### PR TITLE
Signup: split ThemeSelection into two components for clarity

### DIFF
--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -2,15 +2,13 @@
  * External dependencies
  */
 import React from 'react';
-import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
 import SignupActions from 'lib/signup/actions';
-import getThemes from 'lib/signup/themes';
-import ThemesList from 'components/themes-list';
+import SignupThemesList from './signup-themes-list';
 import StepWrapper from 'signup/step-wrapper';
 import Button from 'components/button';
 
@@ -19,29 +17,15 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		useHeadstart: React.PropTypes.bool,
+		stepName: React.PropTypes.string.isRequired,
+		goToNextStep: React.PropTypes.func.isRequired,
+		signupDependencies: React.PropTypes.object.isRequired,
 	},
 
 	getDefaultProps() {
 		return {
 			useHeadstart: true,
 		};
-	},
-
-	getInitialState() {
-		return {
-			themes: this.getThemes()
-		};
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		const { surveyQuestion, designType } = nextProps.signupDependencies;
-		if ( surveyQuestion !== this.props.signupDependencies.surveyQuestion || designType !== this.props.signupDependencies.designType ) {
-			this.setState( { themes: this.getThemes() } );
-		}
-	},
-
-	getThemes() {
-		return getThemes( this.props.signupDependencies.surveyQuestion, this.props.signupDependencies.designType );
 	},
 
 	handleScreenshotClick( theme ) {
@@ -61,25 +45,11 @@ module.exports = React.createClass( {
 	},
 
 	renderThemesList() {
-		var actionLabel = this.translate( 'Pick' ),
-			themes = this.state.themes.map( function( theme ) {
-				return {
-					id: theme.slug,
-					name: theme.name,
-					screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + theme.slug + '/screenshot.png?w=660'
-				};
-			} );
-		return (
-			<ThemesList
-				getButtonOptions= { noop }
-				onScreenshotClick= { this.handleScreenshotClick }
-				onMoreButtonClick= { noop }
-				getActionLabel={ function() {
-					return actionLabel;
-				} }
-				{ ...this.props }
-				themes= { themes } />
-		);
+		return ( <SignupThemesList
+			surveyQuestion={ this.props.signupDependencies.surveyQuestion }
+			designType={ this.props.signupDependencies.designType }
+			handleScreenshotClick={ this.handleScreenshotClick }
+		/> );
 	},
 
 	renderJetpackButton() {

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import getThemes from 'lib/signup/themes';
+import ThemesList from 'components/themes-list';
+
+module.exports = React.createClass( {
+	displayName: 'SignupThemesList',
+
+	propTypes: {
+		surveyQuestion: React.PropTypes.string,
+		designType: React.PropTypes.string,
+		handleScreenshotClick: React.PropTypes.func,
+	},
+
+	getDefaultProps() {
+		return {
+			surveyQuestion: null,
+			designType: null,
+			handleScreenshotClick: noop,
+		};
+	},
+
+	shouldComponentUpdate( nextProps ) {
+		return ( nextProps.surveyQuestion !== this.props.surveyQuestion || nextProps.designType !== this.props.designType );
+	},
+
+	getComputedThemes() {
+		return getThemes( this.props.surveyQuestion, this.props.designType );
+	},
+
+	getScreenshotUrl( slug ) {
+		return 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + slug + '/screenshot.png?w=660';
+	},
+
+	render() {
+		const actionLabel = this.translate( 'Pick' );
+		const getActionLabel = () => actionLabel;
+		const themes = this.getComputedThemes().map( theme => {
+			return {
+				id: theme.slug,
+				name: theme.name,
+				screenshot: this.getScreenshotUrl( theme.slug ),
+			};
+		} );
+		return (
+			<ThemesList
+				getButtonOptions= { noop }
+				onScreenshotClick= { this.props.handleScreenshotClick }
+				onMoreButtonClick= { noop }
+				getActionLabel={ getActionLabel }
+				themes= { themes } />
+		);
+	}
+} );
+


### PR DESCRIPTION
Part of #6038 

Test live: https://calypso.live/?branch=update/signup-themes-list-child