### PR TITLE
Dropzone: updating icon to use Gridicon

### DIFF
--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -9,6 +9,7 @@ import includes from 'lodash/includes';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 import identity from 'lodash/identity';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -188,7 +189,7 @@ export class DropZone extends Component {
 			content = this.props.children;
 		} else {
 			content = createFragment( {
-				icon: <span className={ classNames( 'drop-zone__content-icon', this.props.icon ) } />,
+				icon: <Gridicon icon={ this.props.icon } size={ 48 } className="drop-zone__content-icon" />,
 				text: (
 					<span className="drop-zone__content-text">
 						{ this.props.translate( 'Drop files to upload' ) }
@@ -235,7 +236,7 @@ DropZone.defaultProps = {
 	onVerifyValidTransfer: () => true,
 	onFilesDrop: noop,
 	fullScreen: false,
-	icon: 'dashicons dashicons-admin-media',
+	icon: 'cloud-upload',
 	translate: identity,
 };
 

--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -44,18 +44,15 @@
 	transform: translateY( -50% ) scale( 1.05 );
 }
 
-.drop-zone__content-icon {
+.drop-zone__content-icon,
+.drop-zone__content-text {
 	display: block;
-	margin-bottom: 6px;
-	width: auto;
-	height: auto;
-	font-size: 60px;
+}
+
+.drop-zone__content-icon {
+	margin: 0 auto;
 }
 
 .drop-zone.is-full-screen .drop-zone__content {
 	font-size: 30px;
-}
-
-.drop-zone.is-full-screen .drop-zone__content-icon {
-	font-size: 70px;
 }

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -71,12 +71,12 @@ describe( 'index', function() {
 
 	it( 'should accept an icon to override the default icon', function() {
 		var tree = ReactDom.render( React.createElement( DropZone, {
-				icon: 'hello-world'
+				icon: 'house'
 			} ), container ), icon;
 
 		icon = TestUtils.findRenderedDOMComponentWithClass( tree, 'drop-zone__content-icon' );
 
-		expect( icon.className ).to.contain( 'hello-world' );
+		expect( icon.className ).to.contain( 'gridicons-house' );
 	} );
 
 	it( 'should highlight the drop zone when dragging over the body', function() {


### PR DESCRIPTION
Before|After
---|---
![screen shot 2016-05-27 at 1 47 44 pm](https://cloud.githubusercontent.com/assets/618551/15618071/cd2f4154-2411-11e6-82b0-6e84b9c5bf3a.png)|![screen shot 2016-05-27 at 1 47 28 pm](https://cloud.githubusercontent.com/assets/618551/15618050/a6777ebe-2411-11e6-993b-1f39ed928141.png)

The icon was changed to use the cloud Gridicon. It's more generic for other uses of the component, like Import. I believe that the icon is a prop, so you can set a different icon. But, I'm not sure.

I tested:

- devdocs example
- editor
- media modal in the editor

I couldn't find an example of a "fullscreen" drop zone.

Tested in IE 11, Chrome, Safari, FF