### PR TITLE
Guided Transfer: Complete purchase notice

### DIFF
--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -8,7 +8,10 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import config from 'config';
+import QuerySiteGuidedTransfer from 'components/data/query-site-guided-transfer';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import { isGuidedTransferInProgress } from 'state/sites/guided-transfer/selectors';
 
 import Notices from './notices';
 import ExportCard from './export-card';
@@ -19,13 +22,16 @@ class Exporter extends Component {
 	render() {
 		const {
 			siteId,
+			siteSlug,
 			isGuidedTransferInProgress,
 		} = this.props;
 		const showGuidedTransferOptions = config.isEnabled( 'manage/export/guided-transfer' );
 
 		return (
 			<div className="exporter">
-				<Notices />
+				<QuerySiteGuidedTransfer siteId={ siteId } />
+
+				<Notices siteId={ siteId } siteSlug={ siteSlug } />
 				{ showGuidedTransferOptions && isGuidedTransferInProgress &&
 					<InProgressCard /> }
 				<ExportCard siteId={ siteId } />
@@ -36,14 +42,13 @@ class Exporter extends Component {
 	}
 }
 
-function mapStateToProps( state ) {
-	return {
-		siteId: getSelectedSiteId( state ),
+const mapStateToProps = state => ( {
+	siteId: getSelectedSiteId( state ),
+	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) ),
 
-		// This will be replaced with a Redux selector once we've built out
-		// the reducers
-		isGuidedTransferInProgress: false,
-	};
-}
+	// This will be replaced with a Redux selector once we've built out
+	// the reducers
+	isGuidedTransferInProgress: isGuidedTransferInProgress( state, getSelectedSiteId( state ) ),
+} );
 
 export default connect( mapStateToProps )( Exporter );

--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -29,7 +29,7 @@ class Exporter extends Component {
 
 		return (
 			<div className="exporter">
-				<QuerySiteGuidedTransfer siteId={ siteId } />
+				{ showGuidedTransferOptions && <QuerySiteGuidedTransfer siteId={ siteId } /> }
 
 				<Notices siteId={ siteId } siteSlug={ siteSlug } />
 				{ showGuidedTransferOptions && isGuidedTransferInProgress &&

--- a/client/my-sites/exporter/notices.jsx
+++ b/client/my-sites/exporter/notices.jsx
@@ -12,6 +12,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import support from 'lib/url/support';
 import { getExportingState } from 'state/site-settings/exporter/selectors';
+import { isGuidedTransferAwaitingPurchase } from 'state/sites/guided-transfer/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { States } from 'state/site-settings/exporter/constants';
 
@@ -19,7 +20,7 @@ import { States } from 'state/site-settings/exporter/constants';
  * Displays local notices for the Export tab of Site Settings
  */
 class Notices extends Component {
-	render() {
+	exportNotice() {
 		const {
 			exportDidComplete,
 			exportDidFail,
@@ -59,12 +60,48 @@ class Notices extends Component {
 
 		return null;
 	}
+
+	guidedTransferNotice() {
+		const {
+			translate,
+			siteSlug
+		} = this.props;
+
+		if ( this.props.isGuidedTransferAwaitingPurchase ) {
+			return (
+				<Notice
+					status="is-warning"
+					showDismiss={ false }
+					text={ translate(
+						"It looks like you've started a Guided Transfer. " +
+						"We just need your payment to confirm the transfer and " +
+						"then we'll get started!" ) }
+				>
+					<NoticeAction href={ `/settings/export/guided/${ siteSlug }` }>
+						{ translate( 'Continue' ) }
+					</NoticeAction>
+				</Notice>
+			);
+		}
+
+		return null;
+	}
+
+	render() {
+		return (
+			<div>
+				{ this.exportNotice() }
+				{ this.guidedTransferNotice() }
+			</div>
+		);
+	}
 }
 
-const mapStateToProps = state => ( {
+const mapStateToProps = ( state, { siteId } ) => ( {
 	exportDidComplete: getExportingState( state, getSelectedSiteId( state ) ) === States.COMPLETE,
 	exportDidFail: getExportingState( state, getSelectedSiteId( state ) ) === States.FAILED,
 	exportDownloadURL: state.siteSettings.exporter.downloadURL,
+	isGuidedTransferAwaitingPurchase: isGuidedTransferAwaitingPurchase( state, siteId ),
 } );
 
 export default connect( mapStateToProps )( localize( Notices ) );

--- a/client/state/sites/guided-transfer/selectors.js
+++ b/client/state/sites/guided-transfer/selectors.js
@@ -1,3 +1,31 @@
 export function isRequestingGuidedTransferStatus( state, siteId ) {
 	return state.sites.guidedTransfer.isFetching[ siteId ] === true;
 }
+
+export function isGuidedTransferInProgress( state, siteId ) {
+	const status = state.sites.guidedTransfer.status[ siteId ];
+	if ( ! status ) {
+		return false;
+	}
+
+	return status.upgrade_purchased &&
+		status.host_details_entered;
+}
+
+/**
+ * Returns true if the user has initiated a guided transfer, but
+ * we're still waiting for them to purchase the GT
+ *
+ * @param {Object} state The Redux state object
+ * @param {number} siteId The siteId to check
+ * @return {bool} true if guided transfer is awaiting purchase
+ */
+export function isGuidedTransferAwaitingPurchase( state, siteId ) {
+	const status = state.sites.guidedTransfer.status[ siteId ];
+	if ( ! status ) {
+		return false;
+	}
+
+	return ( ! status.upgrade_purchased ) &&
+		status.host_details_entered;
+}


### PR DESCRIPTION
~~**Code Review: Please only review d74b44a. Prior commits belong to a refactor (#7347) which this is rebased on top of.**~~ #7347 is now merged into master

This adds a notice to the export page of site settings prompting the user to complete a Guided Transfer purchase.

This will appear when the user has entered host details, but hasn't yet completed checkout.

![screen shot 2016-08-01 at 6 15 56 pm](https://cloud.githubusercontent.com/assets/416133/17287611/09aa9030-5814-11e6-8004-a123e2636997.png)
### How to test

~~Currently this is disabled until we have the required data in the Redux store (#6471). In order to test, manually set `isGuidedTransferAwaitingPurchase: true` in `client/my-sites/exporter/index.jsx` on L45~~
1. Go to **My Sites > Settings > Export**
2. Open the Redux devtools. Down the bottom, click **Dispatcher**.
3. Paste the following action (replacing YOUR_SITE_ID_HERE) then press Dispatch:
   
   ``` js
   {
     type: 'GUIDED_TRANSFER_STATUS_RECEIVE',
     siteId: YOUR_SITE_ID_HERE,
     guidedTransferStatus: {
       issues: [],
       upgrade_purchased: false,
       host_details_entered: true,
     }
   }
   ```
4. You should immediately see the orange notice as above.
5. Paste the following into the dispatcher
   
   ``` js
   {
     type: 'GUIDED_TRANSFER_STATUS_RECEIVE',
     siteId: YOUR_SITE_ID_HERE,
     guidedTransferStatus: {
       issues: [],
       upgrade_purchased: true,
       host_details_entered: true,
     }
   }
   ```
6. You should now see the in progress screen, and the Guided Transfer card should disappear:

![screen shot 2016-08-15 at 4 27 07 pm](https://cloud.githubusercontent.com/assets/416133/17657281/31093f54-6305-11e6-83f2-f5f031225f93.png)

cc @dllh @mrheston @omarjackman 

Test live: https://calypso.live/?branch=add/guided-transfer/complete-purchase-notice
