### PR TITLE
Editor: Revert "Extend PureComponent in WebPreview"

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import noop from 'lodash/noop';
+import shallowCompare from 'react-addons-shallow-compare';
 
 /**
  * Internal dependencies
@@ -60,6 +61,10 @@ export class WebPreview extends Component {
 			document.documentElement.classList.add( 'no-scroll', 'is-previewing' );
 		}
 		this.props.setPreviewShowing( this.props.showPreview );
+	}
+
+	shouldComponentUpdate( nextProps, nextState ) {
+		return shallowCompare( this, nextProps, nextState );
 	}
 
 	componentDidUpdate( prevProps ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#6956

Test live: https://calypso.live/?branch=revert-6956-update/web-preview-pure-render