### PR TITLE
Signup: Allow optionalDependencies to be set for steps.

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -159,7 +159,21 @@ assign( SignupFlowController.prototype, {
 	},
 
 	_processStep: function( step ) {
-		const dependencies = steps[ step.stepName ].dependencies || [];
+		let dependencies = steps[ step.stepName ].dependencies || [];
+
+		/**
+		 * Check if there are `optionalDependencies` specified.
+		 */
+		if ( steps[ step.stepName ].optionalDependencies ) {
+			let optionalDependencies = steps[ step.stepName ].optionalDependencies || [];
+
+			/**
+			 * Merge `optionalDependencies` in the main list of dependencies,
+			 * so they can be passed properly to `apiRequestFunction`
+			 */
+			dependencies.push( ...optionalDependencies );
+		}
+
 		const dependenciesFound = pick( SignupDependencyStore.get(), dependencies );
 
 		if ( this._canProcessStep( step ) ) {

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -159,13 +159,13 @@ assign( SignupFlowController.prototype, {
 	},
 
 	_processStep: function( step ) {
-		let dependencies = steps[ step.stepName ].dependencies || [];
+		const dependencies = steps[ step.stepName ].dependencies || [];
 
 		/**
 		 * Check if there are `optionalDependencies` specified.
 		 */
 		if ( steps[ step.stepName ].optionalDependencies ) {
-			let optionalDependencies = steps[ step.stepName ].optionalDependencies || [];
+			const optionalDependencies = steps[ step.stepName ].optionalDependencies;
 
 			/**
 			 * Merge `optionalDependencies` in the main list of dependencies,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -123,7 +123,7 @@ const flows = {
 	},
 
 	main: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2016-05-23'
@@ -138,14 +138,14 @@ const flows = {
 
 	/* WP.com homepage flows */
 	website: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Website" on the two-button homepage. It is now linked to from the default homepage CTA as the main flow was slightly behind given translations.',
 		lastModified: '2016-05-23'
 	},
 
 	blog: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Blog" on the two-button homepage. It is now used from blog-specific landing pages so that verbiage in survey steps refers to "blog" instead of "website".',
 		lastModified: '2016-05-23'
@@ -178,14 +178,14 @@ const flows = {
 	},
 
 	'delta-blog': {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go through this flow receive a blogging-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
 	'delta-site': {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go through this flow receive a website-specific drip email series.',
 		lastModified: '2016-03-09'
@@ -199,14 +199,14 @@ const flows = {
 	},
 
 	desktop: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getPostsDestination,
 		description: 'Signup flow for desktop app',
 		lastModified: '2016-05-30'
 	},
 
 	app: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getPostsDestination,
 		description: 'Used as a web-based control to test the "desktop" flow',
 		lastModified: '2016-05-30'

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -39,7 +39,8 @@ module.exports = {
 		stepName: 'user',
 		apiRequestFunction: stepActions.createAccount,
 		providesToken: true,
-		providesDependencies: [ 'bearer_token', 'username' ]
+		providesDependencies: [ 'bearer_token', 'username' ],
+		optionalDependencies: [ 'surveySiteType', 'surveyQuestion' ]
 	},
 
 	'survey-user': {


### PR DESCRIPTION
Sometimes there is a need to have "optional" dependencies on some of the steps, e.g. dependencies that are loosely defined and are not required, but it's a good way to pass data. An example would be the code duplication that is happening for the [`user`](https://github.com/Automattic/wp-calypso/blob/17d76a8880ba44c8f7cba14cd79b12ef0daffd6a/client/signup/config/steps.js#L38) and [`survey-user`](https://github.com/Automattic/wp-calypso/blob/17d76a8880ba44c8f7cba14cd79b12ef0daffd6a/client/signup/config/steps.js#L45). The only difference between the two steps is the `dependencies` property, which allows passing data to the `survey-user`. The actual `apiRequestFunction` is the [same](https://github.com/Automattic/wp-calypso/blob/17d76a8880ba44c8f7cba14cd79b12ef0daffd6a/client/lib/signup/step-actions.js#L168) for both steps.

Having `optionalDependencies` would reduce the code duplication of steps and allow for passing optional data between the steps.

To test:

* Checkout code
* Open browser console
* Start signup on the default flow - `/start/main` 
* Reach user step
* Submit

Expected:
* No errors in console relating to the dependencies
* Check the create user request at the end. It should have `nux_q_site_type` and `nux_q_question_primary` with proper values.


cc @coreh, @michaeldcain 