### PR TITLE
Reader sidebar: don't scroll to top when clicking empty regions

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -87,7 +87,7 @@ const ReaderSidebar = React.createClass( {
 	},
 
 	handleClick( event ) {
-		if ( ! event.isDefaultPrevented() && ! closest( event.target, 'input,textarea', true ) ) {
+		if ( ! event.isDefaultPrevented() && closest( event.target, 'a,span', true ) ) {
 			layoutFocus.setNext( 'content' );
 			window.scrollTo( 0, 0 );
 		}
@@ -109,7 +109,7 @@ const ReaderSidebar = React.createClass( {
 		const pathParts = this.props.path.split( '/' );
 
 		if ( startsWith( this.props.path, '/tag/' ) ) {
-			const tagSlug = pathParts[2];
+			const tagSlug = pathParts[ 2 ];
 			if ( tagSlug ) {
 				// Open the sidebar
 				if ( ! this.props.isTagsOpen ) {
@@ -120,8 +120,8 @@ const ReaderSidebar = React.createClass( {
 		}
 
 		if ( startsWith( this.props.path, '/read/list/' ) ) {
-			const listOwner = pathParts[3];
-			const listSlug = pathParts[4];
+			const listOwner = pathParts[ 3 ];
+			const listSlug = pathParts[ 4 ];
 			if ( listOwner && listSlug ) {
 				// Open the sidebar
 				if ( ! this.props.isListsOpen ) {
@@ -136,7 +136,7 @@ const ReaderSidebar = React.createClass( {
 		// if promo not configured return
 		if ( ! config.isEnabled( 'desktop-promo' ) ) {
 			return;
-		};
+		}
 
 		// if user settings not loaded, return so we dont show
 		// before we can check if user is already a desktop user


### PR DESCRIPTION
@marekhrabe noticed in #6149 that clicking in blank regions of the Reader sidebar will result in the content pane being scrolled to the top.

![e7788d1a-3706-11e6-8a76-c2840a7a7cdd](https://cloud.githubusercontent.com/assets/17325/16200352/e413c790-3704-11e6-9a8c-16c02513c0f5.gif)

This PR ensures that only clicks on menu items result in a scroll to top.

### To test
1. Starting at URL: Reader - https://wordpress.com/ or http://calypso.localhost:3000/
2. Scroll down in posts
3. Click blank space in sidebar

There should be no scrolling of the main content pane when you click. When clicking on valid menu items, the scroll to top should still occur.

Compare to http://wpcalypso.wordpress.com, where you'll be scrolled to the top in either case.

Fixes #6149.