### PR TITLE
Bring back plans features row highlighting

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -259,6 +259,7 @@ const allPaidPlans = [
 
 export const featuresList = {
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
+		getSlug: () => FEATURE_GOOGLE_ANALYTICS,
 		getTitle: () => i18n.translate( 'Google Analytics Integration' ),
 		getDescription: () => i18n.translate(
 			'Track website statistics with Google Analytics for a ' +
@@ -268,6 +269,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_UNLIMITED_STORAGE ]: {
+		getSlug: () => FEATURE_UNLIMITED_STORAGE,
 		getTitle: () => i18n.translate( '{{strong}}Unlimited{{/strong}} Storage Space', {
 			components: {
 				strong: <strong />
@@ -282,6 +284,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_CUSTOM_DOMAIN ]: {
+		getSlug: () => FEATURE_CUSTOM_DOMAIN,
 		getTitle: () => i18n.translate( 'Custom Domain Name' ),
 		getDescription: () => i18n.translate(
 			'Get a free custom domain name (mywebsite.com) with this plan ' +
@@ -291,6 +294,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_UNLIMITED_PREMIUM_THEMES ]: {
+		getSlug: () => FEATURE_UNLIMITED_PREMIUM_THEMES,
 		getTitle: () => i18n.translate( '{{strong}}Unlimited{{/strong}} Premium Themes', {
 			components: {
 				strong: <strong />
@@ -305,6 +309,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_VIDEO_UPLOADS ]: {
+		getSlug: () => FEATURE_VIDEO_UPLOADS,
 		getTitle: () => i18n.translate( 'VideoPress Support' ),
 		getDescription: () => i18n.translate(
 			'The easiest way to upload videos to your website and display them ' +
@@ -315,6 +320,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_BASIC_DESIGN ]: {
+		getSlug: () => FEATURE_BASIC_DESIGN,
 		getTitle: () => i18n.translate( 'Basic Design Customization' ),
 		getDescription: () => i18n.translate(
 			'Customize your selected theme template with pre-set color schemes, ' +
@@ -325,6 +331,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_ADVANCED_DESIGN ]: {
+		getSlug: () => FEATURE_ADVANCED_DESIGN,
 		getTitle: () => i18n.translate( '{{strong}}Advanced{{/strong}} Design Customization', {
 			components: {
 				strong: <strong />
@@ -339,6 +346,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_NO_ADS ]: {
+		getSlug: () => FEATURE_NO_ADS,
 		getTitle: () => i18n.translate( 'Remove WordPress.com Ads' ),
 		getDescription: () => i18n.translate(
 			'Allow your visitors to visit and read your website without ' +
@@ -349,6 +357,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_NO_BRANDING ]: {
+		getSlug: () => FEATURE_NO_BRANDING,
 		getTitle: () => i18n.translate( 'Remove WordPress.com Branding' ),
 		getDescription: () => i18n.translate(
 			"Keep the focus on your site's brand by removing the WordPress.com footer branding."
@@ -358,6 +367,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_WORDADS_INSTANT ]: {
+		getSlug: () => FEATURE_WORDADS_INSTANT,
 		getTitle: () => i18n.translate( 'Monetize Your Site' ),
 		getDescription: () => i18n.translate(
 			'Add your own advertising to your site through our WordAds program and earn money from impressions.'
@@ -366,6 +376,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_WP_SUBDOMAIN ]: {
+		getSlug: () => FEATURE_WP_SUBDOMAIN,
 		getTitle: () => i18n.translate( 'WordPress.com Subdomain' ),
 		getDescription: () => i18n.translate(
 			'Your site address will use a WordPress.com subdomain (sitename.wordpress.com).'
@@ -374,6 +385,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_FREE_THEMES ]: {
+		getSlug: () => FEATURE_FREE_THEMES,
 		getTitle: () => i18n.translate( 'Hundreds of Free Themes' ),
 		getDescription: () => i18n.translate(
 			'Access to a wide range of professional theme templates ' +
@@ -383,6 +395,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_3GB_STORAGE ]: {
+		getSlug: () => FEATURE_3GB_STORAGE,
 		getTitle: () => i18n.translate( '3GB Storage Space' ),
 		getDescription: () => i18n.translate(
 			"With increased storage space you'll be able to upload " +
@@ -392,6 +405,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_13GB_STORAGE ]: {
+		getSlug: () => FEATURE_13GB_STORAGE,
 		getTitle: () => i18n.translate( '{{strong}}13GB{{/strong}} Storage Space', {
 			components: {
 				strong: <strong />
@@ -405,6 +419,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_COMMUNITY_SUPPORT ]: {
+		getSlug: () => FEATURE_COMMUNITY_SUPPORT,
 		getTitle: () => i18n.translate( 'Community support' ),
 		getDescription: () => i18n.translate(
 			'Get support through our ' +
@@ -414,6 +429,7 @@ export const featuresList = {
 	},
 
 	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {
+		getSlug: () => FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 		getTitle: () => i18n.translate( 'Email & Live Chat Support' ),
 		getDescription: () => i18n.translate(
 			'High quality support to help you get your website up ' +
@@ -422,18 +438,22 @@ export const featuresList = {
 		plans: allPaidPlans
 	},
 	[ FEATURE_SINGLE_SITE_SUPPORT ]: {
+		getSlug: () => FEATURE_SINGLE_SITE_SUPPORT,
 		getTitle: () => i18n.translate( 'Supports 1 Site' ),
 		getDescription: () => i18n.translate( 'For use on 1 WordPress site.' )
 	},
 	[ FEATURE_MULTI_SITE_SUPPORT ]: {
+		getSlug: () => FEATURE_MULTI_SITE_SUPPORT,
 		getTitle: () => i18n.translate( 'Supports 1-3 Sites' ),
 		getDescription: () => i18n.translate( 'For use on up to 3 WordPress sites.' )
 	},
 	[ FEATURE_SPAM_AKISMET_PLUS ]: {
+		getSlug: () => FEATURE_SPAM_AKISMET_PLUS,
 		getTitle: () => i18n.translate( 'Spam Protection' ),
 		getDescription: () => i18n.translate( 'State-of-the-art spam defense powered by Akismet.' )
 	},
 	[ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY ]: {
+		getSlug: () => FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 		getTitle: () => i18n.translate( 'Daily Offsite Backups' ),
 		getDescription: () => i18n.translate(
 			'Automatic daily backups of every single aspect of your site. ' +
@@ -441,6 +461,7 @@ export const featuresList = {
 		)
 	},
 	[ FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME ]: {
+		getSlug: () => FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
 		getTitle: () => i18n.translate( 'Realtime Offsite Backups' ),
 		getDescription: () => i18n.translate(
 			'Automatic realtime backups of every single aspect of your site. ' +
@@ -448,46 +469,55 @@ export const featuresList = {
 		)
 	},
 	[ FEATURE_BACKUP_ARCHIVE_30 ]: {
+		getSlug: () => FEATURE_BACKUP_ARCHIVE_30,
 		getTitle: () => i18n.translate( '30-day Backup Archive' ),
 		getDescription: () => i18n.translate( 'Browse or restore any backup made within the past 30 days.' )
 	},
 	[ FEATURE_BACKUP_ARCHIVE_UNLIMITED ]: {
+		getSlug: () => FEATURE_BACKUP_ARCHIVE_UNLIMITED,
 		getTitle: () => i18n.translate( 'Unlimited Backup Archive' ),
 		getDescription: () => i18n.translate(
 			'Browse or restore any backup made since you activated the service.'
 		)
 	},
 	[ FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED ]: {
+		getSlug: () => FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
 		getTitle: () => i18n.translate( 'Unlimited Backup Storage Space' ),
 		getDescription: () => i18n.translate( 'Absolutely no limits on storage space for your backups.' )
 	},
 	[ FEATURE_AUTOMATED_RESTORES ]: {
+		getSlug: () => FEATURE_AUTOMATED_RESTORES,
 		getTitle: () => i18n.translate( 'Automated Restores' ),
 		getDescription: () => i18n.translate( 'Restore your site from any available backup with a single click.' )
 	},
 	[ FEATURE_EASY_SITE_MIGRATION ]: {
+		getSlug: () => FEATURE_EASY_SITE_MIGRATION,
 		getTitle: () => i18n.translate( 'Easy Site Migration' ),
 		getDescription: () => i18n.translate( 'Easily and quickly move or duplicate your site to any location.' )
 	},
 	[ FEATURE_MALWARE_SCANNING_DAILY ]: {
+		getSlug: () => FEATURE_MALWARE_SCANNING_DAILY,
 		getTitle: () => i18n.translate( 'Daily Malware Scanning' ),
 		getDescription: () => i18n.translate(
 			'Comprehensive and automated scanning for any security vulnerabilities or threats on your site.'
 		)
 	},
 	[ FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND ]: {
+		getSlug: () => FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
 		getTitle: () => i18n.translate( 'Daily and On-demand Malware Scanning' ),
 		getDescription: () => i18n.translate(
 			'Automated security scanning with the option to run complete site scans at any time.'
 		)
 	},
 	[ FEATURE_ONE_CLICK_THREAT_RESOLUTION ]: {
+		getSlug: () => FEATURE_ONE_CLICK_THREAT_RESOLUTION,
 		getTitle: () => i18n.translate( 'One-click Threat Resolution' ),
 		getDescription: () => i18n.translate(
 			'Repair any security issues found on your site with just a single click.'
 		)
 	},
 	[ FEATURE_POLLS_PRO ]: {
+		getSlug: () => FEATURE_POLLS_PRO,
 		getTitle: () => i18n.translate( 'Advanced Polls and Ratings' ),
 		getDescription: () => i18n.translate(
 			'Custom polls, surveys, ratings, and quizzes for the ultimate in customer and reader engagement.'

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -342,7 +342,8 @@ PlanFeatures.propTypes = {
 	plans: PropTypes.array,
 	planProperties: PropTypes.array,
 	isPlaceholder: PropTypes.bool,
-	isInSignup: PropTypes.bool
+	isInSignup: PropTypes.bool,
+	selectedFeature: PropTypes.string
 };
 
 PlanFeatures.defaultProps = {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -266,7 +266,7 @@ class PlanFeatures extends Component {
 		const longestFeatures = this.getLongestFeaturesList();
 		return map( longestFeatures, ( featureKey, rowIndex ) => {
 			return (
-				<tr key={ rowIndex }>
+				<tr key={ rowIndex } className="plan-features__row">
 					{ this.renderPlanFeatureColumns( rowIndex ) }
 				</tr>
 			);
@@ -289,7 +289,7 @@ class PlanFeatures extends Component {
 				key = featureKeys[ rowIndex ],
 				currentFeature = features[ key ];
 
-			const classes = classNames( 'plan-features__table-item', {
+			const classes = classNames( 'plan-features__table-item', getPlanClass( planName ), {
 				'has-partial-border': rowIndex + 1 < featureKeys.length,
 				'is-highlighted': selectedFeature && currentFeature &&
 					selectedFeature === currentFeature.getSlug()

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -274,19 +274,27 @@ class PlanFeatures extends Component {
 	}
 
 	renderPlanFeatureColumns( rowIndex ) {
-		const { planProperties } = this.props;
+		const {
+			planProperties,
+			selectedFeature
+		} = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
 				features,
 				planName
 			} = properties;
-			const featureKeys = Object.keys( features );
-			const key = featureKeys[ rowIndex ];
+
+			const featureKeys = Object.keys( features ),
+				key = featureKeys[ rowIndex ],
+				currentFeature = features[ key ];
+
 			const classes = classNames( 'plan-features__table-item', {
-				'has-partial-border': rowIndex + 1 < featureKeys.length
+				'has-partial-border': rowIndex + 1 < featureKeys.length,
+				'is-highlighted': selectedFeature && currentFeature &&
+					selectedFeature === currentFeature.getSlug()
 			} );
-			const currentFeature = features[ key ];
+
 			return (
 				currentFeature
 					? <td key={ `${ planName }-${ key }` } className={ classes }>

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -91,6 +91,10 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
+.plan-features__row {
+	background: $white;
+}
+
 .plan-features__table-item {
 	border-right: solid 1px lighten( $gray, 27% );
 	border-left: solid 1px lighten( $gray, 27% );
@@ -98,7 +102,37 @@ $plan-features-sidebar-width: 272px;
 	position: relative;
 
 	&.is-highlighted {
-		border: 1px solid $alert-yellow;
+
+		&.is-personal-plan {
+			border: 1px solid $alert-yellow;
+			background-color: rgba( $alert-yellow, 0.1 );
+			.plan-features__item-checkmark {
+				fill: $alert-yellow;
+			}
+		}
+
+		&.is-premium-plan {
+			border: 1px solid $alert-green;
+			background-color: rgba( $alert-green, 0.1 );
+			.plan-features__item-checkmark {
+				fill: $alert-green;
+			}
+		}
+
+		&.is-business-plan {
+			border: 1px solid $alert-purple;
+			background-color: rgba( $alert-purple, 0.1 );
+			.plan-features__item-checkmark {
+				fill: $alert-purple;
+			}
+		}
+
+		position: relative;
+			top: -1px;
+
+		&.has-partial-border::after {
+			display: none;
+		}
 	}
 
 	&.is-selected {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -102,33 +102,14 @@ $plan-features-sidebar-width: 272px;
 	position: relative;
 
 	&.is-highlighted {
-
-		&.is-personal-plan {
-			border: 1px solid $alert-yellow;
-			background-color: rgba( $alert-yellow, 0.1 );
-			.plan-features__item-checkmark {
-				fill: $alert-yellow;
-			}
-		}
-
-		&.is-premium-plan {
-			border: 1px solid $alert-green;
-			background-color: rgba( $alert-green, 0.1 );
-			.plan-features__item-checkmark {
-				fill: $alert-green;
-			}
-		}
-
-		&.is-business-plan {
-			border: 1px solid $alert-purple;
-			background-color: rgba( $alert-purple, 0.1 );
-			.plan-features__item-checkmark {
-				fill: $alert-purple;
-			}
-		}
-
+		border: 1px solid $blue-wordpress;
+		background-color: rgba( $blue-wordpress, 0.1 );
 		position: relative;
 			top: -1px;
+
+		.plan-features__item-checkmark {
+			fill: $blue-wordpress;
+		}
 
 		&.has-partial-border::after {
 			display: none;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -96,10 +96,14 @@ $plan-features-sidebar-width: 272px;
 	border-left: solid 1px lighten( $gray, 27% );
 	background-color: lighten( $gray, 35% );
 	position: relative;
-}
 
-.plan-features__table-item.is-selected {
-	display: table-cell;
+	&.is-highlighted {
+		border: 1px solid $alert-yellow;
+	}
+
+	&.is-selected {
+		display: table-cell;
+	}
 }
 
 .plan-features__table-item.has-partial-border {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -284,7 +284,8 @@ PlansFeaturesMain.PropTypes = {
 	intervalType: PropTypes.string,
 	onUpgradeClick: PropTypes.func,
 	hideFreePlan: PropTypes.bool,
-	showFAQ: PropTypes.bool
+	showFAQ: PropTypes.bool,
+	selectedFeature: PropTypes.string
 };
 
 PlansFeaturesMain.defaultProps = {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -55,7 +55,10 @@ class PlansFeaturesMain extends Component {
 		if ( this.isJetpackSite( site ) ) {
 			return (
 				<div className="plans-features-main__group">
-					<PlanFeatures plans={ [ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ] } />
+					<PlanFeatures
+						plans={ [ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ] }
+						selectedFeature={ selectedFeature }
+					/>
 				</div>
 			);
 		}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -35,7 +35,8 @@ class PlansFeaturesMain extends Component {
 			intervalType,
 			onUpgradeClick,
 			hideFreePlan,
-			isInSignup
+			isInSignup,
+			selectedFeature
 		} = this.props;
 
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
@@ -43,7 +44,10 @@ class PlansFeaturesMain extends Component {
 		if ( this.isJetpackSite( site ) && intervalType === 'monthly' ) {
 			return (
 				<div className="plans-features-main__group">
-					<PlanFeatures plans={ [ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ] } />
+					<PlanFeatures
+						plans={ [ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ] }
+						selectedFeature={ selectedFeature }
+					/>
 				</div>
 			);
 		}
@@ -72,6 +76,7 @@ class PlansFeaturesMain extends Component {
 					plans={ plans }
 					onUpgradeClick={ onUpgradeClick }
 					isInSignup={ isInSignup }
+					selectedFeature={ selectedFeature }
 				/>
 			</div>
 		);

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -74,7 +74,9 @@ export default {
 					sites={ sites }
 					context={ context }
 					intervalType={ context.params.intervalType }
-					destinationType={ context.params.destinationType } />
+					destinationType={ context.params.destinationType }
+					selectedFeature={ context.query.feature }
+				/>
 			</CheckoutData>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -184,6 +184,7 @@ const Plans = React.createClass( {
 									site={ selectedSite }
 									intervalType={ this.props.intervalType }
 									hideFreePlan={ true }
+									selectedFeature={ this.props.selectedFeature }
 								/>
 
 								: <PlanList

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -94,7 +94,7 @@ export default React.createClass( {
 
 		if ( ! this.props.href && site ) {
 			if ( this.props.feature ) {
-				href = `/plans/compare/${ site.slug }?feature=${ this.props.feature }`;
+				href = `/plans/${ site.slug }?feature=${ this.props.feature }`;
 			} else {
 				href = `/plans/${ site.slug }`;
 			}


### PR DESCRIPTION
Fix for #7160. Fixes the plan features highlighting.

## Testing Instructions

1. Navigate to `/plans/:site` and make sure everything works as before;
2. Navigate to `http://calypso.localhost:3000/plans/lamostypremium.wordpress.com?feature=no-wp-branding` and make sure you see the "Remove WordPress.com Branding" feature highlighted.

## Screenshots

### With all three columns highlighted

![selection_019](https://cloud.githubusercontent.com/assets/4988512/17297390/d4bec890-5805-11e6-94ac-e557d01592c9.jpg)

### With one column highlighted

![selection_020](https://cloud.githubusercontent.com/assets/4988512/17297397/d9cf59e4-5805-11e6-9080-6e93d1259746.jpg)

## Todo

- [ ] Add highlighting for Jetpack plans

cc @gwwar @artpi 

Test live: https://calypso.live/?branch=fix/bring-back-plans-features-row-highlighting