### PR TITLE
Advanced SEO: Add Author to Facebook Preview Footer

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -118,6 +118,7 @@ const FacebookPost = ( site, post ) => (
 		type="article"
 		description={ formatExcerpt( post.excerpt || post.content ) }
 		image={ getPostImage( post ) }
+		author={ post.author.name }
 	/>
 );
 

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -5,6 +5,7 @@
  */
 import React, { PropTypes } from 'react';
 import PureComponent from 'react-pure-render/component';
+import compact from 'lodash/compact'
 
 import {
 	firstValid,
@@ -29,9 +30,6 @@ const facebookDescription = firstValid(
 	shortEnough( DESCRIPTION_LENGTH ),
 	hardTruncation( DESCRIPTION_LENGTH )
 );
-
-const authorInfo = author =>
-	author ? ` | ${ author }` : '';
 
 export class FacebookPreview extends PureComponent {
 	render() {
@@ -58,7 +56,7 @@ export class FacebookPreview extends PureComponent {
 							{ facebookDescription( description || '' ) }
 						</div>
 						<div className="facebook-preview__url">
-							{ baseDomain( url ) + authorInfo( author ) }
+							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }
 						</div>
 					</div>
 				</div>

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -30,6 +30,9 @@ const facebookDescription = firstValid(
 	hardTruncation( DESCRIPTION_LENGTH )
 );
 
+const authorInfo = author =>
+	author ? ` | ${ author }` : '';
+
 export class FacebookPreview extends PureComponent {
 	render() {
 		const {
@@ -37,7 +40,8 @@ export class FacebookPreview extends PureComponent {
 			type,
 			title,
 			description,
-			image
+			image,
+			author
 		} = this.props;
 
 		return (
@@ -54,7 +58,7 @@ export class FacebookPreview extends PureComponent {
 							{ facebookDescription( description || '' ) }
 						</div>
 						<div className="facebook-preview__url">
-							{ baseDomain( url ) }
+							{ baseDomain( url ) + authorInfo( author ) }
 						</div>
 					</div>
 				</div>
@@ -69,6 +73,7 @@ FacebookPreview.propTypes = {
 	title: PropTypes.string,
 	description: PropTypes.string,
 	image: PropTypes.string,
+	author: PropTypes.string
 };
 
 export default FacebookPreview;


### PR DESCRIPTION
Pass the author name to the Facebook preview to display it in the footer:

<img width="546" alt="screen shot 2016-08-10 at 4 29 25 pm" src="https://cloud.githubusercontent.com/assets/789137/17574619/a1500726-5f17-11e6-8c0b-a02c34127a13.png">

cc @dmsnell 

Fixes #7395

Test live: https://calypso.live/?branch=fix/7395-seo-facebook-preview-author