### PR TITLE
Upgrades: Enable wordadsinstant on prod

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,6 +27,7 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/ads/wordads-instant": true,
 		"manage/customize": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -24,6 +24,7 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/ads/wordads-instant": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/jetpack": true,


### PR DESCRIPTION
This enables feature introduced in #5292 for all environments initiating the test

This is already in staging, so you can use wordpress.com

## Testing

1. You need premium / business site
2. Put yourself in test  `localStorage.setItem('ABTests','{"wordadsInstantActivation_20160607":"enabled"}')`
3. Go to https://wordpress.com/plans/my-plan/your-site
4. You should see "Monetize your site". Click it, go there :)

Test live: https://calypso.live/?branch=new/wordads-instant-prod

CC @mtias @lamosty @gwwar 