### PR TITLE
CPT: Implement TermQueryManager

### DIFF
--- a/client/lib/query-manager/term/constants.js
+++ b/client/lib/query-manager/term/constants.js
@@ -1,0 +1,11 @@
+export const DEFAULT_TERM_QUERY = {
+	context: 'display',
+	http_envelope: false,
+	pretty: false,
+	number: 100,
+	offset: 0,
+	page: 1,
+	search: '',
+	order: 'ASC',
+	order_by: 'name'
+};

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import includes from 'lodash/includes';
+
+/**
+ * Internal dependencies
+ */
+import PaginatedQueryManager from '../paginated';
+import TermQueryKey from './key';
+import { DEFAULT_TERM_QUERY } from './constants';
+
+/**
+ * TermQueryManager manages terms which can be queried and change over time
+ */
+export default class TermQueryManager extends PaginatedQueryManager {
+	/**
+	 * Returns true if the term matches the given query, or false otherwise.
+	 *
+	 * @param  {Object}  query Query object
+	 * @param  {Object}  term  Item to consider
+	 * @return {Boolean}       Whether term matches query
+	 */
+	matches( query, term ) {
+		if ( ! query.search ) {
+			return true;
+		}
+
+		const search = query.search.toLowerCase();
+		return (
+			( term.name && includes( term.name.toLowerCase(), search ) ) ||
+			( term.slug && includes( term.slug.toLowerCase(), search ) )
+		);
+	}
+
+	/**
+	 * A sort comparison function that defines the sort order of terms under
+	 * consideration of the specified query.
+	 *
+	 * @param  {Object} query Query object
+	 * @param  {Object} termA First term
+	 * @param  {Object} termB Second term
+	 * @return {Number}       0 if equal, less than 0 if termA is first,
+	 *                        greater than 0 if termB is first.
+	 */
+	sort( query, termA, termB ) {
+		let order;
+
+		switch ( query.order_by ) {
+			case 'name':
+				order = termA.name.localeCompare( termB.name );
+				break;
+
+			case 'count':
+				order = termA.post_count - termB.post_count;
+				break;
+		}
+
+		// Default to ascending order. When descending, reverse order.
+		if ( /^desc$/i.test( query.order ) ) {
+			order *= -1;
+		}
+
+		return order || 0;
+	}
+}
+
+TermQueryManager.QueryKey = TermQueryKey;
+
+TermQueryManager.DEFAULT_QUERY = DEFAULT_TERM_QUERY;

--- a/client/lib/query-manager/term/key.js
+++ b/client/lib/query-manager/term/key.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import omitBy from 'lodash/omitBy';
+
+/**
+ * Internal dependencies
+ */
+import PaginatedQueryKey from '../paginated/key';
+import { DEFAULT_TERM_QUERY } from './constants';
+
+/**
+ * Returns true if the specified key value query pair is identical to that of
+ * the default term query.
+ *
+ * @param  {*}       value Value to check
+ * @param  {String}  key   Key to check
+ * @return {Boolean}       Whether key value matches default query
+ */
+function isDefaultQueryValue( value, key ) {
+	return DEFAULT_TERM_QUERY[ key ] === value;
+}
+
+/**
+ * TermQueryKey manages the serialization and deserialization of a query key
+ * for use in tracking query results in an instance of TermQueryManager.
+ */
+export default class TermQueryKey extends PaginatedQueryKey {
+	/**
+	 * Returns a serialized query, given a query object
+	 *
+	 * @param  {Object} query Query object
+	 * @return {String}       Serialized query
+	 */
+	static stringify( query ) {
+		return super.stringify( omitBy( query, isDefaultQueryValue ) );
+	}
+
+	/**
+	 * Returns a query object, given a serialized query
+	 *
+	 * @param  {String} key Serialized query
+	 * @return {Object}     Query object
+	 */
+	static parse( key ) {
+		return omitBy( super.parse( key ), isDefaultQueryValue );
+	}
+}

--- a/client/lib/query-manager/term/test/index.js
+++ b/client/lib/query-manager/term/test/index.js
@@ -1,0 +1,143 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import TermQueryManager from '../';
+
+/**
+ * Constants
+ */
+const DEFAULT_TERM = {
+	ID: 586,
+	name: 'Food',
+	slug: 'my-slug',
+	description: '',
+	post_count: 5
+};
+
+describe( 'TermQueryManager', () => {
+	let manager;
+	beforeEach( () => {
+		manager = new TermQueryManager();
+	} );
+
+	describe( '#matches()', () => {
+		context( 'query.search', () => {
+			it( 'should return false for a non-matching search', () => {
+				const isMatch = manager.matches( {
+					search: 'Cars'
+				}, DEFAULT_TERM );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true for an empty search', () => {
+				const isMatch = manager.matches( {
+					search: ''
+				}, DEFAULT_TERM );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for a matching name search', () => {
+				const isMatch = manager.matches( {
+					search: 'ood'
+				}, DEFAULT_TERM );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for a matching slug search', () => {
+				const isMatch = manager.matches( {
+					search: 'y-sl'
+				}, DEFAULT_TERM );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should search case-insensitive', () => {
+				const isMatch = manager.matches( {
+					search: 'fOoD'
+				}, DEFAULT_TERM );
+
+				expect( isMatch ).to.be.true;
+			} );
+		} );
+	} );
+
+	describe( '#sort()', () => {
+		context( 'query.order', () => {
+			it( 'should sort ascending by default', () => {
+				const sorted = [
+					{ name: 'Food' },
+					{ name: 'Cars' }
+				].sort( manager.sort.bind( manager, {
+					order_by: 'name'
+				} ) );
+
+				expect( sorted ).to.eql( [
+					{ name: 'Cars' },
+					{ name: 'Food' }
+				] );
+			} );
+
+			it( 'should reverse order when specified as descending', () => {
+				const sorted = [
+					{ name: 'Food' },
+					{ name: 'Cars' }
+				].sort( manager.sort.bind( manager, {
+					order_by: 'name',
+					order: 'DESC'
+				} ) );
+
+				expect( sorted ).to.eql( [
+					{ name: 'Food' },
+					{ name: 'Cars' }
+				] );
+			} );
+		} );
+
+		context( 'query.order_by', () => {
+			context( 'name', () => {
+				it( 'should sort by name', () => {
+					const sorted = [
+						{ name: 'Food' },
+						{ name: 'Cars' }
+					].sort( manager.sort.bind( manager, {
+						order_by: 'name'
+					} ) );
+
+					expect( sorted ).to.eql( [
+						{ name: 'Cars' },
+						{ name: 'Food' }
+					] );
+				} );
+			} );
+
+			context( 'count', () => {
+				const unusedTerm = Object.assign( {}, DEFAULT_TERM, {
+					ID: 152,
+					post_count: 0
+				} );
+
+				it( 'should sort by post count', () => {
+					const sorted = [
+						DEFAULT_TERM,
+						unusedTerm
+					].sort( manager.sort.bind( manager, {
+						order_by: 'count'
+					} ) );
+
+					expect( sorted ).to.eql( [
+						unusedTerm,
+						DEFAULT_TERM
+					] );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/lib/query-manager/term/test/key.js
+++ b/client/lib/query-manager/term/test/key.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import TermQueryKey from '../key';
+
+describe( 'TermQueryKey', () => {
+	describe( '.stringify()', () => {
+		it( 'should return a JSON string of the object', () => {
+			const key = TermQueryKey.stringify( { ok: true } );
+
+			expect( key ).to.equal( '[["ok",true]]' );
+		} );
+
+		it( 'should omit default post query parameters', () => {
+			const key = TermQueryKey.stringify( { ok: true, search: '' } );
+
+			expect( key ).to.equal( '[["ok",true]]' );
+		} );
+	} );
+
+	describe( '.parse()', () => {
+		it( 'should return an object of the JSON string', () => {
+			const query = TermQueryKey.parse( '[["ok",true]]' );
+
+			expect( query ).to.eql( { ok: true } );
+		} );
+
+		it( 'should omit default post query parameters', () => {
+			const query = TermQueryKey.parse( '[["ok",true],["search",""]]' );
+
+			expect( query ).to.eql( { ok: true } );
+		} );
+	} );
+} );


### PR DESCRIPTION
Related: #5135

This pull request seeks to implement the `TermQueryManager` query manager class. Much like posts, we need the ability to manage changing state of terms over time. Terms are paginated, queryable, and can be created on-demand, requiring optimistic updating of UI.

__Testing instructions:__

The included changes are not imported by any sections of the application. Instead, ensure only that Mocha tests pass:

```
npm run test-client client/lib/query-manager
```

__Follow-up tasks:__

- Incorporate into terms Redux state
- Use for generic terms fields in the editor (#3697)

/cc @timmyc 

Test live: https://calypso.live/?branch=add/terms-query-manager