### PR TITLE
Plans: auto open for plans descriptions

### DIFF
--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -33,6 +33,12 @@ export default React.createClass( {
 		};
 	},
 
+	componentWillReceiveProps( props ) {
+		if ( this.props.open !== props.open && props.open !== this.state.showPopover ) {
+			this.setState( { showPopover: props.open } );
+		}
+	},
+
 	getInitialState() {
 		return {
 			showPopover: false
@@ -53,7 +59,7 @@ export default React.createClass( {
 				<Gridicon icon="info-outline" size={ 18 } />
 				<Popover
 					id={ this.props.id }
-					isVisible={ this.state.showPopover || this.props.open }
+					isVisible={ this.state.showPopover }
 					context={ this.refs && this.refs.infoPopover }
 					ignoreContext={ this.props.ignoreContext }
 					position={ this.props.position }

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -17,6 +17,7 @@ export default React.createClass( {
 
 	propTypes: {
 		id: React.PropTypes.string,
+		open: React.PropTypes.bool,
 		position: React.PropTypes.string,
 		className: React.PropTypes.string,
 		gaEventCategory: React.PropTypes.string,
@@ -52,7 +53,7 @@ export default React.createClass( {
 				<Gridicon icon="info-outline" size={ 18 } />
 				<Popover
 					id={ this.props.id }
-					isVisible={ this.state.showPopover }
+					isVisible={ this.state.showPopover || this.props.open }
 					context={ this.refs && this.refs.infoPopover }
 					ignoreContext={ this.props.ignoreContext }
 					position={ this.props.position }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -41,6 +41,15 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
+	plansDescriptions: {
+		datestamp: '20160901',
+		variations: {
+			auto: 50,
+			click: 50,
+		},
+		defaultVariation: 'click',
+		allowExistingUsers: false,
+	},
 	signupStore: {
 		datestamp: '20160727',
 		variations: {

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -11,18 +11,17 @@ import Gridicon from 'components/gridicon';
 import InfoPopover from 'components/info-popover';
 import { abtest } from 'lib/abtest';
 
-//export default function PlanFeaturesItem( { description, children, className } ) {
-export default React.createClass( {
-
-	displayName: 'PlanFeaturesItem',
-
-	getInitialState() {
-		return {
+export default class PlanFeaturesItem extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
 			showPopover: false,
 			mouseOverTimeout: null,
 			mouseOver: false
 		};
-	},
+		this.mouseOver = this.mouseOver.bind( this );
+		this.mouseOut = this.mouseOut.bind( this );
+	}
 
 	renderTipinfo( description ) {
 		return (
@@ -35,23 +34,25 @@ export default React.createClass( {
 				</InfoPopover>
 			</div>
 		);
-	},
+	}
+	mouseOver() {
+		this.setState( { mouseOver: true, mouseOverTimeout: setTimeout( () => this.setState( {
+			showPopover: this.state.mouseOver,
+			mouseOverTimeout: null
+		} ), 100 ) } );
+	}
+	mouseOut() {
+		clearTimeout( this.state.mouseOverTimeout );
+		this.setState( { showPopover: false, mouseOverTimeout: null, mouseOver: false } );
+	}
 	render() {
 		const { description, children, className } = this.props;
 		const classes = classNames( 'plan-features__item', className );
 		let popoverBindings = {};
 		if ( abtest( 'plansDescriptions' ) === 'auto' ) {
 			popoverBindings = {
-				onMouseOver: () => {
-					this.setState( { mouseOver: true, mouseOverTimeout: setTimeout( () => this.setState( {
-						showPopover: this.state.mouseOver,
-						mouseOverTimeout: null
-					} ), 150 ) } );
-				},
-				onMouseOut: () => {
-					clearTimeout( this.state.mouseOverTimeout );
-					this.setState( { showPopover: false, mouseOverTimeout: null, mouseOver: false } );
-				}
+				onMouseOver: this.mouseOver,
+				onMouseOut: this.mouseOut
 			};
 		}
 
@@ -63,4 +64,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -9,31 +9,48 @@ import classNames from 'classnames';
  */
 import Gridicon from 'components/gridicon';
 import InfoPopover from 'components/info-popover';
+import { abtest } from 'lib/abtest';
 
-export default function PlanFeaturesItem( { description, children, className } ) {
-	const renderTipinfo = () => {
-		if ( ! description ) {
-			return null;
-		}
+//export default function PlanFeaturesItem( { description, children, className } ) {
+export default React.createClass( {
 
+	displayName: 'PlanFeaturesItem',
+
+	getInitialState() {
+		return {
+			showPopover: false
+		};
+	},
+
+	renderTipinfo( description ) {
 		return (
 			<div className="plan-features__item-tip-info">
 				<InfoPopover
 					position="right"
+					open = { this.state.showPopover }
 				>
 					{ description }
 				</InfoPopover>
 			</div>
 		);
-	};
+	},
+	render() {
+		const { description, children, className } = this.props;
+		const classes = classNames( 'plan-features__item', className );
+		let popoverBindings = {};
+		if( abtest( 'plansDescriptions' ) === 'auto' ) {
+			popoverBindings = {
+				onMouseOver: () => this.setState( { showPopover: true } ),
+				onMouseOut: () => this.setState( { showPopover: false } )
+			};
+		}
 
-	const classes = classNames( 'plan-features__item', className );
-
-	return (
-		<div className={ classes }>
-			<Gridicon className="plan-features__item-checkmark" size={ 18 } icon="checkmark" />
-			{ children }
-			{ renderTipinfo() }
-		</div>
-	);
-}
+		return (
+			<div { ...popoverBindings } className={ classes } >
+				<Gridicon className="plan-features__item-checkmark" size={ 18 } icon="checkmark" />
+				{ children }
+				{ description && this.renderTipinfo( description ) }
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -18,7 +18,9 @@ export default React.createClass( {
 
 	getInitialState() {
 		return {
-			showPopover: false
+			showPopover: false,
+			mouseOverTimeout: null,
+			mouseOver: false
 		};
 	},
 
@@ -38,10 +40,18 @@ export default React.createClass( {
 		const { description, children, className } = this.props;
 		const classes = classNames( 'plan-features__item', className );
 		let popoverBindings = {};
-		if( abtest( 'plansDescriptions' ) === 'auto' ) {
+		if ( abtest( 'plansDescriptions' ) === 'auto' ) {
 			popoverBindings = {
-				onMouseOver: () => this.setState( { showPopover: true } ),
-				onMouseOut: () => this.setState( { showPopover: false } )
+				onMouseOver: () => {
+					this.setState( { mouseOver: true, mouseOverTimeout: setTimeout( () => this.setState( {
+						showPopover: this.state.mouseOver,
+						mouseOverTimeout: null
+					} ), 150 ) } );
+				},
+				onMouseOut: () => {
+					clearTimeout( this.state.mouseOverTimeout );
+					this.setState( { showPopover: false, mouseOverTimeout: null, mouseOver: false } );
+				}
 			};
 		}
 


### PR DESCRIPTION
Introduces test mentioned in #6997

I am not sure about this, because there are some issues in the "Business" plan when the tooltip overlays the hover and I am not sure whats the best way to proceed.

## Testing


1. Check out
2. Assign yourself to plansDescriptions: auto test group using env badge
3. Go to /plans. hover on some descriptions.

CC @rralian @lamosty @gwwar @retrofox 

Test live: https://calypso.live/?branch=new/plans-hover-tooltip