### PR TITLE
Progress Bar: Add a small css transition animation to the progress bar.

### DIFF
--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -19,6 +19,7 @@
 	height: 100%;
 	background-color: lighten( $blue-dark, 10% );
 	border-radius: 4.5px;
+	transition: width 200ms;
 }
 
 /* Percentage bar */


### PR DESCRIPTION
Currently there is no transition animation on the progress bar. This makes the jump between different progress points a bit strange. Since it is expected to see a bit of an animation between 2 different states. 

### How to test
- Go to a jetpack site settings that has 4.2-beta or higher version of Jetpack installed
Click the trigger full sync button.

cc: @MichaelArestad, @rickybanister 

Test live: https://calypso.live/?branch=update/smoother-transition-progress-bar
