### PR TITLE
Framework: Upgrade from ESLint v1.10.3 to v2.12.x

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,5 +4,5 @@ build/
 config/
 docs/
 public/
-
+!.eslintrc.js
 server/devdocs/search-index.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,21 +1,25 @@
-/*eslint-disable quote-props */
+/* eslint-disable quote-props */
 module.exports = {
-	'parser': 'babel-eslint',
-	'env': {
-		'browser': true,
-		'es6': true,
-		'mocha': true,
-		'node': true
+	root: true,
+	parser: 'babel-eslint',
+	env: {
+		browser: true,
+		es6: true,
+		mocha: true,
+		node: true
 	},
-	'ecmaFeatures': {
-		'jsx': true,
-		'modules': true
+	parserOptions: {
+		ecmaVersion: 6,
+		ecmaFeatures: {
+			jsx: true
+		},
+		sourceType: 'module'
 	},
-	'plugins': [
+	plugins: [
 		'eslint-plugin-react',
 		'eslint-plugin-wpcalypso'
 	],
-	'rules': {
+	rules: {
 		'array-bracket-spacing': [ 1, 'always' ],
 		'brace-style': [ 1, '1tbs' ],
 		// REST API objects include underscores
@@ -30,6 +34,7 @@ module.exports = {
 		'eol-last': 1,
 		'indent': [ 1, 'tab', { 'SwitchCase': 1 } ],
 		'key-spacing': 1,
+		'keyword-spacing': 1,
 		'new-cap': [ 1, { 'capIsNew': false, 'newIsCap': true } ],
 		'no-cond-assign': 2,
 		'no-dupe-keys': 2,
@@ -83,7 +88,6 @@ module.exports = {
 		'quotes': [ 1, 'single', 'avoid-escape' ],
 		'semi': 1,
 		'semi-spacing': 1,
-		'space-after-keywords': [ 1, 'always' ],
 		'space-before-blocks': [ 1, 'always' ],
 		'space-before-function-paren': [ 1, 'never' ],
 		'space-in-parens': [ 1, 'always' ],

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,6 +17,9 @@
     "acorn-globals": {
       "version": "3.0.0"
     },
+    "acorn-jsx": {
+      "version": "3.0.1"
+    },
     "after": {
       "version": "0.8.1"
     },
@@ -560,8 +563,14 @@
     "bytes": {
       "version": "2.4.0"
     },
+    "caller-path": {
+      "version": "0.1.0"
+    },
     "callsite": {
       "version": "1.0.0"
+    },
+    "callsites": {
+      "version": "0.2.0"
     },
     "camel-case": {
       "version": "0.1.0"
@@ -578,7 +587,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000486"
+      "version": "1.0.30000488"
     },
     "caseless": {
       "version": "0.11.0"
@@ -632,7 +641,7 @@
       }
     },
     "chokidar": {
-      "version": "1.5.2"
+      "version": "1.6.0"
     },
     "chrono-node": {
       "version": "1.2.3"
@@ -655,7 +664,7 @@
       "version": "1.0.2"
     },
     "cli-width": {
-      "version": "1.1.1"
+      "version": "2.1.0"
     },
     "click-outside": {
       "version": "2.0.1"
@@ -963,13 +972,10 @@
       "version": "2.0.0"
     },
     "doctrine": {
-      "version": "0.7.2",
+      "version": "1.2.2",
       "dependencies": {
         "esutils": {
           "version": "1.1.6"
-        },
-        "isarray": {
-          "version": "0.0.1"
         }
       }
     },
@@ -1137,18 +1143,6 @@
         },
         "estraverse": {
           "version": "1.9.3"
-        },
-        "fast-levenshtein": {
-          "version": "1.1.3"
-        },
-        "levn": {
-          "version": "0.3.0"
-        },
-        "optionator": {
-          "version": "0.8.1"
-        },
-        "wordwrap": {
-          "version": "1.0.0"
         }
       }
     },
@@ -1216,19 +1210,19 @@
       "version": "1.0.1"
     },
     "eslint": {
-      "version": "1.10.3",
+      "version": "2.13.1",
       "dependencies": {
-        "espree": {
-          "version": "2.2.5"
+        "chalk": {
+          "version": "1.1.3"
         },
-        "glob": {
-          "version": "5.0.15"
-        },
-        "minimatch": {
-          "version": "3.0.2"
+        "globals": {
+          "version": "9.8.0"
         },
         "strip-json-comments": {
           "version": "1.0.4"
+        },
+        "supports-color": {
+          "version": "2.0.0"
         },
         "user-home": {
           "version": "2.0.0"
@@ -1239,7 +1233,70 @@
       "version": "3.11.3"
     },
     "eslint-plugin-wpcalypso": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "dependencies": {
+        "cli-width": {
+          "version": "1.1.1"
+        },
+        "doctrine": {
+          "version": "0.7.2",
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6"
+            }
+          }
+        },
+        "eslint": {
+          "version": "1.10.3"
+        },
+        "espree": {
+          "version": "2.2.5"
+        },
+        "fast-levenshtein": {
+          "version": "1.0.7"
+        },
+        "glob": {
+          "version": "5.0.15"
+        },
+        "inquirer": {
+          "version": "0.11.4"
+        },
+        "isarray": {
+          "version": "0.0.1"
+        },
+        "js-yaml": {
+          "version": "3.4.5",
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.2"
+            }
+          }
+        },
+        "levn": {
+          "version": "0.2.5"
+        },
+        "lodash": {
+          "version": "3.10.1"
+        },
+        "minimatch": {
+          "version": "3.0.2"
+        },
+        "optionator": {
+          "version": "0.6.0"
+        },
+        "shelljs": {
+          "version": "0.5.3"
+        },
+        "strip-json-comments": {
+          "version": "1.0.4"
+        },
+        "user-home": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "espree": {
+      "version": "3.1.6"
     },
     "esprima-fb": {
       "version": "10001.1.0-dev-harmony-fb"
@@ -1320,7 +1377,7 @@
       }
     },
     "fast-levenshtein": {
-      "version": "1.0.7"
+      "version": "1.1.3"
     },
     "fastparse": {
       "version": "1.1.1"
@@ -1698,6 +1755,9 @@
     "ieee754": {
       "version": "1.1.6"
     },
+    "ignore": {
+      "version": "3.1.3"
+    },
     "imagesloaded": {
       "version": "4.1.0"
     },
@@ -1706,6 +1766,9 @@
     },
     "imports-loader": {
       "version": "0.6.5"
+    },
+    "imurmurhash": {
+      "version": "0.1.4"
     },
     "indent-string": {
       "version": "2.1.0",
@@ -1728,12 +1791,7 @@
       "version": "1.3.4"
     },
     "inquirer": {
-      "version": "0.11.4",
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1"
-        }
-      }
+      "version": "0.12.0"
     },
     "interpolate-components": {
       "version": "1.1.0"
@@ -1946,7 +2004,7 @@
       "version": "1.0.3"
     },
     "js-yaml": {
-      "version": "3.4.5",
+      "version": "3.6.1",
       "dependencies": {
         "esprima": {
           "version": "2.7.2"
@@ -1995,7 +2053,7 @@
       "version": "2.0.0"
     },
     "jsprim": {
-      "version": "1.2.2"
+      "version": "1.3.0"
     },
     "jstimezonedetect": {
       "version": "1.0.5"
@@ -2022,7 +2080,7 @@
       "version": "1.0.2"
     },
     "levn": {
-      "version": "0.2.5"
+      "version": "0.3.0"
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -2537,7 +2595,12 @@
       }
     },
     "optionator": {
-      "version": "0.6.0"
+      "version": "0.8.1",
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0"
+        }
+      }
     },
     "options": {
       "version": "0.0.6"
@@ -2691,6 +2754,9 @@
     "pkg-conf": {
       "version": "1.1.3"
     },
+    "pluralize": {
+      "version": "1.2.1"
+    },
     "postcss": {
       "version": "5.0.21",
       "dependencies": {
@@ -2719,6 +2785,9 @@
     },
     "process-nextick-args": {
       "version": "1.0.7"
+    },
+    "progress": {
+      "version": "1.1.8"
     },
     "progress-event": {
       "version": "1.0.0"
@@ -2897,10 +2966,13 @@
       "version": "2.0.6"
     },
     "readdirp": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.4"
+        },
+        "minimatch": {
+          "version": "3.0.2"
         }
       }
     },
@@ -3010,6 +3082,9 @@
     "require-main-filename": {
       "version": "1.0.1"
     },
+    "require-uncached": {
+      "version": "1.0.2"
+    },
     "requireindex": {
       "version": "1.1.0"
     },
@@ -3018,6 +3093,9 @@
     },
     "resolve": {
       "version": "1.1.7"
+    },
+    "resolve-from": {
+      "version": "1.0.1"
     },
     "restore-cursor": {
       "version": "1.0.1"
@@ -3197,7 +3275,7 @@
       "version": "1.0.0"
     },
     "shelljs": {
-      "version": "0.5.3"
+      "version": "0.6.0"
     },
     "sigmund": {
       "version": "1.0.1"
@@ -3219,6 +3297,9 @@
     },
     "slash": {
       "version": "1.0.0"
+    },
+    "slice-ansi": {
+      "version": "0.0.4"
     },
     "snake-case": {
       "version": "1.1.2",
@@ -3478,6 +3559,20 @@
     },
     "sync-exec": {
       "version": "0.5.0"
+    },
+    "table": {
+      "version": "3.7.8",
+      "dependencies": {
+        "bluebird": {
+          "version": "3.4.1"
+        },
+        "chalk": {
+          "version": "1.1.3"
+        },
+        "supports-color": {
+          "version": "2.0.0"
+        }
+      }
     },
     "tapable": {
       "version": "0.1.10"
@@ -3822,6 +3917,9 @@
     "xmlhttprequest": {
       "version": "1.5.0",
       "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+    },
+    "xregexp": {
+      "version": "3.1.1"
     },
     "xtend": {
       "version": "4.0.1"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1230,7 +1230,7 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "3.11.3"
+      "version": "5.2.2"
     },
     "eslint-plugin-wpcalypso": {
       "version": "1.1.3",
@@ -1670,7 +1670,7 @@
       "version": "1.0.0"
     },
     "has-unicode": {
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     "hawk": {
       "version": "3.1.3"
@@ -2060,6 +2060,9 @@
     },
     "jstransformer": {
       "version": "0.0.3"
+    },
+    "jsx-ast-utils": {
+      "version": "1.2.1"
     },
     "key-mirror": {
       "version": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "esformatter-semicolons": "1.1.1",
     "esformatter-special-bangs": "1.0.1",
     "eslint": "2.13.1",
-    "eslint-plugin-react": "3.11.3",
+    "eslint-plugin-react": "5.2.2",
     "eslint-plugin-wpcalypso": "1.1.3",
     "glob": "7.0.3",
     "jsdom": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "esformatter-quotes": "1.0.3",
     "esformatter-semicolons": "1.1.1",
     "esformatter-special-bangs": "1.0.1",
-    "eslint": "1.10.3",
+    "eslint": "2.13.1",
     "eslint-plugin-react": "3.11.3",
     "eslint-plugin-wpcalypso": "1.1.3",
     "glob": "7.0.3",


### PR DESCRIPTION
This pull request seeks to upgrade our ESLint dependency from v1.10.3 to v2.12.0.

[See migration guide](http://eslint.org/docs/user-guide/migrating-to-2.0.0)

__Testing instructions:__

When upgraded, ESLint should continue to report warnings as it has without any errors:

```
make lint
```

Test live: https://calypso.live/?branch=update/eslint-2-x