### PR TITLE
CPT: Do not display post author for single user sites

### DIFF
--- a/client/my-sites/post-type-list/post-type-post-author/index.jsx
+++ b/client/my-sites/post-type-list/post-type-post-author/index.jsx
@@ -10,10 +10,11 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { getPost } from 'state/posts/selectors';
+import { isSingleUserSite } from 'state/sites/selectors';
 import Gridicon from 'components/gridicon';
 
-function PostTypePostAuthor( { translate, name } ) {
-	if ( ! name ) {
+function PostTypePostAuthor( { translate, singleUserSite, name } ) {
+	if ( ! name || singleUserSite ) {
 		return null;
 	}
 
@@ -31,11 +32,20 @@ function PostTypePostAuthor( { translate, name } ) {
 PostTypePostAuthor.propTypes = {
 	translate: PropTypes.func,
 	globalId: PropTypes.string,
+	singleUserSite: PropTypes.bool,
 	name: PropTypes.string
 };
 
 export default connect( ( state, ownProps ) => {
+	const post = getPost( state, ownProps.globalId );
+
+	let singleUserSite;
+	if ( post ) {
+		singleUserSite = isSingleUserSite( state, post.site_ID );
+	}
+
 	return {
-		name: get( getPost( state, ownProps.globalId ), [ 'author', 'name' ] )
+		singleUserSite,
+		name: get( post, [ 'author', 'name' ] )
 	};
 } )( localize( PostTypePostAuthor ) );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -71,6 +71,18 @@ export function isSiteConflicting( state, siteId ) {
 }
 
 /**
+ * Returns true if site has only a single user, false if the site not a single
+ * user site, or null if the site is unknown.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is a single user site
+ */
+export function isSingleUserSite( state, siteId ) {
+	return get( getSite( state, siteId ), 'single_user_site', null );
+}
+
+/**
  * Returns true if site is a Jetpack site, false if the site is hosted on
  * WordPress.com, or null if the site is unknown.
  *

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -10,6 +10,7 @@ import {
 	getSite,
 	getSiteCollisions,
 	isSiteConflicting,
+	isSingleUserSite,
 	isJetpackSite,
 	isJetpackModuleActive,
 	isJetpackMinimumVersion,
@@ -120,6 +121,42 @@ describe( 'selectors', () => {
 			}, 77203199 );
 
 			expect( isConflicting ).to.be.true;
+		} );
+	} );
+
+	describe( '#isSingleUserSite()', () => {
+		it( 'should return null if the site is not known', () => {
+			const singleUserSite = isSingleUserSite( {
+				sites: {
+					items: {}
+				}
+			}, 77203074 );
+
+			expect( singleUserSite ).to.be.null;
+		} );
+
+		it( 'it should return true if the site is a single user site', () => {
+			const singleUserSite = isSingleUserSite( {
+				sites: {
+					items: {
+						77203074: { ID: 77203074, URL: 'https://example.wordpress.com', single_user_site: true }
+					}
+				}
+			}, 77203074 );
+
+			expect( singleUserSite ).to.be.true;
+		} );
+
+		it( 'it should return false if the site is not a single user site', () => {
+			const singleUserSite = isSingleUserSite( {
+				sites: {
+					items: {
+						77203074: { ID: 77203074, URL: 'https://example.wordpress.com', single_user_site: false }
+					}
+				}
+			}, 77203074 );
+
+			expect( singleUserSite ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
This pull request seeks to omit the author details from the [custom post types list screen](https://wpcalypso.wordpress.com/types/post) for sites managed by only a single user.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/17102501/df512aa0-5247-11e6-92ba-0989cc6ea005.png)|![After](https://cloud.githubusercontent.com/assets/1779930/17102503/e2bb14e4-5247-11e6-8f94-9622fbcdb461.png)

__Testing instructions:__

Ensure Mocha tests pass:

```
npm run test-client client/state/sites/test/selectors.js
```

Verify that the author details continue to display for multi-user sites, and that it is not present on single user sites.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site, if prompted
3. Note that...
 - If your site is a single user site, author details are not shown for posts
 - If your site is a multi-user site, author details are shown for posts

/cc @mtias 

Test live: https://calypso.live/?branch=remove/cpt-single-user-author