### PR TITLE
Fix notification state after dismissing the browser permission popup

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -235,8 +235,8 @@ export function activateSubscription() {
 				serviceWorkerRegistration.pushManager.subscribe( { userVisibleOnly: true } )
 					.then( () => dispatch( checkPermissionsState() ) )
 					.catch( err => {
-						debug( 'Error receiving subscription', err );
-						dispatch( block() );
+						debug( 'Couldn\'t get subscription', err );
+						dispatch( checkPermissionsState() );
 					} )
 				;
 			} )


### PR DESCRIPTION
This pull request seeks to fix a permission handling issue with browser push notifications.

If permission for receiving push notification has not been granted (or blocked), trying to subscribe for push notifications triggers the browser's native popup with choices like `Allow`, `Block`, and a cross in the top-right corner to dismiss the dialog.

### Current behavior:

If the user dismisses the permission prompt, Calypso incorrectly reports the notifications to be blocked under Notification Settings. It also triggers the browser's notification prompt after every reload of the page.

![imwxziiotn](https://cloud.githubusercontent.com/assets/1017839/16130912/b020611a-340b-11e6-925b-ee51fec11b8a.gif)

### Testing instructions

Do not test this locally in Chrome - the behavior is different that way. Best is to visit https://calypso.live?branch=fix/dismissed-permission-popup, or use Firefox locally.

1. Make sure the browser's notification setting is set to "Ask by default".
2. Navigate to the Notification Settings page
3. Click Enable
4. Observe that the browser's notification prompt shows up.
5. Dismiss the prompt by clicking on the x
6. Confirm that the browser notification state is Disabled, and the button label is Enable

![correct](https://cloud.githubusercontent.com/assets/1017839/16130959/08bc5ce8-340c-11e6-8c53-6811dd95caaa.gif)



