### PR TITLE
GuidedTours: Add themes tour

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -201,6 +201,7 @@ class SelectDropdown extends Component {
 					aria-owns={ 'select-submenu-' + this.state.instanceId }
 					aria-controls={ 'select-submenu-' + this.state.instanceId }
 					aria-expanded={ this.state.isOpen }
+					data-tip-target={ this.props.tipTarget }
 					onClick={ this.toggleDropdown }
 				>
 					<div

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -21,7 +21,7 @@ const tours = {
 			version: '20160601',
 			path: '/',
 			// don't enable this in production (yet)
-			context: ( state ) => 'production' !== config( 'env' ) && isNewUser( state ),
+			context: ( state ) => config.isEnabled( 'guided-tours/main' ) && isNewUser( state ),
 		},
 		init: {
 			text: i18n.translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, and give you some ideas for what to do next.", {

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -10,8 +10,10 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { getSelectedSite, isPreviewShowing } from 'state/ui/selectors';
 import { isNewUser } from 'state/ui/guided-tours/selectors';
+import { getSelectedSite, getSectionName, isPreviewShowing } from 'state/ui/selectors';
+import { isFetchingNextPage, getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
+import { isDesktop } from 'lib/viewport';
 
 const tours = {
 	main: {
@@ -118,10 +120,92 @@ const tours = {
 	},
 	themes: {
 		meta: {
-			version: '20160719',
+			version: '20160609',
+			description: 'Learn how to find and activate a theme',
 			path: '/design',
-			// don't enable this in production (yet)
-			context: () => 'production' !== config( 'env' ),
+			context: ( state ) => config.isEnabled( 'guided-tours/themes' ) && isDesktop() && isNewUser( state ),
+		},
+		init: {
+			text: 'Hey there! Want me to show you how to find a great theme for your site?',
+			type: 'FirstStep',
+			placement: 'right',
+			next: 'search',
+		},
+		search: {
+			text: 'Search for a specific theme name or feature here. Try typing something — for example, "business".',
+			type: 'ActionStep',
+			target: '.themes__search-card .search-open__icon',
+			placement: 'below',
+			continueIf: state => {
+				const params = getQueryParams( state );
+				return params && params.search && params.search.length && ! isFetchingNextPage( state ) && getThemesList( state ).length > 0;
+			},
+			arrow: 'top-left',
+			next: 'filter',
+		},
+		filter: {
+			text: 'Here you can filter between free and premium themes. Try filtering by _free_ themes now.',
+			type: 'ActionStep',
+			target: 'themes-tier-dropdown',
+			placement: 'above',
+			continueIf: state => {
+				const params = getQueryParams( state );
+				return params && params.tier === 'free';
+			},
+			arrow: 'bottom-right',
+			next: 'choose-theme',
+		},
+		'choose-theme': {
+			text: "Tap on a theme to see more details — such as screenshots, the theme's features, or a preview.",
+			type: 'ActionStep',
+			placement: 'center',
+			showInContext: state => getSectionName( state ) === 'themes',
+			continueIf: state => getSectionName( state ) === 'theme',
+			next: 'tab-bar',
+		},
+		'tab-bar': {
+			text: 'Here you can take a look at more screenshots of the theme, read about its features, or get help on how to use it.',
+			type: 'BasicStep',
+			placement: 'center',
+			target: '.section-nav',
+			showInContext: state => getSectionName( state ) === 'theme',
+			next: 'live-preview',
+		},
+		'live-preview': {
+			text: 'Tap here to see a _live demo_ of the theme.',
+			type: 'ActionStep',
+			placement: 'below',
+			target: 'theme-sheet-preview',
+			showInContext: state => getSectionName( state ) === 'theme',
+			arrow: 'top-left',
+			next: 'close-preview',
+		},
+		'close-preview': {
+			target: '.web-preview.is-visible [data-tip-target="web-preview__close"]',
+			arrow: 'left-top',
+			type: 'ActionStep',
+			placement: 'beside',
+			icon: 'cross-small',
+			text: "This is the theme's preview. Take a look around! Then tap to close the preview.",
+			showInContext: state => isPreviewShowing( state ),
+			continueIf: state => ! isPreviewShowing( state ),
+			next: 'back-to-list',
+		},
+		'back-to-list': {
+			arrow: 'left-top',
+			type: 'ActionStep',
+			target: '.theme__sheet-action-bar .header-cake__back.button',
+			placement: 'beside',
+			icon: 'arrow-left',
+			text: 'You can go back to the themes list here.',
+			continueIf: state => getSectionName( state ) === 'themes',
+			next: 'finish',
+		},
+		finish: {
+			placement: 'center',
+			text: "That's it!",
+			showInContext: state => getSectionName( state ) === 'themes',
+			type: 'FinishStep',
 		},
 	},
 	test: {

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -14,7 +14,7 @@ import scrollTo from 'lib/scroll-to';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
 import { errorNotice } from 'state/notices/actions';
-import { getScrollableSidebar, query } from './positioning';
+import { getScrollableSidebar, targetForSlug } from './positioning';
 import {
 	BasicStep,
 	FirstStep,
@@ -60,17 +60,7 @@ class GuidedTours extends Component {
 	}
 
 	updateTarget( step ) {
-		this.tipTargets = this.getTipTargets();
-		this.currentTarget = step && step.target
-			? this.tipTargets[ step.target ]
-			: null;
-	}
-
-	getTipTargets() {
-		const tipTargetDomNodes = query( '[data-tip-target]' );
-		return tipTargetDomNodes.reduce( ( tipTargets, node ) => Object.assign( tipTargets, {
-			[ node.getAttribute( 'data-tip-target' ) ]: node
-		} ), {} );
+		this.currentTarget = step && step.target && targetForSlug( step.target );
 	}
 
 	next() {
@@ -79,7 +69,7 @@ class GuidedTours extends Component {
 
 		const nextTargetFound = () => {
 			if ( nextStepConfig && nextStepConfig.target ) {
-				const target = this.getTipTargets()[ nextStepConfig.target ];
+				const target = targetForSlug( nextStepConfig.target );
 				return target && target.getBoundingClientRect().left >= 0;
 			}
 			return true;

--- a/client/layout/guided-tours/steps.js
+++ b/client/layout/guided-tours/steps.js
@@ -24,7 +24,7 @@ class BasicStep extends Component {
 			'guided-tours__step',
 			'guided-tours__step-glow',
 			targetSlug && 'guided-tours__step-pointing',
-			targetSlug && arrow && 'guided-tours__step-pointing-' + getValidatedArrowPosition( {
+			targetSlug && 'guided-tours__step-pointing-' + getValidatedArrowPosition( {
 				targetSlug,
 				arrow,
 				stepPos
@@ -78,9 +78,12 @@ class FinishStep extends Component {
 				<div className="guided-tours__single-button-row">
 					<Button onClick={ onFinish } primary>{ this.props.translate( "We're all done!" ) }</Button>
 				</div>
-				<div className="guided-tours__external-link">
-					<ExternalLink target="_blank" icon={ true } href={ linkUrl }>{ linkLabel }</ExternalLink>
-				</div>
+				{
+					linkUrl && linkLabel &&
+						<div className="guided-tours__external-link">
+							<ExternalLink target="_blank" icon={ true } href={ linkUrl }>{ linkLabel }</ExternalLink>
+						</div>
+				}
 			</Card>
 		);
 	}
@@ -164,8 +167,10 @@ class ActionStep extends Component {
 					iconText: <strong>{ this.props.iconText }</strong>,
 				},
 			} );
-		} else {
+		} else if ( ! this.props.continueIf ) {
 			instructions = this.props.translate( 'Click to continue.' );
+		} else {
+			instructions = null;
 		}
 
 		const classes = [
@@ -173,7 +178,7 @@ class ActionStep extends Component {
 			'guided-tours__step-action',
 			'guided-tours__step-glow',
 			'guided-tours__step-pointing',
-			arrow && 'guided-tours__step-pointing-' + getValidatedArrowPosition( {
+			'guided-tours__step-pointing-' + getValidatedArrowPosition( {
 				targetSlug,
 				arrow,
 				stepPos
@@ -222,8 +227,8 @@ BasicStep.propTypes = {
 };
 
 ActionStep.propTypes = {
-	targetSlug: PropTypes.string.isRequired,
-	arrow: PropTypes.oneOf( ARROW_TYPES ).isRequired,
+	targetSlug: PropTypes.string,
+	arrow: PropTypes.oneOf( ARROW_TYPES ),
 	placement: PropTypes.string,
 	// text can be a translated string or a translated string with components
 	text: PropTypes.oneOfType( [

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -39,6 +39,7 @@
 	animation-timing-function: ease-out;
 	animation-delay: 2s;
 	animation-fill-mode: both;
+	width: calc( 100% - 10px );
 }
 
 .guided-tours__step-finish {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -154,7 +154,7 @@ const ThemeSheet = React.createClass( {
 		const img = <img className="theme__sheet-img" src={ this.getFullLengthScreenshot() + '?=w680' } />;
 		return (
 			<div className="theme__sheet-screenshot">
-				<a className="theme__sheet-preview-link" onClick={ this.togglePreview } >
+				<a className="theme__sheet-preview-link" onClick={ this.togglePreview } data-tip-target="theme-sheet-preview">
 					<Gridicon icon="themes" size={ 18 } />
 					<span className="theme__sheet-preview-link-text">
 						{ i18n.translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -78,7 +78,7 @@ const ThemesSearchCard = React.createClass( {
 		const selectedTiers = isPremiumThemesEnabled ? tiers : [ tiers.find( tier => tier.value === 'free' ) ];
 
 		return (
-			<div className="themes__search-card">
+			<div className="themes__search-card" data-tip-target="themes-search-card">
 				<SectionNav selectedText={ this.getSelectedTierFormatted( tiers ) }>
 					<NavTabs>
 						{ ! isJetpack && this.getTierNavItems( selectedTiers ) }
@@ -123,7 +123,7 @@ const ThemesSearchCard = React.createClass( {
 		}
 
 		return (
-			<div className="themes__search-card">
+			<div className="themes__search-card" data-tip-target="themes-search-card">
 				<Search
 					onSearch={ this.props.onSearch }
 					initialValue={ this.props.search }

--- a/client/my-sites/themes/themes-search-card/select-dropdown.jsx
+++ b/client/my-sites/themes/themes-search-card/select-dropdown.jsx
@@ -49,6 +49,7 @@ const ThemesSelectDropdown = React.createClass( {
 		return <SelectDropdown
 				style={ this.state.style }
 				initialSelected={ this.props.tier }
+				tipTarget="themes-tier-dropdown"
 				{ ...this.props } />;
 	}
 } );

--- a/client/state/ui/guided-tours/test/config.js
+++ b/client/state/ui/guided-tours/test/config.js
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import { isNewUser } from 'state/ui/guided-tours/selectors';
+import { getSectionName } from 'state/ui/selectors';
+
+const tours = {
+	main: {
+		meta: {
+			version: 'test',
+			path: '/',
+			context: state => isNewUser( state ),
+		},
+		init: {
+			text: "Need a hand? We'd love to show you around the place.",
+			type: 'FirstStep',
+			placement: 'right',
+		},
+	},
+	themes: {
+		meta: {
+			version: 'test',
+			path: '/design',
+			context: () => true,
+		},
+		description: 'Learn how to find and activate a theme',
+		showInContext: state => getSectionName( state ) === 'themes',
+		init: {
+			text: 'Hey there! Want me to show you how to find a great theme for your site?',
+			type: 'FirstStep',
+			placement: 'right',
+		},
+	},
+	test: {
+		meta: {
+			version: 'test',
+			path: '/test',
+			context: () => true,
+		},
+	},
+};
+
+export default {
+	get: tour => tours[ tour ] || null,
+	getAll: () => tours,
+};

--- a/client/state/ui/guided-tours/test/selectors.js
+++ b/client/state/ui/guided-tours/test/selectors.js
@@ -7,12 +7,22 @@ import { constant, times } from 'lodash';
 /**
  * Internal dependencies
  */
-import {
-	getGuidedTourState,
-	findEligibleTour,
-} from '../selectors';
+import useMockery from 'test/helpers/use-mockery';
 
 describe( 'selectors', () => {
+	let getGuidedTourState;
+	let findEligibleTour;
+
+	useMockery( mockery => {
+		mockery.registerSubstitute(
+				'layout/guided-tours/config',
+				'state/ui/guided-tours/test/config' );
+
+		const selectors = require( '../selectors' );
+		getGuidedTourState = selectors.getGuidedTourState;
+		findEligibleTour = selectors.findEligibleTour;
+	} );
+
 	describe( '#getGuidedTourState()', () => {
 		it( 'should return an empty object if no state is present', () => {
 			const tourState = getGuidedTourState( {

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
 		"guided-tours": true,
+		"guided-tours/themes": true,
 		"help": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
 		"guided-tours": true,
+		"guided-tours/main": false,
 		"guided-tours/themes": true,
 		"help": true,
 		"jetpack/connect": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,6 +24,7 @@
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
 		"guided-tours": true,
+		"guided-tours/themes": true,
 		"help": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,6 +24,7 @@
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
 		"guided-tours": true,
+		"guided-tours/main": false,
 		"guided-tours/themes": true,
 		"help": true,
 		"jetpack/connect": true,


### PR DESCRIPTION
A basic themes tour. Used to help us develop the GuidedTours framework. Initially, we'll just push this out into wpcalypso, to get some more eyes on the steps, their flow, and their content.

![themes-1](https://cloud.githubusercontent.com/assets/215074/17056525/c2506436-500b-11e6-825c-2befb6500228.gif)


TODO:-
- [x] Only enable for development and wpcalypso

Test via: http://calypso.localhost:3000/design/[somesite]?tour=themes

Test live: https://calypso.live/?branch=add/themes-tour