### PR TITLE
Update/add distinguishing classes to segmented control items

### DIFF
--- a/client/components/segmented-control/index.jsx
+++ b/client/components/segmented-control/index.jsx
@@ -124,6 +124,7 @@ var SegmentedControl = React.createClass( {
 					selected={ this.state.selected === item.value }
 					onClick={ this.selectItem.bind( this, item ) }
 					path={ item.path }
+					index={ index }
 				>
 					{ item.label }
 				</ControlItem>

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -31,7 +31,7 @@ var SegmentedControlItem = React.createClass( {
 
 		var linkClassName = classNames( {
 			'segmented-control__link': true,
-			[`item-index-${this.props.index}`]: this.props.index != null,
+			[ `item-index-${this.props.index}` ]: this.props.index != null,
 		} );
 
 		return (

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -24,13 +24,12 @@ var SegmentedControlItem = React.createClass( {
 	},
 
 	render: function() {
-		var itemClassName = classNames( {
+		const itemClassName = classNames( {
 			'segmented-control__item': true,
 			'is-selected': this.props.selected
 		} );
 
-		var linkClassName = classNames( {
-			'segmented-control__link': true,
+		const linkClassName = classNames( 'segmented-control__link', {
 			[ `item-index-${this.props.index}` ]: this.props.index != null,
 		} );
 

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -29,11 +29,16 @@ var SegmentedControlItem = React.createClass( {
 			'is-selected': this.props.selected
 		} );
 
+		var linkClassName = classNames( {
+			'segmented-control__link': true,
+			[`item-index-${this.props.index}`]: this.props.index != null,
+		} );
+
 		return (
 			<li className={ itemClassName }>
 				<a
 					href={ this.props.path }
-					className="segmented-control__link"
+					className={ linkClassName }
 					ref="itemLink"
 					onTouchTap={ this.props.onClick }
 					title={ this.props.title }


### PR DESCRIPTION
Currently when `Segmented Control` component creates its items they have no distinctive classes that would help to identify them in for example testing. This change addresses this issues by adding `item-index-${ number } class to each `<a>`. 

This was done for https://github.com/Automattic/wp-e2e-tests/pull/185

This PR was originally a part of https://github.com/Automattic/wp-calypso/pull/7214 but was created to separate concerns. 

Test live: https://calypso.live/?branch=update/add-distinghuishing-classes-to-segmented-control-items