### PR TITLE
Framework: update wpcom to 5.1.0

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-import Me from 'wpcom/dist/lib/me';
+import { Me } from 'wpcom';
 import inherits from 'inherits';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:wpcom-undocumented:me' );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -26,9 +26,6 @@
     "align-text": {
       "version": "0.1.4"
     },
-    "alter": {
-      "version": "0.2.0"
-    },
     "amdefine": {
       "version": "1.0.0"
     },
@@ -104,9 +101,6 @@
     "assertion-error": {
       "version": "1.0.2"
     },
-    "ast-traverse": {
-      "version": "0.1.1"
-    },
     "ast-types": {
       "version": "0.6.16"
     },
@@ -133,46 +127,6 @@
     },
     "aws4": {
       "version": "1.4.1"
-    },
-    "babel": {
-      "version": "5.8.38",
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.38"
-        },
-        "babylon": {
-          "version": "5.8.38"
-        },
-        "commander": {
-          "version": "2.9.0"
-        },
-        "core-js": {
-          "version": "1.2.6"
-        },
-        "glob": {
-          "version": "5.0.15"
-        },
-        "globals": {
-          "version": "6.4.1"
-        },
-        "js-tokens": {
-          "version": "1.0.1"
-        },
-        "lodash": {
-          "version": "3.10.1"
-        },
-        "source-map": {
-          "version": "0.5.6"
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32"
-            }
-          }
-        }
-      }
     },
     "babel-code-frame": {
       "version": "6.11.0",
@@ -255,21 +209,6 @@
     "babel-plugin-check-es2015-constants": {
       "version": "6.8.0"
     },
-    "babel-plugin-constant-folding": {
-      "version": "1.0.1"
-    },
-    "babel-plugin-dead-code-elimination": {
-      "version": "1.0.2"
-    },
-    "babel-plugin-eval": {
-      "version": "1.0.1"
-    },
-    "babel-plugin-inline-environment-variables": {
-      "version": "1.0.1"
-    },
-    "babel-plugin-jscript": {
-      "version": "1.0.4"
-    },
     "babel-plugin-lodash": {
       "version": "3.2.0",
       "dependencies": {
@@ -277,35 +216,6 @@
           "version": "4.13.1"
         }
       }
-    },
-    "babel-plugin-member-expression-literals": {
-      "version": "1.0.1"
-    },
-    "babel-plugin-property-literals": {
-      "version": "1.0.1"
-    },
-    "babel-plugin-proto-to-assign": {
-      "version": "1.0.4",
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1"
-        }
-      }
-    },
-    "babel-plugin-react-constant-elements": {
-      "version": "1.0.3"
-    },
-    "babel-plugin-react-display-name": {
-      "version": "1.0.3"
-    },
-    "babel-plugin-remove-console": {
-      "version": "1.0.1"
-    },
-    "babel-plugin-remove-debugger": {
-      "version": "1.0.1"
-    },
-    "babel-plugin-runtime": {
-      "version": "1.0.7"
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.8.0"
@@ -424,12 +334,6 @@
     "babel-plugin-transform-strict-mode": {
       "version": "6.11.3"
     },
-    "babel-plugin-undeclared-variables-check": {
-      "version": "1.0.2"
-    },
-    "babel-plugin-undefined-to-void": {
-      "version": "1.1.6"
-    },
     "babel-preset-es2015": {
       "version": "6.9.0"
     },
@@ -472,7 +376,7 @@
       "version": "1.0.2"
     },
     "balanced-match": {
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "Base64": {
       "version": "0.2.1"
@@ -525,7 +429,7 @@
       "version": "0.0.9"
     },
     "bluebird": {
-      "version": "2.10.2"
+      "version": "3.4.1"
     },
     "body-parser": {
       "version": "1.15.2",
@@ -549,9 +453,6 @@
     },
     "braces": {
       "version": "1.8.5"
-    },
-    "breakable": {
-      "version": "1.0.0"
     },
     "browser-filesaver": {
       "version": "1.1.0"
@@ -730,35 +631,6 @@
     "commander": {
       "version": "2.3.0"
     },
-    "commoner": {
-      "version": "0.10.4",
-      "dependencies": {
-        "ast-types": {
-          "version": "0.8.15"
-        },
-        "commander": {
-          "version": "2.9.0"
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb"
-        },
-        "glob": {
-          "version": "5.0.15"
-        },
-        "graceful-fs": {
-          "version": "4.1.4"
-        },
-        "q": {
-          "version": "1.4.1"
-        },
-        "recast": {
-          "version": "0.10.43"
-        },
-        "source-map": {
-          "version": "0.5.6"
-        }
-      }
-    },
     "component-bind": {
       "version": "1.0.0"
     },
@@ -876,7 +748,7 @@
       "version": "2.0.1"
     },
     "core-js": {
-      "version": "2.4.0"
+      "version": "2.4.1"
     },
     "core-util-is": {
       "version": "1.0.2"
@@ -995,23 +867,6 @@
         }
       }
     },
-    "defined": {
-      "version": "1.0.0"
-    },
-    "defs": {
-      "version": "1.1.1",
-      "dependencies": {
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb"
-        },
-        "window-size": {
-          "version": "0.1.4"
-        },
-        "yargs": {
-          "version": "3.27.0"
-        }
-      }
-    },
     "del": {
       "version": "2.2.1",
       "dependencies": {
@@ -1040,14 +895,6 @@
     },
     "detect-indent": {
       "version": "3.0.1"
-    },
-    "detective": {
-      "version": "4.3.1",
-      "dependencies": {
-        "acorn": {
-          "version": "1.2.2"
-        }
-      }
     },
     "diff": {
       "version": "1.4.0"
@@ -1452,7 +1299,7 @@
       "version": "2.0.2",
       "dependencies": {
         "core-js": {
-          "version": "1.2.6"
+          "version": "1.2.7"
         },
         "fbjs": {
           "version": "0.7.2"
@@ -1463,7 +1310,7 @@
       "version": "0.5.0",
       "dependencies": {
         "core-js": {
-          "version": "1.2.6"
+          "version": "1.2.7"
         }
       }
     },
@@ -1532,7 +1379,7 @@
       "version": "2.1.1",
       "dependencies": {
         "core-js": {
-          "version": "1.2.6"
+          "version": "1.2.7"
         },
         "fbjs": {
           "version": "0.1.0-alpha.7"
@@ -1574,9 +1421,6 @@
     "fresh": {
       "version": "0.3.0"
     },
-    "fs-readdir-recursive": {
-      "version": "0.1.2"
-    },
     "fs.realpath": {
       "version": "1.0.0"
     },
@@ -1605,6 +1449,9 @@
     },
     "generate-object-property": {
       "version": "1.2.0"
+    },
+    "get-caller-file": {
+      "version": "1.0.1"
     },
     "get-document": {
       "version": "1.0.0"
@@ -1953,9 +1800,6 @@
     "is-glob": {
       "version": "2.0.1"
     },
-    "is-integer": {
-      "version": "1.0.6"
-    },
     "is-lower-case": {
       "version": "1.1.3"
     },
@@ -2214,9 +2058,6 @@
     },
     "ldjson-stream": {
       "version": "1.2.1"
-    },
-    "leven": {
-      "version": "1.0.2"
     },
     "levn": {
       "version": "0.3.0"
@@ -2671,14 +2512,6 @@
     "outlayer": {
       "version": "2.1.0"
     },
-    "output-file-sync": {
-      "version": "1.1.2",
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.4"
-        }
-      }
-    },
     "package-json": {
       "version": "1.2.0"
     },
@@ -2930,7 +2763,7 @@
       "version": "15.1.0",
       "dependencies": {
         "core-js": {
-          "version": "1.2.6"
+          "version": "1.2.7"
         },
         "fbjs": {
           "version": "0.8.3"
@@ -3007,7 +2840,7 @@
       "version": "1.0.2",
       "dependencies": {
         "core-js": {
-          "version": "1.2.6"
+          "version": "1.2.7"
         },
         "fbjs": {
           "version": "0.1.0-alpha.10"
@@ -3018,7 +2851,7 @@
       "version": "1.0.0",
       "dependencies": {
         "core-js": {
-          "version": "1.2.6"
+          "version": "1.2.7"
         },
         "fbjs": {
           "version": "0.2.1"
@@ -3093,23 +2926,6 @@
     "regenerate": {
       "version": "1.3.1"
     },
-    "regenerator": {
-      "version": "0.8.40",
-      "dependencies": {
-        "ast-types": {
-          "version": "0.8.12"
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb"
-        },
-        "recast": {
-          "version": "0.10.33"
-        },
-        "source-map": {
-          "version": "0.5.6"
-        }
-      }
-    },
     "regenerator-runtime": {
       "version": "0.9.5"
     },
@@ -3118,28 +2934,6 @@
     },
     "regexp-quote": {
       "version": "0.0.0"
-    },
-    "regexpu": {
-      "version": "1.3.0",
-      "dependencies": {
-        "ast-types": {
-          "version": "0.8.15"
-        },
-        "esprima": {
-          "version": "2.7.2"
-        },
-        "recast": {
-          "version": "0.10.43",
-          "dependencies": {
-            "esprima-fb": {
-              "version": "15001.1001.0-dev-harmony-fb"
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.5.6"
-        }
-      }
     },
     "regexpu-core": {
       "version": "2.0.0"
@@ -3275,7 +3069,7 @@
           "version": "0.2.0"
         },
         "yargs": {
-          "version": "4.8.0"
+          "version": "4.8.1"
         }
       }
     },
@@ -3379,12 +3173,6 @@
     },
     "signal-exit": {
       "version": "3.0.0"
-    },
-    "simple-fmt": {
-      "version": "0.1.0"
-    },
-    "simple-is": {
-      "version": "0.2.0"
     },
     "sinon": {
       "version": "1.12.2"
@@ -3528,9 +3316,6 @@
         }
       }
     },
-    "stable": {
-      "version": "0.1.5"
-    },
     "statuses": {
       "version": "1.3.0"
     },
@@ -3571,12 +3356,6 @@
     },
     "stringify-object": {
       "version": "2.4.0"
-    },
-    "stringmap": {
-      "version": "0.2.2"
-    },
-    "stringset": {
-      "version": "0.2.1"
     },
     "stringstream": {
       "version": "0.0.5"
@@ -3724,9 +3503,6 @@
     "table": {
       "version": "3.7.8",
       "dependencies": {
-        "bluebird": {
-          "version": "3.4.1"
-        },
         "chalk": {
           "version": "1.1.3"
         },
@@ -3831,17 +3607,8 @@
     "trim-newlines": {
       "version": "1.0.0"
     },
-    "trim-right": {
-      "version": "1.0.1"
-    },
-    "try-resolve": {
-      "version": "1.0.1"
-    },
     "tryit": {
       "version": "1.0.2"
-    },
-    "tryor": {
-      "version": "0.1.2"
     },
     "tty-browserify": {
       "version": "0.0.0"
@@ -4039,15 +3806,7 @@
       "version": "1.3.0"
     },
     "wpcom": {
-      "version": "4.9.15",
-      "dependencies": {
-        "babel-runtime": {
-          "version": "5.8.12"
-        },
-        "core-js": {
-          "version": "0.9.18"
-        }
-      }
+      "version": "5.1.0"
     },
     "wpcom-oauth": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.15",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "4.9.15",
+    "wpcom": "5.1.0",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "2.0.0",
     "wpcom-xhr-request": "0.5.0",


### PR DESCRIPTION
Updates  wpcom.js to `5.1.0` release.
The most important change here we've started to use `babel-6` and `n8-make` in the pre-compiling process.

### Testing

1) clean all dependencies

```cli
> make distclean
```

2) Install dependencies

```cli
npm install
```

3) Test the whole app

Test the application making actions to change data:

* add/edit posts
* change user settings
* login / logout

Test cross-browser Chrome / Safari / Firefox

cc @TooTallNate @timmyc @skeltoac @gwwar 

Test live: https://calypso.live/?branch=update/wpcom-5.1.0