### PR TITLE
Add: single initial fade-in animation for Live link

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -325,6 +325,7 @@
 	color: lighten( $gray, 30% );
 	cursor: pointer;
 	transition: all ease-in-out 100ms;
+	animation: themes__sheet-fade-from-bottom 1.0s ease-in-out;
 
 	&:hover {
 		color: $white;
@@ -369,5 +370,22 @@
 		display: block;
 		margin: -12px auto 0;
 		background: $gray-light;
+	}
+}
+
+@keyframes themes__sheet-fade-from-bottom {
+	0% {
+		opacity: 0.0; // Let's add a small delay
+	}
+	20% {
+		opacity: 0.0;
+		transform: translateY(10px);
+	}
+	70% {
+		opacity: 1.0;
+	}
+	100% {
+		opacity: 1.0;
+		transform: none;
 	}
 }


### PR DESCRIPTION
Proof of concept / prototype for a simple pure CSS animation triggered once on load.

Problem: if the page gets loaded directly, it animates twice.

![cap-](https://cloud.githubusercontent.com/assets/4389/15745743/58ba9fbc-28cb-11e6-8b87-38af656b2ea1.gif)

### To test:

* Open the branch, [live link](https://calypso.live/theme/mood?branch=try/themes/sheet-intro-animation-css)
* Check that on a direct load, the animation happens twice
* Note that if you get there from another Calypso page, it properly animates just once.