### PR TITLE
Reader: Stop preventing widows in post titles

### DIFF
--- a/client/lib/feed-post-store/test/index.js
+++ b/client/lib/feed-post-store/test/index.js
@@ -92,11 +92,10 @@ describe( 'feed-post-store', function() {
 			feedId: 1,
 			postId: 2
 		} ) ).to.be.ok;
-		// dependant on the widow rules to be present
 		expect( FeedPostStore.get( {
 			feedId: 1,
 			postId: 2
-		} ).title ).to.equal( 'chris &\xA0ben' );
+		} ).title ).to.equal( 'chris & ben' );
 	} );
 
 	it( 'should index a post by the site_ID and ID if it is internal', function() {

--- a/client/lib/post-normalizer/rule-prevent-widows.js
+++ b/client/lib/post-normalizer/rule-prevent-widows.js
@@ -9,7 +9,7 @@ import forEach from 'lodash/forEach';
 import formatting from 'lib/formatting';
 
 export default function preventWidows( post ) {
-	forEach( [ 'title', 'excerpt' ], function( prop ) {
+	forEach( [ 'excerpt' ], function( prop ) {
 		if ( post[ prop ] ) {
 			post[ prop ] = formatting.preventWidows( post[ prop ], 2 );
 		}

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -236,8 +236,8 @@ describe( 'index', function() {
 				assert.strictEqual( normalized.author.avatar_URL, 'http://example.com/me.jpg-SAFE?w=200&quality=80&strip=info' );
 				assert.strictEqual( normalized.featured_image, 'http://foo.bar/-SAFE?w=200&quality=80&strip=info' );
 				assert.strictEqual( normalized.featured_media.uri, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' );
-				assert.strictEqual( normalized.attachments['1234'].URL, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' );
-				assert.strictEqual( normalized.attachments['3456'].URL, 'http://example.com/media.jpg' );
+				assert.strictEqual( normalized.attachments[ '1234' ].URL, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' );
+				assert.strictEqual( normalized.attachments[ '3456' ].URL, 'http://example.com/media.jpg' );
 				done( err );
 			} );
 		} );

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -140,13 +140,11 @@ describe( 'index', function() {
 
 	it( 'can prevent widows', function( done ) {
 		var post = {
-			title: 'title',
 			excerpt: 'this is a longer excerpt bar'
 		};
 
 		normalizer( post, [ normalizer.preventWidows ], function( err, normalized ) {
 			assert.deepEqual( normalized, {
-				title: 'title',
 				excerpt: 'this is a longer excerpt\xA0bar'
 			} );
 			done( err );
@@ -155,13 +153,11 @@ describe( 'index', function() {
 
 	it( 'can prevent widows in empty strings', function( done ) {
 		var post = {
-			title: ' ',
 			excerpt: '   '
 		};
 
 		normalizer( post, [ normalizer.preventWidows ], function( err, normalized ) {
 			assert.deepEqual( normalized, {
-				title: '',
 				excerpt: ''
 			} );
 			done( err );


### PR DESCRIPTION
It makes titles on cards wrap in really unfortunate places. Widows are preferable.

Test live: https://calypso.live/?branch=update/reader/allow-widows-in-titles