### PR TITLE
Components: add follow button disabled state

### DIFF
--- a/assets/stylesheets/shared/mixins/_mixins.scss
+++ b/assets/stylesheets/shared/mixins/_mixins.scss
@@ -4,6 +4,7 @@
 @import 'dropdown-menu';
 @import 'hide-content-accessibly';
 @import 'long-content-fade';
+@import 'no-select';
 @import 'noticon';
 @import 'placeholder';
 @import 'stats-fade-text';

--- a/assets/stylesheets/shared/mixins/_no-select.scss
+++ b/assets/stylesheets/shared/mixins/_no-select.scss
@@ -1,0 +1,8 @@
+@mixin no-select {
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}

--- a/client/components/follow-button/README.md
+++ b/client/components/follow-button/README.md
@@ -38,4 +38,5 @@ render: function() {
 
 #### Props
 
-* `following`: (default: false ) a boolean indicating if the current user is currently following the site URL
+* `following`: (default: false) a boolean indicating if the current user is currently following the site URL
+* `disabled`: (default: false) a boolean indicating if the button is currently disabled

--- a/client/components/follow-button/button.jsx
+++ b/client/components/follow-button/button.jsx
@@ -1,33 +1,43 @@
-// External dependencies
-var React = require( 'react' ),
-	noop = require( 'lodash/noop' );
+/**
+* External dependencies
+*/
+import React from 'react';
+import { noop } from 'lodash';
 
-var FollowButton = React.createClass( {
+const FollowButton = React.createClass( {
 
 	propTypes: {
 		following: React.PropTypes.bool.isRequired,
-		onFollowToggle: React.PropTypes.func
+		onFollowToggle: React.PropTypes.func,
+		iconSize: React.PropTypes.number,
+		tagName: React.PropTypes.string,
+		disabled: React.PropTypes.bool
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			following: false,
 			onFollowToggle: noop,
 			iconSize: 20,
-			tagName: 'button'
+			tagName: 'button',
+			disabled: false
 		};
 	},
 
-	componentWillMount: function() {
+	componentWillMount() {
 		this.strings = {
 			FOLLOW: this.translate( 'Follow' ),
 			FOLLOWING: this.translate( 'Following' )
 		};
 	},
 
-	toggleFollow: function( event ) {
+	toggleFollow( event ) {
 		if ( event ) {
 			event.preventDefault();
+		}
+
+		if ( this.props.disabled ) {
+			return;
 		}
 
 		if ( this.props.onFollowToggle ) {
@@ -35,29 +45,31 @@ var FollowButton = React.createClass( {
 		}
 	},
 
-	render: function() {
-		var menuClasses = [ 'button', 'follow-button', 'has-icon' ],
-			label = this.strings.FOLLOW,
-			iconSize = this.props.iconSize;
+	render() {
+		let menuClasses = [ 'button', 'follow-button', 'has-icon' ];
+		let label = this.strings.FOLLOW;
+		const iconSize = this.props.iconSize;
 
 		if ( this.props.following ) {
 			menuClasses.push( 'is-following' );
 			label = this.strings.FOLLOWING;
 		}
 
-		menuClasses = menuClasses.join( ' ' );
+		if ( this.props.disabled ) {
+			menuClasses.push( 'is-disabled' );
+		}
 
-		var followingIcon = ( <svg key="following" className="gridicon gridicon__following" height={ iconSize + "px" } width={ iconSize + "px" } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M23 13.482L15.508 21 12 17.4l1.412-1.388 2.106 2.188 6.094-6.094L23 13.482zm-7.455 1.862L20 10.89V2H2v14c0 1.1.9 2 2 2h4.538l4.913-4.832 2.095 2.176zM8 13H4v-1h4v1zm3-2H4v-1h7v1zm0-2H4V8h7v1zm7-3H4V4h14v2z"/></g></svg> ),
-			followIcon = ( <svg key="follow" className="gridicon gridicon__follow" height={ iconSize + "px" } width={ iconSize + "px" } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z"/></g></svg> ),
+		const followingIcon = ( <svg key="following" className="gridicon gridicon__following" height={ iconSize + 'px' } width={ iconSize + 'px' } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M23 13.482L15.508 21 12 17.4l1.412-1.388 2.106 2.188 6.094-6.094L23 13.482zm-7.455 1.862L20 10.89V2H2v14c0 1.1.9 2 2 2h4.538l4.913-4.832 2.095 2.176zM8 13H4v-1h4v1zm3-2H4v-1h7v1zm0-2H4V8h7v1zm7-3H4V4h14v2z"/></g></svg> ),
+			followIcon = ( <svg key="follow" className="gridicon gridicon__follow" height={ iconSize + 'px' } width={ iconSize + 'px' } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z"/></g></svg> ),
 			followLabel = ( <span key="label" className="follow-button__label">{ label }</span> );
 
 		return React.createElement( this.props.tagName, {
 			onClick: this.toggleFollow,
-			className: menuClasses,
+			className: menuClasses.join( ' ' ),
 			title: label
 		}, [ followingIcon, followIcon, followLabel ] );
 	}
 
 } );
 
-module.exports = FollowButton;
+export default FollowButton;

--- a/client/components/follow-button/docs/example.jsx
+++ b/client/components/follow-button/docs/example.jsx
@@ -1,21 +1,21 @@
 /**
 * External dependencies
 */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-var FollowButton = require( 'components/follow-button/button' ),
-	Card = require( 'components/card/compact' );
+import FollowButton from 'components/follow-button/button';
+import Card from 'components/card/compact';
 
-var FollowButtons = React.createClass( {
+const FollowButtons = React.createClass( {
 	displayName: 'FollowButtons',
 
 	mixins: [ PureRenderMixin ],
 
-	render: function() {
+	render() {
 		return (
 			<div className="design-assets__group">
 				<h2>
@@ -27,9 +27,12 @@ var FollowButtons = React.createClass( {
 				<Card compact>
 					<FollowButton following={ true } />
 				</Card>
+				<Card compact>
+					<FollowButton disabled={ true } />
+				</Card>
 			</div>
 		);
 	}
 } );
 
-module.exports = FollowButtons;
+export default FollowButtons;

--- a/client/components/follow-button/index.jsx
+++ b/client/components/follow-button/index.jsx
@@ -1,58 +1,58 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' ),
-	noop = require( 'lodash/noop' );
+import React from 'react';
+import { noop } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-var FollowButton = require( './button' ),
-	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' ),
-	FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' );
+import FollowButton from './button';
+import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
+import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
 
-var FollowButtonContainer = React.createClass( {
+const FollowButtonContainer = React.createClass( {
 	propTypes: {
 		siteUrl: React.PropTypes.string.isRequired,
 		iconSize: React.PropTypes.number,
 		onFollowToggle: React.PropTypes.func
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			onFollowToggle: noop
 		};
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return this.getStateFromStores();
 	},
 
-	getStateFromStores: function() {
+	getStateFromStores() {
 		return { following: FeedSubscriptionStore.getIsFollowingBySiteUrl( this.props.siteUrl ) };
 	},
 
-	componentDidMount: function() {
+	componentDidMount() {
 		FeedSubscriptionStore.on( 'change', this.onStoreChange );
 	},
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		FeedSubscriptionStore.off( 'change', this.onStoreChange );
 	},
 
-	onStoreChange: function() {
-		var newState = this.getStateFromStores();
+	onStoreChange() {
+		const newState = this.getStateFromStores();
 		if ( newState.following !== this.state.following ) {
 			this.setState( newState );
 		}
 	},
 
-	handleFollowToggle: function( following ) {
+	handleFollowToggle( following ) {
 		FeedSubscriptionActions[ following ? 'follow' : 'unfollow' ]( this.props.siteUrl );
 		this.props.onFollowToggle( following );
 	},
 
-	render: function() {
+	render() {
 		return (
 			<FollowButton
 				following={ this.state.following }
@@ -63,4 +63,4 @@ var FollowButtonContainer = React.createClass( {
 	}
 } );
 
-module.exports = FollowButtonContainer;
+export default FollowButtonContainer;

--- a/client/components/follow-button/style.scss
+++ b/client/components/follow-button/style.scss
@@ -1,3 +1,5 @@
+$follow-button-gray-disabled: lighten( $gray, 20% );
+
 .follow-button {
 
 	.gridicon__follow {
@@ -69,6 +71,31 @@
 			.gridicon {
 				fill: $alert-green;
 			}
+		}
+	}
+
+	&.is-disabled {
+		color: $follow-button-gray-disabled;
+		border-color: $follow-button-gray-disabled;
+		pointer-events: none;
+
+		@include no-select();
+
+		.gridicon {
+			fill: $follow-button-gray-disabled;
+		}
+
+		&:hover {
+			color: $follow-button-gray-disabled;
+			cursor: default;
+
+			.gridicon {
+				fill: $follow-button-gray-disabled;
+			}
+		}
+
+		&:active {
+			border-width: 1px 1px 2px;
 		}
 	}
 }

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -151,19 +151,6 @@
 			padding: 16px 24px;
 		}
 
-		// Disabled button if URL is invalid
-		.follow-button:hover {
-			border-color: lighten( $gray, 20% );
-		}
-
-		.gridicon {
-			fill: lighten( $gray, 20% );
-		}
-
-		.follow-button__label {
-			color: lighten( $gray, 20% );
-		}
-
 		&.is-valid {
 
 			.gridicon {

--- a/client/reader/following-edit/subscribe-form-result.jsx
+++ b/client/reader/following-edit/subscribe-form-result.jsx
@@ -1,44 +1,43 @@
-//const debug = require( 'debug' )( 'calypso:reader:following:edit' );
+/**
+* External dependencies
+*/
+import React from 'react';
+import classNames from 'classnames';
 
-// External dependencies
-const React = require( 'react' ),
-	classNames = require( 'classnames' );
+/**
+* Internal dependencies
+*/
+import { translate } from 'i18n-calypso';
+import ListItem from 'reader/list-item';
+import Icon from 'reader/list-item/icon';
+import Title from 'reader/list-item/title';
+import Description from 'reader/list-item/description';
+import Actions from 'reader/list-item/actions';
+import FollowButton from 'components/follow-button/button';
+import SiteIcon from 'components/site-icon';
 
-// Internal dependencies
-const ListItem = require( 'reader/list-item' ),
-	Icon = require( 'reader/list-item/icon' ),
-	Title = require( 'reader/list-item/title' ),
-	Description = require( 'reader/list-item/description' ),
-	Actions = require( 'reader/list-item/actions' ),
-	FollowButton = require( 'components/follow-button/button' ),
-	SiteIcon = require( 'components/site-icon' );
+const FollowingEditSubscribeFormResult = ( { url, isValid, onFollowToggle } ) => {
+	const message = ! isValid
+		? translate( 'Not a valid URL' )
+		: translate( 'Follow this site' );
+	const classes = classNames( 'is-search-result', { 'is-valid': isValid } );
 
-var FollowingEditSubscribeFormResult = React.createClass( {
+	return (
+		<ListItem className={ classes }>
+			<Icon><SiteIcon size={ 48 } /></Icon>
+			<Title>{ url }</Title>
+			<Description>{ message }</Description>
+			<Actions>
+				<FollowButton disabled={ ! isValid } following={ false } onFollowToggle={ onFollowToggle } />
+			</Actions>
+		</ListItem>
+	);
+};
 
-	propTypes: {
-		url: React.PropTypes.string.isRequired,
-		isValid: React.PropTypes.bool.isRequired,
-		onFollowToggle: React.PropTypes.func.isRequired
-	},
+FollowingEditSubscribeFormResult.propTypes = {
+	url: React.PropTypes.string.isRequired,
+	isValid: React.PropTypes.bool.isRequired,
+	onFollowToggle: React.PropTypes.func.isRequired
+};
 
-	render: function() {
-		const message = ! this.props.isValid
-			? this.translate( 'Not a valid URL' )
-			: this.translate( 'Follow this site' );
-		const classes = classNames( 'is-search-result', { 'is-valid': this.props.isValid } );
-
-		return (
-			<ListItem className={ classes }>
-				<Icon><SiteIcon size={ 48 } /></Icon>
-				<Title>{ this.props.url }</Title>
-				<Description>{ message }</Description>
-				<Actions>
-					<FollowButton following={ false } onFollowToggle={ this.props.onFollowToggle } />
-				</Actions>
-			</ListItem>
-			);
-	}
-
-} );
-
-module.exports = FollowingEditSubscribeFormResult;
+export default FollowingEditSubscribeFormResult;

--- a/client/reader/following-edit/subscribe-form-result.jsx
+++ b/client/reader/following-edit/subscribe-form-result.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 /**
 * Internal dependencies
 */
-import { translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import ListItem from 'reader/list-item';
 import Icon from 'reader/list-item/icon';
 import Title from 'reader/list-item/title';
@@ -16,7 +16,7 @@ import Actions from 'reader/list-item/actions';
 import FollowButton from 'components/follow-button/button';
 import SiteIcon from 'components/site-icon';
 
-const FollowingEditSubscribeFormResult = ( { url, isValid, onFollowToggle } ) => {
+const FollowingEditSubscribeFormResult = ( { url, isValid, onFollowToggle, translate } ) => {
 	const message = ! isValid
 		? translate( 'Not a valid URL' )
 		: translate( 'Follow this site' );
@@ -40,4 +40,4 @@ FollowingEditSubscribeFormResult.propTypes = {
 	onFollowToggle: React.PropTypes.func.isRequired
 };
 
-export default FollowingEditSubscribeFormResult;
+export default localize( FollowingEditSubscribeFormResult );


### PR DESCRIPTION
@jancavan  noticed that in Reader Manage Following, the disabled follow button is still clickable (https://github.com/Automattic/wp-calypso/issues/6537#issuecomment-230597165).

This PR adds a `disabled` prop to the FollowButton component, and takes responsibility for handling the styling and behaviour of the button away from Manage Following.

### To test

Pull up Devdocs and make sure the disabled follow button is greyed out and doesn't respond to interaction:

http://calypso.localhost:3000/devdocs/app-components

<img width="666" alt="screen shot 2016-07-13 at 17 48 16" src="https://cloud.githubusercontent.com/assets/17325/16809846/0ee9ca6c-4922-11e6-850c-572bc6eab0bf.png">

Next, pull up Manage Following and enter an invalid URL in the feed search. Make sure the follow button stays disabled, and interacting with it does nothing.

http://calypso.localhost:3000/following/edit

<img width="764" alt="screen shot 2016-07-13 at 17 48 24" src="https://cloud.githubusercontent.com/assets/17325/16809858/1985039c-4922-11e6-9a3b-fbacc44864bd.png">


Test live: https://calypso.live/?branch=add/follow-button/disabled