### PR TITLE
Editor: Update page templates on theme change

### DIFF
--- a/client/components/data/page-templates-data/index.jsx
+++ b/client/components/data/page-templates-data/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import debugModule from 'debug';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import PageTemplatesStore from 'lib/page-templates/store';
 import PageTemplatesActions from 'lib/page-templates/actions';
 import sitesList from 'lib/sites-list';
 import passToChildren from 'lib/react-pass-to-children';
+import { getCurrentTheme } from 'state/themes/current-theme/selectors';
 
 /**
  * Module variables
@@ -18,10 +20,10 @@ import passToChildren from 'lib/react-pass-to-children';
 const sites = sitesList();
 const debug = debugModule( 'calypso:page-templates-data' );
 
-export default React.createClass( {
-	displayName: 'PageTempaltesData',
+const PageTemplatesData = React.createClass( {
 
 	propTypes: {
+		currentTheme: React.PropTypes.object,
 		siteId: PropTypes.number.isRequired
 	},
 
@@ -49,6 +51,10 @@ export default React.createClass( {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.siteId === this.props.siteId ) {
+			if ( nextProps.currentTheme && nextProps.currentTheme.stylesheet !== this.activeTheme ) {
+				PageTemplatesActions.fetchPageTemplates( this.props.siteId );
+				this.activeTheme = nextProps.currentTheme.stylesheet;
+			}
 			return;
 		}
 		this._fetchIfUnfetched( nextProps.siteId );
@@ -97,3 +103,9 @@ export default React.createClass( {
 		this.setState( this._getUpdatedState( siteId ) );
 	}
 } );
+
+export default connect(
+	( state, ownProps ) => (
+		{ currentTheme: getCurrentTheme( state, ownProps.siteId ) }
+	)
+)( PageTemplatesData );

--- a/client/lib/page-templates/actions.js
+++ b/client/lib/page-templates/actions.js
@@ -16,7 +16,7 @@ const PageTemplatesActions = {
 			debug( 'already fetching pageTemplates', siteId );
 			return;
 		}
-		debug( 'fetcing pageTemplates', siteId );
+		debug( 'fetching pageTemplates', siteId );
 		Dispatcher.handleViewAction( {
 			type: 'FETCHING_PAGE_TEMPLATES',
 			siteId: siteId


### PR DESCRIPTION
Fixes #5387 

Ideally, we could move the page templates store to Redux, but this could act as a temporary fix. I connected the PageTemplatesData component to the currentTheme state. `currentTheme` is then passed in as a prop using [`getCurrentTheme`](https://github.com/Automattic/wp-calypso/blob/3ede1a2bef5bbe24baa7d929338c23603f5dc6e0/client/state/themes/current-theme/selectors.js#L3). In `componentWillReceiveProps`, we're checking if `this.props.currentTheme.stylesheet !== this.activeTheme`. Both of these URLs will be in the format `pub/hemingway-rewritten` for free themes or `premium/affinity` for premium themes. If they're equal, nothing happens. If they're not equal, we trigger a fetch and update `this.activeTheme` accordingly so we don't refetch unnecessarily. 

Using `this.props.currentTheme.stylesheet` feels a bit weird/non-intuitive, but it's the best comparison I could find since we're using `theme_slug` elsewhere as `this.activeTheme`. We don't have [a corresponding `theme_slug` on in the theme details currently.](https://github.com/Automattic/wp-calypso/blob/3ede1a2bef5bbe24baa7d929338c23603f5dc6e0/client/state/themes/theme-details/reducer.js)

## To Test
1. Checkout this branch and get it up and running
2. Activate "Scratchpad" on your site from http://calypso.localhost:3000/design/site.wordpress.com. Scratchpad doesn't have page templates.
3. Click "Add" to start a new page. Check under Page Options. You shouldn't see a page template option.
4. Navigate back to choose a new theme (don't refresh)
5. Activate Hemingway Rewritten (has page templates)
6. Click "Add" to start a new page and check under Page Options again. You should see page templates.

## GIF
(I reversed the steps in the GIF)
![themechange](https://cloud.githubusercontent.com/assets/7240478/15782402/5627ed58-2967-11e6-9ae5-cdfa019cc3ae.gif)