### PR TITLE
Personal Plan: A/B test restart and calypso_abtest_start event fix

### DIFF
--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -15,8 +15,6 @@ import { isJpphpBundle } from 'lib/products-values';
 import Plan from 'components/plans/plan';
 import { isEnabled } from 'config';
 
-const personalPlanTestEnabled = abtest( 'personalPlan' ) === 'show' && isEnabled( 'plans/personal-plan' );
-
 const PlanList = React.createClass( {
 	getInitialState() {
 		return { openPlan: '' };
@@ -27,6 +25,7 @@ const PlanList = React.createClass( {
 	},
 
 	render() {
+		const personalPlanTestEnabled = abtest( 'personalPlan' ) === 'show' && isEnabled( 'plans/personal-plan' );
 		const isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer;
 		const { site, hideFreePlan, plans, intervalType, showJetpackFreePlan } = this.props;
 

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -61,8 +61,6 @@ const wordAdsFeature = {
 	product_slug: WORDADS_INSTANT,
 };
 
-const personalPlanTestEnabled = abtest( 'personalPlan' ) === 'show' && isEnabled( 'plans/personal-plan' );
-
 const PlansCompare = React.createClass( {
 	mixins: [ observe( 'features' ) ],
 
@@ -159,8 +157,12 @@ const PlansCompare = React.createClass( {
 		return this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST;
 	},
 
+	isPersonalPlanTestEnabled() {
+		return abtest( 'personalPlan' ) === 'show' && isEnabled( 'plans/personal-plan' );
+	},
+
 	getColumnCount() {
-		const colsCount = personalPlanTestEnabled ? 5 : 4;
+		const colsCount = this.isPersonalPlanTestEnabled() ? 5 : 4;
 
 		if ( ! this.props.selectedSite || ! this.props.selectedSite.jetpack ) {
 			return colsCount;
@@ -428,7 +430,7 @@ const PlansCompare = React.createClass( {
 				<SectionNav selectedText={ text[ this.state.selectedPlan ] }>
 					<NavTabs>
 						{ freeOption }
-						{ personalPlanTestEnabled &&
+						{ this.isPersonalPlanTestEnabled() &&
 						<NavItem
 							onClick={ this.setPlan.bind( this, 'personal' ) }
 							selected={ 'personal' === this.state.selectedPlan }>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,6 +1,6 @@
 module.exports = {
 	personalPlan: {
-		datestamp: '20160623',
+		datestamp: '20160627',
 		variations: {
 			hide: 50,
 			show: 50


### PR DESCRIPTION
Prevents the `calypso_abtest_start` event to be triggered when entering the signup flow, and restart the `personalPlan` A/B test.

cc: @apeatling @roundhill @rralian 

Test live: https://calypso.live/?branch=fix/personal-plan-test-start-event