### PR TITLE
Domains: Convert letters to uppercase for post codes

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -78,8 +78,6 @@ export default React.createClass( {
 				if ( fieldName === 'postalCode' ) {
 					sanitizedFieldValues[ fieldName ] = sanitizedFieldValues[ fieldName ].toUpperCase();
 				}
-			} else {
-				sanitizedFieldValues[ fieldName ] = fieldValues[ fieldName ];
 			}
 		} );
 

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -57,7 +57,7 @@ export default React.createClass( {
 		this.formStateController = formState.Controller( {
 			fieldNames: this.fieldNames,
 			loadFunction: wpcom.getDomainContactInformation.bind( wpcom ),
-			sanitizerFunction: this.trimWhitespace,
+			sanitizerFunction: this.sanitize,
 			validatorFunction: this.validate,
 			onNewState: this.setFormState,
 			onError: this.handleFormControllerError
@@ -70,17 +70,20 @@ export default React.createClass( {
 		analytics.pageView.record( '/checkout/domain-contact-information', 'Checkout > Domain Contact Information' );
 	},
 
-	trimWhitespace( fieldValues, onComplete ) {
-		const trimmedFieldValues = Object.assign( {}, fieldValues );
+	sanitize( fieldValues, onComplete ) {
+		const sanitizedFieldValues = Object.assign( {}, fieldValues );
 		this.fieldNames.forEach( ( fieldName ) => {
 			if ( typeof fieldValues[ fieldName ] === 'string' ) {
-				trimmedFieldValues[ fieldName ] = fieldValues[ fieldName ].trim();
+				sanitizedFieldValues[ fieldName ] = fieldValues[ fieldName ].trim();
+				if ( fieldName === 'postalCode' ) {
+					sanitizedFieldValues[ fieldName ] = sanitizedFieldValues[ fieldName ].toUpperCase();
+				}
 			} else {
-				trimmedFieldValues[ fieldName ] = fieldValues[ fieldName ];
+				sanitizedFieldValues[ fieldName ] = fieldValues[ fieldName ];
 			}
 		} );
 
-		onComplete( trimmedFieldValues );
+		onComplete( sanitizedFieldValues );
 	},
 
 	validate( fieldValues, onComplete ) {


### PR DESCRIPTION
We should convert all letters in the post code field to upper case - that's the case _all_ post codes use and what our validation logic expects.

#### Testing
Try registering a new domain and during checkout set the country, for example, to United Kingdom (or any country that uses letters in post codes - Ireland, Netherlands, etc.) and use a valid post code that contains lowercase/uppercase/mix letters.
For example, `wr11 1yn` should be converted (sanitized) to uppercase (visible in the form) before submitting to backend for validation (and eventually checkout).

/cc @aidvu @umurkontaci 
Props to @chrisfromthelc for noticing this and reporting! ❤️ 

Test live: https://calypso.live/?branch=fix/uppercase-postcodes