### PR TITLE
Plans: add tooltip info to each feature entry

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -69,7 +69,12 @@ class PlanFeatures extends Component {
 				<PlanFeaturesItemList>
 					{
 						features.map( ( feature, index ) =>
-							<PlanFeaturesItem key={ index }>{ feature.getTitle() }</PlanFeaturesItem>
+							<PlanFeaturesItem
+								key={ index }
+								description={ feature.getDescription ? feature.getDescription() : null }
+							>
+								{ feature.getTitle() }
+							</PlanFeaturesItem>
 						)
 					}
 				</PlanFeaturesItemList>
@@ -117,7 +122,7 @@ export default connect( ( state, ownProps ) => {
 		features: getPlanFeaturesObject( ownProps.plan ),
 		rawPrice: getPlanRawPrice( state, planProductId, showMonthly ),
 		planConstantObj: plansList[ ownProps.plan ],
-		available : canUpgradeToPlan( ownProps.plan ),
+		available: canUpgradeToPlan( ownProps.plan ),
 		onUpgradeClick: () => {
 			const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
 			page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( ownProps.plan ) || '' }` );

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -7,12 +7,30 @@ import React from 'react';
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
+import InfoPopover from 'components/info-popover';
 
-export default function PlanFeaturesItem( { children } ) {
+export default function PlanFeaturesItem( { description, children } ) {
+	const renderTipinfo = () => {
+		if ( ! description ) {
+			return null;
+		}
+
+		return (
+			<div className="plan-features__item-tip-info">
+				<InfoPopover
+					position="right"
+				>
+					{ description }
+				</InfoPopover>
+			</div>
+		);
+	};
+
 	return (
 		<li className="plan-features__item">
 			<Gridicon className="plan-features__item-checkmark" size={ 18 } icon="checkmark" />
 			{ children }
+			{ renderTipinfo() }
 		</li>
 	);
 }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -216,6 +216,21 @@ $plan-features-header-banner-height: 20px;
 	@include placeholder( 23% );
 }
 
+.plan-features__item-tip-info {
+	position: absolute;
+	right: 0;
+	top: 50%;
+	width: 18px;
+	height: 18px;
+	margin-top: -9px;
+	color: lighten( $gray, 20% );
+
+	.info-popover {
+		display: block;
+		height: 19px;
+	}
+}
+
 .plan-features__footer {
 	margin-top: auto;
 	padding: 16px 16px 24px;


### PR DESCRIPTION
Fixes #6476 

With this PR we are going adding a tooltip for each feature that has defined its description.

<img src="https://cloud.githubusercontent.com/assets/77539/16530646/6aaf31dc-3fc9-11e6-9685-5029a0768a7a.png" width="400px" />

<img src="https://cloud.githubusercontent.com/assets/77539/16531544/2c22d4a6-3fcd-11e6-9c78-b3cf6e7f4d3e.png" width="400px" />

The description of each feature is gotten from the [constants-plan file](https://github.com/Automattic/wp-calypso/blob/master/client/lib/plans/constants.js).
Right now the only features that have defined their description are `FEATURE_GOOGLE_AD_CREDITS` and `WORDADS_INSTANT` (that's the reason why we are showing only two tooltips in the features list).

We don't necessarily need to wait for all descriptions of these features since we can add as long as we can/want.

### Testing
- Start Calypso with `ENABLE_FEATURES=manage/plan-features make run`
- Navigate to http://calypso.localhost:3000/plans
- Look at the tooltips and play with them.

cc @gwwar @bubel @apeatling @rralian @lamosty 

Test live: https://calypso.live/?branch=update/add-plan-feature-item-tipinfo