### PR TITLE
Jetpack Sync: Enable in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -24,6 +24,7 @@
 		"help": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,
+		"jetpack/sync-panel": true,
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,


### PR DESCRIPTION
Let's ship the Jetpack sync panel to staging

To test:

- Checkout `update/jetpack-sync-status-to-staging` branch
- In terminal, `CALYPSO_ENV=state make run`
- Go to `/settings/general/$site` where `$site` is on latest `branch-4.2` of Jetpack
- Make sure you see Jetpack sync panel

cc @lezama for code review

Test live: https://calypso.live/?branch=update/jetpack-sync-status-to-staging