### PR TITLE
Enable live chat within the Jetpack Connect flow

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -41,6 +41,7 @@ import Button from 'components/button';
 import { requestSites } from 'state/sites/actions';
 import { isRequestingSites } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
+import LiveChatButton from './live-chat-button';
 
 /**
  * Constants
@@ -473,6 +474,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 					action={ this.translate( 'Get back to Jetpack Connect screen' ) }
 					actionURL="/jetpack/connect"
 				/>
+				<LiveChatButton />
 			</Main>
 		);
 	},
@@ -505,6 +507,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderForm() }
 				</div>
+				<LiveChatButton />
 			</MainWrapper>
 		);
 	}

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -474,7 +474,9 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 					action={ this.translate( 'Get back to Jetpack Connect screen' ) }
 					actionURL="/jetpack/connect"
 				/>
-				<LiveChatButton />
+				<LoggedOutFormLinks>
+					<LiveChatButton />
+				</LoggedOutFormLinks>
 			</Main>
 		);
 	},
@@ -507,7 +509,9 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderForm() }
 				</div>
-				<LiveChatButton />
+				<LoggedOutFormLinks>
+					<LiveChatButton />
+				</LoggedOutFormLinks>
 			</MainWrapper>
 		);
 	}

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -411,6 +411,7 @@ const LoggedInForm = React.createClass( {
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
 					{ this.translate( 'Create a new account' ) }
 				</LoggedOutFormLinkItem>
+				<LiveChatButton />
 			</LoggedOutFormLinks>
 		);
 	},
@@ -509,9 +510,6 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderForm() }
 				</div>
-				<LoggedOutFormLinks>
-					<LiveChatButton />
-				</LoggedOutFormLinks>
 			</MainWrapper>
 		);
 	}

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -256,6 +256,7 @@ const JetpackConnectMain = React.createClass( {
 					? null
 					: <LoggedOutFormLinkItem href="/start">{ this.translate( 'Start a new site on WordPress.com' ) }</LoggedOutFormLinkItem>
 				}
+				<LiveChatButton />
 			</LoggedOutFormLinks>
 		);
 	},
@@ -306,7 +307,6 @@ const JetpackConnectMain = React.createClass( {
 
 					{ this.renderSiteInput( status ) }
 					{ this.renderFooter() }
-					<LiveChatButton />
 				</div>
 			</MainWrapper>
 		);
@@ -328,7 +328,6 @@ const JetpackConnectMain = React.createClass( {
 
 					{ this.renderSiteInput( status ) }
 					{ this.renderFooter() }
-					<LiveChatButton />
 				</div>
 			</MainWrapper>
 		);
@@ -367,7 +366,9 @@ const JetpackConnectMain = React.createClass( {
 						<div>{ this.renderBackButton() }</div>
 					</div>
 				</div>
-				<LiveChatButton />
+				<LoggedOutFormLinks>
+					<LiveChatButton />
+				</LoggedOutFormLinks>
 			</MainWrapper>
 		);
 	},
@@ -422,7 +423,9 @@ const JetpackConnectMain = React.createClass( {
 						{ this.renderBackButton() }
 					</div>
 				</div>
-				<LiveChatButton />
+				<LoggedOutFormLinks>
+					<LiveChatButton />
+				</LoggedOutFormLinks>
 			</MainWrapper>
 		);
 	},

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -250,7 +250,7 @@ const JetpackConnectMain = React.createClass( {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
-					{ this.translate( 'Install Jetpack Manually' ) }
+					{ this.translate( 'Install Jetpack manually' ) }
 				</LoggedOutFormLinkItem>
 				{ this.isInstall()
 					? null

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -26,6 +26,7 @@ import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Gridicon from 'components/gridicon';
 import MainWrapper from './main-wrapper';
+import LiveChatButton from './live-chat-button';
 import {
 	confirmJetpackInstallStatus,
 	dismissUrl,
@@ -305,6 +306,7 @@ const JetpackConnectMain = React.createClass( {
 
 					{ this.renderSiteInput( status ) }
 					{ this.renderFooter() }
+					<LiveChatButton />
 				</div>
 			</MainWrapper>
 		);
@@ -326,6 +328,7 @@ const JetpackConnectMain = React.createClass( {
 
 					{ this.renderSiteInput( status ) }
 					{ this.renderFooter() }
+					<LiveChatButton />
 				</div>
 			</MainWrapper>
 		);
@@ -364,6 +367,7 @@ const JetpackConnectMain = React.createClass( {
 						<div>{ this.renderBackButton() }</div>
 					</div>
 				</div>
+				<LiveChatButton />
 			</MainWrapper>
 		);
 	},
@@ -418,6 +422,7 @@ const JetpackConnectMain = React.createClass( {
 						{ this.renderBackButton() }
 					</div>
 				</div>
+				<LiveChatButton />
 			</MainWrapper>
 		);
 	},

--- a/client/signup/jetpack-connect/live-chat-button.jsx
+++ b/client/signup/jetpack-connect/live-chat-button.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import Gridicon from 'components/gridicon';
 import olarkActions from 'lib/olark-store/actions';

--- a/client/signup/jetpack-connect/live-chat-button.jsx
+++ b/client/signup/jetpack-connect/live-chat-button.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import Button from 'components/button';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import Gridicon from 'components/gridicon';
 import olarkActions from 'lib/olark-store/actions';
 import UserModule from 'lib/user';
@@ -26,11 +27,9 @@ export default React.createClass( {
 		}
 
 		return (
-			<div className="jetpack-connect__live-chat">
-				<Button compact borderless onClick={ this.handleClick }>
-					<Gridicon icon="help-outline" /> { this.translate( 'Help' ) }
-				</Button>
-			</div>
+			<LoggedOutFormLinkItem className="jetpack-connect__live-chat" onClick={ this.handleClick }>
+				<Gridicon icon="help-outline" /> { this.translate( 'Get help connecting your site' ) }
+			</LoggedOutFormLinkItem>
 		);
 	}
 } );

--- a/client/signup/jetpack-connect/live-chat-button.jsx
+++ b/client/signup/jetpack-connect/live-chat-button.jsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import olarkActions from 'lib/olark-store/actions';
+import UserModule from 'lib/user';
+
+const user = UserModule();
+
+export default React.createClass( {
+	displayName: 'JetpackConnectLiveChatButton',
+
+	handleClick() {
+		olarkActions.expandBox();
+	},
+
+	render() {
+		if ( ! user.get() ) {
+			return null;
+		}
+
+		return (
+			<div className="jetpack-connect__live-chat">
+				<Button compact borderless onClick={ this.handleClick }>
+					<Gridicon icon="help-outline" /> { this.translate( 'Help' ) }
+				</Button>
+			</div>
+		);
+	}
+} );

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -25,8 +25,6 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { requestPlans } from 'state/plans/actions';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
-import LoggedOutFormLinks from 'components/logged-out-form/links';
-import LiveChatButton from './live-chat-button';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 
@@ -156,9 +154,6 @@ const Plans = React.createClass( {
 								intervalType="yearly" />
 						</div>
 					</div>
-					<LoggedOutFormLinks>
-						<LiveChatButton />
-					</LoggedOutFormLinks>
 				</Main>
 			</div>
 		);

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -25,6 +25,7 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { requestPlans } from 'state/plans/actions';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
+import LiveChatButton from './live-chat-button';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 
@@ -154,6 +155,7 @@ const Plans = React.createClass( {
 								intervalType="yearly" />
 						</div>
 					</div>
+					<LiveChatButton />
 				</Main>
 			</div>
 		);

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -25,6 +25,7 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { requestPlans } from 'state/plans/actions';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LiveChatButton from './live-chat-button';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
@@ -155,7 +156,9 @@ const Plans = React.createClass( {
 								intervalType="yearly" />
 						</div>
 					</div>
-					<LiveChatButton />
+					<LoggedOutFormLinks>
+						<LiveChatButton />
+					</LoggedOutFormLinks>
 				</Main>
 			</div>
 		);

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -34,6 +34,7 @@ import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import Dialog from 'components/dialog';
 import analytics from 'lib/analytics';
 import MainWrapper from './main-wrapper';
+import LiveChatButton from './live-chat-button';
 
 /*
  * Module variables
@@ -377,6 +378,7 @@ const JetpackSSOForm = React.createClass( {
 					action={ this.translate( 'Read Single Sign-On Documentation' ) }
 					actionURL="https://jetpack.com/support/sso/"
 				/>
+				<LiveChatButton />
 			</Main>
 		);
 	},
@@ -448,6 +450,7 @@ const JetpackSSOForm = React.createClass( {
 				</div>
 
 				{ this.renderSharedDetailsDialog() }
+				<LiveChatButton />
 			</MainWrapper>
 		);
 	}

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -378,7 +378,9 @@ const JetpackSSOForm = React.createClass( {
 					action={ this.translate( 'Read Single Sign-On Documentation' ) }
 					actionURL="https://jetpack.com/support/sso/"
 				/>
-				<LiveChatButton />
+				<LoggedOutFormLinks>
+					<LiveChatButton />
+				</LoggedOutFormLinks>
 			</Main>
 		);
 	},
@@ -450,7 +452,9 @@ const JetpackSSOForm = React.createClass( {
 				</div>
 
 				{ this.renderSharedDetailsDialog() }
-				<LiveChatButton />
+				<LoggedOutFormLinks>
+					<LiveChatButton />
+				</LoggedOutFormLinks>
 			</MainWrapper>
 		);
 	}

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -422,6 +422,8 @@
 }
 
 .jetpack-connect__live-chat {
-	margin-top: 16px;
-	text-align: center;
+	.gridicon {
+		width: 18px;
+		height: 18px;
+	}
 }

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -420,3 +420,8 @@
 .jetpack-connect__sso-placeholder a {
 	color: transparent;
 }
+
+.jetpack-connect__live-chat {
+	margin-top: 16px;
+	text-align: center;
+}


### PR DESCRIPTION
## Purpose
This pull request addresses #7012, adding a "Help" button to each page of the Jetpack Connect flow. Clicking that button expands the live chat popup, allowing users to get in touch with the happiness engineers. 

## Preview
The button can be seen at the bottom of the screen:

![](https://cldup.com/dkgywGHkKy.png)

## Testing instructions

Access every possible screen from the Jetpack Connect flow (including the connect/install screens, plans, authorization form and SSO), and test if the button is there. It should be at the bottom of each screen, and upon click it should reveal the chat box.

Test live: https://calypso.live/?branch=add/jetpack-connect-live-chat