### PR TITLE
Reader: update discover source site on full post view

### DIFF
--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -75,3 +75,7 @@ export function getSourceFollowUrl( post ) {
 	}
 	return followUrl || '';
 }
+
+export function getAttribution( post ) {
+	return get( post, 'discover_metadata.attribution' );
+}

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -62,3 +62,9 @@ export function getLinkProps( linkUrl ) {
 		target: isExternal ? '_blank' : ''
 	};
 }
+
+export function getSourceFollowUrl( post ) {
+	if ( isInternalDiscoverPost( post ) ) {
+		return get( post, 'discover_metadata.attribution.blog_url' );
+	}
+}

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -64,7 +64,14 @@ export function getLinkProps( linkUrl ) {
 }
 
 export function getSourceFollowUrl( post ) {
-	if ( isInternalDiscoverPost( post ) ) {
-		return get( post, 'discover_metadata.attribution.blog_url' );
+	let followUrl;
+
+	if ( ! isDiscoverPost( post ) ) {
+		return;
 	}
+
+	if ( isInternalDiscoverPost( post ) ) {
+		followUrl = get( post, 'discover_metadata.attribution.blog_url' );
+	}
+	return followUrl || '';
 }

--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -132,4 +132,21 @@ describe( 'helper', () => {
 			assert.deepEqual( helper.getLinkProps( siteUrl ), { rel: 'external', target: '_blank' } );
 		} );
 	} );
+
+	describe( 'getSourceFollowUrl', () => {
+		it( 'returns the site url if its a discover pick to an internal site', () => {
+			const followUrl = helper.getSourceFollowUrl( discoverPost );
+			assert.equal( followUrl, get( discoverPost, 'discover_metadata.attribution.blog_url' ) );
+		} );
+
+		it( 'returns undefined if the discover pick is to an external site', () => {
+			const followUrl = helper.getSourceFollowUrl( fixtures.externalDiscoverPost );
+			assert.isUndefined( followUrl );
+		} );
+
+		it( 'returns undefined if the post is not a discover pick', () => {
+			const followUrl = helper.getSourceFollowUrl( fixtures.nonDiscoverPost );
+			assert.isUndefined( followUrl );
+		} );
+	}	);
 } );

--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -139,9 +139,9 @@ describe( 'helper', () => {
 			assert.equal( followUrl, get( discoverPost, 'discover_metadata.attribution.blog_url' ) );
 		} );
 
-		it( 'returns undefined if the discover pick is to an external site', () => {
+		it( 'returns an empty string if the discover pick is to an external site', () => {
 			const followUrl = helper.getSourceFollowUrl( fixtures.externalDiscoverPost );
-			assert.isUndefined( followUrl );
+			assert.equal( followUrl, '' );
 		} );
 
 		it( 'returns undefined if the post is not a discover pick', () => {

--- a/client/reader/full-post/main.jsx
+++ b/client/reader/full-post/main.jsx
@@ -164,7 +164,8 @@ FullPostView = React.createClass( {
 			siteName = utils.siteNameFromSiteAndPost( site, post ),
 			isDiscoverPost = DiscoverHelper.isDiscoverPost( post ),
 			discoverSiteUrl,
-			discoverSiteName;
+			discoverSiteName,
+			followUrl = utils.getFollowUrlFromFeedOrPost( feed, post );
 
 		if ( isDiscoverPost && post.discover_metadata ) {
 			discoverSiteUrl = DiscoverHelper.getSiteUrl( post );
@@ -209,7 +210,7 @@ FullPostView = React.createClass( {
 							onClick={ this.handleSiteClick } />
 
 						<div className="full-post__follow">
-							{ feed && feed.feed_URL && <FollowButton siteUrl={ feed && feed.feed_URL } /> }
+							<FollowButton siteUrl={ followUrl } disabled={ !! followUrl } />
 						</div>
 					</div>
 

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -101,7 +101,11 @@ const PostOptions = React.createClass( {
 	},
 
 	getFollowUrl( feed ) {
-		return feed ? feed.get( 'feed_URL' ) : this.props.post.site_URL;
+		const post = this.props.post;
+		if ( DiscoverHelper.isDiscoverPost( post ) ) {
+			return DiscoverHelper.getSourceFollowUrl( post );
+		}
+		return feed ? feed.get( 'feed_URL' ) : get( post, 'site_URL' );
 	},
 
 	getFeed() {
@@ -163,7 +167,8 @@ const PostOptions = React.createClass( {
 	render() {
 		const post = this.props.post,
 			isEditPossible = PostUtils.userCan( 'edit_post', post ),
-			isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
+			isDiscoverPost = DiscoverHelper.isDiscoverPost( post ),
+			isFollowable = !! this.state.followUrl;
 
 		let triggerClasses = [ 'post-options__trigger', 'ignore-click' ],
 			isBlockPossible = false;
@@ -195,7 +200,7 @@ const PostOptions = React.createClass( {
 						position={ this.state.popoverPosition }
 						context={ this.refs && this.refs.popoverMenuButton }>
 
-					<FollowButton tagName={ PopoverMenuItem } siteUrl={ this.state.followUrl } />
+					{ isFollowable ? <FollowButton tagName={ PopoverMenuItem } siteUrl={ this.state.followUrl } /> : null }
 
 					{ isEditPossible ? <PopoverMenuItem onClick={ this.editPost } className="post-options__edit has-icon">
 						<svg className="gridicon gridicon__edit" height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -200,7 +200,7 @@ const PostOptions = React.createClass( {
 						position={ this.state.popoverPosition }
 						context={ this.refs && this.refs.popoverMenuButton }>
 
-					{ isFollowable ? <FollowButton tagName={ PopoverMenuItem } siteUrl={ this.state.followUrl } /> : null }
+					<FollowButton tagName={ PopoverMenuItem } siteUrl={ this.state.followUrl } disabled={ ! isFollowable } />
 
 					{ isEditPossible ? <PopoverMenuItem onClick={ this.editPost } className="post-options__edit has-icon">
 						<svg className="gridicon gridicon__edit" height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -19,6 +19,7 @@ import SiteBlockStore from 'lib/reader-site-blocks';
 import SiteBlockActions from 'lib/reader-site-blocks/actions';
 import PostUtils from 'lib/posts/utils';
 import FollowButton from 'reader/follow-button';
+import { getFollowUrlFromFeedOrPost as getFollowUrl } from 'reader/utils';
 import * as DiscoverHelper from 'reader/discover/helper';
 
 const stats = require( 'reader/stats' );
@@ -59,7 +60,7 @@ const PostOptions = React.createClass( {
 	getStateFromStores() {
 		const siteId = this.props.post.site_ID,
 			feed = this.getFeed(),
-			followUrl = this.getFollowUrl( feed );
+			followUrl = getFollowUrl( feed, this.props.post );
 
 		return {
 			isBlocked: SiteBlockStore.getIsBlocked( siteId ),
@@ -98,14 +99,6 @@ const PostOptions = React.createClass( {
 		stats.recordTrackForPost( 'calypso_reader_post_reported', this.props.post );
 
 		window.open( 'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ), '_blank' );
-	},
-
-	getFollowUrl( feed ) {
-		const post = this.props.post;
-		if ( DiscoverHelper.isDiscoverPost( post ) ) {
-			return DiscoverHelper.getSourceFollowUrl( post );
-		}
-		return feed ? feed.get( 'feed_URL' ) : get( post, 'site_URL' );
 	},
 
 	getFeed() {

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -78,3 +78,9 @@ export function isPostNotFound( post ) {
 	return post.statusCode === 404;
 }
 
+export function getFollowUrlFromFeedOrPost( feed, post ) {
+	if ( discoverHelper.isDiscoverPost( post ) ) {
+		return discoverHelper.getSourceFollowUrl( post );
+	}
+	return feed ? feed.get( 'feed_URL' ) : get( post, 'site_URL' );
+}

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -1,11 +1,19 @@
-const url = require( 'url' );
+/**
+ * External dependencies
+ */
+import url from 'url';
+import { get } from 'lodash';
 
-const i18n = require( 'i18n-calypso' ),
-	SiteState = require( 'lib/reader-site-store/constants' ).state,
-	FeedDisplayHelper = require( 'reader/lib/feed-display-helper' );
+/**
+ * Internal dependencies
+ */
+import i18n from 'i18n-calypso';
+import { state as SiteState } from 'lib/reader-site-store/constants';
+import FeedDisplayHelper from 'reader/lib/feed-display-helper';
+import * as discoverHelper from 'reader/discover/helper';
 
-function siteNameFromSiteAndPost( site, post ) {
-	var siteName;
+export function siteNameFromSiteAndPost( site, post ) {
+	let siteName;
 
 	if ( site && site.get( 'state' ) === SiteState.COMPLETE ) {
 		siteName = site.get( 'title' ) || site.get( 'domain' );
@@ -32,7 +40,15 @@ function siteNameFromSiteAndPost( site, post ) {
  * @param  {Object} post A Reader post
  * @return {Object}      A site like object
  */
-function siteishFromSiteAndPost( site, post ) {
+export function siteishFromSiteAndPost( site, post ) {
+	if ( discoverHelper.isDiscoverSitePick( post ) ) {
+		const discoverAttribution = discoverHelper.getAttribution( post );
+		return {
+			title: get( discoverAttribution, 'blog_name' ),
+			domain: FeedDisplayHelper.formatUrlForDisplay( get( discoverAttribution, 'blog_url' ) )
+		};
+	}
+
 	if ( site ) {
 		return site.toJS();
 	}
@@ -40,7 +56,7 @@ function siteishFromSiteAndPost( site, post ) {
 	if ( post ) {
 		return {
 			title: siteNameFromSiteAndPost( site, post ),
-			domain: FeedDisplayHelper.formatUrlForDisplay( post.site_URL )
+			domain: FeedDisplayHelper.formatUrlForDisplay( get( post, 'site_URL' ) )
 		};
 	}
 
@@ -50,11 +66,11 @@ function siteishFromSiteAndPost( site, post ) {
 	};
 }
 
-function isSpecialClick( event ) {
+export function isSpecialClick( event ) {
 	return event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey;
 }
 
-function isPostNotFound( post ) {
+export function isPostNotFound( post ) {
 	if ( post === undefined ) {
 		return false;
 	}
@@ -62,9 +78,3 @@ function isPostNotFound( post ) {
 	return post.statusCode === 404;
 }
 
-module.exports = {
-	siteNameFromSiteAndPost,
-	siteishFromSiteAndPost,
-	isSpecialClick,
-	isPostNotFound
-};


### PR DESCRIPTION
Waiting on #7103 
Part of #7057 

Displays the site information and sets the follow url to the source site from discover site picks.
Currently site picks displays discovery.wordpress.com.
discover.wordpress.com is displayed if the pick source is not a wpcom site. 

### Test

Visit a wpcom discovery site pick.
The site information will be for the source site and the follow button will be linked to the source site.

examples:
Current behavior : https://wordpress.com/read/blogs/53424024/posts/16439
Updated behavior: https://calypso.live/read/blogs/53424024/posts/16439?branch=update/reader/discover-full-following or http://calypso.localhost:3000/read/blogs/53424024/posts/16439

Test live: https://calypso.live/?branch=update/reader/discover-full-following