### PR TITLE
Jetpack Plans: Fix duplicate tracks events on plugin auto-installation

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -58,6 +58,14 @@ const helpLinks = {
 
 const PlansSetup = React.createClass( {
 	displayName: 'PlanSetup',
+	sentTracks: false,
+
+	sendTracks( eventName, options = null ) {
+		if ( ! this.sentTracks ) {
+			analytics.tracks.recordEvent( eventName, options );
+		}
+		this.sentTracks = true;
+	},
 
 	// plugins for Jetpack sites require additional data from the wporg-data store
 	addWporgDataToPlugins( plugins ) {
@@ -167,7 +175,7 @@ const PlansSetup = React.createClass( {
 	},
 
 	renderNoJetpackSiteSelected() {
-		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_error_wordpresscom' );
+		this.sendTracks( 'calypso_plans_autoconfig_error_wordpresscom' );
 		return (
 			<JetpackManageErrorPage
 				site={ this.props.selectedSite }
@@ -183,16 +191,16 @@ const PlansSetup = React.createClass( {
 
 		if ( reasons && reasons.length > 0 ) {
 			reason = reasons[ 0 ];
-			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_error_filemod', { error: reason } );
+			this.sendTracks( 'calypso_plans_autoconfig_error_filemod', { error: reason } );
 		} else if ( ! site.hasMinimumJetpackVersion ) {
 			reason = this.translate( 'You need to update your version of Jetpack.' );
-			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_error_jpversion', { jetpack_version: site.options.jetpack_version } );
+			this.sendTracks( 'calypso_plans_autoconfig_error_jpversion', { jetpack_version: site.options.jetpack_version } );
 		} else if ( ! site.isMainNetworkSite() ) {
 			reason = this.translate( 'We can\'t install plugins on multisite sites.' );
-			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_error_multisite' );
+			this.sendTracks( 'calypso_plans_autoconfig_error_multisite' );
 		} else if ( site.options.is_multi_network ) {
 			reason = this.translate( 'We can\'t install plugins on multi-network sites.' );
-			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_error_multinetwork' );
+			this.sendTracks( 'calypso_plans_autoconfig_error_multinetwork' );
 		}
 
 		return (
@@ -344,7 +352,8 @@ const PlansSetup = React.createClass( {
 		pluginsWithErrors.map( ( item ) => {
 			tracksData[ item.slug ] = item.error.name + ': ' + item.error.message;
 		} );
-		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_error_plugin', tracksData );
+
+		this.sendTracks( 'calypso_plans_autoconfig_error_plugin', tracksData );
 
 		if ( pluginsWithErrors.length === 1 ) {
 			noticeText = this.translate(
@@ -393,7 +402,7 @@ const PlansSetup = React.createClass( {
 			return this.renderErrorMessage( pluginsWithErrors );
 		}
 
-		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_success' );
+		this.sendTracks( 'calypso_plans_autoconfig_success' );
 
 		const noticeText = this.translate( 'We\'ve installed your plugins, your site is powered up!' );
 		return (

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -30,7 +30,6 @@ import utils from 'lib/site/utils';
 
 // Redux actions & selectors
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isRequestingSites } from 'state/sites/selectors';
 import { getPlugin } from 'state/plugins/wporg/selectors';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { requestSites } from 'state/sites/actions';
@@ -431,7 +430,7 @@ const PlansSetup = React.createClass( {
 	render() {
 		const site = this.props.selectedSite;
 
-		if ( ! site && ! this.props.isRequestingSites ) {
+		if ( ! site && sites.fetching ) {
 			return this.renderPlaceholder();
 		}
 
@@ -444,7 +443,7 @@ const PlansSetup = React.createClass( {
 		}
 
 		if ( site &&
-			! this.props.isRequestingSites &&
+			! sites.fetching &&
 			! this.props.isRequesting &&
 			! PluginsStore.isFetchingSite( site ) &&
 			! this.props.plugins.length ) {
@@ -506,7 +505,6 @@ export default connect(
 			activePlugin: getActivePlugin( state, siteId ),
 			nextPlugin: getNextPlugin( state, siteId ),
 			selectedSite: site && site.jetpack ? JetpackSite( site ) : site,
-			isRequestingSites: isRequestingSites( state ),
 			siteId
 		};
 	},


### PR DESCRIPTION
It's possible that the page state could update after the install is finished (once the sites list finally loads, for example), and this was causing the page to re-render and send the tracks events multiple times. I've added a helper functions `sendTracks`, which will ensure we only send the result once.

While debugging this, I also noticed we flash the "You need to select a jetpack site to be able to setup your plan" error if the site isn't loaded. Some of the logic here wasn't updated when we switched back to [the `sitesFactory` method of getting the selected site](https://github.com/Automattic/wp-calypso/pull/5907/commits/c244a8c4f8ad74cc3136699de857f620cbd5ccf1). We should now be checking `sites.fetching` rather than `props.isRequestingSites`.

To test:

1. Clear localstorage so the site needs to be re-fetched
2. Turn on analytics debug messages: `localStorage.setItem('debug', 'calypso:analytics');`
3. Load the autoconfig page: `/plugins/setup/$site`
4. Watch for the tracks events, there should just be one success or error message.

cc @johnHackworth @roccotripaldi 

Test live: https://calypso.live/?branch=fix/autoconfig-duplicate-tracks