### PR TITLE
Reader: Remove batching through batcher

### DIFF
--- a/client/lib/feed-post-store/actions.js
+++ b/client/lib/feed-post-store/actions.js
@@ -5,12 +5,12 @@ const assign = require( 'lodash/assign' ),
 // Internal dependencies
 const Dispatcher = require( 'dispatcher' ),
 	ACTION = require( './constants' ).action,
-	PostBatcher = require( './post-batch-fetcher' ),
+	PostFetcher = require( './post-fetcher' ),
 	wpcom = require( 'lib/wp' );
 
-var feedPostBatcher, blogPostBatcher, FeedPostActions;
+let feedPostFetcher, blogPostFetcher, FeedPostActions;
 
-feedPostBatcher = new PostBatcher( {
+feedPostFetcher = new PostFetcher( {
 	makeRequest: function( postKey ) {
 		return wpcom.undocumented().readFeedPost( postKey );
 	},
@@ -35,7 +35,7 @@ feedPostBatcher = new PostBatcher( {
 	}
 } );
 
-blogPostBatcher = new PostBatcher( {
+blogPostFetcher = new PostFetcher( {
 	makeRequest: function( postKey ) {
 		return wpcom.undocumented().readSitePost( { site: postKey.blogId, postId: postKey.postId } );
 	},
@@ -63,14 +63,14 @@ blogPostBatcher = new PostBatcher( {
 FeedPostActions = {
 
 	fetchPost: function( postKey ) {
-		var batcher = postKey.blogId ? blogPostBatcher : feedPostBatcher;
-		batcher.add( postKey );
+		const fetcher = postKey.blogId ? blogPostFetcher : feedPostFetcher;
+		fetcher.add( postKey );
 	},
 
 	receivePost: function( error, data, postKey ) {
-		var batcher = postKey.blogId ? blogPostBatcher : feedPostBatcher;
+		const fetcher = postKey.blogId ? blogPostFetcher : feedPostFetcher;
 		if ( data ) {
-			batcher.remove( postKey );
+			fetcher.remove( postKey );
 		}
 
 		Dispatcher.handleServerAction( assign( {

--- a/client/lib/feed-post-store/actions.js
+++ b/client/lib/feed-post-store/actions.js
@@ -5,17 +5,15 @@ const assign = require( 'lodash/assign' ),
 // Internal dependencies
 const Dispatcher = require( 'dispatcher' ),
 	ACTION = require( './constants' ).action,
-	PostBatcher = require( './post-batch-fetcher' );
+	PostBatcher = require( './post-batch-fetcher' ),
+	wpcom = require( 'lib/wp' );
 
 var feedPostBatcher, blogPostBatcher, FeedPostActions;
 
 feedPostBatcher = new PostBatcher( {
-	BATCH_SIZE: 7,
-	apiVersion: '1.3',
-	buildUrl: function( postKey ) {
-		return '/read/feed/' + encodeURIComponent( postKey.feedId ) + '/posts/' + encodeURIComponent( postKey.postId );
+	makeRequest: function( postKey ) {
+		return wpcom.undocumented().readFeedPost( postKey );
 	},
-	resultKeyRegex: /\/read\/feed\/(\w+)\/posts\/(\w+)/,
 	onFetch: function( postKey ) {
 		Dispatcher.handleViewAction( {
 			type: ACTION.FETCH_FEED_POST,
@@ -38,12 +36,9 @@ feedPostBatcher = new PostBatcher( {
 } );
 
 blogPostBatcher = new PostBatcher( {
-	BATCH_SIZE: 7,
-	apiVersion: '1.1',
-	buildUrl: function( postKey ) {
-		return '/read/sites/' + encodeURIComponent( postKey.blogId ) + '/posts/' + encodeURIComponent( postKey.postId );
+	makeRequest: function( postKey ) {
+		return wpcom.undocumented().readSitePost( { site: postKey.blogId, postId: postKey.postId } );
 	},
-	resultKeyRegex: /\/read\/sites\/(\w+)\/posts\/(\w+)/,
 	onFetch: function( postKey ) {
 		Dispatcher.handleViewAction( {
 			type: ACTION.FETCH_FEED_POST,
@@ -92,7 +87,7 @@ FeedPostActions = {
 				data: {
 					post, source
 				}
-			} )
+			} );
 		} );
 	}
 };

--- a/client/lib/feed-post-store/post-fetcher.js
+++ b/client/lib/feed-post-store/post-fetcher.js
@@ -1,25 +1,21 @@
-var assign = require( 'lodash/assign' ),
-	forOwn = require( 'lodash/forOwn' ),
+const assign = require( 'lodash/assign' ),
 	Immutable = require( 'immutable' ),
 	noop = require( 'lodash/noop' );
 
-var FeedPostStore = require( './' ),
-	wpcom = require( 'lib/wp' );
+const FeedPostStore = require( './' );
 
-function PostBatchFetcher( options ) {
+function PostFetcher( options ) {
 	assign( this, {
-		BATCH_SIZE: 7,
 		onFetch: noop,
 		onPostReceived: noop,
-		onError: noop,
-		apiVersion: '1.1'
+		onError: noop
 	}, options );
 
 	this.postsToFetch = Immutable.OrderedSet(); // eslint-disable-line new-cap
 	this.batchQueued = false;
 }
 
-assign( PostBatchFetcher.prototype, {
+assign( PostFetcher.prototype, {
 
 	add: function( postKey ) {
 		this.postsToFetch = this.postsToFetch.add( Immutable.fromJS( postKey ) );
@@ -43,10 +39,8 @@ assign( PostBatchFetcher.prototype, {
 		}
 
 		toFetch.forEach( function( postKey ) {
-			var post;
-
 			postKey = postKey.toJS();
-			post = FeedPostStore.get( postKey );
+			const post = FeedPostStore.get( postKey );
 
 			if ( post && post._state !== 'minimal' ) {
 				throw new Error( post._state );
@@ -68,4 +62,4 @@ assign( PostBatchFetcher.prototype, {
 	}
 } );
 
-module.exports = PostBatchFetcher;
+module.exports = PostFetcher;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -971,7 +971,7 @@ Undocumented.prototype.readFeedPost = function( query, fn ) {
 	debug( '/read/feed/' + query.feedId + '/posts/' + query.postId );
 	params.apiVersion = '1.3';
 
-	this.wpcom.req.get( '/read/feed/' + encodeURIComponent( query.feedId ) + '/posts/' + encodeURIComponent( query.postId ), params, fn );
+	return this.wpcom.req.get( '/read/feed/' + encodeURIComponent( query.feedId ) + '/posts/' + encodeURIComponent( query.postId ), params, fn );
 };
 
 Undocumented.prototype.readSearch = function( query, fn ) {
@@ -1113,28 +1113,25 @@ Undocumented.prototype.readTeams = function( fn ) {
 Undocumented.prototype.readSite = function( query, fn ) {
 	var params = omit( query, 'site' );
 	debug( '/read/sites/:site' );
-	query.apiVersion = '1.1';
 	return this.wpcom.req.get( '/read/sites/' + query.site, params, fn );
 };
 
 Undocumented.prototype.readSiteFeatured = function( siteId, query, fn ) {
 	var params = omit( query, [ 'before', 'after' ] );
 	debug( '/read/sites/:site/featured' );
-	this.wpcom.req.get( '/read/sites/' + siteId + '/featured', params, fn );
+	return this.wpcom.req.get( '/read/sites/' + siteId + '/featured', params, fn );
 };
 
 Undocumented.prototype.readSitePosts = function( query, fn ) {
 	var params = omit( query, 'site' );
 	debug( '/read/sites/:site/posts' );
-	query.apiVersion = '1.1';
-	this.wpcom.req.get( '/read/sites/' + query.site + '/posts', params, fn );
+	return this.wpcom.req.get( '/read/sites/' + query.site + '/posts', params, fn );
 };
 
 Undocumented.prototype.readSitePost = function( query, fn ) {
 	var params = omit( query, [ 'site', 'postId' ] );
 	debug( '/read/sites/:site/post/:post' );
-	query.apiVersion = '1.1';
-	this.wpcom.req.get( '/read/sites/' + query.site + '/posts/' + query.postId, params, fn );
+	return this.wpcom.req.get( '/read/sites/' + query.site + '/posts/' + query.postId, params, fn );
 };
 
 Undocumented.prototype.readSitePostRelated = function( query, fn ) {


### PR DESCRIPTION
The /batch API is currently broken when working with VIP sites, so instead of using it, just issue API requests directly. 

This still uses the post-batcher class, as it effectively dedupes post requests and it was simpler to re-use that logic than reimplement it.

Test live: https://calypso.live/?branch=fix/reader/remove-post-batcher