### PR TITLE
Reader: exclude user's owned blogs from following count in Cold Start

### DIFF
--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -298,6 +298,11 @@ function addSubscription( subscription, addToTop = true ) {
 	subscriptions.count++;
 	totalSubscriptions++;
 
+	// If we have information about whether the user is the owner of the blog, increment the count
+	if ( newSubscription.has( 'is_owner' ) && ! newSubscription.get( 'is_owner' ) ) {
+		totalSubscriptionsExcludingOwned++;
+	}
+
 	return true;
 }
 
@@ -344,6 +349,11 @@ function updateSubscription( url, newSubscriptionInfo ) {
 
 	if ( existingSubscription.get( 'state' ) === States.UNSUBSCRIBED && updatedSubscription.get( 'state' ) === States.SUBSCRIBED ) {
 		totalSubscriptions++;
+	}
+
+	// If we have information about whether the user is the owner of the blog, increment the count
+	if ( updatedSubscription.has( 'is_owner' ) && ! updatedSubscription.get( 'is_owner' ) ) {
+		totalSubscriptionsExcludingOwned++;
 	}
 
 	return true;

--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -33,6 +33,7 @@ var subscriptions = clone( subscriptionsTemplate ),
 	isLastPage = false,
 	isFetching = false,
 	totalSubscriptions = 0,
+	totalSubscriptionsExcludingOwned = 0,
 	subscriptionTemplate = Immutable.Map( { // eslint-disable-line new-cap
 		state: States.SUBSCRIBED
 	} );
@@ -166,6 +167,7 @@ var FeedSubscriptionStore = {
 
 		if ( currentPage === 1 ) {
 			totalSubscriptions = data.total_subscriptions;
+			totalSubscriptionsExcludingOwned = data.total_subscriptions_excluding_owned;
 		}
 		subscriptions.count = subscriptions.list.count();
 
@@ -189,6 +191,10 @@ var FeedSubscriptionStore = {
 
 	getTotalSubscriptions: function() {
 		return totalSubscriptions;
+	},
+
+	getTotalSubscriptionsExcludingOwned() {
+		return totalSubscriptionsExcludingOwned;
 	},
 
 	getLastError: function() {
@@ -232,6 +238,7 @@ var FeedSubscriptionStore = {
 	clearSubscriptions: function() {
 		subscriptions = clone( subscriptionsTemplate );
 		totalSubscriptions = 0;
+		totalSubscriptionsExcludingOwned = 0;
 	},
 
 	isLastPage: function() {
@@ -353,6 +360,10 @@ function removeSubscription( subscription ) {
 
 	if ( totalSubscriptions > 0 ) {
 		totalSubscriptions--;
+	}
+
+	if ( totalSubscriptionsExcludingOwned > 0 ) {
+		totalSubscriptionsExcludingOwned--;
 	}
 
 	return true;

--- a/client/lib/reader-feed-subscriptions/test/index.js
+++ b/client/lib/reader-feed-subscriptions/test/index.js
@@ -333,4 +333,34 @@ describe( 'store', function() {
 		expect( FeedSubscriptionStore.getSubscriptions().list.count() ).to.eql( 3 );
 		expect( FeedSubscriptionStore.getSubscriptions().list.get( 1 ).get( 'feed_ID' ) ).to.eql( 456 );
 	} );
+
+	it( 'should not increment the totalSubscriptionsExcludingOwned count if the user is the owner of the blog', function() {
+		const siteUrl = 'http://www.tomato.com';
+
+		// The initial action from the UI
+		Dispatcher.handleViewAction( {
+			type: 'FOLLOW_READER_FEED',
+			url: siteUrl,
+			data: { url: siteUrl },
+			error: null
+		} );
+
+		// The action from the API response
+		Dispatcher.handleServerAction( {
+			type: 'RECEIVE_FOLLOW_READER_FEED',
+			url: siteUrl,
+			data: {
+				subscribed: true,
+				subscription: {
+					URL: siteUrl,
+					feed_ID: 123,
+					is_owner: true
+				}
+			}
+		} );
+
+		expect( FeedSubscriptionStore.getIsFollowingBySiteUrl( 'https://www.tomato.com' ) ).to.eq( true );
+		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 1 );
+		expect( FeedSubscriptionStore.getTotalSubscriptionsExcludingOwned() ).to.eq( 0 );
+	} );
 } );

--- a/client/reader/start/main.jsx
+++ b/client/reader/start/main.jsx
@@ -39,7 +39,7 @@ const Start = React.createClass( {
 
 	getStateFromStores() {
 		return {
-			totalSubscriptions: FeedSubscriptionStore.getTotalSubscriptions()
+			totalSubscriptionsExcludingOwned: FeedSubscriptionStore.getTotalSubscriptionsExcludingOwned()
 		};
 	},
 
@@ -60,11 +60,8 @@ const Start = React.createClass( {
 	},
 
 	render() {
-		const totalSubscriptions = this.state.totalSubscriptions;
-
-		// Reduce the total subscription count by one for display (exclude the user's own site)
-		const totalSubscriptionsDisplay = totalSubscriptions > 0 ? totalSubscriptions - 1 : 0;
-		const canGraduate = ( this.state.totalSubscriptions > 1 );
+		const totalSubscriptionsExcludingOwned = this.state.totalSubscriptionsExcludingOwned;
+		const canGraduate = ( totalSubscriptionsExcludingOwned > 0 );
 		const hasRecommendations = this.props.recommendationIds.length > 0;
 
 		return (
@@ -82,12 +79,12 @@ const Start = React.createClass( {
 						<span className="reader-start__bar-text">
 							{
 								this.translate(
-									'You\'re following %(totalSubscriptionsDisplay)d site.',
-									'You\'re following %(totalSubscriptionsDisplay)d sites.',
+									'Great! You\'re now following %(totalSubscriptions)d site.',
+									'Great! You\'re now following %(totalSubscriptions)d sites.',
 									{
-										count: totalSubscriptionsDisplay,
+										count: totalSubscriptionsExcludingOwned,
 										args: {
-											totalSubscriptionsDisplay: totalSubscriptionsDisplay
+											totalSubscriptions: totalSubscriptionsExcludingOwned
 										}
 									}
 								)

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -143,5 +143,5 @@
 		{ "value": 452, "langSlug": "zh-tw", "name": "zh-tw - 繁體中文", "wpLocale": "zh_TW", "popular": 14 }
 	],
 	"project": "wordpress-com",
-	"reader_cold_start_graduation_threshold": 2
+	"reader_cold_start_graduation_threshold": 1
 }


### PR DESCRIPTION
In Reader Cold Start, we encourage users to follow at least one blog before moving on.

When a new user signs up, they're auto-followed to their own blog. This means that the user is following one blog before they see Cold Start.

Previously we auto-removed 1 from the user's following count, but that was a crude solution and caused confusing amongst those testing Cold Start.

This PR changes to use the new `is_owner` and `total_subscriptions_excluding_owned` values from the API instead.

Automatticians: this currently requires the API to be patched with D2150.

Test live: https://calypso.live/?branch=fix/reader/cold-start-following-count