### PR TITLE
Plans: Tweak "Monetize Site" wording

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -354,7 +354,7 @@ export const featuresList = {
 	[ FEATURE_WORDADS_INSTANT ]: {
 		getTitle: () => i18n.translate( 'Monetize Your Site' ),
 		getDescription: () => i18n.translate(
-			'Add advertising to your site through our WordAds program and earn money from impressions.'
+			'Add your own advertising to your site through our WordAds program and earn money from impressions.'
 		),
 		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ]
 	},


### PR DESCRIPTION
Make sure it’s clear that you can add **your own advertising** with this feature, and benefit from that.

In the plans page we show “Remove WordPress.com ads” right above this, so without the clarity the two features seem to conflict. We enable remove ads, then say that you can add ads to make money.

Before:
![screen shot 2016-07-20 at 11 10 31](https://cloud.githubusercontent.com/assets/1464705/16997503/a4a0c55e-4e6a-11e6-8946-3df79a387528.png)

After:
![screen shot 2016-07-20 at 11 11 35](https://cloud.githubusercontent.com/assets/1464705/16997553/d16c054e-4e6a-11e6-8edc-056f8facb211.png)


Test live: https://calypso.live/?branch=update/monetize-feature-wording