### PR TITLE
Jetpack SSO: Render EmptyContent error when validation fails

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -107,12 +107,37 @@ const JetpackSSOForm = React.createClass( {
 		);
 	},
 
+	renderInvalidNonce() {
+		return (
+			<Main>
+				<EmptyContent
+					illustration="/calypso/images/drake/drake-whoops.svg"
+					title={ this.translate(
+						'Oops, something went wrong.'
+					) }
+					line={ this.translate(
+						'Please try again by clicking the {{em}}Log in with WordPress.com button{{/em}} on your Jetpack site.',
+						{
+							components: {
+								em: <em />
+							}
+						}
+					) }
+					action={ this.translate( 'Read Single Sign-On Documentation' ) }
+					actionURL="https://jetpack.com/support/sso/"
+				/>
+			</Main>
+		);
+	},
+
 	render() {
 		const user = this.props.userModule.get();
-		const { ssoNonce, siteId } = this.props;
+		const { ssoNonce, siteId, nonceValid } = this.props;
 
 		if ( ! ssoNonce || ! siteId ) {
 			return this.renderNoQueryArgsError();
+		} else if ( false === nonceValid ) {
+			return this.renderInvalidNonce();
 		}
 
 		return (


### PR DESCRIPTION
Previously, when SSO validation failed, we didn't update the UI. This PR will now show an EmptyContent Drake error when nonce validation fails.

To test:

- Checkout `update/jetpack-sso-failed-validation` branch
- Go to `/jetpack/sso/{$site_id}/badnonce`
- You should see something like this:
    - ![screen shot 2016-05-30 at 7 10 26 pm](https://cloud.githubusercontent.com/assets/1126811/15659981/2fc6666e-269a-11e6-863f-1b03c3149ee5.png)

cc @rickybanister for design review.