### PR TITLE
Revert "Editor: Resolve stuck post ID on navigating to new post from edited"

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -152,8 +152,7 @@ const PostEditor = React.createClass( {
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
-		const { siteId, postId } = this.props;
-		if ( nextProps.siteId === siteId && nextProps.postId !== postId ) {
+		if ( nextProps.editPath !== this.props.editPath ) {
 			// make sure the history entry has the post ID in it, but don't dispatch
 			page.replace( nextProps.editPath, null, false, false );
 		}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#7289

Test live: https://calypso.live/?branch=revert-7289-fix/editor-edited-to-new