### PR TITLE
CPT: track editor usage by CPT/Source/Action.

### DIFF
--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -19,7 +19,7 @@ import SitesList from 'lib/sites-list';
 const debug = debugModule( 'calypso:posts:stats' );
 const sites = new SitesList();
 
-function recordUsageStats( action ) {
+function recordUsageStats( action, postType ) {
 	let source;
 	const site = sites.getSelectedSite();
 
@@ -28,6 +28,10 @@ function recordUsageStats( action ) {
 	if ( site ) {
 		source = site.jetpack ? 'jetpack' : 'wpcom';
 		analytics.mc.bumpStat( 'editor_usage_' + source, action );
+
+		if ( postType ) {
+			analytics.mc.bumpStat( 'editor_cpt_usage_' + source, postType + '_' + action );
+		}
 	}
 }
 
@@ -73,7 +77,7 @@ export function recordSaveEvent() {
 	}
 
 	if ( usageAction ) {
-		recordUsageStats( usageAction );
+		recordUsageStats( usageAction, post.type );
 	}
 
 	// if this action has an mc stat name, record it


### PR DESCRIPTION
Closes #6756

Confirmed that we are already recording tracks with a `post.type` attribute being sent to [tracks](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/stats.js#L94-L100) so this branch adds in a new mc stat group for tracking editor usage by source ( wpcom/jetpack ) and post type / action.

For example, editing an existing testimonial for a JP site would increment:

`editor_cpt_usage_jetpack:jetpack-testimonial_edit`

And saving a new testimonial for a wpcom site would be recorded as

`editor_cpt_usage_wpcom:jetpack-testimonial_new`

__To Test__
- Set your debug to `calypso_analytics`
- Save new and edit existing post types
- Verify the proper stats are being recorded

__Question__
Should we filter out `page` and `post` post types so they are not recorded?

Test live: https://calypso.live/?branch=add/post-type-stats