### PR TITLE
WebPreview: fix toolbar position again

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -69,6 +69,7 @@
 }
 
 .web-preview__toolbar {
+	height: 48px;
 	background: $white;
 	border-bottom: 1px solid lighten( $gray, 20% );
 	border-radius: 4px 4px 0 0;
@@ -98,6 +99,7 @@
 }
 
 .web-preview__close {
+	height: 49px;
 	cursor: pointer;
 }
 
@@ -148,7 +150,7 @@
 .web-preview__placeholder {
 	width: 100%;
 	position: absolute;
-		top: 53px;
+		top: 49px;
 		bottom: 0;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
#5837 fixed the WebPreview's toolbar's vertical position for Safari, but broke it for other browsers. This change reverts the change in the `top` position from #5837 and forces the height of the toolbar buttons
to reasonable sizes so the toolbar's height is corrected on Safari also. 

Before:

<img width="363" alt="before" src="https://cloud.githubusercontent.com/assets/23619/16009477/29ec5580-317d-11e6-9bbe-b4e05f379260.png">

After:

<img width="372" alt="after" src="https://cloud.githubusercontent.com/assets/23619/16009481/2dee0a16-317d-11e6-850c-21407bfb995c.png">

To test: 

- Open the WebPreview for a site by clicking on the site card for an SSL- and non-Jetpack-site. 
- Check that the toolbar looks fine under different browsers. 


Test live: https://calypso.live/?branch=fix/webpreview-toolbar-border