### PR TITLE
ABtest: set the right datestamp of googleVouchers

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -102,7 +102,7 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	googleVouchers: {
-		datestamp: '20160613',
+		datestamp: '20160615',
 		variations: {
 			disabled: 50,
 			enabled: 50,


### PR DESCRIPTION
Since googleVoucher has been deployed today #6053 we have to update the datestamp here.

cc @rralian 

Test live: https://calypso.live/?branch=update/datestamp-abtest-google-voucher