### PR TITLE
Framework: Reuse computed attributes from `site` to `getSite` selector

### DIFF
--- a/client/lib/site/computed-attributes.js
+++ b/client/lib/site/computed-attributes.js
@@ -1,0 +1,61 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import trim from 'lodash/trim';
+
+/**
+ * Internal dependencies
+ */
+import { isHttps } from 'lib/url';
+import config from 'config';
+
+export default function( site ) {
+	const attributes = {};
+
+	// If the user has no access to site.options create it as an empty
+	// attribute to avoid potential errors when trying to access its sub properties
+	attributes.options = site.options || {};
+
+	// Add URL without protocol as a `domain` attribute
+	if ( site.URL ) {
+		attributes.domain = site.URL.replace( /^https?:\/\//, '' );
+		attributes.slug = attributes.domain.replace( /\//g, '::' );
+	}
+	attributes.title = trim( site.name ) || attributes.domain;
+
+	// If a WordPress.com site has a mapped domain create a `wpcom_url`
+	// attribute to allow site selection with either domain.
+	if ( attributes.options && attributes.options.is_mapped_domain && ! site.is_jetpack ) {
+		attributes.wpcom_url = site.options.unmapped_url.replace( /^https?:\/\//, '' );
+	}
+
+	// If a site has an `is_redirect` property use the `unmapped_url`
+	// for the slug and domain to match the wordpress.com original site.
+	if ( ( attributes.options && attributes.options.is_redirect ) || site.hasConflict ) {
+		attributes.slug = attributes.options.unmapped_url.replace( /^https?:\/\//, '' );
+		attributes.domain = attributes.slug;
+	}
+
+	// The 'standard' post format is saved as an option of '0'
+	if ( ! attributes.options.default_post_format || attributes.options.default_post_format === '0' ) {
+		attributes.options.default_post_format = 'standard';
+	}
+
+	//TODO:(ehg) Pull out into selector when my-sites/sidebar is connected
+	attributes.is_previewable = !! (
+		config.isEnabled( 'preview-layout' ) &&
+		attributes.options.unmapped_url &&
+		! site.is_vip &&
+		isHttps( attributes.options.unmapped_url )
+	);
+
+	//TODO:(ehg) Replace instances with canCurrentUser selector when my-sites/sidebar is connected
+	attributes.is_customizable = !! (
+		site.capabilities &&
+		site.capabilities.edit_theme_options
+	);
+
+	return attributes;
+}

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -13,7 +13,6 @@ export const sitesSchema = {
 				jetpack: { type: 'boolean' },
 				post_count: { type: 'number' },
 				subscribers_count: { type: 'number' },
-				slug: { type: 'string' },
 				lang: { type: 'string' },
 				icon: {
 					type: 'object',
@@ -35,10 +34,8 @@ export const sitesSchema = {
 				is_following: { type: 'boolean' },
 				options: { type: 'object' },
 				meta: { type: 'object' },
-				user_can_manager: { type: 'boolean' },
+				user_can_manage: { type: 'boolean' },
 				is_vip: { type: 'boolean' },
-				is_previewable: { type: 'boolean' },
-				is_customizable: { type: 'boolean' },
 				is_multisite: { type: 'boolean' },
 				capabilities: {
 					type: 'object',

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -165,7 +165,7 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', slug: 'example.wordpress.com' }
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
 			} );
 		} );
 
@@ -181,7 +181,7 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', slug: 'example.wordpress.com' }
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
 			} );
 		} );
 

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -30,7 +30,7 @@ describe( 'selectors', () => {
 			const selected = getSelectedSite( {
 				sites: {
 					items: {
-						2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
+						2916284: { ID: 2916284, name: 'WordPress.com Example Blog', URL: 'https://example.com' }
 					}
 				},
 				ui: {
@@ -38,7 +38,20 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			expect( selected ).to.eql( { ID: 2916284, name: 'WordPress.com Example Blog' } );
+			expect( selected ).to.eql( {
+				ID: 2916284,
+				name: 'WordPress.com Example Blog',
+				URL: 'https://example.com',
+				domain: 'example.com',
+				hasConflict: false,
+				is_customizable: false,
+				is_previewable: false,
+				options: {
+					default_post_format: 'standard',
+				},
+				slug: 'example.com',
+				title: 'WordPress.com Example Blog',
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
We don't want computed attributes in the state tree, so let's put them in the `getSite` selector.

- Extracted computed attrs logic into its own module
- Updated `site` to use new module
- Update `getSite` selector to append computed attrs
- Compose `getSite`'s site with the selectors we already have
- Remove computed attrs from schema

/cc @mtias 

TODO:
- [x] Fix/add tests

To test:
 - Since this affects anything that uses `site`, both in the old manner (`sites-list`), and anything using the `getSite` selector. Make sure the various sections work as expected.

Test live: https://calypso.live/?branch=add/computed-attrs-to-getSite-selector