### PR TITLE
Plans: add main plan component — PlanFeatures

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -5,8 +5,6 @@
  */
 import React from 'react';
 import i18n from 'i18n-calypso';
-import filter from 'lodash/filter';
-import sortBy from 'lodash/sortBy';
 
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
@@ -49,14 +47,33 @@ export const plansList = {
 		getTitle: () => i18n.translate( 'Free' ),
 		getPriceTitle: () => i18n.translate( 'Free for life' ),
 		getProductId: () => 1,
-		getDescription: () => i18n.translate( 'Get a free blog and be on your way to publishing your first post in less than five minutes.' )
+		getDescription: () => i18n.translate( 'Get a free blog and be on your way to publishing your first post in less than five minutes.' ),
+		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
+			FEATURE_FREE_SITE,
+			FEATURE_WP_SUBDOMAIN,
+			FEATURE_FREE_THEMES,
+			FEATURE_3GB_STORAGE,
+			FEATURE_COMMUNITY_SUPPORT
+		]
 	},
 
 	[ PLAN_PREMIUM ]: {
 		getTitle: () => i18n.translate( 'Premium' ),
 		getPriceTitle: () => i18n.translate( '$99 per year' ),
 		getProductId: () => 1003,
-		getDescription: () => i18n.translate( 'Your own domain name, powerful customization options, lots of space for audio and video, and $100 advertising credit.' )
+		getDescription: () => i18n.translate( 'Your own domain name, powerful customization options, lots of space for audio and video, and $100 advertising credit.' ),
+		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
+			FEATURE_FREE_SITE,
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_FREE_THEMES,
+			FEATURE_13GB_STORAGE,
+			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+			FEATURE_NO_ADS,
+			FEATURE_CUSTOM_DESIGN,
+			FEATURE_VIDEO_UPLOADS,
+			FEATURE_GOOGLE_AD_CREDITS,
+			WORDADS_INSTANT
+		]
 	},
 
 	[ PLAN_BUSINESS ]: {
@@ -65,6 +82,19 @@ export const plansList = {
 		getProductId: () => 1008,
 		getDescription: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, and Google Analytics.' ),
 		getDescriptionWithWordAdsCredit: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, Google Analytics, and $200 advertising credit.' ),
+		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
+			FEATURE_FREE_SITE,
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_UNLIMITED_PREMIUM_THEMES,
+			FEATURE_UNLIMITED_STORAGE,
+			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+			FEATURE_NO_ADS,
+			FEATURE_CUSTOM_DESIGN,
+			FEATURE_VIDEO_UPLOADS,
+			FEATURE_GOOGLE_AD_CREDITS,
+			WORDADS_INSTANT,
+			FEATURE_GOOGLE_ANALYTICS
+		]
 	},
 
 	[ PLAN_JETPACK_FREE ]: {},
@@ -85,43 +115,36 @@ const allPlans = [
 export const featuresList = {
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
 		getTitle: () => i18n.translate( 'Google Analytics' ),
-		order: 9,
 		plans: [ PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_UNLIMITED_STORAGE ]: {
 		getTitle: () => i18n.translate( 'Unlimited Storage' ),
-		order: 4,
 		plans: [ PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_CUSTOM_DOMAIN ]: {
 		getTitle: () => i18n.translate( 'Custom Domain' ),
-		order: 2,
 		plans: allPaidPlans
 	},
 
 	[ FEATURE_UNLIMITED_PREMIUM_THEMES ]: {
 		getTitle: () => i18n.translate( 'Unlimited Premium Themes' ),
-		order: 3,
 		plans: [ PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_VIDEO_UPLOADS ]: {
 		getTitle: () => i18n.translate( 'VideoPress' ),
-		order: 8,
 		plans: allPaidPlans
 	},
 
 	[ FEATURE_CUSTOM_DESIGN ]: {
 		getTitle: () => i18n.translate( 'Custom Design' ),
-		order: 7,
 		plans: allPaidPlans
 	},
 
 	[ FEATURE_NO_ADS ]: {
 		getTitle: () => i18n.translate( 'No Ads' ),
-		order: 6,
 		plans: allPaidPlans
 	},
 
@@ -141,49 +164,41 @@ export const featuresList = {
 	[ WORDADS_INSTANT ]: {
 		getTitle: () => i18n.translate( 'Monetize Your Site' ),
 		getDescription: () => i18n.translate( 'Add advertising to your site through our WordAds program and get paid.' ),
-		order: 11,
 		plans: allPaidPlans
 	},
 
 	[ FEATURE_FREE_SITE ]: {
 		getTitle: () => i18n.translate( 'Free site' ),
-		order: 1,
 		plans: allPlans
 	},
 
 	[ FEATURE_WP_SUBDOMAIN ]: {
 		getTitle: () => i18n.translate( 'WordPress.com subdomain' ),
-		order: 2,
 		plans: [ PLAN_FREE ]
 	},
 
 	[ FEATURE_FREE_THEMES ]: {
 		getTitle: () => i18n.translate( 'Hundreds of free themes' ),
-		order: 3,
 		plans: [ PLAN_FREE, PLAN_PREMIUM ]
 	},
 
 	[ FEATURE_3GB_STORAGE ]: {
 		getTitle: () => i18n.translate( '3GB of storage' ),
-		order: 4,
 		plans: [ PLAN_FREE ]
 	},
 
 	[ FEATURE_13GB_STORAGE ]: {
 		getTitle: () => i18n.translate( '13GB of storage' ),
-		order: 4,
 		plans: [ PLAN_PREMIUM ]
 	},
 
 	[ FEATURE_COMMUNITY_SUPPORT ]: {
 		getTitle: () => i18n.translate( 'Community support' ),
-		order: 5,
 		plans: [ PLAN_FREE ]
 	},
 
 	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {
 		getTitle: () => i18n.translate( 'Email and live chat support' ),
-		order: 5,
 		plans: allPaidPlans
 	}
 };
@@ -200,9 +215,9 @@ export const getPlanObject = planName => {
 };
 
 export const getPlanFeaturesObject = planName => {
-	const planFeatures = filter( featuresList, obj =>
-		obj.plans.indexOf( planName ) !== -1
-	);
+	const planFeaturesList = plansList[ planName ].getFeatures();
 
-	return sortBy( planFeatures, 'order' );
+	return planFeaturesList.map( featureConstant =>
+		featuresList[ featureConstant ]
+	);
 };

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -25,14 +25,21 @@ export const PLAN_MONTHLY_PERIOD = 31;
 export const PLAN_ANNUAL_PERIOD  = 365;
 
 // features constants
-export const FEATURE_CUSTOM_DESIGN = 'custom-design';
+export const FEATURE_FREE_SITE = 'free-site';
+export const FEATURE_WP_SUBDOMAIN = 'wordpress-subdomain';
 export const FEATURE_CUSTOM_DOMAIN = 'custom-domain';
+export const FEATURE_FREE_THEMES = 'free-themes';
+export const FEATURE_UNLIMITED_PREMIUM_THEMES = 'premium-themes';
+export const FEATURE_3GB_STORAGE = '3gb-storage';
+export const FEATURE_13GB_STORAGE = '13gb-storage';
+export const FEATURE_UNLIMITED_STORAGE = 'unlimited-storage';
+export const FEATURE_COMMUNITY_SUPPORT = 'community-support';
+export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT = 'email-live-chat-support';
+export const FEATURE_CUSTOM_DESIGN = 'custom-design';
 export const FEATURE_GOOGLE_ANALYTICS = 'google-analytics';
 export const FEATURE_GOOGLE_AD_CREDITS = 'google-ad-credits';
 export const FEATURE_LIVE_CHAT_SUPPORT = 'live-chat-support';
 export const FEATURE_NO_ADS = 'no-adverts';
-export const FEATURE_UNLIMITED_PREMIUM_THEMES = 'premium-themes';
-export const FEATURE_UNLIMITED_STORAGE = 'unlimited-storage';
 export const FEATURE_VIDEO_UPLOADS = 'video-upload';
 export const WORDADS_INSTANT = 'wordads-instant';
 
@@ -64,6 +71,12 @@ export const plansList = {
 };
 
 const allPaidPlans = [
+	PLAN_PREMIUM,
+	PLAN_BUSINESS
+];
+
+const allPlans = [
+	PLAN_FREE,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS
 ];
@@ -124,6 +137,41 @@ export const featuresList = {
 	[ WORDADS_INSTANT ]: {
 		getTitle: () => i18n.translate( 'Monetize Your Site' ),
 		getDescription: () => i18n.translate( 'Add advertising to your site through our WordAds program and get paid.' ),
+		plans: allPaidPlans
+	},
+
+	[ FEATURE_FREE_SITE ]: {
+		getTitle: () => i18n.translate( 'Free site' ),
+		plans: allPlans
+	},
+
+	[ FEATURE_WP_SUBDOMAIN ]: {
+		getTitle: () => i18n.translate( 'WordPress.com subdomain' ),
+		plans: [ PLAN_FREE ]
+	},
+
+	[ FEATURE_FREE_THEMES ]: {
+		getTitle: () => i18n.translate( 'Hundreds of free themes' ),
+		plans: [ PLAN_FREE, PLAN_PREMIUM ]
+	},
+
+	[ FEATURE_3GB_STORAGE ]: {
+		getTitle: () => i18n.translate( '3GB of storage' ),
+		plans: [ PLAN_FREE ]
+	},
+
+	[ FEATURE_13GB_STORAGE ]: {
+		getTitle: () => i18n.translate( '13GB of storage' ),
+		plans: [ PLAN_PREMIUM ]
+	},
+
+	[ FEATURE_COMMUNITY_SUPPORT ]: {
+		getTitle: () => i18n.translate( 'Community support' ),
+		plans: [ PLAN_FREE ]
+	},
+
+	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {
+		getTitle: () => i18n.translate( 'Email and live chat support' ),
 		plans: allPaidPlans
 	}
 };

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import i18n from 'i18n-calypso';
 import filter from 'lodash/filter';
+import sortBy from 'lodash/sortBy';
 
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
@@ -84,42 +85,44 @@ const allPlans = [
 export const featuresList = {
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
 		getTitle: () => i18n.translate( 'Google Analytics' ),
+		order: 9,
 		plans: [ PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_UNLIMITED_STORAGE ]: {
 		getTitle: () => i18n.translate( 'Unlimited Storage' ),
+		order: 4,
 		plans: [ PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_CUSTOM_DOMAIN ]: {
 		getTitle: () => i18n.translate( 'Custom Domain' ),
+		order: 2,
 		plans: allPaidPlans
 	},
 
 	[ FEATURE_UNLIMITED_PREMIUM_THEMES ]: {
 		getTitle: () => i18n.translate( 'Unlimited Premium Themes' ),
+		order: 3,
 		plans: [ PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_VIDEO_UPLOADS ]: {
 		getTitle: () => i18n.translate( 'VideoPress' ),
+		order: 8,
 		plans: allPaidPlans
 	},
 
 	[ FEATURE_CUSTOM_DESIGN ]: {
 		getTitle: () => i18n.translate( 'Custom Design' ),
+		order: 7,
 		plans: allPaidPlans
 	},
 
 	[ FEATURE_NO_ADS ]: {
 		getTitle: () => i18n.translate( 'No Ads' ),
+		order: 6,
 		plans: allPaidPlans
-	},
-
-	[ FEATURE_LIVE_CHAT_SUPPORT ]: {
-		getTitle: () => i18n.translate( 'Live Chat Support' ),
-		plans: [ PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_GOOGLE_AD_CREDITS ]: {
@@ -131,47 +134,56 @@ export const featuresList = {
 				hr: <hr className="plans-compare__info-hr"/>
 			}
 		} ),
+		order: 10,
 		plans: allPaidPlans
 	},
 
 	[ WORDADS_INSTANT ]: {
 		getTitle: () => i18n.translate( 'Monetize Your Site' ),
 		getDescription: () => i18n.translate( 'Add advertising to your site through our WordAds program and get paid.' ),
+		order: 11,
 		plans: allPaidPlans
 	},
 
 	[ FEATURE_FREE_SITE ]: {
 		getTitle: () => i18n.translate( 'Free site' ),
+		order: 1,
 		plans: allPlans
 	},
 
 	[ FEATURE_WP_SUBDOMAIN ]: {
 		getTitle: () => i18n.translate( 'WordPress.com subdomain' ),
+		order: 2,
 		plans: [ PLAN_FREE ]
 	},
 
 	[ FEATURE_FREE_THEMES ]: {
 		getTitle: () => i18n.translate( 'Hundreds of free themes' ),
+		order: 3,
 		plans: [ PLAN_FREE, PLAN_PREMIUM ]
 	},
 
 	[ FEATURE_3GB_STORAGE ]: {
 		getTitle: () => i18n.translate( '3GB of storage' ),
+		order: 4,
 		plans: [ PLAN_FREE ]
 	},
 
 	[ FEATURE_13GB_STORAGE ]: {
 		getTitle: () => i18n.translate( '13GB of storage' ),
+		order: 4,
 		plans: [ PLAN_PREMIUM ]
 	},
 
 	[ FEATURE_COMMUNITY_SUPPORT ]: {
 		getTitle: () => i18n.translate( 'Community support' ),
+		order: 5,
 		plans: [ PLAN_FREE ]
 	},
 
 	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {
 		getTitle: () => i18n.translate( 'Email and live chat support' ),
+		order: 5,
 		plans: allPaidPlans
 	}
 };
@@ -188,7 +200,9 @@ export const getPlanObject = planName => {
 };
 
 export const getPlanFeaturesObject = planName => {
-	return filter( featuresList, obj =>
+	const planFeatures = filter( featuresList, obj =>
 		obj.plans.indexOf( planName ) !== -1
 	);
+
+	return sortBy( planFeatures, 'order' );
 };

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1,8 +1,11 @@
 /** @ssr-ready **/
 
+/**
+ * External dependencies
+ */
 import React from 'react';
-
 import i18n from 'i18n-calypso';
+import filter from 'lodash/filter';
 
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
@@ -134,4 +137,10 @@ export const getPlanObject = planName => {
 	} );
 
 	return objectPlan;
+};
+
+export const getPlanFeaturesObject = planName => {
+	return filter( featuresList, obj =>
+		obj.plans.indexOf( planName ) !== -1
+	);
 };

--- a/client/my-sites/plan-features/docs/example.jsx
+++ b/client/my-sites/plan-features/docs/example.jsx
@@ -11,6 +11,7 @@ import PlanFeaturesHeader from '../header';
 import PlanFeaturesItem from '../item';
 import PlanFeaturesItemList from '../list';
 import PlanFeaturesFooter from '../footer';
+import PlanFeatures from '../';
 import { plansList, PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
 import SelectDropdown from 'components/select-dropdown';
 
@@ -87,6 +88,13 @@ export default React.createClass( {
 					<a href="/devdocs/app-components/plan-features">Plan Features</a>
 
 				</h2>
+				<PlanFeatures
+					current
+					title={ plansList[ PLAN_FREE ].getTitle() }
+					planType={ PLAN_FREE }
+					price={ priceFree }
+					billingTimeFrame={ 'for life' }
+				/>
 				<div>
 					<SelectDropdown
 						options={ options }
@@ -101,6 +109,8 @@ export default React.createClass( {
 						rawPrice={ priceData.free }
 						currencyCode={ priceData.currencyCode }
 						billingTimeFrame={ 'for life' }
+						description={ 'Get a free blog and be on your way to publishing your first post in less' +
+							' than five minutes.' }
 					/>
 					<PlanFeaturesItemList>
 						<PlanFeaturesItem>Free site</PlanFeaturesItem>
@@ -109,12 +119,6 @@ export default React.createClass( {
 						<PlanFeaturesItem>3GB of storage</PlanFeaturesItem>
 						<PlanFeaturesItem>Community Support</PlanFeaturesItem>
 					</PlanFeaturesItemList>
-					<PlanFeaturesFooter
-						current
-						description={ 'Get a free blog and be on your way to publishing your first post in less' +
-							' than five minutes.' }
-					/>
-					<br />
 				</div>
 				<div>
 					<PlanFeaturesHeader

--- a/client/my-sites/plan-features/docs/example.jsx
+++ b/client/my-sites/plan-features/docs/example.jsx
@@ -7,12 +7,11 @@ import PureRenderMixin from 'react-pure-render/mixin';
 /**
  * Internal dependencies
  */
-import PlanFeaturesHeader from '../header';
-import PlanFeaturesItem from '../item';
-import PlanFeaturesItemList from '../list';
-import PlanFeaturesFooter from '../footer';
 import PlanFeatures from '../';
 import { plansList, PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
+import QueryPlans from 'components/data/query-plans';
+
+// TODO: use SelectDropdown to select currency.
 import SelectDropdown from 'components/select-dropdown';
 
 const options = [
@@ -88,87 +87,10 @@ export default React.createClass( {
 					<a href="/devdocs/app-components/plan-features">Plan Features</a>
 
 				</h2>
-				<PlanFeatures
-					current
-					title={ plansList[ PLAN_FREE ].getTitle() }
-					planType={ PLAN_FREE }
-					price={ priceFree }
-					billingTimeFrame={ 'for life' }
-				/>
-				<div>
-					<SelectDropdown
-						options={ options }
-						onSelect={ this.onDropdownSelect } />
-					<br />
-				</div>
-				<div>
-					<PlanFeaturesHeader
-						current
-						title={ plansList[ PLAN_FREE ].getTitle() }
-						planType={ PLAN_FREE }
-						rawPrice={ priceData.free }
-						currencyCode={ priceData.currencyCode }
-						billingTimeFrame={ 'for life' }
-						description={ 'Get a free blog and be on your way to publishing your first post in less' +
-							' than five minutes.' }
-					/>
-					<PlanFeaturesItemList>
-						<PlanFeaturesItem>Free site</PlanFeaturesItem>
-						<PlanFeaturesItem>WordPress.com subdomain</PlanFeaturesItem>
-						<PlanFeaturesItem>Hundreds of free themes</PlanFeaturesItem>
-						<PlanFeaturesItem>3GB of storage</PlanFeaturesItem>
-						<PlanFeaturesItem>Community Support</PlanFeaturesItem>
-					</PlanFeaturesItemList>
-				</div>
-				<div>
-					<PlanFeaturesHeader
-						popular
-						title={ plansList[ PLAN_PREMIUM ].getTitle() }
-						planType={ PLAN_PREMIUM }
-						rawPrice={ priceData.premium }
-						currencyCode={ priceData.currencyCode }
-						billingTimeFrame={ 'per month, billed yearly' }
-					/>
-					<PlanFeaturesItemList>
-						<PlanFeaturesItem>Free site</PlanFeaturesItem>
-						<PlanFeaturesItem>Your custom domain</PlanFeaturesItem>
-						<PlanFeaturesItem>Hundreds of free themes</PlanFeaturesItem>
-						<PlanFeaturesItem>13GB of storage</PlanFeaturesItem>
-						<PlanFeaturesItem>Email and live chat support</PlanFeaturesItem>
-						<PlanFeaturesItem>No ads</PlanFeaturesItem>
-						<PlanFeaturesItem>Advanced design customization</PlanFeaturesItem>
-						<PlanFeaturesItem>VideoPress</PlanFeaturesItem>
-					</PlanFeaturesItemList>
-					<PlanFeaturesFooter
-						description={ 'Your own domain name, powerful customization options, and lots of space' +
-							' for audio and video.' }
-					/>
-					<br />
-				</div>
-				<div>
-					<PlanFeaturesHeader
-						title={ plansList[ PLAN_BUSINESS ].getTitle() }
-						planType={ PLAN_BUSINESS }
-						rawPrice={ priceData.business }
-						currencyCode={ priceData.currencyCode }
-						billingTimeFrame={ 'per month, billed yearly' }
-					/>
-					<PlanFeaturesItemList>
-						<PlanFeaturesItem>Free site</PlanFeaturesItem>
-						<PlanFeaturesItem>Your custom domain</PlanFeaturesItem>
-						<PlanFeaturesItem>Unlimited premium themes</PlanFeaturesItem>
-						<PlanFeaturesItem>Unlimited storage</PlanFeaturesItem>
-						<PlanFeaturesItem>Email and live chat support</PlanFeaturesItem>
-						<PlanFeaturesItem>No ads</PlanFeaturesItem>
-						<PlanFeaturesItem>Advanced design customization</PlanFeaturesItem>
-						<PlanFeaturesItem>VideoPress</PlanFeaturesItem>
-						<PlanFeaturesItem>Google Analytics</PlanFeaturesItem>
-					</PlanFeaturesItemList>
-					<PlanFeaturesFooter
-						description={ 'Everything included with Premium, as well as live chat support,' +
-							' and unlimited access to our premium themes.' }
-					/>
-				</div>
+				<QueryPlans />
+				<PlanFeatures plan={ PLAN_FREE } /* onClick={ this.upgradePlan } */ />
+				<PlanFeatures plan={ PLAN_PREMIUM } /* onClick={ this.upgradePlan } */ />
+				<PlanFeatures plan={ PLAN_BUSINESS } /* onClick={ this.upgradePlan } */ />
 			</div>
 		);
 	}

--- a/client/my-sites/plan-features/docs/example.jsx
+++ b/client/my-sites/plan-features/docs/example.jsx
@@ -8,7 +8,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
  * Internal dependencies
  */
 import PlanFeatures from '../';
-import { plansList, PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
 import QueryPlans from 'components/data/query-plans';
 
 // TODO: use SelectDropdown to select currency.

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import PlanFeaturesHeader from './header';
+import PlanFeaturesItemList from './list';
+import PlanFeaturesItem from './item';
+import PlanFeaturesFooter from './footer';
+
+class PlanFeatures extends Component {
+	render() {
+		const { popular, current, features, description } = this.props;
+
+		const classes = classNames( 'plan-features', {
+			'is-popular': popular
+		} );
+
+		return (
+			<div className={ classes } >
+				<PlanFeaturesHeader { ...this.props } />
+				<PlanFeaturesItemList>
+					{
+						features.map( ( feature ) =>
+							<PlanFeaturesItem>{ feature.title }</PlanFeaturesItem>
+						)
+					}
+				</PlanFeaturesItemList>
+				<PlanFeaturesFooter current={ current } description={ description } />
+			</div>
+		);
+	}
+}
+
+PlanFeatures.propTypes = {
+	current: PropTypes.bool,
+	popular: PropTypes.bool,
+	features: PropTypes.array.isRequired,
+	description: PropTypes.string.isRequired
+};
+
+PlanFeaturesHeader.defaultProps = {
+	current: false,
+	popular: false
+};

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -5,6 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -20,6 +21,10 @@ import { plansList, getPlanFeaturesObject, PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINES
 
 class PlanFeatures extends Component {
 	render() {
+		if ( ! this.props.planObject ) {
+			return null;
+		}
+
 		const {
 			planName,
 			rawPrice,
@@ -75,6 +80,7 @@ PlanFeaturesHeader.defaultProps = {
 export default connect( ( state, ownProps ) => {
 	const planProductId = plansList[ ownProps.plan ].getProductId();
 	const selectedSiteId = getSelectedSiteId( state );
+	const planObject = getPlan( state, planProductId );
 
 	return {
 		planName: ownProps.plan,
@@ -83,7 +89,8 @@ export default connect( ( state, ownProps ) => {
 		features: getPlanFeaturesObject( ownProps.plan ),
 		rawPrice: getPlanRawPrice( state, planProductId /**, get from abtest **/ ),
 		planConstantObj: plansList[ ownProps.plan ],
-		billingTimeFrame: getPlan( state, planProductId ).bill_period_label
+		billingTimeFrame: get( planObject, 'bill_period_label', '' ),
+		planObject: planObject
 	};
 } )( PlanFeatures );
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -24,8 +24,8 @@ class PlanFeatures extends Component {
 			rawPrice,
 			popular,
 			current,
+			planConstantObj,
 			features,
-			description,
 			billingTimeFrame
 		} = this.props;
 
@@ -49,7 +49,7 @@ class PlanFeatures extends Component {
 						)
 					}
 				</PlanFeaturesItemList>
-				<PlanFeaturesFooter current={ current } description={ description } />
+				<PlanFeaturesFooter current={ current } description={ planConstantObj.getDescription() } />
 			</div>
 		);
 	}
@@ -70,8 +70,8 @@ export default connect( ( state, ownProps ) => {
 		current: sitePlanObj.currentPlan,
 		popular: ownProps.plan === PLAN_PREMIUM,
 		features: getPlanFeaturesObject( ownProps.plan ),
-		description: plansList[ ownProps.plan ].getDescription(),
-		rawPrice: getPlanRawPrice( state, planProductId ),
+		rawPrice: getPlanRawPrice( state, planProductId /**, get from abtest **/ ),
+		planConstantObj: plansList[ ownProps.plan ],
 		billingTimeFrame: getPlan( state, planProductId ).bill_period_label
 	};
 } )( PlanFeatures );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -12,9 +12,9 @@ import PlanFeaturesHeader from './header';
 import PlanFeaturesItemList from './list';
 import PlanFeaturesItem from './item';
 import PlanFeaturesFooter from './footer';
-import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { getPlanRawPrice , getPlan } from 'state/plans/selectors';
-import sitesFactory from 'lib/sites-list';
+import { isCurrentSitePlan } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getPlanRawPrice, getPlan } from 'state/plans/selectors';
 import { plansList, getPlanFeaturesObject, PLAN_PREMIUM } from 'lib/plans/constants';
 
 class PlanFeatures extends Component {
@@ -58,17 +58,11 @@ class PlanFeatures extends Component {
 
 export default connect( ( state, ownProps ) => {
 	const planProductId = plansList[ ownProps.plan ].getProductId();
-	let sitePlanObj = getCurrentPlan( state, sitesFactory().getSelectedSite() );
-
-	if ( sitePlanObj === null ) {
-		sitePlanObj = {
-			currentPlan: false
-		};
-	}
+	const selectedSiteId = getSelectedSiteId( state );
 
 	return {
 		planName: ownProps.plan,
-		current: sitePlanObj.currentPlan,
+		current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
 		popular: ownProps.plan === PLAN_PREMIUM,
 		features: getPlanFeaturesObject( ownProps.plan ),
 		rawPrice: getPlanRawPrice( state, planProductId /**, get from abtest **/ ),

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ import PlanFeaturesFooter from './footer';
 import { isCurrentSitePlan } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPlanRawPrice, getPlan } from 'state/plans/selectors';
-import { plansList, getPlanFeaturesObject, PLAN_PREMIUM } from 'lib/plans/constants';
+import { plansList, getPlanFeaturesObject, PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
 
 class PlanFeatures extends Component {
 	render() {
@@ -26,7 +27,8 @@ class PlanFeatures extends Component {
 			current,
 			planConstantObj,
 			features,
-			billingTimeFrame
+			billingTimeFrame,
+			onUpgradeClick
 		} = this.props;
 
 		const classes = classNames( 'plan-features', {
@@ -42,6 +44,7 @@ class PlanFeatures extends Component {
 					planType={ planName }
 					rawPrice={ rawPrice }
 					billingTimeFrame={ billingTimeFrame }
+					onClick={ onUpgradeClick }
 				/>
 				<PlanFeaturesItemList>
 					{
@@ -50,11 +53,24 @@ class PlanFeatures extends Component {
 						)
 					}
 				</PlanFeaturesItemList>
-				<PlanFeaturesFooter current={ current } description={ planConstantObj.getDescription() } />
+				<PlanFeaturesFooter
+					current={ current }
+					description={ planConstantObj.getDescription() }
+					onUpgradeClick={ onUpgradeClick }
+				/>
 			</div>
 		);
 	}
 }
+
+PlanFeatures.propTypes = {
+	onUgradeClick: PropTypes.func,
+	plan: React.PropTypes.oneOf( [ PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS ] ).isRequired
+};
+
+PlanFeaturesHeader.defaultProps = {
+	onUpgradeClick: noop
+};
 
 export default connect( ( state, ownProps ) => {
 	const planProductId = plansList[ ownProps.plan ].getProductId();

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -44,8 +44,8 @@ class PlanFeatures extends Component {
 				/>
 				<PlanFeaturesItemList>
 					{
-						features.map( ( feature ) =>
-							<PlanFeaturesItem>{ feature.getTitle() }</PlanFeaturesItem>
+						features.map( ( feature, index ) =>
+							<PlanFeaturesItem key={ index }>{ feature.getTitle() }</PlanFeaturesItem>
 						)
 					}
 				</PlanFeaturesItemList>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -37,6 +37,7 @@ class PlanFeatures extends Component {
 			<div className={ classes } >
 				<PlanFeaturesHeader
 					current={ current }
+					popular={ popular }
 					title={ plansList[ planName ].getTitle() }
 					planType={ planName }
 					rawPrice={ rawPrice }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -36,7 +36,7 @@ class PlanFeatures extends Component {
 		return (
 			<div className={ classes } >
 				<PlanFeaturesHeader
-					current
+					current={ current }
 					title={ plansList[ planName ].getTitle() }
 					planType={ planName }
 					rawPrice={ rawPrice }
@@ -57,10 +57,17 @@ class PlanFeatures extends Component {
 
 export default connect( ( state, ownProps ) => {
 	const planProductId = plansList[ ownProps.plan ].getProductId();
+	let sitePlanObj = getCurrentPlan( state, sitesFactory().getSelectedSite() );
+
+	if ( sitePlanObj === null ) {
+		sitePlanObj = {
+			currentPlan: false
+		};
+	}
 
 	return {
 		planName: ownProps.plan,
-		current: getCurrentPlan( state, sitesFactory().getSelectedSite() ),
+		current: sitePlanObj.currentPlan,
 		popular: ownProps.plan === PLAN_PREMIUM,
 		features: getPlanFeaturesObject( ownProps.plan ),
 		description: plansList[ ownProps.plan ].getDescription(),

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -1,3 +1,29 @@
+.plan-features {
+	margin: 0 0 16px;
+	border: solid 1px lighten( $gray, 27% );
+	background-color: lighten( $gray, 35% );
+
+	&.is-popular {
+		margin-top: 35px; // popular banner + margin
+	}
+
+	@include breakpoint( ">1040px" ) {
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		flex: 1;
+		margin: 0 0 24px 24px;
+
+		&.is-popular {
+			margin-top: 0;
+		}
+
+		&:first-child {
+			margin-left: 0;
+		}
+	}
+}
+
 .plan-features__header {
 	position: relative;
 	display: flex;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -1,10 +1,14 @@
+$header-banner-height: 20px;
+
 .plan-features {
 	margin: 0 0 16px;
 	border: solid 1px lighten( $gray, 27% );
 	background-color: lighten( $gray, 35% );
 
 	&.is-popular {
-		margin-top: 35px; // popular banner + margin
+		$top-margin: 15px;
+
+		margin-top: $header-banner-height + $top-margin;
 	}
 
 	@include breakpoint( ">1040px" ) {
@@ -113,7 +117,7 @@
 	padding: 0 8px;
 	background: $gray-dark;
 	font-size: 10px;
-	line-height: 20px;
+	line-height: $header-banner-height;
 	text-align: center;
 	text-transform: uppercase;
 	color: $white;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -1,4 +1,4 @@
-$header-banner-height: 20px;
+$plan-features-header-banner-height: 20px;
 
 .plan-features {
 	margin: 0 0 16px;
@@ -8,7 +8,7 @@ $header-banner-height: 20px;
 	&.is-popular {
 		$top-margin: 15px;
 
-		margin-top: $header-banner-height + $top-margin;
+		margin-top: $plan-features-header-banner-height + $top-margin;
 	}
 
 	@include breakpoint( ">1040px" ) {
@@ -117,7 +117,7 @@ $header-banner-height: 20px;
 	padding: 0 8px;
 	background: $gray-dark;
 	font-size: 10px;
-	line-height: $header-banner-height;
+	line-height: $plan-features-header-banner-height;
 	text-align: center;
 	text-transform: uppercase;
 	color: $white;


### PR DESCRIPTION
Add `PlanFeatures` component as a part of bigger plans-redesign started in #5715.

## Example usage

```js
import PlanFeatures from 'my-sites/plan-features';
import { PLAN_FREE } from 'lib/plans/constants';
import QueryPlans from 'components/data/query-plans';

export default MyComponent() =>
   <div>
      <QueryPlans />
      <PlanFeatures plan={ PLAN_FREE } />
   </div>
```

## Testing

1. `PlanFeatures` was added to devdocs into App Components;
2. Navigate to http://calypso.localhost:3000/devdocs/app-components/plan-features;
3. See the redesigned plan components (free, premium and business);
4. Look for errors;
5. Is everything fine?

## Screenshots

![selection_022](https://cloud.githubusercontent.com/assets/4988512/16093020/726d3ef0-333a-11e6-9d47-8d5160a9cb96.jpg)

![selection_023](https://cloud.githubusercontent.com/assets/4988512/16093030/7eeb6ec2-333a-11e6-9274-4796f90bab43.jpg)

**Note:** In the second screenshot, the Business plan has a strange price. This is probably related to the recent PR #6001 by @gwwar but she's already working on a better solution here: #6046. That's why I've left it as it is.

If it is not related to that, I'll fix it.

Although this is still work in progress, I think I've arrived to a presentable code so please review. :)

cc @gwwar @rralian @mtias @artpi @retrofox 

Test live: https://calypso.live/?branch=add/plan-features-plan