### PR TITLE
Plans Redesign: Extend max width in plans NUX step to 1200

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -291,6 +291,7 @@ $plan-features-sidebar-width: 272px;
 	font-weight: 400;
 	color: $gray;
 	line-height: .6;
+	white-space: nowrap;
 
 	&.is-placeholder {
 		@include placeholder( 23% );

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -8,7 +8,7 @@
 	}
 
 	.step-header.is-without-subhead {
-		margin-bottom: 0;
+		margin-bottom: 15px;
 	}
 
 	.step-wrapper {

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -4,11 +4,17 @@
 
 	&.is-wide-layout {
 		margin: auto;
-		max-width: 1040px;
+		max-width: 1200px;
 	}
 
 	.step-header.is-without-subhead {
 		margin-bottom: 0;
+	}
+
+	.step-wrapper {
+		&.is-wide-layout {
+			max-width: 1200px;
+		}
 	}
 }
 


### PR DESCRIPTION
Now that we are keeping the Free plan in-line, we should extend max width to 1200. 

Before:

![screen shot 2016-07-19 at 10 20 27](https://cloud.githubusercontent.com/assets/1464705/16963696/8abf1f82-4dac-11e6-86f2-5beaa4391f79.png)

After:

![screen shot 2016-07-19 at 12 28 39](https://cloud.githubusercontent.com/assets/1464705/16963698/90b82fd2-4dac-11e6-8470-61b1550399bf.png)
lans

Test this locally using the `ENABLE_FEATURES=manage/plan-features make run` command.