### PR TITLE
Site Settings: Do not show Jetpack save settings button in > JP 4.1.1

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -352,13 +352,21 @@ const FormGeneral = React.createClass( {
 		);
 	},
 
-	syncNonPublicPostTypes() {
+	showPublicPostTypesCheckbox() {
 		if ( ! config.isEnabled( 'manage/option_sync_non_public_post_stati' ) ) {
-			return null;
+			return false;
 		}
 
 		const { site } = this.props;
 		if ( site.jetpack && site.versionCompare( '4.1.1', '>' ) ) {
+			return false;
+		}
+
+		return true;
+	},
+
+	syncNonPublicPostTypes() {
+		if ( ! this.showPublicPostTypesCheckbox() ) {
 			return null;
 		}
 
@@ -569,7 +577,7 @@ const FormGeneral = React.createClass( {
 					? <div>
 						<SectionHeader label={ this.translate( 'Jetpack' ) }>
 							{ this.jetpackDisconnectOption() }
-							{ config.isEnabled( 'manage/option_sync_non_public_post_stati' )
+							{ this.showPublicPostTypesCheckbox()
 								? <Button
 									compact={ true }
 									onClick={ this.submitForm }


### PR DESCRIPTION
In #6749, I removed the checkbox for enabling/disabling sync of non-public post types for Jetpack versions greater than 4.1.1. But, I didn't handle conditionally removing the "Save Settings" button for the Jetpack section. 😱 

This PR fixes that.

- Checkout `update/settings-general-jetpack-save-4.1.1` 
- Go to `/settings/general/$site` where `$site` on the latest master of Jetpack
- You should see something like this:

    ![screen shot 2016-07-14 at 4 13 49 pm](https://cloud.githubusercontent.com/assets/1126811/16856199/8185a502-49de-11e6-93a2-00a38a6a01de.png)
- Switch to a site with Jetpack 4.1.1 or less
- You should see something like this:
    ![screen shot 2016-07-14 at 4 13 56 pm](https://cloud.githubusercontent.com/assets/1126811/16856208/9509485e-49de-11e6-86e9-39d892dc0bbe.png)

cc @rickybanister @lezama for review


Test live: https://calypso.live/?branch=update/settings-general-jetpack-save-4.1.1