### PR TITLE
Importer: Continue reduxification work

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -173,17 +173,17 @@ export function setUploadProgress( importerId, data ) {
 	} );
 }
 
-export function startImport( siteId, importerType ) {
+export const startImport = ( siteId, importerType ) => {
 	// Use a fake ID until the server returns the real one
 	let importerId = `${ ID_GENERATOR_PREFIX }${ Math.round( Math.random() * 10000 ) }`;
 
-	Dispatcher.handleViewAction( {
+	return {
 		type: IMPORTS_IMPORT_START,
 		importerId,
 		importerType,
 		siteId
-	} );
-}
+	};
+};
 
 export function startImporting( importerStatus ) {
 	const { importerId, site: { ID: siteId } } = importerStatus;

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -12,6 +12,8 @@ import Button from 'components/forms/form-button';
 import { appStates } from 'state/imports/constants';
 import { cancelImport, resetImport, startImport } from 'lib/importer/actions';
 import SocialLogo from 'components/social-logo';
+import flowRight from 'lodash/flowRight';
+import { connectDispatcher } from './dispatcher-converter';
 
 /**
  * Module variables
@@ -27,7 +29,7 @@ const startStates = [ appStates.DISABLED, appStates.INACTIVE ],
 	stopStates = [ appStates.IMPORT_FAILURE, appStates.IMPORTING ],
 	doneStates = [ appStates.IMPORT_SUCCESS ];
 
-export default React.createClass( {
+export const ImporterHeader = React.createClass( {
 	displayName: 'ImporterHeader',
 
 	mixins: [ PureRenderMixin ],
@@ -44,7 +46,17 @@ export default React.createClass( {
 	},
 
 	controlButtonClicked: function() {
-		const { importerStatus: { importerId, importerState, type }, site: { ID: siteId } } = this.props;
+		const {
+			importerStatus: {
+				importerId,
+				importerState,
+				type
+			},
+			site: {
+				ID: siteId
+			},
+			startImport
+		} = this.props;
 
 		if ( includes( [ ...cancelStates, ...stopStates ], importerState ) ) {
 			cancelImport( siteId, importerId );
@@ -102,3 +114,9 @@ export default React.createClass( {
 		);
 	}
 } );
+
+const mapDispatchToProps = dispatch => ( {
+	startImport: flowRight( dispatch, startImport )
+} );
+
+export default connectDispatcher( null, mapDispatchToProps )( ImporterHeader );


### PR DESCRIPTION
Part of #5303

Updates the `startImport` action, which is one of the few actions that
can be simply converted without getting into thunk issues.

No functional or stylistic changes are intended.

**Testing**
Navigate to **My Sites** > **Settings** > **Import** and attempt to start a new import from the collapsed import panel; either WordPress or Medium will work. If an import session is currently in progress, cancel it and try to start a new one. This is mostly a smoke-test.

cc: @roundhill @rodrigoi 

Test live: https://calypso.live/?branch=update/importer-redux/start-import