### PR TITLE
Domains: Implement domain mappings for VIP sites

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1627,6 +1627,24 @@ Undocumented.prototype.updateWhois = function( domainName, whois, fn ) {
 	}, fn );
 };
 
+/**
+ * Add domain mapping for VIP clients.
+ *
+ * @param {int} [siteId] The site ID
+ * @param {string} [domainName] Name of the domain mapping
+ * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
+ */
+Undocumented.prototype.addVipDomainMapping = function( siteId, domainName, fn ) {
+	debug( '/site/:site_id/vip-domain-mapping' );
+	return this.wpcom.req.post( {
+		path: `/sites/${ siteId }/vip-domain-mapping`,
+		body: {
+			domain: domainName
+		}
+	}, fn );
+};
+
 /*
  * Change the theme of a given site.
  *


### PR DESCRIPTION
Domain mappings for VIP sites require different provisioning than regular domain mappings, hence a different flow for them is needed: we don't go through the usual checkout process, just call the backend and redirect to Domains page.
I've implemented this different flow only for Domain management - not for NUX/signup, as it didn't make sense there.
I had to add rudimentary error handling - ideally, we should never need it, as there are different parts of code that check the mappability of the domain and ensure should technically prevent from any failures here.

Testing:
* Check that for normal (non-VIP) sites you can add domain mappings as usual.
* Add a domain mapping on a VIP site - verify it never expires, etc.

/cc @aidvu @umurkontaci @scruffian @matthusby 

Test live: https://calypso.live/?branch=add/vip-unlimited-domain-mappings