### PR TITLE
Define a `getThemes` method for setting the initial state.

### DIFF
--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -29,7 +29,7 @@ module.exports = React.createClass( {
 
 	getInitialState() {
 		return {
-			themes: getThemes( this.props.signupDependencies.surveyQuestion, this.props.signupDependencies.designType )
+			themes: this.getThemes()
 		};
 	},
 
@@ -38,6 +38,10 @@ module.exports = React.createClass( {
 		if ( surveyQuestion !== this.props.signupDependencies.surveyQuestion || designType !== this.props.signupDependencies.designType ) {
 			this.setState( { themes: this.getThemes() } );
 		}
+	},
+
+	getThemes() {
+		return getThemes( this.props.signupDependencies.surveyQuestion, this.props.signupDependencies.designType );
 	},
 
 	handleScreenshotClick( theme ) {


### PR DESCRIPTION
This will also be used to reload themes [if props change](https://github.com/Automattic/wp-calypso/blob/master/client/signup/steps/theme-selection/index.jsx#L39) (currently it would fatal).

Test live: https://calypso.live/?branch=fix/signup-missing-theme-method