### PR TITLE
Framework: Refine ESLint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,20 +26,30 @@ module.exports = {
 		'camelcase': 0,
 		'comma-dangle': 0,
 		'comma-spacing': 1,
+		'comma-style': 2,
 		'computed-property-spacing': [ 1, 'always' ],
+		'constructor-super': 2,
 		// Allows returning early as undefined
 		'consistent-return': 0,
+		'curly': 1,
 		'dot-notation': 1,
 		'eqeqeq': [ 2, 'allow-null' ],
 		'eol-last': 1,
 		'indent': [ 1, 'tab', { 'SwitchCase': 1 } ],
+		'jsx-quotes': [ 1, 'prefer-double' ],
 		'key-spacing': 1,
 		'keyword-spacing': 1,
+		'max-len': [ 1, { code: 100 } ],
 		'new-cap': [ 1, { 'capIsNew': false, 'newIsCap': true } ],
 		'no-cond-assign': 2,
+		'no-const-assign': 2,
+		'no-console': 1,
+		'no-debugger': 2,
+		'no-dupe-args': 2,
 		'no-dupe-keys': 2,
+		'no-duplicate-case': 2,
 		'no-else-return': 1,
-		'no-empty': 1,
+		'no-empty': [ 2, { allowEmptyCatch: true } ],
 		'no-extra-semi': 1,
 		// Flux stores use switch case fallthrough
 		'no-fallthrough': 0,
@@ -48,6 +58,7 @@ module.exports = {
 		'no-mixed-spaces-and-tabs': 1,
 		'no-multiple-empty-lines': [ 1, { max: 1 } ],
 		'no-multi-spaces': 1,
+		'no-negated-in-lhs': 2,
 		'no-nested-ternary': 1,
 		'no-new': 1,
 		'no-process-exit': 1,
@@ -57,11 +68,24 @@ module.exports = {
 		'no-trailing-spaces': 1,
 		'no-undef': 2,
 		'no-underscore-dangle': 0,
+		'no-unreachable': 1,
 		// Allows Chai `expect` expressions
 		'no-unused-expressions': 0,
 		'no-unused-vars': 1,
+		// Allows function use before declaration
+		'no-use-before-define': [ 2, 'nofunc' ],
 		'no-var': 1,
+		'object-curly-spacing': [ 1, 'always' ],
+		// We split external, internal, module variables
+		'one-var': 0,
+		'operator-linebreak': [ 1, 'after', { 'overrides': {
+			'?': 'before',
+			':': 'before'
+		} } ],
+		'padded-blocks': [ 1, 'never' ],
 		'prefer-const': 1,
+		'quote-props': [ 1, 'as-needed', { 'keywords': true } ],
+		'quotes': [ 1, 'single', 'avoid-escape' ],
 		// Teach eslint about React+JSX
 		'react/jsx-uses-react': 1,
 		'react/jsx-uses-vars': 1,
@@ -71,35 +95,25 @@ module.exports = {
 		'react/no-danger': 2,
 		'react/no-did-mount-set-state': 1,
 		'react/no-did-update-set-state': 1,
-		'jsx-quotes': [ 1, 'prefer-double' ],
+		'react/no-is-mounted': 1,
 		'react/jsx-no-bind': 1,
 		'react/jsx-curly-spacing': [ 1, 'always' ],
-		// Allows function use before declaration
-		'no-use-before-define': [ 2, 'nofunc' ],
-		'object-curly-spacing': [ 1, 'always' ],
-		// We split external, internal, module variables
-		'one-var': 0,
-		'operator-linebreak': [ 1, 'after', { 'overrides': {
-			'?': 'before',
-			':': 'before'
-		} } ],
-		'padded-blocks': [ 1, 'never' ],
-		'quote-props': [ 1, 'as-needed', { 'keywords': true } ],
-		'quotes': [ 1, 'single', 'avoid-escape' ],
 		'semi': 1,
 		'semi-spacing': 1,
 		'space-before-blocks': [ 1, 'always' ],
 		'space-before-function-paren': [ 1, 'never' ],
 		'space-in-parens': [ 1, 'always' ],
 		'space-infix-ops': [ 1, { 'int32Hint': false } ],
-		// Ideal for '!' but not for '++'
-		'space-unary-ops': 0,
+		'space-unary-ops': [ 1, {
+			overrides: {
+				'!': true
+			}
+		} ],
 		// Assumed by default with Babel
 		'strict': [ 2, 'never' ],
 		'valid-jsdoc': [ 1, { 'requireReturn': false } ],
 		// Common top-of-file requires, expressions between external, interal
 		'vars-on-top': 1,
-		'yoda': 0,
 		// Custom rules
 		'wpcalypso/no-lodash-import': 2,
 		'wpcalypso/i18n-ellipsis': 1,
@@ -108,6 +122,7 @@ module.exports = {
 		'wpcalypso/i18n-mismatched-placeholders': 1,
 		'wpcalypso/i18n-named-placeholders': 1,
 		'wpcalypso/jsx-gridicon-size': 1,
-		'wpcalypso/jsx-classname-namespace': 1
+		'wpcalypso/jsx-classname-namespace': 1,
+		'yoda': 0
 	}
 };

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -41,7 +41,7 @@ var TokenField = React.createClass( {
 
 			forEach( value, ( item ) => {
 				if ( 'object' === typeof item ) {
-					if ( ! 'value' in item ) {
+					if ( ! ( 'value' in item ) ) {
 						return new Error(
 							"When using object for value prop, each object is expected to have a 'value' property."
 						);

--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -576,7 +576,7 @@ module.exports = {
 				return i18n.translate( 'Plugin is already installed.' );
 
 			case 'incompatible_archive':
-				return i18n.translate( 'Incompatible Archive.' );
+				return i18n.translate( 'Incompatible Archive. The package could not be installed.' );
 
 			case 'empty_archive_pclzip':
 				return i18n.translate( 'Empty archive.' );
@@ -623,9 +623,6 @@ module.exports = {
 
 			case 'mkdir_failed':
 				return i18n.translate( 'Could not create directory.' );
-
-			case 'incompatible_archive':
-				return i18n.translate( 'The package could not be installed.' );
 
 			case 'files_not_writable':
 				return i18n.translate( 'The update cannot be installed because we will be unable to copy some files. This is usually due to inconsistent file permissions.' );

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -99,7 +99,7 @@ export function recordTrack( eventName, eventProperties ) {
 		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
 	}
 	if ( process.env.NODE_ENV !== 'production' ) {
-		if ( 'blog_id' in eventProperties && 'post_id' in eventProperties && ! 'is_jetpack' in eventProperties ) {
+		if ( 'blog_id' in eventProperties && 'post_id' in eventProperties && ! ( 'is_jetpack' in eventProperties ) ) {
 			console.warn( 'consider using recordTrackForPost...', eventName, eventProperties );
 		}
 	}


### PR DESCRIPTION
This pull request seeks to reconcile our ESLint configuration to make use of new rules and new options for existing rules. None of these changes are meant to be controversial (though I was tempted to raise a few 😄 ). The configuration file was also sorted, so I've included a detailed list of changes and reasoning below:

- New: [`comma-style`](http://eslint.org/docs/rules/comma-style) (2)
 - Enforces end-of-line commas, conventionally used in Calypso
 - Follow-up: Document in coding guidelines
- New: [`constructor-super`](http://eslint.org/docs/rules/constructor-super) (2)
 - Enforces `super` call in ES6 class constructor
 - Coding error
- New: [`curly`](http://eslint.org/docs/rules/curly) (1)
 - Requires all blocks to use curly braces
 - [Guideline](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#spacing): "if/else/for/while/try blocks should always use braces, and always go on multiple lines."
- New: [`max-len`](http://eslint.org/docs/rules/max-len) (1)
 - Warns when line length exceeds 100 characters
 - [Guideline](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#spacing): "Lines should usually be no longer than 80 characters, and should not exceed 100 (counting tabs as 4 spaces). This is a “soft” rule, but long lines generally indicate unreadable or disorganized code."
- New: [`no-const-assign`](http://eslint.org/docs/rules/no-const-assign) (2)
 - Prevents reassignment of `const` variables
 - Coding error
- New: [`no-console`](http://eslint.org/docs/rules/no-console) (1)
 - Warns when using `console`
 - Okay to use while debugging, but shouldn't be committed. Intentional usage should disable rule.
 - Follow-up: Change to error, disable rule for existing usage
- New: [`no-debugger`](http://eslint.org/docs/rules/no-debugger) (2)
 - Prevents usage of `debugger;`
 - Okay to leave in while debugging, but shouldn't be committed.
- New: [`no-dupe-args`](http://eslint.org/docs/rules/no-dupe-args) (2)
 - Prevents two function arguments with same name
 - Coding error
- New: [`no-duplicate-case`](http://eslint.org/docs/rules/no-duplicate-case) (2)
 - Prevents two `case` in a `switch` with the same name
 - Coding error
 - cc @enejb There's an instance of this in [plugins/notices.jsx](https://github.com/Automattic/wp-calypso/blob/4c38719db49dff98e9989530478d0a92a412dd07/client/lib/plugins/notices.jsx#L627-L628) and I'm unsure which of the two cases is preferred
- New: [`no-negated-in-lhs`](http://eslint.org/docs/rules/no-negated-in-lhs) (2)
 - Prevents `!` (not) in the left hand of an `in` expression without parantheses
 - Almost always unintentional behavior (`!` is evaluated, i.e. cast to boolean, before `in` check)
 - Resolved two instances of this in aa1aac4
- New: [`no-unreachable`](http://eslint.org/docs/rules/no-unreachable) (1)
 - Warns against unreachable code
 - Follow-up: Change to error, fix remaining issues (most are `break;` following a `return` in a `switch`)
- New: [`react/no-is-mounted`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md) (1)
 - Warns against use of `this.isMounted()` in a React component
 - [Deprecated anti-pattern](https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html)
- Updated: [`space-unary-ops`](http://eslint.org/docs/rules/space-unary-ops) (1)
 - Previously disabled because of inability to configure allowing `!!`, `++`, `--`
- Updated: [`no-empty`](http://eslint.org/docs/rules/no-empty) (2)
 - Upgraded to error, adding exception for `catch`

Possible rules to consider as separate pull requests that I was concerned may be too controversial:
- [arrow-parens](http://eslint.org/docs/rules/arrow-parens): Require parentheses around arrow function parameters
- [react/prefer-es6-class](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md): Prevent usage of `React.createClass`
- [react/prop-types](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md): Require `propTypes` for React components
- [react/jsx-indent](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md): Enforce consistent indentation

And another that's not yet available, but we should keep our eyes on, is [`react/unused-prop-types`](https://github.com/yannickcr/eslint-plugin-react/pull/611).