### PR TITLE
GuidedTours: fix sidebar scrolling

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -91,7 +91,7 @@ class GuidedTours extends Component {
 
 	quit( options = {} ) {
 		// TODO: put into step specific callback?
-		const sidebar = query( '#secondary .sidebar' )[ 0 ];
+		const sidebar = query( '#secondary .sidebar .sidebar__region' )[ 0 ];
 		scrollTo( { y: 0, container: sidebar } );
 
 		this.currentTarget && this.currentTarget.classList.remove( 'guided-tours__overlay' );

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -129,7 +129,7 @@ function scrollIntoView( target ) {
 		return 0;
 	}
 
-	const container = query( '#secondary .sidebar' )[ 0 ];
+	const container = query( '#secondary .sidebar .sidebar__region' )[ 0 ];
 	const scrollMax = container.scrollHeight -
 		container.clientHeight - container.scrollTop;
 	const y = Math.min( .75 * top, scrollMax );


### PR DESCRIPTION
#5737 introduced sidebar regions, which broke the scrolling of the sidebar in GuidedTours. This corrects the selector used for finding the element to scroll. Long-term a more robust solution would be nice, but for now we want to fix the scrolling for the existing tour. 

Fixes #6197.

To test: 
- Take the main tour by going to http://calypso.localhost:3000/?tour=main and check that the Themes step is scrolled into view if it's not initially. For this your users needs to have Theme permissions for the currently selected site. 


Test live: https://calypso.live/?branch=fix/guided-tours-sidebar-scrolling