### PR TITLE
Jetpack Connect: help button

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -41,7 +41,7 @@ import Button from 'components/button';
 import { requestSites } from 'state/sites/actions';
 import { isRequestingSites } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
-import LiveChatButton from './live-chat-button';
+import HelpButton from './help-button';
 import { withoutHttp } from 'lib/url';
 
 /**
@@ -141,6 +141,7 @@ const LoggedOutForm = React.createClass( {
 				<LoggedOutFormLinkItem href={ loginUrl }>
 					{ this.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
+				<HelpButton />
 			</LoggedOutFormLinks>
 		);
 	},
@@ -412,7 +413,7 @@ const LoggedInForm = React.createClass( {
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
 					{ this.translate( 'Create a new account' ) }
 				</LoggedOutFormLinkItem>
-				<LiveChatButton />
+				<HelpButton />
 			</LoggedOutFormLinks>
 		);
 	},
@@ -477,7 +478,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 					actionURL="/jetpack/connect"
 				/>
 				<LoggedOutFormLinks>
-					<LiveChatButton />
+					<HelpButton />
 				</LoggedOutFormLinks>
 			</Main>
 		);

--- a/client/signup/jetpack-connect/help-button.jsx
+++ b/client/signup/jetpack-connect/help-button.jsx
@@ -8,25 +8,13 @@ import React from 'react';
  */
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import Gridicon from 'components/gridicon';
-import olarkActions from 'lib/olark-store/actions';
-import UserModule from 'lib/user';
-
-const user = UserModule();
 
 export default React.createClass( {
-	displayName: 'JetpackConnectLiveChatButton',
-
-	handleClick() {
-		olarkActions.expandBox();
-	},
+	displayName: 'JetpackConnectHelpButton',
 
 	render() {
-		if ( ! user.get() ) {
-			return null;
-		}
-
 		return (
-			<LoggedOutFormLinkItem className="jetpack-connect__live-chat" onClick={ this.handleClick }>
+			<LoggedOutFormLinkItem className="jetpack-connect__help-button" href="https://jetpack.com/contact-support" target="_blank">
 				<Gridicon icon="help-outline" /> { this.translate( 'Get help connecting your site' ) }
 			</LoggedOutFormLinkItem>
 		);

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -26,7 +26,7 @@ import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Gridicon from 'components/gridicon';
 import MainWrapper from './main-wrapper';
-import LiveChatButton from './live-chat-button';
+import HelpButton from './help-button';
 import {
 	confirmJetpackInstallStatus,
 	dismissUrl,
@@ -256,7 +256,7 @@ const JetpackConnectMain = React.createClass( {
 					? null
 					: <LoggedOutFormLinkItem href="/start">{ this.translate( 'Start a new site on WordPress.com' ) }</LoggedOutFormLinkItem>
 				}
-				<LiveChatButton />
+				<HelpButton />
 			</LoggedOutFormLinks>
 		);
 	},
@@ -367,7 +367,7 @@ const JetpackConnectMain = React.createClass( {
 					</div>
 				</div>
 				<LoggedOutFormLinks>
-					<LiveChatButton />
+					<HelpButton />
 				</LoggedOutFormLinks>
 			</MainWrapper>
 		);
@@ -424,7 +424,7 @@ const JetpackConnectMain = React.createClass( {
 					</div>
 				</div>
 				<LoggedOutFormLinks>
-					<LiveChatButton />
+					<HelpButton />
 				</LoggedOutFormLinks>
 			</MainWrapper>
 		);

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -34,7 +34,7 @@ import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import Dialog from 'components/dialog';
 import analytics from 'lib/analytics';
 import MainWrapper from './main-wrapper';
-import LiveChatButton from './live-chat-button';
+import HelpButton from './help-button';
 
 /*
  * Module variables
@@ -379,7 +379,7 @@ const JetpackSSOForm = React.createClass( {
 					actionURL="https://jetpack.com/support/sso/"
 				/>
 				<LoggedOutFormLinks>
-					<LiveChatButton />
+					<HelpButton />
 				</LoggedOutFormLinks>
 			</Main>
 		);
@@ -453,7 +453,7 @@ const JetpackSSOForm = React.createClass( {
 
 				{ this.renderSharedDetailsDialog() }
 				<LoggedOutFormLinks>
-					<LiveChatButton />
+					<HelpButton />
 				</LoggedOutFormLinks>
 			</MainWrapper>
 		);

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -421,7 +421,7 @@
 	color: transparent;
 }
 
-.jetpack-connect__live-chat {
+.jetpack-connect__help-button {
 	.gridicon {
 		width: 18px;
 		height: 18px;


### PR DESCRIPTION
This PR renames `live-chat-button.jsx` to `help-button.jsx`
The help-button will now direct folks to https://jetpack.com/contact-support
instead of opening a live chat window.

We may change the functionality of this button to use live chat once we figure out how to make sure folks requesting help can be directed to the proper support people.

To test:
- check out this branch
- go to calypso.localhost:3000/jetpack/connect
- ensure that the help button at the bottom opens a window for jetpack.com

Test live: https://calypso.live/?branch=fix/jpc-help-button
cc: @oskosk @dllh @johnHackworth 