### PR TITLE
Test i18n-calypso fix in jstimezonedetect

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -581,7 +581,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000476"
+      "version": "1.0.30000477"
     },
     "caseless": {
       "version": "0.11.0"
@@ -1684,8 +1684,14 @@
       "version": "0.0.0"
     },
     "i18n-calypso": {
-      "version": "0.1.1",
+      "version": "1.0.4",
       "dependencies": {
+        "async": {
+          "version": "1.5.2"
+        },
+        "commander": {
+          "version": "2.9.0"
+        },
         "core-js": {
           "version": "1.2.6"
         },
@@ -2000,7 +2006,7 @@
       "version": "1.2.2"
     },
     "jstimezonedetect": {
-      "version": "1.0.6"
+      "version": "1.0.5"
     },
     "jstransform": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "flux": "2.1.1",
     "he": "0.5.0",
     "html-loader": "0.4.0",
-    "i18n-calypso": "0.1.1",
+    "i18n-calypso": "1.0.4",
     "immutable": "3.7.5",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",


### PR DESCRIPTION
Fixes #5879

While moving `i18n-calypso` I upgraded `jstimezonedetect` from 1.0.5 to 1.0.6 and assumed everything was working fine. It looks like it's not the case as it made some pages unresponsive on some environment (windows+firefox it seems).
The first fix is to return `jstimezonedetect` to v1.0.5, and this has been done in the last version of `i18n-calypso` (v1.0.4).

### Testing instructions
Try to access the Site Stats page on calypso.live with firefox and windows. The unresponsiveness should be gone.

Test live: https://calypso.live/?branch=fix/i18n-timezonedetect