### PR TITLE
Plans: change default url of `BACK TO MY SITE` link

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/header.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header.jsx
@@ -42,31 +42,43 @@ const CheckoutThankYouHeader = React.createClass( {
 		}
 
 		if ( isPlan( this.props.primaryPurchase ) ) {
-			return this.translate( "Your site is now on the {{strong}}%(productName)s{{/strong}} plan. It's doing somersaults in excitement!", {
-				args: { productName: this.props.primaryPurchase.productName },
-				components: { strong: <strong /> }
-			} );
+			return this.translate(
+				'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. ' +
+				"It's doing somersaults in excitement!", {
+					args: { productName: this.props.primaryPurchase.productName },
+					components: { strong: <strong /> }
+				}
+			);
 		}
 
 		if ( isDomainRegistration( this.props.primaryPurchase ) ) {
-			return this.translate( 'Your new domain {{strong}}%(domainName)s{{/strong}} is being set up. Your site is doing somersaults in excitement!', {
-				args: { domainName: this.props.primaryPurchase.meta },
-				components: { strong: <strong /> }
-			} );
+			return this.translate(
+				'Your new domain {{strong}}%(domainName)s{{/strong}} is ' +
+				'being set up. Your site is doing somersaults in excitement!', {
+					args: { domainName: this.props.primaryPurchase.meta },
+					components: { strong: <strong /> }
+				}
+			);
 		}
 
 		if ( isDomainMapping( this.props.primaryPurchase ) ) {
-			return this.translate( "Your domain {{strong}}%(domainName)s{{/strong}} was added to your site. But it isn't working yet – follow the instructions below to complete the set up.", {
-				args: { domainName: this.props.primaryPurchase.meta },
-				components: { strong: <strong /> }
-			} );
+			return this.translate(
+				'Your domain {{strong}}%(domainName)s{{/strong}} was added to your site. ' +
+				"But it isn't working yet – follow the instructions below to complete the set up.", {
+					args: { domainName: this.props.primaryPurchase.meta },
+					components: { strong: <strong /> }
+				}
+			);
 		}
 
 		if ( isGoogleApps( this.props.primaryPurchase ) ) {
-			return this.translate( "Your domain {{strong}}%(domainName)s{{/strong}} is now set up to use Google Apps. It's doing somersaults in excitement!", {
-				args: { domainName: this.props.primaryPurchase.meta },
-				components: { strong: <strong /> }
-			} );
+			return this.translate(
+				'Your domain {{strong}}%(domainName)s{{/strong}} is now set up to use Google Apps. ' +
+				"It's doing somersaults in excitement!", {
+					args: { domainName: this.props.primaryPurchase.meta },
+					components: { strong: <strong /> }
+				}
+			);
 		}
 
 		if ( isGuidedTransfer( this.props.primaryPurchase ) ) {
@@ -87,10 +99,13 @@ const CheckoutThankYouHeader = React.createClass( {
 		}
 
 		if ( isSiteRedirect( this.props.primaryPurchase ) ) {
-			return this.translate( "Your site is now redirecting to {{strong}}%(domainName)s{{/strong}}. It's doing somersaults in excitement!", {
-				args: { domainName: this.props.primaryPurchase.meta },
-				components: { strong: <strong /> }
-			} );
+			return this.translate(
+				'Your site is now redirecting to {{strong}}%(domainName)s{{/strong}}. ' +
+				"It's doing somersaults in excitement!", {
+					args: { domainName: this.props.primaryPurchase.meta },
+					components: { strong: <strong /> }
+				}
+			);
 		}
 
 		if ( isChargeback( this.props.primaryPurchase ) ) {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -102,7 +102,11 @@ const CheckoutThankYou = React.createClass( {
 	componentWillReceiveProps( nextProps ) {
 		this.redirectIfThemePurchased();
 
-		if ( ! this.props.receipt.hasLoadedFromServer && nextProps.receipt.hasLoadedFromServer && this.hasPlanOrDomainProduct( nextProps ) ) {
+		if (
+			! this.props.receipt.hasLoadedFromServer &&
+			nextProps.receipt.hasLoadedFromServer &&
+			this.hasPlanOrDomainProduct( nextProps )
+		) {
 			this.props.refreshSitePlans( this.props.selectedSite.ID );
 		}
 	},
@@ -183,7 +187,8 @@ const CheckoutThankYou = React.createClass( {
 	 * Retrieves the component (and any corresponding data) that should be displayed according to the type of purchase
 	 * just performed by the user.
 	 *
-	 * @returns {*[]} an array of varying size with the component instance, then an optional purchase object possibly followed by a domain name
+	 * @returns {*[]} an array of varying size with the component instance,
+	 * then an optional purchase object possibly followed by a domain name
 	 */
 	getComponentAndPrimaryPurchaseAndDomain() {
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -141,8 +141,11 @@ const CheckoutThankYou = React.createClass( {
 			const site = this.props.selectedSite.slug;
 
 			if ( purchases.some( isPlan ) ) {
-				page( `/plans/${ site }` );
-			} else if ( purchases.some( isDomainProduct ) || purchases.some( isDomainRedemption || purchases.some( isSiteRedirect ) ) ) {
+				page( `/plans/my-plan/${ site }` );
+			} else if (
+				purchases.some( isDomainProduct ) ||
+				purchases.some( isDomainRedemption || purchases.some( isSiteRedirect ) )
+			) {
 				page( upgradesPaths.domainManagementList( this.props.selectedSite.slug ) );
 			} else if ( purchases.some( isGoogleApps ) ) {
 				const purchase = find( purchases, isGoogleApps );
@@ -168,7 +171,10 @@ const CheckoutThankYou = React.createClass( {
 
 		return (
 			<Main className={ classes }>
-				<HeaderCake onClick={ this.goBack } isCompact backText={ this.translate( 'Back to my site' ) } />
+				<HeaderCake
+					onClick={ this.goBack }
+					isCompact
+					backText={ this.translate( 'Back to my site' ) } />
 
 				<Card className="checkout-thank-you__content">
 					{ this.productRelatedMessages() }


### PR DESCRIPTION
This PR fix #5903 modifying the default value of `<HeaderCake />` `BACK TO MY SITE` link.

The specific change is here -> b9aee1917f850a41aef2890037fd5770a95605bc. The other ones are simply eslint fixes.



### Testing

1. You must purchase a plan through the NUX. You should get a url similar to `http://calypso.localhost:3000/checkout/thank-you/<your-testing-new-site>/<receiptId>`
2. On the thank you page, hit the `BACK TO MY SITE` link
3. You should see `my-plan` instead of the plans page.

cc @apeatling 

Test live: https://calypso.live/?branch=update/checkout-thank-you-page