### PR TITLE
Guided Transfer: Adds in-progress screen

### DIFF
--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -24,6 +24,7 @@ export default React.createClass( {
 		startExport: PropTypes.func.isRequired,
 		setPostType: PropTypes.func.isRequired,
 		advancedSettingsFetch: PropTypes.func.isRequired,
+		isGuidedTransferInProgress: PropTypes.bool,
 		showGuidedTransferOptions: PropTypes.bool,
 		shouldShowProgress: PropTypes.bool.isRequired,
 		postType: PropTypes.string,

--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -7,6 +7,7 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
+import GuidedTransferInProgress from './guided-transfer-in-progress';
 import GuidedTransferOptions from 'my-sites/exporter/guided-transfer-options';
 import GuidedTransferDetails from 'my-sites/exporter/guided-transfer-details';
 import AdvancedSettings from 'my-sites/exporter/advanced-settings';
@@ -48,6 +49,7 @@ export default React.createClass( {
 			postType,
 			shouldShowProgress,
 			isExporting,
+			isGuidedTransferInProgress,
 			showGuidedTransferOptions,
 		} = this.props;
 		const siteId = this.props.site.ID;
@@ -97,6 +99,7 @@ export default React.createClass( {
 		return (
 			<div className="exporter">
 				{ notice }
+				{ isGuidedTransferInProgress && <GuidedTransferInProgress /> }
 				<FoldableCard
 					actionButtonIcon="cog"
 					header={

--- a/client/my-sites/exporter/guided-transfer-in-progress.jsx
+++ b/client/my-sites/exporter/guided-transfer-in-progress.jsx
@@ -23,7 +23,7 @@ const GuidedTransferInProgress = ( { translate } ) =>
 		<p>
 		{ translate(
 			'A Guided Transfer occurs over a 24 hour period. A Happiness Engineer ' +
-			'will work with you to set up a day to perform the transfer'
+			'will work with you to set up a day to perform the transfer.'
 		) }
 		</p>
 		<Button href={ supportUrls.GUIDED_TRANSFER }>

--- a/client/my-sites/exporter/guided-transfer-in-progress.jsx
+++ b/client/my-sites/exporter/guided-transfer-in-progress.jsx
@@ -13,9 +13,13 @@ import Gridicon from 'components/gridicon';
 import supportUrls from 'lib/url/support';
 
 const GuidedTransferInProgress = ( { translate } ) =>
-	<Card>
-		<Gridicon icon="time" size={ 48 } />
-		<h1>{ translate( 'Your site is being prepared for transfer' ) }</h1>
+	<Card className="exporter__guided-transfer-in-progress">
+		<div className="exporter__guided-transfer-in-progress-icon">
+			<Gridicon icon="time" size={ 48 } />
+		</div>
+		<h1 className="exporter__guided-transfer-in-progress-title">
+			{ translate( 'Your site is being prepared for transfer' ) }
+		</h1>
 		<p>
 		{ translate(
 			'A Guided Transfer occurs over a 24 hour period. A Happiness Engineer ' +

--- a/client/my-sites/exporter/guided-transfer-in-progress.jsx
+++ b/client/my-sites/exporter/guided-transfer-in-progress.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import supportUrls from 'lib/url/support';
+
+const GuidedTransferInProgress = ( { translate } ) =>
+	<Card>
+		<Gridicon icon="time" size={ 48 } />
+		<h1>{ translate( 'Your site is being prepared for transfer' ) }</h1>
+		<p>
+		{ translate(
+			'A Guided Transfer occurs over a 24 hour period. A Happiness Engineer ' +
+			'will work with you to set up a day to perform the transfer'
+		) }
+		</p>
+		<Button href={ supportUrls.GUIDED_TRANSFER }>
+			{ translate( 'Learn more about Guided Transfers' ) }
+		</Button>
+	</Card>;
+
+export default localize( GuidedTransferInProgress );

--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -38,6 +38,10 @@ function mapStateToProps( state ) {
 		didComplete: getExportingState( state, siteId ) === States.COMPLETE,
 		didFail: getExportingState( state, siteId ) === States.FAILED,
 		showGuidedTransferOptions: config.isEnabled( 'manage/export/guided-transfer' ),
+
+		// This will be replaced with a Redux selector once we've built out
+		// the reducers
+		isGuidedTransferInProgress: false,
 	};
 }
 

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -153,4 +153,38 @@
 .exporter__guided-transfer-feature-text {
 	color: $gray;
 }
+
+.exporter__guided-transfer-in-progress {
+	padding-top: 32px;
+	padding-bottom: 32px;
+	font-size: 16px;
+	text-align: center;
+
+	@include breakpoint( ">660px" ) {
+		padding-left: 128px;
+		text-align: left;
+	}
+}
+
+.exporter__guided-transfer-in-progress-icon {
+	margin: 16px auto;
+	width: 48px;
+	height: 48px;
+	padding: 14px;
+	border-radius: 50%;
+	background-color: darken( $gray, 20% );
+	color: $gray-light;
+
+	@include breakpoint( ">660px" ) {
+		position: absolute;
+		margin-left: -96px;
+		margin-top: 16px;
+	}
+}
+
+.exporter__guided-transfer-in-progress-title {
+	font-size: 24px;
+	font-weight: 300;
+	color: $gray-dark;
+}
 // END GUIDED TRANSFER


### PR DESCRIPTION
This adds a card on the Settings > Export tab to be displayed after a Guided Transfer has been purchased by the user.

Currently hidden, it will be enabled once we build out the Redux store and API endpoints.

| Mobile | Desktop |
|----------|------------|
| ![screen shot 2016-06-30 at 9 44 19 pm](https://cloud.githubusercontent.com/assets/416133/16487189/8a5da274-3f0c-11e6-9533-af35930ff029.png) | ![screen shot 2016-06-30 at 9 47 10 pm](https://cloud.githubusercontent.com/assets/416133/16487193/8f4a5322-3f0c-11e6-8c65-4e0be6b627b9.png) |

### How to test

1. Check out the branch `add/guided-transfer/in-progress-screen`
2. In `/client/my-sites/exporter/index.jsx` line 44, manually set `isGuidedTransferInProgress` to `true`.
3. Head to **My Sites > Settings > Export**
4. You should see the screens as above

Note that the option to start a guided transfer is still shown. This will be taken care of when we bring all the pending PRs together with the Redux store integration.

Test live: https://calypso.live/?branch=add/guided-transfer/in-progress-screen