### PR TITLE
Jetpack Connect: Add missing period to install step

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -292,7 +292,7 @@ const JetpackConnectMain = React.createClass( {
 					<div className="jetpack-connect__install-steps">
 						<JetpackInstallStep title={ this.translate( '1. Install Jetpack' ) }
 							text={ this.props.isInstall
-									? this.translate( 'You will be redirected to your site\'s dashboard to install Jetpack. Click the blue "Install Now" button' )
+									? this.translate( 'You will be redirected to your site\'s dashboard to install Jetpack. Click the blue "Install Now" button.' )
 									: this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s dashboard to install Jetpack. Click the blue install button.' )
 								}
 							action={ this.renderAlreadyHaveJetpackButton() }


### PR DESCRIPTION
When I was looking into the `preventWidows()` functionality on the Jetpack connect steps, I notice that one of the steps had a missing period.

This PR fixes that.

After:

![screen shot 2016-06-30 at 2 27 17 pm](https://cloud.githubusercontent.com/assets/1126811/16501558/88fe7148-3ecf-11e6-938b-d9a768fba7d8.png)

To test:

- Checkout `update/jetpack-connect-missing-period` branch
- Go to `/jetpack/connect/install` and enter a site where Jetpack is installed, but not active. 
- Then click the "Don't have Jetpack installed" button in the left step

cc @johnHackworth for review.


Test live: https://calypso.live/?branch=update/jetpack-connect-missing-period