### PR TITLE
Chart: fix tooltip position in `is-streak` mode

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -403,19 +403,8 @@
 	}
 
 	&.is-streak {
-		margin-top: -5px;
-		height: 35px;
-
-		.popover__arrow::before {
-			left: 85px;
-			top: 30px;
-		}
-
 		.popover__inner {
 			width: 160px;
-			position: relative;
-			top: -10px;
-
 			li {
 				height: 14px;
 


### PR DESCRIPTION
**before**
<img src="https://cloud.githubusercontent.com/assets/77539/17712048/aa35da8e-63ca-11e6-92ca-55a4fc261fde.png" width="250px" />


**after**
<img src="https://cloud.githubusercontent.com/assets/77539/17712040/a2741112-63ca-11e6-9950-adf50d5fe2dd.png" width="250px" />

cc @rralian @gwwar 

Test live: https://calypso.live/?branch=fix/insights-chart-popover