### PR TITLE
Discover: Redirect 

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -394,7 +394,7 @@ module.exports = function() {
 		app.get( '/mailing-lists/unsubscribe', setUpRoute, serverRender );
 	}
 
-	if ( config.isEnabled( 'reader/discover' ) && config( 'env' ) !== 'development' ) {
+	if ( config( 'env' ) !== 'development' ) {
 		app.get( '/discover', function( req, res, next ) {
 			if ( req.cookies.wordpress_logged_in ) {
 				setUpLoggedInRoute( req, res, next );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -396,10 +396,10 @@ module.exports = function() {
 
 	if ( config( 'env' ) !== 'development' ) {
 		app.get( '/discover', function( req, res, next ) {
-			if ( req.cookies.wordpress_logged_in ) {
-				setUpLoggedInRoute( req, res, next );
-			} else {
+			if ( ! req.cookies.wordpress_logged_in ) {
 				res.redirect( config( 'discover_logged_out_redirect_url' ) );
+			} else {
+				next();
 			}
 		} );
 	}


### PR DESCRIPTION
Remove a `reader/discover` feature flag check from `server/pages`. That feature flag is now gone, but we really want the redirect in non-dev environments, so we should remove the check. (AFAICS, this was the last occurence of a check for that feature flag.)

Also, skip to next middleware on logged-out `/discover` route, since the catch-all further down will `setUpLoggedInRoute()` and `serverRender()` for us.

To test:
Cannot be tested in dev environment, since that is explicitly exempted by the conditional. Instead, verify in wpcalypso or staging that `/discover` in logged-out mode now redirects to the URL set by `config( 'discover_logged_out_redirect_url' )`, i.e. https://discover.wordpress.com.

/cc @blowery for review