### PR TITLE
WIP: Add webpack-dashboard to local build process

### DIFF
--- a/bin/check-node-version
+++ b/bin/check-node-version
@@ -9,11 +9,11 @@ const results = child_process.spawnSync( 'npm', [ '-v' ], { encoding : 'utf8' } 
 const hasAllowedNpmVersion = results.stdout && semver.satisfies( results.stdout, engines.npm );
 
 if ( ! hasAllowedNodeVersion || ! hasAllowedNpmVersion ) {
-	console.error(
-		'wp-calypso requires node %s and npm %s, found node %s and npm %s Please switch using nvm or n! Or see https://nodejs.org for instructions.',
-		engines.node,
-		engines.npm,
-		process.version,
-		results.stdout || 'unknown'
-	);
+	// console.error(
+	// 	'wp-calypso requires node %s and npm %s, found node %s and npm %s Please switch using nvm or n! Or see https://nodejs.org for instructions.',
+	// 	engines.node,
+	// 	engines.npm,
+	// 	process.version,
+	// 	results.stdout || 'unknown'
+	// );
 }

--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -52,7 +52,7 @@ const tagToToken = s =>
 
 const tokenToTag = n =>
 	'string' !== n.type
-		? `%${ snakeCase( n.type ) }%` // siteName -> %site_name%
+		? `%_${ snakeCase( n.type ) }%` // siteName -> %_site_name%
 		: n.value;                     // arbitrary text passes through
 
 export const rawToNative = r => removeBlanks( map( split( r, tagPattern ), tagToToken ) );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3793,6 +3793,17 @@
           "version": "3.0.0"
         }
       }
+    },
+    "webpack-dashboard": {
+      "version": "0.0.1",
+      "dependencies": {
+        "blessed": {
+          "version": "0.1.81"
+        },
+        "filesize": {
+          "version": "3.3.0"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "socket.io": "1.3.7",
     "stylelint": "^6.5.1",
     "supertest": "^1.1.0",
+    "webpack-dashboard": "0.0.1",
     "webpack-dev-server": "1.11.0"
   }
 }

--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -35,13 +35,13 @@ function setup() {
 		bundler( app );
 
 		// setup logger
-		app.use( morgan( 'dev' ) );
+		// app.use( morgan( 'dev' ) );
 	} else {
 		assets = require( 'bundler/assets' );
 		assets( app );
 
 		// setup logger
-		app.use( morgan( 'combined' ) );
+		// app.use( morgan( 'combined' ) );
 	}
 
 	// attach the static file server to serve the `public` dir

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -45,8 +45,8 @@ function minify( files ) {
 		child.once( 'exit', function() {
 			_children.splice( _children.indexOf( child ), 1 );
 			if ( _children.length === 0 ) {
-				console.log( 'Minification of all bundles completed.' );
-				console.log( 'Total build time: ' + ( new Date().getTime() - start ) + 'ms' );
+				// console.log( 'Minification of all bundles completed.' );
+				// console.log( 'Total build time: ' + ( new Date().getTime() - start ) + 'ms' );
 			}
 		} );
 	} );
@@ -59,9 +59,9 @@ webpack( webpackConfig, function( error, stats ) {
 	var files, assets;
 
 	if( error ) {
-		console.error( error.stack || error );
+		// console.error( error.stack || error );
 		if( error.details ) {
-			console.error( error.details );
+			// console.error( error.details );
 		}
 		process.on( 'exit', function() {
 			process.exit( 1 );
@@ -69,7 +69,7 @@ webpack( webpackConfig, function( error, stats ) {
 		return;
 	}
 
-	process.stdout.write( stats.toString( outputOptions ) + "\n");
+	// process.stdout.write( stats.toString( outputOptions ) + "\n");
 
 	assets = utils.getAssets( stats.toJson() );
 

--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -35,9 +35,9 @@ function middleware( app ) {
 			process.nextTick( function() {
 				if ( beforeFirstCompile ) {
 					beforeFirstCompile = false;
-					console.info( chalk.cyan( '\nReady! You can load http://calypso.localhost:3000/ now. Have fun!' ) );
+					// console.info( chalk.cyan( '\nReady! You can load http://calypso.localhost:3000/ now. Have fun!' ) );
 				} else {
-					console.info( chalk.cyan( '\nReady! All assets are re-compiled. Have fun!' ) );
+					// console.info( chalk.cyan( '\nReady! All assets are re-compiled. Have fun!' ) );
 				}
 			} );
 		} );
@@ -48,7 +48,7 @@ function middleware( app ) {
 			return next();
 		}
 
-		console.info( 'Compiling assets... Wait until you see Ready! and then try http://calypso.localhost:3000/ again.' );
+		// console.info( 'Compiling assets... Wait until you see Ready! and then try http://calypso.localhost:3000/ again.' );
 
 		// a special message for newcomers, because seeing a blank page is confusing
 		if ( request.url === '/' ) {
@@ -74,17 +74,18 @@ function middleware( app ) {
 		publicPath: '/calypso/',
 		stats: {
 			colors: true,
-			hash: true,
+			hash: false,
 			version: false,
 			timings: true,
-			assets: true,
-			chunks: true,
+			assets: false,
+			chunks: false,
 			chunkModules: false,
 			modules: false,
 			cached: false,
 			reasons: false,
 			source: false,
-			errorDetails: true
+			errorDetails: false,
+			publicPath: false
 		}
 	} ) );
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,10 @@
  */
 var webpack = require( 'webpack' ),
 	path = require( 'path' ),
-	config = require( 'config' );
+	config = require( 'config' ),
+	Dashboard = require( 'webpack-dashboard' ),
+	DashboardPlugin = require( 'webpack-dashboard/plugin' ),
+	dashboard = new Dashboard();
 
 /**
  * Internal dependencies
@@ -118,7 +121,10 @@ jsLoader = {
 
 if ( CALYPSO_ENV === 'development' ) {
 	webpackConfig.plugins.push( new PragmaCheckPlugin() );
-	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
+	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin({
+		quiet: true
+	}) );
+	webpackConfig.plugins.push( new DashboardPlugin( dashboard.setData ) );
 	webpackConfig.entry[ 'build-' + CALYPSO_ENV ] = [
 		'webpack-dev-server/client?/',
 		'webpack/hot/only-dev-server',


### PR DESCRIPTION
See: https://github.com/FormidableLabs/webpack-dashboard

This PR is an attempt to start using the new webpack dashboard plugin
which organizes the webpack output into a windowed console UI, showing
additional information beyond build status such as bundle and asset
sizes and also clean error messages.

This is in no way ready to merge, as I have mainly gone in and tried to
silence all the things to prevent overwriting the console output.

Any and all collaboration would be greatly appreciated. Thanks already to @aduth for pointing me to the spots where we are spitting out console messages in the server build.

## Major Tasks
 - [ ] Silence code which is spitting directly to the console as it covers up and messes up the CUI
 - [ ] Make sure that we are only doing this for `DEVELOPMENT` builds
 - [ ] Make sure that this only runs in a local console and not, for instance, on CircleCI
 - [ ] Minimize the silencing and figure out the minimum number of changes needed to make it work

cc: @aduth @blowery @gwwar 

Test live: https://calypso.live/?branch=add/webpack-dashboard