### PR TITLE
Jetpack Sync: First pass at functional UI

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -515,8 +515,6 @@ const FormGeneral = React.createClass( {
 					</form>
 				</Card>
 
-				{ this.renderJetpackSyncPanel() }
-
 				{ this.props.site.jetpack
 					? <div>
 						<SectionHeader label={ this.translate( 'Jetpack' ) }>
@@ -537,6 +535,7 @@ const FormGeneral = React.createClass( {
 							}
 						</SectionHeader>
 
+						{ this.renderJetpackSyncPanel() }
 						{ this.syncNonPublicPostTypes() }
 
 						<Card href={ '../security/' + site.slug } className="is-compact">

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -56,7 +56,7 @@ const JetpackSyncPanel = React.createClass( {
 		if ( this.shouldDisableSync() ) {
 			text = this.translate( 'Full sync in progress' );
 		} else if ( finishedTimestamp.isValid() ) {
-			text = this.translate( 'Last syned %(ago)s', {
+			text = this.translate( 'Last synced %(ago)s', {
 				args: {
 					ago: finishedTimestamp.fromNow()
 				}

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -11,7 +11,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import Button from 'components/button';
 import Notice from 'components/notice';
 import ProgressBar from 'components/progress-bar';
@@ -86,7 +86,7 @@ const JetpackSyncPanel = React.createClass( {
 
 	render() {
 		return (
-			<Card className="jetpack-sync-panel">
+			<CompactCard className="jetpack-sync-panel">
 				<div className="jetpack-sync-panel__action-group">
 					<div className="jetpack-sync-panel__description">
 						{ this.translate(
@@ -111,7 +111,7 @@ const JetpackSyncPanel = React.createClass( {
 				{ this.renderStatusNotice() }
 				{ this.renderProgressBar() }
 				{ this.shouldDisableSync() && <Interval onTick={ this.fetchSyncStatus } period={ EVERY_FIVE_SECONDS } /> }
-			</Card>
+			</CompactCard>
 		);
 	}
 } );

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
-import { throttle } from 'lodash';
+import { get,throttle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -60,10 +60,26 @@ const JetpackSyncPanel = React.createClass( {
 	},
 
 	renderStatusNotice() {
-		const classes = classNames( 'jetpack-sync-panel__notice' );
+		const finished = get( this.props, 'syncStatus.finished' );
+		const finishedTimestamp = this.moment( parseInt( finished, 10 ) * 1000 );
+		let text = '';
+		if ( this.shouldDisableSync() ) {
+			text = this.translate( 'Full sync in progress' );
+		} else if ( finishedTimestamp.isValid() ) {
+			text = this.translate( 'Last syned %(ago)s', {
+				args: {
+					ago: finishedTimestamp.fromNow()
+				}
+			} );
+		}
+
+		if ( ! text ) {
+			return null;
+		}
+
 		return (
-			<Notice isCompact className={ classes }>
-				Placeholder text
+			<Notice isCompact className={ classNames( 'jetpack-sync-panel__notice' ) }>
+				{ text }
 			</Notice>
 		);
 	},

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
-import { get,throttle } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +21,7 @@ import {
 	getSyncStatus,
 	scheduleJetpackFullysync
 } from 'state/jetpack-sync/actions';
+import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
 
 /*
  * Module variables
@@ -31,18 +32,7 @@ const JetpackSyncPanel = React.createClass( {
 	displayName: 'JetpackSyncPanel',
 
 	componentWillMount() {
-		// Created a throttled fetch function that will run a maximum of once for every 4 seconds.
-		this.throttledPoller = throttle( this.fetchSyncStatus, 4000 );
 		this.fetchSyncStatus();
-	},
-
-	componentWillUnmount() {
-		this.throttledPoller.cancel();
-	},
-
-	componentWillReceiveProps() {
-		// Since the polling is throttled, let's trigger every time that we get props.
-		this.throttledPoller();
 	},
 
 	fetchSyncStatus() {
@@ -120,6 +110,7 @@ const JetpackSyncPanel = React.createClass( {
 
 				{ this.renderStatusNotice() }
 				{ this.renderProgressBar() }
+				{ this.shouldDisableSync() && <Interval onTick={ this.fetchSyncStatus } period={ EVERY_FIVE_SECONDS } /> }
 			</Card>
 		);
 	}

--- a/client/my-sites/site-settings/jetpack-sync-panel/style.scss
+++ b/client/my-sites/site-settings/jetpack-sync-panel/style.scss
@@ -23,9 +23,19 @@
 }
 
 .jetpack-sync-panel .progress-bar {
-	margin-top: 16px;
+	margin-top: 8px;
 }
 
 .jetpack-sync-panel .notice {
+	background: none;
+	color: $gray;
 	margin-top: 16px;
+}
+
+.jetpack-sync-panel .notice .notice__text {
+	padding-left: 0;
+}
+
+.jetpack-sync-panel .notice .notice__icon {
+	display: none;
 }

--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -63,12 +63,20 @@ export function syncStatus( state = {}, action ) {
 				)
 			} );
 		case JETPACK_SYNC_STATUS_SUCCESS:
+			const thisState = get( state, [ action.siteId ], {} );
+
+			// lastSuccessfulStatus is any status after we have started sycing
+			let lastSuccessfulStatus = get( thisState, 'lastSuccessfulStatus', false );
+			const isFullSyncing = ( get( action, 'data.started' ) && ! get( action, 'data.finished' ) );
+			if ( lastSuccessfulStatus || isFullSyncing ) {
+				lastSuccessfulStatus = Date.now();
+			}
 			return Object.assign( {}, state, {
 				[ action.siteId ]: Object.assign(
 					{
 						isRequesting: false,
 						error: false,
-						lastSuccessfulStatus: Date.now()
+						lastSuccessfulStatus
 					},
 					pick( action.data, getExpectedResponseKeys() )
 				)

--- a/client/state/jetpack-sync/test/reducer.js
+++ b/client/state/jetpack-sync/test/reducer.js
@@ -61,6 +61,41 @@ const successfulSyncStatusRequest = {
 	}
 };
 
+const inProgressSyncStatusRequest = {
+	type: JETPACK_SYNC_STATUS_SUCCESS,
+	siteId: 1234567,
+	data: {
+		started: 1467998622,
+		queue_finished: 1467998622,
+		sent_started: 1467999200,
+		queue: {
+			constants: 1,
+			functions: 1,
+			options: 1,
+			terms: 1,
+			themes: 1,
+			users: 1,
+			posts: 102,
+			comments: 1,
+			updates: 1
+		},
+		sent: {
+			constants: 1,
+			functions: 1,
+			options: 1,
+			terms: 1,
+			themes: 1,
+			users: 1,
+			posts: 25
+		},
+		is_scheduled: false,
+		_headers: {
+			Date: 'Wed, 15 Jun 2016 17:05:26 GMT',
+			'Content-Type': 'application/json'
+		}
+	}
+};
+
 const erroredSyncStatusRequest = {
 	type: JETPACK_SYNC_STATUS_ERROR,
 	siteId: 1234578,
@@ -155,8 +190,8 @@ describe( 'reducer', () => {
 
 		it( 'should set lastSuccessfulStatus to current time when finished fetching for a site', () => {
 			const startTime = Date.now();
-			const state = syncStatus( undefined, successfulSyncStatusRequest );
-			expect( state ).to.have.property( String( successfulSyncStatusRequest.siteId ) )
+			const state = syncStatus( undefined, inProgressSyncStatusRequest );
+			expect( state ).to.have.property( String( inProgressSyncStatusRequest.siteId ) )
 				.to.have.property( 'lastSuccessfulStatus' )
 				.to.be.at.least( startTime );
 		} );


### PR DESCRIPTION
This PR is a first pass at making the sync status UI functional. At this point, you should be able to go to `/settings/general/$site` and click the "Perform Full Sync" button in order to start a sync.

After starting a sync, you should see a status bar that updates, and when the sync is finished, the UI should reflect that.

cc @lezama for code review and @rickybanister for any early design feedback.

To test:

- Checkout `update/jetpack-sync-status-hook-up` branch
- Make sure Jetpack is on latest of `branch-4.2`
- Go to `/settings/general/$site`
- Click "Perform full sync" button
- Verify full sync is performed by going to `$site/wp-admin/admin.php?page=jetpack-sync`
- Verify progress bar is removed from UI when sync is over

Known issues:

- This PR does not handle the UI for errors during full sync. For example, if you lose internet and then internet comes back.
- <strike>This PR does not yet handle the informational notice. It is still simply a placeholder.</strike>


Test live: https://calypso.live/?branch=update/jetpack-sync-status-hook-up