### PR TITLE
Plans: align info popup with text

### DIFF
--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -187,17 +187,17 @@
 
 .plans-compare__feature-title {
 	position: relative;
+	white-space: nowrap;
 }
 
 .plans-compare__feature-title__container {
-	padding-right: 20px;
+	padding-right: 5px;
 }
 
 .plans-compare__feature-descripcion {
-	position: absolute;
-	top: 50%;
-	margin-top: -9px;
-	right: 0;
+	position: relative;
+	top: -2px;
+	display: inline;
 }
 
 .plans-compare__feature-descripcion .gridicon {


### PR DESCRIPTION
I'm sure there's a more elegant way to handle this, but these tweaks get the info popups to line up a little nicer for now.

## Before
![info popup before](https://cloudup.com/c0ZiBVh3rWc+)

## After
![info popup after](https://cloudup.com/cFh5MVw75Pe+)

cc @apeatling @retrofox 

## Testing
Just make sure the info popup looks good across browsers and at different viewport sizes.

Test live: https://calypso.live/?branch=update/plans-info-popup-design