### PR TITLE
Jetpack SSO: Fixes an issue where validation ran more than necessary

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -38,7 +38,7 @@ const JetpackSSOForm = React.createClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		this.maybeValidateSSO();
+		this.maybeValidateSSO( nextProps );
 
 		if ( nextProps.ssoUrl && ! this.props.ssoUrl ) {
 			// After receiving the SSO URL, which will log the user in on remote site,
@@ -76,8 +76,8 @@ const JetpackSSOForm = React.createClass( {
 		return !! ( ! nonceValid | isAuthorizing | isValidating | ssoUrl );
 	},
 
-	maybeValidateSSO() {
-		const { ssoNonce, siteId, nonceValid, isAuthorizing, isValidating } = this.props;
+	maybeValidateSSO( props = this.props ) {
+		const { ssoNonce, siteId, nonceValid, isAuthorizing, isValidating } = props;
 
 		if ( ssoNonce && siteId && 'undefined' === typeof nonceValid && ! isAuthorizing && ! isValidating ) {
 			this.props.validateSSONonce( siteId, ssoNonce );

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -79,7 +79,7 @@ const JetpackSSOForm = React.createClass( {
 	maybeValidateSSO() {
 		const { ssoNonce, siteId, nonceValid, isAuthorizing, isValidating } = this.props;
 
-		if ( ssoNonce && siteId && ! nonceValid && ! isAuthorizing && ! isValidating ) {
+		if ( ssoNonce && siteId && 'undefined' === typeof nonceValid && ! isAuthorizing && ! isValidating ) {
 			this.props.validateSSONonce( siteId, ssoNonce );
 		}
 	},


### PR DESCRIPTION
Previously, if a bad nonce was passed, the we would continue to run validation. Since nonceValid is boolean value, we should have just checked whether it was set instead of doing ! nonceValid.

To test:

- Check existence of bug, clicking the "Login with WordPress.com" button and then changing the nonce
    - If you look in the "Network" tab, you should see several requests to `jetpack-blogs/$site/sso-validate`
- Now, checkout `fix/jetpack-sso-false-nonce` branch
- Go to your Jetpack site
- Click "Log in with WordPress.com" button
- Change nonce
- Check "Network" tab
- If you filter the network tab for `sso-validate`, you should only see one request