### PR TITLE
Site Settings: Fix ESLint warnings in form-base

### DIFF
--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -89,13 +89,11 @@ module.exports = {
 	 */
 	recordEventOnce( key, eventAction ) {
 		debug( 'record event once: %o - %o', key, eventAction );
-		let newSetting = {};
 		if ( this.state[ 'recordEventOnce-' + key ] ) {
 			return;
 		}
 		this.recordEvent( eventAction );
-		newSetting[ 'recordEventOnce-' + key ] = true;
-		this.setState( newSetting );
+		this.setState( { [ 'recordEventOnce-' + key ]: true } );
 	},
 
 	getInitialState() {
@@ -103,16 +101,14 @@ module.exports = {
 	},
 
 	handleRadio( event ) {
-		var name = event.currentTarget.name,
-			value = event.currentTarget.value,
-			updateObj = {};
+		const name = event.currentTarget.name,
+			value = event.currentTarget.value;
 
-		updateObj[ name ] = value;
-		this.setState( updateObj );
+		this.setState( { [ name ]: value } );
 	},
 
 	toggleJetpackModule( module ) {
-		var event = this.props.site.isModuleActive( module ) ? 'deactivate' : 'activate';
+		const event = this.props.site.isModuleActive( module ) ? 'deactivate' : 'activate';
 		notices.clearNotices( 'notices' );
 		this.setState( { togglingModule: true } );
 		this.props.site.toggleModule( module, error => {
@@ -138,7 +134,7 @@ module.exports = {
 	},
 
 	submitForm( event ) {
-		var site = this.props.site;
+		const { site } = this.props;
 
 		if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
 			event.preventDefault();

--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -101,10 +101,10 @@ module.exports = {
 	},
 
 	handleRadio( event ) {
-		const name = event.currentTarget.name,
-			value = event.currentTarget.value;
+		const currentTargetName = event.currentTarget.name,
+			currentTargetValue = event.currentTarget.value;
 
-		this.setState( { [ name ]: value } );
+		this.setState( { [ currentTargetName ]: currentTargetValue } );
 	},
 
 	toggleJetpackModule( module ) {


### PR DESCRIPTION
This PR fixes some ESLint warnings in the `form-base` mixing for site settings.

To test:

- Checkout `update/site-settings-form-base-eslint` branch
- Go to `/settings/general/$site`
- Test that UI works as expected
    - In console, `localStorage.setItem('debug','calypso:analytics')`.
    - Reload page, and then type in "Site Title".
    - Verify that typing a new site title only fires one event.
    - Verify that you can save settings for a site
    - Verify that you can change radio buttons

cc @enej @lezama for a code review


Test live: https://calypso.live/?branch=update/site-settings-form-base-eslint