### PR TITLE
Update env-badge and the way we display its utilities.

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -510,9 +510,13 @@ body.newdash div.wordpress-com-extension-promo {
 .environment-badge {
 	position: fixed;
 		bottom: 16px;
-		left: 16px;
+		right: 16px;
 	z-index: z-index( 'root', '.environment-badge' );
 	backface-visibility: hidden;
+
+	&:hover .environment {
+		display: inline-block;
+	}
 
 	.bug-report {
 		position: relative;
@@ -535,7 +539,7 @@ body.newdash div.wordpress-com-extension-promo {
 
 	.environment {
 		position: relative;
-		display: inline-block;
+		display: none;
 		font-size: 9px;
 		font-weight: 600;
 		line-height: 1;
@@ -546,16 +550,19 @@ body.newdash div.wordpress-com-extension-promo {
 		&:before {
 			content: '';
 			position: absolute;
-				left: -1px;
-				right: 0;
+				right: -1px;
+				left: 0;
 				top: 0;
 				bottom: 0;
 			z-index: z-index( '.environment-badge', '.environment-badge .environment::before' );
 			background-color: $white;
 			border: solid 1px $gray-dark;
 		}
-		&:first-of-type:before {
-			left: -4px;
+		&.is-env {
+			display: inline-block;
+			&::before {
+				right: -4px;
+			}
 		}
 		a {
 			text-decoration: none;

--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -527,6 +527,7 @@ body.newdash div.wordpress-com-extension-promo {
 		border: solid 1px $gray-dark;
 		border-radius: 50%;
 		color: $gray-dark;
+		margin-left: -4px;
 		text-decoration: none;
 		text-align: center;
 		z-index: z-index( '.environment-badge', '.environment-badge .bug-report' );
@@ -547,22 +548,10 @@ body.newdash div.wordpress-com-extension-promo {
 		padding: 4px 7px 4px 6px;
 		vertical-align: middle;
 		transition: all 0.2s ease-out;
-		&:before {
-			content: '';
-			position: absolute;
-				right: -1px;
-				left: 0;
-				top: 0;
-				bottom: 0;
-			z-index: z-index( '.environment-badge', '.environment-badge .environment::before' );
-			background-color: $white;
-			border: solid 1px $gray-dark;
-		}
+		background-color: $white;
+		box-shadow: 0 0 0 1px $gray-dark;
 		&.is-env {
 			display: inline-block;
-			&::before {
-				right: -4px;
-			}
 		}
 		a {
 			text-decoration: none;
@@ -574,25 +563,17 @@ body.newdash div.wordpress-com-extension-promo {
 			}
 		}
 		&.is-staging {
-			&:before {
-				background-color: $alert-yellow;
-			}
+			background-color: $alert-yellow;
 		}
 		&.is-wpcalypso {
-			&:before {
-				background-color: #B1EED0;
-			}
+			background-color: #B1EED0;
 		}
 		&.is-dev {
-			&:before {
-				background-color: $alert-red;
-			}
+			background-color: $alert-red;
 		}
 		&.is-horizon,
 		&.is-feedback {
-			&:before {
-				background-color: $blue-light;
-			}
+			background-color: $blue-light;
 		}
 		&.branch-name {
 			text-transform: inherit;

--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -508,8 +508,9 @@ body.newdash div.wordpress-com-extension-promo {
 }
 
 .environment-badge {
+	padding: 16px 0;
 	position: fixed;
-		bottom: 16px;
+		bottom: 0;
 		right: 16px;
 	z-index: z-index( 'root', '.environment-badge' );
 	backface-visibility: hidden;
@@ -550,6 +551,7 @@ body.newdash div.wordpress-com-extension-promo {
 		transition: all 0.2s ease-out;
 		background-color: $white;
 		box-shadow: 0 0 0 1px $gray-dark;
+
 		&.is-env {
 			display: inline-block;
 		}

--- a/client/lib/abtest/test-helper/Test.jsx
+++ b/client/lib/abtest/test-helper/Test.jsx
@@ -10,9 +10,9 @@ export default React.createClass( {
 	render() {
 		const currentVariation = this.props.test.getVariation();
 		return (
-			<li>
+			<div>
 				<h5 className="test-helper__test-header">{ this.props.test.name }</h5>
-				<ul>
+				<ul className="test-helper__list">
 					{ this.props.test.variationNames.map( variation => (
 						<li onClick={ this.changeVariant.bind( this, variation ) } key={ variation } >
 							<a className={ classNames( {
@@ -24,7 +24,7 @@ export default React.createClass( {
 						</li>
 					) ) }
 				</ul>
-			</li>
+			</div>
 		);
 	}
 } );

--- a/client/lib/abtest/test-helper/TestList.jsx
+++ b/client/lib/abtest/test-helper/TestList.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Test from './Test';
 
+import Card from 'components/card';
+
 export default React.createClass( {
 	displayName: 'TestList',
 
@@ -8,13 +10,13 @@ export default React.createClass( {
 		return (
 			<div>
 				<a href={ "/devdocs/client/lib/abtest/README.md" } title="ABTests">ABTests</a>
-				<ul className="active-tests">
+				<Card className="active-tests">
 					{ this.props.tests.map( test => <Test
 						key={ test.name }
 						test={ test }
 						onChangeVariant={ this.props.onChangeVariant }
 					/> ) }
-				</ul>
+				</Card>
 			</div>
 		);
 	}

--- a/client/lib/abtest/test-helper/style.scss
+++ b/client/lib/abtest/test-helper/style.scss
@@ -9,7 +9,7 @@
 
 	&.test-helper__current-variation {
 		text-decoration: underline;
-		color: red;
+		color: $orange-jazzy;
 	}
 }
 
@@ -19,12 +19,17 @@
 	font-weight: bolder;
 }
 
-.environment.is-tests:hover {
-	position: absolute;
-	bottom: 5px;
-}
-.environment.is-tests:hover .active-tests {
-	display:block;
+.environment.is-tests:hover .active-tests.card {
+	display: block;
 	max-height: 80vh;
 	overflow-y: scroll;
+	position: absolute;
+		bottom: 0;
+		right: 100%;
+	margin: 0;
+	font-size: 11px;
+}
+
+.test-helper__list {
+	margin: 5px 0 8px 20px;
 }

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -66,15 +66,15 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				.wpcom-site__logo.noticon.noticon-wordpress
 		if badge
 			div.environment-badge
-				a(class='bug-report', href=feedbackURL, title='Report an issue', target='_blank')
-				span(class=['environment', 'is-' + badge])=badge
+				if abTestHelper
+					div(class=['environment', 'is-tests'])
 				if branchName && branchName !== 'master'
 					span(class=['environment', 'branch-name'], title='Commit ' + commitChecksum)=branchName
 				if devDocs
 					span(class=['environment', 'is-docs'])
 						a(href=devDocsURL title='DevDocs') docs
-				if abTestHelper
-					div(class=['environment', 'is-tests'])
+				span(class=['environment', 'is-' + badge, 'is-env'])=badge
+				a(class='bug-report', href=feedbackURL, title='Report an issue', target='_blank')
 
 		if 'development' !== env
 			script( src=catchJsErrors )


### PR DESCRIPTION
- Move to right corner to avoid overlaps.
- Make it more minimal by default until hover.
- Display tests within a Card.

Default view:
![image](https://cloud.githubusercontent.com/assets/548849/15859498/aa3337f2-2cc5-11e6-8dab-50c8e2a59d77.png)

Hover with branch:
![image](https://cloud.githubusercontent.com/assets/548849/15859525/cd6bd576-2cc5-11e6-8c76-07051babe1f1.png)

Showing tests:
![image](https://cloud.githubusercontent.com/assets/548849/15859477/9990b2ee-2cc5-11e6-966a-827630c52639.png)


Test live: https://calypso.live/?branch=update/env-badge