### PR TITLE
DesignPreview: Disable for http sites

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -8,10 +8,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import i18n from 'lib/mixins/i18n';
 
-function get() {
+function get( site ) {
 	return {
 		init: {
 			text: i18n.translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, and give you some ideas for what to do next.", {
@@ -40,7 +39,7 @@ function get() {
 			type: 'BasicStep',
 			target: 'sidebar',
 			placement: 'beside',
-			next: config.isEnabled( 'preview-layout' ) ? 'preview' : 'themes',
+			next: site && site.is_previewable ? 'preview' : 'themes',
 		},
 		preview: {
 			target: 'site-card-preview',

--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -10,9 +10,11 @@ var debug = require( 'debug' )( 'calypso:site' ),
  * Internal dependencies
  */
 var wpcom = require( 'lib/wp' ),
+	config = require( 'config' ),
 	notices = require( 'notices' ),
 	i18n = require( 'lib/mixins/i18n' ),
-	Emitter = require( 'lib/mixins/emitter' );
+	Emitter = require( 'lib/mixins/emitter' ),
+	isHttps = require( 'lib/url' ).isHttps;
 
 function Site( attributes ) {
 	if ( ! ( this instanceof Site ) ) {
@@ -113,6 +115,12 @@ Site.prototype.updateComputedAttributes = function() {
 	if ( ! this.options.default_post_format || this.options.default_post_format === '0' ) {
 		this.options.default_post_format = 'standard';
 	}
+	this.is_previewable = !! (
+		config.isEnabled( 'preview-layout' ) &&
+		this.options.unmapped_url &&
+		! this.is_vip &&
+		isHttps( this.options.unmapped_url )
+	);
 };
 
 /**

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */
@@ -20,4 +22,12 @@ function isExternal( url ) {
 	return isOutsideCalypso( url ) && ! startsWith( url, '//wordpress.com' );
 }
 
-export default { isOutsideCalypso, isExternal };
+function isHttps( url ) {
+	return url && startsWith( url, 'https://' );
+}
+
+export default {
+	isOutsideCalypso,
+	isExternal,
+	isHttps,
+};

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -173,7 +173,7 @@ const DesignPreview = React.createClass( {
 			return null;
 		}
 
-		const parsed = url.parse( site.URL, true );
+		const parsed = url.parse( site.options.unmapped_url, true );
 		parsed.query.iframe = true;
 		parsed.query.theme_preview = true;
 		if ( site.options && site.options.frame_nonce ) {
@@ -186,7 +186,7 @@ const DesignPreview = React.createClass( {
 	render() {
 		const useEndpoint = config.isEnabled( 'preview-endpoint' );
 
-		if ( ! this.props.selectedSite ) {
+		if ( ! this.props.selectedSite || ! this.props.selectedSite.is_previewable ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -54,7 +54,8 @@ module.exports = React.createClass( {
 	},
 
 	onPreviewSite( event ) {
-		if ( config.isEnabled( 'preview-layout' ) ) {
+		const site = this.getSelectedSite();
+		if ( site.is_previewable ) {
 			event.preventDefault();
 			this.props.layoutFocus.set( 'preview' );
 		}

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -227,7 +227,7 @@ export default React.createClass( {
 							onClick={ this.props.onClick }
 							onMouseEnter={ this.props.onMouseEnter }
 							onMouseLeave={ this.props.onMouseLeave }
-							aria-label={ this.props.homeLink && config.isEnabled( 'preview-layout' )
+							aria-label={ this.props.homeLink && site.is_previewable
 								? this.translate( 'Open site %(domain)s in a preview', {
 									args: { domain: site.domain }
 								} )

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -37,6 +37,7 @@ export const sitesSchema = {
 				meta: { type: 'object' },
 				user_can_manager: { type: 'boolean' },
 				is_vip: { type: 'boolean' },
+				is_previewable: { type: 'boolean' },
 				is_multisite: { type: 'boolean' },
 				capabilities: {
 					type: 'object',

--- a/client/state/ui/guided-tours/selectors.js
+++ b/client/state/ui/guided-tours/selectors.js
@@ -7,11 +7,11 @@ import memoize from 'lodash/memoize';
 /**
  * Internal dependencies
  */
-import { isSectionLoading } from 'state/ui/selectors';
+import { isSectionLoading, getSelectedSite } from 'state/ui/selectors';
 import createSelector from 'lib/create-selector';
 import guidedToursConfig from 'layout/guided-tours/config';
 
-const getToursConfig = memoize( () => guidedToursConfig.get() );
+const getToursConfig = memoize( ( site ) => guidedToursConfig.get( site ) );
 
 /**
  * Returns the current state for Guided Tours.
@@ -28,9 +28,10 @@ const getRawGuidedTourState = state => get( state, 'ui.guidedTour', false );
 export const getGuidedTourState = createSelector(
 	state => {
 		const tourState = getRawGuidedTourState( state );
+		const site = getSelectedSite( state );
 		const { shouldReallyShow, stepName = '' } = tourState;
-		const stepConfig = getToursConfig()[ stepName ] || false;
-		const nextStepConfig = getToursConfig()[ stepConfig.next ] || false;
+		const stepConfig = getToursConfig( site )[ stepName ] || false;
+		const nextStepConfig = getToursConfig( site )[ stepConfig.next ] || false;
 
 		const shouldShow = !! (
 			! isSectionLoading( state ) &&
@@ -46,5 +47,6 @@ export const getGuidedTourState = createSelector(
 	state => [
 		getRawGuidedTourState( state ),
 		isSectionLoading( state ),
+		getSelectedSite( state ),
 	]
 );


### PR DESCRIPTION
Since we can't iframe insecure content within secure content, we now a few conditions to decide whether to use an iframe or open a new tab for previewing a site via the site card. 

We use the iframe only when ...

- it's enabled in the environment's config
- the unmapped URL of the site starts with `https://`
- it's not a VIP site

To test: 

- open http://calypso.live/?branch=update/design-preview-disable-http
- try previewing different kinds of sites
- make sure there are no console errors because of non-https content
