### PR TITLE
Reader: Release Related Posts to everyone

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -119,13 +119,4 @@ module.exports = {
 		defaultVariation: 'enabled',
 		allowExistingUsers: false,
 	},
-	readerRelatedPosts: {
-		datestamp: '20160620',
-		variations: {
-			disabled: 90,
-			enabled: 10
-		},
-		defaultVariation: 'disabled',
-		allowExistingUsers: true
-	}
 };

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -80,7 +80,7 @@ let loadingPost = {
 	},
 	FullPostView, FullPostDialog, FullPostContainer;
 
-const relatedPostsEnabled = config.isEnabled( 'reader/related-posts' ) && abtest( 'readerRelatedPosts' ) === 'enabled';
+const relatedPostsEnabled = config.isEnabled( 'reader/related-posts' );
 
 /**
  * The content of a FullPostView


### PR DESCRIPTION
This will enable the Related Posts UI for all users. It may not appear immediately, because we're going to ramp up the percentage of API requests that return results gradually.

Test live: https://calypso.live/?branch=update/reader/release-related-posts