### PR TITLE
Purchases: update copy when a user owns an upgrade for a site they're not part of.

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -120,15 +120,18 @@ const ManagePurchase = React.createClass( {
 
 		return (
 			<div className="manage-purchase__contact-support">
-				{ this.translate( '{{strong}}Looking to renew?{{/strong}} Please {{contactSupportLink}}contact support{{/contactSupportLink}} to renew %(purchaseName)s.', {
-					args: {
-						purchaseName: getName( purchase )
-					},
-					components: {
-						strong: <strong />,
-						contactSupportLink: <a href={ support.CALYPSO_CONTACT } />
-					}
-				} ) }
+				{ this.translate( 'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
+				'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
+				'and consider transferring this purchase to another active user on %(siteSlug)s to avoid this issue in the future.',
+					{
+						args: {
+							purchaseName: getName( purchase ),
+							siteSlug: this.props.selectedSite.slug
+						},
+						components: {
+							contactSupportLink: <a href={ support.CALYPSO_CONTACT } />
+						}
+					} ) }
 			</div>
 		);
 	},


### PR DESCRIPTION
This pull request fixes #6482 by updating the copy of the message displayed when a user tries to renew a purchase on a site they're not part of.
  
The old message read as: Looking to renew? Please contact support to renew DOMAIN.

The new message is:

![screenshot-calypso localhost 3000 2016-07-12 13-08-18](https://cloud.githubusercontent.com/assets/1248436/16764977/c05ead54-4831-11e6-966d-54d81057e179.png)

#### Testing instructions
  
1. Run `git checkout update/ownership-copy-purchases` and start your server.
2. You can force the message to show by commenting lines 117-119 in `/client/me/purchases/manage-purchase/index.jsx`
2. Open the [Purchases](http://calypso.localhost:3000/purchases/) and click on any purchases
3. Check that the new message is displayed correctly -- including upgrade name, site slug and support URL.
  
#### Reviews
  
- [x] Code
- [x] Product
   
@Automattic/sdev-feed

Test live: https://calypso.live/?branch=update/ownership-copy-purchases