### PR TITLE
Plugins: Check if there is a message before rendering a notice

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -153,9 +153,12 @@ module.exports = React.createClass( {
 
 	pluginMeta( pluginData ) {
 		if ( this.props.progress.length ) {
-			return (
-				<Notice isCompact status="is-info" text={ this.doing() } inline={ true }/>
-			);
+			const message = this.doing();
+			if ( message ) {
+				return (
+					<Notice isCompact status="is-info" text={ message } inline={ true }/>
+				);
+			}
 		}
 		if ( this.hasUpdate() ) {
 			return this.renderUpdateFlag();


### PR DESCRIPTION
In some cases (highlighted by the autoconfig process), `this.doing()` can return nothing, causing an empty box to show up under just-installed plugins

![screen shot 2016-07-12 at 2 42 20 pm](https://cloud.githubusercontent.com/assets/541093/16779104/e68bd51c-483e-11e6-86bd-d353b2840290.png)

To test

1. Have a site without at least one of the .org plugins
2. Go through the autoconfig process successfully
3. Visit the installed plugins, and see your new plugins in the list. There should **not** be a blue box.

cc @johnHackworth @roccotripaldi 

Test live: https://calypso.live/?branch=fix/jetpack-plugins-empty-notice