### PR TITLE
Enable app to run fullscreen on iOS

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -20,6 +20,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		meta(name='viewport', content='width=device-width, initial-scale=1, maximum-scale=1')
 		meta(name='format-detection', content='telephone=no')
 		meta(name='mobile-web-app-capable', content='yes')
+		meta(name='apple-mobile-web-app-capable', content='yes')
 		meta(name='referrer', content='origin')
 
 		if helmetMeta


### PR DESCRIPTION
We already have this enabled for Chrome on Android via `mobile-web-app-capable`. However Mobile Safari requires it to be prefixed as `apple-mobile-web-app-capable`.

Test live: https://calypso.live/?branch=enable/mobile-app-fullscreen-ios