### PR TITLE
Fix style issues in localized verification dialog

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -219,7 +219,7 @@
 	border-radius: 0;
 
 	@include breakpoint( ">660px" ) {
-		max-width: 450px;
+		max-width: 550px;
 		border-radius: 3px;
 	}
 }

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -227,8 +227,11 @@
 .post-editor__confirmation-dialog-heading {
 	font-size: 22px;
 	line-height: 1.2;
-	height: auto;
 	margin: 0 0 4px 0;
+}
+
+.post-editor__confirmation-dialog-heading.is-variable-height {
+	height: auto;
 }
 
 .post-editor__confirmation-dialog-email,

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -244,7 +244,6 @@
 .post-editor__confirmation-dialog-email {
 	margin-bottom: 16px;
 	color: darken( $gray, 10 );
-
 }
 
 .post-editor__confirmation-dialog-email-wrapper {

--- a/client/post-editor/verify-email-dialog.jsx
+++ b/client/post-editor/verify-email-dialog.jsx
@@ -99,7 +99,7 @@ class VerifyEmailDialog extends React.Component {
 				buttons={ this.getDialogButtons() }
 				additionalClassNames="post-editor__confirmation-dialog is-narrow"
 			>
-				<h1 className="post-editor__confirmation-dialog-heading">{ strings.confirmHeading }</h1>
+				<h1 className="post-editor__confirmation-dialog-heading is-variable-height">{ strings.confirmHeading }</h1>
 				<p className="post-editor__confirmation-dialog-email">{ strings.confirmEmail }</p>
 				<p className="post-editor__confirmation-dialog-explanation">{ strings.confirmExplanation }</p>
 				<p className="post-editor__confirmation-dialog-reasoning">{ strings.confirmReasoning }</p>


### PR DESCRIPTION
Right now if the heading text is too long, the message overlaps the email address. This is caused by an accidental change in CSS specificity introduced with #6230.

![](https://cloudup.com/cqgXd8tzN8u+)

This PR fixes that, so that if a line wrap takes place, the content gets pushed down as expected.

It also makes the window 100px wider, so that a line wrap doesn't happen in Spanish. (One of the officially supported languages, that has a slightly longer heading because “correo eletrónico” is used instead of “email”.

Test live: https://calypso.live/?branch=fix/localization-issues-in-verification-dialog