### PR TITLE
Remove FirstView styles from .main

### DIFF
--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -34,15 +34,15 @@ const FirstView = React.createClass( {
 	},
 
 	componentDidMount() {
-		this.updatePageScrolling();
+		this.updateDocumentStyles();
 	},
 
 	componentDidUpdate() {
-		this.updatePageScrolling();
+		this.updateDocumentStyles();
 	},
 
 	componentWillUnmount() {
-		this.allowPageScrolling();
+		this.updateDocumentStylesForHiddenFirstView();
 	},
 
 	render() {
@@ -91,20 +91,24 @@ const FirstView = React.createClass( {
 		} );
 	},
 
-	updatePageScrolling() {
+	updateDocumentStyles() {
 		if ( this.props.isVisible ) {
-			this.preventPageScrolling();
+			this.updateDocumentStylesForVisibleFirstView();
 		} else {
-			this.allowPageScrolling();
+			this.updateDocumentStylesForHiddenFirstView();
 		}
 	},
 
-	preventPageScrolling() {
-		document.documentElement.classList.add( 'no-scroll' );
+	updateDocumentStylesForVisibleFirstView() {
+		document.documentElement.classList.add( 'no-scroll', 'is-first-view-visible', 'is-first-view-active' );
 	},
 
-	allowPageScrolling() {
-		document.documentElement.classList.remove( 'no-scroll' );
+	updateDocumentStylesForHiddenFirstView() {
+		document.documentElement.classList.remove( 'no-scroll', 'is-first-view-visible' );
+		// wait until next tick so that we trigger the CSS transition
+		process.nextTick( () => {
+			document.documentElement.classList.remove( 'is-first-view-active' );
+		} );
 	}
 } );
 

--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -105,10 +105,10 @@ const FirstView = React.createClass( {
 
 	updateDocumentStylesForHiddenFirstView() {
 		document.documentElement.classList.remove( 'no-scroll', 'is-first-view-visible' );
-		// wait until next tick so that we trigger the CSS transition
-		process.nextTick( () => {
+		// wait a bit so that we trigger the CSS transition
+		setTimeout( () => {
 			document.documentElement.classList.remove( 'is-first-view-active' );
-		} );
+		}, 200 );
 	}
 } );
 

--- a/client/components/first-view/style.scss
+++ b/client/components/first-view/style.scss
@@ -1,22 +1,22 @@
 // Setting up the .main div to accept the transitions for
 // the First View component.
-.main {
+.is-first-view-active .main {
 	opacity: 1;
 	pointer-events: auto;
 	transform: scale( 1 );
 	transition: all 0.2s ease-in-out;
+}
 
-	&.is-first-view-visible {
-		opacity: 0.4;
-		pointer-events: none;
-		-webkit-filter: blur( 3px );
-		transform: scale( 0.9 );
-		
-		// This limits the blur filter to Safari, as other browsers can't handle the
-		// awesomeness of transitioning blurs.
-		@supports (overflow:-webkit-marquee) and (justify-content:inherit) {
-			filter: blur( 3px );
-		}
+.is-first-view-visible .main {
+	opacity: 0.4;
+	pointer-events: none;
+	-webkit-filter: blur( 3px );
+	transform: scale( 0.9 );
+
+	// This limits the blur filter to Safari, as other browsers can't handle the
+	// awesomeness of transitioning blurs.
+	@supports (overflow:-webkit-marquee) and (justify-content:inherit) {
+		filter: blur( 3px );
 	}
 }
 

--- a/client/my-sites/stats/stats-main/index.jsx
+++ b/client/my-sites/stats/stats-main/index.jsx
@@ -4,31 +4,16 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
-import { shouldViewBeVisible } from 'state/ui/first-view/selectors';
 
-const StatsMain = ( { isFirstViewVisible, children } ) => {
-	const classes = classnames( {
-		'is-first-view-visible': isFirstViewVisible
-	} );
-
+export default ( { children } ) => {
 	return (
-		<Main className={ classes }>
+		<Main>
 			{ children }
 		</Main>
 	);
 };
-
-export default connect(
-	( state ) => {
-		return {
-			isFirstViewVisible: shouldViewBeVisible( state ),
-		};
-	}
-)( StatsMain );


### PR DESCRIPTION
The PR fixed a visual defect introduced recently with #6717. Namely, the positioning of fixed elements was altered (the "1 new post" in Reader no longer was aligned to the very right of the window).

With this change, there is no longer any need for `<StatsMain>` -- I will create a separate PR after this lands to take care of removing `<StatsMain>`, in order to keep this PR small and allow this fix to be deployed sooner.

To test:
- Verify first view still appears correctly (see #6717 for testing instructions)
- Verify that "1 new post" badges appear aligned to the right of the window correctly in the Reader

/cc @blowery @shaunandrews 

Test live: https://calypso.live/?branch=fix/main-styling-fixed-elements