### PR TITLE
Bugfix: env_id error in state/jetpack tests

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -38,7 +38,7 @@ import addQueryArgs from 'lib/route/add-query-args';
  *  Local variables;
  */
 let _fetching = {};
-let calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
+let calypsoEnv;
 const apiBaseUrl = 'https://jetpack.wordpress.com';
 const remoteAuthPath = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
 const remoteInstallPath = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
@@ -49,6 +49,12 @@ const tracksEvent = ( dispatch, eventName, props ) => {
 		dispatch( recordTracksEvent( eventName, props ) );
 	}, 1 );
 };
+
+try {
+	calypsoEnv = config( 'env_id' );
+} catch ( err ) {
+	calypsoEnv = process.env.NODE_ENV || '';
+}
 
 export default {
 	dismissUrl( url ) {


### PR DESCRIPTION
# Steps to reproduce errors

On master, locally:
`npm run test-client -- --grep "state jetpack-connect"`

If you get this:
```
  1) state jetpack-connect actions "before each" hook for "should dispatch validate action when thunk triggered":
     Error: config key `env_id` does not exist
      at config (client/config/index.js:860:8)
      at Object.<anonymous> (client/state/jetpack-connect/actions.js:41:18)
      at normalLoader (node_modules/babel-core/lib/api/register/node.js:199:5)
      at Object.require.extensions.(anonymous function) [as .js] (node_modules/babel-core/lib/api/register/node.js:216:7)
      at require (internal/module.js:20:19)
      at Context.<anonymous> (client/state/jetpack-connect/test/actions.js:33:13)

```

This PR solves it :)

CC @roccotripaldi @johnHackworth 

Test live: https://calypso.live/?branch=fix/jetpack-env_id