### PR TITLE
Framework: Upgrade wpcalypso ESLint plugin, bump max-len to 140

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
 		'jsx-quotes': [ 1, 'prefer-double' ],
 		'key-spacing': 1,
 		'keyword-spacing': 1,
-		'max-len': [ 1, { code: 100 } ],
+		'max-len': [ 1, { code: 140 } ],
 		'new-cap': [ 1, { 'capIsNew': false, 'newIsCap': true } ],
 		'no-cond-assign': 2,
 		'no-const-assign': 2,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -32,9 +32,6 @@
     "amdefine": {
       "version": "1.0.0"
     },
-    "ansi": {
-      "version": "0.3.1"
-    },
     "ansi-escapes": {
       "version": "1.4.0"
     },
@@ -46,6 +43,9 @@
     },
     "anymatch": {
       "version": "1.3.0"
+    },
+    "aproba": {
+      "version": "1.0.4"
     },
     "are-we-there-yet": {
       "version": "1.1.2"
@@ -172,7 +172,7 @@
       }
     },
     "babel-code-frame": {
-      "version": "6.8.0",
+      "version": "6.11.0",
       "dependencies": {
         "chalk": {
           "version": "1.1.3"
@@ -194,7 +194,7 @@
       "version": "6.0.4"
     },
     "babel-generator": {
-      "version": "6.10.2",
+      "version": "6.11.0",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -381,7 +381,7 @@
       "version": "6.8.0"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.8.0"
+      "version": "6.11.0"
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.8.0"
@@ -429,7 +429,7 @@
       "version": "6.5.0"
     },
     "babel-preset-stage-3": {
-      "version": "6.5.0"
+      "version": "6.11.0"
     },
     "babel-register": {
       "version": "6.9.0",
@@ -452,10 +452,10 @@
       "version": "6.10.4"
     },
     "babel-types": {
-      "version": "6.10.2"
+      "version": "6.11.1"
     },
     "babylon": {
-      "version": "6.8.1"
+      "version": "6.8.2"
     },
     "backo2": {
       "version": "1.0.2"
@@ -549,7 +549,7 @@
       "version": "0.1.4"
     },
     "browserslist": {
-      "version": "1.3.3"
+      "version": "1.3.4"
     },
     "buffer": {
       "version": "3.6.0"
@@ -792,6 +792,9 @@
       "version": "1.1.0"
     },
     "console-browserify": {
+      "version": "1.1.0"
+    },
+    "console-control-strings": {
       "version": "1.1.0"
     },
     "constant-case": {
@@ -1233,7 +1236,7 @@
       "version": "5.2.2"
     },
     "eslint-plugin-wpcalypso": {
-      "version": "1.3.2"
+      "version": "1.3.3"
     },
     "espree": {
       "version": "3.1.6"
@@ -1463,7 +1466,7 @@
       "version": "1.0.0"
     },
     "gauge": {
-      "version": "1.2.7"
+      "version": "2.6.0"
     },
     "gaze": {
       "version": "0.5.2"
@@ -1588,6 +1591,9 @@
           "version": "0.0.1"
         }
       }
+    },
+    "has-color": {
+      "version": "0.1.7"
     },
     "has-cors": {
       "version": "1.0.3"
@@ -1927,7 +1933,7 @@
       "version": "1.0.2"
     },
     "js-tokens": {
-      "version": "1.0.3"
+      "version": "2.0.0"
     },
     "js-yaml": {
       "version": "3.6.1",
@@ -2050,9 +2056,6 @@
     "lodash._baseiteratee": {
       "version": "4.7.0"
     },
-    "lodash._baseslice": {
-      "version": "4.0.0"
-    },
     "lodash._basetostring": {
       "version": "4.12.0"
     },
@@ -2077,23 +2080,11 @@
     "lodash.keysin": {
       "version": "4.1.4"
     },
-    "lodash.pad": {
-      "version": "4.4.0"
-    },
-    "lodash.padend": {
-      "version": "4.5.0"
-    },
-    "lodash.padstart": {
-      "version": "4.5.0"
-    },
     "lodash.pickby": {
       "version": "4.4.0"
     },
     "lodash.rest": {
       "version": "4.0.3"
-    },
-    "lodash.tostring": {
-      "version": "4.1.3"
     },
     "lolex": {
       "version": "1.1.0"
@@ -2102,7 +2093,12 @@
       "version": "1.0.1"
     },
     "loose-envify": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "dependencies": {
+        "js-tokens": {
+          "version": "1.0.3"
+        }
+      }
     },
     "loud-rejection": {
       "version": "1.5.0"
@@ -2280,24 +2276,16 @@
       "version": "1.5.3"
     },
     "node-gyp": {
-      "version": "3.3.1",
+      "version": "3.4.0",
       "dependencies": {
         "glob": {
-          "version": "4.5.3",
-          "dependencies": {
-            "minimatch": {
-              "version": "2.0.10"
-            }
-          }
+          "version": "7.0.5"
         },
         "graceful-fs": {
           "version": "4.1.4"
         },
-        "lru-cache": {
-          "version": "2.7.3"
-        },
         "minimatch": {
-          "version": "1.0.0"
+          "version": "3.0.2"
         }
       }
     },
@@ -2356,7 +2344,7 @@
       }
     },
     "npmlog": {
-      "version": "2.0.4"
+      "version": "3.1.2"
     },
     "nth-check": {
       "version": "1.0.1"
@@ -2785,7 +2773,7 @@
       "version": "2.0.6"
     },
     "readdirp": {
-      "version": "2.0.1",
+      "version": "2.1.0",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.4"
@@ -2870,7 +2858,7 @@
       }
     },
     "regexpu-core": {
-      "version": "1.0.0"
+      "version": "2.0.0"
     },
     "regjsgen": {
       "version": "0.2.0"
@@ -2999,6 +2987,9 @@
         "minimatch": {
           "version": "3.0.2"
         },
+        "set-blocking": {
+          "version": "1.0.0"
+        },
         "window-size": {
           "version": "0.2.0"
         },
@@ -3074,7 +3065,10 @@
       }
     },
     "set-blocking": {
-      "version": "1.0.0"
+      "version": "2.0.0"
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1"
     },
     "setprototypeof": {
       "version": "1.0.1"
@@ -3637,6 +3631,9 @@
     },
     "which": {
       "version": "1.2.10"
+    },
+    "wide-align": {
+      "version": "1.1.0"
     },
     "window-size": {
       "version": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "esformatter-special-bangs": "1.0.1",
     "eslint": "2.13.1",
     "eslint-plugin-react": "5.2.2",
-    "eslint-plugin-wpcalypso": "1.3.2",
+    "eslint-plugin-wpcalypso": "1.3.3",
     "glob": "7.0.3",
     "jsdom": "9.2.1",
     "localStorage": "1.0.2",


### PR DESCRIPTION
This pull request seeks to make a couple revisions to our ESLint configuration following #6294.

- Increases `max-len` from 100 to 140. This goes against our guideline, but the problem is widespread enough that we should ease into imposing lower limits.
- Upgrades patch version of `eslint-plugin-wpcalypso` from 1.3.2 to 1.3.3 ([changelog](https://github.com/Automattic/eslint-plugin-wpcalypso/blob/master/CHANGELOG.md))

cc @mtias @blowery 

Test live: https://calypso.live/?branch=update/eslint-max-len-wpcalypso