### PR TITLE
Components: Remove last modified label from draft relative time

### DIFF
--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -140,18 +140,10 @@
 	margin: 0;
 	color: $gray;
 
-	.time {
+	.post-relative-time-status__time {
 		line-height: 1;
-	}
-
-	.time-text {
 		font-size: 10px;
-		color: $gray;
 		text-transform: uppercase;
-	}
-
-	small {
-		display: none;
 	}
 
 	.is-pending {

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -31,27 +31,32 @@ module.exports = React.createClass( {
 	},
 
 	getRelativeTimeText: function() {
-		var status = this.props.post.status,
-			time, timeReference;
+		const status = this.props.post.status;
 
+		let time;
 		if ( status === 'draft' || status === 'pending' ) {
 			time = this.props.post.modified;
-			timeReference = ( <small>{ this.translate( ' (last-modified)' ) }</small> );
 		} else if ( status !== 'new' ) {
 			time = this.props.post.date;
-			timeReference = null;
 		}
 
 		if ( ! time ) {
-			return null;
+			return;
 		}
 
-		return ( <span className="time"><Gridicon icon="time" size={ 18 } /><span className="time-text">{ this.moment( time ).fromNow() }</span>{ timeReference }</span> );
+		return (
+			<span className="post-relative-time-status__time">
+				<Gridicon icon="time" size={ 18 } />
+				<span className="post-relative-time-status__time-text">
+					{ this.moment( time ).fromNow() }
+				</span>
+			</span>
+		);
 	},
 
 	getStatusText: function() {
 		var status = this.props.post.status,
-			statusClassName = 'status',
+			statusClassName = 'post-relative-time-status__status',
 			statusIcon = 'aside',
 			statusText;
 
@@ -81,7 +86,14 @@ module.exports = React.createClass( {
 		}
 
 		if ( statusText ) {
-			return ( <span className={ statusClassName }><Gridicon icon={ statusIcon } size={ 18 } /><span className="status-text">{ statusText }</span></span> );
+			return (
+				<span className={ statusClassName }>
+					<Gridicon icon={ statusIcon } size={ 18 } />
+					<span className="post-relative-time-status__status-text">
+						{ statusText }
+					</span>
+				</span>
+			);
 		}
 	},
 

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -1,21 +1,4 @@
 .post-relative-time-status {
-	.time,
-	.status {
-		display: inline-block;
-		margin-right: (11 / 12) * 1em;
-	}
-
-	.time .time-text {
-		display: inline-block;
-		&::first-letter {
-			text-transform: capitalize;
-		}
-	}
-
-	.status .status-text {
-		text-transform: capitalize;
-	}
-
 	.gridicon {
 		display: inline-block;
 		margin: -4px 8px 0 0;
@@ -37,4 +20,23 @@
 			color: $alert-red;
 		}
 	}
+}
+
+.post-relative-time-status__time,
+.post-relative-time-status__status {
+	display: inline-block;
+	margin-right: ( 11 / 12 ) * 1em;
+}
+
+
+.post-relative-time-status__time-text {
+	display: inline-block;
+
+	&::first-letter {
+		text-transform: capitalize;
+	}
+}
+
+.post-relative-time-status__status-text {
+	text-transform: capitalize;
 }


### PR DESCRIPTION
This pull request seeks to remove the `(last-modified)` small label shown adjacent the `<PostRelativeTimeStatus />` component when the post is a draft. Currently, this is only shown on the custom post types screen because it of a [rule to hide it on the `<DraftsList />`](https://github.com/Automattic/wp-calypso/blob/c7326a9781085173afde96c38222977b0f275c85/client/my-sites/draft/style.scss#L153-L155) (which itself is [not available in production](https://github.com/Automattic/wp-calypso/blob/c7326a9781085173afde96c38222977b0f275c85/config/wpcalypso.json#L40)).

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/16771921/3aa03c66-4820-11e6-9865-bc833647f179.png)|![After](https://cloud.githubusercontent.com/assets/1779930/16771927/3dace7c4-4820-11e6-8b5b-5a1a27615a67.png)

__Testing instructions:__

Verify that no visual regressions occur in the display of `<PostRelativeTimeStatus />`, aside from the removal of `(last-modified)` for draft posts.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site, if prompted
3. Assuming published posts exist, confirm that the date display is identical to current master
4. Change to the Drafts filter
5. Note that the date display lacks `(last-modified)` but otherwise appears the same as on the published filter

/cc @hugobaeta @folletto @mtias 

Test live: https://calypso.live/?branch=remove/draft-last-modified