### PR TITLE
Reader: fix post and byline overlapping if byline is long

### DIFF
--- a/client/components/post-card/author-and-site.jsx
+++ b/client/components/post-card/author-and-site.jsx
@@ -20,19 +20,19 @@ export function AuthorAndSite( { translate, post, site, feed, showGravatar = fal
 	const siteName = site && site.title || post.site_name;
 
 	const username = (
-		<span className="post-card__author-and-site-author">
-			<a href={ `/read/blogs/${post.site_ID}` } onClick={ partial( onClick, { post, site, feed } ) }>
+		<span className="post-card__search-byline-author">
+			<a className="post-card__byline-link" href={ `/read/blogs/${post.site_ID}` } onClick={ partial( onClick, { post, site, feed } ) }>
 				{ showGravatar && <Gravatar user={ post.author } size={ 16 } /> }
 				{ displayName }
 			</a>
 		</span>
 	);
 
-	const sitename = ( <span className="post-card__author-and-site-site">
-		<a href={ `/read/blogs/${post.site_ID}` } onClick={ partial( onClick, { post, site, feed } ) }>{ siteName }</a>
+	const sitename = ( <span className="post-card__byline-site">
+		<a className="post-card__byline-link" href={ `/read/blogs/${post.site_ID}` } onClick={ partial( onClick, { post, site, feed } ) }>{ siteName }</a>
 	</span> );
 	return (
-		<span className="post-card__author-and-site">
+		<span className="post-card__byline-author-and-site">
 			{
 				displayName === '' || siteName === displayName
 				? sitename

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -114,6 +114,10 @@
 			z-index: 1;
 		}
 
+		.post-card__byline-author-and-site {
+			color: $white;
+		}
+
 		.post-card__search-title-link {
 			color: $white;
 
@@ -245,6 +249,7 @@
 }
 
 .post-card__byline-author-and-site {
+	color: $gray;
 	margin-right: 6px;
 }
 

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -109,21 +109,19 @@
 
 		.post-card__search-title {
 			display: block;
+			padding-right: 20px;
+			position: relative;
+				top: 100px;
+			z-index: 1;
 
 			@include breakpoint( ">480px" ) {
 				display: inline;
+				top: 80px;
 			}
 		}
 
 		.post-card__search-title-link {
 			color: $white;
-			padding-right: 20px;
-			position: relative;
-				top: 80px;
-
-				@include breakpoint( "<480px" ) {
-					top: 100px;
-				}
 
 			&:hover {
 				opacity: .8;
@@ -132,10 +130,10 @@
 
 		.post-card__search-byline {
 			position: relative;
-				top: 80px;
+				top: 100px;
 
-				@include breakpoint( "<480px" ) {
-					top: 100px;
+				@include breakpoint( ">480px" ) {
+					top: 80px;
 				}
 
 			a,

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -88,10 +88,10 @@
 	}
 
 	&.is-photo {
-		min-height: 168px;
-		padding: 20px;
+		min-height: 160px;
+		padding: 20px 20px 12px;
 
-		&:before{
+		&::before{
 			background: $gray-dark;
 			content: '';
 			height: 100%;
@@ -109,15 +109,9 @@
 
 		.post-card__search-title {
 			display: block;
-			padding-right: 20px;
+			padding: 30px 20px 0 0;
 			position: relative;
-				top: 100px;
 			z-index: 1;
-
-			@include breakpoint( ">480px" ) {
-				display: inline;
-				top: 80px;
-			}
 		}
 
 		.post-card__search-title-link {
@@ -130,11 +124,6 @@
 
 		.post-card__search-byline {
 			position: relative;
-				top: 100px;
-
-				@include breakpoint( ">480px" ) {
-					top: 80px;
-				}
 
 			a,
 			a:visited {
@@ -152,6 +141,10 @@
 
 		.post-card__search-social {
 			position: relative;
+		}
+
+		.post-card__search-excerpt {
+			display: none;
 		}
 
 		.gridicon {
@@ -187,7 +180,7 @@
 	display: inline;
 	@extend %content-font;
 	font-size: 20px;
-	line-height: 20px;
+	line-height: 1.2;
 	font-weight: 700;
 
 	@include breakpoint( ">480px" ) {
@@ -244,11 +237,6 @@
 	font-size: 13px;
 	list-style: none;
 	margin: 6px 0;
-	padding: 0 0 10px 0;
-
-	@include breakpoint( ">480px" ) {
-		padding: 0 0 20px 0;
-	}
 
 	.gravatar {
 		vertical-align: text-bottom;

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -107,6 +107,14 @@
 			width: 100%;
 		}
 
+		.post-card__search-title {
+			display: block;
+
+			@include breakpoint( ">480px" ) {
+				display: inline;
+			}
+		}
+
 		.post-card__search-title-link {
 			color: $white;
 			padding-right: 20px;
@@ -178,8 +186,8 @@
 }
 
 .post-card__search-title {
-	@extend %content-font;
 	display: inline;
+	@extend %content-font;
 	font-size: 20px;
 	line-height: 20px;
 	font-weight: 700;
@@ -208,14 +216,14 @@
 		bottom: 0;
 		left: 0;
 		top: 0;
-	width: 90px;
+	width: 230px;
 
 	@include breakpoint( "660px-960px" ) {
 		width: 115px;
 	}
 
-	@include breakpoint( ">480px" ) {
-		width: 230px;
+	@include breakpoint( "<480px" ) {
+		width: 90px;
 	}
 }
 
@@ -238,10 +246,10 @@
 	font-size: 13px;
 	list-style: none;
 	margin: 6px 0;
-	padding-bottom: 10px;
+	padding: 0 0 10px 0;
 
 	@include breakpoint( ">480px" ) {
-		padding-bottom: 20px;
+		padding: 0 0 20px 0;
 	}
 
 	.gravatar {

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -249,7 +249,7 @@
 }
 
 .post-card__byline-author-and-site {
-	color: $gray;
+	color: lighten( $gray, 10% );
 	margin-right: 6px;
 }
 

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -88,7 +88,7 @@
 	}
 
 	&.is-photo {
-		height: 168px;
+		min-height: 168px;
 		padding: 20px;
 
 		&:before{
@@ -110,8 +110,12 @@
 		.post-card__search-title-link {
 			color: $white;
 			padding-right: 20px;
-			position: absolute;
-				bottom: 43px;
+			position: relative;
+				top: 80px;
+
+				@include breakpoint( "<480px" ) {
+					top: 100px;
+				}
 
 			&:hover {
 				opacity: .8;
@@ -119,8 +123,12 @@
 		}
 
 		.post-card__search-byline {
-			position: absolute;
-				bottom: 10px;
+			position: relative;
+				top: 80px;
+
+				@include breakpoint( "<480px" ) {
+					top: 100px;
+				}
 
 			a,
 			a:visited {
@@ -200,14 +208,14 @@
 		bottom: 0;
 		left: 0;
 		top: 0;
-	width: 230px;
+	width: 90px;
 
 	@include breakpoint( "660px-960px" ) {
 		width: 115px;
 	}
 
-	@include breakpoint( "<480px" ) {
-		width: 90px;
+	@include breakpoint( ">480px" ) {
+		width: 230px;
 	}
 }
 
@@ -230,16 +238,16 @@
 	font-size: 13px;
 	list-style: none;
 	margin: 6px 0;
-	padding: 0;
+	padding-bottom: 10px;
+
+	@include breakpoint( ">480px" ) {
+		padding-bottom: 20px;
+	}
 
 	.gravatar {
 		vertical-align: text-bottom;
 		margin: 0 4px 0 0;
 	}
-}
-
-.post-card__search-byline-item {
-	display: inline-block;
 }
 
 .post-card__author-and-site {

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -125,8 +125,8 @@
 		.post-card__search-byline {
 			position: relative;
 
-			a,
-			a:visited {
+			.post-card__byline-link,
+			.post-card__byline-link:visited {
 				color: $white;
 			}
 
@@ -244,6 +244,10 @@
 	}
 }
 
+.post-card__byline-author-and-site {
+	margin-right: 6px;
+}
+
 .post-card__author-and-site {
 	color: lighten( $gray, 10% );
 	margin-right: 10px;
@@ -315,16 +319,14 @@
 }
 
 // Custom colors for Site and Author info
+
 .reader__content {
 
-	.post-card__author-and-site {
+	.post-card__byline-link,
+	.post-card__byline-link:visited {
+		color: lighten( $gray, 10% );
 
-		a,
-		a:visited {
-			color: lighten( $gray, 10% );
-		}
-
-		a:hover {
+		&:hover {
 			color: $blue-wordpress;
 		}
 	}


### PR DESCRIPTION
In Search photo cards, if byline is long, it overlaps with the post title. This is especially evident in viewports `<480px`. This PR fixes it.

**Before:**
![screenshot 2016-07-27 14 15 50](https://cloud.githubusercontent.com/assets/4924246/17192778/dc92ced6-5404-11e6-88ce-c8243b06d695.png)

**After:**
![screenshot 2016-07-27 14 17 58](https://cloud.githubusercontent.com/assets/4924246/17192795/ede9e7f0-5404-11e6-8a17-a36ce6029cb7.png)



Test live: https://calypso.live/?branch=fix/reader/search-long-byline-overlap