### PR TITLE
Fix placeholders in /plans/compare

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -3,10 +3,9 @@
  */
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import find from 'lodash/find';
 import page from 'page';
 import React from 'react';
-import times from 'lodash/times';
+import { find, times, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -107,7 +106,9 @@ const PlansCompare = React.createClass( {
 	},
 
 	isDataLoading() {
-		if ( ! this.props.features.get() ) {
+		const planFeatures = this.props.features.get();
+
+		if ( ! planFeatures || isEmpty( planFeatures ) ) {
 			return true;
 		}
 

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -85,6 +85,22 @@ const PlansCompare = React.createClass( {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked View All Plans' );
 	},
 
+	setFreePlan() {
+		this.setPlan( 'free' );
+	},
+
+	setPersonalPlan() {
+		this.setPlan( 'personal' );
+	},
+
+	setPremiumPlan() {
+		this.setPlan( 'premium' );
+	},
+
+	setBusinessPlan() {
+		this.setPlan( 'business' );
+	},
+
 	getPlanURL() {
 		const selectedSite = this.props.selectedSite;
 		let url = '/plans';
@@ -120,11 +136,7 @@ const PlansCompare = React.createClass( {
 			return false;
 		}
 
-		if ( this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer ) {
-			return false;
-		}
-
-		return true;
+		return ! ( this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer );
 	},
 
 	isSelected( plan ) {
@@ -406,7 +418,7 @@ const PlansCompare = React.createClass( {
 
 		let freeOption = (
 			<NavItem
-				onClick={ this.setPlan.bind( this, 'free' ) }
+				onClick={ this.setFreePlan }
 				selected={ 'free' === this.state.selectedPlan }>
 				{ this.translate( 'Free' ) }
 			</NavItem>
@@ -421,21 +433,27 @@ const PlansCompare = React.createClass( {
 				<SectionNav selectedText={ text[ this.state.selectedPlan ] }>
 					<NavTabs>
 						{ freeOption }
+
 						{ isPersonalPlanEnabled &&
-						<NavItem
-							onClick={ this.setPlan.bind( this, 'personal' ) }
-							selected={ 'personal' === this.state.selectedPlan }>
-							{ this.translate( 'Personal' ) }
-						</NavItem>
+							<NavItem
+								onClick={ this.setPersonalPlan }
+								selected={ 'personal' === this.state.selectedPlan }
+							>
+								{ this.translate( 'Personal' ) }
+							</NavItem>
 						}
+
 						<NavItem
-							onClick={ this.setPlan.bind( this, 'premium' ) }
-							selected={ 'premium' === this.state.selectedPlan }>
+							onClick={ this.setPremiumPlan }
+							selected={ 'premium' === this.state.selectedPlan }
+						>
 							{ this.translate( 'Premium' ) }
 						</NavItem>
+
 						<NavItem
-							onClick={ this.setPlan.bind( this, 'business' ) }
-							selected={ 'business' === this.state.selectedPlan }>
+							onClick={ this.setBusinessPlan }
+							selected={ 'business' === this.state.selectedPlan }
+						>
 							{ this.translate( 'Business' ) }
 						</NavItem>
 					</NavTabs>


### PR DESCRIPTION
Fixes #4125.

## Testing Instructions

1. Navigate to http://calypso.localhost:3000/plans;
2. In Calypso, clear localStorage and IndexedDB so we don't have any cached data;
3. Throttle your Internet connection speed in the Network tab as shown on the screenshot below;
4. Click on Compare Plans link and verify that there are loading placeholders.

![selection_063](https://cloud.githubusercontent.com/assets/4988512/16874194/44a6e320-4a98-11e6-82f3-757acbb22c5c.png)

## Screenshots

![selection_076](https://cloud.githubusercontent.com/assets/4988512/17136516/227ce5aa-5336-11e6-8a00-6e85b29696f4.png)

cc @fabianapsimoes @hafizrahman @gwwar

Test live: https://calypso.live/?branch=fix/plans-compare-is-data-loading