### PR TITLE
Signup: add Headstart to `/with-theme/` flow

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -18,12 +18,12 @@ import SignupCart from 'lib/signup/cart';
 import { startFreeTrial } from 'lib/upgrades/actions';
 import { PLAN_PREMIUM } from 'lib/plans/constants';
 
-function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsCartItem, isPurchasingItem, siteUrl, themeSlug, themeItem } ) {
+function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsCartItem, isPurchasingItem, siteUrl, themeSlug, themeSlugWithRepo, themeItem } ) {
 	wpcom.undocumented().sitesNew( {
 		blog_name: siteUrl,
 		blog_title: siteUrl,
 		options: {
-			theme: dependencies.theme
+			theme: dependencies.theme || themeSlugWithRepo
 		},
 		validate: false,
 		find_available_url: isPurchasingItem

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -79,14 +79,31 @@ module.exports = React.createClass( {
 		} );
 	},
 
+	isPurchasingTheme: function() {
+		return this.props.queryObject && this.props.queryObject.premium;
+	},
+
+	getThemeSlug: function() {
+		return this.props.queryObject ? this.props.queryObject.theme : undefined;
+	},
+
 	getThemeArgs: function() {
-		const isPurchasingTheme = this.props.queryObject && this.props.queryObject.premium;
-		const themeSlug = this.props.queryObject ? this.props.queryObject.theme : undefined;
-		const themeItem = isPurchasingTheme
+		const themeSlug = this.getThemeSlug(),
+			themeSlugWithRepo = this.getThemeSlugWithRepo(),
+			themeItem = this.isPurchasingTheme()
 			? cartItems.themeItem( themeSlug, 'signup-with-theme' )
 			: undefined;
 
-		return { themeSlug, themeItem };
+		return { themeSlug, themeSlugWithRepo, themeItem };
+	},
+
+	getThemeSlugWithRepo: function() {
+		const themeSlug = this.getThemeSlug();
+		if ( ! themeSlug ) {
+			return undefined;
+		}
+		// Only allow free themes for now; a valid theme value here (free or premium) will cause a theme_switch by Headstart.
+		return this.isPurchasingTheme() ? undefined : 'pub/' + themeSlug;
 	},
 
 	submitWithDomain: function( googleAppsCartItem ) {


### PR DESCRIPTION
Currently, Headstart only runs on flows that utilize the `themes` step and pass the `theme` dependency. This allows flows with pre-selected themes (i.e. theme showcase signups) to also use Headstart.

Test live: https://calypso.live/start/with-theme/?theme=edin&branch=add/headstart-signup-with-theme

Test with:
- Edin (supports Headstart): 
https://calypso.live/start/with-theme/?theme=edin&branch=add/headstart-signup-with-theme
- Orvis (does not support Headstart): 
https://calypso.live/start/with-theme/?theme=orvis&branch=add/headstart-signup-with-theme
- Forefront (premium, does not support Headstart):
https://calypso.live/start/with-theme/?theme=forefront&premium=true&branch=add/headstart-signup-with-theme