### PR TITLE
Plans: check user capabilities before displaying domain credit notice

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -12,6 +12,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import paths from 'my-sites/upgrades/paths';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
+import { canCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { abtest } from 'lib/abtest';
@@ -53,7 +54,7 @@ const SiteNotice = React.createClass( {
 	},
 
 	domainCreditNotice() {
-		if ( ! this.props.hasDomainCredit ) {
+		if ( ! this.props.hasDomainCredit || ! this.props.canManageOptions ) {
 			return null;
 		}
 
@@ -98,8 +99,10 @@ const SiteNotice = React.createClass( {
 } );
 
 export default connect( ( state, ownProps ) => {
+	const siteId = ownProps.site && ownProps.site.ID ? ownProps.site.ID : null;
 	return {
-		hasDomainCredit: !! ownProps.site && hasDomainCredit( state, ownProps.site.ID )
+		hasDomainCredit: hasDomainCredit( state, siteId ),
+		canManageOptions: canCurrentUser( state, siteId, 'manage_options' )
 	};
 }, ( dispatch ) => {
 	return {


### PR DESCRIPTION
This PR fixes #5640 where we incorrectly displayed a domain credit for users who did not have permissions to manage upgrades. 

Before:
<img width="276" alt="before" src="https://cloud.githubusercontent.com/assets/1270189/15618878/69f14486-2405-11e6-822d-55640c99fac0.png">

After:
<img width="273" alt="after" src="https://cloud.githubusercontent.com/assets/1270189/15618879/6dae107c-2405-11e6-82bd-a637c72c16f9.png">

## Testing instructions
- Setup a site with multiple users and set a different role per user: Admin, Editor etc
- Click on 'My Sites' and switch to that site
- Make sure the `domainCreditsInfoNotice` a/b test is set to `showNotice`
- Only Admins should be able to see the notice.

cc @mtias @rralian @lancewillett 