### PR TITLE
Updated refund information copy to reflect more clearly what actually…

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -25,7 +25,6 @@ import Main from 'components/main';
 import paths from '../paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import ProductLink from 'me/purchases/product-link';
-import support from 'lib/url/support';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
 
@@ -153,17 +152,7 @@ const CancelPurchase = React.createClass( {
 						{ heading }
 					</h2>
 
-					<div className="cancel-purchase__info">
-						<CancelPurchaseRefundInformation purchase={ purchase } />
-
-						<strong className="cancel-purchase__support-information">
-							{ this.translate( 'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}', {
-								components: {
-									contactLink: <a href={ support.CALYPSO_CONTACT } />
-								}
-							} ) }
-						</strong>
-					</div>
+					<CancelPurchaseRefundInformation purchase={ purchase } />
 				</Card>
 
 				<CompactCard className="cancel-purchase__product-information">

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -11,6 +11,7 @@ import i18n from 'i18n-calypso';
 import { getName, isRefundable, isSubscription, isOneTimePurchase } from 'lib/purchases';
 import { isDomainRegistration, isDomainMapping } from 'lib/products-values';
 import { getIncludedDomainPurchase } from 'state/purchases/selectors';
+import support from 'lib/url/support';
 
 const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } ) => {
 	const { refundPeriodInDays } = purchase;
@@ -34,13 +35,16 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 					'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ' +
 					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan minus ' +
 					'%(mappingCost)s for the domain mapping. To cancel the domain mapping with the ' +
-					'plan and ask for a full refund, please contact support.',
+					'plan and ask for a full refund, please {{contactLink}}contact support{{/contactLink}}.',
 					{
 						args: {
 							mappedDomain: includedDomainPurchase.meta,
 							mappingCost: includedDomainPurchase.priceText,
 							planCost: purchase.priceText,
 							refundAmount: purchase.refundText
+						},
+						components: {
+							contactLink: <a href={ support.CALYPSO_CONTACT } />
 						}
 					}
 				);
@@ -50,13 +54,16 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 					'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ' +
 					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
 					'minus %(domainCost)s for the domain.  To cancel the domain with the plan and ask for a full ' +
-					'refund, please contact support.',
+					'refund, please {{contactLink}}contact support{{/contactLink}}.',
 					{
 						args: {
 							domain: includedDomainPurchase.meta,
 							domainCost: includedDomainPurchase.priceText,
 							planCost: purchase.priceText,
 							refundAmount: purchase.refundText
+						},
+						components: {
+							contactLink: <a href={ support.CALYPSO_CONTACT } />
 						}
 					}
 				);

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -74,7 +74,7 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 					),
 					i18n.translate(
 						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-						'minus %(domainCost)s for the domain.  To cancel the domain with the plan and ask for a full ' +
+						'minus %(domainCost)s for the domain. To cancel the domain with the plan and ask for a full ' +
 						'refund, please {{contactLink}}contact support{{/contactLink}}.',
 						{
 							args: {
@@ -160,15 +160,14 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 				: <p className="cancel-purchase__refund-information">{ text }</p>
 			}
 
-			{ showSupportLink
-				? <strong className="cancel-purchase__support-information">
-					{ i18n.translate( 'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}', {
-						components: {
-							contactLink: <a href={ support.CALYPSO_CONTACT }/>
-						}
-					} ) }
-				</strong>
-				: null
+			{ showSupportLink && (
+				<strong className="cancel-purchase__support-information">
+				{ i18n.translate( 'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}', {
+					components: {
+						contactLink: <a href={ support.CALYPSO_CONTACT }/>
+					}
+				} ) }
+				</strong> )
 			}
 		</div>
 	);

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { connect } from 'react-redux';
 import React from 'react';
 import i18n from 'i18n-calypso';
 
@@ -8,11 +9,11 @@ import i18n from 'i18n-calypso';
  * Internal Dependencies
  */
 import { getName, isRefundable, isSubscription, isOneTimePurchase } from 'lib/purchases';
-import { isDomainRegistration } from 'lib/products-values';
+import { isDomainRegistration, isDomainMapping } from 'lib/products-values';
+import { getIncludedDomainPurchase } from 'state/purchases/selectors';
 
-const CancelPurchaseRefundInformation = ( { purchase } ) => {
+const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } ) => {
 	const { refundPeriodInDays } = purchase;
-
 	let text;
 
 	if ( isRefundable( purchase ) ) {
@@ -27,13 +28,47 @@ const CancelPurchaseRefundInformation = ( { purchase } ) => {
 		}
 
 		if ( isSubscription( purchase ) ) {
-			text = i18n.translate(
-				'When you cancel your subscription within %(refundPeriodInDays)d days of purchasing, ' +
-				"you'll receive a refund and it will be removed from your site immediately.",
-				{
-					args: { refundPeriodInDays }
-				}
-			);
+			if ( includedDomainPurchase && isDomainMapping( includedDomainPurchase ) ) {
+				text = i18n.translate(
+					'This plan includes the custom domain mapping for %(mappedDomain)s, normally a %(mappingCost)s purchase. ' +
+					'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ' +
+					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan minus ' +
+					'%(mappingCost)s for the domain mapping. To cancel the domain mapping with the ' +
+					'plan and ask for a full refund, please contact support.',
+					{
+						args: {
+							mappedDomain: includedDomainPurchase.meta,
+							mappingCost: includedDomainPurchase.priceText,
+							planCost: purchase.priceText,
+							refundAmount: purchase.refundText
+						}
+					}
+				);
+			} else if ( includedDomainPurchase && isDomainRegistration( includedDomainPurchase ) ) {
+				text = i18n.translate(
+					'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
+					'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ' +
+					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
+					'minus %(domainCost)s for the domain.  To cancel the domain with the plan and ask for a full ' +
+					'refund, please contact support.',
+					{
+						args: {
+							domain: includedDomainPurchase.meta,
+							domainCost: includedDomainPurchase.priceText,
+							planCost: purchase.priceText,
+							refundAmount: purchase.refundText
+						}
+					}
+				);
+			} else {
+				text = i18n.translate(
+					'When you cancel your subscription within %(refundPeriodInDays)d days of purchasing, ' +
+					"you'll receive a refund and it will be removed from your site immediately.",
+					{
+						args: { refundPeriodInDays }
+					}
+				);
+			}
 		}
 
 		if ( isOneTimePurchase( purchase ) ) {
@@ -68,7 +103,12 @@ const CancelPurchaseRefundInformation = ( { purchase } ) => {
 };
 
 CancelPurchaseRefundInformation.propTypes = {
-	purchase: React.PropTypes.object.isRequired
+	purchase: React.PropTypes.object.isRequired,
+	includedDomainPurchase: React.PropTypes.object
 };
 
-export default CancelPurchaseRefundInformation;
+export default connect(
+	( state, props ) => ( {
+		includedDomainPurchase: getIncludedDomainPurchase( state, props.purchase )
+	} )
+)( CancelPurchaseRefundInformation );

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -16,6 +16,7 @@ import support from 'lib/url/support';
 const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } ) => {
 	const { refundPeriodInDays } = purchase;
 	let text;
+	let showSupportLink = true;
 
 	if ( isRefundable( purchase ) ) {
 		if ( isDomainRegistration( purchase ) ) {
@@ -30,43 +31,65 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 
 		if ( isSubscription( purchase ) ) {
 			if ( includedDomainPurchase && isDomainMapping( includedDomainPurchase ) ) {
-				text = i18n.translate(
-					'This plan includes the custom domain mapping for %(mappedDomain)s, normally a %(mappingCost)s purchase. ' +
-					'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ' +
-					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan minus ' +
-					'%(mappingCost)s for the domain mapping. To cancel the domain mapping with the ' +
-					'plan and ask for a full refund, please {{contactLink}}contact support{{/contactLink}}.',
-					{
-						args: {
-							mappedDomain: includedDomainPurchase.meta,
-							mappingCost: includedDomainPurchase.priceText,
-							planCost: purchase.priceText,
-							refundAmount: purchase.refundText
-						},
-						components: {
-							contactLink: <a href={ support.CALYPSO_CONTACT } />
+				text = [
+					i18n.translate(
+						'This plan includes the custom domain mapping for %(mappedDomain)s, normally a %(mappingCost)s purchase. ' +
+						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
+						{
+							args: {
+								mappedDomain: includedDomainPurchase.meta,
+								mappingCost: includedDomainPurchase.priceText
+							}
 						}
-					}
-				);
+					),
+					i18n.translate(
+						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan minus ' +
+						'%(mappingCost)s for the domain mapping. To cancel the domain mapping with the ' +
+						'plan and ask for a full refund, please {{contactLink}}contact support{{/contactLink}}.',
+						{
+							args: {
+								planCost: purchase.priceText,
+								mappingCost: includedDomainPurchase.priceText,
+								refundAmount: purchase.refundText
+							},
+							components: {
+								contactLink: <a href={ support.CALYPSO_CONTACT } />
+							}
+						}
+					)
+				];
+
+				showSupportLink = false;
 			} else if ( includedDomainPurchase && isDomainRegistration( includedDomainPurchase ) ) {
-				text = i18n.translate(
-					'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
-					'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ' +
-					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-					'minus %(domainCost)s for the domain.  To cancel the domain with the plan and ask for a full ' +
-					'refund, please {{contactLink}}contact support{{/contactLink}}.',
-					{
-						args: {
-							domain: includedDomainPurchase.meta,
-							domainCost: includedDomainPurchase.priceText,
-							planCost: purchase.priceText,
-							refundAmount: purchase.refundText
-						},
-						components: {
-							contactLink: <a href={ support.CALYPSO_CONTACT } />
+				text = [
+					i18n.translate(
+						'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
+						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
+						{
+							args: {
+								domain: includedDomainPurchase.meta,
+								domainCost: includedDomainPurchase.priceText,
+							}
 						}
-					}
-				);
+					),
+					i18n.translate(
+						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
+						'minus %(domainCost)s for the domain.  To cancel the domain with the plan and ask for a full ' +
+						'refund, please {{contactLink}}contact support{{/contactLink}}.',
+						{
+							args: {
+								domainCost: includedDomainPurchase.priceText,
+								planCost: purchase.priceText,
+								refundAmount: purchase.refundText
+							},
+							components: {
+								contactLink: <a href={ support.CALYPSO_CONTACT } />
+							}
+						}
+					)
+				];
+
+				showSupportLink = false;
 			} else {
 				text = i18n.translate(
 					'When you cancel your subscription within %(refundPeriodInDays)d days of purchasing, ' +
@@ -105,7 +128,27 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 	}
 
 	return (
-		<p className="cancel-purchase__refund-information">{ text }</p>
+		<div className="cancel-purchase__info">
+			{ Array.isArray( text )
+				? text.map( ( paragraph, index ) =>
+					<p key={ purchase.id + '_refund_p_' + index } className="cancel-purchase__refund-information">
+						{ paragraph }
+					</p>
+					)
+				: <p className="cancel-purchase__refund-information">{ text }</p>
+			}
+
+			{ showSupportLink
+				? <strong className="cancel-purchase__support-information">
+					{ i18n.translate( 'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}', {
+						components: {
+							contactLink: <a href={ support.CALYPSO_CONTACT }/>
+						}
+					} ) }
+				</strong>
+				: null
+			}
+		</div>
 	);
 };
 

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -115,6 +115,28 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 			'When you cancel your domain, it will remain registered and active until the registration expires, ' +
 			'at which point it will be automatically removed from your site.'
 		);
+	} else if ( isSubscription( purchase ) && includedDomainPurchase && isDomainMapping( includedDomainPurchase ) ) {
+		text = i18n.translate(
+			'This plan includes the custom domain mapping for %(mappedDomain)s. ' +
+			'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
+			{
+				args: {
+					mappedDomain: includedDomainPurchase.meta,
+					mappingCost: includedDomainPurchase.priceText
+				}
+			}
+		);
+	} else if ( isSubscription( purchase ) && includedDomainPurchase && isDomainRegistration( includedDomainPurchase ) ) {
+		text = i18n.translate(
+			'This plan includes the custom domain, %(domain)s. ' +
+			'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
+			{
+				args: {
+					domain: includedDomainPurchase.meta,
+					domainCost: includedDomainPurchase.priceText,
+				}
+			}
+		);
 	} else {
 		text = i18n.translate(
 			"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -52,14 +52,22 @@ export const getSitePurchases = ( state, siteId ) => (
 	getPurchases( state ).filter( purchase => purchase.siteId === siteId )
 );
 
-export const getIncludedDomainPurchase = ( state, purchase ) => {
-	if ( ! purchase || ! isSubscription( purchase ) ) {
+/***
+ * Returns a purchase object that corresponds to that subscription's included domain
+ * @param  {Object} state					global state
+ * @param  {Object} subscriptionPurchase	subscription purchase object
+ * @return {Object} domain purchase if there is one, null if none found or not a subscription object passed
+ */
+export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
+	if ( ! subscriptionPurchase || ! isSubscription( subscriptionPurchase ) ) {
 		return null;
 	}
 
-	const { includedDomain } = purchase;
-	const sitePurchases = getSitePurchases( state, purchase.siteId );
-	const domainPurchase = sitePurchases.find( p => ( isDomainMapping( p ) || isDomainRegistration( p ) ) && includedDomain === p.meta );
+	const { includedDomain } = subscriptionPurchase;
+	const sitePurchases = getSitePurchases( state, subscriptionPurchase.siteId );
+	const domainPurchase = sitePurchases.find( purchase => ( isDomainMapping( purchase ) ||
+															isDomainRegistration( purchase ) ) &&
+															includedDomain === purchase.meta );
 
 	return domainPurchase;
 };

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -1,5 +1,7 @@
 import createSelector from 'lib/create-selector';
 import purchasesAssembler from 'lib/purchases/assembler';
+import { isSubscription } from 'lib/purchases';
+import { isDomainRegistration, isDomainMapping } from 'lib/products-values';
 
 /**
  * Return the list of purchases from state object
@@ -49,6 +51,18 @@ export const getByPurchaseId = ( state, purchaseId ) => (
 export const getSitePurchases = ( state, siteId ) => (
 	getPurchases( state ).filter( purchase => purchase.siteId === siteId )
 );
+
+export const getIncludedDomainPurchase = ( state, purchase ) => {
+	if ( ! purchase || ! isSubscription( purchase ) ) {
+		return null;
+	}
+
+	const { includedDomain } = purchase;
+	const sitePurchases = getSitePurchases( state, purchase.siteId );
+	const domainPurchase = sitePurchases.find( p => ( isDomainMapping( p ) || isDomainRegistration( p ) ) && includedDomain === p.meta );
+
+	return domainPurchase;
+};
 
 export const isFetchingUserPurchases = state => state.purchases.isFetchingUserPurchases;
 export const isFetchingSitePurchases = state => state.purchases.isFetchingSitePurchases;

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 
 // Internal dependencies
-import { getPurchases, getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases } from '../selectors';
+import { getPurchases, getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases, getIncludedDomainPurchase, getSitePurchases } from '../selectors';
 import purchasesAssembler from 'lib/purchases/assembler';
 
 describe( 'selectors', () => {
@@ -130,6 +130,79 @@ describe( 'selectors', () => {
 			};
 
 			expect( isFetchingSitePurchases( state ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'getSitePurchases', () => {
+		it( 'should return purchases of specific site', () => {
+			const state = {
+				purchases: {
+					data: [
+						{
+							ID: '81414',
+							blog_id: '1234'
+						},
+						{
+							ID: '82867',
+							blog_id: '1234'
+						},
+						{
+							ID: '105103',
+							blog_id: '123'
+						}
+					],
+					error: null,
+					isFetchingSitePurchases: true,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false
+				}
+			};
+
+			const result = getSitePurchases( state, 1234 );
+
+			expect( result.length ).to.equal( 2 );
+			expect( result[ 0 ].siteId ).to.equal( 1234 );
+			expect( result[ 1 ].siteId ).to.equal( 1234 );
+		} );
+	} );
+
+	describe( 'getIncludedDomainPurchase', () => {
+		it( 'should return included domain with subscription', () => {
+			const state = {
+				purchases: {
+					data: [
+						{
+							ID: '81414',
+							meta: 'dev.live',
+							blog_id: '123',
+							is_domain_registration: 'true',
+							product_slug: 'dotlive_domain'
+						},
+						{
+							ID: '82867',
+							blog_id: '123',
+							product_slug: 'value_bundle',
+							included_domain: 'dev.live'
+						},
+						{
+							ID: '105103',
+							blog_id: '123',
+							meta: 'wordpress.com',
+							product_slug: 'domain_map'
+						}
+					],
+					error: null,
+					isFetchingSitePurchases: true,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false
+				}
+			};
+
+			const subscriptionPurchase = getPurchases( state ).find( purchase => purchase.productSlug === 'value_bundle' );
+
+			expect( getIncludedDomainPurchase( state, subscriptionPurchase ).meta ).to.equal( 'dev.live' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request fixes #6770, updating the cancelation copy.
 
Cancel plan with domain mapping:
![screen shot 2016-07-26 at 11 20 07 am](https://cloud.githubusercontent.com/assets/326402/17131290/81a484b8-5325-11e6-9a59-701addcc5478.png)


Cancel plan with domain registration:
![screen shot 2016-07-26 at 11 19 58 am](https://cloud.githubusercontent.com/assets/326402/17131273/777c1028-5325-11e6-9bc2-7faee72c43b8.png)

Cancel plan without either:
![screen shot 2016-07-26 at 11 19 46 am](https://cloud.githubusercontent.com/assets/326402/17131268/700c8a48-5325-11e6-81b0-be8a15c855f2.png)

Cancel a plan after the refund period:
![screen shot 2016-07-26 at 12 03 55 pm](https://cloud.githubusercontent.com/assets/326402/17132240/88fee79a-5329-11e6-820d-0be30dee0446.png)


#### Testing instructions
  
1. Run `git checkout update/cancel-plan-copy` and start your server, or open a [live branch](https://calypso.live/?branch=update/cancel-plan-copy)
2. Purchase a plan with domain mapping / domain registration
3. After purchasing a plan with a domain, you should open `/purchases`
4. Select the purchase and then choose the option to have it cancelled.
5. Check that the cancelation copy is as in the screenshots.
  
  
#### Reviews
  
- [x] Code
- [ ] Product
- [ ] Tests
   
@Automattic/sdev-feed
