### PR TITLE
Reader: Style figcaptions as caption text

### DIFF
--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -25,7 +25,7 @@ export default function createBetterExcerpt( post ) {
 	dom.innerHTML = post.content;
 
 	// Ditch any photo captions with the wp-caption-text class, styles, scripts
-	forEach( dom.querySelectorAll( '.wp-caption-text, style, script, blockquote[class^="instagram-"]' ), removeElement );
+	forEach( dom.querySelectorAll( '.wp-caption-text, style, script, blockquote[class^="instagram-"], figure' ), removeElement );
 
 	// limit to paras and brs
 	dom.innerHTML = striptags( dom.innerHTML, [ 'p', 'br' ] );

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -231,7 +231,8 @@
 		}
 	}
 
-	.wp-caption-text {
+	.wp-caption-text,
+	figure figcaption {
 		padding: 12px;
 		margin: 0;
 		font-size: 13px;


### PR DESCRIPTION
before
<img width="678" alt="requiring_employees_to_be_cheerful_isn t_just_mean__it s_bad_business_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/17307944/86cb3826-5805-11e6-92c3-e06aab7d61b4.png">


after
<img width="704" alt="requiring_employees_to_be_cheerful_isn t_just_mean__it s_bad_business_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/17307921/6f070e54-5805-11e6-9bdc-a938e20a2d3f.png">

from https://wordpress.com/read/feeds/5323188/posts/1106061146
