### PR TITLE
Themes: Allow transitions on preview

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -18,6 +18,7 @@ import touchDetect from 'lib/touch-detect';
 import { isMobile } from 'lib/viewport';
 import Spinner from 'components/spinner';
 import { setPreviewShowing } from 'state/ui/actions';
+import { localize } from 'i18n-calypso';
 
 const debug = debugModule( 'calypso:web-preview' );
 
@@ -78,13 +79,11 @@ const WebPreview = React.createClass( {
 		};
 	},
 
-	componentWillMount() {
+	componentDidMount() {
 		// Cache touch and mobile detection for the entire lifecycle of the component
 		this._hasTouch = touchDetect.hasTouch();
 		this._isMobile = isMobile();
-	},
 
-	componentDidMount() {
 		if ( this.props.previewUrl ) {
 			this.setIframeUrl( this.props.previewUrl );
 		}
@@ -239,7 +238,7 @@ const WebPreview = React.createClass( {
 								className="web-preview__frame"
 								src="about:blank"
 								onLoad={ this.setLoaded }
-								title={ this.props.iframeTitle || this.translate( 'Preview' ) }
+								title={ this.props.iframeTitle || this.props.translate( 'Preview' ) }
 							/>
 						}
 					</div>
@@ -249,7 +248,7 @@ const WebPreview = React.createClass( {
 	}
 } );
 
-export default connect(
+export default localize( connect(
 	null,
 	{ setPreviewShowing }
-)( WebPreview );
+)( WebPreview ) );

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -10,6 +10,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
 
 const PreviewToolbar = React.createClass( {
 	devices: [ 'computer', 'tablet', 'phone' ],
@@ -58,7 +59,7 @@ const PreviewToolbar = React.createClass( {
 						className="web-preview__close"
 						data-tip-target="web-preview__close"
 						onClick={ this.props.onClose }
-						aria-label={ this.translate( 'Close preview' ) }
+						aria-label={ this.props.translate( 'Close preview' ) }
 					>
 						<Gridicon icon="cross" />
 					</button>
@@ -78,4 +79,4 @@ const PreviewToolbar = React.createClass( {
 
 } );
 
-export default PreviewToolbar;
+export default localize( PreviewToolbar );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -348,7 +348,7 @@ const ThemeSheet = React.createClass( {
 					action={ this.props[ this.state.selectedAction ] }
 					sourcePath={ `/theme/${ this.props.id }${ section ? '/' + section : '' }` }
 				/> }
-				{ this.state.showPreview && this.renderPreview() }
+				{ this.renderPreview() }
 				<HeaderCake className="theme__sheet-action-bar"
 							backHref={ this.props.backPath }
 							backText={ i18n.translate( 'All Themes' ) }>

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -33,7 +33,11 @@ export function getPreviewUrl( theme, site ) {
 		return site.options.admin_url + 'customize.php?theme=' + theme.id + '&return=' + encodeURIComponent( window.location );
 	}
 
-	return `${theme.demo_uri}?demo=true&iframe=true&theme_preview=true`;
+	if ( theme && theme.demo_uri ) {
+		return `${theme.demo_uri}?demo=true&iframe=true&theme_preview=true`;
+	}
+
+	return '';
 }
 
 export function getCustomizeUrl( theme, site ) {

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -70,15 +70,13 @@ const ThemesLoggedOut = React.createClass( {
 		return (
 			<Main className="themes">
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle }/>
-				{ this.state.showPreview &&
-					<ThemePreview showPreview={ this.state.showPreview }
-						theme={ this.state.previewingTheme }
-						onClose={ this.togglePreview }
-						buttonLabel={ this.translate( 'Choose this design', {
-							comment: 'when signing up for a WordPress.com account with a selected theme'
-						} ) }
-						onButtonClick={ this.onPreviewButtonClick } />
-				}
+				<ThemePreview showPreview={ this.state.showPreview }
+					theme={ this.state.previewingTheme }
+					onClose={ this.togglePreview }
+					buttonLabel={ this.translate( 'Choose this design', {
+						comment: 'when signing up for a WordPress.com account with a selected theme'
+					} ) }
+					onButtonClick={ this.onPreviewButtonClick } />
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }
 					getScreenshotUrl={ buttonOptions.info.getUrl }

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -101,15 +101,13 @@ const ThemesMultiSite = React.createClass( {
 			<Main className="themes">
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle }/>
 				<SidebarNavigation />
-				{ this.state.showPreview &&
-					<ThemePreview showPreview={ this.state.showPreview }
-						theme={ this.state.previewingTheme }
-						onClose={ this.togglePreview }
-						buttonLabel={ this.translate( 'Try & Customize', {
-							context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
-						} ) }
-						onButtonClick={ this.onPreviewButtonClick } />
-				}
+				<ThemePreview showPreview={ this.state.showPreview }
+					theme={ this.state.previewingTheme }
+					onClose={ this.togglePreview }
+					buttonLabel={ this.translate( 'Try & Customize', {
+						context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
+					} ) }
+					onButtonClick={ this.onPreviewButtonClick } />
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }
 					getScreenshotUrl={ buttonOptions.info.getUrl }

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -159,15 +159,13 @@ const ThemesSingleSite = React.createClass( {
 			<Main className="themes">
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle }/>
 				<SidebarNavigation />
-				{ this.state.showPreview &&
-					<ThemePreview showPreview={ this.state.showPreview }
-						theme={ this.state.previewingTheme }
-						onClose={ this.togglePreview }
-						buttonLabel={ this.translate( 'Try & Customize', {
-							context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
-						} ) }
-						onButtonClick={ this.onPreviewButtonClick } />
-				}
+				<ThemePreview showPreview={ this.state.showPreview }
+					theme={ this.state.previewingTheme }
+					onClose={ this.togglePreview }
+					buttonLabel={ this.translate( 'Try & Customize', {
+						context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
+					} ) }
+					onButtonClick={ this.onPreviewButtonClick } />
 				<ThanksModal
 					site={ site }
 					source={ 'list' }/>

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -23,6 +23,10 @@ export default React.createClass( {
 		onButtonClick: React.PropTypes.func
 	},
 
+	shouldComponentUpdate( nextProps ) {
+		return this.props.showPreview !== nextProps.showPreview;
+	},
+
 	onButtonClick() {
 		this.props.onButtonClick( this.props.theme );
 	},
@@ -34,7 +38,7 @@ export default React.createClass( {
 			<WebPreview showPreview={ this.props.showPreview }
 				onClose={ this.props.onClose }
 				previewUrl={ previewUrl }
-				externalUrl={ this.props.theme.demo_uri } >
+				externalUrl={ this.props.theme && this.props.theme.demo_uri } >
 				<Button primary
 					onClick={ this.onButtonClick }
 					>{ this.props.buttonLabel }</Button>


### PR DESCRIPTION
Keep the theme-preview component mounted to allow transition animations.

Also should fix issues with theme previews #5922

Do not merge yet—has severe performance impact. Seems like this is forcing the themes infinite list to scroll all the time. Investigating.

Test live: https://calypso.live/?branch=update/theme-preview