### PR TITLE
Update style and structure of editor preview toolbar

### DIFF
--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -3,79 +3,92 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import classnames from 'classnames';
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { partial } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
 
-const PreviewToolbar = React.createClass( {
-	devices: [ 'computer', 'tablet', 'phone' ],
+const possibleDevices = [
+	'computer',
+	'tablet',
+	'phone'
+];
 
-	propTypes: {
-		// Show device viewport switcher
-		showDeviceSwitcher: React.PropTypes.bool,
-		// Show external link button
-		showExternal: React.PropTypes.bool,
-		// Show close button
-		showClose: React.PropTypes.bool,
-		// The device to display, used for setting preview dimensions
-		device: React.PropTypes.string,
-		// Elements to render on the right side of the toolbar
-		children: React.PropTypes.node,
-		// Called when a device button is clicked
-		setDeviceViewport: React.PropTypes.func,
-		// Called when the close button is pressed
-		onClose: React.PropTypes.func.isRequired,
-	},
+export const PreviewToolbar = props => {
+	const {
+		device: currentDevice,
+		externalUrl,
+		onClose,
+		previewUrl,
+		setDeviceViewport,
+		showClose,
+		showDeviceSwitcher,
+		showExternal,
+		translate
+	} = props;
 
-	renderDevices() {
-		return this.devices.map( ( device ) => {
-			const className = classnames( 'web-preview__device-button', {
-				'is-active': this.props.device === device,
-			} );
-
-			return (
+	return (
+		<div className="web-preview__toolbar">
+			{ showClose &&
 				<button
-					key={ device }
-					className={ className }
-					onClick={ this.props.setDeviceViewport.bind( null, device ) }
-					aria-hidden={ true }
+					aria-label={ translate( 'Close preview' ) }
+					className="web-preview__close"
+					data-tip-target="web-preview__close"
+					onClick={ onClose }
 				>
-					<Gridicon icon={ device } />
+					<Gridicon icon="cross" />
 				</button>
-			);
-		} );
-	},
-
-	render() {
-		return (
-			<div className="web-preview__toolbar">
-				{ this.props.showClose &&
+			}
+			{ showExternal &&
+				<a
+					className="web-preview__external"
+					href={ externalUrl || previewUrl }
+					target="_blank"
+				>
+					<Gridicon icon="external" />
+				</a>
+			}
+			{ showDeviceSwitcher &&
+				possibleDevices.map( device => (
 					<button
-						className="web-preview__close"
-						data-tip-target="web-preview__close"
-						onClick={ this.props.onClose }
-						aria-label={ this.translate( 'Close preview' ) }
+						aria-hidden={ true }
+						key={ device }
+						className={ classNames( 'web-preview__device-button', {
+							'is-active': device === currentDevice,
+						} ) }
+						onClick={ partial( setDeviceViewport, device ) }
 					>
-						<Gridicon icon="cross" />
+						<Gridicon icon={ device } />
 					</button>
-				}
-				{ this.props.showExternal &&
-					<a className="web-preview__external" href={ this.props.externalUrl || this.props.previewUrl } target="_blank">
-						<Gridicon icon="external" />
-					</a>
-				}
-				{ this.props.showDeviceSwitcher && this.renderDevices() }
-				<div className="web-preview__toolbar-tray">
-					{ this.props.children }
-				</div>
+				) )
+			}
+			<div className="web-preview__toolbar-tray">
+				{ props.children }
 			</div>
-		);
-	}
+		</div>
+	);
+};
 
-} );
+PreviewToolbar.propTypes = {
+	// Show device viewport switcher
+	showDeviceSwitcher: PropTypes.bool,
+	// Show external link button
+	showExternal: PropTypes.bool,
+	// Show close button
+	showClose: PropTypes.bool,
+	// The device to display, used for setting preview dimensions
+	device: PropTypes.string,
+	// Elements to render on the right side of the toolbar
+	children: PropTypes.node,
+	// Called when a device button is clicked
+	setDeviceViewport: PropTypes.func,
+	// Called when the close button is pressed
+	onClose: PropTypes.func.isRequired,
+};
 
-export default PreviewToolbar;
+export default localize( PreviewToolbar );


### PR DESCRIPTION
This work precedes the addition of a new SEO preview tab on the editor
preview window.

**There should be no visual or functional changes.**

However, I have made the following changes:
 - Convert the React component into a functional stateless component
 - Moved the PropType definitions outside of the component
 - Inlined the device iteration out of `renderDevices()`
 - Replaced the implicit `this.translate()` via wrapping in
   `i18n-calypso.localize()`

> It appears like the diff is having trouble showing the changes, probably since I shuffled around functions _and_ indentation. It might be worth looking at the split view instead of the unified view

**Testing**
 - Smoke test by previewing something in the post editor.

cc: @ehg

Test live: https://calypso.live/?branch=update/editor-preview-toolbar