### PR TITLE
Jetpack connect: Check for url so we avoid an exception if we are justt showing an error message

### DIFF
--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -17,7 +17,7 @@ export default React.createClass( {
 	},
 
 	getNoticeValues( url ) {
-		let noticeValues = {
+		const noticeValues = {
 			icon: 'notice',
 			status: 'is-error',
 			text: this.translate( 'That\'s not a valid url.' ),
@@ -114,7 +114,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const urlSlug = this.props.url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+		const urlSlug = this.props.url ? this.props.url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' ) : '';
 		const values = this.getNoticeValues( urlSlug );
 		if ( values ) {
 			return (


### PR DESCRIPTION
Related with https://github.com/Automattic/jetpack/pull/3788

Right now, if we try to connect a user/site that is already connected to a different .com account, if we use the jetpack's branch that is intended to add a way to return the flow to calypso so we can show the error message  here, we are getting an exception because we expect to receive an url param that we don't receive. This PR fixes this exception.

![image](https://cloud.githubusercontent.com/assets/1554855/16264426/de14f2f8-3879-11e6-9cdc-a6a1b21d1bc4.png)


How to test: 
=========
1. You need a jetpack site running https://github.com/Automattic/jetpack/pull/3788
2. Connect this site with a .com account (let's call it "A")
3. Log out from A and login to a new .com account ("B")
4. Go to http://calypso.localhost:3000/jetpack/connect/ and try to connect the site (already connected with "A"). You should see that message up there


Test live: https://calypso.live/?branch=fix/jetpack-error-message