### PR TITLE
Reader: remove extra line of text in post preview

### DIFF
--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -98,9 +98,7 @@
 	.post-excerpt.is-long {
 
 		&:after {
-			@include long-content-fade( $color: $white, $direction: right, $size: 100% );
-			height: 20px;
-			position: relative;
+			display: none;
 		}
 	}
 


### PR DESCRIPTION
**Before:**
- ellipsis is displayed after 3rd line and an extra line of text is added after it
- also just removed `long-content-fade` as it was having issues and not being displayed in the 2nd column of `column-count`. I believe it's related to the bug mentioned here: https://github.com/Automattic/wp-calypso/pull/5538#issuecomment-221904692
<img width="364" alt="screenshot 2016-05-28 15 47 31" src="https://cloud.githubusercontent.com/assets/4924246/15630340/d2f872f6-24eb-11e6-9049-c7fe63177449.png">

**After:**
<img width="365" alt="screenshot 2016-05-28 15 47 11" src="https://cloud.githubusercontent.com/assets/4924246/15630342/e62d64c6-24eb-11e6-981e-ca8700f68bb6.png">

/cc @bluefuton 