### PR TITLE
Domain Management: DNS: Pass `deleteEmailForwards` parameter to API

### DIFF
--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -1,8 +1,9 @@
 /**
- * Externel dependencies
+ * External dependencies
  */
-import noop from 'lodash/noop';
 import i18n from 'i18n-calypso';
+import noop from 'lodash/noop';
+import reject from 'lodash/reject';
 
 /**
  * Internal dependencies
@@ -247,7 +248,7 @@ function addDns( domainName, record, onComplete ) {
 
 	const dns = DnsStore.getByDomainName( domainName );
 
-	wpcom.updateDns( domainName, dns.records, ( error ) => {
+	wpcom.updateDns( domainName, dns.records, {}, ( error ) => {
 		const type = ! error ? ActionTypes.DNS_ADD_COMPLETED : ActionTypes.DNS_ADD_FAILED;
 		Dispatcher.handleServerAction( {
 			type,
@@ -259,7 +260,7 @@ function addDns( domainName, record, onComplete ) {
 	} );
 }
 
-function deleteDns( domainName, record, onComplete ) {
+function deleteDns( domainName, record, options, onComplete ) {
 	if ( isBeingProcessed( record ) ) {
 		return;
 	}
@@ -270,9 +271,10 @@ function deleteDns( domainName, record, onComplete ) {
 		record
 	} );
 
-	const dns = DnsStore.getByDomainName( domainName );
+	const dns = DnsStore.getByDomainName( domainName ),
+		records = reject( dns.records, 'isBeingDeleted' );
 
-	wpcom.updateDns( domainName, dns.records, ( error ) => {
+	wpcom.updateDns( domainName, dns.records, options, ( error ) => {
 		const type = ! error ? ActionTypes.DNS_DELETE_COMPLETED : ActionTypes.DNS_DELETE_FAILED;
 
 		Dispatcher.handleServerAction( {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1503,9 +1503,18 @@ Undocumented.prototype.fetchDns = function( domainName, fn ) {
 	this.wpcom.req.get( '/domains/' + domainName + '/dns', fn );
 };
 
-Undocumented.prototype.updateDns = function( domain, records, fn ) {
-	var filtered = reject( records, 'isBeingDeleted' ),
-		body = { dns: JSON.stringify( filtered ) };
+/**
+ * @param {Object} options
+ *   An object containing options to pass along to the endpoint.
+ *
+ * @param {boolean} options.deleteEmailForwards
+ *   If this is set to true the API call will also delete the user's Email
+ *   Forwards.
+ */
+Undocumented.prototype.updateDns = function( domain, records, options, fn ) {
+	var apiOptions = mapKeysRecursively( options, snakeCase ),
+		dns = JSON.stringify( records ),
+		body = Object.assign( {}, apiOptions, { dns } );
 
 	this.wpcom.req.post( '/domains/' + domain + '/dns', body, fn );
 };

--- a/client/my-sites/upgrades/domain-management/dns/dns-list.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-list.jsx
@@ -60,7 +60,8 @@ const DnsList = React.createClass( {
 			return;
 		}
 
-		deleteDnsAction( this.props.selectedDomainName, record, ( error ) => {
+		const options = { deleteEmailForwards: confirmed };
+		deleteDnsAction( this.props.selectedDomainName, record, options, ( error ) => {
 			if ( error ) {
 				notices.error( error.message || this.translate( 'The DNS record has not been deleted.' ) );
 			} else {


### PR DESCRIPTION
This patch changes the DNS editor to pass an explicit parameter to the API when the user confirmed that they want to delete their email forwards.

Depends on D2201-code.

Test live: https://calypso.live/?branch=add/delete-mx-record-confirmation/param