### PR TITLE
Remove /plans/features/:feature generic route

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -210,7 +210,7 @@ const MediaLibraryContent = React.createClass( {
 		return (
 			<NoticeAction
 				external={ true }
-				href={ upgradeNudgeFeature ? `/plans/features/${ upgradeNudgeFeature }/${ this.props.siteSlug }` : `/plans/${ this.props.siteSlug }` }
+				href={ upgradeNudgeFeature ? `/plans/compare/${ this.props.siteSlug }?feature=${ upgradeNudgeFeature }` : `/plans/${ this.props.siteSlug }` }
 				onClick={ this.recordPlansNavigation.bind( this, 'calypso_upgrade_nudge_cta_click', eventProperties ) }>
 				{ this.translate( 'Upgrade Plan' ) }
 				<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -85,13 +85,6 @@ export default function() {
 		);
 
 		page(
-			'/plans/features/:feature/:domain',
-			retarget,
-			controller.siteSelection,
-			plansController.features
-		);
-
-		page(
 			paths.plansDestination(),
 			retarget,
 			controller.siteSelection,


### PR DESCRIPTION
Remove unneeded route to reduce complexity

Relates to @lamosty https://github.com/Automattic/wp-calypso/pull/6119

## Functional changes

None

Test live: https://calypso.live/?branch=update/remove-plans/features-route