### PR TITLE
Jetpack Plans: Sites aren't correctly ID'd as having Manage deactivated

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -152,8 +152,10 @@ function renderProvisionPlugins( context ) {
 	context.store.dispatch( setSection( Object.assign( {}, section, { secondary: false } ) ) );
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 
+	let site = sites.getSelectedSite();
+
 	renderWithReduxStore(
-		React.createElement( PlanSetup, {} ),
+		React.createElement( PlanSetup, { selectedSite: site } ),
 		document.getElementById( 'primary' ),
 		context.store
 	);

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -333,7 +333,6 @@ const PlansSetup = React.createClass( {
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
-		const site = getSelectedSite( state );
 
 		return {
 			wporg: state.plugins.wporg.items,
@@ -344,7 +343,6 @@ export default connect(
 			plugins: getPluginsForSite( state, siteId ),
 			activePlugin: getActivePlugin( state, siteId ),
 			nextPlugin: getNextPlugin( state, siteId ),
-			selectedSite: site && site.jetpack ? JetpackSite( site ) : site,
 			isRequestingSites: isRequestingSites( state ),
 			siteId
 		};


### PR DESCRIPTION
The `JetpackSite` created by `site = getSelectedSite( state );` doesn't fully reflect the real site data - the `module` attribute is undefined, which causes `site.canManage()` to return true, even if Manage is disabled. Fixed by passing the full site object down from the controller.

To test:

- Visit the installer for a site without manage (`/plugins/setup/$site`)
- Without fix: it tries to install the plugins, and all error.
- With fix: it shows a message asking the user to enable Manage.

cc @johnHackworth @roccotripaldi 

Test live: https://calypso.live/?branch=fix/jetpack-selected-site