### PR TITLE
Editor: Fix Pages always being marked as dirty

### DIFF
--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -342,6 +342,10 @@ export const isEditedPostDirty = createSelector(
 		const edits = getPostEdits( state, siteId, postId );
 
 		return some( edits, ( value, key ) => {
+			if ( key === 'type' ) {
+				return false;
+			}
+
 			if ( post ) {
 				return post[ key ] !== value;
 			}

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -933,7 +933,7 @@ describe( 'selectors', () => {
 			expect( isDirty ).to.be.false;
 		} );
 
-		it( 'should return true if newly edited with custom type', () => {
+		it( 'should return false if newly edited with custom type', () => {
 			const isDirty = isEditedPostDirty( {
 				posts: {
 					items: {},
@@ -947,7 +947,7 @@ describe( 'selectors', () => {
 				}
 			}, 2916284 );
 
-			expect( isDirty ).to.be.true;
+			expect( isDirty ).to.be.false;
 		} );
 
 		it( 'should return false if no saved post and value matches default for new post', () => {


### PR DESCRIPTION
Fixes #6859 where the page editor thinks the page being edited always has unsaved changes, and therefore prompts the user to confirm navigating away from the page.

This effectively reverts 0556ad0 from #6548, where the bug was introduced.

## To test

1. Start at URL: http://calypso.localhost:3000/page
2. Select a site
3. Without making any changes to the page, attempt to leave (either by clicking another link or closing the window)

Test live: https://calypso.live/?branch=fix/editor/page-always-dirty