### PR TITLE
Jetpack Plans: Update plans autoconfig tracking

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -66,6 +66,14 @@ const PlansSetup = React.createClass( {
 		this.sentTracks = true;
 	},
 
+	trackManualInstall() {
+		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_click_manual_error' );
+	},
+
+	trackContactSupport() {
+		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_click_contact_support' );
+	},
+
 	// plugins for Jetpack sites require additional data from the wporg-data store
 	addWporgDataToPlugins( plugins ) {
 		return plugins.map( plugin => {
@@ -293,7 +301,7 @@ const PlansSetup = React.createClass( {
 					break;
 			}
 			statusProps.children = (
-				<NoticeAction key="notice_action" href={ helpLinks[ plugin.slug ] }>
+				<NoticeAction key="notice_action" href={ helpLinks[ plugin.slug ] } onClick={ this.trackManualInstall }>
 					{ this.translate( 'Manual Installation' ) }
 				</NoticeAction>
 			);
@@ -363,7 +371,7 @@ const PlansSetup = React.createClass( {
 						plugin: pluginsWithErrors[ 0 ].name,
 					},
 					components: {
-						a: <a href={ support.JETPACK_SUPPORT } />
+						a: <a href={ support.JETPACK_SUPPORT } onClick={ this.trackManualInstall } />
 					}
 				}
 			);
@@ -373,14 +381,14 @@ const PlansSetup = React.createClass( {
 				'It may be possible to fix this by {{a}}manually installing{{/a}} the plugins.',
 				{
 					components: {
-						a: <a href={ support.JETPACK_SUPPORT } />
+						a: <a href={ support.JETPACK_SUPPORT } onClick={ this.trackManualInstall } />
 					}
 				}
 			);
 		}
 		return (
 			<Notice status="is-error" text={ noticeText } showDismiss={ false }>
-				<NoticeAction href={ support.JETPACK_CONTACT_SUPPORT }>
+				<NoticeAction href={ support.JETPACK_CONTACT_SUPPORT } onClick={ this.trackContactSupport }>
 					{ this.translate( 'Contact Support' ) }
 				</NoticeAction>
 			</Notice>

--- a/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
@@ -29,16 +29,16 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
 		const reasons = utils.getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
 		if ( reasons && reasons.length > 0 ) {
-			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_error_filemod', { error: reasons[ 0 ] } );
+			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_halt_filemod', { error: reasons[ 0 ] } );
 		} else if ( ! selectedSite.hasMinimumJetpackVersion ) {
 			analytics.tracks.recordEvent(
-				'calypso_plans_autoconfig_error_jpversion',
+				'calypso_plans_autoconfig_halt_jpversion',
 				{ jetpack_version: selectedSite.options.jetpack_version }
 			);
-		} else if ( ! selectedSite.isMainNetworkSite() ) {
-			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_error_multisite' );
+		} else if ( selectedSite.is_multisite && ! selectedSite.isMainNetworkSite() ) {
+			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_halt_multisite' );
 		} else if ( selectedSite.options.is_multi_network ) {
-			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_error_multinetwork' );
+			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_halt_multinetwork' );
 		}
 
 		props.title = null;

--- a/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
@@ -27,6 +27,12 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 	};
 
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
+		const trackManualInstall = ( eventName ) => {
+			return () => {
+				analytics.tracks.recordEvent( eventName );
+			};
+		};
+
 		const reasons = utils.getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
 		if ( reasons && reasons.length > 0 ) {
 			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_halt_filemod', { error: reasons[ 0 ] } );
@@ -49,13 +55,17 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 			);
 			props.buttonText = i18n.translate( 'Installation Instructions' );
 			props.href = 'https://en.support.wordpress.com/setting-up-premium-services/';
+			props.onClick = trackManualInstall( 'calypso_plans_autoconfig_click_manual_install' );
 		} else {
 			props.description = i18n.translate(
 				'We are about to install Akismet and VaultPress for your site, which will automatically protect your site from spam ' +
 				'and data loss. If you have any questions along the way, we\'re here to help! You can also perform a manual ' +
 				'installation by following {{a}}these instructions{{/a}}.',
 				{ components: {
-					a: <a target="_blank" href="https://en.support.wordpress.com/setting-up-premium-services/" />
+					a: <a
+						target="_blank"
+						href="https://en.support.wordpress.com/setting-up-premium-services/"
+						onClick={ trackManualInstall( 'calypso_plans_autoconfig_click_opt_out' ) } />
 				} }
 			);
 			props.buttonText = i18n.translate( 'Set up your plan' );


### PR DESCRIPTION
Now that autoconfig has launched, we've found a few places where we'd like more tracking, or different tracking. This PR fixes #6888 by adding the following events:

`calypso_plans_autoconfig_click_manual_error` - User clicked "Manual Install" after an error happened

`calypso_plans_autoconfig_click_manual_install` - User clicked "Manual Install" because that's all they can do

`calypso_plans_autoconfig_click_opt_out` - User clicked "Manual Install" instead of going through autoconfig

`calypso_plans_autoconfig_click_contact_support` - User clicked "Contact Support" on the error notice

This also switches the event name for events on the "Thank You" page, where we detect that we can't install for a reason, but no error has happened yet. Instead we "halt" the autoconfig, and have them manually install.

`calypso_plans_autoconfig_halt_filemod`
`calypso_plans_autoconfig_halt_jpversion`
`calypso_plans_autoconfig_halt_multisite`
`calypso_plans_autoconfig_halt_multinetwork`

Finally, this fixes a bug where we flagged the multisite error when it didn't apply.

To Test:

1. Try to buy a plan on a site we don't support, like a multisite. You should see the `halt` event on the Thank You page.
2. Clicking off to Manual Install should send `calypso_plans_autoconfig_click_manual_install`.

1. Buy a plan on a supported site. On the Thank You page, "opt out" by clicking Manual Install in the text.
2. You don't see the error_multisite event
3. You should see the `calypso_plans_autoconfig_click_opt_out` event

1. Run autoconfig on a site with something broken (so a plugin error happens)
2. Click "Manual Install", see `calypso_plans_autoconfig_click_manual_error`
3. Or click "Contact Support" and see `calypso_plans_autoconfig_click_contact_support`

cc @johnHackworth @roccotripaldi @rickybanister (just so you know these new events)

Test live: https://calypso.live/?branch=update/plans-config-tracks