### PR TITLE
Guided Transfer: Adds a query data component

### DIFF
--- a/client/components/data/query-site-guided-transfer/README.md
+++ b/client/components/data/query-site-guided-transfer/README.md
@@ -1,0 +1,8 @@
+Query Site Guided Transfer
+================
+
+`<QuerySiteGuidedTransfer />` is a React component used to fetch the status of any guided transfer for a site.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page.

--- a/client/components/data/query-site-guided-transfer/index.jsx
+++ b/client/components/data/query-site-guided-transfer/index.jsx
@@ -29,12 +29,9 @@ class QuerySiteGuidedTransfer extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.isRequesting ||
-			! nextProps.siteId ||
-			( this.props.siteId === nextProps.siteId ) ) {
-			return;
+		if ( this.props.siteId !== nextProps.siteId ) {
+			this.request( nextProps );
 		}
-		this.request( nextProps );
 	}
 
 	render() {

--- a/client/components/data/query-site-guided-transfer/index.jsx
+++ b/client/components/data/query-site-guided-transfer/index.jsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingGuidedTransferStatus } from 'state/sites/guided-transfer/selectors';
+import { requestGuidedTransferStatus } from 'state/sites/guided-transfer/actions';
+
+class QuerySiteGuidedTransfer extends Component {
+
+	constructor( props ) {
+		super( props );
+		this.request = this.request.bind( this );
+	}
+
+	request( props = this.props ) {
+		if ( ! props.isRequesting && props.siteId ) {
+			props.requestGuidedTransferStatus( props.siteId );
+		}
+	}
+
+	componentWillMount() {
+		this.request();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.isRequesting ||
+			! nextProps.siteId ||
+			( this.props.siteId === nextProps.siteId ) ) {
+			return;
+		}
+		this.request( nextProps );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QuerySiteGuidedTransfer.propTypes = {
+	siteId: PropTypes.number,
+	isRequesting: PropTypes.bool,
+};
+
+QuerySiteGuidedTransfer.defaultProps = {
+	requestGuidedTransferStatus: () => {},
+};
+
+const mapStateToProps = ( state, ownProps ) => ( {
+	isRequesting: isRequestingGuidedTransferStatus( state, ownProps.siteId ),
+} );
+
+const mapDispatchToProps = dispatch =>
+	bindActionCreators( { requestGuidedTransferStatus }, dispatch );
+
+export default connect( mapStateToProps, mapDispatchToProps )( QuerySiteGuidedTransfer );

--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -16,6 +16,7 @@ import Interval, { EVERY_SECOND } from 'lib/interval';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import support from 'lib/url/support';
+import QuerySiteGuidedTransfer from 'components/data/query-site-guided-transfer';
 
 export default React.createClass( {
 	displayName: 'Exporter',
@@ -99,6 +100,7 @@ export default React.createClass( {
 
 		return (
 			<div className="exporter">
+				<QuerySiteGuidedTransfer siteId={ siteId } />
 				{ notice }
 				{ isGuidedTransferInProgress && <GuidedTransferInProgress /> }
 				<FoldableCard

--- a/client/state/sites/guided-transfer/selectors.js
+++ b/client/state/sites/guided-transfer/selectors.js
@@ -1,0 +1,3 @@
+export function isRequestingGuidedTransferStatus( state, siteId ) {
+	return state.sites.guidedTransfer.isFetching[ siteId ] === true;
+}

--- a/client/state/sites/guided-transfer/test/selectors.js
+++ b/client/state/sites/guided-transfer/test/selectors.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isRequestingGuidedTransferStatus
+} from '../selectors';
+
+describe( 'selectors', () => {
+	const testSiteId = 100658273;
+
+	describe( '#isRequestingGuidedTransferStatus()', () => {
+		it( 'should return false for default state {}', () => {
+			const state = deepFreeze( {
+				sites: {
+					guidedTransfer: {
+						isFetching: {},
+					}
+				}
+			} );
+
+			expect( isRequestingGuidedTransferStatus( state, testSiteId ) ).to.be.false;
+		} );
+
+		it( 'should return true when a request is underway', () => {
+			const state = deepFreeze( {
+				sites: {
+					guidedTransfer: {
+						isFetching: {
+							1: false,
+							[ testSiteId ]: true,
+						},
+					}
+				}
+			} );
+
+			expect( isRequestingGuidedTransferStatus( state, testSiteId ) ).to.be.true;
+		} );
+
+
+		it( 'should return false when a isFetching is false', () => {
+			const state = deepFreeze( {
+				sites: {
+					guidedTransfer: {
+						isFetching: {
+							1: true,
+							[ testSiteId ]: false,
+						},
+					}
+				}
+			} );
+
+			expect( isRequestingGuidedTransferStatus( state, testSiteId ) ).to.be.false;
+		} );
+	} );
+} );

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -10,6 +10,7 @@ import merge from 'lodash/merge';
  */
 import { plans } from './plans/reducer';
 import domains from './domains/reducer';
+import guidedTransfer from './guided-transfer/reducer';
 import vouchers from './vouchers/reducer';
 
 import mediaStorage from './media-storage/reducer';
@@ -133,6 +134,7 @@ export default combineReducers( {
 	items,
 	mediaStorage,
 	plans,
+	guidedTransfer,
 	vouchers,
 	requesting
 } );

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -39,6 +39,7 @@ describe( 'reducer', () => {
 			'items',
 			'mediaStorage',
 			'plans',
+			'guidedTransfer',
 			'vouchers',
 			'requesting'
 		] );


### PR DESCRIPTION
This adds a `<QuerySiteGuidedTransfer />` React component which fetches the status of a guided transfer for a given site.

It also adds the guidedTransfer subreducer to state.sites.guidedTransfer.

#### Todo

 - [x] Unit tests for new selector

### How to test

#### Automated tests

This PR includes new tests for the added Redux selector:

```sh
npm run test-client client/state/sites/guided-transfer/test
```

#### Browser testing

1. Load up the [branch](https://calypso.live/?branch=add/guided-transfer/query-component)
2. Go to **My Sites > Site Settings > Export** page
3. Check the Redux devtools, you should see a `GUIDED_TRANSFER_STATUS_RECEIVE` action. Additionally, there should be some data in the state tree under `sites.guidedTransfer`:

![screen shot 2016-08-03 at 5 16 29 pm](https://cloud.githubusercontent.com/assets/416133/17357033/0ee98f34-599e-11e6-96ad-e94619f50580.png)
