### PR TITLE
Theme Sheet: style img caption and padding

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -148,20 +148,31 @@
 		&.alignright,
 		&.alignleft {
 			max-width: 100%;
-			margin: 20px 0;
+			margin: 7px 0 20px;
 		}
 
 		&.alignright {
 			float: right;
+			margin-left: 20px;
 		}
 
 		&.alignleft {
 			float: left;
+			margin-right: 20px;
 		}
 	}
 
+	.wp-caption {
+		margin-bottom: 20px;
+	}
+
+	.wp-caption-text {
+		color: $gray;
+		font-size: 12px;
+	}
+
 	h2 {
-		color: #87a6bc; /* $gray */
+		color: $gray;
 		font-size: 14px;
 		font-weight: 400;
 


### PR DESCRIPTION
This PR fixes:

* Image caption.
* Images margin when left or right aligned.

![screen shot 2016-06-01 at 11 53 35](https://cloud.githubusercontent.com/assets/4389/15707232/8186b8f4-27ef-11e6-9c1d-a9364cc561fe.png)

![screen shot 2016-06-01 at 11 53 39](https://cloud.githubusercontent.com/assets/4389/15707238/84f7198e-27ef-11e6-8b51-e3fa61aae18e.png)


### How to test

* Open http://calypso.live/theme/twentythirteen?branch=update/themes/sheet-content-style-caption
* Check that the caption below the two images is present and properly spaced.
* Check that the left-floated image has the text with some in the middle.
* Check other themes, as much as you can.

Fixes #5692. 
/cc @kathrynwp to check if it works :) 