### PR TITLE
Domains Search Example: Remove use of an extra variable.

### DIFF
--- a/client/components/domains/example-domain-suggestions/index.jsx
+++ b/client/components/domains/example-domain-suggestions/index.jsx
@@ -95,7 +95,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		let examples, mappingInformation;
+		let mappingInformation;
 
 		if ( ! isEmpty( this.props.products ) ) {
 			const components = {
@@ -123,7 +123,7 @@ module.exports = React.createClass( {
 			mappingInformation = this.translate( 'Loading…' );
 		}
 
-		examples = (
+		return (
 			<Card className="example-domain-suggestions">
 				<div className="example-domain-suggestions__illustration" />
 				<div className="example-domain-suggestions__information">
@@ -139,7 +139,5 @@ module.exports = React.createClass( {
 				</div>
 			</Card>
 		);
-
-		return examples;
 	}
 } );


### PR DESCRIPTION
The `examples` variable is unneeded in the context it was defined and used in. 

To test: 

1. Reach domain search list
2. See if the Example domain suggestion component is rendering properly (see screenshot): ![screen shot 2016-07-20 at 14 31 02](https://cloud.githubusercontent.com/assets/184938/16985091/e43cdad8-4e86-11e6-8405-72bf62d6b6a4.png)


Test live: https://calypso.live/?branch=fix/example-domain-suggestions-janitorial-improve-code