### PR TITLE
Framework: disable 'source-map-loader' as default

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,8 @@
  * External dependencies
  */
 var webpack = require( 'webpack' ),
-	path = require( 'path' );
+	path = require( 'path' ),
+	config = require( 'config' );
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ const sectionCount = sections.length;
 webpackConfig = {
 	cache: true,
 	entry: {},
+	devtool: '#eval',
 	output: {
 		path: path.join( __dirname, 'public' ),
 		publicPath: '/calypso/',
@@ -33,15 +35,7 @@ webpackConfig = {
 		chunkFilename: '[name].[chunkhash].js',
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]'
 	},
-	debug: true,
-	devtool: '#eval-cheap-module-source-map',
 	module: {
-		preLoaders: [
-			{
-				test: /\.jsx?$/,
-				loader: 'source-map-loader'
-			}
-		],
 		loaders: [
 			{
 				test: /sections.js$/,
@@ -132,6 +126,16 @@ if ( CALYPSO_ENV === 'development' ) {
 
 	// Add react hot loader before babel-loader
 	jsLoader.loaders = [ 'react-hot' ].concat( jsLoader.loaders );
+
+	if ( config.isEnabled( 'use-source-maps' ) ) {
+		webpackConfig.debug = true;
+		webpackConfig.devtool = '#eval-cheap-module-source-map';
+		webpackConfig.module.preLoaders = webpackConfig.module.preLoaders || [];
+		webpackConfig.module.preLoaders.push( {
+			test: /\.jsx?$/,
+			loader: 'source-map-loader'
+		} );
+	}
 } else {
 	webpackConfig.entry[ 'build-' + CALYPSO_ENV ] = path.join( __dirname, 'client', 'boot' );
 	webpackConfig.debug = false;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,9 +124,6 @@ if ( CALYPSO_ENV === 'development' ) {
 		path.join( __dirname, 'client', 'boot' )
 	];
 
-	// Add react hot loader before babel-loader
-	jsLoader.loaders = [ 'react-hot' ].concat( jsLoader.loaders );
-
 	if ( config.isEnabled( 'use-source-maps' ) ) {
 		webpackConfig.debug = true;
 		webpackConfig.devtool = '#eval-cheap-module-source-map';
@@ -135,6 +132,10 @@ if ( CALYPSO_ENV === 'development' ) {
 			test: /\.jsx?$/,
 			loader: 'source-map-loader'
 		} );
+	} else {
+		// Add react hot loader before babel-loader.
+		// It's loaded by default since `use-source-maps` is disabled by default.
+		jsLoader.loaders = [ 'react-hot' ].concat( jsLoader.loaders );
 	}
 } else {
 	webpackConfig.entry[ 'build-' + CALYPSO_ENV ] = path.join( __dirname, 'client', 'boot' );


### PR DESCRIPTION
Whit this PR `source-map-loader` stuff is determinate by the feature flag `use-source-maps` and its value is `disabled` as default. To enable run the app doing something like ...

``` cli
ENABLE_FEATURES=use-source-maps make run
```

Keep in mind `source-map-loader` is limited to `development` environment as well.

We've been experiencing high use of the CPU after that `source-map-loader` was added to Webpack. https://github.com/Automattic/wp-calypso/pull/5656

![image](https://cloud.githubusercontent.com/assets/77539/16492713/ff2684ec-3ee2-11e6-996e-53deb74f2740.png)

Test live: https://calypso.live/?branch=update/condition-source-map-loader