### PR TITLE
Reader: Fix intermittent issues with cold start cards in Safari

### DIFF
--- a/client/state/reader/posts/selectors.js
+++ b/client/state/reader/posts/selectors.js
@@ -33,7 +33,7 @@ export function getPostBySiteAndId( state, siteId, postId ) {
 		 */
 		const items = state.reader.posts.items,
 			// only internal (wpcom / jetpack) posts have a valid site_ID and post ID
-			internalPosts = filter( items, item => ! item.is_external );
+			internalPosts = filter( items, post => post && post.site_ID && post.ID && ! post.is_external );
 
 		postMapBySiteAndPost = keyBy( internalPosts, post => {
 			return `${post.site_ID}-${post.ID}`;


### PR DESCRIPTION
This makes the selector a bit stricter on what it'll accept into the map.
This should fix a problem we see where the only entry in the selector's memoized map is an entry for .
Currently unsure if this actually fixes the problem, or if something is lurking in the minimized version.

Test live: https://calypso.live/recommendations/start?branch=fix/reader/cold-start-cards-in-safari