### PR TITLE
CPT: Display WordPress.com support article link

### DIFF
--- a/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
+++ b/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
@@ -108,7 +108,7 @@ class CustomPostTypesFieldset extends Component {
 				<p>
 					{ translate( 'Display different types of content on your site with {{link}}custom content types{{/link}}.', {
 						components: {
-							link: <a href="https://jetpack.com/support/custom-content-types/" target="_blank" />
+							link: <a href="https://en.support.wordpress.com/custom-post-types/" target="_blank" />
 						}
 					} ) }
 				</p>


### PR DESCRIPTION
This pull request seeks to change the support article link on the [site settings writing screen custom content types description](https://wordpress.com/settings/writing) from a Jetpack.com article to a WordPress.com support article.

Before: https://jetpack.com/support/custom-content-types/
After: https://en.support.wordpress.com/custom-post-types/

Test live: https://calypso.live/?branch=update/cpt-support-link