### PR TITLE
CPT: create Add Term component

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -98,22 +98,6 @@ function getCategoryIds( post ) {
 	} );
 }
 
-function getTermIds( post ) {
-	if ( ! post || ! post.terms ) {
-		return;
-	}
-
-	// Skip "default" taxonomies
-	const taxonomies = omit( post.terms, [ 'post_tag', 'category' ] );
-	return mapValues( taxonomies, ( taxonomy ) => {
-		const termIds = map( taxonomy, 'ID' );
-
-		// Hack: qs omits empty arrays in wpcom.js request, which prevents
-		// removing all terms for a given taxonomy since the empty array is not sent to the API
-		return termIds.length ? termIds : null;
-	} );
-}
-
 function getParentId( post ) {
 	if ( ! post || ! post.parent ) {
 		return null;
@@ -220,11 +204,6 @@ function normalize( post ) {
 	var categoryIds = getCategoryIds( post );
 	if ( categoryIds ) {
 		post.category_ids = categoryIds;
-	}
-
-	const termIds = getTermIds( post );
-	if ( termIds ) {
-		post.terms_by_id = termIds;
 	}
 
 	post.parent_id = getParentId( post );

--- a/client/my-sites/term-tree-selector/add-term.jsx
+++ b/client/my-sites/term-tree-selector/add-term.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes, Component } from 'react';
 import ReactDom from 'react-dom';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
@@ -148,7 +149,7 @@ class TermSelectorAddTerm extends Component {
 	}
 
 	render() {
-		const { labels, siteId, taxonomy, translate } = this.props;
+		const { labels, siteId, taxonomy, translate, terms } = this.props;
 		const buttons = [ {
 			action: 'cancel',
 			label: translate( 'Cancel' )
@@ -167,9 +168,10 @@ class TermSelectorAddTerm extends Component {
 		}
 
 		const isError = this.state.error && this.state.error.length;
+		const classes = classNames( 'term-tree-selector__add-term', { 'is-compact': terms.length < 8 } );
 
 		return (
-			<div className="term-tree-selector__add-term">
+			<div className={ classes }>
 				<Button borderless compact={ true } onClick={ this.boundOpenDialog }>
 					<Gridicon icon="folder" /> { labels.add_new_item }
 				</Button>

--- a/client/my-sites/term-tree-selector/add-term.jsx
+++ b/client/my-sites/term-tree-selector/add-term.jsx
@@ -168,7 +168,8 @@ class TermSelectorAddTerm extends Component {
 		}
 
 		const isError = this.state.error && this.state.error.length;
-		const classes = classNames( 'term-tree-selector__add-term', { 'is-compact': terms.length < 8 } );
+		const totalTerms = terms ? terms.length : 0;
+		const classes = classNames( 'term-tree-selector__add-term', { 'is-compact': totalTerms < 8 } );
 
 		return (
 			<div className={ classes }>

--- a/client/my-sites/term-tree-selector/add-term.jsx
+++ b/client/my-sites/term-tree-selector/add-term.jsx
@@ -1,0 +1,231 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, Component } from 'react';
+import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import TermTreeSelectorTerms from './terms';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormTextInput from 'components/forms/form-text-input';
+import FormSectionHeading from 'components/forms/form-section-heading';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormFieldset from 'components/forms/form-fieldset';
+import viewport from 'lib/viewport';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
+import { addTerm } from 'state/terms/actions';
+
+class TermSelectorAddTerm extends Component {
+	static initialState = () => {
+		return Object.assign( {}, {
+			showDialog: false,
+			selectedParent: [],
+			isTopLevel: true,
+			isValid: false,
+			error: null
+		} );
+	};
+
+	static propTypes = {
+		labels: PropTypes.object,
+		postType: PropTypes.string,
+		siteId: PropTypes.number,
+		taxonomy: PropTypes.string,
+		translate: PropTypes.func
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = this.constructor.initialState();
+		this.boundCloseDialog = this.closeDialog.bind( this );
+		this.boundOpenDialog = this.openDialog.bind( this );
+		this.boundOnParentChange = this.onParentChange.bind( this );
+		this.boundOnSearch = this.onSearch.bind( this );
+		this.boundSaveTerm = this.saveTerm.bind( this );
+		this.boundOnTopLevelChange = this.onTopLevelChange.bind( this );
+		this.boundValidateInput = this.validateInput.bind( this );
+	}
+
+	onSearch( searchTerm ) {
+		this.setState( { searchTerm: searchTerm } );
+	}
+
+	openDialog( event ) {
+		event.preventDefault();
+
+		this.setState( {
+			showDialog: true,
+			selectedParent: []
+		} );
+	}
+
+	closeDialog() {
+		this.setState( this.constructor.initialState() );
+	}
+
+	onParentChange( item ) {
+		this.setState( {
+			selectedParent: [ item.ID ],
+			isTopLevel: false
+		} );
+	}
+
+	onTopLevelChange() {
+		this.setState( {
+			isTopLevel: ! this.state.isTopLevel,
+			selectedParent: []
+		} );
+	}
+
+	getSelectedValues() {
+		const termName = ReactDom.findDOMNode( this.refs.termName ).value.trim();
+		const parent = this.state.selectedParent.length ? this.state.selectedParent[ 0 ] : 0;
+
+		return {
+			name: termName,
+			parent: parent
+		};
+	}
+
+	isValid() {
+		let error;
+
+		const values = this.getSelectedValues();
+
+		const newTermNameLowerCased = values.name.toLowerCase();
+
+		if ( ! values.name.length ) {
+			error = true;
+		}
+
+		// TODO: Check for duplicate term name
+
+		//if ( existingMatches ) {
+		//	error = this.translate( 'Name already exists', {
+		//		context: 'Terms: Add term error message - duplicate term name exists',
+		//		textOnly: true
+		//	} );
+		//}
+
+		if ( error !== this.state.error ) {
+			this.setState( {
+				error: error,
+				isValid: ! error
+			} );
+		}
+
+		return ! error;
+	}
+
+	validateInput( event ) {
+		if ( 13 === event.keyCode ) {
+			this.saveTerm();
+		} else {
+			this.isValid();
+		}
+	}
+
+	saveTerm() {
+		const values = this.getSelectedValues();
+		if ( ! this.isValid() ) {
+			return;
+		}
+
+		const { siteId, taxonomy } = this.props;
+
+		this.props.addTerm( siteId, taxonomy, values );
+		this.closeDialog();
+	}
+
+	render() {
+		const { labels, siteId, taxonomy, translate } = this.props;
+		const buttons = [ {
+			action: 'cancel',
+			label: translate( 'Cancel' )
+		}, {
+			action: 'add',
+			label: translate( 'Add' ),
+			isPrimary: true,
+			disabled: ! this.state.isValid,
+			onClick: this.boundSaveTerm
+		} ];
+
+		const { searchTerm, selectedParent } = this.state;
+		const query = {};
+		if ( searchTerm && searchTerm.length ) {
+			query.search = searchTerm;
+		}
+
+		const isError = this.state.error && this.state.error.length;
+
+		return (
+			<div className="term-tree-selector__add-term">
+				<Button borderless compact={ true } onClick={ this.boundOpenDialog }>
+					<Gridicon icon="folder" /> { labels.add_new_item }
+				</Button>
+				<Dialog
+					autoFocus={ false }
+					isVisible={ this.state.showDialog }
+					buttons={ buttons }
+					onClose={ this.boundCloseDialog }
+					additionalClassNames="term-tree-selector__add-term-dialog">
+					<FormSectionHeading>{ labels.add_new_item }</FormSectionHeading>
+					<FormFieldset>
+						<FormTextInput
+							autoFocus={ this.state.showDialog && ! viewport.isMobile() }
+							placeholder={ labels.new_item_name }
+							ref="termName"
+							isError={ isError }
+							onKeyUp={ this.boundValidateInput } />
+						{ isError ? <FormInputValidation isError={ true } text={ this.state.error } /> : null }
+					</FormFieldset>
+					<FormFieldset>
+						<FormLegend>
+							{ labels.parent_item }
+						</FormLegend>
+						<FormLabel>
+							<FormCheckbox ref="topLevel" checked={ this.state.isTopLevel } onChange={ this.boundOnTopLevelChange } />
+							<span>{ translate( 'Top level', { context: 'Terms: New term being created is top level' } ) }</span>
+						</FormLabel>
+						<TermTreeSelectorTerms
+							siteId={ siteId }
+							taxonomy={ taxonomy }
+							onSearch={ this.boundOnSearch }
+							onChange={ this.boundOnParentChange }
+							query={ query }
+							selected={ selectedParent }
+						/>
+					</FormFieldset>
+				</Dialog>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => {
+		const siteId = getSelectedSiteId( state );
+		const taxonomyDetails = getPostTypeTaxonomy( state, siteId, ownProps.postType, ownProps.taxonomy ) || {};
+
+		return {
+			labels: taxonomyDetails.labels,
+			siteId
+		};
+	},
+	( dispatch ) => {
+		return bindActionCreators( {
+			addTerm
+		}, dispatch );
+	}
+)( localize( TermSelectorAddTerm ) );

--- a/client/my-sites/term-tree-selector/add-term.scss
+++ b/client/my-sites/term-tree-selector/add-term.scss
@@ -1,0 +1,25 @@
+.term-tree-selector__add-term {
+	border: 1px solid lighten( $gray, 20% );
+	border-top: 0px;
+	margin: 0 0 8px;
+	padding: 8px;
+}
+
+// Dialog
+.term-tree-selector__add-term-dialog .dialog__content {
+	min-width: 40vw;
+}
+
+.term-tree-selector__add-term-dialog .form-input-validation {
+	padding-bottom: 0;
+}
+
+@include breakpoint( "<660px" ) {
+	.term-tree-selector__add-term-dialog {
+		width: 90%;
+	}
+
+	.term-tree-selector__add-term-dialog .dialog__content {
+		min-width: none;
+	}
+}

--- a/client/my-sites/term-tree-selector/add-term.scss
+++ b/client/my-sites/term-tree-selector/add-term.scss
@@ -3,6 +3,10 @@
 	border-top: 0px;
 	margin: 0 0 8px;
 	padding: 8px;
+
+	&.is-compact {
+		border: 0;
+	}
 }
 
 // Dialog

--- a/client/my-sites/term-tree-selector/style.scss
+++ b/client/my-sites/term-tree-selector/style.scss
@@ -1,3 +1,4 @@
+@import 'add-term';
 @import 'search';
 
 .term-tree-selector {

--- a/client/my-sites/term-tree-selector/terms.jsx
+++ b/client/my-sites/term-tree-selector/terms.jsx
@@ -4,13 +4,16 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import includes from 'lodash/includes';
 import { localize } from 'i18n-calypso';
-import debounce from 'lodash/debounce';
-import range from 'lodash/range';
 import VirtualScroll from 'react-virtualized/VirtualScroll';
-import difference from 'lodash/difference';
-import isEqual from 'lodash/isEqual';
+import {
+	debounce,
+	difference,
+	includes,
+	isEqual,
+	range,
+	size
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -95,7 +98,7 @@ const TermTreeSelectorList = React.createClass( {
 			! isEqual( prevProps.selected, this.props.selected ) ||
 			prevProps.loading && ! this.props.loading ||
 			( ! prevProps.terms && this.props.terms ) ||
-			( ( prevProps.terms && this.props.terms ) && ( prevProps.terms.length !== this.props.terms.length ) )
+			size( prevProps.terms ) !== size( this.props.terms )
 		);
 
 		if ( forceUpdate ) {

--- a/client/my-sites/term-tree-selector/terms.jsx
+++ b/client/my-sites/term-tree-selector/terms.jsx
@@ -11,8 +11,7 @@ import {
 	difference,
 	includes,
 	isEqual,
-	range,
-	size
+	range
 } from 'lodash';
 
 /**
@@ -97,12 +96,15 @@ const TermTreeSelectorList = React.createClass( {
 		const forceUpdate = (
 			! isEqual( prevProps.selected, this.props.selected ) ||
 			prevProps.loading && ! this.props.loading ||
-			( ! prevProps.terms && this.props.terms ) ||
-			size( prevProps.terms ) !== size( this.props.terms )
+			( ! prevProps.terms && this.props.terms )
 		);
 
 		if ( forceUpdate ) {
 			this.virtualScroll.forceUpdate();
+		}
+
+		if ( this.props.terms !== prevProps.terms ) {
+			this.recomputeRowHeights();
 		}
 	},
 

--- a/client/my-sites/term-tree-selector/terms.jsx
+++ b/client/my-sites/term-tree-selector/terms.jsx
@@ -94,7 +94,8 @@ const TermTreeSelectorList = React.createClass( {
 		const forceUpdate = (
 			! isEqual( prevProps.selected, this.props.selected ) ||
 			prevProps.loading && ! this.props.loading ||
-			( ! prevProps.terms && this.props.terms )
+			( ! prevProps.terms && this.props.terms ) ||
+			( ( prevProps.terms && this.props.terms ) && ( prevProps.terms.length !== this.props.terms.length ) )
 		);
 
 		if ( forceUpdate ) {

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import createFragment from 'react-addons-create-fragment';
-import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -141,7 +140,7 @@ const EditorDrawer = React.createClass( {
 		// Custom Taxonomies
 		let taxonomies;
 		if ( isCustomTypesEnabled && false !== canJetpackUseTaxonomies ) {
-			taxonomies = <EditorDrawerTaxonomies postTerms={ get( post, 'terms' ) } />;
+			taxonomies = <EditorDrawerTaxonomies />;
 		}
 
 		return createFragment( { categories, taxonomies } );

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -30,7 +30,7 @@ function isSkippedTaxonomy( postType, taxonomy ) {
 	return false;
 }
 
-function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
+function EditorDrawerTaxonomies( { siteId, postType, taxonomies } ) {
 	return (
 		<div className="editor-drawer__taxonomies">
 			{ siteId && postType && (

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -52,7 +52,7 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 						icon={ <Gridicon icon={ icon } /> }
 					>
 					{ hierarchical
-						? <TermSelector postTerms={ postTerms } taxonomyName={ name } />
+						? <TermSelector taxonomyName={ name } />
 						: <TermTokenField taxonomyName={ name } />
 					}
 					</Accordion>
@@ -65,7 +65,6 @@ function EditorDrawerTaxonomies( { siteId, postType, postTerms, taxonomies } ) {
 EditorDrawerTaxonomies.propTypes = {
 	siteId: PropTypes.number,
 	postType: PropTypes.string,
-	postTerms: PropTypes.object,
 	taxonomies: PropTypes.array,
 };
 

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { includes, cloneDeep, map } from 'lodash';
+import { cloneDeep, find, reject, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,30 +32,19 @@ class EditorTermSelector extends Component {
 	onTermsChange( selectedTerm ) {
 		const { postTerms, taxonomyName, siteId, postId } = this.props;
 		const terms = cloneDeep( postTerms ) || {};
-		let taxonomyTerms = map( terms[ taxonomyName ] );
-		const termIds = map( taxonomyTerms, 'ID' );
 
-		if ( includes( termIds, selectedTerm.ID ) ) {
-			taxonomyTerms = taxonomyTerms.reduce( ( prev, term ) => {
-				if ( term.ID === selectedTerm.ID ) {
-					return prev;
-				}
+		// map call transforms object returned by API into an array
+		let taxonomyTerms = map( terms[ taxonomyName ] ) || [];
 
-				prev.push( term );
-				return prev;
-			}, [] );
+		if ( find( taxonomyTerms, { ID: selectedTerm.ID } ) ) {
+			taxonomyTerms = reject( taxonomyTerms, { ID: selectedTerm.ID } );
 		} else {
 			taxonomyTerms.push( selectedTerm );
 		}
 
-		const taxonomyTermIds = map( taxonomyTerms, 'ID' );
-
 		this.props.editPost( {
 			terms: {
 				[ taxonomyName ]: taxonomyTerms
-			},
-			terms_by_id: {
-				[ taxonomyName ]: taxonomyTermIds.length ? taxonomyTermIds : null
 			}
 		}, siteId, postId );
 	}

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { cloneDeep, find, reject, map } from 'lodash';
+import { cloneDeep, findIndex, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,10 +34,10 @@ class EditorTermSelector extends Component {
 		const terms = cloneDeep( postTerms ) || {};
 
 		// map call transforms object returned by API into an array
-		let taxonomyTerms = map( terms[ taxonomyName ] ) || [];
-
-		if ( find( taxonomyTerms, { ID: selectedTerm.ID } ) ) {
-			taxonomyTerms = reject( taxonomyTerms, { ID: selectedTerm.ID } );
+		const taxonomyTerms = map( terms[ taxonomyName ] ) || [];
+		const existingSelectionIndex = findIndex( taxonomyTerms, { ID: selectedTerm.ID } );
+		if ( existingSelectionIndex !== -1 ) {
+			taxonomyTerms.splice( existingSelectionIndex, 1 );
 		} else {
 			taxonomyTerms.push( selectedTerm );
 		}

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -10,13 +10,17 @@ import cloneDeep from 'lodash/cloneDeep';
  * Internal dependencies
  */
 import TermTreeSelector from 'my-sites/term-tree-selector';
+import AddTerm from 'my-sites/term-tree-selector/add-term';
 import PostActions from 'lib/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
 
 class EditorTermSelector extends Component {
 	static propTypes = {
 		siteId: React.PropTypes.number,
 		postTerms: React.PropTypes.object,
+		postType: React.PropTypes.string,
 		taxonomyName: React.PropTypes.string
 	};
 
@@ -50,23 +54,29 @@ class EditorTermSelector extends Component {
 	}
 
 	render() {
-		const { siteId, taxonomyName } = this.props;
+		const { postType, siteId, taxonomyName } = this.props;
 
 		return (
-			<TermTreeSelector
-				analyticsPrefix="Editor"
-				onChange={ this.boundOnTermsChange }
-				selected={ this.getSelectedTermIds() }
-				taxonomy={ taxonomyName }
-				siteId={ siteId }
-				multiple={ true }
-			/>
+			<div>
+				<TermTreeSelector
+					analyticsPrefix="Editor"
+					onChange={ this.boundOnTermsChange }
+					selected={ this.getSelectedTermIds() }
+					taxonomy={ taxonomyName }
+					siteId={ siteId }
+					multiple={ true }
+				/>
+				<AddTerm taxonomy={ taxonomyName } postType={ postType } />
+			</div>
 		);
 	}
 }
 
 export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
 	return {
-		siteId: getSelectedSiteId( state )
+		postType: getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' ),
+		siteId
 	};
 } )( EditorTermSelector );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -44,7 +44,7 @@ import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-d
 import { isEditorDraftsVisible, getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { toggleEditorDraftsVisible, setEditorPostId } from 'state/ui/editor/actions';
 import { receivePost, editPost, resetPostEdits } from 'state/posts/actions';
-import { getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
+import { getNormalizedPostEdits, isEditedPostDirty } from 'state/posts/selectors';
 import EditorSidebarHeader from 'post-editor/editor-sidebar/header';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
@@ -768,7 +768,7 @@ export default connect(
 			showDrafts: isEditorDraftsVisible( state ),
 			editorModePreference: getPreference( state, 'editor-mode' ),
 			editPath: getEditorPath( state, siteId, postId ),
-			edits: getPostEdits( state, siteId, postId ),
+			edits: getNormalizedPostEdits( state, siteId, postId ),
 			dirty: isEditedPostDirty( state, siteId, postId ),
 		};
 	},

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -44,7 +44,7 @@ import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-d
 import { isEditorDraftsVisible, getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { toggleEditorDraftsVisible, setEditorPostId } from 'state/ui/editor/actions';
 import { receivePost, editPost, resetPostEdits } from 'state/posts/actions';
-import { getNormalizedPostEdits, isEditedPostDirty } from 'state/posts/selectors';
+import { getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
 import EditorSidebarHeader from 'post-editor/editor-sidebar/header';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
@@ -768,7 +768,7 @@ export default connect(
 			showDrafts: isEditorDraftsVisible( state ),
 			editorModePreference: getPreference( state, 'editor-mode' ),
 			editPath: getEditorPath( state, siteId, postId ),
-			edits: getNormalizedPostEdits( state, siteId, postId ),
+			edits: getPostEdits( state, siteId, postId ),
 			dirty: isEditedPostDirty( state, siteId, postId ),
 		};
 	},

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -21,6 +21,7 @@ import {
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
 	mergeIgnoringArrays,
+	getTermIdsFromEdits
 } from './utils';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import firstPassCanonicalImage from 'lib/post-normalizer/rule-first-pass-canonical-image';
@@ -314,6 +315,23 @@ export function getEditedPost( state, siteId, postId ) {
 export function getPostEdits( state, siteId, postId ) {
 	const { edits } = state.posts;
 	return get( edits, [ siteId, postId || '' ], null );
+}
+
+/**
+ * Returns an object of normalized edited post attributes for the site ID post ID pairing.
+ *
+ * @param  {Object} state  Global state tree
+ * @param  {Number} siteId Site ID
+ * @param  {Number} postId Post ID
+ * @return {Object}        Normalized Post revisions
+ */
+export function getNormalizedPostEdits( state, siteId, postId ) {
+	const edits = getPostEdits( state, siteId, postId );
+	const normalize = flow( [
+		getTermIdsFromEdits
+	] );
+
+	return normalize( edits );
 }
 
 /**

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -21,7 +21,7 @@ import {
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
 	mergeIgnoringArrays,
-	normalizePost
+	normalizeEditedPost
 } from './utils';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import firstPassCanonicalImage from 'lib/post-normalizer/rule-first-pass-canonical-image';
@@ -314,7 +314,7 @@ export function getEditedPost( state, siteId, postId ) {
  */
 export function getPostEdits( state, siteId, postId ) {
 	const { edits } = state.posts;
-	return normalizePost( get( edits, [ siteId, postId || '' ], null ) );
+	return normalizeEditedPost( get( edits, [ siteId, postId || '' ], null ) );
 }
 
 /**

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -21,7 +21,7 @@ import {
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
 	mergeIgnoringArrays,
-	getTermIdsFromEdits
+	normalizePost
 } from './utils';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import firstPassCanonicalImage from 'lib/post-normalizer/rule-first-pass-canonical-image';
@@ -314,24 +314,7 @@ export function getEditedPost( state, siteId, postId ) {
  */
 export function getPostEdits( state, siteId, postId ) {
 	const { edits } = state.posts;
-	return get( edits, [ siteId, postId || '' ], null );
-}
-
-/**
- * Returns an object of normalized edited post attributes for the site ID post ID pairing.
- *
- * @param  {Object} state  Global state tree
- * @param  {Number} siteId Site ID
- * @param  {Number} postId Post ID
- * @return {Object}        Normalized Post revisions
- */
-export function getNormalizedPostEdits( state, siteId, postId ) {
-	const edits = getPostEdits( state, siteId, postId );
-	const normalize = flow( [
-		getTermIdsFromEdits
-	] );
-
-	return normalize( edits );
+	return normalizePost( get( edits, [ siteId, postId || '' ], null ) );
 }
 
 /**

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -11,6 +11,7 @@ import {
 	getSerializedPostsQuery,
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
+	getTermIdsFromEdits,
 	mergeIgnoringArrays
 } from '../utils';
 
@@ -138,6 +139,82 @@ describe( 'utils', () => {
 
 			expect( merged ).to.eql( {
 				tags_by_id: [ 1, 2, 3, 4 ]
+			} );
+		} );
+	} );
+
+	describe( '#getTermIdsFromEdits()', () => {
+		it( 'should return the same post edit object if no term edits have been made', () => {
+			const normalizedPostEdits = getTermIdsFromEdits( {
+				title: 'Chewbacca Saves'
+			} );
+
+			expect( normalizedPostEdits ).to.eql( {
+				title: 'Chewbacca Saves'
+			} );
+		} );
+
+		it( 'should return the add terms_by_id if terms have been edited', () => {
+			const normalizedPostEdits = getTermIdsFromEdits( {
+				title: 'Chewbacca Saves',
+				terms: {
+					wookie_post_types: {
+						awesomesauce: {
+							ID: 777,
+							name: 'Awesomesauce'
+						}
+					}
+				}
+			} );
+
+			expect( normalizedPostEdits ).to.eql( {
+				title: 'Chewbacca Saves',
+				terms: {
+					wookie_post_types: {
+						awesomesauce: {
+							ID: 777,
+							name: 'Awesomesauce'
+						}
+					}
+				},
+				terms_by_id: {
+					wookie_post_types: [ 777 ]
+				}
+			} );
+		} );
+
+		it( 'should taxonomy terms_by_id to null if object is empty', () => {
+			const normalizedPostEdits = getTermIdsFromEdits( {
+				title: 'Chewbacca Saves',
+				terms: {
+					wookie_post_types: {}
+				}
+			} );
+
+			expect( normalizedPostEdits ).to.eql( {
+				title: 'Chewbacca Saves',
+				terms: {
+					wookie_post_types: {}
+				},
+				terms_by_id: {
+					wookie_post_types: null
+				}
+			} );
+		} );
+
+		it( 'should not set terms_by_id for taxonomies that set an array on terms', () => {
+			const normalizedPostEdits = getTermIdsFromEdits( {
+				title: 'Chewbacca Saves',
+				terms: {
+					wookie_post_tags: [ 'raaar', 'uggggaaarr' ]
+				}
+			} );
+
+			expect( normalizedPostEdits ).to.eql( {
+				title: 'Chewbacca Saves',
+				terms: {
+					wookie_post_tags: [ 'raaar', 'uggggaaarr' ]
+				}
 			} );
 		} );
 	} );

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -155,7 +156,7 @@ describe( 'utils', () => {
 		} );
 
 		it( 'should return the add terms_by_id if terms have been edited', () => {
-			const normalizedPostEdits = getTermIdsFromEdits( {
+			const originalPost = deepFreeze( {
 				title: 'Chewbacca Saves',
 				terms: {
 					wookie_post_types: {
@@ -166,6 +167,8 @@ describe( 'utils', () => {
 					}
 				}
 			} );
+
+			const normalizedPostEdits = getTermIdsFromEdits( originalPost );
 
 			expect( normalizedPostEdits ).to.eql( {
 				title: 'Chewbacca Saves',


### PR DESCRIPTION
This branch introduces the `<AddTerm/>` component which allows for creation of new terms for a given taxonomy:

__Default Display__
![new_project_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/16813265/a504935c-48e5-11e6-9d92-cf3ca6766126.png)

__Dialog__
![new_project_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/16813250/900babd4-48e5-11e6-9c32-4cf4542f97c0.png)

Currently you can add a new term using the dialog, much like the existing "Add Category" feature in the editor sidebar.

__To Test__
- Open up a portfolio project in the editor
- Expand the "Project Types" accordion
- Click the "Add New Project Type" button
- Interact with the modal form.  Use the search box to find a parent.
- Select a parent and note the "Top Level" checkbox unticks
- Play around with validation.  You should not be able to submit a term name that already exists for a given tree level ( i.e. only one top level term could be named `Major Key` ).
- Save a new term, note that it should appear in the original post-editor term selector.  If there are multiple pages of terms, you might need to scroll to trigger a new fetch, or simply search for your newly added term

__Todo in Future PR__
- Auto "checking" newly added term in post that is being edited


Test live: https://calypso.live/?branch=add/term-tree-selector/add-term