### PR TITLE
Editor: Untreeify start/stop index of rendered PostSelector row in considering requested bounds

### DIFF
--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -211,21 +211,25 @@ export function isSitePostsLastPageForQuery( state, siteId, query = {} ) {
  * @param  {Object}  query  Post query object
  * @return {?Array}         Posts for the post query
  */
-export function getSitePostsForQueryIgnoringPage( state, siteId, query ) {
-	const posts = state.posts.queries[ siteId ];
-	if ( ! posts ) {
-		return null;
-	}
+export const getSitePostsForQueryIgnoringPage = createSelector(
+	( state, siteId, query ) => {
+		const posts = state.posts.queries[ siteId ];
+		if ( ! posts ) {
+			return null;
+		}
 
-	const itemsIgnoringPage = posts.getItemsIgnoringPage( query );
-	if ( ! itemsIgnoringPage ) {
-		return null;
-	}
+		const itemsIgnoringPage = posts.getItemsIgnoringPage( query );
+		if ( ! itemsIgnoringPage ) {
+			return null;
+		}
 
-	return itemsIgnoringPage.map( ( post ) => {
-		return getNormalizedPost( state, post.global_ID );
-	} );
-}
+		return itemsIgnoringPage.map( ( post ) => {
+			return getNormalizedPost( state, post.global_ID );
+		} );
+	},
+	( state ) => state.posts.queries,
+	( state, siteId, query ) => getSerializedPostsQuery( query, siteId )
+);
 
 /**
  * Returns true if currently requesting posts for the posts query, regardless

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -30,6 +30,7 @@ describe( 'selectors', () => {
 	beforeEach( () => {
 		getSitePosts.memoizedSelector.cache.clear();
 		getSitePost.memoizedSelector.cache.clear();
+		getSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
 		getSitePostsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
 		isRequestingSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
 		getNormalizedPost.memoizedSelector.cache.clear();


### PR DESCRIPTION
Fixes #6623 
Related: #6629 (alternate fix)
Related: #6495 (regression source)

This pull request seeks to explore a potential solution for an issue related to the introduction of refined requesting behavior based on the visible range of rows in the `<PostSelector />` component (#6495).

The issue manifests itself for sites where a deep hierarchy exists with few top-level posts. For example, if a site has only 5 top-level pages, each with 10 of their own children (55 total pages), the `onRowsRendered` behavior will never pass a `stopIndex` greater than 4 (the 5th top level page) because all of the children are rendered within the same "row" as their parents. Currently, the logic will determine that even with a load offset of 10 posts ahead (15), it will decide not to load any more than the first page, despite there being 3 total pages.

__Implementation notes:__

The changes herein try to determine an extreme start or stop index, given the row index and all of the item's associated with that index (the parent and all of its descendents), trying to find the smallest/greatest index in the original flattened posts array.

Alternatives considered:

- Treeify from the component itself, passing `rowCount` as the flattened posts array count, returning `undefined` when `renderRow` is called for a child page. The problem with this approach is that for search queries where only child pages are returned, nothing will be rendered (because this depends on the child's parent being rendered)

__Testing instructions:__

Ensure that your site is configured to be able to reproduce the original issue in production. Your site should have at least twenty pages, with fewer than 10 top-level pages. When navigating to the [page editor](https://wordpress.com/post), you should observe that the second page never loads (a placeholder is forever shown at the bottom of the list).

Once you've reproduced the issue, repeat these steps in the [post editor of this branch](http://calypso.localhost:3000/post), and verify that the issue is no longer present (that all pages can be loaded), and that there are no regressions in search behavior.

Test live: https://calypso.live/?branch=fix/editor-post-selector-hierarchy