### PR TITLE
Plans: add support page link to google-voucher

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
@@ -161,7 +161,9 @@ class GoogleVoucherDetails extends Component {
 						{
 							this.props.translate( 'Copy this unique, one-time use code to your clipboard and setup your Google AdWords account. {{a}}View help guide{{/a}}',
 								{
-									components: { a: <a className="google-voucher-code__help-link" href="#" target="_blank" /> }
+									components: {
+										a: <a className="google-voucher-code__help-link" href="https://en.support.wordpress.com/google-adwords-credit/" target="_blank" />
+									}
 								}
 							)
 						}


### PR DESCRIPTION
Just add the link of google adWords credit support page t(https://en.support.wordpress.com/google-adwords-credit/( o google-voucher section.

###Testing

Once you have assigned the code you will see the `View` link. Clicking on the link you will get the support page.

![image](https://cloud.githubusercontent.com/assets/77539/16074455/df4db220-32ea-11e6-9cfd-fb9dc630a8d0.png)


Test live: https://calypso.live/?branch=add/google-adwords-credit-link-page