### PR TITLE
Editor: Resolve stuck post ID on navigating to new post from edited

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -152,7 +152,8 @@ const PostEditor = React.createClass( {
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
-		if ( nextProps.editPath !== this.props.editPath ) {
+		const { siteId, postId } = this.props;
+		if ( nextProps.siteId === siteId && nextProps.postId !== postId ) {
 			// make sure the history entry has the post ID in it, but don't dispatch
 			page.replace( nextProps.editPath, null, false, false );
 		}


### PR DESCRIPTION
Related: #6508
Fixes #7280 

This pull request seeks to resolve an issue where the post ID remains in the URL path when navigating from an edited post to a new one, even when switching sites.

__Implementation notes:__

The cause of the issue is that it [hits the `siteSelection` middleware which dispatches an update to site ID](https://github.com/Automattic/wp-calypso/blob/8fbb93c/client/my-sites/controller.js#L167), which then immediately causes the `connect`ed `<PostEditor />` to [receive a new `editPath`](https://github.com/Automattic/wp-calypso/blob/8fbb93c/client/post-editor/post-editor.jsx#L154-L159) consisting of the next site’s slug but the old site’s post ID. Page.js doesn’t like the URL being changed while middleware is being executed, [so it aborts](https://github.com/visionmedia/page.js/blob/aa60550/index.js#L301-L304) and we never reach the `post` controller where the [editor post ID update would take place](
https://github.com/Automattic/wp-calypso/blob/8fbb93c/client/post-editor/controller.js#L117).

I played with a few ideas for how to fix this, and I wasn't entirely happy with any of them. This originates from #6508, specifically the comments starting at https://github.com/Automattic/wp-calypso/pull/6508#discussion_r70088032, leading us to change the way we'd updated the URL after the post was saved. Other ideas I had considered include:

- Not allowing the `componentWillReceiveProps` to update while in the midst of a page URL transition 
  - How to accomplish this? Perhaps actions creators at the start and end of a transition using `page( '*' )` middlewares
- Reverting back to the [original approach](https://github.com/Automattic/wp-calypso/pull/6508/commits/04d5bcc58f1a6ffb0a7c5ac5517f6ef261c925b2) which relies upon the prop change taking effect immediately
  - Funny enough, this immediate update behavior is the cause of this newer bug 😵 
- Reset the [`ui.editor.postId` state](https://github.com/Automattic/wp-calypso/blob/b3d750e068547e84463313f0bb5b7f7b3921a928/client/state/ui/editor/reducer.js#L14-L29) when a `SELECTED_SITE_SET` action is dispatched
  - While this works and I feel like we should do something like this anyways, it's more of an indirect fix

__Testing instructions:__

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site
3. Enter a title and/or content
4. Save the post
5. Note that the URL path contains the post ID after saving has completed
6. From the master bar New Post button, start a draft on a different site
7. Note that the editor transitions to a blank new draft with no post ID in the URL path

/cc @timmyc

Test live: https://calypso.live/?branch=fix/editor-edited-to-new