### PR TITLE
ui.queryArguments: update state less aggressively

### DIFF
--- a/client/state/ui/guided-tours/selectors.js
+++ b/client/state/ui/guided-tours/selectors.js
@@ -94,10 +94,10 @@ const getTourFromQuery = createSelector(
  */
 const hasJustSeenTour = createSelector(
 	( state, tourName ) => {
-		const { timestamp } = getInitialQueryArguments( state );
+		const { _timestamp } = getInitialQueryArguments( state );
 		return getToursHistory( state ).some( entry =>
 			entry.tourName === tourName &&
-			entry.timestamp > timestamp
+			entry.timestamp > _timestamp
 		);
 	},
 	[ getInitialQueryArguments, getToursHistory ]

--- a/client/state/ui/guided-tours/test/selectors.js
+++ b/client/state/ui/guided-tours/test/selectors.js
@@ -149,7 +149,7 @@ describe( 'selectors', () => {
 			const state = makeState( {
 				actionLog: [ navigateToThemes ],
 				toursHistory: [ themesTourSeen, mainTourJustSeen ],
-				queryArguments: { tour: 'main', timestamp: 0 }
+				queryArguments: { tour: 'main', _timestamp: 0 }
 			} );
 			const tour = findEligibleTour( state );
 
@@ -164,7 +164,7 @@ describe( 'selectors', () => {
 			const state = makeState( {
 				actionLog: times( 50, constant( navigateToTest ) ),
 				toursHistory: [ testTourSeen, themesTourSeen ],
-				queryArguments: { tour: 'themes', timestamp: 0 }
+				queryArguments: { tour: 'themes', _timestamp: 0 }
 			} );
 			const tour = findEligibleTour( state );
 

--- a/client/state/ui/query-arguments/reducer.js
+++ b/client/state/ui/query-arguments/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
+import { isEqual, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,13 +17,21 @@ const timestamped = ( query ) => ( {
 	timestamp: Date.now(),
 } );
 
+const isEqualQuery = ( a, b ) =>
+	isEqual(
+		omit( a, 'timestamp' ),
+		omit( b, 'timestamp' ) );
+
 const initial = createReducer( false, {
 	[ ROUTE_SET ]: ( state, { query } ) =>
 		state === false ? timestamped( query ) : state,
 } );
 
 const current = createReducer( {}, {
-	[ ROUTE_SET ]: ( state, { query } ) => timestamped( query ),
+	[ ROUTE_SET ]: ( state, { query } ) =>
+		! isEqualQuery( state, query )
+			? timestamped( query )
+			: state,
 } );
 
 export default combineReducers( {

--- a/client/state/ui/query-arguments/reducer.js
+++ b/client/state/ui/query-arguments/reducer.js
@@ -14,13 +14,13 @@ import {
 
 const timestamped = ( query ) => ( {
 	...query,
-	timestamp: Date.now(),
+	_timestamp: Date.now(),
 } );
 
 const isEqualQuery = ( a, b ) =>
 	isEqual(
-		omit( a, 'timestamp' ),
-		omit( b, 'timestamp' ) );
+		omit( a, '_timestamp' ),
+		omit( b, '_timestamp' ) );
 
 const initial = createReducer( false, {
 	[ ROUTE_SET ]: ( state, { query } ) =>


### PR DESCRIPTION
To implement once #6417 is merged.

Every time `ROUTE_SET` is dispatched, the `ui.queryArguments.current` branch updates itself regardless of whether there is any change in the query data. This potentially leads to unnecessary renders in the view layer or recalculations in memoized selectors.

Test live: https://calypso.live/?branch=update/ui-query-arguments-overwrites