### PR TITLE
Add GET request for Reader related posts

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1136,6 +1136,12 @@ Undocumented.prototype.readSitePost = function( query, fn ) {
 	this.wpcom.req.get( '/read/sites/' + query.site + '/posts/' + query.postId, params, fn );
 };
 
+Undocumented.prototype.readSitePostRelated = function( query, fn ) {
+	debug( '/read/site/:site/post/:post/related' );
+	query.apiVersion = '1.2';
+	this.wpcom.req.get( '/read/site/' + query.site_id + '/post/' + query.post_id + '/related', query, fn );
+};
+
 Undocumented.prototype.fetchSiteRecommendations = function( query, fn ) {
 	this.wpcom.req.get( '/read/recommendations/mine', query, fn );
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1139,7 +1139,7 @@ Undocumented.prototype.readSitePost = function( query, fn ) {
 Undocumented.prototype.readSitePostRelated = function( query, fn ) {
 	debug( '/read/site/:site/post/:post/related' );
 	query.apiVersion = '1.2';
-	this.wpcom.req.get( '/read/site/' + query.site_id + '/post/' + query.post_id + '/related', query, fn );
+	return this.wpcom.req.get( '/read/site/' + query.site_id + '/post/' + query.post_id + '/related', query, fn );
 };
 
 Undocumented.prototype.fetchSiteRecommendations = function( query, fn ) {


### PR DESCRIPTION
New Reader feature to display related posts at the bottom of a post's body. An API endpoint was created at D1916-code that uses Elasticsearch queries (D1913-code) to suggest related reading.

A project at the Data Team Meetup in Denver, CO.