### PR TITLE
Purchases: Survey Debug

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -27,6 +27,12 @@ import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
 
+/**
+ * Module dependencies
+ */
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:purchases:survey' );
+
 const RemovePurchase = React.createClass( {
 	propTypes: {
 		selectedPurchase: React.PropTypes.object.isRequired,
@@ -106,13 +112,15 @@ const RemovePurchase = React.createClass( {
 				'what-better': { text: this.state.questionThreeText }
 			} );
 
+			debug( 'Survey responses', survey );
 			survey.submit()
 				.then( res => {
+					debug( 'Survey submit response', res );
 					if ( ! res.success ) {
 						notices.error( res.err );
 					}
 				} )
-				.catch( err => console.error( err ) ); // shouldn't get here
+				.catch( err => debug( err ) ); // shouldn't get here
 		}
 
 		removePurchase( purchase.id, user.ID, success => {


### PR DESCRIPTION
Per @rralian's request this simple update adds some debug statements to posting the survey.

See: https://github.com/Automattic/wp-calypso/pull/4838#discussion_r68837079

Test live: https://calypso.live/?branch=add/remove-purchase-survey-debug