### PR TITLE
Purchases: Add query component for stored cards

### DIFF
--- a/client/components/data/query-stored-cards/README.md
+++ b/client/components/data/query-stored-cards/README.md
@@ -1,0 +1,9 @@
+Query Stored Cards
+==================
+
+`<QueryStoredCards />` is a React component used to fetch credit card details stored during previous purchases.
+
+## Usage
+
+You can use this query component adjacent to other sibling components which make use of the fetched data made available 
+through the global application state. It does not accept any children, nor does it render any elements to the page.

--- a/client/components/data/query-stored-cards/index.jsx
+++ b/client/components/data/query-stored-cards/index.jsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isFetchingStoredCards } from 'state/stored-cards/selectors';
+import { fetchStoredCards } from 'state/stored-cards/actions';
+
+class QueryStoredCards extends Component {
+	componentWillMount() {
+		this.requestStoredCards();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! nextProps.isRequesting ) {
+			this.requestStoredCards();
+		}
+	}
+
+	requestStoredCards() {
+		this.props.fetchStoredCards();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryStoredCards.propTypes = {
+	fetchStoredCards: PropTypes.func.isRequired,
+	isRequesting: PropTypes.bool.isRequired
+};
+
+export default connect(
+	state => {
+		return {
+			isRequesting: isFetchingStoredCards( state )
+		};
+	},
+	{ fetchStoredCards }
+)( QueryStoredCards );

--- a/client/components/data/query-stored-cards/index.jsx
+++ b/client/components/data/query-stored-cards/index.jsx
@@ -16,13 +16,13 @@ class QueryStoredCards extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.isRequesting ) {
-			this.requestStoredCards();
-		}
+		this.requestStoredCards( nextProps );
 	}
 
-	requestStoredCards() {
-		this.props.fetchStoredCards();
+	requestStoredCards( props = this.props ) {
+		if ( ! props.isRequesting ) {
+			props.fetchStoredCards();
+		}
 	}
 
 	render() {

--- a/client/state/stored-cards/selectors.js
+++ b/client/state/stored-cards/selectors.js
@@ -15,3 +15,5 @@ export const getCards = state => state.storedCards.items;
 export const getByCardId = ( state, cardId ) => (
 	getCards( state ).filter( card => card.stored_details_id === cardId ).shift()
 );
+
+export const isFetchingStoredCards = state => state.storedCards.isFetching;


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/6613 that introduces a [query component](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#query-components) that handles the fetching of credit cards stored during previous purchases. This is one of several pull requests to reduxify the Flux stores used in the [Purchases section](https://wordpress.com/purchases). 
 
#### Testing instructions
 
The code introduced in this pull request is not used anywhere but you may want to check that it doesn't break anything:

1. Run `git checkout add/stored-cards-query` and start your server, or open a [live branch](https://calypso.live/?branch=add/stored-cards-query)
2. Check that everything works as before
 
#### Additional notes
 
I've toyed with the idea of passing the user's purchase data as parameter of `QueryStoredCards`. The reason is that we may want to fetch the list of stored cards as soon as the list of purchases changes: there is indeed a chance that the user uses a new card when purchasing something. However I'm not that fond of introducing such dependency, and I'm not sure it's worth it considering the fact that currently we only display this list of cards on the [`Billing History` page](https://wordpress.com/me/billing). Any feedback is welcome.
 
#### Reviews
 
- [x] Code
- [x] Product
 
@Automattic/sdev-feed