### PR TITLE
Personal Plan: Turn on A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,6 +1,6 @@
 module.exports = {
 	personalPlan: {
-		datestamp: '20160622',
+		datestamp: '20160623', //was 20160622
 		variations: {
 			hide: 50,
 			show: 50

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,6 +1,6 @@
 module.exports = {
 	personalPlan: {
-		datestamp: '20160623', //was 20160622
+		datestamp: '20160623',
 		variations: {
 			hide: 50,
 			show: 50

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -70,7 +70,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": false,
+		"plans/personal-plan": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -63,7 +63,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": false,
+		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -69,7 +69,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": false,
+		"plans/personal-plan": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,7 +87,7 @@
 		"olark": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/personal-plan": false,
+		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -78,7 +78,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": false,
+		"plans/personal-plan": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,


### PR DESCRIPTION
Turns on the Personal Plan test on 2016-06-23 for all environments except desktop.

cc: @apeatling @roundhill 

Test live: https://calypso.live/?branch=update/turn-personal-plan-test-on