### PR TITLE
Framework: Fix screen title state updates from update actions

### DIFF
--- a/client/lib/screen-title/index.js
+++ b/client/lib/screen-title/index.js
@@ -1,22 +1,9 @@
 /**
- * External dependencies
- */
-import includes from 'lodash/includes';
-
-/**
  * Internal dependencies
  */
 import { DOCUMENT_HEAD_TITLE_SET, DOCUMENT_HEAD_UNREAD_COUNT_SET } from 'state/action-types';
-import { setTitle as legacySetTitle } from './actions';
+import { setTitle as legacySetTitle, setCount as legacySetCount } from './actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-
-/**
- * Constants
- */
-const TITLE_UPDATING_ACTIONS = [
-	DOCUMENT_HEAD_TITLE_SET,
-	DOCUMENT_HEAD_UNREAD_COUNT_SET
-];
 
 /**
  * Middleware that updates the screen title when a title updating action is
@@ -26,16 +13,15 @@ const TITLE_UPDATING_ACTIONS = [
  * @param {Object} store Redux store instance
  * @returns {Function} A configured middleware with store
  */
-export const screenTitleMiddleware = store => next => action => {
-	if ( action && includes( TITLE_UPDATING_ACTIONS, action.type ) ) {
-		const state = store.getState();
-		const { title, unreadCount } = state.documentHead;
-		const siteId = getSelectedSiteId( state );
+export const screenTitleMiddleware = ( { getState } ) => ( next ) => ( action ) => {
+	switch ( action.type ) {
+		case DOCUMENT_HEAD_TITLE_SET:
+			legacySetTitle( action.title, { siteID: getSelectedSiteId( getState() ) } );
+			break;
 
-		legacySetTitle( title, {
-			siteID: siteId,
-			count: unreadCount
-		} );
+		case DOCUMENT_HEAD_UNREAD_COUNT_SET:
+			legacySetCount( action.count, { siteID: getSelectedSiteId( getState() ) } );
+			break;
 	}
 
 	return next( action );

--- a/client/state/document-head/middleware.js
+++ b/client/state/document-head/middleware.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { DOCUMENT_HEAD_TITLE_SET, DOCUMENT_HEAD_UNREAD_COUNT_SET } from 'state/action-types';
-import { setTitle as legacySetTitle, setCount as legacySetCount } from './actions';
+import { setTitle as legacySetTitle, setCount as legacySetCount } from 'lib/screen-title/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
@@ -13,7 +13,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
  * @param {Object} store Redux store instance
  * @returns {Function} A configured middleware with store
  */
-export const screenTitleMiddleware = ( { getState } ) => ( next ) => ( action ) => {
+export default ( { getState } ) => ( next ) => ( action ) => {
 	switch ( action.type ) {
 		case DOCUMENT_HEAD_TITLE_SET:
 			legacySetTitle( action.title, { siteID: getSelectedSiteId( getState() ) } );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -77,15 +77,14 @@ export const reducer = combineReducers( {
 	wordads
 } );
 
-let middleware = [ thunkMiddleware, noticesMiddleware ];
+const middleware = [ thunkMiddleware, noticesMiddleware ];
 
-// Analytics middleware currently only works in the browser
 if ( typeof window === 'object' ) {
-	middleware = [
-		require( 'lib/screen-title' ).screenTitleMiddleware,
-		...middleware,
+	// Browser-specific middlewares
+	middleware.push(
+		require( './document-head/middleware' ),
 		require( './analytics/middleware.js' ).analyticsMiddleware
-	];
+	);
 }
 
 let createStoreWithMiddleware = applyMiddleware.apply( null, middleware );


### PR DESCRIPTION
Related: #6669 

This pull request seeks to resolve an issue where updates to Redux `documentHead` title state are not accurately reflected in the screen's title because the middleware introduced in #6669 reads from the current state title value before the action has been applied (i.e. before the title has changed in state). Rather, it should call the legacy actions using the title value as defined in the actions for which it is concerned.

__Testing instructions:__

This is most obvious in the post editor when saving a new post. The title should change from "New Post" to "Edit Post" ([see `<EditorDocumentHead />`](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-document-head/index.jsx)). With these changes, you should observe that this occurs correctly.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Note that the screen title is "New Post"
4. Enter a title and/or content
5. Save the post
6. Note that the screen title is "Edit Post"

/cc @yurynix , @drewblaisdell , @spncrb 

Test live: https://calypso.live/?branch=fix/screen-title-middleware-title