### PR TITLE
Sign Up: show plans step for users not in DWPO

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -109,6 +109,23 @@ const DomainsStep = React.createClass( {
 		return `${repo}/${themeSlug}`;
 	},
 
+	goToNextStep( isPurchasingItem ) {
+		if ( abtest( 'domainsWithPlansOnly' ) === 'plansOnly' || ! isPurchasingItem ) {
+			this.props.goToNextStep();
+			return;
+		}
+
+		SignupActions.submitSignupStep( {
+			processingMessage: this.translate( 'Free plan selected' ),
+			stepName: 'plans',
+			stepSectionName: this.props.stepSectionName,
+			cartItem: null
+		}, [], { cartItem: null } );
+
+		const plansIndex = this.props.steps.indexOf( 'plans' );
+		this.props.goToStep( this.props.steps[ plansIndex + 1 ] );
+	},
+
 	submitWithDomain: function( googleAppsCartItem ) {
 		const suggestion = this.props.step.suggestion,
 			isPurchasingItem = Boolean( suggestion.product_slug ),
@@ -132,7 +149,7 @@ const DomainsStep = React.createClass( {
 			stepSectionName: this.props.stepSectionName
 		}, this.getThemeArgs() ), [], { domainItem } );
 
-		this.props.goToNextStep();
+		this.goToNextStep( isPurchasingItem );
 	},
 
 	handleAddMapping: function( sectionName, domain, state ) {
@@ -151,7 +168,7 @@ const DomainsStep = React.createClass( {
 			stepSectionName: this.props.stepSectionName
 		}, this.getThemeArgs() ) );
 
-		this.props.goToNextStep();
+		this.goToNextStep( isPurchasingItem );
 	},
 
 	handleSave: function( sectionName, state ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -110,7 +110,7 @@ const DomainsStep = React.createClass( {
 	},
 
 	goToNextStep( isPurchasingItem ) {
-		if ( abtest( 'domainsWithPlansOnly' ) === 'plansOnly' || ! isPurchasingItem ) {
+		if ( ! isPurchasingItem ) {
 			this.props.goToNextStep();
 			return;
 		}


### PR DESCRIPTION
Plans step on signup only show the plans step for users not making a purchase or on DWPO. Otherwise, we add the Free Plan and leave the upgrade on the shopping cart.


Test live: https://calypso.live/?branch=fix/signup-plans-allow-existing-users