### PR TITLE
ThemeSheet: remove "Try & Customize" button

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -66,6 +66,12 @@ const ThemeSheet = React.createClass( {
 		};
 	},
 
+	getInitialState() {
+		return {
+			showPreview: false,
+		};
+	},
+
 	componentDidMount() {
 		window.scroll( 0, 0 );
 	},

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
 import titlecase from 'to-title-case';
+import pick from 'lodash/pick';
 
 /**
  * Internal dependencies
@@ -19,21 +20,18 @@ import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
 import ThemeDownloadCard from './theme-download-card';
 import ThemesRelatedCard from './themes-related-card';
+import ThemePickButton from './theme-pick-button';
 import Button from 'components/button';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
-import { signup, purchase, activate, customize } from 'state/themes/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { isPremium, getForumUrl } from 'my-sites/themes/helpers';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCurrentTheme from 'components/data/query-current-theme';
-import { getCurrentTheme } from 'state/themes/current-theme/selectors';
-import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
-import actionLabels from 'my-sites/themes/action-labels';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import ThemePreview from 'my-sites/themes/theme-preview';
@@ -56,11 +54,9 @@ const ThemeSheet = React.createClass( {
 		stylesheet: React.PropTypes.string,
 		active: React.PropTypes.bool,
 		purchased: React.PropTypes.bool,
-		isLoggedIn: React.PropTypes.bool,
 		// Connected props
 		selectedSite: React.PropTypes.object,
 		siteSlug: React.PropTypes.string,
-		currentTheme: React.PropTypes.object,
 		backPath: React.PropTypes.string,
 	},
 
@@ -70,49 +66,12 @@ const ThemeSheet = React.createClass( {
 		};
 	},
 
-	getInitialState() {
-		return { selectedAction: null };
-	},
-
 	componentDidMount() {
 		window.scroll( 0, 0 );
 	},
 
-	hideSiteSelectorModal() {
-		this.setState( { selectedAction: null } );
-	},
-
-	isActive() {
-		const { id, currentTheme } = this.props;
-		return currentTheme && currentTheme.id === id;
-	},
-
-	onPrimaryClick() {
-		if ( ! this.props.isLoggedIn ) {
-			this.props.signup( this.props );
-		} else if ( this.isActive() ) {
-			this.props.customize( this.props, this.props.selectedSite );
-		} else if ( this.props.price ) {
-			this.selectSiteAndDispatch( 'purchase' );
-		} else {
-			this.selectSiteAndDispatch( 'activate' );
-		}
-	},
-
-	onPreviewButtonClick() {
-		if ( ! this.props.isLoggedIn ) {
-			this.props.signup( this.props );
-		} else {
-			this.selectSiteAndDispatch( 'customize' );
-		}
-	},
-
-	selectSiteAndDispatch( action ) {
-		if ( this.props.selectedSite ) {
-			this.props[ action ]( this.props, this.props.selectedSite, 'showcase-sheet' );
-		} else {
-			this.setState( { selectedAction: action } );
-		}
+	getTheme() {
+		return pick( this.props, [ 'id', 'name', 'author', 'screenshot', 'price', 'description', 'descriptionLong', 'supportDocumentation', 'download', 'taxonomies', 'stylesheet', 'active', 'purchased' ] );
 	},
 
 	getValidSections() {
@@ -269,13 +228,13 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderPreview() {
-		const buttonLabel = this.props.isLoggedIn ? i18n.translate( 'Try & Customize' ) : i18n.translate( 'Pick this design' );
 		return(
 			<ThemePreview showPreview={ this.state.showPreview }
 				theme={ this.props }
 				onClose={ this.togglePreview }
-				buttonLabel= { buttonLabel }
-				onButtonClick={ this.onPreviewButtonClick } />
+			>
+				<ThemePickButton theme={ this.getTheme() } />
+			</ThemePreview>
 		);
 	},
 
@@ -303,15 +262,7 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderSheet() {
-		let actionTitle = <span className="themes__sheet-button-placeholder">loading......</span>;
-		if ( this.isActive() ) {
-			actionTitle = i18n.translate( 'Customize' );
-		} else if ( this.props.name ) {
-			actionTitle = i18n.translate( 'Pick this design' );
-		}
-
 		const section = this.validateSection( this.props.section );
-		const priceElement = <span className="themes__sheet-action-bar-cost">{ this.props.price }</span>;
 		const siteID = this.props.selectedSite && this.props.selectedSite.ID;
 
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
@@ -325,23 +276,13 @@ const ThemeSheet = React.createClass( {
 				<ThanksModal
 					site={ this.props.selectedSite }
 					source={ 'details' }/>
-				{ this.state.selectedAction && <ThemesSiteSelectorModal
-					name={ this.state.selectedAction }
-					label={ actionLabels[ this.state.selectedAction ].label }
-					header={ actionLabels[ this.state.selectedAction ].header }
-					selectedTheme={ this.props }
-					onHide={ this.hideSiteSelectorModal }
-					action={ this.props[ this.state.selectedAction ] }
-					sourcePath={ `/theme/${ this.props.id }${ section ? '/' + section : '' }` }
-				/> }
 				{ this.state.showPreview && this.renderPreview() }
 				<HeaderCake className="themes__sheet-action-bar"
 							backHref={ this.props.backPath }
 							backText={ i18n.translate( 'All Themes' ) }>
-					<Button className="themes__sheet-primary-button" onClick={ this.onPrimaryClick }>
-						{ actionTitle }
-						{ ! this.isActive() && priceElement }
-					</Button>
+					<ThemePickButton className="themes__sheet__theme-pick-button"
+						theme={ this.getTheme() }
+					/>
 				</HeaderCake>
 				<div className="themes__sheet-columns">
 					<div className="themes__sheet-column-left">
@@ -371,9 +312,7 @@ export default connect(
 	( state ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
-		const currentTheme = getCurrentTheme( state, selectedSite && selectedSite.ID );
 		const backPath = getBackPath( state );
-		return { selectedSite, siteSlug, currentTheme, backPath };
-	},
-	{ signup, purchase, activate, customize }
+		return { selectedSite, siteSlug, backPath };
+	}
 )( ThemeSheet );

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -60,7 +60,7 @@
 	}
 }
 
-.themes__sheet-primary-button {
+.themes__sheet__theme-pick-button {
 	position: absolute;
 		top: 5px;
 		right: 50%;
@@ -74,11 +74,7 @@
 	}
 }
 
-.themes__sheet-button-placeholder {
-	color: transparent;
-}
-
-.themes__sheet-action-bar-cost {
+.theme-pick-button__cost {
 	font-weight: 600;
 	color: #4AB866;
 	margin-left: 10px;

--- a/client/my-sites/theme/theme-pick-button.jsx
+++ b/client/my-sites/theme/theme-pick-button.jsx
@@ -1,0 +1,137 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import i18n from 'i18n-calypso';
+import classNames from 'classnames';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import { signup, purchase, activate, customize } from 'state/themes/actions';
+import { getSelectedSite } from 'state/ui/selectors';
+import { getCurrentTheme } from 'state/themes/current-theme/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { isPremium } from 'my-sites/themes/helpers';
+import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
+import actionLabels from 'my-sites/themes/action-labels';
+
+const ThemePickButton = React.createClass( {
+	displayName: 'ThemePickButton',
+
+	propTypes: {
+		theme: React.PropTypes.object.isRequired,
+		className: React.PropTypes.string,
+		// activate/purchase/customize action will happen automatically so onClick
+		// is just for extra behavior.
+		onClick: React.PropTypes.func,
+		// The following are provided by connect
+		currentTheme: React.PropTypes.object,
+		selectedSite: React.PropTypes.object,
+		customize: React.PropTypes.func.isRequired,
+		activate: React.PropTypes.func.isRequired,
+		purchase: React.PropTypes.func.isRequired,
+		signup: React.PropTypes.func.isRequired,
+		isLoggedIn: React.PropTypes.bool,
+	},
+
+	getDefaultProps() {
+		return {
+			onClick: noop,
+		};
+	},
+
+	getInitialState() {
+		return { selectedAction: null };
+	},
+
+	hideSiteSelectorModal() {
+		this.setState( { selectedAction: null } );
+	},
+
+	isThemeActive() {
+		return this.props.currentTheme && this.props.currentTheme.id === this.props.theme.id && this.props.selectedSite;
+	},
+
+	selectSiteAndDispatch( action ) {
+		if ( this.props.selectedSite ) {
+			this.props[ action ]( this.props.theme, this.props.selectedSite, 'showcase-sheet' );
+			this.props.onClick( this.props.theme );
+		} else {
+			this.setState( { selectedAction: action } );
+		}
+	},
+
+	onPickTheme() {
+		if ( ! this.props.isLoggedIn ) {
+			this.props.signup( this.props.theme );
+			this.props.onClick( this.props.theme );
+		} else if ( isPremium( this.props.theme ) && ! this.props.theme.purchased ) {
+			this.selectSiteAndDispatch( 'purchase' );
+		} else {
+			this.selectSiteAndDispatch( 'activate' );
+		}
+	},
+
+	onCustomize() {
+		this.props.customize( this.props.theme, this.props.selectedSite );
+		this.props.onClick( this.props.theme );
+	},
+
+	renderSiteSelector() {
+		if ( ! this.state.selectedAction ) {
+			return;
+		}
+		const selectedAction = this.state.selectedAction;
+		const onCompleteSiteSelection = ( selectedTheme, site ) => {
+			this.props[ selectedAction ]( selectedTheme, site, 'showcase-sheet' );
+			this.props.onClick( this.props.theme );
+		};
+		// TODO: this used to be `section`, but I don't know what that is or if it
+		// is needed. Obviously there won't be a `site` if we're calling this function.
+		const site = this.props.selectedSite ? this.props.selectedSite.ID : null;
+		return (
+			<ThemesSiteSelectorModal
+				name={ this.state.selectedAction }
+				label={ actionLabels[ this.state.selectedAction ].label }
+				header={ actionLabels[ this.state.selectedAction ].header }
+				selectedTheme={ this.props.theme }
+				onHide={ this.hideSiteSelectorModal }
+				action={ onCompleteSiteSelection }
+				sourcePath={ `/theme/${ this.props.theme.id }${ site ? '/' + site : '' }` }
+			/>
+		);
+	},
+
+	render() {
+		const isThemeActive = this.isThemeActive();
+		const price = this.props.theme.price ? this.props.theme.price : i18n.translate( 'Free' );
+		const buttonText = ( isThemeActive ? i18n.translate( 'Customize' ) : i18n.translate( 'Pick this design' ) );
+		const priceElement = <span>{ buttonText }<span className="theme-pick-button__cost">{ price }</span></span>;
+		const buttonLabel = ( isThemeActive ? buttonText : priceElement );
+		const onButtonClick = ( isThemeActive ? this.onCustomize : this.onPickTheme );
+		return (
+			<Button className={ classNames( 'theme-pick-button', this.props.className ) } onClick={ onButtonClick }>
+				{ buttonLabel }
+				{ this.renderSiteSelector() }
+			</Button>
+		);
+	}
+} );
+
+export default connect(
+	// props
+	state => {
+		const selectedSite = getSelectedSite( state );
+		const currentTheme = getCurrentTheme( state, selectedSite && selectedSite.ID );
+		const isLoggedIn = !! getCurrentUser( state );
+		return { selectedSite, currentTheme, isLoggedIn };
+	},
+	// Actions
+	{ signup, purchase, activate, customize }
+)( ThemePickButton );

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -12,6 +12,7 @@ import merge from 'lodash/merge';
 import Main from 'components/main';
 import { signup } from 'state/themes/actions' ;
 import ThemePreview from './theme-preview';
+import ThemePickButton from 'my-sites/theme/theme-pick-button';
 import ThemesSelection from './themes-selection';
 import { getSignupUrl, getDetailsUrl, getSupportUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
@@ -54,11 +55,8 @@ const ThemesLoggedOut = React.createClass( {
 		return merge( {}, buttonOptions, actionLabels );
 	},
 
-	onPreviewButtonClick( theme ) {
-		this.setState( { showPreview: false },
-			() => {
-				this.props.signup( theme );
-			} );
+	onPreviewButtonClick() {
+		this.setState( { showPreview: false } );
 	},
 
 	render() {
@@ -71,10 +69,9 @@ const ThemesLoggedOut = React.createClass( {
 					<ThemePreview showPreview={ this.state.showPreview }
 						theme={ this.state.previewingTheme }
 						onClose={ this.togglePreview }
-						buttonLabel={ this.translate( 'Choose this design', {
-							comment: 'when signing up for a WordPress.com account with a selected theme'
-						} ) }
-						onButtonClick={ this.onPreviewButtonClick } />
+					>
+						<ThemePickButton theme={ this.state.previewingTheme } onClick={ this.onPreviewButtonClick } />
+					</ThemePreview>
 				}
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -12,6 +12,7 @@ import merge from 'lodash/merge';
 import Main from 'components/main';
 import { customize, purchase, activate } from 'state/themes/actions';
 import ThemePreview from './theme-preview';
+import ThemePickButton from 'my-sites/theme/theme-pick-button';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import ThemesSelection from './themes-selection';
@@ -81,11 +82,8 @@ const ThemesMultiSite = React.createClass( {
 		return merge( {}, buttonOptions, actionLabels );
 	},
 
-	onPreviewButtonClick( theme ) {
-		this.setState( { showPreview: false },
-			() => {
-				this.getButtonOptions().customize.action( theme );
-			} );
+	onPreviewButtonClick() {
+		this.setState( { showPreview: false } );
 	},
 
 	render() {
@@ -99,10 +97,9 @@ const ThemesMultiSite = React.createClass( {
 					<ThemePreview showPreview={ this.state.showPreview }
 						theme={ this.state.previewingTheme }
 						onClose={ this.togglePreview }
-						buttonLabel={ this.translate( 'Try & Customize', {
-							context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
-						} ) }
-						onButtonClick={ this.onPreviewButtonClick } />
+					>
+						<ThemePickButton theme={ this.state.previewingTheme } onClick={ this.onPreviewButtonClick } />
+					</ThemePreview>
 				}
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -13,6 +13,7 @@ import mapValues from 'lodash/mapValues';
 import Main from 'components/main';
 import { customize, purchase, activate } from 'state/themes/actions';
 import ThemePreview from './theme-preview';
+import ThemePickButton from 'my-sites/theme/theme-pick-button';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -99,11 +100,8 @@ const ThemesSingleSite = React.createClass( {
 		return merge( {}, buttonOptions, actionLabels );
 	},
 
-	onPreviewButtonClick( theme ) {
-		this.setState( { showPreview: false },
-			() => {
-				this.props.customize( theme );
-			} );
+	onPreviewButtonClick() {
+		this.setState( { showPreview: false } );
 	},
 
 	renderJetpackMessage() {
@@ -143,10 +141,9 @@ const ThemesSingleSite = React.createClass( {
 					<ThemePreview showPreview={ this.state.showPreview }
 						theme={ this.state.previewingTheme }
 						onClose={ this.togglePreview }
-						buttonLabel={ this.translate( 'Try & Customize', {
-							context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
-						} ) }
-						onButtonClick={ this.onPreviewButtonClick } />
+					>
+						<ThemePickButton theme={ this.state.previewingTheme } onClick={ this.onPreviewButtonClick } />
+					</ThemePreview>
 				}
 				<ThanksModal
 					site={ site }

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -9,7 +9,6 @@ import React from 'react';
  * Internal dependencies
  */
 import WebPreview from 'components/web-preview';
-import Button from 'components/button';
 import { getPreviewUrl } from './helpers';
 
 export default React.createClass( {
@@ -19,12 +18,6 @@ export default React.createClass( {
 		theme: React.PropTypes.object,
 		showPreview: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
-		buttonLabel: React.PropTypes.string,
-		onButtonClick: React.PropTypes.func
-	},
-
-	onButtonClick() {
-		this.props.onButtonClick( this.props.theme );
 	},
 
 	render() {
@@ -35,9 +28,7 @@ export default React.createClass( {
 				onClose={ this.props.onClose }
 				previewUrl={ previewUrl }
 				externalUrl={ this.props.theme.demo_uri } >
-				<Button primary
-					onClick={ this.onButtonClick }
-					>{ this.props.buttonLabel }</Button>
+				{ this.props.children }
 			</WebPreview>
 		);
 	}

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * Internal dependencies
  */

--- a/client/state/users/selectors.js
+++ b/client/state/users/selectors.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * Returns a user object by user ID.
  *


### PR DESCRIPTION
This is for use after the Theme Sheets are launched.

The "Try & Customize" button in the theme sheet preview is problematic for a few reasons, but primarily IMO it can cause a lot of confusion with Headstart.

When Headstart is fully launched (soon), switching themes on a site with no custom content (basically a new site) will cause all the content on a site (posts, pages, menus, widgets) to be replaced with placeholder content appropriate to the theme.

If a user presses "Try & Customize" prior to switching themes, they will see and customize their old content, and then when they activate the switch, all those customizations will be replaced by the new placeholder content, making for a very poor experience.

With this PR, anyone viewing a site preview through Theme Sheets or the theme showcase will not have the option of "Try & Customize", but will go directly to "Activate".

That is, when clicking this button:

<img width="941" alt="screen_shot_2016-06-14_at_1_15_04_pm" src="https://cloud.githubusercontent.com/assets/2036909/16052402/2054f2c4-3232-11e6-882e-38d8bcf86b09.png">

Before:

<img width="1438" alt="screen shot 2016-06-14 at 1 14 51 pm" src="https://cloud.githubusercontent.com/assets/2036909/16052416/30f4839c-3232-11e6-9c91-e70a6124b08a.png">

After:

<img width="1439" alt="screen shot 2016-06-24 at 11 17 39 am" src="https://cloud.githubusercontent.com/assets/2036909/16341884/500c5584-39fd-11e6-8bd3-189d2dc46406.png">


## Testing Instructions

(trying to cover all the things this PR touches)

1. Visit the theme sheet page (eg: http://calypso.localhost:3000/theme/twentysixteen) and verify that the button looks ok and works correctly ("Pick this design" and "Free" or the price).
2. Try activating the theme and make sure it brings up the site picker and the theme is activated.
3. Repeat steps 1-2 for the theme sheet page for a specific site (eg: http://calypso.localhost:3000/theme/twentysixteen/mysite.wordpress.com)
4. Same test for the theme sheet page for a specific site, but use the theme sheet for a site that already has that theme. The button should read "Customize" instead (with no price).
5. Repeat steps 1-4 after clicking on the "Open live demo" link in the theme sheet to bring up the theme preview.
6. Visit the theme showcase page (eg: http://calypso.localhost:3000/design/) and click on a theme with a price, verifying that the button in the preview says "Pick this design" and has the price.
7. Repeat step 5 with a free theme and verify that it reads "Free".
8. Visit the theme showcase page for a specific site (eg: http://calypso.localhost:3000/design/mysite.wordpress.com) and repeat step 7.
9. Activate a theme after step 8 and verify that it is activated.
10. Visit the theme showcase while logged-out (eg: http://calypso.localhost:3000/design/) and repeat step 9, but verify that clicking the link brings you to sign up and the resulting site has the theme you chose.

**In summary**, this button changes or updates the UI for:
- button variations (free/paid themes, the currently active theme)
- theme sheet (single site, multi-site, logged-out, and associated theme previews)
- theme showcase previews (single site, multi-site, and logged-out)

Test live: https://calypso.live/?branch=remove/theme-sheet-customize-button