### PR TITLE
Domains: Use a more helpful phone placeholder in Domains Contact Info form

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -208,7 +208,16 @@ export default React.createClass( {
 					{ ...fieldProps( 'organization' ) }/>
 
 				<Input label={ this.translate( 'Email', { textOnly } ) } { ...fieldProps( 'email' ) }/>
-				<Input label={ this.translate( 'Phone', { textOnly } ) } { ...fieldProps( 'phone' ) }/>
+				<Input
+					label={ this.translate( 'Phone', { textOnly } ) }
+					placeholder={ this.translate(
+						'e.g. +1.555.867.5309',
+						{
+							context: 'Domain contact info phone placeholder',
+							comment: 'Please use the phone number format most common for your language, but it must begin with just the country code in the format \'+1\' - no parenthesis, leading zeros, etc.'
+						}
+					) }
+					{ ...fieldProps( 'phone' ) }/>
 
 				<CountrySelect
 					label={ this.translate( 'Country', { textOnly } ) }

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -77,7 +77,7 @@ export default React.createClass( {
 			<div className={ classes }>
 				<FormLabel htmlFor={ this.props.name }>{ this.props.label }</FormLabel>
 				<FormTextInput
-					placeholder={ this.props.label }
+					placeholder={ this.props.placeholder ? this.props.placeholder : this.props.label }
 					id={ this.props.name }
 					value={ this.props.value }
 					name={ this.props.name }


### PR DESCRIPTION
@alexjgustafson made a very good suggestion in https://github.com/Automattic/wp-calypso/issues/2535#issuecomment-222519859 - that is, we should provide a more helpful placeholder for the phone input field. The one right now just reads `Phone` - not indicating that a country code is required too.
This PR changes this placeholder to `e.g. +1.555.867.5309`.

While this is not a definitely not a complete fix, it should at least somewhat improve the situation.

/cc @aidvu @umurkontaci 