### PR TITLE
Themes: Streamline `Head` usage

### DIFF
--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -41,4 +41,6 @@ Head.propTypes = {
 	children: React.PropTypes.node,
 };
 
+Head.defaultProps = { siteName: 'WordPress.com' };
+
 export default Head;

--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -35,6 +35,9 @@ Head.propTypes = {
 	title: React.PropTypes.string,
 	description: React.PropTypes.string,
 	canonicalUrl: React.PropTypes.string,
+	type: React.PropTypes.string,
+	siteName: React.PropTypes.string,
+	image: React.PropTypes.string,
 	children: React.PropTypes.node,
 };
 

--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:layout:head' );
 
-const Head = ( { title, description, canonicalUrl, type, site_name, image, children } ) => (
+const Head = ( { title, description, canonicalUrl, type, siteName, image, children } ) => (
 	<div>
 		<Helmet
 			title={ title }
@@ -18,7 +18,7 @@ const Head = ( { title, description, canonicalUrl, type, site_name, image, child
 				title ? { property: 'og:title', content: title } : {},
 				canonicalUrl ? { property: 'og:url', content: canonicalUrl } : {},
 				type ? { property: 'og:type', content: type } : {},
-				site_name ? { property: 'og:site_name', content: site_name } : {},
+				siteName ? { property: 'og:site_name', content: siteName } : {},
 				image ? { property: 'og:image', content: image } : {},
 			] }
 			link={ [

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -12,6 +12,7 @@ import i18n from 'i18n-calypso';
  */
 import ThemeSheetComponent from './main';
 import ThemeDetailsComponent from 'components/data/theme-details';
+import LayoutHead from 'layout/head';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getThemeDetails } from 'state/themes/theme-details/selectors';
 import {
@@ -81,9 +82,6 @@ export function details( context, next ) {
 	const title = i18n.translate( '%(themeName)s Theme', {
 		args: { themeName }
 	} );
-	const Head = user
-		? require( 'layout/head' )
-		: require( 'my-sites/themes/head' );
 
 	const props = {
 		themeSlug: slug,
@@ -105,7 +103,7 @@ export function details( context, next ) {
 		</ThemeDetailsComponent>
 	);
 
-	context.primary = makeElement( ConnectedComponent, Head, context.store, props );
+	context.primary = makeElement( ConnectedComponent, LayoutHead, context.store, props );
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();
 }

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -25,7 +25,7 @@ import config from 'config';
 import { decodeEntities } from 'lib/formatting';
 
 const debug = debugFactory( 'calypso:themes' );
-let themeDetailsCache = new Map();
+const themeDetailsCache = new Map();
 
 export function makeElement( ThemesComponent, Head, store, props ) {
 	return (

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -16,7 +16,6 @@ const ThemesHead = ( { title, description, canonicalUrl, type, image, tier, chil
 		description={ description ? description : get( 'description', tier ) }
 		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) }
 		type={ type ? type : 'website' }
-		siteName={ 'WordPress.com' }
 		image={ image ? image : {} } >
 		{ children }
 	</Head>

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -16,7 +16,7 @@ const ThemesHead = ( { title, description, canonicalUrl, type, image, tier, chil
 		description={ description ? description : get( 'description', tier ) }
 		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) }
 		type={ type ? type : 'website' }
-		site_name={ 'WordPress.com' }
+		siteName={ 'WordPress.com' }
 		image={ image ? image : {} } >
 		{ children }
 	</Head>


### PR DESCRIPTION
Couple of small fixes, most notably removing an unnecessary conditional import (all `my-sites/themes/head` provided props were always overridden by theme sheet ones anyway).

There'll be a follow-up where I'll try to remove `makeElement` from `my-sites/themes/controller` altogether, but first I'll have to think a little more about where to provide props to `Head` instead.

No visual changes. To test:
* Verify that Calypso still works as before
* Verifiy that HTML `<title>` and relevant `<meta>` tags for individual theme sheets and the showcase  are unchanged compared to production
 * in page source (when logged-out)
 * in the page inspector

Obviously, logged-out server-side rendered content is most relevant here since it affects search engines.

Test live: https://calypso.live/?branch=update/themes-streamline-head