### PR TITLE
Framework: Add a QueryPurchases Component

### DIFF
--- a/client/components/data/query-site-purchases/README.md
+++ b/client/components/data/query-site-purchases/README.md
@@ -1,7 +1,7 @@
 Query Site Purchases
 ================
 
-`<QuerySitePurchases />` is a React component used in managing network requests for sites/purchases (across all users).
+`<QuerySitePurchases />` is a React component used in managing network requests for site purchases (across all users).
 
 ## Usage
 

--- a/client/components/data/query-site-purchases/README.md
+++ b/client/components/data/query-site-purchases/README.md
@@ -1,0 +1,8 @@
+Query Site Purchases
+================
+
+`<QuerySitePurchases />` is a React component used in managing network requests for sites/purchases (across all users).
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page.

--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -11,11 +11,6 @@ import { isFetchingSitePurchases } from 'state/purchases/selectors';
 import { fetchSitePurchases } from 'state/purchases/actions';
 
 class QuerySitePurchases extends Component {
-	constructor( props ) {
-		super( props );
-		this.requestSitePurchases = this.requestSitePurchases.bind( this );
-	}
-
 	requestSitePurchases( props = this.props ) {
 		this.props.fetchSitePurchases( props.siteId );
 	}

--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -25,7 +25,7 @@ class QuerySitePurchases extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.fetchingSitePurchases ||
+		if ( nextProps.requesting ||
 			! nextProps.siteId ||
 			( this.props.siteId === nextProps.siteId ) ) {
 			return;
@@ -40,14 +40,14 @@ class QuerySitePurchases extends Component {
 
 QuerySitePurchases.propTypes = {
 	siteId: PropTypes.number.isRequired,
-	fetchingSitePurchases: PropTypes.bool.isRequired,
+	requesting: PropTypes.bool.isRequired,
 	fetchSitePurchases: PropTypes.func.isRequired
 };
 
 export default connect(
 	state => {
 		return {
-			fetchingSitePurchases: isFetchingSitePurchases( state )
+			requesting: isFetchingSitePurchases( state )
 		};
 	},
 	{ fetchSitePurchases }

--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isFetchingSitePurchases } from 'state/purchases/selectors';
+import { fetchSitePurchases } from 'state/purchases/actions';
+
+class QuerySitePurchases extends Component {
+	constructor( props ) {
+		super( props );
+		this.requestSitePurchases = this.requestSitePurchases.bind( this );
+	}
+
+	requestSitePurchases( props = this.props ) {
+		this.props.fetchSitePurchases( props.siteId );
+	}
+
+	componentWillMount() {
+		this.requestSitePurchases();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.fetchingSitePurchases ||
+			! nextProps.siteId ||
+			( this.props.siteId === nextProps.siteId ) ) {
+			return;
+		}
+		this.requestSitePurchases( nextProps );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QuerySitePurchases.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	fetchingSitePurchases: PropTypes.bool.isRequired,
+	fetchSitePurchases: PropTypes.func.isRequired
+};
+
+export default connect(
+	state => {
+		return {
+			fetchingSitePurchases: isFetchingSitePurchases( state )
+		};
+	},
+	{ fetchSitePurchases }
+)( QuerySitePurchases );

--- a/client/components/data/query-user-purchases/README.md
+++ b/client/components/data/query-user-purchases/README.md
@@ -1,0 +1,8 @@
+Query User Purchases
+================
+
+`<QueryUserPurchases />` is a React component used in managing network requests for user purchases.
+
+## Usage
+
+Render the component, passing `userId`. It does not accept any children, nor does it render any elements to the page.

--- a/client/components/data/query-user-purchases/index.jsx
+++ b/client/components/data/query-user-purchases/index.jsx
@@ -11,11 +11,6 @@ import { isFetchingUserPurchases } from 'state/purchases/selectors';
 import { fetchUserPurchases } from 'state/purchases/actions';
 
 class QueryUserPurchases extends Component {
-	constructor( props ) {
-		super( props );
-		this.requestUserPurchases = this.requestUserPurchases.bind( this );
-	}
-
 	requestUserPurchases( props = this.props ) {
 		this.props.fetchUserPurchases( props.userId );
 	}

--- a/client/components/data/query-user-purchases/index.jsx
+++ b/client/components/data/query-user-purchases/index.jsx
@@ -25,7 +25,7 @@ class QueryUserPurchases extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.fetchingUserPurchases ||
+		if ( nextProps.requesting ||
 			! nextProps.userId ||
 			( this.props.userId === nextProps.userId ) ) {
 			return;
@@ -40,14 +40,14 @@ class QueryUserPurchases extends Component {
 
 QueryUserPurchases.propTypes = {
 	userId: PropTypes.number.isRequired,
-	fetchingUserPurchases: PropTypes.bool.isRequired,
+	requesting: PropTypes.bool.isRequired,
 	fetchUserPurchases: PropTypes.func.isRequired
 };
 
 export default connect(
 	state => {
 		return {
-			fetchingUserPurchases: isFetchingUserPurchases( state )
+			requesting: isFetchingUserPurchases( state )
 		};
 	},
 	{ fetchUserPurchases }

--- a/client/components/data/query-user-purchases/index.jsx
+++ b/client/components/data/query-user-purchases/index.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isFetchingUserPurchases } from 'state/purchases/selectors';
+import { fetchUserPurchases } from 'state/purchases/actions';
+
+class QueryUserPurchases extends Component {
+	constructor( props ) {
+		super( props );
+		this.requestUserPurchases = this.requestUserPurchases.bind( this );
+	}
+
+	requestUserPurchases( props = this.props ) {
+		this.props.fetchUserPurchases( props.userId );
+	}
+
+	componentWillMount() {
+		this.requestUserPurchases();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.fetchingUserPurchases ||
+			! nextProps.userId ||
+			( this.props.userId === nextProps.userId ) ) {
+			return;
+		}
+		this.requestUserPurchases( nextProps );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryUserPurchases.propTypes = {
+	userId: PropTypes.number.isRequired,
+	fetchingUserPurchases: PropTypes.bool.isRequired,
+	fetchUserPurchases: PropTypes.func.isRequired
+};
+
+export default connect(
+	state => {
+		return {
+			fetchingUserPurchases: isFetchingUserPurchases( state )
+		};
+	},
+	{ fetchUserPurchases }
+)( QueryUserPurchases );

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -1,5 +1,5 @@
 /**
- * Return user's purchases from state object
+ * Return the list of purchases from state object
  *
  * @param {Object} state - current state object
  * @return {Array} Purchases

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -1,9 +1,19 @@
-// External dependencies
-import assign from 'lodash/assign';
-import find from 'lodash/find';
+/**
+ * Return user's purchases from state object
+ *
+ * @param {Object} state - current state object
+ * @return {Array} Purchases
+ */
+export const getPurchases = state => state.purchases.data;
 
-export const getByPurchaseId = ( state, id ) => (
-	assign( {}, state, { data: find( state.data, { id } ) } )
+/**
+ * Returns a Purchase object from the state using its id
+ * @param  {Object} state       global state
+ * @param  {Number} purchaseId  the purchase id
+ * @return {Object} the matching purchase if there is one
+ */
+export const getByPurchaseId = ( state, purchaseId ) => (
+	getPurchases( state ).filter( purchase => purchase.id === purchaseId ).shift()
 );
 
 export const isFetchingUserPurchases = state => state.purchases.isFetchingUserPurchases;

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -5,3 +5,6 @@ import find from 'lodash/find';
 export const getByPurchaseId = ( state, id ) => (
 	assign( {}, state, { data: find( state.data, { id } ) } )
 );
+
+export const isFetchingUserPurchases = state => state.purchases.isFetchingUserPurchases;
+export const isFetchingSitePurchases = state => state.purchases.isFetchingSitePurchases;

--- a/client/state/purchases/test/reducer.js
+++ b/client/state/purchases/test/reducer.js
@@ -142,18 +142,11 @@ describe( 'items', () => {
 			purchaseId: 2
 		} );
 
-		expect( getByPurchaseId( state, 2 ) ).to.be.eql( {
-			data: {
-				id: 2,
-				error: 'Unable to fetch stored cards',
-				siteId,
-				userId
-			},
-			error: null,
-			isFetchingSitePurchases: false,
-			isFetchingUserPurchases: false,
-			hasLoadedSitePurchasesFromServer: true,
-			hasLoadedUserPurchasesFromServer: true
+		expect( getByPurchaseId( { purchases: state }, 2 ) ).to.be.eql( {
+			id: 2,
+			error: 'Unable to fetch stored cards',
+			siteId,
+			userId
 		} );
 	} );
 
@@ -182,20 +175,13 @@ describe( 'items', () => {
 			}
 		} );
 
-		expect( getByPurchaseId( state, 2 ) ).to.be.eql( {
-			data: {
-				amount: 2200,
-				error: null,
-				hasPrivateRegistration: false,
-				id: 2,
-				siteId,
-				userId
-			},
+		expect( getByPurchaseId( { purchases: state }, 2 ) ).to.be.eql( {
+			amount: 2200,
 			error: null,
-			isFetchingSitePurchases: false,
-			isFetchingUserPurchases: false,
-			hasLoadedSitePurchasesFromServer: true,
-			hasLoadedUserPurchasesFromServer: true
+			hasPrivateRegistration: false,
+			id: 2,
+			siteId,
+			userId
 		} );
 	} );
 } );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -6,7 +6,7 @@ import { getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases } fro
 
 describe( 'selectors', () => {
 	describe( 'getByPurchaseId', () => {
-		it( 'should return a purchase by its ID, preserving the top-level flags', () => {
+		it( 'should return a purchase by its ID', () => {
 			const state = {
 				purchases: {
 					data: [
@@ -43,7 +43,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isFetchingSitePurchases', () => {
-		it( 'should return a purchase by its ID, preserving the top-level flags', () => {
+		it( 'should return the current state of the site purchases request', () => {
 			const state = {
 				purchases: {
 					data: [],

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 
 // Internal dependencies
-import { getByPurchaseId } from '../selectors';
+import { getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( 'getByPurchaseId', () => {
@@ -27,6 +27,40 @@ describe( 'selectors', () => {
 				hasLoadedSitePurchasesFromServer: false,
 				hasLoadedUserPurchasesFromServer: true
 			} );
+		} );
+	} );
+
+	describe( 'isFetchingUserPurchases', () => {
+		it( 'should return the current state of the user purchases request', () => {
+			const state = {
+				purchases: {
+					data: [],
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: true,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false
+				}
+			};
+
+			expect( isFetchingUserPurchases( state ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'isFetchingSitePurchases', () => {
+		it( 'should return a purchase by its ID, preserving the top-level flags', () => {
+			const state = {
+				purchases: {
+					data: [],
+					error: null,
+					isFetchingSitePurchases: true,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false
+				}
+			};
+
+			expect( isFetchingSitePurchases( state ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -8,25 +8,20 @@ describe( 'selectors', () => {
 	describe( 'getByPurchaseId', () => {
 		it( 'should return a purchase by its ID, preserving the top-level flags', () => {
 			const state = {
-				data: [
-					{ id: 1, name: 'domain registration' },
-					{ id: 2, name: 'premium plan' }
-				],
-				error: null,
-				isFetchingSitePurchases: false,
-				isFetchingUserPurchases: false,
-				hasLoadedSitePurchasesFromServer: false,
-				hasLoadedUserPurchasesFromServer: true
+				purchases: {
+					data: [
+						{ id: 1, name: 'domain registration' },
+						{ id: 2, name: 'premium plan' }
+					],
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true
+				}
 			};
 
-			expect( getByPurchaseId( state, 2 ) ).to.be.eql( {
-				data: { id: 2, name: 'premium plan' },
-				error: null,
-				isFetchingSitePurchases: false,
-				isFetchingUserPurchases: false,
-				hasLoadedSitePurchasesFromServer: false,
-				hasLoadedUserPurchasesFromServer: true
-			} );
+			expect( getByPurchaseId( state, 2 ) ).to.be.eql( { id: 2, name: 'premium plan' } );
 		} );
 	} );
 


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/5046

This PR actually adds 2 new Query Components:
- `QuerySitePurchases` to query site purchases
- `QueryUserPurchases` to query user purchases

### Reviews

Those components aren't used anywhere yet but will be used in an upcoming PR to update components to use the new `state.purchases` reducer introduced in https://github.com/Automattic/wp-calypso/pull/6317 and https://github.com/Automattic/wp-calypso/pull/6383 

- [x] Code

@Automattic/sdev-feed 

Test live: https://calypso.live/?branch=add/query-purchases