### PR TITLE
Sites: Remove unused site starring logic

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -42,8 +42,7 @@ export default React.createClass( {
 			isSelected: false,
 
 			homeLink: false,
-			enableActions: false,
-			disableStarring: true
+			enableActions: false
 		};
 	},
 
@@ -57,14 +56,12 @@ export default React.createClass( {
 		isSelected: React.PropTypes.bool,
 		site: React.PropTypes.object.isRequired,
 		onClick: React.PropTypes.func,
-		enableActions: React.PropTypes.bool,
-		disableStarring: React.PropTypes.bool
+		enableActions: React.PropTypes.bool
 	},
 
 	getInitialState() {
 		return {
 			showActions: false,
-			starTooltip: false,
 			cogTooltip: false
 		};
 	},
@@ -78,57 +75,12 @@ export default React.createClass( {
 		event.preventDefault(); // this doesn't actually do anything...
 	},
 
-	starSite() {
-		const site = this.props.site;
-		sites.toggleStarred( site.ID );
-	},
-
-	enableStarTooltip() {
-		this.setState( { starTooltip: true } );
-	},
-
-	disableStarTooltip() {
-		this.setState( { starTooltip: false } );
-	},
-
 	enableCogTooltip() {
 		this.setState( { cogTooltip: true } );
 	},
 
 	disableCogTooltip() {
 		this.setState( { cogTooltip: false } );
-	},
-
-	renderStar() {
-		const site = this.props.site;
-
-		if ( ! site || this.props.disableStarring ) {
-			return null;
-		}
-
-		const isStarred = sites.isStarred( site );
-
-		return (
-			<button
-				className="site__star"
-				onClick={ this.starSite }
-				onMouseEnter={ this.enableStarTooltip }
-				onMouseLeave={ this.disableStarTooltip }
-				ref="starButton"
-			>
-				{ isStarred
-					? <Gridicon icon="star" />
-					: <Gridicon icon="star-outline" />
-				}
-				<Tooltip
-					context={ this.refs && this.refs.starButton }
-					isVisible={ this.state.starTooltip && ! isStarred }
-					position="bottom"
-				>
-					{ this.translate( 'Star this site' ) }
-				</Tooltip>
-			</button>
-		);
 	},
 
 	renderCog() {
@@ -282,16 +234,10 @@ export default React.createClass( {
 									<Gridicon icon="house" size={ 18 } />
 								</span>
 							}
-							{ ! this.props.disableStarring && sites.isStarred( this.props.site ) &&
-								<span className="site__badge">
-									<Gridicon icon="star" size={ 18 } />
-								</span>
-							}
 						</a>
 					: <div className="site__content">
 							{ this.renderEditIcon() }
 							<div className="site__actions">
-								{ this.renderStar() }
 								{ this.renderCog() }
 							</div>
 						</div>

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -228,9 +228,7 @@ export default React.createClass( {
 			return null;
 		}
 
-		const recentSites = sites.filter( function( site ) {
-			return ! this.props.sites.isStarred( site );
-		}, this ).map( function( site ) {
+		const recentSites = sites.map( function( site ) {
 			var siteHref;
 
 			if ( this.props.siteBasePath ) {
@@ -258,39 +256,6 @@ export default React.createClass( {
 		return <div className="site-selector__recent">{ recentSites }</div>;
 	},
 
-	renderStarredSites() {
-		const sites = this.props.sites.getStarred();
-
-		if ( ! sites || this.state.search || ! this.shouldShowGroups() || ! this.props.sites.starred.length ) {
-			return null;
-		}
-
-		const starredSites = sites.map( function( site ) {
-			var siteHref;
-
-			if ( this.props.siteBasePath ) {
-				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
-			}
-
-			return (
-				<Site
-					site={ site }
-					href={ siteHref }
-					key={ 'site-' + site.ID }
-					indicator={ this.props.indicator }
-					onSelect={ this.onSiteSelect.bind( this, site.slug ) }
-					isSelected={ this.isSelected( site ) }
-				/>
-			);
-		}, this );
-
-		return (
-			<div className="site-selector__starred">
-				{ starredSites }
-			</div>
-		);
-	},
-
 	render() {
 		const selectorClass = classNames( 'site-selector', 'sites-list', {
 			'is-large': user.get().site_count > 6,
@@ -309,7 +274,6 @@ export default React.createClass( {
 					/>
 					<div className="site-selector__sites" ref="selector">
 						{ this.renderAllSites() }
-						{ this.renderStarredSites() }
 						{ this.renderSites() }
 					</div>
 					{ this.props.showAddNewSite && this.addNewSite() }

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -38,7 +38,6 @@ function SitesList() {
 	this.selected = null;
 	this.lastSelected = null;
 	this.propagateChange = this.propagateChange.bind( this );
-	this.starred = PreferencesStore.get( 'starredSites' ) || [];
 	this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
 }
 
@@ -386,39 +385,6 @@ SitesList.prototype.isSelected = function( site ) {
 };
 
 /**
- * Is the site starred?
- *
- * @api public
- */
-SitesList.prototype.isStarred = function( site ) {
-	return this.starred.indexOf( site.ID ) > -1;
-};
-
-SitesList.prototype.toggleStarred = function( siteID ) {
-	if ( ! siteID ) {
-		return;
-	}
-
-	// do not add duplicates
-	if ( this.starred.indexOf( siteID ) === -1 ) {
-		this.starred.unshift( siteID );
-	} else {
-		this.starred.splice( this.starred.indexOf( siteID ), 1 );
-	}
-
-	PreferencesActions.set( 'starredSites', this.starred );
-
-	this.emit( 'change' );
-};
-
-SitesList.prototype.getStarred = function() {
-	// Disable stars
-	return false;
-	this.starred = PreferencesStore.get( 'starredSites' ) || [];
-	return this.get().filter( this.isStarred, this );
-};
-
-/**
  * Set recently selected site
  *
  * @param {number} Site ID
@@ -436,16 +402,11 @@ SitesList.prototype.setRecentlySelectedSite = function( siteID ) {
 	const index = this.recentlySelected.indexOf( siteID );
 
 	// do not add duplicates
-	if ( index === -1 ) {
-		if ( ! this.isStarred( this.getSite( siteID ) ) ) {
-			this.recentlySelected.unshift( siteID );
-		}
-	} else {
+	if ( index !== -1 ) {
 		this.recentlySelected.splice( index, 1 );
-		if ( ! this.isStarred( this.getSite( siteID ) ) ) {
-			this.recentlySelected.unshift( siteID );
-		}
 	}
+
+	this.recentlySelected.unshift( siteID );
 
 	const sites = this.recentlySelected.slice( 0, 3 );
 	PreferencesActions.set( 'recentSites', sites );
@@ -573,21 +534,6 @@ SitesList.prototype.getVisibleAndNotRecent = function() {
 		}
 
 		return site.visible === true && this.recentlySelected && this.recentlySelected.indexOf( site.ID ) === -1;
-	}, this );
-};
-
-/**
- * Get sites that are marked as visible and not recently selected
- *
- * @api public
- **/
-SitesList.prototype.getVisibleAndNotRecentNorStarred = function() {
-	return this.get().filter( function( site ) {
-		if ( user.get().visible_site_count < 12 ) {
-			return site.visible === true && ! this.isStarred( site );
-		}
-
-		return site.visible === true && this.recentlySelected && this.recentlySelected.indexOf( site.ID ) === -1 && ! this.isStarred( site );
 	}, this );
 };
 


### PR DESCRIPTION
This pull request is the first step in moving the `<SiteSelector />` component toward using Redux-based preferences state and query component, and in working to resolve a warning which occurs from `<PreferencesData />` passing `preferences`, a prop unknown to the rendered `div` tag*. It seeks to remove the site starring behavior which was introduced in #2871 before being later disabled in #3558.

__*__ Unlike previously remarked, the rendering of `<PreferencesData />` is required in that it at least triggers the fetch of user preferences settings from the API, despite its `preferences` prop passing not being used directly.

__Testing instructions:__

Verify that there are no regressions in using the site selector (New Post, Switch Sites), specifically with regards to recent sites. Also verify that no errors or regressions occur in the site ellipsis menu edit toggle, where render behavior of site starring had previously existed.

/cc @mtias 

Test live: https://calypso.live/?branch=update/sites-list-preferences