### PR TITLE
Reader: fix inconsistent colored links in Cold Start columns

### DIFF
--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -31,6 +31,7 @@
 
 .reader-start__cards {
 
+	padding-bottom: 100px;
 	transform: translateX( 0 ); // Prevents overflowing content from disappearing
 
     @include breakpoint( ">960px" ) {
@@ -63,14 +64,6 @@
 	&:nth-child( even ),
 	&:last-child {
 		margin-right: 0;
-	}
-
-	&:last-child {
-		margin-bottom: 100px;
-
-		@include breakpoint( ">480px" ) {
-			margin-bottom: 80px;
-		}
 	}
 
 	.site-icon__img {
@@ -226,11 +219,15 @@
 	font-family: $serif;
 	font-size: 16px;
 	font-weight: 600;
-	line-height: 1;
+	line-height: 1.3;
 	margin-bottom: 5px;
 
 	&:hover {
 		color: darken( $gray, 10% );
+	}
+
+	&:visited {
+		color: $gray-dark;
 	}
 }
 
@@ -304,7 +301,7 @@
 
 // Appending inline recommendations
 
-.reader-start-card {
+/*.reader-start-card {
 
 	&:last-child {
 		animation: slide-right .7s ease-out 5s 1 forwards;
@@ -339,4 +336,4 @@
     		transform: translateX( 105% );
     	}
 	}
-}
+}*/

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -301,7 +301,7 @@
 
 // Appending inline recommendations
 
-/*.reader-start-card {
+.reader-start-card {
 
 	&:last-child {
 		animation: slide-right .7s ease-out 5s 1 forwards;
@@ -336,4 +336,4 @@
     		transform: translateX( 105% );
     	}
 	}
-}*/
+}

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -227,7 +227,7 @@
 	}
 
 	&:visited {
-		color: $gray-dark;
+		color: inherit;
 	}
 }
 


### PR DESCRIPTION
As mentioned in: https://github.com/Automattic/wp-calypso/pull/5538#issuecomment-222318385

**Before:**
<img width="751" alt="screenshot 2016-05-28 14 57 08" src="https://cloud.githubusercontent.com/assets/4924246/15630220/156b8d8c-24e5-11e6-8c38-545c5d6d72d5.png">

**After:**
<img width="738" alt="screenshot 2016-05-28 14 57 45" src="https://cloud.githubusercontent.com/assets/4924246/15630221/1b33f1a0-24e5-11e6-84eb-859714f9665c.png">

/cc @bluefuton 