### PR TITLE
Editor: fix warning on clicking post delete button.

### DIFF
--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -49,6 +49,9 @@ export default React.createClass( {
 
 	onSendToTrash() {
 		let message;
+		if ( this.state.isTrashing ) {
+			return;
+		}
 
 		if ( this.props.post.type === 'page' ) {
 			message = this.translate( 'Are you sure you want to trash this page?' );
@@ -80,7 +83,7 @@ export default React.createClass( {
 			<Button
 				borderless
 				className={ classes }
-				onClick={ ! this.state.isTrashing && this.onSendToTrash }
+				onClick={ this.onSendToTrash }
 				onMouseEnter={ () => this.setState( { tooltip: true } ) }
 				onMouseLeave={ () => this.setState( { tooltip: false } ) }
 				aria-label={ tooltipText }


### PR DESCRIPTION
Currently when you click the delete post button within the editor, and confirm the delete action, a warning is shown:

<img width="1133" alt="blog_posts_ _testingtimmy2_wordpress_com_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/16933349/752e346a-4d01-11e6-9cdb-f0a7dab1b198.png">

This branch adds a quick refactor to fix the warning.

__To Test__
- Open up a published post in the editor
- Click the trash icon
- Click Move to Trash in the dialog
- Verify no warning is shown

Test live: https://calypso.live/?branch=fix/editor/editor-delete-post-warning