### PR TITLE
Fix client/lib/signup readme formatting

### DIFF
--- a/client/lib/signup/README.md
+++ b/client/lib/signup/README.md
@@ -51,6 +51,7 @@ var SignupDependencyStore = require( 'lib/signup/dependency-store' ),
 SignupActions.processedSignupStep( { stepName: 'example' }, [], { userId: 1337 } );
 
 SignupDependencyStore.get() // => { userId: 1337 }
+```
 
 ### `SignupFlowController`
 `SignupFlowController` initializes a new signup flow and handles initiating API requests for the steps that have an `apiRequestFunction` property. It provides a view with a method for getting the current step and a callback for when the flow is completed.


### PR DESCRIPTION
There was a missing closing markup for JS code, which broke the formatting and made the readme hard to read.