### PR TITLE
Cold Start: add loading placeholders

### DIFF
--- a/client/reader/start/card-placeholder.jsx
+++ b/client/reader/start/card-placeholder.jsx
@@ -1,0 +1,36 @@
+// External dependencies
+import React from 'react';
+
+// Internal dependencies
+import Card from 'components/card';
+import SiteIcon from 'components/site-icon';
+
+const StartCardPlaceholder = ( {} ) => {
+	return (
+		<Card className="reader-start-card is-placeholder">
+			<header className="reader-start-card__header">
+				<SiteIcon site={ null } size={ 30 } />
+				<div className="reader-start-card__site-info">
+					<h1 className="reader-start-card__site-title">Site title</h1>
+					<div className="reader-start-card__follower-count">
+						Number of followers
+					</div>
+				</div>
+			</header>
+			<article className="reader-start-post-preview">
+				<div className="reader-start-post-preview__featured-label">Featured Post</div>
+				<div className="reader-start-post-preview__featured-image is-dark"></div>
+				<div className="reader-start-post-preview__post-content">
+					<h1 className="reader-start-post-preview__title">Post title</h1>
+					<div className="reader-start-post-preview__byline">
+						<span className="reader-start-post-preview__author">by author name</span>
+					</div>
+					<p className="reader-start-post-preview__excerpt">This is where the post excerpt will
+					appear - just the first couple of lines of the post.</p>
+				</div>
+			</article>
+		</Card>
+	);
+};
+
+export default StartCardPlaceholder;

--- a/client/reader/start/main.jsx
+++ b/client/reader/start/main.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import map from 'lodash/map';
 import page from 'page';
 import Masonry from 'react-masonry-component';
+import times from 'lodash/times';
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ import StartCard from './card';
 import RootChild from 'components/root-child';
 import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
 import smartSetState from 'lib/react-smart-set-state';
+import CardPlaceholder from './card-placeholder';
 
 const Start = React.createClass( {
 
@@ -55,8 +57,16 @@ const Start = React.createClass( {
 		page.redirect( '/' );
 	},
 
+	renderLoadingPlaceholders() {
+		const count = 4;
+		return times( count, function( i ) {
+			return( <CardPlaceholder key={ 'placeholder-' + i } /> );
+		} );
+	},
+
 	render() {
 		const canGraduate = ( this.state.totalSubscriptions > 0 );
+		const hasRecommendations = this.props.recommendationIds.length > 0;
 		return (
 			<Main className="reader-start">
 				<QueryReaderStartRecommendations />
@@ -66,7 +76,9 @@ const Start = React.createClass( {
 					<p className="reader-start__description">{ this.translate( "We've suggested some sites that you might enjoy. Follow one or more sites to get started." ) }</p>
 				</header>
 
-				<Masonry className="reader-start__cards" updateOnEachImageLoad={ true } options={ { gutter: 14 } }>
+				{ ! hasRecommendations && this.renderLoadingPlaceholders() }
+
+				{ hasRecommendations && <Masonry className="reader-start__cards"  updateOnEachImageLoad={ true } options={ { gutter: 14 } }>
 					{ this.props.recommendationIds ? map( this.props.recommendationIds, ( recId ) => {
 						return (
 							<StartCard
@@ -74,9 +86,9 @@ const Start = React.createClass( {
 								recommendationId={ recId } />
 						);
 					} ) : null }
-				</Masonry>
+				</Masonry> }
 
-				<RootChild className="reader-start__bar">
+				{ hasRecommendations && <RootChild className="reader-start__bar">
 					<div className="reader-start__bar-action main">
 						<span className="reader-start__bar-text">
 							{ canGraduate
@@ -94,7 +106,7 @@ const Start = React.createClass( {
 						</span>
 						<Button onClick={ this.graduateColdStart } disabled={ ! canGraduate }>{ this.translate( "OK, I'm all set!" ) }</Button>
 					</div>
-				</RootChild>
+				</RootChild> }
 			</Main>
 		);
 	}

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -44,6 +44,55 @@
 	margin-bottom: 25px;
 	width: 100%;
 
+	// Loading Placeholders
+	&.is-placeholder {
+		pointer-events: none;
+		user-select: none;
+		margin-right: 14px !important;
+
+		.reader-start-card__site-title,
+		.reader-start-post-preview__title,
+		.reader-start-post-preview__byline,
+		.reader-start-post-preview__excerpt,
+		.reader-start-card__follower-count,
+		.site-icon {
+			color: transparent;
+			background-color: lighten( $gray, 30% );
+			animation: loading-fade 1.6s ease-in-out infinite;
+		}
+
+		.reader-start-card__site-title {
+			margin-bottom: 2px;
+		}
+
+		.reader-start-post-preview__title,
+		.reader-start-post-preview__byline {
+			width: 60%;
+		}
+
+		.reader-start-post-preview__excerpt {
+			margin-bottom: 0;
+		}
+
+		.reader-start-post-preview__post-content {
+			padding-bottom: 1em;
+		}
+
+		.site-icon {
+			float: left;
+			margin: 5px 5px 0 0;
+		}
+
+		.reader-start-post-preview__featured-label {
+			display: none;
+		}
+
+		.reader-start-post-preview__post-content {
+			margin-top: 0;
+			padding: 15px 10px 20px;
+		}
+	}
+
 	@include breakpoint( ">960px" ) {
 		display: inline-block;
 			margin: 0px 0px 14px 0px;


### PR DESCRIPTION
While waiting for the initial set of Cold Start recommendations to load, there's currently no indication that loading is happening.

This PR adds placeholder cards to let the user know that real cards are on their way.

<img width="757" alt="screen shot 2016-06-20 at 20 53 02" src="https://cloud.githubusercontent.com/assets/17325/16208322/7b8ef224-3729-11e6-8e9e-0b224fa321cd.png">


Test live: https://calypso.live/?branch=add/reader/cold-start-loading-placeholders