### PR TITLE
[Browser Push Notifications] Remember dismissed notice state

### DIFF
--- a/client/components/push-notification/prompt.jsx
+++ b/client/components/push-notification/prompt.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import store from 'store';
 
 /**
  * Internal dependencies
@@ -27,7 +28,7 @@ export default React.createClass( {
 
 	getInitialState: function() {
 		return {
-			dismissed: false,
+			dismissed: store.get( 'push-notification-notice-dismissed' ),
 			subscribed: false
 		};
 	},
@@ -41,6 +42,7 @@ export default React.createClass( {
 	},
 
 	dismissNotice: function() {
+		store.set( 'push-notification-notice-dismissed', true );
 		this.setState( { dismissed: true } );
 	},
 


### PR DESCRIPTION
This pull request prevents the browser push notification notice from popping up after the user dismissed it.

Users who do not have browser notifications enabled get a notice that encourages them to opt-in:

![Notice](https://cloud.githubusercontent.com/assets/1017839/15472851/5dfe8036-20fd-11e6-9412-71d5f8be9084.png)

Dismissing the notice makes it go away only temporarily because its dismissed state gets reset on page reloads and if the browser window is closed.

With this pull request we will remember the user's choice about the dismissed notice.

### Testing instructions

- Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/4987
- Make sure you start with a clean state, that is, you are not subscribed to browser notifications. You can verify this by navigating to http://calypso.localhost:3000/ and checking that the notice is visible.
- Dismiss the notice.
- Reload the page.
- Verify that the notice is not displayed anymore.