### PR TITLE
Reader: Use the source tag name on post bylines and fix empty tag streams

### DIFF
--- a/client/reader/post-byline/index.jsx
+++ b/client/reader/post-byline/index.jsx
@@ -104,7 +104,7 @@ class PostByline extends React.Component {
 				</li> : null }
 			{ primaryTag ?
 				<li className="reader-post-byline__tag">
-					<a href={ '/tag/' + primaryTag.slug } className="ignore-click" onClick={ this.recordTagClick }><Gridicon icon="tag" size={ 16 } /> { primaryTag.display_name }</a>
+					<a href={ '/tag/' + primaryTag.slug } className="ignore-click" onClick={ this.recordTagClick }><Gridicon icon="tag" size={ 16 } /> { primaryTag.name }</a>
 				</li> : null }
 			</ul>
 		);

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  */
 import EmptyContent from 'components/empty-content';
 import * as stats from 'reader/stats';
-import discoverHelper from 'reader/discover/helper';
+import { isDiscoverEnabled } from 'reader/discover/helper';
 
 const TagEmptyContent = React.createClass( {
 	propTypes: {
@@ -37,7 +37,7 @@ const TagEmptyContent = React.createClass( {
 			onClick={ this.recordAction }
 			href="/">{ this.translate( 'Back to Following' ) }</a> );
 
-		const secondaryAction = discoverHelper.isDiscoverEnabled()
+		const secondaryAction = isDiscoverEnabled()
 			? ( <a
 			className="empty-content__action button"
 			onClick={ this.recordSecondaryAction }


### PR DESCRIPTION
before 
<img width="727" alt="crisis_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/17415748/16b540e4-5a59-11e6-8a1f-0a06c64b3efe.png">

after
<img width="717" alt="crisis_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/17415724/066d2292-5a59-11e6-97b0-d605835dfbb6.png">
