### PR TITLE
CPT: Fix a "Failed propType" warning in PostActionsEllipsisMenuStats

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -35,7 +35,7 @@ function PostActionsEllipsisMenuStats( { translate, siteSlug, postId, status, is
 PostActionsEllipsisMenuStats.propTypes = {
 	globalId: PropTypes.string,
 	translate: PropTypes.func.isRequired,
-	siteSlug: PropTypes.number,
+	siteSlug: PropTypes.string,
 	postId: PropTypes.number,
 	status: PropTypes.string,
 	isStatsActive: PropTypes.bool


### PR DESCRIPTION
### To test

1. Visit the CPT listing page
2. Click the ellipsis menu
3. Observe the following warning in `master` but not on this branch:

> Warning: Failed propType: Invalid prop `siteSlug` of type `string` supplied to `PostActionsEllipsisMenuStats`, expected `number`. Check the render method of `LocalizedPostActionsEllipsisMenuStats`.

### Screenshot

![image](https://cloud.githubusercontent.com/assets/227022/17201644/f52eb1e8-5455-11e6-8e48-0b62a67d8acc.png)

Test live: https://calypso.live/?branch=fix/cpt-posts-stats-siteSlug-propType