### PR TITLE
Devdocs: Make main header clickable

### DIFF
--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -21,7 +21,9 @@ export default React.createClass( {
 	render() {
 		return (
 			<Sidebar>
-				<h1 className="devdocs__title">Calypso Docs</h1>
+				<a href="/devdocs">
+					<h1 className="devdocs__title">Calypso Docs</h1>
+				</a>
 				<SidebarMenu>
 					<ul>
 						<SidebarItem


### PR DESCRIPTION
It's not entirely obvious how to get back to the main index of the
Calypso documentation, so this PR makes the main "Calypso Docs" header
clickable.

Test live: https://calypso.live/?branch=update/devdocs/clickable-header