### PR TITLE
Stats: update Most Popular component to use QuerySiteStats.

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -121,7 +121,6 @@ module.exports = {
 			activeFilter = false,
 			basePath = route.sectionify( context.path ),
 			followList,
-			insightsList,
 			commentsList,
 			tagsList,
 			publicizeList,
@@ -169,7 +168,6 @@ module.exports = {
 		const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
 			? site.slug : route.getSiteFragment( context.path );
 
-		insightsList = new StatsList( { siteID: siteId, statType: 'statsInsights', domain: siteDomain } );
 		commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: siteDomain } );
 		tagsList = new StatsList( { siteID: siteId, statType: 'statsTags', domain: siteDomain } );
 		publicizeList = new StatsList( { siteID: siteId, statType: 'statsPublicize', domain: siteDomain } );
@@ -184,7 +182,6 @@ module.exports = {
 				React.createElement( StatsComponent, {
 					site: site,
 					followList: followList,
-					insightsList: insightsList,
 					commentsList: commentsList,
 					tagsList: tagsList,
 					publicizeList: publicizeList,

--- a/client/my-sites/stats/most-popular/index.jsx
+++ b/client/my-sites/stats/most-popular/index.jsx
@@ -42,21 +42,21 @@ class StatsMostPopular extends Component {
 			statType
 		} = this.props;
 
-		const classes = [
+		const classes = classNames(
+			'most-popular',
 			'stats-module',
-			'stats-most-popular',
 			'is-site-overview',
 			{
 				'is-loading': requesting && ! percent,
 				'is-empty': ! percent
 			}
-		];
+		);
 
 		return (
 			<div>
 				{ siteId && <QuerySiteStats siteId={ siteId } statType={ statType } /> }
 				<SectionHeader label={ translate( 'Most popular day and hour' ) }></SectionHeader>
-					<Card className={ classNames( classes ) }>
+					<Card className={ classes }>
 						<div className="most-popular__wrapper">
 							<div className="most-popular__item">
 								<span className="most-popular__label">{ translate( 'Most popular day' ) }</span>

--- a/client/my-sites/stats/most-popular/index.jsx
+++ b/client/my-sites/stats/most-popular/index.jsx
@@ -1,47 +1,58 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	SectionHeader = require( 'components/section-header' );
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsInsightsData
+} from 'state/stats/lists/selectors';
 
-module.exports = React.createClass( {
-	displayName: 'StatsModuleMostPopular',
-
+const StatsMostPopular = React.createClass( {
 	propTypes: {
-		insightsList: React.PropTypes.object.isRequired
+		day: PropTypes.string,
+		percent: PropTypes.number,
+		hour: PropTypes.string,
+		hour_percent: PropTypes.number,
+		requesting: PropTypes.bool,
+		siteId: PropTypes.number,
+		query: PropTypes.object
 	},
 
-	mixins: [ observe( 'insightsList' ) ],
+	mixins: [ PureRenderMixin ],
 
-	render: function() {
-		var emptyMessage = null,
-			data,
-			isLoading,
-			isEmpty,
-			classes;
+	render() {
+		const {
+			day,
+			percent,
+			hour,
+			hour_percent,
+			requesting,
+			siteId
+		} = this.props;
+		let emptyMessage;
 
-		data = this.props.insightsList.response;
-		isLoading = this.props.insightsList.isLoading();
-		isEmpty = ! ( data.percent );
-
-		classes = [
+		const classes = [
 			'stats-module',
 			'stats-most-popular',
 			'is-site-overview',
 			{
-				'is-loading': isLoading,
-				'is-empty': isEmpty
+				'is-loading': requesting,
+				'is-empty': ! percent
 			}
 		];
 
-		if ( isEmpty && ! isLoading ) {
+		if ( ! percent && ! requesting ) {
 			// should use real notice component or custom class
 			emptyMessage = (
 				<div className="stats-popular__empty">
@@ -57,19 +68,20 @@ module.exports = React.createClass( {
 
 		return (
 			<div>
+				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsInsights" /> }
 				<SectionHeader label={ this.translate( 'Most popular day and hour' ) }></SectionHeader>
 					<Card className={ classNames( classes ) }>
 						<div className="module-content">
 							<div className="stats-popular">
 								<div className="stats-popular__item">
 									<span className="stats-popular__label">{ this.translate( 'Most popular day' ) }</span>
-									<span className="stats-popular__day">{ data.day }</span>
-									<span className="stats-popular__percentage">{ this.translate( '%(percent)d%% of views', { args: { percent: data.percent || 0 }, context: 'Stats: Percentage of views' } ) }</span>
+									<span className="stats-popular__day">{ day }</span>
+									<span className="stats-popular__percentage">{ this.translate( '%(percent)d%% of views', { args: { percent: percent || 0 }, context: 'Stats: Percentage of views' } ) }</span>
 								</div>
 								<div className="stats-popular__item">
 									<span className="stats-popular__label">{ this.translate( 'Most popular hour' ) }</span>
-									<span className="stats-popular__hour">{ data.hour }</span>
-									<span className="stats-popular__percentage">{ this.translate( '%(percent)d%% of views', { args: { percent: data.hour_percent || 0 }, context: 'Stats: Percentage of views' } ) }</span>
+									<span className="stats-popular__hour">{ hour }</span>
+									<span className="stats-popular__percentage">{ this.translate( '%(percent)d%% of views', { args: { percent: hour_percent || 0 }, context: 'Stats: Percentage of views' } ) }</span>
 								</div>
 								{ emptyMessage }
 							</div>
@@ -79,3 +91,14 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const allTimeData = getSiteStatsInsightsData( state, siteId );
+
+	return {
+		requesting: isRequestingSiteStatsForQuery( state, siteId, 'statsInsights', {} ),
+		siteId,
+		...allTimeData
+	};
+} )( StatsMostPopular );

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -13,16 +13,6 @@
 	}
 }
 
-.most-popular {
-	position: relative;
-	width: 80%;
-	margin: 0 auto;
-
-	@include breakpoint( "<480px" ) {
-		width: 100%;
-	}
-}
-
 .most-popular__item {
 	width: 50%;
 	float: left;

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -1,10 +1,10 @@
 // Most popular Day and Time section
 
-.stats-most-popular {
+.most-popular__wrapper {
 	clear: both;
 }
 
-.stats-module.is-loading .stats-popular,
+.stats-module.is-loading .most-popular__wrapper,
 .is-empty .stats-popular {
 	min-height: 150px;
 
@@ -13,7 +13,7 @@
 	}
 }
 
-.stats-popular {
+.most-popular {
 	position: relative;
 	width: 80%;
 	margin: 0 auto;
@@ -23,7 +23,7 @@
 	}
 }
 
-.stats-popular__item {
+.most-popular__item {
 	width: 50%;
 	float: left;
 	text-align: center;
@@ -39,13 +39,13 @@
 	}
 }
 
-.stats-popular__label {
+.most-popular__label {
 	text-transform: uppercase;
 	font-size: 11px;
 	letter-spacing: 0.1em;
 }
 
-.stats-popular__percentage {
+.most-popular__percentage {
 	color: $gray;
 	display: block;
 	margin-top: -1em;
@@ -53,19 +53,15 @@
 	letter-spacing: 0.01em;
 }
 
-.stats-popular__day,
-.stats-popular__hour {
+.most-popular__day,
+.most-popular__hour {
 	display: block;
-}
-
-.stats-popular__day,
-.stats-popular__hour {
 	color: $gray-dark;
 	font-size: 20px;
 	margin: 6px 0 22px;
 }
 
-.stats-popular__empty {
+.most-popular__empty {
 	position: absolute;
 		top: 40px;
 		right: 0;
@@ -74,11 +70,17 @@
 	line-height: 24px;
 	clear: both;
 	z-index: z-index( 'root', '.stats-popular__empty' );
+}
 
-	.notice {
-		box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px $gray-light;
-		color: $gray-dark;
-		display: inline-block;
-		padding: 15px 45px;
-	}
+.most-popular__notice {
+	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px $gray-light;
+	color: $gray-dark;
+	display: inline-block;
+	padding: 15px 45px;
+	position: relative;
+	margin-bottom: 24px;
+	border-radius: 1px;
+	background: lighten( $gray, 30 );
+	box-sizing: border-box;
+	animation: appear .3s ease-in-out;
 }

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -29,7 +29,6 @@ export default React.createClass( {
 		commentsList: PropTypes.object.isRequired,
 		emailFollowersList: PropTypes.object.isRequired,
 		followList: PropTypes.object.isRequired,
-		insightsList: PropTypes.object.isRequired,
 		publicizeList: PropTypes.object.isRequired,
 		site: React.PropTypes.oneOfType( [
 			React.PropTypes.bool,
@@ -45,7 +44,6 @@ export default React.createClass( {
 			commentsList,
 			emailFollowersList,
 			followList,
-			insightsList,
 			publicizeList,
 			site,
 			wpcomFollowersList } = this.props;
@@ -87,7 +85,7 @@ export default React.createClass( {
 						title={ this.translate( 'Today\'s Stats' ) }
 					/>
 					<AllTime />
-					<MostPopular insightsList={ insightsList } />
+					<MostPopular />
 					<DomainTip siteId={ site ? site.ID : 0 } event="stats_insights_domain" />
 					<div className="stats-nonperiodic has-recent">
 						<div className="module-list">

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -10,7 +10,6 @@ import {
 	getSiteStatsMaxPostsByDay,
 	getSiteStatsPostStreakData,
 	getSiteStatsForQuery,
-	getSiteStatsInsightsData,
 	getSiteStatsPostsCountByDay,
 	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -10,6 +10,7 @@ import {
 	getSiteStatsMaxPostsByDay,
 	getSiteStatsPostStreakData,
 	getSiteStatsForQuery,
+	getSiteStatsInsightsData,
 	getSiteStatsPostsCountByDay,
 	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -69,5 +69,35 @@ describe( 'utils', () => {
 				} );
 			} );
 		} );
+
+		describe( 'statsInsights()', () => {
+			it( 'should return an empty object if no data is passed', () => {
+				const stats = normalizers.statsInsights();
+
+				expect( stats ).to.eql( {} );
+			} );
+
+			it( 'should return null if data.highest_day_of_week is not numeric', () => {
+				const stats = normalizers.statsInsights( { highest_day_of_week: false } );
+
+				expect( stats ).to.eql( {} );
+			} );
+
+			it( 'should return properly formatted data if matching data exists', () => {
+				const stats = normalizers.statsInsights( {
+					highest_hour: 11,
+					highest_day_percent: 10,
+					highest_day_of_week: 6,
+					highest_hour_percent: 5
+				} );
+
+				expect( stats ).to.eql( {
+					day: 'Sunday',
+					hour: '11:00 AM',
+					hourPercent: 5,
+					percent: 10
+				} );
+			} );
+		} );
 	} );
 } );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -5,6 +5,8 @@ import sortBy from 'lodash/sortBy';
 import toPairs from 'lodash/toPairs';
 import camelCase from 'lodash/camelCase';
 import mapKeys from 'lodash/mapKeys';
+import isNumber from 'lodash/isNumber';
+import { moment } from 'i18n-calypso';
 
 /**
  * Returns a serialized stats query, used as the key in the
@@ -30,5 +32,31 @@ export const normalizers = {
 		}
 
 		return mapKeys( data.stats, ( value, key ) => camelCase( key ) );
+	},
+
+	/**
+	 * Returns a normalized payload from `/sites/{ site }/stats/insights`
+	 *
+	 * @param  {Object} data    Stats query
+	 * @return {Object?}        Normalized stats data
+	 */
+	statsInsights: ( data ) => {
+		if ( ! data || ! isNumber( data.highest_day_of_week ) ) {
+			return {};
+		}
+
+		const { highest_hour, highest_day_percent, highest_day_of_week, highest_hour_percent } = data;
+		// Adjust Day of Week from 0 = Monday to 0 = Sunday (for Moment)
+		let dayOfWeek = highest_day_of_week + 1;
+		if ( dayOfWeek > 6 ) {
+			dayOfWeek = 0;
+		}
+
+		return {
+			day: moment().day( dayOfWeek ).format( 'dddd' ),
+			percent: Math.round( highest_day_percent ),
+			hour: moment().hour( highest_hour ).startOf( 'hour' ).format( 'LT' ),
+			hourPercent: Math.round( highest_hour_percent )
+		};
 	}
 };

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -45,7 +45,13 @@ export const normalizers = {
 			return {};
 		}
 
-		const { highest_hour, highest_day_percent, highest_day_of_week, highest_hour_percent } = data;
+		const {
+			highest_hour,
+			highest_day_percent,
+			highest_day_of_week,
+			highest_hour_percent
+		} = data;
+
 		// Adjust Day of Week from 0 = Monday to 0 = Sunday (for Moment)
 		let dayOfWeek = highest_day_of_week + 1;
 		if ( dayOfWeek > 6 ) {


### PR DESCRIPTION
This branch updates the Most Popular component on the stats insights page to use `<QuerySiteStats />` and the global state tree - with the added benefit of turning Most Popular Stats into a pure component.

__To Test__
- Open up a stats insights page
- Validate the Most Popular component has the same data, and operates as it does in production ( loading state etc )

<img width="731" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/16066671/398a126e-326a-11e6-8e1c-a6f52e730568.png">


Test live: https://calypso.live/?branch=update/stats/most-popular-to-redux