### PR TITLE
Component [Popover] Enable setting of className for RootChild

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -37,6 +37,7 @@ class Popover extends Component {
 		id: PropTypes.string,
 		ignoreContext: PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
 		position: PropTypes.string,
+		rootClassName: PropTypes.string,
 		showDelay: PropTypes.number,
 
 		onClose: PropTypes.func.isRequired,
@@ -386,7 +387,7 @@ class Popover extends Component {
 		this.debug( 'rendering ...' );
 
 		return (
-			<RootChild>
+			<RootChild className={ this.props.rootClassName }>
 				<div
 					style={ this.getStylePosition() }
 					className={ classes }


### PR DESCRIPTION
When using Calypso components within a wp-admin page, the scss imports
have to be done within a nested context. Otherwise, one gets css class
naming conflicts.  In order to make this work, all Calypso components
need to exist under an html element with the given class.

This commit allows RootChild to be set with the css class needed to
support the nested context for scss imports.

cc @retrofox 

Test live: https://calypso.live/?branch=update/popover-root-classname