### PR TITLE
CPT: Disable CPT writing settings for unsupported Jetpack versions

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -62,7 +62,7 @@ const SiteSettingsFormWriting = React.createClass( {
 	isCustomPostTypesSettingsEnabled() {
 		return (
 			config.isEnabled( 'manage/custom-post-types' ) &&
-			false !== this.props.jetpackVersionSupportsCustomTypes
+			this.props.jetpackVersionSupportsCustomTypes
 		);
 	},
 
@@ -168,7 +168,7 @@ const SiteSettingsFormWriting = React.createClass( {
 						</FormSelect>
 					</FormFieldset>
 
-					{ config.isEnabled( 'manage/custom-post-types' ) && (
+					{ config.isEnabled( 'manage/custom-post-types' ) && this.props.jetpackVersionSupportsCustomTypes && (
 						<CustomPostTypeFieldset
 							requestingSettings={ this.state.fetchingSettings }
 							value={ pick( this.state, 'jetpack_testimonial', 'jetpack_portfolio' ) }
@@ -227,8 +227,8 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
-			jetpackCustomTypesModuleActive: isJetpackModuleActive( state, siteId, 'custom-content-types' ),
-			jetpackVersionSupportsCustomTypes: isJetpackMinimumVersion( state, siteId, '4.2.0' )
+			jetpackCustomTypesModuleActive: false !== isJetpackModuleActive( state, siteId, 'custom-content-types' ),
+			jetpackVersionSupportsCustomTypes: false !== isJetpackMinimumVersion( state, siteId, '4.2.0' )
 		};
 	},
 	{ requestPostTypes },


### PR DESCRIPTION
Related: #7035 

This pull request seeks to temporarily disable custom content type settings for Jetpack sites when running an unsupported version (older than 4.2). Because Jetpack 4.2 has not yet been released and we'd like to make custom post types available in production, we cannot prompt users to upgrade to the latest version until that version is available. Instead, we should hide the writing settings until Jetpack 4.2 becomes available, at which point we can revert these changes.

__Testing instructions:__

1. Navigate to [site writing settings](http://calypso.localhost:3000/settings/writing/wpjetpack.andrewduthie.com)
2. Select a site
3. Note that...
 - If WordPress.com site or Jetpack site running 4.2.0 stable or newer (not beta, but 4.3 alpha is okay), custom content type settings are shown
 - If Jetpack site running 4.1.x or 4.2.0-RC or older, not custom content type settings are shown

Test live: https://calypso.live/?branch=remove/cpt-jetpack-support