### PR TITLE
Version bump w.js

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -28,7 +28,7 @@ window.ga = window.ga || function() {
 };
 window.ga.l = +new Date();
 
-loadScript( '//stats.wp.com/w.js?52' );
+loadScript( '//stats.wp.com/w.js?53' ); // W_JS_VER
 loadScript( '//www.google-analytics.com/analytics.js' );
 
 function buildQuerystring( group, name ) {


### PR DESCRIPTION
This keeps version the same as the stats file loaded by WordPress.com. Also added a comment to make this easier to find next time when searching for the version constant used in the WPCOM codebase.

Test live: https://calypso.live/?branch=update/stats-js-version