### PR TITLE
Fix styles that were altered during Olark's recent updates.

### DIFF
--- a/assets/stylesheets/shared/_livechat.scss
+++ b/assets/stylesheets/shared/_livechat.scss
@@ -491,6 +491,7 @@
 	padding:0;
 	margin: 8px 0 0 0;
 	overflow:visible;
+	text-indent: 0px !important;
 }
 
 #habla_window_div .habla_conversation_person1 {
@@ -842,7 +843,7 @@
 	display: block;
 }
 
-#habla_conversation_div .habla_conversation_text_span {
+#habla_conversation_div .habla_conversation_text_span.hbl_pal_main_fg {
 	display: block;
 	margin-left: 48px;
 }
@@ -855,11 +856,6 @@
 	text-transform: capitalize;
 	display: inline-block;
 	white-space: nowrap;
-}
-
-#habla_conversation_div .habla_conversation_p_item:not(:first-child) .hbl_pal_local_fg,
-#habla_conversation_div .habla_conversation_p_item:not(:first-child) .hbl_pal_remote_fg {
-	margin-top: 16px;
 }
 
 #habla_conversation_div .olrk_avatar {

--- a/client/me/help/help-contact/style.scss
+++ b/client/me/help/help-contact/style.scss
@@ -36,6 +36,7 @@
 
 		#habla_chatform_form {
 			margin-top: 0px;
+			padding-left: 0px;
 		}
 
 		#habla_input_div {
@@ -47,7 +48,7 @@
 
 		#habla_wcsend_input {
 			border: none;
-			resize: none;
+			resize: none !important;
 		}
 
 		#habla_middle_div {
@@ -57,6 +58,7 @@
 		#habla_conversation_div .habla_conversation_p_item {
 			margin-left: 14px;
 			margin-right: 10px;
+			margin-top: 8px;
 		}
 	}
 }


### PR DESCRIPTION
Olark recently pushed out an update which caused some style breakage in calypso. This pull request attempts to fix some of the breakage.

### How to test:
1. Navigate to https://calypso.live/?branch=fix/olark-css-modifications
2. Click "My Sites" in the upper left corner
3. Click "Help" in the bottom left corner. (You may need to scroll to see it)
4. Scroll down and click "Contact us"
5. Fill out all fields to start a chat.
6. Chat with a Happiness Engineer. Try entering lots of text so that it wraps to a new line and also try sending a few messages so that there are many messages.

Before:
![screen shot 2016-07-11 at 10 12 47 pm](https://cloud.githubusercontent.com/assets/1854440/16753114/dfb74382-47b4-11e6-8065-c6dd6c276afa.png)

After:
![screen shot 2016-07-11 at 10 11 58 pm](https://cloud.githubusercontent.com/assets/1854440/16753109/d67cb194-47b4-11e6-940f-9f3b0133c76c.png)


Note: there are many other CSS issues caused by Olark's recent update but this pull request aims to fix the issues in the chat box.


Test live: https://calypso.live/?branch=fix/olark-css-modifications