### PR TITLE
CPT / Themes: Refresh post types when site theme changes

### DIFF
--- a/client/components/data/query-post-types/README.md
+++ b/client/components/data/query-post-types/README.md
@@ -34,7 +34,7 @@ export default function MyPostTypesList( { postTypes } ) {
 
 <table>
 	<tr><th>Type</th><td>Number</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
 </table>
 
 The site ID for which post types should be requested.

--- a/client/components/data/query-post-types/index.jsx
+++ b/client/components/data/query-post-types/index.jsx
@@ -3,7 +3,6 @@
  */
 import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -49,9 +48,5 @@ export default connect(
 			requestingPostTypes: isRequestingPostTypes( state, ownProps.siteId )
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators( {
-			requestPostTypes
-		}, dispatch );
-	}
+	{ requestPostTypes }
 )( QueryPostTypes );

--- a/client/components/data/query-post-types/index.jsx
+++ b/client/components/data/query-post-types/index.jsx
@@ -8,23 +8,36 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { isRequestingPostTypes } from 'state/post-types/selectors';
+import { getSiteOption } from 'state/sites/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 
 class QueryPostTypes extends Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		requestingPostTypes: PropTypes.bool,
+		themeSlug: PropTypes.string,
+		requestPostTypes: PropTypes.func
+	};
+
 	componentWillMount() {
-		if ( ! this.props.requestingPostTypes && this.props.siteId ) {
-			this.props.requestPostTypes( this.props.siteId );
-		}
+		this.request( this.props );
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.requestingPostTypes ||
-				! nextProps.siteId ||
-				( this.props.siteId === nextProps.siteId ) ) {
+		const { siteId, themeSlug } = this.props;
+		const { siteId: nextSiteId, themeSlug: nextThemeSlug } = nextProps;
+		const hasThemeChanged = themeSlug && nextThemeSlug && themeSlug !== nextThemeSlug;
+		if ( siteId !== nextSiteId || hasThemeChanged ) {
+			this.request( nextProps );
+		}
+	}
+
+	request( props ) {
+		if ( props.requestingPostTypes ) {
 			return;
 		}
 
-		nextProps.requestPostTypes( nextProps.siteId );
+		props.requestPostTypes( props.siteId );
 	}
 
 	render() {
@@ -32,20 +45,11 @@ class QueryPostTypes extends Component {
 	}
 }
 
-QueryPostTypes.propTypes = {
-	siteId: PropTypes.number,
-	requestingPostTypes: PropTypes.bool,
-	requestPostTypes: PropTypes.func
-};
-
-QueryPostTypes.defaultProps = {
-	requestPostTypes: () => {}
-};
-
 export default connect(
 	( state, ownProps ) => {
 		return {
-			requestingPostTypes: isRequestingPostTypes( state, ownProps.siteId )
+			requestingPostTypes: isRequestingPostTypes( state, ownProps.siteId ),
+			themeSlug: getSiteOption( state, ownProps.siteId, 'theme_slug' )
 		};
 	},
 	{ requestPostTypes }

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -403,7 +403,7 @@ const PostSelectorPosts = React.createClass( {
 						siteId={ siteId }
 						query={ { ...query, page } } />
 				) ) }
-				{ isTypeLabelsVisible && (
+				{ isTypeLabelsVisible && siteId && (
 					<QueryPostTypes siteId={ siteId } />
 				) }
 				{ showSearch && (

--- a/client/post-editor/editor-status-label/placeholder.jsx
+++ b/client/post-editor/editor-status-label/placeholder.jsx
@@ -36,7 +36,7 @@ function EditorStatusLabelPlaceholder( { translate, siteId, typeSlug, type, clas
 
 	return (
 		<button className={ classes }>
-			{ 'post' !== typeSlug && 'page' !== typeSlug && (
+			{ 'post' !== typeSlug && 'page' !== typeSlug && siteId && (
 				<QueryPostTypes siteId={ siteId } />
 			) }
 			<strong>{ label }</strong>

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -21,6 +21,7 @@ import {
 	SITES_REQUEST_SUCCESS,
 	DESERIALIZE,
 	SERIALIZE,
+	THEME_ACTIVATED,
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
 } from 'state/action-types';
 import { sitesSchema } from './schema';
@@ -62,6 +63,22 @@ export function items( state = {}, action ) {
 				memo[ site.ID ] = pick( site, VALID_SITE_KEYS );
 				return memo;
 			}, {} );
+
+		case THEME_ACTIVATED:
+			const { siteId, theme } = action;
+			const site = state[ siteId ];
+			if ( ! site ) {
+				break;
+			}
+
+			return {
+				...state,
+				[ siteId ]: merge( {}, site, {
+					options: {
+						theme_slug: theme.stylesheet
+					}
+				} )
+			};
 
 		case DESERIALIZE:
 			if ( isValidStateWithSchema( state, sitesSchema ) ) {

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -14,6 +14,7 @@ import {
 	SITES_REQUEST,
 	SITES_REQUEST_FAILURE,
 	SITES_REQUEST_SUCCESS,
+	THEME_ACTIVATED,
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
 	SERIALIZE,
 	DESERIALIZE
@@ -214,6 +215,36 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
+			} );
+		} );
+
+		it( 'should update the theme slug option when a theme is activated', () => {
+			const original = deepFreeze( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog',
+					options: {
+						theme_slug: 'pub/twentythirteen'
+					}
+				}
+			} );
+			const state = items( original, {
+				type: THEME_ACTIVATED,
+				siteId: 2916284,
+				theme: {
+					name: 'Twenty Sixteen',
+					stylesheet: 'pub/twentysixteen'
+				}
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog',
+					options: {
+						theme_slug: 'pub/twentysixteen'
+					}
+				}
 			} );
 		} );
 

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -219,7 +219,8 @@ export function activated( theme, site, source = 'unknown', purchased = false ) 
 		const action = {
 			type: THEME_ACTIVATED,
 			theme,
-			site
+			site,
+			siteId: site.ID
 		};
 
 		const trackThemeActivation = recordTracksEvent(


### PR DESCRIPTION
Fixes #7131

This pull request seeks to resolve an issue where sidebar Publish menu items are not updated after changing the theme for a site to reflect post types supported by that theme.

__Testing instructions:__

Verify that after changing a theme, if support is added or removed for a post type, the Publish menu is updated accordingly. It may be easiest to start with a theme that does not have support for any built-in post types, disable [custom content types on writing settings](http://calypso.localhost:3000/settings/writing), then switching to a theme with custom post type support (e.g. Sketch theme supporting Portfolios). I've found that some themes, when switched, appear to activate the "Portfolio" custom content type option automatically, so even when switching to a theme without default support, the Portfolio menu will (correctly) still display.

1. Navigate to the [themes screen](http://calypso.localhost:3000/design)
2. Select a site, if prompted
3. Change the theme
4. Note that the Publish menu items reflect available post types for the theme

/cc @ockham 

Test live: https://calypso.live/?branch=fix/7131-post-types-refresh-theme-change