### PR TITLE
Reader Cold Start: pass post down to post preview rather than using selector

### DIFF
--- a/client/reader/start/card-header.jsx
+++ b/client/reader/start/card-header.jsx
@@ -1,11 +1,9 @@
 // External dependencies
 import React from 'react';
-import { connect } from 'react-redux';
 import { numberFormat } from 'i18n-calypso';
 
 // Internal dependencies
 import SiteIcon from 'components/site-icon';
-import { getSite } from 'state/reader/sites/selectors';
 import FollowButton from 'reader/follow-button';
 
 const StartCardHeader = ( { site } ) => {
@@ -29,13 +27,7 @@ const StartCardHeader = ( { site } ) => {
 };
 
 StartCardHeader.propTypes = {
-	siteId: React.PropTypes.number.isRequired
+	site: React.PropTypes.object.isRequired
 };
 
-export default connect(
-	( state, ownProps ) => {
-		return {
-			site: getSite( state, ownProps.siteId )
-		};
-	}
-)( StartCardHeader );
+export default StartCardHeader;

--- a/client/reader/start/card.jsx
+++ b/client/reader/start/card.jsx
@@ -13,6 +13,7 @@ import StartCardHeader from './card-header';
 import { recordRecommendationInteraction } from 'state/reader/start/actions';
 import { getRecommendationById } from 'state/reader/start/selectors';
 import { getPostBySiteAndId } from 'state/reader/posts/selectors';
+import { getSite } from 'state/reader/sites/selectors';
 import { recordTrack, recordTrackForPost, recordTracksRailcarInteract } from 'reader/stats';
 
 const debug = debugModule( 'calypso:reader:start' ); //eslint-disable-line no-unused-vars
@@ -39,20 +40,20 @@ const StartCard = React.createClass( {
 	},
 
 	render() {
-		const { siteId, postId, post } = this.props;
-
+		const { post, site } = this.props;
+		const hasPost = !! post;
 		const cardClasses = classnames(
 			'reader-start-card',
 			{
-				'has-post-preview': ( postId > 0 ),
-				'is-photo': post && post.excerpt.length < 1
+				'has-post-preview': hasPost,
+				'is-photo': hasPost && post.excerpt.length < 1
 			}
 		);
 
 		return (
 			<Card className={ cardClasses } onClick={ this.onCardInteraction }>
-				<StartCardHeader siteId={ siteId } />
-				{ postId > 0 && <StartPostPreview siteId={ siteId } postId={ postId } /> }
+				<StartCardHeader site={ site } />
+				{ hasPost && <StartPostPreview post={ post } /> }
 			</Card>
 		);
 	}
@@ -67,14 +68,13 @@ export default connect(
 		const recommendation = getRecommendationById( state, ownProps.recommendationId );
 		const siteId = get( recommendation, 'recommended_site_ID' );
 		const postId = get( recommendation, 'recommended_post_ID' );
-
+		const site = siteId ? getSite( state, siteId ) : undefined;
 		const post = postId ? getPostBySiteAndId( state, siteId, postId ) : undefined;
 
 		return {
 			recommendation,
-			siteId,
-			postId,
-			post
+			post,
+			site
 		};
 	},
 	( dispatch ) => bindActionCreators( {

--- a/client/reader/start/post-preview.jsx
+++ b/client/reader/start/post-preview.jsx
@@ -1,6 +1,5 @@
 // External dependencies
 import React from 'react';
-import { connect } from 'react-redux';
 import get from 'lodash/get';
 import classNames from 'classnames';
 
@@ -8,7 +7,6 @@ import classNames from 'classnames';
 import Gravatar from 'components/gravatar';
 import PostExcerpt from 'components/post-excerpt';
 import page from 'page';
-import { getPostBySiteAndId } from 'state/reader/posts/selectors';
 import safeImageUrl from 'lib/safe-image-url';
 import resizeImageUrl from 'lib/resize-image-url';
 
@@ -70,14 +68,7 @@ const StartPostPreview = React.createClass( {
 } );
 
 StartPostPreview.propTypes = {
-	siteId: React.PropTypes.number.isRequired,
-	postId: React.PropTypes.number.isRequired
+	post: React.PropTypes.object.isRequired
 };
 
-export default connect(
-	( state, ownProps ) => {
-		return {
-			post: getPostBySiteAndId( state, ownProps.siteId, ownProps.postId )
-		};
-	}
-)( StartPostPreview );
+export default StartPostPreview;


### PR DESCRIPTION
When loading cards in Cold Start, we're having an intermittent issue where the featured post does not load:

![4691df4e-37d0-11e6-87a6-af0cc03bb4bd](https://cloud.githubusercontent.com/assets/17325/16267722/2bd93d06-3883-11e6-8c03-930d61d09ba4.png)

As we're already loading the post in the card component, this PR passes the post object down to the post preview component, rather than just handing it the post ID.

Fingers crossed, this should solve the missing featured post. I'm unable to reproduce locally so don't know for certain.

Fixes #6181.

Test live: https://calypso.live/?branch=fix/reader/cold-start-post-preview-not-displaying-safari