### PR TITLE
Jetpack Connect: Add missing action tests

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -129,11 +129,16 @@ function mapPostStatus( status ) {
 	}
 }
 
+function externalRedirect( url ) {
+	window.location = url;
+}
+
 module.exports = {
 	getSiteFragment: getSiteFragment,
 	addSiteFragment: addSiteFragment,
 	getStatsDefaultSitePage: getStatsDefaultSitePage,
 	getStatsPathForTab: getStatsPathForTab,
 	sectionify: sectionify,
-	mapPostStatus: mapPostStatus
+	mapPostStatus: mapPostStatus,
+	externalRedirect: externalRedirect
 };

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -36,6 +36,7 @@ import {
 import userFactory from 'lib/user';
 import config from 'config';
 import addQueryArgs from 'lib/route/add-query-args';
+import { externalRedirect } from 'lib/route/path';
 
 /**
  *  Local variables;
@@ -177,10 +178,12 @@ export default {
 				url: url,
 				type: 'remote_auth'
 			} );
-			window.location = addQueryArgs( {
-				jetpack_connect_url: url + remoteAuthPath,
-				calypso_env: calypsoEnv
-			}, apiBaseUrl );
+			externalRedirect(
+				addQueryArgs( {
+					jetpack_connect_url: url + remoteAuthPath,
+					calypso_env: calypsoEnv
+				}, apiBaseUrl )
+			);
 		};
 	},
 	goToPluginInstall( url ) {
@@ -193,10 +196,12 @@ export default {
 				url: url,
 				type: 'plugin_install'
 			} );
-			window.location = addQueryArgs( {
-				jetpack_connect_url: url + remoteInstallPath,
-				calypso_env: calypsoEnv
-			}, apiBaseUrl );
+			externalRedirect(
+				addQueryArgs( {
+					jetpack_connect_url: url + remoteInstallPath,
+					calypso_env: calypsoEnv
+				}, apiBaseUrl )
+			);
 		};
 	},
 	goToPluginActivation( url ) {
@@ -209,10 +214,12 @@ export default {
 				url: url,
 				type: 'plugin_activation'
 			} );
-			window.location = addQueryArgs( {
-				jetpack_connect_url: url + remoteActivatePath,
-				calypso_env: calypsoEnv
-			}, apiBaseUrl );
+			externalRedirect(
+				addQueryArgs( {
+					jetpack_connect_url: url + remoteActivatePath,
+					calypso_env: calypsoEnv
+				}, apiBaseUrl )
+			);
 		};
 	},
 	goBackToWpAdmin( url ) {
@@ -220,7 +227,7 @@ export default {
 			dispatch( {
 				type: JETPACK_CONNECT_REDIRECT_WP_ADMIN
 			} );
-			window.location = url;
+			externalRedirect( url );
 		};
 	},
 	goToXmlrpcErrorFallbackUrl( queryObject, authorizationCode ) {
@@ -234,7 +241,7 @@ export default {
 				url
 			} );
 			tracksEvent( dispatch, 'calyspo_jpc_xmlrpc_error', { error: queryObject.authorizeError } );
-			window.location = url;
+			externalRedirect( url );
 		};
 	},
 	createAccount( userData ) {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -285,7 +285,7 @@ export default {
 				type: JETPACK_CONNECT_AUTHORIZE,
 				queryObject: queryObject
 			} );
-			wpcom.undocumented().jetpackLogin( client_id, _wp_nonce, redirect_uri, scope, state )
+			return wpcom.undocumented().jetpackLogin( client_id, _wp_nonce, redirect_uri, scope, state )
 			.then( ( data ) => {
 				debug( 'Jetpack login complete. Trying Jetpack authorize.', data );
 				dispatch( {
@@ -336,7 +336,7 @@ export default {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 					siteId: client_id,
 					data: null,
-					error: error
+					error: pick( error, [ 'error', 'status', 'message' ] )
 				} );
 			} );
 		};

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -401,7 +401,7 @@ export default {
 				type: JETPACK_CONNECT_ACTIVATE_MANAGE,
 				blogId: blogId
 			} );
-			wpcom.undocumented().activateManage( blogId, state, secret )
+			return wpcom.undocumented().activateManage( blogId, state, secret )
 			.then( ( data ) => {
 				tracksEvent( dispatch, 'calypso_jpc_activate_manage_success' );
 				debug( 'Manage activated!', data );
@@ -417,7 +417,7 @@ export default {
 				dispatch( {
 					type: JETPACK_CONNECT_ACTIVATE_MANAGE_RECEIVE,
 					data: null,
-					error: error
+					error: pick( error, [ 'error', 'status', 'message' ] )
 				} );
 			} );
 		};

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -10,6 +10,8 @@ import nock from 'nock';
 import {
 	JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
 	JETPACK_CONNECT_DISMISS_URL_STATUS,
+	JETPACK_CONNECT_REDIRECT,
+	JETPACK_CONNECT_REDIRECT_WP_ADMIN,
 	JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST,
 	JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
 	JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
@@ -20,6 +22,7 @@ import {
 
 import useFakeDom from 'test/helpers/use-fake-dom';
 import { useSandbox } from 'test/helpers/use-sinon';
+import path from 'lib/route/path';
 
 describe( 'actions', () => {
 	let actions, sandbox, spy;
@@ -29,6 +32,7 @@ describe( 'actions', () => {
 	useSandbox( newSandbox => {
 		sandbox = newSandbox;
 		spy = sandbox.spy();
+		sandbox.stub( path, 'externalRedirect' );
 	} );
 
 	beforeEach( function() {
@@ -59,6 +63,61 @@ describe( 'actions', () => {
 			expect( spy ).to.have.been.calledWith( {
 				type: JETPACK_CONNECT_DISMISS_URL_STATUS,
 				url: url
+			} );
+		} );
+	} );
+
+	describe( '#goToRemoteAuth()', () => {
+		it( 'should dispatch redirect action when called', () => {
+			const { goToRemoteAuth } = actions;
+			const url = 'http://example.com';
+
+			goToRemoteAuth( url )( spy );
+
+			expect( spy ).to.have.been.calledWith( {
+				type: JETPACK_CONNECT_REDIRECT,
+				url: url
+			} );
+		} );
+	} );
+
+	describe( '#goToPluginInstall()', () => {
+		it( 'should dispatch redirect action when called', () => {
+			const { goToPluginInstall } = actions;
+			const url = 'http://example.com';
+
+			goToPluginInstall( url )( spy );
+
+			expect( spy ).to.have.been.calledWith( {
+				type: JETPACK_CONNECT_REDIRECT,
+				url: url
+			} );
+		} );
+	} );
+
+	describe( '#goToPluginActivation()', () => {
+		it( 'should dispatch redirect action when called', () => {
+			const { goToPluginActivation } = actions;
+			const url = 'http://example.com';
+
+			goToPluginActivation( url )( spy );
+
+			expect( spy ).to.have.been.calledWith( {
+				type: JETPACK_CONNECT_REDIRECT,
+				url: url
+			} );
+		} );
+	} );
+
+	describe( '#goBackToWpAdmin()', () => {
+		it( 'should dispatch redirect action when called', () => {
+			const { goBackToWpAdmin } = actions;
+			const url = 'http://example.com';
+
+			goBackToWpAdmin( url )( spy );
+
+			expect( spy ).to.have.been.calledWith( {
+				type: JETPACK_CONNECT_REDIRECT_WP_ADMIN,
 			} );
 		} );
 	} );

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -8,12 +8,14 @@ import nock from 'nock';
  * Internal dependencies
  */
 import {
+	JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
+	JETPACK_CONNECT_DISMISS_URL_STATUS,
 	JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST,
 	JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
 	JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
 	JETPACK_CONNECT_SSO_VALIDATION_REQUEST,
 	JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
-	JETPACK_CONNECT_SSO_VALIDATION_ERROR,
+	JETPACK_CONNECT_SSO_VALIDATION_ERROR
 } from 'state/action-types';
 
 import useFakeDom from 'test/helpers/use-fake-dom';
@@ -31,6 +33,34 @@ describe( 'actions', () => {
 
 	beforeEach( function() {
 		actions = require( '../actions' );
+	} );
+
+	describe( '#confirmJetpackInstallStatus()', () => {
+		it( 'should dispatch confirm status action when called', () => {
+			const { confirmJetpackInstallStatus } = actions;
+			const jetpackStatus = true;
+
+			confirmJetpackInstallStatus( jetpackStatus )( spy );
+
+			expect( spy ).to.have.been.calledWith( {
+				type: JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
+				status: jetpackStatus
+			} );
+		} );
+	} );
+
+	describe( '#dismissUrl()', () => {
+		it( 'should dispatch dismiss url status action when called', () => {
+			const { dismissUrl } = actions;
+			const url = 'http://example.com';
+
+			dismissUrl( url )( spy );
+
+			expect( spy ).to.have.been.calledWith( {
+				type: JETPACK_CONNECT_DISMISS_URL_STATUS,
+				url: url
+			} );
+		} );
 	} );
 
 	describe( '#validateSSONonce()', () => {

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -156,7 +156,7 @@ describe( 'actions', () => {
 			redirect_uri: 'https://example.com/',
 			scope: 'auth',
 			secret: '1234abcd',
-			state: 'abcd1234'
+			state: 12345678
 		};
 		const code = 'abcdefghi1234';
 		const activateManageSecret = 'klmnop1234';

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -12,6 +12,7 @@ import {
 	JETPACK_CONNECT_DISMISS_URL_STATUS,
 	JETPACK_CONNECT_REDIRECT,
 	JETPACK_CONNECT_REDIRECT_WP_ADMIN,
+	JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL,
 	JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST,
 	JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
 	JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
@@ -118,6 +119,26 @@ describe( 'actions', () => {
 
 			expect( spy ).to.have.been.calledWith( {
 				type: JETPACK_CONNECT_REDIRECT_WP_ADMIN,
+			} );
+		} );
+	} );
+
+	describe( '#goToXmlrpcErrorFallbackUrl()', () => {
+		it( 'should dispatch redirect with xmlrpc error action when called', () => {
+			const { goToXmlrpcErrorFallbackUrl } = actions;
+			const queryObject = {
+				state: '12345678',
+				redirect_uri: 'https://example.com/',
+				authorizeError: {}
+			};
+			const authorizationCode = 'abcdefgh';
+			const url = queryObject.redirect_uri + '?code=' + authorizationCode + '&state=' + queryObject.state;
+
+			goToXmlrpcErrorFallbackUrl( queryObject, authorizationCode )( spy );
+
+			expect( spy ).to.have.been.calledWith( {
+				type: JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL,
+				url
 			} );
 		} );
 	} );


### PR DESCRIPTION
This PR adds some missing tests for Jetpack Connect actions. It does not cover a couple of actions that will need a more significant refactor in order to be tested.

To test:

1. Get this branch going at your Calypso development environment.
2. In your command line terminal, navigate to your Calypso directory and run the following command: `npm run test-client -- --grep "state jetpack-connect actions"`. Verify all tests are passing ✅ .
3. Since the PR introduces minor changes to Jetpack Connect actions in order to make them testable, verify that there are no regressions in any of the JPC flows.

Test live: https://calypso.live/?branch=update/jetpack-connect-state-actions-tests