### PR TITLE
SectionNav: only change color of count on mobile.

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -270,9 +270,12 @@
 	.is-selected & {
 		color: $white;
 		background-color: $blue-medium;
-		.count {
-			color: $white;
-			border-color: $white;
+
+		@include breakpoint( "<480px" ) {
+			.count {
+				color: $white;
+				border-color: $white;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes bug introduced in #4728.

Test live: https://calypso.live/?branch=fix/section-nav-count