### PR TITLE
Signup: Properly get the site address from the API response when creating a new site.

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -5,6 +5,7 @@ import assign from 'lodash/assign';
 import defer from 'lodash/defer';
 import isEmpty from 'lodash/isEmpty';
 import async from 'async';
+import { parse as parseURL } from 'url';
 
 /**
  * Internal dependencies
@@ -34,7 +35,9 @@ function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsC
 			return;
 		}
 
-		const siteSlug = response.blog_details.blogname + '.wordpress.com';
+		const parsedBlogURL = parseURL( response.blog_details.url );
+
+		const siteSlug = parsedBlogURL.hostname;
 		const siteId = response.blog_details.blogid;
 		const isFreeThemePreselected = themeSlug && ! themeItem;
 		const providedDependencies = {
@@ -191,7 +194,9 @@ module.exports = {
 			let providedDependencies, siteSlug;
 
 			if ( response && response.blog_details ) {
-				siteSlug = response.blog_details.blogname + '.wordpress.com';
+				const parsedBlogURL = parseURL( response.blog_details.url );
+				siteSlug = parsedBlogURL.hostname;
+
 				providedDependencies = { siteSlug };
 			}
 


### PR DESCRIPTION
This PR aims to fix a problem in Signup that made impossible to set a custom Site Title during signup and this needs to be fixed before we can add a `Site Title` step in signup.

Problem description:

`siteSlug` relied on `blogname` to contain the site address in the API response. This is not the case for signup and contains only the site/blog title. This coincidentally worked, because the site title was set to be the same as the site address without the `.wordpress.com` suffix. For example currently if you create a site and choose an address like: `myawesomesite.wordpress.com`, your site title (and `blogname`) would be set to `myawesomesite`.

The proper address is contained in `url`.

How to test:
1. Go through Signup in both the default flow and the developer flow.
2. Finish signup
3. See if you are properly sent to your new site after you finish Signup.

cc @michaeldcain @coreh @meremagee 

Test live: https://calypso.live/?branch=fix/proper-login-and-redirect-after-completed-signup