### PR TITLE
Reader: decode tag names in empty message, and tidy up TagEmptyContent component

### DIFF
--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -1,32 +1,37 @@
-var React = require( 'react' );
+/**
+ * External dependencies
+ */
+import React from 'react';
 
-var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' ),
-	discoverHelper = require( 'reader/discover/helper' );
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'components/empty-content';
+import * as stats from 'reader/stats';
+import discoverHelper from 'reader/discover/helper';
 
-var TagEmptyContent = React.createClass( {
-
+const TagEmptyContent = React.createClass( {
 	propTypes: {
 		tag: React.PropTypes.string
 	},
 
-	shouldComponentUpdate: function() {
+	shouldComponentUpdate() {
 		return false;
 	},
 
-	recordAction: function() {
+	recordAction() {
 		stats.recordAction( 'clicked_following_on_empty' );
 		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
 		stats.recordTrack( 'calypso_reader_following_on_empty_tag_stream_clicked' );
 	},
 
-	recordSecondaryAction: function() {
+	recordSecondaryAction() {
 		stats.recordAction( 'clicked_discover_on_empty' );
 		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
 		stats.recordTrack( 'calypso_reader_discover_on_empty_tag_stream_clicked' );
 	},
 
-	render: function() {
+	render() {
 		const action = ( <a
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
@@ -40,7 +45,7 @@ var TagEmptyContent = React.createClass( {
 
 		const message = this.translate(
 			'No posts have recently been tagged with {{tagName /}} for your language.',
-			{ components: { tagName: <em>{ this.props.tag }</em> } }
+			{ components: { tagName: <em>{ decodeURIComponent( this.props.tag ) }</em> } }
 		);
 
 		return ( <EmptyContent
@@ -54,4 +59,4 @@ var TagEmptyContent = React.createClass( {
 	}
 } );
 
-module.exports = TagEmptyContent;
+export default TagEmptyContent;

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
-import has from 'lodash/has';
+import { has } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -15,8 +15,7 @@ import TagSubscriptions from 'lib/reader-tags/subscriptions';
 import StreamHeader from 'reader/stream-header';
 import HeaderBack from 'reader/header-back';
 import smartSetState from 'lib/react-smart-set-state';
-
-const stats = require( 'reader/stats' );
+import * as stats from 'reader/stats';
 
 const TagStream = React.createClass( {
 
@@ -51,7 +50,7 @@ const TagStream = React.createClass( {
 	},
 
 	updateState( props = this.props ) {
-		var newState = {
+		const newState = {
 			title: this.getTitle( props ),
 			subscribed: this.isSubscribed( props ),
 			canFollow: has( ReaderTags.get( props.tag ), 'ID' )
@@ -60,7 +59,7 @@ const TagStream = React.createClass( {
 	},
 
 	getTitle( props = this.props ) {
-		var tag = ReaderTags.get( props.tag );
+		const tag = ReaderTags.get( props.tag );
 		if ( ! ( tag && tag.ID ) ) {
 			ReaderTagActions.fetchTag( props.tag );
 			return props.tag;
@@ -70,7 +69,7 @@ const TagStream = React.createClass( {
 	},
 
 	isSubscribed( props = this.props ) {
-		var tag = ReaderTags.get( props.tag );
+		const tag = ReaderTags.get( props.tag );
 		if ( ! tag ) {
 			return false;
 		}
@@ -78,7 +77,7 @@ const TagStream = React.createClass( {
 	},
 
 	toggleFollowing( isFollowing ) {
-		var tag = ReaderTags.get( this.props.tag );
+		const tag = ReaderTags.get( this.props.tag );
 		ReaderTagActions[ isFollowing ? 'follow' : 'unfollow' ]( tag );
 		stats.recordAction( isFollowing ? 'followed_topic' : 'unfollowed_topic' );
 		stats.recordGaEvent( isFollowing ? 'Clicked Follow Topic' : 'Clicked Unfollow Topic', tag.slug );
@@ -89,9 +88,10 @@ const TagStream = React.createClass( {
 
 	render() {
 		const emptyContent = ( <EmptyContent tag={ this.props.tag } /> );
+		const title = decodeURIComponent( this.state.title );
 
 		if ( this.props.setPageTitle ) {
-			this.props.setPageTitle( this.state.title );
+			this.props.setPageTitle( title );
 		}
 
 		return (
@@ -100,7 +100,7 @@ const TagStream = React.createClass( {
 				<StreamHeader
 					isPlaceholder={ false }
 					icon={ <svg className="gridicon gridicon__tag" height="32" width="32" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M16 7H5c-1.105 0-2 .896-2 2v6c0 1.104.895 2 2 2h11l5-5-5-5z"/></g></svg> }
-					title={ this.state.title }
+					title={ title }
 					showFollow={ this.state.canFollow }
 					following={ this.state.subscribed }
 					onFollowToggle={ this.toggleFollowing } />


### PR DESCRIPTION
@blowery noticed that empty tag streams with an emoji-fied slug showed their URL-encoded name. For example:

http://calypso.localhost:3000/tag/%E2%AD%90%E2%AD%90%E2%AD%90%E2%AD%90

Before

<img width="795" alt="screen shot 2016-07-27 at 16 15 19" src="https://cloud.githubusercontent.com/assets/17325/17178506/01222984-5416-11e6-93b5-0d5e8a48232e.png">

After

<img width="790" alt="screen shot 2016-07-27 at 16 15 08" src="https://cloud.githubusercontent.com/assets/17325/17178507/0132f174-5416-11e6-923c-b3655df999d1.png">


Test live: https://calypso.live/?branch=fix/reader/decode-tag-names-in-empty-message