### PR TITLE
Stats: disable post-trends for mobile using isMobile

### DIFF
--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -5,7 +5,6 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import throttle from 'lodash/throttle';
-import touchDetect from 'lib/touch-detect';
 import i18n from 'i18n-calypso';
 
 /**
@@ -148,10 +147,6 @@ const PostTrends = React.createClass( {
 		containerClass = classNames( 'post-trends', {
 			'is-loading': requesting
 		} );
-
-		if ( touchDetect.hasTouch() ) {
-			return null;
-		}
 
 		return (
 

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -3,6 +3,9 @@
 	user-select: none;
 	position: relative;
 	width: 100%;
+	@include breakpoint( "<480px" ) {
+		display: none;
+	}
 }
 
 .post-trends__title {

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -22,6 +22,7 @@ import MostPopular from 'my-sites/stats/most-popular';
 import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
 import Main from 'components/main';
+import { isMobile } from 'lib/viewport';
 
 export default React.createClass( {
 	displayName: 'StatsInsights',
@@ -77,7 +78,7 @@ export default React.createClass( {
 				<SidebarNavigation />
 				<StatsNavigation section="insights" site={ site } />
 				<div id="my-stats-content">
-					<PostingActivity />
+					{ ! isMobile() && <PostingActivity /> }
 					<LatestPostSummary site={ site } />
 					<TodaysStats
 						siteId={ site ? site.ID : 0 }

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -22,7 +22,6 @@ import MostPopular from 'my-sites/stats/most-popular';
 import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
 import Main from 'components/main';
-import { isMobile } from 'lib/viewport';
 
 export default React.createClass( {
 	displayName: 'StatsInsights',
@@ -78,7 +77,7 @@ export default React.createClass( {
 				<SidebarNavigation />
 				<StatsNavigation section="insights" site={ site } />
 				<div id="my-stats-content">
-					{ ! isMobile() && <PostingActivity /> }
+					<PostingActivity />
 					<LatestPostSummary site={ site } />
 					<TodaysStats
 						siteId={ site ? site.ID : 0 }


### PR DESCRIPTION
While viewing js-errors ( /ht @artpi - that is just fantastic! ) I was noticing the following exception:

<img width="972" alt="timmydcrawford_on_autonet_irc_network_ __js-errors__29_users_" src="https://cloud.githubusercontent.com/assets/22080/16542782/1fe7bf2c-406c-11e6-8cce-ba595fb523b6.png">

And tracked down the issue to the fact we are returning `null` from the `<PostTrends />` render based off of the _no-longer-should-be-used_ `lib/touch-detect` module.  Logic was still firing to find sizing/attributes for the element which are obviously not in the DOM, and as such errors are happening.

This branch removes the returning of `null` from the `render()` in `<PostTrends />` and instead utilizes `lib/viewport#isMobile()` to conditionally render the component on the `<StatsInsights />` page.  Worth noting the reasoning for disabling this visualization on mobile is due to the current poor user experience.

__To Test__
- Using the iOS emulator along with Safari dev tools, open a stats insights page
- Verify no errors are thrown in the console and the Post Trends component is not rendered
- Open a stats insights page in a desktop browser and verify the Post Trends component is still rendered

__Notes__
I did notice some differing usage of `isMobile()` in other parts of Calypso.  In [themes](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/themes/themes-search-card/index.jsx#L34-L38) the output of `isMobile()` is being stored in the component state, and wrapped in a debounce.  I went with a similar approach that is seen in the [media library](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/media-library/header.jsx#L187) though - but curious as to why the other approach was taken in themes.

Test live: https://calypso.live/?branch=fix/stats/mobile-safari-exception