### PR TITLE
Plans Redesign: Adjust responsiveness

### DIFF
--- a/assets/stylesheets/shared/mixins/_breakpoints.scss
+++ b/assets/stylesheets/shared/mixins/_breakpoints.scss
@@ -3,7 +3,7 @@
 // See https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md#media-queries
 // ==========================================================================
 
-$breakpoints: 480px, 660px, 960px, 1040px; // Think very carefully before adding a new breakpoint
+$breakpoints: 480px, 660px, 960px, 1040px, 1280px; // Think very carefully before adding a new breakpoint
 
 @mixin breakpoint( $sizes... ){
 	@each $size in $sizes {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -96,7 +96,6 @@ class PlanFeatures extends Component {
 						rawPrice={ rawPrice }
 						discountPrice={ discountPrice }
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
-						onClick={ onUpgradeClick }
 						isPlaceholder={ isPlaceholder }
 					/>
 					<p className="plan-features__description">
@@ -141,7 +140,6 @@ class PlanFeatures extends Component {
 				currencyCode,
 				current,
 				discountPrice,
-				onUpgradeClick,
 				planConstantObj,
 				planName,
 				popular,
@@ -159,7 +157,6 @@ class PlanFeatures extends Component {
 						rawPrice={ rawPrice }
 						discountPrice={ discountPrice }
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
-						onClick={ onUpgradeClick }
 						isPlaceholder={ isPlaceholder }
 					/>
 				</td>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -109,7 +109,7 @@ class PlanFeatures extends Component {
 						isPlaceholder={ isPlaceholder }
 					/>
 					<FoldableCard
-						header={ translate( 'Show included features' ) }
+						header={ translate( 'Show features' ) }
 						clickableHeader
 						compact>
 						{ this.renderMobileFeatures( features ) }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -109,7 +109,7 @@ class PlanFeatures extends Component {
 						isPlaceholder={ isPlaceholder }
 					/>
 					<FoldableCard
-						summary={ translate( 'Show included features' ) }
+						header={ translate( 'Show included features' ) }
 						compact>
 						{ this.renderMobileFeatures( features ) }
 					</FoldableCard>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -42,6 +42,9 @@ class PlanFeatures extends Component {
 	render() {
 		return (
 			<div className="plan-features">
+				<div className="plan-features__mobile">
+					{ this.renderMobileView() }
+				</div>
 				<table className="plan-features__table">
 					<tbody>
 						<tr>
@@ -61,6 +64,56 @@ class PlanFeatures extends Component {
 				</table>
 			</div>
 		);
+	}
+
+	renderMobileView() {
+		const { planProperties, isPlaceholder } = this.props;
+
+		return map( planProperties, ( properties ) => {
+			const {
+				available,
+				currencyCode,
+				current,
+				discountPrice,
+				onUpgradeClick,
+				planConstantObj,
+				planName,
+				popular,
+				rawPrice
+			} = properties;
+
+			return (
+				<div className="plan-features__mobile-plan">
+					<PlanFeaturesHeader
+						current={ current }
+						currencyCode={ currencyCode }
+						popular={ popular }
+						title={ planConstantObj.getTitle() }
+						planType={ planName }
+						rawPrice={ rawPrice }
+						discountPrice={ discountPrice }
+						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
+						onClick={ onUpgradeClick }
+						isPlaceholder={ isPlaceholder }
+					/>
+					{
+						isPlaceholder
+							? <SpinnerLine />
+							: null
+					}
+					<p className="plan-features__description">
+						{ planConstantObj.getDescription() }
+					</p>
+					<PlanFeaturesActions
+						current={ current }
+						available = { available }
+						onUpgradeClick={ onUpgradeClick }
+						freePlan={ planName === PLAN_FREE }
+						isPlaceholder={ isPlaceholder }
+					/>
+				</div>
+			);
+		} );
 	}
 
 	renderPlanHeaders() {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -42,12 +42,17 @@ import FoldableCard from 'components/foldable-card';
 class PlanFeatures extends Component {
 
 	render() {
+		const { planProperties } = this.props;
+
+		const tableClasses = classNames( 'plan-features__table',
+			`has-${ planProperties.length }-cols` );
+
 		return (
 			<div className="plan-features">
 				<div className="plan-features__mobile">
 					{ this.renderMobileView() }
 				</div>
-				<table className="plan-features__table">
+				<table className={ tableClasses }>
 					<tbody>
 						<tr>
 							{ this.renderPlanHeaders() }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -110,6 +110,7 @@ class PlanFeatures extends Component {
 					/>
 					<FoldableCard
 						header={ translate( 'Show included features' ) }
+						clickableHeader
 						compact>
 						{ this.renderMobileFeatures( features ) }
 					</FoldableCard>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { map, reduce, noop } from 'lodash';
 import page from 'page';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -36,6 +37,7 @@ import {
 } from 'lib/plans';
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import SpinnerLine from 'components/spinner-line';
+import FoldableCard from 'components/foldable-card';
 
 class PlanFeatures extends Component {
 
@@ -67,13 +69,14 @@ class PlanFeatures extends Component {
 	}
 
 	renderMobileView() {
-		const { planProperties, isPlaceholder } = this.props;
+		const { planProperties, isPlaceholder, translate } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
 				available,
 				currencyCode,
 				current,
+				features,
 				discountPrice,
 				onUpgradeClick,
 				planConstantObj,
@@ -83,7 +86,7 @@ class PlanFeatures extends Component {
 			} = properties;
 
 			return (
-				<div className="plan-features__mobile-plan">
+				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
 						current={ current }
 						currencyCode={ currencyCode }
@@ -96,11 +99,6 @@ class PlanFeatures extends Component {
 						onClick={ onUpgradeClick }
 						isPlaceholder={ isPlaceholder }
 					/>
-					{
-						isPlaceholder
-							? <SpinnerLine />
-							: null
-					}
 					<p className="plan-features__description">
 						{ planConstantObj.getDescription() }
 					</p>
@@ -111,7 +109,26 @@ class PlanFeatures extends Component {
 						freePlan={ planName === PLAN_FREE }
 						isPlaceholder={ isPlaceholder }
 					/>
+					<FoldableCard
+						summary={ translate( 'Show included features' ) }
+						compact>
+						{ this.renderMobileFeatures( features ) }
+					</FoldableCard>
 				</div>
+			);
+		} );
+	}
+
+	renderMobileFeatures( features ) {
+		return map( features, ( currentFeature, index ) => {
+			return (
+				<PlanFeaturesItem key={ index } description={
+					currentFeature.getDescription
+						? currentFeature.getDescription()
+						: null
+				}>
+					{ currentFeature.getTitle() }
+				</PlanFeaturesItem>
 			);
 		} );
 	}
@@ -356,4 +373,4 @@ export default connect( ( state, ownProps ) => {
 		isPlaceholder,
 		planProperties: planProperties
 	};
-} )( PlanFeatures );
+} )( localize( PlanFeatures ) );

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -97,15 +97,19 @@ $plan-features-header-banner-height: 20px;
 	border: solid 6px $gray-light;
 	border-radius: 50%;
 
-	@include breakpoint( "<1280px" ) {
-		width: 20px;
-		height: 20px;
-		border: solid 2px $gray-light;
-		margin-right: 10px;
-	}
-
 	@include breakpoint( "<1040px" ) {
 		display: none;
+	}
+}
+
+.is-section-plans {
+	.plan-features__header-figure {
+		@include breakpoint( "<1280px" ) {
+			width: 20px;
+			height: 20px;
+			border: solid 2px $gray-light;
+			margin-right: 10px;
+		}
 	}
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -29,8 +29,10 @@ $plan-features-header-banner-height: 20px;
 		padding: 0;
 	}
 
-	.plan-features__header-figure {
+	.plan-features__header .plan-features__header-figure {
 		display: block;
+		width: 50px;
+		height: 50px;
 	}
 
 	.plan-features__header-banner {
@@ -140,7 +142,6 @@ $plan-features-header-banner-height: 20px;
 	}
 }
 
-.plan-features__mobile .plan-features__header-figure,
 .plan-features__header-figure {
 	position: relative;
 	width: 50px;
@@ -150,7 +151,8 @@ $plan-features-header-banner-height: 20px;
 	border-radius: 50%;
 }
 
-.plan-features__header-figure {
+//We only need this for /plans since nux has no sidebar
+.is-section-plans .plan-features__header-figure {
 	@include breakpoint( "<1280px" ) {
 		width: 20px;
 		height: 20px;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -1,5 +1,5 @@
 $plan-features-header-banner-height: 20px;
-
+$plan-features-sidebar-width: 272px;
 
 /* Breakpoints 1150px, */
 
@@ -8,12 +8,19 @@ $plan-features-header-banner-height: 20px;
 	padding-top: $plan-features-header-banner-height;
 }
 
+.is-section-plans .plan-features__mobile {
+	display: block;
+	@media ( min-width: $plan-features-sidebar-width + 480px ) {
+		display: none;
+	}
+}
+
 .plan-features__mobile {
 	color: $gray;
 	margin: 0 16px;
 	display: block;
 
-	@media ( min-width: 840px ) {
+	@include breakpoint( ">480px" ) {
 		display: none;
 	}
 
@@ -58,6 +65,13 @@ $plan-features-header-banner-height: 20px;
 	margin-bottom: 24px;
 }
 
+.is-section-plans .plan-features__table {
+	display: none;
+	@media ( min-width: $plan-features-sidebar-width + 480px ) {
+		display: table;
+	}
+}
+
 .plan-features__table {
 	font-size: 14px;
 	color: $gray;
@@ -65,7 +79,7 @@ $plan-features-header-banner-height: 20px;
 	margin-top: -16px;
 	display: none;
 
-	@media ( min-width: 840px ) {
+	@include breakpoint( ">480px" ) {
 		display: table;
 	}
 
@@ -153,7 +167,6 @@ $plan-features-header-banner-height: 20px;
 	border-radius: 50%;
 }
 
-//We only need this for /plans since nux has no sidebar
 .is-section-plans .plan-features__header-figure {
 	@include breakpoint( "<1280px" ) {
 		width: 20px;
@@ -161,11 +174,16 @@ $plan-features-header-banner-height: 20px;
 		border: solid 2px $gray-light;
 		margin-right: 10px;
 	}
+}
 
+.plan-features__header-figure,
+.plan-features__table.has-1-cols .plan-features__header-figure,
+.plan-features__table.has-2-cols .plan-features__header-figure {
 	@include breakpoint( "<1040px" ) {
 		display: none;
 	}
 }
+
 
 .plan-features__header-checkmark {
 	position: absolute;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -17,6 +17,18 @@ $plan-features-header-banner-height: 20px;
 		display: none;
 	}
 
+	.foldable-card {
+		box-shadow: none;
+	}
+
+	.foldable-card.card.is-expanded { //original rule has this specificity
+		margin-bottom: 0;
+	}
+
+	.foldable-card.is-expanded .foldable-card__content { //original rule has this specificity
+		padding: 0;
+	}
+
 	.plan-features__header-figure {
 		display: block;
 	}
@@ -24,9 +36,19 @@ $plan-features-header-banner-height: 20px;
 	.plan-features__header-banner {
 		display: none;
 	}
+
+	.plan-features__item {
+		border-bottom: solid 1px lighten( $gray, 27% );
+		font-size: 14px;
+	}
+
+	.plan-features__item:last-child {
+		border-bottom: none;
+	}
 }
 
 .plan-features__mobile-plan {
+	font-size: 14px;
 	border: solid 1px lighten( $gray, 27% );
 	background-color: lighten( $gray, 35% );
 	margin-bottom: 24px;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -371,10 +371,4 @@ $plan-features-header-banner-height: 20px;
 			margin-right: 8px;
 		}
 	}
-
-	@media
-		(min-width: 480px) and (max-width: 660px),
-		(min-width: 800px) and (max-width: 1040px) {
-			max-width: 260px;
-	}
 }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -303,6 +303,10 @@ $plan-features-header-banner-height: 20px;
 	@include breakpoint( "<1040px" ) {
 		padding: 12px 12px 0 12px;
 	}
+
+	@include breakpoint( "<660px" ) {
+		padding: 20px 20px 0 20px;
+	}
 }
 
 .plan-features__item {
@@ -349,6 +353,11 @@ $plan-features-header-banner-height: 20px;
 	@include breakpoint( "<1040px" ) {
 		padding: 0 12px 12px 12px;
 	}
+
+	@include breakpoint( "<660px" ) {
+		padding: 0 20px 20px 20px;
+		border-bottom: solid 1px $gray-light;
+	}
 }
 
 .plan-features__actions-buttons {
@@ -370,5 +379,9 @@ $plan-features-header-banner-height: 20px;
 			fill: $alert-green;
 			margin-right: 8px;
 		}
+	}
+
+	@include breakpoint( "<660px" ) {
+		margin-top: 20px;
 	}
 }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -8,11 +8,40 @@ $plan-features-header-banner-height: 20px;
 	padding-top: $plan-features-header-banner-height;
 }
 
+.plan-features__mobile {
+	color: $gray;
+	margin: 0 16px;
+	display: block;
+
+	@include breakpoint( ">660px" ) {
+		display: none;
+	}
+
+	.plan-features__header-figure {
+		display: block;
+	}
+
+	.plan-features__header-banner {
+		display: none;
+	}
+}
+
+.plan-features__mobile-plan {
+	border: solid 1px lighten( $gray, 27% );
+	background-color: lighten( $gray, 35% );
+	margin-bottom: 24px;
+}
+
 .plan-features__table {
 	font-size: 14px;
 	color: $gray;
 	border-spacing: 16px 0;
 	margin-top: -16px;
+	display: none;
+
+	@include breakpoint( ">660px" ) {
+		display: table;
+	}
 
 	@include breakpoint( "<1040px" ) {
 		border-spacing: 0;
@@ -89,6 +118,7 @@ $plan-features-header-banner-height: 20px;
 	}
 }
 
+.plan-features__mobile .plan-features__header-figure,
 .plan-features__header-figure {
 	position: relative;
 	width: 50px;
@@ -96,20 +126,18 @@ $plan-features-header-banner-height: 20px;
 	margin-right: 15px;
 	border: solid 6px $gray-light;
 	border-radius: 50%;
+}
+
+.plan-features__header-figure {
+	@include breakpoint( "<1280px" ) {
+		width: 20px;
+		height: 20px;
+		border: solid 2px $gray-light;
+		margin-right: 10px;
+	}
 
 	@include breakpoint( "<1040px" ) {
 		display: none;
-	}
-}
-
-.is-section-plans {
-	.plan-features__header-figure {
-		@include breakpoint( "<1280px" ) {
-			width: 20px;
-			height: 20px;
-			border: solid 2px $gray-light;
-			margin-right: 10px;
-		}
 	}
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -1,20 +1,24 @@
 $plan-features-header-banner-height: 20px;
 
-.plan-features {
-	overflow-x: auto;
-	margin: 0 0 0 -16px;
-	padding-top: $plan-features-header-banner-height;
 
-	@include breakpoint( ">960px" ) {
-		margin: -16px -16px 0 -16px;
-	}
+/* Breakpoints 1150px, */
+
+.plan-features {
+	margin: -16px -16px 0 -16px;
+	padding-top: $plan-features-header-banner-height;
 }
 
 .plan-features__table {
 	font-size: 14px;
 	color: $gray;
-	table-layout: fixed;
 	border-spacing: 16px 0;
+	margin-top: -16px;
+
+	@include breakpoint( "<1040px" ) {
+		border-spacing: 0;
+		margin: 0 15px;
+		width: calc( 100% - 30px );
+	}
 }
 
 .plan-features__table-item {
@@ -39,6 +43,11 @@ $plan-features-header-banner-height: 20px;
 		position: absolute;
 		bottom: 0;
 		margin: 0 24px;
+
+		@include breakpoint( "<1040px" ) {
+			margin: 0 12px;
+			width: calc( 100% - 24px );
+		}
 	}
 }
 
@@ -74,6 +83,10 @@ $plan-features-header-banner-height: 20px;
 	padding: 12px 24px 0 15px;
 	border-bottom: solid 2px lighten( $gray, 20% );
 	background-color: $white;
+
+	@include breakpoint( "<960px" ) {
+		padding: 12px 12px 0 12px;
+	}
 }
 
 .plan-features__header-figure {
@@ -83,6 +96,17 @@ $plan-features-header-banner-height: 20px;
 	margin-right: 15px;
 	border: solid 6px $gray-light;
 	border-radius: 50%;
+
+	@include breakpoint( "<1280px" ) {
+		width: 20px;
+		height: 20px;
+		border: solid 2px $gray-light;
+		margin-right: 10px;
+	}
+
+	@include breakpoint( "<1040px" ) {
+		display: none;
+	}
 }
 
 .plan-features__header-checkmark {
@@ -91,6 +115,10 @@ $plan-features-header-banner-height: 20px;
 	right: -3px;
 	transform: translate( 25%, -25% );
 	fill: $alert-green;
+
+	@include breakpoint( "<1280px" ) {
+		display: none;
+	}
 }
 
 .plan-features__header-text {
@@ -102,6 +130,10 @@ $plan-features-header-banner-height: 20px;
 	font-size: 22px;
 	color: $blue-wordpress;
 	line-height: 0.7;
+
+	@include breakpoint( "<960px" ) {
+		font-size: 20px;
+	}
 }
 
 .plan-features__price {
@@ -115,6 +147,10 @@ $plan-features-header-banner-height: 20px;
 		width: 60px;
 		margin: 10px 0;
 		height: 21px;
+	}
+
+	@include breakpoint( "<960px" ) {
+		font-size: 24px;
 	}
 }
 
@@ -209,17 +245,25 @@ $plan-features-header-banner-height: 20px;
 .plan-features__description {
 	margin: 0;
 	padding: 24px 24px 0 24px;
+
+	@include breakpoint( "<1040px" ) {
+		padding: 12px 12px 0 12px;
+	}
 }
 
 .plan-features__item {
 	position: relative;
 	margin: 0 24px;
-	padding: 12px 0 12px 30px;
+	padding: 12px 20px 12px 30px;
 	font-size: 14px;
 	color: $gray-dark;
 
-	@include breakpoint( "<480px" ) {
-		margin: 0 16px;
+	@include breakpoint( "<1040px" ) {
+		margin: 0 12px;
+	}
+
+	@include breakpoint( "<960px" ) {
+		font-size: 12px;
 	}
 }
 
@@ -247,6 +291,10 @@ $plan-features-header-banner-height: 20px;
 
 .plan-features__actions {
 	padding: 0 24px 24px 24px;
+
+	@include breakpoint( "<1040px" ) {
+		padding: 0 12px 12px 12px;
+	}
 }
 
 .plan-features__actions-buttons {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -29,12 +29,6 @@ $plan-features-header-banner-height: 20px;
 		padding: 0;
 	}
 
-	.plan-features__header .plan-features__header-figure {
-		display: block;
-		width: 50px;
-		height: 50px;
-	}
-
 	.plan-features__header-banner {
 		display: none;
 	}
@@ -47,6 +41,14 @@ $plan-features-header-banner-height: 20px;
 	.plan-features__item:last-child {
 		border-bottom: none;
 	}
+}
+
+.plan-features__mobile .plan-features__header .plan-features__header-figure,
+.plan-features__table.has-1-cols .plan-features__header-figure,
+.plan-features__table.has-2-cols .plan-features__header-figure {
+	display: block;
+	width: 50px;
+	height: 50px;
 }
 
 .plan-features__mobile-plan {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -13,7 +13,7 @@ $plan-features-header-banner-height: 20px;
 	margin: 0 16px;
 	display: block;
 
-	@include breakpoint( ">660px" ) {
+	@media ( min-width: 840px ) {
 		display: none;
 	}
 
@@ -61,7 +61,7 @@ $plan-features-header-banner-height: 20px;
 	margin-top: -16px;
 	display: none;
 
-	@include breakpoint( ">660px" ) {
+	@media ( min-width: 840px ) {
 		display: table;
 	}
 


### PR DESCRIPTION
Work in progress. Replace the scrolling table for the new plans page with columns that more easily reduce in size at each breakpoint.

To see this, start Calypso with `ENABLE_FEATURES=manage/plan-features make run`

Full width:

![screen shot 2016-07-11 at 2 21 06 pm](https://cloud.githubusercontent.com/assets/1464705/16747214/f9ebbf0e-4772-11e6-8651-74994dc25433.png)

1280px wide:

![screen shot 2016-07-11 at 2 21 40 pm](https://cloud.githubusercontent.com/assets/1464705/16747222/021bb094-4773-11e6-80e3-1f27e557f8a8.png)

1040px wide:

![screen shot 2016-07-11 at 2 22 04 pm](https://cloud.githubusercontent.com/assets/1464705/16747244/1122d004-4773-11e6-82fa-80b7b0b3fc91.png)
0px:

960px wide:

![screen shot 2016-07-11 at 2 22 24 pm](https://cloud.githubusercontent.com/assets/1464705/16747256/19bd1eae-4773-11e6-8bb2-8b581b504d4b.png)

Still working on smaller/mobile widths.


 

Test live: https://calypso.live/?branch=update/plans-table-responsiveness