### PR TITLE
Plugins: Fixes #5138 fixes plugin install bug

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -260,7 +260,7 @@ const PluginsActions = {
 		}
 
 		const install = () => {
-			const bound = getPluginBoundMethod( site, plugin.id, 'install' );
+			const bound = getPluginBoundMethod( site, plugin.slug, 'install' );
 			return queueSitePluginActionAsPromise( bound, site.ID, plugin.slug );
 		};
 


### PR DESCRIPTION
Plugin instal needs the plugin slug and not plugin id since we don't check to make sure that the slug is in the format that it is supposed to be any more. 

The error happend in this strange way because the plugin id would be set to the plugin slug if we didn't have it installed somewhere else already and things would work as expected. 

Props to @aheckler, @sahin and @jeherve for binging it up. 

*To test*
- Connect at least two Jetpack sites with Manage enabled.
- Using wp-admin, install and enable Hello Dolly (or any other plugin) on one of the sites.
- Go here: https://wordpress.com/plugins/hello-dolly
- Click the Install button for the site without Hello Dolly installed.

Also make sure that you are able to install a plugin that is not available on any site as well. 

Fixes #5138
ping @johnHackworth, @jeherve for review. 
