### PR TITLE
GuidedTours: move `relevantFeatures` array into tours configuration

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -5,114 +5,140 @@
  */
 import React from 'react';
 import i18n from 'i18n-calypso';
+import config from 'config';
 
 /**
  * Internal dependencies
  */
 import { getSelectedSite } from 'state/ui/selectors';
 
-function get( tour ) {
-	const tours = {
-		main: {
+const tours = {
+	main: {
+		meta: {
 			version: '20160601',
-			init: {
-				text: i18n.translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, and give you some ideas for what to do next.", {
-					components: {
-						strong: <strong />,
-					}
-				} ),
-				type: 'FirstStep',
-				placement: 'right',
-				next: 'my-sites',
-			},
-			'my-sites': {
-				target: 'my-sites',
-				arrow: 'top-left',
-				type: 'ActionStep',
-				icon: 'my-sites',
-				placement: 'below',
-				text: i18n.translate( "{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing your site's content and design.", {
-					components: {
-						strong: <strong />,
-					}
-				} ),
-				next: 'sidebar',
-			},
-			sidebar: {
-				text: i18n.translate( 'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.' ),
-				type: 'BasicStep',
-				target: 'sidebar',
-				arrow: 'left-middle',
-				placement: 'beside',
-				next: 'click-preview',
-			},
-			'click-preview': {
-				target: 'site-card-preview',
-				arrow: 'top-left',
-				type: 'ActionStep',
-				iconText: i18n.translate( "your site's name", {
-					context: "Click your site's name to continue.",
-				} ),
-				placement: 'below',
-				showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
-				text: i18n.translate( "This shows your currently {{strong}}selected site{{/strong}}'s name and address.", {
-					components: {
-						strong: <strong />,
-					}
-				} ),
-				next: 'in-preview',
-			},
-			'in-preview': {
-				text: i18n.translate( "This is your site's {{strong}}Preview{{/strong}}. From here you can see how your site looks to others.", {
-					components: {
-						strong: <strong />,
-					}
-				} ),
-				type: 'BasicStep',
-				placement: 'center',
-				showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
-				next: 'close-preview',
-			},
-			'close-preview': {
-				target: 'web-preview__close',
-				arrow: 'left-top',
-				type: 'ActionStep',
-				placement: 'beside',
-				icon: 'cross-small',
-				text: i18n.translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ),
-				showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
-				next: 'themes',
-			},
-			themes: {
-				text: i18n.translate( "Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} your theme's colors, fonts, and more.", {
-					components: {
-						strong: <strong />,
-					}
-				} ),
-				type: 'BasicStep',
-				target: 'themes',
-				arrow: 'top-left',
-				placement: 'below',
-				showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_customizable,
-				next: 'finish',
-			},
-			finish: {
-				placement: 'center',
-				text: i18n.translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.", {
-					components: {
-						strong: <strong />,
-					}
-				} ),
-				type: 'FinishStep',
-				linkLabel: i18n.translate( 'Learn more about WordPress.com' ),
-				linkUrl: 'https://learn.wordpress.com',
-			},
+			path: '/',
+			context: () => false,
 		},
-	};
+		init: {
+			text: i18n.translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, and give you some ideas for what to do next.", {
+				components: {
+					strong: <strong />,
+				}
+			} ),
+			type: 'FirstStep',
+			placement: 'right',
+			next: 'my-sites',
+		},
+		'my-sites': {
+			target: 'my-sites',
+			arrow: 'top-left',
+			type: 'ActionStep',
+			icon: 'my-sites',
+			placement: 'below',
+			text: i18n.translate( "{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing your site's content and design.", {
+				components: {
+					strong: <strong />,
+				}
+			} ),
+			next: 'sidebar',
+		},
+		sidebar: {
+			text: i18n.translate( 'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.' ),
+			type: 'BasicStep',
+			target: 'sidebar',
+			arrow: 'left-middle',
+			placement: 'beside',
+			next: 'click-preview',
+		},
+		'click-preview': {
+			target: 'site-card-preview',
+			arrow: 'top-left',
+			type: 'ActionStep',
+			iconText: i18n.translate( "your site's name", {
+				context: "Click your site's name to continue.",
+			} ),
+			placement: 'below',
+			showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
+			text: i18n.translate( "This shows your currently {{strong}}selected site{{/strong}}'s name and address.", {
+				components: {
+					strong: <strong />,
+				}
+			} ),
+			next: 'in-preview',
+		},
+		'in-preview': {
+			text: i18n.translate( "This is your site's {{strong}}Preview{{/strong}}. From here you can see how your site looks to others.", {
+				components: {
+					strong: <strong />,
+				}
+			} ),
+			type: 'BasicStep',
+			placement: 'center',
+			showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
+			next: 'close-preview',
+		},
+		'close-preview': {
+			target: 'web-preview__close',
+			arrow: 'left-top',
+			type: 'ActionStep',
+			placement: 'beside',
+			icon: 'cross-small',
+			text: i18n.translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ),
+			showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
+			next: 'themes',
+		},
+		themes: {
+			text: i18n.translate( "Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} your theme's colors, fonts, and more.", {
+				components: {
+					strong: <strong />,
+				}
+			} ),
+			type: 'BasicStep',
+			target: 'themes',
+			arrow: 'top-left',
+			placement: 'below',
+			showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_customizable,
+			next: 'finish',
+		},
+		finish: {
+			placement: 'center',
+			text: i18n.translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.", {
+				components: {
+					strong: <strong />,
+				}
+			} ),
+			type: 'FinishStep',
+			linkLabel: i18n.translate( 'Learn more about WordPress.com' ),
+			linkUrl: 'https://learn.wordpress.com',
+		},
+	},
+	themes: {
+		meta: {
+			version: '20160719',
+			path: '/design',
+			// don't enable this in production (yet)
+			context: () => 'production' !== config( 'env' ),
+		},
+	},
+	test: {
+		meta: {
+			version: '20160719',
+			path: '/test',
+			// don't enable this in production
+			context: () => 'production' !== config( 'env' ),
+		},
+	},
+};
 
+function get( tour ) {
 	return tours[ tour ] || null;
+}
+
+function getAll() {
+	return tours;
 }
 
 export default {
 	get,
+	getAll,
 };

--- a/client/state/ui/guided-tours/actions.js
+++ b/client/state/ui/guided-tours/actions.js
@@ -26,7 +26,7 @@ export function quitGuidedTour( { tour, stepName, finished, error } ) {
 
 	const trackEvent = recordTracksEvent( `calypso_guided_tours_${ finished ? 'finished' : 'quit' }`, {
 		step: stepName,
-		tour_version: guidedToursConfig.get( tour ).version,
+		tour_version: guidedToursConfig.get( tour ).meta.version,
 		tour,
 		error,
 	} );
@@ -46,7 +46,7 @@ export function nextGuidedTourStep( { tour, stepName } ) {
 
 	const trackEvent = recordTracksEvent( 'calypso_guided_tours_next_step', {
 		step: stepName,
-		tour_version: guidedToursConfig.get( tour ).version,
+		tour_version: guidedToursConfig.get( tour ).meta.version,
 		tour,
 	} );
 

--- a/client/state/ui/guided-tours/selectors.js
+++ b/client/state/ui/guided-tours/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, difference, find, memoize, noop, startsWith, uniq } from 'lodash';
+import { get, difference, find, map, memoize, noop, startsWith, uniq } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -17,27 +17,13 @@ import guidedToursConfig from 'layout/guided-tours/config';
 const getToursConfig = memoize( ( tour ) => guidedToursConfig.get( tour ) );
 const getToursHistory = state => getPreference( state, 'guided-tours-history' );
 const debug = debugFactory( 'calypso:guided-tours' );
-
-/*
- * This would/will be part of the existing config for tours.
- */
-const relevantFeatures = [
-	{
-		path: '/',
-		tour: 'main',
-		context: () => false,
-	},
-	{
-		path: '/design',
-		tour: 'themes',
-		context: () => true,
-	},
-	{
-		path: '/test',
-		tour: 'test',
-		context: () => true,
-	},
-];
+const relevantFeatures = map( guidedToursConfig.getAll(), ( tour, key ) => {
+	return {
+		tour: key,
+		path: tour.meta.path,
+		context: tour.meta.context,
+	};
+} );
 
 /*
  * Returns a collection of tour names. These tours are selected if the user has


### PR DESCRIPTION
Putting the `relevantFeatures` array into the selectors module was temporary, as we were (and are) still evolving the architecture. This change moves `relevantFeatures` into the tours configuration where it's intended to be.

To test: 
- Add a call to `debug` or `console.log` in `selectors.js` to print out the contents of `relevantFeatures` and compare with the removed static array. 

/cc @ehg @mcsf 

Test live: https://calypso.live/?branch=update/guided-tours-relevant-features-in-config