### PR TITLE
Themes: Use getDetailsHelper instead of action for theme info

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -90,6 +90,7 @@ const Theme = React.createClass( {
 		if ( this.props.screenshotClickUrl || this.props.onScreenshotClick ) {
 			return (
 				<a className="theme__active-focus"
+					href={ this.props.screenshotClickUrl }
 					onClick={ this.onScreenshotClick }>
 					<span>
 						{ this.props.actionLabel }

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import merge from 'lodash/merge';
@@ -45,7 +44,6 @@ const ThemesLoggedOut = React.createClass( {
 				separator: true
 			},
 			info: {
-				action: theme => page( getDetailsUrl( theme ) ),
 				getUrl: theme => getDetailsUrl( theme ),
 			},
 			support: {
@@ -83,9 +81,7 @@ const ThemesLoggedOut = React.createClass( {
 				}
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }
-					onScreenshotClick={ function( theme ) {
-						buttonOptions.info.action( theme );
-					} }
+					getScreenshotUrl={ buttonOptions.info.getUrl }
 					getActionLabel={ function() {
 						return buttonOptions.info.label;
 					} }

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import merge from 'lodash/merge';
@@ -75,7 +74,6 @@ const ThemesMultiSite = React.createClass( {
 				separator: true
 			},
 			info: {
-				action: theme => page( getDetailsUrl( theme ) ),
 				getUrl: theme => getDetailsUrl( theme ),
 			},
 			support: {
@@ -114,9 +112,7 @@ const ThemesMultiSite = React.createClass( {
 				}
 				<ThemesSelection search={ this.props.search }
 					selectedSite={ false }
-					onScreenshotClick={ function( theme ) {
-						buttonOptions.info.action( theme );
-					} }
+					getScreenshotUrl={ buttonOptions.info.getUrl }
 					getActionLabel={ function() {
 						return buttonOptions.info.label;
 					} }

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import merge from 'lodash/merge';
@@ -22,7 +21,7 @@ import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import ThemesSelection from './themes-selection';
-import { getDetailsUrl, getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
+import { getCustomizeUrl, getDetailsUrl, getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
 import actionLabels from './action-labels';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 import sitesFactory from 'lib/sites-list';
@@ -67,7 +66,7 @@ const ThemesSingleSite = React.createClass( {
 			buttonOptions = {
 				customize: site && site.isCustomizable()
 					? {
-						action: this.props.customize,
+						getUrl: theme => getCustomizeUrl( theme, site ),
 						hideForTheme: theme => ! theme.active
 					}
 					: {},
@@ -86,14 +85,13 @@ const ThemesSingleSite = React.createClass( {
 					hideForTheme: theme => theme.active || ( theme.price && ! theme.purchased )
 				},
 				tryandcustomize: {
-					action: theme => this.props.customize( theme ),
+					getUrl: theme => getCustomizeUrl( theme, site ),
 					hideForTheme: theme => theme.active
 				},
 				separator: {
 					separator: true
 				},
 				info: {
-					action: theme => page( getDetailsUrl( theme, site ) ),
 					getUrl: theme => getDetailsUrl( theme, site ), // TODO: Make this a selector
 				},
 				support: ! site.jetpack // We don't know where support docs for a given theme on a self-hosted WP install are.
@@ -178,8 +176,8 @@ const ThemesSingleSite = React.createClass( {
 						key={ site.ID }
 						siteId={ this.props.siteId }
 						selectedSite={ site }
-						onScreenshotClick={ function( theme ) {
-							getScreenshotAction( theme ).action( theme );
+						getScreenshotUrl={ function( theme ) {
+							return getScreenshotAction( theme ).getUrl( theme );
 						} }
 						getActionLabel={ function( theme ) {
 							return getScreenshotAction( theme ).label;

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -21,7 +21,14 @@ import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import ThemesSelection from './themes-selection';
-import { getCustomizeUrl, getDetailsUrl, getSupportUrl, getHelpUrl, isPremium, addTracking } from './helpers';
+import {
+	getCustomizeUrl,
+	getDetailsUrl,
+	getSupportUrl,
+	getHelpUrl,
+	isPremium,
+	addTracking
+} from './helpers';
 import actionLabels from './action-labels';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 import sitesFactory from 'lib/sites-list';

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -27,7 +27,7 @@ const ThemesSelection = React.createClass( {
 		] ).isRequired,
 		siteId: PropTypes.string,
 		search: PropTypes.string,
-		onScreenshotClick: PropTypes.func.isRequired,
+		onScreenshotClick: PropTypes.func,
 		getOptions: React.PropTypes.func,
 		queryParams: PropTypes.object.isRequired,
 		themesList: PropTypes.array.isRequired,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import partialRight from 'lodash/partialRight';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import { getPreviewUrl, trackClick } from './helpers';
+import { trackClick } from './helpers';
 import ThemesSearchCard from './themes-search-card';
 import ThemesData from 'components/data/themes-list-fetcher';
 import ThemesList from 'components/themes-list';
@@ -79,7 +78,7 @@ const ThemesSelection = React.createClass( {
 		if ( ! theme.active ) {
 			this.recordSearchResultsClick( theme, resultsRank );
 		}
-		this.props.onScreenshotClick( theme );
+		this.props.onScreenshotClick && this.props.onScreenshotClick( theme );
 	},
 
 	render() {
@@ -105,7 +104,7 @@ const ThemesSelection = React.createClass( {
 					<ThemesList getButtonOptions={ this.props.getOptions }
 						onMoreButtonClick={ this.onMoreButtonClick }
 						onScreenshotClick={ this.onScreenshotClick }
-						getScreenshotUrl={ site ? partialRight( getPreviewUrl, site ) : null }
+						getScreenshotUrl={ this.props.getScreenshotUrl }
 						getActionLabel={ this.props.getActionLabel } />
 				</ThemesData>
 			</div>


### PR DESCRIPTION
This is part of the longer-term project to only use actions (and thus `onClick`) when really needed, and fall back to `href`s otherwise (possibly with side-effects, such as analytics, covered by `onClick`). This will allow us to get rid of actions that are basically just consisting of a `page()` call. (Related issue: #4057) UX-wise, this has the benefit of allowing users to open stuff in new tabs if they wish.

This is particularly relevant for #6349, where in multi-site mode, the higher-order component will intercept all `action`s with the site selector modal, but leave all `get...Url` options untouched. Since 'Info' (ie the Theme Details sheet) shouldn't require a site selection, this PR changes `info` back from an `action` to `getDetailsUrl`.

This PR also uses selectors instead of two site attributes (`isCustomizable` and `isJetpack`) to fix errors when transitioning from single-site to multi-site mode (when `site` is briefly `null`, but `multi-site` hasn't loaded yet). While there are other ways to guard against that case, I think this is rather future-proof for when options will be defined in `connect` anyway (#6349).

To test:
* Verify that the theme showcase still works as before (try logged-out, multi-site, single-site modes; invoke different theme actions; also test the Current Theme bar in single-site mode).
* Note that contrarily to before, you can now right-click on a theme screenshot and open it in a new tab.

cc @sirbrillig 

Test live: https://calypso.live/?branch=update/themes-use-helpers-instead-of-actions