### PR TITLE
Forms: Updated colors for Counted Textarea Component

### DIFF
--- a/client/components/forms/counted-textarea/style.scss
+++ b/client/components/forms/counted-textarea/style.scss
@@ -22,5 +22,5 @@
 .counted-textarea__count-panel {
 	padding: 8px;
 	font-size: 12px;
-	color: darken( $gray, 10% );
+	color: darken( $gray, 20% );
 }

--- a/client/components/forms/counted-textarea/style.scss
+++ b/client/components/forms/counted-textarea/style.scss
@@ -1,6 +1,6 @@
 .counted-textarea {
 	border: 1px solid lighten( $gray, 20% );
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-light;
 
 	&.is-exceeding-acceptable-length {
 		background: $alert-red;
@@ -22,5 +22,5 @@
 .counted-textarea__count-panel {
 	padding: 8px;
 	font-size: 12px;
-	color: darken( $gray, 10% );
+	color: $gray-dark;
 }

--- a/client/components/forms/counted-textarea/style.scss
+++ b/client/components/forms/counted-textarea/style.scss
@@ -22,5 +22,5 @@
 .counted-textarea__count-panel {
 	padding: 8px;
 	font-size: 12px;
-	color: $gray-dark;
+	color: darken( $gray, 10% );
 }

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -42,7 +42,7 @@
 .form-text-input-with-affixes__suffix {
 	background: $gray-light;
 	border: 1px solid lighten( $gray, 20% );
-	color: darken( $gray, 10% );
+	color: darken( $gray, 20% );
 	padding: 8px 14px;
 	white-space: nowrap;
 }

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -40,9 +40,9 @@
 
 .form-text-input-with-affixes__prefix,
 .form-text-input-with-affixes__suffix {
-	background: lighten( $gray, 30% );
+	background: $gray-light;
 	border: 1px solid lighten( $gray, 20% );
-	color: $gray-dark;
+	color: darken( $gray, 10% );
 	padding: 8px 14px;
 	white-space: nowrap;
 }


### PR DESCRIPTION
Updated colors for the `counted-textarea` component.

<img width="691" alt="screen shot 2016-06-08 at 2 46 10 pm" src="https://cloud.githubusercontent.com/assets/789137/15912173/c15de16c-2d87-11e6-8c09-3f39885fb919.png">

@drw158 

Fixes #5904

Test live: https://calypso.live/?branch=update/5904-counted-textarea-color