### PR TITLE
Domains: Fix privacy protection details for non-WWD domains

### DIFF
--- a/client/lib/domains/whois/protected-contact-information.js
+++ b/client/lib/domains/whois/protected-contact-information.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import {
+	endsWith,
+	some
+} from 'lodash';
+
+const OPENSRS_TLDS = [ '.live' ],
+	OPENHRS_TLDS = [
+		'.net',
+		'.wales'
+	];
+
+function domainEndsWithTld( domain, tlds ) {
+	return some( tlds, ( tld ) => endsWith( domain, tld ) );
+}
+
+function getOpenHrsProtectedContactInformation( domain ) {
+	return {
+		firstName: 'Private',
+		lastName: 'Whois',
+		organization: 'Knock Knock Whois Not There LLC',
+		email: `${ domain }@privatewho.is`,
+		phone: '+1.8772738550',
+		address1: '60, 29th Street, #343',
+		address2: '',
+		city: 'San Francisco',
+		state: 'CA',
+		postalCode: '94110-4929',
+		countryCode: 'US'
+	};
+}
+
+function getOpenSrsProtectedContactInformation( domain ) {
+	return {
+		firstName: 'Contact Privacy Inc.',
+		lastName: 'Customer 012345',
+		organization: 'Contact Privacy Inc. Customer 012345',
+		email: `${ domain }@contactprivacy.com`,
+		phone: '+1.4165385457',
+		address1: '96 Mowat Ave',
+		address2: '',
+		city: 'Toronto',
+		state: 'ON',
+		postalCode: 'M6K 3M1',
+		countryCode: 'CA'
+	};
+}
+
+function getWwdProtectedContactInformation( domain ) {
+	return {
+		firstName: 'Registration',
+		lastName: 'Private',
+		organization: 'Domains By Proxy, LLC',
+		email: `${ domain }@domainsbyproxy.com`,
+		phone: '+1.4806242599',
+		fax: '+1.4806242598',
+		address1: 'DomainsByProxy.com',
+		address2: '14747 N Northsight Blvd Suite 111, PMB 309',
+		city: 'Scottsdale',
+		state: 'AZ',
+		postalCode: '85260',
+		countryCode: 'US'
+	};
+}
+
+function getProtectedContactInformation( domain ) {
+	if ( domainEndsWithTld( domain, OPENHRS_TLDS ) ) {
+		return getOpenHrsProtectedContactInformation( domain );
+	} else if ( domainEndsWithTld( domain, OPENSRS_TLDS ) ) {
+		return getOpenSrsProtectedContactInformation( domain );
+	}
+	return getWwdProtectedContactInformation( domain );
+}
+
+export default getProtectedContactInformation;

--- a/client/my-sites/upgrades/checkout/privacy-protection-dialog.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection-dialog.jsx
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-const React = require( 'react' );
+const React = require( 'react' ),
+	transform = require( 'lodash/transform' );
 
 /**
  * Internal dependencies
  */
 const Dialog = require( 'components/dialog' ),
-	PrivacyProtectionExample = require( './privacy-protection-example' );
+	PrivacyProtectionExample = require( './privacy-protection-example' ),
+	getProtectedContactInformation = require( 'lib/domains/whois/protected-contact-information' );
 
 module.exports = React.createClass( {
 	displayName: 'PrivacyProtectionDialog',
@@ -18,20 +20,10 @@ module.exports = React.createClass( {
 		};
 	},
 
-	getProtectedFields: function() {
-		return {
-			firstName: {},
-			lastName: {},
-			organization: { value: 'Domains By Proxy, LLC' },
-			email: { value: this.props.domain + '@domainsbyproxy.com' },
-			phone: { value: '+1.4806242599' },
-			address1: { value: '14747 N Northsight Blvd' },
-			address2: { value: 'Suite 111, PMB 309' },
-			city: { value: 'Scottsdale' },
-			state: { value: 'AZ' },
-			postalCode: { value: '85260' },
-			countryCode: { value: 'US' }
-		};
+	formatAsFields: function( contactInformation ) {
+		return transform( contactInformation, ( result, value, key ) => {
+			result[ key ] = { value };
+		}, {} );
 	},
 
 	render: function() {
@@ -68,7 +60,7 @@ module.exports = React.createClass( {
 						</div>
 						<PrivacyProtectionExample
 							countriesList= { this.props.countriesList }
-							fields={ this.getProtectedFields() } />
+							fields={ this.formatAsFields( getProtectedContactInformation( this.props.domain ) ) } />
 						<button
 								className="button is-primary"
 								disabled={ this.props.disabled }

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -708,8 +708,8 @@
 				display: block;
 				height: 25px;
 				position: absolute;
-					left: -8px;
-					top: -8px;
+				left: -8px;
+				top: -8px;
 				width: 25px;
 			}
 
@@ -750,7 +750,7 @@
 				background: $gray-light;
 				font-size: 12px;
 				margin: 20px -20px;
-				min-height: 126px;
+				min-height: 144px;
 				padding: 20px;
 
 				span {


### PR DESCRIPTION
For our non-WWD domains we are using different privacy services than Domains By Proxy:
- for OpenHRS (currently `.wales` only), we are using Knock Knock Whois Not There LLC
- for OpenSRS (currently `.live` only), we are using Contact Privacy Inc.

This PR selects the correct privacy service's details based on the selected TLD and displays that information in two places:
- in `Contacts and Privacy` view public record preview
  **WWD domain with privacy**
  <img width="748" alt="screen shot 2016-07-27 at 10 54 56" src="https://cloud.githubusercontent.com/assets/3392497/17169876/eae26700-53e9-11e6-9e63-4f15d2492fff.png">
  **OpenHRS domain with privacy**
  <img width="768" alt="screen shot 2016-07-27 at 10 55 36" src="https://cloud.githubusercontent.com/assets/3392497/17169878/eb1b55c4-53e9-11e6-84c0-9914eac9ed19.png">
  **OpenSRS domain with privacy**
  <img width="770" alt="screen shot 2016-07-27 at 10 56 32" src="https://cloud.githubusercontent.com/assets/3392497/17169879/eb1d71ce-53e9-11e6-9ba7-07ca38838e6b.png">
  **Any domain with privacy disabled** (try initiating transfer to disable privacy temporarily)
  <img width="760" alt="screen shot 2016-07-27 at 11 04 14" src="https://cloud.githubusercontent.com/assets/3392497/17169877/eb199d4c-53e9-11e6-98e1-a3fb78328020.png">
- during checkout, when comparing privacy protected domain vs public one
  **WWD domain during checkout**
  <img width="704" alt="screen shot 2016-07-27 at 11 05 41" src="https://cloud.githubusercontent.com/assets/3392497/17169985/67dd2e84-53ea-11e6-9fff-584cca22aae8.png">
  **OpenHRS domain during checkout**
  <img width="699" alt="screen shot 2016-07-27 at 11 06 55" src="https://cloud.githubusercontent.com/assets/3392497/17169988/681e2754-53ea-11e6-9cab-d13191b4681a.png">
  **OpenSRS domain during checkout**
  <img width="690" alt="screen shot 2016-07-27 at 11 07 52" src="https://cloud.githubusercontent.com/assets/3392497/17169987/6812dd9a-53ea-11e6-8d94-48f789be8e8e.png">

Please note that there's some disrepancy between what WHOIS tells you right now for private OpenHRS domains and what is set in code in this PR. I've talked with @wensco and we need to make small changes to our First, Last and Organization Names - they should (and will, soon) read:
First Name: Private
Last Name: Whois
Organization Name: Knock Knock Whois Not There LLC 

Fixes #6920 and #6938.

cc @aidvu @umurkontaci @wensco 

Test live: https://calypso.live/?branch=fix/protected-contact-information
