### PR TITLE
State: Introduce extendAction utility for decorating actions with additional data

### DIFF
--- a/client/state/README.md
+++ b/client/state/README.md
@@ -16,3 +16,29 @@ const store = createReduxStore();
 ## Adding to the tree
 
 All the application information and data in Calypso should go through this data flow. When you are creating a new module with new data requirements, you should add them to this global store.
+
+## Utilities
+
+`state/utils.js` contains a number of helper utilities you may find useful in implementing your state subtree:
+
+### extendAction( action, data )
+
+Use `extendAction` to leverage the behavior of an existing action creator, extending any dispatched action via the original action creator with the provided data object. By using this helper, you avoid unnecessarily duplicating the original logic or tying the original action creator to your new (presumably optional) requirements. This is the equivalent of calling `Object.assign` on a plain-object action creator result, but also accepts an action thunk for which action objects should be extended.
+
+__Example:__
+
+```js
+function original() {
+	return ( dispatch ) => {
+		dispatch( { type: 'example' } );
+		dispatch( { type: 'example' } );
+	};
+}
+
+function extended() {
+	return extendAction( original(), { extended: true } );
+}
+
+dispatch( extended() );
+// Dispatches two actions `{ type: 'example', extended: true }`
+```

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -7,6 +7,8 @@ import omit from 'lodash/omit';
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
+import { dispatchWithMeta } from 'state/utils';
+import { addTerm } from 'state/terms/actions';
 import {
 	POST_DELETE,
 	POST_DELETE_SUCCESS,
@@ -295,4 +297,19 @@ export function restorePost( siteId, postId ) {
 			} );
 		} );
 	};
+}
+
+/**
+ * Returns an action thunk which, when dispatched, triggers a network request
+ * to create a new term. All actions dispatched by the thunk will include meta
+ * to associate it with the specified post ID.
+ *
+ * @param  {Number}   siteId   Site ID
+ * @param  {String}   taxonomy Taxonomy Slug
+ * @param  {Object}   term     Object of new term attributes
+ * @param  {Number}   postId   ID of post to which term is associated
+ * @return {Function}          Action thunk
+ */
+export function addTermForPost( siteId, taxonomy, term, postId ) {
+	return dispatchWithMeta( addTerm( siteId, taxonomy, term ), { postId } );
 }

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -7,7 +7,7 @@ import omit from 'lodash/omit';
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
-import { dispatchWithMeta } from 'state/utils';
+import { extendAction } from 'state/utils';
 import { addTerm } from 'state/terms/actions';
 import {
 	POST_DELETE,
@@ -311,5 +311,5 @@ export function restorePost( siteId, postId ) {
  * @return {Function}          Action thunk
  */
 export function addTermForPost( siteId, taxonomy, term, postId ) {
-	return dispatchWithMeta( addTerm( siteId, taxonomy, term ), { postId } );
+	return extendAction( addTerm( siteId, taxonomy, term ), { postId } );
 }

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -26,7 +26,8 @@ import {
 	POSTS_RECEIVE,
 	POSTS_REQUEST,
 	POSTS_REQUEST_SUCCESS,
-	POSTS_REQUEST_FAILURE
+	POSTS_REQUEST_FAILURE,
+	TERMS_RECEIVE
 } from 'state/action-types';
 import {
 	receivePost,
@@ -39,7 +40,8 @@ import {
 	savePost,
 	trashPost,
 	deletePost,
-	restorePost
+	restorePost,
+	addTermForPost
 } from '../actions';
 
 describe( 'actions', () => {
@@ -540,6 +542,39 @@ describe( 'actions', () => {
 					siteId: 77203074,
 					postId: 102,
 					error: sinon.match( { message: 'User cannot restore trashed posts' } )
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'addTermForPost', () => {
+		before( () => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.post( '/rest/v1.1/sites/2916284/taxonomies/jetpack-portfolio/terms/new' )
+				.reply( 200, {
+					ID: 123,
+					name: 'ribs',
+					description: ''
+				} );
+		} );
+
+		it( 'should dispatch a TERMS_RECEIVE event on success with post meta', () => {
+			return addTermForPost( 2916284, 'jetpack-portfolio', { name: 'ribs' }, 13640 )( spy ).then( () => {
+				expect( spy ).to.have.been.calledWith( {
+					type: TERMS_RECEIVE,
+					siteId: 2916284,
+					taxonomy: 'jetpack-portfolio',
+					terms: [ {
+						ID: 123,
+						name: 'ribs',
+						description: ''
+					} ],
+					query: undefined,
+					found: undefined,
+					meta: {
+						postId: 13640
+					}
 				} );
 			} );
 		} );

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -547,7 +547,7 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'addTermForPost', () => {
+	describe( 'addTermForPost()', () => {
 		before( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
@@ -572,9 +572,7 @@ describe( 'actions', () => {
 					} ],
 					query: undefined,
 					found: undefined,
-					meta: {
-						postId: 13640
-					}
+					postId: 13640
 				} );
 			} );
 		} );

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -570,8 +570,6 @@ describe( 'actions', () => {
 						name: 'ribs',
 						description: ''
 					} ],
-					query: undefined,
-					found: undefined,
 					postId: 13640
 				} );
 			} );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -22,31 +22,29 @@ describe( 'utils', () => {
 		} ),
 		actionSerialize = { type: SERIALIZE },
 		actionDeserialize = { type: DESERIALIZE };
-	let dispatchWithMeta, createReducer, reducer;
+	let extendAction, createReducer, reducer;
 
 	useMockery( ( mockery ) => {
 		mockery.registerMock( 'lib/warn', noop );
 
-		( { dispatchWithMeta, createReducer } = require( 'state/utils' ) );
+		( { extendAction, createReducer } = require( 'state/utils' ) );
 	} );
 
-	describe( 'dispatchWithMeta()', () => {
+	describe( 'extendAction()', () => {
 		it( 'should return an updated action object', () => {
-			const action = dispatchWithMeta( {
+			const action = extendAction( {
 				type: 'ACTION_TEST'
 			}, { ok: true } );
 
 			expect( action ).to.eql( {
 				type: 'ACTION_TEST',
-				meta: {
-					ok: true
-				}
+				ok: true
 			} );
 		} );
 
 		it( 'should return an updated action thunk', () => {
 			const dispatch = spy();
-			const action = dispatchWithMeta(
+			const action = extendAction(
 				( thunkDispatch ) => thunkDispatch( { type: 'ACTION_TEST' } ),
 				{ ok: true }
 			);
@@ -54,9 +52,7 @@ describe( 'utils', () => {
 			action( dispatch );
 			expect( dispatch ).to.have.been.calledWithExactly( {
 				type: 'ACTION_TEST',
-				meta: {
-					ok: true
-				}
+				ok: true
 			} );
 		} );
 	} );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -31,28 +31,50 @@ describe( 'utils', () => {
 	} );
 
 	describe( 'extendAction()', () => {
-		it( 'should return an updated action object', () => {
+		it( 'should return an updated action object, merging data', () => {
 			const action = extendAction( {
-				type: 'ACTION_TEST'
-			}, { ok: true } );
+				type: 'ACTION_TEST',
+				meta: {
+					preserve: true
+				}
+			}, {
+				meta: {
+					ok: true
+				}
+			} );
 
 			expect( action ).to.eql( {
 				type: 'ACTION_TEST',
-				ok: true
+				meta: {
+					preserve: true,
+					ok: true
+				}
 			} );
 		} );
 
-		it( 'should return an updated action thunk', () => {
+		it( 'should return an updated action thunk, merging data on dispatch', () => {
 			const dispatch = spy();
 			const action = extendAction(
-				( thunkDispatch ) => thunkDispatch( { type: 'ACTION_TEST' } ),
-				{ ok: true }
+				( thunkDispatch ) => thunkDispatch( {
+					type: 'ACTION_TEST',
+					meta: {
+						preserve: true
+					}
+				} ),
+				{
+					meta: {
+						ok: true
+					}
+				}
 			);
 
 			action( dispatch );
 			expect( dispatch ).to.have.been.calledWithExactly( {
 				type: 'ACTION_TEST',
-				ok: true
+				meta: {
+					preserve: true,
+					ok: true
+				}
 			} );
 		} );
 	} );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -4,7 +4,7 @@
 import deepFreeze from 'deep-freeze';
 import { expect } from 'chai';
 import noop from 'lodash/noop';
-import { stub } from 'sinon';
+import { stub, spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -22,12 +22,43 @@ describe( 'utils', () => {
 		} ),
 		actionSerialize = { type: SERIALIZE },
 		actionDeserialize = { type: DESERIALIZE };
-	let createReducer, reducer;
+	let dispatchWithMeta, createReducer, reducer;
 
 	useMockery( ( mockery ) => {
 		mockery.registerMock( 'lib/warn', noop );
 
-		createReducer = require( 'state/utils' ).createReducer;
+		( { dispatchWithMeta, createReducer } = require( 'state/utils' ) );
+	} );
+
+	describe( 'dispatchWithMeta()', () => {
+		it( 'should return an updated action object', () => {
+			const action = dispatchWithMeta( {
+				type: 'ACTION_TEST'
+			}, { ok: true } );
+
+			expect( action ).to.eql( {
+				type: 'ACTION_TEST',
+				meta: {
+					ok: true
+				}
+			} );
+		} );
+
+		it( 'should return an updated action thunk', () => {
+			const dispatch = spy();
+			const action = dispatchWithMeta(
+				( thunkDispatch ) => thunkDispatch( { type: 'ACTION_TEST' } ),
+				{ ok: true }
+			);
+
+			action( dispatch );
+			expect( dispatch ).to.have.been.calledWithExactly( {
+				type: 'ACTION_TEST',
+				meta: {
+					ok: true
+				}
+			} );
+		} );
 	} );
 
 	describe( '#createReducer()', () => {

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -26,18 +26,21 @@ export function isValidStateWithSchema( state, schema, checkForCycles = false, b
 
 /**
  * Given an action object or thunk, returns an updated object or thunk which
- * will include additional meta in the action (as provided) when dispatched.
+ * will include additional data in the action (as provided) when dispatched.
  *
  * @param  {(Function|Object)} action Action object or thunk
- * @param  {Object}            meta   Additional meta to include in action
+ * @param  {Object}            data   Additional data to include in action
  * @return {(Function|Object)}        Augmented action object or thunk
  */
-export function dispatchWithMeta( action, meta ) {
+export function extendAction( action, data ) {
 	if ( 'function' !== typeof action ) {
-		return { ...action, meta };
+		return { ...action, ...data };
 	}
 
-	return ( dispatch ) => action( ( thunkAction ) => dispatch( { ...thunkAction, meta } ) );
+	return ( dispatch ) => {
+		const newDispatch = ( thunkAction ) => dispatch( { ...thunkAction, ...data } );
+		return action( newDispatch );
+	};
 }
 
 /**

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import tv4 from 'tv4';
+import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,11 +35,11 @@ export function isValidStateWithSchema( state, schema, checkForCycles = false, b
  */
 export function extendAction( action, data ) {
 	if ( 'function' !== typeof action ) {
-		return { ...action, ...data };
+		return merge( {}, action, data );
 	}
 
 	return ( dispatch ) => {
-		const newDispatch = ( thunkAction ) => dispatch( { ...thunkAction, ...data } );
+		const newDispatch = ( thunkAction ) => dispatch( merge( {}, thunkAction, data ) );
 		return action( newDispatch );
 	};
 }

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -25,6 +25,22 @@ export function isValidStateWithSchema( state, schema, checkForCycles = false, b
 }
 
 /**
+ * Given an action object or thunk, returns an updated object or thunk which
+ * will include additional meta in the action (as provided) when dispatched.
+ *
+ * @param  {(Function|Object)} action Action object or thunk
+ * @param  {Object}            meta   Additional meta to include in action
+ * @return {(Function|Object)}        Augmented action object or thunk
+ */
+export function dispatchWithMeta( action, meta ) {
+	if ( 'function' !== typeof action ) {
+		return { ...action, meta };
+	}
+
+	return ( dispatch ) => action( ( thunkAction ) => dispatch( { ...thunkAction, meta } ) );
+}
+
+/**
  * Returns a reducer function with state calculation determined by the result
  * of invoking the handler key corresponding with the dispatched action type,
  * passing both the current state and action object. Defines default


### PR DESCRIPTION
Related: #7018

This pull request seeks to experiment with an idea for implementing action creators which could benefit from leveraging other existing action creators but needing additional data, without explicitly applying those enhancements to the original action creator.

Example use cases:

- Creating a new term in the context of the editor should associate that term with the edited post, in which case it's necessary to distinguish the received terms by the post for which it was created (if applicable)
- We may consider differentiating [actions for which notices are shown](https://github.com/Automattic/wp-calypso/blob/c2c94205e6d642d84523a611fd42f63f01b6dea3/client/state/notices/middleware.js#L84-L88) on the basis of user interaction. In other words, we may want to be able to save a post without a notice being shown if it is a background operation. In these cases, we could create a separate action creator for user-invoked post saving which applies `extendAction` to the existing `savePost` action creator.
- We could trigger analytics recording from a component's `connect` `bindDispatchToProps`, using the existing [analytics middleware](https://github.com/Automattic/wp-calypso/blob/master/client/state/analytics/middleware.js) meta signature

Why is this necessary?

- For action creators which return plain objects, it's easy enough to call and add to that action creator's resulting value. For thunk-based action creators, however, there is not an existing pattern for adding additional details the action objects being dispatched.

__Example:__

See included [`addTermForPost`](https://github.com/Automattic/wp-calypso/blob/cdbb20764d17e84fd10a3a62f8290bef52e378c8/client/state/posts/actions.js#L302-L315) action creator and [`extendAction` test cases](https://github.com/Automattic/wp-calypso/blob/cdbb20764d17e84fd10a3a62f8290bef52e378c8/client/state/test/utils.js#L33-L62).

__Testing instructions:__

There should be no effective changes to existing behavior. Included is the utility and a new `addTermForPost` action creator. Verify that tests pass for both:

```
npm run test-client client/state
```

Test live: https://calypso.live/?branch=add/state-utils-dispatch-with-meta