### PR TITLE
Plans: fix mobile description toggle

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -16,7 +16,8 @@ import PlanActions from 'components/plans/plan-actions';
 import PlanDiscountMessage from 'components/plans/plan-discount-message';
 import PlanHeader from 'components/plans/plan-header';
 import PlanPrice from 'components/plans/plan-price';
-import WpcomPlanDetails from 'my-sites/plans/wpcom-plan-details' ;
+import WpcomPlanDetails from 'my-sites/plans/wpcom-plan-details';
+import { isDesktop } from 'lib/viewport';
 
 const Plan = React.createClass( {
 	handleLearnMoreClick() {
@@ -208,7 +209,7 @@ const Plan = React.createClass( {
 
 	clickPlanHeader( event ) {
 		// clicking a card should select a plan, see issue 4486
-		if ( this.imagePlanActionRef ) {
+		if ( isDesktop() && this.imagePlanActionRef ) {
 			this.imagePlanActionRef.handleSelectPlan( event );
 		}
 	},


### PR DESCRIPTION
Fixes regression in #5849

## Testing instructions

### New User Flow
- Log out
- Load Calypso
- Start a signup flow
- Progress through the flow until you get to the plan selection screen (# of steps depends on the flow)

In Mobile:
- You should be able to click on the card header and the plan description will toggle

In Desktop:
- Try to click on the plan card / header (or anywhere except the button or illustration). This will select a plan.
- Clicking on the plan description and the buttons underneath should work.

### Plan Upgrade
- Navigate to http://calypso.localhost:3000/plans
- Select a site with a free plan
- Attempt to click on the Premium card as shown in the image above.

In Mobile:
- You should be able to click on the card header and the plan description will toggle

In Desktop:
- Try to click on the plan card / header (or anywhere except the button or illustration). This will select a plan.
- Clicking on the plan description and the buttons underneath should work.

cc @alisterscott @jblz @rralian @retrofox 

Test live: https://calypso.live/?branch=fix/plans-mobile