### PR TITLE
WebPreview: add transitions when preview is invoked.

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -24,7 +24,6 @@ $sidebar-width-min: 228px;
 	left: 0;
 	right: 0;
 	padding: 6px;
-
 	color: $white;
 	background: rgba( $gray-dark, 0.8 );
 	text-align: center;

--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -17,6 +17,7 @@ import Toolbar from './toolbar';
 import touchDetect from 'lib/touch-detect';
 import { isMobile } from 'lib/viewport';
 import Spinner from 'components/spinner';
+import RootChild from 'components/root-child';
 import { setPreviewShowing } from 'state/ui/actions';
 
 const debug = debugModule( 'calypso:web-preview' );
@@ -213,38 +214,40 @@ const WebPreview = React.createClass( {
 		} );
 
 		return (
-			<div className={ className }>
-				<div className="web-preview__backdrop" onClick={ this.props.onClose } />
-				<div className="web-preview__content">
-					<Toolbar setDeviceViewport={ this.setDeviceViewport }
-						device={ this.state.device }
-						{ ...this.props }
-						showExternal={ ( this.props.previewUrl ? this.props.showExternal : false ) }
-						showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
-					/>
-					<div className="web-preview__placeholder">
-						{ ! this.state.loaded &&
-							<div>
-								<Spinner />
-								{ this.props.loadingMessage &&
-									<span className="web-preview__loading-message">
-										{ this.props.loadingMessage }
-									</span>
-								}
-							</div>
-						}
-						{ this.shouldRenderIframe() &&
-							<iframe
-								ref="iframe"
-								className="web-preview__frame"
-								src="about:blank"
-								onLoad={ this.setLoaded }
-								title={ this.props.iframeTitle || this.translate( 'Preview' ) }
-							/>
-						}
+			<RootChild>
+				<div className={ className }>
+					<div className="web-preview__backdrop" onClick={ this.props.onClose } />
+					<div className="web-preview__content">
+						<Toolbar setDeviceViewport={ this.setDeviceViewport }
+							device={ this.state.device }
+							{ ...this.props }
+							showExternal={ ( this.props.previewUrl ? this.props.showExternal : false ) }
+							showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
+						/>
+						<div className="web-preview__placeholder">
+							{ ! this.state.loaded &&
+								<div>
+									<Spinner />
+									{ this.props.loadingMessage &&
+										<span className="web-preview__loading-message">
+											{ this.props.loadingMessage }
+										</span>
+									}
+								</div>
+							}
+							{ this.shouldRenderIframe() &&
+								<iframe
+									ref="iframe"
+									className="web-preview__frame"
+									src="about:blank"
+									onLoad={ this.setLoaded }
+									title={ this.props.iframeTitle || this.translate( 'Preview' ) }
+								/>
+							}
+						</div>
 					</div>
 				</div>
-			</div>
+			</RootChild>
 		);
 	}
 } );

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -92,7 +92,7 @@ const WebPreview = React.createClass( {
 			this.setIframeMarkup( this.props.previewMarkup );
 		}
 		if ( this.props.showPreview ) {
-			document.documentElement.classList.add( 'no-scroll' );
+			document.documentElement.classList.add( 'no-scroll', 'is-previewing' );
 		}
 		this.props.setPreviewShowing( this.props.showPreview );
 	},
@@ -128,17 +128,17 @@ const WebPreview = React.createClass( {
 		}
 		if ( showPreview ) {
 			window.addEventListener( 'keydown', this.keyDown );
-			document.documentElement.classList.add( 'no-scroll' );
+			document.documentElement.classList.add( 'no-scroll', 'is-previewing' );
 		} else {
 			window.removeEventListener( 'keydown', this.keyDown );
-			document.documentElement.classList.remove( 'no-scroll' );
+			document.documentElement.classList.remove( 'no-scroll', 'is-previewing' );
 		}
 	},
 
 	componentWillUnmount() {
 		this.props.setPreviewShowing( false );
 		window.removeEventListener( 'keydown', this.keyDown );
-		document.documentElement.classList.remove( 'no-scroll' );
+		document.documentElement.classList.remove( 'no-scroll', 'is-previewing' );
 	},
 
 	keyDown( event ) {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -22,12 +22,12 @@
 }
 
 .wp.layout {
-	transition: all 0.3s ease-in-out;
+	transition: all 0.5s ease-in-out;
 }
 
 .is-previewing .wp.layout {
-	filter: blur( 3px );
-	opacity: 0.3;
+	-webkit-filter: blur( 3px );
+	opacity: 0.2;
 }
 
 .web-preview__backdrop {
@@ -51,7 +51,7 @@
 	margin: 0 auto;
 	opacity: 0;
 	transform: translateY( 80vh );
-	transition: transform 0.3s cubic-bezier(0.895, 0.03, 0.685, 0.22),
+	transition: transform 0.2s ease-out,
 		opacity 0.1s ease-in-out,
 		max-width 0.2s ease-out;
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -56,7 +56,11 @@
 		max-width 0.2s ease-out;
 
 	.is-computer & {
-		max-width: 1040px;
+		max-width: 1200px;
+		@include breakpoint( ">960px" ) {
+			left: 24px;
+			right: 24px;
+		}
 	}
 
 	.is-tablet & {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -46,7 +46,7 @@
 	// transform: scale( 0.96 );
 	// transition: 0.1s transform cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
 	transition: transform 0.2s;
-	transform: translateY(20%);
+	transform: translateY(12%) scale( 0.95 );
 	background: lighten( $gray, 30% );
 
 	.is-computer & {
@@ -79,7 +79,7 @@
 	visibility: visible;
 
 	.web-preview__content {
-		transform: translateY(0%);
+		transform: translateY(0%) scale(1);
 		transition: transform 0.5s;
 	}
 }

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -45,7 +45,7 @@
 	margin: 0 auto;
 	// transform: scale( 0.96 );
 	// transition: 0.1s transform cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
-	transition: transform 0.4s, visibility 0s 0.5s;
+	transition: transform 0.2s;
 	transform: translateY(20%);
 	background: lighten( $gray, 30% );
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -24,7 +24,7 @@
 }
 
 .web-preview__backdrop {
-	background: rgba( $gray, 0.9 );
+	background: rgba( darken( $gray, 52% ), 0.8 );
 	position: absolute;
 		top: 0;
 		left: 0;
@@ -38,7 +38,7 @@
 		0 1px 2px lighten( $gray-dark, 30% );
 	border-radius: 4px 4px 0 0;
 	position: absolute;
-		top: 47px;
+		top: 0;
 		left: 0;
 		right: 0;
 		bottom: 0;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -46,7 +46,7 @@
 	// transform: scale( 0.96 );
 	// transition: 0.1s transform cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
 	transition: transform 0.2s;
-	transform: translateY(12%) scale( 0.95 );
+	transform: translateY(12%) scale( 0.98 );
 	background: lighten( $gray, 30% );
 
 	.is-computer & {
@@ -80,7 +80,7 @@
 
 	.web-preview__content {
 		transform: translateY(0%) scale(1);
-		transition: transform 0.5s;
+		transition: transform 0.5s, width 0.2s ease-out;
 	}
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -5,10 +5,22 @@
 		right: 0;
 	margin: 0 auto;
 	height: 0;
+	// height: 100%;
+	// width: 100%;
 	overflow: hidden;
-	z-index: z-index( 'root', '.web-preview' ); // Above TinyMCE dialogs
 	opacity: 0;
+	z-index: z-index( 'root', '.web-preview' ); // Above TinyMCE dialogs
 	transition: 0s 0.2s height, 0.2s opacity cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
+}
+
+.is-previewing {
+	.masterbar {
+		transform: translateY( -100% );
+		transition: transform 0.15s ease-out;
+	}
+	.wp-content {
+		opacity: 0.6;
+	}
 }
 
 .web-preview__backdrop {
@@ -31,8 +43,10 @@
 		right: 0;
 		bottom: 0;
 	margin: 0 auto;
-	transform: scale( 0.96 );
-	transition: 0.1s transform cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
+	// transform: scale( 0.96 );
+	// transition: 0.1s transform cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
+	transition: transform 0.4s, visibility 0s 0.5s;
+	transform: translateY(20%);
 	background: lighten( $gray, 30% );
 
 	.is-computer & {
@@ -62,9 +76,11 @@
 	height: 100%;
 	opacity: 1;
 	transition: 0s height, 0.2s opacity cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
+	visibility: visible;
 
 	.web-preview__content {
-		transform: scale( 1 );
+		transform: translateY(0%);
+		transition: transform 0.5s;
 	}
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -1,30 +1,36 @@
 .web-preview {
 	position: fixed;
 		top: 0;
-		left: 0;
 		right: 0;
+		left: 0;
 	margin: 0 auto;
-	height: 0;
-	// height: 100%;
-	// width: 100%;
 	overflow: hidden;
 	opacity: 0;
 	z-index: z-index( 'root', '.web-preview' ); // Above TinyMCE dialogs
-	transition: 0s 0.2s height, 0.2s opacity cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
+	transition: opacity 0.3s ease-in-out;
+
+	&.is-visible {
+		opacity: 1;
+		bottom: 0;
+		visibility: visible;
+
+		.web-preview__content {
+			opacity: 1;
+			transform: translateY( 0 ) scale( 1 );
+		}
+	}
 }
 
-.is-previewing {
-	.masterbar {
-		transform: translateY( -100% );
-		transition: transform 0.15s ease-out;
-	}
-	.wp-content {
-		opacity: 0.6;
-	}
+.wp.layout {
+	transition: all 0.3s ease-in-out;
+}
+
+.is-previewing .wp.layout {
+	filter: blur( 3px );
+	opacity: 0.3;
 }
 
 .web-preview__backdrop {
-	background: rgba( darken( $gray, 52% ), 0.8 );
 	position: absolute;
 		top: 0;
 		left: 0;
@@ -34,53 +40,41 @@
 }
 
 .web-preview__content {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray-dark, 20% ), .5 ),
-		0 1px 2px lighten( $gray-dark, 30% );
+	box-shadow: 0 0 0 1px rgba( $gray, 0.5 );
+	background: $gray-light;
 	border-radius: 4px 4px 0 0;
 	position: absolute;
-		top: 0;
+		top: 24px;
 		left: 0;
 		right: 0;
 		bottom: 0;
 	margin: 0 auto;
-	// transform: scale( 0.96 );
-	// transition: 0.1s transform cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
-	transition: transform 0.2s;
-	transform: translateY(12%) scale( 0.98 );
-	background: lighten( $gray, 30% );
+	opacity: 0;
+	transform: translateY( 80vh );
+	transition: transform 0.3s cubic-bezier(0.895, 0.03, 0.685, 0.22),
+		opacity 0.1s ease-in-out,
+		max-width 0.2s ease-out;
 
 	.is-computer & {
-		width: 100%;
+		max-width: 1040px;
 	}
 
 	.is-tablet & {
-		width: 783px;
+		max-width: 783px;
 	}
 
 	.is-phone & {
-		width: 460px;
+		max-width: 460px;
 	}
 }
 
 .web-preview.is-computer .web-preview__content,
 .web-preview.is-tablet .web-preview__content,
 .web-preview.is-phone .web-preview__content {
-	@include breakpoint( "<660px" ) {
-		left: 0;
-		right: 0;
+	@include breakpoint( "<960px" ) {
+		top: 0;
 		width: 100%;
-	}
-}
-
-.web-preview.is-visible {
-	height: 100%;
-	opacity: 1;
-	transition: 0s height, 0.2s opacity cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
-	visibility: visible;
-
-	.web-preview__content {
-		transform: translateY(0%) scale(1);
-		transition: transform 0.5s, width 0.2s ease-out;
+		border-radius: 0;
 	}
 }
 
@@ -90,10 +84,6 @@
 	border-bottom: 1px solid lighten( $gray, 20% );
 	border-radius: 4px 4px 0 0;
 	display: flex;
-}
-
-.web-preview.is-computer .web-preview__toolbar {
-	border-radius: 0;
 }
 
 .web-preview__close,
@@ -156,7 +146,7 @@
 	height: 100%;
 	opacity: 0;
 	transition: opacity 0.2s ease-in-out;
-	background: $gray-light;
+	//background: $gray-light;
 
 	.is-loaded & {
 		opacity: 1;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -21,15 +21,6 @@
 	}
 }
 
-.wp.layout {
-	transition: all 0.5s ease-in-out;
-}
-
-.is-previewing .wp.layout {
-	-webkit-filter: blur( 3px );
-	opacity: 0.2;
-}
-
 .web-preview__backdrop {
 	position: absolute;
 		top: 0;
@@ -150,7 +141,6 @@
 	height: 100%;
 	opacity: 0;
 	transition: opacity 0.2s ease-in-out;
-	//background: $gray-light;
 
 	.is-loaded & {
 		opacity: 1;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -16,6 +16,7 @@ $autobar-height: 20px;
 	width: 100%;
 	z-index: z-index( 'root', '.masterbar' );
 	-webkit-font-smoothing: subpixel-antialiased;
+	transition: transform 0.2s ease-out;
 
 	.is-support-user & {
 		background: $orange-jazzy;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -5,6 +5,7 @@
 	padding: 32px 32px 32px ( $sidebar-width-max + 32px );
 	box-sizing: border-box;
 	overflow: hidden;
+	transition: opacity 0.3s;
 
 	.has-no-sidebar & {
 		padding-left: 32px;
@@ -158,13 +159,4 @@
 .layout__loader.is-active {
 	visibility: visible;
 	opacity: 1;
-}
-
-.layout__preview.web-preview.is-visible,
-.layout__preview.web-preview {
-	left: 0;
-	.web-preview__content {
-		top: 0;
-		transform: scale( 1 );
-	}
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -1,3 +1,12 @@
+.layout {
+	transition: all 0.4s ease-in-out;
+
+	.is-previewing & {
+		-webkit-filter: blur( 3px );
+		opacity: 0.2;
+	}
+}
+
 .layout__content {
 	@include clear-fix;
 	position: relative;


### PR DESCRIPTION
Video:
https://cloudup.com/c7s03qG-570

Test live: https://calypso.live/?branch=add/web-preview-transitions

Known WebPreview usage:
- Site card in my-sites sidebar
- Editor
- Themes list (/design)
- Themes details (/theme/mood)