### PR TITLE
First-view: Increase AB-test percentage from 5 to 40

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -85,8 +85,8 @@ module.exports = {
 	firstView: {
 		datestamp: '20160726',
 		variations: {
-			disabled: 95,
-			enabled: 5,
+			disabled: 60,
+			enabled: 40,
 		},
 		defaultVariation: 'disabled',
 		allowExistingUsers: false,


### PR DESCRIPTION
We've been running first-view at 5% for a while now, without any issues. This PR bumps the participation in first-view to 40%, so that we're more quickly able to gather data.

![image](https://cloud.githubusercontent.com/assets/363749/17376453/3a6d4826-597b-11e6-8ef5-5c12b678a7f8.png)


Test live: https://calypso.live/?branch=update/first-view/ab-percentage