### PR TITLE
Framework: Fix infinite scroll

### DIFF
--- a/client/lib/mixins/infinite-scroll/index.js
+++ b/client/lib/mixins/infinite-scroll/index.js
@@ -33,7 +33,7 @@ module.exports = function( nextPageMethod ) {
 
 		checkScrollPosition: function( options ) {
 			var scrollPosition = window.pageYOffset,
-				documentHeight = document.body.clientHeight,
+				documentHeight = document.body.scrollHeight,
 				viewportHeight = window.innerHeight,
 				scrollOffset = 2 * viewportHeight,
 				triggeredByScroll = options.triggeredByScroll,


### PR DESCRIPTION
Remove a layout tweak introduced in #4506 that causes infinite-scroll to constantly request data.

Since a CSS [change](https://github.com/Automattic/wp-calypso/pull/4506/files#diff-73fb7e175d9b17f2f1a188509b0a4168R76) in #4506, `document.body.clientHeight` is always equal to `window.innerHeight`, meaning infinite-scroll always [thinks it needs](https://github.com/Automattic/wp-calypso/blob/f248c9aecc968dc01321d6a10230cda1cf22470b/client/lib/mixins/infinite-scroll/index.js#L42) more data.

This chage uses `scrollHeight`, which includes the space not visible in the viewport, instead of `clientHeight`.

**To Test**
* Note that currently at https://wordpress.com/design, the themes are loaded until the complete list is on the page (check the network tab in the browser tools)
* With this PR, the themes are loaded in blocks of 20 as you scroll, as intended

@hoverduck: I'd be interested to know if this PR fixes the e2e test problem with the theme list?



Test live: https://calypso.live/?branch=fix/infinite-scroll