### PR TITLE
Stats: adding post trends component back.

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -18,7 +18,6 @@ import TodaysStats from '../stats-site-overview';
 import StatsModule from '../stats-module';
 import StatsConnectedModule from '../stats-module/connected-list';
 import statsStrings from '../stats-strings';
-import touchDetect from 'lib/touch-detect';
 import MostPopular from 'my-sites/stats/most-popular';
 import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
@@ -78,7 +77,7 @@ export default React.createClass( {
 				<SidebarNavigation />
 				<StatsNavigation section="insights" site={ site } />
 				<div id="my-stats-content">
-					{ touchDetect.hasTouch() && <PostingActivity /> }
+					<PostingActivity />
 					<LatestPostSummary site={ site } />
 					<TodaysStats
 						siteId={ site ? site.ID : 0 }


### PR DESCRIPTION
Something went amiss with the merge in #6507 - not quite sure how it happened yet but this re-enables the Post Trends component on the stats insights page.

__To Test__
- Open a stats insights page in a full sized viewport, verify that "Post Trends" module shows up top
- Resize the viewport to <480, verify Post Trends is not shown.

Test live: https://calypso.live/?branch=fix/stats/post-trends