### PR TITLE
State: Post normalization consistency / cleanup

### DIFF
--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -23,7 +23,6 @@ import {
 	getSitePostsForQuery
 } from 'state/posts/selectors';
 import { getPostStat } from 'state/stats/posts/selectors';
-import { decodeEntities } from 'lib/formatting';
 
 const StatsPostPerformance = React.createClass( {
 
@@ -93,7 +92,7 @@ const StatsPostPerformance = React.createClass( {
 			if ( ! post.title ) {
 				postTitle = this.translate( '(no title)' );
 			} else {
-				postTitle = decodeEntities( post.title );
+				postTitle = post.title;
 			}
 		}
 

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -34,15 +34,16 @@ export function getPost( state, globalId ) {
 }
 
 /**
- * Returns a normalized post object by its global ID.
+ * Returns a normalized post object by its global ID, or null if the post does
+ * not exist.
  *
- * @param  {Object} state    Global state tree
- * @param  {String} globalId Post global ID
- * @return {Object}          Post object
+ * @param  {Object}  state    Global state tree
+ * @param  {String}  globalId Post global ID
+ * @return {?Object}          Post object
  */
 export const getNormalizedPost = createSelector(
 	( () => {
-		// Cache normalize flow in immediately-invoked closure so to avoid
+		// Cache normalize flow in immediately-invoked closure to avoid
 		// regenerating same flow on each call to this selector
 		const normalize = flow( [
 			firstPassCanonicalImage,
@@ -50,7 +51,14 @@ export const getNormalizedPost = createSelector(
 			stripHtml
 		] );
 
-		return ( state, globalId ) => normalize( cloneDeep( getPost( state, globalId ) ) );
+		return ( state, globalId ) => {
+			const post = getPost( state, globalId );
+			if ( ! post ) {
+				return null;
+			}
+
+			return normalize( cloneDeep( post ) );
+		};
 	} )(),
 	( state ) => state.posts.items
 );

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -35,7 +35,8 @@ export function getPost( state, globalId ) {
 
 /**
  * Returns a normalized post object by its global ID, or null if the post does
- * not exist.
+ * not exist. A normalized post includes common transformations to prepare the
+ * post for display.
  *
  * @param  {Object}  state    Global state tree
  * @param  {String}  globalId Post global ID
@@ -89,8 +90,10 @@ export const getSitePost = createSelector(
 );
 
 /**
- * Returns an array of posts for the posts query, or null if no posts have been
- * received.
+ * Returns an array of normalized posts for the posts query, or null if no
+ * posts have been received.
+ *
+ * @see getNormalizedPost
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
@@ -183,8 +186,10 @@ export function isSitePostsLastPageForQuery( state, siteId, query = {} ) {
 }
 
 /**
- * Returns an array of posts for the posts query, including all known
- * queried pages, or null if the number of pages is unknown.
+ * Returns an array of normalized posts for the posts query, including all
+ * known queried pages, or null if the posts for the query are not known.
+ *
+ * @see getNormalizedPost
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
@@ -208,9 +213,12 @@ export function getSitePostsForQueryIgnoringPage( state, siteId, query ) {
 }
 
 /**
- * Returns an array of posts for the posts query, including all known queried
- * pages, preserving hierarchy. Returns null if no posts have been received.
- * Hierarchy is represented by `parent` and `items` properties on each post.
+ * Returns an array of normalized posts for the posts query, including all
+ * known queried pages, preserving hierarchy. Returns null if no posts have
+ * been received. Hierarchy is represented by `parent` and `items` properties
+ * on each post.
+ *
+ * @see getNormalizedPost
  *
  * @param  {Object} state  Global state tree
  * @param  {Number} siteId Site ID

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -98,11 +98,17 @@ export const getSitePost = createSelector(
  * @return {?Array}         Posts for the post query
  */
 export function getSitePostsForQuery( state, siteId, query ) {
-	if ( ! state.posts.queries[ siteId ] ) {
+	const manager = state.posts.queries[ siteId ];
+	if ( ! manager ) {
 		return null;
 	}
 
-	return state.posts.queries[ siteId ].getItems( query );
+	const posts = manager.getItems( query );
+	if ( ! posts ) {
+		return null;
+	}
+
+	return posts.map( ( post ) => getNormalizedPost( state, post.global_ID ) );
 }
 
 /**

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -146,31 +146,49 @@ describe( 'selectors', () => {
 				posts: {
 					queries: {}
 				}
-			}, 2916284, { search: 'Hello' } );
+			}, 2916284, { search: 'Ribs' } );
 
 			expect( sitePosts ).to.be.null;
 		} );
 
-		it( 'should return an array of the known queried posts', () => {
+		it( 'should return null if the query is not tracked to the query manager', () => {
 			const sitePosts = getSitePostsForQuery( {
 				posts: {
 					queries: {
 						2916284: new PostQueryManager( {
+							items: {},
+							queries: {}
+						} )
+					}
+				}
+			}, 2916284, { search: 'Ribs' } );
+
+			expect( sitePosts ).to.be.null;
+		} );
+
+		it( 'should return an array of normalized known queried posts', () => {
+			const sitePosts = getSitePostsForQuery( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs &amp; Chicken' }
+					},
+					queries: {
+						2916284: new PostQueryManager( {
 							items: {
-								841: { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+								841: { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs &amp; Chicken' }
 							},
 							queries: {
-								'[["search","Hello"]]': {
+								'[["search","Ribs"]]': {
 									itemKeys: [ 841 ]
 								}
 							}
 						} )
 					}
 				}
-			}, 2916284, { search: 'Hello' } );
+			}, 2916284, { search: 'Ribs' } );
 
 			expect( sitePosts ).to.eql( [
-				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs & Chicken' }
 			] );
 		} );
 	} );

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -48,6 +48,16 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getNormalizedPost()', () => {
+		it( 'should return null if the post is not tracked', () => {
+			const normalizedPost = getNormalizedPost( {
+				posts: {
+					items: {}
+				}
+			}, '3d097cb7c5473c169bba0eb8e3c6cb64' );
+
+			expect( normalizedPost ).to.be.null;
+		} );
+
 		it( 'should return a normalized copy of the post', () => {
 			const post = {
 				ID: 841,

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -43,6 +44,42 @@ describe( 'selectors', () => {
 			}, '3d097cb7c5473c169bba0eb8e3c6cb64' );
 
 			expect( post ).to.eql( { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' } );
+		} );
+	} );
+
+	describe( 'getNormalizedPost()', () => {
+		it( 'should return a normalized copy of the post', () => {
+			const post = {
+				ID: 841,
+				site_ID: 2916284,
+				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+				title: 'Ribs &amp; Chicken',
+				author: {
+					name: 'Badman <img onerror= />'
+				},
+				featured_image: 'https://example.com/logo.png'
+			};
+
+			const normalizedPost = getNormalizedPost( deepFreeze( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': post
+					}
+				}
+			} ), '3d097cb7c5473c169bba0eb8e3c6cb64' );
+
+			expect( normalizedPost ).to.not.equal( post );
+			expect( normalizedPost ).to.eql( {
+				...post,
+				title: 'Ribs & Chicken',
+				author: {
+					name: 'Badman '
+				},
+				canonical_image: {
+					type: 'image',
+					uri: 'https://example.com/logo.png'
+				}
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
Related: #4936

This pull request seeks to perform some cleanup and bug fixes around post normalization. Specifically:

- `getNormalizedPost` will result in an error when called if the post is not tracked
- `getNormalizedPost` did not have any associated tests
- `getSitePostsForQuery` will result in an error if called when a query is tracked for the site (i.e. `PostQueryManager` initialized), but not the query specified as the argument
- `getSitePostsForQuery` did not previously return normalized posts, while `getSitePostsForQueryIgnoringPage` did
- `<StatsPostPerformance />` no longer needs to manually decode entities after updates to `getSitePostsForQuery`

__Testing instructions:__

Ensure Mocha tests pass:

```
npm run test-client client/state/posts/test/selectors.js
```

Ensure that "Latest Post Summary" on [Stats Insights Screen](http://calypso.localhost:3000/stats/insights) still displays the latest post with its title's entities decoded.

__Follow-up tasks:__

- We should probably memoize `getSitePostsForQuery` and `getSitePostsForQueryIgnoringPage`
- The posts queries reducer is [mutating state when receiving items for a query](https://github.com/Automattic/wp-calypso/blob/a52caa351c9c434b5f6879790d2d26d31c883ea5/client/state/posts/reducer.js#L145). This should be resolved.

/cc @mtias @timmyc @youknowriad 

Test live: https://calypso.live/?branch=update/post-normalize-consistency