### PR TITLE
Reader: Use the new style post normalization

### DIFF
--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -6,7 +6,6 @@ import flow from 'lodash/flow';
 import forEach from 'lodash/forEach';
 import url from 'url';
 import matches from 'lodash/matches';
-import cloneDeep from 'lodash/cloneDeep';
 
 /**
  * Internal Dependencies

--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -154,7 +154,7 @@ const fastPostNormalizationRules = flow( [
 ] );
 
 export function runFastRules( post ) {
-	post = cloneDeep( post );
+	post = Object.assign( {}, post );
 	fastPostNormalizationRules( post );
 	return post;
 }
@@ -166,6 +166,6 @@ const slowSyncRules = flow( [
 ] );
 
 export function runSlowRules( post ) {
-	post = cloneDeep( post );
+	post = Object.assign( {}, post );
 	return waitForImagesToLoad( post ).then( slowSyncRules );
 }

--- a/client/lib/feed-post-store/test/index.js
+++ b/client/lib/feed-post-store/test/index.js
@@ -96,7 +96,7 @@ describe( 'feed-post-store', function() {
 		expect( FeedPostStore.get( {
 			feedId: 1,
 			postId: 2
-		} ).title ).to.equal( 'chris & ben' );
+		} ).title ).to.equal( 'chris &\xA0ben' );
 	} );
 
 	it( 'should index a post by the site_ID and ID if it is internal', function() {

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -23,6 +23,7 @@ function debugForPost( post ) {
  * If successful, the callback is invoked with `(null, theMutatedPost)`
  */
 function normalizePost( post, transforms, callback ) {
+	console && console.warn( '[DEPRECATED]: Please run the rules you need by hand' );
 	if ( ! callback ) {
 		throw new Error( 'must supply a callback' );
 	}

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -2,8 +2,7 @@
  * External Dependencies
  */
 var async = require( 'async' ),
-	debug = require( 'debug' )( 'calypso:post-normalizer' ),
-	cloneDeep = require( 'lodash/cloneDeep' );
+	debug = require( 'debug' )( 'calypso:post-normalizer' );
 /**
  * Internal dependencies
  */
@@ -32,7 +31,7 @@ function normalizePost( post, transforms, callback ) {
 		return;
 	}
 
-	let normalizedPost = cloneDeep( post ),
+	let normalizedPost = Object.assign( {}, post ),
 		postDebug = debugForPost( post );
 
 	postDebug( 'running transforms' );

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -23,7 +23,6 @@ function debugForPost( post ) {
  * If successful, the callback is invoked with `(null, theMutatedPost)`
  */
 function normalizePost( post, transforms, callback ) {
-	console && console.warn( '[DEPRECATED]: Please run the rules you need by hand' );
 	if ( ! callback ) {
 		throw new Error( 'must supply a callback' );
 	}

--- a/client/lib/post-normalizer/rule-first-pass-canonical-image.js
+++ b/client/lib/post-normalizer/rule-first-pass-canonical-image.js
@@ -31,4 +31,5 @@ export default function firstPassCanonicalImage( post ) {
 			};
 		}
 	}
+	return post;
 }


### PR DESCRIPTION
~~#5577 needs to land before this and this will need to be rebased.~~

This updates the feed-post-store to use the post normalizer in the new way. It no longer uses `async` to run the rule set and the initial pass is guaranteed to run synchronously. 

To test, use the Reader as you normally would and look for any errors in the console. Should work just like before.