### PR TITLE
Update browser notification settings text

### DIFF
--- a/client/components/push-notification/prompt.jsx
+++ b/client/components/push-notification/prompt.jsx
@@ -65,7 +65,7 @@ const PushNotificationPrompt = React.createClass( {
 		const noticeText = (
 			<div>
 				<p>
-					<strong>{ this.translate( 'Get notifications on your desktop!' ) }</strong> { this.translate( 'Instantly see your likes, comments, and more—even when you don\'t have WordPress.com open in your browser.' ) }
+					<strong>{ this.translate( 'Get notifications on your desktop!' ) }</strong> { this.translate( 'Get notifications for new comments, likes, and more instantly, even when you are not actively using WordPress.com.' ) }
 				</p>
 				<p>
 					{ this.translate(

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -335,7 +335,7 @@ const PushNotificationSettings = React.createClass( {
 					<small className={ classNames( 'notification-settings-push-notification-settings__settings-state', stateClass ) }>{ stateText }</small>
 				</h2>
 
-				<p className="notification-settings-push-notification-settings__settings-description">{ this.translate( 'Get notifications for new comments, likes, and more instantly, even when your browser is closed.' ) }</p>
+				<p className="notification-settings-push-notification-settings__settings-description">{ this.translate( 'Get notifications for new comments, likes, and more instantly, even when you are not actively using WordPress.com.' ) }</p>
 
 				<Button className={ classNames( 'notification-settings-push-notification-settings__settings-button', buttonClass ) } disabled={ buttonDisabled } onClick={ this.clickHandler } >{ buttonText }</Button>
 


### PR DESCRIPTION
This PR seeks to make the wording clearer for when users get browser notifications.

If the browser is closed completely (i.e. it does not run in the background), users will not receive notifications. However, if it is running in the background (without having any visible windows) then notifications will be delivered.

![screen shot 2016-07-22 at 4 01 55 pm](https://cloud.githubusercontent.com/assets/1017839/17059476/a782267a-5025-11e6-875d-ef1f39d05a61.png)

![screen shot 2016-07-25 at 4 12 45 pm](https://cloud.githubusercontent.com/assets/1017839/17104322/b12053dc-5282-11e6-9ae7-cb187a8864a1.png)

### Testing instructions

1. Navigate to `/me/notifications`, and verify that the text is correct.
2. Navigate to `/`, and verify that the notice text is correct (you may need a new user if you dismissed the notice earlier).

Test live: https://calypso.live/?branch=fix/browser-notification-dialog-text

