### PR TITLE
Fix post comment content word break issue

### DIFF
--- a/client/reader/comments/style.scss
+++ b/client/reader/comments/style.scss
@@ -244,6 +244,7 @@
 	padding-top: 4px;
 	font-size: 14px;
 	line-height: 1.8;
+	word-break: break-word;
 
 	p {
 		color: darken( $gray, 30% );


### PR DESCRIPTION
Fixing the issue that is reported in this  [#7261](https://github.com/Automattic/wp-calypso/issues/7261)

Test live: https://calypso.live/?branch=fix/post-comment-content-word-break