### PR TITLE
Jetpack Sync: Initial pass at UI

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -272,6 +272,7 @@
 @import 'my-sites/site-settings/delete-site/style';
 @import 'my-sites/site-settings/delete-site-options/style';
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
+@import 'my-sites/site-settings/jetpack-sync-panel/style';
 @import 'my-sites/importer/style';
 @import 'my-sites/site/style';
 @import 'my-sites/sites/style';

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -29,6 +29,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Timezone from 'components/timezone';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDomainsBySite } from 'state/sites/domains/selectors';
+import JetpackSyncPanel from './jetpack-sync-panel';
 
 const FormGeneral = React.createClass( {
 	displayName: 'SiteSettingsFormGeneral',
@@ -426,6 +427,21 @@ const FormGeneral = React.createClass( {
 		);
 	},
 
+	renderJetpackSyncPanel() {
+		if ( ! config.isEnabled( 'jetpack/sync-panel' ) ) {
+			 return null;
+		}
+
+		const site = this.props.site;
+		if ( ! site.jetpack || this.props.site.versionCompare( '4.2.0-alpha', '<' ) ) {
+			return null;
+		}
+
+		return (
+			<JetpackSyncPanel siteId={ site.ID } />
+		);
+	},
+
 	render() {
 		var site = this.props.site;
 		if ( site.jetpack && ! site.hasMinimumJetpackVersion ) {
@@ -498,6 +514,8 @@ const FormGeneral = React.createClass( {
 						{ this.relatedPostsOptions() }
 					</form>
 				</Card>
+
+				{ this.renderJetpackSyncPanel() }
 
 				{ this.props.site.jetpack
 					? <div>

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
+import debugModule from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import Notice from 'components/notice';
+import ProgressBar from 'components/progress-bar';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+/*
+ * Module variables
+ */
+const debug = debugModule( 'calypso:site-settings:jetpack-sync-panel' );
+
+const JetpackSyncPanel = React.createClass( {
+	displayName: 'JetpackSyncPanel',
+
+	shouldDisableSync() {
+		return true;
+	},
+
+	onSyncRequestButtonClick( event ) {
+		event.preventDefault();
+		debug( 'Perform full sync button clicked' );
+	},
+
+	renderStatusNotice() {
+		const classes = classNames( 'jetpack-sync-panel__notice' );
+		return (
+			<Notice isCompact className={ classes }>
+				Placeholder text
+			</Notice>
+		);
+	},
+
+	renderProgressBar() {
+		return (
+			<ProgressBar value={ 0 } />
+		);
+	},
+
+	render() {
+		return (
+			<Card className="jetpack-sync-panel">
+				<div className="jetpack-sync-panel__action-group">
+					<div className="jetpack-sync-panel__description">
+						{ this.translate(
+							'{{strong}}Jetpack Sync keeps your WordPress.com dashboard up to date.{{/strong}} ' +
+							'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience. ' +
+							'If you suspect some data is missing, you can initiate a sync manually.',
+							{
+								components: {
+									strong: <strong />
+								}
+							}
+						) }
+					</div>
+
+					<div className="jetpack-sync-panel__action">
+						<Button onClick={ this.onSyncRequestButtonClick } disabled={ this.shouldDisableSync() }>
+							{ this.translate( 'Perform full sync', { context: 'Button' } ) }
+						</Button>
+					</div>
+				</div>
+
+				{ this.renderStatusNotice() }
+				{ this.renderProgressBar() }
+			</Card>
+		);
+	}
+} );
+
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		return {
+			siteId
+		};
+	},
+	dispatch => bindActionCreators( {}, dispatch )
+)( JetpackSyncPanel );

--- a/client/my-sites/site-settings/jetpack-sync-panel/style.scss
+++ b/client/my-sites/site-settings/jetpack-sync-panel/style.scss
@@ -1,0 +1,31 @@
+.jetpack-sync-panel__action {
+	margin-top: 16px
+}
+
+@include breakpoint( ">660px" ) {
+	.jetpack-sync-panel__action-group {
+		display: flex;
+	}
+
+	.jetpack-sync-panel__description {
+		display: block;
+		flex-grow: 1;
+		padding-right: 8px;
+	}
+
+	.jetpack-sync-panel__action {
+		align-self: center;
+		flex-grow: 1;
+		flex-shrink: 0;
+		margin-top: 0;
+		padding-left: 8px;
+	}
+}
+
+.jetpack-sync-panel .progress-bar {
+	margin-top: 16px;
+}
+
+.jetpack-sync-panel .notice {
+	margin-top: 16px;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -43,6 +43,7 @@
 		"jetpack/connect": true,
 		"jetpack/sso": true,
 		"jetpack_core_inline_update": true,
+		"jetpack/sync-panel": true,
 		"keyboard-shortcuts": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,


### PR DESCRIPTION
This PR is a first pass the Jetpack Sync Panel UI, and is a continuation of factoring out #6044.

To test:

- Checkout `add/jetpack-sync-panel-ui` branch
- Go to `/settings/general/$site` where `$site` is on `4.2.0-alpha` (latest master)
- Do you see something like this?

![screen shot 2016-07-08 at 3 44 55 pm](https://cloud.githubusercontent.com/assets/1126811/16701329/b16f5150-4524-11e6-9c33-bb7dd34674b7.png)
- There shouldn't be any sync status specific errors. Note: There are other errors for site settings right now... 😞 
- Now go to `/settings/general/$site` where `$site` is on some lesser version of Jetpack (ex. - `4.1.1`)
- You should not see the sync panel

Test live: https://calypso.live/?branch=add/jetpack-sync-panel-ui