### PR TITLE
Plans: Change "Enable Manage" link to allow returning to plan setup

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -450,9 +450,7 @@ const PlansSetup = React.createClass( {
 
 		let turnOnManage;
 		if ( site && ! site.canManage() ) {
-			const returnTitle = encodeURIComponent( this.translate( 'Back to Plan Setup' ) );
-			const returnUrl = encodeURIComponent( window.location.href );
-			const manageUrl = site.getRemoteManagementURL() + '&return_url=' + returnUrl + '&return_title=' + returnTitle;
+			const manageUrl = site.getRemoteManagementURL() + '&section=plugins-setup';
 			turnOnManage = (
 				<Card className="jetpack-plugins-setup__need-manage">
 					<p>{

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -450,7 +450,9 @@ const PlansSetup = React.createClass( {
 
 		let turnOnManage;
 		if ( site && ! site.canManage() ) {
-			const manageUrl = site.getRemoteManagementURL() + '&section=plugins';
+			const returnTitle = encodeURIComponent( this.translate( 'Back to Plan Setup' ) );
+			const returnUrl = encodeURIComponent( window.location.href );
+			const manageUrl = site.getRemoteManagementURL() + '&return_url=' + returnUrl + '&return_title=' + returnTitle;
 			turnOnManage = (
 				<Card className="jetpack-plugins-setup__need-manage">
 					<p>{


### PR DESCRIPTION
## Purpose
This PR addresses https://github.com/Automattic/wp-calypso/issues/6006 - it updates the **"Enable Manage"** link in the **"Enable Manage"** card in the plans setup page. It adds a new value `plugins-setup` to the `section` GET parameter, allowing the user to continue with the plan setup process. 

Related Jetpack PR: https://github.com/Automattic/jetpack/pull/4666

## Preview
The **"Enable Manage"** card, for reference (unchanged in terms of appearance):
![](https://cldup.com/aRVbWzSU3l.png)

## Testing instructions:
* Checkout the `update/jetpack-manage-plugins-setup-redirect` branch
* Visit the installer for a site with Jetpack Manage disabled - `/plugins/setup/$site`
* Click on the **"Enable Manage"** button and verify it takes you to an URL that contains the GET parameter `&section=plugins-setup`.

cc @roccotripaldi and @ryelle 

Test live: https://calypso.live/?branch=update/jetpack-manage-plugins-setup-redirect