### PR TITLE
DesignPreview: Enable in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -63,6 +63,8 @@
 		"persist-redux": true,
 		"post-editor/author-selector": true,
 		"press-this": true,
+		"preview-layout": true,
+		"preview-endpoint": false,
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/tags-with-elasticsearch": false,


### PR DESCRIPTION
This enables:
- Showing (preloaded) sites in an iframe, when the site card is clicked
- The preview steps in GuidedTours