### PR TITLE
Translator: Remove Invitation A/B Test

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -31,7 +31,7 @@
 
 $z-layers: (
 	'root': (
-		'.translator-invitation:before': -1,
+		'.community-translator__translator-invitation:before': -1,
 		'.NuxWelcome:before': -1,
 		'.infinite-scroll-end:before': -1,
 		'.is-group-editor::before': -1,

--- a/client/layout/community-translator/invitation.jsx
+++ b/client/layout/community-translator/invitation.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import merge from 'lodash/merge';
 
 /**
  * Internal dependencies
@@ -25,7 +24,7 @@ export default React.createClass( {
 
 		invitationUtils.recordInvitationDisplayed();
 
-		let subComponents = {
+		const subComponents = {
 			title: this.translate( 'Translate WordPress.com as you go' ),
 			acceptButtonText: this.translate( 'Try it now!' ),
 			dismissButtonText: this.translate( 'No thanks' ),
@@ -33,37 +32,37 @@ export default React.createClass( {
 			' native language using the Community Translator tool. ' +
 			'{{docsLink}}Find out more{{/docsLink}}. ',
 				{ components: { docsLink: <a target="_blank"
-						className="translator-invitation__link"
+						className="community-translator__translator-invitation__link"
 						href="https://en.support.wordpress.com/community-translator/"
 						onClick={ this.docsLink } /> } } )
 		};
 
 		return (
-			<div className="translator-invitation welcome-message">
-				<div className="translator-invitation__primary-content">
-					<h3 className="translator-invitation__title">{ subComponents.title }</h3>
+			<div className="community-translator__translator-invitation welcome-message">
+				<div className="community-translator__translator-invitation__primary-content">
+					<h3 className="community-translator__translator-invitation__title">{ subComponents.title }</h3>
 
-					<div className="translator-invitation__secondary-content">
-						<p className="translator-invitation__intro">
+					<div className="community-translator__translator-invitation__secondary-content">
+						<p className="community-translator__translator-invitation__intro">
 							{ subComponents.content }
 						</p>
-						<div className="translator-invitation__actions">
+						<div className="community-translator__translator-invitation__actions">
 							<button
 								type="button"
-								className="button is-primary"
+								className="community-translator__action button is-primary"
 								onClick={ this.acceptButton }>
 								{ subComponents.acceptButtonText }
 							</button>
 							<button
 								type="button"
-								className="button"
+								className="community-translator__action button"
 								onClick={ this.dismissButton }>
 								{ subComponents.dismissButtonText }
 							</button>
 						</div>
 					</div>
 				</div>
-				<Gridicon className="translator-invitation__decoration" icon="globe" />
+				<Gridicon className="community-translator__translator-invitation__decoration" icon="globe" />
 			</div>
 		);
 	},

--- a/client/layout/community-translator/invitation.jsx
+++ b/client/layout/community-translator/invitation.jsx
@@ -27,7 +27,7 @@ export default React.createClass( {
 
 		let subComponents = {
 			title: this.translate( 'Translate WordPress.com as you go' ),
-			acceptButtonText: this.translate( 'Start now' ),
+			acceptButtonText: this.translate( 'Try it now!' ),
 			dismissButtonText: this.translate( 'No thanks' ),
 			content: this.translate( 'Help translate the WordPress.com dashboard into your' +
 			' native language using the Community Translator tool. ' +
@@ -37,9 +37,6 @@ export default React.createClass( {
 						href="https://en.support.wordpress.com/community-translator/"
 						onClick={ this.docsLink } /> } } )
 		};
-
-		// Apply ABTest related changes
-		subComponents = merge( subComponents, invitationUtils.subComponentVariations() );
 
 		return (
 			<div className="translator-invitation welcome-message">

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -95,7 +95,7 @@ body {
 	max-width: 400px;
 }
 
-.translator-invitation {
+.community-translator__translator-invitation {
 	background: none;
 	position: relative;
 	padding: 24px 18px 0;
@@ -113,13 +113,13 @@ body {
 			right: 0;
 		height: 1px;
 		margin-top: 35px;
-		z-index: z-index( 'root', '.translator-invitation:before' );
+		z-index: z-index( 'root', '.community-translator__translator-invitation:before' );
 		background: linear-gradient( to right, fade-out( lighten( $gray, 20% ), 1 ) 0%, lighten( $gray, 20% ) 20%, lighten( $gray, 20% ) 80%, fade-out( lighten( $gray, 20% ), 1 ) 100% );
 	}
 	.close-button {
 		padding: 6px;
 	}
-	.translator-invitation__decoration {
+	.community-translator__translator-invitation__decoration {
 		// copied from noticons styling
 		background-color: $gray-light;
 		color: $gray;
@@ -135,7 +135,7 @@ body {
 	}
 }
 
-.translator-invitation__title {
+.community-translator__translator-invitation__title {
 	@extend %heading;
 	color: $gray-dark;
 	font-family: $serif;
@@ -145,7 +145,7 @@ body {
 	margin: 0 0 12px;
 }
 
-.translator-invitation__primary-content {
+.community-translator__translator-invitation__primary-content {
 	font-size: 16px;
 	line-height: 24px;
 	.button {
@@ -157,16 +157,16 @@ body {
 	}
 }
 
-.translator-invitation__secondary-content {
+.community-translator__translator-invitation__secondary-content {
 	flex-direction: column;
 }
 
-.translator-invitation__intro {
+.community-translator__translator-invitation__intro {
 	flex-grow: 100%;
 	margin-bottom: 20px;
 }
 
-.translator-invitation__link {
+.community-translator__translator-invitation__link {
 	color: $blue-medium;
 	text-shadow: 1px 0 lighten( $gray, 30% ), 2px 0 lighten( $gray, 30% ), -1px 0 lighten( $gray, 30% ), -2px 0 lighten( $gray, 30% );
 	background-image: linear-gradient( to bottom, transparent 50%, $blue-medium 50% );
@@ -175,7 +175,7 @@ body {
 	background-position: 0 85%;
 }
 
-.translator-invitation__actions {
+.community-translator__translator-invitation__actions {
 	flex-grow: 100%;
 	> :last-child {
 		margin-right: 0;
@@ -183,15 +183,15 @@ body {
 }
 
 @include breakpoint( ">660px" ) {
-	.translator-invitation {
+	.community-translator__translator-invitation {
 		padding: 12px 0 0;
 	}
 
-	.translator-invitation__title {
+	.community-translator__translator-invitation__title {
 		clear: none;
 	}
 
-	.translator-invitation__primary-content {
+	.community-translator__translator-invitation__primary-content {
 		margin-bottom: 0;
 		.button {
 			display: inline-block;
@@ -202,17 +202,17 @@ body {
 		}
 	}
 
-	.translator-invitation__intro {
+	.community-translator__translator-invitation__intro {
 		flex: 0 1 auto;
 		margin-bottom: 0px;
 	}
 
-	.translator-invitation__actions {
+	.community-translator__translator-invitation__actions {
 		flex: 0 0 auto;
 		margin-left: 2%;
 	}
 
-	.translator-invitation__secondary-content {
+	.community-translator__translator-invitation__secondary-content {
 		align-items: center;
 		display: flex;
 		flex-direction: row;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -60,19 +60,6 @@ module.exports = {
 		defaultVariation: 'designTypeWithoutStore',
 		allowExistingUsers: false,
 	},
-	translatorInvitation: {
-		datestamp: '20150910',
-		variations: {
-			noNotice: 1,
-			startNow: 1,
-			helpUs: 1,
-			tryItNow: 1,
-			startTranslating: 1,
-			improve: 1
-		},
-		defaultVariation: 'noNotice',
-		allowAnyLocale: true
-	},
 	firstView: {
 		datestamp: '20160726',
 		variations: {


### PR DESCRIPTION
The A/B test has been running long enough, so it's time to remove it. cc @deBhal 

I also took the opportunity to fix the linting errors and pull it up to ES5.

Test live: https://calypso.live/?branch=remove/translation-invitation-ab-test