### PR TITLE
State: Jetpack Connect

### DIFF
--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -121,12 +121,13 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_AUTHORIZE:
 			return Object.assign(
 				{},
-				state,
+				omit( state, 'userData', 'bearerToken' ),
 				{
 					isAuthorizing: true,
 					authorizeSuccess: false,
 					authorizeError: false,
-					isRedirectingToWpAdmin: false
+					isRedirectingToWpAdmin: false,
+					autoAuthorize: false
 				}
 			);
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE:
@@ -206,7 +207,8 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 				{
 					isAuthorizing: true,
 					authorizeSuccess: false,
-					authorizeError: false
+					authorizeError: false,
+					autoAuthorize: true
 				}
 			);
 		case JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE:


### PR DESCRIPTION
Adjusting logic for when we auto-authorize a Jetpack connection.
The Safari browser was getting into a race condition where it would not pick up the `autoAuthorize` property.

To test:
- Check out this branch
- Ensure you can still connect sites as expected via calypso.localhost:3000/jetpack/connect

cc: @ryelle @johnHackworth 

Test live: https://calypso.live/?branch=fix/jp-connect-unlogged