### PR TITLE
Signup: Fix /start/premium and /start/business flows (Fixes: #5758)

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -65,7 +65,10 @@ const flows = {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
 		description: 'Create an account and a blog and then add the business plan to the users cart.',
-		lastModified: '2016-01-21'
+		lastModified: '2016-01-21',
+		meta: {
+			skipBundlingPlan: true
+		}
 	},
 
 	premium: {
@@ -73,8 +76,12 @@ const flows = {
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
-		description: 'Create an account and a blog and then add the business plan to the users cart.',
-		lastModified: '2016-01-21'
+		description: 'Create an account and a blog and then add the premium plan to the users cart.',
+		lastModified: '2016-01-21',
+		meta: {
+			skipBundlingPlan: true
+		}
+
 	},
 
 	free: {
@@ -90,7 +97,10 @@ const flows = {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
 		description: 'Made for CT CMO trial project. Create an account and a blog, without theme selection, and then add the business plan to the users cart.',
-		lastModified: '2016-02-26'
+		lastModified: '2016-02-26',
+		meta: {
+			skipBundlingPlan: true
+		}
 	},
 
 	premiumv2: {
@@ -98,8 +108,11 @@ const flows = {
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
-		description: 'Made for CT CMO trial project. Create an account and a blog, without theme selection, and then add the business plan to the users cart.',
-		lastModified: '2016-02-26'
+		description: 'Made for CT CMO trial project. Create an account and a blog, without theme selection, and then add the premium plan to the users cart.',
+		lastModified: '2016-02-26',
+		meta: {
+			skipBundlingPlan: true
+		}
 	},
 
 	'with-theme': {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -303,7 +303,8 @@ const Signup = React.createClass( {
 		let currentStepProgress = find( this.state.progress, { stepName: this.props.stepName } ),
 			CurrentComponent = stepComponents[ this.props.stepName ],
 			propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props ),
-			stepKey = this.state.loadingScreenStartTime ? 'processing' : this.props.stepName;
+			stepKey = this.state.loadingScreenStartTime ? 'processing' : this.props.stepName,
+			flow = flows.getFlow( this.props.flowName );
 
 		return (
 			<div className="signup__step" key={ stepKey }>
@@ -314,8 +315,9 @@ const Signup = React.createClass( {
 					<CurrentComponent
 						path={ this.props.path }
 						step={ currentStepProgress }
-						steps={ flows.getFlow( this.props.flowName ).steps }
+						steps={ flow.steps }
 						stepName={ this.props.stepName }
+						meta={ flow.meta || {} }
 						goToNextStep={ this.goToNextStep }
 						goToStep={ this.goToStep }
 						flowName={ this.props.flowName }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -154,8 +154,10 @@ module.exports = React.createClass( {
 
 	goToNextStep( isPurchasingItem ) {
 		if ( domainsWithPlansOnlyTestEnabled && isPurchasingItem && abtest( 'freeTrialsInSignup' ) !== 'enabled' ) {
-			this.submitPlansStepWithPremium();
 			const plansIndex = this.props.steps.indexOf( 'plans' );
+			if ( ! this.props.meta.skipBundlingPlan ) {
+				this.submitPlansStepWithPremium();
+			}
 
 			if ( plansIndex === this.props.steps.length - 1 || plansIndex === -1 ) {
 				// if plans is the last step or not in the flow, this'll finish the flow


### PR DESCRIPTION
Fixes /start/premium and /start/business flows where `plans` step doesn't exist.

Testing
-
1. Go to /start/premium AND/OR /start/business
2. Follow instructions
3. You should end up in checkout with the correct items in your cart
4. Remove plan from your cart
5. Dependent domain should be removed.

/cc: @bisko @michaeldcain @klimeryk 