### PR TITLE
Editor: Fix breaking linting errors.

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -5,10 +5,8 @@ var assign = require( 'lodash/assign' ),
 	debug = require( 'debug' )( 'calypso:posts:post-edit-store' ),
 	emitter = require( 'lib/mixins/emitter' ),
 	isEqual = require( 'lodash/isEqual' ),
-	clone = require( 'lodash/clone' ),
 	filter = require( 'lodash/filter' ),
 	without = require( 'lodash/without' ),
-	map = require( 'lodash/map' ),
 	pickBy = require( 'lodash/pickBy' );
 
 /**
@@ -221,9 +219,7 @@ function isContentEmpty( content ) {
 
 function dispatcherCallback( payload ) {
 	var action = payload.action,
-		changed,
-		category,
-		postId;
+		changed;
 
 	switch ( action.type ) {
 

--- a/client/lib/posts/test/post-edit-store.js
+++ b/client/lib/posts/test/post-edit-store.js
@@ -50,53 +50,6 @@ describe( 'post-edit-store', function() {
 		} );
 	}
 
-	function dispatchCreateTerm( createNewDraft, postId ) {
-		if ( createNewDraft ) {
-			dispatcherCallback( {
-				action: {
-					type: 'DRAFT_NEW_POST',
-					siteId: 123
-				}
-			} );
-		}
-
-		dispatcherCallback( {
-			action: {
-				type: 'CREATE_TERM',
-				id: 'default',
-				siteId: 123,
-				data: {
-					termType: 'categories',
-					terms: [ {
-						name: 'wookies',
-						ID: 'temporary-0',
-						postId: postId
-					} ]
-				},
-				error: null
-			}
-		} );
-	}
-
-	function dispatchReceiveAddTerm() {
-		dispatcherCallback( {
-			action: {
-				type: 'RECEIVE_ADD_TERM',
-				id: 'default',
-				siteId: 123,
-				data: {
-					termType: 'categories',
-					terms: [ {
-						ID: 787,
-						name: 'wookies',
-						temporaryId: 'temporary-0'
-					} ]
-				},
-				error: null
-			}
-		} );
-	}
-
 	it( 'initializes new draft post properly', function() {
 		var siteId = 1234,
 			post;


### PR DESCRIPTION
This branch fixes some breaking `no-unused-vars` violations that were caused by the merge of #7247.  

__To Test__
- `npm run test-client client/lib/posts`

/cc @aduth 

Test live: https://calypso.live/?branch=fix/editor/linting-errors