### PR TITLE
Framework: Exit failing build with non-0 return for non-dev builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ var CALYPSO_ENV = process.env.CALYPSO_ENV || 'development',
 const sectionCount = sections.length;
 
 webpackConfig = {
+	bail: CALYPSO_ENV !== 'development',
 	cache: true,
 	entry: {},
 	devtool: '#eval',


### PR DESCRIPTION
Prevent code with compile errors building successfully anywhere except `development` environment. This will prevent failing builds being deployed to servers, as happened recently with #7021.

**Todo**
- [ ] Check that this actually does halt a non-dev build using a docker build

cc @ehg 

Test live: https://calypso.live/?branch=modify/build-bail