### PR TITLE
Framework: make sure localStorage polyfill is loaded

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -1,5 +1,6 @@
 // Initialize localStorage polyfill before any dependencies are loaded
-require( 'lib/local-storage' )();
+import localStoragePolyfill from 'lib/local-storage';
+localStoragePolyfill();
 
 /**
  * External dependencies

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -1,6 +1,5 @@
 // Initialize localStorage polyfill before any dependencies are loaded
-import localStoragePolyfill from 'lib/local-storage';
-localStoragePolyfill();
+require( 'lib/local-storage' )();
 
 /**
  * External dependencies
@@ -24,7 +23,9 @@ var React = require( 'react' ),
  */
 // lib/local-storage must be run before lib/user
 var config = require( 'config' ),
-	abtest = require( 'lib/abtest' ).abtest,
+	abtestModule = require( 'lib/abtest' ),
+	abtest = abtestModule.abtest,
+	getSavedVariations = abtestModule.getSavedVariations,
 	switchLocale = require( 'lib/i18n-utils/switch-locale' ),
 	analytics = require( 'lib/analytics' ),
 	route = require( 'lib/route' ),
@@ -56,7 +57,6 @@ var config = require( 'config' ),
 	Layout;
 
 import { getSelectedSiteId, getSectionName, isSectionIsomorphic } from 'state/ui/selectors';
-import { getSavedVariations } from 'lib/abtest';
 
 function init() {
 	var i18nLocaleStringsObject = null;


### PR DESCRIPTION
This PR fixes the import ordering so the localStorage polyfill is loaded before the `lib/abtest` imports. The `store` module incorrectly detects that localStorage works in private mode on Safari, so we need this polyfill to be loaded to avoid any `QUOTA_EXCEEDED_ERR` which will prevent the page from loading.

## Testing Instructions
- On a Safari Private window, navigate to http://calypso.localhost:3000
- The page should load normally. 

cc @aduth @meremagee @shaunandrews 

Test live: https://calypso.live/?branch=fix/private-safari