### PR TITLE
Revert "State: Post normalization consistency / cleanup"

### DIFF
--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -23,6 +23,7 @@ import {
 	getSitePostsForQuery
 } from 'state/posts/selectors';
 import { getPostStat } from 'state/stats/posts/selectors';
+import { decodeEntities } from 'lib/formatting';
 
 const StatsPostPerformance = React.createClass( {
 
@@ -92,7 +93,7 @@ const StatsPostPerformance = React.createClass( {
 			if ( ! post.title ) {
 				postTitle = this.translate( '(no title)' );
 			} else {
-				postTitle = post.title;
+				postTitle = decodeEntities( post.title );
 			}
 		}
 

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -34,17 +34,15 @@ export function getPost( state, globalId ) {
 }
 
 /**
- * Returns a normalized post object by its global ID, or null if the post does
- * not exist. A normalized post includes common transformations to prepare the
- * post for display.
+ * Returns a normalized post object by its global ID.
  *
- * @param  {Object}  state    Global state tree
- * @param  {String}  globalId Post global ID
- * @return {?Object}          Post object
+ * @param  {Object} state    Global state tree
+ * @param  {String} globalId Post global ID
+ * @return {Object}          Post object
  */
 export const getNormalizedPost = createSelector(
 	( () => {
-		// Cache normalize flow in immediately-invoked closure to avoid
+		// Cache normalize flow in immediately-invoked closure so to avoid
 		// regenerating same flow on each call to this selector
 		const normalize = flow( [
 			firstPassCanonicalImage,
@@ -52,14 +50,7 @@ export const getNormalizedPost = createSelector(
 			stripHtml
 		] );
 
-		return ( state, globalId ) => {
-			const post = getPost( state, globalId );
-			if ( ! post ) {
-				return null;
-			}
-
-			return normalize( cloneDeep( post ) );
-		};
+		return ( state, globalId ) => normalize( cloneDeep( getPost( state, globalId ) ) );
 	} )(),
 	( state ) => state.posts.items
 );
@@ -90,10 +81,8 @@ export const getSitePost = createSelector(
 );
 
 /**
- * Returns an array of normalized posts for the posts query, or null if no
- * posts have been received.
- *
- * @see getNormalizedPost
+ * Returns an array of posts for the posts query, or null if no posts have been
+ * received.
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
@@ -101,17 +90,11 @@ export const getSitePost = createSelector(
  * @return {?Array}         Posts for the post query
  */
 export function getSitePostsForQuery( state, siteId, query ) {
-	const manager = state.posts.queries[ siteId ];
-	if ( ! manager ) {
+	if ( ! state.posts.queries[ siteId ] ) {
 		return null;
 	}
 
-	const posts = manager.getItems( query );
-	if ( ! posts ) {
-		return null;
-	}
-
-	return posts.map( ( post ) => getNormalizedPost( state, post.global_ID ) );
+	return state.posts.queries[ siteId ].getItems( query );
 }
 
 /**
@@ -186,10 +169,8 @@ export function isSitePostsLastPageForQuery( state, siteId, query = {} ) {
 }
 
 /**
- * Returns an array of normalized posts for the posts query, including all
- * known queried pages, or null if the posts for the query are not known.
- *
- * @see getNormalizedPost
+ * Returns an array of posts for the posts query, including all known
+ * queried pages, or null if the number of pages is unknown.
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
@@ -213,12 +194,9 @@ export function getSitePostsForQueryIgnoringPage( state, siteId, query ) {
 }
 
 /**
- * Returns an array of normalized posts for the posts query, including all
- * known queried pages, preserving hierarchy. Returns null if no posts have
- * been received. Hierarchy is represented by `parent` and `items` properties
- * on each post.
- *
- * @see getNormalizedPost
+ * Returns an array of posts for the posts query, including all known queried
+ * pages, preserving hierarchy. Returns null if no posts have been received.
+ * Hierarchy is represented by `parent` and `items` properties on each post.
  *
  * @param  {Object} state  Global state tree
  * @param  {Number} siteId Site ID

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -44,52 +43,6 @@ describe( 'selectors', () => {
 			}, '3d097cb7c5473c169bba0eb8e3c6cb64' );
 
 			expect( post ).to.eql( { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' } );
-		} );
-	} );
-
-	describe( 'getNormalizedPost()', () => {
-		it( 'should return null if the post is not tracked', () => {
-			const normalizedPost = getNormalizedPost( {
-				posts: {
-					items: {}
-				}
-			}, '3d097cb7c5473c169bba0eb8e3c6cb64' );
-
-			expect( normalizedPost ).to.be.null;
-		} );
-
-		it( 'should return a normalized copy of the post', () => {
-			const post = {
-				ID: 841,
-				site_ID: 2916284,
-				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-				title: 'Ribs &amp; Chicken',
-				author: {
-					name: 'Badman <img onerror= />'
-				},
-				featured_image: 'https://example.com/logo.png'
-			};
-
-			const normalizedPost = getNormalizedPost( deepFreeze( {
-				posts: {
-					items: {
-						'3d097cb7c5473c169bba0eb8e3c6cb64': post
-					}
-				}
-			} ), '3d097cb7c5473c169bba0eb8e3c6cb64' );
-
-			expect( normalizedPost ).to.not.equal( post );
-			expect( normalizedPost ).to.eql( {
-				...post,
-				title: 'Ribs & Chicken',
-				author: {
-					name: 'Badman '
-				},
-				canonical_image: {
-					type: 'image',
-					uri: 'https://example.com/logo.png'
-				}
-			} );
 		} );
 	} );
 
@@ -146,49 +99,31 @@ describe( 'selectors', () => {
 				posts: {
 					queries: {}
 				}
-			}, 2916284, { search: 'Ribs' } );
+			}, 2916284, { search: 'Hello' } );
 
 			expect( sitePosts ).to.be.null;
 		} );
 
-		it( 'should return null if the query is not tracked to the query manager', () => {
+		it( 'should return an array of the known queried posts', () => {
 			const sitePosts = getSitePostsForQuery( {
 				posts: {
-					queries: {
-						2916284: new PostQueryManager( {
-							items: {},
-							queries: {}
-						} )
-					}
-				}
-			}, 2916284, { search: 'Ribs' } );
-
-			expect( sitePosts ).to.be.null;
-		} );
-
-		it( 'should return an array of normalized known queried posts', () => {
-			const sitePosts = getSitePostsForQuery( {
-				posts: {
-					items: {
-						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs &amp; Chicken' }
-					},
 					queries: {
 						2916284: new PostQueryManager( {
 							items: {
-								841: { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs &amp; Chicken' }
+								841: { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
 							},
 							queries: {
-								'[["search","Ribs"]]': {
+								'[["search","Hello"]]': {
 									itemKeys: [ 841 ]
 								}
 							}
 						} )
 					}
 				}
-			}, 2916284, { search: 'Ribs' } );
+			}, 2916284, { search: 'Hello' } );
 
 			expect( sitePosts ).to.eql( [
-				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs & Chicken' }
+				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
 			] );
 		} );
 	} );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#6242

Observed in staging during a very specific flow that an error could occur when starting on the Stats Insights screen, navigating to the post editor, opening "Add link to existing content" (Add Link), then navigating back to the Stats Insights screen (via My Sites master bar link).

Reverting until regression can be resolved separately.

/cc @youknowriad 

Test live: https://calypso.live/?branch=revert-6242-update/post-normalize-consistency