### PR TITLE
Reader: fix text wrapping around center-aligned images

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -259,6 +259,7 @@
 
 	.aligncenter {
 		clear: both;
+		display: block;
 		margin-top: 24px;
 		margin-bottom: 24px;
 	}


### PR DESCRIPTION
This PR fixes images with `. aligncenter` class as text is being wrapped around them.

**Before:**
![screenshot 2016-06-14 10 18 12](https://cloud.githubusercontent.com/assets/4924246/16052873/159e738a-321b-11e6-9c55-132920db2bda.png)

**After:**
![screenshot 2016-06-14 10 32 52](https://cloud.githubusercontent.com/assets/4924246/16052930/5fb2a2e8-321b-11e6-9d9e-15b2fac6fca0.png)

Example: http://calypso.dev:3000/read/blogs/104338846/posts/101

Test live: https://calypso.live/?branch=fix/reader/aligncenter-image