### PR TITLE
Clean up Gravatar component and add to devdocs

### DIFF
--- a/client/components/gravatar/README.md
+++ b/client/components/gravatar/README.md
@@ -6,9 +6,9 @@ This component is used to display the [Gravatar](https://gravatar.com/) for a us
 #### How to use:
 
 ```js
-var Gravatar = require( 'components/gravatar' );
+import Gravatar from 'components/gravatar';
 
-render: function() {
+render() {
     return (
         <Gravatar user={ post.author } />
     );

--- a/client/components/gravatar/docs/example.jsx
+++ b/client/components/gravatar/docs/example.jsx
@@ -2,29 +2,32 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Gravatar from 'components/gravatar';
+import { getCurrentUser } from 'state/current-user/selectors';
 
-export default React.createClass( {
+const GravatarExample = React.createClass( {
 
 	displayName: 'Gravatar',
 
 	render() {
-		const user = {
-			avatar_URL: 'https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=identicon',
-			display_name: 'Bob The Tester'
-		};
-
 		return (
 			<div className="design-assets__group">
 				<h2>
 					<a href="/devdocs/components/gravatar">Gravatar</a>
 				</h2>
-				<Gravatar user={ user } size={ 96 } />
+				<Gravatar user={ this.props.currentUser } size={ 96 } />
 			</div>
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	return {
+		currentUser: getCurrentUser( state )
+	};
+} )( GravatarExample );

--- a/client/components/gravatar/docs/example.jsx
+++ b/client/components/gravatar/docs/example.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gravatar from 'components/gravatar';
+
+export default React.createClass( {
+
+	displayName: 'Gravatar',
+
+	render() {
+		const user = {
+			avatar_URL: 'https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=identicon',
+			display_name: 'Bob The Tester'
+		};
+
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/components/gravatar">Gravatar</a>
+				</h2>
+				<Gravatar user={ user } size={ 96 } />
+			</div>
+		);
+	}
+} );

--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	url = require( 'url' ),
-	qs = require( 'querystring' );
+import React from 'react';
+import url from 'url';
+import qs from 'querystring';
 
 /**
  * Internal dependencies
  */
-var safeImageURL = require( 'lib/safe-image-url' );
+import safeImageURL from 'lib/safe-image-url';
 
 module.exports = React.createClass( {
 	displayName: 'Gravatar',
@@ -19,7 +19,7 @@ module.exports = React.createClass( {
 		imgSize: React.PropTypes.number
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		// The REST-API returns s=96 by default, so that is most likely to be cached
 		return {
 			imgSize: 96,
@@ -27,18 +27,17 @@ module.exports = React.createClass( {
 		};
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			failedToLoad: false
-		}
+		};
 	},
 
-	_getResizedImageURL: function( imageURL ) {
-		var parsedURL, query;
-
+	getResizedImageURL( imageURL ) {
 		imageURL = imageURL || 'https://www.gravatar.com/avatar/0';
-		parsedURL = url.parse( imageURL );
-		query = qs.parse( parsedURL.query );
+		const parsedURL = url.parse( imageURL );
+		const query = qs.parse( parsedURL.query );
+
 		if ( /^([-a-zA-Z0-9_]+\.)*(gravatar.com)$/.test( parsedURL.hostname ) ) {
 			query.s = this.props.imgSize;
 			query.d = 'mm';
@@ -46,15 +45,16 @@ module.exports = React.createClass( {
 			// assume photon
 			query.resize = this.props.imgSize + ',' + this.props.imgSize;
 		}
+
 		parsedURL.search = qs.stringify( query );
 		return url.format( parsedURL );
 	},
 
-	onError: function() {
+	onError() {
 		this.setState( { failedToLoad: true } );
 	},
 
-	render: function() {
+	render() {
 		const size = this.props.size;
 
 		if ( ! this.props.user ) {
@@ -64,11 +64,10 @@ module.exports = React.createClass( {
 		}
 
 		const alt = this.props.alt || this.props.user.display_name;
-		const avatarURL = this._getResizedImageURL( safeImageURL( this.props.user.avatar_URL ) );
+		const avatarURL = this.getResizedImageURL( safeImageURL( this.props.user.avatar_URL ) );
 
 		return (
 			<img alt={ alt } className="gravatar" src={ avatarURL } width={ size } height={ size } onError={ this.onError } />
 		);
 	}
-
 } );

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -16,6 +16,7 @@ import SearchCard from 'components/search-card';
 import SearchDemo from 'components/search/docs/example';
 import Notices from 'components/notice/docs/example';
 import GlobalNotices from 'components/global-notices/docs/example';
+import Gravatar from 'components/gravatar/docs/example';
 import Buttons from 'components/button/docs/example';
 import ButtonGroups from 'components/button-group/docs/example';
 import Gridicons from 'components/gridicon/docs/example';
@@ -120,6 +121,7 @@ let DesignAssets = React.createClass( {
 					<FormFields searchKeywords="input textbox textarea radio"/>
 					<Gauge />
 					<GlobalNotices />
+					<Gravatar />
 					<Gridicons />
 					<Headers />
 					<InfoPopover />


### PR DESCRIPTION
This PR ES6-ifies the `Gravatar` component and adds an example to Devdocs:

http://calypso.localhost:3000/devdocs/design

<img width="233" alt="screen shot 2016-08-18 at 20 58 17" src="https://cloud.githubusercontent.com/assets/17325/17786750/886577bc-6586-11e6-82f7-c26185637c62.png">


Test live: https://calypso.live/?branch=update/gravatar-cleanup