### PR TITLE
Purchaes: Add purchase and type to cancellation survey.

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -114,7 +114,7 @@ const RemovePurchase = React.createClass( {
 					text: this.state.questionTwoText
 				},
 				'what-better': { text: this.state.questionThreeText },
-				purchase: purchase,
+				purchase: purchase.productSlug,
 				type: 'cancel'
 			} );
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -113,7 +113,9 @@ const RemovePurchase = React.createClass( {
 					response: this.state.questionTwoRadio,
 					text: this.state.questionTwoText
 				},
-				'what-better': { text: this.state.questionThreeText }
+				'what-better': { text: this.state.questionThreeText },
+				purchase: purchase,
+				type: 'cancel'
 			} );
 
 			debug( 'Survey responses', survey );


### PR DESCRIPTION
Adding a bit more data to the cancel purchase survey submission.

## Testing

With `calypso:purchases:survey` debug turned on go to http://calypso.localhost:3000/purchases/ and select a site with a product to remove (not refund).

<img width="1243" alt="screen shot 2016-06-22 at 10 45 12 am" src="https://cloud.githubusercontent.com/assets/273708/16277138/84d1ad16-3866-11e6-931b-5e381e5b957b.png">

Then click on 'Remove \<product>' to bring the survey up.

<img width="792" alt="screen shot 2016-06-22 at 10 47 21 am" src="https://cloud.githubusercontent.com/assets/273708/16277205/c55e808e-3866-11e6-8e2e-12a3ac7edfb2.png">

Remove the product and check the debug, you should see `'Survey responses'` with the purchase and type included in _responses.

<img width="1269" alt="screen shot 2016-07-18 at 3 28 58 pm" src="https://cloud.githubusercontent.com/assets/273708/16932628/6d8aeafa-4cfc-11e6-8913-e9a3cc70ecba.png">
