### PR TITLE
Purchases: Add disabled state for Save Card button when processing form

### DIFF
--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -48,6 +48,7 @@ const EditCardDetails = React.createClass( {
 	getInitialState() {
 		return {
 			form: null,
+			formSubmitting: false,
 			notice: null
 		};
 	},
@@ -141,8 +142,15 @@ const EditCardDetails = React.createClass( {
 	onSubmit( event ) {
 		event.preventDefault();
 
+		if ( this.state.formSubmitting ) {
+			return;
+		}
+
+		this.setState( { formSubmitting: true } );
+
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			if ( hasErrors ) {
+				this.setState( { formSubmitting: false } );
 				return;
 			}
 
@@ -160,17 +168,20 @@ const EditCardDetails = React.createClass( {
 
 		createPaygateToken( 'card_update', cardDetails, ( paygateError, token ) => {
 			if ( paygateError ) {
+				this.setState( { formSubmitting: false } );
 				notices.error( paygateError.message );
 				return;
 			}
 
 			wpcom.updateCreditCard( this.getParamsForApi( token ), ( apiError, response ) => {
 				if ( apiError ) {
+					this.setState( { formSubmitting: false } );
 					notices.error( apiError.message );
 					return;
 				}
 
 				if ( response.error ) {
+					this.setState( { formSubmitting: false } );
 					notices.error( response.error );
 					return;
 				}
@@ -268,8 +279,12 @@ const EditCardDetails = React.createClass( {
 					<CompactCard className="edit-card-details__footer">
 						<em>{ this.translate( 'All fields required' ) }</em>
 
-						<FormButton type="submit">
-							{ this.translate( 'Save Card', { context: 'Button label', comment: 'Credit card' } ) }
+						<FormButton
+							disabled={ this.state.formSubmitting }
+							type="submit">
+							{ this.state.formSubmitting
+								? this.translate( 'Saving Card…', { context: 'Button label', comment: 'Credit card' } )
+								: this.translate( 'Save Card', { context: 'Button label', comment: 'Credit card' } ) }
 						</FormButton>
 					</CompactCard>
 				</form>


### PR DESCRIPTION
Fixes #221 according to the @fabianapsimoes proposal:

> To begin with, we should make sure to at least disable the button in Edit Payment Details. We can look into a more general solution to improve processing states later on.

### Before
When updating a credit card for a subscription, upon hitting `Save Card`, there's  no indication that anything is happening, leading many users to believe that nothing is happening - leading them to submit several times. 

See below: 
![card-update-interaction](https://cloud.githubusercontent.com/assets/331500/16282891/d7157262-3887-11e6-9c3d-862c40c0fa37.gif)

(note: credit card number used above is not valid)

### After
`Save Card` button gets disabled when form is processing and we update it's text:

![screen shot 2016-06-23 at 13 54 24](https://cloud.githubusercontent.com/assets/699132/16302306/ae98b45c-394a-11e6-8fc1-7354eafb2941.png)

Note: I updated the text to `Saving Card…` to align better with the original wording :)

### Testing
To test it:
1. Go to Manage Purchases page (http://calypso.localhost:3000/purchases.
2. Select a purchase.
3. Click `Edit Payment Method` link.
4. Fill in form and click `Save Card` button.

/cc @fabianapsimoes @peterbutler 
