### PR TITLE
Signup: Proper spacing for navigation links on the themes step

### DIFF
--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -4,3 +4,7 @@
 	margin: 24px auto;
 	text-align: center;
 }
+
+.navigation-link:nth-child(2):last-child {
+	margin-left:24px;
+}

--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -1,10 +1,7 @@
 .navigation-link {
 	cursor: pointer;
 	display: inline-block;
-	margin: 24px auto;
+	margin: 24px 12px;
 	text-align: center;
 }
 
-.navigation-link:nth-child(2):last-child {
-	margin-left:24px;
-}

--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -4,4 +4,3 @@
 	margin: 24px 12px;
 	text-align: center;
 }
-


### PR DESCRIPTION
Navigation links on the bottom of the themes step didn't have any spacing between them and were right next to each other, which made them harder to comprehend.

Spacing was fixed for this case.

To test: 

* Start signup
* Reach themes step
* Scroll to the bottom

Before:
<img width="926" alt="screen shot 2016-05-27 at 14 00 12" src="https://cloud.githubusercontent.com/assets/184938/15606329/3c54b512-2414-11e6-8b9a-8ce865582cef.png">


After:
<img width="933" alt="screen shot 2016-05-27 at 13 59 43" src="https://cloud.githubusercontent.com/assets/184938/15606341/4c88edea-2414-11e6-8434-ec0abc37c113.png">

cc @michaeldcain @coreh @shaunandrews 