### PR TITLE
First-View: Adjust z-index to fix display issue

### DIFF
--- a/client/components/first-view/style.scss
+++ b/client/components/first-view/style.scss
@@ -29,6 +29,7 @@
 		bottom: 0;
 		top: 0;
 	width: 100%;
+	z-index: 20;
 
 	&.is-visible {
 		.first-view__content {


### PR DESCRIPTION
Before (in Firefox and IE11):

![image](https://cloud.githubusercontent.com/assets/363749/16856390/747327ee-49df-11e6-8fd7-221e874e5406.png)

After: 

![image](https://cloud.githubusercontent.com/assets/363749/16856407/8643e9c2-49df-11e6-8b2d-8a3d81b92d1b.png)


Test live: https://calypso.live/?branch=fix/first-view/opacity

To test: visit the Stats page. If it doesn't show, you may have already dismissed the dialog, try visiting the Stats page with a new user.