### PR TITLE
My-Sites: Display better support options about themes for paid users.

### DIFF
--- a/client/components/data/query-user-purchases/index.jsx
+++ b/client/components/data/query-user-purchases/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -31,6 +31,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { isPremium, getForumUrl } from 'my-sites/themes/helpers';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCurrentTheme from 'components/data/query-current-theme';
+import QueryUserPurchases from 'components/data/query-user-purchases';
 import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
 import {
 	signup,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -227,25 +227,37 @@ const ThemeSheet = React.createClass( {
 		);
 	},
 
+	renderThemeForumCard() {
+		return (
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="comment" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ i18n.translate( 'Need extra help?' ) }
+					<small>{ i18n.translate( 'Visit the theme support forum' ) }</small>
+				</div>
+				<Button primary={ true } href={ getForumUrl( this.props ) }>Visit forum</Button>
+			</Card>
+		);
+	},
+
+	renderCssSupportCard() {
+		return (
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="briefcase" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ i18n.translate( 'Need CSS help? ' ) }
+					<small>{ i18n.translate( 'Visit the CSS customization forum' ) }</small>
+				</div>
+				<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
+			</Card>
+		);
+	},
+
 	renderSupportTab() {
 		return (
 			<div>
-				<Card className="theme__sheet-card-support">
-					<Gridicon icon="comment" size={ 48 } />
-					<div className="theme__sheet-card-support-details">
-						{ i18n.translate( 'Need extra help?' ) }
-						<small>{ i18n.translate( 'Visit the theme support forum' ) }</small>
-					</div>
-					<Button primary={ true } href={ getForumUrl( this.props ) }>Visit forum</Button>
-				</Card>
-				<Card className="theme__sheet-card-support">
-					<Gridicon icon="briefcase" size={ 48 } />
-					<div className="theme__sheet-card-support-details">
-						{ i18n.translate( 'Need CSS help? ' ) }
-						<small>{ i18n.translate( 'Visit the CSS customization forum' ) }</small>
-					</div>
-					<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
-				</Card>
+				{ this.renderThemeForumCard() }
+				{ this.renderCssSupportCard() }
 			</div>
 		);
 	},

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -236,7 +236,7 @@ const ThemeSheet = React.createClass( {
 					{ i18n.translate( 'Need extra help?' ) }
 					<small>{ i18n.translate( 'Get in touch with our support team' ) }</small>
 				</div>
-				<Button primary={ isPrimary } href={ getForumUrl( this.props ) }>Contact us</Button>
+				<Button primary={ isPrimary } href={ '/help/contact/' }>Contact us</Button>
 			</Card>
 		);
 	},

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -228,15 +228,28 @@ const ThemeSheet = React.createClass( {
 		);
 	},
 
-	renderThemeForumCard() {
+	renderContactUsCard( isPrimary = false ) {
+		return (
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="help-outline" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ i18n.translate( 'Need extra help?' ) }
+					<small>{ i18n.translate( 'Get in touch with our support team' ) }</small>
+				</div>
+				<Button primary={ isPrimary } href={ getForumUrl( this.props ) }>Contact us</Button>
+			</Card>
+		);
+	},
+
+	renderThemeForumCard( isPrimary = false ) {
 		return (
 			<Card className="theme__sheet-card-support">
 				<Gridicon icon="comment" size={ 48 } />
 				<div className="theme__sheet-card-support-details">
-					{ i18n.translate( 'Need extra help?' ) }
-					<small>{ i18n.translate( 'Visit the theme support forum' ) }</small>
+					{ i18n.translate( 'Have a question about this theme?' ) }
+					<small>{ i18n.translate( 'Get in touch with the theme author' ) }</small>
 				</div>
-				<Button primary={ true } href={ getForumUrl( this.props ) }>Visit forum</Button>
+				<Button primary={ isPrimary } href={ getForumUrl( this.props ) }>Visit forum</Button>
 			</Card>
 		);
 	},
@@ -255,12 +268,27 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderSupportTab() {
-		return (
-			<div>
-				{ this.renderThemeForumCard() }
-				{ this.renderCssSupportCard() }
-			</div>
-		);
+		const {
+			hasLoadedUserPurchasesFromServer,
+			isCurrentUserPaid,
+		} = this.props;
+
+		if ( hasLoadedUserPurchasesFromServer && isCurrentUserPaid ) {
+			return (
+				<div>
+					{ this.renderContactUsCard( true ) }
+					{ this.renderThemeForumCard() }
+					{ this.renderCssSupportCard() }
+				</div>
+			);
+		} else {
+			return (
+				<div>
+					{ this.renderThemeForumCard( true ) }
+					{ this.renderCssSupportCard() }
+				</div>
+			);
+		}
 	},
 
 	renderFeaturesCard() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -28,6 +28,8 @@ import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { isUserPaid, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { isPremium, getForumUrl } from 'my-sites/themes/helpers';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCurrentTheme from 'components/data/query-current-theme';
@@ -402,6 +404,7 @@ const ThemeSheet = React.createClass( {
 				type={ 'website' }
 				canonicalUrl={ canonicalUrl }
 				image={ this.props.screenshot }>
+				<QueryUserPurchases userId={ this.props.currentUserId } />
 				<Main className="theme__sheet">
 					<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle }/>
 						{ this.renderBar() }
@@ -494,16 +497,15 @@ export default connect(
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
 		const backPath = getBackPath( state );
+		const currentUserId = getCurrentUserId( state );
+		const isCurrentUserPaid = isUserPaid( state, currentUserId );
 
-		// TODO:
-		// Connect these two to the real state value
-		const hasLoadedUserPurchasesFromServer = true;
-		const isCurrentUserPaid = true;
 		return {
 			selectedSite,
 			siteSlug,
 			backPath,
-			hasLoadedUserPurchasesFromServer,
+			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+			currentUserId,
 			isCurrentUserPaid,
 		};
 	},

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -466,7 +466,18 @@ export default connect(
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
 		const backPath = getBackPath( state );
-		return { selectedSite, siteSlug, backPath };
+
+		// TODO:
+		// Connect these two to the real state value
+		const hasLoadedUserPurchasesFromServer = true;
+		const isCurrentUserPaid = true;
+		return {
+			selectedSite,
+			siteSlug,
+			backPath,
+			hasLoadedUserPurchasesFromServer,
+			isCurrentUserPaid,
+		};
 	},
 	bindDefaultOptionToDispatch,
 	mergeProps

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -244,9 +244,9 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderThemeForumCard( isPrimary = false ) {
-		const description = isPremium( this.props ) ?
-			i18n.translate( 'Get in touch with the theme author' ) :
-			i18n.translate( 'Get help from volunteers and staff' );
+		const description = isPremium( this.props )
+			? i18n.translate( 'Get in touch with the theme author' )
+			: i18n.translate( 'Get help from volunteers and staff' );
 
 		return (
 			<Card className="theme__sheet-card-support">
@@ -282,14 +282,14 @@ const ThemeSheet = React.createClass( {
 					{ this.renderCssSupportCard() }
 				</div>
 			);
-		} else {
-			return (
-				<div>
-					{ this.renderThemeForumCard( true ) }
-					{ this.renderCssSupportCard() }
-				</div>
-			);
 		}
+
+		return (
+			<div>
+				{ this.renderThemeForumCard( true ) }
+				{ this.renderCssSupportCard() }
+			</div>
+		);
 	},
 
 	renderFeaturesCard() {
@@ -348,7 +348,8 @@ const ThemeSheet = React.createClass( {
 					title={ emptyContentTitle }
 					line={ emptyContentMessage }
 					action={ i18n.translate( 'View the showcase' ) }
-					actionURL="/design"/>
+					actionURL="/design"
+				/>
 			</Main>
 		);
 	},
@@ -405,12 +406,12 @@ const ThemeSheet = React.createClass( {
 				image={ this.props.screenshot }>
 				<QueryUserPurchases userId={ this.props.currentUserId } />
 				<Main className="theme__sheet">
-					<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle }/>
+					<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 						{ this.renderBar() }
-						{ siteID && <QueryCurrentTheme siteId={ siteID }/> }
+						{ siteID && <QueryCurrentTheme siteId={ siteID } /> }
 					<ThanksModal
 						site={ this.props.selectedSite }
-						source={ 'details' }/>
+						source={ 'details' } />
 					{ this.state.showPreview && this.renderPreview() }
 					<HeaderCake className="theme__sheet-action-bar"
 								backHref={ this.props.backPath }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -29,7 +29,7 @@ import Gridicon from 'components/gridicon';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { isUserPaid, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import { isUserPaid } from 'state/purchases/selectors';
 import { isPremium, getForumUrl } from 'my-sites/themes/helpers';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCurrentTheme from 'components/data/query-current-theme';
@@ -274,12 +274,7 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderSupportTab() {
-		const {
-			hasLoadedUserPurchasesFromServer,
-			isCurrentUserPaid,
-		} = this.props;
-
-		if ( hasLoadedUserPurchasesFromServer && isCurrentUserPaid ) {
+		if ( this.props.isCurrentUserPaid ) {
 			return (
 				<div>
 					{ this.renderContactUsCard( true ) }
@@ -508,7 +503,6 @@ export default connect(
 			selectedSite,
 			siteSlug,
 			backPath,
-			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 			currentUserId,
 			isCurrentUserPaid,
 		};

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -244,12 +244,16 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderThemeForumCard( isPrimary = false ) {
+		const description = isPremium( this.props ) ?
+			i18n.translate( 'Get in touch with the theme author' ) :
+			i18n.translate( 'Get help from volunteers and staff' );
+
 		return (
 			<Card className="theme__sheet-card-support">
 				<Gridicon icon="comment" size={ 48 } />
 				<div className="theme__sheet-card-support-details">
 					{ i18n.translate( 'Have a question about this theme?' ) }
-					<small>{ i18n.translate( 'Get in touch with the theme author' ) }</small>
+					<small>{ description }</small>
 				</div>
 				<Button primary={ isPrimary } href={ getForumUrl( this.props ) }>Visit forum</Button>
 			</Card>
@@ -262,7 +266,7 @@ const ThemeSheet = React.createClass( {
 				<Gridicon icon="briefcase" size={ 48 } />
 				<div className="theme__sheet-card-support-details">
 					{ i18n.translate( 'Need CSS help? ' ) }
-					<small>{ i18n.translate( 'Visit the CSS customization forum' ) }</small>
+					<small>{ i18n.translate( 'Get help from the experts in our CSS forum' ) }</small>
 				</div>
 				<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
 			</Card>

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 // External dependencies
 import i18n from 'i18n-calypso';
 

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -80,6 +80,16 @@ export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
 	return domainPurchase;
 };
 
+/**
+ * Returns a list of Purchases associated with a User from the state using its userId
+ * @param  {Object}  state       global state
+ * @param  {Number}  userId      the user id
+ * @return {Boolean} if the user currently has any purchases.
+ */
+export const isUserPaid = ( state, userId ) => (
+	state.purchases.hasLoadedUserPurchasesFromServer && 0 < getUserPurchases( state, userId ).length
+);
+
 export const isFetchingUserPurchases = state => state.purchases.isFetchingUserPurchases;
 export const isFetchingSitePurchases = state => state.purchases.isFetchingSitePurchases;
 export const hasLoadedUserPurchasesFromServer = state => state.purchases.hasLoadedUserPurchasesFromServer;

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 
 // Internal dependencies
-import { getPurchases, getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases, getIncludedDomainPurchase, getSitePurchases } from '../selectors';
+import { getPurchases, getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases, getIncludedDomainPurchase, getSitePurchases, isUserPaid, getUserPurchases } from '../selectors';
 import purchasesAssembler from 'lib/purchases/assembler';
 
 describe( 'selectors', () => {
@@ -203,6 +203,74 @@ describe( 'selectors', () => {
 			const subscriptionPurchase = getPurchases( state ).find( purchase => purchase.productSlug === 'value_bundle' );
 
 			expect( getIncludedDomainPurchase( state, subscriptionPurchase ).meta ).to.equal( 'dev.live' );
+		} );
+	} );
+
+	describe( 'isUserPaid', () => {
+		const targetUserId = 123;
+		const examplePurchases = Object.freeze( [
+			{ ID: 1, product_name: 'domain registration', blog_id: 1337, user_id: targetUserId, },
+			{ ID: 2, product_name: 'premium plan', blog_id: 1337, user_id: targetUserId, },
+		] );
+
+		it( 'should return false because there is no purchases', () => {
+			const state = {
+				purchases: {
+					data: [],
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true,
+				}
+			};
+
+			expect( isUserPaid( state, targetUserId ) ).to.be.false;
+		} );
+
+		it( 'should return true because there are purchases from the target user', () => {
+			const state = {
+				purchases: {
+					data: examplePurchases,
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true,
+				}
+			};
+
+			expect( isUserPaid( state, targetUserId ) ).to.be.true;
+		} );
+
+		it( 'should return false because there are no purchases from this user', () => {
+			const state = {
+				purchases: {
+					data: examplePurchases,
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: true,
+				}
+			};
+
+			expect( isUserPaid( state, 65535 ) ).to.be.false;
+		} );
+
+		it( 'should return false because the data is not ready.', () => {
+			const state = {
+				purchases: {
+					data: examplePurchases,
+					error: null,
+					isFetchingSitePurchases: false,
+					isFetchingUserPurchases: false,
+					hasLoadedSitePurchasesFromServer: false,
+					hasLoadedUserPurchasesFromServer: false,
+				}
+			};
+
+			expect( isUserPaid( state, targetUserId ) ).to.be.false;
 		} );
 	} );
 } );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -2,7 +2,16 @@
 import { expect } from 'chai';
 
 // Internal dependencies
-import { getPurchases, getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases, getIncludedDomainPurchase, getSitePurchases, isUserPaid } from '../selectors';
+import {
+	getPurchases,
+	getByPurchaseId,
+	isFetchingUserPurchases,
+	isFetchingSitePurchases,
+	getIncludedDomainPurchase,
+	getSitePurchases,
+	isUserPaid,
+} from '../selectors';
+
 import purchasesAssembler from 'lib/purchases/assembler';
 
 describe( 'selectors', () => {

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 
 // Internal dependencies
-import { getPurchases, getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases, getIncludedDomainPurchase, getSitePurchases, isUserPaid, getUserPurchases } from '../selectors';
+import { getPurchases, getByPurchaseId, isFetchingUserPurchases, isFetchingSitePurchases, getIncludedDomainPurchase, getSitePurchases, isUserPaid } from '../selectors';
 import purchasesAssembler from 'lib/purchases/assembler';
 
 describe( 'selectors', () => {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -95,6 +95,7 @@ module.exports = {
 		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/preview-upgrade-nudge$/, 'components/empty-component' ), //Depends on page.js and should never be required server side
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^components\/data\/query-user-purchases$/, 'components/empty-component' ),
 		new webpack.NormalModuleReplacementPlugin( /^state\/ui\/editor\/selectors$/, 'lodash/noop' ), // will never be called server-side
 		new webpack.NormalModuleReplacementPlugin( /^state\/posts\/selectors$/, 'lodash/noop' ), // will never be called server-side
 		new webpack.NormalModuleReplacementPlugin( /^client\/layout\/guided-tours\/config$/, 'components/empty-component' ) // should never be required server side

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -90,12 +90,12 @@ module.exports = {
 		new webpack.BannerPlugin( 'require( "source-map-support" ).install();', { raw: true, entryOnly: false } ),
 		new webpack.NormalModuleReplacementPlugin( /^lib\/analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib\/upgrades\/actions$/, 'lodash/noop' ), // Uses Flux dispatcher
+		new webpack.NormalModuleReplacementPlugin( /^lib\/olark$/, 'lodash/noop' ), // Too many dependencies, e.g. sites-list
 		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ), // Depends too much on page.js
 		new webpack.NormalModuleReplacementPlugin( /^lib\/post-normalizer\/rule-create-better-excerpt$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/preview-upgrade-nudge$/, 'components/empty-component' ), //Depends on page.js and should never be required server side
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^components\/data\/query-user-purchases$/, 'components/empty-component' ),
 		new webpack.NormalModuleReplacementPlugin( /^state\/ui\/editor\/selectors$/, 'lodash/noop' ), // will never be called server-side
 		new webpack.NormalModuleReplacementPlugin( /^state\/posts\/selectors$/, 'lodash/noop' ), // will never be called server-side
 		new webpack.NormalModuleReplacementPlugin( /^client\/layout\/guided-tours\/config$/, 'components/empty-component' ) // should never be required server side


### PR DESCRIPTION
This PR serves as an attempt to resolve #6514.

### TODO
- [x] Implement the selector which checks if the current user has any purchases.
- [x] Implement the paid-user version of the theme support tab.
- [x] Switch the paid / free version of the theme support tab based on the new selector above.
- [ ] <strike>Placeholders during fetching for the purchases info.</strike> ( not needed! )

Test live: https://calypso.live/?branch=enhance/6514-improve-theme-support-options-for-paid-users