### PR TITLE
Remove the feature flag for the importer

### DIFF
--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -16,9 +16,8 @@ module.exports = function() {
 	 */
 	page( '/settings', controller.siteSelection, settingsController.redirectToGeneral );
 
-	if ( config.isEnabled( 'manage/import' ) ) {
-		page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
-	}
+	page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
+
 	if ( config.isEnabled( 'manage/export' ) ) {
 		page( '/settings/export/:site_id', controller.siteSelection, controller.navigation, settingsController.exportSite );
 	}

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -156,15 +156,12 @@ export class SiteSettingsComponent extends Component {
 						</NavItem>
 					}
 
-					{
-						config.isEnabled( 'manage/import' ) &&
-							<NavItem
-								path={ this.getImportPath() }
-								selected={ section === 'import' }
-								isExternalLink={ !! site.jetpack } >
-									{ strings.import }
-							</NavItem>
-					}
+					<NavItem
+						path={ this.getImportPath() }
+						selected={ section === 'import' }
+						isExternalLink={ !! site.jetpack } >
+							{ strings.import }
+					</NavItem>
 
 					{
 						config.isEnabled( 'manage/export' ) &&

--- a/config/development.json
+++ b/config/development.json
@@ -53,7 +53,6 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/export": true,
-		"manage/import": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -32,7 +32,6 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/export": true,
-		"manage/import": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -30,7 +30,6 @@
 		"manage/jetpack-plans": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
-		"manage/import": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
 		"manage/people": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -32,7 +32,6 @@
 		"manage/edit-user": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,
-		"manage/import": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/test.json
+++ b/config/test.json
@@ -48,7 +48,6 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/export": true,
-		"manage/import": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,
 		"manage/media": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,7 +38,6 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/export": true,
-		"manage/import": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,


### PR DESCRIPTION
Closes #5353 

This patch will enable the importer on all remaining Calypso platforms,
including the desktop client.

It also entirely removes the config flag and all of the corresponding
config-flag checks.

cc: @rachelmcr @johngodley @roundhill @dllh 