### PR TITLE
Reader Cold Start: add railcar for follows and unfollows

### DIFF
--- a/client/reader/follow-button/README.md
+++ b/client/reader/follow-button/README.md
@@ -6,5 +6,6 @@ A specialization of the generic `components/follow-button` that sends stats.
 
 - `location`: the MC stats key for the current page, e.g. following_edit
 - `isButtonOnly`: if true, use the FollowButton component rather than FollowButtonContainer
+- `railcar`: Train Tracks Railcar string for stats (optional)
 
 See `components/follow-button` for other props this component accepts.

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -15,7 +15,13 @@ const ReaderFollowButton = React.createClass( {
 
 	mixins: [ PureRenderMixin ],
 
-	recordFollowToggle: function( isFollowing ) {
+	propTypes: {
+		following: React.PropTypes.bool.isRequired,
+		onFollowToggle: React.PropTypes.func,
+		railcar: React.PropTypes.string
+	},
+
+	recordFollowToggle( isFollowing ) {
 		stats[ isFollowing ? 'recordFollow' : 'recordUnfollow' ]( this.props.siteUrl, this.props.railcar );
 
 		if ( this.props.onFollowToggle ) {
@@ -23,7 +29,7 @@ const ReaderFollowButton = React.createClass( {
 		}
 	},
 
-	render: function() {
+	render() {
 		if ( this.props.isButtonOnly ) {
 			return (
 				<FollowButton { ...this.props } onFollowToggle={ this.recordFollowToggle } />

--- a/client/reader/start/card-header.jsx
+++ b/client/reader/start/card-header.jsx
@@ -6,7 +6,7 @@ import { numberFormat } from 'i18n-calypso';
 import SiteIcon from 'components/site-icon';
 import FollowButton from 'reader/follow-button';
 
-const StartCardHeader = ( { site } ) => {
+const StartCardHeader = ( { site, railcar } ) => {
 	const subscribersCount = numberFormat( site.subscribers_count );
 	return (
 		<header className="reader-start-card__header">
@@ -22,14 +22,15 @@ const StartCardHeader = ( { site } ) => {
 				</div>
 			</div>
 			<div className="reader-start-card__follow">
-				<FollowButton siteUrl={ site.URL } />
+				<FollowButton siteUrl={ site.URL } railcar={ railcar } />
 			</div>
 		</header>
 	);
 };
 
 StartCardHeader.propTypes = {
-	site: React.PropTypes.object.isRequired
+	site: React.PropTypes.object.isRequired,
+	railcar: React.PropTypes.string
 };
 
 export default StartCardHeader;

--- a/client/reader/start/card.jsx
+++ b/client/reader/start/card.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import debugModule from 'debug';
-import get from 'lodash/get';
+import { get } from 'lodash';
 import classnames from 'classnames';
 
 // Internal dependencies
@@ -51,10 +51,11 @@ const StartCard = React.createClass( {
 				'is-photo': hasPost && post.excerpt.length < 1
 			}
 		);
+		const railcar = get( this.props.recommendation, 'railcar' );
 
 		return (
 			<Card className={ cardClasses } onClick={ this.onCardInteraction }>
-				<StartCardHeader site={ site } />
+				<StartCardHeader site={ site } railcar={ railcar } />
 				{ hasPost && <StartPostPreview post={ post } /> }
 			</Card>
 		);


### PR DESCRIPTION
In #6732 @blowery added the ability to specify a `railcar` on the Reader follow button.

This PR sends the `railcar` we have for a recommendation when following/unfollowing from a Cold Start card (as suggested by @gibrown in https://github.com/Automattic/wp-calypso/pull/6732#issuecomment-232677841).

Test live: https://calypso.live/?branch=fix/reader/add-train-tracks-to-follows