### PR TITLE
Community Translator: bump version

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -20,7 +20,7 @@ var config = require( 'config' ),
  * Local variables
  */
 var communityTranslatorBaseUrl = 'https://widgets.wp.com/community-translator/',
-	communityTranslatorVersion = '1.160628',
+	communityTranslatorVersion = '1.160723',
 	translationDataFromPage = {
 		localeCode: 'en',
 		languageName: 'English',


### PR DESCRIPTION
We [fixed the disabled submit button](https://github.com/Automattic/community-translator/commit/72b5d49ad2414a45ca69301a8f64c473af86b2a2) but we're still serving the old file because of caching.

Test live: https://calypso.live/?branch=fix/bump-ct-version