### PR TITLE
Add clickable row A/B test for Domain Suggestions

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -60,6 +60,7 @@ $z-layers: (
 		'.accessible-focus .current-theme__button:focus': 1,
 		'.signup-processing-screen__processing-step.is-processing:before': 1,
 		'.accessible-focus .theme__more-button button:focus': 1,
+		'.domain-suggestion.is-clickable:hover': 1,
 		'.reader-update-notice': 2,
 		'.people-list-item .card__link-indicator': 2,
 		'.updated-confirmation': 2,

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -64,7 +64,7 @@ const DomainSuggestion = React.createClass( {
 					{ clickableRow ? this.renderNonButton() : this.renderButton() }
 				</div>
 				{ clickableRow &&
-					<div className="domain-suggestion__chevron"><Gridicon icon="chevron-right" /></div> }
+					<Gridicon className="domain-suggestion__chevron" icon="chevron-right" /> }
 			</div>
 		);
 	}
@@ -83,7 +83,7 @@ DomainSuggestion.Placeholder = React.createClass( {
 				</div>
 				<div className={ clickableRow ? 'domain-suggestion__non-button-action' : 'domain-suggestion__action' } />
 				{ clickableRow &&
-					<div className="domain-suggestion__chevron"><Gridicon icon="chevron-right" /></div> }
+					<Gridicon className="domain-suggestion__chevron" icon="chevron-right" /> }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -8,6 +8,8 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import DomainProductPrice from 'components/domains/domain-product-price';
+import Gridicon from 'components/gridicon';
+import { abtest } from 'lib/abtest';
 
 const DomainSuggestion = React.createClass( {
 
@@ -34,22 +36,30 @@ const DomainSuggestion = React.createClass( {
 		);
 	},
 
+	renderNonButton() {
+		return (
+			<span>{ this.props.buttonContent } <Gridicon className="domain-suggestion__chevron" icon="chevron-right" /></span>
+		);
+	},
+
 	render() {
+		const clickableRow = true;//abtest( 'domainSuggestionClickableRow' ) === 'clickableRow';
 		const { price, isAdded, extraClasses, children, priceRule } = this.props;
 		let classes = classNames( 'domain-suggestion', 'card', 'is-compact', {
-			'is-added': isAdded
+			'is-added': isAdded,
+			'is-clickable': clickableRow,
 		}, extraClasses );
 
 		return (
-			<div className={ classes }>
+			<div className={ classes } onClick={ clickableRow ? this.props.onButtonClick : undefined }>
 				<div className="domain-suggestion__content">
 					{ children }
 					<DomainProductPrice
 						rule={ priceRule }
 						price={ price }/>
 				</div>
-				<div className="domain-suggestion__action">
-					{ this.renderButton() }
+				<div className={ clickableRow? 'domain-suggestion__non-button-action' : 'domain-suggestion__action' }>
+					{ clickableRow ? this.renderNonButton() : this.renderButton() }
 				</div>
 			</div>
 		);

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -62,8 +62,8 @@ const DomainSuggestion = React.createClass( {
 				<div className={ clickableRow ? 'domain-suggestion__non-button-action' : 'domain-suggestion__action' }>
 					{ clickableRow ? this.renderNonButton() : this.renderButton() }
 				</div>
-				{ clickableRow
-					&& <div className="domain-suggestion__chevron"><Gridicon icon="chevron-right" /></div> }
+				{ clickableRow &&
+					<div className="domain-suggestion__chevron"><Gridicon icon="chevron-right" /></div> }
 			</div>
 		);
 	}
@@ -81,8 +81,8 @@ DomainSuggestion.Placeholder = React.createClass( {
 					<h3 />
 				</div>
 				<div className={ clickableRow ? 'domain-suggestion__non-button-action' : 'domain-suggestion__action' } />
-				{ clickableRow
-					&& <div className="domain-suggestion__chevron"><Gridicon icon="chevron-right" /></div> }
+				{ clickableRow &&
+					<div className="domain-suggestion__chevron"><Gridicon icon="chevron-right" /></div> }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -37,9 +37,7 @@ const DomainSuggestion = React.createClass( {
 	},
 
 	renderNonButton() {
-		return (
-			<span>{ this.props.buttonContent } <Gridicon className="domain-suggestion__chevron" icon="chevron-right" /></span>
-		);
+		return this.props.buttonContent;
 	},
 
 	render() {
@@ -64,6 +62,8 @@ const DomainSuggestion = React.createClass( {
 				<div className={ clickableRow ? 'domain-suggestion__non-button-action' : 'domain-suggestion__action' }>
 					{ clickableRow ? this.renderNonButton() : this.renderButton() }
 				</div>
+				{ clickableRow
+					&& <div className="domain-suggestion__chevron"><Gridicon icon="chevron-right" /></div> }
 			</div>
 		);
 	}
@@ -71,12 +71,18 @@ const DomainSuggestion = React.createClass( {
 
 DomainSuggestion.Placeholder = React.createClass( {
 	render() {
+		const clickableRow = true;//abtest( 'domainSuggestionClickableRow' ) === 'clickableRow';
+		const classes = classNames( 'domain-suggestion', 'card', 'is-compact', 'is-placeholder', {
+			'is-clickable': clickableRow,
+		} );
 		return (
-			<div className="domain-suggestion card is-compact is-placeholder">
+			<div className={ classes }>
 				<div className="domain-suggestion__content">
 					<h3 />
 				</div>
-				<div className="domain-suggestion__action" />
+				<div className={ clickableRow ? 'domain-suggestion__non-button-action' : 'domain-suggestion__action' } />
+				{ clickableRow
+					&& <div className="domain-suggestion__chevron"><Gridicon icon="chevron-right" /></div> }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -41,7 +41,7 @@ const DomainSuggestion = React.createClass( {
 	},
 
 	render() {
-		const clickableRow = true;//abtest( 'domainSuggestionClickableRow' ) === 'clickableRow';
+		const clickableRow = abtest( 'domainSuggestionClickableRow' ) === 'clickableRow';
 		const { price, isAdded, extraClasses, children, priceRule } = this.props;
 		let classes = classNames( 'domain-suggestion', 'card', 'is-compact', {
 			'is-added': isAdded,
@@ -72,7 +72,7 @@ const DomainSuggestion = React.createClass( {
 
 DomainSuggestion.Placeholder = React.createClass( {
 	render() {
-		const clickableRow = true;//abtest( 'domainSuggestionClickableRow' ) === 'clickableRow';
+		const clickableRow = abtest( 'domainSuggestionClickableRow' ) === 'clickableRow';
 		const classes = classNames( 'domain-suggestion', 'card', 'is-compact', 'is-placeholder', {
 			'is-clickable': clickableRow,
 		} );

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -51,14 +51,17 @@ const DomainSuggestion = React.createClass( {
 		}, extraClasses );
 
 		return (
-			<div className={ classes } onClick={ clickableRow ? this.props.onButtonClick : undefined } aria-role={ clickableRow ? 'button' : undefined }>
+			<div
+				className={ classes }
+				onClick={ clickableRow ? this.props.onButtonClick : undefined }
+				aria-role={ clickableRow ? 'button' : undefined }>
 				<div className="domain-suggestion__content">
 					{ children }
 					<DomainProductPrice
 						rule={ priceRule }
 						price={ price }/>
 				</div>
-				<div className={ clickableRow? 'domain-suggestion__non-button-action' : 'domain-suggestion__action' }>
+				<div className={ clickableRow ? 'domain-suggestion__non-button-action' : 'domain-suggestion__action' }>
 					{ clickableRow ? this.renderNonButton() : this.renderButton() }
 				</div>
 			</div>

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -51,7 +51,7 @@ const DomainSuggestion = React.createClass( {
 		}, extraClasses );
 
 		return (
-			<div className={ classes } onClick={ clickableRow ? this.props.onButtonClick : undefined }>
+			<div className={ classes } onClick={ clickableRow ? this.props.onButtonClick : undefined } aria-role={ clickableRow ? 'button' : undefined }>
 				<div className="domain-suggestion__content">
 					{ children }
 					<DomainProductPrice

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -52,7 +52,8 @@ const DomainSuggestion = React.createClass( {
 			<div
 				className={ classes }
 				onClick={ clickableRow ? this.props.onButtonClick : undefined }
-				aria-role={ clickableRow ? 'button' : undefined }>
+				aria-role={ clickableRow ? 'button' : undefined }
+				data-e2e-domain={ clickableRow ? this.props.domain : undefined }>
 				<div className="domain-suggestion__content">
 					{ children }
 					<DomainProductPrice

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -1,6 +1,7 @@
 .domain-suggestion {
 	box-sizing: border-box;
 	display: flex;
+	align-items: center;
 
 	@include clear-fix;
 
@@ -59,7 +60,9 @@
 	@include breakpoint( ">660px" ) {
 		.is-placeholder & {
 			margin-right: 50%;
-			min-height: 32px;
+			min-height: 22px;
+			margin-top: 9px;
+			margin-bottom: 9px;
 		}
 
 		.is-placeholder:nth-of-type(2n+1) & {
@@ -87,16 +90,11 @@
 .domain-suggestion__non-button-action {
 	flex: 1 0 auto;
 	min-width: 66px;
-	text-align: right;
+	text-align: center;
 	color: $blue-medium;
-	min-height: 32px;
 
 	> span {
 		vertical-align: top;
-	}
-
-	@include breakpoint( ">660px" ) {
-		margin: 8px 0 0 0;
 	}
 
 	.is-placeholder & {
@@ -106,23 +104,17 @@
 		border-radius: 0;
 		color: transparent;
 		margin-left: 40px;
-		min-height: 0;
-		max-height: 26px;
+		min-height: 26px;
 	}
 }
 
 .domain-suggestion__chevron {
 
 	margin-left: 10px;
+	flex: 1 0 auto;
 
 	> svg {
 		color: $gray;
-	}
-
-	flex: 1 0 auto;
-
-	@include breakpoint( ">660px" ) {
-		margin-top: 8px;
 	}
 
 	.is-placeholder & {
@@ -153,6 +145,7 @@
 		border: none;
 		border-radius: 0;
 		color: transparent;
+		height: 40px;
 
 		.button {
 			opacity: 0;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -112,17 +112,11 @@
 
 	margin-left: 10px;
 	flex: 1 0 auto;
-
-	> svg {
-		color: $gray;
-	}
+	color: $gray;
 
 	.is-placeholder & {
 		animation: loading-fade 1.6s ease-in-out infinite;
-
-		svg {
-			color: lighten( $gray, 30% );
-		}
+		color: lighten( $gray, 30% );
 	}
 }
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -16,7 +16,7 @@
 		cursor: pointer;
 
 		&:hover {
-			box-shadow: 0 0 0 1px #87a6bc, 0 2px 4px #c8d7e1;
+			box-shadow: 0 0 0 1px $gray;
 			z-index: z-index('root', '.domain-suggestion.is-clickable:hover');
 		}
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -93,10 +93,6 @@
 	text-align: center;
 	color: $blue-medium;
 
-	> span {
-		vertical-align: top;
-	}
-
 	.is-placeholder & {
 		animation: loading-fade 1.6s ease-in-out infinite;
 		background-color: lighten( $gray, 30% );

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -12,6 +12,15 @@
 		}
 	}
 
+	&.is-clickable {
+		cursor: pointer;
+
+		&:hover {
+			box-shadow: 0 0 0 1px #87a6bc, 0 2px 4px #c8d7e1;
+			z-index: z-index('root', '.domain-suggestion.is-clickable:hover');
+		}
+	}
+
 	&.is-added {
 		background-color: lighten( $gray, 35% );
 
@@ -57,6 +66,25 @@
 			height: 32px;
 		}
 	}
+}
+
+.domain-suggestion__non-button-action {
+	flex: 1 0 auto;
+	min-width: 100px;
+	text-align: right;
+	color: $blue-medium;
+
+	> span {
+		vertical-align: top;
+	}
+
+	@include breakpoint( ">660px" ) {
+		margin: 8px 0 0 0;
+	}
+}
+
+.domain-suggestion__chevron {
+	color: $gray;
 }
 
 .domain-suggestion__action {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -34,6 +34,7 @@
 
 .domain-suggestion__content {
 	width: 100%;
+	min-height: 32px;
 
 	@include breakpoint( ">660px" ) {
 		display: flex;
@@ -52,6 +53,21 @@
 		animation: loading-fade 1.6s ease-in-out infinite;
 		background-color: lighten( $gray, 30% );
 		color: transparent;
+
+	}
+
+	@include breakpoint( ">660px" ) {
+		.is-placeholder & {
+			margin-right: 50%;
+		}
+
+		.is-placeholder:nth-of-type(2n+1) & {
+			margin-right: 52%;
+		}
+
+		.is-placeholder:nth-of-type(1) & {
+			margin-right: 40%;
+		}
 	}
 
 	> h3 {
@@ -63,16 +79,16 @@
 
 		.is-placeholder & {
 			color: transparent;
-			height: 32px;
 		}
 	}
 }
 
 .domain-suggestion__non-button-action {
 	flex: 1 0 auto;
-	min-width: 100px;
+	min-width: 66px;
 	text-align: right;
 	color: $blue-medium;
+	min-height: 32px;
 
 	> span {
 		vertical-align: top;
@@ -81,10 +97,38 @@
 	@include breakpoint( ">660px" ) {
 		margin: 8px 0 0 0;
 	}
+
+	.is-placeholder & {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		background-color: lighten( $gray, 30% );
+		border: none;
+		border-radius: 0;
+		color: transparent;
+		margin-left: 40px;
+	}
 }
 
 .domain-suggestion__chevron {
-	color: $gray;
+
+	margin-left: 10px;
+
+	> svg {
+		color: $gray;
+	}
+
+	flex: 1 0 auto;
+
+	@include breakpoint( ">660px" ) {
+		margin-top: 8px;
+	}
+
+	.is-placeholder & {
+		animation: loading-fade 1.6s ease-in-out infinite;
+
+		svg {
+			color: lighten( $gray, 30% );
+		}
+	}
 }
 
 .domain-suggestion__action {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -53,12 +53,13 @@
 		animation: loading-fade 1.6s ease-in-out infinite;
 		background-color: lighten( $gray, 30% );
 		color: transparent;
-
+		min-height: 44px;
 	}
 
 	@include breakpoint( ">660px" ) {
 		.is-placeholder & {
 			margin-right: 50%;
+			min-height: 32px;
 		}
 
 		.is-placeholder:nth-of-type(2n+1) & {
@@ -105,6 +106,8 @@
 		border-radius: 0;
 		color: transparent;
 		margin-left: 40px;
+		min-height: 0;
+		max-height: 26px;
 	}
 }
 

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -31,9 +31,9 @@ describe( 'Domain Suggestion', function() {
 			const domainSuggestion = shallow( <DomainSuggestion
 				domain="example.com" isAdded={ false }/> );
 			if ( domainSuggestion.props()[ 'data-e2e-domain' ] ) {
-				expect( domainSuggestion.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' )
+				expect( domainSuggestion.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
 			} else {
-				const domainSuggestionButton = domainSuggestion.find( `.domain-suggestion__select-button` );
+				const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button' );
 				expect( domainSuggestionButton.length ).to.equal( 1 );
 				expect( domainSuggestionButton.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
 			}

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -30,9 +30,13 @@ describe( 'Domain Suggestion', function() {
 		it( 'should have data-e2e-domain attribute for e2e testing', () => {
 			const domainSuggestion = shallow( <DomainSuggestion
 				domain="example.com" isAdded={ false }/> );
-			const domainSuggestionButton = domainSuggestion.find( `.domain-suggestion__select-button` );
-			expect( domainSuggestionButton.length ).to.equal( 1 );
-			expect( domainSuggestionButton.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
+			if ( domainSuggestion.props()[ 'data-e2e-domain' ] ) {
+				expect( domainSuggestion.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' )
+			} else {
+				const domainSuggestionButton = domainSuggestion.find( `.domain-suggestion__select-button` );
+				expect( domainSuggestionButton.length ).to.equal( 1 );
+				expect( domainSuggestionButton.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
+			}
 		} );
 	} );
 } );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -28,9 +28,9 @@ module.exports = {
 		datestamp: '20160802',
 		variations: {
 			clickableRow: 20,
-			nonClickableRow: 80
+			clickableButton: 80
 		},
-		defaultVariation: 'nonClickableRow'
+		defaultVariation: 'clickableButton'
 	},
 	multiDomainRegistrationV1: {
 		datestamp: '20200721',

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -24,6 +24,14 @@ module.exports = {
 		defaultVariation: 'noChanges',
 		allowExistingUsers: false,
 	},
+	domainSuggestionClickableRow: {
+		datestamp: '20160802',
+		variations: {
+			clickableRow: 20,
+			nonClickableRow: 80
+		},
+		defaultVariation: 'nonClickableRow'
+	},
 	multiDomainRegistrationV1: {
 		datestamp: '20200721',
 		variations: {


### PR DESCRIPTION
This PR adds an A/B test for #7132.

**Hypothesis:**
The repeating buttons on the current design are distracting, and create a perception of complexity. Removing the buttons (and making the row clickable) will make it easier to understand the options at hand (and maybe easier to click). It also matches the design of the vertical survey, which the user has ​_just_​ seen and interacted with — consistency here may help.

**Before:**
![screen-shot-2016-08-04-at-12-15-16-pm](https://cloud.githubusercontent.com/assets/942359/17410864/90ebc024-5a43-11e6-8f59-91a5f9187a00.png)

**After:**
<img width="1030" alt="screen shot 2016-08-02 at 21 26 11" src="https://cloud.githubusercontent.com/assets/418473/17349851/c6fa4ee4-58f7-11e6-8a5a-e7c5131fa281.png">

**TODO:** 
- [x] Design tweaks
- [x] ARIA accessibility support
- [x] Figure out how to properly support `data-e2e-domain`
  - [x] Wait until https://github.com/Automattic/wp-e2e-tests/pull/191 is merged
- [x] Fix tests
- [x] Code/style cleanup
- [x] Test on:
  - [x] Safari
  - [x] Firefox
  - [x] Chrome
  - [x] Edge
  - [x] IE 11

Test live: https://calypso.live/start/?branch=add/domain-suggestion-clickable-row-abtest