### PR TITLE
Upgrades: Fix google analytics feature page

### DIFF
--- a/client/my-sites/plans/plan-feature/google-analytics.js
+++ b/client/my-sites/plans/plan-feature/google-analytics.js
@@ -47,7 +47,7 @@ export default function( context ) {
 	const planSlug = ( site && site.ID ) ? getSitePlanSlug( site.ID ) : PLAN_FREE;
 
 	const SvgLogo = () => (
-		<svg width="84" height="84" viewBox="0 0 84 84" xmlns="http://www.w3.org/2000/svg" style="overflow: visible;">
+		<svg width="84" height="84" viewBox="0 0 84 84" xmlns="http://www.w3.org/2000/svg" style={ { overflow: 'hidden' } }>
 			<title>icon - google analytics</title>
 			<g fill="none" fillRule="evenodd">
 				<rect fillOpacity=".27" fill="#C8D7E1" x="4" y="4" width="80" height="80" rx="6"/>


### PR DESCRIPTION
I know we probably want to delete this page, but for now I'm just fixing it.

Error in parsing String style declaration was rendering empty page

Go to
https://wordpress.com/plans/features/google-analytics/$site to see

# Testing
http://calypso.localhost:3000/plans/features/google-analytics/$site

![zrzut ekranu 2016-06-23 o 17 21 54](https://cloud.githubusercontent.com/assets/3775068/16309096/cda7a4d0-3967-11e6-9302-656505374601.png)


CC @rralian @gwwar @lamosty 


Test live: https://calypso.live/?branch=fix/google-analytics-feature-page