### PR TITLE
Plans: add identifer to plans button for easier testing

### DIFF
--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -16,38 +16,19 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_PERSONAL
+	PLAN_PERSONAL,
+	getPlanClass
 } from 'lib/plans/constants';
 
 export default class PlanIcon extends Component {
 	render() {
 		const { plan, className } = this.props;
-		const planClass = this.getPlanClass( plan );
+		const planClass = getPlanClass( plan );
 		const classes = classNames( 'plan-icon', planClass, className );
 
 		return (
 			<div className={ classes } />
 		);
-	}
-
-	getPlanClass( plan ) {
-		switch ( plan ) {
-			case PLAN_JETPACK_FREE:
-			case PLAN_FREE:
-				return 'is-free-plan';
-			case PLAN_PERSONAL:
-				return 'is-personal-plan';
-			case PLAN_PREMIUM:
-			case PLAN_JETPACK_PREMIUM:
-			case PLAN_JETPACK_PREMIUM_MONTHLY:
-				return 'is-premium-plan';
-			case PLAN_BUSINESS:
-			case PLAN_JETPACK_BUSINESS:
-			case PLAN_JETPACK_BUSINESS_MONTHLY:
-				return 'is-business-plan';
-			default:
-				return '';
-		}
 	}
 }
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -519,3 +519,23 @@ export function isMonthly( plan ) {
 export function isPopular( plan ) {
 	return includes( POPULAR_PLANS, plan );
 }
+
+export function getPlanClass( plan ) {
+	switch ( plan ) {
+		case PLAN_JETPACK_FREE:
+		case PLAN_FREE:
+			return 'is-free-plan';
+		case PLAN_PERSONAL:
+			return 'is-personal-plan';
+		case PLAN_PREMIUM:
+		case PLAN_JETPACK_PREMIUM:
+		case PLAN_JETPACK_PREMIUM_MONTHLY:
+			return 'is-premium-plan';
+		case PLAN_BUSINESS:
+		case PLAN_JETPACK_BUSINESS:
+		case PLAN_JETPACK_BUSINESS_MONTHLY:
+			return 'is-business-plan';
+		default:
+			return '';
+	}
+}

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -13,6 +13,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 
 const PlanFeaturesActions = ( {
+	className,
 	available = true,
 	current = false,
 	popular = false,
@@ -22,15 +23,18 @@ const PlanFeaturesActions = ( {
 	translate
 } ) => {
 	let upgradeButton;
-	const className = classNames( {
-		'plan-features__actions-button': true,
-		'is-current': current,
-		'is-primary': popular && ! isPlaceholder,
-	} );
+	const classes = classNames(
+		'plan-features__actions-button',
+		{
+			'is-current': current,
+			'is-primary': popular && ! isPlaceholder
+		},
+		className
+	);
 
 	if ( current ) {
 		upgradeButton = (
-			<Button className={ className } disabled>
+			<Button className={ classes } disabled>
 				<Gridicon size={ 18 } icon="checkmark" />
 				{ translate( 'Your plan' ) }
 			</Button>
@@ -38,7 +42,7 @@ const PlanFeaturesActions = ( {
 	} else if ( available || isPlaceholder ) {
 		upgradeButton = (
 			<Button
-				className={ className }
+				className={ classes }
 				onClick={ isPlaceholder ? noop : onUpgradeClick }
 				disabled={ isPlaceholder }
 			>
@@ -61,6 +65,7 @@ const PlanFeaturesActions = ( {
 };
 
 PlanFeaturesActions.propTypes = {
+	className: PropTypes.string,
 	popular: PropTypes.bool,
 	current: PropTypes.bool,
 	available: PropTypes.bool,

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -21,7 +21,8 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_PERSONAL
+	PLAN_PERSONAL,
+	getPlanClass
 } from 'lib/plans/constants';
 import PlanIcon from 'components/plans/plan-icon';
 
@@ -43,11 +44,7 @@ class PlanFeaturesHeader extends Component {
 			'is-discounted': isDiscounted,
 			'is-placeholder': isPlaceholder
 		} );
-		const headerClasses = classNames( 'plan-features__header', {
-			'is-personal': planType === 'personal-bundle',
-			'is-premium': planType === 'value_bundle',
-			'is-business': planType === 'business-bundle'
-		} );
+		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 
 		return (
 			<header className={ headerClasses } onClick={ this.props.onClick } >

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -32,7 +32,8 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
-	getPlanFeaturesObject
+	getPlanFeaturesObject,
+	getPlanClass
 } from 'lib/plans/constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import {
@@ -120,6 +121,7 @@ class PlanFeatures extends Component {
 						{ planConstantObj.getDescription() }
 					</p>
 					<PlanFeaturesActions
+						className={ getPlanClass( planName ) }
 						current={ current }
 						popular={ popular }
 						available = { available }
@@ -234,6 +236,7 @@ class PlanFeatures extends Component {
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
+						className={ getPlanClass( planName ) }
 						current={ current }
 						available = { available }
 						popular={ popular }
@@ -317,6 +320,7 @@ class PlanFeatures extends Component {
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
+						className={ getPlanClass( planName ) }
 						current={ current }
 						available = { available }
 						popular={ popular }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -157,15 +157,15 @@ $plan-features-sidebar-width: 272px;
 		padding: 12px 12px 0 12px;
 	}
 
-	&.is-personal {
+	&.is-personal-plan {
 		border-bottom: solid 2px $alert-yellow;
 	}
 
-	&.is-premium {
+	&.is-premium-plan {
 		border-bottom: solid 2px $alert-green;
 	}
 
-	&.is-business {
+	&.is-business-plan {
 		border-bottom: solid 2px $alert-purple;
 	}
 }


### PR DESCRIPTION
This PR fixes #7092 by adding a plan modifier class to each plan button. This also fixes the Jetpack /plans page to show some color on the header instead of grey:
<img width="780" alt="screen shot 2016-07-27 at 4 00 18 pm" src="https://cloud.githubusercontent.com/assets/1270189/17195918/ab49781e-5415-11e6-82e7-fcb86744d4ad.png">


## Testing Instructions
- No functional changes in NUX flow (http://calypso.localhost/start)
- No functional changes in http://calypso.localhost:3000/plans upgrade
- plan modifier is available on all plan buttons, including desktop and mobile views


cc @hoverduck @rralian @lamosty @artpi @retrofox 

Test live: https://calypso.live/?branch=update/plan-feature-test-selector