### PR TITLE
Editor: fix page.replace call to use proper CPT edit path.

### DIFF
--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -17,6 +17,23 @@ describe( 'utils', function() {
 		postUtils = require( '../utils' );
 	} );
 
+	describe( '#getEditURL', function() {
+		it( 'should return correct path type=post is supplied', function() {
+			const url = postUtils.getEditURL( { ID: 123, type: 'post' }, { slug: 'en.blog.wordpress.com' } );
+			assert( url === '/post/en.blog.wordpress.com/123' );
+		} );
+
+		it( 'should return correct path type=page is supplied', function() {
+			const url = postUtils.getEditURL( { ID: 123, type: 'page' }, { slug: 'en.blog.wordpress.com' } );
+			assert( url === '/page/en.blog.wordpress.com/123' );
+		} );
+
+		it( 'should return correct path when custom post type is supplied', function() {
+			const url = postUtils.getEditURL( { ID: 123, type: 'jetpack-portfolio' }, { slug: 'en.blog.wordpress.com' } );
+			assert( url === '/edit/jetpack-portfolio/en.blog.wordpress.com/123' );
+		} );
+	} );
+
 	describe( '#getVisibility', function() {
 		it( 'should return undefined when no post is supplied', function() {
 			assert( postUtils.getVisibility() === undefined );

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -4,6 +4,7 @@
 var url = require( 'url' ),
 	i18n = require( 'i18n-calypso' ),
 	moment = require( 'moment-timezone' );
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -14,7 +15,13 @@ var postNormalizer = require( 'lib/post-normalizer' ),
 var utils = {
 
 	getEditURL: function( post, site ) {
-		return `/${post.type}/${site.slug}/${post.ID}`;
+		let basePath = '';
+
+		if ( ! includes( [ 'post', 'page' ], post.type ) ) {
+			basePath = '/edit';
+		}
+
+		return `${basePath}/${post.type}/${site.slug}/${post.ID}`;
 	},
 
 	getPreviewURL: function( post ) {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -253,6 +253,13 @@ const PostEditor = React.createClass( {
 		this.hideDrafts();
 	},
 
+	componentWillReceiveProps: function( nextProps ) {
+		if ( nextProps.editPath !== this.props.editPath ) {
+			// make sure the history entry has the post ID in it, but don't dispatch
+			page.replace( nextProps.editPath, null, false, false );
+		}
+	},
+
 	renderNotice: function() {
 		var arrowLink;
 
@@ -840,9 +847,6 @@ const PostEditor = React.createClass( {
 
 		// Receive updated post into state
 		this.props.receivePost( post );
-
-		// make sure the history entry has the post ID in it, but don't dispatch
-		page.replace( this.props.editPath, null, false, false );
 
 		nextState = {
 			isSaving: false,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -818,14 +818,7 @@ const PostEditor = React.createClass( {
 	},
 
 	onSaveSuccess: function( message, action, link ) {
-		var post = PostEditStore.get(),
-			basePath, nextState;
-
-		if ( utils.isPage( post ) ) {
-			basePath = '/page';
-		} else {
-			basePath = '/post';
-		}
+		var post = PostEditStore.get(), nextState;
 
 		if ( 'draft' === post.status ) {
 			this.props.setEditorLastDraft( post.site_ID, post.ID );
@@ -848,8 +841,9 @@ const PostEditor = React.createClass( {
 		this.props.receivePost( post );
 
 		// make sure the history entry has the post ID in it, but don't dispatch
+		const site = this.props.sites.getSite( post.site_ID );
 		page.replace(
-			basePath + '/' + this.props.sites.getSite( post.site_ID ).slug + '/' + post.ID,
+			utils.getEditURL( post, site ),
 			null, false, false
 		);
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -842,10 +842,7 @@ const PostEditor = React.createClass( {
 		this.props.receivePost( post );
 
 		// make sure the history entry has the post ID in it, but don't dispatch
-		page.replace(
-			this.props.editPath,
-			null, false, false
-		);
+		page.replace( this.props.editPath, null, false, false );
 
 		nextState = {
 			isSaving: false,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -44,7 +44,7 @@ const actions = require( 'lib/posts/actions' ),
 
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-draft/actions';
-import { isEditorDraftsVisible, getEditorPostId } from 'state/ui/editor/selectors';
+import { isEditorDraftsVisible, getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { toggleEditorDraftsVisible, setEditorPostId } from 'state/ui/editor/actions';
 import { receivePost, editPost, resetPostEdits } from 'state/posts/actions';
 import EditorSidebarHeader from 'post-editor/editor-sidebar/header';
@@ -172,6 +172,7 @@ const PostEditor = React.createClass( {
 		sites: React.PropTypes.object,
 		user: React.PropTypes.object,
 		userUtils: React.PropTypes.object,
+		editPath: React.PropTypes.string
 	},
 
 	_previewWindow: null,
@@ -841,9 +842,8 @@ const PostEditor = React.createClass( {
 		this.props.receivePost( post );
 
 		// make sure the history entry has the post ID in it, but don't dispatch
-		const site = this.props.sites.getSite( post.site_ID );
 		page.replace(
-			utils.getEditURL( post, site ),
+			this.props.editPath,
 			null, false, false
 		);
 
@@ -910,11 +910,14 @@ const PostEditor = React.createClass( {
 
 export default connect(
 	( state ) => {
+		const postId = getEditorPostId( state );
+		const siteId = getSelectedSiteId( state );
 		return {
-			siteId: getSelectedSiteId( state ),
-			postId: getEditorPostId( state ),
 			showDrafts: isEditorDraftsVisible( state ),
 			editorModePreference: getPreference( state, 'editor-mode' ),
+			editPath: getEditorPath( state, siteId, postId ),
+			siteId,
+			postId
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
Fixes #6463.  Currently when an auto-save, or an update occurs on a custom post type in the editor, a call to `page.replace` is issued with an incorrect edit path.  This causes all sorts of frustration in the history stack, not to mention to developers testing CPTs in the editor.

This branch updates the logic of `lib/posts/utils#getEditURL` to be aware of the proper CPT edit path, and adds some tests.

__To Test__
- Edit an existing CPT in the editor, click update.  Note the URL should not change and you can hard refresh
- Create a new CPT post in the editor, add a title or some content, after the auto save fires note that the URL path is correct for the CPT.  Issue a hard refresh to double check
- Follow the same steps with a post and a page to ensure all is normal there too

Test live: https://calypso.live/?branch=fix/editor/6463