### PR TITLE
Fixing incorrect filename in `config/client/readme.md`

### DIFF
--- a/client/config/README.md
+++ b/client/config/README.md
@@ -1,7 +1,7 @@
 client/config
 =============
 
-The `index.js` file is generated on startup by `regenerate.js`. Based on the environment, data is read from the appropriate .json file in the root config directory, for example, `/config/development.json`. The data is then compared against a whitelist in `/config/client.json`, and whitelisted items are added to the data object in `/client/config/index.js`. You can read more about how to use `config` in the [main documentation](https://github.com/Automattic/wp-calypso#config).
+The `index.js` file is generated on startup by `regenerate-client.js`. Based on the environment, data is read from the appropriate .json file in the root config directory, for example, `/config/development.json`. The data is then compared against a whitelist in `/config/client.json`, and whitelisted items are added to the data object in `/client/config/index.js`. You can read more about how to use `config` in the [main documentation](https://github.com/Automattic/wp-calypso#config).
 
 Feature Flags API
 -----------------


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/blob/cfb84845df83c02df5dd075150f455bc3156379d/client/config/README.md refers to an outdated `regenerate.js` file that was changed in https://github.com/Automattic/wp-calypso/commit/8c0fb1ce690d6e0d69d9bc413638d8957110735c#diff-ab2b453f728f30a0b09d94f01e6245af. This PR just tweaks the corresponding `README.md` to point to the new filename.

Test live: https://calypso.live/?branch=fix/incorrect-filename-in-client-config-readme