### PR TITLE
Advanced SEO: Display custom seo meta descriptions in Social Previews

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -82,7 +82,7 @@ const getSeoExcerptForSite = ( site ) => {
 	}
 
 	return formatExcerpt( find( [
-		site.options.seo_meta_description,
+		get( site, 'options.seo_meta_description' ),
 		site.description
 	], identity ) );
 };

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -10,7 +10,8 @@ import { localize } from 'i18n-calypso';
 import {
 	compact,
 	find,
-	get
+	get,
+	identity
 } from 'lodash';
 
 /**
@@ -21,6 +22,7 @@ import FacebookPreview from 'components/seo/facebook-preview';
 import TwitterPreview from 'components/seo/twitter-preview';
 import SearchPreview from 'components/seo/search-preview';
 import VerticalMenu from 'components/vertical-menu';
+import PostMetadata from 'lib/post-metadata';
 import { formatExcerpt } from 'lib/post-normalizer/rule-create-better-excerpt';
 import { parseHtml } from 'lib/formatting';
 import { SocialItem } from 'components/vertical-menu/items';
@@ -62,6 +64,29 @@ const getPostImage = ( post ) => {
 		: null;
 };
 
+const getSeoExcerptForPost = ( post ) => {
+	if ( ! post ) {
+		return null;
+	}
+
+	return formatExcerpt( find( [
+		PostMetadata.metaDescription( post ),
+		post.excerpt,
+		post.content
+	], identity ) );
+};
+
+const getSeoExcerptForSite = ( site ) => {
+	if ( ! site ) {
+		return null;
+	}
+
+	return formatExcerpt( find( [
+		site.options.seo_meta_description,
+		site.description
+	], identity ) );
+};
+
 const ComingSoonMessage = translate => (
 	<div className="seo-preview-pane__message">
 		{ translate( 'Coming Soon!' ) }
@@ -75,7 +100,7 @@ const ReaderPost = ( site, post ) => {
 			siteSlug={ site.slug }
 			siteIcon={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=32` }
 			postTitle={ post.title }
-			postExcerpt={ formatExcerpt( post.content ) }
+			postExcerpt={ formatExcerpt( post.excerpt || post.content ) }
 			postImage={ getPostImage( post ) }
 			postDate={ post.date }
 			authorName={ post.author.name }
@@ -85,11 +110,10 @@ const ReaderPost = ( site, post ) => {
  };
 
 const GoogleSite = site => (
-
 	<SearchPreview
 		title={ site.name }
 		url={ site.URL }
-		snippet={ formatExcerpt( site.description ) }
+		snippet={ getSeoExcerptForSite( site ) }
 	/>
 );
 
@@ -97,7 +121,7 @@ const GooglePost = ( site, post ) => (
 	<SearchPreview
 		title={ post.title }
 		url={ post.URL }
-		snippet={ formatExcerpt( post.excerpt || post.content ) }
+		snippet={ getSeoExcerptForPost( post ) }
 	/>
 );
 
@@ -106,7 +130,7 @@ const FacebookSite = site => (
 		title={ site.name }
 		url={ site.URL }
 		type="website"
-		description={ formatExcerpt( site.description ) }
+		description={ getSeoExcerptForSite( site ) }
 		image={ largeBlavatar( site ) }
 	/>
 );
@@ -116,7 +140,7 @@ const FacebookPost = ( site, post ) => (
 		title={ post.title }
 		url={ post.URL }
 		type="article"
-		description={ formatExcerpt( post.excerpt || post.content ) }
+		description={ getSeoExcerptForPost( post ) }
 		image={ getPostImage( post ) }
 		author={ post.author.name }
 	/>
@@ -127,7 +151,7 @@ const TwitterSite = site => (
 		title={ site.name }
 		url={ site.URL }
 		type="summary"
-		description={ formatExcerpt( site.description ) }
+		description={ getSeoExcerptForSite( site ) }
 		image={ largeBlavatar( site ) }
 	/>
 );
@@ -137,7 +161,7 @@ const TwitterPost = ( site, post ) => (
 		title={ post.title }
 		url={ post.URL }
 		type="large_image_summary"
-		description={ formatExcerpt( post.excerpt || post.content ) }
+		description={ getSeoExcerptForPost( post ) }
 		image={ getPostImage( post ) }
 	/>
 );

--- a/client/lib/post-metadata/index.js
+++ b/client/lib/post-metadata/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
Adds support for site and post custom meta descriptions in the social previews.

**To test**
*  View a site preview, it should display either the custom seo site description if it was set, or fall back to the site description.
* View a post preview, it should display the custom seo post description, or fallback to either the post excerpt or post content. Note: the Reader should not display the custom seo description.

I've also ran into `ssr` conflicts again... not sure if it's ok to have the `lib/post-metadata/` file marked as SSR ready?

cc @dmsnell 

<img width="876" alt="screen shot 2016-08-11 at 3 56 51 pm" src="https://cloud.githubusercontent.com/assets/789137/17607695/43dc526e-5fdc-11e6-9b3f-6fff6250bd0e.png">


Test live: https://calypso.live/?branch=update/seo-preview-seo-descriptions