### PR TITLE
Upgrades: Move WordAds sidebar link lower

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -698,7 +698,6 @@ module.exports = React.createClass( {
 				<SidebarMenu>
 					<ul>
 						{ this.stats() }
-						{ this.ads() }
 						{ this.plan() }
 					</ul>
 				</SidebarMenu>
@@ -760,6 +759,7 @@ module.exports = React.createClass( {
 					? <SidebarMenu>
 						<SidebarHeading>{ this.translate( 'Configure' ) }</SidebarHeading>
 						<ul>
+							{ this.ads() }
 							{ this.sharing() }
 							{ this.users() }
 							{ this.plugins() }


### PR DESCRIPTION
@apeatling and @drw158 have voiced concerns that WordAds sidebar link is too high.
This PR is mostly to have this discussion :)

# visuals

![zrzut ekranu 2016-06-07 o 11 44 09](https://cloud.githubusercontent.com/assets/3775068/15853568/ef4b5e70-2ca5-11e6-998f-1711a1a08636.png)


CC @rralian @mtias @dbspringer 

https://calypso.live/?branch=update/wordads-sidebar-lower