### PR TITLE
Plans: enable google vouchers in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -23,6 +23,7 @@
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
 		"guided-tours": true,
+		"google-voucher": true,
 		"help": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,


### PR DESCRIPTION
We're ready to do our internal testing.

Test live: https://calypso.live/?branch=update/enable-vouchers-in-wpcalypso