### PR TITLE
Plans: fix monthly pricing for JPY currency

### DIFF
--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -23,8 +23,9 @@ const PlanPrice = React.createClass( {
 				return this.translate( 'Free', { context: 'Zero cost product price' } );
 			}
 
-			const monthlyPrice = +( rawPrice / 12 ).toFixed( 2 );
-			formattedPrice = formattedPrice.replace( rawPrice, monthlyPrice );
+			const currencySymbol = formattedPrice.slice( 0, 1 );
+			const monthlyPrice = +( rawPrice / 12 ).toFixed( currencySymbol === '¥' ? 0 : 2 );
+			formattedPrice = `${ currencySymbol }${ monthlyPrice }`;
 
 			return formattedPrice;
 		}

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -72,7 +72,7 @@ export default React.createClass( {
 
 		return this.translate( '(%(monthlyPrice)f %(currency)s x 12 months)', {
 			args: {
-				monthlyPrice: +( cost / 12 ).toFixed( 2 ),
+				monthlyPrice: +( cost / 12 ).toFixed( currency === 'JPY' ? 0 : 2 ),
 				currency
 			}
 		} );

--- a/client/state/plans/selectors.js
+++ b/client/state/plans/selectors.js
@@ -51,11 +51,12 @@ export function getPlanPriceObject( state, productId, isMonthly = false ) {
 		return null;
 	}
 	const cost = plan.raw_price;
-	const price = isMonthly ? +( cost / 12 ).toFixed( 2 ) : cost;
+	const currencySymbol = plan.formatted_price.slice( 0, 1 );
+	const price = isMonthly ? +( cost / 12 ).toFixed( currencySymbol === '¥' ? 0 : 2 ) : cost;
 	const dollars = Math.floor( price );
 	const cents = ( price - dollars ) * 100;
 	return {
-		currencySymbol: plan.formatted_price.slice( 0, 1 ),
+		currencySymbol,
 		decimalMark: '.', //hard code this for now until we can get number localization from the server
 		dollars,
 		cents

--- a/client/state/plans/test/selectors.js
+++ b/client/state/plans/test/selectors.js
@@ -77,5 +77,26 @@ describe( 'selectors', () => {
 			const priceObject = getPlanPriceObject( state, 44, true );
 			expect( priceObject ).to.eql( null );
 		} );
+		it( 'should handle JPY localization correctly', () => {
+			const state = {
+				plans: {
+					items: [ {
+						product_id: 2000,
+						product_name: 'Premium',
+						formatted_price: '¥11,800',
+						raw_price: 11800
+					} ],
+					requesting: false,
+					error: false
+				}
+			};
+			const priceObject = getPlanPriceObject( state, 2000, true );
+			expect( priceObject ).to.eql( {
+				currencySymbol: '¥',
+				decimalMark: '.',
+				dollars: 983,
+				cents: 0
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
This PR fixes monthly pricing in yen.

Before:
<img width="766" alt="screen shot 2016-06-13 at 11 37 24 am" src="https://cloud.githubusercontent.com/assets/1270189/16019725/48534d3a-315f-11e6-83bc-0131b41a19f4.png">

After:
<img width="757" alt="screen shot 2016-06-13 at 11 52 05 am" src="https://cloud.githubusercontent.com/assets/1270189/16019722/45f43ee6-315f-11e6-9b1c-d2e21bf5417f.png">

## Testing Instructions
- This one is a bit tricky to test. You either need a user who has a currency of 'JPY', or you can sandbox and override `get_user_currency` in `wpcom-store.php` to always return 'JPY'
- Navigate to /plans
- annual prices are divided by 12 and we do not display any fractional values, as a single yen is the smallest unit.

### Notes
- This is mostly a short term fix for this issue
- We should update the plans api endpoint to return the formatted monthly prices OR
- Only return raw price and currency (USD vs JPY) from the api and let the client localize prices with https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString and a polyfill for Safari

cc @rralian @lamosty @mtias @rodrigoi 

Test live: https://calypso.live/?branch=fix/monthly-pricing-JPY