### PR TITLE
Ads: Add order id parameter to purchase conversion tracking

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -145,13 +145,20 @@ function recordAddToCart( cartItem ) {
 	);
 }
 
-function recordPurchase( product ) {
+/**
+ * Recorders an individual product purchase conversion
+ *
+ * @param {Object} product - the product
+ * @param {Number} orderId - the order id
+ * @returns {void}
+ */
+function recordPurchase( product, orderId ) {
 	if ( ! config.isEnabled( 'ad-tracking' ) ) {
 		return;
 	}
 
 	if ( ! hasStartedFetchingScripts ) {
-		return loadTrackingScripts( recordPurchase.bind( null, product ) );
+		return loadTrackingScripts( recordPurchase.bind( null, product, orderId ) );
 	}
 
 	const isJetpackPlan = productsValues.isJetpackPlan( product );
@@ -174,7 +181,8 @@ function recordPurchase( product ) {
 			currency: product.currency,
 			product_slug: product.product_slug,
 			value: product.cost,
-			user_id: userId
+			user_id: userId,
+			order_id: orderId
 		}
 	);
 
@@ -196,7 +204,8 @@ function recordPurchase( product ) {
 		google_conversion_currency: product.currency,
 		google_custom_params: {
 			product_slug: product.product_slug,
-			user_id: userId
+			user_id: userId,
+			order_id: orderId
 		},
 		google_remarketing_only: false
 	} );
@@ -208,8 +217,9 @@ function recordPurchase( product ) {
  * @see https://app.atlassolutions.com/help/atlashelp/727514814019823/ (Atlas account required)
  *
  * @param {Object} cart - cart as `CartValue` object
+ * @param {Number} orderId - the order id
  */
-function recordOrderInAtlas( cart ) {
+function recordOrderInAtlas( cart, orderId ) {
 	if ( ! config.isEnabled( 'ad-tracking' ) ) {
 		return;
 	}
@@ -222,7 +232,8 @@ function recordOrderInAtlas( cart ) {
 		product_slugs: cart.products.map( product => product.product_slug ).join( ', ' ),
 		revenue: cart.total_cost,
 		currency_code: cart.currency,
-		user_id: currentUser ? currentUser.ID : 0
+		user_id: currentUser ? currentUser.ID : 0,
+		order_id: orderId
 	};
 
 	const urlParams = Object.keys( params ).map( function( key ) {

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -93,8 +93,10 @@ var TransactionStepsMixin = {
 					// Makes sure free trials are not recorded as purchases in ad trackers since they are products with
 					// zero-value cost and would thus lead to a wrong computation of conversions
 					if ( ! cartItems.hasFreeTrial( cartValue ) ) {
-						cartValue.products.map( adTracking.recordPurchase );
-						adTracking.recordOrderInAtlas( cartValue );
+						cartValue.products.forEach( product => {
+							adTracking.recordPurchase( product, step.data.receipt_id );
+						} );
+						adTracking.recordOrderInAtlas( cartValue, step.data.receipt_id );
 					}
 
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {


### PR DESCRIPTION
This PR adds each order's id to the ad tracking scripts. This will give us more insights into our orders and allow us to identify discrepancies between each of our tracking services.

To test:

1. In your WordPress.com sandbox, ensure you have the `USE_STORE_SANDBOX` constant set to true.
2. In `development.json`, set `ad-tracking` to `true`.
3. Make a purchase using a test credit card
4. Check the Network tab in Chrome, search for `order_id`. It should look like this:

![screen shot 2016-07-14 at 10 19 30 am](https://cloud.githubusercontent.com/assets/44436/16842732/7ab0c004-49ac-11e6-9e92-b17027518f1f.png)

Atlas should include the order_id (`17385638` in this example):

> https://ad.atdmt.com/m/a.js;m=11187200770563;cache=0.2097910166934096?event=Purchase&products=WordPress.com%20Personal&product_slugs=personal-bundle&revenue=71.88&currency_code=USD&user_id=107631499&order_id=17385638

As well as Facebook:

> https://www.facebook.com/tr/?id=823166884443641&ev=Purchase&dl=http%3A%2F%2Fcalypso.localhost%3A3000%2Fcheckout%2Fmhmazur20160714v1.wordpress.com&rl=http%3A%2F%2Fcalypso.localhost%3A3000%2Fplans%2Fmhmazur20160714v1.wordpress.com&if=false&ts=1468506835087&cd[currency]=USD&cd[product_slug]=personal-bundle&cd[value]=71.88&cd[user_id]=107631499&cd[order_id]=17385638&v=2.5.0&pv=visible

And each of the three AdWords conversions:

> https://www.googleadservices.com/pagead/conversion/1067250390/?random=1468506835088&cv=8&fst=1468506835088&num=1&fmt=3&value=71.88&currency_code=USD&label=MznpCMGHr2MQ1uXz_AM&guid=ON&u_h=1200&u_w=1920&u_ah=1096&u_aw=1920&u_cd=24&u_his=23&u_tz=-240&u_java=false&u_nplug=5&u_nmime=7&data=product_slug%3Dpersonal-bundle%3Buser_id%3D107631499%3Border_id%3D17385638&frm=0&url=http%3A//calypso.localhost%3A3000/checkout/mhmazur20160714v1.wordpress.com&tiba=Checkout%20%E2%80%B9%20mhmazur20160714v1%20%E2%80%94%20WordPress.com&async=1

Test live: https://calypso.live/?branch=add/receipt-id-to-conversion-tracking