### PR TITLE
Editor: Move slug to redux

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -34,7 +34,6 @@ var _initialRawContent = null,
 	_queueChanges = false,
 	_rawContent = null,
 	_savedPost = null,
-	_suggestedSlug = null,
 	PostEditStore;
 
 function resetState() {
@@ -50,35 +49,7 @@ function resetState() {
 	_queue = [];
 	_queueChanges = false;
 	_rawContent = null;
-	_suggestedSlug = null;
 	_savedPost = null;
-}
-
-function getSlug( post ) {
-	var suggestedSlug = utils.getSuggestedSlug( post );
-
-	if ( ! post ) {
-		return null;
-	}
-
-	if ( utils.isPublished( post ) ) {
-		return post.slug;
-	}
-
-	// if the existing post is using the suggested slug, accept the new suggestion
-	if ( _savedPost &&
-			_savedPost.slug === _suggestedSlug &&
-			suggestedSlug
-	) {
-		return suggestedSlug;
-	}
-
-	// loading a draft if no slug is present, use suggestedSlug
-	if ( ! _savedPost && ! post.slug && suggestedSlug ) {
-		return suggestedSlug;
-	}
-
-	return post.slug || null;
 }
 
 function getParentId( post ) {
@@ -103,12 +74,10 @@ function getPageTemplate( post ) {
 function startEditing( post ) {
 	resetState();
 	post = normalize( post );
-	post.slug = getSlug( post );
 	if ( post.title ) {
 		post.title = decodeEntities( post.title );
 	}
 	_previewUrl = utils.getPreviewURL( post );
-	_suggestedSlug = utils.getSuggestedSlug( post );
 	_savedPost = Object.freeze( post );
 	_post = _savedPost;
 	_isLoading = false;
@@ -116,12 +85,10 @@ function startEditing( post ) {
 
 function updatePost( post ) {
 	post = normalize( post );
-	post.slug = getSlug( post );
 	if ( post.title ) {
 		post.title = decodeEntities( post.title );
 	}
 	_previewUrl = utils.getPreviewURL( post );
-	_suggestedSlug = utils.getSuggestedSlug( post );
 	_savedPost = Object.freeze( post );
 	_post = _savedPost;
 	_isNew = false;

--- a/client/lib/posts/test/post-edit-store.js
+++ b/client/lib/posts/test/post-edit-store.js
@@ -445,8 +445,7 @@ describe( 'post-edit-store', function() {
 				type: 'post',
 				parent_id: null,
 				title: '',
-				content: '',
-				slug: null
+				content: ''
 			} ) );
 		} );
 	} );
@@ -754,112 +753,6 @@ describe( 'post-edit-store', function() {
 			} );
 
 			assert( PostEditStore.hasContent() === false );
-		} );
-	} );
-
-	describe( 'slugs', function() {
-		it( 'should use existing slug on puglished posts', function() {
-			var post;
-			dispatcherCallback( {
-				action: {
-					type: 'RECEIVE_POST_TO_EDIT',
-					post: {
-						ID: 777,
-						site_ID: 123,
-						title: 'Super Slug',
-						slug: 'super-rad-slug',
-						status: 'publish',
-						other_URLs: {
-							suggested_slug: 'no-slugs-for-you'
-						}
-					}
-				}
-			} );
-			post = PostEditStore.get();
-			assert( post.slug === 'super-rad-slug' );
-		} );
-
-		it( 'should use new suggested slug if prior _savedPost did', function() {
-			var post;
-			dispatcherCallback( {
-				action: {
-					type: 'RECEIVE_POST_TO_EDIT',
-					post: {
-						ID: 777,
-						site_ID: 123,
-						title: 'Oh My Slugness',
-						status: 'draft',
-						slug: 'oh-my-slugness',
-						other_URLs: {
-							suggested_slug: 'oh-my-slugness'
-						}
-
-					}
-				}
-			} );
-
-			post = PostEditStore.get();
-			assert( post.slug === 'oh-my-slugness' );
-
-			dispatcherCallback( {
-				action: {
-					type: 'RECEIVE_POST_BEING_EDITED',
-					post: {
-						ID: 777,
-						site_ID: 123,
-						title: 'Oh My Slugness Wat!',
-						status: 'draft',
-						other_URLs: {
-							suggested_slug: 'oh-my-slugness-wat'
-						}
-					}
-				}
-			} );
-
-			post = PostEditStore.get();
-			assert( post.slug === 'oh-my-slugness-wat' );
-		} );
-
-		it( 'should not use suggested slug if a custom one has been set', function() {
-			var post;
-			dispatcherCallback( {
-				action: {
-					type: 'RECEIVE_POST_TO_EDIT',
-					post: {
-						ID: 777,
-						site_ID: 123,
-						title: 'Too Many Slugs',
-						status: 'draft',
-						slug: 'too-many-slugs',
-						other_URLs: {
-							suggested_slug: 'oh-my-slugness'
-						}
-
-					}
-				}
-			} );
-
-			post = PostEditStore.get();
-			assert( post.slug === 'too-many-slugs' );
-
-			dispatcherCallback( {
-				action: {
-					type: 'RECEIVE_POST_BEING_EDITED',
-					post: {
-						ID: 777,
-						site_ID: 123,
-						title: 'Too Many Slugs on my API',
-						status: 'draft',
-						slug: 'sluga-saurus-rex',
-						other_URLs: {
-							suggested_slug: 'too-many-slugs-on-my-api'
-						}
-					}
-				}
-			} );
-
-			post = PostEditStore.get();
-			assert( post.slug === 'sluga-saurus-rex' );
 		} );
 	} );
 

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -207,14 +207,6 @@ var utils = {
 		return pathParts.join( '/' );
 	},
 
-	getSuggestedSlug: function( post ) {
-		if ( ! post || ! post.other_URLs || ! post.other_URLs.suggested_slug ) {
-			return null;
-		}
-
-		return post.other_URLs.suggested_slug;
-	},
-
 	/**
 	 * Returns the ID of the featured image assigned to the specified post, or
 	 * `undefined` otherwise. A utility function is useful because the format

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -273,11 +273,7 @@ const EditorDrawer = React.createClass( {
 				icon={ <Gridicon icon="ellipsis" /> }
 				className="editor-drawer__more-options"
 			>
-				{ siteUtils.isPermalinkEditable( this.props.site ) && (
-					<EditorMoreOptionsSlug
-						slug={ this.props.post ? this.props.post.slug : '' }
-						type={ this.props.type } />
-				) }
+				{ siteUtils.isPermalinkEditable( this.props.site ) && <EditorMoreOptionsSlug /> }
 				{ this.renderExcerpt() }
 				{ this.renderLocation() }
 				{ this.renderDiscussion() }

--- a/client/post-editor/editor-more-options/slug.jsx
+++ b/client/post-editor/editor-more-options/slug.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes, PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -10,17 +11,19 @@ import { localize } from 'i18n-calypso';
 import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 import AccordionSection from 'components/accordion/section';
 import Slug from 'post-editor/editor-slug';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
 
 class EditorMoreOptionsSlug extends PureComponent {
 	static propTypes = {
-		slug: PropTypes.string,
-		type: PropTypes.string,
+		postType: PropTypes.string,
 		translate: PropTypes.func
 	};
 
 	getPopoverLabel() {
-		const { translate } = this.props;
-		if ( 'page' === this.props.type ) {
+		const { translate, postType } = this.props;
+		if ( 'page' === postType ) {
 			return translate( 'The slug is the URL-friendly version of the page title.' );
 		}
 
@@ -28,14 +31,13 @@ class EditorMoreOptionsSlug extends PureComponent {
 	}
 
 	render() {
-		const { slug, type, translate } = this.props;
+		const { postType, translate } = this.props;
 
 		return (
 			<AccordionSection className="editor-more-options__slug">
 				<EditorDrawerLabel labelText={ translate( 'Slug' ) } helpText={ this.getPopoverLabel() }>
 					<Slug
-						slug={ slug }
-						instanceName={ type + '-sidebar' }
+						instanceName={ postType + '-sidebar' }
 						className="editor-more-options__slug-field" />
 				</EditorDrawerLabel>
 			</AccordionSection>
@@ -43,4 +45,12 @@ class EditorMoreOptionsSlug extends PureComponent {
 	}
 }
 
-export default localize( EditorMoreOptionsSlug );
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			postType: getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' )
+		};
+	},
+)( localize( EditorMoreOptionsSlug ) );

--- a/client/post-editor/editor-page-slug/index.jsx
+++ b/client/post-editor/editor-page-slug/index.jsx
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
-import pick from 'lodash/pick';
+import React, { PropTypes, Component } from 'react';
 
 /**
  * Internal Dependencies
@@ -11,24 +9,16 @@ import pick from 'lodash/pick';
 import EditorSlug from 'post-editor/editor-slug';
 import Gridicon from 'components/gridicon';
 
-export default React.createClass( {
-	displayName: 'PostEditorPageSlug',
-
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
-		path: PropTypes.string,
-		slug: PropTypes.string
-	},
+export default class PostEditorPageSlug extends Component {
+	static propTypes = {
+		path: PropTypes.string
+	};
 
 	render() {
 		return (
-			<EditorSlug
-				{ ...pick( this.props, 'path', 'slug' ) }
-				instanceName="page-permalink"
-			>
+			<EditorSlug path={ this.props.path } instanceName="page-permalink">
 				<Gridicon icon="link" />
 			</EditorSlug>
 		);
 	}
-} );
+}

--- a/client/post-editor/editor-page-slug/index.jsx
+++ b/client/post-editor/editor-page-slug/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import React, { PropTypes, PureComponent } from 'react';
 
 /**
  * Internal Dependencies
@@ -9,7 +9,7 @@ import React, { PropTypes, Component } from 'react';
 import EditorSlug from 'post-editor/editor-slug';
 import Gridicon from 'components/gridicon';
 
-export default class PostEditorPageSlug extends Component {
+export default class PostEditorPageSlug extends PureComponent {
 	static propTypes = {
 		path: PropTypes.string
 	};

--- a/client/post-editor/editor-permalink/index.jsx
+++ b/client/post-editor/editor-permalink/index.jsx
@@ -1,36 +1,48 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	pick = require( 'lodash/pick' );
+import React, { PropTypes, Component } from 'react';
+import { pick } from 'lodash';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-var Gridicon = require( 'components/gridicon' ),
-	Slug = require( 'post-editor/editor-slug' ),
-	Popover = require( 'components/popover' ),
-	Tooltip = require( 'components/tooltip' ),
-	ClipboardButton = require( 'components/forms/clipboard-button' );
+import Gridicon from 'components/gridicon';
+import Slug from 'post-editor/editor-slug';
+import Popover from 'components/popover';
+import Tooltip from 'components/tooltip';
+import ClipboardButton from 'components/forms/clipboard-button';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostSlug } from 'state/posts/selectors';
 
-var EditorPermalink = React.createClass( {
+class EditorPermalink extends Component {
+	static propTypes = {
+		path: PropTypes.string,
+		isEditable: PropTypes.bool,
+		translate: PropTypes.func,
+		slug: PropTypes.string
+	};
 
-	propTypes: {
-		path: React.PropTypes.string,
-		slug: React.PropTypes.string,
-		isEditable: React.PropTypes.bool
-	},
+	constructor() {
+		super( ...arguments );
+		this.showPopover = this.showPopover.bind( this );
+		this.showTooltip = this.showTooltip.bind( this );
+		this.onCopy = this.onCopy.bind( this );
+		this.hideTooltip = this.hideTooltip.bind( this );
+		this.closePopover = this.closePopover.bind( this );
 
-	getInitialState: function() {
-		return {
+		this.state = {
 			showPopover: false,
 			popoverVisible: false,
 			showCopyConfirmation: false,
 			tooltip: false
 		};
-	},
+	}
 
-	componentDidUpdate: function( prevProps, prevState ) {
+	componentDidUpdate( prevProps, prevState ) {
 		if ( this.state.showPopover !== prevState.showPopover ) {
 			// The contents of <Popover /> are only truly rendered into the
 			// DOM after its `componentDidUpdate` finishes executing, so we
@@ -39,26 +51,26 @@ var EditorPermalink = React.createClass( {
 				popoverVisible: this.state.showPopover
 			} );
 		}
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		clearTimeout( this.dismissCopyConfirmation );
-	},
+	}
 
-	showPopover: function() {
+	showPopover() {
 		this.setState( {
 			showPopover: ! this.state.showPopover,
 			tooltip: false
 		} );
-	},
+	}
 
-	showTooltip: function() {
+	showTooltip() {
 		if ( ! this.state.showPopover ) {
 			this.setState( { tooltip: true } );
 		}
-	},
+	}
 
-	onCopy: function() {
+	onCopy() {
 		this.setState( {
 			showCopyConfirmation: true
 		} );
@@ -69,46 +81,47 @@ var EditorPermalink = React.createClass( {
 				showCopyConfirmation: false
 			} );
 		}, 4000 );
-	},
+	}
 
-	hideTooltip: function() {
+	hideTooltip() {
 		this.setState( { tooltip: false } );
-	},
+	}
 
-	closePopover: function() {
+	closePopover() {
 		this.setState( { showPopover: false } );
-	},
+	}
 
-	renderCopyButton: function() {
-		var label;
-
+	renderCopyButton() {
 		if ( ! this.state.popoverVisible ) {
 			return;
 		}
+		const { path, slug, translate } = this.props;
 
+		let label;
 		if ( this.state.showCopyConfirmation ) {
-			label = this.translate( 'Copied!' );
+			label = translate( 'Copied!' );
 		} else {
-			label = this.translate( 'Copy', { context: 'verb' } );
+			label = translate( 'Copy', { context: 'verb' } );
 		}
 
 		return (
 			<ClipboardButton
-				text={ this.props.path + this.props.slug }
+				text={ path + slug }
 				onCopy={ this.onCopy }
 				compact>
 				{ label }
 			</ClipboardButton>
-		)
-	},
+		);
+	}
 
-	render: function() {
-		var tooltipMessage;
+	render() {
+		const { translate } = this.props;
+		let tooltipMessage;
 
 		if ( this.props.isEditable ) {
-			tooltipMessage = this.translate( 'Edit post URL' );
+			tooltipMessage = translate( 'Edit post URL' );
 		} else {
-			tooltipMessage = this.translate( 'View post URL' );
+			tooltipMessage = translate( 'View post URL' );
 		}
 
 		return (
@@ -127,7 +140,7 @@ var EditorPermalink = React.createClass( {
 					className="editor-permalink__popover"
 				>
 					<Slug
-						{ ...pick( this.props, 'slug', 'path', 'isEditable' ) }
+						{ ...pick( this.props, 'path', 'isEditable' ) }
 						onEscEnter={ this.closePopover }
 						instanceName="post-popover"
 					/>
@@ -143,6 +156,15 @@ var EditorPermalink = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
-module.exports = EditorPermalink;
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+
+		return {
+			slug: getEditedPostSlug( state, siteId, postId )
+		};
+	},
+)( localize( EditorPermalink ) );

--- a/client/post-editor/editor-slug/index.jsx
+++ b/client/post-editor/editor-slug/index.jsx
@@ -2,79 +2,84 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
-import React, { PropTypes } from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import noop from 'lodash/noop';
 
 /**
  * Internal Dependencies
  */
-import actions from 'lib/posts/actions';
 import TrackInputChanges from 'components/track-input-changes';
 import FormTextInput from 'components/forms/form-text-input';
 import { recordStat, recordEvent } from 'lib/posts/stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostSlug } from 'state/posts/selectors';
+import { editPost } from 'state/posts/actions';
 
-export default React.createClass( {
-	displayName: 'PostEditorSlug',
-
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
+class PostEditorSlug extends Component {
+	static propTypes = {
 		path: PropTypes.string,
 		slug: PropTypes.string,
 		onEscEnter: PropTypes.func,
 		className: PropTypes.string,
 		isEditable: PropTypes.bool,
-		postType: PropTypes.string,
-		instanceName: PropTypes.string
-	},
+		instanceName: PropTypes.string,
+		translate: PropTypes.func
+	};
 
-	getDefaultProps() {
-		return {
-			onEscEnter: noop,
-			isEditable: true
-		};
-	},
+	static defaultProps = {
+		onEscEnter: () => {},
+		isEditable: true
+	};
 
-	getInitialState() {
-		return {
-			isSlugFocused: false
-		};
-	},
+	constructor() {
+		super( ...arguments );
+		this.state = { isSlugFocused: false };
+
+		this.onSlugKeyDown = this.onSlugKeyDown.bind( this );
+		this.onSlugChange = this.onSlugChange.bind( this );
+		this.onBlur = this.onBlur.bind( this );
+		this.onFocus = this.onFocus.bind( this );
+		this.focusSlug = this.focusSlug.bind( this );
+		this.recordChangeStats = this.recordChangeStats.bind( this );
+		this.statTracked = false;
+	}
 
 	onSlugChange( event ) {
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.edit( { slug: event.target.value } );
-	},
+		const { siteId, postId } = this.props;
+		this.props.editPost( siteId, postId, { slug: event.target.value } );
+	}
 
 	onSlugKeyDown( event ) {
 		if ( event.key === 'Enter' || event.key === 'Escape' ) {
+			const { onEscEnter, isEditable } = this.props;
 			this.setState( { isSlugFocused: false }, function() {
-				this.props.onEscEnter();
+				onEscEnter();
 
-				if ( this.props.isEditable ) {
+				if ( isEditable ) {
 					ReactDom.findDOMNode( this.refs.slugField ).blur();
 				}
 			} );
 		}
-	},
+	}
 
 	onBlur() {
 		if ( this.state.isSlugFocused ) {
 			this.setState( { isSlugFocused: false } );
 		}
-	},
+	}
 
 	onFocus() {
 		this.setState( { isSlugFocused: true } );
-	},
+	}
 
 	focusSlug() {
 		if ( this.props.isEditable ) {
 			ReactDom.findDOMNode( this.refs.slugField ).focus();
 		}
-	},
+	}
 
 	recordChangeStats() {
 		switch ( this.props.instanceName ) {
@@ -98,33 +103,43 @@ export default React.createClass( {
 				recordEvent( 'Slug Edited (Page Permalink)' );
 				break;
 		}
-	},
+	}
 
 	render() {
-		const wrapperClass = classNames( 'editor-slug', this.props.className, {
+		const { className, translate, slug, children, path, isEditable } = this.props;
+		const wrapperClass = classNames( 'editor-slug', className, {
 			'is-focused': this.state.isSlugFocused
 		} );
 
 		return (
 			<div className={ wrapperClass } onClick={ this.focusSlug }>
-				{ this.props.children }
-				<span className="editor-slug__url-path" onClick={ this.focusSlug }>{ this.props.path }</span>
-				{ this.props.isEditable ?
+				{ children }
+				<span className="editor-slug__url-path" onClick={ this.focusSlug }>{ path }</span>
+				{ isEditable &&
 					<TrackInputChanges onNewValue={ this.recordChangeStats }>
 						<FormTextInput
 							ref="slugField"
-							value={ this.props.slug ? this.props.slug : '' }
+							value={ slug || '' }
 							onChange={ this.onSlugChange }
 							onKeyDown={ this.onSlugKeyDown }
 							onBlur={ this.onBlur }
 							onFocus={ this.onFocus }
-							aria-label={ this.translate( 'Enter slug' ) }
+							aria-label={ translate( 'Enter slug' ) }
 						/>
 					</TrackInputChanges>
-				:
-					null
 				}
 			</div>
 		);
 	}
-} );
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const slug = getEditedPostSlug( state, siteId, postId );
+
+		return { siteId, postId, slug };
+	},
+	{ editPost }
+)( localize( PostEditorSlug ) );

--- a/client/post-editor/editor-slug/index.jsx
+++ b/client/post-editor/editor-slug/index.jsx
@@ -26,12 +26,15 @@ class PostEditorSlug extends Component {
 		className: PropTypes.string,
 		isEditable: PropTypes.bool,
 		instanceName: PropTypes.string,
-		translate: PropTypes.func
+		translate: PropTypes.func,
+		siteId: PropTypes.number,
+		postId: PropTypes.number
 	};
 
 	static defaultProps = {
 		onEscEnter: () => {},
-		isEditable: true
+		isEditable: true,
+		slug: ''
 	};
 
 	constructor() {
@@ -119,7 +122,7 @@ class PostEditorSlug extends Component {
 					<TrackInputChanges onNewValue={ this.recordChangeStats }>
 						<FormTextInput
 							ref="slugField"
-							value={ slug || '' }
+							value={ slug }
 							onChange={ this.onSlugChange }
 							onKeyDown={ this.onSlugKeyDown }
 							onBlur={ this.onBlur }

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -96,7 +96,6 @@ export default React.createClass( {
 			<div className={ classes }>
 				{ post && post.ID && ! PostUtils.isPage( post ) &&
 					<EditorPermalink
-						slug={ post.slug }
 						path={ isPermalinkEditable ? PostUtils.getPermalinkBasePath( post ) : post.URL }
 						isEditable={ isPermalinkEditable } />
 				}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -219,7 +219,6 @@ const PostEditor = React.createClass( {
 									tabIndex={ 1 } />
 								{ this.state.post && isPage && site
 									? <EditorPageSlug
-										slug={ this.state.post.slug }
 										path={ this.state.post.URL && ( this.state.post.URL !== siteURL )
 											? utils.getPagePath( this.state.post )
 											: siteURL

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -1,12 +1,9 @@
 /**
  * External dependencies
  */
-import get from 'lodash/get';
+import { get, includes, isEqual, omit, some } from 'lodash';
 import createSelector from 'lib/create-selector';
-import includes from 'lodash/includes';
-import some from 'lodash/some';
-import omit from 'lodash/omit';
-import isEqual from 'lodash/isEqual';
+import moment from 'moment-timezone';
 
 /**
  * Internal dependencies
@@ -360,6 +357,61 @@ export const isEditedPostDirty = createSelector(
 	},
 	( state ) => [ state.posts.items, state.posts.edits ]
 );
+
+/**
+ * Returns true if the post status is publish, private, or future
+ * and the date is in the past
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Number}  postId Post ID
+ * @return {Boolean}        Whether post is published
+ */
+export const isPostPublished = createSelector(
+	( state, siteId, postId ) => {
+		const post = getSitePost( state, siteId, postId );
+
+		if ( ! post ) {
+			return null;
+		}
+
+		return includes( [ 'publish', 'private' ], post.status ) ||
+			( post.status === 'future' && moment( post.date ).isBefore( moment() ) );
+	},
+	( state ) => state.posts.items
+);
+
+/**
+ * Returns the slug, or suggested_slug, for the edited post
+ *
+ * @param  {Object} state  Global state tree
+ * @param  {Number} siteId Site ID
+ * @param  {Number} postId Post ID
+ * @return {String}             Slug value
+ */
+export function getEditedPostSlug( state, siteId, postId ) {
+	const post = getSitePost( state, siteId, postId );
+	const postEdits = getPostEdits( state, siteId, postId ) || {};
+	const suggestedSlug = get( post, [ 'other_URLs', 'suggested_slug' ] );
+	const postSlug = get( post, 'slug' );
+
+	// if local edits exists, return them regardless of post status
+	if ( postEdits.hasOwnProperty( 'slug' ) ) {
+		return postEdits.slug;
+	}
+
+	// when post is published, return the slug
+	if ( isPostPublished( state, siteId, postId ) ) {
+		return postSlug;
+	}
+
+	// only return suggested_slug if slug has not been edited
+	if ( suggestedSlug && ! postSlug ) {
+		return suggestedSlug;
+	}
+
+	return postSlug;
+}
 
 /**
  * Returns the most reliable preview URL for the post by site ID, post ID pair,

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, includes, isEqual, omit, some } from 'lodash';
+import { has, get, includes, isEqual, omit, some } from 'lodash';
 import createSelector from 'lib/create-selector';
 import moment from 'moment-timezone';
 
@@ -378,7 +378,7 @@ export const isPostPublished = createSelector(
 		return includes( [ 'publish', 'private' ], post.status ) ||
 			( post.status === 'future' && moment( post.date ).isBefore( moment() ) );
 	},
-	( state ) => state.posts.items
+	( state ) => state.posts.queries
 );
 
 /**
@@ -390,15 +390,14 @@ export const isPostPublished = createSelector(
  * @return {String}             Slug value
  */
 export function getEditedPostSlug( state, siteId, postId ) {
-	const post = getSitePost( state, siteId, postId );
-	const postEdits = getPostEdits( state, siteId, postId ) || {};
-	const suggestedSlug = get( post, [ 'other_URLs', 'suggested_slug' ] );
-	const postSlug = get( post, 'slug' );
-
 	// if local edits exists, return them regardless of post status
-	if ( postEdits.hasOwnProperty( 'slug' ) ) {
+	const postEdits = getPostEdits( state, siteId, postId );
+	if ( has( postEdits, 'slug' ) ) {
 		return postEdits.slug;
 	}
+
+	const post = getSitePost( state, siteId, postId );
+	const postSlug = get( post, 'slug' );
 
 	// when post is published, return the slug
 	if ( isPostPublished( state, siteId, postId ) ) {
@@ -406,6 +405,7 @@ export function getEditedPostSlug( state, siteId, postId ) {
 	}
 
 	// only return suggested_slug if slug has not been edited
+	const suggestedSlug = get( post, [ 'other_URLs', 'suggested_slug' ] );
 	if ( suggestedSlug && ! postSlug ) {
 		return suggestedSlug;
 	}


### PR DESCRIPTION
Another (big) step in moving the editor to redux, this branch moves the post `slug` into the state tree.  While doing so, I have tried to simplify the logic/flow of when the `suggested_slug` is shown in the editor using the newly added `getEditedPostSlug` selector.

The logic behind the selector is to _always_ return the slug in the `edits` tree, if one exists, then return the `post.slug` if the post is published.  Otherwise, the suggested slug will be shown if one was returned by the API.

As such, once a slug is manually entered on a drafted post ( i.e. the suggested slug is changed ), the suggested slug will no longer be used.  In the flux approach, we would track the prior suggested slug vs the slug returned by the API, and I feel this implementation is much easier to grok.

Slugs are an interesting beast in the editor.  They are shown in multiple places ( sidebar, below title ) and the display differs based upon post type.  So testing is _fun_.  But having the `slug` stored in the state tree will be quite nice.

__To Test__
- Open a new post in the editor
- Add a title, and some content, wait for an auto-save
- Either click the "link" icon to the left of the title, or expand more options in the sidebar ( or both ), and note that the suggested slug will be shown
- Update the title, save, verify the suggested slug has been updated
- Change the slug via one of the slug fields, verify that your changes are persisted once a save happens
- Open a published post in the editor, verify you can change the slug, and it is persisted.
_** note that slug validation and changes happen at the API, as in if you don't dasherize your slug, the API will properly slug your input for you_

Follow the same steps above, but do so with Pages

Test live: https://calypso.live/?branch=update/editor/redux-slug