### PR TITLE
Framework: extenal link, don't pass unexpected  props to a native link

### DIFF
--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classnames from 'classnames';
-import assign from 'lodash/assign';
+import { assign, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +36,7 @@ export default React.createClass( {
 			'has-icon': !! this.props.icon,
 		} );
 
-		const props = assign( {}, this.props, {
+		const props = assign( {}, omit( this.props, 'icon', 'iconSize' ), {
 			className: classes,
 			rel: 'external'
 		} );


### PR DESCRIPTION
As part of #7413, this PR makes sure that we do not pass unexpected props to a native link in the `ExternalLink` component. 

## Testing Instructions

- Navigate to http://calypso.localhost:3000/
- You should no longer see:
<img width="915" alt="screen shot 2016-08-12 at 1 54 16 pm" src="https://cloud.githubusercontent.com/assets/1270189/17636780/4c5c866c-6094-11e6-8fb0-bf01118d5c67.png">
in the console

cc @aduth @rralian @lamosty @retrofox @artpi 

Test live: https://calypso.live/?branch=fix/external-link-warning