### PR TITLE
Sites: fix recent sites on refresh

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -425,7 +425,7 @@ SitesList.prototype.getStarred = function() {
  * @api private
  */
 SitesList.prototype.setRecentlySelectedSite = function( siteID ) {
-	if ( ! this.recentlySelected ) {
+	if ( ! this.recentlySelected || this.recentlySelected.length === 0 ) {
 		this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
 	}
 


### PR DESCRIPTION
This PR fixes display of recent sites on page refresh
<img width="281" alt="screen shot 2016-06-10 at 12 12 25 pm" src="https://cloud.githubusercontent.com/assets/1270189/15975914/bd7121da-2f04-11e6-8e3c-a25c2494afc7.png">

## Testing Instructions
- Have > 5 sites
- Click on 'My Sites'
- Switch Sites to 3 other sites and note which ones they are
- Switch Sites again, they should display near the search bar, as shown in the image above
- refresh the page
- Switch Sites, confirm that you see the same 3 recent sites.

cc @artpi @mtias @rralian

Test live: https://calypso.live/?branch=fix/recent-sites