### PR TITLE
Site Card: remove settings cog from expanded site actions

### DIFF
--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -291,8 +291,6 @@ export default React.createClass( {
 					: <div className="site__content">
 							{ this.renderEditIcon() }
 							<div className="site__actions">
-								{ this.renderStar() }
-								{ this.renderCog() }
 							</div>
 						</div>
 				}


### PR DESCRIPTION
Before:
<img width="238" alt="screen shot 2016-06-28 at 2 10 15 pm" src="https://cloud.githubusercontent.com/assets/437258/16427170/2872dd14-3d3a-11e6-8bac-c61d06bde83f.png">

After:
<img width="287" alt="screen shot 2016-06-28 at 2 10 05 pm" src="https://cloud.githubusercontent.com/assets/437258/16427181/2f64774a-3d3a-11e6-8a46-6c090c9240ff.png">

This just removes the render line for the site actions, not all the logic. There'd be more long-term clean up to do in `my-sites/site/index.jsx`

@meremagee @mtias 

Test live: https://calypso.live/?branch=update/remove-site-card-settings-cog