### PR TITLE
Framework: Route based on sections whitelist, fall back to 404

### DIFF
--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -12,5 +12,6 @@ export default function( router ) {
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		router( '/design', makeLayout );
 		router( '/design/type/:tier', makeLayout );
+		router( '/design/*', makeLayout ); // Needed so direct hits don't result in a 404.
 	}
 }

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -5,9 +5,7 @@ import { getLanguage } from 'lib/i18n-utils';
 
 export default function( router ) {
 	router( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpLocale );
-	router( '/jetpack/*', ( context, next ) => {
-		next();
-	} ); // Required so this route doesn't 404
+	router( '/jetpack/*' ); // Required so this route doesn't 404
 }
 
 // Set up the locale in case it has ended up in the flow param

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -5,6 +5,9 @@ import { getLanguage } from 'lib/i18n-utils';
 
 export default function( router ) {
 	router( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpLocale );
+	router( '/jetpack/*', ( context, next ) => {
+		next();
+	} ); // Required so this route doesn't 404
 }
 
 // Set up the locale in case it has ended up in the flow param

--- a/server/pages/404.jade
+++ b/server/pages/404.jade
@@ -23,5 +23,4 @@ html(lang='en')
 							h2.empty-content__title Uh oh. Page not found.
 							h3.empty-content__line.
 								Sorry, the page you were looking for doesn't exist or has been moved.
-							a(href='/' class='empty-content__action button button-primary') Go back home
-
+							a(href='/' class='empty-content__action button button-primary') Return Home

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -334,11 +334,7 @@ module.exports = function() {
 				} );
 
 				if ( ! section.isomorphic ) {
-					if ( section.enableLoggedOut ) {
-						app.get( pathRegex, setUpRoute, serverRender );
-					} else {
-						app.get( pathRegex, setUpLoggedInRoute, serverRender );
-					}
+					app.get( pathRegex, section.enableLoggedOut ? setUpRoute : setUpLoggedInRoute, serverRender );
 				}
 			} );
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -309,22 +309,6 @@ module.exports = function() {
 		res.redirect( redirectUrl );
 	} );
 
-	app.get( '/calypso/?*', render404 );
-
-	if ( config.isEnabled( 'jetpack/connect' ) ) {
-		app.get( '/jetpack/connect/:locale?', setUpRoute, serverRender );
-		app.get( '/jetpack/connect/authorize/:locale?', setUpRoute, serverRender );
-	}
-
-	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
-		setUpRoute,
-		serverRender
-	);
-
-	if ( config.isEnabled( 'mailing-lists/unsubscribe' ) ) {
-		app.get( '/mailing-lists/unsubscribe', setUpRoute, serverRender );
-	}
-
 	if ( config( 'env' ) !== 'development' ) {
 		app.get( '/discover', function( req, res, next ) {
 			if ( ! req.cookies.wordpress_logged_in ) {
@@ -350,7 +334,11 @@ module.exports = function() {
 				} );
 
 				if ( ! section.isomorphic ) {
-					app.get( pathRegex, setUpLoggedInRoute, serverRender );
+					if ( section.enableLoggedOut ) {
+						app.get( pathRegex, setUpRoute, serverRender );
+					} else {
+						app.get( pathRegex, setUpLoggedInRoute, serverRender );
+					}
 				}
 			} );
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -11,8 +11,7 @@ var config = require( 'config' ),
 	utils = require( 'bundler/utils' ),
 	sectionsModule = require( '../../client/sections' ),
 	serverRouter = require( 'isomorphic-routing' ).serverRouter,
-	serverRender = require( 'render' ).serverRender,
-	i18n = require( 'i18n-calypso' );
+	serverRender = require( 'render' ).serverRender;
 
 var HASH_LENGTH = 10,
 	URL_BASE_PATH = '/calypso',
@@ -27,15 +26,7 @@ var staticFiles = [
 	{ path: 'style-rtl.css' }
 ];
 
-var chunksByPath = {};
-
 var sections = sectionsModule.get();
-
-sections.forEach( function( section ) {
-	section.paths.forEach( function( path ) {
-		chunksByPath[ path ] = section.name;
-	} );
-} );
 
 /**
  * Generates a hash of a files contents to be used as a version parameter on asset requests.
@@ -97,26 +88,6 @@ function generateStaticUrls( request ) {
 	return urls;
 }
 
-function getChunk( path ) {
-	var regex, chunkPath;
-
-	for ( chunkPath in chunksByPath ) {
-		if ( chunkPath === path ) {
-			return chunksByPath[ chunkPath ];
-		}
-
-		if ( chunkPath === '/' ) {
-			continue;
-		}
-
-		regex = utils.pathToRegExp( chunkPath );
-
-		if ( regex.test( path ) ) {
-			return chunksByPath[ chunkPath ];
-		}
-	}
-}
-
 function getCurrentBranchName() {
 	try {
 		return execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().replace( /\s/gm, '' );
@@ -134,9 +105,7 @@ function getCurrentCommitShortChecksum() {
 }
 
 function getDefaultContext( request ) {
-	var context, chunk;
-
-	context = {
+	var context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,
 		urls: generateStaticUrls( request ),
 		user: false,
@@ -153,7 +122,7 @@ function getDefaultContext( request ) {
 		devDocsURL: '/devdocs',
 		catchJsErrors: '/calypso/catch-js-errors-' + 'v2' + '.min.js',
 		isPushEnabled: !! config.isEnabled( 'push-notifications' )
-	};
+	} );
 
 	context.app = {
 		// use ipv4 address when is ipv4 mapped address
@@ -189,14 +158,6 @@ function getDefaultContext( request ) {
 		context.faviconURL = '/calypso/images/favicons/favicon-development.ico';
 		context.branchName = getCurrentBranchName();
 		context.commitChecksum = getCurrentCommitShortChecksum();
-	}
-
-	if ( config.isEnabled( 'code-splitting' ) ) {
-		chunk = getChunk( request.path );
-
-		if ( chunk ) {
-			context.chunk = chunk;
-		}
 	}
 
 	return context;
@@ -309,6 +270,12 @@ function setUpRoute( req, res, next ) {
 	}
 }
 
+function render404( request, response ) {
+	response.status( 404 ).render( '404.jade', {
+		urls: generateStaticUrls( request )
+	} );
+}
+
 module.exports = function() {
 	var app = express();
 
@@ -342,11 +309,7 @@ module.exports = function() {
 		res.redirect( redirectUrl );
 	} );
 
-	app.get( '/calypso/?*', function( request, response ) {
-		response.status( 404 ).render( '404.jade', {
-			urls: generateStaticUrls( request )
-		} );
-	} );
+	app.get( '/calypso/?*', render404 );
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
 		app.get( '/jetpack/connect/:locale?', setUpRoute, serverRender );
@@ -374,15 +337,30 @@ module.exports = function() {
 
 	app.get( '/theme', ( req, res ) => res.redirect( '/design' ) );
 
-	// Isomorphic routing
 	sections
-		.filter( section => section.isomorphic )
 		.forEach( section => {
-			sectionsModule.require( section.module )( serverRouter( app, setUpRoute, section ) );
+			section.paths.forEach( path => {
+				const pathRegex = utils.pathToRegExp( path );
+
+				app.get( pathRegex, function( req, res, next ) {
+					if ( config.isEnabled( 'code-splitting' ) ) {
+						req.context = Object.assign( {}, req.context, { chunk: section.name } );
+					}
+					next();
+				} );
+
+				if ( ! section.isomorphic ) {
+					app.get( pathRegex, setUpLoggedInRoute, serverRender );
+				}
+			} );
+
+			if ( section.isomorphic ) {
+				sectionsModule.require( section.module )( serverRouter( app, setUpRoute, section ) );
+			}
 		} );
 
-	// catchall path to serve shell for all non-static-file requests (other than auth routes)
-	app.get( '*', setUpLoggedInRoute, serverRender );
+	// catchall to render 404 for all routes not whitelisted in client/sections
+	app.get( '*', render404 );
 
 	return app;
 };


### PR DESCRIPTION
**Reboot of #4632.**

Use paths from `client/sections` for routing, and fall back to a 404 otherwise.
Also, use express middleware to add chunk `<script>` to HTML output (instead of manually testing RegEx compiled from `client/sections` path).

Before (http://calypso.localhost:3000/noexiste):

![before](https://cloud.githubusercontent.com/assets/96308/14406354/8be6fd5e-fea5-11e5-9587-c13930492f03.png)

After (http://calypso.localhost:3000/noexiste):

![after](https://cloud.githubusercontent.com/assets/96308/14406356/9394482c-fea5-11e5-80fe-cc4c41166e93.png)


To test:
* Try directly landing on different sections of Calypso and make sure they still work. In particular, check http://calypso.localhost:3000/design/<yoursite>
 * Check page source to see if there is a `<script>` for the corresponding chunk (e.g. for `/pages`, watch out for `<script src="/calypso/posts-pages.fb43c97d94c0abab7702.js">`).
 * Verify that server side rendering of theme sheets still works, e.g. http://calypso.localhost:3000/theme/prosperity/overview
* Verify that the routes that previously received special treating in `server/pages` still work _both while logged in and out_, specifically:
 * `/jetpack/connect`
 * `/accept-invite`
 * `/mailing-lists/unsubscribe`
 * `/calypso/something` (should 404)
 * Also, try the logged-out Jetpack connect and mailing lists routes with a locale suffix (e.g. `/de`) and verify that content is then disabled in the specified language.
* Try directly landing on a route that doesn't exist, and verify that you get a 404.
