### PR TITLE
DesignPreview: Show/hide preview based on Redux state

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -18,7 +18,6 @@ import touchDetect from 'lib/touch-detect';
 import { isMobile } from 'lib/viewport';
 import Spinner from 'components/spinner';
 import RootChild from 'components/root-child';
-import { setPreviewShowing } from 'state/ui/actions';
 
 const debug = debugModule( 'calypso:web-preview' );
 
@@ -95,17 +94,12 @@ const WebPreview = React.createClass( {
 		if ( this.props.showPreview ) {
 			document.documentElement.classList.add( 'no-scroll', 'is-previewing' );
 		}
-		this.props.setPreviewShowing( this.props.showPreview );
 	},
 
 	componentDidUpdate( prevProps ) {
 		const { showPreview, previewUrl } = this.props;
 
 		this.setIframeUrl( previewUrl );
-
-		if ( prevProps.showPreview !== showPreview ) {
-			this.props.setPreviewShowing( showPreview );
-		}
 
 		if ( ! this.shouldRenderIframe() ) {
 			this.setState( {
@@ -137,7 +131,6 @@ const WebPreview = React.createClass( {
 	},
 
 	componentWillUnmount() {
-		this.props.setPreviewShowing( false );
 		window.removeEventListener( 'keydown', this.keyDown );
 		document.documentElement.classList.remove( 'no-scroll', 'is-previewing' );
 	},
@@ -252,7 +245,4 @@ const WebPreview = React.createClass( {
 	}
 } );
 
-export default connect(
-	null,
-	{ setPreviewShowing }
-)( WebPreview );
+export default WebPreview;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -35,6 +35,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	Layout,
 	SupportUser;
 
+import layoutFocus from 'lib/layout-focus';
 import { isOffline } from 'state/application/selectors';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import DesignPreview from 'my-sites/design-preview';
@@ -55,6 +56,7 @@ Layout = React.createClass( {
 	_sitesPoller: null,
 
 	componentWillUpdate: function( nextProps ) {
+		this.updateLayoutFocus();
 		if ( this.props.section.group !== nextProps.section.group ) {
 			if ( nextProps.section.group === 'sites' ) {
 				setTimeout( function() {
@@ -151,12 +153,18 @@ Layout = React.createClass( {
 		);
 	},
 
+	updateLayoutFocus() {
+		if ( this.props.isPreviewShowing ) {
+			return layoutFocus.set( 'preview' );
+		}
+		return layoutFocus.set( 'content' );
+	},
+
 	renderPreview() {
 		if ( config.isEnabled( 'preview-layout' ) && this.props.section.group === 'sites' ) {
 			return (
 				<DesignPreview
 					className="layout__preview"
-					showPreview={ this.props.focus.getCurrent() === 'preview' }
 					defaultViewportDevice="computer"
 				/>
 			);
@@ -204,9 +212,10 @@ Layout = React.createClass( {
 
 export default connect(
 	( state ) => {
-		const { isLoading, section } = state.ui;
+		const { isLoading, section, isPreviewShowing } = state.ui;
 		return {
 			isLoading,
+			isPreviewShowing,
 			isSupportUser: state.support.isSupportUser,
 			section,
 			isOffline: isOffline( state ),

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -16,7 +16,7 @@ import { fetchPreviewMarkup, undoCustomization, clearCustomizations } from 'stat
 import accept from 'lib/accept';
 import { updatePreviewWithChanges } from 'lib/design-preview';
 import layoutFocus from 'lib/layout-focus';
-import { getSelectedSite, getSelectedSiteId, getPreviewUrl } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId, getPreviewUrl, isPreviewShowing } from 'state/ui/selectors';
 import { getSiteOption } from 'state/sites/selectors';
 import { getPreviewMarkup, getPreviewCustomizations, isPreviewUnsaved } from 'state/preview/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
@@ -29,8 +29,6 @@ const DesignPreview = React.createClass( {
 	propTypes: {
 		// Any additional classNames to set on this wrapper
 		className: React.PropTypes.string,
-		// True to show the preview; same as WebPreview.
-		showPreview: React.PropTypes.bool,
 		// The viewport device to show initially; same as WebPreview but defaults to 'tablet'.
 		defaultViewportDevice: React.PropTypes.string,
 		// Show close button; same as WebPreview.
@@ -52,6 +50,8 @@ const DesignPreview = React.createClass( {
 		undoCustomization: React.PropTypes.func.isRequired,
 		clearCustomizations: React.PropTypes.func.isRequired,
 		clearPreviewUrl: React.PropTypes.func.isRequired,
+		// True to show the preview; same as WebPreview.
+		showPreview: React.PropTypes.bool,
 	},
 
 	getInitialState() {
@@ -221,6 +221,7 @@ function mapStateToProps( state ) {
 	const selectedSiteId = getSelectedSiteId( state );
 
 	return {
+		showPreview: isPreviewShowing( state ),
 		selectedSite,
 		selectedSiteId,
 		selectedSiteUrl: getSiteOption( state, selectedSiteId, 'unmapped_url' ),

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -11,11 +11,10 @@ import debugFactory from 'debug';
  */
 import config from 'config';
 import WebPreview from 'components/web-preview';
-import { clearPreviewUrl } from 'state/ui/actions';
+import { clearPreviewUrl, setPreviewShowing } from 'state/ui/actions';
 import { fetchPreviewMarkup, undoCustomization, clearCustomizations } from 'state/preview/actions';
 import accept from 'lib/accept';
 import { updatePreviewWithChanges } from 'lib/design-preview';
-import layoutFocus from 'lib/layout-focus';
 import { getSelectedSite, getSelectedSiteId, getPreviewUrl, isPreviewShowing } from 'state/ui/selectors';
 import { getSiteOption } from 'state/sites/selectors';
 import { getPreviewMarkup, getPreviewCustomizations, isPreviewUnsaved } from 'state/preview/selectors';
@@ -42,6 +41,7 @@ const DesignPreview = React.createClass( {
 		selectedSiteNonce: React.PropTypes.string,
 		selectedSite: React.PropTypes.object,
 		selectedSiteId: React.PropTypes.number,
+		showPreview: React.PropTypes.bool,
 		previewUrl: React.PropTypes.string,
 		previewMarkup: React.PropTypes.string,
 		customizations: React.PropTypes.object,
@@ -50,8 +50,7 @@ const DesignPreview = React.createClass( {
 		undoCustomization: React.PropTypes.func.isRequired,
 		clearCustomizations: React.PropTypes.func.isRequired,
 		clearPreviewUrl: React.PropTypes.func.isRequired,
-		// True to show the preview; same as WebPreview.
-		showPreview: React.PropTypes.bool,
+		setPreviewShowing: React.PropTypes.func.isRequired,
 	},
 
 	getInitialState() {
@@ -153,13 +152,13 @@ const DesignPreview = React.createClass( {
 				if ( accepted ) {
 					this.props.clearPreviewUrl( this.props.selectedSiteId );
 					this.props.clearCustomizations( this.props.selectedSiteId );
-					layoutFocus.set( 'sidebar' );
+					this.props.setPreviewShowing( false );
 				}
 			} );
 		}
 		this.props.clearPreviewUrl( this.props.selectedSiteId );
 		this.props.clearCustomizations( this.props.selectedSiteId );
-		layoutFocus.set( 'sidebar' );
+		this.props.setPreviewShowing( false );
 	},
 
 	onPreviewClick( event ) {
@@ -235,5 +234,5 @@ function mapStateToProps( state ) {
 
 export default connect(
 	mapStateToProps,
-	{ fetchPreviewMarkup, undoCustomization, clearCustomizations, clearPreviewUrl }
+	{ fetchPreviewMarkup, undoCustomization, clearCustomizations, clearPreviewUrl, setPreviewShowing }
 )( DesignPreview );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -9,6 +9,8 @@ var analytics = require( 'lib/analytics' ),
 	React = require( 'react' );
 
 import page from 'page';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -30,8 +32,10 @@ import Button from 'components/button';
 import SidebarButton from 'layout/sidebar/button';
 import SidebarFooter from 'layout/sidebar/footer';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
+import { setPreviewShowing } from 'state/ui/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-module.exports = React.createClass( {
+const MySitesSidebar = React.createClass( {
 	displayName: 'MySitesSidebar',
 
 	componentDidMount: function() {
@@ -47,7 +51,8 @@ module.exports = React.createClass( {
 		const site = this.getSelectedSite();
 		if ( site.is_previewable && ! event.metaKey && ! event.ctrlKey ) {
 			event.preventDefault();
-			this.props.layoutFocus.set( 'preview' );
+			this.props.setPreviewShowing( true );
+			//this.props.layoutFocus.set( 'preview' );
 		}
 	},
 
@@ -750,3 +755,16 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+function mapStateToProps( state ) {
+	const selectedSiteId = getSelectedSiteId( state );
+	return {
+		selectedSiteId,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators( { setPreviewShowing }, dispatch );
+}
+
+module.exports = connect( mapStateToProps, mapDispatchToProps )( MySitesSidebar );


### PR DESCRIPTION
Right now there is a Redux action called `setPreviewVisible` which simply updates `state.ui.isPreviewShowing`. However, despite the name, that state has no effect on the preview. It is merely updated when a `WebPreview` component is visible. 

This is an attempt to invert that flow, so that `state.ui.isPreviewShowing` controls the visibility of the always-on preview (the `DesignPreview` component).

There are some challenges with this approach because there is already a global state which controls the visibility of the preview: the `layoutFocus` library. The preview is visible right now when `layoutFocus` is set to `preview`. 

Ultimately, we may want to move `layoutFocus` to use the Redux state instead of having its own store. If that was the case, we'd probably want to remove `isPreviewShowing` entirely and replace it with something like `currentLayoutFocus`. Perhaps that could be done in this PR or this could exist as a stop-gap measure along that path.

This evolved from a conversation in #6151.

cc: @aduth @mtias @lsinger @ehg 

Test live: https://calypso.live/?branch=update/preview-from-is-preview-showing