### PR TITLE
Fix typo [SERIALIZE] to [DESERIALIZE]

### DIFF
--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -323,7 +323,7 @@ instead of returning a plain object, we create an Immutable.js instance:
 ```javascript
 export const items = createReducer( defaultState, {
 	[THEMES_RECEIVE]: ( state, action ) => // ...
-	[SERIALIZE]: state => fromJS( state )
+	[DESERIALIZE]: state => fromJS( state )
 } );
 ```
 If your reducer state is already a plain object, you may choose to omit `SERIALIZE` and `DESERIALIZE` handlers, or 


### PR DESCRIPTION
In the [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md) doc, I think there is a typo in the Data Persistence section. When we are storing state to browser storage, the `[SERIALIZE]` action type is used. However, when we are restoring the state from the browser storage, the `[DESERIALIZE]` action type is used.

cc @gziolo @rralian 

Test live: https://calypso.live/?branch=fix/approach-to-data-md-serialize