### PR TITLE
changed like button tag from button to anchor

### DIFF
--- a/client/blocks/like-button/docs/example.jsx
+++ b/client/blocks/like-button/docs/example.jsx
@@ -47,13 +47,13 @@ const LikeButtons = React.createClass( {
 		return (
 			<div>
 				<Card compact>
-					<SimpleLikeButtonContainer tagName="button" likeCount={ 0 } />
+					<SimpleLikeButtonContainer tagName="a" likeCount={ 0 } />
 				</Card>
 				<Card compact>
-					<SimpleLikeButtonContainer tagName="button" likeCount={ 12 } />
+					<SimpleLikeButtonContainer tagName="a" likeCount={ 12 } />
 				</Card>
 				<Card compact>
-					<SimpleLikeButtonContainer tagName="button" likeCount={ 12 } liked={ true } />
+					<SimpleLikeButtonContainer tagName="a" likeCount={ 12 } liked={ true } />
 				</Card>
 			</div>
 		);


### PR DESCRIPTION
This fixes #7257. The problem is that flex doesn't work for button elements in firefox as discussed here: https://bugzilla.mozilla.org/show_bug.cgi?id=984869

The solution I found was to change the elements tag from button to anchor.