### PR TITLE
Site Settings: Fix loading of /settings/general/$site route

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { connect } from 'react-redux';
 import Card from 'components/card';
 import Button from 'components/button';
 import formBase from './form-base';
@@ -27,8 +26,6 @@ import FormRadio from 'components/forms/form-radio';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Timezone from 'components/timezone';
-import QuerySiteDomains from 'components/data/query-site-domains';
-import { getDomainsBySite } from 'state/sites/domains/selectors';
 import JetpackSyncPanel from './jetpack-sync-panel';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { isBusiness } from 'lib/products-values';
@@ -459,7 +456,6 @@ const FormGeneral = React.createClass( {
 
 		return (
 			<div className={ this.state.fetchingSettings ? 'is-loading' : '' }>
-				{ site && <QuerySiteDomains siteId={ site.ID } /> }
 				<SectionHeader label={ this.translate( 'Site Profile' ) }>
 					<Button
 						compact={ true }
@@ -597,11 +593,4 @@ const FormGeneral = React.createClass( {
 	}
 } );
 
-// connect exposing `domains` props
-export default connect( ( state, ownProps ) => {
-	const { site } = ownProps;
-
-	return {
-		domains: getDomainsBySite( state, site )
-	};
-} )( FormGeneral );
+export default FormGeneral;


### PR DESCRIPTION
Fixes #6235.

When a user goes directly to `/settings/general/$site`, the settings are not displayed after getting data from the API. But, if a user clicks another tab, such as "Writing", and then navigates back to "General", the data is displayed.

After a bit of testing, I was able to narrow down the issue to #4972 by checking out 49d52ac14245baf4bad1f90683be9673799faf4f and attempting to load `/settings/general/$site`. From there I was able to narrow it down to the `connect()` statement.

The root issue seems to be that wrapping the component results in breaking the logic we have for updating state in `form-base.js`. I tested this theory by removing the first argument (`mapStateToProps`) which, according to the `connect()` docs, removes the subscription to the store and should only inject `dispatch` into the `FormGeneral` component. When I did this, the WP.com site also did not update. Which leads me to believe that the logic we have in `form-base.js` does not function properly when wrapped.

So, why did WP.com sites work? My best guess is that it has to do with state changes, which then cause `connect()` to render. Perhaps @retrofox can help with this?

For the first reason, and because we're not using the domains data, I think we should move forward with this PR. In the future, when we're ready for the domains data, perhaps we can create a smaller component that subscribes to `domains` instead of wrapping the entire `FormGeneral` component? This seems to have worked for my work on the Jetpack sync panel within the `FormGeneral` component.

To test:

- Checkout `fix/site-settings-general-load` branch
- Go to `/settings/general/$site` where `$site` is a Jetpack site
- Verify that the settings are displayed after a brief delay
- Switch sites to a WP.com site
- Verify that the settings are displayed after a brief delay
- Verify that there are no JavaScript errors in the console;

Note: There are some existing warnings due to `valueLink`. Those existed before this PR.

cc @retrofox @enejb for review

Test live: https://calypso.live/?branch=fix/site-settings-general-load