### PR TITLE
Plugins / i18n: Fix pluralization of star label in plugin details

### DIFF
--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -19,6 +19,7 @@
 
 .plugin-information__wrapper {
 	flex-grow: 1;
+	margin-bottom: 16px;
 }
 
 .plugin-information__version-shell {
@@ -86,12 +87,10 @@
 
 .plugin-information .plugin-ratings {
 	flex-grow: 1;
-	margin-top: 16px;
 
 	@include breakpoint( '>480px' ) {
 		flex-grow: 0;
 		width: 160px;
-		margin-top: 0;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -124,7 +124,7 @@ export default React.createClass( {
 						args: { ratingsNumber: numRatings }
 					} ) }
 				</div>
-				<div className="plugin-ratings__tiers">
+				<div className="plugin-ratings__rating-tiers">
 					{ tierViews }
 				</div>
 				{ this.renderDownloaded() }

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -51,7 +51,11 @@ export default React.createClass( {
 		};
 
 		return (
-			<a key={ `plugins-ratings__tier-${ ratingTier }` } className="plugin-ratings__rating-container" target="_blank" rel="noopener noreferrer"
+			<a
+				className="plugin-ratings__rating-container"
+				key={ `plugins-ratings__tier-${ ratingTier }` }
+				target="_blank"
+				rel="noopener noreferrer"
 				onClick={ onClickPluginRatingsLink }
 				href={ this.buildReviewUrl( ratingTier ) }
 			>

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -51,28 +51,26 @@ export default React.createClass( {
 		};
 
 		return (
-			<div className="plugin-ratings__rating-tier" key={ `plugins-ratings__tier-${ ratingTier }` }>
-				<a className="plugin-ratings__rating-container" target="_blank" rel="noopener noreferrer"
-					onClick={ onClickPluginRatingsLink }
-					href={ this.buildReviewUrl( ratingTier ) }
-				>
-					<span className="plugin-ratings__rating-tier-text">
-						{
-							this.translate(
-								'%(ratingTier)s star', '%(ratingTier)s stars', {
-									count: ratingTier, args: { ratingTier: ratingTier }
-								}
-							)
-						}
-					</span>
-					<span className="plugin_ratings__bar">
-						<ProgressBar value={ numberOfRatings }
-							total={ numRatings }
-							title={ this.translate( '%(numberOfRatings)s ratings', { args: { numberOfRatings } } ) }
-						/>
-					</span>
-				</a>
-			</div>
+			<a key={ `plugins-ratings__tier-${ ratingTier }` } className="plugin-ratings__rating-container" target="_blank" rel="noopener noreferrer"
+				onClick={ onClickPluginRatingsLink }
+				href={ this.buildReviewUrl( ratingTier ) }
+			>
+				<span className="plugin-ratings__rating-tier-text">
+					{
+						this.translate(
+							'%(ratingTier)s star', '%(ratingTier)s stars', {
+								count: ratingTier, args: { ratingTier: ratingTier }
+							}
+						)
+					}
+				</span>
+				<span className="plugin_ratings__bar">
+					<ProgressBar value={ numberOfRatings }
+						total={ numRatings }
+						title={ this.translate( '%(numberOfRatings)s ratings', { args: { numberOfRatings } } ) }
+					/>
+				</span>
+			</a>
 		);
 	},
 
@@ -120,7 +118,9 @@ export default React.createClass( {
 						args: { ratingsNumber: numRatings }
 					} ) }
 				</div>
-				{ tierViews }
+				<div className="plugin-ratings-tiers">
+					{ tierViews }
+				</div>
 				{ this.renderDownloaded() }
 			</div>
 		);

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -33,7 +33,7 @@ export default React.createClass( {
 	},
 
 	renderPlaceholder() {
-		return (
+		return ( // eslint-disable-next-line
 			<div className="plugin-ratings is-placeholder">
 				<div className="plugin-ratings__rating-stars">
 					<Rating rating={ 0 } />
@@ -63,13 +63,15 @@ export default React.createClass( {
 					{
 						this.translate(
 							'%(ratingTier)s star', '%(ratingTier)s stars', {
-								count: ratingTier, args: { ratingTier: ratingTier }
+								count: ratingTier,
+								args: { ratingTier: ratingTier }
 							}
 						)
 					}
 				</span>
-				<span className="plugin_ratings__bar">
-					<ProgressBar value={ numberOfRatings }
+				<span className="plugin-ratings__bar">
+					<ProgressBar
+						value={ numberOfRatings }
 						total={ numRatings }
 						title={ this.translate( '%(numberOfRatings)s ratings', { args: { numberOfRatings } } ) }
 					/>
@@ -122,7 +124,7 @@ export default React.createClass( {
 						args: { ratingsNumber: numRatings }
 					} ) }
 				</div>
-				<div className="plugin-ratings-tiers">
+				<div className="plugin-ratings__tiers">
 					{ tierViews }
 				</div>
 				{ this.renderDownloaded() }

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -58,9 +58,11 @@ export default React.createClass( {
 				>
 					<span className="plugin-ratings__rating-tier-text">
 						{
-							this.translate( '%(ratingTier)s stars', {
-								args: { ratingTier }
-							} )
+							this.translate(
+								'%(ratingTier)s star', '%(ratingTier)s stars', {
+									count: ratingTier, args: { ratingTier: ratingTier }
+								}
+							)
 						}
 					</span>
 					<span className="plugin_ratings__bar">

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -17,40 +17,39 @@
 	}
 }
 
-.plugin-ratings__rating-tier {
-	line-height: 18px;
-}
-
 .plugin-ratings__rating-text {
-	font-size: 11px;
+	font-size: 12px;
 	color: $gray;
-	text-transform: uppercase;
 	margin-bottom: 16px;
 
 	@include breakpoint( '<480px' ) {
 		display: inline;
 		line-height: 24px;
-	vertical-align: top;
+		vertical-align: top;
 	}
-}
-
-.plugin-ratings__rating-container {
-	display: flex;
-	width: 100%;
-	justify-content: space-between;
 }
 
 .plugin-ratings__rating-tier-text,
 .plugin-ratings__downloads {
-	font-size: 11px;
+	font-size: 12px;
 	color: $gray;
 	white-space: pre;
 	text-overflow: ellipsis;
-	text-transform: uppercase;
 	overflow: hidden;
 }
 
+.plugin-ratings__rating-tiers {
+	display: table;
+}
+
+.plugin-ratings__rating-container {
+	display: table-row;
+	width: 100%;
+	line-height: 18px;
+}
+
 .plugin-ratings__rating-tier-text {
+	display: table-cell;
 	padding-right: 16px;
 }
 
@@ -59,13 +58,11 @@
 }
 
 .plugin_ratings__bar {
-	width: 78px;
-	display: inline-block;
-	flex-grow: 1;
+	display: table-cell;
+	width: 100%;
 
 	.progress-bar {
 		position: relative;
-		top: -2px;
 		border-radius: 0;
 		height: 8px;
 		background-color: lighten( $gray, 20% );

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -57,7 +57,7 @@
 	margin-top: 16px;
 }
 
-.plugin_ratings__bar {
+.plugin-ratings__bar {
 	display: table-cell;
 	width: 100%;
 


### PR DESCRIPTION
Fixes #5002 - though it introduces a style issue:
![screen shot 2016-05-30 at 14 25 05](https://cloud.githubusercontent.com/assets/844866/15648354/a76f1fd0-2672-11e6-92ea-7fcfab4feff8.png)

This could get worse with other locales:
![screen shot 2016-05-30 at 14 30 34](https://cloud.githubusercontent.com/assets/844866/15648412/1ca4bc9c-2673-11e6-8a89-f3f2c2bf900a.png)

(mock hebrew - plz ignore the wrong direction)
