### PR TITLE
Personal Plan: disable A/B Testing

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -70,7 +70,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": true,
+		"plans/personal-plan": false,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -63,7 +63,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": true,
+		"plans/personal-plan": false,
 		"post-editor/author-selector": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -69,7 +69,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": true,
+		"plans/personal-plan": false,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,7 +87,7 @@
 		"olark": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/personal-plan": true,
+		"plans/personal-plan": false,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -78,7 +78,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": true,
+		"plans/personal-plan": false,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,


### PR DESCRIPTION
Disables the personal plan test on all environments except development.

cc: @apeatling @roundhill 

Test live: https://calypso.live/?branch=fix/stop-personal-plan-test