### PR TITLE
Lower the z-index for first views.

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -91,6 +91,7 @@ $z-layers: (
 		'.select-dropdown.is-open .select-dropdown__container': 170,
 		'.accessible-focus .select-dropdown.is-open .select-dropdown__container': 170,
 		'.sites-dropdown.is-open .sites-dropdown__wrapper' : 170,
+		'.first-view': 175,
 		'.popover.editor-visibility__popover': 179,
 		'.feature-example__gradient': 179,
 		'.global-notices': 179,
@@ -128,7 +129,6 @@ $z-layers: (
 		'popover.is-dialog-visible': 100300,
 		'body .webui-popover': 100300,
 		'.fullscreen-fader': 200000,
-		'.first-view': 2000010,
 		'.guided-tours__overlay': 200050,
 		'.guided-tours__step': 201000,
 		'#habla_window_div.habla_window_div_base': 99999999 //olark


### PR DESCRIPTION
This PR seeks to fix a first-view related visual issue when the notification pane is open.

The first-view layer is supposed to cover the page content, but elements like the notification pane or the environment badge should be above the first view layer.

Before:

<img width="1110" alt="screen shot 2016-08-08 at 5 07 41 pm" src="https://cloud.githubusercontent.com/assets/1017839/17484550/c0978c46-5d8a-11e6-8d26-d6688f2bfc06.png">

After:

<img width="1436" alt="screen shot 2016-08-08 at 4 18 38 pm" src="https://cloud.githubusercontent.com/assets/1017839/17484577/e202415a-5d8a-11e6-9f3e-c562cdb06122.png">

### Testing instructions

1. Check out this branch locally, and visit http://calypso.localhost:3000/stats
2. Verify that the Stats first view is visible. If it's not, you probably dismissed it before; visit http://calypso.localhost/stats/reset-first-view to reset it.
3. Open the notification pane by clicking the bell icon in the top-right corner, and verify that the notification pane is on top just like in the "After" screenshot above.
4. Test in various browsers for visual regressions.

Test live: https://calypso.live/?branch=fix/first-view-above-notif-pane