### PR TITLE
Plans: /my-plan should show domains even if already upgraded 

### DIFF
--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -172,5 +172,18 @@ export default {
 
 	isJetpack( site ) {
 		return site && site.jetpack;
+	},
+
+	/**
+	 * Checks whether a site has a custom mapped URL.
+	 * @param  {Object}   site Site object
+	 * @return {?Boolean}      Whether site has custom domain
+	 */
+	hasCustomDomain( site ) {
+		if ( ! site || ! site.domain || ! site.wpcom_url ) {
+			return null;
+		}
+
+		return site.domain !== site.wpcom_url;
 	}
 };

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -17,7 +17,10 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 
 	return (
 		<div>
-			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
+			<CustomDomainPurchaseDetail
+				selectedSite={ selectedSite }
+				hasDomainCredit={ plan && plan.hasDomainCredit }
+			/>
 
 			{ ! selectedFeature &&
 				<PurchaseDetail

--- a/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -39,7 +39,7 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 					components: { em: <em /> }
 				}
 			) }
-			buttonText={ translate( 'Manage my domain(s)' ) }
+			buttonText={ translate( 'Manage my domains' ) }
 			href={ `/domains/manage/${ selectedSite.slug }` }
 		/>;
 

--- a/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -20,7 +20,7 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 					'Your plan includes a free custom domain. Replace {{em}}%(siteDomain)s{{/em}} ' +
 					'with a custom domain to personalize your site.',
 					{
-						args: { siteDomain: selectedSite.slug },
+						args: { siteDomain: selectedSite.domain },
 						components: { em: <em /> }
 					}
 				)
@@ -35,20 +35,9 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 			title={ translate( 'Custom Domain' ) }
 			description={ translate(
 				'Your plan includes the custom domain {{em}}%(siteDomain)s{{/em}}, your own personal corner of the web.', {
-					args: { siteDomain: selectedSite.slug },
+					args: { siteDomain: selectedSite.domain },
 					components: { em: <em /> }
 				}
-			) }
-			buttonText={ translate( 'Manage my domain(s)' ) }
-			href={ `/domains/manage/${ selectedSite.slug }` }
-		/>;
-
-	const renderMaybeHasCustomDomain = () =>
-		<PurchaseDetail
-			icon="globe"
-			title={ translate( 'Custom Domain' ) }
-			description={ translate(
-				'Your plan includes a free custom domain.'
 			) }
 			buttonText={ translate( 'Manage my domain(s)' ) }
 			href={ `/domains/manage/${ selectedSite.slug }` }
@@ -59,7 +48,7 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 			return renderHasCustomDomain();
 		}
 
-		return renderMaybeHasCustomDomain();
+		return null;
 	};
 
 	return (

--- a/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -2,30 +2,70 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import PurchaseDetail from 'components/purchase-detail';
+import { hasCustomDomain } from 'lib/site/utils';
 
-const CustomDomainPurchaseDetail = ( { selectedSite } ) => {
-	return (
+const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate } ) => {
+	const renderClaimCustomDomain = () =>
 		<PurchaseDetail
 			icon="globe"
-			title={ i18n.translate( 'Get your custom domain' ) }
+			title={ translate( 'Select Your Custom Domain' ) }
 			description={
-				i18n.translate(
-					"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
-					'A free domain is included with your plan.',
+				translate(
+					'Your plan includes a free custom domain. Replace {{em}}%(siteDomain)s{{/em}} ' +
+					'with a custom domain to personalize your site.',
 					{
 						args: { siteDomain: selectedSite.slug },
 						components: { em: <em /> }
 					}
 				)
 			}
-			buttonText={ i18n.translate( 'Claim your free domain' ) }
-			href={ '/domains/add/' + selectedSite.slug } />
+			buttonText={ translate( 'Claim your free domain' ) }
+			href={ `/domains/add/${ selectedSite.slug }` }
+		/>;
+
+	const renderHasCustomDomain = () =>
+		<PurchaseDetail
+			icon="globe"
+			title={ translate( 'Custom Domain' ) }
+			description={ translate(
+				'Your plan includes the custom domain {{em}}%(siteDomain)s{{/em}}, your own personal corner of the web.', {
+					args: { siteDomain: selectedSite.slug },
+					components: { em: <em /> }
+				}
+			) }
+			buttonText={ translate( 'Manage my domain(s)' ) }
+			href={ `/domains/manage/${ selectedSite.slug }` }
+		/>;
+
+	const renderMaybeHasCustomDomain = () =>
+		<PurchaseDetail
+			icon="globe"
+			title={ translate( 'Custom Domain' ) }
+			description={ translate(
+				'Your plan includes a free custom domain.'
+			) }
+			buttonText={ translate( 'Manage my domain(s)' ) }
+			href={ `/domains/manage/${ selectedSite.slug }` }
+		/>;
+
+	const renderCustomDomainDetail = () => {
+		if ( hasCustomDomain( selectedSite ) ) {
+			return renderHasCustomDomain();
+		}
+
+		return renderMaybeHasCustomDomain();
+	};
+
+	return (
+		hasDomainCredit
+			? renderClaimCustomDomain()
+			: renderCustomDomainDetail()
 	);
 };
 
@@ -33,7 +73,8 @@ CustomDomainPurchaseDetail.propTypes = {
 	selectedSite: React.PropTypes.oneOfType( [
 		React.PropTypes.bool,
 		React.PropTypes.object
-	] ).isRequired
+	] ).isRequired,
+	hasDomainCredit: React.PropTypes.bool
 };
 
-export default CustomDomainPurchaseDetail;
+export default localize( CustomDomainPurchaseDetail );

--- a/client/my-sites/upgrades/checkout-thank-you/personal-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/personal-plan-details.jsx
@@ -17,7 +17,10 @@ const PersonalPlanDetails = ( { translate, selectedSite, sitePlans } ) => {
 
 	return (
 		<div>
-			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
+			<CustomDomainPurchaseDetail
+				selectedSite={ selectedSite }
+				hasDomainCredit={ plan && plan.hasDomainCredit }
+			/>
 
 			<PurchaseDetail
 				icon="speaker"

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -26,7 +26,10 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 
 	return (
 		<div>
-			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
+			<CustomDomainPurchaseDetail
+				selectedSite={ selectedSite }
+				hasDomainCredit={ plan && plan.hasDomainCredit }
+			/>
 
 			<PurchaseDetail
 				icon="speaker"


### PR DESCRIPTION
Fixes #7177. Shows that you own a custom domain as a part of plan upgrade on My Plan page. We need proper wording (and maybe custom design?).

## Testing Instructions

1. With Personal site, navigate to `/plans/my-plan` and claim your free domain;
2. After claiming the free domain, navigate back to `/plans/my-plan` and check whether it shows either "Custom Domain" feature box or "$yourDomain" feature box;
3. Upgrade to Premium and check whether it shows the same;
4. Upgrade to Business and check whether it shows the same.

## Issues

The main problem is that after you claim your free domain, it takes a while (say 5-10 mins) before we can detect you have a custom domain in code. However, we can detect immediately whether you have domain credit or not. I fixed this by showing a generic text "Custom Domain" if you don't have free domain credit and showing your domain name when you don't have domain credit + I can safely tell you have a custom domain.

However, there is a problem with this fix. Let's imagine the following scenario:

1. User upgrades to Personal plan and claims the free custom domain;
2. She then cancels this domain;
3. Now, she has no domain credit and no custom domain but still sees the "Custom Domain" feature box telling her that she has a custom domain because she is on the Personal plan.

I'm not sure how to fix this. Maybe with some special wording. Refer to screenshots below to better understand what I mean by "Custom Domain" feature box.

## Screenshots

### With custom domain unknown/having no domain credit

![selection_030](https://cloud.githubusercontent.com/assets/4988512/17450074/8feece66-5b5e-11e6-8edc-895912eee9ee.jpg)

### With custom domain known

![selection_032](https://cloud.githubusercontent.com/assets/4988512/17450200/40b1ddf6-5b5f-11e6-8af0-b495c4f89f74.jpg)

### With claim your free domain (no changes from current implementation)

![selection_031](https://cloud.githubusercontent.com/assets/4988512/17450149/fa214ebc-5b5e-11e6-8a03-6a34744c9d00.jpg)

cc @rralian @gwwar @meremagee @mtias @apeatling 

Test live: https://calypso.live/?branch=add/show-domain-upgrade-on-my-plan-page

Note: sorry about the failing tests. In `lib/site/utils`, I moved functions from global `export default { }` to individual function definitions so I could access the fns from within the same file. This broke parts of Calypso. However, things in this branch can still be tested just fine. I'll see what I can do about this next week.