### PR TITLE
Jetpack Sync: Initial pass at adding selectors

### DIFF
--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns a sync status object by site ID.
+ * @param  {Object} state    Global state tree
+ * @param  {Number} siteId   Post global ID
+ * @return {Object}          Sync status object
+ */
+function getSyncStatus( state, siteId ) {
+	return get( state, [ 'jetpackSync', 'syncStatus', siteId ] );
+}
+
+/**
+ * Returns a full sync request object by site ID.
+ * @param  {Object} state    Global state tree
+ * @param  {Number} siteId   Post global ID
+ * @return {Object}          Full sync request object
+ */
+function getFullSyncRequest( state, siteId ) {
+	return get( state, [ 'jetpackSync', 'fullSyncRequest', siteId ] );
+}
+
+export default {
+	getSyncStatus,
+	getFullSyncRequest
+};

--- a/client/state/jetpack-sync/test/selectors.js
+++ b/client/state/jetpack-sync/test/selectors.js
@@ -1,0 +1,127 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getSyncStatus,
+	getFullSyncRequest
+} from '../selectors';
+
+const nonExistentId = '111111';
+const requestedSiteId = '123456';
+const successfulSiteId = '1234567';
+const errorSiteId = '12345678';
+
+const syncStatusSuccessful = {
+	isRequesting: false,
+	error: false,
+	lastSuccessfulStatus: 1467926563436,
+	started: 1466010260,
+	queue_finished: 1466010260,
+	sent_started: 1466010290,
+	finished: 1466010313,
+	queue: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 3,
+		themes: 1,
+		users: 2,
+		posts: 15,
+		comments: 1,
+		updates: 6
+	},
+	sent: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 3,
+		themes: 1,
+		users: 2,
+		posts: 15,
+		comments: 1
+	},
+	is_scheduled: false
+};
+
+const syncStatusErrored = {
+	isRequesting: false,
+	error: {
+		statusCode: 400
+	}
+};
+
+const fullSyncRequested = {
+	isRequesting: true,
+	lastRequested: 1467944517955
+};
+
+const fullSyncRequestSuccessful = {
+	isRequesting: true,
+	scheduled: true,
+	error: false,
+	lastRequested: 1467944517955
+};
+
+const fullSyncRequestErrored = {
+	isRequesting: false,
+	scheduled: false,
+	lastRequested: 1467944517955,
+	error: {
+		statusCode: 400
+	}
+};
+
+const testState = {
+	jetpackSync: {
+		syncStatus: {
+			[ successfulSiteId ]: syncStatusSuccessful,
+			[ errorSiteId ]: syncStatusErrored
+		},
+		fullSyncRequest: {
+			[ requestedSiteId ]: fullSyncRequested,
+			[ successfulSiteId ]: fullSyncRequestSuccessful,
+			[ errorSiteId ]: fullSyncRequestErrored
+		}
+	}
+};
+
+describe( 'selectors', () => {
+	describe( '#getSyncStatus()', () => {
+		it( 'should return undefined when state is {}', () => {
+			const syncStatus = getSyncStatus( {}, nonExistentId );
+			expect( syncStatus ).to.be.eql( undefined );
+		} );
+
+		it( 'should return undefined if site is not in state', () => {
+			const syncStatus = getSyncStatus( testState, nonExistentId );
+			expect( syncStatus ).to.be.eql( undefined );
+		} );
+
+		it( 'should return sync status for site if site in state', () => {
+			const syncStatus = getSyncStatus( testState, successfulSiteId );
+			expect( syncStatus ).to.be.eql( testState.jetpackSync.syncStatus[ successfulSiteId ] );
+		} );
+	} );
+
+	describe( '#getFullSyncRequest()', () => {
+		it( 'should return undefined when state is {}', () => {
+			const fullSyncRequest = getFullSyncRequest( {}, nonExistentId );
+			expect( fullSyncRequest ).to.be.eql( undefined );
+		} );
+
+		it( 'should return undefined if site is not in state', () => {
+			const fullSyncRequest = getFullSyncRequest( testState, nonExistentId );
+			expect( fullSyncRequest ).to.be.eql( undefined );
+		} );
+
+		it( 'should return full sync status for a site if in state', () => {
+			const fullSyncRequest = getFullSyncRequest( testState, successfulSiteId );
+			expect( fullSyncRequest ).to.be.eql( testState.jetpackSync.fullSyncRequest[ successfulSiteId ] );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR is a continuation of factoring #6044 into smaller PRs, and is possible now that the reducer went in with #6579.

To test:

- Checkout `add/jetpack-sync-selectors` branch
- Run tests: `npm run test-client -- --grep "state jetpack-sync"`

Test live: https://calypso.live/?branch=add/jetpack-sync-selectors