### PR TITLE
Editor: try compact notice for categories

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -326,6 +326,7 @@
 @import 'post-editor/edit-post-status/style';
 @import 'post-editor/editor-action-bar/style';
 @import 'post-editor/editor-author/style';
+@import 'post-editor/editor-categories-tags/style';
 @import 'post-editor/editor-delete-post/style';
 @import 'post-editor/editor-discussion/style';
 @import 'post-editor/editor-drawer/style';

--- a/client/post-editor/editor-categories-tags/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/accordion.jsx
@@ -18,6 +18,7 @@ import TermSelector from 'post-editor/editor-term-selector';
 import Tags from 'post-editor/editor-tags';
 import unescapeString from 'lodash/unescape';
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 import { addSiteFragment } from 'lib/route';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -44,14 +45,11 @@ export class EditorCategoriesTagsAccordion extends Component {
 	renderJetpackNotice() {
 		const { translate, siteSlug } = this.props;
 		return (
-			<Notice status="is-warning" showDismiss={ false }>
-				{ translate( 'You must update Jetpack to use this feature. {{update}}Update Now{{/update}}', {
-					components: {
-						update: (
-							<a href={ addSiteFragment( '/plugins/jetpack', siteSlug ) } />
-						)
-					}
-				} ) }
+			<Notice status="is-warning" showDismiss={ false } isCompact>
+				{ translate( 'You must update Jetpack to use this feature.' ) }
+				<NoticeAction href={ addSiteFragment( '/plugins/jetpack', siteSlug ) }>
+					{ translate( 'Update Now' ) }
+				</NoticeAction>
 			</Notice>
 		);
 	}

--- a/client/post-editor/editor-categories-tags/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/accordion.jsx
@@ -45,8 +45,11 @@ export class EditorCategoriesTagsAccordion extends Component {
 	renderJetpackNotice() {
 		const { translate, siteSlug } = this.props;
 		return (
-			<Notice status="is-warning" showDismiss={ false } isCompact>
-				{ translate( 'You must update Jetpack to use this feature.' ) }
+			<Notice
+				status="is-warning"
+				showDismiss={ false }
+				text={ translate( 'You must update Jetpack to use this feature.' ) }
+				className="editor-categories-tags__upgrade-notice" >
 				<NoticeAction href={ addSiteFragment( '/plugins/jetpack', siteSlug ) }>
 					{ translate( 'Update Now' ) }
 				</NoticeAction>

--- a/client/post-editor/editor-categories-tags/style.scss
+++ b/client/post-editor/editor-categories-tags/style.scss
@@ -1,0 +1,14 @@
+.editor-categories-tags__upgrade-notice {
+	.notice__icon {
+		display: none;
+	}
+
+	.notice__content {
+		flex-direction: column;
+	}
+
+	.notice__action {
+		margin: 0;
+		justify-content: flex-end;
+	}
+}


### PR DESCRIPTION
This is a follow-up item from #7247 - specifically, in that branch a notice was added that is shown when the Jetpack version does not satisfy the minimum requirement for the taxonomy endpoints.  This branch changes up the current look with the `isCompact` on the `<Notice />`

__Before__
<img width="258" alt="new_post_ _major_keys_and_monads_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/17755154/1f751914-648d-11e6-8502-d3dd22e91b22.png">

__After__
<img width="257" alt="new_post_ _major_keys_and_monads_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/17755175/365df916-648d-11e6-9700-9df43a6437b7.png">

__To Test__
In order to test this out, you must have a Jetpack site running a version older than `4.1.0`, and then open a post in the editor for that site.

Test live: https://calypso.live/?branch=update/editor/jp-update-notice