### PR TITLE
Devdocs: redirect devdocs/app-components to devdocs/blocks

### DIFF
--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -15,7 +15,9 @@ export default function() {
 		page( '/devdocs/form-state-examples/:component?', controller.sidebar, controller.formStateExamples );
 		page( '/devdocs/design/typography', controller.sidebar, controller.typography );
 		page( '/devdocs/design/:component?', controller.sidebar, controller.design );
-		page( '/devdocs/blocks/:component?', controller.sidebar, controller.blocks );
+		page( '/devdocs/app-components/:component?',
+			( context ) => page.redirect( '/devdocs/blocks/' + ( context.params.component || '' ) ) );
+		page( '/devdocs/app-components', '/devdocs/blocks' );
 		page( '/devdocs/blocks/:component?', controller.sidebar, controller.blocks );
 		page( '/devdocs/start', controller.pleaseLogIn );
 		page( '/devdocs/welcome', controller.sidebar, controller.welcome );


### PR DESCRIPTION
Accidentally removed in #7031.

Instead of just making devdocs/app-components URLS work, though, here
we do an actual redirect. This way users will see the new URL.

Test live: https://calypso.live/?branch=fix/redirect-app-components-to-blocks