### PR TITLE
Framework: Upgrade classnames from 1.1.1 to 2.2.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -510,7 +510,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000515"
+      "version": "1.0.30000517"
     },
     "caseless": {
       "version": "0.11.0"
@@ -576,7 +576,7 @@
       "version": "0.3.1"
     },
     "classnames": {
-      "version": "1.1.1"
+      "version": "2.2.5"
     },
     "clean-css": {
       "version": "3.4.19",
@@ -1774,7 +1774,7 @@
       "version": "1.0.1"
     },
     "is-buffer": {
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     "is-builtin-module": {
       "version": "1.0.0"
@@ -2853,12 +2853,7 @@
       }
     },
     "react-virtualized": {
-      "version": "7.9.1",
-      "dependencies": {
-        "classnames": {
-          "version": "2.2.5"
-        }
-      }
+      "version": "7.9.1"
     },
     "read-all-stream": {
       "version": "3.1.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chalk": "1.0.0",
     "char-spinner": "1.0.1",
     "chrono-node": "^1.0.6",
-    "classnames": "1.1.1",
+    "classnames": "2.2.5",
     "click-outside": "2.0.1",
     "clipboard": "1.5.3",
     "commander": "2.3.0",


### PR DESCRIPTION
This pull request seeks to upgrade the `classnames` dependency from 1.1.1 to 2.2.5, in hopes of taking advantage of [some performance improvements noted in many versions released since 1.1.1](https://github.com/JedWatson/classnames/blob/master/HISTORY.md).

The breaking change in 2.0.0 affects usage only in IE8 or earlier, which is not a supported browser of Calypso and should not be a concern.

__Testing instructions:__

Verify that no regressions occur in generating class names in Calypso (most obviously in styling of components and lack of console errors).

Test live: https://calypso.live/?branch=update/classnames-2-2-5