### PR TITLE
Jetpack Connect: isCalypsoStartedConnection

### DIFF
--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -10,7 +10,7 @@ import React from 'react';
  */
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
-import { isCalypsoStartedConnection, getFlowType } from 'state/jetpack-connect/selectors';
+import { getFlowType } from 'state/jetpack-connect/selectors';
 import Main from 'components/main';
 import ConnectHeader from './connect-header';
 import observe from 'lib/mixins/data-observe';
@@ -93,13 +93,9 @@ const Plans = React.createClass( {
 	},
 
 	selectFreeJetpackPlan() {
-		const selectedSite = this.props.sites.getSelectedSite();
 		this.props.recordTracksEvent( 'calypso_jpc_plans_submit_free', {
 			user: this.props.userId
 		} );
-		if ( isCalypsoStartedConnection( this.props.jetpackConnectSessions, selectedSite.slug ) ) {
-			page.redirect( CALYPSO_REDIRECTION_PAGE + selectedSite.slug );
-		}
 	},
 
 	hasPlan( site ) {

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -93,9 +93,11 @@ const Plans = React.createClass( {
 	},
 
 	selectFreeJetpackPlan() {
+		const selectedSite = this.props.sites.getSelectedSite();
 		this.props.recordTracksEvent( 'calypso_jpc_plans_submit_free', {
 			user: this.props.userId
 		} );
+		page.redirect( CALYPSO_REDIRECTION_PAGE + selectedSite.slug );
 	},
 
 	hasPlan( site ) {

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -112,9 +112,9 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE:
 			if ( isEmpty( action.error ) && action.data ) {
 				const { plans_url, activate_manage } = action.data;
-				return Object.assign( {}, state, { authorizeError: false, authorizeSuccess: true, autoAuthorize: false, plansUrl: plans_url, siteReceived: false, activateManageSecret: activate_manage } );
+				return Object.assign( {}, state, { authorizeError: false, authorizeSuccess: true, plansUrl: plans_url, siteReceived: false, activateManageSecret: activate_manage } );
 			}
-			return Object.assign( {}, state, { isAuthorizing: false, authorizeError: action.error, authorizeSuccess: false, autoAuthorize: false } );
+			return Object.assign( {}, state, { isAuthorizing: false, authorizeError: action.error, authorizeSuccess: false } );
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST:
 			const updateQueryObject = omit( state.queryObject, '_wp_nonce', 'secret', 'scope' );
 			return Object.assign( {}, omit( state, 'queryObject' ), { siteReceived: true, isAuthorizing: false, queryObject: updateQueryObject } );
@@ -129,12 +129,12 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_QUERY_UPDATE:
 			return Object.assign( {}, state, { queryObject: Object.assign( {}, state.queryObject, { [ action.property ]: action.value } ) } );
 		case JETPACK_CONNECT_CREATE_ACCOUNT:
-			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, autoAuthorize: true } );
+			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false } );
 		case JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE:
 			if ( ! isEmpty( action.error ) ) {
-				return Object.assign( {}, state, { isAuthorizing: false, authorizeSuccess: false, authorizeError: true, autoAuthorize: false } );
+				return Object.assign( {}, state, { isAuthorizing: false, authorizeSuccess: false, authorizeError: true } );
 			}
-			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, autoAuthorize: true, userData: action.userData, bearerToken: action.data.bearer_token } );
+			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, userData: action.userData, bearerToken: action.data.bearer_token } );
 		case JETPACK_CONNECT_REDIRECT_WP_ADMIN:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
 		case DESERIALIZE:

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -25,7 +25,6 @@ export const jetpackConnectAuthorizeSchema = {
 				activateManageSecret: { type: 'string' },
 				authorizeError: { type: 'boolean' },
 				authorizeSuccess: { type: 'boolean' },
-				autoAuthorize: { type: 'boolean' },
 				isActivating: { type: 'boolean' },
 				isAuthorizing: { type: 'boolean' },
 				isRedirectingToWpAdmin: { type: 'boolean' },

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -1,18 +1,3 @@
-const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // an hour
-
-const isCalypsoStartedConnection = function( state, siteSlug ) {
-	if ( ! siteSlug ) {
-		return false;
-	}
-	const site = siteSlug.replace( /.*?:\/\//g, '' );
-	if ( state && state[ site ] ) {
-		const currentTime = ( new Date() ).getTime();
-		return ( currentTime - state[ site ].timestamp < JETPACK_CONNECT_TTL );
-	}
-
-	return false;
-};
-
 const getFlowType = function( state, site ) {
 	const siteSlug = site.slug.replace( /.*?:\/\//g, '' );
 	if ( state && state[ siteSlug ] ) {
@@ -21,4 +6,4 @@ const getFlowType = function( state, site ) {
 	return false;
 };
 
-export default { isCalypsoStartedConnection, getFlowType };
+export default { getFlowType };


### PR DESCRIPTION
Remove references to `isCalypsoStartedConnection` because we no longer depend on that variable to tell is to redirect to plans page. We will redirect to the plans page by default always.

This will get us closer to #6399 

### Flows to test

#### Site already has a plan
- [x] User logged in
- [x] User logged out, creates new account
- [x] User logged out, uses existing account

#### Site has no plan
- [x] User logged in, not site owner
- [x] User logged in, site owner
- [x] User logged out, creates new account
- [ ] User logged out, uses existing account

cc: @johnHackworth @rickybanister 

Test live: https://calypso.live/?branch=update/jetpack-connect-plans-logic