### PR TITLE
Editor/CPT: Display dialog when user cannot edit posts

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -317,6 +317,7 @@
 @import 'post-editor/editor-drawer-well/style';
 @import 'post-editor/editor-featured-image/style';
 @import 'post-editor/editor-fieldset/style';
+@import 'post-editor/editor-forbidden/style';
 @import 'post-editor/editor-ground-control/style';
 @import 'post-editor/editor-location/style';
 @import 'post-editor/editor-mobile-navigation/style';

--- a/client/post-editor/editor-forbidden/index.jsx
+++ b/client/post-editor/editor-forbidden/index.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import get from 'lodash/get';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
+import { getPostType } from 'state/post-types/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import { canCurrentUser } from 'state/current-user/selectors';
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+
+function EditorForbidden( { translate, userCanEdit, siteSlug } ) {
+	if ( false !== userCanEdit ) {
+		// [TODO]: React 15 supports returning `null` from function components
+		return <noscript />;
+	}
+
+	const buttons = [
+		<Button key="back" href={ `/posts/${ siteSlug }` } primary>
+			{ translate( 'Back to My Sites' ) }
+		</Button>
+	];
+
+	return (
+		<Dialog
+			isVisible
+			buttons={ buttons }
+			className="editor-forbidden">
+			<h1>{ translate( 'You can\'t edit this post type' ) }</h1>
+			<p>{ translate( 'If you think you should have access to this post type, request that your site administrator grant you access.' ) }</p>
+		</Dialog>
+	);
+}
+
+EditorForbidden.propTypes = {
+	translate: PropTypes.func,
+	userCanEdit: PropTypes.bool,
+	siteSlug: PropTypes.string
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const type = getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
+	const typeObject = getPostType( state, siteId, type );
+	const capability = get( typeObject, [ 'capabilities', 'edit_posts' ], null );
+
+	return {
+		userCanEdit: canCurrentUser( state, siteId, capability ),
+		siteSlug: getSiteSlug( state, siteId )
+	};
+} )( localize( EditorForbidden ) );

--- a/client/post-editor/editor-forbidden/style.scss
+++ b/client/post-editor/editor-forbidden/style.scss
@@ -1,0 +1,3 @@
+.editor-forbidden {
+	max-width: 400px;
+}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -51,6 +51,7 @@ import { receivePost, editPost, resetPostEdits } from 'state/posts/actions';
 import EditorSidebarHeader from 'post-editor/editor-sidebar/header';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
+import EditorForbidden from 'post-editor/editor-forbidden';
 import { setPreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import QueryPreferences from 'components/data/query-preferences';
@@ -296,6 +297,7 @@ const PostEditor = React.createClass( {
 				<QueryPreferences />
 				<EditorDocumentHead />
 				<EditorPostTypeUnsupported />
+				<EditorForbidden />
 				<div className="post-editor__inner">
 					<div className="post-editor__content">
 						<EditorMobileNavigation site={ site } onClose={ this.onClose } />


### PR DESCRIPTION
Fixes #5398
Related: #5598
Concepts: https://github.com/Automattic/wp-calypso/pull/5598#issuecomment-222169832

This pull request seeks to display a warning dialog when the user attempts to navigate to the editor for a post type for which they do not have access to edit.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15901508/8744e888-2d71-11e6-8725-a2b2259d99b0.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15901494/7ffdd166-2d71-11e6-92ad-15eaaa4fad2e.png)

__Testing instructions:__

1. Switch to a user with "Contributor" role on a site
2. Navigate to the [page editor](http://calypso.localhost:3000/page)
3. If prompted, select the site on which the user is a contributor
4. Note that you are prompted with a warning that you do not have access to edit this type (since contributors lack `edit_pages` capability)

Test live: https://calypso.live/?branch=update/editor-cpt-forbidden