### PR TITLE
Framework: Upgrade Immutable.js to 3.8.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1710,7 +1710,7 @@
       "version": "1.1.6"
     },
     "immutable": {
-      "version": "3.7.5"
+      "version": "3.8.1"
     },
     "imports-loader": {
       "version": "0.6.5"
@@ -2720,7 +2720,7 @@
       "version": "0.1.6"
     },
     "process": {
-      "version": "0.11.3"
+      "version": "0.11.4"
     },
     "process-nextick-args": {
       "version": "1.0.7"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "he": "0.5.0",
     "html-loader": "0.4.0",
     "i18n-calypso": "1.0.4",
-    "immutable": "3.7.5",
+    "immutable": "3.8.1",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",
     "jade": "pugjs/jade#29784fd",


### PR DESCRIPTION
Changelog at https://github.com/facebook/immutable-js/releases (nothing too spectacular)

To test -- verify that everthing still works. `/design` uses Immutable quite a bit, for example.

/cc @blowery

Test live: https://calypso.live/?branch=upgrade/immutable-3-8-1