### PR TITLE
Config: adding 'env_id' parameter

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -34,9 +34,9 @@ import Spinner from 'components/spinner';
 /**
  * Constants
  */
-
+let calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
 const PLANS_PAGE = '/jetpack/connect/plans/';
-const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + config( 'env_id' );
+const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
 const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
 
 const LoggedOutForm = React.createClass( {

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -36,7 +36,7 @@ import Spinner from 'components/spinner';
  */
 
 const PLANS_PAGE = '/jetpack/connect/plans/';
-const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + process.env.NODE_ENV;
+const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + config( 'env_id' );
 const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
 
 const LoggedOutForm = React.createClass( {

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -47,7 +47,7 @@ const JetpackSSOForm = React.createClass( {
 			//
 			// Note: We add `calypso_env` so that when we are redirected back to Calypso,
 			// we land in the same development environment.
-			const redirect = addQueryArgs( { calypso_env: config( 'env' ) }, nextProps.ssoUrl );
+			const redirect = addQueryArgs( { calypso_env: config( 'env_id' ) }, nextProps.ssoUrl );
 			debug( 'Redirecting to: ' + redirect );
 			window.location.href = redirect;
 		}

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -47,7 +47,8 @@ const JetpackSSOForm = React.createClass( {
 			//
 			// Note: We add `calypso_env` so that when we are redirected back to Calypso,
 			// we land in the same development environment.
-			const redirect = addQueryArgs( { calypso_env: config( 'env_id' ) }, nextProps.ssoUrl );
+			let configEnv = config( 'env_id' ) || process.env.NODE_ENV;
+			const redirect = addQueryArgs( { calypso_env: configEnv }, nextProps.ssoUrl );
 			debug( 'Redirecting to: ' + redirect );
 			window.location.href = redirect;
 		}

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -37,7 +37,8 @@ import config from 'config';
  *  Local variables;
  */
 let _fetching = {};
-const authURL = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + config( 'env_id' );
+let calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
+const authURL = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
 const installURL = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 const activateURL = '/wp-admin/plugins.php';
 const userModule = userFactory();

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -31,12 +31,13 @@ import {
 	JETPACK_CONNECT_SSO_VALIDATION_ERROR
 } from 'state/action-types';
 import userFactory from 'lib/user';
+import config from 'config';
 
 /**
  *  Local variables;
  */
 let _fetching = {};
-const authURL = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + process.env.NODE_ENV;
+const authURL = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + config( 'env_id' );
 const installURL = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 const activateURL = '/wp-admin/plugins.php';
 const userModule = userFactory();

--- a/config/client.json
+++ b/config/client.json
@@ -1,5 +1,6 @@
 [
   "env",
+  "env_id",
   "client_slug",
   "hostname",
   "wpcom_user_bootstrap",

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -1,5 +1,6 @@
 {
 	"env": "production",
+	"env_id": "desktop-mac-app-store",
 	"client_slug": "mac-app-store",
 	"hostname": "127.0.0.1",
 	"i18n_default_locale_slug": "en",

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -1,5 +1,6 @@
 {
 	"env": "production",
+	"env_id": "desktop",
 	"client_slug": "desktop",
 	"hostname": "127.0.0.1",
 	"i18n_default_locale_slug": "en",

--- a/config/development.json
+++ b/config/development.json
@@ -1,5 +1,6 @@
 {
 	"env": "development",
+	"env_id": "development",
 	"client_slug": "browser",
 	"hostname": "calypso.localhost",
 	"port": 3000,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -1,5 +1,6 @@
 {
 	"env": "production",
+	"env_id": "horizon",
 	"client_slug": "browser",
 	"hostname": "horizon.wordpress.com",
 	"i18n_default_locale_slug": "en",

--- a/config/production.json
+++ b/config/production.json
@@ -1,5 +1,6 @@
 {
 	"env": "production",
+	"env_id": "production",
 	"client_slug": "browser",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",

--- a/config/stage.json
+++ b/config/stage.json
@@ -1,5 +1,6 @@
 {
 	"env": "production",
+	"env_id": "stage",
 	"client_slug": "browser",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",

--- a/config/test.json
+++ b/config/test.json
@@ -1,5 +1,6 @@
 {
 	"env": "development",
+	"env_id": "test",
 	"client_slug": "browser",
 	"hostname": "calypso.localhost",
 	"port": 3000,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -1,5 +1,6 @@
 {
 	"env": "production",
+	"env_id": "wpcalypso",
 	"client_slug": "browser",
 	"hostname": "wpcalypso.wordpress.com",
 	"i18n_default_locale_slug": "en",


### PR DESCRIPTION
With the new Jetpack Connect signup flow, we are redirecting folks
to their Jetpack site for authorization, then redirecting back into Calypso
to complete the flow. We need an 'env_id' parameter in our config files
so that we know which environment to use when redirecting back into Calypso.
'env_id' corresponds to the name of the given config file.

To test:

- check out this branch, and in the config file for `wpcalypso`, set `wpcom_user_bootstrap` to `false`
- run `CALYPSO_ENV=wpcalypso make run`
- go to calypso.localhost:3000/jetpack/connect and connect an un-connected Jetpack site
- ensure that you are redirected back to wpcalypso.wordpress.com instead of calypso.localhost

cc: @ebinnion @johnHackworth @mtias 