### PR TITLE
Components: Fix AuthorSelector single DevDocs example rendering

### DIFF
--- a/client/blocks/author-selector/docs/example.jsx
+++ b/client/blocks/author-selector/docs/example.jsx
@@ -30,9 +30,7 @@ function AuthorSelectorExample( { primarySiteId, displayName } ) {
 	);
 }
 
-AuthorSelectorExample.displayName = 'AuthorSelector';
-
-export default connect( ( state ) => {
+const ConnectedAuthorSelectorExample = connect( ( state ) => {
 	const user = getCurrentUser( state );
 	if ( ! user ) {
 		return {};
@@ -43,3 +41,7 @@ export default connect( ( state ) => {
 		displayName: user.display_name
 	};
 } )( AuthorSelectorExample );
+
+ConnectedAuthorSelectorExample.displayName = 'AuthorSelector';
+
+export default ConnectedAuthorSelectorExample;


### PR DESCRIPTION
Related: #7124 

The DevDocs screens are pretty picky about the display names of the example components. This pull request seeks to resolve an issue where visiting the single example view for the `<AuthorSelector />` was not correctly displaying the example.

__Testing instructions:__

Verify that the `<AuthorSelector />` example is shown when visiting this URL:

http://calypso.localhost:3000/devdocs/blocks/author-selector

/cc @mtias 

Test live: https://calypso.live/?branch=fix/components-author-selector-example