### PR TITLE
Reader: fix link colours in refreshed full post view

### DIFF
--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -24,12 +24,11 @@
     		}
     	}
 
-			&.is-following .follow-button__label {
-				color: $alert-green;
-			}
+		&.is-following .follow-button__label {
+			color: $alert-green;
+		}
 
 		&:hover {
-
 			.gridicon__follow {
 				fill: lighten( $gray, 10% );
 			}
@@ -38,6 +37,19 @@
 				color: lighten( $gray, 10% );
 			}
 		}
+
+        // No hover if already following
+        &.is-following {
+            &:hover {
+                .gridicon__follow {
+                    fill: $alert-green;
+                }
+
+                .follow-button__label {
+                    color: $alert-green;
+                }
+            }
+        }
     }
 }
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -85,7 +85,7 @@
 }
 
 .reader-full-post .author-compact-profile {
-	z-index: z-index( '.masterbar', '.reader-profile'	);
+	z-index: z-index( '.masterbar', '.reader-profile' );
 	@include breakpoint( "<660px" ) {
 		margin-top: 20px;
 		.gravatar {
@@ -113,6 +113,19 @@
 
 		.author-compact-profile__follow-count {
 			display: none;
+		}
+	}
+}
+
+.reader-full-post .reader-full-post__sidebar {
+	color: lighten( $gray, 10% );
+
+	a.reader-author-link,
+	a.author-compact-profile__site-link {
+		color: $blue-medium;
+
+		&:hover {
+			color: $blue-light;
 		}
 	}
 }
@@ -194,7 +207,7 @@
 	color: $gray;
 
 	&:hover {
-		color: darken( $gray, 20% );
+		color: $blue-light;
 	}
 }
 
@@ -249,6 +262,6 @@
 	color: $gray;
 
 	&:hover {
-		color: darken( $gray, 20% );
+		color: $blue-light;
 	}
 }


### PR DESCRIPTION
@fraying suggested the following link colours for the new full post view:

> Sidebar (author name, site name, follower count, and comment/like counts):
> Normal: Gray Lighten 10 (#a8bece)
> Link: Medium Blue (#00aadc)
> Hover: Light Blue (#78dcfa)
> 
> Date and tags:
> Normal: Gray Lighten 10 (#a8bece)
> Link: Gray (#87a6bc)
> Hover: Light Blue (#78dcfa)

This marvellous PR implements them.

Test live: https://calypso.live/?branch=fix/reader/full-post-colors