### PR TITLE
Export: Validate date range before export

### DIFF
--- a/client/my-sites/exporter/advanced-settings.jsx
+++ b/client/my-sites/exporter/advanced-settings.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
 import PostTypeOptions from './post-type-options';
 import SpinnerButton from './spinner-button';
 import { isDateValid as isExportDateValid } from 'state/site-settings/exporter/selectors';
-import FormInputValidation from 'components/forms/form-input-validation';
 
 /**
  * Displays additional options for customising an export
@@ -53,9 +52,6 @@ const AdvancedSettings = React.createClass( {
 						description={ this.translate( 'Survey results etc.' ) }
 					/>
 				</div>
-				{ this.props.isDateValid ? null
-					: <FormInputValidation isError={ true } text={ this.translate( 'The start date is later than the end date' ) } />
-				}
 				<SpinnerButton
 					className="exporter__export-button"
 					disabled={ ! this.props.isValid }
@@ -75,7 +71,6 @@ const mapStateToProps = ( state, ownProps ) => {
 	const isDateValid = isExportDateValid( state, siteId, postType );
 	return {
 		siteId,
-		isDateValid,
 		isValid: postType && isDateValid,
 	};
 };

--- a/client/my-sites/exporter/advanced-settings.jsx
+++ b/client/my-sites/exporter/advanced-settings.jsx
@@ -9,6 +9,8 @@ import { connect } from 'react-redux';
  */
 import PostTypeOptions from './post-type-options';
 import SpinnerButton from './spinner-button';
+import { isDateValid as isExportDateValid } from 'state/site-settings/exporter/selectors';
+import FormInputValidation from 'components/forms/form-input-validation';
 
 /**
  * Displays additional options for customising an export
@@ -51,9 +53,12 @@ const AdvancedSettings = React.createClass( {
 						description={ this.translate( 'Survey results etc.' ) }
 					/>
 				</div>
+				{ this.props.isDateValid ? null
+					: <FormInputValidation isError={ true } text={ this.translate( 'The start date is later than the end date' ) } />
+				}
 				<SpinnerButton
 					className="exporter__export-button"
-					disabled={ ! this.props.postType }
+					disabled={ ! this.props.isValid }
 					loading={ this.props.shouldShowProgress }
 					isPrimary={ true }
 					onClick={ this.props.onClickExport }
@@ -64,10 +69,14 @@ const AdvancedSettings = React.createClass( {
 	}
 } );
 
-const mapStateToProps = ( state ) => {
+const mapStateToProps = ( state, ownProps ) => {
 	const siteId = state.ui.selectedSiteId;
+	const postType = ownProps.postType;
+	const isDateValid = isExportDateValid( state, siteId, postType );
 	return {
-		siteId
+		siteId,
+		isDateValid,
+		isValid: postType && isDateValid,
 	};
 };
 

--- a/client/my-sites/exporter/advanced-settings.jsx
+++ b/client/my-sites/exporter/advanced-settings.jsx
@@ -9,7 +9,8 @@ import { connect } from 'react-redux';
  */
 import PostTypeOptions from './post-type-options';
 import SpinnerButton from './spinner-button';
-import { isDateValid as isExportDateValid } from 'state/site-settings/exporter/selectors';
+import { isDateRangeValid as isExportDateRangeValid } from 'state/site-settings/exporter/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Displays additional options for customising an export
@@ -66,9 +67,9 @@ const AdvancedSettings = React.createClass( {
 } );
 
 const mapStateToProps = ( state, ownProps ) => {
-	const siteId = state.ui.selectedSiteId;
+	const siteId = getSelectedSiteId( state );
 	const postType = ownProps.postType;
-	const isDateValid = isExportDateValid( state, siteId, postType );
+	const isDateValid = isExportDateRangeValid( state, siteId, postType );
 	return {
 		siteId,
 		isValid: postType && isDateValid,

--- a/client/my-sites/exporter/post-type-options.jsx
+++ b/client/my-sites/exporter/post-type-options.jsx
@@ -4,21 +4,21 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { connect } from 'react-redux';
-import { map } from 'lodash/collection';
 import { get } from 'lodash/object';
 
 /**
  * Internal dependencies
  */
 import FormRadio from 'components/forms/form-radio';
-import Select from './select';
 import Label from 'components/forms/form-label';
+import Select from './select';
 
 import { setPostType, setPostTypeFieldValue } from 'state/site-settings/exporter/actions';
 import {
 	getPostTypeFieldOptions,
 	getPostTypeFieldValues,
 	getSelectedPostType,
+	isDateValid as isExportDateValid,
 } from 'state/site-settings/exporter/selectors';
 
 const mapStateToProps = ( state, ownProps ) => {
@@ -30,6 +30,8 @@ const mapStateToProps = ( state, ownProps ) => {
 		siteId,
 		fields,
 		fieldValues,
+
+		isDateValid: isExportDateValid( state, siteId, ownProps.postType ),
 
 		// Show placeholders when fields options are not yet available
 		shouldShowPlaceholders: ! fields,
@@ -70,11 +72,12 @@ const PostTypeOptions = React.createClass( {
 			postType,
 			shouldShowPlaceholders,
 			siteId,
+			isDateValid,
 		} = this.props;
 
 		const fieldsForPostType = get( {
-			'post': [ 'author', 'status', 'start_date', 'end_date', 'category' ],
-			'page': [ 'author', 'status', 'start_date', 'end_date' ],
+			post: [ 'author', 'status', 'start_date', 'end_date', 'category' ],
+			page: [ 'author', 'status', 'start_date', 'end_date' ],
 		}, postType, [] );
 
 		const Field = ( props ) => {
@@ -96,6 +99,7 @@ const PostTypeOptions = React.createClass( {
 				key={ props.defaultLabel }
 				defaultLabel={ props.defaultLabel }
 				options={ options }
+				isError={ this.props.isEnabled && props.isError }
 				value={ fieldValues[ props.fieldName ] }
 				disabled={ shouldShowPlaceholders || ! this.props.isEnabled } />;
 		};
@@ -104,8 +108,8 @@ const PostTypeOptions = React.createClass( {
 			<div className="exporter__option-fieldset-fields">
 				<Field defaultLabel={ this.translate( 'Author…' ) } fieldName="author" options="authors" />
 				<Field defaultLabel={ this.translate( 'Status…' ) } fieldName="status" options="statuses" />
-				<Field defaultLabel={ this.translate( 'Start Date…' ) } fieldName="start_date" options="dates" />
-				<Field defaultLabel={ this.translate( 'End Date…' ) } fieldName="end_date" options="dates" />
+				<Field defaultLabel={ this.translate( 'Start Date…' ) } fieldName="start_date" options="dates" isError={ ! isDateValid } />
+				<Field defaultLabel={ this.translate( 'End Date…' ) } fieldName="end_date" options="dates" isError={ ! isDateValid } />
 				<Field defaultLabel={ this.translate( 'Category…' ) } fieldName="category" options="categories" />
 			</div>
 		);

--- a/client/my-sites/exporter/post-type-options.jsx
+++ b/client/my-sites/exporter/post-type-options.jsx
@@ -57,6 +57,7 @@ const PostTypeOptions = React.createClass( {
 		const {
 			description,
 			legend,
+			isDateValid,
 			isEnabled,
 			onSelect,
 			postType,
@@ -88,6 +89,7 @@ const PostTypeOptions = React.createClass( {
 							postType={ postType }
 							fieldName={ fieldName }
 							isEnabled={ isEnabled }
+							isError={ ( fieldName === 'start_date' || fieldName === 'end_date' ) && ! isDateValid }
 						/>
 					) }
 				</div>

--- a/client/my-sites/exporter/post-type-options.jsx
+++ b/client/my-sites/exporter/post-type-options.jsx
@@ -65,6 +65,13 @@ const PostTypeOptions = React.createClass( {
 		} = this.props;
 
 		const fields = [ 'author', 'status', 'start_date', 'end_date', 'category' ];
+
+		const setRef = fieldName => c => {
+			if ( fieldName === 'start_date' ) {
+				this._startDate = c;
+			}
+		};
+
 		return (
 			<div className="exporter__option-fieldset">
 
@@ -84,7 +91,7 @@ const PostTypeOptions = React.createClass( {
 				<div className="exporter__option-fieldset-fields">
 					{ fields.map( fieldName =>
 						<Select key={ fieldName }
-							ref={ fieldName }
+							ref={ setRef( fieldName ) }
 							siteId={ siteId }
 							postType={ postType }
 							fieldName={ fieldName }
@@ -95,7 +102,7 @@ const PostTypeOptions = React.createClass( {
 				</div>
 
 				<Tooltip
-					context={ this.refs && this.refs.start_date }
+					context={ this._startDate }
 					status="error"
 					isVisible={ isEnabled && ! this.props.isDateValid }>
 						{ this.translate( 'Selected start date is later than the end date' ) }

--- a/client/my-sites/exporter/post-type-options.jsx
+++ b/client/my-sites/exporter/post-type-options.jsx
@@ -16,7 +16,7 @@ import Tooltip from 'components/tooltip';
 import { setPostType } from 'state/site-settings/exporter/actions';
 import {
 	getSelectedPostType,
-	isDateValid as isExportDateValid,
+	isDateRangeValid as isExportDateRangeValid,
 } from 'state/site-settings/exporter/selectors';
 
 const mapStateToProps = ( state, ownProps ) => {
@@ -25,7 +25,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	return {
 		siteId,
 
-		isDateValid: isExportDateValid( state, siteId, ownProps.postType ),
+		isDateValid: isExportDateRangeValid( state, siteId, ownProps.postType ),
 
 		// Disable options when this post type is not selected
 		isEnabled: getSelectedPostType( state ) === ownProps.postType,

--- a/client/my-sites/exporter/select.jsx
+++ b/client/my-sites/exporter/select.jsx
@@ -50,7 +50,7 @@ export default class Select extends Component {
 			this.props.setValue( e.target.value );
 		};
 
-		const options = this.props.options.map( ( option, i ) => {
+		const options = this.props.options && this.props.options.map( ( option, i ) => {
 			return <option key={ i } value={ option.value }>{ option.label }</option>;
 		} );
 		return (

--- a/client/my-sites/exporter/select.jsx
+++ b/client/my-sites/exporter/select.jsx
@@ -2,23 +2,91 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { get } from 'lodash/object';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import FormSelect from 'components/forms/form-select';
+import {
+	getPostTypeFieldOptions,
+	getPostTypeFieldValue,
+} from 'state/site-settings/exporter/selectors';
+import {
+	setPostTypeFieldValue,
+} from 'state/site-settings/exporter/actions';
+import i18n from 'lib/mixins/i18n';
 
 export default class Select extends Component {
 	render() {
+		const {
+			isEnabled,
+			isError,
+			postType,
+			shouldShowPlaceholders,
+			value,
+			fieldName,
+		} = this.props;
+
+		const fieldsForPostType = get( {
+			post: [ 'author', 'status', 'start_date', 'end_date', 'category' ],
+			page: [ 'author', 'status', 'start_date', 'end_date' ],
+		}, postType, [] );
+
+		const label = get( {
+			author: i18n.translate( 'Author…' ),
+			status: i18n.translate( 'Status…' ),
+			start_date: i18n.translate( 'Start Date…' ),
+			end_date: i18n.translate( 'End Date…' ),
+			category: i18n.translate( 'Category…' ),
+		}, fieldName, '' );
+
+		if ( fieldsForPostType.indexOf( this.props.fieldName ) < 0 ) {
+			return null;
+		}
+
+		const setValue = ( e ) => {
+			this.props.setValue( e.target.value );
+		};
+
 		const options = this.props.options.map( ( option, i ) => {
 			return <option key={ i } value={ option.value }>{ option.label }</option>;
 		} );
-
 		return (
-			<FormSelect { ...this.props }>
-				<option value="">{ this.props.defaultLabel }</option>
+			<FormSelect
+				className={ shouldShowPlaceholders ? 'exporter__placeholder-select' : '' }
+				disabled={ shouldShowPlaceholders || ! isEnabled }
+				isError={ isEnabled && isError }
+				onChange={ setValue }
+				value={ value }
+			>
+				<option value="">{ label }</option>
 				{ options }
 			</FormSelect>
 		);
 	}
 }
+
+const mapStateToProps = ( state, ownProps ) => {
+	const { siteId, postType, fieldName } = ownProps;
+
+	const options = getPostTypeFieldOptions( state, siteId, postType, fieldName );
+	const value = getPostTypeFieldValue( state, siteId, postType, fieldName );
+
+	return {
+		shouldShowPlaceholders: ! options,
+		options,
+		value,
+	};
+};
+
+const mapDispatchToProps = ( dispatch, ownProps ) => {
+	const { siteId, postType, fieldName } = ownProps;
+
+	return {
+		setValue: ( value ) => dispatch( setPostTypeFieldValue( siteId, postType, fieldName, value ) )
+	};
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( Select );

--- a/client/my-sites/exporter/select.jsx
+++ b/client/my-sites/exporter/select.jsx
@@ -16,7 +16,7 @@ import {
 import {
 	setPostTypeFieldValue,
 } from 'state/site-settings/exporter/actions';
-import i18n from 'lib/mixins/i18n';
+import i18n from 'i18n-calypso';
 
 export default class Select extends Component {
 	render() {

--- a/client/my-sites/exporter/select.jsx
+++ b/client/my-sites/exporter/select.jsx
@@ -16,9 +16,18 @@ import {
 import {
 	setPostTypeFieldValue,
 } from 'state/site-settings/exporter/actions';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 export default class Select extends Component {
+	constructor( props ) {
+		super( props );
+		this.setValue = this.setValue.bind( this );
+	}
+
+	setValue( e ) {
+		this.props.setValue( e.target.value );
+	}
+
 	render() {
 		const {
 			isEnabled,
@@ -35,20 +44,16 @@ export default class Select extends Component {
 		}, postType, [] );
 
 		const label = get( {
-			author: i18n.translate( 'Author…' ),
-			status: i18n.translate( 'Status…' ),
-			start_date: i18n.translate( 'Start Date…' ),
-			end_date: i18n.translate( 'End Date…' ),
-			category: i18n.translate( 'Category…' ),
+			author: this.props.translate( 'Author…' ),
+			status: this.props.translate( 'Status…' ),
+			start_date: this.props.translate( 'Start Date…' ),
+			end_date: this.props.translate( 'End Date…' ),
+			category: this.props.translate( 'Category…' ),
 		}, fieldName, '' );
 
 		if ( fieldsForPostType.indexOf( this.props.fieldName ) < 0 ) {
 			return null;
 		}
-
-		const setValue = ( e ) => {
-			this.props.setValue( e.target.value );
-		};
 
 		const options = this.props.options && this.props.options.map( ( option, i ) => {
 			return <option key={ i } value={ option.value }>{ option.label }</option>;
@@ -58,7 +63,7 @@ export default class Select extends Component {
 				className={ shouldShowPlaceholders ? 'exporter__placeholder-select' : '' }
 				disabled={ shouldShowPlaceholders || ! isEnabled }
 				isError={ isEnabled && isError }
-				onChange={ setValue }
+				onChange={ this.setValue }
 				value={ value }
 			>
 				<option value="">{ label }</option>
@@ -89,4 +94,4 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 	};
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( Select );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( Select ) );

--- a/client/state/site-settings/exporter/selectors.js
+++ b/client/state/site-settings/exporter/selectors.js
@@ -36,6 +36,25 @@ export function isExporting( state, siteId ) {
 	return exportingState === States.EXPORTING;
 }
 
+export function isDateValid( state, siteId, postType ) {
+	const site = state.siteSettings.exporter.selectedAdvancedSettings[ siteId ];
+	if ( ! site ) {
+		return true;
+	}
+	const values = site[ postType ];
+	if ( ! values ) {
+		return true;
+	}
+
+	const startDate = values.start_date;
+	const endDate = values.end_date;
+	if ( startDate && endDate && startDate > endDate ) {
+		return false;
+	}
+
+	return true;
+}
+
 export const getAdvancedSettings = ( state, siteId ) => state.siteSettings.exporter.advancedSettings[ siteId ];
 export const getSelectedPostType = ( state ) => state.siteSettings.exporter.selectedPostType;
 export const getPostTypeFieldOptions = ( state, siteId, postType ) => {

--- a/client/state/site-settings/exporter/selectors.js
+++ b/client/state/site-settings/exporter/selectors.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { States } from './constants.js';
+import { get } from 'lodash/object';
 
 export const getExportingState = ( state, siteId ) => {
 	const exportingState = state.siteSettings.exporter.exportingState;
@@ -57,14 +58,41 @@ export function isDateValid( state, siteId, postType ) {
 
 export const getAdvancedSettings = ( state, siteId ) => state.siteSettings.exporter.advancedSettings[ siteId ];
 export const getSelectedPostType = ( state ) => state.siteSettings.exporter.selectedPostType;
-export const getPostTypeFieldOptions = ( state, siteId, postType ) => {
+export const getPostTypeFieldOptions = ( state, siteId, postType, fieldName ) => {
+	// Choose which set of options to return for the given field name
+	const optionSet = get( {
+		author: 'authors',
+		status: 'statuses',
+		start_date: 'dates',
+		end_date: 'dates',
+		category: 'categories',
+	}, fieldName, null );
+
 	const advancedSettings = getAdvancedSettings( state, siteId );
-	return advancedSettings ? advancedSettings[ postType ] : null;
+	if ( ! advancedSettings ) {
+		return null;
+	}
+	const fields = advancedSettings[ postType ];
+	if ( ! fields ) {
+		return null;
+	}
+	return fields[ optionSet ] || null;
 };
 
 export const getPostTypeFieldValues = ( state, siteId, postType ) => {
 	const site = state.siteSettings.exporter.selectedAdvancedSettings[ siteId ];
-	return site && site[ postType ] || {};
+	if ( ! site ) {
+		return null;
+	}
+	return site[ postType ] || null;
+};
+
+export const getPostTypeFieldValue = ( state, siteId, postType, fieldName ) => {
+	const fields = getPostTypeFieldValues( state, siteId, postType );
+	if ( ! fields ) {
+		return null;
+	}
+	return fields[ fieldName ] || null;
 };
 
 /**

--- a/client/state/site-settings/exporter/selectors.js
+++ b/client/state/site-settings/exporter/selectors.js
@@ -37,7 +37,7 @@ export function isExporting( state, siteId ) {
 	return exportingState === States.EXPORTING;
 }
 
-export function isDateValid( state, siteId, postType ) {
+export function isDateRangeValid( state, siteId, postType ) {
 	const site = state.siteSettings.exporter.selectedAdvancedSettings[ siteId ];
 	if ( ! site ) {
 		return true;

--- a/client/state/site-settings/exporter/test/selectors.js
+++ b/client/state/site-settings/exporter/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isExporting } from '../selectors';
+import { isExporting, isDateValid } from '../selectors';
 import { States } from '../constants.js';
 
 describe( 'selectors', () => {
@@ -49,6 +49,44 @@ describe( 'selectors', () => {
 			}, 100658273 );
 
 			expect( exporting ).to.eql( true );
+		} );
+
+		it( 'should return invalid date if start date is after end date', () => {
+			const state = {
+				siteSettings: {
+					exporter: {
+						selectedAdvancedSettings: {
+							100658273: {
+								post: {
+									start_date: '2016-06',
+									end_date: '2004-03',
+								}
+							}
+						}
+					}
+				}
+			};
+			expect( isDateValid( state, 100658273, 'post' ) ).to.equal( false );
+			expect( isDateValid( state, 100658273, 'page' ) ).to.equal( true );
+		} );
+
+		it( 'should return valid date if end date is after start date', () => {
+			const state = {
+				siteSettings: {
+					exporter: {
+						selectedAdvancedSettings: {
+							100658273: {
+								post: {
+									start_date: '2006-06',
+									end_date: '2024-03',
+								}
+							}
+						}
+					}
+				}
+			};
+			expect( isDateValid( state, 100658273, 'post' ) ).to.equal( true );
+			expect( isDateValid( state, 100658273, 'page' ) ).to.equal( true );
 		} );
 	} );
 } );

--- a/client/state/site-settings/exporter/test/selectors.js
+++ b/client/state/site-settings/exporter/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isExporting, isDateValid } from '../selectors';
+import { isExporting, isDateRangeValid } from '../selectors';
 import { States } from '../constants.js';
 
 describe( 'selectors', () => {
@@ -66,8 +66,8 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			expect( isDateValid( state, 100658273, 'post' ) ).to.equal( false );
-			expect( isDateValid( state, 100658273, 'page' ) ).to.equal( true );
+			expect( isDateRangeValid( state, 100658273, 'post' ) ).to.equal( false );
+			expect( isDateRangeValid( state, 100658273, 'page' ) ).to.equal( true );
 		} );
 
 		it( 'should return valid date if end date is after start date', () => {
@@ -85,8 +85,27 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			expect( isDateValid( state, 100658273, 'post' ) ).to.equal( true );
-			expect( isDateValid( state, 100658273, 'page' ) ).to.equal( true );
+			expect( isDateRangeValid( state, 100658273, 'post' ) ).to.equal( true );
+			expect( isDateRangeValid( state, 100658273, 'page' ) ).to.equal( true );
+		} );
+
+		it( 'should return valid date if end date is the same as start date', () => {
+			const state = {
+				siteSettings: {
+					exporter: {
+						selectedAdvancedSettings: {
+							100658273: {
+								post: {
+									start_date: '2040-06',
+									end_date: '2040-06',
+								}
+							}
+						}
+					}
+				}
+			};
+			expect( isDateRangeValid( state, 100658273, 'post' ) ).to.equal( true );
+			expect( isDateRangeValid( state, 100658273, 'page' ) ).to.equal( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
This change adds a validation error notice when the selected start date is after the end date. Submitting the form with the wrong date range would result in an empty export, so the Export Selected Content button is also disabled.


### How to test
0. Run the automated tests:
```
npm run test-client client/state/site-settings/exporter/test/*.js
```
1. Go to https://calypso.live/?branch=add/exporter/date-validation or check out `add/exporter/date-validation` locally.
2. **My Site > Settings > Export**
3. Click the down chevron to open the advanced settings
4. Select a start date and end date in the wrong order (start date later than end date)
5. Confirm that the error notice is displayed as in the first screenshot below, and a red border appears around the date dropdowns.
6. Confirm that the 'Export Selected Items' button is disabled until the validation error is corrected

Here's how it looks:
![screen shot 2016-06-08 at 4 00 58 pm](https://cloud.githubusercontent.com/assets/416133/15884254/729a260c-2d92-11e6-82fc-cb9b0c8132a2.png)
