### PR TITLE
Signup: Survey step transitions aren't smooth

### DIFF
--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -18,15 +18,15 @@
 .survey-step__verticals {
 	pointer-events: none;
 	opacity: 0.4;
-	filter: blur( 3px );
-	transform: translateX( -20% ) scale( 0.9 );
-	transition: filter 0.15s ease-out, opacity 0.15s ease-out, transform 0.15s ease-out;
+	-webkit-filter: blur( 3px );
+	transform: translateX( -20% );
+	transition: -webkit-filter 0.15s ease-out, opacity 0.15s ease-out, transform 0.15s ease-out;
 
 	&.active {
-		filter: blur( 0 );
 		pointer-events: auto;
 		opacity: 1;
-		transform: translateX( 0 ) scale( 1 );
+		-webkit-filter: blur( 0 );
+		transform: translateX( 0 );
 	}
 }
 
@@ -41,8 +41,8 @@
 	margin-bottom: 24px;
 	pointer-events: none;
 	opacity: 0;
-	transform: translateY( 100px );
-	transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+	transform: translateY( 50px );
+	transition: opacity 0.2s ease-out, transform 0.2s ease-out;
 
 	&.active {
 		pointer-events: auto;

--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -18,15 +18,23 @@
 .survey-step__verticals {
 	pointer-events: none;
 	opacity: 0.4;
-	-webkit-filter: blur( 3px );
-	transform: translateX( -20% );
-	transition: -webkit-filter 0.15s ease-out, opacity 0.15s ease-out, transform 0.15s ease-out;
+	transform: translateX( -20% ) scale( 0.8 );
+	transition: filter 0.15s linear, opacity 0.15s ease-out, transform 0.15s ease-out;
 
 	&.active {
 		pointer-events: auto;
 		opacity: 1;
-		-webkit-filter: blur( 0 );
-		transform: translateX( 0 );
+		transform: translateX( 0 ) scale( 1 );
+	}
+
+	// This limits the blur filter to Safari, as other browsers can't handle the
+	// awesomeness of transitioning blurs.
+	@supports (overflow:-webkit-marquee) and (justify-content:inherit) {
+		filter: blur( 3px );
+
+		&.active {
+			filter: blur( 0 );
+		}
 	}
 }
 

--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -41,15 +41,13 @@
 	margin-bottom: 24px;
 	pointer-events: none;
 	opacity: 0;
-	filter: blur( 3px );
-	transform: translateX( 20% );
-	transition: filter 0.2s ease-in-out, opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+	transform: translateY( 100px );
+	transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
 
 	&.active {
 		pointer-events: auto;
 		opacity: 1;
-		filter: blur( 0 );
-		transform: translateX( 0 );
+		transform: translateY( 0 );
 	}
 
 	// Override HeaderCake's margin


### PR DESCRIPTION
Tweaking the transitions to perform better in Firefox and on retina displays.

![survey-transition](https://cloud.githubusercontent.com/assets/191598/16633204/17ccd796-4396-11e6-8e6f-e1bcb6dba58f.gif)

(Be aware, the gif is way "jankier" than real life.)

To test:

- go to http://calypso.localhost:3000/start/survey
- make sure the animation when selecting the first top category is smooth enough
- use different browsers and devices

Test live: https://calypso.live/?branch=fix/signup-survey-transition-smoothness