### PR TITLE
Revert "Remove site icon when 'icon' prop is not present in new attributes coming from API"

### DIFF
--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -14,8 +14,7 @@ var wpcom = require( 'lib/wp' ),
 	config = require( 'config' ),
 	notices = require( 'notices' ),
 	Emitter = require( 'lib/mixins/emitter' ),
-	isHttps = require( 'lib/url' ).isHttps,
-	sitesSchema = require( 'state/sites/schema' ).sitesSchema;
+	isHttps = require( 'lib/url' ).isHttps;
 
 function Site( attributes ) {
 	if ( ! ( this instanceof Site ) ) {
@@ -62,13 +61,6 @@ Site.prototype.attributes = function( attributes ) {
 	this.updateComputedAttributes();
 };
 
-/**
- * Updates one or many site's attributes. Won't remove current attributes if they are not
- * present in the new ones. Use Site.prototype.replace if you want to remove them.
- *
- * @param {object} attributes - New attributes for a site.
- * @returns {boolean} - Returns true if attributes changed, otherwise false.
- */
 Site.prototype.set = function( attributes ) {
 	var changed = false;
 
@@ -86,49 +78,7 @@ Site.prototype.set = function( attributes ) {
 	}
 
 	return changed;
-};
 
-/**
- * Replaces all site's attributes. Will remove current attributes if they are not present in the
- * new ones. Use Site.prototype.set if you want to update one or few attributes instead.
- *
- * @param {object} attributes - New attributes for a site.
- * @returns {boolean} - Returns true if attributes changed, otherwise false.
- */
-Site.prototype.replace = function( attributes ) {
-	const siteKeys = Object.keys( sitesSchema.patternProperties[ '^\\d+$' ].properties );
-
-	let changed = false;
-
-	// Set attrs which will get computed and will mean the same before doing equality checks
-	// so the 'change' event is not triggered. See Site.prototype.updateComputedAttributes.
-	if ( attributes.hasOwnProperty( 'options' ) ) {
-		let options = attributes.options;
-
-		if ( ! options.default_post_format || options.default_post_format === '0' ) {
-			options.default_post_format = 'standard';
-		}
-	}
-
-	siteKeys.forEach( siteKey => {
-		if ( attributes.hasOwnProperty( siteKey ) && ! isEqual( attributes[ siteKey ], this[ siteKey ] ) ) {
-			this[ siteKey ] = attributes[ siteKey ];
-
-			changed = true;
-		} else if ( ! attributes.hasOwnProperty( siteKey ) && siteKey in this ) {
-			delete this[ siteKey ];
-
-			changed = true;
-		}
-	} );
-
-	if ( changed ) {
-		this.updateComputedAttributes();
-
-		this.emit( 'change' );
-	}
-
-	return changed;
 };
 
 /**

--- a/client/lib/site/test/index.js
+++ b/client/lib/site/test/index.js
@@ -12,7 +12,7 @@ describe( 'Calypso Site', () => {
 			ID: 1234,
 			name: 'Hello',
 			description: 'Hunting bugs is fun.'
-		};
+		}
 
 		it( 'attribute changed', () => {
 			const site = Site( mockSiteData );
@@ -60,60 +60,6 @@ describe( 'Calypso Site', () => {
 			site.once( 'change', changeCallback );
 			site.set( { arr: [ 1, 2, 3 ] } );
 			expect( changeCallback.called ).to.be.false;
-		} );
-
-		it( "doesn't remove attributes which are not present in the new ones", () => {
-			const site = Site( mockSiteData );
-
-			site.set( {
-				ID: 1234,
-				//name: 'Hello', // name attribute missing in new ones
-				description: 'Hunting bugs is fun.'
-			} );
-
-			expect( site ).to.have.property( 'name' );
-		} );
-	} );
-
-	describe( 'replacing attributes', () => {
-		const mockSiteData = {
-			ID: 1234,
-			name: 'Hello',
-			description: 'Hunting bugs is fun.'
-		};
-
-		it( "removes icon attr if it isn't present in the new attributes", () => {
-			const site = Site( Object.assign( {}, mockSiteData, { icon: {} } ) );
-
-			site.replace( mockSiteData );
-
-			expect( site ).to.not.have.property( 'icon' );
-			expect( site ).to.have.property( 'ID' );
-			expect( site ).to.have.property( 'description' );
-		} );
-
-		it( 'fires change event on attribute removal', () => {
-			const changeCallback = sinon.spy();
-			const site = Site( mockSiteData );
-
-			site.on( 'change', changeCallback );
-
-			site.replace( { ID: 1234, name: 'Goodbye' } );
-
-			expect( changeCallback.called ).to.be.true;
-			expect( site ).to.not.have.property( 'description' );
-		} );
-
-		it( 'fires change event on attribute change', () => {
-			const changeCallback = sinon.spy();
-			const site = Site( mockSiteData );
-			
-			site.on( 'change', changeCallback );
-			
-			site.replace( Object.assign( {}, mockSiteData, { name: 'Goodbye' } ) );
-			
-			expect( changeCallback.called ).to.be.true;
-			expect( site.name ).to.equal( 'Goodbye' );
 		} );
 	} );
 } );

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -205,7 +205,7 @@ SitesList.prototype.update = function( sites ) {
 		if ( sitesMap[ site.ID ] ) {
 			// Update existing Site object
 			siteObj = sitesMap[ site.ID ];
-			result = siteObj.replace( site );
+			result = siteObj.set( site );
 			if ( result ) {
 				changed = true;
 			}

--- a/client/lib/sites-list/test/fixtures/data.js
+++ b/client/lib/sites-list/test/fixtures/data.js
@@ -8,7 +8,6 @@ export const original = [
 		'URL': 'https://testonesite2014.wordpress.com',
 		'jetpack': false,
 		'post_count': 1,
-		'slug': 'testonesite2014.wordpress.com',
 		'subscribers_count': 1,
 		'lang': 'en',
 		'logo': {
@@ -146,8 +145,7 @@ export const original = [
 				'xmlrpc': 'https://gcbu.wordpress.com/xmlrpc.php'
 			}
 		},
-		'user_can_manage': true,
-		'is_previewable': true
+		'user_can_manage': true
 	},
 	{
 		'ID': 54117,
@@ -189,7 +187,6 @@ export const original = [
 				'quote': 'Quote',
 				'image': 'Image'
 			},
-			'default_post_format': false,
 			'default_likes_enabled': false,
 			'default_sharing_status': true,
 			'default_comment_status': false,

--- a/client/lib/sites-list/test/index.js
+++ b/client/lib/sites-list/test/index.js
@@ -39,7 +39,7 @@ describe( 'SitesList', () => {
 
 		it( 'should create Site objects', () => {
 			forEach( initializedSites, site => {
-				assert.instanceOf( site, Site );
+				assert.instanceOf( site, Site )
 			} );
 		} );
 
@@ -84,16 +84,6 @@ describe( 'SitesList', () => {
 			forEach( updatedSite, ( updatedValue, prop ) => {
 				assert.deepEqual( updatedValue, site[ prop ] );
 			} );
-		} );
-
-		it( 'should not trigger change when sites attributes didn\'t change', () => {
-			const changeCallback = sinon.spy();
-
-			sitesList.once( 'change', changeCallback );
-
-			sitesList.update( cloneDeep( data.original ) );
-
-			assert.isFalse( changeCallback.called );
 		} );
 	} );
 

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -13,6 +13,7 @@ export const sitesSchema = {
 				jetpack: { type: 'boolean' },
 				post_count: { type: 'number' },
 				subscribers_count: { type: 'number' },
+				slug: { type: 'string' },
 				lang: { type: 'string' },
 				icon: {
 					type: 'object',
@@ -36,6 +37,8 @@ export const sitesSchema = {
 				meta: { type: 'object' },
 				user_can_manager: { type: 'boolean' },
 				is_vip: { type: 'boolean' },
+				is_previewable: { type: 'boolean' },
+				is_customizable: { type: 'boolean' },
 				is_multisite: { type: 'boolean' },
 				capabilities: {
 					type: 'object',

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -163,12 +163,13 @@ describe( 'reducer', () => {
 				site: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
+					slug: 'example.wordpress.com',
 					updateComputedAttributes() {}
 				}
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', slug: 'example.wordpress.com' }
 			} );
 		} );
 
@@ -178,12 +179,13 @@ describe( 'reducer', () => {
 				sites: [ {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
+					slug: 'example.wordpress.com',
 					updateComputedAttributes() {}
 				} ]
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', slug: 'example.wordpress.com' }
 			} );
 		} );
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#5628

We need to test if this PR causes #5963.

Please checkout this branch and test locally.

Test live: https://calypso.live/?branch=revert-5628-fix/remove-site-icon-from-site-attrs