### PR TITLE
Plans: add PlanFeaturesFooter

### DIFF
--- a/assets/stylesheets/shared/mixins/_breakpoints.scss
+++ b/assets/stylesheets/shared/mixins/_breakpoints.scss
@@ -5,54 +5,56 @@
 
 $breakpoints: 480px, 660px, 960px, 1040px; // Think very carefully before adding a new breakpoint
 
-@mixin breakpoint( $size ){
-	@if type-of($size) == string {
-	  $approved-value: 0;
-		@each $breakpoint in $breakpoints {
-			$and-larger: ">" + $breakpoint;
-			$and-smaller: "<" + $breakpoint;
+@mixin breakpoint( $sizes... ){
+	@each $size in $sizes {
+		@if type-of($size) == string {
+			$approved-value: 0;
+			@each $breakpoint in $breakpoints {
+				$and-larger: ">" + $breakpoint;
+				$and-smaller: "<" + $breakpoint;
 
-			@if $size == $and-smaller {
-				$approved-value: 1;
-				@media ( max-width: $breakpoint ) {
-					@content;
-				}
-			}
-			@else {
-				@if $size == $and-larger {
-					$approved-value: 2;
-					@media ( min-width: $breakpoint + 1 ) {
+				@if $size == $and-smaller {
+					$approved-value: 1;
+					@media ( max-width: $breakpoint ) {
 						@content;
 					}
 				}
 				@else {
-					@each $breakpoint-end in $breakpoints {
-						$range: $breakpoint + "-" + $breakpoint-end;
-						@if $size == $range {
-							$approved-value: 3;
-							@media ( min-width: $breakpoint + 1 ) and ( max-width: $breakpoint-end ) {
-								@content;
+					@if $size == $and-larger {
+						$approved-value: 2;
+						@media ( min-width: $breakpoint + 1 ) {
+							@content;
+						}
+					}
+					@else {
+						@each $breakpoint-end in $breakpoints {
+							$range: $breakpoint + "-" + $breakpoint-end;
+							@if $size == $range {
+								$approved-value: 3;
+								@media ( min-width: $breakpoint + 1 ) and ( max-width: $breakpoint-end ) {
+									@content;
+								}
 							}
 						}
 					}
 				}
 			}
+			@if $approved-value == 0 {
+				$sizes: "";
+				@each $breakpoint in $breakpoints {
+					$sizes: $sizes + " " + $breakpoint;
+				}
+				// TODO - change this to use @error, when it is supported by node-sass
+				@warn "ERROR in breakpoint( #{ $size } ): You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+			}
 		}
-		@if $approved-value == 0 {
+		@else {
 			$sizes: "";
 			@each $breakpoint in $breakpoints {
 				$sizes: $sizes + " " + $breakpoint;
 			}
 			// TODO - change this to use @error, when it is supported by node-sass
-			@warn "ERROR in breakpoint( #{ $size } ): You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+			@warn "ERROR in breakpoint( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
 		}
-	}
-	@else {
-		$sizes: "";
-		@each $breakpoint in $breakpoints {
-			$sizes: $sizes + " " + $breakpoint;
-		}
-		// TODO - change this to use @error, when it is supported by node-sass
-		@warn "ERROR in breakpoint( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
 	}
 }

--- a/client/my-sites/plan-features/docs/example.jsx
+++ b/client/my-sites/plan-features/docs/example.jsx
@@ -10,6 +10,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import PlanFeaturesHeader from '../header';
 import PlanFeaturesItem from '../item';
 import PlanFeaturesItemList from '../list';
+import PlanFeaturesFooter from '../footer';
 import { plansList, PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
 
 export default React.createClass( {
@@ -57,6 +58,11 @@ export default React.createClass( {
 						<PlanFeaturesItem>3GB of storage</PlanFeaturesItem>
 						<PlanFeaturesItem>Community Support</PlanFeaturesItem>
 					</PlanFeaturesItemList>
+					<PlanFeaturesFooter
+						current
+						description={ 'Get a free blog and be on your way to publishing your first post in less' +
+							' than five minutes.' }
+					/>
 					<br />
 				</div>
 				<div>
@@ -77,6 +83,10 @@ export default React.createClass( {
 						<PlanFeaturesItem>Advanced design customization</PlanFeaturesItem>
 						<PlanFeaturesItem>VideoPress</PlanFeaturesItem>
 					</PlanFeaturesItemList>
+					<PlanFeaturesFooter
+						description={ 'Your own domain name, powerful customization options, and lots of space' +
+							' for audio and video.' }
+					/>
 					<br />
 				</div>
 				<div>
@@ -97,6 +107,10 @@ export default React.createClass( {
 						<PlanFeaturesItem>VideoPress</PlanFeaturesItem>
 						<PlanFeaturesItem>Google Analytics</PlanFeaturesItem>
 					</PlanFeaturesItemList>
+					<PlanFeaturesFooter
+						description={ 'Everything included with Premium, as well as live chat support,' +
+							' and unlimited access to our premium themes.' }
+					/>
 				</div>
 			</div>
 		);

--- a/client/my-sites/plan-features/footer.jsx
+++ b/client/my-sites/plan-features/footer.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import noop from 'lodash/noop';
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+
+const PlanFeaturesFooter = ( { translate, current = false, description, onUpgradeClick = noop } ) => {
+	return (
+		<footer className="plan-features__footer">
+			<p className="plan-features__footer-desc">{ description }</p>
+			<div className="plan-features__footer-buttons">
+				{
+					current
+						? <Button className="plan-features__footer-button is-current" disabled>
+							<Gridicon size={ 18 } icon="checkmark" />
+							{ translate( 'Your plan' ) }
+						</Button>
+						: <Button className="plan-features__footer-button" onClick={ onUpgradeClick } primary>
+							{ translate( 'Upgrade' ) }
+						</Button>
+				}
+			</div>
+		</footer>
+	);
+};
+
+PlanFeaturesFooter.propTypes = {
+	current: PropTypes.bool,
+	description: PropTypes.string.isRequired,
+	onUpgradeClick: PropTypes.func
+};
+
+export default localize( PlanFeaturesFooter );

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -125,3 +125,51 @@
 	transform: translateY(-50%);
 	fill: $blue-wordpress;
 }
+
+.plan-features__footer {
+	margin-top: auto;
+	padding: 16px 16px 24px;
+	border-top: solid 1px lighten( $gray, 27% );
+
+	@include breakpoint( ">480px" ) {
+		padding: 16px 24px 24px;
+	}
+}
+
+.plan-features__footer-desc {
+	margin: 0;
+	font-size: 14px;
+	color: $gray;
+}
+
+.plan-features__footer-buttons {
+	text-align: center;
+}
+
+.plan-features__footer-button {
+	width: 100%;
+	margin-top: 8px;
+
+	&:first-child {
+		margin-top: 16px;
+	}
+
+	&.is-current {
+		border-bottom-width: 1px;
+		border-color: lighten( $gray, 27% );
+		background: transparent;
+		font-weight: 400;
+		color: $gray;
+
+		.gridicon {
+			fill: $alert-green;
+			margin-right: 8px;
+		}
+	}
+
+	@media
+		(min-width: 480px) and (max-width: 660px),
+		(min-width: 800px) and (max-width: 1040px) {
+			max-width: 260px;
+	}
+}


### PR DESCRIPTION
This is part of the plans redesign, which breaks out the plan features item component from @adambbecker's work in #5715
![b6a11926-2cd1-11e6-8322-f88c322fbdcd](https://cloud.githubusercontent.com/assets/1270189/15950642/7de29322-2e65-11e6-8040-666615b10657.png)

This PR adds the plan features footer to [devdocs](http://calypso.localhost:3000/devdocs/app-components/plan-features).

**Current plan:**
![selection_028](https://cloud.githubusercontent.com/assets/4988512/15967212/06e247dc-2f27-11e6-82b2-0bb7a264e7c4.jpg)

**Not current plan:**
![selection_029](https://cloud.githubusercontent.com/assets/4988512/15967221/11c52a84-2f27-11e6-9bba-2d0724448c62.jpg)

## Testing Instructions

- No functional changes to Calypso.
- Navigate to http://calypso.localhost:3000/devdocs/app-components/plan-features
- You should see the PlanFeatures component as shown above

cc @gwwar @rralian @mtias @rodrigoi 

**Note:** This PR is based on top of #5952.

Test live: https://calypso.live/?branch=add/plan-features-footer