### PR TITLE
Devdocs: Use ellipsis character

### DIFF
--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -102,7 +102,7 @@ function makeSnippet( doc, query ) {
 	}
 
 	if ( snippets.length ) {
-		return '...' + snippets.join( ' ... ' ) + '...';
+		return '…' + snippets.join( ' … ' ) + '…';
 	};
 
 	return defaultSnippet( doc );
@@ -116,7 +116,7 @@ function escapeRegexString( str ) {
 
 function defaultSnippet( doc ) {
 	var content = doc.body.substring( 0, DEFAULT_SNIPPET_LENGTH );
-	return escapeHTML( content ) + '&hellip;';
+	return escapeHTML( content ) + '…';
 }
 
 /**


### PR DESCRIPTION
This PR fixes an issue with devdocs search results displaying `&hellip;` instead of the ellipsis character.

## Before

![image](https://cloud.githubusercontent.com/assets/227022/16052047/f31ab5f0-3227-11e6-9e50-76a1e365d84d.png)

## After

![image](https://cloud.githubusercontent.com/assets/227022/16052049/f7167554-3227-11e6-904e-10a8e07ba17d.png)

Also changes search results to the ellipsis character instead of three dots, but no visual changes there.

Test live: https://calypso.live/?branch=fix/devdocs/ellipsis