### PR TITLE
Purchases: Add survey to refund flow.

### DIFF
--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -2,14 +2,12 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { action as ActionTypes } from '../constants';
-import Dispatcher from 'dispatcher';
 import wp from 'lib/wp';
+import notices from 'notices';
 
 const debug = debugFactory( 'calypso:upgrades:actions:purchases' ),
 	wpcom = wp.undocumented();
@@ -28,7 +26,23 @@ function cancelAndRefundPurchase( purchaseId, data, onComplete ) {
 	wpcom.cancelAndRefundPurchase( purchaseId, data, onComplete );
 }
 
+function submitSurvey( surveyName, siteID, surveyData ) {
+	const survey = wp.marketing().survey( surveyName, siteID );
+	survey.addResponses( surveyData );
+
+	debug( 'Survey responses', survey );
+	survey.submit()
+		.then( res => {
+			debug( 'Survey submit response', res );
+			if ( ! res.success ) {
+				notices.error( res.err );
+			}
+		} )
+		.catch( err => debug( err ) ); // shouldn't get here
+}
+
 export {
 	cancelAndRefundPurchase,
 	cancelPurchase,
+	submitSurvey
 };

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -7,17 +7,20 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
+import config from 'config';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
-import { cancelAndRefundPurchase, cancelPurchase } from 'lib/upgrades/actions';
+import { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from 'lib/upgrades/actions';
 import { clearPurchases } from 'state/purchases/actions';
 import { connect } from 'react-redux';
 import Dialog from 'components/dialog';
+import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import { getName, getSubscriptionEndDate, isOneTimePurchase, isRefundable, isSubscription } from 'lib/purchases';
 import { isDomainRegistration, isTheme, isGoogleApps } from 'lib/products-values';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
+import FormSectionHeading from 'components/forms/form-section-heading';
 
 const CancelPurchaseButton = React.createClass( {
 	propTypes: {
@@ -27,7 +30,14 @@ const CancelPurchaseButton = React.createClass( {
 
 	getInitialState() {
 		return {
-			disabled: false
+			disabled: false,
+			showDialog: false,
+			isRemoving: false,
+			surveyStep: 1,
+			survey: {
+				questionOneRadio: null,
+				questionTwoRadio: null
+			}
 		};
 	},
 
@@ -43,83 +53,82 @@ const CancelPurchaseButton = React.createClass( {
 
 	closeDialog() {
 		this.setState( {
-			showDialog: false
+			showDialog: false,
+			surveyStep: 1,
+			survey: {
+				questionOneRadio: null,
+				questionTwoRadio: null
+			}
 		} );
 	},
 
+	changeSurveyStep() {
+		this.setState( {
+			surveyStep: this.state.surveyStep === 1 ? 2 : 1,
+		} );
+	},
+
+	onSurveyChange( update ) {
+		this.setState( {
+			survey: update,
+		} );
+	},
+
+	isSurveyIncomplete() {
+		return this.state.survey.questionOneRadio === null || this.state.survey.questionTwoRadio === null ||
+			( this.state.survey.questionOneRadio === 'anotherReasonOne' && this.state.survey.questionOneText === '' ) ||
+			( this.state.survey.questionTwoRadio === 'anotherReasonTwo' && this.state.survey.questionTwoText === '' );
+	},
+
 	renderCancelConfirmationDialog() {
-		const { domain, refundText } = this.props.purchase,
-			purchaseName = getName( this.props.purchase ),
-			buttons = [
-				{
+		const buttons = {
+				close: {
 					action: 'close',
 					label: this.translate( "No, I'll Keep It" )
 				},
-				{
+				next: {
+					action: 'next',
+					disabled: this.state.isRemoving || this.isSurveyIncomplete(),
+					label: this.translate( 'Next' ),
+					onClick: this.changeSurveyStep
+				},
+				prev: {
+					action: 'prev',
+					disabled: this.state.isRemoving,
+					label: this.translate( 'Previous Step' ),
+					onClick: this.changeSurveyStep
+				},
+				cancel: {
 					action: 'cancel',
 					label: this.translate( 'Yes, Cancel Now' ),
 					isPrimary: true,
 					disabled: this.state.submitting,
 					onClick: this.submitCancelAndRefundPurchase
 				}
-			];
+			},
+			purchaseName = getName( this.props.purchase ),
+			inStepOne = this.state.surveyStep === 1;
 
-		let cancelationEffectText = this.translate(
-			'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.', {
-				args: {
-					cost: refundText
-				}
-			}
-		);
-
-		if ( isTheme( this.props.purchase ) ) {
-			cancelationEffectText = this.translate(
-				'Your site\'s appearance will revert to its previously selected theme and you will be refunded %(cost)s.', {
-					args: {
-						cost: refundText
-					}
-				}
-			);
-		}
-
-		if ( isGoogleApps( this.props.purchase ) ) {
-			cancelationEffectText = this.translate(
-				'You will be refunded %(cost)s, but your Google Apps account will continue working without interruption. ' +
-				'You will be able to manage your Google Apps billing directly through Google.', {
-					args: {
-						cost: refundText
-					}
-				}
-			);
+		let buttonsArr;
+		if ( ! config.isEnabled( 'upgrades/removal-survey' ) ) {
+			buttonsArr = [ buttons.close, buttons.cancel ];
+		} else {
+			buttonsArr = inStepOne ? [ buttons.close, buttons.next ] : [ buttons.prev, buttons.close, buttons.cancel ];
 		}
 
 		return (
 			<Dialog
 				isVisible={ this.state.showDialog }
-				buttons={ buttons }
+				buttons={ buttonsArr }
 				onClose={ this.closeDialog }
-				className="cancel-purchase-button__warning-dialog">
-				<h1>
-					{ this.translate( 'Cancel %(purchaseName)s', {
-						args: {
-							purchaseName
-						}
-					} ) }
-				</h1>
-				<p>
-					{ this.translate(
-						'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
-							args: {
-								purchaseName,
-								domain
-							},
-							components: {
-								em: <em />
-							}
-						}
-					) }
-					{ cancelationEffectText }
-				</p>
+				className="cancel-purchase__button-warning-dialog">
+				<FormSectionHeading>{ this.translate( 'Cancel %(purchaseName)s', { args: { purchaseName } } ) }</FormSectionHeading>
+				<CancelPurchaseForm
+					surveyStep={ this.state.surveyStep }
+					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
+					defaultContent={ this.renderCancellationEffect() }
+					onInputChange={ this.onSurveyChange }
+				/>
 			</Dialog>
 		);
 	},
@@ -146,7 +155,8 @@ const CancelPurchaseButton = React.createClass( {
 
 			if ( success ) {
 				notices.success( this.translate(
-					'%(purchaseName)s was successfully cancelled. It will be available for use until it expires on %(subscriptionEndDate)s.',
+					'%(purchaseName)s was successfully cancelled. It will be available ' +
+					'for use until it expires on %(subscriptionEndDate)s.',
 					{
 						args: {
 							purchaseName,
@@ -211,7 +221,77 @@ const CancelPurchaseButton = React.createClass( {
 			submitting: true
 		} );
 
+		if ( config.isEnabled( 'upgrades/removal-survey' ) ) {
+			const { purchase } = this.props,
+				surveyData = {
+					'why-cancel': {
+						response: this.state.survey.questionOneRadio,
+						text: this.state.survey.questionOneText
+					},
+					'next-adventure': {
+						response: this.state.survey.questionTwoRadio,
+						text: this.state.survey.questionTwoText
+					},
+					'what-better': { text: this.state.survey.questionThreeText },
+					purchase: purchase.productSlug,
+					type: 'refund'
+				};
+
+			submitSurvey( 'calypso-remove-purchase', this.props.selectedSite.ID, surveyData );
+		}
+
 		cancelAndRefundPurchase( this.props.purchase.id, { product_id: this.props.purchase.productId }, this.handleSubmit );
+	},
+
+	renderCancellationEffect() {
+		const { domain, refundText } = this.props.purchase,
+			purchaseName = getName( this.props.purchase );
+
+		let cancelationEffectText = this.translate(
+			'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.', {
+				args: {
+					cost: refundText
+				}
+			}
+		);
+
+		if ( isTheme( this.props.purchase ) ) {
+			cancelationEffectText = this.translate(
+				'Your site\'s appearance will revert to its previously selected theme and you will be refunded %(cost)s.', {
+					args: {
+						cost: refundText
+					}
+				}
+			);
+		}
+
+		if ( isGoogleApps( this.props.purchase ) ) {
+			cancelationEffectText = this.translate(
+				'You will be refunded %(cost)s, but your Google Apps account will continue working without interruption. ' +
+				'You will be able to manage your Google Apps billing directly through Google.', {
+					args: {
+						cost: refundText
+					}
+				}
+			);
+		}
+
+		return (
+			<p>
+				{ this.translate(
+					'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
+						args: {
+							purchaseName,
+							domain
+						},
+						components: {
+							em: <em />
+						}
+					}
+				) }
+				{ cancelationEffectText }
+			</p>
+		);
 	},
 
 	render() {

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -113,6 +113,6 @@
 	width: 50%;
 }
 
-.cancel-purchase-button__warning-dialog {
+.cancel-purchase__button-warning-dialog {
 	max-width: 472px;
 }


### PR DESCRIPTION
This PR adds the customer survey onto the `CancelPurchaseButton` flow. We were previously not gaining any insight as to why our customers were cancelling their purchases, so this short, mandatory survey has been prepended to the cancellation action. This update fully utilizes the existing `CancelPurchaseButton` components with a reshuffling of the dialogs and a new call to `wpcom.marketing().survey().submit()`.

This update is pretty similar to https://github.com/Automattic/wp-calypso/pull/4838

**Note:** You may need to add `define( 'USE_STORE_SANDBOX', true );` somewhere in your sandbox to get access to refundable purchases.

### /purchases/:site/:purchase
Nothing has changed on the surface here.
<img width="1171" alt="screen shot 2016-07-15 at 11 37 43 am" src="https://cloud.githubusercontent.com/assets/273708/16884884/b83d4f76-4a80-11e6-80a0-066a0bf9e3ba.png">


### Cancel and Refund \<product>
#### `isEnabled( 'upgrades/removal-survey' )` == true
Clicking the cancel button will bring up the first page of the survey dialog. None of the options are selected by default and their order (minus 'another reason...') is randomized. 'Next' does not activate until both questions are answered.

<img width="459" alt="screen shot 2016-07-27 at 12 10 16 pm" src="https://cloud.githubusercontent.com/assets/273708/17188705/2a032aa6-53f3-11e6-982c-9f50edbd3e1f.png">

Second dialog after clicking 'Next' brings up final optional question and the rest of the original remove product dialog. Clicking 'Yes, Cancel Now' is the original remove `cancelPurchase()` action with the additional action of submitting the responses to the `wpcom.marketing()` endpoint.

<img width="547" alt="screen shot 2016-07-15 at 11 40 28 am" src="https://cloud.githubusercontent.com/assets/273708/16885016/63576086-4a81-11e6-8087-8fc314ac171c.png">

#### `isEnabled( 'upgrades/removal-survey' )` == false
Original dialog is presented, survey is not sent.

<img width="549" alt="screen shot 2016-07-15 at 11 46 09 am" src="https://cloud.githubusercontent.com/assets/273708/16885083/c127ea6e-4a81-11e6-83d8-7f71237f579d.png">

## Testing

With `"upgrades/removal-survey": true,` set in development.json go to http://calypso.localhost:3000/purchases/ and select a site with a refundable product to cancel.

<img width="1243" alt="screen shot 2016-06-22 at 10 45 12 am" src="https://cloud.githubusercontent.com/assets/273708/16277138/84d1ad16-3866-11e6-931b-5e381e5b957b.png">

Then click on 'Cancel and Refund \<product>' to bring the survey up.

<img width="1171" alt="screen shot 2016-07-15 at 11 37 43 am" src="https://cloud.githubusercontent.com/assets/273708/16884884/b83d4f76-4a80-11e6-80a0-066a0bf9e3ba.png">
