### PR TITLE
Jetpack Connect: Add MainWrapper component to fix ESLint warnings

### DIFF
--- a/client/signup/jetpack-connect/main-wrapper.jsx
+++ b/client/signup/jetpack-connect/main-wrapper.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+
+export default React.createClass( {
+	displayName: 'JetpackConnectMainWrapper',
+
+	render() {
+		return (
+			<Main className={ classNames( this.props.className, 'jetpack-connect__main' ) }>
+				{ this.props.children }
+			</Main>
+		);
+	}
+} );

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -33,6 +33,7 @@ import Gridicon from 'components/gridicon';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import Dialog from 'components/dialog';
 import analytics from 'lib/analytics';
+import MainWrapper from './main-wrapper';
 
 /*
  * Module variables
@@ -388,7 +389,7 @@ const JetpackSSOForm = React.createClass( {
 		}
 
 		return (
-			<Main className="jetpack-connect">
+			<MainWrapper>
 				<div className="jetpack-connect__sso">
 					<ConnectHeader
 						showLogo={ false }
@@ -446,7 +447,7 @@ const JetpackSSOForm = React.createClass( {
 				</div>
 
 				{ this.renderSharedDetailsDialog() }
-			</Main>
+			</MainWrapper>
 		);
 	}
 } );

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -1,4 +1,6 @@
-.jetpack-connect {
+// @TODO: Remove .jetpack-connect once we cleared out all instances
+.jetpack-connect,
+.jetpack-connect__main {
 	max-width: 400px;
 
 	.logged-out-form__links {
@@ -12,7 +14,6 @@
 		}
 
 	}
-
 }
 
 .jetpack-connect-wide {


### PR DESCRIPTION
This PR adds a `MainWrapper` component to Jetpack Connect in an effort to clear out ESLint warnings. This PR applies that component to the SSO component. Note: There are other ESLint warnings in the SSO component, but those are handled in #6986.

To test:

- Checkout `update/jetpack-connect-main-wrapper` 
- Go to `$site/wp-admin`
- Click "Log in with WordPress.com" button
- Ensure the 'jetpack-connect__main` class is applied and styles are applied

cc @roccotripaldi and @johnHackworth

In the near future, we can extend this component with an `isWide` prop to handle cases where `jetpack-connect-wide` is used.

Test live: https://calypso.live/?branch=update/jetpack-connect-main-wrapper