### PR TITLE
Me: Open username profile link in new window

### DIFF
--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -43,7 +43,7 @@ module.exports = React.createClass( {
 				<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
 
 				<div className="profile-gravatar__user-secondary-info">
-					<a href={ profileURL }>@{ this.props.user.username }</a>
+					<a href={ profileURL } target="_blank">@{ this.props.user.username }</a>
 				</div>
 			</div>
 		);


### PR DESCRIPTION
In `/me`, all links that lead to Gravatar open in a new window, with one exception: the username link below the profile picture. This PR addresses this, so this link will open in a new window as well.

To test:

* Checkout this branch
* Go to `http://calypso.localhost:3000/me`
* Verify the `@YOURUSERNAME` link below your profile picture and name opens in a new window.

/cc @oskosk

Test live: https://calypso.live/?branch=update/profile-username-link-new-window