### PR TITLE
Reader: Add click tracking for related posts in reader full post view

### DIFF
--- a/client/components/post-card/small.jsx
+++ b/client/components/post-card/small.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import classnames from 'classnames';
+import noop from 'lodash/noop';
+import partial from 'lodash/partial';
 
 /**
  * Internal Dependencies
@@ -12,24 +14,24 @@ import SiteIcon from 'components/site-icon';
 import safeImageUrl from 'lib/safe-image-url';
 import resizeImageUrl from 'lib/resize-image-url';
 
-export default function SmallPostCard( { post, site } ) {
+export default function SmallPostCard( { post, site, onPostClick = noop, onSiteClick = noop } ) {
 	const classes = classnames( 'post-card small', {
 		'has-image': post.canonical_image
 	} );
 	return (
 		<Card className={ classes }>
 			<div className="post-card__site-info-title">
-				<a className="post-card__site-info" href={ `/read/blogs/${post.site_ID}` }>
+				<a className="post-card__site-info" href={ `/read/blogs/${post.site_ID}` } onClick={ partial( onSiteClick, site, post ) }>
 					<SiteIcon site={ site } size={ 16 } />
 					<span className="post-card__site-title">{ site && site.title || post.site_name }</span>
 				</a>
 				<h1 className="post-card__title">
-					<a className="post-card__anchor" href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` }>{ post.title }</a>
+					<a className="post-card__anchor" href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` } onClick={ partial( onPostClick, post ) }>{ post.title }</a>
 				</h1>
 			</div>
 			<div>
 			{ post.canonical_image && (
-					<a href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` }><img className="post-card__thumbnail" src={ resizeImageUrl( safeImageUrl( post.canonical_image.uri ), { resize: '96,72' } ) } /></a> ) }
+					<a href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` } onClick={ partial( onPostClick, post ) }><img className="post-card__thumbnail" src={ resizeImageUrl( safeImageUrl( post.canonical_image.uri ), { resize: '96,72' } ) } /></a> ) }
 			</div>
 		</Card>
 	);

--- a/client/components/related-posts/index.jsx
+++ b/client/components/related-posts/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
+import noop from 'lodash/noop';
 
 /**
  * Internal Dependencies
@@ -16,7 +17,11 @@ import QueryReaderRelatedPosts from 'components/data/query-reader-related-posts'
 
 const RelatedPost = React.createClass( {
 	render() {
-		return <SmallPost post={ this.props.post } site={ this.props.site } />;
+		return <SmallPost
+			post={ this.props.post }
+			site={ this.props.site }
+			onPostClick={ this.props.onPostClick }
+			onSiteClick={ this.props.onSiteClick } />;
 	}
 } );
 
@@ -32,7 +37,7 @@ const ConnectedRelatedPost = connect(
 	}
 )( RelatedPost );
 
-function RelatedPosts( { siteId, postId, posts } ) {
+function RelatedPosts( { siteId, postId, posts, onPostClick = noop, onSiteClick = noop } ) {
 	if ( ! posts ) {
 		return <QueryReaderRelatedPosts siteId={ siteId } postId={ postId } />;
 	}
@@ -40,7 +45,12 @@ function RelatedPosts( { siteId, postId, posts } ) {
 		<div className="related-posts">
 			<h1 className="related-posts__heading">{ i18n.translate( 'Related Reading' ) }</h1>
 			<ul className="related-posts__list">
-				{ posts.map( post_id => <li key={ post_id } className="related-posts__list-item"><ConnectedRelatedPost post={ post_id } /></li> ) }
+				{ posts.map( post_id => {
+					return ( <li key={ post_id } className="related-posts__list-item">
+							<ConnectedRelatedPost post={ post_id } onPostClick={ onPostClick } onSiteClick={ onSiteClick } />
+						</li> );
+				} )
+				}
 			</ul>
 		</div>
 	);

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -227,12 +227,20 @@ FullPostView = React.createClass( {
 
 					{ shouldShowExcerptOnly && ! isDiscoverPost ? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> : null }
 					{ discoverSiteName && discoverSiteUrl ? <DiscoverVisitLink siteName={ discoverSiteName } siteUrl={ discoverSiteUrl } /> : null }
-					{ config.isEnabled( 'reader/related-posts' ) && ! post.is_external && post.site_ID && <RelatedPosts siteId={ post.site_ID } postId={ post.ID } /> }
+					{ config.isEnabled( 'reader/related-posts' ) && ! post.is_external && post.site_ID && <RelatedPosts siteId={ post.site_ID } postId={ post.ID } onPostClick={ this.recordRelatedPostClicks } onSiteClick={ this.recordRelatedPostSiteClicks }/> }
 					{ this.props.shouldShowComments ? <PostCommentList ref="commentList" post={ post } initialSize={ 25 } pageSize={ 25 } onCommentsUpdate={ this.checkForCommentAnchor } /> : null }
 				</article>
 			</div>
 		);
 		/*eslint-enable react/no-danger*/
+	},
+
+	recordRelatedPostClicks: function( post ) {
+		stats.recordTrackForPost( 'calypso_reader_related_post_clicked', post );
+	},
+
+	recordRelatedPostSiteClicks: function( site, post ) {
+		stats.recordTrackForPost( 'calypso_reader_related_post_site_clicked', post );
 	},
 
 	_generateButtonClickHandler: function( clickHandler ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -107,6 +107,8 @@ export function recordTrack( eventName, eventProperties ) {
 
 const tracksRailcarEventWhitelist = new Set();
 tracksRailcarEventWhitelist
+	.add( 'calypso_reader_related_post_clicked' )
+	.add( 'calypso_reader_related_post_site_clicked' )
 	.add( 'calypso_reader_article_liked' )
 	.add( 'calypso_reader_article_commented_on' )
 	.add( 'calypso_reader_article_opened' )


### PR DESCRIPTION
Add tracks event tracking to Reader related posts. 

To test, load up the full post view for a post from wpcom or jetpack and look for the related posts, just before the comments. Then click on a post title or site title in the related set. In the network tab, you should see requests being made to tracks to log calypso_reader_related_post_clicked (for posts), calypso_reader_related_post_site_clicked (for the site title) and a traintracks interact event for the given railcar. 