### PR TITLE
Framework: Improve selected sidebar path matching

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -6,8 +6,7 @@ var analytics = require( 'lib/analytics' ),
 	debug = require( 'debug' )( 'calypso:my-sites:sidebar' ),
 	has = require( 'lodash/has' ),
 	includes = require( 'lodash/includes' ),
-	React = require( 'react' ),
-	startsWith = require( 'lodash/startsWith' );
+	React = require( 'react' );
 
 import page from 'page';
 
@@ -84,7 +83,7 @@ module.exports = React.createClass( {
 		}
 
 		return paths.some( function( path ) {
-			return startsWith( this.props.path, path );
+			return path === this.props.path || 0 === this.props.path.indexOf( path + '/' );
 		}, this );
 	},
 

--- a/client/my-sites/sidebar/test/sidebar.jsx
+++ b/client/my-sites/sidebar/test/sidebar.jsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+import EmptyComponent from 'test/helpers/react/empty-component';
+
+describe( 'Sidebar', () => {
+	let Sidebar;
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'page', function() {} );
+		mockery.registerMock( 'lib/analytics', {} );
+		mockery.registerMock( 'lib/products-values', {} );
+		mockery.registerMock( 'my-sites/current-site', EmptyComponent );
+		mockery.registerMock( './publish-menu', EmptyComponent );
+		mockery.registerMock( 'layout/sidebar', EmptyComponent );
+		mockery.registerMock( 'post-editor/drafts-button', EmptyComponent );
+		mockery.registerMock( 'components/tooltip', EmptyComponent );
+		mockery.registerMock( 'components/site-stats-sticky-link', EmptyComponent );
+
+		Sidebar = require( '../sidebar' );
+	} );
+
+	describe( '#isItemLinkSelected()', () => {
+		it( 'should return false if none of the paths are a prefix', () => {
+			const isSelected = Sidebar.prototype.isItemLinkSelected.call( {
+				props: {
+					path: '/posts/example.wordpress.com'
+				}
+			}, [ '/types/jetpack-testimonial' ] );
+
+			expect( isSelected ).to.be.false;
+		} );
+
+		it( 'should return false if one of the paths is a prefix, but not at end or separated by slash', () => {
+			const isSelected = Sidebar.prototype.isItemLinkSelected.call( {
+				props: {
+					path: '/types/jetpack-testimonial-jk'
+				}
+			}, [ '/types/jetpack-testimonial' ] );
+
+			expect( isSelected ).to.be.false;
+		} );
+
+		it( 'should return true if one of the paths is a prefix of the current path and separated by slash', () => {
+			const isSelected = Sidebar.prototype.isItemLinkSelected.call( {
+				props: {
+					path: '/types/jetpack-testimonial/example.wordpress.com'
+				}
+			}, [ '/types/jetpack-testimonial' ] );
+
+			expect( isSelected ).to.be.true;
+		} );
+
+		it( 'should return true if one of the paths is a prefix of the current path and at end', () => {
+			const isSelected = Sidebar.prototype.isItemLinkSelected.call( {
+				props: {
+					path: '/types/jetpack-testimonial'
+				}
+			}, [ '/types/jetpack-testimonial' ] );
+
+			expect( isSelected ).to.be.true;
+		} );
+
+		it( 'should accept a path string', () => {
+			const isSelected = Sidebar.prototype.isItemLinkSelected.call( {
+				props: {
+					path: '/types/jetpack-testimonial'
+				}
+			}, '/types/jetpack-testimonial' );
+
+			expect( isSelected ).to.be.true;
+		} );
+	} );
+} );


### PR DESCRIPTION
This pull request seeks to improve our sidebar item selected logic, which is naive in its approach to checking that the current path is prefixed by one of the sidebar item's available paths. The downside to this approach is that some routes are incorrectly showing as selected when they should not be.

For example, navigating to [`/types/jetpack-testimonialssssss`](https://wpcalypso.wordpress.com/types/jetpack-testimonialssssss) will show the "Testimonials" link in the sidebar as selected (if the site has activated Testimonials), despite not being the route for testimonials.

__Implementation notes:__

- The path detection has been updated to match only when the prefix matches to the end of the currently selected path (e.g. `/posts`) or if the prefix is followed by a slash (`/posts/example.wordpress.com`).
- We could consider using [`sectionify`](https://github.com/Automattic/wp-calypso/blob/a73373c46edc3229ddccf74b75efad058e3d131b/client/lib/route/path.js#L66-L74) to compare the base route, but I'm not confident that all of the intended matched paths are specified by each sidebar item.

__Testing instructions:__

Verify that sidebar selected highlighting continues to behave as expected, and that the [route mentioned above](http://calypso.localhost/types/jetpack-testimonialssssss)) does not highlight the Testimonials sidebar item (and that the [valid Testimonials link](http://calypso.localhost/types/jetpack-testimonial) does).

Test live: https://calypso.live/?branch=fix/sidebar-route-prefix-matching