### PR TITLE
Added themes-list-loaded flag after rendering ThemesList component

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -92,14 +92,17 @@ export const ThemesList = React.createClass( {
 				/>;
 	},
 
+	// The themes-list-loaded class is used as a trigger for the e2e tests to
+	// indicate when the component is finished loading all themes
+	// -- https://github.com/Automattic/wp-e2e-tests
 	componentWillUpdate: function() {
 		var node = ReactDom.findDOMNode( this );
 		node.className = node.className.replace( / themes-list-loaded/, '' );
 	},
 
 	componentDidUpdate: function() {
-		ReactDom.findDOMNode( this ).className += " themes-list-loaded";
-	  },
+		ReactDom.findDOMNode( this ).className += ' themes-list-loaded';
+	},
 
 	render() {
 		if ( ! this.props.loading && this.props.themes.length === 0 ) {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import ReactDom from 'react-dom';
 import times from 'lodash/times';
 import isEqual from 'lodash/isEqual';
 
@@ -90,6 +91,15 @@ export const ThemesList = React.createClass( {
 				line={ this.props.translate( 'Try a different search or more filters?' ) }
 				/>;
 	},
+
+	componentWillUpdate: function() {
+		var node = ReactDom.findDOMNode( this );
+		node.className = node.className.replace( / themes-list-loaded/, '' );
+	},
+
+	componentDidUpdate: function() {
+		ReactDom.findDOMNode( this ).className += " themes-list-loaded";
+	  },
 
 	render() {
 		if ( ! this.props.loading && this.props.themes.length === 0 ) {


### PR DESCRIPTION
We've been having instability in our e2e tests because we can't detect when the themes list is done loading (see #6168 as one example).  So I've put this together to add a class `themes-list-loaded` to the DOM element via the `componentDidUpdate` event after it's been rendered .

But I'm not sure if A) there's any harm to this implementation, B) whether it will be 100% reliable as the themes list is filtered/updated, and C) if there's a better way to accomplish the same goal

Thoughts?

Test live: https://calypso.live/?branch=try/themes-list-done-loading-flag