### PR TITLE
Plans: update navigation

### DIFF
--- a/client/my-sites/plans/current-plan/controller.js
+++ b/client/my-sites/plans/current-plan/controller.js
@@ -11,7 +11,9 @@ import CurrentPlanOverview from './main';
 
 export default function( context ) {
 	renderWithReduxStore(
-		<CurrentPlanOverview/>,
+		React.createElement( CurrentPlanOverview, {
+			context: context
+		} ),
 		document.getElementById( 'primary' ),
 		context.store
 	);

--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -27,6 +27,7 @@ import {
 } from 'lib/products-values';
 import Gridicon from 'components/gridicon';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import PlansNavigation from 'my-sites/upgrades/navigation';
 
 const PlanDetailsComponent = React.createClass( {
 	PropTypes: {
@@ -88,9 +89,14 @@ const PlanDetailsComponent = React.createClass( {
 				/>
 			</div> );
 		}
-
+		console.log(this.props);
 		return (
 			<Main className="current-plan">
+				<PlansNavigation
+					sitePlans={ this.props.sitePlans }
+					path={ this.props.context.path }
+					selectedSite={ selectedSite }
+				/>
 				<Card>
 					<div className="current-plan__header">
 						<div className="current-plan__header-content">
@@ -127,11 +133,11 @@ const PlanDetailsComponent = React.createClass( {
 	}
 } );
 
-export default connect(
-	( state ) => {
+export default connect( ( state, ownProps ) => {
 		return {
 			selectedSite: getSelectedSite( state ),
-			sitePlans: getPlansBySite( state, getSelectedSite( state ) )
+			sitePlans: getPlansBySite( state, getSelectedSite( state ) ),
+			context: ownProps.context
 		};
 	},
 	dispatch => ( {

--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -89,7 +89,7 @@ const PlanDetailsComponent = React.createClass( {
 				/>
 			</div> );
 		}
-		console.log(this.props);
+
 		return (
 			<Main className="current-plan">
 				<PlansNavigation

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -18,7 +18,7 @@ import PopoverCart from 'my-sites/upgrades/cart/popover-cart';
 
 const PlansNavigation = React.createClass( {
 	propTypes: {
-		cart: React.PropTypes.object.isRequired,
+		cart: React.PropTypes.object,
 		path: React.PropTypes.string.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
@@ -61,7 +61,7 @@ const PlansNavigation = React.createClass( {
 					onMobileNavPanelOpen={ this.onMobileNavPanelOpen }>
 				<NavTabs label="Section" selectedText={ path }>
 					{ ! isJetpack && hasPlan &&
-						<NavItem path={ `/plans/my-plan/${ site.slug }` } key="myPlan" selected={ path === '/my-plan' }>
+						<NavItem path={ `/plans/my-plan/${ site.slug }` } key="myPlan" selected={ path === '/plans/my-plan' }>
 							{ this.translate( 'My Plan' ) }
 						</NavItem>
 					}
@@ -103,7 +103,7 @@ const PlansNavigation = React.createClass( {
 	},
 
 	cartToggleButton() {
-		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
+		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! this.props.cart ) {
 			return null;
 		}
 

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -1,35 +1,27 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	startsWith = require( 'lodash/startsWith' ),
-	Dispatcher = require( 'dispatcher' ),
-	find = require( 'lodash/find' ),
-	propertyOf = require( 'lodash/propertyOf' ),
-	flatten = require( 'lodash/flatten' ),
-	map = require( 'lodash/map' ),
-	sortBy = require( 'lodash/sortBy' ),
-	size = require( 'lodash/size' ),
-	filter = require( 'lodash/filter' ),
-	includes = require( 'lodash/includes' ),
-	i18n = require( 'i18n-calypso' );
+import React from 'react';
+import { startsWith, find, propertyOf, flatten, map, sortBy, size, filter, includes } from 'lodash';
+import Dispatcher from 'dispatcher';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	SectionNav = require( 'components/section-nav' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	NavItem = require( 'components/section-nav/item' ),
-	upgradesPaths = require( 'my-sites/upgrades/paths' ),
-	viewport = require( 'lib/viewport' ),
-	upgradesActionTypes = require( 'lib/upgrades/constants' ).action,
-	PopoverCart = require( 'my-sites/upgrades/cart/popover-cart' );
+import config from 'config';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import upgradesPaths from 'my-sites/upgrades/paths';
+import viewport from 'lib/viewport';
+import { action as upgradesActionTypes } from 'lib/upgrades/constants';
+import PopoverCart from 'my-sites/upgrades/cart/popover-cart';
 
 // The first path acts as the primary path that the button will link to. The
 // remaining paths will make the button highlighted on that page.
 
-var NAV_ITEMS = {
+const NAV_ITEMS = {
 	Addons: {
 		paths: [ '/plans' ],
 		label: i18n.translate( 'Add-ons for Jetpack sites' ),
@@ -64,7 +56,7 @@ var NAV_ITEMS = {
 	}
 };
 
-var UpgradesNavigation = React.createClass( {
+const PlansNavigation = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
 		path: React.PropTypes.string.isRequired,
@@ -75,14 +67,14 @@ var UpgradesNavigation = React.createClass( {
 		sitePlans: React.PropTypes.object.isRequired
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			cartVisible: false,
 			cartShowKeepSearching: false
 		};
 	},
 
-	componentWillMount: function() {
+	componentWillMount() {
 		this.dispatchToken = Dispatcher.register( function( payload ) {
 			if ( payload.action.type === upgradesActionTypes.CART_POPUP_OPEN ) {
 				this.setState( { cartVisible: true, cartShowKeepSearching: payload.action.options.showKeepSearching } );
@@ -92,12 +84,12 @@ var UpgradesNavigation = React.createClass( {
 		}.bind( this ) );
 	},
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		Dispatcher.unregister( this.dispatchToken );
 	},
 
-	render: function() {
-		var navItems = this.getNavItemData().map( this.navItem ),
+	render() {
+		const navItems = this.getNavItemData().map( this.navItem ),
 			selectedNavItem = this.getSelectedNavItem(),
 			selectedText = selectedNavItem && selectedNavItem.label;
 
@@ -106,7 +98,7 @@ var UpgradesNavigation = React.createClass( {
 					hasPinnedItems={ viewport.isMobile() }
 					selectedText={ selectedText }
 					onMobileNavPanelOpen={ this.onMobileNavPanelOpen }>
-				<NavTabs label='Section' selectedText={ selectedText }>
+				<NavTabs label="Section" selectedText={ selectedText }>
 					{ navItems }
 				</NavTabs>
 				{ this.cartToggleButton() }
@@ -114,8 +106,8 @@ var UpgradesNavigation = React.createClass( {
 		);
 	},
 
-	getNavItemData: function() {
-		var items;
+	getNavItemData() {
+		let items;
 
 		if ( this.props.selectedSite.jetpack ) {
 			items = [ 'Addons' ];
@@ -126,8 +118,8 @@ var UpgradesNavigation = React.createClass( {
 		return items.map( propertyOf( NAV_ITEMS ) );
 	},
 
-	getSelectedNavItem: function() {
-		var allPaths = flatten( map( this.getNavItemData(), 'paths' ) ),
+	getSelectedNavItem() {
+		const allPaths = flatten( map( this.getNavItemData(), 'paths' ) ),
 			sortedPaths = sortBy( allPaths, function( path ) {
 				return -countSlashes( path );
 			} ),
@@ -140,7 +132,7 @@ var UpgradesNavigation = React.createClass( {
 		} );
 	},
 
-	navItem: function( itemData ) {
+	navItem( itemData ) {
 		var { paths, allSitesPath, label } = itemData,
 			slug = this.props.selectedSite ? this.props.selectedSite.slug : null,
 			selectedNavItem = this.getSelectedNavItem(),
@@ -162,7 +154,7 @@ var UpgradesNavigation = React.createClass( {
 		);
 	},
 
-	toggleCartVisibility: function( event ) {
+	toggleCartVisibility( event ) {
 		if ( event ) {
 			event.preventDefault();
 		}
@@ -170,15 +162,15 @@ var UpgradesNavigation = React.createClass( {
 		this.setState( { cartVisible: ! this.state.cartVisible } );
 	},
 
-	onMobileNavPanelOpen: function() {
+	onMobileNavPanelOpen() {
 		this.setState( { cartVisible: false } );
 	},
 
-	onKeepSearchingClick: function() {
+	onKeepSearchingClick() {
 		this.setState( { cartVisible: false } );
 	},
 
-	cartToggleButton: function() {
+	cartToggleButton() {
 		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
 			return null;
 		}
@@ -204,4 +196,4 @@ function countSlashes( path ) {
 	} ) );
 }
 
-module.exports = UpgradesNavigation;
+export default PlansNavigation;

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -53,13 +53,14 @@ const PlansNavigation = React.createClass( {
 		const isJetpack = site && site.jetpack;
 		const path = sectionify( this.props.path );
 		const hasPlan = site && site.plan && site.plan.product_slug !== 'free_plan';
+		const sectionTitle = path.split( '?' )[ 0 ].replace( /\//g, ' ' );
 
 		return (
 			<SectionNav
 					hasPinnedItems={ viewport.isMobile() }
-					selectedText={ path }
+					selectedText={ sectionTitle }
 					onMobileNavPanelOpen={ this.onMobileNavPanelOpen }>
-				<NavTabs label="Section" selectedText={ path }>
+				<NavTabs label="Section" selectedText={ sectionTitle }>
 					{ ! isJetpack && hasPlan &&
 						<NavItem path={ `/plans/my-plan/${ site.slug }` } key="myPlan" selected={ path === '/plans/my-plan' }>
 							{ this.translate( 'My Plan' ) }

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -52,7 +52,7 @@ const PlansNavigation = React.createClass( {
 		const site = this.props.selectedSite;
 		const isJetpack = site && site.jetpack;
 		const path = sectionify( this.props.path );
-		const hasPlan = site && site.plan.product_slug !== 'free_plan';
+		const hasPlan = site && site.plan && site.plan.product_slug !== 'free_plan';
 
 		return (
 			<SectionNav


### PR DESCRIPTION
This PR cleans up the way we construct the plans section navigation, adds an item for "My Plan" if the site has a plan that is not the free one, and rewords the Jetpack item menu from the long "Add-ons for Jetpack sites" to just "Plans".

It also renders the navigation in the "My Plan" page:

![image](https://cloud.githubusercontent.com/assets/548849/16689067/75f1c0fc-4521-11e6-98e0-29f231b484da.png)

![image](https://cloud.githubusercontent.com/assets/548849/16689123/ae9269d4-4521-11e6-93b1-c1e67dc56680.png)


Test live: https://calypso.live/?branch=update/plans-navigations