### PR TITLE
Editor: Render PublicizeOptions by post type supports

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -166,8 +166,7 @@ const EditorDrawer = React.createClass( {
 		return (
 			<EditorSharingAccordion
 				site={ this.props.site }
-				post={ this.props.post }
-				isNew={ this.props.isNew } />
+				post={ this.props.post } />
 		);
 	},
 

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -122,13 +122,7 @@ const EditorSharingAccordion = React.createClass( {
 				) }
 				<AccordionSection>
 					{ ! hideSharing && (
-						<Sharing
-							site={ this.props.site }
-							post={ this.props.post }
-							isNew={ this.props.isNew }
-							connections={ this.props.connections }
-							fetchConnections={ this.props.requestConnections }
-						/>
+						<Sharing site={ this.props.site } post={ this.props.post } />
 					) }
 					{ this.renderShortUrl() }
 				</AccordionSection>

--- a/client/post-editor/editor-sharing/index.jsx
+++ b/client/post-editor/editor-sharing/index.jsx
@@ -1,85 +1,24 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { PropTypes } from 'react';
 
 /**
  * Internal dependencies
  */
-var PublicizeOptions = require( './publicize-options' ),
-	SharingLikeOptions = require( './sharing-like-options' ),
-	postUtils = require( 'lib/posts/utils' );
+import PublicizeOptions from './publicize-options';
+import SharingLikeOptions from './sharing-like-options';
 
-module.exports = React.createClass( {
-	displayName: 'EditorSharing',
+export default function EditorSharing( { post, site } ) {
+	return (
+		<div className="editor-sharing">
+			<PublicizeOptions post={ post } site={ site } />
+			<SharingLikeOptions post={ post } site={ site } />
+		</div>
+	);
+}
 
-	propTypes: {
-		site: React.PropTypes.object,
-		post: React.PropTypes.object,
-		isNew: React.PropTypes.bool,
-		connections: React.PropTypes.array,
-		fetchConnections: React.PropTypes.func
-	},
-
-	isSharingButtonsEnabled() {
-		if ( ! this.props.site || ! this.props.site.jetpack ) {
-			return true;
-		}
-
-		if ( ! this.props.site.isModuleActive( 'sharedaddy' ) ) {
-			return false;
-		}
-
-		return true;
-	},
-
-	isLikesEnabled() {
-		if ( ! this.props.site || ! this.props.site.jetpack ) {
-			return true;
-		}
-
-		if ( ! this.props.site.isModuleActive( 'likes' ) ) {
-			return false;
-		}
-
-		return true;
-	},
-
-	renderSharingLikeOptions() {
-		if ( ! this.isSharingButtonsEnabled() && ! this.isLikesEnabled() ) {
-			return null;
-		}
-
-		return(
-			<SharingLikeOptions
-				post={ this.props.post }
-				site={ this.props.site }
-				isSharingButtonsEnabled={ this.isSharingButtonsEnabled() }
-				isLikesEnabled={ this.isLikesEnabled() }
-				isNew={ this.props.isNew } />
-		);
-	},
-
-	renderPublicizeOptions() {
-		if ( postUtils.isPage( this.props.post ) ) {
-			return;
-		}
-
-		return (
-			<PublicizeOptions
-				post={ this.props.post }
-				site={ this.props.site }
-				connections={ this.props.connections }
-				fetchConnections={ this.props.fetchConnections } />
-		);
-	},
-
-	render: function() {
-		return (
-			<div className="editor-sharing">
-				{ this.renderPublicizeOptions() }
-				{ this.renderSharingLikeOptions() }
-			</div>
-		);
-	}
-} );
+EditorSharing.propTypes = {
+	site: PropTypes.object,
+	post: PropTypes.object
+};

--- a/client/post-editor/editor-sharing/sharing-like-options.jsx
+++ b/client/post-editor/editor-sharing/sharing-like-options.jsx
@@ -1,19 +1,21 @@
 /**
  * External dependencies
  */
-const React = require( 'react' );
+import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-const EditorFieldset = require( 'post-editor/editor-fieldset' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
-	PostActions = require( 'lib/posts/actions' ),
-	stats = require( 'lib/posts/stats' );
+import EditorFieldset from 'post-editor/editor-fieldset';
+import FormCheckbox from 'components/forms/form-checkbox';
+import PostActions from 'lib/posts/actions';
+import { recordStat, recordEvent } from 'lib/posts/stats';
+import { isEditorNewPost } from 'state/ui/editor/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackModuleActive } from 'state/sites/selectors';
 
-export default React.createClass( {
-	displayName: 'SharingLikeOptions',
-
+const SharingLikeOptions = React.createClass( {
 	propTypes: {
 		site: React.PropTypes.object,
 		post: React.PropTypes.object,
@@ -94,11 +96,15 @@ export default React.createClass( {
 		mcStat += event.target.checked ? '_enabled' : '_disabled';
 		eventStat += event.target.checked ? ' Enabled' : ' Disabled';
 
-		stats.recordStat( mcStat );
-		stats.recordEvent( eventStat );
+		recordStat( mcStat );
+		recordEvent( eventStat );
 	},
 
 	render: function() {
+		if ( ! this.props.isSharingButtonsEnabled && ! this.props.isLikesEnabled ) {
+			return null;
+		}
+
 		return (
 			<EditorFieldset
 				className="editor-sharing__sharing-like-options"
@@ -110,3 +116,13 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		isSharingButtonsEnabled: false !== isJetpackModuleActive( state, siteId, 'sharedaddy' ),
+		isLikesEnabled: false !== isJetpackModuleActive( state, siteId, 'likes' ),
+		isNew: isEditorNewPost( state )
+	};
+} )( SharingLikeOptions );

--- a/client/state/post-types/selectors.js
+++ b/client/state/post-types/selectors.js
@@ -39,6 +39,36 @@ export function getPostType( state, siteId, slug ) {
 }
 
 /**
+ * Returns true if the post type supports the specified feature, false if the
+ * post type does not support the specified feature, or null if post type
+ * support cannot be determined.
+ *
+ * @param  {Object}   state   Global state tree
+ * @param  {Number}   siteId  Site ID
+ * @param  {String}   slug    Post type slug
+ * @param  {String}   feature Feature slug
+ * @return {?Boolean}         Whether post type supports feature
+ */
+export function postTypeSupports( state, siteId, slug, feature ) {
+	// Hard-coded overrides; even if we know the post type object, continue to
+	// defer to these values. Indicates that REST API supports are inaccurate.
+	switch ( slug ) {
+		case 'post':
+			switch ( feature ) {
+				case 'publicize':
+					return true;
+			}
+	}
+
+	const postType = getPostType( state, siteId, slug );
+	if ( postType ) {
+		return !! postType.supports[ feature ];
+	}
+
+	return null;
+}
+
+/**
  * Returns true if the site supported the post type, false if the site does not
  * support the post type, or null if support cannot be determined (if site is
  * not currently known).

--- a/client/state/post-types/test/selectors.js
+++ b/client/state/post-types/test/selectors.js
@@ -10,6 +10,7 @@ import {
 	isRequestingPostTypes,
 	getPostTypes,
 	getPostType,
+	postTypeSupports,
 	isPostTypeSupported
 } from '../selectors';
 
@@ -113,6 +114,86 @@ describe( 'selectors', () => {
 			}, 2916284, 'post' );
 
 			expect( postType ).to.eql( { name: 'post', label: 'Posts' } );
+		} );
+	} );
+
+	describe( 'postTypeSupports()', () => {
+		it( 'should return true for post publicize if type is unknown', () => {
+			const isSupported = postTypeSupports( {
+				postTypes: {
+					items: {}
+				}
+			}, 2916284, 'post', 'publicize' );
+
+			expect( isSupported ).to.be.true;
+		} );
+
+		it( 'should return true for post publicize even if type is known', () => {
+			const isSupported = postTypeSupports( {
+				postTypes: {
+					items: {
+						2916284: {
+							post: {
+								name: 'post',
+								label: 'Posts',
+								supports: {
+									publicize: false
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'post', 'publicize' );
+
+			expect( isSupported ).to.be.true;
+		} );
+
+		it( 'should return null if post type is not known', () => {
+			const isSupported = postTypeSupports( {
+				postTypes: {
+					items: {}
+				}
+			}, 2916284, 'jetpack-portfolio', 'publicize' );
+
+			expect( isSupported ).to.be.null;
+		} );
+
+		it( 'should return false if post type support omits feature', () => {
+			const isSupported = postTypeSupports( {
+				postTypes: {
+					items: {
+						2916284: {
+							'jetpack-testimonial': {
+								name: 'jetpack-testimonial',
+								label: 'Testimonials',
+								supports: {}
+							}
+						}
+					}
+				}
+			}, 2916284, 'jetpack-testimonial', 'publicize' );
+
+			expect( isSupported ).to.be.false;
+		} );
+
+		it( 'should return true if post type supports feature', () => {
+			const isSupported = postTypeSupports( {
+				postTypes: {
+					items: {
+						2916284: {
+							'jetpack-portfolio': {
+								name: 'jetpack-portfolio',
+								label: 'Projects',
+								supports: {
+									publicize: true
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'jetpack-portfolio', 'publicize' );
+
+			expect( isSupported ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
Closes #7072 

This pull request seeks to refactor the editor sharing component to use the post type supports object in considering whether to render `<PublicizeOptions />` (i.e. connected Publicize service listing).

These changes significantly refactor existing editor sharing components to be more self-sufficient in determining their render behavior and making use of data directly from state when possible. Future iterations should continue this refactoring, especially in deprecating passing `site` and `posts` props through descendants.

__Testing instructions:__

Verify that there are no regressions in sharing behavior. Specifically, presence of sharing components should respect active Jetpack modules. Next, ensure that Publicize connections services are available only if the post type supports them (posts, portfolios, not pages or testimonials).

1. Navigate to the [post editor](http://calypso.localhost:3000/post) or editor for a custom post type ([portfolio](http://calypso.localhost:3000/edit/jetpack-portfolio), [testimonial](http://calypso.localhost:3000/edit/jetpack-testimonial))
2. Select a site, if prompted
3. Note that...
 - If the post type does not support Publicize, nor are the Likes and Sharing Jetpack modules activated, no Sharing accordion is present
 - If the post type does not support Publicize, but one or both of the Likes and Sharing Jetpack modules are activated, a Sharing accordion is present with only "Show Likes" and/or "Show Sharing Buttons" respectively
 - If the post type does support Publicize, a Sharing accordion is present with the connected services listed

__Caveats:__

The [page editor](http://calypso.localhost:3000/page) shows a Sharing accordion when Publicize, Likes, and Sharing modules are all disabled for a site. This issue is present in master and will be addressed separately. See #7088 for tracking.

Test live: https://calypso.live/?branch=update/7072-editor-cpt-publicize