### PR TITLE
Guided Transfer: Add blue host account info page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -203,6 +203,7 @@
 @import 'my-sites/drafts/style';
 @import 'my-sites/exporter/style';
 @import 'my-sites/feature-comparison/style';
+@import 'my-sites/guided-transfer/style';
 @import 'my-sites/invites/invite-form-header/style';
 @import 'my-sites/invites/invite-header/style';
 @import 'my-sites/invites/invite-accept-logged-in/style';

--- a/client/my-sites/exporter/guided-transfer-options.jsx
+++ b/client/my-sites/exporter/guided-transfer-options.jsx
@@ -18,7 +18,7 @@ export default React.createClass( {
 	},
 
 	purchaseGuidedTransfer() {
-		page( `/settings/export/${this.props.siteSlug}/guided` );
+		page( `/settings/export/guided/${this.props.siteSlug}` );
 	},
 
 	render() {

--- a/client/my-sites/guided-transfer/account-info.jsx
+++ b/client/my-sites/guided-transfer/account-info.jsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import SectionHeader from 'components/section-header';
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormPasswordInput from 'components/forms/form-password-input';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+export default React.createClass( {
+	propTypes: {
+		hostInfo: PropTypes.shape( {
+			label: PropTypes.string.isRequired,
+			url: PropTypes.string.isRequired
+		} ).isRequired
+	},
+
+	render() {
+		const { hostInfo } = this.props;
+
+		return (
+			<div>
+				<SectionHeader label={ this.translate( 'Account Info' ) } />
+				<CompactCard>
+					<p>
+						{ this.translate(
+							'Please enter your credentials. They will be stored securely so that one ' +
+							'of our Happiness Engineers can get the transfer going for you.' ) }
+					</p>
+					<div>
+						<FormFieldset className="guided-transfer__account-username-fieldset">
+							<FormLabel htmlFor="username">{ this.translate( '%(host)s account username', {
+								args: {
+									host: hostInfo.label
+								}
+							} ) }</FormLabel>
+							<FormTextInput
+								id="username"
+								placeholder={ this.translate( 'Username' ) } />
+						</FormFieldset>
+
+						<FormFieldset className="guided-transfer__account-password-fieldset">
+							<FormLabel htmlFor="password">{ this.translate( '%(host)s account password', {
+								args: {
+									host: hostInfo.label
+								}
+							} ) }</FormLabel>
+							<FormPasswordInput
+								autoCapitalize="off"
+								autoComplete="off"
+								autoCorrect="off"
+								id="password"
+								placeholder={ this.translate( 'Password' ) } />
+						</FormFieldset>
+					</div>
+					<FormSettingExplanation className="guided-transfer__account-info-tip">
+						{ this.translate(
+							'You don\'t have a %(host)s account yet? ' +
+							'{{host_link}}Create one{{/host_link}} and return here.', {
+								components: {
+									host_link: <a href={ hostInfo.url } />
+								},
+								args: {
+									host: hostInfo.label
+								}
+							}
+						) }
+					</FormSettingExplanation>
+				</CompactCard>
+				<CompactCard>
+					<FormButton>Continue</FormButton>
+				</CompactCard>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/guided-transfer/guided-transfer.jsx
+++ b/client/my-sites/guided-transfer/guided-transfer.jsx
@@ -3,16 +3,28 @@
  */
 import React, { PropTypes } from 'react';
 import page from 'page';
+import get from 'lodash/get';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import HeaderCake from 'components/header-cake';
+import AccountInfo from './account-info';
+
+const guidedTransferHosts = {
+	bluehost: {
+		label: i18n.translate( 'Bluehost' ),
+		url: '#bluehost',
+	},
+};
 
 export default React.createClass( {
 	displayName: 'GuidedTransfer',
 
 	propTypes: {
+		hostSlug: PropTypes.string,
 		siteSlug: PropTypes.string.isRequired
 	},
 
@@ -20,10 +32,39 @@ export default React.createClass( {
 		page( `/settings/export/${this.props.siteSlug}` );
 	},
 
+	showHostSelection() {
+		page( `/settings/export/guided/${this.props.siteSlug}` );
+	},
+
+	showBluehostAccountInfo() {
+		page( `/settings/export/guided/bluehost/${this.props.siteSlug}` );
+	},
+
+	goBack() {
+		if ( this.props.hostSlug ) {
+			this.showHostSelection();
+		} else {
+			this.showExporter();
+		}
+	},
+
 	render: function() {
+		const hostInfo = get( guidedTransferHosts, this.props.hostSlug );
+
 		return (
 			<div className="guided-transfer">
-				<HeaderCake onClick={ this.showExporter } isCompact={ true }>{ this.translate( 'Guided Transfer' ) }</HeaderCake>
+				<div className="guided-transfer__header-nav">
+					<HeaderCake onClick={ this.goBack }>
+						{ this.translate( 'Guided Transfer' ) }
+					</HeaderCake>
+				</div>
+
+				<div className="guided-transfer__content">
+					{ hostInfo
+						? <AccountInfo hostInfo={ hostInfo } />
+						: <Button onClick={ this.showBluehostAccountInfo }>Bluehost</Button>
+					}
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/guided-transfer/style.scss
+++ b/client/my-sites/guided-transfer/style.scss
@@ -1,0 +1,25 @@
+.guided-transfer {
+	.guided-transfer__header-nav {
+		margin: 0 0 17px 0;
+	}
+
+	.guided-transfer__account-username-fieldset,
+	.guided-transfer__account-password-fieldset {
+		display: inline-block;
+		width: 100%;
+	}
+
+	@include breakpoint( ">960px" ) {
+		.guided-transfer__account-username-fieldset,
+		.guided-transfer__account-password-fieldset {
+			width: 50%;
+
+			/* Override the default margin bottom provided for FormFieldset */
+			margin-bottom: 0px;
+		}
+
+		.guided-transfer__account-username-fieldset {
+			padding-right: 10px;
+		}
+	}
+}

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -19,7 +19,7 @@ module.exports = function() {
 	page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
 
 	if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
-		page( '/settings/export/:site_id/guided', controller.siteSelection, controller.navigation, settingsController.guidedTransfer );
+		page( '/settings/export/guided/:host_slug?/:site_id', controller.siteSelection, controller.navigation, settingsController.guidedTransfer );
 	}
 	if ( config.isEnabled( 'manage/export' ) ) {
 		page( '/settings/export/:site_id', controller.siteSelection, controller.navigation, settingsController.exportSite );

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -97,7 +97,7 @@ export class SiteSettingsComponent extends Component {
 			seo: <SeoSettings site={ site } />,
 			'import': <ImportSettings site={ site } />,
 			'export': <ExportSettings site={ site } store={ context.store } />,
-			guidedTransfer: <GuidedTransfer store={ context.store } />
+			guidedTransfer: <GuidedTransfer store={ context.store } hostSlug={ context.params.host_slug } />
 		};
 	}
 

--- a/client/my-sites/site-settings/section-guided-transfer.jsx
+++ b/client/my-sites/site-settings/section-guided-transfer.jsx
@@ -13,7 +13,7 @@ export default class extends Component {
 	render() {
 		return (
 			<Provider store={ this.props.store }>
-				<GuidedTransfer />
+				<GuidedTransfer hostSlug={ this.props.hostSlug } />
 			</Provider>
 		);
 	}


### PR DESCRIPTION
Add the UI elements for collecting bluehost account info for Guided Transfer.

## How to test
1. Navigate to https://calypso.live/?branch=add/guided-transfer/host-select-screen
2. Click "My Sites" in the upper left corner of the page.
3. Scroll down in the left navigation area if needed and click "Settings"
4. Click "Export" in the page navigation.
5. Click "Purchase a Guided Transfer"
6. Click the bluehost button. 
*Note: The bluehost button that stands alone is temporary and will be replaced with the host selection screen built in #6012*

## What to expect

![screen shot 2016-06-27 at 11 51 19 pm](https://cloud.githubusercontent.com/assets/1854440/16403340/20935cae-3cc2-11e6-9592-ba0e03c19c6a.png)

![screen shot 2016-06-27 at 11 50 56 pm](https://cloud.githubusercontent.com/assets/1854440/16403343/26438444-3cc2-11e6-946e-687dd6c578d7.png)
