### PR TITLE
Jetpack Sync: Update polling to every 10 seconds

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -20,7 +20,7 @@ import {
 	getSyncStatus,
 	scheduleJetpackFullysync
 } from 'state/jetpack-sync/actions';
-import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
+import Interval, { EVERY_TEN_SECONDS } from 'lib/interval';
 import NoticeAction from 'components/notice/notice-action';
 import analytics from 'lib/analytics';
 
@@ -190,7 +190,7 @@ const JetpackSyncPanel = React.createClass( {
 				{ this.renderErrorNotice() }
 				{ this.renderStatusNotice() }
 				{ this.renderProgressBar() }
-				{ this.shouldDisableSync() && <Interval onTick={ this.fetchSyncStatus } period={ EVERY_FIVE_SECONDS } /> }
+				{ this.shouldDisableSync() && <Interval onTick={ this.fetchSyncStatus } period={ EVERY_TEN_SECONDS } /> }
 			</CompactCard>
 		);
 	}


### PR DESCRIPTION
Currently, we poll the Jetpack site every 5 seconds which is a bit wasteful due to how we throttle sync.

Per a team chat we had:

> Typical full sync requests run for 15 - 20 seconds, and then it sets the “next sync time” 10 seconds into the future

Because of this, it was suggested that we increase the interval between polling requests to at least 10 seconds for now.

To test:

- Checkout `update/jetpack-sync-increase-polling-interval` branch
- Go to `/settings/general/$site` where `$site` has the latest `branch-4.2` of Jetpack
- Click "Perform full sync"
- Open "Network" tab of developer tools and ensure polling is done at 10 second intervals

cc @lezama @gravityrail for review.

Test live: https://calypso.live/?branch=update/jetpack-sync-increase-polling-interval