### PR TITLE
Add AdWords remarketing tracking to all page views

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -119,8 +119,16 @@ function retarget() {
 	if ( ! retargetingInitialized ) {
 		debug( 'Retargeting initialized' );
 
-		window.fbq( 'track', 'PageView' );
 		retargetingInitialized = true;
+
+		// Facebook
+		window.fbq( 'track', 'PageView' );
+
+		// AdWords
+		window.google_trackConversion( {
+			google_conversion_id: GOOGLE_CONVERSION_ID,
+			google_remarketing_only: true
+		} );
 	}
 }
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -19,6 +19,8 @@ var config = require( 'config' ),
 	_superProps,
 	_user;
 
+import { retarget } from 'lib/analytics/ad-tracking';
+
 // Load tracking scripts
 window._tkq = window._tkq || [];
 window.ga = window.ga || function() {
@@ -167,6 +169,9 @@ var analytics = {
 			}
 
 			analytics.tracks.recordEvent( 'calypso_page_view', eventProperties );
+
+			// Ensure every Calypso user is added to our retargeting audience via the AdWords retargeting tag
+			retarget();
 		},
 
 		createRandomId:  function() {

--- a/client/lib/analytics/test/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/test/lib/analytics/ad-tracking.js
@@ -1,0 +1,3 @@
+export function retarget() {
+
+}

--- a/client/lib/feed-post-store/test/lib/analytics.js
+++ b/client/lib/feed-post-store/test/lib/analytics.js
@@ -1,0 +1,1 @@
+// nothing in analytics should be called

--- a/client/lib/menu-data/test/lib/analytics.js
+++ b/client/lib/menu-data/test/lib/analytics.js
@@ -1,0 +1,8 @@
+export default {
+	mc: {
+		bumpStat: function() {}
+	},
+	tracks: {
+		recordEvent: function() {}
+	}
+};

--- a/client/lib/plugins/test/actions.js
+++ b/client/lib/plugins/test/actions.js
@@ -18,6 +18,7 @@ describe( 'WPcom Data Actions', () => {
 
 	useMockery( mockery => {
 		mockery.registerMock( 'lib/wp', mockedWpcom );
+		mockery.registerMock( 'lib/analytics', { mc: { bumpStat: noop }, tracks: { recordEvent: noop } } );
 	} );
 
 	beforeEach( () => {

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -10,7 +10,6 @@ import config from 'config';
 import controller from 'my-sites/controller';
 import paths from './paths';
 import plansController from './controller';
-import { retarget } from 'lib/analytics/ad-tracking';
 import googleAnalyticsLandingPage from './plan-feature/google-analytics';
 import yourPlan from './current-plan/controller';
 
@@ -18,7 +17,6 @@ export default function() {
 	if ( config.isEnabled( 'manage/plan-features' ) ) {
 		page(
 			'/plans/features',
-			retarget,
 			controller.siteSelection,
 			controller.sites
 		);
@@ -27,14 +25,12 @@ export default function() {
 	if ( config.isEnabled( 'manage/plans' ) ) {
 		page(
 			'/plans',
-			retarget,
 			controller.siteSelection,
 			controller.sites
 		);
 
 		page(
 			'/plans/compare',
-			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			plansController.plansCompare
@@ -42,7 +38,6 @@ export default function() {
 
 		page(
 			'/plans/my-plan/:site',
-			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			yourPlan
@@ -50,7 +45,6 @@ export default function() {
 
 		page(
 			'/plans/compare/:domain',
-			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			plansController.plansCompare
@@ -58,7 +52,6 @@ export default function() {
 
 		page(
 			'/plans/compare/:intervalType?/:domain',
-			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			plansController.plansCompare
@@ -66,7 +59,6 @@ export default function() {
 
 		page(
 			'/plans/compare/:feature/:domain',
-			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			plansController.plansCompare
@@ -74,14 +66,12 @@ export default function() {
 
 		page(
 			'/plans/select/:plan/:domain',
-			retarget,
 			controller.siteSelection,
 			plansController.redirectToCheckout
 		);
 
 		page(
 			'/plans/features/google-analytics/:domain',
-			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			googleAnalyticsLandingPage
@@ -89,13 +79,11 @@ export default function() {
 
 		page(
 			'/plans/features/google-analytics',
-			retarget,
 			controller.sites
 		);
 
 		page(
 			paths.plansDestination(),
-			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			plansController.plans

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -11,8 +11,7 @@ const controller = require( 'my-sites/controller' ),
 	domainManagementController = require( './domain-management/controller' ),
 	SiftScience = require( 'lib/siftscience' ),
 	config = require( 'config' ),
-	paths = require( './paths' ),
-	adTracking = require( 'lib/analytics/ad-tracking' );
+	paths = require( './paths' );
 
 function registerMultiPage( { paths, handlers } ) {
 	paths.forEach( path => page( path, ...handlers ) );
@@ -141,7 +140,6 @@ module.exports = function() {
 	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
 		page(
 			'/domains/add',
-			adTracking.retarget,
 			controller.siteSelection,
 			upgradesController.domainsAddHeader,
 			controller.jetPackWarning,
@@ -150,7 +148,6 @@ module.exports = function() {
 
 		page(
 			'/domains/add/mapping',
-			adTracking.retarget,
 			controller.siteSelection,
 			upgradesController.domainsAddHeader,
 			controller.jetPackWarning,
@@ -159,7 +156,6 @@ module.exports = function() {
 
 		page(
 			'/domains/add/site-redirect',
-			adTracking.retarget,
 			controller.siteSelection,
 			upgradesController.domainsAddRedirectHeader,
 			controller.jetPackWarning,
@@ -167,7 +163,6 @@ module.exports = function() {
 		);
 
 		page( '/domains/add/:domain',
-			adTracking.retarget,
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
@@ -176,7 +171,6 @@ module.exports = function() {
 		);
 
 		page( '/domains/add/suggestion/:suggestion/:domain',
-			adTracking.retarget,
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
@@ -185,7 +179,6 @@ module.exports = function() {
 		);
 
 		page( '/domains/add/:registerDomain/google-apps/:domain',
-			adTracking.retarget,
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
@@ -194,7 +187,6 @@ module.exports = function() {
 		);
 
 		page( '/domains/add/mapping/:domain',
-			adTracking.retarget,
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add/mapping' ),
@@ -203,7 +195,6 @@ module.exports = function() {
 		);
 
 		page( '/domains/add/site-redirect/:domain',
-			adTracking.retarget,
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add/site-redirect' ),
@@ -235,7 +226,6 @@ module.exports = function() {
 
 		page(
 			'/checkout/features/:feature/:domain/:plan_name?',
-			adTracking.retarget,
 			controller.siteSelection,
 			upgradesController.checkout
 		);
@@ -248,7 +238,6 @@ module.exports = function() {
 
 		page(
 			'/checkout/:domain/:product?',
-			adTracking.retarget,
 			controller.siteSelection,
 			upgradesController.checkout
 		);

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -8,14 +8,12 @@ import page from 'page';
  */
 import controller from './controller';
 import jetpackConnectController from './jetpack-connect/controller';
-import adTracking from 'lib/analytics/ad-tracking';
 import config from 'config';
 import sitesController from 'my-sites/controller';
 
 module.exports = function() {
 	page(
 		'/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
-		adTracking.retarget,
 		controller.saveRefParameter,
 		controller.saveQueryObject,
 		controller.redirectWithoutLocaleIfLoggedIn,


### PR DESCRIPTION
When determining whether to show WordPress.com ads to folks searching on Google, we want to exclude recently active users because we don't want to spend money advertising to users who are already using the site.

There are two ways to build this list of active users: one is through a connection with Google Analytics, another is through an AdWords remarketing tag. In the past we've relied on the Google Analytics method, but we're still showing ads to active users for some unknown reason. To remedy this, we're going to try the AdWords remarketing tag approach.

This PR updates Calypso so that every time a page load analytics event is triggered, we also track the visit via the AdWords remarketing tag.

We were doing this for a few sections of the site already - sign up and a few plans pages - but to ensure we capture all active users I removed the tracking from those pages and set it up to track on every page load.

Here's how to test:

1) In `development.json`, set `ad-tracking` to `true`.
2) Turn on debugging: `localStorage.setItem('debug', 'calypso:ad-tracking');`
3) Load any page in Calypso. You should see a _calypso:ad-tracking Retargeting initialized_ log in the console. This is only fired once when you initially load a page; it is not fired multiple times as the user navigates around Calypso.
4) To verify the request is sent properly, search the Network tab for `1067250390` (our AdWords conversion id) and you should find something like this:

> https://www.google.com/ads/user-lists/1067250390/?fmt=3&num=1&cv=8&frm=0&url=http%3A//calypso.localhost%3A3000/domains/add/example.com&random=1707501640

5) Because this PR also removes the existing remarketing tracking from a few places in Calypso, also run though sign up, domains, and checkout to ensure nothing is amiss. As you can see from the relevant commits, the changes to remove this code were simple and should not cause any adverse effects.

Test live: https://calypso.live/?branch=add/adwords-remarketing-tracking-to-all-page-views