### PR TITLE
First-view: Use config with paths for determining active view

### DIFF
--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -84,7 +84,7 @@ const FirstView = React.createClass( {
 	},
 
 	hide() {
-		this.props.hideView( { view: this.props.sectionName, enabled: this.state.isEnabled } );
+		this.props.hideView( { enabled: this.state.isEnabled } );
 	},
 
 	enableOrDisableNextTime( event ) {

--- a/client/state/ui/first-view/actions.js
+++ b/client/state/ui/first-view/actions.js
@@ -12,19 +12,20 @@ import {
 
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
-import { bucketedTimeSpentOnCurrentView } from './selectors';
+import { bucketedTimeSpentOnCurrentView, getConfigForCurrentView } from './selectors';
 
-export function hideView( { view, enabled } ) {
-	const hideAction = {
-		type: FIRST_VIEW_HIDE,
-		view,
-	};
-
+export function hideView( { enabled } ) {
 	return ( dispatch, getState ) => {
 		const timeBucket = bucketedTimeSpentOnCurrentView( getState() );
+		const config = getConfigForCurrentView( getState() );
+
+		const hideAction = {
+			type: FIRST_VIEW_HIDE,
+			view: config.name,
+		};
 
 		const tracksEvent = recordTracksEvent( `calypso_first_view_dismissed`, {
-			view,
+			view: config.name,
 			showAgain: enabled,
 			timeSpent: timeBucket,
 		} );
@@ -34,7 +35,7 @@ export function hideView( { view, enabled } ) {
 		dispatch( bumpStat( 'calypso_first_view_duration', timeBucket ) );
 		dispatch( tracksEvent );
 		dispatch( hideAction );
-		dispatch( persistToPreferences( { getState, view, disabled: ! enabled } ) );
+		dispatch( persistToPreferences( { getState, view: config.name, disabled: ! enabled } ) );
 	};
 }
 

--- a/client/state/ui/first-view/actions.js
+++ b/client/state/ui/first-view/actions.js
@@ -19,6 +19,10 @@ export function hideView( { enabled } ) {
 		const timeBucket = bucketedTimeSpentOnCurrentView( getState() );
 		const config = getConfigForCurrentView( getState() );
 
+		if ( ! config || ! config.name ) {
+			return false;
+		}
+
 		const hideAction = {
 			type: FIRST_VIEW_HIDE,
 			view: config.name,

--- a/client/state/ui/first-view/constants.js
+++ b/client/state/ui/first-view/constants.js
@@ -2,13 +2,19 @@
 
 import { isEnabled } from 'config';
 
-const startDates = {
-	stats: '2016-06-22',
-};
-
-if ( isEnabled( 'pages/first-view-prototype' ) ) {
-	// this date will need to be changed before we release the pages FV
-	startDates[ 'posts-pages' ] = '2020-01-01';
-}
-
-export const FIRST_VIEW_START_DATES = startDates;
+export const FIRST_VIEW_CONFIG = [
+	{
+		name: 'stats',
+		paths: [
+			'/stats',
+		],
+		enabled: true,
+	},
+	{
+		name: 'pages-prototype',
+		paths: [
+			'/pages',
+		],
+		enabled: isEnabled( 'pages/first-view-prototype' ),
+	}
+];

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -37,7 +37,7 @@ export function isViewEnabled( state, config ) {
 	const firstViewHistory = getPreference( state, 'firstViewHistory' ).filter( entry => entry.view === config.name );
 	const latestFirstViewHistory = [ ...firstViewHistory ].pop();
 	const isViewDisabled = latestFirstViewHistory ? ( !! latestFirstViewHistory.disabled ) : false;
-	return ! isViewDisabled;
+	return config.enabled && ! isViewDisabled;
 }
 
 export function wasFirstViewHiddenSinceEnteringCurrentSection( state, config ) {

--- a/client/state/ui/first-view/test/actions.js
+++ b/client/state/ui/first-view/test/actions.js
@@ -8,7 +8,8 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	FIRST_VIEW_HIDE
+	FIRST_VIEW_HIDE,
+	ROUTE_SET,
 } from 'state/action-types';
 import {
 	hideView
@@ -23,7 +24,12 @@ describe( 'actions', () => {
 			}
 		},
 		ui: {
-			actionLog: []
+			actionLog: [
+				{
+					type: ROUTE_SET,
+					path: '/stats',
+				},
+			]
 		}
 	} );
 

--- a/client/state/ui/first-view/test/selectors.js
+++ b/client/state/ui/first-view/test/selectors.js
@@ -67,25 +67,25 @@ describe( 'selectors', () => {
 
 		it( 'should return true if the preferences have been fetched, the config has a first view for the current view,' +
 			' and it is not disabled', () => {
-				const viewEnabled = isViewEnabled( {
-					preferences: {
-						values: {
-							firstViewHistory: [
-								{
-									view: 'stats',
-									timestamp: 123456,
-									disabled: false
-								}
-							]
-						},
-						lastFetchedTimestamp: 123456,
+			const viewEnabled = isViewEnabled( {
+				preferences: {
+					values: {
+						firstViewHistory: [
+							{
+								view: 'stats',
+								timestamp: 123456,
+								disabled: false
+							}
+						]
 					},
-					ui: {
-						actionLog: actions,
-					}
-				}, config );
+					lastFetchedTimestamp: 123456,
+				},
+				ui: {
+					actionLog: actions,
+				}
+			}, config );
 
-				expect( viewEnabled ).to.be.true;
+			expect( viewEnabled ).to.be.true;
 		} );
 
 		it( 'should return true if preferences have been fetched and the history is empty', () => {

--- a/client/state/ui/first-view/test/selectors.js
+++ b/client/state/ui/first-view/test/selectors.js
@@ -47,7 +47,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			expect( firstViewConfig ).to.deep.equal ( { name: 'stats', paths: [ '/stats' ], enabled: true } );
+			expect( firstViewConfig ).to.deep.equal( { name: 'stats', paths: [ '/stats' ], enabled: true } );
 		} );
 	} );
 
@@ -65,27 +65,27 @@ describe( 'selectors', () => {
 			enabled: true,
 		};
 
-		it( 'should return true if the preferences have been fetched, the config has a first view for the current view, and it is not disabled', () => {
-			
-			const viewEnabled = isViewEnabled( {
-				preferences: {
-					values: {
-						firstViewHistory: [
-							{
-								view: 'stats',
-								timestamp: 123456,
-								disabled: false
-							}
-						]
+		it( 'should return true if the preferences have been fetched, the config has a first view for the current view,' +
+			' and it is not disabled', () => {
+				const viewEnabled = isViewEnabled( {
+					preferences: {
+						values: {
+							firstViewHistory: [
+								{
+									view: 'stats',
+									timestamp: 123456,
+									disabled: false
+								}
+							]
+						},
+						lastFetchedTimestamp: 123456,
 					},
-					lastFetchedTimestamp: 123456,
-				},
-				ui: {
-					actionLog: actions,
-				}
-			}, config );
+					ui: {
+						actionLog: actions,
+					}
+				}, config );
 
-			expect( viewEnabled ).to.be.true;
+				expect( viewEnabled ).to.be.true;
 		} );
 
 		it( 'should return true if preferences have been fetched and the history is empty', () => {
@@ -161,7 +161,7 @@ describe( 'selectors', () => {
 			}, config );
 
 			expect( viewEnabled ).to.be.false;
-		} )
+		} );
 	} );
 
 	describe( '#wasFirstViewHiddenSinceEnteringCurrentSection()', () => {


### PR DESCRIPTION
This PR switches from using section-based triggering for first-views to using path-based triggering. Those paths are stored in a new `FIRST_VIEW_CONFIG` which replaces `FIRST_VIEW_START_DATES`. Since the start-date data wasn't actually being used, I've removed it -- if we add start dates in the future, they could easily be added to the config array.

To test:
* Checkout branch and `make run`
* Reset first-view state if necessary (visit `/stats/reset-first-view`) or test with a new user
* Visit any `/stats` page, and make sure the Stats First View shows as expected and the preference is remembered as expected.
* Visit `/pages` (without enabling `pages/first-view-prototype`), and make sure that the first view *does not* show
* Use Control+C to stop `make run`
* Enable `pages/first-view-prototype` and `make run` again. The easiest way to do this is `ENABLE_FEATURES=pages/first-view-prototype make run`
* Visit `/pages`, and make sure the prototype first-view is displayed. Make sure the preference is remembered as expected.

Test live: https://calypso.live/?branch=update/first-view/view-selector