### PR TITLE
Docs: Include paragraph about SCREAMING_SNAKE_CASE constants (JS)

### DIFF
--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -226,10 +226,20 @@ var userIdToDelete, siteUrl;
 var userIDToDelete, siteURL;
 ```
 
-Constructors intended for use with new should have a capital first letter (UpperCamelCase).
-
 Names should be descriptive, but not excessively so. Exceptions are allowed for iterators, such as the use of `i` to represent the index in a loop.
 
+Constructors intended for use with new should have a capital first letter (UpperCamelCase).
+
+Variables intended to be used as a [constant](https://en.wikipedia.org/wiki/Constant_(computer_programming)) can be defined with the [SCREAMING_SNAKE_CASE naming convention](https://en.wikipedia.org/wiki/Snake_case). Note that while any variable declared using `const` could be considered a constant, in the context of our application this usage should usually be limited to top-level or exported module values.
+
+```js
+const DUMMY_VALUE = 10;
+
+function getIncrementedDummyValue() {
+	const incrementedValue = DUMMY_VALUE + 1;
+	return incrementedValue;
+}
+```
 
 ## Comments
 


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/pull/5743#discussion_r65885223

This pull request seeks to add a paragraph to our JavaScript coding standards about the use of "screaming snake case" naming convention for constant values. This naming convention is already quite widespread in the application, but is not documented.

__Testing instructions:__

No application changes included.

Ensure that the paragraph and example are readable and the use of "screaming snake case" (a term I'd not seen used previously) is well-understood.

/cc @timmyc @mtias @nb 