### PR TITLE
Plans: clicking on any part of the card should select a plan

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -166,6 +166,11 @@ const PlanActions = React.createClass( {
 		if ( this.props.onSelectPlan ) {
 			return this.props.onSelectPlan( cartItem );
 		}
+
+		if ( ! cartItem ) {
+			return;
+		}
+
 		upgradesActions.addItem( cartItem );
 
 		const checkoutPath = this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -69,9 +69,13 @@ const Plan = React.createClass( {
 		);
 	},
 
-	showDetails() {
+	showDetails( event ) {
 		if ( 'function' === typeof ( this.props.onOpen ) ) {
 			this.props.onOpen( this.props.plan.product_id );
+		}
+		// clicking a card should select a plan, see issue 4486
+		if ( this.imagePlanActionRef ) {
+			this.imagePlanActionRef.handleSelectPlan( event );
 		}
 	},
 
@@ -186,9 +190,14 @@ const Plan = React.createClass( {
 		);
 	},
 
+	setImagePlanActionRef( imagePlanActionRef ) {
+		this.imagePlanActionRef = imagePlanActionRef;
+	},
+
 	getImagePlanAction() {
 		return (
 			<PlanActions
+				ref={ this.setImagePlanActionRef }
 				plan={ this.props.plan }
 				isInSignup={ this.props.isInSignup }
 				onSelectPlan={ this.props.onSelectPlan }


### PR DESCRIPTION
This PR fixes #4486, where clicking below or above the pen/pencil icons would not select a plan.

![ddd5f55e-f827-11e5-8081-fcf7cf89beb5](https://cloud.githubusercontent.com/assets/1270189/15793951/20741b8e-299c-11e6-955e-3880dcdc245c.png)

## Testing instructions

### New User Flow
- Log out
- Load Calypso
- Start a signup flow
- Progress through the flow until you get to the plan selection screen (# of steps depends on the flow)
- Try to click on the plan card / header (or anywhere except the button or illustration)
- This branch will succeed, and prod will fail

### Plan Upgrade
- Navigate to http://calypso.localhost:3000/plans
- Select a site with a free plan
- Attempt to click on the Premium card as shown in the image above.
- This branch will succeed, and prod will fail

cc @jblz @rralian @retrofox 
