### PR TITLE
Jetpack "My Plan": Remove “Add additional sites” card until the feature exists

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack.jsx
+++ b/client/my-sites/plans/current-plan/jetpack.jsx
@@ -49,16 +49,6 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 				href="https://polldaddy.com/dashboard/" />
 			}
 
-			{ isBusiness && <PurchaseDetail
-				icon="add-outline"
-				title={ i18n.translate( 'Add additional sites' ) }
-				description={ i18n.translate(
-					'You can add an additional 2 sites to this plan.'
-				) }
-				buttonText={ i18n.translate( 'Add another site' ) }
-				href="#" />
-			}
-
 			<PurchaseDetail
 				icon="plugins"
 				title={ i18n.translate( 'Get the most from WordPress.com' ) }


### PR DESCRIPTION
The "Add additional sites" card was added to the My Plan page, but that feature doesn't exist yet. We'll remove the card, and re-add it once the feature is started.

Test

1. Go to `/plans/my-plan/$site` with a Professional site
2. See a list of plan features
3. There should not be a card titled "Add additional sites"

cc @johnHackworth @rickybanister @roccotripaldi 

Test live: https://calypso.live/?branch=fix/jetpack-my-plan-add-sites