### PR TITLE
Plans: remove monthly prices abtest

### DIFF
--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import WpcomPlanPrice from 'my-sites/plans/wpcom-plan-price';
 
 const PlanPrice = React.createClass( {
@@ -24,10 +23,8 @@ const PlanPrice = React.createClass( {
 				return this.translate( 'Free', { context: 'Zero cost product price' } );
 			}
 
-			if ( abtest( 'planPricing' ) === 'monthly' ) {
-				const monthlyPrice = +( rawPrice / 12 ).toFixed( 2 );
-				formattedPrice = formattedPrice.replace( rawPrice, monthlyPrice );
-			}
+			const monthlyPrice = +( rawPrice / 12 ).toFixed( 2 );
+			formattedPrice = formattedPrice.replace( rawPrice, monthlyPrice );
 
 			return formattedPrice;
 		}
@@ -57,7 +54,7 @@ const PlanPrice = React.createClass( {
 
 		if ( ! plan ) {
 			periodLabel = '';
-		} else if ( abtest( 'planPricing' ) === 'monthly' && plan.raw_price > 0 ) {
+		} else if ( plan.raw_price > 0 ) {
 			periodLabel = this.translate( 'per month, billed yearly' );
 		} else {
 			periodLabel = hasDiscount ? this.translate( 'due today when you upgrade' ) : plan.bill_period_label;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -92,16 +92,6 @@ module.exports = {
 		allowExistingUsers: false,
 		allowAnyLocale: true
 	},
-	planPricing: {
-		datestamp: '20160426',
-		variations: {
-			monthly: 90,
-			annual: 10
-		},
-		defaultVariation: 'monthly',
-		allowExistingUsers: true,
-		allowAnyLocale: true
-	},
 	wordadsInstantActivation: {
 		datestamp: '20160607',
 		variations: {

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -16,7 +16,6 @@ import {
 	isPlan
 } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
-import { abtest } from 'lib/abtest';
 
 const getIncludedDomain = cartItems.getIncludedDomain;
 
@@ -67,7 +66,7 @@ export default React.createClass( {
 			return null;
 		}
 
-		if ( abtest( 'planPricing' ) === 'annual' || cost <= 0 ) {
+		if ( cost <= 0 ) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR removes the monthly prices abtest, in favor of showing everyone monthly prices for plans.

<img width="761" alt="screen shot 2016-06-09 at 10 07 28 am" src="https://cloud.githubusercontent.com/assets/1270189/15938993/ac199492-2e2a-11e6-9a8a-f0a2b4a66637.png">
<img width="760" alt="screen shot 2016-06-09 at 10 08 27 am" src="https://cloud.githubusercontent.com/assets/1270189/15938997/adc4b600-2e2a-11e6-8509-17b3ad3baf7c.png">
<img width="270" alt="screen shot 2016-06-09 at 10 08 03 am" src="https://cloud.githubusercontent.com/assets/1270189/15939000/b2519cba-2e2a-11e6-9bca-a1f5a4be88a6.png">

## Testing Instructions
- Confirm that plans pricing is shown in a monthly timeframe in /plans, /plans/compare and in the cart items
- Verify that non-plan products like domains and themes show the correct amount in the cart

cc @rralian @apeatling 

Test live: https://calypso.live/?branch=update/remove-monthly-pricing-test