### PR TITLE
Framework: Update/abtest to filter non english

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -136,7 +136,8 @@ ABTest.prototype.getVariation = function() {
 ABTest.prototype.isEligibleForAbTest = function() {
 	const selectedSite = sites.getSelectedSite();
 	const client = ( typeof navigator !== 'undefined' ) ? navigator : {};
-	const clientLanguage = client.language || client.userLanguage || 'en';
+	const clientLocale = client.language || client.userLanguage || 'en';
+	const localeFromSession = i18n.getLocaleSlug() || 'en';
 
 	if ( ! store.enabled ) {
 		debug( '%s: Local storage is not enabled', this.experimentId );
@@ -148,8 +149,12 @@ ABTest.prototype.isEligibleForAbTest = function() {
 			debug( '%s: User has a non-English locale', this.experimentId );
 			return false;
 		}
-		if ( ! isUserSignedIn() && ! clientLanguage.match( /^en\-?/i ) ) {
+		if ( ! isUserSignedIn() && ! clientLocale.match( /^en\-?/i ) ) {
 			debug( '%s: Logged-out user has a non-English browser locale', this.experimentId );
+			return false;
+		}
+		if ( ! isUserSignedIn() && ! localeFromSession.match( /^en\-?/i ) ) {
+			debug( '%s: Logged-out user has a non-English locale in session', this.experimentId );
 			return false;
 		}
 	}

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -8,7 +8,7 @@ import store from 'store';
 /**
  * Internal dependencies
  */
-import activeTests from './active-tests';
+import activeTests from 'lib/abtest/active-tests';
 import analytics from 'lib/analytics';
 import i18n from 'i18n-calypso';
 import userFactory from 'lib/user';
@@ -137,6 +137,7 @@ ABTest.prototype.isEligibleForAbTest = function() {
 	const selectedSite = sites.getSelectedSite();
 	const client = ( typeof navigator !== 'undefined' ) ? navigator : {};
 	const clientLocale = client.language || client.userLanguage || 'en';
+	const browserLocale = ( client.languages && client.languages.length ) ? client.languages[ 0 ] : 'en';
 	const localeFromSession = i18n.getLocaleSlug() || 'en';
 
 	if ( ! store.enabled ) {
@@ -150,6 +151,10 @@ ABTest.prototype.isEligibleForAbTest = function() {
 			return false;
 		}
 		if ( ! isUserSignedIn() && ! clientLocale.match( /^en\-?/i ) ) {
+			debug( '%s: Logged-out user has a non-English OS locale', this.experimentId );
+			return false;
+		}
+		if ( ! isUserSignedIn() && ! browserLocale.match( /^en\-?/i ) ) {
 			debug( '%s: Logged-out user has a non-English browser locale', this.experimentId );
 			return false;
 		}

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -139,6 +139,7 @@ ABTest.prototype.isEligibleForAbTest = function() {
 	const clientLocale = client.language || client.userLanguage || 'en';
 	const browserLocale = ( client.languages && client.languages.length ) ? client.languages[ 0 ] : 'en';
 	const localeFromSession = i18n.getLocaleSlug() || 'en';
+	const englishMatcher = /^en-?/i;
 
 	if ( ! store.enabled ) {
 		debug( '%s: Local storage is not enabled', this.experimentId );
@@ -150,15 +151,15 @@ ABTest.prototype.isEligibleForAbTest = function() {
 			debug( '%s: User has a non-English locale', this.experimentId );
 			return false;
 		}
-		if ( ! isUserSignedIn() && ! clientLocale.match( /^en\-?/i ) ) {
+		if ( ! isUserSignedIn() && ! clientLocale.match( englishMatcher ) ) {
 			debug( '%s: Logged-out user has a non-English OS locale', this.experimentId );
 			return false;
 		}
-		if ( ! isUserSignedIn() && ! browserLocale.match( /^en\-?/i ) ) {
+		if ( ! isUserSignedIn() && ! browserLocale.match( englishMatcher ) ) {
 			debug( '%s: Logged-out user has a non-English browser locale', this.experimentId );
 			return false;
 		}
-		if ( ! isUserSignedIn() && ! localeFromSession.match( /^en\-?/i ) ) {
+		if ( ! isUserSignedIn() && ! localeFromSession.match( englishMatcher ) ) {
 			debug( '%s: Logged-out user has a non-English locale in session', this.experimentId );
 			return false;
 		}

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -4,13 +4,13 @@
 import debugFactory from 'debug';
 import { includes, keys, reduce, some } from 'lodash';
 import store from 'store';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import activeTests from 'lib/abtest/active-tests';
 import analytics from 'lib/analytics';
-import i18n from 'i18n-calypso';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 import sitesList from 'lib/sites-list';

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -136,8 +136,8 @@ ABTest.prototype.getVariation = function() {
 ABTest.prototype.isEligibleForAbTest = function() {
 	const selectedSite = sites.getSelectedSite();
 	const client = ( typeof navigator !== 'undefined' ) ? navigator : {};
-	const clientLocale = client.language || client.userLanguage || 'en';
-	const browserLocale = ( client.languages && client.languages.length ) ? client.languages[ 0 ] : 'en';
+	const clientLanguage = client.language || client.userLanguage || 'en';
+	const clientLanguagesPrimary = ( client.languages && client.languages.length ) ? client.languages[ 0 ] : 'en';
 	const localeFromSession = i18n.getLocaleSlug() || 'en';
 	const englishMatcher = /^en-?/i;
 
@@ -151,12 +151,12 @@ ABTest.prototype.isEligibleForAbTest = function() {
 			debug( '%s: User has a non-English locale', this.experimentId );
 			return false;
 		}
-		if ( ! isUserSignedIn() && ! clientLocale.match( englishMatcher ) ) {
-			debug( '%s: Logged-out user has a non-English OS locale', this.experimentId );
+		if ( ! isUserSignedIn() && ! clientLanguage.match( englishMatcher ) ) {
+			debug( '%s: Logged-out user has a non-English navigator.language preference', this.experimentId );
 			return false;
 		}
-		if ( ! isUserSignedIn() && ! browserLocale.match( englishMatcher ) ) {
-			debug( '%s: Logged-out user has a non-English browser locale', this.experimentId );
+		if ( ! isUserSignedIn() && ! clientLanguagesPrimary.match( englishMatcher ) ) {
+			debug( '%s: Logged-out user has a non-English navigator.languages primary preference', this.experimentId );
 			return false;
 		}
 		if ( ! isUserSignedIn() && ! localeFromSession.match( englishMatcher ) ) {

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -134,17 +134,24 @@ ABTest.prototype.getVariation = function() {
 };
 
 ABTest.prototype.isEligibleForAbTest = function() {
-	var selectedSite = sites.getSelectedSite();
+	const selectedSite = sites.getSelectedSite();
+	const client = ( typeof navigator !== 'undefined' ) ? navigator : {};
+	const clientLanguage = client.language || client.userLanguage || 'en';
 
 	if ( ! store.enabled ) {
 		debug( '%s: Local storage is not enabled', this.experimentId );
 		return false;
 	}
 
-	if ( ! this.allowAnyLocale && isUserSignedIn() &&
-			user.get().localeSlug !== 'en' ) {
-		debug( '%s: User has a non-English locale', this.experimentId );
-		return false;
+	if ( ! this.allowAnyLocale ) {
+		if ( isUserSignedIn() && user.get().localeSlug !== 'en' ) {
+			debug( '%s: User has a non-English locale', this.experimentId );
+			return false;
+		}
+		if ( ! isUserSignedIn() && ! clientLanguage.match( /^en\-?/i ) ) {
+			debug( '%s: Logged-out user has a non-English browser locale', this.experimentId );
+			return false;
+		}
 	}
 
 	if ( this.excludeJetpackSites && selectedSite && selectedSite.jetpack ) {

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -143,12 +143,12 @@ describe( 'abtest', () => {
 				abtest( 'mockedTest' );
 				expect( setSpy ).to.have.been.calledOnce;
 			} );
-			it( 'show return default and skip store.set for non-English OS setting', () => {
+			it( 'show return default and skip store.set for non-English navigator.language', () => {
 				navigator.language = 'de';
 				expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );
 				expect( setSpy ).not.to.have.been.called;
 			} );
-			it( 'should return default and skip store.set for non-English browser setting', () => {
+			it( 'should return default and skip store.set for non-English navigator.languages primary preference', () => {
 				navigator.languages = [ 'de' ];
 				expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );
 				expect( setSpy ).not.to.have.been.called;

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -1,0 +1,165 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import mockery from 'mockery';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+
+const DATE_BEFORE = '2015-06-30T01:32:21.196Z';
+const DATE_AFTER = '2016-06-30T01:32:21.196Z';
+
+describe( 'abtest', () => {
+	let abtest;
+	let mockedUser = {};
+	let ABTests;
+	const setSpy = sinon.spy( () => {} );
+
+	useFakeDom();
+	useMockery( () => {
+		require( 'lib/local-storage' )( global );
+		mockery.registerMock( 'lib/abtest/active-tests', {
+			mockedTest: {
+				datestamp: '20160627',
+				variations: {
+					hide: 50,
+					show: 50
+				},
+				defaultVariation: 'hide',
+				allowExistingUsers: false
+			},
+			mockedTestAllowExisting: {
+				datestamp: '20160627',
+				variations: {
+					hide: 50,
+					show: 50
+				},
+				defaultVariation: 'hide',
+				allowExistingUsers: true
+			},
+		} );
+		mockery.registerMock( 'store', {
+			enabled: () => true,
+			get: () => {
+				return ABTests;
+			},
+			set: setSpy,
+		} );
+		mockery.registerMock( 'lib/user', () => {
+			return {
+				get: () => mockedUser
+			};
+		} );
+		abtest = require( 'lib/abtest' ).abtest;
+	} );
+
+	describe( 'stored value', () => {
+		beforeEach( () => {
+			ABTests = { mockedTest_20160627: 'show' };
+			setSpy.reset();
+		} );
+		it( 'should return stored value and skip store.set for existing users', () => {
+			mockedUser = {
+				localeSlug: 'en',
+				date: DATE_BEFORE
+			};
+			navigator = {
+				language: 'en',
+				languages: [ 'en' ]
+			};
+			expect( abtest( 'mockedTest' ) ).to.equal( 'show' );
+			expect( setSpy ).not.to.have.been.called;
+		} );
+		it( 'should return stored value and skip store.set for any user, including new, non-English users', () => {
+			mockedUser = {
+				localeSlug: 'de',
+				date: DATE_AFTER
+			};
+			expect( abtest( 'mockedTest' ) ).to.equal( 'show' );
+			expect( setSpy ).not.to.have.been.called;
+		} );
+		it( 'should return stored value and skip store.set for a logged-out user', () => {
+			mockedUser = null;
+			expect( abtest( 'mockedTest' ) ).to.equal( 'show' );
+			expect( setSpy ).not.to.have.been.called;
+		} );
+	} );
+
+	describe( 'no stored value', () => {
+		beforeEach( () => {
+			ABTests = {};
+			setSpy.reset();
+		} );
+		describe( 'existing users', () => {
+			beforeEach( () => {
+				mockedUser = {
+					localeSlug: 'en',
+					date: DATE_BEFORE
+				};
+			} );
+			it( 'should return default and skip store.set when allowExistingUsers is false', () => {
+				expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );
+				expect( setSpy ).not.to.have.been.called;
+			} );
+			it( 'should call store.set when allowExistingUsers is true', () => {
+				abtest( 'mockedTestAllowExisting' );
+				expect( setSpy ).to.have.been.calledOnce;
+			} );
+		} );
+
+		describe( 'new users', () => {
+			beforeEach( () => {
+				mockedUser = {
+					localeSlug: 'en',
+					date: DATE_AFTER
+				};
+			} );
+			it( 'should call store.set for new users with English settings', () => {
+				abtest( 'mockedTest' );
+				expect( setSpy ).to.have.been.calledOnce;
+			} );
+			it( 'should return default and skip store.set for new users with non-English settings', () => {
+				mockedUser.localeSlug = 'de';
+				expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );
+				expect( setSpy ).not.to.have.been.called;
+			} );
+		} );
+
+		describe( 'logged-out users', () => {
+			beforeEach( () => {
+				mockedUser = false;
+				setSpy.reset();
+				navigator = {
+					language: 'en',
+					languages: [ 'en' ]
+				};
+			} );
+			it( 'should call store.set for logged-out users with English locale', () => {
+				abtest( 'mockedTest' );
+				expect( setSpy ).to.have.been.calledOnce;
+			} );
+			it( 'show return default and skip store.set for non-English OS setting', () => {
+				navigator.language = 'de';
+				expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );
+				expect( setSpy ).not.to.have.been.called;
+			} );
+			it( 'should return default and skip store.set for non-English browser setting', () => {
+				navigator.languages = [ 'de' ];
+				expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );
+				expect( setSpy ).not.to.have.been.called;
+			} );
+			it( 'should return default and skip store.set for non-English IE10 userLanguage setting', () => {
+				navigator = {
+					userLanguage: 'de'
+				};
+				expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );
+				expect( setSpy ).not.to.have.been.called;
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
We discovered that we are unintentionally including non-English users in our abtests when they are logged-out, which is the primary case for our NUX. This is an issue because most experiments will not have had the time for any new strings to be translated, which means users in other languages are getting partially translated pages, and that's going to hurt their experience and also hurt the performance of the test variant.

So this PR adds two checks for non-english locales. The first check is against `navigator.language`, which is the first preference in `navigator.languages` in all modern browsers except IE10. I'm using `navigator.userLanguage` as the fallback for IE10.

I am also adding a check against `i18nUtils.getLocaleSlug()`, which can be different from `navigator.language` if the user has gone to a page with a language in the url (e.g., https://wordpress.com/start/survey/es). This can happen with a direct link or if the user has accepted a language suggestion from the `locale-suggestions` component.

Last, there's quite a bit more changes in this PR because I addressed all linting issues and es6-ified the `abtest` module. You can view the individual commits to see these changes separately.

## Testing
First, you can run the tests in this branch and read through them to see what's been added.

```bsh
npm run test-client client/lib/abtest/test/index.js
```

### English Case -- Make Sure It Still Works
Open an incognito browser, set the debug string to `calypso:analytics`, open your inspector console and filter for `calypso_abtest_start" called` and go through the nux flow at `http://calypso.localhost:3000/start`. You should see several events get triggered as you go through the process.

![screen shot 2016-07-08 at 12 34 44 pm](https://cloud.githubusercontent.com/assets/134044/16696014/7c5a0bde-4508-11e6-8f14-710366927f24.png)

### Non-English as Primary Browser Language
Now go into your chrome preferences (use whatever browser you want, but these instructions are for chrome) and click "show advanced settings" on the bottom.

![screen shot 2016-07-08 at 10 03 28 am](https://cloud.githubusercontent.com/assets/134044/16696098/e6a081e4-4508-11e6-962e-88f60ebc028a.png)

Now go to Languages

![screen shot 2016-07-08 at 10 03 41 am](https://cloud.githubusercontent.com/assets/134044/16696106/f1eb30f8-4508-11e6-9b9e-95ce930ce30e.png)

And add a non-English language and drag it to the top.

![screen shot 2016-07-08 at 10 04 05 am](https://cloud.githubusercontent.com/assets/134044/16696121/053d8a5c-4509-11e6-8edc-1809cccad71d.png)

Close your incognito window and open a new one to clear out cookies and localStorage. Then load up http://calypso.localhost:3000. Clear your localStorage again via console. And now set the debug listener string to `calypso:analytics,calypso:abtests`.

Now if you go through the NUX you should no longer see the calypso_abtest_event firing.

### Non-English as OS Language
This one's a little tricker, but you can trigger this case by changing your entire OS language, which will require a restart.

### Non-English as Accepted Suggestion
Change your OS language back, and then go back into your browser preferences and set a non-English language as one of your preferences, but leave English as the _top_ preference. Now when you go through the NUX flow, you should get a suggestion to view the NUX in that language. Accept the suggestion and go through the NUX with the new language. You may have seen some `calypso_abtest_start` events prior to accepting the language change, but you should no longer see those events after switching languages.

/cc @coreh @michaeldcain @meremagee @gwwar @mtias @blowery 

Test live: https://calypso.live/?branch=update/abtest-filter-non-english