### PR TITLE
CPT: Display sidebar for small-screen display

### DIFF
--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -11,6 +11,7 @@ import get from 'lodash/get';
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PostTypeFilter from 'my-sites/post-type-filter';
 import PostTypeList from 'my-sites/post-type-list';
 import PostTypeUnsupported from './post-type-unsupported';
@@ -26,6 +27,7 @@ function Types( { siteId, query, postType, postTypeSupported, userCanEdit } ) {
 			<PageViewTracker
 				path={ siteId ? '/types/:site' : '/types' }
 				title="Custom Post Type" />
+			<SidebarNavigation />
 			{ false !== userCanEdit && false !== postTypeSupported && [
 				<PostTypeFilter
 					key="filter"


### PR DESCRIPTION
Fixes #7025

This pull request seeks to include the missing Sidebar / site details component on the custom post types list screen for small-screen displays.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/17139723/a14a77da-5313-11e6-9edc-e3066676bb2f.png)|![After](https://cloud.githubusercontent.com/assets/1779930/17139731/a7e9700a-5313-11e6-9bb1-0dc0df3c4ee6.png)

__Testing instructions:__

Verify that the sidebar / site details is shown for small screens.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site
3. Note that...
 - If larger display, there are no visual changes from master
 - If small display, a sidebar / site details component is shown above the posts list

Test live: https://calypso.live/?branch=fix/7025-cpt-missing-mobile-site