### PR TITLE
Plans Redesign: Make sure the "Free" column is a consistent size

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -78,6 +78,7 @@ $plan-features-sidebar-width: 272px;
 	border-spacing: 16px 0;
 	margin-top: -16px;
 	display: none;
+	table-layout: fixed;
 
 	@include breakpoint( ">480px" ) {
 		display: table;
@@ -95,7 +96,7 @@ $plan-features-sidebar-width: 272px;
 	border-left: solid 1px lighten( $gray, 27% );
 	background-color: lighten( $gray, 35% );
 	position: relative;
-	width: 300px;
+	width: 25%;
 }
 
 .plan-features__table-item.is-selected {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -96,7 +96,6 @@ $plan-features-sidebar-width: 272px;
 	border-left: solid 1px lighten( $gray, 27% );
 	background-color: lighten( $gray, 35% );
 	position: relative;
-	width: 25%;
 }
 
 .plan-features__table-item.is-selected {


### PR DESCRIPTION
The Free column in NUX was being squished smaller than the other columns on smaller viewports.

Before:
![cloudup-f0e4fec4-ee8b-49c5-8ea9-c78455bda9c9](https://cloud.githubusercontent.com/assets/1464705/16998890/46afba12-4e70-11e6-95a5-7e0603dce05c.png)

After:
![screen shot 2016-07-20 at 11 51 38](https://cloud.githubusercontent.com/assets/1464705/16998904/5a827c00-4e70-11e6-96db-422d2de387ac.png)

/cc @meremagee 

Test live: https://calypso.live/?branch=fix/plans-nux-free-size