### PR TITLE
Reader: add aria-label to sidebar inputs

### DIFF
--- a/client/reader/sidebar/expandable-add-form.jsx
+++ b/client/reader/sidebar/expandable-add-form.jsx
@@ -14,6 +14,7 @@ import Button from 'components/button';
 const ExpandableSidebarAddForm = React.createClass( {
 
 	propTypes: {
+		addLabel: React.PropTypes.string,
 		addPlaceholder: React.PropTypes.string,
 		onAddSubmit: React.PropTypes.func,
 		onAddClick: React.PropTypes.func
@@ -29,7 +30,7 @@ const ExpandableSidebarAddForm = React.createClass( {
 		return {
 			onAddSubmit: noop,
 			onAddClick: noop
-		}
+		};
 	},
 
 	toggleAdd() {
@@ -58,12 +59,13 @@ const ExpandableSidebarAddForm = React.createClass( {
 			}
 		);
 
-		return(
+		return (
 			<div className={ classes }>
 				<Button compact className="sidebar__menu-add-button" onClick={ this.toggleAdd }>{ this.translate( 'Add' ) }</Button>
 
 				<div className="sidebar__menu-add">
 					<input
+						aria-label={ this.props.addLabel }
 						className="sidebar__menu-add-input"
 						type="text"
 						placeholder={ this.props.addPlaceholder }

--- a/client/reader/sidebar/expandable.jsx
+++ b/client/reader/sidebar/expandable.jsx
@@ -16,6 +16,7 @@ const ExpandableSidebarMenu = React.createClass( {
 	propTypes: {
 		title: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] ).isRequired,
 		count: React.PropTypes.number,
+		addLabel: React.PropTypes.string,
 		addPlaceholder: React.PropTypes.string,
 		onAddSubmit: React.PropTypes.func,
 		onAddClick: React.PropTypes.func,
@@ -40,7 +41,7 @@ const ExpandableSidebarMenu = React.createClass( {
 		return (
 			<SidebarMenu className={ classes }>
 				<ExpandableSidebarHeading title={ this.props.title } count={ this.props.count } onClick={ this.props.onClick } />
-				<ExpandableSidebarAddForm addPlaceholder={ this.props.addPlaceholder } onAddClick={ this.props.onAddClick } onAddSubmit={ this.props.onAddSubmit } />
+				<ExpandableSidebarAddForm addLabel={ this.props.addLabel } addPlaceholder={ this.props.addPlaceholder } onAddClick={ this.props.onAddClick } onAddSubmit={ this.props.onAddSubmit } />
 				<ul className="sidebar__menu-list">
 					{ this.props.children }
 				</ul>

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -43,6 +43,7 @@ const ReaderSidebarLists = React.createClass( {
 				expanded={ this.props.isOpen }
 				title={ this.translate( 'Lists' ) }
 				count={ listCount }
+				addLabel={ this.translate( 'New list name' ) }
 				addPlaceholder={ this.translate( 'Give your list a name' ) }
 				onAddClick={ this.handleAddClick }
 				onAddSubmit={ this.createList }

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -26,7 +26,7 @@ const ReaderSidebarTags = React.createClass( {
 	},
 
 	followTag: function( tag ) {
-		let subscription = TagStore.getSubscription( TagActions.slugify( tag ) );
+		const subscription = TagStore.getSubscription( TagActions.slugify( tag ) );
 		if ( subscription ) {
 			this.props.onTagExists( subscription );
 		} else {
@@ -65,6 +65,7 @@ const ReaderSidebarTags = React.createClass( {
 				expanded={ this.props.isOpen }
 				title={ this.translate( 'Tags' ) }
 				count={ tagCount }
+				addLabel={ this.translate( 'New tag name' ) }
 				addPlaceholder={ this.translate( 'Add any tag' ) }
 				onAddSubmit={ this.followTag }
 				onAddClick={ this.handleAddClick }


### PR DESCRIPTION
As reported in #5047, Reader sidebar inputs do not have a label.

This PR adds the `aria-label` attribute to both the 'new list' and 'new tag' inputs to help those navigating the forms using assistive technologies.

Test live: https://calypso.live/?branch=fix/reader/sidebar-input-labels