### PR TITLE
Collect arbitrary Redux actions into a semi-permanent log

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -22,6 +22,7 @@ import {
 	ActionStep,
 } from './steps';
 import wait from './wait';
+import QueryPreferences from 'components/data/query-preferences';
 
 const debug = debugFactory( 'calypso:guided-tours' );
 
@@ -69,7 +70,7 @@ class GuidedTours extends Component {
 
 		const nextTargetFound = () => {
 			if ( nextStepConfig && nextStepConfig.target ) {
-				const target = this.getTipTargets()[nextStepConfig.target];
+				const target = this.getTipTargets()[ nextStepConfig.target ];
 				return target && target.getBoundingClientRect().left >= 0;
 			}
 			return true;
@@ -121,6 +122,7 @@ class GuidedTours extends Component {
 
 		return (
 			<div className="guided-tours">
+				<QueryPreferences />
 				<StepComponent
 					{ ...stepConfig }
 					key={ stepConfig.target }

--- a/client/state/preferences/constants.js
+++ b/client/state/preferences/constants.js
@@ -11,5 +11,21 @@ export const DEFAULT_PREFERENCES = {
 	mediaModalGalleryInstructionsDismissedForSession: {
 		schema: null, //We only want to store this preference for current session. mediaModalGalleryInstructionsDismissed is the version stored in api and localStorage
 		'default': false
-	}
+	},
+	'guided-tours-history': {
+		schema: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					tourName: { type: 'string' },
+					timestamp: { type: 'number', minimum: 0 },
+					finished: { type: 'boolean' },
+				},
+				required: [ 'tourName', 'timestamp', 'finished' ],
+				additionalProperties: false,
+			},
+		},
+		'default': [],
+	},
 };

--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import includes from 'lodash/includes';
+import takeRight from 'lodash/takeRight';
+
+/**
+ * Internal dependencies
+ */
+import {
+	GUIDED_TOUR_SHOW,
+	GUIDED_TOUR_UPDATE,
+	THEMES_RECEIVE,
+	PREVIEW_IS_SHOWING,
+	ROUTE_SET,
+} from 'state/action-types';
+
+const isRelevantActionType = includes.bind( null, [
+	GUIDED_TOUR_SHOW,
+	GUIDED_TOUR_UPDATE,
+	THEMES_RECEIVE,
+	PREVIEW_IS_SHOWING,
+	ROUTE_SET,
+] );
+
+const newAction = ( action ) => ( {
+	...action, timestamp: Date.now()
+} );
+
+export default ( state = [], action ) =>
+	isRelevantActionType( action.type )
+		? takeRight( [ ...state, newAction( action ) ], 50 )
+		: state;

--- a/client/state/ui/action-log/selectors.js
+++ b/client/state/ui/action-log/selectors.js
@@ -1,0 +1,15 @@
+/**
+ * Returns a log of actions from certain types that have previously been
+ * dispatched for the current user.
+ *
+ * These actions are to be consumed by and inform Calypso's Guided Tours
+ * framework, but other components interested in listening to a log of Calypso
+ * actions are welcome to use and/or extend it.
+ *
+ * @param  {Object}   state      Global state tree
+ * @return {Array}               Array of Redux actions, each with timestamp
+ */
+export function getActionLog( state ) {
+	return state.ui.actionLog;
+}
+

--- a/client/state/ui/action-log/test/reducer.js
+++ b/client/state/ui/action-log/test/reducer.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { useFakeTimers } from 'test/helpers/use-sinon';
+import {
+	ROUTE_SET,
+} from 'state/action-types';
+import reducer from '../reducer';
+
+describe( 'reducer', () => {
+	useFakeTimers( 1337 );
+
+	it( 'should default to an empty list', () => {
+		const state = reducer( undefined, {} );
+
+		expect( state ).to.eql( [] );
+	} );
+
+	it( 'should add actions to the log', () => {
+		const actions = [
+			{
+				type: ROUTE_SET,
+				path: '/menus/77203074',
+			},
+			{
+				type: ROUTE_SET,
+				path: '/menus/foobar',
+			},
+		];
+		const state = actions.reduce( reducer, undefined );
+
+		expect( state ).to.eql( [
+			{ ...actions[ 0 ], timestamp: 1337 },
+			{ ...actions[ 1 ], timestamp: 1337 },
+		] );
+	} );
+} );

--- a/client/state/ui/action-log/test/selectors.js
+++ b/client/state/ui/action-log/test/selectors.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getActionLog,
+} from '../selectors';
+
+import {
+	GUIDED_TOUR_UPDATE,
+	ROUTE_SET,
+} from 'state/action-types';
+
+describe( 'selectors', () => {
+	describe( 'actionLog', () => {
+		it( 'should initially return one empty list', () => {
+			const log = getActionLog( {
+				ui: {
+					actionLog: [],
+				}
+			} );
+
+			expect( log ).to.eql( [] );
+		} );
+
+		it( 'should retrieve all actions from the log', () => {
+			const actions = [
+				{
+					type: GUIDED_TOUR_UPDATE,
+					shouldShow: false,
+				},
+				{
+					type: ROUTE_SET,
+					path: '/menus/77203074',
+				}
+			];
+			const log = getActionLog( {
+				ui: {
+					actionLog: actions,
+				},
+			} );
+
+			expect( log ).to.eql( actions );
+		} );
+	} );
+} );

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -18,6 +18,7 @@ import editor from './editor/reducer';
 import guidedTour from './guided-tours/reducer';
 import reader from './reader/reducer';
 import olark from './olark/reducer';
+import actionLog from './action-log/reducer';
 
 /**
  * Tracks the currently selected site ID.
@@ -95,7 +96,8 @@ const reducer = combineReducers( {
 	guidedTour,
 	editor,
 	reader,
-	olark
+	olark,
+	actionLog,
 } );
 
 export default function( state, action ) {


### PR DESCRIPTION
Product of exploration in #6146. See that PR for context.

### Rationale

The action log is to be consumed by Guided Tours selectors. The aforementioned PR showcases this. The tests should be self-explaining, but feel free to ask questions. The initial implementation of this PR had `actionLog` be made of two branches, `temporary` and `permanent`, hence the term _semi-permanent_ in this PR's title. It then evolved into a single-branched temporary `actionLog`, combined with a persistent user setting.

### Testing
- Run Calypso with the Redux Dev Tools open on the side (`state.currentUser.actionLog`).
- Make sure that certain actions carried out in Calypso alter the log: navigating to a section adds a `SET_ROUTE` action to the log (temporary branch), opening a theme preview, etc.
- Try the tour at http://calypso.localhost:3000/stats/day?tour=main and keep an eye on the permanent branch of the log: proceeding to the next step should only affect the temporary branch, but quitting or completing the whole tour should add an action to the permanent one.

### Questions
- ~~Is this the best place in the Redux tree? The decision was made by myself, @lsinger and @ehg.~~
- [x] Are these the best places in the Redux tree? `state.ui.actionLog` for the ephemeral log, `state.preferences#guided-tours-history` to remember which tours have been seen.

### Caveat
The way we persist which tours have been seen by the user is subject to concurrency issues and history loss, since _adding a tour_ to that collection is actually achieved by _adding a tour to the client's copy of the collection and saving that as the new history_. However, for the purpose of this PR, the current approach suffices.

### To do
- [x] Rebase and adjust to recent changes in the way user preferences are saved
- [x] Move selectors to `action-log/selectors`
- ~~Change `guided-tours-history` schema to object-based, rather than array-~~
- _^ an array may suit us better, since we care about all the times a user has completed/rejected a tour, and not just the end state_
- [x] Simplify main selector
- [ ] Address _§ Caveat_ in subsequent PR(s)

Test live: https://calypso.live/?branch=add/action-log