### PR TITLE
Stats: Fix empty modules in locales with alternate date formats

### DIFF
--- a/client/lib/stats/stats-list/stats-parser.js
+++ b/client/lib/stats/stats-list/stats-parser.js
@@ -17,7 +17,7 @@ function StatsParser() {
 }
 
 function rangeOfPeriod( period, date ) {
-	date = new i18n.moment( date );
+	date = new i18n.moment( date ).locale( 'en' );
 	var periodRange = { period: period,
 		startOf: date.clone().startOf( period ),
 		endOf: date.clone().endOf( period )

--- a/client/lib/stats/stats-list/stats-parser.js
+++ b/client/lib/stats/stats-list/stats-parser.js
@@ -167,7 +167,7 @@ StatsParser.prototype.statsVisits = function( payload ) {
 		attributes = [ 'visits', 'likes', 'visitors', 'comments', 'posts' ];
 
 	response.data = payload.data.map( function( record ) {
-		var dataRecord = {}, date, dayOfWeek;
+		var dataRecord = {}, date, dayOfWeek, localizedDate;
 
 		record.forEach( function( value, i ) {
 			// Remove W from weeks
@@ -192,16 +192,17 @@ StatsParser.prototype.statsVisits = function( payload ) {
 		dataRecord.classNames = [];
 
 		if ( dataRecord.period ) {
-			date = i18n.moment( dataRecord.period, 'YYYY-MM-DD' );
+			date = i18n.moment( dataRecord.period, 'YYYY-MM-DD' ).locale( 'en' );
+			localizedDate = i18n.moment( dataRecord.period, 'YYYY-MM-DD' );
 			if ( date.isValid() ) {
 				dayOfWeek = date.toDate().getDay();
 				if ( ( 'day' === payload.unit ) && ( ( 6 === dayOfWeek ) || ( 0 === dayOfWeek ) ) ) {
 					dataRecord.classNames.push( 'is-weekend' );
 				}
-				dataRecord.labelDay = date.format( 'MMM D' );
-				dataRecord.labelWeek = date.format( 'MMM D' );
-				dataRecord.labelMonth = date.format( 'MMM' );
-				dataRecord.labelYear = date.format( 'YYYY' );
+				dataRecord.labelDay = localizedDate.format( 'MMM D' );
+				dataRecord.labelWeek = localizedDate.format( 'MMM D' );
+				dataRecord.labelMonth = localizedDate.format( 'MMM' );
+				dataRecord.labelYear = localizedDate.format( 'YYYY' );
 			}
 		}
 

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -351,12 +351,12 @@ module.exports = {
 			}
 			momentSiteZone = i18n.moment().utcOffset( siteOffset );
 			activeFilter = activeFilter.shift();
-			chartDate = rangeOfPeriod( activeFilter.period, momentSiteZone.clone() ).endOf;
+			chartDate = rangeOfPeriod( activeFilter.period, momentSiteZone.clone().locale( 'en' ) ).endOf;
 			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid ) {
-				date = i18n.moment( queryOptions.startDate );
+				date = i18n.moment( queryOptions.startDate ).locale( 'en' );
 				numPeriodAgo = getNumPeriodAgo( momentSiteZone, date, activeFilter.period );
 			} else {
-				date = rangeOfPeriod( activeFilter.period, momentSiteZone.clone() ).startOf;
+				date = rangeOfPeriod( activeFilter.period, momentSiteZone.clone().locale( 'en' ) ).startOf;
 			}
 
 			numPeriodAgo = parseInt( numPeriodAgo, 10 );

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -186,8 +186,8 @@ const PostTrends = React.createClass( {
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const query = {
-		startDate: i18n.moment().subtract( 1, 'year' ).startOf( 'month' ).format( 'YYYY-MM-DD' ),
-		endDate: i18n.moment().endOf( 'month' ).format( 'YYYY-MM-DD' ),
+		startDate: i18n.moment().locale( 'en' ).subtract( 1, 'year' ).startOf( 'month' ).format( 'YYYY-MM-DD' ),
+		endDate: i18n.moment().locale( 'en' ).endOf( 'month' ).format( 'YYYY-MM-DD' ),
 		max: 3000
 	};
 

--- a/client/my-sites/stats/post-trends/week.jsx
+++ b/client/my-sites/stats/post-trends/week.jsx
@@ -32,7 +32,7 @@ export default React.createClass( {
 		const { month, startDate, streakData, max } = this.props;
 
 		for ( let i = 0; i < 7; i++ ) {
-			const dayDate = i18n.moment( startDate ).add( i, 'day' );
+			const dayDate = i18n.moment( startDate ).locale( 'en' ).add( i, 'day' );
 			const postCount = streakData[ dayDate.format( 'YYYY-MM-DD' ) ] || 0;
 			let classNames = [];
 			let level = Math.ceil( ( postCount / max ) * 4 );

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -3,6 +3,11 @@
  */
 import React, { PropTypes } from 'react';
 
+/**
+ * Internal dependencies
+ */
+import userUtils from 'lib/user/utils';
+
 export default React.createClass( {
 	displayName: 'StatsDatePicker',
 
@@ -16,7 +21,8 @@ export default React.createClass( {
 	},
 
 	dateForDisplay() {
-		const date = this.moment( this.props.date );
+		const locale = userUtils.getLocaleSlug();
+		const date = this.moment( this.props.date ).locale( locale );
 		let formattedDate;
 
 		switch ( this.props.period ) {

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -59,7 +59,7 @@ export const getSiteStatsPostStreakData = createSelector(
 
 		if ( streakData && streakData.data ) {
 			Object.keys( streakData.data ).forEach( ( timestamp ) => {
-				const postDay = i18n.moment.unix( timestamp );
+				const postDay = i18n.moment.unix( timestamp ).locale( 'en' );
 				const datestamp = postDay.format( 'YYYY-MM-DD' );
 				if ( 'undefined' === typeof( response[ datestamp ] ) ) {
 					response[ datestamp ] = 0;


### PR DESCRIPTION
TL;DR: Make sure we use the 'en' locale when doing period manipulations on a moment date. The returned date is formatted according to current locale, but then later used to access property names which won't work when localized. `Moment.format()` should only be used for **display** purposes.

The issue flows from

```periodRange = rangeOfPeriod( this.options.period, this.options.date ),
startDate = periodRange.startOf.format( 'YYYY-MM-DD' );```

The above doesn't only change the date format, it also localizes it, assuming momentjs is currently loaded with a locale.

That would be ok for display purposes, but then we do ```payload.days[ startDate ]```  which assumes the date in English. If the locale is in Arabic, `startDate` would be something like `٢٠١٦-٠٦-٢٣`.

The solution presented here is a **workaround**, meant as a quick fix. A better solution would be to make sure we're not using `moment.format()` for anything but display purposes.

cc @timmyc who recently worked on this parts :)

**Test:**
1. Change UI locale to Arabic in your user settings
2. Check your stats and notice modules are populated with data in tis branch, but aren't in master.




Test live: https://calypso.live/?branch=fix/non-latin-dates-stats