### PR TITLE
Editor: Allow modal previews for Jetpack sites

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -580,8 +580,7 @@ const PostEditor = React.createClass( {
 	},
 
 	iframePreviewEnabled: function() {
-		var site = this.props.sites.getSelectedSite();
-		return site && ! site.jetpack;
+		return true;
 	},
 
 	iframePreview: function() {


### PR DESCRIPTION
This PR requires that Automattic/jetpack#4692 be merged first.

Currently, the preview modal is disabled for Jetpack sites because we are not able to display drafts when the user is logged out of the remote Jetpack site. 

Automattic/jetpack#4692 begins syncing a frame nonce and provides logic to display a draft when that nonce is passed.

Test live: https://calypso.live/?branch=update/editor-allow-jetpack-preview