### PR TITLE
Plans: parts are not translated

### DIFF
--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -80,6 +80,7 @@ export const requestPlans = () => {
 		dispatch( plansRequestAction() );
 
 		return wpcom
+			.withLocale()
 			.plans()
 			.list( { apiVersion: '1.2' } )
 			.then( data => {


### PR DESCRIPTION
**Old:** Not translated (except plan "Personal" which is loaded in a different way): taglines, descriptions, billing cycle for Free
![screen shot 2016-07-19 at 14 47 06](https://cloud.githubusercontent.com/assets/203408/16950262/b58d48ac-4dbf-11e6-93c4-dc3295055b32.png)

**New:** Everything translated: (Free has been agreed on to be deliberately not translated by the German community)
![screen shot 2016-07-19 at 14 46 41](https://cloud.githubusercontent.com/assets/203408/16950295/d27b0224-4dbf-11e6-98f7-e3563fe4ba87.png)


Test live: https://calypso.live/?branch=fix/plans-translated