### PR TITLE
Jetpack connect: Open in production

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -20,6 +20,7 @@
 		"fluid-width": true,
 		"help": true,
 		"login": false,
+		"jetpack/connect": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
 		"manage/ads": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,6 +21,7 @@
 		"devdocs": false,
 		"guided-tours": true,
 		"help": true,
+		"jetpack/connect": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login": false,

--- a/config/production.json
+++ b/config/production.json
@@ -19,6 +19,7 @@
 		"desktop-promo": true,
 		"guided-tours": true,
 		"help": true,
+		"jetpack/connect": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
 		"manage/ads": true,


### PR DESCRIPTION
This PR opens /jetpack/connect and all the related routes in production, the desktop app and horizon

ping @richardmuscat 
