### PR TITLE
Plans: fall back to domain upgrade nudge if domain tip cannot be shown

### DIFF
--- a/client/my-sites/domain-tip/docs/example.jsx
+++ b/client/my-sites/domain-tip/docs/example.jsx
@@ -27,7 +27,7 @@ export default React.createClass( {
 					<a href="/devdocs/app-components/domain-tip">Domain Tip</a>
 				</h2>
 				<div>
-					<DomainTip siteId={ siteId } />
+					<DomainTip siteId={ siteId } event="domain_app_example" />
 				</div>
 			</div>
 		);

--- a/client/my-sites/domain-tip/index.jsx
+++ b/client/my-sites/domain-tip/index.jsx
@@ -32,6 +32,7 @@ const DomainTip = React.createClass( {
 
 	propTypes: {
 		className: React.PropTypes.string,
+		event: React.PropTypes.string.isRequired,
 		siteId: React.PropTypes.number.isRequired
 	},
 
@@ -49,11 +50,11 @@ const DomainTip = React.createClass( {
 	domainUpgradeNudge() {
 		return (
 			<UpgradeNudge
-					title={ this.translate( 'Get a free Custom Domain' ) }
-					message={ this.translate( 'Custom domains are free when you upgrade to a Premium or Business plan.' ) }
-					feature={ FEATURE_CUSTOM_DOMAIN }
-					event="stats_insights_domain"
-				/>
+				title={ this.translate( 'Get a free Custom Domain' ) }
+				message={ this.translate( 'Custom domains are free when you upgrade to a Premium or Business plan.' ) }
+				feature={ FEATURE_CUSTOM_DOMAIN }
+				event={ this.props.event }
+			/>
 		);
 	},
 
@@ -74,7 +75,7 @@ const DomainTip = React.createClass( {
 				{
 					suggestion
 						? <UpgradeNudge
-						event="domain-tip"
+						event={ `domain_tip_${ this.props.event }` }
 						shouldDisplay={ this.noticeShouldDisplay }
 						feature={ FEATURE_CUSTOM_DOMAIN }
 						title={ this.translate( '{{span}}%(domain)s{{/span}} is available!', {

--- a/client/my-sites/domain-tip/index.jsx
+++ b/client/my-sites/domain-tip/index.jsx
@@ -46,10 +46,21 @@ const DomainTip = React.createClass( {
 		return true;
 	},
 
+	domainUpgradeNudge() {
+		return (
+			<UpgradeNudge
+					title={ this.translate( 'Get a free Custom Domain' ) }
+					message={ this.translate( 'Custom domains are free when you upgrade to a Premium or Business plan.' ) }
+					feature={ FEATURE_CUSTOM_DOMAIN }
+					event="stats_insights_domain"
+				/>
+		);
+	},
+
 	render() {
 		if ( ! this.props.site || this.props.site.jetpack || ! this.props.siteSlug ||
 				abtest( 'domainsWithPlansOnly' ) !== 'plansOnly' || ! isFreePlan( this.props.site.plan ) ) {
-			return null;
+			return this.domainUpgradeNudge();
 		}
 		const classes = classNames( this.props.className, 'domain-tip' );
 		const { query, quantity, vendor } = getQueryObject( this.props.site, this.props.siteSlug );
@@ -61,7 +72,8 @@ const DomainTip = React.createClass( {
 					quantity={ quantity }
 					vendor={ vendor } />
 				{
-					suggestion && <UpgradeNudge
+					suggestion
+						? <UpgradeNudge
 						event="domain-tip"
 						shouldDisplay={ this.noticeShouldDisplay }
 						feature={ FEATURE_CUSTOM_DOMAIN }
@@ -71,8 +83,8 @@ const DomainTip = React.createClass( {
 								span: <span className="domain-tip__suggestion" />
 							} } ) }
 						message={ this.translate( 'Upgrade your plan to register a domain.' ) }
-						href={ `/domains/add/${ this.props.siteSlug }` }
-					/>
+						href={ `/domains/add/${ this.props.siteSlug }` } />
+						: this.domainUpgradeNudge()
 				}
 			</div>
 		);

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -84,7 +84,7 @@ export default React.createClass( {
 					/>
 					<AllTime allTimeList={ allTimeList } />
 					<MostPopular insightsList={ insightsList } />
-					<DomainTip siteId={ site.ID } />
+					<DomainTip siteId={ site.ID } event="stats_insights_domain" />
 					<div className="stats-nonperiodic has-recent">
 						<div className="module-list">
 							<div className="module-column">


### PR DESCRIPTION
As requested by @mtias this PR may fall back to a domain upgrade nudge if a domain tip cannot be shown.

Fallback:
<img width="742" alt="domain-upgrade" src="https://cloud.githubusercontent.com/assets/1270189/15691263/85ec35ee-273c-11e6-9800-064e1ecfb5a6.png">
Domain Tip:
<img width="745" alt="domain-tip" src="https://cloud.githubusercontent.com/assets/1270189/15691271/92ae7c42-273c-11e6-98f9-2937620b9aac.png">

## Testing Instructions
- Switch to a site with a free plan
- the a/b test `domainsWithPlansOnly` is set to `original`
- Navigate to My Sites, you should see the fallback
- update `domainsWithPlansOnly` to `plansOnly`
- You should see a domain tip

cc @matias @rralian @retrofox 