### PR TITLE
Reader: hide discover pick byline

### DIFF
--- a/client/reader/full-post/main.jsx
+++ b/client/reader/full-post/main.jsx
@@ -221,7 +221,7 @@ FullPostView = React.createClass( {
 
 					{ post.title ? <h1 className="reader__post-title" onClick={ this.handlePermalinkClick }><ExternalLink className="reader__post-title-link" href={ post.URL } target="_blank" icon={ false }>{ post.title }</ExternalLink></h1> : null }
 
-					<PostByline post={ post } site={ site } icon={ true }/>
+					<PostByline post={ post } site={ site } icon={ true } isDiscoverPost={ isDiscoverPost }/>
 
 					{ post && post.use_excerpt
 						? <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />

--- a/client/reader/post-byline/index.jsx
+++ b/client/reader/post-byline/index.jsx
@@ -1,40 +1,61 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal Dependencies
  */
-var ExternalLink = require( 'components/external-link' ),
-	Gravatar = require( 'components/gravatar' ),
-	Gridicon = require( 'components/gridicon' ),
-	PostTime = require( 'reader/post-time' ),
-	utils = require( 'reader/utils' ),
-	stats = require( 'reader/stats' );
+import ExternalLink from 'components/external-link';
+import Gravatar from 'components/gravatar';
+import Gridicon from 'components/gridicon';
+import PostTime from 'reader/post-time';
+import { siteNameFromSiteAndPost } from 'reader/utils';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrackForPost,
+	recordPermalinkClick
+ } from 'reader/stats';
 
-var PostByline = React.createClass( {
+class PostByline extends React.Component {
 
-	recordTagClick: function() {
-		stats.recordAction( 'click_tag' );
-		stats.recordGaEvent( 'Clicked Tag Link' );
-		stats.recordTrackForPost( 'calypso_reader_tag_clicked', this.props.post, {
+	constructor( ) {
+		super( );
+		this.recordTagClick = this.recordTagClick.bind( this );
+		this.recordAuthorClick = this.recordAuthorClick.bind( this );
+	}
+
+	static propTypes = {
+		post: React.PropTypes.object.isRequired,
+		site: React.PropTypes.object,
+		icon: React.PropTypes.bool,
+	}
+
+	static defaultProps = {
+		icon: false,
+	}
+
+	recordTagClick() {
+		recordAction( 'click_tag' );
+		recordGaEvent( 'Clicked Tag Link' );
+		recordTrackForPost( 'calypso_reader_tag_clicked', this.props.post, {
 			tag: this.props.post.primary_tag.slug
 		} );
-	},
+	}
 
-	recordDateClick: function() {
-		stats.recordPermalinkClick( 'timestamp' );
-		stats.recordGaEvent( 'Clicked Post Permalink', 'timestamp' );
-	},
+	recordDateClick() {
+		recordPermalinkClick( 'timestamp' );
+		recordGaEvent( 'Clicked Post Permalink', 'timestamp' );
+	}
 
-	recordAuthorClick: function() {
-		stats.recordAction( 'click_author' );
-		stats.recordGaEvent( 'Clicked Author Link' );
-		stats.recordTrackForPost( 'calypso_reader_author_link_clicked', this.props.post );
-	},
+	recordAuthorClick() {
+		recordAction( 'click_author' );
+		recordGaEvent( 'Clicked Author Link' );
+		recordTrackForPost( 'calypso_reader_author_link_clicked', this.props.post );
+	}
 
-	renderAuthorName: function() {
+	renderAuthorName() {
 		const post = this.props.post,
 			gravatar = ( <Gravatar user={ post.author } size={ 24 } /> ),
 			authorName = ( <span className="byline__author-name">{ post.author.name }</span> );
@@ -54,13 +75,12 @@ var PostByline = React.createClass( {
 				{ authorName }
 			</ExternalLink>
 		);
-	},
+	}
 
-	render: function() {
-		var post = this.props.post,
-			site = this.props.site,
-			siteName = utils.siteNameFromSiteAndPost( site, post ),
+	render() {
+		const { post, site } = this.props,
 			primaryTag = post && post.primary_tag;
+		let siteName = siteNameFromSiteAndPost( site, post );
 
 		if ( ! siteName ) {
 			siteName = this.translate( '(no title)' );
@@ -89,6 +109,6 @@ var PostByline = React.createClass( {
 		/* eslint-enable wpcalypso/jsx-gridicon-size */
 	}
 
-} );
+}
 
-module.exports = PostByline;
+export default PostByline;

--- a/client/reader/post-byline/index.jsx
+++ b/client/reader/post-byline/index.jsx
@@ -30,10 +30,12 @@ class PostByline extends React.Component {
 		post: React.PropTypes.object.isRequired,
 		site: React.PropTypes.object,
 		icon: React.PropTypes.bool,
+		isDiscoverPost: React.PropTypes.bool
 	}
 
 	static defaultProps = {
 		icon: false,
+		isDiscoverPost: false
 	}
 
 	recordTagClick() {
@@ -78,7 +80,7 @@ class PostByline extends React.Component {
 	}
 
 	render() {
-		const { post, site } = this.props,
+		const { post, site, icon, isDiscoverPost } = this.props,
 			primaryTag = post && post.primary_tag;
 		let siteName = siteNameFromSiteAndPost( site, post );
 
@@ -89,7 +91,7 @@ class PostByline extends React.Component {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
 			<ul className="reader-post-byline">
-			{ post.author && post.author.name ?
+			{ ! isDiscoverPost && post.author && post.author.name ?
 				<li className="reader-post-byline__author">
 					{ this.renderAuthorName() }
 				</li> : null }
@@ -98,7 +100,7 @@ class PostByline extends React.Component {
 					<a className="reader-post-byline__date-link"
 						onClick={ this.recordDateClick }
 						href={ post.URL }
-						target="_blank"><PostTime date={ post.date } />{ this.props.icon ? <Gridicon icon="external" size={ 14 } /> : null }</a>
+						target="_blank"><PostTime date={ post.date } />{ icon ? <Gridicon icon="external" size={ 14 } /> : null }</a>
 				</li> : null }
 			{ primaryTag ?
 				<li className="reader-post-byline__tag">

--- a/client/reader/post-byline/test/fixtures.js
+++ b/client/reader/post-byline/test/fixtures.js
@@ -1,0 +1,14 @@
+
+export const post = {
+	primary_tag: {
+		slug: 'hippity-hops',
+		display_name: 'hippity hops'
+	},
+	author: {
+		name: 'Elmyra Duff',
+		URL: 'http://tinytoons.wikia.com/wiki/Elmyra_Duff'
+	},
+	date: '2016-07-29T15:00:17-04:00',
+	URL: 'https://kidsblockblog.wordpress.com/2011/09/21/list-of-tiny-toon-adventures-gag-credits/'
+
+};

--- a/client/reader/post-byline/test/index.jsx
+++ b/client/reader/post-byline/test/index.jsx
@@ -117,8 +117,8 @@ describe( 'PostByline', () => {
 			} );
 
 			it( 'does not render if the post is a discover pick', () => {
-				const disoverPick = shallow( <PostByline post={ post } isDiscoverPost={ true } /> );
-				assert.lengthOf( disoverPick.find( authorSelector ), 0 );
+				const discoverPick = shallow( <PostByline post={ post } isDiscoverPost={ true } /> );
+				assert.lengthOf( discoverPick.find( authorSelector ), 0 );
 			} );
 		} );
 

--- a/client/reader/post-byline/test/index.jsx
+++ b/client/reader/post-byline/test/index.jsx
@@ -1,0 +1,163 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+import { spy } from 'sinon';
+import { each, partial, omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+ import Gridicon from 'components/gridicon';
+ import useMockery from 'test/helpers/use-mockery';
+ import { post } from './fixtures';
+
+describe( 'PostByline', () => {
+	let PostByline;
+	const statsSpies = {
+		recordAction: spy(),
+		recordGaEvent: spy(),
+		recordTrackForPost: spy(),
+		recordPermalinkClick: spy()
+	};
+
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'reader/stats', statsSpies );
+	} );
+
+	before( () => {
+		PostByline = require( 'reader/post-byline' );
+	} );
+
+	context( 'prop requirements', () => {
+		it( 'requires a post', () => {
+			const shallowRender = partial( shallow, <PostByline /> );
+			assert.throws( shallowRender );
+		} );
+
+		it( 'requires a valid post', () => {
+			const shallowRender = partial( shallow, <PostByline post={ post } /> );
+			assert.doesNotThrow( shallowRender );
+		} );
+	} );
+
+	describe( 'tracking', () => {
+		let postByline;
+
+		before( () => {
+			postByline = shallow( <PostByline post={ post } /> );
+		} );
+
+		context( 'tag clicks', () => {
+			before( () => {
+				postByline.find( '.reader-post-byline__tag a' ).simulate( 'click' );
+			} );
+
+			after( () => {
+				each( statsSpies, statSpy => statSpy.reset() );
+			} );
+
+			it( 'records the action', () => {
+				assert.isTrue( statsSpies.recordAction.calledWith( 'click_tag' ) );
+			} );
+
+			it( 'records GA event', () =>{
+				assert.isTrue( statsSpies.recordGaEvent.calledWith( 'Clicked Tag Link' ) );
+			} );
+
+			it( 'records track for post', () => {
+				const [ keyArg, postArg, tagArg ] = statsSpies.recordTrackForPost.args[ 0 ];
+				assert.equal( keyArg, 'calypso_reader_tag_clicked' );
+				assert.deepEqual( postArg, post );
+				assert.equal( tagArg.tag, post.primary_tag.slug );
+			} );
+		} );
+
+		context( 'date clicks', () => {
+			before( () => {
+				postByline.find( '.reader-post-byline__date-link' ).simulate( 'click' );
+			} );
+
+			after( () => {
+				each( statsSpies, statSpy => statSpy.reset() );
+			} );
+
+			it( 'records permalink clicks', () => {
+				assert.isTrue( statsSpies.recordPermalinkClick.calledWith( 'timestamp' ) );
+			} );
+
+			it( 'records GA event', () => {
+				assert.isTrue( statsSpies.recordGaEvent.calledWith( 'Clicked Post Permalink', 'timestamp' ) );
+			} );
+		} );
+
+		context( 'author click', () => {
+			before( () => {
+				postByline.find( '.reader-post-byline__author' ).children().simulate( 'click' );
+			} );
+
+			it( 'records the action', () => {
+				assert.isTrue( statsSpies.recordAction.calledWith( 'click_author' ) );
+			} );
+
+			it( 'records GA event', () =>{
+				assert.isTrue( statsSpies.recordGaEvent.calledWith( 'Clicked Author Link' ) );
+			} );
+
+			it( 'records track for post', () => {
+				const [ keyArg, postArg ] = statsSpies.recordTrackForPost.args[ 0 ];
+				assert.equal( keyArg, 'calypso_reader_author_link_clicked' );
+				assert.deepEqual( postArg, post );
+			} );
+		}	);
+	} );
+
+	describe( 'rendering', () => {
+		describe( 'author block', () => {
+			const authorSelector = '.reader-post-byline__author';
+
+			it( 'does not render if the post does not have an author', () => {
+				const authorLessByline = shallow( <PostByline post={ omit( post, 'author' ) } /> );
+				assert.lengthOf( authorLessByline.find( authorSelector ), 0 );
+			} );
+			it( 'does not render if the post author does not have a name', () => {
+				const author = omit( post.author, 'name' );
+				const nameLessByline = shallow( <postByline post={ Object.assign( {}, post, { author } ) } /> );
+				assert.lengthOf( nameLessByline.find( authorSelector ), 0 );
+			} );
+		} );
+
+		describe( 'date block', () => {
+			const dateSelector = '.reader-post-byline__date';
+
+			it( 'does not render if the post does not have a date', () => {
+				const dateLess = shallow( <PostByline post={ omit( post, 'date' ) } /> );
+				assert.lengthOf( dateLess.find( dateSelector ), 0 );
+			} );
+
+			it( 'does not render if the post does nto have an url', () => {
+				const urlLess = shallow( <PostByline post={ omit( post, 'URL' ) } /> );
+				assert.lengthOf( urlLess.find( dateSelector ), 0 );
+			} );
+
+			it( 'does not render external icon by default', () => {
+				const postByline = shallow( <PostByline post={ post } /> );
+				assert.notMatch( postByline.find( `${dateSelector}-link` ).text(), /<Gridicon \/>/ );
+			} );
+
+			it( 'renders an external icon if the props.icon is true', () => {
+				const withIcon = shallow( <PostByline post={ post } icon={ true } /> );
+				assert.match( withIcon.find( `${dateSelector}-link` ).text(), /<Gridicon \/>/ );
+			} );
+		} );
+
+		describe( 'primary tag block', () => {
+			it( 'does not render if the post does not have a primary tag', () =>{
+				const primaryTagLess = shallow( <PostByline post={ omit( post, 'primary_tag' ) } /> );
+				assert.lengthOf( primaryTagLess.find( '.reader-post-byline__tag' ), 0 );
+			} );
+		} );
+	} );
+} );

--- a/client/reader/post-byline/test/index.jsx
+++ b/client/reader/post-byline/test/index.jsx
@@ -10,7 +10,6 @@ import { each, partial, omit } from 'lodash';
 /**
  * Internal dependencies
  */
- import Gridicon from 'components/gridicon';
  import useMockery from 'test/helpers/use-mockery';
  import { post } from './fixtures';
 
@@ -29,18 +28,6 @@ describe( 'PostByline', () => {
 
 	before( () => {
 		PostByline = require( 'reader/post-byline' );
-	} );
-
-	context( 'prop requirements', () => {
-		it( 'requires a post', () => {
-			const shallowRender = partial( shallow, <PostByline /> );
-			assert.throws( shallowRender );
-		} );
-
-		it( 'requires a valid post', () => {
-			const shallowRender = partial( shallow, <PostByline post={ post } /> );
-			assert.doesNotThrow( shallowRender );
-		} );
 	} );
 
 	describe( 'tracking', () => {
@@ -122,10 +109,16 @@ describe( 'PostByline', () => {
 				const authorLessByline = shallow( <PostByline post={ omit( post, 'author' ) } /> );
 				assert.lengthOf( authorLessByline.find( authorSelector ), 0 );
 			} );
+
 			it( 'does not render if the post author does not have a name', () => {
 				const author = omit( post.author, 'name' );
-				const nameLessByline = shallow( <postByline post={ Object.assign( {}, post, { author } ) } /> );
+				const nameLessByline = shallow( <PostByline post={ Object.assign( {}, post, { author } ) } /> );
 				assert.lengthOf( nameLessByline.find( authorSelector ), 0 );
+			} );
+
+			it( 'does not render if the post is a discover pick', () => {
+				const disoverPick = shallow( <PostByline post={ post } isDiscoverPost={ true } /> );
+				assert.lengthOf( disoverPick.find( authorSelector ), 0 );
 			} );
 		} );
 

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -419,7 +419,7 @@ const Post = React.createClass( {
 
 				{ post.title ? <h1 className="reader__post-title"><a className="reader__post-title-link" href={ post.URL } target="_blank">{ post.title }</a></h1> : null }
 
-				<PostByline post={ post } site={ this.props.site } />
+				<PostByline post={ post } site={ this.props.site } isDiscoverPost={ isDiscoverPost } />
 
 				{ shouldUseFullExcerpt
 					? <EmbedContainer>


### PR DESCRIPTION
This hides the byline for discover posts. 

The change request came out of a discussion around content attribution for these posts.  The current design leads too many to attribute the editor as the original author of the content.  The decision for now is to remove the editor byline from discovery posts.

### Screens

**Before**
![screen shot 2016-08-01 at 10 51 26 am](https://cloud.githubusercontent.com/assets/744755/17303554/160dd942-57d6-11e6-8f6e-b087130adcea.png)

**After**
![screen shot 2016-08-01 at 10 52 56 am](https://cloud.githubusercontent.com/assets/744755/17303581/312f1c36-57d6-11e6-885e-d63ae3c8daa9.png)


### Testing

``` npm run test-client client/reader/post-byline ```

Test live: https://calypso.live/?branch=update/reader/hide-discover-byline