### PR TITLE
Jetpack Plans: Add tracking for plugins autoconfig

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -149,8 +149,11 @@ function renderPluginsBrowser( context, siteUrl ) {
 
 function renderProvisionPlugins( context ) {
 	const section = context.store.getState().ui.section;
+	const site = sites.getSelectedSite();
 	context.store.dispatch( setSection( Object.assign( {}, section, { secondary: false } ) ) );
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+
+	analytics.pageView.record( context.pathname.replace( site.domain, ':site' ), 'Jetpack Plugins Setup' );
 
 	renderWithReduxStore(
 		React.createElement( PlanSetup, {} ),


### PR DESCRIPTION
This adds tracking for plugins autoconfig success & errors.

The errors we track are:

- We can't modify files
- The Jetpack version is out of date
- It's a multisite subsite
- It's a multinetwork site
- It's WordPress.com
- The plugin just didn't install/activate (+ what error we got from the server)

We also track if the user navigates away mid-install.

To test:

1. Enable debug for analytics: `localStorage.setItem( 'debug', 'calypso:analytics' );`
2. Run through the purchase + config flow
3. The various tracks events should show up in your console.

cc @johnHackworth

Test live: https://calypso.live/?branch=add/jetpack-setup-tracks