### PR TITLE
Importer: Reduxifies `start_upload` action

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -3,6 +3,7 @@
  */
 import Dispatcher from 'dispatcher';
 import includes from 'lodash/includes';
+import flowRight from 'lodash/flowRight';
 import partial from 'lodash/partial';
 const wpcom = require( 'lib/wp' ).undocumented();
 
@@ -103,13 +104,11 @@ export function cancelImport( siteId, importerId ) {
 		.catch( apiFailure );
 }
 
-export function failUpload( importerId, { message: error } ) {
-	Dispatcher.handleViewAction( {
-		type: IMPORTS_UPLOAD_FAILED,
-		importerId,
-		error
-	} );
-}
+export const failUpload = importerId => ( { message: error } ) => ( {
+	type: IMPORTS_UPLOAD_FAILED,
+	importerId,
+	error
+} );
 
 export function fetchState( siteId ) {
 	apiStart();
@@ -122,12 +121,11 @@ export function fetchState( siteId ) {
 		.catch( apiFailure );
 }
 
-export function finishUpload( importerId, importerStatus ) {
-	Dispatcher.handleViewAction( {
-		type: IMPORTS_UPLOAD_COMPLETED,
-		importerId, importerStatus
-	} );
-}
+export const finishUpload = importerId => importerStatus => ( {
+	type: IMPORTS_UPLOAD_COMPLETED,
+	importerId,
+	importerStatus
+} );
 
 export const mapAuthor = ( importerId, sourceAuthor, targetAuthor ) => ( {
 	type: IMPORTS_AUTHORS_SET_MAPPING,
@@ -164,14 +162,12 @@ export function startMappingAuthors( importerId ) {
 	} );
 }
 
-export function setUploadProgress( importerId, data ) {
-	Dispatcher.handleViewAction( {
-		type: IMPORTS_UPLOAD_SET_PROGRESS,
-		uploadLoaded: data.uploadLoaded,
-		uploadTotal: data.uploadTotal,
-		importerId
-	} );
-}
+export const setUploadProgress = ( importerId, data ) => ( {
+	type: IMPORTS_UPLOAD_SET_PROGRESS,
+	uploadLoaded: data.uploadLoaded,
+	uploadTotal: data.uploadTotal,
+	importerId
+} );
 
 export function startImport( siteId, importerType ) {
 	// Use a fake ID until the server returns the real one
@@ -198,7 +194,7 @@ export function startImporting( importerStatus ) {
 	wpcom.updateImporter( siteId, importOrder( importerStatus ) );
 }
 
-export function startUpload( importerStatus, file ) {
+export const startUpload = ( importerStatus, file ) => dispatch => {
 	let { importerId, site: { ID: siteId } } = importerStatus;
 
 	wpcom
@@ -206,21 +202,21 @@ export function startUpload( importerStatus, file ) {
 			importStatus: toApi( importerStatus ),
 			file,
 
-			onprogress: event => {
+			onprogress: event => dispatch(
 				setUploadProgress( importerId, {
 					uploadLoaded: event.loaded,
 					uploadTotal: event.total
-				} );
-			},
+				} )
+			),
 
 			onabort: () => cancelImport( siteId, importerId )
 		} )
 		.then( data => Object.assign( data, { siteId } ) )
 		.then( fromApi )
-		.then( partial( finishUpload, importerId ) )
-		.catch( partial( failUpload, importerId ) );
+		.then( flowRight( dispatch, finishUpload( importerId ) ) )
+		.catch( flowRight( dispatch, failUpload( importerId ) ) );
 
-	Dispatcher.handleViewAction( {
+	dispatch( {
 		type: IMPORTS_UPLOAD_START,
 		filename: file.name,
 		importerId

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
+import flowRight from 'lodash/flowRight';
 import noop from 'lodash/noop';
 import includes from 'lodash/includes';
 
@@ -16,8 +17,9 @@ import Button from 'components/forms/form-button';
 import DropZone from 'components/drop-zone';
 import ProgressBar from 'components/progress-bar';
 import Gridicon from 'components/gridicon';
+import { connectDispatcher } from './dispatcher-converter';
 
-export default React.createClass( {
+export const UploadingPane = React.createClass( {
 	displayName: 'SiteSettingsUploadingPane',
 
 	mixins: [ PureRenderMixin ],
@@ -111,6 +113,8 @@ export default React.createClass( {
 	},
 
 	startUpload: function( file ) {
+		const { startUpload } = this.props;
+
 		startUpload( this.props.importerStatus, file );
 	},
 
@@ -132,3 +136,9 @@ export default React.createClass( {
 		);
 	}
 } );
+
+const mapDispatchToProps = dispatch => ( {
+	startUpload: flowRight( dispatch, startUpload )
+} );
+
+export default connectDispatcher( null, mapDispatchToProps )( UploadingPane );


### PR DESCRIPTION
Part of #5303 - reduxifying the importer

There is one lingering piece to this PR, namely that the `cancelImport`
action hasn't yet been converted.

There are no functional or stylistic changes in this PR.

**Testing**
Navigate to **My Sites** > **Settings** > **Import** and attempt to upload a file to start a new import. Look for warnings or errors in the console.

cc: @roundhill @rodrigoi 

Test live: https://calypso.live/?branch=update/importer-redux/start-upload