### PR TITLE
Add bug source and flow suggested keywords to new issue template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,9 +10,9 @@ Just [file a GitHub issue](https://github.com/Automattic/wp-calypso/issues/), th
 
 If you’re filing a bug, specific steps to reproduce are helpful. Please include the URL of the page that has the bug, along with what you expected to see and what happened instead.
 
-Here is a [handy link for submitting a new bug](https://github.com/Automattic/wp-calypso/issues/new?body=URL%3A%0A%0AWhat+I+expected%3A%0A%0AWhat+happened+instead%3A%0A%0ASteps+to+reproduce%3A%0A%0ABrowser%20OS%20version%3A%0A%0AScreenshots/Video%3A&title=Feature:%20description%20of%20the%20problem&labels%5B%5D=%5BType%5D%20Bug).
+Here is a [handy link for submitting a new bug](https://github.com/Automattic/wp-calypso/issues/new?labels%5B%5D=%5BType%5D%20Bug).
 
-Feel free to share your unique context to help us understand your perspective. You can add context tags such as: `#journey` `#anecdote` `#narrative` `#context` `#empathy` `#perspective` `#reallife` `#dogfooding` `#livesharing` `#flowsharing` `#anxiety` `#anxiety-flow` `#stresscase` `#painpoint`. We'd also love to know how you found the bug: `#dogfooding`, `#manual-testing`, `#automated-testing`, or `#user-report`.
+Feel free to share your unique context to help us understand your perspective. You can add context tags such as: `#journey` `#anecdote` `#narrative` `#context` `#empathy` `#perspective` `#reallife` `#dogfooding` `#livesharing` `#flowsharing` `#anxiety` `#anxiety-flow` `#stresscase` `#painpoint`. We'd also love to know how you found the bug: `#dogfooding`, `#manual-testing`, `#automated-testing`, or `#user-report` if applicable.
 
 ## Installing Calypso Locally
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,6 +12,8 @@ If you’re filing a bug, specific steps to reproduce are helpful. Please includ
 
 Here is a [handy link for submitting a new bug](https://github.com/Automattic/wp-calypso/issues/new?body=URL%3A%0A%0AWhat+I+expected%3A%0A%0AWhat+happened+instead%3A%0A%0ASteps+to+reproduce%3A%0A%0ABrowser%20OS%20version%3A%0A%0AScreenshots/Video%3A&title=Feature:%20description%20of%20the%20problem&labels%5B%5D=%5BType%5D%20Bug).
 
+Feel free to share your unique context to help us understand your perspective. You can add context tags such as: `#journey` `#anecdote` `#narrative` `#context` `#empathy` `#perspective` `#reallife` `#dogfooding` `#livesharing` `#flowsharing` `#anxiety` `#anxiety-flow` `#stresscase` `#painpoint`. We'd also love to know how you found the bug: `#dogfooding`, `#manual-testing`, `#automated-testing`, or `#user-report`.
+
 ## Installing Calypso Locally
 
 If you’d like to contribute code, first, you will need to run Calypso locally. Here is the short version:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,7 +19,12 @@
 
 
 #### Context / Source
-<!-- Optional: Share with us your perspective and source, using suggested flow and source keywords here: https://github.com/Automattic/wp-calypso/blob/master/.github/CONTRIBUTING.md#reporting-bugs-asking-questions-sending-suggestions. -->
+<!-- Optional: share your unique context to help us understand your perspective. You can add context tags such as: #journey #anecdote #narrative #context #empathy #perspective #reallife #dogfooding #livesharing #flowsharing #anxiety #anxiety-flow #stresscase #painpoint.
+
+We'd also love to know how you found the bug: #dogfooding, #manual-testing, #automated-testing, or #user-report if applicable.
+
+If requesting a new feature, explain why you'd like to see it added.
+-->
 
 
 
@@ -27,7 +32,6 @@
 PLEASE NOTE
 - These comments won't show up when you submit the issue.
 - Everything is optional, but try to add as many details as possible.
-- If requesting a new feature, explain why you'd like to see it added.
 
 Docs & troubleshooting:
 https://github.com/Automattic/wp-calypso/blob/master/.github/CONTRIBUTING.md

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,6 +17,12 @@
 
 #### Screenshot / Video
 
+
+#### Context / Source
+<!-- Optional: Share with us your perspective and source, using suggested flow and source keywords here: https://github.com/Automattic/wp-calypso/blob/master/.github/CONTRIBUTING.md#reporting-bugs-asking-questions-sending-suggestions. -->
+
+
+
 <!--
 PLEASE NOTE
 - These comments won't show up when you submit the issue.


### PR DESCRIPTION
This is to help us at Automattic, triaging new bugs and suggestions — and others following the project — remember to use common keywords to give perspective, avoid misunderstandings, add context, and show a bit of stats around sources of bugs.