### PR TITLE
Jetpack SSO: Update footer to add shared details modal dialog

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -258,7 +258,7 @@ const JetpackSSOForm = React.createClass( {
 		const buttons = [
 			{
 				action: 'close',
-				label: this.translate( 'Close', { context: 'Verb. Used in a button to close a modal window.' } )
+				label: this.translate( 'Got it', { context: 'Used in a button. Similar phrase would be, "I understand".' } )
 			}
 		];
 

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -29,6 +29,7 @@ import Site from 'my-sites/site';
 import SitePlaceholder from 'my-sites/site/placeholder';
 import { decodeEntities } from 'lib/formatting';
 import Gridicon from 'components/gridicon';
+import LoggedOutFormFooter from 'components/logged-out-form/footer';
 
 /*
  * Module variables
@@ -76,6 +77,10 @@ const JetpackSSOForm = React.createClass( {
 	onTryAgainClick( event ) {
 		debug( 'Clicked try again link' );
 		this.returnToSiteFallback( event );
+	},
+
+	onClickSharedDetailsModal( event ) {
+		event.preventDefault();
 	},
 
 	returnToSiteFallback( event ) {
@@ -218,14 +223,31 @@ const JetpackSSOForm = React.createClass( {
 							</div>
 						</div>
 
-						<div className="jetpack-connect__sso__actions">
+						<LoggedOutFormFooter className="jetpack-connect__sso__actions">
+							<p className="jetpack-connect__tos-link">
+								{ this.translate( 'By logging in you agree to share {{detailsLink}}details{{/detailsLink}} between WordPress.com and %(siteName)s', {
+									components: {
+										detailsLink: (
+											<a
+												href="#"
+												onClick={ this.onClickSharedDetailsModal }
+												className="jetpack-connect__sso__actions__modal-link"
+											/>
+										)
+									},
+									args: {
+										siteName: get( this.props, 'blogDetails.title' )
+									}
+								} ) }
+							</p>
+
 							<Button
 								primary
 								onClick={ this.onApproveSSO }
 								disabled={ this.isButtonDisabled() }>
 								{ this.translate( 'Log in' ) }
 							</Button>
-						</div>
+						</LoggedOutFormFooter>
 					</Card>
 
 					<LoggedOutFormLinks>

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -353,7 +353,7 @@ const JetpackSSOForm = React.createClass( {
 
 						<LoggedOutFormFooter className="jetpack-connect__sso__actions">
 							<p className="jetpack-connect__tos-link">
-								{ this.translate( 'By logging in you agree to share {{detailsLink}}details{{/detailsLink}} between WordPress.com and %(siteName)s', {
+								{ this.translate( 'By logging in you agree to share {{detailsLink}}details{{/detailsLink}} between WordPress.com and %(siteName)s.', {
 									components: {
 										detailsLink: (
 											<a

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -236,10 +236,10 @@ const JetpackSSOForm = React.createClass( {
 
 		return (
 			<table className="jetpack-connect__sso__shared-details-table">
-				{
-					map( sharedDetails, ( value, key ) => {
+				<tbody>
+					{ map( sharedDetails, ( value, key ) => {
 						return (
-							<tr className="jetpack-connect__sso__shared-detail-row">
+							<tr key={ key } className="jetpack-connect__sso__shared-detail-row">
 								<td className="jetpack-connect__sso__shared-detail-label">
 									{ this.getSharedDetailLabel( key ) }
 								</td>
@@ -248,8 +248,8 @@ const JetpackSSOForm = React.createClass( {
 								</td>
 							</tr>
 						);
-					} )
-				}
+					} ) }
+				</tbody>
 			</table>
 		);
 	},

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -353,7 +353,7 @@ const JetpackSSOForm = React.createClass( {
 
 						<LoggedOutFormFooter className="jetpack-connect__sso__actions">
 							<p className="jetpack-connect__tos-link">
-								{ this.translate( 'By logging in you agree to share {{detailsLink}}details{{/detailsLink}} between WordPress.com and %(siteName)s.', {
+								{ this.translate( 'By logging in you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.', {
 									components: {
 										detailsLink: (
 											<a

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -254,3 +254,49 @@
 .jetpack-connect__site.card {
 	padding: 0;
 }
+
+.jetpack-connect_sso_terms-dialog {
+	max-height: 70vh;
+	overflow-y: auto;
+}
+
+.jetpack-connect__sso__shared-details-table {
+	border-collapse: separate;
+	// border-spacing: 10px;
+}
+
+.jetpack-connect__sso__shared-detail-row {
+	margin-bottom: 16px;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.jetpack-connect__sso__shared-detail-label {
+	font-weight: bold;
+}
+
+.jetpack-connect__sso__shared-detail-value {
+	padding-left: 16px;
+}
+
+.jetpack-connect__sso__shared-detail-label,
+.jetpack-connect__sso__shared-detail-value {
+	padding-bottom: 8px;
+}
+
+@include breakpoint( "<480px" ) {
+	.jetpack-connect__sso__shared-detail-label,
+	.jetpack-connect__sso__shared-detail-value {
+		display: block;
+	}
+
+	.jetpack-connect__sso__shared-detail-label {
+		padding-bottom: 0;
+	}
+
+	.jetpack-connect__sso__shared-detail-value {
+		padding-left: 0;
+	}
+}

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -262,7 +262,6 @@
 
 .jetpack-connect__sso__shared-details-table {
 	border-collapse: separate;
-	// border-spacing: 10px;
 }
 
 .jetpack-connect__sso__shared-detail-row {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -293,7 +293,8 @@ export default {
 				dispatch( {
 					type: JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
 					success: data.success,
-					blogDetails: data.blog_details
+					blogDetails: data.blog_details,
+					sharedDetails: data.shared_details
 				} );
 			} ).catch( ( error ) => {
 				dispatch( {

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -149,7 +149,8 @@ export function jetpackSSO( state = {}, action ) {
 				isValidating: false,
 				validationError: false,
 				nonceValid: action.success,
-				blogDetails: action.blogDetails
+				blogDetails: action.blogDetails,
+				sharedDetails: action.sharedDetails
 			} );
 		case JETPACK_CONNECT_SSO_VALIDATION_ERROR:
 			return Object. assign( state, { isValidating: false, validationError: action.error, nonceValid: false } );

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -48,6 +48,19 @@ describe( 'actions', () => {
 			admin_url: 'https://website.com/wp-admin'
 		};
 
+		const sharedDetails = {
+			ID: 0,
+			login: 'bbquser',
+			email: 'ieatbbq@website.com',
+			url: 'https://website.com',
+			first_name: 'Lou',
+			last_name: 'Bucket',
+			display_name: 'bestbbqtester',
+			description: 'I like BBQ, a lot.',
+			two_step_enabled: 0,
+			external_user_id: 1
+		};
+
 		describe( 'success', () => {
 			before( () => {
 				nock( 'https://public-api.wordpress.com:443' )
@@ -60,7 +73,8 @@ describe( 'actions', () => {
 							'Content-Type': 'application/json'
 						},
 						success: true,
-						blog_details: blogDetails
+						blog_details: blogDetails,
+						shared_details: sharedDetails
 					} );
 			} );
 
@@ -85,6 +99,7 @@ describe( 'actions', () => {
 					expect( spy ).to.have.been.calledWith( {
 						success: true,
 						blogDetails: blogDetails,
+						sharedDetails: sharedDetails,
 						type: JETPACK_CONNECT_SSO_VALIDATION_SUCCESS
 					} );
 				} );

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -39,16 +39,23 @@ const successfulSSOValidation = {
 			ico: '',
 		},
 		URL: 'https://website.com',
-		is_vip: false,
 		admin_url: 'https://website.com/wp-admin'
+	},
+	sharedDetails: {
+		ID: 0,
+		login: 'bbquser',
+		email: 'ieatbbq@website.com',
+		url: 'https://website.com',
+		first_name: 'Lou',
+		last_name: 'Bucket',
+		display_name: 'bestbbqtester',
+		description: 'I like BBQ, a lot.',
+		two_step_enabled: 0,
+		external_user_id: 1
 	}
 };
 
-const falseSSOValidation = {
-	type: JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
-	success: false,
-	blogDetails: {}
-};
+const falseSSOValidation = Object.assign( successfulSSOValidation, { success: false } );
 
 describe( 'reducer', () => {
 	useSandbox( ( sandbox ) => {
@@ -235,16 +242,16 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'should store blog details after successful validation', () => {
+		it( 'should store blog details after validation', () => {
 			const successState = jetpackSSO( undefined, successfulSSOValidation );
 			expect( successState ).to.have.property( 'blogDetails' )
 				.to.be.eql( successfulSSOValidation.blogDetails );
 		} );
 
-		it( 'should store empty object in blog_details when validation is false', () => {
-			const failedState = jetpackSSO( undefined, falseSSOValidation );
-			expect( failedState ).to.have.property( 'blogDetails' )
-				.to.be.eql( {} );
+		it( 'should store shared details after validation', () => {
+			const successState = jetpackSSO( undefined, successfulSSOValidation );
+			expect( successState ).to.have.property( 'sharedDetails' )
+				.to.be.eql( successfulSSOValidation.sharedDetails );
 		} );
 
 		it( 'should set isAuthorizing to false after authorization', () => {


### PR DESCRIPTION
In a design review, it was mentioned that we should display the shared details (information that is shared from WP.com to the remote Jetpack site when a user logs in via SSO) in a modal.

To do this, we needed to add the shared details to the JetpackSSO redux store and then we needed to modify the SSO UI to accommodate. This PR does both.

cc @rickybanister for design review and @lezama for code review.

For design review, let's keep in mind that we have addressed several issues in #5762. So, for this PR, we should focus on the look of the footer (with the log in button) and the modal.

cc @kevko for a review of the wording that we're using in the footer. Specifically, `By logging in you agree to share {{detailsLink}}details{{/detailsLink}} between WordPress.com and %(siteName)s.`

To test:

- Checkout `update/sso-add-shared-details` branch
- Make sure that you're on the latest Jetpack master
- Go to `$site/wp-admin`
- Click "Log in with WordPress.com" button (make sure you test with a user that is not connected to WP.com and with SSO module enabled)
- You should land on `wpcalypso.wordpress.com/jetpack/sso...`.
- Replace `wpcalypso.wordpress.com` with `calypso.localhost:3000`
- You should see something that looks similar to this:
![screen shot 2016-06-02 at 10 59 15 pm](https://cloud.githubusercontent.com/assets/1126811/15768365/bc07fd72-2915-11e6-98ac-c2f4fc304caf.png)

Here's what the modal looks like:

![screen shot 2016-06-02 at 10 50 08 pm](https://cloud.githubusercontent.com/assets/1126811/15768225/ae3674f4-2914-11e6-88ed-4aa235aca7ea.png)

![screen shot 2016-06-02 at 10 50 15 pm](https://cloud.githubusercontent.com/assets/1126811/15768232/b5fcffb4-2914-11e6-92ae-5129b3ca32ed.png)

![screen shot 2016-06-02 at 10 50 19 pm](https://cloud.githubusercontent.com/assets/1126811/15768235/b9305f78-2914-11e6-9f38-b55873dbb6e5.png)