### PR TITLE
Jetpack Connect: Add disclaimer text with action button

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -43,6 +43,7 @@ import { isRequestingSites } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
 import { withoutHttp } from 'lib/url';
+import LoggedOutFormFooter from 'components/logged-out-form/footer';
 
 /**
  * Constants
@@ -345,6 +346,41 @@ const LoggedInForm = React.createClass( {
 		return this.translate( 'Approve' );
 	},
 
+	onClickDisclaimerLink() {
+		this.props.recordTracksEvent( 'calypso_jpc_disclaimer_link_click' );
+	},
+
+	getDisclaimerText() {
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const { blogname } = queryObject;
+
+		const detailsLink = (
+			<a
+				target="_blank"
+				onClick={ this.onClickDisclaimerLink }
+				href="https://jetpack.com/support/what-data-does-jetpack-sync/"
+				className="jetpack-connect__sso-actions-modal-link" />
+		);
+
+		const text = this.translate(
+			'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
+			{
+				components: {
+					detailsLink
+				},
+				args: {
+					siteName: decodeEntities( blogname )
+				}
+			}
+		);
+
+		return (
+			<p className="jetpack-connect__tos-link">
+				{ text }
+			</p>
+		);
+	},
+
 	getUserText() {
 		const { authorizeSuccess } = this.props.jetpackConnectAuthorize;
 		let text = this.translate( 'Connecting as {{strong}}%(user)s{{/strong}}', {
@@ -428,9 +464,13 @@ const LoggedInForm = React.createClass( {
 			);
 		}
 		return (
-			<Button primary disabled={ this.isAuthorizing() } onClick={ this.handleSubmit }>
-				{ this.getButtonText() }
-			</Button>
+			<LoggedOutFormFooter className="jetpack-connect__action-disclaimer">
+				{ this.getDisclaimerText() }
+				<Button primary disabled={ this.isAuthorizing() } onClick={ this.handleSubmit }>
+					{ this.getButtonText() }
+				</Button>
+			</LoggedOutFormFooter>
+
 		);
 	},
 


### PR DESCRIPTION
Before allowing a user to authorize their site, we should be sure that the user has a chance to learn what we sync about their site. This PR handles that by adding disclaimer text to the authorize form with a link to https://jetpack.com/support/what-data-does-jetpack-sync/.

![screen shot 2016-08-10 at 12 13 38 pm](https://cloud.githubusercontent.com/assets/1126811/17564616/932ae2ba-5ef9-11e6-8670-eecd92cdbea9.png)

cc @roccotripaldi for code review.
cc @kevko @rickybanister for wording and design review

Test live: https://calypso.live/?branch=update/jetpack-connect-authorize-what-we-sync