### PR TITLE
Personal Plan: Stops A/B Test

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -71,7 +71,6 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -67,7 +67,6 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -71,7 +71,6 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/test.json
+++ b/config/test.json
@@ -88,7 +88,6 @@
 		"olark": true,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -79,7 +79,6 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
-		"plans/personal-plan": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,


### PR DESCRIPTION
Disables the Personal Plan A/B Test on all environments except development.

cc: @apeatling @roundhill 

Test live: https://calypso.live/?branch=update/disable-personal-plan-ab-test