### PR TITLE
GuidedTours: Add step explaining what the preview is before showing the close-preview step.

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -43,7 +43,7 @@ function get( site ) {
 			placement: 'beside',
 			next: ( () => {
 				if ( site && site.is_previewable ) {
-					return 'preview';
+					return 'click-preview';
 				}
 				if ( site && site.is_customizable ) {
 					return 'themes';
@@ -51,7 +51,7 @@ function get( site ) {
 				return 'finish';
 			}() ),
 		},
-		preview: {
+		'click-preview': {
 			target: 'site-card-preview',
 			arrow: 'top-left',
 			type: 'ActionStep',
@@ -59,11 +59,21 @@ function get( site ) {
 				context: "Click your site's name to continue.",
 			} ),
 			placement: 'below',
-			text: i18n.translate( 'Open {{strong}}Preview{{/strong}} to see what your site looks like.', {
+			text: i18n.translate( "This shows your currently {{strong}}selected site{{/strong}}'s name and address.", {
 				components: {
 					strong: <strong />,
 				}
 			} ),
+			next: 'in-preview',
+		},
+		'in-preview': {
+			text: i18n.translate( "This is your site's {{strong}}Preview{{/strong}}. From here you can see how your site looks to others.", {
+				components: {
+					strong: <strong />,
+				}
+			} ),
+			type: 'BasicStep',
+			placement: 'center',
 			next: 'close-preview',
 		},
 		'close-preview': {
@@ -72,11 +82,7 @@ function get( site ) {
 			type: 'ActionStep',
 			placement: 'beside',
 			icon: 'cross-small',
-			text: i18n.translate( 'Below you can see a {{strong}}Preview{{/strong}} of your site. You can come back here anytime.', {
-				components: {
-					strong: <strong />,
-				}
-			} ),
+			text: i18n.translate( 'Take a look at your site—and then close the site preview. You can come back here anytime.' ),
 			next: ( () => {
 				if ( site && site.is_customizable ) {
 					return 'themes';
@@ -112,5 +118,5 @@ function get( site ) {
 
 export default {
 	get,
-	version: '20160421',
+	version: '20160601',
 };


### PR DESCRIPTION
Allows for a better view of the WebPreview controls, and site logo (across both steps).

![step-preview](https://cloud.githubusercontent.com/assets/215074/15788419/6419f976-29bf-11e6-9936-434606189453.gif)

