### PR TITLE
Add 16px of top margin to full-post featured image

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -147,7 +147,7 @@
 }
 
 .full-post__featured-image {
-	margin: 8px -32px;
+	margin: 24px -32px 8px -32px;
 	max-width: calc(100% + 64px);
 	text-align: center;
 	background: $gray-light;

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -147,7 +147,7 @@
 }
 
 .full-post__featured-image {
-	margin: 24px -32px 8px -32px;
+	margin: 18px -32px 8px;
 	max-width: calc(100% + 64px);
 	text-align: center;
 	background: $gray-light;


### PR DESCRIPTION
Fixes #6517 by adding some top-margin to the Reader's full-post featured-image so it better separates itself from the post header.

@shaunandrews , would you mind reviewing this? Thanks!

Test live: https://calypso.live/?branch=fix/6517-featured-image-add-top-margin