### PR TITLE
Reader: add title box to Cold Start cards with posts

### DIFF
--- a/client/reader/start/main.jsx
+++ b/client/reader/start/main.jsx
@@ -60,9 +60,9 @@ const Start = React.createClass( {
 			<Main className="reader-start">
 				<QueryReaderStartRecommendations />
 				<header className="reader-start__intro">
-					<h1 className="reader-start__title">{ this.translate( 'Welcome to the Reader' ) }</h1>
-					<p className="reader-start__description">{ this.translate( "Discover great stories and read your favorite sites' posts all in one place. Every time there are new updates to the sites you follow, you'll be the first to know!" ) }
-				</p>
+					<h1 className="reader-start__title">{ this.translate( 'Welcome to the WordPress.com Reader' ) }</h1>
+					<p className="reader-start__description">{ this.translate( "Discover great stories and read your favorite sites' posts all in one place. Every time there are new updates to the sites you follow, you'll be the first to know!" ) }</p>
+					<p className="reader-start__description">{ this.translate( "We've curated a list of content for you. Follow one or more sites to get started." ) }</p>
 				</header>
 
 				<div className="reader-start__cards">
@@ -80,8 +80,8 @@ const Start = React.createClass( {
 						<span className="reader-start__bar-text">
 							{ canGraduate
 								? this.translate(
-									'Great! You\'re following %(totalSubscriptions)d site.',
-									'Great! You\'re following %(totalSubscriptions)d sites.', {
+									'Great! You\'re now following %(totalSubscriptions)d site.',
+									'Great! You\'re now following %(totalSubscriptions)d sites.', {
 										count: this.state.totalSubscriptions,
 										args: {
 											totalSubscriptions: this.state.totalSubscriptions

--- a/client/reader/start/post-preview.jsx
+++ b/client/reader/start/post-preview.jsx
@@ -29,12 +29,15 @@ const StartPostPreview = React.createClass( {
 		}
 		return (
 			<article className="reader-start-post-preview">
-				<h1><a href={ this.getFullPostUrl() } onClick={ this.showFullPost } className="reader-start-post-preview__title">{ post.title }</a></h1>
-				<div className="reader-start-post-preview__byline">
-					<Gravatar user={ post.author } size={ 20 } />
-					<span className="reader-start-post-preview__author">by { post.author.name }</span>
+				<span className="reader-start-post-preview__popular">Popular from this site</span>
+				<div className="reader-start-post-preview__post-content">
+					<h1><a href={ this.getFullPostUrl() } onClick={ this.showFullPost } className="reader-start-post-preview__title">{ post.title }</a></h1>
+					<div className="reader-start-post-preview__byline">
+						<Gravatar user={ post.author } size={ 20 } />
+						<span className="reader-start-post-preview__author">by { post.author.name }</span>
+					</div>
+					<PostExcerpt maxLength={ 160 } content={ post.excerpt } className="reader-start-post-preview__excerpt" />
 				</div>
-				<PostExcerpt maxLength={ 160 } content={ post.excerpt } className="reader-start-post-preview__excerpt" />
 			</article>
 		);
 	}

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -84,7 +84,7 @@
 	.post-excerpt.is-long {
 		font-family: $serif;
 		font-size: 12px;
-		margin: 10px 0 -10px;
+		margin: 10px 0 -3px;
 		max-height: none;
 	}
 
@@ -179,7 +179,7 @@
 }
 
 .reader-start-card__site-description {
-	color: $gray;
+	color: darken( $gray, 20% );
 	font-size: 12px;
 
 	.site-icon {
@@ -208,8 +208,26 @@
 .reader-start-post-preview {
 	border: 1px solid lighten( $gray, 30% );
 	border-radius: 1px;
-	margin-top: -8px;
+	margin-top: 23px;
 	padding: 10px 10px 20px;
+}
+
+.reader-start-post-preview__popular {
+    background-color: $white;
+    color: $gray;
+    display: inline;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: .05em;
+    margin-left: -3px;
+    padding: 0 4px;
+	position: relative;
+    	top : -24px;
+    text-transform: uppercase;
+}
+
+.reader-start-post-preview__post-content {
+	margin-top: -13px;
 }
 
 .reader-start-post-preview__title {
@@ -222,7 +240,7 @@
 	margin-bottom: 5px;
 
 	&:hover {
-		color: darken( $gray, 10% );
+		color: darken( $gray, 20% );
 	}
 
 	&:visited {


### PR DESCRIPTION
Some feedback from @martinremy:

> the intro title at the top.  should it say "Welcome to the WordPress.com Reader", adding "WordPress.com" in?

**Before:**
![screenshot 2016-06-09 12 47 17](https://cloud.githubusercontent.com/assets/4924246/15944016/6f208120-2e40-11e6-81f7-635cef209386.png)

**After:**
![screenshot 2016-06-09 12 48 24](https://cloud.githubusercontent.com/assets/4924246/15944026/7b10a384-2e40-11e6-9032-35eba891dcd3.png)

> the intro text at the top.  it's a good summary of the reader, but it doesn't tell the user what is on the page they are currently on (the cold start page).

**Before:**
![screenshot 2016-06-09 12 47 20](https://cloud.githubusercontent.com/assets/4924246/15944032/812e1396-2e40-11e6-8f69-254e2d02e936.png)

**After:**
![screenshot 2016-06-09 12 48 27](https://cloud.githubusercontent.com/assets/4924246/15944035/85d6d0ea-2e40-11e6-95ac-413b5ca640d3.png)

> treatment of blogs that have no blavatar or header image.  should we just have a different type of card for these, since we have variable height anyway?

I think we should keep the layout within the cards the same regardless if they have a blavatar/header image or not. It will be confusing to have cards with a different layout. We know why we're doing this (because some cards don't have header images and some do), but users don't know that.

> cards with posts.  can we try a short explanation above the post, something like "A popular post from The Belle Jar" or something like that?

**Before:**
![screenshot 2016-06-09 12 47 24](https://cloud.githubusercontent.com/assets/4924246/15944049/8ff75e82-2e40-11e6-9e58-40b5a82cc259.png)

**After:**
![screenshot 2016-06-09 12 49 27](https://cloud.githubusercontent.com/assets/4924246/15944061/9cda4a88-2e40-11e6-9c47-ca563f13ad00.png)