### PR TITLE
Replace yellow star by plan icon on my-plan page

### DIFF
--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -28,10 +28,18 @@ import {
 	isPersonal,
 	isFreePlan
 } from 'lib/products-values';
-import Gridicon from 'components/gridicon';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlansNavigation from 'my-sites/upgrades/navigation';
 import { isPlanFeaturesEnabled } from 'lib/plans';
+import {
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_PERSONAL
+} from 'lib/plans/constants';
+import PlanIcon from 'components/plans/plan-icon';
 
 const PlanDetailsComponent = React.createClass( {
 	PropTypes: {
@@ -48,9 +56,7 @@ const PlanDetailsComponent = React.createClass( {
 	render: function() {
 		const { selectedSite } = this.props;
 		const { hasLoadedFromServer } = this.props.sitePlans;
-		let title;
-		let tagLine;
-		let featuresList;
+		let currentPlan, title, tagLine, featuresList;
 
 		if ( ! selectedSite || ! hasLoadedFromServer ) {
 			featuresList = (
@@ -62,13 +68,18 @@ const PlanDetailsComponent = React.createClass( {
 		} else if ( isFreePlan( this.props.selectedSite.plan ) ) {
 			page.redirect( '/plans/' + this.props.selectedSite.slug );
 		} else if ( this.props.selectedSite.jetpack ) {
+			currentPlan = PLAN_JETPACK_FREE;
 			title = this.translate( 'Your site is on a Free plan' );
 			tagLine = this.translate( 'Unlock the full potential of your site with all the features included in your plan.' );
+
 			if ( isJetpackPremium( this.props.selectedSite.plan ) ) {
+				currentPlan = PLAN_JETPACK_PREMIUM;
 				title = this.translate( 'Your site is on a Premium plan' );
 			} else if ( isJetpackBusiness( this.props.selectedSite.plan ) ) {
+				currentPlan = PLAN_JETPACK_BUSINESS;
 				title = this.translate( 'Your site is on a Professional plan' );
 			}
+
 			featuresList = (
 				<JetpackPlanDetails
 					selectedSite={ this.props.selectedSite }
@@ -76,8 +87,10 @@ const PlanDetailsComponent = React.createClass( {
 				/>
 			);
 		} else if ( isPersonal( this.props.selectedSite.plan ) ) {
+			currentPlan = PLAN_PERSONAL;
 			title = this.translate( 'Your site is on a Personal plan' );
 			tagLine = this.translate( 'Unlock the full potential of your site with all the features included in your plan.' );
+
 			featuresList = (
 				<PersonalPlanDetails
 					selectedSite={ this.props.selectedSite }
@@ -85,8 +98,10 @@ const PlanDetailsComponent = React.createClass( {
 				/>
 			);
 		} else if ( isPremium( this.props.selectedSite.plan ) ) {
+			currentPlan = PLAN_PREMIUM;
 			title = this.translate( 'Your site is on a Premium plan' );
 			tagLine = this.translate( 'Unlock the full potential of your site with the premium features included in your plan.' );
+
 			featuresList = (
 				<PremiumPlanDetails
 					selectedSite={ selectedSite }
@@ -94,9 +109,11 @@ const PlanDetailsComponent = React.createClass( {
 				/>
 			);
 		} else if ( isBusiness( selectedSite.plan ) ) {
+			currentPlan = PLAN_BUSINESS;
 			title = this.translate( 'Your site is on a Business plan' );
 			tagLine = this.translate( 'Learn more about everything included with Business and take advantage of' +
 				' its professional features.' );
+
 			featuresList = ( <div>
 				<BusinessPlanDetails
 					selectedSite={ selectedSite }
@@ -122,9 +139,12 @@ const PlanDetailsComponent = React.createClass( {
 				<Card>
 					<div className="current-plan__header">
 						<div className="current-plan__header-content">
-							<span className="current-plan__header-icon">
-								<Gridicon icon="star" size={ 48 } />
-							</span>
+							<div className="current-plan__header-icon">
+								{
+									currentPlan &&
+										<PlanIcon plan={ currentPlan } />
+								}
+							</div>
 
 							<div className="current-plan__header-copy">
 								<h1 className={ classNames( {

--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -31,14 +31,6 @@ import {
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlansNavigation from 'my-sites/upgrades/navigation';
 import { isPlanFeaturesEnabled } from 'lib/plans';
-import {
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_PERSONAL
-} from 'lib/plans/constants';
 import PlanIcon from 'components/plans/plan-icon';
 
 const PlanDetailsComponent = React.createClass( {
@@ -56,7 +48,8 @@ const PlanDetailsComponent = React.createClass( {
 	render: function() {
 		const { selectedSite } = this.props;
 		const { hasLoadedFromServer } = this.props.sitePlans;
-		let currentPlan, title, tagLine, featuresList;
+		const currentPlan = this.props.selectedSite.plan.product_slug;
+		let title, tagLine, featuresList;
 
 		if ( ! selectedSite || ! hasLoadedFromServer ) {
 			featuresList = (
@@ -68,15 +61,12 @@ const PlanDetailsComponent = React.createClass( {
 		} else if ( isFreePlan( this.props.selectedSite.plan ) ) {
 			page.redirect( '/plans/' + this.props.selectedSite.slug );
 		} else if ( this.props.selectedSite.jetpack ) {
-			currentPlan = PLAN_JETPACK_FREE;
 			title = this.translate( 'Your site is on a Free plan' );
 			tagLine = this.translate( 'Unlock the full potential of your site with all the features included in your plan.' );
 
 			if ( isJetpackPremium( this.props.selectedSite.plan ) ) {
-				currentPlan = PLAN_JETPACK_PREMIUM;
 				title = this.translate( 'Your site is on a Premium plan' );
 			} else if ( isJetpackBusiness( this.props.selectedSite.plan ) ) {
-				currentPlan = PLAN_JETPACK_BUSINESS;
 				title = this.translate( 'Your site is on a Professional plan' );
 			}
 
@@ -87,7 +77,6 @@ const PlanDetailsComponent = React.createClass( {
 				/>
 			);
 		} else if ( isPersonal( this.props.selectedSite.plan ) ) {
-			currentPlan = PLAN_PERSONAL;
 			title = this.translate( 'Your site is on a Personal plan' );
 			tagLine = this.translate( 'Unlock the full potential of your site with all the features included in your plan.' );
 
@@ -98,7 +87,6 @@ const PlanDetailsComponent = React.createClass( {
 				/>
 			);
 		} else if ( isPremium( this.props.selectedSite.plan ) ) {
-			currentPlan = PLAN_PREMIUM;
 			title = this.translate( 'Your site is on a Premium plan' );
 			tagLine = this.translate( 'Unlock the full potential of your site with the premium features included in your plan.' );
 
@@ -109,7 +97,6 @@ const PlanDetailsComponent = React.createClass( {
 				/>
 			);
 		} else if ( isBusiness( selectedSite.plan ) ) {
-			currentPlan = PLAN_BUSINESS;
 			title = this.translate( 'Your site is on a Business plan' );
 			tagLine = this.translate( 'Learn more about everything included with Business and take advantage of' +
 				' its professional features.' );

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -13,28 +13,21 @@
 }
 
 .current-plan__header-icon {
-	display: block;
-	margin: 0 auto;
-	position: relative;
-	text-align: center;
-
 	@include breakpoint( ">660px" ) {
+		width: 132px;
 		height: 132px;
 		margin-right: 16px;
-		width: 132px;
 	}
 
-	.gridicon {
-		background: white;
-		color: $alert-yellow;
-		height: 48px;
-		margin: 21px 0 0 21px;
+	.plan-icon {
 		width: 48px;
+		height: 48px;
+		margin: 0 auto;
 
 		@include breakpoint( ">660px" ) {
+			width: 72px;
 			height: 72px;
 			margin: 30px 0 0 30px;
-			width: 72px;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #6759. Replaces the yellow "star" icon with the icon of a plan on `/plans/my-plan` page.

## Testing Instructions

1. Select a Personal/Premium/Business/Jetpack-premium-business site and navigate to `/plans/my-plan`;
2. Do you see the plan icon instead of the yellow star on top of the page? Does it look okay?

## Screenshot

A Jetpack Professional site:

![selection_062](https://cloud.githubusercontent.com/assets/4988512/16841116/1182d9ec-49d8-11e6-9ad4-6bc3fd116202.jpg)


cc @gwwar @rralian @apeatling @artpi 




Test live: https://calypso.live/?branch=update/my-plan-use-plan-icon