### PR TITLE
SectionNav: only change color of count on mobile.

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -271,8 +271,8 @@
 		color: $white;
 		background-color: $blue-medium;
 
-		.count {
-			.section-nav.is-open & {
+		@include breakpoint( "<480px" ) {
+			.count {
 				color: $white;
 				border-color: $white;
 			}


### PR DESCRIPTION
Related: #6441 (effectively same PR)
Related: #6442 

This pull request solves the same issue as addressed in #6442, but accounts for resizing the viewport while the navigation item is open / selected.

(Apparently force-pushing a closed pull request branch causes a separate branch to be created.)

__Testing instructions:__

Verify that white border on selected section nav item (specifically, [on posts screen](http://calypso.localhost:3000/posts/my)) is only applied in mobile selected case, and that this remains consistent while viewport is resized.

/cc @mtias (this is your commit, feel free to merge on 👍 )

Test live: https://calypso.live/?branch=fix/section-nav-count