### PR TITLE
Guided Tours: Parse tour configs for branching data

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -17,6 +17,7 @@ import {
 import Card from 'components/card';
 import Button from 'components/button';
 import ExternalLink from 'components/external-link';
+import { tourBranching } from './config-parsing';
 import {
 	posToCss,
 	getStepPosition,
@@ -25,6 +26,7 @@ import {
 } from './positioning';
 
 const contextTypes = Object.freeze( {
+	branching: PropTypes.object.isRequired,
 	next: PropTypes.func.isRequired,
 	quit: PropTypes.func.isRequired,
 	isValid: PropTypes.func.isRequired,
@@ -44,8 +46,8 @@ export class Tour extends Component {
 	static childContextTypes = contextTypes;
 
 	getChildContext() {
-		const { next, quit, isValid, tour, tourVersion, step } = this.tourMeta;
-		return { next, quit, isValid, tour, tourVersion, step };
+		const { branching, next, quit, isValid, tour, tourVersion, step } = this.tourMeta;
+		return { branching, next, quit, isValid, tour, tourVersion, step };
 	}
 
 	constructor( props, context ) {
@@ -58,8 +60,8 @@ export class Tour extends Component {
 	}
 
 	setTourMeta( props ) {
-		const { next, quit, isValid, name, version, stepName } = props;
-		this.tourMeta = { next, quit, isValid, tour: name, tourVersion: version, step: stepName };
+		const { branching, next, quit, isValid, name, version, stepName } = props;
+		this.tourMeta = { branching, next, quit, isValid, tour: name, tourVersion: version, step: stepName };
 	}
 
 	render() {
@@ -286,6 +288,7 @@ export const makeTour = tree => {
 	const tour = ( { stepName, isValid, next, quit } ) =>
 		React.cloneElement( tree, {
 			stepName, isValid, next, quit,
+			branching: tourBranching( tree ),
 		} );
 
 	tour.propTypes = {
@@ -293,6 +296,7 @@ export const makeTour = tree => {
 		isValid: PropTypes.func.isRequired,
 		next: PropTypes.func.isRequired,
 		quit: PropTypes.func.isRequired,
+		branching: PropTypes.object.isRequired,
 	};
 	tour.meta = omit( tree.props, 'children' );
 	return tour;

--- a/client/layout/guided-tours/config-parsing.js
+++ b/client/layout/guided-tours/config-parsing.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { Children } from 'react';
+import {
+	chunk,
+	fromPairs,
+	flatMap,
+	flow,
+	property,
+	zipObject,
+} from 'lodash';
+
+/*
+ * Transforms
+ *
+ *   [ 'a', 'b', 'c', 'd', 'e', 'f' ]
+ *
+ * into
+ *
+ *   { a: 'b', c: 'd', e: 'f' }
+ */
+const fromPairsSequence = flow(
+	xs => chunk( xs, 2 ),
+	fromPairs
+);
+
+/*
+ * Transforms a tree of elements (Step or deeper) into a sequence with the
+ * following shape:
+ *
+ *   [ 'next', 'my-sites', 'continue', 'some-other-step' ]
+ *
+ * It achieves this thanks to two premises:
+ *
+ * - Whatever the result type for any given `element` (may be empty element,
+ *   leaf element or element with children), return a list, which may or may
+ *   not have values.
+ *
+ * - Using `flatMap` rather than `map` preserves the simple list type of the
+ *   branching data even as we go up a level in the element tree. For instance,
+ *   if element A has two leaves B and C, with
+ *
+ *     branching( B ) = [ 'b1', 'b2' ]
+ *
+ *   and
+ *
+ *     branching( C ) = [ 'c1', 'c2' ]
+ *
+ *   then
+ *
+ *     branching( A ) = flatten( branching( B ), branching( C ) )
+ *                    = [ 'b1', 'b2', 'c1', 'c2' ]
+ *
+ * Using lists and `flatMap` also works nicely with empty values, because the
+ * empty list is a flattening identity, i.e.:
+ *
+ *   flatten( xs, [] ) === flatten( xs )
+ *
+ * The end result is that `flatMap` acts as an all-in-one map-filter-combine
+ * chain.
+ *
+ */
+const branching = element => {
+	if ( ! element || ! element.props ) {
+		return [];
+	}
+
+	if ( element.props.step ) {
+		return [ element.type.name.toLowerCase(), element.props.step ];
+	}
+
+	return flatMap(
+		Children.toArray( element.props.children ),
+		c => branching( c ) || []
+	);
+};
+
+export const tourBranching = tourTree => {
+	const steps = Children
+		.toArray( tourTree.props.children );
+
+	const stepsBranching = steps
+		.map( branching )
+		.map( fromPairsSequence );
+
+	return zipObject(
+		steps.map( property( 'props.name' ) ),
+		stepsBranching
+	);
+};


### PR DESCRIPTION
For any rendered tour, collect an object mapping a tour's steps to the branching elements they contain.

For instance, the following config:

```js
<Tour name="main">
  <Step name="first">
    <Next step="second" />
  </Step>
  <Step name="second">
    <Continue step="third" when={ actionPerformed } />
  </Step>
  <Step name="third">
    <Quit />
  </Step>
</Tour>
```

yields the following branching object:

```js
{
  first: { next: 'second' },
  second: { continue: 'third' },
  third: {},
}
```

This object is available throughout a tour at `this.context.branching`.

For now, this works by looking for any step descendants with a `next` property. Only the element's name and the value for `next` are collected. More props (e.g. `when`) may later be collected if that need is found.

Test live: https://calypso.live/?branch=add/guided-tours-branching-data