### PR TITLE
Plans: fix bug in plans routing logic

### DIFF
--- a/client/my-sites/plans/plan-overview/index.jsx
+++ b/client/my-sites/plans/plan-overview/index.jsx
@@ -8,7 +8,6 @@ import React from 'react';
  * Internal dependencies
  */
 import Main from 'components/main';
-import paths from '../paths';
 import PlanFeatures from './plan-features';
 import PlanRemove from './plan-remove';
 import PlanStatus from './plan-status';
@@ -30,7 +29,8 @@ const PlanOverview = React.createClass( {
 	},
 
 	redirectToDefault() {
-		page.redirect( paths.plans( this.props.selectedSite.slug ) );
+		const site = this.props.selectedSite.slug;
+		page.redirect( `/plans/${ site }` );
 	},
 
 	renderNotice() {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -46,7 +46,6 @@ import {
 } from 'lib/products-values';
 import JetpackPlanDetails from './jetpack-plan-details';
 import Main from 'components/main';
-import plansPaths from 'my-sites/plans/paths';
 import PersonalPlanDetails from './personal-plan-details';
 import PremiumPlanDetails from './premium-plan-details';
 import BusinessPlanDetails from './business-plan-details';
@@ -133,9 +132,10 @@ const CheckoutThankYou = React.createClass( {
 	goBack() {
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			const purchases = getPurchases( this.props );
+			const site = this.props.selectedSite.slug;
 
 			if ( purchases.some( isPlan ) ) {
-				page( plansPaths.plans( this.props.selectedSite.slug ) );
+				page( `/plans/${ site }` );
 			} else if ( purchases.some( isDomainProduct ) || purchases.some( isDomainRedemption || purchases.some( isSiteRedirect ) ) ) {
 				page( upgradesPaths.domainManagementList( this.props.selectedSite.slug ) );
 			} else if ( purchases.some( isGoogleApps ) ) {


### PR DESCRIPTION
This fixes #6304 where clicking on "back to my site" link after purchasing a wpcom plan took you to a bad URL that looks like https://wordpress.com/plans/:intervalType/justanexample.wordpress.com. The issue is that we added some routing logic for monthly/yearly plans in #6029, but the way routing works in plans, if you don't set that parameter, we return the route with a default string of ":intervalType" as a placeholder.

At first I tried removing the default value for `intervalType` [in this router function](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/plans/paths.js#L5), which is where the issue is coming from. But that broke the annual/monthly jetpack plans toggle. We're using this same `paths.plans()` function to return the routing string with regex tokens as well as to create an actual URL for redirection.

All of this routing logic and abstraction is unnecessary and frankly causing problems. I think we just need to remove these functions and replace them with the routing approach we apply in other areas of calypso. I'm starting that here by building explicit strings in the redirect logic. It's actually no more code than using the router abstraction method, but it's a lot clearer.

## Testing

Go through the process of purchasing a WordPress.com plan for one of your sites (with credits, as an Automattician). On the "thank-you" page, click the "back to your site" link in the upper-left. It should take you to the plans page.

Also test to make sure the logic to display annual and monthly plan options for jetpack sites is working. Go to the `/plans` page for a jetpack site. You should see a "show yearly plans" / "show monthly plans" toggle. Use the toggle and make sure it works correctly.

![jetpack toggle](https://cloudup.com/colGLh1Fh9b+)

/cc @gwwar @rickybanister @johnHackworth 