### PR TITLE
Fix browser push notifications schema validation

### DIFF
--- a/client/state/push-notifications/schema.js
+++ b/client/state/push-notifications/schema.js
@@ -1,32 +1,34 @@
 
 const boolType = { type: 'boolean' };
 const stringType = { type: 'string' };
+const numberType = { type: 'number' };
 
 export const settingsSchema = {
-	name: 'settings',
 	type: 'object',
-	patternProperties: {
+	properties: {
 		enabled: boolType,
 		dismissedNotice: boolType,
-		dismissedNoticeAt: stringType,
+		dismissedNoticeAt: numberType,
 		showingUnblockInstructions: boolType
 	},
 	additionalProperties: false
 };
 
 export const systemSchema = {
-	name: 'system',
 	type: 'object',
-	patternProperties: {
+	properties: {
 		apiReady: boolType,
 		authorized: boolType,
 		authorizationLoaded: boolType,
 		blocked: boolType,
 		wpcomSubscription: {
 			type: 'object',
-			patternProperties: {
-				lastUpdated: {
-					type: 'string'
+			properties: {
+				lastUpdated: stringType,
+				ID: numberType,
+				settings: {
+					type: 'object',
+					additionalProperties: true
 				}
 			}
 		}

--- a/client/state/push-notifications/test/reducer.js
+++ b/client/state/push-notifications/test/reducer.js
@@ -12,9 +12,32 @@ import {
 } from 'state/action-types';
 import reducer, {} from '../reducer';
 
+const wpcomSubscription = {
+	ID: 42,
+	lastUpdated: '2016-06-16T14:41:09+02:00',
+	settings: {
+		comments: {
+			desc: 'Comments',
+			long_desc: '"Someone comments one of my posts"',
+			value: '1' }
+	}
+};
+
 describe( 'system reducer', () => {
+
+	it( 'should persist keys', () => {
+		const state = reducer( {
+			system: {
+				wpcomSubscription: wpcomSubscription,
+			}
+		}, { type: SERIALIZE } );
+
+		expect( state.system ).to.eql( {
+			wpcomSubscription,
+		} );
+	} );
+
 	it( 'should refuse to persist particular keys', () => {
-		const wpcomSubscription = { ID: 42 };
 		const state = reducer( {
 			system: {
 				apiReady: true,
@@ -24,6 +47,18 @@ describe( 'system reducer', () => {
 				wpcomSubscription: wpcomSubscription,
 			}
 		}, { type: SERIALIZE } );
+
+		expect( state.system ).to.eql( {
+			wpcomSubscription,
+		} );
+	} );
+
+	it( 'should restore keys', () => {
+		const state = reducer( {
+			system: {
+				wpcomSubscription: wpcomSubscription,
+			}
+		}, { type: DESERIALIZE } );
 
 		expect( state.system ).to.eql( {
 			wpcomSubscription,
@@ -49,19 +84,29 @@ describe( 'system reducer', () => {
 } );
 
 describe( 'settings reducer', () => {
+
+	it( 'should persist keys', () => {
+		const state = reducer( {
+			settings: {
+				enabled: false,
+				dismissedNotice: true,
+				dismissedNoticeAt: 1466067124796,
+			}
+		}, { type: SERIALIZE } );
+
+		expect( state.settings ).to.eql( {
+			dismissedNotice: true,
+			dismissedNoticeAt: 1466067124796,
+			enabled: false,
+		} );
+	} );
+
 	it( 'should refuse to persist particular keys', () => {
-		const wpcomSubscription = { ID: 42 };
 		const state = reducer( {
 			settings: {
 				enabled: true,
 				showingUnblockInstructions: true,
-			},
-			system: {
-				authorized: true,
-				authorizationLoaded: true,
-				blocked: true,
-				wpcomSubscription: wpcomSubscription,
-			},
+			}
 		}, { type: SERIALIZE } );
 
 		expect( state.settings ).to.eql( {
@@ -69,19 +114,28 @@ describe( 'settings reducer', () => {
 		} );
 	} );
 
+	it( 'should restore keys', () => {
+		const state = reducer( {
+			settings: {
+				enabled: false,
+				dismissedNotice: true,
+				dismissedNoticeAt: 1466067124796,
+			}
+		}, { type: DESERIALIZE } );
+
+		expect( state.settings ).to.eql( {
+			dismissedNotice: true,
+			dismissedNoticeAt: 1466067124796,
+			enabled: false,
+		} );
+	} );
+
 	it( 'should refuse to restore particular keys', () => {
-		const wpcomSubscription = { ID: 42 };
 		const state = reducer( {
 			settings: {
 				enabled: true,
 				showingUnblockInstructions: true,
-			},
-			system: {
-				authorized: true,
-				authorizationLoaded: true,
-				blocked: true,
-				wpcomSubscription: wpcomSubscription,
-			},
+			}
 		}, { type: DESERIALIZE } );
 
 		expect( state.settings ).to.eql( {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/6086

Browser Notifications store various properties in the redux state tree, and persist them. Data is validated against a schema upon persistence, and also when the data is deserialized. This PR seeks to fix the schema validation error that results in Browser Notifications always starting with the default state.

### Testing instructions

#### Unit tests

Run `npm run test-client -- --grep "state push-notifications"`

#### In browser

I. Remembering the state of the prompt

1. Visit https://calypso.live/?branch=fix-notifications-schema-validation
2. Observe the Browser Notification Notice
3. Dismiss the notice
4. Reload the page
5. Confirm that the notice is gone


II. Remembering the push subscription

1. Visit https://calypso.live/?branch=fix-notifications-schema-validation
2. Enable Browser Notifications under Notification Settings
3. Confirm that notifications are enabled
4. Reload the page
5. Confirm that notifications are still displayed in enabled state
6. Trigger a notification (e.g. like a test post)
7. Confirm that the notification arrives

