### PR TITLE
Fix the mis-aligned buttons upon resizing issue of the happiness-support component upon resizing.

### DIFF
--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -70,8 +70,10 @@
 		}
 
 		@include breakpoint( ">660px" ) {
-			+ .button {
-				margin-left: 16px;
+			margin-top: 10px;
+
+			&:first-of-type {
+				margin-right: 16px;
 			}
 		}
 	}


### PR DESCRIPTION
This PR attempts to fix #4335.

The original cause of misalignment is that there is a `margin-left` attached to the second button, and thus causes a gap on the left when the two got squeezed into one column. Replacing it with the `margin-right` on the first button resolves the issue. Also, I added a `margin-top` to leave a gap between the two.

Here is the screencast after applying it:
![demo-resizing](https://cloud.githubusercontent.com/assets/1842898/15694614/de8ee0a8-27d1-11e6-9317-7135024525f4.gif)

