### PR TITLE
Add sass linting configuration.

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,94 @@
+options:
+  formatter: stylish
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+  # Extends
+  extends-before-mixins: 1
+  extends-before-declarations: 1
+  placeholder-in-extend: 1
+
+  # Mixins
+  mixins-before-declarations: 1
+
+  # Line Spacing
+  one-declaration-per-line: 1
+  empty-line-between-blocks: 1
+  single-line-per-selector: 1
+
+  # Disallows
+  no-color-keywords: 1
+  no-color-literals: 1
+  no-css-comments: 0
+  no-debug: 1
+  no-duplicate-properties: 1
+  no-empty-rulesets: 1
+  no-extends: 0
+  no-ids: 1
+  no-important: 1
+  no-invalid-hex: 1
+  no-mergeable-selectors: 1
+  no-misspelled-properties: 1
+  no-qualifying-elements: 1
+  no-trailing-whitespace: 1
+  no-trailing-zero: 1
+  no-transition-all: 1
+  no-url-protocols: 1
+  no-vendor-prefixes: 1
+  no-warn: 1
+  property-units: 0
+
+  # Nesting
+  force-attribute-nesting: 1
+  force-element-nesting: 1
+  force-pseudo-nesting: 1
+
+  # Name Formats
+  class-name-format:
+    - 1
+    -
+      convention: strictbem
+  function-name-format: 1
+  id-name-format: 0
+  mixin-name-format: 1
+  placeholder-name-format: 1
+  variable-name-format: 1
+
+  # Style Guide
+  bem-depth: 0
+  border-zero: 1
+  brace-style: 1
+  clean-import-paths: 1
+  empty-args: 1
+  hex-length: 1
+  hex-notation: 1
+  indentation:
+    - 1
+    -
+      size: 1
+  leading-zero: 0
+  nesting-depth: 1
+  property-sort-order: 1
+  quotes: 1
+  shorthand-values: 1
+  url-quotes: 1
+  variable-for-property: 1
+  zero-unit: 1
+
+  # Inner Spacing
+  space-after-comma: 1
+  space-before-colon: 1
+  space-after-colon: 1
+  space-before-brace: 1
+  space-before-bang: 1
+  space-after-bang: 1
+  space-between-parens:
+    - 1
+    -
+      include: 1
+      spaces: 1
+  space-around-operator: 1
+
+  # Final Items
+  trailing-semicolon: 1
+  final-newline: 1


### PR DESCRIPTION
This PR adds a .sass-lint.yml which can be used with https://github.com/sasstools/sass-lint and the associated editor plugins.

I did not add in the associated build tolling as there are a lot of issues with the sass that will need to be resolved first.  

I used this document to setup the configuration file:  https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md

Please let me know if I was over strict.

I went with sass-lint over scss-lint as it uses libsass.  scss-lint requires ruby and the sass gem to run.

The easiest way to test this commit is via your editor:

https://atom.io/packages/linter-sass-lint
https://packagecontrol.io/packages/SublimeLinter-contrib-sass-lint

Test live: https://calypso.live/?branch=add-sass-lint-configuration