### PR TITLE
Framework: Fix lint runs in Circle CI by avoiding npm run

### DIFF
--- a/bin/run-lint
+++ b/bin/run-lint
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const child_process = require( 'child_process' );
 const path = require( 'path' );
-var args = [ '--cache', '--ext=.js',  '--ext=.jsx' ];
+var args = [ '--cache', '--quiet', '--ext=.js',  '--ext=.jsx' ];
 if ( process.argv.length > 2 ) {
 	args = args.concat( process.argv.slice( 2 ) );
 } else {
@@ -9,7 +9,7 @@ if ( process.argv.length > 2 ) {
 }
 
 const results = child_process.spawnSync( path.join( '.', 'node_modules', '.bin', 'eslint' ), args );
-console.log( 'got', results.status );
+console.log( 'eslint returned', results.status );
 
 if ( results.stdout ) {
 	process.stdout.write( results.stdout );

--- a/bin/run-lint
+++ b/bin/run-lint
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 const child_process = require( 'child_process' );
-var args = [ '--cache', '--quiet', '--ext=.js',  '--ext=.jsx' ];
+const path = require( 'path' );
+var args = [ '--cache', '--ext=.js',  '--ext=.jsx' ];
 if ( process.argv.length > 2 ) {
 	args = args.concat( process.argv.slice( 2 ) );
 } else {
 	args = args.concat( [ '.' ] );
 }
 
-const results = child_process.spawnSync( 'eslint', args );
+const results = child_process.spawnSync( path.join( '.', 'node_modules', '.bin', 'eslint' ), args );
+console.log( 'got', results.status );
 
 if ( results.stdout ) {
 	process.stdout.write( results.stdout );

--- a/bin/run-lint
+++ b/bin/run-lint
@@ -9,7 +9,6 @@ if ( process.argv.length > 2 ) {
 }
 
 const results = child_process.spawnSync( path.join( '.', 'node_modules', '.bin', 'eslint' ), args );
-console.log( 'eslint returned', results.status );
 
 if ( results.stdout ) {
 	process.stdout.write( results.stdout );

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ test:
     - NODE_ENV=test make client/config/index.js:
         parallel: true
   override:
-    - npm run lint -- :
+    - bin/run-lint :
         parallel: true
         files:
           - client/**/*.js


### PR DESCRIPTION
This may help with failing lint when using 2 executors? No idea why though.

Test live: https://calypso.live/?branch=fix/use-lint-from-node-modules