### PR TITLE
Reader: use the `header_image` on Recommendation cards

### DIFF
--- a/client/reader/start/card-footer.jsx
+++ b/client/reader/start/card-footer.jsx
@@ -8,10 +8,10 @@ import FollowButton from 'reader/follow-button';
 import { numberFormat } from 'lib/mixins/i18n';
 
 const StartCardFooter = ( { site } ) => {
-	const count = numberFormat( site.subscribers_count );
+	const subscribersCount = numberFormat( site.subscribers_count );
 	return (
 		<footer>
-			<div className="reader-start-card__follower-count">{ count } followers</div>
+			<div className="reader-start-card__follower-count">{ subscribersCount } followers</div>
 			<FollowButton siteUrl={ site.URL } />
 		</footer>
 	);

--- a/client/reader/start/card-footer.jsx
+++ b/client/reader/start/card-footer.jsx
@@ -5,11 +5,13 @@ import { connect } from 'react-redux';
 // Internal dependencies
 import { getSite } from 'state/reader/sites/selectors';
 import FollowButton from 'reader/follow-button';
+import { numberFormat } from 'lib/mixins/i18n';
 
 const StartCardFooter = ( { site } ) => {
+	const count = numberFormat( site.subscribers_count );
 	return (
 		<footer>
-			<div className="reader-start-card__follower-count">{ site.subscribers_count } followers</div>
+			<div className="reader-start-card__follower-count">{ count } followers</div>
 			<FollowButton siteUrl={ site.URL } />
 		</footer>
 	);

--- a/client/reader/start/card.jsx
+++ b/client/reader/start/card.jsx
@@ -15,12 +15,12 @@ import { getSite } from 'state/reader/sites/selectors';
 const debug = debugModule( 'calypso:reader:start' ); //eslint-disable-line no-unused-vars
 
 const StartCard = ( { site, siteId, postId } ) => {
-	const { header_image } = site;
+	const headerImage = site.header_image;
 
 	let heroStyle;
-	if ( header_image ) {
+	if ( headerImage ) {
 		heroStyle = {
-			backgroundImage: `url("${ header_image.url }")`
+			backgroundImage: `url("${ headerImage.url }")`
 		};
 	}
 

--- a/client/reader/start/card.jsx
+++ b/client/reader/start/card.jsx
@@ -10,15 +10,23 @@ import StartPostPreview from './post-preview';
 import StartCardHeader from './card-header';
 import StartCardFooter from './card-footer';
 import { getRecommendationById } from 'state/reader/start/selectors';
+import { getSite } from 'state/reader/sites/selectors';
 
 const debug = debugModule( 'calypso:reader:start' ); //eslint-disable-line no-unused-vars
 
-const StartCard = ( { recommendation } ) => {
-	const siteId = get( recommendation, 'recommended_site_ID' );
-	const postId = get( recommendation, 'recommended_post_ID' );
+const StartCard = ( { site, siteId, postId } ) => {
+	const { header_image } = site;
+
+	let heroStyle;
+	if ( header_image ) {
+		heroStyle = {
+			backgroundImage: `url("${ header_image.url }")`
+		};
+	}
+
 	return (
 		<Card className="reader-start-card">
-			<div className="reader-start-card__hero"></div>
+			<div className="reader-start-card__hero" style={ heroStyle }></div>
 			<StartCardHeader siteId={ siteId } />
 			{ postId > 0 && <StartPostPreview siteId={ siteId } postId={ postId } /> }
 			<StartCardFooter siteId={ siteId } />
@@ -32,8 +40,15 @@ StartCard.propTypes = {
 
 export default connect(
 	( state, ownProps ) => {
+		const recommendation = getRecommendationById( state, ownProps.recommendationId );
+		const siteId = get( recommendation, 'recommended_site_ID' );
+		const postId = get( recommendation, 'recommended_post_ID' );
+		const site = getSite( state, siteId );
+
 		return {
-			recommendation: getRecommendationById( state, ownProps.recommendationId )
+			siteId,
+			postId,
+			site
 		};
 	}
 )( StartCard );

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -74,7 +74,13 @@
 	}
 
 	.reader-start-card__hero {
-		background: url( "images/reader/hero.jpg" ); // Temp hero image
+		background-repeat: no-repeat;
+		background-position: center center;
+		background-image: url( "images/reader/hero.jpg" ); // Default hero image
+		-webkit-background-size: cover;
+		-moz-background-size: cover;
+		-o-background-size: cover;
+		background-size: cover;
 		height: 100px;
 		margin: -24px;
 	}


### PR DESCRIPTION
When present, that is…

Considering optimizing this case to pull from the "featured image"
logic for regular Reader posts. It seems like only ~15-20% of sites
have a `header_image` so another layer of fallback logic would be
beneficial.

Depends on D1903-code to be landed first.