### PR TITLE
Editor: Fix wptextpattern expansions during fast typing

### DIFF
--- a/client/components/tinymce/plugins/wptextpattern/plugin.js
+++ b/client/components/tinymce/plugins/wptextpattern/plugin.js
@@ -68,15 +68,14 @@ function wptextpattern( editor ) {
 		if ( event.keyCode === VK.ENTER && ! VK.modifierPressed( event ) ) {
 			enter();
 		}
-	}, true );
 
-	editor.on( 'keyup', function( event ) {
+		// Wait for the browser to insert the character.
 		if ( event.keyCode === VK.SPACEBAR && ! event.ctrlKey && ! event.metaKey && ! event.altKey ) {
-			space();
+			setTimeout( space );
 		} else if ( event.keyCode > 47 && ! ( event.keyCode >= 91 && event.keyCode <= 93 ) ) {
-			inline();
+			setTimeout( inline );
 		}
-	} );
+	}, true );
 
 	function inline() {
 		var rng = editor.selection.getRng();


### PR DESCRIPTION
In the wptextpattern TinyMCE plugin (both core and Calypso versions), the [keyboard shortcuts for adding lists](https://codex.wordpress.org/Keyboard_Shortcuts#Formatting_Shortcuts) are somewhat unreliable.

For example, typing `*` or `-` starts an unordered list. This reformatting is performed upon receiving the `keyup` event of the space key, and it is only performed if the current cursor position matches the length of the `*[space]` pattern.

This means that the following sequence of key events does not result in conversion of the current line to a list:

- (Start on a blank line)
- Press and release `-`
- Press the spacebar but do not release it
- Press `a`
- Release the spacebar
- Release `a`

There are similar issues with using backticks to format \``code snippets`\`.

The fix is to trigger the text pattern on the `keydown` event, but after a timeout, so that the browser has time to insert the character that corresponds to the key pressed.

More info on the core ticket:  https://core.trac.wordpress.org/ticket/36585

Test live: https://calypso.live/?branch=fix/editor/wptextpattern-fast-typing