### PR TITLE
Framework: Bump i18n-calypso to 1.3.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -578,7 +578,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000479"
+      "version": "1.0.30000480"
     },
     "caseless": {
       "version": "0.11.0"
@@ -1628,7 +1628,7 @@
       "version": "2.16.3"
     },
     "hoist-non-react-statics": {
-      "version": "1.1.0"
+      "version": "1.2.0"
     },
     "home-or-tmp": {
       "version": "1.0.0"
@@ -1685,7 +1685,7 @@
       "version": "0.0.0"
     },
     "i18n-calypso": {
-      "version": "1.2.0",
+      "version": "1.3.1",
       "dependencies": {
         "async": {
           "version": "1.5.2"
@@ -1739,7 +1739,7 @@
       }
     },
     "interpolate-components": {
-      "version": "1.0.5"
+      "version": "1.1.0"
     },
     "interpret": {
       "version": "0.6.6"
@@ -3135,13 +3135,19 @@
       "version": "1.0.2"
     },
     "serve-index": {
-      "version": "1.7.3",
+      "version": "1.8.0",
       "dependencies": {
+        "accepts": {
+          "version": "1.3.3"
+        },
         "escape-html": {
           "version": "1.0.3"
         },
         "http-errors": {
-          "version": "1.3.1"
+          "version": "1.5.0"
+        },
+        "negotiator": {
+          "version": "0.6.1"
         }
       }
     },
@@ -3167,6 +3173,9 @@
     },
     "set-blocking": {
       "version": "1.0.0"
+    },
+    "setprototypeof": {
+      "version": "1.0.1"
     },
     "sha.js": {
       "version": "2.2.6"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "flux": "2.1.1",
     "he": "0.5.0",
     "html-loader": "0.4.0",
-    "i18n-calypso": "1.2.0",
+    "i18n-calypso": "1.3.1",
     "immutable": "3.8.1",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",


### PR DESCRIPTION
Which allows interpolate-component to use Babel 6.

cc @gwwar @blowery 

Test live: https://calypso.live/?branch=update/interpolate-components-1-3-0