### PR TITLE
Sites: harden isMainNetworkSite to not throw an error when options is empty

### DIFF
--- a/client/lib/site/test/utils.js
+++ b/client/lib/site/test/utils.js
@@ -37,7 +37,7 @@ describe( 'Site Utils', function() {
 					is_multi_network: false,
 					file_mod_disabled: [ 'something else' ]
 				}
-			}
+			};
 			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
 		} );
 
@@ -51,7 +51,7 @@ describe( 'Site Utils', function() {
 					is_multi_network: false,
 					file_mod_disabled: false
 				}
-			}
+			};
 			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
 		} );
 
@@ -65,7 +65,7 @@ describe( 'Site Utils', function() {
 					is_multi_network: false,
 					file_mod_disabled: false
 				}
-			}
+			};
 			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
 		} );
 
@@ -79,7 +79,7 @@ describe( 'Site Utils', function() {
 					is_multi_network: false,
 					file_mod_disabled: false
 				}
-			}
+			};
 			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
 		} );
 
@@ -93,7 +93,7 @@ describe( 'Site Utils', function() {
 					is_multi_network: false,
 					file_mod_disabled: false
 				}
-			}
+			};
 			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
 		} );
 
@@ -107,7 +107,7 @@ describe( 'Site Utils', function() {
 					is_multi_network: false,
 					file_mod_disabled: false
 				}
-			}
+			};
 			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
 		} );
 	} );
@@ -136,7 +136,7 @@ describe( 'Site Utils', function() {
 					unmapped_url: 'someurl',
 					main_network_site: 'someurl-different',
 				}
-			}
+			};
 			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
 		} );
 
@@ -147,7 +147,7 @@ describe( 'Site Utils', function() {
 					unmapped_url: 'someurl',
 					main_network_site: 'someurl-different',
 				}
-			}
+			};
 			assert.isTrue( SiteUtils.isMainNetworkSite( site ) );
 		} );
 
@@ -156,7 +156,7 @@ describe( 'Site Utils', function() {
 				options: {
 					is_multi_network: true,
 				}
-			}
+			};
 			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
 		} );
 
@@ -167,7 +167,7 @@ describe( 'Site Utils', function() {
 					unmapped_url: 'http://someurl',
 					main_network_site: 'https://someurl',
 				}
-			}
+			};
 			assert.isTrue( SiteUtils.isMainNetworkSite( site ) );
 		} );
 
@@ -178,7 +178,15 @@ describe( 'Site Utils', function() {
 					unmapped_url: 'http://someurl',
 					main_network_site: 'ftp://someurl',
 				}
-			}
+			};
+			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
+		} );
+
+		it( 'Does not explode when unmapped_url is not defined', function() {
+			const site = {
+				is_multisite: true,
+				options: {}
+			};
 			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
 		} );
 	} );

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import i18n from 'i18n-calypso';
+import get from 'lodash/get';
 
 export default {
 	userCan( capability, site ) {
@@ -157,10 +158,13 @@ export default {
 		}
 
 		if ( site.is_multisite ) {
+			const unmappedUrl = get( site.options, 'unmapped_url', null );
+			const mainNetworkSite = get( site.options, 'main_network_site', null );
+			if ( ! unmappedUrl || ! mainNetworkSite ) {
+				return false;
+			}
 			// Compare unmapped_url with the main_network_site to see if is the main network site.
-			return ! ( site.options &&
-				site.options.unmapped_url.replace( /^https?:\/\//, '' ) !== site.options.main_network_site.replace( /^https?:\/\//, '' )
-			);
+			return ! ( unmappedUrl.replace( /^https?:\/\//, '' ) !== mainNetworkSite.replace( /^https?:\/\//, '' ) );
 		}
 
 		return false;

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -3,6 +3,7 @@
 */
 import React, { PropTypes } from 'react';
 import i18n from 'i18n-calypso';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -57,8 +58,9 @@ export default React.createClass( {
 
 		let momentSiteZone = i18n.moment();
 
-		if ( site && site.options ) {
-			momentSiteZone = i18n.moment().utcOffset( site.options.gmt_offset );
+		const gmtOffset = get( site.options, 'gmt_offset', null );
+		if ( gmtOffset ) {
+			momentSiteZone = i18n.moment().utcOffset( gmtOffset );
 		}
 
 		const summaryDate = momentSiteZone.format( 'YYYY-MM-DD' );


### PR DESCRIPTION
Fixes #6276 so isMainNetworkSite does not unexpectedly throw an error when expected data is not present. 

cc @lamosty 

Test live: https://calypso.live/?branch=fix/site-util