### PR TITLE
Editor: Prevent switching editor tabs from marking content as dirty

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -471,7 +471,23 @@ PostEditStore = {
 	},
 
 	isDirty: function() {
-		return _post !== _savedPost || _rawContent !== _initialRawContent;
+		debug(
+			'isDirty post?%s rawContent?%s initial=%s content=%s',
+			_post !== _savedPost,
+			_rawContent !== _initialRawContent,
+			_initialRawContent,
+			_rawContent
+		);
+		if ( _post !== _savedPost ) {
+			return true;
+		}
+		if ( _rawContent !== _initialRawContent ) {
+			return (
+				! isContentEmpty( _rawContent ) ||
+				! isContentEmpty( _initialRawContent )
+			);
+		}
+		return false;
 	},
 
 	isNew: function() {

--- a/client/lib/posts/test/post-edit-store.js
+++ b/client/lib/posts/test/post-edit-store.js
@@ -570,6 +570,56 @@ describe( 'post-edit-store', function() {
 
 			assert( PostEditStore.isDirty() );
 		} );
+
+		it( 'returns false if content changes from empty to <p><br></p>', function() {
+			dispatcherCallback( {
+				action: {
+					type: 'RECEIVE_POST_TO_EDIT',
+					post: {}
+				}
+			} );
+
+			dispatcherCallback( {
+				action: {
+					type: 'EDIT_POST_RAW_CONTENT',
+					content: ''
+				}
+			} );
+
+			dispatcherCallback( {
+				action: {
+					type: 'EDIT_POST_RAW_CONTENT',
+					content: '<p><br data-mce-bogus="1"></p>'
+				}
+			} );
+
+			assert( ! PostEditStore.isDirty() );
+		} );
+
+		it( 'returns false if content changes from <p><br></p> to empty', function() {
+			dispatcherCallback( {
+				action: {
+					type: 'RECEIVE_POST_TO_EDIT',
+					post: {}
+				}
+			} );
+
+			dispatcherCallback( {
+				action: {
+					type: 'EDIT_POST_RAW_CONTENT',
+					content: '<p><br data-mce-bogus="1"></p>'
+				}
+			} );
+
+			dispatcherCallback( {
+				action: {
+					type: 'EDIT_POST_RAW_CONTENT',
+					content: ''
+				}
+			} );
+
+			assert( ! PostEditStore.isDirty() );
+		} );
 	} );
 
 	describe( '#isSaveBlocked()', function() {


### PR DESCRIPTION
Fixes #6869 where switching between the Visual and HTML tabs would cause the post/page being edited to be marked as dirty.

This is because our `wpautop` filter and TinyMCE apply changes to empty content that makes it look like this:  `<p><br data-mce-bogus="1"></p>`

We have an `isContentEmpty` function that accounts for this specific string, and we should use it to make sure that truly empty content is treated the same as the special empty content string above.

This works well when the editor content is actually empty.  Typing any text into the editor then switching tabs may still cause the post to be marked as dirty, but the fix for this situation is more involved because we will need to judiciously apply `wpautop` (right now we are not consistent about how this is done).

The debug statement added here will come in handy for future related changes.

## To test

1. Start a new post or page
2. Do not add any content, but switch between the Visual and HTML editor
3. Refresh the page and verify that you are prompted to save non-existent changes in master but not in this branch

/cc @aduth - I think you had a different idea about how to fix this, but I feel more comfortable with this simple approach, though it only works well with empty post content.

Test live: https://calypso.live/?branch=fix/editor/dirty-on-switch-tabs