### PR TITLE
State: layout

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -49,7 +49,10 @@ LayoutLoggedOut.propTypes = {
 	primary: React.PropTypes.element,
 	secondary: React.PropTypes.element,
 	tertiary: React.PropTypes.element,
-	section: React.PropTypes.object
+	section: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object,
+	] )
 };
 
 export default connect(

--- a/client/mailing-lists/controller.js
+++ b/client/mailing-lists/controller.js
@@ -14,7 +14,7 @@ import MainComponent from './main';
 export default {
 	unsubscribe( context ) {
 		// We don't need the sidebar here.
-		context.store.dispatch( setSection( 'me', {
+		context.store.dispatch( setSection( { name: 'me' }, {
 			hasSidebar: false
 		} ) );
 

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -215,7 +215,7 @@ module.exports = {
 
 		analytics.pageView.record( basePath, 'Checkout Thank You' );
 
-		context.store.dispatch( setSection( 'checkout-thank-you', { hasSidebar: false } ) );
+		context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
 
 		titleActions.setTitle( i18n.translate( 'Thank You' ) );
 

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -41,7 +41,7 @@ const jetpackConnectFirstStep = ( context, type ) => {
 
 	userModule.fetch();
 
-	context.store.dispatch( setSection( 'jetpackConnect', {
+	context.store.dispatch( setSection( { name: 'jetpackConnect' }, {
 		hasSidebar: false
 	} ) );
 
@@ -132,7 +132,7 @@ export default {
 			analyticsPageTitle = 'Jetpack Authorize';
 
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-		context.store.dispatch( setSection( 'jetpackConnect', {
+		context.store.dispatch( setSection( { name: 'jetpack-connect' }, {
 			hasSidebar: false
 		} ) );
 
@@ -156,7 +156,7 @@ export default {
 			analyticsPageTitle = 'Jetpack SSO';
 
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-		context.store.dispatch( setSection( 'jetpackConnect', {
+		context.store.dispatch( setSection( { name: 'jetpackConnect' }, {
 			hasSidebar: false
 		} ) );
 


### PR DESCRIPTION
This PR clears some JS warnings emited by `Layout` by
- Ensuring we pass a layout object to `setSection`.
- Ensuring that `LoggedOutLayout` uses the same proptype for section that `Layout` uses.

To test:
- [x] Ensure there are no regressions in Jetpack Connect ( @johnHackworth , @tyxla )
- [ ] Ensure there are no regressions in Mailing Lists ( @artpi )
- [x] Ensure there are no regressions in Upgrades ( @retrofox )

Test live: https://calypso.live/?branch=fix/layout-js-warnings