### PR TITLE
Domains: Use selectedSite's slug in paths, instead of domain

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/utils.js
+++ b/client/my-sites/upgrades/checkout-thank-you/utils.js
@@ -3,16 +3,10 @@
  */
 import paths from 'my-sites/upgrades/paths';
 
-function getDomainManagementUrl( selectedSite, domain ) {
-	let url;
-
-	if ( domain ) {
-		url = paths.domainManagementEdit( selectedSite.domain, domain );
-	} else {
-		url = paths.domainManagementList( selectedSite.domain );
-	}
-
-	return url;
+function getDomainManagementUrl( { slug }, domain ) {
+	return domain
+		? paths.domainManagementEdit( slug, domain )
+		: paths.domainManagementList( slug );
 }
 
 export default {

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -183,7 +183,7 @@ export default React.createClass( {
 				key="unverified-domains"
 				text={ this.translate( 'Urgent! Your domain %(domain)s may be lost forever because your email address is not verified.', { args: { domain } } ) }>
 
-				<NoticeAction href={ paths.domainManagementEdit( this.props.selectedSite.domain, domain ) }>
+				<NoticeAction href={ paths.domainManagementEdit( this.props.selectedSite.slug, domain ) }>
 					{ this.translate( 'Fix now' ) }
 				</NoticeAction>
 			</Notice>
@@ -197,7 +197,7 @@ export default React.createClass( {
 				<ul>{
 					domains.map( ( domain ) => {
 						return <li key={ domain.name }>
-							{ domain.name } <a href={ paths.domainManagementEdit( this.props.selectedSite.domain, domain.name ) }>{ this.translate( 'Fix now' ) }</a>
+							{ domain.name } <a href={ paths.domainManagementEdit( this.props.selectedSite.slug, domain.name ) }>{ this.translate( 'Fix now' ) }</a>
 						</li>;
 					} )
 				}</ul>

--- a/client/my-sites/upgrades/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/upgrades/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -265,7 +265,7 @@ const AddEmailAddressesCard = React.createClass( {
 		} );
 		googleAppsCartItems.forEach( upgradesActions.addItem );
 
-		page( '/checkout/' + this.props.selectedSite.domain );
+		page( '/checkout/' + this.props.selectedSite.slug );
 	},
 
 	handleCancel( event ) {
@@ -273,7 +273,7 @@ const AddEmailAddressesCard = React.createClass( {
 
 		this.recordEvent( 'cancelClick', this.props.selectedDomainName );
 
-		page( paths.domainManagementEmail( this.props.selectedSite.domain, this.props.selectedDomainName ) );
+		page( paths.domainManagementEmail( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/add-google-apps/index.jsx
+++ b/client/my-sites/upgrades/domain-management/add-google-apps/index.jsx
@@ -31,7 +31,7 @@ const AddGoogleApps = React.createClass( {
 
 		if ( needsRedirect ) {
 			const path = paths.domainManagementEmail(
-				this.props.selectedSite.domain,
+				this.props.selectedSite.slug,
 				this.props.selectedDomainName
 			);
 
@@ -60,7 +60,7 @@ const AddGoogleApps = React.createClass( {
 
 	goToEmail() {
 		const path = paths.domainManagementEmail(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.selectedDomainName
 		);
 

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
@@ -52,13 +52,13 @@ const ContactsPrivacy = React.createClass( {
 						privateDomain={ privateDomain } />
 
 					<VerticalNavItem
-							path={ paths.domainManagementEditContactInfo( this.props.selectedSite.domain, this.props.selectedDomainName ) }>
+							path={ paths.domainManagementEditContactInfo( this.props.selectedSite.slug, this.props.selectedDomainName ) }>
 						{ this.translate( 'Edit Contact Info' ) }
 					</VerticalNavItem>
 
 					{ ! hasPrivacyProtection && (
 						<VerticalNavItem
-							path={ paths.domainManagementPrivacyProtection( this.props.selectedSite.domain, this.props.selectedDomainName ) }>
+							path={ paths.domainManagementPrivacyProtection( this.props.selectedSite.slug, this.props.selectedDomainName ) }>
 							{ this.translate( 'Privacy Protection' ) }
 						</VerticalNavItem>
 					) }
@@ -72,7 +72,7 @@ const ContactsPrivacy = React.createClass( {
 	},
 
 	goToEdit() {
-		page( paths.domainManagementEdit( this.props.selectedSite.domain, this.props.selectedDomainName ) );
+		page( paths.domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/dns/delete-email-forwards-dialog.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/delete-email-forwards-dialog.jsx
@@ -66,7 +66,7 @@ const DeleteEmailForwardsDialog = React.createClass( {
 
 	getEmailForwardingPath: function() {
 		return domainManagementEmailForwarding(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.selectedDomainName
 		);
 	}

--- a/client/my-sites/upgrades/domain-management/dns/index.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/index.jsx
@@ -69,7 +69,7 @@ const Dns = React.createClass( {
 		}
 
 		page( path(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.selectedDomainName
 		) );
 	}

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -258,7 +258,7 @@ const EditContactInfoFormCard = React.createClass( {
 	},
 
 	goToContactsPrivacy() {
-		page( paths.domainManagementContactsPrivacy( this.props.selectedSite.domain, this.props.selectedDomainName ) );
+		page( paths.domainManagementContactsPrivacy( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	},
 
 	saveContactInfo( event ) {

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/index.jsx
@@ -66,7 +66,7 @@ const EditContactInfo = React.createClass( {
 	},
 
 	goToContactsPrivacy() {
-		page( paths.domainManagementContactsPrivacy( this.props.selectedSite.domain, this.props.selectedDomainName ) );
+		page( paths.domainManagementContactsPrivacy( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/edit/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/index.jsx
@@ -61,7 +61,7 @@ const Edit = React.createClass( {
 	},
 
 	goToDomainManagement() {
-		page( paths.domainManagementList( this.props.selectedSite.domain ) );
+		page( paths.domainManagementList( this.props.selectedSite.slug ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -117,7 +117,7 @@ const RegisteredDomain = React.createClass( {
 
 	emailNavItem() {
 		const path = paths.domainManagementEmail(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.domain.name
 		);
 
@@ -130,7 +130,7 @@ const RegisteredDomain = React.createClass( {
 
 	nameServersNavItem() {
 		const path = paths.domainManagementNameServers(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.domain.name
 		);
 
@@ -143,7 +143,7 @@ const RegisteredDomain = React.createClass( {
 
 	contactsPrivacyNavItem() {
 		const path = paths.domainManagementContactsPrivacy(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.domain.name
 		);
 
@@ -156,7 +156,7 @@ const RegisteredDomain = React.createClass( {
 
 	transferNavItem() {
 		const path = paths.domainManagementTransfer(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.domain.name
 		);
 

--- a/client/my-sites/upgrades/domain-management/edit/site-redirect.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/site-redirect.jsx
@@ -67,7 +67,7 @@ const SiteRedirect = React.createClass( {
 
 	siteRedirectNavItem() {
 		return (
-			<VerticalNavItem path={ paths.domainManagementRedirectSettings( this.props.selectedSite.domain, this.props.domain.name ) }>
+			<VerticalNavItem path={ paths.domainManagementRedirectSettings( this.props.selectedSite.slug, this.props.domain.name ) }>
 				{ this.translate( 'Redirect Settings' ) }
 			</VerticalNavItem>
 		);

--- a/client/my-sites/upgrades/domain-management/email-forwarding/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email-forwarding/index.jsx
@@ -62,7 +62,7 @@ const EmailForwarding = React.createClass( {
 	},
 
 	goToEditEmail() {
-		page( paths.domainManagementEmail( this.props.selectedSite.domain, this.props.selectedDomainName ) );
+		page( paths.domainManagementEmail( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/upgrades/domain-management/email/add-google-apps-card.jsx
@@ -181,7 +181,7 @@ const AddGoogleAppsCard = React.createClass( {
 	},
 
 	goToAddGoogleApps() {
-		page( paths.domainManagementAddGoogleApps( this.props.selectedSite.domain, this.props.selectedDomainName ) );
+		page( paths.domainManagementAddGoogleApps( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -333,7 +333,7 @@ export const List = React.createClass( {
 	},
 
 	goToEditDomainRoot( domain ) {
-		page( paths.domainManagementEdit( this.props.selectedSite.domain, domain.name ) );
+		page( paths.domainManagementEdit( this.props.selectedSite.slug, domain.name ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/name-servers/index.jsx
+++ b/client/my-sites/upgrades/domain-management/name-servers/index.jsx
@@ -149,7 +149,7 @@ const NameServers = React.createClass( {
 	},
 
 	back() {
-		page( paths.domainManagementEdit( this.props.selectedSite.domain, this.props.selectedDomainName ) );
+		page( paths.domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	},
 
 	customNameservers() {
@@ -203,7 +203,7 @@ const NameServers = React.createClass( {
 
 		return (
 			<VerticalNavItem
-				path={ paths.domainManagementDns( this.props.selectedSite.domain, this.props.selectedDomainName ) }>
+				path={ paths.domainManagementDns( this.props.selectedSite.slug, this.props.selectedDomainName ) }>
 				{ this.translate( 'DNS Records' ) }
 			</VerticalNavItem>
 		);

--- a/client/my-sites/upgrades/domain-management/privacy-protection/index.jsx
+++ b/client/my-sites/upgrades/domain-management/privacy-protection/index.jsx
@@ -44,7 +44,7 @@ const PrivacyProtection = React.createClass( {
 		}
 
 		if ( ! this.canAddPrivacyProtection() ) {
-			page( paths.domainManagementContactsPrivacy( this.props.selectedSite.domain, this.props.selectedDomainName ) );
+			page( paths.domainManagementContactsPrivacy( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 		}
 	},
 
@@ -93,7 +93,7 @@ const PrivacyProtection = React.createClass( {
 		}
 
 		page( path(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.selectedDomainName
 		) );
 	}

--- a/client/my-sites/upgrades/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/upgrades/domain-management/site-redirect/index.jsx
@@ -72,7 +72,7 @@ const SiteRedirect = React.createClass( {
 			this.recordEvent( 'updateSiteRedirectClick', this.props.selectedDomainName, this.state.location, success );
 
 			if ( success ) {
-				page( paths.domainManagementRedirectSettings( this.props.selectedSite.domain, this.state.location ) );
+				page( paths.domainManagementRedirectSettings( this.props.selectedSite.slug, this.state.location ) );
 			}
 		} );
 	},
@@ -146,7 +146,7 @@ const SiteRedirect = React.createClass( {
 	goToEdit() {
 		this.recordEvent( 'cancelClick', this.props.selectedDomainName );
 
-		page( paths.domainManagementEdit( this.props.selectedSite.domain, this.props.selectedDomainName ) );
+		page( paths.domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/transfer/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/index.jsx
@@ -65,7 +65,7 @@ const Transfer = React.createClass( {
 
 	goToEdit() {
 		page( paths.domainManagementEdit(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.selectedDomainName
 		) );
 	},


### PR DESCRIPTION
This the widely accepted pattern throughout Calypso (except Domain Management, where we love domains!). Using `domain` instead of `slug` could also potentially lead to some issues when there's a conflict between sites (a Jetpack site and a wpcom site redirecting to the same domain as the Jetpack one).

*Testing:*
Navigate around Domains in Calypso, check no navigation path is broken.
Search the code for any paths that are using `selectedSite.domain` instead of `selectedSite.slug` (I might have missed something if the domain was passed instead of the whole `selectedSite` object).

Fixes #1152

/cc @aidvu @umurkontaci 

Test live: https://calypso.live/?branch=fix/use-slug-in-domain-management