### PR TITLE
Editor: remove extra label on token-field CPT term selector

### DIFF
--- a/client/post-editor/term-token-field/index.jsx
+++ b/client/post-editor/term-token-field/index.jsx
@@ -20,7 +20,6 @@ import { decodeEntities } from 'lib/formatting';
 import TermsConstants from 'lib/terms/constants';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import QueryTerms from 'components/data/query-terms';
-import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 
 const debug = _debug( 'calypso:post-editor:editor-terms' );
 
@@ -69,7 +68,7 @@ class TermTokenField extends React.Component {
 		const termNames = map( this.props.terms, 'name' );
 
 		return (
-			<EditorDrawerLabel labelText={ this.props.taxonomyLabel }>
+			<div>
 				<QueryTerms
 					siteId={ this.props.siteId }
 					taxonomy={ this.props.taxonomyName }
@@ -82,7 +81,7 @@ class TermTokenField extends React.Component {
 					onChange={ this.boundOnTermsChange }
 					maxSuggestions={ TermsConstants.MAX_TERMS_SUGGESTIONS }
 				/>
-			</EditorDrawerLabel>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
Originally brought up by @aduth in #7412 - this branch removes the extra label that is shown on non-hierarchical terms in the editor.  This matches the hierarchical term-tree-selector accordion which does not display a label either:

__Before__
<img width="273" alt="new_project_ _testingtimmy2_wordpress_com_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/17701983/e472816a-6380-11e6-994e-ea1e63356550.png">

__After__
<img width="271" alt="new_project_ _testingtimmy2_wordpress_com_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/17702007/fc3ee234-6380-11e6-8e7e-0c6f32cd7e03.png">

__To Test__
- Open up a Portfolio CPT in the editor
- Expand the "Project Tags" accordion

Test live: https://calypso.live/?branch=update/editor/remove-taxonomy-label