### PR TITLE
State: Jetpack Connect

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -166,11 +166,16 @@ const LoggedInForm = React.createClass( {
 	displayName: 'LoggedInForm',
 
 	componentWillMount() {
-		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const { queryObject, autoAuthorize } = this.props.jetpackConnectAuthorize;
 		this.props.recordTracksEvent( 'calypso_jpc_auth_view' );
 		if ( ! this.props.isAlreadyOnSitesList &&
 			! queryObject.already_authorized &&
-			( this.props.calypsoStartedConnection || this.props.isSSO || queryObject.new_user_started_connection )
+			(
+				this.props.calypsoStartedConnection ||
+				this.props.isSSO ||
+				queryObject.new_user_started_connection ||
+				autoAuthorize
+			)
 		) {
 			debug( 'Authorizing automatically on component mount' );
 			return this.props.authorize( queryObject );

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -112,9 +112,9 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE:
 			if ( isEmpty( action.error ) && action.data ) {
 				const { plans_url, activate_manage } = action.data;
-				return Object.assign( {}, state, { authorizeError: false, authorizeSuccess: true, plansUrl: plans_url, siteReceived: false, activateManageSecret: activate_manage } );
+				return Object.assign( {}, state, { authorizeError: false, authorizeSuccess: true, autoAuthorize: false, plansUrl: plans_url, siteReceived: false, activateManageSecret: activate_manage } );
 			}
-			return Object.assign( {}, state, { isAuthorizing: false, authorizeError: action.error, authorizeSuccess: false } );
+			return Object.assign( {}, state, { isAuthorizing: false, authorizeError: action.error, authorizeSuccess: false, autoAuthorize: false } );
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST:
 			const updateQueryObject = omit( state.queryObject, '_wp_nonce', 'secret', 'scope' );
 			return Object.assign( {}, omit( state, 'queryObject' ), { siteReceived: true, isAuthorizing: false, queryObject: updateQueryObject } );
@@ -132,9 +132,9 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false } );
 		case JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE:
 			if ( ! isEmpty( action.error ) ) {
-				return Object.assign( {}, state, { isAuthorizing: false, authorizeSuccess: false, authorizeError: true } );
+				return Object.assign( {}, state, { isAuthorizing: false, authorizeSuccess: false, authorizeError: true, autoAuthorize: false } );
 			}
-			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, userData: action.userData, bearerToken: action.data.bearer_token } );
+			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, autoAuthorize: true, userData: action.userData, bearerToken: action.data.bearer_token } );
 		case JETPACK_CONNECT_REDIRECT_WP_ADMIN:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
 		case DESERIALIZE:

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -25,6 +25,7 @@ export const jetpackConnectAuthorizeSchema = {
 				activateManageSecret: { type: 'string' },
 				authorizeError: { type: 'boolean' },
 				authorizeSuccess: { type: 'boolean' },
+				autoAuthorize: { type: 'boolean' },
 				isActivating: { type: 'boolean' },
 				isAuthorizing: { type: 'boolean' },
 				isRedirectingToWpAdmin: { type: 'boolean' },


### PR DESCRIPTION
In #6634, I removed `autoAuthorize` from Jetpack Connect state tree, thinking we would no longer need it.

Why do we need it back?
A new flow we are testing will not make use of `calypsoStartedConnection` because in this flow, the connection is not started in Calypso. We'll need to switch on autoAuthorize instead.

To test:
- Checkout this branch, and ensure that all connections made from calypso.localhost:3000/jetpack still work as expected
- Ensure that SSO still works as expected
- Ping me if you need instructions to test the new flow, as it requires changes on the server

cc: @johnHackworth, @ebinnion 

Test live: https://calypso.live/?branch=update/jetpack-auto-authorize