### PR TITLE
Jetpack Connect: Run site icon through safe image URL to get https image

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -36,6 +36,7 @@ import Site from 'my-sites/site';
 import { decodeEntities } from 'lib/formatting';
 import versionCompare from 'lib/version-compare';
 import EmptyContent from 'components/empty-content';
+import safeImageUrl from 'lib/safe-image-url';
 
 /**
  * Constants
@@ -48,7 +49,7 @@ const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
 const SiteCard = React.createClass( {
 	render() {
 		const { site_icon, blogname, home_url, site_url } = this.props.queryObject;
-		const siteIcon = site_icon ? { img: site_icon } : false;
+		const siteIcon = site_icon ? { img: safeImageUrl( site_icon ) } : false;
 		const url = decodeEntities( home_url );
 		const parsedUrl = urlModule.parse( url );
 		const path = ( parsedUrl.path === '/' ) ? '' : parsedUrl.path;

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -37,11 +37,12 @@ import { decodeEntities } from 'lib/formatting';
 import versionCompare from 'lib/version-compare';
 import EmptyContent from 'components/empty-content';
 import safeImageUrl from 'lib/safe-image-url';
+import Button from 'components/button';
 
 /**
  * Constants
  */
-let calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
+const calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
 const PLANS_PAGE = '/jetpack/connect/plans/';
 const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
 const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
@@ -62,7 +63,8 @@ const SiteCard = React.createClass( {
 			is_vip: false,
 			title: decodeEntities( blogname )
 		};
-		return(
+
+		return (
 			<CompactCard className="jetpack-connect__site">
 				<Site site={ site } />
 			</CompactCard>
@@ -85,7 +87,7 @@ const LoggedOutForm = React.createClass( {
 			? <SiteCard queryObject={ queryObject } />
 			: null;
 
-		return(
+		return (
 			<div>
 				<ConnectHeader
 					showLogo={ false }
@@ -198,7 +200,7 @@ const LoggedInForm = React.createClass( {
 			? <SiteCard queryObject={ queryObject } />
 			: null;
 
-		return(
+		return (
 			<div>
 				<ConnectHeader
 					showLogo={ false }
@@ -216,7 +218,15 @@ const LoggedInForm = React.createClass( {
 	},
 
 	handleSubmit() {
-		const { siteReceived, queryObject, manageActivated, activateManageSecret, plansUrl, authorizeError } = this.props.jetpackConnectAuthorize;
+		const {
+			siteReceived,
+			queryObject,
+			manageActivated,
+			activateManageSecret,
+			plansUrl,
+			authorizeError
+		} = this.props.jetpackConnectAuthorize;
+
 		if ( ! this.props.isAlreadyOnSitesList &&
 			queryObject.already_authorized ) {
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
@@ -264,7 +274,14 @@ const LoggedInForm = React.createClass( {
 	},
 
 	getButtonText() {
-		const { queryObject, isAuthorizing, authorizeSuccess, isRedirectingToWpAdmin, siteReceived, authorizeError } = this.props.jetpackConnectAuthorize;
+		const {
+			queryObject,
+			isAuthorizing,
+			authorizeSuccess,
+			isRedirectingToWpAdmin,
+			siteReceived,
+			authorizeError
+		} = this.props.jetpackConnectAuthorize;
 
 		if ( ! this.props.isAlreadyOnSitesList &&
 			queryObject.already_authorized ) {
@@ -315,7 +332,7 @@ const LoggedInForm = React.createClass( {
 
 	isWaitingForConfirmation() {
 		const { isAuthorizing, authorizeSuccess, siteReceived } = this.props.jetpackConnectAuthorize;
-		return !( isAuthorizing || authorizeSuccess || siteReceived );
+		return ! ( isAuthorizing || authorizeSuccess || siteReceived );
 	},
 
 	getRedirectionTarget() {
@@ -331,8 +348,10 @@ const LoggedInForm = React.createClass( {
 
 	renderFooterLinks() {
 		const { queryObject, authorizeSuccess, isAuthorizing } = this.props.jetpackConnectAuthorize;
-		const loginUrl = config( 'login_url' ) + '?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) + '&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
-		let backToWpAdminLink = (
+		const loginUrl = config( 'login_url' ) +
+			'?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) +
+			'&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
+		const backToWpAdminLink = (
 			<LoggedOutFormLinkItem icon={ true } href={ queryObject.redirect_after_auth }>
 				{ this.translate( 'Cancel and go back to my site' ) } <Gridicon size={ 18 } icon="external" />
 			</LoggedOutFormLinkItem>
@@ -353,7 +372,7 @@ const LoggedInForm = React.createClass( {
 			);
 		}
 
-		return(
+		return (
 			<LoggedOutFormLinks>
 				{ ! this.props.calypsoStartedConnection && this.isWaitingForConfirmation() ? backToWpAdminLink : null }
 				<LoggedOutFormLinkItem href={ loginUrl }>
@@ -369,14 +388,16 @@ const LoggedInForm = React.createClass( {
 	renderStateAction() {
 		const { authorizeSuccess, siteReceived } = this.props.jetpackConnectAuthorize;
 		if ( this.isAuthorizing() || ( authorizeSuccess && ! siteReceived ) ) {
-			return ( <div className="jetpack-connect-logged-in-form__loading">
-				<span>{ this.getButtonText() }</span> <Spinner size={ 20 } duration={ 3000 } />
-			</div> );
+			return (
+				<div className="jetpack-connect-logged-in-form__loading">
+					<span>{ this.getButtonText() }</span> <Spinner size={ 20 } duration={ 3000 } />
+				</div>
+			);
 		}
 		return (
-			<button disabled={ this.isAuthorizing() } onClick={ this.handleSubmit } className="button is-primary">
+			<Button primary disabled={ this.isAuthorizing() } onClick={ this.handleSubmit }>
 				{ this.getButtonText() }
-			</button>
+			</Button>
 		);
 	},
 
@@ -429,11 +450,14 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 	renderForm() {
 		const { userModule } = this.props;
-		let user = userModule.get();
+		const user = userModule.get();
 		const props = Object.assign( {}, this.props, {
 			user: user
 		} );
-		const calypsoStartedConnection = isCalypsoStartedConnection( this.props.jetpackConnectSessions, this.props.jetpackConnectAuthorize.queryObject.site );
+		const calypsoStartedConnection = isCalypsoStartedConnection(
+			this.props.jetpackConnectSessions,
+			this.props.jetpackConnectAuthorize.queryObject.site
+		);
 
 		return (
 			( user )


### PR DESCRIPTION
Alternate solution to Automattic/jetpack#4248.

Runs the site icon through `safe-image-url` to filter the URL and run the image through Photon if necessary. This ensure that we get rid of mixed content warnings with http and https.

To test:

- Checkout `update/jetpack-connect-authorize-site-icon-photonize` branch
- Test with a non-https Jetpack site
- Make sure site icon is set on Jetpack site
- Checkout latest version of `branch-4.1` in Jetpack
- Disconnect Jetpack site
- Go to `calypso.localhost:3000/jetpack/connect`
- Connect site 
- Ensure that when the page refreshes, there are no mixed content warnings and the site icon is https

cc @johnHackworth for review.

Note: I addressed many of the ESLint warnings in the `authorize-form` component, but there are several warnings for improper class names. Perhaps this is something Luna can take a pass at it?

Test live: https://calypso.live/?branch=update/jetpack-connect-authorize-site-icon-photonize