### PR TITLE
Plugins Page: Localize the wpcom plugin page info header

### DIFF
--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import { localize } from 'i18n-calypso';
 
 export const InfoHeader = React.createClass( {
 	render() {

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -17,7 +17,10 @@ export const InfoHeader = React.createClass( {
 			<Notice
 				status="is-info"
 				showDismiss={ false }
-				text={ translate( 'Your site comes pre-installed with a wide variety of plugins. Uploading your own plugins is not available on WordPress.com.' ) }
+				text={ translate(
+					'Your site comes pre-installed with a wide variety of plugins. ' +
+					'Uploading your own plugins is not available on WordPress.com.'
+				) }
 			>
 				<NoticeAction href="https://en.support.wordpress.com/plugins/" external={ true }>
 					{ translate( 'Learn More' ) }

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -1,22 +1,30 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import { localize } from 'i18n-calypso';
 
 export const InfoHeader = React.createClass( {
 	render() {
+		const { translate } = this.props;
 		return (
 			<Notice
 				status="is-info"
 				showDismiss={ false }
-				text={ "Your site comes pre-installed with a wide variety of plugins. Uploading your own plugins is not available on WordPress.com." }
+				text={ translate( 'Your site comes pre-installed with a wide variety of plugins. Uploading your own plugins is not available on WordPress.com.' ) }
 			>
 				<NoticeAction href="https://en.support.wordpress.com/plugins/" external={ true }>
-					{ "Learn More" }
+					{ translate( 'Learn More' ) }
 				</NoticeAction>
 			</Notice>
 		);
 	}
 } );
 
-export default InfoHeader;
+export default localize( InfoHeader );


### PR DESCRIPTION
While browsing in another language, I noticed the plugins page info header isn't translated:

![screen shot 2016-06-23 at 10 10 24 am](https://cloud.githubusercontent.com/assets/416133/16288068/934af1fc-392b-11e6-837b-d88b627ebf21.png)

This PR wraps the text with `translate`

Test live: https://calypso.live/?branch=fix/localize-plugins-page-notice

cc @deBhal 