### PR TITLE
Jetpack Connect: Auto-authorize for new users from wp-admin

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -170,7 +170,7 @@ const LoggedInForm = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_auth_view' );
 		if ( ! this.props.isAlreadyOnSitesList &&
 			! queryObject.already_authorized &&
-			( this.props.calypsoStartedConnection || this.props.isSSO )
+			( this.props.calypsoStartedConnection || this.props.isSSO || queryObject.new_user_started_connection )
 		) {
 			debug( 'Authorizing automatically on component mount' );
 			return this.props.authorize( queryObject );

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -40,6 +40,7 @@ export const jetpackConnectAuthorizeSchema = {
 						from: { type: 'string' },
 						home_url: { type: 'string' },
 						jp_version: { type: 'string' },
+						new_user_started_connection: { type: 'boolean' },
 						redirect_after_auth: { type: 'string' },
 						redirect_uri: { type: 'string' },
 						scope: { type: 'string' },


### PR DESCRIPTION
Checks `queryObject` for a cue to auto-authorize for new wpcom users coming from their remote wp-admin.

To test:
- apply this patch and ensure none of the sign up flows are broken ( JPC, SSO )

cc: @johnHackworth 

Test live: https://calypso.live/?branch=update/jetpack-connect-user-only