### PR TITLE
Retain open live preview link icon below 960px.

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -351,7 +351,7 @@
 		text-transform: uppercase;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( "<960px" ) {
 		color: transparentize( $gray, 0.2 );
 		top: 90%;
 		margin-left: 30px;


### PR DESCRIPTION
This PR addresses the #5803 question about `Open live preview` link visibility.

Previously it was not visible after window width was smaller than 960.
It appeared back after 660px. Now it is visible all the time.

To check:
1. Open theme sheet.
2. Lower window width bellow 960. Two panes view is switched to one pane view.
3. Open live preview link icon is visible and link works. 

Test live: https://calypso.live/?branch=fix/missing-open-live-preview-link