### PR TITLE
Stats: Fetch preferences for FirstView

### DIFF
--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -100,14 +100,21 @@ const FirstView = React.createClass( {
 	},
 
 	updateDocumentStylesForVisibleFirstView() {
-		document.documentElement.classList.add( 'no-scroll', 'is-first-view-visible', 'is-first-view-active' );
+		document.documentElement.classList.add( 'no-scroll', 'is-first-view-active' );
+		process.nextTick( () => {
+			if ( this.props.isVisible ) {
+				document.documentElement.classList.add( 'is-first-view-visible' );
+			}
+		} );
 	},
 
 	updateDocumentStylesForHiddenFirstView() {
 		document.documentElement.classList.remove( 'no-scroll', 'is-first-view-visible' );
 		// wait a bit so that we trigger the CSS transition
 		setTimeout( () => {
-			document.documentElement.classList.remove( 'is-first-view-active' );
+			if ( ! this.props.isVisible ) {
+				document.documentElement.classList.remove( 'is-first-view-active' );
+			}
 		}, 600 );
 	}
 } );

--- a/client/components/first-view/style.scss
+++ b/client/components/first-view/style.scss
@@ -28,13 +28,6 @@
 	width: 100%;
 	z-index: z-index( 'root', '.first-view' );
 
-	&.is-visible {
-		.first-view__content {
-			opacity: 1;
-			transform: scale( 1 ) translateY( 0 );
-		}
-	}
-
 	@include breakpoint( "<480px" ) {
 		padding: 0;
 		margin-top: 47px;
@@ -126,6 +119,11 @@
 			min-width: 200px;
 		}
 	}
+}
+
+.is-first-view-visible .first-view__content {
+	opacity: 1;
+	transform: scale( 1 ) translateY( 0 );
 }
 
 .first-view__hide-preference {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -31,6 +31,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	SitesListNotices = require( 'lib/sites-list/notices' ),
 	OfflineStatus = require( 'layout/offline-status' ),
 	PollerPool = require( 'lib/data-poller' ),
+	QueryPreferences = require( 'components/data/query-preferences' ),
 	KeyboardShortcutsMenu,
 	Layout,
 	SupportUser;
@@ -175,6 +176,7 @@ Layout = React.createClass( {
 
 		return (
 			<div className={ sectionClass }>
+				<QueryPreferences />
 				{ config.isEnabled( 'guided-tours' ) ? <GuidedTours /> : null }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				{ this.renderMasterbar() }

--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -34,8 +34,12 @@ export const fetching = createReducer( false, {
 	[ PREFERENCES_FETCH_FAILURE ]: () => false,
 	[ PREFERENCES_FETCH ]: () => true,
 } );
+const lastFetchedTimestamp = createReducer( false, {
+	[ PREFERENCES_FETCH_SUCCESS ]: () => Date.now(),
+} );
 
 export default combineReducers( {
 	values,
-	fetching
+	fetching,
+	lastFetchedTimestamp,
 } );

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -3,3 +3,5 @@
 export const fetchingPreferences = state => ( !! state.preferences.fetching );
 
 export const getPreference = ( state, key ) => state.preferences.values[ key ];
+
+export const preferencesLastFetchedTimestamp = state => ( state.preferences.lastFetchedTimestamp );

--- a/client/state/preferences/test/reducer.js
+++ b/client/state/preferences/test/reducer.js
@@ -23,7 +23,8 @@ describe( 'reducer', () => {
 	it( 'should export expected reducer keys', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'values',
-			'fetching'
+			'fetching',
+			'lastFetchedTimestamp'
 		] );
 	} );
 

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -14,7 +14,7 @@ import takeRightWhile from 'lodash/takeRightWhile';
  */
 import { FIRST_VIEW_START_DATES } from './constants';
 import { getActionLog } from 'state/ui/action-log/selectors';
-import { getPreference } from 'state/preferences/selectors';
+import { getPreference, preferencesLastFetchedTimestamp } from 'state/preferences/selectors';
 import { getSectionName, isSectionLoading } from 'state/ui/selectors';
 import { isEnabled } from 'config';
 import { FIRST_VIEW_HIDE, ROUTE_SET } from 'state/action-types';
@@ -24,6 +24,13 @@ export function doesViewHaveFirstView( view ) {
 }
 
 export function isViewEnabled( state, view ) {
+	// in order to avoid using an out-of-date preference for whether a
+	// FV should be enabled or not, wait until we have fetched the
+	// preferences from the API
+	if ( ! preferencesLastFetchedTimestamp( state ) ) {
+		return false;
+	}
+
 	const firstViewHistory = getPreference( state, 'firstViewHistory' ).filter( entry => entry.view === view );
 	const latestFirstViewHistory = [ ...firstViewHistory ].pop();
 	const isViewDisabled = latestFirstViewHistory ? ( !! latestFirstViewHistory.disabled ) : false;

--- a/client/state/ui/first-view/test/selectors.js
+++ b/client/state/ui/first-view/test/selectors.js
@@ -34,7 +34,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#isViewEnabled()', () => {
-		it( 'should return true if the view has a first view and it is not disabled', () => {
+		it( 'should return true if the preferences have been fetched, the view has a first view, and it is not disabled', () => {
 			const viewEnabled = isViewEnabled( {
 				preferences: {
 					values: {
@@ -45,19 +45,21 @@ describe( 'selectors', () => {
 								disabled: false
 							}
 						]
-					}
+					},
+					lastFetchedTimestamp: 123456,
 				}
 			}, 'stats' );
 
 			expect( viewEnabled ).to.be.true;
 		} );
 
-		it( 'should return true if the history is empty', () => {
+		it( 'should return true if preferences have been fetched and the history is empty', () => {
 			const viewEnabled = isViewEnabled( {
 				preferences: {
 					values: {
 						firstViewHistory: []
-					}
+					},
+					lastFetchedTimestamp: 123456,
 				}
 			}, 'stats' );
 
@@ -75,7 +77,8 @@ describe( 'selectors', () => {
 								disabled: true
 							}
 						]
-					}
+					},
+					lastFetchedTimestamp: 123456,
 				}
 			}, 'stats' );
 
@@ -87,12 +90,26 @@ describe( 'selectors', () => {
 				preferences: {
 					values: {
 						firstViewHistory: []
-					}
+					},
+					lastFetchedTimestamp: 123456,
 				}
 			}, 'devdocs' );
 
 			expect( viewEnabled ).to.be.false;
 		} );
+
+		it( 'should return false if the preferences haven\'t been fetched', () => {
+			const viewEnabled = isViewEnabled( {
+				preferences: {
+					values: {
+						firstViewHistory: []
+					},
+					lastFetchedTimestamp: false,
+				}
+			}, 'stats' );
+
+			expect( viewEnabled ).to.be.false;
+		} )
 	} );
 
 	describe( '#wasFirstViewHiddenSinceEnteringCurrentSection()', () => {


### PR DESCRIPTION
This PR fetches preferences from the API for First View.

To test:
- Navigate to `/stats` pages, both from within Calypso and by directly loading `/stats` URLs. Make sure the First View behaves as expected.

Note: #6953 and #6954 are related PRs. Without those, Safari Private Mode will not work, and the preferences fetch will be cached. But, all three PRs can be merged separately.

Test live: https://calypso.live/?branch=fix/fetch-first-view-prefs