### PR TITLE
Export: Additional tracks for export button click

### DIFF
--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -6,6 +6,7 @@ import React, { PropTypes } from 'react';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import FoldableCard from 'components/foldable-card';
 import GuidedTransferOptions from 'my-sites/exporter/guided-transfer-options';
 import GuidedTransferDetails from 'my-sites/exporter/guided-transfer-details';
@@ -52,8 +53,16 @@ export default React.createClass( {
 		} = this.props;
 		const siteId = this.props.site.ID;
 
-		const exportAll = () => startExport( siteId );
-		const exportSelectedItems = () => startExport( siteId, { exportAll: false } );
+		const exportAll = () => {
+			analytics.tracks.recordEvent( 'calypso_export_start_click', { scope: 'all' } );
+			return startExport( siteId );
+		};
+
+		const exportSelectedItems = () => {
+			analytics.tracks.recordEvent( 'calypso_export_start_click', { scope: 'selected' } );
+			return startExport( siteId, { exportAll: false } );
+		};
+
 		const fetchStatus = () => exportStatusFetch( siteId );
 
 		const exportButton = (

--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -6,7 +6,6 @@ import React, { PropTypes } from 'react';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import FoldableCard from 'components/foldable-card';
 import GuidedTransferOptions from 'my-sites/exporter/guided-transfer-options';
 import GuidedTransferDetails from 'my-sites/exporter/guided-transfer-details';
@@ -53,16 +52,8 @@ export default React.createClass( {
 		} = this.props;
 		const siteId = this.props.site.ID;
 
-		const exportAll = () => {
-			analytics.tracks.recordEvent( 'calypso_export_start_click', { scope: 'all' } );
-			return startExport( siteId );
-		};
-
-		const exportSelectedItems = () => {
-			analytics.tracks.recordEvent( 'calypso_export_start_click', { scope: 'selected' } );
-			return startExport( siteId, { exportAll: false } );
-		};
-
+		const exportAll = () => startExport( siteId );
+		const exportSelectedItems = () => startExport( siteId, { exportAll: false } );
 		const fetchStatus = () => exportStatusFetch( siteId );
 
 		const exportButton = (

--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -7,6 +7,7 @@ import flowRight from 'lodash/flowRight';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import config from 'config';
 import Exporter from './exporter';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -45,7 +46,12 @@ function mapDispatchToProps( dispatch ) {
 		advancedSettingsFetch: flowRight( dispatch, advancedSettingsFetch ),
 		exportStatusFetch: flowRight( dispatch, exportStatusFetch ),
 		setPostType: flowRight( dispatch, setPostType ),
-		startExport: flowRight( dispatch, startExport ),
+		startExport: ( siteId, options ) => {
+			analytics.tracks.recordEvent( 'calypso_export_start_button_click', {
+				scope: ( options && options.exportAll === false ) ? 'selected' : 'all'
+			} );
+			dispatch( startExport( siteId, options ) );
+		}
 	};
 }
 


### PR DESCRIPTION
Adds a Calypso tracks event `calypso_export_start_click` for clicking the 'Export' button, with a property to distinguish between Export All and Export Selected Items buttons.

![wordpress_com_](https://cloud.githubusercontent.com/assets/416133/16406752/5dec9944-3d53-11e6-9c52-7b8e61d96531.png)

cc @dllh 

Test live: https://calypso.live/?branch=add/exporter/extra-tracks-events