### PR TITLE
JPC: Add missing selector tests

### DIFF
--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isCalypsoStartedConnection, getFlowType } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '#isCalypsoStartedConnection()', () => {
+		it( 'should return true if the user have started a session in calypso less than an hour ago', () => {
+			const state = {
+				jetpackConnectSessions: {
+					sitetest: {
+						timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
+						flowType: ''
+					}
+				}
+			};
+			expect( isCalypsoStartedConnection( state.jetpackConnectSessions, 'sitetest' ) ).to.be.true;
+		} );
+		it( 'should return false if the user haven\'t started a session in calypso  ', () => {
+			const state = {
+				jetpackConnectSessions: {
+					sitetest: {}
+				}
+			};
+			expect( isCalypsoStartedConnection( state.jetpackConnectSessions, 'sitetest' ) ).to.be.false;
+		} );
+
+		it( 'should return false if the user started a session in calypso more than an hour ago', () => {
+			const state = {
+				jetpackConnectSessions: {
+					sitetest: {
+						timestamp: new Date( Date.now() - 60 * 60 * 1000 ).getTime(),
+						flow: ''
+					}
+				}
+			};
+			expect( isCalypsoStartedConnection( state.jetpackConnectSessions, 'sitetest' ) ).to.be.false;
+		} );
+	} );
+	describe( '#getFlowType()', () => {
+		it( 'should return the flow of the session for a site', () => {
+			const state = {
+				jetpackConnectSessions: {
+					sitetest: {
+						timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
+						flowType: 'pro'
+					}
+				}
+			};
+			expect( getFlowType( state.jetpackConnectSessions, { slug: 'sitetest' } ) ).to.eql( 'pro' );
+		} );
+
+		it( 'should return the false if there\'s no session for a site', () => {
+			const state = {
+				jetpackConnectSessions: {}
+			};
+			expect( getFlowType( state.jetpackConnectSessions, { slug: 'sitetest' } ) ).to.be.false;
+		} );
+	} );
+} );
+


### PR DESCRIPTION
Well, what title says. This PR adds a bunch of tests that we were missing in the JPC redux state.

How to test
=========
1. Go to you command line, navigate to calypso folder, and run `npm run test-client -- --grep "state jetpack-connect"`. All the tests should be green

![image](https://cloud.githubusercontent.com/assets/1554855/17592350/4790e892-5fe2-11e6-8c85-894e6b07f374.png)


/cc @roccotripaldi  @tyxla 


Test live: https://calypso.live/?branch=add/jpc-selector-tests