### PR TITLE
Reader: Ask for and consume site info for search streams

### DIFF
--- a/client/components/post-card/author-and-site.jsx
+++ b/client/components/post-card/author-and-site.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import partial from 'lodash/partial';
 import noop from 'lodash/noop';
 import { localize } from 'i18n-calypso';
+import Immutable from 'immutable';
 
 /**
  * Internal Dependencies
@@ -13,6 +14,9 @@ import Gravatar from 'components/gravatar';
 
 export function AuthorAndSite( { translate, post, site, feed, showGravatar = false, onClick = noop } ) {
 	const displayName = post.author && post.author.name;
+	if ( Immutable.Iterable.isIterable( site ) ) {
+		site = site.toJS();
+	}
 	const siteName = site && site.title || post.site_name;
 
 	const username = (

--- a/client/components/post-card/search.jsx
+++ b/client/components/post-card/search.jsx
@@ -44,6 +44,7 @@ export function SearchPostCard( { post, site, feed, onClick = noop, onCommentCli
 		'has-thumbnail': !! featuredImage,
 		'is-photo': hasPost && ( post.display_type & DisplayTypes.PHOTO_ONLY )
 	} );
+
 	return (
 		<Card className={ classes } onClick={ partial( onClick, { post, site, feed } ) }>
 		{ featuredImage && <FeaturedImage image={ featuredImage } href={ post.URL } /> }

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -7,6 +7,7 @@ var Dispatcher = require( 'dispatcher' ),
 	ActionType = require( './constants' ).action,
 	FeedPostStoreActions = require( 'lib/feed-post-store/actions' ),
 	feedPostListCache = require( './feed-stream-cache' ),
+	SiteStoreActions = require( 'lib/reader-site-store/actions' ),
 	FeedStreamActions;
 
 function getNextPageParams( store ) {
@@ -71,6 +72,10 @@ FeedStreamActions = {
 						blogId: post.meta.data.discover_original_post.site_ID,
 						postId: post.meta.data.discover_original_post.ID
 					} );
+				}
+
+				if ( get( post, 'meta.data.site' ) ) {
+					SiteStoreActions.receiveFetch( post.site_ID, null, post.meta.data.site );
 				}
 
 				if ( post && get( post, 'meta.data.post' ) ) {

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -6,7 +6,7 @@ var config = require( 'config' ),
 	FeedStream = require( './feed-stream' ),
 	PagedStream = require( './paged-stream' ),
 	FeedStreamCache = require( './feed-stream-cache' ),
-	analytics = require( 'lib/analytics'),
+	analytics = require( 'lib/analytics' ),
 	forEach = require( 'lodash/forEach' ),
 	wpcomUndoc = require( 'lib/wp' ).undocumented();
 
@@ -92,6 +92,7 @@ function getStoreForSearch( storeId ) {
 	const slug = storeId.split( ':' )[ 1 ];
 	const fetcher = function( query, callback ) {
 		query.q = slug;
+		query.meta = 'site';
 		wpcomUndoc.readSearch( query, callback );
 	};
 
@@ -230,7 +231,7 @@ function feedStoreFactory( storeId ) {
 		store = getStoreForFeatured( storeId );
 	} else if ( storeId.indexOf( 'search:' ) === 0 ) {
 		store = getStoreForSearch( storeId );
-	}else {
+	} else {
 		throw new Error( 'Unknown feed store ID' );
 	}
 


### PR DESCRIPTION
Also properly deal with site objects that are the immutable version from reader-site-store.

Knew I should have made those records.

Test live: https://calypso.live/?branch=fix/reader/blank-site-title-in-search

To test, pull up search and search for `cookies`. The _Colossal Cookies_ result should now have a site name listed after the author.