### PR TITLE
Site Selector: add reference to how many hidden sites there are.

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -286,21 +286,30 @@ const SiteSelector = React.createClass( {
 					{ this.renderAllSites() }
 					{ this.renderSites() }
 					{ hiddenSitesCount > 0 &&
-						<span className="site-selector__hidden-sites-message">
-							{ this.translate(
-								'%(hiddenSitesCount)d more hidden site.{{br/}} Use search to access it.',
-								'%(hiddenSitesCount)d more hidden sites.{{br/}} Use search to access them.',
-								{
-									count: hiddenSitesCount,
-									args: {
-										hiddenSitesCount: hiddenSitesCount
-									},
-									components: {
-										br: <br />
+						<div className="site-selector__hidden-sites">
+							<span className="site-selector__hidden-sites-message">
+								{ this.translate(
+									'%(hiddenSitesCount)d more hidden site.{{br/}}Use search to access it.',
+									'%(hiddenSitesCount)d more hidden sites.{{br/}}Use search to access them.',
+									{
+										count: hiddenSitesCount,
+										args: {
+											hiddenSitesCount: hiddenSitesCount
+										},
+										components: {
+											br: <br />
+										}
 									}
-								}
-							) }
-						</span>
+								) }
+							</span>
+							<a
+								href="https://wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
+								className="site-selector__manage-hidden-sites"
+								title={ this.translate( 'Manage your hidden sites' ) }
+							>
+								<Gridicon icon="cog" size={ 24 } />
+							</a>
+						</div>
 					}
 				</div>
 				{ this.props.showAddNewSite && this.addNewSite() }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -271,6 +271,8 @@ const SiteSelector = React.createClass( {
 			'is-single': user.get().visible_site_count === 1
 		} );
 
+		const hiddenSitesCount = user.get().site_count - user.get().visible_site_count;
+
 		return (
 			<div className={ selectorClass }>
 				<Search
@@ -283,6 +285,23 @@ const SiteSelector = React.createClass( {
 				<div className="site-selector__sites" ref="selector">
 					{ this.renderAllSites() }
 					{ this.renderSites() }
+					{ hiddenSitesCount > 0 &&
+						<span className="site-selector__hidden-sites-message">
+							{ this.translate(
+								'%(hiddenSitesCount)d more hidden site.{{br/}} Use search to access it.',
+								'%(hiddenSitesCount)d more hidden sites.{{br/}} Use search to access them.',
+								{
+									count: hiddenSitesCount,
+									args: {
+										hiddenSitesCount: hiddenSitesCount
+									},
+									components: {
+										br: <br />
+									}
+								}
+							) }
+						</span>
+					}
 				</div>
 				{ this.props.showAddNewSite && this.addNewSite() }
 			</div>

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -306,6 +306,8 @@ const SiteSelector = React.createClass( {
 								href="https://wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
 								className="site-selector__manage-hidden-sites"
 								title={ this.translate( 'Manage your hidden sites' ) }
+								target="_blank"
+								rel="noopener noreferrer"
 							>
 								<Gridicon icon="cog" size={ 24 } />
 							</a>

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -21,10 +21,8 @@ import Gridicon from 'components/gridicon';
 import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import Search from 'components/search';
-import userModule from 'lib/user';
 import config from 'config';
 
-const user = userModule();
 const noop = () => {};
 
 const SiteSelector = React.createClass( {
@@ -267,11 +265,11 @@ const SiteSelector = React.createClass( {
 
 	render() {
 		const selectorClass = classNames( 'site-selector', 'sites-list', {
-			'is-large': user.get().site_count > 6,
-			'is-single': user.get().visible_site_count === 1
+			'is-large': this.props.siteCount > 6,
+			'is-single': this.props.visibleSiteCount === 1
 		} );
 
-		const hiddenSitesCount = user.get().site_count - user.get().visible_site_count;
+		const hiddenSitesCount = this.props.siteCount - this.props.visibleSiteCount;
 
 		return (
 			<div className={ selectorClass }>
@@ -316,8 +314,11 @@ const SiteSelector = React.createClass( {
 } );
 
 export default connect( ( state ) => {
+	const visibleSiteCount = get( getCurrentUser( state ), 'visible_site_count', 0 );
 	return {
 		showRecentSites: get( getCurrentUser( state ), 'visible_site_count', 0 ) > 11,
-		recentSites: getPreference( state, 'recentSites' )
+		recentSites: getPreference( state, 'recentSites' ),
+		siteCount: get( getCurrentUser( state ), 'site_count', 0 ),
+		visibleSiteCount: visibleSiteCount,
 	};
 } )( SiteSelector );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -216,7 +216,7 @@ const SiteSelector = React.createClass( {
 			// There is currently no "all sites" version of the insights page
 			allSitesPath = allSitesPath.replace( /^\/stats\/insights\/?$/, '/stats/day' );
 
-			return(
+			return (
 				<AllSites
 					key="selector-all-sites"
 					sites={ this.props.sites.get() }
@@ -296,11 +296,11 @@ const SiteSelector = React.createClass( {
 									components: {
 										br: <br />,
 										a: <a
-												href="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
-												className="site-selector__manage-hidden-sites"
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
+											href="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
+											className="site-selector__manage-hidden-sites"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
 									}
 								}
 							) }
@@ -314,11 +314,12 @@ const SiteSelector = React.createClass( {
 } );
 
 export default connect( ( state ) => {
-	const visibleSiteCount = get( getCurrentUser( state ), 'visible_site_count', 0 );
+	const user = getCurrentUser( state );
+	const visibleSiteCount = get( user, 'visible_site_count', 0 );
 	return {
-		showRecentSites: get( getCurrentUser( state ), 'visible_site_count', 0 ) > 11,
+		showRecentSites: get( user, 'visible_site_count', 0 ) > 11,
 		recentSites: getPreference( state, 'recentSites' ),
-		siteCount: get( getCurrentUser( state ), 'site_count', 0 ),
+		siteCount: get( user, 'site_count', 0 ),
 		visibleSiteCount: visibleSiteCount,
 	};
 } )( SiteSelector );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -286,32 +286,27 @@ const SiteSelector = React.createClass( {
 					{ this.renderAllSites() }
 					{ this.renderSites() }
 					{ hiddenSitesCount > 0 &&
-						<div className="site-selector__hidden-sites">
-							<span className="site-selector__hidden-sites-message">
-								{ this.translate(
-									'%(hiddenSitesCount)d more hidden site.{{br/}}Use search to access it.',
-									'%(hiddenSitesCount)d more hidden sites.{{br/}}Use search to access them.',
-									{
-										count: hiddenSitesCount,
-										args: {
-											hiddenSitesCount: hiddenSitesCount
-										},
-										components: {
-											br: <br />
-										}
+						<span className="site-selector__hidden-sites-message">
+							{ this.translate(
+								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
+								'%(hiddenSitesCount)d more hidden sites. {{a}}Change{{/a}}.{{br/}}Use search to access them.',
+								{
+									count: hiddenSitesCount,
+									args: {
+										hiddenSitesCount: hiddenSitesCount
+									},
+									components: {
+										br: <br />,
+										a: <a
+												href="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
+												className="site-selector__manage-hidden-sites"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
 									}
-								) }
-							</span>
-							<a
-								href="https://wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
-								className="site-selector__manage-hidden-sites"
-								title={ this.translate( 'Manage your hidden sites' ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								<Gridicon icon="cog" size={ 24 } />
-							</a>
-						</div>
+								}
+							) }
+						</span>
 					}
 				</div>
 				{ this.props.showAddNewSite && this.addNewSite() }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -176,19 +176,14 @@
 	}
 }
 
-.site-selector__hidden-sites {
-	display: flex;
-	justify-content: space-between;
-	padding: 16px 16px 24px;
-	align-items: center;
-}
-
 .site-selector__hidden-sites-message {
 	color: $gray;
 	display: block;
 	font-size: 12px;
-}
+	padding: 16px 16px 24px;
 
-.site-selector__manage-hidden-sites .gridicon {
-	fill: $gray;
+	.site-selector__manage-hidden-sites {
+		color: $gray;
+		text-decoration: underline;
+	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -175,3 +175,10 @@
 		border-bottom-width: 0;
 	}
 }
+
+.site-selector__hidden-sites-message {
+	color: $gray;
+	display: block;
+	font-size: 12px;
+	padding: 16px 16px 24px;
+}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -187,3 +187,7 @@
 		text-decoration: underline;
 	}
 }
+
+.site-selector__no-results + .site-selector__hidden-sites-message {
+	display: none;
+}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -176,9 +176,19 @@
 	}
 }
 
+.site-selector__hidden-sites {
+	display: flex;
+	justify-content: space-between;
+	padding: 16px 16px 24px;
+	align-items: center;
+}
+
 .site-selector__hidden-sites-message {
 	color: $gray;
 	display: block;
 	font-size: 12px;
-	padding: 16px 16px 24px;
+}
+
+.site-selector__manage-hidden-sites .gridicon {
+	fill: $gray;
 }


### PR DESCRIPTION
This is a subtle hint for users with hidden sites that they have hidden sites, and that they can still access them via search.

![image](https://cloud.githubusercontent.com/assets/548849/17364705/0c8cea7c-5982-11e6-8cd8-a98eaee8d820.png)


Test live: https://calypso.live/posts?branch=add/hidden-sites-reference