### PR TITLE
Posts: move "/posts" to consume from state tree

### DIFF
--- a/client/components/data/query-posts/index.jsx
+++ b/client/components/data/query-posts/index.jsx
@@ -11,7 +11,7 @@ import debug from 'debug';
  * Internal dependencies
  */
 import { isRequestingSitePostsForQuery, isRequestingSitePost } from 'state/posts/selectors';
-import { requestSitePosts, requestSitePost } from 'state/posts/actions';
+import { requestSitePosts, requestSitePost, requestPosts } from 'state/posts/actions';
 
 /**
  * Module variables
@@ -35,6 +35,7 @@ class QueryPosts extends Component {
 
 	request( props ) {
 		const single = !! props.postId;
+		const allSites = ! props.siteId;
 
 		if ( ! single && ! props.requestingPosts ) {
 			log( 'Request post list for site %d using query %o', props.siteId, props.query );
@@ -44,6 +45,11 @@ class QueryPosts extends Component {
 		if ( single && ! props.requestingPost ) {
 			log( 'Request single post for site %d post %d', props.siteId, props.postId );
 			props.requestSitePost( props.siteId, props.postId );
+		}
+
+		if ( allSites && ! props.requestingPost ) {
+			log( 'Request post list for all the user sites using query %o', props.query );
+			props.requestPosts( props.query );
 		}
 	}
 
@@ -75,7 +81,8 @@ export default connect(
 	( dispatch ) => {
 		return bindActionCreators( {
 			requestSitePosts,
-			requestSitePost
+			requestSitePost,
+			requestPosts
 		}, dispatch );
 	}
 )( QueryPosts );

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -24,6 +24,7 @@ import {
 import PostTypeListPost from './post';
 import PostTypeListPostPlaceholder from './post-placeholder';
 import PostTypeListEmptyContent from './empty-content';
+import PostCard from 'my-sites/posts/post';
 
 /**
  * Constants
@@ -39,7 +40,8 @@ class PostTypeList extends Component {
 		lastPage: PropTypes.number,
 		posts: PropTypes.array,
 		requestingFirstPage: PropTypes.bool,
-		requestingLastPage: PropTypes.bool
+		requestingLastPage: PropTypes.bool,
+		postComponent: PropTypes.element
 	};
 
 	constructor() {
@@ -138,6 +140,11 @@ class PostTypeList extends Component {
 		}
 
 		const { global_ID: globalId } = posts[ requestingFirstPage ? index - 1 : index ];
+
+		if ( this.props.bigCards ) {
+			return <PostCard key={ globalId } globalId={ globalId } />;
+		}
+
 		return <PostTypeListPost key={ globalId } globalId={ globalId } />;
 	}
 

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -48,7 +48,7 @@ var PostList = React.createClass( {
 		};
 
 		return (
-			<PostTypeList query={ query } />
+			<PostTypeList query={ query } bigCards />
 		);
 	}
 } );

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -23,6 +23,7 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	mapStatus = route.mapPostStatus;
 
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import PostTypeList from 'my-sites/post-type-list';
 
 var GUESSED_POST_HEIGHT = 250;
 
@@ -40,18 +41,14 @@ var PostList = React.createClass( {
 	},
 
 	render: function() {
+		const query = {
+			type: 'post',
+			status: mapStatus( this.props.statusSlug ),
+			author: this.props.author
+		};
+
 		return (
-			<PostListFetcher
-				siteID={ this.props.siteID }
-				status={ mapStatus( this.props.statusSlug ) }
-				author={ this.props.author }
-				withImages={ true }
-				withCounts={ true }
-				search={ this.props.search }>
-				<Posts
-					{ ...omit( this.props, 'children' ) }
-				/>
-			</PostListFetcher>
+			<PostTypeList query={ query } />
 		);
 	}
 } );


### PR DESCRIPTION
_In Progress_

This is going to be a big one.

### To do

- [x] Support querying for posts across sites.
- [x] Respect author toggle control.
- [ ] Refactor and use `<PostCard>` component in post-type-list via prop.


Test live: https://calypso.live/?branch=add/use-post-type-list-for-main-posts