### PR TITLE
Plans: Nudge for footer credit

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -163,6 +163,7 @@ var Customize = React.createClass( {
 		const panels = {
 			widgets: { panel: 'widgets' },
 			fonts: { section: 'jetpack_fonts' },
+			identity: { section: 'title_tagline' },
 			'custom-css': { section: 'jetpack_custom_css' },
 		};
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -502,7 +502,7 @@ const FormGeneral = React.createClass( {
 						<SectionHeader label={ this.translate( '"WordPress.com" Footer Credit' ) } />
 						{
 							isBusiness( site.plan ) ? <Card href={ '/customize/identity/' + site.slug }>
-								<div className="">
+								<div>
 									<h2 className="site-settings__footer-credit-title">{ this.translate( 'Change or remove footer at the bottom of your page.' ) }</h2>
 									<p className="site-settings__footer-credit-description">
 										{ this.translate( 'Because you have Business plan, you can remove the footer credit' ) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -30,6 +30,8 @@ import Timezone from 'components/timezone';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDomainsBySite } from 'state/sites/domains/selectors';
 import JetpackSyncPanel from './jetpack-sync-panel';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
+import { isBusiness } from 'lib/products-values';
 
 const FormGeneral = React.createClass( {
 	displayName: 'SiteSettingsFormGeneral',
@@ -495,6 +497,26 @@ const FormGeneral = React.createClass( {
 					</form>
 				</Card>
 
+				{
+					! this.props.site.jetpack && <div>
+						<SectionHeader label={ this.translate( '"WordPress.com" Footer Credit' ) } />
+						{
+							isBusiness( site.plan ) ? <Card href={ '/customize/identity/' + site.slug }>
+								<div className="">
+									<h2 className="site-settings__footer-credit-title">{ this.translate( 'Change or remove footer at the bottom of your page.' ) }</h2>
+									<p className="site-settings__footer-credit-description">
+										{ this.translate( 'Because you have Business plan, you can remove the footer credit' ) }
+									</p>
+								</div>
+							</Card> : <UpgradeNudge
+								className="site-settings__footer-credit-nudge"
+								title="Remove WordPress.com footer credit with Business Plan"
+								message="With Business plan you can remove footes branding, add google analytics and more"
+								icon="customize"
+							/>
+						}
+					</div>
+				}
 				<SectionHeader label={ this.translate( 'Related Posts' ) }>
 					<Button
 						compact={ true }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -498,30 +498,24 @@ const FormGeneral = React.createClass( {
 					</form>
 				</Card>
 				{
-					! this.props.site.jetpack && <div>
+					! this.props.site.jetpack && <div className="site-settings__footer-credit-container">
 						<SectionHeader label={ this.translate( 'Footer Credit' ) } />
 						<CompactCard className="site-settings__footer-credit-explanation">
-							{ this.translate( `All WordPress.com users can choose among several options for the footer credit,
-								from a minimalist WordPress.com logo to text options like 
-								“A WordPress.com Website” or “Powered by WordPress.com.”` ) }
-						</CompactCard>
-						<Card href={ ( isBusiness( site.plan ) ? '/customize/identity/' : '/plans/' ) + site.slug }>
+							<p>
+								{ this.translate( 'You can customize your website by changing the footer credit in customizer.' ) }
+							</p>
 							<div>
-								<h2 className="site-settings__footer-credit-title">
-									{ this.translate( 'Change or remove footer at the bottom of your page.' ) }
-								</h2>
-								{
-									isBusiness( site.plan ) ? <p className="site-settings__footer-credit-description">
-										{ this.translate( 'Because you have Business plan, you can remove the footer credit' ) }
-									</p> : <div className="site-settings__footer-credit-nudge">
-										<Gridicon className="site-settings__footer-credit-nudge-icon" icon="customize" size={ 18 } />
-										<div className="site-settings__footer-credit-nudge-title">
-											{ this.translate( 'Available with a businesss plan' ) }
-										</div>
-									</div>
-								}
+								<Button className="site-settings__footer-credit-change" href={ '/customize/identity/' + site.slug }>
+									{ this.translate( 'Change footer credit' ) }
+								</Button>
 							</div>
-						</Card>
+						</CompactCard>
+						{ ! isBusiness( site.plan ) && <UpgradeNudge
+							className="site-settings__footer-credit-nudge"
+							title="Remove the footer credit entirely with Business Plan"
+							message="Upgrade to remove the footer credit, add google analytics and more"
+							icon="customize"
+						/> }
 					</div>
 				}
 				<SectionHeader label={ this.translate( 'Related Posts' ) }>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -503,7 +503,9 @@ const FormGeneral = React.createClass( {
 						{
 							isBusiness( site.plan ) ? <Card href={ '/customize/identity/' + site.slug }>
 								<div>
-									<h2 className="site-settings__footer-credit-title">{ this.translate( 'Change or remove footer at the bottom of your page.' ) }</h2>
+									<h2 className="site-settings__footer-credit-title">
+										{ this.translate( 'Change or remove footer at the bottom of your page.' ) }
+									</h2>
 									<p className="site-settings__footer-credit-description">
 										{ this.translate( 'Because you have Business plan, you can remove the footer credit' ) }
 									</p>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -32,6 +32,7 @@ import { getDomainsBySite } from 'state/sites/domains/selectors';
 import JetpackSyncPanel from './jetpack-sync-panel';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { isBusiness } from 'lib/products-values';
+import CompactCard from 'components/card/compact';
 
 const FormGeneral = React.createClass( {
 	displayName: 'SiteSettingsFormGeneral',
@@ -496,27 +497,31 @@ const FormGeneral = React.createClass( {
 						{ this.visibilityOptions() }
 					</form>
 				</Card>
-
 				{
 					! this.props.site.jetpack && <div>
-						<SectionHeader label={ this.translate( '"WordPress.com" Footer Credit' ) } />
-						{
-							isBusiness( site.plan ) ? <Card href={ '/customize/identity/' + site.slug }>
-								<div>
-									<h2 className="site-settings__footer-credit-title">
-										{ this.translate( 'Change or remove footer at the bottom of your page.' ) }
-									</h2>
-									<p className="site-settings__footer-credit-description">
+						<SectionHeader label={ this.translate( 'Footer Credit' ) } />
+						<CompactCard className="site-settings__footer-credit-explanation">
+							{ this.translate( `All WordPress.com users can choose among several options for the footer credit,
+								from a minimalist WordPress.com logo to text options like 
+								“A WordPress.com Website” or “Powered by WordPress.com.”` ) }
+						</CompactCard>
+						<Card href={ ( isBusiness( site.plan ) ? '/customize/identity/' : '/plans/' ) + site.slug }>
+							<div>
+								<h2 className="site-settings__footer-credit-title">
+									{ this.translate( 'Change or remove footer at the bottom of your page.' ) }
+								</h2>
+								{
+									isBusiness( site.plan ) ? <p className="site-settings__footer-credit-description">
 										{ this.translate( 'Because you have Business plan, you can remove the footer credit' ) }
-									</p>
-								</div>
-							</Card> : <UpgradeNudge
-								className="site-settings__footer-credit-nudge"
-								title="Remove WordPress.com footer credit with Business Plan"
-								message="With Business plan you can remove footer branding, add google analytics and more"
-								icon="customize"
-							/>
-						}
+									</p> : <div className="site-settings__footer-credit-nudge">
+										<Gridicon className="site-settings__footer-credit-nudge-icon" icon="customize" size={ 18 } />
+										<div className="site-settings__footer-credit-nudge-title">
+											{ this.translate( 'Available with a businesss plan' ) }
+										</div>
+									</div>
+								}
+							</div>
+						</Card>
 					</div>
 				}
 				<SectionHeader label={ this.translate( 'Related Posts' ) }>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -511,7 +511,7 @@ const FormGeneral = React.createClass( {
 							</Card> : <UpgradeNudge
 								className="site-settings__footer-credit-nudge"
 								title="Remove WordPress.com footer credit with Business Plan"
-								message="With Business plan you can remove footes branding, add google analytics and more"
+								message="With Business plan you can remove footer branding, add google analytics and more"
 								icon="customize"
 							/>
 						}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -122,7 +122,28 @@
 			background: $alert-yellow;
 		}
 	}
+
+	.site-settings__footer-credit-nudge.upgrade-nudge.card {
+		margin-top: 0
+	}
+
+	.site-settings__footer-credit-title {
+		margin-bottom: 16px;
+		font-size: 21px;
+		font-weight: 300;
+		line-height: 24px;
+		color: #2e4453;
+	}
+
+	.site-settings__footer-credit-description {
+		margin-bottom:0;
+	    font-size: 13px;
+	    color: #87a6bc;
+	    font-style: italic;
+	}
 }
+
+
 
 .writing-settings,
 .general-settings {
@@ -280,3 +301,4 @@
 .site-settings__jetpack-prompt-text {
 	flex: 4;
 }
+

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -148,8 +148,6 @@
 	    margin-right: 16px;
 	    color: white;
 	    padding: 6px;
-	    -webkit-align-self: center;
-	    -ms-flex-item-align: center;
 	    align-self: center;
 	}
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -122,27 +122,26 @@
 			background: $alert-yellow;
 		}
 	}
-
-	.site-settings__footer-credit-container {
-		margin-bottom: 16px;
-	}
-
-	.site-settings__footer-credit-nudge.card {
-		margin: 0;
-	}
-
-	.site-settings__footer-credit-change {
-		width: 175px;
-		text-align:center;
-	}
-
-	.site-settings__footer-credit-explanation {
-		display:flex;
-	    flex-direction: row;
-	    justify-content: space-between;
-	}
 }
 
+.site-settings__footer-credit-container {
+	margin-bottom: 16px;
+}
+
+.site-settings__footer-credit-nudge.card.upgrade-nudge {
+	margin: 0;
+}
+
+.site-settings__footer-credit-change {
+	width: 175px;
+	text-align:center;
+}
+
+.site-settings__footer-credit-explanation {
+	display:flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
 
 
 .writing-settings,

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -123,44 +123,23 @@
 		}
 	}
 
-	.site-settings__footer-credit-title {
+	.site-settings__footer-credit-container {
 		margin-bottom: 16px;
-		font-size: 21px;
-		font-weight: 300;
-		line-height: 24px;
-		color: #2e4453;
 	}
 
-	.site-settings__footer-credit-description {
-		margin-bottom:0;
-	    color: #87a6bc;
-	    font-style: italic;
+	.site-settings__footer-credit-nudge.card {
+		margin: 0;
 	}
 
-	.site-settings__footer-credit-nudge {
-		display: flex;
-		flex-direction: row;
-	}
-
-	.site-settings__footer-credit-nudge-icon {
-		background: $alert-yellow;
-	    border-radius: 50%;
-	    margin-right: 16px;
-	    color: white;
-	    padding: 6px;
-	    align-self: center;
-	}
-
-	.site-settings__footer-credit-nudge-title {
-	    font-weight: 500;
-	    color: black;
-	    margin-top: 4px;
+	.site-settings__footer-credit-change {
+		width: 175px;
+		text-align:center;
 	}
 
 	.site-settings__footer-credit-explanation {
-		font-size: 13px;
-		color: $gray;
-	    font-style: italic;
+		display:flex;
+	    flex-direction: row;
+	    justify-content: space-between;
 	}
 }
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -143,7 +143,7 @@
 	}
 
 	.site-settings__footer-credit-nudge-icon {
-	    background: #f0b849;
+		background: $alert-yellow;
 	    border-radius: 50%;
 	    margin-right: 16px;
 	    color: white;
@@ -161,7 +161,7 @@
 
 	.site-settings__footer-credit-explanation {
 		font-size: 13px;
-	    color: #87a6bc;
+		color: $gray;
 	    font-style: italic;
 	}
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -123,10 +123,6 @@
 		}
 	}
 
-	.site-settings__footer-credit-nudge.upgrade-nudge.card {
-		margin-top: 0
-	}
-
 	.site-settings__footer-credit-title {
 		margin-bottom: 16px;
 		font-size: 21px;
@@ -137,7 +133,34 @@
 
 	.site-settings__footer-credit-description {
 		margin-bottom:0;
-	    font-size: 13px;
+	    color: #87a6bc;
+	    font-style: italic;
+	}
+
+	.site-settings__footer-credit-nudge {
+		display: flex;
+		flex-direction: row;
+	}
+
+	.site-settings__footer-credit-nudge-icon {
+	    background: #f0b849;
+	    border-radius: 50%;
+	    margin-right: 16px;
+	    color: white;
+	    padding: 6px;
+	    -webkit-align-self: center;
+	    -ms-flex-item-align: center;
+	    align-self: center;
+	}
+
+	.site-settings__footer-credit-nudge-title {
+	    font-weight: 500;
+	    color: black;
+	    margin-top: 4px;
+	}
+
+	.site-settings__footer-credit-explanation {
+		font-size: 13px;
 	    color: #87a6bc;
 	    font-style: italic;
 	}


### PR DESCRIPTION
Now we can customize footer credit on wpcom:
https://en.blog.wordpress.com/2016/07/06/customize-footer-credit/

This introduces a proper nudge and a link in settings.

### Non-Business site

![screen shot 2016-07-12 at 12 10 02 pm](https://cloud.githubusercontent.com/assets/3775068/16763980/d3f29066-482b-11e6-9879-6ad39987ae9b.png)


### Business site

![screen shot 2016-07-12 at 12 10 12 pm](https://cloud.githubusercontent.com/assets/3775068/16763972/cc3e38f2-482b-11e6-8e20-d61b23c332cb.png)


# Testing

1. Go to http://calypso.localhost:3000/settings/general
2. Select a non-buriness site
3. See a nudge
4. Change to business
5. See  a link to customizer
6. See that link redirects you to a proper place in customizer

CC @rralian @mtias @gwwar @lamosty

Test live: https://calypso.live/?branch=add/nudge-business-custom-credit