### PR TITLE
Framework: Add support for logged in isomorphic layout rendering

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -188,10 +188,16 @@ Layout = React.createClass( {
 					{ this.renderWelcome() }
 					{ this.renderPushNotificationPrompt() }
 					<GlobalNotices id="notices" notices={ notices.list } forcePinned={ 'post' === this.props.section.name } />
-					<div id="primary" className="wp-primary wp-section" />
-					<div id="secondary" className="wp-secondary" />
+					<div id="primary" className="wp-primary wp-section">
+						{ this.props.primary }
+					</div>
+					<div id="secondary" className="wp-secondary">
+						{ this.props.secondary }
+					</div>
 				</div>
-				<div id="tertiary" />
+				<div id="tertiary">
+					{ this.props.tertiary }
+				</div>
 				<TranslatorLauncher
 					isEnabled={ translator.isEnabled() }
 					isActive={ translator.isActivated() }/>

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -36,27 +36,6 @@ import trackScrollPage from 'lib/track-scroll-page';
 const user = userFactory();
 const sites = sitesFactory();
 
-/*
- * The main navigation of My Sites consists of a component with
- * the site selector list and the sidebar section items
- */
-function renderNavigation( context, allSitesPath, siteBasePath ) {
-	// Render the My Sites navigation in #secondary
-	ReactDom.render(
-		React.createElement( ReduxProvider, { store: context.store },
-			React.createElement( NavigationComponent, {
-				layoutFocus,
-				path: context.path,
-				allSitesPath,
-				siteBasePath,
-				user,
-				sites
-			} )
-		),
-		document.getElementById( 'secondary' )
-	);
-}
-
 function removeSidebar( context ) {
 	context.store.dispatch( setSection( {
 		group: 'sites',
@@ -249,7 +228,23 @@ module.exports = {
 			basePath = route.sectionify( context.pathname );
 		}
 
-		renderNavigation( context, basePath, basePath );
+		context.secondary = React.createElement( ReduxProvider, { store: context.store },
+			React.createElement( NavigationComponent, {
+				layoutFocus,
+				path: context.path,
+				allSitesPath: basePath,
+				siteBasePath: basePath,
+				user,
+				sites
+			} )
+		);
+
+		// Render the My Sites navigation in #secondary
+		ReactDom.render(
+			context.secondary,
+			document.getElementById( 'secondary' )
+		);
+
 		next();
 	},
 


### PR DESCRIPTION
Related: #6311
Related: [Isomorphic Routing](https://github.com/Automattic/wp-calypso/blob/master/docs/isomorphic-routing.md)

*__Note:__ This is in-progress and may not be mergeable in the near future, depending on how much `<Layout />` is tied to the presence of a DOM*

This pull request seeks to add support for `makeLayout` to be used in rendering client-side logged-in screens. These are pieces from an initial approach in #6311.

Few notes on what remains:

- There are warnings when navigating away from a screen that uses this approach, since those other screens call `ReactDom.render` on an element initially rendered by React when using `makeLayout`. I suppose this is expected and is indicative of the work we need to do to move away from direct rendering.
- I expect there's cases where we have logged in server-side rendered pages? In those cases, `require( 'layout' );` will probably bomb because of all the DOM-dependent modules it uses. I suppose we'll need a SSR-ready logged-in layout alternative component?

/cc @ockham 

Test live: https://calypso.live/?branch=update/isomorphic-routing-logged-in