### PR TITLE
Plans: WordAds settings do not save when users does not change USstate

### DIFF
--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -142,7 +142,7 @@ const AdsFormSettings = React.createClass( {
 			optimized_ads: false,
 			paypal: '',
 			show_to_logged_in: 'yes',
-			state: '',
+			state: 'AL',
 			taxid_last4: '',
 			tos: 'signed',
 			us_resident: 'no',


### PR DESCRIPTION
As pointed out by Christopher Smith:

> I found one quirk. If you tick the US Resident box and fill out the form, Alabama is already selected. However, if you leave Alabama (maybe it’s a user from Alabama) without clicking and re-selecting it, you trigger an error to select a state. I’m guessing that affects a pretty slim segment of users in Alabama, but perhaps a “select state” item to force the click there would be a better choice.

The underlying issue was that alabama got dosplaed by diefault, but react component  state got updated only on change.

The quickest fix was setting default state in component

That needs further testing / cleanup

CC @rralian @dbspringer 

Test live: https://calypso.live/?branch=fix/wordads-select-state