### PR TITLE
Editor: prevent post.type from being null when transitioning to saved.

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -674,18 +674,13 @@ const PostEditor = React.createClass( {
 	},
 
 	onSaveSuccess: function( message, action, link ) {
-		var post = PostEditStore.get(), nextState;
+		const post = PostEditStore.get();
 
 		if ( 'draft' === post.status ) {
 			this.props.setEditorLastDraft( post.site_ID, post.ID );
 		} else {
 			this.props.resetEditorLastDraft();
 		}
-
-		// Reset previous edits, preserving type
-		this.props.resetPostEdits( this.props.siteId );
-		this.props.resetPostEdits( post.site_ID, post.ID );
-		this.props.editPost( { type: this.props.type }, post.site_ID, post.ID );
 
 		// Assign editor post ID to saved value (especially important when
 		// transitioning from an unsaved post to a saved one)
@@ -696,7 +691,12 @@ const PostEditor = React.createClass( {
 		// Receive updated post into state
 		this.props.receivePost( post );
 
-		nextState = {
+		// Reset previous edits, preserving type
+		this.props.resetPostEdits( this.props.siteId );
+		this.props.resetPostEdits( post.site_ID, post.ID );
+		this.props.editPost( { type: this.props.type }, post.site_ID, post.ID );
+
+		const nextState = {
 			isSaving: false,
 			isPublishing: false
 		};

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -43,7 +43,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-draft/actions';
 import { isEditorDraftsVisible, getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { toggleEditorDraftsVisible, setEditorPostId } from 'state/ui/editor/actions';
-import { receivePost, editPost, resetPostEdits } from 'state/posts/actions';
+import { receivePost, resetPostEdits } from 'state/posts/actions';
 import { getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
 import EditorSidebarHeader from 'post-editor/editor-sidebar/header';
 import EditorDocumentHead from 'post-editor/editor-document-head';
@@ -694,7 +694,6 @@ const PostEditor = React.createClass( {
 		// Reset previous edits, preserving type
 		this.props.resetPostEdits( this.props.siteId );
 		this.props.resetPostEdits( post.site_ID, post.ID );
-		this.props.editPost( { type: this.props.type }, post.site_ID, post.ID );
 
 		const nextState = {
 			isSaving: false,
@@ -778,7 +777,6 @@ export default connect(
 			setEditorLastDraft,
 			resetEditorLastDraft,
 			receivePost,
-			editPost,
 			resetPostEdits,
 			setEditorPostId,
 			setEditorModePreference: savePreference.bind( null, 'editor-mode' ),


### PR DESCRIPTION
Fixes #7023 - when a post is transitioning from an un-saved draft to saved ( either via an autoSave or manually clicking the save button ), there were a few render calls being made to `<EditorDrawerTaxonomies />` where the `post.type` was undefined, and therefore no `taxonomies` were being passed to the render call.

This resulted in the component rendering empty, and then re-rendering with all the correct `taxonomies` for the post type.

For the fix I have changed the order of the dispatches in `onSaveSuccess`, and did a small bit of lint fixing in that function as well.

__To Test__
- Open up a new portfolio item in the editor
- Expand Project Types accordion in the sidebar
- add a title, and some content and click save
- verify the Project Types accordion is still open

@aduth can you think of any flows where changing the order of these actions might cause issues?

Test live: https://calypso.live/?branch=fix/editor/7023