### PR TITLE
Site Settings: Do not show non-public post sync checkbox for JP sites > 4.1.1

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -337,6 +337,12 @@ const FormGeneral = React.createClass( {
 		if ( ! config.isEnabled( 'manage/option_sync_non_public_post_stati' ) ) {
 			return null;
 		}
+
+		const { site } = this.props;
+		if ( site.jetpack && site.versionCompare( '4.1.1', '>' ) ) {
+			return null;
+		}
+
 		return (
 			<Card className="is-compact">
 				<form onChange={ this.markChanged }>


### PR DESCRIPTION
In [this comment](https://github.com/Automattic/wp-calypso/pull/6695#issuecomment-232150925), @rickybanister suggested we remove the checkbox that allows enabling/disabling syncing of posts with non-public post statuses. @lezama suggested that we make the change for sites `> 4.1.1` of Jetpack.

cc @lezama for code review.

To test:

- Checkout `update/jetpack-settings-remove-post-statuses-checkbox` branch
- Go to `/settings/general/$site` where `$site` is on lastest Jetpack master
- You should see something like this:

    ![screen shot 2016-07-13 at 12 06 52 pm](https://cloud.githubusercontent.com/assets/1126811/16812348/513da1de-48f2-11e6-899d-a33d70c76fa9.png)
- Switch to a site with Jetpack `<= 4.1.1`
- You should see something like this:
    ![screen shot 2016-07-13 at 12 07 41 pm](https://cloud.githubusercontent.com/assets/1126811/16812372/6d4a8680-48f2-11e6-8668-138d2410f47b.png)



Test live: https://calypso.live/?branch=update/jetpack-settings-remove-post-statuses-checkbox