### PR TITLE
Signup: Resume signup on the last incomplete step

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import page from 'page';
 import startsWith from 'lodash/startsWith';
-import sortBy from 'lodash/sortBy';
 import last from 'lodash/last';
 import find from 'lodash/find';
 import filter from 'lodash/filter';
@@ -279,22 +278,15 @@ const Signup = React.createClass( {
 		// Update the Flows object to know that the signup flow is being resumed.
 		flows.resumingFlow = true;
 
-		const flowSteps = flows.getFlow( this.props.flowName ).steps,
-			signupProgress = filter(
-				SignupProgressStore.get(),
-				step => ( -1 !== flowSteps.indexOf( step.stepName ) ),
-			),
-			lastUpdatedStep = sortBy( signupProgress, 'lastUpdated' ).reverse()[ 0 ],
-			lastUpdatedStepName = lastUpdatedStep.stepName,
-			stepSectionName = lastUpdatedStep.stepSectionName,
-			resumingStep = lastUpdatedStepName || this.firstUnsubmittedStepName();
+		const firstUnsubmittedStep = this.firstUnsubmittedStepName(),
+			stepSectionName = firstUnsubmittedStep.stepSectionName;
 
 		// set `resumingStep` so we don't render/animate anything until we have mounted this step
-		this.setState( { resumingStep } );
+		this.setState( { firstUnsubmittedStep } );
 
 		return page.redirect( utils.getStepUrl(
 			this.props.flowName,
-			resumingStep,
+			firstUnsubmittedStep,
 			stepSectionName,
 			this.props.locale
 		) );


### PR DESCRIPTION
Currently if you resume Signup, you will be sent to the last updated step, which in most cases refers to the last completed step. This doesn't make sense to the user, because you will be asked to complete a step again in order to continue the signup.

Now the user will be sent to the first incomplete step.
## To test
- Checkout branch / calypso.live
- Start signup
- Reach some step 
- Refresh
- Arrive at the same step, not the previous one. 
- Monitor the console for errors. 

cc @michaeldcain @coreh 
