### PR TITLE
Fix scroll-into-viewport recursive call

### DIFF
--- a/client/lib/scroll-into-viewport/index.js
+++ b/client/lib/scroll-into-viewport/index.js
@@ -4,35 +4,35 @@
  * @param {Object} node - The node to start walking
  * @param {string} valueProp - The name of the property to fetch the value from
  * @param {string} nextNodeProp - The name of the property for the next node
- * @param {number} [value=0} - The initial value
+ * @param {number} [value=0] - The initial value
  * @returns {number} - Summed value at the end of the walk
  */
 function recursivelyWalkAndSum( node, valueProp, nextNodeProp, value = 0 ) {
 	value += node[ valueProp ];
 	if ( ! node[ nextNodeProp ] ) {
-		return value
+		return value;
 	}
 	return recursivelyWalkAndSum( node[ nextNodeProp ], valueProp, nextNodeProp, value );
 }
 
 /**
  * Checks whether the given bounds are within the viewport
- * @param {number} elementStart
- * @param {number} elementEnd
- * @returns {boolean}
+ * @param {number} elementStart - Y position of element's top side
+ * @param {number} elementEnd - Y position of element's bottom side
+ * @returns {boolean} Element is within viewport
  */
 function isInViewportRange( elementStart, elementEnd ) {
-	var viewportStart = window.scrollY,
+	const viewportStart = window.scrollY,
 		viewportEnd = document.documentElement.clientHeight + window.scrollY;
 	return elementStart > viewportStart && elementEnd < viewportEnd;
 }
 
 /**
  * Scroll an element into the viewport if it's not already inside the viewport
- * @param {HTMLElement} element
+ * @param {HTMLElement} element Element that should be scrolled into viewport
  */
 function scrollIntoViewport( element ) {
-	var elementStartY = recursivelyWalkAndSum( element, 'offsetTop', 'offsetParent' ),
+	const elementStartY = recursivelyWalkAndSum( element, 'offsetTop', 'offsetParent' ),
 		elementEndY = elementStartY + element.offsetHeight;
 	! isInViewportRange( elementStartY, elementEndY ) && window.scrollTo( 0, elementStartY );
 }

--- a/client/lib/scroll-into-viewport/index.js
+++ b/client/lib/scroll-into-viewport/index.js
@@ -12,7 +12,7 @@ function recursivelyWalkAndSum( node, valueProp, nextNodeProp, value = 0 ) {
 	if ( ! node[ nextNodeProp ] ) {
 		return value
 	}
-	return recursivelyWalkAndSum( node[ nextNodeProp ], valueProp, value );
+	return recursivelyWalkAndSum( node[ nextNodeProp ], valueProp, nextNodeProp, value );
 }
 
 /**


### PR DESCRIPTION
I noticed that the recursive implementation had an error that made it only work in a non-recursive way — just one node deep. 

It was passing only three arguments out of four and that caused it to read `node[ value ]` instead of `node[ nextNodeProp ]` in the next call. That always stopped the recursion right in the second call.

The real fix is just line 15. The rest of this PR is making JSLint feel happy about that code (it showed many warnings before)

cc: @umurkontaci

Can you please test if something wasn't actually relying on this behavior? 

Test live: https://calypso.live/?branch=fix/scroll-into-viewport-recursive