### PR TITLE
Reader: Add left margin to search intro on small viewports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -364,6 +364,7 @@
 @import 'reader/post-images/style';
 @import 'reader/reading-time/style';
 @import 'reader/recommendations/style';
+@import 'reader/search-stream/style';
 @import 'reader/share/style';
 @import 'reader/sidebar/style';
 @import 'reader/site-and-author-icon/style';

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -137,7 +137,7 @@ const FeedStream = React.createClass( {
 	render() {
 		const emptyContent = this.props.query
 			? <EmptyContent query={ this.props.query } />
-			: <div>{ this.translate( 'What would you like to find?' ) }</div>;
+			: <p className="search-stream__intro">{ this.translate( 'What would you like to find?' ) }</p>;
 
 		if ( this.props.setPageTitle ) {
 			this.props.setPageTitle( this.state.title || this.translate( 'Search' ) );

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -1,0 +1,5 @@
+.search-stream__intro {
+	@include breakpoint( "<660px" ) {
+		margin-left: 16px;
+	}
+}


### PR DESCRIPTION
Before:

<img width="403" alt="screen shot 2016-07-12 at 21 33 45" src="https://cloud.githubusercontent.com/assets/17325/16780762/64efd5f0-4878-11e6-8b42-0341f4337f4c.png">

After: 

<img width="400" alt="screen shot 2016-07-12 at 21 33 27" src="https://cloud.githubusercontent.com/assets/17325/16780763/651286ae-4878-11e6-9ace-cae457aed187.png">


Test live: https://calypso.live/?branch=fix/reader/search-intro-padding-mobile