### PR TITLE
First-View: Break remove statement up into 2 parts to fix IE

### DIFF
--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -111,7 +111,8 @@ const FirstView = React.createClass( {
 	},
 
 	updateDocumentStylesForHiddenFirstView() {
-		document.documentElement.classList.remove( 'no-scroll', 'is-first-view-visible' );
+		document.documentElement.classList.remove( 'no-scroll' );
+		document.documentElement.classList.remove( 'is-first-view-visible' );
 		// wait a bit so that we trigger the CSS transition
 		setTimeout( () => {
 			if ( ! this.props.isVisible ) {

--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -102,7 +102,8 @@ const FirstView = React.createClass( {
 	},
 
 	updateDocumentStylesForVisibleFirstView() {
-		document.documentElement.classList.add( 'no-scroll', 'is-first-view-active' );
+		document.documentElement.classList.add( 'no-scroll' );
+		document.documentElement.classList.add( 'is-first-view-active' );
 		process.nextTick( () => {
 			if ( this.props.isVisible ) {
 				document.documentElement.classList.add( 'is-first-view-visible' );


### PR DESCRIPTION
IE wasn't removing the second class from the classList, causing the underlay to remain visible. This PR fixes that by using two separate remove statements, which appears to fix the IE issue without any adverse side effects.

To test, in IE dismiss the first view before and after this diff.

To see the first-view, visit any of the /stats pages as a user who has not yet dismissed the first view.