### PR TITLE
Upgrades: google-voucher: enable in stage environment

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -20,6 +20,7 @@
 		"community-translator": true,
 		"desktop-promo": true,
 		"guided-tours": true,
+		"google-voucher": true,
 		"help": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,


### PR DESCRIPTION
Enable google voucher feature in `stage` env before to enable it in `horizon` and `production` (PR #6053)

### Testing

This feature is already enabled in `development` this environment to test it.

1) Select a PREMIUM or BUSINESS plan
2) Enable test `localStorage.setItem('ABTests','{"googleVouchers_ 20160613":"enabled"}')`
3) Go to my plans page -> http://wordpress.com/plans/my-plan/<my-site>
4) You should see and can follow the flow of `Google AdWords credit` section.

cc @mtias 


Test live: https://calypso.live/?branch=update/google-voucher-in-stage