### PR TITLE
Docs: Remove exception for array and object key spacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,11 +16,13 @@ module.exports = {
 		'eslint-plugin-wpcalypso'
 	],
 	'rules': {
+		'array-bracket-spacing': [ 1, 'always' ],
 		'brace-style': [ 1, '1tbs' ],
 		// REST API objects include underscores
 		'camelcase': 0,
 		'comma-dangle': 0,
 		'comma-spacing': 1,
+		'computed-property-spacing': [ 1, 'always' ],
 		// Allows returning early as undefined
 		'consistent-return': 0,
 		'dot-notation': 1,
@@ -67,6 +69,7 @@ module.exports = {
 		'react/jsx-curly-spacing': [ 1, 'always' ],
 		// Allows function use before declaration
 		'no-use-before-define': [ 2, 'nofunc' ],
+		'object-curly-spacing': [ 1, 'always' ],
 		// We split external, internal, module variables
 		'one-var': 0,
 		'operator-linebreak': [ 1, 'after', { 'overrides': {
@@ -81,8 +84,6 @@ module.exports = {
 		'space-after-keywords': [ 1, 'always' ],
 		'space-before-blocks': [ 1, 'always' ],
 		'space-before-function-paren': [ 1, 'never' ],
-		// Our array literal index exception violates this rule
-		'space-in-brackets': 0,
 		'space-in-parens': [ 1, 'always' ],
 		'space-infix-ops': [ 1, { 'int32Hint': false } ],
 		// Ideal for '!' but not for '++'

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -81,16 +81,6 @@ foo( function() {
 
 ```
 
-
-Exceptions:
-
-```js
-// For consistency with our PHP standards, do not include a space around
-// string literals or integers used as key values in array notation:
-prop = object['default'];
-firstArrayElement = arr[0];
-```
-
 ## Examples of Good Spacing
 
 ```js


### PR DESCRIPTION
This pull request seeks to remove an exception detailed in our JavaScript coding standards which allows for exceptions in our array and object spacing guideline when using numbers or string literals.

>For consistency with our PHP standards, do not include a space around string literals or integers used as key values in array notation

I propose we remove this exception for the following reasons:

- It's noted the exception is for consistency with the WordPress coding standards, but we have already diverged from this standards with our [spacing guidelines on function arguments](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#arrays-and-function-calls) (ref: 1683-gh-calypso-pre-oss)
- By their nature, any exception to a rule is a barrier in that they prescribe additional burdens of knowledge
- We can more easily leverage existing ESLint rules that do not support differentiating on the type of array or object key
- Exempting on string/integers is completely arbitrary (though I welcome dissenting arguments)

Not only does this pull request remove the rule from our documentation, but it also enables related rules in our ESLint configuration:

- [`computed-property-spacing`](http://eslint.org/docs/rules/computed-property-spacing)
- [`object-curly-spacing`](http://eslint.org/docs/rules/object-curly-spacing)
- [`array-bracket-spacing`](http://eslint.org/docs/rules/array-bracket-spacing)