### PR TITLE
Editor: Hide CPT accordions if Jetpack unsupported version

### DIFF
--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -88,6 +88,7 @@ EditorDrawerTaxonomies.propTypes = {
 	translate: PropTypes.func,
 	siteId: PropTypes.number,
 	postType: PropTypes.string,
+	isSupported: PropTypes.bool,
 	terms: PropTypes.oneOfType( [
 		PropTypes.object,
 		PropTypes.array

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -15,6 +15,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostTypeTaxonomies } from 'state/post-types/taxonomies/selectors';
+import { isJetpackMinimumVersion } from 'state/sites/selectors';
 import Accordion from 'components/accordion';
 import Gridicon from 'components/gridicon';
 import TermTokenField from 'post-editor/term-token-field';
@@ -32,7 +33,11 @@ function isSkippedTaxonomy( postType, taxonomy ) {
 	return false;
 }
 
-function EditorDrawerTaxonomies( { translate, siteId, postType, taxonomies, terms } ) {
+function EditorDrawerTaxonomies( { translate, siteId, postType, isSupported, taxonomies, terms } ) {
+	if ( ! isSupported ) {
+		return null;
+	}
+
 	return (
 		<div className="editor-drawer__taxonomies">
 			{ siteId && postType && (
@@ -94,10 +99,12 @@ export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );
+	const isSupported = false !== isJetpackMinimumVersion( state, siteId, '4.1.0' );
 
 	return {
 		siteId,
 		postType,
+		isSupported,
 		terms: getEditedPostValue( state, siteId, postId, 'terms' ),
 		taxonomies: getPostTypeTaxonomies( state, siteId, postType )
 	};


### PR DESCRIPTION
Closes #6105 
Related: #7247 (cc @timmyc we'll need similar checks)
Related: Automattic/jetpack#4128

This pull request seeks to add a version guard for Jetpack versions which do not support custom taxonomies REST API endpoints, hiding the custom taxonomy accordions in the editor if support does not exist.

__Testing instructions:__

You should verify that WordPress.com sites, sites running Jetpack 4.1+, and sites running Jetpack 4.0.x display taxonomy accordions dependent upon their ability to support the custom taxonomy endpoints.

1. Navigate to the [post editor for Portfolio](http://calypso.localhost:3000/edit/jetpack-portfolio) (assumes Portfolio Custom Content Types has been enabled)
2. Select a site
3. Note that...
 - If a WordPress.com site or a Jetpack site running 4.1 and newer, the Portfolio Types and Portfolio Tags accordions are shown in the sidebar
 - If a Jetpack site running 4.0.x ([4.0.3 download](https://downloads.wordpress.org/plugin/jetpack.4.0.3.zip)), the Portfolio Types and Portfolio Tags accordions are not shown in the sidebar, but you can still manage and save the post

Test live: https://calypso.live/?branch=update/editor-hide-cpt-unsupported