### PR TITLE
Jetpack SSO: Deploy to production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -21,6 +21,7 @@
 		"guided-tours": true,
 		"help": true,
 		"jetpack/connect": true,
+		"jetpack/sso": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
 		"manage/ads": true,


### PR DESCRIPTION
Launches `/jetpack/sso` to production.

To test:

- Checkout `update/sso-to-production` branch
- In terminal, `CALYPSO_ENV=production make run`
- Go to `/jetpack/sso`
- Do you see a Drake error message?

Test live: https://calypso.live/?branch=update/sso-to-production