### PR TITLE
Reader: Fix how we key and detect posts from sites.

### DIFF
--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -195,7 +195,7 @@ function receivePostFromPage( newPost ) {
 		return;
 	}
 
-	if ( newPost.feed_ID && newPost.ID && ! _posts[ newPost.ID ] ) {
+	if ( newPost.feed_ID && ! newPost.site_ID && newPost.ID && ! _posts[ newPost.ID ] ) {
 		// 1.3 style
 		setPost( newPost.ID, assign( {}, newPost, { _state: 'minimal' } ) );
 	} else if ( newPost.site_ID && ! _postsForBlogs[ blogKey( {

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -78,7 +78,7 @@ FeedStreamActions = {
 						feedId: post.feed_ID,
 						postId: post.ID
 					} );
-				} else if ( post && post.feed_ID ) {
+				} else if ( post && post.feed_ID && post.feed_item_ID ) {
 					// 1.2 style
 					FeedPostStoreActions.receivePost( null, post, {
 						feedId: post.feed_ID,

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -25,10 +25,10 @@ function siteKeyMaker( post ) {
 }
 
 function mixedKeyMaker( post ) {
-	if ( post.feed_ID ) {
+	if ( post.feed_ID && post.feed_item_ID ) {
 		return {
 			feedId: post.feed_ID,
-			postId: post.ID
+			postId: post.feed_item_ID
 		};
 	}
 


### PR DESCRIPTION
Now that site posts have feed_IDs on them, we need to alter how we detect posts from endpoints not driven by the feedbag. This teaches the various bits that work with posts how to detect posts that originate with the feedbag

Test live: https://calypso.live/?branch=fix/reader/keying-for-site-posts