### PR TITLE
Sign Up: Plans width for paid plans only

### DIFF
--- a/client/signup/steps/paid-plans-only/style.scss
+++ b/client/signup/steps/paid-plans-only/style.scss
@@ -1,4 +1,0 @@
-.paid-plans-only .plan-list {
-	margin: 0 auto;
-	max-width: 458px;
-}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -3,7 +3,8 @@
  */
 var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:steps:plans' ),
-	isEmpty = require( 'lodash/isEmpty' );
+	isEmpty = require( 'lodash/isEmpty' ),
+	classNames = require( 'classnames' );
 
 /**
  * Internal dependencies
@@ -138,7 +139,11 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		return <div className="plans plans-step has-no-sidebar">
+		const className = classNames( 'plans plans-step has-no-sidebar', {
+			'paid-plans-only': this.props.hideFreePlan
+		} );
+
+		return <div { ...{ className } }>
 			{
 				'compare' === this.props.stepSectionName
 				? this.plansCompare()

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -1,6 +1,18 @@
 .plans-step {
 	margin: 0 auto;
 	max-width: 700px;
+
+	&.paid-plans-only {
+		.plan-list {
+			margin: 0 auto;
+			max-width: 458px;
+		}
+
+		.plans-compare {
+		  max-width: 600px;
+		  margin: 25px auto 0;
+		}
+	}
 }
 
 .plans-step__compare-plans-link {


### PR DESCRIPTION
Fixing width of plans and plans compare on the signup flow when showing only paid plans

![plans](https://cloud.githubusercontent.com/assets/233601/15938503/d694be08-2e49-11e6-9f3a-904d2a16d73a.png)
![compare](https://cloud.githubusercontent.com/assets/233601/15938507/dacbb850-2e49-11e6-91db-bb221de2d635.png)

cc: @apeatling @roundhill 

Test live: https://calypso.live/?branch=fix/signup-plans-step-white-space