### PR TITLE
SSO: Add placeholders for site name

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -229,6 +229,81 @@ const JetpackSSOForm = React.createClass( {
 		return decodeEntities( value );
 	},
 
+	getReturnToSiteText() {
+		const title = get( this.props, 'blogDetails.title' );
+
+		if ( ! title ) {
+			return this.translate( 'Return to {{placeholder}}your Jetpack site{{/placeholder}}', {
+				context: 'This is a placeholder string until we have the site title.',
+				components: {
+					placeholder: <span className="jetpack-connect__sso__placeholder" />
+				}
+			} );
+		}
+
+		return this.translate( 'Return to %(siteName)s', {
+			args: {
+				siteName: title
+			}
+		} );
+	},
+
+	getTOSText() {
+		const title = get( this.props, 'blogDetails.title' );
+		if ( ! title ) {
+			return this.translate(
+				'By logging in you agree to share details between WordPress.com and {{placeholder}}your Jetpack site{{/placeholder}}',
+				{
+					context: 'This is a placeholder string until we have the site title.',
+					components: {
+						placeholder: <span className="jetpack-connect__sso__placeholder" />
+					}
+				}
+			);
+		}
+
+		return this.translate(
+			'By logging in you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
+			{
+				components: {
+					detailsLink: (
+						<a
+							href="#"
+							onClick={ this.onClickSharedDetailsModal }
+							className="jetpack-connect__sso__actions__modal-link"
+						/>
+					)
+				},
+				args: {
+					siteName: title
+				}
+			}
+		);
+	},
+
+	getSubHeaderText() {
+		const title = get( this.props, 'blogDetails.title' );
+		if ( ! title ) {
+			return this.translate(
+				'To use Single Sign-On, WordPress.com needs to be able to connect to your account on {{placeholder}}your Jetpack site{{/placeholder}}.',
+				{
+					context: 'This is a placeholder string until we have the site title.',
+					components: {
+						placeholder: <span className="jetpack-connect__sso__placeholder" />
+					}
+				}
+			);
+		}
+
+		return this.translate(
+			'To use Single Sign-On, WordPress.com needs to be able to connect to your account on %(siteName)s.', {
+				args: {
+					siteName: title
+				}
+			}
+		);
+	},
+
 	renderSharedDetailsList() {
 		const expectedSharedDetails = {
 			ID: '',
@@ -330,13 +405,7 @@ const JetpackSSOForm = React.createClass( {
 					<ConnectHeader
 						showLogo={ false }
 						headerText={ this.translate( 'Connect with WordPress.com' ) }
-						subHeaderText={ this.translate(
-							'To use Single Sign-On, WordPress.com needs to be able to connect to your account on %(siteName)s.', {
-								args: {
-									siteName: get( this.props, 'blogDetails.title' )
-								}
-							}
-						) }
+						subHeaderText={ this.getSubHeaderText() }
 					/>
 
 					{ this.renderSiteCard() }
@@ -363,20 +432,7 @@ const JetpackSSOForm = React.createClass( {
 
 						<LoggedOutFormFooter className="jetpack-connect__sso__actions">
 							<p className="jetpack-connect__tos-link">
-								{ this.translate( 'By logging in you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.', {
-									components: {
-										detailsLink: (
-											<a
-												href="#"
-												onClick={ this.onClickSharedDetailsModal }
-												className="jetpack-connect__sso__actions__modal-link"
-											/>
-										)
-									},
-									args: {
-										siteName: get( this.props, 'blogDetails.title' )
-									}
-								} ) }
+								{ this.getTOSText() }
 							</p>
 
 							<Button
@@ -397,11 +453,7 @@ const JetpackSSOForm = React.createClass( {
 							href={ get( this.props, 'blogDetails.admin_url', '#' ) }
 							onClick={ this.onCancelClick }>
 							<Gridicon icon="arrow-left" size={ 18 } />
-							{ this.translate( 'Return to %(siteName)s', {
-								args: {
-									siteName: get( this.props, 'blogDetails.title' )
-								}
-							} ) }
+							{ this.getReturnToSiteText() }
 						</LoggedOutFormLinkItem>
 					</LoggedOutFormLinks>
 				</div>

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -230,39 +230,24 @@ const JetpackSSOForm = React.createClass( {
 	},
 
 	getReturnToSiteText() {
-		const title = get( this.props, 'blogDetails.title' );
-
-		if ( ! title ) {
-			return this.translate( 'Return to {{placeholder}}your Jetpack site{{/placeholder}}', {
-				context: 'This is a placeholder string until we have the site title.',
-				components: {
-					placeholder: <span className="jetpack-connect__sso__placeholder" />
+		const text = (
+			<span className="jetpack-connect__sso__return-to-site">
+				<Gridicon icon="arrow-left" size={ 18 } />
+				{
+					this.translate( 'Return to %(siteName)s', {
+						args: {
+							siteName: get( this.props, 'blogDetails.title' )
+						}
+					} )
 				}
-			} );
-		}
+			</span>
+		);
 
-		return this.translate( 'Return to %(siteName)s', {
-			args: {
-				siteName: title
-			}
-		} );
+		return this.maybeWrapWithPlaceholder( text );
 	},
 
 	getTOSText() {
-		const title = get( this.props, 'blogDetails.title' );
-		if ( ! title ) {
-			return this.translate(
-				'By logging in you agree to share details between WordPress.com and {{placeholder}}your Jetpack site{{/placeholder}}',
-				{
-					context: 'This is a placeholder string until we have the site title.',
-					components: {
-						placeholder: <span className="jetpack-connect__sso__placeholder" />
-					}
-				}
-			);
-		}
-
-		return this.translate(
+		const text = this.translate(
 			'By logging in you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
 			{
 				components: {
@@ -275,32 +260,35 @@ const JetpackSSOForm = React.createClass( {
 					)
 				},
 				args: {
-					siteName: title
+					siteName: get( this.props, 'blogDetails.title' )
 				}
 			}
 		);
+
+		return this.maybeWrapWithPlaceholder( text );
 	},
 
 	getSubHeaderText() {
-		const title = get( this.props, 'blogDetails.title' );
-		if ( ! title ) {
-			return this.translate(
-				'To use Single Sign-On, WordPress.com needs to be able to connect to your account on {{placeholder}}your Jetpack site{{/placeholder}}.',
-				{
-					context: 'This is a placeholder string until we have the site title.',
-					components: {
-						placeholder: <span className="jetpack-connect__sso__placeholder" />
-					}
-				}
-			);
-		}
-
-		return this.translate(
+		const text = this.translate(
 			'To use Single Sign-On, WordPress.com needs to be able to connect to your account on %(siteName)s.', {
 				args: {
-					siteName: title
+					siteName: get( this.props, 'blogDetails.title' )
 				}
 			}
+		);
+		return this.maybeWrapWithPlaceholder( text );
+	},
+
+	maybeWrapWithPlaceholder( input ) {
+		const title = get( this.props, 'blogDetails.title' );
+		if ( title ) {
+			return input;
+		}
+
+		return (
+			<span className="jetpack-connect__sso__placeholder">
+				{ input }
+			</span>
 		);
 	},
 
@@ -452,7 +440,6 @@ const JetpackSSOForm = React.createClass( {
 							rel="external"
 							href={ get( this.props, 'blogDetails.admin_url', '#' ) }
 							onClick={ this.onCancelClick }>
-							<Gridicon icon="arrow-left" size={ 18 } />
 							{ this.getReturnToSiteText() }
 						</LoggedOutFormLinkItem>
 					</LoggedOutFormLinks>

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -412,3 +412,7 @@
 		padding-left: 0;
 	}
 }
+
+.jetpack-connect__sso__placeholder {
+	@include placeholder( 23% );
+}

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -415,4 +415,9 @@
 
 .jetpack-connect__sso__placeholder {
 	@include placeholder( 23% );
+	background-color: transparent;
+}
+
+.jetpack-connect__sso__placeholder a {
+	color: transparent;
 }

--- a/client/signup/step-header/index.jsx
+++ b/client/signup/step-header/index.jsx
@@ -13,10 +13,7 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		headerText: PropTypes.string,
-		subHeaderText: React.PropTypes.oneOfType( [
-			PropTypes.array,
-			PropTypes.string
-		] )
+		subHeaderText: React.PropTypes.node
 	},
 
 	render: function() {


### PR DESCRIPTION
Closes #5686.

This adds placeholders while we are making the SSO validation request.

cc @rickybanister for design review and @lezama for code review.

To test:

- Checkout latest Jetpack master
- Checkout `update/jetpack-sso-site-name-placeholders`
- Go to `$site/wp-admin`
- Click "Log in with WordPress.com button"
- Make sure you see placeholders and that placeholders go away


### After
Note: Video is slowed to 25% of normal speed.

![sso_placeholders](https://cloud.githubusercontent.com/assets/1126811/16133177/7cd8094c-33e4-11e6-8ddc-0abe9749fa91.gif)
[Higher resolution video](https://cloudup.com/cPfdQHFMUTL)