### PR TITLE
Theme Sheets: added "hiding" class to hide content with a highly specific CSS class.

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -382,3 +382,9 @@
 		background: $gray-light;
 	}
 }
+
+.theme__sheet-content-presentation-image {
+	// This is used in conjunction with the theme content output.
+	// NOT to be used anywhere in Calypso UI.
+  display: none;
+}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -386,5 +386,5 @@
 .theme__sheet-content-presentation-image {
 	// This is used in conjunction with the theme content output.
 	// NOT to be used anywhere in Calypso UI.
-  display: none;
+	display: none;
 }


### PR DESCRIPTION
This PR adds a single CSS rule to allow specific parts of the Theme Showcase sheet contents to be hidden.

### Why?

The old showcases don't have any notion about the screenshots of the current theme sheet, so the way to include them was to simply include the main screenshot in `the_content` body.
The new Calypso theme showcase sheets instead read the screenshots field from the API itself, and show it in a dedicated UI.
Adding the `<p class="theme__sheet-content-presentation-image">` paragraph to wrap that first image in `the_content` allows a flexible way to remove the image when we thing it's not needed, while also **keeping backward compatibility**.

_Note: the screenshot in the right column in Calypso is where we can then enhance the UI: longer screenshots, multiple screenshots, etc._

### How to test?

1. Open one of the themes that have already had the tag added (see list in the first comment below) with the code from this PR
2. Notice that the first image disappeared.
3. Check the old showcases https://theme.wordpress.com and https://wordpress.com/themes for the same theme and ensure the screenshot is still present, with no other visual issue.

Does this approach work? (apart from having to edit ~400 themes)

---

Before:

![screen shot 2016-07-18 at 16 38 21](https://cloud.githubusercontent.com/assets/4389/16920605/2ce206be-4d06-11e6-9fc4-549e36fa8453.png)

After:

![screen shot 2016-07-18 at 16 38 57](https://cloud.githubusercontent.com/assets/4389/16920615/37fe1fe2-4d06-11e6-9a98-ae3a022280e0.png)

### Notes

* WordPress has [wpautop()](https://codex.wordpress.org/Function_Reference/wpautop) function that adds the `p`s if missing. 
* `wpautop()` doesn't wrap if `p` is already present.

Test live: https://calypso.live/?branch=try/themes/sheet-hide-first-content-image

/cc @ianstewart 