### PR TITLE
Plans: Enable WordAds for all

### DIFF
--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -7,7 +7,6 @@ import times from 'lodash/times';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Card from 'components/card';
 import { filterPlansBySiteAndProps } from 'lib/plans';
 import { getCurrentPlan } from 'lib/plans';
@@ -81,18 +80,14 @@ const PlanList = React.createClass( {
 		if ( plans.length > 0 ) {
 			let filteredPlans = filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalType, showJetpackFreePlan );
 
-			if (
-				isEnabled( 'manage/ads/wordads-instant' ) &&
-				abtest( 'wordadsInstantActivation' ) === 'enabled'
-			) {
-				filteredPlans = filteredPlans.map( plan => {
-					if ( plan.product_id === 1003 ) {
-						plan.description = this.translate( 'Your own domain name, powerful customization options, ' +
-							'easy monetization with WordAds and lots of space for audio and video.' );
-					}
-					return plan;
-				} );
-			}
+
+			filteredPlans = filteredPlans.map( plan => {
+				if ( plan.product_id === 1003 ) {
+					plan.description = this.translate( 'Your own domain name, powerful customization options, ' +
+						'easy monetization with WordAds and lots of space for audio and video.' );
+				}
+				return plan;
+			} );
 
 			plansList = filteredPlans.map( plan => {
 				return (

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -80,7 +80,6 @@ const PlanList = React.createClass( {
 		if ( plans.length > 0 ) {
 			let filteredPlans = filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalType, showJetpackFreePlan );
 
-
 			filteredPlans = filteredPlans.map( plan => {
 				if ( plan.product_id === 1003 ) {
 					plan.description = this.translate( 'Your own domain name, powerful customization options, ' +

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -11,7 +11,6 @@ import times from 'lodash/times';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import Card from 'components/card';
 import { fetchSitePlans } from 'state/sites/plans/actions';
@@ -212,9 +211,7 @@ const PlansCompare = React.createClass( {
 			googleAdVouchersFeature[ '1008' ] = '$200'; // Google AdWords $100 voucher + WordAds $100 voucher
 		}
 
-		if ( isEnabled( 'manage/ads/wordads-instant' ) && abtest( 'wordadsInstantActivation' ) === 'enabled' ) {
-			features.splice( 6, 0, wordAdsFeature );
-		}
+		features.splice( 6, 0, wordAdsFeature );
 
 		return features;
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -56,15 +56,6 @@ module.exports = {
 		allowExistingUsers: true,
 		allowAnyLocale: true
 	},
-	wordadsInstantActivation: {
-		datestamp: '20160607',
-		variations: {
-			disabled: 50,
-			enabled: 50,
-		},
-		defaultVariation: 'disabled',
-		allowExistingUsers: true,
-	},
 	googleVouchers: {
 		datestamp: '20160708',
 		variations: {

--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -27,7 +27,6 @@ export function canAccessWordads( site ) {
 
 export function isWordadsInstantActivationEligible( site ) {
 	if (
-		config.isEnabled( 'manage/ads/wordads-instant' ) &&
 		( isBusiness( site.plan ) || isPremium( site.plan ) ) &&
 		userCan( 'activate_wordads', site ) &&
 		! site.jetpack

--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -4,7 +4,6 @@
 import config from 'config';
 import { userCan } from 'lib/site/utils';
 import { isBusiness, isPremium } from 'lib/products-values';
-import { abtest } from 'lib/abtest';
 
 /**
  * Returns true if the site has WordAds access
@@ -30,7 +29,6 @@ export function isWordadsInstantActivationEligible( site ) {
 	if (
 		config.isEnabled( 'manage/ads/wordads-instant' ) &&
 		( isBusiness( site.plan ) || isPremium( site.plan ) ) &&
-		abtest( 'wordadsInstantActivation' ) === 'enabled' &&
 		userCan( 'activate_wordads', site ) &&
 		! site.jetpack
 	) {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -106,13 +106,9 @@ export const plansList = {
 		getPathSlug: () => 'premium',
 		getStoreSlug: () => PLAN_PREMIUM,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
-		getDescription: () => i18n.translate( 'Your own domain name, powerful customization options, and' +
-			' lots of space for audio and video.' ),
-		getDescriptionWithGoogleVouchers: () => i18n.translate( 'Your own domain name, powerful customization options,' +
-			' lots of space for audio and video, and $100 advertising voucher.' ),
-		getDescriptionWithWordAdsInstantActivation: () => i18n.translate( 'Your own domain name, powerful' +
+		getDescription: () => i18n.translate( 'Your own domain name, powerful' +
 			' customization options, easy monetization with WordAds and lots of space for audio and video.' ),
-		getDescriptionWithWordAdsInstantActivationAndGoogleVouchers: () => i18n.translate( 'Your own domain name, powerful' +
+		getDescriptionWithGoogleVouchers: () => i18n.translate( 'Your own domain name, powerful' +
 			' customization options, easy monetization with WordAds, lots of space for audio and video, and $100 advertising voucher.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_CUSTOM_DOMAIN,

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -31,7 +31,6 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
-	FEATURE_WORDADS_INSTANT,
 	FEATURE_GOOGLE_AD_VOUCHERS_100,
 	FEATURE_GOOGLE_WORDADS_AD_VOUCHERS_200
 } from 'lib/plans/constants';
@@ -189,11 +188,6 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalTy
 	} );
 }
 
-export const isWordadsInstantActivationEnabled = () => {
-	return isEnabled( 'manage/ads/wordads-instant' ) &&
-		abtest( 'wordadsInstantActivation' ) === 'enabled';
-};
-
 export const isGoogleVouchersEnabled = () => {
 	return ( isEnabled( 'google-voucher' ) && abtest( 'googleVouchers' ) === 'enabled' );
 };
@@ -223,12 +217,6 @@ export function applyTestFiltersToPlansList( planName ) {
 	let filteredPlanFeaturesConstantList = plansList[ planName ].getFeatures();
 
 	const removeDisabledFeatures = () => {
-		if ( ! isWordadsInstantActivationEnabled() ) {
-			filteredPlanFeaturesConstantList = filter( filteredPlanFeaturesConstantList,
-				( value ) => value !== FEATURE_WORDADS_INSTANT
-			);
-		}
-
 		if ( ! isGoogleVouchersEnabled() ) {
 			filteredPlanFeaturesConstantList = filter( filteredPlanFeaturesConstantList,
 				( value ) => value !== FEATURE_GOOGLE_AD_VOUCHERS_100 &&
@@ -238,11 +226,7 @@ export function applyTestFiltersToPlansList( planName ) {
 	};
 
 	const updatePlanDescriptions = () => {
-		if ( isWordadsInstantActivationEnabled() && isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
-			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsInstantActivationAndGoogleVouchers;
-		} else if ( isWordadsInstantActivationEnabled() && planName === PLAN_PREMIUM ) {
-			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsInstantActivation;
-		} else if ( isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
+		if ( isGoogleVouchersEnabled() && planName === PLAN_PREMIUM ) {
 			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithGoogleVouchers;
 		} else if ( isWordpressAdCreditsEnabled() && planName === PLAN_BUSINESS ) {
 			filteredPlanConstantObj.getDescription = plansList[ planName ].getDescriptionWithWordAdsCredit;

--- a/config/development.json
+++ b/config/development.json
@@ -49,7 +49,6 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
-		"manage/ads/wordads-instant": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/customize": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,7 +28,6 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
-		"manage/ads/wordads-instant": true,
 		"manage/customize": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -26,7 +26,6 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
-		"manage/ads/wordads-instant": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/export": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -29,7 +29,6 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
-		"manage/ads/wordads-instant": true,
 		"manage/advanced-seo": true,
 		"manage/customize": true,
 		"manage/edit-user": true,

--- a/config/test.json
+++ b/config/test.json
@@ -43,7 +43,6 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
-		"manage/ads/wordads-instant": true,
 		"manage/customize": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -33,7 +33,6 @@
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
 		"manage/ads": true,
-		"manage/ads/wordads-instant": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/customize": true,


### PR DESCRIPTION
This stops wordads instant activation test and enables the feature for all users.

### Testing

1. Build with just regular make run
2. Go to /plans, see description mentioning WordAds
3. Go to /plans/compare, see wordads feature
4. Build with `ENABLE_FEATURES=manage/plan-features make run` to see redesigned plans page
5. Go to http://calypso.localhost:3000/plans/ to see if WordAds is in new table
6. You need premium / business site
7. Go to https://wordpress.com/plans/my-plan/your-site
8. You should see "Monetize your site". Click it, go there :)


CC @lamosty @rralian @gwwar 

Test live: https://calypso.live/?branch=update/wordads-for-all