### PR TITLE
CPT: Display notice when permanent deletion succeeds or fails

### DIFF
--- a/client/state/notices/reducer.js
+++ b/client/state/notices/reducer.js
@@ -13,6 +13,8 @@ import { translate } from 'i18n-calypso';
 import {
 	NOTICE_CREATE,
 	NOTICE_REMOVE,
+	POST_DELETE_FAILURE,
+	POST_DELETE_SUCCESS,
 	POST_SAVE_SUCCESS,
 	ROUTE_SET
 } from 'state/action-types';
@@ -87,6 +89,48 @@ export const items = createReducer( {}, {
 				noticeId,
 				count,
 				text
+			}
+		};
+	},
+	[ POST_DELETE_SUCCESS ]: ( state, action ) => {
+		// A request to permanently delete a post has completed successfully
+		const count = get( state, [ action.type, 'count' ], 0 ) + 1;
+
+		let text;
+		if ( 1 === count ) {
+			text = translate( 'Post successfully deleted' );
+		} else {
+			text = translate(
+				'%d post successfully deleted',
+				'%d posts successfully deleted',
+				{ count, args: [ count ] }
+			);
+		}
+
+		return {
+			...state,
+			[ action.type ]: {
+				showDismiss: true,
+				isPersistent: false,
+				displayOnNextPage: false,
+				status: 'is-success',
+				noticeId: action.type,
+				count,
+				text
+			}
+		};
+	},
+	[ POST_DELETE_FAILURE ]: ( state, action ) => {
+		// A request to permanently delete a post has failed
+		return {
+			...state,
+			[ action.type ]: {
+				showDismiss: true,
+				isPersistent: false,
+				displayOnNextPage: false,
+				status: 'is-error',
+				noticeId: action.type,
+				text: translate( 'An error occurred while deleting the post' )
 			}
 		};
 	}

--- a/client/state/notices/test/reducer.js
+++ b/client/state/notices/test/reducer.js
@@ -10,6 +10,8 @@ import deepFreeze from 'deep-freeze';
 import {
 	NOTICE_CREATE,
 	NOTICE_REMOVE,
+	POST_DELETE_FAILURE,
+	POST_DELETE_SUCCESS,
 	POST_SAVE_SUCCESS,
 	ROUTE_SET
 } from 'state/action-types';
@@ -180,6 +182,76 @@ describe( 'reducer', () => {
 						noticeId: 'POST_SAVE_SUCCESS',
 						count: 2,
 						text: '2 posts successfully moved to trash'
+					}
+				} );
+			} );
+		} );
+
+		context( 'POST_DELETE_SUCCESS', () => {
+			it( 'should return state with single delete success', () => {
+				const original = deepFreeze( {} );
+				const state = items( original, {
+					type: POST_DELETE_SUCCESS
+				} );
+
+				expect( state ).to.eql( {
+					POST_DELETE_SUCCESS: {
+						showDismiss: true,
+						isPersistent: false,
+						displayOnNextPage: false,
+						status: 'is-success',
+						noticeId: 'POST_DELETE_SUCCESS',
+						count: 1,
+						text: 'Post successfully deleted'
+					}
+				} );
+			} );
+
+			it( 'should return state with multiple delete success', () => {
+				const original = deepFreeze( {
+					POST_DELETE_SUCCESS: {
+						showDismiss: true,
+						isPersistent: false,
+						displayOnNextPage: false,
+						status: 'is-success',
+						noticeId: 'POST_DELETE_SUCCESS',
+						count: 1,
+						text: 'Post successfully deleted'
+					}
+				} );
+				const state = items( original, {
+					type: POST_DELETE_SUCCESS
+				} );
+
+				expect( state ).to.eql( {
+					POST_DELETE_SUCCESS: {
+						showDismiss: true,
+						isPersistent: false,
+						displayOnNextPage: false,
+						status: 'is-success',
+						noticeId: 'POST_DELETE_SUCCESS',
+						count: 2,
+						text: '2 posts successfully deleted'
+					}
+				} );
+			} );
+		} );
+
+		context( 'POST_DELETE_FAILURE', () => {
+			it( 'should return state with delete failure notice', () => {
+				const original = deepFreeze( {} );
+				const state = items( original, {
+					type: POST_DELETE_FAILURE
+				} );
+
+				expect( state ).to.eql( {
+					POST_DELETE_FAILURE: {
+						showDismiss: true,
+						isPersistent: false,
+						displayOnNextPage: false,
+						status: 'is-error',
+						noticeId: 'POST_DELETE_FAILURE',
+						text: 'An error occurred while deleting the post'
 					}
 				} );
 			} );


### PR DESCRIPTION
Related: #6306

This pull request seeks to cause a notice to be displayed after a request to permanently delete a post has completed, reflecting the success or failure of that request.

![delete](https://cloud.githubusercontent.com/assets/1779930/16595799/e927beb0-42be-11e6-8252-f2c7fdf83544.gif)

__Testing instructions:__

Verify that a notice is shown after a post permanent delete request finishes. You can force a delete failure by toggling the "Offline" throttle option in Chrome Developer Tools Network tab.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site, if prompted
3. (Prerequisite) If Trashed filter is not available (because of no trashed posts), first trash a post
4. Select the Trashed filter
5. Under a post's action menu, select Permanently Delete and confirm your choice
6. Note that after the request completes, a notice is shown reflecting its success or failure

Test live: https://calypso.live/?branch=add/cpt-delete-post-notice