### PR TITLE
Testing: Refactor terms tests to remove rewire

### DIFF
--- a/client/lib/terms/category-store-factory.js
+++ b/client/lib/terms/category-store-factory.js
@@ -3,13 +3,8 @@
  **/
 var CategoryStore = require( './category-store' );
 
-/**
- * Module variables
- **/
-var _categoryStores = {};
-
 function categoryStoreFactory( storeId ) {
-	var categoryStore = _categoryStores[ storeId ];
+	var categoryStore = categoryStoreFactory._categoryStores[ storeId ];
 
 	if ( categoryStore ) {
 		return categoryStore;
@@ -17,9 +12,11 @@ function categoryStoreFactory( storeId ) {
 
 	categoryStore = new CategoryStore( storeId );
 
-	_categoryStores[ storeId ] = categoryStore;
+	categoryStoreFactory._categoryStores[ storeId ] = categoryStore;
 
 	return categoryStore;
 }
+
+categoryStoreFactory._categoryStores = {};
 
 module.exports = categoryStoreFactory;

--- a/client/lib/terms/tag-store.js
+++ b/client/lib/terms/tag-store.js
@@ -16,15 +16,13 @@ var Dispatcher = require( 'dispatcher' ),
 * Module Variables
 */
 
-var _tagIds = {},
-	_siteStatus = {},
-	ActionTypes = TermsConstants.action;
+var ActionTypes = TermsConstants.action;
 
 var TagStore = {};
 
 function ensureSiteHasStatus( siteId ) {
-	if ( ! ( siteId in _siteStatus ) ) {
-		_siteStatus[ siteId ] = {
+	if ( ! ( siteId in TagStore._siteStatus ) ) {
+		TagStore._siteStatus[ siteId ] = {
 			page: 1,
 			isFetchingPage: false
 		};
@@ -34,24 +32,24 @@ function ensureSiteHasStatus( siteId ) {
 function updateSiteStatus( siteId, values ) {
 	debug( 'updateSiteStatus', siteId, values );
 	ensureSiteHasStatus( siteId );
-	assign( _siteStatus[ siteId ], values );
+	assign( TagStore._siteStatus[ siteId ], values );
 }
 
 function updateNextPage( siteId, data ) {
 	ensureSiteHasStatus( siteId );
 
-	if ( data.found !== _tagIds[ siteId ].length && data.terms.length ) {
+	if ( data.found !== TagStore._tagIds[ siteId ].length && data.terms.length ) {
 		debug( 'updateNextPage - site has next page', siteId, data );
-		_siteStatus[ siteId ].page++;
+		TagStore._siteStatus[ siteId ].page++;
 	} else {
 		debug( 'updateNextPage - site has no more pages', siteId, data );
-		delete _siteStatus[ siteId ].page;
+		delete TagStore._siteStatus[ siteId ].page;
 	}
 }
 
 function ensureTagIds( siteId ) {
-	if ( ! ( siteId in _tagIds ) ) {
-		_tagIds[ siteId ] = [];
+	if ( ! ( siteId in TagStore._tagIds ) ) {
+		TagStore._tagIds[ siteId ] = [];
 	}
 }
 
@@ -61,12 +59,12 @@ function receiveTags( siteId, tags ) {
 
 	tags.forEach( function( tag ) {
 		var tagId = tag.ID,
-			existingIndex = _tagIds[ siteId ].indexOf( tagId );
+			existingIndex = TagStore._tagIds[ siteId ].indexOf( tagId );
 
 		if ( -1 !== existingIndex ) {
-			_tagIds[ siteId ].splice( existingIndex, 1, tagId );
+			TagStore._tagIds[ siteId ].splice( existingIndex, 1, tagId );
 		} else {
-			_tagIds[ siteId ].push( tagId );
+			TagStore._tagIds[ siteId ].push( tagId );
 		}
 	} );
 }
@@ -77,12 +75,16 @@ TagStore._queryDefaults = {
 	order: 'DESC'
 };
 
+TagStore._tagIds = {};
+
+TagStore._siteStatus = {};
+
 TagStore.hasNextPage = function( siteId ) {
-	return ! ( siteId in _siteStatus ) || !! _siteStatus[ siteId ].page;
+	return ! ( siteId in TagStore._siteStatus ) || !! TagStore._siteStatus[ siteId ].page;
 };
 
 TagStore.isFetchingPage = function( siteId ) {
-	return ( siteId in _siteStatus ) && _siteStatus[ siteId ].isFetchingPage;
+	return ( siteId in TagStore._siteStatus ) && TagStore._siteStatus[ siteId ].isFetchingPage;
 };
 
 TagStore.get = function( siteId, tagId ) {
@@ -90,7 +92,7 @@ TagStore.get = function( siteId, tagId ) {
 };
 
 TagStore.all = function( siteId ) {
-	var ids = _tagIds[ siteId ],
+	var ids = TagStore._tagIds[ siteId ],
 		tags;
 
 	if ( ids ) {
@@ -107,7 +109,7 @@ TagStore.getQueryParams = function( siteId ) {
 	return assign(
 		{},
 		TagStore._queryDefaults,
-		{ page: _siteStatus[ siteId ].page }
+		{ page: TagStore._siteStatus[ siteId ].page }
 	);
 };
 

--- a/client/lib/terms/test/actions.js
+++ b/client/lib/terms/test/actions.js
@@ -1,25 +1,23 @@
 /**
  * External dependencies
  */
-var rewire = require( 'rewire' ),
-	assert = require( 'chai' ).assert,
-	sinon = require( 'sinon' ),
-	mockery = require( 'mockery' );
+import { assert } from 'chai';
+import sinon from 'sinon';
+import mockery from 'mockery';
 
 /**
  * Internal dependencies
  */
-var useMockery = require( 'test/helpers/use-mockery' ),
-	data = require( './data' ),
-	TermsConstants = require( '../constants' );
+import useMockery from 'test/helpers/use-mockery';
+import data from './data';
+import TermsConstants from '../constants';
 
-var ActionTypes = TermsConstants.action,
+const ActionTypes = TermsConstants.action,
 	TEST_SITE_ID = 777,
 	TEST_CATEGORY_STORE_ID = 'default',
 	TEST_CATEGORY_ID = 999,
 	TAGS_DEFAULT_PER_PAGE = TermsConstants.MAX_TAGS,
 	CATEGORIES_DEFAULT_PER_PAGE = 300,
-	TEMPORARY_ID = 'temporary-0',
 	TEST_CATEGORY_NAME = 'OMGKITIES',
 	CATEGORY_API_RESPONSE = {
 		categories: data.treeList,
@@ -27,7 +25,6 @@ var ActionTypes = TermsConstants.action,
 	},
 	ADD_CATEGORY_API_RESPONSE = {
 		ID: TEST_CATEGORY_ID,
-		temporaryId: TEST_CATEGORY_ID,
 		name: TEST_CATEGORY_NAME
 	},
 	TEST_QUERY = {
@@ -57,14 +54,13 @@ describe( 'actions', function() {
 				};
 			}
 		} );
-		TermActions = rewire( '../actions' );
+		TermActions = require( '../actions' );
 		// have to require dispatcher after turning on mockery because we get a different instance after mockery cleans out the cache.
 		// yay singletons that are not single
 		Dispatcher = require( 'dispatcher' );
 	} );
 
 	beforeEach( function() {
-		this.revertTermActions = TermActions.__set__( 'temporaryIdCount', 0 );
 		sandbox = sinon.sandbox.create();
 
 		getCategories = sandbox.stub().callsArgWithAsync( 1, null, CATEGORY_API_RESPONSE );
@@ -75,7 +71,6 @@ describe( 'actions', function() {
 	} );
 
 	afterEach( function() {
-		this.revertTermActions();
 		sandbox.restore();
 	} );
 
@@ -88,7 +83,7 @@ describe( 'actions', function() {
 				data: {
 					termType: 'categories',
 					terms: [ {
-						ID: TEMPORARY_ID,
+						ID: sinon.match( /^temporary-/ ),
 						name: TEST_CATEGORY_NAME,
 						parent: undefined,
 						postId: undefined
@@ -105,7 +100,7 @@ describe( 'actions', function() {
 				data: {
 					termType: 'categories',
 					terms: [ {
-						ID: TEMPORARY_ID,
+						ID: sinon.match( /^temporary-/ ),
 						name: TEST_CATEGORY_NAME,
 						parent: TEST_CATEGORY_ID,
 						postId: undefined

--- a/client/lib/terms/test/category-store.js
+++ b/client/lib/terms/test/category-store.js
@@ -1,27 +1,23 @@
 /**
  * External dependencies
  */
-const rewire = require( 'rewire' ),
-	assert = require( 'chai' ).assert,
-	includes = require( 'lodash/includes' );
+import { assert } from 'chai';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
  */
-const common = require( './common' ),
-	data = require( './data' ),
-	ActionTypes = require( '../constants' ).action;
+import common from './common';
+import data from './data';
+import { action as ActionTypes } from '../constants';
+import CategoryStoreFactory from '../category-store-factory';
+import Dispatcher from 'dispatcher';
 
 describe( 'category-store', function() {
-	let CategoryStoreFactory, Dispatcher, defaultCategoryStore;
-
-	before( function() {
-		CategoryStoreFactory = rewire( '../category-store-factory' );
-		Dispatcher = require( 'dispatcher' );
-	} );
+	let defaultCategoryStore;
 
 	beforeEach( function() {
-		CategoryStoreFactory.__set__( '_categoryStores', [] );
+		CategoryStoreFactory._categoryStores = {};
 		defaultCategoryStore = CategoryStoreFactory( common.TEST_CATEGORY_STORE_ID );
 	} );
 

--- a/client/lib/terms/test/tag-store.js
+++ b/client/lib/terms/test/tag-store.js
@@ -1,30 +1,27 @@
 /**
  * External dependencies
  */
-var rewire = require( 'rewire' ),
-	assert = require( 'chai' ).assert;
+import { assert } from 'chai';
 
 /**
  * Internal dependencies
  */
-var data = require( './data' ),
-	ActionTypes = require( '../constants' ).action;
+import data from './data';
+import { action as ActionTypes } from '../constants';
+import TagStore from '../tag-store';
+import Dispatcher from 'dispatcher';
 
-var TEST_SITE_ID = 777,
-	TEST_TAG_ID = 8,
-	TEST_NUM_TAGS = data.tagList.length;
+/**
+ * Constants
+ */
+const TEST_SITE_ID = 777;
+const TEST_TAG_ID = 8;
+const TEST_NUM_TAGS = data.tagList.length;
 
 describe( 'tag-store', function() {
-	let TagStore, Dispatcher;
-
-	before( function() {
-		TagStore = rewire( '../tag-store' );
-		Dispatcher = require( 'dispatcher' );
-	} );
-
 	beforeEach( function() {
-		TagStore.__set__( '_tagIds', {} );
-		TagStore.__set__( '_siteStatus', {} );
+		TagStore._tagIds = {};
+		TagStore._siteStatus = {};
 	} );
 
 	function dispatchReceiveTerms() {


### PR DESCRIPTION
Related: #1515

This pull request seeks to refactor `client/lib/terms` to remove its dependency on `rewire`, in an effort to move forward with Calypo's Babel 6 migration.

__Testing instructions:__

Ensure that Mocha tests continue to pass.

Verify that no regressions are introduced to terms (categories and tags) usage, particular in menu management and post editor.

/cc @gziolo 