### PR TITLE
Themes: Turn helpers into selectors

### DIFF
--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import React from 'react';
 import Card from 'components/card';
 import i18n from 'i18n-calypso';
 import SectionHeader from 'components/section-header';
-import { getDetailsUrl } from 'my-sites/themes/helpers';
+import { getThemeDetailsUrl } from 'state/themes/themes/selectors';
 
 const ThemesRelatedCard = React.createClass( {
 
@@ -58,7 +59,7 @@ const ThemesRelatedCard = React.createClass( {
 					{ themes.map( theme => (
 						<li key={ theme.id }>
 							<Card className="themes__sheet-related-themes-card">
-								<a href={ getDetailsUrl( theme ) }>
+								<a href={ this.props.getDetailsUrl( theme ) }>
 									<img src={ theme.screenshot + '?w=' + '660' }/>
 								</a>
 							</Card>
@@ -70,4 +71,8 @@ const ThemesRelatedCard = React.createClass( {
 	}
 } );
 
-export default ThemesRelatedCard;
+export default connect(
+	state => ( {
+		getDetailsUrl: getThemeDetailsUrl.bind( null, state )
+	} )
+)( ThemesRelatedCard );

--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -38,8 +38,8 @@ const ThemesRelatedCard = React.createClass( {
 		themes.delete( this.props.currentTheme );
 		themes = [ ...themes ];
 
-		let randomThemeIndex = this.props.currentTheme.charCodeAt( 0 ) % themes.length;
-		let theme = themes.splice( randomThemeIndex, 1 )[ 0 ];
+		const randomThemeIndex = this.props.currentTheme.charCodeAt( 0 ) % themes.length;
+		const theme = themes.splice( randomThemeIndex, 1 )[ 0 ];
 		const selectedThemes = [ theme ];
 		selectedThemes.push( themes[ theme.charCodeAt( 0 ) % themes.length ] );
 

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -12,12 +12,11 @@ import Card from 'components/card';
 import CurrentThemeButton from './button';
 import {
 	getCustomizeUrl,
-	getDetailsUrl,
-	getSupportUrl,
 	isPremium,
 	trackClick
 } from '../helpers';
 import { getCurrentTheme } from 'state/themes/current-theme/selectors';
+import { getThemeDetailsUrl, getThemeSupportUrl } from 'state/themes/themes/selectors';
 import QueryCurrentTheme from 'components/data/query-current-theme';
 
 /**
@@ -27,12 +26,15 @@ import QueryCurrentTheme from 'components/data/query-current-theme';
 const CurrentTheme = React.createClass( {
 
 	propTypes: {
-		currentTheme: React.PropTypes.object,
 		site: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool
 		] ).isRequired,
-		canCustomize: React.PropTypes.bool.isRequired
+		canCustomize: React.PropTypes.bool.isRequired,
+		// connected props
+		currentTheme: React.PropTypes.object,
+		detailsUrl: React.PropTypes.string,
+		supportUrl: React.PropTypes.string
 	},
 
 	trackClick: trackClick.bind( null, 'current theme' ),
@@ -66,12 +68,12 @@ const CurrentTheme = React.createClass( {
 					<CurrentThemeButton name="details"
 						label={ this.translate( 'Details' ) }
 						noticon="info"
-						href={ currentTheme ? getDetailsUrl( currentTheme, site ) : null }
+						href={ currentTheme ? this.props.detailsUrl : null }
 						onClick={ this.trackClick } />
 					{ displaySupportButton && <CurrentThemeButton name="support"
 						label={ this.translate( 'Setup' ) }
 						noticon="help"
-						href={ currentTheme ? getSupportUrl( currentTheme, site ) : null }
+						href={ currentTheme ? this.props.supportUrl : null }
 						onClick={ this.trackClick } /> }
 				</div>
 			</Card>
@@ -80,7 +82,13 @@ const CurrentTheme = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => (
-		{ currentTheme: getCurrentTheme( state, props.site && props.site.ID ) }
-	)
+	( state, props ) => {
+		const currentTheme = getCurrentTheme( state, props.site && props.site.ID );
+
+		return {
+			currentTheme,
+			detailsUrl: getThemeDetailsUrl( state, currentTheme ),
+			supportUrl: getThemeSupportUrl( state, currentTheme )
+		};
+	}
 )( CurrentTheme );

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -60,20 +60,6 @@ export function getDetailsUrl( theme, site ) {
 	return baseUrl + ( site ? `/${ site.slug }` : '' );
 }
 
-export function getSupportUrl( theme, site ) {
-	if ( site && site.jetpack ) {
-		return '//wordpress.org/support/theme/' + theme.id;
-	}
-
-	const sitePart = site ? `/${ site.slug }` : '';
-
-	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		return `/theme/${ theme.id }/setup${ sitePart }`;
-	}
-
-	return `${ oldShowcaseUrl }${ sitePart }${ theme.id }/support`;
-}
-
 export function getForumUrl( theme ) {
 	return isPremium( theme ) ? '//premium-themes.forums.wordpress.com/forum/' + theme.id : '//en.forums.wordpress.com/forum/themes';
 }

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -15,8 +15,7 @@ import mapValues from 'lodash/mapValues';
  */
 import config from 'config';
 import route from 'lib/route';
-
-const oldShowcaseUrl = '//wordpress.com/themes/';
+import { oldShowcaseUrl } from 'state/themes/themes/selectors';
 
 export function getSignupUrl( theme ) {
 	let url = '/start/with-theme?ref=calypshowcase&theme=' + theme.id;

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -65,12 +65,12 @@ export function getSupportUrl( theme, site ) {
 		return '//wordpress.org/support/theme/' + theme.id;
 	}
 
+	const sitePart = site ? `/${ site.slug }` : '';
+
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		const sitePart = site ? `/${ site.slug }` : '';
 		return `/theme/${ theme.id }/setup${ sitePart }`;
 	}
 
-	const sitePart = site ? `${ site.slug }/` : '';
 	return `${ oldShowcaseUrl }${ sitePart }${ theme.id }/support`;
 }
 

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -64,19 +64,6 @@ export function getForumUrl( theme ) {
 	return isPremium( theme ) ? '//premium-themes.forums.wordpress.com/forum/' + theme.id : '//en.forums.wordpress.com/forum/themes';
 }
 
-export function getHelpUrl( theme, site ) {
-	if ( site && site.jetpack ) {
-		return getSupportUrl( theme, site );
-	}
-
-	let baseUrl = oldShowcaseUrl + theme.id;
-	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		baseUrl = `/theme/${ theme.id }/support`;
-	}
-
-	return baseUrl + ( site ? `/${ site.slug }` : '' );
-}
-
 export function getExternalThemesUrl( site ) {
 	if ( ! site ) {
 		return oldShowcaseUrl;

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -13,9 +13,10 @@ import Main from 'components/main';
 import { signup } from 'state/themes/actions' ;
 import ThemePreview from './theme-preview';
 import ThemesSelection from './themes-selection';
-import { getSignupUrl, getDetailsUrl, getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
+import { getSignupUrl, getHelpUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
+import { getThemeDetailsUrl, getThemeSupportUrl } from 'state/themes/themes/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const ThemesLoggedOut = React.createClass( {
@@ -43,10 +44,10 @@ const ThemesLoggedOut = React.createClass( {
 				separator: true
 			},
 			details: {
-				getUrl: theme => getDetailsUrl( theme ),
+				getUrl: this.props.getDetailsUrl,
 			},
 			support: {
-				getUrl: theme => getSupportUrl( theme ),
+				getUrl: this.props.getSupportUrl,
 				// Free themes don't have support docs.
 				hideForTheme: theme => ! isPremium( theme )
 			},
@@ -104,7 +105,9 @@ const ThemesLoggedOut = React.createClass( {
 export default connect(
 	state => ( {
 		queryParams: getQueryParams( state ),
-		themesList: getThemesList( state )
+		themesList: getThemesList( state ),
+		getDetailsUrl: getThemeDetailsUrl.bind( null, state ),
+		getSupportUrl: getThemeSupportUrl.bind( null, state )
 	} ),
 	{ signup }
 )( ThemesLoggedOut );

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -13,10 +13,10 @@ import Main from 'components/main';
 import { signup } from 'state/themes/actions' ;
 import ThemePreview from './theme-preview';
 import ThemesSelection from './themes-selection';
-import { getSignupUrl, getHelpUrl, isPremium, addTracking } from './helpers';
+import { getSignupUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
-import { getThemeDetailsUrl, getThemeSupportUrl } from 'state/themes/themes/selectors';
+import { getThemeDetailsUrl, getThemeSupportUrl, getThemeHelpUrl } from 'state/themes/themes/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const ThemesLoggedOut = React.createClass( {
@@ -52,7 +52,7 @@ const ThemesLoggedOut = React.createClass( {
 				hideForTheme: theme => ! isPremium( theme )
 			},
 			help: {
-				getUrl: theme => getHelpUrl( theme )
+				getUrl: this.props.getHelpUrl
 			},
 		};
 		return merge( {}, buttonOptions, actionLabels );
@@ -107,7 +107,8 @@ export default connect(
 		queryParams: getQueryParams( state ),
 		themesList: getThemesList( state ),
 		getDetailsUrl: getThemeDetailsUrl.bind( null, state ),
-		getSupportUrl: getThemeSupportUrl.bind( null, state )
+		getSupportUrl: getThemeSupportUrl.bind( null, state ),
+		getHelpUrl: getThemeHelpUrl.bind( null, state )
 	} ),
 	{ signup }
 )( ThemesLoggedOut );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -19,10 +19,10 @@ import ThemePreview from './theme-preview';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import ThemesSelection from './themes-selection';
-import { getHelpUrl, isPremium, addTracking } from './helpers';
+import { isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
-import { getThemeDetailsUrl, getThemeSupportUrl } from 'state/themes/themes/selectors';
+import { getThemeDetailsUrl, getThemeSupportUrl, getThemeHelpUrl } from 'state/themes/themes/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import config from 'config';
 
@@ -81,7 +81,7 @@ const ThemesMultiSite = React.createClass( {
 				hideForTheme: theme => ! isPremium( theme )
 			},
 			help: {
-				getUrl: theme => getHelpUrl( theme )
+				getUrl: this.props.getHelpUrl
 			},
 		};
 		return merge( {}, buttonOptions, actionLabels );
@@ -146,7 +146,8 @@ export default connect(
 		queryParams: getQueryParams( state ),
 		themesList: getThemesList( state ),
 		getDetailsUrl: getThemeDetailsUrl.bind( null, state ),
-		getSupportUrl: getThemeSupportUrl.bind( null, state )
+		getSupportUrl: getThemeSupportUrl.bind( null, state ),
+		getHelpUrl: getThemeHelpUrl.bind( null, state )
 	} ),
 	{
 		activate,

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -19,9 +19,10 @@ import ThemePreview from './theme-preview';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import ThemesSelection from './themes-selection';
-import { getDetailsUrl, getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
+import { getHelpUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
+import { getThemeDetailsUrl, getThemeSupportUrl } from 'state/themes/themes/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import config from 'config';
 
@@ -72,10 +73,10 @@ const ThemesMultiSite = React.createClass( {
 				separator: true
 			},
 			details: {
-				getUrl: theme => getDetailsUrl( theme ),
+				getUrl: this.props.getDetailsUrl,
 			},
 			support: {
-				getUrl: theme => getSupportUrl( theme ),
+				getUrl: this.props.getSupportUrl,
 				// Free themes don't have support docs.
 				hideForTheme: theme => ! isPremium( theme )
 			},
@@ -143,7 +144,9 @@ const ThemesMultiSite = React.createClass( {
 export default connect(
 	state => ( {
 		queryParams: getQueryParams( state ),
-		themesList: getThemesList( state )
+		themesList: getThemesList( state ),
+		getDetailsUrl: getThemeDetailsUrl.bind( null, state ),
+		getSupportUrl: getThemeSupportUrl.bind( null, state )
 	} ),
 	{
 		activate,

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -21,8 +21,9 @@ import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import ThemesSelection from './themes-selection';
-import { getDetailsUrl, getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
+import { getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
+import { getThemeDetailsUrl } from 'state/themes/themes/selectors';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 import sitesFactory from 'lib/sites-list';
 import { FEATURE_CUSTOM_DESIGN } from 'lib/plans/constants';
@@ -90,7 +91,7 @@ const ThemesSingleSite = React.createClass( {
 					separator: true
 				},
 				details: {
-					getUrl: theme => getDetailsUrl( theme, site ), // TODO: Make this a selector
+					getUrl: this.props.getDetailsUrl
 				},
 				support: ! site.jetpack // We don't know where support docs for a given theme on a self-hosted WP install are.
 					? {
@@ -200,7 +201,8 @@ export default connect(
 	state => ( {
 		queryParams: getQueryParams( state ),
 		themesList: getThemesList( state ),
-		selectedSite: getSelectedSite( state )
+		selectedSite: getSelectedSite( state ),
+		getDetailsUrl: getThemeDetailsUrl.bind( null, state )
 	} ),
 	{
 		activate,

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -21,9 +21,9 @@ import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import ThemesSelection from './themes-selection';
-import { getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
+import { getHelpUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
-import { getThemeDetailsUrl } from 'state/themes/themes/selectors';
+import { getThemeDetailsUrl, getThemeSupportUrl } from 'state/themes/themes/selectors';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 import sitesFactory from 'lib/sites-list';
 import { FEATURE_CUSTOM_DESIGN } from 'lib/plans/constants';
@@ -95,7 +95,7 @@ const ThemesSingleSite = React.createClass( {
 				},
 				support: ! site.jetpack // We don't know where support docs for a given theme on a self-hosted WP install are.
 					? {
-						getUrl: theme => getSupportUrl( theme, site ),
+						getUrl: this.props.getSupportUrl,
 						hideForTheme: theme => ! isPremium( theme )
 					}
 					: {},
@@ -202,7 +202,8 @@ export default connect(
 		queryParams: getQueryParams( state ),
 		themesList: getThemesList( state ),
 		selectedSite: getSelectedSite( state ),
-		getDetailsUrl: getThemeDetailsUrl.bind( null, state )
+		getDetailsUrl: getThemeDetailsUrl.bind( null, state ),
+		getSupportUrl: getThemeSupportUrl.bind( null, state )
 	} ),
 	{
 		activate,

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -21,9 +21,9 @@ import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import ThemesSelection from './themes-selection';
-import { getHelpUrl, isPremium, addTracking } from './helpers';
+import { isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
-import { getThemeDetailsUrl, getThemeSupportUrl } from 'state/themes/themes/selectors';
+import { getThemeDetailsUrl, getThemeSupportUrl, getThemeHelpUrl } from 'state/themes/themes/selectors';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 import sitesFactory from 'lib/sites-list';
 import { FEATURE_CUSTOM_DESIGN } from 'lib/plans/constants';
@@ -101,7 +101,7 @@ const ThemesSingleSite = React.createClass( {
 					: {},
 				help: ! site.jetpack // We don't know where support forums for a given theme on a self-hosted WP install are.
 					? {
-						getUrl: theme => getHelpUrl( theme, site )
+						getUrl: this.props.getHelpUrl
 					}
 					: {},
 			};
@@ -203,7 +203,8 @@ export default connect(
 		themesList: getThemesList( state ),
 		selectedSite: getSelectedSite( state ),
 		getDetailsUrl: getThemeDetailsUrl.bind( null, state ),
-		getSupportUrl: getThemeSupportUrl.bind( null, state )
+		getSupportUrl: getThemeSupportUrl.bind( null, state ),
+		getHelpUrl: getThemeHelpUrl.bind( null, state )
 	} ),
 	{
 		activate,

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -10,7 +10,8 @@ import page from 'page';
  */
 import Dialog from 'components/dialog';
 import PulsingDot from 'components/pulsing-dot';
-import { getDetailsUrl, getCustomizeUrl, getForumUrl, trackClick } from './helpers';
+import { getCustomizeUrl, getForumUrl, trackClick } from './helpers';
+import { getThemeDetailsUrl } from 'state/themes/themes/selectors';
 import {
 	isActivating,
 	hasActivated,
@@ -59,7 +60,7 @@ const ThanksModal = React.createClass( {
 	renderWpcomInfo() {
 		const features = this.translate( "Discover this theme's {{a}}awesome features.{{/a}}", {
 			components: {
-				a: <a href={ getDetailsUrl( this.props.currentTheme, this.props.site ) }
+				a: <a href={ this.props.detailsUrl }
 					onClick={ this.onLinkClick( 'features' ) }/>
 			}
 		} );
@@ -190,10 +191,15 @@ const ThanksModal = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => ( {
-		isActivating: isActivating( state ),
-		hasActivated: hasActivated( state ),
-		currentTheme: getCurrentTheme( state, props.site ? props.site.ID : null )
-	} ),
+	( state, props ) => {
+		const currentTheme = getCurrentTheme( state, props.site && props.site.ID );
+
+		return {
+			currentTheme,
+			detailsUrl: getThemeDetailsUrl( state, currentTheme ),
+			isActivating: isActivating( state ),
+			hasActivated: hasActivated( state ),
+		};
+	},
 	{ clearActivated }
 )( ThanksModal );

--- a/client/state/themes/themes/selectors.js
+++ b/client/state/themes/themes/selectors.js
@@ -19,6 +19,10 @@ export function getThemeById( state, id ) {
 }
 
 export function getThemeDetailsUrl( state, theme ) {
+	if ( ! theme ) {
+		return null;
+	}
+
 	const site = getSelectedSite( state );
 
 	if ( site && isJetpackSite( state, site.ID ) ) {
@@ -34,6 +38,10 @@ export function getThemeDetailsUrl( state, theme ) {
 }
 
 export function getThemeSupportUrl( state, theme ) {
+	if ( ! theme ) {
+		return null;
+	}
+
 	const site = getSelectedSite( state );
 
 	if ( site && isJetpackSite( state, site.ID ) ) {

--- a/client/state/themes/themes/selectors.js
+++ b/client/state/themes/themes/selectors.js
@@ -32,3 +32,19 @@ export function getThemeDetailsUrl( state, theme ) {
 
 	return baseUrl + ( site ? `/${ getSiteSlug( state, site.ID ) }` : '' );
 }
+
+export function getThemeSupportUrl( state, theme ) {
+	const site = getSelectedSite( state );
+
+	if ( site && isJetpackSite( state, site.ID ) ) {
+		return '//wordpress.org/support/theme/' + theme.id;
+	}
+
+	const sitePart = site ? `/${ getSiteSlug( state, site.ID ) }` : '';
+
+	if ( config.isEnabled( 'manage/themes/details' ) ) {
+		return `/theme/${ theme.id }/setup${ sitePart }`;
+	}
+
+	return `${ oldShowcaseUrl }${ sitePart }${ theme.id }/support`;
+}

--- a/client/state/themes/themes/selectors.js
+++ b/client/state/themes/themes/selectors.js
@@ -1,5 +1,14 @@
 /** @ssr-ready **/
 
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+
+export const oldShowcaseUrl = '//wordpress.com/themes/';
+
 export function getThemes( state ) {
 	return state.themes.themes.get( 'themes' ).toJS();
 }
@@ -7,4 +16,19 @@ export function getThemes( state ) {
 export function getThemeById( state, id ) {
 	const theme = state.themes.themes.getIn( [ 'themes', id ] );
 	return theme ? theme.toJS() : undefined;
+}
+
+export function getThemeDetailsUrl( state, theme ) {
+	const site = getSelectedSite( state );
+
+	if ( site && isJetpackSite( state, site.ID ) ) {
+		return site.options.admin_url + 'themes.php?theme=' + theme.id;
+	}
+
+	let baseUrl = oldShowcaseUrl + theme.id;
+	if ( config.isEnabled( 'manage/themes/details' ) ) {
+		baseUrl = `/theme/${ theme.id }`;
+	}
+
+	return baseUrl + ( site ? `/${ getSiteSlug( state, site.ID ) }` : '' );
 }

--- a/client/state/themes/themes/selectors.js
+++ b/client/state/themes/themes/selectors.js
@@ -56,3 +56,22 @@ export function getThemeSupportUrl( state, theme ) {
 
 	return `${ oldShowcaseUrl }${ sitePart }${ theme.id }/support`;
 }
+
+export function getThemeHelpUrl( state, theme ) {
+	if ( ! theme ) {
+		return null;
+	}
+
+	const site = getSelectedSite( state );
+
+	if ( site && site.jetpack ) {
+		return getThemeSupportUrl( state, theme );
+	}
+
+	let baseUrl = oldShowcaseUrl + theme.id;
+	if ( config.isEnabled( 'manage/themes/details' ) ) {
+		baseUrl = `/theme/${ theme.id }/support`;
+	}
+
+	return baseUrl + ( site ? `/${ site.slug }` : '' );
+}


### PR DESCRIPTION
**Will need some very heavy rebasing after #6349 lands!**

In a Redux setting, most of our helpers arguably have always been selectors, if in a disguise.

This PR seeks to turn them into actual ones. This makes binding a selector to a site a matter of binding it to Redux state, which can be perfectly done at `connect` level, providing a bound function to the `connect`ed component, which is then much easier to use.

Eventually, this might be a first step towards merging back `single-site.jsx`, `multi-site.jsx`, and `logged-out.jsx`. (I think our dreaded `buttonOptions` might end up as the params to `connect`, with some logic moved to selectors.)

Note that this PR induces a minor behavioral change: On a theme sheet for a single site, related themes now also link to the respective sheets _for that site_.

TODO:

- [ ] Add tests for new selectors
- [ ] Have selectors accept a `themeID` instead of an entire theme object (and have them obtain other required theme attributes as needed). (Possibly same for `site` -> `siteId`)
- [ ] Turn all `get...Url()` helpers into selectors.
- [ ] Update `propTypes`

cc @budzanowski -- this might be a nice exercise to familiarize yourself more with Redux.

Test live: https://calypso.live/?branch=update/themes-turn-helpers-into-selectors