### PR TITLE
Revert "Framework: Fix single- to multi-tree layout transitions"

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -23,7 +23,6 @@ class ThemeMoreButton extends React.Component {
 		this.state = { showPopover: false };
 		this.togglePopover = this.togglePopover.bind( this );
 		this.closePopover = this.closePopover.bind( this );
-		this.onClick = this.onClick.bind( this );
 	}
 
 	togglePopover() {
@@ -38,10 +37,6 @@ class ThemeMoreButton extends React.Component {
 
 	focus( event ) {
 		event.target.focus();
-	}
-
-	onClick( action ) {
-		return this.closePopover.bind( this, action );
 	}
 
 	render() {
@@ -71,7 +66,7 @@ class ThemeMoreButton extends React.Component {
 							return (
 								<a className="theme__more-button-menu-item popover__menu-item"
 									onMouseOver={ this.focus }
-									onClick={ this.onClick( option.action ) }
+									onClick={ option.action }
 									key={ option.label }
 									href={ url }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#7021

Test live: https://calypso.live/?branch=revert-7021-fix/6990