### PR TITLE
Plans: update example domain in plans popup

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -297,7 +297,7 @@ export const featuresList = {
 		getSlug: () => FEATURE_CUSTOM_DOMAIN,
 		getTitle: () => i18n.translate( 'Custom Domain Name' ),
 		getDescription: () => i18n.translate(
-			'Get a free custom domain name (mywebsite.com) with this plan ' +
+			'Get a free custom domain name (example.com) with this plan ' +
 			'to use for your website.'
 		),
 		plans: allPaidPlans


### PR DESCRIPTION
Fixes #7296. Use `example.com` instead of `mywebsite.com` as an example domain for Custom Domain plans feature.

## Testing Instructions

1. Navigate to http://calypso.localhost:3000/plans and verify that Custom Doman feature popup contains "example.com";
2. Navigate to http://calypso.localhost:3000/start and when you get to the `/plans` step, verify the same as in the first point.

## Screenshot

![selection_114](https://cloud.githubusercontent.com/assets/4988512/17492399/ed19e78e-5dab-11e6-9bc6-04a3484af6bb.png)

cc @rralian 


Test live: https://calypso.live/?branch=fix/plans-custom-domain-popup-wording