### PR TITLE
Jetpack connect: refresh plans page when plans list is fetched

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -483,7 +483,9 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 export default connect(
 	state => {
-		const site = state.jetpackConnect.jetpackConnectAuthorize && state.jetpackConnect.jetpackConnectAuthorize.queryObject
+		const site = state.jetpackConnect.jetpackConnectAuthorize &&
+			state.jetpackConnect.jetpackConnectAuthorize.queryObject &&
+			state.jetpackConnect.jetpackConnectAuthorize.queryObject.site
 			? getSiteByUrl( state, state.jetpackConnect.jetpackConnectAuthorize.queryObject.site )
 			: null;
 		return {

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -24,12 +24,10 @@ import jetpackSSOForm from './sso';
 import i18nUtils from 'lib/i18n-utils';
 import analytics from 'lib/analytics';
 import config from 'config';
-import plansFactory from 'lib/plans-list';
 import route from 'lib/route';
 import sitesFactory from 'lib/sites-list';
 import titleActions from 'lib/screen-title/actions';
 
-const plans = plansFactory();
 const sites = sitesFactory();
 
 /**
@@ -202,7 +200,6 @@ export default {
 			<CheckoutData>
 				<Plans
 					sites={ sites }
-					plans={ plans }
 					context={ context }
 					destinationType={ context.params.destinationType } />
 			</CheckoutData>,

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -1,6 +1,9 @@
 const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // an hour
 
 const isCalypsoStartedConnection = function( state, siteSlug ) {
+	if ( ! siteSlug ) {
+		return false;
+	}
 	const site = siteSlug.replace( /.*?:\/\//g, '' );
 	if ( state && state[ site ] ) {
 		const currentTime = ( new Date() ).getTime();


### PR DESCRIPTION
We currently have a bug in the jetpack connect premium & pro pages that cause a blank screen when the user finish authorizing their site if the plans info is not already stored locally.

This PR makes the page to be refreshed once the info is fetched, so we don't get stuck in that blank page.

How to test
==========
1. You need a jetpack site running latest's Jetpack master
2. In a incognito window, go to calypso.localhost:3000/jetpack/connect/pro (you will need to be logged into your WordPress.com account, because if you are not, you will be redirected to .com once you log and the flow will be broken)
3. enter your jetpack site url and wait until it's connected
4. You should end in the checkout page, with a professional plan waiting to be paid for

ping @oskosk 

Test live: https://calypso.live/?branch=fix/jpc_plans