### PR TITLE
Plans: redirect from /plans to /pricing when logged out

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -354,6 +354,7 @@ function reduxStoreReady( reduxStore ) {
 				return;
 			}
 
+			//see server/pages/index for prod redirect
 			if ( '/plans' === context.pathname ) {
 				// pricing page is outside of Calypso, needs a full page load
 				window.location = 'https://wordpress.com/pricing';

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -319,6 +319,13 @@ module.exports = function() {
 
 	app.get( '/theme', ( req, res ) => res.redirect( '/design' ) );
 
+	app.get( '/plans', function( req, res, next ) {
+		if ( config( 'env' ) !== 'development' && ! req.cookies.wordpress_logged_in ) {
+			res.redirect( 'https://wordpress.com/pricing' );
+		}
+		next();
+	} );
+
 	sections
 		.forEach( section => {
 			section.paths.forEach( path => {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -315,16 +315,17 @@ module.exports = function() {
 				next();
 			}
 		} );
+
+		app.get( '/plans', function( req, res, next ) {
+			if ( ! req.cookies.wordpress_logged_in ) {
+				res.redirect( 'https://wordpress.com/pricing' );
+			} else {
+				next();
+			}
+		} );
 	}
 
 	app.get( '/theme', ( req, res ) => res.redirect( '/design' ) );
-
-	app.get( '/plans', function( req, res, next ) {
-		if ( config( 'env' ) !== 'development' && ! req.cookies.wordpress_logged_in ) {
-			res.redirect( 'https://wordpress.com/pricing' );
-		}
-		next();
-	} );
 
 	sections
 		.forEach( section => {


### PR DESCRIPTION
Fixes #7010 to redirect logged out users on/plans to /pricing instead of taking them to sign in. We'll want to eventually convert the plans page to be SSR ready, but this requires a bit of work to do so and will be easier to tackle when the redesign test is finished and we are using a single plans page.

## Testing Instructions

In Local Dev:
- Make sure you are logged out
- Navigate to http://calypso.localhost:3000/plans
- You will be redirected to https://wordpress.com/pricing
- Log in, and navigate to http://calypso.localhost:3000/plans
- The plans page renders
- Nux/Upgrade flows work normally.

We must also test the local docker image, as our local dev environment follows a different logic path when setting up a user.
- Follow image instructions at PCYsg-5XR-p2
- Make sure you are logged out
- Navigate to http://wpcalypso.wordpress.com/plans
- You will be redirected to https://wordpress.com/pricing
- Log in, and navigate to http://wpcalypso.wordpress.com/plans
- The plans page renders
- Nux/Upgrade flows work normally.

cc @rralian @artpi @lamosty @retrofox

Test live: https://calypso.live/?branch=update/logged-out-plans