### PR TITLE
Revert "DesignPreview: Enable preview-layout in wpcalypso and horizon"

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -70,8 +70,6 @@
 		"phone_signup": false,
 		"post-editor/insert-menu": true,
 		"press-this": true,
-		"preview-layout": true,
-		"preview-endpoint": false,
 		"reader": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -79,8 +79,6 @@
 		"phone_signup": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
-		"preview-layout": true,
-		"preview-endpoint": false,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/recommendations/posts": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#5616

Reverting until we fix iframed http content erroring when parent on https