### PR TITLE
Devdocs: fix display of plan items.

### DIFF
--- a/client/my-sites/plan-features/docs/example.jsx
+++ b/client/my-sites/plan-features/docs/example.jsx
@@ -35,14 +35,18 @@ export default React.createClass( {
 
 				</h2>
 				<QueryPlans />
-				<PlanFeatures plan={ PLAN_FREE } />
-				<PlanFeatures plan={ PLAN_PERSONAL } />
-				<PlanFeatures plan={ PLAN_PREMIUM } />
-				<PlanFeatures plan={ PLAN_BUSINESS } />
-				<PlanFeatures plan={ PLAN_JETPACK_BUSINESS } />
-				<PlanFeatures plan={ PLAN_JETPACK_BUSINESS_MONTHLY } />
-				<PlanFeatures plan={ PLAN_JETPACK_PREMIUM } />
-				<PlanFeatures plan={ PLAN_JETPACK_PREMIUM_MONTHLY } />
+				<div style={ { display: 'flex' } } >
+					<PlanFeatures plan={ PLAN_FREE } />
+					<PlanFeatures plan={ PLAN_PERSONAL } />
+					<PlanFeatures plan={ PLAN_PREMIUM } />
+					<PlanFeatures plan={ PLAN_BUSINESS } />
+				</div>
+				<div style={ { display: 'flex' } }>
+					<PlanFeatures plan={ PLAN_JETPACK_BUSINESS } />
+					<PlanFeatures plan={ PLAN_JETPACK_BUSINESS_MONTHLY } />
+					<PlanFeatures plan={ PLAN_JETPACK_PREMIUM } />
+					<PlanFeatures plan={ PLAN_JETPACK_PREMIUM_MONTHLY } />
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/548849/16451406/222b73b6-3e03-11e6-922c-6808bfc68696.png)

After:
![image](https://cloud.githubusercontent.com/assets/548849/16451392/0bb365f8-3e03-11e6-8c7c-cc6b031897d0.png)

cc @gwwar @lamosty 


Test live: https://calypso.live/?branch=fix/plans-in-devdocs