### PR TITLE
CPT: Display post preview on list screen post View action

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -10,32 +10,28 @@ import includes from 'lodash/includes';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import WebPreview from 'components/web-preview';
 import { getPost, getPostPreviewUrl } from 'state/posts/selectors';
+import { setPreviewUrl } from 'state/ui/actions';
+import layoutFocus from 'lib/layout-focus';
 
 class PostActionsEllipsisMenuView extends Component {
 	static propTypes = {
 		globalId: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		status: PropTypes.string,
-		previewUrl: PropTypes.string
+		previewUrl: PropTypes.string,
+		setPreviewUrl: PropTypes.func.isRequired
 	};
 
 	constructor() {
 		super( ...arguments );
 
 		this.previewPost = this.previewPost.bind( this );
-		this.showPreview = this.togglePreview.bind( this, true );
-		this.hidePreview = this.togglePreview.bind( this, false );
-		this.state = { isPreviewing: false };
-	}
-
-	togglePreview( isPreviewing ) {
-		this.setState( { isPreviewing } );
 	}
 
 	previewPost( event ) {
-		this.showPreview();
+		this.props.setPreviewUrl( this.props.previewUrl );
+		layoutFocus.set( 'preview' );
 		event.preventDefault();
 	}
 
@@ -54,19 +50,18 @@ class PostActionsEllipsisMenuView extends Component {
 				{ includes( [ 'publish', 'private' ], status )
 					? translate( 'View', { context: 'verb' } )
 					: translate( 'Preview', { context: 'verb' } ) }
-				<WebPreview
-					showPreview={ this.state.isPreviewing }
-					previewUrl={ previewUrl }
-					onClose={ this.hidePreview } />
 			</PopoverMenuItem>
 		);
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const post = getPost( state, ownProps.globalId );
-	return {
-		status: post ? post.status : null,
-		previewUrl: post ? getPostPreviewUrl( state, post.site_ID, post.ID ) : null
-	};
-} )( localize( PostActionsEllipsisMenuView ) );
+export default connect(
+	( state, ownProps ) => {
+		const post = getPost( state, ownProps.globalId );
+		return {
+			status: post ? post.status : null,
+			previewUrl: post ? getPostPreviewUrl( state, post.site_ID, post.ID ) : null
+		};
+	},
+	{ setPreviewUrl }
+)( localize( PostActionsEllipsisMenuView ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import includes from 'lodash/includes';
@@ -10,39 +10,63 @@ import includes from 'lodash/includes';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { getPost } from 'state/posts/selectors';
+import WebPreview from 'components/web-preview';
+import { getPost, getPostPreviewUrl } from 'state/posts/selectors';
 
-function PostActionsEllipsisMenuView( { translate, status } ) {
-	if ( 'trash' === status ) {
-		return null;
+class PostActionsEllipsisMenuView extends Component {
+	static propTypes = {
+		globalId: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+		status: PropTypes.string,
+		previewUrl: PropTypes.string
+	};
+
+	constructor() {
+		super( ...arguments );
+
+		this.previewPost = this.previewPost.bind( this );
+		this.showPreview = this.togglePreview.bind( this, true );
+		this.hidePreview = this.togglePreview.bind( this, false );
+		this.state = { isPreviewing: false };
 	}
 
-	function viewPost() {
-		alert( 'Not Yet Implemented' );
+	togglePreview( isPreviewing ) {
+		this.setState( { isPreviewing } );
 	}
 
-	return (
-		<PopoverMenuItem onClick={ viewPost } icon="external">
-			{ includes( [ 'publish', 'private' ], status )
-				? translate( 'View', { context: 'verb' } )
-				: translate( 'Preview', { context: 'verb' } ) }
-		</PopoverMenuItem>
-	);
+	previewPost( event ) {
+		this.showPreview();
+		event.preventDefault();
+	}
+
+	render() {
+		const { translate, status, previewUrl } = this.props;
+		if ( ! previewUrl ) {
+			return null;
+		}
+
+		return (
+			<PopoverMenuItem
+				href={ previewUrl }
+				onClick={ this.previewPost }
+				icon="external"
+				target="_blank">
+				{ includes( [ 'publish', 'private' ], status )
+					? translate( 'View', { context: 'verb' } )
+					: translate( 'Preview', { context: 'verb' } ) }
+				<WebPreview
+					showPreview={ this.state.isPreviewing }
+					previewUrl={ previewUrl }
+					onClose={ this.hidePreview } />
+			</PopoverMenuItem>
+		);
+	}
 }
-
-PostActionsEllipsisMenuView.propTypes = {
-	globalId: PropTypes.string,
-	translate: PropTypes.func.isRequired,
-	status: PropTypes.string
-};
 
 export default connect( ( state, ownProps ) => {
 	const post = getPost( state, ownProps.globalId );
-	if ( ! post ) {
-		return {};
-	}
-
 	return {
-		status: post.status
+		status: post ? post.status : null,
+		previewUrl: post ? getPostPreviewUrl( state, post.site_ID, post.ID ) : null
 	};
 } )( localize( PostActionsEllipsisMenuView ) );

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -26,6 +26,8 @@ import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import firstPassCanonicalImage from 'lib/post-normalizer/rule-first-pass-canonical-image';
 import decodeEntities from 'lib/post-normalizer/rule-decode-entities';
 import stripHtml from 'lib/post-normalizer/rule-strip-html';
+import { getSite } from 'state/sites/selectors';
+import addQueryArgs from 'lib/route/add-query-args';
 
 /**
  * Returns a post object by its global ID.
@@ -358,3 +360,52 @@ export const isEditedPostDirty = createSelector(
 	},
 	( state ) => [ state.posts.items, state.posts.edits ]
 );
+
+/**
+ * Returns the most reliable preview URL for the post by site ID, post ID pair,
+ * or null if a preview URL cannot be determined.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Number}  postId Post ID
+ * @return {?String}        Post preview URL
+ */
+export function getPostPreviewUrl( state, siteId, postId ) {
+	const post = getSitePost( state, siteId, postId );
+	if ( ! post ) {
+		return null;
+	}
+
+	const { URL: url, status } = post;
+	if ( ! url || status === 'trash' ) {
+		return null;
+	}
+
+	let previewUrl = post.preview_URL;
+	if ( ! previewUrl ) {
+		previewUrl = url;
+
+		if ( 'publish' !== status ) {
+			previewUrl = addQueryArgs( {
+				preview: true
+			}, previewUrl );
+		}
+	}
+
+	const site = getSite( state, siteId );
+	if ( ! site || ! site.options ) {
+		return previewUrl;
+	}
+
+	if ( site.options.is_mapped_domain ) {
+		previewUrl = previewUrl.replace( site.URL, site.options.unmapped_url );
+	}
+
+	if ( site.options.frame_nonce ) {
+		previewUrl = addQueryArgs( {
+			'frame-nonce': site.options.frame_nonce
+		}, previewUrl );
+	}
+
+	return previewUrl;
+}

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -381,29 +381,14 @@ export function getPostPreviewUrl( state, siteId, postId ) {
 		return null;
 	}
 
-	let previewUrl = post.preview_URL;
-	if ( ! previewUrl ) {
-		previewUrl = url;
-
-		if ( 'publish' !== status ) {
-			previewUrl = addQueryArgs( {
-				preview: true
-			}, previewUrl );
-		}
+	if ( post.preview_URL ) {
+		return post.preview_URL;
 	}
 
-	const site = getSite( state, siteId );
-	if ( ! site || ! site.options ) {
-		return previewUrl;
-	}
-
-	if ( site.options.is_mapped_domain ) {
-		previewUrl = previewUrl.replace( site.URL, site.options.unmapped_url );
-	}
-
-	if ( site.options.frame_nonce ) {
+	let previewUrl = url;
+	if ( 'publish' !== status ) {
 		previewUrl = addQueryArgs( {
-			'frame-nonce': site.options.frame_nonce
+			preview: true
 		}, previewUrl );
 	}
 

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -24,6 +24,7 @@ import {
 	getPostEdits,
 	getEditedPostValue,
 	isEditedPostDirty,
+	getPostPreviewUrl
 } from '../selectors';
 import PostQueryManager from 'lib/query-manager/post';
 
@@ -1037,6 +1038,125 @@ describe( 'selectors', () => {
 			}, 2916284, 841 );
 
 			expect( isDirty ).to.be.true;
+		} );
+	} );
+
+	describe( 'getPostPreviewUrl()', () => {
+		it( 'should return null if the post is not known', () => {
+			const previewUrl = getPostPreviewUrl( {
+				posts: {
+					items: {}
+				},
+				sites: {
+					items: {}
+				}
+			}, 2916284, 841 );
+
+			expect( previewUrl ).to.be.null;
+		} );
+
+		it( 'should return null if the post has no URL', () => {
+			const previewUrl = getPostPreviewUrl( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': {
+							ID: 841,
+							site_ID: 2916284,
+							global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64'
+						}
+					}
+				},
+				sites: {
+					items: {}
+				}
+			}, 2916284, 841 );
+
+			expect( previewUrl ).to.be.null;
+		} );
+
+		it( 'should return null if the post is trashed', () => {
+			const previewUrl = getPostPreviewUrl( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': {
+							ID: 841,
+							site_ID: 2916284,
+							global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+							URL: 'http://example.com/post-url',
+							status: 'trash'
+						}
+					}
+				},
+				sites: {
+					items: {}
+				}
+			}, 2916284, 841 );
+
+			expect( previewUrl ).to.be.null;
+		} );
+
+		it( 'should prefer the post preview URL if available', () => {
+			const previewUrl = getPostPreviewUrl( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': {
+							ID: 841,
+							site_ID: 2916284,
+							global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+							status: 'publish',
+							URL: 'http://example.com/post-url',
+							preview_URL: 'https://example.com/preview-url'
+						}
+					}
+				},
+				sites: {
+					items: {}
+				}
+			}, 2916284, 841 );
+
+			expect( previewUrl ).to.equal( 'https://example.com/preview-url' );
+		} );
+
+		it( 'should use post URL if preview URL not available', () => {
+			const previewUrl = getPostPreviewUrl( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': {
+							ID: 841,
+							site_ID: 2916284,
+							global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+							status: 'publish',
+							URL: 'https://example.com/post-url'
+						}
+					}
+				},
+				sites: {
+					items: {}
+				}
+			}, 2916284, 841 );
+
+			expect( previewUrl ).to.equal( 'https://example.com/post-url' );
+		} );
+
+		it( 'should append preview query argument to non-published posts', () => {
+			const previewUrl = getPostPreviewUrl( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': {
+							ID: 841,
+							site_ID: 2916284,
+							global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+							status: 'draft',
+							URL: 'https://example.com/post-url?other_arg=1'
+						}
+					}
+				},
+				sites: {
+					items: {}
+				}
+			}, 2916284, 841 );
+
+			expect( previewUrl ).to.equal( 'https://example.com/post-url?other_arg=1&preview=true' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to enable a user to view a post on the [custom post types list screen](https://wpcalypso.wordpress.com/types/post) via the "View" menu action.

![view](https://cloud.githubusercontent.com/assets/1779930/16594966/e1d5e37a-42ba-11e6-9125-858619118112.gif)

__Implementation notes:__

Implementation for included `getPostPreviewUrl` referenced from [existing `PostUtils.getPreviewURL`](https://github.com/Automattic/wp-calypso/blob/178b3e7814e1c106928b78b42b5813f1b76bf48c/client/lib/posts/utils.js#L20-L52).

__Testing instructions:__

Verify that a WebPreview is shown in response to clicking View on the custom post types list screen, and that you can open the preview in an external window either via the external link in the `<WebPreview />` component or right-click options in the list view menu.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site, if prompted (Optional: Choose a secure blog where frame nonce is required)
3. (Optional) Change filter, as preview URL may vary by post status
4. In the list, select View for a post under the menu toggle
5. Note that a preview for that post is shown in a `<WebPreview />`

Test live: https://calypso.live/?branch=update/cpt-view-post