### PR TITLE
State / CPT: Persist posts query state

### DIFF
--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -34,23 +34,6 @@ export const DELETE_PATCH_KEY = '__DELETE';
  */
 export default class QueryManager {
 	/**
-	 * Returns an instance of QueryManager or extending class given a
-	 * serialized string representation of the instance. If the serialized
-	 * string is invalid, a new empty instance is returned.
-	 *
-	 * @param  {String}       serialized Serialized QueryManager
-	 * @return {QueryManager}            QueryManager instance
-	 */
-	static parse( serialized ) {
-		try {
-			const { data, options } = JSON.parse( serialized );
-			return new this.prototype.constructor( data, options );
-		} catch ( e ) {
-			return new this.prototype.constructor();
-		}
-	}
-
-	/**
 	 * Constructs a new instance of QueryManager
 	 *
 	 * @param {Object} data            Initial data
@@ -66,16 +49,6 @@ export default class QueryManager {
 		this.options = Object.assign( {
 			itemKey: 'ID'
 		}, options );
-	}
-
-	/**
-	 * Returns a serialized string representation of the instance
-	 *
-	 * @return {String} String representation of the instance
-	 */
-	toJSON() {
-		const { data, options } = this;
-		return JSON.stringify( { data, options } );
 	}
 
 	/**

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -18,22 +18,6 @@ describe( 'QueryManager', () => {
 		manager = new QueryManager();
 	} );
 
-	describe( '.parse()', () => {
-		it( 'should return an instance from a serialized JSON string', () => {
-			manager = QueryManager.parse( '{"data":{"items":{"144":{"ID":144},"152":{"ID":152}},"queries":{"[]":{"itemKeys":[152],"found":1}}},"options":{"itemKey":"ID"}}' );
-
-			expect( manager.getItems() ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
-			expect( manager.getItems( {} ) ).to.eql( [ { ID: 152 } ] );
-		} );
-
-		it( 'should return a new empty instance on invalid input', () => {
-			manager = QueryManager.parse( '{"data":{"item"!!!---INVALID---"ID"}}' );
-
-			expect( manager ).to.be.an.instanceof( QueryManager );
-			expect( manager.getItems() ).to.eql( [] );
-		} );
-	} );
-
 	describe( '#constructor()', () => {
 		it( 'should accept initial data', () => {
 			manager = new QueryManager( {
@@ -58,15 +42,6 @@ describe( 'QueryManager', () => {
 			manager = manager.receive( { name: 'foo' } );
 
 			expect( manager.data.items ).to.have.keys( [ 'foo' ] );
-		} );
-	} );
-
-	describe( '#toJSON()', () => {
-		it( 'should return a serialized JSON string', () => {
-			manager = manager.receive( { ID: 144 } );
-			manager = manager.receive( { ID: 152 }, { query: {}, found: 1 } );
-
-			expect( manager.toJSON() ).to.equal( '{"data":{"items":{"144":{"ID":144},"152":{"ID":152}},"queries":{"[]":{"itemKeys":[152],"found":1}}},"options":{"itemKey":"ID"}}' );
 		} );
 	} );
 

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -215,14 +215,16 @@ export const queries = ( () => {
 			return applyToManager( state, siteId, 'removeItem', false, postId );
 		},
 		[ SERIALIZE ]: ( state ) => {
-			return mapValues( state, ( manager ) => manager.toJSON() );
+			return mapValues( state, ( { data, options } ) => ( { data, options } ) );
 		},
 		[ DESERIALIZE ]: ( state ) => {
 			if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
 				return {};
 			}
 
-			return mapValues( state, ( manager ) => PostQueryManager.parse( manager ) );
+			return mapValues( state, ( { data, options } ) => {
+				return new PostQueryManager( data, options );
+			} );
 		}
 	} );
 } )();

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -2,15 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import get from 'lodash/get';
-import set from 'lodash/set';
-import omit from 'lodash/omit';
-import omitBy from 'lodash/omitBy';
-import isEqual from 'lodash/isEqual';
-import reduce from 'lodash/reduce';
-import groupBy from 'lodash/groupBy';
-import merge from 'lodash/merge';
-import findKey from 'lodash/findKey';
+import { get, set, omit, omitBy, isEqual, reduce, groupBy, merge, findKey, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,7 +32,8 @@ import {
 	getSerializedPostsQuery,
 	mergeIgnoringArrays,
 } from './utils';
-import { createReducer } from 'state/utils';
+import { createReducer, isValidStateWithSchema } from 'state/utils';
+import { itemsSchema, queriesSchema } from './schema';
 
 /**
  * Tracks all known post objects, indexed by post global ID.
@@ -78,7 +71,7 @@ export const items = createReducer( {}, {
 
 		return omit( state, globalId );
 	}
-} );
+}, itemsSchema );
 
 /**
  * Returns the updated site post requests state after an action has been
@@ -209,6 +202,16 @@ export const queries = ( () => {
 		},
 		[ POST_DELETE_SUCCESS ]: ( state, { siteId, postId } ) => {
 			return applyToManager( state, siteId, 'removeItem', false, postId );
+		},
+		[ SERIALIZE ]: ( state ) => {
+			return mapValues( state, ( manager ) => manager.toJSON() );
+		},
+		[ DESERIALIZE ]: ( state ) => {
+			if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
+				return {};
+			}
+
+			return mapValues( state, ( manager ) => PostQueryManager.parse( manager ) );
 		}
 	} );
 } )();

--- a/client/state/posts/schema.js
+++ b/client/state/posts/schema.js
@@ -18,9 +18,45 @@ export const queriesSchema = {
 	patternProperties: {
 		// Site ID
 		'^\\d+$': {
-			// Serialized QueryManager is a JSON string
-			type: 'string',
-			pattern: '^\\{.*\\}$'
+			type: 'object',
+			properties: {
+				data: {
+					type: 'object',
+					required: [ 'items', 'queries' ],
+					properties: {
+						items: {
+							type: 'object'
+						},
+						queries: {
+							patternProperties: {
+								// Query key pairs
+								'^\\[.*\\]$': {
+									type: 'object',
+									required: [ 'itemKeys' ],
+									properties: {
+										itemKeys: {
+											type: 'array'
+										},
+										found: {
+											type: 'number'
+										}
+									}
+								}
+							},
+							additionalProperties: false
+						}
+					}
+				},
+				options: {
+					type: 'object',
+					required: [ 'itemKey' ],
+					properties: {
+						itemKey: {
+							type: 'string'
+						}
+					}
+				}
+			}
 		}
 	},
 	additionalProperties: false

--- a/client/state/posts/schema.js
+++ b/client/state/posts/schema.js
@@ -1,0 +1,27 @@
+export const itemsSchema = {
+	type: 'object',
+	patternProperties: {
+		'^\\w+$': {
+			type: 'array',
+			items: {
+				type: 'number'
+			},
+			minItems: 2,
+			maxItems: 2
+		}
+	},
+	additionalProperties: false
+};
+
+export const queriesSchema = {
+	type: 'object',
+	patternProperties: {
+		// Site ID
+		'^\\d+$': {
+			// Serialized QueryManager is a JSON string
+			type: 'string',
+			pattern: '^\\{.*\\}$'
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -18,8 +18,8 @@ import {
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
 	mergeIgnoringArrays,
-	normalizeEditedPost,
-	normalizePost
+	normalizePostForEditing,
+	normalizePostForDisplay
 } from './utils';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import addQueryArgs from 'lib/route/add-query-args';
@@ -56,7 +56,7 @@ export function getPost( state, globalId ) {
  * @return {?Object}          Post object
  */
 export const getNormalizedPost = createSelector(
-	( state, globalId ) => normalizePost( getPost( state, globalId ) ),
+	( state, globalId ) => normalizePostForDisplay( getPost( state, globalId ) ),
 	( state ) => [ state.posts.items, state.posts.queries ]
 );
 
@@ -129,7 +129,7 @@ export const getSitePostsForQuery = createSelector(
 			return null;
 		}
 
-		return posts.map( normalizePost );
+		return posts.map( normalizePostForDisplay );
 	},
 	( state ) => state.posts.queries,
 	( state, siteId, query ) => getSerializedPostsQuery( query, siteId )
@@ -227,7 +227,7 @@ export const getSitePostsForQueryIgnoringPage = createSelector(
 			return null;
 		}
 
-		return itemsIgnoringPage.map( normalizePost );
+		return itemsIgnoringPage.map( normalizePostForDisplay );
 	},
 	( state ) => state.posts.queries,
 	( state, siteId, query ) => getSerializedPostsQueryWithoutPage( query, siteId )
@@ -314,7 +314,7 @@ export function getEditedPost( state, siteId, postId ) {
  */
 export function getPostEdits( state, siteId, postId ) {
 	const { edits } = state.posts;
-	return normalizeEditedPost( get( edits, [ siteId, postId || '' ], null ) );
+	return normalizePostForEditing( get( edits, [ siteId, postId || '' ], null ) );
 }
 
 /**

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -533,19 +533,53 @@ describe( 'reducer', () => {
 			const state = queries( original, { type: SERIALIZE } );
 
 			expect( state ).to.eql( {
-				2916284: '{"data":{"items":{"841":{"ID":841,"site_ID":2916284,' +
-					'"global_ID":"3d097cb7c5473c169bba0eb8e3c6cb64","title":"H' +
-					'ello World"}},"queries":{"[[\\"search\\",\\"Hello\\"]]":{' +
-					'"itemKeys":[841],"found":1}}},"options":{"itemKey":"ID"}}'
+				2916284: {
+					data: {
+						items: {
+							841: {
+								ID: 841,
+								site_ID: 2916284,
+								global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+								title: 'Hello World'
+							}
+						},
+						queries: {
+							'[["search","Hello"]]': {
+								itemKeys: [ 841 ],
+								found: 1
+							}
+						}
+					},
+					options: {
+						itemKey: 'ID'
+					}
+				}
 			} );
 		} );
 
 		it( 'should load valid persisted state', () => {
 			const original = deepFreeze( {
-				2916284: '{"data":{"items":{"841":{"ID":841,"site_ID":2916284,' +
-					'"global_ID":"3d097cb7c5473c169bba0eb8e3c6cb64","title":"H' +
-					'ello World"}},"queries":{"[[\\"search\\",\\"Hello\\"]]":{' +
-					'"itemKeys":[841],"found":1}}},"options":{"itemKey":"ID"}}'
+				2916284: {
+					data: {
+						items: {
+							841: {
+								ID: 841,
+								site_ID: 2916284,
+								global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+								title: 'Hello World'
+							}
+						},
+						queries: {
+							'[["search","Hello"]]': {
+								itemKeys: [ 841 ],
+								found: 1
+							}
+						}
+					},
+					options: {
+						itemKey: 'ID'
+					}
+				}
 			} );
 
 			const state = queries( original, { type: DESERIALIZE } );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -250,15 +250,25 @@ describe( 'reducer', () => {
 				query: { search: 'Hello' },
 				found: 1,
 				posts: [
-					{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+					{
+						ID: 841,
+						site_ID: 2916284,
+						global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+						title: 'Hello World',
+						meta: {}
+					}
 				]
 			} );
 
 			expect( state ).to.have.keys( [ '2916284' ] );
 			expect( state[ 2916284 ] ).to.be.an.instanceof( PostQueryManager );
-			expect( state[ 2916284 ].getItems( { search: 'Hello' } ) ).to.eql( [
-				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-			] );
+			expect( state[ 2916284 ].getItems( { search: 'Hello' } ) ).to.eql( [ {
+				ID: 841,
+				site_ID: 2916284,
+				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+				title: 'Hello World',
+				meta: null
+			} ] );
 		} );
 
 		it( 'should accumulate query request success', () => {

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -106,18 +106,32 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {} );
 		} );
 
-		it( 'should not persist state', () => {
+		it( 'should persist state', () => {
 			const original = deepFreeze( {
 				'3d097cb7c5473c169bba0eb8e3c6cb64': [ 2916284, 841 ]
 			} );
 			const state = items( original, { type: SERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.eql( original );
 		} );
 
-		it( 'should not load persisted state', () => {
+		it( 'should load valid persisted state', () => {
 			const original = deepFreeze( {
 				'3d097cb7c5473c169bba0eb8e3c6cb64': [ 2916284, 841 ]
+			} );
+			const state = items( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		it( 'should not load invalid persisted state', () => {
+			const original = deepFreeze( {
+				'3d097cb7c5473c169bba0eb8e3c6cb64': {
+					ID: 841,
+					site_ID: 2916284,
+					global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+					title: 'Hello World'
+				}
 			} );
 			const state = items( original, { type: DESERIALIZE } );
 
@@ -495,7 +509,7 @@ describe( 'reducer', () => {
 			expect( state[ 2916284 ].getItems() ).to.have.length( 0 );
 		} );
 
-		it( 'should not persist state', () => {
+		it( 'should persist state', () => {
 			const original = deepFreeze( queries( deepFreeze( {} ), {
 				type: POSTS_REQUEST_SUCCESS,
 				siteId: 2916284,
@@ -508,12 +522,47 @@ describe( 'reducer', () => {
 
 			const state = queries( original, { type: SERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.eql( {
+				2916284: '{"data":{"items":{"841":{"ID":841,"site_ID":2916284,' +
+					'"global_ID":"3d097cb7c5473c169bba0eb8e3c6cb64","title":"H' +
+					'ello World"}},"queries":{"[[\\"search\\",\\"Hello\\"]]":{' +
+					'"itemKeys":[841],"found":1}}},"options":{"itemKey":"ID"}}'
+			} );
 		} );
 
-		it( 'should load persisted state', () => {
+		it( 'should load valid persisted state', () => {
 			const original = deepFreeze( {
-				2916284: '{}'
+				2916284: '{"data":{"items":{"841":{"ID":841,"site_ID":2916284,' +
+					'"global_ID":"3d097cb7c5473c169bba0eb8e3c6cb64","title":"H' +
+					'ello World"}},"queries":{"[[\\"search\\",\\"Hello\\"]]":{' +
+					'"itemKeys":[841],"found":1}}},"options":{"itemKey":"ID"}}'
+			} );
+
+			const state = queries( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( {
+				2916284: new PostQueryManager( {
+					items: {
+						841: {
+							ID: 841,
+							global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+							site_ID: 2916284,
+							title: 'Hello World'
+						}
+					},
+					queries: {
+						'[["search","Hello"]]': {
+							found: 1,
+							itemKeys: [ 841 ]
+						}
+					}
+				} )
+			} );
+		} );
+
+		it( 'should not load invalid persisted state', () => {
+			const original = deepFreeze( {
+				2916284: '{INVALID'
 			} );
 
 			const state = queries( original, { type: DESERIALIZE } );

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -8,7 +8,8 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	normalizePost,
+	normalizePostForDisplay,
+	normalizePostForState,
 	getNormalizedPostsQuery,
 	getSerializedPostsQuery,
 	getDeserializedPostsQueryDetails,
@@ -18,9 +19,9 @@ import {
 } from '../utils';
 
 describe( 'utils', () => {
-	describe( 'normalizePost()', () => {
+	describe( 'normalizePostForDisplay()', () => {
 		it( 'should return null if post is falsey', () => {
-			const normalizedPost = normalizePost();
+			const normalizedPost = normalizePostForDisplay();
 			expect( normalizedPost ).to.be.null;
 		} );
 
@@ -36,7 +37,7 @@ describe( 'utils', () => {
 				featured_image: 'https://example.com/logo.png'
 			};
 
-			const normalizedPost = normalizePost( post );
+			const normalizedPost = normalizePostForDisplay( post );
 			expect( normalizedPost ).to.eql( {
 				...post,
 				title: 'Ribs & Chicken',
@@ -46,6 +47,38 @@ describe( 'utils', () => {
 				canonical_image: {
 					type: 'image',
 					uri: 'https://example.com/logo.png'
+				}
+			} );
+		} );
+	} );
+
+	describe( 'normalizePostForState()', () => {
+		it( 'should deeply unset all meta', () => {
+			const original = deepFreeze( {
+				ID: 814,
+				meta: {},
+				terms: {
+					category: {
+						Code: {
+							ID: 6,
+							meta: {}
+						}
+					}
+				}
+			} );
+			const revised = normalizePostForState( original );
+
+			expect( revised ).to.not.equal( original );
+			expect( revised ).to.eql( {
+				ID: 814,
+				meta: null,
+				terms: {
+					category: {
+						Code: {
+							ID: 6,
+							meta: null
+						}
+					}
 				}
 			} );
 		} );

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -1,7 +1,20 @@
 /**
  * External dependencies
  */
-import { isEmpty, isPlainObject, flow, map, mapValues, mergeWith, omit, omitBy, reduce, toArray, cloneDeep } from 'lodash';
+import {
+	isEmpty,
+	isPlainObject,
+	flow,
+	map,
+	mapValues,
+	mergeWith,
+	omit,
+	omitBy,
+	reduce,
+	toArray,
+	cloneDeep,
+	cloneDeepWith
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +38,7 @@ const normalizeEditedFlow = flow( [
 	getTermIdsFromEdits
 ] );
 
-const normalizeFlow = flow( [
+const normalizeDisplayFlow = flow( [
 	firstPassCanonicalImage,
 	decodeEntities,
 	stripHtml
@@ -116,12 +129,12 @@ export function mergeIgnoringArrays( object, ...sources ) {
  * @param  {Object} post Raw post object
  * @return {Object}      Normalized post object
  */
-export function normalizePost( post ) {
+export function normalizePostForDisplay( post ) {
 	if ( ! post ) {
 		return null;
 	}
 
-	return normalizeFlow( cloneDeep( post ) );
+	return normalizeDisplayFlow( cloneDeep( post ) );
 }
 
 /**
@@ -130,12 +143,27 @@ export function normalizePost( post ) {
  * @param  {Ojbect} post Raw edited post object
  * @return {Object}      Normalized post object
  */
-export function normalizeEditedPost( post ) {
+export function normalizePostForEditing( post ) {
 	if ( ! post ) {
 		return null;
 	}
 
 	return normalizeEditedFlow( post );
+}
+
+/**
+ * Given a post object, returns a normalized post object prepared for storing
+ * in the global state object.
+ *
+ * @param  {Object} post Raw post object
+ * @return {Object}      Normalized post object
+ */
+export function normalizePostForState( post ) {
+	return cloneDeepWith( post, ( value, key ) => {
+		if ( 'meta' === key ) {
+			return null;
+		}
+	} );
 }
 
 /**

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -98,8 +98,8 @@ export const queries = createReducer( {}, {
 	},
 	[ SERIALIZE ]: ( state ) => {
 		return mapValues( state, ( taxonomies ) => {
-			return mapValues( taxonomies, ( manager ) => {
-				return manager.toJSON();
+			return mapValues( taxonomies, ( { data, options } ) => {
+				return { data, options };
 			} );
 		} );
 	},
@@ -109,8 +109,8 @@ export const queries = createReducer( {}, {
 		}
 
 		return mapValues( state, ( taxonomies ) => {
-			return mapValues( taxonomies, ( manager ) => {
-				return TermQueryManager.parse( manager );
+			return mapValues( taxonomies, ( { data, options } ) => {
+				return new TermQueryManager( data, options );
 			} );
 		} );
 	}

--- a/client/state/terms/schema.js
+++ b/client/state/terms/schema.js
@@ -7,9 +7,46 @@ export const queriesSchema = {
 			patternProperties: {
 				// Taxonomy
 				'^[A-Za-z0-9-_]+$': {
-					// Serialized TermQueryManager is a JSON string
-					type: 'string',
-					pattern: '^\\{.*\\}$'
+					type: 'object',
+					properties: {
+						// Query Manager
+						data: {
+							type: 'object',
+							required: [ 'items', 'queries' ],
+							properties: {
+								items: {
+									type: 'object'
+								},
+								queries: {
+									patternProperties: {
+										// Query key pairs
+										'^\\[.*\\]$': {
+											type: 'object',
+											required: [ 'itemKeys' ],
+											properties: {
+												itemKeys: {
+													type: 'array'
+												},
+												found: {
+													type: 'number'
+												}
+											}
+										}
+									},
+									additionalProperties: false
+								}
+							}
+						},
+						options: {
+							type: 'object',
+							required: [ 'itemKey' ],
+							properties: {
+								itemKey: {
+									type: 'string'
+								}
+							}
+						}
+					}
 				}
 			},
 			additionalProperties: false

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -269,7 +269,7 @@ describe( 'reducer', () => {
 
 			expect( state ).to.have.keys( [ '2916284' ] );
 			expect( state[ 2916284 ] ).to.have.keys( [ 'category' ] );
-			expect( state[ 2916284 ].category ).to.be.a( 'string' );
+			expect( state[ 2916284 ].category ).to.have.keys( [ 'data', 'options' ] );
 		} );
 
 		it( 'should load persisted state', () => {


### PR DESCRIPTION
This pull request seeks to add state persistence for posts query data. The effect of this is immediate rendering of posts on the posts listing or `<PostSelector />` on subsequent visits, automatically refreshed as the page is scrolled.

__Implementation notes:__

In 8b08ab2, I introduced another layer of normalization to "trim" a post object before it is inserted into state, removing `meta` data which consumes significant memory but is rarely useful in the context of the Calypso application. This is towards a goal of cautiousness in how much data we are storing. To that end, there's also the open question of: Is this too much data to be storing in the client? For browsers with limited storage availability, we may quickly hit our allotted quota for sites with a reasonable amount of data. I had also considered omitting additional redundant fields like `categories` and `tags` (whose data is duplicated onto `terms.category` and `terms.post_tag`), but wondered if this could potentially lead to confusion on missing API properties. Generally, this may speak to a larger discussion on whether we should be "shaping" our state to conform to the needs of the application more than we are currently. We presently store all of the REST API data, which admittedly is convenient from an implementation point of view.

__Testing instructions:__

Verify that upon visiting the [custom post types list screen](http://calypso.localhost:3000/types/post) and refreshing the page, posts loaded prior to the refresh are shown immediately after the refresh, with no warnings in your developer tools console, and that all posts are refreshed (noted by loading indicator).

Test live: https://calypso.live/?branch=update/state-persist-posts