### PR TITLE
Fix domain search box writing direction (retry)

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -235,6 +235,7 @@ const RegisterDomainStep = React.createClass( {
 					autoFocus={ true }
 					delaySearch={ true }
 					delayTimeout={ 1000 }
+					dir="ltr"
 				/>
 			</div>
 		);

--- a/client/components/search-card/index.jsx
+++ b/client/components/search-card/index.jsx
@@ -20,7 +20,8 @@ var SearchCard = React.createClass( {
 		onSearchChange: React.PropTypes.func,
 		analyticsGroup: React.PropTypes.string,
 		autoFocus: React.PropTypes.bool,
-		disabled: React.PropTypes.bool
+		disabled: React.PropTypes.bool,
+		dir: React.PropTypes.string
 	},
 
 	render: function() {

--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -40,6 +40,11 @@ This value is passed to the disabled attribute of the `<input>` element, and det
 ### searching (optional) bool ( default false )
 Whether to display a [`<Spinner />`](../spinner/) in place of the search icon.
 
+### dir (optional) string ( default undefined )
+Whether to force a specific writing direction for the search field, regardless of the current global writing direction. Useful for inputting domains, codes, etc that use LTR direction when in a RTL language.
+
+Supported values are `'ltr'`, `'rtl'` and `undefined` (the default, which uses the current global writing direction of the app).
+
 ## Methods
 
 ### getCurrentSearchValue()

--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -43,7 +43,9 @@ Whether to display a [`<Spinner />`](../spinner/) in place of the search icon.
 ### dir (optional) string ( default undefined )
 Whether to force a specific writing direction for the search field, regardless of the current global writing direction. Useful for inputting domains, codes, etc that use LTR direction when in a RTL language.
 
-Supported values are `'ltr'`, `'rtl'` and `undefined` (the default, which uses the current global writing direction of the app).
+Currently supports forcing a LTR field in a RTL language, but not the other way around.
+
+Supported values are `'ltr'` and `undefined` (the default, which uses the current global writing direction of the app).
 
 ## Methods
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -48,7 +48,8 @@ const Search = React.createClass( {
 		disableAutocorrect: React.PropTypes.bool,
 		onBlur: React.PropTypes.func,
 		searching: React.PropTypes.bool,
-		isOpen: React.PropTypes.bool
+		isOpen: React.PropTypes.bool,
+		dir: React.PropTypes.string
 	},
 
 	getInitialState: function() {
@@ -70,7 +71,8 @@ const Search = React.createClass( {
 			onKeyDown: noop,
 			disableAutocorrect: false,
 			searching: false,
-			isOpen: false
+			isOpen: false,
+			dir: undefined
 		};
 	},
 
@@ -253,6 +255,8 @@ const Search = React.createClass( {
 			'is-pinned': this.props.pinned,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
+			rtl: this.props.dir === 'rtl',
+			ltr: this.props.dir === 'ltr',
 			search: true
 		} );
 
@@ -269,12 +273,12 @@ const Search = React.createClass( {
 					}
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }>
-				<Gridicon icon="search" className="search-open__icon"/>
+				<Gridicon icon="search" className={ 'search-open__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) }/>
 				</div>
 				<input
 					type="search"
 					id={ 'search-component-' + this.state.instanceId }
-					className="search__input"
+					className={ 'search__input' + ( this.props.dir ? ' ' + this.props.dir : '' ) }
 					placeholder={ placeholder }
 					role="search"
 					value={ searchValue }
@@ -287,6 +291,7 @@ const Search = React.createClass( {
 					disabled={ this.props.disabled }
 					aria-hidden={ ! isOpenUnpinnedOrQueried }
 					autoCapitalize="none"
+					dir={ this.props.dir }
 					{...autocorrect } />
 				{ ( searchValue || this.state.isOpen ) ? this.closeButton() : null }
 			</div>
@@ -301,7 +306,7 @@ const Search = React.createClass( {
 				onKeyDown={ this._keyListener.bind( this, 'closeSearch' ) }
 				aria-controls={ 'search-component-' + this.state.instanceId }
 				aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
-			<Gridicon icon="cross" className="search-close__icon"/>
+			<Gridicon icon="cross" className={ 'search-close__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) } />
 			</span>
 		);
 	},

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -40,7 +40,19 @@
 		position: absolute;
 			bottom: 0;
 			top: 50%;
+
+		&:not(.ltr):not(.rtl) {
 			right: 0;
+		}
+
+		&.ltr {
+			right: 0 #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			left: 0 #{"/*rtl:ignore*/"};
+		}
+
 		margin-top: -12px;
 		width: 60px;
 		cursor: pointer;
@@ -83,12 +95,34 @@
 	position: absolute;
 		bottom: 0;
 		top: 0;
+
+	&:not(.ltr):not(.rtl) {
 		right: 0;
+	}
+
+	&.ltr {
+		right: 0 #{"/*rtl:ignore*/"};
+	}
+
+	&.rtl {
+		left: 0 #{"/*rtl:ignore*/"};
+	}
+
 	// matching dropdown-selector
 	z-index: z-index( 'root', '.search.is-pinned' );
 
 	.search-open__icon {
-		right: 0;
+		&:not(.ltr):not(.rtl) {
+			right: 0;
+		}
+
+		&.ltr {
+			right: 0 #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			left: 0 #{"/*rtl:ignore*/"};
+		}
 	}
 
 	.search__input[type="search"] {
@@ -111,8 +145,21 @@
 
 	@include breakpoint( "<660px" ) {
 		opacity: 0;
-		left: 0;
-		padding-left: 50px;
+
+		&:not(.ltr):not(.rtl) {
+			right: 0;
+			padding-left: 50px;
+		}
+
+		&.ltr {
+			left: 0 #{"/*rtl:ignore*/"};
+			padding-left: 50px #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			right: 0 #{"/*rtl:ignore*/"};
+			padding-right: 50px #{"/*rtl:ignore*/"};
+		}
 	}
 
 	&::-webkit-search-cancel-button {
@@ -127,12 +174,36 @@
 
 // When search input is opened
 .search.is-open {
-	margin-right: 0 !important;
+
+	&:not(.ltr):not(.rtl) {
+		margin-right: 0 !important;
+	}
+
+	&.ltr {
+		margin-right: 0 #{"/*rtl:ignore*/"} !important;
+	}
+
+	&.rtl {
+		margin-left: 0 #{"/*rtl:ignore*/"} !important;
+	}
+
 	width: 100%;
 
 	.search-open__icon {
 		color: darken( $gray, 30% );
-		left: 0;
+
+		&:not(.ltr):not(.rtl) {
+			left: 0;
+		}
+
+		&.ltr {
+			left: 0 #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			right: 0 #{"/*rtl:ignore*/"};
+		}
+
 	}
 
 	.search-close__icon {
@@ -153,11 +224,34 @@
 	display: none;
 	position: absolute;
 		top: 50%;
+
+	&:not(.ltr):not(.rtl) {
 		left: 30px;
+	}
+
+	&.ltr {
+		left: 30px #{"/*rtl:ignore*/"};
+	}
+
+	&.rtl {
+		right: 30px #{"/*rtl:ignore*/"};
+	}
+
 	transform: translate( -50%, -50% );
 
 	@include breakpoint( "<660px" ) {
-		left: 25px;
+
+		&:not(.ltr):not(.rtl) {
+			left: 25px;
+		}
+
+		&.ltr {
+			left: 25px #{"/*rtl:ignore*/"};
+		}
+
+		&.rtl {
+			right: 25px #{"/*rtl:ignore*/"};
+		}
 	}
 }
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -41,16 +41,12 @@
 			bottom: 0;
 			top: 50%;
 
-		&:not(.ltr):not(.rtl) {
+		&:not(.ltr) {
 			right: 0;
 		}
 
 		&.ltr {
 			right: 0 #{"/*rtl:ignore*/"};
-		}
-
-		&.rtl {
-			left: 0 #{"/*rtl:ignore*/"};
 		}
 
 		margin-top: -12px;
@@ -96,7 +92,7 @@
 		bottom: 0;
 		top: 0;
 
-	&:not(.ltr):not(.rtl) {
+	&:not(.ltr) {
 		right: 0;
 	}
 
@@ -104,24 +100,16 @@
 		right: 0 #{"/*rtl:ignore*/"};
 	}
 
-	&.rtl {
-		left: 0 #{"/*rtl:ignore*/"};
-	}
-
 	// matching dropdown-selector
 	z-index: z-index( 'root', '.search.is-pinned' );
 
 	.search-open__icon {
-		&:not(.ltr):not(.rtl) {
+		&:not(.ltr) {
 			right: 0;
 		}
 
 		&.ltr {
 			right: 0 #{"/*rtl:ignore*/"};
-		}
-
-		&.rtl {
-			left: 0 #{"/*rtl:ignore*/"};
 		}
 	}
 
@@ -146,7 +134,7 @@
 	@include breakpoint( "<660px" ) {
 		opacity: 0;
 
-		&:not(.ltr):not(.rtl) {
+		&:not(.ltr) {
 			right: 0;
 			padding-left: 50px;
 		}
@@ -154,11 +142,6 @@
 		&.ltr {
 			left: 0 #{"/*rtl:ignore*/"};
 			padding-left: 50px #{"/*rtl:ignore*/"};
-		}
-
-		&.rtl {
-			right: 0 #{"/*rtl:ignore*/"};
-			padding-right: 50px #{"/*rtl:ignore*/"};
 		}
 	}
 
@@ -175,7 +158,7 @@
 // When search input is opened
 .search.is-open {
 
-	&:not(.ltr):not(.rtl) {
+	&:not(.ltr) {
 		margin-right: 0 !important;
 	}
 
@@ -183,27 +166,18 @@
 		margin-right: 0 #{"/*rtl:ignore*/"} !important;
 	}
 
-	&.rtl {
-		margin-left: 0 #{"/*rtl:ignore*/"} !important;
-	}
-
 	width: 100%;
 
 	.search-open__icon {
 		color: darken( $gray, 30% );
 
-		&:not(.ltr):not(.rtl) {
+		&:not(.ltr) {
 			left: 0;
 		}
 
 		&.ltr {
 			left: 0 #{"/*rtl:ignore*/"};
 		}
-
-		&.rtl {
-			right: 0 #{"/*rtl:ignore*/"};
-		}
-
 	}
 
 	.search-close__icon {
@@ -225,7 +199,7 @@
 	position: absolute;
 		top: 50%;
 
-	&:not(.ltr):not(.rtl) {
+	&:not(.ltr) {
 		left: 30px;
 	}
 
@@ -233,24 +207,16 @@
 		left: 30px #{"/*rtl:ignore*/"};
 	}
 
-	&.rtl {
-		right: 30px #{"/*rtl:ignore*/"};
-	}
-
 	transform: translate( -50%, -50% );
 
 	@include breakpoint( "<660px" ) {
 
-		&:not(.ltr):not(.rtl) {
+		&:not(.ltr) {
 			left: 25px;
 		}
 
 		&.ltr {
 			left: 25px #{"/*rtl:ignore*/"};
-		}
-
-		&.rtl {
-			right: 25px #{"/*rtl:ignore*/"};
 		}
 	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -107,8 +107,16 @@
 		padding: 0;
 		width: auto;
 		position: absolute;
-			left: 18px;
 			top: 50%;
+
+		&:not(.ltr) {
+			left: 18px;
+		}
+
+		&.ltr {
+			left: 18px #{"/*rtl:ignore*/"};
+		}
+
 		margin-top: -9px;
 		width: 18px;
 		height: 18px;
@@ -117,7 +125,15 @@
 	&.is-open {
 		.search-close__icon {
 			color: $gray;
-			right: 16px;
+
+			&:not(.ltr) {
+				right: 16px;
+			}
+
+			&.ltr {
+				right: 16px #{"/*rtl:ignore*/"};
+			}
+
 			margin-top: -9px;
 			width: 18px;
 			height: 18px;


### PR DESCRIPTION
#5649 introduced some visual breakage in the `site-selector` component, and had to be reverted.

This PR fixes that, and also removes the ability to introduce a RTL component in a LTR context, per @mtias's suggestion. That would not be as common and we can save some CSS file size removing the rules.