### PR TITLE
Add a Guided Transfer option to the main exporter page

### DIFF
--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -7,6 +7,7 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
+import GuidedTransferOptions from 'my-sites/exporter/guided-transfer-options';
 import AdvancedSettings from 'my-sites/exporter/advanced-settings';
 import SpinnerButton from './spinner-button';
 import Interval, { EVERY_SECOND } from 'lib/interval';
@@ -21,7 +22,7 @@ export default React.createClass( {
 		startExport: PropTypes.func.isRequired,
 		setPostType: PropTypes.func.isRequired,
 		advancedSettingsFetch: PropTypes.func.isRequired,
-
+		showGuidedTransferOptions: PropTypes.bool,
 		shouldShowProgress: PropTypes.bool.isRequired,
 		postType: PropTypes.string,
 		siteId: PropTypes.number
@@ -45,6 +46,7 @@ export default React.createClass( {
 			postType,
 			shouldShowProgress,
 			isExporting,
+			showGuidedTransferOptions,
 		} = this.props;
 		const siteId = this.props.site.ID;
 
@@ -115,6 +117,7 @@ export default React.createClass( {
 						onClickExport={ exportSelectedItems }
 					/>
 				</FoldableCard>
+				{ showGuidedTransferOptions && <GuidedTransferOptions /> }
 				{ isExporting && <Interval onTick={ fetchStatus } period={ EVERY_SECOND } /> }
 			</div>
 		);

--- a/client/my-sites/exporter/guided-transfer-options.jsx
+++ b/client/my-sites/exporter/guided-transfer-options.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import Button from 'components/forms/form-button';
+
+export default React.createClass( {
+	displayName: 'GuidedTransferOptions',
+
+	render: function() {
+		return (
+			<div>
+				<CompactCard>
+					<div className="exporter__guided-transfer-options-header-title-container">
+						<h1 className="exporter__title">
+							{ this.translate( 'Guided Transfer' ) }
+						</h1>
+					</div>
+					<div className="exporter__guided-transfer-options-header-button-container">
+						<Button
+							isPrimary={ true }>
+							{ this.translate( 'Purchase a Guided Transfer' ) }
+						</Button>
+					</div>
+				</CompactCard>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -7,6 +7,7 @@ import flowRight from 'lodash/flowRight';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Exporter from './exporter';
 import {
 	shouldShowProgress,
@@ -33,6 +34,7 @@ function mapStateToProps( state ) {
 		downloadURL: state.siteSettings.exporter.downloadURL,
 		didComplete: getExportingState( state, siteId ) === States.COMPLETE,
 		didFail: getExportingState( state, siteId ) === States.FAILED,
+		showGuidedTransferOptions: config.isEnabled( 'manage/export/guided-transfer' ),
 	};
 }
 

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -80,3 +80,15 @@
 		width: 100%;
 	}
 }
+
+// START GUIDED TRANSFER
+.exporter__guided-transfer-options-header-title-container {
+	display: inline-block;
+	float: left;
+}
+
+.exporter__guided-transfer-options-header-button-container {
+	display: inline-block;
+	float: right;
+}
+// END GUIDED TRANSFER

--- a/config/development.json
+++ b/config/development.json
@@ -54,6 +54,7 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/export": true,
+		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,


### PR DESCRIPTION
This pull request is the first of many that will introduce Guided Transfer to calypso. Here we'll add a new empty Guided Transfer section to the main Export screen with a single button that will serve as its entry point.
Currently the primary button performs no actions when clicked.

## How to test
1. Navigate to https://calypso.live/?branch=new/add-guided-transfer-option
2. Click "My Sites" in the upper left corner of the page.
3. Scroll down in the left navigation area if needed and click "Settings"
4. Click "Export" in the page navigation.
5. View the new Guided Transfer area.

*Note: Clicking the primary guided transfer button currently has no action*

### What to expect
![screen shot 2016-06-07 at 12 30 41 pm](https://cloud.githubusercontent.com/assets/1854440/15866217/bf2e43c8-2cab-11e6-824e-36394852fabe.png)
