### PR TITLE
Plugins: Fixes invariant violation due to not having store in plugins browser

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -135,7 +135,7 @@ function renderPluginsBrowser( context, siteUrl ) {
 	.pageView
 	.record( context.pathname.replace( site.domain, ':site' ), analyticsPageTitle );
 
-	ReactDom.render(
+	renderWithReduxStore(
 		React.createElement( PluginBrowser, {
 			site: site ? site.slug : null,
 			path: context.path,
@@ -143,7 +143,8 @@ function renderPluginsBrowser( context, siteUrl ) {
 			sites,
 			search: searchTerm
 		} ),
-		document.getElementById( 'primary' )
+		document.getElementById( 'primary' ),
+		context.store
 	);
 }
 


### PR DESCRIPTION
Today, @MichaelArestad pointed out that the plugins browser was broken. 😱 

Here's the error info:

<img width="1306" alt="screen shot 2016-08-16 at 5 09 35 pm" src="https://cloud.githubusercontent.com/assets/1126811/17717625/b42467cc-63d4-11e6-8950-dbdfe74c7564.png">

```
Uncaught Invariant Violation: Could not find "store" in either the context or props of "Connect(SidebarNavigation)". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(SidebarNavigation)".
```

To repro:

- Go to `/plugins/$site`
- Click the add plugin button
- Notice error in console

To test fix:

- Checkout `update/fix-plugins-browser` branch
- Follow steps above
- Notice plugins browser

cc @MichaelArestad  @lezama for review

Test live: https://calypso.live/?branch=update/fix-plugins-browser