### PR TITLE
Fix this.getInitialState is not a function err in DropZone component

### DIFF
--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -162,10 +162,7 @@ export class DropZone extends Component {
 		// where files dragged directly from the dock are not recognized
 		event.dataTransfer && event.dataTransfer.files.length;
 
-		this.setState( {
-			isDraggingOverDocument: false,
-			isDraggingOverElement: false
-		} );
+		this.resetDragState();
 
 		if ( ! this.props.fullScreen && ! ReactDom.findDOMNode( this.refs.zone ).contains( event.target ) ) {
 			return;

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -63,7 +63,10 @@ export class DropZone extends Component {
 			return;
 		}
 
-		this.setState( this.getInitialState() );
+		this.setState( {
+			isDraggingOverDocument: false,
+			isDraggingOverElement: false
+		} );
 	}
 
 	toggleMutationObserver() {


### PR DESCRIPTION
Fixes #7353. During [refactoring](https://github.com/Automattic/wp-calypso/pull/5383) the DropZone component, `getInitialState` method was removed. However, its call in `resetDragState` method was not removed which causes 2169 errors in 24 hour period (thanks @artpi for your work on JS error logging!).

In this PR, I propose a simple fix in which we reset state in `resetDragState` more verbosely by enumerating specific props and their initial values instead of calling some method. Props @aduth for this solution and help.

I also reuse the `resetDragState` method in `onDrop` event handler as the resetting functionality was unnecessarily duplicated there.

## Testing Instructions

To be honest, I couldn't reproduce the issue the "normal" way. I couldn't get the [mouseup event](https://github.com/Automattic/wp-calypso/blob/master/client/components/drop-zone/index.jsx#L43-L43) triggered by using Calypso (maybe you could, [here are some steps](https://github.com/Automattic/wp-calypso/pull/550#issuecomment-159694352)).

Fortunately, we can create and fire events manually through Dev Console. So, firstly, let's reproduce the bug and then see if it's fixed:

1. Checkout `master` branch and open `client/components/drop-zone/index.jsx` in your favorite editor;
2. Comment/delete [these lines](https://github.com/Automattic/wp-calypso/blob/master/client/components/drop-zone/index.jsx#L62-L64) (they prevent us from seeing the error with the manual event firing);
3. Load Calypso Media Library or just create a new post;
3. Open Dev Tools and copy paste the following code in the Console tab:

```js
var event = document.createEvent("HTMLEvents");

event.initEvent("mouseup", true, true);

window.dispatchEvent(event);
```
4. Notice the `this.getInitialState is not a function` error;
5. Checkout this branch and do the same;
6. Is there still an error?

cc @aduth @ockham @gwwar @timmyc @artpi 

Test live: https://calypso.live/?branch=fix/drop-zone-reset-drag-state