### PR TITLE
Posts: Remove key and ref from list of props to check in Post component

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -50,7 +50,7 @@ module.exports = React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps, nextState ) {
-		const propsToCheck = [ 'ref', 'key', 'post', 'postImages', 'fullWidthPost', 'path' ];
+		const propsToCheck = [ 'post', 'postImages', 'fullWidthPost', 'path' ];
 
 		if ( checkPropsChange( this.props, nextProps, propsToCheck ) ) {
 			return true;


### PR DESCRIPTION
When running Calypso locally and navigating to the `/posts` section, I noticed the following warnings in the console:

```
Warning: Post: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)

Warning: Post: `ref` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)
```

This PR addresses that.

No functionality should have changed. Test by verifying that the posts section functions as it did previously.

Test live: https://calypso.live/?branch=fix/post-access-key-prop