### PR TITLE
Create editPostsMiddleware to handle new terms.

### DIFF
--- a/client/my-sites/term-tree-selector/add-term.jsx
+++ b/client/my-sites/term-tree-selector/add-term.jsx
@@ -26,7 +26,7 @@ import viewport from 'lib/viewport';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import { getTerms } from 'state/terms/selectors';
-import { addTerm } from 'state/terms/actions';
+import { addTermForPost } from 'state/posts/actions';
 
 class TermSelectorAddTerm extends Component {
 	static initialState = {
@@ -40,6 +40,10 @@ class TermSelectorAddTerm extends Component {
 	static propTypes = {
 		labels: PropTypes.object,
 		postType: PropTypes.string,
+		postId: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.number
+		] ),
 		siteId: PropTypes.number,
 		terms: PropTypes.array,
 		taxonomy: PropTypes.string,
@@ -142,9 +146,9 @@ class TermSelectorAddTerm extends Component {
 			return;
 		}
 
-		const { siteId, taxonomy } = this.props;
+		const { postId, siteId, taxonomy } = this.props;
 
-		this.props.addTerm( siteId, taxonomy, term );
+		this.props.addTermForPost( siteId, taxonomy, term, postId );
 		this.closeDialog();
 	}
 
@@ -227,5 +231,5 @@ export default connect(
 			siteId
 		};
 	},
-	{ addTerm }
+	{ addTermForPost }
 )( localize( TermSelectorAddTerm ) );

--- a/client/my-sites/term-tree-selector/add-term.jsx
+++ b/client/my-sites/term-tree-selector/add-term.jsx
@@ -40,10 +40,7 @@ class TermSelectorAddTerm extends Component {
 	static propTypes = {
 		labels: PropTypes.object,
 		postType: PropTypes.string,
-		postId: PropTypes.oneOfType( [
-			PropTypes.string,
-			PropTypes.number
-		] ),
+		postId: PropTypes.number,
 		siteId: PropTypes.number,
 		terms: PropTypes.array,
 		taxonomy: PropTypes.string,

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import { cloneDeep, findIndex, map } from 'lodash';
 
@@ -17,11 +17,14 @@ import { getEditedPostValue } from 'state/posts/selectors';
 
 class EditorTermSelector extends Component {
 	static propTypes = {
-		siteId: React.PropTypes.number,
-		postId: React.PropTypes.number,
-		postTerms: React.PropTypes.object,
-		postType: React.PropTypes.string,
-		taxonomyName: React.PropTypes.string
+		siteId: PropTypes.number,
+		postId: PropTypes.oneOfType( [
+			PropTypes.number,
+			PropTypes.string
+		] ),
+		postTerms: PropTypes.object,
+		postType: PropTypes.string,
+		taxonomyName: PropTypes.string
 	};
 
 	constructor( props ) {
@@ -56,7 +59,7 @@ class EditorTermSelector extends Component {
 	}
 
 	render() {
-		const { postType, siteId, taxonomyName } = this.props;
+		const { postType, postId, siteId, taxonomyName } = this.props;
 
 		return (
 			<div>
@@ -68,7 +71,7 @@ class EditorTermSelector extends Component {
 					siteId={ siteId }
 					multiple={ true }
 				/>
-				<AddTerm taxonomy={ taxonomyName } postType={ postType } />
+				<AddTerm taxonomy={ taxonomyName } postType={ postType } postId={ postId } />
 			</div>
 		);
 	}
@@ -77,7 +80,7 @@ class EditorTermSelector extends Component {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const postId = getEditorPostId( state );
+		const postId = getEditorPostId( state ) || '';
 
 		return {
 			postType: getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' ),

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
-import { cloneDeep, findIndex, map } from 'lodash';
+import { cloneDeep, findIndex, map, toArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,10 +18,7 @@ import { getEditedPostValue } from 'state/posts/selectors';
 class EditorTermSelector extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
-		postId: PropTypes.oneOfType( [
-			PropTypes.number,
-			PropTypes.string
-		] ),
+		postId: PropTypes.number,
 		postTerms: PropTypes.object,
 		postType: PropTypes.string,
 		taxonomyName: PropTypes.string
@@ -37,7 +34,7 @@ class EditorTermSelector extends Component {
 		const terms = cloneDeep( postTerms ) || {};
 
 		// map call transforms object returned by API into an array
-		const taxonomyTerms = map( terms[ taxonomyName ] ) || [];
+		const taxonomyTerms = toArray( terms[ taxonomyName ] );
 		const existingSelectionIndex = findIndex( taxonomyTerms, { ID: selectedTerm.ID } );
 		if ( existingSelectionIndex !== -1 ) {
 			taxonomyTerms.splice( existingSelectionIndex, 1 );
@@ -80,7 +77,7 @@ class EditorTermSelector extends Component {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const postId = getEditorPostId( state ) || '';
+		const postId = getEditorPostId( state );
 
 		return {
 			postType: getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' ),

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -8,6 +8,7 @@ import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
  * Internal dependencies
  */
 import noticesMiddleware from './notices/middleware';
+import postsEditMiddleware from './posts/middleware';
 import application from './application/reducer';
 import comments from './comments/reducer';
 import componentsUsageStats from './components-usage-stats/reducer';
@@ -79,7 +80,7 @@ export const reducer = combineReducers( {
 	wordads
 } );
 
-const middleware = [ thunkMiddleware, noticesMiddleware ];
+const middleware = [ thunkMiddleware, noticesMiddleware, postsEditMiddleware ];
 
 if ( typeof window === 'object' ) {
 	// Browser-specific middlewares

--- a/client/state/posts/middleware.js
+++ b/client/state/posts/middleware.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { cloneDeep, isNumber, map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { TERMS_RECEIVE } from 'state/action-types';
+import { getEditedPost } from 'state/posts/selectors';
+import { editPost } from 'state/posts/actions';
+
+/**
+ * Dispatches editPost when a new term has been added
+ * that also has a postId on the action
+ *
+ * @param  {Function} dispatch  Dispatch method
+ * @param  {Object}   state     Global state tree
+ * @param  {Object}   action    Action object
+ */
+export function onTermsReceive( dispatch, state, action ) {
+	const { postId, taxonomy, terms, siteId } = action;
+	const post = getEditedPost( state, siteId, postId );
+	const newTerm = terms[ 0 ];
+
+	// if there is no post, no term, or term is temporary, bail
+	if ( ! post || ! newTerm || ! isNumber( newTerm.ID ) ) {
+		return;
+	}
+
+	const postTerms = cloneDeep( post.terms ) || {};
+
+	// map call transforms object returned by API into an array
+	const taxonomyTerms = map( postTerms[ taxonomy ] ) || [];
+	taxonomyTerms.push( newTerm );
+
+	dispatch( editPost( {
+		terms: {
+			[ taxonomy ]: taxonomyTerms
+		}
+	}, siteId, postId ) );
+}
+
+export default ( { dispatch, getState } ) => ( next ) => ( action ) => {
+	if ( TERMS_RECEIVE === action.type && action.hasOwnProperty( 'postId' ) ) {
+		onTermsReceive( dispatch, getState(), action );
+	}
+	return next( action );
+};

--- a/client/state/posts/middleware.js
+++ b/client/state/posts/middleware.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { cloneDeep, isNumber, map } from 'lodash';
+import { isNumber, toArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,10 +28,10 @@ export function onTermsReceive( dispatch, state, action ) {
 		return;
 	}
 
-	const postTerms = cloneDeep( post.terms ) || {};
+	const postTerms = post.terms || {};
 
-	// map call transforms object returned by API into an array
-	const taxonomyTerms = map( postTerms[ taxonomy ] ) || [];
+	// ensure we have an array since API returns an object
+	const taxonomyTerms = toArray( postTerms[ taxonomy ] );
 	taxonomyTerms.push( newTerm );
 
 	dispatch( editPost( {

--- a/client/state/posts/test/middleware.js
+++ b/client/state/posts/test/middleware.js
@@ -1,0 +1,161 @@
+/**
+ * External dependencies
+ */
+import sinon from 'sinon';
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import {
+	POST_EDIT
+} from 'state/action-types';
+import { onTermsReceive } from '../middleware';
+import PostQueryManager from 'lib/query-manager/post';
+
+describe( 'middleware', () => {
+	const spy = sinon.spy();
+
+	beforeEach( () => {
+		spy.reset();
+	} );
+
+	describe( 'onTermsReceive()', () => {
+		it( 'postEdit should not dispatch when no matching post exists', () => {
+			const action = {
+				site: 2916284,
+				taxonomy: 'category',
+				postId: 111,
+				terms: [ {
+					ID: 777,
+					name: 'chicken'
+				} ]
+			};
+			onTermsReceive( spy, { posts: { queries: {}, items: {}, edits: {} } }, action );
+			expect( spy ).to.not.have.been.called;
+		} );
+
+		it( 'should not dispatch a postEdit when a temporary term is added', () => {
+			const action = {
+				siteId: 2916284,
+				taxonomy: 'category',
+				postId: 841,
+				terms: [ {
+					ID: 'temporary1',
+					name: 'meat'
+				} ]
+			};
+
+			onTermsReceive( spy, { posts: { queries: {}, items: {}, edits: {} } }, action );
+			expect( spy ).to.not.have.been.called;
+		} );
+
+		it( 'should dispatch a postEdit when a post exists', () => {
+			const action = {
+				siteId: 2916284,
+				taxonomy: 'category',
+				postId: 841,
+				terms: [ {
+					ID: 777,
+					name: 'meat'
+				} ]
+			};
+
+			const postObject = {
+				ID: 841,
+				site_ID: 2916284,
+				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+				title: 'Ribs &amp; Chicken'
+			};
+
+			const state = deepFreeze( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': [ 2916284, 841 ]
+					},
+					queries: {
+						2916284: new PostQueryManager( {
+							items: { 841: postObject }
+						} )
+					},
+					edits: {}
+				}
+			} );
+
+			onTermsReceive( spy, state, action );
+			expect( spy ).to.have.been.calledWith( {
+				type: POST_EDIT,
+				post: {
+					terms: {
+						category: [ {
+							ID: 777,
+							name: 'meat'
+						} ]
+					}
+				},
+				siteId: 2916284,
+				postId: 841
+			} );
+		} );
+
+		it( 'should dispatch a postEdit with accumulated terms by taxonomy', () => {
+			const action = {
+				siteId: 2916284,
+				taxonomy: 'category',
+				postId: 841,
+				terms: [ {
+					ID: 790,
+					name: 'yummy'
+				} ]
+			};
+
+			const postObject = {
+				ID: 841,
+				site_ID: 2916284,
+				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+				title: 'Ribs &amp; Chicken',
+				terms: {
+					category: {
+						meat: {
+							ID: 777,
+							name: 'meat'
+						}
+					}
+				}
+			};
+
+			const state = deepFreeze( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': [ 2916284, 841 ]
+					},
+					queries: {
+						2916284: new PostQueryManager( {
+							items: { 841: postObject }
+						} )
+					},
+					edits: {}
+				}
+			} );
+
+			onTermsReceive( spy, state, action );
+			expect( spy ).to.have.been.calledWith( {
+				type: POST_EDIT,
+				post: {
+					terms: {
+						category: [ {
+							ID: 777,
+							name: 'meat'
+						}, {
+							ID: 790,
+							name: 'yummy'
+						} ]
+					}
+				},
+				siteId: 2916284,
+				postId: 841
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This is an alternate solution to #7018, but utilizes a new redux middleware to apply the appropriate term edits to a post when applicable.  As such, the testing steps remain the same as the prior PR:

This branch seeks to auto-select newly added hierarchical terms in the editor sidebar after they have been persisted to the API.  Currently you can add a new term, but the new term is not checked in the `<EditorTermSelector />`.

__To Test__
- Open up a Portfolio in the editor
- Expand the 'Project Type' accordion, and click "Add New Project Type"
- Fill out the term form and save
- Confirm the new term is added and auto-selected

__Implementation Notes__
Big /ht to @aduth for the suggestion of middleware - this solution is so much cleaner than the prior one.  I did add logic to **not** auto-check temporary terms.  Currently the `REMOVE_TERM` action is not passing along a `postId` so using the middleware to "uncheck" a temporarily checked temp term is not feasible.  This does fix the issue pointed on in #7018.  Additionally this approach handles the scenario of multiple new terms being added, and auto-selected for a given post.

Test live: https://calypso.live/?branch=update/post-edits/auto-select-new-terms