### PR TITLE
Editor: Display page attributes accordion inputs by type support

### DIFF
--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -3,8 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
-import mapKeys from 'lodash/mapKeys';
-import snakeCase from 'lodash/snakeCase';
+import { reduce, snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -58,9 +57,15 @@ export default React.createClass( {
 	getQuery() {
 		const { type, status, excludeTree, orderBy, order } = this.props;
 		const { search } = this.state;
-		return mapKeys( { type, status, excludeTree, orderBy, order, search }, ( value, key ) => {
-			return snakeCase( key );
-		} );
+
+		return reduce( { type, status, excludeTree, orderBy, order, search }, ( memo, value, key ) => {
+			if ( null === value || undefined === value ) {
+				return memo;
+			}
+
+			memo[ snakeCase( key ) ] = value;
+			return memo;
+		}, {} );
 	},
 
 	render() {

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -20,13 +20,9 @@ import PostFormatsData from 'components/data/post-formats-data';
 import PostFormatsAccordion from 'post-editor/editor-post-formats/accordion';
 import Location from 'post-editor/editor-location';
 import Discussion from 'post-editor/editor-discussion';
-import PageParent from 'post-editor/editor-page-parent';
 import SeoAccordion from 'post-editor/editor-seo-accordion';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
 import InfoPopover from 'components/info-popover';
-import PageTemplatesData from 'components/data/page-templates-data';
-import PageTemplates from 'post-editor/editor-page-templates';
-import PageOrder from 'post-editor/editor-page-order';
 import PostMetadata from 'lib/post-metadata';
 import TrackInputChanges from 'components/track-input-changes';
 import actions from 'lib/posts/actions';
@@ -42,6 +38,7 @@ import { isJetpackMinimumVersion } from 'state/sites/selectors';
 import config from 'config';
 import EditorDrawerFeaturedImage from './featured-image';
 import EditorDrawerTaxonomies from './taxonomies';
+import EditorDrawerPageOptions from './page-options';
 
 /**
  * Constants
@@ -298,24 +295,7 @@ const EditorDrawer = React.createClass( {
 			return;
 		}
 
-		return (
-			<Accordion
-				title={ this.translate( 'Page Options' ) }
-				icon={ <Gridicon icon="pages" /> }>
-				{ this.props.site && this.props.post ?
-					<div>
-						<PageParent siteId={ this.props.site.ID }
-							postId={ this.props.post.ID }
-							parent={ this.props.post.parent_id ? this.props.post.parent_id : 0 }
-						/>
-						<PageTemplatesData siteId={ this.props.site.ID } >
-							<PageTemplates post={ this.props.post } />
-						</PageTemplatesData>
-					</div>
-				: null }
-				<PageOrder menuOrder={ this.props.post ? this.props.post.menu_order : 0 } />
-			</Accordion>
-		);
+		return <EditorDrawerPageOptions />;
 	},
 
 	render: function() {

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -295,7 +295,7 @@ const EditorDrawer = React.createClass( {
 			return;
 		}
 
-		return <EditorDrawerPageOptions />;
+		return <EditorDrawerPageOptions post={ this.props.post } />;
 	},
 
 	render: function() {

--- a/client/post-editor/editor-drawer/page-options.jsx
+++ b/client/post-editor/editor-drawer/page-options.jsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditedPost } from 'state/posts/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getPostType } from 'state/post-types/selectors';
+import PageParent from 'post-editor/editor-page-parent';
+import PageTemplatesData from 'components/data/page-templates-data';
+import PageTemplates from 'post-editor/editor-page-templates';
+import PageOrder from 'post-editor/editor-page-order';
+import Accordion from 'components/accordion';
+import Gridicon from 'components/gridicon';
+
+function EditorDrawerPageOptions( { translate, siteId, postId, post, postType, hierarchical } ) {
+	let title;
+	if ( 'page' === postType ) {
+		title = translate( 'Page Attributes' );
+	} else {
+		title = translate( 'Attributes' );
+	}
+
+	return (
+		<Accordion title={ title } icon={ <Gridicon icon="pages" /> }>
+			{ hierarchical && (
+				<PageParent
+					siteId={ siteId }
+					postId={ postId }
+					parent={ get( post, 'parent_id', 0 ) } />
+			) }
+			{ siteId && 'page' === postType && (
+				<PageTemplatesData siteId={ siteId } >
+					<PageTemplates post={ post } />
+				</PageTemplatesData>
+			) }
+			<PageOrder menuOrder={ get( post, 'menu_order', 0 ) } />
+		</Accordion>
+	);
+}
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const postId = getEditorPostId( state );
+	const post = getEditedPost( state, siteId, postId );
+	const postType = get( post, 'type' );
+	const hierarchical = 'page' === postType || get( getPostType( state, siteId, postType ), 'hierarchical' );
+
+	return { siteId, postId, post, postType, hierarchical };
+} )( localize( EditorDrawerPageOptions ) );

--- a/client/post-editor/editor-drawer/page-options.jsx
+++ b/client/post-editor/editor-drawer/page-options.jsx
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getEditedPost } from 'state/posts/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import PageParent from 'post-editor/editor-page-parent';
@@ -49,9 +49,8 @@ function EditorDrawerPageOptions( { translate, siteId, postId, post, postType, h
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
-	const post = getEditedPost( state, siteId, postId );
-	const postType = get( post, 'type' );
+	const postType = getEditedPostValue( state, siteId, postId, 'type' );
 	const hierarchical = 'page' === postType || get( getPostType( state, siteId, postType ), 'hierarchical' );
 
-	return { siteId, postId, post, postType, hierarchical };
+	return { siteId, postId, postType, hierarchical };
 } )( localize( EditorDrawerPageOptions ) );

--- a/client/post-editor/editor-page-templates/index.jsx
+++ b/client/post-editor/editor-page-templates/index.jsx
@@ -75,11 +75,17 @@ export default React.createClass( {
 	},
 
 	_getSelectedTemplateText() {
-		let post = this.props.post;
-		let selectedTemplate = find( this.props.pageTemplates, ( template ) => template.file === post.page_template );
+		const { post, pageTemplates } = this.props;
+
+		let selectedTemplate;
+		if ( post ) {
+			selectedTemplate = find( pageTemplates, { file: post.page_template } );
+		}
+
 		if ( selectedTemplate ) {
 			return selectedTemplate.label;
 		}
+
 		return this.translate( 'Default Template' );
 	}
 


### PR DESCRIPTION
Closes #7007 

This pull request seeks to update the post editor Page Options accordion to be more generalized in supporting custom post types. Specifically, while the accordion was previously driven by post type support for `page-attributes`, this was not specific enough to accurately reflect support for page parent or page template (see https://github.com/Automattic/wp-calypso/issues/7007#issuecomment-235399421 for more information).

With these changes, I've changed the accordion name from "Page Options" ("Options" for custom post types) to "Page Attributes" ("Attributes" for custom post types). The reasoning for this is (a) to avoid confusion between "Options" and "More Options" (separate accordions) and (b) to align with core WordPress, where these labels are used ([reference](https://github.com/WordPress/WordPress/blob/de5a513027e852de6597b6cbfdc3ef94ef56f8ed/wp-admin/edit-form-advanced.php#L262-L263)).

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/17156175/6b675870-5356-11e6-9093-bcb88c0c1318.png)|![After](https://cloud.githubusercontent.com/assets/1779930/17156177/6f43d284-5356-11e6-98b1-5ad4c2a8d1a5.png)

__Testing instructions:__

Since this accordion is used in the production page editor, verify that no regressions have occurred with managing page parent, page template, or order for [page editing](http://calypso.localhost:3000/page).

Further, verify that "Attributes" input fields for custom post types match expected support as described at https://github.com/Automattic/wp-calypso/issues/7007#issuecomment-235399421 . It may help to compare the Attributes available in wp-admin for the same post type. For example, [Testimonials editor](http://calypso.localhost:3000/edit/jetpack-testimonial) should should "Attributes" as the accordion label and contain only an Order field.

Test live: https://calypso.live/?branch=update/7007-editor-cpt-page-options