### PR TITLE
Site Settings SEO: Fix for Receiving New Props and Dirty State for Fields

### DIFF
--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -129,7 +129,7 @@ export const SeoForm = React.createClass( {
 			return;
 		}
 
-		let dirtyFields = this.state.dirtyFields || [];
+		const { dirtyFields = [] } = this.state;
 		if ( ! includes( dirtyFields, serviceCode ) ) {
 			dirtyFields.push( serviceCode );
 		}

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -50,7 +50,8 @@ function stateForSite( site ) {
 		googleCode: get( site, 'options.verification_services_codes.google', '' ),
 		bingCode: get( site, 'options.verification_services_codes.bing', '' ),
 		pinterestCode: get( site, 'options.verification_services_codes.pinterest', '' ),
-		yandexCode: get( site, 'options.verification_services_codes.yandex', '' )
+		yandexCode: get( site, 'options.verification_services_codes.yandex', '' ),
+		isFetchingSettings: get( site, 'fetchingSettings', false )
 	};
 }
 
@@ -210,6 +211,7 @@ export const SeoForm = React.createClass( {
 
 		const {
 			isSubmittingForm,
+			isFetchingSettings,
 			seoMetaDescription,
 			showPasteError = false,
 			hasHtmlTagError = false,
@@ -219,7 +221,7 @@ export const SeoForm = React.createClass( {
 		let { googleCode, bingCode, pinterestCode, yandexCode } = this.state;
 
 		const isSitePrivate = parseInt( blog_public, 10 ) !== 1;
-		const isDisabled = isSitePrivate || isSubmittingForm;
+		const isDisabled = isSitePrivate || isSubmittingForm || isFetchingSettings;
 		const isSaveDisabled = isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
 
 		const sitemapUrl = `https://${ slug }/sitemap.xml`;

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -103,7 +103,7 @@ export const SeoForm = React.createClass( {
 		// Don't allow html tags in the input field
 		const hasHtmlTagError = anyHtmlTag.test( seoMetaDescription );
 
-		let dirtyFields = this.state.dirtyFields || [];
+		const { dirtyFields = [] } = this.state;
 		if ( ! includes( dirtyFields, 'seoMetaDescription' ) ) {
 			dirtyFields.push( 'seoMetaDescription' );
 		}


### PR DESCRIPTION
Previously, `componentWillReceiveProps` was blocking any new data from loading unless the site changed. This removes that check and also adds tracking for 'dirty' form fields, so that user's changes don't get overwritten when the props update.

I also moved each verification code to be its own prop instead of in an object, so that it would be easier to use with `omit`.

It now works a lot like `form-base.js`, but without using the `dirtyLinkedState` mixin, which we couldn't use in this component because of the error checking and array-based data structure for the SEO settings api.

This also includes a fix #5612 so that the form will be disabled while settings are being fetched.

**To Test**: Load `/settings/seo` directly, you should see the form disabled for a second and then load the latest settings from the API.