### PR TITLE
CPT: Restore posts to the Trashed list if deletion fails

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -19,6 +19,7 @@ import PostQueryManager from 'lib/query-manager/post';
 import {
 	POST_DELETE,
 	POST_DELETE_SUCCESS,
+	POST_DELETE_FAILURE,
 	POST_EDIT,
 	POST_EDITS_RESET,
 	POST_REQUEST,
@@ -198,6 +199,12 @@ export const queries = ( () => {
 			return applyToManager( state, siteId, 'receive', false, {
 				ID: postId,
 				status: '__DELETE_PENDING'
+			}, { patch: true } );
+		},
+		[ POST_DELETE_FAILURE ]: ( state, { siteId, postId } ) => {
+			return applyToManager( state, siteId, 'receive', false, {
+				ID: postId,
+				status: 'trash'
 			}, { patch: true } );
 		},
 		[ POST_DELETE_SUCCESS ]: ( state, { siteId, postId } ) => {

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -11,6 +11,7 @@ import sinon from 'sinon';
 import {
 	POST_DELETE,
 	POST_DELETE_SUCCESS,
+	POST_DELETE_FAILURE,
 	POST_EDIT,
 	POST_EDITS_RESET,
 	POST_REQUEST,
@@ -438,6 +439,40 @@ describe( 'reducer', () => {
 
 			expect( state[ 2916284 ].getItem( 841 ).status ).to.equal( '__DELETE_PENDING' );
 			expect( state[ 2916284 ].getItems( { status: 'trash' } ) ).to.have.length( 0 );
+		} );
+
+		it( 'should restore item when post delete fails', () => {
+			let original = deepFreeze( {} );
+			original = queries( original, {
+				type: POSTS_REQUEST_SUCCESS,
+				siteId: 2916284,
+				query: { status: 'trash' },
+				found: 1,
+				posts: [ {
+					ID: 841,
+					site_ID: 2916284,
+					global_ID: '48b6010b559efe6a77a429773e0cbf12',
+					title: 'Trashed',
+					status: 'trash',
+					type: 'post'
+				} ]
+			} );
+			original = queries( original, {
+				type: POST_DELETE,
+				siteId: 2916284,
+				postId: 841
+			} );
+
+			expect( original[ 2916284 ].getItems( { status: 'trash' } ) ).to.have.length( 0 );
+
+			const state = queries( original, {
+				type: POST_DELETE_FAILURE,
+				siteId: 2916284,
+				postId: 841
+			} );
+
+			expect( state[ 2916284 ].getItem( 841 ).status ).to.equal( 'trash' );
+			expect( state[ 2916284 ].getItems( { status: 'trash' } ) ).to.have.length( 1 );
 		} );
 
 		it( 'should remove item when post delete action success dispatched', () => {


### PR DESCRIPTION
Fixes #7116 - see that issue for details and a recording of the current behavior.

### To test

In order to test this PR you'll need to make delete requests to the API fail.  The cleanest way I know of to do this without affecting other network requests is to sandbox public-api.wordpress.com and apply this patch: 152f0-pb

1. Start with one or more trashed posts in the CPT posts list.
2. Delete the post using the ellipsis menu and confirm the deletion.
3. Observe notice "An error occurred while deleting ..." and the post is restored to the "Trashed" list.

### Implementation notes

- The `/delete` API endpoint calls [`wp_delete_post`](https://codex.wordpress.org/Function_Reference/wp_delete_post) which will trash a post on the first call and delete it on the second.
- In Calypso we only call the `/delete` endpoint from the [`deletePost` action](https://github.com/Automattic/wp-calypso/blob/ce274a4/client/state/posts/actions.js#L234-L266), and we only call this action [if the post status is already `trash`](https://github.com/Automattic/wp-calypso/blob/986ee29/client/my-sites/post-type-list/post-actions-ellipsis-menu/trash.jsx#L46).  (The inline documentation for the `deletePost` action mentions this as the recommended usage.)

So, from the perspective of both the API and the Calypso code, we can safely assume that the previous post status was `trash` before the failed deletion.

Test live: https://calypso.live/?branch=fix/state-posts-delete-failure