### PR TITLE
Jetpack Connect: Persist current Calypso environment throughout the JPC flow

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -48,9 +48,8 @@ import LoggedOutFormFooter from 'components/logged-out-form/footer';
 /**
  * Constants
  */
-const calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
 const PLANS_PAGE = '/jetpack/connect/plans/';
-const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
+const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
 const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
 
 const SiteCard = React.createClass( {

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -62,11 +62,7 @@ const JetpackSSOForm = React.createClass( {
 		if ( nextProps.ssoUrl && ! this.props.ssoUrl ) {
 			// After receiving the SSO URL, which will log the user in on remote site,
 			// we redirect user to remote site to be logged in.
-			//
-			// Note: We add `calypso_env` so that when we are redirected back to Calypso,
-			// we land in the same development environment.
-			const configEnv = config( 'env_id' ) || process.env.NODE_ENV;
-			const redirect = addQueryArgs( { calypso_env: configEnv }, nextProps.ssoUrl );
+			const redirect = nextProps.ssoUrl;
 			debug( 'Redirecting to: ' + redirect );
 			window.location.href = redirect;
 		}

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -62,7 +62,11 @@ const JetpackSSOForm = React.createClass( {
 		if ( nextProps.ssoUrl && ! this.props.ssoUrl ) {
 			// After receiving the SSO URL, which will log the user in on remote site,
 			// we redirect user to remote site to be logged in.
-			const redirect = nextProps.ssoUrl;
+			//
+			// Note: We add `calypso_env` so that when we are redirected back to Calypso,
+			// we land in the same development environment.
+			const configEnv = config( 'env_id' ) || process.env.NODE_ENV;
+			const redirect = addQueryArgs( { calypso_env: configEnv }, nextProps.ssoUrl );
 			debug( 'Redirecting to: ' + redirect );
 			window.location.href = redirect;
 		}

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -41,7 +41,7 @@ import addQueryArgs from 'lib/route/add-query-args';
 const _fetching = {};
 const calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
 const apiBaseUrl = 'https://jetpack.wordpress.com';
-const remoteAuthPath = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
+const remoteAuthPath = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
 const remoteInstallPath = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 const remoteActivatePath = '/wp-admin/plugins.php';
 const userModule = userFactory();
@@ -175,7 +175,10 @@ export default {
 				url: url,
 				type: 'remote_auth'
 			} );
-			window.location = addQueryArgs( { jetpack_connect_url: url + remoteAuthPath }, apiBaseUrl );
+			window.location = addQueryArgs( {
+				jetpack_connect_url: url + remoteAuthPath,
+				calypso_env: calypsoEnv
+			}, apiBaseUrl );
 		};
 	},
 	goToPluginInstall( url ) {
@@ -188,7 +191,10 @@ export default {
 				url: url,
 				type: 'plugin_install'
 			} );
-			window.location = addQueryArgs( { jetpack_connect_url: url + remoteInstallPath }, apiBaseUrl );
+			window.location = addQueryArgs( {
+				jetpack_connect_url: url + remoteInstallPath,
+				calypso_env: calypsoEnv
+			}, apiBaseUrl );
 		};
 	},
 	goToPluginActivation( url ) {
@@ -201,7 +207,10 @@ export default {
 				url: url,
 				type: 'plugin_activation'
 			} );
-			window.location = addQueryArgs( { jetpack_connect_url: url + remoteActivatePath }, apiBaseUrl );
+			window.location = addQueryArgs( {
+				jetpack_connect_url: url + remoteActivatePath,
+				calypso_env: calypsoEnv
+			}, apiBaseUrl );
 		};
 	},
 	goBackToWpAdmin( url ) {


### PR DESCRIPTION
## Background
Currently, when going through the Jetpack Connect flow and Jetpack is either not installed or not activated, the user will be redirected to the production Calypso environment. This does not make sense in cases where the user originates from another environment (e.g. `development`, `staging`, etc.). The reason for this behavior is that the GET parameter for the current environment is being lost when navigating within the `wp-admin` to install and/or activate Jetpack.

## Solution
This PR addresses this issue by storing the current Calypso environment in a cookie instead of a GET parameter. The cookie will persist after Jetpack installation and/or activation and will redirect the user to the right environment. This PR fixes #6856 (works together with #D2457-code).

## Testing instructions
* Check out the `fix/jetpack-connect-proper-calypso-env` branch in Calypso.
* Open http://calypso.localhost:3000/jetpack/connect/ and connect an unconnected site without Jetpack installed.
* Proceed with installation and/or activation. 
* Click on the **Connect to WordPress.com** button.
* Verify that you've returned to the Plans page on the development environment (`calypso.localhost`) and not the production one.
* Repeat the above steps for unconnected site and deactivated Jetpack.
* Repeat the above steps for unconnected site and activated Jetpack.
* Test this with the SSO flow.

CC @johnHackworth for the JPC flow and @ebinnion for the SSO flow.


Test live: https://calypso.live/?branch=fix/jetpack-connect-proper-calypso-env