### PR TITLE
Purchases: Reduxify stored cards

### DIFF
--- a/client/components/data/query-stored-cards/index.jsx
+++ b/client/components/data/query-stored-cards/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isFetchingStoredCards } from 'state/stored-cards/selectors';
+import { hasLoadedStoredCardsFromServer, isFetchingStoredCards } from 'state/stored-cards/selectors';
 import { fetchStoredCards } from 'state/stored-cards/actions';
 
 class QueryStoredCards extends Component {
@@ -20,7 +20,7 @@ class QueryStoredCards extends Component {
 	}
 
 	requestStoredCards( props = this.props ) {
-		if ( ! props.isRequesting ) {
+		if ( ! props.isRequesting && ! props.hasLoadedFromServer ) {
 			props.fetchStoredCards();
 		}
 	}
@@ -38,6 +38,7 @@ QueryStoredCards.propTypes = {
 export default connect(
 	state => {
 		return {
+			hasLoadedFromServer: hasLoadedStoredCardsFromServer( state ),
 			isRequesting: isFetchingStoredCards( state )
 		};
 	},

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -12,7 +12,6 @@ var observe = require( 'lib/mixins/data-observe' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	config = require( 'config' ),
 	CreditCards = require( 'me/credit-cards' ),
-	storedCards = require( 'lib/stored-cards' )(),
 	eventRecorder = require( 'me/event-recorder' ),
 	PurchasesHeader = require( '../purchases/list/header' ),
 	BillingHistoryTable = require( './billing-history-table' ),
@@ -49,7 +48,7 @@ module.exports = React.createClass( {
 						</Card>
 					</div> }
 				{ config.isEnabled( 'upgrades/credit-cards' ) &&
-					<CreditCards cards={ storedCards } /> }
+					<CreditCards /> }
 			</Main>
 		);
 	}

--- a/client/me/credit-cards/credit-card-delete.jsx
+++ b/client/me/credit-cards/credit-card-delete.jsx
@@ -43,9 +43,6 @@ const CreditCardDelete = React.createClass( {
 		if ( response ) {
 			debug( 'Card deleted sucessfully' );
 			this.props.successNotice( this.translate( 'Card deleted successfully' ) );
-
-			// Update the list of cards
-			this.props.cards.fetch();
 		}
 	},
 

--- a/client/me/credit-cards/index.jsx
+++ b/client/me/credit-cards/index.jsx
@@ -35,7 +35,7 @@ var CreditCards = React.createClass( {
 		return this.props.cards.map( function( card ) {
 			return (
 				<div className="credit-cards_single-card" key={ card.stored_details_id }>
-					<CreditCardDelete card={ card } cards={ this.props.cards } />
+					<CreditCardDelete card={ card } />
 				</div>
 			);
 		}, this );

--- a/client/me/credit-cards/index.jsx
+++ b/client/me/credit-cards/index.jsx
@@ -1,28 +1,22 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:me:credit-cards' );
+var connect = require( 'react-redux' ).connect,
+	React = require( 'react' );
 
 /**
  * Internal dependencies
  */
 var CreditCardDelete = require( './credit-card-delete' ),
-	observe = require( 'lib/mixins/data-observe' ),
 	Card = require( 'components/card' ),
+	getStoredCards = require( 'state/stored-cards/selectors' ).getStoredCards,
+	isFetchingStoredCards = require( 'state/stored-cards/selectors' ).isFetchingStoredCards,
+	QueryStoredCards = require( 'components/data/query-stored-cards' ),
 	SectionHeader = require( 'components/section-header' );
 
-module.exports = React.createClass( {
-
-	displayName: 'CreditCards',
-
-	mixins: [ observe( 'cards' ) ],
-
+var CreditCards = React.createClass( {
 	renderCards: function() {
-		var cards = this.props.cards.get();
-
-		// Loading state
-		if ( ! this.props.cards.initialized ) {
+		if ( this.props.isFetchingStoredCards ) {
 			return (
 				<div className="credit-cards__no-results">
 					{ this.translate( 'Loading…' ) }
@@ -30,8 +24,7 @@ module.exports = React.createClass( {
 			);
 		}
 
-		// No cards
-		if ( ! cards.length ) {
+		if ( ! this.props.cards.length ) {
 			return (
 				<div className="credit-cards__no-results">
 					{ this.translate( 'You have no saved cards.' ) }
@@ -39,8 +32,7 @@ module.exports = React.createClass( {
 			);
 		}
 
-		// Show cards
-		return cards.map( function( card ) {
+		return this.props.cards.map( function( card ) {
 			return (
 				<div className="credit-cards_single-card" key={ card.stored_details_id }>
 					<CreditCardDelete card={ card } cards={ this.props.cards } />
@@ -50,10 +42,12 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		debug( 'Render credit cards' );
 		return (
 			<div>
+				<QueryStoredCards />
+
 				<SectionHeader label={ this.translate( 'Manage Your Credit Cards' ) } />
+
 				<Card>
 					<div className="credit-cards">
 						{ this.renderCards() }
@@ -63,3 +57,10 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+module.exports = connect(
+	state => ( {
+		cards: getStoredCards( state ),
+		isFetchingStoredCards: isFetchingStoredCards( state )
+	} )
+)( CreditCards );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -18,10 +18,11 @@ import jetpackConnect from './jetpack-connect/reducer';
 import jetpackSync from './jetpack-sync/reducer';
 import notices from './notices/reducer';
 import plans from './plans/reducer';
-import preview from './preview/reducer';
-import posts from './posts/reducer';
 import plugins from './plugins/reducer';
+import posts from './posts/reducer';
 import postTypes from './post-types/reducer';
+import preferences from './preferences/reducer';
+import preview from './preview/reducer';
 import pushNotifications from './push-notifications/reducer';
 import reader from './reader/reducer';
 import receipts from './receipts/reducer';
@@ -29,13 +30,13 @@ import sharing from './sharing/reducer';
 import sites from './sites/reducer';
 import siteSettings from './site-settings/reducer';
 import stats from './stats/reducer';
+import storedCards from './stored-cards/reducer';
 import support from './support/reducer';
 import terms from './terms/reducer';
 import themes from './themes/reducer';
 import ui from './ui/reducer';
 import users from './users/reducer';
 import wordads from './wordads/reducer';
-import preferences from './preferences/reducer';
 
 /**
  * Module variables
@@ -64,6 +65,7 @@ export const reducer = combineReducers( {
 	sites,
 	siteSettings,
 	stats,
+	storedCards,
 	support,
 	terms,
 	themes,

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -29,12 +29,35 @@ export const items = ( state = [], action ) => {
 	switch ( action.type ) {
 		case STORED_CARDS_FETCH_COMPLETED:
 			return action.list;
+
 		case STORED_CARDS_DELETE_COMPLETED:
 			return state.filter( item => item.stored_details_id !== action.card.stored_details_id );
+
 		// return initial state when serializing/deserializing
 		case SERIALIZE:
 		case DESERIALIZE:
 			return [];
+	}
+
+	return state;
+};
+
+/**
+ * Returns whether the list of stored cards has been loaded from the server in reaction to the specified action.
+ *
+ * @param {Array} state - current state
+ * @param {Object} action - action payload
+ * @return {Boolean} - updated state
+ */
+export const hasLoadedFromServer = ( state = false, action ) => {
+	switch ( action.type ) {
+		case STORED_CARDS_FETCH_COMPLETED:
+			return true;
+
+		// return initial state when serializing/deserializing
+		case SERIALIZE:
+		case DESERIALIZE:
+			return false;
 	}
 
 	return state;
@@ -52,9 +75,11 @@ export const isFetching = ( state = false, action ) => {
 	switch ( action.type ) {
 		case STORED_CARDS_FETCH:
 			return true;
+
 		case STORED_CARDS_FETCH_COMPLETED:
 		case STORED_CARDS_FETCH_FAILED:
 			return false;
+
 		// return initial state when serializing/deserializing
 		case SERIALIZE:
 		case DESERIALIZE:
@@ -76,9 +101,11 @@ export const isDeleting = ( state = false, action ) => {
 	switch ( action.type ) {
 		case STORED_CARDS_DELETE:
 			return true;
+
 		case STORED_CARDS_DELETE_FAILED:
 		case STORED_CARDS_DELETE_COMPLETED:
 			return false;
+
 		// return initial state when serializing/deserializing
 		case SERIALIZE:
 		case DESERIALIZE:
@@ -89,7 +116,8 @@ export const isDeleting = ( state = false, action ) => {
 };
 
 export default combineReducers( {
-	items,
+	hasLoadedFromServer,
+	isDeleting,
 	isFetching,
-	isDeleting
+	items
 } );

--- a/client/state/stored-cards/selectors.js
+++ b/client/state/stored-cards/selectors.js
@@ -16,4 +16,6 @@ export const getStoredCardById = ( state, cardId ) => (
 	getStoredCards( state ).filter( card => card.stored_details_id === cardId ).shift()
 );
 
+export const hasLoadedStoredCardsFromServer = state => state.storedCards.hasLoadedFromServer;
+
 export const isFetchingStoredCards = state => state.storedCards.isFetching;

--- a/client/state/stored-cards/selectors.js
+++ b/client/state/stored-cards/selectors.js
@@ -4,7 +4,7 @@
  * @param {Object} state - current state object
  * @return {Array} Stored Cards
  */
-export const getCards = state => state.storedCards.items;
+export const getStoredCards = state => state.storedCards.items;
 
 /**
  * Returns a Stored Card
@@ -12,8 +12,8 @@ export const getCards = state => state.storedCards.items;
  * @param  {Number} cardId  the card id
  * @return {Object} the matching card if there is one
  */
-export const getByCardId = ( state, cardId ) => (
-	getCards( state ).filter( card => card.stored_details_id === cardId ).shift()
+export const getStoredCardById = ( state, cardId ) => (
+	getStoredCards( state ).filter( card => card.stored_details_id === cardId ).shift()
 );
 
 export const isFetchingStoredCards = state => state.storedCards.isFetching;

--- a/client/state/stored-cards/test/reducer.js
+++ b/client/state/stored-cards/test/reducer.js
@@ -23,7 +23,8 @@ describe( 'items', () => {
 		expect( reducer( undefined, { type: 'UNRELATED' } ) ).to.be.eql( {
 			items: [],
 			isFetching: false,
-			isDeleting: false
+			isDeleting: false,
+			hasLoadedFromServer: false
 		} );
 	} );
 
@@ -31,7 +32,8 @@ describe( 'items', () => {
 		expect( reducer( undefined, { type: STORED_CARDS_FETCH } ) ).to.be.eql( {
 			items: [],
 			isFetching: true,
-			isDeleting: false
+			isDeleting: false,
+			hasLoadedFromServer: false
 		} );
 	} );
 
@@ -44,7 +46,8 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: false
+			isDeleting: false,
+			hasLoadedFromServer: true
 		} );
 	} );
 
@@ -56,7 +59,8 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: [],
 			isFetching: false,
-			isDeleting: false
+			isDeleting: false,
+			hasLoadedFromServer: false
 		} );
 	} );
 
@@ -64,7 +68,8 @@ describe( 'items', () => {
 		const state = reducer( deepFreeze( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: false
+			isDeleting: false,
+			hasLoadedFromServer: true
 		} ), {
 			type: STORED_CARDS_DELETE,
 			card: STORED_CARDS_FROM_API[ 0 ]
@@ -73,7 +78,8 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: true
+			isDeleting: true,
+			hasLoadedFromServer: true
 		} );
 	} );
 
@@ -81,7 +87,8 @@ describe( 'items', () => {
 		const state = reducer( deepFreeze( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: true
+			isDeleting: true,
+			hasLoadedFromServer: true
 		} ), {
 			type: STORED_CARDS_DELETE_COMPLETED,
 			card: STORED_CARDS_FROM_API[ 0 ]
@@ -90,7 +97,8 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: [ STORED_CARDS_FROM_API[ 1 ] ],
 			isFetching: false,
-			isDeleting: false
+			isDeleting: false,
+			hasLoadedFromServer: true
 		} );
 	} );
 
@@ -98,7 +106,8 @@ describe( 'items', () => {
 		const state = reducer( deepFreeze( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: true
+			isDeleting: true,
+			hasLoadedFromServer: true
 		} ), {
 			type: STORED_CARDS_DELETE_FAILED
 		} );
@@ -106,7 +115,8 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: false
+			isDeleting: false,
+			hasLoadedFromServer: true
 		} );
 	} );
 } );

--- a/client/state/stored-cards/test/selectors.js
+++ b/client/state/stored-cards/test/selectors.js
@@ -3,14 +3,15 @@ import deepFreeze from 'deep-freeze';
 import { expect } from 'chai';
 
 // Internal dependencies
-import { getStoredCardById, getStoredCards } from '../selectors';
+import { getStoredCardById, getStoredCards, hasLoadedStoredCardsFromServer } from '../selectors';
 import { STORED_CARDS_FROM_API } from './fixture';
 
 describe( 'selectors', () => {
 	describe( 'getStoredCards', () => {
-		it( 'should return a purchase by its ID, preserving the top-level flags', () => {
+		it( 'should return all cards', () => {
 			const state = deepFreeze( {
 				storedCards: {
+					hasLoadedFromServer: true,
 					isFetching: false,
 					isDeleting: false,
 					items: STORED_CARDS_FROM_API
@@ -22,9 +23,10 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getStoredCardById', () => {
-		it( 'should return a purchase by its ID, preserving the top-level flags', () => {
+		it( 'should return a card by its ID, preserving the top-level flags', () => {
 			const state = deepFreeze( {
 				storedCards: {
+					hasLoadedFromServer: true,
 					isFetching: false,
 					isDeleting: false,
 					items: STORED_CARDS_FROM_API
@@ -32,6 +34,21 @@ describe( 'selectors', () => {
 			} );
 
 			expect( getStoredCardById( state, 12345 ) ).to.be.eql( STORED_CARDS_FROM_API[ 1 ] );
+		} );
+	} );
+
+	describe( 'hasLoadedStoredCardsFromServer', () => {
+		it( 'should return the flag that determines whether the list of cards has been loaded from the server', () => {
+			const state = deepFreeze( {
+				storedCards: {
+					hasLoadedFromServer: true,
+					isFetching: false,
+					isDeleting: false,
+					items: STORED_CARDS_FROM_API
+				}
+			} );
+
+			expect( hasLoadedStoredCardsFromServer( state ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/stored-cards/test/selectors.js
+++ b/client/state/stored-cards/test/selectors.js
@@ -3,11 +3,11 @@ import deepFreeze from 'deep-freeze';
 import { expect } from 'chai';
 
 // Internal dependencies
-import { getCards, getByCardId } from '../selectors';
+import { getStoredCardById, getStoredCards } from '../selectors';
 import { STORED_CARDS_FROM_API } from './fixture';
 
 describe( 'selectors', () => {
-	describe( 'getCards', () => {
+	describe( 'getStoredCards', () => {
 		it( 'should return a purchase by its ID, preserving the top-level flags', () => {
 			const state = deepFreeze( {
 				storedCards: {
@@ -17,11 +17,11 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			expect( getCards( state ) ).to.be.eql( STORED_CARDS_FROM_API );
+			expect( getStoredCards( state ) ).to.be.eql( STORED_CARDS_FROM_API );
 		} );
 	} );
 
-	describe( 'getByCardId', () => {
+	describe( 'getStoredCardById', () => {
 		it( 'should return a purchase by its ID, preserving the top-level flags', () => {
 			const state = deepFreeze( {
 				storedCards: {
@@ -31,7 +31,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			expect( getByCardId( state, 12345 ) ).to.be.eql( STORED_CARDS_FROM_API[ 1 ] );
+			expect( getStoredCardById( state, 12345 ) ).to.be.eql( STORED_CARDS_FROM_API[ 1 ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/6613 and https://github.com/Automattic/wp-calypso/pull/6628 that removes the [Flux store](https://github.com/Automattic/wp-calypso/tree/master/client/lib/stored-cards) that handles credit cards stored during previous purchases, or when a user added a new payment method for a specific purchase. This data is used on the `Secure Payment` page in the checkout as well as on the `Billing History` page:

##### Secure Payment

![screenshot](https://cloud.githubusercontent.com/assets/594356/16713694/ffa58768-46af-11e6-8ce7-6fbff038bdfd.png)


##### Billing History

![screenshot](https://cloud.githubusercontent.com/assets/594356/16713691/f7e02984-46af-11e6-8ded-60407c9cdfa8.png)

##### Manage Purchase

#### Testing instructions
 
You may want to keep an eye on your browser's console to check that no error is thrown while testing.
 
1. Run `git checkout update/reduxify-stored-cards` and start your server, or open a [live branch](https://calypso.live/?branch=update/reduxify-stored-cards)
2. Sandbox the store
3. Purchase a [premium theme](http://calypso.localhost:3000/design), a [plan](http://calypso.localhost:3000/plans), or a [site redirect](http://calypso.localhost:3000/domains/add/site-redirect) with a fake credit card
4. Open the [`Billing History` page](http://calypso.localhost:3000/me/billing)
5. Check that you can see the card with the right information in the `Manage Your Credit Cards` section
6. Add another purchase to your shopping cart and head to checkout
7. Check that you can see the previous credit card on the `Secure Payment` page
8. Enter a new fake credit card and click the `Pay` button
9. Repeat steps #4 to #5
10. Click the `Delete` button next to any stored card on the `Billing History` page
11. Check that the card is deleted successfully
12. Head to the [`Purchases` page](http://calypso.localhost:3000/purchases)
13. Click any purchase other than the ones that never expire
14. Click on the `Edit Payment Method` action
15. Enter a new fake credit card and click the `Save Card` button
16. Check that you are redirected back to the `Manage Purchase` page with a success message
17. Check that you can see this new card on the `Billing History` page

You could check there is no side effect by testing different payment methods, or any other kind of purchases. You may want to keep an eye on the Redux actions triggered as well.
 
#### Reviews
 
- [ ] Code
- [ ] Product
- [ ] Tests
 
@Automattic/sdev-feed