### PR TITLE
Jetpack Plans: Switch “Continue” link to the new My Plans page

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -398,7 +398,7 @@ const PlansSetup = React.createClass( {
 		const noticeText = this.translate( 'We\'ve installed your plugins, your site is powered up!' );
 		return (
 			<Notice status="is-success" text={ noticeText } showDismiss={ false }>
-				<NoticeAction href={ `/stats/insights/${site.slug}` }>
+				<NoticeAction href={ `/plans/my-plan/${site.slug}` }>
 					{ this.translate( 'Continue' ) }
 				</NoticeAction>
 			</Notice>


### PR DESCRIPTION
After connecting Jetpack, purchasing a plan, and setting up their plugins, we want to direct users to the My Plan page.

To test:

1. Start the autoconfig process on a paid Jetpack site: `/plugins/setup/$site`
2. Wait for it to finish successfully
3. Click "Continue" & you should be directed to a "My Plan" page

Fixes #5892

cc @johnHackworth @rickybanister 

Test live: https://calypso.live/?branch=update/autoconfig-finish-link