### PR TITLE
Signup: Add side spacing to step header for small mobile devices

### DIFF
--- a/client/signup/step-header/style.scss
+++ b/client/signup/step-header/style.scss
@@ -14,6 +14,10 @@
 .step-header__title {
 	font-size: 24px;
 	margin: 0 0 5px 0;
+
+	@include breakpoint( "<480px" ) {
+		padding: 0 20px;
+	}
 }
 
 .step-header__subtitle {


### PR DESCRIPTION
### Purpose

This PR adds side spacing to the Signup step header title for devices smaller than `< 480px` width. Reason - on certain devices with smaller width, the title bumps into the sides. 

### How to reproduce

Scale to `360px` width, or use a device that uses this width. I'm able to reproduce it with my Samsung Galaxy Note 4, here is a preview:

![](https://cldup.com/1rj3HV8dw0.png)

### Solution

We should allow the title to breathe a little. This PR is following the same pattern that is applied on the subtitle - it adds `20px` to both sides when on a device with width up to `480px`. 

So if we use the Inspector for guide, it changes from this:

![](https://cldup.com/IdrLL7b3Gv.png)

to this:

![](https://cldup.com/ImXszq4fU9.png)

### Testing instructions

* Checkout this branch - `update/signup-header-title-side-spacing`.
* Either scale your browser to 360px width, or use a mobile device with that width.
* Head to `/jetpack/connect`
* Verify that the title goes on two lines, instead of bumping into the sides.





Test live: https://calypso.live/?branch=update/signup-header-title-side-spacing