### PR TITLE
CPT: Add stats button to post actions

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -9,6 +9,7 @@ import React, { PropTypes, Children, cloneElement } from 'react';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuSeparator from 'components/popover/menu-separator';
 import PostActionsEllipsisMenuEdit from './edit';
+import PostActionsEllipsisMenuStats from './stats';
 import PostActionsEllipsisMenuPublish from './publish';
 import PostActionsEllipsisMenuTrash from './trash';
 import PostActionsEllipsisMenuView from './view';
@@ -21,6 +22,7 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 		actions.push(
 			<PostActionsEllipsisMenuEdit key="edit" />,
 			<PostActionsEllipsisMenuView key="view" />,
+			<PostActionsEllipsisMenuStats key="stats" />,
 			<PostActionsEllipsisMenuPublish key="publish" />,
 			<PostActionsEllipsisMenuRestore key="restore" />,
 			<PostActionsEllipsisMenuTrash key="trash" />

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PopoverMenuItem from 'components/popover/menu-item';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getPost } from 'state/posts/selectors';
+
+function PostActionsEllipsisMenuStats( { translate, siteSlug, postId, status, isStatsActive } ) {
+	if ( ! isStatsActive || 'publish' !== status ) {
+		return null;
+	}
+
+	return (
+		<PopoverMenuItem href={ `/stats/post/${ postId }/${ siteSlug }` } icon="stats-alt">
+			{ translate( 'Stats' ) }
+		</PopoverMenuItem>
+	);
+}
+
+PostActionsEllipsisMenuStats.propTypes = {
+	globalId: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+	siteSlug: PropTypes.number,
+	postId: PropTypes.number,
+	status: PropTypes.string,
+	isStatsActive: PropTypes.bool
+};
+
+export default connect( ( state, ownProps ) => {
+	const post = getPost( state, ownProps.globalId );
+	if ( ! post ) {
+		return {};
+	}
+
+	return {
+		siteSlug: getSiteSlug( state, post.site_ID ),
+		postId: post.ID,
+		status: post.status,
+		isStatsActive: true // [TODO]: This should be made accurate by detecting active status of Jetpack "stats" module
+	};
+} )( localize( PostActionsEllipsisMenuStats ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getPost } from 'state/posts/selectors';
 
 function PostActionsEllipsisMenuStats( { translate, siteSlug, postId, status, isStatsActive } ) {
@@ -43,6 +43,6 @@ export default connect( ( state, ownProps ) => {
 		siteSlug: getSiteSlug( state, post.site_ID ),
 		postId: post.ID,
 		status: post.status,
-		isStatsActive: true // [TODO]: This should be made accurate by detecting active status of Jetpack "stats" module
+		isStatsActive: false !== isJetpackModuleActive( state, post.site_ID, 'stats' )
 	};
 } )( localize( PostActionsEllipsisMenuStats ) );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -87,6 +87,25 @@ export function isJetpackSite( state, siteId ) {
 }
 
 /**
+ * Returns true if the site is a Jetpack site with the specified module active,
+ * or false if the module is not active. Returns null if the site is not known
+ * or is not a Jetpack site.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @param  {String}   slug   Module slug
+ * @return {?Boolean}        Whether site has Jetpack module active
+ */
+export function isJetpackModuleActive( state, siteId, slug ) {
+	const site = getSite( state, siteId );
+	if ( ! site || ! site.jetpack_modules ) {
+		return null;
+	}
+
+	return includes( site.jetpack_modules, slug );
+}
+
+/**
  * Returns the slug for a site, or null if the site is unknown.
  *
  * @param  {Object}  state  Global state tree

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -97,12 +97,12 @@ export function isJetpackSite( state, siteId ) {
  * @return {?Boolean}        Whether site has Jetpack module active
  */
 export function isJetpackModuleActive( state, siteId, slug ) {
-	const site = getSite( state, siteId );
-	if ( ! site || ! site.jetpack_modules ) {
+	const modules = getSiteOption( state, siteId, 'active_modules' );
+	if ( ! modules ) {
 		return null;
 	}
 
-	return includes( site.jetpack_modules, slug );
+	return includes( modules, slug );
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -11,6 +11,7 @@ import {
 	getSiteCollisions,
 	isSiteConflicting,
 	isJetpackSite,
+	isJetpackModuleActive,
 	getSiteSlug,
 	isRequestingSites,
 	getSiteByUrl,
@@ -154,6 +155,68 @@ describe( 'selectors', () => {
 			}, 77203074 );
 
 			expect( jetpackSite ).to.be.false;
+		} );
+	} );
+
+	describe( 'isJetpackModuleActive()', () => {
+		it( 'should return null if the site is not known', () => {
+			const isActive = isJetpackModuleActive( {
+				sites: {
+					items: {}
+				}
+			}, 77203074, 'custom-content-types' );
+
+			expect( isActive ).to.be.null;
+		} );
+
+		it( 'should return null if the site is known and not a Jetpack site', () => {
+			const isActive = isJetpackModuleActive( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.worpdress.com',
+							jetpack: false
+						}
+					}
+				}
+			}, 77203074, 'custom-content-types' );
+
+			expect( isActive ).to.be.null;
+		} );
+
+		it( 'should return false if the site is a Jetpack site without the module active', () => {
+			const isActive = isJetpackModuleActive( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.worpdress.com',
+							jetpack: true,
+							jetpack_modules: []
+						}
+					}
+				}
+			}, 77203074, 'custom-content-types' );
+
+			expect( isActive ).to.be.false;
+		} );
+
+		it( 'should return true if the site is a Jetpack site and the module is active', () => {
+			const isActive = isJetpackModuleActive( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.worpdress.com',
+							jetpack: true,
+							jetpack_modules: [ 'custom-content-types' ]
+						}
+					}
+				}
+			}, 77203074, 'custom-content-types' );
+
+			expect( isActive ).to.be.true;
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -175,8 +175,9 @@ describe( 'selectors', () => {
 					items: {
 						77203074: {
 							ID: 77203074,
-							URL: 'https://example.worpdress.com',
-							jetpack: false
+							URL: 'https://example.wordpress.com',
+							jetpack: false,
+							options: {}
 						}
 					}
 				}
@@ -191,9 +192,11 @@ describe( 'selectors', () => {
 					items: {
 						77203074: {
 							ID: 77203074,
-							URL: 'https://example.worpdress.com',
+							URL: 'https://example.com',
 							jetpack: true,
-							jetpack_modules: []
+							options: {
+								active_modules: []
+							}
 						}
 					}
 				}
@@ -208,9 +211,11 @@ describe( 'selectors', () => {
 					items: {
 						77203074: {
 							ID: 77203074,
-							URL: 'https://example.worpdress.com',
+							URL: 'https://example.com',
 							jetpack: true,
-							jetpack_modules: [ 'custom-content-types' ]
+							options: {
+								active_modules: [ 'custom-content-types' ]
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/issues/6540#issuecomment-230582954

This pull request seeks to add a "Stats" link to the [custom post types list screen](https://wpcalypso.wordpress.com/types/post) action menu.

![Stats](https://cloud.githubusercontent.com/assets/1779930/16781889/4621aaea-484b-11e6-9e1d-1a6eb69865b0.png)

__Testing instructions:__

Verify that a stats menu item is shown for published posts.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site, if prompted
3. Click the action menu for a post
4. Note that...
 - If the post is published, a stats link is shown that will direct you to the respective stats detail for that post
 - If the post is not published, a stats link is not shown in the options

Test live: https://calypso.live/?branch=add/cpt-stats-action