### PR TITLE
Permit more recent Node versions in 5.x range without error

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "xgettext-js": "0.3.0"
   },
   "engines": {
-    "node": "5.11.1",
+    "node": "^5.11.1",
     "npm": "3.8.6"
   },
   "scripts": {


### PR DESCRIPTION
While it is understandable that running Calypso in exactly the right minor release of Node would be preferable, I was surprised that the warning in the console (which is driven off the engines definition) did not account for more recent point releases of Node: I would expect that if the supported version of Node is pinned to 5.11 then 5.12 ought to work as well without complaint.

```
wp-calypso requires node 5.11.1 and npm 3.8.6, found node v5.12.0 and npm 3.8.6
 Please switch using nvm or n! Or see https://nodejs.org for instructions.
```

This PR adds the `^` major-version carat to the supported engines definition to suppress this error if you're using a more recent version of node in the 5.x range, in order to permit developers to always take advantage of security releases and non-breaking changes as they occur.

This might be superseded entirely by #5595, though in that case I would propose that the 6.1 engines definition be similarly loosened with `^`.

Test live: https://calypso.live/?branch=adjust-supported-node-engine-version