### PR TITLE
State: Cache serialization result when defining custom behavior

### DIFF
--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -24,25 +24,63 @@ export function isValidStateWithSchema( state, schema, checkForCycles = false, b
 	return result.valid;
 }
 
-export function createReducer( initialState = null, handlers = {}, schema = null ) {
-	const defaultHandlers = {
-		[SERIALIZE]: ( state ) => {
-			if ( schema !== null ) {
-				return state;
-			}
+/**
+ * Returns a reducer function with state calculation determined by the result
+ * of invoking the handler key corresponding with the dispatched action type,
+ * passing both the current state and action object. Defines default
+ * serialization (persistence) handlers based on the presence of a schema.
+ *
+ * @param  {*}        initialState   Initial state
+ * @param  {Object}   customHandlers Object mapping action types to state
+ *                                   action handlers
+ * @param  {?Object}  schema         JSON schema object for deserialization
+ *                                   validation
+ * @return {Function}                Reducer function
+ */
+export function createReducer( initialState = null, customHandlers = {}, schema = null ) {
+	// Define default handlers for serialization actions. If no schema is
+	// provided, always return the initial state. Otherwise, allow for
+	// serialization and validate on deserialize.
+	let defaultHandlers;
+	if ( schema ) {
+		defaultHandlers = {
+			[ SERIALIZE ]: ( state ) => state,
+			[ DESERIALIZE ]: ( state ) => {
+				if ( isValidStateWithSchema( state, schema ) ) {
+					return state;
+				}
 
-			return initialState;
-		},
-		[DESERIALIZE]: ( state ) => {
-			if ( schema !== null && isValidStateWithSchema( state, schema ) ) {
-				return state;
+				return initialState;
 			}
+		};
+	} else {
+		defaultHandlers = {
+			[ SERIALIZE ]: () => initialState,
+			[ DESERIALIZE ]: () => initialState
+		};
+	}
 
-			return initialState;
-		}
+	const handlers = {
+		...defaultHandlers,
+		...customHandlers
 	};
 
-	handlers = Object.assign( {}, defaultHandlers, handlers );
+	// When custom serialization behavior is provided, we assume that it may
+	// involve heavy logic (mapping, converting from Immutable instance), so
+	// we cache the result and only regenerate when state has changed.
+	if ( customHandlers[ SERIALIZE ] ) {
+		let lastState, lastSerialized;
+		handlers[ SERIALIZE ] = ( state, action ) => {
+			if ( state === lastState ) {
+				return lastSerialized;
+			}
+
+			const serialized = customHandlers[ SERIALIZE ]( state, action );
+			lastState = state;
+			lastSerialized = serialized;
+			return serialized;
+		};
+	}
 
 	return ( state = initialState, action ) => {
 		const { type } = action;


### PR DESCRIPTION
This pull request seeks to enhance `createReducer`, caching serialization results when a custom `SERIALIZE` handler is specified. The thinking here is that if a developer defines a custom handler for `SERIALIZE`, chances are the implementation involves some heavy computation. An example of this is the [reducer for `state.terms.queries`](https://github.com/Automattic/wp-calypso/blob/3adc20a3320635c4d2c16112dd0c1340837fd4ca/client/state/terms/reducer.js#L99-L105). Because [the entire tree is serialized any time state changes (with minor throttling)](https://github.com/Automattic/wp-calypso/blob/3adc20a3320635c4d2c16112dd0c1340837fd4ca/client/state/initial-state.js#L73-L85), it can become very wasteful to regenerate the serialized value of this reducer when no changes have been made to that part of the tree. Separately, we may consider optimizing the subscribe call to at a minimum only re-serialize the changed top-level keys of the tree.

__Testing instructions:__

Ensure Mocha tests pass:

```
npm run test-client
```

The example given, `state.terms.queries`, is not yet used in the UI, at least not until #5366 is merged. From what I can determine, there is no usage of `createReducer` where a `SERIALIZE` handler is defined (at least as far as it affects the UI).

/cc @gziolo @gwwar @timmyc 

Test live: https://calypso.live/?branch=update/redux-state-serialize-perf