### PR TITLE
JS Errors: better path passing

### DIFF
--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -77,9 +77,10 @@ export default class ErrorLogger {
 	}
 
 	saveNewPath( newPath ) {
-		this.diagnosticData.extra.previousPaths.unshift( this.diagnosticData.path );
-		this.diagnosticData.extra.previousPaths = this.diagnosticData.extra.previousPaths.slice( 0, 4 );
-		this.diagnosticData.path = newPath;
+		const paths = this.diagnosticData.extra.previousPaths;
+		paths.unshift( newPath );
+		this.diagnosticData.extra.previousPaths = paths.slice( 0, 5 );
+		this.diagnosticData.calypso_path = newPath;
 	}
 
 	saveDiagnosticReducer( fn ) {

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -17,7 +17,7 @@ export default class ErrorLogger {
 	constructor() {
 		this.diagnosticData = {
 			extra: {
-				previousPaths: []
+				previous_paths: []
 			}
 		};
 		this.diagnosticReducers = [];
@@ -77,9 +77,9 @@ export default class ErrorLogger {
 	}
 
 	saveNewPath( newPath ) {
-		const paths = this.diagnosticData.extra.previousPaths;
+		const paths = this.diagnosticData.extra.previous_paths;
 		paths.unshift( newPath );
-		this.diagnosticData.extra.previousPaths = paths.slice( 0, 5 );
+		this.diagnosticData.extra.previous_paths = paths.slice( 0, 5 );
 		this.diagnosticData.calypso_path = newPath;
 	}
 


### PR DESCRIPTION
We are not correctly aggregating data in the `path` property, but once changed to `calypso_path`, aggregates correctly.
Turns out `path` is a reserved keyword in elasticsearch, Furtunately / by mistake we have `calypso_path` also already merged.

## Testing

- Build with `ENABLE_FEATURES=catch-js-errors make run`
- Assign yourself to the group that generates an error: `localStorage.setItem('log-errors', 'rest-api');`
- Reload
- Go to http://calypso.localhost:3000/plugins . IF you have a Jetpack site, you will get an error there. 
- Go to `kibana4/goto/7fa9e6ab34999aaae96350e15b20d29b` to see your error.
- See that `calypso_path` has correct data

Test live: https://calypso.live/?branch=update/error-logging-details

CC @rralian @lamosty @gwwar 