### PR TITLE
Community Translator: bump version

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -20,7 +20,7 @@ var config = require( 'config' ),
  * Local variables
  */
 var communityTranslatorBaseUrl = 'https://widgets.wp.com/community-translator/',
-	communityTranslatorVersion = '1.160620',
+	communityTranslatorVersion = '1.160628',
 	translationDataFromPage = {
 		localeCode: 'en',
 		languageName: 'English',


### PR DESCRIPTION
This fixes #6328 - the community translator was using a (too) generic class on the form element. This has been fixed with https://github.com/Automattic/community-translator/commit/c95a63daef6a781ee2190f643c0049258d5445b4 which is now live on wpcom.


Test live: https://calypso.live/?branch=fix/bump-ct-version