### PR TITLE
Pages: Update "Trashed" section navigation

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -56,13 +56,13 @@ module.exports = React.createClass( {
 			published: this.translate( 'Published', { context: 'Filter label for pages list' } ),
 			drafts: this.translate( 'Drafts', { context: 'Filter label for pages list' } ),
 			scheduled: this.translate( 'Scheduled', { context: 'Filter label for pages list' } ),
-			trashed: this.translate( 'Trash', { context: 'Filter label for pages list' } )
+			trashed: this.translate( 'Trashed', { context: 'Filter label for pages list' } )
 		};
 		const searchStrings = {
-			published: this.translate( 'Search published…', { context: 'Search placeholder for pages list', textOnly: true } ),
-			drafts: this.translate( 'Search drafts…', { context: 'Search placeholder for pages list', textOnly: true } ),
-			scheduled: this.translate( 'Search scheduled…', { context: 'Search placeholder for pages list', textOnly: true } ),
-			trashed: this.translate( 'Search trash…', { context: 'Search placeholder for pages list', textOnly: true } )
+			published: this.translate( 'Search Published…', { context: 'Search placeholder for pages list', textOnly: true } ),
+			drafts: this.translate( 'Search Drafts…', { context: 'Search placeholder for pages list', textOnly: true } ),
+			scheduled: this.translate( 'Search Scheduled…', { context: 'Search placeholder for pages list', textOnly: true } ),
+			trashed: this.translate( 'Search Trashed…', { context: 'Search placeholder for pages list', textOnly: true } )
 		};
 		return (
 			<div className="main main-column pages" role="main">


### PR DESCRIPTION
This is a quick PR to address #1959. It updates the label in the /pages navigation from "Trash" to "Trashed" to be consistent with the navigation on /posts. I also updated the search placeholder text for the /pages list to be consistent with the placeholder on /posts.

## To test

1. Load up this branch.
2. Visit http://calypso.localhost:3000/pages/trashed/site.wordpress.com in your browser. You should see "Trashed" in the navigation.
3. Click the search icon. You should see "Searched Trashed..." The same applies for any navigation tab within /pages. It should have both words capitalized. This will match what you find at http://calypso.localhost:3000/posts/trashed/site.wordpress.com.

## Screenshots

Updated navigation

<img width="783" alt="updatedmenu" src="https://cloud.githubusercontent.com/assets/7240478/15914886/d49a7c26-2da1-11e6-85b6-2f37480ecea7.png">

Updated search placeholder

<img width="787" alt="updatedsearch" src="https://cloud.githubusercontent.com/assets/7240478/15914888/dc0c06e6-2da1-11e6-9058-0416bf50ff78.png">

cc @lancewillett in case you have a sec to give it a spin

Test live: https://calypso.live/?branch=fix/1959-trashed-label