### PR TITLE
CPT: Convert terms state to use TermQueryManager

### DIFF
--- a/client/state/terms/schema.js
+++ b/client/state/terms/schema.js
@@ -1,51 +1,15 @@
-export const termsSchema = {
-	type: 'object',
-	patternProperties: {
-		'^\\d+$': {
-			type: 'object',
-			patternProperties: {
-				'^[A-Za-z0-9-_]+$': {
-					type: 'object',
-					patternProperties: {
-						'^\\d+$': {
-							type: 'object',
-							required: [ 'ID', 'name' ],
-							properties: {
-								ID: { type: 'number' },
-								name: { type: 'string' },
-								slug: { type: 'string' },
-								description: { type: 'string' },
-								post_count: { type: 'number' },
-								parent: { type: 'number' }
-							}
-						}
-					},
-					additionalProperties: false
-				}
-			},
-			additionalProperties: false
-		}
-	},
-	additionalProperties: false
-};
-
 export const queriesSchema = {
 	type: 'object',
 	patternProperties: {
+		// Site ID
 		'^\\d+$': {
 			type: 'object',
 			patternProperties: {
+				// Taxonomy
 				'^[A-Za-z0-9-_]+$': {
-					type: 'object',
-					patternProperties: {
-						'^\\{[^\\}]*\\}$': {
-							type: 'array',
-							items: {
-								type: 'number'
-							}
-						}
-					},
-					additionalProperties: false
+					// Serialized TermQueryManager is a JSON string
+					type: 'string',
+					pattern: '^\\{.*\\}$'
 				}
 			},
 			additionalProperties: false

--- a/client/state/terms/test/utils.js
+++ b/client/state/terms/test/utils.js
@@ -8,23 +8,10 @@ import { expect } from 'chai';
  */
 import {
 	getNormalizedTermsQuery,
-	getSerializedTermsQuery,
-	getSerializedTermsQueryWithoutPage
+	getSerializedTermsQuery
 } from '../utils';
 
 describe( 'utils', () => {
-	describe( 'getSerializedTermsQueryWithoutPage()', () => {
-		it( 'should exclude page and default values', () => {
-			const query = getSerializedTermsQueryWithoutPage( {
-				page: 2,
-				number: 100,
-				search: 'ribs'
-			} );
-
-			expect( query ).to.eql( '{"search":"ribs"}' );
-		} );
-	} );
-
 	describe( 'getNormalizedTermsQuery()', () => {
 		it( 'should exclude default values', () => {
 			const query = getNormalizedTermsQuery( {

--- a/client/state/terms/utils.js
+++ b/client/state/terms/utils.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import omitBy from 'lodash/omitBy';
-import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
@@ -30,15 +29,4 @@ export function getNormalizedTermsQuery( query ) {
 export function getSerializedTermsQuery( query = {} ) {
 	const normalizedQuery = getNormalizedTermsQuery( query );
 	return JSON.stringify( normalizedQuery ).toLocaleLowerCase();
-}
-
-/**
- * Returns a serialized terms query, excluding any page parameter, used as the
- * key in the `state.terms.queriesLastPage` state object.
- *
- * @param  {Object} query  Terms query
- * @return {String}        Serialized terms query
- */
-export function getSerializedTermsQueryWithoutPage( query ) {
-	return getSerializedTermsQuery( omit( query, 'page' ) );
 }


### PR DESCRIPTION
Related: #6022, #5135

This pull request seeks to convert the `state.terms` state to using `TermQueryManager`. See the [`QueryManager` README](https://github.com/Automattic/wp-calypso/blob/master/client/lib/query-manager/README.md) for more information and background on why query manager exists.

__Testing instructions:__

Ensure that Mocha tests pass:

```
npm run test-client client/state/terms
```

To my knowledge, terms state is not actively used anywhere in the Calypso UI.

__Open questions:__

Is `queries` an accurate name for the `terms` subkey? Since we want it to track items generally, regardless of whether associated with a query. What would be an alternative?

/cc @timmyc 

Test live: https://calypso.live/?branch=update/state-terms-query-manager