### PR TITLE
Themes: use two buttons in most previews

### DIFF
--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -36,7 +36,8 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => Object.assign(
 	stateProps,
 	{
 		options: dispatchProps,
-		defaultOption: dispatchProps.tryandcustomize,
+		defaultOption: dispatchProps.activate,
+		secondaryOption: dispatchProps.tryandcustomize,
 		getScreenshotOption: () => dispatchProps.info
 	}
 );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -122,7 +122,8 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 		stateProps,
 		{
 			options: boundOptions,
-			defaultOption: boundOptions.tryandcustomize,
+			defaultOption: boundOptions.activate,
+			secondaryOption: boundOptions.tryandcustomize,
 			getScreenshotOption: theme => theme.active ? boundOptions.customize : boundOptions.info
 		}
 	);

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -20,36 +20,58 @@ export default React.createClass( {
 		theme: React.PropTypes.object,
 		showPreview: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
-		buttonLabel: React.PropTypes.string,
-		onButtonClick: React.PropTypes.func,
-		getButtonHref: React.PropTypes.func
+		primaryButtonLabel: React.PropTypes.string.isRequired,
+		onPrimaryButtonClick: React.PropTypes.func,
+		getPrimaryButtonHref: React.PropTypes.func,
+		secondaryButtonLabel: React.PropTypes.string,
+		onSecondaryButtonClick: React.PropTypes.func,
+		getSecondaryButtonHref: React.PropTypes.func,
 	},
 
 	getDefaultProps() {
 		return {
-			onButtonClick: noop,
-			getButtonHref: () => null
+			onPrimaryButtonClick: noop,
+			getPrimaryButtonHref: () => null,
+			onSecondaryButtonClick: noop,
+			getSecondaryButtonHref: () => null,
 		};
 	},
 
-	onButtonClick() {
-		this.props.onButtonClick( this.props.theme );
+	onPrimaryButtonClick() {
+		this.props.onPrimaryButtonClick( this.props.theme );
 		this.props.onClose();
 	},
 
+	onSecondaryButtonClick() {
+		this.props.onSecondaryButtonClick( this.props.theme );
+		this.props.onClose();
+	},
+
+	renderSecondaryButton() {
+		if ( ! this.props.secondaryButtonLabel ) {
+			return;
+		}
+		const buttonHref = this.props.getSecondaryButtonHref ? this.props.getSecondaryButtonHref( this.props.theme ) : null;
+		return (
+			<Button onClick={ this.onSecondaryButtonClick } href={ buttonHref } >
+				{ this.props.secondaryButtonLabel }
+			</Button>
+		);
+	},
+
 	render() {
-		const previewUrl = getPreviewUrl( this.props.theme ),
-			buttonHref = this.props.getButtonHref ? this.props.getButtonHref( this.props.theme ) : null;
+		const previewUrl = getPreviewUrl( this.props.theme );
+		const buttonHref = this.props.getPrimaryButtonHref ? this.props.getPrimaryButtonHref( this.props.theme ) : null;
 
 		return (
 			<WebPreview showPreview={ this.props.showPreview }
 				onClose={ this.props.onClose }
 				previewUrl={ previewUrl }
 				externalUrl={ this.props.theme.demo_uri } >
-				<Button primary
-					onClick={ this.onButtonClick }
-					href={ buttonHref }
-					>{ this.props.buttonLabel }</Button>
+				{ this.renderSecondaryButton() }
+				<Button primary onClick={ this.onPrimaryButtonClick } href={ buttonHref } >
+					{ this.props.primaryButtonLabel }
+				</Button>
 			</WebPreview>
 		);
 	}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -28,6 +28,7 @@ const ThemeShowcase = React.createClass( {
 		// Connected props
 		options: PropTypes.objectOf( optionShape ),
 		defaultOption: optionShape,
+		secondaryOption: optionShape,
 		getScreenshotOption: PropTypes.func
 	},
 
@@ -48,15 +49,41 @@ const ThemeShowcase = React.createClass( {
 		this.setState( { showPreview: ! this.state.showPreview, previewingTheme: theme } );
 	},
 
-	onPreviewButtonClick( theme ) {
-		const { defaultOption } = this.props;
+	onPrimaryPreviewButtonClick( theme ) {
+		const option = this.getPrimaryOption();
 		this.setState( { showPreview: false }, () => {
-			defaultOption.action && defaultOption.action( theme );
+			option.action && option.action( theme );
 		} );
 	},
 
+	onSecondaryPreviewButtonClick( theme ) {
+		const { secondaryOption } = this.props;
+		this.setState( { showPreview: false }, () => {
+			secondaryOption && secondaryOption.action ? secondaryOption.action( theme ) : null;
+		} );
+	},
+
+	getPrimaryOption() {
+		if ( ! this.state.showPreview ) {
+			return this.props.defaultOption;
+		}
+		const { translate } = this.props;
+		const { purchase, activate } = this.props.options;
+		const { price } = this.state.previewingTheme;
+		let primaryOption = this.props.defaultOption;
+		if ( price && purchase ) {
+			primaryOption = purchase;
+			primaryOption.label = translate( 'Pick this design' );
+		} else if ( activate ) {
+			primaryOption = activate;
+			primaryOption.label = translate( 'Activate this design' );
+		}
+		return primaryOption;
+	},
+
 	render() {
-		const { options, defaultOption, getScreenshotOption } = this.props;
+		const { options, getScreenshotOption, secondaryOption } = this.props;
+		const primaryOption = this.getPrimaryOption();
 
 		// If a preview action is passed, use that. Otherwise, use our own.
 		if ( options.preview && ! options.preview.action ) {
@@ -71,9 +98,13 @@ const ThemeShowcase = React.createClass( {
 					<ThemePreview showPreview={ this.state.showPreview }
 						theme={ this.state.previewingTheme }
 						onClose={ this.togglePreview }
-						primaryButtonLabel={ defaultOption.label }
-						getPrimaryButtonHref={ defaultOption.getUrl }
-						onPrimaryButtonClick={ this.onPreviewButtonClick } />
+						primaryButtonLabel={ primaryOption.label }
+						getPrimaryButtonHref={ primaryOption.getUrl }
+						onPrimaryButtonClick={ this.onPrimaryPreviewButtonClick }
+						secondaryButtonLabel={ secondaryOption ? secondaryOption.label : null }
+						getSecondaryButtonHref={ secondaryOption ? secondaryOption.getUrl : null }
+						onSecondaryButtonClick={ this.onSecondaryPreviewButtonClick }
+					/>
 				}
 				<ThemesSelection search={ this.props.search }
 					siteId={ this.props.siteId }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -71,9 +71,9 @@ const ThemeShowcase = React.createClass( {
 					<ThemePreview showPreview={ this.state.showPreview }
 						theme={ this.state.previewingTheme }
 						onClose={ this.togglePreview }
-						buttonLabel={ defaultOption.label }
-						getButtonHref={ defaultOption.getUrl }
-						onButtonClick={ this.onPreviewButtonClick } />
+						primaryButtonLabel={ defaultOption.label }
+						getPrimaryButtonHref={ defaultOption.getUrl }
+						onPrimaryButtonClick={ this.onPreviewButtonClick } />
 				}
 				<ThemesSelection search={ this.props.search }
 					siteId={ this.props.siteId }

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -83,7 +83,8 @@ const ThemesSiteSelectorModal = React.createClass( {
 			this.props.children,
 			Object.assign( {}, omit( this.props, [ 'children', 'options', 'defaultOption' ] ), {
 				options: mapValues( this.props.options, this.wrapOption ),
-				defaultOption: this.wrapOption( this.props.defaultOption )
+				defaultOption: this.wrapOption( this.props.defaultOption ),
+				secondaryOption: this.props.secondaryOption ? this.wrapOption( this.props.secondaryOption ) : null,
 			} )
 		);
 


### PR DESCRIPTION
When #6349 was merged, it (intentionally) removed the "Try & Customize" button from both the Theme Sheet and the Theme Preview. 

This PR restores the "Try & Customize" button as a *secondary* option in the preview except for logged-out users or active themes.

In order for it to be secondary, this PR also *replaces* the primary button in some previews with a different one when the primary button would already be "Try & Customize" (previews from the theme showcase).

Some of the complexity is that the new primary button needs to be different based on the theme's free/non-free status.

Before (free, logged-in, single-site, non-active theme, from theme sheet):

<img width="984" alt="screen shot 2016-07-21 at 12 58 34 pm" src="https://cloud.githubusercontent.com/assets/2036909/17031622/0b796bfe-4f43-11e6-9c6f-7cb1e9021a17.png">

After (free, logged-in, single-site, non-active theme, from theme sheet):

<img width="993" alt="screen shot 2016-07-21 at 1 00 28 pm" src="https://cloud.githubusercontent.com/assets/2036909/17031636/22bb4968-4f43-11e6-9b94-b4ef36439e02.png">

Before (free, logged-in, single-site, non-active theme, from theme showcase):

<img width="982" alt="screen shot 2016-07-21 at 1 04 48 pm" src="https://cloud.githubusercontent.com/assets/2036909/17031764/c13133b4-4f43-11e6-8319-9479a8f57014.png">

After (free, logged-in, single-site, non-active theme, from theme showcase):

<img width="978" alt="screen shot 2016-07-21 at 1 05 52 pm" src="https://cloud.githubusercontent.com/assets/2036909/17031800/ecc7f562-4f43-11e6-8651-c5bd5cfc719c.png">

Before (non-free, logged-in, single-site, non-active theme, from theme sheet):

<img width="983" alt="screen shot 2016-07-21 at 1 11 04 pm" src="https://cloud.githubusercontent.com/assets/2036909/17031934/a5a17388-4f44-11e6-944c-91402d3827db.png">

After (non-free, logged-in, single-site, non-active theme, from theme sheet):

<img width="985" alt="screen shot 2016-07-21 at 1 13 52 pm" src="https://cloud.githubusercontent.com/assets/2036909/17032002/06090682-4f45-11e6-9c7a-8c29eefe6c75.png">

Before (non-free, logged-in, single-site, non-active theme, from theme showcase):

<img width="984" alt="screen shot 2016-07-21 at 1 10 50 pm" src="https://cloud.githubusercontent.com/assets/2036909/17031948/b1bcd11c-4f44-11e6-934c-8fcb721d9ba8.png">

After (non-free, logged-in, single-site, non-active theme, from theme showcase):

<img width="985" alt="screen shot 2016-07-21 at 1 13 52 pm" src="https://cloud.githubusercontent.com/assets/2036909/17032002/06090682-4f45-11e6-9c7a-8c29eefe6c75.png">

Split from #6928 



Test live: https://calypso.live/design?branch=add/try-and-customize-for-all-previews