### PR TITLE
Redux: connection middleware

### DIFF
--- a/client/state/connectionMiddleware/README.md
+++ b/client/state/connectionMiddleware/README.md
@@ -1,0 +1,70 @@
+# Connection Middleware
+
+Connection Middleware is used instead of `redux-thunk` to easier manage API communication.
+
+## Usage
+
+To initiate connection to API, you need 2 parts
+
+- action that starts a connection
+- function that handles it
+
+### Action
+
+To promote optimistic updating of UI, connection can only be initiated when corresponding action has been dispatched
+We recommend handling that action in reducer and UI in an optimistic manner.
+
+### Function
+
+Connection function is what handles your actual endpoint communication. We recommend writing it in pure manner and storing in `connections.js` file.
+Wpcom reference will be injected in a higher scope.
+Your connectionFunction should dispatch appropriate `SUCCESS` action upon success and `FAILURE` action upon failure.
+Simple connectionFunction would look like this:
+```
+const myConnectionFunction = wpcom => ( action, dispatch ) {
+    dispatch( { type: SUCCESS } );
+}
+
+```
+
+### Binding action and connection together
+
+To register a connection, simply:
+
+```
+import { registerConnection } from 'state/connectionMiddleware/middleware';
+registerConnection( ACTION_TYPE_TRIGGERING_A_CALL, myConnectionFunction );
+
+```
+
+We recommend doing it in `actions.js`, so that it is easy to grasp what is happening after an action is dispatched.
+
+
+## Writing tests
+
+This approach decouples `FETCH` and `SUCCESS/FAILURE` actionTypes. So:
+- your `FETCH` action should return a pure object and treat is as such
+- connectionFunction should be a pure function returning a function. You should not need to mock any imports to test it.
+
+To test your connectionFunction you can use `createWpcomSpy` that wraps sinon spy into a path in a similar fashion as wpcom does:
+```
+it( 'should dispatch "SITE_PLANS_FETCH_COMPLETED" upon success', () => {
+    const wpcom = createWpcomSpy(
+        [ 'undocumented', 'getSitePlans' ],
+        ( siteId, callback ) => callback( null, {} )
+    );
+    connectFetchSitePlans( wpcom )( { siteId: 5 }, dispatchMock );
+    expect(
+        dispatchMock.calledWithMatch( { type: SITE_PLANS_FETCH_COMPLETED, siteId: 5 } )
+    ).ok;
+} );
+```
+
+## Work in progress
+
+Other benefits possible because of decoupling FETCH actions from connection handling:
+- throttling API calls
+- batching requests
+- storing actions in a queue while offline
+- debouncing
+- less action / state mixing that happen because of `getState` in `thunk`

--- a/client/state/connectionMiddleware/middleware.js
+++ b/client/state/connectionMiddleware/middleware.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+
+const connections = {};
+
+export const connectionMiddleware = store => next => action => {
+	if ( connections.hasOwnProperty( action.type ) ) {
+		connections[ action.type ].connectionFunction( wpcom )( action, store.dispatch );
+		next( action );
+	} else {
+		next( action );
+	}
+};
+
+export function registerConnection( actionType, connectionFunction, options = {} ) {
+	connections[ actionType ] = Object.assign( { connectionFunction }, options );
+}

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -9,6 +9,7 @@ import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
  */
 import application from './application/reducer';
 import comments from './comments/reducer';
+import { connectionMiddleware } from './connectionMiddleware/middleware';
 import componentsUsageStats from './components-usage-stats/reducer';
 import currentUser from './current-user/reducer';
 import documentHead from './document-head/reducer';
@@ -68,7 +69,7 @@ export const reducer = combineReducers( {
 	wordads
 } );
 
-let middleware = [ thunkMiddleware ];
+let middleware = [ thunkMiddleware, connectionMiddleware ];
 
 // Analytics middleware currently only works in the browser
 if ( typeof window === 'object' ) {

--- a/client/state/sites/plans/connections.js
+++ b/client/state/sites/plans/connections.js
@@ -1,0 +1,59 @@
+import debugFactory from 'debug';
+import map from 'lodash/map';
+
+import {
+	SITE_PLANS_FETCH_FAILED,
+	SITE_PLANS_TRIAL_CANCEL_COMPLETED,
+	SITE_PLANS_TRIAL_CANCEL_FAILED
+} from 'state/action-types';
+import { createSitePlanObject } from './assembler';
+import { fetchSitePlansCompleted } from './actions';
+import i18n from 'i18n-calypso';
+
+const debug = debugFactory( 'calypso:site-plans:connections' );
+
+export const connectCancelSitePlanTrial = wpcom => ( action, dispatch ) => {
+	return new Promise( ( resolve, reject ) => {
+		wpcom.undocumented().cancelPlanTrial( action.planId, ( error, data ) => {
+			if ( data && data.success ) {
+				dispatch( {
+					type: SITE_PLANS_TRIAL_CANCEL_COMPLETED,
+					siteId: action.siteId,
+					plans: map( data.plans, createSitePlanObject )
+				} );
+
+				resolve();
+			} else {
+				debug( 'Canceling site plan trial failed: ', error );
+
+				const errorMessage = error.message || i18n.translate( 'There was a problem canceling the plan trial. Please try again later or contact support.' );
+
+				dispatch( {
+					type: SITE_PLANS_TRIAL_CANCEL_FAILED,
+					siteId: action.siteId,
+					error: errorMessage
+				} );
+
+				reject( errorMessage );
+			}
+		} );
+	} );
+}
+
+export const connectFetchSitePlans = wpcom => ( action, dispatch ) =>
+	wpcom.undocumented().getSitePlans( action.siteId, ( error, data ) => {
+			if ( error ) {
+				debug( 'Fetching site plans failed: ', error );
+
+				const errorMessage = error.message || i18n.translate( 'There was a problem fetching site plans. Please try again later or contact support.' );
+
+				dispatch( {
+					type: SITE_PLANS_FETCH_FAILED,
+					siteId: action.siteId,
+					error: errorMessage
+				} );
+			} else {
+				dispatch( fetchSitePlansCompleted( action.siteId, data ) );
+			}
+		}
+	);

--- a/client/state/sites/plans/test/connections.js
+++ b/client/state/sites/plans/test/connections.js
@@ -1,0 +1,48 @@
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+/**
+ * Internal dependencies
+ */
+import { SITE_PLANS_FETCH_COMPLETED, SITE_PLANS_FETCH_FAILED } from 'state/action-types';
+import { connectFetchSitePlans } from '../connections';
+import { createWpcomSpy } from 'test/helpers/use-sinon';
+
+describe( 'connections', () => {
+	describe( '#connectFetchSitePlans()', () => {
+		const dispatchMock = spy();
+
+		it( 'should pass siteId to API call', () => {
+			const wpcom = createWpcomSpy(
+				[ 'undocumented', 'getSitePlans' ],
+				( siteId, callback ) => callback( null, {} )
+			);
+			connectFetchSitePlans( wpcom )( { siteId: 5 }, dispatchMock );
+			expect( wpcom.responseSpy.calledWith( 5 ) ).ok;
+		} );
+
+		it( 'should dispatch "SITE_PLANS_FETCH_COMPLETED" upon success', () => {
+			const wpcom = createWpcomSpy(
+				[ 'undocumented', 'getSitePlans' ],
+				( siteId, callback ) => callback( null, {} )
+			);
+			connectFetchSitePlans( wpcom )( { siteId: 5 }, dispatchMock );
+			expect(
+				dispatchMock.calledWithMatch( { type: SITE_PLANS_FETCH_COMPLETED, siteId: 5 } )
+			).ok;
+		} );
+		it( 'should dispatch "SITE_PLANS_FETCH_FAILED" upon failure and pass proper error message', () => {
+			const wpcom = createWpcomSpy(
+				[ 'undocumented', 'getSitePlans' ],
+				( siteId, callback ) => callback( { message: 'error message' }, {} )
+			);
+			connectFetchSitePlans( wpcom )( { siteId: 5 }, dispatchMock );
+			expect(
+				dispatchMock.calledWithMatch( { type: SITE_PLANS_FETCH_FAILED, siteId: 5, error: 'error message' } )
+			).ok;
+		} );
+	} );
+} );

--- a/test/test/helpers/use-sinon/index.js
+++ b/test/test/helpers/use-sinon/index.js
@@ -1,4 +1,4 @@
-import sinon from 'sinon';
+import sinon, { spy } from 'sinon';
 import noop from 'lodash/noop';
 import isFunction from 'lodash/isFunction';
 
@@ -65,4 +65,19 @@ export function useSandbox( config, sandboxCallback = noop ) {
 			this.sandbox = null;
 		}
 	} );
+}
+
+/**
+ * Creates a sinon spy out of responseFunction and wraps it in layers of function calls, like wpcom does.
+ * Returned object stubs wpcom.
+ * responseSpy attribute of returned object provides reference to sinon spy.
+ * @param {Array} path
+ * @param {Function} responseFunction
+ * @returns {Object} wpcom-like wrapped object
+ */
+export function createWpcomSpy( path, responseFunction ) {
+	const responseSpy = spy( responseFunction );
+	const wpcom =  path.reverse().reduce( ( prev, current, index ) => ( { [ current ]: index ? () => prev : prev } ), responseSpy );
+	wpcom.responseSpy = responseSpy;
+	return wpcom;
 }


### PR DESCRIPTION
## What?

This is middleware to be used instead of thunk to manage api calls

## Why?

- thunk is messy
- this pr enables easy testing of connecting functions
- with this system in place we can handle queuing of offline actions
- enforces optimistic updates

## Testing

Go to `http://calypso.localhost:3000/plans/your-site` and verify that it loads

# Background

This introduces framework for #3269 - offline replay action queue
In February, late Core Calypso (now house Stark) started playing with making Calypso offline.
In order to accomplish that, we needed a way to halt network connections while offline and replay them once online, all while updating UI in optimistic manner.

I created #3269 to do that, but PR got too messy and offline queue wont be immidiately implemented, because nit everything is ported to redux. It is worth continuing and I intend to do so.

I'm especially happy that action creators and connectionfunctions are now pure and that enables easy testing without a need to mock `wpcom` or use http mocking framework such as `nock`.
It is also synchronous.

CC @gwwar @dmsnell @blowery @rralian @mtias @aduth @coderkevin @gziolo @apeatling @Tug 

# README (also in file)

### Connection Middleware

Connection Middleware is used instead of `redux-thunk` to easier manage API communication.

#### Usage

To initiate connection to API, you need 2 parts

- action that starts a connection
- function that handles it

#### Action

To promote optimistic updating of UI, connection can only be initiated when corresponding action has been dispatched
We recommend handling that action in reducer and UI in an optimistic manner.

#### Function

Connection function is what handles your actual endpoint communication. We recommend writing it in pure manner and storing in `connections.js` file.
Wpcom reference will be injected in a higher scope.
Your connectionFunction should dispatch appropriate `SUCCESS` action upon success and `FAILURE` action upon failure.
Simple connectionFunction would look like this:
```
const myConnectionFunction = wpcom => ( action, dispatch ) {
    dispatch( { type: SUCCESS } );
}

```

#### Binding action and connection together

To register a connection, simply:

```
import { registerConnection } from 'state/connectionMiddleware/middleware';
registerConnection( ACTION_TYPE_TRIGGERING_A_CALL, myConnectionFunction );

```

We recommend doing it in `actions.js`, so that it is easy to grasp what is happening after an action is dispatched.


### Writing tests

This approach decouples `FETCH` and `SUCCESS/FAILURE` actionTypes. So:
- your `FETCH` action should return a pure object and treat is as such
- connectionFunction should be a pure function returning a function. You should not need to mock any imports to test it.

To test your connectionFunction you can use `createWpcomSpy` that wraps sinon spy into a path in a similar fashion as wpcom does:
```
it( 'should dispatch "SITE_PLANS_FETCH_COMPLETED" upon success', () => {
    const wpcom = createWpcomSpy(
        [ 'undocumented', 'getSitePlans' ],
        ( siteId, callback ) => callback( null, {} )
    );
    connectFetchSitePlans( wpcom )( { siteId: 5 }, dispatchMock );
    expect(
        dispatchMock.calledWithMatch( { type: SITE_PLANS_FETCH_COMPLETED, siteId: 5 } )
    ).ok;
} );
```

### Work in progress

Other benefits possible because of decoupling FETCH actions from connection handling:
- throttling API calls
- batching requests
- storing actions in a queue while offline
- debouncing
- less action / state mixing that happen because of `getState` in `thunk`


Test live: https://calypso.live/?branch=new/connection-middleware