### PR TITLE
reader-author-link block: allow a siteUrl to be provided in case author.URL is missing

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -32,7 +32,7 @@ const AuthorCompactProfile = React.createClass( {
 		return (
 			<div className="author-compact-profile">
 				<Gravatar size={ 96 } user={ author } />
-				<ReaderAuthorLink author={ author }>{ author.name }</ReaderAuthorLink>
+				<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>{ author.name }</ReaderAuthorLink>
 				{ siteName && siteUrl
 					? <ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId }>
 						{ siteName }

--- a/client/blocks/reader-author-link/README.md
+++ b/client/blocks/reader-author-link/README.md
@@ -9,11 +9,19 @@ This component does not dictate the content of the link, only the href and click
 The `ReaderAuthorLink` component can be used in much the same way that you would use an `<ExternalLink>` component. The link wraps whatever is placed between the ReaderAuthorLink elements.
 
 ```html
-<ReaderAuthorLink post={ post }>Your link text here</ReaderAuthorLink>
+<ReaderAuthorLink author={ author } siteUrl={ siteUrl}>Your link text here</ReaderAuthorLink>
 ```
 
 ## Props
 
+### `author` (required)
+
+An author object to pull the author info from.
+
+### `siteUrl`
+
+A site URL to use for the link in case author.URL is missing.
+
 ### `post`
 
-A post object to pull the site info from. Should have either a feed_ID or a site_ID.
+A post object, used for stats only. If provided, we fire recordTrackForPost() when the link is clicked.

--- a/client/blocks/reader-author-link/README.md
+++ b/client/blocks/reader-author-link/README.md
@@ -9,7 +9,7 @@ This component does not dictate the content of the link, only the href and click
 The `ReaderAuthorLink` component can be used in much the same way that you would use an `<ExternalLink>` component. The link wraps whatever is placed between the ReaderAuthorLink elements.
 
 ```html
-<ReaderAuthorLink author={ author } siteUrl={ siteUrl}>Your link text here</ReaderAuthorLink>
+<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>Your link text here</ReaderAuthorLink>
 ```
 
 ## Props

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import ExternalLink from 'components/external-link';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
-const ReaderAuthorLink = ( { author, post, children } ) => {
+const ReaderAuthorLink = ( { author, post, siteUrl, children } ) => {
 	const recordAuthorClick = ( { } ) => {
 		recordAction( 'click_author' );
 		recordGaEvent( 'Clicked Author Link' );
@@ -18,12 +18,18 @@ const ReaderAuthorLink = ( { author, post, children } ) => {
 		}
 	};
 
-	if ( ! author.URL ) {
-		return ( <span className="reader-author-link">{ children }</span> );
+	let linkUrl = author.URL;
+	if ( ! linkUrl ) {
+		linkUrl = siteUrl;
+	}
+
+	// If we have neither author.URL or siteUrl, just return children
+	if ( ! linkUrl ) {
+		return children;
 	}
 
 	return (
-		<ExternalLink className="reader-author-link" href={ author.URL } target="_blank" onClick={ recordAuthorClick }>
+		<ExternalLink className="reader-author-link" href={ linkUrl } target="_blank" onClick={ recordAuthorClick }>
 			{ children }
 		</ExternalLink>
 	);
@@ -31,7 +37,8 @@ const ReaderAuthorLink = ( { author, post, children } ) => {
 
 ReaderAuthorLink.propTypes = {
 	author: React.PropTypes.object.isRequired,
-	post: React.PropTypes.object // for stats only
+	post: React.PropTypes.object, // for stats only,
+	siteUrl: React.PropTypes.string // used as fallback if author.URL is missing
 };
 
 export default ReaderAuthorLink;


### PR DESCRIPTION
@blowery suggested in https://github.com/Automattic/wp-calypso/issues/7425#issuecomment-239490131:

> Those are authors that have no profile URL associated with their account. We should just use the site URL if the profile URL is missing.

This PR adds a `siteUrl` prop to the `reader-author-link` block, and that URL is now used if author.URL is blank.

### To test

Visit https://calypso.live/read/feeds/41437948/posts/1117086279 and ensure that the author name is linked to the site URL.

Before:

![f4e55532-5fec-11e6-93ef-c05a9e700c15](https://cloud.githubusercontent.com/assets/17325/17703332/91f7813c-63d1-11e6-831b-5577445ab279.png)

After:

<img width="190" alt="screen shot 2016-08-16 at 16 50 34" src="https://cloud.githubusercontent.com/assets/17325/17703340/9775d1e0-63d1-11e6-99c7-198e352d68fc.png">

cc @fraying 

Fixes #7425.