### PR TITLE
Sites: Wait for site counts to match before redirecting to all sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -187,12 +187,13 @@ module.exports = {
 			const selectOnSitesChange = () => {
 				// if sites have loaded, but siteID is invalid, redirect to allSitesPath
 				if ( sites.select( siteID ) ) {
+					sites.initialized = true;
 					onSelectedSiteAvailable();
 					if ( waitingNotice ) {
 						notices.removeNotice( waitingNotice );
 					}
-					// clear notice
 				} else if ( ( currentUser.visible_site_count !== sites.getVisible().length ) ) {
+					sites.initialized = false;
 					waitingNotice = notices.info( i18n.translate( 'Waiting for site…' ), { showDismiss: false } );
 					sites.once( 'change', selectOnSitesChange );
 					sites.fetch();

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -176,6 +176,7 @@ module.exports = {
 		// set site visibility to just that site on the picker
 		if ( sites.select( siteID ) ) {
 			onSelectedSiteAvailable();
+			next();
 		} else {
 			// if sites has fresh data and siteID is invalid
 			// redirect to allSitesPath
@@ -197,15 +198,15 @@ module.exports = {
 					waitingNotice = notices.info( i18n.translate( 'Waiting for site…' ), { showDismiss: false } );
 					sites.once( 'change', selectOnSitesChange );
 					sites.fetch();
+					return;
 				} else {
 					page.redirect( allSitesPath );
 				}
+				next();
 			};
 			// Otherwise, check when sites has loaded
 			sites.once( 'change', selectOnSitesChange );
 		}
-
-		next();
 	},
 
 	awaitSiteLoaded( context, next ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -187,6 +187,12 @@ module.exports = {
 				// if sites have loaded, but siteID is invalid, redirect to allSitesPath
 				if ( sites.select( siteID ) ) {
 					onSelectedSiteAvailable();
+				} else if ( ( currentUser.visible_site_count !== sites.getVisible().length ) ) {
+					setTimeout( () => {
+						page.redirect( context.canonicalPath );
+					}, 1000 );
+					// We haven't set the main site, so we don't want to continue `next()`
+					return;
 				} else {
 					page.redirect( allSitesPath );
 				}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -113,6 +113,8 @@ module.exports = {
 	 * Set up site selection based on last URL param and/or handle no-sites error cases
 	 */
 	siteSelection( context, next ) {
+		const Main = require( 'components/main' );
+		const JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
 		const siteID = route.getSiteFragment( context.path );
 		const analyticsPageTitle = 'Sites';
 		const basePath = route.sectionify( context.path );
@@ -188,6 +190,12 @@ module.exports = {
 				if ( sites.select( siteID ) ) {
 					onSelectedSiteAvailable();
 				} else if ( ( currentUser.visible_site_count !== sites.getVisible().length ) ) {
+					ReactDom.render( (
+						<Main>
+							<JetpackManageErrorPage template="waitForJetpackSite" />
+						</Main>
+					), document.getElementById( 'primary' ) );
+
 					setTimeout( () => {
 						page.redirect( context.canonicalPath );
 					}, 1000 );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -195,7 +195,7 @@ module.exports = {
 					}
 				} else if ( ( currentUser.visible_site_count !== sites.getVisible().length ) ) {
 					sites.initialized = false;
-					waitingNotice = notices.info( i18n.translate( 'Waiting for site…' ), { showDismiss: false } );
+					waitingNotice = notices.info( i18n.translate( 'Finishing set up…' ), { showDismiss: false } );
 					sites.once( 'change', selectOnSitesChange );
 					sites.fetch();
 					return;

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -58,7 +58,11 @@ module.exports = React.createClass( {
 				action: this.translate( 'View Plans' ),
 				actionURL: '/plans/' + ( this.props.site ? this.props.site.slug : '' )
 			},
-			default: {}
+			waitForJetpackSite: {
+				title: this.translate( 'Waiting for site to connect…' ),
+				illustration: '/calypso/images/drake/drake-jetpack.svg',
+			},
+			'default': {}
 		};
 		return Object.assign( {}, defaults[ this.props.template ] || defaults.default, this.props );
 	},

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -58,10 +58,6 @@ module.exports = React.createClass( {
 				action: this.translate( 'View Plans' ),
 				actionURL: '/plans/' + ( this.props.site ? this.props.site.slug : '' )
 			},
-			waitForJetpackSite: {
-				title: this.translate( 'Waiting for site to connect…' ),
-				illustration: '/calypso/images/drake/drake-jetpack.svg',
-			},
 			'default': {}
 		};
 		return Object.assign( {}, defaults[ this.props.template ] || defaults.default, this.props );


### PR DESCRIPTION
See #5571 — After connecting a Jetpack site, the `me/sites` endpoint can have a delay before registering that the user has a new site. For users, this means we sometimes drop them into the all sites view instead of the view for the site they just connected.

Since the user's site count is correct, this PR changes the site selection code to wait until the site count and number of sites returned is equal. This doesn't address the underlying API cause, it's more of a workaround.

I dropped a Drake "error" on the page to give the user some feedback, but I'd like real designer feedback if we go this route :)

To test:

1. Have an unconnected Jetpack site
2. Clear localStorage and IndexedDB (possibly only necessary if you've connected this site in the past?)
3. Connect your Jetpack site
4. Immediately try to view any calypso page for that site: `/plugins/$site`, `/pages/$site`, etc
5. You should see a "wait" message with Drake, then the page you're expecting (as opposed to the all sites view)

cc @roccotripaldi @rickybanister -- I left this as "In Progress" since I'd like to have some discussion about whether we think this is too much "workaround a problem" and not enough "solve the problem" :)

Test live: https://calypso.live/?branch=add/wait-for-sites-list