### PR TITLE
LikeButton: update CSS to use flex for alignment.

### DIFF
--- a/client/components/comment-button/style.scss
+++ b/client/components/comment-button/style.scss
@@ -1,4 +1,5 @@
 .comment-button {
+	align-items: center;
 	color: lighten( $gray, 10 );
 	display: inline-flex;
 	list-style-type: none;

--- a/client/components/like-button/style.scss
+++ b/client/components/like-button/style.scss
@@ -1,6 +1,7 @@
 .like-button {
-	display: inline-block;
-	padding: 3px 4px 4px 27px;
+	align-items: center;
+	display: inline-flex;
+	padding: 4px;
 	color: lighten( $gray, 10 );;
 	position: relative;
 	box-sizing: border-box;
@@ -8,7 +9,6 @@
 
 	.gridicon {
 		position: absolute;
-		top: 2px;
 		left: 0;
 	}
 
@@ -77,8 +77,14 @@
 	}
 }
 
+.like-button__like-icons {
+	height: 24px;
+	width: 24px;
+}
+
 .like-button__label {
 	// this keeps the label from collapsing and making the icon drop down
 	margin-left: 1px;
 	font-size: 14px;
+	min-width: 10px;
 }

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -218,10 +218,6 @@
 	padding-left: 20px;
 }
 
-.post-card__search .comment-button .gridicon {
-	top: 1px;
-}
-
 .post-card__search-byline {
 	font-size: 13px;
 	list-style: none;

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -218,10 +218,6 @@
 	padding-left: 20px;
 }
 
-.post-card__search .like-button .gridicon {
-	top: 2px;
-}
-
 .post-card__search .comment-button .gridicon {
 	top: 1px;
 }

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -163,6 +163,7 @@
 	font-size: 14px;
 	color: $gray;
 	display: flex;
+	align-items: center;
 
 	li {
 		margin-right: 8px;


### PR DESCRIPTION
It also sets a min-width on the like number to avoid shuffling the width for single digit increments.

![image](https://cloud.githubusercontent.com/assets/548849/17181417/5d973164-5420-11e6-85de-d63007411157.png)


----

Before:
![image](https://cloud.githubusercontent.com/assets/548849/17181384/3efd99e6-5420-11e6-84c3-edb56e4c163a.png)

After:
![image](https://cloud.githubusercontent.com/assets/548849/17181368/2ea8708e-5420-11e6-8f26-9587b18c098c.png)


Test live: https://calypso.live/?branch=update/like-button-with-flex