### PR TITLE
Stats: use Redux for statsSummary

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -114,7 +114,6 @@ module.exports = {
 	insights: function( context, next ) {
 		var Insights = require( 'my-sites/stats/stats-insights' ),
 			StatsList = require( 'lib/stats/stats-list' ),
-			StatsSummaryList = require( 'lib/stats/summary-list' ),
 			FollowList = require( 'lib/follow-list' ),
 			site,
 			siteId = context.params.site_id,
@@ -124,7 +123,6 @@ module.exports = {
 			followList,
 			allTimeList,
 			insightsList,
-			statSummaryList,
 			commentsList,
 			tagsList,
 			publicizeList,
@@ -173,7 +171,6 @@ module.exports = {
 			? site.slug : route.getSiteFragment( context.path );
 
 		allTimeList = new StatsList( { siteID: siteId, statType: 'stats', domain: siteDomain } );
-		statSummaryList = new StatsSummaryList( { period: 'day', sites: summarySites, domain: siteDomain } );
 		insightsList = new StatsList( { siteID: siteId, statType: 'statsInsights', domain: siteDomain } );
 		commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: siteDomain } );
 		tagsList = new StatsList( { siteID: siteId, statType: 'statsTags', domain: siteDomain } );
@@ -190,7 +187,6 @@ module.exports = {
 					site: site,
 					followList: followList,
 					allTimeList: allTimeList,
-					statSummaryList: statSummaryList,
 					insightsList: insightsList,
 					commentsList: commentsList,
 					tagsList: tagsList,
@@ -207,7 +203,6 @@ module.exports = {
 
 	overview: function( context, next ) {
 		var StatsComponent = require( './overview' ),
-			StatsSummaryList = require( 'lib/stats/summary-list' ),
 			filters = function() {
 				return [
 					{ title: i18n.translate( 'Days' ), path: '/stats/day', altPaths: ['/stats'], id: 'stats-day', period: 'day' },
@@ -219,7 +214,6 @@ module.exports = {
 			activeFilter = false,
 			queryOptions = context.query,
 			basePath = route.sectionify( context.path ),
-			statSummaryList,
 			summarySites;
 
 		window.scrollTo( 0, 0 );
@@ -252,10 +246,6 @@ module.exports = {
 			} );
 
 			activeFilter = activeFilter.shift();
-			statSummaryList = new StatsSummaryList( {
-				period: activeFilter.period,
-				sites: summarySites
-			} );
 
 			analytics.mc.bumpStat( 'calypso_stats_overview_period', activeFilter.period );
 			analytics.pageView.record( basePath, analyticsPageTitle + ' > ' + titlecase( activeFilter.period ) );
@@ -263,13 +253,14 @@ module.exports = {
 			recordVisitDate();
 
 			ReactDom.render(
-				React.createElement( StatsComponent, {
-					period: activeFilter.period,
-					sites: sites,
-					statSummaryList: statSummaryList,
-					path: context.pathname,
-					user: user
-				} ),
+				React.createElement( ReactRedux.Provider, { store: context.store },
+					React.createElement( StatsComponent, {
+						period: activeFilter.period,
+						sites: sites,
+						path: context.pathname,
+						user: user
+					} )
+				),
 				document.getElementById( 'primary' )
 			);
 		}

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -20,12 +20,11 @@ export default React.createClass( {
 	mixins: [ observe( 'sites' ) ],
 
 	propTypes: {
-		statSummaryList: PropTypes.object,
 		path: PropTypes.string
 	},
 
 	render() {
-		const { statSummaryList, path } = this.props;
+		const { path, period } = this.props;
 		const sites = this.props.sites.getVisible();
 		const statsPath = ( path === '/stats' ) ? '/stats/day' : path;
 
@@ -70,14 +69,20 @@ export default React.createClass( {
 			}
 
 			const date = this.moment().utcOffset( siteOffset ).format( 'YYYY-MM-DD' );
-			const summaryData = statSummaryList.get( site.ID, date );
 
 			if ( 0 === index || sitesSorted[ index - 1 ].periodEnd !== site.periodEnd ) {
-				overview.push( <DatePicker period={ this.props.period } date={ date } /> );
+				overview.push( <DatePicker period={ period } date={ date } /> );
 			}
 
 			overview.push(
-				<SiteOverview key={ site.ID } site={ site } summaryData={ summaryData } path={ statsPath } />
+				<SiteOverview
+					key={ site.ID }
+					siteId={ site.ID }
+					period={ period }
+					date={ date }
+					path={ statsPath }
+					title={ site.title }
+				/>
 			);
 
 			return overview;

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -82,6 +82,7 @@ export default React.createClass( {
 					date={ date }
 					path={ statsPath }
 					title={ site.title }
+					siteSlug={ site.slug }
 				/>
 			);
 

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react'
+import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -21,7 +21,10 @@ export default React.createClass( {
 	displayName: 'StatsComments',
 
 	propTypes: {
-		site: PropTypes.object,
+		site: PropTypes.oneOfType( [
+			PropTypes.object,
+			PropTypes.bool
+		] ),
 		commentsList: PropTypes.object,
 		commentFollowersList: PropTypes.object
 	},

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -2,6 +2,7 @@
 * External dependencies
 */
 import React, { PropTypes } from 'react';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -49,14 +50,19 @@ export default React.createClass( {
 			insightsList,
 			publicizeList,
 			site,
-			statSummaryList,
-			summaryDate,
 			wpcomFollowersList } = this.props;
 
 		const moduleStrings = statsStrings();
 
 		let tagsList;
-		let summaryData = statSummaryList.get( site.ID, summaryDate );
+
+		let momentSiteZone = i18n.moment();
+
+		if ( site && site.options ) {
+			momentSiteZone = i18n.moment().utcOffset( site.options.gmt_offset );
+		}
+
+		const summaryDate = momentSiteZone.format( 'YYYY-MM-DD' );
 
 		if ( ! site.jetpack ) {
 			tagsList = <StatsModule
@@ -75,10 +81,11 @@ export default React.createClass( {
 					<PostingActivity />
 					<LatestPostSummary site={ site } />
 					<TodaysStats
-						site={ site }
-						summaryData={ summaryData }
+						siteId={ site ? site.ID : false }
+						period="day"
+						date={ summaryDate }
 						path={ '/stats/day' }
-						insights={ true }
+						title={ this.translate( 'Today\'s Stats' ) }
 					/>
 					<AllTime allTimeList={ allTimeList } />
 					<MostPopular insightsList={ insightsList } />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -35,7 +35,6 @@ export default React.createClass( {
 			React.PropTypes.bool,
 			React.PropTypes.object
 		] ),
-		statSummaryList: PropTypes.object.isRequired,
 		summaryDate: PropTypes.string,
 		wpcomFollowersList: PropTypes.object
 	},

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -80,7 +80,7 @@ export default React.createClass( {
 					<PostingActivity />
 					<LatestPostSummary site={ site } />
 					<TodaysStats
-						siteId={ site ? site.ID : false }
+						siteId={ site ? site.ID : 0 }
 						period="day"
 						date={ summaryDate }
 						path={ '/stats/day' }
@@ -88,7 +88,7 @@ export default React.createClass( {
 					/>
 					<AllTime allTimeList={ allTimeList } />
 					<MostPopular insightsList={ insightsList } />
-					<DomainTip siteId={ site.ID } event="stats_insights_domain" />
+					<DomainTip siteId={ site ? site.ID : 0 } event="stats_insights_domain" />
 					<div className="stats-nonperiodic has-recent">
 						<div className="module-list">
 							<div className="module-column">

--- a/client/my-sites/stats/stats-site-overview/index.jsx
+++ b/client/my-sites/stats/stats-site-overview/index.jsx
@@ -23,6 +23,7 @@ const StatsSiteOverview = React.createClass( {
 
 	proptypes: {
 		siteId: PropTypes.number,
+		siteSlug: PropTypes.string,
 		period: PropTypes.string,
 		date: PropTypes.string,
 		path: PropTypes.string.isRequired,
@@ -81,16 +82,18 @@ const StatsSiteOverview = React.createClass( {
 } );
 
 export default connect( ( state, ownProps ) => {
-	const { siteId, date, period } = ownProps;
+	const { siteId, date, period, siteSlug } = ownProps;
 	const query = {
 		date,
 		period
 	};
+	// It seems not all sites are in the sites/items subtree consistently
+	const slug = siteSlug || getSiteSlug( state, siteId );
 
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, 'statsSummary', query ),
 		summaryData: getSiteStatsForQuery( state, siteId, 'statsSummary', query ) || {},
-		siteSlug: getSiteSlug( state, siteId ),
+		siteSlug: slug,
 		query
 	};
 } )( StatsSiteOverview );

--- a/client/my-sites/stats/stats-site-overview/index.jsx
+++ b/client/my-sites/stats/stats-site-overview/index.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import route from 'lib/route';
 import Card from 'components/card';
 import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
@@ -17,7 +16,7 @@ import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsForQuery
 } from 'state/stats/lists/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
 const StatsSiteOverview = React.createClass( {
 	displayName: 'StatsSiteOverview',
@@ -39,9 +38,8 @@ const StatsSiteOverview = React.createClass( {
 	},
 
 	render() {
-		const { siteId, site, path, summaryData, query, title } = this.props;
+		const { siteId, siteSlug, path, summaryData, query, title } = this.props;
 		const { views, visitors, likes, comments } = summaryData;
-		const siteSlug = site ? site.slug : null;
 		const siteStatsPath = [ path, siteSlug ].join( '/' );
 		let headerPath = siteStatsPath;
 
@@ -92,7 +90,7 @@ export default connect( ( state, ownProps ) => {
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, 'statsSummary', query ),
 		summaryData: getSiteStatsForQuery( state, siteId, 'statsSummary', query ) || {},
-		site: getSite( state, siteId ),
+		siteSlug: getSiteSlug( state, siteId ),
 		query
 	};
 } )( StatsSiteOverview );

--- a/client/my-sites/stats/stats-site-overview/index.jsx
+++ b/client/my-sites/stats/stats-site-overview/index.jsx
@@ -12,10 +12,7 @@ import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
-import {
-	isRequestingSiteStatsForQuery,
-	getSiteStatsForQuery
-} from 'state/stats/lists/selectors';
+import { getSiteStatsForQuery } from 'state/stats/lists/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 
 const StatsSiteOverview = React.createClass( {
@@ -28,7 +25,6 @@ const StatsSiteOverview = React.createClass( {
 		date: PropTypes.string,
 		path: PropTypes.string.isRequired,
 		query: PropTypes.object,
-		requesting: PropTypes.bool,
 		summaryData: PropTypes.object,
 		insights: PropTypes.bool,
 		title: PropTypes.string
@@ -91,7 +87,6 @@ export default connect( ( state, ownProps ) => {
 	const slug = siteSlug || getSiteSlug( state, siteId );
 
 	return {
-		requesting: isRequestingSiteStatsForQuery( state, siteId, 'statsSummary', query ),
 		summaryData: getSiteStatsForQuery( state, siteId, 'statsSummary', query ) || {},
 		siteSlug: slug,
 		query

--- a/client/my-sites/stats/stats-site-overview/index.jsx
+++ b/client/my-sites/stats/stats-site-overview/index.jsx
@@ -16,8 +16,6 @@ import { getSiteStatsForQuery } from 'state/stats/lists/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 
 const StatsSiteOverview = React.createClass( {
-	displayName: 'StatsSiteOverview',
-
 	proptypes: {
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
@@ -84,7 +82,7 @@ export default connect( ( state, ownProps ) => {
 		period
 	};
 	// It seems not all sites are in the sites/items subtree consistently
-	const slug = siteSlug || getSiteSlug( state, siteId );
+	const slug = getSiteSlug( state, siteId ) || siteSlug;
 
 	return {
 		summaryData: getSiteStatsForQuery( state, siteId, 'statsSummary', query ) || {},

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import omit from 'lodash/omit';
+
+/**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
@@ -48,7 +53,7 @@ export function requestSiteStats( siteId, statType, query ) {
 		} );
 
 		return wpcom.site( siteId )[ statType ]( query ).then( data => {
-			dispatch( receiveSiteStats( siteId, statType, query, data.data ) );
+			dispatch( receiveSiteStats( siteId, statType, query, omit( data, '_headers' ) ) );
 			dispatch( {
 				type: SITE_STATS_REQUEST_SUCCESS,
 				statType,

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -55,16 +55,16 @@ export function getSiteStatsForQuery( state, siteId, statType, query ) {
 export const getSiteStatsPostStreakData = createSelector(
 	( state, siteId, query ) => {
 		const response = {};
-		const streakData = getSiteStatsForQuery( state, siteId, 'statsStreak', query ) || {};
+		const streakData = getSiteStatsForQuery( state, siteId, 'statsStreak', query ) || { data: {} };
 
-		Object.keys( streakData ).forEach( ( timestamp ) => {
+		Object.keys( streakData.data ).forEach( ( timestamp ) => {
 			const postDay = i18n.moment.unix( timestamp );
 			const datestamp = postDay.format( 'YYYY-MM-DD' );
 			if ( 'undefined' === typeof( response[ datestamp ] ) ) {
 				response[ datestamp ] = 0;
 			}
 
-			response[ datestamp ] += streakData[ timestamp ];
+			response[ datestamp ] += streakData.data[ timestamp ];
 		} );
 
 		return response;

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -55,17 +55,19 @@ export function getSiteStatsForQuery( state, siteId, statType, query ) {
 export const getSiteStatsPostStreakData = createSelector(
 	( state, siteId, query ) => {
 		const response = {};
-		const streakData = getSiteStatsForQuery( state, siteId, 'statsStreak', query ) || { data: {} };
+		const streakData = getSiteStatsForQuery( state, siteId, 'statsStreak', query );
 
-		Object.keys( streakData.data ).forEach( ( timestamp ) => {
-			const postDay = i18n.moment.unix( timestamp );
-			const datestamp = postDay.format( 'YYYY-MM-DD' );
-			if ( 'undefined' === typeof( response[ datestamp ] ) ) {
-				response[ datestamp ] = 0;
-			}
+		if ( streakData && streakData.data ) {
+			Object.keys( streakData.data ).forEach( ( timestamp ) => {
+				const postDay = i18n.moment.unix( timestamp );
+				const datestamp = postDay.format( 'YYYY-MM-DD' );
+				if ( 'undefined' === typeof( response[ datestamp ] ) ) {
+					response[ datestamp ] = 0;
+				}
 
-			response[ datestamp ] += streakData.data[ timestamp ];
-		} );
+				response[ datestamp ] += streakData.data[ timestamp ];
+			} );
+		}
 
 		return response;
 	},

--- a/client/state/stats/lists/test/actions.js
+++ b/client/state/stats/lists/test/actions.js
@@ -90,7 +90,7 @@ describe( 'actions', () => {
 					type: SITE_STATS_RECEIVE,
 					siteId: SITE_ID,
 					statType: STAT_TYPE,
-					data: STREAK_RESPONSE.data,
+					data: STREAK_RESPONSE,
 					query: STREAK_QUERY
 				} );
 			} );

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -123,7 +123,7 @@ describe( 'selectors', () => {
 			expect( stats ).to.eql( {} );
 		} );
 
-		it( 'should properly formatted data if matching data for query exists', () => {
+		it( 'should return properly formatted data if matching data for query exists', () => {
 			const stats = getSiteStatsPostStreakData( {
 				stats: {
 					lists: {
@@ -131,9 +131,12 @@ describe( 'selectors', () => {
 							2916284: {
 								statsStreak: {
 									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
-										1461961382: 1,
-										1464110402: 1,
-										1464110448: 1
+										streak: {},
+										data: {
+											1461961382: 1,
+											1464110402: 1,
+											1464110448: 1
+										}
 									}
 								}
 							}
@@ -170,9 +173,11 @@ describe( 'selectors', () => {
 							2916284: {
 								statsStreak: {
 									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
-										1461961382: 1,
-										1464110402: 1,
-										1464110448: 1
+										data: {
+											1461961382: 1,
+											1464110402: 1,
+											1464110448: 1
+										}
 									}
 								}
 							}
@@ -192,8 +197,10 @@ describe( 'selectors', () => {
 							2916284: {
 								statsStreak: {
 									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
-										1461961382: 12,
-										1464110402: 2
+										data: {
+											1461961382: 12,
+											1464110402: 2
+										}
 									}
 								}
 							}
@@ -227,9 +234,11 @@ describe( 'selectors', () => {
 							2916284: {
 								statsStreak: {
 									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
-										1461961382: 1,
-										1464110402: 1,
-										1464110448: 1
+										data: {
+											1461961382: 1,
+											1464110402: 1,
+											1464110448: 1
+										}
 									}
 								}
 							}


### PR DESCRIPTION
Another stats-list bites the dust.  In this branch, the components that use `statsSummary` data are migrated to redux.  This branch builds upon #5847, and fixes one small premature optimization in `state/stats/lists/actions` that was causing issues with the payload response for `statsSummary` ( as it would many other stats payloads ).

The component that now uses `<QuerySiteStats />` and the state tree is `<StatsSiteOverview />`.  This component is used in two different places within stats, the insights page, and the stats overview page:

_Insights Page_
![stats_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/15978726/df6a5652-2f14-11e6-9a42-0544a19877ae.png)

_Stats Overview Page_
![stats_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/15978750/fbe674c8-2f14-11e6-9e50-e94b643909f3.png)

__To Test__
- Ensure all the tests pass `npm run test-client client/state/stats`
- Load the stats overview page http://calypso.localhost:3000/stats
- Validate that all the numbers match up against production, note loading state should still function as expected
- Test out the links, make sure they open the proper site/period/stat combo.  As in, if you have the 'Weeks' filter, and click on the Visitors tab, that site stat page should open, with weeks selected, and the visitors tab in the chart active
- Visit an Insights page http://calypso.localhost:3000/stats/insights - select a site if prompted
- Again note the loading state on "Today's Stats"
- Again validate the numbers are correct, and the links work as expected

Test live: https://calypso.live/?branch=update/stats/insights-todays-stats