### PR TITLE
Plans:: google voucher: tweak mobile view

### DIFF
--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -9,7 +9,7 @@
 			border-bottom: none;
 		}
 
-		.button {
+		.button:not(.clipboard-button) {
 			width: 80%;
 		}
 	}

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -4,14 +4,12 @@
 	color: $gray;
 	position: relative;
 
-	@include breakpoint( "<660px" ) {
-		&:last-child {
-			border-bottom: none;
-		}
+	&:last-child {
+		border-bottom: none;
+	}
 
-		.button:not(.clipboard-button) {
-			width: 80%;
-		}
+	.button:not(.clipboard-button) {
+		width: 80%;
 	}
 
 	@include breakpoint( ">660px" ) {
@@ -20,6 +18,14 @@
 		max-width: 700px;
 		margin: 16px auto;
 		text-align: left;
+
+		&:last-child {
+			border-bottom-width: 1px;
+		}
+
+		.button:not(.clipboard-button) {
+			width: auto;
+		}
 	}
 
 	&.is-placeholder {

--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
@@ -94,7 +94,7 @@ class GoogleVoucherDetails extends Component {
 
 	getVoucher( props = this.props ) {
 		const { googleAdCredits } = props;
-		return googleAdCredits.length > 0 ? googleAdCredits[0] : {};
+		return googleAdCredits.length > 0 ? googleAdCredits[ 0 ] : {};
 	}
 
 	renderInitialStep() {
@@ -168,6 +168,7 @@ class GoogleVoucherDetails extends Component {
 					</p>
 
 					<PurchaseButton
+						className="google-voucher-code__setup-google-adwords"
 						href="https://www.google.com/adwords/"
 						target="_blank"
 						text={ this.props.translate( 'Setup Google AdWords' ) } />

--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/style.scss
@@ -1,14 +1,18 @@
 .google-voucher-code {
-	display: flex;
-	align-items: flex-start;
 	margin-top: 12px;
 	padding-bottom: 12px;
 	border-bottom: solid 1px $gray-light;
+
 
 	p.form-setting-explanation {
 		flex: 1;
 		margin-right: 16px;
 		margin-top: 0px
+	}
+
+	@include breakpoint( ">660px" ) {
+		display: flex;
+		align-items: flex-start;
 	}
 }
 
@@ -20,6 +24,14 @@
 	margin-top: 12px;
 	display: flex;
 	max-width: 100%;
+}
+
+.button.google-voucher-code__setup-google-adwords:not(.is-compact) {
+	margin-top: 10px;
+	@include breakpoint( ">660px" ) {
+		width: 190px;
+		text-align: center;
+	}
 }
 
 // dialog

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -40,7 +40,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 
 			{ isGoogleVouchersEnabled() && <QuerySiteVouchers siteId={ selectedSite.ID } /> }
 			{ isGoogleVouchersEnabled() &&
-				<div className="purchase-detail__body">
+				<div>
 					<GoogleVoucherDetails selectedSite={ selectedSite } />
 				</div>
 			}


### PR DESCRIPTION
**Before**
![image](https://cloud.githubusercontent.com/assets/77539/16002134/3d1c4614-3156-11e6-9040-391ff225cc6d.png)

**After**
![image](https://cloud.githubusercontent.com/assets/77539/16002143/492ef2d0-3156-11e6-816f-a37b5ecdb321.png)

### Testing

Assign a google voucher to a site (`PREMIUM` and `BUSINESS` plans) and test this state (after accepts Terms and Conditions) in mobile mode.

cc @rralian 

Test live: https://calypso.live/?branch=fix/copy-button-width