### PR TITLE
Plans: descending price / description on hover abstest

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -42,7 +42,7 @@ module.exports = {
 		defaultVariation: 'singlePurchaseFlow'
 	},
 	plansDescriptions: {
-		datestamp: '20160901',
+		datestamp: '20160826',
 		variations: {
 			ascendingPriceSubtleDescription: 25,
 			ascendingPriceEagerDescription: 25,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -44,8 +44,8 @@ module.exports = {
 	plansPriceOrder: {
 		datestamp: '20160901',
 		variations: {
-			ascending: 80,
-			descending: 20,
+			ascending: 50,
+			descending: 50,
 		},
 		defaultVariation: 'ascending',
 		allowExistingUsers: false,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -41,6 +41,15 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
+	plansPriceOrder: {
+		datestamp: '20160901',
+		variations: {
+			ascending: 80,
+			descending: 20,
+		},
+		defaultVariation: 'ascending',
+		allowExistingUsers: false,
+	},
 	signupStore: {
 		datestamp: '20160727',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -41,13 +41,15 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
-	plansPriceOrder: {
+	plansDescriptions: {
 		datestamp: '20160901',
 		variations: {
-			ascending: 50,
-			descending: 50,
+			ascendingPriceSubtleDescription: 25,
+			ascendingPriceEagerDescription: 25,
+			descendingPriceSubtleDescription: 25,
+			descendingPriceEagerDescription: 25
 		},
-		defaultVariation: 'ascending',
+		defaultVariation: 'ascendingPriceSubtleDescription',
 		allowExistingUsers: false,
 	},
 	signupStore: {

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
+import { abtest } from 'lib/abtest';
 
 export default function PlanFeaturesItem( {
 	children,
@@ -27,15 +28,25 @@ export default function PlanFeaturesItem( {
 		onMouseLeave( event.currentTarget, description );
 	};
 
+	const mouseEvents = {
+		onMouseEnter: handleOnMouseEvent,
+		onMouseLeave: handleOnMouseLeave
+	};
+	const hoverOnRow = (
+		abtest( 'plansDescriptions' ) === 'ascendingPriceEagerDescription' ||
+		abtest( 'plansDescriptions' ) === 'descendingPriceEagerDescription'
+	);
+
 	return (
-		<div className="plan-features__item">
+		<div className="plan-features__item"
+			{ ...( hoverOnRow && mouseEvents ) }
+		>
 			<Gridicon
 				className="plan-features__item-checkmark"
 				size={ 18 } icon="checkmark" />
 			{ children }
 			<span
-				onMouseEnter={ handleOnMouseEvent }
-				onMouseLeave={ handleOnMouseLeave }
+				{ ...( ! hoverOnRow && mouseEvents ) }
 				onTouchStart={ handleOnTouchStart }
 				className="plan-features__item-tip-info"
 			>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -85,7 +85,7 @@ class PlansFeaturesMain extends Component {
 		}
 
 		let plans;
-		if ( abtest( 'plansPriceOrder' ) === 'descending' ) {
+		if ( abtest( 'plansDescriptions' ) === 'descendingPriceSubtleDescription' || abtest( 'plansDescriptions' ) === 'descendingPriceEagerDescription' ) {
 			plans = filter(
 				[
 					PLAN_BUSINESS,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -23,6 +23,7 @@ import {
 import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 import { isEnabled } from 'config';
+import { abtest } from 'lib/abtest';
 
 class PlansFeaturesMain extends Component {
 
@@ -83,15 +84,28 @@ class PlansFeaturesMain extends Component {
 			);
 		}
 
-		const plans = filter(
-			[
-				hideFreePlan ? null : PLAN_FREE,
-				isPersonalPlanEnabled ? PLAN_PERSONAL : null,
-				PLAN_PREMIUM,
-				PLAN_BUSINESS
-			],
-			value => !! value
-		);
+		let plans;
+		if ( abtest( 'plansPriceOrder' ) === 'descending' ) {
+			plans = filter(
+				[
+					PLAN_BUSINESS,
+					PLAN_PREMIUM,
+					isPersonalPlanEnabled ? PLAN_PERSONAL : null,
+					hideFreePlan ? null : PLAN_FREE,
+				],
+				value => !! value
+			);
+		} else {
+			plans = filter(
+				[
+					hideFreePlan ? null : PLAN_FREE,
+					isPersonalPlanEnabled ? PLAN_PERSONAL : null,
+					PLAN_PREMIUM,
+					PLAN_BUSINESS
+				],
+				value => !! value
+			);
+		}
 
 		return (
 			<div className="plans-features-main__group">

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -85,7 +85,10 @@ class PlansFeaturesMain extends Component {
 		}
 
 		let plans;
-		if ( abtest( 'plansDescriptions' ) === 'descendingPriceSubtleDescription' || abtest( 'plansDescriptions' ) === 'descendingPriceEagerDescription' ) {
+		if (
+			abtest( 'plansDescriptions' ) === 'descendingPriceSubtleDescription' ||
+			abtest( 'plansDescriptions' ) === 'descendingPriceEagerDescription'
+		) {
 			plans = filter(
 				[
 					PLAN_BUSINESS,


### PR DESCRIPTION
Introduces Abtests mentioned in #6997.

- Decreasing price order
- Description on hover

### [📺 Watch video](https://youtu.be/pu03RLBBzlw)

# NUX

![zrzut ekranu 2016-08-15 o 11 58 32](https://cloud.githubusercontent.com/assets/3775068/17662149/e65dbd3e-62e3-11e6-8612-014d1ba09f3c.png)

# Plans

![zrzut ekranu 2016-08-15 o 11 59 22](https://cloud.githubusercontent.com/assets/3775068/17662158/f24d3674-62e3-11e6-9aaa-8df821e79a1a.png)


## Testing

1. Check out
2. Assign yourself to plansDescriptions: descendingPriceEagerDescription test group using env badge
3. Go to /plans. see that plans are sorted in descending price
4. Assign yourself ascendingPriceEagerDescription - see that descriptions open on hover
5. Test also ascendingPriceSubtleDescription ( control ) and descendingPriceSubtleDescription
4. Repeat all of that in nux

CC @rralian @lamosty @gwwar @retrofox 


Test live: https://calypso.live/?branch=new/plan-reorder-test