### PR TITLE
Design placeholder for PlanFeatures

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -71,14 +71,22 @@ class PlanFeatures extends Component {
 
 PlanFeatures.propTypes = {
 	onUgradeClick: PropTypes.func,
-	plan: React.PropTypes.oneOf( [ PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS ] ).isRequired
+	// either you specify the plan prop or isPlaceholder prop
+	plan: React.PropTypes.oneOf( [ PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINESS ] ),
+	isPlaceholder: PropTypes.bool
 };
 
-PlanFeaturesHeader.defaultProps = {
+PlanFeatures.defaultProps = {
 	onUpgradeClick: noop
 };
 
 export default connect( ( state, ownProps ) => {
+	if ( ownProps.placeholder ) {
+		return {
+			isPlaceholder: true
+		};
+	}
+
 	const planProductId = plansList[ ownProps.plan ].getProductId();
 	const selectedSiteId = getSelectedSiteId( state );
 	const planObject = getPlan( state, planProductId );
@@ -91,8 +99,7 @@ export default connect( ( state, ownProps ) => {
 		rawPrice: getPlanRawPrice( state, planProductId /**, get from abtest **/ ),
 		planConstantObj: plansList[ ownProps.plan ],
 		billingTimeFrame: get( planObject, 'bill_period_label', '' ),
-		planObject: planObject,
-		isPlaceholder: get( ownProps, 'placeholder', false )
+		planObject: planObject
 	};
 } )( PlanFeatures );
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -14,6 +14,7 @@ import PlanFeaturesHeader from './header';
 import PlanFeaturesItemList from './list';
 import PlanFeaturesItem from './item';
 import PlanFeaturesFooter from './footer';
+import PlanFeaturesPlaceholder from './placeholder';
 import { isCurrentSitePlan } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPlanRawPrice, getPlan } from 'state/plans/selectors';
@@ -21,8 +22,8 @@ import { plansList, getPlanFeaturesObject, PLAN_FREE, PLAN_PREMIUM, PLAN_BUSINES
 
 class PlanFeatures extends Component {
 	render() {
-		if ( ! this.props.planObject ) {
-			return null;
+		if ( ! this.props.planObject || this.props.isPlaceholder ) {
+			return <PlanFeaturesPlaceholder />;
 		}
 
 		const {
@@ -90,7 +91,8 @@ export default connect( ( state, ownProps ) => {
 		rawPrice: getPlanRawPrice( state, planProductId /**, get from abtest **/ ),
 		planConstantObj: plansList[ ownProps.plan ],
 		billingTimeFrame: get( planObject, 'bill_period_label', '' ),
-		planObject: planObject
+		planObject: planObject,
+		isPlaceholder: get( ownProps, 'placeholder', false )
 	};
 } )( PlanFeatures );
 

--- a/client/my-sites/plan-features/placeholder.jsx
+++ b/client/my-sites/plan-features/placeholder.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function PlanFeaturesPlaceholder() {
+	return (
+		<div className="plan-features is-placeholder" >
+			<div className="plan-features__header is-placeholder">
+				<div className="plan-features__header-figure is-placeholder"></div>
+				<div className="plan-features__header-text is-placeholder">
+					<h4 className="plan-features__header-title is-placeholder"></h4>
+					<h4 className="plan-features__header-price is-placeholder"></h4>
+					<p className="plan-features__header-timeframe is-placeholder"></p>
+				</div>
+			</div>
+			<ul className="plan-features__item-list is-placeholder">
+				<li className="plan-features__item is-placeholder">
+					<div className="plan-features__item-text-placeholder"></div>
+				</li>
+				<li className="plan-features__item is-placeholder">
+					<div className="plan-features__item-text-placeholder"></div>
+				</li>
+				<li className="plan-features__item is-placeholder">
+					<div className="plan-features__item-text-placeholder"></div>
+				</li>
+				<li className="plan-features__item is-placeholder">
+					<div className="plan-features__item-text-placeholder"></div>
+				</li>
+				<li className="plan-features__item is-placeholder">
+					<div className="plan-features__item-text-placeholder"></div>
+				</li>
+				<li className="plan-features__item is-placeholder">
+					<div className="plan-features__item-text-placeholder"></div>
+				</li>
+			</ul>
+			<footer className="plan-features__footer is-placeholder">
+				<p className="plan-features__footer-desc is-placeholder"></p>
+				<div className="plan-features__footer-buttons is-placeholder">
+					<div className="plan-features__footer-button is-placeholder"></div>
+				</div>
+			</footer>
+		</div>
+	);
+}
+

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -44,6 +44,11 @@ $plan-features-header-banner-height: 20px;
 	margin-right: 12px;
 	border: solid 6px $gray-light;
 	border-radius: 50%;
+
+	&.is-placeholder {
+		@include placeholder( 23% );
+	}
+
 }
 
 .plan-features__header-checkmark {
@@ -64,6 +69,16 @@ $plan-features-header-banner-height: 20px;
 .plan-features__header-timeframe {
 	line-height: 1;
 	margin: 0;
+
+	&.is-placeholder {
+		@include placeholder( 23% );
+		width: 60px;
+		margin-bottom: 15px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
 }
 
 .plan-features__header-title {
@@ -143,6 +158,10 @@ $plan-features-header-banner-height: 20px;
 		border-bottom: none;
 	}
 
+	&.is-placeholder {
+		padding-left: 1px;
+	}
+
 	@include breakpoint( "<480px" ) {
 		margin: 0 16px;
 	}
@@ -154,6 +173,10 @@ $plan-features-header-banner-height: 20px;
 	top: 50%;
 	transform: translateY(-50%);
 	fill: $blue-wordpress;
+}
+
+.plan-features__item-text-placeholder {
+	@include placeholder( 23% );
 }
 
 .plan-features__footer {
@@ -170,6 +193,12 @@ $plan-features-header-banner-height: 20px;
 	margin: 0;
 	font-size: 14px;
 	color: $gray;
+
+	&.is-placeholder {
+		@include placeholder( 23% );
+		height: 50px;
+		margin-top: 5px;
+	}
 }
 
 .plan-features__footer-buttons {
@@ -195,6 +224,10 @@ $plan-features-header-banner-height: 20px;
 			fill: $alert-green;
 			margin-right: 8px;
 		}
+	}
+
+	&.is-placeholder {
+		@include placeholder( 23% );
 	}
 
 	@media


### PR DESCRIPTION
In our current plans page implementation, the `Plan` component has a placeholder for case when data is still loading and is not available. In this PR, I've designed similar placeholder for our new `PlanFeatures` component.

I've taken different approach than in `Plan` component placeholder. While the placeholder in `Plan` is displayed in many places (such as `PlanHeader`, `PlanActions`, etc), I've decided to create a new component called `PlanFeaturesPlaceholder` which has almost identical structure to `PlanFeatures` so that `PlanFeatures` can be simply swapped with `PlanFeaturesPlaceholder` when the need arises.

## Screenshot

![selection_049](https://cloud.githubusercontent.com/assets/4988512/16266823/07cbcbfa-3887-11e6-8454-2af3b4ecc121.jpg)

## Usage

```js

import PlanFeatures from 'my-sites/plan-features';

<PlanFeatures isPlaceholder={ true } />

```

## Testing instructions

It's not straightforward to test this in its current form. Ideally, we would test it with `PlansFeaturesMain` component #6119 as we could simply simulate no network and see the placeholders instead of the plans there. Currently, we can test it on devdocs page (broken at the moment: #6205 — just remove `<PostCard>` from `devdocs/design/app-components`).

The steps on how to test this are depicted on the screenshot below:

![selection_048](https://cloud.githubusercontent.com/assets/4988512/16266948/a068ebd6-3887-11e6-9349-6c1d82652318.jpg)

## Other notes

Is the placeholder's design good? I tried to follow the structure of `PlanFeatures` as much as possible. Maybe this will need a design review?

cc @gwwar @mtias @artpi @rralian 

Test live: https://calypso.live/?branch=add/plan-features-placeholder