### PR TITLE
Editor: Show connections subtitle only if post type supports Publicize

### DIFF
--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -39,12 +39,8 @@ const EditorSharingAccordion = React.createClass( {
 
 	getSubtitle: function() {
 		const { isPublicizeEnabled, post, connections } = this.props;
-		if ( ! isPublicizeEnabled ) {
+		if ( ! isPublicizeEnabled || ! post || ! connections ) {
 			return;
-		}
-
-		if ( ! post || ! connections ) {
-			return this.translate( 'Loading…' );
 		}
 
 		const skipped = PostMetadata.publicizeSkipped( post );

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { map, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,48 +19,41 @@ import Sharing from './';
 import AccordionSection from 'components/accordion/section';
 import postUtils from 'lib/posts/utils';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
+import { isJetpackModuleActive, getSiteOption } from 'state/sites/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
+import { postTypeSupports } from 'state/post-types/selectors';
 import { fetchConnections as requestConnections } from 'state/sharing/publicize/actions';
 
 const EditorSharingAccordion = React.createClass( {
-	displayName: 'EditorSharingAccordion',
-
 	propTypes: {
-		site: React.PropTypes.object,
-		post: React.PropTypes.object,
-		isNew: React.PropTypes.bool,
-		connections: React.PropTypes.array,
-		requestConnections: React.PropTypes.func
+		site: PropTypes.object,
+		post: PropTypes.object,
+		isNew: PropTypes.bool,
+		connections: PropTypes.array,
+		isPublicizeEnabled: PropTypes.bool
 	},
 
 	getSubtitle: function() {
-		var skipped, targeted;
-
-		if ( this.props.site && (
-				( this.props.site.jetpack && ! this.props.site.isModuleActive( 'publicize' ) ) ||
-				this.props.site.options.publicize_permanently_disabled
-		) ) {
+		const { isPublicizeEnabled, post, connections } = this.props;
+		if ( ! isPublicizeEnabled ) {
 			return;
 		}
 
-		if ( postUtils.isPage( this.props.post ) ) {
-			return;
-		}
-
-		if ( ! this.props.post || ! this.props.connections ) {
+		if ( ! post || ! connections ) {
 			return this.translate( 'Loading…' );
 		}
 
-		skipped = PostMetadata.publicizeSkipped( this.props.post );
-		targeted = this.props.connections.filter( function( connection ) {
-			return -1 === skipped.indexOf( connection.keyring_connection_ID );
+		const skipped = PostMetadata.publicizeSkipped( post );
+		const targeted = connections.filter( ( connection ) => {
+			return ! includes( skipped, connection.keyring_connection_ID );
 		} );
+		const targetedServices = serviceConnections.getServicesFromConnections( targeted );
 
-		return serviceConnections.getServicesFromConnections( targeted ).map( function( service ) {
-			return service.label;
-		} ).join( ', ' );
+		return map( targetedServices, 'label' ).join( ', ' );
 	},
 
 	renderShortUrl: function() {
@@ -133,13 +127,19 @@ const EditorSharingAccordion = React.createClass( {
 
 export default connect(
 	( state ) => {
-		const site = getSelectedSite( state );
-		const user = getCurrentUser( state );
+		const siteId = getSelectedSiteId( state );
+		const userId = getCurrentUserId( state );
+		const postId = getEditorPostId( state );
+		const postType = getEditedPostValue( state, siteId, postId, 'type' );
+		const isPublicizeEnabled = (
+			false !== isJetpackModuleActive( state, siteId, 'publicize' ) &&
+			true !== getSiteOption( state, siteId, 'publicize_permanently_disabled' ) &&
+			postTypeSupports( state, siteId, postType, 'publicize' )
+		);
 
 		return {
-			// [TODO]: Reintroduce selected site from Redux state once needs
-			// have been met for use (e.g. `site.isModuleActive`)
-			connections: site && user ? getSiteUserConnections( state, site.ID, user.ID ) : null
+			isPublicizeEnabled,
+			connections: getSiteUserConnections( state, siteId, userId )
 		};
 	},
 	( dispatch ) => {

--- a/client/state/post-types/selectors.js
+++ b/client/state/post-types/selectors.js
@@ -65,6 +65,17 @@ export function postTypeSupports( state, siteId, slug, feature ) {
 		return !! postType.supports[ feature ];
 	}
 
+	// Hard-coded fallbacks; while themes can technically override these
+	// supports, we can be relatively safe in making the assumption. By
+	// defining fallbacks, we avoid UI flickering after request completes.
+	switch ( slug ) {
+		case 'page':
+			switch ( feature ) {
+				case 'publicize':
+					return false;
+			}
+	}
+
 	return null;
 }
 

--- a/client/state/post-types/test/selectors.js
+++ b/client/state/post-types/test/selectors.js
@@ -195,6 +195,12 @@ describe( 'selectors', () => {
 
 			expect( isSupported ).to.be.true;
 		} );
+
+		it( 'should return hard-coded fallback values for unknown post types', () => {
+			const state = { postTypes: { items: {} } };
+
+			expect( postTypeSupports( state, 2916284, 'page', 'publicize' ) ).to.be.false;
+		} );
 	} );
 
 	describe( 'isPostTypeSupported', () => {


### PR DESCRIPTION
Related: #7062, #7089 

This pull request seeks to resolve an issue where active connections are shown in the editor Sharing accordion subtitle even when the post type does not support Publicize. This only affects custom post types (notably, Testimonials). It also removes the "Loading..." label from the Sharing accordion which is inconsistent with other accordions in the editor.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/17254745/14dda4ac-5584-11e6-883c-0b83fe938b68.png)|![After](https://cloud.githubusercontent.com/assets/1779930/17254748/1751d514-5584-11e6-9982-00b36c7b8ded.png)

__Testing instructions:__

Verify that there are no regressions in the display of the Sharing accordion subtitle. In particular, the subtitle should show a comma-separated list of all available connections for a new post. As connections are toggled, the comma-separated list should update, and after saving and reloading the page should still be correct.

1. (Prerequisite) Activate Testimonials from [site writing settings](http://calypso.localhost:3000/settings/writing) if not already enabled
2. (Prerequisite) Connect at least one Publicize account from the [connections screen](http://calypso.localhost:3000/sharing)
3. Navigate to the [testimonials editor](http://calypso.localhost:3000/edit/jetpack-testimonial)
4. Note that there is no subtitle of the Sharing accordion

Test live: https://calypso.live/?branch=fix/editor-cpt-no-publicize-support