### PR TITLE
Plans features action: add context to buttons

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -44,8 +44,8 @@ const PlanFeaturesActions = ( {
 			>
 				{
 					freePlan
-						? translate( 'Select Free' )
-						: translate( 'Upgrade' )
+						? translate( 'Select Free', { context: 'button' } )
+						: translate( 'Upgrade', { context: 'verb' } )
 				}
 			</Button>
 		);


### PR DESCRIPTION
The current context-less strings are confusing translators.

Test live: https://calypso.live/?branch=fix/plan-upgrade-button-i18n