### PR TITLE
Jetpack Plans: Launch the auto-config flow to all users

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -46,7 +46,7 @@
 		"manage/plan-features": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
-		"manage/plugins/setup": false,
+		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/seo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -43,7 +43,7 @@
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
-		"manage/plugins/setup": false,
+		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/seo": true,


### PR DESCRIPTION
Exactly what the title suggests, this PR is to open the .org plugins automated install & configuration to all users.

Test live: https://calypso.live/?branch=add/jetpack-autoconfig-production