### PR TITLE
Reader Search: fire separate tracks events for search loaded and search performed

### DIFF
--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -30,9 +30,13 @@ export default {
 		}
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-		recordTrack( 'calypso_reader_search_loaded', searchSlug && {
-			query: searchSlug
-		} );
+		if ( searchSlug ) {
+			recordTrack( 'calypso_reader_search_performed', {
+				query: searchSlug
+			} );
+		} else {
+			recordTrack( 'calypso_reader_search_loaded' );
+		}
 
 		ReactDom.render(
 			React.createElement( SearchStream, {


### PR DESCRIPTION
Sirin requested that we fire different events for loading of search, and performing a search.

Currently, we fire `calypso_reader_search_loaded` in both instances.

This PR adds a new event `calypso_reader_search_performed` for when we actually have a search string, and retains `calypso_reader_search_loaded` for the initial load of the page.

Test live: https://calypso.live/?branch=fix/reader/search-tracks-events