### PR TITLE
Domains: Remove domain suggestion vendor AB test

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -30,7 +30,6 @@ import DomainSearchResults from 'components/domains/domain-search-results';
 import ExampleDomainSuggestions from 'components/domains/example-domain-suggestions';
 import analyticsMixin from 'lib/mixins/analytics';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { abtest } from 'lib/abtest';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
 import {
 	getDomainsSuggestions,
@@ -45,7 +44,7 @@ const SUGGESTION_QUANTITY = 10;
 const INITIAL_SUGGESTION_QUANTITY = 2;
 
 const analytics = analyticsMixin( 'registerDomain' ),
-	searchVendor = abtest( 'domainSuggestionVendor' );
+	searchVendor = 'domainsbot';
 
 let searchQueue = [],
 	searchStackTimer = null,
@@ -345,7 +344,7 @@ const RegisterDomainStep = React.createClass( {
 							query: domain,
 							quantity: SUGGESTION_QUANTITY,
 							include_wordpressdotcom: this.props.includeWordPressDotCom,
-							vendor: abtest( 'domainSuggestionVendor' )
+							vendor: searchVendor
 						},
 						timestamp = Date.now();
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -24,14 +24,6 @@ module.exports = {
 		defaultVariation: 'noChanges',
 		allowExistingUsers: false,
 	},
-	domainSuggestionVendor: {
-		datestamp: '20160614',
-		variations: {
-			namegen: 50,
-			domainsbot: 50
-		},
-		defaultVariation: 'namegen'
-	},
 	multiDomainRegistrationV1: {
 		datestamp: '20200721',
 		variations: {

--- a/client/my-sites/domain-tip/index.jsx
+++ b/client/my-sites/domain-tip/index.jsx
@@ -9,7 +9,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { getSite, getSiteSlug } from 'state/sites/selectors';
 import { getDomainsSuggestions, } from 'state/domains/suggestions/selectors';
 import { currentUserHasFlag } from 'state/current-user/selectors';
@@ -26,7 +25,7 @@ function getQueryObject( site, siteSlug ) {
 	return {
 		query: siteSlug.split( '.' )[ 0 ],
 		quantity: 1,
-		vendor: abtest( 'domainSuggestionVendor' )
+		vendor: 'domainsbot'
 	};
 }
 
@@ -68,7 +67,7 @@ const DomainTip = React.createClass( {
 		}
 		const classes = classNames( this.props.className, 'domain-tip' );
 		const { query, quantity, vendor } = getQueryObject( this.props.site, this.props.siteSlug );
-		const suggestion = this.props.suggestions ? this.props.suggestions[0] : null;
+		const suggestion = this.props.suggestions ? this.props.suggestions[ 0 ] : null;
 		return (
 			<div className={ classes } >
 				<QueryDomainsSuggestions


### PR DESCRIPTION
- Remove `domainSuggestionVendor` A/B Test
- Default vendor to `domainsbot`, but leave mechanism so in the future we can reuse it

Test live: https://calypso.live/?branch=update/remove-suggestion-vendor-abtest