### PR TITLE
Show a notice of email verification in `/help/` and `/help/contact`.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -156,6 +156,7 @@
 @import 'me/help/help-contact-confirmation/style';
 @import 'me/help/help-contact/style';
 @import 'me/help/help-contact-form/style';
+@import 'me/help/help-unverified-warning/style';
 @import 'me/help/help-happiness-engineers/style';
 @import 'me/help/help-results/style';
 @import 'me/help/help-search/style';

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -24,7 +24,9 @@ module.exports = {
 		analytics.pageView.record( basePath, 'Help' );
 
 		ReactDom.render(
-			React.createElement( Help ),
+			<ReduxProvider store={ context.store } >
+				<Help />
+			</ReduxProvider>,
 			document.getElementById( 'primary' )
 		);
 	},

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -439,7 +439,11 @@ const HelpContact = React.createClass( {
 		return (
 			<Main className="help-contact">
 				<HeaderCake onClick={ this.backToHelp } isCompact={ true }>{ this.translate( 'Contact Us' ) }</HeaderCake>
-				{ ! user().get().email_verified && <HelpUnverifiedWarning /> }
+				{ ! user().get().email_verified &&
+					<HelpUnverifiedWarning
+						sendVerificationEmail={ user().sendVerificationEmail }
+					/>
+				}
 				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
 					{ this.getView() }
 				</Card>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -23,8 +23,8 @@ import notices from 'notices';
 import siteList from 'lib/sites-list';
 import analytics from 'lib/analytics';
 import i18n from 'lib/i18n-utils';
-import user from 'lib/user';
 import { isOlarkTimedOut } from 'state/ui/olark/selectors';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import QueryOlark from 'components/data/query-olark';
 import HelpUnverifiedWarning from '../help-unverified-warning';
 
@@ -439,11 +439,7 @@ const HelpContact = React.createClass( {
 		return (
 			<Main className="help-contact">
 				<HeaderCake onClick={ this.backToHelp } isCompact={ true }>{ this.translate( 'Contact Us' ) }</HeaderCake>
-				{ ! user().get().email_verified &&
-					<HelpUnverifiedWarning
-						sendVerificationEmail={ user().sendVerificationEmail }
-					/>
-				}
+				{ ! this.props.isEmailVerified && <HelpUnverifiedWarning /> }
 				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
 					{ this.getView() }
 				</Card>
@@ -456,7 +452,8 @@ const HelpContact = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			olarkTimedOut: isOlarkTimedOut( state )
+			olarkTimedOut: isOlarkTimedOut( state ),
+			isEmailVerified: isCurrentUserEmailVerified( state ),
 		};
 	}
 )( HelpContact );

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -23,8 +23,10 @@ import notices from 'notices';
 import siteList from 'lib/sites-list';
 import analytics from 'lib/analytics';
 import i18n from 'lib/i18n-utils';
+import user from 'lib/user';
 import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import QueryOlark from 'components/data/query-olark';
+import HelpUnverifiedWarning from '../help-unverified-warning';
 
 /**
  * Module variables
@@ -437,6 +439,7 @@ const HelpContact = React.createClass( {
 		return (
 			<Main className="help-contact">
 				<HeaderCake onClick={ this.backToHelp } isCompact={ true }>{ this.translate( 'Contact Us' ) }</HeaderCake>
+				{ ! user().get().email_verified && <HelpUnverifiedWarning /> }
 				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
 					{ this.getView() }
 				</Card>

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import userFactory from 'lib/user';
 
@@ -52,7 +51,7 @@ class HelpUnverifiedWarning extends Component {
 				resendState: RESEND_IN_PROGRESS,
 			} );
 
-			this.props.sendVerificationEmail()
+			user.sendVerificationEmail()
 				.then( () => {
 					const nextResendState = RESEND_SUCCESS;
 
@@ -82,9 +81,4 @@ class HelpUnverifiedWarning extends Component {
 	}
 }
 
-export default connect(
-	( state ) => {
-		return {
-			sendVerificationEmail: user.sendVerificationEmail,
-		};
-} )( localize( HelpUnverifiedWarning ) );
+export default localize( HelpUnverifiedWarning );

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -27,8 +27,25 @@ class HelpUnverifiedWarning extends Component {
 	render() {
 		const { sendVerificationEmail } = this.props;
 
+		const { resendState } = this.state;
+
 		const resendEmail = () => {
+			this.setState( {
+				resendState: RESEND_IN_PROGRESS,
+			} );
+
 			sendVerificationEmail( ( error, response ) => {
+				if ( error ) {
+					this.setState( {
+						resendState: RESEND_ERROR,
+					} );
+
+					return;
+				}
+
+				this.setState( {
+					resendState: RESEND_SUCCESS,
+				} );
 			} );
 		};
 
@@ -47,14 +64,31 @@ class HelpUnverifiedWarning extends Component {
 			}
 		};
 
+		const resendStateToNoticeType = ( resendState ) => {
+			switch ( resendState ) {
+				case RESEND_IDLE:
+					return 'is-warning';
+				case RESEND_IN_PROGRESS:
+					return 'is-info';
+				case RESEND_SUCCESS:
+					return 'is-success';
+				case RESEND_ERROR:
+					return 'is-error';
+				default:
+					return 'is-error';
+			}
+		};
+
 		return (
 			<Notice
-				status="is-warning"
+				status={ resendStateToNoticeType( resendState ) }
 				showDismiss={ false }
-				text={ resendStateToMessage( this.state.resendState ) }>
-				<NoticeAction href="#" onClick={ resendEmail } >
-					{ this.props.translate( "Resend Email" ) }
-				</NoticeAction>
+				text={ resendStateToMessage( resendState ) }>
+				{ RESEND_IDLE === resendState &&
+					<NoticeAction href="#" onClick={ resendEmail } >
+						{ this.props.translate( "Resend Email" ) }
+					</NoticeAction>
+				}
 			</Notice>
 		);
 	}

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import userFactory from 'lib/user';
 
@@ -11,6 +12,8 @@ import userFactory from 'lib/user';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import notices from 'notices';
+
+const user = userFactory();
 
 const RESEND_IDLE = 0,
 	RESEND_IN_PROGRESS = 1,
@@ -49,7 +52,7 @@ class HelpUnverifiedWarning extends Component {
 				resendState: RESEND_IN_PROGRESS,
 			} );
 
-			userFactory().sendVerificationEmail()
+			this.props.sendVerificationEmail()
 				.then( () => {
 					const nextResendState = RESEND_SUCCESS;
 
@@ -79,4 +82,9 @@ class HelpUnverifiedWarning extends Component {
 	}
 }
 
-export default localize( HelpUnverifiedWarning );
+export default connect(
+	( state ) => {
+		return {
+			sendVerificationEmail: user.sendVerificationEmail,
+		};
+} )( localize( HelpUnverifiedWarning ) );

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+
+class HelpUnverifiedWarning extends Component {
+	constructor( props ) {
+		super( props );
+	}
+
+	render() {
+		return (
+			<Notice
+				status="is-warning"
+				showDismiss={ false }
+				text={ this.props.translate( "Trouble activating your account? Just click this button and we'll resend the activation for you." ) }>
+				<NoticeAction href="#">
+					{ this.props.translate( "Resend Email" ) }
+				</NoticeAction>
+			</Notice>
+	    );
+	}
+}
+
+export default localize( HelpUnverifiedWarning );

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -10,6 +10,7 @@ import userFactory from 'lib/user';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import notices from 'notices';
 
 const RESEND_IDLE = 0,
 	RESEND_IN_PROGRESS = 1,
@@ -28,24 +29,14 @@ class HelpUnverifiedWarning extends Component {
 	render() {
 		const { resendState } = this.state;
 
-		const resendEmail = () => {
-			this.setState( {
-				resendState: RESEND_IN_PROGRESS,
-			} );
-
-			userFactory().sendVerificationEmail()
-				.then( () => this.setState( { resendState: RESEND_SUCCESS } ) )
-				.catch( () => this.setState( { resendState: RESEND_ERROR } ) );
-		};
-
 		const resendStateToMessage = ( resendState ) => {
 			switch ( resendState ) {
 				case RESEND_IDLE:
 					return this.props.translate( "Trouble activating your account? Just click this button and we'll resend the activation for you." );
 				case RESEND_IN_PROGRESS:
-					return this.props.translate( 'Sending…' );
+					return '';
 				case RESEND_SUCCESS:
-					return this.props.translate( "Please check your email for an activation email and click the link to finish your signup. If you don't receive the email within a few minutes, please be sure to check your spam folders." );
+					return this.props.translate( "Please check your email for an activation email and click the link to finish your signup." );
 				case RESEND_ERROR:
 					return this.props.translate( "Sorry that we've encountered an error on sending you an activation email. Please try again later." );
 				default:
@@ -53,32 +44,37 @@ class HelpUnverifiedWarning extends Component {
 			}
 		};
 
-		const resendStateToNoticeType = ( resendState ) => {
-			switch ( resendState ) {
-				case RESEND_IDLE:
-					return 'is-warning';
-				case RESEND_IN_PROGRESS:
-					return 'is-info';
-				case RESEND_SUCCESS:
-					return 'is-success';
-				case RESEND_ERROR:
-					return 'is-error';
-				default:
-					return 'is-error';
-			}
+		const resendEmail = () => {
+			this.setState( {
+				resendState: RESEND_IN_PROGRESS,
+			} );
+
+			userFactory().sendVerificationEmail()
+				.then( () => {
+					const nextResendState = RESEND_SUCCESS;
+
+					this.setState( { resendState: nextResendState } )
+					notices[ 'success' ]( resendStateToMessage( nextResendState ) );
+				} )
+				.catch( () => {
+					const nextResendState = RESEND_ERROR;
+
+					this.setState( { resendState: nextResendState } )
+					notices[ 'error' ]( resendStateToMessage( nextResendState ) );
+				} );
 		};
 
 		return (
-			<Notice
-				status={ resendStateToNoticeType( resendState ) }
-				showDismiss={ false }
-				text={ resendStateToMessage( resendState ) }>
-				{ RESEND_IDLE === resendState &&
-					<NoticeAction href="#" onClick={ resendEmail } >
-						{ this.props.translate( "Resend Email" ) }
-					</NoticeAction>
-				}
-			</Notice>
+			RESEND_IDLE === resendState &&
+				<Notice
+					className='help-unverified-warning__notice'
+					status='is-warning'
+					showDismiss={ false }
+					text={ resendStateToMessage( resendState ) } >
+						<NoticeAction href="#" onClick={ resendEmail } >
+							{ this.props.translate( "Resend Email" ) }
+						</NoticeAction>
+				</Notice>
 		);
 	}
 }

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -33,19 +33,9 @@ class HelpUnverifiedWarning extends Component {
 				resendState: RESEND_IN_PROGRESS,
 			} );
 
-			userFactory().sendVerificationEmail( ( error, response ) => {
-				if ( error ) {
-					this.setState( {
-						resendState: RESEND_ERROR,
-					} );
-
-					return;
-				}
-
-				this.setState( {
-					resendState: RESEND_SUCCESS,
-				} );
-			} );
+			userFactory().sendVerificationEmail()
+				.then( () => this.setState( { resendState: RESEND_SUCCESS } ) )
+				.catch( () => this.setState( { resendState: RESEND_ERROR } ) );
 		};
 
 		const resendStateToMessage = ( resendState ) => {

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -10,22 +10,53 @@ import { localize } from 'i18n-calypso';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 
+const RESEND_IDLE = 0,
+	RESEND_IN_PROGRESS = 1,
+	RESEND_SUCCESS = 2,
+	RESEND_ERROR = 3;
+
 class HelpUnverifiedWarning extends Component {
 	constructor( props ) {
 		super( props );
+
+		this.state = {
+			resendState: RESEND_IDLE,
+		};
 	}
 
 	render() {
+		const { sendVerificationEmail } = this.props;
+
+		const resendEmail = () => {
+			sendVerificationEmail( ( error, response ) => {
+			} );
+		};
+
+		const resendStateToMessage = ( resendState ) => {
+			switch ( resendState ) {
+				case RESEND_IDLE:
+					return this.props.translate( "Trouble activating your account? Just click this button and we'll resend the activation for you." );
+				case RESEND_IN_PROGRESS:
+					return this.props.translate( 'Sending…' );
+				case RESEND_SUCCESS:
+					return this.props.translate( "Please check your email for an activation email and click the link to finish your signup. If you don't receive the email within a few minutes, please be sure to check your spam folders." );
+				case RESEND_ERROR:
+					return this.props.translate( "Sorry that we've encountered an error on sending you an activation email. Please try again later." );
+				default:
+					return 'Unknown activation email resending state.';
+			}
+		};
+
 		return (
 			<Notice
 				status="is-warning"
 				showDismiss={ false }
-				text={ this.props.translate( "Trouble activating your account? Just click this button and we'll resend the activation for you." ) }>
-				<NoticeAction href="#">
+				text={ resendStateToMessage( this.state.resendState ) }>
+				<NoticeAction href="#" onClick={ resendEmail } >
 					{ this.props.translate( "Resend Email" ) }
 				</NoticeAction>
 			</Notice>
-	    );
+		);
 	}
 }
 

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -31,16 +31,17 @@ class HelpUnverifiedWarning extends Component {
 	render() {
 		const { resendState } = this.state;
 
-		const resendStateToMessage = ( resendState ) => {
-			switch ( resendState ) {
+		const resendStateToMessage = ( val ) => {
+			switch ( val ) {
 				case RESEND_IDLE:
-					return this.props.translate( "Trouble activating your account? Just click this button and we'll resend the activation for you." );
+					return this.props.translate( 'Trouble activating your account?\
+							Just click this button and we\'ll resend the activation for you.' );
 				case RESEND_IN_PROGRESS:
 					return '';
 				case RESEND_SUCCESS:
-					return this.props.translate( "Please check your email for an activation email and click the link to finish your signup." );
+					return this.props.translate( 'Activation email sent. Please check your inbox.' );
 				case RESEND_ERROR:
-					return this.props.translate( "Sorry that we've encountered an error on sending you an activation email. Please try again later." );
+					return this.props.translate( 'There\'s been an error. Please try again later.' );
 				default:
 					return 'Unknown activation email resending state.';
 			}
@@ -55,26 +56,26 @@ class HelpUnverifiedWarning extends Component {
 				.then( () => {
 					const nextResendState = RESEND_SUCCESS;
 
-					this.setState( { resendState: nextResendState } )
-					notices[ 'success' ]( resendStateToMessage( nextResendState ) );
+					this.setState( { resendState: nextResendState } );
+					notices.success( resendStateToMessage( nextResendState ) );
 				} )
 				.catch( () => {
 					const nextResendState = RESEND_ERROR;
 
-					this.setState( { resendState: nextResendState } )
-					notices[ 'error' ]( resendStateToMessage( nextResendState ) );
+					this.setState( { resendState: nextResendState } );
+					notices.error( resendStateToMessage( nextResendState ) );
 				} );
 		};
 
 		return (
 			RESEND_IDLE === resendState &&
 				<Notice
-					className='help-unverified-warning__notice'
-					status='is-warning'
+					className="help-unverified-warning"
+					status="is-warning"
 					showDismiss={ false }
 					text={ resendStateToMessage( resendState ) } >
 						<NoticeAction href="#" onClick={ resendEmail } >
-							{ this.props.translate( "Resend Email" ) }
+							{ this.props.translate( 'Resend Email' ) }
 						</NoticeAction>
 				</Notice>
 		);

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import userFactory from 'lib/user';
 
 /**
  * Internal dependencies
@@ -25,8 +26,6 @@ class HelpUnverifiedWarning extends Component {
 	}
 
 	render() {
-		const { sendVerificationEmail } = this.props;
-
 		const { resendState } = this.state;
 
 		const resendEmail = () => {
@@ -34,7 +33,7 @@ class HelpUnverifiedWarning extends Component {
 				resendState: RESEND_IN_PROGRESS,
 			} );
 
-			sendVerificationEmail( ( error, response ) => {
+			userFactory().sendVerificationEmail( ( error, response ) => {
 				if ( error ) {
 					this.setState( {
 						resendState: RESEND_ERROR,

--- a/client/me/help/help-unverified-warning/style.scss
+++ b/client/me/help/help-unverified-warning/style.scss
@@ -1,3 +1,3 @@
-.help-unverified-warning__notice {
+.help-unverified-warning {
 	margin-top: 16px;
 }

--- a/client/me/help/help-unverified-warning/style.scss
+++ b/client/me/help/help-unverified-warning/style.scss
@@ -1,0 +1,3 @@
+.help-unverified-warning__notice {
+	margin-top: 16px;
+}

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -9,13 +9,15 @@ var React = require( 'react' ),
  */
 var Main = require( 'components/main' ),
 	analytics = require( 'lib/analytics' ),
+	user = require( 'lib/user' )(),
 	HappinessEngineers = require( 'me/help/help-happiness-engineers' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	HelpSearch = require( './help-search' ),
 	CompactCard = require( 'components/card/compact' ),
 	Button = require( 'components/button' ),
 	SectionHeader = require( 'components/section-header' ),
-	HelpResult = require( './help-results/item' );
+	HelpResult = require( './help-results/item' ),
+	HelpUnverifiedWarning = require( './help-unverified-warning' );
 
 module.exports = React.createClass( {
 	displayName: 'Help',
@@ -95,6 +97,7 @@ module.exports = React.createClass( {
 			<Main className="help">
 				<MeSidebarNavigation />
 				<HelpSearch />
+				{ ! user.get().email_verified && <HelpUnverifiedWarning /> }
 				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }
 				<HappinessEngineers />

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -97,7 +97,11 @@ module.exports = React.createClass( {
 			<Main className="help">
 				<MeSidebarNavigation />
 				<HelpSearch />
-				{ ! user.get().email_verified && <HelpUnverifiedWarning /> }
+				{ ! user.get().email_verified &&
+					<HelpUnverifiedWarning
+						sendVerificationEmail={ user.sendVerificationEmail }
+					/>
+				}
 				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }
 				<HappinessEngineers />

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -3,13 +3,14 @@
  */
 var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	debug = require( 'debug' )( 'calypso:help-search' );
+	debug = require( 'debug' )( 'calypso:help-search' ),
+	reactRedux = require( 'react-redux' );
 /**
  * Internal dependencies
  */
 var Main = require( 'components/main' ),
 	analytics = require( 'lib/analytics' ),
-	user = require( 'lib/user' )(),
+	currentUser = require( 'state/current-user/selectors' ),
 	HappinessEngineers = require( 'me/help/help-happiness-engineers' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	HelpSearch = require( './help-search' ),
@@ -19,7 +20,7 @@ var Main = require( 'components/main' ),
 	HelpResult = require( './help-results/item' ),
 	HelpUnverifiedWarning = require( './help-unverified-warning' );
 
-module.exports = React.createClass( {
+const Help = React.createClass( {
 	displayName: 'Help',
 
 	mixins: [ PureRenderMixin ],
@@ -97,11 +98,7 @@ module.exports = React.createClass( {
 			<Main className="help">
 				<MeSidebarNavigation />
 				<HelpSearch />
-				{ ! user.get().email_verified &&
-					<HelpUnverifiedWarning
-						sendVerificationEmail={ user.sendVerificationEmail }
-					/>
-				}
+				{ ! this.props.isEmailVerified && <HelpUnverifiedWarning /> }
 				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }
 				<HappinessEngineers />
@@ -109,3 +106,11 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+module.exports = reactRedux.connect(
+	( state ) => {
+		return {
+			isEmailVerified: currentUser.isCurrentUserEmailVerified( state ),
+		};
+	}
+)( Help );

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -102,3 +102,13 @@ export function canCurrentUser( state, siteId, capability ) {
 export function currentUserHasFlag( state, flagName ) {
 	return state.currentUser.flags.indexOf( flagName ) !== -1;
 }
+
+/**
+ * Returns true if the current user is email-verified.
+ *
+ * @param {Object} state Global state tree
+ * @returns {boolean Whether the current user is email-verified.
+ */
+export function isCurrentUserEmailVerified( state ) {
+	return state.currentUser.email_verified;
+}


### PR DESCRIPTION
### Summary
This is how it works:
![demo-contact-help](https://cloud.githubusercontent.com/assets/1842898/17044867/118d514c-4fff-11e6-809e-5ac9e82bab05.gif)
The purpose behind it is that we have directed users to `/help/contact` for finding an activation links for a long time, e.g. from Gravatar, but they actually can't find it there. More details can be find in p2UL9c-2Nw .

### How to test
1. Create a new account and don't activate it.
1. Visit `/help/`, and make sure you see the notice there.
1. Visit `/help/contact`, and make sure you see the notice there.
1. Click on the "Resend Email" button, and you should receive the activation email.
1. Click on the activation link you received, and it should activate the account successfully.

Test live: https://calypso.live/?branch=feature/show-verification-warning-in-help

cc @mrheston  @jordwest @dllh 