### PR TITLE
Plans: enables the "skip plans for free" test in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -71,6 +71,8 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/personal-plan": true,
+		"plans/skip-plans-for-free": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -67,6 +67,8 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/personal-plan": true,
+		"plans/skip-plans-for-free": true,
 		"post-editor/author-selector": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -71,6 +71,8 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"plans/personal-plan": true,
+		"plans/skip-plans-for-free": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/test.json
+++ b/config/test.json
@@ -88,6 +88,8 @@
 		"olark": true,
 		"perfmon": false,
 		"persist-redux": true,
+		"plans/personal-plan": true,
+		"plans/skip-plans-for-free": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
 		"press-this": true,


### PR DESCRIPTION
This feature has already been tested in #6701 and then in wpcalypso. It should be pretty safe, but you could try running calypso with different environment flags if you want to be safe.

Test live: https://calypso.live/?branch=update/launch-skip-plans-for-free-test