### PR TITLE
Themes: Fix 'more' button links in IE11

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -67,8 +67,12 @@ class ThemeMoreButton extends React.Component {
 								<a className="theme__more-button-menu-item popover__menu-item"
 									onMouseOver={ this.focus }
 									key={ option.label }
-									// Use absolute link to work around IE11 bug with relative links in modals #5766
-									// TODO (seear): remove when we drop support for IE11
+									/*
+									 * Use absolute link to work around IE11 bug with relative links in modals #5766
+									 * TODO (seear): remove when we drop support for IE11
+									 *
+									 * If we match a leading slash followed by a non-slash, prepend //host
+									 */
 									href={ url.replace( /^\/[^\/]/, `//${ window.location.host }$&` ) }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>
 									{ option.label }

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -68,7 +68,7 @@ class ThemeMoreButton extends React.Component {
 									onMouseOver={ this.focus }
 									key={ option.label }
 									// Use absolute link to work around IE11 bug with relative links in modals
-									href={ url.replace( /^\//, `//${ window.location.host }/` ) }
+									href={ url.replace( /^\/[^\/]/, `//${ window.location.host }$&` ) }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>
 									{ option.label }
 								</a>

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -67,7 +67,8 @@ class ThemeMoreButton extends React.Component {
 								<a className="theme__more-button-menu-item popover__menu-item"
 									onMouseOver={ this.focus }
 									key={ option.label }
-									// Use absolute link to work around IE11 bug with relative links in modals
+									// Use absolute link to work around IE11 bug with relative links in modals #5766
+									// TODO (seear): remove when we drop support for IE11
 									href={ url.replace( /^\/[^\/]/, `//${ window.location.host }$&` ) }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>
 									{ option.label }

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -71,9 +71,9 @@ class ThemeMoreButton extends React.Component {
 									 * Use absolute link to work around IE11 bug with relative links in modals #5766
 									 * TODO (seear): remove when we drop support for IE11
 									 *
-									 * If we match a leading slash followed by a non-slash, prepend //host
+									 * If we match a leading slash followed by a non-slash, prepend protocol+host+port
 									 */
-									href={ url.replace( /^\/[^\/]/, `//${ window.location.host }$&` ) }
+									href={ url.replace( /^\/[^\/]/, `${ window.location.origin }$&` ) }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>
 									{ option.label }
 								</a>

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -67,7 +67,8 @@ class ThemeMoreButton extends React.Component {
 								<a className="theme__more-button-menu-item popover__menu-item"
 									onMouseOver={ this.focus }
 									key={ option.label }
-									href={ url }
+									// Use absolute link to work around IE11 bug with relative links in modals
+									href={ url.replace( /^\//, `//${ window.location.host }/` ) }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>
 									{ option.label }
 								</a>


### PR DESCRIPTION
Workaround for #5766

Use only absolute links in the the theme 'more' button.

**To Test**
* Go to /design
* in IE11, the 'details' and 'setup' links in the '...' button menu for a theme should work as intended
* All other links in the '...' menu should work as before, across all browsers


Test live: https://calypso.live/?branch=fix/themes-more-button-links-ie11