### PR TITLE
SEO Preview: Discern post vs. site preview

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -17,7 +17,12 @@ import TwitterPreview from 'components/seo/twitter-preview';
 import SearchPreview from 'components/seo/search-preview';
 import VerticalMenu from 'components/vertical-menu';
 import { SocialItem } from 'components/vertical-menu/items';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getSitePost } from 'state/posts/selectors';
+import {
+	getSectionName,
+	getSelectedSite
+} from 'state/ui/selectors';
 
 const ComingSoonMessage = translate => (
 	<div className="seo-preview-pane__message">
@@ -32,44 +37,44 @@ const GooglePreview = site =>
 		snippet={ site.description }
 	/>;
 
-const PreviewFacebook = site => (
-	<div>
-		<FacebookPreview
-			title={ site.name }
-			url={ site.URL }
-			type="website"
-			description={ site.description }
-			image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
-		/>
-		<div style={ { marginBottom: '2em' } } />
-		<FacebookPreview
-			title={ site.name }
-			url={ site.URL }
-			type="article"
-			description={ site.description }
-			image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
-		/>
-	</div>
+const FacebookSite = site => (
+	<FacebookPreview
+		title={ site.name }
+		url={ site.URL }
+		type="website"
+		description={ site.description }
+		image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
+	/>
 );
 
-const PreviewTwitter = site => (
-	<div>
-		<TwitterPreview
-			title={ site.name }
-			url={ site.URL }
-			type="summary"
-			description={ site.description }
-			image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
-		/>
-		<div style={ { marginBottom: '2em' } } />
-		<TwitterPreview
-			title={ site.name }
-			url={ site.URL }
-			type="large_image_summary"
-			description={ site.description }
-			image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
-		/>
-	</div>
+const FacebookPost = ( site, post ) => (
+	<FacebookPreview
+		title={ site.name }
+		url={ site.URL }
+		type="article"
+		description={ site.description }
+		image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
+	/>
+);
+
+const TwitterSite = site => (
+	<TwitterPreview
+		title={ site.name }
+		url={ site.URL }
+		type="summary"
+		description={ site.description }
+		image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
+	/>
+);
+
+const TwitterPost = ( site, post ) => (
+	<TwitterPreview
+		title={ site.name }
+		url={ site.URL }
+		type="large_image_summary"
+		description={ site.description }
+		image={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=512` }
+	/>
 );
 
 export class SeoPreviewPane extends PureComponent {
@@ -89,6 +94,7 @@ export class SeoPreviewPane extends PureComponent {
 
 	render() {
 		const {
+			post,
 			site,
 			translate
 		} = this.props;
@@ -118,10 +124,15 @@ export class SeoPreviewPane extends PureComponent {
 				</div>
 				<div className="seo-preview-pane__preview-area">
 					<div className="seo-preview-pane__preview">
-						{ get( {
-							facebook: PreviewFacebook( site ),
+						{ post && get( {
+							facebook: FacebookPost( site, post ),
 							google: GooglePreview( site ),
-							twitter: PreviewTwitter( site )
+							twitter: TwitterPost( site, post )
+						}, selectedService, ComingSoonMessage( translate ) ) }
+						{ ! post && get( {
+							facebook: FacebookSite( site ),
+							google: GooglePreview( site ),
+							twitter: TwitterSite( site )
 						}, selectedService, ComingSoonMessage( translate ) ) }
 					</div>
 					<div className="seo-preview-pane__preview-spacer" />
@@ -131,12 +142,15 @@ export class SeoPreviewPane extends PureComponent {
 	}
 }
 
-SeoPreviewPane.propTypes = {
-	type: PropTypes.oneOf( [ 'site', 'page', 'post' ] ).isRequired
-};
+const mapStateToProps = state => {
+	const site = getSelectedSite( state );
+	const postId = getEditorPostId( state );
+	const isEditorShowing = 'post-editor' === getSectionName( state );
 
-const mapStateToProps = state => ( {
-	site: getSelectedSite( state )
-} );
+	return {
+		site: site,
+		post: isEditorShowing && getSitePost( state, site.ID, postId )
+	}
+};
 
 export default connect( mapStateToProps, null )( localize( SeoPreviewPane ) );

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -226,7 +226,7 @@ export class WebPreview extends Component {
 								/>
 							}
 							{ 'seo' === this.state.device &&
-								<SeoPreviewPane type="site" siteId="" postId="" pageId=""/>
+								<SeoPreviewPane />
 							}
 						</div>
 					</div>

--- a/server/pragma-checker/index.js
+++ b/server/pragma-checker/index.js
@@ -19,7 +19,9 @@ var IGNORED_MODULES = [
 	'lib/upgrades/actions', // nooped on the server as it still uses the singleton Flux architecture
 	'i18n-calypso', // ignore this until we make it work properly on the server
 	'my-sites/themes/thanks-modal', // stubbed on the server until we develop an isomorphic version
-	'my-sites/themes/themes-site-selector-modal' // stubbed on the server until we develop an isomorphic version
+	'my-sites/themes/themes-site-selector-modal', // stubbed on the server until we develop an isomorphic version
+	'state/ui/editor/selectors', // stubbed on the server until all the dependencies are @ssr-ready
+	'state/posts/selectors', // stubbed on the server until all the dependencies are @ssr-ready
 ];
 
 function PragmaCheckPlugin( options ) {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -87,7 +87,9 @@ module.exports = {
 		new webpack.NormalModuleReplacementPlugin( /^lib\/upgrades\/actions$/, 'lodash/noop' ), // Uses Flux dispatcher
 		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ), // Depends too much on page.js
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ) // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^state\/ui\/editor\/selectors$/, 'lodash/noop' ), // will never be called server-side
+		new webpack.NormalModuleReplacementPlugin( /^state\/posts\/selectors$/, 'lodash/noop' ) // will never be called server-side
 	],
 	externals: getExternals()
 };


### PR DESCRIPTION
Previously, every preview in the SEO preview pane was showing both a
site and a post preview because it was unaware if we were viewing from
somewhere like **My Sites** instead of from within the **Post Editor**.

Now, the preview component detects if the post editor is currently open
and if it is will fill in the `post` prop to the `<SeoPreviewPane />`
inside of `connect()`

*Note* that this does not fill in the appropriate data _from_ the post
or sites into the preview components; it merely makes the information
and distinction available.

**Testing**
There are two ways of showing the SEO preview (three maybe until we decide for sure whether or not it should show on Theme previews). The **My Sites** site preview and the **Post Editor** post preview. In **master** these previews should all be identical, but afterwards, the **My Sites** preview should show _site_ previews while the **post editor** preview should show post-specific previews.

**Site Preview**
This is small and has the image on the left:
<img width="839" alt="screen shot 2016-08-03 at 3 33 47 pm" src="https://cloud.githubusercontent.com/assets/5431237/17384253/cb676fe6-598f-11e6-8825-a32eefa2b0c0.png">

**Post Preview**
This is bigger and has the image at the top:
<img width="841" alt="screen shot 2016-08-03 at 3 34 08 pm" src="https://cloud.githubusercontent.com/assets/5431237/17384268/d2bb90f6-598f-11e6-8302-d2dfb0c9f0c1.png">

cc: @roundhill 

Test live: https://calypso.live/?branch=update/seo-preview-post-data