### PR TITLE
Reader: remove 'Visit <site> for the full post' link from summary card

### DIFF
--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -42,7 +42,6 @@ const
 	EmbedHelper = require( 'reader/embed-helper' ),
 	readerRoute = require( 'reader/route' ),
 	stats = require( 'reader/stats' ),
-	PostExcerptLink = require( 'reader/post-excerpt-link' ),
 	PostPermalink = require( 'reader/post-permalink' ),
 	DiscoverPostAttribution = require( 'reader/discover/post-attribution' ),
 	DiscoverSiteAttribution = require( 'reader/discover/site-attribution' ),
@@ -169,7 +168,7 @@ const Post = React.createClass( {
 	featuredImageComponent: function( post ) {
 		var featuredImage = ( post.canonical_image && post.canonical_image.uri ),
 			featuredEmbed = head( filter( post.content_embeds, ( embed ) => {
-				return ! startsWith( embed.type, 'special-' )
+				return ! startsWith( embed.type, 'special-' );
 			} ) ),
 			maxWidth = Math.min( 653, window.innerWidth ),
 			featuredSize, useFeaturedEmbed;
@@ -426,10 +425,6 @@ const Post = React.createClass( {
 						</EmbedContainer>
 					: <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
 				}
-
-				{ shouldShowExcerptOnly
-					? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
-					: null }
 
 				{ ! shouldShowExcerptOnly
 					? <PostImages postImages={ post.content_images || [] } />

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -1,49 +1,54 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' );
+ import React from 'react';
+ import classNames from 'classnames';
 
-// Internal Dependencies
-var stats = require( 'reader/stats' );
+/**
+ * Internal dependencies
+ */
+import {
+	recordPermalinkClick,
+	recordGaEvent
+} from 'reader/stats';
 
-var PostExcerptOnly = React.createClass( {
+const PostExcerptLink = React.createClass( {
 
 	propTypes: {
 		siteName: React.PropTypes.string,
 		postUrl: React.PropTypes.string
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			isShowingNotice: false
 		};
 	},
 
-	toggleNotice: function( event ) {
+	toggleNotice( event ) {
 		event.preventDefault();
 		this.setState( {
 			isShowingNotice: ! this.state.isShowingNotice
 		} );
 	},
 
-	recordClick: function() {
-		stats.recordPermalinkClick( 'summary_card_site_name' );
-		stats.recordGaEvent( 'Clicked Excerpt Notice Permalink' );
+	recordClick() {
+		recordPermalinkClick( 'summary_card_site_name' );
+		recordGaEvent( 'Clicked Excerpt Notice Permalink' );
 	},
 
-	render: function() {
-		var siteName = ( <a onClick={ this.recordClick } href={ this.props.postUrl } rel="external" target="_blank">
-				<span className="post-excerpt-only-site-name">{ this.props.siteName || '(untitled)' }</span>
-			</a> ),
-			classes = classnames( {
-				'post-excerpt-link': true,
-				'is-showing-notice': this.state.isShowingNotice
-			} );
-
+	render() {
 		if ( ! this.props.siteName || ! this.props.postUrl ) {
 			return null;
 		}
+
+		const siteName = ( <a onClick={ this.recordClick } href={ this.props.postUrl } rel="external" target="_blank">
+				<span className="post-excerpt-only-site-name">{ this.props.siteName || '(untitled)' }</span>
+			</a> );
+		const classes = classNames( {
+			'post-excerpt-link': true,
+			'is-showing-notice': this.state.isShowingNotice
+		} );
 
 		return (
 			<div className={ classes }>
@@ -57,4 +62,4 @@ var PostExcerptOnly = React.createClass( {
 	}
 } );
 
-module.exports = PostExcerptOnly;
+export default PostExcerptLink;


### PR DESCRIPTION
For summary feeds, we show a post excerpt link component directing the user to the originating site, and explaining why the full post content is unavailable:

<img width="750" alt="screen shot 2016-06-16 at 15 56 11" src="https://cloud.githubusercontent.com/assets/17325/16121402/07ddc52c-33db-11e6-964c-49d0bd8d8759.png">

This PR removes that component from the summary card, where some users have found it confusing. It is still in the place on the full post view.

Test live: https://calypso.live/?branch=remove/reader/excerpt-link-from-summary-card