### PR TITLE
First-View: Record Tracks events and bump stats

### DIFF
--- a/client/state/ui/first-view/actions.js
+++ b/client/state/ui/first-view/actions.js
@@ -5,8 +5,14 @@ import {
 	FIRST_VIEW_HIDE
 } from 'state/action-types';
 
+import {
+	bumpStat,
+	recordTracksEvent,
+} from 'state/analytics/actions';
+
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
+import { bucketedTimeSpentOnCurrentView } from './selectors';
 
 export function hideView( { view, enabled } ) {
 	const hideAction = {
@@ -15,6 +21,18 @@ export function hideView( { view, enabled } ) {
 	};
 
 	return ( dispatch, getState ) => {
+		const timeBucket = bucketedTimeSpentOnCurrentView( getState() );
+
+		const tracksEvent = recordTracksEvent( `calypso_first_view_dismissed`, {
+			view,
+			showAgain: enabled,
+			timeSpent: timeBucket,
+		} );
+
+
+		dispatch( bumpStat( 'calypso_first_view_dismissed', enabled ? 'show_again' : 'dont_show' ) );
+		dispatch( bumpStat( 'calypso_first_view_duration', timeBucket ) );
+		dispatch( tracksEvent );
 		dispatch( hideAction );
 		dispatch( persistToPreferences( { getState, view, disabled: ! enabled } ) );
 	};

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import filter from 'lodash/filter';
+import last from 'lodash/last';
 import some from 'lodash/some';
 import startsWith from 'lodash/startsWith';
 import takeRightWhile from 'lodash/takeRightWhile';
@@ -49,4 +50,40 @@ export function shouldViewBeVisible( state ) {
 		! wasViewHidden( state, sectionName ) &&
 		switchedFromDifferentSection( state ) &&
 		! isSectionLoading( state );
+}
+
+export function secondsSpentOnCurrentView( state, now = Date.now() ) {
+	const routeSets = filter( getActionLog( state ), { type: ROUTE_SET } );
+	const currentRoute = last( routeSets );
+	return currentRoute ? ( now - currentRoute.timestamp ) / 1000 : -1;
+}
+
+export function bucketedTimeSpentOnCurrentView( state, now = Date.now() ) {
+	const timeSpent = secondsSpentOnCurrentView( state, now );
+
+	if ( -1 === timeSpent ) {
+		return 'unknown';
+	}
+
+	if ( timeSpent < 2 ) {
+		return 'under2';
+	}
+
+	if ( timeSpent < 5 ) {
+		return '2-5';
+	}
+
+	if ( timeSpent < 10 ) {
+		return '5-10';
+	}
+
+	if ( timeSpent < 20 ) {
+		return '10-20';
+	}
+
+	if ( timeSpent < 60 ) {
+		return '20-60';
+	}
+
+	return '60plus';
 }

--- a/client/state/ui/first-view/test/actions.js
+++ b/client/state/ui/first-view/test/actions.js
@@ -21,6 +21,9 @@ describe( 'actions', () => {
 			values: {
 				firstViewHistory: []
 			}
+		},
+		ui: {
+			actionLog: []
 		}
 	} );
 

--- a/client/state/ui/first-view/test/selectors.js
+++ b/client/state/ui/first-view/test/selectors.js
@@ -10,7 +10,9 @@ import {
 	doesViewHaveFirstView,
 	isViewEnabled,
 	wasViewHidden,
-	switchedFromDifferentSection
+	switchedFromDifferentSection,
+	secondsSpentOnCurrentView,
+	bucketedTimeSpentOnCurrentView,
 } from '../selectors';
 import {
 	ROUTE_SET
@@ -166,6 +168,255 @@ describe( 'selectors', () => {
 			}, 'stats' );
 
 			expect( hasSwitchedSections ).to.be.false;
+		} );
+	} );
+
+	describe( '#secondsSpentOnCurrentView()', () => {
+		it( 'should return -1 if the action log is empty', () => {
+			const actions = [];
+
+			const seconds = secondsSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			} );
+
+			expect( seconds ).to.equal( -1 );
+		} );
+
+		it( 'should return 3 when now is 3000 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const seconds = secondsSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962293000 );
+
+			expect( seconds ).to.equal( 3 );
+		} );
+
+		it( 'should return 5.678 when now is 5678 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats/insights',
+					timestamp: 1468962221009,
+				},
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const seconds = secondsSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962295678 );
+
+			expect( seconds ).to.equal( 5.678 );
+		} );
+	} );
+
+	describe( '#bucketedTimeSpentOnCurrentView()', () => {
+		it( 'should return \'unknown\' when the action log is empty', () => {
+			const actions = [];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			} );
+
+			expect( bucket ).to.equal( 'unknown' );
+		} );
+
+		it( 'should return \'under2\' when now is 1999 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962291999 );
+
+			expect( bucket ).to.equal( 'under2' );
+		} );
+
+		it( 'should return \'2-5\' when now is 2000 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962292000 );
+
+			expect( bucket ).to.equal( '2-5' );
+		} );
+
+		it( 'should return \'2-5\' when now is 4999 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962294999 );
+
+			expect( bucket ).to.equal( '2-5' );
+		} );
+
+		it( 'should return \'5-10\' when now is 5000 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962295000 );
+
+			expect( bucket ).to.equal( '5-10' );
+		} );
+
+		it( 'should return \'5-10\' when now is 9999 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962299999 );
+
+			expect( bucket ).to.equal( '5-10' );
+		} );
+
+		it( 'should return \'10-20\' when now is 10000 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962300000 );
+
+			expect( bucket ).to.equal( '10-20' );
+		} );
+
+		it( 'should return \'10-20\' when now is 19999 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962309999 );
+
+			expect( bucket ).to.equal( '10-20' );
+		} );
+
+		it( 'should return \'20-60\' when now is 20000 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962310000 );
+
+			expect( bucket ).to.equal( '20-60' );
+		} );
+
+		it( 'should return \'20-60\' when now is 59999 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962349999 );
+
+			expect( bucket ).to.equal( '20-60' );
+		} );
+
+		it( 'should return \'60plus\' when now is 60000 millis after the last action in the log', () => {
+			const actions = [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+					timestamp: 1468962290000,
+				}
+			];
+
+			const bucket = bucketedTimeSpentOnCurrentView( {
+				ui: {
+					actionLog: actions
+				}
+			}, 1468962350000 );
+
+			expect( bucket ).to.equal( '60plus' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds stats and Tracks events to the dismissal of the first-view dialog.

![image](https://cloud.githubusercontent.com/assets/363749/16999669/cc286022-4e84-11e6-9563-281999cf776a.png)

![image](https://cloud.githubusercontent.com/assets/363749/16999720/1146d242-4e85-11e6-9beb-68e4f75a5809.png)


To test:
* Open your browser's console, and enter the line `localStorage.setItem( 'debug', 'calypso:analytics' )`
* Visit the Stats page as a user who has not yet dismissed the first view (or as a new user)
* Uncheck the "Don't show this again" checkbox, and dismiss the first view dialog.
* Make sure that in the console you see a stat getting bumped in the `calypso_first_view_dismissed` group with the name `show_again`.
* Make sure that in the console you see a stat getting bumped in the `calypso_first_view_duration` group with a name corresponding to the amount of time you spent on the page before dismissing the dialog
* Make sure you see a Tracks event recorded which contains both the state of the checkbox and the duration
* Reload the page. Since you unchecked the box, you should see the first-view dialog again
* Repeat the above, but this time leave the box checked. Make sure the stat and tracks event reflect the fact the checkbox was left checked.