### PR TITLE
Plans Redesign Core/Essentials

### DIFF
--- a/client/components/main/index.jsx
+++ b/client/components/main/index.jsx
@@ -11,7 +11,7 @@ module.exports = React.createClass( {
 
 	render: function() {
 		return (
-			<main className={ classnames( this.props.className, 'main' ) } role="main">
+			<main className={ classnames( this.props.className, 'main' ) } role="main" style={ this.props.style }>
 				{ this.props.children }
 			</main>
 		);

--- a/client/components/plans-redesign/plan-actions/index.jsx
+++ b/client/components/plans-redesign/plan-actions/index.jsx
@@ -1,0 +1,285 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import page from 'page';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import { cartItems } from 'lib/cart-values';
+import config from 'config';
+import { isBusiness, isEnterprise, isFreePlan, isFreeJetpackPlan } from 'lib/products-values';
+import purchasesPaths from 'me/purchases/paths';
+import { isValidFeatureKey } from 'lib/plans';
+import * as upgradesActions from 'lib/upgrades/actions';
+
+const PlanActions = React.createClass( {
+	propTypes: {
+		plan: React.PropTypes.object,
+		selectedFeature: React.PropTypes.string
+	},
+
+	getButtons() {
+		if ( this.props.isImageButton ) {
+			return this.getImageButton();
+		}
+
+		if ( this.props.isInSignup ) {
+			return this.upgradeActions();
+		}
+
+		if ( ! this.props.sitePlan ) {
+			return null;
+		}
+
+		if ( this.props.site && ! this.props.site.isUpgradeable() ) {
+			return null;
+		}
+
+		if ( this.siteHasThisPlan() ) {
+			if ( this.props.sitePlan.freeTrial ) {
+				return this.upgradeActions();
+			}
+
+			return (
+				<div className="plan-actions__action-details">
+					<div className="plan-actions__current">
+						{ this.managePlanButton() }
+						{ this.getCurrentPlanHint() }
+					</div>
+				</div>
+			);
+		}
+
+		if ( this.canSelectPlan( this.props.plan ) ) {
+			return this.getInternalButtons();
+		}
+	},
+
+	getInternalButtons() {
+		if ( ! this.props.cart.hasLoadedFromServer || ! this.props.site ) {
+			return null;
+		}
+
+		return this.upgradeActions();
+	},
+
+	freePlanButton() {
+		return (
+			<div>
+				<button className="button is-primary plan-actions__upgrade-button"
+					disabled={ this.props.isSubmitting }
+					onClick={ this.handleSelectPlan }>
+					{ this.translate( 'Select Free Plan' ) }
+				</button>
+			</div>
+		);
+	},
+
+	freeJetpackPlanButton() {
+		return (
+			<div>
+				<button className="button is-primary plan-actions__upgrade-button"
+					disabled={ this.props.isSubmitting }
+					onClick={ this.handleSelectJetpackFreePlan }>
+					{ this.translate( 'Select Free Plan' ) }
+				</button>
+			</div>
+		);
+	},
+
+	upgradeActions() {
+		if ( isFreePlan( this.props.plan ) ) {
+			return this.freePlanButton();
+		}
+
+		if ( isFreeJetpackPlan( this.props.plan ) ) {
+			return this.freeJetpackPlanButton();
+		}
+
+		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
+			return null;
+		}
+
+		let label = this.translate( 'Upgrade Now' );
+
+		if ( this.props.sitePlan && this.props.sitePlan.freeTrial ) {
+			label = this.translate( 'Purchase Now' );
+		}
+
+		return (
+			<div>
+				<button
+					className="button is-primary plan-actions__upgrade-button"
+					disabled={ this.props.isSubmitting }
+					onClick={ this.handleSelectPlan }>
+					{ label }
+				</button>
+			</div>
+		);
+	},
+
+	recordUpgradeNowClick() {
+		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Link', 'Product ID', this.props.plan.product_id );
+	},
+
+	recordUpgradeNowButton() {
+		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Button', 'Product ID', this.props.plan.product_id );
+	},
+
+	getCartItem( properties ) {
+		return cartItems.getItemForPlan( this.props.plan, properties );
+	},
+
+	handleSelectJetpackFreePlan( event ) {
+		event.preventDefault();
+
+		if ( this.props.onSelectFreeJetpackPlan ) {
+			return this.props.onSelectFreeJetpackPlan();
+		}
+	},
+
+	handleSelectPlan( event ) {
+		event.preventDefault();
+
+		if ( this.props.isSubmitting ) {
+			return;
+		}
+
+		if ( this.props.site && ! this.props.site.isUpgradeable() ) {
+			return;
+		}
+
+		const actionType = event.target.tagName === 'A' ? 'link' : 'button';
+
+		if ( 'link' === actionType ) {
+			this.recordUpgradeNowClick();
+		} else {
+			this.recordUpgradeNowButton();
+		}
+
+		const cartItem = isFreePlan( this.props.plan ) ? null : this.getCartItem();
+
+		if ( this.props.onSelectPlan ) {
+			return this.props.onSelectPlan( cartItem );
+		}
+		upgradesActions.addItem( cartItem );
+
+		const checkoutPath = this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
+			? `/checkout/features/${this.props.selectedFeature}/${ this.props.site.slug }`
+			: `/checkout/${ this.props.site.slug }`;
+
+		page( checkoutPath );
+	},
+
+	canSelectPlan() {
+		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
+			return false;
+		}
+
+		if ( this.props.site ) {
+			if ( this.siteHasThisPlan() ) {
+				return false;
+			}
+
+			return this.planHasCost() && ! isBusiness( this.props.site.plan );
+		}
+
+		return true;
+	},
+
+	getImageButton() {
+		const classes = classNames( 'plan-actions__illustration', this.props.plan.product_slug );
+
+		if ( ! this.canSelectPlan( this.props.plan ) ) {
+			return (
+				<div className={ classes } />
+			);
+		}
+
+		return (
+			<div onClick={ this.handleSelectPlan } className={ classes } />
+		);
+	},
+
+	downgradeMessage() {
+		return (
+			<small className="plan-actions__trial-period">{ this.translate( 'Contact support to downgrade your plan.' ) }</small>
+		);
+	},
+
+	siteHasThisPlan() {
+		return ! this.props.isInSignup && this.props.site && this.props.site.plan.product_id === this.props.plan.product_id;
+	},
+
+	managePlanButton() {
+		if ( this.planHasCost() && this.props.sitePlan.userIsOwner ) {
+			const link = purchasesPaths.managePurchase( this.props.site.slug, this.props.sitePlan.id );
+
+			return (
+				<a href={ link } className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>
+			);
+		}
+	},
+
+	freePlanExpiration() {
+		if ( ! this.planHasCost() ) {
+			return (
+				<span className="plan-actions__plan-expiration">{ this.translate( 'Never expires', { context: 'Expiration info for free plan in /plans/' } ) }</span>
+			);
+		}
+	},
+
+	recordCurrentPlanClick() {
+		analytics.ga.recordEvent( 'Upgrades', 'Clicked Current Plan' );
+	},
+
+	getCurrentPlanHint() {
+		return (
+			<div>
+				<span className="plan-actions__current-plan-label" onClick={ this.recordCurrentPlanClick }>
+				{ this.translate( 'Your current plan', { context: 'Informing the user of their current plan on /plans/' } ) }</span>
+				{ this.freePlanExpiration() }
+			</div>
+		);
+	},
+
+	planHasCost() {
+		return this.props.plan.cost > 0;
+	},
+
+	placeholder() {
+		return <span className="button plan-actions__upgrade-button" />;
+	},
+
+	getContent() {
+		if ( this.props.isPlaceholder ) {
+			return this.placeholder();
+		}
+
+		if ( ! this.props.isInSignup && this.props.site && isEnterprise( this.props.site.plan ) ) {
+			return this.downgradeMessage();
+		}
+
+		return this.getButtons();
+	},
+
+	render() {
+		const classes = classNames( {
+			'plan-actions': true,
+			'is-placeholder': this.props.isPlaceholder,
+			'is-image-button': this.props.isImageButton
+		} );
+
+		return (
+			<div className={ classes }>
+				{ this.getContent() }
+			</div>
+		);
+	}
+} );
+
+export default PlanActions;

--- a/client/components/plans-redesign/plan-actions/style.scss
+++ b/client/components/plans-redesign/plan-actions/style.scss
@@ -1,0 +1,145 @@
+.plan { // This nesting is necessary to prevent these styles bleeding onto the /plans/compare screen
+	.plan-actions {
+		float: left;
+		width: 100%;
+		padding: 0 16px 16px 16px;
+		box-sizing: border-box;
+
+		&.is-image-button {
+			padding: 0;
+		}
+
+		.plan-actions__upgrade-button {
+			margin-top: 20px;
+		}
+	}
+
+	.plan-actions__action-details {
+		clear: both;
+		font-size: 12px;
+		color: darken( $gray, 10% );
+		@include clear-fix;
+		text-align: center;
+	}
+}
+
+.plan-actions__upgrade-button {
+	display: block;
+	text-align: center;
+	width: 100%;
+}
+
+.plan-actions__trial-period {
+	text-align: center;
+	line-height: 16px;
+	display: block;
+	padding: 5px 10px 0 5px;
+	color: $gray-dark;
+	opacity: .8;
+}
+
+.plan-actions.is-placeholder {
+	.plan-actions__upgrade-button {
+		@include placeholder( 23% );
+		border: none;
+		border-radius: 0;
+		margin-bottom: 0.5em;
+		pointer-events: none;
+	}
+
+	.plan-actions__trial-period {
+		height: 3em;
+	}
+}
+
+.plan-actions__current {
+	.plan-actions__upgrade-button {
+		background: $white;
+		margin: 0 0 8px 0;
+	}
+
+	.plan-actions__plan-expiration {
+		color: $gray-dark;
+		display: block;
+		font-size: 11px;
+		opacity: .8;
+		padding: 7px 0 0 0;
+	}
+}
+
+.plan-actions__current-plan-label {
+	border: 1px solid lighten( $gray, 20% );
+	border-radius: 4px;
+	color: $gray-dark;
+	display: block;
+	font-size: 14px;
+	opacity: .6;
+	padding: 0.5em 1.2em 0.62em;
+	text-align: center;
+
+	&:before {
+		@extend %clear-text;
+		@include noticon( '\f418', 18px );
+
+		color: $alert-green;
+		margin-left: -10px;
+		padding-right: 5px;
+		text-align: center;
+		vertical-align: middle;
+	}
+}
+
+.plan-actions__trial-hint {
+	font-size: 12px;
+	line-height: 18px;
+}
+
+.plan-actions__trial-upgrade-now {
+	white-space: nowrap;
+}
+
+.plans.has-sidebar {
+	@include breakpoint( "<960px" ) {
+		@include plans-collapsed();
+	}
+
+	@include breakpoint( ">960px" ) {
+		@include plans-in-three-columns();
+	}
+}
+
+.plans.has-no-sidebar {
+	@include breakpoint( "<660px" ) {
+		@include plans-collapsed();
+	}
+
+	@include breakpoint( ">660px" ) {
+		@include plans-in-three-columns();
+	}
+}
+.plan-actions__illustration {
+	width: 100px;
+	height: 100px;
+	margin: 5px auto 10px auto;
+	background-size: 100%;
+	border-radius: 50%;
+	border: 5px solid lighten( $gray, 30% );
+}
+
+.free_plan.plan-actions__illustration,
+.jetpack_free.plan-actions__illustration {
+	background-image: url('/calypso/images/plans/plan-beginner.svg');
+}
+
+.personal-bundle.plan-actions__illustration {
+	background-image: url('/calypso/images/plans/plan-personal.svg');
+}
+
+.value_bundle.plan-actions__illustration,
+.jetpack_premium.plan-actions__illustration {
+	background-image: url('/calypso/images/plans/plan-premium.svg');
+}
+.business-bundle.plan-actions__illustration,
+.jetpack_business.plan-actions__illustration {
+	background-image: url('/calypso/images/plans/plan-business.svg');
+}

--- a/client/components/plans-redesign/plan-discount-message/index.jsx
+++ b/client/components/plans-redesign/plan-discount-message/index.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { isBusiness, isPremium } from 'lib/products-values';
+
+const PlanDiscountMessage = React.createClass( {
+	showMostPopularMessage() {
+		return (
+			this.props.showMostPopularMessage &&
+			isPremium( this.props.plan ) &&
+			this.props.plan.product_id !== ( this.props.site && this.props.site.plan.product_id )
+		);
+	},
+
+	mostPopularPlan() {
+		const hasBusiness = this.props.site && isBusiness( this.props.site.plan );
+
+		return (
+			hasBusiness ? null : <div className="plan-discount-message">{ this.translate( 'Our most popular plan' ) }</div>
+		);
+	},
+
+	planHasDiscount() {
+		return this.props.sitePlan && this.props.sitePlan.rawDiscount > 0;
+	},
+
+	planDiscountMessage() {
+		const message = this.translate( 'Get %(discount)s off your first year', {
+			args: { discount: this.props.sitePlan.formattedDiscount }
+		} );
+
+		return (
+			<span className="plan-discount-message">{ message }</span>
+		);
+	},
+
+	render() {
+		if ( this.showMostPopularMessage() ) {
+			return this.mostPopularPlan();
+		}
+		return false;
+	}
+} );
+
+export default PlanDiscountMessage;

--- a/client/components/plans-redesign/plan-discount-message/style.scss
+++ b/client/components/plans-redesign/plan-discount-message/style.scss
@@ -1,0 +1,59 @@
+.plan-discount-message {
+	display: block;
+	padding: 2px 10px;
+	box-sizing: border-box;
+	background: $gray-dark;
+	color: $white;
+	font-size: 10px;
+	text-transform: uppercase;
+}
+
+.plan-discount-message {
+	display: block;
+	width: 100%;
+}
+
+@mixin plans-in-three-columns() {
+	.plan-discount-message {
+		text-align: center;
+	}
+
+	.plan-discount-message {
+		position: absolute;
+			top: -19px;
+		z-index: z-index( 'root', '.plan-discount-message' );
+	}
+
+	.plans-compare {
+		.plan-discount-message {
+			margin: 0 10px;
+			padding: 5px 10px;
+			position: relative;
+				top: auto;
+			width: calc( 100% - 20px );
+
+			&:after {
+				content: "";
+				position: absolute;
+				border-width: 10px;
+				border-style: solid;
+				border-color: transparent transparent $gray-dark transparent;
+				top: -20px;
+				left: 42%;
+			}
+		}
+	}
+}
+
+.plans.has-sidebar {
+	@include breakpoint( ">960px" ) {
+		@include plans-in-three-columns();
+	}
+}
+
+.plans.has-no-sidebar {
+	@include breakpoint( ">660px" ) {
+		@include plans-in-three-columns();
+	}
+}
+

--- a/client/components/plans-redesign/plan-header/index.jsx
+++ b/client/components/plans-redesign/plan-header/index.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React from 'react';
+
+const PlanHeader = React.createClass( {
+	propTypes: {
+		isPlaceholder: React.PropTypes.bool,
+		text: React.PropTypes.string
+	},
+
+	render() {
+		const classes = classNames( {
+			'plan-header': true,
+			'is-placeholder': this.props.isPlaceholder
+		} );
+
+		return (
+			<div className={ classes }>
+				<h2 className="plan-header__title">{ this.props.text }</h2>
+
+				{ this.props.children }
+			</div>
+		);
+	}
+} );
+
+export default PlanHeader;

--- a/client/components/plans-redesign/plan-header/style.scss
+++ b/client/components/plans-redesign/plan-header/style.scss
@@ -1,0 +1,164 @@
+.plan, .plan-feature-column {
+	.plan-header__title {
+		&:before {
+			background-size: 100%;
+			content: '';
+			display: block;
+			margin: 0 auto;
+			width: 35px;
+			height: 35px;
+		}
+	}
+
+	&.personal-bundle {
+		.plan-header__title:before {
+			background-image: url( '/calypso/images/plans/plan-personal.svg' );
+		}
+	}
+	&.free_plan,
+	&.jetpack_free {
+		.plan-header__title:before {
+			background-image: url( '/calypso/images/plans/plan-beginner.svg' );
+		}
+	}
+	&.value_bundle,
+	&.jetpack_premium {
+		.plan-header__title:before {
+			background-image: url( '/calypso/images/plans/plan-premium.svg' );
+		}
+	}
+	&.business-bundle,
+	&.jetpack_business {
+		.plan-header__title:before {
+			background-image: url( '/calypso/images/plans/plan-business.svg' );
+		}
+	}
+}
+
+.plan {
+	.plan-header {
+		background: $white;
+		width: 100%;
+		padding: 24px 16px 16px;
+		position: relative;
+		box-sizing: border-box;
+		cursor: pointer;
+
+		&:after {
+			@include noticon( '\f431', 16px );
+			color: $blue-medium;
+			font-size: 30px;
+			position: absolute;
+				right: 10px;
+				top: 20px;
+			transition: all .3s ease-in-out;
+		}
+
+		.plan-header__title {
+			color: $blue-wordpress;
+			display: block;
+			font-size: 17px;
+			line-height: 16px;
+			text-align: center;
+
+			&:before {
+				left: 10px;
+				top: 16px;
+				position: absolute;
+			}
+		}
+	}
+
+	&.is-active {
+		.plan-header:after {
+			transform: rotate(180deg);
+		}
+	}
+}
+
+.plan-header.is-placeholder {
+	.plan-header__title {
+		@include placeholder( 23% );
+		margin: 0 auto 5px;
+		width: 60%;
+
+		&:before {
+			display: none;
+		}
+	}
+
+	@include breakpoint( "<480px" ) {
+		height: 70px;
+	}
+}
+
+@mixin plans-in-three-columns() {
+	.plan, .plan-feature-column {
+		.plan-header {
+			.plan-header__title {
+				&:before {
+					display: none;
+				}
+			}
+		}
+	}
+
+	.plan.card {
+		.plan-header {
+			border-bottom: 2px solid lighten( $gray, 20% );
+			min-height: 282px;
+			padding: 16px;
+
+			&:after {
+				display: none;
+			}
+
+			.plan-header__title {
+				line-height: 20px;
+			}
+		}
+	}
+}
+
+@mixin plans-collapsed() {
+	.plan.card {
+		.plan-header {
+			float: left;
+
+			.plan-header__title {
+				margin: -8px 0 0 0;
+				padding: 0 0 0 40px;
+				text-align: left;
+			}
+			.plan-actions {
+				display: none;
+			}
+		}
+	}
+}
+
+.plans.has-sidebar {
+	@include breakpoint( "<960px" ) {
+		@include plans-collapsed();
+	}
+
+	@include breakpoint( ">960px" ) {
+		@include plans-in-three-columns();
+	}
+}
+
+.plans.has-no-sidebar {
+	@include breakpoint( "<660px" ) {
+		@include plans-collapsed();
+	}
+
+	@include breakpoint( ">660px" ) {
+		@include plans-in-three-columns();
+	}
+}
+
+.plan-list .jetpack_free .plan-header__title,
+.plan-list .jetpack_premium .plan-header__title,
+.plan-list .jetpack_business .plan-header__title {
+	margin-top: 15px;
+}

--- a/client/components/plans-redesign/plan-list/index.jsx
+++ b/client/components/plans-redesign/plan-list/index.jsx
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import times from 'lodash/times';
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+import Card from 'components/card';
+import { filterPlansBySiteAndProps } from 'lib/plans';
+import { getCurrentPlan } from 'lib/plans';
+import { isJpphpBundle } from 'lib/products-values';
+import Plan from 'components/plans/plan';
+
+const PlanListRedesign = React.createClass( {
+	getInitialState() {
+		return { openPlan: '' };
+	},
+
+	openPlan( planId ) {
+		this.setState( { openPlan: planId === this.state.openPlan ? '' : planId } );
+	},
+
+	render() {
+		const isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer;
+		const { site, hideFreePlan, plans, showJetpackFreePlan } = this.props;
+
+		let className = '',
+			numberOfPlaceholders = abtest( 'personalPlan' ) === 'hide' ? 3 : 4;
+
+		if ( hideFreePlan || ( site && site.jetpack ) ) {
+			numberOfPlaceholders = showJetpackFreePlan ? 3 : 2;
+			className = 'jetpack';
+		}
+
+		let plansList;
+
+		if ( plans.length === 0 || isLoadingSitePlans ) {
+			plansList = times( numberOfPlaceholders, ( n ) => {
+				return (
+					<Plan
+						className={ className }
+						placeholder={ true }
+						isInSignup={ this.props.isInSignup }
+						key={ `plan-${ n }` } />
+				);
+			} );
+
+			return (
+				<div className="plan-list">
+					{ plansList }
+				</div>
+			);
+		}
+
+		if ( ! this.props.isInSignup ) {
+			// check if this site was registered via the JPPHP "Jetpack Start" program
+			// if so, we want to display a message that this plan is managed via the hosting partner
+			const currentPlan = getCurrentPlan( this.props.sitePlans.data );
+
+			if ( isJpphpBundle( currentPlan ) ) {
+				return (
+					<Card>
+						<p>
+							{
+								this.translate( 'This plan is managed by your web host. ' +
+									'Please log into your host\'s control panel to manage subscription ' +
+									'and billing information.' )
+							}
+						</p>
+					</Card>
+				);
+			}
+		}
+
+		if ( plans.length > 0 ) {
+			const filteredPlans = filterPlansBySiteAndProps( plans, site, hideFreePlan, showJetpackFreePlan );
+
+			plansList = filteredPlans.map( plan => {
+				return (
+					<Plan
+						plan={ plan }
+						sitePlans={ this.props.sitePlans }
+						comparePlansUrl={ this.props.comparePlansUrl }
+						hideDiscountMessage={ hideFreePlan }
+						isInSignup={ this.props.isInSignup }
+						key={ plan.product_id }
+						open={ plan.product_id === this.state.openPlan }
+						onOpen={ this.openPlan }
+						onSelectPlan={ this.props.onSelectPlan }
+						site={ site }
+						cart={ this.props.cart }
+						isSubmitting={ this.props.isSubmitting }
+						onSelectFreeJetpackPlan={ this.props.onSelectFreeJetpackPlan } />
+				);
+			} );
+		}
+
+		return (
+			<div className="plan-list--redesign">
+				{ plansList }
+			</div>
+		);
+	}
+} );
+
+export default PlanListRedesign;

--- a/client/components/plans-redesign/plan-list/style.scss
+++ b/client/components/plans-redesign/plan-list/style.scss
@@ -1,0 +1,231 @@
+.plan-list--redesign {
+	@include breakpoint( ">1040px" ) {
+		display: flex;
+		flex-flow: row wrap;
+		padding-top: 19px; // popular banner height adjustment
+	}
+
+	+ .faq {
+		margin-top: 20px;
+	}
+}
+
+// (component) Plan
+.plan--redesign {
+	margin: 0 0 16px;
+	border: solid 1px lighten( $gray, 27% );
+	background-color: lighten( $gray, 35% );
+
+	&.is-popular {
+		margin-top: 35px; // popular banner + margin
+	}
+
+	@include breakpoint( ">1040px" ) {
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		flex: 1;
+		margin: 0 0 24px 24px;
+
+		&.is-popular {
+			margin-top: 0;
+		}
+
+		&:first-child {
+			margin-left: 0;
+		}
+	}
+}
+
+// (component) PlanHeader
+.plan-header--redesign {
+	position: relative;
+	display: flex;
+	align-items: center;
+	padding: 12px 24px 12px 12px;
+	border-bottom: solid 2px lighten( $gray, 20% );
+	background-color: $white;
+}
+
+.plan-header__figure--redesign {
+	position: relative;
+	width: 70px;
+	height: 70px;
+	margin-right: 12px;
+	border: solid 6px $gray-light;
+	border-radius: 50%;
+	background-size: cover;
+
+	&.is-free {
+		background-image: url( '/calypso/images/plans/plan-beginner.svg' );
+	}
+
+	&.is-premium {
+		background-image: url( '/calypso/images/plans/plan-premium.svg' );
+	}
+
+	&.is-business {
+		background-image: url( '/calypso/images/plans/plan-business.svg' );
+	}
+
+	.gridicon {
+		position: absolute;
+		top: 0;
+		right: 0;
+		transform: translate(25%, -25%);
+		fill: $alert-green;
+	}
+}
+
+.plan-header__text--redesign {
+	flex: 1;
+	padding: 6px 0;
+}
+
+.plan-header__title--redesign,
+.plan-header__price--redesign,
+.plan-header__timeframe--redesign {
+	line-height: 1;
+	margin: 0;
+}
+
+.plan-header__title--redesign {
+	font-size: 18px;
+	color: $blue-wordpress;
+}
+
+.plan-header__price--redesign {
+	margin: 8px 0;
+	font-size: 24px;
+}
+
+.plan-header__price__symbol--redesign,
+.plan-header__price__minor--redesign {
+	vertical-align: super;
+	font-size: 12px;
+}
+
+.plan-header__price__symbol--redesign {
+	color: $gray;
+}
+
+.plan-header__price__minor--redesign,
+.plan-header__price__major--redesign {
+	color: $gray-dark;
+}
+
+.plan-header__price__major--redesign {
+	margin: 0 3px;
+	font-weight: 400;
+}
+
+.plan-header__price__minor--redesign {
+	font-weight: 500;
+}
+
+.plan-header__timeframe--redesign {
+	font-size: 12px;
+	font-style: italic;
+	font-weight: 400;
+	color: $gray;
+}
+
+.plan-header__popular-banner--redesign {
+	box-sizing: border-box;
+	position: absolute;
+	left: -1px;
+	right: -1px;
+	top: 0;
+	transform: translateY( calc( -100% - 1px ) );
+	padding: 0 8px;
+	background: $gray-dark;
+	font-size: 10px;
+	line-height: 20px;
+	text-align: center;
+	text-transform: uppercase;
+	color: $white;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+// (component) PlanFeatureList
+.plan-feature-list--redesign {
+	list-style: none;
+	margin: 0;
+}
+
+// (component) PlanFeature
+.plan-feature--redesign {
+	position: relative;
+	margin: 0 16px;
+	padding: 12px 0 12px 30px;
+	border-bottom: solid 1px lighten( $gray, 27% );
+	font-size: 14px;
+	color: $gray-dark;
+
+	&:last-child {
+		border-bottom: none;
+	}
+
+	.gridicons-checkmark {
+		position: absolute;
+		left: 0;
+		top: 50%;
+		transform: translateY(-50%);
+		fill: $blue-wordpress;
+	}
+
+	@include breakpoint( ">480px" ) {
+		margin: 0 24px;
+	}
+}
+
+// (component) PlanFooter
+.plan-footer--redesign {
+	margin-top: auto;
+	padding: 16px 16px 24px;
+	border-top: solid 1px lighten( $gray, 27% );
+
+	@include breakpoint( ">480px" ) {
+		padding: 16px 24px 24px;
+	}
+}
+
+.plan-footer__desc--redesign {
+	margin: 0;
+	font-size: 14px;
+	color: $gray;
+}
+
+.plan-footer__buttons--redesign {
+	text-align: center;
+}
+
+.plan-footer__button--redesign {
+	width: 100%;
+	margin-top: 8px;
+
+	&:first-child {
+		margin-top: 16px;
+	}
+
+	&.is-current {
+		border-bottom-width: 1px;
+		border-color: lighten( $gray, 27% );
+		background: transparent;
+		font-weight: 400;
+		color: $gray;
+
+		.gridicon {
+			fill: $alert-green;
+			margin-right: 8px;
+		}
+	}
+
+	@media
+	(min-width: 480px) and (max-width: 660px),
+	(min-width: 800px) and (max-width: 1040px) {
+		max-width: 260px;
+	}
+}

--- a/client/components/plans-redesign/plan-price/index.jsx
+++ b/client/components/plans-redesign/plan-price/index.jsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import isUndefined from 'lodash/isUndefined';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+import WpcomPlanPrice from 'my-sites/plans/wpcom-plan-price';
+
+const PlanPrice = React.createClass( {
+	getFormattedPrice( plan ) {
+		let rawPrice, formattedPrice;
+
+		if ( plan ) {
+			// the properties of a plan object from sites-list is snake_case
+			// the properties of a plan object from the global state are camelCase
+			rawPrice = isUndefined( plan.rawPrice ) ? plan.raw_price : plan.rawPrice;
+			formattedPrice = isUndefined( plan.formattedPrice ) ? plan.formatted_price : plan.formattedPrice;
+
+			if ( rawPrice === 0 ) {
+				return this.translate( 'Free', { context: 'Zero cost product price' } );
+			}
+
+			if ( abtest( 'planPricing' ) === 'monthly' ) {
+				const monthlyPrice = +( rawPrice / 12 ).toFixed( 2 );
+				formattedPrice = formattedPrice.replace( rawPrice, monthlyPrice );
+			}
+
+			return formattedPrice;
+		}
+
+		return this.translate( 'Loading' );
+	},
+
+	getPrice() {
+		const standardPrice = this.getFormattedPrice( this.props.plan ),
+			discountedPrice = this.getFormattedPrice( this.props.sitePlan );
+
+		if ( this.props.sitePlan && this.props.sitePlan.rawDiscount > 0 ) {
+			return ( <span><span className="plan-price__discounted">{ standardPrice }</span> { discountedPrice }</span> );
+		}
+
+		return ( <span>{ standardPrice }</span> );
+	},
+
+	render() {
+		let periodLabel;
+		const { plan, sitePlan: details } = this.props,
+			hasDiscount = details && details.rawDiscount > 0;
+
+		if ( this.props.isPlaceholder ) {
+			return <div className="plan-price is-placeholder" />;
+		}
+
+		if ( ! plan ) {
+			periodLabel = '';
+		} else if ( abtest( 'planPricing' ) === 'monthly' && plan.raw_price > 0 ) {
+			periodLabel = this.translate( 'per month, billed yearly' );
+		} else {
+			periodLabel = hasDiscount ? this.translate( 'due today when you upgrade' ) : plan.bill_period_label;
+		}
+
+		return (
+			<WpcomPlanPrice
+				getPrice={ this.getPrice }
+				hasDiscount={ hasDiscount }
+				periodLabel={ periodLabel } />
+		);
+	}
+} );
+
+export default PlanPrice;

--- a/client/components/plans-redesign/plan-price/style.scss
+++ b/client/components/plans-redesign/plan-price/style.scss
@@ -1,0 +1,135 @@
+.plan-header .plan-price,
+.plan-header .jetpack-plan-price,
+.plan-header .wpcom-plan-price {
+	color: $gray-dark;
+	font-size: 14px;
+	font-weight: 400;
+	line-height: 20px;
+}
+
+.plan-price__billing-period,
+.jetpack-plan-price__billing-period,
+.wpcom-plan-price__billing-period {
+	font-size: 12px;
+	font-style: italic;
+	color: darken( $gray, 10% );
+}
+
+.plan-header .plan-price__discount,
+.plan-header .jetpack-plan-price__discount,
+.plan-header .wpcom-plan-price__discount,
+.plan-price__discount .plan-price__billing-period,
+.jetpack-plan-price__discount .jetpack-plan-price__billing-period,
+.wpcom-plan-price__discount .wpcom-plan-price__billing-period {
+	color: $alert-green;
+}
+
+.plan-price.is-placeholder,
+.jetpack-plan-price.is-placeholder,
+.wpcom-plan-price.is-placeholder {
+	@include placeholder( 23% );
+}
+
+.plan-price__discounted,
+.jetpack-plan-price__discounted,
+.wpcom-plan-price__discounted {
+	color: $gray;
+	text-decoration: line-through;
+}
+
+.plans-compare {
+	.plan-price,
+	.jetpack-plan-price,
+	.wpcom-plan-price {
+		font-size: 10px;
+		padding: .25em 0;
+
+		@include breakpoint( ">480px" ) {
+			font-size: 12px;
+		}
+
+		@include breakpoint( ">660px" ) {
+			font-size: 16px;
+		}
+	}
+
+	.plan-price__billing-period,
+	.jetpack-plan-price__billing-period,
+	.wpcom-plan-price__billing-period {
+		display: inline;
+		opacity: .7;
+	}
+
+	.plan-price__discount,
+	.jetpack-plan-price__discount,
+	.wpcom-plan-price__discount {
+		color: $alert-green;
+	}
+}
+
+@mixin plans-collapsed() {
+	.plan-header .plan-price,
+	.plan-header .jetpack-plan-price,
+	.plan-header .wpcom-plan-price {
+		padding: 0 20px 0 40px;
+	}
+
+	.plan-price__billing-period,
+	.jetpack-plan-price__billing-period,
+	.wpcom-plan-price__billing-period {
+		margin-left: 3px;
+	}
+
+	.plans-compare {
+		.plan-header .wpcom-plan-price {
+			font-size: 13px;
+			padding: 0;
+		}
+	}
+}
+
+@mixin plans-in-three-columns() {
+	.plan-header .plan-price,
+	.plan-header .jetpack-plan-price,
+	.plan-header .wpcom-plan-price {
+		text-align: center;
+		font-size: 18px;
+	}
+
+	.plan-price__billing-period,
+	.jetpack-plan-price__billing-period,
+	.wpcom-plan-price__billing-period {
+		display: block;
+	}
+
+	.plans-compare {
+		.plan-header .plan-price {
+			font-size: 16px;
+
+			.plan-price__billing-period {
+				display: inline;
+				margin-left: 3px;
+			}
+		}
+	}
+}
+
+.plans.has-sidebar {
+	@include breakpoint( "<960px" ) {
+		@include plans-collapsed();
+	}
+
+	@include breakpoint( ">960px" ) {
+		@include plans-in-three-columns();
+	}
+}
+
+.plans.has-no-sidebar {
+	@include breakpoint( "<660px" ) {
+		@include plans-collapsed();
+	}
+
+	@include breakpoint( ">660px" ) {
+		@include plans-in-three-columns();
+	}
+}

--- a/client/components/plans-redesign/plan/index.jsx
+++ b/client/components/plans-redesign/plan/index.jsx
@@ -1,0 +1,236 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import find from 'lodash/find';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import JetpackPlanDetails from 'my-sites/plans/jetpack-plan-details';
+import PlanActions from 'components/plans/plan-actions';
+import PlanDiscountMessage from 'components/plans/plan-discount-message';
+import PlanHeader from 'components/plans/plan-header';
+import PlanPrice from 'components/plans/plan-price';
+import WpcomPlanDetails from 'my-sites/plans/wpcom-plan-details' ;
+
+const Plan = React.createClass( {
+	handleLearnMoreClick() {
+		window.scrollTo( 0, 0 );
+		this.recordLearnMoreClick();
+	},
+
+	recordLearnMoreClick() {
+		analytics.ga.recordEvent( 'Upgrades', 'Clicked Learn More Link', 'Product ID', this.props.plan.product_id );
+
+		if ( this.props.isInSignup ) {
+			analytics.tracks.recordEvent( 'calypso_signup_compare_plans_click', {
+				location: 'Learn more link',
+				product_slug: this.props.plan.product_slug
+			} );
+		}
+	},
+
+	getComparePlansUrl() {
+		const site = this.props.site,
+			siteSuffix = site ? site.slug : '';
+
+		return this.props.comparePlansUrl ? this.props.comparePlansUrl : '/plans/compare/' + siteSuffix;
+	},
+
+	getDescription() {
+		const { plan, site } = this.props;
+
+		if ( this.isPlaceholder() ) {
+			return (
+				<div>
+					<p></p>
+
+					<p></p>
+				</div>
+			);
+		}
+
+		if ( site && site.jetpack ) {
+			return (
+				<JetpackPlanDetails plan={ plan } />
+			);
+		}
+
+		return (
+			<WpcomPlanDetails
+				comparePlansUrl={ this.getComparePlansUrl() }
+				handleLearnMoreClick={ this.handleLearnMoreClick }
+				plan={ plan } />
+		);
+	},
+
+	showDetails() {
+		if ( 'function' === typeof ( this.props.onOpen ) ) {
+			this.props.onOpen( this.props.plan.product_id );
+		}
+	},
+
+	selectedSiteHasPlan() {
+		return this.props.site && this.props.site.plan.product_id === this.props.plan.product_id;
+	},
+
+	isPlaceholder() {
+		return this.props.placeholder;
+	},
+
+	getProductSlug() {
+		if ( this.isPlaceholder() ) {
+			return;
+		}
+
+		return this.props.plan.product_slug;
+	},
+
+	getClassNames() {
+		const classObject = {
+			plan: true,
+			'is-active': this.props.open,
+			'is-current-plan': this.selectedSiteHasPlan()
+		};
+
+		if ( this.isPlaceholder() ) {
+			classObject[ 'is-placeholder' ] = true;
+		} else {
+			classObject[ this.props.plan.product_slug ] = true;
+		}
+
+		return classNames( classObject );
+	},
+
+	getSitePlan() {
+		if ( this.isPlaceholder() || ! this.props.site ) {
+			return;
+		}
+
+		return find( this.props.sitePlans.data, { productSlug: this.getProductSlug() } );
+	},
+
+	getPlanDiscountMessage() {
+		if ( this.isPlaceholder() || this.props.hideDiscountMessage ) {
+			return;
+		}
+
+		return (
+			<PlanDiscountMessage
+				plan={ this.props.plan }
+				sitePlan={ this.getSitePlan() }
+				site={ this.props.site }
+				showMostPopularMessage={ true } />
+		);
+	},
+
+	getBadge() {
+		if ( this.props.site && ! this.props.site.jetpack ) {
+			if ( this.props.site.plan.product_slug === this.getProductSlug() ) {
+				return (
+					<Gridicon icon="checkmark-circle" />
+				);
+			}
+		}
+	},
+
+	getProductName() {
+		if ( this.isPlaceholder() ) {
+			return;
+		}
+
+		return this.props.plan.product_name_short;
+	},
+
+	getPlanTagline() {
+		if ( this.isPlaceholder() ) {
+			return;
+		}
+
+		return this.props.plan.tagline;
+	},
+
+	getPlanPrice() {
+		const isAllMySites = ! this.props.site && ! this.props.isInSignup;
+
+		if ( isAllMySites ) {
+			return;
+		}
+
+		return (
+			<PlanPrice
+				plan={ this.props.plan }
+				isPlaceholder={ this.isPlaceholder() }
+				isInSignup={ this.props.isInSignup }
+				sitePlan={ this.getSitePlan() } />
+		);
+	},
+
+	getPlanActions() {
+		return (
+			<PlanActions
+				plan={ this.props.plan }
+				isInSignup={ this.props.isInSignup }
+				onSelectPlan={ this.props.onSelectPlan }
+				sitePlan={ this.getSitePlan() }
+				site={ this.props.site }
+				cart={ this.props.cart }
+				isPlaceholder={ this.isPlaceholder() }
+				isSubmitting={ this.props.isSubmitting }
+				onSelectFreeJetpackPlan={ this.props.onSelectFreeJetpackPlan } />
+		);
+	},
+
+	getImagePlanAction() {
+		return (
+			<PlanActions
+				plan={ this.props.plan }
+				isInSignup={ this.props.isInSignup }
+				onSelectPlan={ this.props.onSelectPlan }
+				sitePlan={ this.getSitePlan() }
+				site={ this.props.site }
+				cart={ this.props.cart }
+				isPlaceholder={ this.isPlaceholder() }
+				isSubmitting={ this.props.isSubmitting }
+				isImageButton />
+		);
+	},
+
+	render() {
+		return (
+			<Card
+				className={ this.getClassNames() }
+				key={ this.getProductSlug() }
+				onClick={ this.showDetails }
+			>
+				{ this.getPlanDiscountMessage() }
+				<PlanHeader
+					onClick={ this.showDetails }
+					text={ this.getProductName() }
+					isPlaceholder={ this.isPlaceholder() }
+				>
+					{ this.getBadge() }
+
+					<p className="plan__plan-tagline">{ this.getPlanTagline() }</p>
+
+					{ this.getImagePlanAction() }
+					{ this.getPlanPrice() }
+				</PlanHeader>
+
+				<div className="plan__plan-expand">
+					<div className="plan__plan-details">
+						{ this.getDescription() }
+					</div>
+					{ this.getPlanActions() }
+				</div>
+			</Card>
+		);
+	}
+} );
+
+export default Plan;

--- a/client/components/plans-redesign/plan/style.scss
+++ b/client/components/plans-redesign/plan/style.scss
@@ -1,0 +1,194 @@
+.plan {
+	background: $gray-light;
+	box-sizing: border-box;
+	position: relative;
+	width: 100%;
+	margin: 0 0 15px 0;
+	padding: 0;
+
+	&.jetpack_free,
+	&.jetpack_premium,
+	&.jetpack_business {
+		display: flex;
+		flex-direction: column;
+	}
+
+	&.is-placeholder {
+		.plan__plan-tagline {
+			@include placeholder( 23% );
+		}
+
+		.plan__illustration {
+			display: none;
+		}
+
+		.plan__plan-details {
+			p {
+				@include placeholder( 25% );
+				margin-bottom: 5px;
+			}
+
+			p:nth-child(2) {
+				width: 70%;
+			}
+		}
+	}
+
+	.gridicons-checkmark-circle {
+		fill: $alert-green;
+		position: absolute;
+		z-index: z-index( 'root', '.plan .gridicons-checkmark-circle' );
+		left: 30px;
+		top: 6px;
+	}
+}
+
+.plan__plan-expand {
+	overflow: hidden;
+	transition: all 0.4s ease-in-out;
+	width: 100%;
+
+	.jetpack_free &,
+	.jetpack_premium &,
+	.jetpack_business & {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+	}
+
+}
+
+.plan__plan-details {
+	box-sizing: border-box;
+	color: $gray-dark;
+	padding: 16px;
+	width: 100%;
+	font-size: 13px;
+	opacity: 0.8;
+
+	ul {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		font-size: 12px;
+
+		li {
+			font-size: 13px;
+			padding: 5px 0 5px 14px;
+			opacity: .8;
+		}
+	}
+
+	p {
+		margin: 0;
+	}
+
+	.plan__learn-more {
+		font-size: 13px;
+		display: block;
+		margin: 8px 0 0 0;
+	}
+
+	.jetpack_free &,
+	.jetpack_premium &,
+	.jetpack_business & {
+		flex-grow: 1;
+	}
+}
+
+@mixin plans-collapsed() {
+	.plan.is-active {
+		.plan__plan-expand {
+			max-height: 500px;
+		}
+	}
+
+	.plan__plan-expand {
+		max-height: 0;
+	}
+
+	.plan__plan-tagline {
+		display: none;
+	}
+
+	.plan__illustration {
+		display: none;
+	}
+
+	.plan__plan-details {
+		border-top: 2px solid lighten( $gray, 20% );
+		float: left;
+	}
+}
+
+@mixin plans-in-three-columns() {
+	.plan {
+		margin: 0 2% 15px 0;
+
+		&:last-child {
+			margin-right: 0;
+		}
+
+		.gridicons-checkmark-circle {
+			left: 50%;
+			top: 64px;
+			margin-left: 30px;
+		}
+
+		&.jetpack_free,
+		&.jetpack_premium,
+		&.jetpack_business {
+			.plan__plan-tagline {
+				height: 32px;
+			}
+		}
+	}
+
+	.plan__plan-tagline {
+		color: $gray;
+		font-size: 13px;
+		font-weight: bold;
+		margin: 0 0 5px 0;
+		padding: 0;
+		text-align: center;
+	}
+
+	.plan__plan-details {
+		min-height: 209px;
+	}
+
+	.plan-list {
+		display: flex;
+			flex-direction: row;
+			flex-wrap: nowrap;
+			justify-content: center;
+	}
+
+}
+
+.plans.has-sidebar {
+	@include breakpoint( "<960px" ) {
+		@include plans-collapsed();
+	}
+
+	@include breakpoint( ">960px" ) {
+		@include plans-in-three-columns();
+	}
+}
+
+.plans.has-no-sidebar {
+	@include breakpoint( "<660px" ) {
+		@include plans-collapsed();
+	}
+
+	@include breakpoint( ">660px" ) {
+		@include plans-in-three-columns();
+	}
+}
+
+.plan__features .gridicon {
+	margin-left: -12px;
+	position: relative;
+		left: -5px;
+		top: 2px;
+}

--- a/client/components/plans-redesign/premium-popover/index.jsx
+++ b/client/components/plans-redesign/premium-popover/index.jsx
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import omit from 'lodash/omit';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Popover from 'components/popover';
+import Gridicon from 'components/gridicon';
+import PlanPrice from 'components/plans/plan-price';
+import { fetchSitePlans } from 'state/sites/plans/actions';
+import { shouldFetchSitePlans } from 'lib/plans';
+import { getPlansBySite } from 'state/sites/plans/selectors';
+import SitesList from 'lib/sites-list';
+import PlansList from 'lib/plans-list';
+const plansList = PlansList();
+const sitesList = SitesList();
+
+let exclusiveViewLock = null;
+
+const PremiumPopover = React.createClass( {
+	propTypes: {
+		context: React.PropTypes.object,
+		className: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.object, React.PropTypes.array ] ),
+		onClose: React.PropTypes.func,
+		isVisible: React.PropTypes.bool,
+		position: React.PropTypes.string.isRequired,
+		bindContextEvents: React.PropTypes.bool
+	},
+	getInitialState() {
+		return {
+			shouldBindEvents: !! this.props.bindContextEvents,
+			visibleByClick: false,
+			visibleByHover: false
+		};
+	},
+	componentDidMount() {
+		this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
+		this.props.fetchPlans();
+	},
+	componentWillReceiveProps( nextProps ) {
+		this.props.fetchSitePlans( nextProps.sitePlans, nextProps.selectedSite );
+	},
+	isVisible() {
+		return ( this.props.isVisible || this.state.visibleByClick || this.state.visibleByHover ) && (
+				! exclusiveViewLock || exclusiveViewLock === this
+			);
+	},
+	priceMessage( price ) {
+		return this.translate( '%(cost)s {{small}}/year{{/small}}', {
+			args: { cost: price },
+			components: { small: <small /> }
+		} );
+	},
+	getSitePlan() {
+		return ( this.props.sitePlans.data || [] ).find( plan => plan.product_slug === 'value_bundle' );
+	},
+	componentDidUpdate( oldProps ) {
+		if ( oldProps.context !== this.props.context ) {
+			this.unbindContextEvents( oldProps.context );
+		}
+
+		if ( this.state.shouldBindEvents ) {
+			this.bindContextEvents();
+		}
+	},
+	componentWillUnmount() {
+		this.unbindContextEvents();
+		if ( exclusiveViewLock === this ) {
+			exclusiveViewLock = null;
+		}
+	},
+	handleClick() {
+		exclusiveViewLock = this;
+		this.setState( { visibleByClick: true } );
+	},
+	handleMouseEnter() {
+		this.setState( { visibleByHover: true } );
+	},
+	handleMouseLeave() {
+		this.setState( { visibleByHover: false } );
+	},
+	unbindContextEvents( elm = this.props.context ) {
+		if ( elm ) {
+			elm.removeEventListener( 'click', this.handleClick );
+			elm.removeEventListener( 'mouseenter', this.handleMouseEnter );
+			elm.removeEventListener( 'mouseleave', this.handleMouseLeave );
+		}
+	},
+	bindContextEvents() {
+		const elm = this.props.context;
+		if ( elm ) {
+			elm.addEventListener( 'click', this.handleClick );
+			elm.addEventListener( 'mouseenter', this.handleMouseEnter );
+			elm.addEventListener( 'mouseleave', this.handleMouseLeave );
+			this.setState( { shouldBindEvents: false } );
+		}
+	},
+	onClose( event ) {
+		if ( exclusiveViewLock === this ) {
+			exclusiveViewLock = null;
+		}
+
+		this.setState( {
+			visibleByClick: false,
+			visibleByHover: false
+		} );
+
+		if ( this.props.onClose ) {
+			return this.props.onClose( event );
+		}
+	},
+	render() {
+		const premiumPlan = this.props.plans.find( plan => plan.product_slug === 'value_bundle' );
+		return (
+			<Popover
+				{ ...omit( this.props, [ 'children', 'className', 'bindContextEvents' ] ) }
+				onClose={ this.onClose }
+				isVisible={ this.isVisible() }
+				className={ classNames( this.props.className, 'premium-popover popover' ) }>
+				<div className="premium-popover__content">
+					<div className="premium-popover__header">
+						<h3>{ this.translate( 'Premium', { context: 'Premium Plan' } ) }</h3>
+						{ premiumPlan ? <PlanPrice plan={ premiumPlan } sitePlan={ this.getSitePlan() }/> : <h5>Loading</h5> }
+					</div>
+					<ul className="premium-popover__items">
+						{ [
+							this.translate( 'A custom domain' ),
+							this.translate( 'Advanced design customization' ),
+							this.translate( '13GB of space for file and media' ),
+							this.translate( 'Video Uploads' ),
+							this.translate( 'No Ads' ),
+							this.translate( 'Email and live chat support' )
+						].map( ( message, i ) => <li key={ i }><Gridicon icon="checkmark" size={ 18 }/> { message }</li> ) }
+					</ul>
+				</div>
+			</Popover>
+		);
+	}
+} );
+
+export default connect( ( state ) => {
+	return {
+		sitePlans: getPlansBySite( state, sitesList.getSelectedSite() ),
+		plans: plansList.get()
+	};
+}, ( dispatch ) => {
+	return {
+		fetchSitePlans( sitePlans, site ) {
+			if ( shouldFetchSitePlans( sitePlans, site ) ) {
+				dispatch( fetchSitePlans( site.ID ) );
+			}
+		},
+		fetchPlans() {
+			plansList.fetch();
+		}
+	};
+} )( PremiumPopover );

--- a/client/components/plans-redesign/premium-popover/style.scss
+++ b/client/components/plans-redesign/premium-popover/style.scss
@@ -1,0 +1,60 @@
+.premium-popover.tip {
+	width: 300px;
+
+	.tip-inner {
+		max-width: 300px !important;
+	}
+}
+
+.premium-popover__content {
+	text-align: left;
+
+	.premium-popover__header {
+		padding: 24px;
+		text-align: center;
+	}
+
+	h3 {
+		color: $gray-dark;
+		font-size: 16px;
+		font-weight: 600;
+	}
+
+	.wpcom-plan-price {
+		color: $gray;
+		font-size: 12px;
+		font-style: italic;
+		margin: 0;
+	}
+
+	.wpcom-plan-price__billing-period {
+		color: lighten( $gray, 10% );
+
+		&:before {
+			content: ' ';
+		}
+	}
+
+	.premium-popover__items {
+		background: lighten( $gray, 35% );
+		border-top: 1px solid lighten( $gray, 30% );
+		border-radius: 0 0 4px 4px;
+		font-size: 14px;
+		list-style: none;
+		margin: 0;
+		padding: 24px;
+
+		li {
+			line-height: 1.9em;
+			color: $gray;
+			margin: 0;
+		}
+
+		.gridicon {
+			color: $alert-green;
+			margin: 0 4px 0 0;
+			vertical-align: middle;
+		}
+	}
+}
+

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -76,6 +76,12 @@ export default {
 	},
 
 	plansCompare( context ) {
+		if ( config.isEnabled( 'manage/plans/redesign' ) ) {
+			const domain = context.params.domain;
+
+			return page.redirect( `/plans/${ domain }` );
+		}
+
 		const PlansCompare = require( 'components/plans/plans-compare' ),
 			Main = require( 'components/main' ),
 			CheckoutData = require( 'components/data/checkout' ),

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import analytics from 'lib/analytics';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
@@ -20,6 +21,7 @@ import Notice from 'components/notice';
 import observe from 'lib/mixins/data-observe';
 import paths from './paths';
 import PlanList from 'components/plans/plan-list' ;
+import PlanListRedesign from 'components/plans-redesign/plan-list';
 import PlanOverview from './plan-overview';
 import { shouldFetchSitePlans } from 'lib/plans';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -107,9 +109,14 @@ const Plans = React.createClass( {
 	},
 
 	render() {
+		const plansRedesignEnabled = config.isEnabled( 'manage/plans/redesign' );
 		const selectedSite = this.props.sites.getSelectedSite();
 		let hasJpphpBundle,
-			currentPlan;
+			currentPlan,
+			mainStyle;
+		
+		// Set which PlanList to use (either PlanList or PlanListRedesign).
+		let List = PlanList;
 
 		if ( this.props.sitePlans.hasLoadedFromServer ) {
 			currentPlan = getCurrentPlan( this.props.sitePlans.data );
@@ -127,12 +134,17 @@ const Plans = React.createClass( {
 					selectedSite={ selectedSite } />
 			);
 		}
+		
+		if ( plansRedesignEnabled ) {
+			List = PlanListRedesign;
+			mainStyle = { maxWidth: 1040 };
+		}
 
 		return (
 			<div>
 				{ this.renderNotice() }
 
-				<Main>
+				<Main style={ mainStyle }>
 					<SidebarNavigation />
 
 					<div id="plans" className="plans has-sidebar">
@@ -144,7 +156,7 @@ const Plans = React.createClass( {
 
 						<QueryPlans />
 
-						<PlanList
+						<List
 							site={ selectedSite }
 							plans={ this.props.plans }
 							sitePlans={ this.props.sitePlans }
@@ -152,7 +164,11 @@ const Plans = React.createClass( {
 							cart={ this.props.cart }
 							isSubmitting={ this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST } />
 
-						{ ! hasJpphpBundle && this.comparePlansLink() }
+						{ 
+							! hasJpphpBundle &&
+							! plansRedesignEnabled &&
+							this.comparePlansLink()
+						}
 					</div>
 				</Main>
 			</div>

--- a/config/development.json
+++ b/config/development.json
@@ -63,6 +63,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
+		"manage/plans/redesign": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/compatibility-warning": false,


### PR DESCRIPTION
In this branch I've:

- duplicated the `client/components/plans` to `client/components/plans-redesign` while renaming some components (e.g. `PlanList` -> `PlanListRedesign`);
- added a feature flag `manage/plans/redesign`;
- added styling to plans page;
- use `PlanListRedesign` instead of `PlanList` if plans redesign is enabled;
- Redirect `/plans/compare` to `/plans` if plans redesign is enabled.

If we merge this branch, it will serve as the core/essentials for plans redesigning. It's useful if multiple people want to work on plan redesign (on smaller tasks) so they don't have to reinvent and duplicate the "core" of plans redesign.

Btw, I know that if we merge this, I will "contribute" a lot of "new" code which is actually not new but copy-pasted. That's a little bit of lying on the Contributors graph. Do you have an idea of how we would do the same but without the duplicated code?

Props @adambbecker for the initial code.

cc @rralian @gwwar @mtias @retrofox @artpi 

Test live: https://calypso.live/?branch=update/plans-redesign-core