### PR TITLE
Framework: Initialize localStorage polyfill at start of boot

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -1,3 +1,6 @@
+// Initialize localStorage polyfill before any dependencies are loaded
+require( 'lib/local-storage' )();
+
 /**
  * External dependencies
  */
@@ -21,7 +24,6 @@ var React = require( 'react' ),
 var config = require( 'config' ),
 	abtest = require( 'lib/abtest' ).abtest,
 	switchLocale = require( 'lib/i18n-utils/switch-locale' ),
-	localStoragePolyfill = require( 'lib/local-storage' )(), //eslint-disable-line
 	analytics = require( 'lib/analytics' ),
 	route = require( 'lib/route' ),
 	user = require( 'lib/user' )(),


### PR DESCRIPTION
Fixes #6555
Suspected regression in #6236 ([`lib/abtest`](https://github.com/Automattic/wp-calypso/blob/master/client/lib/abtest/index.js) pulls in `store`)

This pull request seeks to resolve an issue where Safari Private Mode does not load correctly because of an attempt to access `localStorage` (not available). Our [`localStorage` polyfill](https://github.com/Automattic/wp-calypso/tree/master/client/lib/local-storage) is targeted at resolving this case, but must be loaded before any dependencies making use of `store` or `localStorage`. This pull request moves the initialization to the top of the boot file to ensure that it is always executed first.

__Testing instructions:__

I was never able to reproduce the original issue in development mode locally, perhaps due to some configuration flag that's only active in production (makes sense if it is ABTest related). You may want to search internal documentation for running production mode locally to verify the fix (which I did to verify resolution), else ensure that no regressions occur in using the application. Specifically, ensure that you can load Calypso in Safari Private Mode.

/cc @rachelmcr, @bisko, @blowery, @mjuhasz

Test live: https://calypso.live/?branch=fix/6555-localstorage-private