### PR TITLE
Add/jetpack monthly plans support

### DIFF
--- a/client/components/plans/plan-actions/style.scss
+++ b/client/components/plans/plan-actions/style.scss
@@ -136,10 +136,12 @@
 }
 
 .value_bundle.plan-actions__illustration,
-.jetpack_premium.plan-actions__illustration {
+.jetpack_premium.plan-actions__illustration,
+.jetpack_premium_monthly.plan-actions__illustration {
 	background-image: url('/calypso/images/plans/plan-premium.svg');
 }
 .business-bundle.plan-actions__illustration,
-.jetpack_business.plan-actions__illustration {
+.jetpack_business.plan-actions__illustration,
+.jetpack_business_monthly.plan-actions__illustration {
 	background-image: url('/calypso/images/plans/plan-business.svg');
 }

--- a/client/components/plans/plan-header/style.scss
+++ b/client/components/plans/plan-header/style.scss
@@ -22,13 +22,15 @@
 		}
 	}
 	&.value_bundle,
-	&.jetpack_premium {
+	&.jetpack_premium,
+	&.jetpack_premium_monthly {
 		.plan-header__title:before {
 			background-image: url( '/calypso/images/plans/plan-premium.svg' );
 		}
 	}
 	&.business-bundle,
-	&.jetpack_business {
+	&.jetpack_business,
+	&.jetpack_business_monthly {
 		.plan-header__title:before {
 			background-image: url( '/calypso/images/plans/plan-business.svg' );
 		}
@@ -159,6 +161,8 @@
 
 .plan-list .jetpack_free .plan-header__title,
 .plan-list .jetpack_premium .plan-header__title,
-.plan-list .jetpack_business .plan-header__title {
+.plan-list .jetpack_business .plan-header__title,
+.plan-list .jetpack_premium_monthly .plan-header__title,
+.plan-list .jetpack_business_monthly .plan-header__title {
 	margin-top: 15px;
 }

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -26,7 +26,7 @@ const PlanList = React.createClass( {
 
 	render() {
 		const isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer;
-		const { site, hideFreePlan, plans, showJetpackFreePlan } = this.props;
+		const { site, hideFreePlan, plans, intervalType, showJetpackFreePlan } = this.props;
 
 		let className = '',
 			numberOfPlaceholders = abtest( 'personalPlan' ) === 'hide' ? 3 : 4;
@@ -77,7 +77,7 @@ const PlanList = React.createClass( {
 		}
 
 		if ( plans.length > 0 ) {
-			let filteredPlans = filterPlansBySiteAndProps( plans, site, hideFreePlan, showJetpackFreePlan );
+			let filteredPlans = filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalType, showJetpackFreePlan );
 
 			if (
 				config.isEnabled( 'manage/ads/wordads-instant' ) &&

--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -4,6 +4,7 @@
 import isUndefined from 'lodash/isUndefined';
 import React from 'react';
 import get from 'lodash/get';
+import { isJetpackMonthlyPlan } from 'lib/products-values';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import WpcomPlanPrice from 'my-sites/plans/wpcom-plan-price';
 
 const PlanPrice = React.createClass( {
 	getFormattedPrice( plan ) {
-		let rawPrice, formattedPrice;
+		let rawPrice, formattedPrice, months;
 
 		if ( plan ) {
 			// the properties of a plan object from sites-list is snake_case
@@ -24,6 +25,8 @@ const PlanPrice = React.createClass( {
 				return this.translate( 'Free', { context: 'Zero cost product price' } );
 			}
 
+			months = isJetpackMonthlyPlan( plan ) ? 1 : 12;
+
 			// could get $5.95, A$4.13, ¥298, €3,50, etc…
 			const getCurrencySymbol = price => /(\D+)\d+/.exec( price )[ 1 ];
 			const currencyDigits = currencySymbol => get( {
@@ -31,7 +34,7 @@ const PlanPrice = React.createClass( {
 			}, currencySymbol, 2 );
 
 			const currencySymbol = getCurrencySymbol( formattedPrice );
-			const monthlyPrice = ( rawPrice / 12 ).toFixed( currencyDigits( currencySymbol ) );
+			const monthlyPrice = ( rawPrice / months ).toFixed( currencyDigits( currencySymbol ) );
 
 			return `${ currencySymbol }${ monthlyPrice }`;
 		}
@@ -62,7 +65,11 @@ const PlanPrice = React.createClass( {
 		if ( ! plan ) {
 			periodLabel = '';
 		} else if ( plan.raw_price > 0 ) {
-			periodLabel = this.translate( 'per month, billed yearly' );
+			if ( isJetpackMonthlyPlan( plan ) ) {
+				periodLabel = this.translate( 'per month, billed monthly' );
+			} else {
+				periodLabel = this.translate( 'per month, billed yearly' );
+			}
 		} else {
 			periodLabel = hasDiscount ? this.translate( 'due today when you upgrade' ) : plan.bill_period_label;
 		}

--- a/client/components/plans/plan/style.scss
+++ b/client/components/plans/plan/style.scss
@@ -8,7 +8,9 @@
 
 	&.jetpack_free,
 	&.jetpack_premium,
-	&.jetpack_business {
+	&.jetpack_business,
+	&.jetpack_premium_monthly,
+	&.jetpack_business_monthly{
 		display: flex;
 		flex-direction: column;
 	}
@@ -50,7 +52,9 @@
 
 	.jetpack_free &,
 	.jetpack_premium &,
-	.jetpack_business & {
+	.jetpack_business &
+	.jetpack_premium_monthly &
+	.jetpack_business_monthly & {
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
@@ -91,7 +95,9 @@
 
 	.jetpack_free &,
 	.jetpack_premium &,
-	.jetpack_business & {
+	.jetpack_business &
+	.jetpack_premium_monthly &
+	.jetpack_business_monthly & {
 		flex-grow: 1;
 	}
 }
@@ -137,7 +143,9 @@
 
 		&.jetpack_free,
 		&.jetpack_premium,
-		&.jetpack_business {
+		&.jetpack_business,
+		&.jetpack_premium_monthly,
+		&.jetpack_business_monthly {
 			.plan__plan-tagline {
 				height: 32px;
 			}

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -94,7 +94,16 @@ const PlansCompare = React.createClass( {
 
 	getPlanURL() {
 		const selectedSite = this.props.selectedSite;
-		return selectedSite ? `/plans/${ selectedSite.slug }` : '/plans';
+		let url = '/plans';
+
+		if ( 'monthly' === this.props.intervalType ) {
+			url += '/monthly';
+		}
+
+		if ( selectedSite ) {
+			url += '/' + selectedSite.slug;
+		}
+		return url;
 	},
 
 	goBack() {
@@ -189,7 +198,8 @@ const PlansCompare = React.createClass( {
 		return filterPlansBySiteAndProps(
 			this.props.plans,
 			this.props.selectedSite,
-			this.props.hideFreePlan
+			this.props.hideFreePlan,
+			this.props.intervalType
 		);
 	},
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -36,6 +36,7 @@ var productsValues = require( 'lib/products-values' ),
 	isUnlimitedSpace = productsValues.isUnlimitedSpace,
 	isUnlimitedThemes = productsValues.isUnlimitedThemes,
 	isVideoPress = productsValues.isVideoPress,
+	isJetpackPlan = productsValues.isJetpackPlan,
 	sortProducts = require( 'lib/products-values/sort' ),
 	PLAN_PERSONAL = require( 'lib/plans/constants' ).PLAN_PERSONAL;
 
@@ -91,6 +92,11 @@ function cartItemShouldReplaceCart( cartItem, cart ) {
 	if ( productsValues.isFreeTrial( cartItem ) || hasFreeTrial( cart ) ) {
 		// adding a free trial plan to your cart replaces the cart
 		// adding another product to a cart containing a free trial removes the free trial
+		return true;
+	}
+
+	if ( isJetpackPlan( cartItem ) ) {
+		// adding a jetpack bundle should replace the cart
 		return true;
 	}
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -492,10 +492,12 @@ function getItemForPlan( plan, properties ) {
 			return personalPlan( plan.product_slug, properties );
 		case 'value_bundle':
 		case 'jetpack_premium':
+		case 'jetpack_premium_monthly':
 			return premiumPlan( plan.product_slug, properties );
 
 		case 'business-bundle':
 		case 'jetpack_business':
+		case 'jetpack_business_monthly':
 			return businessPlan( plan.product_slug, properties );
 
 		default:

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -12,6 +12,14 @@ export const PLAN_FREE = 'free_plan';
 export const PLAN_JETPACK_FREE = 'jetpack_free';
 export const PLAN_JETPACK_PREMIUM = 'jetpack_premium';
 export const PLAN_JETPACK_BUSINESS = 'jetpack_business';
+export const PLAN_JETPACK_PREMIUM_MONTHLY = 'jetpack_premium_monthly';
+export const PLAN_JETPACK_BUSINESS_MONTHLY = 'jetpack_business_monthly';
+export const PLAN_HOST_BUNDLE = 'host-bundle';
+export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
+export const PLAN_CHARGEBACK = 'chargeback';
+
+export const PLAN_MONTHLY_PERIOD = 31;
+export const PLAN_ANNUAL_PERIOD  = 365;
 
 // features constants
 export const FEATURE_CUSTOM_DESIGN = 'custom-design';

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -18,7 +18,8 @@ import { addItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
 import {
 	isFreeJetpackPlan,
-	isJetpackPlan
+	isJetpackPlan,
+	isMonthly
 } from 'lib/products-values';
 import {
 	featuresList,
@@ -131,15 +132,23 @@ export function shouldFetchSitePlans( sitePlans, selectedSite ) {
 	return ! sitePlans.hasLoadedFromServer && ! sitePlans.isRequesting && selectedSite;
 }
 
-export function filterPlansBySiteAndProps( plans, site, hideFreePlan, showJetpackFreePlan ) {
+export function filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalType, showJetpackFreePlan ) {
 	const hasPersonalPlan = site && site.plan.product_slug === PLAN_PERSONAL;
 
 	return plans.filter( function( plan ) {
 		if ( site && site.jetpack ) {
-			if ( showJetpackFreePlan ) {
-				return isJetpackPlan( plan );
+			if ( 'monthly' === intervalType ) {
+				if ( showJetpackFreePlan ) {
+					return isJetpackPlan( plan ) && isMonthly( plan );
+				}
+				return isJetpackPlan( plan ) && !isFreeJetpackPlan( plan ) && isMonthly( plan );
 			}
-			return isJetpackPlan( plan ) && ! isFreeJetpackPlan( plan );
+
+			if ( showJetpackFreePlan ) {
+				return isJetpackPlan( plan ) && !isMonthly( plan );
+			}
+
+			return isJetpackPlan( plan ) && !isFreeJetpackPlan( plan ) && !isMonthly( plan );
 		}
 
 		if ( hideFreePlan && PLAN_FREE === plan.product_slug ) {
@@ -158,6 +167,7 @@ export const isGoogleVouchersEnabled = () => {
 	return ( config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' );
 };
 
+
 export const isWordpressAdCreditsEnabled = () => {
 	return (
 		isGoogleVouchersEnabled() &&
@@ -165,3 +175,15 @@ export const isWordpressAdCreditsEnabled = () => {
 		abtest( 'wordpressAdCredits' ) === 'enabled'
 	);
 };
+
+export function plansLink( url, site, intervalType ) {
+	if ( 'monthly' === intervalType ) {
+		url += '/monthly';
+	}
+
+	if ( site ) {
+		url += '/' + site.slug;
+	}
+
+	return url;
+}

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -123,10 +123,12 @@ function isEnterprise( product ) {
 }
 
 function isJetpackPlan( product ) {
+	var jetpackProducts = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ];
+
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return 'jetpack' === product.product_type;
+	return ( jetpackProducts.indexOf( product.product_slug ) >= 0 );
 }
 
 function isJetpackBusiness( product ) {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -11,8 +11,23 @@ var assign = require( 'lodash/assign' ),
 /**
  * Internal dependencies
  */
-var schema = require( './schema.json' ),
-	PLAN_PERSONAL = require( 'lib/plans/constants' ).PLAN_PERSONAL;
+import {
+	PLAN_BUSINESS,
+	PLAN_PREMIUM,
+	PLAN_PERSONAL,
+	PLAN_FREE,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_HOST_BUNDLE,
+	PLAN_WPCOM_ENTERPRISE,
+	PLAN_CHARGEBACK,
+	PLAN_MONTHLY_PERIOD,
+} from 'lib/plans/constants';
+
+var schema = require( './schema.json' );
 
 var productDependencies = {
 	domain: {
@@ -51,21 +66,21 @@ function isChargeback( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return product.product_slug === 'chargeback';
+	return product.product_slug === PLAN_CHARGEBACK;
 }
 
 function isFreePlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return product.product_slug === 'free_plan';
+	return product.product_slug === PLAN_FREE;
 }
 
 function isFreeJetpackPlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return product.product_slug === 'jetpack_free';
+	return product.product_slug === PLAN_JETPACK_FREE;
 }
 
 function isFreeTrial( product ) {
@@ -83,7 +98,7 @@ function isPersonal( product ) {
 }
 
 function isPremium( product ) {
-	var premiumProducts = [ 'value_bundle', 'jetpack_premium' ];
+	var premiumProducts = [ PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];
 
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -92,7 +107,7 @@ function isPremium( product ) {
 }
 
 function isBusiness( product ) {
-	var businessProducts = [ 'business-bundle', 'jetpack_business' ];
+	var businessProducts = [ PLAN_BUSINESS, PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ];
 
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -104,7 +119,7 @@ function isEnterprise( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return product.product_slug === 'wpcom-enterprise';
+	return product.product_slug === PLAN_WPCOM_ENTERPRISE;
 }
 
 function isJetpackPlan( product ) {
@@ -128,11 +143,22 @@ function isJetpackPremium( product ) {
 	return isPremium( product ) && isJetpackPlan( product );
 }
 
+function isJetpackMonthlyPlan( product ) {
+	return isMonthly( product ) && isJetpackPlan( product );
+}
+
+function isMonthly( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+	
+	return product.bill_period === PLAN_MONTHLY_PERIOD;
+}
+
 function isJpphpBundle( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return product.product_slug === 'host-bundle';
+	return product.product_slug === PLAN_HOST_BUNDLE;
 }
 
 function isPlan( product ) {
@@ -319,6 +345,8 @@ module.exports = {
 	isJetpackBusiness,
 	isJetpackPlan,
 	isJetpackPremium,
+	isJetpackMonthlyPlan,
+	isMonthly,
 	isJpphpBundle,
 	isNoAds,
 	isPlan,

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -63,6 +63,7 @@ function addItems( items ) {
 	if ( shouldBundleWithPremium ) {
 		items = [ cartItems.premiumPlan( 'value_bundle', { isFreeTrial: false } ) ].concat( items );
 	}
+
 	const extendedItems = items.map( ( item ) => {
 		const extra = assign( {}, item.extra, {
 			context: 'calypstore',

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -68,6 +68,7 @@ export default {
 				<Plans
 					sites={ sites }
 					context={ context }
+					intervalType={ context.params.intervalType }
 					destinationType={ context.params.destinationType } />
 			</CheckoutData>,
 			document.getElementById( 'primary' ),
@@ -114,6 +115,7 @@ export default {
 						selectedSite={ site }
 						features={ features }
 						selectedFeature={ context.params.feature }
+						intervalType={ context.params.intervalType }
 						productsList={ productsList } />
 				</CheckoutData>
 			</Main>,

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -40,23 +40,15 @@ export default function() {
 		);
 
 		page(
-			'/plans/compare/:intervalType?/:domain',
-			retarget,
-			controller.siteSelection,
-			controller.navigation,
-			plansController.plansCompare
-		);
-
-		page(
-			'/plans/compare/:intervalType?/:domain',
-			retarget,
-			controller.siteSelection,
-			controller.navigation,
-			plansController.plansCompare
-		);
-
-		page(
 			'/plans/compare/:domain',
+			retarget,
+			controller.siteSelection,
+			controller.navigation,
+			plansController.plansCompare
+		);
+
+		page(
+			'/plans/compare/:intervalType?/:domain',
 			retarget,
 			controller.siteSelection,
 			controller.navigation,

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -40,7 +40,7 @@ export default function() {
 		);
 
 		page(
-			'/plans/compare/:intervalType?/:domain',
+			'/plans/compare/:domain',
 			retarget,
 			controller.siteSelection,
 			controller.navigation,
@@ -48,7 +48,7 @@ export default function() {
 		);
 
 		page(
-			'/plans/compare/:domain',
+			'/plans/compare/:intervalType?/:domain',
 			retarget,
 			controller.siteSelection,
 			controller.navigation,

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -40,6 +40,14 @@ export default function() {
 		);
 
 		page(
+			'/plans/compare/:intervalType?/:domain',
+			retarget,
+			controller.siteSelection,
+			controller.navigation,
+			plansController.plansCompare
+		);
+
+		page(
 			'/plans/compare/:domain',
 			retarget,
 			controller.siteSelection,

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -40,7 +40,7 @@ export default function() {
 		);
 
 		page(
-			'/plans/compare/:domain',
+			'/plans/compare/:intervalType?/:domain',
 			retarget,
 			controller.siteSelection,
 			controller.navigation,
@@ -49,6 +49,14 @@ export default function() {
 
 		page(
 			'/plans/compare/:intervalType?/:domain',
+			retarget,
+			controller.siteSelection,
+			controller.navigation,
+			plansController.plansCompare
+		);
+
+		page(
+			'/plans/compare/:domain',
 			retarget,
 			controller.siteSelection,
 			controller.navigation,

--- a/client/my-sites/plans/jetpack-plan-details/style.scss
+++ b/client/my-sites/plans/jetpack-plan-details/style.scss
@@ -1,10 +1,14 @@
 .jetpack_premium .plan__plan-details .plan__plan-details-list,
-.jetpack_business .plan__plan-details .plan__plan-details-list {
+.jetpack_business .plan__plan-details .plan__plan-details-list,
+.jetpack_premium_monthly .plan__plan-details .plan__plan-details-list,
+.jetpack_business_monthly .plan__plan-details .plan__plan-details-list {
 	margin: 8px 0;
 }
 
 .jetpack_premium .plan__plan-details .plan__plan-details-item,
-.jetpack_business .plan__plan-details .plan__plan-details-item {
+.jetpack_business .plan__plan-details .plan__plan-details-item,
+.jetpack_premium_monthly .plan__plan-details .plan__plan-details-item,
+.jetpack_business_monthly .plan__plan-details .plan__plan-details-item {
 	opacity: 1.0;
 	padding: 4px 0;
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -186,6 +186,7 @@ const Plans = React.createClass( {
 							isSubmitting={ this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST } />
 
 						{ ! hasJpphpBundle && this.comparePlansLink() }
+						{ ! hasJpphpBundle && this.showMonthlyPlansLink() }
 					</div>
 				</Main>
 			</div>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -4,6 +4,7 @@
 import { connect } from 'react-redux';
 import page from 'page';
 import React from 'react';
+import find from 'lodash/find';
 
 /**
  * Internal dependencies
@@ -26,6 +27,8 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import QueryPlans from 'components/data/query-plans';
+import { PLAN_MONTHLY_PERIOD } from 'lib/plans/constants';
+
 
 const Plans = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
@@ -96,7 +99,13 @@ const Plans = React.createClass( {
 		}
 
 		let intervalType = this.props.intervalType,
-			showString = '';
+			showString = '',
+			hasMonthlyPlans = find( this.props.sitePlans.data, { interval: PLAN_MONTHLY_PERIOD } );
+
+		if ( hasMonthlyPlans === undefined ) {
+			//No monthly plan found for this site so no need for a monthly plans link
+			return '';
+		}
 
 		if ( 'monthly' === intervalType ) {
 			intervalType = '';

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -21,7 +21,7 @@ import observe from 'lib/mixins/data-observe';
 import paths from './paths';
 import PlanList from 'components/plans/plan-list' ;
 import PlanOverview from './plan-overview';
-import { shouldFetchSitePlans } from 'lib/plans';
+import { shouldFetchSitePlans, plansLink } from 'lib/plans';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
@@ -34,6 +34,7 @@ const Plans = React.createClass( {
 		cart: React.PropTypes.object.isRequired,
 		context: React.PropTypes.object.isRequired,
 		destinationType: React.PropTypes.string,
+		intervalType: React.PropTypes.string,
 		plans: React.PropTypes.array.isRequired,
 		fetchSitePlans: React.PropTypes.func.isRequired,
 		sites: React.PropTypes.object.isRequired,
@@ -68,26 +69,47 @@ const Plans = React.createClass( {
 	},
 
 	comparePlansLink() {
+		if ( this.props.plans.length <= 0 ) {
+			return '';
+		}
+
 		const selectedSite = this.props.sites.getSelectedSite();
-		let url = '/plans/compare',
+		let url = plansLink( '/plans/compare', selectedSite, this.props.intervalType ),
 			compareString = this.translate( 'Compare Plans' );
 
 		if ( selectedSite.jetpack ) {
 			compareString = this.translate( 'Compare Options' );
 		}
 
-		if ( this.props.plans.length <= 0 ) {
-			return '';
-		}
-
-		if ( selectedSite ) {
-			url += '/' + selectedSite.slug;
-		}
-
 		return (
 			<a href={ url } className="compare-plans-link" onClick={ this.recordComparePlansClick }>
 				<Gridicon icon="clipboard" size={ 18 } />
 				{ compareString }
+			</a>
+		);
+	},
+
+	showMonthlyPlansLink() {
+		const selectedSite = this.props.sites.getSelectedSite();
+		if ( !selectedSite.jetpack ) {
+			return '';
+		}
+
+		let intervalType = this.props.intervalType,
+			showString = '';
+
+		if ( 'monthly' === intervalType ) {
+			intervalType = '';
+			showString = this.translate( 'Show Yearly Plans' );
+		} else {
+			intervalType = 'monthly';
+			showString = this.translate( 'Show Monthly Plans' );
+		}
+
+		return (
+			<a href={ plansLink( '/plans', selectedSite, intervalType ) } className="show-monthly-plans-link" onClick={ this.recordShowMonthlyPlansClick }>
+				<Gridicon icon="refresh" size={ 18 } />
+				{ showString }
 			</a>
 		);
 	},
@@ -150,9 +172,11 @@ const Plans = React.createClass( {
 							sitePlans={ this.props.sitePlans }
 							onOpen={ this.openPlan }
 							cart={ this.props.cart }
+							intervalType={ this.props.intervalType }
 							isSubmitting={ this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST } />
 
 						{ ! hasJpphpBundle && this.comparePlansLink() }
+						{ ! hasJpphpBundle && this.showMonthlyPlansLink() }
 					</div>
 				</Main>
 			</div>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -186,7 +186,6 @@ const Plans = React.createClass( {
 							isSubmitting={ this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST } />
 
 						{ ! hasJpphpBundle && this.comparePlansLink() }
-						{ ! hasJpphpBundle && this.showMonthlyPlansLink() }
 					</div>
 				</Main>
 			</div>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -107,7 +107,7 @@ const Plans = React.createClass( {
 		}
 
 		return (
-			<a href={ plansLink( '/plans', selectedSite, intervalType ) } className="show-monthly-plans-link" onClick={ this.recordShowMonthlyPlansClick }>
+			<a href={ plansLink( '/plans', selectedSite, intervalType ) } className="show-monthly-plans-link" onClick={ this.recordComparePlansClick }>
 				<Gridicon icon="refresh" size={ 18 } />
 				{ showString }
 			</a>
@@ -164,6 +164,7 @@ const Plans = React.createClass( {
 							cart={ this.props.cart }
 							selectedSite={ selectedSite } />
 
+						{ ! hasJpphpBundle && this.showMonthlyPlansLink() }
 						<QueryPlans />
 
 						<PlanList
@@ -176,7 +177,6 @@ const Plans = React.createClass( {
 							isSubmitting={ this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST } />
 
 						{ ! hasJpphpBundle && this.comparePlansLink() }
-						{ ! hasJpphpBundle && this.showMonthlyPlansLink() }
 					</div>
 				</Main>
 			</div>

--- a/client/my-sites/plans/paths.js
+++ b/client/my-sites/plans/paths.js
@@ -2,8 +2,8 @@ function root() {
 	return '/plans';
 }
 
-function plans( siteName = ':site' ) {
-	return root() + `/${ siteName }`;
+function plans( siteName = ':site', intervalType = ':intervalType?' ) {
+	return root() + `/${ intervalType }` + `/${ siteName }`;
 }
 
 function plansDestination( siteName = ':site', destinationType = ':destinationType?' ) {

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -1,5 +1,5 @@
 .plans {
-	.compare-plans-link {
+	.compare-plans-link, .show-monthly-plans-link {
 		clear: both;
 		display: block;
 		font-size: 12px;

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -3,7 +3,7 @@
 		clear: both;
 		display: block;
 		font-size: 12px;
-		margin: 20px 0 0 0;
+		margin: 20px 0 20px 0;
 		text-align: center;
 
 		.gridicon {

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -13,6 +13,7 @@ import {
 	isDomainProduct,
 	isGoogleApps,
 	isTheme,
+	isMonthly,
 	isPlan
 } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
@@ -70,6 +71,10 @@ export default React.createClass( {
 			return null;
 		}
 
+		if ( isMonthly( this.props.cartItem ) ) {
+			return null;
+		}
+
 		return this.translate( '(%(monthlyPrice)f %(currency)s x 12 months)', {
 			args: {
 				monthlyPrice: +( cost / 12 ).toFixed( currency === 'JPY' ? 0 : 2 ),
@@ -116,7 +121,11 @@ export default React.createClass( {
 	render: function() {
 		var name = this.getProductName();
 		if ( this.props.cartItem.bill_period && this.props.cartItem.bill_period !== -1 ) {
-			name += ' - ' + this.translate( 'annual subscription' );
+			if ( isMonthly( this.props.cartItem ) ) {
+				name += ' - ' + this.translate( 'monthly subscription' );
+			} else {
+				name += ' - ' + this.translate( 'annual subscription' );
+			}
 		}
 
 		return (

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -18,6 +18,7 @@ const createSitePlanObject = ( plan ) => {
 		freeTrial: Boolean( plan.free_trial ),
 		hasDomainCredit: Boolean( plan.has_domain_credit ),
 		id: Number( plan.id ),
+		interval: Number( plan.interval ),
 		productName: plan.product_name,
 		productSlug: plan.product_slug,
 		rawDiscount: plan.raw_discount,


### PR DESCRIPTION
This adds support for monthly Jetpack plans. When a user has a Jetpack site, they will be able to choose between yearly and monthly jetpack plans, meaning they can pay yearly on each month.

To test;
Apply patch so API endpoints will include new monthly Jetpack plans - D1786-code
Open an account with a Jetpack site connected
Go to plans page for this site i.e. /plans/{jetpack site name}
Try the 'Show Monthly Plans' link on the plans page
Try the Compare Plans page while viewing monthly plans and verify that monthly plans are compared
Try the 'Show Yearly Plans' link on plans page
Try a wpcom site to verify that it works as normal
Anything else you can think of...

Test live: https://calypso.live/?branch=add/jetpack-monthly-plans-support