### PR TITLE
Reader: fix calls to isDiscoverEnabled

### DIFF
--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -32,7 +32,7 @@ const SearchEmptyContent = React.createClass( {
 			onClick={ this.recordAction }
 			href="/">{ this.translate( 'Back to Following' ) }</a> );
 
-		const secondaryAction = discoverHelper.isEnabled()
+		const secondaryAction = discoverHelper.isDiscoverEnabled()
 			? ( <a
 			className="empty-content__action button"
 			onClick={ this.recordSecondaryAction }

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -37,7 +37,7 @@ const TagEmptyContent = React.createClass( {
 			onClick={ this.recordAction }
 			href="/">{ this.translate( 'Back to Following' ) }</a> );
 
-		const secondaryAction = discoverHelper.isEnabled()
+		const secondaryAction = discoverHelper.isDiscoverEnabled()
 			? ( <a
 			className="empty-content__action button"
 			onClick={ this.recordSecondaryAction }


### PR DESCRIPTION
Just found a few broken calls to `discoverHelper.isEnabled`.
Fixed by updating to `discoverHelper.isDiscoverEnabled`

cc @bluefuton 

Test live: https://calypso.live/?branch=fix/reader/discover-isEnabled-helper