### PR TITLE
Plans: Add FAQ component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -32,6 +32,7 @@
 @import 'components/emojify/style';
 @import 'components/empty-content/style';
 @import 'components/external-link/style';
+@import 'components/faq/style';
 @import 'components/feature-example/style';
 @import 'components/foldable-card/style';
 @import 'components/follow-button/style';

--- a/client/components/faq/README.md
+++ b/client/components/faq/README.md
@@ -1,0 +1,42 @@
+FAQ Component
+=============
+
+FAQ component is a React component to display questions with answers in a neat way. The FAQ questions/answers are left
+aligned to each other and they automatically move to the next line if there's no more available space on the current line.
+
+## Usage
+
+The FAQ component is made of two parts:
+- FAQ parent component which has an optional `heading` prop
+- FAQItem child component(s) which has a `question` and an `answer` props
+
+```jsx
+import FAQ from 'components/faq';
+import FAQItem from 'components/faq/faq-item';
+import i18n from 'lib/mixins/i18n';
+
+export default React.createClass( {
+	displayName: 'MyFAQ',
+
+	render() {
+		return (
+			<FAQ>
+				<FAQItem
+					question="Have more questions?"
+					answer="Need help deciding which plan works for you? Our hapiness engineers are available for any questions you may have."
+				/>
+				<FAQItem
+					question={ i18n.translate( 'A translated question?' ) }
+					answer={ i18n.translate( 'Yeah, we got you covered!' ) }
+				/>
+			</FAQ>
+		);
+	}
+} );
+
+```
+
+## Props
+
+If the `heading` prop is not specified, `FAQ` parent component has a default translated string 'Frequently Asked Questions'.
+Both `question` and `answer` props of the `FAQItem` child component must be specified.

--- a/client/components/faq/docs/example.jsx
+++ b/client/components/faq/docs/example.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FAQ from 'components/faq';
+import FAQItem from 'components/faq/faq-item';
+
+export default React.createClass( {
+	displayName: 'FAQ',
+
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/design/faq">FAQ</a>
+				</h2>
+				<FAQ>
+					<FAQItem
+						question="Have more questions?"
+						answer="Need help deciding which plan works for you? Our hapiness engineers are available for any questions you may have."
+					/>
+					<FAQItem
+						question="Can I cancel my subscription?"
+						answer={ [
+							'Yes. We want you to love everything you do at WordPress.com, so we provide a 30-day refund on all of our plans. ',
+							<a href="#" key="manage-purchases">Manage purchases</a>
+						] }
+					/>
+					<FAQItem
+						question="Do you offer email accounts?"
+						answer="Yes. If you register a new domain with our premium or business plans, you can optionally add Google apps for work. You can also set up email forwarding for any custom domain registered through WordPress.com."
+					/>
+					<FAQItem
+						question="Another FAQ item?"
+						answer="Yes. We need to see how more FAQItems align to each other, that's why."
+					/>
+					<FAQItem
+						question="Wait, but why?"
+						answer="I already told you so. But just to be sure long texts work, let's write a long text as an answer here. Still not finished. I'm writing. Okay, this should be enough. Just. One. More. Whole sentence. Maybe a bit more. This is it."
+					/>
+					<FAQItem
+						question="Have more questions?"
+						answer="Need help deciding which plan works for you? Our hapiness engineers are available for any questions you may have."
+					/>
+					<FAQItem
+						question="Can I cancel my subscription?"
+						answer={ [
+							'Yes. We want you to love everything you do at WordPress.com, so we provide a 30-day refund on all of our plans. ',
+							<a href="#" key="manage-purchases-two">Manage purchases</a>
+						] }
+					/>
+					<FAQItem
+						question="Do you offer email accounts?"
+						answer="Yes. If you register a new domain with our premium or business plans, you can optionally add Google apps for work. You can also set up email forwarding for any custom domain registered through WordPress.com."
+					/>
+				</FAQ>
+			</div>
+		);
+	}
+} );
+

--- a/client/components/faq/faq-item.jsx
+++ b/client/components/faq/faq-item.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+const FAQItem = ( { question, answer } ) => {
+	return (
+		<li className="faq__item">
+			<h4 className="faq__question">{ question }</h4>
+			<p className="faq__answer">{ answer }</p>
+		</li>
+	);
+};
+
+FAQItem.propTypes = {
+	// Translations can include <a> links, that's why propType `node` is needed.
+	question: PropTypes.node.isRequired,
+	answer: PropTypes.node.isRequired
+};
+
+export default FAQItem;
+

--- a/client/components/faq/index.jsx
+++ b/client/components/faq/index.jsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+const FAQ = ( { heading, items } ) => {
+	return (
+		<div className="faq">
+			<h1 className="faq__heading">{ heading }</h1>
+			<ul className="faq__list">
+				{
+					items.map( ( { question, answer }, ind ) =>
+						<li className="faq__item" key={ `faq-${ ind }` }>
+							<h4 className="faq__question">{ question }</h4>
+							<p className="faq__answer">{ answer }</p>
+						</li>
+					)
+				}
+			</ul>
+		</div>
+	);
+};
+
+FAQ.propTypes = {
+	heading: PropTypes.string.isRequired,
+	items: PropTypes.arrayOf(
+		PropTypes.shape( {
+			question: PropTypes.string.isRequired,
+			answer: PropTypes.node.isRequired
+		} )
+	).isRequired
+};
+
+export default FAQ;
+

--- a/client/components/faq/index.jsx
+++ b/client/components/faq/index.jsx
@@ -1,35 +1,23 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
 
-const FAQ = ( { heading, items } ) => {
+/**
+ * Internal dependencies
+ */
+import localize from 'lib/mixins/i18n/localize';
+
+function FAQ( { translate, heading = translate( 'Frequently Asked Questions' ), children } ) {
 	return (
 		<div className="faq">
 			<h1 className="faq__heading">{ heading }</h1>
 			<ul className="faq__list">
-				{
-					items.map( ( { question, answer }, ind ) =>
-						<li className="faq__item" key={ `faq-${ ind }` }>
-							<h4 className="faq__question">{ question }</h4>
-							<p className="faq__answer">{ answer }</p>
-						</li>
-					)
-				}
+				{ children }
 			</ul>
 		</div>
 	);
-};
+}
 
-FAQ.propTypes = {
-	heading: PropTypes.string.isRequired,
-	items: PropTypes.arrayOf(
-		PropTypes.shape( {
-			question: PropTypes.string.isRequired,
-			answer: PropTypes.node.isRequired
-		} )
-	).isRequired
-};
-
-export default FAQ;
+export default localize( FAQ );
 

--- a/client/components/faq/style.scss
+++ b/client/components/faq/style.scss
@@ -1,0 +1,69 @@
+.faq {
+	padding: 0 16px;
+
+	@include breakpoint( ">480px" ) {
+		padding: 0 24px;
+	}
+
+	@include breakpoint( ">660px" ) {
+		padding: 0;
+	}
+}
+
+.faq__heading {
+	margin-bottom: 32px;
+	font-size: 24px;
+	font-weight: 300;
+	color: $gray;
+}
+
+.faq__list {
+	display: flex;
+	flex-wrap: wrap;
+	margin: 0;
+	list-style: none;
+}
+
+.faq__item {
+	width: 100%;
+	margin-bottom: 16px;
+	font-size: 14px;
+	line-height: 21px;
+
+	@media
+		(min-width: 480px) and (max-width: 660px),
+		(min-width: 800px) and (max-width: 1040px) {
+			width: calc( ( 100% - 24px ) / 2 );
+			margin-left: 24px;
+
+			&:nth-child( 2n+1 ) {
+				margin-left: 0;
+			}
+	}
+
+	@include breakpoint( ">1040px" ) {
+		width: calc( ( 100% - 48px ) / 3 );
+		margin-left: 24px;
+
+		&:nth-child( 3n+1 ) {
+			margin-left: 0;
+		}
+	}
+}
+
+.faq__question {
+	margin-bottom: 12px;
+	font-weight: 600;
+	color: darken( $gray, 10% );
+}
+
+.faq__answer {
+	margin-bottom: 1em;
+	color: $gray;
+
+	a {
+		color: $blue-medium;
+		text-decoration: underline;
+	}
+}
+

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -55,6 +55,7 @@ import FeatureGate from 'components/feature-example/docs/example';
 import FilePickers from 'components/file-picker/docs/example';
 import Collection from 'devdocs/design/search-collection';
 import fetchComponentsUsageStats from 'state/components-usage-stats/actions';
+import FAQ from 'components/faq/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -107,6 +108,7 @@ let DesignAssets = React.createClass( {
 					<DatePicker />
 					<DropZones searchKeywords="drag" />
 					<ExternalLink />
+					<FAQ />
 					<FeatureGate />
 					<FilePickers />
 					<FoldableCard />


### PR DESCRIPTION
Add a FAQ component. Design and original code by @adambbecker from #5715.

## Visuals

![selection_010](https://cloud.githubusercontent.com/assets/4988512/15786978/b62ed556-29bf-11e6-8ff0-3b488f072c1f.png)

## Behavior

The component should display small boxes with a question in bold and its answer underneath. These boxes should align left to each other.


## Testing

1. Pull and checkout this branch.
2. Go to `http://calypso.localhost:3000/devdocs/design/faq`.
3. Can you see the `FAQ` component? Is it working?

cc @rralian 