### PR TITLE
Upgrades: Fix `<CountrySelect />` warning message.

### DIFF
--- a/client/my-sites/upgrades/components/form/country-select.jsx
+++ b/client/my-sites/upgrades/components/form/country-select.jsx
@@ -38,10 +38,10 @@ export default React.createClass( {
 		const countriesList = this.props.countriesList.get();
 		let options = [];
 		let { value } = this.props;
+		value = value || '';
 
 		if ( isEmpty( countriesList ) ) {
 			options.push( { key: 'loading', label: this.translate( 'Loading…' ), disabled: 'disabled' } );
-			value = '';
 		} else {
 			options = options.concat( [
 				{ key: 'select-country', label: this.translate( 'Select Country' ) },

--- a/client/my-sites/upgrades/components/form/country-select.jsx
+++ b/client/my-sites/upgrades/components/form/country-select.jsx
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	isEmpty = require( 'lodash/isEmpty' ),
-	ReactDom = require( 'react-dom' ),
-	observe = require( 'lib/mixins/data-observe' );
+import React from 'react';
+import classNames from 'classnames';
+import isEmpty from 'lodash/isEmpty';
+import ReactDom from 'react-dom';
+import observe from 'lib/mixins/data-observe';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
-	FormLabel = require( 'components/forms/form-label' ),
-	FormInputValidation = require( 'components/forms/form-input-validation' ),
-	scrollIntoViewport = require( 'lib/scroll-into-viewport' ),
-	FormSelect = require( 'components/forms/form-select' );
+import analytics from 'lib/analytics';
+import FormLabel from 'components/forms/form-label';
+import FormInputValidation from 'components/forms/form-input-validation';
+import scrollIntoViewport from 'lib/scroll-into-viewport';
+import FormSelect from 'components/forms/form-select';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'CountrySelect',
 
 	mixins: [ observe( 'countriesList' ) ],
@@ -28,20 +28,19 @@ module.exports = React.createClass( {
 	},
 
 	focus() {
-		var node = ReactDom.findDOMNode( this.refs.input );
+		const node = ReactDom.findDOMNode( this.refs.input );
 		node.focus();
 		scrollIntoViewport( node );
 	},
 
 	render() {
-		var classes = classNames( this.props.additionalClasses, 'country' ),
-			countriesList = this.props.countriesList.get(),
-			options = [],
-			value = this.props.value;
+		const classes = classNames( this.props.additionalClasses, 'country' );
+		const countriesList = this.props.countriesList.get();
+		let options = [];
+		let { value } = this.props;
 
 		if ( isEmpty( countriesList ) ) {
 			options.push( { key: 'loading', label: this.translate( 'Loading…' ), disabled: 'disabled' } );
-
 			value = '';
 		} else {
 			options = options.concat( [
@@ -49,12 +48,12 @@ module.exports = React.createClass( {
 				{ key: 'divider1', label: '', disabled: 'disabled' }
 			] );
 
-			options = options.concat( countriesList.map( function( country ) {
+			options = options.concat( countriesList.map( country => {
 				if ( isEmpty( country.code ) ) {
 					return { key: 'divider2', label: '', disabled: 'disabled' };
-				} else {
-					return { key: country.code, label: country.name, value: country.code };
 				}
+
+				return { key: country.code, label: country.name, value: country.code };
 			} ) );
 		}
 
@@ -62,6 +61,7 @@ module.exports = React.createClass( {
 			<div className={ classes }>
 				<div>
 					<FormLabel htmlFor={ this.props.name }>{ this.props.label }</FormLabel>
+
 					<FormSelect
 						name={ this.props.name }
 						value={ value }
@@ -70,11 +70,18 @@ module.exports = React.createClass( {
 						onChange={ this.props.onChange }
 						onClick={ this.recordCountrySelectClick }
 						isError={ this.props.isError } >
-						{ options.map( function( option ) {
-							return <option key={ option.key } value={ option.value || '' } disabled={ option.disabled }>{ option.label }</option>;
-						} ) }
+						{ options.map( option => (
+							<option
+								key={ option.key }
+								value={ option.value }
+								disabled={ option.disabled }
+							>
+								{ option.label }
+							</option>
+						) ) }
 					</FormSelect>
 				</div>
+
 				{ this.props.errorMessage && <FormInputValidation text={ this.props.errorMessage } isError /> }
 			</div>
 		);


### PR DESCRIPTION
This PR set an empty string as default value of the select element of the `<CountrySelect />` component. It fixes the following warning:

![](https://cldup.com/4YWPTQ0SnE.png)

Also fixes ESlint warnings and applies ES6 syntax.

###Testing

I was working on the payment page when I got the warning. So to reproduce it:

1) Go to checkout page of a site, for instance `http://calypso.localhost:3000/checkout/<your-testing-blog>`
2) Open the console n the dev tools and look the warning on another branch, for instance `master`
3) Switch to this branch. The warning should despair.

Note: Maybe we should add a example component here.


Test live: https://calypso.live/?branch=fix/upgrades-country-selector