### PR TITLE
Framework: Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.17.0",
   "description": "A pure REST-API and JS based version of the WordPress.com admin",
   "private": true,
+  "license": "GPL-2.0+",
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/wp-calypso.git"


### PR DESCRIPTION
This pull request seeks to add the `license` field to our package.json. I was surprised to find we didn't already have this defined.

__References:__

- https://docs.npmjs.com/files/package.json#license
- https://spdx.org/licenses/

Test live: https://calypso.live/?branch=add/package-license