### PR TITLE
Push Notifications: Make sure serviceWorker is ready before attempting to register

### DIFF
--- a/client/lib/push-notifications/index.js
+++ b/client/lib/push-notifications/index.js
@@ -82,7 +82,11 @@ PushNotifications.prototype.initialize = function() {
 
 	// Only register the service worker in browsers that support it.
 	if ( 'serviceWorker' in window.navigator ) {
-		window.navigator.serviceWorker.register( '/service-worker.js' ).then( initializeState.bind( this ) ).catch( ( err ) => {
+		window.navigator.serviceWorker.ready.then( () => {
+			window.navigator.serviceWorker.register( '/service-worker.js' ).then( initializeState.bind( this ) ).catch( ( err ) => {
+				debug( 'Service worker not supported', err );
+			} );
+		} ).catch( ( err ) => {
 			debug( 'Service worker not supported', err );
 		} );
 	} else {


### PR DESCRIPTION
Prior to this PR, running calypso.localhost:3000 in Chrome, **without using the `--unsafely-treat-insecure-origin-as-secure` command-line argument**, would cause the debugger to stop when we attempted to register the service worker.

Confirm the initial behavior:
* Start Chrome without any flags to treat calypso.localhost as special.
* From the sources tab of the developer console, make sure "Pause on exceptions" is enabled (the icon should be blue): 
![image](https://cloud.githubusercontent.com/assets/363749/15827744/0d3df606-2bd2-11e6-9079-4fb9ca497ea2.png)
* Checkout master and run locally.
* Attempt to load Calypso and verify that this causes the debugger to stop execution: 
![image](https://cloud.githubusercontent.com/assets/363749/15827931/fb9e95ee-2bd2-11e6-90d8-d4bb56052bb2.png)


Confirm the fix:
* Still using your Chrome instance that hasn't been started with any special flags...
* Still making sure that "Pause on exceptions" is enabled...
* Checkout this branch and run locally.
* Attempt to load Calypso and verify that the debugger no longer stops the execution.

Confirm that PNs still work as normal:
* Close Chrome
* Open Chrome using `--unsafely-treat-insecure-origin-as-secure=http://calypso.localhost:3000 --user-data-dir=/tmp/foo`
* Make sure you're still on this branch
* Make sure you're able to manage your PN notifications from `/me/notifications`
* With PNs enabled... make sure you receive a PN when you receive a notification on WP.com