### PR TITLE
i18n: Remove line breaks in translate calls

### DIFF
--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -34,8 +34,8 @@ class HelpUnverifiedWarning extends Component {
 		const resendStateToMessage = ( val ) => {
 			switch ( val ) {
 				case RESEND_IDLE:
-					return this.props.translate( 'Trouble activating your account?\
-							Just click this button and we\'ll resend the activation for you.' );
+					return this.props.translate( 'Trouble activating your account? ' +
+							'Just click this button and we\'ll resend the activation for you.' );
 				case RESEND_IN_PROGRESS:
 					return '';
 				case RESEND_SUCCESS:

--- a/client/my-sites/exporter/guided-transfer-details.jsx
+++ b/client/my-sites/exporter/guided-transfer-details.jsx
@@ -26,9 +26,9 @@ const GuidedTransferDetails = ( { translate } ) => {
 					{ translate( 'Hassle-free migration with two weeks of support' ) }
 				</h1>
 				{ translate(
-`Have one of our Happiness Engineers {{strong}}transfer your
-site{{/strong}} to a self-hosted WordPress.org installation with
-one of our hosting partners.`, { components: { strong: <strong /> } }
+					'Have one of our Happiness Engineers {{strong}}transfer your ' +
+					'site{{/strong}} to a self-hosted WordPress.org installation with ' +
+					'one of our hosting partners.', { components: { strong: <strong /> } }
 				) }
 				<br/>
 				<a href="https://en.support.wordpress.com/guided-transfer/" >

--- a/client/my-sites/guided-transfer/host-select.jsx
+++ b/client/my-sites/guided-transfer/host-select.jsx
@@ -29,11 +29,11 @@ export default React.createClass( {
 				<SectionHeader label={ this.translate( 'Set up Guided Transfer' ) } />
 				<Card>
 					<p>{ this.translate(
-`{{strong}}Please choose{{/strong}} one of our Guided Transfer compatible
-{{partner_link}}partner hosts{{/partner_link}}. You must have a hosting account
-with one of them to be able to move your site. Visit them {{lobby_link}}Guided
-Transfer Lobby{{/lobby_link}} if you have any question before starting, or
-{{learn_link}}learn more{{/learn_link}} about the process.`,
+'{{strong}}Please choose{{/strong}} one of our Guided Transfer compatible ' +
+'{{partner_link}}partner hosts{{/partner_link}}. You must have a hosting account ' +
+'with one of them to be able to move your site. Visit them {{lobby_link}}Guided ' +
+'Transfer Lobby{{/lobby_link}} if you have any question before starting, or ' +
+'{{learn_link}}learn more{{/learn_link}} about the process.',
 						{
 							components: {
 								strong: <strong />,


### PR DESCRIPTION
Line breaks will be discouraged in translatable strings by a [new lint rule](https://github.com/Automattic/eslint-plugin-wpcalypso/pull/14). This changes the affected translatable strings.

Test live: https://calypso.live/?branch=fix/line-breaks-in-translate