### PR TITLE
Editor: Fix "Paste as text" message

### DIFF
--- a/client/components/tinymce/plugins/calypso-alert/plugin.jsx
+++ b/client/components/tinymce/plugins/calypso-alert/plugin.jsx
@@ -18,7 +18,7 @@ function calypsoAlert( editor ) {
 		node.setAttribute( 'class', 'alert-container' );
 		editor.getContainer().appendChild( node );
 
-		editor.windowManager.alert = function( message, callback, scope ) {
+		editor.windowManager.alert = ( message, callback, scope ) => {
 			function onClose() {
 				render( 'hide' );
 				if ( typeof callback === 'function' ) {
@@ -40,6 +40,14 @@ function calypsoAlert( editor ) {
 			}
 
 			render( 'show' );
+		};
+
+		// The only place we should get one of these in Calypso is when
+		// clicking the "Paste as text" button for the first time in a session.
+		// Previous versions of TinyMCE used an alert to show a message;
+		// current versions use a notification instead.
+		editor.notificationManager.open = data => {
+			editor.windowManager.alert( data.text );
 		};
 	} );
 


### PR DESCRIPTION
Fixes #5718.

## Before

![image](https://cloud.githubusercontent.com/assets/128826/15694667/1800e38e-27e3-11e6-9bb8-70eb4bc27c93.png)

## After

![image](https://cloud.githubusercontent.com/assets/227022/15698368/8baaf824-2789-11e6-8a51-41bd1e76feb9.png)

## To test

1. Starting at URL: http://calypso.localhost:3000/post/ (Editor)
2. Click 'Paste as Text' button on editor toolbar
3. Verify that [our custom message](https://github.com/Automattic/wp-calypso/blob/12a27beda288923d5186807f1157f04389f54c06/client/components/tinymce/i18n.js#L59) for this action is shown in a Calypso-styled dialog box.

cc @alisterscott 