### PR TITLE
Change copy that displayed for Google Apps and Premium Theme cancelation

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -13,7 +13,7 @@ import { cancelAndRefundPurchase, cancelPurchase } from 'lib/upgrades/actions';
 import { connect } from 'react-redux';
 import Dialog from 'components/dialog';
 import { getName, getSubscriptionEndDate, isOneTimePurchase, isRefundable, isSubscription } from 'lib/purchases';
-import { isDomainRegistration } from 'lib/products-values';
+import { isDomainRegistration, isTheme, isGoogleApps  } from 'lib/products-values';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
@@ -60,8 +60,37 @@ const CancelPurchaseButton = React.createClass( {
 					isPrimary: true,
 					disabled: this.state.submitting,
 					onClick: this.submitCancelAndRefundPurchase
-				},
+				}
 			];
+
+		let cancelationEffectText = this.translate(
+			'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.', {
+				args: {
+					cost: refundText
+				}
+			}
+		);
+
+		if ( isTheme( this.props.purchase ) ) {
+			cancelationEffectText = this.translate(
+				'Your site\'s appearance will revert to its previously selected theme and you will be refunded %(cost)s.', {
+					args: {
+						cost: refundText
+					}
+				}
+			);
+		}
+
+		if ( isGoogleApps( this.props.purchase ) ) {
+			cancelationEffectText = this.translate(
+				'You will be refunded %(cost)s, but your Google Apps account will continue working without interruption. ' +
+				'You will be able to manage your Google Apps billing directly through Google.', {
+					args: {
+						cost: refundText
+					}
+				}
+			);
+		}
 
 		return (
 			<Dialog
@@ -78,18 +107,17 @@ const CancelPurchaseButton = React.createClass( {
 				</h1>
 				<p>
 					{ this.translate(
-						'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ' +
-						'All plan features and custom changes will be removed from your site and you will be refunded %(priceText)s.', {
+						'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
 							args: {
 								purchaseName,
-								domain,
-								priceText: refundText
+								domain
 							},
 							components: {
 								em: <em />
 							}
 						}
 					) }
+					{ cancelationEffectText }
 				</p>
 			</Dialog>
 		);

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -12,7 +12,7 @@ import Dialog from 'components/dialog';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { getPurchase, isDataLoading } from '../utils';
 import Gridicon from 'components/gridicon';
-import { isDomainRegistration, isPlan } from 'lib/products-values';
+import { isDomainRegistration, isPlan, isGoogleApps } from 'lib/products-values';
 import notices from 'notices';
 import purchasePaths from '../paths';
 import { removePurchase } from 'lib/upgrades/actions';
@@ -168,9 +168,14 @@ const RemovePurchase = React.createClass( {
 						} )
 					}
 					{ ' ' }
-					{ this.translate( 'You will not be able to reuse it again without purchasing a new subscription.', {
-						comment: "'it' refers to a product purchased by a user"
-					} ) }
+					{ isGoogleApps( purchase )
+						? this.translate( 'Your Google Apps account will continue working without interruption. ' +
+						'You will be able to manage your Google Apps billing directly through Google.'
+					)
+						: this.translate( 'You will not be able to reuse it again without purchasing a new subscription.', {
+							comment: "'it' refers to a product purchased by a user"
+						} )
+					}
 				</p>
 
 				{ includedDomainText }


### PR DESCRIPTION
That PR resolves #4698,
by adding the following messages for cancelation of products that are google apps / premium themes:

Remove google apps ( without refund / after cancel + refund ):
![screen shot 2016-05-30 at 10 31 39 am](https://cloud.githubusercontent.com/assets/326402/15644042/3bf257b8-2659-11e6-89c7-6e9dceefb1e1.png)

Google apps cancelation with refund: 
![screen shot 2016-05-30 at 11 10 44 am](https://cloud.githubusercontent.com/assets/326402/15644046/41847c7e-2659-11e6-9fc9-65b51e67b07e.png)

Premium theme cancelation with refund:
![screen shot 2016-05-30 at 11 20 47 am](https://cloud.githubusercontent.com/assets/326402/15644047/435eef98-2659-11e6-93a8-919eae1c7bb7.png)

#### Testing instructions
 
1. Run `git checkout fix/change-cancel-copy` and start your server
2. Purchase Google Apps and a Premium theme
3. Cancel each one of them (both before refund period and after)
4. Verify the correct message appears
 
#### Reviews
 
- [x] Code
- [ ] Product