### PR TITLE
Remove quotes around CSS keyframe identifiers

### DIFF
--- a/assets/stylesheets/shared/_animation.scss
+++ b/assets/stylesheets/shared/_animation.scss
@@ -229,7 +229,7 @@ html {
 }
 
 // Simple animation to make elements appear
-@keyframes "appear" {
+@keyframes appear {
 	0% {
 		opacity: 0;
 	}
@@ -238,17 +238,17 @@ html {
 	}
 }
 
-@keyframes "pulse-light" {
+@keyframes pulse-light {
 	50% { background-color: lighten( $gray, 30% ); }
 }
 
-@keyframes "loading-dot-pulse" {
+@keyframes loading-dot-pulse {
 	0% { opacity: 0; }
 	50% { opacity: 1; }
 	100% { opacity: 0; }
 }
 
-@keyframes "loading-fade" {
+@keyframes loading-fade {
 	0% { opacity: .5; }
 	50% { opacity: 1; }
 	100% { opacity: .5; }


### PR DESCRIPTION
Fix for [#5797](https://github.com/Automattic/wp-calypso/issues/5797).

This PR removes the quotes around some of the CSS keyframe animation names.

**Testing**
*loading-dot-pulse*
This animation is applied to the ellipsis at the end of the "Trashing Post..." message when moving a post to the trash.

*pulse-light*
This animation pulsates the title box briefly when opening a post, before the title is populated.

*loading-fade*
This animation applies a fade effect to the cards on the Themes page before the images load.

*appear*
When saving changes to My Profile, this animation fades in the "Settings saved successfully!" message.

This is not a complete list of the scenarios in which these animations are applied, but should suffice for testing purposes.

Test live: https://calypso.live/?branch=fix/keyframe-animation-names