### PR TITLE
GuidedTours: fix sidebar scrolling to work on both desktop and mobile

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -13,7 +13,7 @@ import scrollTo from 'lib/scroll-to';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
 import { errorNotice } from 'state/notices/actions';
-import { query } from './positioning';
+import { getScrollableSidebar, query } from './positioning';
 import {
 	BasicStep,
 	FirstStep,
@@ -91,7 +91,7 @@ class GuidedTours extends Component {
 
 	quit( options = {} ) {
 		// TODO: put into step specific callback?
-		const sidebar = query( '#secondary .sidebar .sidebar__region' )[ 0 ];
+		const sidebar = getScrollableSidebar();
 		scrollTo( { y: 0, container: sidebar } );
 
 		this.currentTarget && this.currentTarget.classList.remove( 'guided-tours__overlay' );

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -103,6 +103,13 @@ export function getStepPosition( { placement = 'center', targetSlug } ) {
 	};
 }
 
+export function getScrollableSidebar() {
+	if ( viewport.isMobile() ) {
+		return query( '#secondary .sidebar' )[ 0 ];
+	}
+	return query( '#secondary .sidebar .sidebar__region' )[ 0 ];
+}
+
 function validatePlacement( placement, target ) {
 	const targetSlug = target && target.dataset && target.dataset.tipTarget;
 
@@ -122,16 +129,15 @@ function scrollIntoView( target ) {
 		return 0;
 	}
 
+	const container = getScrollableSidebar();
 	const { top, bottom } = target.getBoundingClientRect();
+	const clientHeight = viewport.isMobile() ? document.documentElement.clientHeight : container.clientHeight;
 
-	if ( bottom + DIALOG_PADDING + DIALOG_HEIGHT <=
-			document.documentElement.clientHeight ) {
+	if ( bottom + DIALOG_PADDING + DIALOG_HEIGHT <= clientHeight ) {
 		return 0;
 	}
 
-	const container = query( '#secondary .sidebar .sidebar__region' )[ 0 ];
-	const scrollMax = container.scrollHeight -
-		container.clientHeight - container.scrollTop;
+	const scrollMax = container.scrollHeight - clientHeight - container.scrollTop;
 	const y = Math.min( .75 * top, scrollMax );
 
 	scrollTo( { y, container } );


### PR DESCRIPTION
#5737 introduced sidebar regions, which broke the scrolling of the sidebar in GuidedTours. The fix for that assumed that the container to scroll would be the same for both mobile and desktop, but it's not. This change fixes scrolling so that it works on both desktop and mobile. 

To test: check the `main` tour starting from http://calypso.localhost:3000/?tour=main and check that all steps are properly visible with a normal desktop resolution (wide, Themes menu item visible); a short desktop resolution (desktop width, but not tall enough to have Themes menu item in sidebar visible); and a mobile phone resolution (sidebar takes up all of the screen, tour needs to scroll to Themes menu item).

Test live: https://calypso.live/?branch=fix/guided-tours-sidebar-scrolling-mobile-desktop