### PR TITLE
Invites: Remove take a tour messaging from notice after accept

### DIFF
--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -2,12 +2,12 @@
  * Internal dependencies
  */
 import React from 'react';
-import get from 'lodash/get'
+import get from 'lodash/get';
 import i18n from 'i18n-calypso';
 
 export default {
 	acceptedNotice( invite, displayOnNextPage = true ) {
-		let site = (
+		const site = (
 			<a href={ get( invite, 'site.URL' ) } className="invite-accept__notice-site-link">
 				{ get( invite, 'site.title' ) }
 			</a>
@@ -123,7 +123,7 @@ export default {
 			switch ( invite.role ) {
 				case 'viewer':
 				case 'follower':
-					return get( invite, 'site.URL' ) || readerPath
+					return get( invite, 'site.URL' ) || readerPath;
 					break;
 				default:
 					return get( invite, 'site.admin_url' ) || postsListPath;

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -7,16 +7,6 @@ import i18n from 'i18n-calypso';
 
 export default {
 	acceptedNotice( invite, displayOnNextPage = true ) {
-		let takeATour = (
-			<p className="invite-message__intro">
-				{
-					i18n.translate(
-						'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-						{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
-					)
-				}
-			</p>
-		);
 		let site = (
 			<a href={ get( invite, 'site.URL' ) } className="invite-accept__notice-site-link">
 				{ get( invite, 'site.title' ) }
@@ -65,7 +55,6 @@ export default {
 								args: { site: get( invite, 'site.title' ) }
 							} ) }
 						</p>
-						{ takeATour }
 					</div>,
 					{ displayOnNextPage }
 				];
@@ -81,7 +70,6 @@ export default {
 						<p className="invite-message__intro">
 							{ i18n.translate( 'This is your site dashboard where you can publish and manage your own posts and the posts of others, as well as upload media.' ) }
 						</p>
-						{ takeATour }
 					</div>,
 					{ displayOnNextPage }
 				];
@@ -97,7 +85,6 @@ export default {
 						<p className="invite-message__intro">
 							{ i18n.translate( 'This is your site dashboard where you can publish and edit your own posts as well as upload media.' ) }
 						</p>
-						{ takeATour }
 					</div>,
 					{ displayOnNextPage }
 				];
@@ -113,7 +100,6 @@ export default {
 						<p className="invite-message__intro">
 							{ i18n.translate( 'This is your site dashboard where you can write and manage your own posts.' ) }
 						</p>
-						{ takeATour }
 					</div>,
 					{ displayOnNextPage }
 				];


### PR DESCRIPTION
Fixes #5185

After talking to @rickybanister, we decided that we would go ahead and remove the tour messaging in the notice. In a future NUX iteration, we will be updating this notice to something like this:

![screen shot 2016-06-22 at 1 03 49 pm](https://cloud.githubusercontent.com/assets/1126811/16277742/dc0ac2d0-3879-11e6-8e95-3bca6f830a3e.png)

Not covered by this issue, and something I want to fix in a different PR, is moving the notice into another component. Similar to the first screenshot in this PR: #5871.

But, I think the best way to address that is to go ahead and move invites to redux so we have better data persistence after creating new users from invites.

cc @rickybanister for design review and @lezama or @timmyc for code review.

To test: 

- Checkout `update/invites-user-added-notice` branch
- Send an invite for any role other than `follower`
- Accept the invite while logged out, and create a new user
- You should see something like this:
![screen shot 2016-06-22 at 1 09 29 pm](https://cloud.githubusercontent.com/assets/1126811/16277964/b25dbedc-387a-11e6-9160-815a7dc3050c.png)



Test live: https://calypso.live/?branch=update/invites-user-added-notice