### PR TITLE
Make sidebar footer fixed for “My Sites”, “Reader”

### DIFF
--- a/client/components/app-promo/style.scss
+++ b/client/components/app-promo/style.scss
@@ -1,11 +1,11 @@
 .app-promo {
 	position: relative;
 	max-width: 300px;
-	margin: 35px auto 15px auto;
+	margin: 0 auto 15px auto;
 	padding: 5px 0;
 	overflow: hidden;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( "<660px" ) {
 		display: none;
 	}
 }

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import SidebarRegion from './region';
 
 export default React.createClass( {
 	displayName: 'Sidebar',
@@ -13,8 +14,10 @@ export default React.createClass( {
 	},
 
 	render: function() {
+		let hasRegions = !!this.props.children.find( el => el.type === SidebarRegion );
+
 		return (
-			<ul className={ classNames( 'sidebar', this.props.className ) } onClick={ this.props.onClick } data-tip-target="sidebar">
+			<ul className={ classNames( 'sidebar', this.props.className, { 'has-regions': hasRegions } ) } onClick={ this.props.onClick } data-tip-target="sidebar">
 				{ this.props.children }
 			</ul>
 		);

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -14,7 +14,7 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		let hasRegions = !!this.props.children.find( el => el.type === SidebarRegion );
+		let hasRegions = this.props.children.some( el => el.type === SidebarRegion );
 
 		return (
 			<ul className={ classNames( 'sidebar', this.props.className, { 'has-regions': hasRegions } ) } onClick={ this.props.onClick } data-tip-target="sidebar">

--- a/client/layout/sidebar/region.jsx
+++ b/client/layout/sidebar/region.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 const SidebarRegion = ( { children, className } ) => (
-	<li className={ classNames( 'sidebar__region', className ) }><ul>{ children }</ul></li>
+	<div className={ classNames( 'sidebar__region', className ) }>{ children }</div>
 );
 
 export default SidebarRegion;

--- a/client/layout/sidebar/region.jsx
+++ b/client/layout/sidebar/region.jsx
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+const SidebarRegion = ( { children, className } ) => (
+	<li className={ classNames( 'sidebar__region', className ) }><ul>{ children }</ul></li>
+);
+
+export default SidebarRegion;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -378,3 +378,16 @@ a.sidebar__button {
 		}
 	}
 }
+
+.sidebar__region {
+	ul {
+		display: flex;
+		flex-direction: column;
+	}
+
+	@include breakpoint( ">660px" ) {
+		overflow: auto;
+		flex: 1;
+		transform: translateX( 0 ); /* workaround for safari scrollbar rendering bug */
+	}
+}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -380,13 +380,12 @@ a.sidebar__button {
 }
 
 .sidebar__region {
-	ul {
-		display: flex;
-		flex-direction: column;
-	}
+	display: flex;
+	flex-direction: column;
 
 	@include breakpoint( ">660px" ) {
-		overflow: auto;
+		overflow-y: auto;
+		overflow-x: hidden;
 		flex: 1;
 		transform: translateX( 0 ); /* workaround for safari scrollbar rendering bug */
 	}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -380,10 +380,9 @@ a.sidebar__button {
 }
 
 .sidebar__region {
-	display: flex;
-	flex-direction: column;
-
 	@include breakpoint( ">660px" ) {
+		display: flex;
+		flex-direction: column;
 		overflow-y: auto;
 		overflow-x: hidden;
 		flex: 1;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -386,6 +386,7 @@ a.sidebar__button {
 }
 
 .sidebar__region {
+	flex-shrink: 0;
 	@include breakpoint( ">660px" ) {
 		display: flex;
 		flex-direction: column;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -37,6 +37,12 @@
 			transform: translateX( 100vw );
 		}
 	}
+
+	@include breakpoint( ">660px" ) {
+		&.has-regions {
+			overflow: hidden;
+		}
+	}
 }
 
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -26,6 +26,7 @@ var abtest = require( 'lib/abtest' ).abtest,
 	SidebarHeading = require( 'layout/sidebar/heading' ),
 	SidebarItem = require( 'layout/sidebar/item' ),
 	SidebarMenu = require( 'layout/sidebar/menu' ),
+	SidebarRegion = require( 'layout/sidebar/region' ),
 	SiteStatsStickyLink = require( 'components/site-stats-sticky-link' );
 
 import Button from 'components/button';
@@ -690,6 +691,7 @@ module.exports = React.createClass( {
 
 		return (
 			<Sidebar>
+				<SidebarRegion>
 				<CurrentSite
 					sites={ this.props.sites }
 					siteCount={ this.props.user.get().visible_site_count }
@@ -770,6 +772,7 @@ module.exports = React.createClass( {
 					</SidebarMenu>
 					: null
 				}
+				</SidebarRegion>
 				<SidebarFooter>
 					{ this.addNewWordPress() }
 				</SidebarFooter>

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -22,6 +22,7 @@ import SidebarActions from 'lib/reader-sidebar/actions';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarHeading from 'layout/sidebar/heading';
 import SidebarMenu from 'layout/sidebar/menu';
+import SidebarRegion from 'layout/sidebar/region';
 import Gridicon from 'components/gridicon';
 import discoverHelper from 'reader/discover/helper';
 import ReaderSidebarTags from './reader-sidebar-tags';
@@ -157,6 +158,7 @@ const ReaderSidebar = React.createClass( {
 	render() {
 		return (
 			<Sidebar onClick={ this.handleClick }>
+				<SidebarRegion>
 				<SidebarMenu>
 					<SidebarHeading>{ this.translate( 'Streams' ) }</SidebarHeading>
 					<ul>
@@ -240,6 +242,7 @@ const ReaderSidebar = React.createClass( {
 					currentTag={ this.state.currentTag } />
 
 				{ this.renderAppPromo() }
+				</SidebarRegion>
 				<SidebarFooter />
 			</Sidebar>
 		);

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -241,8 +241,10 @@ const ReaderSidebar = React.createClass( {
 					onTagExists={ this.highlightNewTag }
 					currentTag={ this.state.currentTag } />
 
-				{ this.renderAppPromo() }
 				</SidebarRegion>
+
+				{ this.renderAppPromo() }
+
 				<SidebarFooter />
 			</Sidebar>
 		);


### PR DESCRIPTION
This PR makes the sidebar footer (which houses “Help” and “Add New Site” options, depending on your setup) fixed when scrolling the sidebar. This should hopefully make the “Help” option more discoverable .(Right now it's not visible by default on small displays.)

We achieve this by introducing sidebar regions: Groups of elements on the sidebar that scroll together on overflow, while allowing for the other elements to remain fixed. They are useful for implementing static headers/footers.

On small screen devices, the per-region scrolling behavior is disabled, and the entire sidebar scrolls instead.

![](https://cldup.com/Y9wH7hSk3P.gif)