### PR TITLE
Pass diagnostic data to catch js error module

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -54,6 +54,9 @@ var config = require( 'config' ),
 	// The following components require the i18n mixin, so must be required after i18n is initialized
 	Layout;
 
+import { saveDiagnosticData } from 'lib/catch-js-errors/';
+import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
+
 function init() {
 	var i18nLocaleStringsObject = null;
 
@@ -228,6 +231,16 @@ function reduxStoreReady( reduxStore ) {
 	// Layout themselves when logged in.
 	if ( ! isIsomorphic || user.get() ) {
 		renderLayout( reduxStore );
+
+		//Save data to JS error logger
+		saveDiagnosticData( { user_id: user.get().ID } );
+		saveDiagnosticData( function() {
+			const state = reduxStore.getState();
+			return {
+				blog_id: getSelectedSiteId( state ),
+				section: getSectionName( state )
+			};
+		} );
 	}
 
 	// If `?sb` or `?sp` are present on the path set the focus of layout

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -250,10 +250,7 @@ function reduxStoreReady( reduxStore ) {
 			errorLogger.saveDiagnosticReducer( () => ( { tests: getSavedVariations() } ) );
 			analytics.on( 'record-event', ( eventName, eventProperties ) => errorLogger.saveExtraData( { lastTracksEvent: eventProperties } ) );
 			page( '*', function( context, next ) {
-				errorLogger.saveNewPath( context.canonicalPath.replace(
-					new RegExp( route.getSiteFragment( context.canonicalPath ), 'g' ),
-					':siteId'
-				) );
+				errorLogger.saveNewPath( context.canonicalPath.replace( route.getSiteFragment( context.canonicalPath ), ':siteId' ) );
 				next();
 			} );
 		}

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -238,18 +238,18 @@ function reduxStoreReady( reduxStore ) {
 			//Save data to JS error logger
 			errorLogger.saveDiagnosticData( {
 				user_id: user.get().ID,
-				env: config( 'env_id' )
+				calypso_env: config( 'env_id' )
 			} );
-			errorLogger.saveDiagnosticData( function() {
+			errorLogger.saveDiagnosticReducer( function() {
 				const state = reduxStore.getState();
 				return {
 					blog_id: getSelectedSiteId( state ),
-					section: getSectionName( state )
+					calypso_section: getSectionName( state )
 				};
 			} );
-			errorLogger.saveDiagnosticData( () => ( { tests: getSavedVariations() } ) );
-			analytics.on( 'record-event', ( eventName, eventProperties ) => errorLogger.saveDiagnosticData( { lastTracksEvent: eventProperties } ) );
-			analytics.on( 'page-view', ( urlPath ) => errorLogger.saveDiagnosticData( { path: urlPath } ) );
+			errorLogger.saveDiagnosticReducer( () => ( { tests: getSavedVariations() } ) );
+			analytics.on( 'record-event', ( eventName, eventProperties ) => errorLogger.saveExtraData( { lastTracksEvent: eventProperties } ) );
+			analytics.on( 'page-view', ( urlPath ) => errorLogger.saveDiagnosticData( { calypso_path: urlPath } ) );
 		}
 	}
 

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -249,7 +249,13 @@ function reduxStoreReady( reduxStore ) {
 			} );
 			errorLogger.saveDiagnosticReducer( () => ( { tests: getSavedVariations() } ) );
 			analytics.on( 'record-event', ( eventName, eventProperties ) => errorLogger.saveExtraData( { lastTracksEvent: eventProperties } ) );
-			analytics.on( 'page-view', ( urlPath ) => errorLogger.saveDiagnosticData( { calypso_path: urlPath } ) );
+			page( '*', function( context, next ) {
+				errorLogger.saveNewPath( context.canonicalPath.replace(
+					new RegExp( route.getSiteFragment( context.canonicalPath ), 'g' ),
+					':siteId'
+				) );
+				next();
+			} );
 		}
 	}
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -20,7 +20,7 @@ var config = require( 'config' ),
 	_user;
 
 import { retarget } from 'lib/analytics/ad-tracking';
-import { saveDiagnosticData } from 'lib/catch-js-errors/';
+import emitter from 'lib/mixins/emitter';
 
 // Load tracking scripts
 window._tkq = window._tkq || [];
@@ -113,7 +113,7 @@ var analytics = {
 			mostRecentUrlPath = urlPath;
 			analytics.tracks.recordPageView( urlPath );
 			analytics.ga.recordPageView( urlPath, pageTitle );
-			saveDiagnosticData( { path: urlPath } );
+			analytics.emit( 'page-view', urlPath, pageTitle );
 		}
 	},
 
@@ -151,7 +151,7 @@ var analytics = {
 			debug( 'Recording event "%s" with actual props %o', eventName, eventProperties );
 
 			window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
-			saveDiagnosticData( { lastTracksEvent: Object.assign( { eventName }, eventProperties ) } );
+			analytics.emit( 'record-event', eventName, eventProperties );
 		},
 
 		recordPageView: function( urlPath ) {
@@ -314,5 +314,5 @@ var analytics = {
 		window._tkq.push( [ 'clearIdentity' ] );
 	}
 };
-
+emitter( analytics );
 module.exports = analytics;

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -20,6 +20,7 @@ var config = require( 'config' ),
 	_user;
 
 import { retarget } from 'lib/analytics/ad-tracking';
+import { saveDiagnosticData } from 'lib/catch-js-errors/';
 
 // Load tracking scripts
 window._tkq = window._tkq || [];
@@ -112,6 +113,7 @@ var analytics = {
 			mostRecentUrlPath = urlPath;
 			analytics.tracks.recordPageView( urlPath );
 			analytics.ga.recordPageView( urlPath, pageTitle );
+			saveDiagnosticData( { path: urlPath } );
 		}
 	},
 
@@ -149,6 +151,7 @@ var analytics = {
 			debug( 'Recording event "%s" with actual props %o', eventName, eventProperties );
 
 			window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
+			saveDiagnosticData( { lastTracksEvent: Object.assign( { eventName }, eventProperties ) } );
 		},
 
 		recordPageView: function( urlPath ) {

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -20,7 +20,6 @@ export default class ErrorLogger {
 				previousPaths: []
 			}
 		};
-		window.d = () => this.diagnose();
 		this.diagnosticReducers = [];
 		if ( isLocalStorageNameSupported() && ! window.onerror ) {
 			const assignment = Math.random();

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -16,8 +16,11 @@ function isLocalStorageNameSupported() {
 export default class ErrorLogger {
 	constructor() {
 		this.diagnosticData = {
-			extra: {}
+			extra: {
+				previousPaths: []
+			}
 		};
+		window.d = () => this.diagnose();
 		this.diagnosticReducers = [];
 		if ( isLocalStorageNameSupported() && ! window.onerror ) {
 			const assignment = Math.random();
@@ -72,6 +75,12 @@ export default class ErrorLogger {
 				} );
 			}
 		}
+	}
+
+	saveNewPath( newPath ) {
+		this.diagnosticData.extra.previousPaths.unshift( this.diagnosticData.path );
+		this.diagnosticData.extra.previousPaths = this.diagnosticData.extra.previousPaths.slice( 0, 4 );
+		this.diagnosticData.path = newPath;
 	}
 
 	saveDiagnosticReducer( data ) {

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -1,43 +1,101 @@
 import TraceKit from 'tracekit';
-const diagnosticData = {};
-const diagnosticReducers = [];
-let initialized = false;
 
-export function saveDiagnosticData( data ) {
-	if ( typeof data === 'function' ) {
-		diagnosticReducers.push( data );
-	} else if ( typeof data === 'object' ) {
-		Object.assign( diagnosticData, data );
+// Props http://stackoverflow.com/a/17604754/379063
+function isLocalStorageNameSupported() {
+	var testKey = 'test',
+		storage = window.localStorage;
+	try {
+		storage.setItem( testKey, '1' );
+		storage.removeItem( testKey );
+		return true;
+	} catch ( error ) {
+		return false;
 	}
 }
 
-function diagnose() {
-	diagnosticReducers.forEach( diagnosticReducer => {
-		try {
-			Object.assign( diagnosticData, diagnosticReducer() );
-		} catch ( e ) {
-			console.warn( 'diagnostic', diagnosticData );
-		}
-	} );
-	return diagnosticData;
-}
+export default class ErrorLogger {
+	constructor() {
+		this.diagnosticData = {};
+		this.diagnosticReducers = [];
+		if ( isLocalStorageNameSupported() && ! window.onerror ) {
+			const assignment = Math.random();
+			let errorLogger = localStorage.getItem( 'log-errors' );
+			// Randomly assign 1% of users to log errors
+			if ( ! errorLogger ) {
+				if ( assignment <= 0.01 ) {
+					localStorage.setItem( 'log-errors', 'rest-api' );
+					errorLogger = 'rest-api';
+				} else if ( assignment <= 0.02 ) {
+					localStorage.setItem( 'log-errors', 'analytics' );
+					errorLogger = 'analytics';
+				} else if ( assignment <= 0.03 ) {
+					localStorage.setItem( 'log-errors', 'external' );
+					//Prep the stage up for Google Stackdriver or other service experiment
+				} else {
+					localStorage.setItem( 'log-errors', 'false' );
+				}
+			}
 
-function init() {
-	window.d = diagnose;
-	// Props http://stackoverflow.com/a/17604754/379063
-	function isLocalStorageNameSupported() {
-		var testKey = 'test',
-			storage = window.localStorage;
-		try {
-			storage.setItem( testKey, '1' );
-			storage.removeItem( testKey );
-			return true;
-		} catch ( error ) {
-			return false;
+			if ( errorLogger === 'true' ) {
+				//Fix up any outstanding old settings
+				localStorage.setItem( 'log-errors', 'rest-api' );
+				errorLogger = 'rest-api';
+			}
+
+			if ( errorLogger === 'rest-api' ) {
+				// set up handler to POST errors
+				TraceKit.report.subscribe( errorReport => {
+					const error = {
+						message: errorReport.message,
+						url: document.location.href,
+						trace: errorReport.stack,
+					};
+
+					if ( window.navigator && window.navigator.userAgent ) {
+						error.browser = window.navigator.userAgent;
+					}
+
+					this.diagnose();
+					this.sendToApi( Object.assign( error, this.diagnosticData ) );
+				} );
+			} else if ( errorLogger === 'analytics' ) {
+				TraceKit.report.subscribe( function gaApiLogger( errorReport ) {
+					if ( typeof window.ga === 'function' ) {
+						window.ga(
+							'send',
+							'event',
+							'JS Error',
+							'URL: ' + document.location.href,
+							errorReport.message + ' ' + JSON.stringify( errorReport.stack ),
+							0,
+							{ nonInteraction: true }
+						);
+					}
+				} );
+			}
 		}
 	}
 
-	function sendToApi( error ) {
+	saveDiagnosticData( data ) {
+		if ( typeof data === 'function' ) {
+			this.diagnosticReducers.push( data );
+		} else if ( typeof data === 'object' ) {
+			Object.assign( this.diagnosticData, data );
+		}
+	}
+
+	diagnose() {
+		this.diagnosticReducers.forEach( diagnosticReducer => {
+			try {
+				Object.assign( this.diagnosticData, diagnosticReducer() );
+			} catch ( e ) {
+				console.warn( 'diagnostic', this.diagnosticData );
+			}
+		} );
+		return this.diagnosticData;
+	}
+
+	sendToApi( error ) {
 		const xhr = new XMLHttpRequest();
 		xhr.open( 'POST', 'https://public-api.wordpress.com/rest/v1.1/js-error?http_envelope=1', true );
 		xhr.setRequestHeader( 'Content-type', 'application/x-www-form-urlencoded' );
@@ -45,67 +103,4 @@ function init() {
 		params += encodeURIComponent( JSON.stringify( error ) );
 		xhr.send( params );
 	}
-
-	if ( isLocalStorageNameSupported() && ! window.onerror ) {
-		const assignment = Math.random();
-		let errorLogger = localStorage.getItem( 'log-errors' );
-		// Randomly assign 1% of users to log errors
-		if ( ! errorLogger ) {
-			if ( assignment <= 0.01 ) {
-				localStorage.setItem( 'log-errors', 'rest-api' );
-				errorLogger = 'rest-api';
-			} else if ( assignment <= 0.02 ) {
-				localStorage.setItem( 'log-errors', 'analytics' );
-				errorLogger = 'analytics';
-			} else if ( assignment <= 0.03 ) {
-				localStorage.setItem( 'log-errors', 'external' );
-				//Prep the stage up for Google Stackdriver or other service experiment
-			} else {
-				localStorage.setItem( 'log-errors', 'false' );
-			}
-		}
-
-		if ( errorLogger === 'true' ) {
-			//Fix up any outstanding old settings
-			localStorage.setItem( 'log-errors', 'rest-api' );
-			errorLogger = 'rest-api';
-		}
-
-		if ( errorLogger === 'rest-api' ) {
-			// set up handler to POST errors
-			TraceKit.report.subscribe( function restApiLogger( errorReport ) {
-				const error = {
-					message: errorReport.message,
-					url: document.location.href,
-					trace: errorReport.stack,
-				};
-
-				if ( window.navigator && window.navigator.userAgent ) {
-					error.browser = window.navigator.userAgent;
-				}
-
-				diagnose();
-				sendToApi( Object.assign( error, diagnosticData ) );
-			} );
-		} else if ( errorLogger === 'analytics' ) {
-			TraceKit.report.subscribe( function gaApiLogger( errorReport ) {
-				if ( typeof window.ga === 'function' ) {
-					window.ga(
-						'send',
-						'event',
-						'JS Error',
-						'URL: ' + document.location.href,
-						errorReport.message + ' ' + JSON.stringify( errorReport.stack ),
-						0,
-						{ nonInteraction: true }
-					);
-				}
-			} );
-		}
-	}
-}
-
-if ( ! initialized ) {
-	initialized = true;
-	init();
 }

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -82,8 +82,8 @@ export default class ErrorLogger {
 		this.diagnosticData.path = newPath;
 	}
 
-	saveDiagnosticReducer( data ) {
-		this.diagnosticReducers.push( data );
+	saveDiagnosticReducer( fn ) {
+		this.diagnosticReducers.push( fn );
 	}
 
 	saveDiagnosticData( data ) {
@@ -103,6 +103,7 @@ export default class ErrorLogger {
 			try {
 				this.saveDiagnosticData( diagnosticReducer() );
 			} catch ( e ) {
+				this.saveDiagnosticData( { diagnosticError: e.message } );
 				console.warn( 'diagnostic', this.diagnosticData );
 			}
 		} );

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -13,6 +13,7 @@
 	"features": {
 		"ad-tracking": true,
 		"always_use_logout_url": true,
+		"catch-js-errors": false,
 		"code-splitting": false,
 		"community-translator": true,
 		"desktop": true,

--- a/config/development.json
+++ b/config/development.json
@@ -31,6 +31,7 @@
 		"ad-tracking": false,
 		"brazil-survey-invitation": false,
 		"code-splitting": true,
+		"catch-js-errors": true,
 		"community-translator": true,
 		"desktop-promo": true,
 		"devdocs": true,

--- a/config/development.json
+++ b/config/development.json
@@ -31,7 +31,6 @@
 		"ad-tracking": false,
 		"brazil-survey-invitation": false,
 		"code-splitting": true,
-		"catch-js-errors": true,
 		"community-translator": true,
 		"desktop-promo": true,
 		"devdocs": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -16,6 +16,7 @@
 		"accept-invite": true,
 		"ad-tracking": false,
 		"brazil-survey-invitation": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -14,6 +14,7 @@
 		"accept-invite": true,
 		"ad-tracking": true,
 		"brazil-survey-invitation": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,6 +16,7 @@
 		"accept-invite": true,
 		"ad-tracking": false,
 		"brazil-survey-invitation": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,

--- a/config/test.json
+++ b/config/test.json
@@ -29,6 +29,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,6 +15,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -128,7 +128,6 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		else
 			script(src=urls[ 'vendor-min' ])
 			script(src=urls[ jsFile + '-' + env + '-min' ])
-			script(src=urls[ 'logger' ])
 			if chunk
 				script(src=urls[ '_commons-min' ])
 				script(src=urls[ chunk + '-min' ])

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,7 +96,6 @@ if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 	webpackConfig.output.filename = '[name].js';
 } else {
 	webpackConfig.entry.vendor = [ 'react', 'store', 'page', 'wpcom', 'jed', 'debug' ];
-	webpackConfig.entry.logger = [ 'lib/catch-js-errors' ];
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( 'vendor', '[name].[hash].js' ) );
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( {
 		children: true,


### PR DESCRIPTION
## This PR passes following data to logstash:

- path
- module
- site id
- user id
- last tracks event
- abtests

It also sets up mechanism to pass any redux subtree on error

## Testing

- Build with `ENABLE_FEATURES=catch-js-errors make run`
- Assign yourself to the group that generates an error: `localStorage.setItem('log-errors', 'rest-api');`
- Reload
- Go to http://calypso.localhost:3000/plugins . IF you have a Jetpack site, you will get an error there. 
- You should see a call going to `https://public-api.wordpress.com/rest/v1.1/js-error` in inspector
- See that new data is passed in request
- If you want to see this data captured, see differential D2353


Test live: https://calypso.live/?branch=update/error-logging-details

CC @rralian @lamosty @gwwar 