### PR TITLE
Sites: Switch from 'Add New WordPress' to 'Add New Site'

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -105,7 +105,7 @@ export default React.createClass( {
 		return (
 			<span className="site-selector__add-new-site">
 				<Button compact borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' } onClick={ this.recordAddNewSite }>
-					<Gridicon icon="add-outline" /> { this.translate( 'Add New WordPress' ) }
+					<Gridicon icon="add-outline" /> { this.translate( 'Add New Site' ) }
 				</Button>
 			</span>
 		);

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -373,7 +373,7 @@ const Account = React.createClass( {
 					href={ config( 'signup_url' ) }
 					onClick={ this.recordClickEvent( 'Primary Site Add New WordPress Button' ) }
 				>
-					{ this.translate( 'Add New WordPress' ) }
+					{ this.translate( 'Add New Site' ) }
 				</a>
 			);
 		}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -654,7 +654,7 @@ module.exports = React.createClass( {
 		this.props.layoutFocus.set( 'content' );
 	},
 
-	addNewWordPress: function() {
+	addNewSite: function() {
 		if ( this.props.user.get().visible_site_count > 1 ) {
 			return null;
 		}
@@ -742,7 +742,7 @@ module.exports = React.createClass( {
 				}
 				</SidebarRegion>
 				<SidebarFooter>
-					{ this.addNewWordPress() }
+					{ this.addNewSite() }
 				</SidebarFooter>
 			</Sidebar>
 		);


### PR DESCRIPTION
Along with the very simple WP.com patch 15332-pb, this closes #5722.

### To test

Verify that both instances of the former "Add New WordPress" string now say "Add New Site":

- For users with no sites, at http://calypso.localhost:3000/me/account (you can simulate this condition by applying [this patch](https://gist.github.com/nylen/5e4bc14fc65739de2e3e21f6432ea274))
- For all users, at the bottom of the site picker when you click "← Switch Site"

Test live: https://calypso.live/?branch=update/add-new-site-wording