### PR TITLE
Fix/edit post date bug

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -162,7 +162,7 @@ class Popover extends Component {
 			return null;
 		}
 
-		this.close();
+		this.close( true );
 	}
 
 	// --- cliclout side ---
@@ -357,13 +357,13 @@ class Popover extends Component {
 		this._openDelayTimer = null;
 	}
 
-	close() {
+	close( wasCanceled = false ) {
 		if ( ! this.props.isVisible ) {
 			this.debug( 'popover should be already closed' );
 			return null;
 		}
 
-		this.props.onClose();
+		this.props.onClose( wasCanceled );
 	}
 
 	render() {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -226,9 +226,8 @@ export default React.createClass( {
 		this.setState( { showSchedulePopover: ! this.state.showSchedulePopover } );
 	},
 
-	closeSchedulePopover: function( event ) {
-		// if `event` is defined means that popover has been canceled (ESC key)
-		if ( ! event ) {
+	closeSchedulePopover: function( wasCanceled ) {
+		if ( wasCanceled ) {
 			let date = this.props.savedPost && this.props.savedPost.date
 				? this.moment( this.props.savedPost.date )
 				: null;


### PR DESCRIPTION
This PR fix the bug when the user tries to set the post date through of `<PostSchedule />`.

### Why it happens?

We aren't detecting rightly when the Popover is canceled or when it's closed. In fact now it's always interpreted as if the Popover is canceled.

### Popover changes

We have to determine when the a Popover is `closed` and when it's `canceled`. Popover is _closed_ when its isVisibility property changes to `false`. So it means that it's handled by the parent component and usually it's connected with the function defined on `onCancel` property.

In other hand the Popover is `canceled` when the user press the `ESC` key. it isn't completely handled by the parent component.

So I've added a `wasCanceled` parameter to the close() function defined for the parent component. IN this way we can do:

```es6

this.popoverClose( wasCanceled) {
  if ( wasCanceled ) {
    // nothing to do
    return null;
  }

  // let's consider this change like valid
  // ...
}

render() {
  return (
    <Popover
      onClose={ this.closePopover }
      // ...
    />
```

Whit this change it's easier to detect both events in and proceed correctly.

### Steps to Replicate

1. Create new Post
2. Click "Set date and time" icon
3. Select Date
4. Click "Schedule" button

The post date won't change.

### Testing

Same steps that above but no the post date should change.

Test live: https://calypso.live/?branch=fix/edit-post-date-bug