### PR TITLE
Conversion: Add targeted wording test to plans

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -76,4 +76,12 @@ module.exports = {
 		defaultVariation: 'showPopover',
 		allowExistingUsers: false,
 	},
+	plansWording: {
+		datestamp: '20160727',
+		variations: {
+			originalWording: 50,
+			targetedWording: 50
+		},
+		defaultVariation: 'originalWording'
+	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -77,7 +77,7 @@ module.exports = {
 		allowExistingUsers: false,
 	},
 	plansWording: {
-		datestamp: '20160727',
+		datestamp: '20160817',
 		variations: {
 			originalWording: 50,
 			targetedWording: 50

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -106,7 +106,7 @@ export const plansList = {
 			' website with a custom domain name, and remove all WordPress.com advertising. ' +
 			'Get access to high quality email and live chat support.', {
 				components: {
-					strong: <strong />
+					strong: <strong className="plan-features__targeted-description-heading" />
 				}
 			} ),
 		getFeatures: () => [
@@ -134,7 +134,7 @@ export const plansList = {
 			' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
 			' and the ability to monetize your site with ads.', {
 				components: {
-					strong: <strong />
+					strong: <strong className="plan-features__targeted-description-heading" />
 				}
 			} ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
@@ -165,7 +165,7 @@ export const plansList = {
 			' business website with unlimited premium and business theme templates, Google Analytics support, unlimited' +
 			' storage, and the ability to remove WordPress.com branding.', {
 				components: {
-					strong: <strong />
+					strong: <strong className="plan-features__targeted-description-heading" />
 				}
 			} ),
 		getFeatures: () => compact( [ // pay attention to ordering, it is used on /plan page

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -50,7 +50,7 @@ export const FEATURE_NO_ADS = 'no-adverts';
 export const FEATURE_VIDEO_UPLOADS = 'video-upload';
 export const FEATURE_WORDADS_INSTANT = 'wordads-instant';
 export const FEATURE_NO_BRANDING = 'no-wp-branding';
-export const FEATURE_ADVANCED_SEO = 'advanced-seo'
+export const FEATURE_ADVANCED_SEO = 'advanced-seo';
 
 // jetpack features constants
 export const FEATURE_STANDARD_SECURITY_TOOLS = 'standard-security-tools';
@@ -83,6 +83,8 @@ export const plansList = {
 			'Get a free blog and be on your way to publishing your first post' +
 			' in less than five minutes.'
 		),
+		getTargetedDescription: () => i18n.translate( 'Get a free website and be on your way to publishing your ' +
+			'first post in less than five minutes.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_WP_SUBDOMAIN,
 			FEATURE_COMMUNITY_SUPPORT,
@@ -100,6 +102,13 @@ export const plansList = {
 		availableFor: ( plan ) => includes( [ PLAN_FREE ], plan ),
 		getPathSlug: () => 'personal',
 		getDescription: () => i18n.translate( 'Use your own domain and establish your online presence without ads.' ),
+		getTargetedDescription: () => i18n.translate( '{{strong}}Best for Personal Use:{{/strong}} Boost your' +
+			' website with a custom domain name, and remove all WordPress.com advertising. ' +
+			'Get access to high quality email and live chat support.', {
+				components: {
+					strong: <strong />
+				}
+			} ),
 		getFeatures: () => [
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
@@ -121,6 +130,13 @@ export const plansList = {
 		getDescription: () => i18n.translate( 'Your own domain name, powerful' +
 			' customization options, easy monetization with WordAds, and lots of space for audio and video.'
 		),
+		getTargetedDescription: () => i18n.translate( '{{strong}}Best for Entrepreneurs & Freelancers:{{/strong}}' +
+			' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
+			' and the ability to monetize your site with ads.', {
+				components: {
+					strong: <strong />
+				}
+			} ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
@@ -145,6 +161,13 @@ export const plansList = {
 			'Everything included with Premium, as well as live chat support,' +
 			' unlimited access to premium themes, and Google Analytics.'
 		),
+		getTargetedDescription: () => i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
+			' business website with unlimited premium and business theme templates, Google Analytics support, unlimited' +
+			' storage, and the ability to remove WordPress.com branding.', {
+				components: {
+					strong: <strong />
+				}
+			} ),
 		getFeatures: () => compact( [ // pay attention to ordering, it is used on /plan page
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -291,7 +291,14 @@ export const plansList = {
 	}
 };
 
-const allPaidPlans = [
+export const allPaidPlans = [
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS
+];
+
+export const allWpcomPlans = [
+	PLAN_FREE,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -28,9 +28,11 @@ import {
 	PLAN_FREE,
 	PLAN_JETPACK_FREE, 
 	PLAN_PERSONAL,
+	allWpcomPlans
 } from 'lib/plans/constants';
 import { createSitePlanObject } from 'state/sites/plans/assembler';
 import SitesList from 'lib/sites-list';
+import { abtest } from 'lib/abtest';
 
 /**
  * Module vars
@@ -191,6 +193,10 @@ export const isPlanFeaturesEnabled = () => {
 	return isEnabled( 'manage/plan-features' );
 };
 
+export const isPlansWordingEnabled = () => {
+	return abtest( 'plansWording' ) === 'targetedWording';
+};
+
 export function plansLink( url, site, intervalType ) {
 	if ( 'monthly' === intervalType ) {
 		url += '/monthly';
@@ -210,7 +216,13 @@ export function applyTestFiltersToPlansList( planName ) {
 	// these becomes no-ops when we removed some of the abtest overrides, but
 	// we're leaving the code in place for future tests
 	const removeDisabledFeatures = () => {};
-	const updatePlanDescriptions = () => {};
+
+	const updatePlanDescriptions = () => {
+		if ( isPlansWordingEnabled() && includes( allWpcomPlans, planName ) ) {
+			filteredPlanConstantObj.getDescription = plansList[ planName ].getTargetedDescription;
+		}
+	};
+
 	const updatePlanFeatures = () => {};
 
 	removeDisabledFeatures();

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -7,6 +7,7 @@ import { map, reduce, noop } from 'lodash';
 import page from 'page';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -203,6 +204,12 @@ class PlanFeatures extends Component {
 				'is-placeholder': isPlaceholder
 			} );
 
+			let description = planConstantObj.getDescription();
+
+			if ( abtest( 'plansWording' ) === 'targetedWording' ) {
+				description = planConstantObj.getTargetedDescription();
+			}
+
 			return (
 				<td key={ planName } className={ classes }>
 					{
@@ -212,7 +219,7 @@ class PlanFeatures extends Component {
 					}
 
 					<p className="plan-features__description">
-						{ planConstantObj.getDescription() }
+						{ description }
 					</p>
 				</td>
 			);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -7,7 +7,6 @@ import { map, reduce, noop } from 'lodash';
 import page from 'page';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -204,12 +203,6 @@ class PlanFeatures extends Component {
 				'is-placeholder': isPlaceholder
 			} );
 
-			let description = planConstantObj.getDescription();
-
-			if ( abtest( 'plansWording' ) === 'targetedWording' ) {
-				description = planConstantObj.getTargetedDescription();
-			}
-
 			return (
 				<td key={ planName } className={ classes }>
 					{
@@ -219,7 +212,7 @@ class PlanFeatures extends Component {
 					}
 
 					<p className="plan-features__description">
-						{ description }
+						{ planConstantObj.getDescription() }
 					</p>
 				</td>
 			);

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -361,6 +361,11 @@ $plan-features-sidebar-width: 272px;
 	@include breakpoint( "<660px" ) {
 		padding: 20px 20px 0 20px;
 	}
+
+	strong {
+		display: block;
+		color: lighten( $gray-dark, 25% );
+	}
 }
 
 .plan-features__item {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -361,11 +361,11 @@ $plan-features-sidebar-width: 272px;
 	@include breakpoint( "<660px" ) {
 		padding: 20px 20px 0 20px;
 	}
+}
 
-	strong {
-		display: block;
-		color: lighten( $gray-dark, 25% );
-	}
+.plan-features__targeted-description-heading {
+	display: block;
+	color: lighten( $gray-dark, 25% );
 }
 
 .plan-features__item {


### PR DESCRIPTION
This will run a 50-50 split test using the original plans descriptions, versus more targeted plans descriptions. Part of our follow on tests in #6997.

Original:

<img width="1234" alt="screen shot 2016-07-27 at 12 54 33" src="https://cloud.githubusercontent.com/assets/1464705/17190181/c9687712-53f9-11e6-9017-e3d5c23a499d.png">

Targeted:

<img width="1240" alt="screen shot 2016-07-27 at 12 54 16" src="https://cloud.githubusercontent.com/assets/1464705/17190190/cfc7e732-53f9-11e6-926d-a4929a84276f.png">

Please do not merge until a testing post has been written.



Test live: https://calypso.live/?branch=update/plans-descriptions-v3