### PR TITLE
Advanced SEO: Fix Facebook Preview Styles

### DIFF
--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -12,8 +12,8 @@ import {
 	shortEnough
 } from '../helpers';
 
-const TITLE_LENGTH = 40;
-const DESCRIPTION_LENGTH = 300;
+const TITLE_LENGTH = 80;
+const DESCRIPTION_LENGTH = 270;
 
 const baseDomain = url =>
 	url

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -81,7 +81,6 @@
 
 .facebook-preview__content {
 	display: flex;
-	flex-shrink: 0;
 }
 
 .facebook-preview__body {
@@ -97,7 +96,6 @@
 	font-weight: 500;
 	line-height: 22px;
 	max-height: 100px;
-	max-width: 345px;
 	transition: color 0.1s ease-in-out;
 }
 
@@ -106,8 +104,8 @@
 	font-family: helvetica, arial, sans-serif;
 	font-size: 12px;
 	line-height: 16px;
-	max-height: 80px;
-	max-width: 345px;
+	max-height: 50px;
+	overflow-y: hidden;
 }
 
 .facebook-preview__url {


### PR DESCRIPTION
Fixes up the line lengths and styles for the Facebook preview to look better when a post has 3 lines or more of text content.

Before:
<img width="558" alt="screen shot 2016-08-10 at 2 41 54 pm" src="https://cloud.githubusercontent.com/assets/789137/17572577/298b4c3a-5f0a-11e6-9ddc-138a8f30ae71.png">

After:
<img width="546" alt="screen shot 2016-08-10 at 2 43 48 pm" src="https://cloud.githubusercontent.com/assets/789137/17572580/2f0867ec-5f0a-11e6-968f-05a27cefba97.png">

Fixes #7341

Test live: https://calypso.live/?branch=fix/7341-seo-facebook-preview-styles