### PR TITLE
Jetpack Connect: Lowercase the URL in the site URL input

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -93,7 +93,7 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	getCurrentUrl() {
-		let url = this.refs.siteUrlInputRef.state.value;
+		let url = this.refs.siteUrlInputRef.state.value.toLowerCase();
 		if ( url && url.substr( 0, 4 ) !== 'http' ) {
 			url = 'http://' + url;
 		}

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -92,6 +92,7 @@ export default React.createClass( {
 						icon="globe" />
 					<FormTextInput
 						ref="siteUrl"
+						autoCapitalize="off"
 						autoFocus="autofocus"
 						onChange={ this.onChange }
 						disabled={ this.props.isFetching }


### PR DESCRIPTION
### Purpose 

This PR addresses a small issue with the site URL field in the initial Jetpack Connect screen. When the user inputs a lowercase URL, everything works as expected. However, inputting the same thing with one or more capital letters can lead to different, or delayed results. This behavior is emphasized on mobile devices by the automatic capitalization of the first letter. 

![](https://cldup.com/pqYk2ghg_P.png)

So this PR suggests two simple things:

* Lowercase the site URL value before using it.
* Disable automatic capitalization on mobile devices.

### Inspiration

This PR was inspired by @ebinnion's sharp eyesight (https://github.com/Automattic/wp-calypso/pull/7458).

### How to reproduce:

* Go to https://wordpress.com/jetpack/connect.
* Input the site URL of an already connected Jetpack site. You will see a `Your site is already connected!` message, which is expected.
* Now input the same URL, but with one or more capital letters. The check URL flow will be initiated, and you will be presented with the loading spinner. This is wrong, because this site is already connected.

### How to test this PR

* Checkout this branch - `update/jetpack-connect-site-input-lowercase`
* Go to `/jetpack/connect`.
* Input the site URL of an already existing Jetpack site, but use at least one capital letter.
* Click the "Connect Now" button.
* Verify you're presented with the `Your site is already connected!` message.
* Follow the same steps on mobile.

/cc @johnHackworth for review.

Test live: https://calypso.live/?branch=update/jetpack-connect-site-input-lowercase