### PR TITLE
Popover: Make onClose optional

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -32,7 +32,7 @@ var Content = React.createClass( {
 var Popover = React.createClass( {
 	propTypes: {
 		isVisible: React.PropTypes.bool.isRequired,
-		onClose: React.PropTypes.func.isRequired,
+		onClose: React.PropTypes.func,
 		position: React.PropTypes.string,
 		ignoreContext: React.PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
 	},
@@ -43,6 +43,7 @@ var Popover = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			onClose: () => {},
 			position: 'top',
 			className: 'popover'
 		};

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -34,6 +34,7 @@ var Popover = React.createClass( {
 		isVisible: React.PropTypes.bool.isRequired,
 		onClose: React.PropTypes.func,
 		position: React.PropTypes.string,
+		className: React.PropTypes.string,
 		ignoreContext: React.PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
 	},
 

--- a/client/components/tinymce/plugins/contact-form/dialog/field-remove-button.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field-remove-button.jsx
@@ -40,7 +40,6 @@ export default React.createClass( {
 				<Popover
 					isVisible={ this.state.showTooltip }
 					context={ this.refs && this.refs.removeField }
-					onClose={ () => {} }
 					position="bottom"
 					className="popover tooltip is-dialog-visible">
 					{ this.translate( 'Remove Field', { context: 'button tooltip' } ) }

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import noop from 'lodash/noop';
 import classnames from 'classnames';
 
 /**
@@ -45,7 +44,6 @@ export default React.createClass( {
 				className={ classes }
 				isVisible={ this.props.isVisible }
 				context={ this.props.context }
-				onClose={ noop }
 				position={ this.props.position }
 			>
 				{ this.props.children }


### PR DESCRIPTION
Prompted by https://github.com/Automattic/wp-calypso/pull/5847#discussion_r66177817 - `<Popover onClose={ noop }>` shouldn't be required.

Test live: https://calypso.live/?branch=update/popover/onClose-optional