### PR TITLE
Add locale variants support

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -22,6 +22,7 @@ import {
 } from 'state/current-user/actions';
 import { setRoute as setRouteAction } from 'state/ui/actions';
 import switchLocale from 'lib/i18n-utils/switch-locale';
+import localeVariants from 'lib/i18n-utils/locale-variants';
 import touchDetect from 'lib/touch-detect';
 
 const debug = debugFactory( 'calypso' );
@@ -30,6 +31,7 @@ const switchUserLocale = currentUser => {
 	const localeSlug = currentUser.get().localeSlug;
 	if ( localeSlug ) {
 		switchLocale( localeSlug );
+		localeVariants.init( userSettings.getSetting( 'locale_variant' ) );
 	}
 };
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -23,6 +23,7 @@ import {
 import { setRoute as setRouteAction } from 'state/ui/actions';
 import switchLocale from 'lib/i18n-utils/switch-locale';
 import localeVariants from 'lib/i18n-utils/locale-variants';
+import userSettings from 'lib/user-settings';
 import touchDetect from 'lib/touch-detect';
 
 const debug = debugFactory( 'calypso' );

--- a/client/lib/i18n-utils/locale-variants.js
+++ b/client/lib/i18n-utils/locale-variants.js
@@ -44,5 +44,4 @@ const localeVariants = {
 	}
 };
 
-userSettings.on( 'change', localeVariants.init.bind( localeVariants ) );
 export default localeVariants;

--- a/client/lib/i18n-utils/locale-variants.js
+++ b/client/lib/i18n-utils/locale-variants.js
@@ -14,18 +14,19 @@ const debug = debugFactory( 'calypso:i18n' );
 
 const localeVariants = {
 	init() {
-		const locale_variant = userSettings.getSetting( 'locale_variant' );
-		switch ( locale_variant ) {
+		const localeVariant = userSettings.getSetting( 'locale_variant' );
+		switch ( localeVariant ) {
 			case 'sr_latin':
+				debug( 'Applying mods for ' + localeVariant );
 				i18n.registerTranslateHook( ( translation ) => {
-					return this.cyrillic_to_latin( translation );
+					return this.cyrillicToLatin( translation );
 				} );
 				i18n.reRenderTranslations();
 				break;
 		}
 	},
 
-	cyrillic_to_latin( translation ) {
+	cyrillicToLatin( translation ) {
 		switch ( typeof( translation ) ) {
 			case 'object':
 				for ( let prop in translation ) {

--- a/client/lib/i18n-utils/locale-variants.js
+++ b/client/lib/i18n-utils/locale-variants.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import to_latin from 'cyrillic-to-latin';
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import userSettings from 'lib/user-settings';
+
+const debug = debugFactory( 'calypso:i18n' );
+
+const localeVariants = {
+	init() {
+		const locale_variant = userSettings.getSetting( 'locale_variant' );
+		switch ( locale_variant ) {
+			case 'sr_latin':
+				i18n.registerTranslateHook( ( translation ) => {
+					return this.cyrillic_to_latin( translation );
+				} );
+				i18n.reRenderTranslations();
+				break;
+		}
+	},
+
+	cyrillic_to_latin( translation ) {
+		switch ( typeof( translation ) ) {
+			case 'object':
+				for ( let prop in translation ) {
+					if ( typeof prop === 'string' ) {
+						prop = to_latin( prop );
+					}
+				}
+				break;
+			case 'string':
+				translation = to_latin( translation );
+				break;
+		}
+
+		return translation;
+	}
+};
+
+userSettings.on( 'change', localeVariants.init.bind( localeVariants ) );
+export default localeVariants;

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -9,25 +9,24 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import config from 'config';
+import i18nUtils from 'lib/i18n-utils';
 
 const debug = debugFactory( 'calypso:i18n' );
 
-function languageFileUrl( localeSlug ) {
-	var protocol = typeof window === 'undefined' ? 'https://' : '//'; // use a protocol-relative path in the browser
-	return `${ protocol }widgets.wp.com/languages/calypso/${ localeSlug }.json`;
-}
-
 export default function switchLocale( localeSlug ) {
+
 	if ( localeSlug === i18n.getLocaleSlug() ) {
 		return;
 	}
+
+	debug( 'Switching locale to ' + localeSlug );
 
 	if ( localeSlug === config( 'i18n_default_locale_slug' ) ) {
 		i18n.configure( { defaultLocaleSlug: localeSlug } );
 		return;
 	}
 
-	request.get( languageFileUrl( localeSlug ) ).end( function( error, response ) {
+	request.get( i18nUtils.languageFileUrl( localeSlug ) ).end( function( error, response ) {
 		if ( error ) {
 			debug( 'Encountered an error loading locale file for ' + localeSlug + '. Falling back to English.' );
 			return;

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -14,7 +14,6 @@ import i18nUtils from 'lib/i18n-utils';
 const debug = debugFactory( 'calypso:i18n' );
 
 export default function switchLocale( localeSlug ) {
-
 	if ( localeSlug === i18n.getLocaleSlug() ) {
 		return;
 	}

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -8,8 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-
-import { removeLocaleFromPath, addLocaleToPath, getLanguage, getLocaleFromPathm, languageFileUrl } from 'lib/i18n-utils';
+import { removeLocaleFromPath, addLocaleToPath, getLanguage, languageFileUrl } from 'lib/i18n-utils';
 
 describe( 'utils', function() {
 	describe( '#addLocaleToPath', function() {

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -8,7 +8,8 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { removeLocaleFromPath, addLocaleToPath, getLanguage, getLocaleFromPath } from 'lib/i18n-utils';
+
+import { removeLocaleFromPath, addLocaleToPath, getLanguage, getLocaleFromPathm, languageFileUrl } from 'lib/i18n-utils';
 
 describe( 'utils', function() {
 	describe( '#addLocaleToPath', function() {
@@ -101,6 +102,12 @@ describe( 'utils', function() {
 
 		it( 'should return a language with a three letter country code', function() {
 			expect( getLanguage( 'ast' ).langSlug ).to.equal( 'ast' );
+		} );
+	} );
+
+	describe( '#languageFileUrl', function() {
+		it( 'should return the url', function() {
+			expect( languageFileUrl( 'ja' ) ).to.equal( 'https://widgets.wp.com/languages/calypso/ja.json' );
 		} );
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -9,7 +9,7 @@ import url from 'url';
  */
 import config from 'config';
 
-const localeRegex = /^[A-Z]{2,3}(-[A-Z]{2,3})?(_[A-Z]*)?$/i;
+const localeRegex = /^[A-Z]{2,3}(-[A-Z]{2,3})?(_[A-Z]{2,12})?$/i;
 
 function getPathParts( path ) {
 	// Remove trailing slash then split. If there is a trailing slash,
@@ -72,6 +72,12 @@ const i18nUtils = {
 		}
 
 		return parts.join( '/' ) + queryString;
+	},
+
+	languageFileUrl: function( localeSlug ) {
+		const protocol = typeof window === 'undefined' ? 'https://' : '//'; // use a protocol-relative path in the browser
+		return `${ protocol }widgets.wp.com/languages/calypso/${ localeSlug }.json`;
 	}
+
 };
 export default i18nUtils;

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -9,8 +9,7 @@ import url from 'url';
  */
 import config from 'config';
 
-const localeRegex = /^[A-Z]{2,3}$/i;
-const localeWithRegionRegex = /^[A-Z]{2,3}-[A-Z]{2,3}$/i;
+const localeRegex = /^[A-Z]{2,3}(-[A-Z]{2,3})?(_[A-Z]*)?$/i;
 
 function getPathParts( path ) {
 	// Remove trailing slash then split. If there is a trailing slash,
@@ -21,7 +20,8 @@ function getPathParts( path ) {
 const i18nUtils = {
 	getLanguage: function( langSlug ) {
 		let language;
-		if ( localeRegex.test( langSlug ) || localeWithRegionRegex.test( langSlug ) ) {
+
+		if ( localeRegex.test( langSlug ) ) {
 			language = find( config( 'languages' ), { langSlug: langSlug } ) ||
 				find( config( 'languages' ), { langSlug: langSlug.substring( 0, 2 ) } );
 		}

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -20,7 +20,6 @@ function getPathParts( path ) {
 const i18nUtils = {
 	getLanguage: function( langSlug ) {
 		let language;
-
 		if ( localeRegex.test( langSlug ) ) {
 			language = find( config( 'languages' ), { langSlug: langSlug } ) ||
 				find( config( 'languages' ), { langSlug: langSlug.substring( 0, 2 ) } );

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -229,10 +229,11 @@ UserSettings.prototype.updateSetting = function( settingName, value ) {
 		 * If the two match, we don't consider the setting "changed".
 		 * user_login is a special case since the logic for validating and saving a username
 		 * is more complicated.
+		 * language is a special case too because a user may switch form a variant to the parent
 		 */
 		if (
 			this.settings[ settingName ] === this.unsavedSettings[ settingName ] &&
-			'user_login' !== settingName
+			'user_login' !== settingName && 'language' !== settingName
 		) {
 			debug( 'Removing ' + settingName + ' from changed settings.' );
 			delete this.unsavedSettings[ settingName ];

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -7,6 +7,7 @@ import qs from 'querystring';
  * Internal dependencies
  */
 import { getCurrentUserLocale } from 'state/current-user/selectors';
+import userSettings from 'lib/user-settings';
 
 /**
  * Module variables
@@ -76,7 +77,8 @@ export function injectLocalization( wpcom ) {
  */
 export function bindState( store ) {
 	function setLocaleFromState() {
-		setLocale( getCurrentUserLocale( store.getState() ) );
+		const requestLocale = userSettings.getSetting( 'locale_variant' ) || getCurrentUserLocale( store.getState() );
+		setLocale( requestLocale );
 	}
 
 	store.subscribe( setLocaleFromState );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -84,6 +84,12 @@ const Account = React.createClass( {
 		this.debouncedUsernameValidate = debounce( this.validateUsername, 600 );
 	},
 
+	componentDidUpdate( ) {
+		if ( ! this.state.langSlug ) {
+			this.setState( { langSlug: this.props.userSettings.getOriginalSetting( 'locale_variant' ) || this.props.userSettings.getOriginalSetting( 'language' ) } );
+		}
+	},
+
 	componentWillUnmount() {
 		debug( this.constructor.displayName + ' component is unmounting.' );
 	},
@@ -106,7 +112,17 @@ const Account = React.createClass( {
 
 	updateLanguage( event ) {
 		const { value } = event.target;
-		const originalLanguage = this.props.userSettings.getOriginalSetting( 'language' );
+		const originalLanguage = this.props.userSettings.getOriginalSetting( 'locale_variant' ) || this.props.userSettings.getOriginalSetting( 'language' );
+
+		this.props.userSettings.updateSetting( 'language', value );
+		this.setState( { langSlug: value } );
+
+		if ( value !== originalLanguage ) {
+			this.setState( { redirect: '/me/account' } );
+		} else {
+			this.setState( { redirect: false } );
+		}
+
 
 		this.updateUserSetting( 'language', value );
 		const redirect = value !== originalLanguage ? '/me/account' : false;

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -84,9 +84,11 @@ const Account = React.createClass( {
 		this.debouncedUsernameValidate = debounce( this.validateUsername, 600 );
 	},
 
-	componentDidUpdate( ) {
-		if ( ! this.state.langSlug ) {
-			this.setState( { langSlug: this.props.userSettings.getOriginalSetting( 'locale_variant' ) || this.props.userSettings.getOriginalSetting( 'language' ) } );
+	componentDidUpdate() {
+		const originalLangSlug = this.props.userSettings.getOriginalSetting( 'locale_variant' ) || this.props.userSettings.getOriginalSetting( 'language' )
+
+		if (  originalLangSlug !== null && ! this.state.langSlug ) {
+			this.setState( { langSlug: originalLangSlug } );
 		}
 	},
 
@@ -540,7 +542,8 @@ const Account = React.createClass( {
 						name="language"
 						onFocus={ this.recordFocusEvent( 'Interface Language Field' ) }
 						valueKey="langSlug"
-						value={ this.getUserSetting( 'language' ) || '' }
+						value={ this.state.langSlug }
+						defaultValue={ this.props.userSettings.getOriginalSetting( 'locale_variant' ) || this.props.userSettings.getOriginalSetting( 'language' ) }
 						onChange={ this.updateLanguage }
 					/>
 					{ this.thankTranslationContributors() }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -85,7 +85,7 @@ const Account = React.createClass( {
 	},
 
 	componentDidUpdate() {
-		const originalLangSlug = this.props.userSettings.getOriginalSetting( 'locale_variant' ) || this.props.userSettings.getOriginalSetting( 'language' )
+		const originalLangSlug = this.getOriginalUserSetting( 'locale_variant' ) || this.getOriginalUserSetting( 'language' );
 
 		if (  originalLangSlug !== null && ! this.state.langSlug ) {
 			this.setState( { langSlug: originalLangSlug } );
@@ -98,6 +98,10 @@ const Account = React.createClass( {
 
 	getUserSetting( settingName ) {
 		return this.props.userSettings.getSetting( settingName );
+	},
+
+	getOriginalUserSetting( settingName ) {
+		return this.props.userSettings.getOriginalSetting( settingName );
 	},
 
 	updateUserSetting( settingName, value ) {
@@ -114,17 +118,8 @@ const Account = React.createClass( {
 
 	updateLanguage( event ) {
 		const { value } = event.target;
-		const originalLanguage = this.props.userSettings.getOriginalSetting( 'locale_variant' ) || this.props.userSettings.getOriginalSetting( 'language' );
-
-		this.props.userSettings.updateSetting( 'language', value );
+		const originalLanguage = this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' );
 		this.setState( { langSlug: value } );
-
-		if ( value !== originalLanguage ) {
-			this.setState( { redirect: '/me/account' } );
-		} else {
-			this.setState( { redirect: false } );
-		}
-
 
 		this.updateUserSetting( 'language', value );
 		const redirect = value !== originalLanguage ? '/me/account' : false;
@@ -543,7 +538,7 @@ const Account = React.createClass( {
 						onFocus={ this.recordFocusEvent( 'Interface Language Field' ) }
 						valueKey="langSlug"
 						value={ this.state.langSlug }
-						defaultValue={ this.props.userSettings.getOriginalSetting( 'locale_variant' ) || this.props.userSettings.getOriginalSetting( 'language' ) }
+						defaultValue={ this.getOriginalUserSetting( 'locale_variant' ) || this.getOriginalUserSetting( 'language' ) }
 						onChange={ this.updateLanguage }
 					/>
 					{ this.thankTranslationContributors() }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -146,7 +146,7 @@
 		{ "value": 459, "langSlug": "so", "name": "Afsoomaali", "wpLocale": "so_SO" },
 		{ "value": 66, "langSlug": "sq", "name": "Shqip", "wpLocale": "sq" },
 		{ "value": 67, "langSlug": "sr", "name": "Српски језик", "wpLocale": "sr_RS" },
-		{ "value": 901, "langSlug": "sr_latin",	"name": "Srpski (latinica)", "wpLocale": "sr_RS", "parent_lang_id": 67 },
+		{ "value": 901, "langSlug": "sr_latin",	"name": "Srpski (latinica)", "wpLocale": "sr_RS", "parent_locale_slug": "sr" },
 		{ "value": 441, "langSlug": "su", "name": "Basa Sunda", "wpLocale": "su_ID" },
 		{ "value": 68, "langSlug": "sv", "name": "Svenska", "wpLocale": "sv_SE", "popular": 17 },
 		{ "value": 69, "langSlug": "ta", "name": "தமிழ்", "wpLocale": "ta_IN" },

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -146,6 +146,7 @@
 		{ "value": 459, "langSlug": "so", "name": "Afsoomaali", "wpLocale": "so_SO" },
 		{ "value": 66, "langSlug": "sq", "name": "Shqip", "wpLocale": "sq" },
 		{ "value": 67, "langSlug": "sr", "name": "Српски језик", "wpLocale": "sr_RS" },
+		{ "value": 901, "langSlug": "sr_latin",	"name": "Srpski (latinica)", "wpLocale": "sr_RS", "parent_lang_id": 67 },
 		{ "value": 441, "langSlug": "su", "name": "Basa Sunda", "wpLocale": "su_ID" },
 		{ "value": 68, "langSlug": "sv", "name": "Svenska", "wpLocale": "sv_SE", "popular": 17 },
 		{ "value": 69, "langSlug": "ta", "name": "தமிழ்", "wpLocale": "ta_IN" },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "copy-webpack-plugin": "3.0.1",
     "create-react-class": "15.5.3",
     "creditcards": "2.1.2",
+    "cyrillic-to-latin": "2.0.0",
     "debug": "2.2.0",
     "doctrine": "2.0.0",
     "dom-helpers": "2.4.0",


### PR DESCRIPTION
The purpose of this PR is to add support for WP.COM **locale variants** to Calypso.

Locale variants are (relatively) small variations of existing locales that either need to load a limited amount of different translations and/or run additional code on existing translations.

**Examples:** 
- _sr_latin_ (included in this PR): this enables Serbian users to use WordPress.com with a latin alphabet, rather than the default Cyrillic  (see #6734)
- _de_formal_: a small subset of the translations will need to be changed in order to accommodate a use in formal settings.

**What's included**
- The addition of the locale variants to the list of locales (`_shared.json`)
- Changes to the user settings to make sure a variant can be selected
- A localeVariants module that handles loading of the additional code where necessary.

**Testing Functionality**
- Select Serbian latin as your ui locale
- The page will reload and after a short delay all (translated) ui text should be rendered with latin chars. This should include contend provided by the wpcom API.
- Select  Serbian latin as your site locale
- Visit the site and notice how the (translated) theme strings are rendered using latin chars.
- (Compare the above with just "Serbian" for reference)

Fixes #6734

Test live: https://calypso.live/?branch=add/locale-variant-support
