### PR TITLE
Sidebar: Open preview in new tab if meta or ctrl key clicked

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -55,7 +55,7 @@ module.exports = React.createClass( {
 
 	onPreviewSite( event ) {
 		const site = this.getSelectedSite();
-		if ( site.is_previewable ) {
+		if ( site.is_previewable && ! event.metaKey && ! event.ctrlKey ) {
 			event.preventDefault();
 			this.props.layoutFocus.set( 'preview' );
 		}


### PR DESCRIPTION
Closes #5695

To test:
1. Click the site card with `cmd` held down on OS X, should result in new tab
2. On non-OS X OSes, `ctrl` being held down should open a new tab