### PR TITLE
State: Post normalization consistency / cleanup (2)

### DIFF
--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -154,7 +154,7 @@ const StatsPostPerformance = React.createClass( {
 
 export default connect( ( state, ownProps ) => {
 	const { site } = ownProps;
-	const query = { status: 'published', number: 1 };
+	const query = { status: 'publish', number: 1 };
 	const posts = site ? getSitePostsForQuery( state, site.ID, query ) : null;
 	const post = posts && posts.length ? posts[ 0 ] : null;
 	const viewCount = post && site ? getPostStat( state, 'views', site.ID, post.ID ) : null;

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -23,7 +23,6 @@ import {
 	getSitePostsForQuery
 } from 'state/posts/selectors';
 import { getPostStat } from 'state/stats/posts/selectors';
-import { decodeEntities } from 'lib/formatting';
 
 const StatsPostPerformance = React.createClass( {
 
@@ -93,7 +92,7 @@ const StatsPostPerformance = React.createClass( {
 			if ( ! post.title ) {
 				postTitle = this.translate( '(no title)' );
 			} else {
-				postTitle = decodeEntities( post.title );
+				postTitle = post.title;
 			}
 		}
 

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -9,6 +9,7 @@ import omitBy from 'lodash/omitBy';
 import isEqual from 'lodash/isEqual';
 import reduce from 'lodash/reduce';
 import keyBy from 'lodash/keyBy';
+import groupBy from 'lodash/groupBy';
 import merge from 'lodash/merge';
 import findKey from 'lodash/findKey';
 
@@ -154,13 +155,12 @@ export function queries( state = {}, action ) {
 		}
 
 		case POSTS_RECEIVE:
-			return reduce( action.posts, ( memo, post ) => {
-				const { site_ID: siteId } = post;
+			return reduce( groupBy( action.posts, 'site_ID' ), ( memo, posts, siteId ) => {
 				if ( ! memo[ siteId ] ) {
 					return memo;
 				}
 
-				const nextPosts = memo[ siteId ].receive( post );
+				const nextPosts = memo[ siteId ].receive( posts );
 				if ( nextPosts === memo[ siteId ] ) {
 					return memo;
 				}

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -8,6 +8,7 @@ import find from 'lodash/find';
 import merge from 'lodash/merge';
 import flow from 'lodash/flow';
 import cloneDeep from 'lodash/cloneDeep';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -108,6 +109,15 @@ export function getSitePostsForQuery( state, siteId, query ) {
 
 	const posts = manager.getItems( query );
 	if ( ! posts ) {
+		return null;
+	}
+
+	// PostQueryManager is smart enough to return an array including undefined
+	// entries if it knows that a page of results exists for the query (via a
+	// previous request's `found` value) but the items haven't been received.
+	// While we could impose this on the developer to accommodate, instead we
+	// simply return null when any `undefined` entries exist in the set.
+	if ( includes( posts, undefined ) ) {
 		return null;
 	}
 

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -191,6 +191,31 @@ describe( 'selectors', () => {
 				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs & Chicken' }
 			] );
 		} );
+
+		it( 'should return null if we know the number of found items but the requested set hasn\'t been received', () => {
+			const sitePosts = getSitePostsForQuery( {
+				posts: {
+					items: {
+						'48b6010b559efe6a77a429773e0cbf12': { ID: 1204, site_ID: 2916284, global_ID: '48b6010b559efe6a77a429773e0cbf12', title: 'Sweet &amp; Savory' }
+					},
+					queries: {
+						2916284: new PostQueryManager( {
+							items: {
+								1204: { ID: 1204, site_ID: 2916284, global_ID: '48b6010b559efe6a77a429773e0cbf12', title: 'Sweet &amp; Savory' }
+							},
+							queries: {
+								'[["search","Sweet"]]': {
+									itemKeys: [ 1204, undefined ],
+									found: 2
+								}
+							}
+						} )
+					}
+				}
+			}, 2916284, { search: 'Sweet', number: 1, page: 2 } );
+
+			expect( sitePosts ).to.be.null;
+		} );
 	} );
 
 	describe( '#isRequestingSitePostsForQuery()', () => {
@@ -503,6 +528,33 @@ describe( 'selectors', () => {
 			expect( sitePosts ).to.eql( [
 				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
 				{ ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
+			] );
+		} );
+
+		it( 'should omit found items for which the requested result hasn\'t been received', () => {
+			const sitePosts = getSitePostsForQueryIgnoringPage( {
+				posts: {
+					items: {
+						'48b6010b559efe6a77a429773e0cbf12': { ID: 1204, site_ID: 2916284, global_ID: '48b6010b559efe6a77a429773e0cbf12', title: 'Sweet &amp; Savory' }
+					},
+					queries: {
+						2916284: new PostQueryManager( {
+							items: {
+								1204: { ID: 1204, site_ID: 2916284, global_ID: '48b6010b559efe6a77a429773e0cbf12', title: 'Sweet &amp; Savory' }
+							},
+							queries: {
+								'[["search","Sweet"]]': {
+									itemKeys: [ 1204, undefined ],
+									found: 2
+								}
+							}
+						} )
+					}
+				}
+			}, 2916284, { search: 'Sweet', number: 1 } );
+
+			expect( sitePosts ).to.eql( [
+				{ ID: 1204, site_ID: 2916284, global_ID: '48b6010b559efe6a77a429773e0cbf12', title: 'Sweet & Savory' }
 			] );
 		} );
 	} );

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -43,6 +44,52 @@ describe( 'selectors', () => {
 			}, '3d097cb7c5473c169bba0eb8e3c6cb64' );
 
 			expect( post ).to.eql( { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' } );
+		} );
+	} );
+
+	describe( 'getNormalizedPost()', () => {
+		it( 'should return null if the post is not tracked', () => {
+			const normalizedPost = getNormalizedPost( {
+				posts: {
+					items: {}
+				}
+			}, '3d097cb7c5473c169bba0eb8e3c6cb64' );
+
+			expect( normalizedPost ).to.be.null;
+		} );
+
+		it( 'should return a normalized copy of the post', () => {
+			const post = {
+				ID: 841,
+				site_ID: 2916284,
+				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+				title: 'Ribs &amp; Chicken',
+				author: {
+					name: 'Badman <img onerror= />'
+				},
+				featured_image: 'https://example.com/logo.png'
+			};
+
+			const normalizedPost = getNormalizedPost( deepFreeze( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': post
+					}
+				}
+			} ), '3d097cb7c5473c169bba0eb8e3c6cb64' );
+
+			expect( normalizedPost ).to.not.equal( post );
+			expect( normalizedPost ).to.eql( {
+				...post,
+				title: 'Ribs & Chicken',
+				author: {
+					name: 'Badman '
+				},
+				canonical_image: {
+					type: 'image',
+					uri: 'https://example.com/logo.png'
+				}
+			} );
 		} );
 	} );
 
@@ -99,31 +146,49 @@ describe( 'selectors', () => {
 				posts: {
 					queries: {}
 				}
-			}, 2916284, { search: 'Hello' } );
+			}, 2916284, { search: 'Ribs' } );
 
 			expect( sitePosts ).to.be.null;
 		} );
 
-		it( 'should return an array of the known queried posts', () => {
+		it( 'should return null if the query is not tracked to the query manager', () => {
 			const sitePosts = getSitePostsForQuery( {
 				posts: {
 					queries: {
 						2916284: new PostQueryManager( {
+							items: {},
+							queries: {}
+						} )
+					}
+				}
+			}, 2916284, { search: 'Ribs' } );
+
+			expect( sitePosts ).to.be.null;
+		} );
+
+		it( 'should return an array of normalized known queried posts', () => {
+			const sitePosts = getSitePostsForQuery( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs &amp; Chicken' }
+					},
+					queries: {
+						2916284: new PostQueryManager( {
 							items: {
-								841: { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+								841: { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs &amp; Chicken' }
 							},
 							queries: {
-								'[["search","Hello"]]': {
+								'[["search","Ribs"]]': {
 									itemKeys: [ 841 ]
 								}
 							}
 						} )
 					}
 				}
-			}, 2916284, { search: 'Hello' } );
+			}, 2916284, { search: 'Ribs' } );
 
 			expect( sitePosts ).to.eql( [
-				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Ribs & Chicken' }
 			] );
 		} );
 	} );


### PR DESCRIPTION
Reverts #6271, which in turn reverted #6242 

See #6242 for the original purpose of this pull request. It may be easiest to review individual commits after 9f3460f to analyze the changes necessary to resolve the issues observed by the revert in #6271.

Specifically, this pull request seeks to:

- Include all changes from #6242 
- Resolve an incorrect `status` value specified in a query by the `<PostPerformance />` component
- Ensure that `getSitePostsForQuery` doesn't try to normalize an `undefined` post (in fact, return `null` from the function if any `undefined` entries exist)
- Group posts by site ID before receiving them into `state.posts.queries` (minor performance improvement, helped in debugging `receive` calls)

__Implementation notes:__

The issue manifested itself when navigating the following flow:

1. Start at [Stats Insights](http://calypso.localhost:3000/post)
2. Select a site
3. Start a new post (from master bar or post Add in sidebar)
4. Click Add Link in the editor toolbar
5. Dismiss the modal
6. Navigate back to Stats Insights via "My Sites" in master bar

Details of the issue:

- Stats insights loads a single post to be shown in the "Latest Post Summary" section
- This post was tracked `[["status","published"]]` query in `PostQueryManager` ("published" is not a valid status)
- When opening the Add Link modal, request(s) are issued for all published posts (of any type)
- When these posts are received, `PostQueryManager` tests all received items (which includes the post tracked by Stats Insight's query) on whether they're still matches for the query
- Because the post's status is "publish" and Stats Insights query wants status "published", the post is no longer a match and is removed from the query results
- When returning to Stats Insights, it meets all conditions of the selector `getSitePostsForQuery` in that a previous response had been received for the same query and tries to map results to `getNormalizedPost`
- Because `PostQueryManager` tracks `undefined` item keys for pages of items that are known to exist by the `found` value of the response but haven't been received ([example](https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/posts?number=1&fields=ID,title)), `getSitePostsForQuery` raised an error when trying to access the `global_ID` property of what is now `undefined` (since the previously matched item was no longer included in the tracked query)

See test cases in 9b56cba (+ 3a489e1) for new expected behavior.

__Testing instructions:__

Repeat the steps described in "Implementation notes", noting that no error occurs, and that the post found on the initial request appears immediately after navigating back to Stats Insights from the editor.

Repeat testing instructions from #6242

Ensure Mocha tests pass:

```
npm run test-client client/state/posts/test/selectors.js
```

__Follow-up tasks:__

- Maybe we should make `PostQueryManager` aware of valid query values?

/cc @timmyc , @youknowriad , @mtias 

Test live: https://calypso.live/?branch=update/revert-6271-post-normalize-consistency