### PR TITLE
CPT / Components: Render PostTypeList actions under ellipsis menu

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -29,6 +29,7 @@
 @import 'components/domains/map-domain-step/style';
 @import 'components/domains/register-domain-step/style';
 @import 'components/drop-zone/style';
+@import 'components/ellipsis-menu/style';
 @import 'components/email-verification/style';
 @import 'components/emojify/style';
 @import 'components/empty-content/style';

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -159,6 +159,7 @@ button {
 
 .button.is-borderless {
 	border: none;
+	background: none;
 	color: darken( $gray, 10% );
 	padding-left: 0;
 	padding-right: 0;
@@ -200,8 +201,6 @@ button {
 	}
 
 	&.is-compact {
-		background: transparent;
-
 		.gridicon {
 			width: 18px;
 			height: 18px;

--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -1,0 +1,55 @@
+Ellipsis Menu
+=============
+
+A React component for displaying a toggle menu. By default, only an ellipsis button is rendered which, when clicked, toggles the menu's visibility.
+
+## Usage
+
+Render `<EllipsisMenu />` in a similar fashion as you would [the `<PopoverMenu />` component](../popover-menu), as it is effectively a convenience wrapper for this component with a few additional options. Specifically, you'll still need to render `<PopoverMenuItem />` as children of the `<EllipsisMenu />`.
+
+```jsx
+import EllipsisMenu from 'components/ellipsis-menu';
+import PopoverMenuItem from 'components/popover/menu-item';
+
+export default function MyComponent( { onMenuItemClick } ) {
+	return (
+		<EllipsisMenu>
+			<PopoverMenuItem onClick={ onMenuItemClick }>
+				Click Me!
+			</PopoverMenuItem>
+		</EllipsisMenu>
+	);
+}
+```
+
+## Props
+
+### `toggleTitle`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>null</code></td></tr>
+</table>
+
+Override for the default "Toggle menu" `title` attribute on the toggle button.
+
+### `position`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>null</code></td></tr>
+</table>
+
+The position at which the menu should be rendered. If omitted, uses the default `position` from [the `<PopoverMenu />` component](../popover-menu).
+
+### `children`
+
+<table>
+	<tr><td>Type</td><td><code>PropTypes.node</code></td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>null</code></td></tr>
+</table>
+
+Menu children to be rendered.

--- a/client/components/ellipsis-menu/docs/example.jsx
+++ b/client/components/ellipsis-menu/docs/example.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import EllipsisMenu from '../';
+import PopoverMenuItem from 'components/popover/menu-item';
+import PopoverMenuSeparator from 'components/popover/menu-separator';
+
+export default function EllipsisMenuDemo() {
+	return (
+		<EllipsisMenu position="bottom right">
+			<PopoverMenuItem icon="add">Option A</PopoverMenuItem>
+			<PopoverMenuItem icon="pencil">Option B</PopoverMenuItem>
+			<PopoverMenuSeparator />
+			<PopoverMenuItem icon="help">Option C</PopoverMenuItem>
+		</EllipsisMenu>
+	);
+}
+
+EllipsisMenuDemo.displayName = 'EllipsisMenu';

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import Button from 'components/button';
+import PopoverMenu from 'components/popover/menu';
+
+class EllipsisMenu extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		toggleTitle: PropTypes.string,
+		position: PropTypes.string,
+		children: PropTypes.node
+	};
+
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			isMenuVisible: false,
+			popoverContext: null
+		};
+
+		this.showMenu = this.toggleMenu.bind( this, true );
+		this.hideMenu = this.toggleMenu.bind( this, false );
+
+		this.setPopoverContext = this.setPopoverContext.bind( this );
+	}
+
+	setPopoverContext( popoverContext ) {
+		if ( popoverContext ) {
+			this.setState( { popoverContext } );
+		}
+	}
+
+	toggleMenu( isMenuVisible ) {
+		this.setState( { isMenuVisible } );
+	}
+
+	render() {
+		const { toggleTitle, translate, position, children } = this.props;
+		const { isMenuVisible, popoverContext } = this.state;
+		const classes = classnames( 'ellipsis-menu', {
+			'is-menu-visible': isMenuVisible
+		} );
+
+		return (
+			<span className={ classes }>
+				<Button
+					ref={ this.setPopoverContext }
+					onClick={ isMenuVisible ? this.hideMenu : this.showMenu }
+					title={ toggleTitle || translate( 'Toggle menu' ) }
+					borderless>
+					<Gridicon
+						icon="ellipsis"
+						className="ellipsis-menu__toggle-icon" />
+				</Button>
+				<PopoverMenu
+					isVisible={ isMenuVisible }
+					onClose={ this.hideMenu }
+					position={ position }
+					context={ popoverContext }
+					className="ellipsis-menu__menu popover">
+					{ children }
+				</PopoverMenu>
+			</span>
+		);
+	}
+}
+
+export default localize( EllipsisMenu );

--- a/client/components/ellipsis-menu/style.scss
+++ b/client/components/ellipsis-menu/style.scss
@@ -1,0 +1,12 @@
+.ellipsis-menu__menu hr {
+	margin: 8px 0;
+	background: lighten( $gray, 30% );
+}
+
+.gridicon.ellipsis-menu__toggle-icon {
+	transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+
+	.ellipsis-menu.is-menu-visible & {
+		transform: rotate( 90deg );
+	}
+}

--- a/client/components/ellipsis-menu/style.scss
+++ b/client/components/ellipsis-menu/style.scss
@@ -1,8 +1,3 @@
-.ellipsis-menu__menu hr {
-	margin: 8px 0;
-	background: lighten( $gray, 30% );
-}
-
 .gridicon.ellipsis-menu__toggle-icon {
 	transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 

--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -74,6 +74,7 @@ that can trigger the opening and closing of the Popover then you need to pass in
 	<PopoverMenuItem action="A">Item A</PopoverMenuItem>
 	<PopoverMenuItem action="B"
 			onClick={ this._onPopoverMenuItemBClick }>Item B</PopoverMenuItem>
+	<PopoverMenuSeparator />
 	<PopoverMenuItem action="C">Item C</PopoverMenuItem>
 </PopoverMenu>
 ```

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -1,11 +1,25 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' );
+import React, { PropTypes } from 'react';
+import classnames from 'classnames';
 
-var MenuItem = React.createClass( {
-	getDefaultProps: function() {
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+export default React.createClass( {
+	displayName: 'PopoverMenuItem',
+
+	propTypes: {
+		isVisible: PropTypes.bool,
+		className: PropTypes.string,
+		icon: PropTypes.string,
+		focusOnHover: PropTypes.bool
+	},
+
+	getDefaultProps() {
 		return {
 			isVisible: false,
 			className: '',
@@ -13,23 +27,25 @@ var MenuItem = React.createClass( {
 		};
 	},
 
-	render: function() {
-		var onMouseOver = this.props.focusOnHover ? this._onMouseOver : null;
+	render() {
+		const { focusOnHover, className, disabled, onClick, icon, children } = this.props;
+		const onMouseOver = focusOnHover ? this._onMouseOver : null;
+
 		return (
-			<button className={ classnames( 'popover__menu-item', this.props.className ) }
-					role="menuitem"
-					disabled={ this.props.disabled }
-					onClick={ this.props.onClick }
-					onMouseOver={ onMouseOver }
-					tabIndex="-1">
-				{ this.props.children }
+			<button
+				className={ classnames( 'popover__menu-item', className ) }
+				role="menuitem"
+				disabled={ disabled }
+				onClick={ onClick }
+				onMouseOver={ onMouseOver }
+				tabIndex="-1">
+				{ icon && <Gridicon icon={ icon } size={ 18 } /> }
+				{ children }
 			</button>
 		);
 	},
 
-	_onMouseOver: function( event ) {
+	_onMouseOver( event ) {
 		event.target.focus();
 	}
 } );
-
-module.exports = MenuItem;

--- a/client/components/popover/menu-separator.jsx
+++ b/client/components/popover/menu-separator.jsx
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const hr = <hr className="popover__menu-separator" />;
+
+export default () => hr;

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -190,6 +190,7 @@
 	}
 }
 
+.popover__menu-separator,
 .popover__hr {
 	margin: 8px 0;
 	background: lighten( $gray, 30 );

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -28,6 +28,7 @@ import TokenFields from 'components/token-field/docs/example';
 import CountedTextareas from 'components/forms/counted-textarea/docs/example';
 import ProgressBar from 'components/progress-bar/docs/example';
 import Popovers from 'components/popover/docs/example';
+import EllipsisMenu from 'components/ellipsis-menu/docs/example';
 import Ranges from 'components/forms/range/docs/example';
 import Gauge from 'components/gauge/docs/example';
 import Headers from 'components/header-cake/docs/example';
@@ -107,6 +108,7 @@ let DesignAssets = React.createClass( {
 					<CountedTextareas />
 					<DatePicker />
 					<DropZones searchKeywords="drag" />
+					<EllipsisMenu />
 					<ExternalLink />
 					<FAQ />
 					<FeatureGate />

--- a/client/my-sites/post-type-list/post-actions.jsx
+++ b/client/my-sites/post-type-list/post-actions.jsx
@@ -35,14 +35,17 @@ function PostTypeListPostActions( { translate, post, dispatchTrashPost, dispatch
 	return (
 		<div className="post-type-list__post-actions">
 			<EllipsisMenu position="bottom left">
-				<PopoverMenuItem onClick={ onTrash }>
-					<Gridicon icon="trash" size={ 18 } />
+				<PopoverMenuItem
+					onClick={ onTrash }
+					icon="trash">
 					{ post && 'trash' === post.status
 						? translate( 'Delete Permanently' )
 						: translate( 'Trash', { context: 'verb' } ) }
 				</PopoverMenuItem>
-				<PopoverMenuItem href={ post ? post.URL : '' } target="_blank">
-					<Gridicon icon="external" size={ 18 } />
+				<PopoverMenuItem
+					href={ post ? post.URL : '' }
+					icon="external"
+					target="_blank">
 					{ translate( 'View', { context: 'verb' } ) }
 				</PopoverMenuItem>
 			</EllipsisMenu>

--- a/client/my-sites/post-type-list/post-actions.jsx
+++ b/client/my-sites/post-type-list/post-actions.jsx
@@ -10,7 +10,8 @@ import { localize } from 'i18n-calypso';
  */
 import { getPost } from 'state/posts/selectors';
 import { trashPost, deletePost } from 'state/posts/actions';
-import Button from 'components/button';
+import EllipsisMenu from 'components/ellipsis-menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
 
 function PostTypeListPostActions( { translate, post, dispatchTrashPost, dispatchDeletePost } ) {
@@ -33,20 +34,18 @@ function PostTypeListPostActions( { translate, post, dispatchTrashPost, dispatch
 
 	return (
 		<div className="post-type-list__post-actions">
-			<Button onClick={ onTrash } borderless>
-				<Gridicon icon="trash" />
-				<span className="post-type-list__post-actions-srt">
+			<EllipsisMenu position="bottom left">
+				<PopoverMenuItem onClick={ onTrash }>
+					<Gridicon icon="trash" size={ 18 } />
 					{ post && 'trash' === post.status
 						? translate( 'Delete Permanently' )
 						: translate( 'Trash', { context: 'verb' } ) }
-				</span>
-			</Button>
-			<Button href={ post ? post.URL : '' } target="_blank" borderless>
-				<Gridicon icon="external" />
-				<span className="post-type-list__post-actions-srt">
+				</PopoverMenuItem>
+				<PopoverMenuItem href={ post ? post.URL : '' } target="_blank">
+					<Gridicon icon="external" size={ 18 } />
 					{ translate( 'View', { context: 'verb' } ) }
-				</span>
-			</Button>
+				</PopoverMenuItem>
+			</EllipsisMenu>
 		</div>
 	);
 }

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -94,10 +94,6 @@
 	}
 }
 
-.post-type-list__post-actions-srt {
-	@extend .screen-reader-text;
-}
-
 .post-type-list__post-actions .button {
 	opacity: 0.5;
 	padding-left: 8px;


### PR DESCRIPTION
This pull request seeks to...

- Introduce a new `<EllipsisMenu />` component for simplifying the common pattern of toggled ellipsis menus
- Adds support for `icon` prop on `<PopoverMenuItem />`
- Replace inline `<PostTypeList />` actions with an ellipsis, per custom post types design

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16426190/fac617ea-3d35-11e6-99c3-f0319df4fa57.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16426228/17be3274-3d36-11e6-8bed-8c5fb333981c.png)

__Testing instructions:__

1. Navigate to [CPT post list screen](http://calypso.localhost:3000/post)
2. Select a site
3. Note that each post has actions under an ellipsis menu, that the menu toggles when clicked, and that actions behave as they do in master

Test live: https://calypso.live/?branch=update/cpt-ellipsis-menu