### PR TITLE
Advanced SEO: Remove post title from post meta accordion

### DIFF
--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,39 +12,15 @@ import AccordionSection from 'components/accordion/section';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Gridicon from 'components/gridicon';
 import InfoPopover from 'components/info-popover';
-import TokenField from 'components/token-field';
 import PostActions from 'lib/posts/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
 
-function EditorSeoAccordion( { translate, siteSlug, metaDescription = '' } ) {
-	// Temporary placeholder chips for design review
-	const sampleChips = [ 'Post Title', 'Site Title' ];
-
-	const seoTabUrl = `/settings/seo/${ siteSlug }`;
-
+function EditorSeoAccordion( { translate, metaDescription = '' } ) {
 	return (
 		<Accordion
 			title={ translate( 'Advanced SEO' ) }
 			icon={ <Gridicon icon="search" /> }
 			className="editor-seo-accordion"
 		>
-			<AccordionSection>
-				<span className="editor-drawer__label-text">
-					{ translate( 'Meta Title' ) }
-					<InfoPopover position="top left">
-						{ translate(
-							'To edit the format of the meta title, go to your site\'s {{a}}SEO settings{{/a}}.',
-							{
-								components: {
-									a: <a target="_blank" href={ seoTabUrl } />
-								}
-							}
-						) }
-					</InfoPopover>
-				</span>
-				<TokenField value={ sampleChips } disabled />
-			</AccordionSection>
 			<AccordionSection>
 				<span className="editor-drawer__label-text">
 					{ translate( 'Meta Description' ) }
@@ -77,12 +52,7 @@ function onMetaChange( event ) {
 
 EditorSeoAccordion.propTypes = {
 	translate: PropTypes.func,
-	siteSlug: PropTypes.string,
 	metaDescription: PropTypes.string
 };
 
-const mapStateToProps = ( state ) => ( {
-	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
-} );
-
-export default connect( mapStateToProps )( localize( EditorSeoAccordion ) );
+export default localize( EditorSeoAccordion );


### PR DESCRIPTION
A design decision was made to remove the disabled title field from the post editor accordion. This PR removes it 💥 

**To Test**
View the Advanced SEO accordion in the post editor (you must have a business plan on the site). You should just see the post meta description field:

<img width="273" alt="screen shot 2016-07-29 at 3 43 50 pm" src="https://cloud.githubusercontent.com/assets/789137/17265423/b716c888-55a3-11e6-805a-1fbecb51f5ce.png">

cc @dmsnell @apeatling 


Test live: https://calypso.live/?branch=remove/seo-post-meta-title