### PR TITLE
Plans: Fix highlight in section nav when displaying monthly plans

### DIFF
--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -66,7 +66,7 @@ const PlansNavigation = React.createClass( {
 							{ this.translate( 'My Plan' ) }
 						</NavItem>
 					}
-					<NavItem path={ `/plans/${ site.slug }` } key="plans" selected={ path === '/plans' }>
+					<NavItem path={ `/plans/${ site.slug }` } key="plans" selected={ path === '/plans' || path === '/plans/monthly' }>
 						{ this.translate( 'Plans' ) }
 					</NavItem>
 					{ ! isJetpack &&


### PR DESCRIPTION
I noticed that if I select the monthly plans option for my Jetpack site, that the "Plans" section nav item is no longer selected/highlighted.

![screen shot 2016-07-15 at 1 57 14 am](https://cloud.githubusercontent.com/assets/1126811/16866168/a563921c-4a2f-11e6-9c85-a3ad5bf0241d.png)

I expected "Plans" to stay highlighted as it is with the yearly plans.

![screen shot 2016-07-15 at 1 57 11 am](https://cloud.githubusercontent.com/assets/1126811/16866171/aaca7194-4a2f-11e6-8d10-05425066b0ad.png)

To test:

- Checkout `fix/monthly-plans-section-nav` branch
- Go to `/plans/$site` where `$site` is a Jetpack site
- Verify "Plans" is highlighted
- Click "Show monthly plans"
- Verify "Plans" is highlighted

cc @eoigal who has done some work on monthly plans.

Test live: https://calypso.live/?branch=fix/monthly-plans-section-nav