### PR TITLE
Reader: Whitelist kickstarter and facebook embeds

### DIFF
--- a/client/lib/post-normalizer/rule-content-detect-embeds.js
+++ b/client/lib/post-normalizer/rule-content-detect-embeds.js
@@ -31,12 +31,15 @@ export default function detectEmbeds( post, dom ) {
 		'8tracks.com',
 		'spotify.com',
 		'me.sh',
-		'bandcamp.com'
+		'bandcamp.com',
+		'kickstarter.com',
+		'facebook.com'
 	];
 
 	// hosts that we trust that don't work in a sandboxed iframe
 	const iframeNoSandbox = [
-		'spotify.com'
+		'spotify.com',
+		'kickstarter.com'
 	];
 
 	embeds = filter( embeds, function( iframe ) {


### PR DESCRIPTION
This allows them to work as intended when embedded in the reader.

Test live: https://calypso.live/?branch=fix/reader/whitelist-facebook-kickstarter-embeds