### PR TITLE
Themes: Add free/premium/all buttons to search bar

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -49,6 +49,7 @@ const Search = React.createClass( {
 		delayTimeout: PropTypes.number,
 		onSearch: PropTypes.func.isRequired,
 		onSearchChange: PropTypes.func,
+		onSearchOpen: PropTypes.func,
 		onSearchClose: PropTypes.func,
 		analyticsGroup: PropTypes.string,
 		autoFocus: PropTypes.bool,
@@ -77,6 +78,7 @@ const Search = React.createClass( {
 			autoFocus: false,
 			disabled: false,
 			onSearchChange: noop,
+			onSearchOpen: noop,
 			onSearchClose: noop,
 			onKeyDown: noop,
 			disableAutocorrect: false,
@@ -252,6 +254,8 @@ const Search = React.createClass( {
 			input.value = '';
 			input.value = setValue;
 		}
+
+		this.props.onSearchOpen( );
 	},
 
 	render: function() {

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -60,7 +60,8 @@ const Search = React.createClass( {
 		searching: PropTypes.bool,
 		isOpen: PropTypes.bool,
 		dir: PropTypes.string,
-		fitsContainer: PropTypes.bool
+		fitsContainer: PropTypes.bool,
+		hideCloseOnMobile: PropTypes.bool
 	},
 
 	getInitialState: function() {
@@ -85,7 +86,8 @@ const Search = React.createClass( {
 			searching: false,
 			isOpen: false,
 			dir: undefined,
-			fitsContainer: false
+			fitsContainer: false,
+			hideCloseOnMobile: false
 		};
 	},
 
@@ -284,6 +286,9 @@ const Search = React.createClass( {
 			search: true
 		} );
 
+		const isCloseButtonVisible = ( isMobile() && this.props.hideCloseOnMobile ) ?
+			' no-close-button ' : '';
+
 		return (
 			<div className={ searchClass } role="search">
 				<Spinner />
@@ -302,7 +307,7 @@ const Search = React.createClass( {
 				<input
 					type="search"
 					id={ 'search-component-' + this.state.instanceId }
-					className={ 'search__input' + ( this.props.dir ? ' ' + this.props.dir : '' ) }
+					className={ 'search__input' + isCloseButtonVisible + ( this.props.dir ? ' ' + this.props.dir : '' ) }
 					placeholder={ placeholder }
 					role="search"
 					value={ searchValue }
@@ -317,22 +322,34 @@ const Search = React.createClass( {
 					autoCapitalize="none"
 					dir={ this.props.dir }
 					{ ...autocorrect } />
-				{ ( searchValue || this.state.isOpen ) ? this.closeButton() : null }
+					{ this.closeButton() }
 			</div>
 		);
 	},
 
 	closeButton: function() {
-		return (
-			<span
-				onTouchTap={ this.closeSearch }
-				tabIndex="0"
-				onKeyDown={ this.closeListener }
-				aria-controls={ 'search-component-' + this.state.instanceId }
-				aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
-			<Gridicon icon="cross" className={ 'search-close__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) } />
-			</span>
-		);
+		let showIfSearchIsNotEmpty;
+
+		if( isMobile() && this.props.hideCloseOnMobile ) {
+			showIfSearchIsNotEmpty = false;
+		} else {
+			showIfSearchIsNotEmpty = true;
+		}
+
+		if ( ( this.state.keyword && showIfSearchIsNotEmpty ) || this.state.isOpen ) {
+			return (
+				<span
+					onTouchTap={ this.closeSearch }
+					tabIndex="0"
+					onKeyDown={ this.closeListener }
+					aria-controls={ 'search-component-' + this.state.instanceId }
+					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
+				<Gridicon icon="cross" className={ 'search-close__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) } />
+				</span>
+			);
+		}
+
+		return null;
 	}
 } );
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -61,7 +61,7 @@ const Search = React.createClass( {
 		isOpen: PropTypes.bool,
 		dir: PropTypes.string,
 		fitsContainer: PropTypes.bool,
-		hideCloseOnMobile: PropTypes.bool
+		hideClose: PropTypes.bool
 	},
 
 	getInitialState: function() {
@@ -87,7 +87,7 @@ const Search = React.createClass( {
 			isOpen: false,
 			dir: undefined,
 			fitsContainer: false,
-			hideCloseOnMobile: false
+			hideClose: false
 		};
 	},
 
@@ -281,13 +281,13 @@ const Search = React.createClass( {
 			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
+			'no-close-button' : this.props.hideClose,
 			rtl: this.props.dir === 'rtl',
 			ltr: this.props.dir === 'ltr',
 			search: true
 		} );
 
-		const isCloseButtonVisible = ( isMobile() && this.props.hideCloseOnMobile ) ?
-			' no-close-button ' : '';
+		const isCloseButtonVisible = this.props.hideClose ? ' no-close-button ' : '';
 
 		return (
 			<div className={ searchClass } role="search">
@@ -328,15 +328,7 @@ const Search = React.createClass( {
 	},
 
 	closeButton: function() {
-		let showIfSearchIsNotEmpty;
-
-		if( isMobile() && this.props.hideCloseOnMobile ) {
-			showIfSearchIsNotEmpty = false;
-		} else {
-			showIfSearchIsNotEmpty = true;
-		}
-
-		if ( ( this.state.keyword && showIfSearchIsNotEmpty ) || this.state.isOpen ) {
+		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
 			return (
 				<span
 					onTouchTap={ this.closeSearch }
@@ -344,7 +336,7 @@ const Search = React.createClass( {
 					onKeyDown={ this.closeListener }
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
-				<Gridicon icon="cross" className={ 'search-close__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) } />
+					<Gridicon icon="cross" className={ 'search-close__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) } />
 				</span>
 			);
 		}

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -152,6 +152,10 @@
 	}
 }
 
+.search__input.no-close-button {
+	padding-right: 1px;
+}
+
 // When search input is opened
 .search.is-open {
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -153,7 +153,13 @@
 }
 
 .search__input.no-close-button {
-	padding-right: 1px;
+	padding-right: 0px;
+}
+
+.search.is-open.no-close-button {
+	&::before {
+		right: 0px;
+	}
 }
 
 // When search input is opened
@@ -192,6 +198,11 @@
 
 	.search__input {
 		display: block;
+	}
+
+	&::before {
+		@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1);
+		right: 50px;
 	}
 }
 

--- a/client/components/segmented-control/index.jsx
+++ b/client/components/segmented-control/index.jsx
@@ -124,6 +124,7 @@ var SegmentedControl = React.createClass( {
 					selected={ this.state.selected === item.value }
 					onClick={ this.selectItem.bind( this, item ) }
 					path={ item.path }
+					index={ index }
 				>
 					{ item.label }
 				</ControlItem>

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -31,7 +31,7 @@ var SegmentedControlItem = React.createClass( {
 
 		var linkClassName = classNames( {
 			'segmented-control__link': true,
-			[`item-index-${this.props.index}`]: this.props.index != null,
+			[ `item-index-${this.props.index}` ]: this.props.index != null,
 		} );
 
 		return (

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -29,11 +29,16 @@ var SegmentedControlItem = React.createClass( {
 			'is-selected': this.props.selected
 		} );
 
+		var linkClassName = classNames( {
+			'segmented-control__link': true,
+			[`item-index-${this.props.index}`]: this.props.index != null,
+		} );
+
 		return (
 			<li className={ itemClassName }>
 				<a
 					href={ this.props.path }
-					className="segmented-control__link"
+					className={ linkClassName }
 					ref="itemLink"
 					onTouchTap={ this.props.onClick }
 					title={ this.props.title }

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -76,6 +76,7 @@ const ThemesSearchCard = React.createClass( {
 	renderMobile( tiers ) {
 		const isJetpack = this.props.site && this.props.site.jetpack;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
+		const isM5Enabled = config.isEnabled( 'manage/themes/m5' );
 		const selectedTiers = isPremiumThemesEnabled ? tiers : [ tiers.find( tier => tier.value === 'free' ) ];
 
 		return (
@@ -83,6 +84,17 @@ const ThemesSearchCard = React.createClass( {
 				<SectionNav selectedText={ this.getSelectedTierFormatted( tiers ) }>
 					<NavTabs>
 						{ ! isJetpack && this.getTierNavItems( selectedTiers ) }
+
+						{ isPremiumThemesEnabled && ! isM5Enabled &&
+							<hr className="section-nav__hr" /> }
+
+						{ isPremiumThemesEnabled && ! isM5Enabled &&
+							<NavItem
+								path={ getExternalThemesUrl( this.props.site ) }
+								onClick={ this.onMore }
+								isExternalLink={ true }>
+								{ this.translate( 'More' ) + ' ' }
+							</NavItem> }
 					</NavTabs>
 
 					<Search
@@ -103,6 +115,7 @@ const ThemesSearchCard = React.createClass( {
 	render() {
 		const isJetpack = this.props.site && this.props.site.jetpack;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
+		const isM5Enabled = config.isEnabled( 'manage/themes/m5' );
 
 		const tiers = [
 			{ value: 'all', label: this.translate( 'All' ) },
@@ -114,25 +127,58 @@ const ThemesSearchCard = React.createClass( {
 			return this.renderMobile( tiers );
 		}
 
-		return (
-			<div className="themes__search-card" data-tip-target="themes-search-card">
-				<SectionNav selectedText={ this.getSelectedTierFormatted( tiers ) }>
-					<Search
-						onSearch={ this.props.onSearch }
-						initialValue={ this.props.search }
-						ref="url-search"
-						placeholder={ this.translate( 'What kind of theme are you looking for?' ) }
-						analyticsGroup="Themes"
-						delaySearch={ true }
-					/>
-					<ThemesSelectButtons
-						tier={ this.props.tier }
-						options={ tiers }
-						onSelect={ this.props.select }
-					/>
-				</SectionNav>
-			</div>
+		const search = (
+			<Search
+				onSearch={ this.props.onSearch }
+				initialValue={ this.props.search }
+				ref="url-search"
+				placeholder={ this.translate( 'What kind of theme are you looking for?' ) }
+				analyticsGroup="Themes"
+				delaySearch={ true }
+			/>
 		);
+
+		let searchCard;
+
+		if ( isM5Enabled ) {
+			searchCard = (
+				<div className="themes__search-card" data-tip-target="themes-search-card">
+					<SectionNav selectedText={ this.getSelectedTierFormatted( tiers ) }>
+						{ search }
+						{ isPremiumThemesEnabled && ! isJetpack &&
+							<ThemesSelectButtons
+								tier={ this.props.tier }
+								options={ tiers }
+								onSelect={ this.props.select }
+							/>
+						}
+					</SectionNav>
+				</div>
+			);
+		} else {
+			searchCard = (
+				<div className="themes__search-card" data-tip-target="themes-search-card">
+					{ search }
+					{ isPremiumThemesEnabled && ! isJetpack &&
+						<ThemesSelectDropdown
+							tier={ this.props.tier }
+							options={ tiers }
+							onSelect={ this.props.select }
+						/>
+					}
+					{ isPremiumThemesEnabled &&
+						<a className="button more"
+							href={ getExternalThemesUrl( this.props.site ) }
+							target="_blank"
+							onClick={ this.onMore }>
+							{ this.translate( 'More' ) }
+						</a>
+					}
+				</div>
+			);
+		}
+
+		return searchCard;
 	}
 } );
 

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -115,7 +115,7 @@ const ThemesSearchCard = React.createClass( {
 	render() {
 		const isJetpack = this.props.site && this.props.site.jetpack;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
-		const isM5Enabled = config.isEnabled( 'manage/themes/m5' );
+		const isM5Enabled = config.isEnabled( 'manage/themes/magic_search' );
 
 		const tiers = [
 			{ value: 'all', label: this.translate( 'All' ) },

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -10,6 +10,7 @@ import debounce from 'lodash/debounce';
  */
 import Search from 'components/search';
 import ThemesSelectDropdown from './select-dropdown';
+import ThemesSelectButtons from './select-buttons';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
@@ -82,15 +83,6 @@ const ThemesSearchCard = React.createClass( {
 				<SectionNav selectedText={ this.getSelectedTierFormatted( tiers ) }>
 					<NavTabs>
 						{ ! isJetpack && this.getTierNavItems( selectedTiers ) }
-
-						{ isPremiumThemesEnabled && <hr className="section-nav__hr" /> }
-
-						{ isPremiumThemesEnabled && <NavItem
-							path={ getExternalThemesUrl( this.props.site ) }
-							onClick={ this.onMore }
-							isExternalLink={ true }>
-							{ this.translate( 'More' ) + ' ' }
-						</NavItem> }
 					</NavTabs>
 
 					<Search
@@ -124,26 +116,21 @@ const ThemesSearchCard = React.createClass( {
 
 		return (
 			<div className="themes__search-card" data-tip-target="themes-search-card">
-				<Search
-					onSearch={ this.props.onSearch }
-					initialValue={ this.props.search }
-					ref="url-search"
-					placeholder={ this.translate( 'What kind of theme are you looking for?' ) }
-					analyticsGroup="Themes"
-					delaySearch={ true }
-				/>
-
-				{ isPremiumThemesEnabled && ! isJetpack && <ThemesSelectDropdown
-										tier={ this.props.tier }
-										options={ tiers }
-										onSelect={ this.props.select } /> }
-				{ isPremiumThemesEnabled && <a className="button more"
-												href={ getExternalThemesUrl( this.props.site ) }
-												target="_blank"
-												onClick={ this.onMore }>
-
-												{ this.translate( 'More' ) }
-											</a> }
+				<SectionNav selectedText={ this.getSelectedTierFormatted( tiers ) }>
+					<Search
+						onSearch={ this.props.onSearch }
+						initialValue={ this.props.search }
+						ref="url-search"
+						placeholder={ this.translate( 'What kind of theme are you looking for?' ) }
+						analyticsGroup="Themes"
+						delaySearch={ true }
+					/>
+					<ThemesSelectButtons
+						tier={ this.props.tier }
+						options={ tiers }
+						onSelect={ this.props.select }
+					/>
+				</SectionNav>
 			</div>
 		);
 	}

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -80,7 +80,7 @@ const ThemesSearchCard = React.createClass( {
 	renderMobile( tiers ) {
 		const isJetpack = this.props.site && this.props.site.jetpack;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
-		const isMagicSearchEnabled = config.isEnabled( 'manage/themes/m5' );
+		const isMagicSearchEnabled = config.isEnabled( 'manage/themes/magic_search' );
 		const selectedTiers = isPremiumThemesEnabled ? tiers : [ tiers.find( tier => tier.value === 'free' ) ];
 
 		return (

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -125,8 +125,7 @@ const ThemesSearchCard = React.createClass( {
 	},
 
 	onBlur() {
-		const searchString = this.refs['url-search'].getCurrentSearchValue();
-		if ( searchString === "" ) {
+		if ( this.state.isMobile ) {//searchString === "" ) {
 			this.setState( { searchIsOpen : false } );
 		}
 	},
@@ -158,6 +157,7 @@ const ThemesSearchCard = React.createClass( {
 				onSearchClose={ isMagicSearchEnabled ? this.onSearchClose : noop }
 				onBlur={ isMagicSearchEnabled ? this.onBlur : noop }
 				fitsContainer={ this.state.isMobile && this.state.searchIsOpen }
+				hideCloseOnMobile={ isMagicSearchEnabled }
 			/>
 		);
 

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -127,7 +127,7 @@ const ThemesSearchCard = React.createClass( {
 			return this.renderMobile( tiers );
 		}
 
-		const search = (
+		const searchField = (
 			<Search
 				onSearch={ this.props.onSearch }
 				initialValue={ this.props.search }
@@ -144,7 +144,7 @@ const ThemesSearchCard = React.createClass( {
 			searchCard = (
 				<div className="themes__search-card" data-tip-target="themes-search-card">
 					<SectionNav selectedText={ this.getSelectedTierFormatted( tiers ) }>
-						{ search }
+						{ searchField }
 						{ isPremiumThemesEnabled && ! isJetpack &&
 							<ThemesSelectButtons
 								tier={ this.props.tier }
@@ -158,7 +158,7 @@ const ThemesSearchCard = React.createClass( {
 		} else {
 			searchCard = (
 				<div className="themes__search-card" data-tip-target="themes-search-card">
-					{ search }
+					{ searchField }
 					{ isPremiumThemesEnabled && ! isJetpack &&
 						<ThemesSelectDropdown
 							tier={ this.props.tier }

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -157,7 +157,7 @@ const ThemesSearchCard = React.createClass( {
 				onSearchClose={ isMagicSearchEnabled ? this.onSearchClose : noop }
 				onBlur={ isMagicSearchEnabled ? this.onBlur : noop }
 				fitsContainer={ this.state.isMobile && this.state.searchIsOpen }
-				hideCloseOnMobile={ isMagicSearchEnabled }
+				hideClose={ isMagicSearchEnabled && isMobile() }
 			/>
 		);
 

--- a/client/my-sites/themes/themes-search-card/select-buttons.jsx
+++ b/client/my-sites/themes/themes-search-card/select-buttons.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import ReactDom from 'react-dom';
+
+/**
+ * Internal dependencies
+ */
+import SegmentedControl from 'components/segmented-control';
+
+const ThemesSelectButtons = React.createClass( {
+	propTypes: {
+		tier: React.PropTypes.string.isRequired,
+		options: React.PropTypes.array.isRequired,
+		onSelect: React.PropTypes.func.isRequired
+	},
+
+	render() {
+		return <SegmentedControl
+				options={ this.props.options }
+				initialSelected={ this.props.tier }
+				onSelect={ this.props.onSelect } />;
+	},
+
+} );
+
+export default ThemesSelectButtons;

--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -1,5 +1,6 @@
 .themes__search-card {
 	display: flex;
+	align-items: center;
 	background: white;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
 

--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -25,6 +25,10 @@
 		align-self: center;
 	}
 
+	.segmented-control {
+		padding: 11px 14px 11px;
+	}
+
 	.more {
 		line-height: 18px;
 		padding: 11px 14px 11px;

--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -27,6 +27,7 @@
 	}
 
 	.segmented-control {
+		flex: 0 0 auto;
 		padding: 11px 14px 11px;
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -85,7 +85,7 @@
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
-		"manage/themes/m5": true,
+		"manage/themes/magic_search": true,
 		"me/account": true,
 		"me/billing-history": true,
 		"me/find-friends": false,

--- a/config/development.json
+++ b/config/development.json
@@ -85,6 +85,7 @@
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
+		"manage/themes/m5": true,
 		"me/account": true,
 		"me/billing-history": true,
 		"me/find-friends": false,


### PR DESCRIPTION
Repleacing dropdown choice in `/design` with buttons. New look:

![new_design](https://cloud.githubusercontent.com/assets/17271089/17352939/7018a956-593b-11e6-9522-075c692e19cc.png)

Feature hidden behind feature flag - enabled in dev. 
`More` button removed.

https://calypso.live/design?branch=update/add-free-premium-all-buttons-to-search-bar

Closes #6774