### PR TITLE
Themes: Redirect '/theme' to '/design'

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -412,6 +412,8 @@ module.exports = function() {
 		} );
 	}
 
+	app.get( '/theme', ( req, res ) => res.redirect( '/design' ) );
+
 	// Isomorphic routing
 	sections
 		.filter( section => section.isomorphic )


### PR DESCRIPTION
Redirect '/theme' URLs with no theme slug to the theme showcase main page.

**To Test**
Check the following URLs, logged-in and logged-out:
http://calypso.localhost:3000/theme -> /design
http://calypso.localhost:3000/theme/ -> /design
http://calypso.localhost:3000/theme/{invalid-slug} -> 'Looking for...' page
http://calypso.localhost:3000/theme/{theme-slug} -> theme sheet for theme

