### PR TITLE
Ad Tracking: Add One by AOL conversion pixel

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -31,6 +31,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 	GOOGLE_TRACKING_SCRIPT_URL = 'https://www.googleadservices.com/pagead/conversion_async.js',
 	BING_TRACKING_SCRIPT_URL = 'https://bat.bing.com/bat.js',
 	GOOGLE_CONVERSION_ID = config( 'google_adwords_conversion_id' ),
+	ONE_BY_AOL_PIXEL_URL = 'https://secure.ace-tag.advertising.com/action/type=132958/bins=1/rich=0/Mnum=1516/',
 	TRACKING_IDS = {
 		bingInit: '4074038',
 		facebookInit: '823166884443641',
@@ -261,6 +262,19 @@ function recordOrderInAtlas( cart, orderId ) {
 	loadScript.loadScript( urlWithParams );
 }
 
+/**
+ * Tracks the purchase conversion with One by AOL
+ *
+ * @note One by AOL does not record any specifics about the purchase
+ */
+function recordConversionInOneByAOL() {
+	if ( ! config.isEnabled( 'ad-tracking' ) ) {
+		return;
+	}
+
+	new Image().src = ONE_BY_AOL_PIXEL_URL;
+}
+
 module.exports = {
 	retarget: function( context, next ) {
 		const nextFunction = typeof next === 'function' ? next : noop;
@@ -274,5 +288,6 @@ module.exports = {
 
 	recordAddToCart,
 	recordPurchase,
-	recordOrderInAtlas
+	recordOrderInAtlas,
+	recordConversionInOneByAOL
 };

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -97,6 +97,7 @@ var TransactionStepsMixin = {
 							adTracking.recordPurchase( product, step.data.receipt_id );
 						} );
 						adTracking.recordOrderInAtlas( cartValue, step.data.receipt_id );
+						adTracking.recordConversionInOneByAOL();
 					}
 
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {


### PR DESCRIPTION
This PR adds a new purchase conversion pixel, this one for an ad platform provided by AOL called "One by AOL". 

We already have the leadback pixel on the WordPress.com homepage and marketing landing pages. This conversion pixel lets One by AOL know what a successful conversion looks like for those visitors so it can start understanding what paying users look like.

To test:

1. In `development.json`, set `ad-tracking` to `true`
2. Make a purchase in Calypso
3. In Chrome's Network tab, search for "advertising" and verify the advertising.com pixel is loaded:

![screen shot 2016-07-29 at 10 09 21 am](https://cloud.githubusercontent.com/assets/44436/17251164/91aadef0-5575-11e6-9568-409c32f1e39b.png)


Test live: https://calypso.live/?branch=add/one-by-aol-ad-pixel