### PR TITLE
Remove free trial abtests

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -32,23 +32,6 @@ module.exports = {
 		},
 		defaultVariation: 'namegen'
 	},
-	freeTrialNudgeOnThankYouPage: {
-		datestamp: '20200328',
-		variations: {
-			disabled: 50,
-			enabled: 50
-		},
-		defaultVariation: 'disabled'
-	},
-	freeTrialsInSignup: {
-		datestamp: '20200328',
-		variations: {
-			disabled: 40,
-			enabled: 15,
-			notTested: 45
-		},
-		defaultVariation: 'disabled'
-	},
 	multiDomainRegistrationV1: {
 		datestamp: '20200721',
 		variations: {


### PR DESCRIPTION
Fixes #7279. Removes both `freeTrialsInSignup` and `freeTrialNudgeOnThankYouPage` abtests from `lib/abtest/active-tests` as they are not running/useful anymore.

## Testing Instructions

1. Go through signup/NUX flow and check for any issues

cc @drewblaisdell @rralian 

Test live: https://calypso.live/?branch=remove/free-trial-abtests