### PR TITLE
Layout: Add key (using section name)

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -172,7 +172,7 @@ function boot() {
 }
 
 function renderLayout( reduxStore ) {
-	let props = { focus: layoutFocus };
+	const props = { focus: layoutFocus };
 
 	if ( user.get() ) {
 		Object.assign( props, { user, sites, nuxWelcome, translatorInvitation } );
@@ -189,8 +189,8 @@ function renderLayout( reduxStore ) {
 }
 
 function reduxStoreReady( reduxStore ) {
-	let layoutSection, validSections = [],
-		isIsomorphic = isSectionIsomorphic( reduxStore.getState() );
+	const isIsomorphic = isSectionIsomorphic( reduxStore.getState() );
+	let layoutSection, validSections = [];
 
 	bindWpLocaleState( reduxStore );
 
@@ -205,7 +205,6 @@ function reduxStoreReady( reduxStore ) {
 		reduxStore.dispatch( receiveUser( user.get() ) );
 		reduxStore.dispatch( setCurrentUserId( user.get().ID ) );
 		reduxStore.dispatch( setCurrentUserFlags( user.get().meta.data.flags.active_flags ) );
-
 
 		const participantInPushNotificationsAbTest = config.isEnabled('push-notifications-ab-test') && abtest('browserNotifications') === 'enabled';
 		if ( config.isEnabled( 'push-notifications' ) || participantInPushNotificationsAbTest ) {

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -14,8 +14,7 @@ var React = require( 'react' ),
 	url = require( 'url' ),
 	qs = require( 'querystring' ),
 	injectTapEventPlugin = require( 'react-tap-event-plugin' ),
-	i18n = require( 'i18n-calypso' ),
-	isEmpty = require( 'lodash/isEmpty' );
+	i18n = require( 'i18n-calypso' );
 
 /**
  * Internal dependencies
@@ -378,25 +377,6 @@ function reduxStoreReady( reduxStore ) {
 	if ( config.isEnabled( 'dev/test-helper' ) && document.querySelector( '.environment.is-tests' ) ) {
 		require( 'lib/abtest/test-helper' )( document.querySelector( '.environment.is-tests' ) );
 	}
-
-	/*
-	 * Layouts with differing React mount-points will not reconcile correctly,
-	 * so remove an existing single-tree layout by re-rendering if necessary.
-	 *
-	 * TODO (@seear): React 15's new reconciliation algo may make this unnecessary
-	 */
-	page( '*', function( context, next ) {
-		const sectionNotIsomorphic = ! isSectionIsomorphic( context.store.getState() );
-		const previousLayoutIsSingleTree = ! isEmpty(
-			document.getElementsByClassName( 'wp-singletree-layout' )
-		);
-
-		if ( sectionNotIsomorphic && previousLayoutIsSingleTree ) {
-			debug( 'Re-rendering multi-tree layout' );
-			renderLayout( context.store );
-		}
-		next();
-	} );
 
 	detectHistoryNavigation.start();
 	page.start();

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -23,6 +23,7 @@ class ThemeMoreButton extends React.Component {
 		this.state = { showPopover: false };
 		this.togglePopover = this.togglePopover.bind( this );
 		this.closePopover = this.closePopover.bind( this );
+		this.onClick = this.onClick.bind( this );
 	}
 
 	togglePopover() {
@@ -37,6 +38,10 @@ class ThemeMoreButton extends React.Component {
 
 	focus( event ) {
 		event.target.focus();
+	}
+
+	onClick( action ) {
+		return this.closePopover.bind( this, action );
 	}
 
 	render() {
@@ -66,7 +71,7 @@ class ThemeMoreButton extends React.Component {
 							return (
 								<a className="theme__more-button-menu-item popover__menu-item"
 									onMouseOver={ this.focus }
-									onClick={ option.action }
+									onClick={ this.onClick( option.action ) }
 									key={ option.label }
 									href={ url }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -177,7 +177,7 @@ Layout = React.createClass( {
 			} );
 
 		return (
-			<div className={ sectionClass }>
+			<div className={ sectionClass } key={ this.props.section.name }>
 				{ config.isEnabled( 'guided-tours' ) ? <GuidedTours /> : null }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				{ this.renderMasterbar() }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -27,7 +27,7 @@ const LayoutLoggedOut = ( {
 	} );
 
 	return (
-		<div className={ classes }>
+		<div className={ classes } key={ section.name }>
 			<MasterbarLoggedOut title={ section.title } />
 			<div id="content" className="layout__content">
 				<div id="primary" className="layout__primary">

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -23,7 +23,6 @@ const LayoutLoggedOut = ( {
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
 		'has-no-sidebar': true, // Logged-out never has a sidebar
-		'wp-singletree-layout': !! primary,
 	} );
 
 	return (


### PR DESCRIPTION
This fixes the transition from the logged-out Theme Showcase to signup, aka #6990.

To test:
* Verify that #6990 is fixed.
* Try landing in different sections of Calypso, and navigate in between sections and groups (such as 'My Sites' to 'Reader', see https://github.com/Automattic/wp-calypso/pull/5081#issuecomment-215688028)
* In the logged-in theme showcase, use the site picker to 'Add a New Wordpress', and navigate back. Verify that there is no visual funkiness.

Test live: https://calypso.live/?branch=fix/themes-signup-transition