### PR TITLE
CPT: Enable restoring posts from post actions

### DIFF
--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -12,6 +12,8 @@ import { getSitePost } from 'state/posts/selectors';
 import {
 	POST_DELETE_FAILURE,
 	POST_DELETE_SUCCESS,
+	POST_RESTORE_FAILURE,
+	POST_RESTORE_SUCCESS,
 	POST_SAVE_SUCCESS
 } from 'state/action-types';
 
@@ -42,6 +44,21 @@ export function onPostDeleteFailure( dispatch, action, getState ) {
 	dispatch( errorNotice( message ) );
 }
 
+export function onPostRestoreFailure( dispatch, action, getState ) {
+	const post = getSitePost( getState(), action.siteId, action.postId );
+
+	let message;
+	if ( post ) {
+		message = translate( 'An error occurred while restoring "%s"', {
+			args: [ truncate( post.title, { length: 24 } ) ]
+		} );
+	} else {
+		message = translate( 'An error occurred while restoring the post' );
+	}
+
+	dispatch( errorNotice( message ) );
+}
+
 export function onPostSaveSuccess( dispatch, action ) {
 	let text;
 	switch ( action.post.status ) {
@@ -66,6 +83,8 @@ export function onPostSaveSuccess( dispatch, action ) {
 export const handlers = {
 	[ POST_DELETE_FAILURE ]: onPostDeleteFailure,
 	[ POST_DELETE_SUCCESS ]: dispatchSuccess( translate( 'Post successfully deleted' ) ),
+	[ POST_RESTORE_FAILURE ]: onPostRestoreFailure,
+	[ POST_RESTORE_SUCCESS ]: dispatchSuccess( translate( 'Post successfully restored' ) ),
 	[ POST_SAVE_SUCCESS ]: onPostSaveSuccess
 };
 

--- a/client/state/notices/test/middleware.js
+++ b/client/state/notices/test/middleware.js
@@ -12,6 +12,7 @@ import noticesMiddleware, {
 	handlers,
 	dispatchSuccess,
 	onPostDeleteFailure,
+	onPostRestoreFailure,
 	onPostSaveSuccess
 } from '../middleware';
 import { useSandbox } from 'test/helpers/use-sinon';
@@ -19,6 +20,7 @@ import { successNotice } from 'state/notices/actions';
 import {
 	NOTICE_CREATE,
 	POST_DELETE_FAILURE,
+	POST_RESTORE_FAILURE,
 	POST_SAVE_SUCCESS
 } from 'state/action-types';
 
@@ -123,6 +125,55 @@ describe( 'middleware', () => {
 					notice: {
 						status: 'is-error',
 						text: 'An error occurred while deleting the post'
+					}
+				} );
+			} );
+		} );
+
+		describe( 'onPostRestoreFailure()', () => {
+			it( 'should dispatch error notice with truncated title if known', () => {
+				onPostRestoreFailure( dispatch, {
+					type: POST_RESTORE_FAILURE,
+					siteId: 2916284,
+					postId: 841
+				}, () => ( {
+					posts: {
+						items: {
+							'3d097cb7c5473c169bba0eb8e3c6cb64': {
+								ID: 841,
+								site_ID: 2916284,
+								global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+								title: 'Hello World, This Should Be Truncated'
+							}
+						}
+					}
+				} ) );
+
+				expect( dispatch ).to.have.been.calledWithMatch( {
+					type: NOTICE_CREATE,
+					notice: {
+						status: 'is-error',
+						text: 'An error occurred while restoring "Hello World, This Sho..."'
+					}
+				} );
+			} );
+
+			it( 'should dispatch error notice with unknown title', () => {
+				onPostRestoreFailure( dispatch, {
+					type: POST_RESTORE_FAILURE,
+					siteId: 2916284,
+					postId: 841
+				}, () => ( {
+					posts: {
+						items: {}
+					}
+				} ) );
+
+				expect( dispatch ).to.have.been.calledWithMatch( {
+					type: NOTICE_CREATE,
+					notice: {
+						status: 'is-error',
+						text: 'An error occurred while restoring the post'
 					}
 				} );
 			} );


### PR DESCRIPTION
Related: #6454

This pull request seeks to implement the behaviors related to restoring trashed posts from the [custom post types list screen](https://wpcalypso.wordpress.com/types/post).

![Restore](https://cloud.githubusercontent.com/assets/1779930/16779061/b229ad58-483e-11e6-8649-efc252cb71e4.png)

__Testing instructions:__

Verify that you can restore a trashed post.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. If you don't already have a trashed post, trash one via the action dropdown
3. Change to the Trashed filter
4. For a trashed post, select Restore under the action menu
5. Note that...
 - The post disappears from the trashed list
 - The Trashed post count in the filter bar decrements by one
 - After the restore completes, the post count of the original status increments by one (we can't know until the response is received which status it was originally) and a notice is shown

__Follow-up Tasks:__

- ~~Implement notices to reflect success or failure. I had planned to wait for #6645 to be merged before submitting this pull request, but discussion continues to evolve there, so would rather move forward with these changes.~~ Included in 57da87d after having merged #6645.

Test live: https://calypso.live/?branch=update/cpt-restore-post