### PR TITLE
Enable browser push notifications in production for everybody

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -211,9 +211,7 @@ function reduxStoreReady( reduxStore ) {
 		reduxStore.dispatch( setCurrentUserId( user.get().ID ) );
 		reduxStore.dispatch( setCurrentUserFlags( user.get().meta.data.flags.active_flags ) );
 
-		const participantInPushNotificationsAbTest = config.isEnabled( 'push-notifications-ab-test' ) &&
-			( abtest( 'browserNotifications' ) === 'enabled' || abtest( 'browserNotificationsPreferences' ) === 'enabled' );
-		if ( config.isEnabled( 'push-notifications' ) || participantInPushNotificationsAbTest ) {
+		if ( config.isEnabled( 'push-notifications' ) ) {
 			// If the browser is capable, registers a service worker & exposes the API
 			reduxStore.dispatch( pushNotificationsInit() );
 		}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -92,7 +92,7 @@ Layout = React.createClass( {
 	},
 
 	renderPushNotificationPrompt: function() {
-		const participantInAbTest = config.isEnabled( 'push-notifications-ab-test' ) && abtest( 'browserNotifications' ) === 'enabled';
+		const participantInAbTest = abtest( 'browserNotifications' ) === 'enabled';
 		if ( ! config.isEnabled( 'push-notifications' ) && ! participantInAbTest ) {
 			return null;
 		}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -93,7 +93,7 @@ Layout = React.createClass( {
 
 	renderPushNotificationPrompt: function() {
 		const participantInAbTest = abtest( 'browserNotifications' ) === 'enabled';
-		if ( ! config.isEnabled( 'push-notifications' ) && ! participantInAbTest ) {
+		if ( ! ( config.isEnabled( 'push-notifications' ) && participantInAbTest ) ) {
 			return null;
 		}
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -15,21 +15,6 @@ module.exports = {
 		defaultVariation: 'disabled',
 		allowExistingUsers: true,
 	},
-	// `browserNotificationsPreferences` controls whether or not users see the
-	// preference to enable browser notifications in /me/notifications;
-	// any users with `browserNotifications` enabled will also see the preference;
-	// this is a temporary test just to allow us to ramp up the load gradually so
-	// that make sure things will be smooth when we go to launching browser
-	// notifications for 100% of users
-	browserNotificationsPreferences: {
-		datestamp: '20160801',
-		variations: {
-			disabled: 60,
-			enabled: 40,
-		},
-		defaultVariation: 'disabled',
-		allowExistingUsers: true,
-	},
 	coldStartReader: {
 		datestamp: '20160804',
 		variations: {

--- a/config/production.json
+++ b/config/production.json
@@ -71,7 +71,7 @@
 		"press-this": true,
 		"preview-layout": true,
 		"preview-endpoint": false,
-		"push-notifications-ab-test": true,
+		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/start": true,


### PR DESCRIPTION
This PR enables browser push notifications in production for everybody.

The nudge shown at the top of some pages is still only shown to 5% of users.

Use the environment badge in the bottom right of Calypso to set the AB test variations and verify correct behavior.

`push-notifications` feature flag | `browserNotifications` a/b test | Nudge visible? | Preferences visible?
--------------------- | ---------------------| -------------- | -------------------
`true` | `disabled` | no | yes
`true` | `enabled` | yes | yes
`false` | `disabled` | no | no
`false` | `enabled`| no | no

Note: To test with browser push notifications totally disabled -- like we would have to do if we encounter a problem in production and want to turn things off (note: that will also require us to turn things off on the backend to stop sending notifications) -- use a browser environment that supports Service Workers for `HTTP` connections (like Firefox with the developer toolbox open) and run calypso locally like so:

```
DISABLE_FEATURES=push-notifications make run
```

Test live: https://calypso.live/?branch=update/remove-browser-notification-abtest