### PR TITLE
Ad Tracking: Ensure AdWords Retargeting Tag has loaded before calling it

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -125,10 +125,14 @@ function retarget() {
 		window.fbq( 'track', 'PageView' );
 
 		// AdWords
-		window.google_trackConversion( {
-			google_conversion_id: GOOGLE_CONVERSION_ID,
-			google_remarketing_only: true
-		} );
+
+		// Ensure the AdWords Remarketing Tag has finished loading
+		if ( window.google_trackConversion ) {
+			window.google_trackConversion( {
+				google_conversion_id: GOOGLE_CONVERSION_ID,
+				google_remarketing_only: true
+			} );
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug where we attempt to call the AdWords Retargeting Tag before it has finished loading. This could cause a `Uncaught TypeError: window.google_trackConversion is not a function` error in situations where a user restarts the NUX flow.

Test live: https://calypso.live/?branch=fix/retargeting