### PR TITLE
Desktop: use the ‘env_id’ config for desktop app login

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -38,7 +38,7 @@ module.exports = {
 		const loggedOutRoutes = [ '/login', '/oauth', '/start', '/authorize', '/api/oauth/token' ],
 			isValidSection = loggedOutRoutes.some( route => startsWith( context.path, route ) );
 
-		if ( config( 'env' ) === 'desktop' ) {
+		if ( config( 'env_id' ) === 'desktop' ) {
 			// Check we have an OAuth token, otherwise redirect to login page
 			if ( OAuthToken.getToken() === false && ! isValidSection ) {
 				return page( '/login' );


### PR DESCRIPTION
The oAuth changes in https://github.com/Automattic/wp-calypso/pull/4506 caused the desktop app to use the `/authorize` screen. This seems to be because the choice of whether to use the `/authorize` or `/login` page is determined by the `env` config setting.

In the `desktop.json` file the `env` parameter is set to `production` so the choice always defaults to `/authorize`

This PR changes this to use `env_id` instead. I'm not really sure of the difference for `env` and `env_id`, but in `desktop.json` it is `desktop` and so the app uses the correct `/login` page. There may be other things involved here I'm unaware of.

The `env_id` setting is in all of the config files so the change shouldn't affect anything else.

To test:
- Build the desktop app without this PR, see errors about `oauth_client_id` and authorising the app
- Build the desktop app with this PR and see the app login page

@mtias 

Test live: https://calypso.live/?branch=fix/desktop-app-oauth