### PR TITLE
Jetpack SSO: Use siteUrl from API instead of hostname

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -75,8 +75,9 @@ const JetpackSSOForm = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_log_in_button_click' );
 
 		const { siteId, ssoNonce } = this.props;
+		const siteUrl = get( this.props, 'blogDetails.URL' );
 		debug( 'Approving sso' );
-		this.props.authorizeSSO( siteId, ssoNonce );
+		this.props.authorizeSSO( siteId, ssoNonce, siteUrl );
 	},
 
 	onCancelClick( event ) {

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -232,7 +232,7 @@ const JetpackSSOForm = React.createClass( {
 
 	getReturnToSiteText() {
 		const text = (
-			<span className="jetpack-connect__sso__return-to-site">
+			<span className="jetpack-connect__sso-return-to-site">
 				<Gridicon icon="arrow-left" size={ 18 } />
 				{
 					this.translate( 'Return to %(siteName)s', {
@@ -256,7 +256,7 @@ const JetpackSSOForm = React.createClass( {
 						<a
 							href="#"
 							onClick={ this.onClickSharedDetailsModal }
-							className="jetpack-connect__sso__actions__modal-link"
+							className="jetpack-connect__sso-actions-modal-link"
 						/>
 					)
 				},
@@ -287,7 +287,7 @@ const JetpackSSOForm = React.createClass( {
 		}
 
 		return (
-			<span className="jetpack-connect__sso__placeholder">
+			<span className="jetpack-connect__sso-placeholder">
 				{ input }
 			</span>
 		);
@@ -309,15 +309,15 @@ const JetpackSSOForm = React.createClass( {
 		const sharedDetails = this.props.sharedDetails || expectedSharedDetails;
 
 		return (
-			<table className="jetpack-connect__sso__shared-details-table">
+			<table className="jetpack-connect__sso-shared-details-table">
 				<tbody>
 					{ map( sharedDetails, ( value, key ) => {
 						return (
-							<tr key={ key } className="jetpack-connect__sso__shared-detail-row">
-								<td className="jetpack-connect__sso__shared-detail-label">
+							<tr key={ key } className="jetpack-connect__sso-shared-detail-row">
+								<td className="jetpack-connect__sso-shared-detail-label">
 									{ this.getSharedDetailLabel( key ) }
 								</td>
-								<td className="jetpack-connect__sso__shared-detail-value">
+								<td className="jetpack-connect__sso-shared-detail-value">
 									{ this.getSharedDetailValue( key, value ) }
 								</td>
 							</tr>
@@ -341,9 +341,9 @@ const JetpackSSOForm = React.createClass( {
 				buttons={ buttons }
 				onClose={ this.closeTermsDialog }
 				isVisible={ this.state.showTermsDialog }
-				className="jetpack-connect__sso_terms-dialog">
-				<div className="jetpack-connect__sso_terms-dialog-content">
-					<p className="jetpack-connect__sso_shared-details-intro">
+				className="jetpack-connect__sso-terms-dialog">
+				<div className="jetpack-connect__sso-terms-dialog-content">
+					<p className="jetpack-connect__sso-shared-details-intro">
 						{
 							this.translate(
 								'When you approve logging in with WordPress.com, we will send the following details to your site.'
@@ -401,25 +401,25 @@ const JetpackSSOForm = React.createClass( {
 
 					<Card>
 						{ this.maybeRenderErrorNotice() }
-						<div className="jetpack-connect__sso__user-profile">
+						<div className="jetpack-connect__sso-user-profile">
 							<Gravatar user={ user } size={ 120 } imgSize={ 400 } />
-							<h3 className="jetpack-connect__sso__log-in-as">
+							<h3 className="jetpack-connect__sso-log-in-as">
 								{ this.translate(
 									'Log in as {{strong}}%s{{/strong}}',
 									{
 										args: user.display_name,
 										components: {
-											strong: <strong className="jetpack-connect__sso__display-name"/>
+											strong: <strong className="jetpack-connect__sso-display-name"/>
 										}
 									}
 								) }
 							</h3>
-							<div className="jetpack-connect__sso__user-email">
+							<div className="jetpack-connect__sso-user-email">
 								{ user.email }
 							</div>
 						</div>
 
-						<LoggedOutFormFooter className="jetpack-connect__sso__actions">
+						<LoggedOutFormFooter className="jetpack-connect__sso-actions">
 							<p className="jetpack-connect__tos-link">
 								{ this.getTOSText() }
 							</p>

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -63,7 +63,7 @@ const JetpackSSOForm = React.createClass( {
 			//
 			// Note: We add `calypso_env` so that when we are redirected back to Calypso,
 			// we land in the same development environment.
-			let configEnv = config( 'env_id' ) || process.env.NODE_ENV;
+			const configEnv = config( 'env_id' ) || process.env.NODE_ENV;
 			const redirect = addQueryArgs( { calypso_env: configEnv }, nextProps.ssoUrl );
 			debug( 'Redirecting to: ' + redirect );
 			window.location.href = redirect;
@@ -340,8 +340,8 @@ const JetpackSSOForm = React.createClass( {
 				buttons={ buttons }
 				onClose={ this.closeTermsDialog }
 				isVisible={ this.state.showTermsDialog }
-				className="jetpack-connect_sso_terms-dialog">
-				<div className="jetpack-connect_sso_terms-dialog-content">
+				className="jetpack-connect__sso_terms-dialog">
+				<div className="jetpack-connect__sso_terms-dialog-content">
 					<p className="jetpack-connect__sso_shared-details-intro">
 						{
 							this.translate(

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -368,7 +368,7 @@
 	padding: 0;
 }
 
-.jetpack-connect_sso_terms-dialog {
+.jetpack-connect__sso_terms-dialog {
 	max-height: 70vh;
 	overflow-y: auto;
 }

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -291,33 +291,33 @@
 	color: $gray;
 }
 
-.jetpack-connect__sso__user-profile {
+.jetpack-connect__sso-user-profile {
 	margin-bottom: 16px;
 }
 
-.jetpack-connect__sso__user-profile .gravatar {
+.jetpack-connect__sso-user-profile .gravatar {
 	display: block;
 	margin: 0 auto 16px;
 }
 
-.jetpack-connect__sso__log-in-as{
+.jetpack-connect__sso-log-in-as{
 	font-family: $sans;
 	font-size: 21px;
 	font-weight: 300;
 	text-align: center;
 }
 
-.jetpack-connect__sso__display-name {
+.jetpack-connect__sso-display-name {
 	font-family: $serif;
 }
 
-.jetpack-connect__sso__user-email {
+.jetpack-connect__sso-user-email {
 	color: lighten( $gray, 10% );
 	font-weight: 400;
 	text-align: center;
 }
 
-.jetpack-connect__sso__actions .button {
+.jetpack-connect__sso-actions .button {
 	display: block;
 	text-align: center;
 	width: 100%;
@@ -368,16 +368,16 @@
 	padding: 0;
 }
 
-.jetpack-connect__sso_terms-dialog {
+.jetpack-connect__sso-terms-dialog {
 	max-height: 70vh;
 	overflow-y: auto;
 }
 
-.jetpack-connect__sso__shared-details-table {
+.jetpack-connect__sso-shared-details-table {
 	border-collapse: separate;
 }
 
-.jetpack-connect__sso__shared-detail-row {
+.jetpack-connect__sso-shared-detail-row {
 	margin-bottom: 16px;
 
 	&:last-child {
@@ -385,39 +385,39 @@
 	}
 }
 
-.jetpack-connect__sso__shared-detail-label {
+.jetpack-connect__sso-shared-detail-label {
 	font-weight: bold;
 }
 
-.jetpack-connect__sso__shared-detail-value {
+.jetpack-connect__sso-shared-detail-value {
 	padding-left: 16px;
 }
 
-.jetpack-connect__sso__shared-detail-label,
-.jetpack-connect__sso__shared-detail-value {
+.jetpack-connect__sso-shared-detail-label,
+.jetpack-connect__sso-shared-detail-value {
 	padding-bottom: 8px;
 }
 
 @include breakpoint( "<480px" ) {
-	.jetpack-connect__sso__shared-detail-label,
-	.jetpack-connect__sso__shared-detail-value {
+	.jetpack-connect__sso-shared-detail-label,
+	.jetpack-connect__sso-shared-detail-value {
 		display: block;
 	}
 
-	.jetpack-connect__sso__shared-detail-label {
+	.jetpack-connect__sso-shared-detail-label {
 		padding-bottom: 0;
 	}
 
-	.jetpack-connect__sso__shared-detail-value {
+	.jetpack-connect__sso-shared-detail-value {
 		padding-left: 0;
 	}
 }
 
-.jetpack-connect__sso__placeholder {
+.jetpack-connect__sso-placeholder {
 	@include placeholder( 23% );
 	background-color: transparent;
 }
 
-.jetpack-connect__sso__placeholder a {
+.jetpack-connect__sso-placeholder a {
 	color: transparent;
 }

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -224,7 +224,13 @@ export default {
 				userData,
 				( error, data ) => {
 					if ( error ) {
-						tracksEvent( dispatch, 'calypso_jpc_create_account_error', { error_code: error.code, error: JSON.stringify( error ) } );
+						tracksEvent( dispatch,
+							'calypso_jpc_create_account_error',
+							{
+								error_code: error.code,
+								error: JSON.stringify( error )
+							}
+						);
 					} else {
 						tracksEvent( dispatch, 'calypso_jpc_create_account_success', {} );
 					}

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -332,7 +332,7 @@ export default {
 			} );
 		};
 	},
-	authorizeSSO( siteId, ssoNonce ) {
+	authorizeSSO( siteId, ssoNonce, siteUrl ) {
 		return ( dispatch ) => {
 			debug( 'Attempting to authorize SSO for ' + siteId );
 			dispatch( {
@@ -344,7 +344,8 @@ export default {
 				tracksEvent( dispatch, 'calypso_jpc_authorize_sso_success' );
 				dispatch( {
 					type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
-					ssoUrl: data.sso_url
+					ssoUrl: data.sso_url,
+					siteUrl
 				} );
 			} ).catch( ( error ) => {
 				tracksEvent( dispatch, 'calypso_jpc_authorize_sso_error', {

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -274,8 +274,7 @@ export function jetpackSSO( state = {}, action ) {
 export function jetpackSSOSessions( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS:
-			const parsedUrl = urlModule.parse( action.ssoUrl );
-			return Object.assign( {}, state, buildNoProtocolUrlObj( parsedUrl.hostname ) );
+			return Object.assign( {}, state, buildNoProtocolUrlObj( action.siteUrl ) );
 		case SERIALIZE:
 		case DESERIALIZE:
 			return state;

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -80,7 +80,18 @@ export function jetpackConnectSite( state = {}, action ) {
 	};
 	switch ( action.type ) {
 		case JETPACK_CONNECT_CHECK_URL:
-			return Object.assign( {}, defaultState, { url: action.url, isFetching: true, isFetched: false, isDismissed: false, installConfirmedByUser: null, data: {} } );
+			return Object.assign(
+				{},
+				defaultState,
+				{
+					url: action.url,
+					isFetching: true,
+					isFetched: false,
+					isDismissed: false,
+					installConfirmedByUser: null,
+					data: {}
+				}
+			);
 		case JETPACK_CONNECT_CHECK_URL_RECEIVE:
 			if ( action.url === state.url ) {
 				return Object.assign( {}, state, { isFetching: false, isFetched: true, data: action.data } );
@@ -108,33 +119,121 @@ export function jetpackConnectSite( state = {}, action ) {
 export function jetpackConnectAuthorize( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_AUTHORIZE:
-			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, isRedirectingToWpAdmin: false } );
+			return Object.assign(
+				{},
+				state,
+				{
+					isAuthorizing: true,
+					authorizeSuccess: false,
+					authorizeError: false,
+					isRedirectingToWpAdmin: false
+				}
+			);
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE:
 			if ( isEmpty( action.error ) && action.data ) {
 				const { plans_url, activate_manage } = action.data;
-				return Object.assign( {}, state, { authorizeError: false, authorizeSuccess: true, autoAuthorize: false, plansUrl: plans_url, siteReceived: false, activateManageSecret: activate_manage } );
+				return Object.assign(
+					{},
+					state,
+					{
+						authorizeError: false,
+						authorizeSuccess: true,
+						autoAuthorize: false,
+						plansUrl: plans_url,
+						siteReceived: false,
+						activateManageSecret: activate_manage
+					}
+				);
 			}
-			return Object.assign( {}, state, { isAuthorizing: false, authorizeError: action.error, authorizeSuccess: false, autoAuthorize: false } );
+			return Object.assign(
+				{},
+				state,
+				{
+					isAuthorizing: false,
+					authorizeError: action.error,
+					authorizeSuccess: false,
+					autoAuthorize: false
+				}
+			);
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST:
 			const updateQueryObject = omit( state.queryObject, '_wp_nonce', 'secret', 'scope' );
-			return Object.assign( {}, omit( state, 'queryObject' ), { siteReceived: true, isAuthorizing: false, queryObject: updateQueryObject } );
+			return Object.assign(
+				{},
+				omit( state, 'queryObject' ),
+				{
+					siteReceived: true,
+					isAuthorizing: false,
+					queryObject: updateQueryObject
+				}
+			);
 		case JETPACK_CONNECT_ACTIVATE_MANAGE:
-			return Object.assign( {}, state, { isActivating: true } );
+			return Object.assign(
+				{},
+				state,
+				{ isActivating: true }
+			);
 		case JETPACK_CONNECT_ACTIVATE_MANAGE_RECEIVE:
 			const error = action.error;
-			return Object.assign( {}, state, { isActivating: false, manageActivated: true, manageActivatedError: error, activateManageSecret: false } );
+			return Object.assign(
+				{},
+				state,
+				{
+					isActivating: false,
+					manageActivated: true,
+					manageActivatedError: error,
+					activateManageSecret: false
+				}
+			);
 		case JETPACK_CONNECT_QUERY_SET:
 			const queryObject = Object.assign( {}, action.queryObject );
-			return Object.assign( {}, defaultAuthorizeState, { queryObject: queryObject } );
+			return Object.assign(
+				{},
+				defaultAuthorizeState,
+				{ queryObject: queryObject }
+			);
 		case JETPACK_CONNECT_QUERY_UPDATE:
-			return Object.assign( {}, state, { queryObject: Object.assign( {}, state.queryObject, { [ action.property ]: action.value } ) } );
+			return Object.assign(
+				{},
+				state,
+				{
+					queryObject: Object.assign( {}, state.queryObject, { [ action.property ]: action.value } )
+				}
+			);
 		case JETPACK_CONNECT_CREATE_ACCOUNT:
-			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false } );
+			return Object.assign(
+				{},
+				state,
+				{
+					isAuthorizing: true,
+					authorizeSuccess: false,
+					authorizeError: false
+				}
+			);
 		case JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE:
 			if ( ! isEmpty( action.error ) ) {
-				return Object.assign( {}, state, { isAuthorizing: false, authorizeSuccess: false, authorizeError: true, autoAuthorize: false } );
+				return Object.assign(
+					{},
+					state,
+					{
+						isAuthorizing: false,
+						authorizeSuccess: false,
+						authorizeError: true,
+						autoAuthorize: false
+					}
+				);
 			}
-			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, autoAuthorize: true, userData: action.userData, bearerToken: action.data.bearer_token } );
+			return Object.assign(
+				{},
+				state,
+				{
+					isAuthorizing: true,
+					authorizeSuccess: false,
+					authorizeError: false,
+					autoAuthorize: true,
+					userData: action.userData,
+					bearerToken: action.data.bearer_token
+				}
+			);
 		case JETPACK_CONNECT_REDIRECT_WP_ADMIN:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
 		case DESERIALIZE:

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -170,7 +170,7 @@ describe( 'actions', () => {
 			it( 'should dispatch validate action when thunk triggered', () => {
 				const { authorizeSSO } = actions;
 
-				authorizeSSO( siteId, ssoNonce )( spy );
+				authorizeSSO( siteId, ssoNonce, ssoUrl )( spy );
 				expect( spy ).to.have.been.calledWith( {
 					siteId: siteId,
 					type: JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST
@@ -180,9 +180,10 @@ describe( 'actions', () => {
 			it( 'should dispatch receive action when request completes', () => {
 				const { authorizeSSO } = actions;
 
-				return authorizeSSO( siteId, ssoNonce )( spy ).then( () => {
+				return authorizeSSO( siteId, ssoNonce, ssoUrl )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						ssoUrl,
+						siteUrl: ssoUrl,
 						type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS
 					} );
 				} );
@@ -212,7 +213,7 @@ describe( 'actions', () => {
 			it( 'should dispatch receive action when request completes', () => {
 				const { authorizeSSO } = actions;
 
-				return authorizeSSO( siteId, ssoNonce )( spy ).then( () => {
+				return authorizeSSO( siteId, ssoNonce, ssoUrl )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						error: {
 							error: 'invalid_input',

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -160,7 +160,8 @@ describe( 'reducer', () => {
 			const nowTime = ( new Date() ).getTime();
 			const state = jetpackSSOSessions( undefined, {
 				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
-				ssoUrl: 'https://website.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}'
+				ssoUrl: 'https://website.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
+				siteUrl: 'https://website.com'
 			} );
 
 			expect( state ).to.have.property( 'website.com' )
@@ -258,7 +259,8 @@ describe( 'reducer', () => {
 			const actions = [
 				{
 					type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
-					ssoUrl: 'http://website.com'
+					ssoUrl: 'http://website.com',
+					siteUrl: 'http://website.com'
 				},
 				{
 					type: JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
@@ -277,7 +279,8 @@ describe( 'reducer', () => {
 		it( 'should store sso_url after authorization', () => {
 			const action = deepFreeze( {
 				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
-				ssoUrl: 'http://website.com'
+				ssoUrl: 'http://website.com',
+				siteUrl: 'http://website.com'
 			} );
 
 			const state = jetpackSSO( undefined, action );


### PR DESCRIPTION
This is an alternative solution to #6973.

In #6967, @roccotripaldi reported an issue where we were not auto-authorizing after a user approved the SSO process for sites in a sub-directory. This is because the logic we used for getting the site's URL did not take into account sites in a sub-directory. 😞 

This PR fixes that by using the site URL passed back when validating an SSO nonce.

To test:

- Checkout `update/sso-subdirectory-install` branch
- Go to `$site/wp-admin` where `$site` is a Jetpack site that has SSO configured
- Click "Log in with WordPress.com" button
- Approve SSO process
- On the next page, the connection process should happen automatically

cc @roccotripaldi @lezama 


Test live: https://calypso.live/?branch=update/sso-subdirectory-install