### PR TITLE
Framework: return storedVariation if we have one

### DIFF
--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -26,7 +26,7 @@ module.exports = {
 
 You should include the following information:
 
-* `datestamp` - The YYYMMDD date you want to start tracking the results of the test. If you deploy to production prior to this date, the `abtest` function (see below) will return the value you set for `defaultVariation` and won't track the results.
+* `datestamp` - The YYYMMDD date you want to start tracking the results of the test. If you deploy to production prior to this date, the `abtest` function (see below) will return the any stored variation (which makes for easier testing) or the value you set for `defaultVariation` and won't track the results.
 * `variations` - An object where the keys are the variation names and the values are the allocations. The variation names should be descriptive (don't use `variationA`, `original`, etc). The allocations (50/50) are how you want those variations to be allocated to users. For example, you could also do 90/10 if you want one variation to be shown to only 10% of users. 90/10 is the same as 9/1. If you had three variations you could do 1/1/1 to show each variation one third of the time.
 * `defaultVariation` - The variation to assign users who are not eligible to participate in the test. See the "Dealing with ineligible users" section below for more information.
 

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -110,7 +110,7 @@ ABTest.prototype.getVariationAndSetAsNeeded = function() {
 
 	if ( ! this.hasTestStartedYet() ) {
 		debug( '%s: Test will start on %s.', this.experimentId, this.datestamp );
-		return this.defaultVariation;
+		return savedVariation || this.defaultVariation;
 	}
 
 	if ( savedVariation && includes( this.variationNames, savedVariation ) ) {


### PR DESCRIPTION
I'd like to propose that we honor any stored variation if/when we have one for tests that have not yet started. This makes it much easier to test the different variations by using the bug badge abtest helper to manually set variations.

![bugbadge helper](https://cloudup.com/cORKnecltrh+)

So now for a test that has not yet started, we will return any value currently stored in localStorage first, and if we don't have one, we will return the default variation.

## Testing
Make sure this doesn't destroy all things. Maybe try a known test and make sure it still works as expected. But mostly think through the change to see if you can think of any reason we wouldn't want to do this.

/cc @retrofox @apeatling @dmsnell 

Test live: https://calypso.live/?branch=update/abtest-allow-savedvariation-preview