### PR TITLE
Editor: Avoid rendering input with null value

### DIFF
--- a/client/my-sites/category-selector/index.jsx
+++ b/client/my-sites/category-selector/index.jsx
@@ -52,7 +52,7 @@ module.exports = React.createClass( {
 
 	getInitialState: function() {
 		return {
-			searchTerm: null,
+			searchTerm: '',
 			selectedIds: this.getSelectedIds()
 		};
 	},

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -279,7 +279,7 @@ const EditorDrawer = React.createClass( {
 			>
 				{ siteUtils.isPermalinkEditable( this.props.site ) && (
 					<EditorMoreOptionsSlug
-						slug={ this.props.post ? this.props.post.slug : null }
+						slug={ this.props.post ? this.props.post.slug : '' }
 						type={ this.props.type } />
 				) }
 				{ this.renderExcerpt() }

--- a/client/post-editor/editor-slug/index.jsx
+++ b/client/post-editor/editor-slug/index.jsx
@@ -113,7 +113,7 @@ export default React.createClass( {
 					<TrackInputChanges onNewValue={ this.recordChangeStats }>
 						<FormTextInput
 							ref="slugField"
-							value={ this.props.slug }
+							value={ this.props.slug ? this.props.slug : '' }
 							onChange={ this.onSlugChange }
 							onKeyDown={ this.onSlugKeyDown }
 							onBlur={ this.onBlur }


### PR DESCRIPTION
This pull request seeks to resolve an error that occurs when loading the post editor in development environments.

![warning](https://cloud.githubusercontent.com/assets/22080/16314016/d328099a-3930-11e6-9665-125a1982a575.png)

__Testing instructions:__

Verify that category search and more options slug fields continue to behave as expected in the [post editor](http://calypso.localhost:3000/post).

cc @timmyc 

Test live: https://calypso.live/?branch=fix/editor-input-null