### PR TITLE
Themes: Turn on theme sheets on stage and horizon environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -54,6 +54,7 @@
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
+		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
 		"me/account": true,
 		"me/billing-history": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -52,6 +52,7 @@
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
+		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
 		"me/account": true,
 		"me/billing-history": true,


### PR DESCRIPTION
Turn on the feature flag so that _stage_ and _horizon_ environments match _wpcalypso_ with regards to theme details.