### PR TITLE
Plans: Drag mobile view until 660px

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -20,7 +20,7 @@ $plan-features-sidebar-width: 272px;
 	margin: 0 16px;
 	display: block;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">660px" ) {
 		display: none;
 	}
 
@@ -79,7 +79,7 @@ $plan-features-sidebar-width: 272px;
 	margin-top: -16px;
 	display: none;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">660px" ) {
 		display: table;
 	}
 


### PR DESCRIPTION
# Problem
Our breakpoints 480-660 wnre not exactly awesome for the 480-660 sizes:
<img width="682" alt="zrzut ekranu 2016-07-20 o 20 49 13" src="https://cloud.githubusercontent.com/assets/3775068/16999299/91cb5a7c-4ebd-11e6-8a6c-5b50cadbc173.png">

# Solution

Dragged the mobile view breakpoint until 660px:
<img width="634" alt="zrzut ekranu 2016-07-20 o 21 03 12" src="https://cloud.githubusercontent.com/assets/3775068/16999314/a2f0cc56-4ebd-11e6-8e9a-c46d6a15bf99.png">

# Testing

1. assign `planFeatures` test
2. Go to http://calypso.localhost:3000/start/test-plans
3. Open devtools -> mobile view
4. Chose responsive
5. Drag the screen width and see that until 660px its mobile

CC @rralian @apeatling 

Test live: https://calypso.live/?branch=update/plans-features-responsive