### PR TITLE
Themes: Remove clickable appearance from feature tags list

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -278,7 +278,7 @@
 	li {
 		list-style: none;
 		display: inline-block;
-		background: #E9EFF3;
+		// background: lighten( $gray, 30% ); // To be restored once made clickable
 		color: $gray-dark;
 		font-size: 0.925em;
 		margin: 0.38em 0.37rem;


### PR DESCRIPTION
Simple clone of the one-line change in #5702 to solve conflicts easily. Props @mendezcode. 

This is a temporary style change until we implement search for tags. 

Before:

![screen shot 2016-06-22 at 13 50 53](https://cloud.githubusercontent.com/assets/4389/16267197/5bd4caaa-3880-11e6-910d-c425bcb9773e.png)


After:

![screen shot 2016-06-22 at 13 50 42](https://cloud.githubusercontent.com/assets/4389/16267194/553b1cda-3880-11e6-8a8d-c467c8fb1904.png)


Test live: https://calypso.live/?branch=update/themes/sheet-removel-tags-clickable-appearance