### PR TITLE
CPT: Separately test title and content in post query manager search

### DIFF
--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -34,8 +34,11 @@ export default class PostQueryManager extends PaginatedQueryManager {
 						return true;
 					}
 
-					const content = ( post.title || '' ) + ( post.content || '' );
-					return includes( content.toLowerCase(), value.toLowerCase() );
+					const search = value.toLowerCase();
+					return (
+						( post.title && includes( post.title.toLowerCase(), search ) ) ||
+						( post.content && includes( post.content.toLowerCase(), search ) )
+					);
 
 				case 'after':
 				case 'before':

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -103,6 +103,14 @@ describe( 'PostQueryManager', () => {
 
 				expect( isMatch ).to.be.true;
 			} );
+
+			it( 'should separately test title and content fields', () => {
+				const isMatch = manager.matches( {
+					search: 'ChickenAre'
+				}, DEFAULT_POST );
+
+				expect( isMatch ).to.be.false;
+			} );
 		} );
 
 		context( 'query.after', () => {


### PR DESCRIPTION
Related: #6022

This pull request seeks to resolve an inaccurate query matching success when the search term matches a substring of the concatenated title and content fields. Searching should apply independently to title and content. This was discovered in the course of implementing `TermQueryManager` in #6022.

For example, a post with title "Ribs & Chicken" and content of "Are delicious" should __not__ match the search query "ChickenAre".

__Testing instructions:__

Ensure Mocha tests pass:

```
npm run test-client client/lib/query-manager
```