### PR TITLE
My Sites: remove sidebar draft count experiment.

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -29,8 +29,6 @@ var config = require( 'config' ),
 import Button from 'components/button';
 import SidebarButton from 'layout/sidebar/button';
 import SidebarFooter from 'layout/sidebar/footer';
-import DraftsButton from 'post-editor/drafts-button';
-import Tooltip from 'components/tooltip';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 
 module.exports = React.createClass( {
@@ -38,12 +36,6 @@ module.exports = React.createClass( {
 
 	componentDidMount: function() {
 		debug( 'The sidebar React component is mounted.' );
-	},
-
-	getInitialState: function() {
-		return {
-			draftsTooltip: false
-		};
 	},
 
 	onNavigate: function() {
@@ -676,10 +668,6 @@ module.exports = React.createClass( {
 		);
 	},
 
-	onDraftsClick: function() {
-		page( '/posts/drafts' + this.siteSuffix() );
-	},
-
 	render: function() {
 		var publish = !! this.publish(),
 			appearance = ( !! this.themes() || !! this.menus() ),
@@ -718,26 +706,7 @@ module.exports = React.createClass( {
 
 				{ publish
 					? <SidebarMenu>
-						<SidebarHeading>
-							{ this.translate( 'Publish' ) }
-							{ config.isEnabled( 'sidebar-drafts-count' ) &&
-								<div
-									className="sidebar__drafts-button"
-									onMouseEnter={ () => this.setState( { draftsTooltip: true } ) }
-									onMouseLeave={ () => this.setState( { draftsTooltip: false } ) }
-									ref="draftsButton"
-								>
-									<DraftsButton hideText onClick={ this.onDraftsClick } />
-									<Tooltip
-										context={ this.refs && this.refs.draftsButton }
-										isVisible={ this.state.draftsTooltip }
-										position="top"
-									>
-										{ this.translate( 'Drafts' ) }
-									</Tooltip>
-								</div>
-							}
-						</SidebarHeading>
+						<SidebarHeading>{ this.translate( 'Publish' ) }</SidebarHeading>
 						{ this.publish() }
 					</SidebarMenu>
 					: null

--- a/config/development.json
+++ b/config/development.json
@@ -118,7 +118,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
-		"sidebar-drafts-count": true,
 		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,7 +81,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": false,
-		"sidebar-drafts-count": true,
 		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -83,7 +83,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
-		"sidebar-drafts-count": true,
 		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,7 +93,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
-		"sidebar-drafts-count": true,
 		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,


### PR DESCRIPTION
We tried; it didn't quite work out. Showing latest drafts makes it redundant for the purpose.

![image](https://cloud.githubusercontent.com/assets/548849/16242027/d2d3d708-37f0-11e6-91c9-76ff97e2f715.png)

cc @aduth @folletto 

Test live: https://calypso.live/?branch=update/remove-sidebar-draft-count-experiment