### PR TITLE
Plans: display A$ and C$ correctly for monthly pricing

### DIFF
--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -3,6 +3,7 @@
  */
 import isUndefined from 'lodash/isUndefined';
 import React from 'react';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -23,11 +24,16 @@ const PlanPrice = React.createClass( {
 				return this.translate( 'Free', { context: 'Zero cost product price' } );
 			}
 
-			const currencySymbol = formattedPrice.slice( 0, 1 );
-			const monthlyPrice = +( rawPrice / 12 ).toFixed( currencySymbol === '¥' ? 0 : 2 );
-			formattedPrice = `${ currencySymbol }${ monthlyPrice }`;
+			// could get $5.95, A$4.13, ¥298, €3,50, etc…
+			const getCurrencySymbol = price => /(\D+)\d+/.exec( price )[ 1 ];
+			const currencyDigits = currencySymbol => get( {
+				'¥': 0
+			}, currencySymbol, 2 );
 
-			return formattedPrice;
+			const currencySymbol = getCurrencySymbol( formattedPrice );
+			const monthlyPrice = ( rawPrice / 12 ).toFixed( currencyDigits( currencySymbol ) );
+
+			return `${ currencySymbol }${ monthlyPrice }`;
 		}
 
 		return this.translate( 'Loading' );

--- a/client/state/plans/selectors.js
+++ b/client/state/plans/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External Dependencies
+ */
+import get from 'lodash/get';
+
+/**
  * Internal Dependencies
  */
 import createSelector from 'lib/create-selector';
@@ -50,9 +55,14 @@ export function getPlanPriceObject( state, productId, isMonthly = false ) {
 	if ( ! plan || ! plan.formatted_price || ! plan.raw_price ) {
 		return null;
 	}
-	const cost = plan.raw_price;
-	const currencySymbol = plan.formatted_price.slice( 0, 1 );
-	const price = isMonthly ? +( cost / 12 ).toFixed( currencySymbol === '¥' ? 0 : 2 ) : cost;
+	// could get $5.95, A$4.13, ¥298, €3,50, etc…
+	const getCurrencySymbol = formattedPrice => /(\D+)\d+/.exec( formattedPrice )[ 1 ];
+	const currencyDigits = currencySymbol => get( {
+		'¥': 0
+	}, currencySymbol, 2 );
+
+	const currencySymbol = getCurrencySymbol( plan.formatted_price );
+	const price = isMonthly ? ( plan.raw_price / 12 ).toFixed( currencyDigits( currencySymbol ) ) : plan.raw_price;
 	const dollars = Math.floor( price );
 	const cents = ( price - dollars ) * 100;
 	return {

--- a/client/state/plans/test/selectors.js
+++ b/client/state/plans/test/selectors.js
@@ -98,5 +98,47 @@ describe( 'selectors', () => {
 				cents: 0
 			} );
 		} );
+		it( 'should handle AUD localization correctly', () => {
+			const state = {
+				plans: {
+					items: [ {
+						product_id: 2000,
+						product_name: 'Premium',
+						formatted_price: 'A$99',
+						raw_price: 99
+					} ],
+					requesting: false,
+					error: false
+				}
+			};
+			const priceObject = getPlanPriceObject( state, 2000, true );
+			expect( priceObject ).to.eql( {
+				currencySymbol: 'A$',
+				decimalMark: '.',
+				dollars: 8,
+				cents: 25
+			} );
+		} );
+		it( 'should handle CAD localization correctly', () => {
+			const state = {
+				plans: {
+					items: [ {
+						product_id: 2000,
+						product_name: 'Premium',
+						formatted_price: 'C$99',
+						raw_price: 99
+					} ],
+					requesting: false,
+					error: false
+				}
+			};
+			const priceObject = getPlanPriceObject( state, 2000, true );
+			expect( priceObject ).to.eql( {
+				currencySymbol: 'C$',
+				decimalMark: '.',
+				dollars: 8,
+				cents: 25
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
This fixes a regression in #5997 where we assume currency symbols are only one character. This is a temporary fix until monthly localization occurs on the server, or we return a currency code, so we can localize correctly on the client.

After:
<img width="776" alt="screen shot 2016-06-13 at 1 28 49 pm" src="https://cloud.githubusercontent.com/assets/1270189/16022101/0e0ffa4a-316b-11e6-9b98-fc747f1a6719.png">

## Testing Instructions
- This one is a bit tricky to test. You either need a user who has a currency of 'CAD' or 'AUD', or you can sandbox and override `get_user_currency` in `wpcom-store.php` to always return 'CAD' or 'AUD'
- Navigate to /plans
- we see the full currency symbol `C$` or `A$` instead of `C` or `A`

cc @dmsnell @lamosty @rralian 

Test live: https://calypso.live/?branch=fix/currency-symbol