### PR TITLE
Fixes a glitch on the chat bubble when minimizing the Olark chatbox

### DIFF
--- a/assets/stylesheets/shared/_livechat.scss
+++ b/assets/stylesheets/shared/_livechat.scss
@@ -645,7 +645,11 @@
 }
 
 #habla_window_div #habla_sizebutton_a:hover {
-	background-color: rgba(255, 255, 255, 0.15);
+	background-color: transparent !important;
+}
+
+.olrk-state-compressed #habla_window_div #habla_sizebutton_a:hover {
+	background-color: lighten($blue-wordpress, 20%) !important;
 }
 
 #habla_window_div #habla_closebutton_a {
@@ -920,7 +924,7 @@
 }
 
 .olrk-state-compressed .olrk-fixed-bottom #habla_topbar_div {
-	-webkit-animation-name:tab_in_bottom;
+	-webkit-animation-name: none !important;
 	-webkit-animation-duration:1s;
 	-webkit-animation-iteration-count:1;
 	-webkit-animation-direction:alternate;
@@ -1031,8 +1035,8 @@ div.hbl_pal_main_width {
 	margin-right: -10px;
 	background: transparent;
 	padding: 0;
-	width: 26px;
-	height: 26px;
+	width: 32px;
+	height: 32px;
 }
 
 .olrk-state-compressed #habla_panel_div {
@@ -1041,7 +1045,8 @@ div.hbl_pal_main_width {
 
 .olrk-state-compressed #habla_window_div #habla_sizebutton_a {
 	background-color: $blue-medium;
-	padding: 5px 5px 5px 5px;
+	transition: background-color .2s;
+	padding: 8px;
 	text-decoration: none;
 	margin: 0 !important;
 	border-radius: 0 !important;
@@ -1055,5 +1060,5 @@ div.hbl_pal_main_width {
 }
 
 .olrk-state-compressed div.hbl_pal_main_width {
-	width: 28px !important;
+	width: 32px !important;
 }


### PR DESCRIPTION
The latest Olark update broke some styles for the chatbox in Calypso. This PR is a continuation of #7040, addressing a weird glitch that happened when minimizing the chatbox.

I've also made the minimized button a little bit bigger so it's easier to see and click.

### How to test

1. Run Calypso.
2. Click "Help" in the bottom left corner. (You may need to scroll to see it.)
3. Scroll down and click "Contact us".
4. Fill out all fields to start a chat. (You will need to have upgrades to chat.)
5. Chat with a Happiness Engineer. Jump to another section in Calypso so the conversation follows you as a sticky chatbox instead of a full window.
6. Minimize the chatbox with the arrow pointing downwards and make sure that the button doesn't jump awkwardly and looks good.

**Before:**

![quickcast-03-08-2016-06-13-34](https://cloud.githubusercontent.com/assets/820374/17374479/24c87036-59ad-11e6-8332-67739f5ef210.gif)

**After:**

![quickcast-03-08-2016-06-57-36](https://cloud.githubusercontent.com/assets/820374/17374501/36cd9f2c-59ad-11e6-9be6-dfccd8fadf77.gif)


Test live: https://calypso.live/?branch=fix/olark-minimized-css-modifications