### PR TITLE
Don't show promo for Desktop app on Chromebook

### DIFF
--- a/client/components/app-promo/index.jsx
+++ b/client/components/app-promo/index.jsx
@@ -32,6 +32,11 @@ export default React.createClass( {
 			show_promo = false;
 		}
 
+		const chromeRE = /\bCrOS\b/;
+		if ( chromeRE.test( navigator.userAgent ) ) {
+			show_promo = false;
+		}
+
 		var promo_options = [
 			{ promo_code: 'a0001', message: 'WordPress.com your way  — desktop app now available for Mac, Windows, and Linux.' },
 			{ promo_code: 'a0002', message: 'Get WordPress.com app for your desktop.' },


### PR DESCRIPTION
The desktop app is not available for Chromebooks, so don't show the promo spot.
Adds a check of user agent `CrOS` which is for ChromeOS, the user agent for Chromebook

Test live: https://calypso.live/?branch=fix/appPromoChromebook