### PR TITLE
First-View: Enable AB test in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -84,7 +84,7 @@
 		"settings/security/monitor": true,
 		"support-user": true,
 		"sync-handler": true,
-		"ui/first-view-ab-test": false,
+		"ui/first-view-ab-test": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
This pull request enables the First View AB test in production, on the Stats page, for 5% of new users.

![image](https://cloud.githubusercontent.com/assets/363749/17188092/5d365fe8-5401-11e6-80c0-c36314f8b18f.png)


Test live: https://calypso.live/?branch=update/first-view/enable