### PR TITLE
Update/add fade to long text in search component

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -59,7 +59,8 @@ const Search = React.createClass( {
 		searching: PropTypes.bool,
 		isOpen: PropTypes.bool,
 		dir: PropTypes.string,
-		fitsContainer: PropTypes.bool
+		fitsContainer: PropTypes.bool,
+		hideClose: PropTypes.bool
 	},
 
 	getInitialState: function() {
@@ -83,7 +84,8 @@ const Search = React.createClass( {
 			searching: false,
 			isOpen: false,
 			dir: undefined,
-			fitsContainer: false
+			fitsContainer: false,
+			hideClose: false,
 		};
 	},
 
@@ -271,13 +273,21 @@ const Search = React.createClass( {
 			spellCheck: 'false'
 		};
 
-		searchClass = classNames( this.props.additionalClasses, {
+		const searchClass = classNames( this.props.additionalClasses, {
 			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
+			'no-close-button' : this.props.hideClose,
 			rtl: this.props.dir === 'rtl',
 			ltr: this.props.dir === 'ltr',
 			search: true
+		} );
+
+		const inputClass = classNames ( {
+			'search__input': true,
+			'no-close-button': this.props.hideClose,
+			rtl: this.props.dir === 'rtl',
+			ltr: this.props.dir === 'ltr',
 		} );
 
 		return (
@@ -298,7 +308,7 @@ const Search = React.createClass( {
 				<input
 					type="search"
 					id={ 'search-component-' + this.state.instanceId }
-					className={ 'search__input' + ( this.props.dir ? ' ' + this.props.dir : '' ) }
+					className={ inputClass }
 					placeholder={ placeholder }
 					role="search"
 					value={ searchValue }
@@ -313,22 +323,32 @@ const Search = React.createClass( {
 					autoCapitalize="none"
 					dir={ this.props.dir }
 					{ ...autocorrect } />
-				{ ( searchValue || this.state.isOpen ) ? this.closeButton() : null }
+					{ this.closeButton() }
 			</div>
 		);
 	},
 
 	closeButton: function() {
-		return (
-			<span
-				onTouchTap={ this.closeSearch }
-				tabIndex="0"
-				onKeyDown={ this.closeListener }
-				aria-controls={ 'search-component-' + this.state.instanceId }
-				aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
-			<Gridicon icon="cross" className={ 'search-close__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) } />
-			</span>
-		);
+		const gridIconClass = classNames ( {
+			'search-close__icon': true,
+			rtl: this.props.dir === 'rtl',
+			ltr: this.props.dir === 'ltr',
+		} );
+
+		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
+			return (
+				<span
+					onTouchTap={ this.closeSearch }
+					tabIndex="0"
+					onKeyDown={ this.closeListener }
+					aria-controls={ 'search-component-' + this.state.instanceId }
+					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
+					<Gridicon icon="cross" className={ gridIconClass } />
+				</span>
+			);
+		}
+
+		return null;
 	}
 } );
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -257,8 +257,7 @@ const Search = React.createClass( {
 	},
 
 	render: function() {
-		let searchClass,
-			searchValue = this.state.keyword,
+		let searchValue = this.state.keyword,
 			placeholder = this.props.placeholder ||
 				i18n.translate( 'Search…', { textOnly: true } );
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -152,6 +152,16 @@
 	}
 }
 
+.search__input.no-close-button {
+	padding-right: 0px;
+}
+
+.search.is-open.no-close-button {
+	&::before {
+		right: 0px;
+	}
+}
+
 // When search input is opened
 .search.is-open {
 
@@ -188,6 +198,11 @@
 
 	.search__input {
 		display: block;
+	}
+
+	&::before {
+		@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+		right: 50px;
 	}
 }
 


### PR DESCRIPTION
Wwhen input text is longer then the available width of input field the visible part of text is cut and can create the expression that it is all there is. 

![no_fade](https://cloud.githubusercontent.com/assets/17271089/17511885/655d56f8-5e25-11e6-95aa-57369fca0718.png)

Now there is a fade that suggests that the text is longer then the visible part.

![fade](https://cloud.githubusercontent.com/assets/17271089/17513470/7b62d1e6-5e2d-11e6-9448-d54d6c0c6031.png)

To test open `/design` and write in search fields more charters then the width of search field.

Test live: https://calypso.live/?branch=update/add-fade-to-long-text-in-search-component