### PR TITLE
GuidedTours: change step navigation wording to be less ambiguous

### DIFF
--- a/client/layout/guided-tours/steps.js
+++ b/client/layout/guided-tours/steps.js
@@ -35,8 +35,8 @@ class BasicStep extends Component {
 			<Card className={ classNames( ...classes ) } style={ stepCoords } >
 				<p className="guided-tours__step-text">{ text }</p>
 				<div className="guided-tours__choice-button-row">
-					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
-					<Button onClick={ onQuit } borderless>{ this.props.translate( 'Do this later' ) }</Button>
+					<Button onClick={ onNext } primary>{ this.props.translate( 'Next' ) }</Button>
+					<Button onClick={ onQuit } borderless>{ this.props.translate( 'Exit tour' ) }</Button>
 				</div>
 			</Card>
 		);
@@ -97,8 +97,8 @@ class LinkStep extends Component {
 			<Card className="guided-tours__step" style={ stepCoords } >
 				<p className="guided-tours__step-text">{ text }</p>
 				<div className="guided-tours__choice-button-row">
-					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
-					<Button onClick={ onQuit } borderless>{ this.props.translate( 'Do this later' ) }</Button>
+					<Button onClick={ onNext } primary>{ this.props.translate( 'Next' ) }</Button>
+					<Button onClick={ onQuit } borderless>{ this.props.translate( 'Exit tour' ) }</Button>
 				</div>
 				<div className="guided-tours__external-link">
 					<ExternalLink target="_blank" icon={ true } href={ linkUrl }>{ linkLabel }</ExternalLink>


### PR DESCRIPTION
Previously, most steps offered the user to "Continue" or "Do this later".

We have heard from a few people and have also felt ourselves that, e.g. with the Themes step, this feels like "Continue" means to "do something with themes now instead of continuing the tour" (when it actually means continuing to the next tour step) and "Do this later" to mean "we'll get back to themes stuff later" (when it actually means exiting the tour).

Changing "Continue" (as in "continue with this", with "this" being potentially ambiguous) to "Next" (as in "next tour step") and "Do this later" (with "this" being potentially ambiguous) to "Exit tour" should remove some of the ambiguity. 

Before:

<img width="512" alt="screen shot 2016-07-14 at 1 29 00 pm" src="https://cloud.githubusercontent.com/assets/23619/16838082/a53048a2-49c7-11e6-964e-a70cbfcab98b.png">

After:

<img width="473" alt="screen shot 2016-07-14 at 1 33 33 pm" src="https://cloud.githubusercontent.com/assets/23619/16838077/9fd448d6-49c7-11e6-8a6f-0cc3dab9acf4.png">

To test:
- go through the `main` tour, e.g. starting from http://calypso.localhost:3000/?tour=main
- make sure all tour steps look and read OK
- ponder whether this improves the copy or not


Test live: https://calypso.live/?branch=update/guided-tours-step-navigation-wording