### PR TITLE
Jetpack Connect: added missing punctuation to instructions

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -248,7 +248,7 @@ const JetpackConnectMain = React.createClass( {
 					<ConnectHeader
 						showLogo={ false }
 						headerText={ this.translate( 'Install Jetpack' ) }
-						subHeaderText={ this.translate( 'Installing Jetpack is easy. Please start by typing your site address below and then click "Start Installation"' ) }
+						subHeaderText={ this.translate( 'Installing Jetpack is easy. Please start by typing your site address below and then click "Start Installation".' ) }
 						step={ 1 }
 						steps={ 3 } />
 


### PR DESCRIPTION
A period was missing after "Start Installation"

<img width="455" alt="screen shot 2016-06-23 at 3 10 36 pm" src="https://cloud.githubusercontent.com/assets/437258/16316464/b89e1eb0-3954-11e6-96e0-266368106bb5.png">


Test live: https://calypso.live/?branch=update/jetpack-connect-punctuation