### PR TITLE
ResumeEditing: fix default icon alignment.

### DIFF
--- a/client/my-sites/resume-editing/index.jsx
+++ b/client/my-sites/resume-editing/index.jsx
@@ -113,7 +113,7 @@ const ResumeEditing = React.createClass( {
 					{ translate( 'Continue Editing' ) }
 				</span>
 				<span className="resume-editing__post-title">
-					<SiteIcon size={ 14 } site={ sites.getSite( siteId ) } />
+					<SiteIcon size={ 16 } site={ sites.getSite( siteId ) } />
 					{ draft.title ? decodeEntities( draft.title ) : translate( 'Untitled' ) }
 				</span>
 			</a>

--- a/client/my-sites/resume-editing/style.scss
+++ b/client/my-sites/resume-editing/style.scss
@@ -21,6 +21,11 @@
 		display: inline-block;
 		margin-right: 8px;
 		vertical-align: bottom;
+
+		svg {
+			position: relative;
+			top: 1px;
+		}
 	}
 }
 
@@ -41,7 +46,7 @@
 	white-space: nowrap;
 	font-family: $serif;
 	font-size: 14px;
-	line-height: 1;
+	line-height: 1.1;
 
 	&::after {
 		@include long-content-fade( $size: 24px, $color: $blue-wordpress );


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/548849/16200355/4924e120-370d-11e6-8821-fc395d89d00e.png)

Had to bump the size from 14 to 16 otherwise it was really tough to align optically within the box.

cc @apeatling @aduth 

Test live: https://calypso.live/?branch=fix/default-icon-alignment-in-resume-editing