### PR TITLE
Framework: Remove raf dependency in favor of window.requestAnimationFrame

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -3,7 +3,6 @@
  */
 var debug = require( 'debug' )( 'calypso:infinite-list' ),
 	omit = require( 'lodash/omit' ),
-	raf = require( 'raf' ),
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	page = require( 'page' );
@@ -190,7 +189,7 @@ module.exports = React.createClass( {
 
 	cancelAnimationFrame: function() {
 		if ( this.scrollRAFHandle ) {
-			raf.cancel( this.scrollRAFHandle );
+			window.cancelAnimationFrame( this.scrollRAFHandle );
 			this.scrollRAFHandle = null;
 		}
 		this.lastScrollTop = -1;
@@ -201,7 +200,7 @@ module.exports = React.createClass( {
 			return;
 		}
 		if ( ! this.scrollRAFHandle && this.getCurrentScrollTop() !== this.lastScrollTop ) {
-			this.scrollRAFHandle = raf( this.scrollChecks );
+			this.scrollRAFHandle = window.requestAnimationFrame( this.scrollChecks );
 		}
 	},
 
@@ -287,7 +286,7 @@ module.exports = React.createClass( {
 			InfiniteListActions.storePositions( url, newState );
 		}
 
-		this.scrollRAFHandle = raf( this.scrollChecks );
+		this.scrollRAFHandle = window.requestAnimationFrame( this.scrollChecks );
 	},
 
 	boundsForRef: function( ref ) {

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -4,7 +4,6 @@
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	throttle = require( 'lodash/throttle' ),
-	raf = require( 'raf' ),
 	classNames = require( 'classnames' );
 
 /**
@@ -37,11 +36,11 @@ module.exports = React.createClass( {
 	componentWillUnmount: function() {
 		window.removeEventListener( 'scroll', this.onWindowScroll );
 		window.removeEventListener( 'resize', this.throttleOnResize );
-		raf.cancel( this.rafHandle );
+		window.cancelAnimationFrame( this.rafHandle );
 	},
 
 	onWindowScroll: function() {
-		this.rafHandle = raf( this.updateIsSticky );
+		this.rafHandle = window.requestAnimationFrame( this.updateIsSticky );
 	},
 
 	onWindowResize: function() {

--- a/client/lib/scroll-to/index.js
+++ b/client/lib/scroll-to/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import raf from 'raf';
 import TWEEN from 'tween.js';
 
 function getCurrentScroll( container ) {
@@ -33,10 +32,17 @@ function makeScrollUpdater( container ) {
 }
 
 function animate() {
-	if ( TWEEN.getAll().length > 0 ) {
-		raf( animate );
-		TWEEN.update();
+	if ( ! TWEEN.getAll().length ) {
+		return;
 	}
+
+	if ( 'undefined' !== typeof window && window.requestAnimationFrame ) {
+		window.requestAnimationFrame( animate );
+	} else {
+		process.nextTick( animate );
+	}
+
+	TWEEN.update();
 }
 
 /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2488,9 +2488,6 @@
     "percentage-regex": {
       "version": "3.0.0"
     },
-    "performance-now": {
-      "version": "0.1.4"
-    },
     "phone": {
       "version": "1.0.4-11",
       "from": "git+https://github.com/Automattic/node-phone.git#3161829eba3dbab67c69a3795f74765026d4337a",
@@ -2581,9 +2578,6 @@
     },
     "querystring-es3": {
       "version": "0.2.1"
-    },
-    "raf": {
-      "version": "2.0.4"
     },
     "randomatic": {
       "version": "1.1.5"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "q": "1.0.1",
     "qrcode.react": "0.5.2",
     "qs": "4.0.0",
-    "raf": "2.0.4",
     "react": "0.14.3",
     "react-addons-create-fragment": "0.14.3",
     "react-addons-css-transition-group": "0.14.3",


### PR DESCRIPTION
This pull request seeks to remove the `raf` dependency in favor of using `requestAnimationFrame` directly. Since `requestAnimationFrame` is [available in all supported browsers](http://caniuse.com/#feat=requestanimationframe), we no longer have need for this module.

__Testing instructions:__

Verify that all sections and components affected by included changes continue to behave as expected.

cc review: @blowery 

Test live: https://calypso.live/?branch=remove/raf