### PR TITLE
Framework: Return null in stateless function components after React 15

### DIFF
--- a/client/post-editor/editor-forbidden/index.jsx
+++ b/client/post-editor/editor-forbidden/index.jsx
@@ -20,8 +20,7 @@ import Dialog from 'components/dialog';
 
 function EditorForbidden( { translate, userCanEdit, siteSlug } ) {
 	if ( false !== userCanEdit ) {
-		// [TODO]: React 15 supports returning `null` from function components
-		return <noscript />;
+		return null;
 	}
 
 	const buttons = [

--- a/client/post-editor/editor-post-type-unsupported/index.jsx
+++ b/client/post-editor/editor-post-type-unsupported/index.jsx
@@ -35,8 +35,7 @@ function EditorPostTypeUnsupported( { translate, types, type, typeObject, writeP
 	//  2. The type value has been unset from the edited post (navigating away)
 	//  3. Type object provided (indicates that type indeed exists)
 	if ( ! types || ! type || typeObject ) {
-		// [TODO]: React 15 supports returning `null` from function components
-		return <noscript />;
+		return null;
 	}
 
 	const buttons = [


### PR DESCRIPTION
This pull request seeks to replace `<noscript />` tags previously rendered prior to React 15, due to lack of `null` return value from stateless function components.

See changelog note: https://facebook.github.io/react/blog/2016/04/07/react-v15.html#functional-components-can-now-return-null-too

__Testing instructions:__

1. Start Calypso with `DISABLE_FEATURES=persist-redux make run`
2. Navigate to http://calypso.localhost:3000/post
3. In your developer tools console, enter `localStorage.clear()`
4. Navigate directly to http://calypso.localhost:3000/edit/fake-cpt
5. Select a site, if prompted
6. Note that the dialog for unsupported post type doesn't appear immediately due to `null` return of `EditorPostTypeUnsupported`
7. Note that the dialog appears after post types have been loaded

/cc @ockham 

Test live: https://calypso.live/?branch=update/react-15-cleanup