### PR TITLE
Jetpack Connect Plans: monthly / yearly toggle

### DIFF
--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -25,6 +25,7 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { requestPlans } from 'state/plans/actions';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
+import Gridicon from 'components/gridicon';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 
@@ -38,6 +39,10 @@ const Plans = React.createClass( {
 		sites: React.PropTypes.object.isRequired,
 		sitePlans: React.PropTypes.object.isRequired,
 		showJetpackFreePlan: React.PropTypes.bool
+	},
+
+	getInitialState() {
+		return { intervalType: 'yearly' };
 	},
 
 	componentDidMount() {
@@ -122,6 +127,32 @@ const Plans = React.createClass( {
 		page( checkoutPath );
 	},
 
+	clickIntervalToggle() {
+		if ( this.state.intervalType === 'monthly' ) {
+			this.setState( { intervalType: 'yearly' } );
+		} else {
+			this.setState( { intervalType: 'monthly' } );
+		}
+		this.props.recordTracksEvent( 'calypso_jpc_plans_toggle', {
+			user: this.props.userId
+		} );
+	},
+
+	renderIntervalToggle() {
+		const showText = ( this.state.intervalType === 'yearly' )
+			? this.translate( 'Show Monthly Plans' )
+			: this.translate( 'Show Yearly Plans' );
+		return (
+			<a
+				onClick={ this.clickIntervalToggle }
+				className="jetpack-connect__plans-interval-toggle"
+			>
+				<Gridicon icon="refresh" size={ 18 } />
+				{ showText }
+			</a>
+		);
+	},
+
 	render() {
 		if ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) {
 			return null;
@@ -146,12 +177,14 @@ const Plans = React.createClass( {
 							step={ 1 }
 							steps={ 3 } />
 
+						{ this.renderIntervalToggle() }
+
 						<div id="plans" className="plans has-sidebar">
 							<PlansFeaturesMain
 								site={ selectedSite }
 								isInSignup={ true }
 								onUpgradeClick={ this.selectPlan }
-								intervalType="yearly" />
+								intervalType={ this.state.intervalType } />
 						</div>
 					</div>
 				</Main>

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -134,7 +134,8 @@ const Plans = React.createClass( {
 			this.setState( { intervalType: 'monthly' } );
 		}
 		this.props.recordTracksEvent( 'calypso_jpc_plans_toggle', {
-			user: this.props.userId
+			user: this.props.userId,
+			intervalType: this.state.intervalType
 		} );
 	},
 

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -385,6 +385,20 @@
 	}
 }
 
+.jetpack-connect__plans-interval-toggle {
+	clear: both;
+	display: block;
+	font-size: 12px;
+	margin: 20px 0 20px 0;
+	text-align: center;
+	cursor: pointer;
+
+	.gridicon {
+		margin: -2px 3px 0 0;
+		vertical-align: middle;
+	}
+}
+
 .jetpack-connect__sso-shared-detail-label {
 	font-weight: bold;
 }


### PR DESCRIPTION
Show a toggle to switch between monthly and yearly plans during the JPC flow.

Closes #7013 

Here's a screen cast:
https://cloudup.com/cdOsvFbDkcM

To test:
- checkout this branch and go to calypso.localhost:3000/jetpack/connect
- connect an unconnected Jetpack site that has no upgrades
- ensure that you are presented with the Plans screen, and that you can toggle between monthly and yearly plans

cc: @tyxla @johnHackworth 

Test live: https://calypso.live/?branch=add/jpc-monthly-plans-toggle