### PR TITLE
Update percentage of users able to use browser notifications to 40%

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -211,7 +211,8 @@ function reduxStoreReady( reduxStore ) {
 		reduxStore.dispatch( setCurrentUserId( user.get().ID ) );
 		reduxStore.dispatch( setCurrentUserFlags( user.get().meta.data.flags.active_flags ) );
 
-		const participantInPushNotificationsAbTest = config.isEnabled('push-notifications-ab-test') && abtest('browserNotifications') === 'enabled';
+		const participantInPushNotificationsAbTest = config.isEnabled( 'push-notifications-ab-test' ) &&
+			abtest( 'browserNotifications' ) === 'enabled' || abtest( 'browserNotificationsPreferences' ) === 'enabled';
 		if ( config.isEnabled( 'push-notifications' ) || participantInPushNotificationsAbTest ) {
 			// If the browser is capable, registers a service worker & exposes the API
 			reduxStore.dispatch( pushNotificationsInit() );

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -212,7 +212,7 @@ function reduxStoreReady( reduxStore ) {
 		reduxStore.dispatch( setCurrentUserFlags( user.get().meta.data.flags.active_flags ) );
 
 		const participantInPushNotificationsAbTest = config.isEnabled( 'push-notifications-ab-test' ) &&
-			abtest( 'browserNotifications' ) === 'enabled' || abtest( 'browserNotificationsPreferences' ) === 'enabled';
+			( abtest( 'browserNotifications' ) === 'enabled' || abtest( 'browserNotificationsPreferences' ) === 'enabled' );
 		if ( config.isEnabled( 'push-notifications' ) || participantInPushNotificationsAbTest ) {
 			// If the browser is capable, registers a service worker & exposes the API
 			reduxStore.dispatch( pushNotificationsInit() );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,9 +1,31 @@
 module.exports = {
+	// `browserNotifications` controls whether or not users see the
+	// nudge notice to enable browser notifications at the top of
+	// some Calypso screens; any users with this enabled will also
+	// have the preference available in /me/notifications;
+	// note: not renaming this test at this point in time so that we don't
+	// mess with any users that were put in the `enabled` variation -- don't
+	// want to take their browser notifications preference away from them!
 	browserNotifications: {
 		datestamp: '20160628',
 		variations: {
 			disabled: 95,
 			enabled: 5,
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: true,
+	},
+	// `browserNotificationsPreferences` controls whether or not users see the
+	// preference to enable browser notifications in /me/notifications;
+	// any users with `browserNotifications` enabled will also see the preference;
+	// this is a temporary test just to allow us to ramp up the load gradually so
+	// that make sure things will be smooth when we go to launching browser
+	// notifications for 100% of users
+	browserNotificationsPreferences: {
+		datestamp: '20160801',
+		variations: {
+			disabled: 0,
+			enabled: 40,
 		},
 		defaultVariation: 'disabled',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -24,7 +24,7 @@ module.exports = {
 	browserNotificationsPreferences: {
 		datestamp: '20160801',
 		variations: {
-			disabled: 0,
+			disabled: 60,
 			enabled: 40,
 		},
 		defaultVariation: 'disabled',


### PR DESCRIPTION
This PR increases the number of users able to use browser notifications to 40%, while keeping the number of users nudged on other pages with the notice at the top of the screen to 5%.

To test, use a browser environment that supports Service Workers for `HTTP` connections (like Firefox with the developer toolbox open) and run calypso locally like so:

```
DISABLE_FEATURES=push-notifications ENABLE_FEATURES=push-notifications-ab-test make run
```

This will ensure that you have the configuration flags set as they will be currently in production.

Then, use the environment badge in the bottom right of Calypso to set the AB test variations and verify correct behavior.

`browserNotifications` | `browserNotificationsPreferences` | Nudge visible? | Preferences visible?
---------------------| --------------------------------- | -------------- | -------------------
`disabled` | `disabled` | no | no
`enabled` | `disabled` | yes | yes
`enabled` | `enabled` | yes | yes
`disabled` | `enabled` | no | yes

Test live: https://calypso.live/?branch=update/web-push-abtest-increase