### PR TITLE
Jetpack Plans: Add a success notice after finishing plugins setup

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -268,6 +268,31 @@ const PlansSetup = React.createClass( {
 		return null;
 	},
 
+	renderSuccess() {
+		const site = this.props.selectedSite;
+		if ( ! this.props.hasRequested || ! this.props.isFinished ) {
+			return null;
+		}
+
+		const pluginsWithErrors = filter( this.props.plugins, ( item ) => {
+			return ( item.error !== null );
+		} );
+
+		if ( pluginsWithErrors.length ) {
+			return (
+				<Notice status="is-info" text={ this.translate( 'There were some issues installing your plugins. See the links below.' ) } showDismiss={ false } />
+			);
+		}
+
+		return (
+			<Notice status="is-success" text={ this.translate( 'We\'ve installed your plugins, your site is powered up!' ) } showDismiss={ false }>
+				<NoticeAction href={ `/stats/insights/${site.slug}` }>
+					{ this.translate( 'Continue' ) }
+				</NoticeAction>
+			</Notice>
+		);
+	},
+
 	renderPlaceholder() {
 		return (
 			<div className="jetpack-plugins-setup">
@@ -322,13 +347,7 @@ const PlansSetup = React.createClass( {
 				<h1 className="jetpack-plugins-setup__header">{ this.translate( 'Setting up your %(plan)s Plan', { args: { plan: site.plan.product_name_short } } ) }</h1>
 				<p className="jetpack-plugins-setup__description">{ this.translate( 'We need to install a few plugins for you. It won\'t take long!' ) }</p>
 				{ turnOnManage }
-				{ ! turnOnManage && this.props.hasRequested && this.props.isFinished &&
-					<Notice status="is-success" text={ this.translate( 'We\'ve installed your plugins, your site is powered up!' ) } showDismiss={ false }>
-						<NoticeAction href={ `/stats/insights/${site.slug}` }>
-							{ this.translate( 'Continue' ) }
-						</NoticeAction>
-					</Notice>
-				}
+				{ ! turnOnManage && this.renderSuccess() }
 				{ turnOnManage
 					? <FeatureExample>{ this.renderPlugins( true ) }</FeatureExample>
 					: this.renderPlugins( false )

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -321,6 +321,13 @@ const PlansSetup = React.createClass( {
 				<h1 className="jetpack-plugins-setup__header">{ this.translate( 'Setting up your %(plan)s Plan', { args: { plan: site.plan.product_name_short } } ) }</h1>
 				<p className="jetpack-plugins-setup__description">{ this.translate( 'We need to install a few plugins for you. It won\'t take long!' ) }</p>
 				{ turnOnManage }
+				{ ! turnOnManage && this.props.isFinished &&
+					<Notice status="is-success" text={ this.translate( 'We\'ve installed your plugins, your site is powered up!' ) } showDismiss={ false }>
+						<NoticeAction href={ `/stats/insights/${site.slug}` }>
+							{ this.translate( 'Continue' ) }
+						</NoticeAction>
+					</Notice>
+				}
 				{ turnOnManage
 					? <FeatureExample>{ this.renderPlugins( true ) }</FeatureExample>
 					: this.renderPlugins( false )

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -242,6 +242,7 @@ const PlansSetup = React.createClass( {
 					break;
 				case 'install':
 					statusProps.text = this.translate( 'Working…' );
+					break;
 				case 'wait':
 				default:
 					statusProps.text = this.translate( 'Waiting to install' );
@@ -321,7 +322,7 @@ const PlansSetup = React.createClass( {
 				<h1 className="jetpack-plugins-setup__header">{ this.translate( 'Setting up your %(plan)s Plan', { args: { plan: site.plan.product_name_short } } ) }</h1>
 				<p className="jetpack-plugins-setup__description">{ this.translate( 'We need to install a few plugins for you. It won\'t take long!' ) }</p>
 				{ turnOnManage }
-				{ ! turnOnManage && this.props.isFinished &&
+				{ ! turnOnManage && this.props.hasRequested && this.props.isFinished &&
 					<Notice status="is-success" text={ this.translate( 'We\'ve installed your plugins, your site is powered up!' ) } showDismiss={ false }>
 						<NoticeAction href={ `/stats/insights/${site.slug}` }>
 							{ this.translate( 'Continue' ) }


### PR DESCRIPTION
Fixes #5703, so you're no longer trapped in the install/setup screen.

To test:

1. Run through the plugins install & configuration process at `/plugins/setup/$site`
2. When it finishes, you should see a green success notice that links you off to Insights.

Eventually this will link off to "My Plan" (see #5892)

~~Note: currently doesn't account for errors in setup, so if any fail, the process is still "done" and we show the success. Obviously not a great scenario, but can be fixed in a follow up PR.~~

![screen shot 2016-06-08 at 12 51 02 pm](https://cloud.githubusercontent.com/assets/541093/15902778/afbb5148-2d77-11e6-8b25-bb48501ab32f.png)

cc @johnHackworth @roccotripaldi @rickybanister 

Test live: https://calypso.live/?branch=add/plugins-setup-success