### PR TITLE
Community Translator: version bump

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -20,7 +20,7 @@ var config = require( 'config' ),
  * Local variables
  */
 var communityTranslatorBaseUrl = 'https://widgets.wp.com/community-translator/',
-	communityTranslatorVersion = '1.160723',
+	communityTranslatorVersion = '1.160728',
 	translationDataFromPage = {
 		localeCode: 'en',
 		languageName: 'English',


### PR DESCRIPTION
New [upstream version of the community translator](https://github.com/Automattic/community-translator/commit/4f086e228d8049291dc3d0c109b3418d208d6868) needs a version bump in Calypso.

Test live: https://calypso.live/?branch=fix/bump-ct-version-0728