### PR TITLE
Purchases: Add more testing platforms

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -89,7 +89,8 @@
 		"upgrades/credit-cards": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
-		"upgrades/premium-themes": true
+		"upgrades/premium-themes": true,
+		"upgrades/removal-survey": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -103,7 +103,8 @@
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
-		"upgrades/premium-themes": true
+		"upgrades/premium-themes": true,
+		"upgrades/removal-survey": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
Simple update to release survey to more platforms to test on. Please refer to https://github.com/Automattic/wp-calypso/pull/4838 for full testing instructions.

Test live: https://calypso.live/?branch=update/remove-purchase-survey-platforms