### PR TITLE
JS Errors: Open on stage and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -16,7 +16,7 @@
 		"accept-invite": true,
 		"ad-tracking": false,
 		"brazil-survey-invitation": false,
-		"catch-js-errors": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,7 +16,7 @@
 		"accept-invite": true,
 		"ad-tracking": false,
 		"brazil-survey-invitation": false,
-		"catch-js-errors": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,


### PR DESCRIPTION
We enabled JS-Errors endpoint again.
We want to enable it on horizon & stage. Its working on wpcom all this time.

We want to run it for a while on these 3 envs.
if it will behave, we'll enable it on prod.

Test live: https://calypso.live/?branch=update/js-errors-small-open