### PR TITLE
Remove preferences (me/settings) from sync-handler whitelist

### DIFF
--- a/client/lib/wp/sync-handler/whitelist-handler.js
+++ b/client/lib/wp/sync-handler/whitelist-handler.js
@@ -17,7 +17,7 @@ export const isWhitelisted = params => {
 	if ( params.method && 'get' !== params.method.toLowerCase() ) {
 		debug( 'Do not allow %o request', params.method, params );
 		return false;
-	};
+	}
 
 	for ( let i = 0; i < whitelist.length; i++ ) {
 		if ( whitelist[ i ].test( path ) ) {
@@ -29,4 +29,4 @@ export const isWhitelisted = params => {
 	debug( '%o is not whitelisted', path );
 
 	return false;
-}
+};

--- a/client/lib/wp/sync-handler/whitelist-handler.js
+++ b/client/lib/wp/sync-handler/whitelist-handler.js
@@ -8,7 +8,6 @@ const debug = debugFactory( 'calypso:sync-handler:whitelist' );
 const whitelist = [
 	/^\/wpcom\/v\d\/timezones/,
 	/^\/me\/posts$/,
-	/^\/me\/settings/,
 	/^\/sites\/[\w.]+\/posts$/
 ];
 


### PR DESCRIPTION
As discussed in #6811, caching the preferences has the side effect of using outdated user preferences the next time they are fetched. Since user preferences are directly set by the user in most cases, the most up-to-date data should always be used.

To test:
- Regression test areas of Calypso that use preferences and make sure that things still load/work properly
    - recent sites, editor advanced toolbar visible, editor mode
- Try both with a 'normal' browser environment and with cleared local history/cache

/cc @ehg @mtias 

Test live: https://calypso.live/?branch=update/disable-local-sync-for-preferences