### PR TITLE
State: schema for Jetpack Connect authorization flow

### DIFF
--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -35,7 +35,7 @@ import {
 } from 'state/action-types';
 
 import { isValidStateWithSchema } from 'state/utils';
-import { jetpackConnectSessionsSchema } from './schema';
+import { jetpackConnectSessionsSchema, jetpackConnectAuthorizeSchema } from './schema';
 
 const defaultAuthorizeState = {
 	queryObject: {},
@@ -133,8 +133,12 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, autoAuthorize: true, userData: action.userData, bearerToken: action.data.bearer_token } );
 		case JETPACK_CONNECT_REDIRECT_WP_ADMIN:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
-		case SERIALIZE:
 		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, jetpackConnectAuthorizeSchema ) ) {
+				return state;
+			}
+			return {};
+		case SERIALIZE:
 			return state;
 	}
 	return state;

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -32,7 +32,21 @@ export const jetpackConnectAuthorizeSchema = {
 				manageActivated: { type: 'boolean' },
 				manageActivatedError: { type: 'boolean' },
 				plansUrl: { type: 'string' },
-				queryObject: { type: 'object' },
+				queryObject: {
+					type: 'object',
+					properties: {
+						_wp_nonce: { type: 'string' },
+						client_id: { type: 'string' },
+						from: { type: 'string' },
+						jp_version: { type: 'string' },
+						redirect_after_auth: { type: 'string' },
+						redirect_uri: { type: 'string' },
+						scope: { type: 'string' },
+						secret: { type: 'string' },
+						site: { type: 'string' },
+						state: { type: 'string' }
+					}
+				},
 				siteReceived: { type: 'boolean' }
 			},
 			additionalProperties: false

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -34,18 +34,23 @@ export const jetpackConnectAuthorizeSchema = {
 				plansUrl: { type: 'string' },
 				queryObject: {
 					type: 'object',
+					required: [ '_wp_nonce', 'client_id', 'redirect_uri', 'scope', 'secret', 'site', 'state' ],
 					properties: {
 						_wp_nonce: { type: 'string' },
 						client_id: { type: 'string' },
 						from: { type: 'string' },
+						home_url: { type: 'string' },
 						jp_version: { type: 'string' },
 						redirect_after_auth: { type: 'string' },
 						redirect_uri: { type: 'string' },
 						scope: { type: 'string' },
 						secret: { type: 'string' },
 						site: { type: 'string' },
+						site_icon: { type: 'string' },
+						site_url: { type: 'string' },
 						state: { type: 'string' }
-					}
+					},
+					additionalProperties: false
 				},
 				siteReceived: { type: 'boolean' }
 			},

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -13,3 +13,29 @@ export const jetpackConnectSessionsSchema = {
 		}
 	}
 };
+
+export const jetpackConnectAuthorizeSchema = {
+	type: 'object',
+	additionalProperties: false,
+	patternProperties: {
+		'^.+$': {
+			type: 'object',
+			required: [ 'queryObject' ],
+			properties: {
+				activateManageSecret: { type: 'string' },
+				authorizeError: { type: 'boolean' },
+				authorizeSuccess: { type: 'boolean' },
+				autoAuthorize: { type: 'boolean' },
+				isActivating: { type: 'boolean' },
+				isAuthorizing: { type: 'boolean' },
+				isRedirectingToWpAdmin: { type: 'boolean' },
+				manageActivated: { type: 'boolean' },
+				manageActivatedError: { type: 'boolean' },
+				plansUrl: { type: 'string' },
+				queryObject: { type: 'object' },
+				siteReceived: { type: 'boolean' }
+			},
+			additionalProperties: false
+		}
+	}
+};


### PR DESCRIPTION
This PR adds a schema for the Jetpack Connect authorization flow. It gives a clearer picture of what our state looks like. There are no functional / UI changes here, other than the state will not persist if it is not valid with the schema.

cc: @johnHackworth 