### PR TITLE
Domains: Rerun Domain Suggestions Vendor A/B test

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -46,7 +46,8 @@ const SUGGESTION_QUANTITY = 10;
 const INITIAL_SUGGESTION_QUANTITY = 2;
 
 const analytics = analyticsMixin( 'registerDomain' ),
-	domainsWithPlansOnlyTestEnabled = abtest( 'domainsWithPlansOnly' ) === 'plansOnly';
+	domainsWithPlansOnlyTestEnabled = abtest( 'domainsWithPlansOnly' ) === 'plansOnly',
+	searchVendor = abtest( 'domainSuggestionVendor' );
 
 let searchQueue = [],
 	searchStackTimer = null,
@@ -60,7 +61,7 @@ function getQueryObject( props ) {
 	return {
 		query: props.selectedSite.domain.split( '.' )[ 0 ],
 		quantity: SUGGESTION_QUANTITY,
-		vendor: abtest( 'domainSuggestionVendor' ),
+		vendor: searchVendor,
 		includeSubdomain: props.includeWordPressDotCom
 	};
 }
@@ -89,7 +90,7 @@ function reportSearchStats( { query, section, timestamp } ) {
 	}
 	lastSearchTimestamp = timestamp;
 	searchCount++;
-	analytics.recordEvent( 'searchFormSubmit', query, section, timeDiffFromLastSearchInSeconds, searchCount );
+	analytics.recordEvent( 'searchFormSubmit', query, section, timeDiffFromLastSearchInSeconds, searchCount, searchVendor );
 }
 
 function enqueueSearchStatReport( search ) {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -55,10 +55,10 @@ module.exports = {
 		defaultVariation: 'original'
 	},
 	domainSuggestionVendor: {
-		datestamp: '20160520',
+		datestamp: '20160614',
 		variations: {
-			namegen: 75,
-			domainsbot: 25,
+			namegen: 50,
+			domainsbot: 50
 		},
 		defaultVariation: 'namegen'
 	},

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -69,7 +69,7 @@ const EVENTS = {
 			analytics.tracks.recordEvent( 'calypso_domain_search_results_mapping_button_click', { section } );
 		},
 
-		searchFormSubmit( searchBoxValue, section, timeDiffFromLastSearch, searchCount ) {
+		searchFormSubmit( searchBoxValue, section, timeDiffFromLastSearch, searchCount, searchVendor ) {
 			analytics.ga.recordEvent(
 				'Domain Search',
 				'Submitted Search Form',
@@ -83,6 +83,7 @@ const EVENTS = {
 					search_box_value: searchBoxValue,
 					seconds_from_last_search: timeDiffFromLastSearch,
 					search_count: searchCount,
+					search_vendor: searchVendor,
 					section
 				}
 			);


### PR DESCRIPTION
- Rerun the test with different distribution
- Add vendor parameter to `calypso_domain_search` event

Test live: https://calypso.live/?branch=update/abtest-domain-suggestion-vendor