### PR TITLE
Purchases: Use the assembler to construct cards objects

### DIFF
--- a/client/lib/stored-cards/assembler.js
+++ b/client/lib/stored-cards/assembler.js
@@ -1,0 +1,22 @@
+function createStoredCard( card ) {
+	return {
+		id: Number( card.stored_details_id ),
+		expiry: card.expiry,
+		number: Number( card.card ),
+		type: card.card_type,
+		name: card.name
+	};
+}
+
+function createStoredCardsArray( dataTransferObject ) {
+	if ( ! Array.isArray( dataTransferObject ) ) {
+		return [];
+	}
+
+	return dataTransferObject.map( createStoredCard );
+}
+
+export default {
+	createStoredCardsArray,
+	createStoredCard
+};

--- a/client/lib/stored-cards/test/assembler.js
+++ b/client/lib/stored-cards/test/assembler.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { createStoredCardsArray } from '../assembler.js';
+import { STORED_CARDS_FROM_API, STORED_CARDS } from './data';
+
+describe( 'assembler', () => {
+	it( 'should be a function', () => {
+		expect( createStoredCardsArray ).to.be.an( 'function' );
+	} );
+
+	it( 'should return an empty array when data transfer object is undefined', () => {
+		expect( createStoredCardsArray() ).to.be.eql( [] );
+	} );
+
+	it( 'should return an empty array when data transfer object is null', () => {
+		expect( createStoredCardsArray( null ) ).to.be.eql( [] );
+	} );
+
+	it( 'should convert the data transfer object to the right data structure', () => {
+		expect( createStoredCardsArray( STORED_CARDS_FROM_API ) ).to.be.eql( STORED_CARDS );
+	} );
+} );

--- a/client/lib/stored-cards/test/data/index.js
+++ b/client/lib/stored-cards/test/data/index.js
@@ -1,0 +1,48 @@
+export default {
+	STORED_CARDS_FROM_API: [
+		{
+			user_id: 12345678,
+			stored_details_id: 1234567,
+			expiry: '2016-01-31',
+			card: 1234,
+			card_type: 'visa',
+			mp_ref: '8qkGjuMJJbRhyrwq8qkGjuMJJbRhyrwq',
+			payment_partner: 'moneypress',
+			name: 'John Doe',
+			email: 'john@example.com',
+			remember: 1,
+			meta: [],
+			added: '2015-10-22 11:14:05',
+			last_used: '2015-10-22 11:14:05'
+		}, {
+			user_id: 12345678,
+			stored_details_id: 12345,
+			expiry: '2016-11-30',
+			card: 2596,
+			card_type: 'amex',
+			mp_ref: 'Cb9S1bxEZDhl20cfCb9S1bxEZDhl20cf',
+			payment_partner: 'moneypress',
+			name: 'Jane Doe',
+			email: 'jane@example.com',
+			remember: 1,
+			meta: [],
+			added: '2015-02-06 20:28:11',
+			last_used: '2015-10-22 11:10:10'
+		}
+	],
+	STORED_CARDS: [
+		{
+			id: 1234567,
+			expiry: '2016-01-31',
+			number: 1234,
+			type: 'visa',
+			name: 'John Doe'
+		}, {
+			id: 12345,
+			expiry: '2016-11-30',
+			number: 2596,
+			type: 'amex',
+			name: 'Jane Doe'
+		}
+	]
+};

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -1,8 +1,8 @@
 // External dependencies
 import i18n from 'i18n-calypso';
-import { omit, values } from 'lodash';
 
 // Internal dependencies
+import assembler from 'lib/stored-cards/assembler';
 import {
 	STORED_CARDS_DELETE,
 	STORED_CARDS_DELETE_COMPLETED,
@@ -13,16 +13,6 @@ import {
 } from 'state/action-types';
 import wp from 'lib/wp';
 const wpcom = wp.undocumented();
-
-/**
- * `wpcom` assigns a `_headers` property to the response, even if the response
- * is an array. This function omits the `_headers` property and converts the
- * response to a real array, instead of an object keyed with indices.
- *
- * @param {Object} response - The response to a request from `wpcom`.
- * @return {array} response - The given response converted into an array.
- */
-const getArrayFromResponse = response => values( omit( response, '_headers' ) );
 
 export const fetchStoredCards = () => dispatch => {
 	dispatch( {
@@ -36,7 +26,7 @@ export const fetchStoredCards = () => dispatch => {
 	} ).then( data => {
 		dispatch( {
 			type: STORED_CARDS_FETCH_COMPLETED,
-			list: getArrayFromResponse( data )
+			list: assembler.createStoredCardsArray( data )
 		} );
 	} ).catch( error => {
 		dispatch( {
@@ -52,7 +42,7 @@ export const deleteStoredCard = card => dispatch => {
 	} );
 
 	return new Promise( ( resolve, reject ) => {
-		wpcom.me().storedCardDelete( card, ( error, data ) => {
+		wpcom.me().storedCardDelete( { stored_details_id: card.id }, ( error, data ) => {
 			error ? reject( error ) : resolve( data );
 		} );
 	} ).then( () => {

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -30,7 +30,7 @@ export const items = ( state = [], action ) => {
 		case STORED_CARDS_FETCH_COMPLETED:
 			return action.list;
 		case STORED_CARDS_DELETE_COMPLETED:
-			return state.filter( item => item.stored_details_id !== action.card.stored_details_id );
+			return state.filter( item => item.id !== action.card.id );
 		// return initial state when serializing/deserializing
 		case SERIALIZE:
 		case DESERIALIZE:

--- a/client/state/stored-cards/selectors.js
+++ b/client/state/stored-cards/selectors.js
@@ -13,7 +13,7 @@ export const getCards = state => state.storedCards.items;
  * @return {Object} the matching card if there is one
  */
 export const getByCardId = ( state, cardId ) => (
-	getCards( state ).filter( card => card.stored_details_id === cardId ).shift()
+	getCards( state ).filter( card => card.id === cardId ).shift()
 );
 
 export const isFetchingStoredCards = state => state.storedCards.isFetching;

--- a/client/state/stored-cards/test/actions.js
+++ b/client/state/stored-cards/test/actions.js
@@ -8,6 +8,7 @@ import {
 	deleteStoredCard,
 	fetchStoredCards
 } from '../actions';
+import { STORED_CARDS, STORED_CARDS_FROM_API } from './fixture';
 import {
 	STORED_CARDS_DELETE,
 	STORED_CARDS_DELETE_COMPLETED,
@@ -32,16 +33,11 @@ describe( 'actions', () => {
 	};
 
 	describe( '#fetchStoredCards', () => {
-		const cards = [
-			{ stored_details_id: 1 },
-			{ stored_details_id: 2 }
-		];
-
 		describe( 'success', () => {
 			before( () => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.get( '/rest/v1.1/me/stored-cards' )
-					.reply( 200, cards );
+					.reply( 200, STORED_CARDS_FROM_API );
 			} );
 
 			it( 'should dispatch fetch/complete actions', () => {
@@ -54,7 +50,7 @@ describe( 'actions', () => {
 				return promise.then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: STORED_CARDS_FETCH_COMPLETED,
-						list: cards
+						list: STORED_CARDS
 					} );
 				} );
 			} );
@@ -85,14 +81,12 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#deleteStoredCard', () => {
-		const card = {
-			stored_details_id: 1337
-		};
+		const card = STORED_CARDS[ 0 ];
 
 		describe( 'success', () => {
 			before( () => {
 				nock( 'https://public-api.wordpress.com:443' )
-					.post( `/rest/v1.1/me/stored-cards/${ card.stored_details_id }/delete` )
+					.post( `/rest/v1.1/me/stored-cards/${ card.id }/delete` )
 					.reply( 200, { success: true } );
 			} );
 
@@ -115,7 +109,7 @@ describe( 'actions', () => {
 		describe( 'fail', () => {
 			before( () => {
 				nock( 'https://public-api.wordpress.com:443' )
-					.post( `/rest/v1.1/me/stored-cards/${ card.stored_details_id }/delete` )
+					.post( `/rest/v1.1/me/stored-cards/${ card.id }/delete` )
 					.reply( 403, error );
 			} );
 

--- a/client/state/stored-cards/test/fixture.js
+++ b/client/state/stored-cards/test/fixture.js
@@ -30,3 +30,20 @@ export const STORED_CARDS_FROM_API = [
 		last_used: '2015-10-22 11:10:10'
 	}
 ];
+
+export const STORED_CARDS = [
+	{
+		id: 1234567,
+		expiry: '2016-01-31',
+		number: 1234,
+		type: 'visa',
+		name: 'John Doe'
+	},
+	{
+		id: 12345,
+		expiry: '2016-11-30',
+		number: 2596,
+		type: 'amex',
+		name: 'Jane Doe'
+	}
+];

--- a/client/state/stored-cards/test/reducer.js
+++ b/client/state/stored-cards/test/reducer.js
@@ -16,7 +16,7 @@ import {
 	STORED_CARDS_DELETE_FAILED
 } from 'state/action-types';
 import reducer from '../reducer';
-import { STORED_CARDS_FROM_API } from './fixture';
+import { STORED_CARDS } from './fixture';
 
 describe( 'items', () => {
 	it( 'should return an object with the initial state', () => {
@@ -38,11 +38,11 @@ describe( 'items', () => {
 	it( 'should return an object with the list of stored cards when fetching completed', () => {
 		const state = reducer( undefined, {
 			type: STORED_CARDS_FETCH_COMPLETED,
-			list: STORED_CARDS_FROM_API
+			list: STORED_CARDS
 		} );
 
 		expect( state ).to.be.eql( {
-			items: STORED_CARDS_FROM_API,
+			items: STORED_CARDS,
 			isFetching: false,
 			isDeleting: false
 		} );
@@ -62,16 +62,16 @@ describe( 'items', () => {
 
 	it( 'should keep the current state and enable isDeleting when requesting a stored card deletion', () => {
 		const state = reducer( deepFreeze( {
-			items: STORED_CARDS_FROM_API,
+			items: STORED_CARDS,
 			isFetching: false,
 			isDeleting: false
 		} ), {
 			type: STORED_CARDS_DELETE,
-			card: STORED_CARDS_FROM_API[ 0 ]
+			card: STORED_CARDS[ 0 ]
 		} );
 
 		expect( state ).to.be.eql( {
-			items: STORED_CARDS_FROM_API,
+			items: STORED_CARDS,
 			isFetching: false,
 			isDeleting: true
 		} );
@@ -79,16 +79,16 @@ describe( 'items', () => {
 
 	it( 'should remove a stored card from the list if the stored card deletion request succeeded', () => {
 		const state = reducer( deepFreeze( {
-			items: STORED_CARDS_FROM_API,
+			items: STORED_CARDS,
 			isFetching: false,
 			isDeleting: true
 		} ), {
 			type: STORED_CARDS_DELETE_COMPLETED,
-			card: STORED_CARDS_FROM_API[ 0 ]
+			card: STORED_CARDS[ 0 ]
 		} );
 
 		expect( state ).to.be.eql( {
-			items: [ STORED_CARDS_FROM_API[ 1 ] ],
+			items: [ STORED_CARDS[ 1 ] ],
 			isFetching: false,
 			isDeleting: false
 		} );
@@ -96,7 +96,7 @@ describe( 'items', () => {
 
 	it( 'should not change the list of items if the stored card deletion request failed', () => {
 		const state = reducer( deepFreeze( {
-			items: STORED_CARDS_FROM_API,
+			items: STORED_CARDS,
 			isFetching: false,
 			isDeleting: true
 		} ), {
@@ -104,7 +104,7 @@ describe( 'items', () => {
 		} );
 
 		expect( state ).to.be.eql( {
-			items: STORED_CARDS_FROM_API,
+			items: STORED_CARDS,
 			isFetching: false,
 			isDeleting: false
 		} );

--- a/client/state/stored-cards/test/selectors.js
+++ b/client/state/stored-cards/test/selectors.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 // Internal dependencies
 import { getCards, getByCardId } from '../selectors';
-import { STORED_CARDS_FROM_API } from './fixture';
+import { STORED_CARDS } from './fixture';
 
 describe( 'selectors', () => {
 	describe( 'getCards', () => {
@@ -13,11 +13,11 @@ describe( 'selectors', () => {
 				storedCards: {
 					isFetching: false,
 					isDeleting: false,
-					items: STORED_CARDS_FROM_API
+					items: STORED_CARDS
 				}
 			} );
 
-			expect( getCards( state ) ).to.be.eql( STORED_CARDS_FROM_API );
+			expect( getCards( state ) ).to.be.eql( STORED_CARDS );
 		} );
 	} );
 
@@ -27,11 +27,11 @@ describe( 'selectors', () => {
 				storedCards: {
 					isFetching: false,
 					isDeleting: false,
-					items: STORED_CARDS_FROM_API
+					items: STORED_CARDS
 				}
 			} );
 
-			expect( getByCardId( state, 12345 ) ).to.be.eql( STORED_CARDS_FROM_API[ 1 ] );
+			expect( getByCardId( state, 12345 ) ).to.be.eql( STORED_CARDS[ 1 ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR updates the `storedCards` reducer, actions and selectors to use the assembler from the lib instead of the raw data from the API.

### Testing Instructions
- `git fetch -a && git checkout update/stored-cards-actions-assembler`
- `npm run test-client client/lib/stored-cards/`
- `npm run test-client client/state/stored-cards/`

### Reviews
- [ ] Product
- [ ] Code
