### PR TITLE
Advanced SEO: Add support for saving/editing post meta description

### DIFF
--- a/client/lib/post-metadata/index.js
+++ b/client/lib/post-metadata/index.js
@@ -95,6 +95,21 @@ PostMetadata = {
 	},
 
 	/**
+	 * Given a post object, returns the custom post meta description for
+	 * the post, or undefined if it is has not been set.
+	 *
+	 * @param  {Object} post Post object
+	 * @return {string}      Custom post meta description
+	 */
+	metaDescription: function( post ) {
+		if ( ! post ) {
+			return;
+		}
+
+		return getValueByKey( post.metadata, 'advanced_seo_description' );
+	},
+
+	/**
 	 * Given a post object, returns an array of float coordinates representing
 	 * the geographic location saved for that post, or `undefined` if the value
 	 * cannot be determined.

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -257,7 +257,7 @@ const EditorDrawer = React.createClass( {
 		}
 
 		return (
-			<SeoAccordion />
+			<SeoAccordion metaDescription={ PostMetadata.metaDescription( this.props.post ) } />
 		);
 	},
 

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -14,11 +14,11 @@ import CountedTextarea from 'components/forms/counted-textarea';
 import Gridicon from 'components/gridicon';
 import InfoPopover from 'components/info-popover';
 import TokenField from 'components/token-field';
+import PostActions from 'lib/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 
-function EditorSeoAccordion( props ) {
-	const { translate, siteSlug } = props;
+function EditorSeoAccordion( { translate, siteSlug, metaDescription = '' } ) {
 	// Temporary placeholder chips for design review
 	const sampleChips = [ 'Post Title', 'Site Title' ];
 
@@ -61,15 +61,24 @@ function EditorSeoAccordion( props ) {
 					acceptableLength={ 159 }
 					placeholder={ translate( 'Write a description…' ) }
 					aria-label={ translate( 'Write a description…' ) }
+					value={ metaDescription }
+					onChange={ onMetaChange }
 				/>
 			</AccordionSection>
 		</Accordion>
 	);
 }
 
+function onMetaChange( event ) {
+	PostActions.updateMetadata( {
+		advanced_seo_description: event.target.value
+	} );
+}
+
 EditorSeoAccordion.propTypes = {
 	translate: PropTypes.func,
-	siteSlug: PropTypes.string
+	siteSlug: PropTypes.string,
+	metaDescription: PropTypes.string
 };
 
 const mapStateToProps = ( state ) => ( {


### PR DESCRIPTION
Connects up the SEO meta description textarea to the new `advanced_seo_description` meta field that was recently added to the API.

<img width="276" alt="screen shot 2016-06-24 at 12 35 27 pm" src="https://cloud.githubusercontent.com/assets/789137/16348669/ee6d043e-3a08-11e6-821a-4d30868d6ab2.png">

I followed a similar pattern to saving the postmeta field to what I found in the `editor-location` component.

**To test**
* Ensure your site has a business plan.
* Start a new post, and expand the `Advanced SEO` accordion.
* Enter some text in the `META DESCRIPTION` field, and save the post.
* Ensure that the data was saved by checking the postmeta fields in the `sites/{site}/posts` response.

Refs #5834 

cc @aduth 

Test live: https://calypso.live/?branch=add/5834-advanced-seo-meta-api