### PR TITLE
Plans: display discounts on new plans page

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import noop from 'lodash/noop';
+import classNames from 'classnames';
 
 /**
  * Internal Dependencies
@@ -27,14 +28,17 @@ class PlanFeaturesHeader extends Component {
 	render() {
 		const {
 			billingTimeFrame,
-			currencyCode,
 			current,
+			discountPrice,
 			planType,
 			popular,
-			rawPrice,
 			title,
 			translate
 		} = this.props;
+		const isDiscounted = !! discountPrice;
+		const timeframeClasses = classNames( 'plan-features__header-timeframe', {
+			'is-discounted': isDiscounted
+		} );
 		return (
 			<header className="plan-features__header" onClick={ this.props.onClick } >
 				{
@@ -49,12 +53,33 @@ class PlanFeaturesHeader extends Component {
 				</div>
 				<div className="plan-features__header-text">
 					<h4 className="plan-features__header-title">{ title }</h4>
-					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ rawPrice } />
-					<p className="plan-features__header-timeframe">
+					{ this.getPlanFeaturesPrices() }
+					<p className={ timeframeClasses } >
 						{ billingTimeFrame }
 					</p>
 				</div>
 			</header>
+		);
+	}
+
+	getPlanFeaturesPrices() {
+		const {
+			currencyCode,
+			discountPrice,
+			rawPrice,
+		} = this.props;
+
+		if ( discountPrice ) {
+			return (
+				<span className="plan-features__header-price-group">
+					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ rawPrice } original />
+					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ discountPrice } discounted />
+				</span>
+			);
+		}
+
+		return (
+			<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ rawPrice } />
 		);
 	}
 
@@ -399,6 +424,7 @@ PlanFeaturesHeader.propTypes = {
 	] ).isRequired,
 	popular: PropTypes.bool,
 	rawPrice: PropTypes.number,
+	discountPrice: PropTypes.number,
 	currencyCode: PropTypes.string,
 	title: PropTypes.string.isRequired,
 	translate: PropTypes.func

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -19,6 +19,8 @@ import { isCurrentPlanPaid, isCurrentSitePlan } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getPlanRawPrice, getPlan } from 'state/plans/selectors';
+import { getPlanDiscountPrice } from 'state/sites/plans/selectors';
+
 import {
 	plansList,
 	getPlanFeaturesObject,
@@ -39,6 +41,7 @@ class PlanFeatures extends Component {
 			currencyCode,
 			planName,
 			rawPrice,
+			discountPrice,
 			popular,
 			current,
 			planConstantObj,
@@ -59,6 +62,7 @@ class PlanFeatures extends Component {
 					title={ planConstantObj.getTitle() }
 					planType={ planName }
 					rawPrice={ rawPrice }
+					discountPrice={ discountPrice }
 					billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
 					onClick={ onUpgradeClick }
 				/>
@@ -103,6 +107,7 @@ export default connect( ( state, ownProps ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	const planObject = getPlan( state, planProductId );
 	const isPaid = isCurrentPlanPaid( state, selectedSiteId );
+	const showMonthly = ! isMonthly( ownProps.plan );
 
 	return {
 		planName: ownProps.plan,
@@ -110,14 +115,15 @@ export default connect( ( state, ownProps ) => {
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		popular: isPopular( ownProps.plan ) && ! isPaid,
 		features: getPlanFeaturesObject( ownProps.plan ),
-		rawPrice: getPlanRawPrice( state, planProductId, ! isMonthly( ownProps.plan ) ),
+		rawPrice: getPlanRawPrice( state, planProductId, showMonthly ),
 		planConstantObj: plansList[ ownProps.plan ],
 		available : canUpgradeToPlan( ownProps.plan ),
 		onUpgradeClick: () => {
 			const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
 			page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( ownProps.plan ) || '' }` );
 		},
-		planObject: planObject
+		planObject: planObject,
+		discountPrice: getPlanDiscountPrice( state, selectedSiteId, ownProps.plan, showMonthly )
 	};
 } )( PlanFeatures );
 

--- a/client/my-sites/plan-features/price.jsx
+++ b/client/my-sites/plan-features/price.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal Dependencies
@@ -11,13 +12,17 @@ import { getCurrencyObject } from 'lib/format-currency';
 export default class PlanFeaturesPrice extends Component {
 
 	render() {
-		const { currencyCode, rawPrice } = this.props;
+		const { currencyCode, rawPrice, original, discounted } = this.props;
 		if ( ! currencyCode || ( rawPrice !== 0 && ! rawPrice ) ) {
 			return null;
 		}
 		const price = getCurrencyObject( rawPrice, currencyCode );
+		const classes = classNames( 'plan-features__price', {
+			'is-original': original,
+			'is-discounted': discounted
+		} );
 		return (
-			<h4 className="plan-features__price">
+			<h4 className={ classes }>
 				<sup className="plan-features__price-currency-symbol">
 					{ price.symbol }
 				</sup>
@@ -34,9 +39,13 @@ export default class PlanFeaturesPrice extends Component {
 
 PlanFeaturesPrice.propTypes = {
 	rawPrice: PropTypes.number,
+	original: PropTypes.bool,
+	discount: PropTypes.bool,
 	currencyCode: PropTypes.string
 };
 
 PlanFeaturesPrice.defaultProps = {
-	currencyCode: 'USD'
+	currencyCode: 'USD',
+	original: false,
+	discounted: false
 };

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -81,6 +81,10 @@ $plan-features-header-banner-height: 20px;
 	}
 }
 
+.plan-features__header-timeframe.is-discounted {
+	color: $alert-green;
+}
+
 .plan-features__header-timeframe {
 	line-height: .6;
 }
@@ -95,6 +99,22 @@ $plan-features-header-banner-height: 20px;
 	margin: 0;
 	font-size: 28px;
 	line-height: 1.5;
+	color: $gray-dark;
+}
+
+.plan-features__price.is-original {
+	text-decoration: line-through;
+	color: $gray;
+}
+
+.plan-features__price.is-discounted {
+	color: $alert-green;
+}
+
+.plan-features__price.is-discounted,
+.plan-features__price.is-original {
+	align-items: stretch;
+	margin-right: 8px;
 }
 
 .plan-features__price-currency-symbol,
@@ -103,13 +123,17 @@ $plan-features-header-banner-height: 20px;
 	font-size: 12px;
 }
 
-.plan-features__price-currency-symbol {
-	color: $gray;
+.plan-features__header-price-group {
+	display: flex;
+	flex-flow: row wrap;
 }
 
-.plan-features__price-integer,
-.plan-features__price-fraction {
-	color: $gray-dark;
+.plan-features__price.is-discounted .plan-features__price-currency-symbol {
+	color: $alert-green;
+}
+
+.plan-features__price-currency-symbol {
+	color: $gray;
 }
 
 .plan-features__price-integer {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -81,10 +81,6 @@ $plan-features-header-banner-height: 20px;
 	}
 }
 
-.plan-features__header-timeframe.is-discounted {
-	color: $alert-green;
-}
-
 .plan-features__header-timeframe {
 	line-height: .6;
 }
@@ -103,7 +99,6 @@ $plan-features-header-banner-height: 20px;
 }
 
 .plan-features__price.is-original {
-	text-decoration: line-through;
 	color: $gray;
 }
 
@@ -113,8 +108,20 @@ $plan-features-header-banner-height: 20px;
 
 .plan-features__price.is-discounted,
 .plan-features__price.is-original {
+	position: relative;
 	align-items: stretch;
 	margin-right: 8px;
+}
+
+.plan-features__price.is-original:before {
+	position: absolute;
+	content: "";
+	left: 0;
+	top: 50%;
+	right: 0;
+	border-top: 2px solid $orange-fire;
+	transform: rotate(-16deg);
+	opacity: .9;
 }
 
 .plan-features__price-currency-symbol,

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -78,10 +78,13 @@ export const getSitePlan = createSelector(
  */
 export function getPlanDiscountPrice( state, siteId, productSlug, isMonthly = false ) {
 	const plan = getSitePlan( state, siteId, productSlug );
+
 	if ( get( plan, 'rawPrice', -1 ) < 0 || get( plan, 'rawDiscount', -1 ) <= 0 ) {
 		return null;
 	}
+
 	const discountPrice = plan.rawPrice;
+
 	return isMonthly ? parseFloat( ( discountPrice / 12 ).toFixed( 2 ) ) : discountPrice;
 }
 

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -11,6 +11,7 @@ import debugFactory from 'debug';
 import { initialSiteState } from './reducer';
 import { getSite } from 'state/sites/selectors';
 import { createSitePlanObject } from './assembler';
+import createSelector from 'lib/create-selector';
 
 /**
  * Module dependencies
@@ -46,9 +47,43 @@ export const getCurrentPlan = ( state, siteId ) => {
 		debug( 'current plan: %o', plan );
 		return plan;
 	}
-
 	return null;
 };
+
+/**
+ * Returns a site specific plan
+ * @param  {Object} state        global state
+ * @param  {Number} siteId       the site id
+ * @param  {String} productSlug  the plan product slug
+ * @return {Object} the matching plan
+ */
+export const getSitePlan = createSelector(
+	( state, siteId, productSlug ) => {
+		const plansBySiteId = getPlansBySiteId( state, siteId );
+		if ( ! plansBySiteId || plansBySiteId.isRequesting || ! plansBySiteId.data ) {
+			return null;
+		}
+		return plansBySiteId.data.filter( plan => plan.productSlug === productSlug ).shift();
+	},
+	( state, siteId ) => getPlansBySiteId( state, siteId )
+);
+
+/**
+ * Returns a plan discount price
+ * @param  {Object}  state         global state
+ * @param  {Number}  siteId       the site id
+ * @param  {String}  productSlug   the plan product slug
+ * @param  {Boolean} isMonthly     if true, returns monthly price
+ * @return {Number}  plan discount price
+ */
+export function getPlanDiscountPrice( state, siteId, productSlug, isMonthly = false ) {
+	const plan = getSitePlan( state, siteId, productSlug );
+	if ( get( plan, 'rawPrice', -1 ) < 0 || get( plan, 'rawDiscount', -1 ) <= 0 ) {
+		return null;
+	}
+	const discountPrice = plan.rawPrice;
+	return isMonthly ? parseFloat( ( discountPrice / 12 ).toFixed( 2 ) ) : discountPrice;
+}
 
 export function hasDomainCredit( state, siteId ) {
 	if ( ! siteId ) {

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -7,6 +7,8 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	getSitePlan,
+	getPlanDiscountPrice,
 	getPlansBySite,
 	getPlansBySiteId,
 	hasDomainCredit,
@@ -46,6 +48,186 @@ describe( 'selectors', () => {
 			const plans = getPlansBySiteId( state, 2916284 );
 
 			expect( plans ).to.eql( plans1 );
+		} );
+	} );
+	describe( '#getSitePlan()', () => {
+		it( 'should return plans by site and plan slug', () => {
+			const plans1 = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold'
+				}, {
+					currentPlan: false,
+					productSlug: 'silver'
+				}, { currentPlan: true, productSlug: 'bronze' } ]
+			};
+			const plans2 = {
+				data: [ {
+					currentPlan: true,
+					productSlug: 'gold'
+				}, {
+					currentPlan: false,
+					productSlug: 'silver'
+				}, { currentPlan: false, productSlug: 'bronze' } ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						2916284: plans1,
+						77203074: plans2
+					}
+				}
+			};
+			const plan = getSitePlan( state, 77203074, 'gold' );
+			expect( plan ).to.eql( { currentPlan: true, productSlug: 'gold' } );
+		} );
+		it( 'should return falsey when plan is not found', () => {
+			const plans1 = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold'
+				}, {
+					currentPlan: false,
+					productSlug: 'silver'
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze'
+				} ]
+			};
+			const plans2 = {
+				data: [ {
+					currentPlan: true,
+					productSlug: 'gold'
+				}, {
+					currentPlan: false,
+					productSlug: 'silver'
+				}, {
+					currentPlan: false,
+					productSlug: 'bronze'
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						2916284: plans1,
+						77203074: plans2
+					}
+				}
+			};
+			const plan = getSitePlan( state, 77203074, 'circle' );
+			expect( plan ).to.eql( undefined );
+		} );
+		it( 'should return falsey when siteId is not found', () => {
+			const plans1 = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold'
+				}, {
+					currentPlan: false,
+					productSlug: 'silver'
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze'
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						2916284: plans1
+					}
+				}
+			};
+			const plan = getSitePlan( state, 77203074, 'gold' );
+			expect( plan ).to.eql( null );
+		} );
+	} );
+	describe( '#getPlanDiscountPrice()', () => {
+		it( 'should return a discount price', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+			const discountPrice = getPlanDiscountPrice( state, 77203074, 'bronze' );
+			expect( discountPrice ).to.equal( 99 );
+		} );
+		it( 'should return a monthly discount price', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+			const discountPrice = getPlanDiscountPrice( state, 77203074, 'bronze', true );
+			expect( discountPrice ).to.equal( 8.25 );
+		} );
+		it( 'should return null, if no discount is available', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+			const discountPrice = getPlanDiscountPrice( state, 77203074, 'silver', true );
+			expect( discountPrice ).to.equal( null );
 		} );
 	} );
 	describe( '#hasDomainCredit()', () => {


### PR DESCRIPTION
This closes #6299 to display discounted plan prices on the new plans page.

Before:
<img width="239" alt="1182ad90-39fd-11e6-8b9f-99d2c250977e" src="https://cloud.githubusercontent.com/assets/1270189/16401006/6b472122-3c95-11e6-86ca-fb2994c68275.png">

After:
<img width="354" alt="screen shot 2016-06-29 at 9 18 13 am" src="https://cloud.githubusercontent.com/assets/1270189/16460068/84ea022a-3dda-11e6-838e-90dc6edbf893.png">

## Testing Instructions

- Start Calypso with: `ENABLE_FEATURES=manage/plan-features make run`
- Navigate to `http://calypso.localhost:3000/plans`
- Select a site with a premium plan
- Observe what the business pricing displays

cc @rralian @artpi @lamosty @mtias @rickybanister 


Test live: https://calypso.live/?branch=update/new-plans-discount