### PR TITLE
Fix/domain search box writing direction

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -231,6 +231,7 @@ const RegisterDomainStep = React.createClass( {
 					autoFocus={ true }
 					delaySearch={ true }
 					delayTimeout={ 1000 }
+					dir="ltr"
 				/>
 			</div>
 		);

--- a/client/components/search-card/index.jsx
+++ b/client/components/search-card/index.jsx
@@ -20,7 +20,8 @@ var SearchCard = React.createClass( {
 		onSearchChange: React.PropTypes.func,
 		analyticsGroup: React.PropTypes.string,
 		autoFocus: React.PropTypes.bool,
-		disabled: React.PropTypes.bool
+		disabled: React.PropTypes.bool,
+		dir: React.PropTypes.string
 	},
 
 	render: function() {

--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -40,6 +40,11 @@ This value is passed to the disabled attribute of the `<input>` element, and det
 ### searching (optional) bool ( default false )
 Whether to display a [`<Spinner />`](../spinner/) in place of the search icon.
 
+### dir (optional) string ( default undefined )
+Whether to force a specific writing direction for the search field, regardless of the current global writing direction. Useful for inputting domains, codes, etc that use LTR direction when in a RTL language.
+
+Supported values are `'ltr'`, `'rtl'` and `undefined` (the default, which uses the current global writing direction of the app).
+
 ## Methods
 
 ### getCurrentSearchValue()

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -48,7 +48,8 @@ const Search = React.createClass( {
 		disableAutocorrect: React.PropTypes.bool,
 		onBlur: React.PropTypes.func,
 		searching: React.PropTypes.bool,
-		isOpen: React.PropTypes.bool
+		isOpen: React.PropTypes.bool,
+		dir: React.PropTypes.string
 	},
 
 	getInitialState: function() {
@@ -70,7 +71,8 @@ const Search = React.createClass( {
 			onKeyDown: noop,
 			disableAutocorrect: false,
 			searching: false,
-			isOpen: false
+			isOpen: false,
+			dir: undefined
 		};
 	},
 
@@ -253,6 +255,8 @@ const Search = React.createClass( {
 			'is-pinned': this.props.pinned,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
+			rtl: this.props.dir === 'rtl',
+			ltr: this.props.dir === 'ltr',
 			search: true
 		} );
 
@@ -269,12 +273,12 @@ const Search = React.createClass( {
 					}
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }>
-				<Gridicon icon="search" className="search-open__icon"/>
+				<Gridicon icon="search" className={ 'search-open__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) }/>
 				</div>
 				<input
 					type="search"
 					id={ 'search-component-' + this.state.instanceId }
-					className="search__input"
+					className={ 'search__input' + ( this.props.dir ? ' ' + this.props.dir : '' ) }
 					placeholder={ placeholder }
 					role="search"
 					value={ searchValue }
@@ -287,6 +291,7 @@ const Search = React.createClass( {
 					disabled={ this.props.disabled }
 					aria-hidden={ ! isOpenUnpinnedOrQueried }
 					autoCapitalize="none"
+					dir={ this.props.dir }
 					{...autocorrect } />
 				{ ( searchValue || this.state.isOpen ) ? this.closeButton() : null }
 			</div>
@@ -301,7 +306,7 @@ const Search = React.createClass( {
 				onKeyDown={ this._keyListener.bind( this, 'closeSearch' ) }
 				aria-controls={ 'search-component-' + this.state.instanceId }
 				aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
-			<Gridicon icon="cross" className="search-close__icon"/>
+			<Gridicon icon="cross" className={ 'search-close__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) } />
 			</span>
 		);
 	},

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -40,7 +40,19 @@
 		position: absolute;
 			bottom: 0;
 			top: 50%;
+
+		&:not(.ltr):not(.rtl) {
 			right: 0;
+		}
+
+		&.ltr {
+			right: 0 #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			left: 0 #{"/*rtl:ignore*/"};
+		}
+
 		margin-top: -12px;
 		width: 60px;
 		cursor: pointer;
@@ -83,12 +95,34 @@
 	position: absolute;
 		bottom: 0;
 		top: 0;
+
+	&:not(.ltr):not(.rtl) {
 		right: 0;
+	}
+
+	&.ltr {
+		right: 0 #{"/*rtl:ignore*/"};
+	}
+
+	&.rtl {
+		left: 0 #{"/*rtl:ignore*/"};
+	}
+
 	// matching dropdown-selector
 	z-index: z-index( 'root', '.search.is-pinned' );
 
 	.search-open__icon {
-		right: 0;
+		&:not(.ltr):not(.rtl) {
+			right: 0;
+		}
+
+		&.ltr {
+			right: 0 #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			left: 0 #{"/*rtl:ignore*/"};
+		}
 	}
 
 	.search__input[type="search"] {
@@ -111,8 +145,21 @@
 
 	@include breakpoint( "<660px" ) {
 		opacity: 0;
-		left: 0;
-		padding-left: 50px;
+
+		&:not(.ltr):not(.rtl) {
+			right: 0;
+			padding-left: 50px;
+		}
+
+		&.ltr {
+			left: 0 #{"/*rtl:ignore*/"};
+			padding-left: 50px #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			right: 0 #{"/*rtl:ignore*/"};
+			padding-right: 50px #{"/*rtl:ignore*/"};
+		}
 	}
 
 	&::-webkit-search-cancel-button {
@@ -127,12 +174,36 @@
 
 // When search input is opened
 .search.is-open {
-	margin-right: 0 !important;
+
+	&:not(.ltr):not(.rtl) {
+		margin-right: 0 !important;
+	}
+
+	&.ltr {
+		margin-right: 0 #{"/*rtl:ignore*/"} !important;
+	}
+
+	&.rtl {
+		margin-left: 0 #{"/*rtl:ignore*/"} !important;
+	}
+
 	width: 100%;
 
 	.search-open__icon {
 		color: darken( $gray, 30% );
-		left: 0;
+
+		&:not(.ltr):not(.rtl) {
+			left: 0;
+		}
+
+		&.ltr {
+			left: 0 #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			right: 0 #{"/*rtl:ignore*/"};
+		}
+
 	}
 
 	.search-close__icon {
@@ -153,11 +224,34 @@
 	display: none;
 	position: absolute;
 		top: 50%;
+
+	&:not(.ltr):not(.rtl) {
 		left: 30px;
+	}
+
+	&.ltr {
+		left: 30px #{"/*rtl:ignore*/"};
+	}
+
+	&.rtl {
+		right: 30px #{"/*rtl:ignore*/"};
+	}
+
 	transform: translate( -50%, -50% );
 
 	@include breakpoint( "<660px" ) {
-		left: 25px;
+
+		&:not(.ltr):not(.rtl) {
+			left: 25px;
+		}
+
+		&.ltr {
+			left: 25px #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			right: 25px #{"/*rtl:ignore*/"};
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes #5520, by introducing an option to force the direction of the search field.

I believe this is the expected interaction for this type of field, but I need someone from I18n more used to the RTL interaction to confirm this is correct. (Especially the placeholder.)

![screen shot 2016-05-27 at 19 13 53](https://cloud.githubusercontent.com/assets/418473/15622528/f44d3fce-243f-11e6-9031-dfcb53d8f2c7.png)

![screen shot 2016-05-27 at 19 14 34](https://cloud.githubusercontent.com/assets/418473/15622527/f41ffb4a-243f-11e6-93fe-d79b1874b474.png)

I used a `dir` field to be consistent with the HTML conventions, and some CSS trickery with classes and `:not()` rules. This was needed because `:dir()` is not yet widely implemented) and `[dir="ltr"]` would require me to add support for that attribute on all involved components, including `Gridicon`, and I didn't want to mess with that.

In the long term once browsers support `:dir()` that should make the code way cleaner and more correct.