### PR TITLE
Reader: create a custom style for photo cards in Search

### DIFF
--- a/client/components/post-card/docs/example.jsx
+++ b/client/components/post-card/docs/example.jsx
@@ -8,6 +8,7 @@ import React from 'react';
  */
 import SmallPostCard from 'components/post-card/small';
 import SearchPostCard from 'components/post-card/search';
+import DisplayTypes from 'state/reader/posts/display-types';
 
 const smallItems = [
 	{
@@ -87,7 +88,7 @@ const searchItems = [
 	{
 		post: {
 			ID: 1,
-			title: 'A first post',
+			title: 'A regular post',
 			content: 'Look, I have content!',
 			site_ID: 1,
 			site_URL: 'http://example.com',
@@ -116,6 +117,40 @@ const searchItems = [
 		feed: {
 			feed_ID: 1
 		}
+	},
+	{
+		post: {
+			ID: 2,
+			title: 'A photo post',
+			content: 'Look, I have content!',
+			site_ID: 2,
+			site_URL: 'http://example.com',
+			feed_ID: 2,
+			feed_item_ID: 2,
+			display_type: DisplayTypes.PHOTO_ONLY,
+			author: {
+				name: 'Sue Smith',
+				email: 'sue@example.com'
+			},
+			discussion: {
+				comment_count: 80
+			},
+			canonical_image: {
+				uri: 'https://placekitten.com/600/400',
+				width: 300,
+				height: 200
+			},
+			date: '1976-09-15T10:12:00Z',
+
+			excerpt: 'Amazing cat photos updated daily. Come back at three for tabbies.'
+		},
+		site: {
+			ID: 2,
+			title: 'My Site'
+		},
+		feed: {
+			feed_ID: 2
+		}
 	}
 ];
 
@@ -128,14 +163,18 @@ const PostCards = React.createClass( {
 				<h2>
 					<a href="/devdocs/app-components/post-card">Post Cards</a>
 				</h2>
+
 				<h3>Small Post Cards</h3>
 				<div>
 					{ smallItems.map( item => <SmallPostCard key={ item.post.global_ID } post={ item.post } site={ item.site } /> ) }
 				</div>
 
-				<h3>Search Cards</h3>
+				<h2>
+					<a href="/devdocs/app-components/post-card">Search Cards</a>
+				</h2>
+
 				<div>
-					{ searchItems.map( item => <SearchPostCard key={ item.post.global_ID } post={ item.post } site={ item.site } /> ) }
+					{ searchItems.map( item => <SearchPostCard key={ item.post.site_ID } post={ item.post } site={ item.site } /> ) }
 				</div>
 			</div>
 		);

--- a/client/components/post-card/search.jsx
+++ b/client/components/post-card/search.jsx
@@ -15,6 +15,7 @@ import PostTime from 'reader/post-time';
 import FollowButton from 'reader/follow-button';
 import LikeButton from 'reader/like-button';
 import CommentButton from 'components/comment-button';
+import DisplayTypes from 'state/reader/posts/display-types';
 
 function FeaturedImage( { image, href } ) {
 	return (
@@ -42,7 +43,7 @@ export function SearchPostCard( { post, site, feed, onClick = noop, onCommentCli
 	const hasPost = !! post;
 	const classes = classnames( 'post-card__search', {
 		'has-thumbnail': !! featuredImage,
-		'is-photo': hasPost && post.excerpt.length < 1
+		'is-photo': hasPost && ( post.display_type & DisplayTypes.PHOTO_ONLY )
 	} );
 	return (
 		<Card className={ classes } onClick={ partial( onClick, { post, site, feed } ) }>

--- a/client/components/post-card/search.jsx
+++ b/client/components/post-card/search.jsx
@@ -11,7 +11,6 @@ import partial from 'lodash/partial';
  */
 import Card from 'components/card';
 import AuthorAndSite from './author-and-site';
-import PostTime from 'reader/post-time';
 import FollowButton from 'reader/follow-button';
 import LikeButton from 'reader/like-button';
 import CommentButton from 'components/comment-button';

--- a/client/components/post-card/search.jsx
+++ b/client/components/post-card/search.jsx
@@ -39,8 +39,10 @@ function SearchByline( { post, site, feed } ) {
 
 export function SearchPostCard( { post, site, feed, onClick = noop, onCommentClick = noop } ) {
 	const featuredImage = post.canonical_image;
+	const hasPost = !! post;
 	const classes = classnames( 'post-card__search', {
-		'has-thumbnail': !! featuredImage
+		'has-thumbnail': !! featuredImage,
+		'is-photo': hasPost && post.excerpt.length < 1
 	} );
 	return (
 		<Card className={ classes } onClick={ partial( onClick, { post, site, feed } ) }>

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -155,6 +155,18 @@
 			text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );
 			z-index: 2;
 		}
+
+		.follow-button.is-following {
+
+			.gridicon {
+				fill: $white;
+			}
+
+			.follow-button__label {
+				color: $white;
+			}
+
+		}
 	}
 }
 

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -86,6 +86,13 @@
 			padding-left: 108px;
 		}
 	}
+
+	&.is-photo {
+
+		.post-card__search-featured-image {
+			width: 100%;
+		}
+	}
 }
 
 .post-card__search-title {

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -165,7 +165,6 @@
 			.follow-button__label {
 				color: $white;
 			}
-
 		}
 	}
 }

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -95,11 +95,12 @@
 			background: $gray-dark;
 			content: '';
 			height: 100%;
-			opacity: .2;
+			opacity: .4;
 			position: absolute;
 				left: 0;
 				top: 0;
 			width: 100%;
+			z-index: 1;
 		}
 
 		.post-card__search-featured-image {
@@ -111,6 +112,7 @@
 			padding-right: 20px;
 			position: absolute;
 				bottom: 43px;
+			z-index: 2;
 
 			&:hover {
 				opacity: .8;

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -88,9 +88,71 @@
 	}
 
 	&.is-photo {
+		height: 168px;
+		padding: 20px;
+
+		&:before{
+			background: $gray-dark;
+			content: '';
+			height: 100%;
+			opacity: .2;
+			position: absolute;
+				left: 0;
+				top: 0;
+			width: 100%;
+		}
 
 		.post-card__search-featured-image {
 			width: 100%;
+		}
+
+		.post-card__search-title-link {
+			color: $white;
+			padding-right: 20px;
+			position: absolute;
+				bottom: 43px;
+
+			&:hover {
+				opacity: .8;
+			}
+		}
+
+		.post-card__search-byline {
+			position: absolute;
+				bottom: 10px;
+
+			a,
+			a:visited {
+				color: $white;
+			}
+
+			.gravatar {
+				border: 1px solid rgba( 255, 255, 255, 0.4 );
+			}
+		}
+
+		.post-card__author-and-site {
+			color: $white;
+		}
+
+		.post-card__search-social {
+			position: relative;
+		}
+
+		.gridicon {
+			fill: $white;
+		}
+
+		.comment-button__label-count,
+		.like-button__label-count {
+			color: $white;
+		}
+
+		.post-card__search-title,
+		.post-card__search-byline,
+		.post-card__search-social {
+			text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );
+			z-index: 2;
 		}
 	}
 }
@@ -152,10 +214,10 @@
 }
 
 .post-card__search-byline {
+	font-size: 13px;
 	list-style: none;
 	margin: 6px 0;
 	padding: 0;
-	font-size: 13px;
 
 	.gravatar {
 		vertical-align: text-bottom;
@@ -180,6 +242,7 @@
 
 // Custom styles for Follow button
 .post-card__search .follow-button {
+	background: none;
 	border-style: none;
 	font-size: 13px;
 	margin: 0;

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -112,7 +112,6 @@
 			padding-right: 20px;
 			position: absolute;
 				bottom: 43px;
-			z-index: 2;
 
 			&:hover {
 				opacity: .8;
@@ -150,7 +149,7 @@
 			color: $white;
 		}
 
-		.post-card__search-title,
+		.post-card__search-title-link,
 		.post-card__search-byline,
 		.post-card__search-social {
 			text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );


### PR DESCRIPTION
This PR creates custom styling for photo-only cards in Search to match the design:

![screenshot 2016-07-08 16 23 33](https://cloud.githubusercontent.com/assets/4924246/16704170/f62309dc-4528-11e6-8ddd-91a47d9b91a9.png)


Test live: https://calypso.live/?branch=update/reader/search-style-for-photo-cards