### PR TITLE
Themes: Update search icon styling selector

### DIFF
--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -12,7 +12,7 @@
 		margin: 0;
 	}
 
-	.section-nav-tabs .noticon {
+	.section-nav-tabs .search-open__icon {
 		color: lighten( $gray, 10% );
 	}
 

--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -12,7 +12,7 @@
 		margin: 0;
 	}
 
-	.section-nav-tabs .search-open__icon {
+	.search .search-open__icon {
 		color: lighten( $gray, 10% );
 	}
 


### PR DESCRIPTION
We were still using `.noticon` as the selector here, even though the `<Search/>`  component has been using `Gridicon` for a while.

This PR purports to update the selector accordingly, but from what I can see, it doesn't really work :-p So consider it more of an RFC. cc @folletto

(This is the last occurrence of a `noticon` string in `my-sites/theme[s]`.)

Test live: https://calypso.live/design/?branch=update/themes-search-icon-styling