### PR TITLE
GuidedTours: skip the `themes` step if selected site is not customizable

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -39,7 +39,15 @@ function get( site ) {
 			type: 'BasicStep',
 			target: 'sidebar',
 			placement: 'beside',
-			next: site && site.is_previewable ? 'preview' : 'themes',
+			next: ( () => {
+				if ( site && site.is_previewable ) {
+					return 'preview';
+				}
+				if ( site && site.is_customizable ) {
+					return 'themes';
+				}
+				return 'finish';
+			}() ),
 		},
 		preview: {
 			target: 'site-card-preview',
@@ -58,7 +66,12 @@ function get( site ) {
 			placement: 'beside',
 			icon: 'cross-small',
 			text: i18n.translate( 'Take a look at your site—and then close the site preview. You can come back here anytime.' ),
-			next: 'themes',
+			next: ( () => {
+				if ( site && site.is_customizable ) {
+					return 'themes';
+				}
+				return 'finish';
+			}() ),
 		},
 		themes: {
 			text: i18n.translate( "Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} your theme's colors, fonts, and more.", {

--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -121,6 +121,10 @@ Site.prototype.updateComputedAttributes = function() {
 		! this.is_vip &&
 		isHttps( this.options.unmapped_url )
 	);
+	this.is_customizable = !! (
+		this.capabilities &&
+		this.capabilities.edit_theme_options
+	);
 };
 
 /**

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -38,6 +38,7 @@ export const sitesSchema = {
 				user_can_manager: { type: 'boolean' },
 				is_vip: { type: 'boolean' },
 				is_previewable: { type: 'boolean' },
+				is_customizable: { type: 'boolean' },
 				is_multisite: { type: 'boolean' },
 				capabilities: {
 					type: 'object',


### PR DESCRIPTION
Starting a tour with a non-customizable site previously made GuidedTours stop the tour with an error since the "Themes" menu item wasn't there. We now skip the `themes` step if the site isn't customizable. 

To test:

- go to http://calypso.localhost:3000/stats/day/{{site_url}}?tour=main
- go through the tour and make sure there are no errors with it, either in the console or Calypso error notices
- note what steps appear for the tour and check it's in line with the notes below

Site classes to test: 

- your .com blog: `preview` step is there, `theme` step is there
- .com site where you can't customize (e.g. a p2): `preview` step is there, `theme` step is skipped
- Jetpack: `preview` step skipped, `theme` step is there

GIF of a .com blog that has both `preview` and `theme` steps:

![preview](https://cloud.githubusercontent.com/assets/23619/15647273/d8489a9c-2662-11e6-914a-992c3bfcd277.gif)
