### PR TITLE
CPT: Memoize Terms Selectors and Implement New Selectors

### DIFF
--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -3,12 +3,16 @@
  */
 import get from 'lodash/get';
 import values from 'lodash/values';
+import range from 'lodash/range';
 
 /**
  * Internal dependencies
  */
+import TreeConvert from 'lib/tree-convert';
+import createSelector from 'lib/create-selector';
 import {
-	getSerializedTermsQuery
+	getSerializedTermsQuery,
+	getSerializedTermsQueryWithoutPage
 } from './utils';
 
 /**
@@ -33,24 +37,94 @@ export function isRequestingTermsForQuery( state, siteId, taxonomy, query ) {
  * @param  {Object}  state    Global state tree
  * @param  {Number}  siteId   Site ID
  * @param  {String}  taxonomy Taxonomy slug
- * @param  {Object}  query    Post query object
- * @return {?Array}           Posts for the post query
+ * @param  {Object}  query    Terms query object
+ * @return {?Array}           Terms for the query
  */
-export function getTermsForQuery( state, siteId, taxonomy, query ) {
-	const serializedQuery = getSerializedTermsQuery( query );
-	const queryResults = get( state.terms.queries, [ siteId, taxonomy, serializedQuery ] );
-	if ( ! queryResults ) {
-		return null;
-	}
-
-	return queryResults.reduce( ( memo, termId ) => {
-		const term = get( state.terms, [ 'items', siteId, taxonomy, termId ] );
-		if ( term ) {
-			memo.push( term );
+export const getTermsForQuery = createSelector(
+	( state, siteId, taxonomy, query ) => {
+		const serializedQuery = getSerializedTermsQuery( query );
+		const queryResults = get( state.terms.queries, [ siteId, taxonomy, serializedQuery ] );
+		if ( ! queryResults ) {
+			return null;
 		}
 
-		return memo;
+		return queryResults.reduce( ( memo, termId ) => {
+			const term = get( state.terms, [ 'items', siteId, taxonomy, termId ] );
+			if ( term ) {
+				memo.push( term );
+			}
+
+			return memo;
+		}, [] );
+	},
+	( state, siteId, taxonomy ) => getTerms( state, siteId, taxonomy ),
+	( state, siteId, taxonomy, query ) => {
+		const serializedQuery = getSerializedTermsQuery( query );
+		return [ siteId, taxonomy, serializedQuery ].join();
+	}
+);
+
+/**
+ * Returns an array of terms for the taxonomy query, including all known
+ * queried pages, or null if the number of pages is unknown.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  taxonomy Taxonomy slug
+ * @param  {Object}  query    Terms query object
+ * @return {?Array}           Terms for the query
+ */
+export function getTermsForQueryIgnoringPage( state, siteId, taxonomy, query ) {
+	const lastPage = getTermsLastPageForQuery( state, siteId, taxonomy, query );
+	if ( null === lastPage ) {
+		return lastPage;
+	}
+
+	return range( 1, lastPage + 1 ).reduce( ( memo, page ) => {
+		const termsQuery = Object.assign( {}, query, { page } );
+		return memo.concat( getTermsForQuery( state, siteId, taxonomy, termsQuery ) || [] );
 	}, [] );
+}
+
+/**
+ * Returns an hierarchical array of terms for the taxonomies query, or null if no terms have been
+ * received.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  taxonomy Taxonomy slug
+ * @param  {Object}  query    Term query object
+ * @return {?Array}           Terms for the query
+ */
+export const getTermsHierarchyForQueryIgnoringPage = createSelector(
+	( state, siteId, taxonomy, query ) => {
+		let terms = getTermsForQueryIgnoringPage( state, siteId, taxonomy, query );
+		if ( ! terms ) {
+			return terms;
+		}
+
+		return ( new TreeConvert( 'ID' ) ).treeify( terms );
+	},
+	( state, siteId, taxonomy ) => getTerms( state, siteId, taxonomy ),
+	( state, siteId, taxonomy, query ) => {
+		const serializedQuery = getSerializedTermsQuery( query );
+		return [ siteId, taxonomy, serializedQuery ].join();
+	}
+);
+
+/**
+ * Returns the last queryable page of terms for the given query / taxonomy, or null if the
+ * total number of queryable terms if unknown.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  taxonomy Taxonomy slug
+ * @param  {Object}  query    Terms query object
+ * @return {?Number}          Last terms page
+ */
+export function getTermsLastPageForQuery( state, siteId, taxonomy, query ) {
+	const serializedQuery = getSerializedTermsQueryWithoutPage( query );
+	return get( state.terms.queriesLastPage, [ siteId, taxonomy, serializedQuery ], null );
 }
 
 /**

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -21,7 +21,8 @@ import {
 import reducer, {
 	items,
 	queries,
-	queryRequests,
+	queriesLastPage,
+	queryRequests
 } from '../reducer';
 
 /**
@@ -49,6 +50,7 @@ describe( 'reducer', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'queries',
 			'queryRequests',
+			'queriesLastPage',
 			'items'
 		] );
 	} );
@@ -295,6 +297,122 @@ describe( 'reducer', () => {
 
 			const state = queries( original, { type: DESERIALIZE } );
 
+			expect( state ).to.eql( {} );
+		} );
+	} );
+
+	describe( '#queriesLastPage()', () => {
+		it( 'should default to an empty object', () => {
+			const state = queriesLastPage( undefined, {} );
+
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should track term query request success last page', () => {
+			const state = queriesLastPage( undefined, {
+				type: TERMS_REQUEST_SUCCESS,
+				siteId: 2916284,
+				query: { search: '', number: 1 },
+				found: 2,
+				terms: [ { ID: 321, name: 'Ribs' } ],
+				taxonomy: 'category'
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					category: {
+						'{"number":1}': 2
+					}
+				}
+			} );
+		} );
+
+		it( 'should track last page regardless of page param', () => {
+			const state = queriesLastPage( undefined, {
+				type: TERMS_REQUEST_SUCCESS,
+				siteId: 2916284,
+				query: { search: '', number: 1, page: 2 },
+				found: 2,
+				taxonomy: 'category',
+				terms: [ { ID: 321, name: 'Ribs' } ]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					category: {
+						'{"number":1}': 2
+					}
+				}
+			} );
+		} );
+
+		it( 'should consider no results as having last page of 1', () => {
+			const state = queriesLastPage( undefined, {
+				type: TERMS_REQUEST_SUCCESS,
+				siteId: 2916284,
+				query: { search: 'none', number: 1 },
+				found: 0,
+				terms: [],
+				taxonomy: 'category'
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					category: {
+						'{"search":"none","number":1}': 1
+					}
+				}
+			} );
+		} );
+
+		it( 'should accumulate term request success', () => {
+			const original = deepFreeze( {
+				2916284: {
+					category: {
+						'{"search":"none","number":1}': 1
+					}
+				}
+			} );
+			const state = queriesLastPage( original, {
+				type: TERMS_REQUEST_SUCCESS,
+				siteId: 2916284,
+				query: { search: 'Ribs' },
+				found: 1,
+				terms: [ { ID: 123, name: 'Ribs' } ],
+				taxonomy: 'category'
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					category: {
+						'{"search":"none","number":1}': 1,
+						'{"search":"ribs"}': 1
+					}
+				}
+			} );
+		} );
+
+		it( 'never persists state', () => {
+			const original = deepFreeze( {
+				2916284: {
+					category: {
+						'{"search":"none","number":1}': 1
+					}
+				}
+			} );
+			const state = queriesLastPage( original, { type: SERIALIZE } );
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'never loads persisted state', () => {
+			const original = deepFreeze( {
+				2916284: {
+					category: {
+						'{"search":"none","number":1}': 1
+					}
+				}
+			} );
+			const state = queriesLastPage( original, { type: DESERIALIZE } );
 			expect( state ).to.eql( {} );
 		} );
 	} );

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -16,6 +16,11 @@ import {
 } from '../selectors';
 
 describe( 'selectors', () => {
+	beforeEach( () => {
+		getTermsForQuery.memoizedSelector.cache.clear();
+		getTermsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
+	} );
+
 	describe( 'isRequestingTermsForQuery()', () => {
 		it( 'should return false if no request exists', () => {
 			const requesting = isRequestingTermsForQuery( {
@@ -61,10 +66,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getTermsForQuery()', () => {
-		beforeEach( () => {
-			getTermsForQuery.memoizedSelector.cache.clear();
-		} );
-
 		it( 'should return null if no matching query results exist', () => {
 			const terms = getTermsForQuery( {
 				terms: {
@@ -142,10 +143,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getTermsForQueryIgnoringPage', () => {
-		beforeEach( () => {
-			getTermsForQuery.memoizedSelector.cache.clear();
-		} );
-
 		it( 'should return null if last page is not known', () => {
 			const terms = getTermsForQueryIgnoringPage( {
 				terms: {
@@ -250,10 +247,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getTermsHierarchyForQueryIgnoringPage()', () => {
-		beforeEach( () => {
-			getTermsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
-		} );
-
 		it( 'should return null if no matching query results exist', () => {
 			const terms = getTermsHierarchyForQueryIgnoringPage( {
 				terms: {

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -9,6 +9,9 @@ import { expect } from 'chai';
 import {
 	getTerms,
 	getTermsForQuery,
+	getTermsForQueryIgnoringPage,
+	getTermsHierarchyForQueryIgnoringPage,
+	getTermsLastPageForQuery,
 	isRequestingTermsForQuery
 } from '../selectors';
 
@@ -58,6 +61,10 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getTermsForQuery()', () => {
+		beforeEach( () => {
+			getTermsForQuery.memoizedSelector.cache.clear();
+		} );
+
 		it( 'should return null if no matching query results exist', () => {
 			const terms = getTermsForQuery( {
 				terms: {
@@ -129,6 +136,222 @@ describe( 'selectors', () => {
 				{
 					ID: 111,
 					name: 'Chicken and a biscuit'
+				}
+			] );
+		} );
+	} );
+
+	describe( 'getTermsForQueryIgnoringPage', () => {
+		beforeEach( () => {
+			getTermsForQuery.memoizedSelector.cache.clear();
+		} );
+
+		it( 'should return null if last page is not known', () => {
+			const terms = getTermsForQueryIgnoringPage( {
+				terms: {
+					queriesLastPage: {}
+				}
+			}, 2916284, 'category', { search: 'Hello' } );
+
+			expect( terms ).to.be.null;
+		} );
+
+		it( 'should return terms ignoring page param', () => {
+			const terms = getTermsForQueryIgnoringPage( {
+				terms: {
+					queriesLastPage: {
+						2916284: {
+							category: {
+								'{"search":"hello"}': 2
+							}
+						}
+					},
+					queries: {
+						2916284: {
+							category: {
+								'{"search":"hello"}': [ 123 ],
+								'{"search":"hello","page":2}': [ 124 ]
+							}
+						}
+					},
+					items: {
+						2916284: {
+							category: {
+								123: {
+									ID: 123,
+									name: 'Chicken',
+									slug: 'chicken'
+								},
+								124: {
+									ID: 124,
+									name: 'Ribs',
+									slug: 'ribs'
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'category', { search: 'Hello', page: 2 } );
+
+			expect( terms ).to.eql( [ {
+				ID: 123,
+				name: 'Chicken',
+				slug: 'chicken'
+			}, {
+				ID: 124,
+				name: 'Ribs',
+				slug: 'ribs'
+			} ] );
+		} );
+	} );
+
+	describe( 'getTermsLastPageForQuery()', () => {
+		it( 'should return null if the terms query is not tracked', () => {
+			const lastPage = getTermsLastPageForQuery( {
+				terms: {
+					queriesLastPage: {}
+				}
+			}, 2916284, 'category', { search: 'Hello' } );
+
+			expect( lastPage ).to.be.null;
+		} );
+
+		it( 'should return the last page value for a query', () => {
+			const lastPage = getTermsLastPageForQuery( {
+				terms: {
+					queriesLastPage: {
+						2916284: {
+							category: {
+								'{"search":"hello"}': 4
+							}
+						}
+					}
+				}
+			}, 2916284, 'category', { search: 'Hello' } );
+
+			expect( lastPage ).to.equal( 4 );
+		} );
+
+		it( 'should return the last page value for a terms query, even if including page param', () => {
+			const lastPage = getTermsLastPageForQuery( {
+				terms: {
+					queriesLastPage: {
+						2916284: {
+							category: {
+								'{"search":"hello"}': 4
+							}
+						}
+					}
+				}
+			}, 2916284, 'category', { search: 'Hello', page: 2 } );
+
+			expect( lastPage ).to.equal( 4 );
+		} );
+	} );
+
+	describe( 'getTermsHierarchyForQueryIgnoringPage()', () => {
+		beforeEach( () => {
+			getTermsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
+		} );
+
+		it( 'should return null if no matching query results exist', () => {
+			const terms = getTermsHierarchyForQueryIgnoringPage( {
+				terms: {
+					queries: {}
+				}
+			}, 2916284, 'categories', {} );
+
+			expect( terms ).to.be.null;
+		} );
+
+		it( 'should return an empty array if no matches exist', () => {
+			const terms = getTermsHierarchyForQueryIgnoringPage( {
+				terms: {
+					queriesLastPage: {
+						2916284: {
+							categories: {
+								'{"search":"ribs"}': 1
+							}
+						}
+					},
+					queries: {
+						2916284: {
+							categories: {
+								'{"search":"ribs"}': []
+							}
+						}
+					},
+					items: {
+						2916284: {
+							categories: {
+								111: {
+									ID: 111,
+									name: 'Chicken and a biscuit'
+								},
+								112: {
+									ID: 112,
+									name: 'Ribs',
+									parent: 111
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'categories', { search: 'ribs' } );
+
+			expect( terms ).to.eql( [] );
+		} );
+
+		it( 'should return matching terms in hierarchical structure', () => {
+			const terms = getTermsHierarchyForQueryIgnoringPage( {
+				terms: {
+					queriesLastPage: {
+						2916284: {
+							categories: {
+								'{"search":"ribs"}': 1
+							}
+						}
+					},
+					queries: {
+						2916284: {
+							categories: {
+								'{"search":"ribs"}': [ 111, 112 ]
+							}
+						}
+					},
+					items: {
+						2916284: {
+							categories: {
+								111: {
+									ID: 111,
+									name: 'Chicken and a biscuit'
+								},
+								112: {
+									ID: 112,
+									name: 'Ribs',
+									parent: 111
+								},
+								113: {
+									ID: 113,
+									name: 'Cornbread',
+									parent: 111
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'categories', { search: 'ribs' } );
+
+			expect( terms ).to.eql( [
+				{
+					ID: 111,
+					name: 'Chicken and a biscuit',
+					parent: 0,
+					items: [ {
+						ID: 112,
+						name: 'Ribs',
+						parent: 111
+					} ]
 				}
 			] );
 		} );

--- a/client/state/terms/test/utils.js
+++ b/client/state/terms/test/utils.js
@@ -8,10 +8,23 @@ import { expect } from 'chai';
  */
 import {
 	getNormalizedTermsQuery,
-	getSerializedTermsQuery
+	getSerializedTermsQuery,
+	getSerializedTermsQueryWithoutPage
 } from '../utils';
 
 describe( 'utils', () => {
+	describe( 'getSerializedTermsQueryWithoutPage()', () => {
+		it( 'should exclude page and default values', () => {
+			const query = getSerializedTermsQueryWithoutPage( {
+				page: 2,
+				number: 100,
+				search: 'ribs'
+			} );
+
+			expect( query ).to.eql( '{"search":"ribs"}' );
+		} );
+	} );
+
 	describe( 'getNormalizedTermsQuery()', () => {
 		it( 'should exclude default values', () => {
 			const query = getNormalizedTermsQuery( {

--- a/client/state/terms/utils.js
+++ b/client/state/terms/utils.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import omitBy from 'lodash/omitBy';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
@@ -29,4 +30,15 @@ export function getNormalizedTermsQuery( query ) {
 export function getSerializedTermsQuery( query = {} ) {
 	const normalizedQuery = getNormalizedTermsQuery( query );
 	return JSON.stringify( normalizedQuery ).toLocaleLowerCase();
+}
+
+/**
+ * Returns a serialized terms query, excluding any page parameter, used as the
+ * key in the `state.terms.queriesLastPage` state object.
+ *
+ * @param  {Object} query  Terms query
+ * @return {String}        Serialized terms query
+ */
+export function getSerializedTermsQueryWithoutPage( query ) {
+	return getSerializedTermsQuery( omit( query, 'page' ) );
 }


### PR DESCRIPTION
Further work on the Terms State tree, this branch implements `createSelector` on the more expensive selectors.  Additionally new selectors have been added for hierarchical taxonomies, and selectors that ignore pagination.

__To Test__
Run the terms state tests: `npm run test-client client/state/terms`