### PR TITLE
Reader: update Search titles to wrap around icons

### DIFF
--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -181,11 +181,11 @@
 		top: -2px;
 
 	.gridicon {
-		fill: lighten( $gray, 10% );
+		fill: $blue-wordpress;
 	}
 
 	.follow-button__label {
-		color: lighten( $gray, 10% );
+		color: $blue-wordpress;
 
 		@include breakpoint( "<660px" )
 			display: inline;
@@ -194,15 +194,53 @@
 	&:hover {
 
 		.gridicon {
-			fill: $blue-wordpress;
+			fill: lighten( $gray, 10% );
 		}
 
 		.follow-button__label {
-			color: $blue-wordpress;
+			color: lighten( $gray, 10% );
 		}
 	}
 
 	&:focus {
 		border-radius: 0;
+	}
+
+	&.is-following {
+
+		.gridicon {
+			fill: $alert-green;
+		}
+
+		.follow-button__label {
+			color: $alert-green;
+		}
+
+		&:hover {
+
+			.gridicon {
+				fill: $blue-wordpress;
+			}
+
+			.follow-button__label {
+				color: $blue-wordpress;
+			}
+		}
+	}
+}
+
+// Custom colors for Site and Author info
+.reader__content {
+
+	.post-card__author-and-site {
+
+		a,
+		a:visited {
+			color: lighten( $gray, 10% );
+		}
+
+		a:hover {
+			color: $blue-wordpress;
+		}
 	}
 }

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -97,15 +97,10 @@
 
 .post-card__search-title {
 	@extend %content-font;
+	display: inline;
 	font-size: 24px;
 	line-height: 28px;
 	font-weight: 700;
-	margin: 0 100px 6px 0;
-
-	@include breakpoint( "<960px" ) {
-		display: block;
-		margin-right: 0;
-	}
 }
 
 .post-card__search .post-card__search-title-link {
@@ -140,14 +135,7 @@
 .post-card__search-social {
 	float: right;
 	margin-bottom: 6px;
-
-	@include breakpoint( ">960px" ) {
-		float: none;
-		margin-bottom: 0;
-		position: absolute;
-			right: 10px;
-			top: 18px;
-	}
+	padding-left: 20px;
 }
 
 .post-card__search .like-button .gridicon {
@@ -160,7 +148,7 @@
 
 .post-card__search-byline {
 	list-style: none;
-	margin: 0 0 6px;
+	margin: 6px 0;
 	padding: 0;
 	font-size: 13px;
 

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -83,14 +83,7 @@
 		}
 
 		@include breakpoint( "<480px" ) {
-			padding-left: 20px;
-		}
-
-		.post-card__search-featured-image {
-
-			@include breakpoint( "<480px" ) {
-				display: none;
-			}
+			padding-left: 108px;
 		}
 	}
 }
@@ -98,9 +91,14 @@
 .post-card__search-title {
 	@extend %content-font;
 	display: inline;
-	font-size: 24px;
-	line-height: 28px;
+	font-size: 20px;
+	line-height: 20px;
 	font-weight: 700;
+
+	@include breakpoint( ">480px" ) {
+		font-size: 24px;
+		line-height: 28px;
+	}
 }
 
 .post-card__search .post-card__search-title-link {
@@ -128,7 +126,7 @@
 	}
 
 	@include breakpoint( "<480px" ) {
-		width: 115px;
+		width: 90px;
 	}
 }
 
@@ -156,6 +154,10 @@
 		vertical-align: text-bottom;
 		margin: 0 4px 0 0;
 	}
+}
+
+.post-card__search-byline-item {
+	display: inline-block;
 }
 
 .post-card__author-and-site {


### PR DESCRIPTION
**Changes made:**
- Made titles wrap around icons
- Add images back in viewports `<480px`
- Updated site info and Follow button colors
- Cleanup

**Before:**
![screenshot 2016-07-08 13 30 11](https://cloud.githubusercontent.com/assets/4924246/16700662/26c37022-4510-11e6-8483-2cf5bb39dc7e.png)

**After:**
![screenshot 2016-07-08 13 30 18](https://cloud.githubusercontent.com/assets/4924246/16700666/29998fac-4510-11e6-82ef-742e8d6ea4e2.png)

Test live: https://calypso.live/?branch=update/reader/search-wrap-title-around-icons