### PR TITLE
Push-Notifications: Use a whitelist for displaying push notification prompt

### DIFF
--- a/client/components/push-notification/prompt.jsx
+++ b/client/components/push-notification/prompt.jsx
@@ -11,6 +11,25 @@ import Notice from 'components/notice';
 import Button from 'components/button';
 import observe from 'lib/mixins/data-observe';
 
+const SECTION_NAME_WHITELIST = [
+	'discover',
+	'menus',
+	'people',
+	'plans',
+	'plugins',
+	'posts-pages',
+	'reader',
+	'reader-activities',
+	'reader-list',
+	'reader-recomendations',
+	'reader-search',
+	'reader-tags',
+	'settings',
+	'sharing',
+	'stats',
+	'upgrades'
+];
+
 export default React.createClass( {
 	displayName: 'PushNotificationPrompt',
 
@@ -74,7 +93,7 @@ export default React.createClass( {
 			return null;
 		}
 
-		if ( ! this.props.section || this.props.isLoading || 'notification-settings' === this.props.section.name || 'editor' === this.props.section.group ) {
+		if ( ! this.props.section || this.props.isLoading || -1 === SECTION_NAME_WHITELIST.indexOf( this.props.section.name ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
Fixes #5724

Rather than maintaining a blacklist of sections where the Push Notification prompt should not be displayed, use a whitelist of sections where it should not be displayed.

Note: I chose to omit the prompt from `/me` sections entirely. If we decide that there are pages where the prompt should be included, we can update the whitelist in a separate PR.