### PR TITLE
Reader: Suppress like counts when zero on search cards

### DIFF
--- a/client/components/like-button/_style.scss
+++ b/client/components/like-button/_style.scss
@@ -68,3 +68,8 @@
 		}
 	}
 }
+
+.like-button__label {
+	// this keeps the label from collapsing and making the icon drop down
+	margin-left: 1px;
+}

--- a/client/components/like-button/_style.scss
+++ b/client/components/like-button/_style.scss
@@ -62,10 +62,6 @@
 		}
 	}
 
-	.like-button__label-count {
-		margin-right: 4px;
-	}
-
 	@include breakpoint( "<480px" ) {
 		.like-button__label-status {
 			display: none;

--- a/client/components/like-button/button.jsx
+++ b/client/components/like-button/button.jsx
@@ -83,8 +83,14 @@ var LikeButton = React.createClass( {
 
 		containerClasses = classnames( containerClasses );
 
+		if ( likeCount === 0 && ! this.props.showCount ) {
+			likeCount = '';
+		} else {
+			likeCount = likeCount + ' ';
+		}
+
 		labelElement = ( <span className="like-button__label">
-			{ likeCount > 0 || this.props.showCount ? <span className="like-button__label-count">{ likeCount }</span> : null }
+			<span className="like-button__label-count">{ likeCount }</span>
 			{ this.props.showLabel && <span className="like-button__label-status">{ likeLabel }</span> }
 		</span> );
 

--- a/client/components/like-button/button.jsx
+++ b/client/components/like-button/button.jsx
@@ -83,14 +83,9 @@ var LikeButton = React.createClass( {
 
 		containerClasses = classnames( containerClasses );
 
-		if ( likeCount === 0 && ! this.props.showCount ) {
-			likeCount = '';
-		} else {
-			likeCount = likeCount + ' ';
-		}
-
 		labelElement = ( <span className="like-button__label">
-			<span className="like-button__label-count">{ likeCount }</span>
+			<span className="like-button__label-count">{ likeCount === 0 && ! this.props.showCount ? '' : likeCount }</span>
+			{ this.props.showLabel && ' ' }
 			{ this.props.showLabel && <span className="like-button__label-status">{ likeLabel }</span> }
 		</span> );
 

--- a/client/components/post-card/search.jsx
+++ b/client/components/post-card/search.jsx
@@ -53,7 +53,7 @@ export function SearchPostCard( { post, site, feed, onClick = noop, onCommentCli
 					commentCount={ post.discussion.comment_count }
 					tagName="span" showLabel={ false }
 					onClick={ onCommentClick }/>
-				<LikeButton siteId={ post.site_ID } postId={ post.ID } tagName="span" showCount={ true } showLabel={ false } />
+				<LikeButton siteId={ post.site_ID } postId={ post.ID } tagName="span" showCount={ false } showLabel={ false } />
 			</div>
 			<h1 className="post-card__search-title">
 				<a className="post-card__search-title-link" href={ post.URL }>{ post.title }</a>


### PR DESCRIPTION
Refactor how the count elements are built and styled to make them easier to deal with too. The margin-right on the inline element was causing issues when it was removed from the dom

Test live: https://calypso.live/read/search?branch=update/reader/suppress-like-count-when-zero-in-search