### PR TITLE
Add a link for contacting support in error messages

### DIFF
--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -13,15 +13,16 @@ import Dispatcher from 'dispatcher';
 import olark from 'lib/olark';
 import purchasesAssembler from 'lib/purchases/assembler';
 import wp from 'lib/wp';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 const debug = debugFactory( 'calypso:upgrades:actions:purchases' ),
 	wpcom = wp.undocumented();
 
 const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases. Please try again later or {{a}}contact support{{/a}}.', {
-		components: { a: <a href="https://wordpress.com/help/contact"/> }
+		components: { a: <a href={ CALYPSO_CONTACT } /> }
 	} ),
 	PURCHASE_REMOVE_ERROR_MESSAGE = i18n.translate( 'There was an error removing the purchase. Please try again later or {{a}}contact support{{/a}}.', {
-		components: { a: <a href="https://wordpress.com/help/contact"/> }
+		components: { a: <a href={ CALYPSO_CONTACT } /> }
 	} );
 
 function cancelPurchase( purchaseId, onComplete ) {
@@ -59,7 +60,7 @@ function cancelPrivateRegistration( purchaseId, onComplete ) {
 				type: ActionTypes.PRIVACY_PROTECTION_CANCEL_FAILED,
 				purchaseId,
 				error: i18n.translate( 'There was a problem canceling this private registration. Please try again later or {{a}}contact support{{/a}}.', {
-					components: { a: <a href="https://wordpress.com/help/contact"/> }
+					components: { a: <a href={ CALYPSO_CONTACT } /> }
 				} )
 			} );
 		}
@@ -96,7 +97,7 @@ function deleteStoredCard( card, onComplete ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.STORED_CARDS_DELETE_FAILED,
 				error: i18n.translate( 'There was a problem deleting the stored card. Please try again later or {{a}}contact support{{/a}}.', {
-					components: { a: <a href="https://wordpress.com/help/contact"/> }
+					components: { a: <a href={ CALYPSO_CONTACT } /> }
 				} )
 			} );
 		}
@@ -146,7 +147,7 @@ function fetchStoredCards() {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.STORED_CARDS_FETCH_FAILED,
 				error: i18n.translate( 'There was a problem retrieving stored cards. Please try again later or {{a}}contact support{{/a}}.', {
-					components: { a: <a href="https://wordpress.com/help/contact"/> }
+					components: { a: <a href={ CALYPSO_CONTACT } /> }
 				} )
 			} );
 		}

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -3,6 +3,7 @@
  */
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -16,8 +17,12 @@ import wp from 'lib/wp';
 const debug = debugFactory( 'calypso:upgrades:actions:purchases' ),
 	wpcom = wp.undocumented();
 
-const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' ),
-	PURCHASE_REMOVE_ERROR_MESSAGE = i18n.translate( 'There was an error removing the purchase.' );
+const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases. Please try again later or {{a}}contact support{{/a}}.', {
+		components: { a: <a href="https://wordpress.com/help/contact"/> }
+	} ),
+	PURCHASE_REMOVE_ERROR_MESSAGE = i18n.translate( 'There was an error removing the purchase. Please try again later or {{a}}contact support{{/a}}.', {
+		components: { a: <a href="https://wordpress.com/help/contact"/> }
+	} );
 
 function cancelPurchase( purchaseId, onComplete ) {
 	wpcom.cancelPurchase( purchaseId, ( error, data ) => {
@@ -53,7 +58,9 @@ function cancelPrivateRegistration( purchaseId, onComplete ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.PRIVACY_PROTECTION_CANCEL_FAILED,
 				purchaseId,
-				error: error.message || i18n.translate( 'There was a problem canceling this private registration. Please try again later or contact support.' )
+				error: i18n.translate( 'There was a problem canceling this private registration. Please try again later or {{a}}contact support{{/a}}.', {
+					components: { a: <a href="https://wordpress.com/help/contact"/> }
+				} )
 			} );
 		}
 
@@ -88,7 +95,9 @@ function deleteStoredCard( card, onComplete ) {
 		} else {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.STORED_CARDS_DELETE_FAILED,
-				error: error.message || i18n.translate( 'There was a problem deleting the stored card. Please try again later or contact support.' )
+				error: i18n.translate( 'There was a problem deleting the stored card. Please try again later or {{a}}contact support{{/a}}.', {
+					components: { a: <a href="https://wordpress.com/help/contact"/> }
+				} )
 			} );
 		}
 
@@ -136,7 +145,9 @@ function fetchStoredCards() {
 		} else if ( error ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.STORED_CARDS_FETCH_FAILED,
-				error: error.message || i18n.translate( 'There was a problem retrieving stored cards. Please try again later or contact support.' )
+				error: i18n.translate( 'There was a problem retrieving stored cards. Please try again later or {{a}}contact support{{/a}}.', {
+					components: { a: <a href="https://wordpress.com/help/contact"/> }
+				} )
 			} );
 		}
 	} );


### PR DESCRIPTION
That PR adds links to error messages and fixes #465

Test live: https://calypso.live/?branch=fix/link-contact-support

- [ ] Code
- [ ] Product