### PR TITLE
Jetpack: Add new purchase pixel track for jetpack plans

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -154,7 +154,13 @@ function recordPurchase( product ) {
 		return loadTrackingScripts( recordPurchase.bind( null, product ) );
 	}
 
-	debug( 'Recording purchase', product );
+	const isJetpackPlan = JETPACK_PLANS.indexOf( product.product_slug ) >= 0;
+
+	if ( isJetpackPlan ) {
+		debug( 'Recording Jetpack purchase', product );
+	} else {
+		debug( 'Recording purchase', product );
+	}
 
 	// record the user id as a custom parameter
 	const currentUser = user.get(),
@@ -183,7 +189,9 @@ function recordPurchase( product ) {
 	// record the purchase w/ Google
 	window.google_trackConversion( {
 		google_conversion_id: GOOGLE_CONVERSION_ID,
-		google_conversion_label: TRACKING_IDS.googleConversionLabel,
+		google_conversion_label: isJetpackPlan
+			? TRACKING_IDS.googleConversionLabelJetpack
+			: TRACKING_IDS.googleConversionLabel,
 		google_conversion_value: product.cost,
 		google_conversion_currency: product.currency,
 		google_custom_params: {
@@ -192,19 +200,6 @@ function recordPurchase( product ) {
 		},
 		google_remarketing_only: false
 	} );
-	if ( JETPACK_PLANS.indexOf( product.product_slug ) >= 0 ) {
-		debug( 'Recording Jetpack purchase', product );
-		window.google_trackConversion( {
-			google_conversion_id: GOOGLE_CONVERSION_ID,
-			google_conversion_label: TRACKING_IDS.googleConversionLabelJetpack,
-			google_conversion_value: product.cost,
-			google_conversion_currency: product.currency,
-			google_custom_params: {
-				product_slug: product.product_slug
-			},
-			google_remarketing_only: false
-		} );
-	}
 }
 
 /**

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -12,6 +12,7 @@ const debug = debugFactory( 'calypso:ad-tracking' );
  */
 import loadScript from 'lib/load-script';
 import config from 'config';
+import productsValues from 'lib/products-values';
 import userModule from 'lib/user';
 
 /**
@@ -35,8 +36,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		googleConversionLabel: 'MznpCMGHr2MQ1uXz_AM',
 		googleConversionLabelJetpack: '0fwbCL35xGIQqv3svgM',
 		atlasUniveralTagId: '11187200770563'
-	},
-	JETPACK_PLANS = [ 'jetpack_premium', 'jetpack_business' ];
+	};
 
 /**
  * Globals
@@ -154,7 +154,7 @@ function recordPurchase( product ) {
 		return loadTrackingScripts( recordPurchase.bind( null, product ) );
 	}
 
-	const isJetpackPlan = JETPACK_PLANS.indexOf( product.product_slug ) >= 0;
+	const isJetpackPlan = productsValues.isJetpackPlan( product );
 
 	if ( isJetpackPlan ) {
 		debug( 'Recording Jetpack purchase', product );

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -33,8 +33,10 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		bingInit: '4074038',
 		facebookInit: '823166884443641',
 		googleConversionLabel: 'MznpCMGHr2MQ1uXz_AM',
+		googleConversionLabelJetpack: '0fwbCL35xGIQqv3svgM',
 		atlasUniveralTagId: '11187200770563'
-	};
+	},
+	JETPACK_PLANS = [ 'jetpack_premium', 'jetpack_business' ];
 
 /**
  * Globals
@@ -190,6 +192,19 @@ function recordPurchase( product ) {
 		},
 		google_remarketing_only: false
 	} );
+	if ( JETPACK_PLANS.indexOf( product.product_slug ) >= 0 ) {
+		debug( 'Recording Jetpack purchase', product );
+		window.google_trackConversion( {
+			google_conversion_id: GOOGLE_CONVERSION_ID,
+			google_conversion_label: TRACKING_IDS.googleConversionLabelJetpack,
+			google_conversion_value: product.cost,
+			google_conversion_currency: product.currency,
+			google_custom_params: {
+				product_slug: product.product_slug
+			},
+			google_remarketing_only: false
+		} );
+	}
 }
 
 /**


### PR DESCRIPTION
This PR adds a new pixel track that should be added each time a Jetpack Plan is purchased. ~~Right now is not going to replace the existing pixel track, it's going to be added in addition to that one when the purchased plan is a jetpack one.~~ After some conversations about the issue, we are going to use just the new pixel track for jetpack plans

how to test
========
1. Change the config of your local calypso to allow ad tracking ( in /config/development.json, change the line 31 (ad-tracking) to true.
2. Enable debugging for this subset of events running `localStorage.setItem( 'debug', 'calypso:ad-tracking*' );` in the browser dev's console
3. Go purchase a jetpack plan for any of your jetpack sites (go to http://calypso.localhost:3000/plans/ and choose one of your jetpack sites)
4. Finish the checkout. In the console, you should see some debug info similar to this:
`calypso:ad-tracking Recording Jetpack purchase +4ms Object {product_id: 2001, product_name: "Professional", product_slug: "jetpack_business", meta: "", cost: 299…}`


ping @drewblaisdell  for review & @richardmuscat for notification ;P

Test live: https://calypso.live/?branch=add/jetpack-plans-conversion-track