### PR TITLE
Themes: Remove clickable appearance from feature tags list.

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -335,14 +335,9 @@
 	li {
 		list-style: none;
 		display: inline-block;
-
-		// Commenting background and color from tags to avoid suggesting they are clickable.
-
-		// background: #E9EFF3;
-		// color: $gray-dark;
-
-		color: inherit; // When tags are made clickable, this style can be removed.
-
+		// Commenting background color from tags to avoid suggesting they are clickable.
+		// background: lighten( $gray, 30% );
+		color: $gray-dark;
 		font-size: 0.925em;
 		margin: 0.38em 0.37rem;
 		padding: 0.25em 0.7em;

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -335,8 +335,14 @@
 	li {
 		list-style: none;
 		display: inline-block;
-		background: #E9EFF3;
-		color: $gray-dark;
+
+		// Commenting background and color from tags to avoid suggesting they are clickable.
+
+		// background: #E9EFF3;
+		// color: $gray-dark;
+
+		color: inherit; // When tags are made clickable, this style can be removed.
+
 		font-size: 0.925em;
 		margin: 0.38em 0.37rem;
 		padding: 0.25em 0.7em;


### PR DESCRIPTION
The background color from feature tags has been removed, to avoid suggesting these are clickable.

This makes the feature tags list look like the following:

![screen shot 2016-05-31 at 1 41 49 pm](https://cloud.githubusercontent.com/assets/5881557/15686711/97a388c0-273f-11e6-8630-c87f880e033f.png)


