### PR TITLE
Reader: Remove instagram posts from excerpts, remove styles too

### DIFF
--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -25,7 +25,7 @@ export default function createBetterExcerpt( post ) {
 	dom.innerHTML = post.content;
 
 	// Ditch any photo captions with the wp-caption-text class, styles, scripts
-	forEach( dom.querySelectorAll( '.wp-caption-text, style, script' ), removeElement );
+	forEach( dom.querySelectorAll( '.wp-caption-text, style, script, blockquote[class^="instagram-"]' ), removeElement );
 
 	// limit to paras and brs
 	dom.innerHTML = striptags( dom.innerHTML, [ 'p', 'br' ] );
@@ -39,10 +39,12 @@ export default function createBetterExcerpt( post ) {
 		element.parentNode && element.parentNode.removeChild( element );
 	} );
 
-	// now strip any p's that are empty
+	// now strip any p's that are empty and remove styles
 	forEach( dom.querySelectorAll( 'p' ), function( element ) {
 		if ( trim( element.textContent ).length === 0 ) {
 			element.parentNode && element.parentNode.removeChild( element );
+		} else {
+			element.removeAttribute( 'style' );
 		}
 	} );
 


### PR DESCRIPTION
To test, view http://calypso.localhost:3000/read/feeds/12098 vs. https://wordpress.com/read/feeds/12098

Notice that some posts have excerpts that contain styled text and look bad. Remove the styles.

Also pull out blockquotes that signify instagram posts.

Test live: https://calypso.live/?branch=fix/reader/instagram-in-excerpts