### PR TITLE
GuidedTours: set A/B test to `0` for now

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -49,9 +49,9 @@ module.exports = {
 	guidedTours: {
 		datestamp: '20160603',
 		variations: {
-			original: 34,
-			guided: 50,
-			calypsoOnly: 16
+			original: 100,
+			guided: 0,
+			calypsoOnly: 0
 		},
 		defaultVariation: 'original',
 		allowExistingUsers: true


### PR DESCRIPTION
This concludes the GuidedTours A/B test for the time being. 


Test live: https://calypso.live/?branch=update/guided-tours-abtest