### PR TITLE
Jetpack Connect: Show EmptyContent when going directly to /jetpack/connect/authorize with no query args

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -35,6 +35,7 @@ import Spinner from 'components/spinner';
 import Site from 'my-sites/site';
 import { decodeEntities } from 'lib/formatting';
 import versionCompare from 'lib/version-compare';
+import EmptyContent from 'components/empty-content';
 
 /**
  * Constants
@@ -410,6 +411,21 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		return false;
 	},
 
+	renderNoQueryArgsError() {
+		return (
+			<Main>
+				<EmptyContent
+					illustration="/calypso/images/drake/drake-whoops.svg"
+					title={ this.translate(
+						'Oops, this URL should not be accessed directly'
+					) }
+					action={ this.translate( 'Get back to Jetpack Connect screen' ) }
+					actionURL="/jetpack/connect"
+				/>
+			</Main>
+		);
+	},
+
 	renderForm() {
 		const { userModule } = this.props;
 		let user = userModule.get();
@@ -425,6 +441,11 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		);
 	},
 	render() {
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+		if ( typeof queryObject === 'undefined' ) {
+			return this.renderNoQueryArgsError();
+		}
+
 		return (
 			<Main className="jetpack-connect">
 				<div className="jetpack-connect__authorize-form">


### PR DESCRIPTION
* Shows message stating that `/jetpack/connect/authorize` is not meant to be accessed directly (i.e. without query args from previous jetpack connect step) if the URL as no query arguments. 

Fixes #5109.

![image](https://cloud.githubusercontent.com/assets/746152/16243187/6a8edee6-37cc-11e6-8765-e29475892a81.png)


To test:

* Checkout the `update/jetpack-connect-authorize-no-args` branch
* Go to `/jetpack/connect/auhtorize`.
* See the above