### PR TITLE
Site Settings: Jetpack Related Posts margins are prettier

### DIFF
--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -1,7 +1,11 @@
 .site-settings {
 	fieldset {
 		clear: both;
-		margin-bottom: 20px;
+		margin-bottom: 24px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	label {
@@ -203,26 +207,13 @@
 
 .jp-relatedposts {
 	position: relative;
-	margin: 1em 0;
-	padding: 1em 1em .5em;
+	margin-top: 8px;
+	padding: 16px 8px;
 	width: 100%;
 	background: $gray-light;
 	box-sizing: border-box;
 
-	&:after {
-		content: '';
-		display: block;
-		clear: both;
-	}
-
-	.jp-relatedposts-headline {
-		margin: 0 0 1em 0;
-		display: inline-block;
-		float: left;
-		font-size: 10px;
-		font-weight: 600;
-		font-family: inherit;
-	}
+	@include clear-fix;
 
 	.jp-relatedposts-items {
 		clear: left;
@@ -238,8 +229,8 @@
 		float: left;
 		width: 33%;
 		box-sizing: border-box;
-		margin: 0 0 1em;
-		padding: 0 5px;
+		margin: 0;
+		padding: 0 8px;
 
 		@include breakpoint( "<660px" ) {
 			width: 50%;

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -207,6 +207,7 @@
 
 #settings-reading-relatedposts-preview .form-label {
 	font-weight: 600;
+	margin-top: 16px;
 }
 
 .jp-relatedposts {
@@ -221,7 +222,7 @@
 
 	.jp-relatedposts-headline {
  		margin: 0 0 1em 8px;
- 		font-size: 10px;
+ 		font-size: 11px;
  		font-weight: 600;
  	}
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -205,6 +205,10 @@
 	}
 }
 
+#settings-reading-relatedposts-preview .form-label {
+	font-weight: 600;
+}
+
 .jp-relatedposts {
 	position: relative;
 	margin-top: 8px;
@@ -215,8 +219,26 @@
 
 	@include clear-fix;
 
+	.jp-relatedposts-headline {
+ 		margin: 0 0 1em 8px;
+ 		font-size: 10px;
+ 		font-weight: 600;
+ 	}
+
 	.jp-relatedposts-items {
-		clear: left;
+
+
+		@include breakpoint( ">480px" ) {
+			display: flex;
+			flex-wrap: wrap;
+			.jp-relatedposts-post {
+				width: 50%;
+			}
+		}
+
+		@include breakpoint( ">960px" ) {
+			flex-wrap: nowrap;
+		}
 	}
 
 	.jp-relatedposts-post .jp-relatedposts-post-title a {
@@ -226,22 +248,11 @@
 	}
 
 	.jp-relatedposts-post {
-		float: left;
-		width: 33%;
 		box-sizing: border-box;
 		margin: 0;
 		padding: 0 8px;
-
-		@include breakpoint( "<660px" ) {
-			width: 50%;
-		}
-
-		@include breakpoint( "<480px" ) {
-			width: 100%;
-		}
 	}
 
-	.jp-relatedposts-post img,
 	.jp-relatedposts-post span {
 		display: block;
 		max-width: 90%;


### PR DESCRIPTION
And using standard units on our grid

I also added a `:last-child { margin: 0; }` style for fieldsets in settings which removes an unneeded and ugly extra space below the last form field in each settings area.

**Before:**
<img width="731" alt="screen shot 2016-07-12 at 1 55 52 pm" src="https://cloud.githubusercontent.com/assets/437258/16777789/0035b880-4839-11e6-9209-1b36378b98d6.png">
<img width="604" alt="screen shot 2016-07-12 at 1 56 46 pm" src="https://cloud.githubusercontent.com/assets/437258/16777790/003a09ee-4839-11e6-8a9e-c81c649a8384.png">

**After:**
<img width="760" alt="screen shot 2016-07-13 at 1 58 43 pm" src="https://cloud.githubusercontent.com/assets/437258/16814105/5be8d8c8-4902-11e6-8ac3-805d4af5b060.png">
<img width="624" alt="screen shot 2016-07-13 at 1 58 53 pm" src="https://cloud.githubusercontent.com/assets/437258/16814104/5be87e1e-4902-11e6-859c-8ecfd6b8c0ac.png">
<img width="406" alt="screen shot 2016-07-13 at 1 59 01 pm" src="https://cloud.githubusercontent.com/assets/437258/16814103/5be7c032-4902-11e6-9ca2-a03d971b294a.png">


cc @mtias 

Test live: https://calypso.live/?branch=fix/jetpack-settings-margins