### PR TITLE
Domains: Improve copy for TLDs unavailable for registration on WordPress.com

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -541,10 +541,20 @@ const RegisterDomainStep = React.createClass( {
 				severity = 'info';
 				break;
 			case 'not_registrable':
-				if ( domain.indexOf( '.' ) ) {
-					message = this.translate( 'Sorry but %(domain)s cannot be registered on WordPress.com.', {
-						args: { domain: domain }
-					} );
+				const tldIndex = domain.lastIndexOf( '.' );
+				if ( tldIndex !== -1 ) {
+					message = this.translate(
+						'To use a domain ending with {{strong}}%(tld)s{{/strong}} on your site, ' +
+						'you can register it elsewhere and then add it here. {{a}}Learn more{{/a}}.',
+						{
+							args: { tld: domain.substring( tldIndex ) },
+							components: {
+								strong: <strong />,
+								a: <a target="_blank" href={ support.MAP_EXISTING_DOMAIN } />
+							}
+						}
+					);
+					severity = 'info';
 				}
 				break;
 			case 'not_available':

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -543,7 +543,7 @@ const RegisterDomainStep = React.createClass( {
 				if ( tldIndex !== -1 ) {
 					message = this.translate(
 						'To use a domain ending with {{strong}}%(tld)s{{/strong}} on your site, ' +
-						'you can register it elsewhere and then add it here. {{a}}Learn more{{/a}}.',
+						'you can register it elsewhere first and then add it here. {{a}}Learn more{{/a}}.',
 						{
 							args: { tld: domain.substring( tldIndex ) },
 							components: {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -32,13 +32,11 @@ import analyticsMixin from 'lib/mixins/analytics';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { abtest } from 'lib/abtest';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
-import cartItems from 'lib/cart-values/cart-items';
 import {
 	getDomainsSuggestions,
 	getDomainsSuggestionsError
 } from 'state/domains/suggestions/selectors';
 import support from 'lib/url/support';
-import * as upgradesActions from '../../../lib/upgrades/actions/cart';
 
 const domains = wpcom.domains();
 
@@ -568,7 +566,9 @@ const RegisterDomainStep = React.createClass( {
 			case 'mappable_but_blacklisted_domain':
 				if ( domain.toLowerCase().indexOf( 'wordpress' ) > -1 ) {
 					message = this.translate(
-						'Due to {{a1}}trademark policy{{/a1}}, we are not able to allow domains containing {{strong}}WordPress{{/strong}} to be registered or mapped here. Please {{a2}}contact support{{/a2}} if you have any questions.',
+						'Due to {{a1}}trademark policy{{/a1}}, ' +
+						'we are not able to allow domains containing {{strong}}WordPress{{/strong}} to be registered or mapped here. ' +
+						'Please {{a2}}contact support{{/a2}} if you have any questions.',
 						{
 							components: {
 								strong: <strong />,
@@ -591,7 +591,9 @@ const RegisterDomainStep = React.createClass( {
 				break;
 
 			case 'mappable_but_restricted_domain':
-				message = this.translate( 'You cannot map another WordPress.com subdomain - try creating a new site or one of the custom domains below.' );
+				message = this.translate(
+					'You cannot map another WordPress.com subdomain - try creating a new site or one of the custom domains below.'
+				);
 				break;
 
 			case 'empty_query':


### PR DESCRIPTION
Fixes #6810

Before, the error message was not very helpful (and it was shown as an intimidating error):

<img width="676" alt="screen shot 2016-08-05 at 13 34 21" src="https://cloud.githubusercontent.com/assets/3392497/17435716/e7fde354-5b12-11e6-8aa3-a950ac5dad82.png">

Now, the copy has been improved (thank you, @ranh!) and the notice has `info` severity:

<img width="753" alt="screen shot 2016-08-05 at 13 33 45" src="https://cloud.githubusercontent.com/assets/3392497/17435710/d30aabc6-5b12-11e6-9744-5f9bfb256c99.png">

The `Learn more` link points to `https://en.support.wordpress.com/map-existing-domain/`.

/cc @aidvu @umurkontaci for code review
/cc @spncrb 

Test live: https://calypso.live/?branch=fix/tld-error-message