### PR TITLE
Stats: Fix TypeErrors happening on iOS/Safari

### DIFF
--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -5,7 +5,6 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import throttle from 'lodash/throttle';
-import touchDetect from 'lib/touch-detect';
 import i18n from 'i18n-calypso';
 
 /**
@@ -148,10 +147,6 @@ const PostTrends = React.createClass( {
 		containerClass = classNames( 'post-trends', {
 			'is-loading': requesting
 		} );
-
-		if ( touchDetect.hasTouch() ) {
-			return null;
-		}
 
 		return (
 

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -18,6 +18,7 @@ import TodaysStats from '../stats-site-overview';
 import StatsModule from '../stats-module';
 import StatsConnectedModule from '../stats-module/connected-list';
 import statsStrings from '../stats-strings';
+import touchDetect from 'lib/touch-detect';
 import MostPopular from 'my-sites/stats/most-popular';
 import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
@@ -77,7 +78,7 @@ export default React.createClass( {
 				<SidebarNavigation />
 				<StatsNavigation section="insights" site={ site } />
 				<div id="my-stats-content">
-					<PostingActivity />
+					{ touchDetect.hasTouch() && <PostingActivity /> }
 					<LatestPostSummary site={ site } />
 					<TodaysStats
 						siteId={ site ? site.ID : 0 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -598,7 +598,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000505"
+      "version": "1.0.30000506"
     },
     "caseless": {
       "version": "0.11.0"
@@ -1056,11 +1056,8 @@
       "version": "1.0.0"
     },
     "doiuse": {
-      "version": "2.3.0",
+      "version": "2.4.1",
       "dependencies": {
-        "lodash": {
-          "version": "3.10.1"
-        },
         "source-map": {
           "version": "0.4.4"
         }
@@ -1121,7 +1118,7 @@
       }
     },
     "duplexify": {
-      "version": "3.4.3"
+      "version": "3.4.5"
     },
     "ee-first": {
       "version": "1.1.1"
@@ -1798,7 +1795,7 @@
       "version": "0.0.0"
     },
     "i18n-calypso": {
-      "version": "1.3.1",
+      "version": "1.4.1",
       "dependencies": {
         "async": {
           "version": "1.5.2"
@@ -2421,7 +2418,7 @@
       "version": "0.0.5"
     },
     "nan": {
-      "version": "2.3.5"
+      "version": "2.4.0"
     },
     "ncname": {
       "version": "1.0.0"
@@ -2758,9 +2755,6 @@
     "pipetteur": {
       "version": "2.0.3"
     },
-    "pkg-conf": {
-      "version": "1.1.3"
-    },
     "plur": {
       "version": "2.1.2"
     },
@@ -2791,7 +2785,7 @@
       "version": "0.1.8"
     },
     "postcss-selector-parser": {
-      "version": "2.1.0"
+      "version": "2.1.1"
     },
     "postcss-value-parser": {
       "version": "3.3.0"
@@ -3117,12 +3111,15 @@
       "version": "1.1.3"
     },
     "request": {
-      "version": "2.72.0",
+      "version": "2.73.0",
       "dependencies": {
         "qs": {
-          "version": "6.1.0"
+          "version": "6.2.0"
         }
       }
+    },
+    "require-directory": {
+      "version": "2.1.1"
     },
     "require-from-string": {
       "version": "1.2.0"
@@ -3216,20 +3213,14 @@
     "sass-graph": {
       "version": "2.1.2",
       "dependencies": {
-        "camelcase": {
-          "version": "3.0.0"
-        },
         "cliui": {
           "version": "3.2.0"
-        },
-        "set-blocking": {
-          "version": "1.0.0"
         },
         "window-size": {
           "version": "0.2.0"
         },
         "yargs": {
-          "version": "4.7.1"
+          "version": "4.8.0"
         }
       }
     },
@@ -3508,6 +3499,9 @@
     "stream-combiner": {
       "version": "0.2.2"
     },
+    "stream-shift": {
+      "version": "1.0.0"
+    },
     "string_decoder": {
       "version": "0.10.31"
     },
@@ -3656,9 +3650,6 @@
     },
     "swap-case": {
       "version": "1.1.2"
-    },
-    "symbol": {
-      "version": "0.2.3"
     },
     "symbol-tree": {
       "version": "3.1.4"
@@ -3958,6 +3949,9 @@
     },
     "which": {
       "version": "1.2.10"
+    },
+    "which-module": {
+      "version": "1.0.0"
     },
     "wide-align": {
       "version": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "flux": "2.1.1",
     "he": "0.5.0",
     "html-loader": "0.4.0",
-    "i18n-calypso": "1.3.1",
+    "i18n-calypso": "1.4.1",
     "immutable": "3.8.1",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",


### PR DESCRIPTION
Fixes #6520 

This PR updates to the last version of `i18-calypso` which includes this small fix:
https://github.com/Automattic/i18n-calypso/commit/54935da1010f6d200d1e3ba39252de86950a0975

#### Testing Instructions
- Use Safari on a mac to remote debug an iOS device
- Load https://calypso.live/?branch=master and check that the following error is displayed in the console when you go to Stats and switch from `Insight` to `Days`:
```
TypeError: listener must be a function
```
- Check that the following error is displayed in the console when you switch from `Days` to `Insight`:
```
TypeError: null is not an object (evaluating 'computedStyle.getPropertyValue')
```
- Load https://calypso.live/?branch=fix/ios-listener-typeerror and check that the 2 errors are no more

### Reviews
- [x] Code
- [x] Product

@yoavf @aerych 