### PR TITLE
Reader: add `background-size: cover` to Hero image

### DIFF
--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -169,7 +169,8 @@
 }
 
 .reader-start-card__hero {
-	background: lighten( $gray, 30% ); // Background to be used if no image
+	background-color: lighten( $gray, 30% ); // Background to be used if no image
+	background-size: cover;
 	height: 70px;
 	margin: -24px;
 }


### PR DESCRIPTION
On the Recommendation cards.

### Before

<img width="393" alt="screen shot 2016-05-28 at 3 24 14 pm" src="https://cloud.githubusercontent.com/assets/71256/15630043/4f4b5fac-24e8-11e6-9da9-f7d1810a4a77.png">

### After

<img width="382" alt="screen shot 2016-05-28 at 3 24 27 pm" src="https://cloud.githubusercontent.com/assets/71256/15630044/53c423ac-24e8-11e6-9454-b43208182932.png">

/cc @jancavan 