### PR TITLE
Editor: Use computed site title in notice link

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -76,7 +76,7 @@ export class EditorNotice extends Component {
 				if ( 'page' === type ) {
 					return translate( 'Page published on {{siteLink/}}!', {
 						components: {
-							siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+							siteLink: <a href={ site.URL } target="_blank">{ site.title }</a>
 						},
 						comment: 'Editor: Message displayed when a page is published, with a link to the site it was published on.'
 					} );
@@ -84,7 +84,7 @@ export class EditorNotice extends Component {
 
 				return translate( 'Post published on {{siteLink/}}!', {
 					components: {
-						siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+						siteLink: <a href={ site.URL } target="_blank">{ site.title }</a>
 					},
 					comment: 'Editor: Message displayed when a post is published, with a link to the site it was published on.'
 				} );
@@ -101,7 +101,7 @@ export class EditorNotice extends Component {
 				if ( 'page' === type ) {
 					return translate( 'Page privately published on {{siteLink/}}!', {
 						components: {
-							siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+							siteLink: <a href={ site.URL } target="_blank">{ site.title }</a>
 						},
 						comment: 'Editor: Message displayed when a page is published privately,' +
 							' with a link to the site it was published on.'
@@ -110,7 +110,7 @@ export class EditorNotice extends Component {
 
 				return translate( 'Post privately published on {{siteLink/}}!', {
 					components: {
-						siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+						siteLink: <a href={ site.URL } target="_blank">{ site.title }</a>
 					},
 					comment: 'Editor: Message displayed when a post is published privately,' +
 						' with a link to the site it was published on.'
@@ -137,7 +137,7 @@ export class EditorNotice extends Component {
 				if ( 'page' === type ) {
 					return translate( 'Page updated on {{siteLink/}}!', {
 						components: {
-							siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+							siteLink: <a href={ site.URL } target="_blank">{ site.title }</a>
 						},
 						comment: 'Editor: Message displayed when a page is updated, with a link to the site it was updated on.'
 					} );
@@ -145,7 +145,7 @@ export class EditorNotice extends Component {
 
 				return translate( 'Post updated on {{siteLink/}}!', {
 					components: {
-						siteLink: <a href={ site.URL } target="_blank">{ site.name }</a>
+						siteLink: <a href={ site.URL } target="_blank">{ site.title }</a>
 					},
 					comment: 'Editor: Message displayed when a post is updated, with a link to the site it was updated on.'
 				} );

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -61,7 +61,7 @@ describe( 'EditorNotice', () => {
 				action="view"
 				site={ {
 					URL: 'https://example.wordpress.com',
-					name: 'Example Site'
+					title: 'Example Site'
 				} } />
 		);
 
@@ -94,7 +94,7 @@ describe( 'EditorNotice', () => {
 				action="view"
 				site={ {
 					URL: 'https://example.wordpress.com',
-					name: 'Example Site'
+					title: 'Example Site'
 				} } />
 		);
 

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -60,6 +60,7 @@ export const getSite = createSelector(
 			...site,
 			...getComputedAttributes( site ),
 			hasConflict: isSiteConflicting( state, siteId ),
+			title: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
 			domain: getSiteDomain( state, siteId ),
 			is_previewable: isSitePreviewable( state, siteId )
@@ -212,6 +213,28 @@ export function getSiteDomain( state, siteId ) {
 	}
 
 	return site.URL.replace( /^https?:\/\//, '' );
+}
+
+/**
+ * Returns a title by which the site can be canonically referenced. Uses the
+ * site's name if available, falling back to its domain. Returns null if the
+ * site is not known.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?String}        Site title
+ */
+export function getSiteTitle( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	if ( site.name ) {
+		return site.name.trim();
+	}
+
+	return getSiteDomain( state, siteId );
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -18,6 +18,7 @@ import {
 	isJetpackMinimumVersion,
 	getSiteSlug,
 	getSiteDomain,
+	getSiteTitle,
 	isSitePreviewable,
 	isRequestingSites,
 	isRequestingSite,
@@ -503,6 +504,50 @@ describe( 'selectors', () => {
 			}, 77203199 );
 
 			expect( domain ).to.equal( 'testtwosites2014.wordpress.com' );
+		} );
+	} );
+
+	describe( 'getSiteTitle()', () => {
+		it( 'should return null if the site is not known', () => {
+			const title = getSiteTitle( {
+				sites: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( title ).to.be.null;
+		} );
+
+		it( 'should return the trimmed name of the site', () => {
+			const title = getSiteTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							name: '  Example Site  ',
+							URL: 'https://example.com'
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( title ).to.equal( 'Example Site' );
+		} );
+
+		it( 'should fall back to the domain if the site name is empty', () => {
+			const title = getSiteTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							name: '',
+							URL: 'https://example.com'
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( title ).to.equal( 'example.com' );
 		} );
 	} );
 


### PR DESCRIPTION
Observed at https://github.com/Automattic/wp-calypso/pull/7149#issuecomment-236988101
Regression introduced in #6794

This pull request seeks to resolve an issue where sites with an empty title will display an awkward notice upon publishing, scheduling, or updating a post in the editor.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/17483951/fafe1fb0-5d55-11e6-95cc-60716f09e882.png)|![After](https://cloud.githubusercontent.com/assets/1779930/17484025/3665b676-5d56-11e6-9b1b-d93c53490484.png)

__Implementation notes:__

Note that prior to #6794, the notice had been using the `title` property on the site object, but since these computed attributes weren't available until #6477, it was replaced with the `name` property.

__Testing instructions:__

Verify that when publishing, scheduling, or updating a post...
- If the current site has a title, the title is shown in the notice
- If the current site has an empty title, the domain is shown in the notice

Ensure Mocha tests pass:

```
npm run test-client
```

/cc @timmyc  @jeremeylduvall (we'll want to update #7149 after this lands)

Test live: https://calypso.live/?branch=fix/editor-notice-site-title