### PR TITLE
Checkout: Re-add the border to the last item on the receipt page

### DIFF
--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -20,7 +20,7 @@
 		text-align: left;
 
 		&:last-child {
-			border-bottom-width: 1px;
+			border: 1px solid lighten( $gray, 30% );
 		}
 
 		.button:not(.clipboard-button) {


### PR DESCRIPTION
The mobile styles wiped the bottom border of the last element in the product details list. This re-adds it.

Test:

1. View a checkout "thank you" page: `/checkout/thank-you/$site/$receiptID` 
2. Without patch, the last item is missing a border. With patch, it exists.
3. On smaller screens, there is no bottom border.

Before
 
![screen shot 2016-06-30 at 3 40 24 pm](https://cloud.githubusercontent.com/assets/541093/16501756/05d43514-3ed9-11e6-9f61-d9b33232f739.png)

After

![screen shot 2016-06-30 at 3 39 53 pm](https://cloud.githubusercontent.com/assets/541093/16501764/0a2a556c-3ed9-11e6-9333-dc9b4e51231d.png)

Test live: https://calypso.live/?branch=fix/checkout-missing-border