### PR TITLE
First-View: Update z-index to fix FF/IE display issues

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -128,6 +128,7 @@ $z-layers: (
 		'popover.is-dialog-visible': 100300,
 		'body .webui-popover': 100300,
 		'.fullscreen-fader': 200000,
+		'.first-view': 2000010,
 		'.guided-tours__overlay': 200050,
 		'.guided-tours__step': 201000,
 		'#habla_window_div.habla_window_div_base': 99999999 //olark

--- a/client/components/first-view/style.scss
+++ b/client/components/first-view/style.scss
@@ -29,6 +29,7 @@
 		bottom: 0;
 		top: 0;
 	width: 100%;
+	z-index: z-index( 'root', '.first-view' );
 
 	&.is-visible {
 		.first-view__content {


### PR DESCRIPTION
Before (in Firefox and IE11):

![image](https://cloud.githubusercontent.com/assets/363749/16856390/747327ee-49df-11e6-8fd7-221e874e5406.png)

After: 

![image](https://cloud.githubusercontent.com/assets/363749/16856407/8643e9c2-49df-11e6-8b2d-8a3d81b92d1b.png)

To test: visit the Stats page. If it doesn't show, you may have already dismissed the dialog, try visiting the Stats page with a new user.

Test live: https://calypso.live/?branch=fix/first-view/z-index

Migrated from #6805