### PR TITLE
Push Notifications: update instructions with hint to refresh

### DIFF
--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -250,6 +250,7 @@ const PushNotificationSettings = React.createClass( {
 							) }</p>
 						</div>
 					</div>
+					<Notice className="notification-settings-push-notification-settings__instruction-refresh-notice" showDismiss={ false } text={ this.translate( 'Once you\'ve allowed notifications, you may need to refresh your browser.' ) } />
 				</div>
 				<span tabIndex="0" className="notification-settings-push-notification-settings__instruction-dismiss" onClick={ this.props.toggleUnblockInstructions } >
 					<Gridicon icon="cross" size={ 24 } />

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -250,7 +250,7 @@ const PushNotificationSettings = React.createClass( {
 							) }</p>
 						</div>
 					</div>
-					<Notice className="notification-settings-push-notification-settings__instruction-refresh-notice" showDismiss={ false } text={ this.translate( 'Once you\'ve allowed notifications, you may need to refresh your browser.' ) } />
+					<Notice className="push-notification-settings__instruction-refresh-notice" showDismiss={ false } text={ this.translate( 'Once you\'ve allowed notifications, you may need to refresh your browser.' ) } />
 				</div>
 				<span tabIndex="0" className="notification-settings-push-notification-settings__instruction-dismiss" onClick={ this.props.toggleUnblockInstructions } >
 					<Gridicon icon="cross" size={ 24 } />
@@ -310,7 +310,7 @@ const PushNotificationSettings = React.createClass( {
 				stateClass = { 'is-disabled': true };
 				stateText = this.translate( 'Disabled' );
 
-				deniedText = <Notice className="push-notification-settings__instruction" showDismiss={ false } text={
+				deniedText = <Notice className="notification-settings-push-notification-settings__instruction" showDismiss={ false } text={
 					<div>
 						<div>{ this.translate( 'Your browser is currently set to block notifications from WordPress.com.' ) }</div>
 						<div>{ this.translate(

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -310,7 +310,7 @@ const PushNotificationSettings = React.createClass( {
 				stateClass = { 'is-disabled': true };
 				stateText = this.translate( 'Disabled' );
 
-				deniedText = <Notice className="notification-settings-push-notification-settings__instruction" showDismiss={ false } text={
+				deniedText = <Notice className="push-notification-settings__instruction" showDismiss={ false } text={
 					<div>
 						<div>{ this.translate( 'Your browser is currently set to block notifications from WordPress.com.' ) }</div>
 						<div>{ this.translate(

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -85,7 +85,7 @@
 	left: -32px;
 }
 
-.notification-settings-push-notification-settings__instruction-refresh-notice {
+.push-notification-settings__instruction-refresh-notice {
 	text-align: left;
 	margin-top: 32px;
 	margin-bottom: 0;

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -85,6 +85,13 @@
 	left: -32px;
 }
 
+.notification-settings-push-notification-settings__instruction-refresh-notice {
+	text-align: left;
+	margin-top: 32px;
+	margin-bottom: 0;
+	color: $gray-dark;
+}
+
 .notification-settings-push-notification-settings__settings-state {
 	font-size: 13px;
 	font-weight: 500;


### PR DESCRIPTION
Fixes #6223

Before:

![image](https://cloud.githubusercontent.com/assets/363749/17302147/743249a4-57e0-11e6-9ef5-8bbc2f341121.png)

After:

![image](https://cloud.githubusercontent.com/assets/363749/17302164/838c9292-57e0-11e6-8f07-58f37da6ffce.png)

To test:
* Test via calypso.live or on calypso.localhost using [this workaround for secure origins](https://www.chromium.org/blink/serviceworker/service-worker-faq)
* Change your browser settings to block notification preferences. Click the security icon in the address bar (or the page icon if testing via calypso.localhost) and then set notifications to "Always block on this site".
* Reload the page
* Visit /me/notifications, you should see this: ![image](https://cloud.githubusercontent.com/assets/363749/17302292/2535fa3e-57e1-11e6-8a9e-5c6f8abbae03.png)
* Click "View Instructions to Enable"