### PR TITLE
Fix regression that caused Stats to show instead of sidebar on mobile after picking a site

### DIFF
--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -55,7 +55,14 @@ const SitePicker = React.createClass( {
 	},
 
 	onClose: function( event ) {
-		this.closePicker();
+		if ( event.key === 'Escape' ) {
+			this.closePicker();
+		} else {
+			// We use setNext here, because on mobile we want to show sidebar
+			// instead of Stats page after picking a site
+			this.props.layoutFocus.setNext( 'sidebar' );
+			this.scrollToTop();
+		}
 		this.props.onClose( event );
 	},
 


### PR DESCRIPTION
In `onClose` we need to determine if the event is called after user pressed escape, or when user picked a site. The difference between their behavior is whether they are calling `layoutFocus.set` (to
immediately hide the picker) or `layoutFocus.setNext`, that will show sidebar after navigation to picked site.

Fixes #5804 