### PR TITLE
Jetpack Plans: Fix confirmation dialog when leaving the plugins install screen

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -91,7 +91,6 @@ const PlansSetup = React.createClass( {
 			if ( ! confirmText ) {
 				return next();
 			}
-			console.log( 'We\'re still installing...' );
 			if ( window.confirm( confirmText ) ) { // eslint-disable-line no-aler
 				next();
 			} else {

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-// import classNames from 'classnames';
+import page from 'page';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import filter from 'lodash/filter';
@@ -85,6 +85,23 @@ const PlansSetup = React.createClass( {
 		if ( this.props.siteId ) {
 			this.fetchInstallInstructions();
 		}
+
+		page.exit( '/plugins/setup/*', ( context, next ) => {
+			const confirmText = this.warnIfNotFinished( {} );
+			if ( ! confirmText ) {
+				return next();
+			}
+			console.log( 'We\'re still installing...' );
+			if ( window.confirm( confirmText ) ) { // eslint-disable-line no-aler
+				next();
+			} else {
+				// save off the current path just in case context changes after this call
+				const currentPath = context.canonicalPath;
+				setTimeout( function() {
+					page.replace( currentPath, null, false, false );
+				}, 0 );
+			}
+		} );
 	},
 
 	componentWillUnmount() {

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -110,10 +110,13 @@ const PlansSetup = React.createClass( {
 	},
 
 	warnIfNotFinished( event ) {
-		if ( this.props.isFinished ) {
-			return;
-		}
-		if ( ! this.props.selectedSite.canManage() ) {
+		const site = this.props.selectedSite;
+		if ( ! site ||
+			! site.jetpack ||
+			! site.canUpdateFiles ||
+			! site.canManage() ||
+			this.props.isFinished
+		) {
 			return;
 		}
 		const beforeUnloadText = this.translate( 'We haven\'t finished installing your plugins.' );
@@ -122,14 +125,14 @@ const PlansSetup = React.createClass( {
 	},
 
 	startNextPlugin( plugin ) {
-		let install = this.props.installPlugin;
-		let site = this.props.selectedSite;
+		const install = this.props.installPlugin;
+		const site = this.props.selectedSite;
 
 		// Merge wporg info into the plugin object
 		plugin = Object.assign( {}, plugin, getPlugin( this.props.wporg, plugin.slug ) );
 
 		const getPluginFromStore = function() {
-			let sitePlugin = PluginsStore.getSitePlugin( site, plugin.slug );
+			const sitePlugin = PluginsStore.getSitePlugin( site, plugin.slug );
 			if ( ! sitePlugin && PluginsStore.isFetchingSite( site ) ) {
 				// if the Plugins are still being fetched, we wait. We are not using flux
 				// store events because it would be more messy to handle the one-time-only


### PR DESCRIPTION
This adds better checks for whether we're currently installing plugins, so that the confirmation dialog fires at appropriate times. This also adds a confirmation dialog when navigating to another calypso route.

To test:

1. Start the plugins install & configuration process at /plugins/setup/$site
2. While the process is running, click Reader
3. You're alerted "We haven't finished installing your plugins.", so you can "cancel" and continue installing, or hit "OK" to navigate away.

You can also test this with WordPress.com sites, sites with no write access, etc, and you **should not** see a confirmation dialog when closing the tab.

**Note:** Chrome, Firefox, and Safari [no longer respect the custom text](https://developers.google.com/web/updates/2016/04/chrome-51-deprecations?hl=en#remove-custom-messages-in-onbeforeload-dialogs) returned in the `beforeunload` event, so the text seen when closing the tab is not the same as navigating away in calypso.

Fixes #5908 

cc @johnHackworth @rickybanister @roccotripaldi 

Test live: https://calypso.live/?branch=fix/jetpack-plugins-confirmation