### PR TITLE
Revert "Site settings: Refactor to use locale rather than lang id"

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -288,14 +288,10 @@ Undocumented.prototype.settings = function( siteId, method, data, fn ) {
 		data = {};
 	}
 
-	const path = `/sites/${ siteId }/settings`;
-	const params = { apiVersion: '1.2' };
-
-	if ( 'get' === method ) {
-		this.wpcom.req.get( path , params, fn );
-	} else if ( 'post' === method ) {
-		this.wpcom.req.post( path, params, data, fn )
-	}
+	this.wpcom.req[ method ]( {
+		path: '/sites/' + siteId + '/settings',
+		body: data
+	}, fn );
 };
 
 Undocumented.prototype._sendRequestWithLocale = function( originalParams, fn ) {

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -46,7 +46,7 @@ const FormGeneral = React.createClass( {
 		};
 
 		if ( site.settings ) {
-			settings.locale = site.settings.locale;
+			settings.lang_id = site.settings.lang_id;
 			settings.blog_public = site.settings.blog_public;
 			settings.admin_url = site.settings.admin_url;
 			settings.timezone_string = site.settings.timezone_string;
@@ -93,8 +93,8 @@ const FormGeneral = React.createClass( {
 			fetchingSettings: true,
 			blogname: '',
 			blogdescription: '',
+			lang_id: '',
 			timezone_string: '',
-			locale: '',
 			blog_public: '',
 			admin_url: '',
 			jetpack_relatedposts_allowed: false,
@@ -207,13 +207,12 @@ const FormGeneral = React.createClass( {
 		}
 		return (
 			<FormFieldset>
-				<FormLabel htmlFor="locale">{ this.translate( 'Language' ) }</FormLabel>
+				<FormLabel htmlFor="lang_id">{ this.translate( 'Language' ) }</FormLabel>
 				<LanguageSelector
-					name="locale"
-					id="locale"
+					name="lang_id"
+					id="lang_id"
 					languages={ config( 'languages' ) }
-					valueKey="langSlug"
-					valueLink={ this.linkState( 'locale' ) }
+					valueLink={ this.linkState( 'lang_id' ) }
 					disabled={ this.state.fetchingSettings }
 					onClick={ this.onRecordEvent( 'Clicked Language Field' ) } />
 				<FormSettingExplanation>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#3360

In #3360, we began making calls to the `v1.2` version of the site settings endpoint. The issue with this is that Jetpack wasn't ready.

We added the `v1.2` endpoint files in Automattic/jetpack#3503, but unfortunately, we didn't add the definitions for the `v1.2` endpoints to the `json-endpoints.php` file. This means that current version of Jetpack are not aware of the `v1.2` endpoints, and thus a `resource_not_found` error is returned.

We have a fix for the Jetpack side in Automattic/jetpack#4366, but the Calypso side will need to be downgraded to `v1.1` for now until Jetpack catches up.

In the future, before we flip the switch on upgrading to `v1.2`, we should address how to handle sites that are on `< Jetpack 4.2` (assuming the fix goes in Jetpack 4.2). 

To test: 

- Checkout `revert-3360-update/localeInsteadLangIdSiteSettings` branch
- Go to `/settings/general/$site`
- Verify that there's not an error notice that the settings could not be fetched

cc @yoavf and @lezama for review/testing.

Test live: https://calypso.live/?branch=revert-3360-update/localeInsteadLangIdSiteSettings