### PR TITLE
Purchases: Move boilerplate cancel purchase survey code into its own component.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -71,6 +71,7 @@
 @import 'components/like-button/style';
 @import 'components/logged-out-form/style';
 @import 'components/main/style';
+@import 'components/marketing-survey/cancel-purchase-form/style';
 @import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';
 @import 'components/olark-chatbox/style';

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -1,0 +1,367 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import shuffle from 'lodash/shuffle';
+
+/**
+ * Internal Dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLegend from 'components/forms/form-legend';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
+
+const CancelPurchaseForm = React.createClass( {
+	propTypes: {
+		surveyStep: React.PropTypes.number.isRequired,
+		showSurvey: React.PropTypes.bool.isRequired,
+		defaultContent: React.PropTypes.node.isRequired,
+		onInputChange: React.PropTypes.func.isRequired
+	},
+
+	getInitialState() {
+		// shuffle reason order, but keep anotherReasonOne last
+		const questionOneOrder = shuffle( [
+			'couldNotInstall',
+			'tooHard',
+			'didNotInclude',
+			'onlyNeedFree'
+		] );
+		questionOneOrder.push( 'anotherReasonOne' );
+
+		const questionTwoOrder = shuffle( [
+			'stayingHere',
+			'otherWordPress',
+			'differentService',
+			'noNeed'
+		] );
+		questionTwoOrder.push( 'anotherReasonTwo' );
+
+		return {
+			questionOneRadio: null,
+			questionOneText: '',
+			questionOneOrder: questionOneOrder,
+			questionTwoRadio: null,
+			questionTwoText: '',
+			questionTwoOrder: questionTwoOrder,
+			questionThreeText: ''
+		};
+	},
+
+	onRadioOneChange( event ) {
+		const newState = {
+			...this.state,
+			questionOneRadio: event.currentTarget.value,
+			questionOneText: ''
+		};
+		this.setState( newState );
+		this.props.onInputChange( newState );
+	},
+
+	onTextOneChange( event ) {
+		const newState = {
+			...this.state,
+			questionOneText: event.currentTarget.value
+		};
+		this.setState( newState );
+		this.props.onInputChange( newState );
+	},
+
+	onRadioTwoChange( event ) {
+		const newState = {
+			...this.state,
+			questionTwoRadio: event.currentTarget.value,
+			questionTwoText: ''
+		};
+		this.setState( newState );
+		this.props.onInputChange( newState );
+	},
+
+	onTextTwoChange( event ) {
+		const newState = {
+			...this.state,
+			questionTwoText: event.currentTarget.value
+		};
+		this.setState( newState );
+		this.props.onInputChange( newState );
+	},
+
+	onTextThreeChange( event ) {
+		const newState = {
+			...this.state,
+			questionThreeText: event.currentTarget.value
+		};
+		this.setState( newState );
+		this.props.onInputChange( newState );
+	},
+
+	renderQuestionOne() {
+		const reasons = {};
+
+		const couldNotInstallInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="couldNotInstallInput"
+				id="couldNotInstallInput"
+				value={ this.state.questionOneText }
+				onChange={ this.onTextOneChange }
+				placeholder={ this.translate( 'What plugin/theme were you trying to install?' ) } />
+		);
+		reasons.couldNotInstall = (
+			<FormLabel key="couldNotInstall">
+				<FormRadio
+					name="couldNotInstall"
+					value="couldNotInstall"
+					checked={ 'couldNotInstall' === this.state.questionOneRadio }
+					onChange={ this.onRadioOneChange } />
+				<span>{ this.translate( 'I couldn\'t install a plugin/theme I wanted.' ) }</span>
+				{ 'couldNotInstall' === this.state.questionOneRadio && couldNotInstallInput }
+			</FormLabel>
+		);
+
+		const tooHardInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="tooHardInput"
+				id="tooHardInput"
+				value={ this.state.questionOneText }
+				onChange={ this.onTextOneChange }
+				placeholder={ this.translate( 'Where did you run into problems?' ) } />
+		);
+		reasons.tooHard = (
+			<FormLabel key="tooHard">
+				<FormRadio
+					name="tooHard"
+					value="tooHard"
+					checked={ 'tooHard' === this.state.questionOneRadio }
+					onChange={ this.onRadioOneChange } />
+				<span>{ this.translate( 'It was too hard to set up my site.' ) }</span>
+				{ 'tooHard' === this.state.questionOneRadio && tooHardInput }
+			</FormLabel>
+		);
+
+		const didNotIncludeInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="didNotIncludeInput"
+				id="didNotIncludeInput"
+				value={ this.state.questionOneText }
+				onChange={ this.onTextOneChange }
+				placeholder={ this.translate( 'What are we missing that you need?' ) } />
+		);
+		reasons.didNotInclude = (
+			<FormLabel key="didNotInclude">
+				<FormRadio
+					name="didNotInclude"
+					value="didNotInclude"
+					checked={ 'didNotInclude' === this.state.questionOneRadio }
+					onChange={ this.onRadioOneChange } />
+				<span>{ this.translate( 'This upgrade didn\'t include what I needed.' ) }</span>
+				{ 'didNotInclude' === this.state.questionOneRadio && didNotIncludeInput }
+			</FormLabel>
+		);
+
+		const onlyNeedFreeInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="onlyNeedFreeInput"
+				id="onlyNeedFreeInput"
+				value={ this.state.questionOneText }
+				onChange={ this.onTextOneChange }
+				placeholder={ this.translate( 'How can we improve our upgrades?' ) } />
+		);
+		reasons.onlyNeedFree = (
+			<FormLabel key="onlyNeedFree">
+				<FormRadio
+					name="onlyNeedFree"
+					value="onlyNeedFree"
+					checked={ 'onlyNeedFree' === this.state.questionOneRadio }
+					onChange={ this.onRadioOneChange } />
+				<span>{ this.translate( 'All I need is the free plan.' ) }</span>
+				{ 'onlyNeedFree' === this.state.questionOneRadio && onlyNeedFreeInput }
+			</FormLabel>
+		);
+
+		const anotherReasonOneInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="anotherReasonOneInput"
+				value={ this.state.questionOneText }
+				onChange={ this.onTextOneChange }
+				id="anotherReasonOneInput" />
+		);
+		reasons.anotherReasonOne = (
+			<FormLabel key="anotherReasonOne">
+				<FormRadio
+					name="anotherReasonOne"
+					value="anotherReasonOne"
+					checked={ 'anotherReasonOne' === this.state.questionOneRadio }
+					onChange={ this.onRadioOneChange } />
+				<span>{ this.translate( 'Another reason…' ) }</span>
+				{ 'anotherReasonOne' === this.state.questionOneRadio && anotherReasonOneInput }
+			</FormLabel>
+		);
+
+		const { questionOneOrder } = this.state,
+			orderedReasons = questionOneOrder.map( question => reasons[ question ] );
+
+		return (
+			<div>
+				<FormLegend>{ this.translate( 'Please tell us why you are canceling:' ) }</FormLegend>
+				{ orderedReasons }
+			</div>
+		);
+	},
+
+	renderQuestionTwo() {
+		const reasons = {};
+
+		reasons.stayingHere = (
+			<FormLabel key="stayingHere">
+				<FormRadio
+					name="stayingHere"
+					value="stayingHere"
+					checked={ 'stayingHere' === this.state.questionTwoRadio }
+					onChange={ this.onRadioTwoChange } />
+				<span>{ this.translate( 'I\'m staying here and using the free plan.' ) }</span>
+			</FormLabel>
+		);
+
+		const otherWordPressInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="otherWordPressInput"
+				id="otherWordPressInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.onTextTwoChange }
+				placeholder={ this.translate( 'Mind telling us where?' ) } />
+		);
+		reasons.otherWordPress = (
+			<FormLabel key="otherWordPress">
+				<FormRadio
+					name="otherWordPress"
+					value="otherWordPress"
+					checked={ 'otherWordPress' === this.state.questionTwoRadio }
+					onChange={ this.onRadioTwoChange } />
+				<span>{ this.translate( 'I\'m going to use WordPress somewhere else.' ) }</span>
+				{ 'otherWordPress' === this.state.questionTwoRadio && otherWordPressInput }
+			</FormLabel>
+		);
+
+		const differentServiceInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="differentServiceInput"
+				id="differentServiceInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.onTextTwoChange }
+				placeholder={ this.translate( 'Mind telling us which one?' ) } />
+		);
+		reasons.differentService = (
+			<FormLabel key="differentService">
+				<FormRadio
+					name="differentService"
+					value="differentService"
+					checked={ 'differentService' === this.state.questionTwoRadio }
+					onChange={ this.onRadioTwoChange } />
+				<span>{ this.translate( 'I\'m going to use a different service for my website or blog.' ) }</span>
+				{ 'differentService' === this.state.questionTwoRadio && differentServiceInput }
+			</FormLabel>
+		);
+
+		const noNeedInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="noNeedInput"
+				id="noNeedInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.onTextTwoChange }
+				placeholder={ this.translate( 'What will you do instead?' ) } />
+		);
+		reasons.noNeed = (
+			<FormLabel key="noNeed">
+				<FormRadio
+					name="noNeed"
+					value="noNeed"
+					checked={ 'noNeed' === this.state.questionTwoRadio }
+					onChange={ this.onRadioTwoChange } />
+				<span>{ this.translate( 'I no longer need a website or blog.' ) }</span>
+				{ 'noNeed' === this.state.questionTwoRadio && noNeedInput }
+			</FormLabel>
+		);
+
+		const anotherReasonTwoInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="anotherReasonTwoInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.onTextTwoChange }
+				id="anotherReasonTwoInput" />
+		);
+		reasons.anotherReasonTwo = (
+			<FormLabel key="anotherReasonTwo">
+				<FormRadio
+					name="anotherReasonTwo"
+					value="anotherReasonTwo"
+					checked={ 'anotherReasonTwo' === this.state.questionTwoRadio }
+					onChange={ this.onRadioTwoChange } />
+				<span>{ this.translate( 'Another reason…' ) }</span>
+				{ 'anotherReasonTwo' === this.state.questionTwoRadio && anotherReasonTwoInput }
+			</FormLabel>
+		);
+
+		const { questionTwoOrder } = this.state,
+			orderedReasons = questionTwoOrder.map( question => reasons[ question ] );
+
+		return (
+			<div>
+				<FormLegend>{ this.translate( 'Where is your next adventure taking you?' ) }</FormLegend>
+				{ orderedReasons }
+			</div>
+		);
+	},
+
+	renderFreeformQuestion() {
+		return (
+			<FormFieldset>
+				<FormLabel>
+					{ this.translate( 'What\'s one thing we could have done better? (optional)' ) }
+					<FormTextarea
+						name="improvementInput"
+						id="improvementInput"
+						value={ this.state.questionThreeText }
+						onChange={ this.onTextThreeChange } />
+				</FormLabel>
+			</FormFieldset>
+		);
+	},
+
+	render() {
+		if ( this.props.showSurvey ) {
+			if ( this.props.surveyStep === 1 ) {
+				return (
+					<div>
+						{ this.renderQuestionOne() }
+						{ this.renderQuestionTwo() }
+					</div>
+				);
+			}
+
+			// 2nd surveyStep
+			return (
+				<div>
+					{ this.renderFreeformQuestion() }
+					{ this.props.defaultContent }
+				</div>
+			);
+		}
+
+		// just return the default if we don't want to show the survey
+		return ( <div>{ this.props.defaultContent }</div> );
+	}
+} );
+
+export default CancelPurchaseForm;

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -1,0 +1,4 @@
+.dialog__content .cancel-purchase-form__reason-input {
+	margin: 4px 0 0 24px;
+	width: calc( 100% - 24px );
+}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -4,7 +4,6 @@
 import { connect } from 'react-redux';
 import page from 'page';
 import React from 'react';
-import shuffle from 'lodash/shuffle';
 
 /**
  * Internal dependencies
@@ -13,6 +12,7 @@ import wpcom from 'lib/wp';
 import config from 'config';
 import CompactCard from 'components/card/compact';
 import Dialog from 'components/dialog';
+import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { getPurchase, isDataLoading } from '../utils';
 import Gridicon from 'components/gridicon';
@@ -21,12 +21,6 @@ import notices from 'notices';
 import purchasePaths from '../paths';
 import { removePurchase } from 'state/purchases/actions';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLegend from 'components/forms/form-legend';
-import FormLabel from 'components/forms/form-label';
-import FormRadio from 'components/forms/form-radio';
-import FormTextInput from 'components/forms/form-text-input';
-import FormTextarea from 'components/forms/form-textarea';
 import userFactory from 'lib/user';
 
 const user = userFactory();
@@ -49,39 +43,26 @@ const RemovePurchase = React.createClass( {
 	},
 
 	getInitialState() {
-		// shuffle reason order, but keep anotherReasonOne last
-		const questionOneOrder = shuffle( [
-			'couldNotInstall',
-			'tooHard',
-			'didNotInclude',
-			'onlyNeedFree'
-		] );
-		questionOneOrder.push( 'anotherReasonOne' );
-
-		const questionTwoOrder = shuffle( [
-			'stayingHere',
-			'otherWordPress',
-			'differentService',
-			'noNeed'
-		] );
-		questionTwoOrder.push( 'anotherReasonTwo' );
-
 		return {
 			isDialogVisible: false,
 			isRemoving: false,
 			surveyStep: 1,
-			questionOneRadio: null,
-			questionOneText: '',
-			questionOneOrder: questionOneOrder,
-			questionTwoRadio: null,
-			questionTwoText: '',
-			questionTwoOrder: questionTwoOrder,
-			questionThreeText: ''
+			survey: {
+				questionOneRadio: null,
+				questionTwoRadio: null
+			}
 		};
 	},
 
 	closeDialog() {
-		this.setState( { isDialogVisible: false } );
+		this.setState( {
+			isDialogVisible: false,
+			surveyStep: 1,
+			survey: {
+				questionOneRadio: null,
+				questionTwoRadio: null
+			}
+		} );
 	},
 
 	openDialog( event ) {
@@ -96,6 +77,12 @@ const RemovePurchase = React.createClass( {
 		} );
 	},
 
+	onSurveyChange( update ) {
+		this.setState( {
+			survey: update,
+		} );
+	},
+
 	removePurchase( closeDialog ) {
 		this.setState( { isRemoving: true } );
 
@@ -106,14 +93,14 @@ const RemovePurchase = React.createClass( {
 			const survey = wpcom.marketing().survey( 'calypso-remove-purchase', this.props.selectedSite.ID );
 			survey.addResponses( {
 				'why-cancel': {
-					response: this.state.questionOneRadio,
-					text: this.state.questionOneText
+					response: this.state.survey.questionOneRadio,
+					text: this.state.survey.questionOneText
 				},
 				'next-adventure': {
-					response: this.state.questionTwoRadio,
-					text: this.state.questionTwoText
+					response: this.state.survey.questionTwoRadio,
+					text: this.state.survey.questionTwoText
 				},
-				'what-better': { text: this.state.questionThreeText },
+				'what-better': { text: this.state.survey.questionThreeText },
 				purchase: purchase.productSlug,
 				type: 'cancel'
 			} );
@@ -156,38 +143,6 @@ const RemovePurchase = React.createClass( {
 			closeDialog();
 
 			notices.error( this.props.selectedPurchase.error );
-		} );
-	},
-
-	handleRadioOne( event ) {
-		this.setState( {
-			questionOneRadio: event.currentTarget.value,
-			questionOneText: ''
-		} );
-	},
-
-	handleTextOne( event ) {
-		this.setState( {
-			questionOneText: event.currentTarget.value
-		} );
-	},
-
-	handleRadioTwo( event ) {
-		this.setState( {
-			questionTwoRadio: event.currentTarget.value,
-			questionTwoText: ''
-		} );
-	},
-
-	handleTextTwo( event ) {
-		this.setState( {
-			questionTwoText: event.currentTarget.value
-		} );
-	},
-
-	handleTextThree( event ) {
-		this.setState( {
-			questionThreeText: event.currentTarget.value
 		} );
 	},
 
@@ -259,10 +214,10 @@ const RemovePurchase = React.createClass( {
 				next: {
 					action: 'next',
 					disabled: this.state.isRemoving ||
-						this.state.questionOneRadio === null ||
-						this.state.questionTwoRadio === null ||
-						( this.state.questionOneRadio === 'anotherReasonOne' && this.state.questionOneText === '' ) ||
-						( this.state.questionTwoRadio === 'anotherReasonTwo' && this.state.questionTwoText === '' ),
+						this.state.survey.questionOneRadio === null ||
+						this.state.survey.questionTwoRadio === null ||
+						( this.state.survey.questionOneRadio === 'anotherReasonOne' && this.state.survey.questionOneText === '' ) ||
+						( this.state.survey.questionTwoRadio === 'anotherReasonTwo' && this.state.survey.questionTwoText === '' ),
 					label: this.translate( 'Next' ),
 					onClick: this.changeSurveyStep
 				},
@@ -283,13 +238,11 @@ const RemovePurchase = React.createClass( {
 			productName = getName( getPurchase( this.props ) ),
 			inStepOne = this.state.surveyStep === 1;
 
-		let buttonsArr, dialogContent;
+		let buttonsArr;
 		if ( ! config.isEnabled( 'upgrades/removal-survey' ) ) {
 			buttonsArr = [ buttons.cancel, buttons.remove ];
-			dialogContent = this.renderPlanDialogsText();
 		} else {
-			buttonsArr = ( inStepOne ) ? [ buttons.cancel, buttons.next ] : [ buttons.cancel, buttons.prev, buttons.remove ];
-			dialogContent = ( inStepOne ) ? this.renderDialogContentOne() : this.renderDialogContentTwo();
+			buttonsArr = inStepOne ? [ buttons.cancel, buttons.next ] : [ buttons.cancel, buttons.prev, buttons.remove ];
 		}
 
 		return (
@@ -300,7 +253,12 @@ const RemovePurchase = React.createClass( {
 					isVisible={ this.state.isDialogVisible }
 					onClose={ this.closeDialog }>
 					<FormSectionHeading>{ this.translate( 'Remove %(productName)s', { args: { productName } } ) }</FormSectionHeading>
-					{ dialogContent }
+					<CancelPurchaseForm
+						surveyStep={ this.state.surveyStep }
+						showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
+						defaultContent={ this.renderPlanDialogsText() }
+						onInputChange={ this.onSurveyChange }
+					/>
 				</Dialog>
 			</div>
 		);
@@ -348,265 +306,6 @@ const RemovePurchase = React.createClass( {
 				</p>
 
 				{ ( isPlan( purchase ) && hasIncludedDomain( purchase ) ) && includedDomainText }
-			</div>
-		);
-	},
-
-	renderQuestionOne() {
-		const reasons = {};
-
-		const couldNotInstallInput = (
-			<FormTextInput
-				className="remove-purchase__reason-input"
-				name="couldNotInstallInput"
-				id="couldNotInstallInput"
-				value={ this.state.questionOneText }
-				onChange={ this.handleTextOne }
-				placeholder={ this.translate( 'What plugin/theme were you trying to install?' ) } />
-		);
-		reasons.couldNotInstall = (
-			<FormLabel key="couldNotInstall">
-				<FormRadio
-					name="couldNotInstall"
-					value="couldNotInstall"
-					checked={ 'couldNotInstall' === this.state.questionOneRadio }
-					onChange={ this.handleRadioOne } />
-				<span>{ this.translate( 'I couldn\'t install a plugin/theme I wanted.' ) }</span>
-				{ 'couldNotInstall' === this.state.questionOneRadio && couldNotInstallInput }
-			</FormLabel>
-		);
-
-		const tooHardInput = (
-			<FormTextInput
-				className="remove-purchase__reason-input"
-				name="tooHardInput"
-				id="tooHardInput"
-				value={ this.state.questionOneText }
-				onChange={ this.handleTextOne }
-				placeholder={ this.translate( 'Where did you run into problems?' ) } />
-		);
-		reasons.tooHard = (
-			<FormLabel key="tooHard">
-				<FormRadio
-					name="tooHard"
-					value="tooHard"
-					checked={ 'tooHard' === this.state.questionOneRadio }
-					onChange={ this.handleRadioOne } />
-				<span>{ this.translate( 'It was too hard to set up my site.' ) }</span>
-				{ 'tooHard' === this.state.questionOneRadio && tooHardInput }
-			</FormLabel>
-		);
-
-		const didNotIncludeInput = (
-			<FormTextInput
-				className="remove-purchase__reason-input"
-				name="didNotIncludeInput"
-				id="didNotIncludeInput"
-				value={ this.state.questionOneText }
-				onChange={ this.handleTextOne }
-				placeholder={ this.translate( 'What are we missing that you need?' ) } />
-		);
-		reasons.didNotInclude = (
-			<FormLabel key="didNotInclude">
-				<FormRadio
-					name="didNotInclude"
-					value="didNotInclude"
-					checked={ 'didNotInclude' === this.state.questionOneRadio }
-					onChange={ this.handleRadioOne } />
-				<span>{ this.translate( 'This upgrade didn\'t include what I needed.' ) }</span>
-				{ 'didNotInclude' === this.state.questionOneRadio && didNotIncludeInput }
-			</FormLabel>
-		);
-
-		const onlyNeedFreeInput = (
-			<FormTextInput
-				className="remove-purchase__reason-input"
-				name="onlyNeedFreeInput"
-				id="onlyNeedFreeInput"
-				value={ this.state.questionOneText }
-				onChange={ this.handleTextOne }
-				placeholder={ this.translate( 'How can we improve our upgrades?' ) } />
-		);
-		reasons.onlyNeedFree = (
-			<FormLabel key="onlyNeedFree">
-				<FormRadio
-					name="onlyNeedFree"
-					value="onlyNeedFree"
-					checked={ 'onlyNeedFree' === this.state.questionOneRadio }
-					onChange={ this.handleRadioOne } />
-				<span>{ this.translate( 'All I need is the free plan.' ) }</span>
-				{ 'onlyNeedFree' === this.state.questionOneRadio && onlyNeedFreeInput }
-			</FormLabel>
-		);
-
-		const anotherReasonOneInput = (
-			<FormTextInput
-				className="remove-purchase__reason-input"
-				name="anotherReasonOneInput"
-				value={ this.state.questionOneText }
-				onChange={ this.handleTextOne }
-				id="anotherReasonOneInput" />
-		);
-		reasons.anotherReasonOne = (
-			<FormLabel key="anotherReasonOne">
-				<FormRadio
-					name="anotherReasonOne"
-					value="anotherReasonOne"
-					checked={ 'anotherReasonOne' === this.state.questionOneRadio }
-					onChange={ this.handleRadioOne } />
-				<span>{ this.translate( 'Another reason…' ) }</span>
-				{ 'anotherReasonOne' === this.state.questionOneRadio && anotherReasonOneInput }
-			</FormLabel>
-		);
-
-		const { questionOneOrder } = this.state,
-			orderedReasons = questionOneOrder.map( question => reasons[ question ] );
-
-		return (
-			<div>
-				<FormLegend>{ this.translate( 'Please tell us why you are canceling:' ) }</FormLegend>
-				{ orderedReasons }
-			</div>
-		);
-	},
-
-	renderQuestionTwo() {
-		const reasons = {};
-
-		reasons.stayingHere = (
-			<FormLabel key="stayingHere">
-				<FormRadio
-					name="stayingHere"
-					value="stayingHere"
-					checked={ 'stayingHere' === this.state.questionTwoRadio }
-					onChange={ this.handleRadioTwo } />
-				<span>{ this.translate( 'I\'m staying here and using the free plan.' ) }</span>
-			</FormLabel>
-		);
-
-		const otherWordPressInput = (
-			<FormTextInput
-				className="remove-purchase__reason-input"
-				name="otherWordPressInput"
-				id="otherWordPressInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.handleTextTwo }
-				placeholder={ this.translate( 'Mind telling us where?' ) } />
-		);
-		reasons.otherWordPress = (
-			<FormLabel key="otherWordPress">
-				<FormRadio
-					name="otherWordPress"
-					value="otherWordPress"
-					checked={ 'otherWordPress' === this.state.questionTwoRadio }
-					onChange={ this.handleRadioTwo } />
-				<span>{ this.translate( 'I\'m going to use WordPress somewhere else.' ) }</span>
-				{ 'otherWordPress' === this.state.questionTwoRadio && otherWordPressInput }
-			</FormLabel>
-		);
-
-		const differentServiceInput = (
-			<FormTextInput
-				className="remove-purchase__reason-input"
-				name="differentServiceInput"
-				id="differentServiceInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.handleTextTwo }
-				placeholder={ this.translate( 'Mind telling us which one?' ) } />
-		);
-		reasons.differentService = (
-			<FormLabel key="differentService">
-				<FormRadio
-					name="differentService"
-					value="differentService"
-					checked={ 'differentService' === this.state.questionTwoRadio }
-					onChange={ this.handleRadioTwo } />
-				<span>{ this.translate( 'I\'m going to use a different service for my website or blog.' ) }</span>
-				{ 'differentService' === this.state.questionTwoRadio && differentServiceInput }
-			</FormLabel>
-		);
-
-		const noNeedInput = (
-			<FormTextInput
-				className="remove-purchase__reason-input"
-				name="noNeedInput"
-				id="noNeedInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.handleTextTwo }
-				placeholder={ this.translate( 'What will you do instead?' ) } />
-		);
-		reasons.noNeed = (
-			<FormLabel key="noNeed">
-				<FormRadio
-					name="noNeed"
-					value="noNeed"
-					checked={ 'noNeed' === this.state.questionTwoRadio }
-					onChange={ this.handleRadioTwo } />
-				<span>{ this.translate( 'I no longer need a website or blog.' ) }</span>
-				{ 'noNeed' === this.state.questionTwoRadio && noNeedInput }
-			</FormLabel>
-		);
-
-		const anotherReasonTwoInput = (
-			<FormTextInput
-				className="remove-purchase__reason-input"
-				name="anotherReasonTwoInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.handleTextTwo }
-				id="anotherReasonTwoInput" />
-		);
-		reasons.anotherReasonTwo = (
-			<FormLabel key="anotherReasonTwo">
-				<FormRadio
-					name="anotherReasonTwo"
-					value="anotherReasonTwo"
-					checked={ 'anotherReasonTwo' === this.state.questionTwoRadio }
-					onChange={ this.handleRadioTwo } />
-				<span>{ this.translate( 'Another reason…' ) }</span>
-				{ 'anotherReasonTwo' === this.state.questionTwoRadio && anotherReasonTwoInput }
-			</FormLabel>
-		);
-
-		const { questionTwoOrder } = this.state,
-			orderedReasons = questionTwoOrder.map( question => reasons[ question ] );
-
-		return (
-			<div>
-				<FormLegend>{ this.translate( 'Where is your next adventure taking you?' ) }</FormLegend>
-				{ orderedReasons }
-			</div>
-		);
-	},
-
-	renderFreeformQuestion() {
-		return (
-			<FormFieldset>
-				<FormLabel>
-					{ this.translate( 'What\'s one thing we could have done better? (optional)' ) }
-					<FormTextarea
-						name="improvementInput"
-						id="improvementInput"
-						value={ this.state.questionThreeText }
-						onChange={ this.handleTextThree } />
-				</FormLabel>
-			</FormFieldset>
-		);
-	},
-
-	renderDialogContentOne() {
-		return (
-			<div>
-				{ this.renderQuestionOne() }
-				{ this.renderQuestionTwo() }
-			</div>
-		);
-	},
-
-	renderDialogContentTwo() {
-		return (
-			<div>
-				{ this.renderFreeformQuestion() }
-				{ this.renderPlanDialogsText() }
 			</div>
 		);
 	},

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -11,16 +11,3 @@
 		vertical-align: middle;
 	}
 }
-
-.remove-purchase__dialog.dialog__content {
-	h1 {
-		height: auto;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-}
-
-.remove-purchase__dialog .remove-purchase__reason-input {
-	margin: 4px 0 0 24px;
-	width: calc( 100% - 24px );
-}


### PR DESCRIPTION
This update moves much of the boilerplate purchase cancel marketing survey into its own component so I can be reused in multiple flows.

Please refer to #4838 for testing details--the functionality remains the same (minus being its own component).