### PR TITLE
Purchases: Add actions for the stored cards reducer

### DIFF
--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -1,0 +1,69 @@
+// External dependencies
+import i18n from 'i18n-calypso';
+import { omit, values } from 'lodash';
+
+// Internal dependencies
+import {
+	STORED_CARDS_DELETE,
+	STORED_CARDS_DELETE_COMPLETED,
+	STORED_CARDS_DELETE_FAILED,
+	STORED_CARDS_FETCH,
+	STORED_CARDS_FETCH_COMPLETED,
+	STORED_CARDS_FETCH_FAILED
+} from 'state/action-types';
+import wp from 'lib/wp';
+const wpcom = wp.undocumented();
+
+/**
+ * `wpcom` assigns a `_headers` property to the response, even if the response
+ * is an array. This function omits the `_headers` property and converts the
+ * response to a real array, instead of an object keyed with indices.
+ *
+ * @param {Object} response - The response to a request from `wpcom`.
+ * @return {array} response - The given response converted into an array.
+ */
+const getArrayFromResponse = response => values( omit( response, '_headers' ) );
+
+export const fetchStoredCards = () => dispatch => {
+	dispatch( {
+		type: STORED_CARDS_FETCH
+	} );
+
+	return new Promise( ( resolve, reject ) => {
+		wpcom.getStoredCards( ( error, data ) => {
+			error ? reject( error ) : resolve( data );
+		} );
+	} ).then( data => {
+		dispatch( {
+			type: STORED_CARDS_FETCH_COMPLETED,
+			list: getArrayFromResponse( data )
+		} );
+	} ).catch( error => {
+		dispatch( {
+			type: STORED_CARDS_FETCH_FAILED,
+			error: error.message || i18n.translate( 'There was a problem retrieving stored cards.' )
+		} );
+	} );
+};
+
+export const deleteStoredCard = card => dispatch => {
+	dispatch( {
+		type: STORED_CARDS_DELETE
+	} );
+
+	return new Promise( ( resolve, reject ) => {
+		wpcom.me().storedCardDelete( card, ( error, data ) => {
+			error ? reject( error ) : resolve( data );
+		} );
+	} ).then( () => {
+		dispatch( {
+			type: STORED_CARDS_DELETE_COMPLETED,
+			card
+		} );
+	} ).catch( error => {
+		dispatch( {
+			type: STORED_CARDS_DELETE_FAILED,
+			error: error.message || i18n.translate( 'There was a problem deleting the stored card.' )
+		} );
+	} );
+};

--- a/client/state/stored-cards/test/actions.js
+++ b/client/state/stored-cards/test/actions.js
@@ -1,0 +1,138 @@
+// External dependencies
+import { expect } from 'chai';
+import { nock, useNock } from 'test/helpers/use-nock';
+import sinon from 'sinon';
+
+// Internal dependencies
+import {
+	deleteStoredCard,
+	fetchStoredCards
+} from '../actions';
+import {
+	STORED_CARDS_DELETE,
+	STORED_CARDS_DELETE_COMPLETED,
+	STORED_CARDS_DELETE_FAILED,
+	STORED_CARDS_FETCH,
+	STORED_CARDS_FETCH_COMPLETED,
+	STORED_CARDS_FETCH_FAILED
+} from 'state/action-types';
+
+describe( 'actions', () => {
+	useNock();
+
+	const spy = sinon.spy();
+
+	beforeEach( () => {
+		spy.reset();
+	} );
+
+	const error = {
+		code: 'unauthorized',
+		message: 'you are unauthorized'
+	};
+
+	describe( '#fetchStoredCards', () => {
+		const cards = [
+			{ stored_details_id: 1 },
+			{ stored_details_id: 2 }
+		];
+
+		describe( 'success', () => {
+			before( () => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.get( '/rest/v1.1/me/stored-cards' )
+					.reply( 200, cards );
+			} );
+
+			it( 'should dispatch fetch/complete actions', () => {
+				const promise = fetchStoredCards()( spy );
+
+				expect( spy ).to.have.been.calledWith( {
+					type: STORED_CARDS_FETCH
+				} );
+
+				return promise.then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: STORED_CARDS_FETCH_COMPLETED,
+						list: cards
+					} );
+				} );
+			} );
+		} );
+
+		describe( 'fail', () => {
+			before( () => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.get( '/rest/v1.1/me/stored-cards' )
+					.reply( 403, error );
+			} );
+
+			it( 'should dispatch fetch/fail actions', () => {
+				const promise = fetchStoredCards()( spy );
+
+				expect( spy ).to.have.been.calledWith( {
+					type: STORED_CARDS_FETCH
+				} );
+
+				return promise.then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: STORED_CARDS_FETCH_FAILED,
+						error: error.message
+					} );
+				} );
+			} );
+		} );
+	} );
+
+	describe( '#deleteStoredCard', () => {
+		const card = {
+			stored_details_id: 1337
+		};
+
+		describe( 'success', () => {
+			before( () => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.post( `/rest/v1.1/me/stored-cards/${ card.stored_details_id }/delete` )
+					.reply( 200, { success: true } );
+			} );
+
+			it( 'should dispatch fetch/complete actions', () => {
+				const promise = deleteStoredCard( card )( spy );
+
+				expect( spy ).to.have.been.calledWith( {
+					type: STORED_CARDS_DELETE
+				} );
+
+				return promise.then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: STORED_CARDS_DELETE_COMPLETED,
+						card
+					} );
+				} );
+			} );
+		} );
+
+		describe( 'fail', () => {
+			before( () => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.post( `/rest/v1.1/me/stored-cards/${ card.stored_details_id }/delete` )
+					.reply( 403, error );
+			} );
+
+			it( 'should dispatch fetch/fail actions', () => {
+				const promise = deleteStoredCard( card )( spy );
+
+				expect( spy ).to.have.been.calledWith( {
+					type: STORED_CARDS_DELETE
+				} );
+
+				return promise.then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: STORED_CARDS_DELETE_FAILED,
+						error: error.message
+					} );
+				} );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR adds actions for the `state/stored-cards` reducer, as well as tests for these actions. This is one of several PRs to replace the  Flux stores that run `/purchases` with branches of the global reducer.

**Testing**
You can run the tests with

```
npm run test-client client/state/stored-cards/test/actions.js
```

cc @gziolo as you have been interested in previous PRs of this nature. :)

Test live: https://calypso.live/?branch=add/stored-cards-actions