### PR TITLE
Purchases: Adding refund survey to Horizon and WPCalypso.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,7 +90,8 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true
+		"upgrades/removal-survey": true,
+		"upgrades/refund-survey": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,7 +105,8 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true
+		"upgrades/removal-survey": true,
+		"upgrades/refund-survey": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
Simple update to release survey to more platforms to test on. Please refer to #6831 for full testing instructions.