### PR TITLE
Signup: Flows cleanup and consolidation

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -41,8 +41,6 @@ function getPostsDestination( dependencies ) {
 }
 
 const flows = {
-	/* Production flows*/
-
 	account: {
 		steps: [ 'user' ],
 		destination: '/',
@@ -95,7 +93,6 @@ const flows = {
 		lastModified: '2016-05-23'
 	},
 
-	/* WP.com homepage flows */
 	website: {
 		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getSiteDestination,
@@ -110,9 +107,6 @@ const flows = {
 		lastModified: '2016-05-23'
 	},
 
-	/* On deck flows*/
-
-	/* Testing flows */
 	personal: {
 		steps: [ 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
@@ -124,7 +118,7 @@ const flows = {
 
 	'test-site': {
 		steps: config( 'env' ) === 'development' ? [ 'site', 'user' ] : [ 'user' ],
-		destination: '/me/next/welcome',
+		destination: '/',
 		description: 'This flow is used to test the site step.',
 		lastModified: '2015-09-22'
 	},
@@ -150,24 +144,10 @@ const flows = {
 		lastModified: '2016-03-09'
 	},
 
-	'site-user': {
-		steps: [ 'site', 'user' ],
-		destination: '/me/next?welcome',
-		description: 'Signup flow for free site/account',
-		lastModified: '2015-10-30'
-	},
-
 	desktop: {
 		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getPostsDestination,
 		description: 'Signup flow for desktop app',
-		lastModified: '2016-05-30'
-	},
-
-	app: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
-		destination: getPostsDestination,
-		description: 'Used as a web-based control to test the "desktop" flow',
 		lastModified: '2016-05-30'
 	},
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -56,10 +56,10 @@ const flows = {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
 		description: 'Create an account and a blog and then add the business plan to the users cart.',
+		lastModified: '2016-06-02',
 		meta: {
 			skipBundlingPlan: true
-		},
-		lastModified: '2016-06-02'
+		}
 	},
 
 	premium: {
@@ -67,11 +67,11 @@ const flows = {
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
+		description: 'Create an account and a blog and then add the business plan to the users cart.',
+		lastModified: '2016-06-02',
 		meta: {
 			skipBundlingPlan: true
-		},
-		description: 'Create an account and a blog and then add the business plan to the users cart.',
-		lastModified: '2016-06-02'
+		}
 	},
 
 	free: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -108,7 +108,7 @@ const flows = {
 	},
 
 	personal: {
-		steps: [ 'themes', 'domains', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/personal/' + dependencies.siteSlug;
 		},

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -11,7 +11,6 @@ import reject from 'lodash/reject';
 import { abtest } from 'lib/abtest';
 import config from 'config';
 import { isOutsideCalypso } from 'lib/url';
-import plansPaths from 'my-sites/plans/paths';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
 
@@ -23,14 +22,6 @@ function getCheckoutUrl( dependencies ) {
 
 function dependenciesContainCartItem( dependencies ) {
 	return dependencies.cartItem || dependencies.domainItem || dependencies.themeItem;
-}
-
-function getFreeTrialDestination( dependencies ) {
-	if ( dependenciesContainCartItem( dependencies ) ) {
-		return getCheckoutUrl( dependencies );
-	}
-
-	return plansPaths.plans( dependencies.siteSlug );
 }
 
 function getSiteDestination( dependencies ) {
@@ -60,59 +51,34 @@ const flows = {
 	},
 
 	business: {
-		steps: [ 'themes', 'domains', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'survey-user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
 		description: 'Create an account and a blog and then add the business plan to the users cart.',
-		lastModified: '2016-01-21',
 		meta: {
 			skipBundlingPlan: true
-		}
+		},
+		lastModified: '2016-06-02'
 	},
 
 	premium: {
-		steps: [ 'themes', 'domains', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'survey-user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
-		description: 'Create an account and a blog and then add the premium plan to the users cart.',
-		lastModified: '2016-01-21',
 		meta: {
 			skipBundlingPlan: true
-		}
-
+		},
+		description: 'Create an account and a blog and then add the business plan to the users cart.',
+		lastModified: '2016-06-02'
 	},
 
 	free: {
-		steps: [ 'themes', 'domains', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'survey-user' ],
 		destination: getSiteDestination,
 		description: 'Create an account and a blog and default to the free plan.',
-		lastModified: '2016-02-29'
-	},
-
-	businessv2: {
-		steps: [ 'domains-only', 'user' ],
-		destination: function( dependencies ) {
-			return '/plans/select/business/' + dependencies.siteSlug;
-		},
-		description: 'Made for CT CMO trial project. Create an account and a blog, without theme selection, and then add the business plan to the users cart.',
-		lastModified: '2016-02-26',
-		meta: {
-			skipBundlingPlan: true
-		}
-	},
-
-	premiumv2: {
-		steps: [ 'domains-only', 'user' ],
-		destination: function( dependencies ) {
-			return '/plans/select/premium/' + dependencies.siteSlug;
-		},
-		description: 'Made for CT CMO trial project. Create an account and a blog, without theme selection, and then add the premium plan to the users cart.',
-		lastModified: '2016-02-26',
-		meta: {
-			skipBundlingPlan: true
-		}
+		lastModified: '2016-06-02'
 	},
 
 	'with-theme': {
@@ -127,13 +93,6 @@ const flows = {
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2016-05-23'
-	},
-
-	plan: {
-		steps: [ 'themes', 'domains', 'select-plan', 'user' ],
-		destination: getSiteDestination,
-		description: '',
-		lastModified: '2016-02-02'
 	},
 
 	/* WP.com homepage flows */
@@ -222,13 +181,6 @@ const flows = {
 	jetpack: {
 		steps: [ 'jetpack-user' ],
 		destination: '/'
-	},
-
-	'free-trial': {
-		steps: [ 'themes', 'domains-with-plan', 'user' ],
-		destination: getFreeTrialDestination,
-		description: 'Signup flow for free trials',
-		lastModified: '2016-03-21'
 	}
 };
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -67,7 +67,7 @@ const flows = {
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
-		description: 'Create an account and a blog and then add the business plan to the users cart.',
+		description: 'Create an account and a blog and then add the premium plan to the users cart.',
 		lastModified: '2016-06-02',
 		meta: {
 			skipBundlingPlan: true

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -197,10 +197,6 @@ function removeUserStepFromFlow( flow ) {
 function filterFlowName( flowName ) {
 	const defaultFlows = [ 'main', 'website' ];
 
-	if ( includes( defaultFlows, flowName ) && abtest( 'freeTrialsInSignup' ) === 'enabled' ) {
-		return 'free-trial';
-	}
-
 	if ( includes( defaultFlows, flowName ) && abtest( 'personalPlan' ) === 'show' ) {
 		return 'personal';
 	}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -195,7 +195,7 @@ function filterDestination( destination, dependencies, flowName ) {
 function getGuidedToursDestination( destination, dependencies, flowName ) {
 	const guidedToursVariant = abtest( 'guidedTours' );
 	const tourName = 'main';
-	const disabledFlows = [ 'account', 'site-user', 'jetpack' ];
+	const disabledFlows = [ 'account', 'jetpack' ];
 	const siteSlug = dependencies.siteSlug;
 	const baseUrl = `/stats/${ siteSlug }`;
 


### PR DESCRIPTION
There were some flows in signup that weren't up to date in terms of steps. Updated these to follow `main` as close as possible.

Retired some old flows that didn't get any (or any significant amount of) users.


Left is `site-user` flow, which is still unknown if it should be retired or not. 

cc @meremagee @michaeldcain 