### PR TITLE
Framework: define "sites" as a section to avoid 404s.

### DIFF
--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -12,6 +12,13 @@ var sections,
 
 sections = [
 	{
+		name: 'sites',
+		paths: [ '/sites' ],
+		module: 'my-sites',
+		group: 'sites',
+		secondary: true
+	},
+	{
 		name: 'customize',
 		paths: [ '/customize' ],
 		module: 'my-sites/customize',


### PR DESCRIPTION
Caused by #5823. 

Test live: https://calypso.live/?branch=fix/sites-url-section