### PR TITLE
Reader: Fix proptypes on reader/follow-button

### DIFF
--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -16,9 +16,8 @@ const ReaderFollowButton = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {
-		following: React.PropTypes.bool.isRequired,
 		onFollowToggle: React.PropTypes.func,
-		railcar: React.PropTypes.string
+		railcar: React.PropTypes.object
 	},
 
 	recordFollowToggle( isFollowing ) {


### PR DESCRIPTION
Following is only a prop on one kind of the button, so remove it. The nested component will yell for us.
Also, railcar is an object, not a string

Test live: https://calypso.live/?branch=fix/busted-railcar-search-byline