### PR TITLE
Add easing to spinner animation

### DIFF
--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -71,7 +71,7 @@
 }
 
 .spinner__progress {
-	animation: 3s linear infinite;
+	animation: 3s infinite;
 	transform-origin: 50px 50px;
 	fill: $blue-medium;
 }
@@ -119,10 +119,12 @@
 
 .spinner__progress.is-left,
 .spinner.is-fallback .spinner__progress.is-left::before {
+	animation-timing-function: ease-in;
 	animation-name: rotate-spinner__left;
 }
 
 .spinner__progress.is-right,
 .spinner.is-fallback .spinner__progress.is-right::before {
+	animation-timing-function: ease-out;
 	animation-name: rotate-spinner__right;
 }


### PR DESCRIPTION
This tiny PR adds some easing to the `Spinner` animation, so that it feels more physical / with a sense of weight.

Nothing moves linearly in the real world, so linear animations are a bit uncanny/robotic.

For instance, Google [[1]](https://developers.google.com/web/fundamentals/design-and-ui/animations/the-basics-of-easing?hl=en) and Apple [[2]](https://developer.apple.com/tvos/human-interface-guidelines/visual-design/) [[3]](https://developer.apple.com/watch/human-interface-guidelines/animation/) highly recommend using easing on UX to produce physically realistic animations.

Test live: https://calypso.live/?branch=add/spinner-ease-in-out