### PR TITLE
Advanced SEO: Fix Meta Title Editor for Small Screens

### DIFF
--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -32,7 +32,7 @@ const titleTypes = translate => [
 	{ value: 'frontPage', label: translate( 'Front Page' ) },
 	{ value: 'posts', label: translate( 'Posts' ) },
 	{ value: 'pages', label: translate( 'Pages' ) },
-	{ value: 'groups', label: translate( 'Categories & Tags' ) },
+	{ value: 'groups', label: translate( 'Tags' ) },
 	{ value: 'archives', label: translate( 'Archives' ) }
 ];
 
@@ -129,7 +129,7 @@ export class MetaTitleEditor extends Component {
 		);
 
 		return (
-			<div>
+			<div className="meta-title-editor">
 				<SegmentedControl
 					initialSelected={ type }
 					options={ titleTypes( translate ) }

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -52,9 +52,13 @@
 }
 
 .meta-title-editor .segmented-control__link {
-	@include breakpoint( "<660px" ) {
-		font-size: 12px;
-		line-height: 16px;
-		padding: 4px 2px;
+	font-size: 12px;
+	line-height: 16px;
+	padding: 4px 2px;
+
+	@include breakpoint( ">660px" ) {
+		font-size: 14px;
+		line-height: 18px;
+		padding: 8px 12px;
 	}
 }

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -50,3 +50,11 @@
 	line-height: 1.4;
 	max-width: 616px;
 }
+
+.meta-title-editor .segmented-control__link {
+	@include breakpoint( "<660px" ) {
+		font-size: 12px;
+		line-height: 16px;
+		padding: 4px 2px;
+	}
+}


### PR DESCRIPTION
Adds some styles to get the meta title editor looking better on small screens:

<img width="374" alt="screen shot 2016-07-13 at 4 42 55 pm" src="https://cloud.githubusercontent.com/assets/789137/16823596/4e665a32-491a-11e6-93a5-17e69ac2e13d.png">

Also renamed `Categories & Tags` to `Tags` to help with the small screen display, keeps font size at a readable size. (cc @drw158)

Needs review @dmsnell 

Test live: https://calypso.live/?branch=fix/meta-title-editor-mobile