### PR TITLE
Plans: Nudge for no branding also to premium users

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -30,6 +30,7 @@ import Timezone from 'components/timezone';
 import JetpackSyncPanel from './jetpack-sync-panel';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { isBusiness } from 'lib/products-values';
+import { FEATURE_NO_BRANDING } from 'lib/plans/constants';
 
 const FormGeneral = React.createClass( {
 	displayName: 'SiteSettingsFormGeneral',
@@ -547,8 +548,9 @@ const FormGeneral = React.createClass( {
 						</CompactCard>
 						{ ! isBusiness( site.plan ) && <UpgradeNudge
 							className="site-settings__footer-credit-nudge"
-							title="Remove the footer credit entirely with Business Plan"
-							message="Upgrade to remove the footer credit, add Google Analytics and more"
+							feature={ FEATURE_NO_BRANDING }
+							title={ this.translate( 'Remove the footer credit entirely with Business Plan' ) }
+							message={ this.translate( 'Upgrade to remove the footer credit, add Google Analytics and more' ) }
 							icon="customize"
 						/> }
 					</div>

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -67,7 +67,7 @@ export default React.createClass( {
 		if ( ! site ) {
 			return false;
 		}
-		if ( feature && hasFeature( feature, site.siteID ) ) {
+		if ( feature && hasFeature( feature, site.ID ) ) {
 			return false;
 		}
 		if ( ! feature && ! isFreePlan( site.plan ) ) {


### PR DESCRIPTION
- Nudge was very dumb. Now it appears also to premium users
- Since nudge was expecting `site.siteID` there is a high chance other nudges were broken, so some others should behave better now.

## Testing
- Go to http://calypso.localhost:3000/settings/general/
- Free site: there should be "remove footer credit" a nudge 
- Premium site: there should be "remove footer credit" a nudge 
- Business site: there should *NO* be "remove footer credit" a nudge 

CC @mtias @rralian 

Test live: https://calypso.live/?branch=update/nudge-feature