### PR TITLE
Disable browser push notifications in old chrome versions

### DIFF
--- a/client/state/push-notifications/utils.js
+++ b/client/state/push-notifications/utils.js
@@ -5,6 +5,17 @@ import {
 	isServiceWorkerSupported,
 } from 'lib/service-worker';
 
+export function isUnsupportedChromeVersion() {
+	if ( window && window.chrome && window.navigator.appVersion ) {
+		return getChromeVersion() < 50;
+	}
+	return false;
+}
+
+export function getChromeVersion() {
+	return window.navigator.appVersion.match( /Chrome\/(\d+)/ )[ 1 ];
+}
+
 export function isPushNotificationsSupported() {
 	return (
 		isServiceWorkerSupported() &&


### PR DESCRIPTION
Fixes #6243

This PR seeks to fix the bug whereby browser push notifications do not arrive after enabling them. This bug affects users using Chrome 40-49, and this PR disables the feature for these users.

Chrome versions 40-49 support web push notifications, but not encryption. Our feature detection shows the browser as supporting web push notifications, and allows users to enable them. Due to lack of encryption support in these browsers, the subscription saved does not include encryption keys. When the notification is sent, an error such the following will get logged: 

```
Error sending notification: Malformed subscription: keys and endpoint required.
```

Even though Chrome 49 and below our not supported anymore, we will still disable notification support in these browsers because we see from our logs that some users are sticking with obsolete browser versions.

### Testing instructions

1. Turn on debugging for calypso: `localStorage.setItem( 'debug', 'calypso:*' );`
2. Navigate to the live branch in a Chrome browser v50 or above, and verify that the opt-in notice is visible (you may need a new user if you have dismissed the notice before), and the notification settings page (`/me/notifications`) has the browser notification panel.
3. Navigate to the live branch in a Chrome browser v49 (or below), and verify that neither the notice nor the browser notification settings are not visible. You will also see these lines in the console:

![screen shot 2016-07-07 at 4 22 11 pm](https://cloud.githubusercontent.com/assets/1017839/16657462/e8608336-4462-11e6-9785-1b1d544b7028.png)

I downloaded a VM from http://www.osboxes.org/ubuntu/ and an old Chrome version from http://www.slimjet.com/chrome/google-chrome-old-version.php for testing, but your milage may very.

4. Open the live branch in Firefox, and confirm that the notice and notification settings are visible there (no regression).

Test live: https://calypso.live/?branch=fix/push-notifications-in-old-chrome-6