### PR TITLE
Media: Enable Image Editor in Development

### DIFF
--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -9,7 +9,6 @@ const debug = _debug( 'calypso:media-library:header' );
  * Internal dependencies
  */
 import { isMobile } from 'lib/viewport';
-import Button from 'components/button';
 import FormRange from 'components/forms/range';
 import Gridicon from 'components/gridicon';
 import PopoverMenu from 'components/popover/menu';
@@ -19,7 +18,6 @@ import SegmentedControlItem from 'components/segmented-control/item';
 import UploadButton from './upload-button';
 import MediaLibraryUploadUrl from './upload-url';
 import { userCan } from 'lib/site/utils';
-import config from 'config';
 
 export default React.createClass( {
 	displayName: 'MediaLibraryHeader',
@@ -121,21 +119,6 @@ export default React.createClass( {
 		} );
 	},
 
-	renderUploadAndEditButton() {
-		if ( ! config.isEnabled( 'post-editor/image-editor' ) ) {
-			return;
-		}
-
-		return (
-			<Button
-				className="is-desktop"
-				onClick={ this.props.onAddAndEditImage } >
-				<Gridicon icon="pencil" />
-				{ this.translate( 'Add and edit image' ) }
-			</Button>
-		);
-	},
-
 	renderUploadButtons() {
 		const { site, filter, onAddMedia } = this.props;
 
@@ -157,7 +140,6 @@ export default React.createClass( {
 					className="button is-desktop">
 					{ this.translate( 'Add via URL', { context: 'Media upload' } ) }
 				</button>
-				{ this.renderUploadAndEditButton() }
 				<button
 					ref={ this.setMoreOptionsContext }
 					onClick={ this.toggleMoreOptions.bind( this, ! this.state.isMoreOptionsVisible ) }

--- a/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
@@ -72,7 +72,7 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	getImage( url ) {
 		const req = new XMLHttpRequest();
 		req.open( 'GET', url, true );
-		req.responseType = "arraybuffer";
+		req.responseType = 'arraybuffer';
 		req.onload = () => {
 			const objectURL = window.URL.createObjectURL( new Blob( [ req.response ], { type: this.props.mimeType } ) );
 			this.initImage( objectURL );

--- a/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
@@ -24,7 +24,7 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	propTypes: {
 		src: React.PropTypes.string,
 		mimeType: React.PropTypes.string,
-		transfrom: React.PropTypes.shape( {
+		transform: React.PropTypes.shape( {
 			degrees: React.PropTypes.number,
 			scaleX: React.PropTypes.number,
 			scaleY: React.PropTypes.number
@@ -57,7 +57,7 @@ const MediaModalImageEditorCanvas = React.createClass( {
 
 	componentWillReceiveProps( newProps ) {
 		if ( this.props.src !== newProps.src ) {
-			this.initImage( newProps.src );
+			this.getImage( newProps.src );
 		}
 	},
 
@@ -66,7 +66,18 @@ const MediaModalImageEditorCanvas = React.createClass( {
 			return;
 		}
 
-		this.initImage( this.props.src );
+		this.getImage( this.props.src );
+	},
+
+	getImage( url ) {
+		const req = new XMLHttpRequest();
+		req.open( 'GET', url, true );
+		req.responseType = "arraybuffer";
+		req.onload = () => {
+			const objectURL = window.URL.createObjectURL( new Blob( [ req.response ], { type: this.props.mimeType } ) );
+			this.initImage( objectURL );
+		};
+		req.send();
 	},
 
 	initImage( src ) {

--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -49,13 +49,14 @@ const MediaModalImageEditor = React.createClass( {
 			fileName = 'default',
 			mimeType = 'image/png';
 
-		if ( this.props.items && this.props.items[ this.props.selectedIndex ] ) {
-			src = MediaUtils.url( this.props.items[ this.props.selectedIndex ], {
+		const media = this.props.items[ this.props.selectedIndex ];
+
+		if ( this.props.items && media ) {
+			src = MediaUtils.url( media, {
 				photon: this.props.site && ! this.props.site.is_private
 			} );
-
-			fileName = path.basename( src );
-			mimeType = MediaUtils.getMimeType( this.props.items[ this.props.selectedIndex ] );
+			fileName = media.file || path.basename( src );
+			mimeType = MediaUtils.getMimeType( media );
 		}
 
 		this.props.resetImageEditorState();
@@ -63,16 +64,9 @@ const MediaModalImageEditor = React.createClass( {
 	},
 
 	onDone() {
-		//TODO: this exists to handle cross-origin error - at the moment
-		//the error prevents editing of the images that have been already
-		//uploaded. Consider removing this once the cors headers are added to
-		//the image responses
-		try {
-			const canvasComponent = this.refs.editCanvas.getWrappedInstance();
-			canvasComponent.toBlob( this.onImageExtracted );
-		} finally {
-			this.props.onImageEditorClose();
-		}
+		const canvasComponent = this.refs.editCanvas.getWrappedInstance();
+		canvasComponent.toBlob( this.onImageExtracted );
+		this.props.onImageEditorClose();
 	},
 
 	onImageExtracted( blob ) {
@@ -88,7 +82,7 @@ const MediaModalImageEditor = React.createClass( {
 	//TODO: the drop zone currently exists for presentation purposes,
 	//consider implementing the image open functionality fully or removing it
 	onFilesDrop: function( files ) {
-		const file = files[0];
+		const file = files[ 0 ];
 		const mimePrefix = MediaUtils.getMimePrefix( file );
 		const mimeType = MediaUtils.getMimeType( file );
 

--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -65,7 +65,7 @@ const MediaModalImageEditor = React.createClass( {
 	onDone() {
 		const canvasComponent = this.refs.editCanvas.getWrappedInstance();
 		canvasComponent.toBlob( this.onImageExtracted );
-		this.props.onImageEditorClose();
+		this.props.onImageEditorClose( null, { hasEditedImage: true } );
 	},
 
 	onImageExtracted( blob ) {

--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -48,9 +48,9 @@ const MediaModalImageEditor = React.createClass( {
 			fileName = 'default',
 			mimeType = 'image/png';
 
-		const media = this.props.items[ this.props.selectedIndex ];
+		const media = this.props.items ? this.props.items[ this.props.selectedIndex ] : null;
 
-		if ( this.props.items && media ) {
+		if ( media ) {
 			src = MediaUtils.url( media, {
 				photon: this.props.site && ! this.props.site.is_private
 			} );

--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -12,7 +12,6 @@ import path from 'path';
 import EditCanvas from './image-editor-canvas';
 import EditToolbar from './image-editor-toolbar';
 import EditButtons from './image-editor-buttons';
-import DropZone from 'components/drop-zone';
 import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
 import {
@@ -79,21 +78,6 @@ const MediaModalImageEditor = React.createClass( {
 		} );
 	},
 
-	//TODO: the drop zone currently exists for presentation purposes,
-	//consider implementing the image open functionality fully or removing it
-	onFilesDrop: function( files ) {
-		const file = files[ 0 ];
-		const mimePrefix = MediaUtils.getMimePrefix( file );
-		const mimeType = MediaUtils.getMimeType( file );
-
-		if ( 'image' !== mimePrefix ) {
-			//show an error if the image opening is to be implemented properly
-			return;
-		}
-
-		this.props.setImageEditorFileInfo( URL.createObjectURL( file ), file.name, mimeType );
-	},
-
 	isValidTransfer: function( transfer ) {
 		if ( ! transfer ) {
 			return false;
@@ -117,23 +101,11 @@ const MediaModalImageEditor = React.createClass( {
 		return ! transfer.types || -1 !== Array.prototype.indexOf.call( transfer.types, 'Files' );
 	},
 
-	renderDropZone() {
-		if ( this.props.src ) {
-			return;
-		}
-
-		return ( <DropZone
-			fullScreen={ true }
-			onVerifyValidTransfer={ this.isValidTransfer }
-			onFilesDrop={ this.onFilesDrop } /> );
-	},
-
 	render() {
 		return (
 			<div className="editor-media-modal-image-editor">
 				<figure>
 					<div className="editor-media-modal-image-editor__content editor-media-modal__content" >
-						{ this.renderDropZone() }
 						<EditCanvas ref="editCanvas" />
 						<EditToolbar />
 						<EditButtons

--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -33,13 +33,15 @@ const MediaModalImageEditor = React.createClass( {
 		fileName: React.PropTypes.string,
 		mimeType: React.PropTypes.string,
 		setImageEditorFileInfo: React.PropTypes.func,
-		onImageEditorClose: React.PropTypes.func
+		onImageEditorClose: React.PropTypes.func,
+		onImageEditorCancel: React.PropTypes.func
 	},
 
 	getDefaultProps() {
 		return {
 			selectedIndex: 0,
-			onImageEditorClose: noop
+			onImageEditorClose: noop,
+			onImageEditorCancel: noop
 		};
 	},
 
@@ -65,7 +67,7 @@ const MediaModalImageEditor = React.createClass( {
 	onDone() {
 		const canvasComponent = this.refs.editCanvas.getWrappedInstance();
 		canvasComponent.toBlob( this.onImageExtracted );
-		this.props.onImageEditorClose( null, { hasEditedImage: true } );
+		this.props.onImageEditorClose();
 	},
 
 	onImageExtracted( blob ) {
@@ -109,7 +111,7 @@ const MediaModalImageEditor = React.createClass( {
 						<EditCanvas ref="editCanvas" />
 						<EditToolbar />
 						<EditButtons
-							onCancel={ this.props.onImageEditorClose }
+							onCancel={ this.props.onImageEditorCancel }
 							onDone={ this.onDone } />
 					</div>
 				</figure>

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -209,15 +209,15 @@ module.exports = React.createClass( {
 		this.setView( ModalViews.IMAGE_EDITOR );
 	},
 
-	onImageEditorClose: function() {
+	onImageEditorClose: function( event, { hasEditedImage } = { hasEditedImage: false } ) {
 		const item = this.props.mediaLibrarySelectedItems[ this.state.detailSelectedIndex ];
 
-		if ( item ) {
-			this.setView( ModalViews.DETAIL );
+		if ( ! item || hasEditedImage ) {
+			MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
+			this.setView( ModalViews.LIST );
 			return;
 		}
-
-		this.setView( ModalViews.LIST );
+		this.setView( ModalViews.DETAIL );
 	},
 
 	onFilterChange: function( filter ) {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -209,11 +209,14 @@ module.exports = React.createClass( {
 		this.setView( ModalViews.IMAGE_EDITOR );
 	},
 
-	onImageEditorClose: function( event, { hasEditedImage } = { hasEditedImage: false } ) {
-		const item = this.props.mediaLibrarySelectedItems[ this.state.detailSelectedIndex ];
+	onImageEditorClose: function() {
+		MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
+		this.setView( ModalViews.LIST );
+	},
 
-		if ( ! item || hasEditedImage ) {
-			MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
+	onImageEditorCancel: function() {
+		const item = this.props.mediaLibrarySelectedItems[ this.state.detailSelectedIndex ];
+		if ( ! item ) {
 			this.setView( ModalViews.LIST );
 			return;
 		}
@@ -388,7 +391,9 @@ module.exports = React.createClass( {
 						site={ this.props.site }
 						items={ this.props.mediaLibrarySelectedItems }
 						selectedIndex={ this.state.detailSelectedIndex }
-						onImageEditorClose={ this.onImageEditorClose } />
+						onImageEditorClose={ this.onImageEditorClose }
+						onImageEditorCancel={ this.onImageEditorCancel }
+					/>
 				);
 				break;
 		}

--- a/config/development.json
+++ b/config/development.json
@@ -104,7 +104,7 @@
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
-		"post-editor/image-editor": false,
+		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,
 		"post-editor/media-advanced": true,
 		"press-this": true,


### PR DESCRIPTION
This PR fixes #6639 and #6640 and enables the image editor for development only. This removes the temporary workflow that was needed because of cross-origin issues in #5099. 

Note that this PR just enables an example flow, and we'll want to tackle #7375, #7376, #6642 in separate PRs.

## Testing Instructions

1. Navigate to http://calypso.localhost:3000/post
2. Select a site
3. Add an image
4. Select the image
<img width="914" alt="screen shot 2016-08-09 at 2 12 35 pm" src="https://cloud.githubusercontent.com/assets/1270189/17533873/91f17788-5e3b-11e6-854d-3a23fbcfb366.png">
5. Click "Edit", then click on "Edit Image" in the top right corner of the detail view
<img width="917" alt="screen shot 2016-08-09 at 2 12 43 pm" src="https://cloud.githubusercontent.com/assets/1270189/17533877/961582f0-5e3b-11e6-813e-5cfadb5d47b6.png">
6. The image editor should load. Make some edits and click "Done"
<img width="912" alt="screen shot 2016-08-09 at 2 12 58 pm" src="https://cloud.githubusercontent.com/assets/1270189/17533939/dc97dbc4-5e3b-11e6-8608-57bb43512ced.png">
7. If changes were made, we should go back to the list view, and see a new edited copy of the image being uploaded.
<img width="910" alt="screen shot 2016-08-09 at 2 13 07 pm" src="https://cloud.githubusercontent.com/assets/1270189/17534005/13c200de-5e3c-11e6-8e84-6974bd069ef3.png">

cc @robobot3000 @rralian @aduth @lamosty @artpi @retrofox 


Test live: https://calypso.live/?branch=update/image-editor-prototype