### PR TITLE
Editor: Display Tags accordion for themes supporting Featured Content

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -89,10 +89,6 @@ const EditorDrawer = React.createClass( {
 		actions.edit( { excerpt: event.target.value } );
 	},
 
-	hasHardCodedPostTypeSupports( type ) {
-		return POST_TYPE_SUPPORTS.hasOwnProperty( type );
-	},
-
 	currentPostTypeSupports: function( feature ) {
 		const { typeObject, type } = this.props;
 
@@ -101,7 +97,7 @@ const EditorDrawer = React.createClass( {
 		}
 
 		// Fall back to hard-coded settings if known for type
-		if ( this.hasHardCodedPostTypeSupports( type ) ) {
+		if ( POST_TYPE_SUPPORTS.hasOwnProperty( type ) ) {
 			return !! POST_TYPE_SUPPORTS[ type ][ feature ];
 		}
 
@@ -328,7 +324,7 @@ const EditorDrawer = React.createClass( {
 
 		return (
 			<div className="editor-drawer">
-				{ site && ! this.hasHardCodedPostTypeSupports( type ) && (
+				{ site && (
 					<QueryPostTypes siteId={ site.ID } />
 				) }
 				{ this.renderTaxonomies() }

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -117,9 +117,14 @@ const EditorDrawer = React.createClass( {
 	renderTaxonomies: function() {
 		const { type, post, site, canJetpackUseTaxonomies } = this.props;
 
+		// Compatibility: Allow Tags for pages when supported prior to launch
+		// of custom post types feature (#6934). [TODO]: Remove after launch.
+		const isCustomTypesEnabled = config.isEnabled( 'manage/custom-post-types' );
+		const typeSupportsTags = ! isCustomTypesEnabled && this.currentPostTypeSupports( 'tags' );
+
 		// Categories & Tags
 		let categories;
-		if ( 'post' === type ) {
+		if ( 'post' === type || typeSupportsTags ) {
 			categories = (
 				<CategoriesTagsAccordion
 					site={ site }
@@ -139,8 +144,7 @@ const EditorDrawer = React.createClass( {
 
 		// Custom Taxonomies
 		let taxonomies;
-		if ( config.isEnabled( 'manage/custom-post-types' ) &&
-				false !== canJetpackUseTaxonomies ) {
+		if ( isCustomTypesEnabled && false !== canJetpackUseTaxonomies ) {
 			taxonomies = <EditorDrawerTaxonomies postTerms={ get( post, 'terms' ) } />;
 		}
 


### PR DESCRIPTION
Fixes #6934
Regression introduced in #6626

This pull request seeks to enable Tags sidebar accordion in the editor when the post type supports the `tags` feature. This applies for themes supporting "Featured Content", e.g. Sketch theme.

__Testing instructions:__

For all verification steps, test both with `manage/custom-post-types` enabled and disabled, both running a theme supporting Featured Content (e.g. Sketch) and not, to ensure expectations are met. To disable the feature in development, restart your running Calypso instance with:

```
DISABLE_FEATURES=manage/custom-post-types make run
```

You may also find it useful to run without Redux persistence, since persisted data may leak into subsequent refreshes.

```
DISABLE_FEATURES=persist-redux,manage/custom-post-types make run
```

- Categories & Tags accordion should be displayed [editing posts](http://calypso.localhost:3000/post), both with and without feature flag enabled
- Custom taxonomies accordion are shown when `manage/custom-post-types` feature flag is enabled
- Tags are shown for pages supporting the `tags` feature, both with and without `manage/custom-post-types` feature flag enabled
- ~~Tags are _not_ shown for pages supporting the `tags` feature when `manage/custom-post-types` is enabled. This is a bug with the `GET /sites/%s/post-types/page/taxonomies` endpoint not affecting production usage, to be resolved separately (609-gh-io).~~ (Fixed)

Test live: https://calypso.live/?branch=fix/6934-editor-page-tags-support