### PR TITLE
Jetpack Connect: Site URL - associate label with input

### DIFF
--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -85,13 +85,14 @@ export default React.createClass( {
 		const hasError = this.props.isError && ( 'notExists' !== this.props.isError );
 		return (
 			<div>
-				<FormLabel>{ this.translate( 'Site Address' ) }</FormLabel>
+				<FormLabel htmlFor="siteUrl">{ this.translate( 'Site Address' ) }</FormLabel>
 				<div className="site-address-container">
 					<Gridicon
 						size={ 24 }
 						icon="globe" />
 					<FormTextInput
 						ref="siteUrl"
+						id="siteUrl"
 						autoCapitalize="off"
 						autoFocus="autofocus"
 						onChange={ this.onChange }


### PR DESCRIPTION
Currently, the site URL input in JPC is not associated with its corresponding label. This PR handles this case, connecting the input with the site URL label.

To test:

* Checkout this branch
* Go to `/jetpack/connect`
* Click on the **"Site Address"** label and verify this action focused the site URL input.
* Verify that the `id` attribute of the input matches the `for` attribute of the label.

/cc @ryelle @oskosk 

Test live: https://calypso.live/?branch=update/jetpack-connect-site-input-label-for