### PR TITLE
Components: Progress Bar: Add isPulsing property

### DIFF
--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -11,7 +11,8 @@ module.exports = React.createClass( {
 	getDefaultProps() {
 		return {
 			total: 100,
-			compact: false
+			compact: false,
+			isPulsing: false
 		};
 	},
 
@@ -21,7 +22,8 @@ module.exports = React.createClass( {
 		color: React.PropTypes.string,
 		title: React.PropTypes.string,
 		compact: React.PropTypes.bool,
-		className: React.PropTypes.string
+		className: React.PropTypes.string,
+		isPulsing: React.PropTypes.bool
 	},
 
 	renderBar() {
@@ -39,7 +41,8 @@ module.exports = React.createClass( {
 
 	render() {
 		const classes = classnames( this.props.className, 'progress-bar', {
-			'is-compact': this.props.compact
+			'is-compact': this.props.compact,
+			'is-pulsing': this.props.isPulsing
 		} );
 		return (
 			<div className={ classes }>

--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+import classnames from 'classnames';
 
 module.exports = React.createClass( {
 
@@ -27,11 +27,11 @@ module.exports = React.createClass( {
 	},
 
 	renderBar() {
-		var styles = { width: Math.ceil( this.props.value / this.props.total * 100 ) + '%' },
-			title = this.props.title
+		const title = this.props.title
 				? <span className="screen-reader-text">{ this.props.title }</span>
 				: null;
 
+		let styles = { width: Math.ceil( this.props.value / this.props.total * 100 ) + '%' };
 		if ( this.props.color ) {
 			styles.backgroundColor = this.props.color;
 		}

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -9,6 +9,10 @@
 	&.is-compact {
 		height: 4px;
 	}
+
+	&.is-pulsing {
+		@include placeholder( 20% );
+	}
 }
 
 .progress-bar__progress {

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -9,10 +9,6 @@
 	&.is-compact {
 		height: 4px;
 	}
-
-	&.is-pulsing {
-		@include placeholder( 20% );
-	}
 }
 
 .progress-bar__progress {
@@ -26,6 +22,17 @@
 	transition: width 200ms;
 }
 
+.progress-bar.is-pulsing .progress-bar__progress {
+	animation: progress-bar-animation 2000ms infinite linear;
+	background-image: linear-gradient( 45deg, $blue-dark 0%, $blue-wordpress 50%, $blue-dark 100% );
+	background-size: 50%;
+}
+
+@keyframes progress-bar-animation {
+  0%   { background-position: 100% 0; }
+  100% {  }
+}
+
 /* Percentage bar */
 .percentage-bar {
 	border-radius: 0;
@@ -35,3 +42,4 @@
 		border-radius: 0;
 	}
 }
+

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -163,7 +163,7 @@ const JetpackSyncPanel = React.createClass( {
 		}
 
 		return (
-			<ProgressBar value={ this.props.syncProgress || 0 } />
+			<ProgressBar isPulsing value={ this.props.syncProgress || 0 } />
 		);
 	},
 


### PR DESCRIPTION
As we gear up for the release of Jetpack 4.2, several testers have remarked that they were confused by the sync status UI. Specifically, they didn't know if it was working or not.

To address this, I started with #7236, which improves the algorithm that determine the percent synced. But, since we will only get new information every 20 seconds or so (due to how we batch sync), we can still improve upon that.

At first I thought about adding a spinner, but that looked janky to me. It seemed weird to have a progress bar and a spinner. ¯\_(ツ)_/¯ 

So, then I decided to borrow from the design pattern we have set around pulsing when fetching data. This seems to have worked out well (IMHO).

Note: Currently the blue and the gray colors pulse. If we go with this pattern, should only the gray pulse?

Here's an example:

![sync-progress-bar-pulse](https://cloud.githubusercontent.com/assets/1126811/17377311/c8643948-597e-11e6-9733-f87ee8cdd60a.gif)
[Higher resolution video](https://cloudup.com/cySCUvt4TMe)

To test:

- Checkout `update/jetpack-sync-status-spinner` branch
- Go to `/settings/general/$site` where `$site` has the latest `branch-4.2` of Jetpack
- Click "Perform full sync" button

cc @rickybanister for design review
cc @lezama for code review
cc @gravityrail @samhotchkiss @jeherve who provided some of the critical feedback

Test live: https://calypso.live/?branch=update/jetpack-sync-status-spinner