### PR TITLE
Reader: fix follow button in popover

### DIFF
--- a/client/reader/post-options/_style.scss
+++ b/client/reader/post-options/_style.scss
@@ -57,20 +57,10 @@
 .popover__menu .follow-button {
 
 	.gridicon {
-		height: 24px;
-		width: 24px;
 		position: absolute;
-			left: 12px;
-			top: 10px;
-
-		&.gridicon__edit {
-			left: 12px;
-			top: 5px;
-		}
+			left: 14px;
+			top: 11px;
 	}
-}
-
-.popover__menu .follow-button {
 
 	&:hover,
 	&:focus {
@@ -83,6 +73,7 @@
 	}
 
 	&.is-following {
+
 		&:hover,
 		&:focus {
 			color: $white;
@@ -93,4 +84,8 @@
 			}
 		}
 	}
+}
+
+.popover__menu .follow-button__label {
+	display: inline-block;
 }


### PR DESCRIPTION
**Before:**

- Follow/Following icons were `24p x 24`:

![screenshot 2016-07-22 15 49 42](https://cloud.githubusercontent.com/assets/4924246/17073358/f0633006-5024-11e6-9e33-b92914c9ed81.png)

![screenshot 2016-07-22 15 51 36](https://cloud.githubusercontent.com/assets/4924246/17073359/f4b9b58a-5024-11e6-8c9e-aa7a0f76d1d2.png)

- Icons were not displaying correctly in `<660px`:

![screenshot 2016-07-22 15 49 56](https://cloud.githubusercontent.com/assets/4924246/17073349/d9f3581e-5024-11e6-8112-2260d9423a31.png)

![screenshot 2016-07-22 15 56 51](https://cloud.githubusercontent.com/assets/4924246/17073355/e9530124-5024-11e6-99eb-0e11c0ff783c.png)

**After:**

- Reverted to default size of `18 x 18` and reflect changes made here: https://github.com/Automattic/wp-calypso/pull/6418

- Fix icons not displaying correctly in `<660px`:

![screenshot 2016-07-22 15 58 15](https://cloud.githubusercontent.com/assets/4924246/17073371/24007676-5025-11e6-9eb8-2efa2bd953a7.png)
![screenshot 2016-07-22 15 58 25](https://cloud.githubusercontent.com/assets/4924246/17073372/2400e016-5025-11e6-8c7f-2b1b0de4ba65.png)




Test live: https://calypso.live/?branch=fix/reader/follow-button-popover