### PR TITLE
Plans: fix display of mobile jetpack plans

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -26,6 +26,7 @@ import {
 	featuresList,
 	plansList,
 	PLAN_FREE,
+	PLAN_JETPACK_FREE, 
 	PLAN_PERSONAL,
 } from 'lib/plans/constants';
 import { createSitePlanObject } from 'state/sites/plans/assembler';
@@ -37,6 +38,10 @@ import SitesList from 'lib/sites-list';
 const sitesList = SitesList();
 const debug = debugFactory( 'calypso:plans' );
 const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
+
+export function isFreePlan( plan ) {
+	return plan === PLAN_FREE || plan === PLAN_JETPACK_FREE;
+}
 
 export function getPlan( plan ) {
 	return plansList[ plan ];

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -7,7 +7,6 @@ import { map, reduce, noop } from 'lodash';
 import page from 'page';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,13 +27,10 @@ import {
 import {
 	isPopular,
 	isMonthly,
-	PLAN_FREE,
-	PLAN_PERSONAL,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
 	getPlanFeaturesObject,
 	getPlanClass
 } from 'lib/plans/constants';
+import { isFreePlan } from 'lib/plans';
 import { getSiteSlug } from 'state/sites/selectors';
 import {
 	getPlanPath,
@@ -80,17 +76,23 @@ class PlanFeatures extends Component {
 	}
 
 	renderMobileView() {
-		const { isPlaceholder, translate } = this.props;
-		const planProperties = [];
+		const { isPlaceholder, translate, planProperties } = this.props;
 
-		[ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_FREE ].forEach( planName => {
-			const planObject = find( this.props.planProperties, plan => plan.planName === planName );
-			if ( planObject ) {
-				planProperties.push( planObject );
+		// move any free plan to last place in mobile view
+		let freePlanProperties;
+		const reorderedPlans = planProperties.filter( ( properties ) => {
+			if ( isFreePlan( properties.planName ) ) {
+				freePlanProperties = properties;
+				return false;
 			}
+			return true;
 		} );
 
-		return map( planProperties, ( properties ) => {
+		if ( freePlanProperties ) {
+			reorderedPlans.push( freePlanProperties );
+		}
+
+		return map( reorderedPlans, ( properties ) => {
 			const {
 				available,
 				currencyCode,
@@ -126,7 +128,7 @@ class PlanFeatures extends Component {
 						popular={ popular }
 						available = { available }
 						onUpgradeClick={ onUpgradeClick }
-						freePlan={ planName === PLAN_FREE }
+						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 					/>
 					<FoldableCard
@@ -241,7 +243,7 @@ class PlanFeatures extends Component {
 						available = { available }
 						popular={ popular }
 						onUpgradeClick={ onUpgradeClick }
-						freePlan={ planName === PLAN_FREE }
+						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 					/>
 				</td>
@@ -325,7 +327,7 @@ class PlanFeatures extends Component {
 						available = { available }
 						popular={ popular }
 						onUpgradeClick={ onUpgradeClick }
-						freePlan={ planName === PLAN_FREE }
+						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 					/>
 				</td>


### PR DESCRIPTION
Fixes #7170, so we see Jetpack plans at /plans at mobile sizes.

## Testing Instructions
- Navigate to http://calypso.localhost:3000/plans
- Select a jetpack site
- Resize window to mobile breakpoint
- We should see jetpack plans
- Navigate to http://calypso.localhost:3000/plans
- Select a wpcom site
- Resize window to mobile breakpoint
- Plans display as expected
- Navigate to http://calypso.localhost:3000/start
- Follow signup flow
- On plans selection page, resize window to mobile breakpoint
- All plans should be displayed, with the free plan at the bottom

cc @rralian @artpi @apeatling @lamosty 

Test live: https://calypso.live/?branch=fix/jetpack-mobile-plans