### PR TITLE
Login: Fix redirect URL during development

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -7,6 +7,7 @@ import qs from 'qs';
 import debounce from 'lodash/debounce';
 import page from 'page';
 import { Provider as ReduxProvider } from 'react-redux';
+import url from 'url';
 
 /**
  * Internal dependencies
@@ -132,6 +133,9 @@ const devdocs = {
 	},
 
 	pleaseLogIn: function( context ) {
+		const currentUrl = url.parse( location.href );
+		const redirectUrl = currentUrl.protocol + '//' + currentUrl.host + '/devdocs/welcome';
+
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 
 		ReactDom.render(
@@ -139,7 +143,7 @@ const devdocs = {
 				title: 'Log In to start hacking',
 				line: 'Required to access the WordPress.com API',
 				action: 'Log In to WordPress.com',
-				actionURL: 'https://wordpress.com/wp-login.php?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000/devdocs/welcome',
+				actionURL: 'https://wordpress.com/wp-login.php?redirect_to=' + encodeURIComponent( redirectUrl ),
 				secondaryAction: 'Register',
 				secondaryActionURL: '/start/developer',
 				illustration: '/calypso/images/drake/drake-nosites.svg'


### PR DESCRIPTION
When `config( 'devdocs/redirect-loggedout-homepage' )` is `true` (this is the case in development), we show this screen when accessing the app root while logged out:

![image](https://cloud.githubusercontent.com/assets/227022/16393758/988745ae-3c77-11e6-8f30-0508d4999208.png)

The `redirect_to` URL is hard-coded to `http://calypso.localhost:3000` - but it shouldn't be, because now we can load branches from calypso.live.

This PR makes the protocol and host portions of the `redirect_to` URL dynamic.

### To test

In an incognito window or a new browser profile, go to one of these URLs:

- Any dev branch on calypso.live (https://calypso.live/?branch=fix/token-input-blur for example)
- https://wpcalypso.wordpress.com/devdocs/start (fine to test this PR, but AFAIK there is not a flow that points here)

Confirm that the `redirect_to` portion of the "Log In to WordPress.com" button URL incorrectly points to `http://calypso.localhost:3000`.

In the same window (still logged out), try this branch on calypso.live (https://calypso.live/?branch=fix/login-redirect-url) and confirm that the `redirect_to` URL correctly points to `https://calypso.live`.