### PR TITLE
CPT: Present permissions warning when cannot edit list posts

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -109,7 +109,7 @@ const PostTypeFilter = React.createClass( {
 
 		return (
 			<div>
-				{ siteId && (
+				{ query && siteId && (
 					<QueryPostCounts
 						siteId={ siteId }
 						type={ query.type } />

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -20,19 +20,21 @@ import PostTypeListEmptyContent from './empty-content';
 function PostTypeList( { query, siteId, posts, requesting } ) {
 	return (
 		<div className="post-type-list">
-			<QueryPosts
-				siteId={ siteId }
-				query={ query } />
-			{ posts && ! posts.length && ! requesting && (
+			{ query && (
+				<QueryPosts
+					siteId={ siteId }
+					query={ query } />
+			) }
+			{ query && posts && ! posts.length && ! requesting && (
 				<PostTypeListEmptyContent
 					type={ query.type }
 					status={ query.status } />
 			) }
 			<ul className="post-type-list__posts">
-				{ requesting && (
+				{ ( ! query || requesting ) && (
 					<li><PostTypeListPostPlaceholder /></li>
 				) }
-				{ posts && posts.map( ( post ) => (
+				{ query && posts && posts.map( ( post ) => (
 					<li key={ post.global_ID }>
 						<PostTypeListPost globalId={ post.global_ID } />
 					</li>

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -13,6 +13,7 @@ import DocumentHead from 'components/data/document-head';
 import PostTypeFilter from 'my-sites/post-type-filter';
 import PostTypeList from 'my-sites/post-type-list';
 import PostTypeUnsupported from './post-type-unsupported';
+import PostTypeForbidden from './post-type-forbidden';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostType, isPostTypeSupported } from 'state/post-types/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
@@ -21,7 +22,7 @@ function Types( { query, postType, postTypeSupported, userCanEdit } ) {
 	return (
 		<Main>
 			<DocumentHead title={ get( postType, 'label' ) } />
-			{ false !== postTypeSupported && [
+			{ false !== userCanEdit && false !== postTypeSupported && [
 				<PostTypeFilter
 					key="filter"
 					query={ userCanEdit ? query : null } />,
@@ -31,6 +32,9 @@ function Types( { query, postType, postTypeSupported, userCanEdit } ) {
 			] }
 			{ false === postTypeSupported && (
 				<PostTypeUnsupported type={ query.type } />
+			) }
+			{ false === userCanEdit && (
+				<PostTypeForbidden />
 			) }
 		</Main>
 	);

--- a/client/my-sites/types/post-type-forbidden/index.jsx
+++ b/client/my-sites/types/post-type-forbidden/index.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'components/empty-content';
+
+function PostTypeForbidden( { translate } ) {
+	return (
+		<EmptyContent
+			illustration="/calypso/images/drake/drake-whoops.svg"
+			title={ translate( 'You need permission to manage this post type' ) }
+			line={ translate( 'Ask your site administrator to grant you access' ) } />
+	);
+}
+
+PostTypeForbidden.propTypes = {
+	translate: PropTypes.func
+};
+
+export default localize( PostTypeForbidden );


### PR DESCRIPTION
Related: #5398

This pull request seeks to present an warning message when viewing the post types list for a post type the user does not have access to view.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15899142/c3206ba6-2d68-11e6-8c12-d62eefbec9b4.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15899125/b8677d1c-2d68-11e6-914d-af184142df3e.png)

__Implementation notes:__

- It is technically possible for a user without permission to receive a list of posts, but we still do not want to allow them to view this page because (a) it is not shown in the sidebar and (b) most actions are specific to managing posts and therefore it does not serve much purpose
- An effect of the changes included is that we do not request posts until we know that the user has capability to manage the post type. This requires details about (a) the user, (b) the site, and (c) the post type. In most cases all of this information is already available when navigating to the page, but if not, there could now be a brief delay that had not existed previously during which time we show the loading placeholders until the details exist. It's a question of whether we'd want to optimistically issue the network request before we're even aware of whether the request will succeed or fail with an authorization error.

__Testing instructions:__

- Verify that you can still access post type listing for which you have access.
- Verify that if you do not have access to a post type, that you are presented with the warning in the screenshot above (e.g. contributor role viewing testimonials)
- Verify that the above remains true when switching sites directly while viewing a types list

1. Navigate to My Sites
2. Select a site where at least one custom post type exists
3. Choose the custom post type in the sidebar
4. Note that...
 - If you have permission to `edit_posts` capability for that post type, you are shown the posts
 - Otherwise, you're shown a warning (note that this will never occur in these steps since the sidebar item does not display if you do not have access)

Test live: https://calypso.live/?branch=update/cpt-forbidden-list