### PR TITLE
Testing: Refactor wp localization tests to remove rewire

### DIFF
--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -14,6 +14,24 @@ import { getCurrentUserLocale } from 'state/current-user/selectors';
 let locale;
 
 /**
+ * Setter function for internal locale value
+ *
+ * @param {String} localeToSet Locale to set
+ */
+export function setLocale( localeToSet ) {
+	locale = localeToSet;
+}
+
+/**
+ * Getter function for internal locale value
+ *
+ * @return {String} Locale
+ */
+export function getLocale() {
+	return locale;
+}
+
+/**
  * Given a WPCOM parameter set, modifies the query such that a non-default
  * locale is added to the query parameter.
  *
@@ -29,7 +47,7 @@ export function addLocaleQueryParam( params ) {
 	return Object.assign( params, {
 		query: qs.stringify( Object.assign( query, { locale } ) )
 	} );
-};
+}
 
 /**
  * Modifies a WPCOM instance, returning an updated instance with included
@@ -65,10 +83,10 @@ export function injectLocalization( wpcom ) {
  * @param {Object} store Redux store instance
  */
 export function bindState( store ) {
-	function setLocale() {
-		locale = getCurrentUserLocale( store.getState() );
+	function setLocaleFromState() {
+		setLocale( getCurrentUserLocale( store.getState() ) );
 	}
 
-	store.subscribe( setLocale );
-	setLocale();
+	store.subscribe( setLocaleFromState );
+	setLocaleFromState();
 }

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import rewire from 'rewire';
 import mockery from 'mockery';
 import sinon from 'sinon';
 
@@ -12,8 +11,8 @@ import sinon from 'sinon';
 import useMockery from 'test/helpers/use-mockery';
 
 describe( 'index', () => {
-	let localization, addLocaleQueryParam, injectLocalization, bindState;
-	let getCurrentUserLocaleMock = sinon.stub();
+	let getCurrentUserLocaleMock, localization, addLocaleQueryParam,
+		injectLocalization, bindState, setLocale, getLocale;
 
 	useMockery();
 
@@ -24,14 +23,17 @@ describe( 'index', () => {
 		} );
 
 		// Prepare module for rewiring
-		localization = rewire( '../' );
-		addLocaleQueryParam = localization.addLocaleQueryParam;
-		injectLocalization = localization.injectLocalization;
-		bindState = localization.bindState;
+		( {
+			addLocaleQueryParam,
+			injectLocalization,
+			bindState,
+			setLocale,
+			getLocale
+		} = require( '../' ) );
 	} );
 
 	beforeEach( () => {
-		localization.__set__( 'locale', undefined );
+		setLocale( undefined );
 	} );
 
 	describe( '#addLocaleQueryParam()', () => {
@@ -42,14 +44,14 @@ describe( 'index', () => {
 		} );
 
 		it( 'should not modify params if locale is default', () => {
-			localization.__set__( 'locale', 'en' );
+			setLocale( 'en' );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
 
 			expect( params ).to.eql( { query: 'search=foo' } );
 		} );
 
 		it( 'should include the locale query parameter for a non-default locale', () => {
-			localization.__set__( 'locale', 'fr' );
+			setLocale( 'fr' );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
 
 			expect( params ).to.eql( {
@@ -75,7 +77,7 @@ describe( 'index', () => {
 		} );
 
 		it( 'should not modify params if `withLocale` not used', ( done ) => {
-			localization.__set__( 'locale', 'fr' );
+			setLocale( 'fr' );
 			let wpcom = {
 				request( params ) {
 					expect( params.query ).to.equal( 'search=foo' );
@@ -88,7 +90,7 @@ describe( 'index', () => {
 		} );
 
 		it( 'should modify params if `withLocale` is used', ( done ) => {
-			localization.__set__( 'locale', 'fr' );
+			setLocale( 'fr' );
 			let wpcom = {
 				request( params ) {
 					expect( params.query ).to.equal( 'search=foo&locale=fr' );
@@ -101,7 +103,7 @@ describe( 'index', () => {
 		} );
 
 		it( 'should not modify the request after `withLocale` is used', ( done ) => {
-			localization.__set__( 'locale', 'fr' );
+			setLocale( 'fr' );
 			let assert = false;
 			let wpcom = {
 				request( params ) {
@@ -125,7 +127,7 @@ describe( 'index', () => {
 		it( 'should set initial locale from state', () => {
 			getCurrentUserLocaleMock = sinon.stub().returns( 'fr' );
 			bindState( { subscribe() {}, getState() {} } );
-			expect( localization.__get__( 'locale' ) ).to.equal( 'fr' );
+			expect( getLocale() ).to.equal( 'fr' );
 		} );
 
 		it( 'should subscribe to the store, setting locale on change', () => {
@@ -139,7 +141,7 @@ describe( 'index', () => {
 			getCurrentUserLocaleMock = sinon.stub().returns( 'de' );
 			listener();
 
-			expect( localization.__get__( 'locale' ) ).to.equal( 'de' );
+			expect( getLocale() ).to.equal( 'de' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Related: #1515

This pull request seeks to refactor `client/lib/wp/localization` to remove its dependency on `rewire`, in an effort to move forward with Calypo's Babel 6 migration.

__Testing instructions:__

Ensure that Mocha tests continue to pass.

/cc @gziolo 