### PR TITLE
Triforce: Updating triforce labels to use a Calypso-allowed color, and de-bolding it

### DIFF
--- a/client/signup/steps/design-type/style.scss
+++ b/client/signup/steps/design-type/style.scss
@@ -15,10 +15,9 @@
 	}
 
 	h2 {
-		color: #000;
+		color: darken( $gray, 20% );
 		padding-left: 15px;
 		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
-		font-weight: bold;
 		line-height: 54px;
 	}
 


### PR DESCRIPTION
Before:

![screen shot 2016-06-01 at 9 42 35 pm](https://cloud.githubusercontent.com/assets/2846578/15731276/c9a04d74-2841-11e6-8e71-24d6910a73f2.png)

After:

![screen shot 2016-06-01 at 9 42 29 pm](https://cloud.githubusercontent.com/assets/2846578/15731278/cc625214-2841-11e6-93f1-3304a00f0541.png)

