### PR TITLE
Signup: add signupStore A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -138,4 +138,13 @@ module.exports = {
 		defaultVariation: 'original',
 		allowExistingUsers: false,
 	},
+	signupStore: {
+		datestamp: '20160707',
+		variations: {
+			designTypeWithoutStore: 80,
+			designTypeWithStore: 20,
+		},
+		defaultVariation: 'designTypeWithoutStore',
+		allowExistingUsers: false,
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -4,6 +4,7 @@
 import assign from 'lodash/assign';
 import includes from 'lodash/includes';
 import reject from 'lodash/reject';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -190,6 +191,20 @@ function removeUserStepFromFlow( flow ) {
 	} );
 }
 
+function filterDesignTypeInFlow( flow ) {
+	if ( ! flow ) {
+		return;
+	}
+
+	if ( ! includes( flow.steps, 'design-type' ) || 'designTypeWithStore' !== abtest( 'signupStore' ) ) {
+		return flow;
+	}
+
+	return assign( {}, flow, {
+		steps: flow.steps.map( stepName => stepName === 'design-type' ? 'design-type-with-store' : stepName )
+	} );
+}
+
 function filterFlowName( flowName ) {
 	const defaultFlows = [ 'main', 'website' ];
 	// do nothing. No flows to filter at the moment.
@@ -242,6 +257,10 @@ const Flows = {
 
 		if ( user.get() ) {
 			flow = removeUserStepFromFlow( flow );
+		}
+
+		if ( ! user.get() && 'en' === i18n.getLocaleSlug() ) {
+			flow = filterDesignTypeInFlow( flow );
 		}
 
 		return flow;


### PR DESCRIPTION
Replaces #6438.

The goal of this test is to gather information for a better understanding of volume and signup success rate of new users hoping to set up an online store.

Filter flows with `design-type` step to conditionally use `design-type-with-store`.

Test live: https://calypso.live/start/?branch=add/signup-ecommerce-ab