### PR TITLE
Plans: add upgrade link to top masterbar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -17,6 +17,7 @@ import layoutFocus from 'lib/layout-focus';
 import config from 'config';
 import { preload } from 'sections-preload';
 import ResumeEditing from 'my-sites/resume-editing';
+import { PLAN_FREE } from 'lib/plans/constants';
 
 export default React.createClass( {
 	displayName: 'Masterbar',
@@ -62,7 +63,11 @@ export default React.createClass( {
 	},
 
 	render() {
-		const upgradeLinkEnabled = config.isEnabled( 'masterbar/upgrade-link' );
+		const { user, sites } = this.props;
+
+		const upgradeLinkEnabled = config.isEnabled( 'masterbar/upgrade-link' ) &&
+			user && user.data.site_count === 1 &&
+			sites && sites.data[ 0 ] && sites.data[ 0 ].plan.product_slug === PLAN_FREE;
 
 		return (
 			<Masterbar>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -61,6 +62,8 @@ export default React.createClass( {
 	},
 
 	render() {
+		const upgradeLinkEnabled = config.isEnabled( 'masterbar/upgrade-link' );
+
 		return (
 			<Masterbar>
 				<Stats
@@ -78,7 +81,11 @@ export default React.createClass( {
 				</Stats>
 				<Item
 					tipTarget="reader"
-					className="masterbar__reader"
+					className={
+						classNames( 'masterbar__reader', {
+							'is-upgrade-link': upgradeLinkEnabled
+						} )
+					}
 					url="/"
 					icon="reader"
 					onClick={ this.clickReader }
@@ -88,6 +95,18 @@ export default React.createClass( {
 				>
 					{ this.translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
+				{ upgradeLinkEnabled &&
+					<Item
+						tipTarget="upgrade-link"
+						className="masterbar__upgrade-link"
+						url="/plans"
+						onClick={ this.clickReader }
+						tooltip={ this.translate( 'Upgrade to more powerful plans', { textOnly: true } ) }
+						preloadSection={ () => preload( 'plans' ) }
+					>
+						{ this.translate( 'Upgrade', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
+					</Item>
+				}
 				{ config.isEnabled( 'resume-editing' ) && <ResumeEditing /> }
 				<Publish
 					sites={ this.props.sites }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -279,4 +279,23 @@ $autobar-height: 20px;
 	@include breakpoint( ">480px" ) {
 		margin-right: auto;
 	}
+
+	&.is-upgrade-link {
+		margin-right: 0;
+	}
+
+	@media( min-width: 480px ) and ( max-width: 500px ) {
+		&.is-upgrade-link {
+			margin-right: auto;
+		}
+	}
+}
+
+.masterbar__upgrade-link {
+	display: none;
+
+	@media( min-width: 500px ) {
+		display: flex;
+		margin-right: auto;
+	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -85,6 +85,7 @@
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
+		"masterbar/upgrade-link": true,
 		"me/account": true,
 		"me/billing-history": true,
 		"me/find-friends": false,


### PR DESCRIPTION
Fixes #7288. WIP.

## Screenshots

### Width < 480px => no Upgrade link

![selection_026](https://cloud.githubusercontent.com/assets/4988512/17437255/f0f8a020-5b1c-11e6-9a3d-5bea1a16782e.jpg)

### Width 480px-500px => no Upgrade link (doesn't fit, not enough space)

![selection_027](https://cloud.githubusercontent.com/assets/4988512/17437268/00c58996-5b1d-11e6-8ad7-e5ac5feece97.jpg)

### Width > 500px

![selection_028](https://cloud.githubusercontent.com/assets/4988512/17437289/268d1a86-5b1d-11e6-9ea7-5ab684324d3f.jpg)



Test live: https://calypso.live/?branch=add/upgrade-link-masterbar