### PR TITLE
Importer: Replace built-in `find` with lodash `find`

### DIFF
--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -1,3 +1,4 @@
+import find from 'lodash/find';
 import { fromJS } from 'immutable';
 
 import { appStates } from './constants';
@@ -20,13 +21,17 @@ const importerStateMap = [
 ];
 
 function apiToAppState( state ) {
-	return importerStateMap
-		.find( ( [ , api ] ) => api === state )[0];
+	return find(
+		importerStateMap,
+		( [ , api ] ) => api === state
+	)[0];
 }
 
 function appStateToApi( state ) {
-	return importerStateMap
-		.find( ( [ appState ] ) => appState === state )[1];
+	return find(
+		importerStateMap,
+		( [ appState ] ) => appState === state
+	)[1];
 }
 
 function generateSourceAuthorIds( customData ) {


### PR DESCRIPTION
Closes #3515

IE does not currently support `Array.prototype.find()`, which the
importer makes use of when mapping between the API data structure and
the internal Calypso data structure. This meant that imports have not
been working in IE; that is, an error gets thrown when attempting to
upload a file.

This patch replaces the call to the native `find()` with a call to the
`find()` provided by **lodash**, thus preventing the error.

**Testing**
Navigate to **My Sites** > **Settings** > **Import** and attempt to load
an exported XML file. Previously, or in **master** you would not be able
to start the import process through uploading a file. Now, in this
branch, it should work without throwing an exception.

Props to @rachelmcr, @BandonRandon, and @lancewillett for finding,
testing, and writing up a solid bug report.