### PR TITLE
Use QuerySitePlans in my-sites/plans/main

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -13,6 +13,7 @@ import analytics from 'lib/analytics';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getCurrentPlan } from 'lib/plans';
 import { getPlans } from 'state/plans/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import Gridicon from 'components/gridicon';
 import { isJpphpBundle } from 'lib/products-values';
 import Main from 'components/main';
@@ -82,7 +83,7 @@ const Plans = React.createClass( {
 
 	showMonthlyPlansLink() {
 		const selectedSite = this.props.sites.getSelectedSite();
-		if ( !selectedSite.jetpack ) {
+		if ( ! selectedSite.jetpack ) {
 			return '';
 		}
 
@@ -127,7 +128,8 @@ const Plans = React.createClass( {
 
 	render() {
 		const selectedSite = this.props.sites.getSelectedSite(),
-			mainClassNames = {};
+			mainClassNames = {},
+			siteId = this.props.siteId;
 
 		let	hasJpphpBundle,
 			currentPlan;
@@ -169,7 +171,7 @@ const Plans = React.createClass( {
 
 						{ ! hasJpphpBundle && this.showMonthlyPlansLink() }
 						<QueryPlans />
-						<QuerySitePlans />
+						<QuerySitePlans siteId={ siteId } />
 
 						{
 							showPlanFeatures
@@ -200,7 +202,8 @@ export default connect(
 	( state, props ) => {
 		return {
 			plans: getPlans( state ),
-			sitePlans: getPlansBySite( state, props.sites.getSelectedSite() )
+			sitePlans: getPlansBySite( state, props.sites.getSelectedSite() ),
+			siteId: getSelectedSiteId( state )
 		};
 	}
 )( Plans );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -10,7 +10,6 @@ import find from 'lodash/find';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getCurrentPlan } from 'lib/plans';
 import { getPlans } from 'state/plans/selectors';
@@ -23,11 +22,12 @@ import paths from './paths';
 import PlanList from 'components/plans/plan-list' ;
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlanOverview from './plan-overview';
-import { shouldFetchSitePlans, plansLink } from 'lib/plans';
+import { plansLink } from 'lib/plans';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import QueryPlans from 'components/data/query-plans';
+import QuerySitePlans from 'components/data/query-site-plans';
 import { PLAN_MONTHLY_PERIOD } from 'lib/plans/constants';
 import config from 'config';
 
@@ -42,7 +42,6 @@ const Plans = React.createClass( {
 		destinationType: React.PropTypes.string,
 		intervalType: React.PropTypes.string,
 		plans: React.PropTypes.array.isRequired,
-		fetchSitePlans: React.PropTypes.func.isRequired,
 		sites: React.PropTypes.object.isRequired,
 		sitePlans: React.PropTypes.object.isRequired,
 		transaction: React.PropTypes.object.isRequired
@@ -50,20 +49,6 @@ const Plans = React.createClass( {
 
 	getInitialState() {
 		return { openPlan: '' };
-	},
-
-	componentDidMount() {
-		this.updateSitePlans( this.props.sitePlans );
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		this.updateSitePlans( nextProps.sitePlans );
-	},
-
-	updateSitePlans( sitePlans ) {
-		const selectedSite = this.props.sites.getSelectedSite();
-
-		this.props.fetchSitePlans( sitePlans, selectedSite );
 	},
 
 	openPlan( planId ) {
@@ -184,6 +169,7 @@ const Plans = React.createClass( {
 
 						{ ! hasJpphpBundle && this.showMonthlyPlansLink() }
 						<QueryPlans />
+						<QuerySitePlans />
 
 						{
 							showPlanFeatures
@@ -215,16 +201,6 @@ export default connect(
 		return {
 			plans: getPlans( state ),
 			sitePlans: getPlansBySite( state, props.sites.getSelectedSite() )
-		};
-	},
-
-	dispatch => {
-		return {
-			fetchSitePlans( sitePlans, site ) {
-				if ( shouldFetchSitePlans( sitePlans, site ) ) {
-					dispatch( fetchSitePlans( site.ID ) );
-				}
-			}
 		};
 	}
 )( Plans );


### PR DESCRIPTION
Fix for #6347.

## Testing Instructions

1. Run Calypso with `make run`;
2. Go to `/plans`; verify everything looks/works as before;
3. Try creating new WordPress site; verify everything looks/works as before;
4. Go to incognito mode and create new account; verify everything looks/works as before, especially the plans step.

cc @gwwar 

Test live: https://calypso.live/?branch=fix/use-query-site-plans-in-plans-main