### PR TITLE
SEO Preview: Hide web preview iframe instead of destroying it

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -37,6 +37,8 @@ export class WebPreview extends Component {
 			loaded: false
 		};
 
+		this.setIframeInstance = ref => this.iframe = ref;
+
 		this.keyDown = this.keyDown.bind( this );
 		this.setDeviceViewport = this.setDeviceViewport.bind( this );
 		this.setIframeMarkup = this.setIframeMarkup.bind( this );
@@ -156,7 +158,7 @@ export class WebPreview extends Component {
 	shouldRenderIframe() {
 		// Don't preload iframe on mobile devices as bandwidth is typically more limited and
 		// the preview causes weird issues
-		return ( ! this._isMobile || this.props.showPreview ) && 'seo' !== this.state.device;
+		return ! this._isMobile || this.props.showPreview;
 	}
 
 	setDeviceViewport( device = 'computer' ) {
@@ -216,8 +218,9 @@ export class WebPreview extends Component {
 							}
 							{ this.shouldRenderIframe() &&
 								<iframe
-									ref={ r => this.iframe = r }
+									ref={ this.setIframeInstance }
 									className="web-preview__frame"
+									style={ { display: ('seo' === this.state.device ? 'none' : 'inherit') } }
 									src="about:blank"
 									onLoad={ this.setLoaded }
 									title={ this.props.iframeTitle || translate( 'Preview' ) }


### PR DESCRIPTION
Previously, we removed the iframe showing the site/post
previews when switching to the SEO tab inside of the `<WebPreview />`
component. This resulted in some strange behavior and bugs when
switching back to the preview tabs _after_ visiting the SEO tabs.

This patch adjust the behavior to merely _hide_ the iframe with
`style="display: none"` when the SEO tab is active. That allows us to
quickly change between the tabs without having to reload anything and it
resolves the bugs we were experiencing.

cc: @roundhill 

Test live: https://calypso.live/?branch=update/seo-preview-hide-iframe