### PR TITLE
CPT: Display list post titles as bold

### DIFF
--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -71,7 +71,6 @@
 		.post-type-list__post.is-untitled & {
 			color: $gray;
 			font-style: italic;
-			font-weight: 400;
 		}
 	}
 }

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -54,6 +54,7 @@
 .post-type-list__post-title {
 	@extend %content-font;
 	margin-bottom: 2px;
+	font-weight: 700;
 	white-space: nowrap;
 
 	a {


### PR DESCRIPTION
Closes #6535 

This pull request seeks to display the post titles on the [custom post types list screen](https://wpcalypso.wordpress.com/types/post) as bold.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16596042/17cdb5b6-42c0-11e6-9b6b-d62605cbbf20.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16596051/216f83ec-42c0-11e6-8398-17a5a14ebfa6.png)

__Testing instructions:__

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site, if prompted
3. Note that post titles are shown as bold

/cc @hugobaeta 

Test live: https://calypso.live/?branch=update/6535-cpt-bold-title