### PR TITLE
Jetpack Connect Authorize: only show site card on latest Jetpack

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -34,6 +34,7 @@ import { getSiteByUrl } from 'state/sites/selectors';
 import Spinner from 'components/spinner';
 import Site from 'my-sites/site';
 import { decodeEntities } from 'lib/formatting';
+import versionCompare from 'lib/version-compare';
 
 /**
  * Constants
@@ -78,6 +79,9 @@ const LoggedOutForm = React.createClass( {
 		const headerText = i18n.translate( 'Create your account' );
 		const subHeaderText = i18n.translate( 'You are moments away from connecting your site.' );
 		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
+			? <SiteCard queryObject={ queryObject } />
+			: null;
 
 		return(
 			<div>
@@ -85,7 +89,7 @@ const LoggedOutForm = React.createClass( {
 					showLogo={ false }
 					headerText={ headerText }
 					subHeaderText={ subHeaderText } />
-				<SiteCard queryObject={ queryObject } />
+				{ siteCard }
 			</div>
 		);
 	},
@@ -188,6 +192,9 @@ const LoggedInForm = React.createClass( {
 		const subHeaderText = ( isConnected )
 			? i18n.translate( 'Thank you for flying with Jetpack' )
 			: i18n.translate( 'Jetpack is finishing up the connection process' );
+		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
+			? <SiteCard queryObject={ queryObject } />
+			: null;
 
 		return(
 			<div>
@@ -195,7 +202,7 @@ const LoggedInForm = React.createClass( {
 					showLogo={ false }
 					headerText={ headerText }
 					subHeaderText={ subHeaderText } />
-				<SiteCard queryObject={ queryObject } />
+				{ siteCard }
 			</div>
 		);
 	},


### PR DESCRIPTION
The site card can only be shown on versions of jetpack greater than 4.0.3

To test:
- run this branch at calypso.localhost:3000
- go to calypso.localhost:3000/jetpack/connect
- connect an un-connected Jetpack site running latest stable ( 4.0.3 )
- you should see no site card

![screen shot 2016-06-03 at 8 13 32 pm](https://cloud.githubusercontent.com/assets/2694219/15796224/590938ea-29c8-11e6-8b68-060aef73dba6.png)


Repeat steps for a jetpack site running the latest master ( 4.0.4-alpha ). You should see a site card

![screen shot 2016-06-03 at 8 14 48 pm](https://cloud.githubusercontent.com/assets/2694219/15796229/72e01ab8-29c8-11e6-882a-ea6e3b87bde1.png)





cc: @johnHackworth 