### PR TITLE
Fix Desktop Build Failure

### DIFF
--- a/config/client.json
+++ b/config/client.json
@@ -28,5 +28,6 @@
   "discover_blog_id",
   "support-user",
   "sync-handler-defaults",
-  "email_verification_gate"
+  "email_verification_gate",
+  "project"
 ]


### PR DESCRIPTION
Right now the Desktop app is failing to build.

![image](https://cloud.githubusercontent.com/assets/437043/16284196/e22c853a-3884-11e6-8c22-bce3201d461a.png)

The issue is this PR(https://github.com/Automattic/wp-calypso/pull/5487)and specifically this line(https://github.com/Automattic/wp-calypso/pull/5487/files#diff-81243a1c2b5d87c4c614a9ee048b7614R5). Adding the `project` key to `config/clients.json` fixes the issue.

To test this checkout desktop and point calypso to this branch and run the project. If no error message appears and the desktop app starts normally you are good to go.

cc @gziolo @mkaz @ockham 

Test live: https://calypso.live/?branch=fix/desktop-build-failing