### PR TITLE
Push notifications: update copy to remove confusing 'and more instantly'

### DIFF
--- a/client/components/push-notification/prompt.jsx
+++ b/client/components/push-notification/prompt.jsx
@@ -65,7 +65,7 @@ const PushNotificationPrompt = React.createClass( {
 		const noticeText = (
 			<div>
 				<p>
-					<strong>{ this.translate( 'Get notifications on your desktop!' ) }</strong> { this.translate( 'Get notifications for new comments, likes, and more instantly, even when you are not actively using WordPress.com.' ) }
+					<strong>{ this.translate( 'Get notifications on your desktop!' ) }</strong> { this.translate( 'Get instant notifications for new comments and likes, even when you are not actively using WordPress.com.' ) }
 				</p>
 				<p>
 					{ this.translate(

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -336,7 +336,7 @@ const PushNotificationSettings = React.createClass( {
 					<small className={ classNames( 'notification-settings-push-notification-settings__settings-state', stateClass ) }>{ stateText }</small>
 				</h2>
 
-				<p className="notification-settings-push-notification-settings__settings-description">{ this.translate( 'Get notifications for new comments, likes, and more instantly, even when you are not actively using WordPress.com.' ) }</p>
+				<p className="notification-settings-push-notification-settings__settings-description">{ this.translate( 'Get instant notifications for new comments and likes, even when you are not actively using WordPress.com.' ) }</p>
 
 				<Button className={ classNames( 'notification-settings-push-notification-settings__settings-button', buttonClass ) } disabled={ buttonDisabled } onClick={ this.clickHandler } >{ buttonText }</Button>
 


### PR DESCRIPTION
This PR updated the copy for both the push notifications settings panel, and the push notifications prompt from "Get notifications for new comments, likes, and more instantly, even when you are not actively using WordPress.com." to "Get instant notifications for new comments and likes, even when you are not actively using WordPress.com.".

Before:

![image](https://cloud.githubusercontent.com/assets/363749/17309943/ff63ae34-5806-11e6-8896-7efd9adec22f.png)

![image](https://cloud.githubusercontent.com/assets/363749/17309964/217ddd82-5807-11e6-9330-83ee59707661.png)


After:

![image](https://cloud.githubusercontent.com/assets/363749/17310182/68580ea2-5808-11e6-812a-a71eb4482ab0.png)

![image](https://cloud.githubusercontent.com/assets/363749/17310176/5d0d1006-5808-11e6-9896-2f5d7a1dfe96.png)


To test:
* Use calypso.live or test with calypso.localhost using [these instructions](https://www.chromium.org/blink/serviceworker/service-worker-faq) to overcome secure origin restrictions.
* Visit the any whitelisted page, make sure the prompt has the correct sentence and it appears correctly.
* Visit /me/notifications, make sure that the sentence appears correctly.