### PR TITLE
Adding Traintracks for tracking accuracy of different recommended post algorithms

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -3,6 +3,7 @@
  */
 var debug = require( 'debug' )( 'calypso:analytics' ),
 	assign = require( 'lodash/assign' ),
+	times = require( 'lodash/times' ),
 	omit = require( 'lodash/omit' ),
 	startsWith = require( 'lodash/startsWith' ),
 	isUndefined = require( 'lodash/isUndefined' );
@@ -151,17 +152,15 @@ var analytics = {
 			} );
 		},
 
-		createRandId:  function() {
-			var randomBytesLength = 9, // 9 * 4/3 = 12
+		createRandomId:  function() {
+			var randomBytesLength = 9, // 9 * 4/3 = 12 - this is to avoid getting padding of a random byte string when it is base64 encoded
 					randomBytes = [];
 
 			if ( window.crypto && window.crypto.getRandomValues ) {
 				randomBytes = new Uint8Array( randomBytesLength );
 				window.crypto.getRandomValues( randomBytes );
 			} else {
-				for ( var i = 0; i < randomBytesLength; ++i ) {
-					randomBytes[ i ] = Math.floor( Math.random() * 256 );
-				}
+				randomBytes = times( randomBytesLength, () => Math.floor( Math.random() * 256 ) );
 			}
 
 			return btoa( String.fromCharCode.apply( String, randomBytes ) );

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -149,7 +149,24 @@ var analytics = {
 			analytics.tracks.recordEvent( 'calypso_page_view', {
 				'path': urlPath
 			} );
+		},
+
+		createRandId:  function() {
+			var randomBytesLength = 9, // 9 * 4/3 = 12
+					randomBytes = [];
+
+			if ( window.crypto && window.crypto.getRandomValues ) {
+				randomBytes = new Uint8Array( randomBytesLength );
+				window.crypto.getRandomValues( randomBytes );
+			} else {
+				for ( var i = 0; i < randomBytesLength; ++i ) {
+					randomBytes[ i ] = Math.floor( Math.random() * 256 );
+				}
+			}
+
+			return btoa( String.fromCharCode.apply( String, randomBytes ) );
 		}
+
 	},
 
 	statsd: {

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -168,16 +168,9 @@ function getStoreForRecommendedPosts( storeId ) {
 				stream.algorithm = response.algorithm;
 			}
 			forEach( response && response.posts, ( post, index ) => {
-				let railcar = analytics.tracks.createRandomId() + '-' + index;
-				eventProperties = {
-					railcar: railcar,
-					ui_algo: 'warm-start-v1',
-					ui_position: query.offset + index,
-					fetch_algo: response.algorithm,
-					fetch_position: query.offset + index
-				};
-				post.railcar = railcar;
-				analytics.tracks.recordEvent( eventName, eventProperties );
+				if ( post.railcar ) {
+					analytics.tracks.recordEvent( eventName, post.railcar );
+				}
 			} );
 			callback( err, response );
 		}

--- a/client/reader/comments/form.jsx
+++ b/client/reader/comments/form.jsx
@@ -19,6 +19,7 @@ import {
 import {
 	recordAction,
 	recordGaEvent,
+	recordTrainTrackInteract,
 	recordTrack
 } from 'reader/stats';
 
@@ -135,6 +136,7 @@ class PostCommentForm extends React.Component {
 			post_id: post.ID,
 			parent_post_id: this.props.parentCommentID ? this.props.parentCommentID : undefined
 		} );
+		recordTrainTrackInteract( 'article_commented_on', post );
 
 		this.resetCommentText();
 

--- a/client/reader/comments/form.jsx
+++ b/client/reader/comments/form.jsx
@@ -19,8 +19,7 @@ import {
 import {
 	recordAction,
 	recordGaEvent,
-	recordTrainTrackInteract,
-	recordTrack
+	recordTrackForPost
 } from 'reader/stats';
 
 class PostCommentForm extends React.Component {
@@ -131,12 +130,9 @@ class PostCommentForm extends React.Component {
 
 		recordAction( 'posted_comment' );
 		recordGaEvent( 'Clicked Post Comment Button' );
-		recordTrack( 'calypso_reader_article_commented_on', {
-			blog_id: post.site_ID,
-			post_id: post.ID,
+		recordTrackForPost( 'calypso_reader_article_commented_on', post, {
 			parent_post_id: this.props.parentCommentID ? this.props.parentCommentID : undefined
 		} );
-		recordTrainTrackInteract( 'article_commented_on', post );
 
 		this.resetCommentText();
 

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -452,7 +452,6 @@ FullPostContainer = React.createClass( {
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
 			stats.recordTrackForPost( 'calypso_reader_article_opened', post );
-			stats.recordTrainTrackInteract( 'article_opened', post );
 			this.hasLoaded = true;
 		}
 	},

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -452,6 +452,7 @@ FullPostContainer = React.createClass( {
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
 			stats.recordTrackForPost( 'calypso_reader_article_opened', post );
+			stats.recordTrainTrackInteract( 'article_opened', post );
 			this.hasLoaded = true;
 		}
 	},

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -1,5 +1,5 @@
 var React = require( 'react' );
-var postStream = require( 'lib/feed-post-store' );
+var postStore = require( 'lib/feed-post-store' );
 
 var LikeButtonContainer = require( 'components/like-button' ),
 	stats = require( 'reader/stats' );
@@ -7,7 +7,7 @@ var LikeButtonContainer = require( 'components/like-button' ),
 var ReaderLikeButton = React.createClass( {
 
 	recordLikeToggle: function( liked ) {
-		var post = postStream.get( {
+		var post = postStore.get( {
 			blogId: this.props.siteId,
 			postId: this.props.postId
 		} );

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -1,4 +1,5 @@
 var React = require( 'react' );
+var postStream = require( 'lib/feed-post-store' );
 
 var LikeButtonContainer = require( 'components/like-button' ),
 	stats = require( 'reader/stats' );
@@ -6,12 +7,17 @@ var LikeButtonContainer = require( 'components/like-button' ),
 var ReaderLikeButton = React.createClass( {
 
 	recordLikeToggle: function( liked ) {
+		var post = postStream.get( {
+			blogId: this.props.siteId,
+			postId: this.props.postId
+		} );
 		stats.recordAction( liked ? 'liked_post' : 'unliked_post' );
 		stats.recordGaEvent( liked ? 'Clicked Like Post' : 'Clicked Unlike Post' );
 		stats.recordTrack( liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked', {
 			blog_id: this.props.siteId,
 			post_id: this.props.postId
 		} );
+		stats.recordTrainTrackInteract( 'article_liked', post );
 		if ( this.props.onLikeToggle ) {
 			this.props.onLikeToggle( liked );
 		}

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -13,14 +13,7 @@ var ReaderLikeButton = React.createClass( {
 		} );
 		stats.recordAction( liked ? 'liked_post' : 'unliked_post' );
 		stats.recordGaEvent( liked ? 'Clicked Like Post' : 'Clicked Unlike Post' );
-		stats.recordTrack( liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked', {
-			blog_id: this.props.siteId,
-			post_id: this.props.postId
-		} );
-		stats.recordTrainTrackInteract( 'article_liked', post );
-		if ( this.props.onLikeToggle ) {
-			this.props.onLikeToggle( liked );
-		}
+		stats.recordTrackForPost( liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked', post );
 	},
 
 	render: function() {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -110,6 +110,15 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {} )
 	}, additionalProps ) );
 }
 
+export function recordTrainTrackInteract( action, post = {} ) {
+	if ( typeof( post.railcar ) !== 'undefined' ) {
+		recordTrack( 'calypso_traintracks_interact', {
+			action: 'article_opened',
+			railcar: post.railcar
+		} );
+	}
+}
+
 export function pageViewForPost( blogId, blogUrl, postId, isPrivate ) {
 	let params = {
 		ref: 'http://wordpress.com/',

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -111,9 +111,9 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {} )
 }
 
 export function recordTrainTrackInteract( action, post = {} ) {
-	if ( typeof( post.railcar ) !== 'undefined' ) {
+	if ( post.railcar ) {
 		recordTrack( 'calypso_traintracks_interact', {
-			action: 'article_opened',
+			action: action,
 			railcar: post.railcar
 		} );
 	}

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -97,8 +97,10 @@ export function recordTrack( eventName, eventProperties ) {
 	if ( subCount != null ) {
 		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
 	}
-	if ( 'blog_id' in eventProperties && 'post_id' in eventProperties && ! 'is_jetpack' in eventProperties ) {
-		console.warn( 'consider using recordTrackForPost...', eventName, eventProperties );
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'blog_id' in eventProperties && 'post_id' in eventProperties && ! 'is_jetpack' in eventProperties ) {
+			console.warn( 'consider using recordTrackForPost...', eventName, eventProperties );
+		}
 	}
 	tracks.recordEvent( eventName, eventProperties );
 }
@@ -123,8 +125,8 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {} )
 			action: eventName.replace( 'calypso_reader_', '' ),
 			railcar: post.railcar
 		} );
-	} else if ( post.railcar ) {
-		console.warn( 'maybe you want to whitelist', eventName );
+	} else if ( process.env.NODE_ENV !== 'production' && post.railcar ) {
+		console.warn( 'Consider whitelisting reader track', eventName );
 	}
 }
 


### PR DESCRIPTION
We want to be able to try different algorithms for recommended posts and
track how well they perform. These changes add some general functions
for adding tracks events when a recommended post stream is fetched, and
also when an article is interacted with (liked, commented_on, or opened)
(may also want to add visit on site, and follow)

How to test:

1. Apply differential D1918 in your wpcom sandbox and sandbox the public api
2. Load the recommended posts tab in the reader
3. Interact with some posts (like, open, comment)
4. Scroll for some more posts
5. Get coffee while waiting for 10 minutes
6. Check the tracks live view for `calypso_traintracks_render` and `calypso_traintracks_interact` events