### PR TITLE
Add guards to decodeEntieties so it is not called with undefined.

### DIFF
--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -38,4 +38,6 @@ Head.propTypes = {
 	children: React.PropTypes.node,
 };
 
+Head.defaultProps = { site_name: 'WordPress.com' };
+
 export default Head;

--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -35,6 +35,9 @@ Head.propTypes = {
 	title: React.PropTypes.string,
 	description: React.PropTypes.string,
 	canonicalUrl: React.PropTypes.string,
+	type: React.PropTypes.string,
+	siteName: React.PropTypes.string,
+	image: React.PropTypes.string,
 	children: React.PropTypes.node,
 };
 

--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:layout:head' );
 
-const Head = ( { title, description, canonicalUrl, type, site_name, image, children } ) => (
+const Head = ( { title, description, canonicalUrl, type, siteName, image, children } ) => (
 	<div>
 		<Helmet
 			title={ title }
@@ -18,7 +18,7 @@ const Head = ( { title, description, canonicalUrl, type, site_name, image, child
 				title ? { property: 'og:title', content: title } : {},
 				canonicalUrl ? { property: 'og:url', content: canonicalUrl } : {},
 				type ? { property: 'og:type', content: type } : {},
-				site_name ? { property: 'og:site_name', content: site_name } : {},
+				siteName ? { property: 'og:site_name', content: siteName } : {},
 				image ? { property: 'og:image', content: image } : {},
 			] }
 			link={ [

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -88,8 +88,8 @@ export function details( context, next ) {
 	const props = {
 		themeSlug: slug,
 		contentSection: context.params.section,
-		title: decodeEntities( title ) + ' — WordPress.com', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
-		description: decodeEntities( themeDetails.description ),
+		title: title ? decodeEntities( title ) + ' — WordPress.com' : '', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
+		description: themeDetails.description ? decodeEntities( themeDetails.description ) : '',
 		canonicalUrl: `https://wordpress.com/theme/${ slug }`, // TODO: use getDetailsUrl() When it becomes availavle
 		image: themeDetails.screenshot,
 		isLoggedIn: !! user

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -2,10 +2,8 @@
  * External Dependencies
  */
 import React from 'react';
-import omit from 'lodash/omit';
 import debugFactory from 'debug';
 import startsWith from 'lodash/startsWith';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -13,7 +11,6 @@ import i18n from 'i18n-calypso';
 import ThemeSheetComponent from './main';
 import ThemeDetailsComponent from 'components/data/theme-details';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { getThemeDetails } from 'state/themes/theme-details/selectors';
 import {
 	receiveThemeDetails,
 	receiveThemeDetailsFailure,
@@ -23,7 +20,7 @@ import wpcom from 'lib/wp';
 import config from 'config';
 
 const debug = debugFactory( 'calypso:themes' );
-let themeDetailsCache = new Map();
+const themeDetailsCache = new Map();
 
 export function fetchThemeDetailsData( context, next ) {
 	if ( ! config.isEnabled( 'manage/themes/details' ) || ! context.isServerSide ) {
@@ -61,11 +58,6 @@ export function fetchThemeDetailsData( context, next ) {
 export function details( context, next ) {
 	const { slug } = context.params;
 	const user = getCurrentUser( context.store.getState() );
-	const themeDetails = getThemeDetails( context.store.getState(), slug ) || false;
-	const themeName = themeDetails.name;
-	const title = i18n.translate( '%(themeName)s Theme', {
-		args: { themeName }
-	} );
 
 	if ( startsWith( context.prevPath, '/design' ) ) {
 		context.store.dispatch( setBackPath( context.prevPath ) );
@@ -77,7 +69,7 @@ export function details( context, next ) {
 		</ThemeDetailsComponent>
 	);
 
-	context.primary = ConnectedComponent( { themeSlug : slug, contentSection: context.params.section, isLoggedIn: !! user } );
+	context.primary = ConnectedComponent( { themeSlug: slug, contentSection: context.params.section, isLoggedIn: !! user } );
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();
 }

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -21,7 +21,6 @@ import {
 } from 'state/themes/actions';
 import wpcom from 'lib/wp';
 import config from 'config';
-import { decodeEntities } from 'lib/formatting';
 
 const debug = debugFactory( 'calypso:themes' );
 let themeDetailsCache = new Map();

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -26,20 +26,6 @@ import { decodeEntities } from 'lib/formatting';
 const debug = debugFactory( 'calypso:themes' );
 let themeDetailsCache = new Map();
 
-export function makeElement( ThemesComponent, Head, store, props ) {
-	return (
-		<Head
-			title={ props.title }
-			description={ props.description }
-			type={ 'website' }
-			canonicalUrl={ props.canonicalUrl }
-			image={ props.image }
-			tier={ props.tier || 'all' }>
-			<ThemesComponent { ...omit( props, [ 'title' ] ) } />
-		</Head>
-	);
-}
-
 export function fetchThemeDetailsData( context, next ) {
 	if ( ! config.isEnabled( 'manage/themes/details' ) || ! context.isServerSide ) {
 		return next();
@@ -81,19 +67,6 @@ export function details( context, next ) {
 	const title = i18n.translate( '%(themeName)s Theme', {
 		args: { themeName }
 	} );
-	const Head = user
-		? require( 'layout/head' )
-		: require( 'my-sites/themes/head' );
-
-	const props = {
-		themeSlug: slug,
-		contentSection: context.params.section,
-		title: title ? decodeEntities( title ) + ' — WordPress.com' : '', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
-		description: themeDetails.description ? decodeEntities( themeDetails.description ) : '',
-		canonicalUrl: `https://wordpress.com/theme/${ slug }`, // TODO: use getDetailsUrl() When it becomes availavle
-		image: themeDetails.screenshot,
-		isLoggedIn: !! user
-	};
 
 	if ( startsWith( context.prevPath, '/design' ) ) {
 		context.store.dispatch( setBackPath( context.prevPath ) );
@@ -105,7 +78,7 @@ export function details( context, next ) {
 		</ThemeDetailsComponent>
 	);
 
-	context.primary = makeElement( ConnectedComponent, Head, context.store, props );
+	context.primary = ConnectedComponent( { themeSlug : slug, contentSection: context.params.section, isLoggedIn: !! user } );
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();
 }

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import debugFactory from 'debug';
 import startsWith from 'lodash/startsWith';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * Internal Dependencies
@@ -16,6 +17,7 @@ import {
 	receiveThemeDetailsFailure,
 	setBackPath
 } from 'state/themes/actions';
+import { getThemeDetails } from 'state/themes/theme-details/selectors';
 import wpcom from 'lib/wp';
 import config from 'config';
 
@@ -23,12 +25,20 @@ const debug = debugFactory( 'calypso:themes' );
 const themeDetailsCache = new Map();
 
 export function fetchThemeDetailsData( context, next ) {
-	if ( ! config.isEnabled( 'manage/themes/details' ) || ! context.isServerSide ) {
+	if ( ! config.isEnabled( 'manage/themes/details' ) ) {
 		return next();
 	}
 
 	const themeSlug = context.params.slug;
-	const theme = themeDetailsCache.get( themeSlug );
+
+	// If theme details for the given slug are present in the Redux state,
+	// it has been filled earlier during this request, so we can re-use it.
+	let theme = getThemeDetails( context.store.getState(), themeSlug );
+	if ( ! isEmpty( theme ) ) {
+		return next();
+	}
+
+	theme = themeDetailsCache.get( themeSlug );
 
 	const HOUR_IN_MS = 3600000;
 	if ( theme && ( theme.timestamp + HOUR_IN_MS > Date.now() ) ) {

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import debugFactory from 'debug';
 import startsWith from 'lodash/startsWith';
-import isEmpty from 'lodash/isEmpty';
 
 /**
  * Internal Dependencies
@@ -17,7 +16,6 @@ import {
 	receiveThemeDetailsFailure,
 	setBackPath
 } from 'state/themes/actions';
-import { getThemeDetails } from 'state/themes/theme-details/selectors';
 import wpcom from 'lib/wp';
 import config from 'config';
 
@@ -25,20 +23,12 @@ const debug = debugFactory( 'calypso:themes' );
 const themeDetailsCache = new Map();
 
 export function fetchThemeDetailsData( context, next ) {
-	if ( ! config.isEnabled( 'manage/themes/details' ) ) {
+	if ( ! config.isEnabled( 'manage/themes/details' ) || ! context.isServerSide ) {
 		return next();
 	}
 
 	const themeSlug = context.params.slug;
-
-	// If theme details for the given slug are present in the Redux state,
-	// it has been filled earlier during this request, so we can re-use it.
-	let theme = getThemeDetails( context.store.getState(), themeSlug );
-	if ( ! isEmpty( theme ) ) {
-		return next();
-	}
-
-	theme = themeDetailsCache.get( themeSlug );
+	const theme = themeDetailsCache.get( themeSlug );
 
 	const HOUR_IN_MS = 3600000;
 	if ( theme && ( theme.timestamp + HOUR_IN_MS > Date.now() ) ) {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -347,18 +347,17 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const themeName = this.props.name;
-		const title = i18n.translate( '%(themeName)s Theme', {
-			args: { themeName }
-		} ); // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
+		const title = decodeEntities( i18n.translate( '%(themeName)s Theme', {
+			args: { themeName: this.props.name }
+		} ) ) + ' — WordPress.com'; // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
 
 		const canonicalUrl = `https://wordpress.com/theme/${ this.props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
 
 		return (
 
 			<Head
-				title= { decodeEntities( title || '' ) + ' — WordPress.com' }
-				description={ decodeEntities( this.props.description || '' ) }
+				title= { title }
+				description={ decodeEntities( this.props.description ) }
 				type={ 'website' }
 				canonicalUrl={ canonicalUrl }
 				image={ this.props.screenshot }>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -350,10 +350,10 @@ const ThemeSheet = React.createClass( {
 			? require( 'layout/head' )
 			: require( 'my-sites/themes/head' );
 
-		const themeName =  this.props.name ;
+		const themeName = this.props.name;
 		const title = i18n.translate( '%(themeName)s Theme', {
 			args: { themeName }
-		} )
+		} );
 
 		const canonicalUrl = `https://wordpress.com/theme/${ this.props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
 
@@ -363,7 +363,7 @@ const ThemeSheet = React.createClass( {
 				title= { decodeEntities( title || '' ) + ' — WordPress.com' }
 				description={ decodeEntities( this.props.description || '' ) }
 				type={ 'website' }
-			 	canonicalUrl={ canonicalUrl }
+				canonicalUrl={ canonicalUrl }
 				image={ this.props.screenshot }
 				tier={ this.props.tier || 'all' }>
 				<Main className="theme__sheet">

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -45,6 +45,7 @@ import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import ThemePreview from 'my-sites/themes/theme-preview';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { decodeEntities } from 'lib/formatting';
 
 const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -345,33 +346,53 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
+		const Head = this.props.isLoggedIn
+			? require( 'layout/head' )
+			: require( 'my-sites/themes/head' );
+
+		const themeName =  this.props.name ;
+		const title = i18n.translate( '%(themeName)s Theme', {
+			args: { themeName }
+		} )
+
+		const canonicalUrl = `https://wordpress.com/theme/${ this.props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
+
 		return (
-			<Main className="theme__sheet">
-			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle }/>
-				{ this.renderBar() }
-				{ siteID && <QueryCurrentTheme siteId={ siteID }/> }
-				<ThanksModal
-					site={ this.props.selectedSite }
-					source={ 'details' }/>
-				{ this.state.showPreview && this.renderPreview() }
-				<HeaderCake className="theme__sheet-action-bar"
-							backHref={ this.props.backPath }
-							backText={ i18n.translate( 'All Themes' ) }>
-					{ this.renderButton() }
-				</HeaderCake>
-				<div className="theme__sheet-columns">
-					<div className="theme__sheet-column-left">
-						<div className="theme__sheet-content">
-							{ this.renderSectionNav( section ) }
-							{ this.renderSectionContent( section ) }
-							<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
+
+			<Head
+				title= { decodeEntities( title || '' ) + ' — WordPress.com' }
+				description={ decodeEntities( this.props.description || '' ) }
+				type={ 'website' }
+			 	canonicalUrl={ canonicalUrl }
+				image={ this.props.screenshot }
+				tier={ this.props.tier || 'all' }>
+				<Main className="theme__sheet">
+					<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle }/>
+						{ this.renderBar() }
+						{ siteID && <QueryCurrentTheme siteId={ siteID }/> }
+					<ThanksModal
+						site={ this.props.selectedSite }
+						source={ 'details' }/>
+					{ this.state.showPreview && this.renderPreview() }
+					<HeaderCake className="theme__sheet-action-bar"
+								backHref={ this.props.backPath }
+								backText={ i18n.translate( 'All Themes' ) }>
+						{ this.renderButton() }
+					</HeaderCake>
+					<div className="theme__sheet-columns">
+						<div className="theme__sheet-column-left">
+							<div className="theme__sheet-content">
+								{ this.renderSectionNav( section ) }
+								{ this.renderSectionContent( section ) }
+								<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
+							</div>
+						</div>
+						<div className="theme__sheet-column-right">
+							{ this.renderScreenshot() }
 						</div>
 					</div>
-					<div className="theme__sheet-column-right">
-						{ this.renderScreenshot() }
-					</div>
-				</div>
-			</Main>
+				</Main>
+			</Head>
 		);
 	},
 
@@ -384,40 +405,16 @@ const ThemeSheet = React.createClass( {
 } );
 
 const WrappedThemeSheet = ( props ) => {
-	const Head = props.isLoggedIn
-		? require( 'layout/head' )
-		: require( 'my-sites/themes/head' );
-
-	let sheet;
 	if ( ! props.isLoggedIn || props.selectedSite ) {
-		sheet = <ThemeSheet { ...props } />;
-	} else {
-		sheet = (
-			<ThemesSiteSelectorModal { ...props }
-				sourcePath={ `/theme/${ props.id }${ props.section ? '/' + props.section : '' }` }>
-				<ThemeSheet />
-			</ThemesSiteSelectorModal>
-		);
+		return <ThemeSheet { ...props } />;
 	}
 
-	const themeName = `${ props.name }s Theme`;
-	const title = themeName + ' — WordPress.com';
-
-	const canonicalUrl = `https://wordpress.com/theme/${ props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
-
 	return (
-		<Head
-			title= { title }
-			description={ props.description }
-			type={ 'website' }
-		 	canonicalUrl={ canonicalUrl }
-			image={ props.screenshot }
-			tier={ props.tier || 'all' } >
-			{ sheet }
-		</Head>
-		//sheet
-	)
-
+		<ThemesSiteSelectorModal { ...props }
+			sourcePath={ `/theme/${ props.id }${ props.section ? '/' + props.section : '' }` }>
+			<ThemeSheet />
+		</ThemesSiteSelectorModal>
+	);
 };
 
 const bindDefaultOptionToDispatch = ( dispatch, ownProps ) => {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -75,7 +75,7 @@ const ThemeSheet = React.createClass( {
 			label: React.PropTypes.string.isRequired,
 			action: React.PropTypes.func,
 			getUrl: React.PropTypes.func,
-		} ).isRequired,
+		} ),
 		secondaryOption: React.PropTypes.shape( {
 			label: React.PropTypes.string.isRequired,
 			action: React.PropTypes.func,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -347,7 +347,7 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const themeName = this.props.name;
+		const { name: themeName, description } = this.props;
 		const title = i18n.translate( '%(themeName)s Theme', {
 			args: { themeName }
 		} ); // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
@@ -357,8 +357,8 @@ const ThemeSheet = React.createClass( {
 		return (
 
 			<Head
-				title= { decodeEntities( title || '' ) + ' — WordPress.com' }
-				description={ decodeEntities( this.props.description || '' ) }
+				title= { themeName && decodeEntities( title ) + ' — WordPress.com' }
+				description={ description && decodeEntities( description ) }
 				type={ 'website' }
 				canonicalUrl={ canonicalUrl }
 				image={ this.props.screenshot }>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -45,6 +45,7 @@ import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import ThemePreview from 'my-sites/themes/theme-preview';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import Head from 'layout/head';
 import { decodeEntities } from 'lib/formatting';
 
 const ThemeSheet = React.createClass( {
@@ -346,14 +347,10 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const Head = this.props.isLoggedIn
-			? require( 'layout/head' )
-			: require( 'my-sites/themes/head' );
-
 		const themeName = this.props.name;
 		const title = i18n.translate( '%(themeName)s Theme', {
 			args: { themeName }
-		} );
+		} ); // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
 
 		const canonicalUrl = `https://wordpress.com/theme/${ this.props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -384,16 +384,40 @@ const ThemeSheet = React.createClass( {
 } );
 
 const WrappedThemeSheet = ( props ) => {
+	const Head = props.isLoggedIn
+		? require( 'layout/head' )
+		: require( 'my-sites/themes/head' );
+
+	let sheet;
 	if ( ! props.isLoggedIn || props.selectedSite ) {
-		return <ThemeSheet { ...props } />;
+		sheet = <ThemeSheet { ...props } />;
+	} else {
+		sheet = (
+			<ThemesSiteSelectorModal { ...props }
+				sourcePath={ `/theme/${ props.id }${ props.section ? '/' + props.section : '' }` }>
+				<ThemeSheet />
+			</ThemesSiteSelectorModal>
+		);
 	}
 
+	const themeName = `${ props.name }s Theme`;
+	const title = themeName + ' — WordPress.com';
+
+	const canonicalUrl = `https://wordpress.com/theme/${ props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
+
 	return (
-		<ThemesSiteSelectorModal { ...props }
-			sourcePath={ `/theme/${ props.id }${ props.section ? '/' + props.section : '' }` }>
-			<ThemeSheet />
-		</ThemesSiteSelectorModal>
-	);
+		<Head
+			title= { title }
+			description={ props.description }
+			type={ 'website' }
+		 	canonicalUrl={ canonicalUrl }
+			image={ props.screenshot }
+			tier={ props.tier || 'all' } >
+			{ sheet }
+		</Head>
+		//sheet
+	)
+
 };
 
 const bindDefaultOptionToDispatch = ( dispatch, ownProps ) => {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -361,8 +361,7 @@ const ThemeSheet = React.createClass( {
 				description={ decodeEntities( this.props.description || '' ) }
 				type={ 'website' }
 				canonicalUrl={ canonicalUrl }
-				image={ this.props.screenshot }
-				tier={ this.props.tier || 'all' }>
+				image={ this.props.screenshot }>
 				<Main className="theme__sheet">
 					<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle }/>
 						{ this.renderBar() }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -347,17 +347,18 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const title = decodeEntities( i18n.translate( '%(themeName)s Theme', {
-			args: { themeName: this.props.name }
-		} ) ) + ' — WordPress.com'; // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
+		const themeName = this.props.name;
+		const title = i18n.translate( '%(themeName)s Theme', {
+			args: { themeName }
+		} ); // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
 
 		const canonicalUrl = `https://wordpress.com/theme/${ this.props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
 
 		return (
 
 			<Head
-				title= { title }
-				description={ decodeEntities( this.props.description ) }
+				title= { decodeEntities( title || '' ) + ' — WordPress.com' }
+				description={ decodeEntities( this.props.description || '' ) }
 				type={ 'website' }
 				canonicalUrl={ canonicalUrl }
 				image={ this.props.screenshot }>

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,7 +1,9 @@
 /**
  * External Dependencies
  */
+import React from 'react';
 import i18n from 'i18n-calypso';
+import omit from 'lodash/omit';
 
 /**
  * Internal Dependencies
@@ -12,7 +14,20 @@ import LoggedOutComponent from './logged-out';
 import trackScrollPage from 'lib/track-scroll-page';
 import buildTitle from 'lib/screen-title/utils';
 import { getAnalyticsData } from './helpers';
-import { makeElement } from 'my-sites/theme/controller';
+
+function makeElement( ThemesComponent, Head, store, props ) {
+	return (
+		<Head
+			title={ props.title }
+			description={ props.description }
+			type={ 'website' }
+			canonicalUrl={ props.canonicalUrl }
+			image={ props.image }
+			tier={ props.tier || 'all' }>
+			<ThemesComponent { ...omit( props, [ 'title' ] ) } />
+		</Head>
+	);
+}
 
 function getProps( context ) {
 	const { tier, site_id: siteId } = context.params;

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -16,7 +16,7 @@ const ThemesHead = ( { title, description, canonicalUrl, type, image, tier, chil
 		description={ description ? description : get( 'description', tier ) }
 		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) }
 		type={ type ? type : 'website' }
-		site_name={ 'WordPress.com' }
+		siteName={ 'WordPress.com' }
 		image={ image ? image : {} } >
 		{ children }
 	</Head>

--- a/server/pragma-checker/index.js
+++ b/server/pragma-checker/index.js
@@ -13,6 +13,7 @@ var SSR_READY = '/** @ssr-ready **/';
 var IGNORED_MODULES = [
 	'config', // Different modules on client & server
 	'lib/wp', // Different modules on client & server
+	'lib/formatting', // Different modules on client & server
 	'lib/analytics', // nooped on the server until we develop an isomorphic version
 	'lib/route', // nooped on the server until we can extract the isomorphic bits
 	'lib/upgrades/actions', // nooped on the server as it still uses the singleton Flux architecture


### PR DESCRIPTION
In initial loading phase code was calling `decodeEntieties` before data was available. 
Now we check if the data is ready before the call.

To check:
1. open /desing
2. open /theme (info)
3. observe console

There should be no warnings regarding `decodeEntieties` being called with `null`, `false` or `undefined`.

Test live: https://calypso.live/?branch=fix/call_to_decodeentieties_with_undefined