### PR TITLE
Reader: move Cold Start to /recommendations/start

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -170,7 +170,7 @@ module.exports = {
 			if ( FeedSubscriptionStore.getCurrentPage() > 0 || FeedSubscriptionStore.isLastPage() ) {
 				// we have total subs now, make the decision
 				if ( FeedSubscriptionStore.getTotalSubscriptions() < config( 'reader_cold_start_graduation_threshold' ) ) {
-					defer( page.redirect.bind( page, '/read/start' ) );
+					defer( page.redirect.bind( page, '/recommendations/start' ) );
 				} else {
 					defer( next );
 				}

--- a/client/reader/start/controller.js
+++ b/client/reader/start/controller.js
@@ -15,7 +15,7 @@ const analyticsPageTitle = 'Reader';
 
 export function start( context ) {
 	const startComponent = require( 'reader/start/main' ),
-		basePath = '/read/start',
+		basePath = '/recommendations/start',
 		fullAnalyticsPageTitle = analyticsPageTitle + ' > Start',
 		mcKey = 'start';
 

--- a/client/reader/start/index.js
+++ b/client/reader/start/index.js
@@ -10,5 +10,5 @@ import { start } from './controller';
 import readerController from 'reader/controller';
 
 export default function() {
-	page( '/read/start', readerController.updateLastRoute, readerController.removePost, readerController.sidebar, start );
+	page( '/recommendations/start', readerController.loadSubscriptions, readerController.updateLastRoute, readerController.removePost, readerController.sidebar, start );
 }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -288,7 +288,7 @@ if ( config.isEnabled( 'reader' ) ) {
 	if ( config.isEnabled( 'reader/start' ) ) {
 		sections.push( {
 			name: 'reader-start',
-			paths: [ '/read/start' ],
+			paths: [ '/recommendations/start' ],
 			module: 'reader/start',
 			secondary: true,
 			group: 'reader'


### PR DESCRIPTION
Reader Cold Start currently lives at `/read/start`. As it serves recommendations, we thought it'd make more sense at `/recommendations/start`.

It'd be good to move the `start` folder inside `reader/recommendations` later, but doing so now will scupper all the other Cold Start PRs in the works.

Todo:
- [x] Change route to /recommendations/start

Test live: https://calypso.live/?branch=fix/reader/move-cold-start-path-under-recommendations