### PR TITLE
Domains: Add error message for recently mapped domains

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -605,7 +605,7 @@ const RegisterDomainStep = React.createClass( {
 				break;
 
 			case 'mappable_but_recently_mapped':
-				message = this.translate( 'This domain cannot currently be mapped' );
+				message = this.translate( 'This domain cannot currently be mapped.' );
 				break;
 
 			default:

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -604,6 +604,10 @@ const RegisterDomainStep = React.createClass( {
 				message = this.translate( 'Sorry but there was a problem processing your request. Please try again in a few minutes.' );
 				break;
 
+			case 'mappable_but_recently_mapped':
+				message = this.translate( 'This domain cannot currently be mapped' );
+				break;
+
 			default:
 				throw new Error( 'Unrecognized error code: ' + error.code );
 		}


### PR DESCRIPTION
Needs patch: D2202-code

Test live: https://calypso.live/?branch=add/error-message-for-recently-mapped-domain