### PR TITLE
Redirect /plans/compare/:site and /plans/features/:site to /plans/:site

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -16,7 +16,7 @@ import route from 'lib/route';
 import sitesFactory from 'lib/sites-list';
 import titleActions from 'lib/screen-title/actions';
 import get from 'lodash/get';
-import { isValidFeatureKey, isPlanFeaturesEnabled } from 'lib/plans';
+import { isValidFeatureKey } from 'lib/plans';
 
 const sites = sitesFactory();
 
@@ -89,13 +89,8 @@ export default {
 			productsList = require( 'lib/products-list' )(),
 			analyticsPageTitle = 'Plans > Compare',
 			site = sites.getSelectedSite(),
-			siteDomain = context.params.domain || '',
 			basePath = route.sectionify( context.path );
 		let baseAnalyticsPath;
-
-		if ( isPlanFeaturesEnabled() ) {
-			return page.redirect( `/plans/features/${ siteDomain }` );
-		}
 
 		if ( site && ! site.isUpgradeable() ) {
 			return page.redirect( '/plans/compare' );
@@ -150,5 +145,15 @@ export default {
 	redirectToCheckout( context ) {
 		// this route is deprecated, use `/checkout/:site/:plan` to link to plan checkout
 		page.redirect( `/checkout/${ context.params.domain }/${ context.params.plan }` );
+	},
+
+	redirectToPlans( context ) {
+		const siteDomain = context.params.domain;
+
+		if ( siteDomain ) {
+			return page.redirect( `/plans/${ siteDomain }` );
+		}
+
+		return page.redirect( '/plans' );
 	}
 };

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -25,7 +25,28 @@ export default function() {
 			'/plans/compare',
 			controller.siteSelection,
 			controller.navigation,
-			plansController.plansCompare
+			plansController.redirectToPlans
+		);
+
+		page(
+			'/plans/compare/:domain',
+			controller.siteSelection,
+			controller.navigation,
+			plansController.redirectToPlans
+		);
+
+		page(
+			'/plans/features',
+			controller.siteSelection,
+			controller.navigation,
+			plansController.redirectToPlans
+		);
+
+		page(
+			'/plans/features/:domain',
+			controller.siteSelection,
+			controller.navigation,
+			plansController.redirectToPlans
 		);
 
 		page(
@@ -33,27 +54,6 @@ export default function() {
 			controller.siteSelection,
 			controller.navigation,
 			yourPlan
-		);
-
-		page(
-			'/plans/compare/:domain',
-			controller.siteSelection,
-			controller.navigation,
-			plansController.plansCompare
-		);
-
-		page(
-			'/plans/compare/:intervalType?/:domain',
-			controller.siteSelection,
-			controller.navigation,
-			plansController.plansCompare
-		);
-
-		page(
-			'/plans/compare/:feature/:domain',
-			controller.siteSelection,
-			controller.navigation,
-			plansController.plansCompare
 		);
 
 		page(


### PR DESCRIPTION
Fixes #7094. 

- Redirect `/plans/compare` and `/plans/features` to `/plans`.
- Redirect `/plans/compare/:site` and `/plans/features/:site` to `/plans/:site`

## Testing instructions

1. Make sure that the above routes behave as intended;
2. Also, verify that NUX and/or Jetpack plans (monthly, yearly) have not been affected.

## Additional info

@artpi pulled a nice Google Analytics chart of most visited `/plans` URLs:

![screen_shot_2016-07-28_at_13 08 25_pm](https://cloud.githubusercontent.com/assets/4988512/17216719/0eccadb2-54e2-11e6-9ce7-afb48da0fc97.png)

With this PR, we should cover all the important ones.

We could remove `/plans/features` completely as it was never a real route. However, from the above statistics, a few people are going to that URL. Should we remove it anyways or let it redirect to `/plans` as I did in this PR?

cc @gwwar @rralian @mtias 

Test live: https://calypso.live/?branch=fix/redirect-plans-compare-and-features-to-plans