### PR TITLE
Editor: CPT: Remove <TermTokenField taxonomyLabel="" /> prop

### DIFF
--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -49,7 +49,6 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 							<TermTokenField
 								postTerms={ postTerms }
 								taxonomyName={ taxonomy.name }
-								taxonomyLabel={ taxonomy.label }
 							/>
 						</Accordion>
 					);

--- a/client/post-editor/term-token-field/index.jsx
+++ b/client/post-editor/term-token-field/index.jsx
@@ -11,6 +11,9 @@ import _debug from 'debug';
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getTerms } from 'state/terms/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
+import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import TokenField from 'components/token-field';
 import { decodeEntities } from 'lib/formatting';
 import TermsConstants from 'lib/terms/constants';
@@ -96,8 +99,13 @@ TermTokenField.propTypes = {
 export default connect( ( state, props ) => {
 	const siteId = getSelectedSiteId( state );
 
+	const postId = getEditorPostId( state );
+	const postType = getEditedPostValue( state, siteId, postId, 'type' );
+	const taxonomy = getPostTypeTaxonomy( state, siteId, postType, props.taxonomyName );
+
 	return {
-		siteId: siteId,
+		siteId,
+		taxonomyLabel: taxonomy && taxonomy.label,
 		terms: getTerms( state, siteId, props.taxonomyName ),
 	};
 } )( TermTokenField );

--- a/client/state/post-types/taxonomies/selectors.js
+++ b/client/state/post-types/taxonomies/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import find from 'lodash/find';
 import get from 'lodash/get';
 import values from 'lodash/values';
 
@@ -33,4 +34,23 @@ export function getPostTypeTaxonomies( state, siteId, postType ) {
 	}
 
 	return values( taxonomies );
+}
+
+/**
+ * Returns the given taxonomy for the given post type on a site, or null if the
+ * taxonomies are not known.
+ *
+ * @param  {Object}  state        Global state tree
+ * @param  {Number}  siteId       Site ID
+ * @param  {String}  postType     Post type
+ * @param  {String}  taxonomyName Taxonomy name
+ * @return {Object?}              Post type taxonomy
+ */
+export function getPostTypeTaxonomy( state, siteId, postType, taxonomyName ) {
+	const taxonomies = getPostTypeTaxonomies( state, siteId, postType );
+	if ( ! taxonomies ) {
+		return null;
+	}
+
+	return find( taxonomies, { name: taxonomyName } ) || null;
 }

--- a/client/state/post-types/taxonomies/test/selectors.js
+++ b/client/state/post-types/taxonomies/test/selectors.js
@@ -8,7 +8,8 @@ import { expect } from 'chai';
  */
 import {
 	isRequestingPostTypeTaxonomies,
-	getPostTypeTaxonomies
+	getPostTypeTaxonomies,
+	getPostTypeTaxonomy
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -115,6 +116,98 @@ describe( 'selectors', () => {
 				{ name: 'category', label: 'Categories' },
 				{ name: 'post_tag', label: 'Tags' }
 			] );
+		} );
+	} );
+
+	describe( 'getPostTypeTaxonomy', () => {
+		it( 'should return null if taxonomies are not known', () => {
+			const taxonomy = getPostTypeTaxonomy( {
+				postTypes: {
+					taxonomies: {
+						items: {}
+					}
+				}
+			}, 2916284, 'post', 'post_tag' );
+
+			expect( taxonomy ).to.be.null;
+		} );
+
+		it( 'should return null if post type is not known', () => {
+			const taxonomy = getPostTypeTaxonomy( {
+				postTypes: {
+					taxonomies: {
+						items: {
+							2916284: {
+								post: {
+									category: {
+										name: 'category',
+										label: 'Categories'
+									},
+									post_tag: {
+										name: 'post_tag',
+										label: 'Tags'
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'page', 'post_tag' );
+
+			expect( taxonomy ).to.be.null;
+		} );
+
+		it( 'should return null if taxonomy is not known', () => {
+			const taxonomy = getPostTypeTaxonomy( {
+				postTypes: {
+					taxonomies: {
+						items: {
+							2916284: {
+								post: {
+									category: {
+										name: 'category',
+										label: 'Categories'
+									},
+									post_tag: {
+										name: 'post_tag',
+										label: 'Tags'
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'post', 'not_a_taxonomy' );
+
+			expect( taxonomy ).to.be.null;
+		} );
+
+		it( 'should return a known taxonomy', () => {
+			const taxonomy = getPostTypeTaxonomy( {
+				postTypes: {
+					taxonomies: {
+						items: {
+							2916284: {
+								post: {
+									category: {
+										name: 'category',
+										label: 'Categories'
+									},
+									post_tag: {
+										name: 'post_tag',
+										label: 'Tags'
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'post', 'post_tag' );
+
+			expect( taxonomy ).to.eql( {
+				name: 'post_tag',
+				label: 'Tags'
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Prompted by https://github.com/Automattic/wp-calypso/pull/6468/files#r69581340.

### To test

Verify no functional changes when editing non-hierarchical CPT terms:

> Edit a post of a custom type that has one or more non-hierarchical taxonomies.  Ensure that existing taxonomies are loaded correctly in the `TokenField`:

> - values (terms assigned to the saved post)
> - suggestions (all terms from the site)

> Ensure that terms can be updated and saved as expected.


Test live: https://calypso.live/?branch=update/editor/cpt-terms-remove-label-prop