### PR TITLE
CPT: Display post author in custom post types list

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -237,6 +237,7 @@
 @import 'my-sites/post-selector/style';
 @import 'my-sites/post-type-list/style';
 @import 'my-sites/post-type-list/post-actions-ellipsis-menu/style';
+@import 'my-sites/post-type-list/post-type-post-author/style';
 @import 'my-sites/posts/style';
 @import 'my-sites/plugins/featured-plugins/style';
 @import 'my-sites/plugins/style';

--- a/client/my-sites/post-type-list/post-type-post-author/index.jsx
+++ b/client/my-sites/post-type-list/post-type-post-author/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -9,99 +9,33 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { savePost } from 'state/posts/actions';
 import { getPost } from 'state/posts/selectors';
-import { isValidCapability, canCurrentUser } from 'state/current-user/selectors';
-import { getPostType } from 'state/post-types/selectors';
-import QueryPostTypes from 'components/data/query-post-types';
-import AuthorSelector from 'components/author-selector';
-import Gravatar from 'components/gravatar';
+import Gridicon from 'components/gridicon';
 
-class PostTypePostAuthor extends Component {
-	static propTypes = {
-		globalId: PropTypes.string,
-		siteId: PropTypes.number,
-		postId: PropTypes.number,
-		canAssignUser: PropTypes.bool,
-		author: PropTypes.object,
-		isKnownType: PropTypes.bool
+function PostTypePostAuthor( { translate, name } ) {
+	if ( ! name ) {
+		return null;
 	}
 
-	constructor() {
-		super( ...arguments );
-
-		this.setAuthor = this.setAuthor.bind( this );
-	}
-
-	setAuthor( author ) {
-		const { siteId, postId } = this.props;
-		if ( siteId && postId && author ) {
-			this.props.savePost( {
-				author: author.ID
-			}, siteId, postId );
-		}
-	}
-
-	render() {
-		const { translate, author, siteId, canAssignUser, isKnownType } = this.props;
-
-		let selector;
-		if ( author ) {
-			selector = (
-				<span className="post-type-post-author__name">
-					<Gravatar
-						size={ 18 }
-						user={ author }
-						className="post-type-post-author__gravatar" />
-					{ translate( 'by %(name)s', { args: { name: author.name } } ) }
-				</span>
-			);
-		}
-
-		if ( canAssignUser ) {
-			selector = (
-				<AuthorSelector
-					siteId={ siteId }
-					onSelect={ this.setAuthor }
-					popoverPosition="bottom">
-					{ selector }
-				</AuthorSelector>
-			);
-		}
-
-		return (
-			<div className="post-type-post-author">
-				{ ! isKnownType && siteId && (
-					<QueryPostTypes siteId={ siteId } />
-				) }
-				{ selector }
-			</div>
-		);
-	}
+	return (
+		<div className="post-type-post-author">
+			<Gridicon
+				icon="user"
+				size={ 18 }
+				className="post-type-post-author__icon" />
+			{ translate( 'by %(name)s', { args: { name } } ) }
+		</div>
+	);
 }
 
-export default connect(
-	( state, ownProps ) => {
-		const post = getPost( state, ownProps.globalId );
-		if ( ! post ) {
-			return {};
-		}
+PostTypePostAuthor.propTypes = {
+	translate: PropTypes.func,
+	globalId: PropTypes.string,
+	name: PropTypes.string
+};
 
-		const type = getPostType( state, post.site_ID, post.type );
-
-		let capability = 'edit_others_posts';
-		const typeCapability = get( type, [ 'capabilities', capability ] );
-		if ( isValidCapability( state, post.site_ID, typeCapability ) ) {
-			capability = typeCapability;
-		}
-
-		return {
-			author: post.author,
-			siteId: post.site_ID,
-			postId: post.ID,
-			canAssignUser: canCurrentUser( state, post.site_ID, capability ),
-			isKnownType: !! type
-		};
-	},
-	{ savePost }
-)( localize( PostTypePostAuthor ) );
+export default connect( ( state, ownProps ) => {
+	return {
+		name: get( getPost( state, ownProps.globalId ), [ 'author', 'name' ] )
+	};
+} )( localize( PostTypePostAuthor ) );

--- a/client/my-sites/post-type-list/post-type-post-author/index.jsx
+++ b/client/my-sites/post-type-list/post-type-post-author/index.jsx
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { savePost } from 'state/posts/actions';
+import { getPost } from 'state/posts/selectors';
+import { isValidCapability, canCurrentUser } from 'state/current-user/selectors';
+import { getPostType } from 'state/post-types/selectors';
+import QueryPostTypes from 'components/data/query-post-types';
+import AuthorSelector from 'components/author-selector';
+import Gravatar from 'components/gravatar';
+
+class PostTypePostAuthor extends Component {
+	static propTypes = {
+		globalId: PropTypes.string,
+		siteId: PropTypes.number,
+		postId: PropTypes.number,
+		canAssignUser: PropTypes.bool,
+		author: PropTypes.object,
+		isKnownType: PropTypes.bool
+	}
+
+	constructor() {
+		super( ...arguments );
+
+		this.setAuthor = this.setAuthor.bind( this );
+	}
+
+	setAuthor( author ) {
+		const { siteId, postId } = this.props;
+		if ( siteId && postId && author ) {
+			this.props.savePost( {
+				author: author.ID
+			}, siteId, postId );
+		}
+	}
+
+	render() {
+		const { translate, author, siteId, canAssignUser, isKnownType } = this.props;
+
+		let selector;
+		if ( author ) {
+			selector = (
+				<span className="post-type-post-author__name">
+					<Gravatar
+						size={ 18 }
+						user={ author }
+						className="post-type-post-author__gravatar" />
+					{ translate( 'by %(name)s', { args: { name: author.name } } ) }
+				</span>
+			);
+		}
+
+		if ( canAssignUser ) {
+			selector = (
+				<AuthorSelector
+					siteId={ siteId }
+					onSelect={ this.setAuthor }
+					popoverPosition="bottom">
+					{ selector }
+				</AuthorSelector>
+			);
+		}
+
+		return (
+			<div className="post-type-post-author">
+				{ ! isKnownType && siteId && (
+					<QueryPostTypes siteId={ siteId } />
+				) }
+				{ selector }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => {
+		const post = getPost( state, ownProps.globalId );
+		if ( ! post ) {
+			return {};
+		}
+
+		const type = getPostType( state, post.site_ID, post.type );
+
+		let capability = 'edit_others_posts';
+		const typeCapability = get( type, [ 'capabilities', capability ] );
+		if ( isValidCapability( state, post.site_ID, typeCapability ) ) {
+			capability = typeCapability;
+		}
+
+		return {
+			author: post.author,
+			siteId: post.site_ID,
+			postId: post.ID,
+			canAssignUser: canCurrentUser( state, post.site_ID, capability ),
+			isKnownType: !! type
+		};
+	},
+	{ savePost }
+)( localize( PostTypePostAuthor ) );

--- a/client/my-sites/post-type-list/post-type-post-author/style.scss
+++ b/client/my-sites/post-type-list/post-type-post-author/style.scss
@@ -1,0 +1,9 @@
+.post-type-post-author__name {
+	vertical-align: middle;
+	margin-right: 4px;
+}
+
+.post-type-post-author__gravatar {
+	vertical-align: top;
+	margin-right: 6px;
+}

--- a/client/my-sites/post-type-list/post-type-post-author/style.scss
+++ b/client/my-sites/post-type-list/post-type-post-author/style.scss
@@ -1,9 +1,4 @@
-.post-type-post-author__name {
-	vertical-align: middle;
-	margin-right: 4px;
-}
-
-.post-type-post-author__gravatar {
+.post-type-post-author__icon {
 	vertical-align: top;
-	margin-right: 6px;
+	margin-right: 4px;
 }

--- a/client/my-sites/post-type-list/post.jsx
+++ b/client/my-sites/post-type-list/post.jsx
@@ -15,6 +15,7 @@ import Card from 'components/card';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import PostTypeListPostThumbnail from './post-thumbnail';
 import PostActionsEllipsisMenu from './post-actions-ellipsis-menu';
+import PostTypePostAuthor from './post-type-post-author';
 
 export function PostTypeListPost( { translate, globalId, post, editUrl, className } ) {
 	const classes = classnames( 'post-type-list__post', className, {
@@ -32,6 +33,7 @@ export function PostTypeListPost( { translate, globalId, post, editUrl, classNam
 					</h1>
 					<div className="post-type-list__post-meta">
 						<PostRelativeTimeStatus post={ post } />
+						<PostTypePostAuthor globalId={ globalId } />
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -82,6 +82,11 @@
 	color: lighten( $gray, 10% );
 }
 
+.post-type-list__post-meta .post-relative-time-status,
+.post-type-list__post-meta .post-type-post-author {
+	float: left;
+}
+
 .post-type-list__post-meta .post-relative-time-status {
 	margin-bottom: 0;
 


### PR DESCRIPTION
This pull request seeks to add the post's author to the meta information on the [custom post types list screen](https://wpcalypso.wordpress.com/types/post). ~~It also enables changing the author inline, making use of the existing [`<AuthorSelector />` component](https://github.com/Automattic/wp-calypso/tree/master/client/components/author-selector) (used also in the post editor).~~ (Removed per feedback)

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16742724/ee2d6510-4776-11e6-85f9-f9f37fdfe3d9.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16766699/8aaf16ee-4809-11e6-81b2-ea5ec784dfa9.png)

[_See original concept_](https://cloud.githubusercontent.com/assets/1779930/16742674/b9d91c3c-4776-11e6-870f-6efa76614e65.png)

[_Original version with author selector_](https://cloud.githubusercontent.com/assets/1779930/16742730/f6057912-4776-11e6-9c62-773f09cd0a48.png)

__Testing instructions:__

Verify that you are able to view the author of a post, and reassign the author if you have capabilities for doing so.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Select a filter where posts exist
4. Note that the author is shown~~, with Gravatar,~~ under the post title
5. ~~If capabilities exist, note that a chevron is shown adjacent the author to select a new author~~
6. ~~Select a new author~~
7. ~~Note that after a brief delay, the author is changed and persists through page refresh~~

__Caveats / Follow-up Tasks:__

_These caveats are no longer applicable after removal of author selector per feedback._

- The change in author is not reflected instantaneously, because the format of `author` is different between reading and updating endpoints. This should be resolved by normalizing the post object's author in the `getNormalizedPost` selector.
- The author selector does not account for the capabilities of the author to which the post will be assigned. Even if a user does not have capabilities of editing a particular post type, it will still be presented as an option in the dropdown. This is an issue of the underlying `<AuthorSelector />` component.

Test live: https://calypso.live/?branch=add/cpt-assign-author