### PR TITLE
Ad Tracking: Add Criteo tracking pixel

### DIFF
--- a/client/lib/cart/store/cart-analytics.js
+++ b/client/lib/cart/store/cart-analytics.js
@@ -5,6 +5,8 @@ var analytics = require( 'lib/analytics' ),
 	cartItems = require( 'lib/cart-values' ).cartItems,
 	difference = require( 'lodash/difference' );
 
+import { recordAddToCart } from 'lib/analytics/ad-tracking';
+
 function recordEvents( previousCart, nextCart ) {
 	var previousItems = cartItems.getAll( previousCart ),
 		nextItems = cartItems.getAll( nextCart );
@@ -15,6 +17,7 @@ function recordEvents( previousCart, nextCart ) {
 
 function recordAddEvent( cartItem ) {
 	analytics.tracks.recordEvent( 'calypso_cart_product_add', cartItem );
+	recordAddToCart( cartItem );
 }
 
 function recordRemoveEvent( cartItem ) {

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -6,7 +6,6 @@ import assign from 'lodash/assign';
 /**
  * Internal dependencies
  */
-import { recordAddToCart } from 'lib/analytics/ad-tracking';
 import { action as ActionTypes } from '../constants';
 import Dispatcher from 'dispatcher';
 import { cartItems } from 'lib/cart-values';
@@ -45,15 +44,12 @@ function addItem( item ) {
 }
 
 function addItems( items ) {
-
 	const extendedItems = items.map( ( item ) => {
 		const extra = assign( {}, item.extra, {
 			context: 'calypstore'
 		} );
 		return assign( {}, item, { extra } );
 	} );
-
-	extendedItems.forEach( item => recordAddToCart( item ) );
 
 	Dispatcher.handleViewAction( {
 		type: ActionTypes.CART_ITEMS_ADD,

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -97,6 +97,7 @@ var TransactionStepsMixin = {
 							adTracking.recordPurchase( product, step.data.receipt_id );
 						} );
 						adTracking.recordOrderInAtlas( cartValue, step.data.receipt_id );
+						adTracking.recordOrderInCriteo( cartValue, step.data.receipt_id );
 						adTracking.recordConversionInOneByAOL();
 					}
 


### PR DESCRIPTION
This PR adds Criteo retargeting capabilities to Calypso which will let us serve targeted ads to users who abandon their cart during checkout. 

Note that this PR only adds this functional after the NUX. The NUX involves different logic for handling domain and plan selection. Rather than make this PR even larger than it is, I'll save that for another PR after this one gets merged.

To test:

First, set `ad-tracking` to `true` in `development.json` and turn on debugging for the ad tracking module: `localStorage.setItem( 'debug', 'calypso:ad-tracking' );`

### Adding an item to the cart and viewing the checkout page

1) Load the plans page on an existing account (not the NUX).
2) Select the personal plan by clicking an *Upgrade* button

Here is Criteo's documentation for the `viewItem` event which is tracked when a user views a specific item:

![screen shot 2016-08-09 at 2 35 41 pm](https://cloud.githubusercontent.com/assets/44436/17528805/c4f78750-5e3e-11e6-9088-e428330bd821.png)

The way our checkout works we don't have a section that lets a user view information about a specific product, so we fire the event when the user adds the item to their cart.

In the console, verify there is a `Track 'viewItem' event in Criteo` log whose array items match the format expected by Criteo in the screenshot above. Because you're signed in, you'll see an extra array item in the log for `setEmail` - see the screenshot below for that format.

Similarly, here is their documentation showing what to do when a user views checkout:

![screen shot 2016-08-09 at 2 40 39 pm](https://cloud.githubusercontent.com/assets/44436/17528920/4d3972ea-5e3f-11e6-8a62-43b80273e7a1.png)

Because a user adds a plan to their cart and views the checkout page at the same time, you should also see a `Track 'viewBasket' event in Criteo` console log. Verify the array items are formatted the same as the screenshot above. The `viewBasket` event should also include a `currency` key which is not present in the documentation screenshot, but supported by Criteo per an email conversation with them.

### Payment

Next, purchase whatever is in your cart using a test credit card or credits.

Here's Criteo's documentation again:

![screen shot 2016-08-09 at 3 03 24 pm](https://cloud.githubusercontent.com/assets/44436/17529723/721140f4-5e42-11e6-9c3d-b3b7a8edb693.png)

You should see a `Track 'viewBasket' event in Criteo` console log entry. The only difference with this one is that you'll also see an `id` key with the receipt id:

![screen shot 2016-08-09 at 3 04 25 pm](https://cloud.githubusercontent.com/assets/44436/17529757/9a094aac-5e42-11e6-8817-103851b55f0e.png)

You can also verify the network request is happening by searching for "criteo" in Chrome's network tools:

![screen shot 2016-08-09 at 3 08 24 pm](https://cloud.githubusercontent.com/assets/44436/17529903/31a2131c-5e43-11e6-9af4-95ee60cc534e.png)

Test live: https://calypso.live/?branch=add/criteo-marketing-pixel