### PR TITLE
Reader Redux: when receiving posts, omit undefined values

### DIFF
--- a/client/reader/start/card.jsx
+++ b/client/reader/start/card.jsx
@@ -20,7 +20,7 @@ const StartCard = ( { recommendation } ) => {
 		<Card className="reader-start-card">
 			<div className="reader-start-card__hero"></div>
 			<StartCardHeader siteId={ siteId } />
-			{ postId && <StartPostPreview siteId={ siteId } postId={ postId } /> }
+			{ postId > 0 && <StartPostPreview siteId={ siteId } postId={ postId } /> }
 			<StartCardFooter siteId={ siteId } />
 		</Card>
 	);

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -3,6 +3,8 @@
  */
 import { combineReducers } from 'redux';
 import keyBy from 'lodash/keyBy';
+import omitBy from 'lodash/omitBy';
+import isUndefined from 'lodash/isUndefined';
 
 /**
  * Internal dependencies
@@ -25,7 +27,7 @@ import { isValidStateWithSchema } from 'state/utils';
 export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case READER_POSTS_RECEIVE:
-			return Object.assign( {}, state, keyBy( action.posts, 'global_ID' ) );
+			return Object.assign( {}, state, keyBy( omitBy( action.posts, isUndefined ), 'global_ID' ) );
 		case SERIALIZE:
 			return state;
 		case DESERIALIZE:


### PR DESCRIPTION
When we load recommendations from the new /read/recommendations/start endpoint, some can have a recommended post ID of 0 if they're recommending a site only.

This was causing the Reader posts reducer to add a post object containing `{ undefined: undefined }`.

This PR removes any undefined values from action.posts in the reducer before calling `keyBy`.

cc @TooTallNate 