### PR TITLE
Reader: add ui_algo to all tracks events

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -79,14 +79,21 @@ function getLocation() {
 export function recordTrack( eventName, eventProperties ) {
 	debug( 'reader track', ...arguments );
 	const subCount = SubscriptionStore.getTotalSubscriptions();
+
+	// Add location as ui_algo prop
+	const location = getLocation();
+	eventProperties = Object.assign( { ui_algo: location }, eventProperties );
+
 	if ( subCount != null ) {
 		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
 	}
+
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'blog_id' in eventProperties && 'post_id' in eventProperties && ! ( 'is_jetpack' in eventProperties ) ) {
 			console.warn( 'consider using recordTrackForPost...', eventName, eventProperties ); //eslint-disable-line no-console
 		}
 	}
+
 	tracks.recordEvent( eventName, eventProperties );
 }
 


### PR DESCRIPTION
Currently, we send a `source` prop when recording follow and unfollow events. 

@xyu commented that `source` can be confusing, and suggested we send `ui_algo` instead. 

@gibrown asked that we send `ui_algo` for all tracks events, initially to help differentiate searches that happen in Reader Search and those that happen in Cold Start (work underway in https://github.com/Automattic/wp-calypso/pull/7196).

This PR adds `ui_algo` to all Reader Tracks events. The value comes from the existing `getLocation()` function (e.g. 'recommended_cold_start' or 'search').




Test live: https://calypso.live/?branch=add/reader/ui-algo-to-tracks-events