### PR TITLE
Posts: use CPT component to render drafts.

### DIFF
--- a/assets/stylesheets/shared/mixins/_breakpoints.scss
+++ b/assets/stylesheets/shared/mixins/_breakpoints.scss
@@ -3,7 +3,7 @@
 // See https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md#media-queries
 // ==========================================================================
 
-$breakpoints: 480px, 660px, 960px, 1040px, 1280px; // Think very carefully before adding a new breakpoint
+$breakpoints: 480px, 660px, 960px, 1040px, 1280px, 1600px; // Think very carefully before adding a new breakpoint
 
 @mixin breakpoint( $sizes... ){
 	@each $size in $sizes {

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -18,10 +18,11 @@ import PostTypeListPostThumbnail from 'my-sites/post-type-list/post-thumbnail';
 import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellipsis-menu';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
 
-function PostItem( { translate, globalId, post, editUrl, className } ) {
+function PostItem( { translate, globalId, post, editUrl, className, compact } ) {
 	const title = post ? post.title : null;
 	const classes = classnames( 'post-item', className, {
 		'is-untitled': ! title,
+		'is-mini': compact,
 		'is-placeholder': ! globalId
 	} );
 
@@ -51,7 +52,8 @@ PostItem.propTypes = {
 	translate: PropTypes.func,
 	globalId: PropTypes.string,
 	post: PropTypes.object,
-	className: PropTypes.string
+	className: PropTypes.string,
+	compact: PropTypes.bool
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -69,3 +69,21 @@ a.post-item__title-link {
 	margin-top: -1px;
 	margin-right: 6px;
 }
+
+.post-item.is-mini.card.is-compact {
+	padding: 8px 16px;
+
+	.post-item__meta {
+		display: none;
+	}
+
+	.post-item__title {
+		display: inline;
+		font-size: 13px;
+		margin: 0;
+	}
+
+	.post-actions-ellipsis-menu {
+		margin: 0;
+	}
+}

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -42,6 +42,7 @@ class PostActionsEllipsisMenuView extends Component {
 
 		this.props.setPreviewUrl( previewUrl );
 		this.props.setLayoutFocus( 'preview' );
+		this.props.onClick();
 		event.preventDefault();
 	}
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -22,18 +22,21 @@ class PostActionsEllipsisMenuView extends Component {
 		translate: PropTypes.func.isRequired,
 		status: PropTypes.string,
 		isPreviewable: PropTypes.bool,
+		onClick: PropTypes.func,
 		previewUrl: PropTypes.string,
 		setPreviewUrl: PropTypes.func.isRequired,
 		setLayoutFocus: PropTypes.func.isRequired,
 	};
 
-	constructor() {
-		super( ...arguments );
+	static defaultProps = {
+		globalId: '',
+		status: 'draft',
+		isPreviewable: false,
+		onClick: () => {},
+		previewUrl: '',
+	};
 
-		this.previewPost = this.previewPost.bind( this );
-	}
-
-	previewPost( event ) {
+	previewPost = ( event ) => {
 		const { isPreviewable, previewUrl } = this.props;
 		mc.bumpStat( 'calypso_cpt_actions', 'view' );
 		if ( ! isPreviewable ) {
@@ -44,7 +47,7 @@ class PostActionsEllipsisMenuView extends Component {
 		this.props.setLayoutFocus( 'preview' );
 		this.props.onClick();
 		event.preventDefault();
-	}
+	};
 
 	render() {
 		const { translate, status, previewUrl } = this.props;

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -18,7 +18,6 @@ import Main from 'components/main';
 import notices from 'notices';
 import QueryPosts from 'components/data/query-posts';
 import QueryPostCounts from 'components/data/query-post-counts';
-import Draft from 'my-sites/draft';
 import PostItem from 'blocks/post-item';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
@@ -29,7 +28,10 @@ import Button from 'components/button';
 import Count from 'components/count';
 import SectionHeader from 'components/section-header';
 import { sectionify } from 'lib/route/path';
-import { getAllPostCount } from 'state/posts/counts/selectors';
+import {
+	getAllPostCount,
+	getMyPostCount
+} from 'state/posts/counts/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 
 const PostsMain = React.createClass( {
@@ -54,6 +56,10 @@ const PostsMain = React.createClass( {
 		}
 
 		if ( ! site.jetpack && this.props.draftCount === 0 ) {
+			return false;
+		}
+
+		if ( ! site.jetpack && this.props.author && this.props.myDraftCount === 0 ) {
 			return false;
 		}
 
@@ -82,7 +88,7 @@ const PostsMain = React.createClass( {
 				{ map( this.props.drafts, ( { global_ID: globalId } ) => (
 					<PostItem compact key={ globalId } globalId={ globalId } />
 				) ) }
-				{ isLoading && <Draft isPlaceholder /> }
+				{ isLoading && <PostItem compact /> }
 				{ this.props.draftCount > 6 &&
 					<Button compact borderless className="posts__see-all-drafts" href={ `/posts/drafts/${ site.slug }` }>
 						{ this.translate( 'See all drafts' ) }
@@ -138,6 +144,7 @@ export default connect( ( state, props ) => {
 		loadingDrafts: isRequestingSitePostsForQuery( state, siteId, draftsQuery ),
 		draftsQuery: draftsQuery,
 		draftCount: getAllPostCount( state, siteId, 'post', 'draft' ),
+		myDraftCount: getMyPostCount( state, siteId, 'post', 'draft' ),
 		newPostPath: getEditorNewPostPath( state, siteId )
 	};
 } )( PostsMain );

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -85,7 +85,7 @@ const PostsMain = React.createClass( {
 				<QueryPostCounts siteId={ site.ID } type="post" />
 				<SectionHeader className="posts__drafts-header" label={ translate( 'Latest Drafts' ) }>
 					<Button compact href={ this.props.newPostPath }>
-						{ translate( 'Start New' ) }
+						{ translate( 'New Post' ) }
 					</Button>
 				</SectionHeader>
 				{ map( this.props.drafts, ( { global_ID: globalId } ) => (

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -26,8 +26,8 @@ import {
 	isRequestingSitePostsForQuery
 } from 'state/posts/selectors';
 import Button from 'components/button';
-import Card from 'components/card';
 import Count from 'components/count';
+import SectionHeader from 'components/section-header';
 import { sectionify } from 'lib/route/path';
 import { getAllPostCount } from 'state/posts/counts/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
@@ -74,12 +74,11 @@ const PostsMain = React.createClass( {
 					siteId={ site.ID }
 					query={ this.props.draftsQuery } />
 				<QueryPostCounts siteId={ site.ID } type="post" />
-				<Card compact className="posts__drafts-header">
-					{ this.translate( 'Latest Drafts' ) }
-					<Button borderless href={ this.props.newPostPath }>
-						<Gridicon icon="plus" />
+				<SectionHeader className="posts__drafts-header" label={ this.translate( 'Latest Drafts' ) }>
+					<Button compact href={ this.props.newPostPath }>
+						{ this.translate( 'Start New' ) }
 					</Button>
-				</Card>
+				</SectionHeader>
 				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
 				{ isLoading && <Draft isPlaceholder /> }
 				{ this.props.draftCount > 6 &&
@@ -96,8 +95,6 @@ const PostsMain = React.createClass( {
 		if ( ! draft ) {
 			return null;
 		}
-
-		const site = this.props.sites.getSelectedSite();
 
 		return <PostTypeItem mini key={ draft.global_ID } globalId={ draft.global_ID } />;
 	},

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -19,6 +19,7 @@ import notices from 'notices';
 import QueryPosts from 'components/data/query-posts';
 import QueryPostCounts from 'components/data/query-post-counts';
 import Draft from 'my-sites/draft';
+import PostTypeItem from 'my-sites/post-type-list/post';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getSitePostsForQueryIgnoringPage,
@@ -98,12 +99,7 @@ const PostsMain = React.createClass( {
 
 		const site = this.props.sites.getSelectedSite();
 
-		return <Draft
-			key={ draft.global_ID }
-			post={ draft }
-			sites={ this.props.sites }
-			showAuthor={ site && ! site.single_user_site && ! this.props.author }
-		/>;
+		return <PostTypeItem mini key={ draft.global_ID } globalId={ draft.global_ID } />;
 	},
 
 	render() {

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import Gridicon from 'gridicons';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ import notices from 'notices';
 import QueryPosts from 'components/data/query-posts';
 import QueryPostCounts from 'components/data/query-post-counts';
 import Draft from 'my-sites/draft';
-import PostTypeItem from 'my-sites/post-type-list/post';
+import PostItem from 'blocks/post-item';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getSitePostsForQueryIgnoringPage,
@@ -79,7 +79,9 @@ const PostsMain = React.createClass( {
 						{ this.translate( 'Start New' ) }
 					</Button>
 				</SectionHeader>
-				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
+				{ map( this.props.drafts, ( { global_ID: globalId } ) => (
+					<PostItem compact key={ globalId } globalId={ globalId } />
+				) ) }
 				{ isLoading && <Draft isPlaceholder /> }
 				{ this.props.draftCount > 6 &&
 					<Button compact borderless className="posts__see-all-drafts" href={ `/posts/drafts/${ site.slug }` }>
@@ -89,14 +91,6 @@ const PostsMain = React.createClass( {
 				}
 			</div>
 		);
-	},
-
-	renderDraft( draft ) {
-		if ( ! draft ) {
-			return null;
-		}
-
-		return <PostTypeItem mini key={ draft.global_ID } globalId={ draft.global_ID } />;
 	},
 
 	render() {

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -16,7 +16,6 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PostList from './post-list';
 import config from 'config';
 import Main from 'components/main';
-import notices from 'notices';
 import QueryPosts from 'components/data/query-posts';
 import QueryPostCounts from 'components/data/query-post-counts';
 import PostItem from 'blocks/post-item';
@@ -34,6 +33,7 @@ import {
 	getMyPostCount
 } from 'state/posts/counts/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
+import { warningNotice } from 'state/notices/actions';
 
 const PostsMain = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
@@ -123,7 +123,7 @@ const PostsMain = React.createClass( {
 
 	setWarning( selectedSite ) {
 		if ( selectedSite && selectedSite.jetpack && ! selectedSite.hasMinimumJetpackVersion ) {
-			notices.warning(
+			this.props.warningNotice(
 				this.props.translate( 'Jetpack %(version)s is required to take full advantage of all post editing features.', {
 					args: { version: config( 'jetpack_min_version' ) }
 				} ),
@@ -137,22 +137,27 @@ const PostsMain = React.createClass( {
 
 } );
 
-export default connect( ( state, props ) => {
-	const siteId = getSelectedSiteId( state );
-	const draftsQuery = {
-		type: 'post',
-		status: 'draft',
-		number: 6,
-		order_by: 'modified',
-		author: props.author
-	};
+export default connect(
+	( state, { author } ) => {
+		const siteId = getSelectedSiteId( state );
+		const draftsQuery = {
+			author,
+			number: 6,
+			order_by: 'modified',
+			status: 'draft',
+			type: 'post',
+		};
 
-	return {
-		drafts: getSitePostsForQueryIgnoringPage( state, siteId, draftsQuery ),
-		loadingDrafts: isRequestingSitePostsForQuery( state, siteId, draftsQuery ),
-		draftsQuery: draftsQuery,
-		draftCount: getAllPostCount( state, siteId, 'post', 'draft' ),
-		myDraftCount: getMyPostCount( state, siteId, 'post', 'draft' ),
-		newPostPath: getEditorNewPostPath( state, siteId )
-	};
-} )( localize( PostsMain ) );
+		return {
+			drafts: getSitePostsForQueryIgnoringPage( state, siteId, draftsQuery ),
+			draftCount: getAllPostCount( state, siteId, 'post', 'draft' ),
+			draftsQuery,
+			loadingDrafts: isRequestingSitePostsForQuery( state, siteId, draftsQuery ),
+			myDraftCount: getMyPostCount( state, siteId, 'post', 'draft' ),
+			newPostPath: getEditorNewPostPath( state, siteId )
+		};
+	},
+	{
+		warningNotice,
+	},
+)( localize( PostsMain ) );

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 
 /**
@@ -68,11 +69,13 @@ const PostsMain = React.createClass( {
 
 	mostRecentDrafts() {
 		const site = this.props.sites.getSelectedSite();
-		const isLoading = this.props.draftCount !== 0 && this.props.loadingDrafts;
 
 		if ( ! site || ! this.showDrafts() ) {
 			return null;
 		}
+
+		const { draftCount, translate } = this.props;
+		const isLoading = draftCount !== 0 && this.props.loadingDrafts;
 
 		return (
 			<div className="posts__recent-drafts">
@@ -80,19 +83,19 @@ const PostsMain = React.createClass( {
 					siteId={ site.ID }
 					query={ this.props.draftsQuery } />
 				<QueryPostCounts siteId={ site.ID } type="post" />
-				<SectionHeader className="posts__drafts-header" label={ this.translate( 'Latest Drafts' ) }>
+				<SectionHeader className="posts__drafts-header" label={ translate( 'Latest Drafts' ) }>
 					<Button compact href={ this.props.newPostPath }>
-						{ this.translate( 'Start New' ) }
+						{ translate( 'Start New' ) }
 					</Button>
 				</SectionHeader>
 				{ map( this.props.drafts, ( { global_ID: globalId } ) => (
 					<PostItem compact key={ globalId } globalId={ globalId } />
 				) ) }
 				{ isLoading && <PostItem compact /> }
-				{ this.props.draftCount > 6 &&
+				{ draftCount > 6 &&
 					<Button compact borderless className="posts__see-all-drafts" href={ `/posts/drafts/${ site.slug }` }>
-						{ this.translate( 'See all drafts' ) }
-						{ this.props.draftCount ? <Count count={ this.props.draftCount } /> : null }
+						{ translate( 'See all drafts' ) }
+						{ draftCount ? <Count count={ draftCount } /> : null }
 					</Button>
 				}
 			</div>
@@ -121,8 +124,13 @@ const PostsMain = React.createClass( {
 	setWarning( selectedSite ) {
 		if ( selectedSite && selectedSite.jetpack && ! selectedSite.hasMinimumJetpackVersion ) {
 			notices.warning(
-				this.translate( 'Jetpack %(version)s is required to take full advantage of all post editing features.', { args: { version: config( 'jetpack_min_version' ) } } ),
-				{ button: this.translate( 'Update now' ), href: selectedSite.options.admin_url + 'plugins.php?plugin_status=upgrade' }
+				this.props.translate( 'Jetpack %(version)s is required to take full advantage of all post editing features.', {
+					args: { version: config( 'jetpack_min_version' ) }
+				} ),
+				{
+					button: this.props.translate( 'Update now' ),
+					href: selectedSite.options.admin_url + 'plugins.php?plugin_status=upgrade',
+				}
 			);
 		}
 	}
@@ -147,4 +155,4 @@ export default connect( ( state, props ) => {
 		myDraftCount: getMyPostCount( state, siteId, 'post', 'draft' ),
 		newPostPath: getEditorNewPostPath( state, siteId )
 	};
-} )( PostsMain );
+} )( localize( PostsMain ) );

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -2,9 +2,9 @@
 	display: block;
 	max-width: 720px;
 
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( ">1280px" ) {
 		display: flex;
-		max-width: 1040px;
+		max-width: 1440px;
 		justify-content: center;
 	}
 }
@@ -615,11 +615,30 @@
 .posts__recent-drafts {
 	flex-grow: 1;
 	margin: 0 0 24px 24px;
-	max-width: 296px;
 	display: none;
 
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( ">1280px" ) {
 		display: block;
+	}
+
+	@include breakpoint( ">1600px" ) {
+		.post-type-list__post.is-mini.card.is-compact {
+			padding: 16px 24px;
+
+			.post-type-list__post-meta {
+				display: block;
+			}
+
+			.post-type-list__post-title {
+				display: inline;
+				font-size: 15px;
+				margin-bottom: 2px;
+			}
+
+			.post-actions-ellipsis-menu {
+				margin-left: 8px;
+			}
+		}
 	}
 
 	.draft__actions {
@@ -628,13 +647,10 @@
 }
 
 .posts__recent-drafts .posts__drafts-header.card.is-compact {
-	margin-bottom: 16px;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	padding: 3px 16px;
 	color: $gray-dark;
-	font-size: 14px;
 
 	&::after {
 		display: none;
@@ -642,7 +658,7 @@
 }
 
 .posts.is-single-site .section-nav-tab.is-draft {
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( ">1280px" ) {
 		display: none;
 		&.is-selected {
 			display: block;

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -622,14 +622,14 @@
 	}
 
 	@include breakpoint( ">1600px" ) {
-		.post-type-list__post.is-mini.card.is-compact {
+		.post-item.is-mini.card.is-compact {
 			padding: 16px 24px;
 
-			.post-type-list__post-meta {
+			.post-item__meta {
 				display: block;
 			}
 
-			.post-type-list__post-title {
+			.post-item__title {
 				display: inline;
 				font-size: 15px;
 				margin-bottom: 2px;
@@ -654,15 +654,6 @@
 
 	&::after {
 		display: none;
-	}
-}
-
-.posts.is-single-site .section-nav-tab.is-draft {
-	@include breakpoint( ">1280px" ) {
-		display: none;
-		&.is-selected {
-			display: block;
-		}
 	}
 }
 

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -630,7 +630,6 @@
 			}
 
 			.post-item__title {
-				display: inline;
 				font-size: 15px;
 				margin-bottom: 2px;
 			}


### PR DESCRIPTION
- Add "mini" prop to display an even more condensed post-item.

![image](https://cloud.githubusercontent.com/assets/548849/16958199/db29c55c-4ddf-11e6-94be-348f244ecc04.png)

cc @aduth I think we should move the post.jsx component to its own folder (post-type-item).

Test live: https://calypso.live/posts?branch=update/use-new-cpt-post-component-for-drafts
