### PR TITLE
Current Theme Bar: Use theme options

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -66,7 +66,7 @@ class ThemeMoreButton extends React.Component {
 							return (
 								<a className="theme__more-button-menu-item popover__menu-item"
 									onMouseOver={ this.focus }
-									onClick={ option.action ? option.action : null }
+									onClick={ option.action }
 									key={ option.label }
 									href={ url }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>

--- a/client/my-sites/themes/current-theme/button.jsx
+++ b/client/my-sites/themes/current-theme/button.jsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
  */
 
 import { isOutsideCalypso } from 'lib/url';
+import Gridicon from 'components/gridicon';
 
 export default React.createClass( {
 	displayName: 'CurrentThemeButton',
@@ -16,7 +17,7 @@ export default React.createClass( {
 	propTypes: {
 		name: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,
-		noticon: PropTypes.string.isRequired,
+		icon: PropTypes.string.isRequired,
 		href: PropTypes.string,
 		onClick: PropTypes.func
 	},
@@ -32,10 +33,7 @@ export default React.createClass( {
 				onClick={ this.props.onClick.bind( null, this.props.name ) }
 				href={ this.props.href }
 				target={ isOutsideCalypso( this.props.href ) ? '_blank' : null } >
-				<span className={ classNames(
-					'noticon',
-					'noticon-' + this.props.noticon
-				) } />
+				<Gridicon icon={ this.props.icon } size={ 18 } />
 				<span className="current-theme__button-label">
 					{ this.props.label }
 				</span>

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -72,7 +72,7 @@ const CurrentTheme = React.createClass( {
 					{ map( this.props.options, ( option, name ) => (
 						<CurrentThemeButton name={ name }
 							label={ option.label }
-							noticon={ option.noticon }
+							icon={ option.icon }
 							href={ currentTheme && option.getUrl( currentTheme ) }
 							onClick={ this.trackClick } />
 					) ) }

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -43,7 +43,7 @@ export function getCustomizeUrl( theme, site ) {
 		return site.options.admin_url + 'customize.php?return=' + encodeURIComponent( window.location ) + ( theme ? '&theme=' + theme.id : '' );
 	}
 
-	return '/customize/' + site.slug + ( theme ? '?theme=' + theme.stylesheet : '' );
+	return '/customize/' + site.slug + ( theme && theme.stylesheet ? '?theme=' + theme.stylesheet : '' );
 }
 
 export function getDetailsUrl( theme, site ) {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -48,6 +48,7 @@ export const activate = {
 export const customize = {
 	label: i18n.translate( 'Customize' ),
 	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a site for which to customize a theme' } ),
+	noticon: 'paintbrush',
 	getUrl: ( theme, site ) => getCustomizeUrl( theme, site ),
 	hideForSite: ( { isCustomizable = false } = {} ) => ! isCustomizable,
 	hideForTheme: theme => ! theme.active
@@ -85,11 +86,13 @@ export const info = {
 	label: i18n.translate( 'Info', {
 		comment: 'label for displaying the theme info sheet'
 	} ),
+	noticon: 'info',
 	getUrl: ( theme, site ) => getDetailsUrl( theme, site ), // TODO: Make this a selector
 };
 
 export const support = {
 	label: i18n.translate( 'Setup' ),
+	noticon: 'help',
 	getUrl: ( theme, site ) => getSupportUrl( theme, site ),
 	// We don't know where support docs for a given theme on a self-hosted WP install are.
 	hideForSite: ( { isJetpack = false } = {} ) => isJetpack,

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -48,7 +48,7 @@ export const activate = {
 export const customize = {
 	label: i18n.translate( 'Customize' ),
 	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a site for which to customize a theme' } ),
-	noticon: 'paintbrush',
+	icon: 'customize',
 	getUrl: ( theme, site ) => getCustomizeUrl( theme, site ),
 	hideForSite: ( { isCustomizable = false } = {} ) => ! isCustomizable,
 	hideForTheme: theme => ! theme.active
@@ -86,13 +86,13 @@ export const info = {
 	label: i18n.translate( 'Info', {
 		comment: 'label for displaying the theme info sheet'
 	} ),
-	noticon: 'info',
+	icon: 'info',
 	getUrl: ( theme, site ) => getDetailsUrl( theme, site ), // TODO: Make this a selector
 };
 
 export const support = {
 	label: i18n.translate( 'Setup' ),
-	noticon: 'help',
+	icon: 'help',
 	getUrl: ( theme, site ) => getSupportUrl( theme, site ),
 	// We don't know where support docs for a given theme on a self-hosted WP install are.
 	hideForSite: ( { isJetpack = false } = {} ) => isJetpack,

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -70,7 +70,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 			{},
 			option,
 			option.action || ( option.getUrl && option.header )
-				? { action: theme => this.showSiteSelectorModal( option, theme ) } // prevent default?
+				? { action: theme => this.showSiteSelectorModal( option, theme ) }
 				: {},
 			option.getUrl && option.header
 				? { getUrl: null }


### PR DESCRIPTION
Use theme options to populate the Current Theme bar's buttons. While we're at it, also change the buttons to use Gridicons instead of noticons.

Before:

<img width="728" alt="before" src="https://cloud.githubusercontent.com/assets/96308/16960281/09040bc8-4de9-11e6-82a2-fa770f03ddbe.png">

After:

<img width="736" alt="after" src="https://cloud.githubusercontent.com/assets/96308/16960287/1024a8b8-4de9-11e6-9462-bd02e3a879aa.png">

Designy questions for @folletto:
1. Okay with the Gridicons? Using 18 for size here since that's the closest allowed size to what the noticons were before (16).
2. We still open non-calypso links in a new tab here, but the only time these links point outside Calypso is for a Jetpack site. Keep it that way?

To test -- verify that the Custom Theme bar still works as before. In single-site mode, try both WPCOM and Jetpack sites. Verify that the buttons point to the correct targets, and that the 'Setup'  button is only available for premium WPCOM themes.

Test live: https://calypso.live/?branch=update/current-theme/use-theme-options