### PR TITLE
CPT: Enable removing items from Query Manager

### DIFF
--- a/client/lib/query-manager/README.md
+++ b/client/lib/query-manager/README.md
@@ -20,6 +20,8 @@ Once items have been inserted into the query manager, they can then be retrieved
 - `getItem( itemKey: string )` - Returns a single item
 - `getItems( query: ?object )` - Returns all items tracked, optionally only those associated with the passed query
 - `getFound( query: object )` - Returns the total number of items matching a query
+- `removeItem( itemKey: string )` - Removes a single item, returning a new instance if changed
+- `removeItems( itemKeys: string[] )` - Removes items, returning a new instance if changed
 
 Under the hood, Query Manager reconciles any change to an item across all queries where that item is tracked. 
 

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -186,8 +186,14 @@ export default class QueryManager {
 			const mergedItem = this.mergeItem( item, receivedItem, options.patch );
 
 			if ( undefined === mergedItem ) {
-				// `undefined` item is an intended omission from set
-				return omit( memo, receivedItemKey );
+				if ( item ) {
+					// `undefined` item is an intended omission from set
+					return omit( memo, receivedItemKey );
+				}
+
+				// Item never existed in set in the first place, skip and
+				// return same memo
+				return memo;
 			}
 
 			if ( ! item || ! isEqual( mergedItem, item ) ) {

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -257,6 +257,14 @@ describe( 'QueryManager', () => {
 			expect( newManager.getItems() ).to.eql( [] );
 		} );
 
+		it( 'should do nothing if #mergeItem() returns undefined but the item didn\'t exist', () => {
+			manager = manager.receive();
+			sandbox.stub( manager, 'mergeItem' ).returns( undefined );
+			const newManager = manager.receive( { ID: 144 } );
+
+			expect( manager ).to.equal( newManager );
+		} );
+
 		it( 'should replace a received item when key already exists', () => {
 			manager = manager.receive( { ID: 144, exists: true } );
 			manager = manager.receive( { ID: 144, changed: true } );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { useSandbox } from 'test/helpers/use-sinon';
-import QueryManager from '../';
+import QueryManager, { DELETE_PATCH_KEY } from '../';
 
 describe( 'QueryManager', () => {
 	let sandbox, manager;
@@ -89,6 +89,12 @@ describe( 'QueryManager', () => {
 
 			expect( merged ).to.not.equal( original );
 		} );
+
+		it( 'should return undefined if revised item includes delete key and patching', () => {
+			const merged = manager.mergeItem( { ID: 144 }, { [ DELETE_PATCH_KEY ]: true }, true );
+
+			expect( merged ).to.be.undefined;
+		} );
 	} );
 
 	describe( '#matches()', () => {
@@ -163,6 +169,42 @@ describe( 'QueryManager', () => {
 			manager = manager.receive( { ID: 144 }, { query: {}, found: 1 } );
 
 			expect( manager.getFound( {} ) ).to.equal( 1 );
+		} );
+	} );
+
+	describe( '#removeItem()', () => {
+		it( 'should remove an item by its item key', () => {
+			manager = manager.receive( { ID: 144 } );
+			const newManager = manager.removeItem( 144 );
+
+			expect( manager ).to.not.equal( newManager );
+			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
+			expect( newManager.getItems() ).to.eql( [] );
+		} );
+
+		it( 'should return the same instance if no items removed', () => {
+			manager = manager.receive( { ID: 144 } );
+			const newManager = manager.removeItem( 152 );
+
+			expect( manager ).to.equal( newManager );
+		} );
+	} );
+
+	describe( '#removeItems()', () => {
+		it( 'should remove an array of items by their item keys', () => {
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ] );
+			const newManager = manager.removeItems( [ 144, 152 ] );
+
+			expect( manager ).to.not.equal( newManager );
+			expect( manager.getItems() ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( newManager.getItems() ).to.eql( [] );
+		} );
+
+		it( 'should return the same instance if no items removed', () => {
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ] );
+			const newManager = manager.removeItems( [ 160, 168 ] );
+
+			expect( manager ).to.equal( newManager );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request seeks to add two new functions to `QueryManager`, `removeItem( itemKey: string )` and `removeItems( itemKeys: string[] )`. Trashing/deleting was achieved for posts by calling `receive` with a `{ status: 'trash' }` patch, but it is not currently possible to remove a term from a `TermQueryManager` instance. 

__Testing instructions:__

This feature is not currently used, but some changes affected existing logic. Specifically, ensure that receiving a changed item continues to behave as expected (currently, only applies to trashing a post from the [CPT list screen](http://calypso.localhost:3000/types/post)).

Ensure Mocha tests pass:

```
npm run test-client client/lib/query-manager
```

__Open questions:__

I observed what I noted might be an inconsistency on function names. Some are suffixed with "Item(s)", while `receive` has no suffix. `getItem`, `removeItem`, and `removeItems` take an item key as its parameter, while `receive` and `mergeItem` take object(s). Is this worrying? What would be the alternative?

Test live: https://calypso.live/?branch=update/query-manager-delete