### PR TITLE
Jetpack Sync: Show error notice when sync status fails >= 3 times

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -471,13 +471,13 @@ const FormGeneral = React.createClass( {
 			return null;
 		}
 
-		const site = this.props.site;
+		const { site } = this.props;
 		if ( ! site.jetpack || this.props.site.versionCompare( '4.2-alpha', '<' ) ) {
 			return null;
 		}
 
 		return (
-			<JetpackSyncPanel siteId={ site.ID } />
+			<JetpackSyncPanel />
 		);
 	},
 

--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -80,15 +80,21 @@ export function syncStatus( state = {}, action ) {
 					{
 						isRequesting: false,
 						error: false,
-						lastSuccessfulStatus
+						lastSuccessfulStatus,
+						errorCounter: 0
 					},
 					pick( action.data, getExpectedResponseKeys() )
 				)
 			} );
 		case JETPACK_SYNC_STATUS_ERROR:
+			const errorCounter = get( state, [ action.siteId, 'errorCounter' ], 0 );
 			return Object.assign( {}, state, {
 				[ action.siteId ]: Object.assign(
-					{ isRequesting: false, error: action.error },
+					{
+						isRequesting: false,
+						error: action.error,
+						errorCounter: errorCounter + 1
+					},
 					pick( action.data, getExpectedResponseKeys() )
 				)
 			} );

--- a/client/state/jetpack-sync/test/reducer.js
+++ b/client/state/jetpack-sync/test/reducer.js
@@ -202,8 +202,16 @@ describe( 'reducer', () => {
 				.to.have.all.keys( getExpectedResponseKeys().concat( [
 					'error',
 					'isRequesting',
-					'lastSuccessfulStatus'
+					'lastSuccessfulStatus',
+					'errorCounter'
 				] ) );
+		} );
+
+		it( 'should set errorCounter to 0 after a successful request', () => {
+			const state = syncStatus( undefined, successfulSyncStatusRequest );
+			expect( state ).to.have.property( String( successfulSyncStatusRequest.siteId ) )
+				.to.have.property( 'errorCounter' )
+				.to.be.eql( 0 );
 		} );
 
 		it( 'should set isRequesting to false when fetching for a site errors', () => {
@@ -218,6 +226,24 @@ describe( 'reducer', () => {
 			expect( state ).to.have.property( String( erroredSyncStatusRequest.siteId ) )
 				.to.have.property( 'error' )
 				.to.be.eql( erroredSyncStatusRequest.error );
+		} );
+
+		it( 'should set errorCounter to 1 when errorCounter previously undefined', () => {
+			const state = syncStatus( undefined, erroredSyncStatusRequest );
+			expect( state ).to.have.property( String( erroredSyncStatusRequest.siteId ) )
+				.to.have.property( 'errorCounter' )
+				.to.be.eql( 1 );
+		} );
+
+		it( 'should increment errorCounter when multiple errors occur', () => {
+			const state = syncStatus(
+				syncStatus( undefined, erroredSyncStatusRequest ),
+				erroredSyncStatusRequest
+			);
+
+			expect( state ).to.have.property( String( erroredSyncStatusRequest.siteId ) )
+				.to.have.property( 'errorCounter' )
+				.to.be.eql( 2 );
 		} );
 	} );
 


### PR DESCRIPTION
Closes #6824.

We currently do not have an error notice if sync status fails. The most likely case for this happening in our UI seems to be if a user loses connection.

Since we poll for sync status, and it is a simple GET request, we're not as interested in one failure. But, if a failure occurs at least 3 times we show a notice.

Here's what it looks like:

<img width="430" alt="screen shot 2016-07-15 at 2 49 35 pm" src="https://cloud.githubusercontent.com/assets/1126811/16886993/0a381ed4-4a9d-11e6-8447-6398815b2e5f.png">

The "Check Connection" action links to the debugger on the remote Jetpack site.

To test:

- Checkout `update/jetpack-sync-error-notice-multiple-status` branch
- Go to `/settings/general/$site` where `$site` is a Jetpack site with latest `branch-4.2` version of Jetpack
- Click "Perform full sync" button if sync is not already happening
- Open "Network conditions" panel in console, and turn off wifi
- Look at "Network" tab
- Verify that notice shows up after 3 failed statuses
- Click "Check Connection" action and ensure it sends you to remote site (probably right click and open in new tab to not lose state in current tab)
- Turn wifi back on
- Verify that the sync status UI recovers

cc @rickybanister @lezama @gravityrail for code review

Test live: https://calypso.live/?branch=update/jetpack-sync-error-notice-multiple-status