### PR TITLE
Sharing: Hide No Ads banner on WordAds sites

### DIFF
--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -73,6 +73,9 @@ export default React.createClass( {
 		if ( ! feature && ! isFreePlan( site.plan ) ) {
 			return false;
 		}
+		if ( feature === 'no-adverts' && site.options.wordads ) {
+			return false;
+		}
 		if ( ! jetpack && site.jetpack || jetpack && ! site.jetpack ) {
 			return false;
 		}


### PR DESCRIPTION
This is meant to address #6039. We currently have a boolean on `site.options.wordads` that indicates whether or not a site has WordAds enabled. When we generate the upgrade nudge in [my-sites/sharing/main.jsx](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/sharing/main.jsx#L80), we pass in the feature `no-adverts`. This PR adds a check in [my-sites/upgrade-nudge/index.jsx](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/upgrade-nudge/index.jsx). If `feature === 'no-adverts'` and `site.options.wordads` is true, `shouldDisplay` returns false hiding the No Ads nudge.

### To Test

You'll need three sites:

- A site without WordAds or a plan upgrade
- A site with WordAds enabled and no plan upgrade
- A site without WordAds enabled but has a Premium or Business plan

To test:

1. Load up this branch.
2. Visit the Sharing settings page for each site: http://calypso.localhost:3000/sharing/site.wordpress.com

For the site without WordAds or a plan upgrade, you should see the following nudge:

![screen shot 2016-06-21 at 7 45 21 am](https://cloud.githubusercontent.com/assets/7240478/16231592/1fc78662-3784-11e6-8bff-6d6693ace6e7.png)

For sites with WordAds enabled or with a plan, the nudge should be removed:

![screen shot 2016-06-21 at 7 46 00 am](https://cloud.githubusercontent.com/assets/7240478/16231614/36a6fb42-3784-11e6-9b02-c3e2f88e763f.png)

If you visit the Sharing page in production (wordpress.com/sharing/site.wordpress.com) for a site with WordAds enabled but no plan upgrade, you'll still see the nudge currently.

Test live: https://calypso.live/?branch=fix/6039-no-ads-banner