### PR TITLE
Plans Redesign: do not render FAQ in nux flows

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -268,16 +268,20 @@ class PlansFeaturesMain extends Component {
 	}
 
 	render() {
-		const { site } = this.props;
+		const { site, isInSignup } = this.props;
+		const renderFAQ = () =>
+			this.isJetpackSite( site )
+				? this.getJetpackFAQ()
+				: this.getFAQ( site );
 
 		return (
 			<div class="plans-features-main">
 				{ this.getPlanFeatures() }
 
 				{
-					this.isJetpackSite( site )
-						? this.getJetpackFAQ()
-						: this.getFAQ( site )
+					! isInSignup
+						? renderFAQ()
+						: null
 				}
 			</div>
 		);

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -268,7 +268,7 @@ class PlansFeaturesMain extends Component {
 	}
 
 	render() {
-		const { site, isInSignup } = this.props;
+		const { site, showFAQ } = this.props;
 		const renderFAQ = () =>
 			this.isJetpackSite( site )
 				? this.getJetpackFAQ()
@@ -279,7 +279,7 @@ class PlansFeaturesMain extends Component {
 				{ this.getPlanFeatures() }
 
 				{
-					! isInSignup
+					showFAQ
 						? renderFAQ()
 						: null
 				}
@@ -293,12 +293,14 @@ PlansFeaturesMain.PropTypes = {
 	isInSignup: PropTypes.bool,
 	intervalType: PropTypes.string,
 	onUpgradeClick: PropTypes.func,
-	hideFreePlan: PropTypes.bool
+	hideFreePlan: PropTypes.bool,
+	showFAQ: PropTypes.bool
 };
 
 PlansFeaturesMain.defaultProps = {
 	hideFreePlan: false,
-	site: {}
+	site: {},
+	showFAQ: true
 };
 
 export default localize( PlansFeaturesMain );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -117,7 +117,8 @@ module.exports = React.createClass( {
 				<PlansFeaturesMain
 					hideFreePlan={ hideFreePlan }
 					isInSignup={ true }
-					onUpgradeClick={ this.onSelectPlan } />
+					onUpgradeClick={ this.onSelectPlan }
+					showFAQ={ false } />
 			</div>
 		);
 	},


### PR DESCRIPTION
Fixes #6541.

## Testing Instructions

1. Start Calypso with `ENABLE_FEATURES=manage/plan-features make run`;
2. In Incognito mode, visit http://calypso.localhost:3000/start/test-plans and verify FAQ is not present;
3. Being logged in, visit http://calypso.localhost:3000/start/test-plans and verify FAQ is not present;
4. Verify that FAQ is present on `/plans` page for both a WPcom site and a Jetpack site.

## Screenshots

![selection_030](https://cloud.githubusercontent.com/assets/4988512/16627812/326049da-43af-11e6-8537-d941e9ecf4af.png)

cc @gwwar @apeatling 

Test live: https://calypso.live/?branch=update/remove-faq-from-nux