### PR TITLE
Plans: check if we can add plan to cart

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -227,7 +227,7 @@ const Plan = React.createClass( {
 
 	clickPlanHeader( event ) {
 		// clicking a card should select a plan, see issue 4486
-		if ( isDesktop() && this.imagePlanActionRef ) {
+		if ( isDesktop() && this.imagePlanActionRef && this.imagePlanActionRef.canSelectPlan() ) {
 			this.imagePlanActionRef.handleSelectPlan( event );
 		}
 	},


### PR DESCRIPTION
This PR fixes #6315 so we can no longer add a plan we already own to cart.

## Testing Instructions
1. Navigate to /plans
2. Select a site with a paid plan
3. Click on the current plan header. (Pen icon)

cc @rralian @lamosty @artpi 

Test live: https://calypso.live/?branch=fix/plan-header-add-to-cart