### PR TITLE
Reader: Fix comments line break

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -204,6 +204,19 @@
 	}
 }
 
+.reader-share__button-label,
+.comment-button__label-status,
+.like-button__label-status {
+
+	@media( min-width: 481px ) and ( max-width: 530px ) {
+		display: none;
+	}
+
+	@media( min-width: 661px ) and ( max-width: 790px ) {
+		display: none;
+	}
+}
+
 .reader__post-embed-count {
 	padding: 4px 6px;
 	border-radius: 4px;

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -208,7 +208,7 @@
 .comment-button__label-status,
 .like-button__label-status {
 
-	@media( min-width: 481px ) and ( max-width: 530px ) {
+	@media( max-width: 530px ) {
 		display: none;
 	}
 

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -204,7 +204,7 @@
 	}
 }
 
-// Custom breakpoints that drops action labels text
+// Custom breakpoints that drop action labels text
 // to prevent Likes text from breaking onto a new line
 .reader-share__button-label,
 .comment-button__label-status,

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -204,6 +204,8 @@
 	}
 }
 
+// Custom breakpoints that drops action labels text
+// to prevent Likes text from breaking onto a new line
 .reader-share__button-label,
 .comment-button__label-status,
 .like-button__label-status {
@@ -222,7 +224,6 @@
 	border-radius: 4px;
 	background: $gray-light;
 }
-
 
 /* Tiled Gallery Default Styles
  * Mostly copied from Atlas -Shaun


### PR DESCRIPTION
In the current streams, the word "Likes" gets moved down the second line for posts that have several comments and likes.

This happens right before the `480px` and `660px` breakpoints.

**Before:**
![screenshot 2016-08-16 11 57 30](https://cloud.githubusercontent.com/assets/4924246/17712115/707850fe-63a9-11e6-886a-7c8e47241f08.png)

![screenshot 2016-08-16 11 57 43](https://cloud.githubusercontent.com/assets/4924246/17712121/73f8ee8c-63a9-11e6-9c63-add77e14dbc2.png)

**After:**
![screenshot 2016-08-16 12 09 21](https://cloud.githubusercontent.com/assets/4924246/17712354/5fcd6dce-63aa-11e6-8481-9b76fb80d7e9.png)

![screenshot 2016-08-16 12 09 31](https://cloud.githubusercontent.com/assets/4924246/17712358/62ee05ea-63aa-11e6-8a26-bef6d1e17491.png)

/cc @blowery 

Test live: https://calypso.live/?branch=fix/reader/comments-likes-line-break