### PR TITLE
Theme Sheet: Remove /overview slug for default section

### DIFF
--- a/client/my-sites/theme/index.node.js
+++ b/client/my-sites/theme/index.node.js
@@ -7,6 +7,6 @@ import { details, fetchThemeDetailsData } from './controller';
 
 export default function( router ) {
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		router( '/theme/:slug/:section?/:site_id?', fetchThemeDetailsData, details, makeLayout );
+		router( '/theme/:slug/:section(setup|support)?/:site_id?', fetchThemeDetailsData, details, makeLayout );
 	}
 }

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -8,6 +8,6 @@ import { siteSelection } from 'my-sites/controller';
 
 export default function( router ) {
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		router( '/theme/:slug/:section?/:site_id?', siteSelection, fetchThemeDetailsData, details, makeLayout );
+		router( '/theme/:slug/:section(setup|support)?/:site_id?', siteSelection, fetchThemeDetailsData, details, makeLayout );
 	}
 }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -64,7 +64,7 @@ const ThemeSheet = React.createClass( {
 
 	getDefaultProps() {
 		return {
-			section: 'overview',
+			section: '',
 		};
 	},
 
@@ -116,7 +116,7 @@ const ThemeSheet = React.createClass( {
 
 	getValidSections() {
 		const validSections = [];
-		validSections.push( 'overview' );
+		validSections.push( '' ); // Default section
 		this.props.supportDocumentation && validSections.push( 'setup' );
 		validSections.push( 'support' );
 		return validSections;
@@ -161,7 +161,7 @@ const ThemeSheet = React.createClass( {
 
 	renderSectionNav( currentSection ) {
 		const filterStrings = {
-			overview: i18n.translate( 'Overview', { context: 'Filter label for theme content' } ),
+			'': i18n.translate( 'Overview', { context: 'Filter label for theme content' } ),
 			setup: i18n.translate( 'Setup', { context: 'Filter label for theme content' } ),
 			support: i18n.translate( 'Support', { context: 'Filter label for theme content' } ),
 		};
@@ -173,7 +173,7 @@ const ThemeSheet = React.createClass( {
 			<NavTabs label="Details" >
 				{ this.getValidSections().map( ( section ) => (
 					<NavItem key={ section }
-						path={ `/theme/${ id }/${ section }${ sitePart }` }
+						path={ `/theme/${ id }${ section ? '/' + section : '' }${ sitePart }` }
 						selected={ section === currentSection }>
 						{ filterStrings[ section ] }
 					</NavItem>
@@ -190,7 +190,7 @@ const ThemeSheet = React.createClass( {
 
 	renderSectionContent( section ) {
 		return {
-			overview: this.renderOverviewTab(),
+			'': this.renderOverviewTab(),
 			setup: this.renderSetupTab(),
 			support: this.renderSupportTab(),
 		}[ section ];
@@ -331,7 +331,7 @@ const ThemeSheet = React.createClass( {
 					selectedTheme={ this.props }
 					onHide={ this.hideSiteSelectorModal }
 					action={ this.props[ this.state.selectedAction ] }
-					sourcePath={ `/theme/${ this.props.id }/${ section }` }
+					sourcePath={ `/theme/${ this.props.id }${ section ? '/' + section : '' }` }
 				/> }
 				{ this.state.showPreview && this.renderPreview() }
 				<HeaderCake className="themes__sheet-action-bar"

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -55,7 +55,7 @@ export function getDetailsUrl( theme, site ) {
 
 	let baseUrl = oldShowcaseUrl + theme.id;
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		baseUrl = `/theme/${ theme.id }/overview`;
+		baseUrl = `/theme/${ theme.id }`;
 	}
 
 	return baseUrl + ( site ? `/${ site.slug }` : '' );


### PR DESCRIPTION
Enable access to the theme sheet's default section by just going to `/theme/themename` instead of `/theme/themename/overview`. This is done by changing some object keys and array items to `''`, and by modifying our route handlers to explicitly specify possible section names. This way, validation is done by the route handler, and it won't take `sitename` in a URL like `/theme/themename/sitename` for a section.

If in the latter example `sidename` is invalid, `my-sites`’s `siteSelection` middleware will take care of that and set the selected site to null (i.e. all sites), which is communicated to the theme sheet via the `getSelectedSite` selector.

This leads to the following behavior for invalid slugs:
* /theme/mood/gsafa displays the 'Overview' section in multi-site mode
* /theme/mood/support/ghfgsg displays the 'Support' section in multi-site mode (when activating/purchasing, site selector is shown)
* /theme/mood/fdjshdrg/hrgefqw 404s

Note that `validateSections` is only needed for one edge case now that's not already filtered by the route, and that is a request for the 'Setup' section for a theme that doesn't have one (i.e. a free one, e.g. `/theme/twentysixteen/setup`). (The route handler can't do that for us since at routing stage, we don' know yet if a theme is free or premium.) 

To test -- verify the above claims, and that activation/purchase always work as expected. Also verify that showcase navigation still works as it should ('...' menu items 'Details' and 'Support' still functional?)

Fixes #6216 

Test live: https://calypso.live/?branch=update/theme-drop-overview-slug