### PR TITLE
Framework: Only render react server-side for logged-out users

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -53,6 +53,7 @@ export function fetchThemeDetailsData( context, next ) {
 	if ( theme && ( theme.timestamp + HOUR_IN_MS > Date.now() ) ) {
 		debug( 'found theme!', theme.id );
 		context.store.dispatch( receiveThemeDetails( theme ) );
+		context.renderCacheKey = context.path + theme.timestamp;
 		return next();
 	}
 
@@ -62,11 +63,13 @@ export function fetchThemeDetailsData( context, next ) {
 			themeDetails.timestamp = Date.now();
 			themeDetailsCache.set( themeSlug, themeDetails );
 			context.store.dispatch( receiveThemeDetails( themeDetails ) );
+			context.renderCacheKey = context.path + themeDetails.timestamp;
 			next();
 		} )
 		.catch( error => {
 			debug( `Error fetching theme ${ themeSlug } details: `, error.message || error );
 			context.store.dispatch( receiveThemeDetailsFailure( themeSlug, error ) );
+			context.renderCacheKey = 'theme not found';
 			next();
 		} );
 }

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -12,7 +12,7 @@ import pick from 'lodash/pick';
  */
 import config from 'config';
 
-const markupCache = new Lru( { max: 1000 } );
+const markupCache = new Lru( { max: 3000 } );
 
 function bumpStat( group, name ) {
 	const statUrl = `http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_${ group }=${ name }&t=${ Math.random() }`;

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -74,7 +74,10 @@ export function serverRender( req, res ) {
 		context.i18nLocaleScript = '//widgets.wp.com/languages/calypso/' + context.lang + '.js';
 	}
 
-	if ( config.isEnabled( 'server-side-rendering' ) && context.store && context.layout ) {
+	if ( config.isEnabled( 'server-side-rendering' ) &&
+		context.store &&
+		context.layout &&
+		! context.user ) {
 		context.initialReduxState = pick( context.store.getState(), 'ui', 'themes' );
 		const key = JSON.stringify( context.layout ) + req.path + JSON.stringify( context.initialReduxState );
 		Object.assign( context, render( context.layout, key ) );

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -79,7 +79,7 @@ export function serverRender( req, res ) {
 		context.layout &&
 		! context.user ) {
 		context.initialReduxState = pick( context.store.getState(), 'ui', 'themes' );
-		const key = JSON.stringify( context.layout ) + req.path + JSON.stringify( context.initialReduxState );
+		const key = JSON.stringify( context.layout ) + JSON.stringify( context.initialReduxState );
 		Object.assign( context, render( context.layout, key ) );
 	}
 

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -79,7 +79,7 @@ export function serverRender( req, res ) {
 		context.layout &&
 		! context.user ) {
 		context.initialReduxState = pick( context.store.getState(), 'ui', 'themes' );
-		const key = JSON.stringify( context.layout ) + JSON.stringify( context.initialReduxState );
+		const key = req.path + JSON.stringify( context.initialReduxState );
 		Object.assign( context, render( context.layout, key ) );
 	}
 


### PR DESCRIPTION
Fixes #5580.

No visual changes.

Avoid filling the render cache with markup for every site slug, and avoid flash of english content for users with non-english locales.

This PR also removes the path from the render-cache key. Layout + state is unique for a rendered logged-out page. Using the request path as well only adds duplicate entries to the cache.

**To Test**
Tricky, since dev mode thinks all users are logged out.
* Test cache key change by trying a few theme urls, e.g.:

http://calypso.localhost:3000/theme/twentysixteen/setup
http://calypso.localhost:3000/theme/twentysixteen/support
http://calypso.localhost:3000/theme/mood/support

All should show expected content

Before running `make run`, type the following into your terminal to see render cache activity:
`export DEBUG='calypso:server-render'`

**Note**
This change does not stop logged-in users going through the server middlewares for the /theme route, which means some requests will be delayed waiting for an API return (though this means that logged-in hits will keep the theme-details cache updated for logged-out hits).