### PR TITLE
Jetpack Connect: Use renderSiteEntry() for JPC installation step

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -312,27 +312,6 @@ const JetpackConnectMain = React.createClass( {
 		);
 	},
 
-	renderSiteEntryInstall() {
-		const status = this.getStatus();
-		return (
-			<MainWrapper>
-				{ this.renderLocaleSuggestions() }
-				<div className="jetpack-connect__site-url-entry-container">
-					<QuerySites/>
-					<ConnectHeader
-						showLogo={ false }
-						headerText={ this.getTexts().headerTitle }
-						subHeaderText={ this.getTexts().headerSubtitle }
-						step={ 1 }
-						steps={ 3 } />
-
-					{ this.renderSiteInput( status ) }
-					{ this.renderFooter() }
-				</div>
-			</MainWrapper>
-		);
-	},
-
 	renderInstallInstructions() {
 		return (
 			<MainWrapper isWide>
@@ -437,9 +416,6 @@ const JetpackConnectMain = React.createClass( {
 		}
 		if ( status === 'notActiveJetpack' && ! this.props.jetpackConnectSite.isDismissed ) {
 			return this.renderActivateInstructions();
-		}
-		if ( this.isInstall() ) {
-			return this.renderSiteEntryInstall();
 		}
 		return this.renderSiteEntry();
 	}


### PR DESCRIPTION
Currently, in Jetpack Connect we're using different render methods for the regular site entry step  and the install site entry step. However, they're exactly the same in terms of code. 

This PR gets rid of the code for the installation step, which results in using the regular site entry step render method for the installation screen, too. 

To test:

* Grab this branch
* Make sure there are no regressions in the regular site entry step: `/jetpack/connect`
* Make sure there are no regressions in the installation site entry step: `/jetpack/connect/install`

/cc @roccotripaldi @johnHackworth 

Test live: https://calypso.live/?branch=update/jetpack-connect-render-site-entry-cleanup