### PR TITLE
WordAds: edit the classes for wordads sidebar item and main content

### DIFF
--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -88,10 +88,10 @@ const AdsMain = React.createClass( {
 
 	renderInstantActivationToggle: function( component ) {
 		return ( <div>
-			<Card className="ads__activate-wrapper">
-				<div className="ads__activate-header">
-					<h2 className="ads__activate-header-title">{ this.translate( 'WordAds Disabled' ) }</h2>
-					<div className="ads__activate-header-toggle">
+			<Card className="rads__activate-wrapper">
+				<div className="rads__activate-header">
+					<h2 className="rads__activate-header-title">{ this.translate( 'WordAds Disabled' ) }</h2>
+					<div className="rads__activate-header-toggle">
 						<FormButton
 							disabled={ this.props.site.options.wordads || ( this.props.requestingWordAdsApproval && this.props.wordAdsError === null ) }
 							onClick={ this.props.requestWordAdsApproval }
@@ -101,11 +101,11 @@ const AdsMain = React.createClass( {
 					</div>
 				</div>
 				{ this.props.wordAdsError &&
-					<Notice status="is-error ads__activate-notice" onDismissClick={ this.dismissWordAdsError }>
+					<Notice status="is-error rads__activate-notice" onDismissClick={ this.dismissWordAdsError }>
 						{ this.props.wordAdsError }
 					</Notice>
 				}
-				<p className="ads__activate-description">
+				<p className="rads__activate-description">
 					{ this.translate(
 						'WordAds allows you to make money from advertising that runs on your site. ' +
 						'Because you have a WordPress.com Premium plan, you can skip the review process and activate WordAds instantly. ' +
@@ -141,7 +141,7 @@ const AdsMain = React.createClass( {
 		}
 
 		return (
-			<Main className="ads">
+			<Main className="rads">
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>

--- a/client/my-sites/ads/style.scss
+++ b/client/my-sites/ads/style.scss
@@ -122,28 +122,28 @@
 	}
 }
 
-.ads__activate-header-title {
+.rads__activate-header-title {
 	font-weight: 600;
 }
 
-.ads__activate-notice {
+.rads__activate-notice {
 	margin: 0;
 }
 
-.ads__activate-header-toggle, .ads__activate-header-title {
+.rads__activate-header-toggle, .rads__activate-header-title {
 	margin: auto 0 auto 0;
 }
-.ads__activate-wrapper {
+.rads__activate-wrapper {
 	padding: 0;
 }
-.ads__activate-header {
+.rads__activate-header {
 	padding: 24px;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 }
 
-.ads__activate-description {
+.rads__activate-description {
 	border-top: 1px solid #e9eff3;
 	padding: 24px;
 }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -160,7 +160,7 @@ module.exports = React.createClass( {
 		return (
 			<SidebarItem
 				label={ site.jetpack ? 'AdControl' : 'WordAds' }
-				className={ this.itemLinkClass( '/ads', 'ads' ) }
+				className={ this.itemLinkClass( '/ads', 'rads' ) }
 				link={ adsLink }
 				onNavigate={ this.onNavigate }
 				icon="speaker" />


### PR DESCRIPTION
I found during testing that common ad-blockers on iphone rendered the sidebar item and the content of the WordAds page as totally invisible. This was based on a rule hiding anything with the class "ads". Changing this to the "rads" namespace fixes it in my testing.

![wordads screenshot](https://cloudup.com/cqmHgXCBY7o+)

## Testing
I am using an adblocker app on my iphone called `purify` (https://www.purify-app.com/). One of the styles it applies hides the WordAds sidebar item and the WordAds page content. I've already verified that the new classes make the sidebar item and the WordAds earnings/settings pages display in iphone. The main thing to test beyond that is that we're not messing up any other styles on the page. You can test by going to the WordAds pages for any business/premium site: `/ads/settings/:site` and ensuring the page shows up. If you have WordAds enabled, you should also see the sidebar item.

cc @artpi @dbspringer 

Test live: https://calypso.live/?branch=update/wordads-edit-classes