### PR TITLE
Components: update follow button container to pass disabled prop

### DIFF
--- a/client/components/follow-button/button.jsx
+++ b/client/components/follow-button/button.jsx
@@ -46,8 +46,8 @@ const FollowButton = React.createClass( {
 	},
 
 	render() {
-		let menuClasses = [ 'button', 'follow-button', 'has-icon' ];
 		let label = this.strings.FOLLOW;
+		const menuClasses = [ 'button', 'follow-button', 'has-icon' ];
 		const iconSize = this.props.iconSize;
 
 		if ( this.props.following ) {

--- a/client/components/follow-button/index.jsx
+++ b/client/components/follow-button/index.jsx
@@ -58,7 +58,8 @@ const FollowButtonContainer = React.createClass( {
 				following={ this.state.following }
 				onFollowToggle={ this.handleFollowToggle }
 				iconSize={ this.props.iconSize }
-				tagName={ this.props.tagName } />
+				tagName={ this.props.tagName }
+				disabled={ this.props.disabled }/>
 		);
 	}
 } );


### PR DESCRIPTION
This allows users of the `FollowButtonContainer` to use the `disabled` feature of the `FollowButton` component. 

### Test

Add  `disabled={ true }` to a `FollowButtonContainer` component and the rendered follow button will be disabled.

/cc @bluefuton 

Test live: https://calypso.live/?branch=update/follow-button-container/disabled