### PR TITLE
Refactored site-title to be a proper redux middleware

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -46,7 +46,6 @@ var config = require( 'config' ),
 	setRouteAction = require( 'state/ui/actions' ).setRoute,
 	accessibleFocus = require( 'lib/accessible-focus' ),
 	TitleStore = require( 'lib/screen-title/store' ),
-	bindTitleToStore = require( 'lib/screen-title' ).subscribeToStore,
 	syncHandler = require( 'lib/wp/sync-handler' ),
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
@@ -196,7 +195,6 @@ function reduxStoreReady( reduxStore ) {
 		isIsomorphic = isSectionIsomorphic( reduxStore.getState() );
 
 	bindWpLocaleState( reduxStore );
-	bindTitleToStore( reduxStore );
 
 	supportUser.setReduxStore( reduxStore );
 

--- a/client/lib/screen-title/README.md
+++ b/client/lib/screen-title/README.md
@@ -1,5 +1,4 @@
 Screen Title
 ============
 
-Get and set the title of the current screen and automatically update the &lt;title&gt; element.
-
+Provides actions and a store for getting and setting the title of the current screen and automatically updating the &lt;title&gt; element, as well as middleware for dispatching screen title changes with Redux actions.

--- a/client/lib/screen-title/index.js
+++ b/client/lib/screen-title/index.js
@@ -19,26 +19,24 @@ const TITLE_UPDATING_ACTIONS = [
 ];
 
 /**
- * Given a Redux store instance, subscribes to the store, updating the page
+ * A middleware that updating the page
  * when the title state changes. Currently, this dispatches through the legacy
  * Flux actions used elsewhere in the codebase.
  *
  * @param {Object} store Redux store instance
+ * @returns {Function} A configured middleware with store
  */
-export function subscribeToStore( store ) {
-	const dispatch = store.dispatch;
-	store.dispatch = function( action ) {
-		dispatch( ...arguments );
+export const screenTitleMiddleware = store => next => action => {
+	if ( action && includes( TITLE_UPDATING_ACTIONS, action.type ) ) {
+		const state = store.getState();
+		const { title, unreadCount } = state.documentHead;
+		const siteId = getSelectedSiteId( state );
 
-		if ( action && includes( TITLE_UPDATING_ACTIONS, action.type ) ) {
-			const state = store.getState();
-			const { title, unreadCount } = state.documentHead;
-			const siteId = getSelectedSiteId( state );
+		legacySetTitle( title, {
+			siteID: siteId,
+			count: unreadCount
+		} );
+	}
 
-			legacySetTitle( title, {
-				siteID: siteId,
-				count: unreadCount
-			} );
-		}
-	};
-}
+	return next( action );
+};

--- a/client/lib/screen-title/index.js
+++ b/client/lib/screen-title/index.js
@@ -19,9 +19,9 @@ const TITLE_UPDATING_ACTIONS = [
 ];
 
 /**
- * A middleware that updating the page
- * when the title state changes. Currently, this dispatches through the legacy
- * Flux actions used elsewhere in the codebase.
+ * Middleware that updates the screen title when a title updating action is
+ * dispatched. Currently, this dispatches through the legacy Flux actions used
+ * elsewhere in the codebase.
  *
  * @param {Object} store Redux store instance
  * @returns {Function} A configured middleware with store

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -77,6 +77,7 @@ let middleware = [ thunkMiddleware ];
 // Analytics middleware currently only works in the browser
 if ( typeof window === 'object' ) {
 	middleware = [
+		require( 'lib/screen-title' ).screenTitleMiddleware,
 		...middleware,
 		require( './analytics/middleware.js' ).analyticsMiddleware
 	];


### PR DESCRIPTION
Currently `site-title` monkey patching redux store's `dispatch` method and looses
`dispatch` result.

That PR solves that by making it a proper redux middleware.

#### Testing instructions
  
1. Run `git checkout update/screen-title-middleware` and start your server, or open a [live branch](https://calypso.live/?branch=update/screen-title-middleware)
2. Go to page that uses `DocumentHead` element (redux state document titles), for example the [edit post page page](http://calypso.localhost:3000/post/)
3. Titles should work and vary `New` for a new post, `Edit Post` for existing post edit.
  
#### Reviews
  
- [x] Code
- [x] Product
- [x] Tests
   
@Automattic/sdev-feed
