### PR TITLE
Signup: use padding instead of line-height in design-type

### DIFF
--- a/client/signup/steps/design-type/style.scss
+++ b/client/signup/steps/design-type/style.scss
@@ -18,7 +18,9 @@
 		color: darken( $gray, 20% );
 		padding-left: 15px;
 		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
-		line-height: 54px;
+		line-height: 1.5em;
+		padding-top: 1em;
+		padding-bottom: 1em;
 	}
 
 	&:hover {


### PR DESCRIPTION
Fixes #6110 

To test, using an incognito window, visit `/start/design-type/de` (to force German locale; you may need to go through the first two sign-up questions first) and adjust your window width to about 900px when the text in each option starts to wrap. Be sure that the wrapping doesn't introduce large spaces between the lines.

Also try other locales to see the behavior hopefully remain the same.

Before:

<img width="682" alt="screen shot 2016-06-28 at 11 51 39 am" src="https://cloud.githubusercontent.com/assets/2036909/16422796/abf3cbde-3d27-11e6-9f14-537800d2dc31.png">

After:

<img width="642" alt="screen shot 2016-06-28 at 11 52 41 am" src="https://cloud.githubusercontent.com/assets/2036909/16422802/afe1fc7a-3d27-11e6-97a1-9c02c2a1a568.png">


Test live: https://calypso.live/?branch=fix/triforce-line-height