### PR TITLE
Jetpack Sync: Fixes version check to work with beta branch

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -464,7 +464,7 @@ const FormGeneral = React.createClass( {
 		}
 
 		const site = this.props.site;
-		if ( ! site.jetpack || this.props.site.versionCompare( '4.2.0-alpha', '<' ) ) {
+		if ( ! site.jetpack || this.props.site.versionCompare( '4.2-alpha', '<' ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
The current Jetpack version for `master` is `4.2.0-alpha`. The current version for `branch-4.2` is `4.2-beta1`.

Because the beta version number is incorrect, this means that the sync panel is not being displayed for beta testers. 😱  

This PR fixes that by changing our version check to match that of the beta. Ideally, we would update the version number in `branch-4.2` to be semantic, but @jeherve mentioned that this would cause issues with the beta tester plugin.

To test:

- Checkout `update/jetpack-sync-panel-version-check` branch
- Checkout latest `master` of Jetpack for your site
- Go to `$site/wp-admin/admin.php?page=jetpack-sync`
- Start full sync
- When sync is over, go to `/settings/general/$site` and ensure that you see the sync panel
- Checkout latest `branch-4.2` of Jetpack for your site
- Go to `$site/wp-admin/admin.php?page=jetpack-sync`
- Start a full sync
- Go to /settings/general/$site` and ensure you see the sync panel
- Update version number in `jetpack.php` to be `4.2.0` (making sure that this works when 4.2 drops)
- Start a full sync
- go to `/settings/general/$site` and ensure that you can see the sync panel

cc @lezama @enejb for code review

Test live: https://calypso.live/?branch=update/jetpack-sync-panel-version-check