### PR TITLE
Revert "Plans: clicking on any part of the card should select a plan"

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -166,11 +166,6 @@ const PlanActions = React.createClass( {
 		if ( this.props.onSelectPlan ) {
 			return this.props.onSelectPlan( cartItem );
 		}
-
-		if ( ! cartItem ) {
-			return;
-		}
-
 		upgradesActions.addItem( cartItem );
 
 		const checkoutPath = this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -69,13 +69,9 @@ const Plan = React.createClass( {
 		);
 	},
 
-	showDetails( event ) {
+	showDetails() {
 		if ( 'function' === typeof ( this.props.onOpen ) ) {
 			this.props.onOpen( this.props.plan.product_id );
-		}
-		// clicking a card should select a plan, see issue 4486
-		if ( this.imagePlanActionRef ) {
-			this.imagePlanActionRef.handleSelectPlan( event );
 		}
 	},
 
@@ -190,14 +186,9 @@ const Plan = React.createClass( {
 		);
 	},
 
-	setImagePlanActionRef( imagePlanActionRef ) {
-		this.imagePlanActionRef = imagePlanActionRef;
-	},
-
 	getImagePlanAction() {
 		return (
 			<PlanActions
-				ref={ this.setImagePlanActionRef }
 				plan={ this.props.plan }
 				isInSignup={ this.props.isInSignup }
 				onSelectPlan={ this.props.onSelectPlan }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#5805 and reopens #4486

Sorry, looks like this also affects the text underneath. I'll revert and work around this.

cc @rralian 