### PR TITLE
Reader Search: add autofocus to search box

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -154,6 +154,7 @@ const FeedStream = React.createClass( {
 				<SearchInput
 					initialValue={ this.props.query }
 					onSearch={ this.updateQuery }
+					autoFocus={ true }
 					delaySearch={ true }
 					placeholder={ this.translate( 'Search billions of posts across WordPress.com…' ) } />
 			</Stream>


### PR DESCRIPTION
Search box should auto focus when search tab is selected

Test live: https://calypso.live/?branch=add/reader-search-autofocus