### PR TITLE
Reader Cold Start: redirect to /read/start if user is eligible

### DIFF
--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -55,6 +55,7 @@ module.exports = {
 				'logout_URL',
 				'primary_blog_url',
 				'meta',
+				'is_new_reader'
 			],
 			decodeWhitelist = [
 				'display_name',

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,12 +1,16 @@
-// External dependencies
+/**
+ * External dependencies
+ */
 import React from 'react';
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 import Stream from 'reader/stream';
 
 const FollowingStream = ( props ) => {
 	return (
-		<Stream {...props} />
+		<Stream { ...props } />
 	);
 };
 

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -16,7 +16,7 @@ function forceTeamA8C( context, next ) {
 
 module.exports = function() {
 	if ( config.isEnabled( 'reader' ) ) {
-		page( '/', controller.loadSubscriptions, controller.initAbTests, controller.updateLastRoute, controller.removePost, controller.sidebar, controller.following );
+		page( '/', controller.loadSubscriptions, controller.checkForColdStart, controller.initAbTests, controller.updateLastRoute, controller.removePost, controller.sidebar, controller.following );
 
 		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/' );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -142,5 +142,6 @@
 		{ "value": 449, "langSlug": "zh-cn", "name": "zh-cn - 简体中文", "wpLocale": "zh_CN", "popular": 13 },
 		{ "value": 452, "langSlug": "zh-tw", "name": "zh-tw - 繁體中文", "wpLocale": "zh_TW", "popular": 14 }
 	],
-	"project": "wordpress-com"
+	"project": "wordpress-com",
+	"reader_cold_start_graduation_threshold": 2
 }

--- a/config/client.json
+++ b/config/client.json
@@ -28,5 +28,6 @@
   "discover_blog_id",
   "support-user",
   "sync-handler-defaults",
-  "project"
+  "project",
+  "reader_cold_start_graduation_threshold"
 ]


### PR DESCRIPTION
If the user has not "graduated" Cold Start, we should redirect them there instead of the following stream.

### To test

1. Start new user signup at http://calypso.localhost:3000/start/website
2. In the JavaScript console, run these commands:

`localStorage.clear()`
`localStorage.setItem('ABTests','{"coldStartReader_20160622":"noEmailColdStart"}')`

3. Go through the new user setup process
4. Click on 'Reader' in the top navigation - you should be taken to Cold Start, not the following stream
5. Follow one site
6. Return to http://calypso.localhost:3000/ - you should reach your following stream, not Cold Start.

Test live: https://calypso.live/?branch=add/reader/redirect-to-cold-start