### PR TITLE
Jetpack Connect: Use MainWrapper component to fix ESLint warnings

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -40,6 +40,7 @@ import safeImageUrl from 'lib/safe-image-url';
 import Button from 'components/button';
 import { requestSites } from 'state/sites/actions';
 import { isRequestingSites } from 'state/sites/selectors';
+import MainWrapper from './main-wrapper';
 
 /**
  * Constants
@@ -500,11 +501,11 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		}
 
 		return (
-			<Main className="jetpack-connect">
+			<MainWrapper>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderForm() }
 				</div>
-			</Main>
+			</MainWrapper>
 		);
 	}
 } );

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -13,7 +13,6 @@ import Card from 'components/card';
 import ConnectHeader from './connect-header';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
-import Main from 'components/main';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
 import { getSiteByUrl } from 'state/sites/selectors';

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -334,7 +334,7 @@ const JetpackConnectMain = React.createClass( {
 
 	renderInstallInstructions() {
 		return (
-			<Main className="jetpack-connect jetpack-connect__wide">
+			<MainWrapper isWide>
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
 					<ConnectHeader
@@ -365,7 +365,7 @@ const JetpackConnectMain = React.createClass( {
 						<div>{ this.renderBackButton() }</div>
 					</div>
 				</div>
-			</Main>
+			</MainWrapper>
 		);
 	},
 
@@ -396,7 +396,7 @@ const JetpackConnectMain = React.createClass( {
 
 	renderActivateInstructions() {
 		return (
-			<Main className="jetpack-connect jetpack-connect__wide">
+			<MainWrapper isWide>
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
 					<ConnectHeader showLogo={ false }
@@ -419,7 +419,7 @@ const JetpackConnectMain = React.createClass( {
 						{ this.renderBackButton() }
 					</div>
 				</div>
-			</Main>
+			</MainWrapper>
 		);
 	},
 

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -26,6 +26,7 @@ import versionCompare from 'lib/version-compare';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Gridicon from 'components/gridicon';
+import MainWrapper from './main-wrapper';
 import {
 	confirmJetpackInstallStatus,
 	dismissUrl,
@@ -292,7 +293,7 @@ const JetpackConnectMain = React.createClass( {
 	renderSiteEntry() {
 		const status = this.getStatus();
 		return (
-			<Main className="jetpack-connect">
+			<MainWrapper>
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
 					<QuerySites/>
@@ -306,14 +307,14 @@ const JetpackConnectMain = React.createClass( {
 					{ this.renderSiteInput( status ) }
 					{ this.renderFooter() }
 				</div>
-			</Main>
+			</MainWrapper>
 		);
 	},
 
 	renderSiteEntryInstall() {
 		const status = this.getStatus();
 		return (
-			<Main className="jetpack-connect jetpack-connect__main">
+			<MainWrapper>
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
 					<QuerySites/>
@@ -327,7 +328,7 @@ const JetpackConnectMain = React.createClass( {
 					{ this.renderSiteInput( status ) }
 					{ this.renderFooter() }
 				</div>
-			</Main>
+			</MainWrapper>
 		);
 	},
 

--- a/client/signup/jetpack-connect/main-wrapper.jsx
+++ b/client/signup/jetpack-connect/main-wrapper.jsx
@@ -12,8 +12,20 @@ import Main from 'components/main';
 export default React.createClass( {
 	displayName: 'JetpackConnectMainWrapper',
 
+	propTypes: {
+	    isWide: React.PropTypes.bool
+	},
+
+	getDefaultProps() {
+	    return {
+	        isWide: false
+	    }
+	},
+
 	render() {
-		const wrapperClassName = this.props.isWide ? 'jetpack-connect__main-wide' : 'jetpack-connect__main';
+		const wrapperClassName = classNames( 'jetpack-connect__main', {
+		    'is-wide': this.props.isWide
+		} );
 		return (
 			<Main className={ classNames( this.props.className, wrapperClassName ) }>
 				{ this.props.children }

--- a/client/signup/jetpack-connect/main-wrapper.jsx
+++ b/client/signup/jetpack-connect/main-wrapper.jsx
@@ -19,7 +19,7 @@ export default React.createClass( {
 	getDefaultProps() {
 		return {
 			isWide: false
-		}
+		};
 	},
 
 	render() {

--- a/client/signup/jetpack-connect/main-wrapper.jsx
+++ b/client/signup/jetpack-connect/main-wrapper.jsx
@@ -13,18 +13,18 @@ export default React.createClass( {
 	displayName: 'JetpackConnectMainWrapper',
 
 	propTypes: {
-	    isWide: React.PropTypes.bool
+		isWide: React.PropTypes.bool
 	},
 
 	getDefaultProps() {
-	    return {
-	        isWide: false
-	    }
+		return {
+			isWide: false
+		}
 	},
 
 	render() {
 		const wrapperClassName = classNames( 'jetpack-connect__main', {
-		    'is-wide': this.props.isWide
+			'is-wide': this.props.isWide
 		} );
 		return (
 			<Main className={ classNames( this.props.className, wrapperClassName ) }>

--- a/client/signup/jetpack-connect/main-wrapper.jsx
+++ b/client/signup/jetpack-connect/main-wrapper.jsx
@@ -13,8 +13,9 @@ export default React.createClass( {
 	displayName: 'JetpackConnectMainWrapper',
 
 	render() {
+		const wrapperClassName = this.props.isWide ? 'jetpack-connect__main-wide' : 'jetpack-connect__main';
 		return (
-			<Main className={ classNames( this.props.className, 'jetpack-connect__main' ) }>
+			<Main className={ classNames( this.props.className, wrapperClassName ) }>
 				{ this.props.children }
 			</Main>
 		);

--- a/client/signup/jetpack-connect/main-wrapper.jsx
+++ b/client/signup/jetpack-connect/main-wrapper.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+
+export default React.createClass( {
+	displayName: 'JetpackConnectMainWrapper',
+
+	render() {
+		return (
+			<Main className={ classNames( this.props.className, 'jetpack-connect__main' ) }>
+				{ this.props.children }
+			</Main>
+		);
+	}
+} );

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -33,6 +33,7 @@ import Gridicon from 'components/gridicon';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import Dialog from 'components/dialog';
 import analytics from 'lib/analytics';
+import MainWrapper from './main-wrapper';
 
 /*
  * Module variables
@@ -389,7 +390,7 @@ const JetpackSSOForm = React.createClass( {
 		}
 
 		return (
-			<Main className="jetpack-connect">
+			<MainWrapper>
 				<div className="jetpack-connect__sso">
 					<ConnectHeader
 						showLogo={ false }
@@ -447,7 +448,7 @@ const JetpackSSOForm = React.createClass( {
 				</div>
 
 				{ this.renderSharedDetailsDialog() }
-			</Main>
+			</MainWrapper>
 		);
 	}
 } );

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -1,5 +1,3 @@
-// @TODO: Remove .jetpack-connect once we cleared out all instances
-.jetpack-connect,
 .jetpack-connect__main {
 	max-width: 400px;
 

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -14,7 +14,8 @@
 	}
 }
 
-.jetpack-connect__wide {
+
+.jetpack-connect__main-wide {
 	max-width: 100%;
 	text-align: center;
 	margin-bottom: 24px;

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -1,4 +1,6 @@
-.jetpack-connect {
+// @TODO: Remove .jetpack-connect once we cleared out all instances
+.jetpack-connect,
+.jetpack-connect__main {
 	max-width: 400px;
 
 	.logged-out-form__links {
@@ -12,7 +14,6 @@
 		}
 
 	}
-
 }
 
 .jetpack-connect__wide {

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -14,8 +14,7 @@
 	}
 }
 
-
-.jetpack-connect__main-wide {
+.jetpack-connect__main.is-wide {
 	max-width: 100%;
 	text-align: center;
 	margin-bottom: 24px;


### PR DESCRIPTION
This PR is a continuation of @ebinnion's work on creating and implementing a `MainWrapper` component into the Jetpack Connect SSO module (https://github.com/Automattic/wp-calypso/pull/6987). This is the related issue: https://github.com/Automattic/wp-calypso/issues/7015. Also, some more discussion happened in this closed PR: https://github.com/Automattic/wp-calypso/pull/7269.

The PR applies the new `MainWrapper` component to all locations with `jetpack-connect` class. Additionally, it introduces a `isWide` prop to allow the `MainWrapper` component to handle the `jetpack-connect-wide` cases.

Testing instructions:
* Checkout `update/jetpack-connect-main-wrapper-2`
* Go to `/jetpack/connect` to initiate the JPC flow
* Ensure the `jetpack-connect__main` class and its styles are applied in the following JPC flow screens:
  * Connect a site
  * Connect a site - install Jetpack
  * Authorization form
* Ensure the `jetpack-connect__main` and `is-wide` classes and their styles are applied in the following JPC flow screens:
  * Installation instructions
  * Activation instructions

cc @roccotripaldi, @johnHackworth and @ebinnion 

Test live: https://calypso.live/?branch=update/jetpack-connect-main-wrapper-2