### PR TITLE
Jetpack Connect Plans

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -47,6 +47,10 @@ export const FEATURE_WORDADS_INSTANT = 'wordads-instant';
 export const FEATURE_NO_BRANDING = 'no-wp-branding';
 
 // jetpack features constants
+export const FEATURE_STANDARD_SECURITY_TOOLS = 'standard-security-tools';
+export const FEATURE_SITE_STATS = 'site-stats';
+export const FEATURE_TRAFFIC_TOOLS = 'traffic-tools';
+export const FEATURE_MANAGE = 'jetpack-manage';
 export const FEATURE_SINGLE_SITE_SUPPORT = 'single-site-support';
 export const FEATURE_MULTI_SITE_SUPPORT = 'multi-site-support';
 export const FEATURE_SPAM_AKISMET_PLUS = 'spam-akismet-plus';
@@ -153,8 +157,16 @@ export const plansList = {
 	[ PLAN_JETPACK_FREE ]: {
 		getTitle: () => i18n.translate( 'Free' ),
 		getProductId: () => 2002,
-		getDescription: () => '',
-		getFeatures: () => [],
+		getDescription: () => i18n.translate(
+			'The features most needed by WordPress sites' + 
+			' — perfectly packaged and optimized for everyone.'
+		),
+		getFeatures: () => [
+			FEATURE_STANDARD_SECURITY_TOOLS,
+			FEATURE_SITE_STATS,
+			FEATURE_TRAFFIC_TOOLS,
+			FEATURE_MANAGE
+		],
 		getBillingTimeFrame: () => i18n.translate( 'for life' )
 	},
 	[ PLAN_JETPACK_PREMIUM ]: {
@@ -163,8 +175,8 @@ export const plansList = {
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
 		getPathSlug: () => 'premium',
 		getDescription: () => i18n.translate(
-			'All the features you need to keep your site’s content backed up' +
-			' and secure, as well as spam-free.'
+			'Advanced security features to keep your site safe and sound.' +
+			' With daily backups, malware scanning, and spam defense.'
 		),
 		getFeatures: () => [
 			FEATURE_SINGLE_SITE_SUPPORT,
@@ -185,9 +197,8 @@ export const plansList = {
 		getPathSlug: () => 'premium-monthly',
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
 		getDescription: () => i18n.translate(
-			'All the features you need to keep your site’s content backed' +
-			' up and secure, as well as spam-free.'
-		),
+			'Advanced security features to keep your site safe and sound.' +
+			' With daily backups, malware scanning, and spam defense.'		),
 		getFeatures: () => [
 			FEATURE_SINGLE_SITE_SUPPORT,
 			FEATURE_MALWARE_SCANNING_DAILY,
@@ -207,8 +218,7 @@ export const plansList = {
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ], plan ),
 		getPathSlug: () => 'professional',
 		getDescription: () => i18n.translate(
-			'More powerful security tools and realtime content backup for ' +
-			'the ultimate peace of mind.'
+			'More powerful security tools, including malware removal and realtime content backup, for the ultimate peace of mind.'
 		),
 		getFeatures: () => [
 			FEATURE_MULTI_SITE_SUPPORT,
@@ -232,7 +242,7 @@ export const plansList = {
 		getPathSlug: () => 'professional-monthly',
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ], plan ),
 		getDescription: () => i18n.translate(
-			'More powerful security tools and realtime content backup for the ultimate peace of mind.'
+			'More powerful security tools, including malware removal and realtime content backup, for the ultimate peace of mind.'
 		),
 		getFeatures: () => [
 			FEATURE_MULTI_SITE_SUPPORT,
@@ -436,6 +446,22 @@ export const featuresList = {
 			'and running and working how you want it.'
 		),
 		plans: allPaidPlans
+	},
+	[ FEATURE_STANDARD_SECURITY_TOOLS ]: {
+		getTitle: () => i18n.translate( 'Standard Security Tools' ),
+		getDescription: () => i18n.translate( 'Brute force protection, uptime monitoring, secure sign on, and automatic updates for your plugins.' )
+	},
+	[ FEATURE_SITE_STATS ]: {
+		getTitle: () => i18n.translate( 'Site Stats and Analytics' ),
+		getDescription: () => i18n.translate( 'The most important metrics for your site.' )
+	},
+	[ FEATURE_TRAFFIC_TOOLS ]: {
+		getTitle: () => i18n.translate( 'Traffic and Promotion Tools' ),
+		getDescription: () => i18n.translate( 'Build and engage your audience with more than a dozen optimization tools.' )
+	},
+	[ FEATURE_MANAGE ]: {
+		getTitle: () => i18n.translate( 'Centralized Dashboard' ),
+		getDescription: () => i18n.translate( 'Manage all of your WordPress sites from one location.' )
 	},
 	[ FEATURE_SINGLE_SITE_SUPPORT ]: {
 		getSlug: () => FEATURE_SINGLE_SITE_SUPPORT,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -158,7 +158,7 @@ export const plansList = {
 		getTitle: () => i18n.translate( 'Free' ),
 		getProductId: () => 2002,
 		getDescription: () => i18n.translate(
-			'The features most needed by WordPress sites' + 
+			'The features most needed by WordPress sites' +
 			' — perfectly packaged and optimized for everyone.'
 		),
 		getFeatures: () => [
@@ -448,18 +448,25 @@ export const featuresList = {
 		plans: allPaidPlans
 	},
 	[ FEATURE_STANDARD_SECURITY_TOOLS ]: {
+		getSlug: () => FEATURE_STANDARD_SECURITY_TOOLS,
 		getTitle: () => i18n.translate( 'Standard Security Tools' ),
-		getDescription: () => i18n.translate( 'Brute force protection, uptime monitoring, secure sign on, and automatic updates for your plugins.' )
+		getDescription: () => i18n.translate(
+			'Brute force protection, uptime monitoring, secure sign on,' +
+			'and automatic updates for your plugins.'
+		)
 	},
 	[ FEATURE_SITE_STATS ]: {
+		getSlug: () => FEATURE_SITE_STATS,
 		getTitle: () => i18n.translate( 'Site Stats and Analytics' ),
 		getDescription: () => i18n.translate( 'The most important metrics for your site.' )
 	},
 	[ FEATURE_TRAFFIC_TOOLS ]: {
+		getSlug: () => FEATURE_TRAFFIC_TOOLS,
 		getTitle: () => i18n.translate( 'Traffic and Promotion Tools' ),
 		getDescription: () => i18n.translate( 'Build and engage your audience with more than a dozen optimization tools.' )
 	},
 	[ FEATURE_MANAGE ]: {
+		getSlug: () => FEATURE_MANAGE,
 		getTitle: () => i18n.translate( 'Centralized Dashboard' ),
 		getDescription: () => i18n.translate( 'Manage all of your WordPress sites from one location.' )
 	},

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -20,6 +20,7 @@ const PlanFeaturesActions = ( {
 	freePlan = false,
 	onUpgradeClick = noop,
 	isPlaceholder = false,
+	isInSignup,
 	translate
 } ) => {
 	let upgradeButton;
@@ -32,7 +33,7 @@ const PlanFeaturesActions = ( {
 		className
 	);
 
-	if ( current ) {
+	if ( current && ! isInSignup ) {
 		upgradeButton = (
 			<Button className={ classes } disabled>
 				<Gridicon size={ 18 } icon="checkmark" />

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -76,7 +76,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderMobileView() {
-		const { isPlaceholder, translate, planProperties } = this.props;
+		const { isPlaceholder, translate, planProperties, isInSignup } = this.props;
 
 		// move any free plan to last place in mobile view
 		let freePlanProperties;
@@ -130,6 +130,7 @@ class PlanFeatures extends Component {
 						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
+						isInSignup={ isInSignup }
 					/>
 					<FoldableCard
 						header={ translate( 'Show features' ) }
@@ -218,7 +219,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderTopButtons() {
-		const { planProperties, isPlaceholder } = this.props;
+		const { planProperties, isPlaceholder, isInSignup } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -245,6 +246,7 @@ class PlanFeatures extends Component {
 						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
+						isInSignup={ isInSignup }
 					/>
 				</td>
 			);
@@ -312,7 +314,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderBottomButtons() {
-		const { planProperties, isPlaceholder } = this.props;
+		const { planProperties, isPlaceholder, isInSignup } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -337,6 +339,7 @@ class PlanFeatures extends Component {
 						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
+						isInSignup={ isInSignup }
 					/>
 				</td>
 			);

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -49,7 +49,12 @@ class PlansFeaturesMain extends Component {
 			}
 			return (
 				<div className="plans-features-main__group">
-					<PlanFeatures plans={ jetpackPlans } selectedFeature={ selectedFeature } />
+					<PlanFeatures
+						plans={ jetpackPlans }
+						selectedFeature={ selectedFeature }
+						onUpgradeClick={ onUpgradeClick }
+						isInSignup={ isInSignup }
+					/>
 				</div>
 			);
 		}
@@ -61,7 +66,12 @@ class PlansFeaturesMain extends Component {
 			}
 			return (
 				<div className="plans-features-main__group">
-					<PlanFeatures plans={ jetpackPlans } selectedFeature={ selectedFeature } />
+					<PlanFeatures
+						plans={ jetpackPlans }
+						selectedFeature={ selectedFeature }
+						onUpgradeClick={ onUpgradeClick }
+						isInSignup={ isInSignup }
+					/>
 				</div>
 			);
 		}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -43,7 +43,7 @@ class PlansFeaturesMain extends Component {
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 
 		if ( this.isJetpackSite( site ) && intervalType === 'monthly' ) {
-			let jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ];
+			const jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ];
 			if ( hideFreePlan ) {
 				jetpackPlans.shift();
 			}
@@ -55,7 +55,7 @@ class PlansFeaturesMain extends Component {
 		}
 
 		if ( this.isJetpackSite( site ) ) {
-			let jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ];
+			const jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ];
 			if ( hideFreePlan ) {
 				jetpackPlans.shift();
 			}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -11,6 +11,7 @@ import { filter } from 'lodash';
 import PlanFeatures from 'my-sites/plan-features';
 import {
 	PLAN_FREE,
+	PLAN_JETPACK_FREE,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
@@ -42,23 +43,25 @@ class PlansFeaturesMain extends Component {
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 
 		if ( this.isJetpackSite( site ) && intervalType === 'monthly' ) {
+			let jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ];
+			if ( hideFreePlan ) {
+				jetpackPlans.shift();
+			}
 			return (
 				<div className="plans-features-main__group">
-					<PlanFeatures
-						plans={ [ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ] }
-						selectedFeature={ selectedFeature }
-					/>
+					<PlanFeatures plans={ jetpackPlans } selectedFeature={ selectedFeature } />
 				</div>
 			);
 		}
 
 		if ( this.isJetpackSite( site ) ) {
+			let jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ];
+			if ( hideFreePlan ) {
+				jetpackPlans.shift();
+			}
 			return (
 				<div className="plans-features-main__group">
-					<PlanFeatures
-						plans={ [ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ] }
-						selectedFeature={ selectedFeature }
-					/>
+					<PlanFeatures plans={ jetpackPlans } selectedFeature={ selectedFeature } />
 				</div>
 			);
 		}

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -135,7 +135,7 @@ const Plans = React.createClass( {
 
 		return (
 			<div>
-				<Main isWideLayout={ true }>
+				<Main wideLayout>
 					<QueryPlans />
 					<QuerySitePlans siteId={ selectedSite.ID } />
 					<div className="jetpack-connect__plans">

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -87,8 +87,7 @@ const Plans = React.createClass( {
 						<div id="plans" className="plans has-sidebar">
 							<PlansFeaturesMain
 								site={ selectedSite }
-								intervalType="yearly"
-								hideFreePlan={ false } />
+								intervalType="yearly" />
 						</div>
 					</div>
 				</Main>

--- a/client/state/plans/selectors.js
+++ b/client/state/plans/selectors.js
@@ -40,6 +40,17 @@ export const getPlan = createSelector(
 );
 
 /**
+ * Returns a plan searched by its slug
+ * @param  {Object} state      global state
+ * @param  {String} planSlug the plan slug
+ * @return {Object} the matching plan
+ */
+export const getPlanBySlug = createSelector(
+	( state, planSlug ) => getPlans( state ).filter( plan => plan.product_slug === planSlug ).shift(),
+	( state ) => getPlans( state )
+);
+
+/**
  * Returns a plan price
  * @param  {Object}  state     global state
  * @param  {Number}  productId the plan productId


### PR DESCRIPTION
Updating to newly designed plans layout at `client/my-sites/plans-features-main`

See #7130 

Here's a screencast of the newly designed plan boxes in our Jetpack Connect Flow:
https://cloudup.com/cEatUbI_oHb

And a screenshot:
![jpc-new-plans-page](https://cloud.githubusercontent.com/assets/2694219/17254829/6ef680a8-5584-11e6-826a-61fa25ea450f.jpg)


Currently working on making the Free plan selectable. And it will need some design.
cc: @lamosty 

Test live: https://calypso.live/?branch=update/jetpack-connect-plans