### PR TITLE
Jetpack Sync: Show notice text for pending full sync

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -131,8 +131,12 @@ const JetpackSyncPanel = React.createClass( {
 
 		const finished = get( this.props, 'syncStatus.finished' );
 		const finishedTimestamp = this.moment( parseInt( finished, 10 ) * 1000 );
+		const { isPendingSyncStart, isFullSyncing } = this.props;
+
 		let text = '';
-		if ( this.shouldDisableSync() ) {
+		if ( isPendingSyncStart ) {
+			text = this.translate( 'Full sync will begin shortly' );
+		} else if ( isFullSyncing ) {
 			text = this.translate( 'Full sync in progress' );
 		} else if ( finishedTimestamp.isValid() ) {
 			text = this.translate( 'Last synced %(ago)s', {


### PR DESCRIPTION
During testing of the new Jetpack sync, several users have reported that the UI is confusing and appears to be stuck at times.

To address this, I'd like to suggest #7258 and this PR. #7258 adds an `isPulsing` property to the `ProgressBar` component and implements that for the sync status UI.

This PR simply updates the status notice text such that when we are pending full sync, we'll show "Full sync will begin shortly". Since we schedule full sync via cron, it can potentially be several minutes until full sync begins. Thus, it seems like it could be useful to display some messaging so that users understand that something has happened and they may just need to wait.

cc @gravityrail who made the suggestion.
cc @rickybanister for design review

To test:

- Checkout `update/jetpack-sync-status-sync-scheduled` branch
- Go to `/settings/general/$site` where `$site` has latest `branch-4.2` of Jetpack
- In an incognito tab, or tab where you're not logged in to `$site`, visit the front end of `$site`. This could trigger a cron event which might help show how long sync could be delayed
- Click "Perform full sync" button
- Verify that "Full sync will begin shortly" is displayed for a period of time until "Full sync in progress" is displayed



Test live: https://calypso.live/?branch=update/jetpack-sync-status-sync-scheduled