### PR TITLE
Jetpack Sync: Add onClick analytics to sync panel

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -22,6 +22,7 @@ import {
 } from 'state/jetpack-sync/actions';
 import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
 import NoticeAction from 'components/notice/notice-action';
+import analytics from 'lib/analytics';
 
 /*
  * Module variables
@@ -53,17 +54,26 @@ const JetpackSyncPanel = React.createClass( {
 	onSyncRequestButtonClick( event ) {
 		event.preventDefault();
 		debug( 'Perform full sync button clicked' );
+		analytics.tracks.recordEvent( 'calypso_jetpack_sync_panel_request_button_clicked' );
 		this.props.scheduleJetpackFullysync( this.props.siteId );
 	},
 
 	onTryAgainClick( event ) {
 		event.preventDefault();
 		debug( 'Try again button clicked' );
+		analytics.tracks.recordEvent( 'calypso_jetpack_sync_panel_try_again_button_clicked', {
+			errorCode: get( this.props, 'fullSyncRequest.error.error', '' ),
+			errorMsg: get( this.props, 'fullSyncRequest.error.message', '' )
+		} );
 		this.props.scheduleJetpackFullysync( this.props.siteId );
 	},
 
 	onClickDebug() {
 		debug( 'Clicked check connection button' );
+		analytics.tracks.recordEvent( 'calypso_jetpack_sync_panel_check_connection_button_clicked', {
+			errorCode: get( this.props, 'syncStatus.error.error', '' ),
+			errorMsg: get( this.props, 'syncStatus.error.message', '' )
+		} );
 	},
 
 	renderErrorNotice() {


### PR DESCRIPTION
Closes #6825.

Adds analytics for the Jetpack sync panel. Since the sync panel is a minimal UI, there is not much to add as far as analytics.

To test: 

- Checkout `update/jetpack-sync-status-analytics` branch
- Go to `/settings/general/$site` where `$site` is a Jetpack with latest `branch-4.2` version of Jetpack
- In console, `localStorage.setItem('debug','calypso:analytics')`
- Reload page
- Click "Perform full sync" button and ensure analytics event fired
- Optionally turn off wifi in tab, and click actions in error notice to trigger the other events.

cc @lezama for code review



Test live: https://calypso.live/?branch=update/jetpack-sync-status-analytics