### PR TITLE
CPT: Display all status options for Jetpack sites, combine status filters

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -92,7 +92,7 @@ const PostTypeFilter = React.createClass( {
 	},
 
 	render() {
-		const { siteId, query, jetpack, counts } = this.props;
+		const { siteId, query, jetpack } = this.props;
 		const navItems = this.getNavItems();
 		const selectedItem = find( navItems, 'selected' ) || {};
 
@@ -106,7 +106,7 @@ const PostTypeFilter = React.createClass( {
 				<SectionNav
 					selectedText={ selectedItem.children }
 					selectedCount={ selectedItem.count }>
-					{ ( jetpack || counts ) && [
+					{ query && [
 						<NavTabs
 							key="tabs"
 							label={ this.translate( 'Status', { context: 'Filter group label for tabs' } ) }

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -8,6 +8,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import Types from './main';
+import { mapPostStatus } from 'lib/route/path';
 
 export function redirect() {
 	page.redirect( '/posts' );
@@ -17,7 +18,7 @@ export function list( context, next ) {
 	context.primary = (
 		<Types query={ {
 			type: context.params.type,
-			status: context.params.status || 'publish',
+			status: mapPostStatus( context.params.status ),
 			search: context.query.s
 		} } />
 	);

--- a/client/state/posts/counts/selectors.js
+++ b/client/state/posts/counts/selectors.js
@@ -4,6 +4,11 @@
 import get from 'lodash/get';
 
 /**
+ * Constants
+ */
+const POST_STATUSES = [ 'publish', 'draft', 'pending', 'private', 'future', 'trash' ];
+
+/**
  * Returns true if post counts request is in progress, or false otherwise.
  *
  * @param  {Object}  state    Global state tree
@@ -65,4 +70,56 @@ export function getMyPostCounts( state, siteId, postType ) {
  */
 export function getMyPostCount( state, siteId, postType, status ) {
 	return get( getMyPostCounts( state, siteId, postType ), status, null );
+}
+
+/**
+ * Returns an object of normalized post counts, summing publish/private and
+ * pending/draft counts.
+ *
+ * @param  {Object}   state         Global state tree
+ * @param  {Number}   siteId        Site ID
+ * @param  {String}   postType      Post type
+ * @param  {Function} countSelector Selector from which to retrieve raw counts
+ * @return {Number}                 Normalized post counts
+ */
+export function getNormalizedPostCounts( state, siteId, postType, countSelector = getAllPostCounts ) {
+	const counts = countSelector( state, siteId, postType );
+
+	return POST_STATUSES.reduce( ( memo, status ) => {
+		const count = get( counts, status, 0 );
+
+		let key;
+		switch ( status ) {
+			case 'publish':
+			case 'private':
+				key = 'publish';
+				break;
+
+			case 'draft':
+			case 'pending':
+				key = 'draft';
+				break;
+
+			default:
+				key = status;
+		}
+
+		return {
+			...memo,
+			[ key ]: ( memo[ key ] || 0 ) + count
+		};
+	}, {} );
+}
+
+/**
+ * Returns an object of normalized post counts for current user, summing
+ * publish/private and pending/draft counts.
+ *
+ * @param  {Object} state    Global state tree
+ * @param  {Number} siteId   Site ID
+ * @param  {String} postType Post type
+ * @return {Number}          Normalized post counts
+ */
+export function getNormalizedMyPostCounts( state, siteId, postType ) {
+	return getNormalizedPostCounts( state, siteId, postType, getMyPostCounts );
 }

--- a/client/state/posts/counts/test/selectors.js
+++ b/client/state/posts/counts/test/selectors.js
@@ -11,7 +11,9 @@ import {
 	getAllPostCounts,
 	getAllPostCount,
 	getMyPostCounts,
-	getMyPostCount
+	getMyPostCount,
+	getNormalizedPostCounts,
+	getNormalizedMyPostCounts
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -89,7 +91,7 @@ describe( 'selectors', () => {
 						}
 					}
 				}
-			}, 2916284, 'post' )
+			}, 2916284, 'post' );
 
 			expect( postCounts ).to.eql( {
 				publish: 2
@@ -147,7 +149,7 @@ describe( 'selectors', () => {
 						}
 					}
 				}
-			}, 2916284, 'post' )
+			}, 2916284, 'post' );
 
 			expect( postCounts ).to.eql( {
 				publish: 1
@@ -174,6 +176,90 @@ describe( 'selectors', () => {
 			}, 2916284, 'post', 'publish' );
 
 			expect( postCounts ).to.equal( 1 );
+		} );
+	} );
+
+	describe( 'getNormalizedPostCounts()', () => {
+		it( 'should return normalized post counts using selector', () => {
+			const postCounts = getNormalizedPostCounts( {
+				posts: {
+					counts: {
+						counts: {
+							2916284: {
+								post: {
+									mine: {
+										publish: 1,
+										'private': 1,
+										draft: 2,
+										pending: 1,
+										future: 2,
+										badstatus: 10
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'post', getMyPostCounts );
+
+			expect( postCounts ).to.eql( {
+				publish: 2,
+				draft: 3,
+				future: 2,
+				trash: 0
+			} );
+		} );
+
+		it( 'should default to returning all counts', () => {
+			const postCounts = getNormalizedPostCounts( {
+				posts: {
+					counts: {
+						counts: {
+							2916284: {
+								post: {
+									all: {
+										publish: 1
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'post' );
+
+			expect( postCounts ).to.eql( {
+				publish: 1,
+				draft: 0,
+				future: 0,
+				trash: 0
+			} );
+		} );
+	} );
+
+	describe( 'getNormalizedMyPostCounts()', () => {
+		it( 'should return normalized post counts for mine counts', () => {
+			const postCounts = getNormalizedMyPostCounts( {
+				posts: {
+					counts: {
+						counts: {
+							2916284: {
+								post: {
+									mine: {
+										publish: 1
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'post' );
+
+			expect( postCounts ).to.eql( {
+				publish: 1,
+				draft: 0,
+				future: 0,
+				trash: 0
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/pull/6229#issuecomment-228917292

This pull request seeks to...

- Use post status mapping to combine private/publish, draft/pending counts, for consistency with posts screen (also causes change to status path fragment, e.g. `trash` -> `trashed`, `draft` -> `drafts`, `future` -> `scheduled`)
- Display all status options for Jetpack sites, without count number (not available in WP-API endpoint)

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16427592/05c95430-3d3c-11e6-916d-77ef6fb23234.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16427584/fd0c3830-3d3b-11e6-98c5-48d56b10752d.png)

__Testing instructions:__

1. Navigate to My Sites
2. Switch to a Jetpack site where at least one custom post type exists
3. Click the custom post type in the sidebar
4. Note that filter bar is shown with all status options (as in screenshot above)
5. Note that switching between filters displays relevant items, reflecting behavior of combining publish/private, draft/pending

/cc @nylen 

Test live: https://calypso.live/?branch=fix/cpt-jetpack-counts