### PR TITLE
Upgrades: plans/compare fix selected feature row highlighting

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -114,7 +114,7 @@ export default {
 					<PlansCompare
 						selectedSite={ site }
 						features={ features }
-						selectedFeature={ context.params.feature }
+						selectedFeature={ context.params.feature || context.query.feature }
 						intervalType={ context.params.intervalType }
 						productsList={ productsList } />
 				</CheckoutData>


### PR DESCRIPTION
During refactoring of plans-actions I discovered that we seized highlighting currently-selected feature. We point to these features with nudges.

# Expected result & testing

http://calypso.localhost:3000/plans/features/custom-design/$site 

Should give:
<img width="740" alt="zrzut ekranu 2016-06-22 o 10 54 01" src="https://cloud.githubusercontent.com/assets/3775068/16260423/b451e1b8-3867-11e6-9e05-245edf8f5d78.png">

CC @gwwar @mtias @lamosty @rralian 


Test live: https://calypso.live/?branch=fix/selected-feature