### PR TITLE
Framework: Wrap many component trees in Redux Providers

### DIFF
--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -13,6 +13,7 @@ import analytics from 'lib/analytics';
 import route from 'lib/route';
 import titleActions from 'lib/screen-title/actions';
 import config from 'config';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 module.exports = {
 	help: function( context ) {
@@ -23,9 +24,10 @@ module.exports = {
 
 		analytics.pageView.record( basePath, 'Help' );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( Help ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -15,6 +15,8 @@ var sites = require( 'lib/sites-list' )(),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
 	titleActions = require( 'lib/screen-title/actions' );
 
+import { renderWithReduxStore } from 'lib/react-helpers';
+
 var controller = {
 
 	pages: function( context ) {
@@ -43,7 +45,7 @@ var controller = {
 
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( Pages, {
 				context: context,
 				siteID: siteID,
@@ -57,7 +59,8 @@ var controller = {
 					'Pages'
 				)
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 };

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -37,7 +37,7 @@ export default {
 	},
 
 	enforceSiteEnding( context, next ) {
-		let siteId = route.getSiteFragment( context.path );
+		const siteId = route.getSiteFragment( context.path );
 
 		if ( ! siteId ) {
 			this.redirectToTeam();
@@ -62,14 +62,15 @@ export default {
 function renderPeopleList( filter, context ) {
 	titleActions.setTitle( i18n.translate( 'People', { textOnly: true } ), { siteID: route.getSiteFragment( context.path ) } );
 
-	ReactDom.render(
+	renderWithReduxStore(
 		React.createElement( PeopleList, {
 			sites: sites,
 			peopleLog: PeopleLogStore,
 			filter: filter,
 			search: context.query.s
 		} ),
-		document.getElementById( 'primary' )
+		document.getElementById( 'primary' ),
+		context.store
 	);
 	analytics.pageView.record( 'people/' + filter + '/:site', 'People > ' + titlecase( filter ) );
 }
@@ -133,7 +134,7 @@ function renderSingleTeamMember( context ) {
 		}
 	}
 
-	ReactDom.render(
+	renderWithReduxStore(
 		React.createElement( EditTeamMember, {
 			siteSlug: site && site.slug ? site.slug : undefined,
 			siteId: site && site.ID ? site.ID : undefined,
@@ -142,6 +143,7 @@ function renderSingleTeamMember( context ) {
 			userLogin: userLogin,
 			prevPath: context.prevPath
 		} ),
-		document.getElementById( 'primary' )
+		document.getElementById( 'primary' ),
+		context.store
 	);
 }

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -18,6 +18,8 @@ var sites = require( 'lib/sites-list' )(),
 	titleActions = require( 'lib/screen-title/actions' ),
 	analyticsPageTitle = 'Sharing';
 
+import { renderWithReduxStore } from 'lib/react-helpers';
+
 module.exports = {
 	layout: function( context ) {
 		var Sharing = require( 'my-sites/sharing/main' ),
@@ -30,12 +32,13 @@ module.exports = {
 			site.fetchSettings();
 		}
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( Sharing, {
 				path: context.path,
 				contentComponent: context.contentComponent
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 

--- a/client/vip/controller.js
+++ b/client/vip/controller.js
@@ -13,6 +13,8 @@ var route = require( 'lib/route' ),
 	titleActions = require( 'lib/screen-title/actions' ),
 	sites = require( 'lib/sites-list' )();
 
+import { renderWithReduxStore } from 'lib/react-helpers';
+
 module.exports = {
 
 	vip: function() {
@@ -26,14 +28,15 @@ module.exports = {
 
 		titleActions.setTitle( i18n.translate( 'VIP', { textOnly: true } ), { siteID: siteUrl } );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( vipdashboard, {
 				context: context,
 				sites: sites,
 				site: site,
 				path: context.path
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -44,14 +47,15 @@ module.exports = {
 
 		titleActions.setTitle( i18n.translate( 'VIP Deploys', { textOnly: true } ), { siteID: siteUrl } );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( vipdeploys, {
 				context: context,
 				sites: sites,
 				site: site,
 				path: context.path
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -62,14 +66,15 @@ module.exports = {
 
 		titleActions.setTitle( i18n.translate( 'VIP Billing', { textOnly: true } ), { siteID: siteUrl } );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( vipbilling, {
 				context: context,
 				sites: sites,
 				site: site,
 				path: context.path
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -80,14 +85,15 @@ module.exports = {
 
 		titleActions.setTitle( i18n.translate( 'VIP Support', { textOnly: true } ), { siteID: siteUrl } );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( vipsupport, {
 				context: context,
 				sites: sites,
 				site: site,
 				path: context.path
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -98,14 +104,15 @@ module.exports = {
 
 		titleActions.setTitle( i18n.translate( 'VIP Backups', { textOnly: true } ), { siteID: siteUrl } );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( vipbackups, {
 				context: context,
 				sites: sites,
 				site: site,
 				path: context.path
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -118,7 +125,7 @@ module.exports = {
 
 		titleActions.setTitle( i18n.translate( 'VIP Logs', { textOnly: true } ), { siteID: siteUrl } );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( viplogs, {
 				context: context,
 				search: search,
@@ -127,7 +134,8 @@ module.exports = {
 				status: status,
 				path: context.path
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 };


### PR DESCRIPTION
Wraps the following root components in Redux Providers so that they and their children will have access to the Redux store.

- me/help
- my-sites/pages
- my-sites/people
- my-sites/sharing
- vip

### Testing

Visit routes that use all those controllers and verify that they all display their root components correctly.

Test live: https://calypso.live/?branch=update/wrap-my-sites-in-providers