### PR TITLE
Site Settings: Address ESLint warnings in general settings section

### DIFF
--- a/client/components/forms/form-setting-explanation/index.jsx
+++ b/client/components/forms/form-setting-explanation/index.jsx
@@ -1,18 +1,31 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' ),
-	omit = require( 'lodash/omit' );
 
-module.exports = React.createClass( {
+import React from 'react';
+import classNames from 'classnames';
+import { omit } from 'lodash';
+
+export default React.createClass( {
 
 	displayName: 'FormSettingExplanation',
 
-	render: function() {
+	getDefaultProps() {
+		return {
+			noValidate: false,
+			isIndented: false
+		};
+	},
+
+	render() {
+		const classes = classNames( this.props.className, 'form-setting-explanation', {
+			'no-validate': this.props.noValidate,
+			'is-indented': this.props.isIndented
+		} );
+
 		return (
 			<p { ...omit( this.props, 'className' ) }
-				className={ classnames( this.props.className, 'form-setting-explanation', { 'no-validate': this.props.noValidate } ) } >
+				className={ classes } >
 				{ this.props.children }
 			</p>
 		);

--- a/client/components/forms/form-setting-explanation/index.jsx
+++ b/client/components/forms/form-setting-explanation/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import classNames from 'classnames';
 import { omit } from 'lodash';
@@ -10,10 +9,16 @@ export default React.createClass( {
 
 	displayName: 'FormSettingExplanation',
 
+	propTypes: {
+		noValidate: React.PropTypes.bool,
+		isIndented: React.PropTypes.bool,
+		className: React.PropTypes.string
+	},
+
 	getDefaultProps() {
 		return {
 			noValidate: false,
-			isIndented: false
+			isIndented: false,
 		};
 	},
 

--- a/client/components/forms/form-setting-explanation/style.scss
+++ b/client/components/forms/form-setting-explanation/style.scss
@@ -5,4 +5,8 @@
 	font-style: italic;
 	font-weight: 400;
 	margin: 5px 0 0 0;
+
+	&.is-indented {
+		margin-left: 24px;
+	}
 }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -195,9 +195,9 @@ const FormGeneral = React.createClass( {
 		}
 
 		return (
-			<FormFieldset className="has-divider">
+			<FormFieldset className="site-settings__has-divider">
 				<FormLabel htmlFor="blogaddress">{ this.translate( 'Site Address' ) }</FormLabel>
-				<div className="blogaddress-settings">
+				<div className="site-settings__blogaddress-settings">
 					<FormInput
 						name="blogaddress"
 						type="text"
@@ -260,7 +260,7 @@ const FormGeneral = React.createClass( {
 
 				<FormLabel>
 					<FormRadio
-						name="blog_public"
+						name="blog_public"Ï
 						value="0"
 						checked={ 0 === parseInt( this.state.blog_public, 10 ) }
 						onChange={ this.handleRadio }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -8,6 +8,7 @@ import React from 'react';
  */
 import { connect } from 'react-redux';
 import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import Button from 'components/button';
 import formBase from './form-base';
 import RelatedContentPreview from 'my-sites/site-settings/related-content-preview';
@@ -338,7 +339,7 @@ const FormGeneral = React.createClass( {
 			return null;
 		}
 		return (
-			<Card className="is-compact">
+			<CompactCard>
 				<form onChange={ this.markChanged }>
 					<ul id="settings-jetpack" className="settings-jetpack">
 						<li>
@@ -352,7 +353,7 @@ const FormGeneral = React.createClass( {
 						</li>
 					</ul>
 				</form>
-			</Card>
+			</CompactCard>
 		);
 	},
 
@@ -561,12 +562,12 @@ const FormGeneral = React.createClass( {
 						{ this.renderJetpackSyncPanel() }
 						{ this.syncNonPublicPostTypes() }
 
-						<Card href={ '../security/' + site.slug } className="is-compact">
+						<CompactCard href={ '../security/' + site.slug }>
 							{ this.translate( 'View Jetpack Monitor Settings' ) }
-						</Card>
-						<Card href={ 'https://wordpress.com/manage/' + site.ID } className="is-compact">
+						</CompactCard>
+						<CompactCard href={ 'https://wordpress.com/manage/' + site.ID }>
 							{ this.translate( 'Migrate followers from another WordPress.com blog' ) }
-						</Card>
+						</CompactCard>
 					</div>
 					: null }
 			</div>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -33,7 +33,6 @@ import { getDomainsBySite } from 'state/sites/domains/selectors';
 import JetpackSyncPanel from './jetpack-sync-panel';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { isBusiness } from 'lib/products-values';
-import CompactCard from 'components/card/compact';
 
 const FormGeneral = React.createClass( {
 	displayName: 'SiteSettingsFormGeneral',
@@ -68,7 +67,7 @@ const FormGeneral = React.createClass( {
 			}
 
 			// handling `gmt_offset` and `timezone_string` values
-			let gmt_offset = site.settings.gmt_offset;
+			const gmt_offset = site.settings.gmt_offset;
 
 			if (
 				! settings.timezone_string &&
@@ -155,8 +154,8 @@ const FormGeneral = React.createClass( {
 	},
 
 	blogAddress() {
-		var site = this.props.site,
-			customAddress = '',
+		const { site } = this.props;
+		let customAddress = '',
 			addressDescription = '';
 
 		if ( site.jetpack ) {
@@ -173,13 +172,24 @@ const FormGeneral = React.createClass( {
 			addressDescription =
 				<FormSettingExplanation>
 					{
-						this.translate( 'Buy a {{domainSearchLink}}custom domain{{/domainSearchLink}}, {{mapDomainLink}}map{{/mapDomainLink}} a domain you already own, or {{redirectLink}}redirect{{/redirectLink}} this site.', {
-							components: {
-								domainSearchLink: <a href={ '/domains/add/' + site.slug } onClick={ this.trackUpgradeClick } />,
-								mapDomainLink: <a href={ '/domains/add/mapping/' + site.slug } onClick={ this.trackUpgradeClick } />,
-								redirectLink: <a href={ '/domains/add/site-redirect/' + site.slug } onClick={ this.trackUpgradeClick } />
+						this.translate(
+							'Buy a {{domainSearchLink}}custom domain{{/domainSearchLink}}, ' +
+							'{{mapDomainLink}}map{{/mapDomainLink}} a domain you already own, ' +
+							'or {{redirectLink}}redirect{{/redirectLink}} this site.',
+							{
+								components: {
+									domainSearchLink: (
+										<a href={ '/domains/add/' + site.slug } onClick={ this.trackUpgradeClick } />
+									),
+									mapDomainLink: (
+										<a href={ '/domains/add/mapping/' + site.slug } onClick={ this.trackUpgradeClick } />
+									),
+									redirectLink: (
+										<a href={ '/domains/add/site-redirect/' + site.slug } onClick={ this.trackUpgradeClick } />
+									)
+								}
 							}
-						} )
+						)
 					}
 				</FormSettingExplanation>;
 		}
@@ -230,7 +240,7 @@ const FormGeneral = React.createClass( {
 	},
 
 	visibilityOptions() {
-		var site = this.props.site;
+		const { site } = this.props;
 
 		return (
 			<FormFieldset>
@@ -243,7 +253,7 @@ const FormGeneral = React.createClass( {
 						disabled={ this.state.fetchingSettings }
 						onClick={ this.onRecordEvent( 'Clicked Site Visibility Radio Button' ) } />
 					<span>{ this.translate( 'Public' ) }</span>
-					<FormSettingExplanation className="inside-list is-indented">
+					<FormSettingExplanation isIndented>
 						{ this.translate( 'Your site is visible to everyone, and it may be indexed by search engines.' ) }
 					</FormSettingExplanation>
 				</FormLabel>
@@ -257,7 +267,7 @@ const FormGeneral = React.createClass( {
 						disabled={ this.state.fetchingSettings }
 						onClick={ this.onRecordEvent( 'Clicked Site Visibility Radio Button' ) } />
 					<span>{ this.translate( 'Hidden' ) }</span>
-					<FormSettingExplanation className="inside-list is-indented">
+					<FormSettingExplanation isIndented>
 						{ this.translate( 'Your site is visible to everyone, but we ask search engines to not index your site.' ) }
 					</FormSettingExplanation>
 				</FormLabel>
@@ -267,12 +277,12 @@ const FormGeneral = React.createClass( {
 						<FormRadio
 							name="blog_public"
 							value="-1"
-							checked={ - 1 === parseInt( this.state.blog_public, 10 ) }
+							checked={ -1 === parseInt( this.state.blog_public, 10 ) }
 							onChange={ this.handleRadio }
 							disabled={ this.state.fetchingSettings }
 							onClick={ this.onRecordEvent( 'Clicked Site Visibility Radio Button' ) } />
 						<span>{ this.translate( 'Private' ) }</span>
-						<FormSettingExplanation className="inside-list is-indented">
+						<FormSettingExplanation isIndented>
 							{ this.translate( 'Your site is only visible to you and users you approve.' ) }
 						</FormSettingExplanation>
 					</FormLabel>
@@ -295,7 +305,6 @@ const FormGeneral = React.createClass( {
 							<FormRadio
 								name="jetpack_relatedposts_enabled"
 								value="0"
-								className="tog"
 								checked={ 0 === parseInt( this.state.jetpack_relatedposts_enabled, 10 ) }
 								onChange={ this.handleRadio }
 								onClick={ this.onRecordEvent( 'Clicked Related Posts Radio Button' ) } />
@@ -307,27 +316,39 @@ const FormGeneral = React.createClass( {
 							<FormRadio
 								name="jetpack_relatedposts_enabled"
 								value="1"
-								className="tog"
 								checked={ 1 === parseInt( this.state.jetpack_relatedposts_enabled, 10 ) }
 								onChange={ this.handleRadio }
 								onClick={ this.onRecordEvent( 'Clicked Related Posts Radio Button' ) } />
 							<span>{ this.translate( 'Show related content after posts' ) }</span>
 						</FormLabel>
-						<ul id="settings-reading-relatedposts-customize" className={ 1 === parseInt( this.state.jetpack_relatedposts_enabled, 10 ) ? null : 'disabled-block' }>
+						<ul
+							id="settings-reading-relatedposts-customize"
+							className={ 1 === parseInt( this.state.jetpack_relatedposts_enabled, 10 ) ? null : 'disabled-block' }>
 							<li>
 								<FormLabel>
-									<FormCheckbox name="jetpack_relatedposts_show_headline" checkedLink={ this.linkState( 'jetpack_relatedposts_show_headline' ) }/>
-									<span>{ this.translate( 'Show a "Related" header to more clearly separate the related section from posts' ) }</span>
+									<FormCheckbox
+										name="jetpack_relatedposts_show_headline"
+										checkedLink={ this.linkState( 'jetpack_relatedposts_show_headline' ) }/>
+									<span>
+										{ this.translate(
+											'Show a "Related" header to more clearly separate the related section from posts'
+										) }
+									</span>
 								</FormLabel>
 							</li>
 							<li>
 								<FormLabel>
-									<FormCheckbox name="jetpack_relatedposts_show_thumbnails" checkedLink={ this.linkState( 'jetpack_relatedposts_show_thumbnails' ) }/>
+									<FormCheckbox
+										name="jetpack_relatedposts_show_thumbnails"
+										checkedLink={ this.linkState( 'jetpack_relatedposts_show_thumbnails' ) }/>
 									<span>{ this.translate( 'Use a large and visually striking layout' ) }</span>
 								</FormLabel>
 							</li>
 						</ul>
-						<RelatedContentPreview enabled={ 1 === parseInt( this.state.jetpack_relatedposts_enabled, 10 ) } showHeadline={ this.state.jetpack_relatedposts_show_headline } showThumbnails={ this.state.jetpack_relatedposts_show_thumbnails } />
+						<RelatedContentPreview
+							enabled={ 1 === parseInt( this.state.jetpack_relatedposts_enabled, 10 ) }
+							showHeadline={ this.state.jetpack_relatedposts_show_headline }
+							showThumbnails={ this.state.jetpack_relatedposts_show_thumbnails } />
 					</li>
 				</ul>
 			</FormFieldset>
@@ -341,12 +362,15 @@ const FormGeneral = React.createClass( {
 		return (
 			<CompactCard>
 				<form onChange={ this.markChanged }>
-					<ul id="settings-jetpack" className="settings-jetpack">
+					<ul id="settings-jetpack">
 						<li>
 							<FormLabel>
-								<FormCheckbox name="jetpack_sync_non_public_post_stati" checkedLink={ this.linkState( 'jetpack_sync_non_public_post_stati' ) }/>
+								<FormCheckbox
+									name="jetpack_sync_non_public_post_stati"
+									checkedLink={ this.linkState( 'jetpack_sync_non_public_post_stati' ) }
+								/>
 								<span>{ this.translate( 'Allow synchronization of Posts and Pages with non-public post statuses' ) }</span>
-								<FormSettingExplanation className="is-indented">
+								<FormSettingExplanation isIndented>
 									{ this.translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }
 								</FormSettingExplanation>
 							</FormLabel>
@@ -358,8 +382,8 @@ const FormGeneral = React.createClass( {
 	},
 
 	jetpackDisconnectOption() {
-		var site = this.props.site,
-			disconnectText;
+		const { site } = this.props;
+		let disconnectText;
 
 		if ( ! site.jetpack ) {
 			return null;
@@ -378,7 +402,7 @@ const FormGeneral = React.createClass( {
 
 	holidaySnowOption() {
 		// Note that years and months below are zero indexed
-		let site = this.props.site,
+		const site = this.props.site,
 			today = this.moment(),
 			startDate = this.moment( { year: today.year(), month: 11, day: 1 } ),
 			endDate = this.moment( { year: today.year(), month: 0, day: 4 } );
@@ -433,7 +457,7 @@ const FormGeneral = React.createClass( {
 
 	renderJetpackSyncPanel() {
 		if ( ! config.isEnabled( 'jetpack/sync-panel' ) ) {
-			 return null;
+			return null;
 		}
 
 		const site = this.props.site;
@@ -447,7 +471,7 @@ const FormGeneral = React.createClass( {
 	},
 
 	render() {
-		var site = this.props.site;
+		const { site } = this.props;
 		if ( site.jetpack && ! site.hasMinimumJetpackVersion ) {
 			return this.jetpackDisconnectOption();
 		}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -84,7 +84,7 @@
 		padding-top: 20px;
 	}
 
-	.blogaddress-settings {
+	.site-settings__blogaddress-settings {
 		@include breakpoint( ">660px" ) {
 			display: flex;
 		}
@@ -275,7 +275,8 @@
 	margin-right: 8px;
 }
 
-.has-divider {
+// @TODO: Remove has-divider once all instances have been replaced with .site-settings__has-divider
+.has-divider, .site-settings__has-divider {
 	margin: 0 -24px;
 	padding: 24px 24px 16px 24px;
 	border: 1px lighten( $gray, 30% ) solid;


### PR DESCRIPTION
While working in `form-general.jsx`, I noticed that there were several ESLint warnings that popped up every time I committed. This PR fixes those issues.

To test:

- Checkout `update/general-site-settings-eslint` branch
- Go to `/settings/general/$site`, where `$site` is a Jetpack site
- Ensure there are no errors and that the UI doesn't appear broken
- Can you change settings?
- Switch sites to a WP.com site
- Ensure there are no errors and that the UI doesn't appear broken
- Can you change settings?

Note: You may run into an issue where your settings don't load for Jetpack sites. This is a known issue which was reported in #6235, and is not related to this changeset.

cc @lezama @enejb for code review.