### PR TITLE
CPT: Display post canonical image to right of title

### DIFF
--- a/client/my-sites/post-type-list/post-placeholder.jsx
+++ b/client/my-sites/post-type-list/post-placeholder.jsx
@@ -12,7 +12,6 @@ import { PostTypeListPost } from './post';
 function PostTypeListPostPlaceholder( { translate } ) {
 	const post = {
 		title: translate( 'Loading…' ),
-		featured_image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
 		status: 'draft',
 		modified: '2015-08-10T19:44:08+00:00'
 	};

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import get from 'lodash/get';
+
+/**
+ * Internal dependencies
+ */
+import resizeImageUrl from 'lib/resize-image-url';
+import { getNormalizedPost } from 'state/posts/selectors';
+
+function PostTypeListPostThumbnail( { thumbnail } ) {
+	return (
+		<div className="post-type-list__post-thumbnail-wrapper">
+			{ thumbnail && (
+				<img
+					src={ resizeImageUrl( thumbnail, { w: 80 } ) }
+					className="post-type-list__post-thumbnail" />
+			) }
+		</div>
+	);
+}
+
+PostTypeListPostThumbnail.propTypes = {
+	globalId: PropTypes.string,
+	thumbnail: PropTypes.string
+};
+
+export default connect( ( state, ownProps ) => {
+	const post = getNormalizedPost( state, ownProps.globalId );
+	const thumbnail = get( post, 'canonical_image.uri' );
+
+	return { thumbnail };
+} )( PostTypeListPostThumbnail );

--- a/client/my-sites/post-type-list/post.jsx
+++ b/client/my-sites/post-type-list/post.jsx
@@ -13,7 +13,7 @@ import { getEditorPath } from 'state/ui/editor/selectors';
 import { getNormalizedPost } from 'state/posts/selectors';
 import Card from 'components/card';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
-import resizeImageUrl from 'lib/resize-image-url';
+import PostTypeListPostThumbnail from './post-thumbnail';
 import PostTypeListPostActions from './post-actions';
 
 export function PostTypeListPost( { translate, globalId, post, editUrl, className } ) {
@@ -24,14 +24,6 @@ export function PostTypeListPost( { translate, globalId, post, editUrl, classNam
 	return (
 		<Card compact className={ classes }>
 			<div className="post-type-list__post-detail">
-				{ post.featured_image && (
-					<div className="post-type-list__post-thumbnail-wrapper">
-						<img
-							alt="Post thumbnail"
-							src={ resizeImageUrl( post.featured_image, { w: 80 } ) }
-							className="post-type-list__post-thumbnail" />
-					</div>
-				) }
 				<div className="post-type-list__post-title-meta">
 					<h1 className="post-type-list__post-title">
 						<a href={ editUrl }>
@@ -43,6 +35,7 @@ export function PostTypeListPost( { translate, globalId, post, editUrl, classNam
 					</div>
 				</div>
 			</div>
+			<PostTypeListPostThumbnail globalId={ globalId } />
 			<PostTypeListPostActions globalId={ globalId } />
 		</Card>
 	);

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -10,14 +10,22 @@
 }
 
 .post-type-list__post-detail {
+	position: relative;
 	display: flex;
-	min-width: 0;
+	width: 100%;
 	overflow: hidden;
+	margin-right: auto;
+
+	&::after {
+		@include long-content-fade( $size: 40px );
+		right: 0;
+	}
 }
 
 .post-type-list__post-thumbnail-wrapper {
 	position: relative;
 	width: 80px;
+	align-self: stretch;
 	margin-right: 12px;
 	overflow: hidden;
 
@@ -35,7 +43,6 @@
 
 .post-type-list__post-title-meta {
 	padding: 6px 0;
-	width: 100%;
 }
 
 .post-type-list__post-title {
@@ -83,15 +90,8 @@
 }
 
 .post-type-list__post-actions {
-	position: relative;
-	margin-left: auto;
 	margin-right: -8px;
 	flex-shrink: 0;
-
-	&::before {
-		@include long-content-fade( $size: 40px );
-		right: 100%;
-	}
 }
 
 .post-type-list__post-actions .button {


### PR DESCRIPTION
This pull request seeks to:

- Use the post's canonical image (not just featured image) when displaying its thumbnail in the CPT list
- Show the image to the right of the post title

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16423168/f6d6c4b6-3d28-11e6-8776-5eb46baf9bcb.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16423160/ed6cb11a-3d28-11e6-889a-4178d0d1085c.png)

__Testing instructions:__

1. Navigate to the [CPT post listing screen](http://calypso.localhost:3000/types/post)
2. Select a site
3. Note that if an image has a featured image or canonical image derived from its content, the image is shown to the right of the title

Test live: https://calypso.live/?branch=update/cpt-canonical-image