### PR TITLE
CPT: Display menu children dynamically only when menu visible

### DIFF
--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -47,12 +47,12 @@ The position at which the menu should be rendered. If omitted, uses the default 
 ### `children`
 
 <table>
-	<tr><td>Type</td><td><code>PropTypes.node</code></td></tr>
+	<tr><td>Type</td><td>Function, <code>PropTypes.node</code></td></tr>
 	<tr><td>Required</td><td>No</td></tr>
 	<tr><td>Default</td><td><code>null</code></td></tr>
 </table>
 
-Menu children to be rendered.
+Menu children to be rendered. If specified as a function, the function will be invoked only when the menu is open, and is expected to return the child elements for display in the menu. This can be a performance optimization if the child menu items rendering is prohibitively expensive.
 
 ### `disabled`
 

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
+import PureComponent from 'react-pure-render/component';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 
@@ -12,12 +13,15 @@ import Gridicon from 'components/gridicon';
 import Button from 'components/button';
 import PopoverMenu from 'components/popover/menu';
 
-class EllipsisMenu extends Component {
+class EllipsisMenu extends PureComponent {
 	static propTypes = {
 		translate: PropTypes.func,
 		toggleTitle: PropTypes.string,
 		position: PropTypes.string,
-		children: PropTypes.node,
+		children: PropTypes.oneOfType( [
+			PropTypes.node,
+			PropTypes.func
+		] ),
 		disabled: PropTypes.bool,
 	};
 
@@ -47,8 +51,21 @@ class EllipsisMenu extends Component {
 		}
 	}
 
+	getChildren() {
+		const { children } = this.props;
+		if ( 'function' !== typeof children ) {
+			return children;
+		}
+
+		if ( ! this.state.isMenuVisible ) {
+			return null;
+		}
+
+		return children();
+	}
+
 	render() {
-		const { toggleTitle, translate, position, children, disabled } = this.props;
+		const { toggleTitle, translate, position, disabled } = this.props;
 		const { isMenuVisible, popoverContext } = this.state;
 		const classes = classnames( 'ellipsis-menu', {
 			'is-menu-visible': isMenuVisible,
@@ -74,7 +91,7 @@ class EllipsisMenu extends Component {
 					position={ position }
 					context={ popoverContext }
 					className="ellipsis-menu__menu popover">
-					{ children }
+					{ this.getChildren() }
 				</PopoverMenu>
 			</span>
 		);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes, Children, cloneElement } from 'react';
+import PureComponent from 'react-pure-render/component';
 
 /**
  * Internal dependencies
@@ -15,44 +16,58 @@ import PostActionsEllipsisMenuTrash from './trash';
 import PostActionsEllipsisMenuView from './view';
 import PostActionsEllipsisMenuRestore from './restore';
 
-export default function PostActionsEllipsisMenu( { globalId, includeDefaultActions, children } ) {
-	let actions = [];
+export default class PostActionsEllipsisMenu extends PureComponent {
+	static propTypes = {
+		globalId: PropTypes.string,
+		includeDefaultActions: PropTypes.bool,
+		children: PropTypes.node
+	};
 
-	if ( includeDefaultActions ) {
-		actions.push(
-			<PostActionsEllipsisMenuEdit key="edit" />,
-			<PostActionsEllipsisMenuView key="view" />,
-			<PostActionsEllipsisMenuStats key="stats" />,
-			<PostActionsEllipsisMenuPublish key="publish" />,
-			<PostActionsEllipsisMenuRestore key="restore" />,
-			<PostActionsEllipsisMenuTrash key="trash" />
-		);
+	static defaultProps = {
+		includeDefaultActions: true
+	};
+
+	constructor() {
+		super( ...arguments );
+
+		this.renderChildren = this.renderChildren.bind( this );
 	}
 
-	children = Children.toArray( children );
-	if ( children.length ) {
-		if ( actions.length ) {
-			actions.push( <PopoverMenuSeparator key="separator" /> );
+	renderChildren() {
+		const { globalId, includeDefaultActions } = this.props;
+		let { children } = this.props;
+		let actions = [];
+
+		if ( includeDefaultActions ) {
+			actions.push(
+				<PostActionsEllipsisMenuEdit key="edit" />,
+				<PostActionsEllipsisMenuView key="view" />,
+				<PostActionsEllipsisMenuStats key="stats" />,
+				<PostActionsEllipsisMenuPublish key="publish" />,
+				<PostActionsEllipsisMenuRestore key="restore" />,
+				<PostActionsEllipsisMenuTrash key="trash" />
+			);
 		}
 
-		actions = actions.concat( children );
+		children = Children.toArray( children );
+		if ( children.length ) {
+			if ( actions.length ) {
+				actions.push( <PopoverMenuSeparator key="separator" /> );
+			}
+
+			actions = actions.concat( children );
+		}
+
+		return actions.map( ( action ) => cloneElement( action, { globalId } ) );
 	}
 
-	return (
-		<div className="post-actions-ellipsis-menu">
-			<EllipsisMenu position="bottom left" disabled={ ! globalId }>
-				{ actions.map( ( action ) => cloneElement( action, { globalId } ) ) }
-			</EllipsisMenu>
-		</div>
-	);
+	render() {
+		return (
+			<div className="post-actions-ellipsis-menu">
+				<EllipsisMenu position="bottom left" disabled={ ! this.props.globalId }>
+					{ this.renderChildren }
+				</EllipsisMenu>
+			</div>
+		);
+	}
 }
-
-PostActionsEllipsisMenu.propTypes = {
-	globalId: PropTypes.string,
-	includeDefaultActions: PropTypes.bool,
-	children: PropTypes.node
-};
-
-PostActionsEllipsisMenu.defaultProps = {
-	includeDefaultActions: true
-};


### PR DESCRIPTION
This pull request seeks to optimize the performance of the custom post types list screen by avoiding unnecessary render attempts to post action menu children when the ellipsis menu is not toggled to be visible. It does so by adding new support for specifying `<EllipsisMenu />` children as a function to be invoked only when the menu is visible.

__Testing Instructions:__

Verify that there are no regressions in using the ellipsis menu on the [custom post types list screen](http://calypso.localhost:3000/types/post). To my knowledge, `<EllipsisMenu />` is not used anywhere except this screen, and this screen is not yet a production feature.

Test live: https://calypso.live/?branch=update/cpt-post-actions-function-children