### PR TITLE
Add Browser Notifications AB test

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -19,6 +19,7 @@ var React = require( 'react' ),
  */
 // lib/local-storage must be run before lib/user
 var config = require( 'config' ),
+	abtest = require( 'lib/abtest' ).abtest,
 	switchLocale = require( 'lib/i18n-utils/switch-locale' ),
 	localStoragePolyfill = require( 'lib/local-storage' )(), //eslint-disable-line
 	analytics = require( 'lib/analytics' ),
@@ -205,7 +206,9 @@ function reduxStoreReady( reduxStore ) {
 		reduxStore.dispatch( receiveUser( user.get() ) );
 		reduxStore.dispatch( setCurrentUserId( user.get().ID ) );
 
-		if ( config.isEnabled( 'push-notifications' ) ) {
+
+		const participantInPushNotificationsAbTest = config.isEnabled('push-notifications-ab-test') && abtest('browserNotifications') === 'enabled';
+		if ( config.isEnabled( 'push-notifications' ) || participantInPushNotificationsAbTest ) {
 			// If the browser is capable, registers a service worker & exposes the API
 			reduxStore.dispatch( pushNotificationsInit() );
 		}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -26,6 +26,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	GuidedTours = require( 'layout/guided-tours' ),
 	analytics = require( 'lib/analytics' ),
 	config = require( 'config' ),
+	abtest = require( 'lib/abtest' ).abtest,
 	PulsingDot = require( 'components/pulsing-dot' ),
 	SitesListNotices = require( 'lib/sites-list/notices' ),
 	OfflineStatus = require( 'layout/offline-status' ),
@@ -90,7 +91,8 @@ Layout = React.createClass( {
 	},
 
 	renderPushNotificationPrompt: function() {
-		if ( ! config.isEnabled( 'push-notifications' ) ) {
+		const participantInAbTest = config.isEnabled('push-notifications-ab-test') && abtest('browserNotifications') === 'enabled';
+		if ( ! config.isEnabled( 'push-notifications' ) && ! participantInAbTest ) {
 			return null;
 		}
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -130,4 +130,13 @@ module.exports = {
 		defaultVariation: 'noChanges',
 		allowExistingUsers: false,
 	},
+	browserNotifications: {
+		datestamp: '20160628',
+		variations: {
+			disabled: 95,
+			enabled: 5,
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: true,
+	},
 };

--- a/config/production.json
+++ b/config/production.json
@@ -71,6 +71,7 @@
 		"press-this": true,
 		"preview-layout": true,
 		"preview-endpoint": false,
+		"push-notifications-ab-test": false,
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/tags-with-elasticsearch": false,

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -29,9 +29,6 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		if helmetLink
 			!= helmetLink
 
-		if isPushEnabled
-			link(rel='manifest', href='/calypso/manifest.json')
-
 		link(rel='shortcut icon', type='image/vnd.microsoft.icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')
@@ -48,6 +45,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='152x152', href='//s1.wp.com/i/favicons/apple-touch-icon-152x152.png')
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
+		link(rel='manifest', href='/calypso/manifest.json')
 		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -121,7 +121,6 @@ function getDefaultContext( request ) {
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		devDocsURL: '/devdocs',
 		catchJsErrors: '/calypso/catch-js-errors-' + 'v2' + '.min.js',
-		isPushEnabled: !! config.isEnabled( 'push-notifications' )
 	} );
 
 	context.app = {


### PR DESCRIPTION
This PR seeks to add the necessary configuration to start showing the Browser Notification prompt to 5% of our English speaking users in production, but leave it enabled to all users in staging and development.

Even though the A/B test will start and 5% of our English speaking users will get assigned as participants to the tests, they will not see the prompt until we flip the switch by turning the production config on in a separate PR.

Test live: https://calypso.live/?branch=add/browser-notifications-ab-test