### PR TITLE
Jetpack Sync: Update selector and reducer to use new values in API

### DIFF
--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -104,8 +104,8 @@ function getSyncProgressPercentage( state, siteId ) {
 		return sum += value;
 	}, 0 );
 
-	const percentQueued = Math.ceil( countQueued / countTotal * queuedMultiplier * 100 );
-	const percentSent = Math.ceil( countSent / countTotal * sentMultiplier * 100 );
+	const percentQueued = countQueued / countTotal * queuedMultiplier * 100;
+	const percentSent = countSent / countTotal * sentMultiplier * 100;
 
 	return Math.ceil( percentQueued + percentSent );
 }

--- a/client/state/jetpack-sync/selectors.js
+++ b/client/state/jetpack-sync/selectors.js
@@ -81,11 +81,14 @@ function isFullSyncing( state, siteId ) {
  * @return {Number}          The percentage of sync completed, expressed as an integer
  */
 function getSyncProgressPercentage( state, siteId ) {
-	const syncStatus = getSyncStatus( state, siteId );
-	const queued = get( syncStatus, 'queue' );
-	const sent = get( syncStatus, 'sent' );
+	const syncStatus = getSyncStatus( state, siteId ),
+		queued = get( syncStatus, 'queue' ),
+		sent = get( syncStatus, 'sent' ),
+		total = get( syncStatus, 'total' ),
+		queuedMultiplier = 0.1,
+		sentMultiplier = 0.9;
 
-	if ( isPendingSyncStart( state, siteId ) || ! queued || ! sent ) {
+	if ( isPendingSyncStart( state, siteId ) || ! queued || ! sent || ! total ) {
 		return 0;
 	}
 
@@ -97,7 +100,14 @@ function getSyncProgressPercentage( state, siteId ) {
 		return sum += value;
 	}, 0 );
 
-	return Math.ceil( countSent / countQueued * 100 );
+	const countTotal = reduce( total, ( sum, value ) => {
+		return sum += value;
+	}, 0 );
+
+	const percentQueued = Math.ceil( countQueued / countTotal * queuedMultiplier * 100 );
+	const percentSent = Math.ceil( countSent / countTotal * sentMultiplier * 100 );
+
+	return Math.ceil( percentQueued + percentSent );
 }
 
 export default {

--- a/client/state/jetpack-sync/test/reducer.js
+++ b/client/state/jetpack-sync/test/reducer.js
@@ -28,34 +28,59 @@ const successfulSyncStatusRequest = {
 	type: JETPACK_SYNC_STATUS_SUCCESS,
 	siteId: 1234567,
 	data: {
-		started: 1466010260,
-		queue_finished: 1466010260,
-		sent_started: 1466010290,
-		finished: 1466010313,
+		started: 1470085369,
+		queue_finished: 1470085370,
+		sent_started: 1470085392,
+		finished: 1470087342,
+		total: {
+			constants: 1,
+			functions: 1,
+			options: 1,
+			terms: 25,
+			themes: 1,
+			users: 1,
+			posts: 402,
+			comments: 28,
+			updates: 1
+		},
 		queue: {
 			constants: 1,
 			functions: 1,
 			options: 1,
-			terms: 3,
+			terms: 25,
 			themes: 1,
-			users: 2,
-			posts: 15,
-			comments: 1,
-			updates: 6
+			users: 1,
+			posts: 402,
+			comments: 28,
+			updates: 1
 		},
 		sent: {
 			constants: 1,
 			functions: 1,
 			options: 1,
-			terms: 3,
+			terms: 25,
 			themes: 1,
-			users: 2,
-			posts: 15,
-			comments: 1
+			users: 1,
+			posts: 193
 		},
+		config: {
+			constants: true,
+			functions: true,
+			options: true,
+			terms: true,
+			themes: true,
+			users: true,
+			posts: true,
+			comments: true,
+			updates: true
+		},
+		queue_size: 0,
+		queue_lag: 0,
+		full_queue_size: 239,
+		full_queue_lag: 957.49082708359,
 		is_scheduled: false,
 		_headers: {
-			Date: 'Wed, 15 Jun 2016 17:05:26 GMT',
+			Date: 'Mon, 01 Aug 2016 21:18:47 GMT',
 			'Content-Type': 'application/json'
 		}
 	}
@@ -65,32 +90,55 @@ const inProgressSyncStatusRequest = {
 	type: JETPACK_SYNC_STATUS_SUCCESS,
 	siteId: 1234567,
 	data: {
-		started: 1467998622,
-		queue_finished: 1467998622,
-		sent_started: 1467999200,
+		started: 1470069379,
+		queue_finished: 1470069380,
+		sent_started: 1470069405,
+		total: {
+			constants: 1,
+			functions: 1,
+			options: 1,
+			terms: 25,
+			themes: 1,
+			users: 1,
+			posts: 402,
+			comments: 28,
+			updates: 1
+		},
 		queue: {
 			constants: 1,
 			functions: 1,
 			options: 1,
-			terms: 1,
+			terms: 25,
 			themes: 1,
 			users: 1,
-			posts: 102,
-			comments: 1,
+			posts: 402,
+			comments: 28,
 			updates: 1
 		},
 		sent: {
 			constants: 1,
 			functions: 1,
 			options: 1,
-			terms: 1,
-			themes: 1,
-			users: 1,
-			posts: 25
+			terms: 2
 		},
+		config: {
+			constants: true,
+			functions: true,
+			options: true,
+			terms: true,
+			themes: true,
+			users: true,
+			posts: true,
+			comments: true,
+			updates: true
+		},
+		queue_size: 0,
+		queue_lag: 0,
+		full_queue_size: 457,
+		full_queue_lag: 33.257718086243,
 		is_scheduled: false,
 		_headers: {
-			Date: 'Wed, 15 Jun 2016 17:05:26 GMT',
+			Date: 'Mon, 01 Aug 2016 16:36:53 GMT',
 			'Content-Type': 'application/json'
 		}
 	}

--- a/client/state/jetpack-sync/test/selectors.js
+++ b/client/state/jetpack-sync/test/selectors.js
@@ -24,67 +24,113 @@ const syncStartedSiteId = '87654321';
 const syncInProgressSiteId = '7654321';
 
 const syncStatusSuccessful = {
-	isRequesting: false,
-	error: false,
-	lastSuccessfulStatus: 1467926563436,
-	started: 1466010260,
-	queue_finished: 1466010260,
-	sent_started: 1466010290,
-	finished: 1466010313,
+	started: 1470085369,
+	queue_finished: 1470085370,
+	sent_started: 1470085392,
+	finished: 1470087342,
+	total: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 25,
+		themes: 1,
+		users: 1,
+		posts: 402,
+		comments: 28,
+		updates: 1
+	},
 	queue: {
 		constants: 1,
 		functions: 1,
 		options: 1,
-		terms: 3,
+		terms: 25,
 		themes: 1,
-		users: 2,
-		posts: 15,
-		comments: 1,
-		updates: 6
+		users: 1,
+		posts: 402,
+		comments: 28,
+		updates: 1
 	},
 	sent: {
 		constants: 1,
 		functions: 1,
 		options: 1,
-		terms: 3,
+		terms: 25,
 		themes: 1,
-		users: 2,
-		posts: 15,
-		comments: 1
+		users: 1,
+		posts: 193
 	},
-	is_scheduled: false
+	config: {
+		constants: true,
+		functions: true,
+		options: true,
+		terms: true,
+		themes: true,
+		users: true,
+		posts: true,
+		comments: true,
+		updates: true
+	},
+	queue_size: 0,
+	queue_lag: 0,
+	full_queue_size: 239,
+	full_queue_lag: 957.49082708359,
+	is_scheduled: false,
+	lastSuccessfulStatus: 1470087342000
 };
 
 const syncStatusScheduled = {
-	isRequesting: false,
-	error: false,
-	lastSuccessfulStatus: 1467926563436,
-	started: 1466010260,
-	queue_finished: 1466010260,
-	sent_started: 1466010290,
-	finished: 1466010313,
+	started: 1470085369,
+	queue_finished: 1470085370,
+	sent_started: 1470085392,
+	finished: 1470087342,
+	total: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 25,
+		themes: 1,
+		users: 1,
+		posts: 402,
+		comments: 28,
+		updates: 1
+	},
 	queue: {
 		constants: 1,
 		functions: 1,
 		options: 1,
-		terms: 3,
+		terms: 25,
 		themes: 1,
-		users: 2,
-		posts: 15,
-		comments: 1,
-		updates: 6
+		users: 1,
+		posts: 402,
+		comments: 28,
+		updates: 1
 	},
 	sent: {
 		constants: 1,
 		functions: 1,
 		options: 1,
-		terms: 3,
+		terms: 25,
 		themes: 1,
-		users: 2,
-		posts: 15,
-		comments: 1
+		users: 1,
+		posts: 193
 	},
-	is_scheduled: true
+	config: {
+		constants: true,
+		functions: true,
+		options: true,
+		terms: true,
+		themes: true,
+		users: true,
+		posts: true,
+		comments: true,
+		updates: true
+	},
+	queue_size: 0,
+	queue_lag: 0,
+	full_queue_size: 239,
+	full_queue_lag: 957.49082708359,
+	is_scheduled: true,
+	lastSuccessfulStatus: 1470087343000
 };
 
 const syncStatusErrored = {
@@ -95,48 +141,99 @@ const syncStatusErrored = {
 };
 
 const syncStatusStarted = {
-	started: 1467998622,
-	queue_finished: 1467998622,
+	started: 1470163982,
+	queue_finished: 1470163982,
+	total: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 25,
+		themes: 1,
+		users: 1,
+		posts: 404,
+		comments: 27,
+		updates: 1
+	},
 	queue: {
 		constants: 1,
 		functions: 1,
 		options: 1,
-		terms: 1,
+		terms: 25,
 		themes: 1,
 		users: 1,
-		posts: 102,
-		comments: 1,
+		posts: 404,
+		comments: 27,
 		updates: 1
 	},
 	sent: [],
-	is_scheduled: false
+	config: {
+		constants: true,
+		functions: true,
+		options: true,
+		terms: true,
+		themes: true,
+		users: true,
+		posts: true,
+		comments: true,
+		updates: true
+	},
+	queue_size: 0,
+	queue_lag: 0,
+	full_queue_size: 464,
+	full_queue_lag: 4.1990218162537,
+	is_scheduled: false,
+	lastSuccessfulStatus: 1470163983000
 };
 
 const syncStatusInProgress = {
-	started: 1467998622,
-	queue_finished: 1467998622,
-	sent_started: 1467999200,
+	started: 1470069379,
+	queue_finished: 1470069380,
+	sent_started: 1470069405,
+	total: {
+		constants: 1,
+		functions: 1,
+		options: 1,
+		terms: 25,
+		themes: 1,
+		users: 1,
+		posts: 402,
+		comments: 28,
+		updates: 1
+	},
 	queue: {
 		constants: 1,
 		functions: 1,
 		options: 1,
-		terms: 1,
+		terms: 25,
 		themes: 1,
 		users: 1,
-		posts: 102,
-		comments: 1,
+		posts: 402,
+		comments: 28,
 		updates: 1
 	},
 	sent: {
 		constants: 1,
 		functions: 1,
 		options: 1,
-		terms: 1,
-		themes: 1,
-		users: 1,
-		posts: 25
+		terms: 2
 	},
+	config: {
+		constants: true,
+		functions: true,
+		options: true,
+		terms: true,
+		themes: true,
+		users: true,
+		posts: true,
+		comments: true,
+		updates: true
+	},
+	queue_size: 0,
+	queue_lag: 0,
+	full_queue_size: 457,
+	full_queue_lag: 33.257718086243,
 	is_scheduled: false,
+	lastSuccessfulStatus: 1470069406000
 };
 
 const fullSyncRequested = {
@@ -148,7 +245,7 @@ const fullSyncRequestSuccessful = {
 	isRequesting: true,
 	scheduled: true,
 	error: false,
-	lastRequested: 1467944517955
+	lastRequested: 1470087343001
 };
 
 const fullSyncRequestOld = {
@@ -273,7 +370,7 @@ describe( 'selectors', () => {
 
 		it( 'should return a non-zero integer if site has sent data to be synced', () => {
 			const test = getSyncProgressPercentage( testState, syncInProgressSiteId );
-			expect( test ).to.be.eql( 29 )
+			expect( test ).to.be.eql( 11 )
 		} );
 	} );
 } );

--- a/client/state/jetpack-sync/utils.js
+++ b/client/state/jetpack-sync/utils.js
@@ -12,6 +12,12 @@ export function getExpectedResponseKeys() {
 		'finished',
 		'queue',
 		'sent',
-		'is_scheduled'
+		'is_scheduled',
+		'total',
+		'config',
+		'queue_size',
+		'queue_lag',
+		'full_queue_size',
+		'full_queue_lag'
 	];
 }


### PR DESCRIPTION
We recently updated the `GET /sites/$site/sync/status` endpoint to add some information which should help us provide a better UI for sync status.

This PR takes advantage of this new information and updates the algorithm for determining how finished sync is (in percentage).

The new algorithm was suggested by @gravityrail and takes into account how much was queued as well as how much was sent in determining the percentage complete. This should allow us to show progress sooner to our users.

To test:

- Checkout `update/jetpack-full-sync-totals` branch
- Ensure tests pass
- Go to `/settings/general/$site` where `$site` is on the latest Jetpack `branch-4.2`
- Start a full sync
- Ensure that you see progress in the bar within a few seconds

cc @samhotchkiss @rickybanister @lezama for review/thoughts

Test live: https://calypso.live/?branch=update/jetpack-full-sync-totals