### PR TITLE
Jetpack connect: Fix endpoint selection order

### DIFF
--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -32,7 +32,10 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
+		page( '/jetpack/connect/install', jetpackConnectController.install );
+
 		page( '/jetpack/connect', jetpackConnectController.connect );
+
 		page(
 			'/jetpack/connect/authorize/:locale?',
 			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
@@ -41,15 +44,15 @@ module.exports = function() {
 		);
 
 		page(
-			'/jetpack/connect/:locale?',
-			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
-			jetpackConnectController.connect
-		);
-
-		page(
 			'/jetpack/connect/install/:locale?',
 			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
 			jetpackConnectController.install
+		);
+
+		page(
+			'/jetpack/connect/:locale?',
+			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
+			jetpackConnectController.connect
 		);
 
 		page(


### PR DESCRIPTION
Jetpack install endpoints were not working because the connect route had more priority. With this PR they work again.

how to test
========

1. go to http://calypso.localhost:3000/jetpack/connect/install
2. check the copy & bottom links are not the same than in http://calypso.localhost:3000/jetpack/connect

@roccotripaldi @ebinnion 