### PR TITLE
Purchases: add a link to contacting support

### DIFF
--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -53,7 +53,7 @@ function cancelPrivateRegistration( purchaseId, onComplete ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.PRIVACY_PROTECTION_CANCEL_FAILED,
 				purchaseId,
-				error: error.message || i18n.translate( 'There was a problem canceling this private registration. Please try again later or contact support.' )
+				error: error.message || i18n.translate( 'There was a problem canceling this private registration.' )
 			} );
 		}
 
@@ -88,7 +88,7 @@ function deleteStoredCard( card, onComplete ) {
 		} else {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.STORED_CARDS_DELETE_FAILED,
-				error: error.message || i18n.translate( 'There was a problem deleting the stored card. Please try again later or contact support.' )
+				error: error.message || i18n.translate( 'There was a problem deleting the stored card.' )
 			} );
 		}
 
@@ -136,7 +136,7 @@ function fetchStoredCards() {
 		} else if ( error ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.STORED_CARDS_FETCH_FAILED,
-				error: error.message || i18n.translate( 'There was a problem retrieving stored cards. Please try again later or contact support.' )
+				error: error.message || i18n.translate( 'There was a problem retrieving stored cards.' )
 			} );
 		}
 	} );

--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -19,6 +19,7 @@ import notices from 'notices';
 import Notice from 'components/notice';
 import paths from '../paths';
 import titles from 'me/purchases/titles';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 const CancelPrivateRegistration = React.createClass( {
 	propTypes: {
@@ -145,7 +146,13 @@ const CancelPrivateRegistration = React.createClass( {
 		const purchase = this.props.selectedPurchase.data;
 
 		if ( purchase.error ) {
-			return <Notice status="is-error" showDismiss={ false }>{ purchase.error }</Notice>;
+			return <Notice status="is-error" showDismiss={ false }>
+				{ purchase.error }
+				{ ' ' }
+				{ this.translate( 'Please try again later or {{a}}contact support.{{/a}}', {
+					components: { a: <a href={ CALYPSO_CONTACT } /> }
+				} ) }
+			</Notice>;
 		}
 
 		return null;


### PR DESCRIPTION
Change the error messages to contain only the actual error
When the error is displayed, add a link to contacting support

Instead of:
![screen shot 2016-06-30 at 8 37 04 am](https://cloud.githubusercontent.com/assets/326402/16486141/5905c2b0-3ecb-11e6-93e7-ee5168fbba95.png)

There's now:
![screen shot 2016-06-30 at 2 02 44 pm](https://cloud.githubusercontent.com/assets/326402/16486148/62d8f0a0-3ecb-11e6-97e0-c79374881e84.png)


This replaces #6364 in attempt to adress #465 , this also requires D2133

- [x] Code
- [x] Product

Test live: https://calypso.live/?branch=fix/contact-support-link