### PR TITLE
Plans: Enable Instant WordAds for all environments

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -103,7 +103,7 @@ module.exports = {
 		allowAnyLocale: true
 	},
 	wordadsInstantActivation: {
-		datestamp: '20160614',
+		datestamp: '20160607',
 		variations: {
 			disabled: 50,
 			enabled: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -103,7 +103,7 @@ module.exports = {
 		allowAnyLocale: true
 	},
 	wordadsInstantActivation: {
-		datestamp: '20160607',
+		datestamp: '20160614',
 		variations: {
 			disabled: 50,
 			enabled: 50,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -26,6 +26,7 @@
 		"keyboard-shortcuts": true,
 		"manage/add-people": true,
 		"manage/ads": true,
+		"manage/ads/wordads-instant": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,
 		"manage/drafts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -24,6 +24,7 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/ads/wordads-instant": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/jetpack": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -28,6 +28,7 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/ads/wordads-instant": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/jetpack": true,

--- a/config/test.json
+++ b/config/test.json
@@ -43,6 +43,7 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/ads/wordads-instant": true,
 		"manage/customize": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,


### PR DESCRIPTION
This enables feature introduced in https://github.com/Automattic/wp-calypso/pull/5292 for all environments initiating the test


Test live: https://calypso.live/?branch=enable-instant-wordads