### PR TITLE
Sites: Use Redux state preference for recent sites

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -3,12 +3,15 @@
  */
 import React from 'react';
 import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 import page from 'page';
 import classNames from 'classnames';
+import { filter, size, reduce, includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { getPreference } from 'state/preferences/selectors';
 import AllSites from 'my-sites/all-sites';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
@@ -18,14 +21,11 @@ import SitePlaceholder from 'blocks/site/placeholder';
 import Search from 'components/search';
 import userModule from 'lib/user';
 import config from 'config';
-import PreferencesData from 'components/data/preferences-data';
 
 const user = userModule();
 const noop = () => {};
 
-export default React.createClass( {
-	displayName: 'SiteSelector',
-
+const SiteSelector = React.createClass( {
 	propTypes: {
 		sites: React.PropTypes.object,
 		siteBasePath: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
@@ -149,9 +149,12 @@ export default React.createClass( {
 		if ( this.state.search ) {
 			sites = this.props.sites.search( this.state.search );
 		} else {
-			sites = this.shouldShowGroups()
-				? this.props.sites.getVisibleAndNotRecent()
-				: this.props.sites.getVisible();
+			sites = this.props.sites.getVisible();
+
+			const { recentSites } = this.props;
+			if ( this.shouldShowGroups() && size( recentSites ) ) {
+				sites = filter( sites, ( { ID: siteId } ) => ! includes( recentSites, siteId ) );
+			}
 		}
 
 		if ( this.props.filter ) {
@@ -222,38 +225,48 @@ export default React.createClass( {
 	},
 
 	renderRecentSites() {
-		const sites = this.props.sites.getRecentlySelected();
-
-		if ( ! sites || this.state.search || ! this.shouldShowGroups() ) {
-			return null;
+		if ( this.state.search || ! this.shouldShowGroups() ) {
+			return;
 		}
 
-		const recentSites = sites.map( function( site ) {
-			var siteHref;
-
-			if ( this.props.siteBasePath ) {
-				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
-			}
-
-			const isSelected = this.isSelected( site );
-
-			return (
-				<Site
-					site={ site }
-					href={ siteHref }
-					key={ 'site-' + site.ID }
-					indicator={ this.props.indicator }
-					onSelect={ this.onSiteSelect.bind( this, site.slug ) }
-					isSelected={ isSelected }
-				/>
-			);
-		}, this );
-
-		if ( ! recentSites ) {
-			return null;
+		const { recentSites } = this.props;
+		if ( ! size( recentSites ) ) {
+			return;
 		}
 
-		return <div className="site-selector__recent">{ recentSites }</div>;
+		const sites = this.props.sites.get();
+		if ( ! sites ) {
+			return;
+		}
+
+		return (
+			<div className="site-selector__recent">
+				{ reduce( sites, ( memo, site ) => {
+					const recentIndex = recentSites.indexOf( site.ID );
+					if ( -1 === recentIndex ) {
+						return memo;
+					}
+
+					let siteHref;
+					if ( this.props.siteBasePath ) {
+						siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
+					}
+
+					memo.splice( recentIndex, 0, (
+						<Site
+							site={ site }
+							href={ siteHref }
+							key={ 'site-' + site.ID }
+							indicator={ this.props.indicator }
+							onSelect={ this.onSiteSelect.bind( this, site.slug ) }
+							isSelected={ this.isSelected( site ) }
+						/>
+					) );
+
+					return memo;
+				}, [] ) }
+			</div>
+		);
 	},
 
 	render() {
@@ -263,22 +276,27 @@ export default React.createClass( {
 		} );
 
 		return (
-			<PreferencesData>
-				<div className={ selectorClass }>
-					<Search
-						ref="siteSearch"
-						onSearch={ this.onSearch }
-						autoFocus={ this.props.autoFocus }
-						disabled={ ! this.props.sites.initialized }
-						onSearchClose={ this.props.onClose }
-					/>
-					<div className="site-selector__sites" ref="selector">
-						{ this.renderAllSites() }
-						{ this.renderSites() }
-					</div>
-					{ this.props.showAddNewSite && this.addNewSite() }
+			<div className={ selectorClass }>
+				<Search
+					ref="siteSearch"
+					onSearch={ this.onSearch }
+					autoFocus={ this.props.autoFocus }
+					disabled={ ! this.props.sites.initialized }
+					onSearchClose={ this.props.onClose }
+				/>
+				<div className="site-selector__sites" ref="selector">
+					{ this.renderAllSites() }
+					{ this.renderSites() }
 				</div>
-			</PreferencesData>
+				{ this.props.showAddNewSite && this.addNewSite() }
+			</div>
 		);
 	}
 } );
+
+export default connect(
+	( state ) => ( { recentSites: getPreference( state, 'recentSites' ) } ),
+	null,
+	null,
+	{ pure: false }
+)( SiteSelector );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -6,7 +6,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import page from 'page';
 import classNames from 'classnames';
-import { filter, size, reduce, includes } from 'lodash';
+import { filter, size, keyBy, map, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -229,22 +229,14 @@ const SiteSelector = React.createClass( {
 			return;
 		}
 
-		const { recentSites } = this.props;
-		if ( ! size( recentSites ) ) {
-			return;
-		}
-
-		const sites = this.props.sites.get();
-		if ( ! sites ) {
-			return;
-		}
+		const sitesById = keyBy( this.props.sites.get(), 'ID' );
 
 		return (
 			<div className="site-selector__recent">
-				{ reduce( sites, ( memo, site ) => {
-					const recentIndex = recentSites.indexOf( site.ID );
-					if ( -1 === recentIndex ) {
-						return memo;
+				{ map( this.props.recentSites, ( siteId ) => {
+					const site = sitesById[ siteId ];
+					if ( ! site ) {
+						return;
 					}
 
 					let siteHref;
@@ -252,7 +244,7 @@ const SiteSelector = React.createClass( {
 						siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
 					}
 
-					memo.splice( recentIndex, 0, (
+					return (
 						<Site
 							site={ site }
 							href={ siteHref }
@@ -261,10 +253,8 @@ const SiteSelector = React.createClass( {
 							onSelect={ this.onSiteSelect.bind( this, site.slug ) }
 							isSelected={ this.isSelected( site ) }
 						/>
-					) );
-
-					return memo;
-				}, [] ) }
+					);
+				} ) }
 			</div>
 		);
 	},

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -12,6 +12,7 @@ import { filter, size, keyBy, map, includes } from 'lodash';
  * Internal dependencies
  */
 import { getPreference } from 'state/preferences/selectors';
+import observe from 'lib/mixins/data-observe';
 import AllSites from 'my-sites/all-sites';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
@@ -26,6 +27,8 @@ const user = userModule();
 const noop = () => {};
 
 const SiteSelector = React.createClass( {
+	mixins: [ observe( 'sites' ) ],
+
 	propTypes: {
 		sites: React.PropTypes.object,
 		siteBasePath: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
@@ -284,9 +287,8 @@ const SiteSelector = React.createClass( {
 	}
 } );
 
-export default connect(
-	( state ) => ( { recentSites: getPreference( state, 'recentSites' ) } ),
-	null,
-	null,
-	{ pure: false }
-)( SiteSelector );
+export default connect( ( state ) => {
+	return {
+		recentSites: getPreference( state, 'recentSites' )
+	};
+} )( SiteSelector );

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -170,4 +170,8 @@
 
 .site-selector__recent {
 	border-bottom: 1px solid lighten( $gray, 30% );
+
+	&:empty {
+		border-bottom-width: 0;
+	}
 }

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -17,9 +17,6 @@ var wpcom = require( 'lib/wp' ),
 	Searchable = require( 'lib/mixins/searchable' ),
 	Emitter = require( 'lib/mixins/emitter' ),
 	isPlan = require( 'lib/products-values' ).isPlan,
-	PreferencesActions = require( 'lib/preferences/actions' ),
-	PreferencesStore = require( 'lib/preferences/store' ),
-	user = require( 'lib/user' )(),
 	userUtils = require( 'lib/user/utils' );
 
 /**
@@ -38,7 +35,6 @@ function SitesList() {
 	this.selected = null;
 	this.lastSelected = null;
 	this.propagateChange = this.propagateChange.bind( this );
-	this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
 }
 
 /**
@@ -383,55 +379,6 @@ SitesList.prototype.isSelected = function( site ) {
 };
 
 /**
- * Set recently selected site
- *
- * @param {number} Site ID
- * @api private
- */
-SitesList.prototype.setRecentlySelectedSite = function( siteID ) {
-	if ( ! this.recentlySelected || this.recentlySelected.length === 0 ) {
-		this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
-	}
-
-	if ( ! siteID || ! this.initialized ) {
-		return;
-	}
-
-	const index = this.recentlySelected.indexOf( siteID );
-
-	// do not add duplicates
-	if ( index !== -1 ) {
-		this.recentlySelected.splice( index, 1 );
-	}
-
-	this.recentlySelected.unshift( siteID );
-
-	const sites = this.recentlySelected.slice( 0, 3 );
-	PreferencesActions.set( 'recentSites', sites );
-
-	this.emit( 'change' );
-};
-
-SitesList.prototype.getRecentlySelected = function() {
-	this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
-
-	if ( ! this.recentlySelected.length || ! this.initialized ) {
-		return false;
-	}
-
-	let sites = [];
-
-	this.recentlySelected.forEach( function( id, index ) {
-		sites[ index ] = this.get().filter( function( site ) {
-			return id === site.ID;
-		}, this )[ 0 ];
-	}, this );
-
-	// remove undefined sites
-	return sites.filter( site => site );
-};
-
-/**
  * Get a single site object from a numeric ID or domain ID
  *
  * @api public
@@ -516,22 +463,6 @@ SitesList.prototype.getPublic = function() {
 SitesList.prototype.getVisible = function() {
 	return this.get().filter( function( site ) {
 		return site.visible === true;
-	}, this );
-};
-
-/**
- * Get sites that are marked as visible and not recently selected
- *
- * @api public
- **/
-SitesList.prototype.getVisibleAndNotRecent = function() {
-	this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
-	return this.get().filter( function( site ) {
-		if ( user.get().visible_site_count < 12 ) {
-			return site.visible === true;
-		}
-
-		return site.visible === true && this.recentlySelected && this.recentlySelected.indexOf( site.ID ) === -1;
 	}, this );
 };
 

--- a/client/mailing-lists/controller.js
+++ b/client/mailing-lists/controller.js
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import omit from 'lodash/omit';
-import ReactDom from 'react-dom';
 import React from 'react';
 import { setSection } from 'state/ui/actions';
 
@@ -10,6 +9,7 @@ import { setSection } from 'state/ui/actions';
  * Internal Dependencies
  */
 import MainComponent from './main';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 export default {
 	unsubscribe( context ) {
@@ -18,14 +18,15 @@ export default {
 			hasSidebar: false
 		} ) );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( MainComponent, {
 				email: context.query.email,
 				category: context.query.category,
 				hmac: context.query.hmac,
 				context: omit( context.query, [ 'email', 'category', 'hmac' ] )
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 };

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -6,6 +6,7 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import i18n from 'i18n-calypso';
+import { uniq } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,13 +14,13 @@ import i18n from 'i18n-calypso';
 import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';
 import { receiveSite } from 'state/sites/actions';
-
 import {
 	setSelectedSiteId,
 	setSection,
 	setAllSitesSelected
 } from 'state/ui/actions';
-
+import { savePreference } from 'state/preferences/actions';
+import { getPreference } from 'state/preferences/selectors';
 import NavigationComponent from 'my-sites/navigation';
 import route from 'lib/route';
 import notices from 'notices';
@@ -169,7 +170,15 @@ module.exports = {
 			siteStatsStickyTabActions.saveFilterAndSlug( false, selectedSite.slug );
 			context.store.dispatch( receiveSite( selectedSite ) );
 			context.store.dispatch( setSelectedSiteId( selectedSite.ID ) );
-			sites.setRecentlySelectedSite( selectedSite.ID );
+
+			// Update recent sites preference
+			const recentSites = getPreference( context.store.getState(), 'recentSites' );
+			if ( recentSites && selectedSite.ID !== recentSites[ 0 ] ) {
+				context.store.dispatch( savePreference( 'recentSites', uniq( [
+					selectedSite.ID,
+					...recentSites
+				] ).slice( 0, 3 ) ) );
+			}
 		};
 
 		// If there's a valid site from the url path

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -4,7 +4,6 @@
 import page from 'page';
 import ReactDom from 'react-dom';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 import i18n from 'i18n-calypso';
 import { uniq } from 'lodash';
 
@@ -30,6 +29,7 @@ import siteStatsStickyTabActions from 'lib/site-stats-sticky-tab/actions';
 import utils from 'lib/site/utils';
 import trackScrollPage from 'lib/track-scroll-page';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 /**
  * Module vars
@@ -52,13 +52,11 @@ function createNavigation( context ) {
 	}
 
 	return (
-		<ReduxProvider store={ context.store }>
-			<NavigationComponent path={ context.path }
-				allSitesPath={ basePath }
-				siteBasePath={ basePath }
-				user={ user }
-				sites={ sites } />
-		</ReduxProvider>
+		<NavigationComponent path={ context.path }
+			allSitesPath={ basePath }
+			siteBasePath={ basePath }
+			user={ user }
+			sites={ sites } />
 	);
 }
 
@@ -75,9 +73,10 @@ function renderEmptySites( context ) {
 
 	removeSidebar( context );
 
-	ReactDom.render(
+	renderWithReduxStore(
 		React.createElement( NoSitesMessage ),
-		document.getElementById( 'primary' )
+		document.getElementById( 'primary' ),
+		context.store
 	);
 }
 
@@ -89,7 +88,7 @@ function renderNoVisibleSites( context ) {
 
 	removeSidebar( context );
 
-	ReactDom.render(
+	renderWithReduxStore(
 		React.createElement( EmptyContentComponent, {
 			title: i18n.translate( 'You have %(hidden)d hidden WordPress site.', 'You have %(hidden)d hidden WordPress sites.', {
 				count: hiddenSites,
@@ -105,7 +104,8 @@ function renderNoVisibleSites( context ) {
 			secondaryAction: i18n.translate( 'Create New Site' ),
 			secondaryActionURL: `${ signup_url }?ref=calypso-nosites`
 		} ),
-		document.getElementById( 'primary' )
+		document.getElementById( 'primary' ),
+		context.store
 	);
 }
 
@@ -274,9 +274,10 @@ module.exports = {
 
 	navigation: function( context, next ) {
 		// Render the My Sites navigation in #secondary
-		ReactDom.render(
+		renderWithReduxStore(
 			createNavigation( context ),
-			document.getElementById( 'secondary' )
+			document.getElementById( 'secondary' ),
+			context.store
 		);
 		next();
 	},
@@ -288,14 +289,14 @@ module.exports = {
 		const selectedSite = sites.getSelectedSite();
 
 		if ( selectedSite && selectedSite.jetpack ) {
-			ReactDom.render( (
+			renderWithReduxStore( (
 				<Main>
 					<JetpackManageErrorPage
 						template="noDomainsOnJetpack"
 						site={ sites.getSelectedSite() }
 					/>
 				</Main>
-			), document.getElementById( 'primary' ) );
+			), document.getElementById( 'primary' ), context.store );
 
 			analytics.pageView.record( basePath, '> No Domains On Jetpack' );
 		} else {
@@ -323,7 +324,7 @@ module.exports = {
 
 		analytics.pageView.record( basePath, analyticsPageTitle );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( SitesComponent, {
 				sites,
 				path: context.path,
@@ -337,7 +338,8 @@ module.exports = {
 					'Sites'
 				)
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 };

--- a/client/my-sites/drafts/controller.js
+++ b/client/my-sites/drafts/controller.js
@@ -1,8 +1,7 @@
 /**
  * External Dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react'),
+var React = require( 'react'),
 	i18n = require( 'i18n-calypso' );
 
 /**
@@ -11,6 +10,7 @@ var ReactDom = require( 'react-dom' ),
 var sites = require( 'lib/sites-list' )(),
 	route = require( 'lib/route' ),
 	titleActions = require( 'lib/screen-title/actions' );
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 module.exports = {
 
@@ -20,13 +20,14 @@ module.exports = {
 
 		titleActions.setTitle( i18n.translate( 'Drafts', { textOnly: true } ), { siteID: siteID } );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( Drafts, {
 				siteID: siteID,
 				sites: sites,
 				trackScrollPage: function() {}
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -1,8 +1,7 @@
 /**
  * External Dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react'),
+var React = require( 'react' ),
 	i18n = require( 'i18n-calypso' );
 
 /**
@@ -12,6 +11,7 @@ var sites = require( 'lib/sites-list' )(),
 	route = require( 'lib/route' ),
 	analytics = require( 'lib/analytics' ),
 	titleActions = require( 'lib/screen-title/actions' );
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 module.exports = {
 
@@ -33,13 +33,14 @@ module.exports = {
 		} );
 
 		// Render
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( MediaComponent, {
 				sites: sites,
 				filter: filter,
 				search: search
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 

--- a/client/my-sites/menus/controller.js
+++ b/client/my-sites/menus/controller.js
@@ -19,6 +19,7 @@ var sites = require( 'lib/sites-list' )(),
 	notices = require( 'notices' ),
 	siteMenus = require( 'lib/menu-data' ),
 	titleActions = require( 'lib/screen-title/actions' );
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 var controller = {
 
@@ -36,7 +37,7 @@ var controller = {
 		titleActions.setTitle( i18n.translate( 'Menus', { textOnly: true } ), { siteID: context.params.site_id } );
 
 		function renderJetpackUpgradeMessage() {
-			ReactDom.render(
+			renderWithReduxStore(
 				React.createElement( MainComponent, null,
 					React.createElement( JetpackManageErrorPage, {
 						template: 'updateJetpack',
@@ -48,7 +49,8 @@ var controller = {
 						secondaryActionTarget: '_blank'
 					} )
 				),
-				document.getElementById( 'primary' )
+				document.getElementById( 'primary' ),
+				context.store
 			);
 		}
 

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -3,7 +3,6 @@
  */
 import page from 'page';
 import React from 'react';
-import ReactDom from 'react-dom';
 import i18n from 'i18n-calypso';
 
 /**
@@ -35,7 +34,7 @@ export default {
 		if ( site && site.jetpack && ! isEnabled( 'manage/jetpack-plans' ) ) {
 			analytics.pageView.record( basePath + '/jetpack/:site', analyticsPageTitle + ' > Jetpack Plans Not Available' );
 
-			ReactDom.render(
+			renderWithReduxStore(
 				React.createElement( MainComponent, null,
 					React.createElement( EmptyContentComponent, {
 						title: i18n.translate( 'Plans are not available for Jetpack sites yet.' ),
@@ -45,7 +44,8 @@ export default {
 						illustration: '/calypso/images/drake/drake-nomenus.svg'
 					} )
 				),
-				document.getElementById( 'primary' )
+				document.getElementById( 'primary' ),
+				context.store
 			);
 			return;
 		}

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -147,7 +147,7 @@ module.exports = {
 
 		analytics.pageView.record( '/domains/add/:site/google-apps', 'Domain Search > Domain Registration > Google Apps' );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			(
 				<Main>
 					<CartData>
@@ -160,7 +160,8 @@ module.exports = {
 					</CartData>
 				</Main>
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 

--- a/client/state/preferences/constants.js
+++ b/client/state/preferences/constants.js
@@ -4,6 +4,14 @@ export const DEFAULT_PREFERENCES = {
 		schema: { 'enum': [ null, 'html', 'tinymce' ] },
 		'default': null
 	},
+	recentSites: {
+		schema: {
+			type: [ 'null', 'array' ],
+			items: {
+				type: 'number'
+			}
+		}
+	},
 	firstViewHistory: {
 		schema: {
 			type: 'array',

--- a/client/state/preferences/test/reducer.js
+++ b/client/state/preferences/test/reducer.js
@@ -34,7 +34,11 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'should use DEFAULT_PREFERENCES from constants as a default', () => {
-			expect( reducer( undefined, {} ).values ).to.deep.equal( mapValues( DEFAULT_PREFERENCES, value => value.default ) );
+			const expected = mapValues( DEFAULT_PREFERENCES, ( value ) => {
+				return 'default' in value ? value.default : null;
+			} );
+
+			expect( reducer( undefined, {} ).values ).to.deep.equal( expected );
 		} );
 	} );
 

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -40,26 +40,6 @@ export function selectedSiteId( state = null, action ) {
 	return state;
 }
 
-/**
- * Tracks the four most recently selected site IDs.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
- */
-export function recentlySelectedSiteIds( state = [], action ) {
-	switch ( action.type ) {
-		case SELECTED_SITE_SET:
-			state = [ action.siteId, ...state ];
-			if ( state.length === 3 ) {
-				state.pop();
-			}
-			return state;
-	}
-
-	return state;
-}
-
 //TODO: do we really want to mix strings and booleans?
 export function section( state = false, action ) {
 	switch ( action.type ) {
@@ -109,7 +89,6 @@ const reducer = combineReducers( {
 	currentPreviewUrl,
 	queryArguments,
 	selectedSiteId,
-	recentlySelectedSiteIds,
 	guidedTour,
 	editor,
 	reader,

--- a/client/state/ui/test/reducer.js
+++ b/client/state/ui/test/reducer.js
@@ -14,6 +14,24 @@ import {
 import reducer, { selectedSiteId } from '../reducer';
 
 describe( 'reducer', () => {
+	it( 'should include expected keys in return value', () => {
+		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'section',
+			'isLoading',
+			'layoutFocus',
+			'hasSidebar',
+			'isPreviewShowing',
+			'currentPreviewUrl',
+			'queryArguments',
+			'selectedSiteId',
+			'guidedTour',
+			'editor',
+			'reader',
+			'olark',
+			'actionLog'
+		] );
+	} );
+
 	it( 'should refuse to persist any state', () => {
 		const state = reducer( {
 			selectedSiteId: 2916284


### PR DESCRIPTION
Related: #7323, #7413 

This pull request is a continuation of #7323, migrating the `<SiteSelector />` component toward using Redux-based global state for recent site preferences. It completes the migration, removing recent site logic from the `sites-list` module.

Toward #7413, it resolves a warning logged in development environments related to the `preferences` prop passed to the rendered `div` by the legacy `<PreferencesData />` component.

__Testing instructions:__

There should be no changes in behavior from the master branch. Notably, confirm that your recent sites are shown in the correct order, and that selecting a new site updates this order and is persisted between page sessions.

__Caveats / Open Questions:__

- It's not really specific to this pull request, but I noticed there can be a race condition when saving the recent sites preference while a request is in progress for preferences. If the preference fetch request completes after the update request, the preference value can revert back to its previous value. This is noticeable when loading a page for a site which is not currently the most recently selected site.
- The `<SiteSelector />` doesn't render a `<QueryPreferences />` component of its own, instead depending on the one [rendered in the top-level `<Layout />` component](https://github.com/Automattic/wp-calypso/blob/ec4f9a9f745eab304dcaa6fb251177f4adbc470b/client/layout/index.jsx#L200). This is to avoid excessive requests when toggling the visibility of the `<SiteSelector />` component. It could be argued that this is desirable to keep the preferences data fresh (which would probably resolve the issue in the first noted caveat), but with `<QueryPreferences />` guaranteed to be rendered on every screen by `<Layout />`, it should be safe to rely on this as the source of preference data.

/cc @mtias @gwwar 

Test live: https://calypso.live/?branch=update/site-selector-preferences