### PR TITLE
Framework: update wpcom.js to `4.9.15`

### DIFF
--- a/client/state/sites/vouchers/actions.js
+++ b/client/state/sites/vouchers/actions.js
@@ -94,7 +94,7 @@ export function requestSiteVouchers( siteId ) {
 
 		return wpcom
 			.site( siteId )
-			.adCreditVouchers()
+			.creditVouchers()
 			.list()
 			.then( data => {
 				const { vouchers = [] } = data;
@@ -124,7 +124,7 @@ export function assignSiteVoucher( siteId, serviceType ) {
 
 		return wpcom
 			.site( siteId )
-			.adCreditVouchers()
+			.creditVouchers()
 			.assign( serviceType )
 			.then( data => {
 				const { voucher = {} } = data;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3428,7 +3428,7 @@
       "version": "1.3.0"
     },
     "wpcom": {
-      "version": "4.9.13",
+      "version": "4.9.15",
       "dependencies": {
         "babel": {
           "version": "5.8.38"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.15",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "4.9.13",
+    "wpcom": "4.9.15",
     "wpcom-proxy-request": "2.0.0",
     "wpcom-xhr-request": "0.5.0",
     "xgettext-js": "0.3.0"


### PR DESCRIPTION
Update wpcom.js library to `4.9.15`. Main changes -> https://github.com/Automattic/wpcom.js/blob/master/History.md#4915--2016-06-06

### Testings

Clean and update `npm` dependencies and start up calypso. Everything should be right. Algo, you can test version and new methods from the console in `development` env;

![image](https://cloud.githubusercontent.com/assets/77539/15815847/d29c7b00-2bcf-11e6-90e7-d00d978270c3.png)

![image](https://cloud.githubusercontent.com/assets/77539/15815834/b257ac3e-2bcf-11e6-9ea2-15193ac6d088.png)

cc @timmyc @rralian 


