### PR TITLE
CPT: Resolve prop warning on post action stats menu item

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -35,7 +35,7 @@ function PostActionsEllipsisMenuStats( { translate, siteSlug, postId, status, is
 PostActionsEllipsisMenuStats.propTypes = {
 	globalId: PropTypes.string,
 	translate: PropTypes.func.isRequired,
-	siteSlug: PropTypes.number,
+	siteSlug: PropTypes.string,
 	postId: PropTypes.number,
 	status: PropTypes.string,
 	isStatsActive: PropTypes.bool

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -13,13 +13,13 @@ import { mc } from 'lib/analytics';
 import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getPost } from 'state/posts/selectors';
 
+function bumpStat() {
+	mc.bumpStat( 'calypso_cpt_actions', 'stats' );
+}
+
 function PostActionsEllipsisMenuStats( { translate, siteSlug, postId, status, isStatsActive } ) {
 	if ( ! isStatsActive || 'publish' !== status ) {
 		return null;
-	}
-
-	function bumpStat() {
-		mc.bumpStat( 'calypso_cpt_actions', 'stats' );
 	}
 
 	return (


### PR DESCRIPTION
This pull request seeks to resolve a warning which can occur when toggling the ellipsis menu on the custom post types list screen for a published post. Specifically, the stats action component currently anticipates a `siteSlug` prop of type number, when in fact the slug is a string.

Further, this pull request refactors the component as a class extending `React.Component`, which avoids unnecessarily redeclaring the `bumpStat` function on each render.

__Testing instructions:__

Repeat testing instructions from #6729

Verify that no warning is logged to the console when toggling the ellipsis menu for a published post on the [custom post types list screen](http://calypso.localhost:3000/types/post).

Test live: https://calypso.live/?branch=fix/cpt-stats-action-warning