### PR TITLE
Signup: Add all verticals theme A/B test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -138,4 +138,14 @@ module.exports = {
 		defaultVariation: 'disabled',
 		allowExistingUsers: true,
 	},
+	verticalThemes: {
+		datestamp: '20160630',
+		variations: {
+			original: 25,
+			verticalThemes: 25,
+			notTested: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: false,
+	},
 };

--- a/client/lib/signup/themes-data-test.js
+++ b/client/lib/signup/themes-data-test.js
@@ -312,14 +312,6 @@ export const testThemes = [
 		verticals: [ 'a8c.3', 'a8c.5', 'a8c.7' ]
 	},
 	{
-		name: 'Colinear',
-		slug: 'colinear',
-		repo: 'pub',
-		fallback: false,
-		design: 'blog',
-		verticals: [ 'a8c.3', 'a8c.5', 'a8c.7' ]
-	},
-	{
 		name: 'Lyretail',
 		slug: 'lyretail',
 		repo: 'pub',

--- a/client/lib/signup/themes-data-test.js
+++ b/client/lib/signup/themes-data-test.js
@@ -1,0 +1,410 @@
+export const testThemes = [
+	{
+		name: 'Apostrophe',
+		slug: 'apostrophe',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Baskerville',
+		slug: 'baskerville',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Big Brother',
+		slug: 'big-brother',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		verticals: [ 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.1.1' ]
+	},
+	{
+		name: 'Button',
+		slug: 'button',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.9' ]
+	},
+	{
+		name: 'Cubic',
+		slug: 'cubic',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Dyad',
+		slug: 'dyad',
+		repo: 'pub',
+		fallback: true,
+		design: 'grid',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Ecto',
+		slug: 'ecto',
+		repo: 'pub',
+		fallback: true,
+		design: 'blog',
+		verticals: [ 'a8c.1.1' ]
+	},
+	{
+		name: 'Edin',
+		slug: 'edin',
+		repo: 'pub',
+		fallback: true,
+		design: 'page',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Franklin',
+		slug: 'franklin',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.3', 'a8c.5', 'a8c.7' ]
+	},
+	{
+		name: 'Gateway',
+		slug: 'gateway',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Gazette',
+		slug: 'gazette',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Goran',
+		slug: 'goran',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Harmonic',
+		slug: 'harmonic',
+		repo: 'pub',
+		fallback: true,
+		design: 'page',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Hemingway Rewritten',
+		slug: 'hemingway-rewritten',
+		repo: 'pub',
+		fallback: true,
+		design: 'blog',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.7', 'a8c.1.1' ]
+	},
+	{
+		name: 'Libre',
+		slug: 'libre',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1.1' ]
+	},
+	{
+		name: 'Libretto',
+		slug: 'libretto',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1.1' ]
+	},
+	{
+		name: 'Motif',
+		slug: 'motif',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		verticals: [ 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Penscratch',
+		slug: 'penscratch',
+		repo: 'pub',
+		fallback: true,
+		design: 'blog',
+		verticals: [ 'a8c.3', 'a8c.5', 'a8c.1.1' ]
+	},
+	{
+		name: 'Pictorico',
+		slug: 'pictorico',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Pique',
+		slug: 'pique',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Publication',
+		slug: 'publication',
+		repo: 'pub',
+		fallback: true,
+		design: 'blog',
+		verticals: [ 'a8c.1' ]
+	},
+	{
+		name: 'Rebalance',
+		slug: 'rebalance',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Revelar',
+		slug: 'revelar',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Rowling',
+		slug: 'rowling',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Sapor',
+		slug: 'sapor',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.7', 'a8c.9' ]
+	},
+	{
+		name: 'Sela',
+		slug: 'sela',
+		repo: 'pub',
+		fallback: true,
+		design: 'page',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Sequential',
+		slug: 'sequential',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		verticals: [ 'a8c.1', 'a8c.3', 'a8c.5', 'a8c.7', 'a8c.9', 'a8c.1.1' ]
+	},
+	{
+		name: 'Twenty Sixteen',
+		slug: 'twentysixteen',
+		repo: 'pub',
+		fallback: true,
+		design: 'blog',
+		verticals: [ 'a8c.1.1', 'a8c.7', 'a8c.5', 'a8c.3', 'a8c.1' ]
+	},
+	{
+		name: 'Scratchpad',
+		slug: 'scratchpad',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.9' ]
+	},
+	{
+		name: 'Nucleare',
+		slug: 'nucleare',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.5', 'a8c.7', 'a8c.9' ]
+	},
+	{
+		name: 'Coherent',
+		slug: 'coherent',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.9' ]
+	},
+	{
+		name: 'Sobe',
+		slug: 'sobe',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.9' ]
+	},
+	{
+		name: 'Kelly',
+		slug: 'kelly',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.7', 'a8c.9' ]
+	},
+	{
+		name: 'Resonar',
+		slug: 'resonar',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.7', 'a8c.9' ]
+	},
+	{
+		name: 'Lovecraft',
+		slug: 'lovecraft',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.9' ]
+	},
+	{
+		name: 'Ryu',
+		slug: 'ryu',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1.1' ]
+	},
+	{
+		name: 'Escutcheon',
+		slug: 'escutcheon',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1.1' ]
+	},
+	{
+		name: 'Scrawl',
+		slug: 'scrawl',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1.1' ]
+	},
+	{
+		name: 'Colinear',
+		slug: 'colinear',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.3', 'a8c.5', 'a8c.7' ]
+	},
+	{
+		name: 'Colinear',
+		slug: 'colinear',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.3', 'a8c.5', 'a8c.7' ]
+	},
+	{
+		name: 'Lyretail',
+		slug: 'lyretail',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.7' ]
+	},
+	{
+		name: 'Cearuno',
+		slug: 'cerauno',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.3', 'a8c.5' ]
+	},
+	{
+		name: 'Plane',
+		slug: 'plane',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.3', 'a8c.5' ]
+	},
+	{
+		name: 'Editor',
+		slug: 'editor',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.3', 'a8c.5' ]
+	},
+	{
+		name: 'Satellite',
+		slug: 'satellite',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.3', 'a8c.5' ]
+	},
+	{
+		name: 'Afterlight',
+		slug: 'afterlight',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1' ]
+	},
+	{
+		name: 'Boardwalk',
+		slug: 'boardwalk',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1' ]
+	},
+	{
+		name: 'Intergalactic',
+		slug: 'intergalactic',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1' ]
+	},
+	{
+		name: 'Radcliffe',
+		slug: 'radcliffe',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1' ]
+	},
+	{
+		name: 'Adaption',
+		slug: 'adaption',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1' ]
+	},
+	{
+		name: 'Tonal',
+		slug: 'tonal',
+		repo: 'pub',
+		fallback: false,
+		design: 'blog',
+		verticals: [ 'a8c.1' ]
+	}
+];

--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -1,4 +1,4 @@
-export let themes = [
+export const themes = [
 	{
 		name: 'Apostrophe',
 		slug: 'apostrophe',

--- a/client/lib/signup/themes.js
+++ b/client/lib/signup/themes.js
@@ -1,28 +1,49 @@
 /**
  * External dependencies
  */
-import shuffle from 'lodash/shuffle';
+import includes from 'lodash/includes';
+import sampleSize from 'lodash/sampleSize';
 
 /**
  * Internal dependencies
  */
+import { abtest, getABTestVariation } from 'lib/abtest';
 import { themes } from 'lib/signup/themes-data';
+import { testThemes } from 'lib/signup/themes-data-test';
+
+function getUnusedThemes( themeSet, themePool, quantity ) {
+	const themeSetSlugs = themeSet.map( theme => theme.slug );
+	const filterBySlug = theme => ! includes( themeSetSlugs, theme.slug );
+	const availableThemes = themePool.filter( filterBySlug );
+	return sampleSize( availableThemes, quantity );
+}
 
 export function getDefaultThemes() {
 	const filterByDefault = theme => theme.fallback;
 	return themes.filter( filterByDefault );
 }
 
-export default function getThemes( vertical, designType ) {
+export default function getThemes( vertical, designType, quantity = 9 ) {
 	const filterByType = theme => theme.design === designType;
-	//const filterByVertical = theme => includes( theme.verticals, vertical );
+	const filterByVertical = theme => includes( theme.verticals, vertical );
+	const themePool = ( 'verticalThemes' === abtest( 'verticalThemes' ) ) ? testThemes : themes;
+	const themesByType = themePool.filter( filterByType );
+	let themeSet = themesByType;
 
-	// Filter only by design type until verticals pass testing.
-	let themeSet = themes.filter( filterByType );
-
-	if ( 0 === themeSet.length ) {
-		themeSet = getDefaultThemes();
+	// We don't even have design type matches, so just use whatever default themes.
+	if ( themeSet.length === 0 ) {
+		return sampleSize( getDefaultThemes(), quantity );
 	}
 
-	return shuffle( themeSet );
+	// Apply the vertical filter for test participants.
+	if ( 'verticalThemes' === getABTestVariation( 'verticalThemes' ) ) {
+		themeSet = themeSet.filter( filterByVertical );
+	}
+
+	// Make sure we meet the minimum number of themes by adding back in random design type matches.
+	if ( themeSet.length < quantity ) {
+		themeSet = themeSet.concat( getUnusedThemes( themeSet, themesByType, quantity - themeSet.length ) );
+	}
+
+	return sampleSize( themeSet, quantity );
 }

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -31,14 +31,14 @@ export default React.createClass( {
 		return {
 			surveySiteType: 'site',
 			isOneStep: isSurveyOneStep()
-		}
+		};
 	},
 
 	getInitialState() {
 		return {
 			stepOne: null,
 			verticalList: verticals.get()
-		}
+		};
 	},
 
 	renderStepTwoVertical( vertical ) {
@@ -46,7 +46,7 @@ export default React.createClass( {
 			event.preventDefault();
 			event.stopPropagation();
 			this.handleNextStep( vertical );
-		}
+		};
 		return (
 			<Card className="survey-step__vertical" key={ vertical.value } href="#" onClick={ stepTwoClickHandler }>
 				<label className="survey-step__label">{ vertical.label }</label>
@@ -60,11 +60,11 @@ export default React.createClass( {
 			event.preventDefault();
 			event.stopPropagation();
 			if ( this.props.isOneStep ) {
-				this.handleNextStep( vertical )
+				this.handleNextStep( vertical );
 				return;
 			}
 			this.showStepTwo( vertical );
-		}
+		};
 		return (
 			<Card className="survey-step__vertical" key={ 'step-one-' + vertical.value } href="#" onClick={ stepOneClickHandler }>
 				<Gridicon icon={ icon } className="survey-step__vertical__icon"/>
@@ -141,13 +141,14 @@ export default React.createClass( {
 				category_id: value,
 				category_label: label
 			} );
+			SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { surveySiteType: this.props.surveySiteType, surveyQuestion: this.state.stepOne.value } );
 		} else {
 			analytics.tracks.recordEvent( 'calypso_survey_category_click_level_one', {
 				category_id: value,
 				category_label: label
 			} );
+			SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { surveySiteType: this.props.surveySiteType, surveyQuestion: vertical.value } );
 		}
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { surveySiteType: this.props.surveySiteType, surveyQuestion: vertical.value } );
 		this.props.goToNextStep();
 	}
 } );


### PR DESCRIPTION
Work in progress.

Test live: https://calypso.live/?branch=add/vertical-themes-test

----------------------------------------
Currently, users coming from WordPress.com homepage are going through a two-step vertical survey followed by design-type selection as a part of the signup process. We’re offering there sets of themes for each design type (blog, page, grid). Vertical selection is not taken into account.

This test aims to deliver even more tailored theme selection in signup, by providing themes relevant to both vertical (the top category only) and design type. Themes that are not Headstart-able now, are not included in the test.

**Hypothesis**
Improvements to tailored theme selection in verticals should continue to show an increase in signup conversion (even if tailoring is incomplete) in combination with the new design-type step. Theme steps with tailored themes that show an increase in Signup conversion without a drop in retention or purchasing user conversion will be a success.

**Variations**
- original: the current default flow (25%)
- verticalThemes: the tested flow (25%)
- notTested: receives the current default flow, becomes available to other signup tests (50%)
