### PR TITLE
CPT: Bump mc stats for list screen post actions

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -11,6 +11,7 @@ import get from 'lodash/get';
  */
 import PopoverMenuItem from 'components/popover/menu-item';
 import QueryPostTypes from 'components/data/query-post-types';
+import { mc } from 'lib/analytics';
 import { getPost } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import { getCurrentUserId, isValidCapability, canCurrentUser } from 'state/current-user/selectors';
@@ -21,8 +22,12 @@ function PostActionsEllipsisMenuEdit( { translate, siteId, canEdit, status, edit
 		return null;
 	}
 
+	function bumpStat() {
+		mc.bumpStat( 'calypso_cpt_actions', 'edit' );
+	}
+
 	return (
-		<PopoverMenuItem href={ editUrl } icon="pencil">
+		<PopoverMenuItem href={ editUrl } onClick={ bumpStat } icon="pencil">
 			{ siteId && ! isKnownType && <QueryPostTypes siteId={ siteId } /> }
 			{ translate( 'Edit', { context: 'verb' } ) }
 		</PopoverMenuItem>

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/restore.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
+import { mc } from 'lib/analytics';
 import { getPost } from 'state/posts/selectors';
 import { restorePost } from 'state/posts/actions';
 import { getCurrentUserId, canCurrentUser } from 'state/current-user/selectors';
@@ -36,6 +37,7 @@ class PostActionsEllipsisMenuRestore extends Component {
 			return;
 		}
 
+		mc.bumpStat( 'calypso_cpt_actions', 'restore' );
 		this.props.restorePost( siteId, postId );
 	}
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
+import { mc } from 'lib/analytics';
 import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getPost } from 'state/posts/selectors';
 
@@ -17,8 +18,15 @@ function PostActionsEllipsisMenuStats( { translate, siteSlug, postId, status, is
 		return null;
 	}
 
+	function bumpStat() {
+		mc.bumpStat( 'calypso_cpt_actions', 'stats' );
+	}
+
 	return (
-		<PopoverMenuItem href={ `/stats/post/${ postId }/${ siteSlug }` } icon="stats-alt">
+		<PopoverMenuItem
+			href={ `/stats/post/${ postId }/${ siteSlug }` }
+			onClick={ bumpStat }
+			icon="stats-alt">
 			{ translate( 'Stats' ) }
 		</PopoverMenuItem>
 	);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -9,59 +9,76 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
+import { mc } from 'lib/analytics';
 import { trashPost, deletePost } from 'state/posts/actions';
 import { getPost } from 'state/posts/selectors';
 import { getCurrentUserId, canCurrentUser } from 'state/current-user/selectors';
 
-function PostActionsEllipsisMenuTrash( { translate, siteId, postId, status, canDelete, dispatch } ) {
-	if ( ! canDelete ) {
-		return null;
+class PostActionsEllipsisMenuTrash extends Component {
+	static propTypes = {
+		globalId: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+		postId: PropTypes.number,
+		siteId: PropTypes.number,
+		status: PropTypes.string,
+		canDelete: PropTypes.bool,
+		trashPost: PropTypes.func,
+		deletePost: PropTypes.func
+	};
+
+	constructor() {
+		super( ...arguments );
+
+		this.trashPost = this.trashPost.bind( this );
 	}
 
-	function onTrash() {
+	trashPost() {
+		const { translate, siteId, postId, status } = this.props;
 		if ( ! postId ) {
 			return;
 		}
 
 		if ( 'trash' !== status ) {
-			dispatch( trashPost( siteId, postId ) );
+			mc.bumpStat( 'calypso_cpt_actions', 'trash' );
+			this.props.trashPost( siteId, postId );
 		} else if ( confirm( translate( 'Are you sure you want to permanently delete this post?' ) ) ) {
-			dispatch( deletePost( siteId, postId ) );
+			mc.bumpStat( 'calypso_cpt_actions', 'delete' );
+			this.props.deletePost( siteId, postId );
 		}
 	}
 
-	return (
-		<PopoverMenuItem onClick={ onTrash } icon="trash">
-			{ 'trash' === status
-				? translate( 'Delete Permanently' )
-				: translate( 'Trash', { context: 'verb' } ) }
-		</PopoverMenuItem>
-	);
+	render() {
+		const { translate, status, canDelete } = this.props;
+		if ( ! canDelete ) {
+			return null;
+		}
+
+		return (
+			<PopoverMenuItem onClick={ this.trashPost } icon="trash">
+				{ 'trash' === status
+					? translate( 'Delete Permanently' )
+					: translate( 'Trash', { context: 'verb' } ) }
+			</PopoverMenuItem>
+		);
+	}
 }
 
-PostActionsEllipsisMenuTrash.propTypes = {
-	globalId: PropTypes.string,
-	translate: PropTypes.func.isRequired,
-	postId: PropTypes.number,
-	siteId: PropTypes.number,
-	status: PropTypes.string,
-	canDelete: PropTypes.bool,
-	dispatch: PropTypes.func
-};
+export default connect(
+	( state, ownProps ) => {
+		const post = getPost( state, ownProps.globalId );
+		if ( ! post ) {
+			return {};
+		}
 
-export default connect( ( state, ownProps ) => {
-	const post = getPost( state, ownProps.globalId );
-	if ( ! post ) {
-		return {};
-	}
+		const userId = getCurrentUserId( state );
+		const isAuthor = post.author && post.author.ID === userId;
 
-	const userId = getCurrentUserId( state );
-	const isAuthor = post.author && post.author.ID === userId;
-
-	return {
-		postId: post.ID,
-		siteId: post.site_ID,
-		status: post.status,
-		canDelete: canCurrentUser( state, post.site_ID, isAuthor ? 'delete_posts' : 'delete_others_posts' )
-	};
-} )( localize( PostActionsEllipsisMenuTrash ) );
+		return {
+			postId: post.ID,
+			siteId: post.site_ID,
+			status: post.status,
+			canDelete: canCurrentUser( state, post.site_ID, isAuthor ? 'delete_posts' : 'delete_others_posts' )
+		};
+	},
+	{ trashPost, deletePost }
+)( localize( PostActionsEllipsisMenuTrash ) );

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -10,6 +10,7 @@ import includes from 'lodash/includes';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
+import { mc } from 'lib/analytics';
 import { getPost, getPostPreviewUrl } from 'state/posts/selectors';
 import { setPreviewUrl } from 'state/ui/actions';
 import layoutFocus from 'lib/layout-focus';
@@ -31,6 +32,7 @@ class PostActionsEllipsisMenuView extends Component {
 
 	previewPost( event ) {
 		this.props.setPreviewUrl( this.props.previewUrl );
+		mc.bumpStat( 'calypso_cpt_actions', 'view' );
 		layoutFocus.set( 'preview' );
 		event.preventDefault();
 	}


### PR DESCRIPTION
Related: #6681

This pull request seeks to implement MC stat bumping for action menu interactions on the custom post type list screen.

__Testing instructions:__

Verify that all post actions continue to work as expected, and that clicking on each action bumps the corresponding stat in the group `calypso_cpt_actions`. To verify stat bumps, enable analytics debugging by entering the following your browser's developer tools console and refreshing the page:

```js
localStorage.debug = 'calypso:analytics';
```

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site, if prompted
3. Toggle the actions menu for a post
4. Click an action in the menu
5. Note that a debug statement is logged to your console with the expected group and stat
6. Repeat for all actions across all statuses (edit, publish, restore, stats, trash, delete, view)

Test live: https://calypso.live/?branch=add/cpt-list-actions-analytics