### PR TITLE
Importer: Dispatchify `mapAuthors()`

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -129,14 +129,12 @@ export function finishUpload( importerId, importerStatus ) {
 	} );
 }
 
-export function mapAuthor( importerId, sourceAuthor, targetAuthor ) {
-	Dispatcher.handleViewAction( {
-		type: IMPORTS_AUTHORS_SET_MAPPING,
-		importerId,
-		sourceAuthor,
-		targetAuthor
-	} );
-}
+export const mapAuthor = ( importerId, sourceAuthor, targetAuthor ) => ( {
+	type: IMPORTS_AUTHORS_SET_MAPPING,
+	importerId,
+	sourceAuthor,
+	targetAuthor
+} );
 
 export function resetImport( siteId, importerId ) {
 	// We are done with this import session, so lock it away

--- a/client/my-sites/importer/dispatcher-converter.js
+++ b/client/my-sites/importer/dispatcher-converter.js
@@ -1,0 +1,26 @@
+import Dispatcher from 'dispatcher';
+import React from 'react';
+import identity from 'lodash/identity';
+import isFunction from 'lodash/isFunction';
+
+const ifCallableElse = ( f, g ) => isFunction( f ) ? f : g;
+const mergeProps = ( ...args ) => Object.assign( {}, ...args );
+
+const dispatchObject = action => Dispatcher.handleViewAction( action );
+const dispatchThunk = thunk => thunk( dispatchObject );
+
+const dispatch = action => isFunction( action )
+	? dispatchThunk( action )
+	: dispatchObject( action );
+
+export const connectDispatcher = ( fromState, fromDispatch ) => Component => props => (
+	React.createElement(
+		Component,
+		mergeProps(
+			props,
+			ifCallableElse( fromState, identity )( {} ),
+			ifCallableElse( fromDispatch, identity )( dispatch )
+		),
+		props.children
+	)
+);

--- a/client/my-sites/importer/dispatcher-converter.js
+++ b/client/my-sites/importer/dispatcher-converter.js
@@ -1,9 +1,10 @@
 import Dispatcher from 'dispatcher';
 import React from 'react';
+import find from 'lodash/find';
 import identity from 'lodash/identity';
 import isFunction from 'lodash/isFunction';
 
-const ifCallableElse = ( f, g ) => isFunction( f ) ? f : g;
+const firstCallable = ( ...args ) => find( args, isFunction );
 const mergeProps = ( ...args ) => Object.assign( {}, ...args );
 
 const dispatchObject = action => Dispatcher.handleViewAction( action );
@@ -18,8 +19,8 @@ export const connectDispatcher = ( fromState, fromDispatch ) => Component => pro
 		Component,
 		mergeProps(
 			props,
-			ifCallableElse( fromState, identity )( {} ),
-			ifCallableElse( fromDispatch, identity )( dispatch )
+			firstCallable( fromState, identity )( {} ),
+			firstCallable( fromDispatch, identity )( dispatch )
 		),
 		props.children
 	)

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import Dispatcher from 'dispatcher';
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
@@ -75,7 +76,7 @@ const hasProgressInfo = progress => {
 	return true;
 };
 
-export default React.createClass( {
+export const ImportingPane = React.createClass( {
 	displayName: 'SiteSettingsImportingPane',
 
 	mixins: [ PureRenderMixin ],
@@ -194,9 +195,22 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		const { site: { ID: siteId, name: siteName, single_user_site: hasSingleAuthor } } = this.props;
-		const { importerId, errorData = {}, customData } = this.props.importerStatus;
+		const {
+			importerStatus: {
+				importerId,
+				errorData = {},
+				customData
+			},
+			mapAuthor: mapAuthorFor,
+			site: {
+				ID: siteId,
+				name: siteName,
+				single_user_site: hasSingleAuthor
+			}
+		} = this.props;
+
 		const progressClasses = classNames( 'importer__import-progress', { 'is-complete': this.isFinished() } );
+
 		let { percentComplete, progress, statusMessage } = this.props.importerStatus;
 		let blockingMessage;
 
@@ -221,7 +235,7 @@ export default React.createClass( {
 				{ this.isMapping() &&
 					<MappingPane
 						hasSingleAuthor={ hasSingleAuthor }
-						onMap={ ( source, target ) => mapAuthor( importerId, source, target ) }
+						onMap={ mapAuthorFor( importerId ) }
 						onStartImport={ () => startImporting( this.props.importerStatus ) }
 						{ ...{ siteId } }
 						sourceAuthors={ customData.sourceAuthors }
@@ -240,3 +254,12 @@ export default React.createClass( {
 		);
 	}
 } );
+
+const mapDispatchToProps = () => ( {
+	mapAuthor: importerId => ( source, target ) => Dispatcher.handleViewAction( mapAuthor( importerId, source, target ) )
+} );
+
+export default props => React.createElement(
+	ImportingPane,
+	Object.assign( {}, props, mapDispatchToProps() )
+);

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import Dispatcher from 'dispatcher';
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
@@ -13,6 +12,7 @@ import omit from 'lodash/omit';
  */
 import { mapAuthor, startImporting } from 'lib/importer/actions';
 import { appStates } from 'state/imports/constants';
+import { connectDispatcher } from './dispatcher-converter';
 import ProgressBar from 'components/progress-bar';
 import MappingPane from './author-mapping-pane';
 import Spinner from 'components/spinner';
@@ -255,11 +255,8 @@ export const ImportingPane = React.createClass( {
 	}
 } );
 
-const mapDispatchToProps = () => ( {
-	mapAuthor: importerId => ( source, target ) => Dispatcher.handleViewAction( mapAuthor( importerId, source, target ) )
+const mapDispatchToProps = dispatch => ( {
+	mapAuthor: importerId => ( source, target ) => dispatch( mapAuthor( importerId, source, target ) )
 } );
 
-export default props => React.createElement(
-	ImportingPane,
-	Object.assign( {}, props, mapDispatchToProps() )
-);
+export default connectDispatcher( null, mapDispatchToProps )( ImportingPane );

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -201,7 +201,7 @@ export const ImportingPane = React.createClass( {
 				errorData = {},
 				customData
 			},
-			mapAuthor: mapAuthorFor,
+			mapAuthorFor,
 			site: {
 				ID: siteId,
 				name: siteName,
@@ -256,7 +256,7 @@ export const ImportingPane = React.createClass( {
 } );
 
 const mapDispatchToProps = dispatch => ( {
-	mapAuthor: importerId => ( source, target ) => dispatch( mapAuthor( importerId, source, target ) )
+	mapAuthorFor: importerId => ( source, target ) => dispatch( mapAuthor( importerId, source, target ) )
 } );
 
 export default connectDispatcher( null, mapDispatchToProps )( ImportingPane );


### PR DESCRIPTION
Part of #5302

The importer is being reduxified gradually. The current action creators
all use the `Dispatcher` from Facebook in a tightly integrated way. The
goal of this (and future related) PRs is to try and rid these action
creators from the `Dispatcher` so that they can be ready for Redux
without making a massive changing PR.

The structural change is meant to bridge into using `connect()` with the
store dispatch. Currently it looks odd to pull in the `Dispatcher`
inside a React component, but my hope is that this will foster the
gradual change and will only exist for a short while.

There are no functional or stylistic changes in this patch.

**Open Questions**
 - [ ] Is this too crazy? Would it be better to just create one massive PR to flip over to redux? Please no, oh please don't make me do it! :wink:
 - [ ] Am I missing an obvious alternative to the two given approaches?

cc: @aduth @mtias @ehg 