### PR TITLE
Reader: Fire traintracks.render when accepting posts

### DIFF
--- a/client/lib/feed-post-store/constants.js
+++ b/client/lib/feed-post-store/constants.js
@@ -4,6 +4,7 @@ module.exports = {
 	action: keyMirror( {
 		FETCH_FEED_POST: null,
 		RECEIVE_FEED_POST: null,
-		MARK_FEED_POST_SEEN: null
+		MARK_FEED_POST_SEEN: null,
+		RECEIVE_NORMALIZED_FEED_POST: null
 	} )
 };

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -100,6 +100,10 @@ FeedPostStore.dispatchToken = Dispatcher.register( function( payload ) {
 			}
 			break;
 
+		case FeedPostActionType.RECEIVE_NORMALIZED_FEED_POST:
+			setPost( action.data.feed_item_ID, action.data );
+			break;
+
 		case FeedPostActionType.MARK_FEED_POST_SEEN:
 			markPostSeen( action.data.post, action.data.source );
 			break;

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { nock, useNock } from 'test/helpers/use-nock';
+import { useNock } from 'test/helpers/use-nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -11,13 +11,22 @@ import { expect } from 'chai';
 import {
 	READER_POSTS_RECEIVE
 } from 'state/action-types';
-
-import {
-	receivePosts
-} from '../actions';
+import useMockery from 'test/helpers/use-mockery';
 
 describe( 'actions', () => {
+	let receivePosts;
+
 	useNock();
+
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/analytics', {
+			tracks: {
+				recordEvent: function() {}
+			}
+		} );
+
+		receivePosts = require( '../actions' ).receivePosts;
+	} );
 
 	const spy = sinon.spy();
 


### PR DESCRIPTION
Also keep the post in the feed post store in sync with the posts that are coming into the redux post store. This makes jumping from post to post much faster, as we don't have to load the post again via batch.

Test live: https://calypso.live/?branch=update/traintracks/auto-render