### PR TITLE
WebPreview: remove special case for spinner's vertical position

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -159,10 +159,6 @@
 	position: absolute;
 		top: 45%;
 		left: 50%;
-
-	@include breakpoint( "<660px" ) {
-		top: 20%;
-	}
 }
 
 .web-preview__loading-message {


### PR DESCRIPTION
The WebPreview's loading spinner is positioned at 20% top on mobile, but 50% everywhere else. This commit removes this special case. 

Closes #5696.