### PR TITLE
Themes: Update theme details label to "Info"

### DIFF
--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -46,7 +46,7 @@ const CurrentTheme = React.createClass( {
 		return (
 			<Card className="current-theme">
 				{ site && <QueryCurrentTheme siteId={ site.ID }/> }
-				<div className="current-theme__info">
+				<div className="current-theme__current">
 					<span className="current-theme__label">
 						{ this.translate( 'Current Theme' ) }
 					</span>
@@ -63,8 +63,8 @@ const CurrentTheme = React.createClass( {
 						noticon="paintbrush"
 						href={ this.props.canCustomize ? getCustomizeUrl( null, site ) : null }
 						onClick={ this.trackClick } />
-					<CurrentThemeButton name="details"
-						label={ this.translate( 'Details' ) }
+					<CurrentThemeButton name="info"
+						label={ this.translate( 'Info' ) }
 						noticon="info"
 						href={ currentTheme ? getDetailsUrl( currentTheme, site ) : null }
 						onClick={ this.trackClick } />

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -8,7 +8,7 @@ $current-theme-border: 1px solid lighten( $gray, 20% );
 	margin-bottom: 24px;
 }
 
-.current-theme__info {
+.current-theme__current {
 	@include breakpoint( ">480px" ) {
 		width: 50%;
 		float: left;
@@ -122,7 +122,7 @@ $current-theme-border: 1px solid lighten( $gray, 20% );
 		}
 }
 
-.current-theme__details {
+.current-theme__info {
 	border-left: $current-theme-border;
 	border-right: $current-theme-border;
 }


### PR DESCRIPTION
Addresses #6363 by updating the label on the CurrentTheme card from "Details" to "Info."

Just a note, I looked at changing the name on the `CurrentThemeButton` to `info` as well thereby switching the class on the button to `.current-theme__info`. We use that currently though for the theme name so I left the name as `details` and the class as `.current-theme__details`.

## To test
1. Load up this branch
2. Visit http://calypso.localhost:3000/design/yoursite.wordpress.com

## Screenshot

Previous
![screen shot 2016-06-29 at 7 22 10 am](https://cloud.githubusercontent.com/assets/7240478/16453488/3c4f70aa-3dca-11e6-9f7b-5aeceeef33fe.png)

Updated
![screen shot 2016-06-29 at 7 17 56 am](https://cloud.githubusercontent.com/assets/7240478/16453464/2c22fc06-3dca-11e6-9806-11b842f943df.png)

Test live: https://calypso.live/?branch=fix/6363-theme-info-label