### PR TITLE
Plans: Add descriptions to some free plans features

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -362,7 +362,7 @@ export const featuresList = {
 	[ FEATURE_WP_SUBDOMAIN ]: {
 		getTitle: () => i18n.translate( 'WordPress.com Subdomain' ),
 		getDescription: () => i18n.translate(
-			'Recognizeable name.wordpress.com domain (if it`s available).'
+			'Your site address will use a WordPress.com subdomain (sitename.wordpress.com).'
 		),
 		plans: [ PLAN_FREE ]
 	},
@@ -401,8 +401,8 @@ export const featuresList = {
 	[ FEATURE_COMMUNITY_SUPPORT ]: {
 		getTitle: () => i18n.translate( 'Community support' ),
 		getDescription: () => i18n.translate(
-			'Support and advice provided by ' +
-			'user community of forums.wordpress.com.'
+			'Get support through our ' +
+			'user community forums.'
 		),
 		plans: [ PLAN_FREE ]
 	},

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -361,6 +361,9 @@ export const featuresList = {
 
 	[ FEATURE_WP_SUBDOMAIN ]: {
 		getTitle: () => i18n.translate( 'WordPress.com Subdomain' ),
+		getDescription: () => i18n.translate(
+			'Recognizeable name.wordpress.com domain (if it`s available).'
+		),
 		plans: [ PLAN_FREE ]
 	},
 
@@ -397,6 +400,10 @@ export const featuresList = {
 
 	[ FEATURE_COMMUNITY_SUPPORT ]: {
 		getTitle: () => i18n.translate( 'Community support' ),
+		getDescription: () => i18n.translate(
+			'Support and advice provided by ' +
+			'user community of forums.wordpress.com.'
+		),
 		plans: [ PLAN_FREE ]
 	},
 


### PR DESCRIPTION
<img width="456" alt="zrzut ekranu 2016-07-20 o 20 45 58" src="https://cloud.githubusercontent.com/assets/3775068/16998947/f169f68e-4ebb-11e6-8bf1-d192bfbd4f87.png">
<img width="468" alt="zrzut ekranu 2016-07-20 o 20 45 52" src="https://cloud.githubusercontent.com/assets/3775068/16998950/f5989936-4ebb-11e6-909f-cc0163294a02.png">

##Testing
- assign yourself to `plansFeatures` test
- go to http://calypso.localhost:3000/start/test-plans
- clock on the ℹ icons

CC @rralian @apeatling 

Test live: https://calypso.live/?branch=update/plan-featues-info