### PR TITLE
Js Errors: limit trace field

### DIFF
--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -11,6 +11,14 @@ export default class ErrorLogger {
 
 		if ( ! window.onerror ) {
 			TraceKit.report.subscribe( errorReport => {
+				if ( Array.isArray( errorReport.stack ) ) {
+					errorReport.stack.forEach( report => Object.keys( report ).forEach( key => {
+						if ( typeof report[ key ] === 'string' && report[ key ].length > 512 ) {
+							report[ key ] = report[ key ].substring( 0, 512 );
+						}
+					} ) );
+				}
+
 				const error = {
 					message: errorReport.message,
 					url: document.location.href,

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -13,8 +13,12 @@ export default class ErrorLogger {
 			TraceKit.report.subscribe( errorReport => {
 				if ( Array.isArray( errorReport.stack ) ) {
 					errorReport.stack.forEach( report => Object.keys( report ).forEach( key => {
-						if ( typeof report[ key ] === 'string' && report[ key ].length > 512 ) {
+						if ( key === 'context' ) {
+							report[ key ] = JSON.stringify( report[ key ] ).substring( 0, 512 );
+						} else if ( typeof report[ key ] === 'string' && report[ key ].length > 512 ) {
 							report[ key ] = report[ key ].substring( 0, 512 );
+						} else if ( Array.isArray( report[ key ] ) ) {
+							report[ key ] = report[ key ].slice( 0, 3 );
 						}
 					} ) );
 				}

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -13,7 +13,7 @@ export default class ErrorLogger {
 			TraceKit.report.subscribe( errorReport => {
 				if ( Array.isArray( errorReport.stack ) ) {
 					errorReport.stack.forEach( report => Object.keys( report ).forEach( key => {
-						if ( key === 'context' ) {
+						if ( key === 'context' && report[ key ] ) {
 							report[ key ] = JSON.stringify( report[ key ] ).substring( 0, 512 );
 						} else if ( typeof report[ key ] === 'string' && report[ key ].length > 512 ) {
 							report[ key ] = report[ key ].substring( 0, 512 );


### PR DESCRIPTION
We are generating shitloads of errors because sometimes `stack` field has 112MB !

We need to limit it.
I suspect worst offender is `context` field

This is an attempt

## Testing 

- Build with ENABLE_FEATURES=catch-js-errors make run
- Go to http://calypso.localhost:3000/plugins . IF you have a Jetpack site, you will get an error there.
- You should see a call going to https://public-api.wordpress.com/rest/v1.1/js-error in inspector
- See if it worked
