### PR TITLE
Do not show opt-in notice to new users

### DIFF
--- a/client/components/push-notification/prompt.jsx
+++ b/client/components/push-notification/prompt.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import includes from 'lodash/includes';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -44,6 +45,8 @@ const SECTION_NAME_WHITELIST = [
 	'upgrades'
 ];
 
+const NEW_USER_CUT_OFF_AGE_IN_DAYS = 7;
+
 const PushNotificationPrompt = React.createClass( {
 	displayName: 'PushNotificationPrompt',
 
@@ -79,6 +82,13 @@ const PushNotificationPrompt = React.createClass( {
 		return <Notice className="push-notification__notice" text={ noticeText } icon="bell" onDismissClick={ this.props.dismissNotice } />;
 	},
 
+	isNewUser: function( user ) {
+		const userCreated = moment.utc( user.date );
+		const now = moment().utc();
+
+		return userCreated.isAfter( now.subtract( NEW_USER_CUT_OFF_AGE_IN_DAYS, 'days' ) );
+	},
+
 	render: function() {
 		if (
 			! this.props.isAuthorizationLoaded ||
@@ -91,7 +101,7 @@ const PushNotificationPrompt = React.createClass( {
 		}
 		const user = this.props.user.get();
 
-		if ( ! user || ! user.email_verified ) {
+		if ( ! user || ! user.email_verified || this.isNewUser( user ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR seeks to delay the browser notification opt-in notice by 7 days so that it is not part of the new user experience.

We would like to avoid new users seeing a giant notice as part of their first experience - that's something we’ve worked hard to avoid with email confirmation.

We will delay showing the notice until the user has passed their 7-day mark.

### Testing instructions

This PR can be tested using calypso.live.

- Visit [Calypso master](https://calypso.live/?branch=master) with a new user (younger than 7 days). Observe that the Browser Notification opt-in notice is visible on the [Discover page](https://calypso.live/discover).
- Visit [this Calypso branch](https://calypso.live/?branch=add/delay-push-notification-notice) with a new user (younger than 7 days). Observe that the Browser Notification opt-in notice is **not** visible on the [Discover page](https://calypso.live/discover).
- Visit [this Calypso branch](https://calypso.live/?branch=add/delay-push-notification-notice) with an existing user (older than 7 days). Observe that the Browser Notification opt-in notice is visible on the [Discover page](https://calypso.live/discover).

Test live: https://calypso.live/?branch=add/delay-push-notification-notice