### PR TITLE
Reader Cold Start cards: use post canonical image where available, and use Photon to resize images

### DIFF
--- a/client/reader/start/card-hero.jsx
+++ b/client/reader/start/card-hero.jsx
@@ -1,0 +1,50 @@
+// External dependencies
+import React from 'react';
+import { connect } from 'react-redux';
+import get from 'lodash/get';
+
+// Internal dependencies
+import { getSite } from 'state/reader/sites/selectors';
+import { getPostBySiteAndId } from 'state/reader/posts/selectors';
+import safeImageUrl from 'lib/safe-image-url';
+import resizeImageUrl from 'lib/resize-image-url';
+
+const StartCardHero = ( { site, post } ) => {
+	let headerImageUrl = get( site, 'header_image.url' );
+
+	if ( ! headerImageUrl && post ) {
+		headerImageUrl = get( post, 'canonical_image.uri' );
+	}
+
+	// Resize it with Photon
+	let resizedHeaderImageUrl;
+	if ( headerImageUrl ) {
+		resizedHeaderImageUrl = resizeImageUrl( safeImageUrl( headerImageUrl ), { resize: '350,70' } );
+	}
+
+	// Prepare the style attribute
+	let heroStyle;
+	if ( resizedHeaderImageUrl ) {
+		heroStyle = {
+			backgroundImage: `url("${ resizedHeaderImageUrl }")`
+		};
+	}
+
+	return (
+		<div className="reader-start-card__hero" style={ heroStyle }></div>
+	);
+};
+
+StartCardHero.propTypes = {
+	siteId: React.PropTypes.number.isRequired,
+	postId: React.PropTypes.number.isRequired
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			site: getSite( state, ownProps.siteId ),
+			post: getPostBySiteAndId( state, ownProps.siteId, ownProps.postId )
+		};
+	}
+)( StartCardHero );

--- a/client/reader/start/card.jsx
+++ b/client/reader/start/card.jsx
@@ -8,23 +8,14 @@ import classnames from 'classnames';
 // Internal dependencies
 import Card from 'components/card';
 import StartPostPreview from './post-preview';
+import StartCardHero from './card-hero';
 import StartCardHeader from './card-header';
 import StartCardFooter from './card-footer';
 import { getRecommendationById } from 'state/reader/start/selectors';
-import { getSite } from 'state/reader/sites/selectors';
 
 const debug = debugModule( 'calypso:reader:start' ); //eslint-disable-line no-unused-vars
 
-const StartCard = ( { site, siteId, postId } ) => {
-	const headerImage = site.header_image;
-
-	let heroStyle;
-	if ( headerImage ) {
-		heroStyle = {
-			backgroundImage: `url("${ headerImage.url }")`
-		};
-	}
-
+const StartCard = ( { siteId, postId } ) => {
 	const cardClasses = classnames(
 		'reader-start-card',
 		{
@@ -34,7 +25,7 @@ const StartCard = ( { site, siteId, postId } ) => {
 
 	return (
 		<Card className={ cardClasses }>
-			<div className="reader-start-card__hero" style={ heroStyle }></div>
+			<StartCardHero siteId={ siteId } postId={ postId } />
 			<StartCardHeader siteId={ siteId } />
 			{ postId > 0 && <StartPostPreview siteId={ siteId } postId={ postId } /> }
 			<StartCardFooter siteId={ siteId } />
@@ -51,12 +42,10 @@ export default connect(
 		const recommendation = getRecommendationById( state, ownProps.recommendationId );
 		const siteId = get( recommendation, 'recommended_site_ID' );
 		const postId = get( recommendation, 'recommended_post_ID' );
-		const site = getSite( state, siteId );
 
 		return {
 			siteId,
-			postId,
-			site
+			postId
 		};
 	}
 )( StartCard );


### PR DESCRIPTION
Originally we intended to use site header images as the background of Reader cards, but only 10-15% of sites appear to have them.

<img width="370" alt="screen shot 2016-06-09 at 17 59 04" src="https://cloud.githubusercontent.com/assets/17325/15938647/f76c7b9e-2e6b-11e6-8cc7-abe565dc8213.png">

As an alternative, we'll now use the `post.canonical_image` if there is one.

As some of these images are quite large, we're also now using Photon to grab a resized version of the image for the card.

cc @TooTallNate @blowery 


Test live: https://calypso.live/?branch=add/reader/cold-start-canonical-image