### PR TITLE
State: jetpack connect

### DIFF
--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -36,7 +36,7 @@ import {
 } from 'state/action-types';
 
 import { isValidStateWithSchema } from 'state/utils';
-import { jetpackConnectSessionsSchema, jetpackConnectAuthorizeSchema } from './schema';
+import { jetpackConnectSessionsSchema } from './schema';
 
 const defaultAuthorizeState = {
 	queryObject: {},
@@ -138,10 +138,7 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_REDIRECT_WP_ADMIN:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
 		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, jetpackConnectAuthorizeSchema ) ) {
-				return state;
-			}
-			return {};
+			return state;
 		case SERIALIZE:
 			return state;
 	}


### PR DESCRIPTION
The state validator is not set up properly. This PR disables the validator until
we can get it set up correctly.

To Reproduce bug:
- log out of wordpress.com
- go to wordpress.com/jetpack/connect and connect an unconnected Jetpack site
- create a new wpcom in the next step
- Oh no! Blank calypso screen

<img width="1173" alt="screen shot 2016-07-06 at 4 01 59 pm" src="https://cloud.githubusercontent.com/assets/2694219/16632627/03973878-4393-11e6-98b5-63b81b196e98.png">

To test:
- with this patch applied, go to calypso.localhost:3000/jetpack/connect
- ensure you can connect Jetpack sites while logged in and logged out


Test live: https://calypso.live/?branch=fix/jetpack-connect-state