### PR TITLE
Plans: add top call to action to plans redesign

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -23,6 +23,9 @@ export const PLAN_CHARGEBACK = 'chargeback';
 
 export const POPULAR_PLANS = [ PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];
 export const JETPACK_MONTHLY_PLANS = [ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ];
+export const WPCOM_PLANS = [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ];
+export const JETPACK_PLANS = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ];
 
 export const PLAN_MONTHLY_PERIOD = 31;
 export const PLAN_ANNUAL_PERIOD = 365;
@@ -67,7 +70,9 @@ export const plansList = {
 		getProductId: () => 1,
 		getStoreSlug: () => PLAN_FREE,
 		getPathSlug: () => 'beginner',
-		getDescription: () => i18n.translate( 'Get a free blog and be on your way to publishing your first post in less than five minutes.' ),
+		getDescription: () =>
+			i18n.translate( 'Get a free blog and be on your way to publishing' +
+				' your first post in less than five minutes.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_FREE_SITE,
 			FEATURE_WP_SUBDOMAIN,
@@ -84,7 +89,8 @@ export const plansList = {
 		getStoreSlug: () => PLAN_PERSONAL,
 		availableFor: ( plan ) => includes( [ PLAN_FREE ], plan ),
 		getPathSlug: () => 'personal',
-		getDescription: () => i18n.translate( 'Use your own domain and establish your online presence without ads.' ),
+		getDescription: () => i18n.translate( 'Use your own domain and ' +
+			'establish your online presence without ads.' ),
 		getFeatures: () => [
 			FEATURE_FREE_SITE,
 			FEATURE_CUSTOM_DOMAIN,
@@ -103,7 +109,9 @@ export const plansList = {
 		getPathSlug: () => 'premium',
 		getStoreSlug: () => PLAN_PREMIUM,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
-		getDescription: () => i18n.translate( 'Your own domain name, powerful customization options, lots of space for audio and video, and $100 advertising credit.' ),
+		getDescription: () => i18n.translate( 'Your own domain name, powerful ' +
+			'customization options, lots of space for audio and video, and $100 ' +
+			'advertising credit.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_FREE_SITE,
 			FEATURE_CUSTOM_DOMAIN,
@@ -126,8 +134,13 @@ export const plansList = {
 		getStoreSlug: () => PLAN_BUSINESS,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ], plan ),
 		getPathSlug: () => 'business',
-		getDescription: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, and Google Analytics.' ),
-		getDescriptionWithWordAdsCredit: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, Google Analytics, and $200 advertising credit.' ),
+		getDescription: () => i18n.translate( 'Everything included with Premium, ' +
+			'as well as live chat support, unlimited access to premium themes, ' +
+			'and Google Analytics.' ),
+		getDescriptionWithWordAdsCredit: () => i18n.translate( 'Everything ' +
+			'included with Premium, as well as live chat support, unlimited ' +
+			'access to premium themes, Google Analytics, and $200 advertising ' +
+			'credit.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_FREE_SITE,
 			FEATURE_CUSTOM_DOMAIN,
@@ -156,7 +169,8 @@ export const plansList = {
 		getProductId: () => 2000,
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
 		getPathSlug: () => 'premium',
-		getDescription: () => i18n.translate( 'All the features you need to keep your site’s content backed up and secure, as well as spam-free.' ),
+		getDescription: () => i18n.translate( 'All the features you need to ' +
+			'keep your site’s content backed up and secure, as well as spam-free.' ),
 		getFeatures: () => [
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -174,7 +188,8 @@ export const plansList = {
 		getProductId: () => 2003,
 		getPathSlug: () => 'premium-monthly',
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
-		getDescription: () => i18n.translate( 'All the features you need to keep your site’s content backed up and secure, as well as spam-free.' ),
+		getDescription: () => i18n.translate( 'All the features you need to ' +
+			'keep your site’s content backed up and secure, as well as spam-free.' ),
 		getFeatures: () => [
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -192,7 +207,8 @@ export const plansList = {
 		getProductId: () => 2001,
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ], plan ),
 		getPathSlug: () => 'professional',
-		getDescription: () => i18n.translate( 'More powerful security tools and realtime content backup for the ultimate peace of mind.' ),
+		getDescription: () => i18n.translate( 'More powerful security tools ' +
+			'and realtime content backup for the ultimate peace of mind.' ),
 		getFeatures: () => [
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
@@ -212,8 +228,13 @@ export const plansList = {
 		getTitle: () => i18n.translate( 'Professional' ),
 		getProductId: () => 2004,
 		getPathSlug: () => 'professional-monthly',
-		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ], plan ),
-		getDescription: () => i18n.translate( 'More powerful security tools and realtime content backup for the ultimate peace of mind.' ),
+		availableFor: ( plan ) => includes( [
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY
+		], plan ),
+		getDescription: () => i18n.translate( 'More powerful security tools ' +
+			'and realtime content backup for the ultimate peace of mind.' ),
 		getFeatures: () => [
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
@@ -286,9 +307,12 @@ export const featuresList = {
 
 	[ FEATURE_GOOGLE_AD_CREDITS ]: {
 		getTitle: () => i18n.translate( 'Advertising Credit' ),
-		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25. Offer valid in US and Canada.' ),
-		getDescriptionWithWordAdsCredit: () => i18n.translate( '$100 Google AdWords credit after spending the first $25. ' +
-			'Offer valid in US and Canada. {{hr/}}Business also includes $100 of advertising from WordAds on WordPress.com.', {
+		getDescription: () => i18n.translate( '$100 Google AdWords credit after ' +
+			'spending the first $25. Offer valid in US and Canada.' ),
+		getDescriptionWithWordAdsCredit: () => i18n.translate( '$100 Google ' +
+			'AdWords credit after spending the first $25. ' +
+			'Offer valid in US and Canada. {{hr/}}Business also includes $100 ' +
+			'of advertising from WordAds on WordPress.com.', {
 				components: {
 					hr: <hr className="plans-compare__info-hr"/>
 				}
@@ -299,7 +323,8 @@ export const featuresList = {
 
 	[ WORDADS_INSTANT ]: {
 		getTitle: () => i18n.translate( 'Monetize Your Site' ),
-		getDescription: () => i18n.translate( 'Add advertising to your site through our WordAds program and get paid.' ),
+		getDescription: () => i18n.translate( 'Add advertising to your site ' +
+			'through our WordAds program and get paid.' ),
 		plans: allPaidPlans
 	},
 
@@ -400,4 +425,8 @@ export function isMonthly( plan ) {
 
 export function isPopular( plan ) {
 	return includes( POPULAR_PLANS, plan );
+}
+
+export function isJetpack( plan ) {
+	return includes( JETPACK_PLANS, plan );
 }

--- a/client/my-sites/plan-features/footer.jsx
+++ b/client/my-sites/plan-features/footer.jsx
@@ -34,6 +34,13 @@ const PlanFeaturesFooter = ( {
 				{ translate( 'Upgrade' ) }
 			</Button>
 		);
+	} else {
+		upgradeButton = (
+			<Button className="plan-features__footer-button is-hidden" disabled>
+				<Gridicon size={ 18 } icon="checkmark" />
+				{ translate( 'Downgrade' ) }
+			</Button>
+		);
 	}
 
 	const classes = classNames( 'plan-features__footer', { 'has-description': !! description } );

--- a/client/my-sites/plan-features/footer.jsx
+++ b/client/my-sites/plan-features/footer.jsx
@@ -4,6 +4,7 @@
 import { localize } from 'i18n-calypso';
 import noop from 'lodash/noop';
 import React, { PropTypes } from 'react';
+import reduce from 'lodash/reduce';
 
 /**
  * Internal dependencies
@@ -11,13 +12,35 @@ import React, { PropTypes } from 'react';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
+import {
+	isJetpack,
+	JETPACK_PLANS,
+	plansList,
+	WPCOM_PLANS
+} from 'lib/plans/constants';
+
+function getLongestDescription( planName ) {
+	if ( ! planName ) {
+		return null;
+	}
+	return reduce(
+		isJetpack( planName ) ? JETPACK_PLANS : WPCOM_PLANS,
+		( longestDescription, plan ) => {
+			const currentDescription = plansList[ plan ].getDescription();
+			return currentDescription.length > longestDescription.length
+				? currentDescription : longestDescription;
+		},
+		''
+	);
+}
 
 const PlanFeaturesFooter = ( {
 	available = true,
 	current = false,
 	description,
 	onUpgradeClick = noop,
-	translate
+	planType,
+	translate,
 } ) => {
 
 	let upgradeButton;
@@ -38,10 +61,19 @@ const PlanFeaturesFooter = ( {
 	}
 
 	const classes = classNames( 'plan-features__footer', { 'has-description': !! description } );
-
+	const longestDescription = getLongestDescription( planType );
 	return (
 		<footer className={ classes }>
-			{ description && <p className="plan-features__footer-desc">{ description }</p> }
+			{ description &&
+				<p className="plan-features__footer-desc">
+					<span className="plan-features__footer-desc-text">
+						{ description }
+					</span>
+					<span className="plan-features__footer-desc-longest">
+						{ longestDescription }
+					</span>
+				</p>
+			}
 			<div className="plan-features__footer-buttons">
 				{ upgradeButton }
 			</div>
@@ -53,7 +85,8 @@ PlanFeaturesFooter.propTypes = {
 	current: PropTypes.bool,
 	available: PropTypes.bool,
 	description: PropTypes.string,
-	onUpgradeClick: PropTypes.func
+	onUpgradeClick: PropTypes.func,
+	planType: PropTypes.string
 };
 
 export default localize( PlanFeaturesFooter );

--- a/client/my-sites/plan-features/footer.jsx
+++ b/client/my-sites/plan-features/footer.jsx
@@ -10,10 +10,18 @@ import React, { PropTypes } from 'react';
  */
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
+import classNames from 'classnames';
 
-const PlanFeaturesFooter = ( { translate, current = false, available = true, description, onUpgradeClick = noop } ) => {
+const PlanFeaturesFooter = ( {
+	available = true,
+	current = false,
+	description,
+	onUpgradeClick = noop,
+	translate
+} ) => {
+
 	let upgradeButton;
-
+	
 	if ( current ) {
 		upgradeButton = (
 			<Button className="plan-features__footer-button is-current" disabled>
@@ -29,9 +37,11 @@ const PlanFeaturesFooter = ( { translate, current = false, available = true, des
 		);
 	}
 
+	const classes = classNames( 'plan-features__footer', { 'has-description': !! description } );
+
 	return (
-		<footer className="plan-features__footer">
-			<p className="plan-features__footer-desc">{ description }</p>
+		<footer className={ classes }>
+			{ description && <p className="plan-features__footer-desc">{ description }</p> }
 			<div className="plan-features__footer-buttons">
 				{ upgradeButton }
 			</div>
@@ -42,7 +52,7 @@ const PlanFeaturesFooter = ( { translate, current = false, available = true, des
 PlanFeaturesFooter.propTypes = {
 	current: PropTypes.bool,
 	available: PropTypes.bool,
-	description: PropTypes.string.isRequired,
+	description: PropTypes.string,
 	onUpgradeClick: PropTypes.func
 };
 

--- a/client/my-sites/plan-features/footer.jsx
+++ b/client/my-sites/plan-features/footer.jsx
@@ -4,7 +4,6 @@
 import { localize } from 'i18n-calypso';
 import noop from 'lodash/noop';
 import React, { PropTypes } from 'react';
-import reduce from 'lodash/reduce';
 
 /**
  * Internal dependencies
@@ -12,39 +11,16 @@ import reduce from 'lodash/reduce';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
-import {
-	isJetpack,
-	JETPACK_PLANS,
-	plansList,
-	WPCOM_PLANS
-} from 'lib/plans/constants';
-
-function getLongestDescription( planName ) {
-	if ( ! planName ) {
-		return null;
-	}
-	return reduce(
-		isJetpack( planName ) ? JETPACK_PLANS : WPCOM_PLANS,
-		( longestDescription, plan ) => {
-			const currentDescription = plansList[ plan ].getDescription();
-			return currentDescription.length > longestDescription.length
-				? currentDescription : longestDescription;
-		},
-		''
-	);
-}
 
 const PlanFeaturesFooter = ( {
 	available = true,
 	current = false,
 	description,
 	onUpgradeClick = noop,
-	planType,
-	translate,
+	translate
 } ) => {
-
 	let upgradeButton;
-	
+
 	if ( current ) {
 		upgradeButton = (
 			<Button className="plan-features__footer-button is-current" disabled>
@@ -61,16 +37,12 @@ const PlanFeaturesFooter = ( {
 	}
 
 	const classes = classNames( 'plan-features__footer', { 'has-description': !! description } );
-	const longestDescription = getLongestDescription( planType );
 	return (
 		<footer className={ classes }>
 			{ description &&
 				<p className="plan-features__footer-desc">
 					<span className="plan-features__footer-desc-text">
 						{ description }
-					</span>
-					<span className="plan-features__footer-desc-longest">
-						{ longestDescription }
 					</span>
 				</p>
 			}
@@ -86,7 +58,6 @@ PlanFeaturesFooter.propTypes = {
 	available: PropTypes.bool,
 	description: PropTypes.string,
 	onUpgradeClick: PropTypes.func,
-	planType: PropTypes.string
 };
 
 export default localize( PlanFeaturesFooter );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -104,6 +104,7 @@ class PlanFeaturesHeader extends Component {
 	}
 
 	getPersonalPlanSvg() {
+		/* eslint-disable max-len */
 		return (
 			<svg viewBox="0 0 124 127.1">
 				<ellipse cx="62" cy="63.1" rx="62" ry="62" style={ { fill: 'rgb(211, 222, 230)' } } />
@@ -117,9 +118,11 @@ class PlanFeaturesHeader extends Component {
 				</g>
 			</svg>
 		);
+		/* eslint-enable max-len */
 	}
 
 	getFreePlanSvg() {
+		/* eslint-disable max-len */
 		return (
 			<svg viewBox="0 0 200 200">
 				<path fill="#D3DEE6" d="M133.4,7.6v98.3h-0.2c-9.1,0-16.5-7.4-16.5-16.5v0.2c0,9.1-7.4,16.5-16.5,16.5h-0.3
@@ -138,9 +141,11 @@ class PlanFeaturesHeader extends Component {
 				<path fill="#485567" d="M116.7,89.4c0,9.1,7.4,16.5,16.5,16.5h0.2V7.6c-5.4-1.9-10.9-3.4-16.7-4.4V89.4z"/>
 			</svg>
 		);
+		/* eslint-enable max-len */
 	}
 
 	getPremiumPlanSvg() {
+		/* eslint-disable max-len */
 		return (
 			<svg viewBox="0 0 124 127.1" enableBackground="new 0 0 124 127.1">
 				<circle fill="#D3DEE6" cx="62" cy="63.1" r="62"/>
@@ -338,9 +343,11 @@ class PlanFeaturesHeader extends Component {
 				</g>
 			</svg>
 		);
+		/* eslint-enable max-len */
 	}
 
 	getBusinessPlanSvg() {
+		/* eslint-disable max-len */
 		return (
 			<svg viewBox="0 0 124 127.1" enableBackground="new 0 0 124 127.1">
 				<circle fill="#D3DEE6" cx="62" cy="63.1" r="62"/>
@@ -404,6 +411,7 @@ class PlanFeaturesHeader extends Component {
 				</g>
 			</svg>
 		);
+		/* eslint-enable max-len */
 	}
 }
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -409,7 +409,9 @@ class PlanFeaturesHeader extends Component {
 
 PlanFeaturesHeader.propTypes = {
 	billingTimeFrame: PropTypes.string.isRequired,
+	currencyCode: PropTypes.string,
 	current: PropTypes.bool,
+	discountPrice: PropTypes.number,
 	onClick: PropTypes.func,
 	planType: React.PropTypes.oneOf( [
 		PLAN_FREE,
@@ -424,8 +426,6 @@ PlanFeaturesHeader.propTypes = {
 	] ).isRequired,
 	popular: PropTypes.bool,
 	rawPrice: PropTypes.number,
-	discountPrice: PropTypes.number,
-	currencyCode: PropTypes.string,
 	title: PropTypes.string.isRequired,
 	translate: PropTypes.func
 };

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -74,6 +74,7 @@ class PlanFeatures extends Component {
 				<PlanFeaturesFooter
 					available={ available }
 					current={ current }
+					planType={ planName }
 					description={ planConstantObj.getDescription() }
 					onUpgradeClick={ onUpgradeClick }
 				/>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -44,14 +44,14 @@ class PlanFeatures extends Component {
 		const {
 			available,
 			currencyCode,
-			planName,
-			rawPrice,
-			discountPrice,
-			popular,
 			current,
-			planConstantObj,
+			discountPrice,
 			features,
-			onUpgradeClick
+			onUpgradeClick,
+			planConstantObj,
+			planName,
+			popular,
+			rawPrice,
 		} = this.props;
 
 		const classes = classNames( 'plan-features', {
@@ -71,6 +71,12 @@ class PlanFeatures extends Component {
 					rawPrice={ rawPrice }
 					title={ planConstantObj.getTitle() }
 				/>
+				<PlanFeaturesFooter
+					available={ available }
+					current={ current }
+					description={ planConstantObj.getDescription() }
+					onUpgradeClick={ onUpgradeClick }
+				/>
 				<PlanFeaturesItemList>
 					{
 						features.map( ( feature, index ) =>
@@ -84,8 +90,8 @@ class PlanFeatures extends Component {
 					}
 				</PlanFeaturesItemList>
 				<PlanFeaturesFooter
-					current={ current }
 					available={ available }
+					current={ current }
 					onUpgradeClick={ onUpgradeClick }
 				/>
 			</div>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -61,15 +61,15 @@ class PlanFeatures extends Component {
 		return (
 			<div className={ classes } >
 				<PlanFeaturesHeader
-					current={ current }
-					currencyCode={ currencyCode }
-					popular={ popular }
-					title={ planConstantObj.getTitle() }
-					planType={ planName }
-					rawPrice={ rawPrice }
-					discountPrice={ discountPrice }
 					billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
+					currencyCode={ currencyCode }
+					current={ current }
+					discountPrice={ discountPrice }
 					onClick={ onUpgradeClick }
+					planType={ planName }
+					popular={ popular }
+					rawPrice={ rawPrice }
+					title={ planConstantObj.getTitle() }
 				/>
 				<PlanFeaturesItemList>
 					{
@@ -85,8 +85,7 @@ class PlanFeatures extends Component {
 				</PlanFeaturesItemList>
 				<PlanFeaturesFooter
 					current={ current }
-					available = { available }
-					description={ planConstantObj.getDescription() }
+					available={ available }
 					onUpgradeClick={ onUpgradeClick }
 				/>
 			</div>

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -251,10 +251,23 @@ $plan-features-header-banner-height: 20px;
 	font-size: 14px;
 	color: $gray;
 
+	@include breakpoint( ">960px" ) {
+		height: 105px;
+	}
+
 	&.is-placeholder {
 		@include placeholder( 23% );
 		height: 50px;
 		margin-top: 5px;
+	}
+}
+
+.plan-features__footer-button.is-hidden {
+	display: none;
+
+	@include breakpoint( ">960px" ) {
+		visibility: hidden;
+		display: inline-block;
 	}
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -195,10 +195,6 @@ $plan-features-header-banner-height: 20px;
 		border-bottom: none;
 	}
 
-	&:first-child {
-		border-top: solid 1px lighten( $gray, 27% );
-	}
-
 	&.is-placeholder {
 		padding-left: 1px;
 	}
@@ -237,6 +233,7 @@ $plan-features-header-banner-height: 20px;
 
 .plan-features__footer.has-description {
 	margin-top: 0;
+	border-bottom: solid 1px lighten( $gray, 27% );
 }
 
 .plan-features__footer {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -195,6 +195,10 @@ $plan-features-header-banner-height: 20px;
 		border-bottom: none;
 	}
 
+	&:first-child {
+		border-top: solid 1px lighten( $gray, 27% );
+	}
+
 	&.is-placeholder {
 		padding-left: 1px;
 	}
@@ -229,6 +233,10 @@ $plan-features-header-banner-height: 20px;
 		display: block;
 		height: 19px;
 	}
+}
+
+.plan-features__footer.has-description {
+	margin-top: 0;
 }
 
 .plan-features__footer {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -243,6 +243,7 @@ $plan-features-header-banner-height: 20px;
 	margin-top: auto;
 	padding: 16px 16px 24px;
 	border-top: solid 1px lighten( $gray, 27% );
+	position: relative;
 
 	@include breakpoint( ">480px" ) {
 		padding: 16px 24px 24px;
@@ -253,12 +254,22 @@ $plan-features-header-banner-height: 20px;
 	margin: 0;
 	font-size: 14px;
 	color: $gray;
+	position: relative;
 
 	&.is-placeholder {
 		@include placeholder( 23% );
 		height: 50px;
 		margin-top: 5px;
 	}
+}
+.plan-features__footer-desc-longest {
+	visibility: hidden;
+	display: inline-block;
+}
+
+.plan-features__footer-desc-text {
+	position: absolute;
+	display: inline-block;
 }
 
 .plan-features__footer-buttons {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -240,7 +240,6 @@ $plan-features-header-banner-height: 20px;
 	margin-top: auto;
 	padding: 16px 16px 24px;
 	border-top: solid 1px lighten( $gray, 27% );
-	position: relative;
 
 	@include breakpoint( ">480px" ) {
 		padding: 16px 24px 24px;
@@ -251,22 +250,12 @@ $plan-features-header-banner-height: 20px;
 	margin: 0;
 	font-size: 14px;
 	color: $gray;
-	position: relative;
 
 	&.is-placeholder {
 		@include placeholder( 23% );
 		height: 50px;
 		margin-top: 5px;
 	}
-}
-.plan-features__footer-desc-longest {
-	visibility: hidden;
-	display: inline-block;
-}
-
-.plan-features__footer-desc-text {
-	position: absolute;
-	display: inline-block;
 }
 
 .plan-features__footer-buttons {


### PR DESCRIPTION
This PR is part of #6381 and moves the plan description and a button to the top of each PlanFeatures component.

WPCOM:
<img width="968" alt="screen shot 2016-07-01 at 4 12 55 pm" src="https://cloud.githubusercontent.com/assets/1270189/16536491/1a474990-3fa7-11e6-8677-69afbaa17b4f.png">

Jetpack:
<img width="953" alt="screen shot 2016-07-01 at 4 13 05 pm" src="https://cloud.githubusercontent.com/assets/1270189/16536495/20da197c-3fa7-11e6-98ed-9204d9312be8.png">


### Implementation Notes:
- The plan description alignment is a bit of a hack, where I find the longest plan description and render it as a hidden span. A more proper fix would be to redesign this using a table or grid, but would take more time, and the component pieces would be harder to follow. If anyone can think of a better solution here, I'm all for it.
- I've also cleaned up some warnings and removed the PlanFeatures component from dev docs cc @mtias 
- I'll rename the PlanFeaturesFooter in a followup PR

### Testing Instructions
- Start Calypso with `ENABLE_FEATURES=manage/plan-features make run`
- Navigate to http://calypso.localhost:3000/plans
- Select a WPCOM site
- Verify that upgrade buttons work and that plans look correct
- Navigate to http://calypso.localhost:3000/plans
- Select a Jetpack site
- Navigate to http://calypso.localhost:3000/plans

cc @rralian @apeatling @lamosty @artpi @retrofox @shaunandrews 



Test live: https://calypso.live/?branch=add/plans-call-to-action