### PR TITLE
Themes: Parse key:value filter pairs in the search box

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -14,12 +14,9 @@ import ThemesList from 'components/themes-list';
 import StickyPanel from 'components/sticky-panel';
 import analytics from 'lib/analytics';
 import buildUrl from 'lib/mixins/url-search/build-url';
-import urlSearch from 'lib/mixins/url-search';
 import config from 'config';
 
 const ThemesSelection = React.createClass( {
-	mixins: [ urlSearch ],
-
 	propTypes: {
 		selectedSite: PropTypes.oneOfType( [
 			PropTypes.object,
@@ -38,6 +35,16 @@ const ThemesSelection = React.createClass( {
 		return {
 			tier: this.props.tier || ( config.isEnabled( 'upgrades/premium-themes' ) ? 'all' : 'free' )
 		};
+	},
+
+	doSearch( keywords ) {
+		const searchURL = buildUrl( window.location.href, keywords );
+
+		if ( this.props.search && keywords ) {
+			page.replace( searchURL );
+		} else {
+			page( searchURL );
+		}
 	},
 
 	onMoreButtonClick( theme, resultsRank ) {


### PR DESCRIPTION
Addresses #6775 

- [ ] Parse `key: value` filter pairs from search box using regex
- [ ] Add filter values to URL following scheme in #6602 
- [ ] Parse filter values from the URL in the themes controller and pass to search API call (use D2284-code)
- [ ] Add `key:` back on to the parsed `values` (using a static table) and pass down to search box in `search` prop