### PR TITLE
WebPreview: hide all but last button in toolbar at small width

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -132,6 +132,11 @@
 
 	.button {
 		margin: 4px;
+		&:not(:last-child) {
+			@include breakpoint( "<660px" ) {
+				display: none;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
When the window gets small, hide all but the last (hopefully primary) button in the toolbar.

Fixes #6975

### Testing

1. Starting at URL: http://calypso.localhost:3000/design
2. Click the ellipsis at the bottom of a theme card and select "Live Demo"
3. Adjust the viewport width.
4. Above 660px, you should see "Try & Customize" and "Activate this Design", below 660px, you should only see "Activate this Design" (button will read "Pick" if the theme is not free).

<img width="769" alt="screen shot 2016-07-22 at 4 37 03 pm" src="https://cloud.githubusercontent.com/assets/2036909/17070558/9670c5e4-502a-11e6-869c-2729e8740786.png">

<img width="541" alt="screen shot 2016-07-22 at 4 37 15 pm" src="https://cloud.githubusercontent.com/assets/2036909/17070562/98f39332-502a-11e6-865e-fa46d3b643a4.png">


Test live: https://calypso.live/?branch=update/small-width-hide-non-primary-button-web-preview