### PR TITLE
Reader: Prefer featured image and images early in the DOM for features

### DIFF
--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -69,12 +69,12 @@ export default function waitForImagesToLoad( post ) {
 		// convert to image objects to start the load process
 		let promises = map( imagesToCheck, promiseForURL );
 
-		const imagesLoaded = [];
+		const imagesLoaded = {};
 
 		forEach( promises, promise => {
 			promise.then( image => {
 				// keep track of what loaded successfully. Note these will be out of order.
-				imagesLoaded.push( image );
+				imagesLoaded[ image.src ] = image;
 			} ).catch( () => {
 				// ignore what did not, but return the promise chain to success
 				return null;
@@ -84,7 +84,7 @@ export default function waitForImagesToLoad( post ) {
 				promises = pull( promises, promise );
 				if ( promises.length === 0 ) {
 					const imagesInOrder = filter( map( imagesToCheck, image => {
-						return find( imagesLoaded, { src: image.src } );
+						return imagesLoaded[ image.src ];
 					} ), Boolean );
 					acceptLoadedImages( imagesInOrder );
 				}


### PR DESCRIPTION
The new post normalizer code broke one thing that `async` was giving us: ordering across a series of async events. This caused the loaded images to get out of order, which led to a random image from each post being featured. 

This patch orders the images found in the post, putting features at the front, them images in DOM order. This restores the previous behavior. 

To test, compare http://calypso.localhost:3000/read/blogs/3584907 to https://wordpress.com/read/blogs/3584907 

The post about the new SEO settings panel should have a picture of a reflection in a building. 