### PR TITLE
Editor: replace insert icon

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -21,7 +21,7 @@ const SocialLogoButton = ( { icon, label } ) => (
 export default [
 	{
 		name: 'insert_media_item',
-		item: <GridiconButton icon="image-multiple" label={ i18n.translate( 'Add Media' ) } />,
+		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add Media' ) } />,
 		cmd: 'wpcomAddMedia'
 	},
 	{

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -28,7 +28,7 @@ const initialize = editor => {
 		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),
 		onPostRender() {
 			ReactDOM.render(
-				<Gridicon icon="add-image" />,
+				<Gridicon icon="add-outline" />,
 				this.$el[0].children[0]
 			);
 		}

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -9,8 +9,8 @@
 			color: lighten( $gray, 10% );
 		}
 
-		&:hover .gridicons-add-image,
-		&:focus .gridicons-add-image {
+		&:hover .gridicons-add-outline,
+		&:focus .gridicons-add-outline {
 			fill: lighten( $gray, 10% );
 		}
 
@@ -19,8 +19,8 @@
 			color: $gray-dark;
 		}
 
-		.gridicons-add-image:hover,
-		.gridicons-add-image:focus {
+		.gridicons-add-outline:hover,
+		.gridicons-add-outline:focus {
 			fill: $gray-dark;
 		}
 	}


### PR DESCRIPTION
Before|After
---|---
![screen shot 2016-06-01 at 10 27 44 am](https://cloud.githubusercontent.com/assets/618551/15715360/c5fe48dc-27e3-11e6-8703-1c0a8944288b.png)|![screen shot 2016-06-01 at 10 27 28 am](https://cloud.githubusercontent.com/assets/618551/15715367/cfbea1a0-27e3-11e6-913d-c9a60b7cbef9.png)

This is meant to emphasize that you can add more than just images with the new insert UI. My theory is that more users will try this button if they want to "add" something to the post content. This will be user tested.

Live test link https://calypso.live/?branch=update/insert-ui-icon