### PR TITLE
Jetpack Sync: Allow sync panel in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,6 +27,7 @@
 		"help": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,
+		"jetpack/sync-panel": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"mailing-lists/unsubscribe": true,


### PR DESCRIPTION
Now that we have something working in `development` for Jetpack sync, let's move to `wpcalypso` so that it's a bit easier to test.

cc @lezama for review.

To test:

- Checkout `update/jetpack-sync-wpcalypso` branch
- In `wpcalypso.json` config, change `wpcom_user_bootstrap` to `false`
- In terminal, `CALYPSO_ENV=wpcalypso make run`
- Go to `/settings/general/$site` where `$site` is on latest master of Jetpack
- Verify that you see sync panel

