### PR TITLE
Site settings: remove typo causing a warning

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -258,7 +258,7 @@ const FormGeneral = React.createClass( {
 
 				<FormLabel>
 					<FormRadio
-						name="blog_public"Ï
+						name="blog_public"
 						value="0"
 						checked={ 0 === parseInt( this.state.blog_public, 10 ) }
 						onChange={ this.handleRadio }


### PR DESCRIPTION
Fix warning when viewing site settings caused by errant char.
```
warning.js:44 Warning: Unknown prop `Ï` on <input> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in input (created by FormRadio)
    in FormRadio (created by SiteSettingsFormGeneral)
    in label (created by FormLabel)
    in FormLabel (created by SiteSettingsFormGeneral)
    in fieldset (created by FormFieldset)
    in FormFieldset (created by SiteSettingsFormGeneral)
    in form (created by SiteSettingsFormGeneral)
    in div (created by Card)
    in Card (created by SiteSettingsFormGeneral)
    in div (created by SiteSettingsFormGeneral)
    in SiteSettingsFormGeneral (created by SiteSettingsGeneral)
    in div (created by SiteSettingsGeneral)
    in SiteSettingsGeneral (created by SiteSettingsComponent)
    in div (created by SiteSettingsComponent)
    in section (created by SiteSettingsComponent)
    in SiteSettingsComponent (created by Connect(SiteSettingsComponent))
    in Connect(SiteSettingsComponent)
    in Provider
```
introduced in f2134eb6e712000650ad87b896a0aa8fac410416

Test live: https://calypso.live/?branch=fix/typo-blog-settings