### PR TITLE
Purchases: Update `state.purchases` to reflect the types returned by the API

### DIFF
--- a/client/state/purchases/reducer.js
+++ b/client/state/purchases/reducer.js
@@ -96,12 +96,12 @@ function updatePurchases( existingPurchases, action ) {
 	let purchases, predicate;
 
 	if ( PURCHASES_SITE_FETCH_COMPLETED === action.type ) {
-		predicate = { blog_id: action.siteId };
+		predicate = { blog_id: String( action.siteId ) };
 	}
 
 	if ( PURCHASES_USER_FETCH_COMPLETED === action.type ||
 		PURCHASE_REMOVE_COMPLETED === action.type ) {
-		predicate = { user_id: action.userId };
+		predicate = { user_id: String( action.userId ) };
 	}
 
 	purchases = removeMissingPurchasesByPredicate( existingPurchases, action.purchases, predicate );

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -7,7 +7,10 @@ import purchasesAssembler from 'lib/purchases/assembler';
  * @param {Object} state - current state object
  * @return {Array} Purchases
  */
-export const getPurchases = state => state.purchases.data;
+export const getPurchases = createSelector(
+	state => purchasesAssembler.createPurchasesArray( state.purchases.data ),
+	state => [ state.purchases.data ]
+);
 
 /**
  * Returns the server error for site or user purchases (if there is one)
@@ -24,7 +27,7 @@ export const getPurchasesError = state => state.purchases.error;
  * @return {Object} the matching purchase if there is one
  */
 export const getByPurchaseId = ( state, purchaseId ) => (
-	purchasesAssembler.createPurchasesArray( getPurchases( state ).filter( purchase => purchase.ID === purchaseId ) ).shift()
+	getPurchases( state ).filter( purchase => purchase.id === purchaseId ).shift()
 );
 
 /**

--- a/client/state/purchases/test/reducer.js
+++ b/client/state/purchases/test/reducer.js
@@ -16,8 +16,8 @@ import {
 import reducer from '../reducer';
 
 describe( 'reducer', () => {
-	const userId = 1337,
-		siteId = 2701;
+	const userId = '1337',
+		siteId = '2701';
 
 	it( 'should return an object with the initial state', () => {
 		expect( reducer( undefined, { type: 'UNRELATED' } ) ).to.be.eql( {
@@ -44,19 +44,19 @@ describe( 'reducer', () => {
 	it( 'should return an object with the list of purchases when fetching completed', () => {
 		let state = reducer( undefined, {
 			type: PURCHASES_USER_FETCH_COMPLETED,
-			purchases: [ { ID: 1, blog_id: siteId, user_id: userId }, { ID: 2, blog_id: siteId, user_id: userId } ]
+			purchases: [ { ID: '1', blog_id: siteId, user_id: userId }, { ID: '2', blog_id: siteId, user_id: userId } ]
 		} );
 
 		state = reducer( state, {
 			type: PURCHASES_SITE_FETCH_COMPLETED,
-			purchases: [ { ID: 2, blog_id: siteId, user_id: userId }, { ID: 3, blog_id: siteId, user_id: userId } ]
+			purchases: [ { ID: '2', blog_id: siteId, user_id: userId }, { ID: '3', blog_id: siteId, user_id: userId } ]
 		} );
 
 		expect( state ).to.be.eql( {
 			data: [
-				{ ID: 2, blog_id: siteId, user_id: userId },
-				{ ID: 3, blog_id: siteId, user_id: userId },
-				{ ID: 1, blog_id: siteId, user_id: userId } ],
+				{ ID: '2', blog_id: siteId, user_id: userId },
+				{ ID: '3', blog_id: siteId, user_id: userId },
+				{ ID: '1', blog_id: siteId, user_id: userId } ],
 			error: null,
 			isFetchingSitePurchases: false,
 			isFetchingUserPurchases: false,
@@ -68,9 +68,9 @@ describe( 'reducer', () => {
 	it( 'should only remove purchases missing from the new purchases array with the same `user_id` or `blog_id`', () => {
 		let state = {
 			data: [
-				{ ID: 2, blog_id: siteId, user_id: userId },
-				{ ID: 3, blog_id: siteId, user_id: userId },
-				{ ID: 1, blog_id: siteId, user_id: userId } ],
+				{ ID: '2', blog_id: siteId, user_id: userId },
+				{ ID: '3', blog_id: siteId, user_id: userId },
+				{ ID: '1', blog_id: siteId, user_id: userId } ],
 			error: null,
 			isFetchingSitePurchases: false,
 			isFetchingUserPurchases: false,
@@ -78,22 +78,22 @@ describe( 'reducer', () => {
 			hasLoadedUserPurchasesFromServer: true
 		};
 
-		const newPurchase = { ID: 4, blog_id: 2702, user_id: userId };
+		const newPurchase = { ID: '4', blog_id: 2702, user_id: userId };
 
 		state = reducer( state, {
 			type: PURCHASES_USER_FETCH_COMPLETED,
 			purchases: [
-				{ ID: 1, blog_id: siteId, user_id: userId },
-				{ ID: 2, blog_id: siteId, user_id: userId },
+				{ ID: '1', blog_id: siteId, user_id: userId },
+				{ ID: '2', blog_id: siteId, user_id: userId },
 				newPurchase // include purchase with new `siteId`
 			],
-			userId
+			userId: Number( userId )
 		} );
 
 		expect( state ).to.be.eql( {
 			data: [
-				{ ID: 1, blog_id: siteId, user_id: userId },
-				{ ID: 2, blog_id: siteId, user_id: userId },
+				{ ID: '1', blog_id: siteId, user_id: userId },
+				{ ID: '2', blog_id: siteId, user_id: userId },
 				newPurchase // purchase with ID 3 was removed, `newPurchase` was added
 			],
 			error: null,
@@ -105,14 +105,14 @@ describe( 'reducer', () => {
 
 		state = reducer( state, {
 			type: PURCHASES_SITE_FETCH_COMPLETED,
-			purchases: [ { ID: 2, blog_id: siteId, user_id: userId } ],
-			siteId
+			purchases: [ { ID: '2', blog_id: siteId, user_id: userId } ],
+			siteId: Number( siteId )
 		} );
 
 		expect( state ).to.be.eql( {
 			data: [
-				{ ID: 2, blog_id: siteId, user_id: userId },
-				{ ID: 4, blog_id: 2702, user_id: userId } // the new purchase was not removed because it has a different `blog_id`
+				{ ID: '2', blog_id: siteId, user_id: userId },
+				{ ID: '4', blog_id: 2702, user_id: userId } // the new purchase was not removed because it has a different `blog_id`
 			],
 			error: null,
 			isFetchingSitePurchases: false,
@@ -125,8 +125,8 @@ describe( 'reducer', () => {
 	it( 'should return an object with original purchase and error message when cancelation of private registration failed', () => {
 		let state = {
 			data: [
-				{ ID: 2, blog_id: siteId, user_id: userId },
-				{ ID: 4, blog_id: 2702, user_id: userId }
+				{ ID: '2', blog_id: siteId, user_id: userId },
+				{ ID: '4', blog_id: 2702, user_id: userId }
 			],
 			error: null,
 			isFetchingSitePurchases: false,
@@ -138,19 +138,19 @@ describe( 'reducer', () => {
 		state = reducer( state, {
 			type: PRIVACY_PROTECTION_CANCEL_FAILED,
 			error: 'Unable to fetch stored cards',
-			purchaseId: 2
+			purchaseId: '2'
 		} );
 
 		expect( state ).to.be.eql( {
 			data: [
 				{
-					ID: 2,
+					ID: '2',
 					blog_id: siteId,
 					user_id: userId,
 					error: 'Unable to fetch stored cards'
 				},
 				{
-					ID: 4,
+					ID: '4',
 					blog_id: 2702,
 					user_id: userId
 				}
@@ -166,8 +166,8 @@ describe( 'reducer', () => {
 	it( 'should return an object with updated purchase when cancelation of private registration completed', () => {
 		let state = {
 			data: [
-				{ ID: 2, blog_id: siteId, user_id: userId },
-				{ ID: 4, blog_id: 2702, user_id: userId }
+				{ ID: '2', blog_id: siteId, user_id: userId },
+				{ ID: '4', blog_id: 2702, user_id: userId }
 			],
 			error: null,
 			isFetchingSitePurchases: false,
@@ -179,7 +179,7 @@ describe( 'reducer', () => {
 		state = reducer( state, {
 			type: PRIVACY_PROTECTION_CANCEL_COMPLETED,
 			purchase: {
-				ID: 2,
+				ID: '2',
 				blog_id: siteId,
 				user_id: userId,
 				amount: 2200,
@@ -191,7 +191,7 @@ describe( 'reducer', () => {
 		expect( state ).to.be.eql( {
 			data: [
 				{
-					ID: 2,
+					ID: '2',
 					blog_id: siteId,
 					user_id: userId,
 					amount: 2200,
@@ -199,7 +199,7 @@ describe( 'reducer', () => {
 					has_private_registration: false
 				},
 				{
-					ID: 4,
+					ID: '4',
 					blog_id: 2702,
 					user_id: userId
 				}

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -2,9 +2,42 @@
 import { expect } from 'chai';
 
 // Internal dependencies
-import { getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases } from '../selectors';
+import { getPurchases, getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases } from '../selectors';
+import purchasesAssembler from 'lib/purchases/assembler';
 
 describe( 'selectors', () => {
+	describe( 'getPurchases', () => {
+		it( 'should return different purchases when the purchase data changes', () => {
+			const initialPurchases = Object.freeze( [
+				{ ID: 1, product_name: 'domain registration', blog_id: 1337 },
+				{ ID: 2, product_name: 'premium plan', blog_id: 1337 }
+			] );
+
+			const state = {
+				purchases: {
+					data: initialPurchases,
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true
+				}
+			};
+
+			expect( getPurchases( state ) ).to.deep.equal( purchasesAssembler.createPurchasesArray( initialPurchases ) );
+
+			const newPurchases = Object.freeze( [
+				{ ID: 3, product_name: 'business plan', blog_id: 3117 }
+			] );
+
+			expect( getPurchases( Object.assign( state, {
+				purchases: {
+					data: newPurchases
+				}
+			} ) ) ).to.deep.equal( purchasesAssembler.createPurchasesArray( newPurchases ) );
+		} );
+	} );
+
 	describe( 'getByPurchaseId', () => {
 		it( 'should return a purchase by its ID', () => {
 			const state = {


### PR DESCRIPTION
This fixes an issue with mismatched types in `getUserPurchases` and `getSitePurchases` that is preventing [a modal](https://cloudup.com/cFqevzrkdEy) from warning the user that their site has active purchases, as well as some logic in the `state.purchases` reducer that determines how to update the list of purchases when purchases are fetched or removed.

The `state.purchases` actions were updated to not use the purchases assembler, in favor of storing raw data in the API. The selectors, however, were operating on site data before it was assembled, and unfortunately we missed some quirks in the API (in this case, that the API returns IDs of type `String`) when updating them.

The API should be updated to return the appropriate type, but this will require some bigger changes. In the meantime, we can update the root purchases selector, `getPurchases`, to return assembled purchases, in order to resolve these type issues and fix the other selectors.

**Testing**
- Visit `/settings/general/:site` for a site with active purchases.
- Click the 'Delete Site' link at the bottom of the page.
- Assert that [this modal](https://cloudup.com/i4kCSRiGIyM) appears.

- [x] Code
- [x] Product

Test live: https://calypso.live/?branch=fix/delete-site