### PR TITLE
Payment Methods: Add placeholder for the new Add Credit Card page

### DIFF
--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -5,6 +5,30 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+
+export function concatTitle( ...parts ) {
+	return parts.join( ' › ' );
+}
+
+export function renderPage( context, component ) {
+	renderWithReduxStore(
+		component,
+		document.getElementById( 'primary' ),
+		context.store
+	);
+}
+
+export function recordPageView( path, ...title ) {
+	analytics.pageView.record(
+		path,
+		concatTitle( ...title )
+	);
+}
+
 export function renderWithReduxStore( reactElement, domContainer, reduxStore ) {
 	const domContainerNode = ( 'string' === typeof domContainer )
 			? document.getElementById( domContainer )

--- a/client/me/credit-cards/credit-cards.scss
+++ b/client/me/credit-cards/credit-cards.scss
@@ -3,7 +3,7 @@
 	text-align: center;
 }
 
-.credit-cards_single-card {
+.credit-cards__single-card {
 	border: 1px solid lighten( $gray, 30% );
 	border-top: none;
 

--- a/client/me/credit-cards/index.jsx
+++ b/client/me/credit-cards/index.jsx
@@ -1,22 +1,24 @@
 /**
  * External dependencies
  */
-var connect = require( 'react-redux' ).connect,
-	React = require( 'react' );
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-var CreditCardDelete = require( './credit-card-delete' ),
-	Card = require( 'components/card' ),
-	getStoredCards = require( 'state/stored-cards/selectors' ).getStoredCards,
-	hasLoadedStoredCardsFromServer = require( 'state/stored-cards/selectors' ).hasLoadedStoredCardsFromServer,
-	isFetchingStoredCards = require( 'state/stored-cards/selectors' ).isFetchingStoredCards,
-	QueryStoredCards = require( 'components/data/query-stored-cards' ),
-	SectionHeader = require( 'components/section-header' );
+import Card from 'components/card';
+import CreditCardDelete from './credit-card-delete';
+import {
+	getStoredCards,
+	hasLoadedStoredCardsFromServer,
+	isFetchingStoredCards
+} from 'state/stored-cards/selectors';
+import QueryStoredCards from 'components/data/query-stored-cards';
+import SectionHeader from 'components/section-header';
 
-var CreditCards = React.createClass( {
-	renderCards: function() {
+class CreditCards extends Component {
+	renderCards() {
 		if ( this.props.isFetching && ! this.props.hasLoadedFromServer ) {
 			return (
 				<div className="credit-cards__no-results">
@@ -35,31 +37,31 @@ var CreditCards = React.createClass( {
 
 		return this.props.cards.map( function( card ) {
 			return (
-				<div className="credit-cards_single-card" key={ card.stored_details_id }>
+				<div className="credit-cards__single-card" key={ card.stored_details_id }>
 					<CreditCardDelete card={ card } />
 				</div>
 			);
 		}, this );
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
-			<div>
+			<div className="credit-cards">
 				<QueryStoredCards />
 
 				<SectionHeader label={ this.translate( 'Manage Your Credit Cards' ) } />
 
 				<Card>
-					<div className="credit-cards">
+					<div>
 						{ this.renderCards() }
 					</div>
 				</Card>
 			</div>
 		);
 	}
-} );
+}
 
-module.exports = connect(
+export default connect(
 	state => ( {
 		cards: getStoredCards( state ),
 		hasLoadedFromServer: hasLoadedStoredCardsFromServer( state ),

--- a/client/me/credit-cards/index.jsx
+++ b/client/me/credit-cards/index.jsx
@@ -11,6 +11,7 @@ import React, { Component } from 'react';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import config from 'config';
 import CreditCardDelete from './credit-card-delete';
 import {
 	getStoredCards,
@@ -52,19 +53,29 @@ class CreditCards extends Component {
 		page( addCreditCard() );
 	}
 
+	renderAddCreditCardButton() {
+		if ( ! config.isEnabled( 'manage/payment-methods' ) ) {
+			return null;
+		}
+
+		return (
+			<Button
+				primary
+				compact
+				className="credit-cards__add"
+				onClick={ this.goToAddCreditCard }>
+				{ this.props.translate( 'Add Credit Card' ) }
+			</Button>
+		);
+	}
+
 	render() {
 		return (
 			<div className="credit-cards">
 				<QueryStoredCards />
 
 				<SectionHeader label={ this.props.translate( 'Manage Your Credit Cards' ) }>
-					<Button
-						primary
-						compact
-						className="credit-cards__add"
-						onClick={ this.goToAddCreditCard }>
-						{ this.props.translate( 'Add Credit Card' ) }
-					</Button>
+					{ this.renderAddCreditCardButton() }
 				</SectionHeader>
 
 				<Card>

--- a/client/me/credit-cards/index.jsx
+++ b/client/me/credit-cards/index.jsx
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Card from 'components/card';
 import CreditCardDelete from './credit-card-delete';
 import {
@@ -15,6 +18,7 @@ import {
 	isFetchingStoredCards
 } from 'state/stored-cards/selectors';
 import QueryStoredCards from 'components/data/query-stored-cards';
+import { addCreditCard } from 'me/payment-methods/paths';
 import SectionHeader from 'components/section-header';
 
 class CreditCards extends Component {
@@ -22,7 +26,7 @@ class CreditCards extends Component {
 		if ( this.props.isFetching && ! this.props.hasLoadedFromServer ) {
 			return (
 				<div className="credit-cards__no-results">
-					{ this.translate( 'Loading…' ) }
+					{ this.props.translate( 'Loading…' ) }
 				</div>
 			);
 		}
@@ -30,7 +34,7 @@ class CreditCards extends Component {
 		if ( ! this.props.cards.length ) {
 			return (
 				<div className="credit-cards__no-results">
-					{ this.translate( 'You have no saved cards.' ) }
+					{ this.props.translate( 'You have no saved cards.' ) }
 				</div>
 			);
 		}
@@ -44,12 +48,24 @@ class CreditCards extends Component {
 		}, this );
 	}
 
+	goToAddCreditCard() {
+		page( addCreditCard() );
+	}
+
 	render() {
 		return (
 			<div className="credit-cards">
 				<QueryStoredCards />
 
-				<SectionHeader label={ this.translate( 'Manage Your Credit Cards' ) } />
+				<SectionHeader label={ this.props.translate( 'Manage Your Credit Cards' ) }>
+					<Button
+						primary
+						compact
+						className="credit-cards__add"
+						onClick={ this.goToAddCreditCard }>
+						{ this.props.translate( 'Add Credit Card' ) }
+					</Button>
+				</SectionHeader>
 
 				<Card>
 					<div>
@@ -67,4 +83,4 @@ export default connect(
 		hasLoadedFromServer: hasLoadedStoredCardsFromServer( state ),
 		isFetching: isFetchingStoredCards( state )
 	} )
-)( CreditCards );
+)( localize( CreditCards ) );

--- a/client/me/payment-methods/add-credit-card/index.jsx
+++ b/client/me/payment-methods/add-credit-card/index.jsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { concatTitle } from 'lib/react-helpers';
+import DocumentHead from 'components/data/document-head';
+import * as titles from 'me/payment-methods/titles';
+
+const AddCreditCard = () => (
+	<div>
+		<DocumentHead title={ concatTitle( titles.paymentMethods, titles.addCreditCard, ) } />
+		<h1>Add Credit Card</h1>
+	</div>
+);
+
+export default AddCreditCard;

--- a/client/me/payment-methods/add-credit-card/index.jsx
+++ b/client/me/payment-methods/add-credit-card/index.jsx
@@ -1,20 +1,39 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { connect } from 'react-redux';
+import { noop } from 'lodash';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
 import { concatTitle } from 'lib/react-helpers';
+import CreditCardPage from 'me/purchases/components/credit-card-page';
 import DocumentHead from 'components/data/document-head';
 import * as titles from 'me/payment-methods/titles';
 
-const AddCreditCard = () => (
-	<div>
-		<DocumentHead title={ concatTitle( titles.paymentMethods, titles.addCreditCard, ) } />
-		<h1>Add Credit Card</h1>
-	</div>
-);
+class AddCreditCard extends Component {
+	static propTypes = {
+	};
+
+	render() {
+		return (
+			<div>
+				<DocumentHead title={ concatTitle( titles.paymentMethods, titles.addCreditCard ) } />
+				<CreditCardPage
+					goBack={ noop }
+					recordFormSubmitEvent={ noop }
+					successCallback={ noop }
+					title={ titles.addCreditCard } />
+			</div>
+		);
+	}
+}
+
+const mapDispatchToProps = {
+};
+
+export default connect( {}, mapDispatchToProps )( AddCreditCard );
 
 export default AddCreditCard;

--- a/client/me/payment-methods/controller.js
+++ b/client/me/payment-methods/controller.js
@@ -8,7 +8,7 @@ import React from 'react';
  */
 import AddCreditCard from 'me/payment-methods/add-credit-card';
 import * as paths from './paths';
-import { recordPageView, renderPage, setTitle } from 'lib/react-helpers';
+import { recordPageView, renderPage } from 'lib/react-helpers';
 
 export function addCreditCard( context ) {
 	recordPageView(

--- a/client/me/payment-methods/controller.js
+++ b/client/me/payment-methods/controller.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import AddCreditCard from 'me/payment-methods/add-credit-card';
+import * as paths from './paths';
+import { recordPageView, renderPage, setTitle } from 'lib/react-helpers';
+
+export function addCreditCard( context ) {
+	recordPageView(
+		paths.addCreditCard(),
+		'Payment Methods',
+		'Add Credit Card'
+	);
+
+	renderPage(
+		context,
+		<AddCreditCard />
+	);
+}

--- a/client/me/payment-methods/index.js
+++ b/client/me/payment-methods/index.js
@@ -1,0 +1,19 @@
+/**
+ * External Dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ */
+import * as controller from './controller';
+import * as paths from './paths';
+import { sidebar } from 'me/controller';
+
+export default function() {
+	page(
+		paths.addCreditCard(),
+		sidebar,
+		controller.addCreditCard
+	);
+}

--- a/client/me/payment-methods/paths.js
+++ b/client/me/payment-methods/paths.js
@@ -1,4 +1,4 @@
 export function addCreditCard() {
-	return '/payments/add-credit-card';
+	return '/payment-methods/add-credit-card';
 }
 

--- a/client/me/payment-methods/paths.js
+++ b/client/me/payment-methods/paths.js
@@ -1,0 +1,4 @@
+export function addCreditCard() {
+	return '/payments/add-credit-card';
+}
+

--- a/client/me/payment-methods/titles.js
+++ b/client/me/payment-methods/titles.js
@@ -1,0 +1,7 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+export const addCreditCard = translate( 'Add Credit Card' );
+export const paymentMethods = translate( 'Payment Methods' );

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { partial } from 'lodash';
 import page from 'page';
 import React from 'react';
 import i18n from 'i18n-calypso';
@@ -9,7 +10,6 @@ import i18n from 'i18n-calypso';
  * Internal Dependencies
  */
 import AddCardDetails from './payment/add-card-details';
-import analytics from 'lib/analytics';
 import CancelPrivateRegistration from './cancel-private-registration';
 import CancelPurchase from './cancel-purchase';
 import ConfirmCancelDomain from './confirm-cancel-domain';
@@ -22,7 +22,7 @@ import paths from './paths';
 import PurchasesHeader from './list/header';
 import PurchasesList from './list';
 import { receiveSite } from 'state/sites/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
+import { concatTitle, recordPageView, renderPage } from 'lib/react-helpers';
 import { setAllSitesSelected, setSelectedSiteId } from 'state/ui/actions';
 import sitesFactory from 'lib/sites-list';
 import supportPaths from 'lib/url/support';
@@ -30,27 +30,9 @@ import { setDocumentHeadTitle } from 'state/document-head/actions';
 import titles from './titles';
 import userFactory from 'lib/user';
 
+const recordPurchasesPageView = partial( recordPageView, partial.placeholder, 'Purchases' );
 const sites = sitesFactory();
 const user = userFactory();
-
-function concatTitle( ...parts ) {
-	return parts.join( ' › ' );
-}
-
-function recordPageView( path, ...title ) {
-	analytics.pageView.record(
-		path,
-		concatTitle( 'Purchases', ...title )
-	);
-}
-
-function renderPage( context, component ) {
-	renderWithReduxStore(
-		component,
-		document.getElementById( 'primary' ),
-		context.store
-	);
-}
 
 // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 function setTitle( context, ...title ) {
@@ -92,7 +74,7 @@ export default {
 			titles.addCardDetails
 		);
 
-		recordPageView(
+		recordPurchasesPageView(
 			paths.addCardDetails(),
 			'Add Card Details'
 		);
@@ -112,7 +94,7 @@ export default {
 			titles.cancelPrivateRegistration
 		);
 
-		recordPageView(
+		recordPurchasesPageView(
 			paths.cancelPrivateRegistration(),
 			'Cancel Private Registration'
 		);
@@ -133,7 +115,7 @@ export default {
 			titles.cancelPurchase
 		);
 
-		recordPageView(
+		recordPurchasesPageView(
 			paths.cancelPurchase(),
 			'Cancel Purchase'
 		);
@@ -154,7 +136,7 @@ export default {
 			titles.confirmCancelDomain
 		);
 
-		recordPageView(
+		recordPurchasesPageView(
 			paths.confirmCancelDomain(),
 			'Confirm Cancel Domain'
 		);
@@ -175,7 +157,7 @@ export default {
 			titles.editCardDetails
 		);
 
-		recordPageView(
+		recordPurchasesPageView(
 			paths.editCardDetails(),
 			'Edit Card Details'
 		);
@@ -193,7 +175,7 @@ export default {
 	list( context ) {
 		setTitle( context );
 
-		recordPageView(
+		recordPurchasesPageView(
 			paths.list()
 		);
 
@@ -237,7 +219,7 @@ export default {
 			titles.managePurchase
 		);
 
-		analytics.pageView.record(
+		recordPurchasesPageView(
 			paths.managePurchase(),
 			'Manage Purchase'
 		);
@@ -260,7 +242,7 @@ export default {
 
 		setTitle( context );
 
-		recordPageView(
+		recordPurchasesPageView(
 			context.path,
 			'No Sites'
 		);

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -206,6 +206,16 @@ if ( config.isEnabled( 'manage/drafts' ) ) {
 	} );
 }
 
+if ( config.isEnabled( 'manage/payment-methods' ) ) {
+	sections.push( {
+		name: 'payment-methods',
+		paths: [ '/payment-methods/add-credit-card' ],
+		module: 'me/payment-methods',
+		group: 'me',
+		secondary: true
+	} );
+}
+
 if ( config.isEnabled( 'reader' ) ) {
 	const readerGroup = config.isEnabled( 'reader/refresh-2016-07' ) ? 'reader-refresh' : 'reader';
 	// this MUST be the first section for /read paths so subsequent sections under /read can override settings

--- a/config/development.json
+++ b/config/development.json
@@ -66,6 +66,7 @@
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
+		"manage/payment-methods": false,
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,

--- a/config/development.json
+++ b/config/development.json
@@ -66,7 +66,7 @@
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
-		"manage/payment-methods": false,
+		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,


### PR DESCRIPTION
It's a first part of the Add Credit Card page implementation for Connect for WooCommerce (see #6971 for more details).

This PR adds button and new page placehdoler. It is going to be possible to add new credit card even when users don't have any site or purchase on their account.

### Testing
1. Set `manage/payment-methods` flag to true to enable new button and page placeholder.
2. Execute `make run`.
3. Open http://calypso.localhost:3000/me/billing.
4. You should see Billing History. There should be a list of credit cards on the bottom of the page. There should be now a new button:
![screen shot 2016-08-19 at 09 13 02](https://cloud.githubusercontent.com/assets/699132/17802379/4ba06ab6-65f0-11e6-80ee-1c95ea1a9f4e.png)
5. Click on the button to load Add Credit Card page placeholder (you can also use direct url calypso.localhost:3000/payment-methods/add-credit-card).
6. When page is loading you can see tracking logs on the JS console:
![screen shot 2016-08-19 at 09 09 44](https://cloud.githubusercontent.com/assets/699132/17802391/5832c896-65f0-11e6-8796-d5246f3cd9f6.png)
7. Page title is already set to the proper value.
![screen shot 2016-08-19 at 09 10 40](https://cloud.githubusercontent.com/assets/699132/17802383/506bd076-65f0-11e6-9d14-82bc5c1f65ee.png)
8. This is how page content looks like:
![screen shot 2016-08-22 at 14 12 00](https://cloud.githubusercontent.com/assets/699132/17854422/d8d12e1e-6872-11e6-8ac4-3e0dc5e18f30.png)

### Todo (Another PR)
1. Back button is not implemented.
2. We use wrong REST API call to add credit card - needs to be fixed.
3. When form submit button is clicked we don't send track event.
4. We also miss success callback handling.

Test live: https://calypso.live/?branch=add/credit-card-without-purchase