### PR TITLE
Editor: Bind EditorPageOrder to Redux state

### DIFF
--- a/client/post-editor/editor-drawer/page-options.jsx
+++ b/client/post-editor/editor-drawer/page-options.jsx
@@ -41,7 +41,7 @@ function EditorDrawerPageOptions( { translate, siteId, postId, post, postType, h
 					<PageTemplates post={ post } />
 				</PageTemplatesData>
 			) }
-			<PageOrder menuOrder={ get( post, 'menu_order', 0 ) } />
+			<PageOrder />
 		</Accordion>
 	);
 }

--- a/client/post-editor/editor-page-order/index.jsx
+++ b/client/post-editor/editor-page-order/index.jsx
@@ -31,6 +31,7 @@ class EditorPageOrder extends Component {
 		super( ...arguments );
 
 		this.editMenuOrder = this.editMenuOrder.bind( this );
+		this.statTracked = false;
 	}
 
 	editMenuOrder( event ) {
@@ -40,8 +41,12 @@ class EditorPageOrder extends Component {
 			return;
 		}
 
-		recordStat( 'advanced_menu_order_changed' );
-		recordEvent( 'Changed page menu order' );
+		if ( ! this.statTracked ) {
+			this.statTracked = true;
+			recordStat( 'advanced_menu_order_changed' );
+			recordEvent( 'Changed page menu order' );
+		}
+
 		this.props.editPost( { menu_order: newOrder }, siteId, postId );
 	}
 

--- a/client/post-editor/editor-page-order/style.scss
+++ b/client/post-editor/editor-page-order/style.scss
@@ -10,7 +10,13 @@
 	text-transform: uppercase;
 }
 
-.editor-page-order input[type="text"] {
+input[type="number"].editor-page-order__input {
+	-moz-appearance: textfield;
 	font-size: 13px;
 	width: 50px;
+
+	&::-webkit-outer-spin-button,
+	&::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+	}
 }


### PR DESCRIPTION
Related: #6548

This pull request seeks to refactor the `<EditorPageOrder />` component to use Redux state exclusively for both displaying the current value and editing the value of the `menu_order` post field. Unless I'm mistaken, this would be the first production editor field using Redux state.

It also makes minor usability improvements to render the `<input />` as a proper number field, so that arrow keys can be used to change order and a number input is shown on mobile devices (at least iOS).

__Testing instructions:__

Verify that there are no regressions in using the page order field. Notably, ensure that the post becomes saveable after changing the order, and that saving the post persists the order in the current session and after refresh.

1. Navigate to the [page editor](http://calypso.localhost:3000/page)
2. Select a site, if prompted
3. Enter a title and/or content
4. Save the post
5. Expand the Page Attributes sidebar accordion
6. Change the Order value
7. Note that the Save button is shown
8. Save the post
9. Refresh the page
10. Note that the Order value entered in step 6 is persisted

Test live: https://calypso.live/?branch=update/editor-redux-page-order