### PR TITLE
Editor: fix link modal keyboard shortcut.

### DIFF
--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -51,7 +51,9 @@ function wpLink( editor ) {
 		node = null;
 	} );
 
-	editor.addCommand( 'WP_Link', render );
+	editor.addCommand( 'WP_Link', function() {
+		return render();
+	} );
 
 	// WP default shortcut
 	editor.addShortcut( 'access+a', '', 'WP_Link' );


### PR DESCRIPTION
See #4336

This fix calls render explicitly, without any arguments. Previously, when render was passed directly to `editor.addComand`, it would receive a falsy first argument under certain circumstances. This would cause the modal to render invisibly.

The docs for TinyMCE's [addCommandCallback](http://archive.tinymce.com/wiki.php/api4:callback.tinymce.Editor.addCommandCallback) state that the first argument is a boolean for "display UI state true/false". I wasn't able to find more info, but from my testing it seems like it is set to true when triggered from the button, but when triggered by the keyboard shortcut it is set to false. 

The fix here isolates the render call from any arguments that the addCommandCallback may inject. Open to other ways of achieving the same thing! :)

To test:
- Open a post or page in the editor
- In the post body field, enter the link shortcut: `Command-k` (or `Ctrl-k` if on windows).
- The link modal should appear:

![add link modal](https://cloud.githubusercontent.com/assets/3493970/16126330/9c7a83d4-33c5-11e6-8660-e4e8da2982a9.png)
- Now select an existing link and perform the shortcut. The modal should open in edit mode, like so:

![edit link modal](https://cloud.githubusercontent.com/assets/3493970/16126387/e980f186-33c5-11e6-9366-6578d890bb89.png)
- The same behavior should work with the access shortcut: `Ctrl-Opt-a` (mac) or `Alt-Shift-a` (windows)



Test live: https://calypso.live/?branch=fix/4336-link-shortcut