### PR TITLE
Revert "Plans: adds wordpress ad credit to business plan"

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -9,7 +9,6 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import { abtest } from 'lib/abtest';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import JetpackPlanDetails from 'my-sites/plans/jetpack-plan-details';
@@ -24,7 +23,7 @@ import {
 	PLAN_BUSINESS,
 	getPlanObject,
 } from 'lib/plans/constants';
-import { isGoogleVouchersEnabled, isWordpressAdCreditsEnabled } from 'lib/plans';
+import { isGoogleVouchersEnabled } from 'lib/plans';
 
 const premiumPlan = getPlanObject( PLAN_PREMIUM );
 const businessPlan = getPlanObject( PLAN_BUSINESS );
@@ -77,7 +76,7 @@ const Plan = React.createClass( {
 			if ( plan.product_id === premiumPlan.productId ) {
 				plan.description = premiumPlan.description;
 			} else if ( plan.product_id === businessPlan.productId ) {
-				plan.description = isWordpressAdCreditsEnabled() ? businessPlan.descriptionWithWordAdsCredit : businessPlan.description;
+				plan.description = businessPlan.description;
 			}
 		}
 

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -15,7 +15,7 @@ import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import Card from 'components/card';
 import { fetchSitePlans } from 'state/sites/plans/actions';
-import { filterPlansBySiteAndProps, shouldFetchSitePlans, isGoogleVouchersEnabled, isWordpressAdCreditsEnabled } from 'lib/plans';
+import { filterPlansBySiteAndProps, shouldFetchSitePlans, isGoogleVouchersEnabled } from 'lib/plans';
 import { getPlans } from 'state/plans/selectors';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import Gridicon from 'components/gridicon';
@@ -44,11 +44,11 @@ import {
 const googleAdCredits = featuresList[ FEATURE_GOOGLE_AD_CREDITS ];
 const googleAdCreditsFeature = {
 	title: googleAdCredits.getTitle(),
-	compareDescription: isWordpressAdCreditsEnabled() ? googleAdCredits.getDescriptionWithWordAdsCredit() : googleAdCredits.getDescription(),
+	compareDescription: googleAdCredits.getDescription(),
 	product_slug: FEATURE_GOOGLE_AD_CREDITS,
 	1: false,
 	1003: '$100',
-	1008: isWordpressAdCreditsEnabled() ? '$200' : '$100'
+	1008: '$100'
 };
 // WordAds instant activation feature
 const wordAdsInstant = featuresList[ WORDADS_INSTANT ];

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -204,10 +204,6 @@
 	color: $gray;
 }
 
-.plans-compare__info-hr {
-	margin-bottom: 0.5em;
-}
-
 .layout:not(.has-no-sidebar) .plans-compare {
 	@include breakpoint( "<960px" ) {
 		@include plans-collapsed();

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -110,13 +110,4 @@ module.exports = {
 		defaultVariation: 'enabled',
 		allowExistingUsers: false,
 	},
-	wordpressAdCredits: {
-		datestamp: '20160613',
-		variations: {
-			disabled: 50,
-			enabled: 50,
-		},
-		defaultVariation: 'enabled',
-		allowExistingUsers: false,
-	},
 };

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1,7 +1,5 @@
 /** @ssr-ready **/
 
-import React from 'react';
-
 import i18n from 'i18n-calypso';
 
 // plans constants
@@ -44,8 +42,7 @@ export const plansList = {
 		getTitle: () => i18n.translate( 'Business' ),
 		getPriceTitle: () => i18n.translate( '$299 per year' ),
 		getProductId: () => 1008,
-		getDescription: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, and Google Analytics.' ),
-		getDescriptionWithWordAdsCredit: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, Google Analytics, and $200 advertising credit.' ),
+		getDescription: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, and Google Analytics.' )
 	},
 
 	[ PLAN_JETPACK_FREE ]: {},
@@ -101,12 +98,6 @@ export const featuresList = {
 	[ FEATURE_GOOGLE_AD_CREDITS ]: {
 		getTitle: () => i18n.translate( 'Advertising Credit' ),
 		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25. Offer valid in US and Canada.' ),
-		getDescriptionWithWordAdsCredit: () => i18n.translate( '$100 Google AdWords credit after spending the first $25. ' +
-			'Offer valid in US and Canada. {{hr/}}Business also includes $100 of advertising from WordAds on WordPress.com.', {
-			components: {
-				hr: <hr className="plans-compare__info-hr"/>
-			}
-		} ),
 		plans: allPaidPlans
 	},
 

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -157,11 +157,3 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, showJetpac
 export const isGoogleVouchersEnabled = () => {
 	return ( config.isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' );
 };
-
-export const isWordpressAdCreditsEnabled = () => {
-	return (
-		isGoogleVouchersEnabled() &&
-		config.isEnabled( 'plans/wordpress-ad-credits' ) &&
-		abtest( 'wordpressAdCredits' ) === 'enabled'
-	);
-};

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -34,20 +34,6 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 				description={ i18n.translate( 'Connect to Google Analytics for the perfect complement to WordPress.com stats.' ) }
 				buttonText={ i18n.translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug } />
-
-			<PurchaseDetail
-				icon="star"
-				title={ i18n.translate( 'Boost Your Audience' ) }
-				description={ i18n.translate( 'Get more visitors to your most important Posts or Pages with WordAds Boost. We\'ll display an ad for your site 100,000 times (a $100 value). '+
-					'Contact us at {{a}}wordads-credit@wordpress.com{{/a}} to activate!',
-					{
-						components: {
-							a: <a target="_blank" href="mailto:wordads-credit@automattic.com?subject=WordAds%20Credit&body=Please%20send%20my%20100%2C000%20impressions%20to%20the%20following%20URL%20on%20my%20WordPress.com%20Business%20site.%20I%20understand%20that%20the%20title%20of%20this%20page%20will%20be%20the%20headline%2C%20and%20the%20first%20few%20lines%20of%20content%20will%20be%20used%20for%20the%20body%20of%20the%20advertisement.%0A%0AURL%20TO%20PROMOTE%3A%20" />
-						}
-					}
-				) }
-				/>
-
 		</div>
 	);
 };

--- a/config/development.json
+++ b/config/development.json
@@ -97,7 +97,6 @@
 		"olark": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/wordpress-ad-credits": true,
 		"post-editor-github-link": false,
 		"post-editor/image-editor": false,
 		"post-editor/insert-menu": true,


### PR DESCRIPTION
Missed a necessary point for the feature gate.

Reverts Automattic/wp-calypso#5984

Test live: https://calypso.live/?branch=revert-5984-add/wordads-credit-feature