### PR TITLE
Framework: update wpcom to 5.0.0

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-import Me from 'wpcom/dist/lib/me';
+import Me from 'wpcom/build/lib/me';
 import inherits from 'inherits';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:wpcom-undocumented:me' );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -455,7 +455,7 @@
       "version": "6.11.1"
     },
     "babylon": {
-      "version": "6.8.2"
+      "version": "6.8.3"
     },
     "backo2": {
       "version": "1.0.2"
@@ -587,7 +587,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000488"
+      "version": "1.0.30000492"
     },
     "caseless": {
       "version": "0.11.0"
@@ -644,7 +644,7 @@
       "version": "1.6.0"
     },
     "chrono-node": {
-      "version": "1.2.3"
+      "version": "1.2.4"
     },
     "classnames": {
       "version": "1.1.1"
@@ -1101,12 +1101,7 @@
       "version": "1.1.1"
     },
     "es5-ext": {
-      "version": "0.10.11",
-      "dependencies": {
-        "es6-symbol": {
-          "version": "3.0.2"
-        }
-      }
+      "version": "0.10.12"
     },
     "es6-iterator": {
       "version": "2.0.0"
@@ -1219,7 +1214,7 @@
           "version": "1.1.3"
         },
         "globals": {
-          "version": "9.8.0"
+          "version": "9.9.0"
         },
         "strip-json-comments": {
           "version": "1.0.4"
@@ -2101,7 +2096,7 @@
       }
     },
     "loud-rejection": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "lower-case": {
       "version": "1.1.3"
@@ -2911,7 +2906,7 @@
       "version": "0.1.3"
     },
     "rimraf": {
-      "version": "2.5.2",
+      "version": "2.5.3",
       "dependencies": {
         "glob": {
           "version": "7.0.5"
@@ -3651,15 +3646,7 @@
       "version": "1.3.0"
     },
     "wpcom": {
-      "version": "4.9.15",
-      "dependencies": {
-        "babel-runtime": {
-          "version": "5.8.12"
-        },
-        "core-js": {
-          "version": "0.9.18"
-        }
-      }
+      "version": "5.0.0"
     },
     "wpcom-oauth": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.15",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "4.9.15",
+    "wpcom": "5.0.0",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "2.0.0",
     "wpcom-xhr-request": "0.5.0",


### PR DESCRIPTION
I'm using the `5.0.0-beta.0` of wpcom.js to test the building process. The most important change here we've started to use `babel-6` and `n8-make`.

### Testing

1) clean all dependencies

```cli
> make distclean
```

2) Install dependencies

```cli
npm install
```

3) Test the whole app

Test the application making actions to change data:

* add/edit posts, change user con
* change user settings
* login / logout

Test cross-browser Chrome / Safari / Firefox

cc @TooTallNate @timmyc @skeltoac 

Test live: https://calypso.live/?branch=update/wpcom-5.0.0