### PR TITLE
Reader: use `react-masonry-component` for StartCards

### DIFF
--- a/client/reader/start/main.jsx
+++ b/client/reader/start/main.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import map from 'lodash/map';
 import page from 'page';
+import Masonry from 'react-masonry-component';
 
 /**
  * Internal dependencies
@@ -65,7 +66,7 @@ const Start = React.createClass( {
 				</p>
 				</header>
 
-				<div className="reader-start__cards">
+				<Masonry className="reader-start__cards">
 					{ this.props.recommendationIds ? map( this.props.recommendationIds, ( recId ) => {
 						return (
 							<StartCard
@@ -73,7 +74,7 @@ const Start = React.createClass( {
 								recommendationId={ recId } />
 						);
 					} ) : null }
-				</div>
+				</Masonry>
 
 				<RootChild className="reader-start__bar">
 					<div className="reader-start__bar-action main">

--- a/client/reader/start/main.jsx
+++ b/client/reader/start/main.jsx
@@ -66,7 +66,7 @@ const Start = React.createClass( {
 				</p>
 				</header>
 
-				<Masonry className="reader-start__cards">
+				<Masonry className="reader-start__cards" options={ { gutter: 14 } }>
 					{ this.props.recommendationIds ? map( this.props.recommendationIds, ( recId ) => {
 						return (
 							<StartCard

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -46,7 +46,7 @@
 	@include breakpoint( ">960px" ) {
 		display: inline-block;
 			margin: 8px 5px 8px 2px;
-			width: 350px;
+			width: 341px;
 	}
 
 	&:first-child {

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -42,11 +42,12 @@
 
 .reader-start-card {
 	margin-bottom: 25px;
+	width: 100%;
 
 	@include breakpoint( ">960px" ) {
 		display: inline-block;
 			margin: 8px 5px 8px 2px;
-			width: 341px;
+			width: 48%;
 	}
 
 	&:first-child {

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -34,11 +34,6 @@
 	padding-bottom: 100px;
 	transform: translateX( 0 ); // Prevents overflowing content from disappearing
 
-    @include breakpoint( ">960px" ) {
-	    column-count: 2;
-	    column-gap: 1em;
-    }
-
 	.site-icon {
 		border: 4px solid $white;
 		margin: 0 auto;
@@ -50,8 +45,8 @@
 
 	@include breakpoint( ">960px" ) {
 		display: inline-block;
-	    margin: 8px 5px 8px 2px;
-	    width: 100%;
+			margin: 8px 5px 8px 2px;
+			width: 350px;
 	}
 
 	&:first-child {

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -46,7 +46,7 @@
 
 	@include breakpoint( ">960px" ) {
 		display: inline-block;
-			margin: 8px 5px 8px 2px;
+			margin: 0px 0px 14px 0px;
 			width: 48%;
 	}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -767,6 +767,9 @@
     "depd": {
       "version": "1.1.0"
     },
+    "desandro-matches-selector": {
+      "version": "2.0.1"
+    },
     "destroy": {
       "version": "1.0.3"
     },
@@ -1104,6 +1107,9 @@
     "etag": {
       "version": "1.7.0"
     },
+    "ev-emitter": {
+      "version": "1.0.3"
+    },
     "event-emitter": {
       "version": "0.3.4"
     },
@@ -1236,6 +1242,9 @@
         }
       }
     },
+    "fizzy-ui-utils": {
+      "version": "2.0.2"
+    },
     "flat-cache": {
       "version": "1.0.10"
     },
@@ -1311,6 +1320,9 @@
     },
     "get-document": {
       "version": "1.0.0"
+    },
+    "get-size": {
+      "version": "2.0.2"
     },
     "get-stdin": {
       "version": "4.0.1"
@@ -1544,6 +1556,9 @@
     },
     "ieee754": {
       "version": "1.1.6"
+    },
+    "imagesloaded": {
+      "version": "4.1.0"
     },
     "immutable": {
       "version": "3.7.5"
@@ -2087,6 +2102,9 @@
     "marked": {
       "version": "0.3.5"
     },
+    "masonry-layout": {
+      "version": "4.1.0"
+    },
     "matches-selector": {
       "version": "0.0.1"
     },
@@ -2407,6 +2425,9 @@
     "osenv": {
       "version": "0.1.3"
     },
+    "outlayer": {
+      "version": "2.1.0"
+    },
     "output-file-sync": {
       "version": "1.1.1"
     },
@@ -2664,6 +2685,9 @@
           "version": "0.4.4"
         }
       }
+    },
+    "react-masonry-component": {
+      "version": "4.0.4"
     },
     "react-pure-render": {
       "version": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "react-day-picker": "1.3.2",
     "react-dom": "0.14.3",
     "react-helmet": "2.2.0",
+    "react-masonry-component": "4.0.4",
     "react-pure-render": "1.0.2",
     "react-redux": "4.4.5",
     "react-tap-event-plugin": "0.2.1",


### PR DESCRIPTION
Uses [Masonry](masonry.desandro.com) for layout in Cold Start (see https://github.com/eiriklv/react-masonry-component).

This renders the StartCards from left to right, rather then top to bottom via columns.

#### Example:

<img width="568" alt="screen shot 2016-06-09 at 1 13 20 pm" src="https://cloud.githubusercontent.com/assets/71256/15945278/760ae330-2e46-11e6-9a17-77686ebd14c7.png">

(Note that "TechnoScience as if People Mattered" is the 2nd entry in the DOM list, and is being rendered to the right of the first StartCard, as expected).

This is expected to make the interaction of loading more recs (#5652) be more pleasant.

/cc @jancavan @bluefuton 

Test live: https://calypso.live/?branch=add/reacy-masonry-component