### PR TITLE
Show correct browser notifications enable status when logging back in

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -102,7 +102,7 @@ export function apiReady() {
 			return;
 		}
 
-		dispatch( mustPrompt() );
+		dispatch( checkPermissionsState() );
 		if ( 'disabling' === getStatus( state ) ) {
 			debug( 'Forcibly unregistering device (disabling on apiReady)' );
 			dispatch( unregisterDevice() );

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -178,6 +178,12 @@ function settings( state = {}, action ) {
 				showingUnblockInstructions: ! state.showingUnblockInstructions
 			} );
 		}
+
+		case PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE: {
+			return Object.assign( {}, state, {
+				enabled: true
+			} );
+		}
 	}
 
 	return state;

--- a/client/state/push-notifications/schema.js
+++ b/client/state/push-notifications/schema.js
@@ -25,7 +25,7 @@ export const systemSchema = {
 			type: 'object',
 			properties: {
 				lastUpdated: stringType,
-				ID: numberType,
+				ID: stringType,
 				settings: {
 					type: 'object',
 					additionalProperties: true

--- a/client/state/push-notifications/test/reducer.js
+++ b/client/state/push-notifications/test/reducer.js
@@ -14,7 +14,7 @@ import {
 import reducer, {} from '../reducer';
 
 const wpcomSubscription = {
-	ID: 42,
+	ID: '42',
 	lastUpdated: '2016-06-16T14:41:09+02:00',
 	settings: {
 		comments: {
@@ -64,7 +64,7 @@ describe( 'system reducer', () => {
 	} );
 
 	it( 'should refuse to restore particular keys', () => {
-		const wpcomSubscriptionId = { ID: 42 };
+		const wpcomSubscriptionId = { ID: '42' };
 		const previousState = {
 			system: {
 				apiReady: true,


### PR DESCRIPTION
The state related to whether browser notifications have been enabled is stored in the Redux tree, and persisted in localForage. When a user logs out, localForage is cleared. When the user logs back in, we don't think that browser notifications are enabled, because the state stored in Redux is gone.

This PR fixes that by checking the browser notifications permissions state if the Redux state doesn't show browser notifications as blocked or enabled., This triggers storing the notifications subscription server-side (since we have no record in Redux of it ever being updated) and then storing the subscription (and enabled state) locally in Redux.

To test:
- Enable browser notifications
- Verify browser notifications are received and correct state is represented in UI
- Log out
- Verify browser notifications are received
- Log in
- Verify browser notifications are received and correct state is represented in UI

Test with both new and existing users.

Test in both Chrome and Firefox. 

Test disabling browser notifications and make sure that still works.

General regression testing of browser notifications feature.

Test live: https://calypso.live/?branch=fix/pn-logged-back-in-state