### PR TITLE
Jetpack Connect: Disable the submit button if a site is already connected, focus the URL field

### DIFF
--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -18,6 +18,18 @@ import untrailingslashit from 'lib/route/untrailingslashit';
 export default React.createClass( {
 	displayName: 'JetpackConnectSiteURLInput',
 
+	componentDidUpdate() {
+		if ( ! this.props.isError ) {
+			return;
+		}
+
+		if ( ! this.refs.siteUrl.refs.textField ) {
+			return;
+		}
+
+		this.refs.siteUrl.refs.textField.focus();
+	},
+
 	getInitialState() {
 		return {
 			value: ''
@@ -78,6 +90,7 @@ export default React.createClass( {
 						size={ 24 }
 						icon="globe" />
 					<FormTextInput
+						ref="siteUrl"
 						onChange={ this.onChange }
 						disabled={ this.props.isFetching }
 						placeholder={ this.translate( 'http://www.yoursite.com' ) }
@@ -89,7 +102,7 @@ export default React.createClass( {
 				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }
 					<Button primary
-						disabled={ ( ! this.state.value || this.props.isFetching ) }
+						disabled={ ( ! this.state.value || this.props.isFetching || 'alreadyOwned' === this.props.isError ) }
 						onClick={ this.props.onClick }>{ this.renderButtonLabel() }</Button>
 				</Card>
 			</div>

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -91,6 +91,7 @@ export default React.createClass( {
 						icon="globe" />
 					<FormTextInput
 						ref="siteUrl"
+						autoFocus="autofocus"
 						onChange={ this.onChange }
 						disabled={ this.props.isFetching }
 						placeholder={ this.translate( 'http://www.yoursite.com' ) }

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -82,6 +82,7 @@ export default React.createClass( {
 	},
 
 	render() {
+		const hasError = this.props.isError && ( 'notExists' !== this.props.isError );
 		return (
 			<div>
 				<FormLabel>{ this.translate( 'Site Address' ) }</FormLabel>
@@ -103,7 +104,7 @@ export default React.createClass( {
 				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }
 					<Button primary
-						disabled={ ( ! this.state.value || this.props.isFetching || 'alreadyOwned' === this.props.isError ) }
+						disabled={ ( ! this.state.value || this.props.isFetching || hasError ) }
 						onClick={ this.props.onClick }>{ this.renderButtonLabel() }</Button>
 				</Card>
 			</div>


### PR DESCRIPTION
Currently you can "submit" a connected site over and over, because the button is still enabled even when we know the site exists. This PR disables the button when a site is already connected, and puts focus into the URL field when the page loads/after an error.

**To test**

1. Visit wordpress.com/jetpack/connect
2. Keyboard focus should be in the URL field
3. Enter the URL of an already-connected site
4. See "Your site is already connected!"
5. The submit button is disabled, and your focus is back in the URL field.

**accessibility note:** Using the HTML attribute `autofocus` allows users to disable the behaviour, so screen reader users shouldn't be pulled into a no-context zone.

Fixes #5496, #5492

cc @johnHackworth @roccotripaldi @rickybanister 

Test live: https://calypso.live/?branch=update/connect-siteurl-field