### PR TITLE
Domains: Don't show notice for mapping domains on Jetpack sites

### DIFF
--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -92,6 +92,11 @@ export default React.createClass( {
 
 	wrongNSMappedDomains() {
 		debug( 'Rendering wrongNSMappedDomains' );
+
+		if ( this.props.selectedSite && this.props.selectedSite.jetpack ) {
+			return null;
+		}
+
 		const wrongMappedDomains = this.getDomains().filter( domain =>
 			domain.type === domainTypes.MAPPED && ! domain.pointsToWpcom );
 


### PR DESCRIPTION
As reported by @mcsf, merging #3329 resulted in the warning introduced there to be shown to Jetpack users. This is a quickfix for that - I'll investigate if a fix is needed on the backend later.



Test live: https://calypso.live/?branch=fix/jetpack-mapped-domain-warnings