### PR TITLE
Extend PureComponent in WebPreview

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import noop from 'lodash/noop';
-import shallowCompare from 'react-addons-shallow-compare';
+import PureComponent from 'react-pure-render/component';
 
 /**
  * Internal dependencies
@@ -23,7 +23,7 @@ import { setPreviewShowing } from 'state/ui/actions';
 
 const debug = debugModule( 'calypso:web-preview' );
 
-export class WebPreview extends Component {
+export class WebPreview extends PureComponent {
 	constructor( props ) {
 		super( props );
 
@@ -61,10 +61,6 @@ export class WebPreview extends Component {
 			document.documentElement.classList.add( 'no-scroll', 'is-previewing' );
 		}
 		this.props.setPreviewShowing( this.props.showPreview );
-	}
-
-	shouldComponentUpdate( nextProps, nextState ) {
-		return shallowCompare( this, nextProps, nextState );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import noop from 'lodash/noop';
-import PureComponent from 'react-pure-render/component';
 
 /**
  * Internal dependencies
@@ -23,7 +22,7 @@ import { setPreviewShowing } from 'state/ui/actions';
 
 const debug = debugModule( 'calypso:web-preview' );
 
-export class WebPreview extends PureComponent {
+export class WebPreview extends Component {
 	constructor( props ) {
 		super( props );
 


### PR DESCRIPTION
Previously, during the refactor I made in #6881, I imported the
`shallowCompare()` helper function to replace the `PureRenderMixin` that
was originally there.

In this PR, I am foregoing this import in favor of simply extending the
`PureComponent`, which further removes noise from inside this
already-big component.

**There should be no functional or visual changes in this PR.**

**Testing**
This really just needs a smoke-test, opening the editor preview and making sure that nothing goes wrong.

**Open Question**
 - As @aduth brought up in #6881, the `connect()` wrapper already assumes that a component is pure and makes superfluous adding `shouldComponentUpdate()` (explicitly or through a class or mixin). That being said, I feel like there still remains value in doing something like extending `PureComponent`, as that adds intrinsic, explicit, semantic information to the component. It should also normalize the behavior of the components, such as when we pull them out in their unwrapped states (testing, for example). The only tradeoff seems to be that we risk running the `shouldComponentUpdate()` call twice when it only needs to run once (once in `connect()` and again when rendering the component itself). Thoughts?

Props to @aduth for pointing me to this base class.

Test live: https://calypso.live/?branch=update/web-preview-pure-render