### PR TITLE
CPT: Correct found discrepancy in paginated received set

### DIFF
--- a/client/lib/query-manager/paginated/index.js
+++ b/client/lib/query-manager/paginated/index.js
@@ -165,6 +165,19 @@ export default class PaginatedQueryManager extends QueryManager {
 		// set of data where our assumed item set is incorrect.
 		const modifiedNextQuery = cloneDeep( nextQuery );
 
+		// Found count is not always reliable, usually in consideration of user
+		// capabilities. If we receive a set of items with a count not matching
+		// the expected number for the query, we recalculate the found value to
+		// reflect that this is the last set we can expect to receive. Found is
+		// correct only if the count of items matches expected query number.
+		if ( modifiedNextQuery.hasOwnProperty( 'found' ) && perPage !== items.length ) {
+			// Otherwise, found count should be corrected to equal the number
+			// of items received added to the summed per page total. Note that
+			// we can reach this point if receiving the last page of items, but
+			// the updated value should still be correct given this logic.
+			modifiedNextQuery.found = ( ( page - 1 ) * perPage ) + items.length;
+		}
+
 		// Replace the assumed set with the received items.
 		modifiedNextQuery.itemKeys = [
 			...range( 0, startOffset ).map( ( index ) => {
@@ -189,7 +202,7 @@ export default class PaginatedQueryManager extends QueryManager {
 
 		// If found is known from options, ensure that we fill the end of the
 		// array with undefined entries until found count
-		if ( nextQuery.hasOwnProperty( 'found' ) ) {
+		if ( modifiedNextQuery.hasOwnProperty( 'found' ) ) {
 			modifiedNextQuery.itemKeys = range( 0, modifiedNextQuery.found ).map( ( index ) => {
 				return modifiedNextQuery.itemKeys[ index ];
 			} );

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -262,5 +262,16 @@ describe( 'PaginatedQueryManager', () => {
 				{ ID: 544 }, { ID: 552 }, { ID: 562 }, { ID: 564 }, { ID: 565 }
 			] );
 		} );
+
+		it( 'should correct the found count if received item count does not match query number', () => {
+			// Scenario: Contributor receives first page of two items, with 4
+			// found. Upon receiving second page, only one entry is provided,
+			// presumably because they don't have access to the fourth. Thus,
+			// found should be updated to reflect this discrepency.
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ], { query: { search: 'title', number: 2 }, found: 4 } );
+			manager = manager.receive( [ { ID: 160 } ], { query: { search: 'title', number: 2, page: 2 } } );
+
+			expect( manager.getFound( { search: 'title' } ) ).to.equal( 3 );
+		} );
 	} );
 } );

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -64,9 +64,10 @@ class PostTypeList extends Component {
 	}
 
 	getInitialRequestedPages( props ) {
-		// If we have no posts, start by requesting the first page, since
-		// setRequestedPages won't be called if row count is 0
-		if ( ! props.posts ) {
+		// If we have no posts or we're otherwise not expecting any posts to be
+		// rendered, request the first page, since setRequestedPages won't be
+		// called if row count is 0.
+		if ( 0 === size( props.posts ) ) {
 			return [ 1 ];
 		}
 


### PR DESCRIPTION
Partially remedies #6120

This pull request seeks to enhance `PaginatedQueryManager` with consideration of the ugly truth that the `found` value returned by the [`GET /sites/%s/posts` endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/) is not always accurate. While this is most certainly a problem which should be resolved on the REST API side, it's a difficult challenge given the needs to consider user capabilities for posts outside the range of the requested page of posts.

The changes herein serve as a bandaid to this problem, comparing the count of items received against the expected number, given the query `number` parameter (falling back to the defined default). If a discrepancy is discovered (usually for contributors not having access to another authors' posts), the found count is updated. This resolves the issue of the [`isSitePostsLastPageForQuery` selector](https://github.com/Automattic/wp-calypso/blob/045b256fa4531b0ddc0f376b738e8fdac70a6d92/client/state/posts/selectors.js#L185-L201) returning an inaccurate value, causing a loading placeholder to be forever shown on the [custom post types list screen](https://wpcalypso.wordpress.com) (because it had anticipated more posts to be received).

__Testing instructions:__

Verify that there are no regressions on usage for users with full capabilities to viewing posts.

Verify next that as a contributor on a site where one or more posts exist without the capability to view, posts are loaded according to those for which you have access, but that the exhaustion of page requests is reached appropriately, noted by the removal of the loading placeholder at the bottom of the posts list.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site, if prompted
3. Scroll down the screen to reveal all posts
4. Note that the loading placeholder is shown toward the bottom of the list as needed, until all posts have been loaded (including consideration of those you do not have access to receive)

__Caveats:__

The filter status count is not always reflective of the number of posts you should expect to see. This is also true of the [existing posts screen](https://wordpress.com/posts). We may be able to follow-up with a task that updates the filter count after having noted that fewer items are available to be viewed.

/cc @codebykat 

Test live: https://calypso.live/?branch=update/cpt-found-reliability