### PR TITLE
Domains: Check for validation errors before showing the privacy modal

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -272,16 +272,16 @@ export default React.createClass( {
 	handleSubmitButtonClick( event ) {
 		event.preventDefault();
 
-		if ( ! this.allDomainRegistrationsHavePrivacy() ) {
-			this.openDialog();
-			return;
-		}
-
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			this.recordSubmit();
 
 			if ( hasErrors ) {
 				this.focusFirstError();
+				return;
+			}
+
+			if ( ! this.allDomainRegistrationsHavePrivacy() ) {
+				this.openDialog();
 				return;
 			}
 


### PR DESCRIPTION
When in the `privacyCheckbox` A/B test in the `checkbox` variation (introduced in #3838), any validation error will _not_ prevent the privacy modal from showing, but it _will_ prevent from the buttons there from doing anything. This leads to a confused user (he can't see the errors because of the modal).
This fixes this issue - but I wonder if the test should not be restarted, because I can imagine this could skew the results of the test _a bit_ :wink:

#### Testing
* Make sure you are in the `checkbox` variation of the `privacyCheckbox` A/B test.
* Add a domain to cart.
* On the Domain Contact form, cause a validation error (or start already with invalid information - like a phone number without the country code from a previous purchase).
* Click the `Continue to checkout` button.
* The modal should _not_ be shown - instead, the first field with the validation error should be focused.
* Only when all the validation errors have been dealt with, clicking the `Continue to checkout` button should bring up the modal.

Of course, please test if there are no regressions in the `original` variation too.

Fixes #5531

@aidvu @umurkontaci - code review
@breezyskies @drewblaisdell @scruffian @Tug from the A/B test PR