### PR TITLE
Framework: Fix single to multi-tree render transitions

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -15,7 +15,8 @@ var React = require( 'react' ),
 	qs = require( 'querystring' ),
 	injectTapEventPlugin = require( 'react-tap-event-plugin' ),
 	i18n = require( 'i18n-calypso' ),
-	isEmpty = require( 'lodash/isEmpty' );
+	isEmpty = require( 'lodash/isEmpty' ),
+	includes = require( 'lodash/includes' );
 
 /**
  * Internal dependencies
@@ -51,6 +52,7 @@ var config = require( 'config' ),
 	supportUser = require( 'lib/user/support-user-interop' ),
 	isSectionIsomorphic = require( 'state/ui/selectors' ).isSectionIsomorphic,
 	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default,
+	getSectionName = require( 'state/ui/selectors' ).getSectionName,
 	// The following components require the i18n mixin, so must be required after i18n is initialized
 	Layout;
 
@@ -383,15 +385,13 @@ function reduxStoreReady( reduxStore ) {
 	 * Layouts with differing React mount-points will not reconcile correctly,
 	 * so remove an existing single-tree layout by re-rendering if necessary.
 	 *
-	 * TODO (@seear): React 15's new reconciliation algo may make this unnecessary
+	 * TODO (@seear): Calypso-wide single tree rendering make this unnecessary
 	 */
 	page( '*', function( context, next ) {
-		const sectionNotIsomorphic = ! isSectionIsomorphic( context.store.getState() );
-		const previousLayoutIsSingleTree = ! isEmpty(
-			document.getElementsByClassName( 'wp-singletree-layout' )
-		);
+		const singleTreeSections = [ 'theme', 'themes' ];
+		const sectionName = getSectionName( context.store.getState() );
 
-		if ( sectionNotIsomorphic && previousLayoutIsSingleTree ) {
+		if ( includes( singleTreeSections, sectionName ) ) {
 			debug( 'Re-rendering multi-tree layout' );
 			renderLayout( context.store );
 		}

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -15,7 +15,6 @@ var React = require( 'react' ),
 	qs = require( 'querystring' ),
 	injectTapEventPlugin = require( 'react-tap-event-plugin' ),
 	i18n = require( 'i18n-calypso' ),
-	isEmpty = require( 'lodash/isEmpty' ),
 	includes = require( 'lodash/includes' );
 
 /**

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -175,7 +175,7 @@ function boot() {
 }
 
 function renderLayout( reduxStore ) {
-	let props = { focus: layoutFocus };
+	const props = { focus: layoutFocus };
 
 	if ( user.get() ) {
 		Object.assign( props, { user, sites, nuxWelcome, translatorInvitation } );
@@ -192,8 +192,8 @@ function renderLayout( reduxStore ) {
 }
 
 function reduxStoreReady( reduxStore ) {
-	let layoutSection, validSections = [],
-		isIsomorphic = isSectionIsomorphic( reduxStore.getState() );
+	const isIsomorphic = isSectionIsomorphic( reduxStore.getState() );
+	let layoutSection, validSections = [];
 
 	bindWpLocaleState( reduxStore );
 
@@ -208,7 +208,6 @@ function reduxStoreReady( reduxStore ) {
 		reduxStore.dispatch( receiveUser( user.get() ) );
 		reduxStore.dispatch( setCurrentUserId( user.get().ID ) );
 		reduxStore.dispatch( setCurrentUserFlags( user.get().meta.data.flags.active_flags ) );
-
 
 		const participantInPushNotificationsAbTest = config.isEnabled('push-notifications-ab-test') && abtest('browserNotifications') === 'enabled';
 		if ( config.isEnabled( 'push-notifications' ) || participantInPushNotificationsAbTest ) {

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -23,6 +23,7 @@ class ThemeMoreButton extends React.Component {
 		this.state = { showPopover: false };
 		this.togglePopover = this.togglePopover.bind( this );
 		this.closePopover = this.closePopover.bind( this );
+		this.onClick = this.onClick.bind( this );
 	}
 
 	togglePopover() {
@@ -37,6 +38,10 @@ class ThemeMoreButton extends React.Component {
 
 	focus( event ) {
 		event.target.focus();
+	}
+
+	onClick( action ) {
+		return this.closePopover.bind( this, action );
 	}
 
 	render() {
@@ -66,7 +71,7 @@ class ThemeMoreButton extends React.Component {
 							return (
 								<a className="theme__more-button-menu-item popover__menu-item"
 									onMouseOver={ this.focus }
-									onClick={ option.action }
+									onClick={ this.onClick( option.action ) }
 									key={ option.label }
 									href={ url }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -23,7 +23,6 @@ const LayoutLoggedOut = ( {
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
 		'has-no-sidebar': true, // Logged-out never has a sidebar
-		'wp-singletree-layout': !! primary,
 	} );
 
 	return (


### PR DESCRIPTION
This fixes the transition from the logged-out Theme Showcase to signup, aka #6990. Supersedes #6991. (This one is smaller in scope and possibly affected parts of Calypso.)

To test:
* Verify that #6990 is fixed.
* In the logged-out showcase, click on a (free) theme, and in its theme sheet, click 'Pick this design'. Click back. Verify that everything renders okay.
* Try landing in different sections of Calypso, and navigate in between sections and groups (such as 'My Sites' to 'Reader', see https://github.com/Automattic/wp-calypso/pull/5081#issuecomment-215688028)
* In the logged-in theme showcase, use the site picker to 'Add a New Wordpress', and navigate back. Verify that there is no visual funkiness.
* Also:
 * Land on `/design`
 * Click on any theme's ellipsis menu, pick 'Info'
 * Verify that the ellipsis menu goes away.

Test live: https://calypso.live/?branch=update/single-to-multi-tree-transitions