### PR TITLE
Fix pressable store back button

### DIFF
--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -96,7 +96,7 @@ export default React.createClass( {
 		}, 1 );
 	},
 
-	handlePressableStoreBackClick( event ) {
+	handlePressableStoreBackClick() {
 		this.setState( {
 			showStore: false
 		} );

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -69,7 +69,7 @@ export default React.createClass( {
 		return (
 			<div className="design-type-with-store">
 				<div className={ pressableWrapperClassName } >
-					<PressableStoreStep { ... this.props } ref={ this.onPressableStoreStepRef }/>
+					<PressableStoreStep { ... this.props } ref={ this.onPressableStoreStepRef } onBackClick={ this.handlePressableStoreBackClick }/>
 				</div>
 				<div className={ sectionWrapperClassName }>
 					<StepWrapper
@@ -83,6 +83,25 @@ export default React.createClass( {
 				</div>
 			</div>
 		);
+	},
+
+	scrollUp() {
+		this.windowScroller = setInterval( () => {
+			if ( window.pageYOffset > 0 ) {
+				window.scrollBy( 0, -10 );
+			} else {
+				clearInterval( this.windowScroller );
+				this.windowScroller = null;
+			}
+		}, 1 );
+	},
+
+	handlePressableStoreBackClick( event ) {
+		this.setState( {
+			showStore: false
+		} );
+
+		this.scrollUp();
 	},
 
 	handleChoiceClick( event, type ) {
@@ -99,13 +118,7 @@ export default React.createClass( {
 				showStore: true
 			} );
 
-			this.windowScroller = setInterval( () => {
-				if ( window.pageYOffset > 0 ) {
-					window.scrollBy( 0, -10 );
-				} else {
-					clearInterval( this.windowScroller );
-				}
-			}, 1 );
+			this.scrollUp();
 
 			if ( this._pressableStore ) {
 				this._pressableStore.focus();

--- a/client/signup/steps/design-type-with-store/pressable-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/pressable-store/index.jsx
@@ -103,7 +103,7 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<div>
+			<div className="pressable-store">
 				<StepHeader
 					headerText={ this.translate( 'Create your WordPress Store' ) }
 					subHeaderText={ this.translate( 'Our partners at Pressable and WooCommerce are here for you' ) }

--- a/client/signup/steps/design-type-with-store/pressable-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/pressable-store/index.jsx
@@ -7,9 +7,8 @@ import EmailValidator from 'email-validator';
 /**
  * Internal dependencies
  */
-import StepWrapper from 'signup/step-wrapper';
-import Gridicon from 'components/gridicon';
 
+import Gridicon from 'components/gridicon';
 import LoggedOutForm from 'components/logged-out-form';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
@@ -19,6 +18,8 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormButton from 'components/forms/form-button';
 import FormLabel from 'components/forms/form-label';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import StepHeader from 'signup/step-header';
+import Button from 'components/button';
 
 import HeroImage from './hero-image';
 
@@ -26,8 +27,7 @@ export default React.createClass( {
 	displayName: 'PressableStoreStep',
 
 	propTypes: {
-		stepName: PropTypes.string.isRequired,
-		signupDependencies: PropTypes.object.isRequired,
+		onBackClick: PropTypes.func.isRequired,
 	},
 
 	getInitialState() {
@@ -103,12 +103,19 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<StepWrapper
-				fallbackHeaderText={ this.translate( 'Create your WordPress Store' ) }
-				fallbackSubHeaderText={ this.translate( 'Our partners at Pressable and WooCommerce are here for you' ) }
-				stepContent={ this.renderStoreForm() }
-				{ ...this.props }
-				goToNextStep={ undefined } />
+			<div>
+				<StepHeader
+					headerText={ this.translate( 'Create your WordPress Store' ) }
+					subHeaderText={ this.translate( 'Our partners at Pressable and WooCommerce are here for you' ) }
+				/>
+				{ this.renderStoreForm() }
+				<div className="pressable-store__back-button-wrapper">
+					<Button compact borderless onClick={ this.props.onBackClick }>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ this.translate( 'Back' ) }
+					</Button>
+				</div>
+			</div>
 		);
 	}
 } );

--- a/client/signup/steps/design-type-with-store/pressable-store/style.scss
+++ b/client/signup/steps/design-type-with-store/pressable-store/style.scss
@@ -56,3 +56,7 @@
 	text-align: center;
 }
 
+.pressable-store__back-button-wrapper {
+	margin: 24px 0;
+	text-align: center;
+}


### PR DESCRIPTION
This PR removes `StepWrapper` on the pressable store form, and uses `StepHeader` and a regular `Button`, that way we can hook up to the `onClick` event and go back within the `design-type-with-store` step.

Test live: https://calypso.live/?branch=fix/pressable-store-back-button