### PR TITLE
Revert "Theme Sheet: Use isLoaded() helper"

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -133,7 +133,7 @@ const ThemeSheet = React.createClass( {
 
 	renderBar() {
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
-		const title = this.isLoaded() || placeholder;
+		const title = this.props.name || placeholder;
 		const tag = this.props.author ? i18n.translate( 'by %(author)s', { args: { author: this.props.author } } ) : placeholder;
 
 		return (


### PR DESCRIPTION
This reverts commit 94deb51d8722eeafe58155f1eb624df6b4ef3b46.

Which was a premature optimization, causing the theme title to be no longer displayed on the theme details sheet.