### PR TITLE
Domains: use default domains suggestions from global state

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import async from 'async';
-import extend from 'lodash/extend';
 import flatten from 'lodash/flatten';
 import reject from 'lodash/reject';
 import find from 'lodash/find';
@@ -60,7 +59,7 @@ function getQueryObject( props ) {
 		quantity: SUGGESTION_QUANTITY,
 		vendor: abtest( 'domainSuggestionVendor' ),
 		includeSubdomain: props.includeWordPressDotCom
-	}
+	};
 }
 
 function processSearchStatQueue() {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -34,12 +34,14 @@ import { isPlan } from 'lib/products-values';
 import cartItems from 'lib/cart-values/cart-items';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { abtest } from 'lib/abtest';
+import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
+import { getDomainsSuggestions, } from 'state/domains/suggestions/selectors';
 
 const domains = wpcom.domains();
 
 // max amount of domain suggestions we should fetch/display
-const SUGGESTION_QUANTITY = 10,
-	INITIAL_SUGGESTION_QUANTITY = 2;
+const SUGGESTION_QUANTITY = 10;
+const INITIAL_SUGGESTION_QUANTITY = 2;
 
 const analytics = analyticsMixin( 'registerDomain' ),
 	domainsWithPlansOnlyTestEnabled = abtest( 'domainsWithPlansOnly' ) === 'plansOnly';
@@ -48,6 +50,18 @@ let searchQueue = [],
 	searchStackTimer = null,
 	lastSearchTimestamp = null,
 	searchCount = 0;
+
+function getQueryObject( props ) {
+	if ( ! props.selectedSite || ! props.selectedSite.domain ) {
+		return null;
+	}
+	return {
+		query: props.selectedSite.domain.split( '.' )[ 0 ],
+		quantity: SUGGESTION_QUANTITY,
+		vendor: abtest( 'domainSuggestionVendor' ),
+		includeSubdomain: props.includeWordPressDotCom
+	}
+}
 
 function processSearchStatQueue() {
 	const queue = searchQueue.slice();
@@ -112,7 +126,6 @@ const RegisterDomainStep = React.createClass( {
 			clickedExampleSuggestion: false,
 			lastQuery: suggestion,
 			searchResults: null,
-			defaultSuggestions: null,
 			lastDomainSearched: null,
 			lastDomainError: null,
 			loadingResults: Boolean( suggestion ),
@@ -123,9 +136,6 @@ const RegisterDomainStep = React.createClass( {
 	componentWillMount: function() {
 		searchCount = 0; // reset the counter
 		lastSearchTimestamp = null; // reset timer
-		if ( this.props.selectedSite ) {
-			this.fetchDefaultSuggestions();
-		}
 
 		if ( this.props.initialState ) {
 			this.setState( this.props.initialState );
@@ -143,7 +153,6 @@ const RegisterDomainStep = React.createClass( {
 		if ( this.props.selectedSite && this.props.selectedSite.domain !== prevProps.selectedSite.domain ) {
 			this.setState( this.getInitialState() );
 			this.focusSearchCard();
-			this.fetchDefaultSuggestions();
 		}
 	},
 
@@ -157,39 +166,7 @@ const RegisterDomainStep = React.createClass( {
 	},
 
 	isLoadingSuggestions: function() {
-		return this.state.defaultSuggestions === null;
-	},
-
-	fetchDefaultSuggestions: function() {
-		if ( ! this.props.selectedSite || ! this.props.selectedSite.domain ) {
-			return;
-		}
-
-		const initialQuery = this.props.selectedSite.domain.split( '.' )[ 0 ];
-		const query = {
-			query: initialQuery,
-			quantity: SUGGESTION_QUANTITY,
-			vendor: abtest( 'domainSuggestionVendor' )
-		};
-
-		domains.suggestions( query ).then( suggestions => {
-			if ( ! this.isMounted() ) {
-				return;
-			}
-			this.props.onDomainsAvailabilityChange( true );
-			suggestions = suggestions.map( function( suggestion ) {
-				return extend( suggestion, { isVisible: true } );
-			} );
-			this.setState( { defaultSuggestions: suggestions } );
-		} ).catch( error => {
-			if ( error && error.statusCode === 503 ) {
-				return this.props.onDomainsAvailabilityChange( false );
-			} else if ( error && error.error ) {
-				error.code = error.error;
-				this.showValidationErrorMessage( initialQuery, error );
-			}
-			this.setState( { defaultSuggestions: [] } );
-		} );
+		return ! this.props.defaultSuggestions;
 	},
 
 	render: function() {
@@ -198,7 +175,24 @@ const RegisterDomainStep = React.createClass( {
 				{ this.searchForm() }
 				{ this.notices() }
 				{ this.content() }
+				{ this.queryDomainsSuggestions() }
 			</div>
+		);
+	},
+
+	queryDomainsSuggestions() {
+		const queryObject = getQueryObject( this.props );
+		if ( ! queryObject ) {
+			return null;
+		}
+		const { query, quantity, vendor, includeSubdomain } = queryObject;
+		return (
+			<QueryDomainsSuggestions
+				query={ query }
+				quantity={ quantity }
+				vendor={ vendor }
+				includeSubdomain={ includeSubdomain }
+			/>
 		);
 	},
 
@@ -386,7 +380,7 @@ const RegisterDomainStep = React.createClass( {
 			} );
 		} else {
 			// only display two suggestions initially
-			suggestions = this.state.defaultSuggestions.slice( 0, INITIAL_SUGGESTION_QUANTITY );
+			suggestions = this.props.defaultSuggestions.slice( 0, INITIAL_SUGGESTION_QUANTITY );
 
 			domainRegistrationSuggestions = suggestions.map( function( suggestion ) {
 				return (
@@ -446,7 +440,7 @@ const RegisterDomainStep = React.createClass( {
 				);
 			}
 
-			suggestions = this.state.defaultSuggestions;
+			suggestions = this.props.defaultSuggestions;
 		}
 
 		return (
@@ -603,8 +597,10 @@ const RegisterDomainStep = React.createClass( {
 	}
 } );
 
-module.exports = connect( state => {
+module.exports = connect( ( state, props ) => {
+	const queryObject = getQueryObject( props );
 	return {
-		currentUser: getCurrentUser( state )
+		currentUser: getCurrentUser( state ),
+		defaultSuggestions: getDomainsSuggestions( state, queryObject )
 	};
 } )( RegisterDomainStep );

--- a/client/state/domains/suggestions/reducer.js
+++ b/client/state/domains/suggestions/reducer.js
@@ -66,7 +66,38 @@ export function requesting( state = {}, action ) {
 			}
 			return state;
 		case SERIALIZE:
+		case DESERIALIZE:
 			return {};
+	}
+	return state;
+}
+
+/**
+ * Tracks domains suggestions error state, indexed by a serialized query.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function errors( state = {}, action ) {
+	const serializedQuery = action.queryObject && getSerializedDomainsSuggestionsQuery( action.queryObject );
+	switch ( action.type ) {
+		case DOMAINS_SUGGESTIONS_REQUEST:
+		case DOMAINS_SUGGESTIONS_REQUEST_SUCCESS:
+			if ( serializedQuery ) {
+				return Object.assign( {}, state, {
+					[ serializedQuery ]: null
+				} );
+			}
+			return state;
+		case DOMAINS_SUGGESTIONS_REQUEST_FAILURE:
+			if ( serializedQuery ) {
+				return Object.assign( {}, state, {
+					[ serializedQuery ]: action.error
+				} );
+			}
+			return state;
+		case SERIALIZE:
 		case DESERIALIZE:
 			return {};
 	}
@@ -75,5 +106,6 @@ export function requesting( state = {}, action ) {
 
 export default combineReducers( {
 	items,
-	requesting
+	requesting,
+	errors
 } );

--- a/client/state/domains/suggestions/selectors.js
+++ b/client/state/domains/suggestions/selectors.js
@@ -38,3 +38,21 @@ export function isRequestingDomainsSuggestions( state, queryObject ) {
 	}
 	return false;
 }
+
+/**
+ * Returns an error for a given domains suggestions query.
+ * @param   {Object}     state                                Global state tree
+ * @param   {Object}     queryObject                          domain suggestions queryObject
+ * @param   {String}     queryObject.query                    domainQuery
+ * @param   {Number}     queryObject.quantity                 max results
+ * @param   {String}     queryObject.vendor                   vendor
+ * @param   {?Boolean}   queryObject.includeSubdomain  adds wordpress subdomain suggestions when true
+ * @returns {?Object}    error or null
+ */
+export function getDomainsSuggestionsError( state, queryObject ) {
+	const serializedQuery = getSerializedDomainsSuggestionsQuery( queryObject );
+	if ( serializedQuery ) {
+		return state.domains.suggestions.errors[ serializedQuery ] || null;
+	}
+	return null;
+}

--- a/client/state/domains/suggestions/test/reducer.js
+++ b/client/state/domains/suggestions/test/reducer.js
@@ -17,7 +17,8 @@ import {
 } from 'state/action-types';
 import reducer, {
 	items,
-	requesting
+	requesting,
+	errors
 } from '../reducer';
 import { useSandbox } from 'test/helpers/use-sinon';
 
@@ -32,7 +33,8 @@ describe( 'reducer', () => {
 	it( 'should export expected reducer keys', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'items',
-			'requesting'
+			'requesting',
+			'errors'
 		] );
 	} );
 
@@ -241,7 +243,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'should accumulate fetchingItems by site ID', () => {
+		it( 'should accumulate requesting state by query', () => {
 			const originalState = deepFreeze( {
 				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': true
 			} );
@@ -276,6 +278,141 @@ describe( 'reducer', () => {
 					'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': true
 				} );
 				const state = requesting( original, { type: DESERIALIZE } );
+				expect( state ).to.eql( {} );
+			} );
+		} );
+	} );
+
+	describe( '#errors()', () => {
+		it( 'should default to an empty object', () => {
+			const state = errors( undefined, {} );
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should update errors on failure', () => {
+			const originalState = deepFreeze( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': true
+			} );
+			const queryObject = {
+				query: 'example',
+				quantity: 2,
+				vendor: 'domainsbot',
+				include_wordpressdotcom: false
+			};
+			const error = new Error( 'something bad happened' );
+			const state = errors( originalState, {
+				type: DOMAINS_SUGGESTIONS_REQUEST_FAILURE,
+				queryObject,
+				error
+			} );
+
+			expect( state ).to.eql( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error
+			} );
+		} );
+
+		it( 'should update errors on success', () => {
+			const error = new Error( 'something bad happened' );
+			const originalState = deepFreeze( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error
+			} );
+			const queryObject = {
+				query: 'example',
+				quantity: 2,
+				vendor: 'domainsbot',
+				include_wordpressdotcom: false
+			};
+			const state = errors( originalState, {
+				type: DOMAINS_SUGGESTIONS_REQUEST_SUCCESS,
+				queryObject
+			} );
+
+			expect( state ).to.eql( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': null
+			} );
+		} );
+
+		it( 'should update errors on request', () => {
+			const error = new Error( 'something bad happened' );
+			const originalState = deepFreeze( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error
+			} );
+			const queryObject = {
+				query: 'example',
+				quantity: 2,
+				vendor: 'domainsbot',
+				include_wordpressdotcom: false
+			};
+			const state = errors( originalState, {
+				type: DOMAINS_SUGGESTIONS_REQUEST,
+				queryObject
+			} );
+
+			expect( state ).to.eql( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': null
+			} );
+		} );
+
+		it( 'should update errors on failure', () => {
+			const originalState = deepFreeze( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': true
+			} );
+			const queryObject = {
+				query: 'example',
+				quantity: 2,
+				vendor: 'domainsbot',
+				include_wordpressdotcom: false
+			};
+			const error = new Error( 'something bad happened' );
+			const state = errors( originalState, {
+				type: DOMAINS_SUGGESTIONS_REQUEST_FAILURE,
+				queryObject,
+				error
+			} );
+
+			expect( state ).to.eql( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error
+			} );
+		} );
+
+		it( 'should accumulate errors by queries', () => {
+			const error = new Error( 'something bad happened' );
+			const originalState = deepFreeze( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error
+			} );
+			const queryObject = {
+				query: 'foobar',
+				quantity: 2,
+				vendor: 'domainsbot',
+				include_wordpressdotcom: false
+			};
+			const error2 = new Error( 'something else bad happened' );
+			const state = errors( originalState, {
+				type: DOMAINS_SUGGESTIONS_REQUEST_FAILURE,
+				queryObject,
+				error: error2
+			} );
+
+			expect( state ).to.eql( {
+				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error,
+				'{"query":"foobar","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error2
+			} );
+		} );
+
+		describe( 'persistence', () => {
+			it( 'never persists state', () => {
+				const original = deepFreeze( {
+					'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': new Error()
+				} );
+				const state = errors( original, { type: SERIALIZE } );
+				expect( state ).to.eql( {} );
+			} );
+
+			it( 'never loads persisted state', () => {
+				const original = deepFreeze( {
+					'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': new Error()
+				} );
+				const state = errors( original, { type: DESERIALIZE } );
 				expect( state ).to.eql( {} );
 			} );
 		} );

--- a/client/state/domains/suggestions/test/selectors.js
+++ b/client/state/domains/suggestions/test/selectors.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getDomainsSuggestions,
+	getDomainsSuggestionsError,
 	isRequestingDomainsSuggestions
 } from '../selectors';
 
@@ -83,6 +84,46 @@ describe( 'selectors', () => {
 			expect( isRequestingDomainsSuggestions( state, example ) ).to.equal( true );
 			expect( isRequestingDomainsSuggestions( state, foobar ) ).to.equal( false );
 			expect( isRequestingDomainsSuggestions( state, notDefined ) ).to.equal( false );
+		} );
+		describe( '#getDomainsSuggestionsError()', () => {
+			it( 'should return requesting domains suggestion state for a given query', () => {
+				const error = new Error( 'something went wrong' );
+				const state = {
+					domains: {
+						suggestions: {
+							errors: {
+								'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error,
+								'{"query":"foobar","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': null
+							}
+						}
+					}
+				};
+
+				const example = {
+					query: 'example',
+					quantity: 2,
+					vendor: 'domainsbot',
+					includeSubdomain: false
+				};
+
+				const foobar = {
+					query: 'foobar',
+					quantity: 2,
+					vendor: 'domainsbot',
+					includeSubdomain: false
+				};
+
+				const notDefined = {
+					query: 'notDefined',
+					quantity: 2,
+					vendor: 'domainsbot',
+					includeSubdomain: false
+				};
+
+				expect( getDomainsSuggestionsError( state, example ) ).to.equal( error );
+				expect( getDomainsSuggestionsError( state, foobar ) ).to.equal( null );
+				expect( getDomainsSuggestionsError( state, notDefined ) ).to.equal( null );
+			} );
 		} );
 	} );
 } );

--- a/client/state/domains/suggestions/utils.js
+++ b/client/state/domains/suggestions/utils.js
@@ -6,6 +6,9 @@
  * @return {?String}              Serialized DomainsSuggestions query
  */
 export function getSerializedDomainsSuggestionsQuery( queryObject ) {
+	if ( ! queryObject ) {
+		return null;
+	}
 	const { query, quantity, vendor } = queryObject;
 	if ( ( ! query || query.length === 0 ) || ( ! quantity || quantity <= 0 ) || ( ! vendor || vendor.length === 0 ) ) {
 		return null;

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -4,6 +4,9 @@
 import moment from 'moment';
 
 const createSitePlanObject = ( plan ) => {
+	if ( ! plan ) {
+		return {};
+	}
 	return {
 		canStartTrial: Boolean( plan.can_start_trial ),
 		currentPlan: Boolean( plan.current_plan ),


### PR DESCRIPTION
This PR populates defaultSuggestions from redux global state, instead of calling the wpcom api directly. Since the suggestions are persisted in indexedDB, default suggestions should now load much more quickly the second time.

This PR also fixes a bug where we were unable to create a new site from the sidebar, if we were on `domains/add`. 

## Testing Instructions

### Domains Add
- Navigate to http://calypso.localhost:3000/domains/add
- Select a site you are admin on
- Default suggestions load
- Refresh the page. Default suggestions should load much more quickly

### Domains Add Errors
- Navigate to http://calypso.localhost:3000/domains/add
- Select a site you are admin on
- Sandbox to simulate errors, or do this locally in connect, to set `defaultSuggestions`, and `defaultSuggestionsError`
- 503 error renders a placeholder
- An error with a proper error code should render a respective notice

### Create a new site Bug
- Navigate to http://calypso.localhost:3000/domains/add/yoursite
- Click on switch site
- Click on `Add New Wordpress` at the bottom of the sidebar
- Prod will throw an error, this branch will succeed

### Create a New Site
- Navigate to http://calypso.localhost:3000/domains/add/yoursite
- Click on switch site
- Click on `Add New Wordpress` at the bottom of the sidebar
- Follow instructions, until you're prompted to select a site name
- You should be able to search for a subdomain/domain and complete the site creation process

cc @umurkontaci @rralian @retrofox @drewblaisdell 