### PR TITLE
Lib: Use require statements for formatting module

### DIFF
--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -1,14 +1,14 @@
 /**
  * External Dependencies
  */
-import trim from 'lodash/trim';
-import stripTags from 'striptags';
+const trim = require( 'lodash/trim' ),
+	stripTags = require( 'striptags' );
 
 /**
  * Internal Dependencies
  */
-import warn from 'lib/warn';
-import decode from './decode-entities';
+const warn = require( 'lib/warn' ),
+	decode = require( './decode-entities' );
 
 function decodeEntities( text ) {
 	if ( text === undefined || text === false || text === null ) {


### PR DESCRIPTION
In [this comment](https://github.com/Automattic/wp-calypso/pull/6228#issuecomment-227856082), @blowery mentioned that he was seeing some errors that he believes to be related to using `import` statements in the `formatting` module.

To test:

- Checkout `update/lib-formatting-use-require` branch
- Run tests
- Make sure there are no errors where module is used, such as `/start`

Test live: https://calypso.live/?branch=update/lib-formatting-use-require