### PR TITLE
Refactor domains/components/*

### DIFF
--- a/client/components/domains/domain-mapping-suggestion/index.jsx
+++ b/client/components/domains/domain-mapping-suggestion/index.jsx
@@ -6,22 +6,34 @@ var React = require( 'react' );
 /**
  * Internal dependencies
  */
-var DomainSuggestion = require( 'components/domains/domain-suggestion' );
+var DomainSuggestion = require( 'components/domains/domain-suggestion' ),
+	{ shouldBundleDomainWithPlan, getDomainPriceRule } = require( 'lib/cart-values/cart-items' );
 
 var DomainMappingSuggestion = React.createClass( {
+	propTypes: {
+		cart: React.PropTypes.object,
+		products: React.PropTypes.object.isRequired,
+		onButtonClick: React.PropTypes.func.isRequired,
+		withPlansOnly: React.PropTypes.bool.isRequired,
+		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.object, React.PropTypes.bool ] )
+	},
 	render: function() {
-		var buttonLabel = this.props.buttonLabel || this.translate( 'Map it', {
-			context: 'Go to the flow to add a domain mapping'
-		} );
-
+		const suggestion = {
+				product_slug: this.props.products.domain_map.product_slug,
+				cost: this.props.products.domain_map.cost_display
+			},
+			buttonContent = shouldBundleDomainWithPlan( this.props.withPlansOnly, this.props.selectedSite, this.props.cart, suggestion )
+				? this.translate( 'Upgrade', { context: 'Domain mapping suggestion button with plan upgrade' } )
+				: this.translate( 'Map it', { context: 'Domain mapping suggestion button' } );
 		return (
-			<DomainSuggestion
-					price={ this.props.products.domain_map ? this.props.products.domain_map.cost_display : null }
+				<DomainSuggestion
+					priceRule={ getDomainPriceRule( this.props.withPlansOnly, this.props.selectedSite, this.props.cart, suggestion ) }
+					price={ this.props.products.domain_map && this.props.products.domain_map.cost_display }
 					extraClasses="is-visible domain-mapping-suggestion"
 					buttonClasses="map"
-					buttonLabel={ buttonLabel }
+					withPlansOnly={ this.props.withPlansOnly }
+					buttonContent={ buttonContent }
 					cart={ this.props.cart }
-					isAdded={ false }
 					onButtonClick={ this.props.onButtonClick }>
 				<div className="domain-mapping-suggestion__domain-description">
 					<h3>

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -1,43 +1,30 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	isEmpty = require( 'lodash/isEmpty' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies
  */
 var DomainSuggestion = require( 'components/domains/domain-suggestion' ),
-	cartItems = require( 'lib/cart-values/cart-items' ),
-	DomainSuggestionFlag = require( 'components/domains/domain-suggestion-flag' );
+	Gridicon = require( 'components/gridicon' ),
+	DomainSuggestionFlag = require( 'components/domains/domain-suggestion-flag' ),
+	{ shouldBundleDomainWithPlan, getDomainPriceRule, hasDomainInCart } = require( 'lib/cart-values/cart-items' );
 
-var DomainRegistrationSuggestion = React.createClass( {
+const DomainRegistrationSuggestion = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object,
-		suggestion: React.PropTypes.object,
-		onButtonClick: React.PropTypes.func,
-		withPlansOnly: React.PropTypes.bool
+		suggestion: React.PropTypes.object.isRequired,
+		onButtonClick: React.PropTypes.func.isRequired,
+		withPlansOnly: React.PropTypes.bool.isRequired,
+		selectedSite: React.PropTypes.object
 	},
 
-	buttonLabel: function( isAdded ) {
-		if ( this.props.buttonLabel ) {
-			return this.props.buttonLabel;
-		}
-
-		if ( isAdded ) {
-			return null;
-		}
-
-		return this.translate( 'Add', {
-			context: 'Add a domain registration to the shopping cart'
-		} );
-	},
-
-	render: function() {
-		var suggestion = this.props.suggestion ? this.props.suggestion : {},
-			domainName = suggestion.domain_name ? suggestion.domain_name : this.translate( 'Loading\u2026' ),
-			isAdded = !! ( this.props.cart && cartItems.hasDomainInCart( this.props.cart, suggestion.domain_name ) ),
+	render() {
+		var suggestion = this.props.suggestion || {},
+			isAdded = hasDomainInCart( this.props.cart, suggestion.domain_name ),
 			buttonClasses,
+			buttonContent,
 			domainFlag = null;
 
 		if ( suggestion.domain_name ) {
@@ -46,22 +33,26 @@ var DomainRegistrationSuggestion = React.createClass( {
 
 		if ( isAdded ) {
 			buttonClasses = 'added';
+			buttonContent = <Gridicon icon="checkmark" />;
 		} else {
 			buttonClasses = 'add is-primary';
+			buttonContent = shouldBundleDomainWithPlan( this.props.withPlansOnly, this.props.selectedSite, this.props.cart, suggestion )
+				? this.translate( 'Upgrade', { context: 'Domain mapping suggestion button with plan upgrade' } )
+				: this.translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		}
 
 		return (
 			<DomainSuggestion
-					price={ suggestion.product_slug ? suggestion.cost : undefined }
-					isLoading={ isEmpty( suggestion.cost ) }
+					priceRule={ getDomainPriceRule( this.props.withPlansOnly, this.props.selectedSite, this.props.cart, suggestion ) }
+					price={ suggestion.product_slug && suggestion.cost }
 					domain={ suggestion.domain_name }
 					buttonClasses={ buttonClasses }
-					buttonLabel={ this.buttonLabel( isAdded ) }
-					isAdded={ isAdded }
+					buttonContent={ buttonContent }
 					cart={ this.props.cart }
+					withPlansOnly={ this.props.withPlansOnly }
 					onButtonClick={ this.props.onButtonClick }>
 				<h3>
-					{ domainName }
+					{ suggestion.domain_name }
 					{ domainFlag }
 				</h3>
 			</DomainSuggestion>

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -13,6 +13,7 @@ const React = require( 'react' ),
  */
 const DomainRegistrationSuggestion = require( 'components/domains/domain-registration-suggestion' ),
 	DomainMappingSuggestion = require( 'components/domains/domain-mapping-suggestion' ),
+	DomainSuggestion = require( 'components/domains/domain-suggestion' ),
 	cartItems = require( 'lib/cart-values' ).cartItems,
 	abtest = require( 'lib/abtest' ).abtest,
 	upgradesActions = require( 'lib/upgrades/actions' );
@@ -56,7 +57,9 @@ var DomainSearchResults = React.createClass( {
 				<DomainRegistrationSuggestion
 					suggestion={ availableDomain }
 					key={ availableDomain.domain_name }
-					buttonLabel={ this.props.buttonLabel }
+					withPlansOnly={ domainsWithPlansOnlyTestEnabled }
+					buttonContent={ this.props.buttonContent }
+					selectedSite={ this.props.selectedSite }
 					cart={ this.props.cart }
 					onButtonClick={ this.props.onClickResult.bind( null, availableDomain ) } />
 				);
@@ -122,7 +125,7 @@ var DomainSearchResults = React.createClass( {
 
 	placeholders: function() {
 		return times( this.props.placeholderQuantity, function( n ) {
-			return <DomainRegistrationSuggestion key={ 'suggestion-' + n } />;
+			return <DomainSuggestion.Placeholder key={ 'suggestion-' + n } />;
 		} );
 	},
 
@@ -136,8 +139,9 @@ var DomainSearchResults = React.createClass( {
 					<DomainRegistrationSuggestion
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }
-						buttonLabel={ this.props.buttonLabel }
 						cart={ this.props.cart }
+						selectedSite={ this.props.selectedSite }
+						withPlansOnly={ domainsWithPlansOnlyTestEnabled }
 						onButtonClick={ this.props.onClickResult.bind( null, suggestion ) } />
 				);
 			}, this );
@@ -145,9 +149,10 @@ var DomainSearchResults = React.createClass( {
 			if ( this.props.offerMappingOption ) {
 				mappingOffer = (
 					<DomainMappingSuggestion
-						buttonLabel={ this.props.mappingSuggestionLabel }
 						onButtonClick={ this.props.onClickMapping }
 						products={ this.props.products }
+						selectedSite={ this.props.selectedSite }
+						withPlansOnly={ domainsWithPlansOnlyTestEnabled }
 						cart={ this.props.cart } />
 				);
 			}

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -1,57 +1,52 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var DomainProductPrice = require( 'components/domains/domain-product-price' ),
-	abtest = require( 'lib/abtest' ).abtest,
-	Gridicon = require( 'components/gridicon' );
+import DomainProductPrice from 'components/domains/domain-product-price';
 
-var DomainSuggestion = React.createClass( {
+const DomainSuggestion = React.createClass( {
 
 	propTypes: {
-		buttonLabel: React.PropTypes.string,
+		buttonContent: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] ).isRequired,
 		buttonClasses: React.PropTypes.string,
 		extraClasses: React.PropTypes.string,
-		onButtonClick: React.PropTypes.func,
+		onButtonClick: React.PropTypes.func.isRequired,
+		priceRule: React.PropTypes.string.isRequired,
 		price: React.PropTypes.string,
-		cart: React.PropTypes.object,
-		isAdded: React.PropTypes.bool.isRequired,
-		withPlansOnly: React.PropTypes.bool
+		domain: React.PropTypes.string
 	},
 
-	renderButton: function() {
-		var buttonContent;
-		if ( this.props.isAdded ) {
-			buttonContent = <Gridicon icon="checkmark" ref="checkmark" />;
-		} else {
-			buttonContent = abtest( 'domainsWithPlansOnly' ) === 'plansOnly' && ! this.props.price ? this.translate( 'Select' ) : this.props.buttonLabel;
-		}
+	renderButton() {
+		const buttonClasses = classNames( 'button', 'domain-suggestion__select-button', this.props.buttonClasses );
 		return (
-			<button ref="button" className={ 'button domain-suggestion__select-button ' + this.props.buttonClasses } onClick={ this.props.onButtonClick } data-e2e-domain={ this.props.domain }>
-				{ buttonContent }
+			<button
+				ref="button"
+				className={ buttonClasses }
+				onClick={ this.props.onButtonClick }
+				data-e2e-domain={ this.props.domain }>
+					{ this.props.buttonContent }
 			</button>
 		);
 	},
 
-	render: function() {
-		var classes = classNames( 'domain-suggestion', 'card', 'is-compact', {
-			'is-placeholder': this.props.isLoading,
-			'is-added': this.props.isAdded
-		}, this.props.extraClasses );
+	render() {
+		const { price, isAdded, extraClasses, children, priceRule } = this.props;
+		let classes = classNames( 'domain-suggestion', 'card', 'is-compact', {
+			'is-added': isAdded
+		}, extraClasses );
 
 		return (
 			<div className={ classes }>
 				<div className="domain-suggestion__content">
-					{ this.props.children }
+					{ children }
 					<DomainProductPrice
-						isLoading={ this.props.isLoading }
-						price={ this.props.price }
-						cart={ this.props.cart }/>
+						rule={ priceRule }
+						price={ price }/>
 				</div>
 				<div className="domain-suggestion__action">
 					{ this.renderButton() }
@@ -61,4 +56,17 @@ var DomainSuggestion = React.createClass( {
 	}
 } );
 
-module.exports = DomainSuggestion;
+DomainSuggestion.Placeholder = React.createClass( {
+	render() {
+		return (
+			<div className="domain-suggestion card is-compact is-placeholder">
+				<div className="domain-suggestion__content">
+					<h3 />
+				</div>
+				<div className="domain-suggestion__action" />
+			</div>
+		);
+	}
+} );
+
+export default DomainSuggestion;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -54,6 +54,7 @@
 
 		.is-placeholder & {
 			color: transparent;
+			height: 32px;
 		}
 	}
 }

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -1,28 +1,29 @@
 /**
  * External Dependencies
  */
-import { expect } from 'chai';
 import React from 'react';
+import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import noop from 'lodash/noop';
+import identity from 'lodash/identity';
 
 /**
  * Internal Dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+import EmptyComponent from 'test/helpers/react/empty-component';
 
 describe( 'Domain Suggestion', function() {
 	let DomainSuggestion;
 
 	useFakeDom();
 	useMockery( ( mockery ) => {
-		mockery.registerMock( 'components/plans/premium-popover', noop );
+		mockery.registerMock( 'components/plans/premium-popover', EmptyComponent );
 	} );
 
 	before( () => {
 		DomainSuggestion = require( 'components/domains/domain-suggestion' );
-		DomainSuggestion.prototype.translate = ( x ) => x;
+		DomainSuggestion.prototype.translate = identity;
 	} );
 
 	describe( 'has attributes', () => {
@@ -32,23 +33,6 @@ describe( 'Domain Suggestion', function() {
 			const domainSuggestionButton = domainSuggestion.find( `.domain-suggestion__select-button` );
 			expect( domainSuggestionButton.length ).to.equal( 1 );
 			expect( domainSuggestionButton.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
-		} );
-	} );
-
-	describe( 'added domain', function() {
-		it( 'should show a checkbox when in cart', function() {
-			const domainSuggestion = shallow( <DomainSuggestion isAdded={ true } /> );
-			const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button' );
-			expect( domainSuggestionButton.children().props().icon ).to.equal( 'checkmark' );
-		} );
-
-		it( 'should show the button label when not in cart', function() {
-			const buttonLabel = 'Select';
-			const domainSuggestion = shallow(
-					<DomainSuggestion isAdded={ false } buttonLabel={ buttonLabel } />
-				);
-			const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button' );
-			expect( domainSuggestionButton.text() ).to.equal( buttonLabel );
 		} );
 	} );
 } );

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -15,15 +15,17 @@ var cartItems = require( 'lib/cart-values' ).cartItems,
 	DomainRegistrationSuggestion = require( 'components/domains/domain-registration-suggestion' ),
 	DomainProductPrice = require( 'components/domains/domain-product-price' ),
 	analyticsMixin = require( 'lib/mixins/analytics' ),
+	abtest = require( 'lib/abtest' ).abtest,
 	upgradesActions = require( 'lib/upgrades/actions' ),
 	{ getCurrentUser } = require( 'state/current-user/selectors' );
-
 
 var MapDomainStep = React.createClass( {
 	mixins: [ analyticsMixin( 'mapDomain' ) ],
 
 	propTypes: {
 		products: React.PropTypes.object.isRequired,
+		cart: React.PropTypes.object,
+		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.object, React.PropTypes.bool ] ),
 		initialQuery: React.PropTypes.string,
 		analyticsSection: React.PropTypes.string.isRequired
 	},
@@ -55,7 +57,8 @@ var MapDomainStep = React.createClass( {
 	},
 
 	render: function() {
-		var price = this.props.products.domain_map ? this.props.products.domain_map.cost_display : null;
+		const suggestion = { cost: this.props.products.domain_map.cost_display, product_slug: this.props.products.domain_map.product_slug },
+			price = this.props.products.domain_map ? this.props.products.domain_map.cost_display : null;
 
 		return (
 			<div className="map-domain-step">
@@ -72,8 +75,8 @@ var MapDomainStep = React.createClass( {
 					</div>
 
 					<DomainProductPrice
-						price={ price }
-						cart={ this.props.cart } />
+						rule={ cartItems.getDomainPriceRule( abtest( 'domainsWithPlansOnly' ) === 'plansOnly', this.props.selectedSite, this.props.cart, suggestion ) }
+						price={ price } />
 
 					<fieldset>
 						<input
@@ -117,6 +120,8 @@ var MapDomainStep = React.createClass( {
 				</div>
 				<DomainRegistrationSuggestion
 					suggestion={ suggestion }
+					selectedSite={ this.props.selectedSite }
+					withPlansOnly={ abtest( 'domainsWithPlansOnly' ) === 'plansOnly' }
 					key={ suggestion.domain_name }
 					cart={ this.props.cart }
 					onButtonClick={ this.registerSuggestedDomain } />
@@ -205,7 +210,7 @@ var MapDomainStep = React.createClass( {
 								?email=${ this.props.currentUser && encodeURIComponent( this.props.currentUser.email ) || '' }
 								&domain=${ domain }` }/>
 						}
-				} );
+					} );
 				severity = 'info';
 				break;
 			case 'not_mappable':

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -25,11 +25,11 @@ import { getFixedDomainSearch, canRegister } from 'lib/domains';
 import SearchCard from 'components/search-card';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 import DomainMappingSuggestion from 'components/domains/domain-mapping-suggestion';
+import DomainSuggestion from 'components/domains/domain-suggestion';
 import DomainSearchResults from 'components/domains/domain-search-results';
 import ExampleDomainSuggestions from 'components/domains/example-domain-suggestions';
 import analyticsMixin from 'lib/mixins/analytics';
 import * as upgradesActions from 'lib/upgrades/actions';
-import { isPlan } from 'lib/products-values';
 import cartItems from 'lib/cart-values/cart-items';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { abtest } from 'lib/abtest';
@@ -289,8 +289,7 @@ const RegisterDomainStep = React.createClass( {
 	},
 
 	onSearch: function( searchQuery ) {
-		var suggestions = [],
-			domain = getFixedDomainSearch( searchQuery );
+		const domain = getFixedDomainSearch( searchQuery );
 
 		this.setState( { lastQuery: searchQuery }, this.save );
 
@@ -372,7 +371,6 @@ const RegisterDomainStep = React.createClass( {
 						const analyticsResults = [ error.code || error.error || 'ERROR' + ( error.statusCode || '' ) ];
 						this.recordEvent( 'searchResultsReceive', domain, analyticsResults, timeDiff, -1, this.props.analyticsSection );
 						callback( error, null );
-
 					} );
 				}
 			],
@@ -402,7 +400,7 @@ const RegisterDomainStep = React.createClass( {
 
 		if ( this.isLoadingSuggestions() ) {
 			domainRegistrationSuggestions = times( INITIAL_SUGGESTION_QUANTITY + 1, function( n ) {
-				return <DomainRegistrationSuggestion key={ 'suggestion-' + n } />;
+				return <DomainSuggestion.Placeholder key={ 'suggestion-' + n } />;
 			} );
 		} else {
 			// only display two suggestions initially
@@ -414,7 +412,8 @@ const RegisterDomainStep = React.createClass( {
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }
 						cart={ this.props.cart }
-						buttonLabel={ this.props.buttonLabel }
+						selectedSite={ this.props.selectedSite }
+						withPlansOnly={ domainsWithPlansOnlyTestEnabled }
 						onButtonClick={ this.addRemoveDomainToCart.bind( null, suggestion ) } />
 				);
 			}, this );
@@ -422,9 +421,8 @@ const RegisterDomainStep = React.createClass( {
 			domainMappingSuggestion = (
 				<DomainMappingSuggestion
 					onButtonClick={ this.goToMapDomainStep }
-					buttonLabel={ domainsWithPlansOnlyTestEnabled &&
-						! ( this.props.selectedSite && isPlan( this.props.selectedSite.plan ) ) &&
-						! cartItems.isNextDomainFree( this.props.cart ) && this.translate( 'Upgrade' ) }
+					selectedSite={ this.props.selectedSite }
+					withPlansOnly={ domainsWithPlansOnlyTestEnabled }
 					cart={ this.props.cart }
 					products={ this.props.products } />
 				);
@@ -473,15 +471,12 @@ const RegisterDomainStep = React.createClass( {
 			<DomainSearchResults
 				key="domain-search-results" // key is required for CSS transition of content/
 				availableDomain={ availableDomain }
-				buttonLabel={ this.props.buttonLabel }
+				withPlansOnly={ domainsWithPlansOnlyTestEnabled }
 				lastDomainSearched={ lastDomainSearched }
 				lastDomainError = { this.state.lastDomainError }
 				onAddMapping={ onAddMapping }
 				onClickResult={ this.addRemoveDomainToCart }
 				onClickMapping={ this.goToMapDomainStep }
-				mappingSuggestionLabel={ domainsWithPlansOnlyTestEnabled &&
-						! ( this.props.selectedSite && isPlan( this.props.selectedSite.plan ) ) &&
-						! cartItems.isNextDomainFree( this.props.cart ) && this.translate( 'Upgrade' ) }
 				suggestions={ suggestions }
 				products={ this.props.products }
 				selectedSite={ this.props.selectedSite }
@@ -611,7 +606,6 @@ const RegisterDomainStep = React.createClass( {
 			case 'server_error':
 				message = this.translate( 'Sorry but there was a problem processing your request. Please try again in a few minutes.' );
 				break;
-
 
 			default:
 				throw new Error( 'Unrecognized error code: ' + error.code );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -81,7 +81,7 @@ module.exports = {
 
 		analytics.pageView.record( basePath, 'Domain Search > Site Redirect' );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			(
 				<CartData>
 					<SiteRedirect
@@ -89,7 +89,8 @@ module.exports = {
 						sites={ sites } />
 				</CartData>
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -18,9 +18,6 @@ var observe = require( 'lib/mixins/data-observe' ),
 	RegisterDomainStep = require( 'components/domains/register-domain-step' ),
 	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
 	Main = require( 'components/main' ),
-	abtest = require( 'lib/abtest' ).abtest,
-	isPlan = require( 'lib/products-values' ).isPlan,
-	cartItems = require( 'lib/cart-values/cart-items' ),
 	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans;
 
 var DomainSearch = React.createClass( {
@@ -30,7 +27,7 @@ var DomainSearch = React.createClass( {
 		sites: React.PropTypes.object.isRequired,
 		productsList: React.PropTypes.object.isRequired,
 		basePath: React.PropTypes.string.isRequired,
-		context: React.PropTypes.object.isRequired,
+		context: React.PropTypes.object.isRequired
 	},
 
 	getInitialState: function() {
@@ -77,14 +74,12 @@ var DomainSearch = React.createClass( {
 			classes = classnames( 'main-column', {
 				'domain-search-page-wrapper': this.state.domainRegistrationAvailable
 			} ),
-			withPlansOnlyTestActive = abtest( 'domainsWithPlansOnly' ) === 'plansOnly',
-			selectedSiteHasPlan = !! selectedSite && isPlan( selectedSite.plan ),
 			content;
 
 		if ( ! this.state.domainRegistrationAvailable ) {
 			content = (
 				<EmptyContent
-					illustration='/calypso/images/drake/drake-500.svg'
+					illustration="/calypso/images/drake/drake-500.svg"
 					title={ this.translate( 'Domain registration is unavailable' ) }
 					line={ this.translate( "We're hard at work on the issue. Please check back shortly." ) }
 					action={ this.translate( 'Back to Plans' ) }
@@ -113,9 +108,6 @@ var DomainSearch = React.createClass( {
 							selectedSite={ selectedSite }
 							offerMappingOption
 							basePath={ this.props.basePath }
-							buttonLabel={ withPlansOnlyTestActive &&
-								! cartItems.isNextDomainFree( this.props.cart ) &&
-								! selectedSiteHasPlan ? this.translate( 'Upgrade' ) : null }
 							products={ this.props.productsList.get() } />
 					</div>
 				</span>

--- a/client/my-sites/upgrades/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/upgrades/domain-search/site-redirect-step.jsx
@@ -46,7 +46,9 @@ var SiteRedirectStep = React.createClass( {
 						</p>
 					</div>
 
-					<DomainProductPrice price={ price } cart={ this.props.cart } />
+					<DomainProductPrice
+						price={ price }
+						requiresPlan={ false } />
 
 					<fieldset>
 						<input

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -181,7 +181,6 @@ module.exports = React.createClass( {
 				initialState={ initialState }
 				onAddDomain={ this.handleAddDomain }
 				products={ this.state.products }
-				buttonLabel={ isPlansOnlyTest ? this.translate( 'Upgrade' ) : this.translate( 'Select' ) }
 				basePath={ this.props.path }
 				mapDomainUrl={ this.getMapDomainUrl() }
 				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }


### PR DESCRIPTION
Apologies for the big PR, ironing this out would be really hard if I went piece by piece.

This PR changes a bunch of things:

- Straightens out `buttonLabel` property being intercepted at every level and uses a single source of truth.
- Fixes p2MSmN-4Wg
- Adds `DomainSuggestionMixin`, a component decides to whether we need to bundle a plan with it or how the price should be displayed under various conditions (free .wordpress.com domain, a-la-carte domain, included in premium, domain credit)
- Reported in #5421, fixes: "When you have a Premium plan and a domain in your cart and try to add another domain, its price is marked incorrectly as "Included in WordPress.com Premium" (it should be the regular price)." It will now show the correct price.
- When multiple domains are in cart and some are eligible for a domain credit, we correctly apply pricing labels to individual domains.
- Adds plenty of propTypes for visibility
- Gets rid of abtest dependency inside signup.
- Fixes bunch of eslint warnings

Testing
-
Check the boxes as you test, most cases are super easy to test and won't take a lot of time, they look long because I wanted to cover all cases.

### Signup (DWPO) 

Paid domains should say included in Premium.
Free domains should say free.

- [x] Example suggestions
- [x] Search
- [x] Mapping suggestion
- [x] Mapping page
- [x] Free .wordpress.com domain

### Signup (Legacy) 

Paid domains should have a-la-carte pricing
Free domains should say free.

- [x] Example suggestions
- [x] Search
- [x] Mapping suggestion
- [x] Mapping page
- [x] Free .wordpress.com domain

### Domain Management

#### Cheat sheet

- *Initial suggestions*: Go to domain management don't search for anything
- *Domain available*: Search for an available a .com/net etc. domain
- *Domain not available*: Search for a domain that's registered but mappable 
- *Search Results*: Search a for a keyword
- *Mapping suggestion*: At the bottom of the search results
- *Mapping page*: Individual mapping after clicking a mapping suggestion
- *Site redirect page*: Settings -> Site redirect
- *1+ domain in cart -> add domain page*: Add one or more domains to cart and go back to add domain page.

#### With domain credit (DWPO)

Where the site has a plan with unused domain credits.
Paid domains should say "Free with your plan".
Site redirect should be a-la-carte pricing.

- [x] Initial suggestions
- [x] Domain available
- [x] Domain not available
- [x] Search results
- [x] Mapping suggestion
- [x] Mapping page
- [x] Site redirect page

#### With plan in cart (DWPO)

Where the site has no plan but the user has a plan in their cart.
Paid domains should say "Free with your plan".
Site redirect should be a-la-carte pricing.

- [x] Initial suggestions
- [x] Domain available
- [x] Domain not available
- [x] Search results
- [x] Mapping suggestion
- [x] Mapping page
- [x] Site redirect page
- [x] 1+ domain in cart -> add domain page

#### With plan and credit used (DWPO):

Where the site has a plan with no domain credits.
Paid domains and site redirect should be a-la-carte pricing.

- [x] Initial suggestions
- [x] Domain available
- [x] Domain not available
- [x] Search results
- [x] Mapping suggestion
- [x] Mapping page
- [x] Site redirect page

#### With nothing (DWPO):

Where the site has no plan and an empty cart.
Paid domains should say included in Premium.
Site redirect should be a-la-carte pricing.

- [x] Initial suggestions
- [x] Domain available
- [x] Domain not available
- [x] Search results
- [x] Mapping suggestion
- [x] Mapping page
- [x] Site redirect page - (A-la-carte pricing)


#### With nothing (legacy):

Where DWPO is not enabled and the site has no purchases and has an empty cart.
All domain products should be a-la-carte pricing.

- [x] Initial suggestions
- [x] Domain available
- [x] Domain not available
- [x] Search results
- [x] Mapping suggestion
- [x] Mapping page
- [x] Site redirect page

#### With plan in cart (legacy):

Where DWPO is not enabled and the user a plan in their cart.
Paid domains should say "Free with your plan".
Site redirect should be a-la-carte pricing.

- [x] Initial suggestions
- [x] Domain available
- [x] Domain not available
- [x] Search results
- [x] Mapping suggestion
- [x] Mapping page
- [x] Site redirect page
- [x] 1+ domain in cart -> add domain page

/cc: @klimeryk @bisko 

 

Test live: https://calypso.live/?branch=update/refactor-domains/components