### PR TITLE
Purchases: Remove assembler in favor of selector

### DIFF
--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -1,5 +1,6 @@
 // External dependencies
 import i18n from 'i18n-calypso';
+import { omit, values } from 'lodash';
 
 // Internal dependencies
 import olark from 'lib/olark';
@@ -18,12 +19,21 @@ import {
 	PURCHASE_REMOVE_COMPLETED,
 	PURCHASE_REMOVE_FAILED
 } from 'state/action-types';
-import purchasesAssembler from 'lib/purchases/assembler';
 import wp from 'lib/wp';
 const wpcom = wp.undocumented();
 
 const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' ),
 	PURCHASE_REMOVE_ERROR_MESSAGE = i18n.translate( 'There was an error removing the purchase.' );
+
+/**
+ * `wpcom` assigns a `_headers` property to the response, even if the response
+ * is an array. This function omits the `_headers` property and converts the
+ * response to a real array, instead of an object keyed with indices.
+ *
+ * @param {Object} response - The response to a request from `wpcom`.
+ * @return {array} response - The given response converted into an array.
+ */
+const getArrayFromResponse = response => values( omit( response, '_headers' ) );
 
 export const cancelPrivateRegistration = purchaseId => dispatch => {
 	dispatch( {
@@ -38,7 +48,7 @@ export const cancelPrivateRegistration = purchaseId => dispatch => {
 	} ).then( data => {
 		dispatch( {
 			type: PRIVACY_PROTECTION_CANCEL_COMPLETED,
-			purchase: purchasesAssembler.createPurchaseObject( data.upgrade )
+			purchase: data.upgrade
 		} );
 	} ).catch( error => {
 		dispatch( {
@@ -76,7 +86,7 @@ export const fetchSitePurchases = siteId => dispatch => {
 		dispatch( {
 			type: PURCHASES_SITE_FETCH_COMPLETED,
 			siteId,
-			purchases: purchasesAssembler.createPurchasesArray( data )
+			purchases: getArrayFromResponse( data )
 		} );
 	} ).catch( () => {
 		dispatch( {
@@ -98,7 +108,7 @@ export const fetchUserPurchases = userId => dispatch => {
 	} ).then( data => {
 		dispatch( {
 			type: PURCHASES_USER_FETCH_COMPLETED,
-			purchases: purchasesAssembler.createPurchasesArray( data ),
+			purchases: getArrayFromResponse( data ),
 			userId
 		} );
 	} ).catch( () => {
@@ -122,7 +132,7 @@ export const removePurchase = ( purchaseId, userId ) => dispatch => {
 	} ).then( data => {
 		dispatch( {
 			type: PURCHASE_REMOVE_COMPLETED,
-			purchases: purchasesAssembler.createPurchasesArray( data.purchases ),
+			purchases: data.purchases,
 			userId
 		} );
 

--- a/client/state/purchases/reducer.js
+++ b/client/state/purchases/reducer.js
@@ -39,7 +39,7 @@ function updatePurchaseById( state, id, properties ) {
 	return {
 		...state,
 		data: state.data.map( purchase => {
-			if ( id === purchase.id ) {
+			if ( id === purchase.ID ) {
 				return { ...purchase, ...properties };
 			}
 			return purchase;
@@ -59,7 +59,7 @@ function overwriteExistingPurchases( existingPurchases, newPurchases ) {
 	let purchases = newPurchases;
 
 	existingPurchases.forEach( purchase => {
-		if ( ! find( purchases, { id: purchase.id } ) ) {
+		if ( ! find( purchases, { ID: purchase.ID } ) ) {
 			purchases = purchases.concat( purchase );
 		}
 	} );
@@ -77,7 +77,7 @@ function overwriteExistingPurchases( existingPurchases, newPurchases ) {
  */
 function removeMissingPurchasesByPredicate( existingPurchases, newPurchases, predicate ) {
 	return existingPurchases.filter( purchase => {
-		if ( matches( predicate )( purchase ) && find( newPurchases, { id: purchase.id } ) ) {
+		if ( matches( predicate )( purchase ) && find( newPurchases, { ID: purchase.ID } ) ) {
 			// this purchase is present in the new array
 			return true;
 		}
@@ -96,12 +96,12 @@ function updatePurchases( existingPurchases, action ) {
 	let purchases, predicate;
 
 	if ( PURCHASES_SITE_FETCH_COMPLETED === action.type ) {
-		predicate = { siteId: action.siteId };
+		predicate = { blog_id: action.siteId };
 	}
 
 	if ( PURCHASES_USER_FETCH_COMPLETED === action.type ||
 		PURCHASE_REMOVE_COMPLETED === action.type ) {
-		predicate = { userId: action.userId };
+		predicate = { user_id: action.userId };
 	}
 
 	purchases = removeMissingPurchasesByPredicate( existingPurchases, action.purchases, predicate );
@@ -161,7 +161,7 @@ export default createReducer( initialState, {
 	[ PURCHASES_SITE_FETCH_FAILED ]: assignError,
 	[ PURCHASES_USER_FETCH_FAILED ]: assignError,
 
-	[ PRIVACY_PROTECTION_CANCEL_COMPLETED ]: ( state, action ) => updatePurchaseById( state, action.purchase.id, action.purchase ),
+	[ PRIVACY_PROTECTION_CANCEL_COMPLETED ]: ( state, action ) => updatePurchaseById( state, action.purchase.ID, action.purchase ),
 
 	[ PRIVACY_PROTECTION_CANCEL_FAILED ]: ( state, action ) => updatePurchaseById( state, action.purchaseId, {
 		error: action.error

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -1,3 +1,6 @@
+import createSelector from 'lib/create-selector';
+import purchasesAssembler from 'lib/purchases/assembler';
+
 /**
  * Return the list of purchases from state object
  *
@@ -21,7 +24,7 @@ export const getPurchasesError = state => state.purchases.error;
  * @return {Object} the matching purchase if there is one
  */
 export const getByPurchaseId = ( state, purchaseId ) => (
-	getPurchases( state ).filter( purchase => purchase.id === purchaseId ).shift()
+	purchasesAssembler.createPurchasesArray( getPurchases( state ).filter( purchase => purchase.ID === purchaseId ) ).shift()
 );
 
 /**

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -16,11 +16,9 @@ import {
 	PURCHASE_REMOVE_COMPLETED,
 } from 'state/action-types';
 import useMockery from 'test/helpers/use-mockery';
-import purchasesAssembler from 'lib/purchases/assembler';
 
 describe( 'actions', () => {
-	const purchases = [ { id: 1 } ],
-		assembledPurchases = purchasesAssembler.createPurchasesArray( purchases ),
+	const purchases = [ { ID: 1 } ],
 		userId = 1337,
 		siteId = 1234,
 		purchaseId = 31337;
@@ -78,7 +76,7 @@ describe( 'actions', () => {
 			return promise.then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PRIVACY_PROTECTION_CANCEL_COMPLETED,
-					purchase: assembledPurchases[ 0 ]
+					purchase: purchases[ 0 ]
 				} );
 			} );
 		} );
@@ -103,7 +101,7 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PURCHASES_SITE_FETCH_COMPLETED,
 					siteId,
-					purchases: assembledPurchases
+					purchases
 				} );
 			} );
 		} );
@@ -127,7 +125,7 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PURCHASES_USER_FETCH_COMPLETED,
 					userId,
-					purchases: assembledPurchases
+					purchases
 				} );
 			} );
 		} );
@@ -153,7 +151,7 @@ describe( 'actions', () => {
 			return promise.then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PURCHASE_REMOVE_COMPLETED,
-					purchases: assembledPurchases,
+					purchases,
 					userId
 				} );
 			} );

--- a/client/state/purchases/test/reducer.js
+++ b/client/state/purchases/test/reducer.js
@@ -13,7 +13,6 @@ import {
 	PRIVACY_PROTECTION_CANCEL_COMPLETED,
 	PRIVACY_PROTECTION_CANCEL_FAILED
 } from 'state/action-types';
-import { getByPurchaseId } from '../selectors';
 import reducer from '../reducer';
 
 describe( 'reducer', () => {
@@ -45,19 +44,19 @@ describe( 'reducer', () => {
 	it( 'should return an object with the list of purchases when fetching completed', () => {
 		let state = reducer( undefined, {
 			type: PURCHASES_USER_FETCH_COMPLETED,
-			purchases: [ { id: 1, siteId, userId }, { id: 2, siteId, userId } ]
+			purchases: [ { ID: 1, blog_id: siteId, user_id: userId }, { ID: 2, blog_id: siteId, user_id: userId } ]
 		} );
 
 		state = reducer( state, {
 			type: PURCHASES_SITE_FETCH_COMPLETED,
-			purchases: [ { id: 2, siteId, userId }, { id: 3, siteId, userId } ]
+			purchases: [ { ID: 2, blog_id: siteId, user_id: userId }, { ID: 3, blog_id: siteId, user_id: userId } ]
 		} );
 
 		expect( state ).to.be.eql( {
 			data: [
-				{ id: 2, siteId, userId },
-				{ id: 3, siteId, userId },
-				{ id: 1, siteId, userId } ],
+				{ ID: 2, blog_id: siteId, user_id: userId },
+				{ ID: 3, blog_id: siteId, user_id: userId },
+				{ ID: 1, blog_id: siteId, user_id: userId } ],
 			error: null,
 			isFetchingSitePurchases: false,
 			isFetchingUserPurchases: false,
@@ -66,12 +65,12 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	it( 'should only remove purchases missing from the new purchases array with the same `userId` or `siteId`', () => {
+	it( 'should only remove purchases missing from the new purchases array with the same `user_id` or `blog_id`', () => {
 		let state = {
 			data: [
-				{ id: 2, siteId, userId },
-				{ id: 3, siteId, userId },
-				{ id: 1, siteId, userId } ],
+				{ ID: 2, blog_id: siteId, user_id: userId },
+				{ ID: 3, blog_id: siteId, user_id: userId },
+				{ ID: 1, blog_id: siteId, user_id: userId } ],
 			error: null,
 			isFetchingSitePurchases: false,
 			isFetchingUserPurchases: false,
@@ -79,13 +78,13 @@ describe( 'reducer', () => {
 			hasLoadedUserPurchasesFromServer: true
 		};
 
-		const newPurchase = { id: 4, siteId: 2702, userId };
+		const newPurchase = { ID: 4, blog_id: 2702, user_id: userId };
 
 		state = reducer( state, {
 			type: PURCHASES_USER_FETCH_COMPLETED,
 			purchases: [
-				{ id: 1, siteId, userId },
-				{ id: 2, siteId, userId },
+				{ ID: 1, blog_id: siteId, user_id: userId },
+				{ ID: 2, blog_id: siteId, user_id: userId },
 				newPurchase // include purchase with new `siteId`
 			],
 			userId
@@ -93,8 +92,8 @@ describe( 'reducer', () => {
 
 		expect( state ).to.be.eql( {
 			data: [
-				{ id: 1, siteId, userId },
-				{ id: 2, siteId, userId },
+				{ ID: 1, blog_id: siteId, user_id: userId },
+				{ ID: 2, blog_id: siteId, user_id: userId },
 				newPurchase // purchase with ID 3 was removed, `newPurchase` was added
 			],
 			error: null,
@@ -106,14 +105,14 @@ describe( 'reducer', () => {
 
 		state = reducer( state, {
 			type: PURCHASES_SITE_FETCH_COMPLETED,
-			purchases: [ { id: 2, siteId, userId } ],
+			purchases: [ { ID: 2, blog_id: siteId, user_id: userId } ],
 			siteId
 		} );
 
 		expect( state ).to.be.eql( {
 			data: [
-				{ id: 2, siteId, userId },
-				{ id: 4, siteId: 2702, userId } // the new purchase was not removed because it has a different `siteId`
+				{ ID: 2, blog_id: siteId, user_id: userId },
+				{ ID: 4, blog_id: 2702, user_id: userId } // the new purchase was not removed because it has a different `blog_id`
 			],
 			error: null,
 			isFetchingSitePurchases: false,
@@ -126,8 +125,8 @@ describe( 'reducer', () => {
 	it( 'should return an object with original purchase and error message when cancelation of private registration failed', () => {
 		let state = {
 			data: [
-				{ id: 2, siteId, userId },
-				{ id: 4, siteId: 2702, userId } // the new purchase was not removed because it has a different `siteId`
+				{ ID: 2, blog_id: siteId, user_id: userId },
+				{ ID: 4, blog_id: 2702, user_id: userId }
 			],
 			error: null,
 			isFetchingSitePurchases: false,
@@ -142,19 +141,33 @@ describe( 'reducer', () => {
 			purchaseId: 2
 		} );
 
-		expect( getByPurchaseId( { purchases: state }, 2 ) ).to.be.eql( {
-			id: 2,
-			error: 'Unable to fetch stored cards',
-			siteId,
-			userId
+		expect( state ).to.be.eql( {
+			data: [
+				{
+					ID: 2,
+					blog_id: siteId,
+					user_id: userId,
+					error: 'Unable to fetch stored cards'
+				},
+				{
+					ID: 4,
+					blog_id: 2702,
+					user_id: userId
+				}
+			],
+			error: null,
+			isFetchingSitePurchases: false,
+			isFetchingUserPurchases: false,
+			hasLoadedSitePurchasesFromServer: true,
+			hasLoadedUserPurchasesFromServer: true
 		} );
 	} );
 
 	it( 'should return an object with updated purchase when cancelation of private registration completed', () => {
 		let state = {
 			data: [
-				{ id: 2, siteId, userId },
-				{ id: 4, siteId: 2702, userId }
+				{ ID: 2, blog_id: siteId, user_id: userId },
+				{ ID: 4, blog_id: 2702, user_id: userId }
 			],
 			error: null,
 			isFetchingSitePurchases: false,
@@ -166,22 +179,36 @@ describe( 'reducer', () => {
 		state = reducer( state, {
 			type: PRIVACY_PROTECTION_CANCEL_COMPLETED,
 			purchase: {
+				ID: 2,
+				blog_id: siteId,
+				user_id: userId,
 				amount: 2200,
 				error: null,
-				hasPrivateRegistration: false,
-				id: 2,
-				siteId,
-				userId
+				has_private_registration: false,
 			}
 		} );
 
-		expect( getByPurchaseId( { purchases: state }, 2 ) ).to.be.eql( {
-			amount: 2200,
+		expect( state ).to.be.eql( {
+			data: [
+				{
+					ID: 2,
+					blog_id: siteId,
+					user_id: userId,
+					amount: 2200,
+					error: null,
+					has_private_registration: false
+				},
+				{
+					ID: 4,
+					blog_id: 2702,
+					user_id: userId
+				}
+			],
 			error: null,
-			hasPrivateRegistration: false,
-			id: 2,
-			siteId,
-			userId
+			isFetchingSitePurchases: false,
+			isFetchingUserPurchases: false,
+			hasLoadedSitePurchasesFromServer: true,
+			hasLoadedUserPurchasesFromServer: true
 		} );
 	} );
 } );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -10,8 +10,8 @@ describe( 'selectors', () => {
 			const state = {
 				purchases: {
 					data: [
-						{ id: 1, name: 'domain registration' },
-						{ id: 2, name: 'premium plan' }
+						{ ID: 1, product_name: 'domain registration', blog_id: 1337 },
+						{ ID: 2, product_name: 'premium plan', blog_id: 1337 }
 					],
 					error: null,
 					isFetchingSitePurchases: false,
@@ -21,7 +21,48 @@ describe( 'selectors', () => {
 				}
 			};
 
-			expect( getByPurchaseId( state, 2 ) ).to.be.eql( { id: 2, name: 'premium plan' } );
+			expect( getByPurchaseId( state, 2 ) ).to.be.eql( {
+				id: 2,
+				productName: 'premium plan',
+				siteId: 1337,
+				active: false,
+				amount: NaN,
+				attachedToPurchaseId: NaN,
+				canDisableAutoRenew: false,
+				currencyCode: undefined,
+				currencySymbol: undefined,
+				domain: undefined,
+				error: null,
+				expiryDate: undefined,
+				expiryMoment: null,
+				expiryStatus: '',
+				hasPrivateRegistration: false,
+				includedDomain: undefined,
+				isCancelable: false,
+				isDomainRegistration: false,
+				isRedeemable: false,
+				isRefundable: false,
+				isRenewable: false,
+				meta: undefined,
+				payment: {
+					countryCode: undefined,
+					countryName: undefined,
+					name: undefined,
+					type: undefined
+				},
+				priceText: 'undefinedundefined',
+				productId: NaN,
+				productSlug: undefined,
+				refundPeriodInDays: undefined,
+				refundText: 'undefinedundefined',
+				renewDate: undefined,
+				renewMoment: null,
+				siteName: undefined,
+				subscribedDate: undefined,
+				subscriptionStatus: undefined,
+				tagLine: undefined,
+				userId: NaN
+			} );
 		} );
 	} );
 

--- a/test/test/helpers/use-mockery/index.js
+++ b/test/test/helpers/use-mockery/index.js
@@ -14,6 +14,8 @@ const log = debug( 'calypso:test:use-mockery' );
  */
 export default function useMockery( beforeActions = noop, afterActions = noop ) {
 	before( function turnOnMockery() {
+		// mockery can take a lot of resources, increasing timeout a bit so we don't run into errors
+		this.timeout( 10000 );
 		log( 'turning on mockery' );
 		mockery.enable( {
 			warnOnReplace: false,


### PR DESCRIPTION
This PR moves the purchases assembler from the actions to the selector. The idea is to keep raw data from the API into the global store. Selectors are responsible for converting this raw data and adding more props. This PR does not update the actual assembler.

### Testing instructions
- `git checkout update/purchases-remove-assembler`
- `npm run test-client client/state/purchases`

### Reviews
- [x] Tests
- [x] Code
