### PR TITLE
Refresh site info after updating custom title formats

### DIFF
--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
 import {
 	difference,
 	findKey,
@@ -23,8 +22,6 @@ import {
  */
 import SegmentedControl from 'components/segmented-control';
 import TokenField from 'components/token-field';
-import { getSeoTitleFormats } from 'state/sites/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
 import { localize } from 'i18n-calypso';
 
 import { removeBlanks } from './mappings';
@@ -73,10 +70,7 @@ export class MetaTitleEditor extends Component {
 	constructor( props ) {
 		super( props );
 
-		const { titleFormats } = props;
-
 		this.state = {
-			titleFormats,
 			type: 'frontPage'
 		};
 
@@ -84,36 +78,25 @@ export class MetaTitleEditor extends Component {
 		this.updateTitleFormat = this.updateTitleFormat.bind( this );
 	}
 
-	componentWillUpdate( nextProps ) {
-		const { siteId: prevSiteId } = this.props;
-		const { siteId: nextSiteId, titleFormats } = nextProps;
-
-		if ( nextSiteId !== prevSiteId ) {
-			// Clear all local changes when switching
-			// sites to get the new site's data
-			this.setState( { titleFormats } );
-		}
-	}
-
 	switchType( { value: type } ) {
 		this.setState( { type } );
 	}
 
 	updateTitleFormat( values ) {
-		const { onChange, translate } = this.props;
+		const { onChange, translate, titleFormats } = this.props;
 		const { type } = this.state;
 
 		const tokens = removeBlanks( map( values, tokenize( translate ) ) );
 
-		this.setState( { titleFormats: {
-			...this.state.titleFormats,
+		onChange( {
+			...titleFormats,
 			[ type ]: tokens
-		} }, () => onChange( this.state.titleFormats ) );
+		} );
 	}
 
 	render() {
-		const { disabled, translate } = this.props;
-		const { type, titleFormats } = this.state;
+		const { disabled, translate, titleFormats } = this.props;
+		const { type } = this.state;
 
 		const validTokens = getValidTokens( translate );
 
@@ -150,7 +133,8 @@ export class MetaTitleEditor extends Component {
 
 MetaTitleEditor.propTypes = {
 	disabled: PropTypes.bool,
-	onChange: PropTypes.func
+	onChange: PropTypes.func,
+	titleFormats: PropTypes.object.isRequired
 };
 
 MetaTitleEditor.defaultProps = {
@@ -159,9 +143,4 @@ MetaTitleEditor.defaultProps = {
 	translate: identity
 };
 
-const mapStateToProps = state => ( {
-	siteId: getSelectedSiteId( state ),
-	titleFormats: getSeoTitleFormats( state, getSelectedSiteId( state ) )
-} );
-
-export default connect( mapStateToProps )( localize( MetaTitleEditor ) );
+export default localize( MetaTitleEditor );


### PR DESCRIPTION
Resolves #7112 

There's quite a nasty race-condition when editing a site's advanced SEO custom title formats where refreshing the browser after making changes makes it appear as if those changes were lost. Further, saving _after_ a refresh _can_ wipe out those changes.

Maybe the primary cause of this trouble is the fact that custom title formats are _set_ on the site-settings endpoint but they are _retrieved_ from the site endpoint. This requires refreshing the site data after updating the settings. Unfortunately, I have not been able to find any way to receive a notification once the site object has been updated. Ultimately it will be refactorings of other Calypso pieces that will fix this, so in that sense, this PR is more or less a (probably long-lived) bandaid over the problem.

In this PR I have introduced some code to try and sit and watch for the updates to come back from the API and prevent messing with the editor field while waiting.

This is fairly fragile code, which is to say I cannot completely justify why it works. There are likely two _proper_ solutions:
 - Find some way to receive a notification/subscription to the site object when it has successfully updated
 - Move the advanced SEO custom title fields to the site endpoint.

### Behaviors

Broken in **master**; notice how the recently-updated values disappear through refreshes until the local cache is cleared.

![brokenmastertitle](https://cloud.githubusercontent.com/assets/5431237/17688086/98a97702-6330-11e6-80e5-2b77623a7deb.gif)


Fixed in this PR; notice how despite the fact that a refresh also resets the recently-updated value, it flips to what we expect before the entry is enabled.

![fixbranchtitle](https://cloud.githubusercontent.com/assets/5431237/17688089/9cb3aa52-6330-11e6-99c1-0d0ea9f41d91.gif)


### Testing

 - Navigate to **My Sites** > **Settings** > **SEO** for a site with the business plan or higher subscription.
 - Change the title format for one of the page view types (_e.g._ for the front page)
 - Save the changes
    - The input box should disable itself and the value should persist through the save until it re-enables
    - In **master** the value should also stay.
 - Reload the browser with a simple refresh (`Ctrl+R` or `F5` etc…)
    - The input box should start disabled and may show the previous value, but it should update to the newly-saved value when it enables itself.
    - In **master** the value will likely revert to the old value and stay through several refreshes. Clearing the `indexdb` and `SitesList` from `localStorage` and then refreshing should update the value to the newly-stored value.

Pay particular attention to possible race-conditions with performing multiple edits and refreshing the browser. We should not find the updated values to disappear after the editor re-enables itself.

cc: @roundhill @vindl @mtias 
Test live: https://calypso.live/?branch=fix/7112-refresh-seo-title-formats