### PR TITLE
Editor: Render post selector hierarchy from flattened posts array

### DIFF
--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -211,21 +211,25 @@ export function isSitePostsLastPageForQuery( state, siteId, query = {} ) {
  * @param  {Object}  query  Post query object
  * @return {?Array}         Posts for the post query
  */
-export function getSitePostsForQueryIgnoringPage( state, siteId, query ) {
-	const posts = state.posts.queries[ siteId ];
-	if ( ! posts ) {
-		return null;
-	}
+export const getSitePostsForQueryIgnoringPage = createSelector(
+	( state, siteId, query ) => {
+		const posts = state.posts.queries[ siteId ];
+		if ( ! posts ) {
+			return null;
+		}
 
-	const itemsIgnoringPage = posts.getItemsIgnoringPage( query );
-	if ( ! itemsIgnoringPage ) {
-		return null;
-	}
+		const itemsIgnoringPage = posts.getItemsIgnoringPage( query );
+		if ( ! itemsIgnoringPage ) {
+			return null;
+		}
 
-	return itemsIgnoringPage.map( ( post ) => {
-		return getNormalizedPost( state, post.global_ID );
-	} );
-}
+		return itemsIgnoringPage.map( ( post ) => {
+			return getNormalizedPost( state, post.global_ID );
+		} );
+	},
+	( state ) => [ state.posts.queries, state.posts.items ],
+	( state, siteId, query ) => getSerializedPostsQueryWithoutPage( query, siteId )
+);
 
 /**
  * Returns true if currently requesting posts for the posts query, regardless

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -16,7 +16,6 @@ import isEqual from 'lodash/isEqual';
 /**
  * Internal dependencies
  */
-import TreeConvert from 'lib/tree-convert';
 import {
 	getNormalizedPostsQuery,
 	getSerializedPostsQuery,
@@ -261,41 +260,6 @@ export const isRequestingSitePostsForQueryIgnoringPage = createSelector(
 	},
 	( state ) => state.posts.queryRequests,
 	( state, siteId, query ) => getSerializedPostsQuery( query, siteId )
-);
-
-/**
- * Returns an array of normalized posts for the posts query, including all
- * known queried pages, preserving hierarchy. Returns null if no posts have
- * been received. Hierarchy is represented by `parent` and `items` properties
- * on each post.
- *
- * @see getNormalizedPost
- *
- * @param  {Object} state  Global state tree
- * @param  {Number} siteId Site ID
- * @param  {Object} query  Post query object
- * @return {?Array}        Hierarchical posts for the post query
- */
-export const getSitePostsHierarchyForQueryIgnoringPage = createSelector(
-	( state, siteId, query ) => {
-		let sitePosts = getSitePostsForQueryIgnoringPage( state, siteId, query );
-		if ( ! sitePosts ) {
-			return sitePosts;
-		}
-
-		// For each site post object, add `parent` and `order` properties.
-		// These are used by the TreeConvert library to build the hierarchy.
-		const treeReadySitePosts = sitePosts.map( ( post, i ) => {
-			return Object.assign( {}, post, {
-				parent: post.parent ? post.parent.ID : 0,
-				order: i
-			} );
-		} );
-
-		return ( new TreeConvert( 'ID' ) ).treeify( treeReadySitePosts );
-	},
-	( state ) => [ state.posts.queries ],
-	( state, siteId, query ) => getSerializedPostsQueryWithoutPage( query, siteId )
 );
 
 /**

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -30,6 +30,7 @@ describe( 'selectors', () => {
 	beforeEach( () => {
 		getSitePosts.memoizedSelector.cache.clear();
 		getSitePost.memoizedSelector.cache.clear();
+		getSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
 		getSitePostsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
 		isRequestingSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
 		getNormalizedPost.memoizedSelector.cache.clear();

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -18,7 +18,6 @@ import {
 	getSitePostsLastPageForQuery,
 	isSitePostsLastPageForQuery,
 	getSitePostsForQueryIgnoringPage,
-	getSitePostsHierarchyForQueryIgnoringPage,
 	isRequestingSitePostsForQueryIgnoringPage,
 	isRequestingSitePost,
 	getEditedPost,
@@ -31,7 +30,6 @@ describe( 'selectors', () => {
 		getSitePosts.memoizedSelector.cache.clear();
 		getSitePost.memoizedSelector.cache.clear();
 		getSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
-		getSitePostsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
 		isRequestingSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
 		getNormalizedPost.memoizedSelector.cache.clear();
 	} );
@@ -595,88 +593,6 @@ describe( 'selectors', () => {
 			}, 2916284, { search: 'hel' } );
 
 			expect( isRequesting ).to.be.true;
-		} );
-	} );
-
-	describe( '#getSitePostsHierarchyForQueryIgnoringPage()', () => {
-		it( 'should return a concatenated array of all site posts ignoring page, preserving hierarchy', () => {
-			const sitePosts = getSitePostsHierarchyForQueryIgnoringPage( {
-				posts: {
-					items: {
-						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs &amp; Chicken' },
-						f0cb4eb16f493c19b627438fdc18d57c: { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak &amp; Eggs', parent: { ID: 413 } }
-					},
-					queries: {
-						2916284: new PostQueryManager( {
-							items: {
-								841: { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-								413: { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs &amp; Chicken' },
-								120: { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak &amp; Eggs', parent: { ID: 413 } }
-							},
-							queries: {
-								'[]': {
-									itemKeys: [ 841, 413, 120 ]
-								}
-							}
-						} )
-					}
-				}
-			}, 2916284, { search: '', number: 1 } );
-
-			expect( sitePosts ).to.eql( [
-				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World', parent: 0 },
-				{
-					ID: 413,
-					site_ID: 2916284,
-					global_ID: '6c831c187ffef321eb43a67761a525a3',
-					title: 'Ribs & Chicken',
-					parent: 0,
-					items: [
-						{ ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak & Eggs', parent: 413 }
-					]
-				}
-			] );
-		} );
-	} );
-
-	describe( '#isRequestingSitePost()', () => {
-		it( 'should return false if no request has been made', () => {
-			const isRequesting = isRequestingSitePost( {
-				posts: {
-					siteRequests: {}
-				}
-			}, 2916284, 841 );
-
-			expect( isRequesting ).to.be.false;
-		} );
-
-		it( 'should return true if a request is in progress', () => {
-			const isRequesting = isRequestingSitePost( {
-				posts: {
-					siteRequests: {
-						2916284: {
-							841: true
-						}
-					}
-				}
-			}, 2916284, 841 );
-
-			expect( isRequesting ).to.be.true;
-		} );
-
-		it( 'should return false if a request has finished', () => {
-			const isRequesting = isRequestingSitePost( {
-				posts: {
-					siteRequests: {
-						2916284: {
-							841: false
-						}
-					}
-				}
-			}, 2916284, 841 );
-
-			expect( isRequesting ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #6623 
Related: #6617 (alternate fix)
Related: #6495 (regression source)

This pull request seeks to resolve an issue where attempting to request posts via the rendered indices of the post selector can result in not all pages being shown as options, if few top-level pages exist on the site.

__Implementation notes:__

This approach moves away from using `getSitePostsHierarchyForQueryIgnoringPage` (in fact, the selector can be removed with these changes). Instead, the `<PostSelector />` component receives the original flattened posts array and tricks `<VirtualScroll />` into thinking that rows are rendered corresponding to the length of the flattened post. Hierarchy is reflected by not allowing the child posts to render (and have a 0 height) unless rendered in the context of the parent's recursive child rendering.

Included is some additional memoization and caching to minimize the effect of repeated lookups on posts, but this may be a bit excessive and hard to maintain ([related anti-pattern](https://facebook.github.io/react/tips/props-in-getInitialState-as-anti-pattern.html)).

__Testing instructions:__

Set up your site and repeat the steps to reproduce as described in #6623, verifying that all pages can be loaded in the Parent Page selector.

Test live: https://calypso.live/?branch=fix/6623-editor-hierarchy-loading