### PR TITLE
Components: Limit white border application to mobile/is-open case

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -270,9 +270,12 @@
 	.is-selected & {
 		color: $white;
 		background-color: $blue-medium;
+
 		.count {
-			color: $white;
-			border-color: $white;
+			.section-nav.is-open & {
+				color: $white;
+				border-color: $white;
+			}
 		}
 	}
 


### PR DESCRIPTION
Regression introduced in #4728
Related: #4433

We should apply a white border to count, but only for selected menu item in the mobile/dropdown view (when `.is-open` is applied).

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16491317/7d96d5f8-3eab-11e6-97e6-71ec5fa4aa4e.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16491309/7653a53c-3eab-11e6-95fe-6f231a5041d7.png)

cc @sendilkumarn @mtias @hoverduck 

Test live: https://calypso.live/?branch=fix/section-nav-invisible-count