### PR TITLE
CPT: Adjust placement of thumbnail and action items on list screen

### DIFF
--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -57,7 +57,8 @@ class EllipsisMenu extends Component {
 					ref={ this.setPopoverContext }
 					onClick={ isMenuVisible ? this.hideMenu : this.showMenu }
 					title={ toggleTitle || translate( 'Toggle menu' ) }
-					borderless>
+					borderless
+					className="ellipsis-menu__toggle">
 					<Gridicon
 						icon="ellipsis"
 						className="ellipsis-menu__toggle-icon" />

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -19,9 +19,9 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 
 	if ( includeDefaultActions ) {
 		actions.push(
+			<PostActionsEllipsisMenuEdit key="edit" />,
 			<PostActionsEllipsisMenuView key="view" />,
 			<PostActionsEllipsisMenuPublish key="publish" />,
-			<PostActionsEllipsisMenuEdit key="edit" />,
 			<PostActionsEllipsisMenuRestore key="restore" />,
 			<PostActionsEllipsisMenuTrash key="trash" />
 		);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/style.scss
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/style.scss
@@ -1,3 +1,15 @@
 .post-actions-ellipsis-menu {
 	flex-shrink: 0;
+	align-self: stretch;
+	margin-left: 8px;
+}
+
+.post-actions-ellipsis-menu,
+.post-actions-ellipsis-menu .ellipsis-menu {
+	display: flex;
+}
+
+.post-actions-ellipsis-menu .ellipsis-menu__toggle {
+	padding: 0 16px;
+	margin-right: -16px;
 }

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -22,7 +23,9 @@ function PostActionsEllipsisMenuView( { translate, status } ) {
 
 	return (
 		<PopoverMenuItem onClick={ viewPost } icon="external">
-			{ translate( 'View', { context: 'verb' } ) }
+			{ includes( [ 'publish', 'private' ], status )
+				? translate( 'View', { context: 'verb' } )
+				: translate( 'Preview', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);
 }

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -21,7 +21,7 @@ function PostTypeListPostThumbnail( { thumbnail } ) {
 		<div className={ classes }>
 			{ thumbnail && (
 				<img
-					src={ resizeImageUrl( thumbnail, { w: 80 } ) }
+					src={ resizeImageUrl( thumbnail, { h: 80 } ) }
 					className="post-type-list__post-thumbnail" />
 			) }
 		</div>

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -27,7 +27,7 @@
 	position: relative;
 	width: 80px;
 	align-self: stretch;
-	margin-right: 12px;
+	margin: -8px 0;
 	overflow: hidden;
 
 	&.has-image,
@@ -45,6 +45,8 @@
 		top: 50%;
 		left: 50%;
 	transform: translate( -50%, -50% );
+	max-height: 100%;
+	max-width: none;
 }
 
 .post-type-list__post-title-meta {


### PR DESCRIPTION
Closes #6540 
Closes #6542 

This pull request seeks to...

- Adjust the position of the post thumbnail relative to the action menu
- Reorder the action menu items to mirror that of the posts screen
- Use "Preview" as View action label unless post is published

Incidentally, it also increases the clickable area of the menu toggle button.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16629927/014b3e1e-4386-11e6-92ba-b0a8b97fddef.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16629931/03c896fa-4386-11e6-9e3b-9b1f9b176892.png)

__Testing instructions:__

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Confirm that layout of thumbnail and menu match that as described in #6542
3. Toggle the action menu for a post
4. Confirm that menu items show in same order as on the [posts screen](https://wordpress.com/posts)
5. Verify that "Preview" is shown for drafts or scheduled posts, and that "View" is shown for published or privately published posts (and is not an option for trashed posts)

/cc @hugobaeta 

Test live: https://calypso.live/?branch=update/6540-6542-cpt-list-layout