### PR TITLE
Domains: Cleanup in DomainWarnings' whitelist

### DIFF
--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -48,11 +48,11 @@ export default React.createClass( {
 				'expiredDomains',
 				'expiringDomains',
 				'unverifiedDomains',
-				'pendingGappsToAcceptanceDomains',
+				'pendingGappsTosAcceptanceDomains',
 				'wrongNSMappedDomains',
 				'newDomains'
 			]
-		}
+		};
 	},
 
 	renewLink( count ) {

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -102,8 +102,7 @@ const RegisteredDomain = React.createClass( {
 				'expiringDomains',
 				'newDomainsWithPrimary',
 				'newDomains',
-				'pendingGappsTosAcceptanceDomains',
-				'wrongNSMappedDomains'
+				'pendingGappsTosAcceptanceDomains'
 			] }/>;
 	},
 


### PR DESCRIPTION
As pointed out by @aidvu, the `wrongNSMappedDomains` rule doesn't make sense for registered domains, so I'm removing it from that list (introduced in https://github.com/Automattic/wp-calypso/pull/3329)
Fixing typo in pending Gapps TOS acceptance rule (also introduced in https://github.com/Automattic/wp-calypso/pull/3329).

cc @aidvu 

Test live: https://calypso.live/?branch=fix/domain-warnings-whitelist