### PR TITLE
Components: FormSettingExplanation

### DIFF
--- a/client/components/forms/form-setting-explanation/index.jsx
+++ b/client/components/forms/form-setting-explanation/index.jsx
@@ -29,7 +29,7 @@ export default React.createClass( {
 		} );
 
 		return (
-			<p { ...omit( this.props, 'className' ) }
+			<p { ...omit( this.props, 'className', 'noValidate', 'isIndented' ) }
 				className={ classes } >
 				{ this.props.children }
 			</p>


### PR DESCRIPTION
This PR clears JS warnings emitted by the `FormSettingExplanation` component.

The default props for `FormSettingExplanation` are used to calculate
`className`. We do not need attach those props to the component.

To test:
- visit calypso.localhost:3000/settings/general/$site
- open the JS console, and ensure you see no JS warnings related to `FormSettingExplanation`

cc: @tyxla @ebinnion 

Test live: https://calypso.live/?branch=fix/js-warnings-form-setting-explanation