### PR TITLE
Update No Ads wording on My Plan page

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/personal-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/personal-plan-details.jsx
@@ -21,11 +21,10 @@ const PersonalPlanDetails = ( { translate, selectedSite, sitePlans } ) => {
 
 			<PurchaseDetail
 				icon="speaker"
-				title={ translate( 'No Ads' ) }
+				title={ translate( 'Advertising Removed' ) }
 				description={ translate(
-					'Personal plan automatically removes all Ads from your site. ' +
-					'Now your visitors can enjoy your great content without distractions!'
-				)	}
+					'With your plan, all WordPress.com advertising has been removed from your site.'
+				) }
 			/>
 		</div>
 	);

--- a/client/my-sites/upgrades/checkout-thank-you/personal-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/personal-plan-details.jsx
@@ -23,7 +23,8 @@ const PersonalPlanDetails = ( { translate, selectedSite, sitePlans } ) => {
 				icon="speaker"
 				title={ translate( 'Advertising Removed' ) }
 				description={ translate(
-					'With your plan, all WordPress.com advertising has been removed from your site.'
+					'With your plan, all WordPress.com advertising has been removed from your site. ' +
+					'You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
 				) }
 			/>
 		</div>

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -21,7 +21,8 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 	const adminUrl = selectedSite.URL + '/wp-admin/';
 	const customizerInAdmin = adminUrl + 'customize.php?return=' + encodeURIComponent( window.location.href );
 	const customizeLink = config.isEnabled( 'manage/customize' ) ? '/customize/' + selectedSite.slug : customizerInAdmin;
-	const plan = find( sitePlans.data, isPremium );
+	const plan = find( sitePlans.data, isPremium ),
+		isPremiumPlan = isPremium( selectedSite.plan );
 
 	return (
 		<div>
@@ -30,9 +31,11 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 			<PurchaseDetail
 				icon="speaker"
 				title={ i18n.translate( 'Advertising Removed' ) }
-				description={ i18n.translate(
-					'With your plan, all WordPress.com advertising has been removed from your site.'
-				) }
+				description={ isPremiumPlan
+					? i18n.translate( 'With your plan, all WordPress.com advertising has been removed from your site.' +
+						' You can upgrade to a Business plan to also remove the WordPress.com footer credit.' )
+					: i18n.translate( 'With your plan, all WordPress.com advertising has been removed from your site.' )
+				}
 			/>
 
 			<QuerySiteVouchers siteId={ selectedSite.ID } />

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -29,13 +29,10 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 
 			<PurchaseDetail
 				icon="speaker"
-				title={ i18n.translate( 'No Ads' ) }
-				description={
-					i18n.translate(
-						'Your plan removes advertising from your site so ' +
-						'your visitors can enjoy your content without distractions!'
-					)
-				}
+				title={ i18n.translate( 'Advertising Removed' ) }
+				description={ i18n.translate(
+					'With your plan, all WordPress.com advertising has been removed from your site.'
+				) }
 			/>
 
 			<QuerySiteVouchers siteId={ selectedSite.ID } />


### PR DESCRIPTION
Fixes #6760. After lengthy discussions, we decided to change wording of No Ads feature to "Advertising removed" and update the description so it signifies that no action is required from the user and is more understandable.

## Testing Instructions
1. Build Calypso with `make run`;
2. Navigate to http://calypso.localhost:3000/plans/my-plan/ and select a Personal/Premium/Business site;
3. Scroll down a bit and look for "Advertising Removed" feature. Is the wording alright? 

## Screenshots

![selection_064](https://cloud.githubusercontent.com/assets/4988512/16882012/2b8fe678-4abd-11e6-897c-412aad84a38d.png)

![selection_065](https://cloud.githubusercontent.com/assets/4988512/16882014/2dc5ed8e-4abd-11e6-9c37-c4b91cd98f41.png)

cc @apeatling @rralian @rickybanister 

Test live: https://calypso.live/?branch=update/my-plan-no-ads-wording