### PR TITLE
Jetpack connect: Fix automattician approval screen

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -35,6 +35,8 @@ import Spinner from 'components/spinner';
 import Site from 'my-sites/site';
 import { decodeEntities } from 'lib/formatting';
 import versionCompare from 'lib/version-compare';
+import { requestSites } from 'state/sites/actions';
+import { isRequestingSites } from 'state/sites/selectors';
 
 /**
  * Constants
@@ -273,6 +275,10 @@ const LoggedInForm = React.createClass( {
 			return this.translate( 'Try again' );
 		}
 
+		if ( this.props.isFetchingSites() ) {
+			return this.translate( 'Preparing authorization' );
+		}
+
 		if ( this.props.isAlreadyOnSitesList || siteReceived ) {
 			return this.translate( 'Browse Available Upgrades' );
 		}
@@ -366,7 +372,7 @@ const LoggedInForm = React.createClass( {
 
 	renderStateAction() {
 		const { authorizeSuccess, siteReceived } = this.props.jetpackConnectAuthorize;
-		if ( this.isAuthorizing() || ( authorizeSuccess && ! siteReceived ) ) {
+		if ( this.props.isFetchingSites() || this.isAuthorizing() || ( authorizeSuccess && ! siteReceived ) ) {
 			return ( <div className="jetpack-connect-logged-in-form__loading">
 				<span>{ this.getButtonText() }</span> <Spinner size={ 20 } duration={ 3000 } />
 			</div> );
@@ -440,12 +446,16 @@ export default connect(
 		const site = state.jetpackConnect.jetpackConnectAuthorize && state.jetpackConnect.jetpackConnectAuthorize.queryObject
 			? getSiteByUrl( state, state.jetpackConnect.jetpackConnectAuthorize.queryObject.site )
 			: null;
+		const isFetchingSites = () => {
+			return isRequestingSites( state );
+		};
 		return {
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
 			jetpackSSOSessions: state.jetpackConnect.jetpackSSOSessions,
 			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions,
-			isAlreadyOnSitesList: !! site
+			isAlreadyOnSitesList: !! site,
+			isFetchingSites
 		};
 	},
-	dispatch => bindActionCreators( { recordTracksEvent, authorize, createAccount, activateManage, goBackToWpAdmin }, dispatch )
+	dispatch => bindActionCreators( { requestSites, recordTracksEvent, authorize, createAccount, activateManage, goBackToWpAdmin }, dispatch )
 )( JetpackConnectAuthorizeForm );

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -41,7 +41,7 @@ import { isRequestingSites } from 'state/sites/selectors';
 /**
  * Constants
  */
-let calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
+const calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
 const PLANS_PAGE = '/jetpack/connect/plans/';
 const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
 const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
@@ -336,7 +336,7 @@ const LoggedInForm = React.createClass( {
 	renderFooterLinks() {
 		const { queryObject, authorizeSuccess, isAuthorizing } = this.props.jetpackConnectAuthorize;
 		const loginUrl = config( 'login_url' ) + '?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) + '&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
-		let backToWpAdminLink = (
+		const backToWpAdminLink = (
 			<LoggedOutFormLinkItem icon={ true } href={ queryObject.redirect_after_auth }>
 				{ this.translate( 'Cancel and go back to my site' ) } <Gridicon size={ 18 } icon="external" />
 			</LoggedOutFormLinkItem>
@@ -418,7 +418,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 	renderForm() {
 		const { userModule } = this.props;
-		let user = userModule.get();
+		const user = userModule.get();
 		const props = Object.assign( {}, this.props, {
 			user: user
 		} );


### PR DESCRIPTION
Right now we are redirecting 100% of jetpack auth attempts to the new auth screen for testing when it comes from a user that have a @automattic.com email. 

When a user disconnects a site and the reconnect it, since this screen wasn't updating the calypso's site list, they were getting stuck in the "browse upgrades" button, because calypso thought that the site was already connected. Now, when the connection flow hasn't being started in calypso, we force a reload of the sites list so we have updated info.

This won't be available for any external user, but will stop screwing automatticians trying to test jetpack stuff :) 

![image](https://cloud.githubusercontent.com/assets/1554855/15591204/e4f9c5f0-239b-11e6-8da4-b166184f3dc6.png)


how to test
=========
1. Connect a site using a 3rd party site user that have an @automattic.com email
2. Disconnect the site
2. Connect it again. You shouldn't get stucked in the false "browse upgrades" button

ping @enejb @dereksmart @lsinger 