### PR TITLE
Token Input: Fix Firefox blur problems

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -196,11 +196,11 @@ var TokenField = React.createClass( {
 	_onBlur: function( event ) {
 		if ( this._inputHasValidValue() ) {
 			debug( '_onBlur adding current token' );
-			this._addCurrentToken();
+			this.setState( { isActive: false }, this._addCurrentToken );
 		} else {
 			debug( '_onBlur not adding current token' );
+			this.setState( this.getInitialState() );
 		}
-		this.setState( this.getInitialState() );
 	},
 
 	_onTokenClickRemove: function( event ) {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -95,11 +95,6 @@ var TokenField = React.createClass( {
 		}
 	},
 
-	componentWillUnmount: function() {
-		debug( 'componentWillUnmount' );
-		this._clearBlurTimeout();
-	},
-
 	render: function() {
 		var classes = classNames( 'token-field', {
 			'is-active': this.state.isActive,
@@ -192,13 +187,6 @@ var TokenField = React.createClass( {
 	},
 
 	_onFocus: function( event ) {
-		if ( this._blurTimeoutID ) {
-			this._clearBlurTimeout();
-			return;
-		} else if ( this.state.isActive ) {
-			return; // already active
-		}
-
 		this.setState( { isActive: true } );
 		if ( 'function' === typeof this.props.onFocus ) {
 			this.props.onFocus( event );
@@ -215,15 +203,6 @@ var TokenField = React.createClass( {
 		}
 		debug( '_onBlur resetting component state' );
 		this.setState( this.getInitialState() );
-		this._clearBlurTimeout();
-	},
-
-	_clearBlurTimeout: function() {
-		if ( this._blurTimeoutID ) {
-			debug( '_blurTimeoutID cleared' );
-			window.clearTimeout( this._blurTimeoutID );
-			this._blurTimeoutID = null;
-		}
 	},
 
 	_onTokenClickRemove: function( event ) {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -120,6 +120,8 @@ var TokenField = React.createClass( {
 				<div ref="tokensAndInput"
 					className="token-field__input-container"
 					tabIndex="-1"
+					onMouseDown={ this._onContainerTouched }
+					onTouchStart={ this._onContainerTouched }
 				>
 					{ this._renderTokensAndInput() }
 				</div>
@@ -229,6 +231,14 @@ var TokenField = React.createClass( {
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false
 		} );
+	},
+
+	_onContainerTouched: function( event ) {
+		// Prevent clicking/touching the tokensAndInput container from blurring
+		// the input and adding the current token.
+		if ( event.target === this.refs.tokensAndInput && this.state.isActive ) {
+			event.preventDefault();
+		}
 	},
 
 	_onKeyDown: function( event ) {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -194,14 +194,12 @@ var TokenField = React.createClass( {
 	},
 
 	_onBlur: function( event ) {
-		debug( '_onBlur setting component inactive' );
 		if ( this._inputHasValidValue() ) {
 			debug( '_onBlur adding current token' );
 			this._addCurrentToken();
 		} else {
 			debug( '_onBlur not adding current token' );
 		}
-		debug( '_onBlur resetting component state' );
 		this.setState( this.getInitialState() );
 	},
 

--- a/client/components/token-field/suggestions-list.jsx
+++ b/client/components/token-field/suggestions-list.jsx
@@ -94,6 +94,7 @@ var SuggestionsList = React.createClass( {
 				<li
 					className={ classes }
 					key={ suggestion }
+					onMouseDown={ this._handleMouseDown }
 					onClick={ this._handleClick( suggestion ) }
 					onMouseEnter={ this._handleHover( suggestion ) }>
 					{ match ?
@@ -124,6 +125,11 @@ var SuggestionsList = React.createClass( {
 		return function() {
 			this.props.onSelect( suggestion );
 		}.bind( this );
+	},
+
+	_handleMouseDown: function( e ) {
+		// By preventing default here, we will not lose focus of <input> when clicking a suggestion
+		e.preventDefault();
 	}
 } );
 

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -380,9 +380,8 @@ describe( 'TokenField', function() {
 		it( 'should not lose focus when a suggestion is clicked', test( function() {
 			// prevents regression of https://github.com/Automattic/wp-calypso/issues/1884
 
-			textInputNode.simulate( 'blur', {
-				relatedTarget: document.querySelector( '.token-field__suggestion' )
-			} );
+			const firstSuggestion = tokenFieldNode.find( '.token-field__suggestion' ).at( 0 );
+			firstSuggestion.simulate( 'click' );
 
 			// wait for setState call
 			this.clock.tick( 10 );

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -313,10 +313,6 @@ describe( 'TokenField', function() {
 
 			document.activeElement.blur();
 			textInputNode.simulate( 'blur' );
-
-			// After blur, need to wait for TokenField#_blurTimeoutID
-			clock.tick( 10 );
-
 			testSavedState( false );
 			textInputNode.simulate( 'focus' );
 			testSavedState( true );
@@ -350,31 +346,6 @@ describe( 'TokenField', function() {
 				[ 'foo', 'bar' ], // expectedTokens
 				this.clock
 			);
-		} ) );
-
-		// Firefox on OS X first sends a blur event, then a click event as the
-		// mouse is released. These two tests ensure that the component
-		// activates correctly in this situation.
-		it( 'should allow clicking on the field in Firefox (click event from input container)', test( function() {
-			textInputNode.simulate( 'blur' );
-
-			this.clock.tick( 50 );
-
-			// The click event comes from here the first time you click to
-			// activate the token field.
-			tokenFieldNode.find( '.token-field__input-container' ).simulate( 'click' );
-			expect( tokenFieldNode.find( 'div' ).first().hasClass( 'is-active' ) ).to.equal( true );
-		} ) );
-
-		it( 'should allow clicking on the field in Firefox (click event from <input>)', test( function() {
-			textInputNode.simulate( 'blur' );
-
-			this.clock.tick( 50 );
-
-			// The click event comes from here if you click on the token
-			// field when it is already active.
-			textInputNode.simulate( 'click' );
-			expect( tokenFieldNode.find( 'div' ).first().hasClass( 'is-active' ) ).to.equal( true );
 		} ) );
 
 		it( 'should not lose focus when a suggestion is clicked', test( function() {


### PR DESCRIPTION
Due to some browser event inconsistencies, in Firefox, there is a strange bug that makes `TokenField` steal focus back even after you selected another input and interacted with it. 

#### Steps to reproduce
- Use Firefox
- Open up New post
- Select tag input
- Insert some tag
- Focus Post title input and try to enter "test"

| Wordpress.com | This Branch |
| ----- | ----- |
| ![dot-com-focus](https://cloud.githubusercontent.com/assets/156676/16212326/2667a2dc-3747-11e6-8d74-472565d01c6f.gif) | ![fix-branch](https://cloud.githubusercontent.com/assets/156676/16212328/2a3e2f70-3747-11e6-9231-80fe385e6534.gif) |

On Wordpress, you should be only able to enter the first letter before tag input steals back the focus. This PR fixes that.

---

It is fixed by moving onBlur listener to `<input>` (instead of div) and adding preventDefault as a response to mouseDown on suggestion elements.

I tested this in Chrome, Safari and Firefox. I have not tested IE, I hope someone can.

- Fixes #144
- Fixes #2682
- Fixes #4313

Test live: https://calypso.live/?branch=fix/token-input-blur