### PR TITLE
reader-author-profile: don't display site stream link if author name and site name are the same

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -33,7 +33,7 @@ const AuthorCompactProfile = React.createClass( {
 			<div className="author-compact-profile">
 				<Gravatar size={ 96 } user={ author } />
 				<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>{ author.name }</ReaderAuthorLink>
-				{ siteName && siteUrl
+				{ siteName && siteUrl && siteName.toLowerCase() !== author.name.toLowerCase()
 					? <ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId }>
 						{ siteName }
 					</ReaderSiteStreamLink> : null }

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -11,6 +11,7 @@ import ReaderAuthorLink from 'blocks/reader-author-link';
 import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import ReaderFollowButton from 'reader/follow-button';
 import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
@@ -29,14 +30,20 @@ const AuthorCompactProfile = React.createClass( {
 			return null;
 		}
 
+		const hasMatchingAuthorAndSiteNames = siteName.toLowerCase() === author.name.toLowerCase();
+		const classes = classnames( 'author-compact-profile', {
+			'has-author-link': ! hasMatchingAuthorAndSiteNames
+		} );
+
 		return (
-			<div className="author-compact-profile">
+			<div className={ classes }>
 				<Gravatar size={ 96 } user={ author } />
-				<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>{ author.name }</ReaderAuthorLink>
-				{ siteName && siteUrl && siteName.toLowerCase() !== author.name.toLowerCase()
-					? <ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId }>
+				{ ! hasMatchingAuthorAndSiteNames &&
+					<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>{ author.name }</ReaderAuthorLink> }
+				{ siteName &&
+					<ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId }>
 						{ siteName }
-					</ReaderSiteStreamLink> : null }
+					</ReaderSiteStreamLink> }
 
 				<div className="author-compact-profile__follow">
 				{ followCount
@@ -53,7 +60,7 @@ const AuthorCompactProfile = React.createClass( {
 					) }
 					</div> : null }
 
-				<ReaderFollowButton siteUrl={ siteUrl } />
+					<ReaderFollowButton siteUrl={ siteUrl } />
 				</div>
 			</div>
 		);

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -51,6 +51,14 @@
             }
         }
     }
+
+    // If there's an author link, present site stream link in normal font weight
+    &.has-author-link {
+        .author-compact-profile__site-link {
+            font-weight: inherit;
+            margin-top: 4px;
+        }
+    }
 }
 
 .author-compact-profile .external-link,
@@ -66,13 +74,10 @@
     }
 }
 
-.author-compact-profile .reader-author-link {
+.author-compact-profile .reader-author-link,
+.author-compact-profile__site-link {
 	font-weight: 600;
 	margin-top: 18px;
-}
-
-.author-compact-profile__site-link {
-	margin-top: 4px;
 }
 
 .author-compact-profile__follow {


### PR DESCRIPTION
In the reader-author-profile, we should only show the site name if it does not match the author name.

Before:

![46f049cc-5fed-11e6-92c9-ae8269e09eee](https://cloud.githubusercontent.com/assets/17325/17749455/0431bbc2-64be-11e6-9196-c7a1bd951103.png)

After:

<img width="260" alt="screen shot 2016-08-17 at 21 03 21" src="https://cloud.githubusercontent.com/assets/17325/17749475/202f74a4-64be-11e6-9d1a-069ebae761a0.png">

### To test

Check out http://calypso.localhost:3000/read/feeds/24393283/posts/1116435392.

Fixes #7427.

Test live: https://calypso.live/?branch=fix/reader/author-compact-profile-site-and-author-same-name