### PR TITLE
Component: revert "search box border"

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -121,7 +121,7 @@
 	z-index: z-index( '.search', '.search__input' );
 	top: 0;
 	padding: 0 50px 0 60px;
-	border: 1px solid #87a6bc;
+	border: none;
 	background: $white;
 	height: 51px;
 	appearance: none;
@@ -148,6 +148,7 @@
 
 	&:focus {
 		box-shadow: none;
+		border: none;
 	}
 }
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#6746

Reason: the added border at component level broke the UI elsewhere.

---

Examples of breakage:

My Sites → Themes:
![screen shot 2016-07-14 at 13 35 45](https://cloud.githubusercontent.com/assets/4389/16840205/58e40aac-49cb-11e6-9b59-263ef077929d.png)

Me → Manage Purchases → Billing History
![screen shot 2016-07-14 at 14 01 43](https://cloud.githubusercontent.com/assets/4389/16840247/829f307e-49cb-11e6-8d1e-b5740b06bda8.png)



Test live: https://calypso.live/design/?branch=revert-6746-update/reader/search-borders