### PR TITLE
Reader: Update daily post button to skip site popover if user has only one site

### DIFF
--- a/client/reader/daily-post/index.jsx
+++ b/client/reader/daily-post/index.jsx
@@ -45,6 +45,10 @@ function preloadEditor() {
 	preload( 'post-editor' );
 }
 
+function onlyOneSite() {
+	return sitesList.data.length === 1;
+}
+
 class DailyPostButton extends React.Component {
 	constructor() {
 		super();
@@ -112,6 +116,11 @@ class DailyPostButton extends React.Component {
 			recordAction( 'open_daily_post_challenge' );
 			recordGaEvent( 'Opened Daily Post Challenge' );
 			recordTrackForPost( 'calypso_reader_daily_post_challenge_opened', this.props.post );
+
+			if ( onlyOneSite() ) {
+				const primarySlug = get( sitesList.getPrimary(), 'slug' );
+				return this.openEditorWithSite( primarySlug );
+			}
 		}
 		this._deferMenuChange( ! this.state.showingMenu );
 	}

--- a/client/reader/daily-post/index.jsx
+++ b/client/reader/daily-post/index.jsx
@@ -55,7 +55,7 @@ class DailyPostButton extends React.Component {
 		this._closeTimerId = null;
 		this._isMounted = false;
 
-		[ 'pickSiteToPostTo', 'toggle', 'closeMenu' ].forEach(
+		[ 'openEditorWithSite', 'toggle', 'closeMenu', 'renderSitesPopover' ].forEach(
 			( method ) => this[ method ] = this[ method ].bind( this )
 		);
 	}
@@ -93,7 +93,7 @@ class DailyPostButton extends React.Component {
 		} );
 	}
 
-	pickSiteToPostTo( siteSlug ) {
+	openEditorWithSite( siteSlug ) {
 		const pingbackAttributes = getPingbackAttributes( this.props.post );
 
 		recordAction( 'daily_post_challenge' );
@@ -125,6 +125,22 @@ class DailyPostButton extends React.Component {
 		}
 	}
 
+	renderSitesPopover() {
+		return (
+			<SitesPopover
+				key="menu"
+				header={ <div> { translate( 'Post on' ) } </div> }
+				sites={ sitesList }
+				context={ this.refs && this.refs.dailyPostButton }
+				visible={ this.state.showingMenu }
+				groups={ true }
+				onSiteSelect={ this.openEditorWithSite }
+				onClose={ this.closeMenu }
+				position="top"
+				className="is-reader"/>
+		);
+	}
+
 	render() {
 		const canParticipate = !! sitesList.getPrimary();
 		const title = get( this.props, 'post.title' );
@@ -148,19 +164,7 @@ class DailyPostButton extends React.Component {
 			( <Button ref="dailyPostButton" key="button" compact primary className={ buttonClasses }>
 					<Gridicon icon="create" /><span>{ translate( 'Post about ' ) + title } </span>
 				</Button> ),
-			( this.state.showingMenu
-				? <SitesPopover
-					key="menu"
-					header={ <div> { translate( 'Post on' ) } </div> }
-					sites={ sitesList }
-					context={ this.refs && this.refs.dailyPostButton }
-					visible={ this.state.showingMenu }
-					groups={ true }
-					onSiteSelect={ this.pickSiteToPostTo }
-					onClose={ this.closeMenu }
-					position="top"
-					className="is-reader"/>
-				: null )
+			( this.state.showingMenu ? this.renderSitesPopover() : null )
 		] );
 	}
 }

--- a/client/reader/daily-post/test/fixtures.js
+++ b/client/reader/daily-post/test/fixtures.js
@@ -34,8 +34,8 @@ export const discoverChallengePost = {
 	type: 'dp_discover'
 };
 
-export const sitesList = [
-	{ ID: 108516984, name: 'Join the Narwhal Club' },
-	{ ID: 6200060, name: '"I expected:"' },
-	{ ID: 72386110, name: 'Calypso Project P2' }
+export const sites = [
+	{ ID: 72386110, name: 'Calypso Project P2', slug: 'calypsop2.wordpress.com' },
+	{ ID: 108516984, name: 'Join the Narwhal Club', slug: 'jointhnarwhal.club' },
+	{ ID: 6200060, name: '"I expected:"', slug: 'iexpected' }
 ];

--- a/client/reader/daily-post/test/index.jsx
+++ b/client/reader/daily-post/test/index.jsx
@@ -7,42 +7,48 @@ import { assert } from 'chai';
 import { stub, spy } from 'sinon';
 import qs from 'qs';
 import noop from 'lodash/noop';
+import defer from 'lodash/defer';
+import delay from 'lodash/delay';
 
 /**
  * Internal dependencies
  */
 import useMockery from 'test/helpers/use-mockery';
-import { sitesList, dailyPromptPost } from './fixtures';
+import { sites, dailyPromptPost } from './fixtures';
+import Button from 'components/button';
 
 describe( 'DailyPostButton', () => {
 	const SitesPopover = props => <span { ...props } />;
 	const pageSpy = spy();
+	const sitesListMock = {
+		fetched: true,
+		data: sites,
+		getPrimary: stub()
+	};
 	let DailyPostButton;
 
 	useMockery( ( mockery ) => {
-		const getPrimary = stub();
 		const statsMocks = {
 			recordAction: noop,
 			recordGaEvent: noop,
 			recordTrackForPost: noop,
 		};
 		mockery.registerMock( 'reader/stats', statsMocks );
-
-		getPrimary.onFirstCall().returns( );
-		getPrimary.returns( sitesList );
-		mockery.registerMock( 'lib/sites-list', () => {
-			return { getPrimary };
-		} );
-
+		mockery.registerMock( 'lib/sites-list', () => sitesListMock );
 		mockery.registerMock( 'page', pageSpy );
 		mockery.registerMock( 'components/sites-popover', SitesPopover );
 	} );
 
 	before( () =>{
 		DailyPostButton = require( '../index' );
+		sitesListMock.getPrimary.returns( sitesListMock.data[ 0 ] );
 	} );
 
 	describe( 'rendering', () => {
+		before( () => {
+			sitesListMock.getPrimary.onFirstCall().returns();
+		} );
+
 		it( 'does not render if the user does not have any sites', () => {
 			const dailyPostPrompt = shallow( <DailyPostButton post={ dailyPromptPost }/> );
 			assert.isNull( dailyPostPrompt.type() );
@@ -69,18 +75,33 @@ describe( 'DailyPostButton', () => {
 		} );
 	} );
 
-	describe( 'creating a post', () => {
-		let prompt;
+	describe( 'clicking daily post button', () => {
+		let dailyPostButton;
+
 		before( () => {
-			prompt = shallow( <DailyPostButton post={ dailyPromptPost } /> );
+			dailyPostButton = shallow( <DailyPostButton post={ dailyPromptPost } /> );
 		} );
-		it( 'redirects to the choosen site', () => {
-			prompt.instance().pickSiteToPostTo( 'calypsop2.wordpress.com' );
+
+		afterEach( () => {
+			sitesListMock.data = sites;
+		} );
+
+		it( 'rediects to primary site if the user only has one site', () => {
+			sitesListMock.data = sitesListMock.data.slice( 0, 1 );
+			dailyPostButton.simulate( 'touchTap', { preventDefault: noop } );
 			assert.isTrue( pageSpy.calledWithMatch( /post\/calypsop2.wordpress.com?/ ) );
 		} );
 
+		it( 'shows the site selector if the user has more than one site', ( done ) => {
+			dailyPostButton.instance().renderSitesPopover = done;
+			dailyPostButton.simulate( 'touchTap', { preventDefault: noop } );
+		} );
+	} );
+
+	describe( 'staring a post', () => {
 		it( 'adds the daily post prompt attributes to the redirect url', () => {
-			prompt.instance().pickSiteToPostTo( 'calypsop2.wordpress.com' );
+			const prompt = shallow( <DailyPostButton post={ dailyPromptPost } /> );
+			prompt.instance().openEditorWithSite( 'calypsop2.wordpress.com' );
 			const pageArgs = pageSpy.lastCall.args[ 0 ];
 			const query = qs.parse( pageArgs.split( '?' )[ 1 ] );
 			const { title, URL } = dailyPromptPost;

--- a/client/reader/daily-post/test/index.jsx
+++ b/client/reader/daily-post/test/index.jsx
@@ -7,8 +7,6 @@ import { assert } from 'chai';
 import { stub, spy } from 'sinon';
 import qs from 'qs';
 import noop from 'lodash/noop';
-import defer from 'lodash/defer';
-import delay from 'lodash/delay';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
This bypasses the site list popover when clicking the "Post About Abc" if the user only has one site. 

**Testing**
```npm run test-client client/reader/daily-post ```

cc @blowery 

Test live: https://calypso.live/?branch=update/reader/daily-post-site-prompt