### PR TITLE
Plans: use blue for ribbon and button colors against secondary buttons

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -25,7 +25,7 @@ const PlanFeaturesActions = ( {
 	const className = classNames( {
 		'plan-features__actions-button': true,
 		'is-current': current,
-		'is-popular': popular
+		'is-primary': popular && ! isPlaceholder,
 	} );
 
 	if ( current ) {
@@ -40,7 +40,6 @@ const PlanFeaturesActions = ( {
 			<Button
 				className={ className }
 				onClick={ isPlaceholder ? noop : onUpgradeClick }
-				primary={ ! isPlaceholder }
 				disabled={ isPlaceholder }
 			>
 				{

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -46,7 +46,7 @@ class PlanFeaturesHeader extends Component {
 		return (
 			<header className="plan-features__header" onClick={ this.props.onClick } >
 				{
-					popular && <Ribbon color="green">{ translate( 'Popular' ) }</Ribbon>
+					popular && <Ribbon>{ translate( 'Popular' ) }</Ribbon>
 				}
 				<div className="plan-features__header-figure" >
 					<PlanIcon plan={ planType } />


### PR DESCRIPTION
In response to feedback for our impending redesign, I'm tweaking the colors of the callout ribbon and primary buttons. Rather than using green to callout the popular plan, we'll make the ribbon and upgrade button our standard blue and use secondary buttons for the other plans.

We also discussed adding colorized icons, but I'd like to explore that separately if we're ok with this change first.

## Nux View
![desktop nux](https://cloudup.com/c-CSbQfOORM+)
![mobile nux](https://cloudup.com/ccEEjhKna_P+)

## Plans Page
![plans page free](https://cloudup.com/cMmji834I57+)

## Testing
You can see these pages by setting your abtest value for `planFeatures` to `show` and then going to http://calypso.localhost:3000/plans/ and http://calypso.localhost:3000/start

/cc @apeatling @adambbecker @mtias 

Test live: https://calypso.live/?branch=update/redesign-button-colors