### PR TITLE
Guided Tours: Find & show tours based on state selectors

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -349,7 +349,9 @@ function reduxStoreReady( reduxStore ) {
 
 	// clear notices
 	page( '*', function( context, next ) {
-		context.store.dispatch( setRouteAction( context.pathname ) );
+		context.store.dispatch( setRouteAction(
+					context.pathname,
+					context.query ) );
 		next();
 	} );
 

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -11,7 +11,7 @@ import i18n from 'i18n-calypso';
  */
 import { getSelectedSite } from 'state/ui/selectors';
 
-function get( tour = 'main' ) {
+function get( tour ) {
 	const tours = {
 		main: {
 			version: '20160601',
@@ -108,17 +108,9 @@ function get( tour = 'main' ) {
 				linkUrl: 'https://learn.wordpress.com',
 			},
 		},
-		test: {
-			version: '20160516',
-			init: {
-				description: 'Testing multi tour support',
-				text: i18n.translate( 'Single step tour!' ),
-				type: 'FinishStep',
-			},
-		}
 	};
 
-	return tours[ tour ] || tours.main;
+	return tours[ tour ] || null;
 }
 
 export default {

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -77,7 +77,10 @@ class GuidedTours extends Component {
 			return true;
 		};
 		const proceedToNextStep = () => {
-			this.props.nextGuidedTourStep( { stepName: nextStepName } );
+			this.props.nextGuidedTourStep( {
+				stepName: nextStepName,
+				tour: this.props.tourState.tour,
+			} );
 		};
 		const abortTour = () => {
 			const ERROR_WAITED_TOO_LONG = 'waited too long for next target';
@@ -99,6 +102,7 @@ class GuidedTours extends Component {
 		this.currentTarget && this.currentTarget.classList.remove( 'guided-tours__overlay' );
 		this.props.quitGuidedTour( Object.assign( {
 			stepName: this.props.tourState.stepName,
+			tour: this.props.tourState.tour,
 		}, options ) );
 	}
 

--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import includes from 'lodash/includes';
-import takeRight from 'lodash/takeRight';
+import { takeRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,18 +13,28 @@ import {
 	ROUTE_SET,
 } from 'state/action-types';
 
-const isRelevantActionType = includes.bind( null, [
+const relevantTypes = {
 	GUIDED_TOUR_UPDATE,
 	THEMES_RECEIVE,
 	PREVIEW_IS_SHOWING,
 	ROUTE_SET,
-] );
+};
+
+const isRelevantAction = ( action ) =>
+	relevantTypes.hasOwnProperty( action.type ) &&
+	( typeof relevantTypes[ action.type ] !== 'function' ||
+		relevantTypes[ action.type ]( action ) );
 
 const newAction = ( action ) => ( {
 	...action, timestamp: Date.now()
 } );
 
+const maybeAdd = ( state, action ) =>
+	action
+		? takeRight( [ ...state, action ], 50 )
+		: state;
+
 export default ( state = [], action ) =>
-	isRelevantActionType( action.type )
-		? takeRight( [ ...state, newAction( action ) ], 50 )
+	isRelevantAction( action )
+		? maybeAdd( state, newAction( action ) )
 		: state;

--- a/client/state/ui/action-log/test/reducer.js
+++ b/client/state/ui/action-log/test/reducer.js
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import { useFakeTimers } from 'test/helpers/use-sinon';
 import {
 	ROUTE_SET,
+	COMMENTS_LIKE,
 } from 'state/action-types';
 import reducer from '../reducer';
 
@@ -25,11 +26,11 @@ describe( 'reducer', () => {
 		const actions = [
 			{
 				type: ROUTE_SET,
-				path: '/menus/77203074',
+				path: '/design/77203074',
 			},
 			{
 				type: ROUTE_SET,
-				path: '/menus/foobar',
+				path: '/design/foobar',
 			},
 		];
 		const state = actions.reduce( reducer, undefined );
@@ -38,5 +39,21 @@ describe( 'reducer', () => {
 			{ ...actions[ 0 ], timestamp: 1337 },
 			{ ...actions[ 1 ], timestamp: 1337 },
 		] );
+	} );
+
+	it( 'should discard them if payload is irrelevant', () => {
+		const actions = [
+			{
+				type: COMMENTS_LIKE,
+				path: '/menus/77203074',
+			},
+			{
+				type: COMMENTS_LIKE,
+				path: '/menus/foobar',
+			},
+		];
+		const state = actions.reduce( reducer, undefined );
+
+		expect( state ).to.eql( [] );
 	} );
 } );

--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -42,13 +42,15 @@ export function setAllSitesSelected() {
 /**
  * Returns an action object signalling that the current route is to be changed
  *
- * @param  {String} path Route path
- * @return {Object}      Action object
+ * @param  {String} path    Route path
+ * @param  {Object} [query] Query arguments
+ * @return {Object}         Action object
  */
-export function setRoute( path ) {
+export function setRoute( path, query = {} ) {
 	return {
 		type: ROUTE_SET,
-		path
+		path,
+		query,
 	};
 }
 

--- a/client/state/ui/guided-tours/actions.js
+++ b/client/state/ui/guided-tours/actions.js
@@ -14,13 +14,14 @@ import guidedToursConfig from 'layout/guided-tours/config';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 
-export function quitGuidedTour( { tour = 'main', stepName, finished, error } ) {
+export function quitGuidedTour( { tour, stepName, finished, error } ) {
 	const quitAction = {
 		type: GUIDED_TOUR_UPDATE,
 		shouldShow: false,
 		shouldReallyShow: false,
 		tour,
 		stepName,
+		finished,
 	};
 
 	const trackEvent = recordTracksEvent( `calypso_guided_tours_${ finished ? 'finished' : 'quit' }`, {
@@ -31,14 +32,15 @@ export function quitGuidedTour( { tour = 'main', stepName, finished, error } ) {
 	} );
 
 	return ( dispatch, getState ) => {
-		dispatch( withAnalytics( trackEvent, quitAction ) );
 		dispatch( addSeenGuidedTour( getState, tour, finished ) );
+		dispatch( withAnalytics( trackEvent, quitAction ) );
 	};
 }
 
-export function nextGuidedTourStep( { tour = 'main', stepName } ) {
+export function nextGuidedTourStep( { tour, stepName } ) {
 	const nextAction = {
 		type: GUIDED_TOUR_UPDATE,
+		tour,
 		stepName,
 	};
 

--- a/client/state/ui/guided-tours/selectors.js
+++ b/client/state/ui/guided-tours/selectors.js
@@ -1,17 +1,161 @@
 /**
  * External dependencies
  */
-import get from 'lodash/get';
-import memoize from 'lodash/memoize';
+import { get, difference, find, memoize, noop, startsWith, uniq } from 'lodash';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-import { isSectionLoading, getSelectedSite } from 'state/ui/selectors';
+import { ROUTE_SET } from 'state/action-types';
+import { isSectionLoading, getInitialQueryArguments } from 'state/ui/selectors';
+import { getActionLog } from 'state/ui/action-log/selectors';
+import { getPreference } from 'state/preferences/selectors';
 import createSelector from 'lib/create-selector';
 import guidedToursConfig from 'layout/guided-tours/config';
 
 const getToursConfig = memoize( ( tour ) => guidedToursConfig.get( tour ) );
+const getToursHistory = state => getPreference( state, 'guided-tours-history' );
+const debug = debugFactory( 'calypso:guided-tours' );
+
+/*
+ * This would/will be part of the existing config for tours.
+ */
+const relevantFeatures = [
+	{
+		path: '/',
+		tour: 'main',
+		context: () => false,
+	},
+	{
+		path: '/design',
+		tour: 'themes',
+		context: () => true,
+	},
+	{
+		path: '/test',
+		tour: 'test',
+		context: () => true,
+	},
+];
+
+/*
+ * Returns a collection of tour names. These tours are selected if the user has
+ * recently navigated to a section of Calypso that comes with a corresponding
+ * tour.
+ */
+const getToursFromFeaturesReached = createSelector(
+	state => (
+		uniq( getActionLog( state )
+			.filter( ( { type } ) => type === ROUTE_SET )
+			.reduceRight( ( allTours, { path: triggerPath } ) => {
+				const newTours = relevantFeatures
+					.filter( ( { path: featurePath } ) =>
+						startsWith( triggerPath, featurePath ) )
+					.map( feature => feature.tour );
+
+				return newTours
+					? [ ...allTours, ...newTours ]
+					: allTours;
+			}, [] ) )
+	),
+	getActionLog
+);
+
+/*
+ * Returns the names of the tours that the user has previously seen, both
+ * recently and in the past.
+ */
+const getToursSeen = createSelector(
+	state => uniq(
+		getToursHistory( state )
+			.map( ( { tourName } ) => tourName )
+	),
+	getToursHistory
+);
+
+/*
+ * Returns the name of the tour requested via the URL's query arguments, if the
+ * tour exists. Returns `undefined` otherwise.
+ */
+const getTourFromQuery = createSelector(
+	state => {
+		const { tour } = getInitialQueryArguments( state );
+		if ( tour && find( relevantFeatures, { tour } ) ) {
+			return tour;
+		}
+	},
+	getInitialQueryArguments
+);
+
+/*
+ * Returns true if `tour` has been seen in the current Calypso session, false
+ * otherwise.
+ */
+const hasJustSeenTour = createSelector(
+	( state, tourName ) => {
+		const { timestamp } = getInitialQueryArguments( state );
+		return getToursHistory( state ).some( entry =>
+			entry.tourName === tourName &&
+			entry.timestamp > timestamp
+		);
+	},
+	[ getInitialQueryArguments, getToursHistory ]
+);
+
+/*
+ * Returns the name of the tour requested via URL query arguments if it hasn't
+ * "just" been seen (i.e., in the current Calypso session).
+ */
+const findRequestedTour = state => {
+	const requestedTour = getTourFromQuery( state );
+	if ( requestedTour && ! hasJustSeenTour( state, requestedTour ) ) {
+		return requestedTour;
+	}
+};
+
+/*
+ * Returns the name of the first tour available from triggers, assuming the
+ * tour hasn't been ruled out (e.g. if it has already been seen or if the
+ * "context" isn't right.
+ */
+const findTriggeredTour = state => {
+	const toursFromTriggers = uniq( [
+		...getToursFromFeaturesReached( state ),
+		// Right now, only one source from which to derive tours, but we may
+		// have more later. Examples:
+		// ...getToursFromPurchases( state ),
+		// ...getToursFromFirstActions( state ),
+	] );
+
+	const toursToDismiss = uniq( [
+		// Same idea here.
+		...getToursSeen( state ),
+	] );
+
+	const newTours = difference( toursFromTriggers, toursToDismiss );
+	return newTours.find( tour => {
+		const { context = noop } = find( relevantFeatures, { tour } );
+		return context( state );
+	} );
+};
+
+export const findEligibleTour = createSelector(
+	state => findRequestedTour( state ) || findTriggeredTour( state ),
+	[ getActionLog, getToursHistory ]
+);
+
+const getStepConfig = ( state, tourConfig, stepName ) => {
+	const step = tourConfig[ stepName ] || false;
+	const shouldSkip = !! (
+		step &&
+		( step.showInContext && ! step.showInContext( state ) ) ||
+		( step.continueIf && step.continueIf( state ) )
+	);
+	return shouldSkip
+		? getStepConfig( state, tourConfig, step.next )
+		: step;
+};
 
 /**
  * Returns the current state for Guided Tours.
@@ -28,36 +172,52 @@ const getRawGuidedTourState = state => get( state, 'ui.guidedTour', false );
 export const getGuidedTourState = createSelector(
 	state => {
 		const tourState = getRawGuidedTourState( state );
-		const { shouldReallyShow, stepName = '', tour } = tourState;
+		const { stepName = 'init' } = tourState;
+
+		const tour = findEligibleTour( state );
+		const shouldReallyShow = !! tour;
+
+		debug(
+			'tours: reached', getToursFromFeaturesReached( state ),
+			'seen', getToursSeen( state ),
+			'found', tour );
+
+		if ( ! tour ) {
+			return {
+				...tourState,
+				shouldShow: false,
+				stepConfig: false,
+				nextStepConfig: false,
+			};
+		}
+
 		const tourConfig = getToursConfig( tour );
 
-		const getStepConfig = name => {
-			const step = tourConfig[ name ] || false;
-			const shouldSkip = !! (
-				step &&
-				( step.showInContext && ! step.showInContext( state ) ) ||
-				( step.continueIf && step.continueIf( state ) )
-			);
-			return shouldSkip ? getStepConfig( step.next ) : step;
-		};
+		if ( ! tourConfig ) {
+			debug( 'found no tour configuration for tour "' + tour + '", bailing out' );
+			return {
+				...tourState,
+				shouldShow: false,
+				stepConfig: false,
+				nextStepConfig: false,
+			};
+		}
 
-		const stepConfig = getStepConfig( stepName ) || false;
-		const nextStepConfig = getStepConfig( stepConfig.next ) || false;
+		const stepConfig = getStepConfig( state, tourConfig, stepName ) || false;
+		const nextStepConfig = getStepConfig( state, tourConfig, stepConfig.next ) || false;
 
 		const shouldShow = !! (
 			! isSectionLoading( state ) &&
 			shouldReallyShow
 		);
 
-		return Object.assign( {}, tourState, {
+		return {
+			...tourState,
+			tour,
 			stepConfig,
 			nextStepConfig,
 			shouldShow,
-		} );
+		};
 	},
-	state => [
-		getRawGuidedTourState( state ),
-		isSectionLoading( state ),
-		getSelectedSite( state ),
-	]
+	[ getRawGuidedTourState, isSectionLoading, getActionLog ]
 );

--- a/client/state/ui/guided-tours/test/selectors.js
+++ b/client/state/ui/guided-tours/test/selectors.js
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { constant, times } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import {
 	getGuidedTourState,
+	findEligibleTour,
 } from '../selectors';
 import guidedToursConfig from 'layout/guided-tours/config';
 
@@ -18,28 +20,173 @@ describe( 'selectors', () => {
 				ui: {
 					shouldShow: false,
 					guidedTour: false,
-				}
+					actionLog: [],
+					queryArguments: {
+						initial: {},
+					},
+				},
+				preferences: {
+					values: {
+						'guided-tours-history': [],
+					},
+				},
 			} );
 
 			expect( tourState ).to.deep.equal( { shouldShow: false, stepConfig: false, nextStepConfig: false } );
 		} );
 
-		it( 'should include the config of the current tour step', () => {
+		// disabled because tours are now selected via `findEligibleTour`,
+		// rather than direct guidedTour state
+		xit( 'should include the config of the current tour step', () => {
 			const tourState = getGuidedTourState( {
 				ui: {
 					guidedTour: {
 						stepName: 'sidebar',
 						shouldShow: true,
 						tour: 'main',
-					}
-				}
+					},
+					actionLog: [],
+				},
+				preferences: {
+					values: {
+						'guided-tours-history': [],
+					},
+				},
 			} );
 
-			const stepConfig = guidedToursConfig.get().sidebar;
+			const stepConfig = guidedToursConfig.get( 'main' ).sidebar;
 
 			expect( tourState ).to.deep.equal( Object.assign( {}, tourState, {
 				stepConfig
 			} ) );
+		} );
+	} );
+	describe( '#findEligibleTour()', () => {
+		const makeState = ( {
+			actionLog = [],
+			toursHistory = [],
+			queryArguments = {},
+		} ) => ( {
+			ui: {
+				actionLog,
+				queryArguments: {
+					initial: queryArguments,
+				},
+			},
+			preferences: {
+				values: {
+					'guided-tours-history': toursHistory,
+				},
+			},
+		} );
+
+		const navigateToThemes = {
+			type: 'ROUTE_SET',
+			path: '/design/77203074',
+		};
+
+		const navigateToTest = {
+			type: 'ROUTE_SET',
+			path: '/test',
+		};
+
+		const mainTourSeen = {
+			tourName: 'main',
+			timestamp: 1337,
+			finished: true,
+		};
+
+		const themesTourSeen = {
+			tourName: 'themes',
+			timestamp: 1337,
+			finished: true,
+		};
+
+		const testTourSeen = {
+			tourName: 'test',
+			timestamp: 1337,
+			finished: true,
+		};
+
+		it( 'should return undefined if nothing relevant in log', () => {
+			const state = makeState( { actionLog: [ { type: 'IRRELEVANT' } ] } );
+			const tour = findEligibleTour( state );
+
+			expect( tour ).to.equal( undefined );
+		} );
+		it( 'should find `themes` when applicable', () => {
+			const state = makeState( { actionLog: [ navigateToThemes ] } );
+			const tour = findEligibleTour( state );
+
+			expect( tour ).to.equal( 'themes' );
+		} );
+		it( 'should not find `themes` if previously seen', () => {
+			const state = makeState( {
+				actionLog: [ navigateToThemes ],
+				toursHistory: [ themesTourSeen ],
+			} );
+
+			const tour = findEligibleTour( state );
+
+			expect( tour ).to.equal( undefined );
+		} );
+		it( 'should favor a tour launched via query arguments', () => {
+			const state = makeState( {
+				actionLog: [ navigateToThemes ],
+				toursHistory: [ mainTourSeen, themesTourSeen ],
+				queryArguments: { tour: 'main' }
+			} );
+			const tour = findEligibleTour( state );
+
+			expect( tour ).to.equal( 'main' );
+		} );
+		it( 'should dismiss a requested tour at the end', () => {
+			const mainTourJustSeen = {
+				tourName: 'main',
+				timestamp: 1338,
+				finished: true,
+			};
+			const state = makeState( {
+				actionLog: [ navigateToThemes ],
+				toursHistory: [ themesTourSeen, mainTourJustSeen ],
+				queryArguments: { tour: 'main', timestamp: 0 }
+			} );
+			const tour = findEligibleTour( state );
+
+			expect( tour ).to.equal( undefined );
+		} );
+		it( 'shouldn\'t show a requested tour twice', () => {
+			/*
+			 * Assume that a lot has happened during a Calypso session, so the
+			 * action log doesn't contain actions specific to Guided Tours
+			 * anymore.
+			 */
+			const state = makeState( {
+				actionLog: times( 50, constant( navigateToTest ) ),
+				toursHistory: [ testTourSeen, themesTourSeen ],
+				queryArguments: { tour: 'themes', timestamp: 0 }
+			} );
+			const tour = findEligibleTour( state );
+
+			expect( tour ).to.equal( undefined );
+		} );
+		describe( 'picking a tour based on the most recent actions', () => {
+			it( 'should pick `themes`', () => {
+				const state = makeState( {
+					actionLog: [ navigateToThemes, navigateToTest ]
+				} );
+				const tour = findEligibleTour( state );
+
+				expect( tour ).to.equal( 'test' );
+			} );
+			it( 'should pick `test`', () => {
+				const state = makeState( {
+					actionLog: [ navigateToTest, navigateToThemes ]
+				} );
+				const tour = findEligibleTour( state );
+
+				expect( tour ).to.equal( 'themes' );
+			} );
 		} );
 	} );
 } );

--- a/client/state/ui/query-arguments/reducer.js
+++ b/client/state/ui/query-arguments/reducer.js
@@ -11,13 +11,18 @@ import {
 	ROUTE_SET,
 } from 'state/action-types';
 
+const timestamped = ( query ) => ( {
+	...query,
+	timestamp: Date.now(),
+} );
+
 const initial = createReducer( false, {
 	[ ROUTE_SET ]: ( state, { query } ) =>
-		state === false ? query : state,
+		state === false ? timestamped( query ) : state,
 } );
 
 const current = createReducer( {}, {
-	[ ROUTE_SET ]: ( state, { query } ) => query,
+	[ ROUTE_SET ]: ( state, { query } ) => timestamped( query ),
 } );
 
 export default combineReducers( {

--- a/client/state/ui/query-arguments/reducer.js
+++ b/client/state/ui/query-arguments/reducer.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { createReducer } from 'state/utils';
+import {
+	ROUTE_SET,
+} from 'state/action-types';
+
+const initial = createReducer( false, {
+	[ ROUTE_SET ]: ( state, { query } ) =>
+		state === false ? query : state,
+} );
+
+const current = createReducer( {}, {
+	[ ROUTE_SET ]: ( state, { query } ) => query,
+} );
+
+export default combineReducers( {
+	initial,
+	current,
+} );

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -18,6 +18,7 @@ import {
 import { createReducer } from 'state/utils';
 import editor from './editor/reducer';
 import guidedTour from './guided-tours/reducer';
+import queryArguments from './query-arguments/reducer';
 import reader from './reader/reducer';
 import olark from './olark/reducer';
 import actionLog from './action-log/reducer';
@@ -105,6 +106,7 @@ const reducer = combineReducers( {
 	hasSidebar,
 	isPreviewShowing,
 	currentPreviewUrl,
+	queryArguments,
 	selectedSiteId,
 	recentlySelectedSiteIds,
 	guidedTour,

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -90,3 +90,11 @@ export function isPreviewShowing( state ) {
 export function getPreviewUrl( state ) {
 	return state.ui.currentPreviewUrl;
 }
+
+export function getInitialQueryArguments( state ) {
+	return state.ui.queryArguments.initial;
+}
+
+export function getCurrentQueryArguments( state ) {
+	return state.ui.queryArguments.current;
+}

--- a/client/state/ui/test/actions.js
+++ b/client/state/ui/test/actions.js
@@ -27,7 +27,8 @@ describe( 'actions', () => {
 
 			expect( action ).to.eql( {
 				type: ROUTE_SET,
-				path: '/foo'
+				path: '/foo',
+				query: {}
 			} );
 		} );
 	} );


### PR DESCRIPTION
Previously, GuidedTours was able to trigger only a single tour -- `main`. This was based solely on the presence of `tour=main` in the query arguments. This change introduces a selectors-based approach to triggering tours that is based on the current context and tour-specific requirements for that context. 

Duplicate of #6335, but based on `master` this time.
Product of exploration in #6146. See that PR for context.

### Before merging
- [x] Tests
- [x] For consistency, settle on name: `tour` or `tourName` (punted)
- [x] Assimilate `relevantFeatures` into config, or leave that to next PR? (next PR)
- [x] Don't actually show dummy tours in production
- [x] Misc. cleanup, squash
- [x] Consider only saving _certain_ `ROUTE_SET` actions in state, for performance (punted, later when we need it)

### Testing

- get into the guidedTours abtest***, create a new user account, and make sure after signup you are redirected to a `?tour=main` URL
- make sure the tour works fine
- make sure you can visit other parts of Calypso without throwing an error (especially try clicking on themes)
- make sure you can still summon the tour by appending the `?tour=main` bit

*** `localStorage.setItem( 'ABTests', '{"guidedTours_20160603":"guided"}' );`

Test live: https://calypso.live/?branch=add/guided-tours-log-selectors-rebased