### PR TITLE
Jetpack Plans: Add a query component for requesting premium plugin keys

### DIFF
--- a/client/components/data/query-plugin-keys/README.md
+++ b/client/components/data/query-plugin-keys/README.md
@@ -1,0 +1,19 @@
+Query Plugin Keys
+=================
+
+`<QueryPluginKeys />` is a React component used in managing network requests for premium plugin registration keys.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The site ID for which plugins should be requested. The API handles determining which plugins are enabled, based on the current site's plan.

--- a/client/components/data/query-plugin-keys/index.jsx
+++ b/client/components/data/query-plugin-keys/index.jsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { fetchInstallInstructions } from 'state/plugins/premium/actions';
+import { hasRequested } from 'state/plugins/premium/selectors';
+
+class QueryPluginKeys extends Component {
+	componentWillMount() {
+		if ( this.props.siteId && ! this.props.hasRequested ) {
+			this.props.fetchInstallInstructions( this.props.siteId );
+		}
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.siteId === this.props.siteId ) {
+			return;
+		}
+		this.refresh( nextProps.hasRequested, nextProps.siteId );
+	}
+
+	refresh( hasRequestedKeys, siteId ) {
+		if ( ! hasRequestedKeys ) {
+			this.props.fetchInstallInstructions( siteId );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryPluginKeys.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	hasRequested: PropTypes.bool,
+	fetchInstallInstructions: PropTypes.func
+};
+
+QueryPluginKeys.defaultProps = {
+	fetchInstallInstructions: () => {}
+};
+
+export default connect(
+	( state, props ) => {
+		const siteId = props.siteId;
+		return {
+			hasRequested: hasRequested( state, siteId ),
+		};
+	},
+	{ fetchInstallInstructions }
+)( QueryPluginKeys );

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -18,6 +18,7 @@ import Button from 'components/button';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Spinner from 'components/spinner';
+import QueryPluginKeys from 'components/data/query-plugin-keys';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
@@ -34,7 +35,6 @@ import { getPlugin } from 'state/plugins/wporg/selectors';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { requestSites } from 'state/sites/actions';
 import {
-	fetchInstallInstructions,
 	installPlugin,
 } from 'state/plugins/premium/actions';
 import {
@@ -90,19 +90,9 @@ const PlansSetup = React.createClass( {
 		return ( plugins.length === filter( plugins, { wporg: true } ).length );
 	},
 
-	fetchInstallInstructions( props ) {
-		props = props || this.props;
-		if ( props.siteId && ! props.hasRequested ) {
-			props.fetchInstallInstructions( props.siteId );
-		}
-	},
-
 	componentDidMount() {
 		window.addEventListener( 'beforeunload', this.warnIfNotFinished );
 		this.props.requestSites();
-		if ( this.props.siteId ) {
-			this.fetchInstallInstructions();
-		}
 
 		page.exit( '/plugins/setup/*', ( context, next ) => {
 			const confirmText = this.warnIfNotFinished( {} );
@@ -123,10 +113,6 @@ const PlansSetup = React.createClass( {
 
 	componentWillUnmount() {
 		window.removeEventListener( 'beforeunload', this.warnIfNotFinished );
-	},
-
-	componentWillReceiveProps( props ) {
-		this.fetchInstallInstructions( props );
 	},
 
 	componentDidUpdate() {
@@ -482,6 +468,7 @@ const PlansSetup = React.createClass( {
 
 		return (
 			<div className="jetpack-plugins-setup">
+				<QueryPluginKeys siteId={ site.ID } />
 				<h1 className="jetpack-plugins-setup__header">
 					{ this.translate( 'Setting up your %(plan)s Plan', { args: { plan: site.plan.product_name_short } } ) }
 				</h1>
@@ -516,5 +503,5 @@ export default connect(
 			siteId
 		};
 	},
-	dispatch => bindActionCreators( { requestSites, fetchPluginData, fetchInstallInstructions, installPlugin }, dispatch )
+	dispatch => bindActionCreators( { requestSites, fetchPluginData, installPlugin }, dispatch )
 )( PlansSetup );


### PR DESCRIPTION
Refactor `PlansSetup` to use a query component for fetching plugin keys. This removes the fetch request from the main component.

To test

1. Start the autoconfig process at `/plugins/setup/$site`
2. The page should load the appropriate plugins for your site & plan.

(not sure if there's anything else to test here, I haven't written a query component before)

See #6769

cc @johnHackworth @roccotripaldi 

Test live: https://calypso.live/?branch=add/autoconfig-query-component