### PR TITLE
GetRoles: add locale param to get translated roles names

### DIFF
--- a/client/lib/site-roles/actions.js
+++ b/client/lib/site-roles/actions.js
@@ -18,7 +18,7 @@ var RolesActions = {
 			siteId: siteId
 		} );
 
-		wpcom.undocumented().site( siteId ).getRoles( {}, function( error, data ) {
+		wpcom.undocumented().site( siteId ).getRoles( function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_ROLES',
 				action: 'RECEIVE_ROLES',

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -99,7 +99,7 @@ UndocumentedSite.prototype.domains = function( callback ) {
 };
 
 UndocumentedSite.prototype.postFormatsList = function( callback ) {
-	this.wpcom.req.get( '/sites/' + this._id + '/post-formats', { locale: i18n.getLocaleSlug() }, callback );
+	this.wpcom.withLocale().req.get( '/sites/' + this._id + '/post-formats', {}, callback );
 };
 
 UndocumentedSite.prototype.postAutosave = function( postId, attributes, callback ) {
@@ -123,7 +123,7 @@ UndocumentedSite.prototype.shortcodes = function( attributes, callback ) {
 };
 
 UndocumentedSite.prototype.getRoles = function( callback ) {
-	this.wpcom.req.get( '/sites/' + this._id + '/roles', { locale: i18n.getLocaleSlug() }, callback );
+	this.wpcom.withLocale().req.get( '/sites/' + this._id + '/roles', {}, callback );
 };
 
 UndocumentedSite.prototype.getViewers = function( query, callback ) {

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -122,8 +122,8 @@ UndocumentedSite.prototype.shortcodes = function( attributes, callback ) {
 	this.wpcom.req.get( '/sites/' + this._id + '/shortcodes/render', attributes, callback );
 };
 
-UndocumentedSite.prototype.getRoles = function( query, callback ) {
-	this.wpcom.req.get( '/sites/' + this._id + '/roles', query, callback );
+UndocumentedSite.prototype.getRoles = function( callback ) {
+	this.wpcom.req.get( '/sites/' + this._id + '/roles', { locale: i18n.getLocaleSlug() }, callback );
 };
 
 UndocumentedSite.prototype.getViewers = function( query, callback ) {


### PR DESCRIPTION
Fixes #4284 (I've just pushed a change to the API to make this effective - support was needed there too).

**Test:**
- Set your account to a non-english locale
- Go to screen where you would add a user
- Check that the roles names are localized.

