### PR TITLE
Reader: fix like button spacing

### DIFF
--- a/client/components/like-button/_style.scss
+++ b/client/components/like-button/_style.scss
@@ -62,6 +62,14 @@
 		}
 	}
 
+	&.has-count {
+		&.has-label {
+			.like-button__label-status:before {
+				content: ' ';
+			}
+		}
+	}
+
 	@include breakpoint( "<480px" ) {
 		.like-button__label-status {
 			display: none;

--- a/client/components/like-button/button.jsx
+++ b/client/components/like-button/button.jsx
@@ -47,11 +47,14 @@ var LikeButton = React.createClass( {
 	},
 
 	render: function() {
+		const showLikeCount = ! ( this.props.likeCount === 0 && ! this.props.showCount );
 		var containerClasses = {
 				'like-button': true,
 				'ignore-click': true,
 				'is-mini': this.props.isMini,
-				'is-animated': this.props.animateLike
+				'is-animated': this.props.animateLike,
+				'has-count': showLikeCount,
+				'has-label': this.props.showLabel
 			},
 			likeLabel = this.translate( 'Like', { comment: 'Label for a button to "like" a post.' } ),
 			likeCount = this.props.likeCount,
@@ -84,8 +87,7 @@ var LikeButton = React.createClass( {
 		containerClasses = classnames( containerClasses );
 
 		labelElement = ( <span className="like-button__label">
-			<span className="like-button__label-count">{ likeCount === 0 && ! this.props.showCount ? '' : likeCount }</span>
-			{ this.props.showLabel && ' ' }
+			<span className="like-button__label-count">{ showLikeCount ? likeCount : '' }</span>
 			{ this.props.showLabel && <span className="like-button__label-status">{ likeLabel }</span> }
 		</span> );
 


### PR DESCRIPTION
@nbradbury reported a regression in the like button layout caused by changes in #6754.

<img width="397" alt="screen shot 2016-07-14 at 21 57 39" src="https://cloud.githubusercontent.com/assets/17325/16853821/66bf2358-4a0e-11e6-8aec-1dad89598777.png">

This PR applies extra classes on the button to indicate whether it has a count or label, and uses these classes to apply a space where appropriate.

### To test

Check out the like button section in http://calypso.localhost:3000/devdocs/app-components. Also check the like button looks correct in various spots in the Reader: streams, full post view and search.



Test live: https://calypso.live/?branch=fix/reader/like-label-spacing