### PR TITLE
Reader: do not pass unused prop to InfiniteList

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -452,7 +452,6 @@ module.exports = React.createClass( {
 			fetchNextPage={ this.fetchNextPage }
 			getItemRef= { this.getPostRef }
 			renderItem={ this.renderPost }
-			selectedIndex={ this.props.store.getSelectedIndex() }
 			renderLoadingPlaceholders={ this.renderLoadingPlaceholders } /> );
 			showingStream = true;
 		}


### PR DESCRIPTION
This PR removes an unused prop from InfiniteList that was causing the following React warning:
<img width="1057" alt="screen shot 2016-08-17 at 4 24 58 pm" src="https://cloud.githubusercontent.com/assets/1270189/17757307/805062fe-649a-11e6-8a64-b3919a3d0e1b.png">

## Testing Instructions
1. Navigate to http://calypso.localhost:3000
2. The above error does not appear
3. Scroll down in the reader, Infinite List loads more posts
4. Keyboard shortcuts still work in the reader (j,k,enter)

cc @fraying @bluefuton @aduth 

Test live: https://calypso.live/?branch=fix/infinite-list-warning