### PR TITLE
Reader: update Follow button icon size and clean up

### DIFF
--- a/client/components/follow-button/style.scss
+++ b/client/components/follow-button/style.scss
@@ -1,42 +1,35 @@
 .follow-button {
-	position: relative;
-	background: inherit;
-	color: $gray-dark;
-	cursor: pointer;
-	display: block;
-	font-size: 14px;
-	font-weight: 500;
-	margin: 0;
-	padding: 8px 16px;
-	text-align: left;
 
-	@include breakpoint( "<660px" ) {
-		height: 38px;
+	.gridicon__follow {
+		opacity: 1;
+		pointer-events: auto;
+	}
+
+	.gridicon__following {
+		display: none;
+		pointer-events: auto;
 	}
 
 	&::-moz-focus-inner {
 		border: 0;
 	}
 
+	@include breakpoint( "<660px" ) {
+		padding: 7px 8px 9px 14px;
+	}
+
 	// Menu Items with Icons
 
 	.gridicon {
 		height: 18px;
-    	margin-top: -2px;
+		padding-right: 4px;
+		top: 5px;
 		width: 18px;
-		position: relative;
-			top: 4px;
-		transition: all 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
-	}
-
-	&.has-icon {
-
 	}
 
 	.gridicon__following {
 		opacity: 0;
 		pointer-events: none;
-		transform: rotate( 360deg ) scale( 1 );
 	}
 
 	.gridicon__unfollow {
@@ -44,13 +37,11 @@
 		.gridicon__follow {
 			opacity: 0;
 			pointer-events: none;
-			transform: rotate( -360deg ) scale( 0.5 );
 		}
 
 		.gridicon__following {
 			opacity: 1;
 			pointer-events: auto;
-			transform: rotate( 0 ) scale( 1 );
 		}
 	}
 
@@ -62,29 +53,29 @@
 		}
 
 		.gridicon__follow {
-			opacity: 0;
+			display: none;
 			pointer-events: none;
 		}
 
 		.gridicon__following {
+			display: inline-block;
 			opacity: 1;
 			pointer-events: auto;
 		}
-	}
 
-	&:hover {
-		color: $alert-green;
-
-		.gridicon {
-			fill: $alert-green;
-		}
-
-		&.is-following {
+		&:hover {
 			color: $alert-green;
 
 			.gridicon {
 				fill: $alert-green;
 			}
 		}
+	}
+}
+
+.follow-button__label {
+
+	@include breakpoint( "<660px" ) {
+		display: none;
 	}
 }

--- a/client/components/follow-button/style.scss
+++ b/client/components/follow-button/style.scss
@@ -21,16 +21,16 @@
 	// Menu Items with Icons
 
 	.gridicon {
-		height: 24px;
-		width: 24px;
+		height: 18px;
+    	margin-top: -2px;
+		width: 18px;
+		position: relative;
+			top: 4px;
+		transition: all 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 
 	&.has-icon {
-		padding-left: 42px;
 
-		@include breakpoint( "<660px" ) {
-			padding-left: 36px;
-		}
 	}
 
 	.gridicon__following {
@@ -86,12 +86,5 @@
 				fill: $alert-green;
 			}
 		}
-	}
-
-	.gridicon {
-		position: absolute;
-			left: 18px;
-			top: 7px;
-		transition: all 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 }

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -313,3 +313,38 @@
 	}
 }
 
+/* = Foldable card (toggle arrow is opposite side in Reader)
+ --------------------------------------------------------------- */
+
+.following-edit {
+
+	.foldable-card__action {
+		width: 45px;
+		height: 100%;
+		padding: 0;
+		position: absolute;
+			left: 0;
+			top: 0;
+	}
+
+	.foldable-card.is-expanded {
+		margin-bottom: 0;
+		border-top: 0;
+
+		.foldable-card__content {
+			padding: 0;
+		}
+ 	}
+
+	.foldable-card__expand .gridicon {
+		transform: rotate( -90deg );
+	    position: absolute;
+	    	top: 24px;
+     	left: 0;
+	}
+ }
+
+ // Make sure it rotates in the right direction
+.following-edit .foldable-card.is-expanded .gridicon {
+	transform: rotate( 0deg );
+}

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -313,35 +313,3 @@
 	}
 }
 
-/* = Foldable card (toggle arrow is opposite side in Reader)
--------------------------------------------------------------- */
-.following-edit {
-	.foldable-card__action {
-		width: 45px;
-		height: 100%;
-		padding: 0;
-		position: absolute;
-			left: 0;
-			top: 0;
-	}
-
-	.foldable-card.is-expanded {
-		margin-bottom: 0;
-		border-top: 0;
-
-		.foldable-card__content {
-			padding: 0;
-		}
-	}
-
-	.foldable-card__expand .gridicon {
-		transform: rotate( -90deg );
-	    position: absolute;
-	    	top: 24px;
-	    	left: 0;
-	}
-}
-// Make sure it rotates in the right direction
-.following-edit .foldable-card.is-expanded .gridicon {
-	transform: rotate( 0deg );
-}

--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -29,9 +29,7 @@
 		}
 
 		.gridicon {
-			fill: $gray-dark;
-			left: 15px;
-			top: 10px;
+
 		}
 
 		&:hover {

--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -1,4 +1,5 @@
 .feed-header {
+
 	.site__title::before {
 		font-size: 14px;
 		padding-bottom: 1px;
@@ -9,64 +10,9 @@
 	}
 
 	.follow-button__label {
-		font-family: $sans;
-		font-size: 16px;
 
 		@include breakpoint( "<660px" ) {
 			display: none;
-		}
-	}
-
-	.follow-button {
-		margin: 4px 5px 0 0;
-
-		@include breakpoint( ">480px" ) {
-			margin-right: 15px;
-		}
-
-		.follow-button__label {
-			color: $gray-dark;
-		}
-
-		.gridicon {
-
-		}
-
-		&:hover {
-			background: none;
-
-			.gridicon {
-				fill: $gray-dark;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $gray-dark;
-			}
-		}
-	}
-
-	.follow-button.is-following {
-
-		.gridicon {
-			fill: $alert-green;
-		}
-
-		.follow-button__label {
-			color: $alert-green;
-		}
-
-		&:hover {
-			background: none;
-
-			.gridicon {
-				fill: $alert-green;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $alert-green;
-			}
 		}
 	}
 }
@@ -131,16 +77,14 @@
 }
 
 .feed-header__follow {
-	.follow-button {
-		position: absolute;
-			top: 9px;
-			right: 8px;
+	position: absolute;
+		top: 13px;
+		right: 10px;
 
-		@include breakpoint( ">480px" ) {
-			position: absolute;
-				top: 17px;
-				right: 0;
-		}
+	@include breakpoint( ">480px" ) {
+		position: absolute;
+			top: 21px;
+			right: 25px;
 	}
 }
 
@@ -164,11 +108,11 @@
 }
 
 .feed-header__follow-count {
+	background-color: $gray-light;
 	color: $gray;
 	font-size: 13px;
 	font-style: italic;
+	padding: 0 8px;
 	position: relative;
 		top: 9px;
-	background-color: $gray-light;
-	padding: 0 8px;
 }

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -151,6 +151,19 @@
 			padding: 16px 24px;
 		}
 
+		// Disabled button if URL is invalid
+		.follow-button:hover {
+			border-color: lighten( $gray, 20% );
+		}
+
+		.gridicon {
+			fill: lighten( $gray, 20% );
+		}
+
+		.follow-button__label {
+			color: lighten( $gray, 20% );
+		}
+
 		&.is-valid {
 
 			.gridicon {

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -27,7 +27,10 @@
 	}
 
 	.follow-button__label {
-		display: none;
+
+		@include breakpoint( "<660px" ) {
+			display: none;
+		}
 	}
 
 	.reader-list-item__title,
@@ -153,28 +156,6 @@
 			padding: 16px 24px;
 		}
 
-		.follow-button {
-			cursor: default;
-
-			@include breakpoint( "<660px" ) {
-				margin-top: 7px;
-			}
-
-			.gridicon {
-				cursor: default;
-				fill: lighten( $gray, 20% );
-			}
-
-			.follow-button__label {
-				color: lighten( $gray, 20% );
-				display: inline-block;
-
-				@include breakpoint( "<660px" ) {
-					display: none;
-				}
-			}
-		}
-
 		&.is-valid {
 
 			.gridicon {
@@ -274,7 +255,8 @@
 		margin-right: 100px;
 
 		@include breakpoint( ">660px" ) {
-			padding-left: 0;
+			margin-right: 100px;
+			padding-left: 3px;
 		}
 	}
 
@@ -384,20 +366,6 @@
 
 .following-edit__notification-settings-error {
 	margin-top: 14px;
-}
-
-@include breakpoint( ">660px" ) {
-	.following-edit {
-		.follow-button__label {
-			display: block;
-		}
-
-		.reader-list-item__title,
-		.reader-list-item__description {
-			margin-right: 100px;
-			padding-left: 3px;
-		}
-	}
 }
 
 .is-section-reader .main.following-edit .empty-content {

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -33,11 +33,6 @@
 		}
 	}
 
-	.reader-list-item__title,
-	.reader-list-item__description {
-		margin-right: 20px;
-	}
-
 	.external-link .gridicons-external {
 		margin-left: 4px;
 	}

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -59,60 +59,10 @@
 		}
 	}
 
-	.follow-button {
+	.full-post__follow {
 		position: absolute;
-			top: -3px;
 			right: 0;
-
-		.gridicon {
-			position: absolute;
-				left: 15px;
-				top: 10px;
-		}
-
-		.follow-button__label {
-			color: $gray-dark;
-			font-size: 16px;
-		}
-
-		&:hover {
-			background: none;
-
-			.gridicon {
-				fill: $gray-dark;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $gray-dark;
-			}
-		}
-
-		@include breakpoint( "<660px" ) {
-
-			.follow-button__label {
-				display: none;
-			}
-		}
-	}
-
-	.follow-button.is-following {
-		.follow-button__label {
-			color: $alert-green;
-		}
-
-		&:hover {
-			background: none;
-
-			.gridicon {
-				fill: $alert-green;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $alert-green;
-			}
-		}
+			top: -2px;
 	}
 
 	.reader__post-time {

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -208,7 +208,9 @@ FullPostView = React.createClass( {
 							onSelect={ this.pickSite }
 							onClick={ this.handleSiteClick } />
 
-						{ feed && feed.feed_URL && <FollowButton siteUrl={ feed && feed.feed_URL } /> }
+						<div className="full-post__follow">
+							{ feed && feed.feed_URL && <FollowButton siteUrl={ feed && feed.feed_URL } /> }
+						</div>
 					</div>
 
 					{ hasFeaturedImage

--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -76,7 +76,7 @@
 .reader-list-item__actions {
 	position: absolute;
 		bottom: 0;
-		right: 0;
+		right: 20px;
 		top: 16px;
 
 	.follow-button__label {
@@ -85,8 +85,6 @@
 			display: none;
 		}
 	}
-
-
 }
 
 .foldable-card {
@@ -97,6 +95,10 @@
 
 	.reader-list-item__title,
 	.reader-list-item__description {
-		margin-left: 90px;
+		margin: 0 100px 0 90px;
+
+		@include breakpoint( "<660px" ) {
+			margin: 0 30px 0 90px;
+		}
 	}
 }

--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -3,7 +3,7 @@
 	margin-top: 0;
 	margin-bottom: 0;
 	margin-left: 54px;
-	margin-right: 80px;
+	margin-right: 100px;
 	overflow: hidden;
 	white-space: nowrap;
 	position: relative;
@@ -77,7 +77,7 @@
 	position: absolute;
 		bottom: 0;
 		right: 20px;
-		top: 16px;
+		top: 18px;
 
 	.follow-button__label {
 

--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -86,53 +86,7 @@
 		}
 	}
 
-	.follow-button {
-		font-size: 16px;
-		margin: 1px 15px 0 0;
 
-		.gridicon {
-			left: 15px;
-			top: 9px;
-			fill: $gray-dark;
-		}
-
-		.follow-button__label {
-			fill: $gray-dark;
-		}
-
-		&:hover {
-
-			.gridicon {
-				fill: $gray-dark;
-			}
-
-			.follow-button__label {
-				color: $gray-dark;
-			}
-		}
-	}
-
-	.follow-button.is-following {
-
-		.gridicon {
-			fill: $alert-green;
-		}
-
-		.follow-button__label {
-			color: $alert-green;
-		}
-
-		&:hover {
-
-			.gridicon {
-				fill: $alert-green;
-			}
-
-			.follow-button__label {
-				color: $alert-green;
-			}
-		}
-	}
 }
 
 .foldable-card {

--- a/client/reader/start/card-header.jsx
+++ b/client/reader/start/card-header.jsx
@@ -21,7 +21,9 @@ const StartCardHeader = ( { site } ) => {
 					<a href={ `/read/blogs/${site.ID}` }>{ subscribersCount } followers</a>
 				</div>
 			</div>
-			<FollowButton siteUrl={ site.URL } />
+			<div className="reader-start-card__follow">
+				<FollowButton siteUrl={ site.URL } />
+			</div>
 		</header>
 	);
 };

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -148,71 +148,6 @@
 				top: 36px;
 			}
 		}
-
-		@include breakpoint
-	}
-
-	.follow-button {
-		border-color: $blue-wordpress;
-		float: right;
-		overflow: visible;
-		right: 0;
-
-		.gridicon {
-			fill: $blue-wordpress;
-			position: absolute;
-				left: 15px;
-				top: 9px;
-		}
-
-		.follow-button__label {
-			color: $blue-wordpress;
-			font-size: 16px;
-
-			@include breakpoint( "<660px" ) {
-				display: none;
-			}
-		}
-
-		&:hover {
-			border-color: $gray-dark;
-			color: $gray-dark;
-
-			.gridicon {
-				fill: $gray-dark;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $gray-dark;
-			}
-		}
-	}
-
-	.follow-button.is-following {
-
-		border-color: $alert-green;
-
-		.follow-button__label {
-			color: $alert-green;
-		}
-
-		.gridicon {
-			fill: $alert-green;
-		}
-
-		&:hover {
-			background: none;
-
-			.gridicon {
-				fill: $alert-green;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $alert-green;
-			}
-		}
 	}
 }
 
@@ -226,6 +161,7 @@
 }
 
 .reader-start-card__site-title {
+	color: $gray-dark;
 	display: block;
 	font-weight: 500;
 	line-height: normal;
@@ -236,19 +172,6 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	width: 100%;
-}
-
-.reader-start-card__site-description {
-	color: darken( $gray, 20% );
-	font-size: 12px;
-
-	.site-icon {
-		margin: auto;
-	}
-}
-
-.reader-start-card__site-title {
-	color: $gray-dark;
 }
 
 .reader-start-card__follower-count {
@@ -265,6 +188,11 @@
 	a {
 		color: inherit;
 	}
+}
+
+.reader-start-card__follow {
+	position: absolute;
+		right: 16px;
 }
 
 .reader-start-post-preview {

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -149,6 +149,60 @@
 			}
 		}
 	}
+
+	// Use blue Follow button (Gray dark on hover) only in CS
+
+	.follow-button {
+		border-color: $blue-wordpress;
+
+		.gridicon {
+			fill: $blue-wordpress;
+		}
+
+		.follow-button__label {
+			color: $blue-wordpress;
+		}
+
+		&:hover {
+			border-color: $gray-dark;
+			color: $gray-dark;
+
+			.gridicon {
+				fill: $gray-dark;
+			}
+
+			.follow-button__label {
+				cursor: pointer;
+				color: $gray-dark;
+			}
+		}
+	}
+
+	.follow-button.is-following {
+
+		border-color: $alert-green;
+
+		.follow-button__label {
+			color: $alert-green;
+		}
+
+		.gridicon {
+			fill: $alert-green;
+		}
+
+		&:hover {
+			background: none;
+
+			.gridicon {
+				fill: $alert-green;
+			}
+
+			.follow-button__label {
+				cursor: pointer;
+				color: $alert-green;
+			}
+		}
+	}
 }
 
 .reader-start-card__header {
@@ -172,6 +226,15 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	width: 100%;
+}
+
+.reader-start-card__site-description {
+	color: darken( $gray, 20% );
+	font-size: 12px;
+
+	.site-icon {
+		margin: auto;
+	}
 }
 
 .reader-start-card__follower-count {

--- a/client/reader/stream-header/style.scss
+++ b/client/reader/stream-header/style.scss
@@ -1,65 +1,3 @@
-.stream-header {
-
-	.follow-button__label {
-		font-family: $sans;
-		font-size: 16px;
-	}
-
-	.follow-button {
-
-		margin: 2px 3px 0 0;
-
-		.gridicon {
-			fill: $gray-dark;
-		}
-
-		.follow-button__label {
-			color: $gray-dark;
-
-			@include breakpoint( "<660px" ) {
-				display: none;
-			}
-		}
-
-		&:hover {
-			background: none;
-
-			.gridicon {
-				fill: $gray-dark;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $gray-dark;
-			}
-		}
-	}
-
-	.follow-button.is-following {
-
-		.gridicon {
-			fill: $alert-green;
-		}
-
-		.follow-button__label {
-			color: $alert-green;
-		}
-
-		&:hover {
-			background: none;
-
-			.gridicon {
-				fill: $alert-green;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $alert-green;
-			}
-		}
-	}
-}
-
 .is-group-reader .card.stream-header {
 	min-height: 72px;
 	padding: 24px 144px 24px 24px;
@@ -118,6 +56,12 @@
 	color: $gray;
 }
 
+.stream-header__follow {
+	position: absolute;
+		right: 10px;
+		top: 15px;
+}
+
 .stream-header.is-placeholder {
 	pointer-events: none;
 	user-select: none;
@@ -134,23 +78,9 @@
 		margin-right: 25%;
 	}
 
-
 	.gridicon {
 		display: none;
-	}
-}
-
-.stream-header__follow {
-
-	.follow-button {
-		position: absolute;
-			top: 14px;
-			right: 8px;
-
-		.gridicon {
-			top: 10px;
-			left: 15px;
-		}
+		border: 1px solid red;
 	}
 }
 

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -33,60 +33,9 @@
 
 	.follow-button {
 		position: absolute;
-			top: -8px;
+			top: -3px;
 			right: 0;
 		z-index: z-index( 'reader-card-follow-button-parent', '.reader__card.card .follow-button' );
-
-		.gridicon {
-			position: absolute;
-				left: 15px;
-				top: 10px;
-		}
-
-		.follow-button__label {
-			color: $gray-dark;
-			font-size: 16px;
-
-			@include breakpoint( "<660px" ) {
-				display: none;
-			}
-		}
-
-		&:hover {
-			background: none;
-
-			.gridicon {
-				fill: $gray-dark;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $gray-dark;
-			}
-		}
-
-		@include breakpoint( "<480px" ) {
-			right: 8px;
-		}
-	}
-
-	.follow-button.is-following {
-		.follow-button__label {
-			color: $alert-green;
-		}
-
-		&:hover {
-			background: none;
-
-			.gridicon {
-				fill: $alert-green;
-			}
-
-			.follow-button__label {
-				cursor: pointer;
-				color: $alert-green;
-			}
-		}
 	}
 
 	.reader-post-byline {


### PR DESCRIPTION
This PR updates the Follow/Following buttons in Reader as discussed in: https://github.com/Automattic/wp-calypso/pull/5502#issuecomment-221063242

1. Update icon sizes from `24 x 24` to `18 x 18` to make sure they conform with Calypso design standards
2. Clean up custom positioning values and repeat declaration of Follow/Following button and icon properties in various stylesheets

Updated in:

**Main stream card header:**

Before:
![screenshot 2016-07-01 12 40 29](https://cloud.githubusercontent.com/assets/4924246/16532783/07b50d6c-3f89-11e6-8c7c-4ffd9f8c5ed9.png)

After:
![screenshot 2016-07-01 12 40 35](https://cloud.githubusercontent.com/assets/4924246/16532785/0b0974b2-3f89-11e6-9389-7ffc1427e3f6.png)

**Site stream:**

Before:
![screenshot 2016-07-01 12 48 01](https://cloud.githubusercontent.com/assets/4924246/16532922/0f18fd74-3f8a-11e6-8450-088708fa3dab.png)

After:
![screenshot 2016-07-01 12 47 55](https://cloud.githubusercontent.com/assets/4924246/16532924/11b229b6-3f8a-11e6-85ef-e194e450fc1f.png)

**Full-post view:**

Before:
![screenshot 2016-07-01 12 29 00](https://cloud.githubusercontent.com/assets/4924246/16532533/73b06a54-3f87-11e6-9a6a-702171ddd719.png)

After:
![screenshot 2016-07-01 12 29 04](https://cloud.githubusercontent.com/assets/4924246/16532547/82601478-3f87-11e6-95a5-b635b32c5d47.png)

**List items:**

Before:
![screenshot 2016-07-01 12 30 59](https://cloud.githubusercontent.com/assets/4924246/16532594/c174133a-3f87-11e6-96e2-0b81390947ca.png)

![screenshot 2016-07-01 12 42 12](https://cloud.githubusercontent.com/assets/4924246/16532904/dfa782c2-3f89-11e6-872a-c5fb6846c169.png)

After:
![screenshot 2016-07-01 12 30 39](https://cloud.githubusercontent.com/assets/4924246/16532599/c4f30642-3f87-11e6-9de5-b9bdc441459a.png)

![screenshot 2016-07-01 12 42 16](https://cloud.githubusercontent.com/assets/4924246/16532911/e3768e8e-3f89-11e6-8474-de5218b97949.png)

**Cold Start:**

Before:
![screenshot 2016-07-01 12 36 19](https://cloud.githubusercontent.com/assets/4924246/16532706/99a8fd24-3f88-11e6-9203-a63b17b1a5ce.png)

After:
![screenshot 2016-07-01 12 36 30](https://cloud.githubusercontent.com/assets/4924246/16532716/afb2fc50-3f88-11e6-8d42-0413ff7d110d.png)

/cc @folletto @rickybanister @jasmussen 

Test live: https://calypso.live/?branch=update/reader/follow-button-icon-sizes