### PR TITLE
Plans Redesign: conditionally display plan features

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -74,7 +74,7 @@ const Plan = React.createClass( {
 		// override plan description during google voucher test
 		if ( isGoogleVouchersEnabled() ) {
 			if ( plan.product_id === premiumPlan.productId ) {
-				plan.description = premiumPlan.description;
+				plan.description = premiumPlan.descriptionWithGoogleVouchers;
 			} else if ( plan.product_id === businessPlan.productId ) {
 				plan.description = isWordpressAdCreditsEnabled() ? businessPlan.descriptionWithWordAdsCredit : businessPlan.description;
 			}

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -67,7 +67,8 @@ export const plansList = {
 		getProductId: () => 1,
 		getStoreSlug: () => PLAN_FREE,
 		getPathSlug: () => 'beginner',
-		getDescription: () => i18n.translate( 'Get a free blog and be on your way to publishing your first post in less than five minutes.' ),
+		getDescription: () => i18n.translate( 'Get a free blog and be on your way to publishing your first post' +
+			' in less than five minutes.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_FREE_SITE,
 			FEATURE_WP_SUBDOMAIN,
@@ -103,7 +104,12 @@ export const plansList = {
 		getPathSlug: () => 'premium',
 		getStoreSlug: () => PLAN_PREMIUM,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
-		getDescription: () => i18n.translate( 'Your own domain name, powerful customization options, lots of space for audio and video, and $100 advertising credit.' ),
+		getDescription: () => i18n.translate( 'Your own domain name, powerful customization options, and' +
+			' lots of space for audio and video.' ),
+		getDescriptionWithGoogleVouchers: () => i18n.translate( 'Your own domain name, powerful customization options,' +
+			' lots of space for audio and video, and $100 advertising credit.' ),
+		getDescriptionWithWordAdsInstantActivation: () => i18n.translate( 'Your own domain name, powerful' +
+			' customization options, easy monetization with WordAds and lots of space for audio and video.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_FREE_SITE,
 			FEATURE_CUSTOM_DOMAIN,
@@ -126,8 +132,10 @@ export const plansList = {
 		getStoreSlug: () => PLAN_BUSINESS,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ], plan ),
 		getPathSlug: () => 'business',
-		getDescription: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, and Google Analytics.' ),
-		getDescriptionWithWordAdsCredit: () => i18n.translate( 'Everything included with Premium, as well as live chat support, unlimited access to premium themes, Google Analytics, and $200 advertising credit.' ),
+		getDescription: () => i18n.translate( 'Everything included with Premium, as well as live chat support,' +
+			' unlimited access to premium themes, and Google Analytics.' ),
+		getDescriptionWithWordAdsCredit: () => i18n.translate( 'Everything included with Premium, as well as' +
+			' live chat support, unlimited access to premium themes, Google Analytics, and $200 advertising credit.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_FREE_SITE,
 			FEATURE_CUSTOM_DOMAIN,
@@ -156,7 +164,8 @@ export const plansList = {
 		getProductId: () => 2000,
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
 		getPathSlug: () => 'premium',
-		getDescription: () => i18n.translate( 'All the features you need to keep your site’s content backed up and secure, as well as spam-free.' ),
+		getDescription: () => i18n.translate( 'All the features you need to keep your site’s content backed up' +
+			' and secure, as well as spam-free.' ),
 		getFeatures: () => [
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -174,7 +183,8 @@ export const plansList = {
 		getProductId: () => 2003,
 		getPathSlug: () => 'premium-monthly',
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
-		getDescription: () => i18n.translate( 'All the features you need to keep your site’s content backed up and secure, as well as spam-free.' ),
+		getDescription: () => i18n.translate( 'All the features you need to keep your site’s content backed' +
+			' up and secure, as well as spam-free.' ),
 		getFeatures: () => [
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -293,7 +303,6 @@ export const featuresList = {
 					hr: <hr className="plans-compare__info-hr"/>
 				}
 			} ),
-		order: 10,
 		plans: allPaidPlans
 	},
 
@@ -386,12 +395,21 @@ export const getPlanObject = planName => {
 	return objectPlan;
 };
 
-export const getPlanFeaturesObject = planName => {
-	const planFeaturesList = plansList[ planName ].getFeatures();
+/**
+ * Returns the features list object with keys as the feature constants and values as the feature objects.
+ * Example: { [ FEATURE_XY ] : { getTitle: () => i18n.translate( 'Some title' ) } }
+ *
+ * @param   {Array}  planFeaturesConstantList List of plan features constants (ie: [ FEATURE_XY, FEATURE_Z ])
+ * @returns {Object} Features list object
+ */
+export const getPlanFeaturesConstantObj = ( planFeaturesConstantList ) => {
+	const planFeaturesConstantObj = {};
 
-	return planFeaturesList.map( featureConstant =>
-		featuresList[ featureConstant ]
-	);
+	planFeaturesConstantList.forEach( planFeaturesConst => {
+		planFeaturesConstantObj[ planFeaturesConst ] = featuresList[ planFeaturesConst ];
+	} );
+
+	return planFeaturesConstantObj;
 };
 
 export function isMonthly( plan ) {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -395,23 +395,6 @@ export const getPlanObject = planName => {
 	return objectPlan;
 };
 
-/**
- * Returns the features list object with keys as the feature constants and values as the feature objects.
- * Example: { [ FEATURE_XY ] : { getTitle: () => i18n.translate( 'Some title' ) } }
- *
- * @param   {Array}  planFeaturesConstantList List of plan features constants (ie: [ FEATURE_XY, FEATURE_Z ])
- * @returns {Object} Features list object
- */
-export const getPlanFeaturesConstantObj = ( planFeaturesConstantList ) => {
-	const planFeaturesConstantObj = {};
-
-	planFeaturesConstantList.forEach( planFeaturesConst => {
-		planFeaturesConstantObj[ planFeaturesConst ] = featuresList[ planFeaturesConst ];
-	} );
-
-	return planFeaturesConstantObj;
-};
-
 export function isMonthly( plan ) {
 	return includes( JETPACK_MONTHLY_PLANS, plan );
 }

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -1,14 +1,17 @@
 /**
  * External dependencies
  */
-import find from 'lodash/find';
 import page from 'page';
 import moment from 'moment';
-import get from 'lodash/get';
-import includes from 'lodash/includes';
-import invoke from 'lodash/invoke';
 import debugFactory from 'debug';
-import pickBy from 'lodash/pickBy';
+import {
+	pick,
+	pickBy,
+	find,
+	get,
+	includes,
+	invoke
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,8 +33,7 @@ import {
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
 	WORDADS_INSTANT,
-	FEATURE_GOOGLE_AD_CREDITS,
-	getPlanFeaturesConstantObj
+	FEATURE_GOOGLE_AD_CREDITS
 } from 'lib/plans/constants';
 import { createSitePlanObject } from 'state/sites/plans/assembler';
 import SitesList from 'lib/sites-list';
@@ -73,7 +75,7 @@ export function getSitePlanSlug( siteID ) {
 }
 
 export function canUpgradeToPlan( planKey, site = sitesList.getSelectedSite() ) {
-	const plan = get( site, [ 'plan', 'expired' ], true ) ? PLAN_FREE : get( site, [ 'plan', 'product_slug' ], PLAN_FREE );
+	const plan = get( site, [ 'plan', 'expired' ], false ) ? PLAN_FREE : get( site, [ 'plan', 'product_slug' ], PLAN_FREE );
 	return get( plansList, [ planKey, 'availableFor' ], () => false )( plan );
 }
 
@@ -217,12 +219,12 @@ export function plansLink( url, site, intervalType ) {
 }
 
 export function applyTestFiltersToPlansList( planName ) {
-	const filteredPlanConstantObj = Object.assign( {}, plansList[ planName ] );
-	let filteredPlanFeaturesConstantObj = getPlanFeaturesConstantObj( plansList[ planName ].getFeatures() );
+	const filteredPlanConstantObj = { ...plansList[ planName ] };
+	let filteredPlanFeaturesConstantObj = pick( featuresList, plansList[ planName ].getFeatures() );
 
 	if ( ! isWordadsInstantActivationEnabled() ) {
 		filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
-			( _, key ) => key !== WORDADS_INSTANT
+			( value, key ) => key !== WORDADS_INSTANT
 		);
 	} else if ( planName === PLAN_PREMIUM ) {
 		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsInstantActivation;
@@ -230,7 +232,7 @@ export function applyTestFiltersToPlansList( planName ) {
 
 	if ( ! isGoogleVouchersEnabled() ) {
 		filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
-			( _, key ) => key !== FEATURE_GOOGLE_AD_CREDITS
+			( value, key ) => key !== FEATURE_GOOGLE_AD_CREDITS
 		);
 	} else if ( planName === PLAN_PREMIUM ) {
 		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithGoogleVouchers;

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -4,9 +4,8 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import noop from 'lodash/noop';
 import page from 'page';
-import lodashMap from 'lodash/map';
+import { map, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -76,7 +75,7 @@ class PlanFeatures extends Component {
 				/>
 				<PlanFeaturesItemList>
 					{
-						lodashMap( features, ( featureConstObj, featureConst ) =>
+						map( features, ( featureConstObj, featureConst ) =>
 							<PlanFeaturesItem
 								key={ featureConst }
 								description={ featureConstObj.getDescription


### PR DESCRIPTION
Fix for #6500. With redesigned plans, we show all plans features. However, some features are behind abtests. This PR adds a fn `applyTestFiltersToPlansList` which returns the abtest-filtered `plansList` with `featuresList` embedded as `getFeatures` fn.

## Testing Instructions

These are the active abtests that touch the `/plans` page and/or `/start/plans` page in some way:

- `wordadsInstantActivation`;
- `googleVouchers`;
- `wordpressAdCredits`.

While following the testing instructions below, enable/disable the abtests above and check if it changes the behavior of the `/plans` and `/start/plans` pages.

1. Run Calypso with `ENABLE_FEATURES=manage/plan-features make run`;
2. Disable all abtests;
3. Navigate to `/plans` page and verify that the features/descriptions from the abtests are not present;
4. Enable abtests one by one and check whether it changes the aforementioned pages.

To the authors of the aforementioned abtests: could you please double-check everything works as it should? Thanks!

## Screenshots

With all the aforementioned abtests enabled:

![selection_028](https://cloud.githubusercontent.com/assets/4988512/16626983/84b1cb0e-43ab-11e6-9ae4-3493ffe968ac.png)

With only `googleVouchers` abtest enabled:

![selection_029](https://cloud.githubusercontent.com/assets/4988512/16626989/8ca42dde-43ab-11e6-90c3-5e783406de37.png)


cc @gwwar @rralian @artpi @retrofox @mtias 


Test live: https://calypso.live/?branch=add/plans-redesign-conditionally-display-plan-features