### PR TITLE
Plans: launch plans redesign to production

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -61,15 +61,6 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
-	planFeatures: {
-		datestamp: '20160720',
-		variations: {
-			original: 50,
-			show: 50
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: false
-	},
 	signupStore: {
 		datestamp: '20160707',
 		variations: {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -183,7 +183,7 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalTy
 }
 
 export const isPlanFeaturesEnabled = () => {
-	return true;
+	return isEnabled( 'manage/plan-features' );
 };
 
 export function plansLink( url, site, intervalType ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -30,7 +30,6 @@ import {
 } from 'lib/plans/constants';
 import { createSitePlanObject } from 'state/sites/plans/assembler';
 import SitesList from 'lib/sites-list';
-import { abtest } from 'lib/abtest';
 
 /**
  * Module vars
@@ -184,7 +183,7 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalTy
 }
 
 export const isPlanFeaturesEnabled = () => {
-	return isEnabled( 'manage/plan-features' ) && abtest( 'planFeatures' ) === 'show';
+	return true;
 };
 
 export function plansLink( url, site, intervalType ) {


### PR DESCRIPTION
This PR will launch the plans redesign to 100% for everyone on wordpress.com. Holding off on merging this until we finish the test and ensure we have good i18n coverage.

I'm holding off on any other refactoring and am using this PR just for the launch for web users.

Test live: https://calypso.live/?branch=update/launch-plans-redesign