### PR TITLE
Translator: fix missing singular value

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -87,7 +87,7 @@ communityTranslatorJumpstart = {
 		props = { className: 'translatable' };
 
 		if ( 'string' === typeof originalFromPage ) {
-			props.value = originalFromPage;
+			props[ 'data-singular' ] = originalFromPage;
 		} else {
 			debug( 'unknown original format' );
 			return displayedTranslationFromPage;


### PR DESCRIPTION
Fixes #6139 

Don't use value for the translation singular, as the value doesn't make it to the dom since react v15.1
This requires a matching change in the community translator too ( see https://github.com/Automattic/community-translator/pull/5 )