### PR TITLE
Jetpack Plans: Update how VaultPress' registration option is set to account for errors

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -266,7 +266,7 @@ const PlansSetup = React.createClass( {
 					statusProps.text = this.translate( 'An error occured when configuring %(plugin)s.', { args: { plugin: plugin.name } } );
 					break;
 				default:
-					statusProps.text = this.translate( 'An error occured.' );
+					statusProps.text = plugin.error.message || this.translate( 'An error occured.' );
 					break;
 			}
 			statusProps.children = (

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -8,6 +8,7 @@ import keys from 'lodash/keys';
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
+import versionCompare from 'lib/version-compare';
 import {
 	PLUGIN_SETUP_INSTRUCTIONS_FETCH,
 	PLUGIN_SETUP_INSTRUCTIONS_RECEIVE,
@@ -201,14 +202,15 @@ function configure( site, plugin, dispatch ) {
 		return;
 	}
 	let optionValue = plugin.key;
-	if ( ( 'vaultpress' === plugin.slug ) ) {
+	// VP 1.8.4+ expects a different format for this option.
+	if ( ( 'vaultpress' === plugin.slug ) && versionCompare( plugin.version, '1.8.3', '>' ) ) {
 		optionValue = JSON.stringify( {
 			key: plugin.key,
 			action: 'register',
 		} );
 	}
 	site.setOption( { option_name: option, option_value: optionValue }, ( error, data ) => {
-		if ( ( 'vaultpress' === plugin.slug ) ) {
+		if ( ( 'vaultpress' === plugin.slug ) && versionCompare( plugin.version, '1.8.3', '>' ) ) {
 			const response = JSON.parse( data.option_value );
 			if ( 'response' === response.action && 'broken' === response.status ) {
 				error = new Error( response.error );

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -26,7 +26,7 @@ const _fetching = {};
 const normalizePluginInstructions = ( data ) => {
 	const _plugins = data.keys;
 	return keys( _plugins ).map( ( slug ) => {
-		const apiKey = _plugins[slug];
+		const apiKey = _plugins[ slug ];
 		return {
 			slug: slug,
 			name: slug,
@@ -190,7 +190,7 @@ function configure( site, plugin, dispatch ) {
 			break;
 	}
 	if ( ! option || ! plugin.key ) {
-		let optionError = new Error( 'We can\'t configure this plugin.' );
+		const optionError = new Error( 'We can\'t configure this plugin.' );
 		optionError.name = 'ConfigError';
 		dispatch( {
 			type: PLUGIN_SETUP_ERROR,
@@ -200,7 +200,21 @@ function configure( site, plugin, dispatch ) {
 		} );
 		return;
 	}
-	site.setOption( { option_name: option, option_value: plugin.key }, ( error ) => {
+	let optionValue = plugin.key;
+	if ( ( 'vaultpress' === plugin.slug ) ) {
+		optionValue = JSON.stringify( {
+			key: plugin.key,
+			action: 'register',
+		} );
+	}
+	site.setOption( { option_name: option, option_value: optionValue }, ( error, data ) => {
+		if ( ( 'vaultpress' === plugin.slug ) ) {
+			const response = JSON.parse( data.option_value );
+			if ( 'response' === response.action && 'broken' === response.status ) {
+				error = new Error( response.error );
+				error.name = 'RegisterError';
+			}
+		}
 		if ( error ) {
 			dispatch( {
 				type: PLUGIN_SETUP_ERROR,


### PR DESCRIPTION
VaultPress can encounter errors when verifying a key & registering a site, and we need to capture that in the auto-config process. We've updated the option used in the VaultPress plugin to also contain status information & error messages, and it should be released as 1.8.4. The auto-config process needs to update to handle the new option format.

To test a previously registered site:

1. Install the VaultPress plugin from trunk. Using wp-cli: `wp plugin install vaultpress --version=dev`
2. Update the version number in `vaultpress.php` to 1.8.4.
3. Buy a vaultpress-only plan, and add the registration key to the site (via wp-admin).
4. Unregister the site. Using wp-cli: `wp option delete vaultpress`
5. Buy a WP.com plan & run through the install process.
6. You should see an error, whereas before it would claim success.

(You can skip step 3 if you already have a VP site)

To test a currently registered site:

1. Install the VaultPress plugin from trunk. Using wp-cli: `wp plugin install vaultpress --version=dev`
2. Update the version number in `vaultpress.php` to 1.8.4.
3. Buy a vaultpress-only plan, and add the registration key to the site (via wp-admin).
4. Buy a WP.com plan & run through the install process.
5. You should get a success message, but the site is technically still using the old key.

To test a totally new site:

1. Install the VaultPress plugin from trunk. Using wp-cli: `wp plugin install vaultpress --version=dev`
2. Update the version number in `vaultpress.php` to 1.8.4.
3. Buy a WP.com plan & run through the install process.
5. You should get a success message, and the site is using the new key.

CC @johnHackworth (and @thingalon, if you're interested in testing the calypso side :) )

Test live: https://calypso.live/?branch=fix/vaultpress-autoconfig