### PR TITLE
Checkout: Fix typo in check if product has been supplied to component

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -117,7 +117,7 @@ const Checkout = React.createClass( {
 	redirectIfEmptyCart: function() {
 		var redirectTo = '/plans/';
 
-		if ( ! this.state.previousCart && this.props.productName ) {
+		if ( ! this.state.previousCart && this.props.product ) {
 			// the plan hasn't been added to the cart yet
 			return false;
 		}


### PR DESCRIPTION
This PR is a fix for #6167 

There was a typo in the check if product was added to the cart via URL parameters, which resulted in the item being added to the cart, but the checkout screen wasn't displayed properly.

To test: 
1. Checkout branch and start at `/start/premium` or [`https://calypso.live/start/premium?branch=fix/6167-plans-not-properly-added-to-cart-on-signup`](https://calypso.live/start/premium?branch=fix/6167-plans-not-properly-added-to-cart-on-signup)
2. Finish signup
3. After signup is completed you should see the checkout cart with the premium plan added

cc @scruffian @lamosty @meremagee @alisterscott 