### PR TITLE
Domains: Fix dependency resolution for plansOnly

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -12,6 +12,8 @@ var update = require( 'react-addons-update' ),
 	reject = require( 'lodash/reject' ),
 	tail = require( 'lodash/tail' ),
 	some = require( 'lodash/some' ),
+	uniq = require( 'lodash/uniq' ),
+	flatten = require( 'lodash/flatten' ),
 	filter = require( 'lodash/filter' );
 
 /**
@@ -137,9 +139,11 @@ function removeItemAndDependencies( cartItemToRemove, cart ) {
  * @returns {Object[]} the list of dependency items in the shopping cart
  */
 function getDependentProducts( cartItem, cart ) {
-	return getAll( cart ).filter( function( existingCartItem ) {
+	const dependentProducts = getAll( cart ).filter( function( existingCartItem ) {
 		return isDependentProduct( cartItem, existingCartItem );
 	} );
+
+	return uniq( flatten( dependentProducts.concat( dependentProducts.map( dependentProduct => getDependentProducts( dependentProduct, cart ) ) ) ) );
 }
 
 /**

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -206,7 +206,7 @@ function getDomainProductRanking( product ) {
 }
 
 function isDependentProduct( product, dependentProduct ) {
-	var slug, dependentSlug;
+	var slug, dependentSlug, isPlansOnlyDependent = false;
 
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -215,10 +215,10 @@ function isDependentProduct( product, dependentProduct ) {
 	dependentSlug = isDomainRegistration( dependentProduct ) ? 'domain' : dependentProduct.product_slug;
 
 	if ( ( product.extra && dependentProduct.extra ) && ( product.extra.withPlansOnly === 'yes' || dependentProduct.extra.withPlansOnly === 'yes' ) ) {
-		return isPlan( product ) && ( isDomainRegistration( dependentProduct ) || isDomainMapping( dependentProduct ) );
+		isPlansOnlyDependent = isPlan( product ) && ( isDomainRegistration( dependentProduct ) || isDomainMapping( dependentProduct ) );
 	}
 
-	return (
+	return isPlansOnlyDependent || (
 		productDependencies[ slug ] &&
 		productDependencies[ slug ][ dependentSlug ] &&
 		product.meta === dependentProduct.meta


### PR DESCRIPTION
Fixes finding dependent items in cart on removal.

Before this, if the user was affected by plansOnly changes, they were able to purchase domain-related products by adding them to cart and then removing the domain from the cart.

Testing
-

- Switch to plansOnly
- Add a domain to your cart, along with the plan and a Google Apps license
- Remove plan or domain from your cart
- Google Apps should be removed from there as well

/cc: @klimeryk