### PR TITLE
Domains: Remove mention of price to new users

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -46,18 +46,12 @@ const DomainProductPrice = React.createClass( {
 	renderFree() {
 		return (
 			<div className="domain-product-price">
-				<span className="domain-product-price__price">{ this.translate( 'Free' ) }</span>
 			</div>
 		);
 	},
 	renderIncludedInPremium() {
 		return (
 			<div className="domain-product-price is-with-plans-only">
-				<small className="domain-product-price__premium-text" ref="subMessage">
-					<PremiumPopover
-						position="bottom left"
-						textLabel={ this.translate( 'Included in WordPress.com Premium' ) }/>
-				</small>
 			</div>
 		);
 	},

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import PremiumPopover from 'components/plans/premium-popover';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 
@@ -74,11 +73,10 @@ const DomainProductPrice = React.createClass( {
 
 		switch ( this.props.rule ) {
 			case 'FREE_DOMAIN':
-				return this.renderFree();
+			case 'INCLUDED_IN_PREMIUM':
+				return null;
 			case 'FREE_WITH_PLAN':
 				return this.renderFreeWithPlan();
-			case 'INCLUDED_IN_PREMIUM':
-				return this.renderIncludedInPremium();
 			case 'PRICE':
 			default:
 				return this.renderPrice();
@@ -87,8 +85,8 @@ const DomainProductPrice = React.createClass( {
 } );
 
 export default connect(
-	state => ( { domainsWithPlansOnly: getCurrentUser( state ) ?
-		currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ) :
-		true
+	state => ( { domainsWithPlansOnly: getCurrentUser( state )
+		? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
+		: true
 	} )
 )( DomainProductPrice );

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -1,15 +1,11 @@
 .domain-product-price {
 	color: darken( $gray, 30% );
 	display: inline-block;
-	font-size: 17px;
 	font-weight: 600;
 
 	@include breakpoint( ">660px" ) {
 		min-width: 130px;
-	}
-
-	@include breakpoint( "<660px" ) {
-		font-size: 14px;
+		text-align: right;
 	}
 
 	&.is-with-plans-only:not( .is-free-domain ) {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -6,10 +6,6 @@
 
 	@include breakpoint( ">660px" ) {
 		padding: 15px 20px;
-
-		.domain-product-price {
-			margin-left: 5%;
-		}
 	}
 
 	&.is-added {


### PR DESCRIPTION
Currently, the domains step in signup mentions that a domain is available as part of WordPress.com premium:

![screen shot 2016-08-04 at 4 23 12 pm](https://cloud.githubusercontent.com/assets/191598/17417161/e63d31d6-5a5f-11e6-9fb7-35949e398c2f.png)

While this is true, there are two other plans (personal and business) that also include a domain — and the personal plan is cheaper. Rather than try to squeeze in all the details of whats included in which plans (something that the next step does anyways), we're going to try and remove all mention of price from the domain step in signup. It looks a little something like this:

![screen shot 2016-08-04 at 4 23 39 pm](https://cloud.githubusercontent.com/assets/191598/17438608/bbc9cb66-5af1-11e6-9474-3524f2bb37a1.png)

The idea here is that by removing all of the extraneous information from this step, we may see a higher percentage of users who actually complete the domain step and continue to the next part — picking a plan.

Test live: https://calypso.live/?branch=remove/domain-plan-mention
## 

There's a bunch of scenarios that should be tested to ensure this PR doesn't break anything:
- Domains in signup as a new user.
- Domains in signup as an existing user, with a free plan.
- Domains in signup as an existing user, with a paid plan, and a domain credit.
- Domains in signup as an existing user, with a paid plan, and no domain credit.
- Domains in `/domains/add` as an existing user, with a free plan.
- Domains in `/domains/add` as an existing user, with a paid plan, and a domain credit.
- Domains in `/domains/add` as an existing user, with a paid plan, and no domain credit.

If there are more scenarios that we should test against, please let me know!
## 

This is part of our plan to move towards a more streamlined and responsive domain experience in signup as outlined in #7134.

Before we merge this PR, we're doing a little research into the effect the "Included with WordPress.com Premium" has on step conversion over in #7302. Once we get the data back from that A/B test, we'll make a decision about this PR.
