### PR TITLE
Plans FAQ: fix Manage Purchases link

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -253,8 +253,7 @@ class PlansFeaturesMain extends Component {
 						'Yes. We want you to love everything you do at WordPress.com, so we provide a 30-day' +
 						' refund on all of our plans. {{a}}Manage purchases{{/a}}.',
 						{
-							// TODO: needs correct url
-							components: { a: <a href={ '#' } /> }
+							components: { a: <a href={ '/purchases' } /> }
 						}
 					) }
 				/>


### PR DESCRIPTION
Fixes #7308. Added proper URL to the "Manage Purchases" link on `/plans` page in FAQ section.

## Testing Instructions

1. Navigate to http://calypso.localhost:3000/plans;
2. Scroll down to FAQ section;
3. Verify that "Manage Purchases" link goes to http://calypso.localhost:3000/purchases

cc @shaunandrews

Test live: https://calypso.live/?branch=fix/plans-faq-links