### PR TITLE
TermTreeSelector: Apply fix for term-selector hierarchy.

### DIFF
--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -11,7 +11,6 @@ import {
 	getTerms,
 	getTermsForQuery,
 	getTermsForQueryIgnoringPage,
-	getTermsHierarchyForQueryIgnoringPage,
 	getTermsLastPageForQuery,
 	isRequestingTermsForQuery,
 	isRequestingTermsForQueryIgnoringPage
@@ -20,7 +19,7 @@ import {
 describe( 'selectors', () => {
 	beforeEach( () => {
 		getTermsForQuery.memoizedSelector.cache.clear();
-		getTermsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
+		getTermsForQueryIgnoringPage.memoizedSelector.cache.clear();
 	} );
 
 	describe( 'isRequestingTermsForQuery()', () => {
@@ -402,83 +401,6 @@ describe( 'selectors', () => {
 			}, 2916284, 'category', { search: 'unappetizing' } );
 
 			expect( lastPage ).to.equal( 1 );
-		} );
-	} );
-
-	describe( 'getTermsHierarchyForQueryIgnoringPage()', () => {
-		it( 'should return null if no matching query results exist', () => {
-			const terms = getTermsHierarchyForQueryIgnoringPage( {
-				terms: {
-					queries: {}
-				}
-			}, 2916284, 'category', {} );
-
-			expect( terms ).to.be.null;
-		} );
-
-		it( 'should return an empty array if no matches exist', () => {
-			const terms = getTermsHierarchyForQueryIgnoringPage( {
-				terms: {
-					queries: {
-						2916284: {
-							category: new TermQueryManager( {
-								items: {},
-								queries: {
-									'[["search","unappetizing"]]': {
-										itemKeys: [],
-										found: 0
-									}
-								}
-							} )
-						}
-					}
-				}
-			}, 2916284, 'category', { search: 'unappetizing' } );
-
-			expect( terms ).to.eql( [] );
-		} );
-
-		it( 'should return matching terms in hierarchical structure', () => {
-			const terms = getTermsHierarchyForQueryIgnoringPage( {
-				terms: {
-					queries: {
-						2916284: {
-							category: new TermQueryManager( {
-								items: {
-									111: {
-										ID: 111,
-										name: 'Chicken and a biscuit'
-									},
-									112: {
-										ID: 112,
-										name: 'Ribs',
-										parent: 111
-									}
-								},
-								queries: {
-									'[["search","i"]]': {
-										itemKeys: [ 111, 112 ],
-										found: 2
-									}
-								}
-							} )
-						}
-					}
-				}
-			}, 2916284, 'category', { search: 'i' } );
-
-			expect( terms ).to.eql( [
-				{
-					ID: 111,
-					name: 'Chicken and a biscuit',
-					parent: 0,
-					items: [ {
-						ID: 112,
-						name: 'Ribs',
-						parent: 111
-					} ]
-				}
-			] );
 		} );
 	} );
 

--- a/client/state/terms/test/utils.js
+++ b/client/state/terms/test/utils.js
@@ -8,7 +8,8 @@ import { expect } from 'chai';
  */
 import {
 	getNormalizedTermsQuery,
-	getSerializedTermsQuery
+	getSerializedTermsQuery,
+	getSerializedTermsQueryWithoutPage
 } from '../utils';
 
 describe( 'utils', () => {
@@ -42,6 +43,17 @@ describe( 'utils', () => {
 			} );
 
 			expect( serializedQuery ).to.equal( '{"search":"chicken","page":"2"}' );
+		} );
+	} );
+
+	describe( 'getSerializedTermsQueryWithoutPage()', () => {
+		it( 'should return a JSON string of a normalized query without page', () => {
+			const serializedQuery = getSerializedTermsQueryWithoutPage( {
+				search: 'Chicken',
+				page: '2'
+			} );
+
+			expect( serializedQuery ).to.equal( '{"search":"chicken"}' );
 		} );
 	} );
 } );

--- a/client/state/terms/utils.js
+++ b/client/state/terms/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import omitBy from 'lodash/omitBy';
+import { omit, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,4 +29,15 @@ export function getNormalizedTermsQuery( query ) {
 export function getSerializedTermsQuery( query = {} ) {
 	const normalizedQuery = getNormalizedTermsQuery( query );
 	return JSON.stringify( normalizedQuery ).toLocaleLowerCase();
+}
+
+/**
+ * Returns a serialized terms query, excluding any page parameter
+ *
+ * @param  {Object} query  Terms query
+ * @param  {Number} siteId Optional site ID
+ * @return {String}        Serialized terms query
+ */
+export function getSerializedTermsQueryWithoutPage( query, siteId ) {
+	return getSerializedTermsQuery( omit( query, 'page' ), siteId );
 }

--- a/client/state/terms/utils.js
+++ b/client/state/terms/utils.js
@@ -38,6 +38,6 @@ export function getSerializedTermsQuery( query = {} ) {
  * @param  {Number} siteId Optional site ID
  * @return {String}        Serialized terms query
  */
-export function getSerializedTermsQueryWithoutPage( query, siteId ) {
-	return getSerializedTermsQuery( omit( query, 'page' ), siteId );
+export function getSerializedTermsQueryWithoutPage( query ) {
+	return getSerializedTermsQuery( omit( query, 'page' ) );
 }


### PR DESCRIPTION
Pretty much a clone of the logic in #6617, so /ht to @aduth for the fix.  Much like the issue described there, given a heavily nested list of Terms, a case can arise in the `<TermTreeSelector />` where subsequent pages of terms are never properly requested.

__To Test__
To create the test scenario where this issue happens is a bit more difficult with terms as the default number returned in a page is 100.  As such, feel free to test with my test site `testingtimmy2` ( I think @nylen is a member of the site already ), by opening up a [new Project](http://calypso.localhost:3000/edit/jetpack-portfolio/testingtimmy2.wordpress.com) in the editor.

You can then watch the network tab to verify that two requests are made to the `terms` endpoint for the `jetpack-portfolio-type` taxonomy.  Much like #6617, it helps to see the breaking behavior first on `master` or `wpcalypso`, then test this branch out.

Test live: https://calypso.live/?branch=fix/term-tree-selector-hierarchy