### PR TITLE
Posts: can't rely on counts for Jetpack drafts display.

### DIFF
--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -45,6 +45,20 @@ const PostsMain = React.createClass( {
 		this.setWarning( selectedSite );
 	},
 
+	showNoDraftsMessage() {
+		const site = this.props.sites.getSelectedSite();
+		const noResults = <NoResults text={ this.translate( 'You have no drafts at the moment.' ) } />;
+
+		// Jetpack sites can have malformed counts
+		if ( site.jetpack && ! this.props.loadingDrafts && this.props.drafts && this.props.drafts.length === 0 ) {
+			return noResults;
+		}
+
+		if ( ! site.jetpack && this.props.draftCount === 0 ) {
+			return noResults;
+		}
+	},
+
 	mostRecentDrafts() {
 		const site = this.props.sites.getSelectedSite();
 		const isLoading = this.props.draftCount !== 0 && this.props.loadingDrafts;
@@ -67,7 +81,7 @@ const PostsMain = React.createClass( {
 				</Card>
 				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
 				{ isLoading && <Draft isPlaceholder /> }
-				{ this.props.draftCount === 0 && <NoResults text={ this.translate( 'You have no drafts at the moment.' ) } /> }
+				{ this.showNoDraftsMessage() }
 				{ this.props.draftCount > 6 &&
 					<Button compact borderless className="posts__see-all-drafts" href={ `/posts/drafts/${ site.slug }` }>
 						{ this.translate( 'See all drafts' ) }

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -517,6 +517,7 @@
 	color: $gray;
 	font-size: 14px;
 	margin-left: 16px;
+	line-height: 1.4;
 }
 
 .posts__see-all-drafts {


### PR DESCRIPTION
Fixes #6330.

Test live: https://calypso.live/?branch=update/cannot-rely-on-counts-for-jp