### PR TITLE
My Sites: Make preview link tooltip more direct by changing it to "Preview your site"

### DIFF
--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -242,7 +242,7 @@ export default React.createClass( {
 							data-tip-target={ this.props.tipTarget }
 							target={ this.props.externalLink && ! this.state.showMoreActions && '_blank' }
 							title={ this.props.homeLink
-								? this.translate( 'View "%(title)s"', { args: { title: site.title } } )
+								? this.translate( 'Preview your site' )
 								: site.title
 							}
 							onTouchTap={ this.onSelect }


### PR DESCRIPTION
Addresses #6433 

Before:
<img width="277" alt="screen shot 2016-07-25 at 12 38 28 am" src="https://cloud.githubusercontent.com/assets/8526652/17093787/268d3654-5200-11e6-923f-6eb73f95159e.png">

After:
<img width="284" alt="screen shot 2016-07-25 at 12 14 06 am" src="https://cloud.githubusercontent.com/assets/8526652/17093731/d293f182-51ff-11e6-8fbf-937284402793.png">

cc @ianstewart from #6433 
cc @lsinger from last commit

Test live: https://calypso.live/?branch=update/site-preview-link