### PR TITLE
Plans: Update/google voucher test relaunch

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -52,6 +52,12 @@ const Plan = React.createClass( {
 		return this.props.comparePlansUrl ? this.props.comparePlansUrl : '/plans/compare/' + siteSuffix;
 	},
 
+	isUSorCanadaCurrency() {
+		const { plan } = this.props;
+		const planCurrency = plan.currency_code || 'USD';
+		return [ 'USD', 'CAD' ].indexOf( planCurrency ) > -1;
+	},
+
 	getDescription() {
 		const { plan, site } = this.props;
 
@@ -72,7 +78,7 @@ const Plan = React.createClass( {
 		}
 
 		// override plan description during google voucher test
-		if ( isGoogleVouchersEnabled() ) {
+		if ( this.isUSorCanadaCurrency() && isGoogleVouchersEnabled() ) {
 			if ( plan.product_id === premiumPlan.productId ) {
 				plan.description = premiumPlan.descriptionWithGoogleVouchers;
 			} else if ( plan.product_id === businessPlan.productId ) {

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -20,8 +20,8 @@ import {
 	shouldFetchSitePlans,
 	isGoogleVouchersEnabled,
 	isWordpressAdCreditsEnabled,
-	findCurrencyFromPlans
 } from 'lib/plans';
+import { findCurrencyFromPlans } from 'lib/plans/utils';
 import { getPlans } from 'state/plans/selectors';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import Gridicon from 'components/gridicon';

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -85,7 +85,7 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	googleVouchers: {
-		datestamp: '20160615',
+		datestamp: '20160706',
 		variations: {
 			disabled: 50,
 			enabled: 50,
@@ -94,7 +94,7 @@ module.exports = {
 		allowExistingUsers: false,
 	},
 	wordpressAdCredits: {
-		datestamp: '20160613',
+		datestamp: '20160706',
 		variations: {
 			disabled: 50,
 			enabled: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -85,7 +85,7 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	googleVouchers: {
-		datestamp: '20160706',
+		datestamp: '20160708',
 		variations: {
 			disabled: 50,
 			enabled: 50,
@@ -94,7 +94,7 @@ module.exports = {
 		allowExistingUsers: false,
 	},
 	wordpressAdCredits: {
-		datestamp: '20160706',
+		datestamp: '20160613',
 		variations: {
 			disabled: 50,
 			enabled: 50,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -110,7 +110,7 @@ export const plansList = {
 			' lots of space for audio and video, and $100 advertising voucher.' ),
 		getDescriptionWithWordAdsInstantActivation: () => i18n.translate( 'Your own domain name, powerful' +
 			' customization options, easy monetization with WordAds and lots of space for audio and video.' ),
-		getDescriptionWithWordAdsAndGoogleVouchers: () => i18n.translate( 'Your own domain name, powerful' +
+		getDescriptionWithWordAdsInstantActivationAndGoogleVouchers: () => i18n.translate( 'Your own domain name, powerful' +
 			' customization options, easy monetization with WordAds, lots of space for audio and video, and $100 advertising voucher.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_FREE_SITE,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -107,9 +107,11 @@ export const plansList = {
 		getDescription: () => i18n.translate( 'Your own domain name, powerful customization options, and' +
 			' lots of space for audio and video.' ),
 		getDescriptionWithGoogleVouchers: () => i18n.translate( 'Your own domain name, powerful customization options,' +
-			' lots of space for audio and video, and $100 advertising credit.' ),
+			' lots of space for audio and video, and $100 advertising voucher.' ),
 		getDescriptionWithWordAdsInstantActivation: () => i18n.translate( 'Your own domain name, powerful' +
 			' customization options, easy monetization with WordAds and lots of space for audio and video.' ),
+		getDescriptionWithWordAdsAndGoogleVouchers: () => i18n.translate( 'Your own domain name, powerful' +
+			' customization options, easy monetization with WordAds, lots of space for audio and video, and $100 advertising voucher.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_FREE_SITE,
 			FEATURE_CUSTOM_DOMAIN,
@@ -135,7 +137,7 @@ export const plansList = {
 		getDescription: () => i18n.translate( 'Everything included with Premium, as well as live chat support,' +
 			' unlimited access to premium themes, and Google Analytics.' ),
 		getDescriptionWithWordAdsCredit: () => i18n.translate( 'Everything included with Premium, as well as' +
-			' live chat support, unlimited access to premium themes, Google Analytics, and $200 advertising credit.' ),
+			' live chat support, unlimited access to premium themes, Google Analytics, and $200 advertising vouchers.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_FREE_SITE,
 			FEATURE_CUSTOM_DOMAIN,
@@ -295,9 +297,9 @@ export const featuresList = {
 	},
 
 	[ FEATURE_GOOGLE_AD_CREDITS ]: {
-		getTitle: () => i18n.translate( 'Advertising Credit' ),
-		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25. Offer valid in US and Canada.' ),
-		getDescriptionWithWordAdsCredit: () => i18n.translate( '$100 Google AdWords credit after spending the first $25. ' +
+		getTitle: () => i18n.translate( 'Advertising Vouchers' ),
+		getDescription: () => i18n.translate( '$100 Google AdWords voucher after spending the first $25. Offer valid in US and Canada.' ),
+		getDescriptionWithWordAdsCredit: () => i18n.translate( '$100 Google AdWords voucher after spending the first $25. ' +
 			'Offer valid in US and Canada. {{hr/}}Business also includes $100 of advertising from WordAds on WordPress.com.', {
 				components: {
 					hr: <hr className="plans-compare__info-hr"/>

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -237,7 +237,7 @@ export function applyTestFiltersToPlansList( planName ) {
 
 	const updatePlanDescriptions = () => {
 		if ( isWordadsInstantActivationEnabled() && isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
-			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsAndGoogleVouchers;
+			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsInstantActivationAndGoogleVouchers;
 		} else if ( isWordadsInstantActivationEnabled() && planName === PLAN_PREMIUM ) {
 			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsInstantActivation;
 		} else if ( isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -222,34 +222,41 @@ export function applyTestFiltersToPlansList( planName ) {
 	const filteredPlanConstantObj = { ...plansList[ planName ] };
 	let filteredPlanFeaturesConstantObj = pick( featuresList, plansList[ planName ].getFeatures() );
 
-	// remove disabled features from list
-	if ( ! isWordadsInstantActivationEnabled() ) {
-		filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
-			( value, key ) => key !== WORDADS_INSTANT
-		);
-	}
-	if ( ! isGoogleVouchersEnabled() ) {
-		filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
-			( value, key ) => key !== FEATURE_GOOGLE_AD_CREDITS
-		);
-	}
+	const removeDisabledFeatures = () => {
+		if ( ! isWordadsInstantActivationEnabled() ) {
+			filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
+				( value, key ) => key !== WORDADS_INSTANT
+			);
+		}
+		if ( ! isGoogleVouchersEnabled() ) {
+			filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
+				( value, key ) => key !== FEATURE_GOOGLE_AD_CREDITS
+			);
+		}
+	};
 
-	// update plan descriptions
-	if ( isWordadsInstantActivationEnabled() && isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
-		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsAndGoogleVouchers;
-	} else if ( isWordadsInstantActivationEnabled() && planName === PLAN_PREMIUM ) {
-		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsInstantActivation;
-	} else if ( isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
-		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithGoogleVouchers;
-	} else if ( isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS ) {
-		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsCredit;
-	}
+	const updatePlanDescriptions = () => {
+		if ( isWordadsInstantActivationEnabled() && isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
+			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsAndGoogleVouchers;
+		} else if ( isWordadsInstantActivationEnabled() && planName === PLAN_PREMIUM ) {
+			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsInstantActivation;
+		} else if ( isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
+			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithGoogleVouchers;
+		} else if ( isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS ) {
+			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsCredit;
+		}
+	};
 
-	// update info popup
-	if ( isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS	) {
-		filteredPlanFeaturesConstantObj[ FEATURE_GOOGLE_AD_CREDITS ].getDescription =
-		featuresList[ FEATURE_GOOGLE_AD_CREDITS ].getDescriptionWithWordAdsCredit;
-	}
+	const updateInfoPopups = () => {
+		if ( isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS	) {
+			filteredPlanFeaturesConstantObj[ FEATURE_GOOGLE_AD_CREDITS ].getDescription =
+			featuresList[ FEATURE_GOOGLE_AD_CREDITS ].getDescriptionWithWordAdsCredit;
+		}
+	};
+
+	removeDisabledFeatures();
+	updatePlanDescriptions();
+	updateInfoPopups();
 
 	filteredPlanConstantObj.getFeatures = () => filteredPlanFeaturesConstantObj;
 

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -12,6 +12,9 @@ import {
 	includes,
 	invoke
 } from 'lodash';
+import map from 'lodash/map';
+import head from 'lodash/head';
+import property from 'lodash/property';
 
 /**
  * Internal dependencies
@@ -205,6 +208,8 @@ export const isWordpressAdCreditsEnabled = () => {
 		abtest( 'wordpressAdCredits' ) === 'enabled'
 	);
 };
+
+export const findCurrencyFromPlans = plans => head( map( plans, property( 'currency_code' ) ) ) || 'USD';
 
 export function plansLink( url, site, intervalType ) {
 	if ( 'monthly' === intervalType ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -227,25 +227,33 @@ export function applyTestFiltersToPlansList( planName ) {
 	const filteredPlanConstantObj = { ...plansList[ planName ] };
 	let filteredPlanFeaturesConstantObj = pick( featuresList, plansList[ planName ].getFeatures() );
 
+	// remove disabled features from list
 	if ( ! isWordadsInstantActivationEnabled() ) {
 		filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
 			( value, key ) => key !== WORDADS_INSTANT
 		);
-	} else if ( planName === PLAN_PREMIUM ) {
-		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsInstantActivation;
 	}
-
 	if ( ! isGoogleVouchersEnabled() ) {
 		filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
 			( value, key ) => key !== FEATURE_GOOGLE_AD_CREDITS
 		);
-	} else if ( planName === PLAN_PREMIUM ) {
-		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithGoogleVouchers;
-	} else if ( isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS	) {
-		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsCredit;
+	}
 
+	// update plan descriptions
+	if ( isWordadsInstantActivationEnabled() && isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
+		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsAndGoogleVouchers;
+	} else if ( isWordadsInstantActivationEnabled() && planName === PLAN_PREMIUM ) {
+		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsInstantActivation;
+	} else if ( isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
+		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithGoogleVouchers;
+	} else if ( isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS ) {
+		filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsCredit;
+	}
+
+	// update info popup
+	if ( isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS	) {
 		filteredPlanFeaturesConstantObj[ FEATURE_GOOGLE_AD_CREDITS ].getDescription =
-			featuresList[ FEATURE_GOOGLE_AD_CREDITS ].getDescriptionWithWordAdsCredit;
+		featuresList[ FEATURE_GOOGLE_AD_CREDITS ].getDescriptionWithWordAdsCredit;
 	}
 
 	filteredPlanConstantObj.getFeatures = () => filteredPlanFeaturesConstantObj;

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -12,9 +12,6 @@ import {
 	includes,
 	invoke
 } from 'lodash';
-import map from 'lodash/map';
-import head from 'lodash/head';
-import property from 'lodash/property';
 
 /**
  * Internal dependencies
@@ -208,8 +205,6 @@ export const isWordpressAdCreditsEnabled = () => {
 		abtest( 'wordpressAdCredits' ) === 'enabled'
 	);
 };
-
-export const findCurrencyFromPlans = plans => head( map( plans, property( 'currency_code' ) ) ) || 'USD';
 
 export function plansLink( url, site, intervalType ) {
 	if ( 'monthly' === intervalType ) {

--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -15,7 +15,7 @@ import matchesProperty from 'lodash/matchesProperty';
  */
 import formatCurrency from 'lib/format-currency';
 import { PLAN_FREE, PLAN_PERSONAL } from './constants';
-import { findCurrencyFromPlans } from 'lib/plans';
+import { findCurrencyFromPlans } from 'lib/plans/utils';
 
 export const personalPlan = {
 	product_id: 1009,

--- a/client/lib/plans/personal-plan.js
+++ b/client/lib/plans/personal-plan.js
@@ -3,9 +3,6 @@
  */
 import { translate } from 'i18n-calypso';
 import has from 'lodash/has';
-import head from 'lodash/head';
-import property from 'lodash/property';
-import map from 'lodash/map';
 import some from 'lodash/some';
 import isEmpty from 'lodash/isEmpty';
 import findIndex from 'lodash/findIndex';
@@ -18,6 +15,7 @@ import matchesProperty from 'lodash/matchesProperty';
  */
 import formatCurrency from 'lib/format-currency';
 import { PLAN_FREE, PLAN_PERSONAL } from './constants';
+import { findCurrencyFromPlans } from 'lib/plans';
 
 export const personalPlan = {
 	product_id: 1009,
@@ -48,8 +46,6 @@ export const personalPlan = {
 	has_domain_credit: true
 };
 
-const findCurrency = plans => head( map( plans, property( 'currency_code' ) ) ) || 'USD';
-
 const pricePersonalPlan = currencyCode => {
 	const cost = personalPlan.prices[ currencyCode ];
 	const price = formatCurrency( cost, currencyCode );
@@ -64,7 +60,7 @@ const pricePersonalPlan = currencyCode => {
 	};
 };
 
-const getPricedPersonalPlan = flow( findCurrency, pricePersonalPlan );
+const getPricedPersonalPlan = flow( findCurrencyFromPlans, pricePersonalPlan );
 
 const hasCurrentPlan = partialRight( some, matchesProperty( 'current_plan', true ) );
 

--- a/client/lib/plans/utils.js
+++ b/client/lib/plans/utils.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import map from 'lodash/map';
-import head from 'lodash/head';
-import property from 'lodash/property';
+import { map, head, property } from 'lodash';
 
 export const findCurrencyFromPlans = plans => head(
 	map(

--- a/client/lib/plans/utils.js
+++ b/client/lib/plans/utils.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import map from 'lodash/map';
+import head from 'lodash/head';
+import property from 'lodash/property';
+
+export const findCurrencyFromPlans = plans => head(
+	map(
+		plans,
+		property( 'currency_code' )
+	)
+) || 'USD';

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -16,7 +16,6 @@ import { isPremium } from 'lib/products-values';
 import paths from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
-import { isGoogleVouchersEnabled } from 'lib/plans';
 
 const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 	const adminUrl = selectedSite.URL + '/wp-admin/',
@@ -38,8 +37,8 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 				}
 			/>
 
-			{ isGoogleVouchersEnabled() && <QuerySiteVouchers siteId={ selectedSite.ID } /> }
-			{ isGoogleVouchersEnabled() &&
+			{ config.isEnabled( 'googleVouchers' ) && <QuerySiteVouchers siteId={ selectedSite.ID } /> }
+			{ config.isEnabled( 'googleVouchers' ) &&
 				<div>
 					<GoogleVoucherDetails selectedSite={ selectedSite } />
 				</div>


### PR DESCRIPTION
This PR contains several fixes for the active Google Vouchers test and relaunches the test. The `calypso_abtest_start` event should now only fire once the user reaches the page showing the variant content. This removes some noise from the test. I've also renamed "Advertising Credit" to "Advertising Vouchers" as it was suggested that the term "Credit" can have a negative association and some confusion with a "credit line" indicating a liability. Last, and probably most important I am excluding people with currencies other than USD and CAD from this test, as the google vouchers program is unavailable to people outside the US and Canada for now.

## Testing
First, use a logged-out user with an empty localStorage, and then set your debug listener string to "calypso:analytics". Open your console and filter to `calypso_abtest_start" called`. Then go through the signup flow at `http://calypso.localhost:3000/start`. You will see some `calypso_abtest_start` events with data as you go through the process. Open the attached object of each of them as you go through. Confirm that the `googleVouchers` test is not triggered until you reach the "plans" step.

<img width="927" alt="screen shot 2016-07-06 at 10 23 02 pm" src="https://cloud.githubusercontent.com/assets/134044/16641631/4b5d3268-43c8-11e6-87d6-00c4eb3ebfaa.png">

When the test is enabled you will see mentions of the advertising vouchers on the plans and plans/compare page, both in the NUX and from the sidebar.

### Plans
<img width="978" alt="screen shot 2016-07-06 at 10 25 46 pm" src="https://cloud.githubusercontent.com/assets/134044/16641694/ca442910-43c8-11e6-8a00-d68b477fe57a.png">

---------------------------------

### Plans/Compare
<img width="739" alt="screen shot 2016-07-06 at 10 29 23 pm" src="https://cloud.githubusercontent.com/assets/134044/16641738/275f8f86-43c9-11e6-9d3e-bc347b519922.png">

### i18n
You should _not_ however see this content (nor should you see the `calypso_abtest_start` event for `googleVouchers` if you are viewing these pages with a user that has their currency set to something other than the the US or Canadian Dollar... or in the NUX for a logged-out user whose IP address causes them to see a currency other than USD or CAD.

### Important Note
One important note about this PR worth discussing if anyone disagrees. In order to better isolate users who have USD and CAD currencies and filter out users with other currencies, while still allowing the feature for previous users who have seen this experiment, I have removed the `abtest` check for showing this content on the `my-plan` page. This effectively means more people will be given the actual feature on the `my-plan` page, but our test is meant to gauge the impact of adding this feature to the purchase flow.

/cc @artpi @retrofox 




Test live: https://calypso.live/?branch=update/google-voucher-test-relaunch