### PR TITLE
Site Settings SEO: Move Sitemap Section to Bottom of Form

### DIFF
--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -267,7 +267,7 @@ export const SeoForm = React.createClass( {
 					</p>
 					<form onChange={ this.markChanged } className="seo-form">
 						<FormFieldset>
-							<FormFieldset className="has-divider is-top-only">
+							<FormFieldset className="has-divider">
 								<FormLabel htmlFor="seo_meta_description">{ this.translate( 'Front Page Meta Description' ) }</FormLabel>
 								<CountedTextarea
 									name="seo_meta_description"
@@ -283,14 +283,6 @@ export const SeoForm = React.createClass( {
 								}
 								<FormSettingExplanation>
 									{ this.translate( 'Craft a description of your site in about 160 characters. This description can be used in search engine results for your site\'s Front Page.' ) }
-								</FormSettingExplanation>
-							</FormFieldset>
-
-							<FormFieldset className="has-divider">
-								<FormLabel htmlFor="seo_sitemap">{ this.translate( 'XML Sitemap' ) }</FormLabel>
-								<ExternalLink className="seo-sitemap" icon={ true } href={ sitemapUrl } target="_blank">{ sitemapUrl }</ExternalLink>
-								<FormSettingExplanation>
-									{ this.translate( 'Your site\'s sitemap is automatically sent to all major search engines for indexing.' ) }
 								</FormSettingExplanation>
 							</FormFieldset>
 
@@ -370,6 +362,14 @@ export const SeoForm = React.createClass( {
 									onChange={ event => this.handleVerificationCodeChange( event, 'yandex' ) } />
 								{ hasError( 'yandex' ) && this.getVerificationError( showPasteError ) }
 							</FormFieldset>
+						</FormFieldset>
+
+						<FormFieldset className="has-divider is-top-only">
+								<FormLabel htmlFor="seo_sitemap">{ this.translate( 'XML Sitemap' ) }</FormLabel>
+								<ExternalLink className="seo-sitemap" icon={ true } href={ sitemapUrl } target="_blank">{ sitemapUrl }</ExternalLink>
+								<FormSettingExplanation>
+									{ this.translate( 'Your site\'s sitemap is automatically sent to all major search engines for indexing.' ) }
+								</FormSettingExplanation>
 						</FormFieldset>
 					</form>
 				</Card>


### PR DESCRIPTION
Moves sitemap section to the bottom of the form.

Fixes #5614