### PR TITLE
Exporter: Enable in wpcalypso and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,6 +31,7 @@
 		"manage/customize": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,
+		"manage/export": true,
 		"manage/import": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,6 +37,7 @@
 		"manage/custom-post-types": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,
+		"manage/export": true,
 		"manage/import": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,


### PR DESCRIPTION
This enables the feature flag for the site exporter in wpcalypso and horizon for wider testing.

![site_settings_ _testsite2982_ _wordpress_com](https://cloud.githubusercontent.com/assets/416133/15706459/0aa45e92-2837-11e6-895c-3765032107b3.png)
