### PR TITLE
Sign Up: Plans step for domain upgrades

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -176,11 +176,7 @@ function removeUserStepFromFlow( flow ) {
 
 function filterFlowName( flowName ) {
 	const defaultFlows = [ 'main', 'website' ];
-
-	if ( includes( defaultFlows, flowName ) && abtest( 'personalPlan' ) === 'show' ) {
-		return 'personal';
-	}
-
+	// do nothing. No flows to filter at the moment.
 	return flowName;
 }
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -304,7 +304,10 @@ const Signup = React.createClass( {
 			CurrentComponent = stepComponents[ this.props.stepName ],
 			propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props ),
 			stepKey = this.state.loadingScreenStartTime ? 'processing' : this.props.stepName,
-			flow = flows.getFlow( this.props.flowName );
+			flow = flows.getFlow( this.props.flowName ),
+			hideFreePlan = this.state.dependencies && this.state.dependencies.domainItem
+				? this.state.dependencies.domainItem.is_domain_registration
+				: false;
 
 		return (
 			<div className="signup__step" key={ stepKey }>
@@ -325,6 +328,7 @@ const Signup = React.createClass( {
 						signupDependencies={ this.state.dependencies }
 						stepSectionName={ this.props.stepSectionName }
 						positionInFlow={ this.positionInFlow() }
+						hideFreePlan={ hideFreePlan }
 						{ ...propsFromConfig } />
 				}
 			</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -20,8 +20,6 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	abtest = require( 'lib/abtest' ).abtest,
 	signupUtils = require( 'signup/utils' );
 
-const domainsWithPlansOnlyTestEnabled = abtest( 'domainsWithPlansOnly' ) === 'plansOnly';
-
 module.exports = React.createClass( {
 	displayName: 'DomainsStep',
 
@@ -92,15 +90,15 @@ module.exports = React.createClass( {
 	submitWithDomain: function( googleAppsCartItem ) {
 		const suggestion = this.props.step.suggestion,
 			isPurchasingItem = Boolean( suggestion.product_slug ),
-			siteUrl = isPurchasingItem ?
-				suggestion.domain_name :
-				suggestion.domain_name.replace( '.wordpress.com', '' ),
-			domainItem = isPurchasingItem ?
-				cartItems.domainRegistration( {
+			siteUrl = isPurchasingItem
+				? suggestion.domain_name
+				: suggestion.domain_name.replace( '.wordpress.com', '' ),
+			domainItem = isPurchasingItem
+				? cartItems.domainRegistration( {
 					domain: suggestion.domain_name,
 					productSlug: suggestion.product_slug
-				} ) :
-				undefined;
+				} )
+				: undefined;
 
 		SignupActions.submitSignupStep( Object.assign( {
 			processingMessage: this.translate( 'Adding your domain' ),
@@ -112,19 +110,7 @@ module.exports = React.createClass( {
 			stepSectionName: this.props.stepSectionName
 		}, this.getThemeArgs() ), [], { domainItem } );
 
-		this.goToNextStep( isPurchasingItem );
-	},
-
-	submitPlansStepWithPremium() {
-		const premiumPlan = cartItems.premiumPlan( 'value_bundle', { isFreeTrial: false } );
-		SignupActions.submitSignupStep( {
-			processingMessage: this.translate( 'Adding your plan' ),
-			stepName: 'plans',
-			stepSectionName: this.props.stepSectionName,
-			cartItem: premiumPlan
-		}, [], {
-			cartItem: premiumPlan
-		} );
+		this.props.goToNextStep();
 	},
 
 	handleAddMapping: function( sectionName, domain, state ) {
@@ -141,7 +127,7 @@ module.exports = React.createClass( {
 			stepSectionName: this.props.stepSectionName
 		}, this.getThemeArgs() ) );
 
-		this.goToNextStep( isPurchasingItem );
+		this.props.goToNextStep();
 	},
 
 	handleSave: function( sectionName, state ) {
@@ -150,25 +136,6 @@ module.exports = React.createClass( {
 			stepSectionName: this.props.stepSectionName,
 			[ sectionName ]: state
 		} );
-	},
-
-	goToNextStep( isPurchasingItem ) {
-		if ( domainsWithPlansOnlyTestEnabled && isPurchasingItem && abtest( 'freeTrialsInSignup' ) !== 'enabled' ) {
-			const plansIndex = this.props.steps.indexOf( 'plans' );
-			if ( ! this.props.meta.skipBundlingPlan ) {
-				this.submitPlansStepWithPremium();
-			}
-
-			if ( plansIndex === this.props.steps.length - 1 || plansIndex === -1 ) {
-				// if plans is the last step or not in the flow, this'll finish the flow
-				this.props.goToNextStep();
-			} else {
-				// skip plans step
-				this.props.goToStep( this.props.steps[ plansIndex + 1 ] );
-			}
-		} else {
-			this.props.goToNextStep();
-		}
 	},
 
 	googleAppsForm: function() {
@@ -234,9 +201,9 @@ module.exports = React.createClass( {
 
 	render: function() {
 		let content;
-		const backUrl = this.props.stepSectionName ?
-			signupUtils.getStepUrl( this.props.flowName, this.props.stepName, undefined, i18n.getLocaleSlug() ) :
-			undefined;
+		const backUrl = this.props.stepSectionName
+			? signupUtils.getStepUrl( this.props.flowName, this.props.stepName, undefined, i18n.getLocaleSlug() )
+			: undefined;
 
 		if ( 'mapping' === this.props.stepSectionName ) {
 			content = this.mappingForm();
@@ -253,7 +220,7 @@ module.exports = React.createClass( {
 		if ( this.props.step && 'invalid' === this.props.step.status ) {
 			content = (
 				<div className="domains-step__section-wrapper">
-					<Notice status='is-error' showDismiss={ false }>
+					<Notice status="is-error" showDismiss={ false }>
 						{ this.props.step.errors.message }
 					</Notice>
 					{ content }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -81,13 +81,21 @@ module.exports = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_compare_plans_click', { location: linkLocation } );
 	},
 
+	hideFreePlan: function() {
+		if ( this.props.signupDependencies && this.props.signupDependencies.domainItem ) {
+			return this.props.signupDependencies.domainItem.is_domain_registration;
+		}
+
+		return this.props.hideFreePlan;
+	},
+
 	plansList: function() {
 		return (
 			<div>
 				<PlanList
 					plans={ this.state.plans }
 					comparePlansUrl={ this.comparePlansUrl() }
-					hideFreePlan={ this.props.hideFreePlan }
+					hideFreePlan={ this.hideFreePlan() }
 					isInSignup={ true }
 					onSelectPlan={ this.onSelectPlan } />
 				<a
@@ -128,7 +136,7 @@ module.exports = React.createClass( {
 	plansCompare: function() {
 		return <PlansCompare
 			className="plans-step__compare"
-			hideFreePlan={ this.props.hideFreePlan }
+			hideFreePlan={ this.hideFreePlan() }
 			onSelectPlan={ this.onSelectPlan }
 			isInSignup={ true }
 			backUrl={ this.props.path.replace( '/compare', '' ) }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -81,21 +81,13 @@ module.exports = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_compare_plans_click', { location: linkLocation } );
 	},
 
-	hideFreePlan: function() {
-		if ( this.props.signupDependencies && this.props.signupDependencies.domainItem ) {
-			return this.props.signupDependencies.domainItem.is_domain_registration;
-		}
-
-		return this.props.hideFreePlan;
-	},
-
 	plansList: function() {
 		return (
 			<div>
 				<PlanList
 					plans={ this.state.plans }
 					comparePlansUrl={ this.comparePlansUrl() }
-					hideFreePlan={ this.hideFreePlan() }
+					hideFreePlan={ this.props.hideFreePlan }
 					isInSignup={ true }
 					onSelectPlan={ this.onSelectPlan } />
 				<a
@@ -136,7 +128,7 @@ module.exports = React.createClass( {
 	plansCompare: function() {
 		return <PlansCompare
 			className="plans-step__compare"
-			hideFreePlan={ this.hideFreePlan() }
+			hideFreePlan={ this.props.hideFreePlan }
 			onSelectPlan={ this.onSelectPlan }
 			isInSignup={ true }
 			backUrl={ this.props.path.replace( '/compare', '' ) }


### PR DESCRIPTION
Adding a Domain Registration or Domain Mapping, the signup flows always `goToNextStep` to show the plans page.

Plans and Plans compare on the signup flows hide the Free plan if the user has a domain upgrade.

Test live: https://calypso.live/?branch=add/signup-plans-step