### PR TITLE
Signup: Explicitly set design SVGs to full-width for Safari's sake.

### DIFF
--- a/client/signup/steps/design-type/style.scss
+++ b/client/signup/steps/design-type/style.scss
@@ -12,6 +12,7 @@
 
 	a, svg {
 		display: block;
+		width: 100%;
 	}
 
 	h2 {


### PR DESCRIPTION
Fixes #6111.

Test live: https://calypso.live/?branch=fix/signup-safari-svg