### PR TITLE
Feature/revisit verification notice in help

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -161,6 +161,7 @@
 @import 'me/help/help-contact-confirmation/style';
 @import 'me/help/help-contact/style';
 @import 'me/help/help-contact-form/style';
+@import 'me/help/help-unverified-warning/style';
 @import 'me/help/help-happiness-engineers/style';
 @import 'me/help/help-results/style';
 @import 'me/help/help-search/style';

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -24,7 +24,9 @@ import siteList from 'lib/sites-list';
 import analytics from 'lib/analytics';
 import i18n from 'lib/i18n-utils';
 import { isOlarkTimedOut } from 'state/ui/olark/selectors';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import QueryOlark from 'components/data/query-olark';
+import HelpUnverifiedWarning from '../help-unverified-warning';
 
 /**
  * Module variables
@@ -437,6 +439,7 @@ const HelpContact = React.createClass( {
 		return (
 			<Main className="help-contact">
 				<HeaderCake onClick={ this.backToHelp } isCompact={ true }>{ this.translate( 'Contact Us' ) }</HeaderCake>
+				{ ! this.props.isEmailVerified && <HelpUnverifiedWarning /> }
 				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
 					{ this.getView() }
 				</Card>
@@ -449,7 +452,8 @@ const HelpContact = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			olarkTimedOut: isOlarkTimedOut( state )
+			olarkTimedOut: isOlarkTimedOut( state ),
+			isEmailVerified: isCurrentUserEmailVerified( state ),
 		};
 	}
 )( HelpContact );

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import userFactory from 'lib/user';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import notices from 'notices';
+
+const user = userFactory();
+
+const RESEND_IDLE = 0,
+	RESEND_IN_PROGRESS = 1,
+	RESEND_SUCCESS = 2,
+	RESEND_ERROR = 3;
+
+class HelpUnverifiedWarning extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			resendState: RESEND_IDLE,
+		};
+	}
+
+	render() {
+		const { resendState } = this.state;
+
+		const resendStateToMessage = ( val ) => {
+			switch ( val ) {
+				case RESEND_IDLE:
+					return this.props.translate( 'Trouble activating your account?\
+							Just click this button and we\'ll resend the activation for you.' );
+				case RESEND_IN_PROGRESS:
+					return '';
+				case RESEND_SUCCESS:
+					return this.props.translate( 'Activation email sent. Please check your inbox.' );
+				case RESEND_ERROR:
+					return this.props.translate( 'There\'s been an error. Please try again later.' );
+				default:
+					return 'Unknown activation email resending state.';
+			}
+		};
+
+		const resendEmail = () => {
+			this.setState( {
+				resendState: RESEND_IN_PROGRESS,
+			} );
+
+			user.sendVerificationEmail()
+				.then( () => {
+					const nextResendState = RESEND_SUCCESS;
+
+					this.setState( { resendState: nextResendState } );
+					notices.success( resendStateToMessage( nextResendState ) );
+				} )
+				.catch( () => {
+					const nextResendState = RESEND_ERROR;
+
+					this.setState( { resendState: nextResendState } );
+					notices.error( resendStateToMessage( nextResendState ) );
+				} );
+		};
+
+		return (
+			RESEND_IDLE === resendState &&
+				<Notice
+					className="help-unverified-warning"
+					status="is-warning"
+					showDismiss={ false }
+					text={ resendStateToMessage( resendState ) } >
+						<NoticeAction href="#" onClick={ resendEmail } >
+							{ this.props.translate( 'Resend Email' ) }
+						</NoticeAction>
+				</Notice>
+		);
+	}
+}
+
+export default localize( HelpUnverifiedWarning );

--- a/client/me/help/help-unverified-warning/style.scss
+++ b/client/me/help/help-unverified-warning/style.scss
@@ -1,0 +1,3 @@
+.help-unverified-warning {
+	margin-top: 16px;
+}

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -3,21 +3,24 @@
  */
 var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	debug = require( 'debug' )( 'calypso:help-search' );
+	debug = require( 'debug' )( 'calypso:help-search' ),
+	reactRedux = require( 'react-redux' );
 /**
  * Internal dependencies
  */
 var Main = require( 'components/main' ),
 	analytics = require( 'lib/analytics' ),
+	currentUser = require( 'state/current-user/selectors' ),
 	HappinessEngineers = require( 'me/help/help-happiness-engineers' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	HelpSearch = require( './help-search' ),
 	CompactCard = require( 'components/card/compact' ),
 	Button = require( 'components/button' ),
 	SectionHeader = require( 'components/section-header' ),
-	HelpResult = require( './help-results/item' );
+	HelpResult = require( './help-results/item' ),
+	HelpUnverifiedWarning = require( './help-unverified-warning' );
 
-module.exports = React.createClass( {
+const Help = React.createClass( {
 	displayName: 'Help',
 
 	mixins: [ PureRenderMixin ],
@@ -95,6 +98,7 @@ module.exports = React.createClass( {
 			<Main className="help">
 				<MeSidebarNavigation />
 				<HelpSearch />
+				{ ! this.props.isEmailVerified && <HelpUnverifiedWarning /> }
 				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }
 				<HappinessEngineers />
@@ -102,3 +106,11 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+module.exports = reactRedux.connect(
+	( state ) => {
+		return {
+			isEmailVerified: currentUser.isCurrentUserEmailVerified( state ),
+		};
+	}
+)( Help );

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -103,3 +103,13 @@ export function canCurrentUser( state, siteId, capability ) {
 export function currentUserHasFlag( state, flagName ) {
 	return state.currentUser.flags.indexOf( flagName ) !== -1;
 }
+
+/**
+ * Returns true if the current user is email-verified.
+ *
+ * @param {Object} state Global state tree
+ * @returns {boolean Whether the current user is email-verified.
+ */
+export function isCurrentUserEmailVerified( state ) {
+	return state.currentUser.email_verified;
+}

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -107,9 +107,15 @@ export function currentUserHasFlag( state, flagName ) {
 /**
  * Returns true if the current user is email-verified.
  *
- * @param {Object} state Global state tree
- * @returns {boolean Whether the current user is email-verified.
+ * @param   {Object } state Global state tree
+ * @returns {boolean}       Whether the current user is email-verified.
  */
 export function isCurrentUserEmailVerified( state ) {
-	return state.currentUser.email_verified;
+	const user = getCurrentUser( state );
+
+	if ( ! user ) {
+		return false;
+	}
+
+	return user.email_verified || false;
 }


### PR DESCRIPTION
This pull request is a revisit of the PR #6960, which was latter reverted by #6999 . It is mainly the original PR, plus a fix for the `currentUser.isCurrentUserEmailVerified` selector. 

## Test Plan
For a verified user:
* One should never see a "resend email" notice in `/help` and `/help/contact`

For an unverified user:
+ See the notice in
	+ /help
	+ /help/contact
+ Click on the button, the notice disappears
+ Waiting for a few seconds, the "success" global notice appears
+ Check the mailbox, find the activation email
+ Click on the activation link, now the account should be verified
+ Go back to the `/help` or `/help/contact`, the notice is no longer there. Note that sometimes you would need to refresh to see the proper result.

cc @jordwest @dllh 

Test live: https://calypso.live/?branch=feature/revisit-verification-notice-in-help