### PR TITLE
Site Settings: Rollback API version from 1.2 to 1.1

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -289,7 +289,7 @@ Undocumented.prototype.settings = function( siteId, method, data, fn ) {
 	}
 
 	const path = `/sites/${ siteId }/settings`;
-	const params = { apiVersion: '1.2' };
+	const params = { apiVersion: '1.1' };
 
 	if ( 'get' === method ) {
 		this.wpcom.req.get( path , params, fn );


### PR DESCRIPTION
In #3360, we began making calls to the `v1.2` version of the site settings endpoint. The issue with this is that Jetpack wasn't ready.

We added the `v1.2` endpoint files in #3503, but unfortunately, we didn't add the definitions for the `v1.2` endpoints to the `json-endpoints.php` file. This means that current version of Jetpack are not aware of the `v1.2` endpoints, and thus a `resource_not_found` error is returned.

We have a fix for the Jetpack side in Automattic/jetpack#4366, but the Calypso side will need to be downgraded to `v1.1` for now until Jetpack catches up.

In the future, before we flip the switch on upgrading to `v1.2`, we should address how to handle sites that are on `< Jetpack 4.2` (assuming the fix goes in Jetpack 4.2). 

To test:

- Checkout `update/site-settings-rollback` branch
- Go to `/settings/general/$site` where `$site` is a Jetpack site
- Verify that you don't see a red error notice
- Verify that you can load and save settings for sites

cc @yoavf @gravityrail @lezama for code review and testing.