### PR TITLE
CPT / Editor: Enable custom taxonomies for posts and pages

### DIFF
--- a/client/lib/version-compare/index.js
+++ b/client/lib/version-compare/index.js
@@ -1,3 +1,4 @@
+/** @ssr-ready **/
 /*eslint-disable */
 
 /**

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -39,6 +39,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
+import { isJetpackMinimumVersion } from 'state/sites/selectors';
 import config from 'config';
 import EditorDrawerFeaturedImage from './featured-image';
 import EditorDrawerTaxonomies from './taxonomies';
@@ -77,6 +78,7 @@ const EditorDrawer = React.createClass( {
 	propTypes: {
 		site: React.PropTypes.object,
 		post: React.PropTypes.object,
+		canJetpackUseTaxonomies: React.PropTypes.bool,
 		typeObject: React.PropTypes.object,
 		isNew: React.PropTypes.bool,
 		type: React.PropTypes.string
@@ -113,7 +115,7 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderTaxonomies: function() {
-		const { type, post, site } = this.props;
+		const { type, post, site, canJetpackUseTaxonomies } = this.props;
 
 		// Categories & Tags
 		let categories;
@@ -137,11 +139,9 @@ const EditorDrawer = React.createClass( {
 
 		// Custom Taxonomies
 		let taxonomies;
-		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
-			taxonomies = (
-				<EditorDrawerTaxonomies
-					postTerms={ get( post, 'terms' ) } />
-			);
+		if ( config.isEnabled( 'manage/custom-post-types' ) &&
+				false !== canJetpackUseTaxonomies ) {
+			taxonomies = <EditorDrawerTaxonomies postTerms={ get( post, 'terms' ) } />;
 		}
 
 		return createFragment( { categories, taxonomies } );
@@ -345,6 +345,7 @@ export default connect(
 		const type = getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
 
 		return {
+			canJetpackUseTaxonomies: isJetpackMinimumVersion( state, siteId, '4.1' ),
 			typeObject: getPostType( state, siteId, type )
 		};
 	},

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import includes from 'lodash/includes';
+import createFragment from 'react-addons-create-fragment';
+import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -112,38 +113,38 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderTaxonomies: function() {
-		var element;
+		const { type, post, site } = this.props;
 
-		if ( config.isEnabled( 'manage/custom-post-types' ) &&
-				! includes( [ 'post', 'page' ], this.props.type ) ) {
-			return (
+		// Categories & Tags
+		let categories;
+		if ( 'post' === type ) {
+			categories = (
+				<CategoriesTagsAccordion
+					site={ site }
+					post={ post } />
+			);
+
+			if ( site ) {
+				categories = (
+					<CategoryListData siteId={ site.ID }>
+						<TagListData siteId={ site.ID }>
+							{ categories }
+						</TagListData>
+					</CategoryListData>
+				);
+			}
+		}
+
+		// Custom Taxonomies
+		let taxonomies;
+		if ( config.isEnabled( 'manage/custom-post-types' ) ) {
+			taxonomies = (
 				<EditorDrawerTaxonomies
-					postTerms={ this.props.post && this.props.post.terms }
-				/>
+					postTerms={ get( post, 'terms' ) } />
 			);
 		}
 
-		if ( ! this.currentPostTypeSupports( 'tags' ) ) {
-			return;
-		}
-
-		element = (
-			<CategoriesTagsAccordion
-				site={ this.props.site }
-				post={ this.props.post } />
-		);
-
-		if ( this.props.site ) {
-			element = (
-				<CategoryListData siteId={ this.props.site.ID }>
-					<TagListData siteId={ this.props.site.ID }>
-						{ element }
-					</TagListData>
-				</CategoryListData>
-			);
-		}
-
-		return element;
+		return createFragment( { categories, taxonomies } );
 	},
 
 	renderPostFormats: function() {

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import map from 'lodash/map';
+import { reduce, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,22 +18,34 @@ import Gridicon from 'components/gridicon';
 import TermTokenField from 'post-editor/term-token-field';
 import TermSelector from 'post-editor/editor-term-selector';
 
+function isSkippedTaxonomy( postType, taxonomy ) {
+	if ( includes( [ 'post_format', 'mentions' ], taxonomy ) ) {
+		return true;
+	}
+
+	if ( 'post' === postType ) {
+		return includes( [ 'category', 'post_tag' ], taxonomy );
+	}
+
+	return false;
+}
+
 function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 	return (
 		<div className="editor-drawer__taxonomies">
 			{ siteId && postType && (
 				<QueryTaxonomies { ...{ siteId, postType } } />
 			) }
-			{ map( taxonomies, ( taxonomy ) => {
+			{ reduce( taxonomies, ( memo, taxonomy ) => {
 				const { name, label, hierarchical } = taxonomy;
-				if ( 'post_format' === name ) {
-					// Post format has its own dedicated accordion
-					return;
+
+				if ( isSkippedTaxonomy( postType, name ) ) {
+					return memo;
 				}
 
 				const icon = hierarchical ? 'folder' : 'tag';
 
-				return (
+				return memo.concat(
 					<Accordion
 						key={ name }
 						title={ label }
@@ -45,7 +57,7 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 					}
 					</Accordion>
 				);
-			} ).filter( Boolean ) }
+			}, [] ) }
 		</div>
 	);
 }

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -24,6 +24,7 @@ import {
  */
 import createSelector from 'lib/create-selector';
 import { rawToNative as seoTitleFromRaw } from 'components/seo/meta-title-editor/mappings';
+import versionCompare from 'lib/version-compare';
 
 /**
  * Returns a site object by its ID.
@@ -103,6 +104,30 @@ export function isJetpackModuleActive( state, siteId, slug ) {
 	}
 
 	return includes( modules, slug );
+}
+
+/**
+ * Returns true if the Jetpack site is running a version meeting the specified
+ * minimum, or false if the Jetpack site is running an older version. Returns
+ * null if the version cannot be determined or if not a Jetpack site.
+ *
+ * @param  {Object}   state   Global state tree
+ * @param  {Number}   siteId  Site ID
+ * @param  {String}   version Minimum version
+ * @return {?Boolean}         Whether running minimum version
+ */
+export function isJetpackMinimumVersion( state, siteId, version ) {
+	const isJetpack = isJetpackSite( state, siteId );
+	if ( ! isJetpack ) {
+		return null;
+	}
+
+	const siteVersion = getSiteOption( state, siteId, 'jetpack_version' );
+	if ( ! siteVersion ) {
+		return null;
+	}
+
+	return versionCompare( siteVersion, version, '>=' );
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	isSiteConflicting,
 	isJetpackSite,
 	isJetpackModuleActive,
+	isJetpackMinimumVersion,
 	getSiteSlug,
 	isRequestingSites,
 	getSiteByUrl,
@@ -222,6 +223,88 @@ describe( 'selectors', () => {
 			}, 77203074, 'custom-content-types' );
 
 			expect( isActive ).to.be.true;
+		} );
+	} );
+
+	describe( 'isJetpackMinimumVersion()', () => {
+		it( 'should return null if the site is not known', () => {
+			const isMeetingMinimum = isJetpackMinimumVersion( {
+				sites: {
+					items: {}
+				}
+			}, 77203074, '4.1.0' );
+
+			expect( isMeetingMinimum ).to.be.null;
+		} );
+
+		it( 'should return null if the site is not a Jetpack site', () => {
+			const isMeetingMinimum = isJetpackMinimumVersion( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.wordpress.com',
+							jetpack: false
+						}
+					}
+				}
+			}, 77203074, '4.1.0' );
+
+			expect( isMeetingMinimum ).to.be.null;
+		} );
+
+		it( 'should return null if the site option is not known', () => {
+			const isMeetingMinimum = isJetpackMinimumVersion( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true
+						}
+					}
+				}
+			}, 77203074, '4.1.0' );
+
+			expect( isMeetingMinimum ).to.be.null;
+		} );
+
+		it( 'should return true if meeting the minimum version', () => {
+			const isMeetingMinimum = isJetpackMinimumVersion( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								jetpack_version: '4.1.0'
+							}
+						}
+					}
+				}
+			}, 77203074, '4.1.0' );
+
+			expect( isMeetingMinimum ).to.be.true;
+		} );
+
+		it( 'should return false if not meeting the minimum version', () => {
+			const isMeetingMinimum = isJetpackMinimumVersion( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								jetpack_version: '4.0.1'
+							}
+						}
+					}
+				}
+			}, 77203074, '4.1.0' );
+
+			expect( isMeetingMinimum ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
Closes #6626

This pull request seeks to display the `<EditorDrawerTaxonomies />` component (custom taxonomies) for all post types. Currently, this is only shown for non-post/page types. However, since posts and pages can have custom taxonomies associated with them, we should render this component.

Posts will continue to show Categories & Tags under a single combined accordion, and logic has been included to avoid duplicate accordions from being shown based on the taxonomies associated with the post type.

__Testing instructions:__

Verify that there are no visual regressions between this branch and master when viewing posts, pages, or a custom post type. Also ensure that if your theme has registered a custom taxonomy associated with a post or page that it is shown in the sidebar of the editor.

- [Post editor](http://calypso.localhost:3000/post)
- [Page editor](http://calypso.localhost:3000/page)
- [Portfolio editor](http://calypso.localhost:3000/edit/jetpack-portfolio) (where enabled)

Test live: https://calypso.live/?branch=update/cpt-editor-custom-taxonomies