### PR TITLE
Stats: Request single post in post performance query

### DIFF
--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -155,7 +155,7 @@ const StatsPostPerformance = React.createClass( {
 
 export default connect( ( state, ownProps ) => {
 	const { site } = ownProps;
-	const query = { status: 'published' };
+	const query = { status: 'published', number: 1 };
 	const posts = site ? getSitePostsForQuery( state, site.ID, query ) : null;
 	const post = posts && posts.length ? posts[ 0 ] : null;
 	const viewCount = post && site ? getPostStat( state, 'views', site.ID, post.ID ) : null;


### PR DESCRIPTION
This pull request seeks to improve the performance of the posts query initiated by the `<StatsPostPerformance />` component used for the purpose of displaying the latest post summary on the stats insight screen. Because only a single post is extracted from the results, it's more efficient to include the `number` parameter in the posts request to ensure that unnecessary data is neither processed or included in the response.

Context: The posts endpoint first executes a query to retrieve the matching post IDs for the given query before iterating over post IDs to then request individual posts. Therefore, it's more efficient to limit the number of IDs that the query matches ([source](https://github.com/Automattic/jetpack/blob/ace48b050c9d134b6b1841cc1bb79920c1835afb/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php#L224-L232)).

__Testing instructions:__

Verify that the Latest Post Summary section of the [stats insights screen](http://calypso.localhost:3000/stats/insights/) continues to show information about the most recently published post:

![Summary](https://cloud.githubusercontent.com/assets/1779930/15879171/97d098a0-2cef-11e6-9846-eec1023a3474.png)

/cc @timmyc @youknowriad 

Test live: https://calypso.live/?branch=update/stats-single-post