### PR TITLE
Plans: Push free plan to the end on mobile

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -7,6 +7,7 @@ import { map, reduce, noop } from 'lodash';
 import page from 'page';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +29,9 @@ import {
 	isPopular,
 	isMonthly,
 	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
 	getPlanFeaturesObject
 } from 'lib/plans/constants';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -75,7 +79,15 @@ class PlanFeatures extends Component {
 	}
 
 	renderMobileView() {
-		const { planProperties, isPlaceholder, translate } = this.props;
+		const { isPlaceholder, translate } = this.props;
+		const planProperties = [];
+
+		[ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_FREE ].forEach( planName => {
+			const planObject = find( this.props.planProperties, plan => plan.planName === planName );
+			if ( planObject ) {
+				planProperties.push( planObject );
+			}
+		} );
 
 		return map( planProperties, ( properties ) => {
 			const {


### PR DESCRIPTION
This is a part of plans redesign.
In NUX it pushes the free plan **only in nux on mobile** to the end

![screen shot 2016-07-20 at 17 05 38 pm](https://cloud.githubusercontent.com/assets/3775068/16991605/5fb8ed9a-4e9c-11e6-9440-6fe588d044a4.png)

## Testing
1. Assign yourself to `planFeatures`: show test
2. Go to  http://calypso.localhost:3000/start/test-plans
3. See free plan at the beggining
4. Change the window to mobile size
5. See free at the end
6. Go to http://calypso.localhost:3000/plans/artpitesting.com
7. See no free plan

CC @rralian @retrofox 

Test live: https://calypso.live/?branch=update/plans-change-order-mobile