### PR TITLE
Signup: Fix signup when personal plan is shown

### DIFF
--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -25,7 +25,7 @@ export const personalPlan = {
 	prices: {
 		USD: 71.88,
 		EUR: 71.88,
-		GBR: 54,
+		GBP: 54,
 		JPY: 8985,
 		AUS: 97,
 		CAN: 97


### PR DESCRIPTION
Fixes error:
<img width="505" alt="screen shot 2016-06-29 at 12 10 41" src="https://cloud.githubusercontent.com/assets/215074/16450808/1b305290-3df7-11e6-99e8-c9b567e6ce71.png">

raw_price undefined:
![screen shot 2016-06-29 at 12 38 40](https://cloud.githubusercontent.com/assets/215074/16450797/0c9c189a-3df7-11e6-8c2b-c8594cdc65ba.png)

To test:
1. `localStorage.setItem( 'ABTests', '{"personalPlan_20160627":"show"}' );`
2. http://calypso.localhost:3000/start

Test live: https://calypso.live/?branch=fix/personal-plan-free-signup-error