### PR TITLE
Search: Add focus styles

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -147,8 +147,7 @@
 	}
 
 	&:focus {
-		box-shadow: none;
-		border: none;
+		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
 	}
 }
 

--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -25,6 +25,10 @@
 		align-self: center;
 	}
 
+	.select-dropdown {
+		margin-left: 16px;
+	}
+
 	.more {
 		line-height: 18px;
 		padding: 11px 14px 11px;


### PR DESCRIPTION
Currently, search inputs don't have an obvious focus state:

![screen shot 2016-08-04 at 2 16 42 pm](https://cloud.githubusercontent.com/assets/191598/17413226/596eab60-5a4e-11e6-990b-86911f97f610.png)

This PR adds a box-shadow to the input when it's focused, similar to how we treat other inputs in Calypso:

![screen shot 2016-08-04 at 2 16 31 pm](https://cloud.githubusercontent.com/assets/191598/17413241/6dc79248-5a4e-11e6-9555-d0c815263f42.png)


Test live: https://calypso.live/?branch=update/search-focus-style