### PR TITLE
Jetpack SSO: Update several issues after design review

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -179,6 +179,7 @@ const JetpackSSOForm = React.createClass( {
 			<Main className="jetpack-connect">
 				<div className="jetpack-connect__sso">
 					<ConnectHeader
+						showLogo={ false }
 						headerText={ this.translate( 'Connect with WordPress.com' ) }
 						subHeaderText={ this.translate(
 							'To use Single Sign-On, WordPress.com needs to be able to connect to your account on %(siteName)s', {

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -28,6 +28,7 @@ import NoticeAction from 'components/notice/notice-action';
 import Site from 'my-sites/site';
 import SitePlaceholder from 'my-sites/site/placeholder';
 import { decodeEntities } from 'lib/formatting';
+import Gridicon from 'components/gridicon';
 
 /*
  * Module variables
@@ -235,6 +236,7 @@ const JetpackSSOForm = React.createClass( {
 							rel="external"
 							href={ get( this.props, 'blogDetails.admin_url', '#' ) }
 							onClick={ this.onCancelClick }>
+							<Gridicon icon="arrow-left" size={ 18 } />
 							{ this.translate( 'Return to %(siteName)s', {
 								args: {
 									siteName: get( this.props, 'blogDetails.title' )

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -202,13 +202,13 @@ const JetpackSSOForm = React.createClass( {
 						{ this.maybeRenderAuthorizationError() }
 						<div className="jetpack-connect__sso__user-profile">
 							<Gravatar user={ user } size={ 120 } imgSize={ 400 } />
-							<h3 className="jetpack-connect__sso__user-profile-name">
+							<h3 className="jetpack-connect__sso__log-in-as">
 								{ this.translate(
 									'Log in as {{strong}}%s{{/strong}}',
 									{
 										args: user.display_name,
 										components: {
-											strong: <strong />
+											strong: <strong className="jetpack-connect__sso__display-name"/>
 										}
 									}
 								) }

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -182,7 +182,7 @@ const JetpackSSOForm = React.createClass( {
 						showLogo={ false }
 						headerText={ this.translate( 'Connect with WordPress.com' ) }
 						subHeaderText={ this.translate(
-							'To use Single Sign-On, WordPress.com needs to be able to connect to your account on %(siteName)s', {
+							'To use Single Sign-On, WordPress.com needs to be able to connect to your account on %(siteName)s.', {
 								args: {
 									siteName: get( this.props, 'blogDetails.title' )
 								}

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -91,6 +91,11 @@ const JetpackSSOForm = React.createClass( {
 		return !! ( ! nonceValid || isAuthorizing || isValidating || ssoUrl || authorizationError );
 	},
 
+	getSignInLink() {
+		const loginUrl = config( 'login_url' ) || 'https://wordpress.com/wp-login.php';
+		return addQueryArgs( { redirect_to: window.location.href }, loginUrl );
+	},
+
 	maybeValidateSSO( props = this.props ) {
 		const { ssoNonce, siteId, nonceValid, isAuthorizing, isValidating } = props;
 
@@ -223,6 +228,9 @@ const JetpackSSOForm = React.createClass( {
 					</Card>
 
 					<LoggedOutFormLinks>
+						<LoggedOutFormLinkItem href={ this.getSignInLink() }>
+							{ this.translate( 'Sign in as a different user' ) }
+						</LoggedOutFormLinkItem>
 						<LoggedOutFormLinkItem
 							rel="external"
 							href={ get( this.props, 'blogDetails.admin_url', '#' ) }

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -187,11 +187,15 @@
 	margin: 0 auto 16px;
 }
 
-.jetpack-connect__sso__user-profile-name {
+.jetpack-connect__sso__log-in-as{
 	font-family: $sans;
 	font-size: 21px;
 	font-weight: 300;
 	text-align: center;
+}
+
+.jetpack-connect__sso__display-name {
+	font-family: $serif;
 }
 
 .jetpack-connect__sso__user-email {


### PR DESCRIPTION
After a walkthrough of the Jetpack SSO functionality yesterday, @rickybanister pointed out several design issues. This PR addresses several of those. 

To test:
- Ensure that your Jetpack site is on the latest master
- Ensure that your Jetpack site is connected and SSO is turned on
- With a non-admin user on the Jetpack site that is not connected to WP.com, go to `$site/wp-admin` and click the "Log in with WordPress.com" button
- Checkout the `update/jetpack-sso-visuals` branch for Calypso
- You should land on `wpcalypso.wordpress.com/jetpack/sso/...`. Replace the `wpcalypso.wordpress.com` with calypso.localhost:3000`
- You should see something that looks like this:
![screen shot 2016-06-02 at 1 43 54 pm](https://cloud.githubusercontent.com/assets/1126811/15756749/40287f26-28c8-11e6-8a4e-4a4070d3e2a5.png)
- Try out the "Sign in as a different user" link and the return to site links.
- How does everything look?

cc @rickybanister for design review and @lezama for code review.
