### PR TITLE
CPT: Render list screen using isomorphic route middleware

### DIFF
--- a/client/controller.js
+++ b/client/controller.js
@@ -92,25 +92,31 @@ function renderSeparateTrees( context ) {
 }
 
 function renderPrimary( context ) {
-	const { primary } = context;
+	const { primary, store } = context;
 
 	if ( primary ) {
 		debug( 'Rendering primary', primary );
 		ReactDom.render(
-			primary,
+			<ReduxProvider store={ store }>
+				{ primary }
+			</ReduxProvider>,
 			document.getElementById( 'primary' )
 		);
 	}
 }
 
 function renderSecondary( context ) {
-	if ( context.secondary === null ) {
+	const { secondary, store } = context;
+
+	if ( secondary === null ) {
 		debug( 'Unmounting secondary' );
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-	} else if ( context.secondary !== undefined ) {
+	} else if ( secondary !== undefined ) {
 		debug( 'Rendering secondary' );
 		ReactDom.render(
-			context.secondary,
+			<ReduxProvider store={ store }>
+				{ secondary }
+			</ReduxProvider>,
 			document.getElementById( 'secondary' )
 		);
 	}

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 import omit from 'lodash/omit';
 import debugFactory from 'debug';
 import startsWith from 'lodash/startsWith';
@@ -28,13 +27,16 @@ const debug = debugFactory( 'calypso:themes' );
 let themeDetailsCache = new Map();
 
 export function makeElement( ThemesComponent, Head, store, props ) {
-	return(
-		<ReduxProvider store={ store }>
-			<Head title={ props.title } description={ props.description } type={ 'website' }
-				canonicalUrl={ props.canonicalUrl } image={ props.image } tier={ props.tier || 'all' }>
-				<ThemesComponent { ...omit( props, [ 'title' ] ) } />
-			</Head>
-		</ReduxProvider>
+	return (
+		<Head
+			title={ props.title }
+			description={ props.description }
+			type={ 'website' }
+			canonicalUrl={ props.canonicalUrl }
+			image={ props.image }
+			tier={ props.tier || 'all' }>
+			<ThemesComponent { ...omit( props, [ 'title' ] ) } />
+		</Head>
 	);
 }
 

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -7,8 +7,6 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
-import { getSiteFragment, sectionify } from 'lib/route';
-import { pageView } from 'lib/analytics';
 import Types from './main';
 
 export function redirect() {
@@ -16,16 +14,6 @@ export function redirect() {
 }
 
 export function list( context, next ) {
-	const siteId = getSiteFragment( context.path );
-	const sectionedPath = sectionify( context.path );
-
-	// Analytics
-	let baseAnalyticsPath = sectionedPath;
-	if ( siteId ) {
-		baseAnalyticsPath += '/:site';
-	}
-	pageView.record( baseAnalyticsPath, 'Custom Post Type' );
-
 	context.primary = (
 		<Types query={ {
 			type: context.params.type,

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -2,8 +2,6 @@
  * External Dependencies
  */
 import React from 'react';
-import ReactDom from 'react-dom';
-import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 
 /**
@@ -17,7 +15,7 @@ export function redirect() {
 	page.redirect( '/posts' );
 }
 
-export function list( context ) {
+export function list( context, next ) {
 	const siteId = getSiteFragment( context.path );
 	const sectionedPath = sectionify( context.path );
 
@@ -28,17 +26,13 @@ export function list( context ) {
 	}
 	pageView.record( baseAnalyticsPath, 'Custom Post Type' );
 
-	// Construct query arguments
-	const query = {
-		type: context.params.type,
-		status: context.params.status || 'publish',
-		search: context.query.s
-	};
-
-	ReactDom.render(
-		<ReduxProvider store={ context.store }>
-			<Types query={ query } />
-		</ReduxProvider>,
-		document.getElementById( 'primary' )
+	context.primary = (
+		<Types query={ {
+			type: context.params.type,
+			status: context.params.status || 'publish',
+			search: context.query.s
+		} } />
 	);
+
+	next();
 }

--- a/client/my-sites/types/index.js
+++ b/client/my-sites/types/index.js
@@ -1,21 +1,16 @@
 /**
- * External dependencies
- */
-import page from 'page';
-
-/**
  * Internal dependencies
  */
 import { siteSelection, navigation, sites } from 'my-sites/controller';
 import { list, redirect } from './controller';
 import config from 'config';
 
-export default function() {
+export default function( router ) {
 	if ( ! config.isEnabled( 'manage/custom-post-types' ) ) {
 		return;
 	}
 
-	page( '/types/:type/:status?/:site', siteSelection, navigation, list );
-	page( '/types/:type', siteSelection, sites );
-	page( '/types', redirect );
-};
+	router( '/types/:type/:status?/:site', siteSelection, navigation, list );
+	router( '/types/:type', siteSelection, sites );
+	router( '/types', redirect );
+}

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -10,6 +10,7 @@ import get from 'lodash/get';
  */
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PostTypeFilter from 'my-sites/post-type-filter';
 import PostTypeList from 'my-sites/post-type-list';
 import PostTypeUnsupported from './post-type-unsupported';
@@ -18,10 +19,13 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostType, isPostTypeSupported } from 'state/post-types/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
 
-function Types( { query, postType, postTypeSupported, userCanEdit } ) {
+function Types( { siteId, query, postType, postTypeSupported, userCanEdit } ) {
 	return (
 		<Main>
 			<DocumentHead title={ get( postType, 'label' ) } />
+			<PageViewTracker
+				path={ siteId ? '/types/:site' : '/types' }
+				title="Custom Post Type" />
 			{ false !== userCanEdit && false !== postTypeSupported && [
 				<PostTypeFilter
 					key="filter"
@@ -41,6 +45,7 @@ function Types( { query, postType, postTypeSupported, userCanEdit } ) {
 }
 
 Types.propTypes = {
+	siteId: PropTypes.number,
 	query: PropTypes.object,
 	postType: PropTypes.object,
 	postTypeSupported: PropTypes.bool,
@@ -53,6 +58,7 @@ export default connect( ( state, ownProps ) => {
 	const capability = get( postType, [ 'capabilities', 'edit_posts' ], null );
 
 	return {
+		siteId,
 		postType,
 		postTypeSupported: isPostTypeSupported( state, siteId, ownProps.query.type ),
 		userCanEdit: canCurrentUser( state, siteId, capability )


### PR DESCRIPTION
This pull request seeks to simplify the CPT controller by (a) using the [isomorphic route middleware](https://github.com/Automattic/wp-calypso/blob/master/docs/isomorphic-routing.md) instead of manually rendering to the DOM and (b) removing direct calls to analytics with the [`<PageViewTracker />` component](https://github.com/Automattic/wp-calypso/tree/master/client/lib/analytics/page-view-tracker).

[I mean, just look at how beautiful that controller is now](https://github.com/Automattic/wp-calypso/blob/80244d5927271450c01b0568439485d9f00a7ae4/client/my-sites/types/controller.jsx).

__Testing instructions:__

Verify that there are no regressions to the theme rendering due to moving the `<ReduxProvider />` rendering to `controller.js`.

Verify that the [custom post types list screen](http://calypso.localhost:3000/types/post) renders as it does in master, and that no errors or issues occur when navigating away from or to this screen.

cc @ockham @dmsnell @timmyc 

Test live: https://calypso.live/?branch=update/cpt-controller