### PR TITLE
Themes: simplify URLs for free/premium themes

### DIFF
--- a/client/components/data/themes-list-fetcher/index.jsx
+++ b/client/components/data/themes-list-fetcher/index.jsx
@@ -16,6 +16,7 @@ import { hasSiteChanged, isJetpack } from 'state/themes/themes-last-query/select
 import { isLastPage, isFetchingNextPage, getThemesList, isFetchError } from 'state/themes/themes-list/selectors';
 import { getThemeById } from 'state/themes/themes/selectors';
 import { errorNotice } from 'state/notices/actions';
+import config from 'config';
 
 const ThemesListFetcher = React.createClass( {
 	propTypes: {
@@ -73,10 +74,11 @@ const ThemesListFetcher = React.createClass( {
 			onLastPage,
 			site,
 			search,
-			tier,
 		} = props;
 
 		this.onLastPage = onLastPage ? once( onLastPage ) : null;
+
+		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
 		this.props.query( {
 			search,

--- a/client/components/data/themes-list-fetcher/index.jsx
+++ b/client/components/data/themes-list-fetcher/index.jsx
@@ -78,7 +78,7 @@ const ThemesListFetcher = React.createClass( {
 
 		this.onLastPage = onLastPage ? once( onLastPage ) : null;
 
-		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
+		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? props.tier : 'free';
 
 		this.props.query( {
 			search,

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -36,12 +36,12 @@ const themesMeta = {
 	free: {
 		title: 'Free WordPress Themes — WordPress.com',
 		description: 'Discover Free WordPress Themes on the WordPress.com Theme Showcase.',
-		canonicalUrl: 'https://wordpress.com/design/type/free',
+		canonicalUrl: 'https://wordpress.com/design/free',
 	},
 	premium: {
 		title: 'Premium WordPress Themes — WordPress.com',
 		description: 'Discover Premium WordPress Themes on the WordPress.com Theme Showcase.',
-		canonicalUrl: 'https://wordpress.com/design/type/premium',
+		canonicalUrl: 'https://wordpress.com/design/premium',
 	}
 };
 

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -10,7 +10,6 @@ import { makeLayout } from 'controller';
 
 export default function( router ) {
 	if ( config.isEnabled( 'manage/themes' ) ) {
-		router( '/design', makeLayout );
 		router( '/design/:tier(free|premium)?', makeLayout );
 		router( '/design/*', makeLayout ); // Needed so direct hits don't result in a 404.
 	}

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -11,7 +11,7 @@ import { makeLayout } from 'controller';
 export default function( router ) {
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		router( '/design', makeLayout );
-		router( '/design/type/:tier', makeLayout );
+		router( '/design/:tier(free|premium)?', makeLayout );
 		router( '/design/*', makeLayout ); // Needed so direct hits don't result in a 404.
 	}
 }

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -22,12 +22,12 @@ export default function( router ) {
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
 			router( '/design', multiSite, navigation, siteSelection );
+			router( '/design/:tier(free|premium)?', multiSite, navigation, siteSelection );
+			router( '/design/:tier(free|premium)?/:site_id', singleSite, navigation, siteSelection );
 			router( '/design/:site_id', singleSite, navigation, siteSelection );
-			router( '/design/type/:tier', multiSite, navigation, siteSelection );
-			router( '/design/type/:tier/:site_id', singleSite, navigation, siteSelection );
 		} else {
 			router( '/design', loggedOut, makeLayout );
-			router( '/design/type/:tier', loggedOut, makeLayout );
+			router( '/design/:tier(free|premium)?', loggedOut, makeLayout );
 		}
 	}
 }

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -21,12 +21,9 @@ export default function( router ) {
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
-			router( '/design', multiSite, navigation, siteSelection );
 			router( '/design/:tier(free|premium)?', multiSite, navigation, siteSelection );
 			router( '/design/:tier(free|premium)?/:site_id', singleSite, navigation, siteSelection );
-			router( '/design/:site_id', singleSite, navigation, siteSelection );
 		} else {
-			router( '/design', loggedOut, makeLayout );
 			router( '/design/:tier(free|premium)?', loggedOut, makeLayout );
 		}
 	}

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -19,7 +19,7 @@ import { isMobile } from 'lib/viewport';
 
 const ThemesSearchCard = React.createClass( {
 	propTypes: {
-		tier: React.PropTypes.string.isRequired,
+		tier: React.PropTypes.string,
 		select: React.PropTypes.func.isRequired,
 		site: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
@@ -47,6 +47,10 @@ const ThemesSearchCard = React.createClass( {
 
 	getInitialState() {
 		return { isMobile: isMobile() };
+	},
+
+	getDefaultProps() {
+		return { tier: 'all' };
 	},
 
 	getSelectedTierFormatted( tiers ) {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -15,7 +15,6 @@ import StickyPanel from 'components/sticky-panel';
 import analytics from 'lib/analytics';
 import buildUrl from 'lib/mixins/url-search/build-url';
 import urlSearch from 'lib/mixins/url-search';
-import config from 'config';
 
 const ThemesSelection = React.createClass( {
 	mixins: [ urlSearch ],
@@ -31,13 +30,8 @@ const ThemesSelection = React.createClass( {
 		getOptions: React.PropTypes.func,
 		queryParams: PropTypes.object.isRequired,
 		themesList: PropTypes.array.isRequired,
-		getActionLabel: React.PropTypes.func
-	},
-
-	getInitialState: function() {
-		return {
-			tier: this.props.tier || ( config.isEnabled( 'upgrades/premium-themes' ) ? 'all' : 'free' )
-		};
+		getActionLabel: React.PropTypes.func,
+		tier: React.PropTypes.string,
 	},
 
 	onMoreButtonClick( theme, resultsRank ) {
@@ -68,7 +62,7 @@ const ThemesSelection = React.createClass( {
 	onTierSelect( { value: tier } ) {
 		const siteId = this.props.siteId ? `/${this.props.siteId}` : '';
 		const url = `/design${ tier === 'all' ? '' : '/' + tier }${siteId}`;
-		this.setState( { tier } );
+
 		trackClick( 'search bar filter', tier );
 		page( buildUrl( url, this.props.search ) );
 	},
@@ -91,14 +85,14 @@ const ThemesSelection = React.createClass( {
 							site={ site }
 							onSearch={ this.doSearch }
 							search={ this.props.search }
-							tier={ this.state.tier }
+							tier={ this.props.tier }
 							select={ this.onTierSelect } />
 				</StickyPanel>
 				<ThemesData
 						site={ site }
 						isMultisite={ ! this.props.siteId } // Not the same as `! site` !
 						search={ this.props.search }
-						tier={ this.state.tier }
+						tier={ this.props.tier }
 						onRealScroll={ this.trackScrollPage }
 						onLastPage={ this.trackLastPage } >
 					<ThemesList getButtonOptions={ this.props.getOptions }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -67,7 +67,7 @@ const ThemesSelection = React.createClass( {
 
 	onTierSelect( { value: tier } ) {
 		const siteId = this.props.siteId ? `/${this.props.siteId}` : '';
-		const url = `/design/type/${tier}${siteId}`;
+		const url = `/design${ tier === 'all' ? '' : '/' + tier }${siteId}`;
 		this.setState( { tier } );
 		trackClick( 'search bar filter', tier );
 		page( buildUrl( url, this.props.search ) );


### PR DESCRIPTION
Remove the `/type` and `/all` sections from the /design routes, simplifying the URL structure and giving a canonical URL for 'all' themes.

This is a prerequisite for the M5 routing scheme #6602.

**Was**
/design
/design/type/free
/design/type/premium
/design/type/all (same as /design)

**Now**
/design
/design/free
/design/premium

**To Test**
* Enter above URLs logged-in and logged-out
* Try also with site IDs appended
* Check that the _all/free/premium_ dropdown works as expected:
![screen shot 2016-07-19 at 12 12 18](https://cloud.githubusercontent.com/assets/7767559/16947981/14f8a158-4daa-11e6-9e79-3073ff30d673.png)

To test the moved premium-theme guard, set:
`"upgrades/premium-themes": false,`
in `config/development.json`

Test live: https://calypso.live/?branch=modify/themes-urls