### PR TITLE
Reader: Fix how we build the post key for items that look like feed items

### DIFF
--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -82,7 +82,7 @@ FeedStreamActions = {
 					// 1.2 style
 					FeedPostStoreActions.receivePost( null, post, {
 						feedId: post.feed_ID,
-						postId: post.ID
+						postId: post.feed_item_ID
 					} );
 				} else if ( post && post.site_ID ) {
 					// this looks like a full post object


### PR DESCRIPTION
To test, pull up a list like http://calypso.localhost:3000/read/list/blowery/woodworking and notice it works now. Also try the tag listing, main following stream, a8c stream

Test live: https://calypso.live/?branch=fix/reader/keying