### PR TITLE
Reader: add tracks event for 'Follow by URL' link in Cold Start

### DIFF
--- a/client/reader/start/card.jsx
+++ b/client/reader/start/card.jsx
@@ -17,6 +17,7 @@ import { getSite } from 'state/reader/sites/selectors';
 import { recordTrack, recordTrackForPost, recordTracksRailcarInteract } from 'reader/stats';
 
 const debug = debugModule( 'calypso:reader:start' ); //eslint-disable-line no-unused-vars
+const tracksSource = 'recommended_cold_start';
 
 const StartCard = React.createClass( {
 	onCardInteraction() {
@@ -27,11 +28,12 @@ const StartCard = React.createClass( {
 		);
 
 		if ( this.props.post ) {
-			recordTrackForPost( 'calypso_reader_startcard_clicked', this.props.post );
+			recordTrackForPost( 'calypso_reader_startcard_clicked', this.props.post, { source: tracksSource } );
 		} else {
 			recordTrack( 'calypso_reader_startcard_clicked', {
 				blog_id: this.props.recommendation.recommended_site_ID,
-				recommendation_id: this.props.recommendationId
+				recommendation_id: this.props.recommendationId,
+				source: tracksSource
 			} );
 			if ( this.props.recommendation.railcar ) {
 				recordTracksRailcarInteract( 'startcard_clicked', this.props.recommendation.railcar );

--- a/client/reader/start/main.jsx
+++ b/client/reader/start/main.jsx
@@ -18,6 +18,9 @@ import StartCard from './card';
 import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
 import smartSetState from 'lib/react-smart-set-state';
 import CardPlaceholder from './card-placeholder';
+import { recordTrack } from 'reader/stats';
+
+const tracksSource = 'recommended_cold_start';
 
 const Start = React.createClass( {
 
@@ -57,6 +60,10 @@ const Start = React.createClass( {
 		return times( count, function( i ) {
 			return ( <CardPlaceholder key={ 'placeholder-' + i } /> );
 		} );
+	},
+
+	handleFollowByUrlClick() {
+		recordTrack( 'calypso_reader_start_follow_by_url_link', { source: tracksSource } );
 	},
 
 	render() {
@@ -117,7 +124,7 @@ const Start = React.createClass( {
 
 				{ hasRecommendations &&
 				<div className="reader-start__manage">{ this.translate( 'Didn\'t find a site you\'re looking for?' ) }
-					&nbsp;<a href="/following/edit">Follow by URL</a>.
+					&nbsp;<a href="/following/edit" onClick={ this.handleFollowByUrlClick }>Follow by URL</a>.
 				</div> }
 			</Main>
 		);


### PR DESCRIPTION
This PR adds a tracks event for the 'Follow by URL' link in Reader Cold Start.

<img width="700" alt="screen shot 2016-07-06 at 21 50 51" src="https://cloud.githubusercontent.com/assets/17325/16632300/c8cdba6a-43c3-11e6-8867-646cd86dffe0.png">


Test live: https://calypso.live/recommendations/start?branch=add/reader/tracks-events-follow-by-url-link