### PR TITLE
Devdocs: Make sure we do not add obsolete query strings to the urls

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -43,14 +43,22 @@ const devdocs = {
 	 */
 	devdocs: function( context ) {
 		function onSearchChange( searchTerm ) {
-			var query = context.query;
+			let query = context.query,
+				url = context.pathname;
+
 			if ( searchTerm ) {
 				query.term = searchTerm;
 			} else {
 				delete query.term;
 			}
 
-			page.replace( context.pathname + '?' + qs.stringify( query ).replace( /%20/g, '+' ),
+			const queryString = qs.stringify( query ).replace( /%20/g, '+' ).trim();
+
+			if ( queryString ) {
+				url += '?' + queryString;
+			}
+
+			page.replace( url,
 				context.state,
 				false,
 				false );

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -114,11 +114,17 @@ module.exports = React.createClass( {
 
 		searchResults = this.state.inputValue ? this.state.results : this.state.defaultResults;
 		return searchResults.map( function( result ) {
+			let url = '/devdocs/' + result.path;
+
+			if ( this.state.term ) {
+				url += '?term=' + encodeURIComponent( this.state.term );
+			}
+
 			return (
 				<Card compact className="devdocs__result" key={ result.path }>
 					<header className="devdocs__result-header">
 						<h1 className="devdocs__result-title">
-							<a className="devdocs__result-link" href={ '/devdocs/' + result.path + '?term=' + encodeURIComponent( this.state.term ) }>{ result.title }</a>
+							<a className="devdocs__result-link" href={ url }>{ result.title }</a>
 						</h1>
 						<h2 className="devdocs__result-path">{ result.path }</h2>
 					</header>


### PR DESCRIPTION
Super simple change to avoid seeing urls in the browser bar like:
* https://wpcalypso.wordpress.com/devdocs? when loading https://wpcalypso.wordpress.com/devdocs
* https://wpcalypso.wordpress.com/devdocs/docs/guide/index.md?term= when loading documents on the welcome page

### Testing
1. Load https://calypso.localhost:3000/devdocs.
2. Make sure url doesn't get updated with trailing `?`.
3. Open one of the links.
4. Make sure `?term=` isn't appended to the url.
5. Go back and make sure searching for a given term works as before.

/cc @mtias @nb 

Test live: https://calypso.live/?branch=update/devdocs-urls