### PR TITLE
Editor: Resolve error when navigating away from editor (development)

### DIFF
--- a/client/components/tinymce/plugins/media/advanced/index.jsx
+++ b/client/components/tinymce/plugins/media/advanced/index.jsx
@@ -53,7 +53,9 @@ export default function( editor ) {
 	}
 
 	function unmount() {
-		ReactDom.unmountComponentAtNode( container );
+		if ( container ) {
+			ReactDom.unmountComponentAtNode( container );
+		}
 	}
 
 	function insertMedia( markup ) {


### PR DESCRIPTION
Fixes #5841 

This pull request seeks to resolve an error which occurs when navigating away from the post editor. This only affects the development environment, as the problematic code is guarded by a feature flag.

__Testing instructions:__

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click the Back button
4. Note that no error occurs

/cc @gwwar 

Test live: https://calypso.live/?branch=fix/5841-editor-back