### PR TITLE
Build: check if Calypso is running before regenerating shrinkwrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ githooks-push:
 
 # generate a new shrinkwrap
 shrinkwrap: node-version
+	@! lsof -Pi :3000 -sTCP:LISTEN -t || ( echo "Please stop your Calypso instance running on port 3000 and try again." && exit 1 )
 	@type shonkwrap || ( echo "Please install shonkwrap globally and try again: 'npm install -g shonkwrap'" && exit 1 )
 	@rm -rf node_modules
 	@rm -f npm-shrinkwrap.json


### PR DESCRIPTION
If Calypso is running `make shrinkwrap` may fail. This PR checks to see if Calypso is running on port 3000 before we attempt to shrinkwrap. 

## Testing Instructions
- call `make run`, wait until you can visit a page
- in another tab call `make shrinkwrap`
- the shrinkwrap should fail with a message for you to stop Calypso
- Stop Calypso
- `make shrinkwrap` should succeed

cc @aduth @rralian @lamosty