### PR TITLE
Domains: Design for domain credit with DWPO

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -2,11 +2,14 @@
  * External dependencies
  */
 import React from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import PremiumPopover from 'components/plans/premium-popover';
+import { abtest } from 'lib/abtest';
+
 const DomainProductPrice = React.createClass( {
 	propTypes: {
 		isLoading: React.PropTypes.bool,
@@ -15,16 +18,25 @@ const DomainProductPrice = React.createClass( {
 		requiresPlan: React.PropTypes.bool
 	},
 	renderFreeWithPlan() {
+		const domainsWithPlansOnlyTestEnabled = abtest( 'domainsWithPlansOnly' ) === 'plansOnly';
+
 		return (
-			<div className="domain-product-price is-free-domain">
-				<span className="domain-product-price__price">{ this.translate( '%(cost)s {{small}}/year{{/small}}', {
-					args: { cost: this.props.price },
-					components: { small: <small /> }
-				} ) }</span>
+			<div
+				className={ classnames( 'domain-product-price', 'is-free-domain', { 'no-price': domainsWithPlansOnlyTestEnabled } ) }>
+				{ ! domainsWithPlansOnlyTestEnabled && this.renderFreeWithPlanPrice() }
 				<span className="domain-product-price__free-text" ref="subMessage">
 					{ this.translate( 'Free with your plan' ) }
 				</span>
 			</div>
+		);
+	},
+	renderFreeWithPlanPrice() {
+		return (
+			<span
+				className="domain-product-price__price">{ this.translate( '%(cost)s {{small}}/year{{/small}}', {
+					args: { cost: this.props.price },
+					components: { small: <small /> }
+				} ) }</span>
 		);
 	},
 	renderFree() {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -59,6 +59,15 @@
 			opacity: .6;
 			text-decoration: line-through;
 		}
+
+		&.no-price {
+			@include breakpoint( ">660px" ) {
+				padding-top: 7px;
+			}
+			@include breakpoint( ">960px" ) {
+				padding-top: 13px;
+			}
+		}
 	}
 
 	.is-placeholder & {


### PR DESCRIPTION
Currently, when the user is in plansOnly group and have domain credit, they see the a-la-carte domain pricing scratched off and says "Free with your plan". However, they were not able to buy their first domain
a-la-carte anyway. I think it might a good improvement to change the presentation that doesn't mention
a-la-carte prices.

Test live: https://calypso.live/?branch=update/dwpo-plan-free-domain-no-price


**Steps:**
1. Calypso -> Domains
2. Switch to Plans and add a Premium plan to the cart
3. Go back to Add Domains
4. Check the messaging next to the suggested domains

**Before:**
![plans with price](https://cloud.githubusercontent.com/assets/1103398/16087736/5ada680a-3324-11e6-846c-36d6e13a8990.png)

**After:**
![just free plan](https://cloud.githubusercontent.com/assets/1103398/16087739/5eb91534-3324-11e6-9979-8f0372b68cc0.png)

cc @umurkontaci @klimeryk 