### PR TITLE
Jetpack Connect: Move site's list refreshing to query components

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -17,7 +17,7 @@ import Main from 'components/main';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
 import { getSiteByUrl } from 'state/sites/selectors';
-import { requestSites } from 'state/sites/actions';
+import QuerySites from 'components/data/query-sites';
 import JetpackExampleInstall from './exampleComponents/jetpack-install';
 import JetpackExampleActivate from './exampleComponents/jetpack-activate';
 import JetpackExampleConnect from './exampleComponents/jetpack-connect';
@@ -56,7 +56,6 @@ const JetpackConnectMain = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from
 		} );
-		this.props.requestSites();
 	},
 
 	getInitialState() {
@@ -296,6 +295,7 @@ const JetpackConnectMain = React.createClass( {
 			<Main className="jetpack-connect">
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
+					<QuerySites/>
 					<ConnectHeader
 						showLogo={ false }
 						headerText={ this.getTexts().headerTitle }
@@ -313,9 +313,10 @@ const JetpackConnectMain = React.createClass( {
 	renderSiteEntryInstall() {
 		const status = this.getStatus();
 		return (
-			<Main className="jetpack-connect">
+			<Main className="jetpack-connect jetpack-connect__main">
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
+					<QuerySites/>
 					<ConnectHeader
 						showLogo={ false }
 						headerText={ this.getTexts().headerTitle }
@@ -332,7 +333,7 @@ const JetpackConnectMain = React.createClass( {
 
 	renderInstallInstructions() {
 		return (
-			<Main className="jetpack-connect-wide">
+			<Main className="jetpack-connect jetpack-connect__wide">
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
 					<ConnectHeader
@@ -394,7 +395,7 @@ const JetpackConnectMain = React.createClass( {
 
 	renderActivateInstructions() {
 		return (
-			<Main className="jetpack-connect-wide">
+			<Main className="jetpack-connect jetpack-connect__wide">
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
 					<ConnectHeader showLogo={ false }
@@ -455,7 +456,6 @@ export default connect(
 		confirmJetpackInstallStatus,
 		checkUrl,
 		dismissUrl,
-		requestSites,
 		goToRemoteAuth,
 		goToPluginInstall,
 		goToPluginActivation

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -15,7 +15,7 @@
 
 }
 
-.jetpack-connect-wide {
+.jetpack-connect__wide {
 	max-width: 100%;
 	text-align: center;
 	margin-bottom: 24px;


### PR DESCRIPTION
This PR moves the sites data fetching to query components (and fix a couple of css linting warnings in the process).

Everything should work exactly the same, so there's not a lot to test. You can clear your local calypso's indexedDB, go to http://calypso.localhost:3000/jetpack/connect, wait some seconds to let the sites list to be refetched, and try to connect a site that you already have connected. You should get the usual "your site is already connected"  message

ping  @ryelle and @roccotripaldi for review


Test live: https://calypso.live/?branch=add/jpc-query-components