### PR TITLE
Signup: Add cold start A/B test to signup process

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -120,4 +120,14 @@ module.exports = {
 		defaultVariation: 'enabled',
 		allowExistingUsers: false,
 	},
+	coldStartReader: {
+		datestamp: '20160622',
+		variations: {
+			noEmailColdStart: 10,
+			noEmailNoColdStart: 10,
+			noChanges: 80
+		},
+		defaultVariation: 'noChanges',
+		allowExistingUsers: false,
+	},
 };

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,16 +1,17 @@
 /**
  * External dependencies
  */
-import React from 'react'
-import analytics from 'lib/analytics'
+import React from 'react';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
  */
-import StepWrapper from 'signup/step-wrapper'
-import SignupForm from 'components/signup-form'
-import signupUtils from 'signup/utils'
+import StepWrapper from 'signup/step-wrapper';
+import SignupForm from 'components/signup-form';
+import signupUtils from 'signup/utils';
 import SignupActions from 'lib/signup/actions';
+import { abtest } from 'lib/abtest';
 
 export default React.createClass( {
 
@@ -24,14 +25,13 @@ export default React.createClass( {
 		if ( this.props.flowName !== nextProps.flowName || this.props.subHeaderText !== nextProps.subHeaderText ) {
 			this.setSubHeaderText( nextProps );
 		}
-
 	},
 
 	componentWillMount() {
 		this.setSubHeaderText( this.props );
 	},
 
-	setSubHeaderText( props )  {
+	setSubHeaderText( props ) {
 		let subHeaderText = props.subHeaderText;
 
 		/**
@@ -57,6 +57,17 @@ export default React.createClass( {
 
 		if ( this.props.queryObject && this.props.queryObject.jetpack_redirect ) {
 			queryArgs.jetpackRedirect = this.props.queryObject.jetpack_redirect;
+		}
+
+		// User is participating in Reader Cold Start
+		if ( abtest( 'coldStartReader' ) === 'noEmailColdStart' ) {
+			userData.follow_default_blogs = false;
+			userData.subscription_delivery_email_default = 'never';
+			userData.is_new_reader = true;
+
+		// User is not participating in Reader Cold Start, but is in our "never send email" experiment group
+		} else if ( abtest( 'coldStartReader' ) === 'noEmailNoColdStart' ) {
+			userData.subscription_delivery_email_default = 'never';
 		}
 
 		const formWithoutPassword = Object.assign( {}, form, {
@@ -126,7 +137,7 @@ export default React.createClass( {
 				submitForm={ this.submitForm }
 				submitButtonText={ this.submitButtonText() }
 			/>
-		)
+		);
 	},
 
 	render() {
@@ -141,6 +152,6 @@ export default React.createClass( {
 				signupProgressStore={ this.props.signupProgressStore }
 				stepContent={ this.renderSignupForm() }
 			/>
-		)
+		);
 	}
 } );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -12,6 +12,7 @@ import SignupForm from 'components/signup-form';
 import signupUtils from 'signup/utils';
 import SignupActions from 'lib/signup/actions';
 import { abtest } from 'lib/abtest';
+import config from 'config';
 
 export default React.createClass( {
 
@@ -59,15 +60,17 @@ export default React.createClass( {
 			queryArgs.jetpackRedirect = this.props.queryObject.jetpack_redirect;
 		}
 
-		// User is participating in Reader Cold Start
-		if ( abtest( 'coldStartReader' ) === 'noEmailColdStart' ) {
-			userData.follow_default_blogs = false;
-			userData.subscription_delivery_email_default = 'never';
-			userData.is_new_reader = true;
+		if ( config.isEnabled( 'reader/start' ) ) {
+			// User is participating in Reader Cold Start
+			if ( abtest( 'coldStartReader' ) === 'noEmailColdStart' ) {
+				userData.follow_default_blogs = false;
+				userData.subscription_delivery_email_default = 'never';
+				userData.is_new_reader = true;
 
-		// User is not participating in Reader Cold Start, but is in our "never send email" experiment group
-		} else if ( abtest( 'coldStartReader' ) === 'noEmailNoColdStart' ) {
-			userData.subscription_delivery_email_default = 'never';
+			// User is not participating in Reader Cold Start, but is in our "never send email" experiment group
+			} else if ( abtest( 'coldStartReader' ) === 'noEmailNoColdStart' ) {
+				userData.subscription_delivery_email_default = 'never';
+			}
 		}
 
 		const formWithoutPassword = Object.assign( {}, form, {


### PR DESCRIPTION
For users in the cold start A/B test, the signup flow needs to be modified to stop auto-following blogs and to turn off instant email notifications. Since we want all users that signup, regardless of signup flow, this has been added to the user signup step.

Test live: https://calypso.live/?branch=add/coldstart-abtest

Testing steps:

1) start new user sign up at calypso.localhost:3000/start/website
2) in the javascript console, run these commands:
localStorage.clear()
localStorage.setItem('ABTests','{"coldStartReader_20160622":"noEmailColdStart"}')
3) go through the new user setup process
4) it should complete successfully
5) once it is done, verify that the subscription email settings are set to never and that the new user is not following any blogs
6) also, you can verify that the new user has the is_new_reader property in the user_properties table

The changes to the user endpoint are in patch D2088, and you'll need this applied to test this PR.

**_This PR should only be merged once we want users to access to cold start_**