### PR TITLE
Fix classname on popover devdocs example to match convention

### DIFF
--- a/client/components/popover/docs/example.jsx
+++ b/client/components/popover/docs/example.jsx
@@ -296,7 +296,7 @@ const Popovers = React.createClass( {
 
 	render() {
 		return (
-			<div className="docs__design-assets-group">
+			<div className="design-assets__group">
 				<h2>
 					<a href="/devdocs/design/popovers">Popovers</a>
 				</h2>


### PR DESCRIPTION
With commit https://github.com/Automattic/wp-calypso/commit/d4bae3aba07a4e31bd442e2ad86ea0531fb9c54f the classname on the `div` for the Popover component in the devdocs was changed from `design-assets__group` to `docs__design-assets-group`, which was breaking the visdiff tests that rely on that convention to find the components.

cc: @retrofox 

Test live: https://calypso.live/?branch=fix/popover-devdocs-classname