### PR TITLE
Introduce `draft.js` editor for custom title format

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -126,6 +126,7 @@
 @import 'components/theme/style';
 @import 'components/themes-list/style';
 @import 'components/tinymce/style';
+@import 'components/title-format-editor/style';
 @import 'components/token-field/style';
 @import 'components/post-schedule/style';
 @import 'components/section-header/style';

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -1,5 +1,6 @@
 // External Dependencies
 @import '../../node_modules/react-virtualized/styles';
+@import '../../node_modules/draft-js/dist/Draft.css';
 
 // Shared
 @import 'shared/reset';                        // css reset before the rest of the styles are defined

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -1,6 +1,6 @@
 // External Dependencies
 @import '../../node_modules/react-virtualized/styles';
-@import '../../node_modules/draft-js/dist/Draft.css';
+@import '../../node_modules/draft-js/dist/Draft';
 
 // Shared
 @import 'shared/reset';                        // css reset before the rest of the styles are defined

--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -72,10 +72,10 @@ export class MetaTitleEditor extends Component {
 
 		const tokens =
 			get( tokenMap, type, [] )
-				.map( name => ( {
-					title: get( getValidTokens( translate ), name, '' ),
-					tokenName: name,
-				} ) );
+				.reduce( ( allTokens, name ) => ( {
+					...allTokens,
+					[ name ]: get( getValidTokens( translate ), name, '' )
+				} ), {} );
 
 		return (
 			<div className="meta-title-editor">

--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -72,7 +72,7 @@ export class MetaTitleEditor extends Component {
 						key={ type.value }
 						disabled={ disabled }
 						onChange={ this.updateTitleFormat }
-						type={ disabled ? '' : type }
+						type={ disabled ? { label: '' } : type }
 						titleFormats={ get( titleFormats, type.value, [] ) }
 						tokens={ getTokensForType( type.value, translate ) }
 					/>

--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -27,7 +27,7 @@ const getValidTokens = translate => ( {
 	tagline: translate( 'Tagline' ),
 	postTitle: translate( 'Post Title' ),
 	pageTitle: translate( 'Page Title' ),
-	groupTitle: translate( 'Category/Tag Title' ),
+	groupTitle: translate( 'Tag or Category Name' ),
 	date: translate( 'Date' )
 } );
 

--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -11,7 +11,6 @@ import {
 /**
  * Internal dependencies
  */
-import SegmentedControl from 'components/segmented-control';
 import TitleFormatEditor from 'components/title-format-editor';
 import { localize } from 'i18n-calypso';
 
@@ -40,25 +39,22 @@ const tokenMap = {
 	archives: [ 'siteName', 'tagline', 'date' ]
 };
 
+const getTokensForType = ( type, translate ) => {
+	return get( tokenMap, type, [] )
+				.reduce( ( allTokens, name ) => ( {
+					...allTokens,
+					[ name ]: get( getValidTokens( translate ), name, '' )
+				} ), {} );
+};
+
 export class MetaTitleEditor extends Component {
 	constructor( props ) {
 		super( props );
-
-		this.state = {
-			type: 'frontPage'
-		};
-
-		this.switchType = this.switchType.bind( this );
 		this.updateTitleFormat = this.updateTitleFormat.bind( this );
 	}
 
-	switchType( { value: type } ) {
-		this.setState( { type } );
-	}
-
-	updateTitleFormat( values ) {
+	updateTitleFormat( type, values ) {
 		const { onChange, titleFormats } = this.props;
-		const { type } = this.state;
 
 		onChange( {
 			...titleFormats,
@@ -68,29 +64,19 @@ export class MetaTitleEditor extends Component {
 
 	render() {
 		const { disabled, titleFormats, translate } = this.props;
-		const { type } = this.state;
-
-		const tokens =
-			get( tokenMap, type, [] )
-				.reduce( ( allTokens, name ) => ( {
-					...allTokens,
-					[ name ]: get( getValidTokens( translate ), name, '' )
-				} ), {} );
 
 		return (
 			<div className="meta-title-editor">
-				<SegmentedControl
-					initialSelected={ type }
-					options={ titleTypes( translate ) }
-					onSelect={ this.switchType }
-				/>
-				<TitleFormatEditor
-					disabled={ disabled }
-					onChange={ this.updateTitleFormat }
-					type={ disabled ? '' : type }
-					titleFormats={ get( titleFormats, type, [] ) }
-					tokens={ tokens }
-				/>
+				{ titleTypes( translate ).map( type =>
+					<TitleFormatEditor
+						key={ type.value }
+						disabled={ disabled }
+						onChange={ this.updateTitleFormat }
+						type={ disabled ? '' : type }
+						titleFormats={ get( titleFormats, type.value, [] ) }
+						tokens={ getTokensForType( type.value, translate ) }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/components/title-format-editor/README.md
+++ b/client/components/title-format-editor/README.md
@@ -1,0 +1,1 @@
+# Title Format Editor

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,8 +1,10 @@
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import {
+	get,
 	map,
 	max,
-	min,
+	min
 } from 'lodash';
 import {
 	CompositeDecorator,
@@ -15,6 +17,9 @@ import {
 
 import Token from './token';
 import { fromEditor, toEditor } from './parser';
+import { getSeoTitle } from 'state/sites/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+import { localize } from 'i18n-calypso';
 
 const Chip = onClick => props => <Token { ...props } onClick={ onClick } />;
 
@@ -142,7 +147,11 @@ export class TitleFormatEditor extends Component {
 
 	render() {
 		const { editorState } = this.state;
-		const { tokens, type } = this.props;
+		const { translate, tokens, type, previewText } = this.props;
+
+		const formattedPreview = previewText
+			? `${ translate( 'Preview' ) }: ${ previewText }`
+			: '';
 
 		return (
 			<div className="title-format-editor">
@@ -165,7 +174,7 @@ export class TitleFormatEditor extends Component {
 						ref={ this.storeEditorReference }
 					/>
 				</div>
-				<div className="title-format-editor__preview">Preview: What's up with that?</div>
+				<div className="title-format-editor__preview">{ formattedPreview }</div>
 			</div>
 		);
 	}
@@ -179,4 +188,22 @@ TitleFormatEditor.propTypes = {
 	onChange: PropTypes.func.isRequired
 };
 
-export default TitleFormatEditor;
+const mapStateToProps = ( state, ownProps ) => {
+	const site = getSelectedSite( state );
+	const type = get( ownProps, 'type.value', '' );
+
+	// Add example content for post/page title, tag name and archive dates
+	// TODO: translate() not working here?
+	const content = {
+		site,
+		post: { title: 'Example Title' },
+		tag: 'Example Tag',
+		date: 'August 2013'
+	};
+
+	return ( {
+		previewText: getSeoTitle( state, type, content )
+	} );
+};
+
+export default connect( mapStateToProps )( localize( TitleFormatEditor ) );

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,10 +1,16 @@
 import React, { Component, PropTypes } from 'react';
 import {
 	compact,
+	flowRight as compose,
+	find,
 	get,
 	has,
+	head,
 	invert,
 	mapValues,
+	matchesProperty,
+	reduce,
+	some,
 } from 'lodash';
 import {
 	CompositeDecorator,
@@ -47,7 +53,7 @@ const Token = props => {
 	);
 };
 
-const toFormatObject = rawContent => {
+const toCalypso = rawContent => {
 	const text = get( rawContent, 'blocks[0].text', '' );
 	const ranges = get( rawContent, 'blocks[0].entityRanges', [] );
 	const entities = get( rawContent, 'entityMap' );
@@ -71,45 +77,78 @@ const toFormatObject = rawContent => {
 	] );
 };
 
-const fromFormatObject = format => {
-	const [ entityGuide, ] = format.reduce( ( [ map, lastKey ], { type, value } ) => {
-		if ( value ) {
-			return [ map, lastKey ];
-		}
+const or = ( ...args ) => some( args );
 
-		if ( has( map, type ) ) {
-			return [ map, lastKey ];
-		}
+const isTextPiece = matchesProperty( 'type', 'string' );
 
-		return [
-			{
-				...map,
-				[ type ]: lastKey
-			},
-			lastKey + 1
-		];
-	}, [ {}, 0 ] );
+/**
+ * Creates a dictionary for building an entityMap from a given title format
+ *
+ * There should only be a single entity for each given type of token
+ * available in the editor, and only one for each in the given title
+ * formats. Therefore, we need to build this dictionary, or mapping,
+ * in order to use later when actually creating the entityMap
+ *
+ * E.g.
+ *     From: [
+ *         { type: 'string', value: 'Visit ' },
+ *         { type: 'siteName' },
+ *         { type: 'string', value: ' | ' },
+ *         { type: 'tagline' }
+ *     ]
+ *     To:   { siteName: 0, tagline: 1 }
+ *
+ * @param {object} format native title format object
+ * @returns {object} mapping from token name to presumptive entity id
+ */
+const buildEntityMapping = compose(
+	head, // return only the mapping and discard the lastKey
+	format => reduce( format, ( [ map, lastKey ], { type } ) => (
+		or( isTextPiece( { type } ), has( map, type ) ) // skip strings and existing tokens
+			? [ map, lastKey ]
+			: [ { ...map, [ type ]: lastKey }, lastKey + 1 ]
+	), [ {}, 0 ] )
+);
 
-	const [ blockMap, ] = format.reduce( ( [ block, lastIndex ], { type, value } ) => {
-		return [
-			{
-				...block,
-				entityRanges: compact( [
-					...block.entityRanges,
-					value ? null : {
-						key: entityGuide[ type ],
-						offset: lastIndex,
-						length: type.length
-					}
-				] ),
-				text: block.text + ( value ? value : type )
-			},
-			lastIndex + ( value ? value.length : type.length )
-		];
-	}, [ { text: '', entityRanges: [], type: 'unstyled' }, 0 ] );
+const emptyBlockMap = {
+	text: '',
+	entityRanges: [],
+	type: 'unstyled'
+};
+
+const getTokenTitle = ( type, tokens ) => get(
+	find( tokens, matchesProperty( 'tokenName', type ) ),
+	'title',
+	''
+);
+
+const addPieceToBlock = ( block, offset, { type, value }, tokens, entityGuide ) => ( {
+	...block,
+	entityRanges: compact( [
+		...block.entityRanges,
+		value ? null : {
+			key: entityGuide[ type ],
+			length: getTokenTitle( type, tokens ).length,
+			offset,
+		},
+	] ),
+	text: block.text + ( value ? value : getTokenTitle( type, tokens ) ),
+} );
+
+const buildBlockMap = compose(
+	head,
+	( format, tokens, entityGuide ) => reduce( format, ( [ block, lastIndex ], piece ) => [
+		addPieceToBlock( block, lastIndex, piece, tokens, entityGuide ),
+		lastIndex + ( piece.value ? piece.value.length : getTokenTitle( piece.type, tokens ).length )
+	], [ emptyBlockMap, 0 ] )
+);
+
+const toEditor = ( format, tokens ) => {
+	const entityGuide = buildEntityMapping( format );
+	const blocks = [ buildBlockMap( format, tokens, entityGuide ) ];
 
 	return {
-		blocks: [ blockMap ],
+		blocks,
 		entityMap: mapValues( invert( entityGuide ), name => ( {
 			type: 'TOKEN',
 			mutability: 'IMMUTABLE',
@@ -124,7 +163,7 @@ export class TitleFormatEditor extends Component {
 
 		this.state = {
 			editorState: EditorState.createWithContent(
-				convertFromRaw( fromFormatObject( props.titleFormats ) ),
+				convertFromRaw( toEditor( props.titleFormats, props.tokens ) ),
 				new CompositeDecorator( [ {
 					strategy: this.renderTokens,
 					component: Token
@@ -152,12 +191,12 @@ export class TitleFormatEditor extends Component {
 			return;
 		}
 
-		// Create a new EditoState entirely, because we
+		// Create a new EditorState entirely, because we
 		// don't want to allow things like "undo" which
 		// would revert to the previous title type's format
 		this.setState( {
 			editorState: EditorState.createWithContent(
-				convertFromRaw( fromFormatObject( props.titleFormats ) ),
+				convertFromRaw( toEditor( props.titleFormats, props.tokens ) ),
 				new CompositeDecorator( [ {
 					strategy: this.renderTokens,
 					component: Token
@@ -178,7 +217,7 @@ export class TitleFormatEditor extends Component {
 			{ editorState },
 			() => {
 				editorState.lastChangeType === 'add-token' && this.focusEditor();
-				onChange( toFormatObject( convertToRaw( currentContent ) ) );
+				onChange( toCalypso( convertToRaw( currentContent ) ) );
 			}
 		);
 	}

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -191,14 +191,14 @@ TitleFormatEditor.propTypes = {
 const mapStateToProps = ( state, ownProps ) => {
 	const site = getSelectedSite( state );
 	const type = get( ownProps, 'type.value', '' );
+	const { translate } = ownProps;
 
 	// Add example content for post/page title, tag name and archive dates
-	// TODO: translate() not working here?
 	const content = {
 		site,
-		post: { title: 'Example Title' },
-		tag: 'Example Tag',
-		date: 'August 2013'
+		post: { title: translate( 'Example Title' ) },
+		tag: translate( 'Example Tag' ),
+		date: translate( 'August 2016' )
 	};
 
 	return ( {
@@ -206,4 +206,4 @@ const mapStateToProps = ( state, ownProps ) => {
 	} );
 };
 
-export default connect( mapStateToProps )( localize( TitleFormatEditor ) );
+export default localize( connect( mapStateToProps )( TitleFormatEditor ) );

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,0 +1,260 @@
+import React, { Component, PropTypes } from 'react';
+import {
+	compact,
+	get,
+	has,
+	invert,
+	mapValues,
+} from 'lodash';
+import {
+	CompositeDecorator,
+	Editor,
+	EditorState,
+	Entity,
+	Modifier,
+	convertFromRaw,
+	convertToRaw,
+} from 'draft-js';
+
+const buttonStyle = {
+	padding: '3px',
+	margin: '3px',
+	marginRight: '5px',
+	backgroundColor: '#ebebeb',
+	borderRadius: '3px',
+	fontWeight: 'bold'
+};
+
+const editorStyle = {
+	margin: '12px',
+	padding: '8px',
+	border: '1px solid black',
+	borderRadius: '3px'
+};
+
+const Token = props => {
+	const style = {
+		borderRadius: '3px',
+		backgroundColor: '#08c',
+		marginLeft: '1px',
+		marginRight: '1px',
+		padding: '2px',
+		color: '#fff'
+	};
+
+	return (
+		<span style={ style }>{ props.children }</span>
+	);
+};
+
+const toFormatObject = rawContent => {
+	const text = get( rawContent, 'blocks[0].text', '' );
+	const ranges = get( rawContent, 'blocks[0].entityRanges', [] );
+	const entities = get( rawContent, 'entityMap' );
+
+	const [ o, i, t ] = ranges.reduce( ( [ output, lastIndex, remainingText ], next ) => {
+		const tokenName = get( entities, [ next.key, 'data', 'name' ], null );
+		const textBlock = next.offset > lastIndex
+			? { type: 'string', value: remainingText.slice( lastIndex, next.offset ) }
+			: null;
+
+		return [ [
+			...output,
+			textBlock,
+			{ type: tokenName }
+		], next.offset + next.length, remainingText ];
+	}, [ [], 0, text ] );
+
+	return compact( [
+		...o,
+		i < t.length && { type: 'string', value: t.slice( i ) }
+	] );
+};
+
+const fromFormatObject = format => {
+	const [ entityGuide, ] = format.reduce( ( [ map, lastKey ], { type, value } ) => {
+		if ( value ) {
+			return [ map, lastKey ];
+		}
+
+		if ( has( map, type ) ) {
+			return [ map, lastKey ];
+		}
+
+		return [
+			{
+				...map,
+				[ type ]: lastKey
+			},
+			lastKey + 1
+		];
+	}, [ {}, 0 ] );
+
+	const [ blockMap, ] = format.reduce( ( [ block, lastIndex ], { type, value } ) => {
+		return [
+			{
+				...block,
+				entityRanges: compact( [
+					...block.entityRanges,
+					value ? null : {
+						key: entityGuide[ type ],
+						offset: lastIndex,
+						length: type.length
+					}
+				] ),
+				text: block.text + ( value ? value : type )
+			},
+			lastIndex + ( value ? value.length : type.length )
+		];
+	}, [ { text: '', entityRanges: [], type: 'unstyled' }, 0 ] );
+
+	return {
+		blocks: [ blockMap ],
+		entityMap: mapValues( invert( entityGuide ), name => ( {
+			type: 'TOKEN',
+			mutability: 'IMMUTABLE',
+			data: { name }
+		} ) )
+	};
+};
+
+export class TitleFormatEditor extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			editorState: EditorState.createWithContent(
+				convertFromRaw( fromFormatObject( props.titleFormats ) ),
+				new CompositeDecorator( [ {
+					strategy: this.renderTokens,
+					component: Token
+				} ] )
+			)
+		};
+
+		this.storeEditorReference = r => ( this.editor = r );
+		this.focusEditor = () => this.editor.focus();
+
+		this.updateEditor = this.updateEditor.bind( this );
+		this.addToken = this.addToken.bind( this );
+		this.renderTokens = this.renderTokens.bind( this );
+	}
+
+	componentWillReceiveProps( props ) {
+		const { type: oldType } = this.props;
+		const { type: newType } = props;
+
+		// Only swap out the local changes if we
+		// are switching title types, as within the
+		// same type we are still editing, not
+		// flipping to another
+		if ( oldType === newType ) {
+			return;
+		}
+
+		// Create a new EditoState entirely, because we
+		// don't want to allow things like "undo" which
+		// would revert to the previous title type's format
+		this.setState( {
+			editorState: EditorState.createWithContent(
+				convertFromRaw( fromFormatObject( props.titleFormats ) ),
+				new CompositeDecorator( [ {
+					strategy: this.renderTokens,
+					component: Token
+				} ] )
+			)
+		} );
+	}
+
+	updateEditor( editorState ) {
+		const { onChange } = this.props;
+		const currentContent = editorState.getCurrentContent();
+
+		if ( convertToRaw( currentContent ).blocks.length > 1 ) {
+			return;
+		}
+
+		this.setState(
+			{ editorState },
+			() => {
+				editorState.lastChangeType === 'add-token' && this.focusEditor();
+				onChange( toFormatObject( convertToRaw( currentContent ) ) );
+			}
+		);
+	}
+
+	addToken( title, name ) {
+		return () => {
+			const { editorState } = this.state;
+			const currentSelection = editorState.getSelection();
+
+			const tokenEntity = Entity.create( 'TOKEN', 'IMMUTABLE', { name } );
+
+			const contentState = Modifier.replaceText(
+				editorState.getCurrentContent(),
+				currentSelection,
+				title,
+				null,
+				tokenEntity
+			);
+
+			this.updateEditor( EditorState.push(
+				editorState,
+				contentState,
+				'add-token'
+			) );
+		};
+	}
+
+	renderTokens( contentBlock, callback ) {
+		contentBlock.findEntityRanges(
+			character => {
+				const entity = character.getEntity();
+
+				if ( null === entity ) {
+					return false;
+				}
+
+				return 'TOKEN' === Entity.get( entity ).getType();
+			},
+			callback
+		);
+	}
+
+	render() {
+		const { editorState } = this.state;
+		const { tokens } = this.props;
+
+		return (
+			<div style={ editorStyle }>
+				<div style={ { marginBottom: '10px' } }>
+					{ tokens.map( ( { title, tokenName } ) => (
+						<span
+							key={ tokenName }
+							style={ buttonStyle }
+							onClick={ this.addToken( title, tokenName ) }
+						>
+							{ title }
+						</span>
+					) ) }
+				</div>
+				<Editor
+					editorState={ editorState }
+					onChange={ this.updateEditor }
+					ref={ this.storeEditorReference }
+				/>
+			</div>
+		);
+	}
+}
+
+TitleFormatEditor.displayName = 'TitleFormatEditor';
+
+TitleFormatEditor.propTypes = {
+	tokens: PropTypes.arrayOf( PropTypes.shape( {
+		title: PropTypes.string.isRequired,
+		tokenName: PropTypes.string.isRequired
+	} ) ).isRequired
+};
+
+export default TitleFormatEditor;

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -5,14 +5,94 @@ import {
 	max,
 	min
 } from 'lodash';
-import {
+
+// The following polyfills exist for the draft-js editor, since
+// we are unable to change its codebase and yet we are waiting
+// on a solid solution for general IE polyfills
+//
+// They were borrowed and modified from MDN
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
+if ( ! String.prototype.endsWith ) {
+	String.prototype.endsWith = function( searchString, position ) {
+		const subjectString = this.toString();
+		if (
+			( typeof position !== 'number' ) ||
+			( ! isFinite( position ) ) ||
+			( Math.floor( position ) !== position ) ||
+			( position > subjectString.length )
+		) {
+			position = subjectString.length;
+		}
+		position -= searchString.length;
+		const lastIndex = subjectString.indexOf( searchString, position );
+		return lastIndex !== -1 && lastIndex === position;
+	};
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+if ( ! String.prototype.startsWith ) {
+	String.prototype.startsWith = function( searchString, position ) {
+		position = position || 0;
+		return this.substr( position, searchString.length ) === searchString;
+	};
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
+if ( ! Array.prototype.fill ) {
+	Array.prototype.fill = function( value ) {
+
+		// Steps 1-2.
+		if ( this === null ) {
+			throw new TypeError( 'this is null or not defined' );
+		}
+
+		const O = Object( this );
+
+		// Steps 3-5.
+		const len = O.length >>> 0;
+
+		// Steps 6-7.
+		const start = arguments[ 1 ];
+		const relativeStart = start >> 0;
+
+		// Step 8.
+		let k = relativeStart < 0
+			? Math.max( len + relativeStart, 0 )
+			: Math.min( relativeStart, len );
+
+		// Steps 9-10.
+		const end = arguments[ 2 ];
+		const relativeEnd = end === undefined
+			? len
+			: end >> 0;
+
+		// Step 11.
+		const final = relativeEnd < 0
+			? Math.max( len + relativeEnd, 0 )
+			: Math.min( relativeEnd, len );
+
+		// Step 12.
+		while ( k < final ) {
+			O[ k ] = value;
+			k++;
+		}
+
+		// Step 13.
+		return O;
+	};
+}
+
+// The below is a `require()` statement becuase it needs to
+// be loaded in after the polyfills are created.
+const {
 	CompositeDecorator,
 	Editor,
 	EditorState,
 	Entity,
 	Modifier,
 	SelectionState,
-} from 'draft-js';
+} = require( 'draft-js' );
 
 import Token from './token';
 import { fromEditor, toEditor } from './parser';

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -51,34 +51,8 @@ export class TitleFormatEditor extends Component {
 		this.renderTokens = this.renderTokens.bind( this );
 	}
 
-	componentWillReceiveProps( props ) {
-		const { type: oldType } = this.props;
-		const { type: newType } = props;
-
-		// Only swap out the local changes if we
-		// are switching title types, as within the
-		// same type we are still editing, not
-		// flipping to another
-		if ( oldType === newType ) {
-			return;
-		}
-
-		// Create a new EditorState entirely, because we
-		// don't want to allow things like "undo" which
-		// would revert to the previous title type's format
-		this.setState( {
-			editorState: EditorState.createWithContent(
-				toEditor( props.titleFormats, props.tokens ),
-				new CompositeDecorator( [ {
-					strategy: this.renderTokens,
-					component: Token
-				} ] )
-			)
-		} );
-	}
-
 	updateEditor( editorState ) {
-		const { onChange } = this.props;
+		const { onChange, type } = this.props;
 		const currentContent = editorState.getCurrentContent();
 
 		// limit to one line
@@ -90,7 +64,7 @@ export class TitleFormatEditor extends Component {
 			{ editorState },
 			() => {
 				editorState.lastChangeType === 'add-token' && this.focusEditor();
-				onChange( fromEditor( currentContent ) );
+				onChange( type.value, fromEditor( currentContent ) );
 			}
 		);
 	}
@@ -135,11 +109,12 @@ export class TitleFormatEditor extends Component {
 
 	render() {
 		const { editorState } = this.state;
-		const { tokens } = this.props;
+		const { tokens, type } = this.props;
 
 		return (
 			<div style={ editorStyle }>
 				<div style={ { marginBottom: '10px' } }>
+					{ type.label }
 					{ map( tokens, ( title, name ) => (
 						<span
 							key={ name }
@@ -163,7 +138,9 @@ export class TitleFormatEditor extends Component {
 TitleFormatEditor.displayName = 'TitleFormatEditor';
 
 TitleFormatEditor.propTypes = {
-	tokens: PropTypes.object.isRequired
+	type: PropTypes.object.isRequired,
+	tokens: PropTypes.object.isRequired,
+	onChange: PropTypes.func.isRequired
 };
 
 export default TitleFormatEditor;

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -104,17 +104,24 @@ export class TitleFormatEditor extends Component {
 				.set( 'anchorOffset', min( indices ) )
 				.set( 'focusOffset', max( indices ) );
 
-			this.updateEditor(
-				EditorState.push(
-					editorState,
-					Modifier.removeRange(
-						currentContent,
-						range,
-						'forward'
-					),
-					'remove-range'
-				)
+			const withoutToken = EditorState.push(
+				editorState,
+				Modifier.removeRange(
+					currentContent,
+					range,
+					'forward'
+				),
+				'remove-range'
 			);
+
+			const selectionBeforeToken = EditorState.forceSelection(
+				withoutToken,
+				range
+					.set( 'anchorOffset', min( indices ) )
+					.set( 'focusOffset', min( indices ) )
+			);
+
+			this.updateEditor( selectionBeforeToken );
 		};
 	}
 

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -13,22 +13,6 @@ import {
 import Token from './token';
 import { fromEditor, toEditor } from './parser';
 
-const buttonStyle = {
-	padding: '3px',
-	margin: '3px',
-	marginRight: '5px',
-	backgroundColor: '#ebebeb',
-	borderRadius: '3px',
-	fontWeight: 'bold'
-};
-
-const editorStyle = {
-	margin: '12px',
-	padding: '8px',
-	border: '1px solid black',
-	borderRadius: '3px'
-};
-
 export class TitleFormatEditor extends Component {
 	constructor( props ) {
 		super( props );
@@ -112,24 +96,27 @@ export class TitleFormatEditor extends Component {
 		const { tokens, type } = this.props;
 
 		return (
-			<div style={ editorStyle }>
-				<div style={ { marginBottom: '10px' } }>
-					{ type.label }
+			<div className="title-format-editor">
+				<div className="title-format-editor__header">
+					<span className="title-format-editor__title">{ type.label }</span>
 					{ map( tokens, ( title, name ) => (
 						<span
 							key={ name }
-							style={ buttonStyle }
+							className="title-format-editor__button"
 							onClick={ this.addToken( title, name ) }
 						>
 							{ title }
 						</span>
 					) ) }
 				</div>
-				<Editor
-					editorState={ editorState }
-					onChange={ this.updateEditor }
-					ref={ this.storeEditorReference }
-				/>
+				<div className="title-format-editor__editor-wrapper">
+					<Editor
+						editorState={ editorState }
+						onChange={ this.updateEditor }
+						ref={ this.storeEditorReference }
+					/>
+				</div>
+				<div className="title-format-editor__preview">Preview: What's up with that?</div>
 			</div>
 		);
 	}

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,16 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import {
-	compact,
-	flowRight as compose,
-	get,
-	has,
-	head,
-	invert,
-	map,
-	mapValues,
-	matchesProperty,
-	reduce,
-	some,
+	map
 } from 'lodash';
 import {
 	CompositeDecorator,
@@ -21,6 +11,9 @@ import {
 	convertFromRaw,
 	convertToRaw,
 } from 'draft-js';
+
+import Token from './token';
+import { fromEditor, toEditor } from './parser';
 
 const buttonStyle = {
 	padding: '3px',
@@ -36,165 +29,6 @@ const editorStyle = {
 	padding: '8px',
 	border: '1px solid black',
 	borderRadius: '3px'
-};
-
-const Token = props => {
-	const style = {
-		borderRadius: '3px',
-		backgroundColor: '#08c',
-		marginLeft: '1px',
-		marginRight: '1px',
-		padding: '2px',
-		color: '#fff'
-	};
-
-	return (
-		<span style={ style }>{ props.children }</span>
-	);
-};
-
-/**
- * Converts from ContentState to native Calypso format list
- *
- * @param {ContentState} rawContent Content of editor
- * @returns {Array} title format
- */
-const fromEditor = rawContent => {
-	const text = get( rawContent, 'blocks[0].text', '' );
-	const ranges = get( rawContent, 'blocks[0].entityRanges', [] );
-	const entities = get( rawContent, 'entityMap' );
-
-	const [ o, i, t ] = ranges.reduce( ( [ output, lastIndex, remainingText ], next ) => {
-		const tokenName = get( entities, [ next.key, 'data', 'name' ], null );
-		const textBlock = next.offset > lastIndex
-			? { type: 'string', value: remainingText.slice( lastIndex, next.offset ) }
-			: null;
-
-		return [ [
-			...output,
-			textBlock,
-			{ type: tokenName }
-		], next.offset + next.length, remainingText ];
-	}, [ [], 0, text ] );
-
-	// add final remaining text not captured by any entity ranges
-	return compact( [
-		...o,
-		i < t.length && { type: 'string', value: t.slice( i ) }
-	] );
-};
-
-const or = ( ...args ) => some( args );
-
-const isTextPiece = matchesProperty( 'type', 'string' );
-
-/**
- * Creates a dictionary for building an entityMap from a given title format
- *
- * There should only be a single entity for each given type of token
- * available in the editor, and only one for each in the given title
- * formats. Therefore, we need to build this dictionary, or mapping,
- * in order to use later when actually creating the entityMap
- *
- * E.g.
- *     From: [
- *         { type: 'string', value: 'Visit ' },
- *         { type: 'siteName' },
- *         { type: 'string', value: ' | ' },
- *         { type: 'tagline' }
- *     ]
- *     To:   { siteName: 0, tagline: 1 }
- *
- * @param {object} format native title format object
- * @returns {object} mapping from token name to presumptive entity id
- */
-const buildEntityMapping = compose(
-	head, // return only the mapping and discard the lastKey
-	format => reduce( format, ( [ entityMap, lastKey ], { type } ) => (
-		or( isTextPiece( { type } ), has( entityMap, type ) ) // skip strings and existing tokens
-			? [ entityMap, lastKey ]
-			: [ { ...entityMap, [ type ]: lastKey }, lastKey + 1 ]
-	), [ {}, 0 ] )
-);
-
-const emptyBlockMap = {
-	text: '',
-	entityRanges: [],
-	type: 'unstyled'
-};
-
-const tokenTitle = ( type, tokens ) => get( tokens, type, '' );
-
-/**
- * Creates a new entity reference for a blockMap
- *
- * @param {Number} offset offset of entity into block text
- * @param {String} type token name for entity reference
- * @param {object} tokens mapping between token names and translated titles
- * @param {object} entityGuide mapping between token names and entity key
- * @returns {object} entityRange for use in blockMap in ContentState
- */
-const newEntityAt = ( offset, type, tokens, entityGuide ) => ( {
-	key: entityGuide[ type ],
-	length: tokenTitle( type, tokens ).length,
-	offset
-} );
-
-/**
- * Converts native format object to block map
- *
- * E.g.
- *     From: [
- *         { type: 'siteName' },
- *         { type: 'string', value: ' | ' },
- *         { type: 'tagline' }
- *     ]
- *     To: {
- *         text: 'siteName | tagline',
- *         entityRanges: [
- *             { key: 0, offset: 0, length: 8 },
- *             { key: 1, offset: 11, length: 7 }
- *         ]
- *     }
- *
- * @param {Array} format native Calypso title format object
- * @param {object} tokens mapping between token names and translated titles
- * @param {object} entityGuide mapping between token names and entity key
- * @returns {object} blockMap for use in ContentState
- */
-const buildBlockMap = compose(
-	head,
-	( format, tokens, entityGuide ) => reduce( format, ( [ block, lastIndex ], piece ) => [
-		{
-			...block,
-			entityRanges: isTextPiece( piece )
-				? block.entityRanges
-				: [ ...block.entityRanges, newEntityAt( lastIndex, piece.type, tokens, entityGuide ) ],
-			text: block.text + ( isTextPiece( piece ) ? piece.value : tokenTitle( piece.type, tokens ) ),
-		},
-		lastIndex + ( piece.value ? piece.value.length : tokenTitle( piece.type, tokens ).length )
-	], [ emptyBlockMap, 0 ] )
-);
-
-/**
- * Converts Calypso-native title format into RawDraftContentState for Editor
- *
- * @param {Array} format pieces used to build title format
- * @param {object} tokens mapping between token names and translated titles
- * @returns {RawDraftContentState} content for editor
- */
-const toEditor = ( format, tokens ) => {
-	const entityGuide = buildEntityMapping( format );
-	const blocks = [ buildBlockMap( format, tokens, entityGuide ) ];
-
-	return {
-		blocks,
-		entityMap: mapValues( invert( entityGuide ), name => ( {
-			type: 'TOKEN',
-			mutability: 'IMMUTABLE',
-			data: { name }
-		} ) )
-	};
 };
 
 export class TitleFormatEditor extends Component {

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import {
-	get,
 	map,
 	max,
 	min
@@ -17,7 +16,7 @@ import {
 
 import Token from './token';
 import { fromEditor, toEditor } from './parser';
-import { getSeoTitle } from 'state/sites/selectors';
+import { buildSeoTitle } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { localize } from 'i18n-calypso';
 
@@ -160,7 +159,16 @@ export class TitleFormatEditor extends Component {
 
 	render() {
 		const { editorState } = this.state;
-		const { translate, tokens, type, previewText } = this.props;
+		const {
+			titleData,
+			translate,
+			tokens,
+			type
+		} = this.props;
+
+		const previewText = type.value
+			? buildSeoTitle( { [ type.value ]: fromEditor( editorState.getCurrentContent() ) }, type.value, titleData )
+			: '';
 
 		const formattedPreview = previewText
 			? `${ translate( 'Preview' ) }: ${ previewText }`
@@ -203,19 +211,16 @@ TitleFormatEditor.propTypes = {
 
 const mapStateToProps = ( state, ownProps ) => {
 	const site = getSelectedSite( state );
-	const type = get( ownProps, 'type.value', '' );
 	const { translate } = ownProps;
 
 	// Add example content for post/page title, tag name and archive dates
-	const content = {
-		site,
-		post: { title: translate( 'Example Title' ) },
-		tag: translate( 'Example Tag' ),
-		date: translate( 'August 2016' )
-	};
-
 	return ( {
-		previewText: getSeoTitle( state, type, content )
+		titleData: {
+			site,
+			post: { title: translate( 'Example Title' ) },
+			tag: translate( 'Example Tag' ),
+			date: translate( 'August 2016' )
+		}
 	} );
 };
 

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -34,16 +34,29 @@ export class TitleFormatEditor extends Component {
 		this.addToken = this.addToken.bind( this );
 		this.removeToken = this.removeToken.bind( this );
 		this.renderTokens = this.renderTokens.bind( this );
+		this.editorStateFrom = this.editorStateFrom.bind( this );
 
 		this.state = {
-			editorState: EditorState.createWithContent(
-				toEditor( props.titleFormats, props.tokens ),
-				new CompositeDecorator( [ {
-					strategy: this.renderTokens,
-					component: Chip( this.removeToken )
-				} ] )
-			)
+			editorState: this.editorStateFrom( props ),
 		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.disabled && ! nextProps.disabled ) {
+			this.setState( {
+				editorState: this.editorStateFrom( nextProps )
+			} );
+		}
+	}
+
+	editorStateFrom( props ) {
+		return EditorState.createWithContent(
+			toEditor( props.titleFormats, props.tokens ),
+			new CompositeDecorator( [ {
+				strategy: this.renderTokens,
+				component: Chip( this.removeToken )
+			} ] )
+		);
 	}
 
 	updateEditor( editorState ) {

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -8,8 +8,6 @@ import {
 	EditorState,
 	Entity,
 	Modifier,
-	convertFromRaw,
-	convertToRaw,
 } from 'draft-js';
 
 import Token from './token';
@@ -37,7 +35,7 @@ export class TitleFormatEditor extends Component {
 
 		this.state = {
 			editorState: EditorState.createWithContent(
-				convertFromRaw( toEditor( props.titleFormats, props.tokens ) ),
+				toEditor( props.titleFormats, props.tokens ),
 				new CompositeDecorator( [ {
 					strategy: this.renderTokens,
 					component: Token
@@ -70,7 +68,7 @@ export class TitleFormatEditor extends Component {
 		// would revert to the previous title type's format
 		this.setState( {
 			editorState: EditorState.createWithContent(
-				convertFromRaw( toEditor( props.titleFormats, props.tokens ) ),
+				toEditor( props.titleFormats, props.tokens ),
 				new CompositeDecorator( [ {
 					strategy: this.renderTokens,
 					component: Token
@@ -83,7 +81,8 @@ export class TitleFormatEditor extends Component {
 		const { onChange } = this.props;
 		const currentContent = editorState.getCurrentContent();
 
-		if ( convertToRaw( currentContent ).blocks.length > 1 ) {
+		// limit to one line
+		if ( currentContent.getBlockMap().size > 1 ) {
 			return;
 		}
 
@@ -91,7 +90,7 @@ export class TitleFormatEditor extends Component {
 			{ editorState },
 			() => {
 				editorState.lastChangeType === 'add-token' && this.focusEditor();
-				onChange( fromEditor( convertToRaw( currentContent ) ) );
+				onChange( fromEditor( currentContent ) );
 			}
 		);
 	}

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -11,6 +11,8 @@ import {
 // on a solid solution for general IE polyfills
 //
 // They were borrowed and modified from MDN
+//
+// @TODO Remove these when we have a real Calypso polyfill solution
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
 if ( ! String.prototype.endsWith ) {
@@ -103,6 +105,12 @@ import { localize } from 'i18n-calypso';
 const Chip = onClick => props => <Token { ...props } onClick={ onClick } />;
 
 export class TitleFormatEditor extends Component {
+	static propTypes = {
+		type: PropTypes.object.isRequired,
+		tokens: PropTypes.object.isRequired,
+		onChange: PropTypes.func.isRequired
+	};
+
 	constructor( props ) {
 		super( props );
 
@@ -280,14 +288,6 @@ export class TitleFormatEditor extends Component {
 		);
 	}
 }
-
-TitleFormatEditor.displayName = 'TitleFormatEditor';
-
-TitleFormatEditor.propTypes = {
-	type: PropTypes.object.isRequired,
-	tokens: PropTypes.object.isRequired,
-	onChange: PropTypes.func.isRequired
-};
 
 const mapStateToProps = ( state, ownProps ) => {
 	const site = getSelectedSite( state );

--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -10,20 +10,97 @@ import {
 	reduce,
 	some,
 } from 'lodash';
+import {
+	convertFromRaw,
+	convertToRaw,
+} from 'draft-js';
 
+/*
+ * The functions in this file convert between the
+ * Calypso-native representation of title formats
+ * and its translation into the structure for the
+ * draft-js editor.
+ *
+ * Custom block titles consist of a list of zero
+ * or more "pieces," each of which is either a
+ * predefined "chip" or a sequence of arbitrary
+ * text.
+ *
+ * "Chips" are placeholders for dynamic content
+ * replaced at runtime, such as a site's name or
+ * a post's title.
+ *
+ * <Calypso-native title format>
+ * [
+ *   { type: 'postTitle' },
+ *   { type: 'string', value: ' | ' },
+ *   { type: 'siteName' }
+ * ]
+ *
+ * The draft-js editor however operates on a list
+ * of blocks containing plain-text and associated
+ * meta information about the characters within
+ * each block. It is domain-specific to rich text
+ * and not to our problems at hand. We must map
+ * the title formats into something the editor can
+ * use to render and edit them. See the draft-js
+ * documentation for understanding its data model.
+ *
+ * draft-js translation of above example
+ * (some data omitted to clarify the example)
+ *
+ * <RawDraftContentState>
+ * {
+ *   blocks: [
+ *     0: {
+ *       text: 'Post Title | Site Name',
+ *       type: 'unstyled',
+ *       entityRanges: [
+ *         { key: 0, offset: 0, length: 10 },
+ *         { key: 1, offset: 13, length: 9 }
+ *       ]
+ *     }
+ *   ],
+ *   entityMap: {
+ *     0: { type: 'TOKEN', mutability: 'IMMUTABLE', data: { name: 'postTitle' } },
+ *     1: { type: 'TOKEN', mutability: 'IMMUTABLE', data: { name: 'siteName' } }
+ *   }
+ * }
+ *
+ * The challenge then is to provide an effective
+ * mapping between these formats. Notice that in
+ * the editor we are showing the translations of
+ * the chip names since that is what it will
+ * render to the browser. However, the native name
+ * is stored as metadata for the range of characters
+ * that represent the chip.
+ *
+ */
+
+/**
+ * Returns whether or not at least one arg is truthy
+ *
+ * @param {bool} args pieces to 'or' together
+ * @returns {bool} result of 'or'ing all the args
+ */
 const or = ( ...args ) => some( args );
 
 /**
  * Converts from ContentState to native Calypso format list
  *
- * @param {ContentState} rawContent Content of editor
+ * Since the editor constrains us to a single block, we can
+ * safely assume that we only need to convert the first one
+ *
+ * @param {ContentState} content Content of editor
  * @returns {Array} title format
  */
-export const fromEditor = rawContent => {
+export const fromEditor = content => {
+	const rawContent = convertToRaw( content );
 	const text = get( rawContent, 'blocks[0].text', '' );
 	const ranges = get( rawContent, 'blocks[0].entityRanges', [] );
 	const entities = get( rawContent, 'entityMap' );
 
+	// [ output, index, text ]
 	const [ o, i, t ] = ranges.reduce( ( [ output, lastIndex, remainingText ], next ) => {
 		const tokenName = get( entities, [ next.key, 'data', 'name' ], null );
 		const textBlock = next.offset > lastIndex
@@ -54,6 +131,9 @@ const isTextPiece = matchesProperty( 'type', 'string' );
  * formats. Therefore, we need to build this dictionary, or mapping,
  * in order to use later when actually creating the entityMap
  *
+ * Basically, this finds the set of unique chip tokens in the list
+ * and assigns each one an index that increases monotonically.
+ *
  * E.g.
  *     From: [
  *         { type: 'string', value: 'Visit ' },
@@ -69,9 +149,12 @@ const isTextPiece = matchesProperty( 'type', 'string' );
 const buildEntityMapping = compose(
 	head, // return only the mapping and discard the lastKey
 	format => reduce( format, ( [ entityMap, lastKey ], { type } ) => (
-		or( isTextPiece( { type } ), has( entityMap, type ) ) // skip strings and existing tokens
-			? [ entityMap, lastKey ]
-			: [ { ...entityMap, [ type ]: lastKey }, lastKey + 1 ]
+		or(
+			isTextPiece( { type } ), // text pieces don't get entities
+			has( entityMap, type ) // repeat-tokens don't need new entities
+		)
+			? [ entityMap, lastKey ] // no changes
+			: [ { ...entityMap, [ type ]: lastKey }, lastKey + 1 ] // create the new entity
 	), [ {}, 0 ] )
 );
 
@@ -81,12 +164,19 @@ const emptyBlockMap = {
 	type: 'unstyled'
 };
 
+/**
+ * Returns the translated name for the chip
+ *
+ * @param {string} type chip name, e.g. 'siteName'
+ * @param {object} tokens available tokens, e.g. { siteName: 'Site Name', tagline: 'Tagline' }
+ * @returns {string} translated chip name
+ */
 const tokenTitle = ( type, tokens ) => get( tokens, type, '' );
 
 /**
  * Creates a new entity reference for a blockMap
  *
- * @param {Number} offset offset of entity into block text
+ * @param {Number} offset start of entity inside of block text
  * @param {String} type token name for entity reference
  * @param {object} tokens mapping between token names and translated titles
  * @param {object} entityGuide mapping between token names and entity key
@@ -121,12 +211,12 @@ const newEntityAt = ( offset, type, tokens, entityGuide ) => ( {
  * @returns {object} blockMap for use in ContentState
  */
 const buildBlockMap = compose(
-	head,
+	head, // return only the block map and discard the lastIndex
 	( format, tokens, entityGuide ) => reduce( format, ( [ block, lastIndex ], piece ) => [
 		{
 			...block,
 			entityRanges: isTextPiece( piece )
-				? block.entityRanges
+				? block.entityRanges // text pieces don't add entities
 				: [ ...block.entityRanges, newEntityAt( lastIndex, piece.type, tokens, entityGuide ) ],
 			text: block.text + ( isTextPiece( piece ) ? piece.value : tokenTitle( piece.type, tokens ) ),
 		},
@@ -139,18 +229,18 @@ const buildBlockMap = compose(
  *
  * @param {Array} format pieces used to build title format
  * @param {object} tokens mapping between token names and translated titles
- * @returns {RawDraftContentState} content for editor
+ * @returns {ContentState} content for editor
  */
 export const toEditor = ( format, tokens ) => {
 	const entityGuide = buildEntityMapping( format );
 	const blocks = [ buildBlockMap( format, tokens, entityGuide ) ];
 
-	return {
+	return convertFromRaw( {
 		blocks,
 		entityMap: mapValues( invert( entityGuide ), name => ( {
 			type: 'TOKEN',
 			mutability: 'IMMUTABLE',
 			data: { name }
 		} ) )
-	};
+	} );
 };

--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -1,0 +1,156 @@
+import {
+	compact,
+	flowRight as compose,
+	get,
+	has,
+	head,
+	invert,
+	mapValues,
+	matchesProperty,
+	reduce,
+	some,
+} from 'lodash';
+
+const or = ( ...args ) => some( args );
+
+/**
+ * Converts from ContentState to native Calypso format list
+ *
+ * @param {ContentState} rawContent Content of editor
+ * @returns {Array} title format
+ */
+export const fromEditor = rawContent => {
+	const text = get( rawContent, 'blocks[0].text', '' );
+	const ranges = get( rawContent, 'blocks[0].entityRanges', [] );
+	const entities = get( rawContent, 'entityMap' );
+
+	const [ o, i, t ] = ranges.reduce( ( [ output, lastIndex, remainingText ], next ) => {
+		const tokenName = get( entities, [ next.key, 'data', 'name' ], null );
+		const textBlock = next.offset > lastIndex
+			? { type: 'string', value: remainingText.slice( lastIndex, next.offset ) }
+			: null;
+
+		return [ [
+			...output,
+			textBlock,
+			{ type: tokenName }
+		], next.offset + next.length, remainingText ];
+	}, [ [], 0, text ] );
+
+	// add final remaining text not captured by any entity ranges
+	return compact( [
+		...o,
+		i < t.length && { type: 'string', value: t.slice( i ) }
+	] );
+};
+
+const isTextPiece = matchesProperty( 'type', 'string' );
+
+/**
+ * Creates a dictionary for building an entityMap from a given title format
+ *
+ * There should only be a single entity for each given type of token
+ * available in the editor, and only one for each in the given title
+ * formats. Therefore, we need to build this dictionary, or mapping,
+ * in order to use later when actually creating the entityMap
+ *
+ * E.g.
+ *     From: [
+ *         { type: 'string', value: 'Visit ' },
+ *         { type: 'siteName' },
+ *         { type: 'string', value: ' | ' },
+ *         { type: 'tagline' }
+ *     ]
+ *     To:   { siteName: 0, tagline: 1 }
+ *
+ * @param {object} format native title format object
+ * @returns {object} mapping from token name to presumptive entity id
+ */
+const buildEntityMapping = compose(
+	head, // return only the mapping and discard the lastKey
+	format => reduce( format, ( [ entityMap, lastKey ], { type } ) => (
+		or( isTextPiece( { type } ), has( entityMap, type ) ) // skip strings and existing tokens
+			? [ entityMap, lastKey ]
+			: [ { ...entityMap, [ type ]: lastKey }, lastKey + 1 ]
+	), [ {}, 0 ] )
+);
+
+const emptyBlockMap = {
+	text: '',
+	entityRanges: [],
+	type: 'unstyled'
+};
+
+const tokenTitle = ( type, tokens ) => get( tokens, type, '' );
+
+/**
+ * Creates a new entity reference for a blockMap
+ *
+ * @param {Number} offset offset of entity into block text
+ * @param {String} type token name for entity reference
+ * @param {object} tokens mapping between token names and translated titles
+ * @param {object} entityGuide mapping between token names and entity key
+ * @returns {object} entityRange for use in blockMap in ContentState
+ */
+const newEntityAt = ( offset, type, tokens, entityGuide ) => ( {
+	key: entityGuide[ type ],
+	length: tokenTitle( type, tokens ).length,
+	offset
+} );
+
+/**
+ * Converts native format object to block map
+ *
+ * E.g.
+ *     From: [
+ *         { type: 'siteName' },
+ *         { type: 'string', value: ' | ' },
+ *         { type: 'tagline' }
+ *     ]
+ *     To: {
+ *         text: 'siteName | tagline',
+ *         entityRanges: [
+ *             { key: 0, offset: 0, length: 8 },
+ *             { key: 1, offset: 11, length: 7 }
+ *         ]
+ *     }
+ *
+ * @param {Array} format native Calypso title format object
+ * @param {object} tokens mapping between token names and translated titles
+ * @param {object} entityGuide mapping between token names and entity key
+ * @returns {object} blockMap for use in ContentState
+ */
+const buildBlockMap = compose(
+	head,
+	( format, tokens, entityGuide ) => reduce( format, ( [ block, lastIndex ], piece ) => [
+		{
+			...block,
+			entityRanges: isTextPiece( piece )
+				? block.entityRanges
+				: [ ...block.entityRanges, newEntityAt( lastIndex, piece.type, tokens, entityGuide ) ],
+			text: block.text + ( isTextPiece( piece ) ? piece.value : tokenTitle( piece.type, tokens ) ),
+		},
+		lastIndex + ( piece.value ? piece.value.length : tokenTitle( piece.type, tokens ).length )
+	], [ emptyBlockMap, 0 ] )
+);
+
+/**
+ * Converts Calypso-native title format into RawDraftContentState for Editor
+ *
+ * @param {Array} format pieces used to build title format
+ * @param {object} tokens mapping between token names and translated titles
+ * @returns {RawDraftContentState} content for editor
+ */
+export const toEditor = ( format, tokens ) => {
+	const entityGuide = buildEntityMapping( format );
+	const blocks = [ buildBlockMap( format, tokens, entityGuide ) ];
+
+	return {
+		blocks,
+		entityMap: mapValues( invert( entityGuide ), name => ( {
+			type: 'TOKEN',
+			mutability: 'IMMUTABLE',
+			data: { name }
+		} ) )
+	};
+};

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -1,0 +1,52 @@
+.title-format-editor {
+	margin-bottom: 20px;
+}
+
+.title-format-editor__header {
+	display: flex;
+	align-items: center;
+	margin-bottom: 8px;
+}
+
+.title-format-editor__title {
+	font-weight: bold;
+	flex: 1;
+	align-self: center;
+}
+
+.title-format-editor__button {
+	border-radius: 3px;
+	background-color: lighten( $gray, 30% );
+	color: darken( $gray, 30% );
+	padding: 4px 8px;
+	margin-left: auto;
+	font-size: 12px;
+	font-weight: bold;
+	margin-left: 8px;
+}
+
+.title-format-editor__editor-wrapper {
+	border: 1px solid $gray;
+	padding: 12px;
+}
+
+.title-format-editor__token {
+	display: inline-flex;
+	align-items: center;
+	padding: 4px 6px;
+	background-color: darken( $gray, 20% );
+	color: $white;
+	border-radius: 3px;
+	cursor: default;
+}
+
+.title-format-editor__token-close {
+	margin-left: 10px;
+}
+
+.title-format-editor__preview {
+	color: $gray;
+	font-style: italic;
+	margin-top: 5px;
+	font-size: 13px;
+}

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -23,21 +23,36 @@
 	margin-left: 10px;
 	font-size: 12px;
 	font-weight: bold;
+	cursor: pointer;
+
+	&:before {
+		content: '+';
+		margin-right: 4px;
+		font-weight: 600;
+	}
+
+	&:hover {
+		background-color: lighten( $gray, 20% );
+	}
 }
 
 .title-format-editor__editor-wrapper {
 	border: 1px solid $gray;
-	padding: 12px;
+	padding: 6px 12px;
 }
 
 .title-format-editor__token {
 	display: inline-flex;
 	align-items: center;
-	padding: 4px 6px;
+	padding: 2px 6px;
 	background-color: darken( $gray, 20% );
 	color: $white;
 	border-radius: 3px;
-	cursor: default;
+	cursor: pointer;
+
+	&:hover {
+		background-color: darken( $gray, 10% );
+	}
 }
 
 .title-format-editor__token-close {

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -51,7 +51,7 @@
 	cursor: pointer;
 
 	&:hover {
-		background-color: darken( $gray, 10% );
+		background-color: $alert-red;
 	}
 }
 

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -4,14 +4,15 @@
 
 .title-format-editor__header {
 	display: flex;
-	align-items: center;
-	margin-bottom: 8px;
+	align-items: baseline;
+	justify-content: flex-end;
+	margin-bottom: 6px;
 }
 
 .title-format-editor__title {
 	font-weight: bold;
 	flex: 1;
-	align-self: center;
+	margin-right: auto;
 }
 
 .title-format-editor__button {
@@ -19,10 +20,9 @@
 	background-color: lighten( $gray, 30% );
 	color: darken( $gray, 30% );
 	padding: 4px 8px;
-	margin-left: auto;
+	margin-left: 10px;
 	font-size: 12px;
 	font-weight: bold;
-	margin-left: 8px;
 }
 
 .title-format-editor__editor-wrapper {
@@ -42,6 +42,8 @@
 
 .title-format-editor__token-close {
 	margin-left: 10px;
+	color: lighten( $gray, 10% );
+	font-size: 10px;
 }
 
 .title-format-editor__preview {

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -49,6 +49,7 @@
 	color: $white;
 	border-radius: 3px;
 	cursor: pointer;
+	transition: all 0.3s ease;
 
 	&:hover {
 		background-color: $alert-red;

--- a/client/components/title-format-editor/token.jsx
+++ b/client/components/title-format-editor/token.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
 
 export const Token = props => {
+	const { onClick } = props;
+
 	return (
-		<div className="title-format-editor__token">
+		<div
+			className="title-format-editor__token"
+			onClick={ onClick( props.entityKey ) }
+		>
 			{ props.children }
 			<div className="title-format-editor__token-close noticon noticon-close-alt" />
 		</div>

--- a/client/components/title-format-editor/token.jsx
+++ b/client/components/title-format-editor/token.jsx
@@ -1,17 +1,11 @@
 import React from 'react';
 
 export const Token = props => {
-	const style = {
-		borderRadius: '3px',
-		backgroundColor: '#08c',
-		marginLeft: '1px',
-		marginRight: '1px',
-		padding: '2px',
-		color: '#fff'
-	};
-
 	return (
-		<span style={ style }>{ props.children }</span>
+		<div className="title-format-editor__token">
+			{ props.children }
+			<div className="title-format-editor__token-close noticon noticon-close-alt" />
+		</div>
 	);
 };
 

--- a/client/components/title-format-editor/token.jsx
+++ b/client/components/title-format-editor/token.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export const Token = props => {
+	const style = {
+		borderRadius: '3px',
+		backgroundColor: '#08c',
+		marginLeft: '1px',
+		marginRight: '1px',
+		padding: '2px',
+		color: '#fff'
+	};
+
+	return (
+		<span style={ style }>{ props.children }</span>
+	);
+};
+
+export default Token;

--- a/client/components/title-format-editor/token.jsx
+++ b/client/components/title-format-editor/token.jsx
@@ -3,14 +3,15 @@ import React from 'react';
 export const Token = props => {
 	const { onClick } = props;
 
+	// please ignore the formatting below
+	// if we allow spaces it will mess up
+	// the way the component renders in
+	// the draft-js editor
 	return (
 		<div
 			className="title-format-editor__token"
 			onClick={ onClick( props.entityKey ) }
-		>
-			{ props.children }
-			<div className="title-format-editor__token-close noticon noticon-close-alt" />
-		</div>
+		>{ props.children }</div>
 	);
 };
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -107,7 +107,7 @@ export const SeoForm = React.createClass( {
 		return {
 			...stateForSite( this.props.site ),
 			seoTitleFormats: this.props.storedTitleFormats,
-			isRefreshingSiteData: true,
+			isRefreshingSiteData: false,
 			dirtyFields: Set()
 		};
 	},

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -230,7 +230,7 @@ export const SeoForm = React.createClass( {
 
 		this.setState( {
 			isSubmittingForm: true,
-			isRefreshingSiteData: dirtyFields.has( 'seoTitleFormats' )
+			isRefreshingSiteData: dirtyFields.has( 'seoTitleFormats' ),
 		} );
 
 		// We need to be careful here and only
@@ -589,7 +589,6 @@ export const SeoForm = React.createClass( {
 
 const mapStateToProps = ( state, ownProps ) => {
 	const { site } = ownProps;
-	storedTitleFormats: getSeoTitleFormatsForSite( getSelectedSite( state ) ),
 	const isAdvancedSeoEligible = site && site.plan && hasBusinessPlan( site.plan );
 
 	return {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -107,6 +107,10 @@ export const SeoForm = React.createClass( {
 		return {
 			...stateForSite( this.props.site ),
 			seoTitleFormats: this.props.storedTitleFormats,
+			// dirtyFields is used to prevent prop updates
+			// from overwriting local stateful edits that
+			// are in progress and haven't yet been saved
+			// to the server
 			dirtyFields: Set(),
 			isRefreshingSiteData: true,
 			invalidatedSiteObject: this.props.selectedSite,

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -106,8 +106,8 @@ export const SeoForm = React.createClass( {
 	getInitialState() {
 		return {
 			...stateForSite( this.props.site ),
-			seoTitleFormats: {},
-			isRefreshingSiteData: false,
+			seoTitleFormats: this.props.storedTitleFormats,
+			isRefreshingSiteData: true,
 			dirtyFields: Set()
 		};
 	},
@@ -121,7 +121,7 @@ export const SeoForm = React.createClass( {
 
 		let nextState = {
 			...stateForSite( nextProps.site ),
-			seoTitleFormats: nextProps.storedTitleFormats
+			seoTitleFormats: nextProps.storedTitleFormats,
 		};
 
 		// Don't update state for fields the user has edited
@@ -142,7 +142,7 @@ export const SeoForm = React.createClass( {
 
 		this.setState( {
 			...nextState,
-			isRefreshingSiteData
+			isRefreshingSiteData,
 		} );
 	},
 
@@ -230,7 +230,7 @@ export const SeoForm = React.createClass( {
 
 		this.setState( {
 			isSubmittingForm: true,
-			isRefreshingSiteData: dirtyFields.has( 'seoTitleFormats' ),
+			isRefreshingSiteData: dirtyFields.has( 'seoTitleFormats' )
 		} );
 
 		// We need to be careful here and only
@@ -316,6 +316,7 @@ export const SeoForm = React.createClass( {
 		const {
 			isSubmittingForm,
 			isFetchingSettings,
+			isRefreshingSiteData,
 			seoMetaDescription,
 			showPasteError = false,
 			hasHtmlTagError = false,
@@ -440,7 +441,11 @@ export const SeoForm = React.createClass( {
 									'results, and when shared on social media sites.'
 								) }
 								</p>
-								<MetaTitleEditor onChange={ this.updateTitleFormats } />
+								<MetaTitleEditor
+									disabled={ isRefreshingSiteData || isDisabled }
+									onChange={ this.updateTitleFormats }
+									titleFormats={ this.state.seoTitleFormats }
+								/>
 							</Card>
 						</div>
 					}
@@ -584,6 +589,7 @@ export const SeoForm = React.createClass( {
 
 const mapStateToProps = ( state, ownProps ) => {
 	const { site } = ownProps;
+	storedTitleFormats: getSeoTitleFormatsForSite( getSelectedSite( state ) ),
 	const isAdvancedSeoEligible = site && site.plan && hasBusinessPlan( site.plan );
 
 	return {
@@ -596,7 +602,7 @@ const mapStateToProps = ( state, ownProps ) => {
 
 const mapDispatchToProps = {
 	refreshSiteData: siteId => requestSite( siteId ),
-	trackSubmission: () => recordTracksEvent( 'calypso_seo_settings_form_submit', {} )
+	trackSubmission: () => recordTracksEvent( 'calypso_seo_settings_form_submit', {} ),
 };
 
 export default connect(

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -113,6 +113,13 @@ export const SeoForm = React.createClass( {
 		};
 	},
 
+	componentWillMount() {
+		this.changeGoogleCode = this.handleVerificationCodeChange( 'googleCode' );
+		this.changeBingCode = this.handleVerificationCodeChange( 'bingCode' );
+		this.changePinterestCode = this.handleVerificationCodeChange( 'pinterestCode' );
+		this.changeYandexCode = this.handleVerificationCodeChange( 'yandexCode' );
+	},
+
 	componentDidMount() {
 		this.refreshCustomTitles();
 	},
@@ -164,28 +171,30 @@ export const SeoForm = React.createClass( {
 		) );
 	},
 
-	handleVerificationCodeChange( event, serviceCode ) {
-		const { dirtyFields } = this.state;
+	handleVerificationCodeChange( serviceCode ) {
+		return event => {
+			const { dirtyFields } = this.state;
 
-		if ( ! this.state.hasOwnProperty( serviceCode ) ) {
-			return;
-		}
+			if ( ! this.state.hasOwnProperty( serviceCode ) ) {
+				return;
+			}
 
-		// Show an error if the user types into the field
-		if ( event.target.value.length === 1 ) {
+			// Show an error if the user types into the field
+			if ( event.target.value.length === 1 ) {
+				this.setState( {
+					showPasteError: true,
+					invalidCodes: [ serviceCode.replace( 'Code', '' ) ]
+				} );
+				return;
+			}
+
 			this.setState( {
-				showPasteError: true,
-				invalidCodes: [ serviceCode.replace( 'Code', '' ) ]
+				invalidCodes: [],
+				showPasteError: false,
+				[ serviceCode ]: event.target.value,
+				dirtyFields: dirtyFields.add( serviceCode )
 			} );
-			return;
-		}
-
-		this.setState( {
-			invalidCodes: [],
-			showPasteError: false,
-			[ serviceCode ]: event.target.value,
-			dirtyFields: dirtyFields.add( serviceCode )
-		} );
+		};
 	},
 
 	updateTitleFormats( seoTitleFormats ) {
@@ -379,14 +388,20 @@ export const SeoForm = React.createClass( {
 			/>
 		);
 
-		if ( config.isEnabled('manage/advanced-seo') ) {
+		if ( config.isEnabled( 'manage/advanced-seo' ) ) {
 			preview = (
 				<FormSettingExplanation>
-					<Button className="preview-button" onClick={ this.showPreview }>
-						{ this.translate('Show Previews') }
+					<Button
+						className="preview-button"
+						onClick={ this.showPreview }
+					>
+						{ this.translate( 'Show Previews' ) }
 					</Button>
 					<span className="preview-explanation">
-						{ this.translate('See how this will look on Google, Facebook, and Twitter.') }
+						{ this.translate(
+							'See how this will look on ' +
+							'Google, Facebook, and Twitter.'
+						) }
 					</span>
 				</FormSettingExplanation>
 			);
@@ -395,10 +410,22 @@ export const SeoForm = React.createClass( {
 		/* eslint-disable react/jsx-no-target-blank */
 		return (
 			<div>
-				<PageViewTracker path="/settings/seo/:site" title="Site Settings > SEO" />
+				<PageViewTracker
+					path="/settings/seo/:site"
+					title="Site Settings > SEO"
+				/>
 				{ isSitePrivate &&
-					<Notice status="is-warning" showDismiss={ false } text={ this.translate( 'SEO settings are disabled because the site visibility is not set to Public.' ) }>
-						<NoticeAction href={ generalTabUrl }>{ this.translate( 'View Settings' ) }</NoticeAction>
+					<Notice
+						status="is-warning"
+						showDismiss={ false }
+						text={ this.translate(
+							'SEO settings are disabled because the ' +
+							'site visibility is not set to Public.'
+						) }
+					>
+						<NoticeAction href={ generalTabUrl }>
+							{ this.translate( 'View Settings' ) }
+						</NoticeAction>
 					</Notice>
 				}
 
@@ -508,10 +535,34 @@ export const SeoForm = React.createClass( {
 									components: {
 										b: <strong />,
 										support: <a href="https://en.support.wordpress.com/webmaster-tools/" />,
-										google: <ExternalLink icon={ true } target="_blank" href="https://www.google.com/webmasters/tools/" />,
-										bing: <ExternalLink icon={ true } target="_blank" href="https://www.bing.com/webmaster/" />,
-										pinterest: <ExternalLink icon={ true } target="_blank" href="https://pinterest.com/website/verify/" />,
-										yandex: <ExternalLink icon={ true } target="_blank" href="https://webmaster.yandex.com/sites/" />
+										google: (
+											<ExternalLink
+												icon={ true }
+												target="_blank"
+												href="https://www.google.com/webmasters/tools/"
+											/>
+										),
+										bing: (
+											<ExternalLink
+												icon={ true }
+												target="_blank"
+												href="https://www.bing.com/webmaster/"
+											/>
+										),
+										pinterest: (
+											<ExternalLink
+												icon={ true }
+												target="_blank"
+												href="https://pinterest.com/website/verify/"
+											/>
+										),
+										yandex: (
+											<ExternalLink
+												icon={ true }
+												target="_blank"
+												href="https://webmaster.yandex.com/sites/"
+											/>
+										),
 									}
 								}
 							) }
@@ -527,7 +578,7 @@ export const SeoForm = React.createClass( {
 								disabled={ isDisabled }
 								isError={ hasError( 'google' ) }
 								placeholder={ getMetaTag( 'google', placeholderTagContent ) }
-								onChange={ event => this.handleVerificationCodeChange( event, 'googleCode' ) } />
+								onChange={ this.changeGoogleCode } />
 							{ hasError( 'google' ) && this.getVerificationError( showPasteError ) }
 						</FormFieldset>
 						<FormFieldset>
@@ -541,7 +592,7 @@ export const SeoForm = React.createClass( {
 								disabled={ isDisabled }
 								isError={ hasError( 'bing' ) }
 								placeholder={ getMetaTag( 'bing', placeholderTagContent ) }
-								onChange={ event => this.handleVerificationCodeChange( event, 'bingCode' ) } />
+								onChange={ this.changeBingCode } />
 							{ hasError( 'bing' ) && this.getVerificationError( showPasteError ) }
 						</FormFieldset>
 						<FormFieldset>
@@ -555,7 +606,7 @@ export const SeoForm = React.createClass( {
 								disabled={ isDisabled }
 								isError={ hasError( 'pinterest' ) }
 								placeholder={ getMetaTag( 'pinterest', placeholderTagContent ) }
-								onChange={ event => this.handleVerificationCodeChange( event, 'pinterestCode' ) } />
+								onChange={ this.changePinterestCode } />
 							{ hasError( 'pinterest' ) && this.getVerificationError( showPasteError ) }
 						</FormFieldset>
 						<FormFieldset>
@@ -569,12 +620,19 @@ export const SeoForm = React.createClass( {
 								disabled={ isDisabled }
 								isError={ hasError( 'yandex' ) }
 								placeholder={ getMetaTag( 'yandex', placeholderTagContent ) }
-								onChange={ event => this.handleVerificationCodeChange( event, 'yandexCode' ) } />
+								onChange={ this.changeYandexCode } />
 							{ hasError( 'yandex' ) && this.getVerificationError( showPasteError ) }
 						</FormFieldset>
 						<FormFieldset>
 							<FormLabel htmlFor="seo_sitemap">{ this.translate( 'XML Sitemap' ) }</FormLabel>
-							<ExternalLink className="seo-sitemap" icon={ true } href={ sitemapUrl } target="_blank">{ sitemapUrl }</ExternalLink>
+							<ExternalLink
+								className="seo-sitemap"
+								icon={ true }
+								href={ sitemapUrl }
+								target="_blank"
+							>
+								{ sitemapUrl }
+							</ExternalLink>
 							<FormSettingExplanation>
 								{ this.translate( 'Your site\'s sitemap is automatically sent to all major search engines for indexing.' ) }
 							</FormSettingExplanation>
@@ -583,11 +641,11 @@ export const SeoForm = React.createClass( {
 				</form>
 				<WebPreview
 					showPreview={ showPreview }
-				    onClose={ this.hidePreview }
-				    previewUrl={ siteUrl }
-				    showDeviceSwitcher={ false }
-				    showExternal={ false }
-				    defaultViewportDevice="seo"
+					onClose={ this.hidePreview }
+					previewUrl={ siteUrl }
+					showDeviceSwitcher={ false }
+					showExternal={ false }
+					defaultViewportDevice="seo"
 				/>
 			</div>
 		);

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -8,6 +8,7 @@ import {
 	find,
 	flowRight as compose,
 	get,
+	has,
 	map,
 	partialRight,
 	some,
@@ -330,9 +331,7 @@ export const getSeoTitleFormats = compose(
 	getRawSite
 );
 
-export const getSeoTitle = ( state, type, { site, post = {}, tag = '', date = '' } ) => {
-	const titleFormats = getSeoTitleFormats( state, site.ID );
-
+export const buildSeoTitle = ( titleFormats, type, { site, post = {}, tag = '', date = '' } ) => {
 	const processPiece = ( piece = {}, data ) =>
 		'string' === piece.type
 			? piece.value
@@ -380,6 +379,16 @@ export const getSeoTitle = ( state, type, { site, post = {}, tag = '', date = ''
 		default:
 			return post.title || site.name;
 	}
+};
+
+export const getSeoTitle = ( state, type, data ) => {
+	if ( ! has( data, 'site.ID' ) ) {
+		return '';
+	}
+
+	const titleFormats = getSeoTitleFormats( state, data.site.ID );
+
+	return buildSeoTitle( titleFormats, type, data );
 };
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -330,7 +330,7 @@ export const getSeoTitleFormats = compose(
 	getRawSite
 );
 
-export const getSeoTitle = ( state, type, { site, post = {} } ) => {
+export const getSeoTitle = ( state, type, { site, post = {}, tag = '', date = '' } ) => {
 	const titleFormats = getSeoTitleFormats( state, site.ID );
 
 	const processPiece = ( piece = {}, data ) =>
@@ -355,6 +355,27 @@ export const getSeoTitle = ( state, type, { site, post = {} } ) => {
 				tagline: site.description,
 				postTitle: post.title
 			} ) || post.title;
+
+		case 'pages':
+			return buildTitle( 'pages', {
+				siteName: site.name,
+				tagline: site.description,
+				pageTitle: post.title
+			} );
+
+		case 'groups':
+			return buildTitle( 'groups', {
+				siteName: site.name,
+				tagline: site.description,
+				groupTitle: tag
+			} );
+
+		case 'archives':
+			return buildTitle( 'archives', {
+				siteName: site.name,
+				tagline: site.description,
+				date: date
+			} );
 
 		default:
 			return post.title || site.name;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3723,6 +3723,52 @@
     },
     "yeast": {
       "version": "0.1.2"
+    },
+    "draft-js": {
+      "version": "0.8.1",
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.4",
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7"
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "dependencies": {
+                "node-fetch": {
+                  "version": "1.6.0",
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12"
+                    },
+                    "is-stream": {
+                      "version": "1.1.0"
+                    }
+                  }
+                },
+                "whatwg-fetch": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "promise": {
+              "version": "7.1.1",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.4"
+                }
+              }
+            },
+            "ua-parser-js": {
+              "version": "0.7.10"
+            }
+          }
+        },
+        "immutable": {
+          "version": "3.7.6"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "debug": "2.2.0",
     "dom-helpers": "2.4.0",
     "dom-scroll-into-view": "1.0.1",
+    "draft-js": "0.8.1",
     "email-validator": "1.0.1",
     "emitter-component": "1.1.1",
     "escape-regexp": "0.0.1",


### PR DESCRIPTION
Central to resolving #7285 

In this PR we are introducing the `draft-js` rich editor as a way of improving the user experience when editing the custom title formats for their sites. Previously we were using the `<TokenField />` component as it was pre-built in Calypso and met most of our needs. Unfortunately, the extend to which our needs mapped onto that component hit a brick wall and the editing flow was very awkward. The goal for bringing in `draft-js` is to give us the right tool to make a custom rich-text entry without getting lost in the bugs and details required to make that happen across multiple browsers and millions of edge cases.

The new editor weighs in at around half a megabyte of code un-minified and un-compressed. To facilitate this without causing undue burden on the initial bundle download, we split the `settings/seo` panel into its own asynchronously loading JavaScript chunk. Minified and gzipped this appears to add a mere 66 KB to the app size. That is not a small overhead, but it's also not catastrophic for desktop and mobile users alike.

This PR is meant to be an example and an experiment to give us the opportunity to learn about the `draft-js` editor and gauge whether or not we feel like it would be worth replacing some existing editors (such as the TokenField) with this functional and structurally-backed model.

**Before**
This is the version using `<TokenField />` for the title editing. It relies on typing a `,` in order to insert the token and once the token has been selected, it can't be used a second or third time. It's awkward to work with text around the tokens, and it's impossible (for underlying reasons) to type the text contents of those tokens without replacing the text _with_ the tokens.

<img width="600" alt="screen shot 2016-08-29 at 6 40 09 pm" src="https://cloud.githubusercontent.com/assets/5431237/18073097/300c161c-6e18-11e6-9f15-20d9e465c20b.png">

We could have split the editor out into separate sub panels as in the _after_ shot but didn't since we were working on this iteration. I don't have a video because something is broken right now in the existing development build (this should all be behind feature flags anyway)

**After**
This is the new `draft-js`-based editor. The tokens can now be clicked on from a list to insert and from the title format itself to remove. They easily fit around arbitrary text and there is no need for special commands to work with them.

![draft-title-editor](https://cloud.githubusercontent.com/assets/5431237/18073139/6f41a64e-6e18-11e6-9d64-cc2b8a07fe07.gif)

## Testing

Navigate to **My Sites** > **Settings** > **SEO** for a site with the business plan or above.

To test you will want to open a site with at least a business plan subscription. The editor should be gone for other sites, maybe a nudge will be in its place. Try and play with the title formats for your site. Try to break things.

*For Reference*:
 - [draft.js data format](https://medium.com/@rajaraodv/how-draft-js-represents-rich-text-data-eeabb5f25cf2#.2jdmz2e59)
 - [API docs](https://facebook.github.io/draft-js/docs/overview.html#content)

cc: @sirbrillig @roundhill @rodrigoi @aduth 

Test live: https://calypso.live/settings/seo?branch=experiment/draft-js-meta-title-editor