### PR TITLE
Pages: Update ellipsis to use Gridicon rather than Noticon

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -285,7 +285,7 @@ module.exports = React.createClass( {
 					{ title }
 				</a>
 				{ this.props.multisite ? <span className="page__site-url">{ this.getSiteDomain() }</span> : null }
-				<span className="page__actions-toggle noticon noticon-ellipsis" onClick={ this.togglePageActions } ref="popoverMenuButton" />
+				<Gridicon icon="ellipsis" className="page__actions-toggle" onClick={ this.togglePageActions } ref="popoverMenuButton" />
 				<PopoverMenu
 					isVisible={ this.state.showPageActions }
 					onClose={ this.togglePageActions }

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -17,7 +17,8 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 	SiteIcon = require( 'components/site-icon' ),
 	helpers = require( './helpers' ),
 	analytics = require( 'lib/analytics' ),
-	utils = require( 'lib/posts/utils' );
+	utils = require( 'lib/posts/utils' ),
+	classNames = require( 'classnames' );
 
 function recordEvent( eventAction ) {
 	analytics.ga.recordEvent( 'Pages', eventAction );
@@ -285,7 +286,14 @@ module.exports = React.createClass( {
 					{ title }
 				</a>
 				{ this.props.multisite ? <span className="page__site-url">{ this.getSiteDomain() }</span> : null }
-				<Gridicon icon="ellipsis" className="page__actions-toggle" onClick={ this.togglePageActions } ref="popoverMenuButton" />
+				<Gridicon
+					icon="ellipsis"
+					className={ classNames( {
+						'page__actions-toggle': true,
+						'is-active': this.state.showPageActions
+					} ) }
+					onClick={ this.togglePageActions }
+					ref="popoverMenuButton" />
 				<PopoverMenu
 					isVisible={ this.state.showPageActions }
 					onClose={ this.togglePageActions }

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -77,8 +77,14 @@
 	font-size: 24px;
 	margin: 17px 24px;
 	position: absolute;
-	right: 0;
-	top: 0;
+		right: 0;
+		top: 0;
+	transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+	&.is-active {
+		color: $blue-medium;
+		transform: rotate( 90deg );
+	}
 }
 
 .page__popover-more-info {


### PR DESCRIPTION
The current ellipsis on `/pages/` is using an old Noticon icon, and lacks any transitions that are common elsewhere in Calypso:

![current-ellipsis](https://cloud.githubusercontent.com/assets/191598/17308510/6c4c374a-5808-11e6-8744-2c554bce8111.gif)

This PR updates to use a Gridiron and adds a transition:

![new-ellipsis-transition](https://cloud.githubusercontent.com/assets/191598/17308516/7636d0e4-5808-11e6-94a8-c26788829558.gif)
