### PR TITLE
CPT: Enable CPT feature in staging / Horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,6 +27,7 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -30,6 +30,7 @@
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
+		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/export": true,


### PR DESCRIPTION
This pull request seeks to enable custom post types in the staging and Horizon environments in preparation for this feature's imminent release.

__Testing instructions:__

Ensure that the feature flag included in these configuration matches those applied to `development.json` or `wpcalypso.json`.

Testing stage or horizon feature flags is difficult and may require running production/stage Calypso locally (PCYsg-5YE-p2).

Test live: https://calypso.live/?branch=update/cpt-stage