### PR TITLE
Plans: do not display popular banner if we have a paid plan

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -14,7 +14,7 @@ import PlanFeaturesItemList from './list';
 import PlanFeaturesItem from './item';
 import PlanFeaturesFooter from './footer';
 import PlanFeaturesPlaceholder from './placeholder';
-import { isCurrentSitePlan } from 'state/sites/selectors';
+import { isCurrentPlanPaid, isCurrentSitePlan } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getPlanRawPrice, getPlan } from 'state/plans/selectors';
@@ -96,12 +96,13 @@ export default connect( ( state, ownProps ) => {
 	const planProductId = plansList[ ownProps.plan ].getProductId();
 	const selectedSiteId = getSelectedSiteId( state );
 	const planObject = getPlan( state, planProductId );
+	const isPaid = isCurrentPlanPaid( state, selectedSiteId );
 
 	return {
 		planName: ownProps.plan,
 		current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
-		popular: isPopular( ownProps.plan ),
+		popular: isPopular( ownProps.plan ) && ! isPaid,
 		features: getPlanFeaturesObject( ownProps.plan ),
 		rawPrice: getPlanRawPrice( state, planProductId, ! isMonthly( ownProps.plan ) ),
 		planConstantObj: plansList[ ownProps.plan ],

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -26,7 +26,7 @@ export const sitesSchema = {
 					type: 'object',
 					properties: {
 						id: { type: 'number' },
-						sizes: { type: [ 'array', 'object'] },
+						sizes: { type: [ 'array', 'object' ] },
 						url: { type: 'string' }
 					}
 				},
@@ -48,11 +48,13 @@ export const sitesSchema = {
 				},
 				plan: {
 					type: 'object',
+					required: [ 'product_id', 'product_slug', 'expired' ],
 					properties: {
 						product_id: { type: 'number' },
 						product_slug: { type: 'string' },
 						product_name_short: { type: 'string' },
-						free_trial: { type: 'boolean' }
+						free_trial: { type: 'boolean' },
+						expired: { type: 'boolean' }
 					}
 				},
 				single_user_site: { type: 'boolean' }

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -167,6 +167,23 @@ export function getSitePlan( state, siteId ) {
 }
 
 /**
+ * Returns true if the current site plan is a paid one
+ *
+ * @param  {Object}   state         Global state tree
+ * @param  {Number}   siteId        Site ID
+ * @return {?Boolean}               Whether the current plan is paid
+ */
+export function isCurrentPlanPaid( state, siteId ) {
+	const sitePlan = getSitePlan( state, siteId );
+
+	if ( ! sitePlan ) {
+		return null;
+	}
+
+	return sitePlan.product_id !== 1 && sitePlan.product_id !== 2002;
+}
+
+/**
  * Returns true if site is currently subscribed to supplied plan and false otherwise.
  *
  * @param  {Object}   state         Global state tree

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -8,6 +8,7 @@ import filter from 'lodash/filter';
 import some from 'lodash/some';
 import includes from 'lodash/includes';
 import find from 'lodash/find';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -140,6 +141,26 @@ export function getSitePlan( state, siteId ) {
 
 	if ( ! site ) {
 		return null;
+	}
+
+	if ( get( site.plan, 'expired', false ) ) {
+		if ( site.jetpack ) {
+			return {
+				product_id: 2002,
+				product_slug: 'jetpack_free',
+				product_name_short: 'Free',
+				free_trial: false,
+				expired: false
+			};
+		}
+
+		return {
+			product_id: 1,
+			product_slug: 'free_plan',
+			product_name_short: 'Free',
+			free_trial: false,
+			expired: false
+		};
 	}
 
 	return site.plan;

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -336,6 +336,61 @@ describe( 'selectors', () => {
 				free_trial: false
 			} );
 		} );
+
+		it( 'it should return free plan if expired', () => {
+			const sitePlan = getSitePlan( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							plan: {
+								product_id: 1008,
+								product_slug: 'business-bundle',
+								product_name_short: 'Business',
+								free_trial: false,
+								expired: true
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( sitePlan ).to.eql( {
+				product_id: 1,
+				product_slug: 'free_plan',
+				product_name_short: 'Free',
+				free_trial: false,
+				expired: false
+			} );
+		} );
+
+		it( 'it should return jetpack free plan if expired', () => {
+			const sitePlan = getSitePlan( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							jetpack: true,
+							plan: {
+								product_id: 1234,
+								product_slug: 'fake-plan',
+								product_name_short: 'Fake Plan',
+								free_trial: false,
+								expired: true
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( sitePlan ).to.eql( {
+				product_id: 2002,
+				product_slug: 'jetpack_free',
+				product_name_short: 'Free',
+				free_trial: false,
+				expired: false
+			} );
+		} );
 	} );
 
 	describe( '#isCurrentSitePlan()', () => {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -15,7 +15,8 @@ import {
 	isRequestingSites,
 	getSiteByUrl,
 	getSitePlan,
-	isCurrentSitePlan
+	isCurrentSitePlan,
+	isCurrentPlanPaid
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -453,6 +454,55 @@ describe( 'selectors', () => {
 			}, 77203074, 1003 );
 
 			expect( isCurrent ).to.be.false;
+		} );
+	} );
+
+	describe( '#isCurrentPlanPaid()', () => {
+		it( 'it should return true if not free plan', () => {
+			const isPaid = isCurrentPlanPaid( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							plan: {
+								product_id: 1008
+							}
+						}
+					}
+				}
+			}, 77203074, 1003 );
+
+			expect( isPaid ).to.equal( true );
+		} );
+		it( 'it should return false if free plan', () => {
+			const isPaid = isCurrentPlanPaid( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							plan: {
+								product_id: 1
+							}
+						}
+					}
+				}
+			}, 77203074, 1003 );
+
+			expect( isPaid ).to.equal( false );
+		} );
+
+		it( 'it should return null if plan is missing', () => {
+			const isPaid = isCurrentPlanPaid( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074
+						}
+					}
+				}
+			}, 77203074, 1003 );
+
+			expect( isPaid ).to.equal( null );
 		} );
 	} );
 } );


### PR DESCRIPTION
This fixes #6344 to only show the popular banner when a selected site has a free, or Jetpack free plan. This also updates the getSitePlan selector to respect the expired boolean. (The API may still return a recently expired plan).

<img width="1079" alt="a1153132-3c67-11e6-9913-d72ea3734ea1" src="https://cloud.githubusercontent.com/assets/1270189/16435126/9bd6b178-3d48-11e6-9059-695152f3161d.png">

## Testing Instructions

- Navigate to http://calypso.localhost:3000/plans
- Select a site with a free plan
- Popular banner should display over Premium
- Navigate to http://calypso.localhost:3000/plans
- Select a site with a wpcom paid plan
- Popular banner should not display over Premium
- Navigate to http://calypso.localhost:3000/plans
- Select a site with a Jetpack free plan
- Popular banner should display over Premium
- Navigate to http://calypso.localhost:3000/plans
- Select a site with a Jetpack paid plan
- Popular banner should not display over Premium

cc @artpi @lamosty @rralian 


Test live: https://calypso.live/?branch=update/popular-banner