### PR TITLE
Components: Do not trigger onChange for disabled FormToggle

### DIFF
--- a/client/components/forms/form-toggle/README.md
+++ b/client/components/forms/form-toggle/README.md
@@ -6,18 +6,18 @@ This component is used to implement toggle switches.
 #### How to use:
 
 ```js
-var FormToggle = require( 'components/forms/form-toggle' );
+import FormToggle from 'components/forms/form-toggle';
 
-render: function() {
+export default function MyComponent() {
 	return (
 		<div className="you-rock">
-		  <FormToggle
-			checked={ this.props.checked }
-			toggling={ this.props.toggling }
-			disabled={ this.props.disabled }
-			onChange={ this.props.onChange }
-			id={ 'you-rock-uniquely' }
-		  />
+			<FormToggle
+				checked={ this.props.checked }
+				toggling={ this.props.toggling }
+				disabled={ this.props.disabled }
+				onChange={ this.props.onChange }
+				id="you-rock-uniquely"
+			/>
 		</div>
 	);
 }

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -1,29 +1,40 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { PureComponent, PropTypes } from 'react';
+import classNames from 'classnames';
 
-var idNum = 0;
+export default class FormToggle extends PureComponent {
+	static propTypes = {
+		onChange: PropTypes.func,
+		onKeyDown: PropTypes.func,
+		checked: PropTypes.bool,
+		disabled: PropTypes.bool,
+		id: PropTypes.string,
+		className: PropTypes.string,
+		toggling: PropTypes.bool,
+		'aria-label': PropTypes.string,
+		children: PropTypes.node
+	};
 
-module.exports = React.createClass( {
+	static defaultProps = {
+		checked: false,
+		disabled: false
+	};
 
-	displayName: 'FormToggle',
+	static idNum = 0;
 
-	propTypes: {
-		onChange: React.PropTypes.func,
-		checked: React.PropTypes.bool,
-		disabled: React.PropTypes.bool,
-		id: React.PropTypes.string
-	},
+	constructor() {
+		super( ...arguments );
 
-	getDefaultProps: function() {
-		return {
-			checked: false,
-			disabled: false
-		};
-	},
-	_onKeyDown: function( event ) {
+		this.onKeyDown = this.onKeyDown.bind( this );
+	}
+
+	componentWillMount() {
+		this.id = this.constructor.idNum++;
+	}
+
+	onKeyDown( event ) {
 		if ( ! this.props.disabled ) {
 			if ( event.key === 'Enter' || event.key === ' ' ) {
 				event.preventDefault();
@@ -33,19 +44,18 @@ module.exports = React.createClass( {
 		if ( this.props.onKeyDown ) {
 			this.props.onKeyDown( event );
 		}
-	},
+	}
 
-	render: function() {
-		var id = this.props.id || 'toggle-' + idNum++,
-			toggleClasses = classNames( {
-				'form-toggle': true,
-				'is-toggling': this.props.toggling
-			} );
+	render() {
+		const id = this.props.id || 'toggle-' + this.id;
+		const toggleClasses = classNames( 'form-toggle', this.props.className, {
+			'is-toggling': this.props.toggling
+		} );
 
 		return (
 			<span>
 				<input
-					className={ classNames( this.props.className, toggleClasses ) }
+					className={ toggleClasses }
 					type="checkbox"
 					checked={ this.props.checked }
 					readOnly={ true }
@@ -56,7 +66,7 @@ module.exports = React.createClass( {
 						disabled={ this.props.disabled }
 						id={ id }
 						onClick={ this.props.onChange }
-						onKeyDown={ this._onKeyDown }
+						onKeyDown={ this.onKeyDown }
 						role="checkbox"
 						aria-checked={ this.props.checked }
 						aria-label={ this.props[ 'aria-label' ] }
@@ -67,4 +77,4 @@ module.exports = React.createClass( {
 			</span>
 		);
 	}
-} );
+}

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -28,6 +28,7 @@ export default class FormToggle extends PureComponent {
 		super( ...arguments );
 
 		this.onKeyDown = this.onKeyDown.bind( this );
+		this.onClick = this.onClick.bind( this );
 	}
 
 	componentWillMount() {
@@ -35,14 +36,23 @@ export default class FormToggle extends PureComponent {
 	}
 
 	onKeyDown( event ) {
-		if ( ! this.props.disabled ) {
-			if ( event.key === 'Enter' || event.key === ' ' ) {
-				event.preventDefault();
-				this.props.onChange();
-			}
+		if ( this.props.disabled ) {
+			return;
 		}
+
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			this.props.onChange();
+		}
+
 		if ( this.props.onKeyDown ) {
 			this.props.onKeyDown( event );
+		}
+	}
+
+	onClick() {
+		if ( ! this.props.disabled && this.props.onChange ) {
+			this.props.onChange();
 		}
 	}
 
@@ -65,7 +75,7 @@ export default class FormToggle extends PureComponent {
 					<span className="form-toggle__switch"
 						disabled={ this.props.disabled }
 						id={ id }
-						onClick={ this.props.onChange }
+						onClick={ this.onClick }
 						onKeyDown={ this.onKeyDown }
 						role="checkbox"
 						aria-checked={ this.props.checked }

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -19,7 +19,9 @@ export default class FormToggle extends PureComponent {
 
 	static defaultProps = {
 		checked: false,
-		disabled: false
+		disabled: false,
+		onKeyDown: () => {},
+		onChange: () => {}
 	};
 
 	static idNum = 0;
@@ -45,13 +47,11 @@ export default class FormToggle extends PureComponent {
 			this.props.onChange();
 		}
 
-		if ( this.props.onKeyDown ) {
-			this.props.onKeyDown( event );
-		}
+		this.props.onKeyDown( event );
 	}
 
 	onClick() {
-		if ( ! this.props.disabled && this.props.onChange ) {
+		if ( ! this.props.disabled ) {
 			this.props.onChange();
 		}
 	}


### PR DESCRIPTION
Observed at https://github.com/Automattic/wp-calypso/pull/7047#issuecomment-235691239

This pull request seeks to resolve an issue where `onChange` is still called when clicking a disabled `<FormToggle />` component. This results in dirty form warnings and analytics tracking in the [site writing settings custom type toggles](https://wpcalypso.wordpress.com/settings/writing) when clicking a disabled toggle.

__Implementation notes:__

There are several issues with `<FormToggle />` as a component and is due for some serious refactoring. I attempted to restrain myself with the changes, but see c57af874b3ee5c0fa2a40032c19c7548d784c8ed as an example of changes to be made (that branch isn't working 100% yet).

In this branch, 9e8abc4cbff5f85d51b175da1004d269fcf66550 contains in-place refactoring while 3d757ff4c950b3de6f461f7f9d67592267b886c0 contains the fix itself.

__Testing instructions:__

1. (Prerequisite) Choose a theme for your site which supports Portfolios and/or Testimonials by default (e.g. Sketch)
2. Navigate to [site writing settings](http://calypso.localhost:3000/settings/writing)
3. Select site configured in Step 1
4. Enable analytics debugging by entering `localStorage.debug = 'calypso:analytics';` in your browser developer tools console
5. Refresh the page
6. Click on one of the form toggles
7. Note that...
 - If the toggle is enabled, an analytics event is logged
 - If the toggle is disabled, no analytics event is logged
8. Refresh the page
9. Note that...
 - If the toggle clicked in step 6 is enabled, a dirty form warning is shown
 - If the toggle clicked in step 6 is disabled, no dirty form warning is shown

/cc @timmyc 

Test live: https://calypso.live/?branch=fix/form-toggle-disabled-click