### PR TITLE
Personal Plan: Add Personal Plan on plans fetch.

### DIFF
--- a/client/lib/plans-list/index.js
+++ b/client/lib/plans-list/index.js
@@ -16,6 +16,7 @@ import {
 	PLAN_PREMIUM,
 	PLAN_BUSINESS
 } from 'lib/plans/constants';
+import { insertPersonalPlan } from 'lib/plans/personal-plan';
 
 /**
  * Module vars
@@ -57,7 +58,7 @@ const pathToSlugMapping = {
  * @return {Object} list of plans object
  */
 PlansList.prototype.get = function() {
-	var data;
+	let data;
 	if ( ! this.data ) {
 		debug( 'First time loading PlansList, check store' );
 		data = store.get( 'PlansList' );
@@ -86,7 +87,7 @@ PlansList.prototype.fetch = function() {
 			return;
 		}
 
-		let plans = this.parse( data );
+		const plans = insertPersonalPlan( this.parse( data ) );
 
 		debug( 'PlansList fetched from api:', plans );
 

--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -1,19 +1,20 @@
-import { translate } from 'i18n-calypso';
-
+/**
+ * Internal dependencies
+ */
 import { PLAN_PERSONAL } from './constants';
 
 export default {
 	product_id: 1009,
-	product_name: translate( 'WordPress.com Personal' ),
+	product_name: 'WordPress.com Personal',
 	prices: {
 		USD: 71.88
 	},
-	product_name_short: translate( 'Personal' ),
+	product_name_short: 'Personal',
 	product_slug: PLAN_PERSONAL,
-	tagline: translate( 'Get your own domain' ),
-	shortdesc: translate( 'Use your own domain and establish your online presence without ads.' ),
-	description: translate( 'Use your own domain and establish your online presence without ads.' ),
-	capability: translate( 'manage_options' ),
+	tagline: 'Get your own domain',
+	shortdesc: 'Use your own domain and establish your online presence without ads.',
+	description: 'Use your own domain and establish your online presence without ads.',
+	capability: 'manage_options',
 	cost: 71.88,
 	features_highlight: [
 		{ items: [ 'no-adverts/no-adverts.php', 'custom-domain', 'support', 'space' ] },
@@ -23,7 +24,7 @@ export default {
 	product_type: 'bundle',
 	available: 'yes',
 	bundle_product_ids: [ 12, 9, 50, 5, 6, 46, 54, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 72, 73, 74, 75, 16 ],
-	bill_period_label: translate( 'per year' ),
+	bill_period_label: 'per year',
 	price: '$71.88',
 	formatted_price: '$71.88',
 	raw_price: 71.88

--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -6,13 +6,7 @@ export default {
 	product_id: 1009,
 	product_name: translate( 'WordPress.com Personal' ),
 	prices: {
-		USD: 71.88,
-		NZD: 105.35,
-		AUD: 99.05,
-		CAD: 94.05,
-		JPY: 7874.06,
-		EUR: 64.27,
-		GBP: 49.86
+		USD: 71.88
 	},
 	product_name_short: translate( 'Personal' ),
 	product_slug: PLAN_PERSONAL,

--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -1,29 +1,76 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+import has from 'lodash/has';
+import isEmpty from 'lodash/isEmpty';
+import findIndex from 'lodash/findIndex';
+import matchesProperty from 'lodash/matchesProperty';
+
+/**
  * Internal dependencies
  */
-import { PLAN_PERSONAL } from './constants';
+import { PLAN_FREE, PLAN_PERSONAL } from './constants';
 
-export default {
+export const personalPlan = {
 	product_id: 1009,
-	product_name: 'WordPress.com Personal',
+	product_name: translate( 'WordPress.com Personal' ),
 	prices: { USD: 71.88 },
-	product_name_short: 'Personal',
+	product_name_short: translate( 'Personal' ),
 	product_slug: PLAN_PERSONAL,
-	tagline: 'Get your own domain',
-	shortdesc: 'Use your own domain and establish your online presence without ads.',
-	description: 'Use your own domain and establish your online presence without ads.',
+	tagline: translate( 'Get your own domain' ),
+	shortdesc: translate( 'Use your own domain and establish your online presence without ads.' ),
+	description: translate( 'Use your own domain and establish your online presence without ads.' ),
 	capability: 'manage_options',
 	cost: 71.88,
 	features_highlight: [
 		{ items: [ 'no-adverts/no-adverts.php', 'custom-domain', 'support', 'space' ] },
-		{ title: 'Included with all plans:', items: [ 'free-blog' ] }
+		{ title: translate( 'Included with all plans:' ), items: [ 'free-blog' ] }
 	],
 	bill_period: 365,
 	product_type: 'bundle',
 	available: 'yes',
 	bundle_product_ids: [ 12, 9, 50, 5, 6, 46, 54, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 72, 73, 74, 75, 16 ],
-	bill_period_label: 'per year',
+	bill_period_label: translate( 'per year' ),
 	price: '$71.88',
 	formatted_price: '$71.88',
 	raw_price: 71.88
+};
+
+export const insertPersonalPlan = plans => {
+	const freePlanIndex = findIndex( plans, matchesProperty( 'product_slug', PLAN_FREE ) );
+	const hasPersonalPlan = plans.some( matchesProperty( 'product_slug', PLAN_PERSONAL ) );
+
+	return ! hasPersonalPlan
+		? [ ...plans.slice( 0, freePlanIndex + 1 ), personalPlan, ...plans.slice( freePlanIndex + 1 ) ]
+		: plans;
+};
+
+export const insertSitePersonalPlan = plans => {
+	const {
+		product_id,
+		formatted_price,
+		product_name,
+		product_slug,
+		raw_price
+	} = personalPlan;
+
+	if ( ! ( isEmpty( plans ) || has( plans, product_id ) ) ) {
+		return {
+			...plans,
+			[ product_id ]: {
+				can_start_trial: true,
+				discount_reason: null,
+				formatted_discount: '$0',
+				formatted_price,
+				product_name,
+				product_slug,
+				product_id,
+				raw_discount: 0,
+				raw_price
+			}
+		};
+	}
+
+	return plans;
 };

--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -6,9 +6,7 @@ import { PLAN_PERSONAL } from './constants';
 export default {
 	product_id: 1009,
 	product_name: 'WordPress.com Personal',
-	prices: {
-		USD: 71.88
-	},
+	prices: { USD: 71.88 },
 	product_name_short: 'Personal',
 	product_slug: PLAN_PERSONAL,
 	tagline: 'Get your own domain',

--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -1,0 +1,36 @@
+import { translate } from 'i18n-calypso';
+
+import { PLAN_PERSONAL } from './constants';
+
+export default {
+	product_id: 1009,
+	product_name: translate( 'WordPress.com Personal' ),
+	prices: {
+		USD: 71.88,
+		NZD: 105.35,
+		AUD: 99.05,
+		CAD: 94.05,
+		JPY: 7874.06,
+		EUR: 64.27,
+		GBP: 49.86
+	},
+	product_name_short: translate( 'Personal' ),
+	product_slug: PLAN_PERSONAL,
+	tagline: translate( 'Get your own domain' ),
+	shortdesc: translate( 'Use your own domain and establish your online presence without ads.' ),
+	description: translate( 'Use your own domain and establish your online presence without ads.' ),
+	capability: translate( 'manage_options' ),
+	cost: 71.88,
+	features_highlight: [
+		{ items: [ 'no-adverts/no-adverts.php', 'custom-domain', 'support', 'space' ] },
+		{ title: 'Included with all plans:', items: [ 'free-blog' ] }
+	],
+	bill_period: 365,
+	product_type: 'bundle',
+	available: 'yes',
+	bundle_product_ids: [ 12, 9, 50, 5, 6, 46, 54, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 72, 73, 74, 75, 16 ],
+	bill_period_label: translate( 'per year' ),
+	price: '$71.88',
+	formatted_price: '$71.88',
+	raw_price: 71.88
+};

--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-import findIndex from 'lodash/findIndex';
-import matchesProperty from 'lodash/matchesProperty'
-
-/**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
@@ -15,8 +9,7 @@ import {
 	PLANS_REQUEST_FAILURE
 } from '../action-types';
 
-import { PLAN_FREE, PLAN_PERSONAL } from 'lib/plans/constants';
-import personalPlan from 'lib/plans/personal-plan';
+import { insertPersonalPlan } from 'lib/plans/personal-plan';
 /**
  * Action creator function: RECEIVE
  *
@@ -24,16 +17,9 @@ import personalPlan from 'lib/plans/personal-plan';
  * @return {Object} action object
  */
 export const plansReceiveAction = plans => {
-	const freePlanIndex = findIndex( plans, matchesProperty( 'product_slug', PLAN_FREE ) );
-	const hasPersonalPlan = plans.some( matchesProperty( 'product_slug', PLAN_PERSONAL ) );
-
-	const newPlans = ! hasPersonalPlan
-		? [ ...plans.slice( 0, freePlanIndex + 1 ), personalPlan, ...plans.slice( freePlanIndex + 1 ) ]
-		: plans;
-
 	return {
 		type: PLANS_RECEIVE,
-		plans: newPlans
+		plans: insertPersonalPlan( plans )
 	};
 };
 

--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -1,8 +1,12 @@
 /**
+ * External dependencies
+ */
+import findIndex from 'lodash/findIndex';
+
+/**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
-
 import {
 	PLANS_RECEIVE,
 	PLANS_REQUEST,
@@ -10,6 +14,8 @@ import {
 	PLANS_REQUEST_FAILURE
 } from '../action-types';
 
+import { PLAN_FREE, PLAN_PERSONAL } from 'lib/plans/constants';
+import personalPlan from 'lib/plans/personal-plan';
 /**
  * Action creator function: RECEIVE
  *
@@ -17,6 +23,13 @@ import {
  * @return {Object} action object
  */
 export const plansReceiveAction = plans => {
+	const freePlanIndex = findIndex( plans, plan => plan.product_slug === PLAN_FREE );
+	const personalPlanIndex = findIndex( plans, plan => plan.product_slug === PLAN_PERSONAL );
+
+	if ( personalPlanIndex < 0 ) {
+		plans.splice( freePlanIndex + 1, 0, personalPlan );
+	}
+
 	return {
 		type: PLANS_RECEIVE,
 		plans: plans

--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import findIndex from 'lodash/findIndex';
+import matchesProperty from 'lodash/matchesProperty'
 
 /**
  * Internal dependencies
@@ -23,8 +24,8 @@ import personalPlan from 'lib/plans/personal-plan';
  * @return {Object} action object
  */
 export const plansReceiveAction = plans => {
-	const freePlanIndex = findIndex( plans, plan => plan.product_slug === PLAN_FREE );
-	const hasPersonalPlan = plans.some( ( { product_slug } ) => PLAN_PERSONAL === product_slug );
+	const freePlanIndex = findIndex( plans, matchesProperty( 'product_slug', PLAN_FREE ) );
+	const hasPersonalPlan = plans.some( matchesProperty( 'product_slug', PLAN_PERSONAL ) );
 
 	const newPlans = ! hasPersonalPlan
 		? [ ...plans.slice( 0, freePlanIndex + 1 ), personalPlan, ...plans.slice( freePlanIndex + 1 ) ]

--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -24,15 +24,15 @@ import personalPlan from 'lib/plans/personal-plan';
  */
 export const plansReceiveAction = plans => {
 	const freePlanIndex = findIndex( plans, plan => plan.product_slug === PLAN_FREE );
-	const personalPlanIndex = findIndex( plans, plan => plan.product_slug === PLAN_PERSONAL );
+	const hasPersonalPlan = plans.some( ( { product_slug } ) => PLAN_PERSONAL === product_slug );
 
-	if ( personalPlanIndex < 0 ) {
-		plans.splice( freePlanIndex + 1, 0, personalPlan );
-	}
+	const newPlans = ! hasPersonalPlan
+		? [ ...plans.slice( 0, freePlanIndex + 1 ), personalPlan, ...plans.slice( freePlanIndex + 1 ) ]
+		: plans;
 
 	return {
 		type: PLANS_RECEIVE,
-		plans: plans
+		plans: newPlans
 	};
 };
 

--- a/client/state/plans/test/fixture.js
+++ b/client/state/plans/test/fixture.js
@@ -10,6 +10,8 @@ import {
 
 import { getValidDataFromResponse } from '../actions';
 
+import PLAN_1009 from 'lib/plans/personal-plan';
+
 // WP REST-API error response
 export const ERROR_MESSAGE_RESPONSE = 'There was a problem fetching plans. Please try again later or contact support.';
 
@@ -252,7 +254,7 @@ export const PLAN_2002 = {
 };
 
 export const WPCOM_RESPONSE = [
-	PLAN_1, PLAN_1003, PLAN_1008, PLAN_2000, PLAN_2001, PLAN_2002
+	PLAN_1, PLAN_1003, PLAN_1008, PLAN_1009, PLAN_2000, PLAN_2001, PLAN_2002
 ];
 
 WPCOM_RESPONSE._headers = {

--- a/client/state/plans/test/fixture.js
+++ b/client/state/plans/test/fixture.js
@@ -10,7 +10,7 @@ import {
 
 import { getValidDataFromResponse } from '../actions';
 
-import PLAN_1009 from 'lib/plans/personal-plan';
+import { personalPlan as PLAN_1009 } from 'lib/plans/personal-plan';
 
 // WP REST-API error response
 export const ERROR_MESSAGE_RESPONSE = 'There was a problem fetching plans. Please try again later or contact support.';

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import has from 'lodash/has';
-import isEmpty from 'lodash/isEmpty';
 import map from 'lodash/map';
 import omit from 'lodash/omit';
 import i18n from 'i18n-calypso';
@@ -24,7 +22,7 @@ import {
 	SITE_PLANS_TRIAL_CANCEL_FAILED
 } from 'state/action-types';
 import wpcom from 'lib/wp';
-import personalPlan from 'lib/plans/personal-plan';
+import { insertSitePersonalPlan } from 'lib/plans/personal-plan';
 
 /**
  * Cancels the specified plan trial for the given site.
@@ -125,31 +123,12 @@ export function fetchSitePlans( siteId ) {
  * @returns {Object} the corresponding action object
  */
 export function fetchSitePlansCompleted( siteId, data ) {
-	let plansData = omit( data, '_headers' );
-	const { product_id } = personalPlan;
-
-	if ( ! ( isEmpty( plansData ) || has( plansData, product_id ) ) ) {
-		const { formatted_price, product_name, product_slug, raw_price } = personalPlan;
-		plansData = {
-			...plansData,
-			[ product_id ]: {
-				can_start_trial: true,
-				discount_reason: null,
-				formatted_discount: '$0',
-				formatted_price,
-				product_name,
-				product_slug,
-				product_id,
-				raw_discount: 0,
-				raw_price
-			}
-		};
-	}
+	const plans = insertSitePersonalPlan( omit( data, '_headers' ) );
 
 	return {
 		type: SITE_PLANS_FETCH_COMPLETED,
 		siteId,
-		plans: map( plansData, createSitePlanObject )
+		plans: map( plans, createSitePlanObject )
 	};
 }
 

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import map from 'lodash/map';
+import has from 'lodash/has';
 import isEmpty from 'lodash/isEmpty';
+import map from 'lodash/map';
 import omit from 'lodash/omit';
 import i18n from 'i18n-calypso';
 
@@ -127,7 +128,7 @@ export function fetchSitePlansCompleted( siteId, data ) {
 	let plansData = omit( data, '_headers' );
 	const { product_id } = personalPlan;
 
-	if ( ! isEmpty( plansData ) && ! plansData.hasOwnProperty( product_id ) ) {
+	if ( ! ( isEmpty( plansData ) || has( plansData, product_id ) ) ) {
 		const { formatted_price, product_name, product_slug, raw_price } = personalPlan;
 		plansData = {
 			...plansData,

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -3,6 +3,7 @@
  */
 import debugFactory from 'debug';
 import map from 'lodash/map';
+import isEmpty from 'lodash/isEmpty';
 import omit from 'lodash/omit';
 import i18n from 'i18n-calypso';
 
@@ -22,6 +23,7 @@ import {
 	SITE_PLANS_TRIAL_CANCEL_FAILED
 } from 'state/action-types';
 import wpcom from 'lib/wp';
+import personalPlan from 'lib/plans/personal-plan';
 
 /**
  * Cancels the specified plan trial for the given site.
@@ -123,6 +125,21 @@ export function fetchSitePlans( siteId ) {
  */
 export function fetchSitePlansCompleted( siteId, data ) {
 	data = omit( data, '_headers' );
+	const { product_id } = personalPlan;
+
+	if ( ! isEmpty( data ) && ! data.hasOwnProperty( product_id ) ) {
+		const { formatted_price, product_name, product_slug, raw_price } = personalPlan;
+		data[ product_id ] = {
+			can_start_trial: true,
+			discount_reason: null,
+			formatted_discount: '$0',
+			formatted_price,
+			product_name,
+			product_slug,
+			raw_discount: 0,
+			raw_price
+		};
+	}
 
 	return {
 		type: SITE_PLANS_FETCH_COMPLETED,

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -3,7 +3,7 @@
  */
 import debugFactory from 'debug';
 import map from 'lodash/map';
-import isEmpty from 'lodash/isEmpty';
+import has from 'lodash/has';
 import omit from 'lodash/omit';
 import i18n from 'i18n-calypso';
 
@@ -124,27 +124,30 @@ export function fetchSitePlans( siteId ) {
  * @returns {Object} the corresponding action object
  */
 export function fetchSitePlansCompleted( siteId, data ) {
-	data = omit( data, '_headers' );
+	let plansData = omit( data, '_headers' );
 	const { product_id } = personalPlan;
 
-	if ( ! isEmpty( data ) && ! data.hasOwnProperty( product_id ) ) {
+	if ( ! has( plansData, product_id ) ) {
 		const { formatted_price, product_name, product_slug, raw_price } = personalPlan;
-		data[ product_id ] = {
-			can_start_trial: true,
-			discount_reason: null,
-			formatted_discount: '$0',
-			formatted_price,
-			product_name,
-			product_slug,
-			raw_discount: 0,
-			raw_price
+		plansData = {
+			...plansData,
+			[ product_id ]: {
+				can_start_trial: true,
+				discount_reason: null,
+				formatted_discount: '$0',
+				formatted_price,
+				product_name,
+				product_slug,
+				raw_discount: 0,
+				raw_price
+			}
 		};
 	}
 
 	return {
 		type: SITE_PLANS_FETCH_COMPLETED,
 		siteId,
-		plans: map( data, createSitePlanObject )
+		plans: map( plansData, createSitePlanObject )
 	};
 }
 

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -3,7 +3,7 @@
  */
 import debugFactory from 'debug';
 import map from 'lodash/map';
-import has from 'lodash/has';
+import isEmpty from 'lodash/isEmpty';
 import omit from 'lodash/omit';
 import i18n from 'i18n-calypso';
 
@@ -127,7 +127,7 @@ export function fetchSitePlansCompleted( siteId, data ) {
 	let plansData = omit( data, '_headers' );
 	const { product_id } = personalPlan;
 
-	if ( ! has( plansData, product_id ) ) {
+	if ( ! isEmpty( plansData ) && ! plansData.hasOwnProperty( product_id ) ) {
 		const { formatted_price, product_name, product_slug, raw_price } = personalPlan;
 		plansData = {
 			...plansData,
@@ -138,6 +138,7 @@ export function fetchSitePlansCompleted( siteId, data ) {
 				formatted_price,
 				product_name,
 				product_slug,
+				product_id,
 				raw_discount: 0,
 				raw_price
 			}


### PR DESCRIPTION
Because the Desktop App updates that hide the _Personal Plan_ haven't been deployed yet, the plans and site plans endpoints had to be modified to hide it so the users can't interact with the plan from outside our test scope.

This change forces the action creators for PLANS_RECEIVE and SITE_PLANS_FETCH_COMPLETED to append the personal plan definition to the request response.

This should have no visible effects because the _Personal Plan_ visibility is controlled by the plan list and plan compare components.

This is also temporary and should be removed once the test finalizes and the Desktop App update is released.

cc: @roundhill @dmsnell @apeatling 

Test live: https://calypso.live/?branch=add/add-personal-plan-on-action-creators