### PR TITLE
Themes: use "Activate this design" for logged in users.

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -146,9 +146,6 @@ const Theme = React.createClass( {
 						{ price && ! purchased &&
 							<span className="price">{ price }</span>
 						}
-						{ purchased && ! active &&
-							<span className="price">{ this.translate( 'Purchased' ) }</span>
-						}
 						{ ! isEmpty( this.props.buttonContents ) ? <ThemeMoreButton
 							index={ this.props.index }
 							theme={ this.props.theme }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -309,16 +309,14 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderPrice() {
-		if ( ! this.isLoaded() || this.isActive() ) {
-			return '';
-		}
-
 		let price = this.props.price;
-		if ( ! isPremium( this.props ) ) {
+		if ( ! this.isLoaded() || this.isActive() ) {
+			price = '';
+		} else if ( ! isPremium( this.props ) ) {
 			price = i18n.translate( 'Free' );
 		}
 
-		return <span className="theme__sheet-action-bar-cost">{ price }</span>;
+		return price ? <span className="theme__sheet-action-bar-cost">{ price }</span> : '';
 	},
 
 	renderButton() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -314,10 +314,7 @@ const ThemeSheet = React.createClass( {
 		}
 
 		let price = this.props.price;
-
-		if ( this.props.selectedSite && this.props.purchased ) {
-			price = i18n.translate( 'Purchased' );
-		} else if ( ! isPremium( this.props ) ) {
+		if ( ! isPremium( this.props ) ) {
 			price = i18n.translate( 'Free' );
 		}
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -321,7 +321,7 @@ const ThemeSheet = React.createClass( {
 		if ( this.isActive() ) {
 			actionTitle = i18n.translate( 'Customize' );
 		} else if ( this.props.name ) {
-			actionTitle = i18n.translate( 'Pick this design' );
+			actionTitle = this.props.isLoggedIn ? i18n.translate( 'Activate this design' ) : i18n.translate( 'Pick this design' );
 		}
 
 		const section = this.validateSection( this.props.section );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -78,6 +78,10 @@ const ThemeSheet = React.createClass( {
 		window.scroll( 0, 0 );
 	},
 
+	isLoaded() {
+		return !! this.props.name;
+	},
+
 	hideSiteSelectorModal() {
 		this.setState( { selectedAction: null } );
 	},
@@ -186,7 +190,7 @@ const ThemeSheet = React.createClass( {
 
 		return (
 			<SectionNav className="theme__sheet-section-nav" selectedText={ filterStrings[ currentSection ] }>
-				{ this.props.name && nav }
+				{ this.isLoaded() && nav }
 			</SectionNav>
 		);
 	},
@@ -305,6 +309,10 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderPrice() {
+		if ( ! this.isLoaded() || this.isActive() ) {
+			return '';
+		}
+
 		let price = this.props.price;
 
 		if ( this.props.selectedSite && this.props.purchased ) {
@@ -316,16 +324,29 @@ const ThemeSheet = React.createClass( {
 		return <span className="theme__sheet-action-bar-cost">{ price }</span>;
 	},
 
-	renderSheet() {
-		let actionTitle = <span className="theme__sheet-button-placeholder">loading......</span>;
+	renderButton() {
+		const { isLoggedIn, price } = this.props;
+		const placeholder = <span className="theme__sheet-button-placeholder">loading......</span>;
+
+		let actionTitle;
 		if ( this.isActive() ) {
 			actionTitle = i18n.translate( 'Customize' );
-		} else if ( this.props.name ) {
-			actionTitle = this.props.isLoggedIn ? i18n.translate( 'Activate this design' ) : i18n.translate( 'Pick this design' );
+		} else if ( isLoggedIn && ! price ) {
+			actionTitle = i18n.translate( 'Activate this design' );
+		} else {
+			actionTitle = i18n.translate( 'Pick this design' );
 		}
 
+		return (
+			<Button className="theme__sheet-primary-button" onClick={ this.onPrimaryClick }>
+				{ this.isLoaded() ? actionTitle : placeholder }
+				{ this.renderPrice() }
+			</Button>
+		);
+	},
+
+	renderSheet() {
 		const section = this.validateSection( this.props.section );
-		const priceElement = this.renderPrice();
 		const siteID = this.props.selectedSite && this.props.selectedSite.ID;
 
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
@@ -352,10 +373,7 @@ const ThemeSheet = React.createClass( {
 				<HeaderCake className="theme__sheet-action-bar"
 							backHref={ this.props.backPath }
 							backText={ i18n.translate( 'All Themes' ) }>
-					<Button className="theme__sheet-primary-button" onClick={ this.onPrimaryClick }>
-						{ actionTitle }
-						{ ! this.isActive() && priceElement }
-					</Button>
+					{ this.renderButton() }
 				</HeaderCake>
 				<div className="theme__sheet-columns">
 					<div className="theme__sheet-column-left">


### PR DESCRIPTION
We got good feedback from a few users ([ref](https://en.forums.wordpress.com/topic/accidental-theme-change-wiped-css-and-customization-restore)) that they didn't expect "Pick this design" to instantly activate the theme. This is a problem right now since we have no good undo feature (to reset not just the theme, but also all the settings).

Thus **for logged in users**, we change "Pick this design":

![screen shot 2016-06-30 at 17 48 38](https://cloud.githubusercontent.com/assets/4389/16496663/e8c3df80-3eea-11e6-836f-4169d844cc87.png)

To "Activate this design":

![screen shot 2016-06-30 at 17 48 17](https://cloud.githubusercontent.com/assets/4389/16496667/f2de6ca6-3eea-11e6-8bd2-3e28242bd0b6.png)

The label stays "Pick" for logged out users because that triggers the registration flow — it's not instant.

/ht @kathrynwp 
/fyi @sirbrillig @melchoyce 

Test live: https://calypso.live/?branch=update/themes/label-activate-not-pick