### PR TITLE
Framework: Substitute debug with noop in production

### DIFF
--- a/client/lib/debug-noop/README.md
+++ b/client/lib/debug-noop/README.md
@@ -1,0 +1,4 @@
+Debug Noop
+==========
+
+Debug Noop is a simple [noop](https://en.wikipedia.org/wiki/NOP) intended for use as a drop-in substitute for the [`debug` module](http://npmjs.com/package/debug) in production Webpack configurations using the [`webpack.NormalModuleReplacementPlugin` plugin](https://webpack.github.io/docs/list-of-plugins.html#normalmodulereplacementplugin).

--- a/client/lib/debug-noop/index.js
+++ b/client/lib/debug-noop/index.js
@@ -1,0 +1,1 @@
+export default () => () => {};

--- a/client/lib/debug-noop/index.js
+++ b/client/lib/debug-noop/index.js
@@ -1,1 +1,3 @@
+/** @ssr-ready **/
+
 export default () => () => {};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -144,6 +144,13 @@ if ( CALYPSO_ENV === 'development' ) {
 	webpackConfig.devtool = false;
 }
 
+if ( CALYPSO_ENV === 'production' ) {
+	webpackConfig.plugins.push( new webpack.NormalModuleReplacementPlugin(
+		/^debug$/,
+		path.join( __dirname, 'client', 'lib', 'debug-noop' )
+	) );
+}
+
 webpackConfig.module.loaders = [ jsLoader ].concat( webpackConfig.module.loaders );
 
 module.exports = webpackConfig;


### PR DESCRIPTION
This pull request seeks to update our Webpack configuration to perform module substitution on the `debug` module to a noop in production environments.

This appears to save about 11kb from the vendor bundle in production environments before minification.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/17341892/ba006f4e-58c4-11e6-98b2-c6f76e879fa8.png)|![After](https://cloud.githubusercontent.com/assets/1779930/17341893/ba0281ee-58c4-11e6-9458-64bdf879143b.png)

__Testing instructions:__

Rather than running production locally, might be easiest to simply change the environment condition in your local checkout to include the plugin in `development` environments, verifying that no errors occur and no debug statements are output.

Test live: https://calypso.live/?branch=add/debug-production-noop