### PR TITLE
DesignPreview: Enable in staging env

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -68,6 +68,8 @@
 		"persist-redux": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
+		"preview-layout": true,
+		"preview-endpoint": false,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/recommendations/posts": true,


### PR DESCRIPTION
This enables:
 - Showing (preloaded) sites in an iframe, when the site card is clicked
 - The preview steps in GuidedTours

Before this PR is merged, you can test out the current behaviour on https://wpcalypso.wordpress.com — and the tour at https://wpcalypso.wordpress.com?tour=main

/cc @lsinger & @mcsf — also looping in @mtias 