### PR TITLE
Google Apps: Show errors from backend if present

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -138,6 +138,12 @@ function hasGoogleAppsSupportedDomain( domains ) {
 	return getGoogleAppsSupportedDomains( domains ).length > 0;
 }
 
+function hasPendingGoogleAppsUsers( domain ) {
+	return domain.googleAppsSubscription &&
+		domain.googleAppsSubscription.pendingUsers &&
+		domain.googleAppsSubscription.pendingUsers.length !== 0;
+}
+
 function getSelectedDomain( { domains, selectedDomainName } ) {
 	return find( domains.list, { name: selectedDomainName } );
 }
@@ -159,7 +165,6 @@ function hasMappedDomain( domains ) {
 }
 
 export {
-	hasGoogleAppsSupportedDomain,
 	canAddGoogleApps,
 	canMap,
 	canRedirect,
@@ -171,7 +176,9 @@ export {
 	getRegisteredDomains,
 	getMappedDomains,
 	hasGoogleApps,
+	hasGoogleAppsSupportedDomain,
 	hasMappedDomain,
+	hasPendingGoogleAppsUsers,
 	isInitialized,
 	isRegisteredDomain,
 	isSubdomain

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -16,6 +16,7 @@ import purchasesPaths from 'me/purchases/paths';
 import domainConstants from 'lib/domains/constants';
 import support from 'lib/url/support';
 import paths from 'my-sites/upgrades/paths';
+import { hasPendingGoogleAppsUsers } from 'lib/domains';
 
 const domainTypes = domainConstants.type;
 const debug = _debug( 'calypso:domain-warnings' );
@@ -218,10 +219,7 @@ export default React.createClass( {
 	},
 
 	pendingGappsTosAcceptanceDomains() {
-		const pendingDomains = this.getDomains().filter( domain =>
-				domain.googleAppsSubscription &&
-				domain.googleAppsSubscription.pendingUsers &&
-				domain.googleAppsSubscription.pendingUsers.length !== 0 );
+		const pendingDomains = this.getDomains().filter( hasPendingGoogleAppsUsers );
 		return pendingDomains.length !== 0 && <PendingGappsTosNotice key="pending-gapps-tos-notice" siteSlug={ this.props.selectedSite && this.props.selectedSite.slug } domains={ pendingDomains } section="domain-management" />;
 	},
 

--- a/client/my-sites/upgrades/domain-management/email/google-apps-user-item.jsx
+++ b/client/my-sites/upgrades/domain-management/email/google-apps-user-item.jsx
@@ -18,6 +18,11 @@ const GoogleAppsUserItem = React.createClass( {
 		return this.props.user !== nextProps.user || this.props.onClick !== nextProps.onClick;
 	},
 
+	getLoginLink() {
+		const { email, domain } = this.props.user;
+		return `https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel&continue=https://admin.google.com/a/${ domain }`;
+	},
+
 	render() {
 		return (
 			<li>
@@ -28,7 +33,7 @@ const GoogleAppsUserItem = React.createClass( {
 				<ExternalLink
 					icon
 					className="google-apps-user-item__manage-link"
-					href={ `https://admin.google.com/a/${ this.props.user.domain }` }
+					href={ this.getLoginLink() }
 					onClick={ this.props.onClick }
 					target="_blank">
 					{ this.translate( 'Manage', { context: 'Google Apps user item' } ) }

--- a/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
@@ -2,17 +2,20 @@
  * External dependencies
  */
 import React from 'react';
+import groupBy from 'lodash/groupBy';
 
 /**
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
+import Notice from 'components/notice';
+import Button from 'components/button';
 import PendingGappsTosNotice from 'my-sites/upgrades/components/domain-warnings/pending-gapps-tos-notice';
 import paths from 'my-sites/upgrades/paths';
 import analyticsMixin from 'lib/mixins/analytics';
 import SectionHeader from 'components/section-header';
 import GoogleAppsUserItem from './google-apps-user-item';
-import { getSelectedDomain } from 'lib/domains';
+import { getSelectedDomain, hasPendingGoogleAppsUsers } from 'lib/domains';
 
 const GoogleAppsUsers = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'googleApps' ) ],
@@ -50,42 +53,66 @@ const GoogleAppsUsers = React.createClass( {
 		this.recordEvent( 'addGoogleAppsUserClick', this.props.selectedDomainName );
 	},
 
+	renderDomain( domain, users ) {
+		return (
+			<div key={ `google-apps-user-${ domain }` } className="google-apps-users-card">
+				<SectionHeader
+					label={ domain }>
+					{ this.canAddUsers() && (
+						<Button
+							primary
+							compact
+							href={ paths.domainManagementAddGoogleApps(
+								this.props.selectedSite.slug, domain
+							) }
+							onClick={ this.goToAddGoogleApps }>
+							{ this.translate( 'Add Google Apps User' ) }
+						</Button>
+					) }
+				</SectionHeader>
+				<CompactCard className="google-apps-users-card__user-list">
+					<ul className="google-apps-users-card__user-list-inner">
+						{ users.map( ( user, index ) => this.renderUser( user, index ) ) }
+					</ul>
+				</CompactCard>
+			</div>
+		);
+	},
+
+	renderUser( user, index ) {
+		if ( user.error ) {
+			return (
+				<Notice
+					key={ `google-apps-user-notice-${ user.domain }-${ index }` }
+					showDismiss={ false }
+					status="is-warning"
+					text={ user.error } />
+			);
+		}
+
+		return (
+			<GoogleAppsUserItem
+				key={ `google-apps-user-${ user.domain }-${ index }` }
+				user={ user }
+				onClick={ this.generateClickHandler( user ) }/>
+		);
+	},
+
 	render() {
-		const pendingDomains = this.getDomainsAsList().filter( domain =>
-			domain.googleAppsSubscription &&
-			domain.googleAppsSubscription.pendingUsers &&
-			domain.googleAppsSubscription.pendingUsers.length !== 0 );
+		const pendingDomains = this.getDomainsAsList().filter( hasPendingGoogleAppsUsers ),
+			usersByDomain = groupBy( this.props.googleAppsUsers, 'domain' );
 
 		return (
 			<div>
-				{ pendingDomains.length !== 0 && <PendingGappsTosNotice key="pending-gapps-tos-notice" siteSlug={ this.props.selectedSite.slug } domains={ pendingDomains } section="google-apps" /> }
+				{ pendingDomains.length !== 0 &&
+					<PendingGappsTosNotice
+						key="pending-gapps-tos-notice"
+						siteSlug={ this.props.selectedSite.slug }
+						domains={ pendingDomains }
+						section="google-apps" />
+				}
 
-				<SectionHeader
-					count={ this.props.googleAppsUsers.length }
-					label={ this.translate( 'Google Apps Users' ) }>
-					{ this.canAddUsers() && (
-						<a
-							href={ paths.domainManagementAddGoogleApps(
-								this.props.selectedSite.slug, this.props.selectedDomainName
-							) }
-							className="button is-compact is-primary"
-							onClick={ this.goToAddGoogleApps }>
-							{ this.translate( 'Add Google Apps User' ) }
-						</a>
-					) }
-				</SectionHeader>
-
-				<CompactCard className="google-apps-users-card">
-					<ul className="google-apps-users-card__user-list">
-						{ this.props.googleAppsUsers.map(
-							( user, index ) => (
-								<GoogleAppsUserItem
-									key={ index } user={ user }
-									onClick={ this.generateClickHandler( user ) }/>
-							)
-						) }
-					</ul>
-				</CompactCard>
+				{ Object.keys( usersByDomain ).map( ( domain ) => this.renderDomain( domain, usersByDomain[ domain ] ) ) }
 			</div>
 		);
 	}

--- a/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
@@ -95,9 +95,10 @@ const GoogleAppsUsers = React.createClass( {
 
 			if ( this.isNewUser( user ) ) {
 				status = null;
-				text = this.translate( 'Please be patient while we are setting up %(email)s for you.', {
-					args: { email: user.email }
-				} );
+				text = this.translate(
+					'We are setting up %(email)s for you. It should start working immediately, but may take up to 24 hours.',
+					{ args: { email: user.email } }
+				);
 				supportLink = null;
 			}
 

--- a/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import groupBy from 'lodash/groupBy';
+import find from 'lodash/find';
 
 /**
  * Internal dependencies
@@ -43,6 +44,12 @@ const GoogleAppsUsers = React.createClass( {
 		);
 	},
 
+	isNewUser( user ) {
+		const domain = find( this.props.domains.list, { name: user.domain } );
+
+		return this.moment().subtract( 1, 'day' ).isBefore( domain.googleAppsSubscription.subscribedDate );
+	},
+
 	generateClickHandler( user ) {
 		return () => {
 			this.recordEvent( 'manageClick', this.props.selectedDomainName, user );
@@ -81,12 +88,22 @@ const GoogleAppsUsers = React.createClass( {
 
 	renderUser( user, index ) {
 		if ( user.error ) {
+			let status = 'is-warning',
+				text = user.error;
+
+			if ( this.isNewUser( user ) ) {
+				status = null;
+				text = this.translate( 'Please be patient while we are setting up %(email)s for you.', {
+					args: { email: user.email }
+				} );
+			}
+
 			return (
 				<Notice
 					key={ `google-apps-user-notice-${ user.domain }-${ index }` }
 					showDismiss={ false }
-					status="is-warning"
-					text={ user.error } />
+					status={ status }
+					text={ text } />
 			);
 		}
 

--- a/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
@@ -17,6 +17,7 @@ import analyticsMixin from 'lib/mixins/analytics';
 import SectionHeader from 'components/section-header';
 import GoogleAppsUserItem from './google-apps-user-item';
 import { getSelectedDomain, hasPendingGoogleAppsUsers } from 'lib/domains';
+import support from 'lib/url/support';
 
 const GoogleAppsUsers = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'googleApps' ) ],
@@ -89,21 +90,24 @@ const GoogleAppsUsers = React.createClass( {
 	renderUser( user, index ) {
 		if ( user.error ) {
 			let status = 'is-warning',
-				text = user.error;
+				text = user.error,
+				supportLink = <a href={ support.CALYPSO_CONTACT }><strong>{ this.translate( 'Please contact support' ) }</strong></a>;
 
 			if ( this.isNewUser( user ) ) {
 				status = null;
 				text = this.translate( 'Please be patient while we are setting up %(email)s for you.', {
 					args: { email: user.email }
 				} );
+				supportLink = null;
 			}
 
 			return (
 				<Notice
 					key={ `google-apps-user-notice-${ user.domain }-${ index }` }
 					showDismiss={ false }
-					status={ status }
-					text={ text } />
+					status={ status }>
+					{ text } { supportLink }
+				</Notice>
 			);
 		}
 

--- a/client/my-sites/upgrades/domain-management/email/placeholder.jsx
+++ b/client/my-sites/upgrades/domain-management/email/placeholder.jsx
@@ -11,11 +11,11 @@ import SectionHeader from 'components/section-header';
 import GoogleAppsUserItem from './google-apps-user-item';
 
 const Placeholder = () =>
-	<div className="is-placeholder">
+	<div className="google-apps-users-card is-placeholder">
 		<SectionHeader
 			label={ 'Google Apps Users' } />
-		<CompactCard className="google-apps-users-card">
-			<ul className="google-apps-users-card__user-list">
+		<CompactCard className="google-apps-users-card__user-list">
+			<ul className="google-apps-users-card__user-list-inner">
 				<GoogleAppsUserItem user={ { email: 'mail@example.com', domain: 'example.com' } } />
 			</ul>
 		</CompactCard>

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -1002,36 +1002,18 @@ ul.email-forwarding__list {
 	}
 }
 
-.google-apps-users-card.card {
-	padding: 0;
-	@include clear-fix;
-}
-
-.google-apps-users-card__add-user-button {
-	@include breakpoint( '<480px' ) {
-		width: 100%;
-	}
-
-	@include breakpoint( '>480px' ) {
-		float: right;
-	}
-}
-
-.google-apps-users-card__subtext {
-	font-size: 13px;
-	margin: 5px 0;
-	font-style: italic;
-	font-weight: 400;
-	color: $gray;
-}
-
-.google-apps-users-card__notice.notice {
-	font-size: 13px;
-	margin: 10px 0;
-	animation: none;
+.google-apps-users-card {
+	margin-bottom: 10px;
 }
 
 .google-apps-users-card__user-list {
+	&.card {
+		padding: 0;
+		@include clear-fix;
+	}
+}
+
+.google-apps-users-card__user-list-inner {
 	list-style: none;
 	margin: 0;
 
@@ -1047,6 +1029,10 @@ ul.email-forwarding__list {
 		&:last-of-type {
 			border-bottom: 1px solid $gray-light;
 		}
+	}
+
+	.notice {
+		margin: 0;
 	}
 }
 


### PR DESCRIPTION
Best served with `D2121-code` which adds proper error handling when fetching Gapps users. This PR refactors a bit the Gapps code to show those errors.
Additionally, I've found and fixed a bug: the `Add Google Apps users` button on the site-wide Google Apps page added the users to a random domain, it was impossible to select which one. Now, there's a button for each domain.

### Before

Selected domain:
<img width="692" alt="screen shot 2016-07-15 at 16 38 45" src="https://cloud.githubusercontent.com/assets/3392497/16877905/a65038a8-4aaa-11e6-8d5e-60e137b1acb3.png">

Site-wide:
<img width="691" alt="screen shot 2016-07-15 at 16 38 17" src="https://cloud.githubusercontent.com/assets/3392497/16877916/af556de2-4aaa-11e6-9d35-5b503c1b1a18.png">

Site-wide with an error for one of the domains:
<img width="687" alt="screen shot 2016-07-15 at 16 36 57" src="https://cloud.githubusercontent.com/assets/3392497/16877857/63d0434c-4aaa-11e6-93c3-5394ede8bd06.png">

### After

Selected domain:
<img width="751" alt="screen shot 2016-07-15 at 16 04 16" src="https://cloud.githubusercontent.com/assets/3392497/16877716/dcfae548-4aa9-11e6-9a7c-8d79ada512d5.png">

Site-wide:
<img width="756" alt="screen shot 2016-07-15 at 16 05 27" src="https://cloud.githubusercontent.com/assets/3392497/16877726/e208b056-4aa9-11e6-921b-25da05ae4419.png">

Site-wide with an error for one of the domains:
<img width="761" alt="screen shot 2016-07-15 at 16 26 41" src="https://cloud.githubusercontent.com/assets/3392497/16877729/e6fe9f4e-4aa9-11e6-9306-d82eaeb0913a.png">

/cc @aidvu @umurkontaci 

Test live: https://calypso.live/?branch=fix/gapps-get-users