### PR TITLE
Add "source-map-loader" for ES6 and React source maps

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3301,6 +3301,9 @@
     "source-map": {
       "version": "0.1.39"
     },
+    "source-map-loader": {
+      "version": "0.1.5"
+    },
     "source-map-support": {
       "version": "0.3.2",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "sanitize-html": "1.11.1",
     "semver": "5.1.0",
     "source-map": "0.1.39",
+    "source-map-loader": "0.1.5",
     "source-map-support": "0.3.2",
     "srcset": "1.0.0",
     "store": "1.3.16",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ webpackConfig = {
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]'
 	},
 	debug: true,
-	devtool: '#source-map',
+	devtool: '#eval-cheap-module-source-map',
 	module: {
 		preLoaders: [
 			{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,8 +33,15 @@ webpackConfig = {
 		chunkFilename: '[name].[chunkhash].js',
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]'
 	},
-	devtool: '#eval',
+	debug: true,
+	devtool: '#source-map',
 	module: {
+		preLoaders: [
+			{
+				test: /\.jsx?$/,
+				loader: 'source-map-loader'
+			}
+		],
 		loaders: [
 			{
 				test: /sections.js$/,
@@ -127,6 +134,7 @@ if ( CALYPSO_ENV === 'development' ) {
 	jsLoader.loaders = [ 'react-hot' ].concat( jsLoader.loaders );
 } else {
 	webpackConfig.entry[ 'build-' + CALYPSO_ENV ] = path.join( __dirname, 'client', 'boot' );
+	webpackConfig.debug = false;
 	webpackConfig.devtool = false;
 }
 


### PR DESCRIPTION
### Before:

The Web Inspector would show the babel-transpiled code which is messy and unreadable:

![screen shot 2016-05-28 at 4 51 39 pm](https://cloud.githubusercontent.com/assets/71256/15630382/d625a5c0-24f5-11e6-83e5-928932efaf07.png)

### After:

By adding "source-map-loader" we get the original ES6 and React.js code in the Web Inspector.

![screen shot 2016-05-28 at 4 44 22 pm](https://cloud.githubusercontent.com/assets/71256/15630383/dd73b88a-24f5-11e6-92cb-a9d4c98caf53.png)
