### PR TITLE
Signup: Back button breaks after comparing plans

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -114,7 +114,8 @@ const PlansCompare = React.createClass( {
 
 	goBack() {
 		this.recordViewAllPlansClick();
-		return page.back( this.props.backUrl || this.getPlanURL() );
+
+		page.show( this.props.backUrl || this.getPlanURL() );
 	},
 
 	isDataLoading() {


### PR DESCRIPTION
Fixes #6685. The issue is caused by using `page.back` method on plans compare for navigating to the previous page. The problem is that while `page.back` takes an [argument](https://github.com/visionmedia/page.js/blob/master/page.js#L216) `path`, it uses it only in case there is no browser history recorded. This is fine in most cases, but not in signup because when you are on the `user` page (account creation), navigate back to plans compare page and click on the back btn, the browser history contains the `user` page (account creation) as the previous state, not the `plans` NUX page (which is technically correct but not for our use case).

## Testing Instructions

1. Run Calypso with `make run`;
2. Navigate to `/start/test-plans` and click on compare plans link;
3. On compare plans page, click the upgrade btn on any plan;
4. On account creation page, click the back arrow;
5. You should be taken to the plans compare page. Now, click on the back btn;
6. You should be taken to the plans page.

Verify that `/plans` and `/plans/compare` is working with this change (ie the back btn on `/plans/compare` takes you to `/plans`).

cc @shaunandrews @gwwar @rralian 

Test live: https://calypso.live/?branch=fix/nux-plans-compare-back-button