### PR TITLE
Add label to SEO tab in Web Preview

### DIFF
--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -95,6 +95,7 @@ export const PreviewToolbar = props => {
 					onClick={ selectSeoPreview }
 				>
 					<Gridicon icon="share" />
+					<span className="web-preview__seo-label">{ translate( 'Social Previews' ) }</span>
 				</button>
 			}
 			<div className="web-preview__toolbar-tray">


### PR DESCRIPTION
This isn't exactly ready for deployment. It needs some figurin' out of what text to display and how to style the label.

The purpose is to clarify what the SEO/sharing preview icon means. At one point @mtias mentioned forgetting the "SEO" terminology completely too.

**Before**
![screen shot 2016-08-01 at 11 25 14 am](https://cloud.githubusercontent.com/assets/5431237/17304490/a8f7f0cc-57da-11e6-8492-991b4e58021b.png)


**After**
![screen shot 2016-08-01 at 11 24 21 am](https://cloud.githubusercontent.com/assets/5431237/17304471/94d87ecc-57da-11e6-8ac3-38d8a09c8e34.png)

cc: @roundhill @apeatling @mtias 

Test live: https://calypso.live/?branch=update/seo-preview-label