### PR TITLE
Modules: Remove js error when acivation of modules fails

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -244,7 +244,7 @@ JetpackSite.prototype.deactivateModule = function( moduleId, callback ) {
 JetpackSite.prototype.toggleModule = function( moduleId, callback ) {
 	const isActive = this.isModuleActive( moduleId ),
 		method = isActive ? 'jetpackModulesDeactivate' : 'jetpackModulesActivate',
-		prevActiveModules = Object.assign( {}, this.modules );
+		prevActiveModules = [ ...this.modules ];
 
 	if ( isActive ) {
 		this.modules = this.modules.filter( module => module !== moduleId );


### PR DESCRIPTION
this.modules as incorrectly assigned to an Object instead of an Array
which caused an error. When trying to figure out if a module is active
or not. This PR fixes this by making sure that the module is

### Test
Got to the security settings then visit your site jetpack dashboard on
your jetpack site. And toggle the state of protect. This will cause the
error because the module is already active for example. Notice that
this there is no more JS error.

cc: @lezama, @roccotripaldi 

Test live: https://calypso.live/?branch=fix/modules-activation-js-error