### PR TITLE
i18n: Make it easier to translate Happiness Engineers in context

### DIFF
--- a/client/me/help/help-happiness-engineers/index.jsx
+++ b/client/me/help/help-happiness-engineers/index.jsx
@@ -42,8 +42,12 @@ module.exports = React.createClass( {
 		}
 		return (
 			<div className="help-happiness-engineers">
-				<FormSectionHeading>{ this.translate( 'We care about your happiness!' ) }</FormSectionHeading>
-				<p className="help-happiness-engineers__description">{ this.translate( 'They don\'t call us Happiness Engineers for nothing. If you need help, we\'re here for you!' ) }</p>
+				{ this.translate( '{{headline}}We care about your happiness!{{/headline}}{{p}}They don\'t call us Happiness Engineers for nothing. If you need help, we\'re here for you!{{/p}}', {
+					components: {
+						headline: <FormSectionHeading />,
+						p: <p className="help-happiness-engineers__description" />
+					}
+				} ) }
 				<div className="help-happiness-engineers__tray">
 					{ this.state.happinessEngineers.map( happinessEngineer => <Gravatar key={ happinessEngineer.avatar_URL } user={ { avatar_URL: happinessEngineer.avatar_URL } } size={ 42 } /> ) }
 				</div>


### PR DESCRIPTION
The original version has headline and text below separate, resulting in this translation in Brazilian Portuguese:

> Nos importamos com a sua felicidade!
> Não é a toa que nos chamam de equipe de suporte.

Literally:
> We care about your happiness!
> No wonder why they call us support team.

With the sentences being pulled together, translators can adjust the translation of the second sentence beyond the defined translation, just for this case.

Test live: https://calypso.live/?branch=fix/i18n-happiness-engineers-context