### PR TITLE
Jetpack connect: updated regular expresion schema

### DIFF
--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -2,7 +2,7 @@ export const jetpackConnectSessionsSchema = {
 	type: 'object',
 	additionalProperties: false,
 	patternProperties: {
-		'^[a-z0-9\.\-\:]+$': {
+		'^[a-z0-9\.\-\:\/]+$': {
 			type: 'object',
 			required: [ 'timestamp' ],
 			properties: {


### PR DESCRIPTION
The regexp evaluating urls was discarding anything containing a `/` !!!! 

