### PR TITLE
GuidedTours: fix tour step hidden by preview

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -23,6 +23,7 @@ import {
 } from './steps';
 import wait from './wait';
 import QueryPreferences from 'components/data/query-preferences';
+import RootChild from 'components/root-child';
 
 const debug = debugFactory( 'calypso:guided-tours' );
 
@@ -121,16 +122,18 @@ class GuidedTours extends Component {
 		}[ stepConfig.type ] || BasicStep;
 
 		return (
-			<div className="guided-tours">
-				<QueryPreferences />
-				<StepComponent
-					{ ...stepConfig }
-					key={ stepConfig.target }
-					targetSlug={ stepConfig.target }
-					onNext={ this.next }
-					onQuit={ this.quit }
-					onFinish={ this.finish } />
-			</div>
+			<RootChild>
+				<div className="guided-tours">
+					<QueryPreferences />
+					<StepComponent
+						{ ...stepConfig }
+						key={ stepConfig.target }
+						targetSlug={ stepConfig.target }
+						onNext={ this.next }
+						onQuit={ this.quit }
+						onFinish={ this.finish } />
+				</div>
+			</RootChild>
 		);
 	}
 }


### PR DESCRIPTION
Somewhere along the introduction of the blurring behind the WebPreview component, GuidedTours got hidden behind the blurred preview as well. 

This change puts it on the same level as WebPreview using the RootChild component so that it's not blurred or hidden anymore.

To test:
- go to http://calypso.localhost:3000/?tour=main
- make sure all GuidedTours steps are visible

Test live: https://calypso.live/?branch=fix/guided-tours-hidden-under-preview