### PR TITLE
Framework: Enable ESLint rules to enforce variable declaration style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,8 @@ module.exports = {
 		// Allows Chai `expect` expressions
 		'no-unused-expressions': 0,
 		'no-unused-vars': 1,
+		'no-var': 1,
+		'prefer-const': 1,
 		// Teach eslint about React+JSX
 		'react/jsx-uses-react': 1,
 		'react/jsx-uses-vars': 1,


### PR DESCRIPTION
Related: #4251

This pull request seeks to enable ESLint rules to enforce guidelines laid out in our JavaScript coding guidelines around variable declarations, discouraging the use of `var` ([`no-var`](http://eslint.org/docs/rules/no-var)), and preferring `const` in all cases where a variable is not reassigned ([`prefer-const`](http://eslint.org/docs/rules/prefer-const)).

[See guidelines](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#variable-declarations)

__Testing instructions:__

Includes no changes to the application. Verify that ESLint warnings are triggered on expected issues.

```
./node_modules/.bin/eslint --quiet --ext .jsx --rule 'prefer-const: 2' --rule 'no-var: 2' client/
```

/cc @folletto @mcsf @gwwar 

Test live: https://calypso.live/?branch=update/eslint-prefer-const