### PR TITLE
Add new author-compact-profile component for the new Reader full post view

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -12,6 +12,7 @@
 @import 'components/accordion/style';
 @import 'components/app-promo/style';
 @import 'blocks/author-selector/style';
+@import 'blocks/author-compact-profile/style';
 @import 'components/bulk-select/style';
 @import 'components/button/style';
 @import 'components/button-group/style';

--- a/client/blocks/author-compact-profile/docs/example.jsx
+++ b/client/blocks/author-compact-profile/docs/example.jsx
@@ -26,7 +26,13 @@ export default React.createClass( {
 					<a href="/devdocs/blocks/author-compact-profile">Author Compact Profile</a>
 				</h2>
 				<Card>
-					<AuthorCompactProfile author={ author } />
+					<AuthorCompactProfile
+						author={ author }
+						siteName={ 'Bananas' }
+						siteUrl={ 'http://wpcalypso.wordpress.com' }
+						followCount={ 123 }
+						feedId={ 1 }
+						siteId={ null } />
 				</Card>
 			</div>
 		);

--- a/client/blocks/author-compact-profile/docs/example.jsx
+++ b/client/blocks/author-compact-profile/docs/example.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import AuthorCompactProfile from 'blocks/author-compact-profile';
+import Card from 'components/card';
+
+export default React.createClass( {
+
+	displayName: 'AuthorCompactProfile',
+
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/blocks/author-compact-profile">Author Compact Profile</a>
+				</h2>
+				<Card>
+					<AuthorCompactProfile />
+				</Card>
+			</div>
+		);
+	}
+} );

--- a/client/blocks/author-compact-profile/docs/example.jsx
+++ b/client/blocks/author-compact-profile/docs/example.jsx
@@ -14,13 +14,19 @@ export default React.createClass( {
 	displayName: 'AuthorCompactProfile',
 
 	render() {
+		const author = {
+			avatar_URL: 'https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=identicon',
+			display_name: 'Bob The Tester',
+			URL: 'http://wpcalypso.wordpress.com'
+		};
+
 		return (
 			<div className="design-assets__group">
 				<h2>
 					<a href="/devdocs/blocks/author-compact-profile">Author Compact Profile</a>
 				</h2>
 				<Card>
-					<AuthorCompactProfile />
+					<AuthorCompactProfile author={ author } />
 				</Card>
 			</div>
 		);

--- a/client/blocks/author-compact-profile/docs/example.jsx
+++ b/client/blocks/author-compact-profile/docs/example.jsx
@@ -16,7 +16,7 @@ export default React.createClass( {
 	render() {
 		const author = {
 			avatar_URL: 'https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=identicon',
-			display_name: 'Bob The Tester',
+			name: 'Bob The Tester',
 			URL: 'http://wpcalypso.wordpress.com'
 		};
 

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -14,27 +14,28 @@ import { localize } from 'i18n-calypso';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
-		author: React.PropTypes.object.isRequired
+		author: React.PropTypes.object.isRequired,
+		siteName: React.PropTypes.string,
+		siteUrl: React.PropTypes.string,
+		followCount: React.PropTypes.number,
+		feedId: React.PropTypes.number,
+		siteId: React.PropTypes.number
 	},
 
 	render() {
-		const author = this.props.author;
-
-		// @todo these need to come from props
-		const siteName = 'Bananas';
-		const siteUrl = 'http://wpcalypso.wordpress.com';
-		const followCount = 123;
-		const feedId = 123;
-		const siteId = 123;
+		const { author, siteName, siteUrl, followCount, feedId, siteId } = this.props;
 
 		return (
 			<div className="author-compact-profile">
 				<Gravatar size={ 96 } user={ author } />
 				<ReaderAuthorLink author={ author }>{ author.display_name }</ReaderAuthorLink>
-				<ReaderSiteStreamLink feedId={ feedId } siteId={ siteId }>
-					{ siteName }
-				</ReaderSiteStreamLink>
-				<div className="author-compact-profile__follower-count">
+				{ siteName && siteUrl
+					? <ReaderSiteStreamLink feedId={ feedId } siteId={ siteId }>
+						{ siteName }
+					</ReaderSiteStreamLink> : null }
+
+				{ followCount
+					? <div className="author-compact-profile__follow-count">
 					{ this.props.translate(
 						'%(followCount)d follower',
 						'%(followCount)d followers',
@@ -45,7 +46,8 @@ const AuthorCompactProfile = React.createClass( {
 							}
 						}
 					) }
-				</div>
+					</div> : null }
+
 				<ReaderFollowButton siteUrl={ siteUrl } />
 			</div>
 		);

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -6,15 +6,20 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Gravatar from 'components/gravatar';
+import ReaderAuthorLink from 'components/reader-author-link';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
+		author: React.PropTypes.object.isRequired
 	},
 
 	render() {
+		const author = this.props.author;
 		return (
 			<div className="author-compact-profile">
-				author-compact-profile
+				<Gravatar size={ 96 } user={ author } />
+				<ReaderAuthorLink author={ author }>{ author.display_name }</ReaderAuthorLink>
 			</div>
 		);
 	}

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -25,10 +25,14 @@ const AuthorCompactProfile = React.createClass( {
 	render() {
 		const { author, siteName, siteUrl, followCount, feedId, siteId } = this.props;
 
+		if ( ! author ) {
+			return null;
+		}
+
 		return (
 			<div className="author-compact-profile">
 				<Gravatar size={ 96 } user={ author } />
-				<ReaderAuthorLink author={ author }>{ author.display_name }</ReaderAuthorLink>
+				<ReaderAuthorLink author={ author }>{ author.name }</ReaderAuthorLink>
 				{ siteName && siteUrl
 					? <ReaderSiteStreamLink feedId={ feedId } siteId={ siteId }>
 						{ siteName }

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+const AuthorCompactProfile = React.createClass( {
+	propTypes: {
+	},
+
+	render() {
+		return (
+			<div className="author-compact-profile">
+				author-compact-profile
+			</div>
+		);
+	}
+
+} );
+
+export default AuthorCompactProfile;

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -8,6 +8,9 @@ import React from 'react';
  */
 import Gravatar from 'components/gravatar';
 import ReaderAuthorLink from 'components/reader-author-link';
+import ReaderSiteStreamLink from 'components/reader-site-stream-link';
+import ReaderFollowButton from 'reader/follow-button';
+import { localize } from 'i18n-calypso';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
@@ -16,14 +19,38 @@ const AuthorCompactProfile = React.createClass( {
 
 	render() {
 		const author = this.props.author;
+
+		// @todo these need to come from props
+		const siteName = 'Bananas';
+		const siteUrl = 'http://wpcalypso.wordpress.com';
+		const followCount = 123;
+		const feedId = 123;
+		const siteId = 123;
+
 		return (
 			<div className="author-compact-profile">
 				<Gravatar size={ 96 } user={ author } />
 				<ReaderAuthorLink author={ author }>{ author.display_name }</ReaderAuthorLink>
+				<ReaderSiteStreamLink feedId={ feedId } siteId={ siteId }>
+					{ siteName }
+				</ReaderSiteStreamLink>
+				<div className="author-compact-profile__follower-count">
+					{ this.props.translate(
+						'%(followCount)d follower',
+						'%(followCount)d followers',
+						{
+							count: followCount,
+							args: {
+								followCount: followCount
+							}
+						}
+					) }
+				</div>
+				<ReaderFollowButton siteUrl={ siteUrl } />
 			</div>
 		);
 	}
 
 } );
 
-export default AuthorCompactProfile;
+export default localize( AuthorCompactProfile );

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -34,10 +34,11 @@ const AuthorCompactProfile = React.createClass( {
 				<Gravatar size={ 96 } user={ author } />
 				<ReaderAuthorLink author={ author }>{ author.name }</ReaderAuthorLink>
 				{ siteName && siteUrl
-					? <ReaderSiteStreamLink feedId={ feedId } siteId={ siteId }>
+					? <ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId }>
 						{ siteName }
 					</ReaderSiteStreamLink> : null }
 
+				<div className="author-compact-profile__follow">
 				{ followCount
 					? <div className="author-compact-profile__follow-count">
 					{ this.props.translate(
@@ -53,6 +54,7 @@ const AuthorCompactProfile = React.createClass( {
 					</div> : null }
 
 				<ReaderFollowButton siteUrl={ siteUrl } />
+				</div>
 			</div>
 		);
 	}

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -1,0 +1,64 @@
+.author-compact-profile {
+	font-size: 14px;
+
+	.gravatar {
+    	display: flex;
+    	margin: auto;
+    }
+
+    .follow-button {
+    	border: 0;
+    	border-radius: 0;
+    	padding: 0;
+
+    	.gridicon__follow {
+    		fill: $blue-medium;
+    	}
+
+    	.follow-button__label {
+    		color: $blue-medium;
+
+    		@include breakpoint( "<660px" ) {
+    			display: inline-block;
+    		}
+    	}
+
+		&:hover {
+
+			.gridicon__follow {
+				fill: lighten( $gray, 10% );
+			}
+
+			.follow-button__label {
+				color: lighten( $gray, 10% );
+			}
+		}
+    }
+}
+
+.author-compact-profile .external-link,
+.author-compact-profile__site-link,
+.author-compact-profile__follow {
+    align-items: center;
+    color: $blue-medium;
+	display: flex;
+    justify-content: center;
+
+    &:hover {
+    	color: lighten( $gray, 10% );
+    }
+}
+
+.author-compact-profile .external-link {
+	font-weight: 600;
+	margin-top: 15px;
+}
+
+.author-compact-profile__follow-count {
+	display: inline-flex;
+}
+
+.author-compact-profile__follow-count {
+	color: lighten( $gray, 10% );
+	margin-right: 15px;
+}

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -41,7 +41,7 @@
 .author-compact-profile__follow {
     align-items: center;
     color: $blue-medium;
-	display: flex;
+    display: flex;
     justify-content: center;
 
     &:hover {

--- a/client/components/reader-author-link/docs/example.jsx
+++ b/client/components/reader-author-link/docs/example.jsx
@@ -14,14 +14,14 @@ export default React.createClass( {
 	displayName: 'ReaderAuthorLink',
 
 	render() {
-		const post = { author: { URL: 'http://wpcalypso.wordpress.com' } };
+		const author = { URL: 'http://wpcalypso.wordpress.com' };
 		return (
 			<div className="design-assets__group">
 				<h2>
 					<a href="/devdocs/blocks/reader-author-link">Reader Author Link</a>
 				</h2>
 				<Card>
-					<ReaderAuthorLink post={ post }>Author site</ReaderAuthorLink>
+					<ReaderAuthorLink author={ author }>Author site</ReaderAuthorLink>
 				</Card>
 			</div>
 		);

--- a/client/components/reader-author-link/index.jsx
+++ b/client/components/reader-author-link/index.jsx
@@ -7,10 +7,10 @@ import React from 'react';
  * Internal dependencies
  */
 import ExternalLink from 'components/external-link';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 const ReaderAuthorLink = ( { author, children } ) => {
-	const recordAuthorClick = ( { author } ) => {
+	const recordAuthorClick = ( { } ) => {
 		recordAction( 'click_author' );
 		recordGaEvent( 'Clicked Author Link' );
 		recordTrack( 'calypso_reader_author_link_clicked' );

--- a/client/components/reader-author-link/index.jsx
+++ b/client/components/reader-author-link/index.jsx
@@ -7,13 +7,15 @@ import React from 'react';
  * Internal dependencies
  */
 import ExternalLink from 'components/external-link';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
-const ReaderAuthorLink = ( { author, children } ) => {
+const ReaderAuthorLink = ( { author, post, children } ) => {
 	const recordAuthorClick = ( { } ) => {
 		recordAction( 'click_author' );
 		recordGaEvent( 'Clicked Author Link' );
-		recordTrack( 'calypso_reader_author_link_clicked' );
+		if ( post ) {
+			recordTrackForPost( 'calypso_reader_author_link_clicked', post );
+		}
 	};
 
 	if ( ! author.URL ) {
@@ -28,7 +30,8 @@ const ReaderAuthorLink = ( { author, children } ) => {
 };
 
 ReaderAuthorLink.propTypes = {
-	author: React.PropTypes.object.isRequired
+	author: React.PropTypes.object.isRequired,
+	post: React.PropTypes.object // for stats only
 };
 
 export default ReaderAuthorLink;

--- a/client/components/reader-author-link/index.jsx
+++ b/client/components/reader-author-link/index.jsx
@@ -9,26 +9,26 @@ import React from 'react';
 import ExternalLink from 'components/external-link';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
-const ReaderAuthorLink = ( { post, children } ) => {
-	const recordAuthorClick = ( { post } ) => {
+const ReaderAuthorLink = ( { author, children } ) => {
+	const recordAuthorClick = ( { author } ) => {
 		recordAction( 'click_author' );
 		recordGaEvent( 'Clicked Author Link' );
-		recordTrackForPost( 'calypso_reader_author_link_clicked', post );
+		recordTrack( 'calypso_reader_author_link_clicked' );
 	};
 
-	if ( ! post.author.URL ) {
+	if ( ! author.URL ) {
 		return ( <span>{ children }</span> );
 	}
 
 	return (
-		<ExternalLink href={ post.author.URL } target="_blank" onClick={ recordAuthorClick }>
+		<ExternalLink href={ author.URL } target="_blank" onClick={ recordAuthorClick }>
 			{ children }
 		</ExternalLink>
 	);
 };
 
 ReaderAuthorLink.propTypes = {
-	post: React.PropTypes.object.isRequired
+	author: React.PropTypes.object.isRequired
 };
 
 export default ReaderAuthorLink;

--- a/client/components/reader-full-post/index.jsx
+++ b/client/components/reader-full-post/index.jsx
@@ -19,9 +19,11 @@ import SiteStore from 'lib/reader-site-store';
 import FeedStore from 'lib/feed-store';
 import { fetchPost } from 'lib/feed-post-store/actions';
 import ReaderFullPostHeader from './header';
+import AuthorCompactProfile from 'blocks/author-compact-profile';
 
 export class FullPostView extends React.Component {
 	render() {
+		const post = this.props.post;
 		/*eslint-disable react/no-danger*/
 		return (
 			<Main className="reader-full-post">
@@ -31,8 +33,9 @@ export class FullPostView extends React.Component {
 					{ translate( 'Back' ) }
 					</div>
 				</StickyPanel>
-				<ReaderFullPostHeader post={ this.props.post } />
-				<div dangerouslySetInnerHTML={ { __html: this.props.post.content } } />
+				<AuthorCompactProfile author={ post.author } />
+				<ReaderFullPostHeader post={ post } />
+				<div dangerouslySetInnerHTML={ { __html: post.content } } />
 			</Main>
 		);
 	}

--- a/client/components/reader-full-post/index.jsx
+++ b/client/components/reader-full-post/index.jsx
@@ -17,13 +17,15 @@ import smartSetState from 'lib/react-smart-set-state';
 import PostStore from 'lib/feed-post-store';
 import SiteStore from 'lib/reader-site-store';
 import FeedStore from 'lib/feed-store';
+import { fetch as fetchFeed } from 'lib/feed-store/actions';
+import { fetch as fetchSite } from 'lib/reader-site-store/actions';
 import { fetchPost } from 'lib/feed-post-store/actions';
 import ReaderFullPostHeader from './header';
 import AuthorCompactProfile from 'blocks/author-compact-profile';
 
 export class FullPostView extends React.Component {
 	render() {
-		const post = this.props.post;
+		const { post, site, feed } = this.props;
 		/*eslint-disable react/no-danger*/
 		return (
 			<Main className="reader-full-post">
@@ -37,7 +39,7 @@ export class FullPostView extends React.Component {
 					author={ post.author }
 					siteName={ post.site_name }
 					siteUrl= { post.site_URL }
-					followCount={ 99999 }
+					followCount={ site && site.subscribers_count }
 					feedId={ post.feed_ID }
 					siteId={ post.site_ID } />
 				<ReaderFullPostHeader post={ post } />
@@ -75,9 +77,15 @@ export class FullPostFluxContainer extends React.Component {
 
 		if ( post && post.feed_ID ) {
 			feed = FeedStore.get( post.feed_ID );
+			if ( ! feed ) {
+				fetchFeed( post.feed_ID );
+			}
 		}
 		if ( post && post.site_ID ) {
 			site = SiteStore.get( post.site_ID );
+			if ( ! site ) {
+				fetchSite( post.site_ID );
+			}
 		}
 
 		return {
@@ -109,7 +117,7 @@ export class FullPostFluxContainer extends React.Component {
 
 	render() {
 		return this.state.post
-			? <FullPostView post={ this.state.post } site={ this.state.site } feed={ this.state.feed } />
+			? <FullPostView post={ this.state.post } site={ this.state.site && this.state.site.toJS() } feed={ this.state.feed && this.state.feed.toJS() } />
 			: null;
 	}
 }

--- a/client/components/reader-full-post/index.jsx
+++ b/client/components/reader-full-post/index.jsx
@@ -33,7 +33,13 @@ export class FullPostView extends React.Component {
 					{ translate( 'Back' ) }
 					</div>
 				</StickyPanel>
-				<AuthorCompactProfile author={ post.author } />
+				<AuthorCompactProfile
+					author={ post.author }
+					siteName={ post.site_name }
+					siteUrl= { post.site_URL }
+					followCount={ 99999 }
+					feedId={ post.feed_ID }
+					siteId={ post.site_ID } />
 				<ReaderFullPostHeader post={ post } />
 				<div dangerouslySetInnerHTML={ { __html: post.content } } />
 			</Main>

--- a/client/components/reader-site-stream-link/docs/example.jsx
+++ b/client/components/reader-site-stream-link/docs/example.jsx
@@ -14,14 +14,15 @@ export default React.createClass( {
 	displayName: 'ReaderSiteStreamLink',
 
 	render() {
-		const post = { feed_ID: 40474296 };
+		const feedId = 40474296;
+		const siteId = null;
 		return (
 			<div className="design-assets__group">
 				<h2>
 					<a href="/devdocs/blocks/reader-site-stream-link">Reader Site Stream Link</a>
 				</h2>
 				<Card>
-					<ReaderSiteStreamLink post={ post }>futonbleu</ReaderSiteStreamLink>
+					<ReaderSiteStreamLink feedId={ feedId } siteId={ siteId }>futonbleu</ReaderSiteStreamLink>
 				</Card>
 			</div>
 		);

--- a/client/components/reader-site-stream-link/index.jsx
+++ b/client/components/reader-site-stream-link/index.jsx
@@ -6,22 +6,23 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { getStreamUrlFromPost } from 'reader/route';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
+import { getStreamUrl } from 'reader/route';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 const ReaderSiteStreamLink = React.createClass( {
 	propTypes: {
-		post: React.PropTypes.object.isRequired
+		feedId: React.PropTypes.number,
+		siteId: React.PropTypes.number
 	},
 
 	recordClick() {
 		recordAction( 'visit_blog_feed' );
 		recordGaEvent( 'Clicked Feed Link' );
-		recordTrackForPost( 'calypso_reader_feed_link_clicked', this.props.post );
+		recordTrack( 'calypso_reader_feed_link_clicked' );
 	},
 
 	render() {
-		const link = getStreamUrlFromPost( this.props.post );
+		const link = getStreamUrl( this.props.feedId, this.props.siteId );
 
 		return (
 			<a { ...this.props } href={ link } onClick={ this.recordClick }>{ this.props.children }</a>

--- a/client/components/reader-site-stream-link/index.jsx
+++ b/client/components/reader-site-stream-link/index.jsx
@@ -7,18 +7,21 @@ import React from 'react';
  * Internal dependencies
  */
 import { getStreamUrl } from 'reader/route';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
 const ReaderSiteStreamLink = React.createClass( {
 	propTypes: {
 		feedId: React.PropTypes.number,
-		siteId: React.PropTypes.number
+		siteId: React.PropTypes.number,
+		post: React.PropTypes.object // for stats only
 	},
 
 	recordClick() {
 		recordAction( 'visit_blog_feed' );
 		recordGaEvent( 'Clicked Feed Link' );
-		recordTrack( 'calypso_reader_feed_link_clicked' );
+		if ( this.props.post ) {
+			recordTrackForPost( 'calypso_reader_feed_link_clicked', this.props.post );
+		}
 	},
 
 	render() {

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -31,6 +31,7 @@ import PostCard from 'components/post-card/docs/example';
 import ReaderAuthorLink from 'components/reader-author-link/docs/example';
 import ReaderSiteStreamLink from 'components/reader-site-stream-link/docs/example';
 import ReaderFullPostHeader from 'components/reader-full-post/docs/header-example';
+import AuthorCompactProfile from 'blocks/author-compact-profile/docs/example';
 
 export default React.createClass( {
 
@@ -83,6 +84,7 @@ export default React.createClass( {
 					<ReaderAuthorLink />
 					<ReaderSiteStreamLink />
 					<ReaderFullPostHeader />
+					<AuthorCompactProfile />
 				</Collection>
 			</div>
 		);

--- a/client/reader/route/index.js
+++ b/client/reader/route/index.js
@@ -25,6 +25,14 @@ export function getFeedUrl( feedID ) {
 	return getPrettyFeedUrl( feedID ) || FEED_URL_BASE + feedID;
 }
 
+export function getStreamUrl( feedID, siteID ) {
+	if ( feedID ) {
+		return getFeedUrl( feedID );
+	}
+
+	return getSiteUrl( siteID );
+}
+
 export function getStreamUrlFromPost( post ) {
 	if ( post.feed_ID ) {
 		return getFeedUrl( post.feed_ID );


### PR DESCRIPTION
The new Reader full post view has a summary of the author's details:

<img width="217" alt="screen shot 2016-07-28 at 18 33 24" src="https://cloud.githubusercontent.com/assets/17325/17220948/df1fb964-54f1-11e6-9809-d2950deda390.png">

This PR adds a new block named `AuthorCompactProfile` which contains:
- [x] gravatar
- [x] author name
- [x] site name
- [x] number of followers
- [x] follow button

Test live: https://calypso.live/?branch=add/author-compact-profile-component