### PR TITLE
Cart: fix border-radius bug by removing background color.

### DIFF
--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -19,7 +19,6 @@
 }
 
 .cart-body {
-	background: $white;
 	padding: 15px;
 
 	.cart-items {


### PR DESCRIPTION
This tiny thing has been bugging me for a bit. The border radius at the top of the cart popover is messed up by the containing element having a bg and no border-radius declared.

Before:
![image](https://cloud.githubusercontent.com/assets/548849/16689417/2fface98-4523-11e6-92c4-b8192f7c36f5.png)

After:
![image](https://cloud.githubusercontent.com/assets/548849/16689430/3c7fe4dc-4523-11e6-83d7-ff9e1e1949e2.png)


Test live: https://calypso.live/?branch=fix/cart-popover-bg