### PR TITLE
Sites: fall back to the site domain if the site title only contains spaces

### DIFF
--- a/client/lib/reader-site-store/index.js
+++ b/client/lib/reader-site-store/index.js
@@ -3,7 +3,8 @@
 // External Dependencies
 var Immutable = require( 'immutable' ),
 	omit = require( 'lodash/omit' ),
-	has = require( 'lodash/has' );
+	has = require( 'lodash/has' ),
+	trim = require( 'lodash/trim' );
 
 // Internal Dependencies
 var Dispatcher = require( 'dispatcher' ),
@@ -37,7 +38,7 @@ function adaptSite( attributes ) {
 		attributes.domain = attributes.URL.replace( /^https?:\/\//, '' );
 		attributes.slug = attributes.domain.replace( /\//g, '::' );
 	}
-	attributes.title = attributes.name ? attributes.name : attributes.domain;
+	attributes.title = trim( attributes.name ) || attributes.domain;
 
 	// If a WordPress.com site has a mapped domain create a `wpcom_url`
 	// attribute to allow site selection with either domain.

--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -5,7 +5,8 @@ var debug = require( 'debug' )( 'calypso:site' ),
 	i18n = require( 'i18n-calypso' ),
 	isEqual = require( 'lodash/isEqual' ),
 	find = require( 'lodash/find' ),
-	omit = require( 'lodash/omit' );
+	omit = require( 'lodash/omit' ),
+	trim = require( 'lodash/trim' );
 
 /**
  * Internal dependencies
@@ -96,7 +97,7 @@ Site.prototype.updateComputedAttributes = function() {
 		this.domain = this.URL.replace( /^https?:\/\//, '' );
 		this.slug = this.domain.replace( /\//g, '::' );
 	}
-	this.title = this.name || this.domain;
+	this.title = trim( this.name ) || this.domain;
 
 	// If a WordPress.com site has a mapped domain create a `wpcom_url`
 	// attribute to allow site selection with either domain.

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -4,6 +4,7 @@ import omit from 'lodash/omit';
 import omitBy from 'lodash/omitBy';
 import keyBy from 'lodash/keyBy';
 import map from 'lodash/map';
+import trim from 'lodash/trim';
 
 import {
 	READER_SITE_REQUEST,
@@ -59,7 +60,7 @@ function adaptSite( attributes ) {
 		attributes.domain = attributes.URL.replace( /^https?:\/\//, '' );
 		attributes.slug = attributes.domain.replace( /\//g, '::' );
 	}
-	attributes.title = attributes.name ? attributes.name : attributes.domain;
+	attributes.title = trim( attributes.name ) || attributes.domain;
 
 	// If a WordPress.com site has a mapped domain create a `wpcom_url`
 	// attribute to allow site selection with either domain.


### PR DESCRIPTION
@fraying pointed out that some sites have a single space for a title, e.g.

http://calypso.localhost:3000/read/blogs/94148385

He explained: 

> I think it was because the user uploaded a logo image with the title in it, and the theme didn’t allow them to list a title but not have it show on the page. So they just remove the text in the title field.

Currently, the Site component displays this:

<img width="223" alt="screen shot 2016-06-23 at 15 50 22" src="https://cloud.githubusercontent.com/assets/17325/16307734/47bf226a-395a-11e6-89d9-d8a05c34cd81.png">

This PR changes the site component to fall back to the site domain when the site title isn't available:

<img width="236" alt="screen shot 2016-06-23 at 15 50 27" src="https://cloud.githubusercontent.com/assets/17325/16307725/415bb5c8-395a-11e6-9d4b-b362883c43ae.png">

To test, compare http://calypso.localhost:3000/read/blogs/94148385 and http://wpcalypso.wordpress.com/read/blogs/94148385.

Test live: https://calypso.live/?branch=fix/site-component-missing-site-title