### PR TITLE
Reader Search: test different suggestions

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -90,5 +90,14 @@ module.exports = {
 		},
 		defaultVariation: 'disabled',
 		allowExistingUsers: false,
+	},
+	readerSearchSuggestions: {
+		datestamp: '20160804',
+		variations: {
+			staffSuggestions: 50,
+			popularSuggestions: 50
+		},
+		defaultVariation: 'staffSuggestions',
+		allowExistingUsers: false,
 	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,6 +98,6 @@ module.exports = {
 			popularSuggestions: 50
 		},
 		defaultVariation: 'staffSuggestions',
-		allowExistingUsers: false,
+		allowExistingUsers: true
 	}
 };

--- a/client/reader/search-stream/blank.jsx
+++ b/client/reader/search-stream/blank.jsx
@@ -16,7 +16,7 @@ export function BlankContent( { translate, suggestions } ) {
 
 		suggest = (
 			<p className="search-stream__blank-suggestions">
-				{ translate( 'Staff Suggestions: {{suggestions /}}.', { components: { suggestions: sugList } } ) }
+				{ translate( 'Suggestions: {{suggestions /}}.', { components: { suggestions: sugList } } ) }
 			</p> );
 	}
 

--- a/client/reader/search-stream/blank.jsx
+++ b/client/reader/search-stream/blank.jsx
@@ -1,12 +1,28 @@
+/**
+ * External Dependencies
+ */
 import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
 import { localize } from 'i18n-calypso';
+import { recordTrack } from 'reader/stats';
 
 export function BlankContent( { translate, suggestions } ) {
+	const handleSuggestionClick = ( suggestion ) => {
+		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion } );
+	};
+
 	let suggest = null;
 	if ( suggestions ) {
 		let sugList = suggestions
 			.map( function( query ) {
-				return <a href={ '/read/search?q=' + encodeURIComponent( query ) } >{ query }</a>;
+				return (
+					<a onClick={ () => handleSuggestionClick( query ) } href={ '/read/search?q=' + encodeURIComponent( query ) } >
+						{ query }
+					</a>
+				);
 			} );
 		sugList = sugList
 			.slice( 1 )
@@ -21,6 +37,7 @@ export function BlankContent( { translate, suggestions } ) {
 	}
 
 	const imgPath = '/calypso/images/drake/drake-404.svg';
+
 	return (
 		<div className="search-stream__blank">
 			{ suggest }

--- a/client/reader/search-stream/blank.jsx
+++ b/client/reader/search-stream/blank.jsx
@@ -7,21 +7,15 @@ import React from 'react';
  * Internal Dependencies
  */
 import { localize } from 'i18n-calypso';
-import { recordTrack } from 'reader/stats';
+import Suggestion from './suggestion';
 
 export function BlankContent( { translate, suggestions } ) {
-	const handleSuggestionClick = ( suggestion ) => {
-		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion } );
-	};
-
 	let suggest = null;
 	if ( suggestions ) {
 		let sugList = suggestions
 			.map( function( query ) {
 				return (
-					<a onClick={ () => handleSuggestionClick( query ) } href={ '/read/search?q=' + encodeURIComponent( query ) } >
-						{ query }
-					</a>
+					<Suggestion suggestion={ query } />
 				);
 			} );
 		sugList = sugList

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -21,6 +21,8 @@ import FeedStore from 'lib/feed-store';
 import { recordTrackForPost } from 'reader/stats';
 import sampleSize from 'lodash/sampleSize';
 import i18nUtils from 'lib/i18n-utils';
+import { staffSuggestions, popularSuggestions } from './suggestions';
+import { abtest } from 'lib/abtest';
 
 const SearchCardAdapter = React.createClass( {
 	getInitialState() {
@@ -94,74 +96,28 @@ const emptyStore = {
 
 const FeedStream = React.createClass( {
 
-	searchSuggestions: {
-		en: [
-			'2016 Election',
-			'Astrology',
-			'Batman',
-			'Beach',
-			'Beautiful',
-			'Bloom',
-			'Chickens',
-			'Clinton',
-			'Cocktails',
-			'Colorado',
-			'Craft Beer',
-			'Cute',
-			'DIY',
-			'Delicious',
-			'Dogs',
-			'Elasticsearch',
-			'Fabulous',
-			'Farm',
-			'Flowers',
-			'Funny',
-			'Garden',
-			'Groovy',
-			'Happy Place',
-			'Hiking',
-			'Homesteading',
-			'Iceland',
-			'Inspiration',
-			'Juno',
-			'Mathematics',
-			'Michigan',
-			'Monkeys',
-			'Mountain Biking',
-			'Obama',
-			'Overwatch',
-			'Pokemon GO',
-			'Pride',
-			'Recipe',
-			'Red Sox',
-			'Robots',
-			'Scenic',
-			'Sharks',
-			'Sous vide',
-			'Sunday Brunch',
-			'Tibet',
-			'Toddlers',
-			'Travel Backpacks',
-			'Travel',
-			'Trump',
-			'Woodworking',
-			'WordPress',
-			'Zombies'
-		]
-	},
-
 	propTypes: {
 		query: React.PropTypes.string
 	},
 
 	getInitialState() {
-		let suggestions = null;
 		const lang = i18nUtils.getLocaleSlug();
-		if ( this.searchSuggestions[ lang ] ) {
-			suggestions = sampleSize( this.searchSuggestions[ lang ], 3 );
+		let sourceSuggestions = null;
+		let pickedSuggestions = null;
+
+		// Which set of suggestions should we use?
+		if ( abtest( 'readerSearchSuggestions' ) === 'popularSuggestions' ) {
+			sourceSuggestions = popularSuggestions;
+		} else {
+			sourceSuggestions = staffSuggestions;
 		}
+
+		if ( sourceSuggestions[ lang ] ) {
+			pickedSuggestions = sampleSize( sourceSuggestions[ lang ], 3 );
+		}
+
 		return {
-			suggestions: suggestions,
+			suggestions: pickedSuggestions,
 			title: this.getTitle()
 		};
 	},
@@ -203,7 +159,7 @@ const FeedStream = React.createClass( {
 	},
 
 	render() {
-		const blankContent = this.props.showBlankContent ? <BlankContent suggestions={ this.state.suggestions }/> : null;
+		const blankContent = this.props.showBlankContent ? <BlankContent suggestions={ this.state.suggestions } /> : null;
 		const emptyContent = this.props.query
 			? <EmptyContent query={ this.props.query } />
 			: blankContent;

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -1,0 +1,27 @@
+/**
+ * External Dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import { recordTrack } from 'reader/stats';
+
+export function Suggestion( { suggestion } ) {
+	const handleSuggestionClick = () => {
+		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion } );
+	};
+
+	return (
+		<a onClick={ handleSuggestionClick } href={ '/read/search?q=' + encodeURIComponent( suggestion ) } >
+			{ suggestion }
+		</a>
+	);
+}
+
+Suggestion.propTypes = {
+	suggestion: PropTypes.string.isRequired
+};
+
+export default Suggestion;

--- a/client/reader/search-stream/suggestions.js
+++ b/client/reader/search-stream/suggestions.js
@@ -1,0 +1,63 @@
+export const staffSuggestions = {
+	en: [
+		'2016 Election',
+		'Astrology',
+		'Batman',
+		'Beach',
+		'Beautiful',
+		'Bloom',
+		'Chickens',
+		'Clinton',
+		'Cocktails',
+		'Colorado',
+		'Craft Beer',
+		'Cute',
+		'DIY',
+		'Delicious',
+		'Dogs',
+		'Elasticsearch',
+		'Fabulous',
+		'Farm',
+		'Flowers',
+		'Funny',
+		'Garden',
+		'Groovy',
+		'Happy Place',
+		'Hiking',
+		'Homesteading',
+		'Iceland',
+		'Inspiration',
+		'Juno',
+		'Mathematics',
+		'Michigan',
+		'Monkeys',
+		'Mountain Biking',
+		'Obama',
+		'Overwatch',
+		'Pokemon GO',
+		'Pride',
+		'Recipe',
+		'Red Sox',
+		'Robots',
+		'Scenic',
+		'Sharks',
+		'Sous vide',
+		'Sunday Brunch',
+		'Tibet',
+		'Toddlers',
+		'Travel Backpacks',
+		'Travel',
+		'Trump',
+		'Woodworking',
+		'WordPress',
+		'Zombies'
+	]
+};
+
+export const popularSuggestions = {
+	en: [
+		'Popular1',
+		'Popular2',
+		'Popular3'
+	]
+};

--- a/client/reader/search-stream/suggestions.js
+++ b/client/reader/search-stream/suggestions.js
@@ -56,8 +56,34 @@ export const staffSuggestions = {
 
 export const popularSuggestions = {
 	en: [
-		'Popular1',
-		'Popular2',
-		'Popular3'
+		'Food',
+		'Writing',
+		'Life',
+		'Happy Place',
+		'Art',
+		'DIY',
+		'Love',
+		'Health',
+		'Funny',
+		'Trump',
+		'Fashion',
+		'Fitness',
+		'Anime',
+		'Philosophy',
+		'Yoga',
+		'Travel',
+		'Beauty',
+		'Politics',
+		'Parenting',
+		'Photography',
+		'Books',
+		'Technology',
+		'Vegan',
+		'Motivation',
+		'Poetry',
+		'Psychology',
+		'Makeup',
+		'Homeschool',
+		'Community Pool'
 	]
 };


### PR DESCRIPTION
We currently have staff suggestions shown under the search box, which were chosen by Reader Squad:

<img width="766" alt="screen shot 2016-08-04 at 19 08 32" src="https://cloud.githubusercontent.com/assets/17325/17411080/e540c60a-5a76-11e6-877c-27d2daf7135d.png">

This PR introduces a new list of popular search terms as suggestions, and A/B tests that against the existing staff suggestions.

@gibrown also suggested that we add a Tracks events for any click on a suggestion.



Test live: https://calypso.live/?branch=add/reader/search-test-suggestions