### PR TITLE
Sharing: Gracefully fail on bad message JSON

### DIFF
--- a/client/my-sites/sharing/buttons/preview-buttons.jsx
+++ b/client/my-sites/sharing/buttons/preview-buttons.jsx
@@ -75,7 +75,7 @@ var SharingButtonsPreviewButtons = module.exports = React.createClass( {
 	},
 
 	detectWidgetPreviewChanges: function( event ) {
-		var data, preview, offset;
+		var preview, offset;
 
 		// Ensure this only triggers in the context of an official preview
 		if ( ! this.refs.iframe ) {
@@ -84,7 +84,10 @@ var SharingButtonsPreviewButtons = module.exports = React.createClass( {
 		preview = ReactDom.findDOMNode( this.refs.iframe );
 
 		// Parse the JSON message data
-		data = JSON.parse( event.data );
+		let data;
+		try {
+			data = JSON.parse( event.data );
+		} catch ( error ) {}
 
 		if ( data && event.source === preview.contentWindow ) {
 			if ( 'more-show' === data.action ) {


### PR DESCRIPTION
This pull request seeks to resolve an error which can occur in some cases when a `postmessage` containing a non-JSON-formatted message could result in an error in the sharing buttons preview frame handler.

__Testing instructions:__

Verify that no regressions occur in the usage of the [sharing buttons preview](http://calypso.localhost:3000/sharing/buttons), including previewing (notably "Official" button style where iframe is in use) and updating buttons.

Test live: https://calypso.live/?branch=fix/media-bad-message-handling