### PR TITLE
Change Payment Partner Reference ID label to "Transaction ID"

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -89,13 +89,13 @@ module.exports = React.createClass( {
 	},
 
 	ref: function() {
-		if ( ! this.props.transaction.pay_part ) {
+		if ( ! this.props.transaction.pay_ref ) {
 			return null;
 		}
 
 		return (
 			<li>
-				<strong>{ titleCase( this.props.transaction.pay_part ) } Ref</strong>
+				<strong>{ this.translate( 'Transaction ID' ) }</strong>
 				<span>{ this.props.transaction.pay_ref }</span>
 			</li>
 		);


### PR DESCRIPTION
Don't show the payment gateway partner directly to the users in the receipt to avoid confusion.
The partner can be determined by the format of the transaction ID.

The updated label can be viewed through `/me/billing/` and selecting an existing billing receipt.

Test live: https://calypso.live/?branch=update/change-pay-partner-ref-label-to-transaction-id