### PR TITLE
Reader: fix global notice not persistent

### DIFF
--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -1,4 +1,13 @@
 // Reader-specific tweaks to components
+
+.following {
+
+	@include breakpoint( "<660px" ) {
+		-webkit-perspective: none;
+		perspective: none;
+	}
+}
+
 .reader__card.card {
 	padding: 16px;
 	transition: all 0.1s ease-in-out;


### PR DESCRIPTION
**Before:**

In Chrome, global notice in `<660px` is:

1. not persistent, doesn't scroll to position
2. not sticky

Video: https://cloudup.com/cDLdm3Hi9EV

**After:**

1. global notice is now persistent and scrolls to position in `660px`
2. is now sticky and stays in place as you scroll

Video: https://cloudup.com/cZqVWnUYQkn

This is just a Chrome issue. Safari and Firefox have always worked as expected.


Test live: https://calypso.live/?branch=fix/reader/global-notice-not-fixed-chrome