### PR TITLE
CPT: Add term query support to PostQueryManager

### DIFF
--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
-import every from 'lodash/every';
-import some from 'lodash/some';
-import includes from 'lodash/includes';
-import get from 'lodash/get';
+import { every, some, includes, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -49,6 +46,12 @@ export default class PostQueryManager extends PaginatedQueryManager {
 					const field = /^modified_/.test( key ) ? 'modified' : 'date';
 					return queryDate.isValid() && moment( post[ field ] )[ comparison ]( queryDate );
 				}
+
+				case 'term':
+					return every( value, ( slugs, taxonomy ) => {
+						slugs = slugs.split( ',' );
+						return some( post.terms[ taxonomy ], ( { slug } ) => includes( slugs, slug ) );
+					} );
 
 				case 'tag':
 				case 'category': {

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -47,6 +47,34 @@ const DEFAULT_POST = {
 			slug: 'categorized'
 		}
 	},
+	terms: {
+		post_tag: {
+			Tagged: {
+				ID: 17695,
+				name: 'Tagged!',
+				slug: 'tagged'
+			}
+		},
+		category: {
+			'Categorized!': {
+				ID: 5519,
+				name: 'Categorized!',
+				slug: 'categorized'
+			}
+		},
+		genre: {
+			Fiction: {
+				ID: 5102,
+				name: 'Fiction',
+				slug: 'fiction'
+			},
+			'Sci-Fi': {
+				ID: 5102,
+				name: 'Sci-Fi',
+				slug: 'sci-fi'
+			}
+		}
+	},
 	metadata: [
 		{
 			id: '22573',
@@ -295,6 +323,59 @@ describe( 'PostQueryManager', () => {
 			it( 'should search case-insensitive', () => {
 				const isMatch = manager.matches( {
 					category: 'caTegoriZed'
+				}, DEFAULT_POST );
+
+				expect( isMatch ).to.be.true;
+			} );
+		} );
+
+		context( 'query.term', () => {
+			it( 'should return false if post does not include term', () => {
+				const isMatch = manager.matches( {
+					term: {
+						genre: 'non-fiction'
+					}
+				}, DEFAULT_POST );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return false if one but not both term slug queries match', () => {
+				const isMatch = manager.matches( {
+					term: {
+						genre: 'fiction',
+						category: 'notcategory'
+					}
+				}, DEFAULT_POST );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true if post includes term by slug', () => {
+				const isMatch = manager.matches( {
+					term: {
+						genre: 'fiction'
+					}
+				}, DEFAULT_POST );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true if post includes one of comma-separated term slugs', () => {
+				const isMatch = manager.matches( {
+					term: {
+						genre: 'fiction,non-fiction'
+					}
+				}, DEFAULT_POST );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true if post includes both of comma-separated term slugs', () => {
+				const isMatch = manager.matches( {
+					term: {
+						genre: 'fiction,sci-fi'
+					}
 				}, DEFAULT_POST );
 
 				expect( isMatch ).to.be.true;


### PR DESCRIPTION
This pull request seeks to enhance the `PostQueryManager` query capabilities to cover the newly added `term` query parameter.

https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/

__Testing instructions:__

This query option is not yet used anywhere in Calypso, so simply ensure that Mocha tests pass:

```
npm run test-client client/lib/query-manager
```

Test live: https://calypso.live/?branch=update/post-query-manager-query-term