### PR TITLE
CPT: Avoid displaying Add if non-queryable type

### DIFF
--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -157,7 +157,7 @@ const PublishMenu = React.createClass( {
 		const customPostTypes = omit( this.props.postTypes, [ 'post', 'page' ] );
 		return map( customPostTypes, ( postType, postTypeSlug ) => {
 			let buttonLink;
-			if ( config.isEnabled( 'manage/custom-post-types' ) ) {
+			if ( config.isEnabled( 'manage/custom-post-types' ) && postType.api_queryable ) {
 				buttonLink = this.props.postTypeLinks[ postTypeSlug ];
 			}
 


### PR DESCRIPTION
If a post type is not API queryable, we should not display the "Add" button, as if a user were to try to create a new post in the post editor for this post type, it would fail upon saving.

Before|After
---|---
![before](https://cloud.githubusercontent.com/assets/1779930/16898020/b2087b70-4b7b-11e6-860f-11896dc749ee.png)|![after](https://cloud.githubusercontent.com/assets/1779930/16898019/b205ac74-4b7b-11e6-8171-5b9d8249bbb5.png)

__Testing instructions:__

For a site using a non-queryable post type (e.g. Confit theme's "Menu Items"), ensure that in the My Sites sidebar that no "Add" button is shown in to the post type's menu item.

1. Navigate to My Sites
2. Switch to a site where a non-queryable post type exists
3. Note that no Add link is shown in the post type's menu item

/cc @timmyc 

Test live: https://calypso.live/?branch=fix/cpt-api-non-queryable