### PR TITLE
Purchases: Make credit card page more flexible

### DIFF
--- a/client/me/purchases/components/credit-card-page/index.jsx
+++ b/client/me/purchases/components/credit-card-page/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import page from 'page';
 import React from 'react';
 
 /**
@@ -14,20 +13,15 @@ import CompactCard from 'components/card/compact';
 import { createPaygateToken } from 'lib/store-transactions';
 import CreditCardForm from 'components/upgrades/credit-card-form';
 import CountriesList from 'lib/countries-list';
-import CreditCardPageLoadingPlaceholder from './loading-placeholder';
 import FormButton from 'components/forms/form-button';
 import formState from 'lib/form-state';
 import forOwn from 'lodash/forOwn';
 import HeaderCake from 'components/header-cake' ;
-import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
+import { getPurchase } from 'me/purchases/utils';
 import kebabCase from 'lodash/kebabCase';
 import Main from 'components/main';
 import mapKeys from 'lodash/mapKeys';
 import notices from 'notices';
-import paths from 'me/purchases/paths';
-import QueryStoredCards from 'components/data/query-stored-cards';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import userFactory from 'lib/user';
 import { validateCardDetails } from 'lib/credit-card-details';
 import ValidationErrorList from 'notices/validation-error-list';
 import wpcomFactory from 'lib/wp';
@@ -35,21 +29,14 @@ import Gridicon from 'components/gridicon';
 import support from 'lib/url/support';
 
 const countriesList = CountriesList.forPayments();
-const user = userFactory();
 const wpcom = wpcomFactory.undocumented();
 
 const CreditCardPage = React.createClass( {
 	propTypes: {
-		card: React.PropTypes.object,
-		clearPurchases: React.PropTypes.func.isRequired,
-		hasLoadedSites: React.PropTypes.bool.isRequired,
-		hasLoadedStoredCardsFromServer: React.PropTypes.bool.isRequired,
-		hasLoadedUserPurchasesFromServer: React.PropTypes.bool.isRequired,
-		selectedPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
-		] ),
+		goBack: React.PropTypes.func.isRequired,
+		initialValues: React.PropTypes.object,
+		successCallback: React.PropTypes.func.isRequired,
+		selectedPurchase: React.PropTypes.object
 	},
 
 	getInitialState() {
@@ -73,14 +60,11 @@ const CreditCardPage = React.createClass( {
 
 	componentWillMount() {
 		this._mounted = true;
-		this.redirectIfDataIsInvalid();
-
-		recordPageView( 'edit_card_details', this.props );
 
 		const fields = formState.createNullFieldValues( this.fieldNames );
 
-		if ( this.props.card ) {
-			fields.name = this.props.card.name;
+		if ( this.props.initialValues ) {
+			fields.name = this.props.initialValues.name;
 		}
 
 		this.formStateController = formState.Controller( {
@@ -92,19 +76,6 @@ const CreditCardPage = React.createClass( {
 		this.setState( {
 			form: this.formStateController.getInitialState()
 		} );
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		this.redirectIfDataIsInvalid( nextProps );
-
-		recordPageView( 'edit_card_details', this.props, nextProps );
-
-		if ( ! this.props.hasLoadedStoredCardsFromServer && nextProps.hasLoadedStoredCardsFromServer && nextProps.card ) {
-			this.formStateController.handleFieldChange( {
-				name: 'name',
-				value: nextProps.card.name
-			} );
-		}
 	},
 
 	componentWillUnmount() {
@@ -205,11 +176,7 @@ const CreditCardPage = React.createClass( {
 					persistent: true
 				} );
 
-				const { id } = getPurchase( this.props );
-
-				this.props.clearPurchases();
-
-				page( paths.managePurchase( this.props.selectedSite.slug, id ) );
+				this.props.successCallback();
 			} );
 		} );
 	},
@@ -226,23 +193,6 @@ const CreditCardPage = React.createClass( {
 			paygateToken: token,
 			purchaseId: getPurchase( this.props ).id
 		};
-	},
-
-	redirectIfDataIsInvalid( props = this.props ) {
-		if ( ! this.isDataValid( props ) ) {
-			page( paths.list() );
-		}
-	},
-
-	isDataValid( props = this.props ) {
-		if ( isDataLoading( props ) ) {
-			return true;
-		}
-
-		const purchase = getPurchase( props ),
-			{ selectedSite } = props;
-
-		return purchase && selectedSite;
 	},
 
 	isFieldInvalid( name ) {
@@ -265,26 +215,10 @@ const CreditCardPage = React.createClass( {
 		} );
 	},
 
-	goToManagePurchase() {
-		goToManagePurchase( this.props );
-	},
-
 	render() {
-		if ( isDataLoading( this.props ) || ! this.props.hasLoadedStoredCardsFromServer ) {
-			return (
-				<Main className="credit-card-page">
-					<QueryStoredCards />
-
-					<QueryUserPurchases userId={ user.get().ID } />
-
-					<CreditCardPageLoadingPlaceholder title={ this.props.title } />
-				</Main>
-			);
-		}
-
 		return (
 			<Main className="credit-card-page">
-				<HeaderCake onClick={ this.goToManagePurchase }>{ this.props.title }</HeaderCake>
+				<HeaderCake onClick={ this.props.goBack }>{ this.props.title }</HeaderCake>
 
 				<form onSubmit={ this.onSubmit }>
 					<Card className="credit-card-page__content">

--- a/client/me/purchases/components/credit-card-page/index.jsx
+++ b/client/me/purchases/components/credit-card-page/index.jsx
@@ -150,6 +150,10 @@ const CreditCardPage = React.createClass( {
 		const cardDetails = this.getCardDetails();
 
 		createPaygateToken( 'card_update', cardDetails, ( paygateError, token ) => {
+			if ( ! this._mounted ) {
+				return;
+			}
+
 			if ( paygateError ) {
 				this.setState( { formSubmitting: false } );
 				notices.error( paygateError.message );
@@ -160,13 +164,17 @@ const CreditCardPage = React.createClass( {
 
 			wpcom.updateCreditCard( apiParams, ( apiError, response ) => {
 				if ( apiError ) {
-					this.setState( { formSubmitting: false } );
+					if ( this._mounted ) {
+						this.setState( { formSubmitting: false } );
+					}
 					notices.error( apiError.message );
 					return;
 				}
 
 				if ( response.error ) {
-					this.setState( { formSubmitting: false } );
+					if ( this._mounted ) {
+						this.setState( { formSubmitting: false } );
+					}
 					notices.error( response.error );
 					return;
 				}

--- a/client/me/purchases/components/purchase-card-details/index.jsx
+++ b/client/me/purchases/components/purchase-card-details/index.jsx
@@ -1,0 +1,65 @@
+/**
+ * External Dependencies
+ */
+import page from 'page';
+import { Component } from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import analytics from 'lib/analytics';
+import { getPurchase, goToManagePurchase, isDataLoading } from 'me/purchases/utils';
+import paths from 'me/purchases/paths';
+
+class PurchaseCardDetails extends Component {
+	constructor( props ) {
+		super( props );
+		this.goBack = this.goBack.bind( this );
+		this.recordFormSubmitEvent = this.recordFormSubmitEvent.bind( this );
+		this.successCallback = this.successCallback.bind( this );
+	}
+
+	redirectIfDataIsInvalid( props = this.props ) {
+		if ( isDataLoading( props ) ) {
+			return true;
+		}
+
+		if ( ! this.isDataValid( props ) ) {
+			page( paths.list() );
+		}
+	}
+
+	isDataValid( props = this.props ) {
+		const purchase = getPurchase( props ),
+			{ selectedSite } = props;
+
+		return purchase && selectedSite;
+	}
+
+	getApiParams() {
+		return {
+			purchaseId: getPurchase( this.props ).id
+		};
+	}
+
+	goBack() {
+		goToManagePurchase( this.props );
+	}
+
+	recordFormSubmitEvent() {
+		analytics.tracks.recordEvent(
+			'calypso_purchases_credit_card_form_submit',
+			{ product_slug: getPurchase( this.props ).productSlug }
+		);
+	}
+
+	successCallback() {
+		const { id } = getPurchase( this.props );
+
+		this.props.clearPurchases();
+
+		page( paths.managePurchase( this.props.selectedSite.slug, id ) );
+	}
+}
+
+export default PurchaseCardDetails;

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -8,6 +8,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import AddCardDetails from './payment/add-card-details';
 import analytics from 'lib/analytics';
 import CancelPrivateRegistration from './cancel-private-registration';
 import CancelPurchase from './cancel-purchase';
@@ -84,6 +85,25 @@ const setSelectedSite = ( siteSlug, dispatch ) => {
 };
 
 export default {
+	addCardDetails( context ) {
+		setTitle(
+			titles.addCardDetails
+		);
+
+		recordPageView(
+			paths.addCardDetails(),
+			'Add Card Details'
+		);
+
+		setSelectedSite( context.params.site, context.store.dispatch );
+
+		renderPage(
+			context,
+			<AddCardDetails
+				purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+		);
+	},
+
 	cancelPrivateRegistration( context ) {
 		setTitle(
 			titles.cancelPrivateRegistration

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -36,7 +36,7 @@ export default function() {
 		paths.addCardDetails(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		controller.editCardDetails
+		controller.addCardDetails
 	);
 
 	page(
@@ -64,4 +64,4 @@ export default function() {
 		controller.noSitesMessage,
 		controller.managePurchase
 	);
-};
+}

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -23,11 +23,11 @@ function cancelPrivateRegistration( siteName, purchaseId ) {
 }
 
 function addCardDetails( siteName, purchaseId ) {
-	return managePurchase( siteName, purchaseId ) + '/payment/edit';
+	return managePurchase( siteName, purchaseId ) + '/payment/add';
 }
 
 function editCardDetails( siteName, purchaseId, cardId = ':cardId' ) {
-	return addCardDetails( siteName, purchaseId ) + `/${ cardId }`;
+	return managePurchase( siteName, purchaseId ) + `/payment/edit/${ cardId }`;
 }
 
 export default {

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -2,28 +2,91 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import React from 'react';
+import page from 'page';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal Dependencies
  */
-import { addCardDetails } from 'me/purchases/titles';
 import { clearPurchases } from 'state/purchases/actions';
 import CreditCardPage from 'me/purchases/components/credit-card-page';
+import CreditCardPageLoadingPlaceholder from 'me/purchases/components/credit-card-page/loading-placeholder';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
+import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 import { isRequestingSites } from 'state/sites/selectors';
+import paths from 'me/purchases/paths';
+import QueryUserPurchases from 'components/data/query-user-purchases';
+import titles from 'me/purchases/titles';
+import userFactory from 'lib/user';
 
-const AddCardDetails = props => <CreditCardPage { ...props } />;
+const user = userFactory();
+
+class AddCardDetails extends Component {
+	static propTypes = {
+		hasLoadedSites: PropTypes.bool.isRequired,
+		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired
+	};
+
+	componentWillMount() {
+		this.redirectIfDataIsInvalid();
+
+		recordPageView( 'add_card_details', this.props );
+	}
+
+	redirectIfDataIsInvalid( props = this.props ) {
+		if ( isDataLoading( props ) ) {
+			return true;
+		}
+
+		if ( ! this.isDataValid( props ) ) {
+			page( paths.list() );
+		}
+	}
+
+	isDataValid( props = this.props ) {
+		const purchase = getPurchase( props ),
+			{ selectedSite } = props;
+
+		return purchase && selectedSite;
+	}
+
+	goBack( props ) {
+		goToManagePurchase( props );
+	}
+
+	successCallback( props ) {
+		const { id } = getPurchase( props );
+
+		props.clearPurchases();
+
+		page( paths.managePurchase( props.selectedSite.slug, id ) );
+	}
+
+	render() {
+		if ( isDataLoading( this.props ) ) {
+			return (
+				<div>
+					<QueryUserPurchases userId={ user.get().ID } />
+
+					<CreditCardPageLoadingPlaceholder title={ this.props.title } />
+				</div>
+			);
+		}
+
+		return <CreditCardPage { ...this.props }
+			goBack={ () => this.goBack( this.props ) }
+			successCallback={ () => this.successCallback( this.props ) } />;
+	}
+}
 
 const mapStateToProps = ( state, { purchaseId } ) => {
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedStoredCardsFromServer: true, // TODO: make sure flag is not needed here
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, purchaseId ),
 		selectedSite: getSelectedSiteSelector( state ),
-		title: addCardDetails
+		title: titles.addCardDetails
 	};
 };
 

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -7,25 +7,23 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
+import { addCardDetails } from 'me/purchases/titles';
 import { clearPurchases } from 'state/purchases/actions';
 import CreditCardPage from 'me/purchases/components/credit-card-page';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
-import { getStoredCardById, hasLoadedStoredCardsFromServer } from 'state/stored-cards/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
-import { editCardDetails } from 'me/purchases/titles';
 
-const EditCardDetails = props => <CreditCardPage { ...props } />;
+const AddCardDetails = props => <CreditCardPage { ...props } />;
 
-const mapStateToProps = ( state, { cardId, purchaseId } ) => {
+const mapStateToProps = ( state, { purchaseId } ) => {
 	return {
-		card: getStoredCardById( state, cardId ),
 		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedStoredCardsFromServer: hasLoadedStoredCardsFromServer( state ),
+		hasLoadedStoredCardsFromServer: true, // TODO: make sure flag is not needed here
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, purchaseId ),
 		selectedSite: getSelectedSiteSelector( state ),
-		title: editCardDetails
+		title: addCardDetails
 	};
 };
 
@@ -33,4 +31,4 @@ const mapDispatchToProps = {
 	clearPurchases
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( EditCardDetails );
+export default connect( mapStateToProps, mapDispatchToProps )( AddCardDetails );

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -2,20 +2,89 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import React from 'react';
+import page from 'page';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal Dependencies
  */
 import { clearPurchases } from 'state/purchases/actions';
 import CreditCardPage from 'me/purchases/components/credit-card-page';
+import CreditCardPageLoadingPlaceholder from 'me/purchases/components/credit-card-page/loading-placeholder';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { getStoredCardById, hasLoadedStoredCardsFromServer } from 'state/stored-cards/selectors';
+import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 import { isRequestingSites } from 'state/sites/selectors';
-import { editCardDetails } from 'me/purchases/titles';
+import paths from 'me/purchases/paths';
+import QueryStoredCards from 'components/data/query-stored-cards';
+import QueryUserPurchases from 'components/data/query-user-purchases';
+import titles from 'me/purchases/titles';
+import userFactory from 'lib/user';
 
-const EditCardDetails = props => <CreditCardPage { ...props } />;
+const user = userFactory();
+
+class EditCardDetails extends Component {
+	static propTypes = {
+		hasLoadedSites: PropTypes.bool.isRequired,
+		hasLoadedStoredCardsFromServer: PropTypes.bool.isRequired,
+		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired
+	};
+
+	componentWillMount() {
+		this.redirectIfDataIsInvalid();
+
+		recordPageView( 'edit_card_details', this.props );
+	}
+
+	redirectIfDataIsInvalid( props = this.props ) {
+		if ( isDataLoading( props ) ) {
+			return true;
+		}
+
+		if ( ! this.isDataValid( props ) ) {
+			page( paths.list() );
+		}
+	}
+
+	isDataValid( props = this.props ) {
+		const purchase = getPurchase( props ),
+			{ selectedSite } = props;
+
+		return purchase && selectedSite;
+	}
+
+	goBack( props ) {
+		goToManagePurchase( props );
+	}
+
+	successCallback( props ) {
+		const { id } = getPurchase( props );
+
+		props.clearPurchases();
+
+		page( paths.managePurchase( props.selectedSite.slug, id ) );
+	}
+
+	render() {
+		if ( isDataLoading( this.props ) || ! this.props.hasLoadedStoredCardsFromServer ) {
+			return (
+				<div>
+					<QueryStoredCards />
+
+					<QueryUserPurchases userId={ user.get().ID } />
+
+					<CreditCardPageLoadingPlaceholder title={ this.props.title } />
+				</div>
+			);
+		}
+
+		return <CreditCardPage { ...this.props }
+			goBack={ () => this.goBack( this.props ) }
+			initialValues={ this.props.card }
+			successCallback={ () => this.successCallback( this.props ) } />;
+	}
+}
 
 const mapStateToProps = ( state, { cardId, purchaseId } ) => {
 	return {
@@ -25,7 +94,7 @@ const mapStateToProps = ( state, { cardId, purchaseId } ) => {
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, purchaseId ),
 		selectedSite: getSelectedSiteSelector( state ),
-		title: editCardDetails
+		title: titles.editCardDetails
 	};
 };
 


### PR DESCRIPTION
This is a follow up for #7484.

In this PR I added another couple of refactorings:
* we have now 2 entry React components to distinguish Add Card Details (`<AddCardDetails />`) and Edit Card Details  (`<EditCardDetails />`) pages
* `<PurchaseCardDetails />` was extracted and contains shared logic for Card components that operates on purchases
* `.../payment/edit` url was updated to better reflect functionality of the page - `.../payment/add`

With that in place we should be ready to work on new flow for Connect for WooCommerce.

### Testing.
1. Go to Manage Purchases page (http://calypso.localhost:3000/purchases).
2. Select a purchase paid with credit card.
3. Click on Edit Payment Method link.
4. You should see loading placeholder when page is loading (you can refresh a page if you missed loading step).
5. When page is loaded you should see a form with a cardholder name provided.
6. Play with the form to make sure it works as before.
7. You can also try to click back button while validation is pending to make sure `isMounted` change is working properly. There should be no warnings on JS console complaining about incorrect`setState` usage.
8. Go back to Manage Purchases page.
9. Pick a purchase paid with credits.
10. Click on Add Payment Method link.
11. You should see loading placeholder when page is loading (you can refresh a page if you missed loading step).
12. When page is loaded you should see a form with no fields filled in.
13. Play with the form to make sure it works as before.

Test live: https://calypso.live/?branch=update/improve-credit-card-page