### PR TITLE
Jetpack Plans: Fix incorrect URL for contacting support.

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -372,7 +372,7 @@ const PlansSetup = React.createClass( {
 		}
 		return (
 			<Notice status="is-error" text={ noticeText } showDismiss={ false }>
-				<NoticeAction href={ support.JETPACK_SUPPORT }>
+				<NoticeAction href={ support.JETPACK_CONTACT_SUPPORT }>
 					{ this.translate( 'Contact Support' ) }
 				</NoticeAction>
 			</Notice>


### PR DESCRIPTION
When an error happens during jetpack plugins' autoconfig, we want to link to the support page, not the install instructions.

Test:

1. Run the autoconfig on a site where an error will happen
2. Click "Contact Support" in the error message
3. Get to a contact form, not a support doc

cc @johnHackworth @roccotripaldi 

Test live: https://calypso.live/?branch=fix/autoconfig-support-url