### PR TITLE
CPT: Enable publishing drafts from post listing screen

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -11,15 +11,18 @@ import includes from 'lodash/includes';
  */
 import PopoverMenuItem from 'components/popover/menu-item';
 import { getPost } from 'state/posts/selectors';
+import { savePost } from 'state/posts/actions';
 import { canCurrentUser } from 'state/current-user/selectors';
 
-function PostActionsEllipsisMenuPublish( { translate, status, canPublish } ) {
+function PostActionsEllipsisMenuPublish( { translate, status, siteId, postId, canPublish, dispatchSavePost } ) {
 	if ( ! canPublish || ! includes( [ 'pending', 'draft' ], status ) ) {
 		return null;
 	}
 
 	function publishPost() {
-		alert( 'Not Yet Implemented' );
+		if ( siteId && postId ) {
+			dispatchSavePost( { status: 'publish' }, siteId, postId );
+		}
 	}
 
 	return (
@@ -33,17 +36,25 @@ PostActionsEllipsisMenuPublish.propTypes = {
 	globalId: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 	status: PropTypes.string,
-	canPublish: PropTypes.bool
+	siteId: PropTypes.number,
+	postId: PropTypes.number,
+	canPublish: PropTypes.bool,
+	dispatchSavePost: PropTypes.func
 };
 
-export default connect( ( state, ownProps ) => {
-	const post = getPost( state, ownProps.globalId );
-	if ( ! post ) {
-		return {};
-	}
+export default connect(
+	( state, ownProps ) => {
+		const post = getPost( state, ownProps.globalId );
+		if ( ! post ) {
+			return {};
+		}
 
-	return {
-		status: post.status,
-		canPublish: canCurrentUser( state, post.site_ID, 'publish_posts' )
-	};
-} )( localize( PostActionsEllipsisMenuPublish ) );
+		return {
+			status: post.status,
+			siteId: post.site_ID,
+			postId: post.ID,
+			canPublish: canCurrentUser( state, post.site_ID, 'publish_posts' )
+		};
+	},
+	{ dispatchSavePost: savePost }
+)( localize( PostActionsEllipsisMenuPublish ) );

--- a/client/state/notices/reducer.js
+++ b/client/state/notices/reducer.js
@@ -71,6 +71,18 @@ export const items = createReducer( {}, {
 					);
 				}
 				break;
+
+			case 'publish':
+				if ( 1 === count ) {
+					text = translate( 'Post successfully published' );
+				} else {
+					text = translate(
+						'%d post successfully published',
+						'%d posts successfully published',
+						{ count, args: [ count ] }
+					);
+				}
+				break;
 		}
 
 		if ( ! text ) {

--- a/client/state/notices/test/reducer.js
+++ b/client/state/notices/test/reducer.js
@@ -127,7 +127,7 @@ describe( 'reducer', () => {
 					type: POST_SAVE_SUCCESS,
 					post: {
 						title: 'Hello World',
-						status: 'publish' // [TODO]: We'll eventually want publish notice
+						status: 'invalid'
 					}
 				} );
 
@@ -180,6 +180,56 @@ describe( 'reducer', () => {
 						noticeId: 'POST_SAVE_SUCCESS',
 						count: 2,
 						text: '2 posts successfully moved to trash'
+					}
+				} );
+			} );
+
+			it( 'should return state with single publish success', () => {
+				const original = deepFreeze( {} );
+				const state = items( original, {
+					type: POST_SAVE_SUCCESS,
+					post: { status: 'publish' }
+				} );
+
+				expect( state ).to.eql( {
+					POST_SAVE_SUCCESS: {
+						showDismiss: true,
+						isPersistent: false,
+						displayOnNextPage: false,
+						status: 'is-success',
+						noticeId: 'POST_SAVE_SUCCESS',
+						count: 1,
+						text: 'Post successfully published'
+					}
+				} );
+			} );
+
+			it( 'should return state with multiple publish success', () => {
+				const original = deepFreeze( {
+					POST_SAVE_SUCCESS: {
+						showDismiss: true,
+						isPersistent: false,
+						displayOnNextPage: false,
+						status: 'is-success',
+						noticeId: 'POST_SAVE_SUCCESS',
+						count: 1,
+						text: 'Post successfully published'
+					}
+				} );
+				const state = items( original, {
+					type: POST_SAVE_SUCCESS,
+					post: { status: 'publish' }
+				} );
+
+				expect( state ).to.eql( {
+					POST_SAVE_SUCCESS: {
+						showDismiss: true,
+						isPersistent: false,
+						displayOnNextPage: false,
+						status: 'is-success',
+						noticeId: 'POST_SAVE_SUCCESS',
+						count: 2,
+						text: '2 posts successfully published'
 					}
 				} );
 			} );


### PR DESCRIPTION
This pull request seeks to enable a user to publish a draft from the [custom post types list screen](https://wpcalypso.wordpress.com/types/post).

![publish](https://cloud.githubusercontent.com/assets/1779930/16593144/06fe38cc-42b2-11e6-95c7-6879354d1356.gif)

__Testing instructions:__

Verify that you can publish a post, and that a notice is shown after the publish succeeds.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site
3. Switch to Drafts filter
4. Under the ellipsis menu, choose publish
5. Note that the post disappears from the draft list
6. Note that a notice appears after the publish succeeds
7. Switch to the Published filter
8. Note that the published post appears in the published list (also verify persistence through refresh)

Test live: https://calypso.live/?branch=update/cpt-publish-post