### PR TITLE
CPT: Improve CPT writing toggles for unsupported Jetpack sites

### DIFF
--- a/client/components/feature-example/style.scss
+++ b/client/components/feature-example/style.scss
@@ -1,5 +1,5 @@
 .feature-example {
-	height: 400px;
+	max-height: 400px;
 	margin-top: 36px;
 	position: relative;
 	overflow: hidden;
@@ -8,8 +8,9 @@
 .feature-example__gradient {
 	position: absolute;
 		top: 0;
-	height: 100%;
-	width: 100%;
+		right: 0;
+		bottom: 0;
+		left: 0;
 	background: linear-gradient( to bottom, rgba(243, 246, 248, 0.4), rgba( 243, 246, 248, 1) );
 	z-index: z-index( 'root', '.feature-example__gradient' );
 }

--- a/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
+++ b/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
@@ -10,6 +10,8 @@ import { localize } from 'i18n-calypso';
  */
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isRequestingPostTypes, getPostTypes } from 'state/post-types/selectors';
+import { getSiteSlug, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { addSiteFragment } from 'lib/route';
 import QueryPostTypes from 'components/data/query-post-types';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -17,6 +19,9 @@ import FormToggle from 'components/forms/form-toggle';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
+import FeatureExample from 'components/feature-example';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 class CustomPostTypesFieldset extends Component {
 	constructor( props ) {
@@ -97,7 +102,8 @@ class CustomPostTypesFieldset extends Component {
 	}
 
 	render() {
-		const { translate, siteId, siteUrl, className } = this.props;
+		const { translate, siteId, siteSlug, siteUrl, className, siteSupportsCustomTypes } = this.props;
+		const ToggleWrapper = siteSupportsCustomTypes ? 'div' : FeatureExample;
 
 		return (
 			<FormFieldset className={ className }>
@@ -112,45 +118,57 @@ class CustomPostTypesFieldset extends Component {
 						}
 					} ) }
 				</p>
-				<div className="site-settings__custom-post-type">
-					<SectionHeader label={ translate( 'Testimonials' ) }>
-						<FormToggle
-							checked={ this.isEnabled( 'jetpack-testimonial' ) }
-							onChange={ this.boundToggleTestimonial }
-							disabled={ this.isDisabled( 'jetpack-testimonial' ) } />
-					</SectionHeader>
-					<Card>
-						{ this.hasDefaultPostTypeEnabled( 'jetpack-testimonial' ) && (
-							<FormSettingExplanation>{ translate( 'Your theme supports Testimonials' ) }</FormSettingExplanation>
-						) }
-						{ translate( 'The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( {{code}}[testimonials]{{/code}} ) or you can {{archiveLink}}view a full archive of your testimonials{{/archiveLink}}.', {
-							components: {
-								shortcodeLink: <a href="https://support.wordpress.com/testimonials-shortcode/" />,
-								code: <code />,
-								archiveLink: <a href={ siteUrl.replace( /\/$/, '' ) + '/testimonial' } />
-							}
-						} ) }
-					</Card>
-				</div>
-				<div className="site-settings__custom-post-type">
-					<SectionHeader label={ translate( 'Portfolio Projects' ) }>
-						<FormToggle
-							checked={ this.isEnabled( 'jetpack-portfolio' ) }
-							onChange={ this.boundTogglePortfolio }
-							disabled={ this.isDisabled( 'jetpack-portfolio' ) } />
-					</SectionHeader>
-					<Card>
-						{ this.hasDefaultPostTypeEnabled( 'jetpack-portfolio' ) && (
-							<FormSettingExplanation>{ translate( 'Your theme supports Portfolio Projects' ) }</FormSettingExplanation>
-						) }
-						{ translate( 'The Portfolio custom content type gives you an easy way to manage and showcase projects on your site. If your theme doesn’t support it yet, you can display the portfolio using the {{shortcodeLink}}portfolio shortcode{{/shortcodeLink}} ( {{code}}[portfolio]{{/code}} ) or with a link to the portfolio in the menu.', {
-							components: {
-								shortcodeLink: <a href="https://support.wordpress.com/portfolios/portfolio-shortcode/" />,
-								code: <code />
-							}
-						} ) }
-					</Card>
-				</div>
+				{ ! siteSupportsCustomTypes && (
+					<Notice
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate( 'You must update to the latest version of Jetpack to use this feature' ) }>
+						<NoticeAction href={ addSiteFragment( '/plugins/jetpack', siteSlug ) }>
+							{ translate( 'Update', { context: 'verb' } ) }
+						</NoticeAction>
+					</Notice>
+				) }
+				<ToggleWrapper>
+					<div className="site-settings__custom-post-type">
+						<SectionHeader label={ translate( 'Testimonials' ) }>
+							<FormToggle
+								checked={ this.isEnabled( 'jetpack-testimonial' ) }
+								onChange={ this.boundToggleTestimonial }
+								disabled={ this.isDisabled( 'jetpack-testimonial' ) } />
+						</SectionHeader>
+						<Card>
+							{ this.hasDefaultPostTypeEnabled( 'jetpack-testimonial' ) && (
+								<FormSettingExplanation>{ translate( 'Your theme supports Testimonials' ) }</FormSettingExplanation>
+							) }
+							{ translate( 'The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( {{code}}[testimonials]{{/code}} ) or you can {{archiveLink}}view a full archive of your testimonials{{/archiveLink}}.', {
+								components: {
+									shortcodeLink: <a href="https://support.wordpress.com/testimonials-shortcode/" />,
+									code: <code />,
+									archiveLink: <a href={ siteUrl.replace( /\/$/, '' ) + '/testimonial' } />
+								}
+							} ) }
+						</Card>
+					</div>
+					<div className="site-settings__custom-post-type">
+						<SectionHeader label={ translate( 'Portfolio Projects' ) }>
+							<FormToggle
+								checked={ this.isEnabled( 'jetpack-portfolio' ) }
+								onChange={ this.boundTogglePortfolio }
+								disabled={ this.isDisabled( 'jetpack-portfolio' ) } />
+						</SectionHeader>
+						<Card>
+							{ this.hasDefaultPostTypeEnabled( 'jetpack-portfolio' ) && (
+								<FormSettingExplanation>{ translate( 'Your theme supports Portfolio Projects' ) }</FormSettingExplanation>
+							) }
+							{ translate( 'The Portfolio custom content type gives you an easy way to manage and showcase projects on your site. If your theme doesn’t support it yet, you can display the portfolio using the {{shortcodeLink}}portfolio shortcode{{/shortcodeLink}} ( {{code}}[portfolio]{{/code}} ) or with a link to the portfolio in the menu.', {
+								components: {
+									shortcodeLink: <a href="https://support.wordpress.com/portfolios/portfolio-shortcode/" />,
+									code: <code />
+								}
+							} ) }
+						</Card>
+					</div>
+				</ToggleWrapper>
 			</FormFieldset>
 		);
 	}
@@ -158,12 +176,17 @@ class CustomPostTypesFieldset extends Component {
 
 CustomPostTypesFieldset.propTypes = {
 	translate: PropTypes.func,
-	siteId: PropTypes.number,
-	requestingPostTypes: PropTypes.bool,
 	requestingSettings: PropTypes.bool,
 	value: PropTypes.object,
+	onChange: PropTypes.func,
 	recordEvent: PropTypes.func,
-	className: PropTypes.string
+	className: PropTypes.string,
+	siteId: PropTypes.number,
+	siteSlug: PropTypes.string,
+	siteUrl: PropTypes.string,
+	requestingPostTypes: PropTypes.bool,
+	postTypes: PropTypes.object,
+	siteSupportsCustomTypes: PropTypes.bool
 };
 
 export default connect( ( state ) => {
@@ -172,8 +195,10 @@ export default connect( ( state ) => {
 
 	return {
 		siteId,
+		siteSlug: getSiteSlug( state, siteId ),
 		siteUrl: site ? site.URL : '',
 		requestingPostTypes: isRequestingPostTypes( state, siteId ),
-		postTypes: getPostTypes( state, siteId )
+		postTypes: getPostTypes( state, siteId ),
+		siteSupportsCustomTypes: false !== isJetpackMinimumVersion( state, siteId, '4.2.0' )
 	};
 } )( localize( CustomPostTypesFieldset ) );

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -62,8 +62,7 @@ const SiteSettingsFormWriting = React.createClass( {
 	isCustomPostTypesSettingsEnabled() {
 		return (
 			config.isEnabled( 'manage/custom-post-types' ) &&
-			false !== this.props.jetpackVersionSupportsCustomTypes &&
-			false !== this.props.jetpackCustomTypesModuleActive
+			false !== this.props.jetpackVersionSupportsCustomTypes
 		);
 	},
 
@@ -92,15 +91,42 @@ const SiteSettingsFormWriting = React.createClass( {
 		this.markChanged();
 	},
 
+	submitFormAndActivateCustomContentModule( event ) {
+		this.submitForm( event );
+
+		// Only need to activate module for Jetpack sites
+		if ( ! this.props.site || ! this.props.site.jetpack ) {
+			return;
+		}
+
+		// Jetpack support applies only to more recent versions
+		if ( ! this.props.jetpackVersionSupportsCustomTypes ) {
+			return;
+		}
+
+		// No action necessary if neither content type is enabled in form
+		if ( ! this.state.jetpack_testimonial && ! this.state.jetpack_portfolio ) {
+			return;
+		}
+
+		// Only activate module if not already activated (saves an unnecessary
+		// request for post types after submission completes)
+		if ( ! this.props.jetpackCustomTypesModuleActive ) {
+			// [TODO]: This should be migrated to a Redux action creator, but
+			// is complicated by requirements to sync back to legacy sites-list
+			this.props.site.activateModule( 'custom-content-types', this.onSaveComplete );
+		}
+	},
+
 	render: function() {
 		const markdownSupported = this.state.markdown_supported;
 		return (
-			<form id="site-settings" onSubmit={ this.submitForm } onChange={ this.markChanged }>
+			<form id="site-settings" onSubmit={ this.submitFormAndActivateCustomContentModule } onChange={ this.markChanged }>
 				<SectionHeader label={ this.translate( 'Writing Settings' ) }>
 					<Button
 						compact
 						primary
-						onClick={ this.submitForm }
+						onClick={ this.submitFormAndActivateCustomContentModule }
 						disabled={ this.state.fetchingSettings || this.state.submittingForm }>
 						{ this.state.submittingForm ? this.translate( 'Saving…' ) : this.translate( 'Save Settings' ) }
 					</Button>

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -142,13 +142,13 @@ const SiteSettingsFormWriting = React.createClass( {
 						</FormSelect>
 					</FormFieldset>
 
-					{ this.isCustomPostTypesSettingsEnabled() && (
+					{ config.isEnabled( 'manage/custom-post-types' ) && (
 						<CustomPostTypeFieldset
 							requestingSettings={ this.state.fetchingSettings }
 							value={ pick( this.state, 'jetpack_testimonial', 'jetpack_portfolio' ) }
 							onChange={ this.setCustomPostTypeSetting }
 							recordEvent={ this.recordEvent }
-							className="has-divider is-top-only" />
+							className="site-settings__custom-post-type-fieldset has-divider is-top-only" />
 					) }
 					{ markdownSupported &&
 						<FormFieldset className="has-divider is-top-only">

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -165,6 +165,15 @@
 	margin: 0 0 16px;
 }
 
+.site-settings__custom-post-type-fieldset .feature-example__content {
+	box-sizing: border-box;
+	padding: 1px; // Example overflow is hidden, obscuring border effect from box-shadow
+}
+
+.site-settings__custom-post-type-fieldset .feature-example__gradient {
+	background: linear-gradient( to bottom, rgba( $white, 0.4 ), rgba( $white, 1 ) );
+}
+
 .press-this {
 	/* press this isn't functional on a touch device */
 	.touch & {


### PR DESCRIPTION
This pull request seeks to...

- Allow a Jetpack site to manage custom post types even when the "custom content types" module is inactive, by automatically enabling the module if choosing to toggle a custom post type
- Display a notice recommending update when the Jetpack site is running an unsupported version

![Warning](https://cloud.githubusercontent.com/assets/1779930/17146515/ce8fa062-532c-11e6-8a56-1276918716d9.png)

__Testing instructions:__

Verify that you can manage custom post types while the "custom content types" module is inactive, and that when running a version of Jetpack 4.2 or earlier (4.2 is not yet released), that you are prompted to update to the latest version. It's expected that Jetpack 4.2 will be released before the production launch of the custom post types feature. In the interim, you can run the [Jetpack Beta version](https://jetpack.com/beta/) to verify that 4.2 and newer will allow configuring custom types.

1. Navigate to the [site writing settings screen](http://calypso.localhost:3000/settings/writing)
2. Select a site
3. Note that...
 - If the site is a WordPress.com hosted site, custom types are shown and configurable
 - If the site is a Jetpack site running 4.2 or newer, custom types are shown and configurable
 - If the site is a Jetpack site running 4.1.x or earlier, a notice is shown prompting an upgrade
 - If the site is a Jetpack site without custom content types enabled, custom types are shown and configurable (verify that changes to activate a custom type are persisted and effect the module activation)

Test live: https://calypso.live/?branch=update/cpt-jetpack-directions