### PR TITLE
Plugins: do not use native find

### DIFF
--- a/client/components/push-notification/prompt.jsx
+++ b/client/components/push-notification/prompt.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -58,7 +59,7 @@ const PushNotificationPrompt = React.createClass( {
 	},
 
 	pushUnsubscribedNotice: function() {
-		const buttonDisabled = ( [ 'disabling', 'enabling', 'unknown' ].includes( this.props.status ) );
+		const buttonDisabled = includes( [ 'disabling', 'enabling', 'unknown' ], this.props.status );
 		const noticeText = (
 			<div>
 				<p>

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -1,15 +1,18 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'wporg' ),
-	i18n = require( 'i18n-calypso' ),
-	superagent = require( 'superagent' );
+import debugFactory from 'debug';
+import i18n from 'i18n-calypso';
+import superagent from 'superagent';
+import find from 'lodash/find';
 
 /**
  * Internal dependencies
  */
-var jsonp = require( './jsonp' ),
-	config = require( 'config' );
+import jsonp from './jsonp';
+import config from 'config';
+
+const debug = debugFactory( 'wporg' );
 
 /**
  * Constants
@@ -24,9 +27,10 @@ function getWporgLocaleCode( ) {
 		wpOrgLocaleCode;
 
 	currentLocaleCode = i18n.getLocaleSlug();
-	wpOrgLocaleCode = config( 'languages' ).find( function( language ) {
-		return language.langSlug === currentLocaleCode;
-	} ).wpLocale;
+	wpOrgLocaleCode = find(
+		config( 'languages' ),
+		{ langSlug: currentLocaleCode }
+	).wpLocale;
 
 	if ( wpOrgLocaleCode === '' ) {
 		wpOrgLocaleCode = currentLocaleCode;


### PR DESCRIPTION
This fixes #6422 to use lodash find instead of native find, which is not supported in all browsers. I've also updated a native includes to use lodash includes.

## Testing Instructions
In IE:
- Navigate to http://calypso.localhost:3000.com/plugins/example.jetpacksite.com
- Plugins should load, instead of infinite placeholders.

cc @hoverduck @yoavf @jblz 

Test live: https://calypso.live/?branch=fix/plugins-find