### PR TITLE
Framework/CPT: Join title with separator only if title non-empty

### DIFF
--- a/client/lib/screen-title/utils.js
+++ b/client/lib/screen-title/utils.js
@@ -58,7 +58,11 @@ function appendSite( title, options ) {
 		siteName = options.get( 'siteID' );
 	}
 
-	return title + ' \u2039 ' + siteName;
+	if ( title ) {
+		return title + ' \u2039 ' + siteName;
+	}
+
+	return siteName;
 }
 
 function toImmutable( object = {} ) {


### PR DESCRIPTION
This pull request seeks to resolve an issue where the screen title is prefixed with a separator between an empty title and the site name. When the title is empty, we should simply set the screen title to the derived site name.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15903206/82118bca-2d79-11e6-9ce5-a3c9471bc164.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15903165/582577ae-2d79-11e6-988f-5f00847bb072.png)

__Testing instructions:__

1. Navigate to the [post types list for a post type which does not exist](http://calypso.localhost:3000/types/xyz)
2. Select a site, if prompted
3. Note that the screen title is simply the name of the selected site

__Open questions:__

- Should we have a title name for post types which do not exist for a site?

Test live: https://calypso.live/?branch=fix/cpt-unsupported-title