### PR TITLE
JS Errors: pass commit # to errors

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -239,6 +239,11 @@ function reduxStoreReady( reduxStore ) {
 				user_id: user.get().ID,
 				calypso_env: config( 'env_id' )
 			} );
+
+			if ( window && window.app && window.app.commitChecksum ) {
+				errorLogger.saveDiagnosticData( { commit: window.app.commitChecksum } );
+			}
+
 			errorLogger.saveDiagnosticReducer( function() {
 				const state = reduxStore.getState();
 				return {

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -240,7 +240,7 @@ function reduxStoreReady( reduxStore ) {
 				calypso_env: config( 'env_id' )
 			} );
 
-			if ( window && window.app && window.app.commitChecksum ) {
+			if ( global.window && window.app && window.app.commitChecksum ) {
 				errorLogger.saveDiagnosticData( { commit: window.app.commitChecksum } );
 			}
 

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -68,7 +68,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				if abTestHelper
 					div(class=['environment', 'is-tests'])
 				if branchName && branchName !== 'master'
-					span(class=['environment', 'branch-name'], title='Commit ' + commitChecksum)=branchName
+					span(class=['environment', 'branch-name'], title='Commit ' + app.commitChecksum)=branchName
 				if devDocs
 					span(class=['environment', 'is-docs'])
 						a(href=devDocsURL title='DevDocs') docs

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -3,6 +3,7 @@ var express = require( 'express' ),
 	crypto = require( 'crypto' ),
 	qs = require( 'qs' ),
 	execSync = require( 'child_process' ).execSync,
+	exec = require( 'child_process' ).exec,
 	cookieParser = require( 'cookie-parser' ),
 	debug = require( 'debug' )( 'calypso:pages' );
 
@@ -27,7 +28,12 @@ var staticFiles = [
 ];
 
 var sections = sectionsModule.get();
-var commitChecksum = getCurrentCommitShortChecksum();
+var commitChecksum = '';
+exec( 'git rev-parse --short HEAD', function( error, stdout ) {
+	if ( ! error && stdout ) {
+		commitChecksum = stdout.toString().replace( /\s/gm, '' );
+	}
+} );
 
 /**
  * Generates a hash of a files contents to be used as a version parameter on asset requests.
@@ -92,14 +98,6 @@ function generateStaticUrls( request ) {
 function getCurrentBranchName() {
 	try {
 		return execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().replace( /\s/gm, '' );
-	} catch ( err ) {
-		return undefined;
-	}
-}
-
-function getCurrentCommitShortChecksum() {
-	try {
-		return execSync( 'git rev-parse --short HEAD' ).toString().replace( /\s/gm, '' );
 	} catch ( err ) {
 		return undefined;
 	}

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -127,7 +127,8 @@ function getDefaultContext( request ) {
 		clientIp: request.ip ? request.ip.replace( '::ffff:', '' ) : request.ip,
 		isDebug: context.env === 'development' || context.isDebug,
 		tinymceWpSkin: context.urls[ 'tinymce/skins/wordpress/wp-content.css' ],
-		tinymceEditorCss: context.urls[ 'editor.css' ]
+		tinymceEditorCss: context.urls[ 'editor.css' ],
+		commitChecksum: getCurrentCommitShortChecksum()
 	};
 
 	if ( CALYPSO_ENV === 'wpcalypso' ) {
@@ -155,7 +156,6 @@ function getDefaultContext( request ) {
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
 		context.faviconURL = '/calypso/images/favicons/favicon-development.ico';
 		context.branchName = getCurrentBranchName();
-		context.commitChecksum = getCurrentCommitShortChecksum();
 	}
 
 	return context;

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -27,6 +27,7 @@ var staticFiles = [
 ];
 
 var sections = sectionsModule.get();
+var commitChecksum = getCurrentCommitShortChecksum();
 
 /**
  * Generates a hash of a files contents to be used as a version parameter on asset requests.
@@ -128,7 +129,7 @@ function getDefaultContext( request ) {
 		isDebug: context.env === 'development' || context.isDebug,
 		tinymceWpSkin: context.urls[ 'tinymce/skins/wordpress/wp-content.css' ],
 		tinymceEditorCss: context.urls[ 'editor.css' ],
-		commitChecksum: getCurrentCommitShortChecksum()
+		commitChecksum: commitChecksum
 	};
 
 	if ( CALYPSO_ENV === 'wpcalypso' ) {


### PR DESCRIPTION
This passes commit hash from frontend. This will let us pinpoint problematic commits and actually guess when a problem started was first sighted.

Ideally it would find a PR and comment there.

The only concern I have is that it will call this line on prod:
https://github.com/Automattic/wp-calypso/blob/master/server/pages/index.js#L101

Previously it was only called on development.

## Testing 

- Build with ENABLE_FEATURES=catch-js-errors make run
- `localStorage.setItem('log-errors', 'rest-api');` to assign yourself from the logging group
- Reload
- Go to http://calypso.localhost:3000/plugins . IF you have a Jetpack site, you will get an error there.
- You should see a call going to https://public-api.wordpress.com/rest/v1.1/js-error in inspector
- See that `commit` is passed in request
- Go to `kibana4/goto/7fa9e6ab34999aaae96350e15b20d29b` to see your error.
- Go to `https://github.com/Automattic/wp-calypso/commit/` + commitHash to see that its a valid commit

CC @rralian @gwwar @mtias @lamosty 


Test live: https://calypso.live/?branch=update/error-logging-commit