### PR TITLE
Domains: Add NEW flag to .wales

### DIFF
--- a/client/components/domains/domain-suggestion-flag/index.jsx
+++ b/client/components/domains/domain-suggestion-flag/index.jsx
@@ -15,16 +15,16 @@ const DomainSuggestionFlag = React.createClass( {
 	},
 
 	render() {
-		const newTLDs = [];
+		const newTLDs = [ 'wales' ];
 
-		if ( newTLDs.some( function( tld ) {
-				return endsWith( this.props.domain, tld );
-			}, this ) ) {
+		if ( newTLDs.some( ( tld ) => {
+			return endsWith( this.props.domain, tld );
+		} ) ) {
 			return (
 				<Notice
 					isCompact
 					status="is-success">
-					{ this.translate( 'New', {context: 'Domain suggestion flag'} ) }
+					{ this.translate( 'New', { context: 'Domain suggestion flag' } ) }
 				</Notice>
 			);
 		}


### PR DESCRIPTION
Mark .wales as a new TLD, so it has a flag in domain suggestions

Test live: https://calypso.live/?branch=update/new-wales-tld