### PR TITLE
Getting rid of unnecessary Tracks events in the NUX flow

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -15,7 +15,6 @@ const SignupActions = {
 	},
 
 	saveSignupStep( step ) {
-		analytics.tracks.recordEvent( 'calypso_signup_actions_save_step', { step: step.stepName } );
 
 		// there are some conditions in which a step could be saved/processed in the same event loop
 		// so we should defer the action
@@ -28,7 +27,6 @@ const SignupActions = {
 	},
 
 	submitSignupStep( step, errors, providedDependencies ) {
-		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { step: step.stepName } );
 
 		Dispatcher.handleViewAction( {
 			type: 'SUBMIT_SIGNUP_STEP',
@@ -39,7 +37,6 @@ const SignupActions = {
 	},
 
 	processSignupStep( step, errors, providedDependencies ) {
-		analytics.tracks.recordEvent( 'calypso_signup_actions_process_step', { step: step.stepName } );
 
 		// deferred because a step can be processed as soon as it is submitted
 		defer( () => {


### PR DESCRIPTION
The signup flow currently creates 4 Tracks event for each signup step, all of which are essentially attributed to 1 user action. We want to avoid this confusion when analyzing data with Funnels, so this removes 3 of those events, keeping the one that most people actually look at currently.

Test live: https://calypso.live/?branch=update/remove-unnecessary-nux-tracks-events