### PR TITLE
Reader: Remove in-stream galleries

### DIFF
--- a/client/reader/post-images/_style.scss
+++ b/client/reader/post-images/_style.scss
@@ -1,185 +1,27 @@
-.reader-post-images {
+.post-images {
 	color: $gray;
-	margin: 24px 0 0 0;
-	padding: 8px;
-	border-top: 1px solid lighten( $gray, 30 );
-	border-bottom: 1px solid lighten( $gray, 30 );
+	margin: -24px 0 0 -24px;
+	padding: 0;
 	@include clear-fix;
-
-	&:hover {
-		.reader-post-images__label {
-			color: $blue-light;
-		}
-	}
-
-	&.is-viewing {
-		.reader-post-images__full-list {
-			visibility: visible;
-			opacity: 1;
-			pointer-events: auto;
-			background: lighten( $gray, 30% );
-
-			@include breakpoint( "<660px" ) {
-				max-height: 80vh;
-				margin-top: 12px;
-				border-top: 1px solid lighten( $gray, 20 );
-				border-bottom: 1px solid lighten( $gray, 20 );
-			}
-		}
-	}
 }
 
-.reader-post-images__list {
+.post-images__list {
 	list-style: none;
 	float: left;
-	margin: 0 8px 0 0;
+	margin: 0;
 	overflow: hidden;
-	max-width: 65%;
-	height: 40px;
+	height: 80px;
 	@include clear-fix;
 }
 
-.reader-post-images__image {
+.post-images__item {
 	margin: 0 8px 0 0;
 	float: left;
-
-	img {
-		height: 40px;
-		width: 40px;
-		float: left;
-		box-shadow: inset 0 0 0 1px lighten( $gray, 20 );
-	}
 }
 
-.reader-post-images__label {
-	font-size: 14px;
-	color: $blue-medium;
-	line-height: 1;
-	display: block;
-	position: relative;
-		top: 5px;
-}
-
-.reader-post-images__count {
-	font-size: 12px;
-	color: $gray;
-	line-height: 1;
-	position: relative;
-		top: 2px;
-}
-
-.reader-post-images__full-list {
-	visibility: hidden;
-	opacity: 0;
-	pointer-events: none;
-	transition: all 0.1s 0s linear;
-	position: fixed;
-		top: 47px;
-		right: 0;
-		bottom: 0;
-		left: 0;
-	padding: 24px;
-	background: transparent;
-	z-index: z-index( 'root', '.reader-post-images__full-list' );
-	overflow-y: hidden;
-	overflow-x: auto;
-	-webkit-overflow-scrolling: touch;
-	white-space: nowrap;
-
-	@include breakpoint( "<660px" ) {
-		position: relative;
-			top: 0;
-		clear: both;
-		margin: 0 -24px -9px -16px;
-		max-height: 0;
-		padding: 0;
-		background: lighten( $gray, 20 );
-		color: $gray-dark;
-	}
-
-	ol {
-		display: table;
-		min-height: 100%;
-		margin: 0;
-		list-style: none;
-
-		@include breakpoint( ">660px" ) {
-			padding: 0 10vw;
-		}
-	}
-}
-
-.reader-post-images__close {
-	position: fixed;
-		top: 63px;
-		left: 16px;
-	padding: 10px 10px 10px 36px;
-	color: $gray-dark;
-
-	@include breakpoint( "<660px" ) {
-		display: none;
-	}
-
-	&:before {
-		@include noticon( '\f406', 16px );
-		position: absolute;
-			top: 14px;
-			left: 10px;
-	}
-}
-
-.reader-post-images__full-image {
-	display: table-cell;
-	vertical-align: middle;
-	padding: 16px;
-
-	@include breakpoint( "<660px" ) {
-		padding: 8px 16px;
-	}
-
-	&.gallery-image-appear,
-	&.gallery-image-enter,
-	&.gallery-image-leave {
-		opacity: 0;
-		transform: scale( 0.98 ) translateX( 25vw );
-	}
-
-	&.gallery-image-active {
-		opacity: 1;
-		transform: none;
-	}
-
-	transition: all 0.1s 0s ease-in-out;
-
-	img {
-		background: lighten( $gray, 20% );
-		max-width: 80vw;
-		max-height: 80vh;
-		box-shadow: 0 0 0 1px rgba( $gray-light, 0.2 );
-
-		@include breakpoint( "<660px" ) {
-			max-width: 80vw;
-			max-height: 80vh;
-			transform: translateY( -20px );
-			box-shadow: 0 0 0 1px rgba( $gray-dark, 0.3 );
-		}
-	}
-}
-
-.reader-post-images__full-alt-text {
-	display: none;
-	padding: 8px;
-
-	@include breakpoint( "<480px" ) {
-		font-size: 12px;
-		padding: 4px 0;
-	}
-}
-
-// Stop the rest of the page from scrolling when the gallery is-viewing
-// is opened, but only on larger screens.
-@include breakpoint( ">660px" ) {
-	html.reader-gallery-open {
-		overflow: hidden;
-	}
+.post-images__image {
+	height: 80px;
+	width: 80px;
+	float: left;
+	box-shadow: inset 0 0 0 1px lighten( $gray, 20 );
 }

--- a/client/reader/post-images/_style.scss
+++ b/client/reader/post-images/_style.scss
@@ -21,13 +21,10 @@
 
 .post-images__image {
 	height: 80px;
-	max-width: 79px;
+	width: 100%;
 	object-fit: cover;
 }
 
 .post-images__item:last-child {
 	border-right: none;
-	.post-images__image {
-		max-width: 80px;
-	}
 }

--- a/client/reader/post-images/_style.scss
+++ b/client/reader/post-images/_style.scss
@@ -1,6 +1,6 @@
 .post-images {
 	color: $gray;
-	margin: -24px 0 0 -24px;
+	margin: -24px -24px 0 -24px;
 	padding: 0;
 	@include clear-fix;
 }
@@ -15,13 +15,20 @@
 }
 
 .post-images__item {
-	margin: 0 8px 0 0;
+	margin: 0;
 	float: left;
+	border-right: 1px solid #fff;
 }
 
 .post-images__image {
 	height: 80px;
-	width: 80px;
+	width: 79px;
 	float: left;
-	box-shadow: inset 0 0 0 1px lighten( $gray, 20 );
+}
+
+.post-images__item,:last-child {
+	border-right: none;
+	.post-images__image {
+		width: 80px;
+	}
 }

--- a/client/reader/post-images/_style.scss
+++ b/client/reader/post-images/_style.scss
@@ -2,33 +2,32 @@
 	color: $gray;
 	margin: -24px -24px 0 -24px;
 	padding: 0;
-	@include clear-fix;
+	cursor: pointer;
 }
 
 .post-images__list {
 	list-style: none;
-	float: left;
 	margin: 0;
-	overflow: hidden;
 	height: 80px;
-	@include clear-fix;
+	display: flex;
 }
 
 .post-images__item {
+	display: block;
+	flex: 1;
 	margin: 0;
-	float: left;
 	border-right: 1px solid #fff;
 }
 
 .post-images__image {
 	height: 80px;
-	width: 79px;
-	float: left;
+	max-width: 79px;
+	object-fit: cover;
 }
 
-.post-images__item,:last-child {
+.post-images__item:last-child {
 	border-right: none;
 	.post-images__image {
-		width: 80px;
+		max-width: 80px;
 	}
 }

--- a/client/reader/post-images/_style.scss
+++ b/client/reader/post-images/_style.scss
@@ -8,7 +8,7 @@
 .post-images__list {
 	list-style: none;
 	margin: 0;
-	height: 130px;
+	height: 240px;
 	display: flex;
 }
 
@@ -20,11 +20,11 @@
 }
 
 .post-images__item:first-child {
-	flex: 3
+	flex: 2
 }
 
 .post-images__image {
-	height: 130px;
+	height: 240px;
 	width: 100%;
 	object-fit: cover;
 }

--- a/client/reader/post-images/_style.scss
+++ b/client/reader/post-images/_style.scss
@@ -1,6 +1,6 @@
 .post-images {
 	color: $gray;
-	margin: -24px -24px 0 -24px;
+	margin: 0 -24px 0 -24px;
 	padding: 0;
 	cursor: pointer;
 }
@@ -8,7 +8,7 @@
 .post-images__list {
 	list-style: none;
 	margin: 0;
-	height: 80px;
+	height: 130px;
 	display: flex;
 }
 
@@ -19,8 +19,12 @@
 	border-right: 1px solid #fff;
 }
 
+.post-images__item:first-child {
+	flex: 3
+}
+
 .post-images__image {
-	height: 80px;
+	height: 130px;
 	width: 100%;
 	object-fit: cover;
 }

--- a/client/reader/post-images/index.jsx
+++ b/client/reader/post-images/index.jsx
@@ -4,13 +4,13 @@
 const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	resizeImageUrl = require( 'lib/resize-image-url' );
+import { uniqBy } from 'lodash';
 
 const PostImages = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	render: function() {
-		const images = this.props.postImages,
-			count = images.length;
+		const images = uniqBy( this.props.postImages, 'src' );
 
 		return (
 			<div className="post-images">
@@ -30,7 +30,7 @@ const PostImageThumbList = React.createClass( {
 			thumbList = images.map( function( image, index ) {
 				return (
 					<li key={ 'thumb-image-' + index } className="post-images__item">
-						<img className="post-images__image" src={ resizeImageUrl( image.src, { resize: '640,130' } ) } />
+						<img className="post-images__image" src={ resizeImageUrl( image.src, { resize: '640,240' } ) } />
 					</li>
 				);
 			} );

--- a/client/reader/post-images/index.jsx
+++ b/client/reader/post-images/index.jsx
@@ -12,7 +12,7 @@ const PostImages = React.createClass( {
 		const images = this.props.postImages,
 			count = images.length;
 
-		if ( count < 5 ) {
+		if ( count < 2 ) {
 			return null;
 		}
 
@@ -34,7 +34,7 @@ const PostImageThumbList = React.createClass( {
 			thumbList = images.map( function( image, index ) {
 				return (
 					<li key={ 'thumb-image-' + index } className="post-images__item">
-						<img className="post-images__image" src={ resizeImageUrl( image.src, { resize: '80,80' } ) } />
+						<img className="post-images__image" src={ resizeImageUrl( image.src, { resize: '240,240' } ) } />
 					</li>
 				);
 			} );

--- a/client/reader/post-images/index.jsx
+++ b/client/reader/post-images/index.jsx
@@ -1,185 +1,46 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
+const React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	resizeImageUrl = require( 'lib/resize-image-url' ),
-	domScrollIntoView = require( 'dom-scroll-into-view' ),
-	ReactCSSTransitionGroup = require( 'react-addons-css-transition-group' );
+	resizeImageUrl = require( 'lib/resize-image-url' );
 
-/**
- * Internal dependencies
- */
-var stats = require( 'reader/stats' ),
-	viewport = require( 'lib/viewport' );
-
-var PostImages = React.createClass( {
-
-	getInitialState: function() {
-		return {
-			viewing: false,
-			visibleIndex: 0
-		};
-	},
-
-	_isInput: function( element ) {
-		return [ 'INPUT', 'TEXTAREA' ].indexOf( element.nodeName ) > -1;
-	},
-
-	handleKeyDown: function( event ) {
-		var keyCodes = [ 27, 37, 39 ],
-			nextIndex;
-		if ( ! this._isInput( event.target ) &&
-			keyCodes.indexOf( event.keyCode ) > -1 && viewport.isDesktop() ) {
-			switch ( event.keyCode ) {
-				case 27: //esc
-					this.toggleGallery( event );
-					break;
-				case 37: //left arrow
-					nextIndex = ( this.state.visibleIndex - 1 +
-						this.props.postImages.length ) %
-						this.props.postImages.length;
-					this.scrollToImage( nextIndex );
-					break;
-				case 39: //right arrow
-					nextIndex = ( this.state.visibleIndex + 1 ) %
-						this.props.postImages.length;
-					this.scrollToImage( nextIndex );
-					break;
-			}
-		}
-	},
-
-	componentDidUpdate: function( prevProps, prevState ) {
-		if ( this.state.viewing !== prevState.viewing ) {
-			if ( this.state.viewing ) {
-				// only add desktop handlers if gallery view takes up fullscreen
-				if ( viewport.isDesktop() ) {
-					window.addEventListener( 'keydown', this.handleKeyDown );
-				}
-			} else {
-				window.removeEventListener( 'keydown', this.handleKeyDown );
-			}
-		}
-	},
-
-	componentWillUnmount: function() {
-		window.removeEventListener( 'keydown', this.handleKeyDown );
-	},
-
-	scrollToImage: function( nextIndex ) {
-		this.setState( {
-			visibleIndex: nextIndex
-		} );
-		let container = ReactDom.findDOMNode( this._fullListContainer );
-		let images = ReactDom.findDOMNode( this._fullList ).children;
-		domScrollIntoView( images[ nextIndex ], container, { alignWithLeft: true } );
-	},
-
-	toggleGallery: function( event ) {
-		if ( event.defaultPrevented ) {
-			return;
-		}
-		event.preventDefault();
-		let newState = ! this.state.viewing;
-
-		stats.recordAction( newState ? 'open_gallery' : 'close_gallery' );
-		stats.recordGaEvent( newState ? 'Clicked Open Gallery' : 'Clicked Close Gallery' );
-		stats.recordTrack( 'calypso_reader_post_gallery_' + ( newState ? 'opened' : 'closed' ), {
-			image_count: this.props.postImages && this.props.postImages.length
-		} );
-
-		this.setState( {
-			viewing: newState
-		} );
-
-		document.documentElement.classList.toggle( 'reader-gallery-open' );
-	},
-
-	ignoreClick: function( event ) {
-		event.preventDefault();
-	},
+const PostImages = React.createClass( {
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
-		var images = this.props.postImages,
-			count = images.length,
-			containerClasses = [ 'reader-post-images', 'ignore-click' ],
-			fullList;
+		const images = this.props.postImages,
+			count = images.length;
 
-		if ( count < 2 ) {
+		if ( count < 5 ) {
 			return null;
 		}
 
-		/* Generate a list of large images */
-		if ( this.state.viewing ) {
-			fullList = images.map( function( image, index ) {
-				return (
-					<li key={ 'full-image-' + index } className="reader-post-images__full-image">
-						<img
-							src={ resizeImageUrl( image.src, { h: 800, w: 800 } ) }
-							onClick={ this.ignoreClick }
-						/>
-					</li>
-				);
-			}, this );
-		}
-
-		/* Add the viewing class if needed */
-		if ( this.state.viewing ) {
-			containerClasses.push( 'is-viewing' );
-		}
-
-		containerClasses = containerClasses.join( ' ' );
-
 		return (
-			<div className={ containerClasses } onClick={ this.toggleGallery }>
+			<div className="post-images">
 				<PostImageThumbList postImages={ images } />
-
-				<span className="reader-post-images__label">{ this.translate( 'View Gallery' ) }</span>
-				<span className="reader-post-images__count">{ this.translate( '%(count)d image', '%(count)d images', {
-					count: count,
-					args: { count: count }
-				} ) }
-				</span>
-
-				<div
-					className="reader-post-images__full-list"
-					ref={ ( c ) => this._fullListContainer = c } >
-					<span className="reader-post-images__close">{ this.translate( 'Close' ) }</span>
-					<ReactCSSTransitionGroup
-						ref={ ( c ) => this._fullList = c }
-						component="ol"
-						transitionEnterTimeout={ 200 }
-						transitionLeaveTimeout={ 200 }
-						transitionName="gallery-image"
-						transitionEnter={ true }
-						transitionLeave={ true }>
-						{ fullList }
-					</ReactCSSTransitionGroup>
-				</div>
 			</div>
 		);
 	}
 
 } );
 
-var PostImageThumbList = React.createClass( {
+const PostImageThumbList = React.createClass( {
 
 	mixins: [ PureRenderMixin ],
 
 	render: function() {
-		var images = this.props.postImages,
+		const images = this.props.postImages,
 			thumbList = images.map( function( image, index ) {
 				return (
-					<li key={ 'thumb-image-' + index } className="reader-post-images__image">
-						<img src={ resizeImageUrl( image.src, { resize: '40,40' } ) } />
+					<li key={ 'thumb-image-' + index } className="post-images__item">
+						<img className="post-images__image" src={ resizeImageUrl( image.src, { resize: '80,80' } ) } />
 					</li>
 				);
 			} );
 
 		return (
-			<ol className="reader-post-images__list">
+			<ol className="post-images__list">
 				{ thumbList }
 			</ol>
 		);

--- a/client/reader/post-images/index.jsx
+++ b/client/reader/post-images/index.jsx
@@ -18,7 +18,7 @@ const PostImages = React.createClass( {
 
 		return (
 			<div className="post-images">
-				<PostImageThumbList postImages={ images } />
+				<PostImageThumbList postImages={ images.slice( 0, 9 ) } />
 			</div>
 		);
 	}

--- a/client/reader/post-images/index.jsx
+++ b/client/reader/post-images/index.jsx
@@ -12,13 +12,9 @@ const PostImages = React.createClass( {
 		const images = this.props.postImages,
 			count = images.length;
 
-		if ( count < 2 ) {
-			return null;
-		}
-
 		return (
 			<div className="post-images">
-				<PostImageThumbList postImages={ images.slice( 0, 9 ) } />
+				<PostImageThumbList postImages={ images.slice( 0, 5 ) } />
 			</div>
 		);
 	}
@@ -34,7 +30,7 @@ const PostImageThumbList = React.createClass( {
 			thumbList = images.map( function( image, index ) {
 				return (
 					<li key={ 'thumb-image-' + index } className="post-images__item">
-						<img className="post-images__image" src={ resizeImageUrl( image.src, { resize: '240,240' } ) } />
+						<img className="post-images__image" src={ resizeImageUrl( image.src, { resize: '640,130' } ) } />
 					</li>
 				);
 			} );

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -178,7 +178,7 @@ const Post = React.createClass( {
 			featuredEmbed = null;
 		}
 
-		if ( ! ( featuredImage || featuredEmbed ) ) {
+		if ( ! ( featuredEmbed ) ) {
 			return null;
 		}
 
@@ -203,24 +203,11 @@ const Post = React.createClass( {
 			featuredSize = this.getFeaturedSize( maxWidth );
 		}
 
-		return useFeaturedEmbed
-			? <div
+		return <div
 					ref="featuredEmbed"
 					className="reader__post-featured-video"
 					key="featuredVideo"
-					dangerouslySetInnerHTML={ { __html: featuredEmbed.iframe } } />  //eslint-disable-line react/no-danger
-			: <div
-					className="reader__post-featured-image"
-					onClick={ this.handlePermalinkClick }>
-				{ featuredSize
-					? <img className="reader__post-featured-image-image"
-							ref="featuredImage"
-							src={ featuredImage }
-							style={ featuredSize }
-						/>
-					: <img className="reader__post-featured-image-image" src={ featuredImage } />
-				}
-			</div>;
+					dangerouslySetInnerHTML={ { __html: featuredEmbed.iframe } } />;  //eslint-disable-line react/no-danger
 	},
 
 	updateFeatureSize: function() {
@@ -416,11 +403,9 @@ const Post = React.createClass( {
 				{ this.props.showPostHeader ? <PostHeader site={ site } siteUrl={ post.site_URL } showFollow={ this.props.showFollowInHeader } onSiteSelect={ this.pickSite } onSiteClick={ this.handleSiteClick } /> : null }
 
 				{ featuredImage }
-				{ ! shouldShowExcerptOnly
-					? <PostImages postImages={ ( post.content_images || [] ).filter( img => {
-						return post.canonical_image && img.src !== post.canonical_image.uri;
-					} ) } />
-					: null }
+				{ ! featuredImage && post.images && <PostImages postImages={ post.images.filter( image => {
+					return image.naturalWidth > 320 && image.naturalHeight > 320;
+				} ) } /> }
 
 				{ post.title ? <h1 className="reader__post-title"><a className="reader__post-title-link" href={ post.URL } target="_blank">{ post.title }</a></h1> : null }
 

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -416,6 +416,11 @@ const Post = React.createClass( {
 				{ this.props.showPostHeader ? <PostHeader site={ site } siteUrl={ post.site_URL } showFollow={ this.props.showFollowInHeader } onSiteSelect={ this.pickSite } onSiteClick={ this.handleSiteClick } /> : null }
 
 				{ featuredImage }
+				{ ! shouldShowExcerptOnly
+					? <PostImages postImages={ ( post.content_images || [] ).filter( img => {
+						return post.canonical_image && img.src !== post.canonical_image.uri;
+					} ) } />
+					: null }
 
 				{ post.title ? <h1 className="reader__post-title"><a className="reader__post-title-link" href={ post.URL } target="_blank">{ post.title }</a></h1> : null }
 
@@ -431,10 +436,6 @@ const Post = React.createClass( {
 						</EmbedContainer>
 					: <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
 				}
-
-				{ ! shouldShowExcerptOnly
-					? <PostImages postImages={ post.content_images || [] } />
-					: null }
 
 				{ ( isDiscoverPost && post.discover_metadata && ! isDiscoverSitePick ) ? <DiscoverPostAttribution attribution={ post.discover_metadata.attribution } siteUrl={ discoverSiteUrl } /> : null }
 				{ ( isDiscoverSitePick ) ? <DiscoverSiteAttribution attribution={ post.discover_metadata.attribution } siteUrl={ discoverSiteUrl } /> : null }


### PR DESCRIPTION
They're broken and there's no easy way to fix them given the CSS changes that happened with the `layout` classes at the top of the hierarchy.

Instead, redo them a bit to sit under the featured image and remove all the links and the inline gallery. It still shows that a post is full of images, but folks can click through into the full post view to see the actual images.

This also speeds up the stream a bit.
