### PR TITLE
State: Change order of args on editPost and savePost actions

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/publish.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { partial, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,13 +33,13 @@ class PostActionsEllipsisMenuPublish extends Component {
 	}
 
 	publishPost() {
-		const { siteId, postId, publishPost } = this.props;
+		const { siteId, postId } = this.props;
 		if ( ! siteId || ! postId ) {
 			return;
 		}
 
 		mc.bumpStat( 'calypso_cpt_actions', 'publish' );
-		publishPost( siteId, postId );
+		this.props.savePost( siteId, postId, { status: 'publish' } );
 	}
 
 	render() {
@@ -70,5 +70,5 @@ export default connect(
 			canPublish: canCurrentUser( state, post.site_ID, 'publish_posts' )
 		};
 	},
-	{ publishPost: partial( savePost, { status: 'publish' } ) }
+	{ savePost }
 )( localize( PostActionsEllipsisMenuPublish ) );

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -115,7 +115,7 @@ module.exports = {
 
 		function startEditing( siteId ) {
 			context.store.dispatch( setEditorPostId( postID ) );
-			context.store.dispatch( editPost( { type: postType }, siteId, postID ) );
+			context.store.dispatch( editPost( siteId, postID, { type: postType } ) );
 
 			if ( maybeRedirect( context ) ) {
 				return;

--- a/client/post-editor/editor-page-order/index.jsx
+++ b/client/post-editor/editor-page-order/index.jsx
@@ -47,7 +47,7 @@ class EditorPageOrder extends Component {
 			recordEvent( 'Changed page menu order' );
 		}
 
-		this.props.editPost( { menu_order: newOrder }, siteId, postId );
+		this.props.editPost( siteId, postId, { menu_order: newOrder } );
 	}
 
 	render() {

--- a/client/post-editor/editor-page-parent/index.jsx
+++ b/client/post-editor/editor-page-parent/index.jsx
@@ -37,7 +37,7 @@ class EditorPageParent extends Component {
 	updatePageParent( item ) {
 		const { siteId, postId } = this.props;
 		const parentId = item && item.ID ? item.ID : null;
-		this.props.editPost( { parent: parentId }, siteId, postId );
+		this.props.editPost( siteId, postId, { parent: parentId } );
 	}
 
 	render() {

--- a/client/post-editor/editor-page-templates/index.jsx
+++ b/client/post-editor/editor-page-templates/index.jsx
@@ -38,7 +38,7 @@ class EditorPageTemplates extends Component {
 
 	selectTemplate( file ) {
 		const { siteId, postId } = this.props;
-		this.props.editPost( { page_template: file }, siteId, postId );
+		this.props.editPost( siteId, postId, { page_template: file } );
 	}
 
 	getSelectedTemplateText() {

--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -42,11 +42,11 @@ class EditorTermSelector extends Component {
 			taxonomyTerms.push( selectedTerm );
 		}
 
-		this.props.editPost( {
+		this.props.editPost( siteId, postId, {
 			terms: {
 				[ taxonomyName ]: taxonomyTerms
 			}
-		}, siteId, postId );
+		} );
 	}
 
 	getSelectedTermIds() {

--- a/client/post-editor/term-token-field/index.jsx
+++ b/client/post-editor/term-token-field/index.jsx
@@ -42,12 +42,12 @@ class TermTokenField extends React.Component {
 		recordStat( termStat );
 		recordEvent( 'Changed Terms', termEventLabel );
 
-		const { siteId, postId, postTerms, taxonomyName } = this.props;
-		this.props.editPost( {
+		const { siteId, postId, taxonomyName } = this.props;
+		this.props.editPost( siteId, postId, {
 			terms: {
 				[ taxonomyName ]: selectedTerms
 			}
-		}, siteId, postId );
+		} );
 	}
 
 	getPostTerms() {

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -149,12 +149,12 @@ export function requestPosts( query = {} ) {
  * Returns an action object to be used in signalling that the specified
  * post updates should be applied to the set of edits.
  *
- * @param  {Object} post   Post attribute updates
  * @param  {Number} siteId Site ID
  * @param  {Number} postId Post ID
+ * @param  {Object} post   Post attribute updates
  * @return {Object}        Action object
  */
-export function editPost( post, siteId, postId ) {
+export function editPost( siteId, postId, post ) {
 	return {
 		type: POST_EDIT,
 		post,

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -183,12 +183,12 @@ export function resetPostEdits( siteId, postId ) {
  * Returns an action thunk which, when dispatched, triggers a network request
  * to save the specified post object.
  *
- * @param  {Object}   post   Post attributes
  * @param  {Number}   siteId Site ID
  * @param  {Number}   postId Post ID
+ * @param  {Object}   post   Post attributes
  * @return {Function}        Action thunk
  */
-export function savePost( post, siteId, postId ) {
+export function savePost( siteId, postId, post ) {
 	return async ( dispatch ) => {
 		dispatch( {
 			type: POST_SAVE,
@@ -228,7 +228,7 @@ export function savePost( post, siteId, postId ) {
  * @return {Function}        Action thunk
  */
 export function trashPost( siteId, postId ) {
-	return savePost( { status: 'trash' }, siteId, postId );
+	return savePost( siteId, postId, { status: 'trash' } );
 }
 
 /**

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -154,7 +154,7 @@ export function requestPosts( query = {} ) {
  * @param  {Object} post   Post attribute updates
  * @return {Object}        Action object
  */
-export function editPost( siteId, postId, post ) {
+export function editPost( siteId, postId = null, post ) {
 	return {
 		type: POST_EDIT,
 		post,
@@ -188,7 +188,7 @@ export function resetPostEdits( siteId, postId ) {
  * @param  {Object}   post   Post attributes
  * @return {Function}        Action thunk
  */
-export function savePost( siteId, postId, post ) {
+export function savePost( siteId, postId = null, post ) {
 	return async ( dispatch ) => {
 		dispatch( {
 			type: POST_SAVE,

--- a/client/state/posts/middleware.js
+++ b/client/state/posts/middleware.js
@@ -34,11 +34,11 @@ export function onTermsReceive( dispatch, state, action ) {
 	const taxonomyTerms = toArray( postTerms[ taxonomy ] );
 	taxonomyTerms.push( newTerm );
 
-	dispatch( editPost( {
+	dispatch( editPost( siteId, postId, {
 		terms: {
 			[ taxonomy ]: taxonomyTerms
 		}
-	}, siteId, postId ) );
+	} ) );
 }
 
 export default ( { dispatch, getState } ) => ( next ) => ( action ) => {

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -321,7 +321,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch save action when thunk triggered for new post', () => {
-			savePost( { title: 'Hello World' }, 2916284 )( spy );
+			savePost( 2916284, undefined, { title: 'Hello World' } )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: POST_SAVE,
@@ -334,7 +334,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch post save save success action when request completes for new post', () => {
-			return savePost( { title: 'Hello World' }, 2916284 )( spy ).then( () => {
+			return savePost( 2916284, undefined, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_SUCCESS,
 					siteId: 2916284,
@@ -349,7 +349,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch received post action when request completes for new post', () => {
-			return savePost( { title: 'Hello World' }, 2916284 )( spy ).then( () => {
+			return savePost( 2916284, undefined, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [
@@ -363,7 +363,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch save action when thunk triggered for existing post', () => {
-			savePost( { title: 'Updated' }, 2916284, 13640 )( spy );
+			savePost( 2916284, 13640, { title: 'Updated' } )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: POST_SAVE,
@@ -376,7 +376,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch post save save success action when request completes for existing post', () => {
-			return savePost( { title: 'Updated' }, 2916284, 13640 )( spy ).then( () => {
+			return savePost( 2916284, 13640, { title: 'Updated' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_SUCCESS,
 					siteId: 2916284,
@@ -391,7 +391,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch received post action when request completes for existing post', () => {
-			return savePost( { title: 'Updated' }, 2916284, 13640 )( spy ).then( () => {
+			return savePost( 2916284, 13640, { title: 'Updated' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [
@@ -405,7 +405,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch failure action when error occurs while saving new post', () => {
-			return savePost( { title: 'Hello World' }, 77203074 )( spy ).then( () => {
+			return savePost( 77203074, undefined, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_FAILURE,
 					siteId: 77203074,
@@ -416,7 +416,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch failure action when error occurs while saving existing post', () => {
-			return savePost( { title: 'Hello World' }, 77203074, 102 )( spy ).then( () => {
+			return savePost( 77203074, 102, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_FAILURE,
 					siteId: 77203074,

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -252,7 +252,7 @@ describe( 'actions', () => {
 
 	describe( '#editPost()', () => {
 		it( 'should return an action object for a new post', () => {
-			const action = editPost( {
+			const action = editPost( 2916284, undefined, {
 				title: 'Hello World'
 			}, 2916284 );
 
@@ -265,9 +265,9 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should return an action object for an existing post', () => {
-			const action = editPost( {
+			const action = editPost( 2916284, 413, {
 				title: 'Hello World'
-			}, 2916284, 413 );
+			} );
 
 			expect( action ).to.eql( {
 				type: POST_EDIT,

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -252,14 +252,14 @@ describe( 'actions', () => {
 
 	describe( '#editPost()', () => {
 		it( 'should return an action object for a new post', () => {
-			const action = editPost( 2916284, undefined, {
+			const action = editPost( 2916284, null, {
 				title: 'Hello World'
 			}, 2916284 );
 
 			expect( action ).to.eql( {
 				type: POST_EDIT,
 				siteId: 2916284,
-				postId: undefined,
+				postId: null,
 				post: { title: 'Hello World' }
 			} );
 		} );
@@ -321,12 +321,12 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch save action when thunk triggered for new post', () => {
-			savePost( 2916284, undefined, { title: 'Hello World' } )( spy );
+			savePost( 2916284, null, { title: 'Hello World' } )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: POST_SAVE,
 				siteId: 2916284,
-				postId: undefined,
+				postId: null,
 				post: {
 					title: 'Hello World'
 				}
@@ -334,11 +334,11 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch post save save success action when request completes for new post', () => {
-			return savePost( 2916284, undefined, { title: 'Hello World' } )( spy ).then( () => {
+			return savePost( 2916284, null, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_SUCCESS,
 					siteId: 2916284,
-					postId: undefined,
+					postId: null,
 					post: { title: 'Hello World' },
 					savedPost: sinon.match( {
 						ID: 13640,
@@ -349,7 +349,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch received post action when request completes for new post', () => {
-			return savePost( 2916284, undefined, { title: 'Hello World' } )( spy ).then( () => {
+			return savePost( 2916284, null, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POSTS_RECEIVE,
 					posts: [
@@ -405,11 +405,11 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch failure action when error occurs while saving new post', () => {
-			return savePost( 77203074, undefined, { title: 'Hello World' } )( spy ).then( () => {
+			return savePost( 77203074, null, { title: 'Hello World' } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_SAVE_FAILURE,
 					siteId: 77203074,
-					postId: undefined,
+					postId: null,
 					error: sinon.match( { message: 'User cannot edit posts' } )
 				} );
 			} );


### PR DESCRIPTION
In a few recent PRs @aduth and I have [discussed](https://github.com/Automattic/wp-calypso/pull/7229#discussion_r73565579) how the order of the arguments on the `editPost()` action go against the typical order seen in the other post actions.

In all other actions the argument order is: `siteId`, `postId`.  This branch updates both `editPost()` and `savePost()` to conform to the established argument order of the other post actions.

This branch already touches quite a bit of editor functionality - but seems like it is best that we make this change sooner than later as we are migrating more editor features over to redux.

__To Test__
- Open up a CPT in the editor.
- Validate that changes made to Terms ( hierarchical and token field ) are persisted properly
- Open up a page in the editor
- Confirm that changes to the Order and Parent are persisted properly
- Open up a list view for a CPT, select the draft tab, and hit save from the elipsis menu.  Verify that the post is published properly.

Test live: https://calypso.live/?branch=update/state/posts-editPost