### PR TITLE
Plans: Hide upgrade button if upgrading isn't possible

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -67,7 +67,7 @@ export function getSitePlanSlug( siteID ) {
 }
 
 export function canUpgradeToPlan( planKey, site = sitesList.getSelectedSite() ) {
-	const plan = get( site, [ 'plan', 'expired' ], true ) ? PLAN_FREE : get( site, [ 'plan', 'product_slug' ], PLAN_FREE );
+	const plan = get( site, [ 'plan', 'expired' ], false ) ? PLAN_FREE : get( site, [ 'plan', 'product_slug' ], PLAN_FREE );
 	return get( plansList, [ planKey, 'availableFor' ], () => false )( plan );
 }
 

--- a/client/my-sites/plan-features/footer.jsx
+++ b/client/my-sites/plan-features/footer.jsx
@@ -12,20 +12,28 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 
 const PlanFeaturesFooter = ( { translate, current = false, available = true, description, onUpgradeClick = noop } ) => {
+	let upgradeButton;
+
+	if ( current ) {
+		upgradeButton = (
+			<Button className="plan-features__footer-button is-current" disabled>
+				<Gridicon size={ 18 } icon="checkmark" />
+				{ translate( 'Your plan' ) }
+			</Button>
+		);
+	} else if ( available ) {
+		upgradeButton = (
+			<Button className="plan-features__footer-button" onClick={ onUpgradeClick } primary>
+				{ translate( 'Upgrade' ) }
+			</Button>
+		);
+	}
+
 	return (
 		<footer className="plan-features__footer">
 			<p className="plan-features__footer-desc">{ description }</p>
 			<div className="plan-features__footer-buttons">
-				{
-					current
-						? <Button className="plan-features__footer-button is-current" disabled>
-							<Gridicon size={ 18 } icon="checkmark" />
-							{ translate( 'Your plan' ) }
-						</Button>
-						: <Button className="plan-features__footer-button" { ...( available ? { onClick: onUpgradeClick, primary: true } : { disabled: true } ) }>
-							{ translate( 'Upgrade' ) }
-						</Button>
-				}
+				{ upgradeButton }
 			</div>
 		</footer>
 	);


### PR DESCRIPTION
This is a PR to address #6345. Currently, we don't support downgrades from the `/plans` page. However, if you visit the new `/plans`, you'll still see the "Upgrade" button underneath each plan regardless of whether or not you can "upgrade" to that plan or not (it's disable if not). This PR removes the upgrade button if a user cannot in fact upgrade to that plan.

I used the `current` and `available` props passed into the `PlanFeaturesFooter` component to determine whether we should render the button and which version of the button we should render. If an upgrade isn't the current upgrade on the site or an available upgrade ([logic for that here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/plans/index.js#L69)), the class `.is-empty` is added to `.plan-features_footer-buttons`. I added a style for that class that updates the height to match the normal display with a button (`height: 56px;`). I tested this out on Firefox, Chrome, and Safari as well as on mobile devices in the emulator. It feels hacky, but it appears to work fine across all devices. Any suggestions welcome though.

Related—Some design tweaks to plans in #6381 

## To test
1. Load up this branch using `ENABLE_FEATURES=manage/plan-features make run`
2. Visit http://calypso.localhost:3000/plans/yoursite.com for your site

You should see the "Upgrade" button only on plans of a higher order than your current plan. On your current plan, you'll still see the "Your plan" message. Here are the specific scenarios I tested (h/t @gwwar):

- Select a site with a free plan
- Select a site with a personal plan
- Select a site with a premium plan
- Select a site with a personal plan
- Select a site with a business plan
- Select a Jetpack Site with a free plan
- Select a Jetpack Site with a premium (monthly or annual) plan
- Select a Jetpack Site with a professional (monthly or annual ) plan

## Screenshot

Original (Site with Business plan)
![screen shot 2016-06-30 at 9 01 13 pm](https://cloud.githubusercontent.com/assets/7240478/16510718/cd580c4c-3f05-11e6-9990-99ac934d1411.png)

Updated (Site with Business plan)
![screen shot 2016-06-30 at 9 04 17 pm](https://cloud.githubusercontent.com/assets/7240478/16510771/40867f78-3f06-11e6-9dae-aecb93ad5041.png)

Test live: https://calypso.live/?branch=fix/6345-upgrade-now-appearance