### PR TITLE
Add Jetpack specific FAQ to new plans page

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -24,6 +24,10 @@ import { abtest } from 'lib/abtest';
 
 class PlansFeaturesMain extends Component {
 
+	isJetpackSite( site ) {
+		return site.jetpack;
+	}
+
 	renderPlanPlaceholders() {
 		const { site, hideFreePlan } = this.props;
 
@@ -33,7 +37,7 @@ class PlansFeaturesMain extends Component {
 			numberOfPlaceholders = 3;
 		}
 
-		if ( site && site.jetpack ) {
+		if ( site && this.isJetpackSite( site ) ) {
 			numberOfPlaceholders = 2;
 		}
 
@@ -51,7 +55,7 @@ class PlansFeaturesMain extends Component {
 	}
 
 	getPlanFeatures( site, intervalType ) {
-		if ( site.jetpack && intervalType === 'monthly' ) {
+		if ( this.isJetpackSite( site ) && intervalType === 'monthly' ) {
 			return (
 				<div className="plans-features-main__group">
 					<PlanFeatures plan={ PLAN_JETPACK_PREMIUM_MONTHLY } /* onClick={ this.upgradePlan } */ />
@@ -59,7 +63,7 @@ class PlansFeaturesMain extends Component {
 				</div>
 			);
 		}
-		if ( site.jetpack ) {
+		if ( this.isJetpackSite( site ) ) {
 			return (
 				<div className="plans-features-main__group">
 					<PlanFeatures plan={ PLAN_JETPACK_PREMIUM } /* onClick={ this.upgradePlan } */ />
@@ -77,10 +81,68 @@ class PlansFeaturesMain extends Component {
 		);
 	}
 
+	getJetpackFAQ() {
+		const { translate } = this.props;
+
+		return (
+			<FAQ>
+				<FAQItem
+					question={ translate( 'What are the hosting requirements?' ) }
+					answer={ translate(
+						'You should be running the latest version of WordPress and be using a web host that runs PHP 5 or higher. You will also need a WordPress.com account (you can register one during the connection process) and a publicly accessible site with XML-RPC enabled.'
+					) }
+				/>
+
+				<FAQItem
+					question={ translate( 'What is the cancellation policy?' ) }
+					answer={ translate(
+						'You can request a cancellation within 30 days of purchase and receive a full refund.'
+					) }
+				/>
+
+				<FAQItem
+					question={ translate( 'Does this work with a multisite network?' ) }
+					answer={ translate(
+						'Yes, Jetpack and all of its premium features are compatible with WordPress Multisite networks. If you manage a Multisite network, you will need to make sure you have a subscription for each site you wish to cover with premium features.'
+					) }
+				/>
+
+				<FAQItem
+					question={ translate( 'Can I migrate my subscription to a different site?' ) }
+					answer={ translate(
+						'Absolutely. You are always free to activate your premium services on a different WordPress site.'
+					) }
+				/>
+
+				<FAQItem
+					question={ translate( 'Why do I need a WordPress.com account?' ) }
+					answer={ translate(
+						"Many of Jetpack’s core features make use of the WordPress.com cloud. In order to make sure everything works correctly, Jetpack requires you to connect a (free) WordPress.com account. If you don't already have an account you can easily create one during the connection process."
+					) }
+				/>
+
+				<FAQItem
+					question={ translate( 'I signed up and paid. What’s next?' ) }
+					answer={ translate(
+						'The premium features included with Jetpack subscriptions are powered by a few of our other plugins. If you purchase any subscription, you will need to install the Akismet and VaultPress plugins once you’ve completed the purchase process. If you purchase a Professional subscription, you will also need to install the Polldaddy plugin. Don’t worry - just follow the guide after you complete your purchase.'
+					) }
+				/>
+
+				<FAQItem
+					question={ translate( 'Have more questions?' ) }
+					answer={ translate(
+						'No problem! Feel free to {{a}}get in touch{{/a}} with our Happiness Engineers.',
+						{
+							components: { a: <a href="https://jetpack.com/contact-support/" target="_blank" /> }
+						}
+					) }
+				/>
+			</FAQ>
+
+		);
+	}
+
 	getFAQ( site ) {
-		if ( site.jetpack ) {
-			return null;
-		}
 		const { translate } = this.props;
 		return (
 			<FAQ>
@@ -177,7 +239,11 @@ class PlansFeaturesMain extends Component {
 		return (
 			<div class="plans-features-main">
 				{ this.getPlanFeatures( site, intervalType ) }
-				{ this.getFAQ( site ) }
+				{
+					this.isJetpackSite( site )
+					? this.getJetpackFAQ()
+					: this.getFAQ( site )
+				}
 			</div>
 		);
 	}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -87,30 +87,23 @@ class PlansFeaturesMain extends Component {
 		return (
 			<FAQ>
 				<FAQItem
-					question={ translate( 'What are the hosting requirements?' ) }
+					question={ translate( 'I signed up and paid. What’s next?' ) }
 					answer={ translate(
-						'You should be running the latest version of WordPress and be using a web host that runs PHP 5 or higher. You will also need a WordPress.com account (you can register one during the connection process) and a publicly accessible site with XML-RPC enabled.'
+						'Our premium features are powered by a few of our other plugins. After purchasing you will need to install the Akismet and VaultPress plugins. If you purchase a Professional subscription, you will also need to install the Polldaddy plugin. Just follow the guide after you complete your purchase.'
 					) }
 				/>
 
 				<FAQItem
-					question={ translate( 'What is the cancellation policy?' ) }
+					question={ translate( 'What are the hosting requirements?' ) }
 					answer={ translate(
-						'You can request a cancellation within 30 days of purchase and receive a full refund.'
+						'You should be running the latest version of WordPress and be using a web host that runs PHP 5 or higher. You will also need a WordPress.com account (you can register during the connection process) and a publicly-accessible site with XML-RPC enabled.'
 					) }
 				/>
 
 				<FAQItem
 					question={ translate( 'Does this work with a multisite network?' ) }
 					answer={ translate(
-						'Yes, Jetpack and all of its premium features are compatible with WordPress Multisite networks. If you manage a Multisite network, you will need to make sure you have a subscription for each site you wish to cover with premium features.'
-					) }
-				/>
-
-				<FAQItem
-					question={ translate( 'Can I migrate my subscription to a different site?' ) }
-					answer={ translate(
-						'Absolutely. You are always free to activate your premium services on a different WordPress site.'
+						'Yes, Jetpack and all of its premium features are compatible with WordPress Multisite networks. If you manage a Multisite network you will need to make sure you have a subscription for each site you wish to cover with premium features.'
 					) }
 				/>
 
@@ -122,9 +115,16 @@ class PlansFeaturesMain extends Component {
 				/>
 
 				<FAQItem
-					question={ translate( 'I signed up and paid. What’s next?' ) }
+					question={ translate( 'Can I migrate my subscription to a different site?' ) }
 					answer={ translate(
-						'The premium features included with Jetpack subscriptions are powered by a few of our other plugins. If you purchase any subscription, you will need to install the Akismet and VaultPress plugins once you’ve completed the purchase process. If you purchase a Professional subscription, you will also need to install the Polldaddy plugin. Don’t worry - just follow the guide after you complete your purchase.'
+						'Absolutely. You are always free to activate your premium services on a different WordPress site.'
+					) }
+				/>
+
+				<FAQItem
+					question={ translate( 'What is the cancellation policy?' ) }
+					answer={ translate(
+						'You can request a cancellation within 30 days of purchase and receive a full refund.'
 					) }
 				/>
 


### PR DESCRIPTION
Fixes #6300.

## Testing Instructions

1. Run Calypso with `ENABLE_FEATURES=manage/plan-features make run`;
2. Select a Jetpack site and navigate to `/plans`. Do you see Jetpack specific FAQ?
3. Select a WPcom site and navigate to `/plans`. Do you see WPcom specific FAQ?
4. Is the design/layout of the Jetpack and WPcom FAQ nice?

## Screenshots

### WPcom FAQ

![selection_026](https://cloud.githubusercontent.com/assets/4988512/16464056/c64d00ce-3e38-11e6-82e4-07e18f3ddf8b.jpg)

### Jetpack FAQ

![selection_025](https://cloud.githubusercontent.com/assets/4988512/16464063/cb3ccaec-3e38-11e6-84ae-0d0217871783.jpg)


Props @bubel for the FAQ content! Also, could you @bubel please double-check the content of the Jetpack FAQ in this PR? Just in case I have copied something wrongly:)

cc @gwwar @mtias 

Test live: https://calypso.live/?branch=add/plans-page-jetpack-faq