### PR TITLE
Signup: add AB to test domain results popover

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import PremiumPopover from 'components/plans/premium-popover';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
+import { abtest } from 'lib/abtest';
 
 const DomainProductPrice = React.createClass( {
 	propTypes: {
@@ -20,6 +21,7 @@ const DomainProductPrice = React.createClass( {
 		requiresPlan: React.PropTypes.bool,
 		domainsWithPlansOnly: React.PropTypes.bool.isRequired
 	},
+
 	renderFreeWithPlan() {
 		return (
 			<div
@@ -34,6 +36,7 @@ const DomainProductPrice = React.createClass( {
 			</div>
 		);
 	},
+
 	renderFreeWithPlanPrice() {
 		return (
 			<span
@@ -43,6 +46,7 @@ const DomainProductPrice = React.createClass( {
 				} ) }</span>
 		);
 	},
+
 	renderFree() {
 		return (
 			<div className="domain-product-price">
@@ -50,6 +54,7 @@ const DomainProductPrice = React.createClass( {
 			</div>
 		);
 	},
+
 	renderIncludedInPremium() {
 		return (
 			<div className="domain-product-price is-with-plans-only">
@@ -61,6 +66,7 @@ const DomainProductPrice = React.createClass( {
 			</div>
 		);
 	},
+
 	renderPrice() {
 		return (
 			<div className="domain-product-price">
@@ -73,18 +79,21 @@ const DomainProductPrice = React.createClass( {
 			</div>
 		);
 	},
+
 	render() {
 		if ( this.props.isLoading ) {
 			return <div className="domain-product-price is-placeholder">{ this.translate( 'Loading…' ) }</div>;
 		}
 
+		const showPopover = abtest( 'domainSuggestionPopover' ) === 'showPopover';
+
 		switch ( this.props.rule ) {
 			case 'FREE_DOMAIN':
-				return this.renderFree();
+				return showPopover && this.renderFree();
 			case 'FREE_WITH_PLAN':
 				return this.renderFreeWithPlan();
 			case 'INCLUDED_IN_PREMIUM':
-				return this.renderIncludedInPremium();
+				return showPopover && this.renderIncludedInPremium();
 			case 'PRICE':
 			default:
 				return this.renderPrice();
@@ -93,8 +102,8 @@ const DomainProductPrice = React.createClass( {
 } );
 
 export default connect(
-	state => ( { domainsWithPlansOnly: getCurrentUser( state ) ?
-		currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ) :
-		true
+	state => ( { domainsWithPlansOnly: getCurrentUser( state )
+		? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
+		: true
 	} )
 )( DomainProductPrice );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -92,5 +92,14 @@ module.exports = {
 		},
 		defaultVariation: 'staffSuggestions',
 		allowExistingUsers: true
-	}
+	},
+	domainSuggestionPopover: {
+		datestamp: '20160809',
+		variations: {
+			showPopover: 80,
+			hidePopover: 20,
+		},
+		defaultVariation: 'showPopover',
+		allowExistingUsers: false,
+	},
 };


### PR DESCRIPTION
As part of #7134, we'd like to test the effectiveness of the "Included in WordPress.com Premium" popover in the domain results listing by running a variation that hides the popover.

**Hypothesis from #7303:**

> The idea here is that by removing all of the extraneous information from this step, we may see a higher percentage of users who actually complete the domain step and continue to the next part — picking a plan.

**`showPopover` (Default) Variant:**
![showPopover screenshot](https://cloud.githubusercontent.com/assets/942359/17438794/9e277260-5af2-11e6-87e6-afde09c3a9d6.png)

**`hidePopover` Variant:**
![hidePopover screenshot](https://cloud.githubusercontent.com/assets/942359/17439041/fccff3c2-5af3-11e6-8791-f2d416fc43d6.png)

Test live: https://calypso.live/start/?branch=add/signup-domains-popover-ab