### PR TITLE
Signup: Update some page type themes with newer themes

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -1,5 +1,14 @@
 export const themes = [
 	{
+		name: 'Affinity',
+		slug: 'affinity',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		demo_uri: 'https://affinitydemo.wordpress.com',
+		verticals: []
+	},
+	{
 		name: 'Apostrophe',
 		slug: 'apostrophe',
 		repo: 'pub',
@@ -15,15 +24,6 @@ export const themes = [
 		fallback: false,
 		design: 'grid',
 		demo_uri: 'https://baskervilledemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Big Brother',
-		slug: 'big-brother',
-		repo: 'pub',
-		fallback: false,
-		design: 'page',
-		demo_uri: 'https://bigbrotherdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -135,6 +135,15 @@ export const themes = [
 		verticals: []
 	},
 	{
+		name: 'Karuna',
+		slug: 'karuna',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		demo_uri: 'https://karunademo.wordpress.com',
+		verticals: []
+	},
+	{
 		name: 'Libre',
 		slug: 'libre',
 		repo: 'pub',
@@ -150,15 +159,6 @@ export const themes = [
 		fallback: false,
 		design: 'blog',
 		demo_uri: 'https://librettodemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Motif',
-		slug: 'motif',
-		repo: 'pub',
-		fallback: false,
-		design: 'page',
-		demo_uri: 'https://motifdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -243,12 +243,12 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Sequential',
-		slug: 'sequential',
+		name: 'Shoreditch',
+		slug: 'shoreditch',
 		repo: 'pub',
 		fallback: false,
 		design: 'page',
-		demo_uri: 'https://sequentialdemo.wordpress.com',
+		demo_uri: 'https://shoreditchdemo.wordpress.com',
 		verticals: []
 	},
 	{


### PR DESCRIPTION
We've released some page type themes. It'd be good to swap them with less popular themes that have lower conversion rates.

I'm adding the following themes:
* Affinity
* Karuna
* Shoreditch

And, I'm taking away the following themes:
* Big Brother
* Motif
* Sequential

**New Selection:**
![screen shot 2016-08-10 at 13 02 58](https://cloud.githubusercontent.com/assets/908665/17553226/a1eb4cec-5efc-11e6-8d94-43aabde4b1e0.png)

Historically, we haven't seen a negative impact with updating a theme selection in signup (#3738). So, I doubt this change will affect to the tests currently running, but if this is a concern for your tests, please let me know.

**We need to wait to merge this until the all new themes are Headstart ready. (Expected to be ready today or tomorrow)**

Test live: https://calypso.live/?branch=update/page-type-themes