### PR TITLE
Plans: cancel the skip-for-free test

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -103,7 +103,6 @@
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans/skip-plans-for-free": true,
 		"plans/wordpress-ad-credits": true,
 		"post-editor-github-link": false,
 		"post-editor/image-editor": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -72,7 +72,6 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans/skip-plans-for-free": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -68,7 +68,6 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans/skip-plans-for-free": true,
 		"post-editor/author-selector": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -72,7 +72,6 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans/skip-plans-for-free": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/test.json
+++ b/config/test.json
@@ -89,7 +89,6 @@
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans/skip-plans-for-free": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -81,7 +81,6 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans/skip-plans-for-free": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,


### PR DESCRIPTION
This PR turns off the "skip-plans-for-free" test we were running. The results weren't encouraging, so we decided to kill this early.

/cc @apeatling 

Test live: https://calypso.live/?branch=update/cancel-skip-free-plan-test