### PR TITLE
Progress Bar: Update pulsing styles

### DIFF
--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -23,9 +23,10 @@
 }
 
 .progress-bar.is-pulsing .progress-bar__progress {
-	animation: progress-bar-animation 2000ms infinite linear;
-	background-image: linear-gradient( 45deg, $blue-dark 0%, $blue-wordpress 50%, $blue-dark 100% );
-	background-size: 50%;
+	animation: progress-bar-animation 10000ms infinite linear;;
+
+	background-size: 12.5% 100%;
+	background-image: linear-gradient( -45deg, $blue-wordpress 25%, darken( $blue-wordpress, 5% ) 25%, darken( $blue-wordpress, 5% ) 75%, $blue-wordpress 75%)
 }
 
 @keyframes progress-bar-animation {
@@ -42,4 +43,3 @@
 		border-radius: 0;
 	}
 }
-

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -23,14 +23,20 @@
 }
 
 .progress-bar.is-pulsing .progress-bar__progress {
-	animation: progress-bar-animation 10000ms infinite linear;;
+	animation: progress-bar-animation 3300ms infinite linear;
 
-	background-size: 12.5% 100%;
-	background-image: linear-gradient( -45deg, $blue-wordpress 25%, darken( $blue-wordpress, 5% ) 25%, darken( $blue-wordpress, 5% ) 75%, $blue-wordpress 75%)
+	background-size: 50px 100%;
+	background-image: linear-gradient(
+		-45deg,
+		$blue-wordpress 28%,
+		lighten( $blue-wordpress, 5% ) 28%,
+		lighten( $blue-wordpress, 5% ) 72%,
+		$blue-wordpress 72%
+	);
 }
 
 @keyframes progress-bar-animation {
-  0%   { background-position: 100% 0; }
+  0%   { background-position: 100px 0; }
   100% {  }
 }
 


### PR DESCRIPTION
In #7258, we added an `isPulsing` property that adds an animation to the blue progress bar while performing an action. This is especially useful for actions that may take several minutes (like syncing a site).

This PR aims to update those styles. Here is a demo.

![progress_bar_pulsing](https://cloud.githubusercontent.com/assets/1126811/17540282/7b7d5974-5e7a-11e6-96c7-4b0e302ed7bf.gif)

I still need to track down an issue with how the styles look when little progress has been made. The ribbons appear too close together.

<img width="737" alt="screen shot 2016-08-09 at 9 43 20 pm" src="https://cloud.githubusercontent.com/assets/1126811/17540300/a3139cb4-5e7a-11e6-9f00-f00402907da7.png">

To test:

- Checkout `update/progress-bar-pulse-styles` branch
- Go to `/settings/general/$site` where `$site` is on the latest `branch-4.2`
- Click "Perform full sync" button

cc @rickybanister @folletto 

Also, @folletto, I wasn't sure how to match the color in your [codepen](http://codepen.io/folletto/full/grBPoW/), so I went with `darken( $blue-wordpress, 5% )`. I can update this if it's something different.


Test live: https://calypso.live/?branch=update/progress-bar-pulse-styles