### PR TITLE
Push Notifications: Enable for Staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -72,6 +72,7 @@
 		"press-this": true,
 		"preview-layout": true,
 		"preview-endpoint": false,
+		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/recommendations/posts": true,


### PR DESCRIPTION
Enables Push Notifications in Staging. See #4987, #5748 for fuller context.

Test live: https://calypso.live/?branch=add/push-notification-for-staging