### PR TITLE
Revert "Push Notifications: Enable for Staging"

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -72,7 +72,6 @@
 		"press-this": true,
 		"preview-layout": true,
 		"preview-endpoint": false,
-		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/recommendations/posts": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#6066

Test live: https://calypso.live/?branch=revert-6066-add/push-notification/staging