### PR TITLE
Jetpack SSO: Add error notice when SSO authorization fails

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -84,7 +84,7 @@ const JetpackSSOForm = React.createClass( {
 
 	isButtonDisabled() {
 		const { nonceValid, isAuthorizing, isValidating, ssoUrl } = this.props;
-		return !! ( ! nonceValid | isAuthorizing | isValidating | ssoUrl );
+		return !! ( ! nonceValid || isAuthorizing || isValidating || ssoUrl );
 	},
 
 	maybeValidateSSO( props = this.props ) {

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -23,6 +23,7 @@ import addQueryArgs from 'lib/route/add-query-args';
 import config from 'config';
 import EmptyContent from 'components/empty-content';
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 /*
  * Module variables
@@ -103,21 +104,15 @@ const JetpackSSOForm = React.createClass( {
 
 		return (
 			<Notice
-				icon="notice"
 				status="is-error"
-				text={ this.translate( 'Oops, something went wrong. Please {{tryAgainLink}}try again{{/tryAgainLink}}.', {
-					components: {
-						tryAgainLink: (
-							<a
-								rel="external"
-								href={ get( this.props, 'blogDetails.admin_url', '#' ) }
-								onClick={ this.onTryAgainClick }
-							/>
-						)
-					}
-				} ) }
-				showDismiss={ false }
-			/>
+				text={ this.translate( 'Oops, something went wrong.' ) }
+				showDismiss={ false }>
+				<NoticeAction
+					href={ get( this.props, 'blogDetails.admin_url', '#' ) }
+					onClick={ this.onTryAgainClick }>
+					{ this.translate( 'Try again' ) }
+				</NoticeAction>
+			</Notice>
 		);
 	},
 

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -83,8 +83,8 @@ const JetpackSSOForm = React.createClass( {
 	},
 
 	isButtonDisabled() {
-		const { nonceValid, isAuthorizing, isValidating, ssoUrl } = this.props;
-		return !! ( ! nonceValid || isAuthorizing || isValidating || ssoUrl );
+		const { nonceValid, isAuthorizing, isValidating, ssoUrl, authorizationError } = this.props;
+		return !! ( ! nonceValid || isAuthorizing || isValidating || ssoUrl || authorizationError );
 	},
 
 	maybeValidateSSO( props = this.props ) {


### PR DESCRIPTION
Closes #5685 

When an error occurs after clicking the "Log in" button to authorize the SSO process, we should show the  error some sort of UI instead of just doing nothing. 

In this PR, I suggest that we show an error notice and instruct the user to log in again. When clicking the "try again" link, the user will be sent to `{$site}/wp-admin` where they can start the SSO process over.

Note: Since we pre-validate the SSO details, the chances of this being shown to users are slim. But, it could happen if a user takes longer than 10 minutes to approve the SSO process.

Note: I know there's an orphan word in this screenshot. 😞 

cc @rickybanister for design review and @lezama for code review. 

To test:

- Checkout `update/jetpack-sso-error-notice-authorize` branch
- Ensure you have latest Jetpack on your site
- Go to `{$site}/wp-admin`
- Click "Log in with WordPress.com" button
- Replace `wpcalypso.wordpress.com` with `calypso.localhost:3000` in the URL
- In the "Network" tab of Chrome, turn off Wifi
- Click the blue "Log in" button to authorize
- You should see an error
- Turn off wifi throttling
- Click the "try again" link

After screenshot:

![screen shot 2016-05-31 at 5 22 49 pm](https://cloud.githubusercontent.com/assets/1126811/15692591/df0daa14-2754-11e6-967f-1c1a61f0036b.png)
