### PR TITLE
CPT: Improve reliability of lists screen placeholders, requests

### DIFF
--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -48,7 +48,6 @@ class PostTypeList extends Component {
 		this.renderPostRow = this.renderPostRow.bind( this );
 		this.renderPlaceholder = this.renderPlaceholder.bind( this );
 		this.setRequestedPages = this.setRequestedPages.bind( this );
-		this.setVirtualScrollRef = this.setVirtualScrollRef.bind( this );
 
 		this.state = {
 			requestedPages: this.getInitialRequestedPages( this.props )
@@ -71,10 +70,6 @@ class PostTypeList extends Component {
 		}
 
 		return [];
-	}
-
-	setVirtualScrollRef( ref ) {
-		this.virtualScroll = ref;
 	}
 
 	getPageForIndex( index ) {
@@ -164,7 +159,6 @@ class PostTypeList extends Component {
 							<AutoSizer disableHeight>
 								{ ( { width } ) => (
 									<VirtualScroll
-										ref={ this.setVirtualScrollRef }
 										autoHeight
 										scrollTop={ scrollTop }
 										height={ height }

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -40,7 +40,6 @@ class PostTypeList extends Component {
 		siteId: PropTypes.number,
 		lastPage: PropTypes.number,
 		posts: PropTypes.array,
-		requestingFirstPage: PropTypes.bool,
 		requestingLastPage: PropTypes.bool
 	};
 
@@ -119,7 +118,7 @@ class PostTypeList extends Component {
 	}
 
 	render() {
-		const { query, siteId, posts, requestingFirstPage } = this.props;
+		const { query, siteId, posts } = this.props;
 		const isEmpty = query && posts && ! posts.length && this.isLastPage();
 		const classes = classnames( 'post-type-list', {
 			'is-empty': isEmpty
@@ -138,7 +137,6 @@ class PostTypeList extends Component {
 						type={ query.type }
 						status={ query.status } />
 				) }
-				{ requestingFirstPage && this.renderPlaceholder() }
 				{ ! isEmpty && (
 					<WindowScroller key={ JSON.stringify( query ) }>
 						{ ( { height, scrollTop } ) => (
@@ -158,7 +156,7 @@ class PostTypeList extends Component {
 						) }
 					</WindowScroller>
 				) }
-				{ ! requestingFirstPage && ! this.isLastPage() && this.renderPlaceholder() }
+				{ ! this.isLastPage() && this.renderPlaceholder() }
 			</div>
 		);
 	}
@@ -172,7 +170,6 @@ export default connect( ( state, ownProps ) => {
 		siteId,
 		lastPage,
 		posts: getSitePostsForQueryIgnoringPage( state, siteId, ownProps.query ),
-		requestingFirstPage: isRequestingSitePostsForQuery( state, siteId, { ...ownProps.query, page: 1 } ),
 		requestingLastPage: isRequestingSitePostsForQuery( state, siteId, { ...ownProps.query, page: lastPage } )
 	};
 } )( PostTypeList );

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -1,4 +1,4 @@
-.post-type-list__posts {
+.post-type-list:not( .is-empty ) {
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 }


### PR DESCRIPTION
This pull request seeks to resolve a few edge cases I had observed in switching between statuses in the [custom post types list screen](http://calypso.localhost:3000/types/post), specifically related to optimizations done by `react-virtualized` to avoid calling the `rowRenderer` or `onRowsRendered` callbacks when either the row count has not changed, or the rendered index range has not changed.

Notably, I found that issues would occur when...

1. Navigating from a filter where one post exists to one where two posts exist, then switching back to the first filter (issue is that because row count has not changed, 2 posts = 1 post + 1 placeholder in refreshing the original filter)
2. Navigating from a filter where one post exists to one where one post exists (`onRowsRendered` won't be invoked because range hasn't changed, so `this.state.requestedPages` will be reset to an empty array but the `setRequestedPages` logic won't run and the data won't be refreshed)

__Implementation notes:__

Hopefully the changes here will be seen as a simplification. Rather than try to account for placeholders in the row count, I've made it so that they are rendered separate from the list itself. This alleviates the first problem. To fix the second, I apply a `key` to the `WindowScroller` component corresponding with the serialized query. Therefore, when the query (filter) changes, a new rendered instance will be created and `onRowsRendered={ this.setRequestedPages }` will be invoked.

__Testing instructions:__

I found it easiest to test with the following distribution of posts:

![Status distribution](https://cloud.githubusercontent.com/assets/1779930/16463544/3d69fd7c-3e04-11e6-90b8-3e7fe36c2745.png)

(Two statuses where counts are the same, another where there's one more post)

Ensure that switching between filters, fresh posts are always requested, reflected by placeholders in the following configuration:

- When loading or refreshing first page of data, placeholder shown as first entry and all known posts shown below
- When more than one page exists, placeholder shown at end of list while loading next page, until all items have been exhausted

cc @timmyc 

Test live: https://calypso.live/?branch=fix/cpt-query-change-requests