### PR TITLE
Signup: Add an AB test for offering a Pressable store option.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -139,4 +139,13 @@ module.exports = {
 		defaultVariation: 'disabled',
 		allowExistingUsers: true,
 	},
+	signupStore: {
+		datestamp: '20160629',
+		variations: {
+			disabled: 70,
+			enabled: 30,
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: true,
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -158,6 +158,13 @@ const flows = {
 		lastModified: '2015-11-23'
 	},
 
+	'design-store': {
+		steps: [ 'survey', 'design-store', 'themes', 'domains', 'plans', 'survey-user' ],
+		destination: getSiteDestination,
+		description: 'An AB test flow for offering Pressable to users wanting a store.',
+		lastModified: '2016-06-29'
+	},
+
 	jetpack: {
 		steps: [ 'jetpack-user' ],
 		destination: '/'
@@ -176,7 +183,9 @@ function removeUserStepFromFlow( flow ) {
 
 function filterFlowName( flowName ) {
 	const defaultFlows = [ 'main', 'website' ];
-	// do nothing. No flows to filter at the moment.
+	if ( includes( defaultFlows, flowName ) && 'enabled' === abtest( 'signupStore' ) ) {
+		return 'design-store';
+	}
 	return flowName;
 }
 


### PR DESCRIPTION
See: `p5XAZ9-M4-p2`

This will first need a new `design-store` step to be merged, which would be a combination of #6340 and #6350. We can keep the step and test PRs separate to make removing the test and incorporating the new step into defaults easier (in the case of a successful test).

cc/ @coreh @meremagee @michaeldcain for tracking.

Test live: https://calypso.live/?branch=add/signup-store-abtest