### PR TITLE
Plans: Tighten up the plans header design

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -31,7 +31,7 @@ $plan-features-header-banner-height: 20px;
 .plan-features__header {
 	position: relative;
 	display: flex;
-	align-items: top;
+	align-items: flex-start;
 	padding: 12px 24px 12px 15px;
 	border-bottom: solid 2px lighten( $gray, 20% );
 	background-color: $white;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -31,17 +31,17 @@ $plan-features-header-banner-height: 20px;
 .plan-features__header {
 	position: relative;
 	display: flex;
-	align-items: center;
-	padding: 12px 24px 12px 12px;
+	align-items: top;
+	padding: 12px 24px 12px 15px;
 	border-bottom: solid 2px lighten( $gray, 20% );
 	background-color: $white;
 }
 
 .plan-features__header-figure {
 	position: relative;
-	width: 70px;
-	height: 70px;
-	margin-right: 12px;
+	width: 50px;
+	height: 50px;
+	margin-right: 15px;
 	border: solid 6px $gray-light;
 	border-radius: 50%;
 
@@ -53,8 +53,8 @@ $plan-features-header-banner-height: 20px;
 
 .plan-features__header-checkmark {
 	position: absolute;
-	top: 0;
-	right: 0;
+	top: -3px;
+	right: -3px;
 	transform: translate(25%, -25%);
 	fill: $alert-green;
 }
@@ -81,14 +81,20 @@ $plan-features-header-banner-height: 20px;
 	}
 }
 
+.plan-features__header-timeframe {
+	line-height: .6;
+}
+
 .plan-features__header-title {
-	font-size: 18px;
+	font-size: 22px;
 	color: $blue-wordpress;
+	line-height: 0.7;
 }
 
 .plan-features__price {
-	margin: 8px 0;
-	font-size: 24px;
+	margin: 0;
+	font-size: 28px;
+	line-height: 1.5;
 }
 
 .plan-features__price-currency-symbol,
@@ -107,7 +113,7 @@ $plan-features-header-banner-height: 20px;
 }
 
 .plan-features__price-integer {
-	margin: 0 3px;
+	margin: 0 1px;
 	font-weight: 400;
 }
 


### PR DESCRIPTION
Before:

![screen shot 2016-06-28 at 9 58 02 am](https://cloud.githubusercontent.com/assets/1464705/16424910/da76169e-3d16-11e6-96ca-618f0db2530e.png)

After:

![screen shot 2016-06-28 at 9 57 42 am](https://cloud.githubusercontent.com/assets/1464705/16424914/ddff92e0-3d16-11e6-87e5-b32321f518b8.png)


Test live: https://calypso.live/?branch=update/plans-design-tweaks