### PR TITLE
WebPreview: fix vertical position

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -148,7 +148,7 @@
 .web-preview__placeholder {
 	width: 100%;
 	position: absolute;
-		top: 49px;
+		top: 53px;
 		bottom: 0;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
The iframe containing the preview was positioned 4 pixels too high, obscuring the lower border of the toolbar. This moves it down those 4 pixels so the toolbar's border is visible. 

Before:

<img width="575" alt="before" src="https://cloud.githubusercontent.com/assets/23619/15837344/2b3f0412-2c39-11e6-88c6-6d90fe229a73.png">

After:

<img width="633" alt="after" src="https://cloud.githubusercontent.com/assets/23619/15837346/303734f8-2c39-11e6-85c1-3edc73f13dad.png">


Test live: https://calypso.live/?branch=fix/web-preview-fix-vertical-position