### PR TITLE
Desktop: fix reloading on page change

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -38,21 +38,16 @@ module.exports = {
 		const loggedOutRoutes = [ '/login', '/oauth', '/start', '/authorize', '/api/oauth/token' ],
 			isValidSection = loggedOutRoutes.some( route => startsWith( context.path, route ) );
 
-		if ( config( 'env_id' ) === 'desktop' ) {
-			// Check we have an OAuth token, otherwise redirect to login page
-			if ( OAuthToken.getToken() === false && ! isValidSection ) {
+		// Check we have an OAuth token, otherwise redirect to auth/login page
+		if ( OAuthToken.getToken() === false && ! isValidSection ) {
+			if ( config( 'env_id' ) === 'desktop' ) {
 				return page( '/login' );
-			} else {
-				next();
 			}
+
+			return page( '/authorize' );
 		}
 
-		// Check we have an OAuth token, otherwise redirect to auth page
-		if ( OAuthToken.getToken() === false && ! isValidSection ) {
-			return page( '/authorize' );
-		} else {
-			next();
-		}
+		next();
 	},
 
 	// This controller renders the API authentication screen


### PR DESCRIPTION
#7121 which sent the desktop app to the correct login page revealed a bug that was missed that causes `next()` to be called twice. This PR refactors the logic so the token is first checked, and then we determine which page to redirect to. This results in only one possible `next()` call.

Checked in desktop app which fixes https://github.com/Automattic/wp-desktop/issues/215, and checked in Calypso that OAuth login still works.

@mtias could you take a look again please?

Test live: https://calypso.live/?branch=fix/desktop-reload