### PR TITLE
Add getSitePlan and isCurrentSitePlan selectors with tests

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -144,3 +144,25 @@ export function getSitePlan( state, siteId ) {
 
 	return site.plan;
 }
+
+/**
+ * Returns true if site is currently subscribed to supplied plan and false otherwise.
+ *
+ * @param  {Object}   state         Global state tree
+ * @param  {Number}   siteId        Site ID
+ * @param  {Number}   planProductId Plan product_id
+ * @return {?Boolean}               Whether site's plan matches supplied plan
+ */
+export function isCurrentSitePlan( state, siteId, planProductId ) {
+	if ( planProductId === undefined ) {
+		return null;
+	}
+
+	const sitePlan = getSitePlan( state, siteId );
+
+	if ( ! sitePlan ) {
+		return null;
+	}
+
+	return sitePlan.product_id === planProductId;
+}

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -123,3 +123,24 @@ export function getSiteByUrl( state, url ) {
 
 	return site;
 }
+
+/**
+ * Returns a site's plan object by site ID.
+ *
+ * The difference between this selector and sites/plans/getPlansBySite is that the latter selectors works
+ * with the /sites/$site/plans endpoint while the former selectors works with /sites/$site endpoint.
+ * Query these endpoints to see if you need the first or the second one.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Object}        Site's plan object
+ */
+export function getSitePlan( state, siteId ) {
+	const site = getSite( state, siteId );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return site.plan;
+}

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -14,7 +14,8 @@ import {
 	getSiteSlug,
 	isRequestingSites,
 	getSiteByUrl,
-	getSitePlan
+	getSitePlan,
+	isCurrentSitePlan
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -334,6 +335,69 @@ describe( 'selectors', () => {
 				product_name_short: 'Business',
 				free_trial: false
 			} );
+		} );
+	} );
+
+	describe( '#isCurrentSitePlan()', () => {
+		it( 'should return null if the site is not known', () => {
+			const isCurrent = isCurrentSitePlan( {
+				sites: {
+					items: {}
+				}
+			}, 77203074, 1008 );
+
+			expect( isCurrent ).to.be.null;
+		} );
+
+		it( 'should return null if the planProductId is not supplied', () => {
+			const isCurrent = isCurrentSitePlan( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							plan: {
+								product_id: 1008
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( isCurrent ).to.be.null;
+		} );
+
+		it( 'it should return true if the site\'s plan matches supplied planProductId', () => {
+			const isCurrent = isCurrentSitePlan( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							plan: {
+								product_id: 1008
+							}
+						}
+					}
+				}
+			}, 77203074, 1008 );
+
+			expect( isCurrent ).to.be.true;
+		} );
+
+		it( 'it should return false if the site\'s plan doesn\'t match supplied planProductId', () => {
+			const isCurrent = isCurrentSitePlan( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							plan: {
+								product_id: 1008
+							}
+						}
+					}
+				}
+			}, 77203074, 1003 );
+
+			expect( isCurrent ).to.be.false;
 		} );
 	} );
 } );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -13,7 +13,8 @@ import {
 	isJetpackSite,
 	getSiteSlug,
 	isRequestingSites,
-	getSiteByUrl
+	getSiteByUrl,
+	getSitePlan
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -296,6 +297,43 @@ describe( 'selectors', () => {
 			const site = getSiteByUrl( state, 'https://testtwosites2014.wordpress.com/path/to/site' );
 
 			expect( site ).to.equal( state.sites.items[ 77203199 ] );
+		} );
+	} );
+
+	describe( '#getSitePlan()', () => {
+		it( 'should return null if the site is not known', () => {
+			const sitePlan = getSitePlan( {
+				sites: {
+					items: {}
+				}
+			}, 77203074 );
+
+			expect( sitePlan ).to.be.null;
+		} );
+
+		it( 'it should return site\'s plan object.', () => {
+			const sitePlan = getSitePlan( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							plan: {
+								product_id: 1008,
+								product_slug: 'business-bundle',
+								product_name_short: 'Business',
+								free_trial: false
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( sitePlan ).to.eql( {
+				product_id: 1008,
+				product_slug: 'business-bundle',
+				product_name_short: 'Business',
+				free_trial: false
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Add brand new selectors for easier manipulation of site's currently subscribed plan. With these selectors, we can avoid using the `/sites/$site/plans` endpoint and `state/sites/plans` for some use cases, namely the redesigned plan components in #6002.

## getSitePlan

`getSitePlan` returns the plan to which the site is currently subscribed. Use instead of `getCurrentPlan` from `state/sites/plans/selectors` if the following properties are enough for you:

![selection_019](https://cloud.githubusercontent.com/assets/4988512/16116763/fffcee52-33ce-11e6-86a5-9e09cf279546.jpg)

## isCurrentSitePlan

`isCurrentSitePlan` returns `true` if the supplied `planProductId` matches the `product_id` of the site's currently subscribed plan. Use instead of `current_plan` from `getCurrentPlan`.

cc @gwwar @aduth 

Test live: https://calypso.live/?branch=add/getSitePlan-selector