### PR TITLE
JPC: fix calypso site reconnections

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -165,6 +165,12 @@ const LoggedOutForm = React.createClass( {
 const LoggedInForm = React.createClass( {
 	displayName: 'LoggedInForm',
 
+	getInitialState() {
+		return {
+			hasRefetchedSites: false
+		};
+	},
+
 	componentWillMount() {
 		const { queryObject, autoAuthorize } = this.props.jetpackConnectAuthorize;
 		this.props.recordTracksEvent( 'calypso_jpc_auth_view' );
@@ -179,6 +185,10 @@ const LoggedInForm = React.createClass( {
 		) {
 			debug( 'Authorizing automatically on component mount' );
 			return this.props.authorize( queryObject );
+		}
+		if ( this.props.isAlreadyOnSitesList && ! this.state.hasRefetchedSites && ! this.props.isFetchingSites() ) {
+			this.props.requestSites();
+			this.setState( { hasRefetchedSites: true } );
 		}
 	},
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/6875

Until this PR, if your tried to use the new calypso auth screen from wp-admin, you could run into this bug if you were reconnecting your site. You would see a "browse all upgrades" button instead of the expected "approve" one, and clicking it wouldn't start the authorization as expected. 

The problem was that if the site has been connected before, calypso cached site list could contain outdated information about it, and it would treat it as it were still connected. This PR forces a site-list update when we reach that point, so before showing the "browse all upgrades" button, we first make sure that the site is already connected for real, and if it's not, we show the approval button as expected.

Before:
![untitled screencast 20](https://cloud.githubusercontent.com/assets/1554855/16946650/fce4fe62-4daa-11e6-9eb7-16a5bf3b466b.gif)

After:
![untitled screencast 19](https://cloud.githubusercontent.com/assets/1554855/16946399/979ed844-4da9-11e6-84b2-1233f3a2d6a8.gif)


How to test
=========
1. You need a jetpack sandbox connected to a .com sandbox to test this. Make sure your .com sandbox redirect all jetpack auth requests to your local calypso. Talk with me or with @roccotripaldi about how to do it if you don't know how.
2. Go to your jetpack sandbox site admin and disconnect the site (which should be previously connected).. Then connect it again. Once you are in calypso, you should see a loader that tells you that we are 'preparing authorization'
3. After some seconds, you should see the "approve" button and you can proceed with the auth.


ping @roccotripaldi @ebinnion 

Test live: https://calypso.live/?branch=fix/jpc-fetch-sites