### PR TITLE
Themes: sheet "Live Preview" changed to "Open Live Demo"

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -143,8 +143,8 @@ const ThemeSheet = React.createClass( {
 		return (
 			<div className="themes__sheet-screenshot">
 				<a className="themes__sheet-preview-link" onClick={ this.togglePreview } >
-					<Gridicon icon="external" size={ 18 } />
-					<span className="themes__sheet-preview-link-text">{ i18n.translate( 'Live Preview' ) }</span>
+					<Gridicon icon="themes" size={ 18 } />
+					<span className="themes__sheet-preview-link-text">{ i18n.translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }</span>
 				</a>
 				{ this.props.screenshot && img }
 			</div>


### PR DESCRIPTION
Make the live preview button clearer.

Before:
<img width="515" alt="screen shot 2016-06-10 at 17 59 13" src="https://cloud.githubusercontent.com/assets/4389/15970487/11eaff3a-2f35-11e6-8b52-35b7984526f9.png">

After:
<img width="536" alt="screen shot 2016-06-10 at 17 53 31" src="https://cloud.githubusercontent.com/assets/4389/15970459/f3dc6696-2f34-11e6-8173-1faf775568f8.png">

To test open: http://calypso.live/theme/luxury/overview?branch=update/themes/sheet-live-preview-button 

---

_Feedback originally from [Horizon's testing thread](https://horizonfeedback.wordpress.com/2016/06/02/call-for-testing-theme-details-pages/), by Martin_