### PR TITLE
Framework: createSelector: allow 2nd arg to be array of selectors

### DIFF
--- a/client/lib/create-selector/README.md
+++ b/client/lib/create-selector/README.md
@@ -8,7 +8,7 @@ This module exports a single function which creates a memoized state selector fo
 `createSelector` accepts the following arguments:
 
 - A function which calculates the cached result given a state object and any number of variable arguments necessary to calculate the result
-- A function which returns an array of dependent state given the state and the same arguments as the selector
+- A function or array of functions which return array of dependent state, given the state and the same arguments as the selector
 - _(Optional)_ A function to customize the cache key used by the inner memoized function
 
 For example, we might consider that our state contains post objects, each of which are assigned to a particular site. Retrieving an array of posts for a specific site would require us to filter over all of the known posts. While this would normally be an expensive operation, we can use `createSelector` to create a memoized function:
@@ -47,6 +47,30 @@ When creating a memoized selector via `createSelector`, we pass a function which
 Yes! This is a very common pattern in our state selectors, and is a key differentiator from [`reselect`](https://github.com/reactjs/reselect), another popular tool which achieves a similar goal.
 
 Do note that the internal memoized function calculates its cache key by a simple [`Array.prototype.join`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join) call, so your arguments should not be complex objects.
+
+### How can I express that my new selector depends on state from multiple selectors?
+
+Let's assume your new selector depends on the state selectors `foo`, `bar`, and `baz`. You could then state that like so:
+
+```js
+createSelector(
+    state => foo( state ) && bar( state ),
+    state => [
+        foo( state ),
+        bar( state ),
+        baz( state ),
+    ]
+);
+```
+
+Since this is a reoccurring pattern, there is a shorthand for this situation. You can reduce the above to an array just the selectors:
+
+```js
+createSelector(
+    state => foo( state ) && bar( state ),
+    [ foo, bar, baz ]
+);
+```
 
 ### How can I access the internal cache?
 

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -130,6 +130,30 @@ describe( 'index', () => {
 		expect( selector ).to.have.been.calledOnce;
 	} );
 
+	it( 'should accept an array of dependent selectors', () => {
+		const getPosts = ( state ) => state.posts;
+		const getSitePostsWithArrayDependants = createSelector( selector, [ getPosts ] );
+		const state = {
+			posts: {
+				'3d097cb7c5473c169bba0eb8e3c6cb64': {
+					ID: 841,
+					site_ID: 2916284,
+					global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+					title: 'Hello World'
+				}
+			}
+		};
+
+		const nextState = { posts: {} };
+
+		getSitePostsWithArrayDependants( state, 2916284 );
+		getSitePostsWithArrayDependants( state, 2916284 );
+		getSitePostsWithArrayDependants( nextState, 2916284 );
+		getSitePostsWithArrayDependants( nextState, 2916284 );
+
+		expect( selector ).to.have.been.calledTwice;
+	} );
+
 	it( 'should default to watching entire state, returning cached result if no changes', () => {
 		const getSitePostsWithDefaultGetDependants = createSelector( selector );
 		const state = {
@@ -186,5 +210,16 @@ describe( 'index', () => {
 		memoizedSelector( state, 1, 2, 3 );
 
 		expect( getDeps ).to.have.been.calledWithExactly( state, 1, 2, 3 );
+	} );
+
+	it( 'should handle an array of selectors instead of a dependant state getter', () => {
+		const getPosts = sinon.spy();
+		const getQuuxs = sinon.spy();
+		const memoizedSelector = createSelector( () => null, [ getPosts, getQuuxs ] );
+		const state = {};
+
+		memoizedSelector( state, 1, 2, 3 );
+		expect( getPosts ).to.have.been.calledWithExactly( state, 1, 2, 3 );
+		expect( getQuuxs ).to.have.been.calledWithExactly( state, 1, 2, 3 );
 	} );
 } );


### PR DESCRIPTION
This PR allows consumers of `createSelector` that depend on multiple selectors to simplify their invocation of `createSelector` from:

```js
createSelector(
	state => foo( state ) && bar( state ),
	state => [
		foo( state ),
		bar( state ),
		baz( state ),
	]
);
```

to:

```js
createSelector(
	state => foo( state ) && bar( state ),
	[ foo, bar, baz ]
);
```

### To do
- [x] Tests
- [x] Doc block

Test live: https://calypso.live/?branch=add/create-selector-dependants-array