### PR TITLE
Framework: Remove uses of process.nextTick from non-test code

### DIFF
--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import noop from 'lodash/noop';
+import { defer, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ export default React.createClass( {
 
 	onDialogDidLeave: function() {
 		if ( this.props.onClosed ) {
-			process.nextTick( this.props.onClosed );
+			defer( this.props.onClosed );
 		}
 	},
 

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -7,7 +7,8 @@ const assign = require( 'lodash/assign' ),
 	forEach = require( 'lodash/forEach' ),
 	isEqual = require( 'lodash/isEqual' ),
 	forOwn = require( 'lodash/forOwn' ),
-	clone = require( 'lodash/clone' );
+	clone = require( 'lodash/clone' ),
+	defer = require( 'lodash/defer' );
 
 /**
  * Internal dependencies
@@ -276,7 +277,7 @@ function normalizePost( feedId, postId, post ) {
 	const normalizedPost = runFastRules( post );
 	setPost( postId, normalizedPost );
 
-	process.nextTick( () => {
+	defer( function() {
 		runSlowRules( normalizedPost ).then( setPost.bind( null, postId ) );
 	} );
 }

--- a/client/lib/scroll-to/index.js
+++ b/client/lib/scroll-to/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import TWEEN from 'tween.js';
+import { defer } from 'lodash';
 
 function getCurrentScroll( container ) {
 	if ( container && container.scrollTop !== undefined ) {
@@ -11,7 +12,7 @@ function getCurrentScroll( container ) {
 		};
 	}
 
-	let x = window.pageXOffset || document.documentElement.scrollLeft,
+	const x = window.pageXOffset || document.documentElement.scrollLeft,
 		y = window.pageYOffset || document.documentElement.scrollTop;
 	return { x: x, y: y };
 }
@@ -39,7 +40,7 @@ function animate() {
 	if ( 'undefined' !== typeof window && window.requestAnimationFrame ) {
 		window.requestAnimationFrame( animate );
 	} else {
-		process.nextTick( animate );
+		defer( animate );
 	}
 
 	TWEEN.update();
@@ -57,7 +58,7 @@ function animate() {
  * @param {HTMLElement} options.container - the container to scroll instead of window, if any
  */
 function scrollTo( options ) {
-	var currentScroll = getCurrentScroll( options.container ),
+	const currentScroll = getCurrentScroll( options.container ),
 		tween = new TWEEN.Tween( currentScroll )
 		.easing( options.easing || TWEEN.Easing.Circular.Out )
 		.to( { x: options.x, y: options.y }, options.duration || 500 )

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -7,7 +7,7 @@ import page from 'page';
 import url from 'url';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import startsWith from 'lodash/startsWith';
+import { defer, startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -99,7 +99,7 @@ const ReaderSidebar = React.createClass( {
 	},
 
 	highlightNewTag( tag ) {
-		process.nextTick( function() {
+		defer( function() {
 			page( '/tag/' + tag.slug );
 			window.scrollTo( 0, 0 );
 		} );


### PR DESCRIPTION
The `process.nextTick` polyfill breaks in IE and Edge when using the `webpack-dev-server` and the `eval` devtool. 

Also, the polyfill is slower than necessary. The  replacement uses faster techniques than  in browsers that support it, which is pretty much all of them now.

Test live: https://calypso.live/?branch=fix/no-more-process-next