### PR TITLE
Upgrades : `start/test-plans` route for testing "Plans" in NUX

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -164,6 +164,15 @@ const flows = {
 	}
 };
 
+if ( config( 'env' ) === 'development' ) {
+	flows[ 'test-plans' ] = {
+		steps: [ 'site', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'This flow is used to test plans choice in signup',
+		lastModified: '2016-06-30'
+	};
+}
+
 function removeUserStepFromFlow( flow ) {
 	if ( ! flow ) {
 		return;


### PR DESCRIPTION
This improvement is intended to make Plans testing easier in nux.
Cuts through signup flow straight to domain and plans, so that developers changing plans page can test easier.
Closes #6290

## Usage & Testing

1. Build.
2. Navigate to http://calypso.localhost:3000/start/test-plans

## Open questions

Do we want to make it even faster and prepopulate domain with something random? It will be much hackier.

## How does it look like?

<img width="497" alt="zrzut ekranu 2016-06-30 o 19 06 35" src="https://cloud.githubusercontent.com/assets/3775068/16497138/d768fab2-3ef5-11e6-85ec-bbae2e1035e6.png">

<img width="777" alt="zrzut ekranu 2016-06-30 o 19 06 47" src="https://cloud.githubusercontent.com/assets/3775068/16497143/dc5b9ac0-3ef5-11e6-91ac-7c0351a5b3b6.png">


CC @gwwar @lamosty @rralian @meremagee 



Test live: https://calypso.live/?branch=new/nux-plans-testing