### PR TITLE
Support User: User data defaults to `false` instead of `undefined`

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -50,7 +50,7 @@ communityTranslatorJumpstart = {
 
 		currentUser = user.get();
 
-		if ( 'en' === currentUser.localeSlug || ! currentUser.localeSlug ) {
+		if ( ! currentUser || 'en' === currentUser.localeSlug || ! currentUser.localeSlug ) {
 			return false;
 		}
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -52,6 +52,8 @@ User.prototype.initialize = function() {
 	this.on( 'change', this.checkVerification.bind( this ) );
 
 	if ( isSupportUserSession() ) {
+		this.data = false;
+
 		supportUserBoot();
 		this.fetch();
 


### PR DESCRIPTION
**This is a fix for support user, currently broken.**

This change sets the user data to `false` when the session is a support user session, rather than leaving it as `undefined` which caused an error in the community translator jumpstart.

This change also adds a condition to exit the community translator jumpstart if no user is found, preventing the exception which could halt the boot process.

Support user starts Calypso with no user, which currently causes the `communityTranslatorJumpstart` function to fail with an exception `Cannot read property 'localeSlug' of undefined` - see #3843.

Any code that used this function (usually indirectly via `translate`) was breaking on the exception.

PR #6645 introduced a notices middleware which indirectly called the translator jumpstart somewhere in the Calypso boot process, before the support user was loaded. The localeSlug error thus broke the Calypso boot process.

Closes #3843

Test live: https://calypso.live/?branch=fix/support-user/localeslug-error

cc @deBhal @rralian @yoavf @dllh 