### PR TITLE
Reader: Turn on related posts for 10% of users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -119,4 +119,13 @@ module.exports = {
 		defaultVariation: 'enabled',
 		allowExistingUsers: false,
 	},
+	readerRelatedPosts: {
+		datestamp: '20160620',
+		variations: {
+			disabled: 90,
+			enabled: 10
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: true
+	}
 };

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -17,7 +17,8 @@ var ReactDom = require( 'react-dom' ),
 /**
  * Internal Dependencies
  */
-var config = require( 'config' ),
+var abtest = require( 'lib/abtest' ).abtest,
+	config = require( 'config' ),
 	CommentButton = require( 'components/comment-button' ),
 	Dialog = require( 'components/dialog' ),
 	DISPLAY_TYPES = require( 'lib/feed-post-store/display-types' ),
@@ -78,6 +79,8 @@ let loadingPost = {
 		content: '<p>Error Loading Post</p>'
 	},
 	FullPostView, FullPostDialog, FullPostContainer;
+
+const relatedPostsEnabled = config.isEnabled( 'reader/related-posts' ) && abtest( 'readerRelatedPosts' ) === 'enabled';
 
 /**
  * The content of a FullPostView
@@ -227,7 +230,7 @@ FullPostView = React.createClass( {
 
 					{ shouldShowExcerptOnly && ! isDiscoverPost ? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> : null }
 					{ discoverSiteName && discoverSiteUrl ? <DiscoverVisitLink siteName={ discoverSiteName } siteUrl={ discoverSiteUrl } /> : null }
-					{ config.isEnabled( 'reader/related-posts' ) && ! post.is_external && post.site_ID && <RelatedPosts siteId={ post.site_ID } postId={ post.ID } onPostClick={ this.recordRelatedPostClicks } onSiteClick={ this.recordRelatedPostSiteClicks }/> }
+					{ relatedPostsEnabled && ! post.is_external && post.site_ID && <RelatedPosts siteId={ post.site_ID } postId={ post.ID } onPostClick={ this.recordRelatedPostClicks } onSiteClick={ this.recordRelatedPostSiteClicks }/> }
 					{ this.props.shouldShowComments ? <PostCommentList ref="commentList" post={ post } initialSize={ 25 } pageSize={ 25 } onCommentsUpdate={ this.checkForCommentAnchor } /> : null }
 				</article>
 			</div>

--- a/config/production.json
+++ b/config/production.json
@@ -70,6 +70,7 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/tags-with-elasticsearch": false,
+		"reader/related-posts": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,


### PR DESCRIPTION
This spins up a new abtest that enables Related Posts for 10% of existing users in production.

Test live: https://calypso.live/?branch=add/reader/related-ab-launch