### PR TITLE
Reader Cold Start: decode entities in post preview title, author name and excerpt

### DIFF
--- a/client/reader/start/post-preview.jsx
+++ b/client/reader/start/post-preview.jsx
@@ -7,6 +7,7 @@ import Gravatar from 'components/gravatar';
 import PostExcerpt from 'components/post-excerpt';
 import page from 'page';
 import { getPostBySiteAndId } from 'state/reader/posts/selectors';
+import { decodeEntities } from 'lib/formatting';
 
 const StartPostPreview = React.createClass( {
 	getFullPostUrl() {
@@ -29,12 +30,12 @@ const StartPostPreview = React.createClass( {
 		}
 		return (
 			<article className="reader-start-post-preview">
-				<h1><a href={ this.getFullPostUrl() } onClick={ this.showFullPost } className="reader-start-post-preview__title">{ post.title }</a></h1>
+				<h1><a href={ this.getFullPostUrl() } onClick={ this.showFullPost } className="reader-start-post-preview__title">{ decodeEntities( post.title ) }</a></h1>
 				<div className="reader-start-post-preview__byline">
 					<Gravatar user={ post.author } size={ 20 } />
-					<span className="reader-start-post-preview__author">by { post.author.name }</span>
+					<span className="reader-start-post-preview__author">{ this.translate( 'by' ) } { decodeEntities( post.author.name ) }</span>
 				</div>
-				<PostExcerpt maxLength={ 160 } content={ post.excerpt } className="reader-start-post-preview__excerpt" />
+				<PostExcerpt maxLength={ 160 } content={ decodeEntities( post.excerpt ) } className="reader-start-post-preview__excerpt" />
 			</article>
 		);
 	}


### PR DESCRIPTION
Since switching to Redux for post storage, we're sometimes seeing HTML entities in post previews:

<img width="358" alt="eoth3mq8au-3000x3000" src="https://cloud.githubusercontent.com/assets/17325/15896619/e9c01df4-2d88-11e6-932c-6f4129d5a12f.png">

This PR decodes entities in post preview title, author name and excerpt.

Test live: https://calypso.live/?branch=fix/reader/cold-start-post-entities