### PR TITLE
Reader Search: fix placeholder text

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -157,7 +157,7 @@ const FeedStream = React.createClass( {
 					onSearch={ this.updateQuery }
 					autoFocus={ true }
 					delaySearch={ true }
-					placeholder={ this.translate( 'Search billions of posts across WordPress.com…' ) } />
+					placeholder={ this.translate( 'Search billions of WordPress.com posts…' ) } />
 			</Stream>
 		);
 	}


### PR DESCRIPTION
Reduce length of search placeholder text as per @fraying's suggestion.

It's now "Search billions of WordPress.com posts…".

http://calypso.localhost:3000/read/search

<img width="794" alt="screen shot 2016-07-13 at 21 37 03" src="https://cloud.githubusercontent.com/assets/17325/16817210/fc46a8d8-4941-11e6-8236-b1ff96bd37e4.png">

Test live: https://calypso.live/?branch=fix/reader/search-placeholder-text