### PR TITLE
Service Worker: change the feature flag serving file is associated with

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -114,6 +114,7 @@
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
+		"service-worker-file": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
 		"sidebar-drafts-count": true,

--- a/config/production.json
+++ b/config/production.json
@@ -73,6 +73,7 @@
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
+		"service-worker-file": true,
 		"settings/security/monitor": true,
 		"support-user": true,
 		"sync-handler": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -81,6 +81,7 @@
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
+		"service-worker-file": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
 		"sidebar-drafts-count": true,

--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -47,7 +47,7 @@ function setup() {
 	// attach the static file server to serve the `public` dir
 	app.use( '/calypso', express.static( path.resolve( __dirname, '..', '..', 'public' ) ) );
 
-	if ( config.isEnabled( 'push-notifications' ) ) {
+	if ( config.isEnabled( 'service-worker-file' ) ) {
 		// service-worker needs to be served from root to avoid scope issues
 		app.use( '/service-worker.js', express.static( path.resolve( __dirname, '..', '..', 'client', 'lib', 'service-worker', 'service-worker.js' ) ) );
 	}


### PR DESCRIPTION
To allow the `service-worker.js` file to be served independently of whether or not `push-notifications` are enabled, this PR creates a new feature flag, and ties it to that.

Test live: https://calypso.live/?branch=update/service-worker-file/feature-flag