### PR TITLE
Jetpack SSO: Add analytics events

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -32,6 +32,7 @@ import { decodeEntities } from 'lib/formatting';
 import Gridicon from 'components/gridicon';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import Dialog from 'components/dialog';
+import analytics from 'lib/analytics';
 
 /*
  * Module variables
@@ -71,6 +72,7 @@ const JetpackSSOForm = React.createClass( {
 
 	onApproveSSO( event ) {
 		event.preventDefault();
+		analytics.tracks.recordEvent( 'calypso_jetpack_sso_log_in_button_click' );
 
 		const { siteId, ssoNonce } = this.props;
 		debug( 'Approving sso' );
@@ -79,16 +81,23 @@ const JetpackSSOForm = React.createClass( {
 
 	onCancelClick( event ) {
 		debug( 'Clicked return to site link' );
+		analytics.tracks.recordEvent( 'calypso_jetpack_sso_return_to_site_link_click' );
 		this.returnToSiteFallback( event );
 	},
 
 	onTryAgainClick( event ) {
 		debug( 'Clicked try again link' );
+		analytics.tracks.recordEvent( 'calypso_jetpack_sso_try_again_link_click' );
 		this.returnToSiteFallback( event );
+	},
+
+	onClickSignInDifferentUser() {
+		analytics.tracks.recordEvent( 'calypso_jetpack_sso_sign_in_different_user_link_click' );
 	},
 
 	onClickSharedDetailsModal( event ) {
 		event.preventDefault();
+		analytics.tracks.recordEvent( 'calypso_jetpack_sso_shared_details_link_click' );
 		this.setState( {
 			showTermsDialog: true
 		} );
@@ -104,6 +113,7 @@ const JetpackSSOForm = React.createClass( {
 		// If, for some reason, the API request failed and we do not have the admin URL,
 		// then fallback to the user's last location.
 		if ( ! get( this.props, 'blogDetails.admin_url' ) ) {
+			analytics.tracks.recordEvent( 'calypso_jetpack_sso_admin_url_fallback_redirect' );
 			event.preventDefault();
 			window.history.back();
 		}
@@ -379,7 +389,7 @@ const JetpackSSOForm = React.createClass( {
 					</Card>
 
 					<LoggedOutFormLinks>
-						<LoggedOutFormLinkItem href={ this.getSignInLink() }>
+						<LoggedOutFormLinkItem href={ this.getSignInLink() } onClick={ this.onClickSignInDifferentUser }>
 							{ this.translate( 'Sign in as a different user' ) }
 						</LoggedOutFormLinkItem>
 						<LoggedOutFormLinkItem

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -290,6 +290,7 @@ export default {
 			} );
 
 			return wpcom.undocumented().jetpackValidateSSONonce( siteId, ssoNonce ).then( ( data ) => {
+				tracksEvent( dispatch, 'calypso_jpc_validate_sso_success' );
 				dispatch( {
 					type: JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
 					success: data.success,
@@ -297,6 +298,9 @@ export default {
 					sharedDetails: data.shared_details
 				} );
 			} ).catch( ( error ) => {
+				tracksEvent( dispatch, 'calypso_jpc_validate_sso_error', {
+					error: error
+				} );
 				dispatch( {
 					type: JETPACK_CONNECT_SSO_VALIDATION_ERROR,
 					error: pick( error, [ 'error', 'status', 'message' ] )
@@ -313,11 +317,15 @@ export default {
 			} );
 
 			return wpcom.undocumented().jetpackAuthorizeSSONonce( siteId, ssoNonce ).then( ( data ) => {
+				tracksEvent( dispatch, 'calypso_jpc_authorize_sso_success' );
 				dispatch( {
 					type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
 					ssoUrl: data.sso_url
 				} );
 			} ).catch( ( error ) => {
+				tracksEvent( dispatch, 'calypso_jpc_authorize_sso_error', {
+					error: error
+				} );
 				dispatch( {
 					type: JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
 					error: pick( error, [ 'error', 'status', 'message' ] )


### PR DESCRIPTION
Closes #5826.

Adds analytics events to the Jetpack connect SSO UI.

To test:

- Make sure your Jetpack site is using latest master
- Check out `update/jetpack-sso-add-analytics` branch
- Go to `calypso.localhost:3000` and enter `localStorage.setItem( 'debug', 'calypso:analytics' );`
- Go to `$site/wp-admin` and click "Log in with WordPress.com" button
- Change out `wpcalypso.wordpress.com` with `calypso.localhost:3000`
- Click buttons in UI and test that analytics events are fired

cc @lezama for review.

Test live: https://calypso.live/?branch=update/jetpack-sso-add-analytics