### PR TITLE
New user utility: `beforeLogOut`

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -36,7 +36,6 @@ var config = require( 'config' ),
 	emailVerification = require( 'components/email-verification' ),
 	viewport = require( 'lib/viewport' ),
 	detectHistoryNavigation = require( 'lib/detect-history-navigation' ),
-	pushNotificationsInit = require( 'state/push-notifications/actions' ).init,
 	sections = require( 'sections' ),
 	touchDetect = require( 'lib/touch-detect' ),
 	setRouteAction = require( 'state/notices/actions' ).setRoute,
@@ -51,6 +50,12 @@ var config = require( 'config' ),
 	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default,
 	// The following components require the i18n mixin, so must be required after i18n is initialized
 	Layout;
+
+import { beforeLogOut } from 'lib/user/utils';
+import {
+	init as pushNotificationsInit,
+	unregisterDevice as pushNotificationsUnregisterDevice,
+} from 'state/push-notifications/actions';
 
 function init() {
 	var i18nLocaleStringsObject = null;
@@ -207,6 +212,7 @@ function reduxStoreReady( reduxStore ) {
 
 		if ( config.isEnabled( 'push-notifications' ) ) {
 			// If the browser is capable, registers a service worker & exposes the API
+			beforeLogOut( () => reduxStore.dispatch( pushNotificationsUnregisterDevice() ) );
 			reduxStore.dispatch( pushNotificationsInit() );
 		}
 	} else {

--- a/client/lib/user/README.md
+++ b/client/lib/user/README.md
@@ -26,9 +26,12 @@ var user = require( 'lib/user/utilities' );
 ```
 
 ### `UserUtilities#logout()`
-This is a small module that logs a user out by clearing user stored data by calling `User#clear()` and redirects user to WordPress.com to be logged out.
+This is a small module that logs a user out by clearing user stored data by calling `User#clear()` and redirects user to WordPress.com to be logged out. Sequentially executes callback functions added via `beforeLogOut` prior to actually logging out.
+
+### `UserUtilities#beforeLogOut( callback )`
+Adds a `callback` function to a list that is executed immediately prior to `logout` doing its work. These receive no arguments.
 
 ### `UserUtilities#getLogoutUrl()`
-Returns a localized logout URL based on the current user's language. 
+Returns a localized logout URL based on the current user's language.
 
 For example, an English speaking user be redirected to `wordpress.com` after being logged, but a Spanish speaking user will be redirected to `es.wordpress.com`.;

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -9,6 +9,8 @@ var debug = require( 'debug' )( 'calypso:user:utilities' ),
  */
 var user = require( 'lib/user' )();
 
+const beforeLogOutCallbacks = [];
+
 var userUtils = {
 	getLogoutUrl: function( redirect ) {
 		var url = '/logout',
@@ -42,12 +44,22 @@ var userUtils = {
 	logout: function( redirect ) {
 		var logoutUrl = userUtils.getLogoutUrl( redirect );
 
+		beforeLogOutCallbacks.forEach( function( callback ) {
+			if ( 'function' === typeof callback ) {
+				callback();
+			}
+		} );
+
 		// Clear any data stored locally within the user data module or localStorage
 		user.clear();
 		debug( 'User stored data cleared' );
 
 		// Forward user to WordPress.com to be logged out
 		location.href = logoutUrl;
+	},
+
+	beforeLogOut( callback ) {
+		beforeLogOutCallbacks.push( callback );
 	},
 
 	getLocaleSlug: function() {


### PR DESCRIPTION
`beforeLogOut` appends a callback function to a list which is sequentially executed prior to fully logging out.

Initial usage is to unregister the browser from our device registry.

Migrated from #5977

There is possibly a better way to hook in here, but this is desirable because we can delete our subscription record on the server-side immediately.

Test live: https://calypso.live/?branch=add/push-notifications-unregister-onlogout