### PR TITLE
Stats: update all-time component to use QuerySiteStats.

### DIFF
--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -66,34 +66,32 @@ class StatsAllTime extends Component {
 			<div>
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" query={ query } /> }
 				<SectionHeader label={ translate( 'All-time posts, views, and visitors' ) }></SectionHeader>
-				<Card className={ classNames( 'stats-module', 'stats-all-time', classes ) }>
-					<div className="module-content">
-						<StatsTabs borderless>
-							<StatsTab
-								gridicon="posts"
-								label={ translate( 'Posts' ) }
-								loading={ isLoading }
-								value={ posts } />
-							<StatsTab
-								gridicon="visible"
-								label={ translate( 'Views' ) }
-								loading={ isLoading }
-								value={ views } />
-							<StatsTab
-								gridicon="user"
-								label={ translate( 'Visitors' ) }
-								loading={ isLoading }
-								value={ visitors } />
-							<StatsTab
-								className="is-best"
-								gridicon="trophy"
-								label={ translate( 'Best Views Ever' ) }
-								loading={ isLoading }
-								value={ viewsBestDayTotal }>
-								<span className="stats-all-time__best-day">{ bestDay }</span>
-							</StatsTab>
-						</StatsTabs>
-					</div>
+				<Card className={ classNames( 'stats-module', 'all-time', classes ) }>
+					<StatsTabs borderless>
+						<StatsTab
+							gridicon="posts"
+							label={ translate( 'Posts' ) }
+							loading={ isLoading }
+							value={ posts } />
+						<StatsTab
+							gridicon="visible"
+							label={ translate( 'Views' ) }
+							loading={ isLoading }
+							value={ views } />
+						<StatsTab
+							gridicon="user"
+							label={ translate( 'Visitors' ) }
+							loading={ isLoading }
+							value={ visitors } />
+						<StatsTab
+							className="all-time__is-best"
+							gridicon="trophy"
+							label={ translate( 'Best Views Ever' ) }
+							loading={ isLoading }
+							value={ viewsBestDayTotal }>
+							<span className="all-time__best-day">{ bestDay }</span>
+						</StatsTab>
+					</StatsTabs>
 				</Card>
 			</div>
 		);

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -3,47 +3,66 @@
 */
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-import observe from 'lib/mixins/data-observe';
 import Card from 'components/card';
 import User from 'lib/user';
 import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 import SectionHeader from 'components/section-header';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsForQuery
+} from 'state/stats/lists/selectors';
 
 const user = User();
 
-export default React.createClass( {
-	displayName: 'StatsAllTime',
-
-	mixins: [ observe( 'allTimeList' ) ],
+const StatsAllTime = React.createClass( {
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
-		allTimeList: PropTypes.object.isRequired
+		siteId: PropTypes.number,
+		requesting: PropTypes.bool,
+		query: PropTypes.object,
+		posts: PropTypes.number,
+		views: PropTypes.number,
+		views_best_day: PropTypes.string,
+		views_best_day_total: PropTypes.number
 	},
 
 	render() {
-		const allTimeList = this.props.allTimeList.response;
-		const isLoading = this.props.allTimeList.isLoading();
+		const {
+			siteId,
+			requesting,
+			posts,
+			views,
+			visitors,
+			views_best_day,
+			views_best_day_total,
+			query
+		} = this.props;
+		const isLoading = requesting && ! views;
 
 		let bestDay;
 
-		if ( allTimeList['best-views'] && allTimeList['best-views'].day ) {
-			bestDay = this.moment( allTimeList['best-views'].day ).format( 'LL' );
+		if ( views_best_day && ! isLoading ) {
+			bestDay = this.moment( views_best_day ).format( 'LL' );
 		}
 
 		const classes = {
-			'is-loading': this.props.allTimeList.isLoading(),
+			'is-loading': requesting,
 			'is-non-en': user.data.localeSlug && ( user.data.localeSlug !== 'en' )
 		};
 
-		const bestViews = allTimeList['best-views'] ? allTimeList['best-views'].count : null;
-
 		return (
 			<div>
+				{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" query={ query } /> }
 				<SectionHeader label={ this.translate( 'All-time posts, views, and visitors' ) }></SectionHeader>
 				<Card className={ classNames( 'stats-module', 'stats-all-time', classes ) }>
 					<div className="module-content">
@@ -52,23 +71,23 @@ export default React.createClass( {
 								gridicon="posts"
 								label={ this.translate( 'Posts' ) }
 								loading={ isLoading }
-								value={ allTimeList.posts } />
+								value={ posts } />
 							<StatsTab
 								gridicon="visible"
 								label={ this.translate( 'Views' ) }
 								loading={ isLoading }
-								value={ allTimeList.views } />
+								value={ views } />
 							<StatsTab
 								gridicon="user"
 								label={ this.translate( 'Visitors' ) }
 								loading={ isLoading }
-								value={ allTimeList.visitors } />
+								value={ visitors } />
 							<StatsTab
 								className="is-best"
 								gridicon="trophy"
 								label={ this.translate( 'Best Views Ever' ) }
 								loading={ isLoading }
-								value={ bestViews }>
+								value={ views_best_day_total }>
 								<span className="stats-all-time__best-day">{ bestDay }</span>
 							</StatsTab>
 						</StatsTabs>
@@ -78,3 +97,27 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const query = {};
+	const allTimeData = getSiteStatsForQuery( state, siteId, 'stats', query ) || { stats: {} };
+	const {
+		posts,
+		views,
+		visitors,
+		views_best_day,
+		views_best_day_total
+	} = allTimeData.stats;
+
+	return {
+		requesting: isRequestingSiteStatsForQuery( state, siteId, 'stats', query ),
+		query,
+		siteId,
+		posts,
+		views,
+		visitors,
+		views_best_day,
+		views_best_day_total
+	};
+} )( StatsAllTime );

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -11,7 +11,6 @@ import { localize, moment } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import User from 'lib/user';
 import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 import SectionHeader from 'components/section-header';
@@ -21,8 +20,6 @@ import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsParsedData
 } from 'state/stats/lists/selectors';
-
-const user = User();
 
 class StatsAllTime extends Component {
 
@@ -58,8 +55,7 @@ class StatsAllTime extends Component {
 		}
 
 		const classes = {
-			'is-loading': requesting,
-			'is-non-en': user.data.localeSlug && ( user.data.localeSlug !== 'en' )
+			'is-loading': requesting
 		};
 
 		return (

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -61,7 +61,7 @@ class StatsAllTime extends Component {
 		return (
 			<div>
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" query={ query } /> }
-				<SectionHeader label={ translate( 'All-time posts, views, and visitors' ) }></SectionHeader>
+				<SectionHeader label={ translate( 'All-time posts, views, and visitors' ) } />
 				<Card className={ classNames( 'stats-module', 'all-time', classes ) }>
 					<StatsTabs borderless>
 						<StatsTab

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -18,7 +18,7 @@ import QuerySiteStats from 'components/data/query-site-stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	isRequestingSiteStatsForQuery,
-	getSiteStatsParsedData
+	getSiteStatsNormalizedData
 } from 'state/stats/lists/selectors';
 
 class StatsAllTime extends Component {
@@ -97,7 +97,7 @@ class StatsAllTime extends Component {
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const query = {};
-	const allTimeData = getSiteStatsParsedData( state, siteId, 'stats', query ) || {};
+	const allTimeData = getSiteStatsNormalizedData( state, siteId, 'stats', query ) || {};
 	const allTimeStats = pick( allTimeData, [
 		'posts',
 		'views',

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -1,10 +1,11 @@
 /**
 * External dependencies
 */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import PureRenderMixin from 'react-pure-render/mixin';
+import pick from 'lodash/pick';
+import { localize, moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,41 +19,42 @@ import QuerySiteStats from 'components/data/query-site-stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	isRequestingSiteStatsForQuery,
-	getSiteStatsForQuery
+	getSiteStatsParsedData
 } from 'state/stats/lists/selectors';
 
 const user = User();
 
-const StatsAllTime = React.createClass( {
-	mixins: [ PureRenderMixin ],
+class StatsAllTime extends Component {
 
-	propTypes: {
+	static propTypes = {
+		translate: PropTypes.func,
 		siteId: PropTypes.number,
 		requesting: PropTypes.bool,
 		query: PropTypes.object,
 		posts: PropTypes.number,
 		views: PropTypes.number,
-		views_best_day: PropTypes.string,
-		views_best_day_total: PropTypes.number
-	},
+		viewsBestDay: PropTypes.string,
+		viewsBestDayTotal: PropTypes.number
+	};
 
 	render() {
 		const {
+			translate,
 			siteId,
 			requesting,
 			posts,
 			views,
 			visitors,
-			views_best_day,
-			views_best_day_total,
+			viewsBestDay,
+			viewsBestDayTotal,
 			query
 		} = this.props;
 		const isLoading = requesting && ! views;
 
 		let bestDay;
 
-		if ( views_best_day && ! isLoading ) {
-			bestDay = this.moment( views_best_day ).format( 'LL' );
+		if ( viewsBestDay && ! isLoading ) {
+			bestDay = moment( viewsBestDay ).format( 'LL' );
 		}
 
 		const classes = {
@@ -63,31 +65,31 @@ const StatsAllTime = React.createClass( {
 		return (
 			<div>
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" query={ query } /> }
-				<SectionHeader label={ this.translate( 'All-time posts, views, and visitors' ) }></SectionHeader>
+				<SectionHeader label={ translate( 'All-time posts, views, and visitors' ) }></SectionHeader>
 				<Card className={ classNames( 'stats-module', 'stats-all-time', classes ) }>
 					<div className="module-content">
 						<StatsTabs borderless>
 							<StatsTab
 								gridicon="posts"
-								label={ this.translate( 'Posts' ) }
+								label={ translate( 'Posts' ) }
 								loading={ isLoading }
 								value={ posts } />
 							<StatsTab
 								gridicon="visible"
-								label={ this.translate( 'Views' ) }
+								label={ translate( 'Views' ) }
 								loading={ isLoading }
 								value={ views } />
 							<StatsTab
 								gridicon="user"
-								label={ this.translate( 'Visitors' ) }
+								label={ translate( 'Visitors' ) }
 								loading={ isLoading }
 								value={ visitors } />
 							<StatsTab
 								className="is-best"
 								gridicon="trophy"
-								label={ this.translate( 'Best Views Ever' ) }
+								label={ translate( 'Best Views Ever' ) }
 								loading={ isLoading }
-								value={ views_best_day_total }>
+								value={ viewsBestDayTotal }>
 								<span className="stats-all-time__best-day">{ bestDay }</span>
 							</StatsTab>
 						</StatsTabs>
@@ -96,28 +98,24 @@ const StatsAllTime = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const query = {};
-	const allTimeData = getSiteStatsForQuery( state, siteId, 'stats', query ) || { stats: {} };
-	const {
-		posts,
-		views,
-		visitors,
-		views_best_day,
-		views_best_day_total
-	} = allTimeData.stats;
+	const allTimeData = getSiteStatsParsedData( state, siteId, 'stats', query ) || {};
+	const allTimeStats = pick( allTimeData, [
+		'posts',
+		'views',
+		'visitors',
+		'viewsBestDay',
+		'viewsBestDayTotal'
+	] );
 
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, 'stats', query ),
 		query,
 		siteId,
-		posts,
-		views,
-		visitors,
-		views_best_day,
-		views_best_day_total
+		...allTimeStats
 	};
-} )( StatsAllTime );
+} )( localize( StatsAllTime ) );

--- a/client/my-sites/stats/all-time/style.scss
+++ b/client/my-sites/stats/all-time/style.scss
@@ -1,4 +1,4 @@
-.stats-all-time {
+.all-time {
 
 	.stats-tab {
 
@@ -12,8 +12,8 @@
 			padding-bottom: 0;
 		}
 
-		&.is-best .gridicon,
-		&.is-best .label {
+		&.all-time__is-best .gridicon,
+		&.all-time__is-best .label {
 			color: $alert-yellow;
 		}
 
@@ -22,7 +22,7 @@
 			padding: 10px 0 5px;
 		}
 
-		.stats-all-time__best-day {
+		.all-time__best-day {
 			color: $gray-dark;
 			font-size: 11px;
 			letter-spacing: 0.1em;

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -121,7 +121,6 @@ module.exports = {
 			activeFilter = false,
 			basePath = route.sectionify( context.path ),
 			followList,
-			allTimeList,
 			insightsList,
 			commentsList,
 			tagsList,
@@ -170,7 +169,6 @@ module.exports = {
 		const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
 			? site.slug : route.getSiteFragment( context.path );
 
-		allTimeList = new StatsList( { siteID: siteId, statType: 'stats', domain: siteDomain } );
 		insightsList = new StatsList( { siteID: siteId, statType: 'statsInsights', domain: siteDomain } );
 		commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: siteDomain } );
 		tagsList = new StatsList( { siteID: siteId, statType: 'statsTags', domain: siteDomain } );
@@ -186,7 +184,6 @@ module.exports = {
 				React.createElement( StatsComponent, {
 					site: site,
 					followList: followList,
-					allTimeList: allTimeList,
 					insightsList: insightsList,
 					commentsList: commentsList,
 					tagsList: tagsList,

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -25,7 +25,6 @@ export default React.createClass( {
 	displayName: 'StatsInsights',
 
 	propTypes: {
-		allTimeList: PropTypes.object.isRequired,
 		commentFollowersList: PropTypes.object.isRequired,
 		commentsList: PropTypes.object.isRequired,
 		emailFollowersList: PropTypes.object.isRequired,
@@ -42,7 +41,6 @@ export default React.createClass( {
 
 	render() {
 		const {
-			allTimeList,
 			commentFollowersList,
 			commentsList,
 			emailFollowersList,
@@ -88,7 +86,7 @@ export default React.createClass( {
 						path={ '/stats/day' }
 						title={ this.translate( 'Today\'s Stats' ) }
 					/>
-					<AllTime allTimeList={ allTimeList } />
+					<AllTime />
 					<MostPopular insightsList={ insightsList } />
 					<DomainTip siteId={ site ? site.ID : 0 } event="stats_insights_domain" />
 					<div className="stats-nonperiodic has-recent">

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -11,7 +11,7 @@ import i18n from 'i18n-calypso';
 import createSelector from 'lib/create-selector';
 import {
 	getSerializedStatsQuery,
-	Parsers
+	normalizers
 } from './utils';
 
 /**
@@ -133,8 +133,8 @@ export const getSiteStatsParsedData = createSelector(
 	( state, siteId, statType, query ) => {
 		const data = getSiteStatsForQuery( state, siteId, statType, query );
 
-		if ( 'function' === typeof Parsers[ statType ] ) {
-			return Parsers[ statType ].call( this, data );
+		if ( 'function' === typeof normalizers[ statType ] ) {
+			return normalizers[ statType ].call( this, data );
 		}
 
 		return data;

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -10,7 +10,8 @@ import i18n from 'i18n-calypso';
  */
 import createSelector from 'lib/create-selector';
 import {
-	getSerializedStatsQuery
+	getSerializedStatsQuery,
+	Parsers
 } from './utils';
 
 /**
@@ -119,3 +120,28 @@ export function getSiteStatsPostsCountByDay( state, siteId, query, date ) {
 	return data[ date ] || null;
 }
 
+/**
+ * Returns a parsed object of statsPublicize data for a given query, or default "empty" object
+ * if no statsStreak data has been received for that site.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {Object}  query    Stats query object
+ * @return {Array}            Parsed Data for the query
+ */
+export const getSiteStatsParsedData = createSelector(
+	( state, siteId, statType, query ) => {
+		const data = getSiteStatsForQuery( state, siteId, statType, query );
+
+		if ( 'function' === typeof Parsers[ statType ] ) {
+			return Parsers[ statType ].call( this, data );
+		}
+
+		return data;
+	},
+	( state, siteId, statType, query ) => getSiteStatsForQuery( state, siteId, statType, query ),
+	( state, siteId, statType, query ) => {
+		const serializedQuery = getSerializedStatsQuery( query );
+		return [ siteId, statType, serializedQuery ].join();
+	}
+);

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -121,15 +121,15 @@ export function getSiteStatsPostsCountByDay( state, siteId, query, date ) {
 }
 
 /**
- * Returns a parsed object of statsPublicize data for a given query, or default "empty" object
- * if no statsStreak data has been received for that site.
+ * Returns normalized stats data for a given query and stat type, or the un-normalized response
+ * from the API if no normalizer method for that stats type exists in ./utils
  *
  * @param  {Object}  state    Global state tree
  * @param  {Number}  siteId   Site ID
  * @param  {Object}  query    Stats query object
- * @return {Array}            Parsed Data for the query
+ * @return {*}                Normalized Data for the query, typically an array or object
  */
-export const getSiteStatsParsedData = createSelector(
+export const getSiteStatsNormalizedData = createSelector(
 	( state, siteId, statType, query ) => {
 		const data = getSiteStatsForQuery( state, siteId, statType, query );
 

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -7,7 +7,8 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	getSerializedStatsQuery
+	getSerializedStatsQuery,
+	Parsers
 } from '../utils';
 
 describe( 'utils', () => {
@@ -33,6 +34,40 @@ describe( 'utils', () => {
 			} );
 
 			expect( serializedQuery ).to.eql( serializedQueryTwo );
+		} );
+	} );
+
+	describe( 'Parsers', () => {
+		describe( 'stats()', () => {
+			it( 'should return null if no data is passed', () => {
+				const parsedData = Parsers.stats();
+
+				expect( parsedData ).to.be.null;
+			} );
+
+			it( 'should return null if data object is missing stats attribute', () => {
+				const parsedData = Parsers.stats( { foo: false } );
+
+				expect( parsedData ).to.be.null;
+			} );
+
+			it( 'should return parsed camelCased stats object', () => {
+				const parsedData = Parsers.stats( { stats: {
+					posts: 2,
+					views: 300,
+					visitors: 400,
+					views_best_day: '2010-09-29',
+					views_best_day_total: 100
+				} } );
+
+				expect( parsedData ).to.eql( {
+					posts: 2,
+					views: 300,
+					visitors: 400,
+					viewsBestDay: '2010-09-29',
+					viewsBestDayTotal: 100
+				} );
+			} );
 		} );
 	} );
 } );

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getSerializedStatsQuery,
-	Parsers
+	normalizers
 } from '../utils';
 
 describe( 'utils', () => {
@@ -37,22 +37,22 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe( 'Parsers', () => {
+	describe( 'normalizers', () => {
 		describe( 'stats()', () => {
 			it( 'should return null if no data is passed', () => {
-				const parsedData = Parsers.stats();
+				const parsedData = normalizers.stats();
 
 				expect( parsedData ).to.be.null;
 			} );
 
 			it( 'should return null if data object is missing stats attribute', () => {
-				const parsedData = Parsers.stats( { foo: false } );
+				const parsedData = normalizers.stats( { foo: false } );
 
 				expect( parsedData ).to.be.null;
 			} );
 
 			it( 'should return parsed camelCased stats object', () => {
-				const parsedData = Parsers.stats( { stats: {
+				const parsedData = normalizers.stats( { stats: {
 					posts: 2,
 					views: 300,
 					visitors: 400,

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -3,6 +3,8 @@
  */
 import sortBy from 'lodash/sortBy';
 import toPairs from 'lodash/toPairs';
+import camelCase from 'lodash/camelCase';
+import mapKeys from 'lodash/mapKeys';
 
 /**
  * Returns a serialized stats query, used as the key in the
@@ -14,3 +16,24 @@ import toPairs from 'lodash/toPairs';
 export function getSerializedStatsQuery( query = {} ) {
 	return JSON.stringify( sortBy( toPairs( query ), ( pair ) => pair[ 0 ] ) );
 }
+
+export const Parsers = {
+	/**
+	 * Returns a parsed payload from `/sites/{ site }/stats`
+	 *
+	 * @param  {Object} data    Stats query
+	 * @return {Object?}        Parsed stats data
+	 */
+	stats: ( data ) => {
+		if ( ! data || ! data.stats ) {
+			return null;
+		}
+
+		const parseData = {};
+		mapKeys( data.stats, ( value, key ) => {
+			parseData[ camelCase( key ) ] = value;
+		} );
+
+		return parseData;
+	}
+};

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -17,23 +17,18 @@ export function getSerializedStatsQuery( query = {} ) {
 	return JSON.stringify( sortBy( toPairs( query ), ( pair ) => pair[ 0 ] ) );
 }
 
-export const Parsers = {
+export const normalizers = {
 	/**
-	 * Returns a parsed payload from `/sites/{ site }/stats`
+	 * Returns a normalized payload from `/sites/{ site }/stats`
 	 *
 	 * @param  {Object} data    Stats query
-	 * @return {Object?}        Parsed stats data
+	 * @return {Object?}        Normalized stats data
 	 */
 	stats: ( data ) => {
 		if ( ! data || ! data.stats ) {
 			return null;
 		}
 
-		const parseData = {};
-		mapKeys( data.stats, ( value, key ) => {
-			parseData[ camelCase( key ) ] = value;
-		} );
-
-		return parseData;
+		return mapKeys( data.stats, ( value, key ) => camelCase( key ) );
 	}
 };


### PR DESCRIPTION
This branch updates the All Time component on the stats insights page to use `<QuerySiteStats />` and the global state tree - with the added benefit of turning All Time Stats into a pure component.

__To Test__
- Open up a stats insights page
- Validate the All Time component has the same data, and operates as it does in production ( loading state etc )

<img width="735" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/16031344/f44d6d9c-31ae-11e6-8534-aa1283ea07f8.png">


Test live: https://calypso.live/?branch=update/stats/redux-all-time