### PR TITLE
Plans Redesign: domains and google analytics should use wide layout with new plans page

### DIFF
--- a/client/components/main/index.jsx
+++ b/client/components/main/index.jsx
@@ -3,17 +3,22 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
-module.exports = React.createClass( {
-	displayName: 'Main',
+export default function Main( {
+	className,
+	children,
+	wideLayout = false
+} ) {
+	const classes = classNames( className, 'main', {
+		'is-wide-layout': wideLayout
+	} );
 
-	render: function() {
-		return (
-			<main className={ classnames( this.props.className, 'main' ) } role="main">
-				{ this.props.children }
-			</main>
-		);
-	}
-} );
+	return (
+		<main className={ classes } role="main">
+			{ children }
+		</main>
+	);
+}
+

--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -31,6 +31,7 @@ import {
 import Gridicon from 'components/gridicon';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlansNavigation from 'my-sites/upgrades/navigation';
+import config from 'config';
 
 const PlanDetailsComponent = React.createClass( {
 	PropTypes: {
@@ -47,6 +48,7 @@ const PlanDetailsComponent = React.createClass( {
 	render: function() {
 		const { selectedSite } = this.props;
 		const { hasLoadedFromServer } = this.props.sitePlans;
+		const showPlanFeatures = config.isEnabled( 'manage/plan-features' );
 		let title;
 		let tagLine;
 		let featuresList;
@@ -94,7 +96,8 @@ const PlanDetailsComponent = React.createClass( {
 			);
 		} else if ( isBusiness( selectedSite.plan ) ) {
 			title = this.translate( 'Your site is on a Business plan' );
-			tagLine = this.translate( 'Learn more about everything included with Business and take advantage of its professional features.' );
+			tagLine = this.translate( 'Learn more about everything included with Business and take advantage of' +
+				' its professional features.' );
 			featuresList = ( <div>
 				<BusinessPlanDetails
 					selectedSite={ selectedSite }
@@ -108,7 +111,10 @@ const PlanDetailsComponent = React.createClass( {
 		}
 
 		return (
-			<Main className="current-plan">
+			<Main
+				className="current-plan"
+				wideLayout={ !! showPlanFeatures }
+			>
 				<PlansNavigation
 					sitePlans={ this.props.sitePlans }
 					path={ this.props.context.path }
@@ -122,11 +128,17 @@ const PlanDetailsComponent = React.createClass( {
 							</span>
 
 							<div className="current-plan__header-copy">
-								<h1 className={ classNames( { 'current-plan__header-heading': true, 'is-placeholder': ! hasLoadedFromServer } ) }>
+								<h1 className={ classNames( {
+									'current-plan__header-heading': true,
+									'is-placeholder': ! hasLoadedFromServer
+								} ) }>
 									{ title }
 								</h1>
 
-								<h2 className={ classNames( { 'current-plan__header-text': true, 'is-placeholder': ! hasLoadedFromServer } ) }>
+								<h2 className={ classNames( {
+									'current-plan__header-text': true,
+									'is-placeholder': ! hasLoadedFromServer
+								} ) }>
 									{ tagLine }
 								</h2>
 							</div>
@@ -150,16 +162,19 @@ const PlanDetailsComponent = React.createClass( {
 	}
 } );
 
-export default connect( ( state, ownProps ) => {
+export default connect(
+	( state, ownProps ) => {
 		return {
 			selectedSite: getSelectedSite( state ),
 			sitePlans: getPlansBySite( state, getSelectedSite( state ) ),
 			context: ownProps.context
 		};
 	},
+
 	dispatch => ( {
 		fetchSitePlans: siteId => dispatch( fetchSitePlans( siteId ) )
 	} ),
+
 	( stateProps, dispatchProps ) => {
 		function fetchPlans( props = stateProps ) {
 			if (

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -107,7 +107,11 @@ const Plans = React.createClass( {
 		}
 
 		return (
-			<a href={ plansLink( '/plans', selectedSite, intervalType ) } className="show-monthly-plans-link" onClick={ this.recordComparePlansClick }>
+			<a 
+				href={ plansLink( '/plans', selectedSite, intervalType ) }
+				className="show-monthly-plans-link"
+				onClick={ this.recordComparePlansClick }
+			>
 				<Gridicon icon="refresh" size={ 18 } />
 				{ showString }
 			</a>
@@ -154,16 +158,16 @@ const Plans = React.createClass( {
 			);
 		}
 
-		if ( showPlanFeatures ) {
-			mainClassNames[ 'is-wide-layout' ] = true;
-		}
-		mainClassNames[ 'has-personal-plan' ] = personalPlanTestEnabled;
+		mainClassNames[ 'has-personal-plan' ] = ! showPlanFeatures && personalPlanTestEnabled;
 
 		return (
 			<div>
 				{ this.renderNotice() }
 
-				<Main className={ mainClassNames }>
+				<Main
+					className={ mainClassNames }
+					wideLayout={ !! showPlanFeatures }
+				>
 					<SidebarNavigation />
 
 					<div id="plans" className="plans has-sidebar">

--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import {
 	getSelectedDomain,
 	hasMappedDomain
 } from 'lib/domains';
+import config from 'config';
 
 const Email = React.createClass( {
 	propTypes: {
@@ -41,8 +43,14 @@ const Email = React.createClass( {
 	},
 
 	render() {
+		const showPlanFeatures = config.isEnabled( 'manage/plan-features' );
+
+		const classes = classNames( 'domain-management-email', {
+			'is-wide-layout': showPlanFeatures
+		} );
+
 		return (
-			<Main className="domain-management-email">
+			<Main className={ classes }>
 				<SidebarNavigation />
 				{ this.headerOrUpgradesNavigation() }
 				{ this.content() }
@@ -74,7 +82,7 @@ const Email = React.createClass( {
 			return <Placeholder />;
 		}
 
-		let domainList = this.props.selectedDomainName
+		const domainList = this.props.selectedDomainName
 			? [ getSelectedDomain( this.props ) ]
 			: this.props.domains.list;
 
@@ -100,7 +108,7 @@ const Email = React.createClass( {
 				line: this.translate( 'Only domains registered with WordPress.com are eligible for Google Apps.' ),
 				secondaryAction: this.translate( 'Add Email Forwarding' ),
 				secondaryActionURL: paths.domainManagementEmailForwarding( selectedSite.slug, selectedDomainName )
-			}
+			};
 		} else if ( hasMappedDomain( domains.list ) ) {
 			emptyContentProps = {
 				title: this.translate( 'Google Apps is not supported on mapped domains' ),
@@ -123,7 +131,7 @@ const Email = React.createClass( {
 		} );
 
 		return (
-			<EmptyContent {...emptyContentProps } />
+			<EmptyContent { ...emptyContentProps } />
 		);
 	},
 

--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import page from 'page';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -45,12 +44,11 @@ const Email = React.createClass( {
 	render() {
 		const showPlanFeatures = config.isEnabled( 'manage/plan-features' );
 
-		const classes = classNames( 'domain-management-email', {
-			'is-wide-layout': showPlanFeatures
-		} );
-
 		return (
-			<Main className={ classes }>
+			<Main
+				className="domain-management-email"
+				wideLayout={ !! showPlanFeatures }
+			>
 				<SidebarNavigation />
 				{ this.headerOrUpgradesNavigation() }
 				{ this.content() }

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import times from 'lodash/times';
 import findIndex from 'lodash/findIndex';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -93,16 +92,12 @@ export const List = React.createClass( {
 
 		const showPlanFeatures = config.isEnabled( 'manage/plan-features' );
 
-		const classes = classNames( 'domain-management-list', {
-			'is-wide-layout': showPlanFeatures
-		} );
-
 		if ( ! this.props.domains ) {
 			return null;
 		}
 
 		return (
-			<Main className={ classes }>
+			<Main wideLayout={ !! showPlanFeatures }>
 				<SidebarNavigation />
 				<UpgradesNavigation
 					path={ this.props.context.path }

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import times from 'lodash/times';
 import findIndex from 'lodash/findIndex';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -88,14 +89,20 @@ export const List = React.createClass( {
 	},
 
 	render() {
-		var headerText = this.translate( 'Domains', { context: 'A navigation label.' } );
+		const headerText = this.translate( 'Domains', { context: 'A navigation label.' } );
+
+		const showPlanFeatures = config.isEnabled( 'manage/plan-features' );
+
+		const classes = classNames( 'domain-management-list', {
+			'is-wide-layout': showPlanFeatures
+		} );
 
 		if ( ! this.props.domains ) {
 			return null;
 		}
 
 		return (
-			<Main className="domain-management-list">
+			<Main className={ classes }>
 				<SidebarNavigation />
 				<UpgradesNavigation
 					path={ this.props.context.path }


### PR DESCRIPTION
Fixes #6298. Redesigned `/plans` page has wide layout (`1040px`). Let's add the wide layout to the `/domains/manage` and `/domains/manage/email` pages too.

## Testing Instructions
1. Run Calypso with `ENABLE_FEATURES=manage/plan-features make run`;
2. Navigate to `/plans` and notice the wide layout;
3. Click on Domains in the top navigation — does it have the same (wide) layout as on `/plans`?
4. Check the same for the Google Apps tab.

## Screenshots

![selection_026](https://cloud.githubusercontent.com/assets/4988512/16735745/88334a86-478a-11e6-95c2-077ac60347f8.jpg)

![selection_027](https://cloud.githubusercontent.com/assets/4988512/16735747/8a175716-478a-11e6-8682-3c925204a8a9.jpg)


cc @gwwar @mtias 

Test live: https://calypso.live/?branch=fix/domains-analytics-wide-layout