### PR TITLE
Jetpack Sync: Display an error notice when requesting sync fails

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -58,7 +58,7 @@ const JetpackSyncPanel = React.createClass( {
 			<Notice isCompact status="is-error" className="jetpack-sync-panel__error-notice">
 				{
 					syncRequestError.message
-					? syncRequestError
+					? syncRequestError.message
 					: this.translate( 'There was an error scheduling a full sync. Please try again later.' )
 				}
 			</Notice>

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import classNames from 'classnames';
 import debugModule from 'debug';
 import { get } from 'lodash';
 
@@ -49,7 +48,29 @@ const JetpackSyncPanel = React.createClass( {
 		this.props.scheduleJetpackFullysync( this.props.siteId );
 	},
 
+	renderErrorNotice() {
+		const syncRequestError = get( this.props, 'fullSyncRequest.error' );
+		if ( ! syncRequestError ) {
+			return null;
+		}
+
+		return (
+			<Notice isCompact status="is-error" className="jetpack-sync-panel__error-notice">
+				{
+					syncRequestError.message
+					? syncRequestError
+					: this.translate( 'There was an error scheduling a full sync. Please try again later.' )
+				}
+			</Notice>
+		);
+	},
+
 	renderStatusNotice() {
+		const isErrored = get( this.props, 'syncStatus.error' ) || get( this.props, 'fullSyncRequest.error' );
+		if ( isErrored ) {
+			return null;
+		}
+
 		const finished = get( this.props, 'syncStatus.finished' );
 		const finishedTimestamp = this.moment( parseInt( finished, 10 ) * 1000 );
 		let text = '';
@@ -68,7 +89,7 @@ const JetpackSyncPanel = React.createClass( {
 		}
 
 		return (
-			<Notice isCompact className={ classNames( 'jetpack-sync-panel__notice' ) }>
+			<Notice isCompact className="jetpack-sync-panel__status-notice">
 				{ text }
 			</Notice>
 		);
@@ -108,6 +129,7 @@ const JetpackSyncPanel = React.createClass( {
 					</div>
 				</div>
 
+				{ this.renderErrorNotice() }
 				{ this.renderStatusNotice() }
 				{ this.renderProgressBar() }
 				{ this.shouldDisableSync() && <Interval onTick={ this.fetchSyncStatus } period={ EVERY_FIVE_SECONDS } /> }

--- a/client/my-sites/site-settings/jetpack-sync-panel/style.scss
+++ b/client/my-sites/site-settings/jetpack-sync-panel/style.scss
@@ -35,7 +35,7 @@
 	color: $gray;
 }
 
-.jetpack-sync-panel__status-notice .notice__text {
+.jetpack-sync-panel .jetpack-sync-panel__status-notice .notice__text {
 	padding-left: 0;
 }
 

--- a/client/my-sites/site-settings/jetpack-sync-panel/style.scss
+++ b/client/my-sites/site-settings/jetpack-sync-panel/style.scss
@@ -27,15 +27,18 @@
 }
 
 .jetpack-sync-panel .notice {
-	background: none;
-	color: $gray;
 	margin-top: 16px;
 }
 
-.jetpack-sync-panel .notice .notice__text {
+.jetpack-sync-panel__status-notice {
+	background: none;
+	color: $gray;
+}
+
+.jetpack-sync-panel__status-notice .notice__text {
 	padding-left: 0;
 }
 
-.jetpack-sync-panel .notice .notice__icon {
+.jetpack-sync-panel__status-notice .notice__icon {
 	display: none;
 }

--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -23,7 +23,11 @@ export function fullSyncRequest( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_SYNC_START_REQUEST:
 			return Object.assign( {}, state, {
-				[ action.siteId ]: { isRequesting: true, lastRequested: Date.now() }
+				[ action.siteId ]: Object.assign(
+					{},
+					get( state, [ action.siteId ], {} ),
+					{ isRequesting: true, scheduled: false, lastRequested: Date.now() },
+				)
 			} );
 		case JETPACK_SYNC_START_SUCCESS:
 			return Object.assign( {}, state, {


### PR DESCRIPTION
Before this PR, we have zero error handling for sync status. This PR adds an error notice when requesting a full sync fails. 

If an error message is returned from the API, we display that message in the error notice. Otherwise, we display a generic error message.

To test

- Checkout `update/jetpack-sync-error-on-request` branch
- Go to `/settings/general/$site` where `$site` is on the latest `master` of Jetpack
- After the page loads, verify that the bluish status notice looks OK
- Now, go to "Network Conditions" in the console, and turn off WIFI for the page
- Click "Perform full sync"
- Ensure that error notice is displayed
- Return wifi to normal
- Click "Perform full sync" again
- Ensure that the UI recovers and sync goes through

cc @lezama @enejb for code review. cc @rickybanister for design review.

After screenshots:

![screen shot 2016-07-14 at 2 30 09 pm](https://cloud.githubusercontent.com/assets/1126811/16852908/aea49e1c-49cf-11e6-87a9-edb98f9455aa.png)
![screen shot 2016-07-14 at 2 30 24 pm](https://cloud.githubusercontent.com/assets/1126811/16852909/aea6156c-49cf-11e6-8d4f-1ccca2a0a547.png)
![screen shot 2016-07-14 at 2 30 36 pm](https://cloud.githubusercontent.com/assets/1126811/16852910/aea8e1f2-49cf-11e6-8b9a-abf4fa42e95e.png)


Test live: https://calypso.live/?branch=update/jetpack-sync-error-on-request