### PR TITLE
Fix wording for WPcom branding removal

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -325,8 +325,8 @@ export const featuresList = {
 
 	[ FEATURE_NO_BRANDING ]: {
 		getTitle: () => i18n.translate( 'Remove WordPress.com Branding' ),
-		getDescription: () => i18n.translate( 'Give your site a more professional look by removing the' +
-			' "Powered by WordPress.com" branding in the footer of your website.' ),
+		getDescription: () => i18n.translate( "Keep the focus on your site's brand by removing the WordPress.com" +
+			' footer branding.' ),
 		getStoreSlug: () => 'no-adverts/no-adverts.php',
 		plans: [ PLAN_BUSINESS ]
 	},


### PR DESCRIPTION
Change the wording of WPcom branding removal:

- from "Give your site a more professional look by removing the "Powered by WordPress.com" branding in the footer of your website."
- to "Keep the focus on your site's brand by removing the WordPress.com footer branding."

Proposed by @apeatling [here](https://github.com/Automattic/wp-calypso/pull/6573#issuecomment-231798380).

cc @gwwar 

Test live: https://calypso.live/?branch=fix/remove-wpcom-branding-desc