### PR TITLE
Advanced SEO: Connect custom title formats to site and post previews

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -28,6 +28,7 @@ import { parseHtml } from 'lib/formatting';
 import { SocialItem } from 'components/vertical-menu/items';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getSitePost } from 'state/posts/selectors';
+import { getSeoTitle } from 'state/sites/selectors';
 import {
 	getSectionName,
 	getSelectedSite
@@ -240,11 +241,18 @@ export class SeoPreviewPane extends PureComponent {
 const mapStateToProps = state => {
 	const site = getSelectedSite( state );
 	const postId = getEditorPostId( state );
+	const post = getSitePost( state, site.ID, postId );
 	const isEditorShowing = 'post-editor' === getSectionName( state );
 
 	return {
-		site: site,
-		post: isEditorShowing && getSitePost( state, site.ID, postId )
+		site: {
+			...site,
+			name: getSeoTitle( state, 'frontPage', { site } )
+		},
+		post: isEditorShowing && {
+			...post,
+			title: getSeoTitle( state, 'posts', { site, post } )
+		}
 	};
 };
 

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -333,7 +333,7 @@ export const getSeoTitleFormats = compose(
 export const getSeoTitle = ( state, type, { site, post = {} } ) => {
 	const titleFormats = getSeoTitleFormats( state, site.ID );
 
-	const processPiece = ( piece, data ) =>
+	const processPiece = ( piece = {}, data ) =>
 		'string' === piece.type
 			? piece.value
 			: get( data, piece.type, '' );
@@ -357,7 +357,7 @@ export const getSeoTitle = ( state, type, { site, post = {} } ) => {
 			} );
 
 		default:
-			return 'No title';
+			return post.title || site.name;
 	}
 };
 

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -333,33 +333,28 @@ export const getSeoTitleFormats = compose(
 export const getSeoTitle = ( state, type, { site, post = {} } ) => {
 	const titleFormats = getSeoTitleFormats( state, site.ID );
 
-	const titleData = {
-		frontPage: {
-			siteName: site.name,
-			tagline: site.description
-		},
-		posts: {
-			siteName: site.name,
-			tagline: site.description,
-			postTitle: post.title
-		}
-	};
-
 	const processPiece = ( piece, data ) =>
 		'string' === piece.type
 			? piece.value
-			: data[ piece.type ];
+			: get( data, piece.type, '' );
 
 	const buildTitle = ( format, data ) =>
-		format
+		get( titleFormats, format, [] )
 			.reduce( ( title, piece ) => title + processPiece( piece, data ), '' );
 
 	switch ( type ) {
 		case 'frontPage':
-			return buildTitle( titleFormats.frontPage, titleData.frontPage );
+			return buildTitle( 'frontPage', {
+				siteName: site.name,
+				tagline: site.description
+			} );
 
 		case 'posts':
-			return buildTitle( titleFormats.posts, titleData.posts );
+			return buildTitle( 'posts', {
+				siteName: site.name,
+				tagline: site.description,
+				postTitle: post.title
+			} );
 
 		default:
 			return 'No title';

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -330,6 +330,42 @@ export const getSeoTitleFormats = compose(
 	getRawSite
 );
 
+export const getSeoTitle = ( state, type, { site, post = {} } ) => {
+	const titleFormats = getSeoTitleFormats( state, site.ID );
+
+	const titleData = {
+		frontPage: {
+			siteName: site.name,
+			tagline: site.description
+		},
+		posts: {
+			siteName: site.name,
+			tagline: site.description,
+			postTitle: post.title
+		}
+	};
+
+	const processPiece = ( piece, data ) =>
+		'string' === piece.type
+			? piece.value
+			: data[ piece.type ];
+
+	const buildTitle = ( format, data ) =>
+		format
+			.reduce( ( title, piece ) => title + processPiece( piece, data ), '' );
+
+	switch ( type ) {
+		case 'frontPage':
+			return buildTitle( titleFormats.frontPage, titleData.frontPage );
+
+		case 'posts':
+			return buildTitle( titleFormats.posts, titleData.posts );
+
+		default:
+			return 'No title';
+	}
+};
+
 /**
  * Returns a site object by its URL.
  *


### PR DESCRIPTION
Inserts advanced SEO data for live previews.

Part of #5974

Previously, the site and post previews in the `<WebPreview />` components showed the basic title property of the previewed site or post objects. Since we have added the ability to create titles following a user-specified format, we need to show these new titles in the previews.

This PR hooks up those custom title formats if available. It does this by introducing some new selectors in `state/sites/selectors` which dynamically builds the title from the stored custom format.

**Caveats**
 - All of the raw data must be available inside of Calypso in order for the title builders to work. We need to test this out heavily before deploying to production.
 - It's possible that this data could come out-of-sync with the server-side code. Nonetheless, by having this directly in Calypso, we can avoid API calls to generate the title which would create annoying and needlessly laggy updates to the UI.
 - This PR is all about hooking up the data and not about fixing all of the UI bugs. Please try and review with that in mind.

**Plain site title being shown in preview**
<img width="737" alt="screen shot 2016-08-12 at 5 13 07 pm" src="https://cloud.githubusercontent.com/assets/5431237/17640207/19890492-60b0-11e6-8553-b93b3f5d8057.png">

**Custom title format being rendered in preview**
<img width="740" alt="screen shot 2016-08-12 at 5 10 14 pm" src="https://cloud.githubusercontent.com/assets/5431237/17640212/23096d22-60b0-11e6-8d53-2d6c512d145c.png">


**Testing**
We need to test two different previews: site previews; and post previews.

You may need to setup some custom title formats on a site with at least the business plan before you will be able to see much of a difference in the previews. You can do this from **My Sites** > **Settings** > **SEO**. Please file any bugs from that **Meta Title Format** editor as new issues in GitHub under the `Advanced SEO` milestone.

To test the site preview, navigate to **My Sites** and pick a site. This should be tested both on sites that have a business plan or higher _and_ on sites with a lesser plan (free, personal, premium). The SEO preview tab should only be available to those sites with a business level or above. Once in the preview tab, check out how the titles look for the previews for the various services (Reader, Google, Facebook, Twitter).

To test the post preview, open up a post in the post editor and click on the **Preview** button. Check for the same issues as above for the site preview.

> Please report any issues with the title itself here but report issues with the previews themselves as new GitHub issues with the `Advanced SEO` milestone.

cc: @roundhill 

Test live: https://calypso.live/?branch=add/meta-title-generator