### PR TITLE
Framework: update wpcom.js to `4.9.15`

### DIFF
--- a/client/state/sites/vouchers/actions.js
+++ b/client/state/sites/vouchers/actions.js
@@ -94,7 +94,7 @@ export function requestSiteVouchers( siteId ) {
 
 		return wpcom
 			.site( siteId )
-			.adCreditVouchers()
+			.creditVouchers()
 			.list()
 			.then( data => {
 				const { vouchers = [] } = data;
@@ -124,7 +124,7 @@ export function assignSiteVoucher( siteId, serviceType ) {
 
 		return wpcom
 			.site( siteId )
-			.adCreditVouchers()
+			.creditVouchers()
 			.assign( serviceType )
 			.then( data => {
 				const { voucher = {} } = data;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15,10 +15,10 @@
       "version": "1.2.2"
     },
     "acorn-globals": {
-      "version": "1.0.9",
+      "version": "3.0.0",
       "dependencies": {
         "acorn": {
-          "version": "2.7.0"
+          "version": "3.1.0"
         }
       }
     },
@@ -403,7 +403,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000471"
+      "version": "1.0.30000472"
     },
     "caseless": {
       "version": "0.11.0"
@@ -457,7 +457,7 @@
       "version": "1.1.1"
     },
     "clean-css": {
-      "version": "3.4.16",
+      "version": "3.4.17",
       "dependencies": {
         "commander": {
           "version": "2.8.1"
@@ -669,6 +669,9 @@
     },
     "cssstyle": {
       "version": "0.2.36"
+    },
+    "currently-unhandled": {
+      "version": "0.4.1"
     },
     "d": {
       "version": "0.1.1"
@@ -897,19 +900,24 @@
       "version": "1.1.1"
     },
     "es5-ext": {
-      "version": "0.10.11"
+      "version": "0.10.11",
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.0.2"
+        }
+      }
     },
     "es6-iterator": {
       "version": "2.0.0"
     },
     "es6-map": {
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     "es6-set": {
       "version": "0.1.4"
     },
     "es6-symbol": {
-      "version": "3.0.2"
+      "version": "3.1.0"
     },
     "es6-templates": {
       "version": "0.2.2",
@@ -1766,6 +1774,9 @@
       "dependencies": {
         "acorn": {
           "version": "2.7.0"
+        },
+        "acorn-globals": {
+          "version": "1.0.9"
         }
       }
     },
@@ -1998,7 +2009,7 @@
       "version": "1.2.0"
     },
     "loud-rejection": {
-      "version": "1.3.0"
+      "version": "1.4.1"
     },
     "lower-case": {
       "version": "1.1.3"
@@ -3410,13 +3421,18 @@
       "version": "0.6.5"
     },
     "which": {
-      "version": "1.2.9"
+      "version": "1.2.10"
     },
     "window-size": {
       "version": "0.1.4"
     },
     "with": {
-      "version": "5.0.0"
+      "version": "5.1.1",
+      "dependencies": {
+        "acorn": {
+          "version": "3.1.0"
+        }
+      }
     },
     "within-document": {
       "version": "0.0.1"
@@ -3428,7 +3444,7 @@
       "version": "1.3.0"
     },
     "wpcom": {
-      "version": "4.9.13",
+      "version": "4.9.14",
       "dependencies": {
         "babel": {
           "version": "5.8.38"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.15",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "4.9.13",
+    "wpcom": "4.9.14",
     "wpcom-proxy-request": "2.0.0",
     "wpcom-xhr-request": "0.5.0",
     "xgettext-js": "0.3.0"


### PR DESCRIPTION
Update wpcom.js library to `4.9.14`. Main changes -> https://github.com/Automattic/wpcom.js/blob/master/History.md#4914--2016-06-06

### Testings

Clean and update `npm` dependencies and start up calypso. Everything should be right. Algo, you can test version and new methods from the console in `development` env;

![image](https://cloud.githubusercontent.com/assets/77539/15815847/d29c7b00-2bcf-11e6-90e7-d00d978270c3.png)

![image](https://cloud.githubusercontent.com/assets/77539/15815834/b257ac3e-2bcf-11e6-9ea2-15193ac6d088.png)

cc @timmyc @rralian 


