### PR TITLE
Domain Upgrades: Add plans step to domain upgrades.

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -192,7 +192,13 @@ var MapDomainStep = React.createClass( {
 		upgradesActions.addItem( cartItems.domainMapping( { domain: domain } ) );
 
 		if ( this.isMounted() ) {
-			page( '/checkout/' + this.props.selectedSite.slug );
+			const freeWithPlan = this.props.cart && this.props.cart.hasLoadedFromServer && this.props.cart.next_domain_is_free;
+
+			if ( freeWithPlan ) {
+				page( '/checkout/' + this.props.selectedSite.slug );
+			} else {
+				page( '/domains/add/' + domain + '/plans/' + this.props.selectedSite.slug );
+			}
 		}
 	},
 

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -193,6 +193,24 @@ module.exports = function() {
 			upgradesController.googleAppsWithRegistration
 		);
 
+		page( '/domains/add/:registerDomain/plans/:domain',
+			adTracking.retarget,
+			controller.siteSelection,
+			controller.navigation,
+			upgradesController.redirectIfNoSite( '/domains/add' ),
+			controller.jetPackWarning,
+			upgradesController.selectPlan
+		);
+
+		page( '/domains/add/:registerDomain/plans/compare/:domain',
+			adTracking.retarget,
+			controller.siteSelection,
+			controller.navigation,
+			upgradesController.redirectIfNoSite( '/domains/add' ),
+			controller.jetPackWarning,
+			upgradesController.comparePlans
+		);
+
 		page( '/domains/add/mapping/:domain',
 			adTracking.retarget,
 			controller.siteSelection,

--- a/client/my-sites/upgrades/plans-compare/index.jsx
+++ b/client/my-sites/upgrades/plans-compare/index.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { getPlans } from 'state/plans/selectors';
+import { getPlansBySite } from 'state/sites/plans/selectors';
+import QueryPlans from 'components/data/query-plans';
+import PlansCompare from 'components/plans/plans-compare' ;
+
+const UpgradePlansCompare = ( { domain, sites, plans, features, productsList } ) => {
+	const selectedSite = sites.getSelectedSite();
+	const backUrl = '/domains/add/' + domain + '/plans/' + selectedSite.slug;
+
+	return (
+		<div className="plans has-sidebar">
+			<QueryPlans />
+
+			<PlansCompare { ...{
+				selectedSite,
+				plans,
+				features,
+				productsList,
+				backUrl,
+				hideFreePlan: true,
+				isInSignup: true
+			} } />
+		</div>
+	);
+};
+
+UpgradePlansCompare.propTypes = {
+	domain: React.PropTypes.string.isRequired,
+	sites: React.PropTypes.object.isRequired,
+	plans: React.PropTypes.array.isRequired,
+	features: React.PropTypes.object.isRequired,
+	productsList: React.PropTypes.object.isRequired
+};
+
+export default connect(
+	( state, props ) => ( {
+		plans: getPlans( state ),
+		sitePlans: getPlansBySite( state, props.sites.getSelectedSite )
+	} )
+)( UpgradePlansCompare );

--- a/client/my-sites/upgrades/plans/index.jsx
+++ b/client/my-sites/upgrades/plans/index.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getPlans } from 'state/plans/selectors';
+import { getPlansBySite } from 'state/sites/plans/selectors';
+import QueryPlans from 'components/data/query-plans';
+import PlanList from 'components/plans/plan-list' ;
+import Gridicon from 'components/gridicon';
+import HeaderCake from 'components/header-cake';
+
+const Plans = ( { translate, domain, sites, plans, sitePlans, onGoBack } ) => {
+	const site = sites.getSelectedSite();
+	const comparePlansUrl = '/domains/add/' + domain + '/plans/compare/' + site.slug;
+
+	return (
+		<div className="plans has-sidebar">
+			<HeaderCake onClick={ onGoBack }>
+				{ translate( 'Register %(domain)s', { args: { domain } } ) }
+			</HeaderCake>
+
+			<QueryPlans />
+
+			<PlanList { ...{
+				site,
+				plans,
+				sitePlans,
+				comparePlansUrl,
+				hideFreePlan: true,
+				isInSignup: true
+			} } />
+			<a href={ comparePlansUrl } className="plans-step__compare-plans-link">
+				<Gridicon icon="clipboard" size={ 18 } />
+				{ translate( 'Compare Plans' ) }
+			</a>
+		</div>
+	);
+};
+
+Plans.propTypes = {
+	translate: React.PropTypes.func.isRequired,
+	domain: React.PropTypes.string.isRequired,
+	sites: React.PropTypes.object.isRequired,
+	plans: React.PropTypes.array.isRequired,
+	sitePlans: React.PropTypes.object.isRequired
+};
+
+export default connect(
+	( state, props ) => ( {
+		plans: getPlans( state ),
+		sitePlans: getPlansBySite( state, props.sites.getSelectedSite )
+	} )
+)( localize( Plans ) );


### PR DESCRIPTION
Add a new step on during the domain upgrade flow so the user can select a paid plan.

This only updates the flow and does not remove the _Premium Plan_ messages from DWPO.

cc: @apeatling @roundhill @umurkontaci 

Test live: https://calypso.live/?branch=add/plans-step-domain-upgrades