### PR TITLE
adding terms of service text to the edit card details form

### DIFF
--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -40,6 +40,8 @@ import userFactory from 'lib/user';
 import { validateCardDetails } from 'lib/credit-card-details';
 import ValidationErrorList from 'notices/validation-error-list';
 import wpcomFactory from 'lib/wp';
+import Gridicon from 'components/gridicon';
+import support from 'lib/url/support';
 
 const countriesList = CountriesList.forPayments();
 const user = userFactory();
@@ -286,6 +288,21 @@ const EditCardDetails = React.createClass( {
 							eventFormName="Edit Card Details Form"
 							isFieldInvalid={ this.isFieldInvalid }
 							onFieldChange={ this.onFieldChange } />
+						<div className="card-terms" onClick={ this.recordTermsAndConditionsClick }>
+							<Gridicon icon="info-outline" size={ 18 } />
+							<p>
+								{ this.translate(
+									'By saving a credit card, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your credit card to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{managePurchasesSupportPage}}how to cancel{{/managePurchasesSupportPage}}.', {
+										components: {
+											tosLink: <a href="//wordpress.com/tos/" target="_blank"/>,
+											autoRenewalSupportPage: <a href={ support.AUTO_RENEWAL } target="_blank"/>,
+											managePurchasesSupportPage: <a href={ support.MANAGE_PURCHASES }
+																		   target="_blank"/>
+										}
+									}
+								) }
+							</p>
+						</div>
 					</Card>
 
 					<CompactCard className="edit-card-details__footer">

--- a/client/me/purchases/payment/edit-card-details/style.scss
+++ b/client/me/purchases/payment/edit-card-details/style.scss
@@ -1,5 +1,35 @@
 .edit-card-details__content {
 	margin-bottom: 0;
+
+	.card-terms {
+		color: darken( $gray, 10% );
+		margin: 20px 0 0 0;
+		padding: 0;
+		text-align: center;
+
+		@include breakpoint( ">660px" ) {
+			padding: 0;
+			text-align: left;
+		}
+
+		p {
+			font-size: 12px;
+			font-weight: 100;
+			margin: 0;
+
+			@include breakpoint( ">660px" ) {
+				margin-left: 24px;
+			}
+		}
+
+		.gridicon {
+			float: left;
+
+			@include breakpoint( "<660px" ) {
+				display: none;
+			}
+		}
+	}
 }
 
 .edit-card-details__footer {


### PR DESCRIPTION
The terms of service details around automatic renewal needs to be added to the add/edit credit card screen.  

Current screen:

![](https://cldup.com/iDb-ZaqAeh.png)

Screen with TOS Added:

![](https://cldup.com/lFIHioR51s.png)

You get to this screen when changing a credit card of a current subscription that will be used for renewal.

1. Have a current plan that will auto-renew
2. Go to /purchases
3. Select the subscription
4. Choose Edit Payment Method.