### PR TITLE
Personal Plan: Australian and Canadian currency code fix.

### DIFF
--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -27,8 +27,8 @@ export const personalPlan = {
 		EUR: 71.88,
 		GBP: 54,
 		JPY: 8985,
-		AUS: 97,
-		CAN: 97
+		AUD: 97,
+		CAD: 97
 	},
 	product_name_short: translate( 'Personal' ),
 	product_slug: PLAN_PERSONAL,


### PR DESCRIPTION
Fix currency code for Australia and Canada for the Personal Plan. The country codes were erroneously used.

cc: @ehg 

Test live: https://calypso.live/?branch=fix/personal-plan-free-signup-error-AUD-CAD