### PR TITLE
Editor: Move notices above featured image

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -301,11 +301,11 @@ const PostEditor = React.createClass( {
 								site={ site }
 								type={ this.props.type }
 							/>
+							{ this.renderNotice() }
 							<FeaturedImage
 								site={ site }
 								post={ this.state.post }
 								maxWidth={ 1462 } />
-							{ this.renderNotice() }
 							<div className="editor__header">
 								<EditorTitleContainer
 									onChange={ this.debouncedAutosave }
@@ -812,7 +812,7 @@ const PostEditor = React.createClass( {
 	},
 
 	getEditorMode: function() {
-		var editorMode = 'tinymce'
+		var editorMode = 'tinymce';
 		if ( this.props.preferences ) {
 			if ( this.props.preferences[ 'editor-mode' ] ) {
 				editorMode = this.props.preferences[ 'editor-mode' ];


### PR DESCRIPTION
Quick PR per #5537. This just moves any notices above the featured image when they're displayed.

To test:
1. Checkout the branch
2. Start a new post/page
3. Set a featured image
4. Publish the post/page

Instead of appearing below the featured image (per original issue), the notice will appear above the featured image like this:

![featuredimage](https://cloud.githubusercontent.com/assets/7240478/15609484/80b3aeca-23dd-11e6-88e4-62199888d8e8.png)

Confirmed a few things:
1. It works with any notice ("Updated" for example)
2. Works fine with no featured image and on mobile devices ([screenshots](https://cloudup.com/cotTKEjcpXl))