### PR TITLE
Fix invalid prop warning on empty localStorage.

### DIFF
--- a/client/my-sites/domain-tip/index.jsx
+++ b/client/my-sites/domain-tip/index.jsx
@@ -33,7 +33,10 @@ const DomainTip = React.createClass( {
 	propTypes: {
 		className: React.PropTypes.string,
 		event: React.PropTypes.string.isRequired,
-		siteId: React.PropTypes.number.isRequired
+		siteId: React.PropTypes.oneOfType( [
+			React.PropTypes.number,
+			React.PropTypes.bool
+		] )
 	},
 
 	getDefaultProps() {
@@ -65,7 +68,7 @@ const DomainTip = React.createClass( {
 		}
 		const classes = classNames( this.props.className, 'domain-tip' );
 		const { query, quantity, vendor } = getQueryObject( this.props.site, this.props.siteSlug );
-		const suggestion = this.props.suggestions ? this.props.suggestions[0] : null;
+		const suggestion = this.props.suggestions ? this.props.suggestions[ 0 ] : null;
 		return (
 			<div className={ classes } >
 				<QueryDomainsSuggestions


### PR DESCRIPTION
While working on #5975 - I noticed an invalid prop warning on an empty localStorage in the `<DomainTip />` component:

![stats_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/15981114/03c6bd40-2f26-11e6-902e-ad89e5512177.png)

__To Recreate Issue__
- Visit a stats insights page
- Clear loclaStorage
- Refresh, note warning(s)

A fix for a similar warning from `<StatsComments />` is part of #5975 

__To Test__
Follow the steps above on this branch in development mode and note the warning for `<DomainTip />` no longer appears.

/cc @gwwar 

Test live: https://calypso.live/?branch=fix/domain-tip/prop-warning