### PR TITLE
Themes: Connect dispatch props

### DIFF
--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -56,7 +56,7 @@ const ThemesLoggedOut = React.createClass( {
 	onPreviewButtonClick( theme ) {
 		this.setState( { showPreview: false },
 			() => {
-				this.props.dispatch( signup( theme ) );
+				this.props.signup( theme );
 			} );
 	},
 
@@ -100,5 +100,6 @@ export default connect(
 	state => ( {
 		queryParams: getQueryParams( state ),
 		themesList: getThemesList( state )
-	} )
+	} ),
+	{ signup }
 )( ThemesLoggedOut );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import merge from 'lodash/merge';
@@ -11,7 +10,7 @@ import merge from 'lodash/merge';
  * Internal dependencies
  */
 import Main from 'components/main';
-import * as Action from 'state/themes/actions';
+import { customize, purchase, activate } from 'state/themes/actions';
 import ThemePreview from './theme-preview';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
@@ -89,8 +88,7 @@ const ThemesMultiSite = React.createClass( {
 	},
 
 	render() {
-		const { dispatch } = this.props,
-			buttonOptions = this.getButtonOptions();
+		const buttonOptions = this.getButtonOptions();
 
 		return (
 			<Main className="themes">
@@ -127,7 +125,7 @@ const ThemesMultiSite = React.createClass( {
 					header={ actionLabels[ this.state.selectedAction ].header }
 					selectedTheme={ this.state.selectedTheme }
 					onHide={ this.hideSiteSelectorModal }
-					action={ bindActionCreators( Action[ this.state.selectedAction ], dispatch ) }
+					action={ this.props[ this.state.selectedAction ] }
 					sourcePath={ '/design' }
 				/> }
 			</Main>
@@ -139,5 +137,10 @@ export default connect(
 	state => ( {
 		queryParams: getQueryParams( state ),
 		themesList: getThemesList( state )
-	} )
+	} ),
+	{
+		activate,
+		customize,
+		purchase
+	}
 )( ThemesMultiSite );


### PR DESCRIPTION
This allows binding to `site` at `connect()`ing stage already, making the code quite a bit cleaner.

No visual changes.

To test -- check that the theme showcase still works (try different options such as Activate/Purchase/Preview for logged-out, multi-site, single-site).