### PR TITLE
CPT: add TermTreeSelector to Editor Taxonomies

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -110,7 +110,7 @@ function getTermIds( post ) {
 
 		// Hack: qs omits empty arrays in wpcom.js request, which prevents
 		// removing all terms for a given taxonomy since the empty array is not sent to the API
-		return termIds.length ? termIds : [ 0 ];
+		return termIds.length ? termIds : null;
 	} );
 }
 

--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -10,6 +10,7 @@ var assign = require( 'lodash/assign' ),
 	without = require( 'lodash/without' ),
 	map = require( 'lodash/map' ),
 	pickBy = require( 'lodash/pickBy' );
+import mapValues from 'lodash/mapValues';
 
 /**
  * Internal dependencies
@@ -93,6 +94,16 @@ function getCategoryIds( post ) {
 			return category.ID;
 		}
 		return category;
+	} );
+}
+
+function getTermIds( post ) {
+	if ( ! post || ! post.terms ) {
+		return;
+	}
+
+	return mapValues( post.terms, ( taxonomy ) => {
+		return map( taxonomy, 'ID' );
 	} );
 }
 
@@ -202,6 +213,11 @@ function normalize( post ) {
 	var categoryIds = getCategoryIds( post );
 	if ( categoryIds ) {
 		post.category_ids = categoryIds;
+	}
+
+	const termIds = getTermIds( post );
+	if ( termIds ) {
+		post.terms_by_id = termIds;
 	}
 
 	post.parent_id = getParentId( post );

--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -11,6 +11,7 @@ var assign = require( 'lodash/assign' ),
 	map = require( 'lodash/map' ),
 	pickBy = require( 'lodash/pickBy' );
 import mapValues from 'lodash/mapValues';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
@@ -102,8 +103,14 @@ function getTermIds( post ) {
 		return;
 	}
 
-	return mapValues( post.terms, ( taxonomy ) => {
-		return map( taxonomy, 'ID' );
+	// Skip "default" taxonomies
+	const taxonomies = omit( post.terms, [ 'post_tag', 'category' ] );
+	return mapValues( taxonomies, ( taxonomy ) => {
+		const termIds = map( taxonomy, 'ID' );
+
+		// Hack: qs omits empty arrays in wpcom.js request, which prevents
+		// removing all terms for a given taxonomy since the empty array is not sent to the API
+		return termIds.length ? termIds : [ 0 ];
 	} );
 }
 

--- a/client/my-sites/term-tree-selector/index.jsx
+++ b/client/my-sites/term-tree-selector/index.jsx
@@ -46,7 +46,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { className, taxonomy, onChange, selected, createLink } = this.props;
+		const { className, taxonomy, onChange, selected, createLink, multiple } = this.props;
 
 		const classes = classNames( className );
 		const { search } = this.state;
@@ -64,6 +64,7 @@ export default React.createClass( {
 					query={ query }
 					selected={ selected }
 					createLink={ createLink }
+					multiple={ multiple }
 				/>
 			</div>
 		);

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -16,7 +16,7 @@ import { getPostTypeTaxonomies } from 'state/post-types/taxonomies/selectors';
 import Accordion from 'components/accordion';
 import Gridicon from 'components/gridicon';
 import TermTokenField from 'post-editor/term-token-field';
-import TermSelector from './term-selector';
+import TermSelector from 'post-editor/editor-term-selector';
 
 function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 	return (
@@ -25,50 +25,24 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 				<QueryTaxonomies { ...{ siteId, postType } } />
 			) }
 			{ map( taxonomies, ( taxonomy ) => {
+				const { name, label, hierarchical } = taxonomy;
 				if ( 'post_format' === taxonomy.name ) {
 					// Post format has its own dedicated accordion
 					return;
 				}
 
-				if ( taxonomy.hierarchical ) {
-					return (
-						<Accordion
-							key={ taxonomy.name }
-							title={ taxonomy.label }
-							icon={ <Gridicon icon="folder" /> }
-						>
-							<TermSelector
-								postTerms={ postTerms }
-								taxonomyName={ taxonomy.name }
-							/>
-						</Accordion>
-					);
-				} else {
-					return (
-						<Accordion
-							key={ taxonomy.name }
-							title={ taxonomy.label }
-							icon={ <Gridicon icon="tag" /> }
-						>
-							<TermTokenField
-								postTerms={ postTerms }
-								taxonomyName={ taxonomy.name }
-							/>
-						</Accordion>
-					);
-				}
+				const icon = hierarchical ? 'folder' : 'tag';
 
 				return (
 					<Accordion
-						key={ taxonomy.name }
-						title={ taxonomy.label }
-						icon={ <Gridicon icon="tag" /> }
+						key={ name }
+						title={ label }
+						icon={ <Gridicon icon={ icon } /> }
 					>
-						<TermTokenField
-							postTerms={ postTerms }
-							taxonomyName={ taxonomy.name }
-							taxonomyLabel={ taxonomy.label }
-						/>
+					{ hierarchical
+						? <TermSelector postTerms={ postTerms } taxonomyName={ name } />
+						: <TermTokenField postTerms={ postTerms } taxonomyName={ name } taxonomyLabel={ label } />
+					}
 					</Accordion>
 				);
 			} ).filter( Boolean ) }

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -16,6 +16,7 @@ import { getPostTypeTaxonomies } from 'state/post-types/taxonomies/selectors';
 import Accordion from 'components/accordion';
 import Gridicon from 'components/gridicon';
 import TermTokenField from 'post-editor/term-token-field';
+import TermSelector from './term-selector';
 
 function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 	return (
@@ -34,9 +35,12 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 						<Accordion
 							key={ taxonomy.name }
 							title={ taxonomy.label }
-							icon={ <Gridicon icon="category" /> }
+							icon={ <Gridicon icon="folder" /> }
 						>
-							Work in Progress
+							<TermSelector
+								selectedTermIds={ postTerms ? map( postTerms[ taxonomy.name ], 'ID' ) : [] }
+								taxonomyName={ taxonomy.name }
+							/>
 						</Accordion>
 					);
 				} else {

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -38,7 +38,7 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 							icon={ <Gridicon icon="folder" /> }
 						>
 							<TermSelector
-								selectedTermIds={ postTerms ? map( postTerms[ taxonomy.name ], 'ID' ) : [] }
+								postTerms={ postTerms }
 								taxonomyName={ taxonomy.name }
 							/>
 						</Accordion>

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -57,6 +57,20 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 						</Accordion>
 					);
 				}
+
+				return (
+					<Accordion
+						key={ taxonomy.name }
+						title={ taxonomy.label }
+						icon={ <Gridicon icon="tag" /> }
+					>
+						<TermTokenField
+							postTerms={ postTerms }
+							taxonomyName={ taxonomy.name }
+							taxonomyLabel={ taxonomy.label }
+						/>
+					</Accordion>
+				);
 			} ).filter( Boolean ) }
 		</div>
 	);

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -41,7 +41,7 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 					>
 					{ hierarchical
 						? <TermSelector postTerms={ postTerms } taxonomyName={ name } />
-						: <TermTokenField postTerms={ postTerms } taxonomyName={ name } taxonomyLabel={ label } />
+						: <TermTokenField postTerms={ postTerms } taxonomyName={ name } />
 					}
 					</Accordion>
 				);

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -26,7 +26,7 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 			) }
 			{ map( taxonomies, ( taxonomy ) => {
 				const { name, label, hierarchical } = taxonomy;
-				if ( 'post_format' === taxonomy.name ) {
+				if ( 'post_format' === name ) {
 					// Post format has its own dedicated accordion
 					return;
 				}

--- a/client/post-editor/editor-drawer/term-selector.jsx
+++ b/client/post-editor/editor-drawer/term-selector.jsx
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import map from 'lodash/map';
+import without from 'lodash/without';
+import isEqual from 'lodash/isEqual';
+import clone from 'lodash/clone';
+
+/**
+ * Internal dependencies
+ */
+import TermTreeSelector from 'my-sites/term-tree-selector';
+import PostActions from 'lib/posts/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class EditorDrawerTermSelector extends Component {
+	static propTypes = {
+		siteId: React.PropTypes.number,
+		selectedTermIds: React.PropTypes.array,
+		taxonomyName: React.PropTypes.string
+	};
+
+	constructor( props ) {
+		super( props );
+		this.boundOnTermsChange = this.onTermsChange.bind( this );
+		
+		// This does not seem like a solid approach here
+		this.state = {
+			selectedIds: props.selectedTermIds
+		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! isEqual( nextProps.selectedTermIds, this.state.selectedIds ) ) {
+			this.setState( { selectedIds: nextProps.selectedTermIds } );
+		}
+	}
+
+	onTermsChange( selectedTerm ) {
+		const { selectedTermIds, taxonomyName } = this.props;
+		let termIds = clone( this.state.selectedIds ) || [];
+
+		if ( -1 === termIds.indexOf( selectedTerm.ID ) ) {
+			termIds.push( selectedTerm.ID );
+		} else {
+			termIds = without( termIds, selectedTerm.ID );
+		}
+
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+		PostActions.edit( {
+			terms_by_id: {
+				[ taxonomyName ]: termIds
+			}
+		} );
+
+		this.setState( { selectedIds: termIds } );
+	}
+
+	render() {
+		const { siteId, taxonomyName } = this.props;
+
+		return (
+			<TermTreeSelector
+				analyticsPrefix="Editor"
+				onChange={ this.boundOnTermsChange }
+				selected={ this.state.selectedIds }
+				taxonomy={ taxonomyName }
+				siteId={ siteId }
+				multiple={ true }
+			/>
+		);
+	}
+}
+
+export default connect( ( state ) => {
+	return {
+		siteId: getSelectedSiteId( state )
+	};
+} )( EditorDrawerTermSelector );

--- a/client/post-editor/editor-drawer/term-selector.jsx
+++ b/client/post-editor/editor-drawer/term-selector.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import map from 'lodash/map';
 import without from 'lodash/without';
 import isEqual from 'lodash/isEqual';
 import clone from 'lodash/clone';
@@ -25,7 +24,7 @@ class EditorDrawerTermSelector extends Component {
 	constructor( props ) {
 		super( props );
 		this.boundOnTermsChange = this.onTermsChange.bind( this );
-		
+
 		// This does not seem like a solid approach here
 		this.state = {
 			selectedIds: props.selectedTermIds
@@ -39,7 +38,7 @@ class EditorDrawerTermSelector extends Component {
 	}
 
 	onTermsChange( selectedTerm ) {
-		const { selectedTermIds, taxonomyName } = this.props;
+		const { taxonomyName } = this.props;
 		let termIds = clone( this.state.selectedIds ) || [];
 
 		if ( -1 === termIds.indexOf( selectedTerm.ID ) ) {

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -28,7 +28,7 @@ class EditorTermSelector extends Component {
 	onTermsChange( selectedTerm ) {
 		const { postTerms, taxonomyName } = this.props;
 		const terms = cloneDeep( postTerms ) || {};
-		const taxonomyTerms = terms[ taxonomyName ];
+		const taxonomyTerms = terms[ taxonomyName ] || {};
 
 		if ( taxonomyTerms[ selectedTerm.name ] ) {
 			delete taxonomyTerms[ selectedTerm.name ];

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -13,7 +13,7 @@ import TermTreeSelector from 'my-sites/term-tree-selector';
 import PostActions from 'lib/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-class EditorDrawerTermSelector extends Component {
+class EditorTermSelector extends Component {
 	static propTypes = {
 		siteId: React.PropTypes.number,
 		postTerms: React.PropTypes.object,
@@ -69,4 +69,4 @@ export default connect( ( state ) => {
 	return {
 		siteId: getSelectedSiteId( state )
 	};
-} )( EditorDrawerTermSelector );
+} )( EditorTermSelector );


### PR DESCRIPTION
This branch brings the `<TermTreeSelector />` to the editor sidebar for custom post types that have a hierarchical taxonomy ( i.e. Portfolios ).

<img width="257" alt="edit_project_ _testingtimmy2_wordpress_com_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/16543207/b6064d54-407e-11e6-8d2a-166a8b270253.png">

After working through the items in the _Prior Implementation Notes_ below, I opted to take a similar route we have done with categories in the post editor and to leverage the `normalizer()` in the `post-edit-store` here.  Still not sure if this is the optimal route, but having the data flow from the store->components in this manner feels less hacky then tracking selections in the component state.

__To Test__
- Open the post editor for a site that has Portfolios enabled
- Edit a portfolio or create a new portfolio via the sidebar link
- Interact with both Portfolio Types term selector and Portfolio Tags token field.  Update the post and verify that changes are persisted as expected

__Known Issue__
There is a known issue with the API where if you select two terms with the same name, the API since it returns terms keyed by name, will only return one.  This bug exists for categories currently as well.  So selecting two terms with the same name will not work properly.

__Prior Implementation Notes__
Still some kinks to work out here with this approach.  I encountered some issues with the API wrt using the `terms: {}` object to update hierarchical taxonomy selections.  Updating the terms object like it is received from the API and updating a post does not save the terms, and it produces a warning on my sandbox:

```js
{
terms: {
    jetpack_portfolio_type: {
        'Some Category Name': { ... }
    }
}
```

The `TokenField` implementation sets the term object like:

```
{
    terms: {
        jetpack_portfolio_tag: [ 'some term name', 'some other term name' ]
}
```

This is marshaled into an array on the API, which subsequently looks up the term by name and all works well.  I did attempt this approach with hierarchical taxonomies, and it does work( ish ), it will not work in scenarios where there are similar term names, at different levels of a tree:

![edit_project_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/16510657/f7218944-3efc-11e6-9e4f-4575d8e8a0fe.png)

As such I went with `terms_by_id` here.  It is working well - though it doesn't seem as seamless as just reading/updating the `terms` object on the post.  There are some lingering issues too in this PR such as manipulating tags and types on a CPT during the same save request ( though should be easy enough to fix ).

For similar reasons I think this is what lead us to do hackery in the post-edit-store for categories.  It would be nice to find a solution so we don't need to revisit that approach again.

/cc @nylen @aduth 

Test live: https://calypso.live/?branch=add/cpt/term-tree-selector