### PR TITLE
Plans Redesign: Add color borders to different plans.

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -27,6 +27,7 @@ $orange-fire:            #d54e21;
 $alert-yellow:           #f0b849;
 $alert-red:              #d94f4f;
 $alert-green:            #4ab866;
+$alert-purple:           #855DA6;
 
 // Link hovers
 $link-highlight:         tint($blue-medium, 20%);

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -27,6 +27,7 @@ $orange-fire:            #d54e21;
 $alert-yellow:           #f0b849;
 $alert-red:              #d94f4f;
 $alert-green:            #4ab866;
+$alert-purple:           #855DA6;
 
 // Link hovers
 $link-highlight:         tint($blue-medium, 20%);
@@ -37,7 +38,6 @@ $transparent:            rgba(255,255,255,0);
 
 // Uncommon
 $border-ultra-light-gray: #e8f0f5;
-$business-plan-purple:           #855DA6;
 
 // Layout
 $masterbar-color:          $blue-wordpress;

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -27,7 +27,6 @@ $orange-fire:            #d54e21;
 $alert-yellow:           #f0b849;
 $alert-red:              #d94f4f;
 $alert-green:            #4ab866;
-$alert-purple:           #855DA6;
 
 // Link hovers
 $link-highlight:         tint($blue-medium, 20%);
@@ -38,6 +37,7 @@ $transparent:            rgba(255,255,255,0);
 
 // Uncommon
 $border-ultra-light-gray: #e8f0f5;
+$business-plan-purple:           #855DA6;
 
 // Layout
 $masterbar-color:          $blue-wordpress;

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -43,7 +43,11 @@ class PlanFeaturesHeader extends Component {
 			'is-discounted': isDiscounted,
 			'is-placeholder': isPlaceholder
 		} );
-		const headerClasses = classNames( 'plan-features__header', `plan-features__type-${ planType }` );
+		const headerClasses = classNames( 'plan-features__header', {
+			'is-personal': planType === 'personal-bundle',
+			'is-premium': planType === 'value_bundle',
+			'is-business': planType === 'business-bundle'
+		} );
 
 		return (
 			<header className={ headerClasses } onClick={ this.props.onClick } >

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -43,8 +43,10 @@ class PlanFeaturesHeader extends Component {
 			'is-discounted': isDiscounted,
 			'is-placeholder': isPlaceholder
 		} );
+		const headerClasses = classNames( 'plan-features__header', 'plan-features__type-' + planType );
+
 		return (
-			<header className="plan-features__header" onClick={ this.props.onClick } >
+			<header className={ headerClasses } onClick={ this.props.onClick } >
 				{
 					popular && <Ribbon>{ translate( 'Popular' ) }</Ribbon>
 				}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -43,7 +43,7 @@ class PlanFeaturesHeader extends Component {
 			'is-discounted': isDiscounted,
 			'is-placeholder': isPlaceholder
 		} );
-		const headerClasses = classNames( 'plan-features__header', 'plan-features__type-' + planType );
+		const headerClasses = classNames( 'plan-features__header', `plan-features__type-${ planType }` );
 
 		return (
 			<header className={ headerClasses } onClick={ this.props.onClick } >

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -166,7 +166,7 @@ $plan-features-sidebar-width: 272px;
 	}
 
 	&.is-business {
-		border-bottom: solid 2px $business-plan-purple;
+		border-bottom: solid 2px $alert-purple;
 	}
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -157,15 +157,15 @@ $plan-features-sidebar-width: 272px;
 		padding: 12px 12px 0 12px;
 	}
 
-	&.plan-features__type-personal-bundle {
+	&.is-personal {
 		border-bottom: solid 2px $alert-yellow;
 	}
 
-	&.plan-features__type-value_bundle {
+	&.is-premium {
 		border-bottom: solid 2px $alert-green;
 	}
 
-	&.plan-features__type-business-bundle {
+	&.is-business {
 		border-bottom: solid 2px $business-plan-purple;
 	}
 }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -166,7 +166,7 @@ $plan-features-sidebar-width: 272px;
 	}
 
 	&.plan-features__type-business-bundle {
-		border-bottom: solid 2px $alert-purple;
+		border-bottom: solid 2px $business-plan-purple;
 	}
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -156,6 +156,18 @@ $plan-features-sidebar-width: 272px;
 	@include breakpoint( "<960px" ) {
 		padding: 12px 12px 0 12px;
 	}
+
+	&.plan-features__type-personal-bundle {
+		border-bottom: solid 2px $alert-yellow;
+	}
+
+	&.plan-features__type-value_bundle {
+		border-bottom: solid 2px $alert-green;
+	}
+
+	&.plan-features__type-business-bundle {
+		border-bottom: solid 2px $alert-purple;
+	}
 }
 
 .plan-features__header-figure {


### PR DESCRIPTION
Added border colors to plans:

![screen shot 2016-07-20 at 11 01 41](https://cloud.githubusercontent.com/assets/1464705/16997212/60e8ec66-4e69-11e6-9782-48bc85213fa9.png)

Couple of questions:

- [x] What should the new purple color name be? Just added it as an alert color right now, but it's not being used as an alert. Would `business-plan-purple` under uncommon make more sense?

- [x] What should the CSS classes for plan headers be? I've used `'plan-features__type-' + planType` but I'm not sure that is ideal.

Test live: https://calypso.live/?branch=add/plan-color-borders