### PR TITLE
Theme Details State: Update active field on THEME_ACTIVATED

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -31,7 +31,6 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { isPremium, getForumUrl } from 'my-sites/themes/helpers';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCurrentTheme from 'components/data/query-current-theme';
-import { getCurrentTheme } from 'state/themes/current-theme/selectors';
 import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
 import actionLabels from 'my-sites/themes/action-labels';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
@@ -60,7 +59,6 @@ const ThemeSheet = React.createClass( {
 		// Connected props
 		selectedSite: React.PropTypes.object,
 		siteSlug: React.PropTypes.string,
-		currentTheme: React.PropTypes.object,
 		backPath: React.PropTypes.string,
 	},
 
@@ -86,15 +84,10 @@ const ThemeSheet = React.createClass( {
 		this.setState( { selectedAction: null } );
 	},
 
-	isActive() {
-		const { id, currentTheme } = this.props;
-		return currentTheme && currentTheme.id === id;
-	},
-
 	onPrimaryClick() {
 		if ( ! this.props.isLoggedIn ) {
 			this.props.signup( this.props );
-		} else if ( this.isActive() ) {
+		} else if ( this.props.active ) {
 			this.props.customize( this.props, this.props.selectedSite );
 		} else if ( this.props.price ) {
 			this.selectSiteAndDispatch( 'purchase' );
@@ -310,7 +303,7 @@ const ThemeSheet = React.createClass( {
 
 	renderPrice() {
 		let price = this.props.price;
-		if ( ! this.isLoaded() || this.isActive() ) {
+		if ( ! this.isLoaded() || this.props.active ) {
 			price = '';
 		} else if ( ! isPremium( this.props ) ) {
 			price = i18n.translate( 'Free' );
@@ -324,7 +317,7 @@ const ThemeSheet = React.createClass( {
 		const placeholder = <span className="theme__sheet-button-placeholder">loading......</span>;
 
 		let actionTitle;
-		if ( this.isActive() ) {
+		if ( this.props.active ) {
 			actionTitle = i18n.translate( 'Customize' );
 		} else if ( isLoggedIn && ! price ) {
 			actionTitle = i18n.translate( 'Activate this design' );
@@ -398,9 +391,8 @@ export default connect(
 	( state ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
-		const currentTheme = getCurrentTheme( state, selectedSite && selectedSite.ID );
 		const backPath = getBackPath( state );
-		return { selectedSite, siteSlug, currentTheme, backPath };
+		return { selectedSite, siteSlug, backPath };
 	},
 	{ signup, purchase, activate, customize }
 )( ThemeSheet );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -140,7 +140,7 @@ const ThemeSheet = React.createClass( {
 
 	renderBar() {
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
-		const title = this.props.name || placeholder;
+		const title = this.isLoaded() || placeholder;
 		const tag = this.props.author ? i18n.translate( 'by %(author)s', { args: { author: this.props.author } } ) : placeholder;
 
 		return (

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -10,9 +10,11 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 	SERVER_DESERIALIZE,
+	THEME_ACTIVATED,
 	THEME_DETAILS_RECEIVE,
 	THEME_DETAILS_RECEIVE_FAILURE,
 } from 'state/action-types';
+import { setActiveTheme } from '../themes/reducer';
 
 export default ( state = Map(), action ) => {
 	switch ( action.type ) {
@@ -35,6 +37,8 @@ export default ( state = Map(), action ) => {
 				} ) );
 		case THEME_DETAILS_RECEIVE_FAILURE:
 			return state.set( action.themeId, Map( { error: action.error } ) );
+		case THEME_ACTIVATED:
+			return state.update( setActiveTheme.bind( null, action.theme.id ) );
 		case DESERIALIZE:
 			return Map();
 		case SERVER_DESERIALIZE:

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -11,6 +11,7 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 	SERVER_DESERIALIZE,
+	THEME_ACTIVATED,
 	THEME_DETAILS_RECEIVE
 } from 'state/action-types';
 import reducer from '../reducer';
@@ -83,6 +84,55 @@ describe( 'reducer', () => {
 			active: false,
 			purchased: false
 		} );
+	} );
+
+	// Copied from state/themes/themes/test/reducer
+	it( 'should set the `active` field to true for the given ID on theme activation', () => {
+		const twentyfifteen = Map( {
+			name: 'Twenty Fifteen',
+			author: 'the WordPress team',
+			screenshot: 'https://i1.wp.com/theme.wordpress.com/wp-content/themes/pub/twentyfifteen/screenshot.png',
+			description: 'Our 2015 default theme is clean, blog-focused, and designed for clarity. ...',
+			descriptionLong: '<p>Something something</p>',
+			download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentyfifteen.zip',
+			taxonomies: {},
+			stylesheet: 'pub/twentyfifteen',
+			demo_uri: 'https://twentyfifteendemo.wordpress.com/',
+			active: true
+		} );
+		const twentysixteen = Map( {
+			name: 'Twenty Sixteen',
+			author: 'the WordPress team',
+			screenshot: 'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
+			description: 'Twenty Sixteen is a modernized take on an ever-popular WordPress layout — ...',
+			descriptionLong: '<p>Mumble Mumble</p>',
+			download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentysixteen.zip',
+			taxonomies: {},
+			stylesheet: 'pub/twentysixteen',
+			demo_uri: 'https://twentysixteendemo.wordpress.com/'
+		} );
+		const initialState = Map( { twentyfifteen, twentysixteen } );
+
+		const state = reducer( initialState, {
+			type: THEME_ACTIVATED,
+			theme: {
+				author: 'the WordPress team',
+				author_uri: 'https://wordpress.org/',
+				demo_uri: 'https://twentysixteendemo.wordpress.com/',
+				id: 'twentysixteen',
+				name: 'Twenty Sixteen',
+				screenshot: 'https://i0.wp.com'
+			},
+			site: {
+				ID: 2916284,
+				name: 'Testy McTestsite',
+				description: 'Nothing to see here. Move on.',
+				URL: 'https://example.wordpress.com'
+			}
+		} );
+
+		expect( state.get( 'twentysixteen' ).get( 'active' ) ).to.be.true;
+		expect( state.get( 'twentyfifteen' ).get( 'active' ) ).to.be.not.true;
 	} );
 
 	describe( 'persistence', () => {

--- a/client/state/themes/themes/reducer.js
+++ b/client/state/themes/themes/reducer.js
@@ -26,7 +26,7 @@ function add( newThemes, themes ) {
 	}, {} ) );
 }
 
-function setActiveTheme( themeId, themes ) {
+export function setActiveTheme( themeId, themes ) {
 	return themes
 		.map( theme => theme.delete( 'active' ) )
 		.setIn( [ themeId, 'active' ], true );

--- a/client/state/themes/themes/test/reducer.js
+++ b/client/state/themes/themes/test/reducer.js
@@ -4,6 +4,7 @@
 import { expect } from 'chai';
 import { fromJS } from 'immutable';
 import deepFreeze from 'deep-freeze';
+import { Map } from 'immutable';
 
 /**
  * Internal dependencies
@@ -11,11 +12,61 @@ import deepFreeze from 'deep-freeze';
 import {
 	SERIALIZE,
 	DESERIALIZE,
-	SERVER_DESERIALIZE
+	SERVER_DESERIALIZE,
+	THEME_ACTIVATED
 } from 'state/action-types';
 import reducer, { initialState } from '../reducer';
 
 describe( 'themes reducer', () => {
+	describe( 'theme activation', () => {
+		it( 'should set the `active` field to true for the given ID on theme activation', () => {
+			const twentyfifteen = Map( {
+				name: 'Twenty Fifteen',
+				author: 'the WordPress team',
+				screenshot: 'https://i1.wp.com/theme.wordpress.com/wp-content/themes/pub/twentyfifteen/screenshot.png',
+				description: 'Our 2015 default theme is clean, blog-focused, and designed for clarity. ...',
+				descriptionLong: '<p>Something something</p>',
+				download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentyfifteen.zip',
+				taxonomies: {},
+				stylesheet: 'pub/twentyfifteen',
+				demo_uri: 'https://twentyfifteendemo.wordpress.com/',
+				active: true
+			} );
+			const twentysixteen = Map( {
+				name: 'Twenty Sixteen',
+				author: 'the WordPress team',
+				screenshot: 'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
+				description: 'Twenty Sixteen is a modernized take on an ever-popular WordPress layout — ...',
+				descriptionLong: '<p>Mumble Mumble</p>',
+				download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentysixteen.zip',
+				taxonomies: {},
+				stylesheet: 'pub/twentysixteen',
+				demo_uri: 'https://twentysixteendemo.wordpress.com/'
+			} );
+
+			const state = reducer( Map( { themes: Map( { twentyfifteen, twentysixteen } ) } ), {
+				type: THEME_ACTIVATED,
+				theme: {
+					author: 'the WordPress team',
+					author_uri: 'https://wordpress.org/',
+					demo_uri: 'https://twentysixteendemo.wordpress.com/',
+					id: 'twentysixteen',
+					name: 'Twenty Sixteen',
+					screenshot: 'https://i0.wp.com'
+				},
+				site: {
+					ID: 2916284,
+					name: 'Testy McTestsite',
+					description: 'Nothing to see here. Move on.',
+					URL: 'https://example.wordpress.com'
+				}
+			} );
+
+			expect( state.getIn( [ 'themes', 'twentysixteen' ] ).get( 'active' ) ).to.be.true;
+			expect( state.getIn( [ 'themes', 'twentyfifteen' ] ).get( 'active' ) ).to.be.not.true;
+		} );
+	} );
+
 	describe( 'persistence', () => {
 		it( 'does not persist state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {


### PR DESCRIPTION
This PR drops the `isActive` method from the theme sheet and instead relies on the `active` property of the theme object returned from the theme details store. To keep it updated, the themes-details reducer now listens to `THEME_ACTIVATED`. I'm also adding a test to cover that functionality, and a slightly modified version of that test to cover the same functionality for the `themes` reducer.

This is still rather suboptimal. This is the third reducer covering essentially the same functionality (as evidenced by the imported function we're using here, and by the duplicated test). Ideally, it should be up to selectors to assemble data from single sources of truth. (I think that's one of the things `reselect` was made for.)

No visual changes. To test:
* On a theme sheet, activate the theme and verify that the button label changes to 'Customize' after activation.

Fixes #6595.

Test live: https://calypso.live/?branch=update/themes-details-reducer-update-active-field