### PR TITLE
plan-features: change the InfoPopover implementation

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -71,7 +71,7 @@ class Popover extends Component {
 			show: props.isVisible,
 			left: -99999,
 			top: -99999,
-			positionClass: `is-${ this.getPositionClass( props.position ) }`
+			positionClass: this.getPositionClass( props.position )
 		};
 	}
 

--- a/client/components/popover/util.js
+++ b/client/components/popover/util.js
@@ -127,9 +127,27 @@ function choosePrimary( prefered, room ) {
 
 function chooseSecondary( primary, prefered, el, target, w, h ) {
 	// top, top left, top right in order of preference
+	const isVertical = primary === 'top' || primary === 'bottom';
+
 	const order = prefered
-		? [ primary + ' ' + prefered, primary, primary + ' ' + opposite[ prefered ] ]
-		: [ primary, primary + ' ' + adjacent[ primary ], primary + ' ' + opposite[ adjacent[ primary ] ] ];
+		? [
+			isVertical
+				? `${ primary } ${ prefered }`
+				: `${ prefered } ${ primary }`,
+			primary,
+			isVertical
+				? `${ primary } ${ opposite[ prefered ] }`
+				: `${ opposite[ prefered ] } ${ primary }`
+		]
+		: [
+			primary,
+			isVertical
+				? `${ primary } ${ adjacent[ primary ] }`
+				: `${ adjacent[ primary ] } ${ primary }`,
+			isVertical
+				? `${ primary } ${ opposite[ adjacent[ primary ] ] }`
+				: `${ opposite[ adjacent[ primary ] ] } ${ primary }`
+		];
 
 	let bestPos;
 	let best = 0;
@@ -145,6 +163,7 @@ function chooseSecondary( primary, prefered, el, target, w, h ) {
 				? offBottom - viewport.top
 				: viewport.bottom - off.top, h
 		);
+
 		const xVisible = Math.min(
 			off.left < viewport.left
 				? offRight - viewport.left

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -2,38 +2,45 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
-import InfoPopover from 'components/info-popover';
 
-export default function PlanFeaturesItem( { description, children, className } ) {
-	const renderTipinfo = () => {
-		if ( ! description ) {
-			return null;
-		}
-
-		return (
-			<div className="plan-features__item-tip-info">
-				<InfoPopover
-					position="right"
-				>
-					{ description }
-				</InfoPopover>
-			</div>
-		);
+export default function PlanFeaturesItem( {
+	children,
+	description,
+	onMouseEnter,
+	onMouseLeave,
+	onTouchStart,
+} ) {
+	const handleOnTouchStart = ( event ) => {
+		onTouchStart( event.currentTarget, description );
 	};
 
-	const classes = classNames( 'plan-features__item', className );
+	const handleOnMouseEvent = ( event ) => {
+		onMouseEnter( event.currentTarget, description );
+	};
+
+	const handleOnMouseLeave = ( event ) => {
+		onMouseLeave( event.currentTarget, description );
+	};
 
 	return (
-		<div className={ classes }>
-			<Gridicon className="plan-features__item-checkmark" size={ 18 } icon="checkmark" />
+		<div className="plan-features__item">
+			<Gridicon
+				className="plan-features__item-checkmark"
+				size={ 18 } icon="checkmark" />
 			{ children }
-			{ renderTipinfo() }
+			<span
+				onMouseEnter={ handleOnMouseEvent }
+				onMouseLeave={ handleOnMouseLeave }
+				onTouchStart={ handleOnTouchStart }
+				className="plan-features__item-tip-info"
+			>
+				<Gridicon icon="info-outline" size={ 18 } />
+			</span>
 		</div>
 	);
 }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -411,10 +411,17 @@ $plan-features-sidebar-width: 272px;
 	height: 18px;
 	margin-top: -9px;
 	color: lighten( $gray, 20% );
+	cursor: pointer;
 
-	.info-popover {
-		display: block;
-		height: 19px;
+	&:hover,
+	&:focus {
+		color: $gray-dark;
+	}
+}
+
+.popover__plan-features {
+	.popover__inner {
+		width: 200px;
 	}
 }
 


### PR DESCRIPTION
Before these changes we were creating one InfoPopover for each target element. Now we are creating only one Popover for the all targets elements.

Also fixes the bug when the popover was opened close to the right border of the viewport (#7518)


### Testing

Test the plans page opening/closing the Popovers for each features paying attention to these steps (copied from reported bug #7518):

1. Starting at URL: https://wordpress.com/plans
2. Select a site
3. Shrink the browser viewport enough that there's not much blank space around main content
4. Click an info button under the Business
5. Click the info button again to dismiss the tip
6. Click the info button once more

cc @aduth @artpi @lamosty 

Test live: https://calypso.live/?branch=fix/plan-features-info-popover