### PR TITLE
Breakpoint mixin: allow multiple breakpoint sizes

### DIFF
--- a/assets/stylesheets/shared/mixins/_breakpoints.scss
+++ b/assets/stylesheets/shared/mixins/_breakpoints.scss
@@ -5,54 +5,56 @@
 
 $breakpoints: 480px, 660px, 960px, 1040px; // Think very carefully before adding a new breakpoint
 
-@mixin breakpoint( $size ){
-	@if type-of($size) == string {
-	  $approved-value: 0;
-		@each $breakpoint in $breakpoints {
-			$and-larger: ">" + $breakpoint;
-			$and-smaller: "<" + $breakpoint;
+@mixin breakpoint( $sizes... ){
+	@each $size in $sizes {
+		@if type-of($size) == string {
+			$approved-value: 0;
+			@each $breakpoint in $breakpoints {
+				$and-larger: ">" + $breakpoint;
+				$and-smaller: "<" + $breakpoint;
 
-			@if $size == $and-smaller {
-				$approved-value: 1;
-				@media ( max-width: $breakpoint ) {
-					@content;
-				}
-			}
-			@else {
-				@if $size == $and-larger {
-					$approved-value: 2;
-					@media ( min-width: $breakpoint + 1 ) {
+				@if $size == $and-smaller {
+					$approved-value: 1;
+					@media ( max-width: $breakpoint ) {
 						@content;
 					}
 				}
 				@else {
-					@each $breakpoint-end in $breakpoints {
-						$range: $breakpoint + "-" + $breakpoint-end;
-						@if $size == $range {
-							$approved-value: 3;
-							@media ( min-width: $breakpoint + 1 ) and ( max-width: $breakpoint-end ) {
-								@content;
+					@if $size == $and-larger {
+						$approved-value: 2;
+						@media ( min-width: $breakpoint + 1 ) {
+							@content;
+						}
+					}
+					@else {
+						@each $breakpoint-end in $breakpoints {
+							$range: $breakpoint + "-" + $breakpoint-end;
+							@if $size == $range {
+								$approved-value: 3;
+								@media ( min-width: $breakpoint + 1 ) and ( max-width: $breakpoint-end ) {
+									@content;
+								}
 							}
 						}
 					}
 				}
 			}
+			@if $approved-value == 0 {
+				$sizes: "";
+				@each $breakpoint in $breakpoints {
+					$sizes: $sizes + " " + $breakpoint;
+				}
+				// TODO - change this to use @error, when it is supported by node-sass
+				@warn "ERROR in breakpoint( #{ $size } ): You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+			}
 		}
-		@if $approved-value == 0 {
+		@else {
 			$sizes: "";
 			@each $breakpoint in $breakpoints {
 				$sizes: $sizes + " " + $breakpoint;
 			}
 			// TODO - change this to use @error, when it is supported by node-sass
-			@warn "ERROR in breakpoint( #{ $size } ): You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+			@warn "ERROR in breakpoint( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
 		}
-	}
-	@else {
-		$sizes: "";
-		@each $breakpoint in $breakpoints {
-			$sizes: $sizes + " " + $breakpoint;
-		}
-		// TODO - change this to use @error, when it is supported by node-sass
-		@warn "ERROR in breakpoint( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
 	}
 }


### PR DESCRIPTION
This PR adds functionality to the `breakpoint` mixin to accept multiple breakpoint sizes arguments. Example usage:

```sass
@include breakpoint( "480px-660px", "960px-1040px", "<480px" ) {
   body {
      color: red;
   }
}
```

It's not the best solution we could hope for as the following would be nicer:

```sass
@include breakpoint( "480px-660px" ),
@include breakpoint( "960px-1040px" ) {
}
```

or even

```sass
@include breakpoint( "480px-660px" ) and @include breakpoint( "960px-1040px" ) { }
```

After a bit of research, it turns out that the above is actually not possible to do in Sass (or am I wrong?)

## Testing

1. Make sure Calypso runs and looks normally;
2. Try to write multiple breakpoint sizes in a single `breakpoint` mixin somewhere and see if it compiles + works.

cc @gwwar @mtias 

Test live: https://calypso.live/?branch=update/breakpoint-mixin-more-params