### PR TITLE
Plugins: Fix type that resulted in the state not being passed down to  the components.

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -65,7 +65,7 @@ export default React.createClass( {
 			return true;
 		}
 
-		if ( this.state.bulkManagement !== nextState.bulkManagement ) {
+		if ( this.state.bulkManagementActive !== nextState.bulkManagementActive ) {
 			return true;
 		}
 


### PR DESCRIPTION
Fixes a bug that prevented the user from being able to switch from bulk edit mode and back to regular mode. by clicking the X. This PR fixed it by fixing a typo in the code that determined if the plugin component should be rendered again. 

** to test**
Go to /plugins 
click on Edit all. Click on the X. 
Do the same on the single site plugin list.



Test live: https://calypso.live/?branch=fix/close-plugin-edit-button-action