### PR TITLE
Testing for the Push Notifications Redux state

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -211,8 +211,7 @@ export function sendSubscriptionToWPCOM( pushSubscription ) {
 		}
 
 		debug( 'Sending subscription to WPCOM', pushSubscription );
-
-		wpcom.undocumented().registerDevice( JSON.stringify( pushSubscription ), 'browser', 'Browser' )
+		return wpcom.undocumented().registerDevice( JSON.stringify( pushSubscription ), 'browser', 'Browser' )
 			.then( data => dispatch( {
 				type: PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE,
 				data
@@ -251,7 +250,7 @@ export function unregisterDevice() {
 			dispatch( receiveUnregisterDevice() );
 			return;
 		}
-		wpcom.undocumented().unregisterDevice( deviceId )
+		return wpcom.undocumented().unregisterDevice( deviceId )
 			.then( ( data ) => {
 				debug( 'Successfully unregistered device', data );
 				dispatch( receiveUnregisterDevice( data ) );

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -31,6 +31,7 @@ import {
 } from 'state/action-types';
 const debug = debugFactory( 'calypso:push-notifications' );
 
+// If you change this, also change the corresponding test
 const UNPERSISTED_SYSTEM_NODES = [
 	'apiReady',
 	'authorized',
@@ -128,6 +129,7 @@ function system( state = {}, action ) {
 	return state;
 }
 
+// If you change this, also change the corresponding test
 const UNPERSISTED_SETTINGS_NODES = [
 	// The dialog should default to hidden
 	'showingUnblockInstructions',

--- a/client/state/push-notifications/test/actions.js
+++ b/client/state/push-notifications/test/actions.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import nock from 'nock';
+
+/**
+ * Internal dependencies
+ */
+import {
+	PUSH_NOTIFICATIONS_API_NOT_READY,
+	PUSH_NOTIFICATIONS_RECEIVE_UNREGISTER_DEVICE,
+	PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE,
+} from 'state/action-types';
+import {
+	apiNotReady,
+	receiveUnregisterDevice,
+	sendSubscriptionToWPCOM,
+} from '../actions';
+
+import { useSandbox } from 'test/helpers/use-sinon';
+
+const API_DOMAIN = 'https://public-api.wordpress.com:443';
+
+describe( 'actions', () => {
+	let sandbox, spy;
+
+	useSandbox( newSandbox => {
+		sandbox = newSandbox;
+		spy = sandbox.spy();
+	} );
+
+	beforeEach( () => {
+		spy.reset();
+	} );
+
+	after( () => {
+		nock.cleanAll();
+	} );
+
+	describe( 'receiveUnregisterDevice()', () => {
+		it( 'should return an action object with empty data for empty input', () => {
+			expect( receiveUnregisterDevice() ).to.eql( {
+				type: PUSH_NOTIFICATIONS_RECEIVE_UNREGISTER_DEVICE,
+				data: {},
+			} );
+		} );
+
+		it( 'should return an action object with provided data intact', () => {
+			const data = {
+				devicestuff: 'some_value',
+			};
+			expect( receiveUnregisterDevice( data ) ).to.eql( {
+				type: PUSH_NOTIFICATIONS_RECEIVE_UNREGISTER_DEVICE,
+				data,
+			} );
+		} );
+	} );
+
+	describe( 'apiNotReady()', () => {
+		it( 'should return an action object', () => {
+			expect( apiNotReady() ).to.eql( {
+				type: PUSH_NOTIFICATIONS_API_NOT_READY,
+			} );
+		} );
+	} );
+
+	// @TODO other "action object" tests like ^^
+
+	describe( 'sendSubscriptionToWPCOM()', () => {
+		const getState = () => ( { pushNotifications: { settings: {}, system: {} } } );
+
+		describe( 'success', () => {
+			before( () => {
+				nock( API_DOMAIN )
+					.persist()
+					.post( `/rest/v1.1/devices/new` )
+					.reply( 200, { ID: 123, settings: {} } );
+			} );
+			after( () => {
+				nock.cleanAll();
+			} );
+
+			it( 'should dispatch receive action when request completes', () => {
+				return sendSubscriptionToWPCOM( 'someTruthyValue' )( spy, getState ).then( () => {
+					expect( spy ).to.have.been.calledWithMatch( {
+						type: PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE,
+						data: {}
+					} );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/state/push-notifications/test/reducer.js
+++ b/client/state/push-notifications/test/reducer.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	SERIALIZE,
+	DESERIALIZE
+} from 'state/action-types';
+import reducer, {} from '../reducer';
+
+describe( 'system reducer', () => {
+	it( 'should refuse to persist particular keys', () => {
+		const wpcomSubscription = { ID: 42 };
+		const state = reducer( {
+			system: {
+				apiReady: true,
+				authorized: true,
+				authorizationLoaded: true,
+				blocked: false,
+				wpcomSubscription: wpcomSubscription,
+			}
+		}, { type: SERIALIZE } );
+
+		expect( state.system ).to.eql( {
+			wpcomSubscription,
+		} );
+	} );
+
+	it( 'should refuse to restore particular keys', () => {
+		const wpcomSubscription = { ID: 42 };
+		const state = reducer( {
+			system: {
+				apiReady: true,
+				authorized: true,
+				authorizationLoaded: true,
+				blocked: false,
+				wpcomSubscription: wpcomSubscription,
+			}
+		}, { type: DESERIALIZE } );
+
+		expect( state.system ).to.eql( {
+			wpcomSubscription,
+		} );
+	} );
+} );
+
+describe( 'settings reducer', () => {
+	it( 'should refuse to persist particular keys', () => {
+		const wpcomSubscription = { ID: 42 };
+		const state = reducer( {
+			settings: {
+				enabled: true,
+				showingUnblockInstructions: true,
+			},
+			system: {
+				authorized: true,
+				authorizationLoaded: true,
+				blocked: true,
+				wpcomSubscription: wpcomSubscription,
+			},
+		}, { type: SERIALIZE } );
+
+		expect( state.settings ).to.eql( {
+			enabled: true,
+		} );
+	} );
+
+	it( 'should refuse to restore particular keys', () => {
+		const wpcomSubscription = { ID: 42 };
+		const state = reducer( {
+			settings: {
+				enabled: true,
+				showingUnblockInstructions: true,
+			},
+			system: {
+				authorized: true,
+				authorizationLoaded: true,
+				blocked: true,
+				wpcomSubscription: wpcomSubscription,
+			},
+		}, { type: DESERIALIZE } );
+
+		expect( state.settings ).to.eql( {
+			enabled: true,
+		} );
+	} );
+} );

--- a/client/state/push-notifications/test/selectors.js
+++ b/client/state/push-notifications/test/selectors.js
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getStatus,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '#getStatus()', () => {
+		it( 'should return unknown if API is not ready', () => {
+			const mockState = {
+				pushNotifications: {
+					system: {
+						apiReady: false
+					}
+				}
+			};
+			expect( getStatus( mockState ) ).to.eql( 'unknown' );
+		} );
+
+		it( 'should return denied if blocked & API is ready', () => {
+			const mockState = {
+				pushNotifications: {
+					system: {
+						apiReady: true,
+						blocked: true,
+					}
+				}
+			};
+			expect( getStatus( mockState ) ).to.eql( 'denied' );
+		} );
+
+		it( 'should return subscribed if enabled and wpcomSubscription.ID is truthy', () => {
+			const mockState = {
+				pushNotifications: {
+					settings: {
+						enabled: true,
+					},
+					system: {
+						apiReady: true,
+						blocked: false,
+						wpcomSubscription: {
+							ID: 42
+						},
+					}
+				}
+			};
+			expect( getStatus( mockState ) ).to.eql( 'subscribed' );
+		} );
+
+		it( 'should return enabling if enabled and wpcomSubscription is null', () => {
+			const mockState = {
+				pushNotifications: {
+					settings: {
+						enabled: true,
+					},
+					system: {
+						apiReady: true,
+						blocked: false,
+					}
+				}
+			};
+			expect( getStatus( mockState ) ).to.eql( 'enabling' );
+		} );
+
+		it( 'should return enabling if enabled and wpcomSubscription is false', () => {
+			const mockState = {
+				pushNotifications: {
+					settings: {
+						enabled: true,
+					},
+					system: {
+						apiReady: true,
+						blocked: false,
+						wpcomSubscription: false,
+					}
+				}
+			};
+			expect( getStatus( mockState ) ).to.eql( 'enabling' );
+		} );
+
+		it( 'should return disabling if not enabled and wpcomSubscription is present', () => {
+			const mockState = {
+				pushNotifications: {
+					settings: {
+						enabled: false,
+					},
+					system: {
+						apiReady: true,
+						blocked: false,
+						wpcomSubscription: {
+							ID: 42,
+						},
+					}
+				}
+			};
+			expect( getStatus( mockState ) ).to.eql( 'disabling' );
+		} );
+
+		it( 'should return unsubscribed if not enabled and wpcomSubscription is null', () => {
+			const mockState = {
+				pushNotifications: {
+					settings: {
+						enabled: false,
+					},
+					system: {
+						apiReady: true,
+						blocked: false,
+					}
+				}
+			};
+			expect( getStatus( mockState ) ).to.eql( 'unsubscribed' );
+		} );
+
+		it( 'should return unsubscribed if not enabled and wpcomSubscription is false', () => {
+			const mockState = {
+				pushNotifications: {
+					settings: {
+						enabled: false,
+					},
+					system: {
+						apiReady: true,
+						blocked: false,
+						wpcomSubscription: false
+					}
+				}
+			};
+			expect( getStatus( mockState ) ).to.eql( 'unsubscribed' );
+		} );
+	} );
+} );


### PR DESCRIPTION
Run them like so:
`npm run test-client -- --grep "state push-notifications"`

Test live: https://calypso.live/?branch=add/push-notifications-redux-tests