### PR TITLE
Jetpack SSO: Add site card

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -14,6 +14,7 @@ import Main from 'components/main';
 import ConnectHeader from './connect-header';
 import observe from 'lib/mixins/data-observe';
 import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import Button from 'components/button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
@@ -24,6 +25,9 @@ import config from 'config';
 import EmptyContent from 'components/empty-content';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import Site from 'my-sites/site';
+import SitePlaceholder from 'my-sites/site/placeholder';
+import { decodeEntities } from 'lib/formatting';
 
 /*
  * Module variables
@@ -116,6 +120,30 @@ const JetpackSSOForm = React.createClass( {
 		);
 	},
 
+	renderSiteCard() {
+		const { blogDetails } = this.props;
+		let site = <SitePlaceholder />;
+
+		if ( blogDetails ) {
+			const siteObject = {
+				ID: null,
+				url: get( this.props, 'blogDetails.URL', '' ),
+				admin_url: get( this.props, 'blogDetails.admin_url', '' ),
+				domain: get( this.props, 'blogDetails.domain', '' ),
+				icon: get( this.props, 'blogDetails.icon', { img: '', ico: '' } ),
+				is_vip: false,
+				title: decodeEntities( get( this.props, 'blogDetails.title', '' ) )
+			};
+			site = <Site site={ siteObject } />;
+		}
+
+		return (
+			<CompactCard className="jetpack-connect__site">
+				{ site }
+			</CompactCard>
+		);
+	},
+
 	renderNoQueryArgsError() {
 		return (
 			<Main>
@@ -160,6 +188,8 @@ const JetpackSSOForm = React.createClass( {
 							}
 						) }
 					/>
+
+					{ this.renderSiteCard() }
 
 					<Card>
 						{ this.maybeRenderAuthorizationError() }


### PR DESCRIPTION
During a walkthrough of SSO a couple of days ago, @rickybanister pointed out that we needed to add a site card to the SSO approval route `/jetpack/sso/?.*` to provide more context for users.

It looks a bit like this:

![screen shot 2016-06-02 at 11 56 52 pm](https://cloud.githubusercontent.com/assets/1126811/15769150/e53c8106-291d-11e6-8667-76832d80b721.png)

Note: There are some other pending design updates here in #5762.

To test:

- Checkout `update/jetpack-sso-site-card` branch
- Make sure your site is on the latest Jetpack master
- Make sure your site is connected to WP.com, but you are using a non-admin Jetpack user and a different WP.com account than the main one attached to your site
- Go to `$site/wp-admin`
- Click "Log in with WordPress.com" button
- Replace `wpcalypso.wordpress.com` with `calypso.localhost:3000`
- You should see something like the above
- How does it look? There should be no JS errors

cc @rickybanister for design review and @lezama for code review.

