### PR TITLE
Jetpack Connect: Add site card

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import page from 'page';
+import urlModule from 'url';
 const debug = require( 'debug' )( 'calypso:jetpack-connect:authorize-form' );
 
 /**
@@ -44,21 +45,22 @@ const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
 
 const SiteCard = React.createClass( {
 	render() {
-		const { site_icon, blogname, home_url } = this.props.queryObject;
+		const { site_icon, blogname, home_url, site_url } = this.props.queryObject;
 		const siteIcon = site_icon ? { img: site_icon } : false;
 		const url = decodeEntities( home_url );
-		const title = decodeEntities( blogname );
+		const parsedUrl = urlModule.parse( url );
+		const path = ( parsedUrl.path === '/' ) ? '' : parsedUrl.path;
 		const site = {
 			ID: null,
 			url: url,
-			admin_url: url,
-			domain: url,
+			admin_url: decodeEntities( site_url + '/wp-admin' ),
+			domain: parsedUrl.host + path,
 			icon: siteIcon,
 			is_vip: false,
-			title: title
+			title: decodeEntities( blogname )
 		};
 		return(
-			<CompactCard>
+			<CompactCard className="jetpack-connect__site">
 				<Site site={ site } />
 			</CompactCard>
 		);

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -23,6 +23,7 @@ import JetpackConnectNotices from './jetpack-connect-notices';
 import observe from 'lib/mixins/data-observe';
 import userUtilities from 'lib/user/utils';
 import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import i18n from 'lib/mixins/i18n';
 import Gridicon from 'components/gridicon';
@@ -39,6 +40,34 @@ const PLANS_PAGE = '/jetpack/connect/plans/';
 const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + process.env.NODE_ENV;
 const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
 
+const SiteCard = React.createClass( {
+	render() {
+		const { site_icon } = this.props.queryObject;
+		const style = {
+			height: 32,
+			width: 32,
+			lineHeight: '32px',
+			fontSize: '32px'
+		};
+		const icon = ( site_icon )
+			? <img className="site-icon__img" src={ site_icon } />
+			: <Gridicon icon="globe" size={ Math.round( 32 / 1.3 ) } />;
+		return(
+			<CompactCard>
+				<div className="site">
+					<div className="site-icon" style={ style }>
+						{ icon }
+					</div>
+					<div className="site__info">
+						<div className="site__title">{ this.props.queryObject.blogname }</div>
+						<div className="site__domain">{ this.props.queryObject.home_url }</div>
+					</div>
+				</div>
+			</CompactCard>
+		);
+	}
+} );
+
 const LoggedOutForm = React.createClass( {
 	displayName: 'LoggedOutForm',
 
@@ -46,12 +75,10 @@ const LoggedOutForm = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
 	},
 
-	renderFormHeader( siteUrl ) {
+	renderFormHeader() {
 		const headerText = i18n.translate( 'Create your account' );
-		const subHeaderText = i18n.translate( 'You are moments away from connecting {{span}}%(site)s{{/span}}', {
-			args: { site: siteUrl },
-			components: { span: <span className="jetpack-connect-authorize__site-url" /> }
-		} );
+		const subHeaderText = i18n.translate( 'You are moments away from connecting your site.' );
+		const { queryObject } = this.props.jetpackConnectAuthorize;
 
 		return(
 			<div>
@@ -59,6 +86,7 @@ const LoggedOutForm = React.createClass( {
 					showLogo={ false }
 					headerText={ headerText }
 					subHeaderText={ subHeaderText } />
+				<SiteCard queryObject={ queryObject } />
 			</div>
 		);
 	},
@@ -107,11 +135,10 @@ const LoggedOutForm = React.createClass( {
 
 	render() {
 		const { userData } = this.props.jetpackConnectAuthorize;
-		const { site } = this.props.jetpackConnectAuthorize.queryObject;
 		return (
 			<div>
 				{ this.renderLocaleSuggestions() }
-				{ this.renderFormHeader( site ) }
+				{ this.renderFormHeader() }
 				<SignupForm
 					getRedirectToAfterLoginUrl={ window.location.href }
 					disabled={ this.isSubmitting() }
@@ -154,15 +181,14 @@ const LoggedInForm = React.createClass( {
 		}
 	},
 
-	renderFormHeader( siteUrl, isConnected ) {
+	renderFormHeader( isConnected ) {
+		const { queryObject } = this.props.jetpackConnectAuthorize;
 		const headerText = ( isConnected )
 			? i18n.translate( 'You are connected!' )
 			: i18n.translate( 'Completing connection' );
 		const subHeaderText = ( isConnected )
 			? i18n.translate( 'Thank you for flying with Jetpack' )
-			: i18n.translate( 'Jetpack is finishing up the connection process', {
-				args: { site: siteUrl }
-			} );
+			: i18n.translate( 'Jetpack is finishing up the connection process' );
 
 		return(
 			<div>
@@ -170,6 +196,7 @@ const LoggedInForm = React.createClass( {
 					showLogo={ false }
 					headerText={ headerText }
 					subHeaderText={ subHeaderText } />
+				<SiteCard queryObject={ queryObject } />
 			</div>
 		);
 	},
@@ -347,10 +374,9 @@ const LoggedInForm = React.createClass( {
 
 	render() {
 		const { authorizeSuccess } = this.props.jetpackConnectAuthorize;
-		const { site } = this.props.jetpackConnectAuthorize.queryObject;
 		return (
 			<div className="jetpack-connect-logged-in-form">
-				{ this.renderFormHeader( site, authorizeSuccess ) }
+				{ this.renderFormHeader( authorizeSuccess ) }
 				<Card>
 					<Gravatar user={ this.props.user } size={ 64 } />
 					<p className="jetpack-connect-logged-in-form__user-text">{ this.getUserText() }</p>

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -31,6 +31,7 @@ import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteByUrl } from 'state/sites/selectors';
 import Spinner from 'components/spinner';
+import Site from 'my-sites/site';
 import { decodeEntities } from 'lib/formatting';
 
 /**
@@ -43,27 +44,22 @@ const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
 
 const SiteCard = React.createClass( {
 	render() {
-		const { site_icon } = this.props.queryObject;
-		const style = {
-			height: 32,
-			width: 32,
-			lineHeight: '32px',
-			fontSize: '32px'
+		const { site_icon, blogname, home_url } = this.props.queryObject;
+		const siteIcon = site_icon ? { img: site_icon } : false;
+		const url = decodeEntities( home_url );
+		const title = decodeEntities( blogname );
+		const site = {
+			ID: null,
+			url: url,
+			admin_url: url,
+			domain: url,
+			icon: siteIcon,
+			is_vip: false,
+			title: title
 		};
-		const icon = ( site_icon )
-			? <img className="site-icon__img" src={ site_icon } />
-			: <Gridicon icon="globe" size={ Math.round( 32 / 1.3 ) } />;
 		return(
 			<CompactCard>
-				<div className="site">
-					<div className="site-icon" style={ style }>
-						{ icon }
-					</div>
-					<div className="site__info">
-						<div className="site__title">{ decodeEntities( this.props.queryObject.blogname ) }</div>
-						<div className="site__domain">{ decodeEntities( this.props.queryObject.home_url ) }</div>
-					</div>
-				</div>
+				<Site site={ site } />
 			</CompactCard>
 		);
 	}

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -31,6 +31,7 @@ import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteByUrl } from 'state/sites/selectors';
 import Spinner from 'components/spinner';
+import { decodeEntities } from 'lib/formatting';
 
 /**
  * Constants
@@ -59,8 +60,8 @@ const SiteCard = React.createClass( {
 						{ icon }
 					</div>
 					<div className="site__info">
-						<div className="site__title">{ this.props.queryObject.blogname }</div>
-						<div className="site__domain">{ this.props.queryObject.home_url }</div>
+						<div className="site__title">{ decodeEntities( this.props.queryObject.blogname ) }</div>
+						<div className="site__domain">{ decodeEntities( this.props.queryObject.home_url ) }</div>
 					</div>
 				</div>
 			</CompactCard>

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -246,3 +246,7 @@
 		margin: 0;
 	}
 }
+
+.jetpack-connect__site.card {
+	padding: 0;
+}


### PR DESCRIPTION
Adds a site card to the authorization form based on [Ricky Bannister's mocks](https://github.com/Automattic/wp-calypso/issues/4963).

I could not use the Site component directly because it relies on the selected site within the site's list. Since the site we are connecting is not yet part of the site's list, I simply created a sub-component within AuthorizeForm that uses the same mark up as the Site component.

Fixes #5237 
Fixes #4963

To test:
- run the latest master of Jetpack on your unconnected Jetpack site
- set a site icon on your Jetpack site
- running this branch locally, go to calypso.localhost:3000/jetpack/connect
- connect your jetpack site
- your authorization screen should look like this:
<img width="439" alt="screen shot 2016-05-29 at 1 54 05 pm" src="https://cloud.githubusercontent.com/assets/2694219/15635157/df2462ce-25a4-11e6-8d41-c18f7921a638.png">


cc: @johnHackworth @rickybanister 