### PR TITLE
Domains: show error when disconnected

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -38,6 +38,7 @@ import {
 	getDomainsSuggestions,
 	getDomainsSuggestionsError
 } from 'state/domains/suggestions/selectors';
+import { isOffline } from 'state/application/selectors';
 
 const domains = wpcom.domains();
 
@@ -223,6 +224,9 @@ const RegisterDomainStep = React.createClass( {
 	},
 
 	notices: function() {
+		if ( this.props.offline ) {
+			return <Notice text={ this.translate( 'Oh no! We\'ve lost internet connection. Please check your settings and try again.' ) } status={ `is-error` } showDismiss={ false } />;
+		}
 		if ( this.state.notice ) {
 			return <Notice text={ this.state.notice } status={ `is-${ this.state.noticeSeverity }` } showDismiss={ false } />;
 		}
@@ -235,6 +239,10 @@ const RegisterDomainStep = React.createClass( {
 	},
 
 	content: function() {
+		if ( this.props.content ) {
+			return;
+		}
+
 		if ( Array.isArray( this.state.searchResults ) || this.state.loadingResults ) {
 			return this.allSearchResults();
 		}
@@ -622,6 +630,7 @@ module.exports = connect( ( state, props ) => {
 	return {
 		currentUser: getCurrentUser( state ),
 		defaultSuggestions: getDomainsSuggestions( state, queryObject ),
-		defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject )
+		defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
+		offline: isOffline( state )
 	};
 } )( RegisterDomainStep );


### PR DESCRIPTION
Fixes #5870, which detects when we lose internet connection in domains/add

## Testing Instructions
- Navigate to http://calypso.localhost:3000/domains/add
- Select a site
- Lose internet connection (You can simulate this in Chrome via dev tools > network > click on the 'No throttling' dropdown )
- Wait for your connection loss to be detected
- We see the following
<img width="779" alt="screen shot 2016-06-16 at 2 01 36 pm" src="https://cloud.githubusercontent.com/assets/1270189/16133697/1a5baa64-33ce-11e6-841d-74d573bc4c82.png">


### Implementation Notes
I poked around, and I don't think this was related to QueryDomainsSuggestions changes, but a lack of default handling for a bare error. This PR is currently set to display an error notice, but we may want to also display an empty content notice. Let me know if you had some other behavior in mind.

cc @umurkontaci @rralian 