### PR TITLE
Reader Search: remove tagline on blank search and add the Drake

### DIFF
--- a/client/reader/search-stream/blank.jsx
+++ b/client/reader/search-stream/blank.jsx
@@ -1,0 +1,20 @@
+const React = require( 'react' );
+
+const EmptyContent = require( 'components/empty-content' );
+
+const SearchBlankContent = React.createClass( {
+
+	shouldComponentUpdate: function() {
+		return false;
+	},
+
+	render: function() {
+		return ( <EmptyContent
+			title={ '' }
+			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+			illustrationWidth={ 500 }
+			/> );
+	}
+} );
+
+module.exports = SearchBlankContent;

--- a/client/reader/search-stream/blank.jsx
+++ b/client/reader/search-stream/blank.jsx
@@ -1,20 +1,5 @@
-const React = require( 'react' );
+import React from 'react';
 
-const EmptyContent = require( 'components/empty-content' );
-
-const SearchBlankContent = React.createClass( {
-
-	shouldComponentUpdate: function() {
-		return false;
-	},
-
-	render: function() {
-		return ( <EmptyContent
-			title={ '' }
-			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-			illustrationWidth={ 500 }
-			/> );
-	}
-} );
-
-module.exports = SearchBlankContent;
+export default function BlankContent() {
+	return <p />;
+}

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -17,7 +17,6 @@ import SearchInput from 'components/search';
 import SearchCard from 'components/post-card/search';
 import SiteStore from 'lib/reader-site-store';
 import FeedStore from 'lib/feed-store';
-import recordTrackForPost from 'reader/stats';
 
 //const stats = require( 'reader/stats' );
 //
@@ -53,8 +52,6 @@ const SearchCardAdapter = React.createClass( {
 		if ( closest( event.target, '.ignore-click, [rel=external]', true, rootNode ) ) {
 			return;
 		}
-
-		recordTrackForPost( 'calypso_reader_search_clicked', this.props.post );
 
 		event.preventDefault();
 		this.props.handleClick( this.props.post, {} );

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -11,6 +11,7 @@ import closest from 'component-closest';
  */
 import Stream from 'reader/stream';
 import EmptyContent from './empty';
+import BlankContent from './blank';
 import HeaderBack from 'reader/header-back';
 import SearchInput from 'components/search';
 import SearchCard from 'components/post-card/search';
@@ -139,7 +140,7 @@ const FeedStream = React.createClass( {
 	render() {
 		const emptyContent = this.props.query
 			? <EmptyContent query={ this.props.query } />
-			: null;
+			: <BlankContent />;
 
 		if ( this.props.setPageTitle ) {
 			this.props.setPageTitle( this.state.title || this.translate( 'Search' ) );

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -16,6 +16,7 @@ import SearchInput from 'components/search';
 import SearchCard from 'components/post-card/search';
 import SiteStore from 'lib/reader-site-store';
 import FeedStore from 'lib/feed-store';
+import recordTrackForPost from 'reader/stats';
 
 //const stats = require( 'reader/stats' );
 //
@@ -51,6 +52,8 @@ const SearchCardAdapter = React.createClass( {
 		if ( closest( event.target, '.ignore-click, [rel=external]', true, rootNode ) ) {
 			return;
 		}
+
+		recordTrackForPost( 'calypso_reader_search_clicked', this.props.post );
 
 		event.preventDefault();
 		this.props.handleClick( this.props.post, {} );

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -117,6 +117,7 @@ tracksRailcarEventWhitelist
 	.add( 'calypso_reader_article_commented_on' )
 	.add( 'calypso_reader_article_opened' )
 	.add( 'calypso_reader_startcard_clicked' )
+	.add( 'calypso_reader_search_clicked' )
 ;
 
 export function recordTracksRailcar( action, eventName, railcar ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -117,7 +117,6 @@ tracksRailcarEventWhitelist
 	.add( 'calypso_reader_article_commented_on' )
 	.add( 'calypso_reader_article_opened' )
 	.add( 'calypso_reader_startcard_clicked' )
-	.add( 'calypso_reader_search_clicked' )
 ;
 
 export function recordTracksRailcar( action, eventName, railcar ) {


### PR DESCRIPTION
Feels like the blank search page needed something and since we aren't adding recos, the Drake?

(Unless we have a giraffe around?)


Test live: https://calypso.live/read/search?branch=add/reader-search-remove-tagline