### PR TITLE
State: Initial migration to global selectors directory

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,15 @@
 		"syntax-jsx",
 		"transform-react-jsx",
 		"transform-react-display-name",
-		"lodash"
+		"lodash",
+		[
+			"transform-imports",
+			{
+				"state/selectors": {
+					"transform": "state/selectors/${member}",
+					"kebabCase": true
+				}
+			}
+		]
 	]
 }

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -28,7 +28,7 @@ import {
 } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
 import formatCurrency from 'lib/format-currency';
-import { canCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -12,7 +12,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import paths from 'my-sites/upgrades/paths';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isFinished as isJetpackPluginsFinished } from 'state/plugins/premium/selectors';

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -12,9 +12,10 @@ import get from 'lodash/get';
 import PopoverMenuItem from 'components/popover/menu-item';
 import QueryPostTypes from 'components/data/query-post-types';
 import { mc } from 'lib/analytics';
+import { canCurrentUser } from 'state/selectors';
 import { getPost } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
-import { getCurrentUserId, isValidCapability, canCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUserId, isValidCapability } from 'state/current-user/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
 function PostActionsEllipsisMenuEdit( { translate, siteId, canEdit, status, editUrl, isKnownType } ) {

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -13,7 +13,7 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import { mc } from 'lib/analytics';
 import { getPost } from 'state/posts/selectors';
 import { savePost } from 'state/posts/actions';
-import { canCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 
 class PostActionsEllipsisMenuPublish extends Component {
 	static propTypes = {

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
@@ -10,9 +10,10 @@ import { localize } from 'i18n-calypso';
  */
 import PopoverMenuItem from 'components/popover/menu-item';
 import { mc } from 'lib/analytics';
+import { canCurrentUser } from 'state/selectors';
 import { getPost } from 'state/posts/selectors';
 import { restorePost } from 'state/posts/actions';
-import { getCurrentUserId, canCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class PostActionsEllipsisMenuRestore extends Component {
 	static propTypes = {

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -11,8 +11,9 @@ import { localize } from 'i18n-calypso';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { mc } from 'lib/analytics';
 import { trashPost, deletePost } from 'state/posts/actions';
+import { canCurrentUser } from 'state/selectors';
 import { getPost } from 'state/posts/selectors';
-import { getCurrentUserId, canCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class PostActionsEllipsisMenuTrash extends Component {
 	static propTypes = {

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -10,7 +10,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { canCurrentUser, getCurrentUserId } from 'state/current-user/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import site from 'lib/site';

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import CurrentThemeButton from './button';
-import { connectOptions } from '../theme-options';
+import { connectOptions } from '../theme-options';
 import { trackClick } from '../helpers';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getActiveTheme, getTheme } from 'state/themes/selectors';
@@ -64,10 +64,10 @@ const CurrentTheme = React.createClass( {
 					{ 'two-buttons': Object.keys( options ).length === 2 }
 					) } >
 					{ map( options, ( option, name ) => (
-						<CurrentThemeButton name={ name }
+						<CurrentThemeButton name={ name }
 							key={ name }
 							label={ option.label }
-							icon={ option.icon }
+							icon={ option.icon }
 							href={ currentTheme && option.getUrl( currentTheme ) }
 							onClick={ this.trackClick } />
 					) ) }
@@ -83,7 +83,7 @@ const CurrentThemeWithOptions = ( { siteId, currentTheme, currentThemeId, siteId
 	<ConnectedCurrentTheme currentTheme={ currentTheme }
 		currentThemeId={ currentThemeId }
 		siteIdOrWpcom={ siteIdOrWpcom }
-		siteId={ siteId }
+		siteId={ siteId }
 		options={ [
 			'customize',
 			'info',

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -15,7 +15,7 @@ import sitesFactory from 'lib/sites-list';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { isThemeActive } from 'state/themes/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 
 const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 	const { isJetpack, translate } = props;

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -24,7 +24,7 @@ import {
 } from 'state/themes/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
 const purchase = config.isEnabled( 'upgrades/checkout' )

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -16,9 +16,9 @@ import PostTypeFilter from 'my-sites/post-type-filter';
 import PostTypeList from 'my-sites/post-type-list';
 import PostTypeUnsupported from './post-type-unsupported';
 import PostTypeForbidden from './post-type-forbidden';
+import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostType, isPostTypeSupported } from 'state/post-types/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
 
 function Types( { siteId, query, postType, postTypeSupported, userCanEdit } ) {
 	return (

--- a/client/my-sites/types/post-type-unsupported/index.jsx
+++ b/client/my-sites/types/post-type-unsupported/index.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import EmptyContent from 'components/empty-content';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 
 /**

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -20,7 +20,7 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
 import productsFactory from 'lib/products-list';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import { canCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 

--- a/client/post-editor/editor-forbidden/index.jsx
+++ b/client/post-editor/editor-forbidden/index.jsx
@@ -9,12 +9,12 @@ import get from 'lodash/get';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
+import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
 import Button from 'components/button';
 import Dialog from 'components/dialog';
 

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -10,11 +10,11 @@ import { cloneDeep, findIndex, map, toArray } from 'lodash';
  */
 import TermTreeSelector from 'blocks/term-tree-selector';
 import AddTerm from './add-term';
+import { canCurrentUser } from 'state/selectors';
 import { editPost, addTermForPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
 
 class EditorTermSelector extends Component {
 	static propTypes = {

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -26,7 +26,7 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import {
 	getFlowType,
 	isRedirectingToWpAdmin,

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -42,6 +42,7 @@ export function getCurrentUserLocale( state ) {
 
 	return user.localeSlug || null;
 }
+
 /**
  * Returns the currency code for the current user.
  *
@@ -84,27 +85,6 @@ export function isValidCapability( state, siteId, capability ) {
 	}
 
 	return capabilities.hasOwnProperty( capability );
-}
-
-/**
- * Returns true if the current user has the specified capability for the site,
- * false if the user does not have the capability, or null if the capability
- * cannot be determined (if the site is not currently known, or if specifying
- * an invalid capability).
- *
- * @see https://codex.wordpress.org/Function_Reference/current_user_can
- *
- * @param  {Object}   state      Global state tree
- * @param  {Number}   siteId     Site ID
- * @param  {String}   capability Capability label
- * @return {?Boolean}            Whether current user has capability
- */
-export function canCurrentUser( state, siteId, capability ) {
-	if ( ! isValidCapability( state, siteId, capability ) ) {
-		return null;
-	}
-
-	return state.currentUser.capabilities[ siteId ][ capability ];
 }
 
 /**

--- a/client/state/current-user/test/selectors.js
+++ b/client/state/current-user/test/selectors.js
@@ -12,7 +12,6 @@ import {
 	getCurrentUserLocale,
 	getCurrentUserDate,
 	isValidCapability,
-	canCurrentUser,
 	getCurrentUserCurrencyCode
 } from '../selectors';
 
@@ -182,46 +181,6 @@ describe( 'selectors', () => {
 			}, 2916284, 'manage_foo' );
 
 			expect( isValid ).to.be.false;
-		} );
-	} );
-
-	describe( 'canCurrentUser', () => {
-		it( 'should return null if the site is not known', () => {
-			const isCapable = canCurrentUser( {
-				currentUser: {
-					capabilities: {}
-				}
-			}, 2916284, 'manage_options' );
-
-			expect( isCapable ).to.be.null;
-		} );
-
-		it( 'should return the value for the specified capability', () => {
-			const isCapable = canCurrentUser( {
-				currentUser: {
-					capabilities: {
-						2916284: {
-							manage_options: false
-						}
-					}
-				}
-			}, 2916284, 'manage_options' );
-
-			expect( isCapable ).to.be.false;
-		} );
-
-		it( 'should return null if the capability is invalid', () => {
-			const isCapable = canCurrentUser( {
-				currentUser: {
-					capabilities: {
-						2916284: {
-							manage_options: false
-						}
-					}
-				}
-			}, 2916284, 'manage_foo' );
-
-			expect( isCapable ).to.be.null;
 		} );
 	} );
 

--- a/client/state/selectors/README.md
+++ b/client/state/selectors/README.md
@@ -1,0 +1,13 @@
+State Selectors
+===============
+
+This folder contains all available state selectors. Each file includes a single default exported function which can be used as a helper in retrieving derived data from the global state tree.
+
+To learn more about selectors, refer to the ["Our Approach to Data" document](../../../docs/our-approach-to-data.md#selectors).
+
+When adding a new selector to this directory, make note of the following details:
+
+- Each new selector exists in its own file, named with [kebab case](https://en.wikipedia.org/wiki/Kebab_case) (dash-delimited lowercase)
+- There should be no more than a single default exported function per selector file
+- Tests for each selector should exist in the [`test/` subdirectory](./test) with matching file name of the selector
+- Your selector must be exported from [`index.js`](./index.js) to enable named importing from the base `state/selectors` directory

--- a/client/state/selectors/can-current-user.js
+++ b/client/state/selectors/can-current-user.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { isValidCapability } from 'state/current-user/selectors';
+
+/**
+ * Returns true if the current user has the specified capability for the site,
+ * false if the user does not have the capability, or null if the capability
+ * cannot be determined (if the site is not currently known, or if specifying
+ * an invalid capability).
+ *
+ * @see https://codex.wordpress.org/Function_Reference/current_user_can
+ *
+ * @param  {Object}   state      Global state tree
+ * @param  {Number}   siteId     Site ID
+ * @param  {String}   capability Capability label
+ * @return {?Boolean}            Whether current user has capability
+ */
+export default function canCurrentUser( state, siteId, capability ) {
+	if ( ! isValidCapability( state, siteId, capability ) ) {
+		return null;
+	}
+
+	return state.currentUser.capabilities[ siteId ][ capability ];
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -1,0 +1,14 @@
+/**
+ * Every selector contained within this directory should have its default
+ * export included in the list below. Please keep this list alphabetized for
+ * easy scanning.
+ *
+ * For more information about how we use selectors, refer to the docs:
+ *  - https://wpcalypso.wordpress.com/devdocs/docs/our-approach-to-data.md#selectors
+ *
+ * Studious observers may note that our project is not configured to support
+ * "tree shaking", and that importing from this file might unnecessarily bloat
+ * the size of bundles. Fear not! For we do not truly import from this file,
+ * but instead use a Babel plugin "transform-imports" to transform the import
+ * to its individual file.
+ */

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -12,3 +12,5 @@
  * but instead use a Babel plugin "transform-imports" to transform the import
  * to its individual file.
  */
+
+export canCurrentUser from './can-current-user';

--- a/client/state/selectors/test/can-current-user.js
+++ b/client/state/selectors/test/can-current-user.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { canCurrentUser } from '../';
+
+describe( 'canCurrentUser()', () => {
+	it( 'should return null if the site is not known', () => {
+		const isCapable = canCurrentUser( {
+			currentUser: {
+				capabilities: {}
+			}
+		}, 2916284, 'manage_options' );
+
+		expect( isCapable ).to.be.null;
+	} );
+
+	it( 'should return the value for the specified capability', () => {
+		const isCapable = canCurrentUser( {
+			currentUser: {
+				capabilities: {
+					2916284: {
+						manage_options: false
+					}
+				}
+			}
+		}, 2916284, 'manage_options' );
+
+		expect( isCapable ).to.be.false;
+	} );
+
+	it( 'should return null if the capability is invalid', () => {
+		const isCapable = canCurrentUser( {
+			currentUser: {
+				capabilities: {
+					2916284: {
+						manage_options: false
+					}
+				}
+			}
+		}, 2916284, 'manage_foo' );
+
+		expect( isCapable ).to.be.null;
+	} );
+} );

--- a/client/state/selectors/test/index.js
+++ b/client/state/selectors/test/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import kebabCase from 'lodash/kebabCase';
+import camelCase from 'lodash/camelCase';
+import each from 'lodash/each';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Internal dependencies
+ */
+import * as selectors from '../';
+
+/**
+ * Constants
+ */
+
+/**
+ * Matches string which ends in ".js" file extension
+ *
+ * @type {RegExp}
+ */
+const RX_JS_EXTENSION = /\.js$/;
+
+describe( 'selectors', () => {
+	it( 'should match every selector to its default export', () => {
+		each( selectors, ( selector, key ) => {
+			expect( require( '../' + kebabCase( key ) ) ).to.equal( selector );
+		} );
+	} );
+
+	it( 'should export every selector file', ( done ) => {
+		fs.readdir( path.join( __dirname, '..' ), ( error, files ) => {
+			if ( error ) {
+				return done( error );
+			}
+
+			each( files, ( file ) => {
+				if ( ! RX_JS_EXTENSION.test( file ) || 'index.js' === file ) {
+					return;
+				}
+
+				const exportName = camelCase( file.replace( RX_JS_EXTENSION, '' ) );
+				const errorMessage = `Expected to find selector \`${ exportName }\` (${ file }) in index.js exports.`;
+				expect( selectors, errorMessage ).to.include.keys( exportName );
+			} );
+
+			done();
+		} );
+	} );
+} );

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -7,7 +7,8 @@ import get from 'lodash/get';
 /**
  * Internal dependencies
  */
-import { canCurrentUser, getCurrentUserId } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**

--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -6,7 +6,7 @@ import { filter } from 'lodash';
 /**
  * Internal dependencies
  */
-import { canCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import { isJetpackSite, isJetpackModuleActive } from 'state/sites/selectors';
 
 /**

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -9,7 +9,8 @@ import {
 	getSelectedSiteId,
 } from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
-import { getCurrentUser, canCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import { hasDefaultSiteTitle } from 'state/sites/selectors';
 
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -62,7 +62,7 @@ __Advantages:__
 
 ## Current Recommendations
 
-All new data requirements should be implemented as part of the global Redux state tree. The `client/state` directory contains all of the behavior describing the global application state. The folder structure of the `state` directory should directly mirror the sub-trees within the global state tree. Each sub-tree can include their own reducer, actions, and selectors.
+All new data requirements should be implemented as part of the global Redux state tree. The `client/state` directory contains all of the behavior describing the global application state. The folder structure of the `state` directory should directly mirror the sub-trees within the global state tree. Each sub-tree can include their own reducer and actions.
 
 ### Terminology
 
@@ -83,16 +83,14 @@ The root module of the `state` directory exports a single reducer function. We l
 client/state/
 ├── index.js
 ├── action-types.js
+├── selectors/
 └── { subject }/
     ├── actions.js
     ├── reducer.js
-    ├── selectors.js
     ├── schema.js
-    ├── README.md
     └── test/
         ├── actions.js
-        ├── reducer.js
-        └── selectors.js
+        └── reducer.js
 ```
 
 For example, the reducer responsible for maintaining the `state.sites` key within the global state can be found in `client/state/sites/reducer.js`. It's quite common that the subject reducer is itself a combined reducer. Just as it helps to split the global state into subdirectories responsible for their own part of the tree, as a subject grows, you may find that it's easier to maintain pieces as nested subdirectories. This ease of composability is one of Redux's strengths.
@@ -254,6 +252,16 @@ let posts = state.sites.sitePosts[ siteId ].map( ( postId ) => state.posts.items
 ```
 
 You'll note in this example that the entire `state` object is passed to the selector. We've chosen to standardize on always sending the entire state object to any selector as the first parameter. This consistency should alleviate uncertainty in calling selectors, as you can always assume that it'll have a similar argument signature. More importantly, it's not uncommon for selectors to need to traverse different parts of the global state, as in the example above where we pull from both the `sites` and `posts` top-level state keys.
+
+Much like action types, because selectors operate on the entire global state object, we've chosen to place them one-per-file under the `state/selectors` directory. Not only does this reflect their global nature, it removes uncertainty on where selectors are to be found or created by providing a single location for them to exist.
+
+When using selectors, you can import directly from `state/selectors`. For example:
+
+```js
+import { canCurrentUser } from 'state/selectors';
+```
+
+In this example, the logic for the selector exists at the file `state/selectors/can-current-user.js`. When creating a selector, you must also include its default function export in the list of exports in `state/selectors/index.js`.
 
 It's important that selectors always be pure functions, meaning that the function should always return the same result when passed identical arguments in sequence. There should be no side-effects of calling a selector. For example, in a selector you should never trigger an AJAX request or assign values to variables defined outside the scope of the function.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -330,6 +330,9 @@
     "babel-plugin-transform-export-extensions": {
       "version": "6.8.0"
     },
+    "babel-plugin-transform-imports": {
+      "version": "1.1.0"
+    },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.20.2"
     },
@@ -534,7 +537,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000600"
+      "version": "1.0.30000601"
     },
     "caseless": {
       "version": "0.11.0"
@@ -1335,7 +1338,7 @@
       "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "4.0.3",
+          "version": "4.0.4",
           "dev": true
         }
       }
@@ -1464,7 +1467,7 @@
       "version": "2.1.1"
     },
     "fbjs": {
-      "version": "0.8.6",
+      "version": "0.8.7",
       "dependencies": {
         "core-js": {
           "version": "1.2.7"
@@ -1528,7 +1531,7 @@
       "version": "2.3.0"
     },
     "flat-cache": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dev": true
     },
     "flatten": {
@@ -2385,6 +2388,9 @@
       "version": "3.0.4",
       "dev": true
     },
+    "lodash.kebabcase": {
+      "version": "4.1.1"
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "dev": true
@@ -3019,7 +3025,7 @@
       "version": "1.0.2"
     },
     "pump": {
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "punycode": {
       "version": "1.4.1"
@@ -3474,6 +3480,9 @@
     },
     "set-immediate-shim": {
       "version": "1.0.1"
+    },
+    "setimmediate": {
+      "version": "1.0.5"
     },
     "setprototypeof": {
       "version": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-plugin-syntax-jsx": "6.8.0",
     "babel-plugin-transform-class-properties": "6.9.1",
     "babel-plugin-transform-export-extensions": "6.8.0",
+    "babel-plugin-transform-imports": "1.1.0",
     "babel-plugin-transform-react-display-name": "6.8.0",
     "babel-plugin-transform-react-jsx": "6.8.0",
     "babel-plugin-transform-runtime": "6.9.0",


### PR DESCRIPTION
This pull request seeks to introduce a new Babel plugin, [`transform-imports`](https://www.npmjs.com/package/babel-plugin-transform-imports), to enable named importing of modules saved as files in the `state/selectors` directory. It's anticipated that this technique could also be applied to importing `lodash` modules.

This pull request moves `canCurrentUser` from `state/current-user/selectors.js` to `state/selectors/can-current-user.js` and updates all files making use of the selector.

**Reasoning:**
- https://github.com/Automattic/wp-calypso/pull/5954#issuecomment-225177211
- https://github.com/Automattic/wp-calypso/pull/5954#issuecomment-225469105
- p4TIVU-3B9-p2
- p4TIVU-3zj-p2

**Testing instructions:**

Ensure that all Mocha tests pass:

```
npm run test-client
```

Verify that no regressions occur on any screen making use of current user capabilities (domain credit notice, "manage settings" button on CPT list screen where post type unsupported but configurable - testimonials & portfolios).

/cc @mtias 

Test live: https://calypso.live/?branch=add/transform-wpcalypso-selectors
