### PR TITLE
First-view: Disable A/B test in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -84,7 +84,7 @@
 		"settings/security/monitor": true,
 		"support-user": true,
 		"sync-handler": true,
-		"ui/first-view-ab-test": true,
+		"ui/first-view-ab-test": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
We noticed an issue with dismissing the first-view in IE11. We're disabling the test until we can solve that issue.

Test live: https://calypso.live/?branch=update/first-view/disable-test