### PR TITLE
Plans: redirect /plans to /pricing when logged out

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -354,6 +354,12 @@ function reduxStoreReady( reduxStore ) {
 				return;
 			}
 
+			if ( '/plans' === context.pathname ) {
+				// pricing page is outside of Calypso, needs a full page load
+				window.location = 'https://wordpress.com/pricing';
+				return;
+			}
+
 			if ( isValidSection ) {
 				next();
 			}


### PR DESCRIPTION
Fixes #7010 to redirect logged out users on`/plans` to `/pricing` instead of taking them to sign in. We'll want to eventually convert the plans page to be SSR ready, but this requires a bit of work to do so and will be easier to tackle when the redesign test is finished and we are using a single plans page.

## Testing Instructions
- Make sure you are logged out
- Navigate to http://calypso.localhost:3000/plans
- You will be redirected to https://wordpress.com/pricing
- Log in, and navigate to http://calypso.localhost:3000/plans
- The plans page renders
- Nux/Upgrade flows work normally.

cc @rralian @artpi @lamosty @retrofox 

Test live: https://calypso.live/?branch=update/logged-out-plans