### PR TITLE
Editor: Use TermTokenField to edit non-hierarchical CPT taxonomies

### DIFF
--- a/client/lib/terms/constants.js
+++ b/client/lib/terms/constants.js
@@ -13,3 +13,9 @@ module.exports.action = keyMirror( {
 	FETCH_TAGS: null,
 	SET_CATEGORY_SELECTED_ITEMS: null
 } );
+
+module.exports.defaultNonHierarchicalQuery = {
+	number: module.exports.MAX_TAGS,
+	order_by: 'count',
+	order: 'DESC'
+};

--- a/client/lib/terms/tag-store.js
+++ b/client/lib/terms/tag-store.js
@@ -69,12 +69,6 @@ function receiveTags( siteId, tags ) {
 	} );
 }
 
-TagStore._queryDefaults = {
-	number: TermsConstants.MAX_TAGS,
-	order_by: 'count',
-	order: 'DESC'
-};
-
 TagStore._tagIds = {};
 
 TagStore._siteStatus = {};
@@ -108,7 +102,7 @@ TagStore.getQueryParams = function( siteId ) {
 	ensureSiteHasStatus( siteId );
 	return assign(
 		{},
-		TagStore._queryDefaults,
+		TermsConstants.defaultNonHierarchicalQuery,
 		{ page: TagStore._siteStatus[ siteId ].page }
 	);
 };

--- a/client/post-editor/editor-categories-tags/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/accordion.jsx
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-
 import Accordion from 'components/accordion';
 import AccordionSection from 'components/accordion/section';
 import Gridicon from 'components/gridicon';

--- a/client/post-editor/editor-categories-tags/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/accordion.jsx
@@ -20,7 +20,7 @@ import { isPage } from 'lib/posts/utils';
 import unescapeString from 'lodash/unescape';
 
 module.exports = React.createClass( {
-	displayName: 'EditorTaxonomiesAccordion',
+	displayName: 'EditorCategoriesTagsAccordion',
 
 	propTypes: {
 		site: React.PropTypes.object,

--- a/client/post-editor/editor-categories-tags/test/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/test/accordion.jsx
@@ -12,8 +12,8 @@ import EmptyComponent from 'test/helpers/react/empty-component';
 import useMockery from 'test/helpers/use-mockery';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
-describe( 'EditorTaxonomiesAccordion', function() {
-	let shallow, common, categoryStore, tagStore, i18n, TaxonomiesAccordion, accordion;
+describe( 'EditorCategoriesTagsAccordion', function() {
+	let shallow, common, categoryStore, tagStore, i18n, CategoriesTagsAccordion, accordion;
 
 	useMockery();
 	useFakeDom();
@@ -29,8 +29,8 @@ describe( 'EditorTaxonomiesAccordion', function() {
 		tagStore = require( 'lib/terms/tag-store' );
 		i18n = require( 'i18n-calypso' );
 
-		TaxonomiesAccordion = require( 'post-editor/editor-taxonomies/accordion' );
-		TaxonomiesAccordion.prototype.translate = i18n.translate;
+		CategoriesTagsAccordion = require( 'post-editor/editor-categories-tags/accordion' );
+		CategoriesTagsAccordion.prototype.translate = i18n.translate;
 
 		common.dispatchReceiveCategoryTerms();
 		common.dispatchReceiveTagTerms();
@@ -38,7 +38,7 @@ describe( 'EditorTaxonomiesAccordion', function() {
 
 	function render( postTaxonomiesProps ) {
 		accordion = shallow(
-			<TaxonomiesAccordion
+			<CategoriesTagsAccordion
 				site={ { ID: common.TEST_SITE_ID } }
 				post={ postTaxonomiesProps }
 				categories={ categoryStore.all( common.TEST_SITE_ID ) }
@@ -46,7 +46,7 @@ describe( 'EditorTaxonomiesAccordion', function() {
 		).instance();
 	}
 
-	describe( 'taxonomies subtitle', function() {
+	describe( 'categories+tags subtitle', function() {
 		it( 'should display one top-level category name', function() {
 			render( {
 				category_ids: [ 1 ],

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import Accordion from 'components/accordion';
 import AccordionSection from 'components/accordion/section';
 import Gridicon from 'components/gridicon';
-import TaxonomiesAccordion from 'post-editor/editor-taxonomies/accordion';
+import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordion';
 import CategoryListData from 'components/data/category-list-data';
 import TagListData from 'components/data/tag-list-data';
 import EditorSharingAccordion from 'post-editor/editor-sharing/accordion';
@@ -124,7 +124,7 @@ const EditorDrawer = React.createClass( {
 		}
 
 		element = (
-			<TaxonomiesAccordion
+			<CategoriesTagsAccordion
 				site={ this.props.site }
 				post={ this.props.post } />
 		);

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -116,7 +116,11 @@ const EditorDrawer = React.createClass( {
 
 		if ( config.isEnabled( 'manage/custom-post-types' ) &&
 				! includes( [ 'post', 'page' ], this.props.type ) ) {
-			return <EditorDrawerTaxonomies />;
+			return (
+				<EditorDrawerTaxonomies
+					postTerms={ this.props.post && this.props.post.terms }
+				/>
+			);
 		}
 
 		if ( ! this.currentPostTypeSupports( 'tags' ) ) {

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -15,8 +15,9 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostTypeTaxonomies } from 'state/post-types/taxonomies/selectors';
 import Accordion from 'components/accordion';
 import Gridicon from 'components/gridicon';
+import TermTokenField from 'post-editor/term-token-field';
 
-function EditorDrawerTaxonomies( { siteId, postType, taxonomies } ) {
+function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 	return (
 		<div className="editor-drawer__taxonomies">
 			{ siteId && postType && (
@@ -28,14 +29,31 @@ function EditorDrawerTaxonomies( { siteId, postType, taxonomies } ) {
 					return;
 				}
 
-				return (
-					<Accordion
-						key={ taxonomy.name }
-						title={ taxonomy.label }
-						icon={ <Gridicon icon="tag" /> }>
-						Work in Progress
-					</Accordion>
-				);
+				if ( taxonomy.hierarchical ) {
+					return (
+						<Accordion
+							key={ taxonomy.name }
+							title={ taxonomy.label }
+							icon={ <Gridicon icon="category" /> }
+						>
+							Work in Progress
+						</Accordion>
+					);
+				} else {
+					return (
+						<Accordion
+							key={ taxonomy.name }
+							title={ taxonomy.label }
+							icon={ <Gridicon icon="tag" /> }
+						>
+							<TermTokenField
+								postTerms={ postTerms }
+								taxonomyName={ taxonomy.name }
+								taxonomyLabel={ taxonomy.label }
+							/>
+						</Accordion>
+					);
+				}
 			} ).filter( Boolean ) }
 		</div>
 	);
@@ -44,6 +62,7 @@ function EditorDrawerTaxonomies( { siteId, postType, taxonomies } ) {
 EditorDrawerTaxonomies.propTypes = {
 	siteId: PropTypes.number,
 	postType: PropTypes.string,
+	postTerms: PropTypes.object,
 	taxonomies: PropTypes.array
 };
 

--- a/client/post-editor/term-token-field/index.jsx
+++ b/client/post-editor/term-token-field/index.jsx
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import cloneDeep from 'lodash/cloneDeep';
+import { connect } from 'react-redux';
+import _debug from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getTerms } from 'state/terms/selectors';
+import TokenField from 'components/token-field';
+import { decodeEntities } from 'lib/formatting';
+import TermsConstants from 'lib/terms/constants';
+import PostActions from 'lib/posts/actions';
+import { recordStat, recordEvent } from 'lib/posts/stats';
+import QueryTerms from 'components/data/query-terms';
+
+const debug = _debug( 'calypso:post-editor:editor-terms' );
+
+class TermTokenField extends React.Component {
+	componentWillMount() {
+		this.boundOnTermsChange = this.onTermsChange.bind( this );
+	}
+
+	onTermsChange( selectedTerms ) {
+		debug( 'onTermsChange', selectedTerms, this );
+
+		let termStat, termEventLabel;
+		if ( selectedTerms.length > this.getPostTerms().length ) {
+			termStat = 'term_added';
+			termEventLabel = 'Added Term';
+		} else {
+			termStat = 'term_removed';
+			termEventLabel = 'Removed Term';
+		}
+		recordStat( termStat );
+		recordEvent( 'Changed Terms', termEventLabel );
+
+		const { postTerms, taxonomyName } = this.props;
+		const terms = cloneDeep( postTerms ) || {};
+		terms[ taxonomyName ] = selectedTerms;
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+		PostActions.edit( { terms } );
+	}
+
+	getPostTerms() {
+		const { postTerms, taxonomyName } = this.props;
+
+		if ( ! postTerms || ! postTerms[ taxonomyName ] ) {
+			return [];
+		}
+
+		if ( Array.isArray( postTerms[ taxonomyName ] ) ) {
+			return postTerms[ taxonomyName ];
+		}
+
+		return Object.keys( postTerms[ taxonomyName ] );
+	}
+
+	render() {
+		const termNames = ( this.props.terms || [] ).map( term => term.name );
+
+		return (
+			<label className="editor-drawer__label">
+				<span className="editor-drawer__label-text">
+					{ this.props.taxonomyLabel }
+				</span>
+				<QueryTerms
+					siteId={ this.props.siteId }
+					taxonomy={ this.props.taxonomyName }
+					query={ TermsConstants.defaultNonHierarchicalQuery }
+				/>
+				<TokenField
+					value={ this.getPostTerms() }
+					displayTransform={ decodeEntities }
+					suggestions={ termNames }
+					onChange={ this.boundOnTermsChange }
+					maxSuggestions={ TermsConstants.MAX_TERMS_SUGGESTIONS }
+				/>
+			</label>
+		);
+	}
+}
+
+TermTokenField.propTypes = {
+	siteId: React.PropTypes.number,
+	postTerms: React.PropTypes.object,
+	taxonomyName: React.PropTypes.string,
+	taxonomyLabel: React.PropTypes.string,
+	terms: React.PropTypes.arrayOf( React.PropTypes.object ),
+};
+
+export default connect( ( state, props ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId: siteId,
+		terms: getTerms( state, siteId, props.taxonomyName ),
+	};
+} )( TermTokenField );


### PR DESCRIPTION
This PR adds support for fetching and editing non-hierarchical terms using a `TokenField`.  Adds a new `TermTokenField` component which is modeled after `post-editor/editor-tags/index.jsx`.

Planned future steps:

- After #5445 lands connecting the edited post to Redux state, get rid of the `postTerms` property in favor of `getEditedPostValue( ..., 'terms' )`
- Use reduxified `TermTreeSelector` and `TermTokenField` in `EditorCategoriesTagsAccordion` to edit categories and tags, respectively.  (This is why I renamed `EditorTaxonomiesAccordion` to `EditorCategoriesTagsAccordion` - I expect the logic there will still be used, but to render only categories and tags rather than all taxonomies.)
- Use `EditorDrawerTaxonomies` to render all taxonomies, including tags and categories if present
- Get rid of old code to edit categories and tags, including `TagListData` and `CategoryListData` components

### To test

Edit a post of a custom type that has one or more non-hierarchical taxonomies.  Ensure that existing taxonomies are loaded correctly in the `TokenField`:

- values (terms assigned to the saved post)
- suggestions (all terms from the site)

Ensure that terms can be updated and saved as expected.

Test live: https://calypso.live/?branch=update/editor/cpt-term-token-field