### PR TITLE
Personal Plan: show personal plan on all environments 🚀 🌖 

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -70,6 +70,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/personal-plan": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -63,6 +63,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -68,6 +68,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/personal-plan": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,6 +87,7 @@
 		"olark": true,
 		"perfmon": false,
 		"persist-redux": true,
+		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -77,6 +77,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/personal-plan": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,


### PR DESCRIPTION
Turns on Personal Plan on all environments except desktop.

cc: @apeatling @roundhill 

Test live: https://calypso.live/?branch=add/turn-on-personal-plan