### PR TITLE
GuidedTours: Move responsibility of showing tours into GT component

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -111,12 +111,13 @@ class GuidedTours extends Component {
 	}
 
 	render() {
-		const { stepConfig } = this.props.tourState;
-		debug( 'GuidedTours#render() tourState', this.props.tourState );
+		const { stepConfig, shouldShow } = this.props.tourState;
 
-		if ( ! stepConfig ) {
+		if ( ! shouldShow || ! stepConfig ) {
 			return null;
 		}
+
+		debug( 'GuidedTours#render() tourState', this.props.tourState );
 
 		const StepComponent = {
 			FirstStep,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -36,7 +36,6 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	SupportUser;
 
 import { isOffline } from 'state/application/selectors';
-import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import DesignPreview from 'my-sites/design-preview';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
@@ -179,7 +178,7 @@ Layout = React.createClass( {
 
 		return (
 			<div className={ sectionClass }>
-				{ config.isEnabled( 'guided-tours' ) && this.props.tourState.shouldShow ? <GuidedTours /> : null }
+				{ config.isEnabled( 'guided-tours' ) ? <GuidedTours /> : null }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				{ this.renderMasterbar() }
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
@@ -210,7 +209,6 @@ export default connect(
 			isSupportUser: state.support.isSupportUser,
 			section,
 			isOffline: isOffline( state ),
-			tourState: getGuidedTourState( state ),
 		};
 	}
 )( Layout );


### PR DESCRIPTION
`<GuidedTours>` should be responsible for showing tours or not, `<Layout>` shouldn't care. No functional change.

~~Also moved sectionLoading check into the GT component, going to
investigate why I thought this was necessary in the themes tour PR…~~

To test:
- Make sure http://calypso.localhost:3000/?tour=main still works

Test live: https://calypso.live/?branch=update/guided-tours-component-responsibility