### PR TITLE
Components: Refactor PostRelativeTimeStatus to separate connected components

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -10,6 +10,8 @@
 
 @import 'auth/style';
 @import 'blocks/post-item/style';
+@import 'blocks/post-relative-time/style';
+@import 'blocks/post-status/style';
 @import 'components/accordion/style';
 @import 'components/app-promo/style';
 @import 'blocks/author-selector/style';

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -12,15 +12,11 @@ import { localize } from 'i18n-calypso';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getNormalizedPost } from 'state/posts/selectors';
 import Card from 'components/card';
-import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
+import PostRelativeTime from 'blocks/post-relative-time';
+import PostStatus from 'blocks/post-status';
 import PostTypeListPostThumbnail from 'my-sites/post-type-list/post-thumbnail';
 import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellipsis-menu';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
-
-/**
- * Constants
- */
-const PLACEHOLDER_POST = { status: 'draft', modified: '2015-08-10T19:44:08+00:00' };
 
 function PostItem( { translate, globalId, post, editUrl, className } ) {
 	const title = post ? post.title : null;
@@ -39,7 +35,8 @@ function PostItem( { translate, globalId, post, editUrl, className } ) {
 						</a>
 					</h1>
 					<div className="post-item__meta">
-						<PostRelativeTimeStatus post={ post || PLACEHOLDER_POST } />
+						<PostRelativeTime globalId={ globalId } />
+						<PostStatus globalId={ globalId } />
 						<PostTypePostAuthor globalId={ globalId } />
 					</div>
 				</div>

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -50,23 +50,22 @@ a.post-item__title-link {
 	color: lighten( $gray, 10% );
 }
 
-.post-item__meta .post-relative-time-status,
+.post-item__meta .post-relative-time,
+.post-item__meta .post-status,
 .post-item__meta .post-type-post-author {
 	float: left;
+	margin-right: 12px;
 }
 
-.post-item__meta .post-relative-time-status {
+.post-item__meta .post-relative-time,
+.post-item__meta .post-status {
 	margin-bottom: 0;
-
-
-	.post-item.is-placeholder & {
-		@include placeholder;
-	}
 }
 
-.post-item__meta .post-relative-time-status .gridicon {
+.post-item__meta .post-relative-time__icon,
+.post-item__meta .post-status__icon {
 	width: 14px;
 	height: 14px;
-	margin-top: -3px;
+	margin-top: -1px;
 	margin-right: 6px;
 }

--- a/client/blocks/post-relative-time/README.md
+++ b/client/blocks/post-relative-time/README.md
@@ -1,0 +1,27 @@
+Post Relative Time
+==================
+
+`<PostRelativeTime />` is a React component for rendering the published or modified date of a post in human-readable relative terms.
+
+## Usage
+
+Render the component, passing the global ID of a post:
+
+```js
+function MyPost() {
+	return <PostRelativeTime globalId="e532356fdb689509a1a5149072e8aafc" />
+}
+```
+
+`<PostRelativeTime />` does not render a [query component](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#query-components), so you should ensure that the post is already loaded into global state. If the post cannot be found, the component will be shown with placeholder styles with the assumption that this indicates the post is being requested. If you do not want the placeholder styles to be used, do not render the component until the global ID is known.
+
+## Props
+
+### `globalId`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The global ID of the post. If omitted or the associated post cannot be found in global state, the component is shown with placeholder styling.

--- a/client/blocks/post-relative-time/docs/example.jsx
+++ b/client/blocks/post-relative-time/docs/example.jsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import QueryPosts from 'components/data/query-posts';
+import Card from 'components/card';
+import PostRelativeTime from '../';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { getSitePosts } from 'state/posts/selectors';
+
+function PostRelativeTimeExample( { primarySiteId, primarySiteUrl, globalId } ) {
+	return (
+		<div className="docs__design-assets-group">
+			<h2>
+				<a href="/devdocs/blocks/post-relative-time">Post Relative Time</a>
+			</h2>
+			<Card>
+				{ primarySiteUrl && (
+					<p><small>Example uses result from primary site <strong>{ primarySiteUrl }</strong></small></p>
+				) }
+				{ primarySiteId && (
+					<QueryPosts
+						siteId={ primarySiteId }
+						query={ { number: 1, type: 'any' } } />
+				) }
+				{ ! globalId && <em>No matching post found</em> }
+				{ globalId && <PostRelativeTime globalId={ globalId } /> }
+			</Card>
+		</div>
+	);
+}
+
+const ConnectedPostRelativeTimeExample = connect( ( state ) => {
+	const user = getCurrentUser( state );
+	const primarySiteId = get( user, 'primary_blog' );
+
+	return {
+		primarySiteId,
+		primarySiteUrl: get( user, 'primary_blog_url' ),
+		globalId: get( getSitePosts( state, primarySiteId ), [ 0, 'global_ID' ] )
+	};
+} )( PostRelativeTimeExample );
+
+ConnectedPostRelativeTimeExample.displayName = 'PostRelativeTime';
+
+export default ConnectedPostRelativeTimeExample;

--- a/client/blocks/post-relative-time/index.jsx
+++ b/client/blocks/post-relative-time/index.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { includes } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import { getNormalizedPost } from 'state/posts/selectors';
+
+function PostRelativeTime( { moment, post } ) {
+	let time;
+	if ( post ) {
+		const { status, modified, date } = post;
+		time = includes( [ 'draft', 'pending' ], status ) ? modified : date;
+	}
+
+	const classes = classNames( 'post-relative-time', {
+		'is-placeholder': ! post
+	} );
+
+	return (
+		<span className={ classes }>
+			<Gridicon
+				icon="time"
+				size={ 18 }
+				className="post-relative-time__icon" />
+			<span className="post-relative-time__text">
+				{ moment( time ).fromNow() }
+			</span>
+		</span>
+	);
+}
+
+PostRelativeTime.propTypes = {
+	globalId: PropTypes.string,
+	moment: PropTypes.func,
+	post: PropTypes.object
+};
+
+export default connect( ( state, { globalId } ) => {
+	return {
+		post: getNormalizedPost( state, globalId )
+	};
+} )( localize( PostRelativeTime ) );

--- a/client/blocks/post-relative-time/style.scss
+++ b/client/blocks/post-relative-time/style.scss
@@ -1,0 +1,26 @@
+.post-relative-time.is-placeholder {
+	@include placeholder;
+}
+
+.post-relative-time,
+.post-relative-time__icon,
+.post-relative-time__text {
+	display: inline-block;
+}
+
+.post-relative-time__icon {
+	margin-right: 8px;
+}
+
+.post-relative-time__icon,
+.post-relative-time__text {
+	vertical-align: middle;
+}
+
+.post-relative-time__text {
+	line-height: 1;
+
+	&::first-letter {
+		text-transform: capitalize;
+	}
+}

--- a/client/blocks/post-status/README.md
+++ b/client/blocks/post-status/README.md
@@ -1,0 +1,27 @@
+Post Status
+===========
+
+`<PostStatus />` is a React component for rendering relevant status details about a post (sticky, scheduled, pending review, trashed). Renders nothing if there is no relevant status for the post.
+
+## Usage
+
+Render the component, passing the global ID of a post:
+
+```js
+function MyPost() {
+	return <PostStatus globalId="e532356fdb689509a1a5149072e8aafc" />
+}
+```
+
+`<PostStatus />` does not render a [query component](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#query-components), so you should ensure that the post is already loaded into global state. If the post cannot be found, nothing will be rendered.
+
+## Props
+
+### `globalId`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The global ID of the post. If omitted or the associated post cannot be found in global state, the component returns null.

--- a/client/blocks/post-status/docs/example.jsx
+++ b/client/blocks/post-status/docs/example.jsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { map, mapValues, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import QueryPosts from 'components/data/query-posts';
+import Card from 'components/card';
+import PostStatus from '../';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { getSitePostsForQuery } from 'state/posts/selectors';
+
+function PostStatusExample( { queries, primarySiteId, primarySiteUrl, globalIdByQueryLabel } ) {
+	return (
+		<div className="docs__design-assets-group">
+			<h2>
+				<a href="/devdocs/blocks/post-status">Post Status</a>
+			</h2>
+			<Card>
+				{ primarySiteUrl && (
+					<p><small>Examples use results from primary site <strong>{ primarySiteUrl }</strong></small></p>
+				) }
+				{ map( queries, ( query, label ) => {
+					return (
+						<p key={ label }>
+							<h3>{ label }</h3>
+							{ primarySiteId && (
+								<QueryPosts
+									siteId={ primarySiteId }
+									query={ query } />
+							) }
+							{ ! globalIdByQueryLabel[ label ] && <em>No matching post found</em> }
+							<PostStatus globalId={ globalIdByQueryLabel[ label ] } />
+						</p>
+					);
+				} ) }
+			</Card>
+		</div>
+	);
+}
+
+const ConnectedPostStatusExample = connect( ( state ) => {
+	const user = getCurrentUser( state );
+	const primarySiteId = get( user, 'primary_blog' );
+	const queries = {
+		Scheduled: { status: 'future', number: 1, type: 'any' },
+		Trashed: { status: 'trash', number: 1, type: 'any' },
+		'Pending Review': { status: 'pending', number: 1, type: 'any' },
+		Sticky: { sticky: 'require', number: 1, type: 'any' }
+	};
+
+	return {
+		queries,
+		primarySiteId,
+		primarySiteUrl: get( user, 'primary_blog_url' ),
+		globalIdByQueryLabel: mapValues( queries, ( query ) => {
+			return get( getSitePostsForQuery( state, primarySiteId, query ), [ 0, 'global_ID' ] );
+		} )
+	};
+} )( PostStatusExample );
+
+ConnectedPostStatusExample.displayName = 'PostStatus';
+
+export default ConnectedPostStatusExample;

--- a/client/blocks/post-status/index.jsx
+++ b/client/blocks/post-status/index.jsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import { getNormalizedPost } from 'state/posts/selectors';
+
+function PostStatus( { translate, post } ) {
+	if ( ! post ) {
+		return null;
+	}
+
+	const { sticky, status } = post;
+	let text, classModifier, icon;
+	if ( sticky ) {
+		text = translate( 'Sticky' );
+		classModifier = 'is-sticky';
+		icon = 'bookmark-outline';
+	} else if ( 'pending' === status ) {
+		text = translate( 'Pending Review' );
+		classModifier = 'is-pending';
+		icon = 'aside';
+	} else if ( 'future' === status ) {
+		text = translate( 'Scheduled' );
+		classModifier = 'is-scheduled';
+		icon = 'calendar';
+	} else if ( 'trash' === status ) {
+		text = translate( 'Trashed' );
+		classModifier = 'is-trash';
+		icon = 'trash';
+	}
+
+	if ( ! text ) {
+		return null;
+	}
+
+	const classes = classNames( 'post-status', classModifier );
+
+	return (
+		<span className={ classes }>
+			<Gridicon
+				icon={ icon }
+				size={ 18 }
+				className="post-status__icon" />
+			<span className="post-status__text">
+				{ text }
+			</span>
+		</span>
+	);
+}
+
+PostStatus.propTypes = {
+	globalId: PropTypes.string,
+	translate: PropTypes.func,
+	post: PropTypes.object
+};
+
+export default connect( ( state, { globalId } ) => {
+	return {
+		post: getNormalizedPost( state, globalId )
+	};
+} )( localize( PostStatus ) );

--- a/client/blocks/post-status/style.scss
+++ b/client/blocks/post-status/style.scss
@@ -1,0 +1,18 @@
+.post-status,
+.post-status__icon,
+.post-status__text {
+	display: inline-block;
+}
+
+.post-status__icon,
+.post-status__text {
+	vertical-align: middle;
+}
+
+.post-status__icon {
+	margin-right: 8px;
+}
+
+.post-status__text {
+	line-height: 1;
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -30,6 +30,8 @@ import FeatureComparison from 'my-sites/feature-comparison/docs/example';
 import DomainTip from 'my-sites/domain-tip/docs/example';
 import PostCard from 'components/post-card/docs/example';
 import PostItem from 'blocks/post-item/docs/example';
+import PostRelativeTime from 'blocks/post-relative-time/docs/example';
+import PostStatus from 'blocks/post-status/docs/example';
 import ReaderAuthorLink from 'components/reader-author-link/docs/example';
 import ReaderSiteStreamLink from 'components/reader-site-stream-link/docs/example';
 import ReaderFullPostHeader from 'components/reader-full-post/docs/header-example';
@@ -85,6 +87,8 @@ export default React.createClass( {
 					<DomainTip />
 					<PostCard />
 					<PostItem />
+					<PostRelativeTime />
+					<PostStatus />
 					<ReaderAuthorLink />
 					<ReaderSiteStreamLink />
 					<ReaderFullPostHeader />


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/pull/6707#issuecomment-233398323 (cc @mtias)

This pull request seeks to refactor the [`<PostRelativeTimeStatus />` component](https://github.com/Automattic/wp-calypso/tree/master/client/my-sites/post-relative-time-status), responsible for displaying the relative time and status of a post, into two separate and rewritten `<PostRelativeTime />` and `<PostStatus />` connected components.

- [See README.md for `<PostRelativeTime />`](https://github.com/Automattic/wp-calypso/blob/b381cc959dd7a363599fe6da209d1ec6a542cf7a/client/blocks/post-relative-time/README.md)
- [See README.md for `<PostStatus />`](https://github.com/Automattic/wp-calypso/blob/b381cc959dd7a363599fe6da209d1ec6a542cf7a/client/blocks/post-status/README.md)

__Testing instructions:__

Verify that the relative time and status components display as expected.

- [`<PostRelativeTime />` DevDocs Example](http://calypso.localhost:3000/devdocs/blocks/post-relative-time)
- [`<PostStatus />` DevDocs Example](http://calypso.localhost:3000/devdocs/blocks/post-status)

These components are currently used on the [custom post types list screen](http://calypso.localhost:3000/types/post), so additionally verify that there are no visual regressions in either the placeholder state or loaded post visuals.

__Follow-up Tasks:__

There are only a handful of remaining occurrences of `<PostRelativeTimeStatus />`, and it should be reasonably easy to migrate them to these new components.

Test live: https://calypso.live/?branch=update/post-relative-time-status-blocks