### PR TITLE
Editor: Block saving until TinyMCE initializes

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -181,13 +181,6 @@ const PostEditor = React.createClass( {
 
 	getInitialState() {
 		return {
-			...this.getDefaultState(),
-			isEditorInitialized: false
-		};
-	},
-
-	getDefaultState() {
-		return {
 			...this.getPostEditState(),
 			isSaving: false,
 			isPublishing: false,
@@ -219,6 +212,10 @@ const PostEditor = React.createClass( {
 		this.debouncedAutosave = debounce( throttle( this.autosave, 20000 ), 3000 );
 		this.switchEditorVisualMode = this.switchEditorMode.bind( this, 'tinymce' );
 		this.switchEditorHtmlMode = this.switchEditorMode.bind( this, 'html' );
+
+		this.setState( {
+			isEditorInitialized: false
+		} );
 	},
 
 	componentDidMount: function() {
@@ -477,7 +474,7 @@ const PostEditor = React.createClass( {
 			this.setState( { loadingError } );
 		} else if ( ( PostEditStore.isNew() && ! this.state.isNew ) || PostEditStore.isLoading() ) {
 			// is new or loading
-			this.setState( this.getDefaultState(), function() {
+			this.setState( this.getInitialState(), function() {
 				this.refs.editor.setEditorContent( '' );
 			} );
 		} else {


### PR DESCRIPTION
This pull request seeks to resolve an issue where if the user is able to press publish/update after a post has loaded but before TinyMCE finishes initializing, the post will be saved with empty content.

__Testing instructions:__

This is easiest to test with some sort of network throttling. If using Chrome, the Network tab [includes a throttling dropdown](https://developers.google.com/web/tools/chrome-devtools/profile/network-performance/network-conditions?hl=en#emulate-network-connectivity) to emulate a slower network connection.

Verify that Publish/Update remains disabled until after TinyMCE finishes initializing. Importantly, ensure that publish is available for new posts with some content and existing posts after both the post has loaded and TinyMCE has initialized, and in both of these scenarios when transitioning from a previous editor session (via the drafts drawer or masterbar new post button).

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter a title
4. Note that if TinyMCE has initialized (which at this point, it likely has), the Publish button is available
5. Save the draft or publish the post
6. Refresh the page with throttling applied
7. Note that while the post loads, the Publish/Update button is disabled, and that it continues to be disabled after the post has loaded but TinyMCE has not yet initialized
8. Note that the Publish/Update button is enabled after both of these conditions are satisfied

Ref: p4TIVU-3GA-p2, cc @alisterscott 

Test live: https://calypso.live/?branch=fix/editor-block-save-while-loading