### PR TITLE
Jetpack Plans: Remove the Activate/Autoupdate toggles from plugins setup screen

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -19,7 +19,6 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Spinner from 'components/spinner';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
-import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 import JetpackSite from 'lib/site/jetpack';
@@ -219,7 +218,7 @@ const PlansSetup = React.createClass( {
 					// Done doesn't use a notice
 					return (
 						<div className="plugin-item__finished">
-							{ this.translate( 'Successfully configured.' ) }
+							{ this.translate( 'Successfully installed & configured.' ) }
 						</div>
 					);
 					break;
@@ -251,17 +250,7 @@ const PlansSetup = React.createClass( {
 			);
 		}
 
-		const site = this.props.selectedSite;
-		const sitePlugin = PluginsStore.getSitePlugin( site, plugin.slug );
-		Object.assign( plugin, sitePlugin );
-		return (
-			<div className="plugin-item__actions">
-				<PluginActivateToggle
-					plugin={ plugin }
-					isMock={ true }
-					site={ site } />
-			</div>
-		);
+		return null;
 	},
 
 	renderPlaceholder() {

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -206,7 +206,7 @@ const PlansSetup = React.createClass( {
 					break;
 			}
 			statusProps.children = (
-				<NoticeAction href={ helpLinks[ plugin.slug ] }>
+				<NoticeAction key="notice_action" href={ helpLinks[ plugin.slug ] }>
 					{ "Manual Installation" }
 				</NoticeAction>
 			);

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -20,7 +20,6 @@ import NoticeAction from 'components/notice/notice-action';
 import Spinner from 'components/spinner';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
-import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 import JetpackSite from 'lib/site/jetpack';
@@ -261,11 +260,6 @@ const PlansSetup = React.createClass( {
 					plugin={ plugin }
 					isMock={ true }
 					site={ site } />
-				<PluginAutoupdateToggle
-					plugin={ plugin }
-					isMock={ true }
-					site={ site }
-					wporg={ !! plugin.wporg } />
 			</div>
 		);
 	},

--- a/client/my-sites/plugins/jetpack-plugins-setup/style.scss
+++ b/client/my-sites/plugins/jetpack-plugins-setup/style.scss
@@ -17,6 +17,10 @@ $polldaddy-red:  #D45458;
 			content: ' ';
 		}
 	}
+
+	.plugin-item__link {
+		cursor: default;
+	}
 }
 
 .jetpack-plugins-setup__header {


### PR DESCRIPTION
Fixes #5701 

The autoupdate toggle on the plugin setup screen doesn't reflect reality, and neither it or the activate toggle are functional. Let's just remove them, and make it clear that we've installed these plugins through the status message.

cc @johnHackworth @roccotripaldi 