### PR TITLE
Add warning for ES6 instance functions in development environment

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -1,5 +1,8 @@
 // Initialize localStorage polyfill before any dependencies are loaded
 require( 'lib/local-storage' )();
+if ( process.env.NODE_ENV === 'development' ) {
+	require( 'lib/wrap-es6-functions' )();
+}
 
 /**
  * External dependencies

--- a/client/lib/wrap-es6-functions/index.js
+++ b/client/lib/wrap-es6-functions/index.js
@@ -1,0 +1,28 @@
+import partial from 'lodash/partial';
+import isFunction from 'lodash/isFunction';
+
+function wrapFnWithWarning( fn, name ) {
+	const consoleFn = ( console.error || console.log ).bind( console );
+	return function() {
+		const err = new Error( `${ name } is not supported on all browsers. You must use a replacement method from lodash.` );
+		consoleFn( err );
+		return fn.apply( this, arguments );
+	}
+}
+
+function wrapObjectFn( obj, objectName, key ) {
+	if ( isFunction( obj[ key ] ) ) {
+		Object.defineProperty( obj, key, { value: wrapFnWithWarning( obj[ key ], `${ objectName }${ key}` ) } );
+	}
+}
+
+export default function() {
+	[ 'keys', 'entries', 'values', 'findIndex', 'fill', 'find' ]
+		.map( partial( wrapObjectFn, Array.prototype, 'Array#' ) );
+
+	[ 'codePointAt', 'normalize', 'repeat', 'startsWith', 'endsWith', 'includes' ]
+		.map( partial( wrapObjectFn, String.prototype, 'String#' ) );
+
+	[ 'flags' ].map( partial( wrapObjectFn, RegExp.prototype, 'RegExp#' ) );
+
+}

--- a/client/lib/wrap-es6-functions/test/index.js
+++ b/client/lib/wrap-es6-functions/test/index.js
@@ -1,0 +1,70 @@
+/**
+ * External Dependencies
+ */
+import partial from 'lodash/partial';
+import assert from 'assert';
+import isFunction from 'lodash/isFunction';
+
+/**
+ * Internal Dependencies
+ */
+import { useSandbox } from 'test/helpers/use-sinon';
+
+
+describe( 'wrapping', () => {
+	let sandbox,
+		arrayProps = [ 'keys', 'entries', 'values', 'findIndex', 'fill', 'find' ].filter( key => isFunction( Array.prototype[ key ] ) ),
+		stringProps = [ 'codePointAt', 'normalize', 'repeat', 'startsWith', 'endsWith', 'includes' ].filter( key => isFunction( String.prototype[ key ] ) ),
+		consoleSpy,
+		regExpProps = [ 'flags' ].filter( key => isFunction( RegExp.prototype[ key ] ) );
+
+	function installSpies( props, obj ) {
+		props.forEach( key => {
+			sandbox.spy( obj, key );
+		} );
+	}
+
+	function assertCall( obj, args, key ) {
+		it( key, () => {
+			if ( isFunction( obj[ key ] ) ) {
+				obj[ key ].apply( obj, args );
+				assert( consoleSpy.calledOnce );
+			}
+		} )
+	}
+
+	useSandbox( newSandbox => sandbox = newSandbox );
+	before( () => {
+		consoleSpy = sandbox.stub( console, 'error' );
+		installSpies( arrayProps, Array.prototype );
+		installSpies( stringProps, String.prototype );
+		installSpies( regExpProps, RegExp.prototype );
+
+		require( '../' )();
+	} );
+
+	after( () => {
+		sandbox.restore();
+	} );
+
+	beforeEach( () => {
+		consoleSpy.reset();
+	} );
+
+	describe( 'Array', () => {
+		[ 'keys', 'entries', 'values' ].forEach( partial( assertCall, Array.prototype, [] ) );
+		[ 'findIndex', 'find' ].forEach( partial( assertCall, Array.prototype, [ () => true ] ) );
+		[ 'fill' ].forEach( partial( assertCall, Array.prototype, [ 1 ] ) );
+	} );
+
+	describe( 'String', () => {
+		[ 'codePointAt', 'repeat' ].forEach( partial( assertCall, 'hello', [ 1 ] ) );
+		[ 'startsWith', 'endsWith', 'includes' ].forEach( partial( assertCall, 'hello', [ 'a' ] ) );
+		[ 'normalize' ].forEach( partial( assertCall, 'hello', [] ) );
+	} );
+
+	describe( 'RegExp', () => {
+		[ 'flags' ].forEach( partial( assertCall, /a/, 'flags', [ 'g' ] ) );
+	} );
+
+} );


### PR DESCRIPTION
I've been hit by mistakenly using a not polyfilled function (`Array#find`) and broke IE11 experience for a while.

There has been a number of painful experiences in the past, and I want no one to experience the same thing again. 

We have two real options to the problem at hand:

- Include `babel-polyfill`#2360
- Break those functions in developer environments (failfast)

Both of these options boil down to the same thing: make the environments similar to each other. I am find with using either of them, as long as we have a solution. But need to pick a solution and move forward with it.

This PR approaches this by intentionally breaking the non-polyfilled functions in dev and staging environments for all browsers (Test on Chrome, Safari, Firefox). It iterates through the keys in the prototype object and deletes them.

The approach is a bit unconventional, but after putting my bias aside, I cannot think of an unwanted outcome out of this. Ideas welcome.

I've tried writing a eslint rule at first, but no static analysis tool is going to be reliable as it cannot know the type of the object every time.

I've put the file under `lib/degrade-es6-fns` but we can move it to a better place once we settle on the approach.

/cc: @rralian @gwwar @aduth @klimeryk 

Test live: https://calypso.live/?branch=fix/es6-ie11