### PR TITLE
Remove Purchase Survey: Force users to fill out field for 'Another reason...'

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -254,7 +254,11 @@ const RemovePurchase = React.createClass( {
 				},
 				next: {
 					action: 'next',
-					disabled: this.state.isRemoving || this.state.questionOneRadio == null || this.state.questionTwoRadio == null,
+					disabled: this.state.isRemoving ||
+						this.state.questionOneRadio == null ||
+						this.state.questionTwoRadio == null ||
+						( this.state.questionOneRadio === 'anotherReasonOne' && this.state.questionOneText === '' ) ||
+						( this.state.questionTwoRadio === 'anotherReasonTwo' && this.state.questionTwoText === '' ),
 					label: this.translate( 'Next' ),
 					onClick: this.changeSurveyStep
 				},

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -255,8 +255,8 @@ const RemovePurchase = React.createClass( {
 				next: {
 					action: 'next',
 					disabled: this.state.isRemoving ||
-						this.state.questionOneRadio == null ||
-						this.state.questionTwoRadio == null ||
+						this.state.questionOneRadio === null ||
+						this.state.questionTwoRadio === null ||
 						( this.state.questionOneRadio === 'anotherReasonOne' && this.state.questionOneText === '' ) ||
 						( this.state.questionTwoRadio === 'anotherReasonTwo' && this.state.questionTwoText === '' ),
 					label: this.translate( 'Next' ),


### PR DESCRIPTION
This PR forces users to fill out the text form if they select 'Another reason...' as an option.

### /purchases/:site/:purchase

Select a site with an upgrade from http://calypso.localhost:3000/purchases/

<img width="1169" alt="screen shot 2016-06-22 at 10 15 46 am" src="https://cloud.githubusercontent.com/assets/273708/16276395/04aad1e2-3863-11e6-80aa-4014eb6938c0.png">

Remove a product and select an answer for both questions w/ 'Another reason...' as one (or both) of the answers). The 'Next' button should be disabled.

<img width="480" alt="screen shot 2016-07-05 at 5 37 27 pm" src="https://cloud.githubusercontent.com/assets/273708/16604166/659553dc-42d7-11e6-8193-86d105619790.png">

Now fill in the text field with a response and the 'Next' button should be enabled.

<img width="472" alt="screen shot 2016-07-05 at 5 37 39 pm" src="https://cloud.githubusercontent.com/assets/273708/16604183/850ace18-42d7-11e6-8c9f-b99652ee9be0.png">
