### PR TITLE
Framework: Emit a system event when webpack is done building the client

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,16 @@ var start = Date.now(),
 	host = process.env.HOST || config( 'hostname' ),
 	app = boot(),
 	server,
+	compiler,
 	hotReloader;
+
+function sendBootStatus( status ) {
+	// don't send anything if we're not running in a fork
+	if ( ! process.send ) {
+		return;
+	}
+	process.send( { boot: status } );
+}
 
 console.log( chalk.yellow( '%s booted in %dms - http://%s:%s' ), pkg.name, ( Date.now() ) - start, host, port );
 console.info( chalk.cyan( '\nGetting bundles ready, hold on...' ) );
@@ -24,19 +33,30 @@ console.info( chalk.cyan( '\nGetting bundles ready, hold on...' ) );
 server = http.createServer( app );
 
 // The desktop app runs Calypso in a fork.
-if ( process.env.CALYPSO_IS_FORK ) {
-	// We need to run it with an explicit hostname to avoid firewall warnings.
-	server.listen( { port, host }, function() {
-		// Tell the parent process that Calypso has booted.
-		process.send( { boot: 'ready' } );
-	} );
-} else {
-	// Let non-forks listen on any host.
-	server.listen( port );
+// Let non-forks listen on any host.
+if ( ! process.env.CALYPSO_IS_FORK ) {
+	host = null;
 }
+
+server.listen( { port, host }, function() {
+	// Tell the parent process that Calypso has booted.
+	sendBootStatus( 'ready' );
+} );
 
 // Enable hot reloader in development
 if ( config( 'env' ) === 'development' ) {
 	hotReloader = require( 'bundler/hot-reloader' );
-	hotReloader.listen( server, app.get( 'compiler' ) );
+	compiler = app.get( 'compiler' );
+
+	compiler.plugin( 'compile', function() {
+		sendBootStatus( 'compiler compiling' );
+	} );
+	compiler.plugin( 'invalid', function() {
+		sendBootStatus( 'compiler invalid' );
+	} );
+	compiler.plugin( 'done', function() {
+		sendBootStatus( 'compiler done' );
+	} );
+
+	hotReloader.listen( server, compiler );
 }


### PR DESCRIPTION
This is an experiment for calypso-live-branches to be able to tell when the app is built and ready to receive e2e tests!

### Testing
- Load https://calypso.live/?branch=add/boot-ready-on-build
- Check the status of https://calypso.live/?branch=add/boot-ready-on-build&status=1 
- Push a commit to this branch which changes something (a new empty line is enough) to the server in one of those paths https://github.com/Automattic/calypso-live-branches/blob/master/calypso.json#L16
- Check the status of the branch by polling https://calypso.live/?branch=add/boot-ready-on-build&status=1 
```bash
while true; do curl "https://calypso.live/?branch=add/boot-ready-on-build&status=1"; echo ""; sleep 2; done
```
- The app should restart in less than a minute, check the status, it should update to 'BOOTING', 'ready', then 'compiler done' because we have modified a server file.
- Remove your commit for this branch.

You can also test updating the client:

- Update a file in `client` with a valid change
- Check the status of the branch by polling https://calypso.live/?branch=add/boot-ready-on-build&status=1
- Push your change to this branch
- It should change to 'compiler compiling' (or 'compiler invalid') for a few seconds then come back to 'ready'.
- Remove your commit from this branch

### Reviews
- [x] Code
- [x] Product
