### PR TITLE
Editor: standardize advanced toggle button opacity.

### DIFF
--- a/client/components/tinymce/plugins/advanced/style.scss
+++ b/client/components/tinymce/plugins/advanced/style.scss
@@ -20,6 +20,7 @@
 }
 
 .mce-toolbar .mce-btn-group .mce-advanced.mce-btn.mce-last {
+	background-color: $transparent;
 	position: absolute;
 		top: 0;
 		right: 8px;


### PR DESCRIPTION
See #6073 

Super tiny css update to fix the opacity inconsistency. 

Before:
![before](https://cloud.githubusercontent.com/assets/1270189/16101677/e6dd4168-331c-11e6-9104-30ef90cecda9.png)
After:
![after](https://cloud.githubusercontent.com/assets/3493970/16130951/b2691732-33d9-11e6-9e39-488eac7568b7.png)

To test:
- Start at: http://calypso.localhost:3000/post/
- Select a site
- Add some content, a dark image is best
- Toggle advanced settings open
- Scroll down so the advance button is above the image/content
- Ensure toolbar opacity is visually consistent.