### PR TITLE
Reader: convert railcar to JSON before recording event

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -126,7 +126,7 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {} )
 	if ( post.railcar && tracksRailcarEventWhitelist.has( eventName ) ) {
 		recordTrack( 'calypso_traintracks_interact', {
 			action: eventName.replace( 'calypso_reader_', '' ),
-			railcar: post.railcar
+			railcar: JSON.stringify( post.railcar )
 		} );
 	} else if ( process.env.NODE_ENV !== 'production' && post.railcar ) {
 		console.warn( 'Consider whitelisting reader track', eventName );


### PR DESCRIPTION
The new related posts A/B test is using `railcar` objects for the first time. Unfortunately, we've found that Tracks does not seem to support JS objects when recording an event with `window._tkq.push`, so we're getting:

<img width="442" alt="screen shot 2016-06-21 at 07 52 12" src="https://cloud.githubusercontent.com/assets/17325/16220526/55e647d2-3785-11e6-83b7-88ea1c78795b.png">

This PR JSON-encodes the railcar to ensure it is reported to Tracks:

<img width="625" alt="screen shot 2016-06-21 at 07 55 17" src="https://cloud.githubusercontent.com/assets/17325/16220564/99092688-3785-11e6-8645-47877ebb13d8.png">

We may want a more generic solution later, serializing any object sent to `recordTrack`.


Test live: https://calypso.live/?branch=fix/reader/tracks-railcar