### PR TITLE
Domains: Bypass Domain Search on VIP sites and go straight to mapping

### DIFF
--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 var page = require( 'page' ),
+	qs = require( 'qs' ),
 	i18n = require( 'i18n-calypso' ),
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react' );
@@ -241,6 +242,20 @@ module.exports = {
 
 			if ( ! selectedSite || ! selectedSite.isUpgradeable() ) {
 				return page.redirect( redirectTo );
+			}
+
+			next();
+		};
+	},
+
+	redirectToAddMappingIfVipSite: function() {
+		return function( context, next ) {
+			const selectedSite = sites.getSelectedSite(),
+				domain = context.params.domain ? `/${ context.params.domain }` : '',
+				query = qs.stringify( { initialQuery: context.params.suggestion } );
+
+			if ( selectedSite && selectedSite.is_vip ) {
+				return page.redirect( `/domains/add/mapping${ domain }?${ query }` );
 			}
 
 			next();

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -142,6 +142,7 @@ module.exports = function() {
 			'/domains/add',
 			controller.siteSelection,
 			upgradesController.domainsAddHeader,
+			upgradesController.redirectToAddMappingIfVipSite(),
 			controller.jetPackWarning,
 			controller.sites
 		);
@@ -166,6 +167,7 @@ module.exports = function() {
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
+			upgradesController.redirectToAddMappingIfVipSite(),
 			controller.jetPackWarning,
 			upgradesController.domainSearch
 		);
@@ -174,6 +176,7 @@ module.exports = function() {
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
+			upgradesController.redirectToAddMappingIfVipSite(),
 			controller.jetPackWarning,
 			upgradesController.domainSearch
 		);

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -64,11 +64,18 @@ var MapDomain = React.createClass( {
 	},
 
 	goBack: function() {
-		if ( ! this.props.sites ) {
-			return page( this.props.path.replace( '/mapping', '' ) );
+		const selectedSite = this.props.sites && this.props.sites.getSelectedSite();
+		if ( ! selectedSite ) {
+			page( this.props.path.replace( '/mapping', '' ) );
+			return;
 		}
 
-		page( '/domains/add/' + this.props.sites.getSelectedSite().slug );
+		if ( selectedSite.is_vip ) {
+			page( paths.domainManagementList( selectedSite.slug ) );
+			return;
+		}
+
+		page( '/domains/add/' + selectedSite.slug );
 	},
 
 	handleRegisterDomain( suggestion ) {


### PR DESCRIPTION
VIP users are not interested in domain search/registration - they want to use all those sweet unlimited domain mappings. In fact, Domain Search might be confusing for them, especially when they want to use it only to map domains. Context: `poqVs-dGC-p2`.

I've opted to add a redirect on the controller level so that we don't have to hunt all the possible routes/links to Domain Search and modify lots of code. So, for VIP sites, trying to access Domain Search should automatically redirect you to adding Domain Mapping. Normal sites should not be affected.

### Testing
#### Normal, non-VIP site
* [x] Check that you can add and/or map a domain as usual

#### VIP site
* [x] Check that all the links that would normally lead to Domain Search (`/domains/add`) are redirected to Domain Mapping (`/domains/add/mapping`).
* [x] Verify that domain suggestions (`/domains/add/suggestion/:suggestion/:domain`) are properly redirected too (`/domains/add/mapping/:domain?initialQuery=:suggestion`).
* [x] Verify there are no infinite redirect loops.

/cc @aidvu @umurkontaci 
/cc @philipjohn 

Test live: https://calypso.live/?branch=fix/vip-skip-domain-search