### PR TITLE
Advanced SEO: Add search results preview

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -94,6 +94,7 @@
 @import 'components/section-nav/style';
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
+@import 'components/seo/style';
 @import 'components/signup-form/style';
 @import 'components/site-icon/style';
 @import 'components/site-selector/style';

--- a/client/components/seo/search-preview/index.jsx
+++ b/client/components/seo/search-preview/index.jsx
@@ -13,7 +13,7 @@ export const SearchPreview = React.createClass( {
 
 		return (
 			<div className="seo-search-preview">
-				<h2 className="seo-search-preview__header">{ this.translate( 'Google Preview' ) }</h2>
+				<h2 className="seo-search-preview__header">{ this.translate( 'Search Preview' ) }</h2>
 				<div className="seo-search-preview__display">
 					<div className="seo-search-preview__title">
 						{ title }

--- a/client/components/seo/search-preview/index.jsx
+++ b/client/components/seo/search-preview/index.jsx
@@ -12,16 +12,16 @@ export const SearchPreview = React.createClass( {
 		} = this.props;
 
 		return (
-			<div className="seo-search-result-preview">
-				<h2 className="seo-search-result-preview__header">{ this.translate( 'Google Preview' ) }</h2>
-				<div className="seo-search-result-preview__display">
-					<div className="seo-search-result-preview__title">
+			<div className="seo-search-preview">
+				<h2 className="seo-search-preview__header">{ this.translate( 'Google Preview' ) }</h2>
+				<div className="seo-search-preview__display">
+					<div className="seo-search-preview__title">
 						{ title }
 					</div>
-					<div className="seo-search-result-preview__url">
+					<div className="seo-search-preview__url">
 						{ url } ▾
 					</div>
-					<div className="seo-search-result-preview__snippet">
+					<div className="seo-search-preview__snippet">
 						{ snippet }
 					</div>
 				</div>

--- a/client/components/seo/search-preview/index.jsx
+++ b/client/components/seo/search-preview/index.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 
-export const SeoSiteSearchPreview = React.createClass( {
+export const SearchPreview = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	render() {
@@ -30,10 +30,10 @@ export const SeoSiteSearchPreview = React.createClass( {
 	}
 } );
 
-SeoSiteSearchPreview.propTypes = {
+SearchPreview.propTypes = {
 	title: PropTypes.string,
 	url: PropTypes.string,
 	snippet: PropTypes.string
 };
 
-export default SeoSiteSearchPreview;
+export default SearchPreview;

--- a/client/components/seo/seo-site-search-preview.jsx
+++ b/client/components/seo/seo-site-search-preview.jsx
@@ -1,0 +1,50 @@
+import React, { PropTypes } from 'react';
+
+const reactifyNewlines = message =>
+	message
+		.split( '\n' )
+		.map( ( snip, index ) => [ <span key={ `s${ index }` }>{ snip }</span>, <br key={ `br${ index }` } /> ] )
+		.reduce( ( final, next ) => final.concat( next ), [] )
+		.slice( 0, -1 );
+
+export const SeoSiteSearchPreview = React.createClass( {
+	shouldComponentUpdate( next ) {
+		const current = this.props;
+
+		return ! (
+			current.snippet === next.snippet &&
+			current.title === next.title &&
+			current.url === next.url
+		);
+	},
+
+	render() {
+		const {
+			snippet: rawSnippet,
+			title,
+			url
+		} = this.props;
+
+		const snippet = reactifyNewlines( rawSnippet );
+
+		return (
+			<div className="seo-search-result-preview">
+				<div className="seo-search-result-preview__title">{ title }</div>
+				<div className="seo-search-result-preview__url">
+					{ url } ▾
+				</div>
+				<div className="seo-search-result-preview__snippet">
+					{ snippet }
+				</div>
+			</div>
+		);
+	}
+} );
+
+SeoSiteSearchPreview.propTypes = {
+	title: PropTypes.string,
+	url: PropTypes.string,
+	snippet: PropTypes.string
+};
+
+export default SeoSiteSearchPreview;

--- a/client/components/seo/seo-site-search-preview.jsx
+++ b/client/components/seo/seo-site-search-preview.jsx
@@ -29,12 +29,15 @@ export const SeoSiteSearchPreview = React.createClass( {
 
 		return (
 			<div className="seo-search-result-preview">
-				<div className="seo-search-result-preview__title">{ title }</div>
-				<div className="seo-search-result-preview__url">
-					{ url } ▾
-				</div>
-				<div className="seo-search-result-preview__snippet">
-					{ snippet }
+				<h2 className="seo-search-result-preview__header">{ this.translate( 'Google Preview' ) }</h2>
+				<div className="seo-search-result-preview__display">
+					<div className="seo-search-result-preview__title">{ title }</div>
+					<div className="seo-search-result-preview__url">
+						{ url } ▾
+					</div>
+					<div className="seo-search-result-preview__snippet">
+						{ snippet }
+					</div>
 				</div>
 			</div>
 		);

--- a/client/components/seo/seo-site-search-preview.jsx
+++ b/client/components/seo/seo-site-search-preview.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import toString from 'lodash/toString';
 
 const reactifyNewlines = message =>
 	message
@@ -25,7 +26,7 @@ export const SeoSiteSearchPreview = React.createClass( {
 			url
 		} = this.props;
 
-		const snippet = reactifyNewlines( rawSnippet );
+		const snippet = reactifyNewlines( toString( rawSnippet ) );
 
 		return (
 			<div className="seo-search-result-preview">

--- a/client/components/seo/seo-site-search-preview.jsx
+++ b/client/components/seo/seo-site-search-preview.jsx
@@ -1,12 +1,4 @@
 import React, { PropTypes } from 'react';
-import toString from 'lodash/toString';
-
-const reactifyNewlines = message =>
-	message
-		.split( '\n' )
-		.map( ( snip, index ) => [ <span key={ `s${ index }` }>{ snip }</span>, <br key={ `br${ index }` } /> ] )
-		.reduce( ( final, next ) => final.concat( next ), [] )
-		.slice( 0, -1 );
 
 export const SeoSiteSearchPreview = React.createClass( {
 	shouldComponentUpdate( next ) {
@@ -21,12 +13,10 @@ export const SeoSiteSearchPreview = React.createClass( {
 
 	render() {
 		const {
-			snippet: rawSnippet,
+			snippet,
 			title,
 			url
 		} = this.props;
-
-		const snippet = reactifyNewlines( toString( rawSnippet ) );
 
 		return (
 			<div className="seo-search-result-preview">

--- a/client/components/seo/seo-site-search-preview.jsx
+++ b/client/components/seo/seo-site-search-preview.jsx
@@ -15,7 +15,9 @@ export const SeoSiteSearchPreview = React.createClass( {
 			<div className="seo-search-result-preview">
 				<h2 className="seo-search-result-preview__header">{ this.translate( 'Google Preview' ) }</h2>
 				<div className="seo-search-result-preview__display">
-					<div className="seo-search-result-preview__title">{ title }</div>
+					<div className="seo-search-result-preview__title">
+						{ title }
+					</div>
 					<div className="seo-search-result-preview__url">
 						{ url } ▾
 					</div>

--- a/client/components/seo/seo-site-search-preview.jsx
+++ b/client/components/seo/seo-site-search-preview.jsx
@@ -1,15 +1,8 @@
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 export const SeoSiteSearchPreview = React.createClass( {
-	shouldComponentUpdate( next ) {
-		const current = this.props;
-
-		return ! (
-			current.snippet === next.snippet &&
-			current.title === next.title &&
-			current.url === next.url
-		);
-	},
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		const {

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -1,0 +1,27 @@
+.seo-search-result-preview {
+	padding: 2px;
+}
+
+.seo-search-result-preview__title {
+	color: #1a0dab; // matching Google results
+	font-size: 18px;
+	line-height: 1.2;
+
+	&:hover {
+		cursor: pointer;
+		text-decoration: underline;
+	}
+}
+
+.seo-search-result-preview__url {
+	color: #006621; // matching Google results
+	font-size: 14px;
+	height: 17px;
+	line-height: 16px;
+}
+
+.seo-search-result-preview__snippet {
+	color: #545454; // matching Google results
+	font-size: 13px;
+	line-height: 1.4;
+}

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -1,5 +1,24 @@
 .seo-search-result-preview {
-	padding: 2px;
+	border: 1px solid lighten( $gray, 30% );
+	box-shadow: 0 3px 6px -3px rgba( 0, 0, 0, 0.05 );
+}
+
+.seo-search-result-preview__header {
+	margin: 0;
+	padding: 8px 0;
+	background-color: $gray-light;
+	border: 1px solid lighten( $gray, 30% );
+	border-bottom: 0;
+	font-size: 11px;
+	line-height: 1;
+	font-weight: bold;
+	text-transform: uppercase;
+	text-align: center;
+	color: $gray;
+}
+
+.seo-search-result-preview__display {
+	padding: 10px 20px;
 }
 
 .seo-search-result-preview__title {

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -18,7 +18,10 @@
 }
 
 .seo-search-result-preview__display {
+	font-family: arial, sans-serif;
 	padding: 10px 20px;
+	width: 616px;
+	word-wrap: break-word;
 }
 
 .seo-search-result-preview__title {

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -1,8 +1,8 @@
-.seo-search-result-preview {
+.seo-search-preview {
 	box-shadow: 0 3px 6px -3px rgba( 0, 0, 0, 0.05 );
 }
 
-.seo-search-result-preview__header {
+.seo-search-preview__header {
 	margin: 0;
 	padding: 8px 0;
 	background-color: $gray-light;
@@ -16,14 +16,14 @@
 	color: $gray;
 }
 
-.seo-search-result-preview__display {
+.seo-search-preview__display {
 	border: 1px solid lighten( $gray, 30% );
 	font-family: arial, sans-serif;
 	padding: 10px 20px;
 	word-wrap: break-word;
 }
 
-.seo-search-result-preview__title {
+.seo-search-preview__title {
 	color: #1a0dab; // matching Google results
 	font-size: 18px;
 	line-height: 1.2;
@@ -35,7 +35,7 @@
 	}
 }
 
-.seo-search-result-preview__url {
+.seo-search-preview__url {
 	color: #006621; // matching Google results
 	font-size: 14px;
 	height: 17px;
@@ -43,7 +43,7 @@
 	width: 616px;
 }
 
-.seo-search-result-preview__snippet {
+.seo-search-preview__snippet {
 	color: #545454; // matching Google results
 	font-size: 13px;
 	line-height: 1.4;

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -1,5 +1,4 @@
 .seo-search-result-preview {
-	border: 1px solid lighten( $gray, 30% );
 	box-shadow: 0 3px 6px -3px rgba( 0, 0, 0, 0.05 );
 }
 
@@ -18,9 +17,9 @@
 }
 
 .seo-search-result-preview__display {
+	border: 1px solid lighten( $gray, 30% );
 	font-family: arial, sans-serif;
 	padding: 10px 20px;
-	width: 616px;
 	word-wrap: break-word;
 }
 
@@ -28,6 +27,7 @@
 	color: #1a0dab; // matching Google results
 	font-size: 18px;
 	line-height: 1.2;
+	width: 616px;
 
 	&:hover {
 		cursor: pointer;
@@ -40,10 +40,12 @@
 	font-size: 14px;
 	height: 17px;
 	line-height: 16px;
+	width: 616px;
 }
 
 .seo-search-result-preview__snippet {
 	color: #545454; // matching Google results
 	font-size: 13px;
 	line-height: 1.4;
+	width: 616px;
 }

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -27,7 +27,7 @@
 	color: #1a0dab; // matching Google results
 	font-size: 18px;
 	line-height: 1.2;
-	width: 616px;
+	max-width: 616px;
 
 	&:hover {
 		cursor: pointer;
@@ -40,12 +40,12 @@
 	font-size: 14px;
 	height: 17px;
 	line-height: 16px;
-	width: 616px;
+	max-width: 616px;
 }
 
 .seo-search-preview__snippet {
 	color: #545454; // matching Google results
 	font-size: 13px;
 	line-height: 1.4;
-	width: 616px;
+	max-width: 616px;
 }

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -27,6 +27,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import SearchEngineSeoPreview from 'components/seo/seo-site-search-preview';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const serviceIds = {
@@ -203,10 +204,12 @@ export const SeoForm = React.createClass( {
 
 	render() {
 		const {
+			description: siteDescription,
 			slug = '',
 			settings: {
 				blog_public = 1
-			} = {}
+			} = {},
+			title: siteTitle
 		} = this.props.site;
 
 		const {
@@ -224,7 +227,11 @@ export const SeoForm = React.createClass( {
 		const isDisabled = isSitePrivate || isSubmittingForm || isFetchingSettings;
 		const isSaveDisabled = isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
 
-		const sitemapUrl = `https://${ slug }/sitemap.xml`;
+		const seoTitle = siteDescription.length
+			? `${ siteTitle } | ${ siteDescription }`
+			: siteTitle;
+		const siteUrl = `https://${ slug }/`;
+		const sitemapUrl = `${ siteUrl }/sitemap.xml`;
 		const generalTabUrl = getGeneralTabUrl( slug );
 		const placeholderTagContent = '1234';
 
@@ -293,6 +300,12 @@ export const SeoForm = React.createClass( {
 								<FormSettingExplanation>
 									{ this.translate( 'Craft a description of your site in about 160 characters. This description can be used in search engine results for your site\'s Front Page.' ) }
 								</FormSettingExplanation>
+
+								<SearchEngineSeoPreview
+									title={ seoTitle }
+									url={ siteUrl }
+									snippet={ seoMetaDescription }
+								/>
 							</FormFieldset>
 
 							<FormFieldset>

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -27,7 +27,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import SearchEngineSeoPreview from 'components/seo/seo-site-search-preview';
+import SearchPreview from 'components/seo/search-preview';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const serviceIds = {
@@ -301,7 +301,7 @@ export const SeoForm = React.createClass( {
 									{ this.translate( 'Craft a description of your site in about 160 characters. This description can be used in search engine results for your site\'s Front Page.' ) }
 								</FormSettingExplanation>
 
-								<SearchEngineSeoPreview
+								<SearchPreview
 									title={ seoTitle }
 									url={ siteUrl }
 									snippet={ seoMetaDescription }


### PR DESCRIPTION
Closes #5833

Adds a "preview" for the custom SEO meta provided in the site settings.
This isn't a real preview because we can't control how the search
engines will list the results, but it attempts to make a reasonable and
educated guess based on what information _is_ available.

This patch inserts the preview under the custom meta description field
in the site settings.

![screen shot 2016-06-06 at 2 52 31 pm](https://cloud.githubusercontent.com/assets/5431237/15839116/69d93dfc-2bf6-11e6-98d7-fcc8041bacf8.png)


**Testing**
Navigate to **My Sites** > **Settings** > **SEO** and edit the front page meta description for the site. The content should appear correctly in the preview below.

**Notes**
 - The title is currently set to the site name and optionally the tagline. This will likely change as we continue to iterate on the SEO settings.
 - The URL is assigned the site slug
 - There are no constraints on the `snippet` area, such as limiting the number of lines. We could do this if we wanted. It appears like Google limits it to two or sometimes three lines.
 - The CSS is set to match Google's results, which is why it diverges from some of our CSS style guides.

cc: @drw158 @roundhill 

Test live: https://calypso.live/?branch=add/seo-preview