### PR TITLE
Add "My Plan" page for Jetpack/.org plans

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack.jsx
+++ b/client/my-sites/plans/current-plan/jetpack.jsx
@@ -22,7 +22,7 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 				icon="flag"
 				title={ 'Backups & Security' }
 				description={ i18n.translate(
-					'VaultPress makes it easy to keep an up-to-date backup of your site with both daily and realtime syncing of all your WordPress content. To ensure your site stays safe, VaultPress performs security scans daily and makes it easy to review and fix threats.'
+					'VaultPress makes it easy to keep an up-to-date backup of your site with both daily and real-time syncing of all your WordPress content. To ensure your site stays safe, VaultPress performs security scans daily and makes it easy to review and fix threats.'
 				) }
 				buttonText={ i18n.translate( 'View your backups' ) }
 				href="https://dashboard.vaultpress.com/" />
@@ -32,7 +32,7 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 				icon="comment"
 				title={ 'Anti-Spam' }
 				description={ i18n.translate(
-					'Akismet filters out your comment spam for you, so you can focus on more important things.'
+					'Akismet filters out comment and other forms of spam, so you can focus on more important things.'
 				) } />
 			}
 
@@ -58,9 +58,9 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 
 			<PurchaseDetail
 				icon="plugins"
-				title={ 'Calypso Features' }
+				title={ 'Get the most from WordPress.com' }
 				description={ i18n.translate(
-					'Enable plugin auto-updates, Browse your stats, Try out the new editor, {{a}}Download WordPress.com apps{{/a}}.',
+					'Enable plugin auto-updates, browse your stats, try the improved WordPress.com editor, {{a}}Download WordPress.com apps{{/a}}.',
 					{
 						components: {
 							a: <a href="https://apps.wordpress.com/" />

--- a/client/my-sites/plans/current-plan/jetpack.jsx
+++ b/client/my-sites/plans/current-plan/jetpack.jsx
@@ -20,9 +20,11 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 		<div className="current-plan__details">
 			{ isPaid && <PurchaseDetail
 				icon="flag"
-				title={ 'Backups & Security' }
+				title={ i18n.translate( 'Backups & Security' ) }
 				description={ i18n.translate(
-					'VaultPress makes it easy to keep an up-to-date backup of your site with both daily and real-time syncing of all your WordPress content. To ensure your site stays safe, VaultPress performs security scans daily and makes it easy to review and fix threats.'
+					'VaultPress makes it easy to keep an up-to-date backup of your site with both daily and real-time syncing of all ' +
+					'your WordPress content. To ensure your site stays safe, VaultPress performs security scans daily and makes it ' +
+					'easy to review and fix threats.'
 				) }
 				buttonText={ i18n.translate( 'View your backups' ) }
 				href="https://dashboard.vaultpress.com/" />
@@ -30,7 +32,7 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 
 			{ isPaid && <PurchaseDetail
 				icon="comment"
-				title={ 'Anti-Spam' }
+				title={ i18n.translate( 'Anti-Spam' ) }
 				description={ i18n.translate(
 					'Akismet filters out comment and other forms of spam, so you can focus on more important things.'
 				) } />
@@ -38,9 +40,10 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 
 			{ isBusiness && <PurchaseDetail
 				icon="list-checkmark"
-				title={ 'Surveys & Polls' }
+				title={ i18n.translate( 'Surveys & Polls' ) }
 				description={ i18n.translate(
-					'Unlimited surveys, unlimited responses. Use the survey editor to create surveys quickly and easily. Collect responses via your website, e-mail or on your iPad or iPhone'
+					'Unlimited surveys, unlimited responses. Use the survey editor to create surveys quickly and easily. Collect ' +
+					'responses via your website, e-mail or on your iPad or iPhone'
 				) }
 				buttonText={ i18n.translate( 'Create a new poll' ) }
 				href="https://polldaddy.com/dashboard/" />
@@ -48,7 +51,7 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 
 			{ isBusiness && <PurchaseDetail
 				icon="add-outline"
-				title={ 'Add additional sites' }
+				title={ i18n.translate( 'Add additional sites' ) }
 				description={ i18n.translate(
 					'You can add an additional 2 sites to this plan.'
 				) }
@@ -58,9 +61,10 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 
 			<PurchaseDetail
 				icon="plugins"
-				title={ 'Get the most from WordPress.com' }
+				title={ i18n.translate( 'Get the most from WordPress.com' ) }
 				description={ i18n.translate(
-					'Enable plugin auto-updates, browse your stats, try the improved WordPress.com editor, {{a}}Download WordPress.com apps{{/a}}.',
+					'Enable plugin auto-updates, browse your stats, try the improved WordPress.com editor, ' +
+					'{{a}}Download WordPress.com apps{{/a}}.',
 					{
 						components: {
 							a: <a href="https://apps.wordpress.com/" />
@@ -72,7 +76,7 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 
 			<PurchaseDetail
 				icon="house"
-				title={ 'Return to your site\'s dashboard' }
+				title={ i18n.translate( 'Return to your site\'s dashboard' ) }
 				buttonText={ i18n.translate( 'Go back to %(site)s', { args: { site: selectedSite.name } } ) }
 				href={ `${selectedSite.URL}/wp-admin/` } />
 		</div>

--- a/client/my-sites/plans/current-plan/jetpack.jsx
+++ b/client/my-sites/plans/current-plan/jetpack.jsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+import {
+	isJetpackBusiness,
+	isJetpackPremium
+} from 'lib/products-values';
+
+const JetpackPlanDetails = ( { selectedSite } ) => {
+	const isPaid = ( isJetpackBusiness( selectedSite.plan ) || isJetpackPremium( selectedSite.plan ) );
+	const isBusiness = isJetpackBusiness( selectedSite.plan );
+	return (
+		<div className="current-plan__details">
+			{ isPaid && <PurchaseDetail
+				icon="flag"
+				title={ 'Backups & Security' }
+				description={ i18n.translate(
+					'VaultPress makes it easy to keep an up-to-date backup of your site with both daily and realtime syncing of all your WordPress content. To ensure your site stays safe, VaultPress performs security scans daily and makes it easy to review and fix threats.'
+				) }
+				buttonText={ i18n.translate( 'View your backups' ) }
+				href="https://dashboard.vaultpress.com/" />
+			}
+
+			{ isPaid && <PurchaseDetail
+				icon="comment"
+				title={ 'Anti-Spam' }
+				description={ i18n.translate(
+					'Akismet filters out your comment spam for you, so you can focus on more important things.'
+				) } />
+			}
+
+			{ isBusiness && <PurchaseDetail
+				icon="list-checkmark"
+				title={ 'Surveys & Polls' }
+				description={ i18n.translate(
+					'Unlimited surveys, unlimited responses. Use the survey editor to create surveys quickly and easily. Collect responses via your website, e-mail or on your iPad or iPhone'
+				) }
+				buttonText={ i18n.translate( 'Create a new poll' ) }
+				href="https://polldaddy.com/dashboard/" />
+			}
+
+			{ isBusiness && <PurchaseDetail
+				icon="add-outline"
+				title={ 'Add additional sites' }
+				description={ i18n.translate(
+					'You can add an additional 2 sites to this plan.'
+				) }
+				buttonText={ i18n.translate( 'Add another site' ) }
+				href="#" />
+			}
+
+			<PurchaseDetail
+				icon="plugins"
+				title={ 'Calypso Features' }
+				description={ i18n.translate(
+					'Enable plugin auto-updates, Browse your stats, Try out the new editor, {{a}}Download WordPress.com apps{{/a}}.',
+					{
+						components: {
+							a: <a href="https://apps.wordpress.com/" />
+						}
+					}
+				) }
+				buttonText={ i18n.translate( 'Turn on autoupdates' ) }
+				href={ `/plugins/${selectedSite.slug}` } />
+
+			<PurchaseDetail
+				icon="house"
+				title={ 'Return to your site\'s dashboard' }
+				buttonText={ i18n.translate( 'Go back to %(site)s', { args: { site: selectedSite.name } } ) }
+				href={ `${selectedSite.URL}/wp-admin/` } />
+		</div>
+	);
+};
+
+export default JetpackPlanDetails;

--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import Main from 'components/main';
 import Card from 'components/card';
 import HappinessSupport from 'components/happiness-support';
-import JetpackPlanDetails from 'my-sites/upgrades/checkout-thank-you/jetpack-plan-details';
+import JetpackPlanDetails from './jetpack';
 import PersonalPlanDetails from 'my-sites/upgrades/checkout-thank-you/personal-plan-details';
 import PremiumPlanDetails from 'my-sites/upgrades/checkout-thank-you/premium-plan-details';
 import BusinessPlanDetails from 'my-sites/upgrades/checkout-thank-you/business-plan-details';
@@ -23,6 +23,8 @@ import { fetchSitePlans } from 'state/sites/plans/actions';
 import {
 	isBusiness,
 	isPremium,
+	isJetpackBusiness,
+	isJetpackPremium,
 	isPersonal,
 	isFreePlan
 } from 'lib/products-values';
@@ -58,8 +60,13 @@ const PlanDetailsComponent = React.createClass( {
 		} else if ( isFreePlan( this.props.selectedSite.plan ) ) {
 			page.redirect( '/plans/' + this.props.selectedSite.slug );
 		} else if ( this.props.selectedSite.jetpack ) {
-			title = this.translate( 'Your site is on a Premium plan' );
+			title = this.translate( 'Your site is on a Free plan' );
 			tagLine = this.translate( 'Unlock the full potential of your site with all the features included in your plan.' );
+			if ( isJetpackPremium( this.props.selectedSite.plan ) ) {
+				title = this.translate( 'Your site is on a Premium plan' );
+			} else if ( isJetpackBusiness( this.props.selectedSite.plan ) ) {
+				title = this.translate( 'Your site is on a Professional plan' );
+			}
 			featuresList = (
 				<JetpackPlanDetails
 					selectedSite={ this.props.selectedSite }
@@ -123,7 +130,7 @@ const PlanDetailsComponent = React.createClass( {
 				</Card>
 				<Card>
 					<HappinessSupport
-						isJetpack={ false }
+						isJetpack={ !! this.props.selectedSite.jetpack }
 						isPlaceholder={ false } />
 				</Card>
 				{ selectedSite &&

--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 import Main from 'components/main';
 import Card from 'components/card';
 import HappinessSupport from 'components/happiness-support';
+import JetpackPlanDetails from 'my-sites/upgrades/checkout-thank-you/jetpack-plan-details';
 import PersonalPlanDetails from 'my-sites/upgrades/checkout-thank-you/personal-plan-details';
 import PremiumPlanDetails from 'my-sites/upgrades/checkout-thank-you/premium-plan-details';
 import BusinessPlanDetails from 'my-sites/upgrades/checkout-thank-you/business-plan-details';
@@ -54,8 +55,17 @@ const PlanDetailsComponent = React.createClass( {
 						<PurchaseDetail isPlaceholder />
 				</div>
 			);
-		} else if ( this.props.selectedSite.jetpack || isFreePlan( this.props.selectedSite.plan ) ) {
+		} else if ( isFreePlan( this.props.selectedSite.plan ) ) {
 			page.redirect( '/plans/' + this.props.selectedSite.slug );
+		} else if ( this.props.selectedSite.jetpack ) {
+			title = this.translate( 'Your site is on a Premium plan' );
+			tagLine = this.translate( 'Unlock the full potential of your site with all the features included in your plan.' );
+			featuresList = (
+				<JetpackPlanDetails
+					selectedSite={ this.props.selectedSite }
+					sitePlans={ this.props.sitePlans }
+				/>
+			);
 		} else if ( isPersonal( this.props.selectedSite.plan ) ) {
 			title = this.translate( 'Your site is on a Personal plan' );
 			tagLine = this.translate( 'Unlock the full potential of your site with all the features included in your plan.' );


### PR DESCRIPTION
This adds a "My Plan" page for Jetpack sites, like the WordPress.com counterpart. See #5892 for discussion on the features listed.

To test:

1. Visit `/plans/my-plan/$site`, for any Jetpack site
2. It should load a page telling you what plan you're on (Free, Premium, Professional)
3. You'll see different features based on your plan

The copy is entirely placeholder- VaultPress, Akismet, and Polldaddy were pulled from their sites, but the rest is basically notes. I left in "Add additional sites" since I'm not sure how that'll work — if it's a feature flag, I can use that to enable the card, otherwise we can remove the card 'til that's built.

cc @rickybanister @johnHackworth 

Test live: https://calypso.live/?branch=add/jetpack-my-plan