### PR TITLE
Guided Transfer: Redirect to wp-admin flow

### DIFF
--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -117,7 +117,7 @@ export default React.createClass( {
 						onClickExport={ exportSelectedItems }
 					/>
 				</FoldableCard>
-				<GuidedTransferOptions siteSlug={ this.props.siteSlug } />
+				<GuidedTransferOptions siteSlug={ this.props.siteSlug } siteURL={ this.props.siteURL } />
 				<GuidedTransferDetails />
 				{ isExporting && <Interval onTick={ fetchStatus } period={ EVERY_SECOND } /> }
 			</div>

--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -23,7 +23,6 @@ export default React.createClass( {
 		startExport: PropTypes.func.isRequired,
 		setPostType: PropTypes.func.isRequired,
 		advancedSettingsFetch: PropTypes.func.isRequired,
-		showGuidedTransferOptions: PropTypes.bool,
 		shouldShowProgress: PropTypes.bool.isRequired,
 		postType: PropTypes.string,
 		siteSlug: PropTypes.string,
@@ -48,7 +47,6 @@ export default React.createClass( {
 			postType,
 			shouldShowProgress,
 			isExporting,
-			showGuidedTransferOptions,
 		} = this.props;
 		const siteId = this.props.site.ID;
 
@@ -119,8 +117,8 @@ export default React.createClass( {
 						onClickExport={ exportSelectedItems }
 					/>
 				</FoldableCard>
-				{ showGuidedTransferOptions && <GuidedTransferOptions siteSlug={ this.props.siteSlug } /> }
-				{ showGuidedTransferOptions && <GuidedTransferDetails /> }
+				<GuidedTransferOptions siteSlug={ this.props.siteSlug } />
+				<GuidedTransferDetails />
 				{ isExporting && <Interval onTick={ fetchStatus } period={ EVERY_SECOND } /> }
 			</div>
 		);

--- a/client/my-sites/exporter/guided-transfer-options.jsx
+++ b/client/my-sites/exporter/guided-transfer-options.jsx
@@ -19,12 +19,12 @@ export default React.createClass( {
 	},
 
 	purchaseGuidedTransfer() {
-		const { siteSlug } = this.props;
+		const { siteSlug, siteURL } = this.props;
 		if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
 			page( `/settings/export/${ siteSlug }/guided` );
 		} else {
 			// Redirect to legacy guided transfer
-			window.location = `https://${ siteSlug }/wp-admin/paid-upgrades.php?product=40&view=purchase&source=export`;
+			window.location = siteURL + '/wp-admin/paid-upgrades.php?product=40&view=purchase&source=export';
 		}
 	},
 

--- a/client/my-sites/exporter/guided-transfer-options.jsx
+++ b/client/my-sites/exporter/guided-transfer-options.jsx
@@ -8,6 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
+import config from 'config';
 import Button from 'components/forms/form-button';
 
 export default React.createClass( {
@@ -18,7 +19,13 @@ export default React.createClass( {
 	},
 
 	purchaseGuidedTransfer() {
-		page( `/settings/export/${this.props.siteSlug}/guided` );
+		const { siteSlug } = this.props;
+		if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
+			page( `/settings/export/${ siteSlug }/guided` );
+		} else {
+			// Redirect to legacy guided transfer
+			window.location = `https://${ siteSlug }/wp-admin/paid-upgrades.php?product=40&view=purchase&source=export`;
+		}
 	},
 
 	render() {

--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -7,7 +7,6 @@ import flowRight from 'lodash/flowRight';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import Exporter from './exporter';
 import { getSiteSlug } from 'state/sites/selectors';
 import {
@@ -36,7 +35,6 @@ function mapStateToProps( state ) {
 		downloadURL: state.siteSettings.exporter.downloadURL,
 		didComplete: getExportingState( state, siteId ) === States.COMPLETE,
 		didFail: getExportingState( state, siteId ) === States.FAILED,
-		showGuidedTransferOptions: config.isEnabled( 'manage/export/guided-transfer' ),
 	};
 }
 

--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -8,7 +8,7 @@ import flowRight from 'lodash/flowRight';
  * Internal dependencies
  */
 import Exporter from './exporter';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, getSiteURL } from 'state/sites/selectors';
 import {
 	shouldShowProgress,
 	getSelectedPostType,
@@ -29,6 +29,7 @@ function mapStateToProps( state ) {
 	return {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
+		siteURL: getSiteURL( state, siteId ),
 		postType: getSelectedPostType( state ),
 		shouldShowProgress: shouldShowProgress( state, siteId ),
 		isExporting: isExporting( state, siteId ),

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -96,6 +96,22 @@ export function getSiteSlug( state, siteId ) {
 }
 
 /**
+ * Returns the URL for a site, or null if the site is unknown.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?String}        Site slug
+ */
+export function getSiteURL( state, siteId ) {
+	const site = getSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	return site.URL;
+}
+
+/**
  * Returns true if we are requesting all sites.
  * @param {Object}    state  Global state tree
  * @return {Boolean}        Request State


### PR DESCRIPTION
This makes the Guided Transfer button visible regardless of the "manage/export/guided-transfer" feature flag, but redirects to the existing wp-admin flow while the Calypso flow is under development. Note that the wp-admin flow actually redirects to Calypso for payment, as you can see below:

![legacygt](https://cloud.githubusercontent.com/assets/416133/16032454/41058fb2-3249-11e6-95fe-6f6db7de54cf.gif)

Before this is ready we should:
 - [x] Ensure the legacy flow works correctly from start to finish with this redirect in place.
 - [x] Implement the blurb design to give the user context (#6048):

<img width="536" alt="screen shot 2016-06-14 at 4 03 42 pm" src="https://cloud.githubusercontent.com/assets/416133/16032496/96d30e9c-3249-11e6-9863-4fb9eab07a99.png">

