### PR TITLE
Plans: clicking on the card plan header should select a plan

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -166,6 +166,11 @@ const PlanActions = React.createClass( {
 		if ( this.props.onSelectPlan ) {
 			return this.props.onSelectPlan( cartItem );
 		}
+
+		if ( ! cartItem ) {
+			return;
+		}
+
 		upgradesActions.addItem( cartItem );
 
 		const checkoutPath = this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )

--- a/client/components/plans/plan-header/index.jsx
+++ b/client/components/plans/plan-header/index.jsx
@@ -3,11 +3,19 @@
  */
 import classNames from 'classnames';
 import React from 'react';
+import noop from 'lodash/noop';
 
 const PlanHeader = React.createClass( {
 	propTypes: {
 		isPlaceholder: React.PropTypes.bool,
-		text: React.PropTypes.string
+		text: React.PropTypes.string,
+		onClick: React.PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+			onClick: noop
+		};
 	},
 
 	render() {
@@ -17,7 +25,7 @@ const PlanHeader = React.createClass( {
 		} );
 
 		return (
-			<div className={ classes }>
+			<div className={ classes } onClick={ this.props.onClick } >
 				<h2 className="plan-header__title">{ this.props.text }</h2>
 
 				{ this.props.children }

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -186,9 +186,14 @@ const Plan = React.createClass( {
 		);
 	},
 
+	setImagePlanActionRef( imagePlanActionRef ) {
+		this.imagePlanActionRef = imagePlanActionRef;
+	},
+
 	getImagePlanAction() {
 		return (
 			<PlanActions
+				ref={ this.setImagePlanActionRef }
 				plan={ this.props.plan }
 				isInSignup={ this.props.isInSignup }
 				onSelectPlan={ this.props.onSelectPlan }
@@ -201,6 +206,13 @@ const Plan = React.createClass( {
 		);
 	},
 
+	clickPlanHeader( event ) {
+		// clicking a card should select a plan, see issue 4486
+		if ( this.imagePlanActionRef ) {
+			this.imagePlanActionRef.handleSelectPlan( event );
+		}
+	},
+
 	render() {
 		return (
 			<Card
@@ -210,7 +222,7 @@ const Plan = React.createClass( {
 			>
 				{ this.getPlanDiscountMessage() }
 				<PlanHeader
-					onClick={ this.showDetails }
+					onClick={ this.clickPlanHeader }
 					text={ this.getProductName() }
 					isPlaceholder={ this.isPlaceholder() }
 				>


### PR DESCRIPTION
This PR fixes #4486, where clicking below or above the pen/pencil icons would not select a plan. 

![ddd5f55e-f827-11e5-8081-fcf7cf89beb5](https://cloud.githubusercontent.com/assets/1270189/15793951/20741b8e-299c-11e6-955e-3880dcdc245c.png)

The previous attempt #5805 incorrectly triggered a plan selection when clicking on the plan text or Learn More button. Please take care when testing, and verify that clicking anywhere in the plan description besides the upgrade now button will **not** select a plan.
![screen shot 2016-06-06 at 2 37 36 pm](https://cloud.githubusercontent.com/assets/1270189/15838679/3e776e24-2bf4-11e6-89f2-d9c71ff64180.png)


## Testing instructions

### New User Flow
- Log out
- Load Calypso
- Start a signup flow
- Progress through the flow until you get to the plan selection screen (# of steps depends on the flow)
- Try to click on the plan card / header (or anywhere except the button or illustration)
- This branch will succeed, and prod will fail

### Plan Upgrade
- Navigate to http://calypso.localhost:3000/plans
- Select a site with a free plan
- Attempt to click on the Premium card as shown in the image above.
- This branch will succeed, and prod will fail

cc @jblz @rralian @retrofox 

Test live: https://calypso.live/?branch=fix/plans-card-click