### PR TITLE
First-view: Support startDate config parameter

### DIFF
--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -55,6 +55,21 @@ export function getCurrentUserCurrencyCode( state ) {
 }
 
 /**
+ * Returns the date (of registration) for the current user.
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {?String}        Date of registration for user
+ */
+export function getCurrentUserDate( state ) {
+	const user = getCurrentUser( state );
+	if ( ! user ) {
+		return null;
+	}
+
+	return user.date || null;
+}
+
+/**
  * Returns true if the capability name is valid for the current user on a given
  * site, false if capabilities are known for the site but the name is invalid,
  * or null if capabilities are not known for the site.

--- a/client/state/current-user/test/selectors.js
+++ b/client/state/current-user/test/selectors.js
@@ -10,6 +10,7 @@ import {
 	getCurrentUserId,
 	getCurrentUser,
 	getCurrentUserLocale,
+	getCurrentUserDate,
 	isValidCapability,
 	canCurrentUser,
 	getCurrentUserCurrencyCode
@@ -94,6 +95,53 @@ describe( 'selectors', () => {
 			} );
 
 			expect( locale ).to.equal( 'fr' );
+		} );
+	} );
+
+	describe( 'getCurrentUserDate()', () => {
+		it( 'should return the current user registration date', () => {
+			const currentUserDate = getCurrentUserDate( {
+				users: {
+					items: {
+						73705554: { ID: 73705554, login: 'testonesite2014', date: '2014-10-18T17:14:52+00:00' }
+					}
+				},
+				currentUser: {
+					id: 73705554
+				}
+			} );
+
+			expect( currentUserDate ).to.equal( '2014-10-18T17:14:52+00:00' );
+		} );
+
+		it( 'should return null if the registration date is missing', () => {
+			const currentUserDate = getCurrentUserDate( {
+				users: {
+					items: {
+						73705554: { ID: 73705554, login: 'testonesite2014' }
+					}
+				},
+				currentUser: {
+					id: 73705554
+				}
+			} );
+
+			expect( currentUserDate ).to.be.null;
+		} );
+
+		it( 'should return null if the user is missing', () => {
+			const currentUserDate = getCurrentUserDate( {
+				users: {
+					items: {
+						12345678: { ID: 12345678, login: 'testuser' }
+					}
+				},
+				currentUser: {
+					id: 73705554
+				}
+			} );
+
+			expect( currentUserDate ).to.be.null;
 		} );
 	} );
 

--- a/client/state/ui/first-view/constants.js
+++ b/client/state/ui/first-view/constants.js
@@ -9,6 +9,7 @@ export const FIRST_VIEW_CONFIG = [
 			'/stats',
 		],
 		enabled: true,
+		startDate: '2016-07-26',
 	},
 	{
 		name: 'pages-prototype',

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -16,7 +16,7 @@ import takeRightWhile from 'lodash/takeRightWhile';
 import { FIRST_VIEW_CONFIG } from './constants';
 import { getActionLog } from 'state/ui/action-log/selectors';
 import { getPreference, preferencesLastFetchedTimestamp } from 'state/preferences/selectors';
-import { isSectionLoading, getCurrentQueryArguments } from 'state/ui/selectors';
+import { isSectionLoading, getInitialQueryArguments } from 'state/ui/selectors';
 import { FIRST_VIEW_HIDE, ROUTE_SET } from 'state/action-types';
 import { getCurrentUserDate } from 'state/current-user/selectors';
 
@@ -45,7 +45,7 @@ export function isUserEligible( state, config ) {
 }
 
 export function isQueryStringEnabled( state, config ) {
-	const queryArguments = getCurrentQueryArguments( state );
+	const queryArguments = getInitialQueryArguments( state );
 	return queryArguments.firstView === config.name;
 }
 

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -23,7 +23,7 @@ import { getCurrentUserDate } from 'state/current-user/selectors';
 export function getConfigForCurrentView( state ) {
 	const currentRoute = last( filter( getActionLog( state ), { type: ROUTE_SET } ) );
 	const path = currentRoute.path ? currentRoute.path : '';
-	const config = FIRST_VIEW_CONFIG.filter( entry  => some( entry.paths, entryPath => startsWith( path, entryPath ) ) );
+	const config = FIRST_VIEW_CONFIG.filter( entry => some( entry.paths, entryPath => startsWith( path, entryPath ) ) );
 
 	return config.pop() || false;
 }

--- a/client/state/ui/first-view/test/selectors.js
+++ b/client/state/ui/first-view/test/selectors.js
@@ -30,7 +30,7 @@ describe( 'selectors', () => {
 						}
 					],
 					queryArguments: {
-						current: {},
+						initial: {},
 					},
 				}
 			} );
@@ -48,7 +48,7 @@ describe( 'selectors', () => {
 						}
 					],
 					queryArguments: {
-						current: {},
+						initial: {},
 					},
 				}
 			} );
@@ -76,7 +76,7 @@ describe( 'selectors', () => {
 		};
 
 		const queryArguments = {
-			current: {}
+			initial: {}
 		};
 
 		const config = {

--- a/client/state/ui/first-view/test/selectors.js
+++ b/client/state/ui/first-view/test/selectors.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	isUserEligible,
 	getConfigForCurrentView,
 	isViewEnabled,
 	wasFirstViewHiddenSinceEnteringCurrentSection,
@@ -17,6 +18,75 @@ import {
 	FIRST_VIEW_HIDE,
 	ROUTE_SET
 } from 'state/action-types';
+
+describe( 'isUserEligible()', () => {
+	it( 'makes all users eligible if no start date is defined in the config', () => {
+		const state = {
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2014', date: '2014-10-18T17:14:52+00:00' }
+				}
+			},
+			currentUser: {
+				id: 73705554
+			}
+		};
+		const eligible = isUserEligible( state, {} );
+
+		expect( eligible ).to.be.true;
+	} );
+
+	it( 'does not show the first view if the user does not have a start date', () => {
+		const state = {
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2014' }
+				}
+			},
+			currentUser: {
+				id: 73705554
+			}
+		};
+		const config = { name: 'stats', paths: [ '/stats' ], enabled: true, startDate: '2016-07-26' };
+		const eligible = isUserEligible( state, config );
+
+		expect( eligible ).to.be.false;
+	} );
+
+	it( 'shows the first view if the user registered after the first view start date', () => {
+		const state = {
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2014', date: '2016-07-27T17:14:52+00:00' }
+				}
+			},
+			currentUser: {
+				id: 73705554
+			}
+		};
+		const config = { name: 'stats', paths: [ '/stats' ], enabled: true, startDate: '2016-07-26' };
+		const eligible = isUserEligible( state, config );
+
+		expect( eligible ).to.be.true;
+	} );
+
+	it( 'does not show the first view if the user registered before the first view start date', () => {
+		const state = {
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2014', date: '2016-07-25T17:14:52+00:00' }
+				}
+			},
+			currentUser: {
+				id: 73705554
+			}
+		};
+		const config = { name: 'stats', paths: [ '/stats' ], enabled: true, startDate: '2016-07-26' };
+		const eligible = isUserEligible( state, config );
+
+		expect( eligible ).to.be.false;
+	} );
+} );
 
 describe( 'selectors', () => {
 	describe( '#getConfigForCurrentView()', () => {

--- a/client/state/ui/first-view/test/selectors.js
+++ b/client/state/ui/first-view/test/selectors.js
@@ -28,7 +28,10 @@ describe( 'selectors', () => {
 							type: ROUTE_SET,
 							path: '/devdocs',
 						}
-					]
+					],
+					queryArguments: {
+						current: {},
+					},
 				}
 			} );
 
@@ -43,11 +46,14 @@ describe( 'selectors', () => {
 							type: ROUTE_SET,
 							path: '/stats',
 						}
-					]
+					],
+					queryArguments: {
+						current: {},
+					},
 				}
 			} );
 
-			expect( firstViewConfig ).to.deep.equal( { name: 'stats', paths: [ '/stats' ], enabled: true } );
+			expect( firstViewConfig ).to.deep.equal( { name: 'stats', paths: [ '/stats' ], enabled: true, startDate: '2016-07-26' } );
 		} );
 	} );
 
@@ -59,6 +65,20 @@ describe( 'selectors', () => {
 			}
 		];
 
+		const currentUser = {
+			id: 73705554
+		};
+
+		const users = {
+			items: {
+				73705554: { ID: 73705554, login: 'testonesite2014', date: '2014-10-18T17:14:52+00:00' }
+			}
+		};
+
+		const queryArguments = {
+			current: {}
+		};
+
 		const config = {
 			name: 'stats',
 			paths: [ '/stats' ],
@@ -68,6 +88,8 @@ describe( 'selectors', () => {
 		it( 'should return true if the preferences have been fetched, the config has a first view for the current view,' +
 			' and it is not disabled', () => {
 			const viewEnabled = isViewEnabled( {
+				currentUser,
+				users,
 				preferences: {
 					values: {
 						firstViewHistory: [
@@ -82,6 +104,7 @@ describe( 'selectors', () => {
 				},
 				ui: {
 					actionLog: actions,
+					queryArguments,
 				}
 			}, config );
 
@@ -90,6 +113,8 @@ describe( 'selectors', () => {
 
 		it( 'should return true if preferences have been fetched and the history is empty', () => {
 			const viewEnabled = isViewEnabled( {
+				currentUser,
+				users,
 				preferences: {
 					values: {
 						firstViewHistory: []
@@ -98,6 +123,7 @@ describe( 'selectors', () => {
 				},
 				ui: {
 					actionLog: actions,
+					queryArguments,
 				}
 			}, config );
 
@@ -106,6 +132,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the view is disabled', () => {
 			const viewEnabled = isViewEnabled( {
+				currentUser,
+				users,
 				preferences: {
 					values: {
 						firstViewHistory: [
@@ -120,6 +148,7 @@ describe( 'selectors', () => {
 				},
 				ui: {
 					actionLog: actions,
+					queryArguments,
 				}
 			}, config );
 
@@ -128,6 +157,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the view is disabled in the config', () => {
 			const viewEnabled = isViewEnabled( {
+				currentUser,
+				users,
 				preferences: {
 					values: {
 						firstViewHistory: []
@@ -141,6 +172,7 @@ describe( 'selectors', () => {
 							path: '/devdocs',
 						}
 					],
+					queryArguments,
 				}
 			}, { name: 'devdocs', paths: [ '/devdocs' ], enabled: false } );
 
@@ -149,6 +181,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the preferences haven\'t been fetched', () => {
 			const viewEnabled = isViewEnabled( {
+				currentUser,
+				users,
 				preferences: {
 					values: {
 						firstViewHistory: []
@@ -157,6 +191,7 @@ describe( 'selectors', () => {
 				},
 				ui: {
 					actionLog: actions,
+					queryArguments,
 				}
 			}, config );
 


### PR DESCRIPTION
Existing users are already familiar with the Stats page, and it can be an annoyance for them to dismiss the First View layer.

In the AB test we can exclude existing users (those we registered before the AB test start date), but when we want to enable this feature permanently, we'll have to limit it to new users ourselves.

This PR adds a check so that only those users will see the First View layer who register after the deployment of the First Views outside the AB test.

Test plan:
* Checkout the branch & run locally
* Create a new user
* Visit `http://calypso.localhost:3000/stats`
* Make sure the First View is visible
* Use an existing user (registered prior to `2016-07-26`).
* Visit `http://calypso.localhost:3000/stats`
* Make sure the First View is *not* visible
* Visit `http://calypso.localhost:3000/stats?firstView=stats`
* Make sure the First View is visible
* Alter the date in `client/state/ui/first-view/constants.js` to be just before and just after your registration date -- make sure the First View works as intended.

![image](https://cloud.githubusercontent.com/assets/363749/17569310/439e88be-5f0d-11e6-8f67-f1fd5e39f317.png)


Test live: https://calypso.live/?branch=add/first-view/config/start-date