### PR TITLE
CPT: Fix empty ellipsis menu on posts loading placeholder

### DIFF
--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -53,3 +53,13 @@ The position at which the menu should be rendered. If omitted, uses the default 
 </table>
 
 Menu children to be rendered.
+
+### `disabled`
+
+<table>
+	<tr><td>Type</td><td><code>PropTypes.bool</code></td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>null</code></td></tr>
+</table>
+
+If `true`, then the menu icon will be displayed in light gray and will not be clickable.

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -17,7 +17,8 @@ class EllipsisMenu extends Component {
 		translate: PropTypes.func,
 		toggleTitle: PropTypes.string,
 		position: PropTypes.string,
-		children: PropTypes.node
+		children: PropTypes.node,
+		disabled: PropTypes.bool,
 	};
 
 	constructor() {
@@ -41,14 +42,17 @@ class EllipsisMenu extends Component {
 	}
 
 	toggleMenu( isMenuVisible ) {
-		this.setState( { isMenuVisible } );
+		if ( ! this.props.disabled ) {
+			this.setState( { isMenuVisible } );
+		}
 	}
 
 	render() {
-		const { toggleTitle, translate, position, children } = this.props;
+		const { toggleTitle, translate, position, children, disabled } = this.props;
 		const { isMenuVisible, popoverContext } = this.state;
 		const classes = classnames( 'ellipsis-menu', {
-			'is-menu-visible': isMenuVisible
+			'is-menu-visible': isMenuVisible,
+			'is-disabled': disabled
 		} );
 
 		return (
@@ -58,6 +62,7 @@ class EllipsisMenu extends Component {
 					onClick={ isMenuVisible ? this.hideMenu : this.showMenu }
 					title={ toggleTitle || translate( 'Toggle menu' ) }
 					borderless
+					disabled={ disabled }
 					className="ellipsis-menu__toggle">
 					<Gridicon
 						icon="ellipsis"

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -40,7 +40,7 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 
 	return (
 		<div className="post-actions-ellipsis-menu">
-			<EllipsisMenu position="bottom left">
+			<EllipsisMenu position="bottom left" disabled={ ! globalId }>
 				{ actions.map( ( action ) => cloneElement( action, { globalId } ) ) }
 			</EllipsisMenu>
 		</div>


### PR DESCRIPTION
### To test

1. Visit the CPT listing
2. While posts are loading, click the ellipsis menu
3. Note that in `master` the menu is clickable and displays an empty menu when expanded
4. Note that in this branch the menu is not clickable and the icon displays in a light color with the default cursor due to the [`.button.is-borderless:disabled` styles](https://github.com/Automattic/wp-calypso/blob/1efc66c/client/components/button/style.scss#L180-L188)

### Recording

![cpt-loading-menu](https://cloud.githubusercontent.com/assets/227022/17202103/b25727a4-545c-11e6-8db1-f7b3916b34c9.gif)

Test live: https://calypso.live/?branch=fix/cpt-loading-ellipsis-menu