### PR TITLE
GuidedTours: Fix step positioning on resize or scroll

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -5,6 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import {
+	debounce,
 	find,
 	mapValues,
 	omit,
@@ -21,6 +22,7 @@ import {
 	posToCss,
 	getStepPosition,
 	getValidatedArrowPosition,
+	query,
 	targetForSlug
 } from './positioning';
 
@@ -103,10 +105,26 @@ export class Step extends Component {
 
 	componentWillMount() {
 		this.skipIfInvalidContext( this.props, this.context );
+		this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || global.window;
+		this.setStepPosition( this.props );
+	}
+
+	componentDidMount() {
+		global.window.addEventListener( 'resize', this.onScrollOrResize );
 	}
 
 	componentWillReceiveProps( nextProps, nextContext ) {
 		this.skipIfInvalidContext( nextProps, nextContext );
+		this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
+		this.scrollContainer = query( nextProps.scrollContainer )[ 0 ] || global.window;
+		this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
+		const shouldScrollTo = nextProps.shouldScrollTo && ( this.props.name !== nextProps.name );
+		this.setStepPosition( nextProps, shouldScrollTo );
+	}
+
+	componentWillUnmount() {
+		global.window.removeEventListener( 'resize', this.onScrollOrResize );
+		this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
 	}
 
 	skipIfInvalidContext( props, context ) {
@@ -116,6 +134,17 @@ export class Step extends Component {
 		}
 	}
 
+	onScrollOrResize = debounce( () => {
+		this.setStepPosition( this.props );
+	}, 50 )
+
+	setStepPosition( props, shouldScrollTo ) {
+		const { placement, target } = props;
+		const stepPos = getStepPosition( { placement, targetSlug: target, shouldScrollTo } );
+		const stepCoords = posToCss( stepPos );
+		this.setState( { stepPos, stepCoords } );
+	}
+
 	render() {
 		const { when, children } = this.props;
 
@@ -123,9 +152,8 @@ export class Step extends Component {
 			return null;
 		}
 
-		const { arrow, placement, target: targetSlug } = this.props;
-		const stepPos = getStepPosition( { placement, targetSlug } );
-		const stepCoords = posToCss( stepPos );
+		const { arrow, target: targetSlug } = this.props;
+		const { stepCoords, stepPos } = this.state;
 
 		const classes = [
 			this.props.className,
@@ -185,7 +213,8 @@ export class Quit extends Component {
 		super( props, context );
 	}
 
-	onClick = () => {
+	onClick = ( event ) => {
+		this.props.onClick && this.props.onClick( event );
 		this.context.quit();
 	}
 

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
 import AllTours from 'layout/guided-tours/config';
 import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
-import scrollTo from 'lib/scroll-to';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { getScrollableSidebar } from './positioning';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
@@ -33,10 +32,6 @@ class GuidedTours extends Component {
 	}
 
 	quit = ( options = {} ) => {
-		// TODO: put into step specific callback?
-		const sidebar = getScrollableSidebar();
-		scrollTo( { y: 0, container: sidebar } );
-
 		this.props.quitGuidedTour( Object.assign( {
 			stepName: this.props.tourState.stepName,
 			tour: this.props.tourState.tour,

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -19,7 +19,12 @@ import {
 	previewIsNotShowing,
 	previewIsShowing,
 } from 'state/ui/guided-tours/contexts';
+import { getScrollableSidebar } from 'layout/guided-tours/positioning';
 import Gridicon from 'components/gridicon';
+import scrollTo from 'lib/scroll-to';
+
+const scrollSidebarToTop = () =>
+	scrollTo( { y: 0, container: getScrollableSidebar() } );
 
 export const MainTour = makeTour(
 	<Tour name="main" version="20160601" path="/" when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }>
@@ -169,6 +174,7 @@ export const MainTour = makeTour(
 			when={ selectedSiteIsCustomizable }
 			scrollContainer=".sidebar__region"
 			next="finish"
+			shouldScrollTo
 		>
 			<p className="guided-tours__step-text">
 				{
@@ -201,7 +207,9 @@ export const MainTour = makeTour(
 				}
 			</p>
 			<div className="guided-tours__single-button-row">
-				<Quit primary>{ translate( "We're all done!" ) }</Quit>
+				<Quit onClick={ scrollSidebarToTop } primary>
+					{ translate( "We're all done!" ) }
+				</Quit>
 			</div>
 			<Link href="https://lean.wordpress.com">
 				{ translate( 'Learn more about WordPress.com' ) }

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -122,9 +122,9 @@ export function getValidatedArrowPosition( { targetSlug, arrow, stepPos } ) {
 	return arrow || 'none';
 }
 
-export function getStepPosition( { placement = 'center', targetSlug } ) {
+export function getStepPosition( { placement = 'center', targetSlug, shouldScrollTo = false } ) {
 	const target = targetForSlug( targetSlug );
-	const scrollDiff = scrollIntoView( target );
+	const scrollDiff = shouldScrollTo ? scrollIntoView( target ) : 0;
 	const rect = target && target.getBoundingClientRect
 		? target.getBoundingClientRect()
 		: global.window.document.body.getBoundingClientRect();
@@ -158,10 +158,6 @@ function validatePlacement( placement, target ) {
 
 function scrollIntoView( target ) {
 	const targetSlug = target && target.dataset && target.dataset.tipTarget;
-
-	if ( targetSlug !== 'themes' ) {
-		return 0;
-	}
 
 	const container = getScrollableSidebar();
 	const { top, bottom } = target.getBoundingClientRect();


### PR DESCRIPTION
- Handle scroll and resize events, setting updated positioning for steps
- Allow steps to specify `scrollContainer` to listen on
- Allow `shouldScrollTo` prop on `Step`, which enables auto-scrolling to a target
- Add `onClick` prop to `Next`, which in the `MainTour` scrolls the sidebar to the top

Test live: https://calypso.live/?branch=fix/guided-tours-scroll-resize-positioning