### PR TITLE
Ad Tracking: Add user id to Facebook and AdWords conversion events

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -154,6 +154,10 @@ function recordPurchase( product ) {
 
 	debug( 'Recording purchase', product );
 
+	// record the user id as a custom parameter
+	const currentUser = user.get(),
+		userId = currentUser ? currentUser.ID : 0;
+
 	// record the purchase w/ Facebook
 	window.fbq(
 		'track',
@@ -161,7 +165,8 @@ function recordPurchase( product ) {
 		{
 			currency: product.currency,
 			product_slug: product.product_slug,
-			value: product.cost
+			value: product.cost,
+			user_id: userId
 		}
 	);
 
@@ -180,7 +185,8 @@ function recordPurchase( product ) {
 		google_conversion_value: product.cost,
 		google_conversion_currency: product.currency,
 		google_custom_params: {
-			product_slug: product.product_slug
+			product_slug: product.product_slug,
+			user_id: userId
 		},
 		google_remarketing_only: false
 	} );


### PR DESCRIPTION
This PR adds the user's id to the custom parameters we send to Facebook and AdWords when the user completes a purchase. This will come in handy in future types of analysis we do where we need to identify revenue differences between each service.

To test:

1) In `config/development.json`, set `ad-tracking` to `true`.
2) Complete a purchase on a test account
3) In Chrome's network console, search for `ev=Purchase` to find the Facebook conversion event. The network request should include the user id (107388884 in this example):

> https://www.facebook.com/tr/?id=823166884443641&ev=Purchase&dl=http%3A%2F%2Fcalypso.localhost%3A3000%2Fcheckout%2Fmhmazur20160707v1.wordpress.com&rl=http%3A%2F%2Fcalypso.localhost%3A3000%2Fplans%2Fmhmazur20160707v1.wordpress.com&if=false&ts=1467900206164&cd[currency]=USD&cd[product_slug]=value_bundle&cd[value]=99&cd[user_id]=107388884&v=2.5.0&pv=visible

4) In the network console, search for `google.com/ads/conversion` to find the AdWords conversion event. The request should also include the user id (107388884 in this example):

> https://www.google.com/ads/conversion/1067250390/?random=1101787837&cv=8&fst=1467900206165&num=1&fmt=3&value=99&currency_code=USD&label=MznpCMGHr2MQ1uXz_AM&guid=ON&u_h=1200&u_w=1920&u_ah=1096&u_aw=1920&u_cd=24&u_his=20&u_tz=-240&u_java=false&u_nplug=5&u_nmime=7&data=product_slug%3Dvalue_bundle%3Buser_id%3D107388884&frm=0&url=http%3A//calypso.localhost%3A3000/checkout/mhmazur20160707v1.wordpress.com&tiba=Checkout%20%E2%80%B9%20mhmazur20160707v1%20%E2%80%94%20WordPress.com&async=1&ctc_id=CAIVAgAAAB0CAAAA&ct_cookie_present=false&cdct=2&convclickts=0&ocp_id=LmF-V6f4FsLWpgPCrYXQBw&random=1267351192&pvtc_us=/1067250390/%3Frandom%3D117057350%26cv%3D8%26fst%3D1467900000000%26num%3D1%26fmt%3D3%26value%3D99%26currency_code%3DUSD%26label%3DMznpCMGHr2MQ1uXz_AM%26guid%3DON%26u_h%3D1200%26u_w%3D1920%26u_ah%3D1096%26u_aw%3D1920%26u_cd%3D24%26u_his%3D20%26u_tz%3D-240%26u_java%3Dfalse%26u_nplug%3D5%26u_nmime%3D7%26data%3Dproduct_slug%253Dvalue_bundle%253Buser_id%253D107388884%26frm%3D0%26url%3Dhttp://calypso.localhost:3000/checkout/mhmazur20160707v1.wordpress.com%26tiba%3DCheckout%2520%25E2%2580%25B9%2520mhmazur20160707v1%2520%25E2%2580%2594%2520WordPress.com%26async%3D1%26ctc_id%3DCAIVAgAAAB0CAAAA%26ct_cookie_present%3Dfalse

Test live: https://calypso.live/?branch=add/user-id-to-ad-tracking