### PR TITLE
Jetpack connect new routes

### DIFF
--- a/client/lib/plans-list/README.md
+++ b/client/lib/plans-list/README.md
@@ -14,3 +14,6 @@ The get request will first check for data on the object itself, and if it finds 
 
 `fetch()`
 The fetch method will call out to the `/plans` endpoint, store the results to the `PlansList` object, emit a 'change' event, and store the new data to localStorage.
+
+`getPlanBySlug( slug )`
+Returns a plan from the current list which slug matches the searched term

--- a/client/lib/plans-list/index.js
+++ b/client/lib/plans-list/index.js
@@ -115,6 +115,25 @@ PlansList.prototype.update = function( plans ) {
 	this.data = plans;
 };
 
+/**
+ * Search in the plans list for a plan with a certain slug
+ *
+ * @param {string} slug - Slug to search
+ * @return {array} a list of plans that match the search term
+ */
+PlansList.prototype.getPlanBySlug = function( slug ) {
+	if ( ! this.data ) {
+		return null;
+	}
+	const filteredPlans = this.data.filter( ( plan ) => {
+		if ( plan && plan.product_slug === slug ) {
+			return plan;
+		}
+	} );
+
+	return filteredPlans[ 0 ];
+};
+
 // Save the plans to memory to save them being fetched
 // from the store every time the user switches sites
 let _plans;

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -25,7 +25,9 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
 		page( '/jetpack/connect/install', jetpackConnectController.install );
+
 		page( '/jetpack/connect/premium', jetpackConnectController.premium );
+
 		page( '/jetpack/connect/pro', jetpackConnectController.pro );
 
 		page( '/jetpack/connect', jetpackConnectController.connect );

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-var page = require( 'page' );
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-var controller = require( './controller' ),
-	jetpackConnectController = require( './jetpack-connect/controller' ),
-	adTracking = require( 'lib/analytics/ad-tracking' ),
-	config = require( 'config' ),
-	sitesController = require( 'my-sites/controller' );
+import controller from './controller';
+import jetpackConnectController from './jetpack-connect/controller';
+import adTracking from 'lib/analytics/ad-tracking';
+import config from 'config';
+import sitesController from 'my-sites/controller';
 
 module.exports = function() {
 	page(
@@ -25,6 +25,8 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
 		page( '/jetpack/connect/install', jetpackConnectController.install );
+		page( '/jetpack/connect/premium', jetpackConnectController.premium );
+		page( '/jetpack/connect/pro', jetpackConnectController.pro );
 
 		page( '/jetpack/connect', jetpackConnectController.connect );
 

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -38,7 +38,7 @@ const sites = sitesFactory();
 const debug = new Debug( 'calypso:jetpack-connect:controller' );
 const userModule = userFactory();
 
-const jetpackConnectFirstStep = ( context, isInstall ) => {
+const jetpackConnectFirstStep = ( context, type ) => {
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 
 	userModule.fetch();
@@ -51,7 +51,7 @@ const jetpackConnectFirstStep = ( context, isInstall ) => {
 		React.createElement( JetpackConnect, {
 			path: context.path,
 			context: context,
-			isInstall: isInstall,
+			type: type,
 			userModule: userModule,
 			locale: context.params.locale
 		} ),
@@ -93,13 +93,31 @@ export default {
 		next();
 	},
 
+	premium( context ) {
+		const analyticsBasePath = '/jetpack/connect/premium',
+			analyticsPageTitle = 'Jetpack Connect Premium';
+
+		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
+
+		jetpackConnectFirstStep( context, 'premium' );
+	},
+
+	pro( context ) {
+		const analyticsBasePath = '/jetpack/connect/pro',
+			analyticsPageTitle = 'Jetpack Install Pro';
+
+		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
+
+		jetpackConnectFirstStep( context, 'pro' );
+	},
+
 	install( context ) {
 		const analyticsBasePath = '/jetpack/connect/install',
 			analyticsPageTitle = 'Jetpack Install';
 
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
-		jetpackConnectFirstStep( context, true );
+		jetpackConnectFirstStep( context, 'install' );
 	},
 
 	connect( context ) {

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -234,6 +234,11 @@ const JetpackConnectMain = React.createClass( {
 					'then purchase and activate your plan' ),
 			};
 		}
+		return {
+			headerTitle: this.translate( 'Connect a self-hosted WordPress' ),
+			headerSubtitle: this.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect to ' +
+				'your self-hosted WordPress site.' ),
+		};
 	},
 
 	isInstall() {

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -38,7 +38,7 @@ const JetpackConnectMain = React.createClass( {
 
 	componentDidMount() {
 		let from = 'direct';
-		if ( this.props.isInstall ) {
+		if ( this.props.type === 'install' ) {
 			from = 'jpdotcom';
 		}
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
@@ -196,11 +196,35 @@ const JetpackConnectMain = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
 	},
 
+	getTexts() {
+		if ( this.props.type === 'install' ) {
+			return {
+				headerTitle: this.translate( 'Install Jetpack' ),
+				headerSubtitle: this.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect ' +
+					'to your self-hosted WordPress site.' ),
+			};
+		}
+		if ( this.props.type === 'pro' ) {
+			return {
+				headerTitle: this.translate( 'Get Jetpack Pro' ),
+				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
+					'then purchase and activate your plan' ),
+			};
+		}
+		if ( this.props.type === 'premium' ) {
+			return {
+				headerTitle: this.translate( 'Get Jetpack Premium' ),
+				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
+					'then purchase and activate your plan' ),
+			};
+		}
+	},
+
 	renderFooter() {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">{ this.translate( 'Install Jetpack Manually' ) }</LoggedOutFormLinkItem>
-				{ this.props.isInstall
+				{ this.props.type === 'install'
 					? null
 					: <LoggedOutFormLinkItem href="/start">{ this.translate( 'Start a new site on WordPress.com' ) }</LoggedOutFormLinkItem>
 				}
@@ -223,7 +247,7 @@ const JetpackConnectMain = React.createClass( {
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }
 					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() }
-					isInstall={ this.props.isInstall } />
+					isInstall={ this.props.type === 'install' } />
 			</Card>
 		);
 	},
@@ -246,8 +270,8 @@ const JetpackConnectMain = React.createClass( {
 				<div className="jetpack-connect__site-url-entry-container">
 					<ConnectHeader
 						showLogo={ false }
-						headerText={ this.translate( 'Connect a self-hosted WordPress' ) }
-						subHeaderText={ this.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect to your self-hosted WordPress site.' ) }
+						headerText={ this.getTexts().headerTitle }
+						subHeaderText={ this.getTexts().headerSubtitle }
 						step={ 1 }
 						steps={ 3 } />
 
@@ -266,8 +290,8 @@ const JetpackConnectMain = React.createClass( {
 				<div className="jetpack-connect__site-url-entry-container">
 					<ConnectHeader
 						showLogo={ false }
-						headerText={ this.translate( 'Install Jetpack' ) }
-						subHeaderText={ this.translate( 'Installing Jetpack is easy. Please start by typing your site address below and then click "Start Installation".' ) }
+						headerText={ this.getTexts().headerTitle }
+						subHeaderText={ this.getTexts().headerSubtitle }
 						step={ 1 }
 						steps={ 3 } />
 
@@ -374,7 +398,7 @@ const JetpackConnectMain = React.createClass( {
 		if ( status === 'notActiveJetpack' && ! this.props.jetpackConnectSite.isDismissed ) {
 			return this.renderActivateInstructions();
 		}
-		if ( this.props.isInstall ) {
+		if ( this.props.type === 'install' ) {
 			return this.renderSiteEntryInstall();
 		}
 		return this.renderSiteEntry();

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -16,7 +16,6 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import Main from 'components/main';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
-import { confirmJetpackInstallStatus, dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation, checkUrl } from 'state/jetpack-connect/actions';
 import { getSiteByUrl } from 'state/sites/selectors';
 import { requestSites } from 'state/sites/actions';
 import JetpackExampleInstall from './exampleComponents/jetpack-install';
@@ -27,7 +26,14 @@ import versionCompare from 'lib/version-compare';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Gridicon from 'components/gridicon';
-
+import {
+	confirmJetpackInstallStatus,
+	dismissUrl,
+	goToRemoteAuth,
+	goToPluginInstall,
+	goToPluginActivation,
+	checkUrl
+} from 'state/jetpack-connect/actions';
 /**
  * Constants
  */
@@ -40,6 +46,12 @@ const JetpackConnectMain = React.createClass( {
 		let from = 'direct';
 		if ( this.props.type === 'install' ) {
 			from = 'jpdotcom';
+		}
+		if ( this.props.type === 'pro' ) {
+			from = 'ad';
+		}
+		if ( this.props.type === 'premium' ) {
+			from = 'ad';
 		}
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from
@@ -97,7 +109,11 @@ const JetpackConnectMain = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_url: this.state.currentUrl
 		} );
-		this.props.checkUrl( this.state.currentUrl, !! this.props.getJetpackSiteByUrl( this.state.currentUrl ) );
+		this.props.checkUrl(
+			this.state.currentUrl,
+			!! this.props.getJetpackSiteByUrl( this.state.currentUrl ),
+			this.props.type
+		);
 	},
 
 	installJetpack() {
@@ -220,11 +236,17 @@ const JetpackConnectMain = React.createClass( {
 		}
 	},
 
+	isInstall() {
+		return this.props.type === 'install' || this.props.type === 'pro' || this.props.type === 'premium';
+	},
+
 	renderFooter() {
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">{ this.translate( 'Install Jetpack Manually' ) }</LoggedOutFormLinkItem>
-				{ this.props.type === 'install'
+				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
+					{ this.translate( 'Install Jetpack Manually' ) }
+				</LoggedOutFormLinkItem>
+				{ this.isInstall()
 					? null
 					: <LoggedOutFormLinkItem href="/start">{ this.translate( 'Start a new site on WordPress.com' ) }</LoggedOutFormLinkItem>
 				}
@@ -247,7 +269,7 @@ const JetpackConnectMain = React.createClass( {
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }
 					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() }
-					isInstall={ this.props.type === 'install' } />
+					isInstall={ this.isInstall() } />
 			</Card>
 		);
 	},
@@ -315,7 +337,7 @@ const JetpackConnectMain = React.createClass( {
 						steps={ 3 } />
 					<div className="jetpack-connect__install-steps">
 						<JetpackInstallStep title={ this.translate( '1. Install Jetpack' ) }
-							text={ this.props.isInstall
+							text={ this.isInstall()
 									? this.translate( 'You will be redirected to your site\'s dashboard to install Jetpack. Click the blue "Install Now" button.' )
 									: this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s dashboard to install Jetpack. Click the blue install button.' )
 								}
@@ -398,7 +420,7 @@ const JetpackConnectMain = React.createClass( {
 		if ( status === 'notActiveJetpack' && ! this.props.jetpackConnectSite.isDismissed ) {
 			return this.renderActivateInstructions();
 		}
-		if ( this.props.type === 'install' ) {
+		if ( this.isInstall() ) {
 			return this.renderSiteEntryInstall();
 		}
 		return this.renderSiteEntry();
@@ -419,5 +441,14 @@ export default connect(
 			getJetpackSiteByUrl
 		};
 	},
-	dispatch => bindActionCreators( { recordTracksEvent, confirmJetpackInstallStatus, checkUrl, dismissUrl, requestSites, goToRemoteAuth, goToPluginInstall, goToPluginActivation }, dispatch )
+	dispatch => bindActionCreators( {
+		recordTracksEvent,
+		confirmJetpackInstallStatus,
+		checkUrl,
+		dismissUrl,
+		requestSites,
+		goToRemoteAuth,
+		goToPluginInstall,
+		goToPluginActivation
+	}, dispatch )
 )( JetpackConnectMain );

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -223,7 +223,7 @@ const JetpackConnectMain = React.createClass( {
 		}
 		if ( this.props.type === 'pro' ) {
 			return {
-				headerTitle: this.translate( 'Get Jetpack Pro' ),
+				headerTitle: this.translate( 'Get Jetpack Professional' ),
 				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
 					'then purchase and activate your plan.' ),
 			};

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -169,7 +169,8 @@ const JetpackConnectMain = React.createClass( {
 			return 'notActiveJetpack';
 		}
 
-		if ( this.state.currentUrl.toLowerCase() === 'http://wordpress.com' || this.state.currentUrl.toLowerCase() === 'https://wordpress.com' ) {
+		if ( this.state.currentUrl.toLowerCase() === 'http://wordpress.com' ||
+			this.state.currentUrl.toLowerCase() === 'https://wordpress.com' ) {
 			return 'wordpress.com';
 		}
 		if ( this.checkProperty( 'isWordPressDotCom' ) ) {
@@ -224,14 +225,14 @@ const JetpackConnectMain = React.createClass( {
 			return {
 				headerTitle: this.translate( 'Get Jetpack Pro' ),
 				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
-					'then purchase and activate your plan' ),
+					'then purchase and activate your plan.' ),
 			};
 		}
 		if ( this.props.type === 'premium' ) {
 			return {
 				headerTitle: this.translate( 'Get Jetpack Premium' ),
 				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
-					'then purchase and activate your plan' ),
+					'then purchase and activate your plan.' ),
 			};
 		}
 		return {
@@ -343,8 +344,10 @@ const JetpackConnectMain = React.createClass( {
 					<div className="jetpack-connect__install-steps">
 						<JetpackInstallStep title={ this.translate( '1. Install Jetpack' ) }
 							text={ this.isInstall()
-									? this.translate( 'You will be redirected to your site\'s dashboard to install Jetpack. Click the blue "Install Now" button.' )
-									: this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s dashboard to install Jetpack. Click the blue install button.' )
+									? this.translate( 'You will be redirected to your site\'s dashboard to install ' +
+										'Jetpack. Click the blue "Install Now" button.' )
+									: this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s ' +
+										'dashboard to install Jetpack. Click the blue install button.' )
 								}
 							action={ this.renderAlreadyHaveJetpackButton() }
 							example={ <JetpackExampleInstall url={ this.state.currentUrl } /> } />
@@ -401,7 +404,8 @@ const JetpackConnectMain = React.createClass( {
 						steps={ 3 } />
 					<div className="jetpack-connect__install-steps">
 						<JetpackInstallStep title={ this.translate( '1. Activate Jetpack' ) }
-							text={ this.translate( 'You will be redirected to your site\'s dashboard to activate Jetpack. Click the blue "Activate" link.' ) }
+							text={ this.translate( 'You will be redirected to your site\'s dashboard to activate ' +
+								'Jetpack. Click the blue "Activate" link.' ) }
 							action={ this.renderNotJetpackButton() }
 							example={ <JetpackExampleActivate url={ this.state.currentUrl } isInstall={ false } /> } />
 						<JetpackInstallStep title={ this.translate( '2. Connect Jetpack' ) }

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -70,7 +70,7 @@ export default {
 		};
 	},
 
-	checkUrl( url, isUrlOnSites ) {
+	checkUrl( url, isUrlOnSites, flowType ) {
 		return ( dispatch ) => {
 			if ( _fetching[ url ] ) {
 				return;
@@ -80,12 +80,21 @@ export default {
 				dispatch( {
 					type: JETPACK_CONNECT_CHECK_URL,
 					url: url,
+					flowType: flowType
 				} );
 				setTimeout( () => {
 					dispatch( {
 						type: JETPACK_CONNECT_CHECK_URL_RECEIVE,
 						url: url,
-						data: { exists: true, isWordPress: true, hasJetpack: true, isJetpackActive: true, isJetpackConnected: true, isWordPressDotCom: false, userOwnsSite: true },
+						data: {
+							exists: true,
+							isWordPress: true,
+							hasJetpack: true,
+							isJetpackActive: true,
+							isJetpackConnected: true,
+							isWordPressDotCom: false,
+							userOwnsSite: true
+						},
 						error: null
 					} );
 				} );

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -105,6 +105,7 @@ export default {
 				dispatch( {
 					type: JETPACK_CONNECT_CHECK_URL,
 					url: url,
+					flowType: flowType
 				} );
 			}, 1 );
 			Promise.all( [

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -45,11 +45,11 @@ const defaultAuthorizeState = {
 	authorizeError: false
 };
 
-function buildNoProtocolUrlObj( url, isInstall ) {
+function buildNoProtocolUrlObj( url, flowType ) {
 	const noProtocolUrl = url.replace( /.*?:\/\//g, '' );
 	const sessionValue = {
 		timestamp: Date.now(),
-		isInstall: !! isInstall
+		flowType: flowType || ''
 	};
 	return { [ noProtocolUrl ]: sessionValue };
 }
@@ -57,7 +57,7 @@ function buildNoProtocolUrlObj( url, isInstall ) {
 export function jetpackConnectSessions( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_CHECK_URL:
-			return Object.assign( {}, state, buildNoProtocolUrlObj( action.url, action.isInstall ) );
+			return Object.assign( {}, state, buildNoProtocolUrlObj( action.url, action.flowType ) );
 		case DESERIALIZE:
 			if ( isValidStateWithSchema( state, jetpackConnectSessionsSchema ) ) {
 				return state;

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -189,8 +189,8 @@ export function jetpackSSOSessions( state = {}, action ) {
 
 export default combineReducers( {
 	jetpackConnectSite,
-	jetpackConnectAuthorize,
-	jetpackConnectSessions,
 	jetpackSSOSessions,
 	jetpackSSO,
+	jetpackConnectAuthorize,
+	jetpackConnectSessions,
 } );

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -7,7 +7,7 @@ export const jetpackConnectSessionsSchema = {
 			required: [ 'timestamp' ],
 			properties: {
 				timestamp: { type: 'number' },
-				isInstall: { type: 'boolean' }
+				flowType: { type: 'string' }
 			},
 			additionalProperties: false
 		}

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -10,4 +10,12 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 	return false;
 };
 
-export default { isCalypsoStartedConnection };
+const getFlowType = function( state, site ) {
+	const siteSlug = site.slug.replace( /.*?:\/\//g, '' );
+	if ( state && state[ siteSlug ] ) {
+		return state[ siteSlug ].flowType;
+	}
+	return false;
+};
+
+export default { isCalypsoStartedConnection, getFlowType };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/6398

This PR adds two new routes for jetpack connect, intended to be able to promote our premium & pro plans, so they can end with the user directly on the checkout screen with the plan already in the cart. 

Video of the whole flow:
https://cloudup.com/cDFOCXpYI_d

These routes are http://calypso.localhost:3000/jetpack/connect/premium

![image](https://cloud.githubusercontent.com/assets/1554855/16501871/efa2dea2-3f0b-11e6-9fb5-1db26d9c5861.png)

and http://calypso.localhost:3000/jetpack/connect/pro

![image](https://cloud.githubusercontent.com/assets/1554855/16501877/fb7a564c-3f0b-11e6-9384-7859fada09b0.png)


How to test:
=========

1. You will need a jetpack site, not connected, running latest jetpack's master
2. Go to  http://calypso.localhost:3000/jetpack/connect/premium
3. You should see the same copy than in the screencap up there.
4. Connect your site
5. After connecting your site, you should be redirected to the checkout page, and you should have your new connected site selected and a premium card should be in the shopping cart
6. Disconnect your site and repeat the same process with http://calypso.localhost:3000/jetpack/connect/pro. This time the plan in the cart should be the "proffesional" one.
![image](https://cloud.githubusercontent.com/assets/1554855/16501981/7359f028-3f0c-11e6-9264-dd025a178022.png)


ping @richardmuscat @oskosk @ryelle 

Test live: https://calypso.live/?branch=add/jetpack-connect-new-routes