### PR TITLE
Advanced SEO: Save custom title format to API

### DIFF
--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -12,6 +12,7 @@ import {
 	isUndefined,
 	map,
 	matches,
+	noop,
 	pick,
 	property,
 	values as valuesOf
@@ -99,7 +100,7 @@ export class MetaTitleEditor extends Component {
 	}
 
 	updateTitleFormat( values ) {
-		const { translate } = this.props;
+		const { onChange, translate } = this.props;
 		const { type } = this.state;
 
 		const tokens = removeBlanks( map( values, tokenize( translate ) ) );
@@ -107,7 +108,7 @@ export class MetaTitleEditor extends Component {
 		this.setState( { titleFormats: {
 			...this.state.titleFormats,
 			[ type ]: tokens
-		} } );
+		} }, () => onChange( this.state.titleFormats ) );
 	}
 
 	render() {
@@ -148,11 +149,13 @@ export class MetaTitleEditor extends Component {
 }
 
 MetaTitleEditor.propTypes = {
-	disabled: PropTypes.bool
+	disabled: PropTypes.bool,
+	onChange: PropTypes.func
 };
 
 MetaTitleEditor.defaultProps = {
 	disabled: false,
+	onChange: noop,
 	translate: identity
 };
 

--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -58,6 +58,16 @@ const tokenToTag = n =>
 export const rawToNative = r => removeBlanks( map( split( r, tagPattern ), tagToToken ) );
 export const nativeToRaw = n => join( map( n, tokenToTag ), '' );
 
+// Not only are the format strings themselves stored differently
+// than on the server, but the API expects a different structure
+// for the data mapping the types to the formats, so we additionally
+// need to perform a mapping stage when talking with it, iterating
+// over the full data structure and not just focusing on individual
+// title format strings.
+//
+//  - Rename keys: `front_page` -> `frontPage`
+//  - Translate formats: `%page_title%` -> [ { type: 'pageTitle' } ]
+
 export const toApi = compose(
 	partialRight( mapKeys, rearg( snakeCase, 1 ) ), // 1 -> key from ( value, key )
 	partialRight( mapValues, nativeToRaw )          // native objects to raw strings

--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -24,13 +24,20 @@
 /**
  * External dependencies
  */
-import camelCase from 'lodash/camelCase';
-import join from 'lodash/join';
-import map from 'lodash/map';
-import matchesProperty from 'lodash/matchesProperty';
-import reject from 'lodash/reject';
-import snakeCase from 'lodash/snakeCase';
-import split from 'lodash/split';
+import {
+	camelCase,
+	flowRight as compose,
+	join,
+	map,
+	mapKeys,
+	mapValues,
+	matchesProperty,
+	partialRight,
+	rearg,
+	reject,
+	snakeCase,
+	split
+} from 'lodash';
 
 export const removeBlanks = values => reject( values, matchesProperty( 'value', '' ) );
 
@@ -50,3 +57,13 @@ const tokenToTag = n =>
 
 export const rawToNative = r => removeBlanks( map( split( r, tagPattern ), tagToToken ) );
 export const nativeToRaw = n => join( map( n, tokenToTag ), '' );
+
+export const toApi = compose(
+	partialRight( mapKeys, rearg( snakeCase, 1 ) ), // 1 -> key from ( value, key )
+	partialRight( mapValues, nativeToRaw )          // native objects to raw strings
+);
+
+export const fromApi = compose(
+	partialRight( mapKeys, rearg( camelCase, 1 ) ), // 1 -> key from ( value, key )
+	partialRight( mapValues, rawToNative )          // raw strings to native objects
+);

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -30,6 +30,8 @@ import CountedTextarea from 'components/forms/counted-textarea';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import SearchPreview from 'components/seo/search-preview';
 import config from 'config';
+import { getSeoTitleFormatsForSite } from 'state/sites/selectors';
+import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const serviceIds = {
@@ -50,6 +52,7 @@ function getGeneralTabUrl( slug ) {
 function stateForSite( site ) {
 	return {
 		seoMetaDescription: get( site, 'options.seo_meta_description', '' ),
+		seoTitleFormats: getSeoTitleFormatsForSite( site ),
 		googleCode: get( site, 'options.verification_services_codes.google', '' ),
 		bingCode: get( site, 'options.verification_services_codes.bing', '' ),
 		pinterestCode: get( site, 'options.verification_services_codes.pinterest', '' ),
@@ -145,6 +148,10 @@ export const SeoForm = React.createClass( {
 		} );
 	},
 
+	updateTitleFormats( seoTitleFormats ) {
+		this.setState( { seoTitleFormats } );
+	},
+
 	submitSeoForm( event ) {
 		const { site, trackSubmission } = this.props;
 
@@ -178,6 +185,7 @@ export const SeoForm = React.createClass( {
 		this.setState( { isSubmittingForm: true } );
 
 		const updatedOptions = {
+			advanced_seo_title_formats: seoTitleToApi( this.state.seoTitleFormats ),
 			seo_meta_description: this.state.seoMetaDescription,
 			verification_services_codes: filteredCodes
 		};
@@ -289,7 +297,7 @@ export const SeoForm = React.createClass( {
 								{ config.isEnabled( 'manage/advanced-seo/custom-title' ) &&
 									<div>
 										<FormLabel htmlFor="seo_title">{ this.translate( 'Meta Title Format' ) }</FormLabel>
-										<MetaTitleEditor />
+										<MetaTitleEditor onChange={ this.updateTitleFormats } />
 										<FormSettingExplanation>
 											{ this.translate( 'Customize how the title for your content will appear in search engines and social media.' ) }
 										</FormSettingExplanation>

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -463,7 +463,7 @@ const mapStateToProps = state => ( {
 } );
 
 const mapDispatchToProps = {
-	trackSubmission: recordTracksEvent( 'calypso_seo_settings_form_submit', {} )
+	trackSubmission: () => recordTracksEvent( 'calypso_seo_settings_form_submit', {} )
 };
 
 export default connect(

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -462,9 +462,9 @@ const mapStateToProps = state => ( {
 	storedTitleFormats: getSeoTitleFormatsForSite( getSelectedSite( state ) )
 } );
 
-const mapDispatchToProps = dispatch => ( {
-	trackSubmission: () => dispatch( recordTracksEvent( 'calypso_seo_settings_form_submit', {} ) )
-} );
+const mapDispatchToProps = {
+	trackSubmission: recordTracksEvent( 'calypso_seo_settings_form_submit', {} )
+};
 
 export default connect(
 	mapStateToProps,

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -3,11 +3,14 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import get from 'lodash/get';
-import includes from 'lodash/includes';
-import isString from 'lodash/isString';
-import omit from 'lodash/omit';
-import pickBy from 'lodash/pickBy';
+import {
+	get,
+	includes,
+	isEqual,
+	isString,
+	omit,
+	pickBy
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,6 +34,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import SearchPreview from 'components/seo/search-preview';
 import config from 'config';
 import { getSeoTitleFormatsForSite } from 'state/sites/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -148,8 +152,28 @@ export const SeoForm = React.createClass( {
 		} );
 	},
 
+	/**
+	 * Tracks updates to the title formats
+	 *
+	 * We need to be careful here and only
+	 * send _changes_ to the API instead of
+	 * sending all of the title formats.
+	 * There is a race condition here after
+	 * sending the changes and before updating
+	 * from the SitesList wherein we could
+	 * accidentally overwrite new changes.
+	 *
+	 * @param {object} seoTitleFormats SEO title formats e.g. { frontPage: '%site_name%' }
+	 */
 	updateTitleFormats( seoTitleFormats ) {
-		this.setState( { seoTitleFormats } );
+		const { storedTitleFormats } = this.props;
+
+		const hasChanges = ( format, type ) =>
+			! isEqual( format, storedTitleFormats[ type ] );
+
+		this.setState( {
+			seoTitleFormats: pickBy( seoTitleFormats, hasChanges )
+		} );
 	},
 
 	submitSeoForm( event ) {
@@ -434,8 +458,17 @@ export const SeoForm = React.createClass( {
 	}
 } );
 
+const mapStateToProps = state => ( {
+	storedTitleFormats: getSeoTitleFormatsForSite( getSelectedSite( state ) )
+} );
+
 const mapDispatchToProps = dispatch => ( {
 	trackSubmission: () => dispatch( recordTracksEvent( 'calypso_seo_settings_form_submit', {} ) )
 } );
 
-export default connect( null, mapDispatchToProps, null, { pure: false } )( SeoForm );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+	undefined,
+	{ pure: false } // defaults to true, but this component has internal state
+)( SeoForm );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -4,17 +4,12 @@
  * External dependencies
  */
 import {
-	camelCase,
-	chain,
 	filter,
 	find,
 	flowRight as compose,
 	get,
 	map,
-	mapKeys,
-	mapValues,
 	partialRight,
-	rearg,
 	some,
 	includes,
 } from 'lodash';
@@ -23,7 +18,7 @@ import {
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { rawToNative as seoTitleFromRaw } from 'components/seo/meta-title-editor/mappings';
+import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import versionCompare from 'lib/version-compare';
 
 /**
@@ -177,6 +172,20 @@ export function isRequestingSites( state ) {
 
 /**
  * Returns object describing custom title format
+ * strings for SEO given a site object.
+ *
+ * @see client/components/seo/meta-title-editor
+ *
+ * @param  {Object} site Selected site
+ * @return {Object} Formats by type e.g. { frontPage: { type: 'siteName' } }
+ */
+export const getSeoTitleFormatsForSite = compose(
+	seoTitleFromApi,
+	partialRight( get, 'options.advanced_seo_title_formats', {} )
+);
+
+/**
+ * Returns object describing custom title format
  * strings for SEO.
  *
  * @see client/components/seo/meta-title-editor
@@ -186,9 +195,7 @@ export function isRequestingSites( state ) {
  * @return {Object} Formats by type e.g. { frontPage: { type: 'siteName' } }
  */
 export const getSeoTitleFormats = compose(
-	partialRight( mapValues, seoTitleFromRaw ), // raw strings to native objects
-	partialRight( mapKeys, rearg( camelCase, 1 ) ), // 1 -> key from ( value, key )
-	partialRight( get, 'options.advanced_seo_title_formats', {} ),
+	getSeoTitleFormatsForSite,
 	getSite
 );
 


### PR DESCRIPTION
<del>**DO NOT MERGE** waiting on changes to API whereas partial updates to the custom title formats currently overwrite all title formats.</del> <ins>Merged in r138837-wpcom</ins>

Part of #5834

The prior work in #6467 and #6071 added a UI element to edit custom SEO
title formats inside of Calypso but they did not save the data back
through the API to the servers.

This patch piggy-backs on the settings in `form-seo.jsx` to send changes
setting updates to WordPress.com.

New `fromApi` and `toApi` functions have been created in
`components/seo/meta-title-editor/mappings.js` to foster reusability for
the conversion code to transform between API-native and Calypso-native
formats.

A new `onChange` hook has also been added to the editor so that the SEO
form can be notified of changes. These changes are stateful at the
component level and not at the Redux state level because there remains
considerable work to bring the Redux tree to the point where it need to
be to make this smooth.

Included in these changes are some reformattings of the **lodash**
imports.

There should be **no visual changes in this PR**.

**Remaining Questions**
 - Should we be moving the `mappings.js` file into a place better suited
   for it? Maybe into `client/state/sites/` I'm not sure if that would
   be better or if its current home isn't the best place for it to be.
   It's currently only marginally referenced outside of the component.

**Testing**

You will need a site **with a business plan** and you will need to be **running a local dev environment** to test this because all public-facing changes are still hidden behind a feature flag.

Navigate to **My Sites** > **Settings** > **SEO** and notice the _Meta Title Format_ editor. Most likely it will be blank for you. If you have not selected a site with a business plan, the editor will still be there but it won't work.

You should be able to enter some combination of text and tags/chips/tokens in the boxes for each kind of page type. You may want to verify the following:

 - [x] The formats switch out appropriately if you selected different page types
 - [x] Those changes should persist when switching back to a previous page type
 - [x] If you attempt to navigate away from the page without hitting `Save Settings` then it should alert you of unsaved changes in a popup.
 - [x] If you hit `Save Settings` you should find it successfully send of a network request to the site settings endpoint.
 - [ ] If you reload the page after saving, your changes should come back or persist.

**Notes**
 - I'm not sure how the unsaved-changes popup works. Literally, I didn't even try to make it work right and magically it just did. Likely I have been lucky but it will eventually break. @roundhill maybe you have a quick word of advice.
 - There's a race-condition after saving changes that exists because we aren't updating the Redux state tree directly on title format saves. Instead, once we update the settings on the server, we request an update to the site settings via `site.fetchSettings()`. If we reload the page after the title format save but before those settings are fetched again, it will appear like we have lost the changes. However, if we reload the page again, we are likely to find that they reappear. I'm not sure what the best way to handle this is. I think the probability of experiencing this bug is low due to the likely use-flow of the editor.

cc: @rodrigoi @vindl @gwwar @mtias

Test live: https://calypso.live/?branch=update/seo-title/save-to-api