### PR TITLE
Jetpack Sync: Add selectors for pending sync, progress percentage, and is syncing

### DIFF
--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -23,7 +23,41 @@ function getFullSyncRequest( state, siteId ) {
 	return get( state, [ 'jetpackSync', 'fullSyncRequest', siteId ] );
 }
 
+/**
+ * Returns a boolean for whether a full sync is pending start.
+ * @param  {Object} state    Global state tree
+ * @param  {Number} siteId   Site ID
+ * @return {Boolean}         Whether a sync is pending start for site
+ */
+function isPendingSyncStart( state, siteId ) {
+	const syncStatus = getSyncStatus( state, siteId );
+	const fullSyncRequest = getFullSyncRequest( state, siteId );
+
+	// Is the sync scheduled and awaiting cron?
+	const isScheduled = get( syncStatus, 'is_scheduled' );
+	if ( isScheduled ) {
+		return true;
+	}
+
+	// Have we requested a full sync from Calypso?
+	const requestingFullSync = get( fullSyncRequest, 'isRequesting' ) || get( fullSyncRequest, 'scheduled' );
+	if ( ! requestingFullSync ) {
+		return false;
+	}
+
+	// If we have requested a full sync, is that request newer than the last time we received sync status?
+	const lastRequested = get( fullSyncRequest, 'lastRequested' );
+	const lastSuccessfulStatus = get( syncStatus, 'lastSuccessfulStatus' );
+
+	if ( ! lastSuccessfulStatus ) {
+		return true;
+	}
+
+	return parseInt( lastRequested, 10 ) > parseInt( lastSuccessfulStatus, 10 );
+}
+
 export default {
 	getSyncStatus,
-	getFullSyncRequest
+	getFullSyncRequest,
+	isPendingSyncStart
 };

--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, reduce } from 'lodash';
 
 /**
  * Returns a sync status object by site ID.
@@ -74,9 +74,36 @@ function isFullSyncing( state, siteId ) {
 	return isStarted && ! isFinished;
 }
 
+/**
+ * Returns a rounded up percentage the amount of sync completed.
+ * @param  {Object} state    Global state tree
+ * @param  {Number} siteId   Site ID
+ * @return {Number}          The percentage of sync completed, expressed as an integer
+ */
+function getSyncProgressPercentage( state, siteId ) {
+	const syncStatus = getSyncStatus( state, siteId );
+	const queued = get( syncStatus, 'queue' );
+	const sent = get( syncStatus, 'sent' );
+
+	if ( isPendingSyncStart( state, siteId ) || ! queued || ! sent ) {
+		return 0;
+	}
+
+	const countQueued = reduce( queued, ( sum, value ) => {
+		return sum += value;
+	}, 0 );
+
+	const countSent = reduce( sent, ( sum, value ) => {
+		return sum += value;
+	}, 0 );
+
+	return Math.ceil( countSent / countQueued * 100 );
+}
+
 export default {
 	getSyncStatus,
 	getFullSyncRequest,
 	isPendingSyncStart,
-	isFullSyncing
+	isFullSyncing,
+	getSyncProgressPercentage
 };

--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * Returns a sync status object by site ID.
  * @param  {Object} state    Global state tree
- * @param  {Number} siteId   Post global ID
+ * @param  {Number} siteId   Site ID
  * @return {Object}          Sync status object
  */
 function getSyncStatus( state, siteId ) {
@@ -16,7 +16,7 @@ function getSyncStatus( state, siteId ) {
 /**
  * Returns a full sync request object by site ID.
  * @param  {Object} state    Global state tree
- * @param  {Number} siteId   Post global ID
+ * @param  {Number} siteId   Site ID
  * @return {Object}          Full sync request object
  */
 function getFullSyncRequest( state, siteId ) {

--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -56,8 +56,27 @@ function isPendingSyncStart( state, siteId ) {
 	return parseInt( lastRequested, 10 ) > parseInt( lastSuccessfulStatus, 10 );
 }
 
+/**
+ * Returns a boolean for whether a site is in the process of a full sync.
+ * @param  {Object} state    Global state tree
+ * @param  {Number} siteId   Site ID
+ * @return {Boolean}         Whether a sync is in the process of syncing
+ */
+function isFullSyncing( state, siteId ) {
+	const syncStatus = getSyncStatus( state, siteId );
+	if ( ! syncStatus ) {
+		return false;
+	}
+
+	const isStarted = get( syncStatus, 'started' );
+	const isFinished = get( syncStatus, 'finished' );
+
+	return isStarted && ! isFinished;
+}
+
 export default {
 	getSyncStatus,
 	getFullSyncRequest,
-	isPendingSyncStart
+	isPendingSyncStart,
+	isFullSyncing
 };

--- a/client/state/jetpack-sync/test/selectors.js
+++ b/client/state/jetpack-sync/test/selectors.js
@@ -9,7 +9,8 @@ import { expect } from 'chai';
 import {
 	getSyncStatus,
 	getFullSyncRequest,
-	isPendingSyncStart
+	isPendingSyncStart,
+	isFullSyncing
 } from '../selectors';
 
 const nonExistentId = '111111';
@@ -18,6 +19,7 @@ const successfulSiteId = '1234567';
 const errorSiteId = '12345678';
 const syncScheduledSiteID = '123455';
 const oldSyncSiteId = '987654321';
+const inProgressSiteId = '87654321';
 
 const syncStatusSuccessful = {
 	isRequesting: false,
@@ -90,6 +92,24 @@ const syncStatusErrored = {
 	}
 };
 
+const syncStatusInProgress = {
+	started: 1467998622,
+	queue_finished: 1467998622,
+	queue: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 1,
+		themes: 1,
+		users: 1,
+		posts: 102,
+		comments: 1,
+		updates: 1
+	},
+	sent: [],
+	is_scheduled: false
+};
+
 const fullSyncRequested = {
 	isRequesting: true,
 	lastRequested: 1467944517955
@@ -124,7 +144,8 @@ const testState = {
 			[ successfulSiteId ]: syncStatusSuccessful,
 			[ errorSiteId ]: syncStatusErrored,
 			[ syncScheduledSiteID ]: syncStatusScheduled,
-			[ oldSyncSiteId ]: syncStatusSuccessful
+			[ oldSyncSiteId ]: syncStatusSuccessful,
+			[ inProgressSiteId ]: syncStatusInProgress
 		},
 		fullSyncRequest: {
 			[ requestedSiteId ]: fullSyncRequested,
@@ -189,6 +210,28 @@ describe( 'selectors', () => {
 		it( 'should be false if a sync has been requested, but sync has already finished', () => {
 			const test = isPendingSyncStart( testState, oldSyncSiteId );
 			expect( test ).to.be.false;
+		} );
+	} );
+
+	describe( '#isFullSyncing()', () => {
+		it( 'should return false if no sync status for a site', () => {
+			const test = isFullSyncing( testState, nonExistentId );
+			expect( test ).to.be.false;
+		} );
+
+		it( 'should return false if syncing is has finished', () => {
+			const test = isFullSyncing( testState, successfulSiteId );
+			expect( test ).to.be.false;
+		} );
+
+		it( 'should return false if syncing is scheduled but not started', () => {
+			const test = isFullSyncing( testState, syncScheduledSiteID );
+			expect( test ).to.be.false;
+		} );
+
+		it( 'should return true if sync has started and not finished', () => {
+			const test = isFullSyncing( testState, inProgressSiteId );
+			expect( test ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/jetpack-sync/test/selectors.js
+++ b/client/state/jetpack-sync/test/selectors.js
@@ -8,13 +8,16 @@ import { expect } from 'chai';
  */
 import {
 	getSyncStatus,
-	getFullSyncRequest
+	getFullSyncRequest,
+	isPendingSyncStart
 } from '../selectors';
 
 const nonExistentId = '111111';
 const requestedSiteId = '123456';
 const successfulSiteId = '1234567';
 const errorSiteId = '12345678';
+const syncScheduledSiteID = '123455';
+const oldSyncSiteId = '987654321';
 
 const syncStatusSuccessful = {
 	isRequesting: false,
@@ -48,6 +51,38 @@ const syncStatusSuccessful = {
 	is_scheduled: false
 };
 
+const syncStatusScheduled = {
+	isRequesting: false,
+	error: false,
+	lastSuccessfulStatus: 1467926563436,
+	started: 1466010260,
+	queue_finished: 1466010260,
+	sent_started: 1466010290,
+	finished: 1466010313,
+	queue: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 3,
+		themes: 1,
+		users: 2,
+		posts: 15,
+		comments: 1,
+		updates: 6
+	},
+	sent: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 3,
+		themes: 1,
+		users: 2,
+		posts: 15,
+		comments: 1
+	},
+	is_scheduled: true
+};
+
 const syncStatusErrored = {
 	isRequesting: false,
 	error: {
@@ -67,6 +102,13 @@ const fullSyncRequestSuccessful = {
 	lastRequested: 1467944517955
 };
 
+const fullSyncRequestOld = {
+	isRequesting: true,
+	scheduled: true,
+	error: false,
+	lastRequested: 1467926563435
+};
+
 const fullSyncRequestErrored = {
 	isRequesting: false,
 	scheduled: false,
@@ -80,12 +122,15 @@ const testState = {
 	jetpackSync: {
 		syncStatus: {
 			[ successfulSiteId ]: syncStatusSuccessful,
-			[ errorSiteId ]: syncStatusErrored
+			[ errorSiteId ]: syncStatusErrored,
+			[ syncScheduledSiteID ]: syncStatusScheduled,
+			[ oldSyncSiteId ]: syncStatusSuccessful
 		},
 		fullSyncRequest: {
 			[ requestedSiteId ]: fullSyncRequested,
 			[ successfulSiteId ]: fullSyncRequestSuccessful,
-			[ errorSiteId ]: fullSyncRequestErrored
+			[ errorSiteId ]: fullSyncRequestErrored,
+			[ oldSyncSiteId ]: fullSyncRequestOld
 		}
 	}
 };
@@ -122,6 +167,28 @@ describe( 'selectors', () => {
 		it( 'should return full sync status for a site if in state', () => {
 			const fullSyncRequest = getFullSyncRequest( testState, successfulSiteId );
 			expect( fullSyncRequest ).to.be.eql( testState.jetpackSync.fullSyncRequest[ successfulSiteId ] );
+		} );
+	} );
+
+	describe( '#isPendingSyncStart()', () => {
+		it( 'should return true if a sync is scheduled', () => {
+			const test = isPendingSyncStart( testState, syncScheduledSiteID );
+			expect( test ).to.be.true;
+		} );
+
+		it( 'should return false if sync status and full sync request show not scheduled', () => {
+			const test = isPendingSyncStart( testState, errorSiteId );
+			expect( test ).to.be.false;
+		} );
+
+		it( 'should return true if a sync has been requested, but before sync status has updated', () => {
+			const test = isPendingSyncStart( testState, successfulSiteId );
+			expect( test ).to.be.true;
+		} );
+
+		it( 'should be false if a sync has been requested, but sync has already finished', () => {
+			const test = isPendingSyncStart( testState, oldSyncSiteId );
+			expect( test ).to.be.false;
 		} );
 	} );
 } );

--- a/client/state/jetpack-sync/test/selectors.js
+++ b/client/state/jetpack-sync/test/selectors.js
@@ -10,7 +10,8 @@ import {
 	getSyncStatus,
 	getFullSyncRequest,
 	isPendingSyncStart,
-	isFullSyncing
+	isFullSyncing,
+	getSyncProgressPercentage
 } from '../selectors';
 
 const nonExistentId = '111111';
@@ -19,7 +20,8 @@ const successfulSiteId = '1234567';
 const errorSiteId = '12345678';
 const syncScheduledSiteID = '123455';
 const oldSyncSiteId = '987654321';
-const inProgressSiteId = '87654321';
+const syncStartedSiteId = '87654321';
+const syncInProgressSiteId = '7654321';
 
 const syncStatusSuccessful = {
 	isRequesting: false,
@@ -92,7 +94,7 @@ const syncStatusErrored = {
 	}
 };
 
-const syncStatusInProgress = {
+const syncStatusStarted = {
 	started: 1467998622,
 	queue_finished: 1467998622,
 	queue: {
@@ -108,6 +110,33 @@ const syncStatusInProgress = {
 	},
 	sent: [],
 	is_scheduled: false
+};
+
+const syncStatusInProgress = {
+	started: 1467998622,
+	queue_finished: 1467998622,
+	sent_started: 1467999200,
+	queue: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 1,
+		themes: 1,
+		users: 1,
+		posts: 102,
+		comments: 1,
+		updates: 1
+	},
+	sent: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 1,
+		themes: 1,
+		users: 1,
+		posts: 25
+	},
+	is_scheduled: false,
 };
 
 const fullSyncRequested = {
@@ -145,7 +174,8 @@ const testState = {
 			[ errorSiteId ]: syncStatusErrored,
 			[ syncScheduledSiteID ]: syncStatusScheduled,
 			[ oldSyncSiteId ]: syncStatusSuccessful,
-			[ inProgressSiteId ]: syncStatusInProgress
+			[ syncStartedSiteId ]: syncStatusStarted,
+			[ syncInProgressSiteId ]: syncStatusInProgress
 		},
 		fullSyncRequest: {
 			[ requestedSiteId ]: fullSyncRequested,
@@ -230,8 +260,20 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return true if sync has started and not finished', () => {
-			const test = isFullSyncing( testState, inProgressSiteId );
+			const test = isFullSyncing( testState, syncStartedSiteId );
 			expect( test ).to.be.true;
+		} );
+	} );
+
+	describe( '#getSyncProgressPercentage()', () => {
+		it( 'should return 0 if no sync status for a site', () => {
+			const test = getSyncProgressPercentage( testState, nonExistentId );
+			expect( test ).to.be.eql( 0 );
+		} );
+
+		it( 'should return a non-zero integer if site has sent data to be synced', () => {
+			const test = getSyncProgressPercentage( testState, syncInProgressSiteId );
+			expect( test ).to.be.eql( 29 )
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a few more selectors for Jetpack Sync after #6611 and is a continuation of factoring #6044 into smaller PRs.

To test:

- Checkout `update/jetpack-sync-selectors` branch
- Run tests: `npm run test-client -- --grep "state jetpack-sync"`

Test live: https://calypso.live/?branch=update/jetpack-sync-selectors