### PR TITLE
Plans: add split-test for google vouchers

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -9,8 +9,6 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import config from 'config';
-import { abtest } from 'lib/abtest';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import JetpackPlanDetails from 'my-sites/plans/jetpack-plan-details';
@@ -23,8 +21,9 @@ import { isDesktop } from 'lib/viewport';
 import {
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
-	getPlanObject
+	getPlanObject,
 } from 'lib/plans/constants';
+import { isGoogleVouchersEnabled } from 'lib/plans';
 
 const premiumPlan = getPlanObject( PLAN_PREMIUM );
 const businessPlan = getPlanObject( PLAN_BUSINESS );
@@ -73,7 +72,7 @@ const Plan = React.createClass( {
 		}
 
 		// override plan description during google voucher test
-		if ( config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' ) {
+		if ( isGoogleVouchersEnabled() ) {
 			if ( plan.product_id === premiumPlan.productId ) {
 				plan.description = premiumPlan.description;
 			} else if ( plan.product_id === businessPlan.productId ) {

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -10,6 +10,7 @@ import React from 'react';
  */
 import analytics from 'lib/analytics';
 import config from 'config';
+import { abtest } from 'lib/abtest';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import JetpackPlanDetails from 'my-sites/plans/jetpack-plan-details';
@@ -72,7 +73,7 @@ const Plan = React.createClass( {
 		}
 
 		// override plan description during google voucher test
-		if ( config.isEnabled( 'google-voucher' ) ) {
+		if ( config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' ) {
 			if ( plan.product_id === premiumPlan.productId ) {
 				plan.description = premiumPlan.description;
 			} else if ( plan.product_id === businessPlan.productId ) {

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -15,7 +15,7 @@ import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import Card from 'components/card';
 import { fetchSitePlans } from 'state/sites/plans/actions';
-import { filterPlansBySiteAndProps, shouldFetchSitePlans } from 'lib/plans';
+import { filterPlansBySiteAndProps, shouldFetchSitePlans, isGoogleVouchersEnabled } from 'lib/plans';
 import { getPlans } from 'state/plans/selectors';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import Gridicon from 'components/gridicon';
@@ -174,7 +174,7 @@ const PlansCompare = React.createClass( {
 		}
 
 		// add google-ad-credits feature
-		if ( config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' ) {
+		if ( isGoogleVouchersEnabled() ) {
 			features.splice( 1, 0, googleAdCreditsFeature );
 		}
 

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -174,7 +174,7 @@ const PlansCompare = React.createClass( {
 		}
 
 		// add google-ad-credits feature
-		if ( config.isEnabled( 'google-voucher' ) ) {
+		if ( config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' ) {
 			features.splice( 1, 0, googleAdCreditsFeature );
 		}
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,5 +100,14 @@ module.exports = {
 		},
 		defaultVariation: 'disabled',
 		allowExistingUsers: true,
-	}
+	},
+	googleVouchers: {
+		datestamp: '20160613',
+		variations: {
+			disabled: 50,
+			enabled: 50,
+		},
+		defaultVariation: 'enabled',
+		allowExistingUsers: false,
+	},
 };

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -13,6 +13,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
+import config from 'config';
 import { addItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
 import {
@@ -152,3 +153,7 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, showJetpac
 		return ! isJetpackPlan( plan );
 	} );
 }
+
+export const isGoogleVouchersEnabled = () => {
+	return ( config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' );
+};

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -9,6 +9,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
+import { abtest } from 'lib/abtest';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleVoucherDetails from './google-voucher';
 import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
@@ -24,7 +25,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 
 	return (
 		<div>
-			{ config.isEnabled( 'google-voucher' ) && <QuerySiteVouchers siteId={ selectedSite.ID } /> }
+			{ config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' && <QuerySiteVouchers siteId={ selectedSite.ID } /> }
 
 			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
 
@@ -40,7 +41,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 			/>
 
 			{
-				config.isEnabled( 'google-voucher' ) &&
+				config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' &&
 				<div className="purchase-detail__body">
 					<GoogleVoucherDetails selectedSite={ selectedSite } />
 				</div>

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -9,7 +9,6 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import { abtest } from 'lib/abtest';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleVoucherDetails from './google-voucher';
 import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
@@ -17,6 +16,7 @@ import { isPremium } from 'lib/products-values';
 import paths from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
+import { isGoogleVouchersEnabled } from 'lib/plans';
 
 const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 	const adminUrl = selectedSite.URL + '/wp-admin/',
@@ -25,8 +25,6 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 
 	return (
 		<div>
-			{ config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' && <QuerySiteVouchers siteId={ selectedSite.ID } /> }
-
 			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
 
 			<PurchaseDetail
@@ -40,8 +38,8 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 				}
 			/>
 
-			{
-				config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' &&
+			{ isGoogleVouchersEnabled() && <QuerySiteVouchers siteId={ selectedSite.ID } /> }
+			{ isGoogleVouchersEnabled() &&
 				<div className="purchase-detail__body">
 					<GoogleVoucherDetails selectedSite={ selectedSite } />
 				</div>


### PR DESCRIPTION
This PR adds a split test for google vouchers, set to launch on Monday June 13. The default is to enable the functionality, but we only want new users as part of the test results.

## Testing
Watch default of `caypso:analytics` and ensure you see appropriate analytics events getting triggered on the `/plans`, `/plans/compare`, and `/my-plan` pages. This will only happen if the feature gate for `google-vouchers` in `config/development.json` is set to true... if it is false, you should not see analytics events, nor should you see any google-voucher features or functionality in these pages.

cc @retrofox 

Test live: https://calypso.live/?branch=add/google-voucher-test