### PR TITLE
Domains: Deploy checkbox variation for 'privacyCheckbox' A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -47,14 +47,6 @@ module.exports = {
 		},
 		defaultVariation: 'disabled'
 	},
-	privacyCheckbox: {
-		datestamp: '20160310',
-		variations: {
-			original: 50,
-			checkbox: 50
-		},
-		defaultVariation: 'original'
-	},
 	domainSuggestionVendor: {
 		datestamp: '20160614',
 		variations: {

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -21,7 +21,6 @@ import analytics from 'lib/analytics';
 import formState from 'lib/form-state';
 import { addPrivacyToAllDomains, removePrivacyFromAllDomains, setDomainDetails } from 'lib/upgrades/actions';
 import FormButton from 'components/forms/form-button';
-import { abtest } from 'lib/abtest';
 
 // Cannot convert to ES6 import
 const wpcom = require( 'lib/wp' ).undocumented(),
@@ -154,29 +153,28 @@ export default React.createClass( {
 		return cartItems.getDomainRegistrationsWithoutPrivacy( this.props.cart ).length === 0;
 	},
 
-	renderPrivacySection() {
-		return (
-			<PrivacyProtection
-				cart={ this.props.cart }
-				countriesList= { countriesList }
-				disabled={ formState.isSubmitButtonDisabled( this.state.form ) }
-				fields={ this.state.form }
-				isChecked={ this.allDomainRegistrationsHavePrivacy() }
-				onCheckboxChange={ this.handleCheckboxChange }
-				onButtonSelect={ this.handlePrivacyDialogButtonSelect }
-				onDialogClose={ this.closeDialog }
-				onDialogOpen={ this.openDialog }
-				onDialogSelect={ this.handlePrivacyDialogSelect }
-				isDialogVisible={ this.state.isDialogVisible }
-				productsList={ this.props.productsList } />
-		);
-	},
-
 	renderSubmitButton() {
 		return (
 			<FormButton className="checkout__domain-details-form-submit-button" onClick={ this.handleSubmitButtonClick }>
 				{ this.translate( 'Continue to Checkout' ) }
 			</FormButton>
+		);
+	},
+
+	renderPrivacySection() {
+		return (
+			<PrivacyProtection
+				cart={ this.props.cart }
+				countriesList={ countriesList }
+				disabled={ formState.isSubmitButtonDisabled( this.state.form ) }
+				fields={ this.state.form }
+				isChecked={ this.allDomainRegistrationsHavePrivacy() }
+				onCheckboxChange={ this.handleCheckboxChange }
+				onDialogClose={ this.closeDialog }
+				onDialogOpen={ this.openDialog }
+				onDialogSelect={ this.handlePrivacyDialogSelect }
+				isDialogVisible={ this.state.isDialogVisible }
+				productsList={ this.props.productsList }/>
 		);
 	},
 
@@ -244,19 +242,13 @@ export default React.createClass( {
 
 				<Input label={ this.translate( 'Postal Code', { textOnly } ) } { ...fieldProps( 'postal-code' ) }/>
 
-				{ ( abtest( 'privacyCheckbox' ) !== 'checkbox'
-					? this.renderPrivacySection()
-					: this.renderSubmitButton() ) }
+				{ this.renderSubmitButton() }
 			</div>
 		);
 	},
 
 	handleCheckboxChange() {
-		if ( this.allDomainRegistrationsHavePrivacy() ) {
-			removePrivacyFromAllDomains();
-		} else {
-			addPrivacyToAllDomains();
-		}
+		this.setPrivacyProtectionSubscriptions( ! this.allDomainRegistrationsHavePrivacy() );
 	},
 
 	closeDialog() {
@@ -299,25 +291,6 @@ export default React.createClass( {
 		} );
 	},
 
-	handlePrivacyDialogButtonSelect( options ) {
-		this.formStateController.handleSubmit( ( hasErrors ) => {
-			this.recordSubmit();
-
-			if ( hasErrors ) {
-				this.focusFirstError();
-				return;
-			}
-
-			if ( options.addPrivacy ) {
-				this.finish( { addPrivacy: true } );
-			} else if ( options.skipPrivacyDialog ) {
-				this.finish( { addPrivacy: false } );
-			} else {
-				this.openDialog();
-			}
-		} );
-	},
-
 	recordSubmit() {
 		const errors = formState.getErrorMessages( this.state.form );
 		analytics.tracks.recordEvent( 'calypso_contact_information_form_submit', {
@@ -332,7 +305,9 @@ export default React.createClass( {
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			this.recordSubmit();
 
-			if ( hasErrors ) {
+			if ( hasErrors || options.skipFinish ) {
+				this.setPrivacyProtectionSubscriptions( options.addPrivacy !== false );
+				this.closeDialog();
 				return;
 			}
 
@@ -341,13 +316,17 @@ export default React.createClass( {
 	},
 
 	finish( options = {} ) {
-		if ( options.addPrivacy ) {
-			addPrivacyToAllDomains();
-		} else if ( options.addPrivacy === false ) {
-			removePrivacyFromAllDomains();
-		}
+		this.setPrivacyProtectionSubscriptions( options.addPrivacy !== false );
 
 		setDomainDetails( formState.getAllFieldValues( this.state.form ) );
+	},
+
+	setPrivacyProtectionSubscriptions( enable ) {
+		if ( enable ) {
+			addPrivacyToAllDomains();
+		} else {
+			removePrivacyFromAllDomains();
+		}
 	},
 
 	render() {
@@ -358,10 +337,7 @@ export default React.createClass( {
 
 		return (
 			<div>
-				{ ( abtest( 'privacyCheckbox' ) === 'checkbox'
-					? this.renderPrivacySection()
-					: null ) }
-
+				{ this.renderPrivacySection() }
 				<PaymentBox
 					classSet={ classSet }
 					title={ this.translate(

--- a/client/my-sites/upgrades/checkout/privacy-protection-dialog.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection-dialog.jsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+const React = require( 'react' );
 
 /**
  * Internal dependencies
  */
-var Dialog = require( 'components/dialog' ),
+const Dialog = require( 'components/dialog' ),
 	PrivacyProtectionExample = require( './privacy-protection-example' );
 
 module.exports = React.createClass( {
@@ -35,6 +35,14 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
+		let privacyPrice = this.translate( '%(cost)s per domain / year', { args: { cost: this.props.cost } } );
+		if ( this.props.isFree ) {
+			privacyPrice =
+				<span className="privacy-free-text">
+					{ this.translate( 'Free with your plan' ) }
+				</span>;
+		}
+
 		return (
 			<Dialog additionalClassNames="privacy-protection-dialog" isVisible={ this.props.isVisible } onClose={ this.props.onClose }>
 				<header>
@@ -55,7 +63,9 @@ module.exports = React.createClass( {
 				<ul className="privacy-comparison">
 					<li className="with-privacy">
 						<h3>{ this.translate( 'With Privacy Protection' ) }</h3>
-						<div className="privacy-price">{ this.translate( '%(cost)s per domain / year', { args: { cost: this.props.cost } } ) }</div>
+						<div className="privacy-price">
+							{ privacyPrice }
+						</div>
 						<PrivacyProtectionExample
 							countriesList= { this.props.countriesList }
 							fields={ this.getProtectedFields() } />

--- a/client/my-sites/upgrades/checkout/privacy-protection-example.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection-example.jsx
@@ -1,86 +1,97 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	find = require( 'lodash/find' );
+import React from 'react';
+import find from 'lodash/find';
+import { localize } from 'i18n-calypso';
 
-module.exports = React.createClass( {
-	displayName: 'PrivacyProtectionExample',
+const PrivacyProtectionExample = ( { translate, fields, countriesList } ) => {
+	const {
+			firstName: { value: firstName },
+			lastName: { value: lastName },
+			organization: { value: organization },
+			email: { value: email },
+			address1: { value: address1 },
+			address2: { value: address2 },
+			city: { value: city },
+			state: { value: state },
+			postalCode: { value: postalCode },
+			countryCode: { value: countryCode },
+			phone: { value: phone }
+		} = fields,
+		country = countryCode && find( countriesList.get(), { code: countryCode } ),
+		lines = [];
+	let addressLine = '';
 
-	render: function() {
-		var countriesList = this.props.countriesList.get(),
-			country,
-			lines = [],
-			line = '';
-
-		if ( this.props.fields.firstName.value || this.props.fields.lastName.value ) {
-			lines.push( this.props.fields.firstName.value + ' ' + this.props.fields.lastName.value );
-		} else if ( ! this.props.fields.organization.value ) {
-			lines.push( this.translate( 'Your Name' ) );
-		}
-
-		if ( this.props.fields.organization.value ) {
-			lines.push( this.props.fields.organization.value );
-		}
-
-		if ( this.props.fields.email.value ) {
-			lines.push( this.props.fields.email.value );
-		} else {
-			lines.push( this.translate( 'Your Email' ) );
-		}
-
-		if ( this.props.fields.address1.value || this.props.fields.address2.value ) {
-			if ( this.props.fields.address1.value ) {
-				lines.push( this.props.fields.address1.value );
-			}
-
-			if ( this.props.fields.address2.value ) {
-				lines.push( this.props.fields.address2.value );
-			}
-		} else {
-			lines.push( this.translate( 'Your Address' ) );
-		}
-
-		if ( this.props.fields.city.value ) {
-			line += this.props.fields.city.value;
-		} else {
-			line += this.translate( 'Your City', { textOnly: true } );
-		}
-
-		if ( this.props.fields.state.value || this.props.fields.postalCode.value ) {
-			line += ', ';
-
-			if ( this.props.fields.state.value ) {
-				line += this.props.fields.state.value;
-			}
-
-			line += ' ';
-
-			if ( this.props.fields.postalCode.value ) {
-				line += this.props.fields.postalCode.value;
-			}
-		}
-
-		lines.push( line );
-
-		if ( this.props.fields.countryCode.value ) {
-			country = find( countriesList, { code: this.props.fields.countryCode.value } );
-		}
-
-		if ( country ) {
-			lines.push( country.name );
-		} else {
-			lines.push( this.translate( 'Your Country' ) );
-		}
-
-		if ( this.props.fields.phone.value ) {
-			lines.push( this.props.fields.phone.value );
-		} else {
-			lines.push( this.translate( 'Your Phone Number' ) );
-		}
-
-		return (
-			<p>{ lines.map( l => <span>{ l }</span> ) } </p>
-		);
+	if ( firstName || lastName ) {
+		lines.push( firstName + ' ' + lastName );
+	} else if ( ! organization ) {
+		lines.push( translate( 'Your Name' ) );
 	}
-} );
+
+	if ( organization ) {
+		lines.push( organization );
+	}
+
+	if ( email ) {
+		lines.push( email );
+	} else {
+		lines.push( translate( 'Your Email' ) );
+	}
+
+	if ( address1 || address2 ) {
+		if ( address1 ) {
+			lines.push( address1 );
+		}
+
+		if ( address2 ) {
+			lines.push( address2 );
+		}
+	} else {
+		lines.push( translate( 'Your Address' ) );
+	}
+
+	if ( city ) {
+		addressLine += city;
+	} else {
+		addressLine += translate( 'Your City' );
+	}
+
+	if ( state || postalCode ) {
+		addressLine += ', ';
+
+		if ( state ) {
+			addressLine += state;
+		}
+
+		addressLine += ' ';
+
+		if ( postalCode ) {
+			addressLine += postalCode;
+		}
+	}
+
+	lines.push( addressLine );
+
+	if ( country ) {
+		lines.push( country.name );
+	} else {
+		lines.push( translate( 'Your Country' ) );
+	}
+
+	if ( phone ) {
+		lines.push( phone );
+	} else {
+		lines.push( translate( 'Your Phone Number' ) );
+	}
+
+	return (
+		<p>{ lines.map(
+			( line, index ) => {
+				return <span key={ `privacy-protection-example-line-${ index }` }>{ line }</span>;
+			}
+		) } </p>
+	);
+};
+
+export default localize( PrivacyProtectionExample );

--- a/client/my-sites/upgrades/checkout/privacy-protection.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-const React = require( 'react' );
+const React = require( 'react' ),
+	classnames = require( 'classnames' );
 
 /**
  * Internal dependencies
@@ -9,23 +10,19 @@ const React = require( 'react' );
 const cartItems = require( 'lib/cart-values' ).cartItems,
 	PrivacyProtectionDialog = require( './privacy-protection-dialog' ),
 	Card = require( 'components/card' ),
-	Gridicon = require( 'components/gridicon' ),
-	abtest = require( 'lib/abtest' ).abtest;
+	Gridicon = require( 'components/gridicon' );
 
 module.exports = React.createClass( {
 	displayName: 'PrivacyProtection',
 
 	handleDialogSelect: function( options, event ) {
 		event.preventDefault();
-		this.props.onDialogSelect( options );
-	},
-
-	handleButtonSelect: function( options, event ) {
-		event.preventDefault();
-		this.props.onButtonSelect( options );
+		this.props.onDialogSelect( Object.assign( options, this.state ) );
+		this.setState( { skipFinish: false } );
 	},
 
 	handleDialogOpen: function() {
+		this.setState( { skipFinish: true } );
 		this.props.onDialogOpen();
 	},
 
@@ -60,107 +57,47 @@ module.exports = React.createClass( {
 
 	render: function() {
 		const numberOfDomainRegistrations = this.getNumberOfDomainRegistrations(),
-			hasOneFreePrivacy = this.hasDomainPartOfPlan() && numberOfDomainRegistrations === 1;
+			hasOneFreePrivacy = this.hasDomainPartOfPlan() && numberOfDomainRegistrations === 1,
+			privacyText = this.translate(
+				"Privacy Protection hides your personal information in your domain's public records, to protect your identity and prevent spam."
+			),
+			freeWithPlan = hasOneFreePrivacy &&
+						<span className="checkout__privacy-protection-free-text">
+							{ this.translate( 'Free with your plan' ) }
+						</span>;
 
-		if ( abtest( 'privacyCheckbox' ) === 'checkbox' ) {
-			const privacyText = this.translate( "Privacy Protection hides your personal information in your domain's public records, to protect your identity and prevent spam." ),
-				freeWithPlan = hasOneFreePrivacy &&
-							<span className="checkout__privacy-protection-free-text">
-								{ this.translate( 'Free with your plan' ) }
-							</span>;
-
-			return (
-				<div>
-					<Card className="checkout__privacy-protection-checkbox">
-						<input type="checkbox" onChange={ this.props.onCheckboxChange } checked={ this.props.isChecked } />
-						<div className="privacy-protection-checkbox__description">
+		return (
+			<div>
+				<Card className="checkout__privacy-protection-checkbox">
+					<input type="checkbox" id="privacyProtectionCheckbox" onChange={ this.props.onCheckboxChange } checked={ this.props.isChecked } />
+					<div className="checkout__privacy-protection-checkbox__description">
+						<label htmlFor="privacyProtectionCheckbox">
 							<strong className="checkout__privacy-protection-checkbox-heading">
 								{ this.translate( 'Please keep my information private.', { textOnly: true } ) }
 							</strong>
-							<p className={ 'checkout__privacy-protection-price-text' }>
-								<span className={ ( hasOneFreePrivacy && 'free-with-plan' ) }>
-									{
-										this.translate(
-											'%(cost)s per year',
-											'%(cost)s per domain per year',
-											{
-												args: { cost: this.getPrivacyProtectionCost() },
-												count: numberOfDomainRegistrations
-											}
-										)
-									}
-								</span>
-								{ freeWithPlan }
-							</p>
-							<p className="checkout__privacy-protection-checkbox-text">{ privacyText }</p>
-							<a href="" onClick={ this.handleDialogOpen }>Learn more about Privacy Protection.</a>
-						</div>
-						<div>
-							<Gridicon icon="lock" size={ 48 } />
-						</div>
-					</Card>
-					<PrivacyProtectionDialog
-						disabled={ this.props.disabled }
-						domain={ this.getFirstDomainToRegister() }
-						cost={ this.getPrivacyProtectionCost() }
-						countriesList={ this.props.countriesList }
-						fields={ this.props.fields }
-						isVisible={ this.props.isDialogVisible }
-						onSelect={ this.handleDialogSelect }
-						onClose={ this.handleDialogClose } />
-				</div>
-			);
-		}
-
-		return (
-			<div className="privacy-protection">
-				<h6>{ this.translate(
-					'Do you want {{link}}Privacy Protection{{/link}} for this domain?',
-					'Do you want {{link}}Privacy Protection{{/link}} for these domains?',
-					{
-						count: numberOfDomainRegistrations,
-						components: {
-							link: <a href="" onClick={ this.handleDialogOpen } />
-						}
-					} ) }</h6>
-				<section>
-					<label>
-						<strong>{ this.translate( 'Please keep my information private.', { textOnly: true } ) }</strong>
-						<p>{
-							this.translate(
-								'Privacy protection keeps your information hidden when this domain is searched for in the public database for an extra %(cost)s / year.',
-								'Privacy protection keeps your information hidden when these domains are searched for in the public database for an extra %(cost)s per domain / year.',
+						</label>
+						<p className={ 'checkout__privacy-protection-price-text' }>
+							<span className={ classnames( { 'free-with-plan': hasOneFreePrivacy } ) }>
 								{
-									args: { cost: this.getPrivacyProtectionCost() },
-									count: numberOfDomainRegistrations
+									this.translate(
+										'%(cost)s per year',
+										'%(cost)s per domain per year',
+										{
+											args: { cost: this.getPrivacyProtectionCost() },
+											count: numberOfDomainRegistrations
+										}
+									)
 								}
-							)
-						}</p>
-						<button
-							type="submit"
-							className="button is-primary"
-							disabled={ this.props.disabled }
-							onClick={ this.handleButtonSelect.bind( null, { addPrivacy: true } ) }>
-							{ this.translate( 'Add Privacy Protection' ) }
-						</button>
-					</label>
-					<label>
-						<strong>{ this.translate( 'No thanks, public registration is fine.', { textOnly: true } ) }</strong>
-						<p>{ this.translate(
-							'Your contact information will be viewable when people make inquires about this domain in the public database.',
-							'Your contact information will be viewable when people make inquires about these domains in the public database.',
-							{
-								count: numberOfDomainRegistrations
-							}
-						) }</p>
-						<button
-							className="button"
-							disabled={ this.props.disabled }
-							onClick={ this.handleButtonSelect.bind( null, { addPrivacy: false, skipPrivacyDialog: hasOneFreePrivacy } ) }>
-							{ this.translate( 'Publish My Information' ) }
-						</button>
-					</label>
-				</section>
+							</span>
+							{ freeWithPlan }
+						</p>
+						<p className="checkout__privacy-protection-checkbox-text">{ privacyText }</p>
+						<a href="" onClick={ this.handleDialogOpen }>Learn more about Privacy Protection.</a>
+					</div>
+					<div>
+						<Gridicon icon="lock" size={ 48 } />
+					</div>
+				</Card>
 				<PrivacyProtectionDialog
 					disabled={ this.props.disabled }
 					domain={ this.getFirstDomainToRegister() }
@@ -168,6 +105,7 @@ module.exports = React.createClass( {
 					countriesList={ this.props.countriesList }
 					fields={ this.props.fields }
 					isVisible={ this.props.isDialogVisible }
+					isFree={ hasOneFreePrivacy }
 					onSelect={ this.handleDialogSelect }
 					onClose={ this.handleDialogClose } />
 			</div>

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -745,6 +745,10 @@
 				text-align: center;
 			}
 
+			.privacy-free-text {
+				color: $alert-green;
+			}
+
 			p {
 				background: $gray-light;
 				font-size: 12px;
@@ -823,7 +827,7 @@
 	}
 }
 
-.privacy-protection-checkbox__description {
+.checkout__privacy-protection-checkbox__description {
 	font-size: 13px;
 	padding-left: 16px;
 

--- a/client/my-sites/upgrades/components/form/state-select.jsx
+++ b/client/my-sites/upgrades/components/form/state-select.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+const React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	isEmpty = require( 'lodash/isEmpty' ),
 	ReactDom = require( 'react-dom' ),
@@ -10,7 +10,7 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
+const analytics = require( 'lib/analytics' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormSelect = require( 'components/forms/form-select' ),
 	FormInputValidation = require( 'components/forms/form-input-validation' ),
@@ -29,19 +29,23 @@ module.exports = React.createClass( {
 	},
 
 	focus() {
-		var node = ReactDom.findDOMNode( this.refs.input );
-		node.focus();
-		scrollIntoViewport( node );
+		const node = ReactDom.findDOMNode( this.refs.input );
+		if ( node ) {
+			node.focus();
+			scrollIntoViewport( node );
+		} else {
+			this.refs.state.focus();
+		}
 	},
 
 	render: function() {
-		var classes = classNames( this.props.additionalClasses, 'state' ),
-			statesList = this.props.statesList.getByCountry( this.props.countryCode ),
-			options = [];
+		const classes = classNames( this.props.additionalClasses, 'state' ),
+			statesList = this.props.statesList.getByCountry( this.props.countryCode );
+		let options = [];
 
 		if ( isEmpty( statesList ) ) {
 			return (
-				<Input { ...this.props } />
+				<Input ref="state" { ...this.props } />
 			);
 		}
 
@@ -66,9 +70,9 @@ module.exports = React.createClass( {
 						onChange={ this.props.onChange }
 						onClick={ this.recordStateSelectClick }
 						isError={ this.props.isError } >
-					{ options.map( function( option ) {
-						return <option key={ option.key } value={ option.key } disabled={ option.disabled }>{ option.label }</option>;
-					} ) }
+						{ options.map( function( option ) {
+							return <option key={ option.key } value={ option.key } disabled={ option.disabled }>{ option.label }</option>;
+						} ) }
 					</FormSelect>
 				</div>
 				{ this.props.errorMessage && <FormInputValidation text={ this.props.errorMessage } isError /> }

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -99,9 +99,10 @@ var DomainSearch = React.createClass( {
 			items.push( cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } ) );
 		}
 
-		const shouldBundlePrivacy = cartItems.isNextDomainFree( this.props.cart ) || shouldBundleDomainWithPlan;
-		if ( abtest( 'privacyCheckbox' ) === 'checkbox' && shouldBundlePrivacy ) {
-			items.push( cartItems.domainPrivacyProtection( { domain: suggestion.domain_name } ) );
+		if ( cartItems.isNextDomainFree( this.props.cart ) || shouldBundleDomainWithPlan ) {
+			upgradesActions.addItem( cartItems.domainPrivacyProtection( {
+				domain: suggestion.domain_name
+			} ) );
 		}
 
 		upgradesActions.addItems( items );


### PR DESCRIPTION
Deploy the `checkbox` variation

Test:
1. Login with a user
2. Go to domains page
3. Buy a domain
4. At Contact Information screen, there should be a checkbox on the top that adds/removes privacy from all domains in cart
5. Make sure when you have domain credit from a bundle/plan that privacy is added to cart by default

Test live: https://calypso.live/?branch=update/privacy-checkbox-variation-default

@umurkontaci @klimeryk 