### PR TITLE
Image Editor: update edited image title to include (edited copy)

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -137,7 +137,7 @@ MediaActions.add = function( siteId, files ) {
 				URL: fileUrl,
 				guid: fileUrl,
 				file: fileName,
-				title: path.basename( fileName ),
+				title: file.title || path.basename( fileName ),
 				extension: MediaUtils.getFileExtension( file.fileName || fileContents ),
 				mime_type: MediaUtils.getMimeType( file.fileName || fileContents ),
 				// Size is not an API media property, though can be useful for
@@ -172,7 +172,8 @@ MediaActions.add = function( siteId, files ) {
 			//if there's no parent_id, but the file object is wrapping a Blob
 			//(contains fileContents, fileName etc) still wrap it in a new object
 			file = {
-				file: file
+				file: file,
+				title: file.title
 			};
 		}
 

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -163,6 +163,7 @@ MediaActions.add = function( siteId, files ) {
 
 		// Assign parent ID if currently editing post
 		const post = PostEditStore.get();
+		const title = file.title;
 		if ( post && post.ID ) {
 			file = {
 				parent_id: post.ID,
@@ -172,9 +173,12 @@ MediaActions.add = function( siteId, files ) {
 			//if there's no parent_id, but the file object is wrapping a Blob
 			//(contains fileContents, fileName etc) still wrap it in a new object
 			file = {
-				file: file,
-				title: file.title
+				file: file
 			};
+		}
+
+		if ( title ) {
+			file.title = title;
 		}
 
 		debug( 'Uploading media to %d from %o', siteId, file );

--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -77,14 +77,27 @@ const MediaModalImageEditor = React.createClass( {
 	onImageExtracted( blob ) {
 		const mimeType = MediaUtils.getMimeType( this.props.fileName );
 
+		// check if a title is already post-fixed with '(edited copy)'
+		const editedCopyText = this.props.translate(
+			'%(title)s (edited copy)', {
+				args: {
+					title: ''
+				}
+			} );
+		let title = this.props.title;
+		if ( title.indexOf( editedCopyText ) === -1 ) {
+			title = this.props.translate(
+				'%(title)s (edited copy)', {
+					args: {
+						title: this.props.title
+					}
+				} );
+		}
+
 		MediaActions.add( this.props.site.ID, {
 			fileName: this.props.fileName,
 			fileContents: blob,
-			title: this.props.translate( '%(title)s (edited copy)', {
-				args: {
-					title: this.props.title
-				}
-			} ),
+			title: title,
 			mimeType: mimeType
 		} );
 	},

--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -35,6 +35,7 @@ const MediaModalImageEditor = React.createClass( {
 		mimeType: React.PropTypes.string,
 		setImageEditorFileInfo: React.PropTypes.func,
 		title: React.PropTypes.string,
+		translate: React.PropTypes.func,
 		onImageEditorClose: React.PropTypes.func,
 		onImageEditorCancel: React.PropTypes.func
 	},

--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 import path from 'path';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -33,6 +34,7 @@ const MediaModalImageEditor = React.createClass( {
 		fileName: React.PropTypes.string,
 		mimeType: React.PropTypes.string,
 		setImageEditorFileInfo: React.PropTypes.func,
+		title: React.PropTypes.string,
 		onImageEditorClose: React.PropTypes.func,
 		onImageEditorCancel: React.PropTypes.func
 	},
@@ -48,7 +50,8 @@ const MediaModalImageEditor = React.createClass( {
 	componentDidMount() {
 		let src,
 			fileName = 'default',
-			mimeType = 'image/png';
+			mimeType = 'image/png',
+			title = 'default';
 
 		const media = this.props.items ? this.props.items[ this.props.selectedIndex ] : null;
 
@@ -58,10 +61,11 @@ const MediaModalImageEditor = React.createClass( {
 			} );
 			fileName = media.file || path.basename( src );
 			mimeType = MediaUtils.getMimeType( media );
+			title = media.title;
 		}
 
 		this.props.resetImageEditorState();
-		this.props.setImageEditorFileInfo( src, fileName, mimeType );
+		this.props.setImageEditorFileInfo( src, fileName, mimeType, title );
 	},
 
 	onDone() {
@@ -76,6 +80,11 @@ const MediaModalImageEditor = React.createClass( {
 		MediaActions.add( this.props.site.ID, {
 			fileName: this.props.fileName,
 			fileContents: blob,
+			title: this.props.translate( '%(title)s (edited copy)', {
+				args: {
+					title: this.props.title
+				}
+			} ),
 			mimeType: mimeType
 		} );
 	},
@@ -123,4 +132,4 @@ const MediaModalImageEditor = React.createClass( {
 export default connect(
 	( state ) => ( getImageEditorFileInfo( state ) ),
 	{ resetImageEditorState, setImageEditorFileInfo }
-)( MediaModalImageEditor );
+)( localize( MediaModalImageEditor ) );

--- a/client/state/ui/editor/image-editor/actions.js
+++ b/client/state/ui/editor/image-editor/actions.js
@@ -36,12 +36,13 @@ export function setImageEditorAspectRatio( ratio ) {
 	};
 }
 
-export function setImageEditorFileInfo( src, fileName, mimeType ) {
+export function setImageEditorFileInfo( src, fileName, mimeType, title ) {
 	return {
 		type: IMAGE_EDITOR_SET_FILE_INFO,
 		src,
 		fileName,
-		mimeType
+		mimeType,
+		title
 	};
 }
 

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -60,12 +60,8 @@ export function hasChanges( state = false, action ) {
 export function fileInfo( state = defaultFileInfo, action ) {
 	switch ( action.type ) {
 		case IMAGE_EDITOR_SET_FILE_INFO:
-			return Object.assign( {}, state, {
-				src: action.src,
-				fileName: action.fileName,
-				mimeType: action.mimeType,
-				title: action.title
-			} );
+			const { src, fileName, mimeType, title } = action;
+			return { ...state, src, fileName, mimeType, title };
 	}
 
 	return state;

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -26,7 +26,8 @@ export const defaultTransform = {
 export const defaultFileInfo = {
 	src: '',
 	fileName: 'default',
-	mimeType: 'image/png'
+	mimeType: 'image/png',
+	title: 'default'
 };
 
 export const defaultCropBounds = {
@@ -59,7 +60,12 @@ export function hasChanges( state = false, action ) {
 export function fileInfo( state = defaultFileInfo, action ) {
 	switch ( action.type ) {
 		case IMAGE_EDITOR_SET_FILE_INFO:
-			return Object.assign( {}, state, { src: action.src, fileName: action.fileName, mimeType: action.mimeType } );
+			return Object.assign( {}, state, {
+				src: action.src,
+				fileName: action.fileName,
+				mimeType: action.mimeType,
+				title: action.title
+			} );
 	}
 
 	return state;

--- a/client/state/ui/editor/image-editor/test/actions.js
+++ b/client/state/ui/editor/image-editor/test/actions.js
@@ -60,13 +60,14 @@ describe( 'actions', () => {
 
 	describe( '#setImageEditorFileInfo()', () => {
 		it( 'should return an action object', () => {
-			const action = setImageEditorFileInfo( 'testSrc', 'testFileName', 'image/jpg' );
+			const action = setImageEditorFileInfo( 'testSrc', 'testFileName', 'image/jpg', 'My Title' );
 
 			expect( action ).to.eql( {
 				type: IMAGE_EDITOR_SET_FILE_INFO,
 				src: 'testSrc',
 				fileName: 'testFileName',
-				mimeType: 'image/jpg'
+				mimeType: 'image/jpg',
+				title: 'My Title'
 			} );
 		} );
 	} );

--- a/client/state/ui/editor/image-editor/test/reducer.js
+++ b/client/state/ui/editor/image-editor/test/reducer.js
@@ -220,7 +220,8 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				src: '',
 				fileName: 'default',
-				mimeType: 'image/png'
+				mimeType: 'image/png',
+				title: 'default'
 			} );
 		} );
 
@@ -229,13 +230,15 @@ describe( 'reducer', () => {
 				type: IMAGE_EDITOR_SET_FILE_INFO,
 				src: 'testSrc',
 				fileName: 'testFileName',
-				mimeType: 'image/jpg'
+				mimeType: 'image/jpg',
+				title: 'My Title'
 			} );
 
 			expect( state ).to.eql( {
 				src: 'testSrc',
 				fileName: 'testFileName',
-				mimeType: 'image/jpg'
+				mimeType: 'image/jpg',
+				title: 'My Title'
 			} );
 		} );
 	} );


### PR DESCRIPTION
Fixes #7375 by uploading an edited image with a title of `%(original_title)s (edited copy)` so users have more context as to what's happened.

For example: the image we originally edited had a title of 'Placeholder Image', so the uploaded copy has a title of `Placeholder Image (edited copy)`
<img width="948" alt="screen shot 2016-08-12 at 4 39 57 pm" src="https://cloud.githubusercontent.com/assets/1270189/17639882/d7bf9d90-60ab-11e6-84a5-854231cfd69c.png">

## Testing Instructions
- navigate to http://calypso.localhost:3000/post
- select a site
- add an image and give it a title
- Click "Edit" on the newly uploaded image
- In detail view, click "Edit Image" in the top right corner
- Make some changes in the image, and upload
- The transient image, and the uploaded image should have a title that ends with (edited copy)

### A few design questions:
- Is using the title here more useful or the filename?
- How should we handle the following case, where we edit an edited image? The current solution avoids the issue below, by not appending an additional `(edited copy)` if it detects that it's there in the original title.

<img width="950" alt="screen shot 2016-08-12 at 4 39 38 pm" src="https://cloud.githubusercontent.com/assets/1270189/17639916/66c6911a-60ac-11e6-9129-7fc48e7d1c4e.png">

### See Bugs?

The image editor is still in a bit of a rough state, so if you happen to find any bugs while testing, please create an issue and add it to the [Image Editor Milestone](https://github.com/Automattic/wp-calypso/milestone/107)

cc @rralian @robobot3000 @aduth @lamosty @artpi @retrofox 


Test live: https://calypso.live/?branch=update/image-title