### PR TITLE
Products List: Add query data component for Redux

### DIFF
--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isFetching } from 'state/products-list/selectors';
+import { requestProductsList } from 'state/products-list/actions';
+
+class QueryProductsList extends Component {
+	componentWillMount() {
+		if ( ! this.props.isFetching ) {
+			this.props.requestProductsList();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryProductsList.propTypes = {
+	isFetching: PropTypes.bool,
+	requestProductsList: PropTypes.func
+};
+
+export default connect(
+	state => ( { isFetching: isFetching( state ) } ),
+	{ requestProductsList }
+)( QueryProductsList );

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isFetching } from 'state/products-list/selectors';
+import { isProductsListFetching as isFetching } from 'state/products-list/selectors';
 import { requestProductsList } from 'state/products-list/actions';
 
 class QueryProductsList extends Component {

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -26,6 +26,7 @@ import posts from './posts/reducer';
 import postTypes from './post-types/reducer';
 import preferences from './preferences/reducer';
 import preview from './preview/reducer';
+import productsList from './products-list/reducer';
 import pushNotifications from './push-notifications/reducer';
 import purchases from './purchases/reducer';
 import reader from './reader/reducer';
@@ -64,6 +65,7 @@ export const reducer = combineReducers( {
 	preview,
 	posts,
 	postTypes,
+	productsList,
 	purchases,
 	pushNotifications,
 	reader,

--- a/client/state/products-list/reducer.js
+++ b/client/state/products-list/reducer.js
@@ -15,7 +15,7 @@ import { productsListSchema } from './schema';
 import { createReducer } from 'state/utils';
 
 // Stores the complete list of products, indexed by the product key
-export const items = createReducer( null, {
+export const items = createReducer( {}, {
 	[ PRODUCTS_LIST_RECEIVE ]: ( state, action ) => action.productsList,
 }, productsListSchema );
 

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -1,0 +1,3 @@
+export function isFetching( state ) {
+	return state.productsList.isFetching;
+}

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -1,3 +1,3 @@
-export function isFetching( state ) {
+export function isProductsListFetching( state ) {
 	return state.productsList.isFetching;
 }

--- a/client/state/products-list/test/reducer.js
+++ b/client/state/products-list/test/reducer.js
@@ -37,10 +37,10 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#items()', () => {
-		it( 'should default to null', () => {
+		it( 'should default to empty object', () => {
 			const state = items( undefined, {} );
 
-			expect( state ).to.be.null;
+			expect( state ).to.eql( {} );
 		} );
 
 		it( 'should store the product list received', () => {
@@ -57,7 +57,7 @@ describe( 'reducer', () => {
 				}
 			} ];
 
-			const state = items( null, {
+			const state = items( {}, {
 				type: PRODUCTS_LIST_RECEIVE,
 				productsList
 			} );
@@ -109,7 +109,7 @@ describe( 'reducer', () => {
 					}
 				} );
 				const state = items( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( null );
+				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
~~**Review note: Please review only 00eeb8a; the earlier commits are part of #6143**. This PR will be rebased once #6143 makes it to master.~~

This builds on #6143 to add a QueryProductsList component for retrieving the products list where needed.

This change also adds the `productsList` reducer to the root reducer:

![screen shot 2016-06-23 at 5 47 52 pm](https://cloud.githubusercontent.com/assets/416133/16295901/d9c530f2-396c-11e6-9894-cfca9ced57a6.png)


Test live: https://calypso.live/?branch=add/products-list-query-component