### PR TITLE
Themes: fix issue with missing title mobile viewport

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -14,6 +14,12 @@ import LoggedOutComponent from './logged-out';
 import trackScrollPage from 'lib/track-scroll-page';
 import buildTitle from 'lib/screen-title/utils';
 import { getAnalyticsData } from './helpers';
+import DocumentHead from 'components/data/document-head';
+
+/**
+ * Module Constants
+ */
+const BASE_TITLE = i18n.translate( 'Themes', { textOnly: true } );
 
 function makeElement( ThemesComponent, Head, store, props ) {
 	return (
@@ -24,6 +30,7 @@ function makeElement( ThemesComponent, Head, store, props ) {
 			canonicalUrl={ props.canonicalUrl }
 			image={ props.image }
 			tier={ props.tier || 'all' }>
+			<DocumentHead title={ BASE_TITLE } />
 			<ThemesComponent { ...omit( props, [ 'title' ] ) } />
 		</Head>
 	);
@@ -32,9 +39,7 @@ function makeElement( ThemesComponent, Head, store, props ) {
 function getProps( context ) {
 	const { tier, filter, site_id: siteId } = context.params;
 
-	const title = buildTitle(
-		i18n.translate( 'Themes', { textOnly: true } ),
-		{ siteID: siteId } );
+	const title = buildTitle( BASE_TITLE, { siteID: siteId } );
 
 	const { basePath, analyticsPageTitle } = getAnalyticsData(
 		context.path,


### PR DESCRIPTION
Fixes #7008 - the themes controller currently is not calling `setTitle` which is what powers the title seen on mobile viewports - which results in the title from the previous controller or `setTitle` call being shown:

__Before__
![themes_ _sketchytimmy_ _wordpress_com_and_custom_content_types_ _jetpack_for_wordpress](https://cloud.githubusercontent.com/assets/22080/17234358/fe46614e-54ec-11e6-8c04-5643edcc93b2.png)

__After__
![themes_ _wordpress_com_and_comparing_master___fix_themes_missing-title_ _automattic_wp-calypso](https://cloud.githubusercontent.com/assets/22080/17234367/1a6ad04e-54ed-11e6-90ff-126cf1c1b134.png)

__To Test__
- Adjust your viewport so the mobile breakpoint comes into affect
- Click themes in the sidebar from 'My Sites', verify the correct title is shown


Test live: https://calypso.live/?branch=fix/themes/missing-title