### PR TITLE
Jetpack Connect: modified some instruction copy

### DIFF
--- a/client/signup/jetpack-connect/exampleComponents/jetpack-activate.jsx
+++ b/client/signup/jetpack-connect/exampleComponents/jetpack-activate.jsx
@@ -13,20 +13,20 @@ export default React.createClass( {
 	renderActivate() {
 		if ( this.props.isInstall ) {
 			return (
-				<div className="jetpack-connect__example-content-wp-admin-plugin-card">
-					<div className="jetpack-connect__example-content-wp-admin-plugin-name" aria-hidden="true">
-						{ this.translate( 'Jetpack by WordPress.com', { context: 'Jetpack Connect activate plugin instructions, plugin title' } ) }
-					</div>
-					<div className="jetpack-connect__example-content-wp-admin-plugin-activate-link" aria-hidden="true">
-						{ this.translate( 'Activate', { context: 'Jetpack Connect activate plugin instructions, activate link' } ) }
+				<div className="jetpack-connect__example-content-wp-admin-activate-view">
+					<div className="jetpack-connect__example-content-wp-admin-activate-link" aria-hidden="true">
+						{ this.translate( 'Activate Plugin', { context: 'Jetpack Connect activate plugin instructions, activate link' } ) }
 					</div>
 				</div>
 			);
 		}
 		return (
-			<div className="jetpack-connect__example-content-wp-admin-activate-view">
-				<div className="jetpack-connect__example-content-wp-admin-activate-link" aria-hidden="true">
-					{ this.translate( 'Activate Plugin', { context: 'Jetpack Connect activate plugin instructions, activate link' } ) }
+			<div className="jetpack-connect__example-content-wp-admin-plugin-card">
+				<div className="jetpack-connect__example-content-wp-admin-plugin-name" aria-hidden="true">
+					{ this.translate( 'Jetpack by WordPress.com', { context: 'Jetpack Connect activate plugin instructions, plugin title' } ) }
+				</div>
+				<div className="jetpack-connect__example-content-wp-admin-plugin-activate-link" aria-hidden="true">
+					{ this.translate( 'Activate', { context: 'Jetpack Connect activate plugin instructions, activate link' } ) }
 				</div>
 			</div>
 		);

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -271,17 +271,17 @@ const JetpackConnectMain = React.createClass( {
 						step={ 1 }
 						steps={ 3 } />
 					<div className="jetpack-connect__install-steps">
-						<JetpackInstallStep title={ this.translate( '1. Install' ) }
+						<JetpackInstallStep title={ this.translate( '1. Install Jetpack' ) }
 							text={ this.props.isInstall
 									? this.translate( 'You will be redirected to your site\'s dashboard to install Jetpack. Click the blue "Install Now" button' )
 									: this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s dashboard to install Jetpack. Click the blue install button.' )
-							}
+								}
 							example={ <JetpackExampleInstall url={ this.state.currentUrl } /> } />
 						<JetpackInstallStep title={ this.translate( '2. Activate Jetpack' ) }
-							text={ this.translate( 'You\'ll then need to click the small blue "Activate Plugin" link to activate Jetpack.' ) }
+							text={ this.translate( 'Then you\'ll click the blue "Activate" link to activate Jetpack.' ) }
 							example={ <JetpackExampleActivate url={ this.state.currentUrl } isInstall={ true } /> } />
 						<JetpackInstallStep title={ this.translate( '3. Connect Jetpack' ) }
-							text={ this.translate( 'Finally, just click the green "Connect to WordPress.com" button to finish the process.' ) }
+							text={ this.translate( 'Finally, click the green "Connect to WordPress.com" button to finish the process.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />
 					</div>
 					<Button onClick={ this.installJetpack } primary>{ this.translate( 'Install Jetpack' ) }</Button>
@@ -308,16 +308,16 @@ const JetpackConnectMain = React.createClass( {
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
 					<ConnectHeader showLogo={ false }
-						headerText={ this.translate( 'Ready for installation' ) }
+						headerText={ this.translate( 'Ready for activation' ) }
 						subHeaderText={ this.translate( 'We\'ll need to send you to your site dashboard for a few manual steps.' ) }
 						step={ 1 }
 						steps={ 3 } />
 					<div className="jetpack-connect__install-steps">
 						<JetpackInstallStep title={ this.translate( '1. Activate Jetpack' ) }
-							text={ this.translate( 'You need to click this tiny blue \'Activate\' link from your plugins list page.' ) }
+							text={ this.translate( 'You will be redirected to your site\'s dashboard to activate Jetpack. Click the blue "Activate" link.' ) }
 							example={ <JetpackExampleActivate url={ this.state.currentUrl } isInstall={ false } /> } />
 						<JetpackInstallStep title={ this.translate( '2. Connect Jetpack' ) }
-							text={ this.translate( 'Finally, just click the green "Connect to WordPress.com" button to finish the process.' ) }
+							text={ this.translate( 'Then click the green "Connect to WordPress.com" button to finish the process.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />
 					</div>
 					<Button onClick={ this.activateJetpack } primary>{ this.translate( 'Activate Jetpack' ) }</Button>


### PR DESCRIPTION
Fixed up copy of instructions steps, mainly the activation step and swapped instruction images that were wrong. 

Closes #5143

**Before:**
<img width="1204" alt="screen shot 2016-06-17 at 12 19 08 pm" src="https://cloud.githubusercontent.com/assets/437258/16157309/f93694d0-3485-11e6-99ec-5b02df90a629.png">
<img width="888" alt="screen shot 2016-06-17 at 12 19 36 pm" src="https://cloud.githubusercontent.com/assets/437258/16157310/f938faea-3485-11e6-8af7-ec1700d21fee.png">

**After:**
<img width="931" alt="screen shot 2016-06-17 at 12 18 19 pm" src="https://cloud.githubusercontent.com/assets/437258/16157298/f44d883e-3485-11e6-90d4-352f4f208c59.png">
<img width="1149" alt="screen shot 2016-06-17 at 12 18 49 pm" src="https://cloud.githubusercontent.com/assets/437258/16157300/f45481c0-3485-11e6-9b41-6ef7234e8a57.png">

cc @roccotripaldi @johnHackworth @richardmuscat @jeherve 

Test live: https://calypso.live/?branch=update/jetpack-connect-activate-link-instructions