### PR TITLE
CPT: Use "visible" icon for View button

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -45,7 +45,7 @@ class PostActionsEllipsisMenuView extends Component {
 			<PopoverMenuItem
 				href={ previewUrl }
 				onClick={ this.previewPost }
-				icon="external"
+				icon="visible"
 				target="_blank">
 				{ includes( [ 'publish', 'private' ], status )
 					? translate( 'View', { context: 'verb' } )


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/pull/6534#issuecomment-233474857

This pull request seeks to change the icon used in the [custom post types list screen](https://wpcalypso.wordpress.com/types/post) post menu View button from `icon="external"` to `icon="visible"` (eye).

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/17027538/312fcd18-4f32-11e6-8d94-239a03d13e82.png)|![After](https://cloud.githubusercontent.com/assets/1779930/17027519/1f0ea780-4f32-11e6-9e02-4336cef074ec.png)

__Testing instructions:__

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site
3. Toggle the ellipsis menu for a post
4. Note the "View" icon is `icon="visible"`

cc @hugobaeta @mtias @folletto 

Test live: https://calypso.live/types/post?branch=update/cpt-view-icon