### PR TITLE
UI: Use the hasSidebar property to drive the sidebar instead of section.secondary

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -163,13 +163,13 @@ Layout = React.createClass( {
 	},
 
 	render: function() {
-		var sectionClass = classnames(
+		const sectionClass = classnames(
 				'layout',
 				`is-group-${this.props.section.group}`,
 				`is-section-${this.props.section.name}`,
 				`focus-${this.props.focus.getCurrent()}`,
 				{ 'is-support-user': this.props.isSupportUser },
-				{ 'has-no-sidebar': ! this.props.section.secondary }
+				{ 'has-no-sidebar': ! this.props.hasSidebar }
 			),
 			loadingClass = classnames( {
 				layout__loader: true,
@@ -203,11 +203,12 @@ Layout = React.createClass( {
 
 export default connect(
 	( state ) => {
-		const { isLoading, section } = state.ui;
+		const { isLoading, section, hasSidebar } = state.ui;
 		return {
 			isLoading,
 			isSupportUser: state.support.isSupportUser,
 			section,
+			hasSidebar,
 			isOffline: isOffline( state ),
 		};
 	}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -36,7 +36,6 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	SupportUser;
 
 import { isOffline } from 'state/application/selectors';
-import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { hasSidebar } from 'state/ui/selectors';
 import DesignPreview from 'my-sites/design-preview';
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -36,6 +36,8 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	SupportUser;
 
 import { isOffline } from 'state/application/selectors';
+import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
+import { hasSidebar } from 'state/ui/selectors';
 import DesignPreview from 'my-sites/design-preview';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
@@ -90,7 +92,7 @@ Layout = React.createClass( {
 	},
 
 	renderPushNotificationPrompt: function() {
-		const participantInAbTest = config.isEnabled('push-notifications-ab-test') && abtest('browserNotifications') === 'enabled';
+		const participantInAbTest = config.isEnabled( 'push-notifications-ab-test' ) && abtest( 'browserNotifications' ) === 'enabled';
 		if ( ! config.isEnabled( 'push-notifications' ) && ! participantInAbTest ) {
 			return null;
 		}
@@ -120,22 +122,18 @@ Layout = React.createClass( {
 	},
 
 	renderWelcome: function() {
-		var translatorInvitation = this.props.translatorInvitation,
-			showInvitation,
-			showWelcome,
-			newestSite,
-			disablePollInvitation;
+		const translatorInvitation = this.props.translatorInvitation;
 
 		if ( ! this.props.user ) {
 			return null;
 		}
 
-		showWelcome = this.props.nuxWelcome.getWelcome();
-		newestSite = this.newestSite();
-		showInvitation = ! showWelcome &&
+		const showWelcome = this.props.nuxWelcome.getWelcome();
+		const newestSite = this.newestSite();
+		const showInvitation = ! showWelcome &&
 				translatorInvitation.isPending() &&
 				translatorInvitation.isValidSection( this.props.section.name );
-		disablePollInvitation = showWelcome || showInvitation;
+		const disablePollInvitation = showWelcome || showInvitation;
 
 		return (
 			<span>
@@ -203,12 +201,12 @@ Layout = React.createClass( {
 
 export default connect(
 	( state ) => {
-		const { isLoading, section, hasSidebar } = state.ui;
+		const { isLoading, section } = state.ui;
 		return {
 			isLoading,
 			isSupportUser: state.support.isSupportUser,
 			section,
-			hasSidebar,
+			hasSidebar: hasSidebar( state ),
 			isOffline: isOffline( state ),
 		};
 	}

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -98,3 +98,12 @@ export function getInitialQueryArguments( state ) {
 export function getCurrentQueryArguments( state ) {
 	return state.ui.queryArguments.current;
 }
+
+export function hasSidebar( state ) {
+	// this one is weird. defaults to true, so if true, fall through to the secondary prop on the section
+	const val = state.ui.hasSidebar;
+	if ( val === false ) {
+		return false;
+	}
+	return get( state.ui.section, 'secondary', true );
+}

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -11,6 +11,7 @@ import {
 	getSelectedSiteId,
 	getSectionName,
 	isSectionIsomorphic,
+	hasSidebar
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -118,6 +119,32 @@ describe( 'selectors', () => {
 			} );
 
 			expect( selected ).to.be.true;
+		} );
+	} );
+
+	describe( '#hasSidebar()', () => {
+		it( 'should return false if set', () => {
+			expect( hasSidebar( { ui: { hasSidebar: false } } ) ).to.be.false;
+		} );
+
+		it( 'should be true if true and secondary does not override it', () => {
+			expect( hasSidebar( {
+				ui: {
+					hasSidebar: true,
+					section: {}
+				}
+			} ) ).to.be.true;
+		} );
+
+		it( 'should fall back to the secondary prop on the current section when hasSidebar is true', () => {
+			expect( hasSidebar( {
+				ui: {
+					hasSidebar: true,
+					section: {
+						secondary: false
+					}
+				}
+			} ) ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
This allows components to fire a  action to hide the sidebar and put the apporpriate class on the Layout component

Test live: https://calypso.live/?branch=fix/ui/use-has-no-sidebar