### PR TITLE
Editor: Display subtitle for taxonomy accordions with value

### DIFF
--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -3,11 +3,13 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { reduce, includes } from 'lodash';
+import { reduce, size, map, get, includes } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { decodeEntities } from 'lib/formatting';
 import QueryTaxonomies from 'components/data/query-taxonomies';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -30,7 +32,7 @@ function isSkippedTaxonomy( postType, taxonomy ) {
 	return false;
 }
 
-function EditorDrawerTaxonomies( { siteId, postType, taxonomies } ) {
+function EditorDrawerTaxonomies( { translate, siteId, postType, taxonomies, terms } ) {
 	return (
 		<div className="editor-drawer__taxonomies">
 			{ siteId && postType && (
@@ -43,13 +45,28 @@ function EditorDrawerTaxonomies( { siteId, postType, taxonomies } ) {
 					return memo;
 				}
 
-				const icon = hierarchical ? 'folder' : 'tag';
+				const taxonomyTerms = get( terms, name );
+				const taxonomyTermsCount = size( taxonomyTerms );
+
+				let subtitle;
+				if ( taxonomyTermsCount > 2 ) {
+					subtitle = translate( '%d selected', '%d selected', {
+						count: taxonomyTermsCount,
+						args: [ taxonomyTermsCount ]
+					} );
+				} else {
+					// Terms can be an array of strings or objects with `name`
+					subtitle = map( taxonomyTerms, ( term ) => {
+						return decodeEntities( term.name || term );
+					} ).join( ', ' );
+				}
 
 				return memo.concat(
 					<Accordion
 						key={ name }
 						title={ label }
-						icon={ <Gridicon icon={ icon } /> }
+						subtitle={ subtitle }
+						icon={ <Gridicon icon={ hierarchical ? 'folder' : 'tag' } /> }
 					>
 					{ hierarchical
 						? <TermSelector taxonomyName={ name } />
@@ -63,18 +80,25 @@ function EditorDrawerTaxonomies( { siteId, postType, taxonomies } ) {
 }
 
 EditorDrawerTaxonomies.propTypes = {
+	translate: PropTypes.func,
 	siteId: PropTypes.number,
 	postType: PropTypes.string,
+	terms: PropTypes.oneOfType( [
+		PropTypes.object,
+		PropTypes.array
+	] ),
 	taxonomies: PropTypes.array,
 };
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const postType = getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
+	const postId = getEditorPostId( state );
+	const postType = getEditedPostValue( state, siteId, postId, 'type' );
 
 	return {
 		siteId,
 		postType,
+		terms: getEditedPostValue( state, siteId, postId, 'terms' ),
 		taxonomies: getPostTypeTaxonomies( state, siteId, postType )
 	};
-} )( EditorDrawerTaxonomies );
+} )( localize( EditorDrawerTaxonomies ) );


### PR DESCRIPTION
Closes #6848 

This pull request seeks to display a subtitle for taxonomy accordions in the post editor where one or more terms are assigned to the post. Specifically, term names will be shown inline so long as there are two or fewer terms assigned. Otherwise, "# selected" will be shown.

![types](https://cloud.githubusercontent.com/assets/1779930/17115301/babde78a-5280-11e6-98eb-dc702e74c1ea.gif)

__Testing instructions:__

Verify that taxonomy subtitles are shown for both hierarchical and non-hierarchical terms. This applies to custom post types ([portfolio is a good example with both hierarchical and non-hierarchical taxonomies](https://en.support.wordpress.com/portfolios/)).

1. (Prerequisite) Enable Portfolio custom content type from [site writing settings](http://calypso.localhost:3000/settings/writing)
2. Navigate to the [post editor for Portfolios](http://calypso.localhost:3000/edit/jetpack-portfolio)
3. Select a site, if prompted
4. Select one or more Portfolio Types and/or Portfolio Tags
5. Note that the subtitle is updated to reflect selected terms
6. Save post
7. Refresh the page
8. Note that subtitle is still correct

Test live: https://calypso.live/?branch=add/cpt-editor-taxonomy-subheading