### PR TITLE
Framework: Upgrade jsdom from 7.2.0 to 9.2.1

### DIFF
--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -304,7 +304,7 @@ describe( 'TokenField', function() {
 				expect( tokenFieldNode.find( 'div' ).first().hasClass( 'is-active' ) ).to.equal( isActive );
 			}
 
-			document.activeElement = document.body;
+			document.activeElement.blur();
 			textInputNode.simulate( 'blur' );
 
 			// After blur, need to wait for TokenField#_blurTimeoutID

--- a/client/lib/media-serialization/test/index.js
+++ b/client/lib/media-serialization/test/index.js
@@ -76,8 +76,11 @@ describe( 'MediaSerialization', function() {
 					get: () => 660
 				} );
 			} );
-			img.naturalWidth = 1320;
-			img.naturalHeight = 1320;
+			[ 'naturalWidth', 'naturalHeight' ].forEach( ( dimension ) => {
+				Object.defineProperty( img, dimension, {
+					get: () => 1320
+				} );
+			} );
 			const parsed = deserialize( img );
 
 			expect( parsed.type ).to.equal( MediaTypes.IMAGE );
@@ -89,8 +92,11 @@ describe( 'MediaSerialization', function() {
 			let img = document.createElement( 'img' );
 			img.width = 660;
 			img.height = 660;
-			img.naturalWidth = 1320;
-			img.naturalHeight = 1320;
+			[ 'naturalWidth', 'naturalHeight' ].forEach( ( dimension ) => {
+				Object.defineProperty( img, dimension, {
+					get: () => 1320
+				} );
+			} );
 			img.setAttribute( 'width', '990' );
 			img.setAttribute( 'height', '990' );
 			const parsed = deserialize( img );

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -687,7 +687,7 @@ describe( 'index', function() {
 					content: '<iframe src="http://example.com"></iframe>'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSecure ] ) ], function( err, normalized ) {
-					assert.strictEqual( normalized.content, '<iframe src="https://example.com" sandbox=""></iframe>' );
+					assert.strictEqual( normalized.content, '<iframe src="https://example.com/" sandbox=""></iframe>' );
 					done( err );
 				}
 			);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18,7 +18,7 @@
       "version": "3.0.0",
       "dependencies": {
         "acorn": {
-          "version": "3.1.0"
+          "version": "3.2.0"
         }
       }
     },
@@ -63,6 +63,9 @@
     },
     "arr-flatten": {
       "version": "1.0.1"
+    },
+    "array-equal": {
+      "version": "1.0.0"
     },
     "array-find-index": {
       "version": "1.0.1"
@@ -409,7 +412,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000475"
+      "version": "1.0.30000476"
     },
     "caseless": {
       "version": "0.11.0"
@@ -454,7 +457,7 @@
       }
     },
     "chokidar": {
-      "version": "1.5.1"
+      "version": "1.5.2"
     },
     "chrono-node": {
       "version": "1.2.3"
@@ -1793,7 +1796,7 @@
       }
     },
     "jsdom": {
-      "version": "7.2.0",
+      "version": "9.2.1",
       "dependencies": {
         "acorn": {
           "version": "2.7.0"
@@ -3420,7 +3423,7 @@
       "version": "0.2.9"
     },
     "webidl-conversions": {
-      "version": "2.0.1"
+      "version": "3.0.1"
     },
     "webpack": {
       "version": "1.12.15",
@@ -3463,8 +3466,8 @@
     "whatwg-fetch": {
       "version": "0.9.0"
     },
-    "whatwg-url-compat": {
-      "version": "0.6.5"
+    "whatwg-url": {
+      "version": "3.0.0"
     },
     "which": {
       "version": "1.2.10"
@@ -3476,7 +3479,7 @@
       "version": "5.1.1",
       "dependencies": {
         "acorn": {
-          "version": "3.1.0"
+          "version": "3.2.0"
         }
       }
     },
@@ -3528,7 +3531,7 @@
       "version": "0.3.0",
       "dependencies": {
         "acorn": {
-          "version": "3.1.0"
+          "version": "3.2.0"
         },
         "lodash": {
           "version": "2.4.2"

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "eslint-plugin-react": "3.11.3",
     "eslint-plugin-wpcalypso": "1.1.3",
     "glob": "7.0.3",
-    "jsdom": "7.2.0",
+    "jsdom": "9.2.1",
     "localStorage": "1.0.2",
     "lodash-deep": "1.5.3",
     "mixedindentlint": "1.1.1",


### PR DESCRIPTION
This pull request seeks to upgrade our `jsdom` dependency from 7.2.0 to 9.2.1.

Notably, the 9.0.0 claims "massive performance gain" from the removal of support for mutation events ([release notes](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#900)).

A few tests required updates, in most cases around attempts to assign values to properties that had changed to getters-only.

__Testing instructions:__

`jsdom` is only relevant for testing, so ensure that all tests pass.

/cc @blowery @gziolo 

Test live: https://calypso.live/?branch=update/jsdom-9-2-1