### PR TITLE
Domains search: Popover not displaying on mouse click/hover

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -20,6 +20,17 @@ const DomainProductPrice = React.createClass( {
 		requiresPlan: React.PropTypes.bool,
 		domainsWithPlansOnly: React.PropTypes.bool.isRequired
 	},
+
+	getInitialState() {
+		return {
+			premiumPopoverReference: undefined
+		};
+	},
+	componentDidMount() {
+		this.setState( {
+			premiumPopoverReference: this.refs && this.refs.subMessage
+		} );
+	},
 	renderFreeWithPlan() {
 		return (
 			<div
@@ -56,7 +67,7 @@ const DomainProductPrice = React.createClass( {
 				<small className="domain-product-price__premium-text" ref="subMessage">
 					{ this.translate( 'Included in WordPress.com Premium' ) }
 					<PremiumPopover
-						context={ this.refs && this.refs.subMessage }
+						context={ this.state.premiumPopoverReference }
 						bindContextEvents
 						position="bottom left"/>
 				</small>


### PR DESCRIPTION
In the domains results the `Included with WordPress.com Premium` popover isn't working properly, because the `this.refs` is not updated until the `render()` method actually finishes. This means that an `undefined` is passed down to the `PremiumPopover` component.

The result is that the child never binds its `click` and `mouseover` events, which in turns causes the popup to never show up.

This PR tries to fix that by "updating" the `refs` passed down after the rendering finishes and updates the child component `props`.

The fix is not the best way to do that, since it is not a good practice to use `setState` in `componentDidMount` (causes a re-render) and even `eslint` makes sure to warn us.

I would love some feedback what the proper way to fix this would be. 

I am thinking a better way to rectify this issue would be to just pass the text down and have the component render the element that will be shown and have the events attached there.

cc @michaeldcain @coreh @klimeryk @umurkontaci 

Test live: https://calypso.live/?branch=fix/premium-popover-not-visible-on-first-render