### PR TITLE
Jetpack Autoconfig: Add a `whitelist` param to restrict autoconfig to just one plugin

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -156,7 +156,9 @@ function renderProvisionPlugins( context ) {
 	analytics.pageView.record( context.pathname.replace( site.domain, ':site' ), 'Jetpack Plugins Setup' );
 
 	renderWithReduxStore(
-		React.createElement( PlanSetup, {} ),
+		React.createElement( PlanSetup, {
+			whitelist: context.query.only || false
+		} ),
 		document.getElementById( 'primary' ),
 		context.store
 	);

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -487,16 +487,25 @@ const PlansSetup = React.createClass( {
 } );
 
 export default connect(
-	state => {
+	( state, ownProps ) => {
 		const siteId = getSelectedSiteId( state );
 		const site = sites.getSelectedSite();
+
+		// Filter out only the plugins whitelisted (if we're whitelisting)
+		const plugins = filter( getPluginsForSite( state, siteId ), ( plugin ) => {
+			if ( !! ownProps.whitelist ) {
+				return ( ownProps.whitelist === plugin.slug );
+			}
+			return true;
+		} );
+
 		return {
 			wporg: state.plugins.wporg.items,
 			isRequesting: isRequesting( state, siteId ),
 			hasRequested: hasRequested( state, siteId ),
 			isInstalling: isInstalling( state, siteId ),
 			isFinished: isFinished( state, siteId ),
-			plugins: getPluginsForSite( state, siteId ),
+			plugins,
 			activePlugin: getActivePlugin( state, siteId ),
 			nextPlugin: getNextPlugin( state, siteId ),
 			selectedSite: site && site.jetpack ? JetpackSite( site ) : site,

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -397,7 +397,11 @@ const PlansSetup = React.createClass( {
 
 		this.trackConfigFinished( 'calypso_plans_autoconfig_success' );
 
-		const noticeText = this.translate( 'We\'ve installed your plugins, your site is powered up!' );
+		const noticeText = this.translate(
+			'We\'ve set up your plugin, your site is powered up!',
+			'We\'ve set up your plugins, your site is powered up!',
+			{ count: this.props.plugins.length }
+		);
 		return (
 			<Notice status="is-success" text={ noticeText } showDismiss={ false }>
 				<NoticeAction href={ `/plans/my-plan/${site.slug}` }>


### PR DESCRIPTION
Fixes #7309

This will let us filter out only 1 plugin to install and configure, so we can give users direct links to install only the plugin they need. The new URL would be `/plugins/setup/:site?only={plugin}`.

To test

1. Install only VaultPress on your premium or professional site by visiting `/plugins/setup/:site?only=vaultpress`
2. You should see only 1 list item, VaultPress, while the install process runs
3. After finishing, you should only have VaultPress installed and active, and no Akismet

You can also check that it still installs all plugins, by visiting the site without the query string.

cc @johnHackworth @roccotripaldi @dereksmart

Test live: https://calypso.live/?branch=add/jetpack-single-plugin-setup