### PR TITLE
Lib: Add tests for preventWidows module

### DIFF
--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -1,14 +1,14 @@
 /**
  * External Dependencies
  */
-var trim = require( 'lodash/trim' ),
-	warn = require( 'lib/warn' ),
-	stripTags = require( 'striptags' );
+import trim from 'lodash/trim';
+import stripTags from 'striptags';
 
 /**
  * Internal Dependencies
  */
-var decode = require( './decode-entities' );
+import warn from 'lib/warn';
+import decode from './decode-entities';
 
 function decodeEntities( text ) {
 	if ( text === undefined || text === false || text === null ) {
@@ -28,7 +28,7 @@ function decodeEntities( text ) {
  */
 function interpose( separator, list ) {
 	return list.reduce( function( previousValue, currentValue, index ) {
-		var value;
+		let value;
 		if ( index > 0 ) {
 			value = previousValue.concat( separator, currentValue );
 		} else {
@@ -54,7 +54,7 @@ function stripHTML( string ) {
  * @return {string}             the widow-prevented string
  */
 function preventWidows( text, wordsToKeep = 2 ) {
-	var words, endWords;
+	let words, endWords;
 
 	if ( typeof text !== 'string' ) {
 		return text;
@@ -92,11 +92,12 @@ function preventWidows( text, wordsToKeep = 2 ) {
  * @return {string}        html string with HTML paragraphs instead of double line-breaks
  */
 function wpautop( pee ) {
-	var preserve_linebreaks = false,
-		preserve_br = false,
-		blocklist = 'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
+	const blocklist = 'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
 		'|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section' +
 		'|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary';
+
+	let preserve_linebreaks = false,
+		preserve_br = false;
 
 	if ( pee.indexOf( '<object' ) !== -1 ) {
 		pee = pee.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
@@ -174,10 +175,11 @@ function wpautop( pee ) {
 }
 
 function removep( html ) {
-	var blocklist = 'blockquote|ul|ol|li|table|thead|tbody|tfoot|tr|th|td|h[1-6]|fieldset',
-		blocklist1 = blocklist + '|div|p',
-		blocklist2 = blocklist + '|pre',
-		preserve_linebreaks = false,
+	const blocklist = 'blockquote|ul|ol|li|table|thead|tbody|tfoot|tr|th|td|h[1-6]|fieldset';
+	const blocklist1 = blocklist + '|div|p';
+	const blocklist2 = blocklist + '|pre';
+
+	let preserve_linebreaks = false,
 		preserve_br = false;
 
 	if ( ! html ) {

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -53,7 +53,7 @@ function stripHTML( string ) {
  * @param  {number} wordsToKeep the number of words to keep together
  * @return {string}             the widow-prevented string
  */
-function preventWidows( text, wordsToKeep ) {
+function preventWidows( text, wordsToKeep = 2 ) {
 	var words, endWords;
 
 	if ( typeof text !== 'string' ) {
@@ -66,8 +66,7 @@ function preventWidows( text, wordsToKeep ) {
 	}
 
 	words = text.match( /\S+/g );
-
-	if ( ! words ) { // all whitespace
+	if ( ! words || 1 === words.length ) {
 		return text;
 	}
 

--- a/client/lib/formatting/test/index.js
+++ b/client/lib/formatting/test/index.js
@@ -10,7 +10,7 @@ import useFakeDom from 'test/helpers/use-fake-dom';
 import decodeEntitiesNode from '../decode-entities/node';
 
 describe( 'formatting', () => {
-	let formatting, capitalPDangit, parseHtml, decodeEntitiesBrowser;
+	let formatting, capitalPDangit, parseHtml, decodeEntitiesBrowser, preventWidows;
 
 	useFakeDom();
 
@@ -19,6 +19,7 @@ describe( 'formatting', () => {
 		capitalPDangit = formatting.capitalPDangit;
 		parseHtml = formatting.parseHtml;
 		decodeEntitiesBrowser = require( '../decode-entities/browser' );
+		preventWidows = formatting.preventWidows;
 	} );
 
 	describe( '#capitalPDangit()', function() {
@@ -123,6 +124,56 @@ describe( 'formatting', () => {
 					chai.assert.equal( decoded, 'Ribs > Chicken. Truth & Liars.' );
 				} );
 			} );
+		} );
+	} );
+
+	describe( '#preventWidows()', () => {
+		it( 'should not modify input if type is not string', () => {
+			let types = [
+				{},
+				undefined,
+				1,
+				true,
+				[],
+				function() {}
+			];
+
+			types.forEach( ( type ) => {
+				chai.assert.equal( preventWidows( type ), type );
+			} );
+		} );
+
+		it( 'should return empty string when input is all whitespace', () => {
+			let inputs = [
+				' ',
+				'\t',
+				'\n'
+			];
+
+			inputs.forEach( ( input ) => {
+				chai.assert.equal( preventWidows( input ), '' );
+			} );
+		} );
+
+		it( 'should return input when only one word', () => {
+			chai.assert.equal( preventWidows( 'test' ), 'test' );
+		} );
+
+		it( 'should trim whitespace', () => {
+			chai.assert.equal( preventWidows( 'test ' ), 'test' );
+			chai.assert.equal( preventWidows( '\ntest string ' ), 'test\xA0string' );
+		} );
+
+		it( 'should add non-breaking space between words to keep', () => {
+			const input = 'I really love BBQ. It is one of my favorite foods. Beef ribs are amazing.';
+			chai.assert.equal(
+				preventWidows( input ),
+				'I really love BBQ. It is one of my favorite foods. Beef ribs are\xA0amazing.'
+			);
+			chai.assert.equal(
+				preventWidows( input, 4 ),
+				'I really love BBQ. It is one of my favorite foods. Beef\xA0ribs\xA0are\xA0amazing.'
+			);
 		} );
 	} );
 } );

--- a/client/lib/formatting/test/index.js
+++ b/client/lib/formatting/test/index.js
@@ -24,7 +24,7 @@ describe( 'formatting', () => {
 
 	describe( '#capitalPDangit()', function() {
 		it( 'should error when input is not a string', function() {
-			var types = [
+			const types = [
 				{},
 				undefined,
 				1,
@@ -41,7 +41,7 @@ describe( 'formatting', () => {
 		} );
 
 		it( 'should not modify wordpress', function() {
-			var strings = [ 'wordpress', 'I love wordpress' ];
+			const strings = [ 'wordpress', 'I love wordpress' ];
 
 			strings.forEach( function( string ) {
 				chai.assert.equal( capitalPDangit( string ), string );
@@ -56,12 +56,12 @@ describe( 'formatting', () => {
 		it( 'should replace all instances of Wordpress', function() {
 			chai.assert.equal( capitalPDangit( 'Wordpress Wordpress' ), 'WordPress WordPress' );
 			chai.assert.equal( capitalPDangit( 'I love Wordpress and Wordpress loves me' ), 'I love WordPress and WordPress loves me' );
-		} )
+		} );
 	} );
 
 	describe( '#parseHtml()', function() {
 		it( 'should equal to null when input is not a string', function() {
-			var types = [
+			const types = [
 				{},
 				undefined,
 				1,
@@ -76,28 +76,29 @@ describe( 'formatting', () => {
 		} );
 
 		it( 'should return a DOM element if you pass in DOM element', function() {
-			let div = document.createElement( 'div' );
+			const div = document.createElement( 'div' );
 			chai.assert.equal( div, parseHtml( div ) );
 		} );
 
 		it( 'should return a document fragment if we pass in a string', function() {
-			let fragment = parseHtml( 'hello' );
+			const fragment = parseHtml( 'hello' );
 			chai.assert.isFunction( fragment.querySelector );
 			chai.assert.equal( fragment.querySelectorAll( '*' ).length, 0 );
 		} );
+
 		it( 'should return a document fragment if we pass in a HTML string', function() {
-			let fragment = parseHtml( '<div>hello</div>' );
+			const fragment = parseHtml( '<div>hello</div>' );
 			chai.assert.equal( fragment.querySelectorAll( 'div' ).length, 1 );
 		} );
 
 		it( 'should parseHtml and return document fragment that can be queried', function() {
-			var strings = [
+			const strings = [
 				'<span><a href="stuff">hello world</a></span>',
 				'<div><span></span><a href="stuff">hello world</a></div>'
 			];
 
 			strings.forEach( function( string ) {
-				var link = parseHtml( string ).querySelectorAll( 'a' );
+				const link = parseHtml( string ).querySelectorAll( 'a' );
 				chai.assert.equal( link[ 0 ].innerHTML, 'hello world' );
 			} );
 		} );
@@ -129,7 +130,7 @@ describe( 'formatting', () => {
 
 	describe( '#preventWidows()', () => {
 		it( 'should not modify input if type is not string', () => {
-			let types = [
+			const types = [
 				{},
 				undefined,
 				1,
@@ -144,7 +145,7 @@ describe( 'formatting', () => {
 		} );
 
 		it( 'should return empty string when input is all whitespace', () => {
-			let inputs = [
+			const inputs = [
 				' ',
 				'\t',
 				'\n'


### PR DESCRIPTION
@rickybanister asked that I look into applying the `preventWidows` module more broadly across Calypso. In preparation for that, I looked at the module and noticed there weren't yet unit tests. This PR adds some.

You can see my changes in the first commit: 9834533d4ee590ae0d6bc4245abdf131b7552864. The second commit contains ESLint fixes.

I changed two things functionally:

1) We now default `wordsToKeep` to `2`. In my testing, if `wordsToKeep` was `undefined` we made it to the last line of the function and there was extra whitespace. A default of `2` seems appropriate that way there are at least two words on the last line.

2) If there is only one word, we just return that word (after being trimmed).

To test:

- Checkout `update/formatting-unit-tests` branch
- Make sure tests pass
- While logged out, go to `/start`
- Ensure that you can't get a widow/orphan element in the step header text

cc @blowery for review as it seems he worked on this prior to OSS release. Also cc @lezama.

Test live: https://calypso.live/?branch=update/formatting-unit-tests