### PR TITLE
Themes: aligning theme list dot-dot-dot options popover menu

### DIFF
--- a/client/my-sites/themes/action-labels.js
+++ b/client/my-sites/themes/action-labels.js
@@ -31,7 +31,11 @@ export default {
 	},
 	customize: {
 		label: i18n.translate( 'Customize' ),
-		header: i18n.translate( 'Customize on:', { comment: 'label for selecting a site for which to customize a theme' } ),
+		header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a site for which to customize a theme' } ),
+	},
+	tryandcustomize: {
+		label: i18n.translate( 'Try & Customize' ),
+		header: i18n.translate( 'Try & Customize on:', { comment: 'label in the dialog for opening the Customizer with the theme in preview' } ),
 	},
 	details: {
 		label: i18n.translate( 'Details' ),

--- a/client/my-sites/themes/action-labels.js
+++ b/client/my-sites/themes/action-labels.js
@@ -7,13 +7,13 @@ import i18n from 'i18n-calypso';
 
 export default {
 	signup: {
-		label: i18n.translate( 'Choose this design', {
+		label: i18n.translate( 'Pick this design', {
 			comment: 'when signing up for a WordPress.com account with a selected theme'
 		} )
 	},
 	preview: {
-		label: i18n.translate( 'Preview', {
-			context: 'verb'
+		label: i18n.translate( 'Live Demo', {
+			comment: 'label for previewing the theme demo website'
 		} )
 	},
 	purchase: {
@@ -38,5 +38,8 @@ export default {
 	},
 	support: {
 		label: i18n.translate( 'Setup' ),
+	},
+	help: {
+		label: i18n.translate( 'Support' ),
 	},
 };

--- a/client/my-sites/themes/action-labels.js
+++ b/client/my-sites/themes/action-labels.js
@@ -12,7 +12,7 @@ export default {
 		} )
 	},
 	preview: {
-		label: i18n.translate( 'Live Demo', {
+		label: i18n.translate( 'Live demo', {
 			comment: 'label for previewing the theme demo website'
 		} )
 	},

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -79,6 +79,19 @@ export function getForumUrl( theme ) {
 	return isPremium( theme ) ? '//premium-themes.forums.wordpress.com/forum/' + theme.id : '//en.forums.wordpress.com/forum/themes';
 }
 
+export function getHelpUrl( theme, site ) {
+	if ( site && site.jetpack ) {
+		return getSupportUrl( theme, site );
+	}
+
+	let baseUrl = oldShowcaseUrl + theme.id;
+	if ( config.isEnabled( 'manage/themes/details' ) ) {
+		baseUrl = `/theme/${ theme.id }/support`;
+	}
+
+	return baseUrl + ( site ? `/${ site.slug }` : '' );
+}
+
 export function getExternalThemesUrl( site ) {
 	if ( ! site ) {
 		return oldShowcaseUrl;

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -13,7 +13,7 @@ import Main from 'components/main';
 import { signup } from 'state/themes/actions' ;
 import ThemePreview from './theme-preview';
 import ThemesSelection from './themes-selection';
-import { getSignupUrl, getDetailsUrl, getSupportUrl, isPremium, addTracking } from './helpers';
+import { getSignupUrl, getDetailsUrl, getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -49,6 +49,9 @@ const ThemesLoggedOut = React.createClass( {
 				getUrl: theme => getSupportUrl( theme ),
 				// Free themes don't have support docs.
 				hideForTheme: theme => ! isPremium( theme )
+			},
+			help: {
+				getUrl: theme => getHelpUrl( theme )
 			},
 		};
 		return merge( {}, buttonOptions, actionLabels );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -10,7 +10,11 @@ import merge from 'lodash/merge';
  * Internal dependencies
  */
 import Main from 'components/main';
-import { customize, purchase, activate } from 'state/themes/actions';
+import {
+	customize as tryandcustomize,
+	purchase,
+	activate
+} from 'state/themes/actions';
 import ThemePreview from './theme-preview';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
@@ -143,7 +147,7 @@ export default connect(
 	} ),
 	{
 		activate,
-		tryandcustomize: customize,
+		tryandcustomize,
 		purchase
 	}
 )( ThemesMultiSite );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -48,6 +48,10 @@ const ThemesMultiSite = React.createClass( {
 
 	getButtonOptions() {
 		const buttonOptions = {
+			customize: {
+				action: theme => this.showSiteSelectorModal( 'customize', theme ),
+				hideForTheme: theme => ! theme.active
+			},
 			preview: {
 				action: theme => this.togglePreview( theme ),
 				hideForTheme: theme => theme.active
@@ -62,9 +66,9 @@ const ThemesMultiSite = React.createClass( {
 				action: theme => this.showSiteSelectorModal( 'activate', theme ),
 				hideForTheme: theme => theme.active || ( theme.price && ! theme.purchased )
 			},
-			customize: {
+			tryandcustomize: {
 				action: theme => this.showSiteSelectorModal( 'customize', theme ),
-				hideForTheme: theme => ! theme.active
+				hideForTheme: theme => theme.active
 			},
 			separator: {
 				separator: true

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -15,7 +15,7 @@ import ThemePreview from './theme-preview';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import ThemesSelection from './themes-selection';
-import { getDetailsUrl, getSupportUrl, isPremium, addTracking } from './helpers';
+import { getDetailsUrl, getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -76,6 +76,9 @@ const ThemesMultiSite = React.createClass( {
 				getUrl: theme => getSupportUrl( theme ),
 				// Free themes don't have support docs.
 				hideForTheme: theme => ! isPremium( theme )
+			},
+			help: {
+				getUrl: theme => getHelpUrl( theme )
 			},
 		};
 		return merge( {}, buttonOptions, actionLabels );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -48,27 +48,21 @@ const ThemesMultiSite = React.createClass( {
 
 	getButtonOptions() {
 		const buttonOptions = {
-			customize: {
-				action: theme => this.showSiteSelectorModal( 'customize', theme ),
-				hideForTheme: theme => ! theme.active
-			},
 			preview: {
 				action: theme => this.togglePreview( theme ),
-				hideForTheme: theme => theme.active
 			},
 			purchase: config.isEnabled( 'upgrades/checkout' )
 				? {
 					action: theme => this.showSiteSelectorModal( 'purchase', theme ),
-					hideForTheme: theme => theme.active || theme.purchased || ! theme.price
+					hideForTheme: theme => ! theme.price
 				}
 				: {},
 			activate: {
 				action: theme => this.showSiteSelectorModal( 'activate', theme ),
-				hideForTheme: theme => theme.active || ( theme.price && ! theme.purchased )
+				hideForTheme: theme => theme.price
 			},
 			tryandcustomize: {
-				action: theme => this.showSiteSelectorModal( 'customize', theme ),
-				hideForTheme: theme => theme.active
+				action: theme => this.showSiteSelectorModal( 'tryandcustomize', theme ),
 			},
 			separator: {
 				separator: true
@@ -91,7 +85,7 @@ const ThemesMultiSite = React.createClass( {
 	onPreviewButtonClick( theme ) {
 		this.setState( { showPreview: false },
 			() => {
-				this.getButtonOptions().customize.action( theme );
+				this.getButtonOptions().tryandcustomize.action( theme );
 			} );
 	},
 
@@ -149,7 +143,7 @@ export default connect(
 	} ),
 	{
 		activate,
-		customize,
+		tryandcustomize: customize,
 		purchase
 	}
 )( ThemesMultiSite );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -62,6 +62,12 @@ const ThemesSingleSite = React.createClass( {
 	getButtonOptions() {
 		const site = sites.getSelectedSite(),
 			buttonOptions = {
+				customize: site && site.isCustomizable()
+					? {
+						action: this.props.customize,
+						hideForTheme: theme => ! theme.active
+					}
+					: {},
 				preview: {
 					action: theme => this.togglePreview( theme ),
 					hideForTheme: theme => theme.active
@@ -76,12 +82,6 @@ const ThemesSingleSite = React.createClass( {
 					action: this.props.activate,
 					hideForTheme: theme => theme.active || ( theme.price && ! theme.purchased )
 				},
-				customize: site && site.isCustomizable()
-					? {
-						action: this.props.customize,
-						hideForTheme: theme => ! theme.active
-					}
-					: {},
 				separator: {
 					separator: true
 				},

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -21,7 +21,7 @@ import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import ThemesSelection from './themes-selection';
-import { getDetailsUrl, getSupportUrl, isPremium, addTracking } from './helpers';
+import { getDetailsUrl, getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 import sitesFactory from 'lib/sites-list';
@@ -92,6 +92,11 @@ const ThemesSingleSite = React.createClass( {
 					? {
 						getUrl: theme => getSupportUrl( theme, site ),
 						hideForTheme: theme => ! isPremium( theme )
+					}
+					: {},
+				help: ! site.jetpack // We don't know where support docs for a given theme on a self-hosted WP install are.
+					? {
+						getUrl: theme => getHelpUrl( theme, site )
 					}
 					: {},
 			};

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -98,7 +98,7 @@ const ThemesSingleSite = React.createClass( {
 						hideForTheme: theme => ! isPremium( theme )
 					}
 					: {},
-				help: ! site.jetpack // We don't know where support docs for a given theme on a self-hosted WP install are.
+				help: ! site.jetpack // We don't know where support forums for a given theme on a self-hosted WP install are.
 					? {
 						getUrl: theme => getHelpUrl( theme, site )
 					}

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -82,6 +82,10 @@ const ThemesSingleSite = React.createClass( {
 					action: this.props.activate,
 					hideForTheme: theme => theme.active || ( theme.price && ! theme.purchased )
 				},
+				tryandcustomize: {
+					action: theme => this.props.customize( theme ),
+					hideForTheme: theme => theme.active
+				},
 				separator: {
 					separator: true
 				},


### PR DESCRIPTION
Before:

![screen shot 2016-06-22 at 22 26 56](https://cloud.githubusercontent.com/assets/4389/16284314/82c8e7de-38c8-11e6-8690-cf23ff6e2b49.png)


After:

![screen shot 2016-06-22 at 23 14 18](https://cloud.githubusercontent.com/assets/4389/16285607/0f9e6fa2-38cf-11e6-91b6-6ee7c44cc7bd.png)



### To test

* Open `/design`
* Open the ••• menu on any theme
* Check that all the links open the proper page

Test live: https://calypso.live/?branch=update/themes/dotdotdot-popover-menu-alignment