### PR TITLE
Update/use flex in search component

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -159,8 +159,8 @@ $z-layers: (
 	'.search': (
 		'.search__input': 10,
 		'.search.is-searching .spinner': 20,
-		'.search .search-open__icon': 20,
-		'.search .search-close__icon': 20
+		'.search .search__open-icon': 20,
+		'.search .search__close-icon': 20
 	),
 	'.profile-gravatar__edit-label-wrap': (
 		'.profile-gravatar__edit-label-wrap:after': 0,

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -185,7 +185,8 @@ $z-layers: (
 	),
 	'.following-edit': ( //aka 'main'
 		'.following-edit__subscribe-form .gridicons-add-outline': 23,
-		'.following-edit__subscribe-form .card.is-search-result': 35
+		'.following-edit__subscribe-form .card.is-search-result': 35,
+		'.following-edit__subscribe-form .search': 36
 	),
 
 	// The following may be inserted into different areas.

--- a/client/blocks/author-selector/style.scss
+++ b/client/blocks/author-selector/style.scss
@@ -48,16 +48,19 @@
 
 .author-selector__popover {
 	.search {
+		border-top: 0px;
 		border-bottom: 1px solid lighten( $gray, 30 );
+		border-radius: 5px;
 		// .search should be cleaned up to not force height
 		height: 43px;
 		margin-bottom: 0;
 
+	&.is-open {
+		width: 200px;
+	}
+
 		.search__input[type="search"] {
-			border-radius: 5px;
 			font-size: 14px;
-			height: 43px;
-			padding: 0 50px 0;
 		}
 
 		& + .author-selector__infinite-list {

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -337,8 +337,6 @@ const Search = React.createClass( {
 	},
 
 	closeButton: function() {
-		const gridIconClass = classNames( 'search-close__icon', this.props.dir );
-
 		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
 			return (
 				<div
@@ -348,7 +346,7 @@ const Search = React.createClass( {
 					onKeyDown={ this.closeListener }
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
-					<Gridicon icon="cross" className={ gridIconClass } />
+					<Gridicon icon="cross" className="search__close-icon"/>
 				</div>
 			);
 		}

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -291,6 +291,8 @@ const Search = React.createClass( {
 		} );
 
 		const gridIconClass = classNames ( 'search-open__icon', this.props.dir );
+		const fadeDivClass = classNames ( 'search__input-fade', this.props.dir );
+
 		const isCloseButtonVisible = this.props.hideClose ? ' no-close-button ' : '';
 
 		return (
@@ -309,7 +311,7 @@ const Search = React.createClass( {
 					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }>
 					<Gridicon icon="search" className={ gridIconClass }/>
 				</div>
-				<div className="search__input-fade">
+				<div className={ fadeDivClass }>
 					<input
 						type="search"
 						id={ 'search-component-' + this.state.instanceId }

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -61,7 +61,7 @@ const Search = React.createClass( {
 		isOpen: PropTypes.bool,
 		dir: PropTypes.oneOf( [ 'ltr', 'rtl' ] ),
 		fitsContainer: PropTypes.bool,
-		maxLength: PropTypes.number
+		maxLength: PropTypes.number,
 		hideClose: PropTypes.bool
 	},
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -59,7 +59,7 @@ const Search = React.createClass( {
 		onBlur: PropTypes.func,
 		searching: PropTypes.bool,
 		isOpen: PropTypes.bool,
-		dir: PropTypes.string,
+		dir: PropTypes.oneOf( [ 'ltr', 'rtl' ] ),
 		fitsContainer: PropTypes.bool,
 		maxLength: PropTypes.number
 		hideClose: PropTypes.bool
@@ -266,8 +266,12 @@ const Search = React.createClass( {
 	},
 
 	render: function() {
-		const enableOpenIcon = this.props.pinned && ! this.state.isOpen,
-			isOpenUnpinnedOrQueried = this.state.isOpen ||
+		let searchValue = this.state.keyword,
+			placeholder = this.props.placeholder ||
+				i18n.translate( 'Search…', { textOnly: true } );
+
+		const enableOpenIcon = this.props.pinned && ! this.state.isOpen;
+		const isOpenUnpinnedOrQueried = this.state.isOpen ||
 				! this.props.pinned ||
 				this.props.initialValue;
 
@@ -277,17 +281,16 @@ const Search = React.createClass( {
 			spellCheck: 'false'
 		};
 
-		const searchClass = classNames( this.props.additionalClasses, {
+		const searchClass = classNames( this.props.additionalClasses, this.props.dir, {
 			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
 			'no-close-button' : this.props.hideClose,
 			'has-focus' : this.state.hasFocus,
-			rtl: this.props.dir === 'rtl',
-			ltr: this.props.dir === 'ltr',
 			search: true
 		} );
 
+		const gridIconClass = classNames ( 'search-open__icon', this.props.dir );
 		const isCloseButtonVisible = this.props.hideClose ? ' no-close-button ' : '';
 
 		return (
@@ -304,7 +307,7 @@ const Search = React.createClass( {
 					}
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }>
-					<Gridicon icon="search" className={ 'search-open__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) } />
+					<Gridicon icon="search" className={ gridIconClass }/>
 				</div>
 				<div className="search__input-fade">
 					<input
@@ -334,6 +337,8 @@ const Search = React.createClass( {
 	},
 
 	closeButton: function() {
+		const gridIconClass = classNames ( 'search-close__icon', this.props.dir );
+
 		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
 			return (
 				<div
@@ -343,7 +348,7 @@ const Search = React.createClass( {
 					onKeyDown={ this.closeListener }
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
-					<Gridicon icon="cross" className={ 'search-close__icon' + ( this.props.dir ? ' ' + this.props.dir : '' ) } />
+					<Gridicon icon="cross" className={ gridIconClass } />
 				</div>
 			);
 		}

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -68,7 +68,8 @@ const Search = React.createClass( {
 	getInitialState: function() {
 		return {
 			keyword: this.props.initialValue || '',
-			isOpen: !! this.props.isOpen
+			isOpen: !! this.props.isOpen,
+			hasFocus: false
 		};
 	},
 
@@ -180,6 +181,8 @@ const Search = React.createClass( {
 		if ( this.props.onBlur ) {
 			this.props.onBlur();
 		}
+
+		this.setState( { hasFocus: false } );
 	},
 
 	onChange: function() {
@@ -258,6 +261,7 @@ const Search = React.createClass( {
 			input.value = setValue;
 		}
 
+		this.setState( { hasFocus: true } );
 		this.props.onSearchOpen( );
 	},
 
@@ -278,6 +282,7 @@ const Search = React.createClass( {
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
 			'no-close-button' : this.props.hideClose,
+			'has-focus' : this.state.hasFocus,
 			rtl: this.props.dir === 'rtl',
 			ltr: this.props.dir === 'ltr',
 			search: true

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -285,21 +285,22 @@ const Search = React.createClass( {
 			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
-			'no-close-button' : this.props.hideClose,
-			'has-focus' : this.state.hasFocus,
+			'no-close-button': this.props.hideClose,
+			'has-focus': this.state.hasFocus,
 			search: true
 		} );
 
-		const gridIconClass = classNames ( 'search-open__icon', this.props.dir );
-		const fadeDivClass = classNames ( 'search__input-fade', this.props.dir );
-
-		const isCloseButtonVisible = this.props.hideClose ? ' no-close-button ' : '';
+		const gridIconClass = classNames( 'search-open__icon', this.props.dir );
+		const fadeDivClass = classNames( 'search__input-fade', this.props.dir );
+		const inputClass = classNames( 'search__input', this.props.dir, {
+			'no-close-button': this.props.hideClose
+		} );
 
 		return (
 			<div className={ searchClass } role="search">
 				<Spinner />
 				<div
-					className="search-component-icon-div"
+					className="search__component-icon-div"
 					ref="openIcon"
 					onTouchTap={ enableOpenIcon ? this.openSearch : this.focus }
 					tabIndex={ enableOpenIcon ? '0' : null }
@@ -315,7 +316,7 @@ const Search = React.createClass( {
 					<input
 						type="search"
 						id={ 'search-component-' + this.state.instanceId }
-						className={ 'search__input' + isCloseButtonVisible + ( this.props.dir ? ' ' + this.props.dir : '' ) }
+						className={ inputClass }
 						placeholder={ placeholder }
 						role="search"
 						value={ searchValue }
@@ -339,12 +340,12 @@ const Search = React.createClass( {
 	},
 
 	closeButton: function() {
-		const gridIconClass = classNames ( 'search-close__icon', this.props.dir );
+		const gridIconClass = classNames( 'search-close__icon', this.props.dir );
 
 		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
 			return (
 				<div
-					className='search-component-icon-div'
+					className="search__component-icon-div"
 					onTouchTap={ this.closeSearch }
 					tabIndex="0"
 					onKeyDown={ this.closeListener }

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -297,7 +297,7 @@ const Search = React.createClass( {
 			<div className={ searchClass } role="search">
 				<Spinner />
 				<div
-					className="search__component-icon-div"
+					className="search__icon-navigation"
 					ref="openIcon"
 					onTouchTap={ enableOpenIcon ? this.openSearch : this.focus }
 					tabIndex={ enableOpenIcon ? '0' : null }
@@ -342,7 +342,7 @@ const Search = React.createClass( {
 		if ( ! this.props.hideClose && ( this.state.keyword || this.state.isOpen ) ) {
 			return (
 				<div
-					className="search__component-icon-div"
+					className="search__icon-navigation"
 					onTouchTap={ this.closeSearch }
 					tabIndex="0"
 					onKeyDown={ this.closeListener }

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -293,7 +293,7 @@ const Search = React.createClass( {
 		const inputClass = classNames( 'search__input', this.props.dir );
 
 		return (
-			<div className={ searchClass } role="search">
+			<div dir={this.props.dir || null} className={ searchClass } role="search">
 				<Spinner />
 				<div
 					className="search__icon-navigation"

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -266,8 +266,8 @@ const Search = React.createClass( {
 	},
 
 	render: function() {
-		let searchValue = this.state.keyword,
-			placeholder = this.props.placeholder ||
+		const searchValue = this.state.keyword;
+		const placeholder = this.props.placeholder ||
 				i18n.translate( 'Search…', { textOnly: true } );
 
 		const enableOpenIcon = this.props.pinned && ! this.state.isOpen;
@@ -293,7 +293,7 @@ const Search = React.createClass( {
 		const inputClass = classNames( 'search__input', this.props.dir );
 
 		return (
-			<div dir={this.props.dir || null} className={ searchClass } role="search">
+			<div dir={ this.props.dir || null } className={ searchClass } role="search">
 				<Spinner />
 				<div
 					className="search__icon-navigation"
@@ -306,7 +306,7 @@ const Search = React.createClass( {
 					}
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }>
-					<Gridicon icon="search" className="search__open-icon"/>
+					<Gridicon icon="search" className="search__open-icon" />
 				</div>
 				<div className={ fadeDivClass }>
 					<input
@@ -345,7 +345,7 @@ const Search = React.createClass( {
 					onKeyDown={ this.closeListener }
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
-					<Gridicon icon="cross" className="search__close-icon"/>
+					<Gridicon icon="cross" className="search__close-icon" />
 				</div>
 			);
 		}

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -285,16 +285,13 @@ const Search = React.createClass( {
 			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
-			'no-close-button': this.props.hideClose,
 			'has-focus': this.state.hasFocus,
 			search: true
 		} );
 
 		const gridIconClass = classNames( 'search-open__icon', this.props.dir );
 		const fadeDivClass = classNames( 'search__input-fade', this.props.dir );
-		const inputClass = classNames( 'search__input', this.props.dir, {
-			'no-close-button': this.props.hideClose
-		} );
+		const inputClass = classNames( 'search__input', this.props.dir );
 
 		return (
 			<div className={ searchClass } role="search">

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -289,7 +289,6 @@ const Search = React.createClass( {
 			search: true
 		} );
 
-		const gridIconClass = classNames( 'search-open__icon', this.props.dir );
 		const fadeDivClass = classNames( 'search__input-fade', this.props.dir );
 		const inputClass = classNames( 'search__input', this.props.dir );
 
@@ -307,7 +306,7 @@ const Search = React.createClass( {
 					}
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }>
-					<Gridicon icon="search" className={ gridIconClass }/>
+					<Gridicon icon="search" className="search__open-icon"/>
 				</div>
 				<div className={ fadeDivClass }>
 					<input

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -50,6 +50,10 @@
 		opacity: 0;
 		transition: opacity .2s ease-in;
 	}
+
+	&.has-focus {
+		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+	}
 }
 
 // Position collapsed search-button to the right
@@ -100,6 +104,7 @@
 	z-index: z-index( '.search', '.search__input' );
 	top: 0;
 	border: none;
+	height: 100%;
 	background: $white;
 	appearance: none;
 	box-sizing: border-box;
@@ -111,7 +116,8 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+		box-shadow: none;
+		border: none;
 	}
 }
 
@@ -158,6 +164,7 @@
 .search__input-fade {
 	flex: 1 1 auto;
 	position: inherit;
+	height: 51px;
 	&::before {
 		@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
 	}

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -22,7 +22,7 @@
 	}
 
 	.search-open__icon,
-	.search-close__icon {
+	.search__close-icon {
 		flex: 0 0 auto;
 		width: 50px;
 		z-index: z-index( '.search', '.search .search-open__icon' );
@@ -38,7 +38,7 @@
 		color: darken( $gray, 30% );
 	}
 
-	.search-close__icon {
+	.search__close-icon {
 		color: darken( $gray, 30% );
 		opacity: 0;
 		transition: opacity .2s ease-in;
@@ -104,12 +104,12 @@
 		color: darken( $gray, 30% );
 	}
 
-	.search-close__icon {
+	.search__close-icon {
 		display: inline-block;
 	}
 
 	.search__input,
-	.search-close__icon{
+	.search__close-icon {
 		opacity: 1;
 	}
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -111,8 +111,7 @@
 	}
 
 	&:focus {
-		box-shadow: none;
-		border: none;
+		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
 	}
 }
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -164,7 +164,6 @@
 .search__input-fade {
 	flex: 1 1 auto;
 	position: inherit;
-	height: 51px;
 	&::before {
 		@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
 	}

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -13,7 +13,7 @@
 	z-index: z-index( 'root', '.search' );
 	transition: box-shadow 0.15s;
 
-	.search-component-icon-div {
+	.search__component-icon-div {
 		flex: 0 0 auto;
 		display: flex;
 		align-items: center;

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -69,7 +69,6 @@
 	.search__input[type="search"] {
 		flex: 1 1 auto;
 		display: flex;
-		left: 50px;
 	}
 }
 
@@ -119,8 +118,8 @@
 
 	.search__input-fade {
 		flex: 1 1 auto;
-		position: inherit;
 		height: 100%;
+		position: relative;
 		&::before {
 			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
 		}

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -38,14 +38,6 @@
 	}
 
 	.search-close__icon {
-		&:not(.ltr) {
-			right: 0;
-		}
-
-		&.ltr {
-			right: 0 #{"/*rtl:ignore*/"};
-		}
-
 		color: darken( $gray, 30% );
 		opacity: 0;
 		transition: opacity .2s ease-in;
@@ -66,24 +58,6 @@
 	width: 50px;
 	top: 0;
 	right: 0;
-
-	&:not(.ltr) {
-		right: 0;
-	}
-
-	&.ltr {
-		right: 0 #{"/*rtl:ignore*/"};
-	}
-
-	.search-open__icon {
-		&:not(.ltr) {
-			right: 0;
-		}
-
-		&.ltr {
-			right: 0 #{"/*rtl:ignore*/"};
-		}
-	}
 
 	.search__input-fade {
 		position: relative;
@@ -123,27 +97,10 @@
 
 // When search input is opened
 .search.is-open {
-
-	&:not(.ltr) {
-		margin-right: 0 !important;
-	}
-
-	&.ltr {
-		margin-right: 0 #{"/*rtl:ignore*/"} !important;
-	}
-
 	width: 100%;
 
 	.search-open__icon {
 		color: darken( $gray, 30% );
-
-		&:not(.ltr) {
-			left: 0;
-		}
-
-		&.ltr {
-			left: 0 #{"/*rtl:ignore*/"};
-		}
 	}
 
 	.search-close__icon {
@@ -171,15 +128,6 @@
 
 .search .spinner {
 	display: none;
-
-	&:not(.ltr) {
-		left: 30px;
-	}
-
-	&.ltr {
-		left: 30px #{"/*rtl:ignore*/"};
-	}
-
 }
 
 .search.is-searching .search-open__icon {

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -2,22 +2,28 @@
  * @component Search
  */
 .search {
+	display: flex;
+	flex: 1 1 auto;
 	margin-bottom: 24px;
 	width: 60px;
 	height: 51px;
 	position: relative;
+	align-items: center;
 	// places search above filters
 	z-index: z-index( 'root', '.search' );
 
-	@include breakpoint( "<660px" ) {
-		width: 50px;
+	.search-component-icon-div {
+		flex: 0 0 auto;
+		display: flex;
+		align-items: center;
+		background-color: $white;
+		height: 100%;
 	}
 
-	.search-open__icon {
-		position: absolute;
-			top: 50%;
-		margin-top: -12px;
-		width: 60px;
+	.search-open__icon,
+	.search-close__icon {
+		flex: 0 0 auto;
+		width: 50px;
 		z-index: z-index( '.search', '.search .search-open__icon' );
 		color: $blue-wordpress;
 		cursor: pointer;
@@ -25,11 +31,6 @@
 		.accessible-focus &:focus {
 			outline: dotted 1px $blue-wordpress;
 		}
-
-		@include breakpoint( "<660px" ) {
-			width: 50px;
-		}
-
 	}
 
 	.search-open__icon:hover {
@@ -37,10 +38,6 @@
 	}
 
 	.search-close__icon {
-		position: absolute;
-			bottom: 0;
-			top: 50%;
-
 		&:not(.ltr) {
 			right: 0;
 		}
@@ -49,37 +46,9 @@
 			right: 0 #{"/*rtl:ignore*/"};
 		}
 
-		margin-top: -12px;
-		width: 60px;
-		cursor: pointer;
-		z-index: z-index( '.search', '.search .search-close__icon' );
 		color: darken( $gray, 30% );
-		display: none;
 		opacity: 0;
 		transition: opacity .2s ease-in;
-
-		.accessible-focus &:focus {
-			outline: dotted 1px $blue-wordpress;
-		}
-
-		&::before {
-			position: absolute;
-				left: 0;
-				right: 0;
-				top: 50%;
-			margin-top: -8px;
-			font-size: 16px;
-			text-align: center;
-
-			@include breakpoint( "<660px" ) {
-				font-size: 14px;
-				margin-top: -7px;
-			}
-		}
-
-		@include breakpoint( "<660px" ) {
-			width: 50px;
-		}
 	}
 }
 
@@ -87,10 +56,12 @@
 // of the container element
 .search.is-expanded-to-container {
 	margin-bottom: 0;
-	height: auto;
 	position: absolute;
-	bottom: 0;
+	display: flex;
+	height: 100%;
+	width: 50px;
 	top: 0;
+	right: 0;
 
 	&:not(.ltr) {
 		right: 0;
@@ -110,44 +81,38 @@
 		}
 	}
 
+	.search__input-fade {
+		position: relative;
+		flex: 1 1 auto;
+		display: flex;
+	}
+
 	.search__input[type="search"] {
-		height: 100%;
+		flex: 1 1 auto;
+		display: flex;
+		left: 50px;
 	}
 }
 
 .search__input[type="search"] {
+	flex: 1 1 auto;
 	display: none;
-	position: absolute;
 	z-index: z-index( '.search', '.search__input' );
 	top: 0;
-	padding: 0 50px 0 60px;
 	border: none;
 	background: $white;
-	height: 51px;
 	appearance: none;
 	box-sizing: border-box;
+	padding: 0px;
 	-webkit-appearance: none;
-
-	@include breakpoint( "<660px" ) {
-		opacity: 0;
-
-		&:not(.ltr) {
-			right: 0;
-			padding-left: 50px;
-		}
-
-		&.ltr {
-			left: 0 #{"/*rtl:ignore*/"};
-			padding-left: 50px #{"/*rtl:ignore*/"};
-		}
-	}
 
 	&::-webkit-search-cancel-button {
 		-webkit-appearance: none;
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+		box-shadow: none;
+		border: none;
 	}
 }
 
@@ -188,12 +153,19 @@
 	.search__input {
 		display: block;
 	}
+
+}
+
+.search__input-fade {
+	flex: 1 1 auto;
+	position: inherit;
+	&::before {
+		@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+	}
 }
 
 .search .spinner {
 	display: none;
-	position: absolute;
-		top: 50%;
 
 	&:not(.ltr) {
 		left: 30px;
@@ -203,18 +175,6 @@
 		left: 30px #{"/*rtl:ignore*/"};
 	}
 
-	transform: translate( -50%, -50% );
-
-	@include breakpoint( "<660px" ) {
-
-		&:not(.ltr) {
-			left: 25px;
-		}
-
-		&.ltr {
-			left: 25px #{"/*rtl:ignore*/"};
-		}
-	}
 }
 
 .search.is-searching .search-open__icon {
@@ -222,12 +182,13 @@
 }
 
 .search.is-searching .spinner {
-	display: block;
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	height: 100%;
 	z-index: z-index( '.search', '.search.is-searching .spinner' );
-}
 
-@include breakpoint( "<660px" ) {
-	.animating.search-opening .search input {
-		opacity: 1;
+	.spinner__image {
+		width: 50px;
 	}
 }

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -11,6 +11,7 @@
 	align-items: center;
 	// places search above filters
 	z-index: z-index( 'root', '.search' );
+	transition: box-shadow 0.15s;
 
 	.search-component-icon-div {
 		flex: 0 0 auto;
@@ -124,6 +125,12 @@
 	&::before {
 		@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
 	}
+
+	&.ltr {
+		&::before {
+			@include long-content-fade( $direction: left, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+		}
+	}
 }
 
 .search .spinner {
@@ -144,4 +151,8 @@
 	.spinner__image {
 		width: 50px;
 	}
+}
+
+.animating.search-opening .search input {
+		opacity: 1;
 }

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -21,11 +21,11 @@
 		height: 100%;
 	}
 
-	.search-open__icon,
+	.search__open-icon,
 	.search__close-icon {
 		flex: 0 0 auto;
 		width: 50px;
-		z-index: z-index( '.search', '.search .search-open__icon' );
+		z-index: z-index( '.search', '.search .search__open-icon' );
 		color: $blue-wordpress;
 		cursor: pointer;
 
@@ -34,7 +34,7 @@
 		}
 	}
 
-	.search-open__icon:hover {
+	.search__open-icon:hover {
 		color: darken( $gray, 30% );
 	}
 
@@ -100,7 +100,7 @@
 .search.is-open {
 	width: 100%;
 
-	.search-open__icon {
+	.search__open-icon {
 		color: darken( $gray, 30% );
 	}
 
@@ -138,7 +138,7 @@
 	display: none;
 }
 
-.search.is-searching .search-open__icon {
+.search.is-searching .search__open-icon {
 	display: none;
 }
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -124,9 +124,9 @@
 			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
 		}
 
-		&.ltr {
+		&.ltr { /*rtl:ignore*/
 			&::before {
-				@include long-content-fade( $direction: left, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+				@include long-content-fade( $direction: right, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
 			}
 		}
 	}

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -13,7 +13,7 @@
 	z-index: z-index( 'root', '.search' );
 	transition: box-shadow 0.15s;
 
-	.search__component-icon-div {
+	.search__icon-navigation {
 		flex: 0 0 auto;
 		display: flex;
 		align-items: center;

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -117,19 +117,18 @@
 		display: block;
 	}
 
-}
-
-.search__input-fade {
-	flex: 1 1 auto;
-	position: inherit;
-	height: 100%;
-	&::before {
-		@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
-	}
-
-	&.ltr {
+	.search__input-fade {
+		flex: 1 1 auto;
+		position: inherit;
+		height: 100%;
 		&::before {
-			@include long-content-fade( $direction: left, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+		}
+
+		&.ltr {
+			&::before {
+				@include long-content-fade( $direction: left, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+			}
 		}
 	}
 }

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -122,6 +122,7 @@
 .search__input-fade {
 	flex: 1 1 auto;
 	position: inherit;
+	height: 100%;
 	&::before {
 		@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
 	}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -67,6 +67,8 @@
 
 .site-selector .search {
  	margin: 8px;
+	width: auto;
+	height: 33px;
  }
 
 // The actual list of sites

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -9,6 +9,14 @@
 	border: none;
 	z-index: z-index( 'root', '.site-selector' );
 
+	&.is-large .search  {
+		display: flex;
+	}
+
+	&.is-large .site-selector__sites {
+		border-top: 1px solid lighten( $gray, 20% );
+	}
+
 }
 
 // Styles for Site elements within the Selector
@@ -70,6 +78,7 @@
 	width: auto;
 	height: 33px;
 	border: 1px solid lighten( $gray, 20% );
+	display: none;
 
 	.search__input[type="search"] {
 		font-size: 13px;
@@ -88,7 +97,6 @@
 .site-selector__sites {
 	max-height: calc( 100% - 89px );
 	overflow-y: auto;
-	border-top: 1px solid lighten( $gray, 20% );
 }
 
 .site-selector__no-results {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -100,7 +100,7 @@
 		}
 	}
 
-	.search-open__icon {
+	.search__open-icon {
 		background-color: transparent;
 		border-left: none;
 		color: $gray;
@@ -123,7 +123,7 @@
 	}
 
 	&.is-open {
-		.search-close__icon {
+		.search__close-icon {
 			color: $gray;
 
 			&:not(.ltr) {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -9,9 +9,6 @@
 	border: none;
 	z-index: z-index( 'root', '.site-selector' );
 
-	&.is-large .search  {
-		display: block;
-	}
 }
 
 // Styles for Site elements within the Selector
@@ -69,77 +66,8 @@
 }
 
 .site-selector .search {
-	display: none;
-	margin-bottom: 0;
-	width: auto;
-	height: auto;
-	padding: 8px;
-	border-bottom: 1px solid lighten( $gray, 30% );
-
-	.search__input[type="search"] {
-		position: relative;
-		height: auto;
-		padding-top: 6px;
-		padding-bottom: 6px;
-		padding-left: 32px;
-		font-size: 13px;
-		border: 1px solid lighten( $gray, 20% );
-		-webkit-appearance: none;
-
-		&:hover {
-			border: 1px solid lighten( $gray, 10% );
-			background-color: $white;
-		}
-
-		&::-webkit-input-placeholder {
-			color: $gray;
-		}
-
-		&::-moz-placeholder {
-			color: $gray;
-		}
-	}
-
-	.search__open-icon {
-		background-color: transparent;
-		border-left: none;
-		color: $gray;
-		padding: 0;
-		width: auto;
-		position: absolute;
-			top: 50%;
-
-		&:not(.ltr) {
-			left: 18px;
-		}
-
-		&.ltr {
-			left: 18px #{"/*rtl:ignore*/"};
-		}
-
-		margin-top: -9px;
-		width: 18px;
-		height: 18px;
-	}
-
-	&.is-open {
-		.search__close-icon {
-			color: $gray;
-
-			&:not(.ltr) {
-				right: 16px;
-			}
-
-			&.ltr {
-				right: 16px #{"/*rtl:ignore*/"};
-			}
-
-			margin-top: -9px;
-			width: 18px;
-			height: 18px;
-		}
-	}
-}
+ 	margin: 8px;
+ }
 
 // The actual list of sites
 .site-selector__sites {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -69,6 +69,18 @@
  	margin: 8px;
 	width: auto;
 	height: 33px;
+
+	.search__input[type="search"] {
+		font-size: 13px;
+	}
+
+	.search__open-icon,
+	.search__close-icon {
+		color: $gray;
+		width: 32px;
+		height: 18px;
+	}
+
  }
 
 // The actual list of sites

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -69,6 +69,7 @@
  	margin: 8px;
 	width: auto;
 	height: 33px;
+	border: 1px solid lighten( $gray, 20% );
 
 	.search__input[type="search"] {
 		font-size: 13px;
@@ -87,6 +88,7 @@
 .site-selector__sites {
 	max-height: calc( 100% - 89px );
 	overflow-y: auto;
+	border-top: 1px solid lighten( $gray, 20% );
 }
 
 .site-selector__no-results {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -68,7 +68,6 @@
 		top: 67px;
 		left: 0;
 		right: 0;
-	margin: 0;
 }
 
 .sites-dropdown .site-selector .search input {

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -12,4 +12,8 @@
 
 .sites__selector-wrapper.card {
 	padding: 0;
+
+	.site-selector {
+		overflow: auto;
+	}
 }

--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -12,7 +12,7 @@
 		margin: 0;
 	}
 
-	.search .search-open__icon {
+	.search .search__open-icon {
 		color: lighten( $gray, 10% );
 	}
 

--- a/client/post-editor/editor-location/style.scss
+++ b/client/post-editor/editor-location/style.scss
@@ -10,7 +10,7 @@
 	margin-bottom: 1px;;
 }
 
-.editor-location__search .search-open__icon {
+.editor-location__search .search__open-icon {
 	width: 40px;
 }
 
@@ -23,7 +23,7 @@
 	padding: 0 40px 0 40px;
 }
 
-.editor-location__search .search-close__icon {
+.editor-location__search .search__close-icon {
 	width: 40px;
 }
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -129,16 +129,11 @@
 
 	.search {
 		margin-bottom: 0;
+		z-index: z-index( '.following-edit', '.following-edit__subscribe-form .search' );
 	}
 
 	.search__input[type="search"] {
 		height: 50px;
-		border: 1px solid transparent;
-
-		&:focus {
-			border-color: $blue-wordpress;
-			box-shadow: 0 0 0 2px $blue-light;
-		}
 	}
 
 	.card.is-search-result {

--- a/config/development.json
+++ b/config/development.json
@@ -6,7 +6,7 @@
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": false,
-	"rtl": false,
+	"rtl": true,
 	"jetpack_min_version": "3.3",
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/config/development.json
+++ b/config/development.json
@@ -6,7 +6,7 @@
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": false,
-	"rtl": true,
+	"rtl": false,
 	"jetpack_min_version": "3.3",
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
This PR aims to address issues the `<Search>` component has when used in small widths like for example when search is used on a card with other components: 
![search-error](https://cloud.githubusercontent.com/assets/17271089/17693875/70c710c0-63a1-11e6-9f67-12dca5b7612c.png)
This could be an issue for `/design` on Mobile. To achieve this current static design of search with elements like looking glass or the close button located on padding was replaced with flex layout. This also improves space performance in small widths as the close button space is available to text. 

Other changes to search that fit well with this PR because of overlapping code scope:

1. Search highlight added: 
![highlight](https://cloud.githubusercontent.com/assets/17271089/17695182/b1d7160e-63a7-11e6-9fbf-f3c3f69810d9.png)
Previously highlight was done using `:focus` CSS selector. Now it is impossible to do it in pure CSS (except CSS4) as `<input>` component is not the outlining shape. JS + CSS was used. This way of doing this is also beneficial for work currently done in `/design` as it will allow making highlight as an option - which `/design` will use to create highlight around whole search card and not just input field like so:
![big_highlight](https://cloud.githubusercontent.com/assets/17271089/17695402/b6fdb3a8-63a8-11e6-857d-b5c6bee92e62.png)
2. New callback `onSearchOpen` that can pass information to the parent that the search field was opened. It will be used for implementing highlight and other logic required by new `/design`
3. New prop `hideClose`. When this is set to true the close button(X) is not displayed. Proves to be very useful in small widths. 
4. Fade on long input added. 
![fade](https://cloud.githubusercontent.com/assets/17271089/17697170/71768d0e-63b3-11e6-91f1-5215d843346e.png)




Test live: https://calypso.live/design?branch=update/use-flex-in-search-component