### PR TITLE
Jetpack Connect: After authorize, redirect SSO users back to wp-admin

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -172,7 +172,19 @@ const LoggedInForm = React.createClass( {
 	},
 
 	componentWillReceiveProps( props ) {
-		const { siteReceived, isActivating } = props.jetpackConnectAuthorize;
+		const {
+			siteReceived,
+			isActivating,
+			queryObject,
+			isRedirectingToWpAdmin,
+			authorizeSuccess
+		} = props.jetpackConnectAuthorize;
+
+		// Always and forever redirect SSO to wp-admin.
+		if ( ! isRedirectingToWpAdmin && props.isSSO && authorizeSuccess ) {
+			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
+		}
+
 		if ( siteReceived && ! isActivating ) {
 			this.activateManage();
 		}


### PR DESCRIPTION
@simonwheatley reported that the redirect to wp-admin was broken after a user SSO'ed and went through the connection process.

After some testing, I narrowed down the issue to a refactor in #6634. It looks like the redirect was inadvertently removed when factoring out `isCalypsoStartedConnect`.

This PR fixes that.

To test:

- Checkout `update/fix-sso-redirect-after-authorize` branch
- Checkout `4.1.1` of Jetpack
- To test, your site should be connected, and you should not be using the same WP.com account that is tied to your master user
- Go to `$site/wp-admin` where `$site` is your Jetpack site
- Click "Log in with WordPress.com" button
- Approve SSO flow
- Verify that you land on the authorization flow
- Verify that you land back in wp-admin

Now, let's test regressions:

- Disconnect your site
- WP-CLI command is `wp jetpack disconnect blog`
- Go to `/jetpack/connect` in Calypso
- Enter in site URL
- Connect
- Verify that your site is authorized
- Verify that you land on plans page

cc @roccotripaldi or @lezama for code review

Test live: https://calypso.live/?branch=update/fix-sso-redirect-after-authorize