### PR TITLE
Checkout: refactoring secure-payment-form

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -25,6 +25,7 @@ var analytics = require( 'lib/analytics' ),
 	purchasePaths = require( 'me/purchases/paths' ),
 	QueryStoredCards = require( 'components/data/query-stored-cards' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
+	SecurePaymentFormPlaceholder = require( './secure-payment-form-placeholder' ),
 	supportPaths = require( 'lib/url/support' ),
 	themeItem = require( 'lib/cart-values/cart-items' ).themeItem,
 	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
@@ -214,7 +215,7 @@ const Checkout = React.createClass( {
 			// hasPendingServerUpdates is an important check here as the content we display is dependent on the content of the cart
 
 			return (
-				<SecurePaymentForm.Placeholder />
+				<SecurePaymentFormPlaceholder />
 			);
 		}
 

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies
@@ -56,14 +55,9 @@ var CreditCardPaymentBox = React.createClass( {
 	},
 
 	render: function() {
-		var classSet = classNames( {
-			'credit-card-payment-box': true,
-			selected: this.props.selected === true
-		} );
-
 		return (
 			<PaymentBox
-				classSet={ classSet }
+				classSet="credit-card-payment-box"
 				title={ this.translate( 'Secure Payment' ) }>
 				{ this.content() }
 			</PaymentBox>

--- a/client/my-sites/upgrades/checkout/credits-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credits-payment-box.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies
@@ -46,14 +45,9 @@ var CreditsPaymentBox = React.createClass( {
 	},
 
 	render: function() {
-		var classSet = classNames( {
-			'credits-payment-box': true,
-			selected: this.props.selected === true
-		} );
-
 		return (
 			<PaymentBox
-				classSet={ classSet }
+				classSet="credits-payment-box"
 				title={ this.translate( 'Secure Payment' ) }>
 				{ this.content() }
 			</PaymentBox>

--- a/client/my-sites/upgrades/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/free-cart-payment-box.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies
@@ -63,14 +62,9 @@ var FreeCartPaymentBox = React.createClass( {
 	},
 
 	render: function() {
-		var classSet = classNames( {
-			'credits-payment-box': true,
-			selected: this.props.selected
-		} );
-
 		return (
 			<PaymentBox
-				classSet={ classSet }
+				classSet="credits-payment-box"
 				title={ this.translate( 'Secure Payment' ) }>
 				{ this.content() }
 			</PaymentBox>

--- a/client/my-sites/upgrades/checkout/free-trial-confirmation-box.js
+++ b/client/my-sites/upgrades/checkout/free-trial-confirmation-box.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	classNames = require( 'classnames' ),
 	find = require( 'lodash/find' );
 
 /**
@@ -49,13 +48,8 @@ const FreeTrialConfirmationBox = React.createClass( {
 	},
 
 	render() {
-		const classSet = classNames( {
-			'credits-payment-box': true,
-			selected: this.props.selected === true
-		} );
-
 		return (
-			<PaymentBox classSet={ classSet }>
+			<PaymentBox classSet="credits-payment-box">
 				{ this.content() }
 			</PaymentBox>
 		);

--- a/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var assign = require( 'lodash/assign' ),
-	classNames = require( 'classnames' ),
 	React = require( 'react' );
 
 /**
@@ -168,14 +167,9 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var classSet = classNames( {
-			'paypal-payment-box': true,
-			selected: this.props.selected === true
-		} );
-
 		return (
 			<PaymentBox
-				classSet={ classSet }
+				classSet="paypal-payment-box"
 				title={ this.translate( 'Secure Payment with PayPal' ) }>
 				{ this.content() }
 			</PaymentBox>

--- a/client/my-sites/upgrades/checkout/secure-payment-form-placeholder.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form-placeholder.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PaymentBox from './payment-box.jsx';
+
+const SecurePaymentFormPlaceholder = () => {
+	return (
+		<PaymentBox
+			classSet="selected is-empty"
+			contentClassSet="selected is-empty"
+		>
+			<div className="payment-box-section">
+
+				<div className="placeholder-row placeholder"/>
+				<div className="placeholder-row placeholder"/>
+				<div className="placeholder-col-narrow placeholder-inline-pad">
+					<div className="placeholder" />
+				</div>
+				<div className="placeholder-col-narrow placeholder-inline-pad-only-wide">
+					<div className="placeholder" />
+				</div>
+				<div className="placeholder-col-wide">
+					<div className="placeholder" />
+				</div>
+				<div className="placeholder-row placeholder"/>
+			</div>
+			<div className="payment-box-hr" />
+			<div className="placeholder-button-container">
+				<div className="placeholder-col-narrow">
+					<div className="placeholder placeholder-button"></div>
+				</div>
+			</div>
+		</PaymentBox>
+	);
+};
+
+export default SecurePaymentFormPlaceholder;

--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -7,12 +7,14 @@ import { defer } from 'lodash';
 /**
  * Internal dependencies
  */
-import CreditCardPaymentBox from './credit-card-payment-box';
 import EmptyContent from 'components/empty-content';
-import FreeTrialConfirmationBox from './free-trial-confirmation-box';
-import PayPalPaymentBox from './paypal-payment-box';
+
 import CreditsPaymentBox from './credits-payment-box';
+import FreeTrialConfirmationBox from './free-trial-confirmation-box';
 import FreeCartPaymentBox from './free-cart-payment-box';
+import CreditCardPaymentBox from './credit-card-payment-box';
+import PayPalPaymentBox from './paypal-payment-box';
+
 import storeTransactions from 'lib/store-transactions';
 import analytics from 'lib/analytics';
 import TransactionStepsMixin from './transaction-steps-mixin';
@@ -139,6 +141,87 @@ const SecurePaymentForm = React.createClass( {
 		} );
 	},
 
+	renderCreditsPayentBox() {
+		return (
+			<CreditsPaymentBox
+				cart={ this.props.cart }
+				onSubmit={ this.handlePaymentBoxSubmit }
+				transactionStep={ this.props.transaction.step } />
+		);
+	},
+
+	renderFreeTrialConfirmationBox() {
+		return (
+			<FreeTrialConfirmationBox
+				cart={ this.props.cart }
+				onSubmit={ this.handlePaymentBoxSubmit }
+				transactionStep={ this.props.transaction.step } />
+		);
+	},
+
+	renderFreeCartPaymentBox() {
+		return (
+			<FreeCartPaymentBox
+				cart={ this.props.cart }
+				onSubmit={ this.handlePaymentBoxSubmit }
+				products={ this.props.products }
+				selectedSite={ this.props.selectedSite }
+				transactionStep={ this.props.transaction.step } />
+		);
+	},
+
+	renderCreditCardPaymentBox() {
+		return (
+			<CreditCardPaymentBox
+				cards={ this.props.cards }
+				transaction={ this.props.transaction }
+				cart={ this.props.cart }
+				countriesList={ countriesListForPayments }
+				initialCard={ this.getInitialCard() }
+				selectedSite={ this.props.selectedSite }
+				onToggle={ this.selectPaymentBox }
+				onSubmit={ this.handlePaymentBoxSubmit }
+				transactionStep={ this.props.transaction.step } />
+		);
+	},
+
+	renderPayPalPaymentBox() {
+		return (
+			<PayPalPaymentBox
+				cart={ this.props.cart }
+				transaction={ this.props.transaction }
+				countriesList={ countriesListForPayments }
+				selectedSite={ this.props.selectedSite }
+				onToggle={ this.selectPaymentBox }
+				redirectTo={ this.props.redirectTo } />
+		);
+	},
+
+	renderPaymentBox() {
+		const { visiblePaymentBox } = this.state;
+		debug( 'getting %o payment box ...', visiblePaymentBox );
+
+		switch ( visiblePaymentBox ) {
+			case 'credits':
+				return this.renderCreditsPayentBox();
+
+			case 'free-trial':
+				return this.renderFreeTrialConfirmationBox();
+
+			case 'free-cart':
+				return this.renderFreeCartPaymentBox();
+
+			case 'credit-card':
+				return this.renderCreditCardPaymentBox();
+
+			case 'paypal':
+				return this.renderPayPalPaymentBox();
+			default:
+				debug( 'WARN: %o payment unknown', visiblePaymentBox );
+				return null;
+		}
+	},
+
 	render() {
 		if ( this.state.visiblePaymentBox === null ) {
 			return (
@@ -150,51 +233,10 @@ const SecurePaymentForm = React.createClass( {
 					actionURL={ '/plans/' + this.props.selectedSite.slug } />
 			);
 		}
-		debug( 'showing %o payment box ...', this.state.visiblePaymentBox );
 
 		return (
 			<div className="secure-payment-form">
-				<CreditsPaymentBox
-					cart={ this.props.cart }
-					selected={ this.state.visiblePaymentBox === 'credits' }
-					onSubmit={ this.handlePaymentBoxSubmit }
-					transactionStep={ this.props.transaction.step } />
-
-				<FreeTrialConfirmationBox
-					cart={ this.props.cart }
-					selected={ this.state.visiblePaymentBox === 'free-trial' }
-					onSubmit={ this.handlePaymentBoxSubmit }
-					transactionStep={ this.props.transaction.step } />
-
-				<FreeCartPaymentBox
-					cart={ this.props.cart }
-					selected={ this.state.visiblePaymentBox === 'free-cart' }
-					onSubmit={ this.handlePaymentBoxSubmit }
-					products={ this.props.products }
-					selectedSite={ this.props.selectedSite }
-					transactionStep={ this.props.transaction.step } />
-
-				<CreditCardPaymentBox
-					cards={ this.props.cards }
-					transaction={ this.props.transaction }
-					cart={ this.props.cart }
-					countriesList={ countriesListForPayments }
-					initialCard={ this.getInitialCard() }
-					selected={ this.state.visiblePaymentBox === 'credit-card' }
-					selectedSite={ this.props.selectedSite }
-					onToggle={ this.selectPaymentBox }
-					onSubmit={ this.handlePaymentBoxSubmit }
-					transactionStep={ this.props.transaction.step } />
-
-				<PayPalPaymentBox
-					cart={ this.props.cart }
-					transaction={ this.props.transaction }
-					countriesList={ countriesListForPayments }
-					selected={ this.state.visiblePaymentBox === 'paypal' }
-					selectedSite={ this.props.selectedSite }
-					onToggle={ this.selectPaymentBox }
-					redirectTo={ this.props.redirectTo } />
-
+				{ this.renderPaymentBox() }
 			</div>
 		);
 	}

--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -13,7 +13,6 @@ import FreeTrialConfirmationBox from './free-trial-confirmation-box';
 import PayPalPaymentBox from './paypal-payment-box';
 import CreditsPaymentBox from './credits-payment-box';
 import FreeCartPaymentBox from './free-cart-payment-box';
-import PaymentBox from './payment-box.jsx';
 import storeTransactions from 'lib/store-transactions';
 import analytics from 'lib/analytics';
 import TransactionStepsMixin from './transaction-steps-mixin';
@@ -201,38 +200,5 @@ const SecurePaymentForm = React.createClass( {
 	}
 } );
 
-SecurePaymentForm.Placeholder = React.createClass( {
-	displayName: 'SecurePaymentForm.Placeholder',
-
-	render() {
-		return (
-			<PaymentBox
-				classSet="selected is-empty"
-				contentClassSet="selected is-empty" >
-				<div className="payment-box-section">
-
-					<div className="placeholder-row placeholder"/>
-					<div className="placeholder-row placeholder"/>
-					<div className="placeholder-col-narrow placeholder-inline-pad">
-						<div className="placeholder" />
-					</div>
-					<div className="placeholder-col-narrow placeholder-inline-pad-only-wide">
-						<div className="placeholder" />
-					</div>
-					<div className="placeholder-col-wide">
-						<div className="placeholder" />
-					</div>
-					<div className="placeholder-row placeholder"/>
-				</div>
-				<div className="payment-box-hr" />
-				<div className="placeholder-button-container">
-					<div className="placeholder-col-narrow">
-						<div className="placeholder placeholder-button"></div>
-					</div>
-				</div>
-			</PaymentBox>
-		);
-	}
-} );
-
 export default SecurePaymentForm;
+

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -2,14 +2,9 @@
 	position: relative;
 
 	.payment-box {
-		height: 0;
 		margin-bottom: 0;
-		opacity: 0;
-		overflow: hidden;
-		padding: 0;
 		transform: translateZ(0) scale(.8); // Zoom out effect
 		transition: all .3s ease-in-out;
-		visibility: hidden; // To deal with layering issues
 		width: 100%;
 
 		&:not(.domain-details) {

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -3,22 +3,24 @@
 
 	.payment-box {
 		margin-bottom: 0;
-		transform: translateZ(0) scale(.8); // Zoom out effect
-		transition: all .3s ease-in-out;
+		padding: 0;
 		width: 100%;
+		overflow: hidden;
+
+		opacity: 0;
+		visibility: hidden;
+		transform: translateZ(0) scale(.8); // Zoom out effect
+
+		animation-delay: 0.3s;
+		animation-fill-mode: forwards;
+		animation-duration: 0.4s;
+		animation-name: increase;
 
 		&:not(.domain-details) {
 			@include breakpoint( "<660px" ) {
 				background-color: transparent;
 				box-shadow: none;
 			}
-		}
-
-		&.selected {
-			height: auto;
-			opacity: 1;
-			transform: translateZ(0) scale(1); // Zoom in effect
-			visibility: visible; // To deal with layering issues
 		}
 
 		&.is-empty {
@@ -856,4 +858,20 @@
 .checkout__privacy-protection-free-text {
 	color: $alert-green;
 	padding-left: 8px;
+}
+
+@keyframes increase {
+	from {
+		height: 0;
+		opacity: 0;
+		visibility: hidden;
+		transform: translateZ(0) scale(.8);
+	}
+
+	to {
+		height: auto;
+		opacity: 1;
+		visibility: visible;
+		transform: translateZ(0) scale(1);
+	}
 }


### PR DESCRIPTION
In this PR the main changes:

* remove `placeholder` property from `<SecurePaymentForm />` and make a new file for this `empty` form.
* show/hide each payment box rendering only one box instead of show/hide the all boxes using css class/properties.
* fix eslint warnings
* some ES6ify

### Testing

The different boxes are defined through of the following keys: `credits`, `free-trial`, `free-cart`, `credit-card` and `paypal`. So you can switch the visible box using the react dev tools setting the `visibilePaymenBox` property of the status object:

![image](https://cloud.githubusercontent.com/assets/77539/17716477/3559aafa-63df-11e6-9647-83f183af2c0f.png)

Everything should be ok. I'm not guilty.

### Reviewers

I've gotten some reviewers from `git blame`.

* @janm6k @gziolo @klimeryk  @Tsarpf 

Test live: https://calypso.live/?branch=update/checkout-mounting-components