### PR TITLE
Reader: update discover card stats

### DIFF
--- a/client/reader/discover/_style.scss
+++ b/client/reader/discover/_style.scss
@@ -13,14 +13,13 @@
 			margin-top: 15px;
 		}
 
-		.gridicon-arrow {
+		.gridicons-arrow-right {
 			height: 12px;
 			width: 12px;
 			fill: $white;
 			background: $gray;
 			padding: 4px;
 			border-radius: 100%;
-			transform: rotate(180deg);
 			position: relative;
 				top: 6px;
 			margin-right: 6px;

--- a/client/reader/discover/post-attribution.jsx
+++ b/client/reader/discover/post-attribution.jsx
@@ -7,15 +7,28 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { translate } from 'i18n-calypso';
 import FollowButton from 'reader/follow-button';
 import { getLinkProps } from './helper';
-import { recordTrack } from 'reader/stats';
+import * as discoverStats from './stats';
 
-const arrowGridicon = ( <svg className="gridicon gridicon-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 11H6.414l6.293-6.293-1.414-1.414L2.586 12l8.707 8.707 1.414-1.414L6.414 13H20"/></svg> );
+const arrowGridicon = (
+	<svg className="gridicon gridicon-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<path d="M20 11H6.414l6.293-6.293-1.414-1.414L2.586 12l8.707 8.707 1.414-1.414L6.414 13H20"/>
+	</svg>
+);
 
-const DiscoverPostAttribution = React.createClass( {
+class DiscoverPostAttribution extends React.Component {
 
-	propTypes: {
+	constructor( props ) {
+		super( props );
+
+		[ 'recordAuthorClick', 'recordSiteClick', 'recordFollowToggle' ].forEach(
+			( method ) => this[ method ] = this[ method ].bind( this )
+		);
+	}
+
+	static propTypes = {
 		attribution: React.PropTypes.shape( {
 			author_name: React.PropTypes.string.isRequired,
 			author_url: React.PropTypes.string.isRequired,
@@ -25,19 +38,19 @@ const DiscoverPostAttribution = React.createClass( {
 		} ).isRequired,
 		siteUrl: React.PropTypes.string.isRequired,
 		followUrl: React.PropTypes.string.isRequired
-	},
+	}
 
-	recordAuthorClick() {
-		recordTrack( 'calypso_reader_author_on_discover_card_clicked', {
-			author_url: this.props.attribution.author_url
-		} );
-	},
+	recordAuthorClick( ) {
+		discoverStats.recordAuthorClick( this.props.attribution.author_url );
+	}
 
-	recordSiteClick() {
-		recordTrack( 'calypso_reader_site_on_discover_card_clicked', {
-			site_url: this.props.siteUrl
-		} );
-	},
+	recordSiteClick( ) {
+		discoverStats.recordSiteClick( this.props.siteUrl );
+	}
+
+	recordFollowToggle( isFollowing ) {
+		discoverStats.recordFollowingToggle( isFollowing, this.props.siteUrl );
+	}
 
 	render() {
 		const attribution = this.props.attribution;
@@ -46,20 +59,24 @@ const DiscoverPostAttribution = React.createClass( {
 		} );
 		const siteLinkProps = getLinkProps( this.props.siteUrl );
 		const siteClasses = classNames( 'discover-attribution__blog ignore-click' );
+
 		return (
 			<div className={ classes }>
 				{ attribution.avatar_url ? <img className="gravatar" src={ encodeURI( attribution.avatar_url ) } alt="Avatar" width="20" height="20" /> : arrowGridicon }
 				<span className="discover-attribution__text">
-					{ this.translate( 'Originally posted by' ) }
-					&nbsp;<a className="discover-attribution__author" rel="external" target="_blank" onClick={ this.recordAuthorClick } href={ encodeURI( attribution.author_url ) }>{ attribution.author_name }</a>&nbsp;
-					{ this.translate( 'on' ) }
-					&nbsp;<a { ...siteLinkProps } className={ siteClasses } onClick={ this.recordSiteClick } href={ encodeURI( this.props.siteUrl ) }>{ attribution.blog_name }</a>
-					{ !! this.props.followUrl ? <FollowButton siteUrl={ this.props.followUrl } iconSize={ 20 } /> : null }
+					{ translate( 'Originally posted by' ) }&nbsp;
+					<a className="discover-attribution__author" rel="external" target="_blank" onClick={ this.recordAuthorClick } href={ encodeURI( attribution.author_url ) }>
+						{ attribution.author_name }
+					</a>&nbsp;
+					{ translate( 'on' ) }&nbsp;
+					<a { ...siteLinkProps } className={ siteClasses } onClick={ this.recordSiteClick } href={ encodeURI( this.props.siteUrl ) }>
+						{ attribution.blog_name }
+					</a>
+					{ !! this.props.followUrl ? <FollowButton siteUrl={ this.props.followUrl } iconSize={ 20 } onFollowToggle={ this.recordFollowToggle }/> : null }
 				</span>
 			</div>
 		);
 	}
-
-} );
+}
 
 module.exports = DiscoverPostAttribution;

--- a/client/reader/discover/post-attribution.jsx
+++ b/client/reader/discover/post-attribution.jsx
@@ -8,15 +8,10 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { translate } from 'i18n-calypso';
+import Gridicon from 'components/gridicon';
 import FollowButton from 'reader/follow-button';
 import { getLinkProps } from './helper';
 import * as discoverStats from './stats';
-
-const arrowGridicon = (
-	<svg className="gridicon gridicon-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<path d="M20 11H6.414l6.293-6.293-1.414-1.414L2.586 12l8.707 8.707 1.414-1.414L6.414 13H20"/>
-	</svg>
-);
 
 class DiscoverPostAttribution extends React.Component {
 
@@ -62,7 +57,9 @@ class DiscoverPostAttribution extends React.Component {
 
 		return (
 			<div className={ classes }>
-				{ attribution.avatar_url ? <img className="gravatar" src={ encodeURI( attribution.avatar_url ) } alt="Avatar" width="20" height="20" /> : arrowGridicon }
+				{ attribution.avatar_url
+					? <img className="gravatar" src={ encodeURI( attribution.avatar_url ) } alt="Avatar" width="20" height="20" />
+					: <Gridicon icon="arrow-right" /> }
 				<span className="discover-attribution__text">
 					{ translate( 'Originally posted by' ) }&nbsp;
 					<a className="discover-attribution__author" rel="external" target="_blank" onClick={ this.recordAuthorClick } href={ encodeURI( attribution.author_url ) }>

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -7,12 +7,23 @@
 /**
  * Internal dependencies
  */
+ import { translate } from 'i18n-calypso';
  import FollowButton from 'reader/follow-button';
  import { getLinkProps } from './helper';
+ import * as discoverStats from './stats';
 
-var DiscoverSiteAttribution = React.createClass( {
+// var DiscoverSiteAttribution = React.createClass( {
+class DiscoverSiteAttribution extends React.Component {
 
-	propTypes: {
+	constructor( props ) {
+		super( props );
+
+		[ 'recordSiteClick', 'recordFollowToggle' ].forEach( ( method ) => {
+			this[ method ] = this[ method ].bind( this );
+		} );
+	}
+
+	static propTypes = {
 		attribution: React.PropTypes.shape( {
 			blog_name: React.PropTypes.string.isRequired,
 			blog_url: React.PropTypes.string.isRequired,
@@ -20,9 +31,17 @@ var DiscoverSiteAttribution = React.createClass( {
 		} ).isRequired,
 		siteUrl: React.PropTypes.string.isRequired,
 		followUrl: React.PropTypes.string.isRequired
-	},
+	}
 
-	render: function() {
+	recordSiteClick( ) {
+		discoverStats.recordSiteClick( this.props.siteUrl );
+	}
+
+	recordFollowToggle( isFollowing ) {
+		discoverStats.recordFollowToggle( isFollowing, this.props.siteUrl );
+	}
+
+	render() {
 		const attribution = this.props.attribution;
 		const classes = classNames( 'discover-attribution is-site', {
 			'is-missing-avatar': ! attribution.avatar_url
@@ -34,15 +53,15 @@ var DiscoverSiteAttribution = React.createClass( {
 			<div className={ classes }>
 				{ attribution.avatar_url ? <img className="gravatar" src={ encodeURI( attribution.avatar_url ) } alt="Avatar" width="20" height="20" /> : <span className="noticon noticon-website"></span> }
 				<span>
-					<a { ...siteLinkProps } className={ siteClasses } href={ encodeURI( this.props.siteUrl ) }>
-						{ this.translate( 'visit' ) } <em>{ attribution.blog_name }</em>
+					<a { ...siteLinkProps } className={ siteClasses } href={ encodeURI( this.props.siteUrl ) } onClick={ this.recordSiteClick }>
+						{ translate( 'visit' ) } <em>{ attribution.blog_name }</em>
 					</a>
 				</span>
-				{ !! this.props.followUrl ? <FollowButton siteUrl={ this.props.followUrl } iconSize={ 20 } /> : null }
+				{ !! this.props.followUrl ? <FollowButton siteUrl={ this.props.followUrl } iconSize={ 20 } onFollowToggle={ this.recordFollowToggle }/> : null }
 			</div>
 		);
 	}
 
-} );
+}
 
 module.exports = DiscoverSiteAttribution;

--- a/client/reader/discover/stats.js
+++ b/client/reader/discover/stats.js
@@ -1,0 +1,34 @@
+/**
+* Internal dependencies
+*/
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack
+ } from 'reader/stats';
+
+export function recordAuthorClick( author ) {
+	recordGaEvent( 'Clicked Discover Card Attribution Author' );
+	recordAction( 'discover_card_author_clicked' );
+	recordTrack( 'calypso_reader_author_on_discover_card_clicked', { author_url: author } );
+}
+
+export function recordSiteClick( siteUrl ) {
+	recordGaEvent( 'Clicked Discover Card Site Link' );
+	recordAction( 'discover_card_site_clicked' );
+	recordTrack( 'calypso_reader_site_on_discover_card_clicked', { site_url: siteUrl } );
+}
+
+export function recordFollowToggle( isFollowing, siteUrl ) {
+	recordAction( 'discover_card_following_clicked' );
+
+	if ( isFollowing ) {
+		recordGaEvent( 'Clicked Follow Discover Site' );
+		recordAction( 'discover_card_site_followed' );
+		recordTrack( 'calypso_reader_discover_site_followed', { site_url: siteUrl } );
+	} else {
+		recordGaEvent( 'Clicked Unfollow Discover Site' );
+		recordAction( 'discover_card_site_unfollowed' );
+		recordTrack( 'calypso_reader_discover_site_unfollowed', { site_url: siteUrl } );
+	}
+}

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -24,7 +24,7 @@ const ReaderFollowButton = React.createClass( {
 		stats[ isFollowing ? 'recordFollow' : 'recordUnfollow' ]( this.props.siteUrl, this.props.railcar );
 
 		if ( this.props.onFollowToggle ) {
-			this.props.onFollowToggle();
+			this.props.onFollowToggle( isFollowing );
 		}
 	},
 


### PR DESCRIPTION
Updates for a request to start tracking Discover card following events.
Also filled in some missing tracked events on Discover site picks and did some refactoring.

Test live: https://calypso.live/?branch=update/reader/discover-pick-tracking