### PR TITLE
Components: Remove white background from disabled borderless button

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -180,7 +180,6 @@ button {
 	&[disabled],
 	&:disabled {
 		color: lighten( $gray, 30% );
-		background: $white;
 		cursor: default;
 
 		&:active {


### PR DESCRIPTION
Related: #6378 (specifically c760f56c0390de48fee31e8430a169751db5ccb1)

This pull request seeks to resolve an issue where disabled borderless buttons display with a white background. It was the intention with c760f56c0390de48fee31e8430a169751db5ccb1 to remove the white background from any borderless button.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16590495/cda42fd4-42a5-11e6-8726-36031ae82fb8.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16590487/c4b1dd5e-42a5-11e6-93cf-a0ed98036d7a.png)

__Testing instructions:__

This is most obvious in the post editor, where if no drafts exist, or the draft count is in the process of being requested from the API, the button will be disabled. Verify that with these changes, the background of the button is transparent.

/cc @mtias 

Test live: https://calypso.live/?branch=fix/button-borderless-disabled-background