### PR TITLE
Plans: Fix upgrade nudge feature passing

### DIFF
--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -91,7 +91,7 @@ export default React.createClass( {
 
 		if ( ! this.props.href && site ) {
 			if ( this.props.feature ) {
-				href = `/plans/compare/${ this.props.feature }/${ site.slug }`;
+				href = `/plans/compare/${ site.slug }?feature=${ this.props.feature }`;
 			} else {
 				href = `/plans/${ site.slug }`;
 			}


### PR DESCRIPTION
Turns out our routes for passing a feature are all over the place and on top of that they are buggy.
In https://github.com/Automattic/wp-calypso/pull/6204 I fixed passing the feature to the component but it turned out that nudge is using a route that has been repurposed

The repurposed `/plans/compare/` route is also used in https://github.com/Automattic/wp-calypso/pull/6119 

I removed `/plans/compare/${ this.props.feature }/` and passed a feature to the query string.

# Testing

http://calypso.localhost:3000/design/$your-free-site

![screen shot 2016-06-23 at 13 05 09 pm](https://cloud.githubusercontent.com/assets/3775068/16301255/c0237dac-3944-11e6-8df0-7437e88591f8.png)

Click, you should get the highlight:

![screen shot 2016-06-23 at 13 05 21 pm](https://cloud.githubusercontent.com/assets/3775068/16301265/d1b3c7de-3944-11e6-8166-96fddd697977.png)

Currently on prod, there will be no highlight

CC @mtias @gwwar @lamosty 




Test live: https://calypso.live/?branch=fix/nudges-feature-passing