### PR TITLE
Signup: Pass the survey step vertical as data on site creation.

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -24,7 +24,8 @@ function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsC
 		blog_name: siteUrl,
 		blog_title: siteUrl,
 		options: {
-			theme: dependencies.theme || themeSlugWithRepo
+			theme: dependencies.theme || themeSlugWithRepo,
+			vertical: dependencies.surveyQuestion || undefined
 		},
 		validate: false,
 		find_available_url: isPurchasingItem

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -77,7 +77,7 @@ module.exports = {
 		stepName: 'domains',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
-		dependencies: [ 'theme' ],
+		dependencies: [ 'theme', 'surveyQuestion' ],
 		delayApiRequestUntilComplete: true
 	},
 

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -153,14 +153,13 @@ export default React.createClass( {
 				category_id: value,
 				category_label: label
 			} );
-			SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { surveySiteType: this.props.surveySiteType, surveyQuestion: this.state.stepOne.value } );
 		} else {
 			analytics.tracks.recordEvent( 'calypso_survey_category_click_level_one', {
 				category_id: value,
 				category_label: label
 			} );
-			SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { surveySiteType: this.props.surveySiteType, surveyQuestion: vertical.value } );
 		}
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { surveySiteType: this.props.surveySiteType, surveyQuestion: vertical.value } );
 		this.props.goToNextStep();
 	}
 } );


### PR DESCRIPTION
This will allow the vertical to be taken into account when adding initial custom content and images during site creation.

The vertical returned will go back to being the second-level, more detailed selection as opposed to the first, which was missed while removing the previous verticals test in #6735.

Testing:
* Add a `debugger;` call in `addDomainItemsToCart` (running Calypso locally).
* Run through signup, noting which second-level selection you made at the `survey` step.
* Verify the code in `dependencies.surveyQuestion` in debugger matches the vertical you selected in `client/signup/steps/survey/verticals.js`.

Test live: https://calypso.live/?branch=add/signup-vertical-for-headstart