### PR TITLE
CPT: Infinitely render CPTs using ReactVirtualized

### DIFF
--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -345,7 +345,8 @@ var LinkDialog = React.createClass( {
 								orderBy="date"
 								order="DESC"
 								selected={ this.getSelectedPostId() }
-								onChange={ this.setExistingContent } />
+								onChange={ this.setExistingContent }
+								emptyMessage={ this.translate( 'No posts found' ) } />
 						) }
 					</FormLabel>
 				</FormFieldset>

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -155,7 +155,7 @@ const PostSelectorPosts = React.createClass( {
 	},
 
 	isCompact() {
-		if ( ! this.props.posts || this.state.searchTerm ) {
+		if ( ! this.props.posts || this.state.searchTerm || this.hasNoPosts() ) {
 			return false;
 		}
 
@@ -295,20 +295,30 @@ const PostSelectorPosts = React.createClass( {
 		);
 	},
 
-	renderRow( { index } ) {
-		if ( this.hasNoSearchResults() || this.hasNoPosts() ) {
-			return (
-				<div key="no-results" className="post-selector__list-item is-empty">
-					{ ( this.hasNoSearchResults() || ! this.props.emptyMessage ) && (
-						<NoResults
-							createLink={ this.props.createLink }
-							noResultsMessage={ this.props.noResultsMessage } />
-					) }
-					{ this.hasNoPosts() && this.props.emptyMessage }
-				</div>
+	renderEmptyContent() {
+		let message;
+		if ( this.hasNoSearchResults() ) {
+			message = (
+				<NoResults
+					createLink={ this.props.createLink }
+					noResultsMessage={ this.props.noResultsMessage } />
 			);
+		} else if ( this.hasNoPosts() ) {
+			message = this.props.emptyMessage;
 		}
 
+		if ( ! message ) {
+			return;
+		}
+
+		return (
+			<div key="no-results" className="post-selector__list-item is-empty">
+				{ message }
+			</div>
+		);
+	},
+
+	renderRow( { index } ) {
 		const item = this.getItem( index );
 		if ( item ) {
 			return this.renderItem( item );
@@ -364,6 +374,7 @@ const PostSelectorPosts = React.createClass( {
 							width={ this.getResultsWidth() }
 							height={ isCompact ? this.getCompactContainerHeight() : 300 }
 							onRowsRendered={ onRowsRendered }
+							noRowsRenderer={ this.renderEmptyContent }
 							rowCount={ rowCount }
 							estimatedRowSize={ ITEM_HEIGHT }
 							rowHeight={ this.getRowHeight }

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -1,8 +1,15 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import isEqual from 'lodash/isEqual';
+import includes from 'lodash/includes';
+import difference from 'lodash/difference';
+import range from 'lodash/range';
+import AutoSizer from 'react-virtualized/AutoSizer';
+import WindowScroller from 'react-virtualized/WindowScroller';
+import VirtualScroll from 'react-virtualized/VirtualScroll';
 
 /**
  * Internal dependencies
@@ -11,52 +18,155 @@ import QueryPosts from 'components/data/query-posts';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	isRequestingSitePostsForQuery,
-	getSitePostsForQueryIgnoringPage
+	getSitePostsForQueryIgnoringPage,
+	getSitePostsLastPageForQuery
 } from 'state/posts/selectors';
 import PostTypeListPost from './post';
 import PostTypeListPostPlaceholder from './post-placeholder';
 import PostTypeListEmptyContent from './empty-content';
 
-function PostTypeList( { query, siteId, posts, requesting } ) {
-	return (
-		<div className="post-type-list">
-			{ query && (
-				<QueryPosts
-					siteId={ siteId }
-					query={ query } />
-			) }
-			{ query && posts && ! posts.length && ! requesting && (
-				<PostTypeListEmptyContent
-					type={ query.type }
-					status={ query.status } />
-			) }
-			<ul className="post-type-list__posts">
-				{ ( ! query || requesting ) && (
-					<li><PostTypeListPostPlaceholder /></li>
-				) }
-				{ query && posts && posts.map( ( post ) => (
-					<li key={ post.global_ID }>
-						<PostTypeListPost globalId={ post.global_ID } />
-					</li>
-				) ) }
-			</ul>
-		</div>
-	);
-}
+/**
+ * Constants
+ */
+const POST_ROW_HEIGHT = 86;
+const DEFAULT_POSTS_PER_PAGE = 20;
+const LOAD_OFFSET = 10;
 
-PostTypeList.propTypes = {
-	query: PropTypes.object,
-	siteId: PropTypes.number,
-	posts: PropTypes.array,
-	requesting: PropTypes.bool
-};
+class PostTypeList extends Component {
+	static propTypes = {
+		query: PropTypes.object,
+		siteId: PropTypes.number,
+		lastPage: PropTypes.number,
+		posts: PropTypes.array,
+		requestingFirstPage: PropTypes.bool,
+		requestingLastPage: PropTypes.bool
+	};
+
+	constructor() {
+		super( ...arguments );
+
+		this.renderPostRow = this.renderPostRow.bind( this );
+		this.setRequestedPages = this.setRequestedPages.bind( this );
+		this.state = { requestedPages: [] };
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! isEqual( this.props.query, nextProps.query ) ) {
+			this.setState( { requestedPages: [] } );
+		}
+	}
+
+	getPageForIndex( index ) {
+		const { query, lastPage } = this.props;
+		const perPage = query.number || DEFAULT_POSTS_PER_PAGE;
+		const page = Math.ceil( index / perPage );
+
+		return Math.max( Math.min( page, lastPage || Infinity ), 1 );
+	}
+
+	setRequestedPages( { startIndex, stopIndex } ) {
+		if ( ! this.props.query ) {
+			return;
+		}
+
+		const { requestedPages } = this.state;
+		const pagesToRequest = difference( range(
+			this.getPageForIndex( startIndex - LOAD_OFFSET ),
+			this.getPageForIndex( stopIndex + LOAD_OFFSET ) + 1
+		), requestedPages );
+
+		if ( ! pagesToRequest.length ) {
+			return;
+		}
+
+		this.setState( {
+			requestedPages: requestedPages.concat( pagesToRequest )
+		} );
+	}
+
+	isLastPage() {
+		const { lastPage, requestingLastPage } = this.props;
+		const { requestedPages } = this.state;
+
+		return includes( requestedPages, lastPage ) && ! requestingLastPage;
+	}
+
+	getRowCount() {
+		let count = 1;
+
+		if ( this.props.posts ) {
+			count += this.props.posts.length;
+		}
+
+		if ( this.isLastPage() ) {
+			count--;
+		}
+
+		return count;
+	}
+
+	renderPostRow( { index } ) {
+		const { requestingFirstPage, posts } = this.props;
+		if ( ! posts || ( requestingFirstPage && 0 === index ) ||
+				( ! requestingFirstPage && index >= posts.length ) ) {
+			return <PostTypeListPostPlaceholder key="placeholder" />;
+		}
+
+		const { global_ID: globalId } = posts[ requestingFirstPage ? index - 1 : index ];
+		return <PostTypeListPost key={ globalId } globalId={ globalId } />;
+	}
+
+	render() {
+		const { query, siteId, posts } = this.props;
+		const isEmpty = query && posts && ! posts.length && this.isLastPage();
+
+		return (
+			<div className="post-type-list">
+				{ query && this.state.requestedPages.map( ( page ) => (
+					<QueryPosts
+						key={ `query-${ page }` }
+						siteId={ siteId }
+						query={ { ...query, page } } />
+				) ) }
+				{ isEmpty && (
+					<PostTypeListEmptyContent
+						type={ query.type }
+						status={ query.status } />
+				) }
+				{ ! isEmpty && (
+					<WindowScroller>
+						{ ( { height, scrollTop } ) => (
+							<AutoSizer disableHeight>
+								{ ( { width } ) => (
+									<VirtualScroll
+										autoHeight
+										scrollTop={ scrollTop }
+										height={ height }
+										width={ width }
+										onRowsRendered={ this.setRequestedPages }
+										rowRenderer={ this.renderPostRow }
+										rowHeight={ POST_ROW_HEIGHT }
+										rowCount={ this.getRowCount() }
+										className="post-type-list__posts" />
+								) }
+							</AutoSizer>
+						) }
+					</WindowScroller>
+				) }
+			</div>
+		);
+	}
+}
 
 export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
+	const lastPage = getSitePostsLastPageForQuery( state, siteId, ownProps.query );
 
 	return {
 		siteId,
+		lastPage,
 		posts: getSitePostsForQueryIgnoringPage( state, siteId, ownProps.query ),
-		requesting: isRequestingSitePostsForQuery( state, siteId, ownProps.query )
+		requestingFirstPage: isRequestingSitePostsForQuery( state, siteId, { ...ownProps.query, page: 1 } ),
+		requestingLastPage: isRequestingSitePostsForQuery( state, siteId, { ...ownProps.query, page: lastPage } )
 	};
 } )( PostTypeList );

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -47,6 +47,7 @@ class PostTypeList extends Component {
 
 		this.renderPostRow = this.renderPostRow.bind( this );
 		this.setRequestedPages = this.setRequestedPages.bind( this );
+		this.setVirtualScrollRef = this.setVirtualScrollRef.bind( this );
 		this.state = { requestedPages: [] };
 	}
 
@@ -54,6 +55,20 @@ class PostTypeList extends Component {
 		if ( ! isEqual( this.props.query, nextProps.query ) ) {
 			this.setState( { requestedPages: [] } );
 		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		// If, after requesting, it turns out that there's only a single post,
+		// VirtualScroll may not update because the row count doesn't change
+		// (1 placeholder, 1 post result). In these cases, force an update.
+		if ( this.props.posts && 1 === this.props.posts.length && this.virtualScroll &&
+				! this.props.requestingFirstPage && prevProps.requestingFirstPage ) {
+			this.virtualScroll.forceUpdate();
+		}
+	}
+
+	setVirtualScrollRef( ref ) {
+		this.virtualScroll = ref;
 	}
 
 	getPageForIndex( index ) {
@@ -139,6 +154,7 @@ class PostTypeList extends Component {
 							<AutoSizer disableHeight>
 								{ ( { width } ) => (
 									<VirtualScroll
+										ref={ this.setVirtualScrollRef }
 										autoHeight
 										scrollTop={ scrollTop }
 										height={ height }

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -1,6 +1,6 @@
 .post-type-list__posts {
-	list-style: none;
-	margin-left: 0;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
 }
 
 .post-type-list__post {

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -142,7 +142,12 @@ export function getSitePostsLastPageForQuery( state, siteId, query ) {
 		return null;
 	}
 
-	return state.posts.queries[ siteId ].getNumberOfPages( query );
+	const pages = state.posts.queries[ siteId ].getNumberOfPages( query );
+	if ( null === pages ) {
+		return null;
+	}
+
+	return Math.max( pages, 1 );
 }
 
 /**

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -284,6 +284,26 @@ describe( 'selectors', () => {
 
 			expect( lastPage ).to.equal( 4 );
 		} );
+
+		it( 'should return 1 if there are no found posts', () => {
+			const lastPage = getSitePostsLastPageForQuery( {
+				posts: {
+					queries: {
+						2916284: new PostQueryManager( {
+							items: {},
+							queries: {
+								'[["search","Hello"]]': {
+									itemKeys: [],
+									found: 0
+								}
+							}
+						} )
+					}
+				}
+			}, 2916284, { search: 'Hello' } );
+
+			expect( lastPage ).to.equal( 1 );
+		} );
 	} );
 
 	describe( '#isSitePostsLastPageForQuery()', () => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -191,7 +191,7 @@
       "version": "6.0.4"
     },
     "babel-generator": {
-      "version": "6.10.0",
+      "version": "6.10.2",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -354,7 +354,7 @@
       "version": "6.8.0"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.8.0"
+      "version": "6.10.3"
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.8.0"
@@ -446,10 +446,10 @@
       "version": "6.9.0"
     },
     "babel-traverse": {
-      "version": "6.9.0"
+      "version": "6.10.4"
     },
     "babel-types": {
-      "version": "6.10.0"
+      "version": "6.10.2"
     },
     "babylon": {
       "version": "6.8.1"
@@ -514,10 +514,10 @@
       "version": "2.10.2"
     },
     "body-parser": {
-      "version": "1.15.1",
+      "version": "1.15.2",
       "dependencies": {
         "qs": {
-          "version": "6.1.0"
+          "version": "6.2.0"
         }
       }
     },
@@ -546,7 +546,7 @@
       "version": "0.1.4"
     },
     "browserslist": {
-      "version": "1.3.2"
+      "version": "1.3.3"
     },
     "buffer": {
       "version": "3.6.0"
@@ -558,7 +558,7 @@
       "version": "2.0.0"
     },
     "bytes": {
-      "version": "2.3.0"
+      "version": "2.4.0"
     },
     "callsite": {
       "version": "1.0.0"
@@ -578,7 +578,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000480"
+      "version": "1.0.30000486"
     },
     "caseless": {
       "version": "0.11.0"
@@ -920,13 +920,10 @@
       }
     },
     "del": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
-        "glob": {
-          "version": "6.0.4"
-        },
         "globby": {
-          "version": "4.1.0"
+          "version": "5.0.0"
         }
       }
     },
@@ -1228,7 +1225,7 @@
           "version": "5.0.15"
         },
         "minimatch": {
-          "version": "3.0.0"
+          "version": "3.0.2"
         },
         "strip-json-comments": {
           "version": "1.0.4"
@@ -1458,7 +1455,7 @@
       "version": "1.0.0"
     },
     "fstream": {
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.4"
@@ -1673,7 +1670,7 @@
       "version": "1.7.0"
     },
     "http-errors": {
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "http-proxy": {
       "version": "1.14.0"
@@ -2273,7 +2270,7 @@
       "version": "1.1.2"
     },
     "micromatch": {
-      "version": "2.3.8"
+      "version": "2.3.10"
     },
     "mime": {
       "version": "1.3.4"
@@ -2567,7 +2564,12 @@
       "version": "2.1.0"
     },
     "output-file-sync": {
-      "version": "1.1.1"
+      "version": "1.1.2",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.4"
+        }
+      }
     },
     "page": {
       "version": "1.6.4",
@@ -2773,7 +2775,7 @@
       "version": "1.0.3"
     },
     "raw-body": {
-      "version": "2.1.6"
+      "version": "2.1.7"
     },
     "react": {
       "version": "15.1.0",
@@ -2867,7 +2869,7 @@
       }
     },
     "react-virtualized": {
-      "version": "7.2.0",
+      "version": "7.9.1",
       "dependencies": {
         "classnames": {
           "version": "2.2.5"
@@ -3027,7 +3029,10 @@
       "version": "2.5.2",
       "dependencies": {
         "glob": {
-          "version": "7.0.4"
+          "version": "7.0.5"
+        },
+        "minimatch": {
+          "version": "3.0.2"
         }
       }
     },
@@ -3092,7 +3097,10 @@
           "version": "3.2.0"
         },
         "glob": {
-          "version": "7.0.4"
+          "version": "7.0.5"
+        },
+        "minimatch": {
+          "version": "3.0.2"
         },
         "window-size": {
           "version": "0.2.0"
@@ -3142,9 +3150,6 @@
         },
         "escape-html": {
           "version": "1.0.3"
-        },
-        "http-errors": {
-          "version": "1.5.0"
         },
         "negotiator": {
           "version": "0.6.1"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "react-pure-render": "1.0.2",
     "react-redux": "4.4.5",
     "react-tap-event-plugin": "1.0.0",
-    "react-virtualized": "7.2.0",
+    "react-virtualized": "7.9.1",
     "redux": "3.0.4",
     "redux-thunk": "1.0.0",
     "rtlcss": "2.0.5",


### PR DESCRIPTION
Supersedes #5007

This pull request seeks to implement infinite scroll for the custom post types listing screen.

__Implementation notes:__

This takes a unique approach to loading more items. Rather than triggering a request based on the scroll approaching the next page, it leverages [ReactVirtualized's `onRowsRendered` callback](https://github.com/bvaughn/react-virtualized/blob/master/docs/VirtualScroll.md) to determine which pages should be requested for the query dependent on which rows are currently rendered. The reason for this change is to accommodate persistence of posts queries state, which is not currently persisted. Once persisted, we need a mechanism to responsibly refresh all of the persisted data. In the context of having persisted post entries, traditional "needs more items so fetch" logic does not work well, and naively re-requesting all persisted posts could incur huge network costs if tens of pages had been loaded during the last session.

This pull request also upgrades ReactVirtualized to ~~7.5.0~~ 7.9.1 to make use of the `WindowScroller` HOC ([see release notes](https://github.com/bvaughn/react-virtualized/blob/master/CHANGELOG.md#750)).

__Testing instructions:__

Verify that all posts are revealed on the custom post types list screen, requested 20 at a time infinitely until the last known page. When changing filters, note that the same behavior applies to the new filter.

1. Navigate to [My Sites](http://calypso.localhost:3000/stats/insights)
2. Select a site where at least one custom post type is enabled
3. Choose the custom post type navigation link in the sidebar
4. Note that a loading placeholder or, if persisted state exists, the past results are immediately shown
5. Note that posts are revealed ten at a time
6. Note that as you scroll, more posts are loaded until all pages have been exhausted

/cc @timmyc 

Test live: https://calypso.live/?branch=update/cpt-infinite-list-2