### PR TITLE
Signup: Add Theme Previews A/B Test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -82,6 +82,15 @@ module.exports = {
 		defaultVariation: 'designTypeWithoutStore',
 		allowExistingUsers: false,
 	},
+	signupThemePreview: {
+		datestamp: '20160727',
+		variations: {
+			disabled: 95,
+			enabled: 5,
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: true,
+	},
 	firstView: {
 		datestamp: '20160726',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -85,10 +85,10 @@ module.exports = {
 	signupThemePreview: {
 		datestamp: '20160727',
 		variations: {
-			disabled: 95,
-			enabled: 5,
+			showThemePreview: 20,
+			hideThemePreview: 80,
 		},
-		defaultVariation: 'disabled',
+		defaultVariation: 'hideThemePreview',
 		allowExistingUsers: true,
 	},
 	firstView: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,7 +89,6 @@ module.exports = {
 			hideThemePreview: 80,
 		},
 		defaultVariation: 'hideThemePreview',
-		allowExistingUsers: true,
 	},
 	firstView: {
 		datestamp: '20160726',

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -12,7 +12,7 @@ import SignupThemesList from './signup-themes-list';
 import StepWrapper from 'signup/step-wrapper';
 import ThemePreview from 'my-sites/themes/theme-preview';
 import Button from 'components/button';
-import abtest from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'ThemeSelection',

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -12,9 +12,7 @@ import SignupThemesList from './signup-themes-list';
 import StepWrapper from 'signup/step-wrapper';
 import ThemePreview from 'my-sites/themes/theme-preview';
 import Button from 'components/button';
-import config from 'config';
-
-const themeDemosEnabled = config.isEnabled( 'signup/theme-demos' );
+import abtest from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'ThemeSelection',
@@ -74,7 +72,7 @@ module.exports = React.createClass( {
 	},
 
 	handleScreenshotClick( theme ) {
-		if ( themeDemosEnabled ) {
+		if ( abtest( 'signupThemePreview' ) === 'showThemePreview' ) {
 			this.showPreview( theme );
 		} else {
 			this.pickTheme( theme );

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -9,7 +9,7 @@ import noop from 'lodash/noop';
  */
 import getThemes from 'lib/signup/themes';
 import ThemesList from 'components/themes-list';
-import abtest from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'SignupThemesList',

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -9,9 +9,7 @@ import noop from 'lodash/noop';
  */
 import getThemes from 'lib/signup/themes';
 import ThemesList from 'components/themes-list';
-import config from 'config';
-
-const themeDemosEnabled = config.isEnabled( 'signup/theme-demos' );
+import abtest from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'SignupThemesList',
@@ -43,7 +41,7 @@ module.exports = React.createClass( {
 	},
 
 	render() {
-		const actionLabel = themeDemosEnabled ? this.translate( 'Preview' ) : this.translate( 'Pick' );
+		const actionLabel = ( abtest( 'signupThemePreview' ) === 'showThemePreview' ) ? this.translate( 'Preview' ) : this.translate( 'Pick' );
 		const getActionLabel = () => actionLabel;
 		const themes = this.getComputedThemes().map( theme => {
 			return {

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -41,7 +41,8 @@ module.exports = React.createClass( {
 	},
 
 	render() {
-		const actionLabel = ( abtest( 'signupThemePreview' ) === 'showThemePreview' ) ? this.translate( 'Preview' ) : this.translate( 'Pick' );
+		const actionLabel = ( abtest( 'signupThemePreview' ) === 'showThemePreview' )
+			? this.translate( 'Preview' ) : this.translate( 'Pick' );
 		const getActionLabel = () => actionLabel;
 		const themes = this.getComputedThemes().map( theme => {
 			return {

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -64,7 +64,6 @@
 		"reader/full-errors": false,
 		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,
-		"signup/theme-demos": false,
 		"upgrades/checkout": false,
 		"upgrades/credit-cards": false,
 		"upgrades/domain-search": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -72,7 +72,6 @@
 		"resume-editing": true,
 		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,
-		"signup/theme-demos": false,
 		"ui/first-view": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/development.json
+++ b/config/development.json
@@ -123,7 +123,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
-		"signup/theme-demos": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -84,7 +84,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": false,
-		"signup/theme-demos": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,

--- a/config/production.json
+++ b/config/production.json
@@ -82,7 +82,6 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"signup/theme-demos": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view-ab-test": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -90,7 +90,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
-		"signup/theme-demos": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/test.json
+++ b/config/test.json
@@ -99,7 +99,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
-		"signup/theme-demos": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -98,7 +98,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
-		"signup/theme-demos": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,


### PR DESCRIPTION
Once #6958 lands, we'll add an A/B Test for it.

TODO:

- [x] Decide percentage
- [x] Remove feature flag for Theme Previews
- [x] Make the A/B Test control that instead

Test live: https://calypso.live/?branch=add/signup-theme-preview-abtest