### PR TITLE
CPT: Include list to portfolio archive link

### DIFF
--- a/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
+++ b/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
@@ -140,13 +140,19 @@ class CustomPostTypesFieldset extends Component {
 							{ this.hasDefaultPostTypeEnabled( 'jetpack-testimonial' ) && (
 								<FormSettingExplanation>{ translate( 'Your theme supports Testimonials' ) }</FormSettingExplanation>
 							) }
-							{ translate( 'The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( {{code}}[testimonials]{{/code}} ) or you can {{archiveLink}}view a full archive of your testimonials{{/archiveLink}}.', {
-								components: {
-									shortcodeLink: <a href="https://support.wordpress.com/testimonials-shortcode/" />,
-									code: <code />,
-									archiveLink: <a href={ siteUrl.replace( /\/$/, '' ) + '/testimonial' } />
+							{ translate(
+								'The Testimonial custom content type allows you to add, organize, and display your ' +
+								'testimonials. If your theme doesn’t support it yet, you can display testimonials using ' +
+								'the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( {{code}}[testimonials]{{/code}} ) ' +
+								'or you can {{archiveLink}}view a full archive of your testimonials{{/archiveLink}}.',
+								{
+									components: {
+										shortcodeLink: <a href="https://support.wordpress.com/testimonials-shortcode/" />,
+										code: <code />,
+										archiveLink: <a href={ siteUrl.replace( /\/$/, '' ) + '/testimonial' } />
+									}
 								}
-							} ) }
+							) }
 						</Card>
 					</div>
 					<div className="site-settings__custom-post-type">
@@ -160,12 +166,19 @@ class CustomPostTypesFieldset extends Component {
 							{ this.hasDefaultPostTypeEnabled( 'jetpack-portfolio' ) && (
 								<FormSettingExplanation>{ translate( 'Your theme supports Portfolio Projects' ) }</FormSettingExplanation>
 							) }
-							{ translate( 'The Portfolio custom content type gives you an easy way to manage and showcase projects on your site. If your theme doesn’t support it yet, you can display the portfolio using the {{shortcodeLink}}portfolio shortcode{{/shortcodeLink}} ( {{code}}[portfolio]{{/code}} ) or with a link to the portfolio in the menu.', {
-								components: {
-									shortcodeLink: <a href="https://support.wordpress.com/portfolios/portfolio-shortcode/" />,
-									code: <code />
+							{ translate(
+								'The Portfolio custom content type gives you an easy way to manage and showcase projects ' +
+								'on your site. If your theme doesn’t support it yet, you can display the portfolio using ' +
+								'the {{shortcodeLink}}portfolio shortcode{{/shortcodeLink}} ( {{code}}[portfolio]{{/code}} ) ' +
+								'or you can {{archiveLink}}view a full archive of your portfolio projects{{/archiveLink}}.',
+								{
+									components: {
+										shortcodeLink: <a href="https://support.wordpress.com/portfolios/portfolio-shortcode/" />,
+										code: <code />,
+										archiveLink: <a href={ siteUrl.replace( /\/$/, '' ) + '/portfolio' } />
+									}
 								}
-							} ) }
+							) }
 						</Card>
 					</div>
 				</ToggleWrapper>


### PR DESCRIPTION
Closes #7447

This pull request seeks to...

- Change the support text for Portfolio custom content types to direct users to the archive list of their portfolio projects, for consistency with Testimonial text
- Resolve long-line lint warnings

__Testing instructions:__

1. Navigate to [site writing settings](http://calypso.localhost:3000/settings/writing)
2. Select a WordPress.com site or Jetpack site running 4.2.0 stable or higher
3. Note that the Portfolio support text includes a valid link to the portfolio archive for your site

Also verify that there are no regressions in long-line refactoring, notably that each line has a space separating it from the next (so that words don't run into each other).

Test live: https://calypso.live/?branch=update/cpt-settings-archive-link