### PR TITLE
Reader Cold Start: add updateOnEachImageLoad prop to Masonry

### DIFF
--- a/client/reader/start/main.jsx
+++ b/client/reader/start/main.jsx
@@ -66,7 +66,7 @@ const Start = React.createClass( {
 					<p className="reader-start__description">{ this.translate( "We've suggested some sites that you might enjoy. Follow one or more sites to get started." ) }</p>
 				</header>
 
-				<Masonry className="reader-start__cards" options={ { gutter: 14 } }>
+				<Masonry className="reader-start__cards" updateOnEachImageLoad={ true } options={ { gutter: 14 } }>
 					{ this.props.recommendationIds ? map( this.props.recommendationIds, ( recId ) => {
 						return (
 							<StartCard


### PR DESCRIPTION
This is a proactive attempt to try and fix #6192, but we can't reproduce the bug with today's cards.

To test: make sure that the added prop has no negative effects on the card layout at http://calypso.localhost:3000/read/start.

Test live: https://calypso.live/?branch=add/reader/cold-start-reader-masonry-update-on-image-load