### PR TITLE
Add: use "non preview" url for external open of theme demo site.

### DIFF
--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -31,7 +31,8 @@ export default React.createClass( {
 		return(
 			<WebPreview showPreview={ this.props.showPreview }
 				onClose={ this.props.onClose }
-				previewUrl={ previewUrl } >
+				previewUrl={ previewUrl }
+				externalUrl={ this.props.theme.demo_uri } >
 				<Button primary
 					onClick={ this.onButtonClick }
 					>{ this.props.buttonLabel }</Button>


### PR DESCRIPTION
![screen shot 2016-05-30 at 12 13 25](https://cloud.githubusercontent.com/assets/4389/15648076/f2d4e81e-265f-11e6-9a84-1a5fd8d31248.png)

Changed `ThemePreview` component to use the default demo URL instead of the one appended with the overriding codes (`?demo=true&iframe=true&theme_preview=true`, added in `getPreviewUrl`) for the open in a new window button.

### To test

1. Open http://calypso.localhost:3000/design/
2. Click on "Preview" on any theme thumbnail.
3. The demo site should open in preview without admin bar, nor "Start using this theme on your blog".
4. If the open external icon is clicked, the new site is open with the clean demo URL.
5. Switch to a Jetpack-connected site.
6. Check that it opens properly in the Jetpack-connected site itself.

Possible thanks to #5550. :D 
/cc @ehg 