### PR TITLE
Plans Redesign: Fix compare link on my plan page

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -63,6 +63,11 @@ export default {
 		analytics.tracks.recordEvent( 'calypso_plans_view' );
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
+		// Scroll to the top
+		if ( typeof window !== 'undefined' ) {
+			window.scrollTo( 0, 0 );
+		}
+
 		renderWithReduxStore(
 			<CheckoutData>
 				<Plans

--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -144,7 +144,9 @@ const PlanDetailsComponent = React.createClass( {
 				{ selectedSite &&
 					<Card
 						href={
-							( showPlanFeatures ? '/plans/' : '/plans/compare/' ) + selectedSite.slug
+							showPlanFeatures
+								? `/plans/${ selectedSite.slug }`
+								: `/plans/compare/${ selectedSite.slug }`
 						}
 					>
 						{ this.translate( 'Missing some features? Compare our different plans' ) }

--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -31,6 +31,7 @@ import {
 import Gridicon from 'components/gridicon';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlansNavigation from 'my-sites/upgrades/navigation';
+import config from 'config';
 
 const PlanDetailsComponent = React.createClass( {
 	PropTypes: {
@@ -47,6 +48,7 @@ const PlanDetailsComponent = React.createClass( {
 	render: function() {
 		const { selectedSite } = this.props;
 		const { hasLoadedFromServer } = this.props.sitePlans;
+		const showPlanFeatures = config.isEnabled( 'manage/plan-features' );
 		let title;
 		let tagLine;
 		let featuresList;
@@ -140,7 +142,11 @@ const PlanDetailsComponent = React.createClass( {
 						isPlaceholder={ false } />
 				</Card>
 				{ selectedSite &&
-					<Card href={ '/plans/compare/' + selectedSite.slug }>
+					<Card
+						href={
+							( showPlanFeatures ? '/plans/' : '/plans/compare/' ) + selectedSite.slug
+						}
+					>
 						{ this.translate( 'Missing some features? Compare our different plans' ) }
 					</Card>
 				}


### PR DESCRIPTION
Fixes #6675. When plan features is enabled and user navigates to the `my-plan` page, there is a link on the bottom to compare plans. Let's point it to `/plans/:site_slug` as `/plans/compare` no longer exists.

## Testing Instructions

1. Run Calypso with `ENABLE_FEATURES=manage/plan-features make run`;
2. Go to `http://calypso.localhost:3000/plans/my-plan/:mysite:`;
3. Scroll to the bottom of the page and click on "Missing some features..." link;
4. Are you redirected to `/plans/:mysite`?

cc @gwwar @rralian 

Test live: https://calypso.live/?branch=fix/compare-link-my-plan-page