### PR TITLE
Personal Plan: support for multiple currencies

### DIFF
--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -10,6 +10,7 @@ import some from 'lodash/some';
 import isEmpty from 'lodash/isEmpty';
 import findIndex from 'lodash/findIndex';
 import flow from 'lodash/flow';
+import partialRight from 'lodash/partialRight';
 import matchesProperty from 'lodash/matchesProperty';
 
 /**
@@ -49,6 +50,8 @@ export const personalPlan = {
 
 const getCurrencyCode = plans => head( map( plans, property( 'currency_code' ) ) ) || 'USD';
 
+const hasCurrentPlan = partialRight( some, matchesProperty( 'current_plan', true ) );
+
 const applyCurrency = currencyCode => {
 	const cost = personalPlan.prices[ currencyCode ];
 	const price = formatCurrency( cost, currencyCode );
@@ -86,12 +89,10 @@ export const insertSitePersonalPlan = plans => {
 	} = formatPlan( plans );
 
 	if ( ! ( isEmpty( plans ) || has( plans, product_id ) ) ) {
-		const hasCurrentPlan = some( plans, matchesProperty( 'current_plan', true ) );
-
 		return {
 			...plans,
 			[ product_id ]: {
-				current_plan: ! hasCurrentPlan,
+				current_plan: ! hasCurrentPlan( plans ),
 				currency_code,
 				can_start_trial: true,
 				discount_reason: null,

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -3,19 +3,9 @@
  */
 import moment from 'moment';
 
-/**
- * Internal dependencies
- */
-import { PLAN_PERSONAL } from 'lib/plans/constants';
-import { personalPlan } from 'lib/plans/personal-plan';
-
 const createSitePlanObject = ( plan ) => {
 	if ( ! plan ) {
 		return {};
-	}
-
-	if ( plan.product_slug === PLAN_PERSONAL ) {
-		plan = { ...plan, ...personalPlan };
 	}
 
 	return {


### PR DESCRIPTION
Adds support for multiple currencies to the personal plan, both on the sign up flow and the plan upgrades.

![plans-currencies](https://cloud.githubusercontent.com/assets/233601/16292097/72d5ad0a-38e4-11e6-9d9f-fc8552525242.png)

cc: @apeatling @roundhill @gwwar 

Test live: https://calypso.live/?branch=fix/personal-plan-currencies