### PR TITLE
Jetpack Connect: Minor ESLint polish on the Site URL input

### DIFF
--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -45,11 +45,11 @@ export default React.createClass( {
 	renderButtonLabel() {
 		if ( ! this.props.isFetching ) {
 			if ( ! this.props.isInstall ) {
-				return( this.translate( 'Connect Now' ) );
+				return this.translate( 'Connect Now' );
 			}
 			return this.translate( 'Start Installation' );
 		}
-		return( this.translate( 'Connecting…' ) );
+		return this.translate( 'Connecting…' );
 	},
 
 	handleKeyPress( event ) {


### PR DESCRIPTION
This simple PR takes care of two ESLint warnings in `client/signup/jetpack-connect/site-url-input.jsx`:

![](https://cldup.com/nXHGAsFmxx.thumb.png)

Test live: https://calypso.live/?branch=update/jetpack-connect-site-input-eslint