### PR TITLE
CPT: Enable type toggles for supported Jetpack versions

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -21,7 +21,7 @@ import FormLabel from 'components/forms/form-label';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
-import { isJetpackMinimumVersion } from 'state/sites/selectors';
+import { isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import CustomPostTypeFieldset from './custom-post-types-fieldset';
@@ -62,7 +62,8 @@ const SiteSettingsFormWriting = React.createClass( {
 	isCustomPostTypesSettingsEnabled() {
 		return (
 			config.isEnabled( 'manage/custom-post-types' ) &&
-			false !== this.props.jetpackVersionSupportsCustomTypes
+			false !== this.props.jetpackVersionSupportsCustomTypes &&
+			false !== this.props.jetpackCustomTypesModuleActive
 		);
 	},
 
@@ -200,6 +201,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			jetpackCustomTypesModuleActive: isJetpackModuleActive( state, siteId, 'custom-content-types' ),
 			jetpackVersionSupportsCustomTypes: isJetpackMinimumVersion( state, siteId, '4.2.0' )
 		};
 	},


### PR DESCRIPTION
Related: #4502
Related: #6105
Blocked by: #4369

This pull request seeks to allow Jetpack sites running supported versions and having enabled the "Custom Content Types" feature to toggle the active custom post types for their site.

__Testing instructions:__

As noted above, this is blocked by #4369. It is not currently possible to change the active setting of a custom post type without these changes. Pending future release or with these changes applied manually to your Jetpack site (and meeting or changing the `versionCompare` version), verify that you can toggle custom post types on a site.

1. Navigate to the [site writing settings](http://calypso.localhost:3000/settings/writing)
2. Select a site
3. Note that if your site is hosted on WordPress.com or has the Jetpack "Custom Content Types" module running on a supported Jetpack version, you are offered the option to toggle testimonials or portfolio projects
4. Note that the current toggle setting matches expectations
5. Toggle one or both of the post types and save your changes
6. Note that the save completes successfully and the sidebar navigation item is added or removed to reflect your change
7. Refresh the page to confirm that the setting change has persisted

Test live: https://calypso.live/?branch=update/cpt-jetpack-writing-settings