### PR TITLE
Upgrades: Enable Google AdWords credit in horizon and production envs

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -19,6 +19,7 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,
+		"google-voucher": true,
 		"guided-tours": true,
 		"help": true,
 		"jetpack/connect": true,

--- a/config/production.json
+++ b/config/production.json
@@ -17,6 +17,7 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,
+		"google-voucher": true,
 		"guided-tours": true,
 		"help": true,
 		"jetpack/connect": true,


### PR DESCRIPTION
Enables this feature in `horizon` and `production` environments.

### Testing

This feature is already enabled in `development` and `stage` (https://github.com/Automattic/wp-calypso/pull/6057 ) environments.

1) Select a PREMIUM or BUSINESS plan
2) Enable test `localStorage.setItem('ABTests','{"googleVouchers_ 20160613":"enabled"}')`
3) Go to my plans page -> http://wordpress.com/plans/my-plan/<my-site>
4) You should see and can follow the flow of `Google AdWords credit` section.

Test live: https://calypso.live/?branch=update/google-voucher-in-prod