### PR TITLE
Revert "fix #4433 count is getting hidden for selected value in dropdown"

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -270,10 +270,6 @@
 	.is-selected & {
 		color: $white;
 		background-color: $blue-medium;
-		.count {
-			color: $white;
-			border-color: $white;
-		}
 	}
 
 	&:focus {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#4728

Test live: https://calypso.live/?branch=revert-4728-dropdown