### PR TITLE
Plans: plans compare back navigates to last history position

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -63,20 +63,14 @@ const PlansCompare = React.createClass( {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked View All Plans' );
 	},
 
-	goBack() {
-		if ( this.props.backUrl ) {
-			return page( this.props.backUrl );
-		}
-
+	getPlanURL() {
 		const selectedSite = this.props.selectedSite;
-		let plansLink = '/plans';
+		return selectedSite ? `/plans/${ selectedSite.slug }` : '/plans';
+	},
 
-		if ( selectedSite ) {
-			plansLink += '/' + selectedSite.slug;
-		}
-
+	goBack() {
 		this.recordViewAllPlansClick();
-		page( plansLink );
+		return page.back( this.props.backUrl || this.getPlanURL() );
 	},
 
 	isDataLoading() {


### PR DESCRIPTION
This PR fixes #5795 where clicking on the 'back' button on the header cake would always navigate to a plan page regardless of where you navigated from.

## Testing Instructions

### Back From My Plan
- Switch to a site with a Premium or Business Plan
- Navigate to http://calypso.localhost:3000/plans/my-plan/yoursite
- Scroll to the bottom of the page and click on "Missing some features? Compare our different plans"
- This should navigate to plans/compare
- Click on the back button at the top of the page
- Page should navigate back to the my-plan page

### Back with no history
- Navigate to http://calypso.localhost:3000/plans/yoursite
- Perform a hard browser refresh
- Click on the back button at the top of the page
- Page should navigate back to the plan page

cc @apeatling @rralian @artpi 