### PR TITLE
Jetpack auth button

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -27,6 +27,7 @@ import userUtilities from 'lib/user/utils';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
+import Gridicon from 'components/gridicon';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteByUrl } from 'state/sites/selectors';
@@ -361,6 +362,7 @@ const LoggedInForm = React.createClass( {
 			'&_wp_nonce=' + encodeURIComponent( _wp_nonce );
 		const backToWpAdminLink = (
 			<LoggedOutFormLinkItem icon={ true } href={ redirect_after_auth }>
+				<Gridicon size={ 18 } icon="arrow-left" />
 				{ this.translate( 'Return to %(sitename)s', {
 					args: { sitename: decodeEntities( blogname ) }
 				} ) }

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -20,6 +20,7 @@ import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import config from 'config';
 import { createAccount, authorize, goBackToWpAdmin, activateManage } from 'state/jetpack-connect/actions';
+import { isCalypsoStartedConnection } from 'state/jetpack-connect/selectors';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import observe from 'lib/mixins/data-observe';
 import userUtilities from 'lib/user/utils';
@@ -37,6 +38,8 @@ import versionCompare from 'lib/version-compare';
 import EmptyContent from 'components/empty-content';
 import safeImageUrl from 'lib/safe-image-url';
 import Button from 'components/button';
+import { requestSites } from 'state/sites/actions';
+import { isRequestingSites } from 'state/sites/selectors';
 
 /**
  * Constants
@@ -165,9 +168,12 @@ const LoggedInForm = React.createClass( {
 	componentWillMount() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 		this.props.recordTracksEvent( 'calypso_jpc_auth_view' );
-		if ( ! this.props.isAlreadyOnSitesList && ! queryObject.already_authorized ) {
+		if ( ! this.props.isAlreadyOnSitesList &&
+			! queryObject.already_authorized &&
+			( this.props.calypsoStartedConnection || this.props.isSSO )
+		) {
 			debug( 'Authorizing automatically on component mount' );
-			this.props.authorize( queryObject );
+			return this.props.authorize( queryObject );
 		}
 	},
 
@@ -294,6 +300,10 @@ const LoggedInForm = React.createClass( {
 			return this.translate( 'Try again' );
 		}
 
+		if ( this.props.isFetchingSites() ) {
+			return this.translate( 'Preparing authorization' );
+		}
+
 		if ( this.props.isAlreadyOnSitesList || siteReceived ) {
 			return this.translate( 'Browse Available Upgrades' );
 		}
@@ -385,7 +395,7 @@ const LoggedInForm = React.createClass( {
 
 	renderStateAction() {
 		const { authorizeSuccess, siteReceived } = this.props.jetpackConnectAuthorize;
-		if ( this.isAuthorizing() || ( authorizeSuccess && ! siteReceived ) ) {
+		if ( this.props.isFetchingSites() || this.isAuthorizing() || ( authorizeSuccess && ! siteReceived ) ) {
 			return (
 				<div className="jetpack-connect-logged-in-form__loading">
 					<span>{ this.getButtonText() }</span> <Spinner size={ 20 } duration={ 3000 } />
@@ -452,10 +462,14 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		const props = Object.assign( {}, this.props, {
 			user: user
 		} );
+		const calypsoStartedConnection = isCalypsoStartedConnection(
+			this.props.jetpackConnectSessions,
+			this.props.jetpackConnectAuthorize.queryObject.site
+		);
 
 		return (
 			( user )
-				? <LoggedInForm { ...props } isSSO={ this.isSSO() } />
+				? <LoggedInForm { ...props } calypsoStartedConnection={ calypsoStartedConnection } isSSO={ this.isSSO() } />
 				: <LoggedOutForm { ...props } isSSO={ this.isSSO() } />
 		);
 	},
@@ -478,16 +492,20 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 export default connect(
 	state => {
 		const site = state.jetpackConnect.jetpackConnectAuthorize &&
-			state.jetpackConnect.jetpackConnectAuthorize.queryObject &&
-			state.jetpackConnect.jetpackConnectAuthorize.queryObject.site
+				state.jetpackConnect.jetpackConnectAuthorize.queryObject &&
+				state.jetpackConnect.jetpackConnectAuthorize.queryObject.site
 			? getSiteByUrl( state, state.jetpackConnect.jetpackConnectAuthorize.queryObject.site )
 			: null;
+		const isFetchingSites = () => {
+			return isRequestingSites( state );
+		};
 		return {
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
 			jetpackSSOSessions: state.jetpackConnect.jetpackSSOSessions,
 			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions,
-			isAlreadyOnSitesList: !! site
+			isAlreadyOnSitesList: !! site,
+			isFetchingSites
 		};
 	},
-	dispatch => bindActionCreators( { recordTracksEvent, authorize, createAccount, activateManage, goBackToWpAdmin }, dispatch )
+	dispatch => bindActionCreators( { requestSites, recordTracksEvent, authorize, createAccount, activateManage, goBackToWpAdmin }, dispatch )
 )( JetpackConnectAuthorizeForm );

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -27,7 +27,6 @@ import userUtilities from 'lib/user/utils';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
-import Gridicon from 'components/gridicon';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteByUrl } from 'state/sites/selectors';
@@ -356,12 +355,15 @@ const LoggedInForm = React.createClass( {
 
 	renderFooterLinks() {
 		const { queryObject, authorizeSuccess, isAuthorizing } = this.props.jetpackConnectAuthorize;
+		const { blogname, redirect_after_auth, _wp_nonce } = queryObject;
 		const loginUrl = config( 'login_url' ) +
 			'?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) +
-			'&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
+			'&_wp_nonce=' + encodeURIComponent( _wp_nonce );
 		const backToWpAdminLink = (
-			<LoggedOutFormLinkItem icon={ true } href={ queryObject.redirect_after_auth }>
-				{ this.translate( 'Cancel and go back to my site' ) } <Gridicon size={ 18 } icon="external" />
+			<LoggedOutFormLinkItem icon={ true } href={ redirect_after_auth }>
+				{ this.translate( 'Return to %(sitename)s', {
+					args: { sitename: decodeEntities( blogname ) }
+				} ) }
 			</LoggedOutFormLinkItem>
 		);
 
@@ -507,5 +509,10 @@ export default connect(
 			isFetchingSites
 		};
 	},
-	dispatch => bindActionCreators( { requestSites, recordTracksEvent, authorize, createAccount, activateManage, goBackToWpAdmin }, dispatch )
+	dispatch => bindActionCreators( { requestSites,
+		recordTracksEvent,
+		authorize,
+		createAccount,
+		activateManage,
+		goBackToWpAdmin }, dispatch )
 )( JetpackConnectAuthorizeForm );

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -1,3 +1,18 @@
+const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // an hour
+
+const isCalypsoStartedConnection = function( state, siteSlug ) {
+	if ( ! siteSlug ) {
+		return false;
+	}
+	const site = siteSlug.replace( /.*?:\/\//g, '' );
+	if ( state && state[ site ] ) {
+		const currentTime = ( new Date() ).getTime();
+		return ( currentTime - state[ site ].timestamp < JETPACK_CONNECT_TTL );
+	}
+
+	return false;
+};
+
 const getFlowType = function( state, site ) {
 	const siteSlug = site.slug.replace( /.*?:\/\//g, '' );
 	if ( state && state[ siteSlug ] ) {
@@ -6,4 +21,4 @@ const getFlowType = function( state, site ) {
 	return false;
 };
 
-export default { getFlowType };
+export default { isCalypsoStartedConnection, getFlowType };


### PR DESCRIPTION
closes https://github.com/Automattic/wp-calypso/issues/6399

We need to get ready for the main jetpack authorization flow to be redirected to the new JPC auth screen. This PR adds the changes we need to ask for authorization once they land in the auth screen, before doing the proper auth dance from calypso. It also makes sure that you get redirected back to your wp-admin if you started there and you choose the free jetpack plan.

![image](https://cloud.githubusercontent.com/assets/1554855/16729871/905942d0-476f-11e6-9a86-d157df0f1dbf.png)

Video of the process (a little slow, my sandbox is not being very fast today):
https://cloudup.com/cqIiXoBnx4Q

How to test
========
1. You need a jetpack sandbox running an unconnected >= 4.1 jetpack and pointing to your .com sandbox
2. Modify your .com sandbox so it redirects the jetpack auth requests to calypso no matter what (ask me or @roccotripaldi on slack how to do it)
3. Clear the indexedDb on your browser
4. Go to your site and connect jetpack. You should see the approve button once you land in calypso. After clicking on it, it should authorize your site and you should land at the plans selection screen
5. Click on the free plan button. You should be taken back to your wp-admin

ping @roccotripaldi  for testing and @richardmuscat & @rickybanister for UX 

Test live: https://calypso.live/?branch=add/jetpack-confirmation-button