### PR TITLE
Plans: Fix/plans page whitespace

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -259,7 +259,7 @@ const PlanActions = React.createClass( {
 		return (
 			<div>
 				<span className="plan-actions__current-plan-label" onClick={ this.recordCurrentPlanClick }>
-				{ this.translate( 'Your current plan', { context: 'Informing the user of their current plan on /plans/' } ) }</span>
+				{ this.translate( 'Current Plan', { context: 'Informing the user of their current plan on /plans/' } ) }</span>
 				{ this.freePlanExpiration() }
 			</div>
 		);

--- a/client/components/plans/plan-actions/style.scss
+++ b/client/components/plans/plan-actions/style.scss
@@ -1,12 +1,16 @@
 .plan { // This nesting is necessary to prevent these styles bleeding onto the /plans/compare screen
 	.plan-actions {
-		float: left;
 		width: 100%;
 		padding: 0 16px 16px 16px;
 		box-sizing: border-box;
+		position: absolute;
+		bottom: 0;
+		left: 0;
 
 		&.is-image-button {
 			padding: 0;
+			float: left;
+			position: static;
 		}
 
 		.plan-actions__upgrade-button {

--- a/client/components/plans/plan-actions/style.scss
+++ b/client/components/plans/plan-actions/style.scss
@@ -29,6 +29,7 @@
 
 .plan-actions__upgrade-button {
 	display: block;
+	white-space: nowrap;
 	text-align: center;
 	width: 100%;
 }
@@ -80,6 +81,7 @@
 	opacity: .6;
 	padding: 0.5em 1.2em 0.62em;
 	text-align: center;
+	white-space: nowrap;
 
 	&:before {
 		@extend %clear-text;

--- a/client/components/plans/plan/style.scss
+++ b/client/components/plans/plan/style.scss
@@ -126,6 +126,15 @@
 		border-top: 2px solid lighten( $gray, 20% );
 		float: left;
 	}
+
+	.plan .plan-actions {
+		float:left;
+		position: static;
+	}
+
+	.plan__plan-expand {
+		padding-bottom: 0;
+	}
 }
 
 @mixin plans-in-three-columns() {

--- a/client/components/plans/plan/style.scss
+++ b/client/components/plans/plan/style.scss
@@ -51,6 +51,10 @@
 	width: 100%;
 	padding-bottom: 56px;
 
+	.is-current-plan & {
+		padding-bottom: 102px;
+	}
+
 	.jetpack_free &,
 	.jetpack_premium &,
 	.jetpack_business &

--- a/client/components/plans/plan/style.scss
+++ b/client/components/plans/plan/style.scss
@@ -49,6 +49,7 @@
 	overflow: hidden;
 	transition: all 0.4s ease-in-out;
 	width: 100%;
+	padding-bottom: 56px;
 
 	.jetpack_free &,
 	.jetpack_premium &,
@@ -159,10 +160,6 @@
 		margin: 0 0 5px 0;
 		padding: 0;
 		text-align: center;
-	}
-
-	.plan__plan-details {
-		min-height: 209px;
 	}
 
 	.plan-list {


### PR DESCRIPTION
The current plans page has its action buttons pretty far down the page, and potentially below the fold for quite a few people. This is what you see at 677px height, which is a reasonable viewport size for people with a screensize at 1366x768 (which is extremely common) when you take into account about 100px for menu/tabs/addressbar/status, etc.

![677px hidden calls to action](https://cloudup.com/ctFCR_zaCeb+)

I believe we're just doing this to ensure alignment of elements on the page for variable content. But there's a much better way to do this with CSS. With these tweaks it looks like this, and it will appropriately scale if more content is displayed in one column for a particular locale.

![better alignment](https://cloudup.com/cFcwoApDmvt+)

I've also tested to make sure these changes don't interfere with the existing mobile view.

![mobile view](https://cloudup.com/cZDgiEVddIz+)

## Testing
Go through the new-user-experience at http://calypso.localhost:3000/start and ensure the plans page looks good. Click into the plans/compare page and ensure there are no visual differences or regressions there (none intended). Test the mobile view of both pages as well.

Now test the plans page from the sidebar; http://calypso.localhost:3000/plans and test the plans compare page as well.

And last, test this in different browsers to make sure everything continues to look and work like it should.

/cc @apeatling 

Test live: https://calypso.live/?branch=fix/plans-page-whitespace