### PR TITLE
Domains: Properly handle underscores in SRV records

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -7,6 +7,7 @@ import find from 'lodash/find';
 import includes from 'lodash/includes';
 import mapValues from 'lodash/mapValues';
 import startsWith from 'lodash/startsWith';
+import trimStart from 'lodash/trimStart';
 import without from 'lodash/without';
 import matches from 'lodash/matches';
 import negate from 'lodash/negate';
@@ -87,6 +88,11 @@ function getNormalizedData( record, selectedDomainName ) {
 	if ( record.target ) {
 		normalizedRecord.target = getFieldWithDot( record.target );
 	}
+	// The leading '_' in SRV's service field is a convention
+	// The record itself should not contain it
+	if ( record.service ) {
+		normalizedRecord.service = trimStart( record.service, '_' );
+	}
 
 	return normalizedRecord;
 }
@@ -99,18 +105,10 @@ function getNormalizedName( name, type, selectedDomainName ) {
 	}
 
 	if ( endsWithDomain ) {
-		if ( isIpRecord( type ) ) {
-			return name.replace( new RegExp( '\\.+' + selectedDomainName + '\\.?$', 'i' ), '' );
-		}
-		return getFieldWithDot( name );
-	} else if ( ! isIpRecord( type ) ) {
-		return name + '.' + selectedDomainName + '.';
+		return name.replace( new RegExp( '\\.+' + selectedDomainName + '\\.?$', 'i' ), '' );
 	}
-	return name;
-}
 
-function isIpRecord( type ) {
-	return includes( [ 'A', 'AAAA' ], type );
+	return name;
 }
 
 function isRootDomain( name, domainName ) {

--- a/client/lib/domains/dns/reducer.js
+++ b/client/lib/domains/dns/reducer.js
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import findIndex from 'lodash/findIndex';
-import isUndefined from 'lodash/isUndefined';
-import omitBy from 'lodash/omitBy';
 import pick from 'lodash/pick';
 import reject from 'lodash/reject';
 import update from 'react-addons-update';
@@ -89,7 +87,7 @@ function updateDnsState( state, domainName, record, updatedFields ) {
 
 function findDnsIndex( records, record ) {
 	const matchingFields = pick( record, [ 'id', 'data', 'name', 'type' ] );
-	return findIndex( records, omitBy( matchingFields, isUndefined ) );
+	return findIndex( records, matchingFields );
 }
 
 function getInitialStateForDomain() {

--- a/client/my-sites/upgrades/domain-management/dns/a-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/a-record.jsx
@@ -32,11 +32,18 @@ const ARecord = React.createClass( {
 		const classes = classnames( { 'is-hidden': ! this.props.show } ),
 			{ fieldValues, isValid, onChange, selectedDomainName } = this.props,
 			isNameValid = isValid( 'name' ),
-			isDataValid = isValid( 'data' );
-		let placeholder = this.translate( 'e.g. %(example)s', { args: { example: '123.45.78.9' } } );
+			isDataValid = isValid( 'data' ),
+			isAaaaRecord = this.props.fieldValues.type === 'AAAA';
+		let namePlaceholder = this.translate( 'Enter subdomain (optional)', {
+				context: 'Placeholder shown when entering the optional subdomain part of a new DNS record'
+			} ),
+			dataPlaceholder = this.translate( 'e.g. %(example)s', { args: { example: '123.45.78.9' } } );
 
-		if ( this.props.fieldValues.type === 'AAAA' ) {
-			placeholder = this.translate( 'e.g. %(example)s', { args: { example: '2001:500:84::b' } } );
+		if ( isAaaaRecord ) {
+			namePlaceholder = this.translate( 'Enter subdomain (required)', {
+				context: 'Placeholder shown when entering the required subdomain part of a new DNS record'
+			} ),
+			dataPlaceholder = this.translate( 'e.g. %(example)s', { args: { example: '2001:500:84::b' } } );
 		}
 
 		return (
@@ -45,7 +52,7 @@ const ARecord = React.createClass( {
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
-						placeholder={ this.translate( 'Enter subdomain (optional)', { context: 'Placeholder shown when entering the required subdomain part of a new DNS record' } ) }
+						placeholder={ namePlaceholder }
 						isError={ ! isNameValid }
 						onChange={ onChange }
 						value={ fieldValues.name }
@@ -60,7 +67,7 @@ const ARecord = React.createClass( {
 						isError={ ! isDataValid }
 						onChange={ onChange }
 						value={ fieldValues.data }
-						placeholder={ placeholder } />
+						placeholder={ dataPlaceholder } />
 					{ ! isDataValid ? <FormInputValidation text={ this.translate( 'Invalid IP' ) } isError={ true } /> : null }
 				</FormFieldset>
 			</div>

--- a/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
@@ -83,7 +83,7 @@ const DnsRecord = React.createClass( {
 			isRoot = name === domain + '.';
 
 		if ( 'SRV' === type ) {
-			return service + '._' + protocol + '.' + ( isRoot ? '' : name + '.' ) + domain;
+			return '_' + service + '._' + protocol + '.' + ( isRoot ? '' : name + '.' ) + domain;
 		}
 
 		if ( endsWith( name, '.' ) ) {

--- a/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
@@ -83,7 +83,7 @@ const DnsRecord = React.createClass( {
 			isRoot = name === domain + '.';
 
 		if ( 'SRV' === type ) {
-			return service + '_' + protocol + '.' + ( isRoot ? name + '.' : '' ) + domain;
+			return service + '._' + protocol + '.' + ( isRoot ? '' : name + '.' ) + domain;
 		}
 
 		if ( endsWith( name, '.' ) ) {

--- a/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
@@ -20,10 +20,9 @@ const DnsRecord = React.createClass( {
 	},
 
 	handledBy: function() {
-		let { type, data, aux, target, port, service, weight, protocol } = this.props.dnsRecord;
-
-		data = this.trimDot( data );
-		target = this.trimDot( target );
+		const { type, aux, port, service, weight, protocol } = this.props.dnsRecord,
+			data = this.trimDot( this.props.dnsRecord.data ),
+			target = this.trimDot( this.props.dnsRecord.target );
 
 		if ( this.props.dnsRecord.protected_field ) {
 			if ( 'MX' === type ) {
@@ -38,36 +37,39 @@ const DnsRecord = React.createClass( {
 			case 'AAAA':
 				return this.translate( 'Points to %(data)s', {
 					args: {
-						data: data
+						data
 					}
 				} );
 
 			case 'CNAME':
 				return this.translate( 'Alias of %(data)s', {
 					args: {
-						data: data
+						data
 					}
 				} );
 
 			case 'MX':
 				return this.translate( 'Mail handled by %(data)s with priority %(aux)s', {
 					args: {
-						data: data,
-						aux: aux
+						data,
+						aux
 					}
 				} );
 
 			case 'SRV':
-				return this.translate( 'Service %(service)s (%(protocol)s) on target %(target)s:%(port)s, with priority %(aux)s and weight %(weight)s', {
-					args: {
-						service,
-						protocol,
-						target,
-						port,
-						aux,
-						weight
+				return this.translate(
+					'Service %(service)s (%(protocol)s) on target %(target)s:%(port)s, ' +
+					'with priority %(aux)s and weight %(weight)s', {
+						args: {
+							service,
+							protocol,
+							target,
+							port,
+							aux,
+							weight
+						}
 					}
-				} );
+				);
 		}
 
 		return data;
@@ -80,17 +82,17 @@ const DnsRecord = React.createClass( {
 	getName: function() {
 		const { name, service, protocol, type } = this.props.dnsRecord,
 			domain = this.props.selectedDomainName,
-			isRoot = name === domain + '.';
+			isRoot = name === `${ domain }.`;
 
 		if ( 'SRV' === type ) {
-			return '_' + service + '._' + protocol + '.' + ( isRoot ? '' : name + '.' ) + domain;
+			return `_${ service }._${ protocol }.${ isRoot ? '' : name + '.' }${ domain }`;
 		}
 
 		if ( endsWith( name, '.' ) ) {
 			return name.slice( 0, -1 );
 		}
 
-		return name ? name + '.' + domain : domain;
+		return name ? `${ name }.${ domain }` : domain;
 	},
 
 	deleteDns: function() {
@@ -127,4 +129,4 @@ const DnsRecord = React.createClass( {
 	}
 } );
 
-module.exports = DnsRecord;
+export default DnsRecord;


### PR DESCRIPTION
We are trimming the leading underscores for the service part of the SRV record on the backend, so the frontend should take that into account. Apparently, that's the convention (we already do this for the `protocol` part).
So, now it's `_service._protocol.domain.tld`, instead of the `service_protocol.domain.tld` mess earlier :grin:
This form seems to be the correct one - pasting it as-is to `dig` allows you to properly query a SRV record.
Additionally, I've simplified the getNormalizedName function - it doesn't have to build a complicated name. On the backend we strip it of the domain part either way...

Fixes #5830 

/cc @aidvu @umurkontaci for code review
/cc @BandonRandon @ehti for testing

Test live: https://calypso.live/?branch=fix/underscores-in-srv-records