### PR TITLE
Plans: Update Jetpack monthly/yearly plans toggle

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -602,3 +602,14 @@ export function getPlanClass( plan ) {
 			return '';
 	}
 }
+
+export function getMonthlyPlanByYearly( plan ) {
+	switch ( plan ) {
+		case PLAN_JETPACK_PREMIUM:
+			return PLAN_JETPACK_PREMIUM_MONTHLY;
+		case PLAN_JETPACK_BUSINESS:
+			return PLAN_JETPACK_BUSINESS_MONTHLY;
+		default:
+			return '';
+	}
+}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -40,8 +40,7 @@ class PlanFeaturesHeader extends Component {
 			popular,
 			title,
 			isPlaceholder,
-			translate,
-			intervalType
+			translate
 		} = this.props;
 		const isDiscounted = !! discountPrice;
 		const timeframeClasses = classNames( 'plan-features__header-timeframe', {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -87,25 +87,32 @@ class PlanFeaturesHeader extends Component {
 		const {
 			translate,
 			intervalType,
-			site
+			site,
+			isInJetpackConnect
 		} = this.props;
 
 		if ( ! site.jetpack ) {
 			return '';
 		}
 
+		let plansUrl = '';
+		if ( isInJetpackConnect ) {
+			plansUrl = '/jetpack/connect';
+		}
+		plansUrl += '/plans';
+
 		return (
 			<SegmentedControl className="plan-features__interval-type" primary={ true }>
 				<SegmentedControlItem
 					selected={ intervalType === 'monthly' }
-					path={ plansLink( '/plans', site, 'monthly' ) }
+					path={ plansLink( plansUrl, site, 'monthly' ) }
 				>
 					{ translate( 'Monthly' ) }
 				</SegmentedControlItem>
 
 				<SegmentedControlItem
 					selected={ intervalType === 'yearly' }
-					path={ plansLink( '/plans', site, 'yearly' ) }
+					path={ plansLink( plansUrl, site, 'yearly' ) }
 				>
 					{ translate( 'Yearly' ) }
 				</SegmentedControlItem>
@@ -165,7 +172,8 @@ PlanFeaturesHeader.propTypes = {
 	isPlaceholder: PropTypes.bool,
 	translate: PropTypes.func,
 	intervalType: PropTypes.string,
-	site: PropTypes.object
+	site: PropTypes.object,
+	isInJetpackConnect: PropTypes.bool
 };
 
 PlanFeaturesHeader.defaultProps = {
@@ -174,7 +182,8 @@ PlanFeaturesHeader.defaultProps = {
 	popular: false,
 	isPlaceholder: false,
 	intervalType: 'yearly',
-	site: {}
+	site: {},
+	isInJetpackConnect: false
 };
 
 export default localize( PlanFeaturesHeader );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -33,20 +33,12 @@ class PlanFeaturesHeader extends Component {
 
 	render() {
 		const {
-			billingTimeFrame,
 			current,
-			discountPrice,
 			planType,
 			popular,
 			title,
-			isPlaceholder,
 			translate
 		} = this.props;
-		const isDiscounted = !! discountPrice;
-		const timeframeClasses = classNames( 'plan-features__header-timeframe', {
-			'is-discounted': isDiscounted,
-			'is-placeholder': isPlaceholder
-		} );
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 
 		return (
@@ -61,13 +53,34 @@ class PlanFeaturesHeader extends Component {
 				<div className="plan-features__header-text">
 					<h4 className="plan-features__header-title">{ title }</h4>
 					{ this.getPlanFeaturesPrices() }
-					<p className={ timeframeClasses } >
-						{ ! isPlaceholder ? billingTimeFrame : '' }
-					</p>
-					{ this.getIntervalTypeToggle() }
+					{ this.getBillingTimeframe() }
 				</div>
 			</header>
 		);
+	}
+
+	getBillingTimeframe() {
+		const {
+			billingTimeFrame,
+			discountPrice,
+			isPlaceholder,
+			site
+		} = this.props;
+		const isDiscounted = !! discountPrice;
+		const timeframeClasses = classNames( 'plan-features__header-timeframe', {
+			'is-discounted': isDiscounted,
+			'is-placeholder': isPlaceholder
+		} );
+
+		if ( ! site.jetpack ) {
+			return (
+				<p className={ timeframeClasses } >
+					{ ! isPlaceholder ? billingTimeFrame : '' }
+				</p>
+			);
+		} else {
+			return this.getIntervalTypeToggle();
+		}
 	}
 
 	getIntervalTypeToggle() {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -86,6 +86,7 @@ class PlanFeaturesHeader extends Component {
 	getIntervalTypeToggle() {
 		const {
 			translate,
+			rawPrice,
 			intervalType,
 			site,
 			isInJetpackConnect
@@ -93,6 +94,13 @@ class PlanFeaturesHeader extends Component {
 
 		if ( ! site.jetpack ) {
 			return '';
+		}
+
+		if ( ! rawPrice ) {
+			return (
+				<div className="plan-features__interval-type is-placeholder">
+				</div>
+			);
 		}
 
 		let plansUrl = '';

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -28,6 +29,8 @@ import PlanIcon from 'components/plans/plan-icon';
 import { plansLink } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
 
 class PlanFeaturesHeader extends Component {
 
@@ -96,7 +99,7 @@ class PlanFeaturesHeader extends Component {
 			return '';
 		}
 
-		if ( ! rawPrice ) {
+		if ( ! rawPrice || this.isPlanCurrent() ) {
 			return (
 				<div className="plan-features__interval-type is-placeholder">
 				</div>
@@ -126,6 +129,20 @@ class PlanFeaturesHeader extends Component {
 				</SegmentedControlItem>
 			</SegmentedControl>
 		);
+	}
+
+	isPlanCurrent() {
+		const {
+			planType,
+			current,
+			currentSitePlan
+		} = this.props;
+
+		if ( ! currentSitePlan ) {
+			return current;
+		}
+
+		return getPlanClass( planType ) === getPlanClass( currentSitePlan.productSlug );
 	}
 
 	getPlanFeaturesPrices() {
@@ -181,7 +198,8 @@ PlanFeaturesHeader.propTypes = {
 	translate: PropTypes.func,
 	intervalType: PropTypes.string,
 	site: PropTypes.object,
-	isInJetpackConnect: PropTypes.bool
+	isInJetpackConnect: PropTypes.bool,
+	currentSitePlan: PropTypes.object
 };
 
 PlanFeaturesHeader.defaultProps = {
@@ -191,7 +209,17 @@ PlanFeaturesHeader.defaultProps = {
 	isPlaceholder: false,
 	intervalType: 'yearly',
 	site: {},
-	isInJetpackConnect: false
+	isInJetpackConnect: false,
+	currentSitePlan: {}
 };
 
-export default localize( PlanFeaturesHeader );
+export default connect( ( state, ownProps ) => {
+	const { isInSignup } = ownProps;
+	const selectedSiteId = isInSignup ? null : getSelectedSiteId( state );
+	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
+
+	return Object.assign( {},
+		ownProps,
+		{ currentSitePlan }
+	);
+} )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -25,6 +25,9 @@ import {
 	getPlanClass
 } from 'lib/plans/constants';
 import PlanIcon from 'components/plans/plan-icon';
+import { plansLink } from 'lib/plans';
+import SegmentedControl from 'components/segmented-control';
+import SegmentedControlItem from 'components/segmented-control/item';
 
 class PlanFeaturesHeader extends Component {
 
@@ -37,7 +40,8 @@ class PlanFeaturesHeader extends Component {
 			popular,
 			title,
 			isPlaceholder,
-			translate
+			translate,
+			intervalType
 		} = this.props;
 		const isDiscounted = !! discountPrice;
 		const timeframeClasses = classNames( 'plan-features__header-timeframe', {
@@ -61,8 +65,39 @@ class PlanFeaturesHeader extends Component {
 					<p className={ timeframeClasses } >
 						{ ! isPlaceholder ? billingTimeFrame : '' }
 					</p>
+					{ this.getIntervalTypeToggle() }
 				</div>
 			</header>
+		);
+	}
+
+	getIntervalTypeToggle() {
+		const {
+			translate,
+			intervalType,
+			site
+		} = this.props;
+
+		if ( ! site.jetpack ) {
+			return '';
+		}
+
+		return (
+			<SegmentedControl className="plan-features__interval-type" primary={ true }>
+				<SegmentedControlItem
+					selected={ intervalType === 'monthly' }
+					path={ plansLink( '/plans', site, 'monthly' ) }
+				>
+					{ translate( 'Monthly' ) }
+				</SegmentedControlItem>
+
+				<SegmentedControlItem
+					selected={ intervalType === 'yearly' }
+					path={ plansLink( '/plans', site, 'yearly' ) }
+				>
+					{ translate( 'Yearly' ) }
+				</SegmentedControlItem>
+			</SegmentedControl>
 		);
 	}
 
@@ -116,14 +151,18 @@ PlanFeaturesHeader.propTypes = {
 	currencyCode: PropTypes.string,
 	title: PropTypes.string.isRequired,
 	isPlaceholder: PropTypes.bool,
-	translate: PropTypes.func
+	translate: PropTypes.func,
+	intervalType: PropTypes.string,
+	site: PropTypes.object
 };
 
 PlanFeaturesHeader.defaultProps = {
 	current: false,
 	onClick: noop,
 	popular: false,
-	isPlaceholder: false
+	isPlaceholder: false,
+	intervalType: 'yearly',
+	site: {}
 };
 
 export default localize( PlanFeaturesHeader );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -78,9 +78,9 @@ class PlanFeaturesHeader extends Component {
 					{ ! isPlaceholder ? billingTimeFrame : '' }
 				</p>
 			);
-		} else {
-			return this.getIntervalTypeToggle();
 		}
+
+		return this.getIntervalTypeToggle();
 	}
 
 	getIntervalTypeToggle() {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -146,7 +146,8 @@ class PlanFeaturesHeader extends Component {
 			currencyCode,
 			discountPrice,
 			rawPrice,
-			isPlaceholder
+			isPlaceholder,
+			relatedMonthlyPlan
 		} = this.props;
 
 		if ( isPlaceholder ) {
@@ -160,6 +161,16 @@ class PlanFeaturesHeader extends Component {
 				<span className="plan-features__header-price-group">
 					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ rawPrice } original />
 					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ discountPrice } discounted />
+				</span>
+			);
+		}
+
+		if ( relatedMonthlyPlan ) {
+			const originalPrice = relatedMonthlyPlan.raw_price * 12;
+			return (
+				<span className="plan-features__header-price-group">
+					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ originalPrice } original />
+					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ rawPrice } discounted />
 				</span>
 			);
 		}
@@ -195,7 +206,8 @@ PlanFeaturesHeader.propTypes = {
 	intervalType: PropTypes.string,
 	site: PropTypes.object,
 	isInJetpackConnect: PropTypes.bool,
-	currentSitePlan: PropTypes.object
+	currentSitePlan: PropTypes.object,
+	relatedMonthlyPlan: PropTypes.object
 };
 
 PlanFeaturesHeader.defaultProps = {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -95,10 +95,6 @@ class PlanFeaturesHeader extends Component {
 			isInJetpackConnect
 		} = this.props;
 
-		if ( ! site.jetpack ) {
-			return '';
-		}
-
 		if ( ! rawPrice || this.isPlanCurrent() ) {
 			return (
 				<div className="plan-features__interval-type is-placeholder">

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -22,13 +22,15 @@ import { getPlanDiscountPrice } from 'state/sites/plans/selectors';
 import {
 	getPlanRawPrice,
 	getPlan,
-	getPlanSlug
+	getPlanSlug,
+	getPlanBySlug
 } from 'state/plans/selectors';
 import {
 	isPopular,
 	isMonthly,
 	getPlanFeaturesObject,
-	getPlanClass
+	getPlanClass,
+	getMonthlyPlanByYearly
 } from 'lib/plans/constants';
 import { isFreePlan } from 'lib/plans';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -104,7 +106,8 @@ class PlanFeatures extends Component {
 				planConstantObj,
 				planName,
 				popular,
-				rawPrice
+				rawPrice,
+				relatedMonthlyPlan
 			} = properties;
 
 			return (
@@ -122,6 +125,7 @@ class PlanFeatures extends Component {
 						intervalType={ intervalType }
 						site={ site }
 						isInJetpackConnect={ isInJetpackConnect }
+						relatedMonthlyPlan={ relatedMonthlyPlan }
 					/>
 					<p className="plan-features__description">
 						{ planConstantObj.getDescription() }
@@ -172,7 +176,8 @@ class PlanFeatures extends Component {
 				planConstantObj,
 				planName,
 				popular,
-				rawPrice
+				rawPrice,
+				relatedMonthlyPlan
 			} = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
 			return (
@@ -190,6 +195,7 @@ class PlanFeatures extends Component {
 						intervalType={ intervalType }
 						site={ site }
 						isInJetpackConnect={ isInJetpackConnect }
+						relatedMonthlyPlan={ relatedMonthlyPlan }
 					/>
 				</td>
 			);
@@ -393,6 +399,7 @@ export default connect(
 			const isLoadingSitePlans = ! isInSignup && ! sitePlans.hasLoadedFromServer;
 			const showMonthly = ! isMonthly( plan );
 			const available = isInSignup ? true : canUpgradeToPlan( plan );
+			const relatedMonthlyPlan = showMonthly ? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) ) : null;
 
 			if ( placeholder || ! planObject || isLoadingSitePlans ) {
 				isPlaceholder = true;
@@ -422,7 +429,8 @@ export default connect(
 				planName: plan,
 				planObject: planObject,
 				popular: isPopular( plan ) && ! isPaid,
-				rawPrice: getPlanRawPrice( state, planProductId, showMonthly )
+				rawPrice: getPlanRawPrice( state, planProductId, ! relatedMonthlyPlan && showMonthly ),
+				relatedMonthlyPlan: relatedMonthlyPlan
 			};
 		} );
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -77,7 +77,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderMobileView() {
-		const { isPlaceholder, translate, planProperties, isInSignup } = this.props;
+		const { isPlaceholder, translate, planProperties, isInSignup, intervalType, site } = this.props;
 
 		// move any free plan to last place in mobile view
 		let freePlanProperties;
@@ -119,6 +119,8 @@ class PlanFeatures extends Component {
 						discountPrice={ discountPrice }
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
 						isPlaceholder={ isPlaceholder }
+						intervalType={ intervalType }
+						site={ site }
 					/>
 					<p className="plan-features__description">
 						{ planConstantObj.getDescription() }
@@ -159,7 +161,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderPlanHeaders() {
-		const { planProperties, isPlaceholder } = this.props;
+		const { planProperties, isPlaceholder, intervalType, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -184,6 +186,8 @@ class PlanFeatures extends Component {
 						discountPrice={ discountPrice }
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
 						isPlaceholder={ isPlaceholder }
+						intervalType={ intervalType }
+						site={ site }
 					/>
 				</td>
 			);
@@ -359,12 +363,16 @@ PlanFeatures.propTypes = {
 	planProperties: PropTypes.array,
 	isPlaceholder: PropTypes.bool,
 	isInSignup: PropTypes.bool,
-	selectedFeature: PropTypes.string
+	selectedFeature: PropTypes.string,
+	intervalType: PropTypes.string,
+	site: PropTypes.object
 };
 
 PlanFeatures.defaultProps = {
 	onUpgradeClick: noop,
-	isInSignup: false
+	isInSignup: false,
+	intervalType: 'yearly',
+	site: {}
 };
 
 export default connect(

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -77,7 +77,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderMobileView() {
-		const { isPlaceholder, translate, planProperties, isInSignup, intervalType, site } = this.props;
+		const { isPlaceholder, translate, planProperties, isInSignup, intervalType, site, isInJetpackConnect } = this.props;
 
 		// move any free plan to last place in mobile view
 		let freePlanProperties;
@@ -121,6 +121,7 @@ class PlanFeatures extends Component {
 						isPlaceholder={ isPlaceholder }
 						intervalType={ intervalType }
 						site={ site }
+						isInJetpackConnect={ isInJetpackConnect }
 					/>
 					<p className="plan-features__description">
 						{ planConstantObj.getDescription() }
@@ -161,7 +162,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderPlanHeaders() {
-		const { planProperties, isPlaceholder, intervalType, site } = this.props;
+		const { planProperties, isPlaceholder, intervalType, site, isInJetpackConnect } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -188,6 +189,7 @@ class PlanFeatures extends Component {
 						isPlaceholder={ isPlaceholder }
 						intervalType={ intervalType }
 						site={ site }
+						isInJetpackConnect={ isInJetpackConnect }
 					/>
 				</td>
 			);
@@ -363,6 +365,7 @@ PlanFeatures.propTypes = {
 	planProperties: PropTypes.array,
 	isPlaceholder: PropTypes.bool,
 	isInSignup: PropTypes.bool,
+	isInJetpackConnect: PropTypes.bool,
 	selectedFeature: PropTypes.string,
 	intervalType: PropTypes.string,
 	site: PropTypes.object
@@ -371,6 +374,7 @@ PlanFeatures.propTypes = {
 PlanFeatures.defaultProps = {
 	onUpgradeClick: noop,
 	isInSignup: false,
+	isInJetpackConnect: false,
 	intervalType: 'yearly',
 	site: {}
 };

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -333,6 +333,14 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__interval-type {
 	margin-bottom: 1.4em;
+
+	&.is-placeholder {
+		height: 36px;
+
+		@include breakpoint( "<660px" ) {
+			height: auto;
+		}
+	}
 }
 
 .plan-features__header-banner {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -331,6 +331,10 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
+.plan-features__interval-type {
+	margin-bottom: 1.4em;
+}
+
 .plan-features__header-banner {
 	box-sizing: border-box;
 	position: absolute;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -37,6 +37,7 @@ class PlansFeaturesMain extends Component {
 			onUpgradeClick,
 			hideFreePlan,
 			isInSignup,
+			isInJetpackConnect,
 			selectedFeature
 		} = this.props;
 
@@ -54,6 +55,7 @@ class PlansFeaturesMain extends Component {
 						selectedFeature={ selectedFeature }
 						onUpgradeClick={ onUpgradeClick }
 						isInSignup={ isInSignup }
+						isInJetpackConnect={ isInJetpackConnect }
 						intervalType={ intervalType }
 						site={ site }
 					/>
@@ -73,6 +75,7 @@ class PlansFeaturesMain extends Component {
 						selectedFeature={ selectedFeature }
 						onUpgradeClick={ onUpgradeClick }
 						isInSignup={ isInSignup }
+						isInJetpackConnect={ isInJetpackConnect }
 						intervalType={ intervalType }
 						site={ site }
 					/>
@@ -96,6 +99,7 @@ class PlansFeaturesMain extends Component {
 					plans={ plans }
 					onUpgradeClick={ onUpgradeClick }
 					isInSignup={ isInSignup }
+					isInJetpackConnect={ isInJetpackConnect }
 					selectedFeature={ selectedFeature }
 					intervalType={ intervalType }
 					site={ site }
@@ -302,6 +306,7 @@ class PlansFeaturesMain extends Component {
 PlansFeaturesMain.PropTypes = {
 	site: PropTypes.object,
 	isInSignup: PropTypes.bool,
+	isInJetpackConnect: PropTypes.bool,
 	intervalType: PropTypes.string,
 	onUpgradeClick: PropTypes.func,
 	hideFreePlan: PropTypes.bool,
@@ -310,6 +315,7 @@ PlansFeaturesMain.PropTypes = {
 };
 
 PlansFeaturesMain.defaultProps = {
+	isInJetpackConnect: false,
 	intervalType: 'yearly',
 	hideFreePlan: false,
 	site: {},

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -54,6 +54,8 @@ class PlansFeaturesMain extends Component {
 						selectedFeature={ selectedFeature }
 						onUpgradeClick={ onUpgradeClick }
 						isInSignup={ isInSignup }
+						intervalType={ intervalType }
+						site={ site }
 					/>
 				</div>
 			);
@@ -71,6 +73,8 @@ class PlansFeaturesMain extends Component {
 						selectedFeature={ selectedFeature }
 						onUpgradeClick={ onUpgradeClick }
 						isInSignup={ isInSignup }
+						intervalType={ intervalType }
+						site={ site }
 					/>
 				</div>
 			);
@@ -93,6 +97,8 @@ class PlansFeaturesMain extends Component {
 					onUpgradeClick={ onUpgradeClick }
 					isInSignup={ isInSignup }
 					selectedFeature={ selectedFeature }
+					intervalType={ intervalType }
+					site={ site }
 				/>
 			</div>
 		);
@@ -304,6 +310,7 @@ PlansFeaturesMain.PropTypes = {
 };
 
 PlansFeaturesMain.defaultProps = {
+	intervalType: 'yearly',
 	hideFreePlan: false,
 	site: {},
 	showFAQ: true

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -36,6 +36,12 @@ const Plans = React.createClass( {
 		sitePlans: React.PropTypes.object.isRequired
 	},
 
+	getDefaultProps() {
+		return {
+			intervalType: 'yearly'
+		};
+	},
+
 	showMonthlyPlansLink() {
 		const selectedSite = this.props.sites.getSelectedSite();
 		if ( ! selectedSite.jetpack ) {
@@ -104,6 +110,7 @@ const Plans = React.createClass( {
 							intervalType={ this.props.intervalType }
 							hideFreePlan={ true }
 							selectedFeature={ this.props.selectedFeature }
+							intervalType={ this.props.intervalType }
 						/>
 					</div>
 				</Main>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -3,7 +3,6 @@
  */
 import { connect } from 'react-redux';
 import React from 'react';
-import find from 'lodash/find';
 
 /**
  * Internal dependencies
@@ -11,16 +10,13 @@ import find from 'lodash/find';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getPlans } from 'state/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import observe from 'lib/mixins/data-observe';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
-import { plansLink } from 'lib/plans';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { PLAN_MONTHLY_PERIOD } from 'lib/plans/constants';
 
 const Plans = React.createClass( {
 	mixins: [ observe( 'sites' ) ],

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -9,11 +9,9 @@ import find from 'lodash/find';
  * Internal dependencies
  */
 import { getPlansBySite } from 'state/sites/plans/selectors';
-import { getCurrentPlan } from 'lib/plans';
 import { getPlans } from 'state/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Gridicon from 'components/gridicon';
-import { isJpphpBundle } from 'lib/products-values';
 import Main from 'components/main';
 import observe from 'lib/mixins/data-observe';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
@@ -42,51 +40,9 @@ const Plans = React.createClass( {
 		};
 	},
 
-	showMonthlyPlansLink() {
-		const selectedSite = this.props.sites.getSelectedSite();
-		if ( ! selectedSite.jetpack ) {
-			return '';
-		}
-
-		let intervalType = this.props.intervalType,
-			showString = '';
-		const hasMonthlyPlans = find( this.props.sitePlans.data, { interval: PLAN_MONTHLY_PERIOD } );
-
-		if ( hasMonthlyPlans === undefined ) {
-			//No monthly plan found for this site so no need for a monthly plans link
-			return '';
-		}
-
-		if ( 'monthly' === intervalType ) {
-			intervalType = '';
-			showString = this.translate( 'Show Yearly Plans' );
-		} else {
-			intervalType = 'monthly';
-			showString = this.translate( 'Show Monthly Plans' );
-		}
-
-		return (
-			<a
-				href={ plansLink( '/plans', selectedSite, intervalType ) }
-				className="show-monthly-plans-link"
-			>
-				<Gridicon icon="refresh" size={ 18 } />
-				{ showString }
-			</a>
-		);
-	},
-
 	render() {
 		const selectedSite = this.props.sites.getSelectedSite(),
 			siteId = this.props.siteId;
-
-		let	hasJpphpBundle,
-			currentPlan;
-
-		if ( this.props.sitePlans.hasLoadedFromServer ) {
-			currentPlan = getCurrentPlan( this.props.sitePlans.data );
-			hasJpphpBundle = isJpphpBundle( currentPlan );
-		}
 
 		return (
 			<div>
@@ -100,8 +56,6 @@ const Plans = React.createClass( {
 							cart={ this.props.cart }
 							selectedSite={ selectedSite } />
 
-						{ ! hasJpphpBundle && this.showMonthlyPlansLink() }
-
 						<QueryPlans />
 						<QuerySitePlans siteId={ siteId } />
 
@@ -110,7 +64,6 @@ const Plans = React.createClass( {
 							intervalType={ this.props.intervalType }
 							hideFreePlan={ true }
 							selectedFeature={ this.props.selectedFeature }
-							intervalType={ this.props.intervalType }
 						/>
 					</div>
 				</Main>

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -54,6 +54,12 @@ module.exports = function() {
 			sitesController.siteSelection,
 			jetpackConnectController.plansLanding
 		);
+
+		page(
+			'/jetpack/connect/plans/:intervalType?/:site',
+			sitesController.siteSelection,
+			jetpackConnectController.plansLanding
+		);
 	}
 
 	if ( config.isEnabled( 'jetpack/sso' ) ) {

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -201,7 +201,8 @@ export default {
 				<Plans
 					sites={ sites }
 					context={ context }
-					destinationType={ context.params.destinationType } />
+					destinationType={ context.params.destinationType }
+					intervalType={ context.params.intervalType } />
 			</CheckoutData>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -37,7 +37,14 @@ const Plans = React.createClass( {
 		destinationType: React.PropTypes.string,
 		sites: React.PropTypes.object.isRequired,
 		sitePlans: React.PropTypes.object.isRequired,
-		showJetpackFreePlan: React.PropTypes.bool
+		showJetpackFreePlan: React.PropTypes.bool,
+		intervalType: React.PropTypes.string
+	},
+
+	getDefaultProps() {
+		return {
+			intervalType: 'yearly'
+		};
 	},
 
 	componentDidMount() {
@@ -150,8 +157,9 @@ const Plans = React.createClass( {
 							<PlansFeaturesMain
 								site={ selectedSite }
 								isInSignup={ true }
+								isInJetpackConnect={ true }
 								onUpgradeClick={ this.selectPlan }
-								intervalType="yearly" />
+								intervalType={ this.props.intervalType } />
 						</div>
 					</div>
 				</Main>


### PR DESCRIPTION
## Purpose
This PR updates the Jetpack Plans monthly/yearly plans toggle to use a segmented control within each plan card instead of having just one button toggle at the top of all plans. Applies to the plans in the Jetpack Connect flow, too. Intentionally, it does not apply to the WordPress.com plans. Further discussion and design guidelines can be found here: https://github.com/Automattic/wp-calypso/issues/6301

## Summary of changes
Here is a summary of the changes this PR introduces:
* Remove the old monthly/yearly toggle that was displayed above the plans
* Implement a new monthly/yearly toggle as a segmented control in each plan card
* Remove the billing timeframe `per month, billed yearly` in favor of the new toggle
* Add support for the monthly plans and the toggle in the Jetpack Connect plans page
* Hide the new toggle and display an empty placeholder instead in any of the following cases:
  * On a free plan (or any other plan that costs $0)
  * On the current plan

## Previews (before & after)

### Main Jetpack Plans page - while on a Free plan

**Before**
![](https://cldup.com/U6owfDQknP.png)

**After**
![](https://cldup.com/g_6hhvbRG2.png)

### Jetpack Connect Plans page

**Before**
![](https://cldup.com/KQct5bSYWB.png)

**After**
![](https://cldup.com/zhbXGgvRRn.png)

### Main Jetpack Plans page - while on a Premium plan

**Before**
![](https://cldup.com/KOaw0UMDlx.png)

**After**
![](https://cldup.com/tSt8eGrEBG.png)

## Testing instructions

* Checkout this branch - `update/jetpack-plans-interval-type-toggle`
* Test the steps below in all of the following cases:
  * In `/plans/` with a Jetpack site that is on a **Free** plan
  * In `/plans/` with a Jetpack site that is on a **Premium** or **Professional** plan
  * In `/jetpack/connect/plans/`
* Verify the old monthly/yearly toggle is not there anymore, as well as the old billing timeframe text.
* Verify the new monthly toggle is there both in Jetpack Connect plans and the main Plans page.
* Verify the new monthly toggle properly switches through the monthly and yearly view, and that is properly reflected in the URL, the prices and the toggle current state itself.
* Verify the new monthly toggle is hidden on the **Free** plan card.
* Verify the new monthly toggle is hidden for the current plan (if there is such).
* Verify that none of these changes have been applied to the WordPress.com plans pages.

Test live: https://calypso.live/?branch=update/jetpack-plans-interval-type-toggle