### PR TITLE
Exporter: add guided transfer routes

### DIFF
--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -25,6 +25,7 @@ export default React.createClass( {
 		showGuidedTransferOptions: PropTypes.bool,
 		shouldShowProgress: PropTypes.bool.isRequired,
 		postType: PropTypes.string,
+		siteSlug: PropTypes.string,
 		siteId: PropTypes.number
 	},
 
@@ -117,7 +118,7 @@ export default React.createClass( {
 						onClickExport={ exportSelectedItems }
 					/>
 				</FoldableCard>
-				{ showGuidedTransferOptions && <GuidedTransferOptions /> }
+				{ showGuidedTransferOptions && <GuidedTransferOptions siteSlug={ this.props.siteSlug } /> }
 				{ isExporting && <Interval onTick={ fetchStatus } period={ EVERY_SECOND } /> }
 			</div>
 		);

--- a/client/my-sites/exporter/guided-transfer-options.jsx
+++ b/client/my-sites/exporter/guided-transfer-options.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -12,7 +13,15 @@ import Button from 'components/forms/form-button';
 export default React.createClass( {
 	displayName: 'GuidedTransferOptions',
 
-	render: function() {
+	propTypes: {
+		siteSlug: PropTypes.string.isRequired
+	},
+
+	purchaseGuidedTransfer() {
+		page( `/settings/export/${this.props.siteSlug}/guided` );
+	},
+
+	render() {
 		return (
 			<div>
 				<CompactCard>
@@ -23,6 +32,7 @@ export default React.createClass( {
 					</div>
 					<div className="exporter__guided-transfer-options-header-button-container">
 						<Button
+							onClick={ this.purchaseGuidedTransfer }
 							isPrimary={ true }>
 							{ this.translate( 'Purchase a Guided Transfer' ) }
 						</Button>

--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -9,6 +9,7 @@ import flowRight from 'lodash/flowRight';
  */
 import config from 'config';
 import Exporter from './exporter';
+import { getSiteSlug } from 'state/sites/selectors';
 import {
 	shouldShowProgress,
 	getSelectedPostType,
@@ -28,6 +29,7 @@ function mapStateToProps( state ) {
 
 	return {
 		siteId,
+		siteSlug: getSiteSlug( state, siteId ),
 		postType: getSelectedPostType( state ),
 		shouldShowProgress: shouldShowProgress( state, siteId ),
 		isExporting: isExporting( state, siteId ),

--- a/client/my-sites/guided-transfer/guided-transfer.jsx
+++ b/client/my-sites/guided-transfer/guided-transfer.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'components/header-cake';
+
+export default React.createClass( {
+	displayName: 'GuidedTransfer',
+
+	propTypes: {
+		siteSlug: PropTypes.string.isRequired
+	},
+
+	showExporter() {
+		page( `/settings/export/${this.props.siteSlug}` );
+	},
+
+	render: function() {
+		return (
+			<div className="guided-transfer">
+				<HeaderCake onClick={ this.showExporter } isCompact={ true }>{ this.translate( 'Guided Transfer' ) }</HeaderCake>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/guided-transfer/index.js
+++ b/client/my-sites/guided-transfer/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import GuidedTransfer from './guided-transfer';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+
+function mapStateToProps( state ) {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, siteId );
+	return {
+		siteSlug,
+	};
+}
+
+export default connect( mapStateToProps )( GuidedTransfer );

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -132,6 +132,17 @@ module.exports = {
 		);
 	},
 
+	guidedTransfer( context ) {
+		ReactDom.render(
+			<SiteSettingsComponent
+				context={ context }
+				sites={ sites }
+				section="guidedTransfer"
+				path={ context.path } />,
+			document.getElementById( 'primary' )
+		);
+	},
+
 	deleteSite( context ) {
 		var site = sites.getSelectedSite();
 

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -18,6 +18,9 @@ module.exports = function() {
 
 	page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
 
+	if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
+		page( '/settings/export/:site_id/guided', controller.siteSelection, controller.navigation, settingsController.guidedTransfer );
+	}
 	if ( config.isEnabled( 'manage/export' ) ) {
 		page( '/settings/export/:site_id', controller.siteSelection, controller.navigation, settingsController.exportSite );
 	}

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -19,6 +19,7 @@ import AnalyticsSettings from './section-analytics';
 import SeoSettings from './section-seo';
 import ImportSettings from './section-import';
 import ExportSettings from './section-export';
+import GuidedTransfer from './section-guided-transfer';
 import SiteSecurity from './section-security';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 
@@ -95,7 +96,8 @@ export class SiteSettingsComponent extends Component {
 			analytics: <AnalyticsSettings site={ site } />,
 			seo: <SeoSettings site={ site } />,
 			'import': <ImportSettings site={ site } />,
-			'export': <ExportSettings site={ site } store={ context.store } />
+			'export': <ExportSettings site={ site } store={ context.store } />,
+			guidedTransfer: <GuidedTransfer store={ context.store } />
 		};
 	}
 
@@ -108,6 +110,11 @@ export class SiteSettingsComponent extends Component {
 
 		if ( ! site ) {
 			return ( <SectionNav /> );
+		}
+
+		if ( section === 'guidedTransfer' ) {
+			// Dont show the navigation for guided transfer since it includes its own back navigation
+			return null;
 		}
 
 		return (

--- a/client/my-sites/site-settings/section-guided-transfer.jsx
+++ b/client/my-sites/site-settings/section-guided-transfer.jsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { Provider } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import GuidedTransfer from 'my-sites/guided-transfer';
+
+export default class extends Component {
+	render() {
+		return (
+			<Provider store={ this.props.store }>
+				<GuidedTransfer />
+			</Provider>
+		);
+	}
+}


### PR DESCRIPTION
This pull request adds a new Guided Transfer section in the "My settings" area of calypso. This new section for now is just a blank page that will eventually allow a user to purchase transfers for different hosts.

## How to test
1. Navigate to https://calypso.live/?branch=new/add-guided-transfer-routes
2. Click "My Sites" in the upper left corner of the page.
3. Scroll down in the left navigation area if needed and click "Settings"
4. Click "Export" in the page navigation.
5. Click the "Purchase a Guided Transfer" button
7. View the blank guided transfer page

### What to expect
**Export**
![screen shot 2016-06-07 at 12 30 41 pm](https://cloud.githubusercontent.com/assets/1854440/15866217/bf2e43c8-2cab-11e6-824e-36394852fabe.png)

**Guided Transfer**
![screen shot 2016-06-09 at 2 36 08 pm](https://cloud.githubusercontent.com/assets/1854440/15941789/b3d09b98-2e4f-11e6-9b8f-d2ace8d4523e.png)