### PR TITLE
Reader: Update left margin on followed sites option

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -316,7 +316,7 @@
 	color: $gray-dark;
 
 	&.is-compact {
-		padding: 10px 0;
+		padding: 10px 16px;
 
 		@include breakpoint( ">660px" ) {
 			padding-left: 105px;


### PR DESCRIPTION
This is a quick PR to address #5878. Currently, the followed sites options have [a `padding-left` of 105px on screen sizes larger than `660px`](https://github.com/Automattic/wp-calypso/blob/master/client/reader/following-edit/style.scss#L322). On small screens though, the options appear directly against the left side of the screen (screenshot below). 

This PR adds a 16px right and left padding to `.following-edit__notification-settings-card .is-compact`, which matches [the absolute positioning of the toggle](https://github.com/Automattic/wp-calypso/blob/master/client/reader/following-edit/style.scss#L345) so everything appears centered (see comparison screenshot). This should only affect small screens since the 660px breakpoint kicks in. Using the padding on the right and left doesn't appear to have any negative effects.

### To test
1. Visit wordpress.com/following/edit on a mobile device
2. Try to edit the following options for one of your sites. Notice everything sites against the left side of the screen.
3. Load up this branch. Visit http://calypso.localhost:3000/following/edit. Use the device toolbar in Chrome to emulate a small screen.
4. Toggle the following options. They should now appear centered.

### Screenshots

Original
<img width="546" alt="original" src="https://cloud.githubusercontent.com/assets/7240478/16291008/7c463280-38bf-11e6-9c1d-6c7b1ee3b131.png">

Updated
<img width="479" alt="updated" src="https://cloud.githubusercontent.com/assets/7240478/16291010/80dc310a-38bf-11e6-8756-b3f30e29d627.png">

Tested across Safari, Firefox, and Chrome at various screen widths.

Test live: https://calypso.live/?branch=fix/5878-followed-sites-options