### PR TITLE
Push Notifications: No longer tie service-worker file to PN flag

### DIFF
--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -47,10 +47,8 @@ function setup() {
 	// attach the static file server to serve the `public` dir
 	app.use( '/calypso', express.static( path.resolve( __dirname, '..', '..', 'public' ) ) );
 
-	if ( config.isEnabled( 'push-notifications' ) ) {
-		// service-worker needs to be served from root to avoid scope issues
-		app.use( '/service-worker.js', express.static( path.resolve( __dirname, '..', '..', 'client', 'lib', 'service-worker', 'service-worker.js' ) ) );
-	}
+	// service-worker needs to be served from root to avoid scope issues
+	app.use( '/service-worker.js', express.static( path.resolve( __dirname, '..', '..', 'client', 'lib', 'service-worker', 'service-worker.js' ) ) );
 
 	// serve files when not in production so that the source maps work correctly
 	if ( 'development' === config( 'env' ) ) {


### PR DESCRIPTION
There is no reason for the `/service-worker.js` file to be tied to the feature-flag for push notifications, as the file isn't requested unless the feature-flag is enabled -- and associating it with the feature flag could cause issues in some environments.

Test live: https://calypso.live/?branch=remove/service-worker-file-feature-flag