### PR TITLE
GuidedTours: change highlighting to a border and an arrow

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -24,6 +24,7 @@ function get( site ) {
 		},
 		'my-sites': {
 			target: 'my-sites',
+			arrow: 'top-left',
 			type: 'ActionStep',
 			icon: 'my-sites',
 			placement: 'below',
@@ -38,6 +39,7 @@ function get( site ) {
 			text: i18n.translate( 'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.' ),
 			type: 'BasicStep',
 			target: 'sidebar',
+			arrow: 'left-middle',
 			placement: 'beside',
 			next: ( () => {
 				if ( site && site.is_previewable ) {
@@ -51,9 +53,13 @@ function get( site ) {
 		},
 		preview: {
 			target: 'site-card-preview',
+			arrow: 'top-left',
 			type: 'ActionStep',
-			placement: 'beside',
-			text: i18n.translate( '{{strong}}Preview:{{/strong}} Click here to see what your site looks like.', {
+			iconText: i18n.translate( "your site's name", {
+				context: "Click your site's name to continue.",
+			} ),
+			placement: 'below',
+			text: i18n.translate( 'Open {{strong}}Preview{{/strong}} to see what your site looks like.', {
 				components: {
 					strong: <strong />,
 				}
@@ -62,10 +68,15 @@ function get( site ) {
 		},
 		'close-preview': {
 			target: 'web-preview__close',
+			arrow: 'left-top',
 			type: 'ActionStep',
 			placement: 'beside',
 			icon: 'cross-small',
-			text: i18n.translate( 'Take a look at your site—and then close the site preview. You can come back here anytime.' ),
+			text: i18n.translate( 'Below you can see a {{strong}}Preview{{/strong}} of your site. You can come back here anytime.', {
+				components: {
+					strong: <strong />,
+				}
+			} ),
 			next: ( () => {
 				if ( site && site.is_customizable ) {
 					return 'themes';
@@ -81,6 +92,7 @@ function get( site ) {
 			} ),
 			type: 'BasicStep',
 			target: 'themes',
+			arrow: 'top-left',
 			placement: 'below',
 			next: 'finish',
 		},

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -9,6 +9,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import localize from 'lib/mixins/i18n/localize';
+import scrollTo from 'lib/scroll-to';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
@@ -90,6 +91,10 @@ class GuidedTours extends Component {
 	}
 
 	quit( options = {} ) {
+		// TODO: put into step specific callback?
+		const sidebar = query( '#secondary .sidebar' )[ 0 ];
+		scrollTo( { y: 0, container: sidebar } );
+
 		this.currentTarget && this.currentTarget.classList.remove( 'guided-tours__overlay' );
 		this.props.quitGuidedTour( Object.assign( {
 			stepName: this.props.tourState.stepName,

--- a/client/layout/guided-tours/steps.js
+++ b/client/layout/guided-tours/steps.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -11,16 +12,27 @@ import Card from 'components/card';
 import Button from 'components/button';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'components/gridicon';
-import { posToCss, getStepPosition, getBullseyePosition, targetForSlug } from './positioning';
+import { posToCss, getStepPosition, getValidatedArrowPosition, targetForSlug } from './positioning';
 
 class BasicStep extends Component {
 	render() {
 		const stepPos = getStepPosition( this.props );
 		const stepCoords = posToCss( stepPos );
+		const { text, onNext, onQuit, targetSlug, arrow } = this.props;
 
-		const { text, onNext, onQuit } = this.props;
+		const classes = [
+			'guided-tours__step',
+			'guided-tours__step-glow',
+			targetSlug && 'guided-tours__step-pointing',
+			targetSlug && arrow && 'guided-tours__step-pointing-' + getValidatedArrowPosition( {
+				targetSlug,
+				arrow,
+				stepPos
+			} ),
+		].filter( Boolean );
+
 		return (
-			<Card className="guided-tours__step" style={ stepCoords } >
+			<Card className={ classNames( ...classes ) } style={ stepCoords } >
 				<p className="guided-tours__step-text">{ text }</p>
 				<div className="guided-tours__choice-button-row">
 					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
@@ -55,11 +67,13 @@ class FinishStep extends Component {
 	render() {
 		const stepPos = getStepPosition( this.props );
 		const stepCoords = posToCss( stepPos );
+		// let the CSS override top
+		stepCoords.top = undefined;
 
 		const { text, onFinish, linkUrl, linkLabel } = this.props;
 
 		return (
-			<Card className="guided-tours__step" style={ stepCoords } >
+			<Card className="guided-tours__step guided-tours__step-finish guided-tours__step-glow" style={ stepCoords } >
 				<p className="guided-tours__step-text">{ text }</p>
 				<div className="guided-tours__single-button-row">
 					<Button onClick={ onFinish } primary>{ this.props.translate( "We're all done!" ) }</Button>
@@ -131,35 +145,69 @@ class ActionStep extends Component {
 
 	render() {
 		const stepPos = getStepPosition( this.props );
-		const bullseyePos = getBullseyePosition( this.props );
 		const stepCoords = posToCss( stepPos );
-		const pointerCoords = posToCss( bullseyePos );
+		const { text, targetSlug, arrow } = this.props;
 
-		const { text } = this.props;
+		let instructions;
 
-		let components = {};
 		if ( this.props.icon ) {
-			components.gridicon = <Gridicon icon={ this.props.icon } size={ 24 } />
+			instructions = this.props.translate( 'Click the {{GridIcon/}} to continue.', {
+				components: {
+					GridIcon: <Gridicon icon={ this.props.icon } size={ 24 } />,
+				},
+			} );
+		} else if ( this.props.iconText ) {
+			instructions = this.props.translate( 'Click {{iconText/}} to continue.', {
+				components: {
+					iconText: <strong>{ this.props.iconText }</strong>,
+				},
+			} );
 		} else {
-			components.gridicon = <span className="guided-tours__bullseye-text">○</span>
+			instructions = this.props.translate( 'Click to continue.' );
 		}
 
+		const classes = [
+			'guided-tours__step',
+			'guided-tours__step-action',
+			'guided-tours__step-glow',
+			'guided-tours__step-pointing',
+			arrow && 'guided-tours__step-pointing-' + getValidatedArrowPosition( {
+				targetSlug,
+				arrow,
+				stepPos
+			} ),
+		].filter( Boolean );
+
 		return (
-			<Card className="guided-tours__step" style={ stepCoords } >
+			<Card className={ classNames( ...classes ) } style={ stepCoords } >
 				<p className="guided-tours__step-text">{ text }</p>
-				<p className="guided-tours__bullseye-instructions">
-					{ this.props.translate( 'Click the {{gridicon/}} to continue.', {
-						components: components
-					} ) }
+				<p className="guided-tours__actionstep-instructions">
+					{ instructions }
 				</p>
-				<Pointer style={ pointerCoords } />
 			</Card>
 		);
 	}
 }
 
+const ARROW_TYPES = [
+	'none',
+	'top-left',
+	'top-center',
+	'top-right',
+	'right-top',
+	'right-middle',
+	'right-bottom',
+	'bottom-right',
+	'bottom-center',
+	'bottom-left',
+	'left-bottom',
+	'left-middle',
+	'left-top',
+];
+
 BasicStep.propTypes = {
 	targetSlug: PropTypes.string,
+	arrow: PropTypes.oneOf( ARROW_TYPES ),
 	placement: PropTypes.string,
 	// text can be a translated string or a translated string with components
 	text: PropTypes.oneOfType( [
@@ -173,6 +221,7 @@ BasicStep.propTypes = {
 
 ActionStep.propTypes = {
 	targetSlug: PropTypes.string.isRequired,
+	arrow: PropTypes.oneOf( ARROW_TYPES ).isRequired,
 	placement: PropTypes.string,
 	// text can be a translated string or a translated string with components
 	text: PropTypes.oneOfType( [
@@ -180,6 +229,7 @@ ActionStep.propTypes = {
 		PropTypes.array
 	] ),
 	icon: PropTypes.string,
+	iconText: PropTypes.string,
 	next: PropTypes.string,
 	onNext: PropTypes.func.isRequired,
 	onQuit: PropTypes.func.isRequired,
@@ -224,21 +274,6 @@ FinishStep.propTypes = {
 	linkLabel: PropTypes.string,
 	linkUrl: PropTypes.string,
 	onFinish: PropTypes.func.isRequired,
-};
-
-class Pointer extends Component {
-	render() {
-		return (
-			<div className="guided-tours__bullseye" style={ this.props.style }>
-				<div className="guided-tours__bullseye-ring" />
-				<div className="guided-tours__bullseye-center" />
-			</div>
-		);
-	}
-}
-
-Pointer.propTypes = {
-	style: PropTypes.object.isRequired,
 };
 
 export default {

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -2,17 +2,24 @@
 	position: fixed;
 	max-width: 410px;
 	z-index: z-index( 'root', '.guided-tours__step' );
-	border: 1px solid lighten( $gray, 10 );
-	box-shadow: 0px 2px 4px 0px rgba( $gray-dark, 0.15 );
+	background: darken( $gray, 52 );
+	box-shadow: 0 2px 24px 0 rgba( darken( $gray, 52 ), 0.5 );
 	border-radius: 4px;
 	padding-top: 19px;
 	margin-left: 5px;
 	margin-right: 5px;
 	font-size: 14px;
+	animation-duration: 0.15s;
+	animation-name: guided-tours__step-fadein;
+	animation-timing-function: ease-in-out;
 
 	.guided-tours__step-text {
-		color: $gray-dark;
+		color: lighten( $gray, 30 );
 		margin-bottom: 16px;
+
+		strong {
+			color: $white;
+		}
 	}
 
 	.gridicon[height="16"] {
@@ -27,19 +34,42 @@
 }
 
 .guided-tours__step-first {
-	animation-duration: 900ms;
+	animation-duration: 0.25s;
 	animation-name: guided-tours__step-slidein;
-	animation-timing-function: ease-in-out;
+	animation-timing-function: ease-out;
 	animation-delay: 2s;
 	animation-fill-mode: both;
 }
 
+.guided-tours__step-finish {
+	top: 20%;
+}
+
+@keyframes guided-tours__step-fadein {
+	0% {
+		opacity: 0;
+		transform: translateY( 20px ) scale( 0.98 );
+	}
+	100% {
+		opacity: 1;
+		transform: translateY( 0 ) scale( 1 );
+	}
+}
+
 @keyframes guided-tours__step-slidein {
 	0% {
-		transform: translateX( 200% );
+		opacity: 0;
+		pointer-events: none;
+		transform: translateX( 100% );
+	}
+
+	80% {
+		transform: translateX( -16px );
 	}
 
 	100% {
+		opacity: 1;
+		pointer-events: auto;
 		transform: translateX( 0 );
 	}
 }
@@ -51,6 +81,11 @@
 	.button:nth-child(1) {
 		margin-right: 4%;
 	}
+	.button:nth-child(2) {
+		color: darken( $white, 20% );
+		background: none;
+		border: none;
+	}
 }
 
 .guided-tours__single-button-row {
@@ -60,8 +95,8 @@
 }
 
 .guided-tours__external-link,
-.guided-tours__bullseye-instructions {
-	color: darken( $gray, 10 );
+.guided-tours__actionstep-instructions {
+	color: lighten( $gray, 10 );
 	margin-bottom: 0;
 	font-style: italic;
 
@@ -71,77 +106,111 @@
 	}
 
 	.external-link {
-		border-top: 1px solid $gray-light;
+		font-style: normal;
+		border-top: 1px solid $gray-dark;
 		display: block;
-		padding-top: 8px;
+		padding-top: 12px;
 		margin-top: 16px;
 	}
 }
 
-.guided-tours__bullseye-instructions {
+.guided-tours__actionstep-instructions {
 	margin-top: -7px;
 }
 
-// the bullseye used for showing an action step's target
-$animation-speed: 2s;
-$size: 10px;
-$zoom-scale: 5; // the multiplier determining the size of the animated rings
-
-@keyframes guided-tours__bullseye-animation {
-	0% {
-		transform: scale( .2 );
-		opacity: 1;
-	}
-}
-
-.guided-tours__bullseye {
-	position: fixed;
-	z-index: z-index( 'root', '.guided-tours__step' );
-	width: $size;
-	height: $size;
-	pointer-events: none;
-}
-
-.guided-tours__bullseye-center,
-.guided-tours__bullseye-ring,
-.guided-tours__bullseye-ring:before,
-.guided-tours__bullseye-ring:after {
-	position: absolute;
-		top: 0;
-		right: 0;
-	width: 10px;
-	height: 10px;
-	border-radius: 50%;
-	z-index: 1;
-}
-
-.guided-tours__bullseye-center {
-	background: #fff;
-	border: 1px solid #a8bece;
-	box-shadow: 0 1px 2px rgba( 79, 116, 142, .3 );
-}
-
-.guided-tours__bullseye-ring:before,
-.guided-tours__bullseye-ring:after {
-	content: "";
-	top: ( -1 * $zoom-scale * $size / 2 ) + ( $size / 2 ) + 1;
-	left: ( -1 * $zoom-scale * $size / 2 ) + ( $size / 2 ) - 1;
-	width: $size * $zoom-scale;
-	height: $size * $zoom-scale;
-	background-image: radial-gradient( rgb( 0, 170, 220 ), #fff );
-	opacity: 0;
-	animation: guided-tours__bullseye-animation $animation-speed ease-in-out infinite;
-}
-
-.guided-tours__bullseye-ring:after {
-	animation-delay: #{ $animation-speed / 4 };
-}
-
-// the pure text representation of the bullseye dot
-.guided-tours__bullseye-text {
+// style the pure text representation of the actionstep icon
+.guided-tours__actionstep-text {
 	position: relative;
 		top: 3px;
 	font-style: normal;
 	font-size: 190%;
 	line-height: 0;
+}
+
+// arrow if we have a target
+.guided-tours__step-pointing:before {
+	position: absolute;
+	border: darken( $gray, 52% );
+	content: " ";
+	pointer-events: none;
+	background: darken( $gray, 52% );
+	width: 12px;
+	height: 12px;
+}
+
+// the different arrow directions
+.guided-tours__step-pointing.guided-tours__step-pointing-none:before {
+	display: none;
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-top-left:before {
+	top: -5.5px;
+	left: 12px;
+	transform: rotate(45deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-top-center:before {
+	top: -5.5px;
+	left: 49%;
+	transform: rotate(45deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-top-right:before {
+	top: -5.5px;
+	right: 12px;
+	transform: rotate(45deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-right-top:before {
+	top: 15px;
+	right: -5.5px;
+	transform: rotate(135deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-right-middle:before {
+	top: 42%;
+	right: -5.5px;
+	transform: rotate(135deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-right-bottom:before {
+	bottom: 12px;
+	right: -5.5px;
+	transform: rotate(135deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-bottom-right:before {
+	bottom: -5.5px;
+	right: 12px;
+	transform: rotate(225deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-bottom-center:before {
+	bottom: -5.5px;
+	left: 49%;
+	transform: rotate(225deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-bottom-left:before {
+	bottom: -5.5px;
+	left: 12px;
+	transform: rotate(225deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-left-bottom:before {
+	bottom: 12px;
+	left: -5.5px;
+	transform: rotate(-45deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-left-middle:before {
+	top: 42%;
+	left: -5.5px;
+	transform: rotate(-45deg);
+}
+
+.guided-tours__step-pointing.guided-tours__step-pointing-left-top:before {
+	top: 12px;
+	left: -5.5px;
+	transform: rotate(-45deg);
 }


### PR DESCRIPTION
We have gotten feedback that it's not always very clear which element a tour step is pointing towards.  Additionally the contrast between the step itself and the rest of Calypso wasn't high enough to make it stand out. This PR adds a glow around steps and an arrow that points towards steps' targets. This should  make clearer that there is a step and where it is referring to.

This new design has four goals:

- increase the visibility and contrast of the steps themselves to make clear that they are not really a part of the functional interface but a separate meta thing
- make clearer to the user what target element they are expected to look at, as previous solutions (see below) were too subtle based on what we heard from testers
- couple the technical implementation to the target element that the step is pointing at, as previous attempts eg with fading out everything but the target element proved too unreliable when taking scrolling and resizing into account
- replace previous attempts at fading out the rest of Calypso, since that removed any points of reference the user might have had in the UI

Previously, with pulsating dot:

![pulsating-dot](https://cloud.githubusercontent.com/assets/23619/15722548/8aced2ee-283e-11e6-9664-248d0fcae5ba.gif)

Previously, with fading out the rest of Calypso:

![fade-out](https://cloud.githubusercontent.com/assets/23619/15722544/8217f6bc-283e-11e6-8827-da83ddcc0d22.gif)

The previous method of highlighting target elements by fading out the rest of Calypso turned out to be not reliable enough with scrolling and resizing taken into account. As an alternative, we are now trying a method that decorates the actual target, and should thus be less fragile. 

GIF of the updated design proposed in this PR:

![arrow-highlights](https://cloud.githubusercontent.com/assets/23619/15712544/f74f1482-2812-11e6-8b44-16ec88b9683f.gif)

To test:

- open http://calypso.localhost:3000/?tour=main and go through the tour
- make sure the glowing border and arrow look correct, and that the arrow points to a reasonable element
- test this works on different screen sizes as well, i.e. desktop / tablet / phone

Props @ehg @shaunandrews @mcsf 