### PR TITLE
Plans: class should be className

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -280,7 +280,7 @@ class PlansFeaturesMain extends Component {
 				: this.getFAQ( site );
 
 		return (
-			<div class="plans-features-main">
+			<div className="plans-features-main">
 				{ this.getPlanFeatures() }
 
 				{


### PR DESCRIPTION
As @aduth pointed out, we have a typo on the `plans-features-main` component. This PR updates the reserved `class` property to be `className` 
![64b0be54-5fc7-11e6-9372-8b26b883cfb1](https://cloud.githubusercontent.com/assets/1270189/17595993/4ad77022-5fa4-11e6-8e97-4a9d9ea8d4dc.jpg)

cc @lamosty @rralian @artpi 


Test live: https://calypso.live/?branch=update/fix-classname