### PR TITLE
Add an utility fn to strip http(s) out of an URL

### DIFF
--- a/client/lib/reader-site-store/index.js
+++ b/client/lib/reader-site-store/index.js
@@ -13,6 +13,8 @@ var Dispatcher = require( 'dispatcher' ),
 	FeedStoreActionType = require( 'lib/feed-store/constants' ).action,
 	State = require( './constants' ).state;
 
+import { withoutHttp } from 'lib/url';
+
 var sites = {}, SiteStore;
 
 SiteStore = {
@@ -35,7 +37,7 @@ function adaptSite( attributes ) {
 	attributes = omit( attributes, [ 'meta', '_headers' ] );
 
 	if ( attributes.URL ) {
-		attributes.domain = attributes.URL.replace( /^https?:\/\//, '' );
+		attributes.domain = withoutHttp( attributes.URL );
 		attributes.slug = attributes.domain.replace( /\//g, '::' );
 	}
 	attributes.title = trim( attributes.name ) || attributes.domain;
@@ -43,13 +45,13 @@ function adaptSite( attributes ) {
 	// If a WordPress.com site has a mapped domain create a `wpcom_url`
 	// attribute to allow site selection with either domain.
 	if ( attributes.options && attributes.options.is_mapped_domain && ! attributes.is_jetpack ) {
-		attributes.wpcom_url = attributes.options.unmapped_url.replace( /^https?:\/\//, '' );
+		attributes.wpcom_url = withoutHttp( attributes.options.unmapped_url );
 	}
 
 	// If a site has an `is_redirect` property use the `unmapped_url`
 	// for the slug and domain to match the wordpress.com original site.
 	if ( attributes.options && attributes.options.is_redirect ) {
-		attributes.slug = attributes.options.unmapped_url.replace( /^https?:\/\//, '' );
+		attributes.slug = withoutHttp( attributes.options.unmapped_url );
 		attributes.domain = attributes.slug;
 	}
 	return attributes;

--- a/client/lib/site/computed-attributes.js
+++ b/client/lib/site/computed-attributes.js
@@ -8,7 +8,7 @@ import trim from 'lodash/trim';
 /**
  * Internal dependencies
  */
-import { isHttps } from 'lib/url';
+import { isHttps, withoutHttp } from 'lib/url';
 import config from 'config';
 
 export default function( site ) {
@@ -20,7 +20,7 @@ export default function( site ) {
 
 	// Add URL without protocol as a `domain` attribute
 	if ( site.URL ) {
-		attributes.domain = site.URL.replace( /^https?:\/\//, '' );
+		attributes.domain = withoutHttp( site.URL );
 		attributes.slug = attributes.domain.replace( /\//g, '::' );
 	}
 	attributes.title = trim( site.name ) || attributes.domain;
@@ -28,13 +28,13 @@ export default function( site ) {
 	// If a WordPress.com site has a mapped domain create a `wpcom_url`
 	// attribute to allow site selection with either domain.
 	if ( attributes.options && attributes.options.is_mapped_domain && ! site.is_jetpack ) {
-		attributes.wpcom_url = site.options.unmapped_url.replace( /^https?:\/\//, '' );
+		attributes.wpcom_url = withoutHttp( site.options.unmapped_url );
 	}
 
 	// If a site has an `is_redirect` property use the `unmapped_url`
 	// for the slug and domain to match the wordpress.com original site.
 	if ( ( attributes.options && attributes.options.is_redirect ) || site.hasConflict ) {
-		attributes.slug = attributes.options.unmapped_url.replace( /^https?:\/\//, '' );
+		attributes.slug = withoutHttp( attributes.options.unmapped_url );
 		attributes.domain = attributes.slug;
 	}
 

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -3,6 +3,7 @@
  */
 import i18n from 'i18n-calypso';
 import get from 'lodash/get';
+import { withoutHttp } from 'lib/url';
 
 export default {
 	userCan( capability, site ) {
@@ -164,7 +165,7 @@ export default {
 				return false;
 			}
 			// Compare unmapped_url with the main_network_site to see if is the main network site.
-			return ! ( unmappedUrl.replace( /^https?:\/\//, '' ) !== mainNetworkSite.replace( /^https?:\/\//, '' ) );
+			return ! ( withoutHttp( unmappedUrl ) !== withoutHttp( mainNetworkSite ) );
 		}
 
 		return false;

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -26,8 +26,22 @@ function isHttps( url ) {
 	return url && startsWith( url, 'https://' );
 }
 
+/**
+ * Returns the supplied URL without the initial http(s).
+ * @param  {String}  url The URL to remove http(s) from
+ * @return {?String}     URL without the initial http(s)
+ */
+function withoutHttp( url ) {
+	if ( ! url ) {
+		return null;
+	}
+
+	return url.replace( /^https?:\/\//, '' );
+}
+
 export default {
 	isOutsideCalypso,
 	isExternal,
 	isHttps,
+	withoutHttp
 };

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -26,6 +26,8 @@ function isHttps( url ) {
 	return url && startsWith( url, 'https://' );
 }
 
+const urlWithoutHttpRegex = /^https?:\/\//;
+
 /**
  * Returns the supplied URL without the initial http(s).
  * @param  {String}  url The URL to remove http(s) from
@@ -36,7 +38,7 @@ function withoutHttp( url ) {
 		return null;
 	}
 
-	return url.replace( /^https?:\/\//, '' );
+	return url.replace( urlWithoutHttpRegex, '' );
 }
 
 export default {

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -34,6 +34,10 @@ const urlWithoutHttpRegex = /^https?:\/\//;
  * @return {?String}     URL without the initial http(s)
  */
 function withoutHttp( url ) {
+	if ( url === '' ) {
+		return '';
+	}
+
 	if ( ! url ) {
 		return null;
 	}

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { withoutHttp } from '../';
+
+describe( 'withoutHttp', () => {
+	it( 'should return null if URL is not provided', () => {
+		expect( withoutHttp() ).to.be.null;
+	} );
+
+	it( 'should return URL without initial http', () => {
+		const urlWithHttp = 'http://example.com';
+		const urlWithoutHttp = withoutHttp( urlWithHttp );
+
+		expect( urlWithoutHttp ).to.equal( 'example.com' );
+	} );
+
+	it( 'should return URL without initial https', () => {
+		const urlWithHttps = 'https://example.com';
+		const urlWithoutHttps = withoutHttp( urlWithHttps );
+
+		expect( urlWithoutHttps ).to.equal( 'example.com' );
+	} );
+
+	it( "should return provided URL if it doesn't include http(s)", () => {
+		const urlWithoutHttp = 'example.com';
+
+		expect( withoutHttp( urlWithoutHttp ) ).to.equal( urlWithoutHttp );
+	} );
+} );

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -39,4 +39,10 @@ describe( 'withoutHttp', () => {
 
 		expect( withoutHttp( urlWithoutHttp ) ).to.equal( urlWithoutHttp );
 	} );
+
+	it( 'should return empty string if URL is empty string', () => {
+		const urlEmptyString = '';
+
+		expect( withoutHttp( urlEmptyString ) ).to.equal( '' );
+	} );
 } );

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -27,6 +27,13 @@ describe( 'withoutHttp', () => {
 		expect( urlWithoutHttps ).to.equal( 'example.com' );
 	} );
 
+	it( 'should return URL without initial http and query string if has any', () => {
+		const urlWithHttpAndQueryString = 'http://example.com?foo=bar#anchor';
+		const urlWithoutHttpAndQueryString = withoutHttp( urlWithHttpAndQueryString );
+
+		expect( urlWithoutHttpAndQueryString ).to.equal( 'example.com?foo=bar#anchor' );
+	} );
+
 	it( "should return provided URL if it doesn't include http(s)", () => {
 		const urlWithoutHttp = 'example.com';
 

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -9,6 +9,7 @@ import includes from 'lodash/includes';
  */
 import config from 'config';
 import { decodeEntities } from 'lib/formatting';
+import { withoutHttp } from 'lib/url';
 
 /**
  * Module variables
@@ -31,7 +32,7 @@ function getLanguage( slug ) {
 }
 
 function getSiteSlug( url ) {
-	var slug = url.replace( /^https?:\/\//, '' );
+	var slug = withoutHttp( url );
 	return slug.replace( /\//g, '::' );
 }
 

--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -11,6 +11,8 @@ var ActionRemove = require( 'me/action-remove' ),
 	safeProtocolUrl = require( 'lib/safe-protocol-url' ),
 	eventRecorder = require( 'me/event-recorder' );
 
+import { withoutHttp } from 'lib/url';
+
 module.exports = React.createClass( {
 
 	displayName: 'ProfileLink',
@@ -69,7 +71,7 @@ module.exports = React.createClass( {
 						{ this.props.title }
 					</span>
 					<span className="profile-link__url">
-						{ this.props.url.replace( /^https?:\/\//, '' ) }
+						{ withoutHttp( this.props.url ) }
 					</span>
 				</a>
 

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -1,4 +1,5 @@
 import { getSiteUrl, getFeedUrl } from 'reader/route';
+import { withoutHttp } from 'lib/url';
 
 module.exports = {
 	formatUrlForDisplay: function( url ) {
@@ -6,7 +7,7 @@ module.exports = {
 			return;
 		}
 
-		return url.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
+		return withoutHttp( url ).replace( /\/$/, '' );
 	},
 
 	// Use either the site name, feed name or display URL for the feed name

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -42,6 +42,7 @@ import { requestSites } from 'state/sites/actions';
 import { isRequestingSites } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import LiveChatButton from './live-chat-button';
+import { withoutHttp } from 'lib/url';
 
 /**
  * Constants
@@ -368,7 +369,7 @@ const LoggedInForm = React.createClass( {
 	getRedirectionTarget() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 		const site = queryObject.site;
-		const siteSlug = site.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+		const siteSlug = withoutHttp( site ).replace( /\//g, '::' );
 		return PLANS_PAGE + siteSlug;
 	},
 

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -7,6 +7,7 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import Notice from 'components/notice';
+import { withoutHttp } from 'lib/url';
 
 export default React.createClass( {
 	displayName: 'JetpackConnectNotices',
@@ -114,7 +115,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const urlSlug = this.props.url ? this.props.url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' ) : '';
+		const urlSlug = this.props.url ? withoutHttp( this.props.url ).replace( /\//g, '::' ) : '';
 		const values = this.getNoticeValues( urlSlug );
 		if ( values ) {
 			return (

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -17,6 +17,7 @@ import {
 
 import { isValidStateWithSchema } from 'state/utils';
 import { readerSitesSchema } from './schema';
+import { withoutHttp } from 'lib/url';
 
 const actionMap = {
 	[ SERIALIZE ]: handleSerialize,
@@ -57,7 +58,7 @@ function adaptSite( attributes ) {
 	attributes = omit( attributes, [ 'meta', '_headers' ] );
 
 	if ( attributes.URL ) {
-		attributes.domain = attributes.URL.replace( /^https?:\/\//, '' );
+		attributes.domain = withoutHttp( attributes.URL );
 		attributes.slug = attributes.domain.replace( /\//g, '::' );
 	}
 	attributes.title = trim( attributes.name ) || attributes.domain;
@@ -65,13 +66,13 @@ function adaptSite( attributes ) {
 	// If a WordPress.com site has a mapped domain create a `wpcom_url`
 	// attribute to allow site selection with either domain.
 	if ( attributes.options && attributes.options.is_mapped_domain && ! attributes.is_jetpack ) {
-		attributes.wpcom_url = attributes.options.unmapped_url.replace( /^https?:\/\//, '' );
+		attributes.wpcom_url = withoutHttp( attributes.options.unmapped_url );
 	}
 
 	// If a site has an `is_redirect` property use the `unmapped_url`
 	// for the slug and domain to match the wordpress.com original site.
 	if ( attributes.options && attributes.options.is_redirect ) {
-		attributes.slug = attributes.options.unmapped_url.replace( /^https?:\/\//, '' );
+		attributes.slug = withoutHttp( attributes.options.unmapped_url );
 		attributes.domain = attributes.slug;
 	}
 	return attributes;

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -18,7 +18,7 @@ import {
  * Internal dependencies
  */
 import config from 'config';
-import { isHttps } from 'lib/url';
+import { isHttps, withoutHttp } from 'lib/url';
 
 /**
  * Internal dependencies
@@ -79,11 +79,11 @@ export const getSite = createSelector(
 export const getSiteCollisions = createSelector(
 	( state ) => {
 		return map( filter( state.sites.items, ( wpcomSite ) => {
-			const wpcomSiteUrlSansProtocol = wpcomSite.URL.replace( /^https?:\/\//, '' );
+			const wpcomSiteUrlSansProtocol = withoutHttp( wpcomSite.URL );
 			return ! wpcomSite.jetpack && some( state.sites.items, ( jetpackSite ) => {
 				return (
 					jetpackSite.jetpack &&
-					wpcomSiteUrlSansProtocol === jetpackSite.URL.replace( /^https?:\/\//, '' )
+					wpcomSiteUrlSansProtocol === withoutHttp( jetpackSite.URL )
 				);
 			} );
 		} ), 'ID' );
@@ -188,10 +188,10 @@ export function getSiteSlug( state, siteId ) {
 	}
 
 	if ( getSiteOption( state, siteId, 'is_redirect' ) || isSiteConflicting( state, siteId ) ) {
-		return getSiteOption( state, siteId, 'unmapped_url' ).replace( /^https?:\/\//, '' );
+		return withoutHttp( getSiteOption( state, siteId, 'unmapped_url' ) );
 	}
 
-	return site.URL.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+	return withoutHttp( site.URL ).replace( /\//g, '::' );
 }
 
 /**
@@ -212,7 +212,7 @@ export function getSiteDomain( state, siteId ) {
 		return null;
 	}
 
-	return site.URL.replace( /^https?:\/\//, '' );
+	return withoutHttp( site.URL );
 }
 
 /**
@@ -338,7 +338,7 @@ export const getSeoTitleFormats = compose(
  * @return {?Object}       Site object
  */
 export function getSiteByUrl( state, url ) {
-	const slug = url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+	const slug = withoutHttp( url ).replace( /\//g, '::' );
 	const site = find( state.sites.items, ( item, siteId ) => {
 		return getSiteSlug( state, siteId ) === slug;
 	} );


### PR DESCRIPTION
I think it's a good addition to Calypso as I've seen .replace( /^https?:\/\//, '' ) on too many places.

cc @gwwar 

Test live: https://calypso.live/?branch=add/without-http-utility-fn