### PR TITLE
Draft: display "author" gravatar if it's a multiauthor blog.

### DIFF
--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -22,6 +22,8 @@ var CompactCard = require( 'components/card/compact' ),
 	utils = require( 'lib/posts/utils' ),
 	hasTouch = require( 'lib/touch-detect' ).hasTouch;
 
+import Gravatar from 'components/gravatar';
+
 module.exports = React.createClass( {
 
 	displayName: 'Draft',
@@ -35,14 +37,16 @@ module.exports = React.createClass( {
 		sites: React.PropTypes.object,
 		onTitleClick: React.PropTypes.func,
 		postImages: React.PropTypes.object,
-		selected: React.PropTypes.bool
+		selected: React.PropTypes.bool,
+		showAuthor: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
 		return {
 			showAllActions: false,
 			onTitleClick: noop,
-			selected: false
+			selected: false,
+			showAuthor: false
 		};
 	},
 
@@ -181,6 +185,7 @@ module.exports = React.createClass( {
 				<h3 className="draft__title">
 					{ post.status === 'pending' &&
 						<span className="draft__pending-label">{ this.translate( 'Pending' ) }</span> }
+					{ this.props.showAuthor && <Gravatar user={ post.author } size={ 22 } /> }
 					<a href={ editPostURL } onClick={ this.props.onTitleClick }>
 						{ post.format === 'aside' ? excerpt : title }
 					</a>

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -1,3 +1,6 @@
+.draft.card.is-compact {
+	padding: 16px;
+}
 
 .draft__title {
 	display: inline-block;
@@ -289,4 +292,9 @@
 	margin-right: 8px;
 	padding: 2px 8px;
 	text-transform: uppercase;
+}
+
+.draft .gravatar {
+	margin-right: 8px;
+	vertical-align: middle;
 }

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -83,7 +83,14 @@ const PostsMain = React.createClass( {
 			return null;
 		}
 
-		return <Draft key={ draft.global_ID } post={ draft } sites={ this.props.sites } showAuthor={ ! this.props.author } />;
+		const site = this.props.sites.getSelectedSite();
+
+		return <Draft
+			key={ draft.global_ID }
+			post={ draft }
+			sites={ this.props.sites }
+			showAuthor={ site && ! site.single_user_site && ! this.props.author }
+		/>;
 	},
 
 	render() {

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -83,7 +83,7 @@ const PostsMain = React.createClass( {
 			return null;
 		}
 
-		return <Draft key={ draft.global_ID } post={ draft } sites={ this.props.sites } />;
+		return <Draft key={ draft.global_ID } post={ draft } sites={ this.props.sites } showAuthor={ ! this.props.author } />;
 	},
 
 	render() {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/548849/16380099/4967a970-3c75-11e6-9b06-9ae6b53dd1fe.png)

If site is multiauthor, and user selects the "Everyone" filter in posts view, render a gravatar next to the draft title.

Test live: https://calypso.live/?branch=add/author-to-multiauthor-sites-drafts