### PR TITLE
Limit SEO preview to business plan sites

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -202,7 +202,6 @@ export class WebPreview extends Component {
 							{ ...this.props }
 							showExternal={ ( this.props.previewUrl ? this.props.showExternal : false ) }
 							showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
-							showSeo={ true }
 							selectSeoPreview={ this.setDeviceViewport.bind( null, 'seo' ) }
 						/>
 						<div className="web-preview__placeholder">

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -6,13 +6,21 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import config from 'config';
-import { partial } from 'lodash';
+import { connect } from 'react-redux';
+import {
+	overSome,
+	partial
+} from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
+import { isBusiness, isEnterprise } from 'lib/products-values';
 import { localize } from 'i18n-calypso';
+import { getSelectedSite } from 'state/ui/selectors';
+
+const hasBusinessPlan = overSome( isBusiness, isEnterprise );
 
 const possibleDevices = [
 	'computer',
@@ -123,4 +131,8 @@ PreviewToolbar.propTypes = {
 	onClose: PropTypes.func.isRequired,
 };
 
-export default localize( PreviewToolbar );
+const mapStateToProps = state => ( {
+	showSeo: hasBusinessPlan( getSelectedSite( state ).plan )
+} );
+
+export default connect( mapStateToProps )( localize( PreviewToolbar ) );


### PR DESCRIPTION
Currently, the new SEO preview pane in the `<WebPreview />` component is showing for all sites regardless of whether or not they have the business plan (or a higher plan) enabled. The design of this feature is a perk on those paid plan types, so it is necessary to limit the sites for which it shows.

This PR brings in the changes to make that limitation active. It is worth noting that this entire feature still lives behind a feature flag for development and preview environments.

**Testing**
Open up the site preview from either a post in the editor or from the site icon under **My Sites**. Once the preview is open, if a site has a business or enterprise plan, there should be a fourth tab next to the device tabs across the top of the preview with a share icon. Sites without the business plan level or higher will not have that tab.

In another PR we will show the tab for all sites, but will otherwise be deactivated and provide a nudge for an upgrade.

cc: @roundhill @rodrigoi 