### PR TITLE
Theme Sheet: Discern Sections when tracking page views

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
+import titlecase from 'to-title-case';
 
 /**
  * Internal dependencies
@@ -313,8 +314,8 @@ const ThemeSheet = React.createClass( {
 		const priceElement = <span className="themes__sheet-action-bar-cost">{ this.props.price }</span>;
 		const siteID = this.props.selectedSite && this.props.selectedSite.ID;
 
-		const analyticsPath = `/theme/:slug${ section ? '/:section' : '' }${ siteID ? '/:site_id' : '' }`;
-		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > Section' : '' }${ siteID ? ' > Site' : '' }`;
+		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
+		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
 		return (
 			<Main className="themes__sheet">


### PR DESCRIPTION
Supposed to fix #6225

To test:
* In the console: type `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* Land on a theme details page (try directly, and via a theme's 'Details' link). Verify that an event like `Recording Page View ~ [URL: /themes/owari/:slug] [Title: Themes > Details Sheet]` is tracked.
* Verify that when switching 'Tabs' (Overview, Setup, Support), the tab name and slug are properly tracked by the page view event. 

cc @folletto 

Test live: https://calypso.live/?branch=update/theme-track-section-in-page-view