### PR TITLE
Reader: Make blockquotes the same size as the rest of the content

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -207,7 +207,6 @@
 		margin: 16px 0 32px;
 		color: darken( $gray, 20% );
 		font-weight: normal;
-		font-size: 20px;
 		background: transparent;
 	}
 

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -203,8 +203,9 @@
 	}
 
 	blockquote {
-		padding: 16px 24px;
-		margin: 16px 0 32px;
+		padding: 0 24px 0 32px;
+    	margin: 16px 0 32px;
+    	border-left: 3px solid lighten( $gray, 30% );
 		color: darken( $gray, 20% );
 		font-weight: normal;
 		background: transparent;


### PR DESCRIPTION
This is a thing thats bugged me for a while. The `blockquote` style is so much bigger than the rest of the content. It can be a bit jarring. 

This PR makes it the same size. 

Before:
![screen shot 2016-06-13 at 1 31 46 pm](https://cloud.githubusercontent.com/assets/5835847/16020512/b4145af8-316b-11e6-858d-15e600c3536b.png)
![screen shot 2016-06-13 at 1 32 46 pm](https://cloud.githubusercontent.com/assets/5835847/16020523/bf757526-316b-11e6-9864-ac1006e5a23b.png)

After:

![screen shot 2016-06-13 at 1 32 01 pm](https://cloud.githubusercontent.com/assets/5835847/16020496/9e77647e-316b-11e6-92ae-d8198a6d411d.png)

![screen shot 2016-06-13 at 1 32 23 pm](https://cloud.githubusercontent.com/assets/5835847/16020498/a61a7bd0-316b-11e6-97cc-2f4dbbc6658d.png)
(Kottke uses them a lot and he's at the top of my feed.)

Better? Worse? Leave it alone?

Test live: https://calypso.live/?branch=try/reader-blockquotes-smaller