### PR TITLE
Adding themes to the checkout URLs

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -24,6 +24,7 @@ var analytics = require( 'lib/analytics' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
 	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
 	upgradesActions = require( 'lib/upgrades/actions' ),
+	themeItem = require( 'lib/cart-values/cart-items' ).themeItem,
 	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
 	notices = require( 'notices' ),
 	supportPaths = require( 'lib/url/support' );
@@ -51,8 +52,8 @@ const Checkout = React.createClass( {
 		if ( this.props.cart.hasLoadedFromServer ) {
 			this.trackPageView();
 
-			if ( this.props.planName ) {
-				this.addPlanToCart();
+			if ( this.props.product ) {
+				this.addProductToCart();
 			}
 		}
 
@@ -64,8 +65,8 @@ const Checkout = React.createClass( {
 			// if the cart hadn't loaded when this mounted, record the page view when it loads
 			this.trackPageView( nextProps );
 
-			if ( this.props.planName ) {
-				this.addPlanToCart();
+			if ( this.props.product ) {
+				this.addProductToCart();
 			}
 		}
 	},
@@ -94,17 +95,29 @@ const Checkout = React.createClass( {
 		} );
 	},
 
-	addPlanToCart: function() {
-		var planSlug = this.props.plans.getSlugFromPath( this.props.planName ),
-			planItem = cartItems.getItemForPlan( { product_slug: planSlug }, { isFreeTrial: false } );
+	addProductToCart: function() {
+		var planSlug = this.props.plans.getSlugFromPath( this.props.product ),
+			cartItem,
+			cartMeta;
 
-		upgradesActions.addItem( planItem );
+		if ( planSlug ) {
+			cartItem = cartItems.getItemForPlan( { product_slug: planSlug }, { isFreeTrial: false } );
+		}
+
+		if ( this.props.product.indexOf( 'theme' ) === 0 ) {
+			cartMeta = this.props.product.split( ':' )[1];
+			cartItem = themeItem( cartMeta );
+		}
+
+		if ( cartItem ) {
+			upgradesActions.addItem( cartItem );
+		}
 	},
 
 	redirectIfEmptyCart: function() {
 		var redirectTo = '/plans/';
 
-		if ( ! this.state.previousCart && this.props.planName ) {
+		if ( ! this.state.previousCart && this.props.productName ) {
 			// the plan hasn't been added to the cart yet
 			return false;
 		}

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -168,10 +168,10 @@ module.exports = {
 			SecondaryCart = require( './cart/secondary-cart' ),
 			storedCards = require( 'lib/stored-cards' )(),
 			basePath = route.sectionify( context.path ),
-			planName = context.params.plan_name,
+			product = context.params.product,
 			selectedFeature = context.params.feature;
 
-		if ( 'thank-you' === planName ) {
+		if ( 'thank-you' === product ) {
 			return;
 		}
 
@@ -186,7 +186,7 @@ module.exports = {
 				<CheckoutData>
 					<Checkout
 						cards={ storedCards }
-						planName={ planName }
+						product={ product }
 						plans={ plansList }
 						productsList={ productsList }
 						selectedFeature={ selectedFeature }

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -247,7 +247,7 @@ module.exports = function() {
 		);
 
 		page(
-			'/checkout/:domain/:plan_name?',
+			'/checkout/:domain/:product?',
 			adTracking.retarget,
 			controller.siteSelection,
 			upgradesController.checkout


### PR DESCRIPTION
This makes it possible to add a theme to the user's basket on the checkout. This should happen when the user visits `/checkout/:domain/theme:radiate` for example.

#### Testing instructions
 
1. Run `git checkout add/themes-to-checkout` and start your server
2. Open the [`Checkout with business` page](http://calypso.localhost:3000/checkout/:domain/business)
3. Check that you have a Business plan in your cart
2. Open the [`Checkout with theme` page](http://calypso.localhost:3000/checkout/:domain/theme:radiate)
3. Check that you have the radiate theme in your cart
 
Test live: https://calypso.live/?branch=add/themes-to-checkout

Pinging @seear for a review
@Automattic/spectrum 