### PR TITLE
Me: Adds route and filepicker for updating Gravatar

### DIFF
--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -102,6 +102,17 @@ export default {
 		);
 	},
 
+	gravatar( context ) {
+		const GravatarUpload = require( './gravatar-upload' );
+		renderWithReduxStore(
+			React.createElement( GravatarUpload, {
+				context
+			} ),
+			document.getElementById( 'primary' ),
+			context.store
+		);
+	},
+
 	// Users that are redirected to `/me/next?welcome` after signup should visit
 	// `/me/next/welcome` instead.
 	nextStepsWelcomeRedirect( context, next ) {

--- a/client/me/gravatar-upload/index.jsx
+++ b/client/me/gravatar-upload/index.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import HeaderCake from 'components/header-cake';
+import Card from 'components/card';
+import FilePicker from 'components/file-picker';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+
+/*
+ * Module variables
+ */
+
+const JetpackSSOForm = React.createClass( {
+	displayName: 'GravatarUpload',
+
+	getInitialState() {
+		return {
+			selectedImage: false
+		};
+	},
+
+	goBack() {
+		page.back( '/me' );
+	},
+
+	onPick( files ) {
+		const file = files [ 0 ];
+		if ( ! file ) {
+			return;
+		}
+
+		console.log( file );
+
+		this.setState( {
+			selectedImage: file
+		} );
+	},
+
+	render() {
+		return (
+			<Main>
+				<MeSidebarNavigation />
+				<HeaderCake isCompact onClick={ this.goBack }>
+					{ this.translate( 'Update Gravatar' ) }
+				</HeaderCake>
+
+				<Card>
+					<FilePicker accept="image/*" onPick={ this.onPick } >
+						<a href="#">Select an image!</a>
+					</FilePicker>
+				</Card>
+			</Main>
+		);
+	}
+} );
+
+export default connect()( JetpackSSOForm );

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -34,4 +34,8 @@ export default function() {
 	}
 
 	page( '/me/get-apps', controller.sidebar, controller.apps );
-};
+
+	if ( config.isEnabled( 'me/gravatar' ) ) {
+		page( '/me/gravatar', controller.sidebar, controller.gravatar );
+	}
+}

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -1,14 +1,20 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:me:sidebar-gravatar' );
+import React from 'react';
+import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
-var Gravatar = require( 'components/gravatar' ),
-	eventRecorder = require( 'me/event-recorder' );
+import Gravatar from 'components/gravatar';
+import eventRecorder from 'me/event-recorder';
+import config from 'config';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:me:sidebar-gravatar' );
 
 module.exports = React.createClass( {
 
@@ -21,15 +27,24 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var profileURL = '//gravatar.com/' + this.props.user.username;
+		const profileURL = '//gravatar.com/' + this.props.user.username;
+		let updateProps = {
+			href: '/me/gravatar',
+			className: 'profile-gravatar__edit',
+			onClick: this.recordClickEvent( 'Gravatar Update Profile Photo in Sidebar' )
+		};
+
+		// Legacy support
+		if ( ! config.isEnabled( 'me/gravatar' ) ) {
+			updateProps = Object.assign( updateProps, {
+				href: 'https://secure.gravatar.com/site/wpcom?wpcc-no-close',
+				target: '_blank'
+			} );
+		}
 
 		return (
 			<div className="profile-gravatar">
-				<a
-					href="https://secure.gravatar.com/site/wpcom?wpcc-no-close"
-					target="_blank"
-					className="profile-gravatar__edit"
-					onClick={ this.recordClickEvent( 'Gravatar Update Profile Photo in Sidebar' ) } >
+				<a { ... updateProps } >
 
 					<Gravatar user={ this.props.user } size={ 150 } imgSize={ 400 } />
 

--- a/config/development.json
+++ b/config/development.json
@@ -88,6 +88,7 @@
 		"me/account": true,
 		"me/billing-history": true,
 		"me/find-friends": false,
+		"me/gravatar": true,
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,


### PR DESCRIPTION
This PR is an attempt at fixing #7238.

Previously, the issue we had was that the API didn't allow updating a Gravatar. But, this has now been fixed, and users are now [allowed to update Gravatars in the WordPress Android app](https://github.com/wordpress-mobile/WordPress-Android/blob/24c81ba9e84e9b12ecec9de14534a1621e6eca66/WordPress/src/main/java/org/wordpress/android/networking/GravatarApi.java).

Some hurdles that I anticipate:

- Where/when do we crop the image?
- How do I get the bearer token to send to the Gravatar API?
    - Since we used cookie based auth, and an iFrame proxy, I anticipate that this will be interesting. 😄 

Test live: https://calypso.live/?branch=try/me-update-gravatar