### PR TITLE
Testing: Get rid of double callback warning

### DIFF
--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -41,7 +41,7 @@ describe( 'LoginTest', function() {
 	} );
 
 	it( 'cannot submit until login details entered', function( done ) {
-		var submit = TestUtils.findRenderedDOMComponentWithTag( page, 'button' );
+		const submit = TestUtils.findRenderedDOMComponentWithTag( page, 'button' );
 
 		page.setState( { login: 'test', password: 'test', inProgress: false }, function() {
 			expect( submit.disabled ).to.be.false;
@@ -65,7 +65,7 @@ describe( 'LoginTest', function() {
 	} );
 
 	it( 'submits login form', function( done ) {
-		var submit = TestUtils.findRenderedDOMComponentWithTag( page, 'form' );
+		const submit = TestUtils.findRenderedDOMComponentWithTag( page, 'form' );
 
 		page.setState( { login: 'user', password: 'pass', auth_code: 'otp' }, function() {
 			TestUtils.Simulate.submit( submit );

--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import identity from 'lodash/identity';
+import { identity, noop } from 'lodash';
 import { stub } from 'sinon';
 
 /**
@@ -20,6 +20,7 @@ describe( 'LoginTest', function() {
 		mockery.registerMock( 'lib/oauth-store/actions', {
 			login: loginStub
 		} );
+		mockery.registerMock( 'lib/analytics', { ga: { recordEvent: noop } } );
 	} );
 
 	before( () => {

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import identity from 'lodash/identity';
+import { identity, noop } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -14,11 +14,14 @@ import useMockery from 'test/helpers/use-mockery';
 import EmptyComponent from 'test/helpers/react/empty-component';
 
 describe( 'Domain Suggestion', function() {
-	let DomainSuggestion;
+	let abtestResult, DomainSuggestion;
 
 	useFakeDom();
 	useMockery( ( mockery ) => {
 		mockery.registerMock( 'components/plans/premium-popover', EmptyComponent );
+		mockery.registerMock( 'lib/abtest', {
+			abtest: () => abtestResult
+		} );
 	} );
 
 	before( () => {
@@ -27,16 +30,44 @@ describe( 'Domain Suggestion', function() {
 	} );
 
 	describe( 'has attributes', () => {
-		it( 'should have data-e2e-domain attribute for e2e testing', () => {
-			const domainSuggestion = shallow( <DomainSuggestion
-				domain="example.com" isAdded={ false }/> );
-			if ( domainSuggestion.props()[ 'data-e2e-domain' ] ) {
-				expect( domainSuggestion.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
-			} else {
+		context( 'AB test clickableButton', () => {
+			before( () => {
+				abtestResult = 'clickableButton';
+			} );
+
+			it( 'should have data-e2e-domain attribute for e2e testing', () => {
+				const domainSuggestion = shallow(
+					<DomainSuggestion
+						buttonContent="Click Me"
+						domain="example.com"
+						isAdded={ false }
+						onButtonClick={ noop }
+						priceRule="PRICE" />
+				);
+
 				const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button' );
 				expect( domainSuggestionButton.length ).to.equal( 1 );
 				expect( domainSuggestionButton.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
-			}
+			} );
+		} );
+
+		context( 'AB test clickableRow', () => {
+			before( () => {
+				abtestResult = 'clickableRow';
+			} );
+
+			it( 'should have data-e2e-domain attribute for e2e testing', () => {
+				const domainSuggestion = shallow(
+					<DomainSuggestion
+						buttonContent="Click Me"
+						domain="example.com"
+						isAdded={ false }
+						onButtonClick={ noop }
+						priceRule="PRICE" />
+				);
+
+				expect( domainSuggestion.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
+			} );
 		} );
 	} );
 } );

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -1,11 +1,21 @@
-var assert = require( 'chai' ).assert,
-	sinon = require( 'sinon' ),
-	useMockery = require( 'test/helpers/use-mockery' ),
-	useFakeDom = require( 'test/helpers/use-fake-dom' ),
-	ReactDom, React, TestUtils, SectionNav;
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { noop } from 'lodash';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+import useFakeDom from 'test/helpers/use-fake-dom';
+
+let	ReactDom, React, TestUtils, SectionNav;
 
 function createComponent( component, props, children ) {
-	var shallowRenderer = TestUtils.createRenderer();
+	const shallowRenderer = TestUtils.createRenderer();
+
 	shallowRenderer.render(
 		React.createElement( component, props, children )
 	);
@@ -24,14 +34,15 @@ describe( 'section-nav', function() {
 		const EMPTY_COMPONENT = require( 'test/helpers/react/empty-component' );
 
 		mockery.registerMock( 'components/gridicon', EMPTY_COMPONENT );
+		mockery.registerMock( 'lib/analytics', { ga: { recordEvent: noop } } );
 
 		SectionNav = require( '../' );
 	} );
 
 	describe( 'rendering', function() {
 		before( function() {
-			var selectedText = 'test';
-			var children = ( <p>mmyellow</p> );
+			const selectedText = 'test';
+			const children = ( <p>mmyellow</p> );
 
 			this.sectionNav = createComponent( SectionNav, {
 				selectedText: selectedText
@@ -66,32 +77,40 @@ describe( 'section-nav', function() {
 
 	describe( 'interaction', function() {
 		it( 'should call onMobileNavPanelOpen function passed as a prop when tapped', function( done ) {
-			var elem = React.createElement( SectionNav, {
+			const elem = React.createElement( SectionNav, {
 				selectedText: 'placeholder',
 				onMobileNavPanelOpen: function() {
 					done();
 				}
 			}, ( <p>placeholder</p> ) );
-			var tree = TestUtils.renderIntoDocument( elem );
+			const tree = TestUtils.renderIntoDocument( elem );
 			assert( ! tree.state.mobileOpen );
-			TestUtils.Simulate.touchTap( ReactDom.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
+			TestUtils.Simulate.touchTap( ReactDom.findDOMNode(
+				TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
+			) );
 			assert( tree.state.mobileOpen );
 		} );
 
 		it( 'should call onMobileNavPanelOpen function passed as a prop twice when tapped three times', function( done ) {
-			var spy = sinon.spy();
-			var elem = React.createElement( SectionNav, {
+			const spy = sinon.spy();
+			const elem = React.createElement( SectionNav, {
 				selectedText: 'placeholder',
 				onMobileNavPanelOpen: spy
 			}, ( <p>placeholder</p> ) );
-			var tree = TestUtils.renderIntoDocument( elem );
+			const tree = TestUtils.renderIntoDocument( elem );
 
 			assert( ! tree.state.mobileOpen );
-			TestUtils.Simulate.touchTap( ReactDom.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
+			TestUtils.Simulate.touchTap( ReactDom.findDOMNode(
+				TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
+			) );
 			assert( tree.state.mobileOpen );
-			TestUtils.Simulate.touchTap( ReactDom.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
+			TestUtils.Simulate.touchTap( ReactDom.findDOMNode(
+				TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
+			) );
 			assert( ! tree.state.mobileOpen );
-			TestUtils.Simulate.touchTap( ReactDom.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
+			TestUtils.Simulate.touchTap( ReactDom.findDOMNode(
+				TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' )
+			) );
 			assert( tree.state.mobileOpen );
 
 			assert( spy.calledTwice );

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -1,14 +1,18 @@
+/**
+ * External dependencies
+ */
 import { expect } from 'chai';
-import TestUtils from 'react-addons-test-utils' ;
-import useMockery from 'test/helpers/use-mockery' ;
-
+import { identity, noop } from 'lodash';
 import React from 'react';
 import ReactDOM from 'react-dom';
-
 import sinon from 'sinon';
+import TestUtils from 'react-addons-test-utils' ;
 
-import identity from 'lodash/identity';
+/**
+ * Internal dependencies
+ */
 import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery' ;
 
 describe( '#signupStep User', () => {
 	let User, testElement, rendered, EMPTY_COMPONENT;
@@ -18,6 +22,7 @@ describe( '#signupStep User', () => {
 	useMockery( ( mockery ) => {
 		EMPTY_COMPONENT = require( 'test/helpers/react/empty-component' );
 
+		mockery.registerMock( 'lib/abtest', noop );
 		mockery.registerMock( 'lib/analytics', {} );
 		mockery.registerMock( 'components/signup-form', EMPTY_COMPONENT );
 		mockery.registerMock( 'signup/step-wrapper', EMPTY_COMPONENT );
@@ -73,7 +78,7 @@ describe( '#signupStep User', () => {
 
 			spyComponentProps = sinon.spy( User.prototype, 'componentWillReceiveProps' );
 
-			let element = React.createElement( User, {
+			const element = React.createElement( User, {
 				subHeaderText: 'test subheader message',
 				flowName: 'someOtherFlow'
 			} );
@@ -85,7 +90,7 @@ describe( '#signupStep User', () => {
 		} );
 
 		it( 'should show community subheader text when new flow has user as first step', () => {
-			let testProps = {
+			const testProps = {
 				subHeaderText: 'My test message',
 				flowName: 'userAsFirstStepInFlow'
 			};
@@ -99,7 +104,7 @@ describe( '#signupStep User', () => {
 		} );
 
 		it( 'should show provided subheader text when new flow doesn\'t have user as first step', () => {
-			let testProps = {
+			const testProps = {
 				subHeaderText: 'My test message',
 				flowName: 'another test message test'
 			};

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -47,7 +47,6 @@ const apiBaseUrl = 'https://jetpack.wordpress.com';
 const remoteAuthPath = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
 const remoteInstallPath = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 const remoteActivatePath = '/wp-admin/plugins.php';
-const userModule = userFactory();
 const tracksEvent = ( dispatch, eventName, props ) => {
 	setTimeout( () => {
 		dispatch( recordTracksEvent( eventName, props ) );
@@ -308,7 +307,7 @@ export default {
 					error: null
 				} );
 				// Update the user now that we are fully connected.
-				userModule.fetch();
+				userFactory().fetch();
 				return wpcom.me().sites( { site_visibility: 'all' } );
 			} )
 			.then( ( data ) => {

--- a/client/state/sites/domains/test/selectors.js
+++ b/client/state/sites/domains/test/selectors.js
@@ -80,7 +80,7 @@ describe( 'selectors', () => {
 
 			const domainExpirationMoment = moment( domains[ 0 ].expiry );
 
-			expect( decoratedDomains[ 0 ].registrationMoment.date() ).to.equal( domainExpirationMoment.date() );
+			expect( decoratedDomains[ 0 ].expirationMoment.date() ).to.equal( domainExpirationMoment.date() );
 		} );
 	} );
 } );


### PR DESCRIPTION
Partially fixes #4206.

It removes couple of double callback warnings related to Analytics and AB tests libraries. It looks like there are triggered network requests behind the scenes that aren't prevented by `nock`.

### Testing
Run:
* `npm run test-client client/auth/`
* `npm run test-client client/components/`
* `npm run test-client client/signup/`
* `npm run test-client client/state/`

There should be __no__ `double callback` warnings printed on the console.

Test live: https://calypso.live/?branch=remove/double-callback-warning