### PR TITLE
Reader: Fix how we report interacts

### DIFF
--- a/client/reader/start/card.jsx
+++ b/client/reader/start/card.jsx
@@ -13,7 +13,7 @@ import StartCardHeader from './card-header';
 import { recordRecommendationInteraction } from 'state/reader/start/actions';
 import { getRecommendationById } from 'state/reader/start/selectors';
 import { getPostBySiteAndId } from 'state/reader/posts/selectors';
-import { recordTrack, recordTrackForPost } from 'reader/stats';
+import { recordTrack, recordTrackForPost, recordTracksRailcarInteract } from 'reader/stats';
 
 const debug = debugModule( 'calypso:reader:start' ); //eslint-disable-line no-unused-vars
 
@@ -33,10 +33,7 @@ const StartCard = React.createClass( {
 				recommendation_id: this.props.recommendationId
 			} );
 			if ( this.props.recommendation.railcar ) {
-				recordTrack( 'calypso_traintracks_interact', {
-					action: 'startcard_clicked',
-					railcar: this.props.recommendation.railcar
-				} );
+				recordTracksRailcarInteract( 'startcard_clicked', this.props.recommendation.railcar );
 			}
 		}
 	},

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -1,5 +1,6 @@
 import assign from 'lodash/assign';
 import debugFactory from 'debug';
+import partial from 'lodash/partial';
 
 import { mc, ga, tracks } from 'lib/analytics';
 
@@ -115,6 +116,16 @@ tracksRailcarEventWhitelist
 	.add( 'calypso_reader_startcard_clicked' )
 ;
 
+export function recordTracksRailcar( action, eventName, railcar ) {
+	// flatten the railcar down into the event props
+	recordTrack( action, Object.assign( {
+		action: eventName.replace( 'calypso_reader_', '' )
+	}, railcar ) );
+}
+
+export const recordTracksRailcarRender = partial( recordTracksRailcar, 'calypso_traintracks_render' );
+export const recordTracksRailcarInteract = partial( recordTracksRailcar, 'calypso_traintracks_interact' );
+
 export function recordTrackForPost( eventName, post = {}, additionalProps = {} ) {
 	recordTrack( eventName, assign( {
 		blog_id: ! post.is_external && post.site_ID > 0 ? post.site_ID : undefined,
@@ -124,10 +135,7 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {} )
 		is_jetpack: post.is_jetpack
 	}, additionalProps ) );
 	if ( post.railcar && tracksRailcarEventWhitelist.has( eventName ) ) {
-		recordTrack( 'calypso_traintracks_interact', {
-			action: eventName.replace( 'calypso_reader_', '' ),
-			railcar: JSON.stringify( post.railcar )
-		} );
+		recordTracksRailcarInteract( eventName, post.railcar );
 	} else if ( process.env.NODE_ENV !== 'production' && post.railcar ) {
 		console.warn( 'Consider whitelisting reader track', eventName );
 	}


### PR DESCRIPTION
Merge railcar props into the event props

To test, perform some actions that generate train tracks interact events, like clicking on Related Posts in the full post view, or click on a card in the new /read/start view. Check the network tab, you should see t.gif requests with the railcar properties as top-level querystring parameters, with no prefix.

Test live: https://calypso.live/?branch=fix/reader/railcar-reporting