### PR TITLE
WebPreview: Fix device icon margins when showExternal is false

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -107,7 +107,11 @@
 .web-preview__external {
 	display: flex;
 	align-items: center;
-	margin-right: 8px;
+}
+
+.web-preview__device-switcher {
+	display: flex;
+	margin-left: 8px;
 }
 
 .web-preview__device-button {

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -54,18 +54,20 @@ export const PreviewToolbar = props => {
 				</a>
 			}
 			{ showDeviceSwitcher &&
-				possibleDevices.map( device => (
-					<button
-						aria-hidden={ true }
-						key={ device }
-						className={ classNames( 'web-preview__device-button', {
-							'is-active': device === currentDevice,
-						} ) }
-						onClick={ partial( setDeviceViewport, device ) }
-					>
-						<Gridicon icon={ device } />
-					</button>
-				) )
+				<div className="web-preview__device-switcher">
+					{ possibleDevices.map( device => (
+						<button
+							aria-hidden={ true }
+							key={ device }
+							className={ classNames( 'web-preview__device-button', {
+								'is-active': device === currentDevice,
+							} ) }
+							onClick={ partial( setDeviceViewport, device ) }
+						>
+							<Gridicon icon={ device } />
+						</button>
+					) ) }
+				</div>
 			}
 			<div className="web-preview__toolbar-tray">
 				{ props.children }


### PR DESCRIPTION
As pointed out by @melchoyce on #6958, whenever the “External” button is hidden on the `WebPreview` component, the spacing between the close button and the device buttons is incorrect.

This is because the spacing was being achieved by using `margin-right` on the “External” button. This PR changes that, to use `margin-left` on a new wrapper element around the device buttons.

Test live: https://calypso.live/?branch=update/web-preview-device-icon-margin