### PR TITLE
Editor: use EditorDrawerLabel where applicable

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -22,7 +22,6 @@ import Location from 'post-editor/editor-location';
 import Discussion from 'post-editor/editor-discussion';
 import SeoAccordion from 'post-editor/editor-seo-accordion';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
-import InfoPopover from 'components/info-popover';
 import PostMetadata from 'lib/post-metadata';
 import TrackInputChanges from 'components/track-input-changes';
 import actions from 'lib/posts/actions';
@@ -39,6 +38,7 @@ import config from 'config';
 import EditorDrawerFeaturedImage from './featured-image';
 import EditorDrawerTaxonomies from './taxonomies';
 import EditorDrawerPageOptions from './page-options';
+import EditorDrawerLabel from './label';
 
 /**
  * Constants
@@ -180,7 +180,7 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderExcerpt: function() {
-		var excerpt;
+		let excerpt;
 
 		if ( ! this.currentPostTypeSupports( 'excerpt' ) ) {
 			return;
@@ -192,12 +192,9 @@ const EditorDrawer = React.createClass( {
 
 		return (
 			<AccordionSection>
-				<span className="editor-drawer__label-text">
+				<EditorDrawerLabel helpText={ this.translate( 'Excerpts are optional hand-crafted summaries of your content.' ) }>
 					{ this.translate( 'Excerpt' ) }
-					<InfoPopover position="top left">
-						{ this.translate( 'Excerpts are optional hand-crafted summaries of your content.' ) }
-					</InfoPopover>
-				</span>
+				</EditorDrawerLabel>
 				<TrackInputChanges onNewValue={ this.recordExcerptChangeStats }>
 					<FormTextarea
 						id="excerpt"
@@ -223,7 +220,7 @@ const EditorDrawer = React.createClass( {
 
 		return (
 			<AccordionSection>
-				<span className="editor-drawer__label-text">{ this.translate( 'Location' ) }</span>
+				<EditorDrawerLabel>{ this.translate( 'Location' ) }</EditorDrawerLabel>
 				<Location coordinates={ PostMetadata.geoCoordinates( this.props.post ) } />
 			</AccordionSection>
 		);
@@ -234,7 +231,7 @@ const EditorDrawer = React.createClass( {
 			return;
 		}
 
-		return(
+		return (
 			<AccordionSection>
 				<Discussion
 					site={ this.props.site }
@@ -298,7 +295,7 @@ const EditorDrawer = React.createClass( {
 	},
 
 	render: function() {
-		const { site, type } = this.props;
+		const { site } = this.props;
 
 		return (
 			<div className="editor-drawer">

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -192,19 +192,21 @@ const EditorDrawer = React.createClass( {
 
 		return (
 			<AccordionSection>
-				<EditorDrawerLabel helpText={ this.translate( 'Excerpts are optional hand-crafted summaries of your content.' ) }>
-					{ this.translate( 'Excerpt' ) }
+				<EditorDrawerLabel
+					labelText={ this.translate( 'Excerpt' ) }
+					helpText={ this.translate( 'Excerpts are optional hand-crafted summaries of your content.' ) }
+				>
+					<TrackInputChanges onNewValue={ this.recordExcerptChangeStats }>
+						<FormTextarea
+							id="excerpt"
+							name="excerpt"
+							onChange={ this.onExcerptChange }
+							value={ excerpt }
+							placeholder={ this.translate( 'Write an excerpt…' ) }
+							aria-label={ this.translate( 'Write an excerpt…' ) }
+						/>
+					</TrackInputChanges>
 				</EditorDrawerLabel>
-				<TrackInputChanges onNewValue={ this.recordExcerptChangeStats }>
-					<FormTextarea
-						id="excerpt"
-						name="excerpt"
-						onChange={ this.onExcerptChange }
-						value={ excerpt }
-						placeholder={ this.translate( 'Write an excerpt…' ) }
-						aria-label={ this.translate( 'Write an excerpt…' ) }
-					/>
-				</TrackInputChanges>
 			</AccordionSection>
 		);
 	},
@@ -220,7 +222,7 @@ const EditorDrawer = React.createClass( {
 
 		return (
 			<AccordionSection>
-				<EditorDrawerLabel>{ this.translate( 'Location' ) }</EditorDrawerLabel>
+				<EditorDrawerLabel labelText={ this.translate( 'Location' ) } />
 				<Location coordinates={ PostMetadata.geoCoordinates( this.props.post ) } />
 			</AccordionSection>
 		);

--- a/client/post-editor/editor-drawer/label.jsx
+++ b/client/post-editor/editor-drawer/label.jsx
@@ -3,16 +3,23 @@
  */
 import React, { PropTypes } from 'react';
 
-export default function EditorDrawerLabel( { children } ) {
+/**
+ * Internal dependencies
+ */
+import InfoPopover from 'components/info-popover';
+
+export default function EditorDrawerLabel( { children, helpText } ) {
 	return (
 		<label className="editor-drawer__label">
 			<span className="editor-drawer__label-text">
 				{ children }
+				{ helpText && <InfoPopover position="top left">{ helpText }</InfoPopover> }
 			</span>
 		</label>
 	);
 }
 
 EditorDrawerLabel.propTypes = {
-	children: PropTypes.node
+	children: PropTypes.node,
+	helpText: PropTypes.object
 };

--- a/client/post-editor/editor-drawer/label.jsx
+++ b/client/post-editor/editor-drawer/label.jsx
@@ -8,12 +8,13 @@ import React, { PropTypes } from 'react';
  */
 import InfoPopover from 'components/info-popover';
 
-export default function EditorDrawerLabel( { children, helpText } ) {
+export default function EditorDrawerLabel( { children, labelText, helpText } ) {
 	return (
 		<label className="editor-drawer__label">
 			<span className="editor-drawer__label-text">
-				{ children }
+				{ labelText }
 				{ helpText && <InfoPopover position="top left">{ helpText }</InfoPopover> }
+				{ children }
 			</span>
 		</label>
 	);
@@ -21,5 +22,6 @@ export default function EditorDrawerLabel( { children, helpText } ) {
 
 EditorDrawerLabel.propTypes = {
 	children: PropTypes.node,
-	helpText: PropTypes.object
+	helpText: PropTypes.string,
+	labelText: PropTypes.string
 };

--- a/client/post-editor/editor-drawer/label.jsx
+++ b/client/post-editor/editor-drawer/label.jsx
@@ -14,8 +14,8 @@ export default function EditorDrawerLabel( { children, labelText, helpText } ) {
 			<span className="editor-drawer__label-text">
 				{ labelText }
 				{ helpText && <InfoPopover position="top left">{ helpText }</InfoPopover> }
-				{ children }
 			</span>
+			{ children }
 		</label>
 	);
 }

--- a/client/post-editor/editor-more-options/slug.jsx
+++ b/client/post-editor/editor-more-options/slug.jsx
@@ -1,45 +1,40 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PropTypes, PureComponent } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 import AccordionSection from 'components/accordion/section';
-import InfoPopover from 'components/info-popover';
 import Slug from 'post-editor/editor-slug';
 
-export default React.createClass( {
-	displayName: 'EditorMoreOptionsSlug',
-
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
+class EditorMoreOptionsSlug extends PureComponent {
+	static propTypes = {
 		slug: PropTypes.string,
-		type: PropTypes.string
-	},
+		type: PropTypes.string,
+		translate: PropTypes.func
+	};
 
 	getPopoverLabel() {
+		const { translate } = this.props;
 		if ( 'page' === this.props.type ) {
-			return this.translate( 'The slug is the URL-friendly version of the page title.' );
+			return translate( 'The slug is the URL-friendly version of the page title.' );
 		}
 
-		return this.translate( 'The slug is the URL-friendly version of the post title.' );
-	},
+		return translate( 'The slug is the URL-friendly version of the post title.' );
+	}
 
 	render() {
-		const { slug, type } = this.props;
+		const { slug, type, translate } = this.props;
 
 		return (
 			<AccordionSection className="editor-more-options__slug">
-				<div className="editor-drawer__label-text">
-					{ this.translate( 'Slug' ) }
-					<InfoPopover position="top left">
-						{ this.getPopoverLabel() }
-					</InfoPopover>
-				</div>
+				<EditorDrawerLabel helpText={ this.getPopoverLabel() }>
+					{ translate( 'Slug' ) }
+				</EditorDrawerLabel>
 				<Slug
 					slug={ slug }
 					instanceName={ type + '-sidebar' }
@@ -47,4 +42,6 @@ export default React.createClass( {
 			</AccordionSection>
 		);
 	}
-} );
+}
+
+export default localize( EditorMoreOptionsSlug );

--- a/client/post-editor/editor-more-options/slug.jsx
+++ b/client/post-editor/editor-more-options/slug.jsx
@@ -32,13 +32,12 @@ class EditorMoreOptionsSlug extends PureComponent {
 
 		return (
 			<AccordionSection className="editor-more-options__slug">
-				<EditorDrawerLabel helpText={ this.getPopoverLabel() }>
-					{ translate( 'Slug' ) }
+				<EditorDrawerLabel labelText={ translate( 'Slug' ) } helpText={ this.getPopoverLabel() }>
+					<Slug
+						slug={ slug }
+						instanceName={ type + '-sidebar' }
+						className="editor-more-options__slug-field" />
 				</EditorDrawerLabel>
-				<Slug
-					slug={ slug }
-					instanceName={ type + '-sidebar' }
-					className="editor-more-options__slug-field" />
 			</AccordionSection>
 		);
 	}

--- a/client/post-editor/editor-page-templates/index.jsx
+++ b/client/post-editor/editor-page-templates/index.jsx
@@ -76,24 +76,23 @@ class EditorPageTemplates extends Component {
 				{ siteId && <QueryPageTemplates siteId={ siteId } /> }
 				{ size( templates ) > 1 && (
 					<AccordionSection>
-						<EditorDrawerLabel>
-							{ translate( 'Page Template' ) }
+						<EditorDrawerLabel labelText={ translate( 'Page Template' ) }>
+							<SelectDropdown selectedText={ this.getSelectedTemplateText() }>
+								{ map( templates, ( { file, label } ) => (
+									/* eslint-disable react/jsx-no-bind */
+									// jsx-no-bind disabled because while it's possible
+									// to extract this out into a separate component
+									// with its own click handler, that would severely
+									// harm the readability of this component.
+									<DropdownItem
+										key={ file }
+										selected={ file === template }
+										onClick={ () => this.selectTemplate( file ) }>
+										{ label }
+									</DropdownItem>
+								) ) }
+							</SelectDropdown>
 						</EditorDrawerLabel>
-						<SelectDropdown selectedText={ this.getSelectedTemplateText() }>
-							{ map( templates, ( { file, label } ) => (
-								/* eslint-disable react/jsx-no-bind */
-								// jsx-no-bind disabled because while it's possible
-								// to extract this out into a separate component
-								// with its own click handler, that would severely
-								// harm the readability of this component.
-								<DropdownItem
-									key={ file }
-									selected={ file === template }
-									onClick={ () => this.selectTemplate( file ) }>
-									{ label }
-								</DropdownItem>
-							) ) }
-						</SelectDropdown>
 					</AccordionSection>
 				) }
 			</div>

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -26,17 +26,18 @@ function EditorSeoAccordion( { translate, metaDescription = '' } ) {
 					helpText={ translate(
 						'Craft a description of your post for search engine results. ' +
 						'The post content is used by default.'
-					) }>
-					{ translate( 'Meta Description' ) }
+					) }
+					labelText={ translate( 'Meta Description' ) }
+				>
+					<CountedTextarea
+						maxLength="300"
+						acceptableLength={ 159 }
+						placeholder={ translate( 'Write a description…' ) }
+						aria-label={ translate( 'Write a description…' ) }
+						value={ metaDescription }
+						onChange={ onMetaChange }
+					/>
 				</EditorDrawerLabel>
-				<CountedTextarea
-					maxLength="300"
-					acceptableLength={ 159 }
-					placeholder={ translate( 'Write a description…' ) }
-					aria-label={ translate( 'Write a description…' ) }
-					value={ metaDescription }
-					onChange={ onMetaChange }
-				/>
 			</AccordionSection>
 		</Accordion>
 	);

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -11,8 +11,8 @@ import Accordion from 'components/accordion';
 import AccordionSection from 'components/accordion/section';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Gridicon from 'components/gridicon';
-import InfoPopover from 'components/info-popover';
 import PostActions from 'lib/posts/actions';
+import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 
 function EditorSeoAccordion( { translate, metaDescription = '' } ) {
 	return (
@@ -22,15 +22,13 @@ function EditorSeoAccordion( { translate, metaDescription = '' } ) {
 			className="editor-seo-accordion"
 		>
 			<AccordionSection>
-				<span className="editor-drawer__label-text">
+				<EditorDrawerLabel
+					helpText={ translate(
+						'Craft a description of your post for search engine results. ' +
+						'The post content is used by default.'
+					) }>
 					{ translate( 'Meta Description' ) }
-					<InfoPopover position="top left">
-						{ translate(
-							'Craft a description of your post for search engine results. ' +
-							'The post content is used by default.'
-						) }
-					</InfoPopover>
-				</span>
+				</EditorDrawerLabel>
 				<CountedTextarea
 					maxLength="300"
 					acceptableLength={ 159 }

--- a/client/post-editor/editor-tags/index.jsx
+++ b/client/post-editor/editor-tags/index.jsx
@@ -13,7 +13,7 @@ import TermsConstants from 'lib/terms/constants';
 import PostActions from 'lib/posts/actions';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import { isPage } from 'lib/posts/utils';
-import InfoPopover from 'components/info-popover';
+import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 
 const debug = _debug( 'calypso:post-editor:editor-tags' );
 
@@ -28,7 +28,7 @@ export default React.createClass( {
 	},
 
 	onTagsChange: function( selectedTags ) {
-		var tagStat, tagEventLabel;
+		let tagStat, tagEventLabel;
 
 		debug( 'onTagsChange', selectedTags );
 
@@ -63,20 +63,19 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		var tagNames = ( this.props.tags || [] ).map( function( tag ) {
+		const tagNames = ( this.props.tags || [] ).map( function( tag ) {
 			return tag.name;
 		} );
 
+		const helpText = isPage( this.props.post )
+			? this.translate( 'Use tags to associate more specific keywords with your pages.' )
+			: this.translate( 'Use tags to associate more specific keywords with your posts.' );
+
 		return (
-			<label className="editor-drawer__label">
-				<span className="editor-drawer__label-text">
+			<div>
+				<EditorDrawerLabel helpText={ helpText }>
 					{ this.translate( 'Tags' ) }
-					<InfoPopover position="top left">
-						{ isPage( this.props.post )
-							? this.translate( 'Use tags to associate more specific keywords with your pages.' )
-							: this.translate( 'Use tags to associate more specific keywords with your posts.' ) }
-					</InfoPopover>
-				</span>
+				</EditorDrawerLabel>
 				<TokenField
 					value={ this.getPostTags() }
 					displayTransform={ unescapeString }
@@ -84,7 +83,7 @@ export default React.createClass( {
 					onChange={ this.onTagsChange }
 					maxSuggestions={ TermsConstants.MAX_TAGS_SUGGESTIONS }
 				/>
-			</label>
+			</div>
 		);
 	}
 } );

--- a/client/post-editor/editor-tags/index.jsx
+++ b/client/post-editor/editor-tags/index.jsx
@@ -72,10 +72,7 @@ export default React.createClass( {
 			: this.translate( 'Use tags to associate more specific keywords with your posts.' );
 
 		return (
-			<div>
-				<EditorDrawerLabel helpText={ helpText }>
-					{ this.translate( 'Tags' ) }
-				</EditorDrawerLabel>
+			<EditorDrawerLabel helpText={ helpText } labelText={ this.translate( 'Tags' ) }>
 				<TokenField
 					value={ this.getPostTags() }
 					displayTransform={ unescapeString }
@@ -83,7 +80,7 @@ export default React.createClass( {
 					onChange={ this.onTagsChange }
 					maxSuggestions={ TermsConstants.MAX_TAGS_SUGGESTIONS }
 				/>
-			</div>
+			</EditorDrawerLabel>
 		);
 	}
 } );

--- a/client/post-editor/term-token-field/index.jsx
+++ b/client/post-editor/term-token-field/index.jsx
@@ -69,10 +69,7 @@ class TermTokenField extends React.Component {
 		const termNames = map( this.props.terms, 'name' );
 
 		return (
-			<div>
-				<EditorDrawerLabel>
-					{ this.props.taxonomyLabel }
-				</EditorDrawerLabel>
+			<EditorDrawerLabel labelText={ this.props.taxonomyLabel }>
 				<QueryTerms
 					siteId={ this.props.siteId }
 					taxonomy={ this.props.taxonomyName }
@@ -85,7 +82,7 @@ class TermTokenField extends React.Component {
 					onChange={ this.boundOnTermsChange }
 					maxSuggestions={ TermsConstants.MAX_TERMS_SUGGESTIONS }
 				/>
-			</div>
+			</EditorDrawerLabel>
 		);
 	}
 }

--- a/client/post-editor/term-token-field/index.jsx
+++ b/client/post-editor/term-token-field/index.jsx
@@ -20,6 +20,7 @@ import { decodeEntities } from 'lib/formatting';
 import TermsConstants from 'lib/terms/constants';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import QueryTerms from 'components/data/query-terms';
+import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 
 const debug = _debug( 'calypso:post-editor:editor-terms' );
 
@@ -68,10 +69,10 @@ class TermTokenField extends React.Component {
 		const termNames = map( this.props.terms, 'name' );
 
 		return (
-			<label className="editor-drawer__label">
-				<span className="editor-drawer__label-text">
+			<div>
+				<EditorDrawerLabel>
 					{ this.props.taxonomyLabel }
-				</span>
+				</EditorDrawerLabel>
 				<QueryTerms
 					siteId={ this.props.siteId }
 					taxonomy={ this.props.taxonomyName }
@@ -84,7 +85,7 @@ class TermTokenField extends React.Component {
 					onChange={ this.boundOnTermsChange }
 					maxSuggestions={ TermsConstants.MAX_TERMS_SUGGESTIONS }
 				/>
-			</label>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
This branch is a result of a [comment](https://github.com/Automattic/wp-calypso/pull/7247#discussion_r74303858) from @aduth on #7247.  Here a new prop of `helpText` is added to the `<EditorDrawerLabel />` to accommodate the frequent (i)nfo bubble that is shown next to labels in the editor sidebar.

Additionally, other components that were using the `.editor-drawer__label-text` have been updated to use the new `<EditorDrawerLabel />` component.  I also fixed up random linting warnings along the way, and did a bit of an overhaul to the `<EditorMoreOptionsSlug />`, because mixins and `createClass` are 🙈 

__To Test__
- Open up the editor and verify that the labels and info bubbles ( when shown ) still look correct for Excerpt, Location, More Options > Slug, Tags, and SEO Meta Description.  The last one requires you test on a site with a paid plan.
- Open up the editor for a CPT like Portfolio, and verify that the Post Tags label also looks good

Test live: https://calypso.live/?branch=update/editor/use-drawer-label