### PR TITLE
Ad Tracking: Add Facebook Atlas support

### DIFF
--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -94,6 +94,7 @@ var TransactionStepsMixin = {
 					// zero-value cost and would thus lead to a wrong computation of conversions
 					if ( ! cartItems.hasFreeTrial( cartValue ) ) {
 						cartValue.products.map( adTracking.recordPurchase );
+						adTracking.recordOrderInAtlas( cartValue );
 					}
 
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {


### PR DESCRIPTION
This PR adds purchase tracking for Facebook Atlas's ad server.

To test:

1. In `development.json`, change `ad-tracking` to `true`.
2. Ensure the store code is sandboxed so you can make a purchase from your dev environment.
3. Purchase something using a test credit card.
4. In Chrome's Network tools, search for "atdmt". You should see a request to a URL similar to this one:

> https://ad.atdmt.com/m/a.js;m=11187200770563;cache=0.20352581433458683?event=Purchase&products=WordPress.com%20Premium&revenue=99&currency_code=USD&user_id=106779244

For multiple products, it would look like this:

> https://ad.atdmt.com/m/a.js;m=11187200770563;cache=0.19369032819669307?event=Purchase&products=Domain%20Registration%2C%20Private%20Registration&revenue=26&currency_code=USD&user_id=106779244

For comparison, this is the example Atlas provides in their documentation:

![12056968_723724347757504_1987350131_n](https://cloud.githubusercontent.com/assets/44436/16208860/2950af9c-3702-11e6-866e-e5155d8ce2f3.jpg)

Note that there are three special properties included: `revenue`, `currency_code`, and `event` as instructed by Atlas's documentation.

I have confirmed in Atlas that it is receiving my test events.