### PR TITLE
Framework: Add babel-plugin-lodash to enable root Lodash imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,7 @@
 		"add-module-exports",
 		"syntax-jsx",
 		"transform-react-jsx",
-		"transform-react-display-name"
+		"transform-react-display-name",
+		"lodash"
 	]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,7 +115,6 @@ module.exports = {
 		// Common top-of-file requires, expressions between external, interal
 		'vars-on-top': 1,
 		// Custom rules
-		'wpcalypso/no-lodash-import': 2,
 		'wpcalypso/i18n-ellipsis': 1,
 		'wpcalypso/i18n-no-variables': 1,
 		'wpcalypso/i18n-no-placeholders-only': 1,

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -3,12 +3,7 @@
 /**
  * External dependencies
  */
-import map from 'lodash/map';
-import filter from 'lodash/filter';
-import some from 'lodash/some';
-import includes from 'lodash/includes';
-import find from 'lodash/find';
-import get from 'lodash/get';
+import { map, filter, some, includes, find, get } from 'lodash';
 
 /**
  * Internal dependencies

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -232,7 +232,7 @@
       "version": "6.9.0"
     },
     "babel-helper-remap-async-to-generator": {
-      "version": "6.8.0"
+      "version": "6.11.2"
     },
     "babel-helper-replace-supers": {
       "version": "6.8.0"
@@ -266,6 +266,14 @@
     },
     "babel-plugin-jscript": {
       "version": "1.0.4"
+    },
+    "babel-plugin-lodash": {
+      "version": "3.2.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.13.1"
+        }
+      }
     },
     "babel-plugin-member-expression-literals": {
       "version": "1.0.1"
@@ -455,7 +463,7 @@
       "version": "6.11.1"
     },
     "babylon": {
-      "version": "6.8.2"
+      "version": "6.8.3"
     },
     "backo2": {
       "version": "1.0.2"
@@ -491,7 +499,7 @@
       "version": "3.1.3"
     },
     "binary-extensions": {
-      "version": "1.4.1"
+      "version": "1.5.0"
     },
     "bl": {
       "version": "1.1.2"
@@ -587,7 +595,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000488"
+      "version": "1.0.30000492"
     },
     "caseless": {
       "version": "0.11.0"
@@ -644,7 +652,7 @@
       "version": "1.6.0"
     },
     "chrono-node": {
-      "version": "1.2.3"
+      "version": "1.2.4"
     },
     "classnames": {
       "version": "1.1.1"
@@ -910,7 +918,7 @@
       "version": "1.1.2",
       "dependencies": {
         "object-keys": {
-          "version": "1.0.9"
+          "version": "1.0.11"
         }
       }
     },
@@ -1101,12 +1109,7 @@
       "version": "1.1.1"
     },
     "es5-ext": {
-      "version": "0.10.11",
-      "dependencies": {
-        "es6-symbol": {
-          "version": "3.0.2"
-        }
-      }
+      "version": "0.10.12"
     },
     "es6-iterator": {
       "version": "2.0.0"
@@ -1219,7 +1222,7 @@
           "version": "1.1.3"
         },
         "globals": {
-          "version": "9.8.0"
+          "version": "9.9.0"
         },
         "strip-json-comments": {
           "version": "1.0.4"
@@ -2101,7 +2104,7 @@
       }
     },
     "loud-rejection": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "lower-case": {
       "version": "1.1.3"
@@ -2278,9 +2281,6 @@
     "node-gyp": {
       "version": "3.4.0",
       "dependencies": {
-        "glob": {
-          "version": "7.0.5"
-        },
         "graceful-fs": {
           "version": "4.1.4"
         },
@@ -2371,10 +2371,10 @@
       "version": "0.4.0"
     },
     "object.assign": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dependencies": {
         "object-keys": {
-          "version": "1.0.9"
+          "version": "1.0.11"
         }
       }
     },
@@ -2609,7 +2609,7 @@
       "version": "1.2.4"
     },
     "protochain": {
-      "version": "1.0.3"
+      "version": "1.0.5"
     },
     "proxy-addr": {
       "version": "1.0.10"
@@ -2911,7 +2911,7 @@
       "version": "0.1.3"
     },
     "rimraf": {
-      "version": "2.5.2",
+      "version": "2.5.3",
       "dependencies": {
         "glob": {
           "version": "7.0.5"
@@ -2980,12 +2980,6 @@
         },
         "cliui": {
           "version": "3.2.0"
-        },
-        "glob": {
-          "version": "7.0.5"
-        },
-        "minimatch": {
-          "version": "3.0.2"
         },
         "set-blocking": {
           "version": "1.0.0"
@@ -3403,7 +3397,7 @@
       "version": "1.4.2"
     },
     "tiny-emitter": {
-      "version": "1.0.2"
+      "version": "1.1.0"
     },
     "tinymce": {
       "version": "4.3.12"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-core": "6.9.1",
     "babel-loader": "6.2.4",
     "babel-plugin-add-module-exports": "0.2.1",
+    "babel-plugin-lodash": "3.2.0",
     "babel-plugin-syntax-jsx": "6.8.0",
     "babel-plugin-transform-class-properties": "6.9.1",
     "babel-plugin-transform-export-extensions": "6.8.0",

--- a/server/config/test/data/mocks.js
+++ b/server/config/test/data/mocks.js
@@ -1,4 +1,8 @@
+/**
+ * External dependencies
+ */
 import path from 'path';
+import fs from 'fs';
 
 function toJSON( val ) {
 	return JSON.stringify( val );
@@ -6,11 +10,13 @@ function toJSON( val ) {
 
 export default {
 	INVALID_PATH: {
+		...fs,
 		existsSync: () => false,
 		readFileSync: () => ''
 	},
 
 	VALID_SECRETS: {
+		...fs,
 		existsSync: ( file ) => {
 			switch ( path.basename( file ) ) {
 				case 'secrets.json':
@@ -38,6 +44,7 @@ export default {
 	},
 
 	VALID_ENV_FILES: {
+		...fs,
 		existsSync: ( file ) => {
 			switch ( path.basename( file ) ) {
 				case '_shared.json':


### PR DESCRIPTION
Related: #3015, #735

This pull request seeks to include [babel-plugin-lodash](https://www.npmjs.com/package/babel-plugin-lodash) in our Babel configuration to allow for root Lodash imports without worrying about unnecessarily bloating the size of resulting bundles.

Before / After reflects build without Babel plugin, then build with plugin and sites selectors dependency revisions (4995c88).

Before|After
---|---
![before](https://cloud.githubusercontent.com/assets/1779930/16597217/bdf9e400-42c5-11e6-9120-2a013a87d409.png)|![after](https://cloud.githubusercontent.com/assets/1779930/16597216/bdf88ea2-42c5-11e6-9ca5-f13b4660b3ba.png)

__Testing instructions:__

May be worth having a second set of eyes on before/after build sizes to confirm that no bundle bloating occurs. Verify that no regressions occur in usage of application (sites selectors are pretty pervasive through the app, notably My Sites section).

Test live: https://calypso.live/?branch=add/babel-plugin-lodash