### PR TITLE
Delete Site: toLowerCase() before validating domain

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -82,7 +82,10 @@ export const DeleteSite = React.createClass( {
 			adminURL = site.options && site.options.admin_url ? site.options.admin_url : '',
 			exportLink = config.isEnabled( 'manage/export' ) ? '/settings/export/' + site.slug : adminURL + 'tools.php?page=export-choices',
 			exportTarget = config.isEnabled( 'manage/export' ) ? undefined : '_blank',
-			deleteDisabled = ( typeof this.state.confirmDomain !== 'string' || this.state.confirmDomain.replace( /\s/g, '' ) !== site.domain );
+			deleteDisabled = (
+				typeof this.state.confirmDomain !== 'string' ||
+				this.state.confirmDomain.toLowerCase().replace( /\s/g, '' ) !== site.domain
+			);
 
 		const deleteButtons = [
 			<Button
@@ -195,7 +198,13 @@ export const DeleteSite = React.createClass( {
 								}
 							} )
 						}</p>
-					<input className="delete-site__confirm-input" type="text" valueLink={ this.linkState( 'confirmDomain' ) }/>
+
+						<input
+							autoCapitalize="off"
+							className="delete-site__confirm-input"
+							type="text"
+							valueLink={ this.linkState( 'confirmDomain' ) }
+							/>
 					</Dialog>
 				</ActionPanel>
 			</div>


### PR DESCRIPTION
At WordCamp Boston, a user came up to me while I was working the Jetpack booth and asked me to walk her through the process of deleting her site. So, I did that. But, as I walked the user through how to delete her site on her iPad, I realized that we weren't being very friendly to mobile users in our validation logic.

Specifically, our logic checks that the domain the user entered is exactly the same as the site's acutal domain. The problem with this is that the mobile keyboard by default capitalizes the first character. So, the user, after having entered her site domain multiple times became frustrated.

This PR aims to fix this by lower casing the entered domain before running validation logic as well as turning off `autoCapitalize`.

To test:

- Checkout `update/delete-site-to-lower` branch
- Go to `/settings/general/$site` where `$site` is a WP.com site
- Click "Delete site" at bottom of page
- Click "Delete site" button at bottom of page
- Fill out domain in modal
- Ensure delete button is NOT disabled
- Follow same steps on mobile


Test live: https://calypso.live/?branch=update/delete-site-to-lower