### PR TITLE
Revert "404: Change wording to 'Return Home'"

### DIFF
--- a/server/pages/404.jade
+++ b/server/pages/404.jade
@@ -23,4 +23,4 @@ html(lang='en')
 							h2.empty-content__title Uh oh. Page not found.
 							h3.empty-content__line.
 								Sorry, the page you were looking for doesn't exist or has been moved.
-							a(href='/' class='empty-content__action button button-primary') Return Home
+							a(href='/' class='empty-content__action button button-primary') Return to Home


### PR DESCRIPTION
Reverts Automattic/wp-calypso#5820

Signup is broken -- likely because of #4632. This one is based on that, so need to revert.

/cc @aduth