### PR TITLE
Reader: New styles for full-post view, hook up back

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -95,6 +95,7 @@
 @import 'components/purchase-detail/style';
 @import 'components/push-notification/style';
 @import 'components/rating/style';
+@import 'components/reader-main/style';
 @import 'components/related-posts/style';
 @import 'components/ribbon/style';
 @import 'components/search/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -142,7 +142,9 @@ $z-layers: (
 		'.environment-badge .bug-report': 1000
 	),
 	'.masterbar': (
-		'.masterbar__notifications-bubble': 99999
+		'.masterbar__notifications-bubble': 99999,
+		'.reader-back': 99999,
+		'.reader-profile': 100000
 	),
 	'.detail-page__backdrop': (
 		'.detail-page__action-buttons': 200

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -18,10 +18,15 @@
     	.follow-button__label {
     		color: $blue-medium;
 
+
     		@include breakpoint( "<660px" ) {
     			display: inline-block;
     		}
     	}
+
+			&.is-following .follow-button__label {
+				color: $alert-green;
+			}
 
 		&:hover {
 
@@ -49,9 +54,17 @@
     }
 }
 
-.author-compact-profile .external-link {
+.author-compact-profile .reader-author-link {
 	font-weight: 600;
-	margin-top: 15px;
+	margin-top: 18px;
+}
+
+.author-compact-profile__site-link {
+	margin-top: 4px;
+}
+
+.author-compact-profile__follow {
+	margin: 11px 0;
 }
 
 .author-compact-profile__follow-count {

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -30,6 +30,8 @@
 
 .comment-button__icon {
 	fill: lighten( $gray, 10% );
+	position: relative;
+		top: 1px;
 	&:hover {
 		fill: $blue-light;
 	}

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -19,11 +19,11 @@ const ReaderAuthorLink = ( { author, post, children } ) => {
 	};
 
 	if ( ! author.URL ) {
-		return ( <span>{ children }</span> );
+		return ( <span className="reader-author-link">{ children }</span> );
 	}
 
 	return (
-		<ExternalLink href={ author.URL } target="_blank" onClick={ recordAuthorClick }>
+		<ExternalLink className="reader-author-link" href={ author.URL } target="_blank" onClick={ recordAuthorClick }>
 			{ children }
 		</ExternalLink>
 	);

--- a/client/blocks/reader-full-post/header-tags.jsx
+++ b/client/blocks/reader-full-post/header-tags.jsx
@@ -10,7 +10,7 @@ const ReaderFullPostHeaderTags = ( { tags } ) => {
 	const listItems = map( tagsToDisplay, tag => {
 		return (
 			<li key={ `post-tag-${tag.slug}` } className="reader-full-post__header-tag-list-item">
-				<a href={ `/tag/${tag.slug}` } className="reader-full-post__header-tag-list-item-link">{ tag.display_name }</a>
+					<a href={ `/tag/${tag.slug}` } className="reader-full-post__header-tag-list-item-link">{ tag.name }</a>
 			</li>
 		);
 	} );

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -81,8 +81,8 @@ export class FullPostView extends React.Component {
 							followCount={ site && site.subscribers_count }
 							feedId={ post.feed_ID }
 							siteId={ post.site_ID } />
-							{ shouldShowLikes( post ) && <LikeButton siteId={ post.site_ID } postId={ post.ID } fullPost={ true } tagName="div" /> }
 							{ shouldShowComments( post ) && <CommentButton key="comment-button" commentCount={ post.discussion.comment_count } onClick={ this.handleCommentClick } tagName="div" /> }
+							{ shouldShowLikes( post ) && <LikeButton siteId={ post.site_ID } postId={ post.ID } fullPost={ true } tagName="div" /> }
 
 					</div>
 					<div className="reader-full-post__story">

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -6,6 +6,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { translate } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal Dependencies
@@ -13,6 +14,8 @@ import { translate } from 'i18n-calypso';
 import ReaderMain from 'components/reader-main';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
+import EmbedContainer from 'components/embed-container';
+import PostExcerpt from 'components/post-excerpt';
 import { setSection } from 'state/ui/actions';
 import smartSetState from 'lib/react-smart-set-state';
 import PostStore from 'lib/feed-post-store';
@@ -24,12 +27,18 @@ import { fetchPost } from 'lib/feed-post-store/actions';
 import ReaderFullPostHeader from './header';
 import AuthorCompactProfile from 'blocks/author-compact-profile';
 import LikeButton from 'components/like-button';
+import { isDiscoverPost, isDiscoverSitePick, getSourceFollowUrl, getSiteUrl } from 'reader/discover/helper';
+import { isDailyPostChallengeOrPrompt } from 'reader/daily-post/helper';
+import DiscoverSiteAttribution from 'reader/discover/site-attribution';
+import DailyPostButton from 'reader/daily-post';
 import { shouldShowLikes } from 'reader/like-helper';
 import { shouldShowComments } from 'reader/comments/helper';
 import CommentButton from 'blocks/comment-button';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 import Comments from 'reader/comments';
 import scrollTo from 'lib/scroll-to';
+import PostExcerptLink from 'reader/post-excerpt-link';
+import { siteNameFromSiteAndPost } from 'reader/utils';
 
 export class FullPostView extends React.Component {
 	constructor( props ) {
@@ -64,9 +73,18 @@ export class FullPostView extends React.Component {
 
 	render() {
 		const { post, site } = this.props;
+		const siteName = siteNameFromSiteAndPost( site, post );
+		const classes = { 'reader-full-post': true };
+		if ( post.site_ID ) {
+			classes[ 'blog-' + post.site_ID ] = true;
+		}
+		if ( post.feed_ID ) {
+			classes[ 'feed-' + post.feed_ID ] = true;
+		}
+
 		/*eslint-disable react/no-danger*/
 		return (
-			<ReaderMain className="reader-full-post">
+			<ReaderMain className={ classNames( classes ) }>
 				<div className="reader-full-post__back-container">
 					<Button className="reader-full-post__back" borderless compact onClick={ this.handleBack }>
 						<Gridicon icon="arrow-left" /> { translate( 'Back' ) }
@@ -81,15 +99,55 @@ export class FullPostView extends React.Component {
 							followCount={ site && site.subscribers_count }
 							feedId={ post.feed_ID }
 							siteId={ post.site_ID } />
-							{ shouldShowComments( post ) && <CommentButton key="comment-button" commentCount={ post.discussion.comment_count } onClick={ this.handleCommentClick } tagName="div" /> }
-							{ shouldShowLikes( post ) && <LikeButton siteId={ post.site_ID } postId={ post.ID } fullPost={ true } tagName="div" /> }
+						{ shouldShowComments( post ) &&
+							<CommentButton key="comment-button"
+								commentCount={ post.discussion.comment_count }
+								onClick={ this.handleCommentClick }
+								tagName="div" />
+						}
+						{ shouldShowLikes( post ) &&
+							<LikeButton siteId={ post.site_ID }
+								postId={ post.ID }
+								fullPost={ true }
+								tagName="div" />
+						}
 
 					</div>
 					<div className="reader-full-post__story">
 						<ReaderFullPostHeader post={ post } />
-						<div className="reader__full-post-content" dangerouslySetInnerHTML={ { __html: this.props.post.content } } />
+						{ post.use_excerpt
+							? <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
+							: <EmbedContainer>
+									<div
+										className="reader-full-post__story-content reader__full-post-content"
+										dangerouslySetInnerHTML={ { __html: post.content } } />
+								</EmbedContainer>
+						}
+
+						{ post.show_excerpt && ! isDiscoverPost( post )
+							? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
+							: null
+						}
+						{ isDiscoverSitePick( post )
+							? <DiscoverSiteAttribution
+									attribution={ post.discover_metadata.attribution }
+									siteUrl={ getSiteUrl( post ) }
+									followUrl={ getSourceFollowUrl( post ) } />
+							: null
+						}
+						{ isDailyPostChallengeOrPrompt( post )
+							? <DailyPostButton post={ post } tagName="span" />
+							: null
+						}
+					{ shouldShowComments( post )
+						? <Comments ref={ this.bindComments }
+								post={ post }
+								initialSize={ 25 }
+								pageSize={ 25 }
+								onCommentsUpdate={ this.checkForCommentAnchor } />
+						: null
+					}
 					</div>
-					{ shouldShowComments( post ) ? <Comments ref={ this.bindComments } post={ post } initialSize={ 25 } pageSize={ 25 } onCommentsUpdate={ this.checkForCommentAnchor } /> : null }
 				</div>
 			</ReaderMain>
 		);

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -125,17 +125,19 @@
 	@include breakpoint( "<660px" ) {
 		position: fixed;
 			top: 9px;
-			right: 100px;
+			right: 20px;
 		z-index: z-index( '.masterbar', '.reader-profile' );
 	}
 }
 
 .reader-full-post__sidebar .comment-button {
+	margin-right: 18px;
 	@include breakpoint( "<660px" ) {
 		position: fixed;
 			top: 10px;
-			right: 20px;
+			right: 100px;
 		z-index: z-index( '.masterbar', '.reader-profile' );
+		margin-right: 0;
 	}
 	.comment-button__label-status {
 		display: none;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,18 +1,171 @@
+.reader-full-post.main {
+	max-width: none;
+	// Turns off the implicit positioning context set up by the normal main styles
+	// This allows our fixed positioned elements to be positioned relative to the main html document
+	backface-visibility: visible;
+	perspective: none;
+}
+
+.reader-full-post__content {
+	@include breakpoint( ">1280px" ) {
+		width: 720px;
+		padding-left: 260px;
+	}
+	@include breakpoint( "1040px-1280px" ) {
+		width: 720px;
+		padding-left: 240px;
+	}
+	@include breakpoint( "660px-1040px" ) {
+		width: auto;
+		margin: 0;
+		padding-left: 240px;
+	}
+	@include breakpoint( "<660px" ) {
+		width: auto;
+		padding: 0 20px;
+	}
+	margin: 0 auto;
+}
+
+.reader-full-post__back-container {
+	margin: 0;
+	position: fixed;
+		top: 47px;
+		left: 0px;
+	z-index: z-index( '.masterbar', '.reader-back'	);
+
+	.button.is-compact.is-borderless {
+		padding: 18px 40px 18px 20px;
+	}
+
+	@include breakpoint( "<660px" ) {
+		top: 0;
+		left: 0;
+		right: 0;
+		height:46px;
+		background: #fff;
+		border-bottom: 1px solid $gray-light;
+		margin-top: 0;
+
+		.button.is-compact.is-borderless {
+			padding: 20px 40px 16px 20px;
+		}
+	}
+}
+
+.reader-full-post__sidebar {
+	width: 220px;
+	position: fixed;
+	@include breakpoint( ">1280px" ) {
+		left: calc( 50% - 490px );
+	}
+	@include breakpoint( "1040px-1280px" ) {
+		left: calc( 50% - 480px );
+	}
+	@include breakpoint( "660px-1040px" ) {
+		left: 20px;
+	}
+	@include breakpoint( "<660px" ) {
+		position: static;
+		width: auto;
+		text-align: left;
+	}
+	text-align: center;
+}
+
+.reader-full-post__story {
+	max-width: 720px;
+	font-size: 17px;
+	line-height: 28px;
+
+	@include breakpoint( "<480px" ) {
+		font-size: 15px;
+		line-height: 24px;
+	}
+}
+
+.reader-full-post .author-compact-profile {
+	z-index: z-index( '.masterbar', '.reader-profile'	);
+	@include breakpoint( "<660px" ) {
+		margin-top: 20px;
+		.gravatar {
+			display: inline-block;
+			vertical-align: bottom;
+			height: 24px;
+			width: 24px;
+			margin-right: 1em;
+		}
+		.reader-author-link {
+			font-weight: 700;
+			display: inline;
+			margin: 0;
+		}
+		.author-compact-profile__site-link {
+			display: inline;
+			margin-left: 1em;
+		}
+		.author-compact-profile__follow .follow-button {
+			position: fixed;
+			top: 15px;
+			right: 180px;
+			z-index: z-index( '.masterbar', '.reader-profile' )
+		}
+
+		.author-compact-profile__follow-count {
+			display: none;
+		}
+	}
+}
+
+.reader-full-post__sidebar .like-button {
+	.like-button__label-status {
+		display: none;
+	}
+
+	@include breakpoint( "<660px" ) {
+		position: fixed;
+			top: 9px;
+			right: 100px;
+		z-index: z-index( '.masterbar', '.reader-profile' );
+	}
+}
+
+.reader-full-post__sidebar .comment-button {
+	@include breakpoint( "<660px" ) {
+		position: fixed;
+			top: 10px;
+			right: 20px;
+		z-index: z-index( '.masterbar', '.reader-profile' );
+	}
+	.comment-button__label-status {
+		display: none;
+	}
+}
+
 .reader-full-post__header-title {
 	clear: none;
 	color: $gray-dark;
 	font-family: $serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-	font-size: 20px;
+	font-size: 26px;
 	font-weight: 700;
-	line-height: 1.3;
-	margin: 24px 0 8px;
+	line-height: 34px;
+	margin: 60px 0 8px;
 	max-width: 750px;
 
-	@include breakpoint( ">480px" ) {
-		font-size: 28px;
-		line-height: 1.4;
+	@include breakpoint( ">960px" ) {
+		font-size: 36px;
+		line-height: 46px;
+	}
+
+	@include breakpoint( "480px-960px" ) {
+		font-size: 32px;
+		line-height: 40px;
+	}
+
+	@include breakpoint( "<660px" ) {
+		margin-top: 8px;
 	}
 
 	.reader-full-post__header-title-link,
@@ -45,7 +198,7 @@
 
 .reader-full-post__header-tags {
 	display: inline-flex;
-    width: calc(100% - 120px);
+	width: calc(100% - 120px);
 
 	.gridicon {
 		fill: $gray;
@@ -59,16 +212,15 @@
 	color: $gray;
 	list-style: none;
 	margin: 0;
-    padding: 0;
-    position: relative;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    width: 100%;
+	padding: 0;
+	position: relative;
+	overflow: hidden;
+	white-space: nowrap;
+	width: 100%;
 
-    &::after {
-    	@include long-content-fade( $size: 35% );
-    }
+	&::after {
+		@include long-content-fade( $size: 20px );
+	}
 }
 
 .reader-full-post__header-tag-list-item {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -214,6 +214,7 @@
 	margin: 0;
 	padding: 0;
 	position: relative;
+		top: -2px;
 	overflow: hidden;
 	white-space: nowrap;
 	width: 100%;

--- a/client/components/reader-main/index.jsx
+++ b/client/components/reader-main/index.jsx
@@ -1,0 +1,23 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import Main from 'components/main';
+
+export default class ReaderMain extends React.Component {
+	componentWillMount() {
+		document.querySelector( 'body' ).classList.add( 'is-reader-page' );
+	}
+
+	componentWillUnmount() {
+		document.querySelector( 'body' ).classList.remove( 'is-reader-page' );
+	}
+
+	render() {
+		return ( <Main { ...this.props } /> );
+	}
+}

--- a/client/components/reader-main/style.scss
+++ b/client/components/reader-main/style.scss
@@ -1,0 +1,3 @@
+body.is-reader-page {
+	background-color: #fff;
+}

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -26,6 +26,7 @@ module.exports = React.createClass( {
 		// Determine and cache vertical threshold from rendered element's
 		// offset relative the document
 		this.threshold = ReactDom.findDOMNode( this ).offsetTop;
+		console.log( this.threshold );
 		this.throttleOnResize = throttle( this.onWindowResize, 200 );
 
 		window.addEventListener( 'scroll', this.onWindowScroll );

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -26,7 +26,6 @@ module.exports = React.createClass( {
 		// Determine and cache vertical threshold from rendered element's
 		// offset relative the document
 		this.threshold = ReactDom.findDOMNode( this ).offsetTop;
-		console.log( this.threshold );
 		this.throttleOnResize = throttle( this.onWindowResize, 200 );
 
 		window.addEventListener( 'scroll', this.onWindowScroll );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -82,7 +82,7 @@ const MasterbarLoggedIn = React.createClass( {
 					url="/"
 					icon="reader"
 					onClick={ this.clickReader }
-					isActive={ this.isActive( 'reader' ) }
+					isActive={ this.isActive( config.isEnabled( 'reader/refresh-2016-07' ) ? 'reader-refresh' : 'reader' ) }
 					tooltip={ this.translate( 'Read the blogs and topics you follow', { textOnly: true } ) }
 					preloadSection={ () => preload( 'reader' ) }
 				>

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -1,3 +1,7 @@
+.is-group-reader-refresh .layout__content {
+ 	padding-top: 0;
+ }
+
 .reader__content {
 	a {
 		color: $blue-medium;
@@ -291,7 +295,8 @@
 	opacity: 0;
 }
 
-.is-group-reader .main .empty-content {
+.is-group-reader .main .empty-content,
+.is-group-reader-refresh .main .empty-content {
 	margin-top: -120px;
 	padding-top: 0;
 
@@ -308,7 +313,8 @@
 	}
 }
 
-.is-group-reader .empty-content__action {
+.is-group-reader .empty-content__action,
+.is-group-reader-refresh .empty-content__action {
 	@include breakpoint( "<480px" ) {
 		margin-bottom: 10px;
 	}

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -1,6 +1,18 @@
 .is-group-reader-refresh .layout__content {
  	padding-top: 0;
- }
+}
+
+.is-group-reader-refresh .reader__content {
+	margin-top: 10px;
+
+	@include breakpoint( ">480px" ) {
+		margin-top: 30px;
+	}
+}
+
+.is-group-reader-refresh .reader__full-post-content {
+	margin-top: 0;
+}
 
 .reader__content {
 	a {

--- a/client/reader/discover/_style.scss
+++ b/client/reader/discover/_style.scss
@@ -1,4 +1,4 @@
-.reader__card.card, .reader__full-post {
+.reader__card.card, .reader__full-post, .reader-full-post {
 
 	.discover-attribution {
 		font-size: 13px;

--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -31,7 +31,8 @@
 	}
 }
 
-.is-group-reader .card.feed-header__site { // Extra specific to override the :hover
+.is-group-reader .card.feed-header__site,
+.is-group-reader-refresh .card.feed-header__site { // Extra specific to override the :hover
 	&:hover {
 		cursor: default;
 		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -276,7 +276,7 @@
 }
 
 // Discover-Specific Full Post View Styles
-.reader__full-post.blog-53424024 .reader__full-post-content {
+.blog-53424024 .reader__full-post-content {
 
 	.intro {
 		font-size: 20px;
@@ -377,7 +377,7 @@
 }
 
 // Daily Post-Specific Full Post View Styles
-.reader__full-post.blog-489937 .reader__full-post-content {
+.blog-489937 .reader__full-post-content {
 
 	blockquote.left,
 	blockquote.alignleft,

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -1,5 +1,6 @@
 // Reader Sidebar
-.is-group-reader .sidebar {
+.is-group-reader .sidebar,
+.is-group-reader-refresh .sidebar {
 
 	overflow-x: hidden;
 

--- a/client/reader/stream-header/style.scss
+++ b/client/reader/stream-header/style.scss
@@ -1,4 +1,5 @@
-.is-group-reader .card.stream-header {
+.is-group-reader .card.stream-header,
+.is-group-reader-refresh .card.stream-header {
 	min-height: 72px;
 	padding: 24px 144px 24px 24px;
 

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -5,9 +5,11 @@ const i18n = require( 'i18n-calypso' ),
 	FeedDisplayHelper = require( 'reader/lib/feed-display-helper' );
 
 function siteNameFromSiteAndPost( site, post ) {
-	var siteName;
+	let siteName;
 
-	if ( site && site.get( 'state' ) === SiteState.COMPLETE ) {
+	if ( site && ( site.title || site.domain ) ) {
+		siteName = site.title || site.domain;
+	} else if ( site && site.get && site.get( 'state' ) === SiteState.COMPLETE ) {
 		siteName = site.get( 'title' ) || site.get( 'domain' );
 	} else if ( post ) {
 		if ( post.site_name ) {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -207,13 +207,14 @@ if ( config.isEnabled( 'manage/drafts' ) ) {
 }
 
 if ( config.isEnabled( 'reader' ) ) {
+	const readerGroup = config.isEnabled( 'reader/refresh-2016-07' ) ? 'reader-refresh' : 'reader';
 	// this MUST be the first section for /read paths so subsequent sections under /read can override settings
 	sections.push( {
 		name: 'reader',
 		paths: [ '/', '/read' ],
 		module: 'reader',
 		secondary: true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	sections.push( {
@@ -221,7 +222,7 @@ if ( config.isEnabled( 'reader' ) ) {
 		paths: [ '/read/feeds/[^\\/]+/posts/[^\\/]+', '/read/blogs/[^\\/]+/posts/[^\\/]+' ],
 		module: 'reader/full-post',
 		secondary: config.isEnabled( 'reader/refresh-2016-07' ) ? false : true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	sections.push( {
@@ -229,7 +230,7 @@ if ( config.isEnabled( 'reader' ) ) {
 		paths: [ '/recommendations/posts' ],
 		module: 'reader/recommendations',
 		secondary: true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	sections.push( {
@@ -237,7 +238,7 @@ if ( config.isEnabled( 'reader' ) ) {
 		paths: [ '/recommendations' ],
 		module: 'reader/recommendations',
 		secondary: true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	sections.push( {
@@ -245,7 +246,7 @@ if ( config.isEnabled( 'reader' ) ) {
 		paths: [ '/discover' ],
 		module: 'reader/discover',
 		secondary: true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	sections.push( {
@@ -253,7 +254,7 @@ if ( config.isEnabled( 'reader' ) ) {
 		paths: [ '/following' ],
 		module: 'reader/following',
 		secondary: true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	sections.push( {
@@ -261,7 +262,7 @@ if ( config.isEnabled( 'reader' ) ) {
 		paths: [ '/tags', '/tag' ],
 		module: 'reader/tag-stream',
 		secondary: true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	sections.push( {
@@ -269,7 +270,7 @@ if ( config.isEnabled( 'reader' ) ) {
 		paths: [ '/activities' ],
 		module: 'reader/liked-stream',
 		secondary: true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	sections.push( {
@@ -277,7 +278,7 @@ if ( config.isEnabled( 'reader' ) ) {
 		paths: [ '/read/search' ],
 		module: 'reader/search',
 		secondary: true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	sections.push( {
@@ -285,7 +286,7 @@ if ( config.isEnabled( 'reader' ) ) {
 		paths: [ '/read/list' ],
 		module: 'reader/list',
 		secondary: true,
-		group: 'reader'
+		group: readerGroup
 	} );
 
 	if ( config.isEnabled( 'reader/start' ) ) {
@@ -294,7 +295,7 @@ if ( config.isEnabled( 'reader' ) ) {
 			paths: [ '/recommendations/start' ],
 			module: 'reader/start',
 			secondary: true,
-			group: 'reader'
+			group: readerGroup
 		} );
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -114,7 +114,7 @@
 		"reader/list-management": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
-		"reader/refresh-2016-07": false,
+		"reader/refresh-2016-07": true,
 		"reader/search": true,
 		"reader/start": true,
 		"reader/tags-with-elasticsearch": true,


### PR DESCRIPTION
Add in styles for the new full post view. Scope some of these off the dynamic 'reader' group, which is set based on a feature flag.

Also hook up the back button and use the compact button for it.

Test live: https://calypso.live/?branch=add/reader-refresh/full-post-background

~~To test, start a local calypso like this: 
`make clean; ENABLE_FEATURES=reader/refresh-2016-07 make run`~~

I've enabled the feature flag, so it just works now