### PR TITLE
Domains: Fix price alignment on site redirect

### DIFF
--- a/assets/stylesheets/sections/_domain-search.scss
+++ b/assets/stylesheets/sections/_domain-search.scss
@@ -44,15 +44,23 @@
 	}
 
 	.domain-product-price {
-		@include breakpoint( ">660px" ) {
+		float: left;
+		margin-bottom: 20px;
+		min-width: 0;
+
+		@include breakpoint( ">960px" ) {
 			float: right;
 			margin-top: -5px;
+			margin-bottom: 0;
 		}
 	}
 }
 
 .site-redirect-step__domain-description {
-	@include breakpoint( ">660px" ) {
+	word-break: break-word;
+
+	@include breakpoint( ">960px" ) {
+		max-width: 75%;
 		float: left;
 		margin-bottom: 20px;
 	}

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -19,9 +19,14 @@
 	}
 
 	.domain-product-price {
-		@include breakpoint( ">660px" ) {
+		float: left;
+		margin-bottom: 20px;
+		min-width: 0;
+
+		@include breakpoint( ">960px" ) {
 			float: right;
 			margin-top: -5px;
+			margin-bottom: 0;
 		}
 	}
 
@@ -31,7 +36,8 @@
 }
 
 .map-domain-step__domain-description {
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( ">960px" ) {
+		max-width: 75%;
 		float: left;
 		margin-bottom: 20px;
 	}


### PR DESCRIPTION
This PR is set to address a small style tweak for #4501. Currently, on small screens, the price for site redirects appears out of alignment. This PR makes a few changes.

First, it removes the min-width of 130px set on the `.domain-product-price`. This is useful on the main “Add Domains” page (domains/add/site.wordpress.com) but removing it here means the price lines up correctly with the button. Second, it changes the breakpoint to 960px for `.domain-product-price` so the price shifts to the left for smaller screens. Lastly, I added a `max-width` of `75%` to `.site-redirect-step_domain-description` and a `word-break: break-word` to account for long site addresses and maintain proper spacing when the price shifts to the left.

## To test:
1. Load this PR
2. Visit the following page for your site: http://calypso.localhost:3000/domains/add/site-redirect/site.wordpress.com

## Screenshots

I tested in Firefox, Safari, and Chrome using the emulator for various devices including a tablet and phone. Here’s how it should appear:

Large
![redirectbig](https://cloud.githubusercontent.com/assets/7240478/16424092/eff01b5a-3d1b-11e6-8604-759a8fde8e97.png)

Mid-Size
![redirectmid](https://cloud.githubusercontent.com/assets/7240478/16424097/f36d5b58-3d1b-11e6-8ad5-9fae13dbea32.png)

Small
![redirectsmall](https://cloud.githubusercontent.com/assets/7240478/16424102/f7218ae4-3d1b-11e6-9603-36d31d8204bf.png)

cc @breezyskies if you have a chance to take a peek

Test live: https://calypso.live/?branch=fix/4501-site-redirect-price-alignment