### PR TITLE
Reader: Increase debounce timeout to 750ms

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -220,6 +220,7 @@ const FeedStream = React.createClass( {
 						onSearch={ this.updateQuery }
 						autoFocus={ true }
 						delaySearch={ true }
+						delayTimeout={ 750 }
 						placeholder={ this.translate( 'Search billions of WordPress.com posts…' ) } />
 				</CompactCard>
 			</Stream>

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -220,7 +220,7 @@ const FeedStream = React.createClass( {
 						onSearch={ this.updateQuery }
 						autoFocus={ true }
 						delaySearch={ true }
-						delayTimeout={ 750 }
+						delayTimeout={ 500 }
 						placeholder={ this.translate( 'Search billions of WordPress.com posts…' ) } />
 				</CompactCard>
 			</Stream>


### PR DESCRIPTION
gives the user more time to type, and searches are kinda pokey

To test, try typing in the search input at `/read/search`. You should get a reasonable amount of time to type before results start loading.

Test live: https://calypso.live/?branch=update/reader/increase-search-debounce-time