### PR TITLE
CPT: Don't display embedded post preview for unsupportable sites

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -17,6 +17,12 @@ import {
 /**
  * Internal dependencies
  */
+import config from 'config';
+import { isHttps } from 'lib/url';
+
+/**
+ * Internal dependencies
+ */
 import createSelector from 'lib/create-selector';
 import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import versionCompare from 'lib/version-compare';
@@ -56,6 +62,7 @@ export const getSite = createSelector(
 			hasConflict: isSiteConflicting( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
 			domain: getSiteDomain( state, siteId ),
+			is_previewable: isSitePreviewable( state, siteId )
 		};
 	},
 	( state ) => state.sites.items
@@ -205,6 +212,33 @@ export function getSiteDomain( state, siteId ) {
 	}
 
 	return site.URL.replace( /^https?:\/\//, '' );
+}
+
+/**
+ * Returns true if the site can be previewed, false if the site cannot be
+ * previewed, or null if preview ability cannot be determined. This indicates
+ * whether it is safe to embed iframe previews for the site.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is previewable
+ */
+export function isSitePreviewable( state, siteId ) {
+	if ( ! config.isEnabled( 'preview-layout' ) ) {
+		return false;
+	}
+
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	if ( site.is_vip ) {
+		return false;
+	}
+
+	const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
+	return !! unmappedUrl && isHttps( unmappedUrl );
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -28,6 +28,11 @@ import {
 } from '../selectors';
 
 describe( 'selectors', () => {
+	beforeEach( () => {
+		getSite.memoizedSelector.cache.clear();
+		getSiteCollisions.memoizedSelector.cache.clear();
+	} );
+
 	describe( '#getSite()', () => {
 		useSandbox( ( sandbox ) => {
 			sandbox.stub( config, 'isEnabled' ).withArgs( 'preview-layout' ).returns( true );
@@ -78,10 +83,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSiteCollisions', () => {
-		beforeEach( () => {
-			getSiteCollisions.memoizedSelector.cache.clear();
-		} );
-
 		it( 'should not consider distinct URLs as conflicting', () => {
 			const collisions = getSiteCollisions( {
 				sites: {
@@ -123,10 +124,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#isSiteConflicting()', () => {
-		beforeEach( () => {
-			getSiteCollisions.memoizedSelector.cache.clear();
-		} );
-
 		it( 'it should return false if the specified site ID is not included in conflicting set', () => {
 			const isConflicting = isSiteConflicting( {
 				sites: {
@@ -376,10 +373,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSiteSlug()', () => {
-		beforeEach( () => {
-			getSiteCollisions.memoizedSelector.cache.clear();
-		} );
-
 		it( 'should return null if the site is not known', () => {
 			const slug = getSiteSlug( {
 				sites: {
@@ -447,10 +440,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSiteDomain()', () => {
-		beforeEach( () => {
-			getSiteCollisions.memoizedSelector.cache.clear();
-		} );
-
 		it( 'should return null if the site is not known', () => {
 			const domain = getSiteDomain( {
 				sites: {


### PR DESCRIPTION
Observed at https://github.com/Automattic/wp-calypso/pull/6894#issuecomment-237213282

This pull request seeks to resolve an issue where "Preview" and "View" actions on the custom post types list screen will do nothing when viewing an unsupported site like a non-HTTPS Jetpack site. With the changes included here, these actions will launch a new tab for the preview on unsupportable sites.

__Testing instructions:__

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site
3. Select View/Preview from a post's action menu
4. Note that...
 - If the site supports preview (e.g. WordPress.com site, HTTPS Jetpack site), an iframe preview will be shown
 - If the site doesn't support preview (e.g. VIP site, non-HTTPS Jetpack site, disabled `preview-layout` config), a new tab will be shown instead

/cc @mtias 

Test live: https://calypso.live/?branch=fix/cpt-jetpack-preview