### PR TITLE
GuidedTours: Update analytics methodology

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -9,6 +9,7 @@ import { defer } from 'lodash';
 /**
  * Internal dependencies
  */
+import { tracks } from 'lib/analytics';
 import AllTours from 'layout/guided-tours/config';
 import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
@@ -22,24 +23,52 @@ class GuidedTours extends Component {
 		return this.props.tourState !== nextProps.tourState;
 	}
 
-	next = ( tour, nextStepName ) => {
+	start = ( { tour, tourVersion: tour_version } ) => {
+		if ( tour && tour_version ) {
+			tracks.recordEvent( 'calypso_guided_tours_start', {
+				tour,
+				tour_version,
+			} );
+		}
+	}
+
+	next = ( { step, tour, tourVersion, nextStepName, skipping = false } ) => {
+		if ( ! skipping && step ) {
+			tracks.recordEvent( 'calypso_guided_tours_seen_step', {
+				tour,
+				step,
+				tour_version: tourVersion,
+			} );
+		}
+
 		defer( () => {
 			this.props.nextGuidedTourStep( {
+				tour,
 				stepName: nextStepName,
-				tour: tour,
 			} );
 		} );
 	}
 
-	quit = ( options = {} ) => {
-		this.props.quitGuidedTour( Object.assign( {
-			stepName: this.props.tourState.stepName,
-			tour: this.props.tourState.tour,
-		}, options ) );
-	}
+	quit = ( { step, tour, tourVersion: tour_version, isLastStep } ) => {
+		if ( step ) {
+			tracks.recordEvent( 'calypso_guided_tours_seen_step', {
+				tour,
+				step,
+				tour_version,
+			} );
+		}
 
-	finish = () => {
-		this.quit( { finished: true } );
+		tracks.recordEvent( `calypso_guided_tours_${ isLastStep ? 'finished' : 'quit' }`, {
+			step,
+			tour,
+			tour_version,
+		} );
+
+		this.props.quitGuidedTour( {
+			tour,
+			stepName: step,
+			finished: isLastStep,
+		} );
 	}
 
 	render() {
@@ -65,7 +94,8 @@ class GuidedTours extends Component {
 							lastAction={ this.props.lastAction }
 							isValid={ this.props.isValid }
 							next={ this.next }
-							quit={ this.quit } />
+							quit={ this.quit }
+							start={ this.start } />
 				</div>
 			</RootChild>
 		);

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -28,7 +28,7 @@ const scrollSidebarToTop = () =>
 
 export const MainTour = makeTour(
 	<Tour name="main" version="20160601" path="/" when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }>
-		<Step name="init" placement="right" next="my-sites" className="guided-tours__step-first">
+		<Step name="init" placement="right" className="guided-tours__step-first">
 			<p className="guided-tours__step-text">
 				{
 					translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place," +
@@ -50,7 +50,6 @@ export const MainTour = makeTour(
 			target="my-sites"
 			placement="below"
 			arrow="top-left"
-			next="sidebar"
 		>
 			<p className="guided-tours__step-text">
 				{
@@ -80,7 +79,6 @@ export const MainTour = makeTour(
 			target="sidebar"
 			arrow="left-middle"
 			placement="beside"
-			next="click-preview"
 		>
 			<p className="guided-tours__step-text">
 				{ translate( 'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.' ) }
@@ -98,7 +96,6 @@ export const MainTour = makeTour(
 			placement="below"
 			when={ selectedSiteIsPreviewable }
 			scrollContainer=".sidebar__region"
-			next="in-preview"
 		>
 			<p className="guided-tours__step-text">
 				{
@@ -114,7 +111,7 @@ export const MainTour = makeTour(
 					{
 						translate( "Click {{strong}}your site's name{{/strong}} to continue.", {
 							components: {
-								strong: <strong/>,
+								strong: <strong />,
 							},
 						} )
 					}
@@ -125,7 +122,6 @@ export const MainTour = makeTour(
 		<Step name="in-preview"
 			placement="center"
 			when={ selectedSiteIsPreviewable }
-			next="close-preview"
 		>
 			<p className="guided-tours__step-text">
 				{
@@ -149,7 +145,6 @@ export const MainTour = makeTour(
 			arrow="left-top"
 			placement="beside"
 			when={ and( selectedSiteIsPreviewable, previewIsShowing ) }
-			next="themes"
 		>
 			<p className="guided-tours__step-text">
 				{ translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ) }
@@ -173,7 +168,6 @@ export const MainTour = makeTour(
 			placement="below"
 			when={ selectedSiteIsCustomizable }
 			scrollContainer=".sidebar__region"
-			next="finish"
 			shouldScrollTo
 		>
 			<p className="guided-tours__step-text">

--- a/client/state/ui/guided-tours/actions.js
+++ b/client/state/ui/guided-tours/actions.js
@@ -5,15 +5,10 @@ import {
 	GUIDED_TOUR_UPDATE,
 } from 'state/action-types';
 
-import {
-	withAnalytics,
-	recordTracksEvent,
-} from 'state/analytics/actions';
-
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 
-export function quitGuidedTour( { tour, stepName, finished, error } ) {
+export function quitGuidedTour( { tour, stepName, finished } ) {
 	const quitAction = {
 		type: GUIDED_TOUR_UPDATE,
 		shouldShow: false,
@@ -23,33 +18,18 @@ export function quitGuidedTour( { tour, stepName, finished, error } ) {
 		finished,
 	};
 
-	const trackEvent = recordTracksEvent( `calypso_guided_tours_${ finished ? 'finished' : 'quit' }`, {
-		step: stepName,
-		//tour_version: guidedToursConfig.get( tour ).meta.version,
-		tour,
-		error,
-	} );
-
 	return ( dispatch, getState ) => {
 		dispatch( addSeenGuidedTour( getState, tour, finished ) );
-		dispatch( withAnalytics( trackEvent, quitAction ) );
+		dispatch( quitAction );
 	};
 }
 
 export function nextGuidedTourStep( { tour, stepName } ) {
-	const nextAction = {
+	return {
 		type: GUIDED_TOUR_UPDATE,
 		tour,
 		stepName,
 	};
-
-	const trackEvent = recordTracksEvent( 'calypso_guided_tours_next_step', {
-		step: stepName,
-		//tour_version: guidedToursConfig.get( tour ).meta.version,
-		tour,
-	} );
-
-	return withAnalytics( trackEvent, nextAction );
 }
 
 // TODO(mcsf): come up with a much better (read: safer) solution


### PR DESCRIPTION
(edits by @mcsf)

Instead of tracking in the actions, track in the components.

- [x] Use isLastStep to infer when a tour is finished
- [x] Don't track 'skipped' steps
- [x] Make sure first non-skipped step after skipped steps is recorded 
- [x] `start` event
- [x] Missing event when closing the preview (main tour)

~~Note: This is broken atm, as finishing a tour brings back another tour.~~

Test live: https://calypso.live/?branch=update/guided-tours-analytics