### PR TITLE
Reader: Prevent loops in history and the related posts rabbit hole

### DIFF
--- a/client/components/post-card/small.jsx
+++ b/client/components/post-card/small.jsx
@@ -12,7 +12,10 @@ import SiteIcon from 'components/site-icon';
 import safeImageUrl from 'lib/safe-image-url';
 import resizeImageUrl from 'lib/resize-image-url';
 
-export default function SmallPostCard( { post, site } ) {
+export default function SmallPostCard( { post, site, onPostClick } ) {
+	function handlePostClick( event ) {
+		onPostClick && onPostClick( event, post, site );
+	}
 	const classes = classnames( 'post-card small', {
 		'has-image': post.canonical_image
 	} );
@@ -24,12 +27,12 @@ export default function SmallPostCard( { post, site } ) {
 					<span className="post-card__site-title">{ site && site.title || post.site_name }</span>
 				</a>
 				<h1 className="post-card__title">
-					<a className="post-card__anchor" href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` }>{ post.title }</a>
+					<a className="post-card__anchor" href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` } onClick={ handlePostClick }>{ post.title }</a>
 				</h1>
 			</div>
 			<div>
 			{ post.canonical_image && (
-					<a href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` }><img className="post-card__thumbnail" src={ resizeImageUrl( safeImageUrl( post.canonical_image.uri ), { resize: '96,72' } ) } /></a> ) }
+					<a href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` }><img className="post-card__thumbnail" src={ resizeImageUrl( safeImageUrl( post.canonical_image.uri ), { resize: '96,72' } ) } onClick={ handlePostClick } /></a> ) }
 			</div>
 		</Card>
 	);

--- a/client/components/related-posts/index.jsx
+++ b/client/components/related-posts/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
+import noop from 'lodash/noop';
 
 /**
  * Internal Dependencies
@@ -15,8 +16,19 @@ import SmallPost from 'components/post-card/small';
 import QueryReaderRelatedPosts from 'components/data/query-reader-related-posts';
 
 const RelatedPost = React.createClass( {
+	getDefaultProps() {
+		return {
+			onPostClick: noop,
+			onSiteClick: noop
+		};
+	},
 	render() {
-		return <SmallPost post={ this.props.post } site={ this.props.site } />;
+		return ( <SmallPost
+			post={ this.props.post }
+			site={ this.props.site }
+			onPostClick={ this.props.onPostClick }
+			onSiteClick={ this.props.onSiteClick }
+		/> );
 	}
 } );
 
@@ -32,15 +44,19 @@ const ConnectedRelatedPost = connect(
 	}
 )( RelatedPost );
 
-function RelatedPosts( { siteId, postId, posts } ) {
+function RelatedPosts( { siteId, postId, posts, onPostClick, onSiteClick } ) {
 	if ( ! posts ) {
 		return <QueryReaderRelatedPosts siteId={ siteId } postId={ postId } />;
+	}
+
+	if ( posts.length === 0 ) {
+		return <noscript />;
 	}
 	return (
 		<div className="related-posts">
 			<h1 className="related-posts__heading">{ i18n.translate( 'Suggested Reading' ) }</h1>
 			<ul className="related-posts__list">
-				{ posts.map( post_id => <li key={ post_id } className="related-posts__list-item"><ConnectedRelatedPost post={ post_id } /></li> ) }
+				{ posts.map( post_id => <li key={ post_id } className="related-posts__list-item"><ConnectedRelatedPost post={ post_id } onPostClick={ onPostClick } onSiteClick={ onSiteClick } /></li> ) }
 			</ul>
 		</div>
 	);

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -148,6 +148,15 @@ FullPostView = React.createClass( {
 		}
 	},
 
+	showFullPost( event, post ) {
+		event && event.preventDefault();
+		if ( post.feed_ID && post.feed_item_ID ) {
+			page.replace( `/read/feeds/${post.feed_ID}/posts/${post.feed_item_ID}` );
+		} else {
+			page.replace( `/read/blogs/${post.site_ID}/posts/${post.ID}` );
+		}
+	},
+
 	render: function() {
 		var post = this.props.post,
 			site = this.props.site,
@@ -227,7 +236,7 @@ FullPostView = React.createClass( {
 
 					{ shouldShowExcerptOnly && ! isDiscoverPost ? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> : null }
 					{ discoverSiteName && discoverSiteUrl ? <DiscoverVisitLink siteName={ discoverSiteName } siteUrl={ discoverSiteUrl } /> : null }
-					{ config.isEnabled( 'reader/related-posts' ) && ! post.is_external && post.site_ID && <RelatedPosts siteId={ post.site_ID } postId={ post.ID } /> }
+					{ config.isEnabled( 'reader/related-posts' ) && ! post.is_external && post.site_ID && <RelatedPosts siteId={ post.site_ID } postId={ post.ID } onPostClick={ this.showFullPost } /> }
 					{ this.props.shouldShowComments ? <PostCommentList ref="commentList" post={ post } initialSize={ 25 } pageSize={ 25 } onCommentsUpdate={ this.checkForCommentAnchor } /> : null }
 				</article>
 			</div>


### PR DESCRIPTION
Replace the current state instead of pushing it when going to a full post from a full post. This way, the back button, both in the browser UI and in the page UI, returns you to the original starting point, instead of the previous post you looked at.

Test live: https://calypso.live/?branch=fix/reader/infinite-related-posts