### PR TITLE
Optimistic UI during the "Disable" action

### DIFF
--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -91,11 +91,7 @@ function system( state = {}, action ) {
 		}
 
 		case PUSH_NOTIFICATIONS_RECEIVE_UNREGISTER_DEVICE: {
-			const { data } = action;
-			if ( ! data.success ) {
-				debug( 'Couldn\'t unregister device', data );
-			}
-			debug( 'Deleted WPCOM subscription', data );
+			debug( 'Deleted WPCOM subscription' );
 			return omit( state, [ 'wpcomSubscription' ] );
 		}
 

--- a/client/state/push-notifications/test/actions.js
+++ b/client/state/push-notifications/test/actions.js
@@ -39,20 +39,9 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'receiveUnregisterDevice()', () => {
-		it( 'should return an action object with empty data for empty input', () => {
+		it( 'should return an action object', () => {
 			expect( receiveUnregisterDevice() ).to.eql( {
-				type: PUSH_NOTIFICATIONS_RECEIVE_UNREGISTER_DEVICE,
-				data: {},
-			} );
-		} );
-
-		it( 'should return an action object with provided data intact', () => {
-			const data = {
-				devicestuff: 'some_value',
-			};
-			expect( receiveUnregisterDevice( data ) ).to.eql( {
-				type: PUSH_NOTIFICATIONS_RECEIVE_UNREGISTER_DEVICE,
-				data,
+				type: PUSH_NOTIFICATIONS_RECEIVE_UNREGISTER_DEVICE
 			} );
 		} );
 	} );


### PR DESCRIPTION
Previous behavior was to wait until the `unregisterDevice` call completed before the client forgot the subscription & re-enabled the `Enable` button (It stays in the the `disabling` status for longer than is necessary).

This optimistically assumes the device is unregistered & forgets its reference to the subscription moving it to the `unsubscribed` status much more quickly.

To test, very quickly toggle between Enabled & Disabled & make sure it behaves as expected and that the interaction change is desirable.

Retargeted #6017 on `master` since #5748 got merged.

Test live: https://calypso.live/?branch=update/push-notifications-disable