### PR TITLE
Ad Tracking: Wrap AdWords Tag Manager tracking call

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -133,10 +133,12 @@ function retarget() {
 		window.fbq( 'track', 'PageView' );
 
 		// AdWords
-		window.google_trackConversion( {
-			google_conversion_id: GOOGLE_CONVERSION_ID,
-			google_remarketing_only: true
-		} );
+		if ( window.google_trackConversion ) {
+			window.google_trackConversion( {
+				google_conversion_id: GOOGLE_CONVERSION_ID,
+				google_remarketing_only: true
+			} );
+		}
 	}
 }
 
@@ -211,20 +213,22 @@ function recordPurchase( product, orderId ) {
 	}
 
 	// record the purchase w/ Google
-	window.google_trackConversion( {
-		google_conversion_id: GOOGLE_CONVERSION_ID,
-		google_conversion_label: isJetpackPlan
-			? TRACKING_IDS.googleConversionLabelJetpack
-			: TRACKING_IDS.googleConversionLabel,
-		google_conversion_value: product.cost,
-		google_conversion_currency: product.currency,
-		google_custom_params: {
-			product_slug: product.product_slug,
-			user_id: userId,
-			order_id: orderId
-		},
-		google_remarketing_only: false
-	} );
+	if ( window.google_trackConversion ) {
+		window.google_trackConversion( {
+			google_conversion_id: GOOGLE_CONVERSION_ID,
+			google_conversion_label: isJetpackPlan
+				? TRACKING_IDS.googleConversionLabelJetpack
+				: TRACKING_IDS.googleConversionLabel,
+			google_conversion_value: product.cost,
+			google_conversion_currency: product.currency,
+			google_custom_params: {
+				product_slug: product.product_slug,
+				user_id: userId,
+				order_id: orderId
+			},
+			google_remarketing_only: false
+		} );
+	}
 }
 
 /**


### PR DESCRIPTION
This prevents the `window.google_trackConversion is not a function` error mentioned in #3484 and #7357 by wrapping that function in a conditional that checks whether it exists.

I'm not sure what the root cause of this is though. Blocking googleadservices.com either via /etc/hosts or via an ad blocker like Ghostery doesn't cause this because there is logic in the module that detects whether the script fails to load and if so, doesn't ever call the tracking function:

```
calypso:ad-tracking Some scripts failed to load:  +0ms Object {src: "https://www.googleadservices.com/pagead/conversion_async.js"}
```

However, rather than spend time investigating while users run into this issue, let's ship this patch and investigate later.

To test:

1. Set `ad-tracking` to `true` in `development.json`.
2. Add a `window.google_trackConversion = undefined` line before the function call in the ad tracking module's `retarget` method.
3. Load any page and verify that no errors are thrown.

Test live: https://calypso.live/?branch=fix/7357-google-retargeting-tag