### PR TITLE
Jetpack Connect: Short-circuit connection flow for SSO

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -201,12 +201,12 @@ const LoggedInForm = React.createClass( {
 			authorizeSuccess
 		} = props.jetpackConnectAuthorize;
 
-		// Always and forever redirect SSO to wp-admin.
-		if ( ! isRedirectingToWpAdmin && props.isSSO && authorizeSuccess ) {
-			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
-		}
-
-		if ( siteReceived && ! isActivating ) {
+		// SSO specific logic here.
+		if ( props.isSSO ) {
+			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
+				this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
+			}
+		} else if ( siteReceived && ! isActivating ) {
 			this.activateManage();
 		}
 	},


### PR DESCRIPTION
Intermittently, users are sometimes being forwarded to the plans page after logging in via SSO. A user should always be forward back to wp-admin when logging in via SSO.

I was not able to reproduce this myself. But, after looking at the code, it seems like this is mostly likely happening because of a timing issue that results in manage being activated. But, for SSO, all we're interested in is the user being authorized.

To fix this, I restructured the logic in `componentWillReceiveProps` such that non-SSO logic should not be run.

To test:

- Checkout `fix/sso-sometimes-redirect-to-plans` branch
- Go to `$site/wp-admin`
- Click "Log in with WordPress.com" button
- Ensure you are logged in to WordPress.com, and with a user that is not connected to WP.com
- Swap out `wordpress.com` with `calypso.localhost:3000` 
- Approve SSO process
- Verify that user is auto authorized and that you are redirected to wp-admin

cc @roccotripaldi @simonwheatley 

Test live: https://calypso.live/?branch=fix/sso-sometimes-redirect-to-plans