### PR TITLE
Add example of TermTreeSelector.

### DIFF
--- a/client/devdocs/design/app-components.jsx
+++ b/client/devdocs/design/app-components.jsx
@@ -28,6 +28,7 @@ import PlanCompareCard from 'my-sites/plan-compare-card/docs/example';
 import FeatureComparison from 'my-sites/feature-comparison/docs/example';
 import DomainTip from 'my-sites/domain-tip/docs/example';
 import PostCard from 'components/post-card/docs/example';
+import TermTreeSelector from 'my-sites/term-tree-selector/docs/example';
 
 export default React.createClass( {
 
@@ -70,6 +71,7 @@ export default React.createClass( {
 					<PostSelector />
 					<Sites />
 					<SitesDropdown />
+					<TermTreeSelector />
 					<Theme />
 					<ThemesListExample />
 					<UpgradeNudge />

--- a/client/my-sites/menus/item-options/category-options.jsx
+++ b/client/my-sites/menus/item-options/category-options.jsx
@@ -77,6 +77,7 @@ module.exports = React.createClass( {
 			<div className="menu-item-options menu-item-options__term-tree-selector">
 				<MenuPanelBackButton label={ this.props.itemType.label } onClick={ this.props.onBackClick } />
 				<CategorySelector
+					siteId={ this.props.siteId }
 					analyticsPrefix="Menus"
 					onChange={ this.onChange }
 					createLink={ this.props.itemType.createLink }

--- a/client/my-sites/term-tree-selector/docs/example.jsx
+++ b/client/my-sites/term-tree-selector/docs/example.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+
+/**
+ * Internal dependencies
+ */
+import TermTreeSelector from '../';
+import observe from 'lib/mixins/data-observe';
+import sites from 'lib/sites-list';
+
+const TermTreeSelectorExample = React.createClass( {
+	mixins: [ observe( 'sites' ), PureRenderMixin ],
+
+	render() {
+		const primary = this.props.sites.getPrimary();
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/app-components/term-tree-selector">Term Tree Selector</a>
+				</h2>
+				<div style={ { width: 300 } }>
+					{ this.props.sites.initialized && (
+						<TermTreeSelector
+							siteId={ primary ? primary.ID : 3584907 }
+							taxonomy="category" />
+					) }
+				</div>
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+} );
+
+export default React.createClass( {
+	displayName: 'TermTreeSelector',
+
+	mixins: [ PureRenderMixin ],
+
+	render() {
+		return <TermTreeSelectorExample sites={ sites() } />;
+	}
+} );

--- a/client/my-sites/term-tree-selector/index.jsx
+++ b/client/my-sites/term-tree-selector/index.jsx
@@ -19,7 +19,8 @@ export default React.createClass( {
 		selected: PropTypes.array,
 		createLink: PropTypes.string,
 		analyticsPrefix: PropTypes.string,
-		taxonomy: PropTypes.string
+		taxonomy: PropTypes.string,
+		siteId: PropTypes.number
 	},
 
 	getDefaultProps() {
@@ -46,7 +47,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { className, taxonomy, onChange, selected, createLink, multiple } = this.props;
+		const { className, taxonomy, onChange, selected, createLink, multiple, siteId } = this.props;
 
 		const classes = classNames( className );
 		const { search } = this.state;
@@ -65,6 +66,7 @@ export default React.createClass( {
 					selected={ selected }
 					createLink={ createLink }
 					multiple={ multiple }
+					siteId={ siteId }
 				/>
 			</div>
 		);

--- a/client/my-sites/term-tree-selector/terms.jsx
+++ b/client/my-sites/term-tree-selector/terms.jsx
@@ -20,7 +20,6 @@ import NoResults from './no-results';
 import Search from './search';
 import { decodeEntities } from 'lib/formatting';
 import QueryTerms from 'components/data/query-terms';
-import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	isRequestingTermsForQueryIgnoringPage,
 	getTermsLastPageForQuery,
@@ -85,7 +84,8 @@ const TermTreeSelectorList = React.createClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.taxonomy !== this.props.taxonomy ) {
+		if ( nextProps.taxonomy !== this.props.taxonomy ||
+				nextProps.siteId !== this.props.siteId ) {
 			this.setState( this.getInitialState() );
 		}
 	},
@@ -362,7 +362,7 @@ const TermTreeSelectorList = React.createClass( {
 
 		return (
 			<div ref={ this.setSelectorRef } className={ classes }>
-				{ this.state.requestedPages.map( ( page ) => (
+				{ siteId && this.state.requestedPages.map( ( page ) => (
 					<QueryTerms
 						key={ `query-${ page }` }
 						siteId={ siteId }
@@ -391,15 +391,13 @@ const TermTreeSelectorList = React.createClass( {
 } );
 
 export default connect( ( state, ownProps ) => {
-	const siteId = getSelectedSiteId( state );
-	const { taxonomy, query } = ownProps;
+	const { taxonomy, query, siteId } = ownProps;
 
 	return {
 		loading: isRequestingTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
 		terms: getTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
 		termsHierarchy: getTermsHierarchyForQueryIgnoringPage( state, siteId, taxonomy, query ),
 		lastPage: getTermsLastPageForQuery( state, siteId, taxonomy, query ),
-		siteId,
 		query
 	};
 } )( localize( TermTreeSelectorList ) );


### PR DESCRIPTION
Suggested in #5366 - this branch adds an example to devdocs.  Additionally while making this move, I moved away from getting the `siteId` via `getSelectedSiteId` in `term-tree-selector/terms.jsx`, and actually switched over to using the prop ( as the README says you should ).

This was necessary to make the devdocs example work, but also seems like the precedent used in the `PostSelector`, and it also fixes an issue reported by @aduth where an extra request happens to `/site/{ site }/terms` when switching sites in the menu builder.

__To Test__
- Open [menus](http://calypso.localhost:3000/menus/) for a site, validate you can set/update a menu target using the category accordion
- Open a new Portfolio in the editor for a site that has the portfolio CPT enabled. Verify that the "Portfolio Type" accordion displays the `TermTreeSelector` as expected
- View the new [TermTreeSelector Devdocs example](http://calypso.localhost:3000/devdocs/app-components/term-tree-selector)

Test live: https://calypso.live/?branch=add/term-tree-selector-example