### PR TITLE
Fixes undesired reset of follow bar color in 'recommendations/start'.

### DIFF
--- a/client/reader/start/main.jsx
+++ b/client/reader/start/main.jsx
@@ -24,9 +24,7 @@ const Start = React.createClass( {
 	smartSetState: smartSetState,
 
 	getInitialState() {
-		return {
-			totalSubscriptions: 0
-		};
+		return this.getStateFromStores();
 	},
 
 	// Add change listeners to stores


### PR DESCRIPTION
Fixes #6453.

<img width="455" alt="screen shot 2016-07-02 at 12 48 14 am" src="https://cloud.githubusercontent.com/assets/7499938/16537977/6b3b309a-3fee-11e6-9b65-e50dfc83d506.png">

The `is-following` class is applied applied to the reader start bar (pictured above) if the user's `totalSubscriptions` are greater than 1. `totalSubscriptions` was being set via `getInitialState()` to 0 each time the page renders.

So, if a user followed a number of sites, then selected one by title and clicked back, `totalSubscriptions` would be set back to zero, even if the user's stored number of total subscriptions is much greater than zero.

My solution ensures the initial state reflects the store value and is consistent with a number of other components in the Reader module.

cc @bluefuton @jancavan 

Test live: https://calypso.live/?branch=fix/reader-start-bar