### PR TITLE
Enable first view on staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -91,7 +91,7 @@
 		"settings/security/scan": true,
 		"support-user": true,
 		"sync-handler": true,
-		"ui/first-view": false,
+		"ui/first-view": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
This pull request enables the [Stats First View overlay](https://github.com/Automattic/wp-calypso/pull/6717) on staging.

It is already available on wpcalypso, and shortly after merging this PR, we are going to enable it in production for users eligible for this feature in [our A/B test](https://github.com/Automattic/wp-calypso/pull/6835).

Test live: https://calypso.live/?branch=add/first-view-on-staging