### PR TITLE
Enable browser push notifications A/B test

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -71,7 +71,7 @@
 		"press-this": true,
 		"preview-layout": true,
 		"preview-endpoint": false,
-		"push-notifications-ab-test": false,
+		"push-notifications-ab-test": true,
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/start": true,


### PR DESCRIPTION
This PR enables showing the Browser Notification prompt to 5% of our English speaking users in production.

A/B testing started with 5% of our English speaking users on 28 June, 2016 in the sense that they got assigned as participants to the test, but they will not see the prompt until we flip the switch by turning the production config on in this PR.

See: https://github.com/Automattic/wp-calypso/pull/6236

Test live: https://calypso.live/?branch=update/push-notification-ab-test-flag