### PR TITLE
Mixins: Remove component from protect-form formsChanged on unmount

### DIFF
--- a/client/lib/mixins/protect-form/index.js
+++ b/client/lib/mixins/protect-form/index.js
@@ -1,13 +1,18 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:protect-form' ),
-	page = require( 'page' ),
-	i18n = require( 'i18n-calypso' );
+import debugModule from 'debug';
+import page from 'page';
+import i18n from 'i18n-calypso';
+import { without } from 'lodash';
 
-var confirmText = i18n.translate( 'You have unsaved changes. Are you sure you want to leave this page?' ),
-	beforeUnloadText = i18n.translate( 'You have unsaved changes.' ),
-	formsChanged = [];
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:protect-form' );
+const confirmText = i18n.translate( 'You have unsaved changes. Are you sure you want to leave this page?' );
+const beforeUnloadText = i18n.translate( 'You have unsaved changes.' );
+let formsChanged = [];
 
 module.exports = {
 	mixin: {
@@ -16,6 +21,7 @@ module.exports = {
 		},
 		componentWillUnmount: function() {
 			window.removeEventListener( 'beforeunload', this.warnIfChanged );
+			formsChanged = without( formsChanged, this );
 		},
 		warnIfChanged: function( event ) {
 			if ( ! formsChanged.length ) {


### PR DESCRIPTION
Partially addresses #6869 

This pull request seeks to change the behavior of the `protect-form` mixin such that it removes the component from the internal `formsChanged` array as the component is unmounted, to avoid situations where the user will be prompted to save their changes after the component has already unmounted.

This only partially addresses #6869 since the editor is marking as changed in situations where it should not be (as unmounting, when content is empty, not properly comparing HTML and Visual edited content). These issues should be remedied separately.

__Testing instructions:__

Repeat the steps to reproduce in #6869. Note that you are prompted with unsaved changes, but after navigating away, you are not prompted on subsequent navigations. Ensure also that existing `protect-form` usage is unaffected.

cc @rralian @nylen 

Test live: https://calypso.live/?branch=fix/6869-editor-switch-prompt