### PR TITLE
Revert "Limit SEO preview to business plan sites"

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -202,6 +202,7 @@ export class WebPreview extends Component {
 							{ ...this.props }
 							showExternal={ ( this.props.previewUrl ? this.props.showExternal : false ) }
 							showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
+							showSeo={ true }
 							selectSeoPreview={ this.setDeviceViewport.bind( null, 'seo' ) }
 						/>
 						<div className="web-preview__placeholder">

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -6,21 +6,13 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import config from 'config';
-import { connect } from 'react-redux';
-import {
-	overSome,
-	partial
-} from 'lodash';
+import { partial } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
-import { isBusiness, isEnterprise } from 'lib/products-values';
 import { localize } from 'i18n-calypso';
-import { getSelectedSite } from 'state/ui/selectors';
-
-const hasBusinessPlan = overSome( isBusiness, isEnterprise );
 
 const possibleDevices = [
 	'computer',
@@ -131,8 +123,4 @@ PreviewToolbar.propTypes = {
 	onClose: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = state => ( {
-	showSeo: hasBusinessPlan( getSelectedSite( state ).plan )
-} );
-
-export default connect( mapStateToProps )( localize( PreviewToolbar ) );
+export default localize( PreviewToolbar );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#7267

Test live: https://calypso.live/?branch=revert-7267-update/seo-preview/limit-tobusiness