### PR TITLE
Signup: Use lodash .find because IE11

### DIFF
--- a/client/components/plans/premium-popover/index.jsx
+++ b/client/components/plans/premium-popover/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import omit from 'lodash/omit';
+import find from 'lodash/find';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
@@ -57,7 +58,7 @@ const PremiumPopover = React.createClass( {
 		} );
 	},
 	getSitePlan() {
-		return ( this.props.sitePlans.data || [] ).find( plan => plan.product_slug === 'value_bundle' );
+		return find( ( this.props.sitePlans.data || [] ), ( plan => plan.product_slug === 'value_bundle' ) );
 	},
 	componentDidUpdate( oldProps ) {
 		if ( oldProps.context !== this.props.context ) {
@@ -115,7 +116,7 @@ const PremiumPopover = React.createClass( {
 		}
 	},
 	render() {
-		const premiumPlan = this.props.plans.find( plan => plan.product_slug === 'value_bundle' );
+		const premiumPlan = find( this.props.plans, ( plan => plan.product_slug === 'value_bundle' ) );
 		return (
 			<Popover
 				{ ...omit( this.props, [ 'children', 'className', 'bindContextEvents' ] ) }


### PR DESCRIPTION
This PR switches usage of `Array.prototype.find` to `lodash.find` and fixes signup problems in IE11.

/cc: @aidvu @rralian 

Test live: https://calypso.live/?branch=fix/signup-domain-search-ie11