### PR TITLE
Editor: Request post selector posts by rows rendered

### DIFF
--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -43,7 +43,6 @@ export default React.createClass( {
 
 	getInitialState() {
 		return {
-			page: 1,
 			search: ''
 		};
 	},
@@ -51,7 +50,6 @@ export default React.createClass( {
 	onSearch( term ) {
 		if ( term !== this.state.search ) {
 			this.setState( {
-				page: 1,
 				search: term
 			} );
 		}
@@ -59,29 +57,9 @@ export default React.createClass( {
 
 	getQuery() {
 		const { type, status, excludeTree, orderBy, order } = this.props;
-		const { page, search } = this.state;
-		return mapKeys( { type, status, excludeTree, orderBy, order, page, search }, ( value, key ) => {
+		const { search } = this.state;
+		return mapKeys( { type, status, excludeTree, orderBy, order, search }, ( value, key ) => {
 			return snakeCase( key );
-		} );
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		const isChangingQuery = [
-			'type',
-			'status',
-			'excludeTree',
-			'orderBy',
-			'order'
-		].some( ( prop ) => nextProps[ prop ] !== this.props[ prop ] );
-
-		if ( isChangingQuery ) {
-			this.setState( { page: 1 } );
-		}
-	},
-
-	incrementPage() {
-		this.setState( {
-			page: this.state.page + 1
 		} );
 	},
 
@@ -92,7 +70,6 @@ export default React.createClass( {
 			<PostSelectorPosts
 				siteId={ siteId }
 				query={ this.getQuery() }
-				onNextPage={ this.incrementPage }
 				onSearch={ this.onSearch }
 				multiple={ multiple }
 				onChange={ onChange }

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -51,6 +51,14 @@ input[type=checkbox].post-selector__input {
 	margin-right: 8px;
 }
 
+.post-selector__results {
+	height: 300px;
+
+	.post-selector.is-compact & {
+		height: auto;
+	}
+}
+
 .post-selector__nested-list {
 	margin-left: 1em;
 }

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -104,6 +104,7 @@ input[type=checkbox].post-selector__input {
 .post-selector__label-type {
 	display: none;
 	margin-left: 8px;
+	flex-shrink: 0;
 	font-size: 11px;
 	text-transform: uppercase;
 	color: $gray;

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -173,7 +173,7 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': true
+				'2916284:{"search":"Hello"}': true
 			} );
 		} );
 
@@ -184,13 +184,13 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'{"search":"hello"}': true
+				'{"search":"Hello"}': true
 			} );
 		} );
 
 		it( 'should accumulate queries', () => {
 			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': true
+				'2916284:{"search":"Hello"}': true
 			} );
 
 			const state = queryRequests( original, {
@@ -200,8 +200,8 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': true,
-				'2916284:{"search":"hello w"}': true
+				'2916284:{"search":"Hello"}': true,
+				'2916284:{"search":"Hello W"}': true
 			} );
 		} );
 
@@ -217,7 +217,7 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': false
+				'2916284:{"search":"Hello"}': false
 			} );
 		} );
 
@@ -230,13 +230,13 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': false
+				'2916284:{"search":"Hello"}': false
 			} );
 		} );
 
 		it( 'should never persist state', () => {
 			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': true
+				'2916284:{"search":"Hello"}': true
 			} );
 
 			const state = queryRequests( original, { type: SERIALIZE } );
@@ -246,7 +246,7 @@ describe( 'reducer', () => {
 
 		it( 'should never load persisted state', () => {
 			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': true
+				'2916284:{"search":"Hello"}': true
 			} );
 
 			const state = queryRequests( original, { type: DESERIALIZE } );

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -235,7 +235,7 @@ describe( 'selectors', () => {
 			const isRequesting = isRequestingSitePostsForQuery( {
 				posts: {
 					queryRequests: {
-						'2916284:{"search":"hel"}': true
+						'2916284:{"search":"Hel"}': true
 					}
 				}
 			}, 2916284, { search: 'Hello' } );
@@ -247,7 +247,7 @@ describe( 'selectors', () => {
 			const isRequesting = isRequestingSitePostsForQuery( {
 				posts: {
 					queryRequests: {
-						'2916284:{"search":"hello"}': true
+						'2916284:{"search":"Hello"}': true
 					}
 				}
 			}, 2916284, { search: 'Hello' } );
@@ -259,7 +259,7 @@ describe( 'selectors', () => {
 			const isRequesting = isRequestingSitePostsForQuery( {
 				posts: {
 					queryRequests: {
-						'2916284:{"search":"hello"}': false
+						'2916284:{"search":"Hello"}': false
 					}
 				}
 			}, 2916284, { search: 'Hello' } );

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -19,6 +19,7 @@ import {
 	isSitePostsLastPageForQuery,
 	getSitePostsForQueryIgnoringPage,
 	getSitePostsHierarchyForQueryIgnoringPage,
+	isRequestingSitePostsForQueryIgnoringPage,
 	isRequestingSitePost,
 	getEditedPost,
 	getEditedPostValue
@@ -30,6 +31,7 @@ describe( 'selectors', () => {
 		getSitePosts.memoizedSelector.cache.clear();
 		getSitePost.memoizedSelector.cache.clear();
 		getSitePostsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
+		isRequestingSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
 		getNormalizedPost.memoizedSelector.cache.clear();
 	} );
 
@@ -556,6 +558,42 @@ describe( 'selectors', () => {
 			expect( sitePosts ).to.eql( [
 				{ ID: 1204, site_ID: 2916284, global_ID: '48b6010b559efe6a77a429773e0cbf12', title: 'Sweet & Savory' }
 			] );
+		} );
+	} );
+
+	describe( 'isRequestingSitePostsForQueryIgnoringPage()', () => {
+		it( 'should return false if not requesting for query', () => {
+			const isRequesting = isRequestingSitePostsForQueryIgnoringPage( {
+				posts: {
+					queryRequests: {}
+				}
+			}, 2916284, { search: 'hel' } );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return true requesting for query at exact page', () => {
+			const isRequesting = isRequestingSitePostsForQueryIgnoringPage( {
+				posts: {
+					queryRequests: {
+						'2916284:{"search":"hel","page":4}': true
+					}
+				}
+			}, 2916284, { search: 'hel', page: 4 } );
+
+			expect( isRequesting ).to.be.true;
+		} );
+
+		it( 'should return true requesting for query without page specified', () => {
+			const isRequesting = isRequestingSitePostsForQueryIgnoringPage( {
+				posts: {
+					queryRequests: {
+						'2916284:{"search":"hel","page":4}': true
+					}
+				}
+			}, 2916284, { search: 'hel' } );
+
+			expect( isRequesting ).to.be.true;
 		} );
 	} );
 

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import {
 	getNormalizedPostsQuery,
 	getSerializedPostsQuery,
+	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage
 } from '../utils';
 
@@ -50,6 +51,35 @@ describe( 'utils', () => {
 			}, 2916284 );
 
 			expect( serializedQuery ).to.equal( '2916284:{"search":"hello"}' );
+		} );
+	} );
+
+	describe( 'getDeserializedPostsQueryDetails()', () => {
+		it( 'should return undefined query and site if string does not contain JSON', () => {
+			const queryDetails = getDeserializedPostsQueryDetails( 'bad' );
+
+			expect( queryDetails ).to.eql( {
+				siteId: undefined,
+				query: undefined
+			} );
+		} );
+
+		it( 'should return query but not site if string does not contain site prefix', () => {
+			const queryDetails = getDeserializedPostsQueryDetails( '{"search":"hello"}' );
+
+			expect( queryDetails ).to.eql( {
+				siteId: undefined,
+				query: { search: 'hello' }
+			} );
+		} );
+
+		it( 'should return query and site if string contains site prefix and JSON', () => {
+			const queryDetails = getDeserializedPostsQueryDetails( '2916284:{"search":"hello"}' );
+
+			expect( queryDetails ).to.eql( {
+				siteId: 2916284,
+				query: { search: 'hello' }
+			} );
 		} );
 	} );
 

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -37,20 +37,12 @@ describe( 'utils', () => {
 			expect( serializedQuery ).to.equal( '{"type":"page"}' );
 		} );
 
-		it( 'should lowercase the result', () => {
-			const serializedQuery = getSerializedPostsQuery( {
-				search: 'HeLlO'
-			} );
-
-			expect( serializedQuery ).to.equal( '{"search":"hello"}' );
-		} );
-
 		it( 'should prefix site ID if specified', () => {
 			const serializedQuery = getSerializedPostsQuery( {
-				search: 'HeLlO'
+				search: 'Hello'
 			}, 2916284 );
 
-			expect( serializedQuery ).to.equal( '2916284:{"search":"hello"}' );
+			expect( serializedQuery ).to.equal( '2916284:{"search":"Hello"}' );
 		} );
 	} );
 
@@ -93,22 +85,13 @@ describe( 'utils', () => {
 			expect( serializedQuery ).to.equal( '{"type":"page"}' );
 		} );
 
-		it( 'should lowercase the result', () => {
-			const serializedQuery = getSerializedPostsQueryWithoutPage( {
-				search: 'HeLlO',
-				page: 2
-			} );
-
-			expect( serializedQuery ).to.equal( '{"search":"hello"}' );
-		} );
-
 		it( 'should prefix site ID if specified', () => {
 			const serializedQuery = getSerializedPostsQueryWithoutPage( {
-				search: 'HeLlO',
+				search: 'Hello',
 				page: 2
 			}, 2916284 );
 
-			expect( serializedQuery ).to.equal( '2916284:{"search":"hello"}' );
+			expect( serializedQuery ).to.equal( '2916284:{"search":"Hello"}' );
 		} );
 	} );
 } );

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -10,6 +10,12 @@ import omitBy from 'lodash/omitBy';
 import { DEFAULT_POST_QUERY } from './constants';
 
 /**
+ * Constants
+ */
+
+const REGEXP_SERIALIZED_QUERY = /^((\d+):)?(.*)$/;
+
+/**
  * Returns a normalized posts query, excluding any values which match the
  * default post query.
  *
@@ -36,6 +42,27 @@ export function getSerializedPostsQuery( query = {}, siteId ) {
 	}
 
 	return serializedQuery;
+}
+
+/**
+ * Returns an object with details related to the specified serialized query.
+ * The object will include siteId and/or query object, if can be parsed.
+ *
+ * @param  {String} serializedQuery Serialized posts query
+ * @return {Object}                 Deserialized posts query details
+ */
+export function getDeserializedPostsQueryDetails( serializedQuery ) {
+	let siteId, query;
+
+	const matches = serializedQuery.match( REGEXP_SERIALIZED_QUERY );
+	if ( matches ) {
+		siteId = Number( matches[ 2 ] ) || undefined;
+		try {
+			query = JSON.parse( matches[ 3 ] );
+		} catch ( error ) {}
+	}
+
+	return { siteId, query };
 }
 
 /**

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -35,7 +35,7 @@ export function getNormalizedPostsQuery( query ) {
  */
 export function getSerializedPostsQuery( query = {}, siteId ) {
 	const normalizedQuery = getNormalizedPostsQuery( query );
-	const serializedQuery = JSON.stringify( normalizedQuery ).toLocaleLowerCase();
+	const serializedQuery = JSON.stringify( normalizedQuery );
 
 	if ( siteId ) {
 		return [ siteId, serializedQuery ].join( ':' );


### PR DESCRIPTION
This pull request seeks to enhance the infinite loading of the `<PostSelector />` component by triggering network requests specifically corresponding to the indices of the rows rendered in the selector. This is a prerequisite for state persistence of posts query data, as otherwise it is not possible to reliably or responsibly refresh persisted query state. State persistence of post queries will assist in faster initial load experiences of not only the `<PostSelector />` component, but also upcoming custom post types listing screens.

__Testing instructions:__

There are no visual or usability changes by the changes in this pull request. Rather, ensure that there are no regressions to existing behavior.

Verify that the post selector works in both "Add Link" existing content, and in page editor parent page selector. Ensure that compact view is shown when fewer than 7 posts exist, and that pages are loaded infinitely (with indicator) until all pages are exhausted. Verify that search continues to behave as expected, including pagination within search and clearing search results.

Test live: https://calypso.live/?branch=update/post-selector-rows-rendered