### PR TITLE
Theme: Remove 'Live Demo' option for Jetpack sites

### DIFF
--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import pickBy from 'lodash/pickBy';
-import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
@@ -108,13 +107,8 @@ const ThemesSingleSite = ( props ) => {
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const { selectedSite: site, isJetpack } = stateProps;
+	const { selectedSite: site } = stateProps;
 	const options = dispatchProps;
-
-	if ( isJetpack ) {
-		options.preview.getUrl = theme => dispatchProps.customize.getUrl( theme, site );
-		options.preview.action = noop;
-	}
 
 	const filteredOptions = pickBy( options, option =>
 		! ( option.hideForSite && option.hideForSite( stateProps ) )

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -64,6 +64,8 @@ export const tryandcustomize = {
 	hideForTheme: theme => theme.active
 };
 
+// This is a special option that gets its `action` added by `ThemeShowcase` or `ThemeSheet`,
+// respectively. TODO: Replace with a real action once we're able to use `DesignPreview`.
 export const preview = {
 	label: i18n.translate( 'Live demo', {
 		comment: 'label for previewing the theme demo website'

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -68,6 +68,7 @@ export const preview = {
 	label: i18n.translate( 'Live demo', {
 		comment: 'label for previewing the theme demo website'
 	} ),
+	hideForSite: ( { isJetpack = false } = {} ) => isJetpack,
 	hideForTheme: theme => theme.active
 };
 


### PR DESCRIPTION
It currently does the exact same thing as 'Try and Customize', and requires an ugly hack.

Test live: https://calypso.live/?branch=remove/themes-jetpack-site-preview