### PR TITLE
Add state to PostSelector example

### DIFF
--- a/client/my-sites/post-selector/docs/example.jsx
+++ b/client/my-sites/post-selector/docs/example.jsx
@@ -17,8 +17,15 @@ const PostSelectorExample = React.createClass( {
 
 	getInitialState() {
 		return {
-			showTypeLabels: true
+			showTypeLabels: true,
+			selectedPostID: '',
 		};
+	},
+
+	setSelected( post ) {
+		this.setState( {
+			selectedPostID: post.ID,
+		} );
 	},
 
 	render() {
@@ -43,7 +50,9 @@ const PostSelectorExample = React.createClass( {
 							type="any"
 							orderBy="date"
 							order="DESC"
-							showTypeLabels={ this.state.showTypeLabels } />
+							showTypeLabels={ this.state.showTypeLabels }
+							selected={ this.state.selectedPostID }
+							onChange={ this.setSelected } />
 					) }
 				</div>
 			</div>

--- a/client/my-sites/post-selector/docs/example.jsx
+++ b/client/my-sites/post-selector/docs/example.jsx
@@ -18,7 +18,7 @@ const PostSelectorExample = React.createClass( {
 	getInitialState() {
 		return {
 			showTypeLabels: true,
-			selectedPostId: '',
+			selectedPostId: null,
 		};
 	},
 

--- a/client/my-sites/post-selector/docs/example.jsx
+++ b/client/my-sites/post-selector/docs/example.jsx
@@ -18,13 +18,13 @@ const PostSelectorExample = React.createClass( {
 	getInitialState() {
 		return {
 			showTypeLabels: true,
-			selectedPostID: '',
+			selectedPostId: '',
 		};
 	},
 
 	setSelected( post ) {
 		this.setState( {
-			selectedPostID: post.ID,
+			selectedPostId: post.ID,
 		} );
 	},
 
@@ -51,7 +51,7 @@ const PostSelectorExample = React.createClass( {
 							orderBy="date"
 							order="DESC"
 							showTypeLabels={ this.state.showTypeLabels }
-							selected={ this.state.selectedPostID }
+							selected={ this.state.selectedPostId }
 							onChange={ this.setSelected } />
 					) }
 				</div>


### PR DESCRIPTION
In order to demonstrate how the selection works, the container component
needs to manage the `selected` prop, feeding the `post.ID` retrieved from
the `PostSelector` `onChange` event.

Test live: https://calypso.live/?branch=update/docs-post-selector-state