### PR TITLE
Editor: Fix negative draft count on newly published draft

### DIFF
--- a/client/state/posts/counts/reducer.js
+++ b/client/state/posts/counts/reducer.js
@@ -108,7 +108,7 @@ export const counts = ( () => {
 			memo[ subKey ] = {};
 
 			// Decrement count from the current status before transitioning
-			memo[ subKey ][ postStatus.status ] = ( subKeyCounts[ postStatus.status ] || 0 ) - 1;
+			memo[ subKey ][ postStatus.status ] = Math.max( ( subKeyCounts[ postStatus.status ] || 0 ) - 1, 0 );
 
 			// So long as we're not trashing an already trashed post or page,
 			// increment the count for the transitioned status
@@ -165,11 +165,6 @@ export const counts = ( () => {
 
 				postStatuses[ postStatusKey ] = pick( post, 'type', 'status' );
 				postStatuses[ postStatusKey ].authorId = get( post.author, 'ID' );
-
-				// If the post wasn't previously known to us, track new status
-				if ( ! postStatus ) {
-					state = transitionPostStateToStatus( state, post.site_ID, post.ID, post.status );
-				}
 			} );
 
 			return state;

--- a/client/state/posts/counts/selectors.js
+++ b/client/state/posts/counts/selectors.js
@@ -43,7 +43,12 @@ export function getAllPostCounts( state, siteId, postType ) {
  * @return {Number}          Post count
  */
 export function getAllPostCount( state, siteId, postType, status ) {
-	return get( getAllPostCounts( state, siteId, postType ), status, null );
+	const counts = getAllPostCounts( state, siteId, postType );
+	if ( ! counts ) {
+		return null;
+	}
+
+	return counts[ status ] || 0;
 }
 
 /**
@@ -69,7 +74,12 @@ export function getMyPostCounts( state, siteId, postType ) {
  * @return {Number}          Post count
  */
 export function getMyPostCount( state, siteId, postType, status ) {
-	return get( getMyPostCounts( state, siteId, postType ), status, null );
+	const counts = getMyPostCounts( state, siteId, postType );
+	if ( ! counts ) {
+		return null;
+	}
+
+	return counts[ status ] || 0;
 }
 
 /**

--- a/client/state/posts/counts/test/reducer.js
+++ b/client/state/posts/counts/test/reducer.js
@@ -399,7 +399,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'should increment status when receiving an unrecognized post when counts known', () => {
+		it( 'should never decrement a status count into negatives', () => {
 			let state = counts( undefined, {
 				type: POST_COUNTS_RECEIVE,
 				siteId: 2916284,
@@ -417,29 +417,18 @@ describe( 'reducer', () => {
 				]
 			} );
 
-			expect( state ).to.eql( {
-				2916284: {
-					post: {
-						all: { publish: 3, draft: 1, trash: 0 },
-						mine: { publish: 2, draft: 0, trash: 0 }
-					}
-				}
-			} );
-		} );
-
-		it( 'should increment status when receiving an unrecognized post when counts unknown', () => {
-			const state = counts( undefined, {
+			state = counts( state, {
 				type: POSTS_RECEIVE,
 				posts: [
-					{ ID: 98, site_ID: 2916284, type: 'post', status: 'draft', author: { ID: 73705554 } }
+					{ ID: 98, site_ID: 2916284, type: 'post', status: 'publish', author: { ID: 73705554 } }
 				]
 			} );
 
 			expect( state ).to.eql( {
 				2916284: {
 					post: {
-						all: { draft: 1 },
-						mine: {}
+						all: { publish: 4, draft: 0, trash: 0 },
+						mine: { publish: 2, draft: 0, trash: 0 }
 					}
 				}
 			} );

--- a/client/state/posts/counts/test/reducer.js
+++ b/client/state/posts/counts/test/reducer.js
@@ -399,6 +399,52 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should increment status when receiving an unrecognized post when counts known', () => {
+			let state = counts( undefined, {
+				type: POST_COUNTS_RECEIVE,
+				siteId: 2916284,
+				postType: 'post',
+				counts: {
+					all: { publish: 3, draft: 0, trash: 0 },
+					mine: { publish: 2, draft: 0, trash: 0 }
+				}
+			} );
+
+			state = counts( state, {
+				type: POSTS_RECEIVE,
+				posts: [
+					{ ID: 98, site_ID: 2916284, type: 'post', status: 'draft', author: { ID: 73705554 } }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					post: {
+						all: { publish: 3, draft: 1, trash: 0 },
+						mine: { publish: 2, draft: 0, trash: 0 }
+					}
+				}
+			} );
+		} );
+
+		it( 'should increment status when receiving an unrecognized post when counts unknown', () => {
+			const state = counts( undefined, {
+				type: POSTS_RECEIVE,
+				posts: [
+					{ ID: 98, site_ID: 2916284, type: 'post', status: 'draft', author: { ID: 73705554 } }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					post: {
+						all: { draft: 1 },
+						mine: {}
+					}
+				}
+			} );
+		} );
+
 		it( 'should persist state', () => {
 			const original = deepFreeze( {
 				2916284: {

--- a/client/state/posts/counts/test/selectors.js
+++ b/client/state/posts/counts/test/selectors.js
@@ -67,9 +67,7 @@ describe( 'selectors', () => {
 		it( 'should return null if counts haven\'t been received for site', () => {
 			const postCounts = getAllPostCounts( {
 				posts: {
-					counts: {
-						all: {}
-					}
+					counts: {}
 				}
 			}, 2916284, 'post' );
 
@@ -85,7 +83,8 @@ describe( 'selectors', () => {
 								post: {
 									all: {
 										publish: 2
-									}
+									},
+									mine: {}
 								}
 							}
 						}
@@ -100,8 +99,20 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getAllPostCount()', () => {
+		it( 'should return null if post counts haven\'t been received for site', () => {
+			const postCount = getAllPostCount( {
+				posts: {
+					counts: {
+						counts: {}
+					}
+				}
+			}, 2916284, 'post', 'publish' );
+
+			expect( postCount ).to.be.null;
+		} );
+
 		it( 'should return post count for status', () => {
-			const postCounts = getAllPostCount( {
+			const postCount = getAllPostCount( {
 				posts: {
 					counts: {
 						counts: {
@@ -109,7 +120,8 @@ describe( 'selectors', () => {
 								post: {
 									all: {
 										publish: 2
-									}
+									},
+									mine: {}
 								}
 							}
 						}
@@ -117,7 +129,28 @@ describe( 'selectors', () => {
 				}
 			}, 2916284, 'post', 'publish' );
 
-			expect( postCounts ).to.equal( 2 );
+			expect( postCount ).to.equal( 2 );
+		} );
+
+		it( 'should return 0 if post counts have been received for site, but no status key exists', () => {
+			const postCount = getAllPostCount( {
+				posts: {
+					counts: {
+						counts: {
+							2916284: {
+								post: {
+									all: {
+										publish: 1
+									},
+									mine: {}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'post', 'draft' );
+
+			expect( postCount ).to.equal( 0 );
 		} );
 	} );
 
@@ -125,9 +158,7 @@ describe( 'selectors', () => {
 		it( 'should return null if counts haven\'t been received for site', () => {
 			const postCounts = getMyPostCounts( {
 				posts: {
-					counts: {
-						mine: {}
-					}
+					counts: {}
 				}
 			}, 2916284, 'post' );
 
@@ -141,6 +172,7 @@ describe( 'selectors', () => {
 						counts: {
 							2916284: {
 								post: {
+									all: {},
 									mine: {
 										publish: 1
 									}
@@ -158,13 +190,26 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getMyPostCount()', () => {
+		it( 'should return null if post counts haven\'t been received for site', () => {
+			const postCount = getMyPostCount( {
+				posts: {
+					counts: {
+						counts: {}
+					}
+				}
+			}, 2916284, 'post', 'publish' );
+
+			expect( postCount ).to.be.null;
+		} );
+
 		it( 'should return post count for status', () => {
-			const postCounts = getMyPostCount( {
+			const postCount = getMyPostCount( {
 				posts: {
 					counts: {
 						counts: {
 							2916284: {
 								post: {
+									all: {},
 									mine: {
 										publish: 1
 									}
@@ -175,7 +220,28 @@ describe( 'selectors', () => {
 				}
 			}, 2916284, 'post', 'publish' );
 
-			expect( postCounts ).to.equal( 1 );
+			expect( postCount ).to.equal( 1 );
+		} );
+
+		it( 'should return 0 if post counts have been received for site, but no status key exists', () => {
+			const postCount = getMyPostCount( {
+				posts: {
+					counts: {
+						counts: {
+							2916284: {
+								post: {
+									all: {},
+									mine: {
+										publish: 1
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'post', 'draft' );
+
+			expect( postCount ).to.equal( 0 );
 		} );
 	} );
 
@@ -187,6 +253,7 @@ describe( 'selectors', () => {
 						counts: {
 							2916284: {
 								post: {
+									all: {},
 									mine: {
 										publish: 1,
 										'private': 1,
@@ -219,7 +286,8 @@ describe( 'selectors', () => {
 								post: {
 									all: {
 										publish: 1
-									}
+									},
+									mine: {}
 								}
 							}
 						}
@@ -244,6 +312,7 @@ describe( 'selectors', () => {
 						counts: {
 							2916284: {
 								post: {
+									all: {},
 									mine: {
 										publish: 1
 									}


### PR DESCRIPTION
This pull request seeks to resolve an issue which can occur when saving, then publishing a draft when no drafts had existed prior to the current editor session.

In the course of fixing this behavior, the changes also resolve a few general state issues:
- The post counts endpoint will always return `mine` and `all` subkeys, but these weren't guaranteed to be assigned to the state reducer value
- If post counts had been received but there were no posts of a particular status, the endpoint will not return a key for that status and so the selectors would incorrectly return `null` (instead of `0`)

![Negative](https://cloud.githubusercontent.com/assets/1779930/17701883/9b67e186-6399-11e6-8d0a-d12c6a9d3cb5.png)

__Testing instructions:__

1. (Prerequisite) Delete all existing drafts from your site
 - The change to displaying a draft panel removed this option from the `/posts` screen
 - Instead, you can use either the [CPT list screen for posts](http://calypso.localhost:3000/types/post) or wp-admin
2. Navigate to the [post editor](http://calypso.localhost:3000/post)
3. Select a site, if prompted
4. Enter a title and/or content
5. (Optional) Save the post as a draft
 - ~~Note that the Draft count displays as (1)~~ (this was backed out, confirm instead that the Draft button does not display a count)
6. Publish the post
7. Note that the Draft count does not display a count (since there are no drafts)

Test live: https://calypso.live/?branch=fix/editor-drafts-negative-count