### PR TITLE
Remove site icon when 'icon' prop is not present in new attributes coming from API

### DIFF
--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -100,6 +100,16 @@ Site.prototype.replace = function( attributes ) {
 
 	let changed = false;
 
+	// Set attrs which will get computed and will mean the same before doing equality checks
+	// so the 'change' event is not triggered. See Site.prototype.updateComputedAttributes.
+	if ( attributes.hasOwnProperty( 'options' ) ) {
+		let options = attributes.options;
+
+		if ( ! options.default_post_format || options.default_post_format === '0' ) {
+			options.default_post_format = 'standard';
+		}
+	}
+
 	siteKeys.forEach( siteKey => {
 		if ( attributes.hasOwnProperty( siteKey ) && ! isEqual( attributes[ siteKey ], this[ siteKey ] ) ) {
 			this[ siteKey ] = attributes[ siteKey ];
@@ -112,9 +122,9 @@ Site.prototype.replace = function( attributes ) {
 		}
 	} );
 
-	this.updateComputedAttributes();
-
 	if ( changed ) {
+		this.updateComputedAttributes();
+
 		this.emit( 'change' );
 	}
 

--- a/client/lib/site/test/index.js
+++ b/client/lib/site/test/index.js
@@ -12,7 +12,7 @@ describe( 'Calypso Site', () => {
 			ID: 1234,
 			name: 'Hello',
 			description: 'Hunting bugs is fun.'
-		}
+		};
 
 		it( 'attribute changed', () => {
 			const site = Site( mockSiteData );
@@ -60,6 +60,18 @@ describe( 'Calypso Site', () => {
 			site.once( 'change', changeCallback );
 			site.set( { arr: [ 1, 2, 3 ] } );
 			expect( changeCallback.called ).to.be.false;
+		} );
+
+		it( "doesn't remove attributes which are not present in the new ones", () => {
+			const site = Site( mockSiteData );
+
+			site.set( {
+				ID: 1234,
+				//name: 'Hello', // name attribute missing in new ones
+				description: 'Hunting bugs is fun.'
+			} );
+
+			expect( site ).to.have.property( 'name' );
 		} );
 	} );
 } );

--- a/client/lib/site/test/index.js
+++ b/client/lib/site/test/index.js
@@ -74,4 +74,46 @@ describe( 'Calypso Site', () => {
 			expect( site ).to.have.property( 'name' );
 		} );
 	} );
+
+	describe( 'replacing attributes', () => {
+		const mockSiteData = {
+			ID: 1234,
+			name: 'Hello',
+			description: 'Hunting bugs is fun.'
+		};
+
+		it( "removes icon attr if it isn't present in the new attributes", () => {
+			const site = Site( Object.assign( {}, mockSiteData, { icon: {} } ) );
+
+			site.replace( mockSiteData );
+
+			expect( site ).to.not.have.property( 'icon' );
+			expect( site ).to.have.property( 'ID' );
+			expect( site ).to.have.property( 'description' );
+		} );
+
+		it( 'fires change event on attribute removal', () => {
+			const changeCallback = sinon.spy();
+			const site = Site( mockSiteData );
+
+			site.on( 'change', changeCallback );
+
+			site.replace( { ID: 1234, name: 'Goodbye' } );
+
+			expect( changeCallback.called ).to.be.true;
+			expect( site ).to.not.have.property( 'description' );
+		} );
+
+		it( 'fires change event on attribute change', () => {
+			const changeCallback = sinon.spy();
+			const site = Site( mockSiteData );
+			
+			site.on( 'change', changeCallback );
+			
+			site.replace( Object.assign( {}, mockSiteData, { name: 'Goodbye' } ) );
+			
+			expect( changeCallback.called ).to.be.true;
+			expect( site.name ).to.equal( 'Goodbye' );
+		} );
+	} );
 } );

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -205,7 +205,7 @@ SitesList.prototype.update = function( sites ) {
 		if ( sitesMap[ site.ID ] ) {
 			// Update existing Site object
 			siteObj = sitesMap[ site.ID ];
-			result = siteObj.set( site );
+			result = siteObj.replace( site );
 			if ( result ) {
 				changed = true;
 			}

--- a/client/lib/sites-list/test/fixtures/data.js
+++ b/client/lib/sites-list/test/fixtures/data.js
@@ -8,6 +8,7 @@ export const original = [
 		'URL': 'https://testonesite2014.wordpress.com',
 		'jetpack': false,
 		'post_count': 1,
+		'slug': 'testonesite2014.wordpress.com',
 		'subscribers_count': 1,
 		'lang': 'en',
 		'logo': {
@@ -145,7 +146,8 @@ export const original = [
 				'xmlrpc': 'https://gcbu.wordpress.com/xmlrpc.php'
 			}
 		},
-		'user_can_manage': true
+		'user_can_manage': true,
+		'is_previewable': true
 	},
 	{
 		'ID': 54117,
@@ -187,6 +189,7 @@ export const original = [
 				'quote': 'Quote',
 				'image': 'Image'
 			},
+			'default_post_format': false,
 			'default_likes_enabled': false,
 			'default_sharing_status': true,
 			'default_comment_status': false,

--- a/client/lib/sites-list/test/index.js
+++ b/client/lib/sites-list/test/index.js
@@ -39,7 +39,7 @@ describe( 'SitesList', () => {
 
 		it( 'should create Site objects', () => {
 			forEach( initializedSites, site => {
-				assert.instanceOf( site, Site )
+				assert.instanceOf( site, Site );
 			} );
 		} );
 
@@ -84,6 +84,16 @@ describe( 'SitesList', () => {
 			forEach( updatedSite, ( updatedValue, prop ) => {
 				assert.deepEqual( updatedValue, site[ prop ] );
 			} );
+		} );
+
+		it( 'should not trigger change when sites attributes didn\'t change', () => {
+			const changeCallback = sinon.spy();
+
+			sitesList.once( 'change', changeCallback );
+
+			sitesList.update( cloneDeep( data.original ) );
+
+			assert.isFalse( changeCallback.called );
 		} );
 	} );
 

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -13,7 +13,6 @@ export const sitesSchema = {
 				jetpack: { type: 'boolean' },
 				post_count: { type: 'number' },
 				subscribers_count: { type: 'number' },
-				slug: { type: 'string' },
 				lang: { type: 'string' },
 				icon: {
 					type: 'object',
@@ -37,8 +36,6 @@ export const sitesSchema = {
 				meta: { type: 'object' },
 				user_can_manager: { type: 'boolean' },
 				is_vip: { type: 'boolean' },
-				is_previewable: { type: 'boolean' },
-				is_customizable: { type: 'boolean' },
 				is_multisite: { type: 'boolean' },
 				capabilities: {
 					type: 'object',

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -163,13 +163,12 @@ describe( 'reducer', () => {
 				site: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
-					slug: 'example.wordpress.com',
 					updateComputedAttributes() {}
 				}
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', slug: 'example.wordpress.com' }
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
 			} );
 		} );
 
@@ -179,13 +178,12 @@ describe( 'reducer', () => {
 				sites: [ {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
-					slug: 'example.wordpress.com',
 					updateComputedAttributes() {}
 				} ]
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', slug: 'example.wordpress.com' }
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
 			} );
 		} );
 


### PR DESCRIPTION
Helps to fix #1857 (but doesn't fix entirely as another part is related to Jetpack).

After removing site icon on either WP.com site or Jetpack connected WP site, the `icon` property in the API result can have two states:

1. [Gravatar logo](https://secure.gravatar.com/blavatar/9de6281ba3183a48d80e8b3c8af3cc85?ts=1464349551) — when it is WP.com site;
2. The `icon` property gets removed from the `/me/sites` API endpoint results — with Jetpack connected WP site or after a while with WP.com site.

Screenshots:

1. state (Gravatar logo)
![selection_026](https://cloud.githubusercontent.com/assets/4988512/15607396/b71b79f4-2412-11e6-9611-42bc3faa173f.jpg)

2. state (`icon` prop gets removed from the API result)
![selection_027](https://cloud.githubusercontent.com/assets/4988512/15607405/cdfc8a78-2412-11e6-9dc5-16ef31e4d1ca.jpg)

However, if the `icon` prop is removed, the site icon is not removed in Calypso because `Site.prototype.set` method — which is used to apply/set new attributes from the API — doesn't remove those props from a `Site` which are no longer present in the new `attributes` that are being set. It only updates the old props if they've been changed in the new `attributes`.

I found out these 3 solutions to the problem and decided to use the easiest to implement but also the least disruptive one. Let me explain:

#### 1. Modify WP.com API to always include the `icon` prop and set `icon` to an empty object if a site doesn't have site icon.

We would still need to update particular Calypso code which handles site icons because it shows empty icon only if the `icon` prop doesn't exist on a `Site` currently. What is more, if some other/3rd party apps that are consuming WP.com API depend on `icon` not being there, this change would break those apps. That's why I decided strongly against this approach. Maybe with a new API version.

#### 2. Modify `Site` obj in Calypso and add a new method (e.g. `Site.prototype.replace(attrs)`)

This new method would replace all the existing attributes on a `Site` with the new attributes if they changed. If an attribute is missing from the new attributes, remove it from the `Site`. Initially, I had this coded up and ready to create a PR, but the problem with this approach is that a site's attributes are stored in an instance of `Site` object which also contains other props such as `_maxListeners`, `options` and other programmatically added props. I would also delete those because they would be missing from the new attributes.

There are two solutions to this but I liked none of them:

1. Add a "whitelist" or a schema of all the attributes a site can have and remove only those not present from these. Problem is that attributes in API can be added/removed and this list would have to be updated manually all the time.

2. Move all the site's attributes to another object, say `site.attributes`. Then we could work only with this object and not with a `site` which includes other props. Problem is that `Site` object is used in many places and everything would have to be refactored. Quite a change for one site icon, don't you think?

#### 3. Add a condition that if new attributes don't contain 'icon' and current do, remove it from the current ones

This is the simplest and most straightforward approach and I finally went with it because:

1. We must add only 3 new lines of code, nothing else to change;
2. There are no other attributes which are removed from the API result except `icon` I know of. Even if there were, the `if` condition could be put into a loop.
3. When I talked about this issue with @rralian last time, he said that the Calypso code working with sites (e.g.: `Site`, `SitesList`) will be refactored into Redux anyway sometime in the future and we could use more solid approach when doing this that time.


I'm open to all suggestions/other approaches. Also, if you think approach 1. or 2. is better, please explain why.

Thanks.

@rralian @gwwar @mtias @dmsnell 