### PR TITLE
CPT: Show thumbnail only when assigned or placeholder

### DIFF
--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import classnames from 'classnames';
 import { connect } from 'react-redux';
 import get from 'lodash/get';
 
@@ -12,8 +13,12 @@ import resizeImageUrl from 'lib/resize-image-url';
 import { getNormalizedPost } from 'state/posts/selectors';
 
 function PostTypeListPostThumbnail( { thumbnail } ) {
+	const classes = classnames( 'post-type-list__post-thumbnail-wrapper', {
+		'has-image': !! thumbnail
+	} );
+
 	return (
-		<div className="post-type-list__post-thumbnail-wrapper">
+		<div className={ classes }>
 			{ thumbnail && (
 				<img
 					src={ resizeImageUrl( thumbnail, { w: 80 } ) }

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -23,11 +23,17 @@
 }
 
 .post-type-list__post-thumbnail-wrapper {
+	display: none;
 	position: relative;
 	width: 80px;
 	align-self: stretch;
 	margin-right: 12px;
 	overflow: hidden;
+
+	&.has-image,
+	.post-type-list__post-placeholder & {
+		display: block;
+	}
 
 	.post-type-list__post-placeholder & {
 		@include placeholder;


### PR DESCRIPTION
Regression introduced in #6372

This fixes a small issue introduced in #6372, where the thumbnail wrapper is always rendered, causing some longer titles to be prematurely abbreviated despite having more space available.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16469826/07753e6c-3e21-11e6-9f28-271ae01b0cbc.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16469822/fc5548ba-3e20-11e6-9739-3ee73693c58b.png)

__Testing instructions:__

Verify that on the [custom post type list screen](http://calypso.localhost:3000/types/post), post titles are faded only when reaching the ellipsis menu, or the thumbnail (only if thumbnail is present).

/cc @timmyc 

Test live: https://calypso.live/?branch=fix/cpt-long-title-image