### PR TITLE
Domains: Consistenly use "name server" instead of "nameserver"

### DIFF
--- a/client/components/data/domain-management/nameservers/README.md
+++ b/client/components/data/domain-management/nameservers/README.md
@@ -1,7 +1,7 @@
 NameserversData
 ===============
 
-A component that fetches a domain's nameservers related data and passes it to its children.
+A component that fetches a domain's name servers related data and passes it to its children.
 
 ## Usage
 
@@ -43,6 +43,6 @@ The child component should receive processed props defined during the render:
 As well as:
 
 * `domains` - a list of domains, it's the result of a call to `DomainsStore.getBySite` for the current site
-* `nameservers` - nameservers data, it's the result of a call to `NameserversStore.getByDomainName` for the current domain  
+* `nameservers` - name servers data, it's the result of a call to `NameserversStore.getByDomainName` for the current domain  
 
 It's updated whenever `DomainsStore`, `NameserversStore` or `sites` changes.

--- a/client/lib/domains/nameservers/reducer.js
+++ b/client/lib/domains/nameservers/reducer.js
@@ -15,11 +15,11 @@ const initialDomainState = {
 };
 
 /**
- * @desc Updates nameservers entry for given domain.
+ * @desc Updates name servers entry for given domain.
  *
  * @param {Object} [state] Current state.
  * @param {string} [domainName] Domain name.
- * @param {Object} [data] Domain nameservers data.
+ * @param {Object} [data] Domain name servers data.
  * @return {Object} New state
  */
 function updateState( state, domainName, data ) {

--- a/client/lib/domains/nameservers/test/store.js
+++ b/client/lib/domains/nameservers/test/store.js
@@ -60,7 +60,7 @@ describe( 'store', () => {
 		} );
 	} );
 
-	it( 'should return a list with nameservers when fetching domain data completed', () => {
+	it( 'should return a list with name servers when fetching domain data completed', () => {
 		Dispatcher.handleViewAction( {
 			type: ActionTypes.NAMESERVERS_FETCH_COMPLETED,
 			domainName: DOMAIN_NAME,
@@ -74,7 +74,7 @@ describe( 'store', () => {
 		} );
 	} );
 
-	it( 'should return an updated list with nameservers when nameservers update completed', () => {
+	it( 'should return an updated list with name servers when name servers update completed', () => {
 		const UPDATED_NAMESERVERS = [
 			'ns1.foo.com',
 			'ns2.foo.com'

--- a/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
+++ b/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
@@ -33,7 +33,7 @@ export default [
 		value: 'transfer',
 		label: i18n.translate( 'I want to transfer my domain to another registrar' ),
 		helpMessage: i18n.translate(
-			'You may not transfer a domain name for 60 days after its purchase, renewal, nameserver change, ' +
+			'You may not transfer a domain name for 60 days after its purchase, renewal, name server change, ' +
 			'or any contact information change. This is a rule set by the Internet Corporation for ' +
 			'Assigned Names and Numbers (ICANN) and standard across all registrars. ' +
 			'You will need to {{a}}update your name servers{{/a}} instead.', {

--- a/client/my-sites/upgrades/domain-management/README.md
+++ b/client/my-sites/upgrades/domain-management/README.md
@@ -14,7 +14,7 @@ Supported routes:
 - `/domains/manage/:site/edit/:domain` - displays domain details
 - `/domains/manage/:site/edit-contact-info/:domain` - manages contact information for a domain
 - `/domains/manage/:site/email-forwarding/:domain` - manages email forwarding information for a domain
-- `/domains/manage/:site/name-servers/:domain` - manages nameservers for a domain
+- `/domains/manage/:site/name-servers/:domain` - manages name servers for a domain
 - `/domains/manage/:site/primary-domain/:domain` - changes primary domain for a site
 - `/domains/manage/:site/privacy-protection/:domain` - adds privacy protection for a domain
 - `/domains/manage/:site/redirect-settings/:domain` - changes redirect settings for a domain

--- a/client/my-sites/upgrades/domain-management/name-servers/index.jsx
+++ b/client/my-sites/upgrades/domain-management/name-servers/index.jsx
@@ -131,7 +131,7 @@ const NameServers = React.createClass( {
 			if ( error ) {
 				notices.error( error.message );
 			} else {
-				this.props.successNotice( this.translate( 'Yay, the nameservers have been successfully updated!' ) );
+				this.props.successNotice( this.translate( 'Yay, the name servers have been successfully updated!' ) );
 			}
 
 			this.setState( { formSubmitting: false } );


### PR DESCRIPTION
Raised by @designsimply - we are not consistent when it comes to using "name server" vs "nameserver". This PR fixes this inconsistency in the messages shown to the user.

The two place (apart from some comments in code) are:

* transfer view, when the domain is new (< 60 days old) or has been recently edited
* notice after successfully updating the name servers

cc @aidvu @umurkontaci 

Test live: https://calypso.live/?branch=fix/nameserver-vs-name-server