### PR TITLE
Domains: Allow WHOIS editing when privacy enabled for SRS/HRS

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -29,6 +29,7 @@ function createDomainObjects( dataTransferObject ) {
 			hasPrivacyProtection: domain.has_private_registration,
 			isAutoRenewing: domain.auto_renewing,
 			currentUserCanManage: domain.current_user_can_manage || domain.is_current_user_owner,
+			isWhoisEditable: domain.is_whois_editable,
 			isPendingIcannVerification: domain.is_pending_icann_verification,
 			isPrimary: domain.primary_domain,
 			manualTransferRequired: domain.manual_transfer_required,

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -40,6 +40,7 @@ describe( 'assembler', () => {
 			hasPrivacyProtection: undefined,
 			isAutoRenewing: undefined,
 			currentUserCanManage: undefined,
+			isWhoisEditable: undefined,
 			isPendingIcannVerification: undefined,
 			isPrimary: false,
 			name: DOMAIN_NAME,

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/index.jsx
@@ -56,7 +56,7 @@ const EditContactInfo = React.createClass( {
 			return <NonOwnerCard selectedDomainName={ this.props.selectedDomainName } />;
 		}
 
-		if ( domain.hasPrivacyProtection ) {
+		if ( ! domain.isWhoisEditable ) {
 			return <EditContactInfoPrivacyEnabledCard />;
 		}
 


### PR DESCRIPTION
OpenSRS and OpenHRS allow editing of WHOIS information even while privacy protection is enabled - something that was not possible with our previous API. This is make the process of editing WHOIS information more straightforward - you don't have to temporarily disable privacy protection.

### Testing

You need `D2333-code` on the backend.

For OpenSRS (`.live` only currently) and OpenHRS (`.wales` only currently), verify that you can edit the WHOIS information even if the privacy protection is enabled (be aware of #6920 :)):

<img width="778" alt="screen shot 2016-07-22 at 20 05 49" src="https://cloud.githubusercontent.com/assets/3392497/17066865/43670e3e-5049-11e6-82a4-6e7b96ebd4bb.png">
<img width="757" alt="screen shot 2016-07-22 at 20 06 13" src="https://cloud.githubusercontent.com/assets/3392497/17066864/436169d4-5049-11e6-9572-0fb8480d1588.png">

For other domains, when privacy protection is enabled, you should see the usual notice:

<img width="781" alt="screen shot 2016-07-22 at 20 00 25" src="https://cloud.githubusercontent.com/assets/3392497/17066863/432afed0-5049-11e6-83ad-73241a186063.png">

For all types of domain, when privacy protection is disabled (currently only by initiating a transfer), you should be able to edit WHOIS information.

/cc @aidvu @umurkontaci 

Test live: https://calypso.live/?branch=fix/is-whois-editable