### PR TITLE
SEO Preview: Add Mobile Styles

### DIFF
--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -1,24 +1,70 @@
 .seo-preview-pane {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
+
+	@include breakpoint( ">660px" ) {
+		flex-direction: row;
+	}
 }
 
 .seo-preview-pane__sidebar {
 	display: flex;
 	flex-direction: column;
 
-	width: 250px;
-	min-width: 250px;
-
 	background-color: $white;
-	border-right: 1px solid lighten( $gray, 20% );
+
+	.vertical-menu {
+		flex-direction: row;
+		justify-content: center;
+		max-width: none;
+
+		.vertical-menu__social-item {
+			border: 0;
+			padding: 8px;
+		}
+
+		.vertical-menu__items.is-selected {
+			border-left: 0;
+    		border-bottom: 3px solid #0087be;
+		}
+
+		.vertical-menu__items__social-label {
+			display: none;
+		}
+
+		@include breakpoint( ">660px" ) {
+			flex-direction: column;
+			justify-content: flex-start;
+			border-bottom: 1px solid #c8d7e1;
+
+
+			.vertical-menu__social-item {
+				border-top: 1px solid #c8d7e1;
+				padding: 0;
+			}
+
+			.vertical-menu__items.is-selected {
+				border-left: 3px solid #0087be;
+				border-bottom: 0;
+			}
+
+			.vertical-menu__items__social-label {
+				display: block;
+			}
+		}
+	}
+
+	@include breakpoint( ">660px" ) {
+		width: 250px;
+		min-width: 250px;
+		border-right: 1px solid lighten( $gray, 20% );
+	}
 }
 
 .seo-preview-pane__explanation {
 	display: flex;
 	flex-direction: column;
-	margin: 40px 0 40px 20px;
-	max-width: 200px;
+	margin: 20px 20px 0;
 
 	font-family: $sans;
 
@@ -29,6 +75,11 @@
 	.seo-preview-pane__description {
 		font-size: 12px;
 		color: $gray;
+	}
+
+	@include breakpoint( ">660px" ) {
+		margin: 40px 0 40px 20px;
+		max-width: 200px;
 	}
 }
 

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -44,7 +44,9 @@ export const SocialItem = props => {
 			<div className="vertical-menu__items__social-icon">
 				<SocialLogo icon={ icon } size={ 24 } />
 			</div>
-			{ label }
+			<span className="vertical-menu__items__social-label">
+				{ label }
+			</span>
 		</div>
 	);
 };

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -126,6 +126,10 @@
 	@include breakpoint( "<660px" ) {
 		display: none;
 	}
+
+	&.web-preview__seo-button {
+		display: block;
+	}
 }
 
 .web-preview__toolbar-tray {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -132,6 +132,14 @@
 	}
 }
 
+.web-preview__back-to-preview-button {
+	display: none;
+
+	@include breakpoint( "<660px" ) {
+		display: block;
+	}
+}
+
 .web-preview__toolbar-tray {
 	margin-left: auto;
 	display: flex;

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -71,6 +71,19 @@ export const PreviewToolbar = props => {
 				) )
 			}
 			{ showSeo && config.isEnabled( 'manage/advanced-seo' ) &&
+			<button
+				aria-hidden={ true }
+				key={ 'back-to-preview' }
+				className={ classNames(
+					'web-preview__device-button',
+					'web-preview__back-to-preview-button'
+				) }
+				onClick={ partial( setDeviceViewport, 'phone' ) }
+			>
+				<Gridicon icon="phone" />
+			</button>
+			}
+			{ showSeo && config.isEnabled( 'manage/advanced-seo' ) &&
 				<button
 					aria-label={ translate( 'Show SEO and search previews' ) }
 					className={ classNames(

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -76,8 +76,9 @@ export const PreviewToolbar = props => {
 				key={ 'back-to-preview' }
 				className={ classNames(
 					'web-preview__device-button',
-					'web-preview__back-to-preview-button'
-				) }
+					'web-preview__back-to-preview-button', {
+					'is-active': currentDevice !== 'seo'
+				} ) }
 				onClick={ partial( setDeviceViewport, 'phone' ) }
 			>
 				<Gridicon icon="phone" />


### PR DESCRIPTION
Mobile styles for the seo preview:
* SEO button is forced to show in the toolbar, even on small screens. 
* Vertical menu items get shifted to horizontal so they function like tabs.
* Vertical menu item text is hidden on mobile.

<img width="421" alt="screen shot 2016-07-28 at 3 39 37 pm" src="https://cloud.githubusercontent.com/assets/789137/17231917/a7957f64-54d9-11e6-97a5-a1aed428fa99.png">

- [x] There's a bug though, you aren't able to switch back to the web preview once you've tapped on the seo button.

Fixes #7115 

cc @dmsnell 

Test live: https://calypso.live/?branch=fix/seo-preview-mobile