### PR TITLE
Signup: Prefill selected address in domain search

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -207,7 +207,8 @@ module.exports = React.createClass( {
 				withPlansOnly={ isPlansOnlyTest }
 				includeWordPressDotCom
 				isSignupStep
-				showExampleSuggestions />
+				showExampleSuggestions
+				suggestion={ this.props.queryObject ? this.props.queryObject.new : '' } />
 		);
 	},
 


### PR DESCRIPTION
This PR is a fix for #5462 

If there is a supplied address search in the query parameters, it will be properly pre-filled in the domain search now.

How it works now: https://cloudup.com/ceNx12zyqoY

To test:
* Checkout branch 
* Open the local calypso instance like that: `http://calypso.localhost:3000/start?ref=typo&new=totallyanunusedaddress160603`
* Alternative: `https://calypso.live/start?branch=fix/5462-prefill-selected-address-in-domain-search&new=totallyanunusedaddress160603`

* Run through the signup until you reach the domains step
* You should have `totallyanunusedaddress160603` prefilled in the domains search and the search should be started.


cc @sixhours @michaeldcain @coreh @meremagee 