### PR TITLE
Themes: Tweak server routing and caching

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -56,18 +56,19 @@ export function fetchThemeDetailsData( context, next ) {
 		return next();
 	}
 
-	themeSlug && wpcom.undocumented().themeDetails( themeSlug, ( error, data ) => {
-		if ( error ) {
+	wpcom.undocumented().themeDetails( themeSlug )
+		.then( themeDetails => {
+			debug( 'caching', themeSlug );
+			themeDetails.timestamp = Date.now();
+			themeDetailsCache.set( themeSlug, themeDetails );
+			context.store.dispatch( receiveThemeDetails( themeDetails ) );
+			next();
+		} )
+		.catch( error => {
 			debug( `Error fetching theme ${ themeSlug } details: `, error.message || error );
 			context.store.dispatch( receiveThemeDetailsFailure( themeSlug, error ) );
-		} else {
-			debug( 'caching', themeSlug );
-			data.timestamp = Date.now();
-			themeDetailsCache.set( themeSlug, data );
-			context.store.dispatch( receiveThemeDetails( data ) );
-		}
-		next();
-	} );
+			next();
+		} );
 }
 
 export function details( context, next ) {

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -49,27 +49,26 @@ export function fetchThemeDetailsData( context, next ) {
 	const themeSlug = context.params.slug;
 	const theme = themeDetailsCache.get( themeSlug );
 
-	if ( theme ) {
+	const HOUR_IN_MS = 3600000;
+	if ( theme && ( theme.timestamp + HOUR_IN_MS > Date.now() ) ) {
 		debug( 'found theme!', theme.id );
 		context.store.dispatch( receiveThemeDetails( theme ) );
-		next();
+		return next();
 	}
 
 	themeSlug && wpcom.undocumented().themeDetails( themeSlug, ( error, data ) => {
 		if ( error ) {
 			debug( `Error fetching theme ${ themeSlug } details: `, error.message || error );
 			context.store.dispatch( receiveThemeDetailsFailure( themeSlug, error ) );
-			return next();
-		}
-		const themeData = themeDetailsCache.get( themeSlug );
-		if ( ! themeData || ( Date( data.date_updated ) > Date( themeData.date_updated ) ) ) {
+		} else {
 			debug( 'caching', themeSlug );
+			data.timestamp = Date.now();
 			themeDetailsCache.set( themeSlug, data );
 			context.store.dispatch( receiveThemeDetails( data ) );
-			next();
 		}
+		next();
 	} );
-} // TODO(ehg): We don't want to hit the endpoint for every req. Debounce based on theme arg?
+}
 
 export function details( context, next ) {
 	const { slug } = context.params;

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -13,17 +13,17 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 			combineMiddlewares(
 				setSectionMiddlewareFactory( section ),
 				...middlewares
-			),
-			serverRender
+			)
 		);
 	};
 }
 
 function combineMiddlewares( ...middlewares ) {
-	return function( req, res, next ) {
+	return function( req, res ) {
 		req.context = getEnhancedContext( req );
-		applyMiddlewares( req.context, middlewares );
-		next();
+		applyMiddlewares( req.context, ...middlewares, () => {
+			serverRender( req, res );
+		} );
 	};
 }
 
@@ -40,7 +40,7 @@ function getEnhancedContext( req ) {
 	} );
 }
 
-function applyMiddlewares( context, middlewares ) {
+function applyMiddlewares( context, ...middlewares ) {
 	const liftedMiddlewares = middlewares.map( middleware => next => middleware( context, next ) );
 	compose( ...liftedMiddlewares )();
 }

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -13,16 +13,17 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 			combineMiddlewares(
 				setSectionMiddlewareFactory( section ),
 				...middlewares
-			)
+			),
+			serverRender
 		);
 	};
 }
 
 function combineMiddlewares( ...middlewares ) {
-	return function( req, res ) {
+	return function( req, res, next ) {
 		req.context = getEnhancedContext( req );
 		applyMiddlewares( req.context, ...middlewares, () => {
-			serverRender( req, res );
+			next();
 		} );
 	};
 }


### PR DESCRIPTION
No visual changes.

1) Fix a bug in the iso-router that was calling `serverRender` regardless before async middleware
2) Simplify the theme-details cache at the server by using a TTL instead of making an API request for every server request.

**To Test**
* Make requests to http://calypso.localhost:3000/theme/{theme}

EXPECTED: pages render ok as before

These changes are necessary for server-side rendering a 404 page for missing themes (#5559) since for that to work, the async path needs to be functioning correctly.

