### PR TITLE
Signup: fix `NavigationLink` back button when `backUrl` is provided.

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -30,8 +30,8 @@ const NavigationLink = React.createClass( {
 			return;
 		}
 
-		if ( this.props.getBackUrl ) {
-			return this.props.getBackUrl;
+		if ( this.props.backUrl ) {
+			return this.props.backUrl;
 		}
 
 		const previousStepName = signupUtils.getPreviousStepName( this.props.flowName, this.props.stepName ),

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -13,6 +13,18 @@ import config from 'config';
 export default React.createClass( {
 	displayName: 'StepWrapper',
 
+	renderBack: function() {
+		return (
+			<NavigationLink
+				direction="back"
+				flowName={ this.props.flowName }
+				positionInFlow={ this.props.positionInFlow }
+				stepName={ this.props.stepName }
+				backUrl={ this.props.backUrl }
+				signupProgressStore={ this.props.signupProgressStore } />
+		);
+	},
+
 	renderSkip: function() {
 		if ( this.props.goToNextStep ) {
 			return (
@@ -65,13 +77,7 @@ export default React.createClass( {
 				<div className="is-animated-content">
 					{ this.props.stepContent }
 					<div className="step-wrapper__buttons">
-						<NavigationLink
-							direction="back"
-							flowName={ this.props.flowName }
-							positionInFlow={ this.props.positionInFlow }
-							stepName={ this.props.stepName }
-							backUrl={ this.props.backUrl }
-							signupProgressStore={ this.props.signupProgressStore } />
+						{ this.renderBack() }
 						{ this.renderSkip() }
 					</div>
 				</div>


### PR DESCRIPTION
Fixes #5532.

There was a typo in `getBackUrl()`, ignoring the `backUrl` prop that can be passed to `NavigationLink`.

To test:

1. Enter Signup
2. Complete a few steps
3. Check "back" button destination from different steps (i.e. themes) and sub-steps (i.e. domain mapping or google apps)

/cc @coreh @bisko @meremagee @apeatling 

Test live: https://calypso.live/?branch=fix/signup-navigation-back-button