### PR TITLE
Jetpack Plans: Remove the plugins auto-configuration flow from staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -42,7 +42,7 @@
 		"manage/plans": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
-		"manage/plugins/setup": true,
+		"manage/plugins/setup": false,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/sharing": true,


### PR DESCRIPTION
Turn off `manage/plugins/setup` for staging, so that Jetpack Connect can be tested without landing in the plugins auto-configuration (which isn't as ready for testing).