### PR TITLE
Post-Normalizer: Use DOMParser if available

### DIFF
--- a/client/lib/post-normalizer/rule-content-detect-polls.js
+++ b/client/lib/post-normalizer/rule-content-detect-polls.js
@@ -7,6 +7,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import { domForHtml } from './utils';
 
 export default function detectPolls( post, dom ) {
 	if ( ! dom ) {
@@ -22,16 +23,15 @@ export default function detectPolls( post, dom ) {
 			return;
 		}
 
-		const noscriptDom = document.createElement( 'div' );
 		// some browers don't require this and let us query the dom inside a noscript. some do not. maybe just jsdom.
-		noscriptDom.innerHTML = noscript.innerHTML;
+		const noscriptDom = domForHtml( noscript.innerHTML );
 
 		let pollLink = noscriptDom.querySelector( 'a[href^="http://polldaddy.com/poll/"]' );
 		if ( pollLink ) {
-			const pollId = pollLink.href.match( /http:\/\/polldaddy.com\/poll\/([0-9]+)/ )[ 1 ];
+			const pollId = pollLink.href.match( /https?:\/\/polldaddy.com\/poll\/([0-9]+)/ )[ 1 ];
 			if ( pollId ) {
 				let p = document.createElement( 'p' );
-				p.innerHTML = '<a rel="external" target="_blank" href="http://polldaddy.com/poll/' + pollId + '">' + i18n.translate( 'Take our poll' ) + '</a>';
+				p.innerHTML = '<a rel="external" target="_blank" href="https://polldaddy.com/poll/' + pollId + '">' + i18n.translate( 'Take our poll' ) + '</a>';
 				noscript.parentNode.replaceChild( p, noscript );
 			}
 		}

--- a/client/lib/post-normalizer/rule-content-detect-polls.js
+++ b/client/lib/post-normalizer/rule-content-detect-polls.js
@@ -7,7 +7,6 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { decodeEntities } from 'lib/formatting';
 
 export default function detectPolls( post, dom ) {
 	if ( ! dom ) {
@@ -22,12 +21,19 @@ export default function detectPolls( post, dom ) {
 		if ( ! noscript.firstChild ) {
 			return;
 		}
-		let firstChildData = decodeEntities( noscript.firstChild.data );
-		let match = firstChildData.match( '^<a href="http:\/\/polldaddy.com\/poll\/([0-9]+)' );
-		if ( match ) {
-			let p = document.createElement( 'p' );
-			p.innerHTML = '<a rel="external" target="_blank" href="http://polldaddy.com/poll/' + match[1] + '">' + i18n.translate( 'Take our poll' ) + '</a>';
-			noscript.parentNode.replaceChild( p, noscript );
+
+		const noscriptDom = document.createElement( 'div' );
+		// some browers don't require this and let us query the dom inside a noscript. some do not. maybe just jsdom.
+		noscriptDom.innerHTML = noscript.innerHTML;
+
+		let pollLink = noscriptDom.querySelector( 'a[href^="http://polldaddy.com/poll/"]' );
+		if ( pollLink ) {
+			const pollId = pollLink.href.match( /http:\/\/polldaddy.com\/poll\/([0-9]+)/ )[ 1 ];
+			if ( pollId ) {
+				let p = document.createElement( 'p' );
+				p.innerHTML = '<a rel="external" target="_blank" href="http://polldaddy.com/poll/' + pollId + '">' + i18n.translate( 'Take our poll' ) + '</a>';
+				noscript.parentNode.replaceChild( p, noscript );
+			}
 		}
 	} );
 

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -8,6 +8,7 @@ import trim from 'lodash/trim';
 /**
  * Internal Dependencies
  */
+import { domForHtml } from './utils';
 
 export default function createBetterExcerpt( post ) {
 	if ( ! post || ! post.content ) {
@@ -19,14 +20,7 @@ export default function createBetterExcerpt( post ) {
 	}
 
 	// Spin up a new DOM for the linebreak markup
-	let dom;
-	if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
-		const parser = new DOMParser();
-		dom = parser.parseFromString( post.content, 'text/html' ).body;
-	} else {
-		dom = document.createElement( 'div' );
-		dom.innerHTML = post.content;
-	}
+	const dom = domForHtml( post.content );
 	dom.id = '__better_excerpt__';
 	dom.innerHTML = post.content;
 

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -19,7 +19,14 @@ export default function createBetterExcerpt( post ) {
 	}
 
 	// Spin up a new DOM for the linebreak markup
-	const dom = document.createElement( 'div' );
+	let dom;
+	if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
+		const parser = new DOMParser();
+		dom = parser.parseFromString( post.content, 'text/html' );
+	} else {
+		dom = document.createElement( 'div' );
+		dom.innerHTML = post.content;
+	}
 	dom.id = '__better_excerpt__';
 	dom.innerHTML = post.content;
 

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -22,7 +22,7 @@ export default function createBetterExcerpt( post ) {
 	let dom;
 	if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
 		const parser = new DOMParser();
-		dom = parser.parseFromString( post.content, 'text/html' );
+		dom = parser.parseFromString( post.content, 'text/html' ).body;
 	} else {
 		dom = document.createElement( 'div' );
 		dom.innerHTML = post.content;

--- a/client/lib/post-normalizer/rule-with-content-dom.js
+++ b/client/lib/post-normalizer/rule-with-content-dom.js
@@ -1,4 +1,12 @@
+/**
+ * External Dependencies
+ */
 import reduce from 'lodash/reduce';
+
+/**
+ * Internal Dependencies
+ */
+import { domForHtml } from './utils';
 
 export default function createDomTransformRunner( transforms ) {
 	return function withContentDOM( post ) {
@@ -6,20 +14,15 @@ export default function createDomTransformRunner( transforms ) {
 			return post;
 		}
 
-		let dom;
-		if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
-			const parser = new DOMParser();
-			dom = parser.parseFromString( post.content, 'text/html' ).body;
-		} else {
-			dom = document.createElement( 'div' );
-			dom.innerHTML = post.content;
-		}
+		const dom = domForHtml( post.content );
 
 		post = reduce( transforms, ( memo, transform ) => {
 			return transform( memo, dom );
 		}, post );
+
 		post.content = dom.innerHTML;
 		dom.innerHTML = '';
+
 		return post;
 	};
 }

--- a/client/lib/post-normalizer/rule-with-content-dom.js
+++ b/client/lib/post-normalizer/rule-with-content-dom.js
@@ -6,9 +6,15 @@ export default function createDomTransformRunner( transforms ) {
 			return post;
 		}
 
-		// spin up the DOM
-		const dom = document.createElement( 'div' );
-		dom.innerHTML = post.content;
+		let dom;
+		if ( typeof DOMParser !== 'undefined' ) {
+			const parser = new DOMParser();
+			dom = parser.parseFromString( post.content, 'text/html' );
+		} else {
+			dom = document.createElement( 'div' );
+			dom.innerHTML = post.content;
+		}
+
 		post = reduce( transforms, ( memo, transform ) => {
 			return transform( memo, dom );
 		}, post );

--- a/client/lib/post-normalizer/rule-with-content-dom.js
+++ b/client/lib/post-normalizer/rule-with-content-dom.js
@@ -9,7 +9,7 @@ export default function createDomTransformRunner( transforms ) {
 		let dom;
 		if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
 			const parser = new DOMParser();
-			dom = parser.parseFromString( post.content, 'text/html' );
+			dom = parser.parseFromString( post.content, 'text/html' ).body;
 		} else {
 			dom = document.createElement( 'div' );
 			dom.innerHTML = post.content;

--- a/client/lib/post-normalizer/rule-with-content-dom.js
+++ b/client/lib/post-normalizer/rule-with-content-dom.js
@@ -7,7 +7,7 @@ export default function createDomTransformRunner( transforms ) {
 		}
 
 		let dom;
-		if ( typeof DOMParser !== 'undefined' ) {
+		if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
 			const parser = new DOMParser();
 			dom = parser.parseFromString( post.content, 'text/html' );
 		} else {

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -911,7 +911,7 @@ describe( 'index', function() {
 				[
 					normalizer.withContentDOM( [ normalizer.content.detectPolls ] )
 				], function( err, normalized ) {
-					assert.include( normalized.content, '<p><a rel="external" target="_blank" href="http://polldaddy.com/poll/8980420">Take our poll</a></p>' );
+					assert.include( normalized.content, '<p><a rel="external" target="_blank" href="https://polldaddy.com/poll/8980420">Take our poll</a></p>' );
 					done( err );
 				}
 			);

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -75,3 +75,15 @@ export function makeImageURLSafe( object, propName, maxWidth, baseURL ) {
 		}
 	}
 }
+
+export function domForHtml( html ) {
+	let dom;
+	if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
+		const parser = new DOMParser();
+		dom = parser.parseFromString( html, 'text/html' ).body;
+	} else {
+		dom = document.createElement( 'div' );
+		dom.innerHTML = html;
+	}
+	return dom;
+}


### PR DESCRIPTION
This appears to prevent Firefox from trying to preload elements in the background DOM we use for normalization.

Test live: https://calypso.live/?branch=fix/post-norm/noscript