### PR TITLE
Routing: Correctly route to legacy paths with a trailing slash

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -30,6 +30,7 @@ var config = require( 'config' ),
 	analytics = require( 'lib/analytics' ),
 	route = require( 'lib/route' ),
 	normalize = require( 'lib/route/normalize' ),
+	{ isLegacyRoute } = require( 'lib/route/legacy-routes' ),
 	user = require( 'lib/user' )(),
 	receiveUser = require( 'state/users/actions' ).receiveUser,
 	setCurrentUserId = require( 'state/current-user/actions' ).setCurrentUserId,
@@ -255,18 +256,6 @@ function reduxStoreReady( reduxStore ) {
 			} );
 		}
 	}
-
-	const isLegacyRoute = ( path ) => {
-		return ( /.php$/.test( path ) ||
-			/^\/?$/.test( path ) && ! config.isEnabled( 'reader' ) ||
-			/^\/my-stats/.test( path ) ||
-			/^\/notifications/.test( path ) ||
-			/^\/themes/.test( path ) ||
-			/^\/manage/.test( path ) ||
-			/^\/plans/.test( path ) && ! config.isEnabled( 'manage/plans' ) ||
-			/^\/me/.test( path ) && ! /^\/me\/billing/.test( path ) &&
-			! /^\/me\/next/.test( path ) && ! config.isEnabled( 'me/my-profile' ) );
-	};
 
 	// If `?sb` or `?sp` are present on the path set the focus of layout
 	// This can be removed when the legacy version is retired.

--- a/client/lib/route/legacy-routes.js
+++ b/client/lib/route/legacy-routes.js
@@ -1,0 +1,28 @@
+/**
+ * A legacy route is a path that Calypso should ignore, allowing the browser
+ * to reload the page.
+ */
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+/**
+ * Determines if a path is a legacy route, and should be ignored by Calypso
+ *
+ * @param {any} path      The path to check
+ * @param {any} isEnabled For stubbing
+ * @returns {boolean} True if legacy path, false otherwise
+ */
+export function isLegacyRoute( path ) {
+	return ( /.php$/.test( path ) ||
+		/^\/?$/.test( path ) && ! config.isEnabled( 'reader' ) ||
+		/^\/my-stats/.test( path ) ||
+		/^\/notifications/.test( path ) ||
+		/^\/themes/.test( path ) ||
+		/^\/manage/.test( path ) ||
+		/^\/plans/.test( path ) && ! config.isEnabled( 'manage/plans' ) ||
+		/^\/me/.test( path ) && ! /^\/me\/billing/.test( path ) &&
+		! /^\/me\/next/.test( path ) && ! config.isEnabled( 'me/my-profile' ) );
+}

--- a/client/lib/route/test/legacy-routes.js
+++ b/client/lib/route/test/legacy-routes.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import config from 'config';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { isLegacyRoute } from '../legacy-routes';
+
+let features = [];
+
+describe( 'legacy-routes', function() {
+	describe( '#isLegacyRoute()', () => {
+		before( () => {
+			sinon.stub( config, 'isEnabled', ( flag ) => {
+				return features.indexOf( flag ) > -1;
+			} );
+		} );
+
+		after( () => {
+			config.isEnabled.restore();
+		} );
+
+		it( 'should return true for /themes/sometheme', () => {
+			expect( isLegacyRoute( '/themes/sometheme' ) ).to.be.true;
+		} );
+
+		it( 'should return true for /notifications', () => {
+			expect( isLegacyRoute( '/notifications' ) ).to.be.true;
+		} );
+
+		it( 'should return false for /settings/general', () => {
+			expect( isLegacyRoute( '/settings/general' ) ).to.be.false;
+		} );
+
+		it( 'should return true for / when reader is disabled', () => {
+			expect( isLegacyRoute( '/' ) ).to.be.true;
+		} );
+
+		it( 'should return false for / when reader is enabled', () => {
+			features = [ 'reader' ];
+			expect( isLegacyRoute( '/' ) ).to.be.false;
+		} );
+
+		it( 'should return true for any path ending in .php', () => {
+			expect( isLegacyRoute( '/test.php' ) ).to.be.true;
+			expect( isLegacyRoute( 'test.php' ) ).to.be.true;
+			expect( isLegacyRoute( '/some/nested/page.php' ) ).to.be.true;
+		} );
+
+		it( 'should return true for /plans when `manage/plans` feature flag disabled', () => {
+			expect( isLegacyRoute( '/plans' ) ).to.be.true;
+		} );
+
+		it( 'should return false for /plans when `manage/plans` feature flag enabled', () => {
+			features = [ 'manage/plans' ];
+			expect( isLegacyRoute( '/plans' ) ).to.be.false;
+		} );
+	} );
+} );

--- a/client/lib/route/test/legacy-routes.js
+++ b/client/lib/route/test/legacy-routes.js
@@ -37,10 +37,13 @@ describe( 'legacy-routes', function() {
 		} );
 
 		it( 'should return true for / when reader is disabled', () => {
+			// config.isEnabled( 'reader' ) === false
+			features = [];
 			expect( isLegacyRoute( '/' ) ).to.be.true;
 		} );
 
 		it( 'should return false for / when reader is enabled', () => {
+			// config.isEnabled( 'reader' ) === true
 			features = [ 'reader' ];
 			expect( isLegacyRoute( '/' ) ).to.be.false;
 		} );
@@ -52,12 +55,53 @@ describe( 'legacy-routes', function() {
 		} );
 
 		it( 'should return true for /plans when `manage/plans` feature flag disabled', () => {
+			// config.isEnabled( 'manage/plans' ) === false
+			features = [];
 			expect( isLegacyRoute( '/plans' ) ).to.be.true;
 		} );
 
 		it( 'should return false for /plans when `manage/plans` feature flag enabled', () => {
+			// config.isEnabled( 'manage/plans' ) === true
 			features = [ 'manage/plans' ];
 			expect( isLegacyRoute( '/plans' ) ).to.be.false;
+		} );
+
+		describe( 'when `me/my-profile` feature flag is enabled', () => {
+			// config.isEnabled( 'me/my-profile' ) === true
+			beforeEach( () => {
+				features = [ 'me/my-profile' ];
+			} );
+
+			it( 'should return false for /me', () => {
+				expect( isLegacyRoute( '/me' ) ).to.be.false;
+			} );
+
+			it( 'should return false for /me/billing', () => {
+				expect( isLegacyRoute( '/me/billing' ) ).to.be.false;
+			} );
+
+			it( 'should return false for /me/next', () => {
+				expect( isLegacyRoute( '/me/next' ) ).to.be.false;
+			} );
+		} );
+
+		describe( 'when `me/my-profile` feature flag is disabled', () => {
+			// config.isEnabled( 'me/my-profile' ) === false
+			beforeEach( () => {
+				features = [];
+			} );
+
+			it( 'should return true for /me', () => {
+				expect( isLegacyRoute( '/me' ) ).to.be.true;
+			} );
+
+			it( 'should return false for /me/billing', () => {
+				expect( isLegacyRoute( '/me/billing' ) ).to.be.false;
+			} );
+
+			it( 'should return false for /me/next', () => {
+				expect( isLegacyRoute( '/me/next' ) ).to.be.false;
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
This fixes #5623 and p2UL9c-2GR-p2.

When a legacy link is clicked - that is one beginning with wordpress.com but not handled by Calypso - we don't want Calypso to handle that URL using pushState, but for the browser to reload that page.

Before this change, any link to a legacy route that contained a trailing slash was being caught by the page module and redirected to the path without the trailing slash.

This meant that a legacy route was considered 'handled' by Calypso and pushed to the browser's history state, instead of letting the browser do its thing.

This change detects legacy links, and skips the internal redirect. This lets the request fall through Calypso's routing mechanism unhandled, allowing the browser to handle it.

### How to test
1. Click around, ensure normal internal routes work as expected.
2. Create a link to a legacy route somewhere in Calypso ending with a trailing slash. The easiest way to do this is to start a chat and send 'https://wordpress.com/themes/affinity/'.
3. Click the link.
4. You should be redirected correctly in this branch, while `master` won't redirect.

cc @ebinnion @blowery 