### PR TITLE
Advanced SEO: Add Twitter Preview Component

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -13,6 +13,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import FacebookPreview from 'components/seo/facebook-preview';
+import TwitterPreview from 'components/seo/twitter-preview';
 import SearchPreview from 'components/seo/search-preview';
 import VerticalMenu from 'components/vertical-menu';
 import { SocialItem } from 'components/vertical-menu/items';
@@ -45,6 +46,26 @@ const PreviewFacebook = site => (
 			title={ site.name }
 			url={ site.URL }
 			type="article"
+			description={ site.description }
+			image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
+		/>
+	</div>
+);
+
+const PreviewTwitter = site => (
+	<div>
+		<TwitterPreview
+			title={ site.name }
+			url={ site.URL }
+			type="summary"
+			description={ site.description }
+			image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
+		/>
+		<div style={ { marginBottom: '2em' } } />
+		<TwitterPreview
+			title={ site.name }
+			url={ site.URL }
+			type="large_image_summary"
 			description={ site.description }
 			image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
 		/>
@@ -99,7 +120,8 @@ export class SeoPreviewPane extends PureComponent {
 					<div className="seo-preview-pane__preview">
 						{ get( {
 							facebook: PreviewFacebook( site ),
-							google: GooglePreview( site )
+							google: GooglePreview( site ),
+							twitter: PreviewTwitter( site )
 						}, selectedService, ComingSoonMessage( translate ) ) }
 					</div>
 					<div className="seo-preview-pane__preview-spacer" />

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -179,3 +179,96 @@
 		margin-top: auto;
 	}
 }
+
+.twitter-card-preview__container {
+	width: inherit;
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+}
+
+.twitter-card-preview__summary {
+	width: 506px;
+	height: 125px;
+	margin: 0 auto;
+	overflow: hidden;
+	border: 1px solid #E1E8ED;
+	border-radius: 0.42857em;
+}
+
+.twitter-card-preview__large_image_summary {
+	width: 506px;
+	height: auto;
+	margin: 0 auto;
+	overflow: hidden;
+	border: 1px solid #E1E8ED;
+	border-radius: 0.42857em;
+}
+
+.twitter-card-preview__image {
+	background-size: cover;
+	background-position: center;
+}
+
+.twitter-card-preview__summary
+.twitter-card-preview__image {
+	float: left;
+	width: 125px;
+	height: 125px;
+	border-right: 1px solid #E1E8ED;
+}
+
+.twitter-card-preview__large_image_summary
+.twitter-card-preview__image {
+	width: 506px;
+	height: 254px;
+	border-bottom: 1px solid #E1E8ED;
+}
+
+.twitter-card-preview__body {
+	padding: .75em;
+	text-decoration: none;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	color: black;
+	text-align: left;
+	line-height: 1.3em;
+	overflow: hidden;
+}
+
+.twitter-card-preview__summary
+.twitter-card-preview__body {
+	margin-left: 125px;
+}
+
+.twitter-card-preview__large_image_summary
+.twitter-card-preview__body {
+	padding-left: 1em;
+	padding-right: 1em;
+}
+
+.twitter-card-preview__title {
+	max-height: 1.3em;
+	white-space: nowrap;
+	font-weight: bold;
+	font-size: 1em;
+	margin: 0 0 .15em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.twitter-card-preview__description {
+	margin-top: 0.32333em;
+	max-height: 3.9em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.twitter-card-preview__url {
+	text-transform: lowercase;
+	color: #8899A6;
+	max-height: 1.3em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-top: 0.32333em;
+}

--- a/client/components/seo/twitter-preview/index.jsx
+++ b/client/components/seo/twitter-preview/index.jsx
@@ -1,0 +1,54 @@
+/** @ssr-ready **/
+import React, { PropTypes } from 'react';
+import PureComponent from 'react-pure-render/component';
+
+const baseDomain = url =>
+	url
+		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
+		.replace( /\/.*$/, '' ); // strip everything after the domain
+
+export class TwitterPreview extends PureComponent {
+	render() {
+		const {
+			url,
+			title,
+			type,
+			description,
+			image
+		} = this.props;
+
+		var previewImageStyle = {
+			backgroundImage: 'url(' + image + ')'
+		}
+
+		return (
+			<div className="twitter-card-preview__container">
+				<div className={ `twitter-card-preview twitter-card-preview__${ type }` }>
+					<div className="twitter-card-preview__image" style={ previewImageStyle }>
+					</div>
+					<div className="twitter-card-preview__body">
+						<div className="twitter-card-preview__title">
+							{ title }
+						</div>
+						<div className="twitter-card-preview__description">
+							{ description }
+						</div>
+						<div className="twitter-card-preview__url">
+							{ baseDomain( url ) }
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+TwitterPreview.propTypes = {
+	url: PropTypes.string,
+	title: PropTypes.string,
+	type: PropTypes.string,
+	description: PropTypes.string,
+	image: PropTypes.string
+};
+
+export default TwitterPreview;


### PR DESCRIPTION
Closes #5971

Adds a Twitter preview component which can show summary card and summary card with large image for post object. Will eventually land on the editor preview pane.

**Summary card and Large image summary preview**

<img width="550" alt="screenshot from 2016-07-20 16-01-34" src="https://cloud.githubusercontent.com/assets/1182160/16989732/94a433a4-4e95-11e6-8cc9-828380218aa7.png">


**Testing**

This component should be tested with various description and title lengths in order to verify that text truncation is working properly. Description that this PR uses for testing can be changed in My Sites > Settings > SEO. Site title and tagline are used for card title (My Sites > Settings > General).

Previews do not currently pull the post content which would normally exist in the preview.

Test live: https://calypso.live/?branch=add/twitter-preview