### PR TITLE
Editor: Fix error when loading editor for Jetpack site pre-3.9.2

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -93,7 +93,7 @@ const EditorDrawer = React.createClass( {
 	currentPostTypeSupports: function( feature ) {
 		const { typeObject, type } = this.props;
 
-		if ( typeObject ) {
+		if ( typeObject && typeObject.supports ) {
 			return !! typeObject.supports[ feature ];
 		}
 


### PR DESCRIPTION
Support for post types `supports` was added to Jetpack in 3.9.2 (see Automattic/Jetpack@06769e07a1d5772faf68c8c4114c01b06d523a50). In earlier versions, attempting to navigate to the [post editor](https://wordpress.com/post) will result in an error. We should check to ensure that `supports` exists on the object before attempting to check for that feature's support. See remainder of function for fallback logic, which should at least cover cases for proper supports detection on posts and pages for these sites. To protect against post types which aren't hardcoded, we should ensure to version guard against custom post types editor usage to support only 3.9.2+ (related: #6105).

__Testing instructions:__

Verify that the [post editor](http://calypso.localhost:3000/post) loads for a Jetpack site running 3.9.1 or earlier ([3.8.3 download link](https://downloads.wordpress.org/plugin/jetpack.3.8.3.zip)).

/cc @mtias 

Test live: https://calypso.live/?branch=fix/jetpack-pre-3-9-2-types