### PR TITLE
Jetpack Plans: Update the receipt details to show install instructions when we can't install plugins

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
@@ -26,14 +26,20 @@ var JetpackPlanDetails = ( { selectedSite } ) => {
 
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
 		props.title = null;
-		props.description = i18n.translate(
-			'We are about to install Akismet and VaultPress for your site, which will automatically protect your site from spam and data loss. If you have any questions along the way, we\'re here to help! You can also perform a manual installation by following {{a}}these instructions{{/a}}.',
-			{ components: {
-				a: <a target="_blank" href="https://en.support.wordpress.com/setting-up-premium-services/" />
-			} }
-		);
-		props.buttonText = i18n.translate( 'Set up your plan' );
-		props.href = `/plugins/setup/${selectedSite.slug}`;
+		if ( ! selectedSite.canUpdateFiles ) {
+			props.description = i18n.translate( 'You can now install Akismet and VaultPress, which will automatically protect your site from spam and data loss. If you have any questions along the way, we\'re here to help!' );
+			props.buttonText = i18n.translate( 'Installation Instructions' );
+			props.href = 'https://en.support.wordpress.com/setting-up-premium-services/';
+		} else {
+			props.description = i18n.translate(
+				'We are about to install Akismet and VaultPress for your site, which will automatically protect your site from spam and data loss. If you have any questions along the way, we\'re here to help! You can also perform a manual installation by following {{a}}these instructions{{/a}}.',
+				{ components: {
+					a: <a target="_blank" href="https://en.support.wordpress.com/setting-up-premium-services/" />
+				} }
+			);
+			props.buttonText = i18n.translate( 'Set up your plan' );
+			props.href = `/plugins/setup/${selectedSite.slug}`;
+		}
 	}
 
 	return (


### PR DESCRIPTION
See #5729

If we can't automatically install plugins on a site, we shouldn't try to direct people to the automated install screen. Instead, we'll link to the manual install instructions.

Test this by viewing a receipt on a site we can't install on, for example a multisite sub-site.

@johnHackworth @roccotripaldi @rickybanister 