### PR TITLE
Purchases: Fix string 'Manage Purchase' not localized

### DIFF
--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -3,17 +3,13 @@
  */
 import i18n from 'i18n-calypso';
 
-const options = {
-	context: 'Title text'
-};
-
 export default {
-	cancelPrivateRegistration: i18n.translate( 'Cancel Private Registration', options ),
-	cancelPurchase: i18n.translate( 'Cancel Purchase', options ),
-	confirmCancelDomain: i18n.translate( 'Cancel Domain', options ),
-	editCardDetails: i18n.translate( 'Edit Card Details', Object.assign( {}, options, { comment: 'Credit card' } ) ),
-	addCardDetails: i18n.translate( 'Add Card Details', Object.assign( {}, options, { comment: 'Credit card' } ) ),
-	editPaymentMethod: i18n.translate( 'Edit Payment Method', options ),
-	managePurchase: i18n.translate( 'Manage Purchase', options ),
-	purchases: i18n.translate( 'Purchases', options )
+	cancelPrivateRegistration: i18n.translate( 'Cancel Private Registration' ),
+	cancelPurchase: i18n.translate( 'Cancel Purchase' ),
+	confirmCancelDomain: i18n.translate( 'Cancel Domain' ),
+	editCardDetails: i18n.translate( 'Edit Card Details', { comment: 'Credit card' } ),
+	addCardDetails: i18n.translate( 'Add Card Details', { comment: 'Credit card' } ),
+	editPaymentMethod: i18n.translate( 'Edit Payment Method' ),
+	managePurchase: i18n.translate( 'Manage Purchase' ),
+	purchases: i18n.translate( 'Purchases' )
 };


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/7016#issuecomment-235216304

> Defining a [context in this way](https://github.com/Automattic/wp-calypso/blob/8a20ad81021ebb87bef3b3b4aac341b209c6caca/client/me/purchases/titles.js#L6)  doesn't work.
> 
> When we extract strings for translation, we are looking just at the **raw js text file**, we don't run JavaScript (it would be far to complex). So for that reason the string gets added to GlotPress [without a context (no grey box with white text next to the original)](https://translate.wordpress.com/projects/wpcom/es/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=202166&filters%5Btranslation_id%5D=5703499) but when we ask for displaying the string, a context is provided `Title text`, hence no translation with that context can be found.

Fixes #7016

pt-br:
![screen shot 2016-07-26 at 12 13 57](https://cloud.githubusercontent.com/assets/203408/17134398/7739aad0-532a-11e6-9a4a-674794cc7b34.png)


Test live: https://calypso.live/?branch=fix/manage-purchases-translation