### PR TITLE
Fix linter warnings.

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -135,25 +135,25 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderBar() {
-		const placeholder = <span className="themes__sheet-placeholder">loading.....</span>;
+		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = this.props.name || placeholder;
 		const tag = this.props.author ? i18n.translate( 'by %(author)s', { args: { author: this.props.author } } ) : placeholder;
 
 		return (
-			<div className="themes__sheet-bar">
-				<span className="themes__sheet-bar-title">{ title }</span>
-				<span className="themes__sheet-bar-tag">{ tag }</span>
+			<div className="theme__sheet-bar">
+				<span className="theme__sheet-bar-title">{ title }</span>
+				<span className="theme__sheet-bar-tag">{ tag }</span>
 			</div>
 		);
 	},
 
 	renderScreenshot() {
-		const img = <img className="themes__sheet-img" src={ this.props.screenshot + '?=w680' } />;
+		const img = <img className="theme__sheet-img" src={ this.props.screenshot + '?=w680' } />;
 		return (
-			<div className="themes__sheet-screenshot">
-				<a className="themes__sheet-preview-link" onClick={ this.togglePreview } >
+			<div className="theme__sheet-screenshot">
+				<a className="theme__sheet-preview-link" onClick={ this.togglePreview } >
 					<Gridicon icon="themes" size={ 18 } />
-					<span className="themes__sheet-preview-link-text">{ i18n.translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }</span>
+					<span className="theme__sheet-preview-link-text">{ i18n.translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }</span>
 				</a>
 				{ this.props.screenshot && img }
 			</div>
@@ -183,7 +183,7 @@ const ThemeSheet = React.createClass( {
 		);
 
 		return (
-			<SectionNav className="themes__sheet-section-nav" selectedText={ filterStrings[ currentSection ] }>
+			<SectionNav className="theme__sheet-section-nav" selectedText={ filterStrings[ currentSection ] }>
 				{ this.props.name && nav }
 			</SectionNav>
 		);
@@ -200,7 +200,7 @@ const ThemeSheet = React.createClass( {
 	renderOverviewTab() {
 		return (
 			<div>
-				<Card className="themes__sheet-content">
+				<Card className="theme__sheet-content">
 					<div dangerouslySetInnerHTML={ { __html: this.props.descriptionLong } } />
 				</Card>
 				{ this.renderFeaturesCard() }
@@ -213,7 +213,7 @@ const ThemeSheet = React.createClass( {
 	renderSetupTab() {
 		return (
 			<div>
-				<Card className="themes__sheet-content">
+				<Card className="theme__sheet-content">
 					<div dangerouslySetInnerHTML={ { __html: this.props.supportDocumentation } } />
 				</Card>
 			</div>
@@ -223,17 +223,17 @@ const ThemeSheet = React.createClass( {
 	renderSupportTab() {
 		return (
 			<div>
-				<Card className="themes__sheet-card-support">
+				<Card className="theme__sheet-card-support">
 					<Gridicon icon="comment" size={ 48 } />
-					<div className="themes__sheet-card-support-details">
+					<div className="theme__sheet-card-support-details">
 						{ i18n.translate( 'Need extra help?' ) }
 						<small>{ i18n.translate( 'Visit the theme support forum' ) }</small>
 					</div>
 					<Button primary={ true } href={ getForumUrl( this.props ) }>Visit forum</Button>
 				</Card>
-				<Card className="themes__sheet-card-support">
+				<Card className="theme__sheet-card-support">
 					<Gridicon icon="briefcase" size={ 48 } />
-					<div className="themes__sheet-card-support-details">
+					<div className="theme__sheet-card-support-details">
 						{ i18n.translate( 'Need CSS help? ' ) }
 						<small>{ i18n.translate( 'Visit the CSS customization forum' ) }</small>
 					</div>
@@ -253,7 +253,7 @@ const ThemeSheet = React.createClass( {
 			<div>
 				<SectionHeader label={ i18n.translate( 'Features' ) } />
 				<Card>
-					<ul className="themes__sheet-features-list">
+					<ul className="theme__sheet-features-list">
 						{ themeFeatures }
 					</ul>
 				</Card>
@@ -270,7 +270,7 @@ const ThemeSheet = React.createClass( {
 
 	renderPreview() {
 		const buttonLabel = this.props.isLoggedIn ? i18n.translate( 'Try & Customize' ) : i18n.translate( 'Pick this design' );
-		return(
+		return (
 			<ThemePreview showPreview={ this.state.showPreview }
 				theme={ this.props }
 				onClose={ this.togglePreview }
@@ -287,7 +287,7 @@ const ThemeSheet = React.createClass( {
 			comment: 'Message displayed when requested theme was not found',
 		} );
 
-		return(
+		return (
 			<Main>
 				<EmptyContentComponent
 					title={ emptyContentTitle }
@@ -303,7 +303,7 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderSheet() {
-		let actionTitle = <span className="themes__sheet-button-placeholder">loading......</span>;
+		let actionTitle = <span className="theme__sheet-button-placeholder">loading......</span>;
 		if ( this.isActive() ) {
 			actionTitle = i18n.translate( 'Customize' );
 		} else if ( this.props.name ) {
@@ -311,14 +311,14 @@ const ThemeSheet = React.createClass( {
 		}
 
 		const section = this.validateSection( this.props.section );
-		const priceElement = <span className="themes__sheet-action-bar-cost">{ this.props.price }</span>;
+		const priceElement = <span className="theme__sheet-action-bar-cost">{ this.props.price }</span>;
 		const siteID = this.props.selectedSite && this.props.selectedSite.ID;
 
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
 		return (
-			<Main className="themes__sheet">
+			<Main className="theme__sheet">
 			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle }/>
 				{ this.renderBar() }
 				{ siteID && <QueryCurrentTheme siteId={ siteID }/> }
@@ -335,23 +335,23 @@ const ThemeSheet = React.createClass( {
 					sourcePath={ `/theme/${ this.props.id }${ section ? '/' + section : '' }` }
 				/> }
 				{ this.state.showPreview && this.renderPreview() }
-				<HeaderCake className="themes__sheet-action-bar"
+				<HeaderCake className="theme__sheet-action-bar"
 							backHref={ this.props.backPath }
 							backText={ i18n.translate( 'All Themes' ) }>
-					<Button className="themes__sheet-primary-button" onClick={ this.onPrimaryClick }>
+					<Button className="theme__sheet-primary-button" onClick={ this.onPrimaryClick }>
 						{ actionTitle }
 						{ ! this.isActive() && priceElement }
 					</Button>
 				</HeaderCake>
-				<div className="themes__sheet-columns">
-					<div className="themes__sheet-column-left">
-						<div className="themes__sheet-content">
+				<div className="theme__sheet-columns">
+					<div className="theme__sheet-column-left">
+						<div className="theme__sheet-content">
 							{ this.renderSectionNav( section ) }
 							{ this.renderSectionContent( section ) }
-							<div className="footer__line"><Gridicon icon="my-sites" /></div>
+							<div className="theme__footer_line"><Gridicon icon="my-sites" /></div>
 						</div>
 					</div>
-					<div className="themes__sheet-column-right">
+					<div className="theme__sheet-column-right">
 						{ this.renderScreenshot() }
 					</div>
 				</div>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -1,8 +1,8 @@
-.themes__sheet {
+.theme__sheet {
 	max-width: none;
 }
 
-.themes__sheet-bar
+.theme__sheet-bar
 {
 	background-color: $blue-wordpress;
 	color: white;
@@ -11,7 +11,7 @@
 	margin: 0;
 }
 
-.themes__sheet-bar-title {
+.theme__sheet-bar-title {
 	display: block;
 	font-size: 33px;
 	font-weight: 100;
@@ -20,7 +20,7 @@
 	line-height: 1;
 }
 
-.themes__sheet-bar-tag {
+.theme__sheet-bar-tag {
 	max-width: none;
 	display: block;
 	color: rgba(255, 255, 255, 0.6);
@@ -30,7 +30,7 @@
 	padding-left: 25px;
 }
 
-.themes__sheet-columns {
+.theme__sheet-columns {
 	display: flex;
 	flex-direction: row;
 
@@ -39,8 +39,8 @@
 	}
 }
 
-.themes__sheet-column-left,
-.themes__sheet-column-right {
+.theme__sheet-column-left,
+.theme__sheet-column-right {
 	display: flex;
 	width: 50%;
 	flex-direction: column;
@@ -50,7 +50,7 @@
 	}
 }
 
-.themes__sheet-action-bar {
+.theme__sheet-action-bar {
 	height: 50px;
 
 	@include breakpoint( "<960px" ) {
@@ -60,7 +60,7 @@
 	}
 }
 
-.themes__sheet-primary-button {
+.theme__sheet-primary-button {
 	position: absolute;
 		top: 5px;
 		right: 50%;
@@ -74,11 +74,11 @@
 	}
 }
 
-.themes__sheet-button-placeholder {
+.theme__sheet-button-placeholder {
 	color: transparent;
 }
 
-.themes__sheet-action-bar-cost {
+.theme__sheet-action-bar-cost {
 	font-weight: 600;
 	color: #4AB866;
 	margin-left: 10px;
@@ -86,7 +86,7 @@
 	max-width: 50%;
 }
 
-.themes__sheet-screenshot {
+.theme__sheet-screenshot {
 	display: block;
 	position: absolute;
 	top: 90px;
@@ -118,12 +118,12 @@
 	}
 }
 
-.themes__sheet-img {
+.theme__sheet-img {
 	display: block;
 	width: 100%;
 }
 
-.themes__sheet-content {
+.theme__sheet-content {
 	padding: 20px;
 	font-size: 14px;
 
@@ -264,13 +264,13 @@
 	}
 }
 
-.themes__sheet-placeholder {
+.theme__sheet-placeholder {
 	color: transparent;
 	background-color: rgba(255, 255, 255, 0.4);
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
-.themes__sheet-features-list {
+.theme__sheet-features-list {
 	text-align: center;
 	margin: -0.78em 0;
 	padding: 0;
@@ -291,7 +291,7 @@
 	}
 }
 
-.themes__sheet-card-support {
+.theme__sheet-card-support {
 	display: flex;
 	align-items: center;
 
@@ -319,7 +319,7 @@
 	}
 }
 
-.themes__sheet-card-support-details {
+.theme__sheet-card-support-details {
 	flex: 1 1 20px;
 	padding: 0 20px;
 
@@ -329,7 +329,7 @@
 	}
 }
 
-.themes__sheet-preview-link {
+.theme__sheet-preview-link {
 	display: flex;
 	position: absolute;
 		top: -28px;
@@ -345,7 +345,7 @@
 		margin: 0 8px 0 -4px;
 	}
 
-	.themes__sheet-preview-link-text {
+	.theme__sheet-preview-link-text {
 		font-size: 12px;
 		margin-top: 2px;
 		text-transform: uppercase;
@@ -365,13 +365,13 @@
 			height: 24px;
 		}
 
-		.themes__sheet-preview-link-text {
+		.theme__sheet-preview-link-text {
 			display: none;
 		}
 	}
 }
 
-.footer__line {
+.theme__footer_line {
 	color: lighten( $gray, 20% );
 	border-top: 1px solid lighten( $gray, 20% );
 	margin: 32px 0 20px;

--- a/client/my-sites/theme/theme-download-card/index.jsx
+++ b/client/my-sites/theme/theme-download-card/index.jsx
@@ -13,7 +13,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 
-var ThemeDownloadCard = React.createClass( {
+const ThemeDownloadCard = React.createClass( {
 
 	propTypes: {
 		theme: React.PropTypes.string.isRequired,
@@ -29,7 +29,7 @@ var ThemeDownloadCard = React.createClass( {
 			}
 		} );
 		return (
-			<Card className="themes__sheet-download">
+			<Card className="theme-download-card">
 				<Gridicon icon="cloud-download" size={ 48 } />
 				<p>{ downloadText }</p>
 				<Button href={ downloadURI }>{ i18n.translate( 'Download' ) }</Button>

--- a/client/my-sites/theme/theme-download-card/style.scss
+++ b/client/my-sites/theme/theme-download-card/style.scss
@@ -1,4 +1,4 @@
-.themes__sheet-download {
+.theme-download-card {
 
 	text-align: center;
 
@@ -24,7 +24,7 @@
 
 @include breakpoint( ">1040px" ) {
 
-	.themes__sheet-download {
+	.theme-download-card {
 		text-align: inherit;
 
 		.gridicon {

--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -37,8 +37,8 @@ const ThemesRelatedCard = React.createClass( {
 		themes.delete( this.props.currentTheme );
 		themes = [ ...themes ];
 
-		let randomThemeIndex = this.props.currentTheme.charCodeAt( 0 ) % themes.length;
-		let theme = themes.splice( randomThemeIndex, 1 )[ 0 ];
+		const randomThemeIndex = this.props.currentTheme.charCodeAt( 0 ) % themes.length;
+		const theme = themes.splice( randomThemeIndex, 1 )[ 0 ];
 		const selectedThemes = [ theme ];
 		selectedThemes.push( themes[ theme.charCodeAt( 0 ) % themes.length ] );
 
@@ -54,10 +54,10 @@ const ThemesRelatedCard = React.createClass( {
 		return (
 			<div>
 				<SectionHeader label={ i18n.translate( 'You might also like' ) } />
-				<ul className="themes__sheet-related-themes">
+				<ul className="themes-related-card__">
 					{ themes.map( theme => (
 						<li key={ theme.id }>
-							<Card className="themes__sheet-related-themes-card">
+							<Card className="themes-related-card__card">
 								<a href={ getDetailsUrl( theme ) }>
 									<img src={ theme.screenshot + '?w=' + '660' }/>
 								</a>

--- a/client/my-sites/theme/themes-related-card/style.scss
+++ b/client/my-sites/theme/themes-related-card/style.scss
@@ -1,4 +1,4 @@
-.themes__sheet-related-themes{
+.themes-related-card__{
 	display: flex;
 	margin-top: 16px;
 	margin-left: 0px;
@@ -25,11 +25,11 @@
 
 }
 
-.themes__sheet-related-themes-card {
+.themes-related-card__card {
 	padding: 0;
 }
 
-.themes__sheet-related-themes-link {
+.themes-related-card__link {
 
 	p {
 		text-align: center;


### PR DESCRIPTION
Since CSS linter checks where enabled for wp-calypso `client/my-sites/theme` needed a little cleanup.
Mostly CSS class warnings + couple small indentation and var vs. const/let warnings.

Test live: https://calypso.live/?branch=fix/linter-css-warnings-in-theme-sheet