### PR TITLE
Framework: fix parsing of chrome version

### DIFF
--- a/client/state/push-notifications/utils.js
+++ b/client/state/push-notifications/utils.js
@@ -13,7 +13,8 @@ export function isUnsupportedChromeVersion() {
 }
 
 export function getChromeVersion() {
-	return window.navigator.appVersion.match( /Chrome\/(\d+)/ )[ 1 ];
+	const match = window.navigator.appVersion.match( /Chrome\/(\d+)/ );
+	return match ? match[ 1 ] : -1;
 }
 
 export function isPushNotificationsSupported() {


### PR DESCRIPTION
This fixes the following error that will occur when the string does not match the regex.
![screen_shot_2016-07-11_at_4 45 21_pm_480](https://cloud.githubusercontent.com/assets/1270189/16750690/5fc267b4-4788-11e6-85e6-61ef74f7c74f.png)

## Testing Instructions

- Attempt to load Calypso in an iPhone 6 Plus or iPhone emulator

cc @dmsnell @mjuhasz 

Test live: https://calypso.live/?branch=fix/ios