### PR TITLE
Themes: make sure the welcome modal closes on navigation

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -50,7 +50,10 @@ const ThanksModal = React.createClass( {
 	},
 
 	onLinkClick( link ) {
-		return this.trackClick.bind( null, link, 'click' );
+		return () => {
+			this.onCloseModal();
+			this.trackClick.call( null, link, 'click' );
+		};
 	},
 
 	renderWpcomInfo() {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -52,7 +52,7 @@ const ThanksModal = React.createClass( {
 	onLinkClick( link ) {
 		return () => {
 			this.onCloseModal();
-			this.trackClick.call( null, link, 'click' );
+			this.trackClick( link, 'click' );
 		};
 	},
 


### PR DESCRIPTION
Current issue:

![cap-](https://cloud.githubusercontent.com/assets/4389/16276608/045e3276-38a7-11e6-8fb3-f223aa910978.gif)

This PR moves the close action to every click in the dialog.

### To Test

* Open theme listing → https://calypso.live/design?branch=fix/themes/activation-welcome-not-closing
* Click ••• and Activate
* Click on "see awesome features"
* The dialog should close while the page navigates
