### PR TITLE
Customizer: Don't block the Customizer on small screens

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -21,8 +21,7 @@ var notices = require( 'notices' ),
 	Actions = require( 'my-sites/customize/actions' ),
 	themeActivated = require( 'state/themes/actions' ).activated;
 
-var mobileWidth = 400,
-	loadingTimer;
+var loadingTimer;
 
 var Customize = React.createClass( {
 	displayName: 'Customize',
@@ -288,14 +287,6 @@ var Customize = React.createClass( {
 			this.cancelWaitingTimer();
 			return this.renderErrorPage( {
 				title: this.translate( 'Sorry, you do not have enough permissions to customize this site' )
-			} );
-		}
-
-		if ( window.innerWidth <= mobileWidth ) {
-			this.cancelWaitingTimer();
-			return this.renderErrorPage( {
-				title: this.translate( 'Sorry, our customization tools are not ready for use on small screens yet' ),
-				line: this.translate( 'Please use a tablet or desktop browser to customize your site' )
 			} );
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -89,6 +89,7 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"preview-layout": true,
+		"preview-endpoint": false,
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,


### PR DESCRIPTION
It's been fine for small screens for a good while now, and we definitely don't have Muse as of #5485

Also restore `preview-endpoint` in dev config, removed by mistake in bc930720fd0bfd454803b76467113acd50d2ae2d