### PR TITLE
Plans Redesign: add the dollar value to Google Ad Vouchers

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -210,7 +210,7 @@ const PlansCompare = React.createClass( {
 		// this is necessary here so we don't call the abtest module outside of render
 		if ( this.isUSorCanada() && isWordpressAdCreditsEnabled() ) {
 			googleAdVouchersFeature.compareDescription = googleWordAdsAdVouchers.getDescription();
-			googleAdVouchersFeature[ '1008' ] = '$200';
+			googleAdVouchersFeature[ '1008' ] = '$200'; // Google AdWords $100 voucher + WordAds $100 voucher
 		}
 
 		if ( isEnabled( 'manage/ads/wordads-instant' ) && abtest( 'wordadsInstantActivation' ) === 'enabled' ) {

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -42,20 +42,24 @@ import InfoPopover from 'components/info-popover';
 import { isJetpack } from 'lib/site/utils';
 import {
 	featuresList,
-	FEATURE_GOOGLE_AD_CREDITS,
+	FEATURE_GOOGLE_AD_VOUCHERS_100,
+	FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200,
 	FEATURE_WORDADS_INSTANT,
 } from 'lib/plans/constants';
 
 // google ad credits feature
-const googleAdCredits = featuresList[ FEATURE_GOOGLE_AD_CREDITS ];
-const googleAdCreditsFeature = {
-	title: googleAdCredits.getTitle(),
-	compareDescription: googleAdCredits.getDescription(),
-	product_slug: FEATURE_GOOGLE_AD_CREDITS,
+const googleAdVouchers = featuresList[ FEATURE_GOOGLE_AD_VOUCHERS_100 ];
+const googleAdVouchersFeature = {
+	title: googleAdVouchers.getTitleForOldPlans(),
+	compareDescription: googleAdVouchers.getDescription(),
+	product_slug: FEATURE_GOOGLE_AD_VOUCHERS_100,
 	1: false,
 	1003: '$100',
 	1008: '$100'
 };
+
+const googleWordAdsAdVouchers = featuresList[ FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200 ];
+
 // WordAds instant activation feature
 const wordAdsInstant = featuresList[ FEATURE_WORDADS_INSTANT ];
 const wordAdsFeature = {
@@ -64,7 +68,7 @@ const wordAdsFeature = {
 	1: false,
 	1003: true,
 	1008: true,
-	product_slug: FEATURE_WORDADS_INSTANT,
+	product_slug: FEATURE_WORDADS_INSTANT
 };
 
 const PlansCompare = React.createClass( {
@@ -200,13 +204,13 @@ const PlansCompare = React.createClass( {
 
 		// add google-ad-credits feature
 		if ( this.isUSorCanada() && isGoogleVouchersEnabled() ) {
-			features.splice( 1, 0, googleAdCreditsFeature );
+			features.splice( 1, 0, googleAdVouchersFeature );
 		}
 		// update the description if we are also including wordpressAdCredits
 		// this is necessary here so we don't call the abtest module outside of render
 		if ( this.isUSorCanada() && isWordpressAdCreditsEnabled() ) {
-			googleAdCreditsFeature.compareDescription = googleAdCredits.getDescriptionWithWordAdsCredit();
-			googleAdCreditsFeature[ '1008' ] = '$200';
+			googleAdVouchersFeature.compareDescription = googleWordAdsAdVouchers.getDescription();
+			googleAdVouchersFeature[ '1008' ] = '$200';
 		}
 
 		if ( isEnabled( 'manage/ads/wordads-instant' ) && abtest( 'wordadsInstantActivation' ) === 'enabled' ) {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -342,7 +342,11 @@ export const featuresList = {
 	},
 
 	[ FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200 ]: {
-		getTitle: () => i18n.translate( '$200 Advertising Voucher' ),
+		getTitle: () => i18n.translate( '{{strong}}$200{{/strong}} Advertising Voucher', {
+			components: {
+				strong: <strong />
+			}
+		} ),
 		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25' +
 			' (valid in US & Canada), plus a $100 WordAds advertising credit (valid worldwide).' ),
 		plans: [ PLAN_BUSINESS ]

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -40,7 +40,8 @@ export const FEATURE_EMAIL_LIVE_CHAT_SUPPORT = 'email-live-chat-support';
 export const FEATURE_BASIC_DESIGN = 'basic-design';
 export const FEATURE_ADVANCED_DESIGN = 'advanced-design';
 export const FEATURE_GOOGLE_ANALYTICS = 'google-analytics';
-export const FEATURE_GOOGLE_AD_CREDITS = 'google-ad-credits';
+export const FEATURE_GOOGLE_AD_VOUCHERS_100 = 'google-ad-vouchers-100';
+export const FEATURE_GOOGLE_AD_VOUCHERS_200 = 'google-ad-vouchers-200';
 export const FEATURE_LIVE_CHAT_SUPPORT = 'live-chat-support';
 export const FEATURE_NO_ADS = 'no-adverts';
 export const FEATURE_VIDEO_UPLOADS = 'video-upload';
@@ -120,7 +121,7 @@ export const plansList = {
 			FEATURE_ADVANCED_DESIGN,
 			FEATURE_13GB_STORAGE,
 			FEATURE_NO_ADS,
-			FEATURE_GOOGLE_AD_CREDITS,
+			FEATURE_GOOGLE_AD_VOUCHERS_100,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS
 		],
@@ -145,7 +146,7 @@ export const plansList = {
 			FEATURE_ADVANCED_DESIGN,
 			FEATURE_UNLIMITED_STORAGE,
 			FEATURE_NO_ADS,
-			FEATURE_GOOGLE_AD_CREDITS,
+			FEATURE_GOOGLE_AD_VOUCHERS_200,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS,
 			FEATURE_GOOGLE_ANALYTICS,
@@ -331,23 +332,25 @@ export const featuresList = {
 		plans: [ PLAN_BUSINESS ]
 	},
 
-	[ FEATURE_GOOGLE_AD_CREDITS ]: {
-		getTitle: () => i18n.translate( 'Advertising Vouchers' ),
-		getDescription: () => i18n.translate( '$100 Google AdWords voucher after spending the first $25. Offer valid in US and Canada.' ),
-		getDescriptionWithWordAdsCredit: () => i18n.translate( '$100 Google AdWords voucher after spending the first $25. ' +
-			'Offer valid in US and Canada. {{hr/}}Business also includes $100 of advertising from WordAds on WordPress.com.', {
-				components: {
-					hr: <hr className="plans__const-info-hr"/>
-				}
-			} ),
-		plans: allPaidPlans
+	[ FEATURE_GOOGLE_AD_VOUCHERS_100 ]: {
+		getTitle: () => i18n.translate( '$100 Advertising Voucher' ),
+		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25.' +
+			' Offer valid in US and Canada.' ),
+		plans: [ PLAN_PREMIUM ]
+	},
+
+	[ FEATURE_GOOGLE_AD_VOUCHERS_200 ]: {
+		getTitle: () => i18n.translate( '$200 Advertising Voucher' ),
+		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25' +
+			' (valid in US & Canada), plus a $100 Wordads advertising credit (valid worldwide).' ),
+		plans: [ PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_WORDADS_INSTANT ]: {
 		getTitle: () => i18n.translate( 'Monetize Your Site' ),
 		getDescription: () => i18n.translate( 'Add advertising to your site through our WordAds program and' +
 			' earn money from impressions.' ),
-		plans: allPaidPlans
+		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_WP_SUBDOMAIN ]: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -41,7 +41,7 @@ export const FEATURE_BASIC_DESIGN = 'basic-design';
 export const FEATURE_ADVANCED_DESIGN = 'advanced-design';
 export const FEATURE_GOOGLE_ANALYTICS = 'google-analytics';
 export const FEATURE_GOOGLE_AD_VOUCHERS_100 = 'google-ad-vouchers-100';
-export const FEATURE_GOOGLE_AD_VOUCHERS_200 = 'google-ad-vouchers-200';
+export const FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200 = 'google-ad-vouchers-200';
 export const FEATURE_LIVE_CHAT_SUPPORT = 'live-chat-support';
 export const FEATURE_NO_ADS = 'no-adverts';
 export const FEATURE_VIDEO_UPLOADS = 'video-upload';
@@ -146,7 +146,7 @@ export const plansList = {
 			FEATURE_ADVANCED_DESIGN,
 			FEATURE_UNLIMITED_STORAGE,
 			FEATURE_NO_ADS,
-			FEATURE_GOOGLE_AD_VOUCHERS_200,
+			FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS,
 			FEATURE_GOOGLE_ANALYTICS,
@@ -339,10 +339,10 @@ export const featuresList = {
 		plans: [ PLAN_PREMIUM ]
 	},
 
-	[ FEATURE_GOOGLE_AD_VOUCHERS_200 ]: {
+	[ FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200 ]: {
 		getTitle: () => i18n.translate( '$200 Advertising Voucher' ),
 		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25' +
-			' (valid in US & Canada), plus a $100 Wordads advertising credit (valid worldwide).' ),
+			' (valid in US & Canada), plus a $100 WordAds advertising credit (valid worldwide).' ),
 		plans: [ PLAN_BUSINESS ]
 	},
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -334,6 +334,7 @@ export const featuresList = {
 
 	[ FEATURE_GOOGLE_AD_VOUCHERS_100 ]: {
 		getTitle: () => i18n.translate( '$100 Advertising Voucher' ),
+		getTitleForOldPlans: () => i18n.translate( 'Advertising Vouchers' ),
 		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25.' +
 			' Offer valid in US and Canada.' ),
 		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ] // Business too because when wordpressAdCredits is disabled,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -336,7 +336,8 @@ export const featuresList = {
 		getTitle: () => i18n.translate( '$100 Advertising Voucher' ),
 		getDescription: () => i18n.translate( '$100 Google AdWords credit after spending the first $25.' +
 			' Offer valid in US and Canada.' ),
-		plans: [ PLAN_PREMIUM ]
+		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ] // Business too because when wordpressAdCredits is disabled,
+												// you get only $100 vouchers (this feature) in Business plan.
 	},
 
 	[ FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200 ]: {
@@ -453,6 +454,12 @@ export const getPlanObject = planName => {
 	} );
 
 	return objectPlan;
+};
+
+export const getPlanFeaturesObject = planFeaturesList => {
+	return planFeaturesList.map( featuresConst =>
+		featuresList[ featuresConst ]
+	);
 };
 
 export function isMonthly( plan ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -5,8 +5,7 @@ import page from 'page';
 import moment from 'moment';
 import debugFactory from 'debug';
 import {
-	pick,
-	pickBy,
+	filter,
 	find,
 	get,
 	includes,
@@ -221,27 +220,29 @@ export function plansLink( url, site, intervalType ) {
 
 export function applyTestFiltersToPlansList( planName ) {
 	const filteredPlanConstantObj = { ...plansList[ planName ] };
-	let filteredPlanFeaturesConstantObj = pick( featuresList, plansList[ planName ].getFeatures() );
+	let filteredPlanFeaturesConstantList = plansList[ planName ].getFeatures();
 
 	const removeDisabledFeatures = () => {
 		if ( ! isWordadsInstantActivationEnabled() ) {
-			filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
-				( value, key ) => key !== FEATURE_WORDADS_INSTANT
+			filteredPlanFeaturesConstantList = filter( filteredPlanFeaturesConstantList,
+				( value ) => value !== FEATURE_WORDADS_INSTANT
 			);
 		}
 
 		if ( ! isGoogleVouchersEnabled() ) {
-			filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
-				( value, key ) => key !== FEATURE_GOOGLE_AD_VOUCHERS_100 ||
-					key !== FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200
+			filteredPlanFeaturesConstantList = filter( filteredPlanFeaturesConstantList,
+				( value ) => value !== FEATURE_GOOGLE_AD_VOUCHERS_100 &&
+					value !== FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200
 			);
 		}
 
-		// TODO: use mapKeys/mapValues to replace with ad_vouchers_100
 		if ( ! isWordpressAdCreditsEnabled() ) {
-			filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
-				( value, key ) => key !== FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200
-			);
+			const wordpressAdCreditsFeatureIndex = filteredPlanFeaturesConstantList.
+				indexOf( FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200 );
+
+			if ( wordpressAdCreditsFeatureIndex !== -1 ) {
+				filteredPlanFeaturesConstantList[ wordpressAdCreditsFeatureIndex ] = FEATURE_GOOGLE_AD_VOUCHERS_100;
+			}
 		}
 	};
 
@@ -260,7 +261,7 @@ export function applyTestFiltersToPlansList( planName ) {
 	removeDisabledFeatures();
 	updatePlanDescriptions();
 
-	filteredPlanConstantObj.getFeatures = () => filteredPlanFeaturesConstantObj;
+	filteredPlanConstantObj.getFeatures = () => filteredPlanFeaturesConstantList;
 
 	return filteredPlanConstantObj;
 }

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -235,15 +235,6 @@ export function applyTestFiltersToPlansList( planName ) {
 					value !== FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200
 			);
 		}
-
-		if ( ! isWordpressAdCreditsEnabled() ) {
-			const wordpressAdCreditsFeatureIndex = filteredPlanFeaturesConstantList.
-				indexOf( FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200 );
-
-			if ( wordpressAdCreditsFeatureIndex !== -1 ) {
-				filteredPlanFeaturesConstantList[ wordpressAdCreditsFeatureIndex ] = FEATURE_GOOGLE_AD_VOUCHERS_100;
-			}
-		}
 	};
 
 	const updatePlanDescriptions = () => {
@@ -258,8 +249,20 @@ export function applyTestFiltersToPlansList( planName ) {
 		}
 	};
 
+	const updatePlanFeatures = () => {
+		if ( ! isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS ) {
+			const wordpressAdCreditsFeatureIndex = filteredPlanFeaturesConstantList.
+				indexOf( FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200 );
+
+			if ( wordpressAdCreditsFeatureIndex !== -1 ) {
+				filteredPlanFeaturesConstantList[ wordpressAdCreditsFeatureIndex ] = FEATURE_GOOGLE_AD_VOUCHERS_100;
+			}
+		}
+	};
+
 	removeDisabledFeatures();
 	updatePlanDescriptions();
+	updatePlanFeatures();
 
 	filteredPlanConstantObj.getFeatures = () => filteredPlanFeaturesConstantList;
 

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -34,7 +34,7 @@ import {
 	PLAN_BUSINESS,
 	FEATURE_WORDADS_INSTANT,
 	FEATURE_GOOGLE_AD_VOUCHERS_100,
-	FEATURE_GOOGLE_AD_VOUCHERS_200
+	FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200
 } from 'lib/plans/constants';
 import { createSitePlanObject } from 'state/sites/plans/assembler';
 import SitesList from 'lib/sites-list';
@@ -233,14 +233,14 @@ export function applyTestFiltersToPlansList( planName ) {
 		if ( ! isGoogleVouchersEnabled() ) {
 			filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
 				( value, key ) => key !== FEATURE_GOOGLE_AD_VOUCHERS_100 ||
-					key !== FEATURE_GOOGLE_AD_VOUCHERS_200
+					key !== FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200
 			);
 		}
 
 		// TODO: use mapKeys/mapValues to replace with ad_vouchers_100
 		if ( ! isWordpressAdCreditsEnabled() ) {
 			filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
-				( value, key ) => key !== FEATURE_GOOGLE_AD_VOUCHERS_200
+				( value, key ) => key !== FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200
 			);
 		}
 	};

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -33,7 +33,8 @@ import {
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
 	FEATURE_WORDADS_INSTANT,
-	FEATURE_GOOGLE_AD_CREDITS
+	FEATURE_GOOGLE_AD_VOUCHERS_100,
+	FEATURE_GOOGLE_AD_VOUCHERS_200
 } from 'lib/plans/constants';
 import { createSitePlanObject } from 'state/sites/plans/assembler';
 import SitesList from 'lib/sites-list';
@@ -228,9 +229,18 @@ export function applyTestFiltersToPlansList( planName ) {
 				( value, key ) => key !== FEATURE_WORDADS_INSTANT
 			);
 		}
+
 		if ( ! isGoogleVouchersEnabled() ) {
 			filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
-				( value, key ) => key !== FEATURE_GOOGLE_AD_CREDITS
+				( value, key ) => key !== FEATURE_GOOGLE_AD_VOUCHERS_100 ||
+					key !== FEATURE_GOOGLE_AD_VOUCHERS_200
+			);
+		}
+
+		// TODO: use mapKeys/mapValues to replace with ad_vouchers_100
+		if ( ! isWordpressAdCreditsEnabled() ) {
+			filteredPlanFeaturesConstantObj = pickBy( filteredPlanFeaturesConstantObj,
+				( value, key ) => key !== FEATURE_GOOGLE_AD_VOUCHERS_200
 			);
 		}
 	};
@@ -247,16 +257,8 @@ export function applyTestFiltersToPlansList( planName ) {
 		}
 	};
 
-	const updateInfoPopups = () => {
-		if ( isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS	) {
-			filteredPlanFeaturesConstantObj[ FEATURE_GOOGLE_AD_CREDITS ].getDescription =
-			featuresList[ FEATURE_GOOGLE_AD_CREDITS ].getDescriptionWithWordAdsCredit;
-		}
-	};
-
 	removeDisabledFeatures();
 	updatePlanDescriptions();
-	updateInfoPopups();
 
 	filteredPlanConstantObj.getFeatures = () => filteredPlanFeaturesConstantObj;
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -27,7 +27,8 @@ import {
 import {
 	isPopular,
 	isMonthly,
-	PLAN_FREE
+	PLAN_FREE,
+	getPlanFeaturesObject
 } from 'lib/plans/constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import {
@@ -349,7 +350,7 @@ export default connect( ( state, ownProps ) => {
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
 			discountPrice: getPlanDiscountPrice( state, selectedSiteId, plan, showMonthly ),
-			features: planConstantObj.getFeatures(),
+			features: getPlanFeaturesObject( planConstantObj.getFeatures() ),
 			onUpgradeClick: onUpgradeClick
 				? () => {
 					const planSlug = getPlanSlug( state, planProductId );


### PR DESCRIPTION
Fixes #6676. Instead of having one feature for Google AdWords credits, I created two features and added their dollar value to their titles.

## Testing Instructions

1. Start Calypso with `ENABLE_FEATURES=manage/plan-features make run`;
2. Navigate to `/plans`;
3. Check if the Advertising Vouchers features have dollar values before them;
4. Toggle `googleVouchers` and `wordpressAdCredits` abtests to verify that the dollar value of the vouchers changes appropriately.

## Screenshots

With all plan features abtests enabled:

![selection_039](https://cloud.githubusercontent.com/assets/4988512/16775377/9cdbd17a-4860-11e6-89c1-5e5f9a814930.jpg)

With `wordpressAdCredits` disabled:

![selection_040](https://cloud.githubusercontent.com/assets/4988512/16775392/af841a3a-4860-11e6-99a5-a64335945d91.jpg)

With all plan features abtests disabled:

![selection_041](https://cloud.githubusercontent.com/assets/4988512/16775463/0749a668-4861-11e6-98c1-f2e352dd3375.jpg)


cc @gwwar 

Test live: https://calypso.live/?branch=update/google-vouchers-dollar-value