### PR TITLE
SEO: Add Facebook preview components

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -92,8 +92,6 @@ export class SeoPreviewPane extends PureComponent {
 					<VerticalMenu onClick={ this.selectPreview }>
 						<SocialItem service="google" />
 						<SocialItem service="facebook" />
-						<SocialItem service="wordpress" />
-						<SocialItem service="linkedin" />
 						<SocialItem service="twitter" />
 					</VerticalMenu>
 				</div>

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -12,6 +12,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import FacebookPreview from 'components/seo/facebook-preview';
 import SearchPreview from 'components/seo/search-preview';
 import VerticalMenu from 'components/vertical-menu';
 import { SocialItem } from 'components/vertical-menu/items';
@@ -29,6 +30,26 @@ const GooglePreview = site =>
 		url={ site.URL }
 		snippet={ site.description }
 	/>;
+
+const PreviewFacebook = site => (
+	<div>
+		<FacebookPreview
+			title={ site.name }
+			url={ site.URL }
+			type="website"
+			description={ site.description }
+			image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
+		/>
+		<div style={ { marginBottom: '2em' } } />
+		<FacebookPreview
+			title={ site.name }
+			url={ site.URL }
+			type="article"
+			description={ site.description }
+			image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
+		/>
+	</div>
+);
 
 export class SeoPreviewPane extends PureComponent {
 	constructor( props ) {
@@ -79,6 +100,7 @@ export class SeoPreviewPane extends PureComponent {
 				<div className="seo-preview-pane__preview-area">
 					<div className="seo-preview-pane__preview">
 						{ get( {
+							facebook: PreviewFacebook( site ),
 							google: GooglePreview( site )
 						}, selectedService, ComingSoonMessage( translate ) ) }
 					</div>

--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -32,12 +32,14 @@
 	}
 }
 
+.seo-preview-pane__preview-area {
+	margin: 10px auto;
+}
+
 .seo-preview-pane__preview {
 	padding: 10px;
-	margin: 10px;
 	min-width: 400px;
 	height: auto;
-	width: 100%;
 
 	background-color: $white;
 	border: 1px solid lighten( $gray, 25% );

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -1,0 +1,74 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import PureComponent from 'react-pure-render/component';
+
+import {
+	firstValid,
+	hardTruncation,
+	shortEnough
+} from '../helpers';
+
+const TITLE_LENGTH = 40;
+const DESCRIPTION_LENGTH = 300;
+
+const baseDomain = url =>
+	url
+		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
+		.replace( /\/.*$/, '' ); // strip everything after the domain
+
+const facebookTitle = firstValid(
+	shortEnough( TITLE_LENGTH ),
+	hardTruncation( TITLE_LENGTH )
+);
+
+const facebookDescription = firstValid(
+	shortEnough( DESCRIPTION_LENGTH ),
+	hardTruncation( DESCRIPTION_LENGTH )
+);
+
+export class FacebookPreview extends PureComponent {
+	render() {
+		const {
+			url,
+			type,
+			title,
+			description,
+			image
+		} = this.props;
+
+		return (
+			<div className={ `facebook-preview facebook-preview__${ type }` }>
+				<div className="facebook-preview__content">
+					<div className="facebook-preview__image">
+						<img src={ image } />
+					</div>
+					<div className="facebook-preview__body">
+						<div className="facebook-preview__title">
+							{ facebookTitle( title || '' ) }
+						</div>
+						<div className="facebook-preview__description">
+							{ facebookDescription( description || '' ) }
+						</div>
+						<div className="facebook-preview__url">
+							{ baseDomain( url ) }
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+FacebookPreview.propTypes = {
+	url: PropTypes.string,
+	type: PropTypes.string,
+	title: PropTypes.string,
+	description: PropTypes.string,
+	image: PropTypes.string,
+};
+
+export default FacebookPreview;

--- a/client/components/seo/helpers.js
+++ b/client/components/seo/helpers.js
@@ -1,0 +1,22 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+export const shortEnough = limit => title => title.length <= limit ? title : false;
+
+export const truncatedAtSpace = ( lower, upper ) => fullTitle => {
+	const title = fullTitle.slice( 0, upper );
+	const lastSpace = title.lastIndexOf( ' ' );
+
+	return ( lastSpace > lower && lastSpace < upper )
+		? title.slice( 0, lastSpace ).concat( '…' )
+		: false;
+};
+
+export const hardTruncation = limit => title => title.slice( 0, limit ).concat( '…' );
+
+export const firstValid = ( ...predicates ) => a =>
+	find( predicates, ( p => false !== p( a ) ) )( a );

--- a/client/components/seo/search-preview/index.jsx
+++ b/client/components/seo/search-preview/index.jsx
@@ -5,26 +5,16 @@
  */
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
-import find from 'lodash/find';
+
+import {
+	firstValid,
+	hardTruncation,
+	shortEnough,
+	truncatedAtSpace
+} from '../helpers';
 
 const TITLE_LENGTH = 63;
 const SNIPPET_LENGTH = 160;
-
-const shortEnough = limit => title => title.length <= limit ? title : false;
-
-const truncatedAtSpace = ( lower, upper ) => fullTitle => {
-	const title = fullTitle.slice( 0, upper );
-	const lastSpace = title.lastIndexOf( ' ' );
-
-	return ( lastSpace > lower && lastSpace < upper )
-		? title.slice( 0, lastSpace ).concat( '…' )
-		: false;
-};
-
-const hardTruncation = limit => title => title.slice( 0, limit ).concat( '…' );
-
-const firstValid = ( ...predicates ) => a =>
-	find( predicates, ( p => false !== p( a ) ) )( a );
 
 const googleTitle = firstValid(
 	shortEnough( TITLE_LENGTH ),

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -9,11 +9,6 @@
  * @blame: dmsnell
 */
 
-.seo-search-preview {
-	margin-top: 1.5em;
-	margin-bottom: 1.5em;
-}
-
 .seo-search-preview__header {
 	margin: 0;
 	padding: 8px 0;

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -102,6 +102,7 @@
 	font-weight: 500;
 	line-height: 22px;
 	max-height: 100px;
+	max-width: 345px;
 	transition: color 0.1s ease-in-out;
 }
 
@@ -111,6 +112,7 @@
 	font-size: 12px;
 	line-height: 16px;
 	max-height: 80px;
+	max-width: 345px;
 }
 
 .facebook-preview__url {

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -1,3 +1,14 @@
+/*
+ * CSS values in this file are specific and
+ * designed to match the CSS on external sites,
+ * such as Google and Facebook. Therefore there
+ * will be exceptions to our CSS guidelines here
+ * but please do not "update" this file to
+ * conform.
+ *
+ * @blame: dmsnell
+*/
+
 .seo-search-preview {
 	margin-top: 1.5em;
 	margin-bottom: 1.5em;
@@ -60,5 +71,114 @@
 		font-size: 14px;
 		line-height: 18px;
 		padding: 8px 12px;
+	}
+}
+
+.facebook-preview {
+	border: 1px solid;
+	border-color: #e9ebee #e9ebee #d1d1d1;
+	display: flex;
+	overflow-x: auto;
+	max-width: 527px;
+	margin: 0 auto;
+	-webkit-overflow-scrolling: touch;
+}
+
+.facebook-preview__content {
+	display: flex;
+	flex-shrink: 0;
+}
+
+.facebook-preview__body {
+	display: flex;
+	flex-direction: column;
+	margin: 10px 12px;
+}
+
+.facebook-preview__title {
+	color: #1d2129;
+	font-family: Georgia, serif;
+	font-size: 18px;
+	font-weight: 500;
+	line-height: 22px;
+	max-height: 100px;
+	transition: color 0.1s ease-in-out;
+}
+
+.facebook-preview__description {
+	color: #4b4f56;
+	font-family: helvetica, arial, sans-serif;
+	font-size: 12px;
+	line-height: 16px;
+	max-height: 80px;
+}
+
+.facebook-preview__url {
+	color: #90949c;
+	font-family: helvetica, arial, sans-serif;
+	font-size: 11px;
+	line-height: 11px;
+	text-transform: uppercase;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.facebook-preview__article {
+	.facebook-preview__content {
+		flex-direction: column;
+		min-width: 100%;
+	}
+
+	.facebook-preview__image {
+		height: auto;
+		max-height: 250px;
+		width: 100%;
+		overflow: hidden;
+
+		& img {
+			height: auto;
+			width: 100%;
+		}
+	}
+
+	.facebook-preview__body {
+		height: auto;
+		max-height: 100px;
+	}
+
+	.facebook-preview__title {
+		margin-bottom: 5px;
+	}
+
+	.facebook-preview__url {
+		margin-top: 9px;
+	}
+}
+
+.facebook-preview__website {
+	max-height: 158px;
+
+	.facebook-preview__image {
+		height: 100%;
+		width: 158px;
+
+		& img {
+			font-size: 14px;
+			height: auto;
+			width: 100%;
+		}
+	}
+
+	.facebook-preview__body {
+		height: 138px;
+	}
+
+	.facebook-preview__title {
+		margin-bottom: 5px;
+		max-height: 110px;
+	}
+
+	.facebook-preview__url {
+		margin-top: auto;
 	}
 }

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -63,7 +63,7 @@
 	}
 
 	.is-seo & {
-		max-width: 783px;
+		max-width: 865px;
 	}
 }
 


### PR DESCRIPTION
<del>**Do not merge!**</del>

Closes #5972 

Adds a Facebook preview component which can show previews for post object or site objects

**Site Type**
<img width="548" alt="screen shot 2016-06-14 at 7 54 27 pm" src="https://cloud.githubusercontent.com/assets/5431237/16066641/e73554d8-3269-11e6-8c0c-00fc286f0cf3.png">

**Article Type**
<img width="544" alt="screen shot 2016-06-14 at 7 54 36 pm" src="https://cloud.githubusercontent.com/assets/5431237/16066644/f148f344-3269-11e6-91a7-c54f6c8eb716.png">

**Testing**
This needs lots of testing with various parameters (short descriptions, long descriptions, really long words in title, etc…).

 - The post (or article) type preview doesn't currently pull the post content which would normally exist in the preview.
 - The title is currently made up while waiting for some API work. The point to pay attention to in this PR is how the supplied title looks, not _what_ the supplied title is.
 - I have attempted to mimic the way Facebook truncates text but had a harder time finding exact knowledge about this than for with Google.

cc: @roundhill @rodrigoi @vindl


Test live: https://calypso.live/?branch=add/facebook-preview