### PR TITLE
Plans: adds wordpress ad credit to business plan

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -9,6 +9,7 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { abtest } from 'lib/abtest';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import JetpackPlanDetails from 'my-sites/plans/jetpack-plan-details';
@@ -23,7 +24,7 @@ import {
 	PLAN_BUSINESS,
 	getPlanObject,
 } from 'lib/plans/constants';
-import { isGoogleVouchersEnabled } from 'lib/plans';
+import { isGoogleVouchersEnabled, isWordpressAdCreditsEnabled } from 'lib/plans';
 
 const premiumPlan = getPlanObject( PLAN_PREMIUM );
 const businessPlan = getPlanObject( PLAN_BUSINESS );
@@ -76,7 +77,7 @@ const Plan = React.createClass( {
 			if ( plan.product_id === premiumPlan.productId ) {
 				plan.description = premiumPlan.description;
 			} else if ( plan.product_id === businessPlan.productId ) {
-				plan.description = businessPlan.description;
+				plan.description = isWordpressAdCreditsEnabled() ? businessPlan.descriptionWithWordAdsCredit : businessPlan.description;
 			}
 		}
 

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -15,7 +15,7 @@ import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import Card from 'components/card';
 import { fetchSitePlans } from 'state/sites/plans/actions';
-import { filterPlansBySiteAndProps, shouldFetchSitePlans, isGoogleVouchersEnabled } from 'lib/plans';
+import { filterPlansBySiteAndProps, shouldFetchSitePlans, isGoogleVouchersEnabled, isWordpressAdCreditsEnabled } from 'lib/plans';
 import { getPlans } from 'state/plans/selectors';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import Gridicon from 'components/gridicon';
@@ -44,11 +44,11 @@ import {
 const googleAdCredits = featuresList[ FEATURE_GOOGLE_AD_CREDITS ];
 const googleAdCreditsFeature = {
 	title: googleAdCredits.getTitle(),
-	compareDescription: googleAdCredits.getDescription(),
+	compareDescription: isWordpressAdCreditsEnabled() ? googleAdCredits.getDescriptionWithWordAdsCredit() : googleAdCredits.getDescription(),
 	product_slug: FEATURE_GOOGLE_AD_CREDITS,
 	1: false,
 	1003: '$100',
-	1008: '$100'
+	1008: isWordpressAdCreditsEnabled() ? '$200' : '$100'
 };
 // WordAds instant activation feature
 const wordAdsInstant = featuresList[ WORDADS_INSTANT ];

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -204,6 +204,10 @@
 	color: $gray;
 }
 
+.plans-compare__info-hr {
+	margin-bottom: 0.5em;
+}
+
 .layout:not(.has-no-sidebar) .plans-compare {
 	@include breakpoint( "<960px" ) {
 		@include plans-collapsed();

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -110,4 +110,13 @@ module.exports = {
 		defaultVariation: 'enabled',
 		allowExistingUsers: false,
 	},
+	wordpressAdCredits: {
+		datestamp: '20160613',
+		variations: {
+			disabled: 50,
+			enabled: 50,
+		},
+		defaultVariation: 'enabled',
+		allowExistingUsers: false,
+	},
 };

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1,5 +1,7 @@
 /** @ssr-ready **/
 
+import React from 'react';
+
 import i18n from 'i18n-calypso';
 
 // plans constants
@@ -42,7 +44,8 @@ export const plansList = {
 		getTitle: () => i18n.translate( 'Business' ),
 		getPriceTitle: () => i18n.translate( '$299 per year' ),
 		getProductId: () => 1008,
-		getDescription: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, and Google Analytics.' )
+		getDescription: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, and Google Analytics.' ),
+		getDescriptionWithWordAdsCredit: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, Google Analytics, and $200 advertising credit.' ),
 	},
 
 	[ PLAN_JETPACK_FREE ]: {},
@@ -98,6 +101,12 @@ export const featuresList = {
 	[ FEATURE_GOOGLE_AD_CREDITS ]: {
 		getTitle: () => i18n.translate( 'Advertising Credit' ),
 		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25. Offer valid in US and Canada.' ),
+		getDescriptionWithWordAdsCredit: () => i18n.translate( '$100 Google AdWords credit after spending the first $25. ' +
+			'Offer valid in US and Canada. {{hr/}}Business also includes $100 of advertising from WordAds on WordPress.com.', {
+			components: {
+				hr: <hr className="plans-compare__info-hr"/>
+			}
+		} ),
 		plans: allPaidPlans
 	},
 

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -157,3 +157,11 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, showJetpac
 export const isGoogleVouchersEnabled = () => {
 	return ( config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' );
 };
+
+export const isWordpressAdCreditsEnabled = () => {
+	return (
+		isGoogleVouchersEnabled() &&
+		config.isEnabled( 'plans/wordpress-ad-credits' ) &&
+		abtest( 'wordpressAdCredits' ) === 'enabled'
+	);
+};

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -34,6 +34,20 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 				description={ i18n.translate( 'Connect to Google Analytics for the perfect complement to WordPress.com stats.' ) }
 				buttonText={ i18n.translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug } />
+
+			<PurchaseDetail
+				icon="star"
+				title={ i18n.translate( 'Boost Your Audience' ) }
+				description={ i18n.translate( 'Business includes 100,000 advertising impressions from our WordAds network at $100 value to boost a post or page of your choosing. '+
+					'Contact us at {{a}}wordads-credit@automattic.com{{/a}} to tell us which page you would like to promote.',
+					{
+						components: {
+							a: <a target="_blank" href="mailto:wordads-credit@automattic.com?subject=WordAds%20Credit&body=Please%20send%20my%20100%2C000%20impressions%20to%20the%20following%20URL%20on%20my%20WordPress.com%20Business%20site.%20I%20understand%20that%20the%20title%20of%20this%20page%20will%20be%20the%20headline%2C%20and%20the%20first%20few%20lines%20of%20content%20will%20be%20used%20for%20the%20body%20of%20the%20advertisement.%0A%0AURL%20TO%20PROMOTE%3A%20" />
+						}
+					}
+				) }
+				/>
+
 		</div>
 	);
 };

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -38,8 +38,8 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 			<PurchaseDetail
 				icon="star"
 				title={ i18n.translate( 'Boost Your Audience' ) }
-				description={ i18n.translate( 'Business includes 100,000 advertising impressions from our WordAds network at $100 value to boost a post or page of your choosing. '+
-					'Contact us at {{a}}wordads-credit@automattic.com{{/a}} to tell us which page you would like to promote.',
+				description={ i18n.translate( 'Get more visitors to your most important Posts or Pages with WordAds Boost. We\'ll display an ad for your site 100,000 times (a $100 value). '+
+					'Contact us at {{a}}wordads-credit@wordpress.com{{/a}} to activate!',
 					{
 						components: {
 							a: <a target="_blank" href="mailto:wordads-credit@automattic.com?subject=WordAds%20Credit&body=Please%20send%20my%20100%2C000%20impressions%20to%20the%20following%20URL%20on%20my%20WordPress.com%20Business%20site.%20I%20understand%20that%20the%20title%20of%20this%20page%20will%20be%20the%20headline%2C%20and%20the%20first%20few%20lines%20of%20content%20will%20be%20used%20for%20the%20body%20of%20the%20advertisement.%0A%0AURL%20TO%20PROMOTE%3A%20" />

--- a/config/development.json
+++ b/config/development.json
@@ -97,6 +97,7 @@
 		"olark": true,
 		"perfmon": false,
 		"persist-redux": true,
+		"plans/wordpress-ad-credits": true,
 		"post-editor-github-link": false,
 		"post-editor/image-editor": false,
 		"post-editor/insert-menu": true,


### PR DESCRIPTION
This PR adds the config, test, and proposed content for the WordPress Ad Credit project. This is a very simple version of the project where users gain the capability to boost a post or page of their choosing with 100,000 advertising impressions from our WordAds network. In this initial version we are handling the request manually with an email to a specific email address (which still needs to be set up) at automattic.com.

I am running this test as a _subtest_ of the Google Vouchers test, as this program makes the most sense as an additive feature on top of that one. You can see new content on the /plans, /plans/compare, and my-plan pages. Here is all of the new content.

### /plans
![plans page](https://cloudup.com/cmO_kLyL0ig+)

### /plans/compare
![plans compare](https://cloudup.com/cGnx1IVKxS5+)

### /plans/compare info popup
![plans compare info popup](https://cloudup.com/cv2vTeAoRBi+)

### my-plan/thank-you
![my -plan](https://cloudup.com/cG4CmZFKM2q+)

### mailto-triggered-email
![mailto-triggered-email](https://cloudup.com/ciqHXQ67iga+)

## Testing
I am interested in feedback on the implementation and the copy. Once we're happy with this approach and copy, I will request the email address to be set up, and we can launch this. But it should not be launched ahead of setting up the email address and it should not be launched ahead of the google-vouchers project.

cc @apeatling @Essayoh @egill 

Test live: https://calypso.live/?branch=add/wordads-credit-feature