### PR TITLE
Ad Tracking: Add product slugs to Atlas tracking

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -203,6 +203,7 @@ function recordOrderInAtlas( cart ) {
 	const params = {
 		event: 'Purchase',
 		products: cart.products.map( product => product.product_name ).join( ', ' ),
+		product_slugs: cart.products.map( product => product.product_slug ).join( ', ' ),
 		revenue: cart.total_cost,
 		currency_code: cart.currency,
 		user_id: currentUser ? currentUser.ID : 0


### PR DESCRIPTION
When we track conversions in Atlas, we currently pass a `products` parameter but because the product names can be translated, it makes analyzing the data in Atlas more difficult. A domain registration might be "Domain Registration" in one place and "Registro de dominio" in another. 

This PR adds a new parameter, `product_slugs`, which contains the untranslated product slugs for each product in the order. This will make analyzing the data easier.

To test:

1) In `config/development.json`, set `ad-tracking` to `true`.
2) Complete a purchase
3) Search Chrome's network console for `atdmt`. It should include a `product_slugs` parameter:

> https://ad.atdmt.com/m/a.js;m=11187200770563;cache=0.4330833436203063?event=Purchase&products=WordPress.com%20Premium&product_slugs=value_bundle&revenue=99&currency_code=USD&user_id=107388884




Test live: https://calypso.live/?branch=add/product-slugs-to-atlas-tracking