### PR TITLE
Posts: handle cases with drafts but no published posts

### DIFF
--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -146,7 +146,7 @@ export default React.createClass( {
 
 		for ( status in this.filterStatuses ) {
 			if ( 'undefined' === typeof this.state.counts[ status ] &&
-				( ! isJetpackSite ) ) {
+				( ! isJetpackSite ) && 'publish' !== status ) {
 				continue;
 			}
 

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -168,6 +168,10 @@ export default React.createClass( {
 				}
 			}
 
+			if ( 'publish' === status && ! count ) {
+				count = 0;
+			}
+
 			statusItems.push(
 				<NavItem
 					className={ 'is-' + status }


### PR DESCRIPTION
Fixes:

![image](https://cloud.githubusercontent.com/assets/548849/16456363/efbac80e-3e17-11e6-9c2e-daa9bb2c0e59.png)

Note: before this the mobile view would render a malformed "published" label as current status but wouldn't let you navigate if you switched to drafts.

Since "Published" is the default view we always show it.

Test live: https://calypso.live/?branch=update/no-published-posts-view