### PR TITLE
Purchases: Record page views in 'EditCardDetails'

### DIFF
--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -95,6 +95,8 @@ const EditCardDetails = React.createClass( {
 
 	componentWillReceiveProps( nextProps ) {
 		this.redirectIfDataIsInvalid( nextProps );
+
+		recordPageView( 'edit_card_details', this.props, nextProps );
 	},
 
 	validate( formValues, onComplete ) {


### PR DESCRIPTION
This is a quick fix to address #4590. It adds a call to `recordPageView` in `componentWillReceiveProps` so that we're recording page views whenever required render data is present. Passes in `nextProps` along with `this.props`. Not a ton to test here really.

cc @drewblaisdell if you have a sec to give this a look over

Test live: https://calypso.live/?branch=fix/4590-page-views-edit-card-details