### PR TITLE
Chart: fix ESLint warnings

### DIFF
--- a/client/components/chart/bar-container.jsx
+++ b/client/components/chart/bar-container.jsx
@@ -8,7 +8,9 @@ import React from 'react';
  */
 import Bar from './bar';
 import XAxis from './x-axis';
-const user = require( 'lib/user' )();
+import userModule from 'lib/user';
+
+const user = userModule();
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartBarContainer',

--- a/client/components/chart/bar-container.jsx
+++ b/client/components/chart/bar-container.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var Bar = require( './bar' ),
-	XAxis = require( './x-axis' ),
-	user = require( 'lib/user' )();
+import Bar from './bar';
+import XAxis from './x-axis';
+const user = require( 'lib/user' )();
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartBarContainer',
@@ -22,17 +22,15 @@ module.exports = React.createClass( {
 	},
 
 	buildBars: function( max ) {
-		var bars,
-			numberBars = this.props.data.length,
-			tooltipPosition = user.isRTL() ? 'bottom left' : 'bottom right',
+		const numberBars = this.props.data.length,
 			width = this.props.chartWidth,
 			barWidth = ( width / numberBars );
+		let tooltipPosition = user.isRTL() ? 'bottom left' : 'bottom right';
 
-		bars = this.props.data.map( function ( item, index ) {
-			var barOffset = barWidth * ( index + 1 );
+		const bars = this.props.data.map( function( item, index ) {
+			const barOffset = barWidth * ( index + 1 );
 
-			if ( ( ( barOffset + 230 ) > width ) &&
-					( ( ( barOffset + barWidth ) - 230 ) > 0 ) ) {
+			if ( ( ( barOffset + 230 ) > width ) && ( ( ( barOffset + barWidth ) - 230 ) > 0 ) ) {
 				tooltipPosition = user.isRTL() ? 'bottom right' : 'bottom left';
 			}
 

--- a/client/components/chart/bar-container.jsx
+++ b/client/components/chart/bar-container.jsx
@@ -10,6 +10,9 @@ import Bar from './bar';
 import XAxis from './x-axis';
 import userModule from 'lib/user';
 
+/**
+ * Module variables
+ */
 const user = userModule();
 
 module.exports = React.createClass( {

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -3,13 +3,15 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-const debug = require( 'debug' )( 'calypso:module-chart:bar' );
+import debugModule from 'debug';
+
+const debug = debugModule( 'calypso:module-chart:bar' );
 
 /**
  * Internal dependencies
  */
 import Tooltip from 'components/tooltip';
-import Gridicon from 'components/Gridicon';
+import Gridicon from 'components/gridicon';
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartBar',

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	debug = require( 'debug' )( 'calypso:module-chart:bar' );
+import React from 'react';
+import classNames from 'classnames';
+const debug = require( 'debug' )( 'calypso:module-chart:bar' );
 
 /**
  * Internal dependencies
  */
-var	Tooltip = require( 'components/tooltip' ),
-	Gridicon = require( 'components/gridicon' );
+import Tooltip from 'components/tooltip';
+import Gridicon from 'components/Gridicon';
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartBar',
@@ -29,23 +29,23 @@ module.exports = React.createClass( {
 	},
 
 	buildSections: function() {
-		var value = this.props.data.value,
+		const value = this.props.data.value,
 			max = this.props.max,
 			percentage = max ? Math.ceil( ( value / max ) * 10000 ) / 100 : 0,
 			remain = 100 - percentage,
 			remainFloor = Math.max( 1, Math.floor( remain ) ),
 			sections = [],
-			remainStyle,
-			valueStyle,
 			nestedValue = this.props.data.nestedValue,
-			nestedBar,
-			nestedPercentage,
-			nestedStyle,
 			spacerClassOptions = {
 				'chart__bar-section': true,
 				'is-spacer': true,
 				'is-ghost': ( 100 === remain ) && ! this.props.active
 			};
+		let remainStyle,
+			valueStyle,
+			nestedBar,
+			nestedPercentage,
+			nestedStyle;
 
 		remainStyle = {
 			height: remainFloor + '%'
@@ -72,14 +72,13 @@ module.exports = React.createClass( {
 		return sections;
 	},
 
-	clickHandler: function(){
+	clickHandler: function() {
 		if ( 'function' === typeof( this.props.clickHandler ) ) {
 			this.props.clickHandler( this.props.data );
 		}
 	},
 
-
-	mouseEnter: function(){
+	mouseEnter: function() {
 		this.setState( { showPopover: true } );
 	},
 
@@ -99,8 +98,8 @@ module.exports = React.createClass( {
 		const { tooltipData } = this.props.data;
 
 		const listItemElements = tooltipData.map( function( options, i ) {
-			var wrapperClasses = [ 'module-content-list-item' ],
-				gridiconSpan;
+			const wrapperClasses = [ 'module-content-list-item' ];
+			let	gridiconSpan;
 
 			if ( options.icon ) {
 				gridiconSpan = ( <Gridicon icon={ options.icon } size={ 18 } /> );
@@ -110,9 +109,9 @@ module.exports = React.createClass( {
 
 			return (
 				<li key={ i } className={ wrapperClasses.join( ' ' ) } >
-					<span className='wrapper'>
-						<span className='value'>{ options.value }</span>
-						<span className='label'>{ gridiconSpan }{ options.label }</span>
+					<span className="chart__tooltip-wrapper wrapper">
+						<span className="chart__tooltip-value value">{ options.value }</span>
+						<span className="chart__tooltip-label label">{ gridiconSpan }{ options.label }</span>
 					</span>
 				</li>
 			);
@@ -137,13 +136,11 @@ module.exports = React.createClass( {
 	render: function() {
 		debug( 'Rendering bar', this.state );
 
-		var barStyle,
-			barClass,
-			count = this.props.count || 1;
+		const barClass = { chart__bar: true };
+		const count = this.props.count || 1;
+		let barStyle;
 
-		barClass = { chart__bar: true };
-
-		if ( this.props.className ){
+		if ( this.props.className ) {
 			barClass[ this.props.className ] = true;
 		}
 

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -5,13 +5,16 @@ import React from 'react';
 import classNames from 'classnames';
 import debugModule from 'debug';
 
-const debug = debugModule( 'calypso:module-chart:bar' );
-
 /**
  * Internal dependencies
  */
 import Tooltip from 'components/tooltip';
 import Gridicon from 'components/gridicon';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:module-chart:bar' );
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartBar',

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -23,6 +23,10 @@ module.exports = React.createClass( {
 		count: React.PropTypes.number
 	},
 
+	getDefaultProps: () => ( {
+		max: Infinity,
+	} ),
+
 	getInitialState: function() {
 		return { showPopover: false };
 	},
@@ -31,7 +35,7 @@ module.exports = React.createClass( {
 		const { active, data, max } = this.props;
 		const { nestedValue, value } = data;
 
-		const percentage = max ? Math.ceil( ( value / max ) * 10000 ) / 100 : 0,
+		const percentage = Math.ceil( ( value / max ) * 10000 ) / 100,
 			remain = 100 - percentage,
 			remainFloor = Math.max( 1, Math.floor( remain ) ),
 			sections = [],

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -3,18 +3,12 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
 import Tooltip from 'components/tooltip';
 import Gridicon from 'components/gridicon';
-
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:module-chart:bar' );
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartBar',
@@ -135,8 +129,6 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		debug( 'Rendering bar', this.state );
-
 		const barClass = { chart__bar: true };
 		const count = this.props.count || 1;
 		const barStyle = {

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -129,15 +129,11 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		const barClass = { chart__bar: true };
+		const barClass = classNames( 'chart__bar', this.props.className );
 		const count = this.props.count || 1;
 		const barStyle = {
 			width: ( ( 1 / count ) * 100 ) + '%'
 		};
-
-		if ( this.props.className ) {
-			barClass[ this.props.className ] = true;
-		}
 
 		return (
 			<div onClick={ this.clickHandler }

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -34,33 +34,29 @@ module.exports = React.createClass( {
 	},
 
 	buildSections: function() {
-		const value = this.props.data.value,
-			max = this.props.max,
-			percentage = max ? Math.ceil( ( value / max ) * 10000 ) / 100 : 0,
+		const { active, data, max } = this.props;
+		const { nestedValue, value } = data;
+
+		const percentage = max ? Math.ceil( ( value / max ) * 10000 ) / 100 : 0,
 			remain = 100 - percentage,
 			remainFloor = Math.max( 1, Math.floor( remain ) ),
 			sections = [],
-			nestedValue = this.props.data.nestedValue,
 			spacerClassOptions = {
 				'chart__bar-section': true,
 				'is-spacer': true,
-				'is-ghost': ( 100 === remain ) && ! this.props.active
+				'is-ghost': ( 100 === remain ) && ! active
+			},
+			remainStyle = {
+				height: remainFloor + '%'
+			},
+			valueStyle = {
+				top: remainFloor + '%'
 			};
-		let remainStyle,
-			valueStyle,
-			nestedBar,
+		let nestedBar,
 			nestedPercentage,
 			nestedStyle;
 
-		remainStyle = {
-			height: remainFloor + '%'
-		};
-
 		sections.push( <div key="spacer" className={ classNames( spacerClassOptions ) } style={ remainStyle } /> );
-
-		valueStyle = {
-			top: remainFloor + '%'
-		};
 
 		if ( nestedValue ) {
 			nestedPercentage = value ? Math.ceil( ( nestedValue / value ) * 10000 ) / 100 : 0;
@@ -143,15 +139,13 @@ module.exports = React.createClass( {
 
 		const barClass = { chart__bar: true };
 		const count = this.props.count || 1;
-		let barStyle;
+		const barStyle = {
+			width: ( ( 1 / count ) * 100 ) + '%'
+		};
 
 		if ( this.props.className ) {
 			barClass[ this.props.className ] = true;
 		}
-
-		barStyle = {
-			width: ( ( 1 / count ) * 100 ) + '%'
-		};
 
 		return (
 			<div onClick={ this.clickHandler }

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -59,23 +59,21 @@ module.exports = React.createClass( {
 	},
 
 	resize: function() {
-		if ( this.isMounted() ) {
-			const node = this.refs.chart;
-			let	width = node.clientWidth - 82,
-				maxBars;
+		const node = this.refs.chart;
+		let	width = node.clientWidth - 82,
+			maxBars;
 
-			if ( touchDetect.hasTouch() ) {
-				width = ( width <= 0 ) ? 350 : width; // mobile safari bug with zero width
-				maxBars = Math.floor( width / this.props.minTouchBarWidth );
-			} else {
-				maxBars = Math.floor( width / this.props.minBarWidth );
-			}
-
-			this.setState( {
-				maxBars: maxBars,
-				width: width
-			} );
+		if ( touchDetect.hasTouch() ) {
+			width = ( width <= 0 ) ? 350 : width; // mobile safari bug with zero width
+			maxBars = Math.floor( width / this.props.minTouchBarWidth );
+		} else {
+			maxBars = Math.floor( width / this.props.minBarWidth );
 		}
+
+		this.setState( {
+			maxBars: maxBars,
+			width: width
+		} );
 	},
 
 	getYAxisMax: function( values ) {

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { some, noop, throttle } from 'lodash';
-import debugModule from 'debug';
 
 /**
  * Internal dependencies
@@ -11,11 +10,6 @@ import debugModule from 'debug';
 import BarContainer from './bar-container';
 import observe from 'lib/mixins/data-observe';
 import touchDetect from 'lib/touch-detect';
-
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:chart' );
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChart',
@@ -116,8 +110,6 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		debug( 'Rendering chart with props: ', this.props );
-
 		const values = this.getValues(),
 			yAxisMax = this.getYAxisMax( values ),
 			data = this.getData();

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -5,14 +5,17 @@ import React from 'react';
 import { some, noop, throttle } from 'lodash';
 import debugModule from 'debug';
 
-const debug = debugModule( 'calypso:chart' );
-
 /**
  * Internal dependencies
  */
 import BarContainer from './bar-container';
 import observe from 'lib/mixins/data-observe';
 import touchDetect from 'lib/touch-detect';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:chart' );
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChart',

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:chart' );
+import React from 'react';
 import { some, noop, throttle } from 'lodash';
+const debug = require( 'debug' )( 'calypso:chart' );
 
 /**
  * Internal dependencies
  */
-var BarContainer = require( './bar-container' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	touchDetect = require( 'lib/touch-detect' );
+import BarContainer from './bar-container';
+import observe from 'lib/mixins/data-observe';
+import touchDetect from 'lib/touch-detect';
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChart',
@@ -60,8 +60,8 @@ module.exports = React.createClass( {
 
 	resize: function() {
 		if ( this.isMounted() ) {
-			var node = this.refs.chart,
-				width = node.clientWidth - 82,
+			const node = this.refs.chart;
+			let	width = node.clientWidth - 82,
 				maxBars;
 
 			if ( touchDetect.hasTouch() ) {
@@ -79,9 +79,9 @@ module.exports = React.createClass( {
 	},
 
 	getYAxisMax: function( values ) {
-		var max = Math.max.apply( null, values ),
-			operand = Math.pow( 10, ( max.toString().length - 1 ) ),
-			rounded = ( Math.ceil( ( max + 1 ) / operand ) * operand );
+		const max = Math.max.apply( null, values ),
+			operand = Math.pow( 10, ( max.toString().length - 1 ) );
+		let rounded = ( Math.ceil( ( max + 1 ) / operand ) * operand );
 
 		if ( rounded < 10 ) {
 			rounded = 10;
@@ -91,7 +91,7 @@ module.exports = React.createClass( {
 	},
 
 	getData: function() {
-		var data = this.props.data;
+		let data = this.props.data;
 
 		data = data.slice( 0 - this.state.maxBars );
 
@@ -99,9 +99,9 @@ module.exports = React.createClass( {
 	},
 
 	getValues: function() {
-		var data = this.getData();
+		let data = this.getData();
 
-		data = data.map( function ( item ) {
+		data = data.map( function( item ) {
 			return item.value;
 		}, this );
 
@@ -115,10 +115,10 @@ module.exports = React.createClass( {
 	render: function() {
 		debug( 'Rendering chart with props: ', this.props );
 
-		var values = this.getValues(),
+		const values = this.getValues(),
 			yAxisMax = this.getYAxisMax( values ),
-			data = this.getData(),
-			emptyChart;
+			data = this.getData();
+		let	emptyChart;
 
 		// If we have an empty chart, show a message
 		// @todo this message needs to either use a <Notice> or make a custom "chart__notice" class
@@ -136,7 +136,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<div ref="chart" className='chart'>
+			<div ref="chart" className="chart">
 				<div className="chart__y-axis-markers">
 					<div className="chart__y-axis-marker is-hundred"></div>
 					<div className="chart__y-axis-marker is-fifty"></div>
@@ -148,7 +148,13 @@ module.exports = React.createClass( {
 					<div className="chart__y-axis-label is-fifty">{ this.numberFormat( yAxisMax / 2 ) }</div>
 					<div className="chart__y-axis-label is-zero">{ this.numberFormat( 0 ) }</div>
 				</div>
-				<BarContainer barClick={ this.props.barClick } data={ data } yAxisMax={ yAxisMax } chartWidth={ this.state.width } isTouch={ touchDetect.hasTouch() } />
+				<BarContainer
+					barClick={ this.props.barClick }
+					data={ data }
+					yAxisMax={ yAxisMax }
+					chartWidth={ this.state.width }
+					isTouch={ touchDetect.hasTouch() }
+				/>
 				{ emptyChart }
 			</div>
 		);

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -65,7 +65,7 @@ module.exports = React.createClass( {
 
 	resize: function() {
 		const node = this.refs.chart;
-		let	width = node.clientWidth - 82,
+		let width = node.clientWidth - 82,
 			maxBars;
 
 		if ( touchDetect.hasTouch() ) {

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -3,7 +3,9 @@
  */
 import React from 'react';
 import { some, noop, throttle } from 'lodash';
-const debug = require( 'debug' )( 'calypso:chart' );
+import debugModule from 'debug';
+
+const debug = debugModule( 'calypso:chart' );
 
 /**
  * Internal dependencies

--- a/client/components/chart/label.jsx
+++ b/client/components/chart/label.jsx
@@ -2,12 +2,16 @@
  * External dependencies
  */
 import React from 'react';
-const debug = require( 'debug' )( 'calypso:module-chart:label' );
+import debugModule from 'debug';
+
+const debug = debugModule( 'calypso:module-chart:label' );
 
 /**
  * Internal dependencies
  */
-const user = require( 'lib/user' )();
+ import userModule from 'lib/user';
+
+ const user = userModule();
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartLabel',

--- a/client/components/chart/label.jsx
+++ b/client/components/chart/label.jsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:module-chart:label' );
+import React from 'react';
+const debug = require( 'debug' )( 'calypso:module-chart:label' );
 
 /**
  * Internal dependencies
  */
-var user = require( 'lib/user' )();
+const user = require( 'lib/user' )();
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartLabel',
@@ -21,8 +21,8 @@ module.exports = React.createClass( {
 	render: function() {
 		debug( 'Rendering label' );
 
-		var labelStyle,
-			dir = user.isRTL() ? 'right' : 'left';
+		const dir = user.isRTL() ? 'right' : 'left';
+		let labelStyle;
 
 		labelStyle = {
 			width: this.props.width + 'px'

--- a/client/components/chart/label.jsx
+++ b/client/components/chart/label.jsx
@@ -4,14 +4,16 @@
 import React from 'react';
 import debugModule from 'debug';
 
-const debug = debugModule( 'calypso:module-chart:label' );
-
 /**
  * Internal dependencies
  */
  import userModule from 'lib/user';
 
- const user = userModule();
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:module-chart:label' );
+const user = userModule();
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartLabel',

--- a/client/components/chart/label.jsx
+++ b/client/components/chart/label.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import debugModule from 'debug';
 
 /**
  * Internal dependencies
@@ -12,7 +11,6 @@ import debugModule from 'debug';
 /**
  * Module variables
  */
-const debug = debugModule( 'calypso:module-chart:label' );
 const user = userModule();
 
 module.exports = React.createClass( {
@@ -25,8 +23,6 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		debug( 'Rendering label' );
-
 		const dir = user.isRTL() ? 'right' : 'left';
 		let labelStyle;
 

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -3,14 +3,14 @@
  */
 import React from 'react';
 import { find } from 'lodash';
-const PureRenderMixin = require( 'react-pure-render/mixin' );
 import debugModule from 'debug';
 
-const debug = debugModule( 'calypso:module-chart:legend' );
-
 /**
- * Internal dependencies
+ * Module variables
  */
+const debug = debugModule( 'calypso:module-chart:legend' );
+// TODO: remove and extend from PureComponent after porting the component to ES6
+const PureRenderMixin = require( 'react-pure-render/mixin' );
 
 const LegendItem = React.createClass( {
 	displayName: 'ModuleChartLegendItem',

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -3,12 +3,10 @@
  */
 import React from 'react';
 import { find } from 'lodash';
-import debugModule from 'debug';
 
 /**
  * Module variables
  */
-const debug = debugModule( 'calypso:module-chart:legend' );
 // TODO: remove and extend from PureComponent after porting the component to ES6
 const PureRenderMixin = require( 'react-pure-render/mixin' );
 
@@ -57,7 +55,6 @@ const Legend = React.createClass( {
 	},
 
 	render: function() {
-		debug( 'Rendering legend', this.props );
 		const legendColors = [ 'chart__legend-color is-dark-blue' ],
 			activeTab = this.props.activeTab;
 

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -4,7 +4,9 @@
 import React from 'react';
 import { find } from 'lodash';
 const PureRenderMixin = require( 'react-pure-render/mixin' );
-const debug = require( 'debug' )( 'calypso:module-chart:legend' );
+import debugModule from 'debug';
+
+const debug = debugModule( 'calypso:module-chart:legend' );
 
 /**
  * Internal dependencies
@@ -61,15 +63,8 @@ const Legend = React.createClass( {
 
 		const legendItems = this.props.availableCharts.map( function( legendItem, index ) {
 			const colorClass = legendColors[ index ],
-				checked = ( -1 !== this.props.activeCharts.indexOf( legendItem ) );
-
-<<<<<<< 3e62c004563c7407e4e39f2f39d684ba75b48e14
-			tab = find( this.props.tabs, { attr: legendItem } );
-=======
-			const tab = this.props.tabs.filter( function( propTab ) {
-				return propTab.attr === legendItem;
-			} ).shift();
->>>>>>> Fix ESLint warnings
+				checked = ( -1 !== this.props.activeCharts.indexOf( legendItem ) ),
+				tab = find( this.props.tabs, { attr: legendItem } );
 
 			return <LegendItem
 				key={ index }

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	debug = require( 'debug' )( 'calypso:module-chart:legend' );
+import React from 'react';
 import { find } from 'lodash';
+const PureRenderMixin = require( 'react-pure-render/mixin' );
+const debug = require( 'debug' )( 'calypso:module-chart:legend' );
 
 /**
  * Internal dependencies
  */
 
-var LegendItem = React.createClass( {
+const LegendItem = React.createClass( {
 	displayName: 'ModuleChartLegendItem',
 
 	mixins: [ PureRenderMixin ],
@@ -30,7 +30,7 @@ var LegendItem = React.createClass( {
 		return (
 			<li className="chart__legend-option">
 				<label htmlFor="checkbox" className="chart__legend-label is-selectable" onClick={ this.clickHandler } >
-					<input type="checkbox" className="chart__legend-checkbox" checked={ this.props.checked } onChange={ function(){} } />
+					<input type="checkbox" className="chart__legend-checkbox" checked={ this.props.checked } onChange={ function() {} } />
 					<span className={ this.props.className }></span>{ this.props.label }
 				</label>
 			</li>
@@ -39,7 +39,7 @@ var LegendItem = React.createClass( {
 
 } );
 
-var Legend = React.createClass( {
+const Legend = React.createClass( {
 	displayName: 'ModuleChartLegend',
 
 	propTypes: {
@@ -56,25 +56,40 @@ var Legend = React.createClass( {
 
 	render: function() {
 		debug( 'Rendering legend', this.props );
-		var legendColors = [ 'chart__legend-color is-dark-blue' ],
-			tab = this.props.activeTab,
-			legendItems;
+		const legendColors = [ 'chart__legend-color is-dark-blue' ],
+			activeTab = this.props.activeTab;
 
-		legendItems = this.props.availableCharts.map( function( legendItem, index ) {
-			var colorClass = legendColors[ index ],
-				checked = ( -1 !== this.props.activeCharts.indexOf( legendItem ) ),
-				tab;
+		const legendItems = this.props.availableCharts.map( function( legendItem, index ) {
+			const colorClass = legendColors[ index ],
+				checked = ( -1 !== this.props.activeCharts.indexOf( legendItem ) );
 
+<<<<<<< 3e62c004563c7407e4e39f2f39d684ba75b48e14
 			tab = find( this.props.tabs, { attr: legendItem } );
+=======
+			const tab = this.props.tabs.filter( function( propTab ) {
+				return propTab.attr === legendItem;
+			} ).shift();
+>>>>>>> Fix ESLint warnings
 
-			return <LegendItem key={ index } className={ colorClass } label={ tab.label } attr={ tab.attr } changeHandler={ this.onFilterChange } checked={ checked } />;
+			return <LegendItem
+				key={ index }
+				className={ colorClass }
+				label={ tab.label }
+				attr={ tab.attr }
+				changeHandler={ this.onFilterChange }
+				checked={ checked }
+			/>;
 		}, this );
-
 
 		return (
 			<div className="chart__legend">
 				<ul className="chart__legend-options">
-					<li className="chart__legend-option" key='default-tab'><span className="chart__legend-label"><span className="chart__legend-color is-wordpress-blue"></span>{ tab.label }</span></li>
+					<li className="chart__legend-option" key="default-tab">
+						<span className="chart__legend-label">
+							<span className="chart__legend-color is-wordpress-blue"></span>
+							{ activeTab.label }
+						</span>
+					</li>
 					{ legendItems }
 				</ul>
 			</div>

--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:module-chart:x-axis' ),
-	throttle = require( 'lodash/throttle' );
+import React from 'react';
+import { throttle } from 'lodash';
+const debug = require( 'debug' )( 'calypso:module-chart:x-axis' );
 
 /**
  * Internal dependencies
  */
-var Label = require( './label' );
+import Label from './label';
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartXAxis',
@@ -34,7 +34,7 @@ module.exports = React.createClass( {
 
 	// Remove listener
 	componentWillUnmount: function() {
-		if( this.resizeThrottled.cancel ) {
+		if ( this.resizeThrottled.cancel ) {
 			this.resizeThrottled.cancel();
 		}
 		window.removeEventListener( 'resize', this.resizeThrottled );
@@ -45,52 +45,41 @@ module.exports = React.createClass( {
 	},
 
 	resize: function( nextProps ) {
-		if ( this.isMounted() ) {
-			var node,
-				props = this.props,
-				width,
-				dataCount,
-				spacing,
-				labelWidth,
-				divisor;
-
-			node = this.refs.axis;
-
-			if ( nextProps && ! ( nextProps instanceof Event ) ) {
-				props = nextProps;
-			}
-
-			/**
-			 * Overflow needs to be hidden to calculate the desired width,
-			 * but visible to display each labels' overflow :/
-			 */
-
-			node.style.overflow = 'hidden';
-			width = node.clientWidth;
-			node.style.overflow = 'visible';
-
-			dataCount = props.data.length || 1;
-			spacing = width / dataCount;
-			labelWidth = props.labelWidth;
-			divisor = Math.ceil( labelWidth / spacing );
-
-			this.setState( {
-				divisor: divisor,
-				spacing: spacing
-			} );
+		let props = this.props;
+		if ( nextProps && ! ( nextProps instanceof Event ) ) {
+			props = nextProps;
 		}
+
+		const node = this.refs.axis;
+		const width = node.clientWidth;
+		const dataCount = props.data.length || 1;
+		const spacing = width / dataCount;
+		const labelWidth = props.labelWidth;
+		const divisor = Math.ceil( labelWidth / spacing );
+
+		/**
+		 * Overflow needs to be hidden to calculate the desired width,
+		 * but visible to display each labels' overflow :/
+		 */
+
+		node.style.overflow = 'hidden';
+		node.style.overflow = 'visible';
+
+		this.setState( {
+			divisor: divisor,
+			spacing: spacing
+		} );
 	},
 
 	render: function() {
 		debug( 'Rendering chart x-axis', this.props.data );
 
-		var labels,
-			data = this.props.data;
+		const data = this.props.data;
 
-		labels = data.map( function ( item, index ) {
-			var x = ( index * this.state.spacing ) + ( ( this.state.spacing - this.props.labelWidth ) / 2 ),
-				rightIndex = data.length - index - 1,
-				label;
+		const labels = data.map( function( item, index ) {
+			const x = ( index * this.state.spacing ) + ( ( this.state.spacing - this.props.labelWidth ) / 2 ),
+				rightIndex = data.length - index - 1;
+			let label;
 
 			if ( rightIndex % this.state.divisor === 0 ) {
 				label = <Label key={ index } label={ item.label } width={ this.props.labelWidth } x={ x } />;
@@ -104,4 +93,3 @@ module.exports = React.createClass( {
 		);
 	}
 } );
-

--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -3,7 +3,9 @@
  */
 import React from 'react';
 import { throttle } from 'lodash';
-const debug = require( 'debug' )( 'calypso:module-chart:x-axis' );
+import debugModule from 'debug';
+
+const debug = debugModule( 'calypso:module-chart:x-axis' );
 
 /**
  * Internal dependencies

--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -5,12 +5,15 @@ import React from 'react';
 import { throttle } from 'lodash';
 import debugModule from 'debug';
 
-const debug = debugModule( 'calypso:module-chart:x-axis' );
-
 /**
  * Internal dependencies
  */
 import Label from './label';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:module-chart:x-axis' );
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartXAxis',

--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -50,11 +50,6 @@ module.exports = React.createClass( {
 		}
 
 		const node = this.refs.axis;
-		const width = node.clientWidth;
-		const dataCount = props.data.length || 1;
-		const spacing = width / dataCount;
-		const labelWidth = props.labelWidth;
-		const divisor = Math.ceil( labelWidth / spacing );
 
 		/**
 		 * Overflow needs to be hidden to calculate the desired width,
@@ -62,7 +57,13 @@ module.exports = React.createClass( {
 		 */
 
 		node.style.overflow = 'hidden';
+		const width = node.clientWidth;
 		node.style.overflow = 'visible';
+
+		const dataCount = props.data.length || 1;
+		const spacing = width / dataCount;
+		const labelWidth = props.labelWidth;
+		const divisor = Math.ceil( labelWidth / spacing );
 
 		this.setState( {
 			divisor: divisor,

--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -3,17 +3,11 @@
  */
 import React from 'react';
 import { throttle } from 'lodash';
-import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
 import Label from './label';
-
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:module-chart:x-axis' );
 
 module.exports = React.createClass( {
 	displayName: 'ModuleChartXAxis',
@@ -77,8 +71,6 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		debug( 'Rendering chart x-axis', this.props.data );
-
 		const data = this.props.data;
 
 		const labels = data.map( function( item, index ) {


### PR DESCRIPTION
Fix the following ESLint errors:
- `no-unused-vars`
- `no-var`
- `prefer-const`
- `no-mixed-spaces-and-tabs`
- `jsx-quotes`
- `wpcalypso/jsx-classname-namespace`
- `no-multiple-empty-lines`
- `no-spaced-func`
- `no-trailing-spaces`
- `max-len`
- `no-redeclare`
- `react/no-is-mounted`
