### PR TITLE
JS Errors: Turn off

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -16,7 +16,7 @@
 		"accept-invite": true,
 		"ad-tracking": false,
 		"brazil-survey-invitation": false,
-		"catch-js-errors": true,
+		"catch-js-errors": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -14,7 +14,7 @@
 		"accept-invite": true,
 		"ad-tracking": true,
 		"brazil-survey-invitation": false,
-		"catch-js-errors": true,
+		"catch-js-errors": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,7 +16,7 @@
 		"accept-invite": true,
 		"ad-tracking": false,
 		"brazil-survey-invitation": false,
-		"catch-js-errors": true,
+		"catch-js-errors": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,

--- a/config/test.json
+++ b/config/test.json
@@ -29,7 +29,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
-		"catch-js-errors": true,
+		"catch-js-errors": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,


### PR DESCRIPTION
We had some problems with `js-error` endpoint. 
The endpoint is under repair, but it would be good to stop sending errors there for the time being.
This turns off that possibolity

## Testing

Honestly, I dunno how to test effectiveness of feature flags

Test live: https://calypso.live/?branch=update/js-errors-off