### PR TITLE
Components: Display multiple actions under ellipsis menu

### DIFF
--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -10,6 +10,7 @@ import { stub } from 'sinon';
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+import EmptyComponent from 'test/helpers/react/empty-component';
 
 describe( 'LoginTest', function() {
 	let Login, loginStub, page, React, ReactDom, ReactInjection, TestUtils;
@@ -17,6 +18,7 @@ describe( 'LoginTest', function() {
 	useFakeDom.withContainer();
 	useMockery( ( mockery ) => {
 		loginStub = stub();
+		mockery.registerMock( 'components/notice', EmptyComponent );
 		mockery.registerMock( 'lib/oauth-store/actions', {
 			login: loginStub
 		} );

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -75,18 +75,12 @@ const NoticesList = React.createClass( {
 		//This is an interim solution for displaying both notices from redux store
 		//and from the old component. When all notices are moved to redux store, this component
 		//needs to be updated.
-		noticesList = noticesList.concat( this.props.storeNotices.map( function( notice, index ) {
-			return (
-				<Notice
-					key={ 'notice-' + index }
-					status={ notice.status }
-					duration = { notice.duration || null }
-					showDismiss={ notice.showDismiss }
-					onDismissClick={ this.props.removeNotice.bind( this, notice.noticeId ) }
-					text={ notice.text }>
-				</Notice>
-			);
-		}, this ) );
+		noticesList = noticesList.concat( this.props.storeNotices.map( ( notice, index ) => (
+			<Notice
+				key={ 'notice-' + index }
+				onDismissClick={ this.props.removeNotice.bind( this, notice.noticeId ) }
+				{ ...notice } />
+		) ) );
 
 		if ( ! noticesList.length ) {
 			return null;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -150,6 +150,19 @@ a.notice__action {
 	text-decoration: none;
 	white-space: nowrap;
 
+	.gridicon {
+		margin-left: 8px;
+		opacity: 0.7;
+	}
+
+	@include breakpoint( "<480px" ) {
+		margin: 0;
+		justify-content: flex-end;
+	}
+}
+
+a.notice__action,
+.notice__content + .ellipsis-menu {
 	.is-success &,
 	.is-error &,
 	.is-warning &,
@@ -162,19 +175,9 @@ a.notice__action {
 	.is-warning & { background: darken( $alert-yellow, 15 ); }
 	.is-info & { background: darken( $blue-wordpress, 15 ); }
 
-	.gridicon {
-		margin-left: 8px;
-		opacity: 0.7;
-	}
-
 	&:hover,
 	&:focus {
 		background: rgba( 255, 255, 255, 0.2 );
-	}
-
-	@include breakpoint( "<480px" ) {
-		margin: 0;
-		justify-content: flex-end;
 	}
 }
 
@@ -243,4 +246,10 @@ a.notice__action {
 			opacity: 1;
 		}
 	}
+}
+
+.notice .ellipsis-menu__toggle {
+	color: currentColor;
+	padding-left: 13px;
+	padding-right: 13px;
 }

--- a/client/my-sites/upgrades/components/domain-warnings/test/index.js
+++ b/client/my-sites/upgrades/components/domain-warnings/test/index.js
@@ -11,19 +11,21 @@ import TestUtils from 'react-addons-test-utils';
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
 import { type as domainTypes } from 'lib/domains/constants';
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+import EmptyComponent from 'test/helpers/react/empty-component';
 
 describe( 'index', () => {
-	let DomainWarnings;
+	let DomainWarnings, Notice;
 
 	useFakeDom();
 
 	useMockery( mockery => {
 		mockery.registerMock( 'lib/analytics', {} );
+		mockery.registerMock( 'components/ellipsis-menu', EmptyComponent );
 		DomainWarnings = require( '../' );
+		Notice = require( 'components/notice' );
 	} );
 
 	beforeEach( () => {

--- a/client/my-sites/upgrades/domain-management/edit/test/mapped-domain.js
+++ b/client/my-sites/upgrades/domain-management/edit/test/mapped-domain.js
@@ -9,6 +9,7 @@ import sinon from 'sinon';
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+import EmptyComponent from 'test/helpers/react/empty-component';
 
 describe( 'mapped-domain', () => {
 	let React,
@@ -31,7 +32,9 @@ describe( 'mapped-domain', () => {
 	} );
 
 	useFakeDom.withContainer();
-	useMockery();
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'components/notice', EmptyComponent );
+	} );
 
 	before( () => {
 		React = require( 'react' );

--- a/client/post-editor/editor-sharing/test/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/test/publicize-connection.jsx
@@ -9,6 +9,8 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+import EmptyComponent from 'test/helpers/react/empty-component';
 
 /**
  * Module variables
@@ -26,6 +28,9 @@ describe( 'PublicizeConnection', function() {
 	let PublicizeConnection;
 
 	useFakeDom();
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'components/notice', EmptyComponent );
+	} );
 
 	before( () => {
 		PublicizeConnection = require( '../publicize-connection' );

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -18,20 +18,47 @@ export function removeNotice( noticeId ) {
 	};
 }
 
+/**
+ * Returns an action object used in signalling that a global notice is to be
+ * created.
+ *
+ * @param  {String}   status                    Notice status (e.g. is-success)
+ * @param  {String}   text                      Notice text
+ * @param  {Object}   options                   Notice options
+ * @param  {String}   options.id                Custom notice ID
+ * @param  {Number}   options.duration          Notice duration (milliseconds),
+ *                                              defaulting to shown forever
+ * @param  {Boolean}  options.showDismiss       Enable user to dismiss notice,
+ *                                              defaulting to true
+ * @param  {Boolean}  options.isPersistent      Whether notice should continue
+ *                                              to show after navigating
+ * @param  {Boolean}  options.displayOnNextPage Whether notice should be shown
+ *                                              on the next screen
+ * @param  {Object[]} options.actions           Notice actions
+ * @return {Object}                             Action object
+ */
 export function createNotice( status, text, options = {} ) {
-	const notice = {
-		noticeId: options.id || uniqueId(),
-		duration: options.duration,
-		showDismiss: ( typeof options.showDismiss === 'boolean' ? options.showDismiss : true ),
-		isPersistent: options.isPersistent || false,
-		displayOnNextPage: options.displayOnNextPage || false,
-		status: status,
-		text: text
-	};
+	const {
+		id: noticeId = uniqueId(),
+		duration,
+		showDismiss = true,
+		isPersistent,
+		displayOnNextPage,
+		actions
+	} = options;
 
 	return {
 		type: NOTICE_CREATE,
-		notice: notice
+		notice: {
+			noticeId,
+			duration,
+			showDismiss,
+			isPersistent,
+			displayOnNextPage,
+			actions,
+			status,
+			text
+		}
 	};
 }
 

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -59,20 +59,25 @@ export function onPostRestoreFailure( dispatch, action, getState ) {
 	dispatch( errorNotice( message ) );
 }
 
-export function onPostSaveSuccess( dispatch, action ) {
-	let text;
-	switch ( action.post.status ) {
+export function onPostSaveSuccess( dispatch, { post, savedPost } ) {
+	let text, actions;
+	switch ( post.status ) {
 		case 'trash':
 			text = translate( 'Post successfully moved to trash' );
 			break;
 
 		case 'publish':
 			text = translate( 'Post successfully published' );
+			actions = [ {
+				href: savedPost.URL,
+				text: translate( 'View', { context: 'verb' } ),
+				external: true
+			} ];
 			break;
 	}
 
 	if ( text ) {
-		dispatch( successNotice( text ) );
+		dispatch( successNotice( text, { actions } ) );
 	}
 }
 

--- a/client/state/notices/test/actions.js
+++ b/client/state/notices/test/actions.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { NOTICE_CREATE, NOTICE_REMOVE } from 'state/action-types';
-import { removeNotice, successNotice, errorNotice } from '../actions';
+import { removeNotice, successNotice, errorNotice, createNotice } from '../actions';
 
 describe( 'actions', function() {
 	describe( 'removeNotice()', function() {
@@ -53,6 +53,51 @@ describe( 'actions', function() {
 				text,
 				status: 'is-error'
 			} );
+		} );
+	} );
+
+	describe( 'createNotice()', () => {
+		it( 'should return an action object', () => {
+			const action = createNotice( 'is-success', 'Success!', {
+				id: 'example-notice',
+				duration: 4000,
+				showDismiss: false,
+				isPersistent: true,
+				displayOnNextPage: true,
+				actions: [ {
+					text: 'View',
+					href: 'https://example.com'
+				} ]
+			} );
+
+			expect( action ).to.eql( {
+				type: NOTICE_CREATE,
+				notice: {
+					status: 'is-success',
+					text: 'Success!',
+					noticeId: 'example-notice',
+					duration: 4000,
+					showDismiss: false,
+					isPersistent: true,
+					displayOnNextPage: true,
+					actions: [ {
+						text: 'View',
+						href: 'https://example.com'
+					} ]
+				}
+			} );
+		} );
+
+		it( 'should default to an auto-generated ID', () => {
+			const action = createNotice( 'is-success', 'Success!' );
+
+			expect( action.notice.noticeId ).to.not.be.empty;
+		} );
+
+		it( 'should default to showing dismiss', () => {
+			const action = createNotice( 'is-success', 'Success!' );
+
+			expect( action.notice.showDismiss ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/notices/test/middleware.js
+++ b/client/state/notices/test/middleware.js
@@ -212,14 +212,22 @@ describe( 'middleware', () => {
 			it( 'should dispatch success notice for publish', () => {
 				onPostSaveSuccess( dispatch, {
 					type: POST_SAVE_SUCCESS,
-					post: { status: 'publish' }
+					post: { status: 'publish' },
+					savedPost: {
+						URL: 'https://example.com/example-post'
+					}
 				} );
 
 				expect( dispatch ).to.have.been.calledWithMatch( {
 					type: NOTICE_CREATE,
 					notice: {
 						status: 'is-success',
-						text: 'Post successfully published'
+						text: 'Post successfully published',
+						actions: [ {
+							href: 'https://example.com/example-post',
+							text: 'View',
+							external: true
+						} ]
 					}
 				} );
 			} );


### PR DESCRIPTION
This pull request seeks to enhance both the notices state and `<Notice />` component to render actions associated with a notice. Currently, the behavior is such that if two or more actions (counting Dismiss) are to be shown, an ellipsis menu is shown instead. If only a dismiss or only a single action is to be shown, it will be displayed inline.

![Notice ellipsis](https://cloud.githubusercontent.com/assets/1779930/16904458/d3d239f0-4c4b-11e6-89fa-733e46a549b8.png)

__Testing Instructions:__

1. Navigate to the [custom post types drafts screen](http://calypso.localhost:3000/types/post/drafts)
2. Assuming a draft exists, select Publish under the draft item action menu
3. After the post has published, note that a success notice is displayed with an ellipsis menu containing View and Dismiss options
4. Note that both View and Dismiss behave as expected

/cc @mtias 

Ref: p1467905764000500-slack-calypso-design

Test live: https://calypso.live/?branch=add/state-notices-actions