### PR TITLE
Components: Resolve DOM prop warnings on FormTextInput

### DIFF
--- a/client/components/forms/form-text-input/README.md
+++ b/client/components/forms/form-text-input/README.md
@@ -1,0 +1,43 @@
+Form Text Input
+===============
+
+`<FormTextInput />` is a React component suited for rendering an `<input />` field enhanced with Calypso-specific styling and validity indicators.
+
+## Usage
+
+Render as you would an `<input />` element. Any props passed not included in the props documentation below will be applied to the rendered `<input />` element.
+
+```jsx
+export default function MyForm() {
+	return <FormTextInput isValid initialValue="Hello World!" />;	
+}
+```
+
+## Props
+
+### `isError`
+
+<table>
+	<tr><td>Type</td><td>Boolean</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Whether the input should be rendered with error styling.
+
+### `isValid`
+
+<table>
+	<tr><td>Type</td><td>Boolean</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Whether the input should be rendered with valid (success) styling.
+
+### `selectOnFocus`
+
+<table>
+	<tr><td>Type</td><td>Boolean</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Whether the value should be selected when the input is focused.

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -1,47 +1,48 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import { omit } from 'lodash';
 
-export default React.createClass( {
+export default class FormTextInput extends PureComponent {
+	static propTypes = {
+		isError: PropTypes.bool,
+		isValid: PropTypes.bool,
+		selectOnFocus: PropTypes.bool,
+		className: PropTypes.string
+	};
 
-	displayName: 'FormTextInput',
+	constructor() {
+		super( ...arguments );
 
-	getDefaultProps() {
-		return {
-			isError: false,
-			isValid: false,
-			selectOnFocus: false,
-			type: 'text'
-		};
-	},
+		this.selectOnFocus = this.selectOnFocus.bind( this );
+	}
 
 	focus() {
 		this.refs.textField.focus();
-	},
+	}
+
+	selectOnFocus( event ) {
+		if ( this.props.selectOnFocus ) {
+			event.target.select();
+		}
+	}
 
 	render() {
-		const { className, selectOnFocus } = this.props;
 		const props = omit( this.props, 'isError', 'isValid', 'selectOnFocus' );
-		const classes = classNames( className, {
-			'form-text-input': true,
+		const classes = classNames( 'form-text-input', this.props.className, {
 			'is-error': this.props.isError,
 			'is-valid': this.props.isValid
 		} );
 
 		return (
 			<input
+				type="text"
 				{ ...props }
 				ref="textField"
 				className={ classes }
-				onClick={ selectOnFocus ? this.selectOnFocus : null } />
+				onClick={ this.selectOnFocus } />
 		);
-	},
-
-	selectOnFocus( event ) {
-		event.target.select();
 	}
-
-} );
+}

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import { omit } from 'lodash';
 
 export default React.createClass( {
 
@@ -23,6 +24,7 @@ export default React.createClass( {
 
 	render() {
 		const { className, selectOnFocus } = this.props;
+		const props = omit( this.props, 'isError', 'isValid', 'selectOnFocus' );
 		const classes = classNames( className, {
 			'form-text-input': true,
 			'is-error': this.props.isError,
@@ -31,7 +33,7 @@ export default React.createClass( {
 
 		return (
 			<input
-				{ ...this.props }
+				{ ...props }
 				ref="textField"
 				className={ classes }
 				onClick={ selectOnFocus ? this.selectOnFocus : null } />


### PR DESCRIPTION
This pull request seeks to refactor the `<FormTextInput />` component to resolve DOM prop warnings which occur due to unconstrained spread prop passing of validity props. It also includes general refactoring of the component to a `PureComponent` class, removing redundant props and adding documentation. To this end, it may be easier to review the commits separately to isolate the DOM props warning fix.

__Testing instructions:__

Verify that there are no regressions in using the `<FormTextInput />` component. Notably, review:

- [DevDocs Form Fields variants](http://calypso.localhost:3000/devdocs/design/form-fields) to ensure styling is still applied, including validity styles
- Confirm `focus` via parent component `ref` is unaffected. Type `su` on any screen to open support user login, and press Enter while the "Username" field is focused to verify that focus changes to the password field.
- Confirm `selectOnFocus` is unaffected. Visit the [DevDocs Clipboard Button Input demo](http://calypso.localhost:3000/devdocs/design/clipboard-button-input) and verify that clicking on the input selects the text.

Test live: https://calypso.live/?branch=fix/form-text-input-dom-props