### PR TITLE
Jetpack SSO: SSO to staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -22,6 +22,7 @@
 		"guided-tours": true,
 		"help": true,
 		"jetpack/connect": true,
+		"jetpack/sso": true,
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,


### PR DESCRIPTION
To assist in testing, let's ship the `/jetpack/sso` route to staging.

To test:

- Checkout `update/jetpack-sso-to-staging` branch
- In `stage.json`, set `wpcom_user_bootstrap` to `false`
- In terminal, `CALYPSO_ENV=stage make run`
- Go to `/jetpack/sso`. Does route show?