### PR TITLE
Jetpack connect: Remove unused browse upgrades button

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -242,26 +242,28 @@ const LoggedInForm = React.createClass( {
 
 	handleSubmit() {
 		const {
-			siteReceived,
 			queryObject,
 			manageActivated,
 			activateManageSecret,
-			plansUrl,
 			authorizeError
 		} = this.props.jetpackConnectAuthorize;
 
 		if ( ! this.props.isAlreadyOnSitesList &&
 			queryObject.already_authorized ) {
-			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
-		} else 	if ( activateManageSecret && ! manageActivated ) {
-			this.activateManage();
-		} else if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
-			window.location.href = queryObject.site + authUrl;
-		} else if ( this.props.isAlreadyOnSitesList || ( siteReceived && plansUrl ) ) {
-			page( plansUrl );
-		} else {
-			this.props.authorize( queryObject );
+			return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		}
+		if ( activateManageSecret && ! manageActivated ) {
+			return this.activateManage();
+		}
+		if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
+			window.location.href = queryObject.site + authUrl;
+			return;
+		}
+		if ( this.props.isAlreadyOnSitesList ) {
+			return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
+		}
+
+		return this.props.authorize( queryObject );
 	},
 
 	handleSignOut() {
@@ -302,7 +304,6 @@ const LoggedInForm = React.createClass( {
 			isAuthorizing,
 			authorizeSuccess,
 			isRedirectingToWpAdmin,
-			siteReceived,
 			authorizeError
 		} = this.props.jetpackConnectAuthorize;
 
@@ -319,10 +320,6 @@ const LoggedInForm = React.createClass( {
 			return this.translate( 'Preparing authorization' );
 		}
 
-		if ( this.props.isAlreadyOnSitesList || siteReceived ) {
-			return this.translate( 'Browse Available Upgrades' );
-		}
-
 		if ( authorizeSuccess && isRedirectingToWpAdmin ) {
 			return this.translate( 'Returning to your site' );
 		}
@@ -335,6 +332,10 @@ const LoggedInForm = React.createClass( {
 
 		if ( isAuthorizing ) {
 			return this.translate( 'Authorizing your connection' );
+		}
+
+		if ( this.props.isAlreadyOnSitesList ) {
+			return this.translate( 'Return to your site' );
 		}
 
 		return this.translate( 'Approve' );


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/7014

In an early version of Jetpack Connect, there was this 'browse upgrades' button that we were showing to the users once they fulfilled certain conditions. That use case was removed, but the code showing the button remained.

Certain hard to reproduce failing states are now fulfilling this conditions and showing a (non working) button, causing confusion. This PR removes this button and introduces a fallback, a working "return to your site" one.

How to test
========

To be honest, I don't know. This button shouldn't be shown anywhere in the process, and I'm only able to see it working if I manually trigger those error conditions. One way of triggering it is connect a site, and copy the url of the redirection you get just after the flow comes back from your wp-admin (the one that looks like `http://calypso.localhost:3000/jetpack/connect/authorize?client_id=10333333&redirect_uri=https%3A%2F%2Fjohnpercivalhackworth.wpsandbox.me%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack%26action%3Dauthorize%26_wpnonce%3D6sdgasdg997%26redirect%3Dhttps%253A%252F%252Fjohnpercivalhackworth.wpsandbox.me%252Fwp-admin%252Fadmin.php%253Fpage%253Djetpack&state=1&scope=administrator%3Ada8ad66bbc3713db6906dacf1321907f&user_email=javi.alvarez%2Btest%40automattic.com&jp_version=4.1.1&secret=asdgasgdasgasgasdgasdgasdgsgasdgasg&locale&blogname=javi%26%23039%3Bs+jetpack+site&site_url=https%3A%2F%2Fjohnpercivalhackworth.wpsandbox.me&home_url=http%3A%2F%2Fjohnpercivalhackworth.wpsandbox.me&site_icon=http%3A%2F%2Fjohnpercivalhackworth.wpsandbox.me%2Fwp-content%2Fuploads%2F2016%2F06%2Fcropped-IMG_20160602_202249-1.jpg&from=iframe&calypso_env=development&already_authorized=false&_wp_nonce=111111&redirect_after_auth=https%3A%2F%2Fjohnpercivalhackworth.wpsandbox.me%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack&site=https%3A%2F%2Fjohnpercivalhackworth.wpsandbox.mep` 

Once your site is connected, visit http://calypso.localhost:3000/jetpack/connect and wait some seconds so your local calypso sites list is refreshed, and then try that url again. It should show you a "preparing connection" message while it fetches the sites again and then show a "return to your site" button instead of the previous "browse upgrades" one 

ping @roccotripaldi 

Test live: https://calypso.live/?branch=fix/jpc-remove-browse-sites-button