### PR TITLE
CPT: Improve handling of edge case titles in post listing

### DIFF
--- a/client/my-sites/post-type-list/post.jsx
+++ b/client/my-sites/post-type-list/post.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { getEditorPath } from 'state/ui/editor/selectors';
-import { getPost } from 'state/posts/selectors';
+import { getNormalizedPost } from 'state/posts/selectors';
 import Card from 'components/card';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import resizeImageUrl from 'lib/resize-image-url';
@@ -56,7 +56,7 @@ PostTypeListPost.propTypes = {
 };
 
 export default connect( ( state, ownProps ) => {
-	const post = getPost( state, ownProps.globalId );
+	const post = getNormalizedPost( state, ownProps.globalId );
 
 	return {
 		post,

--- a/client/my-sites/post-type-list/post.jsx
+++ b/client/my-sites/post-type-list/post.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,8 +16,10 @@ import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import resizeImageUrl from 'lib/resize-image-url';
 import PostTypeListPostActions from './post-actions';
 
-export function PostTypeListPost( { globalId, post, editUrl, className } ) {
-	const classes = classnames( 'post-type-list__post', className );
+export function PostTypeListPost( { translate, globalId, post, editUrl, className } ) {
+	const classes = classnames( 'post-type-list__post', className, {
+		'is-untitled': ! post.title
+	} );
 
 	return (
 		<Card compact className={ classes }>
@@ -32,7 +35,7 @@ export function PostTypeListPost( { globalId, post, editUrl, className } ) {
 				<div className="post-type-list__post-title-meta">
 					<h1 className="post-type-list__post-title">
 						<a href={ editUrl }>
-							{ post.title }
+							{ post.title || translate( 'Untitled' ) }
 						</a>
 					</h1>
 					<div className="post-type-list__post-meta">
@@ -46,6 +49,7 @@ export function PostTypeListPost( { globalId, post, editUrl, className } ) {
 }
 
 PostTypeListPost.propTypes = {
+	translate: PropTypes.func,
 	globalId: PropTypes.string,
 	post: PropTypes.object,
 	className: PropTypes.string
@@ -58,4 +62,4 @@ export default connect( ( state, ownProps ) => {
 		post,
 		editUrl: getEditorPath( state, state.ui.selectedSiteId, post.ID )
 	};
-} )( PostTypeListPost );
+} )( localize( PostTypeListPost ) );

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -49,6 +49,12 @@
 		.post-type-list__post-placeholder & {
 			@include placeholder;
 		}
+
+		.post-type-list__post.is-untitled & {
+			color: $gray;
+			font-style: italic;
+			font-weight: 400;
+		}
 	}
 }
 

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -81,6 +81,7 @@
 .post-type-list__post-actions {
 	margin-left: auto;
 	margin-right: -8px;
+	flex-shrink: 0;
 }
 
 .post-type-list__post-actions .button {

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -11,6 +11,8 @@
 
 .post-type-list__post-detail {
 	display: flex;
+	min-width: 0;
+	overflow: hidden;
 }
 
 .post-type-list__post-thumbnail-wrapper {
@@ -33,11 +35,13 @@
 
 .post-type-list__post-title-meta {
 	padding: 6px 0;
+	width: 100%;
 }
 
 .post-type-list__post-title {
 	@extend %content-font;
 	margin-bottom: 2px;
+	white-space: nowrap;
 
 	a {
 		color: $gray-dark;
@@ -79,9 +83,15 @@
 }
 
 .post-type-list__post-actions {
+	position: relative;
 	margin-left: auto;
 	margin-right: -8px;
 	flex-shrink: 0;
+
+	&::before {
+		@include long-content-fade( $size: 40px );
+		right: 100%;
+	}
 }
 
 .post-type-list__post-actions .button {


### PR DESCRIPTION
This pull request seeks to...
- Display "(Untitled)" when post lacks title
- Prevent actions from collapsing on itself when title is very long

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16019550/954702cc-3177-11e6-9db5-1e4524b34163.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16019556/9ccb3e0a-3177-11e6-8bbb-f68f458adc5e.png)

__Testing instructions:__

Verify that if a post has no title, it is shown as "(Untitled)" in the [CPT posts list](http://calypso.localhost:3000/types/post). Similarly, if a post has a very long title that breaks onto a second line, verify that the action buttons do not shrink.

__Follow-up tasks:__

In the context of #5995 where rendered post rows are assigned a fixed height, we should consider whether we'd want the post title to wrap on multiple lines. If not, we'll need to adjust the logic of infinite rendering to track rendered row height.

Test live: https://calypso.live/?branch=fix/cpt-titles