### PR TITLE
Remove plans-step specific max-width

### DIFF
--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -1,8 +1,3 @@
-.plans-step {
-	margin: 0 auto;
-	max-width: 700px;
-}
-
 .plans-step__compare-plans-link {
 	clear: both;
 	display: block;


### PR DESCRIPTION
I noticed when going through signup that the four-plans screen looked very squished. The wrapper around it was giving it a max-width of 700px, which is okay for three plans, but not four. Removing that wrapper’s special styling lets it expand out to 1000px wide, which looks much better IMO for the four plans.

Before:

![plans-before](https://cloud.githubusercontent.com/assets/2846578/16432220/019641d2-3d52-11e6-9f1b-dc00a657d0a5.jpg)

After:

![plans-after](https://cloud.githubusercontent.com/assets/2846578/16432224/0373f58a-3d52-11e6-9d5e-f1aa5d027048.jpg)

Test live: https://calypso.live/?branch=update/four-plans-in-signup