### PR TITLE
Editor: Add success notice for scheduled posts

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -312,8 +312,7 @@ export default React.createClass( {
 			this.props.isDirty &&
 			this.props.hasContent &&
 			!! this.props.post &&
-			! postUtils.isPublished( this.props.post ) &&
-			! ( this.props.post.status === 'future' );
+			! postUtils.isPublished( this.props.post );
 	},
 
 	isPreviewEnabled: function() {
@@ -335,10 +334,6 @@ export default React.createClass( {
 
 	onPrimaryButtonClick: function() {
 		this.trackPrimaryButton();
-
-		if ( postUtils.isFutureDated( this.props.post ) ) {
-			return this.props.onSave( 'future' );
-		}
 
 		if ( postUtils.isPublished( this.props.savedPost ) &&
 			! postUtils.isBackDatedPublished( this.props.savedPost )

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -312,7 +312,8 @@ export default React.createClass( {
 			this.props.isDirty &&
 			this.props.hasContent &&
 			!! this.props.post &&
-			! postUtils.isPublished( this.props.post );
+			! postUtils.isPublished( this.props.post ) &&
+			! ( this.props.post.status === 'future' );
 	},
 
 	isPreviewEnabled: function() {

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -375,41 +375,41 @@ describe( 'EditorGroundControl', function() {
 		it( 'should schedule a posted dated in future', function() {
 			var now = moment( new Date() ),
 				nextMonth = now.month( now.month() + 1 ).format(),
-				onSave = sinon.spy(),
+				onPublish = sinon.spy(),
 				tree;
 
 			tree = shallow(
 				<EditorGroundControl
 					savedPost={ { status: 'draft', date: nextMonth } }
 					post={ { title: 'change', status: 'draft', date: nextMonth } }
-					onSave={ onSave }
+					onPublish={ onPublish }
 					site={ MOCK_SITE }
 				/>
 			).instance();
 
 			tree.onPrimaryButtonClick();
 
-			expect( onSave ).to.have.been.calledWith( 'future' );
+			expect( onPublish ).to.have.been.called;
 		} );
 
 		it( 'should save a scheduled post dated in future', function() {
 			var now = moment( new Date() ),
 				nextMonth = now.month( now.month() + 1 ).format(),
-				onSave = sinon.spy(),
+				onPublish = sinon.spy(),
 				tree;
 
 			tree = shallow(
 				<EditorGroundControl
 					savedPost={ { status: 'future', date: nextMonth } }
 					post={ { title: 'change', status: 'future', date: nextMonth } }
-					onSave={ onSave }
+					onPublish={ onPublish }
 					site={ MOCK_SITE }
 				/>
 			).instance();
 
 			tree.onPrimaryButtonClick();
 
-			expect( onSave ).to.have.been.calledWith( 'future' );
+			expect( onPublish ).to.have.been.called;
 		} );
 
 		it( 'should publish a scheduled post dated in past', function() {

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -142,10 +142,6 @@ export class EditorNotice extends Component {
 				} );
 
 			case 'view':
-				if ( 'scheduled' === this.props.message ) {
-					return translate( 'View Preview' );
-				}
-
 				if ( 'page' === type ) {
 					return translate( 'View Page' );
 				} else if ( 'post' !== type && typeObject ) {
@@ -153,6 +149,9 @@ export class EditorNotice extends Component {
 				}
 
 				return translate( 'View Post' );
+
+			case 'preview':
+				return translate( 'View Preview' );
 
 			case 'updated':
 				if ( ! site ) {

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -89,6 +89,31 @@ export class EditorNotice extends Component {
 					comment: 'Editor: Message displayed when a post is published, with a link to the site it was published on.'
 				} );
 
+			case 'scheduled':
+				if ( ! site ) {
+					if ( 'page' === type ) {
+						return translate( 'Page scheduled!' );
+					}
+
+					return translate( 'Post scheduled!' );
+				}
+
+				if ( 'page' === type ) {
+					return translate( 'Page scheduled on {{siteLink/}}!', {
+						components: {
+							siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+						},
+						comment: 'Editor: Message displayed when a page is scheduled, with a link to the site it was scheduled on.'
+					} );
+				}
+
+				return translate( 'Post scheduled on {{siteLink/}}!', {
+					components: {
+						siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+					},
+					comment: 'Editor: Message displayed when a post is scheduled, with a link to the site it was scheduled on.'
+				} );
+
 			case 'publishedPrivately':
 				if ( ! site ) {
 					if ( 'page' === type ) {
@@ -117,6 +142,10 @@ export class EditorNotice extends Component {
 				} );
 
 			case 'view':
+				if ( 'scheduled' === this.props.message ) {
+					return translate( 'View Preview' );
+				}
+
 				if ( 'page' === type ) {
 					return translate( 'View Page' );
 				} else if ( 'post' !== type && typeObject ) {

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -101,7 +101,7 @@ export class EditorNotice extends Component {
 				if ( 'page' === type ) {
 					return translate( 'Page scheduled on {{siteLink/}}!', {
 						components: {
-							siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+							siteLink: <a href={ site.URL } target="_blank">{ site.title }</a>
 						},
 						comment: 'Editor: Message displayed when a page is scheduled, with a link to the site it was scheduled on.'
 					} );
@@ -109,7 +109,7 @@ export class EditorNotice extends Component {
 
 				return translate( 'Post scheduled on {{siteLink/}}!', {
 					components: {
-						siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+						siteLink: <a href={ site.URL } target="_blank">{ site.title }</a>
 					},
 					comment: 'Editor: Message displayed when a post is scheduled, with a link to the site it was scheduled on.'
 				} );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -668,7 +668,7 @@ const PostEditor = React.createClass( {
 			message = 'published';
 		}
 
-		this.onSaveSuccess( message, 'view', savedPost.URL );
+		this.onSaveSuccess( message, ( message === 'published' ? 'view' : 'preview' ), savedPost.URL );
 		this.toggleSidebar();
 	},
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -444,7 +444,14 @@ const PostEditor = React.createClass( {
 			return;
 		}
 
-		if ( utils.isPublished( this.state.savedPost ) || utils.isPublished( this.state.post ) ) {
+		if (
+			utils.isPublished( this.state.savedPost ) ||
+			utils.isPublished( this.state.post ) ||
+			(
+				this.state.post.status === 'future' &&
+				utils.isFutureDated( this.state.post )
+			)
+		) {
 			callback = function() {};
 		} else {
 			this.setState( { isSaving: true } );
@@ -612,8 +619,11 @@ const PostEditor = React.createClass( {
 
 	onSaveDraftSuccess: function() {
 		const { post } = this.state;
+
 		if ( utils.isPublished( post ) ) {
 			this.onSaveSuccess( 'updated', 'view', post.URL );
+		} else if ( post.status === 'future' && utils.isFutureDated( post ) ) {
+			this.onSaveSuccess( 'scheduled', 'view', this.state.previewUrl );
 		} else {
 			this.onSaveSuccess();
 		}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -444,14 +444,7 @@ const PostEditor = React.createClass( {
 			return;
 		}
 
-		if (
-			utils.isPublished( this.state.savedPost ) ||
-			utils.isPublished( this.state.post ) ||
-			(
-				this.state.post.status === 'future' &&
-				utils.isFutureDated( this.state.post )
-			)
-		) {
+		if ( utils.isPublished( this.state.savedPost ) || utils.isPublished( this.state.post ) ) {
 			callback = function() {};
 		} else {
 			this.setState( { isSaving: true } );
@@ -622,8 +615,6 @@ const PostEditor = React.createClass( {
 
 		if ( utils.isPublished( post ) ) {
 			this.onSaveSuccess( 'updated', 'view', post.URL );
-		} else if ( post.status === 'future' && utils.isFutureDated( post ) ) {
-			this.onSaveSuccess( 'scheduled', 'view', this.state.previewUrl );
 		} else {
 			this.onSaveSuccess();
 		}
@@ -638,6 +629,8 @@ const PostEditor = React.createClass( {
 		// determine if this is a private publish
 		if ( utils.isPrivate( this.state.post ) ) {
 			edits.status = 'private';
+		} else if ( utils.isFutureDated( this.state.post ) ) {
+			edits.status = 'future';
 		}
 
 		// Update content on demand to avoid unnecessary lag and because it is expensive
@@ -664,10 +657,18 @@ const PostEditor = React.createClass( {
 	},
 
 	onPublishSuccess: function() {
-		const { savedPost, post } = this.state;
-		const message = utils.isPrivate( savedPost ) ? 'publishedPrivately' : 'published';
+		const { savedPost } = this.state;
 
-		this.onSaveSuccess( message, 'view', post.URL );
+		let message;
+		if ( utils.isPrivate( savedPost ) ) {
+			message = 'publishedPrivately';
+		} else if ( utils.isFutureDated( savedPost ) ) {
+			message = 'scheduled';
+		} else {
+			message = 'published';
+		}
+
+		this.onSaveSuccess( message, 'view', savedPost.URL );
 		this.toggleSidebar();
 	},
 


### PR DESCRIPTION
Closes #4799

This is a replacement for #5032 after the refactoring work that went on in `EditorNotices`. It's meant to address #4799 by adding a success message for scheduled posts similar to the one we display for published posts.

## What I Did
To actually display the message, I added a conditional to `onSaveDraftSuccess()` that checks for both `post.status === 'future'` and `utils.isFutureDated( post )`. The former is the important check here. It's necessary for differentiating from drafts that might have a future date set but might not be scheduled yet.

One issue I ran into was the notice appearing when a scheduled post was autosaved after it was scheduled. To circumvent that, I mimicked how we approach published posts by setting [an empty callback in `autosave`](https://github.com/Automattic/wp-calypso/blob/7816d0442f83b8cc08432381683eb1d6a79c6e83/client/post-editor/post-editor.jsx#L448).

Finally, I added a condition to `EditorGroundControl` in `isSaveEnabled` to hide the "Save" button, which matches the behavior on published posts. Of note, if a user schedules a post and then adds additional content that is autosaved, the additional content will be published in the post even though the user didn't specifically click "Schedule" or "Update" after adding it. This does match the current behavior—the autosave signal is just lost with the "Save" button.

## To Test
1. Start a new post with this branch
2. Type in some content. Set the date to future (but don't schedule it). You should still see the "Save" button.
3. Schedule the post. You should see a success notice with a preview link. Future typing should not bring the "Save" button back although autosave will fire.

Here's the save button I'm referring to for context:

![screen shot 2016-07-28 at 21 43 43](https://cloud.githubusercontent.com/assets/7240478/17237187/60dcded6-550c-11e6-83ad-d2992a814394.png)

View of success notice:

![screen shot 2016-07-28 at 9 32 32 pm](https://cloud.githubusercontent.com/assets/7240478/17237191/695a6af6-550c-11e6-8298-8d864c899bde.png)


Test live: https://calypso.live/?branch=fix/4799-add-scheduled-notice