### PR TITLE
Prevent duplicate requests for start graduation

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -29,6 +29,7 @@ import { recordTrack } from 'reader/stats';
 import FeedError from 'reader/feed-error';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { requestGraduate } from 'state/reader/start/actions';
+import { isRequestingGraduation } from 'state/reader/start/selectors';
 
 const analyticsPageTitle = 'Reader';
 
@@ -173,7 +174,9 @@ module.exports = {
 				if ( FeedSubscriptionStore.getTotalSubscriptions() < config( 'reader_cold_start_graduation_threshold' ) ) {
 					defer( page.redirect.bind( page, '/recommendations/start' ) );
 				} else {
-					context.store.dispatch( requestGraduate() );
+					if ( ! isRequestingGraduation( context.store.getState() ) ) {
+						context.store.dispatch( requestGraduate() );
+					}
 					defer( next );
 				}
 			} else if ( tries > -1 ) {

--- a/client/state/reader/start/selectors.js
+++ b/client/state/reader/start/selectors.js
@@ -91,3 +91,12 @@ export function hasGraduatedRecommendations( state ) {
 	}
 	return graduated;
 }
+
+/**
+ * Returns true if the reader is currently requesting graduation
+ * @param  {object}  state Global state tree
+ * @return {Boolean}       Is the user requesting graduation?
+ */
+export function isRequestingGraduation( state ) {
+	return state.reader.start.isRequestingGraduation;
+}

--- a/client/state/reader/start/test/selectors.js
+++ b/client/state/reader/start/test/selectors.js
@@ -9,7 +9,8 @@ import { expect } from 'chai';
 import {
 	getRecommendations,
 	hasGraduatedRecommendations,
-	isRequestingRecommendations
+	isRequestingRecommendations,
+	isRequestingGraduation
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -31,6 +32,32 @@ describe( 'selectors', () => {
 				reader: {
 					start: {
 						isRequestingRecommendations: true
+					}
+				}
+			} );
+
+			expect( isRequesting ).to.be.true;
+		} );
+	} );
+
+	describe( '#isRequestingGraduation()', () => {
+		it( 'should return false if not fetching', () => {
+			const isRequesting = isRequestingGraduation( {
+				reader: {
+					start: {
+						isRequestingGraduation: false
+					}
+				}
+			} );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return true if fetching', () => {
+			const isRequesting = isRequestingGraduation( {
+				reader: {
+					start: {
+						isRequestingGraduation: true
 					}
 				}
 			} );


### PR DESCRIPTION
To test, create a new user and push them into the abtest. Then do enough to graduate and then hit done. You should only see one request for graduation fire in the network tab.