### PR TITLE
Terms: fix regression of no search results in TermTreeSelector

### DIFF
--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -69,7 +69,7 @@ export const getTermsForQuery = createSelector(
 
 		return manager.getItems( query );
 	},
-	( state, siteId, taxonomy ) => getTerms( state, siteId, taxonomy ),
+	( state, siteId, taxonomy ) => get( state.terms.queries, [ siteId, taxonomy ] ),
 	( state, siteId, taxonomy, query ) => {
 		const serializedQuery = getSerializedTermsQuery( query );
 		return [ siteId, taxonomy, serializedQuery ].join();
@@ -95,7 +95,7 @@ export const getTermsForQueryIgnoringPage = createSelector(
 
 		return manager.getItemsIgnoringPage( query );
 	},
-	( state, siteId, taxonomy ) => getTerms( state, siteId, taxonomy ),
+	( state, siteId, taxonomy ) => get( state.terms.queries, [ siteId, taxonomy ] ),
 	( state, siteId, taxonomy, query ) => {
 		const serializedQuery = getSerializedTermsQueryWithoutPage( query );
 		return [ siteId, taxonomy, serializedQuery ].join();


### PR DESCRIPTION
A regression was introduced in #6661 due to the `createSelector` dependent being tied to the array of taxonomy terms - which when passed through `shallowEqual` in the `createSelector` logic does not trigger the cache to be invalidated at times.

__Reproduce The Issue__
It might be best to first see the issue in action on production.  It is best seen when working in the Menu Builder for a site that has less than 100 categories.

- Open the menu builder
- Add or edit a menu item and select Category
- Use the search/filter box to search for a category name you know exists
- Sometimes the term will not be shown, other times it will be shown
- Remove the last character of your search using backspace, the term should still show, but does not

![search-terms-bug](https://cloud.githubusercontent.com/assets/22080/17342021/2d2138be-58ac-11e6-9863-fb5b4d744ca6.gif)

__The Fix__
In this branch I changed the dependent parameter of `getTermsForQueryIgnoringPage` to be that of the query manager itself.  This seems to invalidate the `createSelector` cache properly since a new `QueryManager` instance is created when it receives a different query result.

__To Test__
Repeat the steps above and confirm that terms are shown properly when searching.

/cc @aduth 

Test live: https://calypso.live/?branch=fix/term-selector-search