### PR TITLE
Jetpack SSO: Fix auto authorize for SSO after #5458

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -371,7 +371,8 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
 		if ( this.props.jetpackSSOSessions && this.props.jetpackSSOSessions[ site ] ) {
 			const currentTime = ( new Date() ).getTime();
-			return ( currentTime - this.props.jetpackSSOSessions[ site ] < JETPACK_CONNECT_TTL );
+			const sessionTimestamp = this.props.jetpackSSOSessions[ site ].timestamp || 0;
+			return ( currentTime - sessionTimestamp < JETPACK_CONNECT_TTL );
 		}
 
 		return false;


### PR DESCRIPTION
In #5458, we changed how data was stored in `jetpackSSOSessions`. Instead of just storing a timestamp for each site, we now store an object for each site. This led to some logic failing in `authorize-form.jsx` that would auto authorize the user after being logged in to the remote site.

To test:
- Checkout `update/sso-auto-authorize-fix` branch
- Ensure you have latest master of Jetpack on your site
- Ensure that your username/site is added as a tester in WP.com sandbox (ping @ebinnion for instructions)
- Make sure user is not connected to WP.com
- SSO
- You should see an approve button in Calypso
- Click the button
- Afterwards, you should be auto authorized 