### PR TITLE
Plans: Properly pass domain from plans/compare to plans/features

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -89,11 +89,12 @@ export default {
 			productsList = require( 'lib/products-list' )(),
 			analyticsPageTitle = 'Plans > Compare',
 			site = sites.getSelectedSite(),
+			siteDomain = context.params.domain,
 			basePath = route.sectionify( context.path );
 		let baseAnalyticsPath;
 
 		if ( config.isEnabled( 'manage/plan-features' ) ) {
-			return page.redirect( '/plans/features' );
+			return page.redirect( `/plans/features/${ siteDomain || '' }` );
 		}
 
 		if ( site && ! site.isUpgradeable() ) {

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -89,12 +89,12 @@ export default {
 			productsList = require( 'lib/products-list' )(),
 			analyticsPageTitle = 'Plans > Compare',
 			site = sites.getSelectedSite(),
-			siteDomain = context.params.domain,
+			siteDomain = context.params.domain || '',
 			basePath = route.sectionify( context.path );
 		let baseAnalyticsPath;
 
 		if ( config.isEnabled( 'manage/plan-features' ) ) {
-			return page.redirect( `/plans/features/${ siteDomain || '' }` );
+			return page.redirect( `/plans/features/${ siteDomain }` );
 		}
 
 		if ( site && ! site.isUpgradeable() ) {


### PR DESCRIPTION
Fixes #6800

The domain was not passed on while redirecting from /plans/compare to /plans/features.

## Testing
1. start Calypso with ENABLE_FEATURES=manage/plan-features make run
2. try navigating to http://calypso.localhost:3000/plans/compare/:mysite:
3. You should be redirected to http://calypso.localhost:3000/plans/features/:mysite:

CC @rralian @mtias @retrofox 

Test live: https://calypso.live/?branch=fix/plans-compare-redirect