### PR TITLE
CPT: Ensure site settings event tracking only occurs when clicked

### DIFF
--- a/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
+++ b/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
@@ -84,13 +84,20 @@ class CustomPostTypesFieldset extends Component {
 	}
 
 	onChange( postType ) {
-		this.props.onChange( {
+		const { recordEvent, onChange } = this.props;
+
+		switch ( postType ) {
+			case 'jetpack-testimonial': recordEvent( 'Clicked Jetpack Testimonial CPT Checkbox' ); break;
+			case 'jetpack-portfolio': recordEvent( 'Clicked Jetpack Portfolio CPT Checkbox' ); break;
+		}
+
+		onChange( {
 			[ this.getPostTypeValueKey( postType ) ]: ! this.isEnabled( postType )
 		} );
 	}
 
 	render() {
-		const { translate, siteId, siteUrl, recordEvent, className } = this.props;
+		const { translate, siteId, siteUrl, className } = this.props;
 
 		return (
 			<FormFieldset className={ className }>
@@ -110,8 +117,7 @@ class CustomPostTypesFieldset extends Component {
 						<FormToggle
 							checked={ this.isEnabled( 'jetpack-testimonial' ) }
 							onChange={ this.boundToggleTestimonial }
-							disabled={ this.isDisabled( 'jetpack-testimonial' ) }
-							onClick={ recordEvent( 'Clicked Jetpack Testimonial CPT Checkbox' ) } />
+							disabled={ this.isDisabled( 'jetpack-testimonial' ) } />
 					</SectionHeader>
 					<Card>
 						{ this.hasDefaultPostTypeEnabled( 'jetpack-testimonial' ) && (
@@ -131,8 +137,7 @@ class CustomPostTypesFieldset extends Component {
 						<FormToggle
 							checked={ this.isEnabled( 'jetpack-portfolio' ) }
 							onChange={ this.boundTogglePortfolio }
-							disabled={ this.isDisabled( 'jetpack-portfolio' ) }
-							onClick={ recordEvent( 'Clicked Jetpack Portfolio CPT Checkbox' ) } />
+							disabled={ this.isDisabled( 'jetpack-portfolio' ) } />
 					</SectionHeader>
 					<Card>
 						{ this.hasDefaultPostTypeEnabled( 'jetpack-portfolio' ) && (


### PR DESCRIPTION
This pull request seeks to resolve an issue where [custom post types writing settings](https://wpcalypso.wordpress.com/settings/writing) event tracking is triggered upon every render, rather than the intended click interaction.

__Testing instructions:__

Enable analytics debug logging by entering the following in your browser's developer tools console and refreshing the page:

```js
localStorage.debug = 'calypso:analytics';
```

1. Navigate to the [site settings writing screen](http://calypso.localhost:3000/settings/writing)
2. Select a site, if prompted
3. Note that no "Recording Event" message is logged to your developer tools console for either "Clicked Jetpack Testimonial CPT Checkbox" or "Clicked Jetpack Portfolio CPT Checkbox"
4. Click one or the other of testimonial or portfolio toggles
5. Note that a "Recording Event" message is logged to your developer tools console corresponding to the post type that you had toggled

Test live: https://calypso.live/?branch=fix/site-settings-cpt-stats