### PR TITLE
Framework: Update to click-outside@2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -658,7 +658,7 @@
       "version": "1.1.1"
     },
     "click-outside": {
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     "clipboard": {
       "version": "1.5.3"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6,7 +6,7 @@
       "version": "1.0.3"
     },
     "abbrev": {
-      "version": "1.0.7"
+      "version": "1.0.9"
     },
     "accepts": {
       "version": "1.2.13"
@@ -69,10 +69,10 @@
       "version": "1.0.0"
     },
     "array-union": {
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "array-uniq": {
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     "array-unique": {
       "version": "0.2.1"
@@ -658,15 +658,7 @@
       "version": "1.1.1"
     },
     "click-outside": {
-      "version": "1.0.4",
-      "dependencies": {
-        "babel-runtime": {
-          "version": "4.7.4"
-        },
-        "core-js": {
-          "version": "0.6.1"
-        }
-      }
+      "version": "2.0.0"
     },
     "clipboard": {
       "version": "1.5.3"
@@ -1462,6 +1454,9 @@
     "fs-readdir-recursive": {
       "version": "0.1.2"
     },
+    "fs.realpath": {
+      "version": "1.0.0"
+    },
     "fstream": {
       "version": "1.0.9",
       "dependencies": {
@@ -1681,7 +1676,7 @@
       "version": "1.4.0"
     },
     "http-proxy": {
-      "version": "1.13.3"
+      "version": "1.14.0"
     },
     "http-signature": {
       "version": "1.1.1"
@@ -2236,7 +2231,7 @@
       "version": "1.2.0"
     },
     "loud-rejection": {
-      "version": "1.4.1"
+      "version": "1.5.0"
     },
     "lower-case": {
       "version": "1.1.3"
@@ -3032,7 +3027,7 @@
       "version": "2.5.2",
       "dependencies": {
         "glob": {
-          "version": "7.0.3"
+          "version": "7.0.4"
         }
       }
     },
@@ -3097,7 +3092,7 @@
           "version": "3.2.0"
         },
         "glob": {
-          "version": "7.0.3"
+          "version": "7.0.4"
         },
         "window-size": {
           "version": "0.2.0"
@@ -3194,7 +3189,7 @@
       "version": "1.0.1"
     },
     "signal-exit": {
-      "version": "2.1.2"
+      "version": "3.0.0"
     },
     "simple-fmt": {
       "version": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "char-spinner": "1.0.1",
     "chrono-node": "^1.0.6",
     "classnames": "1.1.1",
-    "click-outside": "1.0.4",
+    "click-outside": "2.0.0",
     "clipboard": "1.5.3",
     "commander": "2.3.0",
     "component-closest": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "char-spinner": "1.0.1",
     "chrono-node": "^1.0.6",
     "classnames": "1.1.1",
-    "click-outside": "2.0.0",
+    "click-outside": "2.0.1",
     "clipboard": "1.5.3",
     "commander": "2.3.0",
     "component-closest": "0.1.4",


### PR DESCRIPTION
Removes the transitive dep on the babel@4 runtime

Test live: https://calypso.live/?branch=update/click-outside-2