### PR TITLE
Add FirstView AB test configuration

### DIFF
--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -16,6 +16,8 @@ import RootChild from 'components/root-child';
 import { getSectionName } from 'state/ui/selectors';
 import { shouldViewBeVisible } from 'state/ui/first-view/selectors';
 import { hideView } from 'state/ui/first-view/actions';
+import { abtest } from 'lib/abtest';
+import { isEnabled } from 'config';
 
 // component to avoid having a wrapper element for the transition
 // see: https://facebook.github.io/react/docs/animation.html#rendering-a-single-child
@@ -121,9 +123,11 @@ const FirstView = React.createClass( {
 
 export default connect(
 	( state ) => {
+		const participantInFirstViewAbTest = isEnabled( 'ui/first-view-ab-test' ) && abtest( 'firstView' ) === 'enabled';
+
 		return {
 			sectionName: getSectionName( state ),
-			isVisible: shouldViewBeVisible( state ),
+			isVisible: ( isEnabled( 'ui/first-view' ) || participantInFirstViewAbTest ) && shouldViewBeVisible( state ),
 		};
 	},
 	{

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -92,4 +92,13 @@ module.exports = {
 		defaultVariation: 'noNotice',
 		allowAnyLocale: true
 	},
+	firstView: {
+		datestamp: '20160728',
+		variations: {
+			disabled: 95,
+			enabled: 5,
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: false,
+	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -93,7 +93,7 @@ module.exports = {
 		allowAnyLocale: true
 	},
 	firstView: {
-		datestamp: '20160728',
+		datestamp: '20160726',
 		variations: {
 			disabled: 95,
 			enabled: 5,

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -16,7 +16,6 @@ import { FIRST_VIEW_START_DATES } from './constants';
 import { getActionLog } from 'state/ui/action-log/selectors';
 import { getPreference, preferencesLastFetchedTimestamp } from 'state/preferences/selectors';
 import { getSectionName, isSectionLoading } from 'state/ui/selectors';
-import { isEnabled } from 'config';
 import { FIRST_VIEW_HIDE, ROUTE_SET } from 'state/action-types';
 
 export function doesViewHaveFirstView( view ) {
@@ -55,8 +54,7 @@ function routeSetIsInCurrentSection( state, routeSet ) {
 export function shouldViewBeVisible( state ) {
 	const sectionName = getSectionName( state );
 
-	return isEnabled( 'ui/first-view' ) &&
-		isViewEnabled( state, sectionName ) &&
+	return isViewEnabled( state, sectionName ) &&
 		! wasFirstViewHiddenSinceEnteringCurrentSection( state ) &&
 		! isSectionLoading( state );
 }

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -16,8 +16,7 @@ import { FIRST_VIEW_START_DATES } from './constants';
 import { getActionLog } from 'state/ui/action-log/selectors';
 import { getPreference, preferencesLastFetchedTimestamp } from 'state/preferences/selectors';
 import { getSectionName, isSectionLoading } from 'state/ui/selectors';
-import { isEnabled } from 'config';
-import { FIRST_VIEW_HIDE, ROUTE_SET } from 'state/action-types';
+import { ROUTE_SET } from 'state/action-types';
 
 export function doesViewHaveFirstView( view ) {
 	return !! ( FIRST_VIEW_START_DATES[ view ] );
@@ -55,9 +54,9 @@ function routeSetIsInCurrentSection( state, routeSet ) {
 export function shouldViewBeVisible( state ) {
 	const sectionName = getSectionName( state );
 
-	return isEnabled( 'ui/first-view' ) &&
-		isViewEnabled( state, sectionName ) &&
-		! wasFirstViewHiddenSinceEnteringCurrentSection( state ) &&
+	return isViewEnabled( state, sectionName ) &&
+		! wasViewHidden( state, sectionName ) &&
+		switchedFromDifferentSection( state ) &&
 		! isSectionLoading( state );
 }
 

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -16,7 +16,8 @@ import { FIRST_VIEW_START_DATES } from './constants';
 import { getActionLog } from 'state/ui/action-log/selectors';
 import { getPreference, preferencesLastFetchedTimestamp } from 'state/preferences/selectors';
 import { getSectionName, isSectionLoading } from 'state/ui/selectors';
-import { ROUTE_SET } from 'state/action-types';
+import { isEnabled } from 'config';
+import { FIRST_VIEW_HIDE, ROUTE_SET } from 'state/action-types';
 
 export function doesViewHaveFirstView( view ) {
 	return !! ( FIRST_VIEW_START_DATES[ view ] );
@@ -54,9 +55,9 @@ function routeSetIsInCurrentSection( state, routeSet ) {
 export function shouldViewBeVisible( state ) {
 	const sectionName = getSectionName( state );
 
-	return isViewEnabled( state, sectionName ) &&
-		! wasViewHidden( state, sectionName ) &&
-		switchedFromDifferentSection( state ) &&
+	return isEnabled( 'ui/first-view' ) &&
+		isViewEnabled( state, sectionName ) &&
+		! wasFirstViewHiddenSinceEnteringCurrentSection( state ) &&
 		! isSectionLoading( state );
 }
 

--- a/config/production.json
+++ b/config/production.json
@@ -84,6 +84,7 @@
 		"settings/security/monitor": true,
 		"support-user": true,
 		"sync-handler": true,
+		"ui/first-view-ab-test": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
This PR seeks to add the necessary configuration to start showing the Stats First View overlay to 5% of our new English speaking users in production, but leave it enabled for all users in wpcalypso and development.

Test live: https://calypso.live/?branch=add/first-view-ab-test-config