### PR TITLE
Fix for annoying double callback message

### DIFF
--- a/test/boot-test.js
+++ b/test/boot-test.js
@@ -9,11 +9,9 @@ module.exports = {
 		Chai.use( immutableChai );
 		Chai.use( sinonChai );
 		sinon.assert.expose( Chai.assert, { prefix: '' } );
-		nock.disableNetConnect();
 	},
 	after: function() {
 		nock.cleanAll();
-		nock.enableNetConnect();
 		nock.restore();
 	}
 };


### PR DESCRIPTION
Issue: #4206
Superagent + Nock do not play well when you run nock.disableNetConnect();
- requests don't get formulated properly because of nock and then superagent throws an error and outputs:
- "double callback warning"
  Tracking issue: https://github.com/node-nock/nock/issues/211
