### PR TITLE
Framework: Bump i18n-calypso to 1.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -644,7 +644,7 @@
       "version": "1.1.1"
     },
     "clean-css": {
-      "version": "3.4.17",
+      "version": "3.4.18",
       "dependencies": {
         "commander": {
           "version": "2.8.1"
@@ -1696,7 +1696,7 @@
       "version": "0.0.0"
     },
     "i18n-calypso": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "async": {
           "version": "1.5.2"
@@ -1708,10 +1708,10 @@
           "version": "1.2.6"
         },
         "fbjs": {
-          "version": "0.6.1"
+          "version": "0.8.3"
         },
         "react": {
-          "version": "0.14.8"
+          "version": "15.1.0"
         }
       }
     },
@@ -1759,7 +1759,7 @@
       }
     },
     "interpolate-components": {
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     "interpret": {
       "version": "0.6.6"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "flux": "2.1.1",
     "he": "0.5.0",
     "html-loader": "0.4.0",
-    "i18n-calypso": "1.1.0",
+    "i18n-calypso": "1.2.0",
     "immutable": "3.8.1",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",


### PR DESCRIPTION
Which allows interpolate-component to use React 15.

Related to #5116.

cc @blowery

Test live: https://calypso.live/?branch=upgrade/i18-calypso-1-2-0