### PR TITLE
Editor: Fix redirect which can occur upon dropping media

### DIFF
--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import createFragment from 'react-addons-create-fragment';
 import without from 'lodash/without';
 import includes from 'lodash/includes';
@@ -17,37 +17,48 @@ import { localize } from 'i18n-calypso';
  */
 import RootChild from 'components/root-child';
 
-export class DropZone extends Component {
-	constructor( props ) {
-		super( props );
+export const DropZone = React.createClass( {
+	propTypes: {
+		onDrop: PropTypes.func,
+		onVerifyValidTransfer: PropTypes.func,
+		onFilesDrop: PropTypes.func,
+		fullScreen: PropTypes.bool,
+		icon: PropTypes.string,
+		translate: PropTypes.func,
+	},
 
-		this.state = {
+	getInitialState() {
+		return {
 			isDraggingOverDocument: false,
 			isDraggingOverElement: false
 		};
+	},
 
-		// Bind listeners found in componentDidMount(), except for the ones whose
-		// implementation doesn't refer to `this`.
-		this.onDrop = this.onDrop.bind( this );
-		this.toggleDraggingOverDocument = this.toggleDraggingOverDocument.bind( this );
-		this.resetDragState = this.resetDragState.bind( this );
-	}
+	getDefaultProps() {
+		return {
+			onDrop: noop,
+			onVerifyValidTransfer: () => true,
+			onFilesDrop: noop,
+			fullScreen: false,
+			icon: 'cloud-upload',
+			translate: identity,
+		};
+	},
 
 	componentDidMount() {
 		this.dragEnterNodes = [];
-
 		window.addEventListener( 'dragover', this.preventDefault );
 		window.addEventListener( 'drop', this.onDrop );
 		window.addEventListener( 'dragenter', this.toggleDraggingOverDocument );
 		window.addEventListener( 'dragleave', this.toggleDraggingOverDocument );
 		window.addEventListener( 'mouseup', this.resetDragState );
-	}
+	},
 
 	componentDidUpdate( prevProps, prevState ) {
 		if ( prevState.isDraggingOverDocument !== this.state.isDraggingOverDocument ) {
 			this.toggleMutationObserver();
 		}
-	}
+	},
 
 	componentWillUnmount() {
 		window.removeEventListener( 'dragover', this.preventDefault );
@@ -56,7 +67,7 @@ export class DropZone extends Component {
 		window.removeEventListener( 'dragleave', this.toggleDraggingOverDocument );
 		window.removeEventListener( 'mouseup', this.resetDragState );
 		this.disconnectMutationObserver();
-	}
+	},
 
 	resetDragState() {
 		if ( ! ( this.state.isDraggingOverDocument || this.state.isDraggingOverElement ) ) {
@@ -67,7 +78,7 @@ export class DropZone extends Component {
 			isDraggingOverDocument: false,
 			isDraggingOverElement: false
 		} );
-	}
+	},
 
 	toggleMutationObserver() {
 		this.disconnectMutationObserver();
@@ -79,7 +90,7 @@ export class DropZone extends Component {
 				subtree: true
 			} );
 		}
-	}
+	},
 
 	disconnectMutationObserver() {
 		if ( ! this.observer ) {
@@ -88,7 +99,7 @@ export class DropZone extends Component {
 
 		this.observer.disconnect();
 		delete this.observer;
-	}
+	},
 
 	detectNodeRemoval( mutations ) {
 		mutations.forEach( ( mutation ) => {
@@ -98,7 +109,7 @@ export class DropZone extends Component {
 
 			this.dragEnterNodes = without( this.dragEnterNodes, Array.from( mutation.removedNodes ) );
 		} );
-	}
+	},
 
 	toggleDraggingOverDocument( event ) {
 		let isDraggingOverDocument, detail, isValidDrag;
@@ -133,11 +144,11 @@ export class DropZone extends Component {
 			// from tracked nodes since another "real" event will be triggered.
 			this.dragEnterNodes = without( this.dragEnterNodes, window );
 		}
-	}
+	},
 
 	preventDefault( event ) {
 		event.preventDefault();
-	}
+	},
 
 	isWithinZoneBounds( x, y ) {
 		let rect;
@@ -155,7 +166,7 @@ export class DropZone extends Component {
 
 		return x >= rect.left && x <= rect.right &&
 			y >= rect.top && y <= rect.bottom;
-	}
+	},
 
 	onDrop( event ) {
 		// This seemingly useless line has been shown to resolve a Safari issue
@@ -180,7 +191,7 @@ export class DropZone extends Component {
 
 		event.stopPropagation();
 		event.preventDefault();
-	}
+	},
 
 	renderContent() {
 		let content;
@@ -199,7 +210,7 @@ export class DropZone extends Component {
 		}
 
 		return <div className="drop-zone__content">{ content }</div>;
-	}
+	},
 
 	render() {
 		const classes = classNames( 'drop-zone', {
@@ -220,24 +231,6 @@ export class DropZone extends Component {
 		}
 		return element;
 	}
-}
-
-DropZone.propTypes = {
-	onDrop: PropTypes.func,
-	onVerifyValidTransfer: PropTypes.func,
-	onFilesDrop: PropTypes.func,
-	fullScreen: PropTypes.bool,
-	icon: PropTypes.string,
-	translate: PropTypes.func,
-};
-
-DropZone.defaultProps = {
-	onDrop: noop,
-	onVerifyValidTransfer: () => true,
-	onFilesDrop: noop,
-	fullScreen: false,
-	icon: 'cloud-upload',
-	translate: identity,
-};
+} );
 
 export default localize( DropZone );

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -132,13 +132,10 @@ describe( 'index', function() {
 	} );
 
 	it( 'should further highlight the drop zone when dragging over the element', function() {
-		var tree, dragEnterEvent;
+		const tree = ReactDom.render( React.createElement( DropZone ), container );
+		sandbox.stub( tree, 'isWithinZoneBounds' ).returns( true );
 
-		sandbox.stub( DropZone.prototype, 'isWithinZoneBounds' ).returns( true );
-
-		tree = ReactDom.render( React.createElement( DropZone ), container );
-
-		dragEnterEvent = new window.MouseEvent( 'dragenter' );
+		const dragEnterEvent = new window.MouseEvent( 'dragenter' );
 		window.dispatchEvent( dragEnterEvent );
 
 		expect( tree.state.isDraggingOverDocument ).to.be.ok;


### PR DESCRIPTION
This pull request seeks to resolve an issue which can occur when trying to drop media onto the editor after having opened and then closed the media library.

__Implementation Notes:__

The solution here is to revert `<DropZone />` from a `React.Component` to a `React.createClass` component. It was originally converted to a component class in #5383 (cc @ockham , @gwwar).

I've spent the better part of my day trying to determine the cause of this issue. I had narrowed it down to that the `<DropZone />`'s `window` drop handler was not being triggered (perhaps being unbound) when dropping after the media library had been previously opened. In the TinyMCE media plugin there is [dance which occurs](https://github.com/Automattic/wp-calypso/blob/0807eca7a605573adf897a1b34fbae0e8c0d57c0/client/components/tinymce/plugins/media/plugin.jsx#L60-L62) when opening or closing the modal to oppositely render the main page `<DropZone />`. The unbounding theory would seem to imply that the bound functions instantiated in the constructor were shared between rendered components, which I was unable to prove. However, that it works with `React.createClass` where methods are auto-bound does lead some legitimacy to this theory.

An alternative approach to consider is binding to the `window` drop events in the `<PostEditor />`, calling `preventDefault`. The benefit to this is that it also prevents unintended redirects when accidentally dropping a media file outside the displayed droppable area.

__Testing instructions:__

Verify that you can drop media into the [post editor](http://calypso.localhost:3000/post) and media library, regardless of whether the media library had been opened already within the same editor session.

Test live: https://calypso.live/?branch=fix/editor-media-drop-redirect