### PR TITLE
Plans: correct the google vouchers config string

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -18,9 +18,10 @@ import PurchaseDetail from 'components/purchase-detail';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
 
 const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
-	const adminUrl = selectedSite.URL + '/wp-admin/',
-		customizeLink = config.isEnabled( 'manage/customize' ) ? '/customize/' + selectedSite.slug : adminUrl + 'customize.php?return=' + encodeURIComponent( window.location.href ),
-		plan = find( sitePlans.data, isPremium );
+	const adminUrl = selectedSite.URL + '/wp-admin/';
+	const customizerInAdmin = adminUrl + 'customize.php?return=' + encodeURIComponent( window.location.href );
+	const customizeLink = config.isEnabled( 'manage/customize' ) ? '/customize/' + selectedSite.slug : customizerInAdmin;
+	const plan = find( sitePlans.data, isPremium );
 
 	return (
 		<div>
@@ -37,8 +38,8 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 				}
 			/>
 
-			{ config.isEnabled( 'googleVouchers' ) && <QuerySiteVouchers siteId={ selectedSite.ID } /> }
-			{ config.isEnabled( 'googleVouchers' ) &&
+			{ config.isEnabled( 'google-voucher' ) && <QuerySiteVouchers siteId={ selectedSite.ID } /> }
+			{ config.isEnabled( 'google-voucher' ) &&
 				<div>
 					<GoogleVoucherDetails selectedSite={ selectedSite } />
 				</div>


### PR DESCRIPTION
I had a bug in #6591 that resulted in the google-vouchers being hidden on the "my-plan" page because I was using the split-test name for a config check instead of the config string ("googleVouchers" rather than "google-voucher"). This changes corrects it.

I'm also addressing a linting error with a line that is too long. I don't think we really need the config check or ternary on that line anymore, but I think it'd be better to discuss that separately from this change.

## Testing
Just go to the "my-plan" page for any business site and make sure you see the card for the google-voucher feature.

Test live: https://calypso.live/?branch=fix/google-voucher-my-plan