### PR TITLE
Reader: update Cold Start intro and graduation button

### DIFF
--- a/client/reader/start/main.jsx
+++ b/client/reader/start/main.jsx
@@ -74,7 +74,7 @@ const Start = React.createClass( {
 				{ /* Have not followed a site yet */ }
 				{ ! canGraduate && hasRecommendations &&
 					<div className="reader-start__bar is-follow">
-						<span className="reader-start__bar-text">{ this.translate( 'Follow one or more sites to get started' ) }</span>
+						<span className="reader-start__bar-text">{ this.translate( 'Follow some sites to begin.' ) }</span>
 					</div>
 				}
 
@@ -84,8 +84,8 @@ const Start = React.createClass( {
 						<span className="reader-start__bar-text">
 							{
 								this.translate(
-									'Great! You\'re now following %(totalSubscriptionsDisplay)d site.',
-									'Great! You\'re now following %(totalSubscriptionsDisplay)d sites.',
+									'You\'re following %(totalSubscriptionsDisplay)d site.',
+									'You\'re following %(totalSubscriptionsDisplay)d sites.',
 									{
 										count: totalSubscriptionsDisplay,
 										args: {
@@ -95,14 +95,14 @@ const Start = React.createClass( {
 								)
 							}
 						</span>
-						<a onClick={ this.exitColdStart } className="reader-start__bar-action">{ this.translate( 'OK, I\'m all set!' ) }</a>
+						<a onClick={ this.exitColdStart } className="reader-start__bar-action">{ this.translate( 'Done.' ) }</a>
 					</div>
 				}
 
 				<QueryReaderStartRecommendations />
 				<header className="reader-start__intro">
-					<h1 className="reader-start__title">{ this.translate( 'Welcome to the WordPress.com Reader' ) }</h1>
-					<p className="reader-start__description">{ this.translate( 'Reader is like a customizable magazine with stories from your favorite places. Follow a few sites and their latest posts will appear here. Below are some suggestions – give it a try!' ) }</p>
+					<h1 className="reader-start__title">{ this.translate( 'This is Reader' ) }</h1>
+					<p className="reader-start__description">{ this.translate( 'Reader is a customizable magazine of stories from WordPress.com and across the web. Follow a few sites and their latest posts will appear here. Below are some suggestions. Give it a try!' ) }</p>
 				</header>
 
 				{ ! hasRecommendations && this.renderLoadingPlaceholders() }

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -549,31 +549,26 @@
 		display: flex;
 		padding: 0;
 		position: fixed;
-			left: 47%;
+			left: 50%;
 
 		@include breakpoint( "<660px" ) {
-		    bottom: 20px;
 			left: 5%;
 		    width: 90%;
-		    margin: 0 auto;
 		}
 
 		.reader-start__bar-text {
-			padding: 12px 15px;
-
-			@include breakpoint( "<660px" ) {
-				text-align: left;
-			}
+			padding: 13px 15px;
+			text-align: center;
+			width: 75%;
 		}
 	}
 
 	&.is-follow {
 
 		@include breakpoint( "<660px" ) {
-		    bottom: 0;
-			left: 5%;
+			bottom: 0;
+			left: 3%;
 		    width: 80%;
-		    margin: 0 auto;
 		}
 	}
 }
@@ -601,7 +596,11 @@
 	color: $white;
 	cursor: pointer;
 	margin-left: auto;
-	padding: 12px 14px 12px 13px;
+	padding: 13px 25px 13px 20px;
+
+	@include breakpoint( "<660px" ) {
+		padding: 13px 35px 13px 30px;
+	}
 
 	&:hover {
 		background: lighten( $alert-green, 15% );


### PR DESCRIPTION
This PR updates the intro copy and graduation button in Cold Start.

Before:
![screenshot 2016-06-30 16 14 14](https://cloud.githubusercontent.com/assets/4924246/16507290/b52cbaf0-3edd-11e6-9b4e-6f41d7c2d5d0.png)

After:
![screenshot 2016-06-30 16 14 34](https://cloud.githubusercontent.com/assets/4924246/16507299/bfcd2e2c-3edd-11e6-87b9-62691b1df84e.png)

Before:
![screenshot 2016-06-30 16 16 42](https://cloud.githubusercontent.com/assets/4924246/16507347/1a07ce42-3ede-11e6-9e67-a998ecba2173.png)

After:
<img width="244" alt="screenshot 2016-06-30 19 02 04" src="https://cloud.githubusercontent.com/assets/4924246/16509786/348ab1aa-3ef5-11e6-80d7-0036e1e2d93f.png">

Before:
![screenshot 2016-06-30 16 18 58](https://cloud.githubusercontent.com/assets/4924246/16507397/63813afe-3ede-11e6-95f5-aaaa5f6555de.png)

After:
![screenshot 2016-07-01 09 16 22](https://cloud.githubusercontent.com/assets/4924246/16527569/7cb4aa4a-3f6c-11e6-9f13-36f419cd3251.png)


Test live: https://calypso.live/read/start?branch=update/reader/cold-start-copy-and-grad-button