### PR TITLE
Log errors to Google Analytics

### DIFF
--- a/public/catch-js-errors.js
+++ b/public/catch-js-errors.js
@@ -118,6 +118,20 @@
 					savedWindowOnError();
 				}
 			};
+		} else if ( localStorage.getItem( 'log-errors' ) === 'analytics' ) {
+			window.onerror = function( message, scriptUrl, lineNumber ) {
+				if ( typeof window.ga === 'function' ) {
+					window.ga(
+						'send',
+						'event',
+						'JS Error',
+						message,
+						'URL: ' + document.location.href + '| ' + scriptUrl + ':' + lineNumber,
+						0,
+						{ nonInteraction: true }
+					);
+				}
+			};
 		}
 	}
 }() );

--- a/public/catch-js-errors.js
+++ b/public/catch-js-errors.js
@@ -1,6 +1,7 @@
 ( function() {
 	var savedWindowOnError = window.onerror,
 		assignment = 1,
+		localStorageAssignment = 'false',
 		savedErrors = [],
 		lastTimeSent = 0,
 		packTimeout = null,
@@ -93,13 +94,15 @@
 
 	if ( isLocalStorageNameSupported() ) {
 		assignment = Math.random();
+		localStorageAssignment = localStorage.getItem( 'log-errors' );
 		// Randomly assign 1% of users to log errors
-		if ( ! localStorage.getItem( 'log-errors' ) ) {
+		if ( ! localStorageAssignment ) {
 			if ( assignment <= 0.01 ) {
 				localStorage.setItem( 'log-errors', 'rest-api' );
+				localStorageAssignment = 'rest-api';
 			} else if ( assignment <= 0.02 ) {
 				localStorage.setItem( 'log-errors', 'analytics' );
-				//Prep the stage up for GA logging experiment
+				localStorageAssignment = 'analytics';
 			} else if ( assignment <= 0.03 ) {
 				localStorage.setItem( 'log-errors', 'external' );
 				//Prep the stage up for Google Stackdriver or other service experiment
@@ -108,8 +111,8 @@
 			}
 		}
 
-		if ( localStorage.getItem( 'log-errors' ) !== undefined &&
-			( localStorage.getItem( 'log-errors' ) === 'rest-api' || localStorage.getItem( 'log-errors' ) === 'true' )
+		if ( localStorageAssignment !== undefined &&
+			( localStorageAssignment === 'rest-api' || localStorageAssignment === 'true' )
 		) {
 			// set up handler to POST errors
 			window.onerror = function( message, scriptUrl, lineNumber, columnNumber, error ) {
@@ -118,7 +121,7 @@
 					savedWindowOnError();
 				}
 			};
-		} else if ( localStorage.getItem( 'log-errors' ) === 'analytics' ) {
+		} else if ( localStorageAssignment === 'analytics' ) {
 			window.onerror = function( message, scriptUrl, lineNumber ) {
 				if ( typeof window.ga === 'function' ) {
 					window.ga(

--- a/public/catch-js-errors.js
+++ b/public/catch-js-errors.js
@@ -134,6 +134,9 @@
 						{ nonInteraction: true }
 					);
 				}
+				if ( savedWindowOnError ) {
+					savedWindowOnError();
+				}
 			};
 		}
 	}


### PR DESCRIPTION
In #6360 with @scruffian we introduced error logging mechanism that logs errors to our REST-API endpoint.
That is all dandy, we have plenty errors in our IRC channel, but we would like so much more context!
Well, there is a place we have plenty of context for current user already:

#### Google analytics

This PR sends errors from 1% of our users to Google Analytics, so we can slice & dice and extract valuable data.

## Testing 

Because GA script works only for non-proxied `wordpress.com`, this is not going to be easy.

- Grab credentials to our `Atlas&Calypso` GA property
- Un-proxy yourself ( serious stuff! )
- restart browser so you are really unproxied
- Remove hardcoded protection in `server/pages/index.jade` (to test you need to remove the line "development") :
```
		if 'development' !== env
			script( src=urls['catch-js-errors.js'] )
```
- break something [ call potato() in some render for example ]
- build project (after removing the line - the live reload does not work for jade)
- Put yourself in logging group: `localStorage.setItem('log-errors', 'analytics');`
- hard reload
- Validate that you have onerror script `window.onerror`
- Spoof GA call in your console: `window.ga = ( ...args ) => console.log( JSON.stringify( args ) );`
- navigate where you broke stuff
- see error on console. Copy the content without `[]`.
- Navigate to http://wordpress.com
- Call GA script with copied data. It should look like: 
```
window.ga("send","event","JS Error","Uncaught ReferenceError: potato is not defined","URL: http://calypso.localhost:3000/stats/insights/artpitesting17.wordpress.com| http://calypso.localhost:3000/stats/insights/artpitesting17.wordpress.com:26",0,{"nonInteraction":true});
```
- [ENTER]
- Open GA `Real Time` -> `Events` -> `Events (Last 30 min)`
- Search `JS Error` on the search box
- See your error.
- Profit.

<img width="1166" alt="zrzut ekranu 2016-07-01 o 17 03 16" src="https://cloud.githubusercontent.com/assets/3775068/16526332/0140fd9c-3fb1-11e6-922f-3bc4f76a5cd2.png">


CC @gwwar @rralian @scruffian 


Test live: https://calypso.live/?branch=update/errors-analytics