### PR TITLE
Add backtick string test for server/i18n

### DIFF
--- a/server/i18n/test/examples/i18n-test-examples.jsx
+++ b/server/i18n/test/examples/i18n-test-examples.jsx
@@ -63,6 +63,8 @@ function test() {
 
 	content = this.translate( 'The string key text',
 		{ 'context': 'context with a literal string key' } );
+
+	content = this.translate( `A string template with no interpolation` );
 }
 
 module.exports = test;

--- a/server/i18n/test/index.js
+++ b/server/i18n/test/index.js
@@ -153,4 +153,8 @@ describe( 'index', function() {
 	it( 'should find options with a literal string key', function() {
 		assert.notEqual( -1, output.indexOf( 'context with a literal string key' ) );
 	} );
+
+	it( 'should allow literal string templates (backticks) with no interpolation', function() {
+		assert.notEqual( -1, output.indexOf( 'A string template with no interpolation' ) );
+	} );
 } );


### PR DESCRIPTION
This PR is about supporting literal string templates (es6 backtick strings).

`get-i18n` already handles backticks, which you can verify with the new tests and also because `client/my-sites/site-settings/section-export.jsx` already includes the string `Visit your site's wp-admin for all your import and export needs.`, which is correctly added to calypso-strings.php ), so all we're doing here is adding a test to make that support more explicit and make sure we don't break it in future.

This change is mostly about https://github.com/Automattic/eslint-plugin-wpcalypso/pull/6 which updates our eslint rules to allow for these strings and to disallow interpolation.

Once that's merged, I'll add the version bump here.

Test live: https://calypso.live/?branch=add/server-i18n-backtick-test