### PR TITLE
Editor: hide sharing on page editor for JP sites without sharing/likes enabled

### DIFF
--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -34,7 +34,10 @@ const EditorSharingAccordion = React.createClass( {
 		post: PropTypes.object,
 		isNew: PropTypes.bool,
 		connections: PropTypes.array,
-		isPublicizeEnabled: PropTypes.bool
+		isPublicizeEnabled: PropTypes.bool,
+		isSharingActive: PropTypes.bool,
+		isLikesActive: PropTypes.bool,
+		postType: PropTypes.string
 	},
 
 	getSubtitle: function() {
@@ -53,7 +56,7 @@ const EditorSharingAccordion = React.createClass( {
 	},
 
 	renderShortUrl: function() {
-		var classes = classNames( 'editor-sharing__shortlink', {
+		const classes = classNames( 'editor-sharing__shortlink', {
 			'is-standalone': this.hideSharing()
 		} );
 
@@ -61,7 +64,7 @@ const EditorSharingAccordion = React.createClass( {
 			return null;
 		}
 
-		return(
+		return (
 			<div className={ classes }>
 				<label
 					className="editor-sharing__shortlink-label"
@@ -82,18 +85,15 @@ const EditorSharingAccordion = React.createClass( {
 	},
 
 	hideSharing: function() {
-		return this.props.site &&
-			this.props.site.jetpack &&
-			! this.props.site.isModuleActive( 'publicize' ) &&
-			! this.props.site.isModuleActive( 'sharedaddy' ) &&
-			! this.props.site.isModuleActive( 'likes' );
+		const { isSharingActive, isLikesActive, isPublicizeEnabled } = this.props;
+		return ( ! isSharingActive && ! isLikesActive ) && ! isPublicizeEnabled;
 	},
 
 	render: function() {
-		var hideSharing = this.hideSharing(),
-			classes = classNames( 'editor-sharing__accordion', this.props.className, {
-				'is-loading': ! this.props.post || ! this.props.connections
-			} );
+		const hideSharing = this.hideSharing();
+		const classes = classNames( 'editor-sharing__accordion', this.props.className, {
+			'is-loading': ! this.props.post || ! this.props.connections
+		} );
 
 		// if sharing is hidden, and post is not published (no short URL yet),
 		// then do not render this accordion
@@ -132,10 +132,15 @@ export default connect(
 			true !== getSiteOption( state, siteId, 'publicize_permanently_disabled' ) &&
 			postTypeSupports( state, siteId, postType, 'publicize' )
 		);
+		const isSharingActive = false !== isJetpackModuleActive( state, siteId, 'sharedaddy' );
+		const isLikesActive = false !== isJetpackModuleActive( state, siteId, 'likes' );
 
 		return {
+			connections: getSiteUserConnections( state, siteId, userId ),
+			isSharingActive,
+			isLikesActive,
 			isPublicizeEnabled,
-			connections: getSiteUserConnections( state, siteId, userId )
+			postType
 		};
 	},
 	( dispatch ) => {

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -36,8 +36,7 @@ const EditorSharingAccordion = React.createClass( {
 		connections: PropTypes.array,
 		isPublicizeEnabled: PropTypes.bool,
 		isSharingActive: PropTypes.bool,
-		isLikesActive: PropTypes.bool,
-		postType: PropTypes.string
+		isLikesActive: PropTypes.bool
 	},
 
 	getSubtitle: function() {
@@ -86,7 +85,7 @@ const EditorSharingAccordion = React.createClass( {
 
 	hideSharing: function() {
 		const { isSharingActive, isLikesActive, isPublicizeEnabled } = this.props;
-		return ( ! isSharingActive && ! isLikesActive ) && ! isPublicizeEnabled;
+		return ! isSharingActive && ! isLikesActive && ! isPublicizeEnabled;
 	},
 
 	render: function() {
@@ -139,8 +138,7 @@ export default connect(
 			connections: getSiteUserConnections( state, siteId, userId ),
 			isSharingActive,
 			isLikesActive,
-			isPublicizeEnabled,
-			postType
+			isPublicizeEnabled
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
Fixes #7088 - This branch fixes a minor issue that happens for Jetpack sites that have likes and sharing disabled in the page editor:

<img width="479" alt="new_page_ _haiku2_ _wordpress_com_" src="https://cloud.githubusercontent.com/assets/22080/17535545/0af6439a-5e44-11e6-8e8a-662b7115d1e9.png">

To re-create the issue, you need to disable Likes and Sharing on a Jetpack site, but keep Publicize *enabled*.

__To Test__
- Configure a jetpack site as outlined above
- Open up a page in the editor for that site, verify that the sharing accordion is not shown
- Open a post in the editor for that JP site, verify the sharing accordion is shown for publicize

/cc @aduth 

Test live: https://calypso.live/?branch=fix/editor/7088