### PR TITLE
Theme Actions: Use isJetpack() selector

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -40,6 +40,7 @@ import {
 import { isJetpack } from './themes-last-query/selectors';
 import { getQueryParams } from './themes-list/selectors';
 import { getThemeById } from './themes/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import wpcom from 'lib/wp';
 
 export function fetchThemes( site ) {
@@ -165,7 +166,7 @@ export function receiveThemes( data, site, queryParams, responseTime ) {
 		const themeAction = {
 			type: THEMES_RECEIVE,
 			siteId: site.ID,
-			isJetpack: !! site.jetpack,
+			isJetpack: isJetpackSite( getState(), site.ID ),
 			wasJetpack: isJetpack( getState() ),
 			themes: data.themes,
 			found: data.found,


### PR DESCRIPTION
Attempting to fix the following bug (present in production):

* Land on the single-site theme showcase for a Jetpack site (e.g. https://wordpress.com/design/<jetpacksite>)
* Using the site selector, switch to All sites
* Switch back to the previous JP site

Instead of only the themes installed on your Jetpack site, you will also see a number of (all?)  WordPress.com ones

* Switch back again to All Sites

You'll get a JavaScript error, `Uncaught TypeError: Cannot read property 'id' of undefined`

Test live: https://calypso.live/?branch=fix/themes-jetpack