### PR TITLE
GuidedTours: fix mobile positioning for first step

### DIFF
--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -45,7 +45,7 @@ const dialogPositioners = {
 		y: MASTERBAR_HEIGHT / 2 + DIALOG_HEIGHT / 2,
 	} ),
 	right: () => ( {
-		x: document.documentElement.clientWidth - DIALOG_WIDTH - ( 3 * DIALOG_PADDING ),
+		x: Math.max( 0, document.documentElement.clientWidth - DIALOG_WIDTH - ( 3 * DIALOG_PADDING ) ),
 		y: MASTERBAR_HEIGHT + 16,
 	} ),
 };
@@ -59,7 +59,7 @@ export const posToCss = ( { x, y } ) => ( {
 } );
 
 export function targetForSlug( targetSlug ) {
-	return query( '[data-tip-target="' + targetSlug + '"]' )[0];
+	return query( '[data-tip-target="' + targetSlug + '"]' )[ 0 ];
 }
 
 export function getValidatedArrowPosition( { targetSlug, arrow, stepPos } ) {
@@ -110,7 +110,7 @@ function validatePlacement( placement, target ) {
 		return 'middle';
 	}
 
-	return ( placement !== 'center' && viewport.isMobile() )
+	return ( target && placement !== 'center' && viewport.isMobile() )
 		? 'below'
 		: placement;
 }


### PR DESCRIPTION
The positioning of the first GuidedTours step on mobile devices has been off for some time, to the point that it isn't visible anymore because its `top` coordinate would place it below the sidebar. 

This was initially introduced to make steps bound to a target and with positionings such as `right` display properly on mobile (there is no "right of the sidebar" on mobile, since it fills the whole screen), but wasn't intended for the initial step that has no target. 

This PR fixes that issue.

Test live: https://calypso.live/?branch=fix/guided-tours-mobile-positioning-first-step