### PR TITLE
Plans: always remind users when they have a free domain

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -17,16 +17,6 @@ module.exports = {
 		defaultVariation: 'noChanges',
 		allowExistingUsers: false,
 	},
-	domainCreditsInfoNotice: {
-		datestamp: '20160420',
-		variations: {
-			showNotice: 90,
-			original: 10
-		},
-		defaultVariation: 'showNotice',
-		allowExistingUsers: true,
-		allowAnyLocale: true
-	},
 	domainSuggestionVendor: {
 		datestamp: '20160614',
 		variations: {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -16,7 +16,6 @@ import { canCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isFinished as isJetpackPluginsFinished } from 'state/plugins/premium/selectors';
-import { abtest } from 'lib/abtest';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
 const SiteNotice = React.createClass( {
@@ -59,28 +58,19 @@ const SiteNotice = React.createClass( {
 			return null;
 		}
 
-		if ( abtest( 'domainCreditsInfoNotice' ) === 'showNotice' ) {
-			const eventName = 'calypso_domain_credit_reminder_impression';
-			const eventProperties = { cta_name: 'current_site_domain_notice' };
-			return (
-				<Notice isCompact status="is-success" icon="info-outline">
-					{ this.translate( 'Free domain available' ) }
-					<NoticeAction
-						onClick={ this.props.clickClaimDomainNotice }
-						href={ `/domains/add/${ this.props.site.slug }` }
-					>
-						{ this.translate( 'Claim' ) }
-						<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
-					</NoticeAction>
-				</Notice>
-			);
-		}
-
-		//otherwise still track what happens when we don't show a notice
-		const eventName = 'calypso_domain_credit_reminder_no_impression';
+		const eventName = 'calypso_domain_credit_reminder_impression';
 		const eventProperties = { cta_name: 'current_site_domain_notice' };
 		return (
-			<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+			<Notice isCompact status="is-success" icon="info-outline">
+				{ this.translate( 'Free domain available' ) }
+				<NoticeAction
+					onClick={ this.props.clickClaimDomainNotice }
+					href={ `/domains/add/${ this.props.site.slug }` }
+				>
+					{ this.translate( 'Claim' ) }
+					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+				</NoticeAction>
+			</Notice>
 		);
 	},
 

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -35,7 +35,6 @@ import NoticeAction from 'components/notice/notice-action';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { abtest } from 'lib/abtest';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 
 export const List = React.createClass( {
@@ -63,29 +62,21 @@ export const List = React.createClass( {
 			return null;
 		}
 
-		if ( abtest( 'domainCreditsInfoNotice' ) === 'showNotice' ) {
-			const eventName = 'calypso_domain_credit_reminder_impression';
-			const eventProperties = { cta_name: 'domain_info_notice' };
-			return (
-				<Notice
-					status="is-info"
-					showDismiss={ false }
-					text={ this.translate( 'Free domain available' ) }
-					icon="globe">
-					<NoticeAction onClick={ this.props.clickClaimDomainNotice } href={ `/domains/add/${ this.props.selectedSite.slug }` }>
-						{ this.translate( 'Claim Free Domain' ) }
-						<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
-					</NoticeAction>
-				</Notice>
-			);
-		}
-
-		//otherwise still track what happens when we don't show a notice
-		const eventName = 'calypso_domain_credit_reminder_no_impression';
+		const eventName = 'calypso_domain_credit_reminder_impression';
 		const eventProperties = { cta_name: 'domain_info_notice' };
 		return (
-			<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+			<Notice
+				status="is-info"
+				showDismiss={ false }
+				text={ this.translate( 'Free domain available' ) }
+				icon="globe">
+				<NoticeAction onClick={ this.props.clickClaimDomainNotice } href={ `/domains/add/${ this.props.selectedSite.slug }` }>
+					{ this.translate( 'Claim Free Domain' ) }
+					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+				</NoticeAction>
+			</Notice>
 		);
+
 	},
 
 	render() {


### PR DESCRIPTION
This PR removes the `domainCreditsInfoNotice` abtest so that we always display the following notices when a user has a free domain. 

<img width="731" alt="screen shot 2016-07-26 at 1 29 57 pm" src="https://cloud.githubusercontent.com/assets/1270189/17154344/87871a02-5335-11e6-8a1b-ac0946a76a65.png">

<img width="274" alt="screen shot 2016-07-26 at 1 29 37 pm" src="https://cloud.githubusercontent.com/assets/1270189/17154364/96a28936-5335-11e6-94b3-0ae4edd6adc0.png">

## Testing Instructions
- Navigate to http://calypso.localhost:3000
- Click on "My Sites"
- Switch to a site that has a paid plan, but hasn't yet used the domain credit
- We should see the green notice on the Site List
- Navigate to http://calypso.localhost:3000/domains/manage
- Select a site that has a paid plan, but hasn't yet used the domain credit
- We should see the blue notice

cc @rralian @retrofox @lamosty @artpi 

Test live: https://calypso.live/?branch=update/remove-domain-credit-abtest