### PR TITLE
Ribbon: fix ribbon example link

### DIFF
--- a/client/components/ribbon/docs/example.jsx
+++ b/client/components/ribbon/docs/example.jsx
@@ -24,22 +24,23 @@ export default React.createClass( {
 				</h2>
 				<Card>
 					<Ribbon>Default</Ribbon>
-					<p> 
+					<p>
 						Ribbon is a component you can slap on a Card or a similar container to ditinguish it in some way.
 						You can just render <b>&lt;Ribbon&gt;Text&lt;/Ribbon&gt;</b> inside to have it marked.
 					</p>
 				</Card>
 				<Card>
 					<Ribbon>History</Ribbon>
-					<p> 
-						Ribbons came to us in the early 2010s when they were put on every container on the web. 
+					<p>
+						Ribbons came to us in the early 2010s when they were put on every container on the web.
 						Since then, the internet's love for ribbons have subsided, but they will always find a place in our hearts.
 					</p>
 				</Card>
 				<Card>
 					<Ribbon color="green">Green</Ribbon>
-					<p> 
-						There are additional color versions. You can change them by passing color prop. The ribbon you can see on the right side is rendered by
+					<p>
+						There are additional color versions.&nbsp;
+						You can change them by passing color prop. The ribbon you can see on the right side is rendered by
 						<b>&lt;Ribbon color="green"&gt;Green&lt;/Ribbon&gt;</b>
 					</p>
 				</Card>

--- a/client/components/ribbon/docs/example.jsx
+++ b/client/components/ribbon/docs/example.jsx
@@ -20,7 +20,7 @@ export default React.createClass( {
 		return (
 			<div className="design-assets__group">
 				<h2>
-					<a href="/devdocs/app-components/ribbon">Ribbon</a>
+					<a href="/devdocs/design/ribbon">Ribbon</a>
 				</h2>
 				<Card>
 					<Ribbon>Default</Ribbon>


### PR DESCRIPTION
* Fix ESLint warnings
* Fix `<Ribbon />` example

### Testing

1 - Search `Ribbon` example into devdocs/design page: http://calypso.localhost:3000/devdocs/design
2 - Filter typing `Rib...`
3 - Click in **Ribbon** component

![image](https://cloud.githubusercontent.com/assets/77539/16960677/ec1b6c86-4dc0-11e6-927f-ddb960f5e60d.png)

You should get `http://calypso.localhost:3000/devdocs/design/ribbon` page.

cc @rralian 



Test live: https://calypso.live/?branch=update/fix-ribbon-example-page