### PR TITLE
Add theme demos to signup

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -5,6 +5,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'grid',
+		demo_uri: 'https://apostrophedemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -13,6 +14,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'grid',
+		demo_uri: 'https://baskervilledemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -21,6 +23,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'page',
+		demo_uri: 'https://bigbrotherdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -29,6 +32,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'blog',
+		demo_uri: 'https://buttondemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -37,6 +41,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'grid',
+		demo_uri: 'https://cubicdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -45,6 +50,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: true,
 		design: 'grid',
+		demo_uri: 'https://dyaddemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -53,6 +59,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: true,
 		design: 'blog',
+		demo_uri: 'https://ectodemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -61,6 +68,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: true,
 		design: 'page',
+		demo_uri: 'https://edindemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -69,6 +77,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'blog',
+		demo_uri: 'https://franklindemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -77,6 +86,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'page',
+		demo_uri: 'https://gatewaydemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -85,6 +95,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'grid',
+		demo_uri: 'https://gazettedemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -93,6 +104,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'page',
+		demo_uri: 'https://gorandemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -101,6 +113,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: true,
 		design: 'page',
+		demo_uri: 'https://harmonicdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -109,6 +122,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: true,
 		design: 'blog',
+		demo_uri: 'https://hemingwayrewrittendemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -117,6 +131,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: '',
+		demo_uri: 'http://independentpublisherdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -125,6 +140,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'blog',
+		demo_uri: 'https://libredemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -133,6 +149,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'blog',
+		demo_uri: 'https://librettodemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -141,6 +158,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'page',
+		demo_uri: 'https://motifdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -149,6 +167,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: true,
 		design: 'blog',
+		demo_uri: 'https://penscratchdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -157,6 +176,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'grid',
+		demo_uri: 'https://pictoricodemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -165,6 +185,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'page',
+		demo_uri: 'https://piquedemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -173,6 +194,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: true,
 		design: '',
+		demo_uri: 'https://publicationdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -181,6 +203,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'grid',
+		demo_uri: 'https://rebalancedemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -189,6 +212,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'grid',
+		demo_uri: 'https://revelardemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -197,6 +221,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'grid',
+		demo_uri: 'https://rowlingdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -205,6 +230,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'blog',
+		demo_uri: 'https://sapordemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -213,6 +239,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: true,
 		design: 'page',
+		demo_uri: 'https://selademo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -221,6 +248,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: false,
 		design: 'page',
+		demo_uri: 'https://sequentialdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -229,6 +257,7 @@ export const themes = [
 		repo: 'pub',
 		fallback: true,
 		design: 'blog',
+		demo_uri: 'https://twentysixteendemo.wordpress.com',
 		verticals: []
 	},
 ];

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -19,6 +19,7 @@ export default React.createClass( {
 	propTypes: {
 		theme: React.PropTypes.object,
 		showPreview: React.PropTypes.bool,
+		showExternal: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
 		primaryButtonLabel: React.PropTypes.string.isRequired,
 		onPrimaryButtonClick: React.PropTypes.func,
@@ -65,6 +66,7 @@ export default React.createClass( {
 
 		return (
 			<WebPreview showPreview={ this.props.showPreview }
+				showExternal={ this.props.showExternal }
 				onClose={ this.props.onClose }
 				previewUrl={ previewUrl }
 				externalUrl={ this.props.theme.demo_uri } >

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -28,7 +28,8 @@ module.exports = React.createClass( {
 
 	getInitialState() {
 		return {
-			previewTheme: null,
+			previewTheme: {},
+			isPreviewVisible: false,
 		};
 	},
 
@@ -57,6 +58,7 @@ module.exports = React.createClass( {
 	showPreview( theme ) {
 		this.setState( {
 			previewTheme: theme,
+			isPreviewVisible: true,
 		} );
 	},
 
@@ -66,7 +68,8 @@ module.exports = React.createClass( {
 
 	handleThemePreviewCloseClick() {
 		this.setState( {
-			previewTheme: null,
+			previewTheme: {},
+			isPreviewVisible: false,
 		} );
 	},
 
@@ -93,18 +96,16 @@ module.exports = React.createClass( {
 	},
 
 	renderThemePreview() {
-		if ( this.state.previewTheme ) {
-			return (
-				<ThemePreview
-					showPreview={ true }
-					showExternal={ false }
-					theme={ this.state.previewTheme }
-					buttonLabel={ this.translate( 'Pick this Theme' ) }
-					onClose={ this.handleThemePreviewCloseClick }
-					onButtonClick={ this.handleThemePreviewButtonClick }>
-				</ThemePreview>
-			);
-		}
+		return (
+			<ThemePreview
+				showPreview={ this.state.isPreviewVisible }
+				showExternal={ false }
+				theme={ this.state.previewTheme }
+				buttonLabel={ this.translate( 'Pick this Theme' ) }
+				onClose={ this.handleThemePreviewCloseClick }
+				onButtonClick={ this.handleThemePreviewButtonClick }>
+			</ThemePreview>
+		);
 	},
 
 	renderStepContent() {

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -98,7 +98,7 @@ module.exports = React.createClass( {
 				<ThemePreview
 					showPreview={ true }
 					theme={ this.state.previewTheme }
-					buttonLabel={ this.translate( 'Pick' ) }
+					buttonLabel={ this.translate( 'Pick this Theme' ) }
 					onClose={ this.handleThemePreviewCloseClick }
 					onButtonClick={ this.handleThemePreviewButtonClick }>
 				</ThemePreview>

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -97,6 +97,7 @@ module.exports = React.createClass( {
 			return (
 				<ThemePreview
 					showPreview={ true }
+					showExternal={ false }
 					theme={ this.state.previewTheme }
 					buttonLabel={ this.translate( 'Pick this Theme' ) }
 					onClose={ this.handleThemePreviewCloseClick }

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -39,7 +39,7 @@ module.exports = React.createClass( {
 	},
 
 	pickTheme( theme ) {
-		let themeSlug = theme.id;
+		const themeSlug = theme.id;
 
 		analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -39,7 +39,7 @@ module.exports = React.createClass( {
 	},
 
 	pickTheme( theme ) {
-		var themeSlug = theme.id;
+		let themeSlug = theme.id;
 
 		analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
 
@@ -95,7 +95,13 @@ module.exports = React.createClass( {
 	renderThemePreview() {
 		if ( this.state.previewTheme ) {
 			return (
-				<ThemePreview showPreview={ true } theme={ this.state.previewTheme } buttonLabel={ this.translate( 'Pick' ) } onClose={ this.handleThemePreviewCloseClick } onButtonClick={ this.handleThemePreviewButtonClick }></ThemePreview>
+				<ThemePreview
+					showPreview={ true }
+					theme={ this.state.previewTheme }
+					buttonLabel={ this.translate( 'Pick' ) }
+					onClose={ this.handleThemePreviewCloseClick }
+					onButtonClick={ this.handleThemePreviewButtonClick }>
+				</ThemePreview>
 			);
 		}
 	},

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -10,6 +10,7 @@ import analytics from 'lib/analytics';
 import SignupActions from 'lib/signup/actions';
 import SignupThemesList from './signup-themes-list';
 import StepWrapper from 'signup/step-wrapper';
+import ThemePreview from 'my-sites/themes/theme-preview';
 import Button from 'components/button';
 import config from 'config';
 
@@ -23,6 +24,12 @@ module.exports = React.createClass( {
 		stepName: React.PropTypes.string.isRequired,
 		goToNextStep: React.PropTypes.func.isRequired,
 		signupDependencies: React.PropTypes.object.isRequired,
+	},
+
+	getInitialState() {
+		return {
+			previewTheme: null,
+		};
 	},
 
 	getDefaultProps() {
@@ -48,7 +55,19 @@ module.exports = React.createClass( {
 	},
 
 	showPreview( theme ) {
-		// TODO: add preview implementation
+		this.setState( {
+			previewTheme: theme,
+		} );
+	},
+
+	handleThemePreviewButtonClick() {
+		this.pickTheme( this.state.previewTheme );
+	},
+
+	handleThemePreviewCloseClick() {
+		this.setState( {
+			previewTheme: null,
+		} );
 	},
 
 	handleScreenshotClick( theme ) {
@@ -73,6 +92,23 @@ module.exports = React.createClass( {
 		);
 	},
 
+	renderThemePreview() {
+		if ( this.state.previewTheme ) {
+			return (
+				<ThemePreview showPreview={ true } theme={ this.state.previewTheme } buttonLabel={ this.translate( 'Pick' ) } onClose={ this.handleThemePreviewCloseClick } onButtonClick={ this.handleThemePreviewButtonClick }></ThemePreview>
+			);
+		}
+	},
+
+	renderStepContent() {
+		return (
+			<div>
+				{ this.renderThemesList() }
+				{ this.renderThemePreview() }
+			</div>
+		);
+	},
+
 	render() {
 		const defaultDependencies = this.props.useHeadstart ? { theme: 'pub/twentysixteen' } : undefined;
 		return (
@@ -80,7 +116,7 @@ module.exports = React.createClass( {
 				fallbackHeaderText={ this.translate( 'Choose a theme.' ) }
 				fallbackSubHeaderText={ this.translate( 'No need to overthink it. You can always switch to a different theme later.' ) }
 				subHeaderText={ this.translate( 'Choose a theme. You can always switch to a different theme later.' ) }
-				stepContent={ this.renderThemesList() }
+				stepContent={ this.renderStepContent() }
 				defaultDependencies={ defaultDependencies }
 				headerButton={ this.renderJetpackButton() }
 				{ ...this.props } />

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -11,6 +11,9 @@ import SignupActions from 'lib/signup/actions';
 import SignupThemesList from './signup-themes-list';
 import StepWrapper from 'signup/step-wrapper';
 import Button from 'components/button';
+import config from 'config';
+
+const themeDemosEnabled = config.isEnabled( 'signup/theme-demos' );
 
 module.exports = React.createClass( {
 	displayName: 'ThemeSelection',
@@ -28,7 +31,7 @@ module.exports = React.createClass( {
 		};
 	},
 
-	handleScreenshotClick( theme ) {
+	pickTheme( theme ) {
 		var themeSlug = theme.id;
 
 		analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
@@ -42,6 +45,18 @@ module.exports = React.createClass( {
 		} );
 
 		this.props.goToNextStep();
+	},
+
+	showPreview( theme ) {
+		// TODO: add preview implementation
+	},
+
+	handleScreenshotClick( theme ) {
+		if ( themeDemosEnabled ) {
+			this.showPreview( theme );
+		} else {
+			this.pickTheme( theme );
+		}
 	},
 
 	renderThemesList() {

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -101,9 +101,9 @@ module.exports = React.createClass( {
 				showPreview={ this.state.isPreviewVisible }
 				showExternal={ false }
 				theme={ this.state.previewTheme }
-				buttonLabel={ this.translate( 'Pick this Theme' ) }
+				primaryButtonLabel={ this.translate( 'Pick this Theme' ) }
 				onClose={ this.handleThemePreviewCloseClick }
-				onButtonClick={ this.handleThemePreviewButtonClick }>
+				onPrimaryButtonClick={ this.handleThemePreviewButtonClick }>
 			</ThemePreview>
 		);
 	},

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -9,6 +9,9 @@ import noop from 'lodash/noop';
  */
 import getThemes from 'lib/signup/themes';
 import ThemesList from 'components/themes-list';
+import config from 'config';
+
+const themeDemosEnabled = config.isEnabled( 'signup/theme-demos' );
 
 module.exports = React.createClass( {
 	displayName: 'SignupThemesList',
@@ -40,12 +43,13 @@ module.exports = React.createClass( {
 	},
 
 	render() {
-		const actionLabel = this.translate( 'Pick' );
+		const actionLabel = themeDemosEnabled ? this.translate( 'Preview' ) : this.translate( 'Pick' );
 		const getActionLabel = () => actionLabel;
 		const themes = this.getComputedThemes().map( theme => {
 			return {
 				id: theme.slug,
 				name: theme.name,
+				demo_uri: theme.demo_uri,
 				screenshot: this.getScreenshotUrl( theme.slug ),
 			};
 		} );

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -64,6 +64,7 @@
 		"reader/full-errors": false,
 		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,
+		"signup/theme-demos": false,
 		"upgrades/checkout": false,
 		"upgrades/credit-cards": false,
 		"upgrades/domain-search": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -71,6 +71,7 @@
 		"resume-editing": true,
 		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,
+		"signup/theme-demos": false,
 		"ui/first-view": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/development.json
+++ b/config/development.json
@@ -121,6 +121,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
+		"signup/theme-demos": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,
@@ -138,5 +139,6 @@
 		"vip/deploys": true,
 		"vip/logs": true,
 		"vip/support": true
-	}
+	},
+	"signup_theme_demos": true
 }

--- a/config/development.json
+++ b/config/development.json
@@ -139,6 +139,5 @@
 		"vip/deploys": true,
 		"vip/logs": true,
 		"vip/support": true
-	},
-	"signup_theme_demos": true
+	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -82,6 +82,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": false,
+		"signup/theme-demos": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,

--- a/config/production.json
+++ b/config/production.json
@@ -81,6 +81,7 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"signup/theme-demos": false,
 		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -88,6 +88,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
+		"signup/theme-demos": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,

--- a/config/test.json
+++ b/config/test.json
@@ -98,6 +98,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
+		"signup/theme-demos": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -95,6 +95,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
+		"signup/theme-demos": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,


### PR DESCRIPTION
This PR adds a preview dialog to the Theme Picker on signup.

- Hidden behind the `signup/theme-demos` feature flag
- Hover text on theme thumbnail is changed from “Pick” to “Preview”
- Clicking opens the theme preview dialog
- CTA button on dialog says “Pick this Theme” (I chose this over the less specific “Pick“, to make the action more clear)
- "Open in External Window" Button is hidden, to avoid having users “escape“ the signup flow
- I avoided using a general rule for the demo URLs (`'https://' + slug + 'demo.wordpress.com'` because some future demo sites could be different, wanted to make sure it was easier to add more in the future)

Screenshots:

![](https://cloudup.com/cunZMWw0Hw6+)
![](https://cloudup.com/cv9UhC_Too3+)