### PR TITLE
Jetpack Plans: Add the plugin setup flow back to staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,7 @@
 		"manage/plans": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
-		"manage/plugins/setup": false,
+		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/sharing": true,


### PR DESCRIPTION
Now that Connect is live, we don't need to worry about this interfering with testing there, and we're ready to start testing the plugins install flow 🎉 

cc @johnHackworth @roccotripaldi

Test live: https://calypso.live/?branch=add/plugin-setup-stage