### PR TITLE
Guided Transfer: Add guided transfer description

### DIFF
--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -8,6 +8,7 @@ import React, { PropTypes } from 'react';
  */
 import FoldableCard from 'components/foldable-card';
 import GuidedTransferOptions from 'my-sites/exporter/guided-transfer-options';
+import GuidedTransferDetails from 'my-sites/exporter/guided-transfer-details';
 import AdvancedSettings from 'my-sites/exporter/advanced-settings';
 import SpinnerButton from './spinner-button';
 import Interval, { EVERY_SECOND } from 'lib/interval';
@@ -119,6 +120,7 @@ export default React.createClass( {
 					/>
 				</FoldableCard>
 				{ showGuidedTransferOptions && <GuidedTransferOptions siteSlug={ this.props.siteSlug } /> }
+				{ showGuidedTransferOptions && <GuidedTransferDetails /> }
 				{ isExporting && <Interval onTick={ fetchStatus } period={ EVERY_SECOND } /> }
 			</div>
 		);

--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -66,7 +66,7 @@ export default React.createClass( {
 				loadingText={ this.translate( 'Exporting…' ) } />
 		);
 
-		var notice = null;
+		let notice = null;
 		if ( this.props.didComplete ) {
 			notice = (
 				<Notice

--- a/client/my-sites/exporter/guided-transfer-details.jsx
+++ b/client/my-sites/exporter/guided-transfer-details.jsx
@@ -31,7 +31,9 @@ site{{/strong}} to a self-hosted WordPress.org installation with
 one of our hosting partners.`, { components: { strong: <strong /> } }
 				) }
 				<br/>
-				<a href="#" >{ translate( 'Learn more.' ) }</a>
+				<a href="https://en.support.wordpress.com/guided-transfer/" >
+					{ translate( 'Learn more.' ) }
+				</a>
 			</div>
 			<ul className="exporter__guided-transfer-feature-list">
 				<Item>{ translate( 'Seamless content transfer' ) }</Item>
@@ -39,7 +41,7 @@ one of our hosting partners.`, { components: { strong: <strong /> } }
 				<Item>
 					{ translate( 'Switch your domain over {{link}}and more!{{/link}}', {
 						components: {
-							link: <a href="#" />
+							link: <a href="https://en.support.wordpress.com/guided-transfer/" />
 						}
 					} ) }
 				</Item>

--- a/client/my-sites/exporter/guided-transfer-details.jsx
+++ b/client/my-sites/exporter/guided-transfer-details.jsx
@@ -8,16 +8,16 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import GridiconList from 'components/gridicon-list';
-import GridiconListItem from 'components/gridicon-list/item';
+import Gridicon from 'components/gridicon';
 
 const GuidedTransferDetails = ( { translate } ) => {
 	const Item = ( { children } ) =>
-		<GridiconListItem className="exporter__guided-transfer-feature-list-item" icon="checkmark">
+		<li className="exporter__guided-transfer-feature-list-item">
+			<Gridicon className="exporter__guided-transfer-feature-icon" size={ 18 } icon="checkmark" />
 			<span className="exporter__guided-transfer-feature-text">
 				{ children }
 			</span>
-		</GridiconListItem>;
+		</li>;
 
 	return <CompactCard className="exporter__guided-transfer-details">
 		<div className="exporter__guided-transfer-details-container">
@@ -33,7 +33,7 @@ one of our hosting partners.`, { components: { strong: <strong /> } }
 				<br/>
 				<a href="#" >{ translate( 'Learn more.' ) }</a>
 			</div>
-			<GridiconList className="exporter__guided-transfer-feature-list">
+			<ul className="exporter__guided-transfer-feature-list">
 				<Item>{ translate( 'Seamless content transfer' ) }</Item>
 				<Item>{ translate( 'Install and configure plugins to keep your functionality' ) }</Item>
 				<Item>
@@ -43,7 +43,7 @@ one of our hosting partners.`, { components: { strong: <strong /> } }
 						}
 					} ) }
 				</Item>
-			</GridiconList>
+			</ul>
 		</div>
 	</CompactCard>;
 };

--- a/client/my-sites/exporter/guided-transfer-details.jsx
+++ b/client/my-sites/exporter/guided-transfer-details.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+
+const GuidedTransferDetails = ( { translate } ) =>
+	<CompactCard className="exporter__guided-transfer-details">
+		<div className="exporter__guided-transfer-details-container">
+			<div className="exporter__guided-transfer-details-text">
+				<h1 className="exporter__guided-transfer-details-title">
+					{ translate( 'Hassle-free migration with two weeks of support' ) }
+				</h1>
+				{ translate(
+`Have one of our Happiness Engineers {{strong}}transfer your
+site{{/strong}} to a self-hosted WordPress.org installation with
+one of our hosting partners.`, { components: { strong: <strong /> } }
+				) }
+				<br/>
+				<a href="#" >{ translate( 'Learn more.' ) }</a>
+			</div>
+			<ul className="exporter__guided-transfer-feature-list">
+			<li>{ translate( 'Seamless content transfer' ) }</li>
+			<li>{ translate( 'Install and configure plugins to keep your functionality' ) }</li>
+			<li>{ translate( 'Switch your domain over {{link}}and more!{{/link}}', {
+				components: {
+					link: <a href="#" />
+				}
+			} ) }</li>
+			</ul>
+		</div>
+	</CompactCard>;
+
+export default localize( GuidedTransferDetails );
+

--- a/client/my-sites/exporter/guided-transfer-details.jsx
+++ b/client/my-sites/exporter/guided-transfer-details.jsx
@@ -8,9 +8,18 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
+import GridiconList from 'components/gridicon-list';
+import GridiconListItem from 'components/gridicon-list/item';
 
-const GuidedTransferDetails = ( { translate } ) =>
-	<CompactCard className="exporter__guided-transfer-details">
+const GuidedTransferDetails = ( { translate } ) => {
+	const Item = ( { children } ) =>
+		<GridiconListItem className="exporter__guided-transfer-feature-list-item" icon="checkmark">
+			<span className="exporter__guided-transfer-feature-text">
+				{ children }
+			</span>
+		</GridiconListItem>;
+
+	return <CompactCard className="exporter__guided-transfer-details">
 		<div className="exporter__guided-transfer-details-container">
 			<div className="exporter__guided-transfer-details-text">
 				<h1 className="exporter__guided-transfer-details-title">
@@ -24,17 +33,20 @@ one of our hosting partners.`, { components: { strong: <strong /> } }
 				<br/>
 				<a href="#" >{ translate( 'Learn more.' ) }</a>
 			</div>
-			<ul className="exporter__guided-transfer-feature-list">
-			<li>{ translate( 'Seamless content transfer' ) }</li>
-			<li>{ translate( 'Install and configure plugins to keep your functionality' ) }</li>
-			<li>{ translate( 'Switch your domain over {{link}}and more!{{/link}}', {
-				components: {
-					link: <a href="#" />
-				}
-			} ) }</li>
-			</ul>
+			<GridiconList className="exporter__guided-transfer-feature-list">
+				<Item>{ translate( 'Seamless content transfer' ) }</Item>
+				<Item>{ translate( 'Install and configure plugins to keep your functionality' ) }</Item>
+				<Item>
+					{ translate( 'Switch your domain over {{link}}and more!{{/link}}', {
+						components: {
+							link: <a href="#" />
+						}
+					} ) }
+				</Item>
+			</GridiconList>
 		</div>
 	</CompactCard>;
+};
 
 export default localize( GuidedTransferDetails );
 

--- a/client/my-sites/exporter/guided-transfer-options.jsx
+++ b/client/my-sites/exporter/guided-transfer-options.jsx
@@ -23,12 +23,15 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<div>
-				<CompactCard>
+			<CompactCard>
+				<div className="exporter__guided-transfer-options">
 					<div className="exporter__guided-transfer-options-header-title-container">
-						<h1 className="exporter__title">
+						<h1 className="exporter__guided-transfer-title">
 							{ this.translate( 'Guided Transfer' ) }
 						</h1>
+						<h2 className="exporter__guided-transfer-subtitle">
+							<span className="exporter__guided-transfer-price">$129</span> One-time expense
+						</h2>
 					</div>
 					<div className="exporter__guided-transfer-options-header-button-container">
 						<Button
@@ -37,8 +40,8 @@ export default React.createClass( {
 							{ this.translate( 'Purchase a Guided Transfer' ) }
 						</Button>
 					</div>
-				</CompactCard>
-			</div>
+				</div>
+			</CompactCard>
 		);
 	}
 } );

--- a/client/my-sites/exporter/spinner-button.jsx
+++ b/client/my-sites/exporter/spinner-button.jsx
@@ -26,7 +26,7 @@ export default React.createClass( {
 		return {
 			size: 24,
 			loading: false
-		}
+		};
 	},
 
 	render() {

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -82,13 +82,56 @@
 }
 
 // START GUIDED TRANSFER
+.exporter__guided-transfer-options {
+	display: flex;
+}
+
 .exporter__guided-transfer-options-header-title-container {
-	display: inline-block;
-	float: left;
+	flex-grow: 1;
 }
 
 .exporter__guided-transfer-options-header-button-container {
-	display: inline-block;
-	float: right;
+	margin: auto;
+}
+
+.exporter__guided-transfer-title {
+	font-size: 21px;
+	font-weight: 300;
+	color: $gray-dark;
+	clear: left;
+}
+
+.exporter__guided-transfer-subtitle {
+	color: $gray;
+	font-style: italic;
+	font-size: 14px;
+}
+
+.exporter__guided-transfer-price {
+	font-style: normal;
+	font-size: 18px;
+}
+
+.exporter__guided-transfer-details {
+	background-color: lighten( $gray-light, 2% );
+}
+
+.exporter__guided-transfer-details-container {
+	display: flex;
+}
+
+.exporter__guided-transfer-details-title {
+	color: $gray-dark;
+	font-weight: 600;
+	margin-bottom: 12px;
+}
+
+.exporter__guided-transfer-details-text {
+	flex-basis: 60%;
+	color: $gray;
+}
+
+.exporter__guided-transfer-feature-list {
+	flex-basis: 40%;
 }
 // END GUIDED TRANSFER

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -132,6 +132,15 @@
 }
 
 .exporter__guided-transfer-feature-list {
+	color: $alert-green;
 	flex-basis: 40%;
+
+	.exporter__guided-transfer-feature-list-item {
+		margin-bottom: 8px;
+	}
+}
+
+.exporter__guided-transfer-feature-text {
+	color: $gray;
 }
 // END GUIDED TRANSFER

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -84,6 +84,7 @@
 // START GUIDED TRANSFER
 .exporter__guided-transfer-options {
 	display: flex;
+	font-size: 14px;
 }
 
 .exporter__guided-transfer-options-header-title-container {
@@ -114,6 +115,7 @@
 
 .exporter__guided-transfer-details {
 	background-color: lighten( $gray-light, 2% );
+	font-size: 14px;
 }
 
 .exporter__guided-transfer-details-container {

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -136,7 +136,15 @@
 	flex-basis: 40%;
 
 	.exporter__guided-transfer-feature-list-item {
+		list-style-type: none;
+		text-indent: -24px;
 		margin-bottom: 8px;
+	}
+
+	.exporter__guided-transfer-feature-icon {
+		margin-right: 6px;
+		margin-top: -4px;
+		vertical-align: middle;
 	}
 }
 


### PR DESCRIPTION
~~Depends on #6113~~

This purely UI change adds details explaining the Guided Transfer on the Export tab, along with a link to documentation about the process.

### Before
![screen shot 2016-06-15 at 11 46 15 am](https://cloud.githubusercontent.com/assets/416133/16065521/cc62b0a8-32ee-11e6-9028-f924658945d6.png)

### After
#### Original design by @mrheston:
<img width="536" alt="screen shot 2016-06-14 at 4 03 42 pm" src="https://cloud.githubusercontent.com/assets/416133/16065475/73977c10-32ee-11e6-84ad-7465729abcf7.png">

#### Current PR:
![screen shot 2016-06-17 at 9 40 34 pm](https://cloud.githubusercontent.com/assets/416133/16149443/2acb23dc-34d4-11e6-8b3c-a41c9192a40f.png)

### How to test
1. Go to https://calypso.live/?branch=add/guided-transfer/export-description
2. Go to My Site > Settings > Export

cc @dllh @scruffian 