### PR TITLE
Themes: prevent links in "thank you" modal from wrapping.

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -24,6 +24,10 @@
 	ul {
 		display: block;
 		margin-left: 10px;
+
+		a {
+			white-space: nowrap;
+		}
 	}
 }
 


### PR DESCRIPTION
The _Thank you_ modal currently wraps the links inside it (see image below). This PR fixes that behavior and adds `nowrap` to the links inside the modal's unordered list.

![](https://cldup.com/SAUaPTItT8.png)




Test live: https://calypso.live/?branch=update/thanks-modal-add-nbsp