### PR TITLE
Reader: update small to compact in post-card Component

### DIFF
--- a/client/components/post-card/compact.jsx
+++ b/client/components/post-card/compact.jsx
@@ -16,7 +16,7 @@ import resizeImageUrl from 'lib/resize-image-url';
 import AuthorAndSite from './author-and-site';
 
 export function CompactPostCard( { translate, post, site, onPostClick = noop, onSiteClick = noop } ) {
-	const classes = classnames( 'post-card__compact small', {
+	const classes = classnames( 'post-card__compact', {
 		'has-image': post.canonical_image
 	} );
 	const displayName = post.author.name;

--- a/client/components/post-card/compact.jsx
+++ b/client/components/post-card/compact.jsx
@@ -15,20 +15,20 @@ import safeImageUrl from 'lib/safe-image-url';
 import resizeImageUrl from 'lib/resize-image-url';
 import AuthorAndSite from './author-and-site';
 
-export function SmallPostCard( { translate, post, site, onPostClick = noop, onSiteClick = noop } ) {
-	const classes = classnames( 'post-card small', {
+export function CompactPostCard( { translate, post, site, onPostClick = noop, onSiteClick = noop } ) {
+	const classes = classnames( 'post-card__compact small', {
 		'has-image': post.canonical_image
 	} );
 	const displayName = post.author.name;
 	const siteName = site && site.title || post.site_name;
 
 	const username = (
-		<span className="post-card__author">
+		<span className="post-card__compact-author">
 			<a href={ `/read/blogs/${post.site_ID}` } onClick={ partial( onSiteClick, site, post ) }>{ displayName }</a>
 		</span>
 	);
 
-	const sitename = ( <span className="post-card__site-title">
+	const sitename = ( <span className="post-card__compact-site-title">
 		<a href={ `/read/blogs/${post.site_ID}` } onClick={ partial( onSiteClick, site, post ) }>{ siteName }</a>
 	</span> );
 
@@ -36,22 +36,22 @@ export function SmallPostCard( { translate, post, site, onPostClick = noop, onSi
 
 	return (
 		<Card className={ classes }>
-			<div className="post-card__site-info-title">
-				<h1 className="post-card__title">
-					<a className="post-card__anchor" href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` } onClick={ partial( onPostClick, post ) }>{ post.title }</a>
+			<div className="post-card__compact-site-info-title">
+				<h1 className="post-card__compact-title">
+					<a className="post-card__compact-anchor" href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` } onClick={ partial( onPostClick, post ) }>{ post.title }</a>
 				</h1>
-				<div className="post-card__site-info">
+				<div className="post-card__compact-site-info">
 					<AuthorAndSite post={ post } site={ site } />
 				</div>
 			</div>
 			<div>
 			{ post.canonical_image && (
 					<a href={ `/read/blogs/${post.site_ID}/posts/${post.ID}` } onClick={ partial( onPostClick, post ) }>
-						<img className="post-card__thumbnail" src={ thumbnailUrl } />
+						<img className="post-card__compact-thumbnail" src={ thumbnailUrl } />
 					</a> ) }
 			</div>
 		</Card>
 	);
 }
 
-export default localize( SmallPostCard );
+export default localize( CompactPostCard );

--- a/client/components/post-card/style.scss
+++ b/client/components/post-card/style.scss
@@ -1,14 +1,14 @@
-.post-card__site-info-title {
+.post-card__compact-site-info-title {
 	color: $gray;
 	float: left;
 	width: 100%;
 }
 
-.has-image .post-card__site-info-title {
+.has-image .post-card__compact-site-info-title {
 	width: calc( 100% - 120px );
 }
 
-.post-card__site-info {
+.post-card__compact-site-info {
 	color: $gray;
 	display: block;
 	font-size: 13px;
@@ -18,19 +18,6 @@
 	white-space: nowrap;
 	width: 100%;
 
-	a {
-		color: $gray;
-		text-decoration: none;
-
-		&:visited {
-			color: inherit;
-		}
-
-		&:hover {
-			color: $blue-wordpress;
-		}
-	}
-
 	.site-icon {
 		align-self: auto;
 		float: left;
@@ -39,18 +26,29 @@
 	}
 }
 
-.post-card__title {
+.post-card__byline-link,
+.post-card__byline-link:visited {
+	color: $gray;
+	text-decoration: none;
+
+	&:hover {
+		color: $blue-wordpress;
+	}
+}
+
+.post-card__compact-title {
 	float: left;
 	line-height: 1.2;
 	margin-top: 6px;
 	width: 98%;
 }
 
-.post-card__anchor {
+.post-card__compact-anchor {
 	color: $gray-dark;
 	font-size: 15px;
 	font-weight: 600;
 	line-height: 1.4;
+	text-decoration: none;
 	@extend %content-font;
 
 	&:visited {
@@ -62,7 +60,7 @@
 	}
 }
 
-.post-card__thumbnail {
+.post-card__compact-thumbnail {
 	border-radius: 2px;
 	clear: right;
 	float: right;
@@ -256,7 +254,7 @@
 	margin-top: 6px;
 }
 
-// Custom styles for Follow button
+// Custom styles for Follow button in Search
 .post-card__search .follow-button {
 	background: none;
 	border-style: none;
@@ -315,16 +313,12 @@
 	}
 }
 
-// Custom colors for Site and Author info
+.reader__content .post-card__byline-link,
+.reader__content .post-card__byline-link:visited {
+	color: $gray;
+	text-decoration: none;
 
-.reader__content {
-
-	.post-card__byline-link,
-	.post-card__byline-link:visited {
-		color: lighten( $gray, 10% );
-
-		&:hover {
-			color: $blue-wordpress;
-		}
+	&:hover {
+		color: $blue-wordpress;
 	}
 }

--- a/client/components/related-posts/index.jsx
+++ b/client/components/related-posts/index.jsx
@@ -12,12 +12,12 @@ import noop from 'lodash/noop';
 import { relatedPostsForPost } from 'state/reader/related-posts/selectors';
 import { getPost } from 'state/reader/posts/selectors';
 import { getSite } from 'state/reader/sites/selectors';
-import SmallPost from 'components/post-card/small';
+import CompactPost from 'components/post-card/compact';
 import QueryReaderRelatedPosts from 'components/data/query-reader-related-posts';
 
 const RelatedPost = React.createClass( {
 	render() {
-		return <SmallPost
+		return <CompactPost
 			post={ this.props.post }
 			site={ this.props.site }
 			onPostClick={ this.props.onPostClick }


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/7142, we plan on using `.post-card` as a generic card component name for the new cards in Reader Refresh.

This component name is currently being by `small.jsx` so this needs to be renamed.

Test live: https://calypso.live/?branch=update/reader/small-to-post-card-compact