### PR TITLE
Enable Stats FirstView for all new users

### DIFF
--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -125,11 +125,9 @@ const FirstView = React.createClass( {
 
 export default connect(
 	( state ) => {
-		const participantInFirstViewAbTest = isEnabled( 'ui/first-view-ab-test' ) && abtest( 'firstView' ) === 'enabled';
-
 		return {
 			sectionName: getSectionName( state ),
-			isVisible: ( isEnabled( 'ui/first-view' ) || participantInFirstViewAbTest ) && shouldViewBeVisible( state ),
+			isVisible: isEnabled( 'ui/first-view' ) && shouldViewBeVisible( state ),
 		};
 	},
 	{

--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -16,7 +16,6 @@ import RootChild from 'components/root-child';
 import { getSectionName } from 'state/ui/selectors';
 import { shouldViewBeVisible } from 'state/ui/first-view/selectors';
 import { hideView } from 'state/ui/first-view/actions';
-import { abtest } from 'lib/abtest';
 import { isEnabled } from 'config';
 
 // component to avoid having a wrapper element for the transition

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -58,15 +58,6 @@ module.exports = {
 		},
 		defaultVariation: 'hideThemePreview',
 	},
-	firstView: {
-		datestamp: '20160726',
-		variations: {
-			disabled: 60,
-			enabled: 40,
-		},
-		defaultVariation: 'disabled',
-		allowExistingUsers: false,
-	},
 	readerSearchSuggestions: {
 		datestamp: '20160804',
 		variations: {

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,7 +86,7 @@
 		"settings/security/scan": false,
 		"support-user": true,
 		"sync-handler": true,
-		"ui/first-view": false,
+		"ui/first-view": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/in-app-purchase": false,

--- a/config/production.json
+++ b/config/production.json
@@ -84,7 +84,7 @@
 		"settings/security/monitor": true,
 		"support-user": true,
 		"sync-handler": true,
-		"ui/first-view-ab-test": true,
+		"ui/first-view": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
This PR removes the a/b test for the Stats FirstView and enables it for all new users.

Test plan (shamelessly lifted from #7387):

- Checkout the branch & run locally
- Create a new user
- Visit http://calypso.localhost:3000/stats
- Make sure the First View is visible
- Use an existing user (registered prior to 2016-07-26).
- Visit http://calypso.localhost:3000/stats
- Make sure the First View is not visible
- Visit http://calypso.localhost:3000/stats?firstView=stats
- Make sure the First View is visible
- Alter the date in client/state/ui/first-view/constants.js to be just before and just after your registration date -- make sure the First View works as intended.

Test live: https://calypso.live/?branch=update/enable-stats-fv-for-all