### PR TITLE
Site Selection: Omit URL params from site selection header text

### DIFF
--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -64,7 +64,7 @@ export default React.createClass( {
 			return this.props.getSiteSelectionHeaderText();
 		}
 
-		const path = this.props.path.replace( /\//g, ' ' );
+		const path = this.props.path.split( '?' )[ 0 ].replace( /\//g, ' ' );
 
 		return this.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
 			args: {


### PR DESCRIPTION
When visiting a page that requires the user to select a site, we grab the name of the page from the URL path to use in the site selection header. For example, going to /plans displays:

> Please select a site to open **Plans**

However, if the URL contains query parameters, those are also displayed in the header text. Going to /plans?utm_campaign=email would display:

> Please select a site to open **Plans?utm_campaign=email**

This PR ensures we only display the name of the page based on the path prior to any URL query parameters.

To test on an account with multiple sites:

1. Go to http://calypso.localhost:3000/plans/ and verify it just says "Please select a site to open Plans"
2. Go to http://calypso.localhost:3000/plans/?utm_campaign=email, verify it just says "Please select a site to open Plans" (omitting the URL params from the header text)


Test live: https://calypso.live/?branch=fix-plans-page-header