### PR TITLE
Plans: remove the skip-plans-for-free code

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -13,7 +13,7 @@ import { cartItems } from 'lib/cart-values';
 import config from 'config';
 import { isBusiness, isEnterprise, isFreePlan, isFreeJetpackPlan } from 'lib/products-values';
 import purchasesPaths from 'me/purchases/paths';
-import { isValidFeatureKey, isSkipPlansTestEnabled } from 'lib/plans';
+import { isValidFeatureKey } from 'lib/plans';
 import * as upgradesActions from 'lib/upgrades/actions';
 
 const PlanActions = React.createClass( {
@@ -108,15 +108,6 @@ const PlanActions = React.createClass( {
 
 		if ( this.props.sitePlan && this.props.sitePlan.freeTrial ) {
 			label = this.translate( 'Purchase Now' );
-		}
-
-		if ( this.props.isInSignup && isSkipPlansTestEnabled() ) {
-			label = this.translate( 'Select %(plan)s', {
-				args: {
-					plan: this.props.plan.product_name_short
-				},
-				context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
-			} );
 		}
 
 		return (

--- a/client/components/plans/plan-header/style.scss
+++ b/client/components/plans/plan-header/style.scss
@@ -108,6 +108,7 @@
 	.plan.card {
 		.plan-header {
 			border-bottom: 2px solid lighten( $gray, 20% );
+			min-height: 282px;
 			padding: 16px;
 
 			&:after {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -83,13 +83,4 @@ module.exports = {
 		defaultVariation: 'designTypeWithoutStore',
 		allowExistingUsers: false,
 	},
-	skipPlansLinkForFree: {
-		datestamp: '20160711',
-		variations: {
-			showFreePlan: 50,
-			skipPlansForFree: 50
-		},
-		defaultVariation: 'showFreePlan',
-		allowExistingUsers: false,
-	}
 };

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -14,7 +14,6 @@ import {
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { isEnabled } from 'config';
 import { addItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
@@ -213,9 +212,3 @@ export function applyTestFiltersToPlansList( planName ) {
 
 	return filteredPlanConstantObj;
 }
-
-export const isSkipPlansTestEnabled = () => {
-	return isEnabled( 'plans/skip-plans-for-free' ) &&
-		abtest( 'skipPlansLinkForFree' ) === 'skipPlansForFree' &&
-		isPersonalPlanEnabled;
-};

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,17 +10,8 @@ import { connect } from 'react-redux';
 import StepHeader from 'signup/step-header';
 import NavigationLink from 'signup/navigation-link';
 import config from 'config';
-import sitesList from 'lib/sites-list';
-import { plansLink, isSkipPlansTestEnabled } from 'lib/plans';
-import Gridicon from 'components/gridicon';
-import { recordGoogleEvent } from 'state/analytics/actions';
 
-/**
- * Module variables
- */
-const sites = sitesList();
-
-const StepWrapper = React.createClass( {
+export default React.createClass( {
 	displayName: 'StepWrapper',
 
 	renderBack: function() {
@@ -75,48 +65,11 @@ const StepWrapper = React.createClass( {
 		}
 	},
 
-	recordComparePlansClick() {
-		this.props.trackCompareClick();
-	},
-
-	renderComparePlans() {
-		const { stepName } = this.props;
-		if ( stepName !== 'plans' || ! isSkipPlansTestEnabled() ) {
-			return null;
-		}
-
-		const selectedSite = sites.getSelectedSite();
-		const url = plansLink( '/start/plans/compare', selectedSite );
-		const compareString = this.translate( 'Compare Plan Features' );
-
-		return (
-			<a href={ url } className="step-wrapper__compare-plans" onClick={ this.recordComparePlansClick }>
-				<Gridicon icon="clipboard" size={ 18 } />
-				{ compareString }
-			</a>
-		);
-	},
-
-	renderNavigation() {
-		const { stepName } = this.props;
-		const classes = classNames( 'step-wrapper__buttons', {
-			'is-wide-navigation': stepName === 'plans' && isSkipPlansTestEnabled()
-		} );
-		return (
-			<div className={ classes }>
-				{ this.renderBack() }
-				{ this.renderComparePlans() }
-				{ this.renderSkip() }
-			</div>
-		);
-	},
-
 	render: function() {
-		const { stepName, stepContent, headerButton } = this.props;
+		const { stepContent, headerButton } = this.props;
 		const classes = classNames( 'step-wrapper', {
 			'is-wide-layout': this.props.isWideLayout
 		} );
-		const showTopNavigation = stepName === 'plans' && isSkipPlansTestEnabled();
 
 		return (
 			<div className={ classes }>
@@ -128,17 +81,13 @@ const StepWrapper = React.createClass( {
 						: null }
 				</StepHeader>
 				<div className="step-wrapper__content is-animated-content">
-					{ showTopNavigation && this.renderNavigation() }
 					{ stepContent }
-					{ this.renderNavigation() }
+					<div className="step-wrapper__buttons">
+						{ this.renderBack() }
+						{ this.renderSkip() }
+					</div>
 				</div>
 			</div>
 		);
 	}
 } );
-
-const mapDispatchToProps = dispatch => ( {
-	trackCompareClick: () => dispatch( recordGoogleEvent( 'Upgrades', 'Clicked Compare Plans Link' ) )
-} );
-
-export default connect( null, mapDispatchToProps )( StepWrapper );

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -2,33 +2,6 @@
 	text-align: center;
 }
 
-.step-wrapper__buttons.is-wide-navigation {
-	display: flex;
-	justify-content: space-around;
-	align-items: center;
-}
-.step-wrapper__buttons.is-wide-navigation .navigation-link {
-	width: 30%;
-	text-align: left;
-	white-space: nowrap;
-	margin: 24px 0;
-}
-.step-wrapper__buttons.is-wide-navigation .navigation-link:last-child {
-	text-align: right;
-}
-.step-wrapper__compare-plans {
-	display: block;
-	font-size: 12px;
-	margin: 20px 0 20px 0;
-	text-align: center;
-	flex-grow: 2;
-
-	.gridicon {
-		margin: -2px 3px 0 0;
-		vertical-align: middle;
-	}
-}
-
 .step-wrapper__buttons .button.is-borderless {
 	color: darken( $gray, 20 );
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -25,7 +25,6 @@ import { isEnabled } from 'config';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import QueryPlans from 'components/data/query-plans';
 import config from 'config';
-import { isSkipPlansTestEnabled } from 'lib/plans';
 
 module.exports = React.createClass( {
 	displayName: 'PlansStep',
@@ -90,22 +89,21 @@ module.exports = React.createClass( {
 	},
 
 	plansList: function() {
-		const hideFreePlan = this.props.hideFreePlan || isSkipPlansTestEnabled();
 		return (
 			<div>
 				<PlanList
 					plans={ this.state.plans }
 					comparePlansUrl={ this.comparePlansUrl() }
-					hideFreePlan={ hideFreePlan }
+					hideFreePlan={ this.props.hideFreePlan }
 					isInSignup={ true }
 					onSelectPlan={ this.onSelectPlan } />
-				{ ! isSkipPlansTestEnabled() && <a
+				<a
 					href={ this.comparePlansUrl() }
 					className="plans-step__compare-plans-link"
 					onClick={ this.handleComparePlansLinkClick.bind( null, 'footer' ) }>
 						<Gridicon icon="clipboard" size={ 18 } />
 						{ this.translate( 'Compare Plans' ) }
-				</a> }
+				</a>
 			</div>
 		);
 	},
@@ -128,8 +126,7 @@ module.exports = React.createClass( {
 
 	plansSelection: function() {
 		const headerText = this.translate( 'Pick a plan that\'s right for you.' );
-		const hideSubHeader = isSkipPlansTestEnabled();
-		const subHeaderText = hideSubHeader ? null : this.translate(
+		const subHeaderText = this.translate(
 				'Not sure which plan to choose? Take a look at our {{a}}plan comparison chart{{/a}}.', {
 					components: { a: <a
 						href={ this.comparePlansUrl() }
@@ -140,7 +137,6 @@ module.exports = React.createClass( {
 		return (
 			<StepWrapper
 				flowName={ this.props.flowName }
-				goToNextStep={ isSkipPlansTestEnabled() ? this.onSelectPlan : undefined }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
 				headerText={ headerText }
@@ -179,10 +175,9 @@ module.exports = React.createClass( {
 	},
 
 	plansCompare: function() {
-		const hideFreePlan = this.props.hideFreePlan || isSkipPlansTestEnabled();
 		return <PlansCompare
 			className="plans-step__compare"
-			hideFreePlan={ hideFreePlan }
+			hideFreePlan={ this.props.hideFreePlan }
 			onSelectPlan={ this.onSelectPlan }
 			isInSignup={ true }
 			backUrl={ this.props.path.replace( '/compare', '' ) }


### PR DESCRIPTION
This test has already been turned off in #6839 by removing the feature flags from our environment configs. So this PR shouldn't change anything in the UX, but just cleans up the code since we're not going to implement this change as designed.

## Testing
Review the plans, plans/compare, start/plans, and start/plans/compare pages and make sure you don't see any changes, any bugs, any issues, etc.

Test live: https://calypso.live/?branch=update/remove-free-plans-skip-code