### PR TITLE
GuidedTours: Introduce continueIf condition for steps

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -10,7 +10,7 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, isPreviewShowing } from 'state/ui/selectors';
 
 const tours = {
 	main: {
@@ -75,6 +75,7 @@ const tours = {
 			type: 'BasicStep',
 			placement: 'center',
 			showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
+			continueIf: state => ! isPreviewShowing( state ),
 			next: 'close-preview',
 		},
 		'close-preview': {
@@ -85,6 +86,7 @@ const tours = {
 			icon: 'cross-small',
 			text: i18n.translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ),
 			showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
+			continueIf: state => ! isPreviewShowing( state ),
 			next: 'themes',
 		},
 		themes: {

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
+import { defer } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,6 +43,13 @@ class GuidedTours extends Component {
 		this.updateTarget( stepConfig );
 	}
 
+	componentWillReceiveProps( nextProps ) {
+		const { stepConfig } = nextProps.tourState;
+
+		stepConfig.continueIf &&
+			stepConfig.continueIf( nextProps.state ) &&
+			this.next();
+	}
 	shouldComponentUpdate( nextProps ) {
 		return this.props.tourState !== nextProps.tourState;
 	}
@@ -91,7 +99,7 @@ class GuidedTours extends Component {
 			);
 			this.quit( { error: ERROR_WAITED_TOO_LONG } );
 		};
-		wait( { condition: nextTargetFound, consequence: proceedToNextStep, onError: abortTour } );
+		defer( () => wait( { condition: nextTargetFound, consequence: proceedToNextStep, onError: abortTour } ) );
 	}
 
 	quit( options = {} ) {
@@ -144,6 +152,7 @@ class GuidedTours extends Component {
 
 export default connect( ( state ) => ( {
 	tourState: getGuidedTourState( state ),
+	state,
 } ), {
 	nextGuidedTourStep,
 	quitGuidedTour,

--- a/client/layout/guided-tours/steps.js
+++ b/client/layout/guided-tours/steps.js
@@ -126,20 +126,22 @@ class ActionStep extends Component {
 	}
 
 	addTargetListener() {
-		const { targetSlug = false, onNext } = this.props;
+		const { targetSlug = false, onNext, continueIf } = this.props;
 		const target = targetForSlug( targetSlug );
 
-		if ( onNext && target && target.addEventListener ) {
+		if ( ! continueIf && onNext && target && target.addEventListener ) {
 			target.addEventListener( 'click', onNext );
+			target.addEventListener( 'touchstart', onNext );
 		}
 	}
 
 	removeTargetListener() {
-		const { targetSlug = false, onNext } = this.props;
+		const { targetSlug = false, onNext, continueIf } = this.props;
 		const target = targetForSlug( targetSlug );
 
-		if ( onNext && target && target.removeEventListener ) {
+		if ( ! continueIf && onNext && target && target.removeEventListener ) {
 			target.removeEventListener( 'click', onNext );
+			target.removeEventListener( 'touchstart', onNext );
 		}
 	}
 


### PR DESCRIPTION
Sometimes we want an ActionStep to be completed when a certain condition
has been reached, e.g. there are theme results found from a search.

We can specify this in a step config like:
```continueIf: ( state ) => themeResultsShown( state )```

The way is this implemented at the moment is suboptimal, as we are
passing the entire Redux state to the GuidedTours component, since we
want to call the `proceedToNextStep()` action, to make sure step
progression is correct in the state.

Middleware seems like a more reasonable place to do this, but should be
part of a later refactoring, when we're satifisied that the whole
GuidedTour framework… works.

To test:
- http://calypso.localhost:3000?tour=main
- Go through the steps, when you've opened the site preview, you should be able to get good step progression when you:
 - Close the preview on the 'This is your site's preview…' step via a click on the X
 - Close the preview on the  'Take a look at your site step', with the escape key

Also fixes #5812

Test live: https://calypso.live/?branch=update/guided-tours-continueif