### PR TITLE
Domain Contact Form: Add errors_count and submission_count to submit event

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -49,7 +49,8 @@ export default React.createClass( {
 	getInitialState() {
 		return {
 			form: null,
-			isDialogVisible: false
+			isDialogVisible: false,
+			submissionCount: 0
 		};
 	},
 
@@ -318,9 +319,13 @@ export default React.createClass( {
 	},
 
 	recordSubmit() {
+		const errors = formState.getErrorMessages( this.state.form );
 		analytics.tracks.recordEvent( 'calypso_contact_information_form_submit', {
-			errors: formState.getErrorMessages( this.state.form )
+			errors,
+			errors_count: errors && errors.length || 0,
+			submission_count: this.state.submissionCount + 1
 		} );
+		this.setState( { submissionCount: this.state.submissionCount + 1 } );
 	},
 
 	handlePrivacyDialogSelect( options ) {


### PR DESCRIPTION
This PR adds two properties two tracking event: `errors_count` and `submission_count`. We need to add `errors_count` because Tracks removes properties with empty values, making it impossible to create a funnel for submissions with no errors.

#### Testing:
- Go to contact information form
- Enter invalid data
- Ensure we send the correct data and incrementing `submission_count` in `t.gif` request

/cc: @klimeryk 

Test live: https://calypso.live/?branch=add/contact-info-form-analytics