### PR TITLE
Themes: update theme links to go to theme sheets

### DIFF
--- a/client/my-sites/themes/action-labels.js
+++ b/client/my-sites/themes/action-labels.js
@@ -12,8 +12,8 @@ export default {
 		} )
 	},
 	preview: {
-		label: i18n.translate( 'Info', {
-			comment: 'label for displaying the theme info sheet'
+		label: i18n.translate( 'Live demo', {
+			comment: 'label for previewing the theme demo website'
 		} )
 	},
 	purchase: {
@@ -38,7 +38,9 @@ export default {
 		header: i18n.translate( 'Try & Customize on:', { comment: 'label in the dialog for opening the Customizer with the theme in preview' } ),
 	},
 	details: {
-		label: i18n.translate( 'Details' ),
+		label: i18n.translate( 'Info', {
+			comment: 'label for displaying the theme info sheet'
+		} )
 	},
 	support: {
 		label: i18n.translate( 'Setup' ),

--- a/client/my-sites/themes/action-labels.js
+++ b/client/my-sites/themes/action-labels.js
@@ -12,8 +12,8 @@ export default {
 		} )
 	},
 	preview: {
-		label: i18n.translate( 'Live demo', {
-			comment: 'label for previewing the theme demo website'
+		label: i18n.translate( 'Info', {
+			comment: 'label for displaying the theme info sheet'
 		} )
 	},
 	purchase: {

--- a/client/my-sites/themes/action-labels.js
+++ b/client/my-sites/themes/action-labels.js
@@ -37,7 +37,7 @@ export default {
 		label: i18n.translate( 'Try & Customize' ),
 		header: i18n.translate( 'Try & Customize on:', { comment: 'label in the dialog for opening the Customizer with the theme in preview' } ),
 	},
-	details: {
+	info: {
 		label: i18n.translate( 'Info', {
 			comment: 'label for displaying the theme info sheet'
 		} )

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import merge from 'lodash/merge';
@@ -22,7 +23,8 @@ const ThemesLoggedOut = React.createClass( {
 
 	getInitialState() {
 		return {
-			showPreview: false
+			showPreview: false,
+			previewingTheme: null,
 		};
 	},
 
@@ -42,7 +44,8 @@ const ThemesLoggedOut = React.createClass( {
 			separator: {
 				separator: true
 			},
-			details: {
+			info: {
+				action: theme => page( getDetailsUrl( theme ) ),
 				getUrl: theme => getDetailsUrl( theme ),
 			},
 			support: {
@@ -58,10 +61,9 @@ const ThemesLoggedOut = React.createClass( {
 	},
 
 	onPreviewButtonClick( theme ) {
-		this.setState( { showPreview: false },
-			() => {
-				this.props.signup( theme );
-			} );
+		this.setState( { showPreview: false }, () => {
+			this.props.signup( theme );
+		} );
 	},
 
 	render() {
@@ -82,10 +84,10 @@ const ThemesLoggedOut = React.createClass( {
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }
 					onScreenshotClick={ function( theme ) {
-						buttonOptions.preview.action( theme );
+						buttonOptions.info.action( theme );
 					} }
 					getActionLabel={ function() {
-						return buttonOptions.preview.label;
+						return buttonOptions.info.label;
 					} }
 					getOptions={ function( theme ) {
 						return pickBy(

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -16,7 +16,6 @@ import {
 	purchase,
 	activate
 } from 'state/themes/actions';
-import ThemePreview from './theme-preview';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import ThemesSelection from './themes-selection';
@@ -37,10 +36,6 @@ const ThemesMultiSite = React.createClass( {
 
 	showSiteSelectorModal( action, theme ) {
 		this.setState( { selectedTheme: theme, selectedAction: action } );
-	},
-
-	togglePreview( theme ) {
-		this.setState( { showPreview: ! this.state.showPreview, previewingTheme: theme } );
 	},
 
 	hideSiteSelectorModal() {
@@ -87,13 +82,6 @@ const ThemesMultiSite = React.createClass( {
 		return merge( {}, buttonOptions, actionLabels );
 	},
 
-	onPreviewButtonClick( theme ) {
-		this.setState( { showPreview: false },
-			() => {
-				this.getButtonOptions().tryandcustomize.action( theme );
-			} );
-	},
-
 	render() {
 		const buttonOptions = this.getButtonOptions();
 
@@ -101,15 +89,6 @@ const ThemesMultiSite = React.createClass( {
 			<Main className="themes">
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle }/>
 				<SidebarNavigation />
-				{ this.state.showPreview &&
-					<ThemePreview showPreview={ this.state.showPreview }
-						theme={ this.state.previewingTheme }
-						onClose={ this.togglePreview }
-						buttonLabel={ this.translate( 'Try & Customize', {
-							context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
-						} ) }
-						onButtonClick={ this.onPreviewButtonClick } />
-				}
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }
 					onScreenshotClick={ function( theme ) {

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -67,9 +67,6 @@ const ThemesMultiSite = React.createClass( {
 			separator: {
 				separator: true
 			},
-			details: {
-				getUrl: theme => getDetailsUrl( theme ),
-			},
 			support: {
 				getUrl: theme => getSupportUrl( theme ),
 				// Free themes don't have support docs.

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import merge from 'lodash/merge';
@@ -53,7 +54,7 @@ const ThemesMultiSite = React.createClass( {
 	getButtonOptions() {
 		const buttonOptions = {
 			preview: {
-				action: theme => this.togglePreview( theme ),
+				action: theme => page( getDetailsUrl( theme ) ),
 			},
 			purchase: config.isEnabled( 'upgrades/checkout' )
 				? {

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -74,7 +74,7 @@ const ThemesMultiSite = React.createClass( {
 			separator: {
 				separator: true
 			},
-			details: {
+			info: {
 				action: theme => page( getDetailsUrl( theme ) ),
 				getUrl: theme => getDetailsUrl( theme ),
 			},
@@ -115,10 +115,10 @@ const ThemesMultiSite = React.createClass( {
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }
 					onScreenshotClick={ function( theme ) {
-						buttonOptions.details.action( theme );
+						buttonOptions.info.action( theme );
 					} }
 					getActionLabel={ function() {
-						return buttonOptions.details.label;
+						return buttonOptions.info.label;
 					} }
 					getOptions={ function( theme ) {
 						return pickBy(

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -16,6 +16,7 @@ import {
 	purchase,
 	activate
 } from 'state/themes/actions';
+import ThemePreview from './theme-preview';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import ThemesSelection from './themes-selection';
@@ -31,11 +32,17 @@ const ThemesMultiSite = React.createClass( {
 		return {
 			selectedTheme: null,
 			selectedAction: null,
+			showPreview: null,
+			previewingTheme: null,
 		};
 	},
 
 	showSiteSelectorModal( action, theme ) {
 		this.setState( { selectedTheme: theme, selectedAction: action } );
+	},
+
+	togglePreview( theme ) {
+		this.setState( { showPreview: ! this.state.showPreview, previewingTheme: theme } );
 	},
 
 	hideSiteSelectorModal() {
@@ -49,7 +56,7 @@ const ThemesMultiSite = React.createClass( {
 	getButtonOptions() {
 		const buttonOptions = {
 			preview: {
-				action: theme => page( getDetailsUrl( theme ) ),
+				action: theme => this.togglePreview( theme ),
 			},
 			purchase: config.isEnabled( 'upgrades/checkout' )
 				? {
@@ -67,6 +74,10 @@ const ThemesMultiSite = React.createClass( {
 			separator: {
 				separator: true
 			},
+			details: {
+				action: theme => page( getDetailsUrl( theme ) ),
+				getUrl: theme => getDetailsUrl( theme ),
+			},
 			support: {
 				getUrl: theme => getSupportUrl( theme ),
 				// Free themes don't have support docs.
@@ -79,6 +90,12 @@ const ThemesMultiSite = React.createClass( {
 		return merge( {}, buttonOptions, actionLabels );
 	},
 
+	onPreviewButtonClick( theme ) {
+		this.setState( { showPreview: false }, () => {
+			this.getButtonOptions().tryandcustomize.action( theme );
+		} );
+	},
+
 	render() {
 		const buttonOptions = this.getButtonOptions();
 
@@ -86,13 +103,22 @@ const ThemesMultiSite = React.createClass( {
 			<Main className="themes">
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle }/>
 				<SidebarNavigation />
+				{ this.state.showPreview &&
+					<ThemePreview showPreview={ this.state.showPreview }
+						theme={ this.state.previewingTheme }
+						onClose={ this.togglePreview }
+						buttonLabel={ this.translate( 'Try & Customize', {
+							context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
+						} ) }
+						onButtonClick={ this.onPreviewButtonClick } />
+				}
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }
 					onScreenshotClick={ function( theme ) {
-						buttonOptions.preview.action( theme );
+						buttonOptions.details.action( theme );
 					} }
 					getActionLabel={ function() {
-						return buttonOptions.preview.label;
+						return buttonOptions.details.label;
 					} }
 					getOptions={ function( theme ) {
 						return pickBy(

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -92,7 +92,7 @@ const ThemesSingleSite = React.createClass( {
 				separator: {
 					separator: true
 				},
-				details: {
+				info: {
 					action: theme => page( getDetailsUrl( theme, site ) ),
 					getUrl: theme => getDetailsUrl( theme, site ), // TODO: Make this a selector
 				},
@@ -136,7 +136,7 @@ const ThemesSingleSite = React.createClass( {
 			jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' ),
 			buttonOptions = this.getButtonOptions(),
 			getScreenshotAction = function( theme ) {
-				return buttonOptions[ theme.active ? 'customize' : 'details' ];
+				return buttonOptions[ theme.active ? 'customize' : 'info' ];
 			};
 
 		if ( isJetpack && jetpackEnabled && ! site.hasJetpackThemes ) {

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -13,7 +13,6 @@ import mapValues from 'lodash/mapValues';
  */
 import Main from 'components/main';
 import { customize, purchase, activate } from 'state/themes/actions';
-import ThemePreview from './theme-preview';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -49,15 +48,6 @@ const ThemesSingleSite = React.createClass( {
 			selectedTheme: null,
 			selectedAction: null,
 		};
-	},
-
-	togglePreview( theme ) {
-		const site = sites.getSelectedSite();
-		if ( site.jetpack ) {
-			this.props.customize( theme );
-		} else {
-			this.setState( { showPreview: ! this.state.showPreview, previewingTheme: theme } );
-		}
 	},
 
 	getButtonOptions() {
@@ -109,13 +99,6 @@ const ThemesSingleSite = React.createClass( {
 		return merge( {}, buttonOptions, actionLabels );
 	},
 
-	onPreviewButtonClick( theme ) {
-		this.setState( { showPreview: false },
-			() => {
-				this.props.customize( theme );
-			} );
-	},
-
 	renderJetpackMessage() {
 		const site = sites.getSelectedSite();
 		return (
@@ -149,15 +132,6 @@ const ThemesSingleSite = React.createClass( {
 			<Main className="themes">
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle }/>
 				<SidebarNavigation />
-				{ this.state.showPreview &&
-					<ThemePreview showPreview={ this.state.showPreview }
-						theme={ this.state.previewingTheme }
-						onClose={ this.togglePreview }
-						buttonLabel={ this.translate( 'Try & Customize', {
-							context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
-						} ) }
-						onButtonClick={ this.onPreviewButtonClick } />
-				}
 				<ThanksModal
 					site={ site }
 					source={ 'list' }/>

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -80,9 +80,6 @@ const ThemesSingleSite = React.createClass( {
 				separator: {
 					separator: true
 				},
-				details: {
-					getUrl: theme => getDetailsUrl( theme, site ), // TODO: Make this a selector
-				},
 				support: ! site.jetpack // We don't know where support docs for a given theme on a self-hosted WP install are.
 					? {
 						getUrl: theme => getSupportUrl( theme, site ),

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import merge from 'lodash/merge';
@@ -69,7 +70,7 @@ const ThemesSingleSite = React.createClass( {
 					}
 					: {},
 				preview: {
-					action: theme => this.togglePreview( theme ),
+					action: theme => page( getDetailsUrl( theme, site ) ),
 					hideForTheme: theme => theme.active
 				},
 				purchase: config.isEnabled( 'upgrades/checkout' )


### PR DESCRIPTION
Previously clicking a theme link in the showcase activated the theme preview.
This changes that behavior so that instead we see the theme sheet for that theme
(the details page), which includes a link to the theme preview.

Fixes #6221

Visiting `/design` or `/design/yourgroovysite.wordpress.com` will show the new links.

Before:

<img width="287" alt="screen shot 2016-06-27 at 4 08 53 pm" src="https://cloud.githubusercontent.com/assets/2036909/16394088/7bae4fe0-3c81-11e6-99ff-10d21cfdad12.png">

<img width="299" alt="screen shot 2016-06-27 at 4 09 01 pm" src="https://cloud.githubusercontent.com/assets/2036909/16394092/7e966ed6-3c81-11e6-8a2d-c24b158ca33d.png">


After:

<img width="295" alt="screen shot 2016-06-27 at 4 06 46 pm" src="https://cloud.githubusercontent.com/assets/2036909/16394014/2d14c918-3c81-11e6-929d-796c871ded54.png">


<img width="302" alt="screen shot 2016-06-27 at 5 26 43 pm" src="https://cloud.githubusercontent.com/assets/2036909/16396362/5fbb485a-3c8c-11e6-9e18-eddd6e8de916.png">


Test live: https://calypso.live/?branch=update/theme-sheet-from-showcase