### PR TITLE
Domains Search: Improve the way `PremiumPopover` component handles mouse events.

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -20,17 +20,6 @@ const DomainProductPrice = React.createClass( {
 		requiresPlan: React.PropTypes.bool,
 		domainsWithPlansOnly: React.PropTypes.bool.isRequired
 	},
-
-	getInitialState() {
-		return {
-			premiumPopoverReference: undefined
-		};
-	},
-	componentDidMount() {
-		this.setState( {
-			premiumPopoverReference: this.refs && this.refs.subMessage
-		} );
-	},
 	renderFreeWithPlan() {
 		return (
 			<div
@@ -65,11 +54,9 @@ const DomainProductPrice = React.createClass( {
 		return (
 			<div className="domain-product-price is-with-plans-only">
 				<small className="domain-product-price__premium-text" ref="subMessage">
-					{ this.translate( 'Included in WordPress.com Premium' ) }
 					<PremiumPopover
-						context={ this.state.premiumPopoverReference }
-						bindContextEvents
-						position="bottom left"/>
+						position="bottom left"
+						textLabel={ this.translate( 'Included in WordPress.com Premium' ) }/>
 				</small>
 			</div>
 		);

--- a/client/components/domains/example-domain-suggestions/index.jsx
+++ b/client/components/domains/example-domain-suggestions/index.jsx
@@ -55,12 +55,9 @@ module.exports = React.createClass( {
 		if ( cost && this.props.domainsWithPlansOnly ) {
 			return (
 				<span className="example-domain-suggestions__premium-price" ref="premiumPrice">
-					{ this.translate( 'Included in WordPress.com Premium' ) }
 					<PremiumPopover
-						context={ this.refs && this.refs.premiumPrice }
 						position="bottom left"
-						bindContextEvents
-					/>
+						textLabel={ this.translate( 'Included in WordPress.com Premium' ) }/>
 				</span>
 			);
 		}

--- a/client/components/plans/premium-popover/index.jsx
+++ b/client/components/plans/premium-popover/index.jsx
@@ -25,16 +25,14 @@ let exclusiveViewLock = null;
 
 const PremiumPopover = React.createClass( {
 	propTypes: {
-		context: React.PropTypes.object,
 		className: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.object, React.PropTypes.array ] ),
 		onClose: React.PropTypes.func,
 		isVisible: React.PropTypes.bool,
 		position: React.PropTypes.string.isRequired,
-		bindContextEvents: React.PropTypes.bool
+		textLabel: React.PropTypes.string
 	},
 	getInitialState() {
 		return {
-			shouldBindEvents: !! this.props.bindContextEvents,
 			visibleByClick: false,
 			visibleByHover: false
 		};
@@ -60,17 +58,7 @@ const PremiumPopover = React.createClass( {
 	getSitePlan() {
 		return find( ( this.props.sitePlans.data || [] ), ( plan => plan.product_slug === 'value_bundle' ) );
 	},
-	componentDidUpdate( oldProps ) {
-		if ( oldProps.context !== this.props.context ) {
-			this.unbindContextEvents( oldProps.context );
-		}
-
-		if ( this.state.shouldBindEvents ) {
-			this.bindContextEvents();
-		}
-	},
 	componentWillUnmount() {
-		this.unbindContextEvents();
 		if ( exclusiveViewLock === this ) {
 			exclusiveViewLock = null;
 		}
@@ -84,22 +72,6 @@ const PremiumPopover = React.createClass( {
 	},
 	handleMouseLeave() {
 		this.setState( { visibleByHover: false } );
-	},
-	unbindContextEvents( elm = this.props.context ) {
-		if ( elm ) {
-			elm.removeEventListener( 'click', this.handleClick );
-			elm.removeEventListener( 'mouseenter', this.handleMouseEnter );
-			elm.removeEventListener( 'mouseleave', this.handleMouseLeave );
-		}
-	},
-	bindContextEvents() {
-		const elm = this.props.context;
-		if ( elm ) {
-			elm.addEventListener( 'click', this.handleClick );
-			elm.addEventListener( 'mouseenter', this.handleMouseEnter );
-			elm.addEventListener( 'mouseleave', this.handleMouseLeave );
-			this.setState( { shouldBindEvents: false } );
-		}
 	},
 	onClose( event ) {
 		if ( exclusiveViewLock === this ) {
@@ -118,28 +90,38 @@ const PremiumPopover = React.createClass( {
 	render() {
 		const premiumPlan = find( this.props.plans, ( plan => plan.product_slug === 'value_bundle' ) );
 		return (
-			<Popover
-				{ ...omit( this.props, [ 'children', 'className', 'bindContextEvents' ] ) }
-				onClose={ this.onClose }
-				isVisible={ this.isVisible() }
-				className={ classNames( this.props.className, 'premium-popover popover' ) }>
-				<div className="premium-popover__content">
-					<div className="premium-popover__header">
-						<h3>{ this.translate( 'Premium', { context: 'Premium Plan' } ) }</h3>
-						{ premiumPlan ? <PlanPrice plan={ premiumPlan } sitePlan={ this.getSitePlan() }/> : <h5>Loading</h5> }
+			<span
+				onClick={ this.handleClick }
+				onMouseEnter={ this.handleMouseEnter }
+				onMouseLeave={ this.handleMouseLeave }>
+				{ this.props.textLabel }
+				<Popover
+					{ ...omit( this.props, [ 'children', 'className', 'textLabel' ] ) }
+					onClose={ this.onClose }
+					context={ this }
+					isVisible={ this.isVisible() }
+					className={ classNames( this.props.className, 'premium-popover popover' ) }>
+					<div className="premium-popover__content">
+						<div className="premium-popover__header">
+							<h3>{ this.translate( 'Premium', { context: 'Premium Plan' } ) }</h3>
+							{ premiumPlan
+								? <PlanPrice plan={ premiumPlan } sitePlan={ this.getSitePlan() }/>
+								: <h5>Loading</h5> }
+						</div>
+						<ul className="premium-popover__items">
+							{ [
+								this.translate( 'A custom domain' ),
+								this.translate( 'Advanced design customization' ),
+								this.translate( '13GB of space for file and media' ),
+								this.translate( 'Video Uploads' ),
+								this.translate( 'No Ads' ),
+								this.translate( 'Email and live chat support' )
+							].map( ( message, i ) => <li key={ i }><Gridicon icon="checkmark" size={ 18 }/> { message }
+							</li> ) }
+						</ul>
 					</div>
-					<ul className="premium-popover__items">
-						{ [
-							this.translate( 'A custom domain' ),
-							this.translate( 'Advanced design customization' ),
-							this.translate( '13GB of space for file and media' ),
-							this.translate( 'Video Uploads' ),
-							this.translate( 'No Ads' ),
-							this.translate( 'Email and live chat support' )
-						].map( ( message, i ) => <li key={ i }><Gridicon icon="checkmark" size={ 18 }/> { message }</li> ) }
-					</ul>
-				</div>
-			</Popover>
+				</Popover>
+			</span>
 		);
 	}
 } );


### PR DESCRIPTION
The `PremiumPopover` component relied on binding mouse events on a parent element, which is not very optimal.

The component has been updated to bind the mouse events on an element that is contained within the component.

This is an update to #6892 where a fix was issued, but the underlying problem wasn't fixed. 

To test: 

1. Reach the Domains list
2. Check if the popup works on the example screen (see screenshot): ![screen shot 2016-07-20 at 14 01 11](https://cloud.githubusercontent.com/assets/184938/16984448/b1cedb36-4e82-11e6-8d21-4e9aa920161a.png)
3. Search for a domain
4. Check if the popup works on the domains search results screen (see screenshot): ![screen shot 2016-07-20 at 14 02 09](https://cloud.githubusercontent.com/assets/184938/16984461/c0fd9b88-4e82-11e6-8732-03d6377697b3.png)

Expected behavior:
- If you just hover on the popup it will show and it will disappear after you move the mouse out of the text label.
- If you click on the text label, the popup should stay open until you click elsewhere. No other popup should show on mouse over. 


cc @michaeldcain @coreh @klimeryk @umurkontaci

Test live: https://calypso.live/?branch=fix/6892-proper-fix-for-premium-popover