### PR TITLE
Themes: sheet SEO

### DIFF
--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:layout:head' );
 
-const Head = ( { title, description, canonicalUrl, type, site_name, children } ) => (
+const Head = ( { title, description, canonicalUrl, type, site_name, image, children } ) => (
 	<div>
 		<Helmet
 			title={ title }
@@ -19,6 +19,7 @@ const Head = ( { title, description, canonicalUrl, type, site_name, children } )
 				canonicalUrl ? { property: 'og:url', content: canonicalUrl } : {},
 				type ? { property: 'og:type', content: type } : {},
 				site_name ? { property: 'og:site_name', content: site_name } : {},
+				image ? { property: 'og:image', content: image } : {},
 			] }
 			link={ [
 				canonicalUrl ? { rel: 'canonical', href: canonicalUrl } : {}

--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -17,8 +17,8 @@ const Head = ( { title, description, canonicalUrl, type, site_name, children } )
 				description ? { name: 'description', property: 'og:description', content: description } : {},
 				title ? { property: 'og:title', content: title } : {},
 				canonicalUrl ? { property: 'og:url', content: canonicalUrl } : {},
-				type ? { property: 'og:type', content: type} : {},
-				site_name ? { property: 'og:site_name', content: site_name} : {},
+				type ? { property: 'og:type', content: type } : {},
+				site_name ? { property: 'og:site_name', content: site_name } : {},
 			] }
 			link={ [
 				canonicalUrl ? { rel: 'canonical', href: canonicalUrl } : {}

--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:layout:head' );
 
-const Head = ( { title, description, canonicalUrl, children } ) => (
+const Head = ( { title, description, canonicalUrl, type, site_name, children } ) => (
 	<div>
 		<Helmet
 			title={ title }
@@ -17,6 +17,8 @@ const Head = ( { title, description, canonicalUrl, children } ) => (
 				description ? { name: 'description', property: 'og:description', content: description } : {},
 				title ? { property: 'og:title', content: title } : {},
 				canonicalUrl ? { property: 'og:url', content: canonicalUrl } : {},
+				type ? { property: 'og:type', content: type} : {},
+				site_name ? { property: 'og:site_name', content: site_name} : {},
 			] }
 			link={ [
 				canonicalUrl ? { rel: 'canonical', href: canonicalUrl } : {}

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -87,7 +87,7 @@ export function details( context, next ) {
 		themeSlug: slug,
 		contentSection: context.params.section,
 		title: decodeEntities( title ) + ' — WordPress.com', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
-		description: themeDetails.description,
+		description: decodeEntities( themeDetails.description ),
 		canonicalUrl: `https://wordpress.com/theme/${ slug }`, // TODO: use getDetailsUrl() When it becomes availavle
 		image: themeDetails.screenshot,
 		isLoggedIn: !! user

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -30,8 +30,8 @@ let themeDetailsCache = new Map();
 export function makeElement( ThemesComponent, Head, store, props ) {
 	return(
 		<ReduxProvider store={ store }>
-			<Head title={ props.title } description={ props.description }
-				type={ 'website' } canonicalUrl={ props.canonicalUrl } tier={ props.tier || 'all' }>
+			<Head title={ props.title } description={ props.description } type={ 'website' }
+				 canonicalUrl={ props.canonicalUrl } image={ props.image } tier={ props.tier || 'all' }>
 				<ThemesComponent { ...omit( props, [ 'title' ] ) } />
 			</Head>
 		</ReduxProvider>
@@ -89,6 +89,7 @@ export function details( context, next ) {
 		title: decodeEntities( title ) + ' — WordPress.com', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
 		description: themeDetails.description,
 		canonicalUrl: `https://wordpress.com/theme/${ slug }`, // TODO: use getDetailsUrl() When it becomes availavle
+		image: themeDetails.screenshot,
 		isLoggedIn: !! user
 	};
 

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -30,7 +30,7 @@ let themeDetailsCache = new Map();
 export function makeElement( ThemesComponent, Head, store, props ) {
 	return(
 		<ReduxProvider store={ store }>
-			<Head title={ props.title } tier={ props.tier || 'all' }>
+			<Head title={ props.title } description={ props.description } tier={ props.tier || 'all' }>
 				<ThemesComponent { ...omit( props, [ 'title' ] ) } />
 			</Head>
 		</ReduxProvider>
@@ -73,7 +73,9 @@ export function fetchThemeDetailsData( context, next ) {
 export function details( context, next ) {
 	const { slug } = context.params;
 	const user = getCurrentUser( context.store.getState() );
-	const themeName = ( getThemeDetails( context.store.getState(), slug ) || false ).name;
+	const themeDetails = getThemeDetails( context.store.getState(), slug ) || false;
+	const themeName = themeDetails.name;
+	const themeDescription = themeDetails.description;
 	const title = i18n.translate( '%(themeName)s Theme', {
 		args: { themeName }
 	} );
@@ -85,6 +87,7 @@ export function details( context, next ) {
 		themeSlug: slug,
 		contentSection: context.params.section,
 		title: decodeEntities( title ) + ' — WordPress.com', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
+		description : themeDescription,
 		isLoggedIn: !! user
 	};
 

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -76,8 +76,6 @@ export function details( context, next ) {
 	const user = getCurrentUser( context.store.getState() );
 	const themeDetails = getThemeDetails( context.store.getState(), slug ) || false;
 	const themeName = themeDetails.name;
-	const themeDescription = themeDetails.description;
-	const themeCanonicalUrl = `https://wordpress.com/theme/${ slug }`;
 	const title = i18n.translate( '%(themeName)s Theme', {
 		args: { themeName }
 	} );
@@ -89,8 +87,8 @@ export function details( context, next ) {
 		themeSlug: slug,
 		contentSection: context.params.section,
 		title: decodeEntities( title ) + ' — WordPress.com', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
-		description: themeDescription,
-		canonicalUrl: themeCanonicalUrl,
+		description: themeDetails.description,
+		canonicalUrl: `https://wordpress.com/theme/${ slug }`, // TODO: use getDetailsUrl() When it becomes availavle
 		isLoggedIn: !! user
 	};
 

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -30,7 +30,7 @@ let themeDetailsCache = new Map();
 export function makeElement( ThemesComponent, Head, store, props ) {
 	return(
 		<ReduxProvider store={ store }>
-			<Head title={ props.title } description={ props.description } tier={ props.tier || 'all' }>
+			<Head title={ props.title } description={ props.description } canonicalUrl={ props.canonicalUrl } tier={ props.tier || 'all' }>
 				<ThemesComponent { ...omit( props, [ 'title' ] ) } />
 			</Head>
 		</ReduxProvider>
@@ -76,6 +76,7 @@ export function details( context, next ) {
 	const themeDetails = getThemeDetails( context.store.getState(), slug ) || false;
 	const themeName = themeDetails.name;
 	const themeDescription = themeDetails.description;
+	const themeCanonicalUrl = `https://wordpress.com/theme/${ slug }`;
 	const title = i18n.translate( '%(themeName)s Theme', {
 		args: { themeName }
 	} );
@@ -87,7 +88,8 @@ export function details( context, next ) {
 		themeSlug: slug,
 		contentSection: context.params.section,
 		title: decodeEntities( title ) + ' — WordPress.com', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
-		description : themeDescription,
+		description: themeDescription,
+		canonicalUrl: themeCanonicalUrl,
 		isLoggedIn: !! user
 	};
 

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -30,7 +30,8 @@ let themeDetailsCache = new Map();
 export function makeElement( ThemesComponent, Head, store, props ) {
 	return(
 		<ReduxProvider store={ store }>
-			<Head title={ props.title } description={ props.description } canonicalUrl={ props.canonicalUrl } tier={ props.tier || 'all' }>
+			<Head title={ props.title } description={ props.description }
+				type={ 'website' } canonicalUrl={ props.canonicalUrl } tier={ props.tier || 'all' }>
 				<ThemesComponent { ...omit( props, [ 'title' ] ) } />
 			</Head>
 		</ReduxProvider>

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -31,7 +31,7 @@ export function makeElement( ThemesComponent, Head, store, props ) {
 	return(
 		<ReduxProvider store={ store }>
 			<Head title={ props.title } description={ props.description } type={ 'website' }
-				 canonicalUrl={ props.canonicalUrl } image={ props.image } tier={ props.tier || 'all' }>
+				canonicalUrl={ props.canonicalUrl } image={ props.image } tier={ props.tier || 'all' }>
 				<ThemesComponent { ...omit( props, [ 'title' ] ) } />
 			</Head>
 		</ReduxProvider>

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -10,11 +10,11 @@ import React from 'react';
  */
 import Head from 'layout/head';
 
-const ThemesHead = ( { title, tier, children } ) => (
+const ThemesHead = ( { title, description, canonicalUrl, tier, children } ) => (
 	<Head
 		title={ title ? title : get( 'title', tier ) }
-		description={ get( 'description', tier ) }
-		canonicalUrl={ get( 'canonicalUrl', tier ) } >
+		description={ description ? description: get( 'description', tier ) }
+		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) } >
 		{ children }
 	</Head>
 )

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -13,13 +13,13 @@ import Head from 'layout/head';
 const ThemesHead = ( { title, description, canonicalUrl, type, tier, children } ) => (
 	<Head
 		title={ title ? title : get( 'title', tier ) }
-		description={ description ? description: get( 'description', tier ) }
+		description={ description ? description : get( 'description', tier ) }
 		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) }
 		type={ type ? type : 'website' }
 		site_name={ 'WprdPress.com' } >
 		{ children }
 	</Head>
-)
+);
 
 ThemesHead.propTypes = {
 	title: React.PropTypes.string,

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -10,14 +10,16 @@ import React from 'react';
  */
 import Head from 'layout/head';
 
-const ThemesHead = ( { title, description, canonicalUrl, tier, children } ) => (
+const ThemesHead = ( { title, description, canonicalUrl, type, tier, children } ) => (
 	<Head
 		title={ title ? title : get( 'title', tier ) }
-		description={ description ? description : get( 'description', tier ) }
-		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) } >
+		description={ description ? description: get( 'description', tier ) }
+		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) }
+		type={ type ? type : 'website' }
+		site_name={ 'WprdPress.com' } >
 		{ children }
 	</Head>
-);
+)
 
 ThemesHead.propTypes = {
 	title: React.PropTypes.string,

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -13,11 +13,11 @@ import Head from 'layout/head';
 const ThemesHead = ( { title, description, canonicalUrl, tier, children } ) => (
 	<Head
 		title={ title ? title : get( 'title', tier ) }
-		description={ description ? description: get( 'description', tier ) }
+		description={ description ? description : get( 'description', tier ) }
 		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) } >
 		{ children }
 	</Head>
-)
+);
 
 ThemesHead.propTypes = {
 	title: React.PropTypes.string,
@@ -40,7 +40,7 @@ const themesMeta = {
 		description: 'Discover Premium WordPress Themes on the WordPress.com Theme Showcase.',
 		canonicalUrl: 'https://wordpress.com/design/type/premium',
 	}
-}
+};
 
 function get( key, tier ) {
 	return tier in themesMeta && key in themesMeta[ tier ]

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -10,13 +10,14 @@ import React from 'react';
  */
 import Head from 'layout/head';
 
-const ThemesHead = ( { title, description, canonicalUrl, type, tier, children } ) => (
+const ThemesHead = ( { title, description, canonicalUrl, type, image, tier, children } ) => (
 	<Head
 		title={ title ? title : get( 'title', tier ) }
 		description={ description ? description : get( 'description', tier ) }
 		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) }
 		type={ type ? type : 'website' }
-		site_name={ 'WprdPress.com' } >
+		site_name={ 'WprdPress.com' }
+		image={ image ? image : {} } >
 		{ children }
 	</Head>
 );

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -16,7 +16,7 @@ const ThemesHead = ( { title, description, canonicalUrl, type, image, tier, chil
 		description={ description ? description : get( 'description', tier ) }
 		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) }
 		type={ type ? type : 'website' }
-		site_name={ 'WprdPress.com' }
+		site_name={ 'WordPress.com' }
 		image={ image ? image : {} } >
 		{ children }
 	</Head>


### PR DESCRIPTION
This PR is created to address issue #3658.

How to test:
1. Open theme sheet, for example /theme/twentysixteen
2. Open _source_
3. Look for og:title, og:descripton, og:url

Those 3 meta should all have meaningful(not generic) content for that theme.

Test live: https://calypso.live/?branch=fix/3658-sheet-seo