### PR TITLE
Jetpack Connect: Run install step text through preventWidows when no action

### DIFF
--- a/client/signup/jetpack-connect/install-step.jsx
+++ b/client/signup/jetpack-connect/install-step.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,23 +14,22 @@ export default React.createClass( {
 	displayName: 'JetpackInstallStep',
 
 	renderText() {
-		const { action } = this.props;
-		let { text } = this.props;
+		let { text, action } = this.props;
 
-		if ( ! action ) {
-			return (
-				<span>
-					{ preventWidows( text ) }
-				</span>
+		if ( ! action || ! React.isValidElement( action ) ) {
+			text = preventWidows( text );
+		} else if ( 1 === React.Children.count( action.props.children ) ) {
+			action = React.cloneElement(
+				action,
+				omit( action.props, 'children' ),
+				React.Children.map( action.props.children, child => {
+					return preventWidows( child );
+				} )
 			);
 		}
 
 		return (
-			<span>
-				{ text }
-				<span> </span>
-				{ action }
-			</span>
+			<span>{ text } { action }</span>
 		);
 	},
 

--- a/client/signup/jetpack-connect/install-step.jsx
+++ b/client/signup/jetpack-connect/install-step.jsx
@@ -7,9 +7,31 @@ import React from 'react';
  * Internal dependencies
  */
 import Card from 'components/card';
+import { preventWidows } from 'lib/formatting';
 
 export default React.createClass( {
 	displayName: 'JetpackInstallStep',
+
+	renderText() {
+		const { action } = this.props;
+		let { text } = this.props;
+
+		if ( ! action ) {
+			return (
+				<span>
+					{ preventWidows( text ) }
+				</span>
+			);
+		}
+
+		return (
+			<span>
+				{ text }
+				<span> </span>
+				{ action }
+			</span>
+		);
+	},
 
 	render() {
 		return (
@@ -18,9 +40,9 @@ export default React.createClass( {
 					{ this.props.title }
 				</div>
 				<div className="jetpack-connect__install-step-text">
-					<span>{ this.props.text }</span> <span>{ this.props.action ? this.props.action : '' }</span>
+					{ this.renderText() }
 				</div>
-					{ this.props.example }
+				{ this.props.example }
 			</Card>
 		);
 	}


### PR DESCRIPTION
Recently, @rickybanister asked me to look over the Jetpack install steps and make sure there were no widows/orphans in the steps. 

I thought this would be quite easy since we have a `preventWidows` module in `lib/formatting`. But, that module expects to receive `text` as input. And as I thought through the process of supporting markup/components/etc., I realized I'd need to think about it a bit more.

So, what I decided to do for now is run the install text through `preventWidows` when there is no action. In practice, this means that all but the first install step should get the treatment. It also fixes the one issue that I saw (at least for English) at desktop width.

**Before:**

![screen shot 2016-06-30 at 2 59 06 pm](https://cloud.githubusercontent.com/assets/1126811/16502447/1886f7dc-3ed4-11e6-95f5-2d828a0dd8a9.png)

**After:**

![screen shot 2016-06-30 at 2 58 40 pm](https://cloud.githubusercontent.com/assets/1126811/16502466/277cc244-3ed4-11e6-80bb-08c56bc0438e.png)

To test:

- Checkout `update/jetpack-connect-fix-widows` branch
- Go to `/jetpack/connect/install` and enter a site where Jetpack is installed, but not active. 
- Then click the "Don't have Jetpack installed" button in the left step

cc @rickybanister for design review and @johnHackworth for code review.

Test live: https://calypso.live/?branch=update/jetpack-connect-fix-widows