### PR TITLE
Plans: launches the plans redesign test to production

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -62,7 +62,7 @@ module.exports = {
 		defaultVariation: 'singlePurchaseFlow'
 	},
 	planFeatures: {
-		datestamp: '20160801',
+		datestamp: '20160720',
 		variations: {
 			original: 50,
 			show: 50

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -41,7 +41,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plan-features": false,
+		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": true,

--- a/config/production.json
+++ b/config/production.json
@@ -37,7 +37,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plan-features": false,
+		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plan-features": false,
+		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": true,

--- a/config/test.json
+++ b/config/test.json
@@ -57,7 +57,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plan-features": false,
+		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/compatibility-warning": false,


### PR DESCRIPTION
Updates the test date today and enables the test in all environments except desktop. I'm not sure it's appropriate to enable it there right now, and think it's probably better for us to keep abtests in the web version.

## Testing
We've already tested this feature in wpcalypso, so there isn't too much to test here. Just agree that the redesign is ready. :-)

Test live: https://calypso.live/?branch=update/launch-plans-redesign-test