### PR TITLE
Plans: some wording tweaks to premium plan features

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -33,8 +33,8 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 				title={ i18n.translate( 'No Ads' ) }
 				description={
 					i18n.translate(
-						'Premium plan automatically removes all Ads from your site. ' +
-						'Now your visitors can enjoy your great content without distractions!'
+						'Your plan removes advertising from your site so ' +
+						'your visitors can enjoy your content without distractions!'
 					)
 				}
 			/>
@@ -80,7 +80,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 					description={
 						i18n.translate(
 							'Take advantage of WordAds instant activation on your upgraded site. ' +
-							'WordAds lets you display promotional content and earn money.'
+							'WordAds lets you earn money by displaying promotional content.'
 						)
 					}
 					buttonText={ i18n.translate( 'Start Earning' ) }


### PR DESCRIPTION
nothing major, just for more natural language and flow

## Before
![no ads before](https://cloudup.com/cbd7CIf0pUW+)

--------------
![wordads before](https://cloudup.com/cjF8shutSp1+)

## After
![no ads after](https://cloudup.com/caMU-V28VjY+)

-------------
![wordads after](https://cloudup.com/c5gp9WzZJyD+)

## Testing
You can view this wording by clicking on the "Plans" link in the sidebar on any premium or business plan site.

cc @gwwar @artpi 

Test live: https://calypso.live/?branch=update/my-plans-wording