### PR TITLE
Jetpack Connect: Fix various ESLint warnings

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -457,7 +457,7 @@ const LoggedInForm = React.createClass( {
 		const { authorizeSuccess, siteReceived } = this.props.jetpackConnectAuthorize;
 		if ( this.props.isFetchingSites() || this.isAuthorizing() || ( authorizeSuccess && ! siteReceived ) ) {
 			return (
-				<div className="jetpack-connect-logged-in-form__loading">
+				<div className="jetpack-connect__logged-in-form-loading">
 					<span>{ this.getButtonText() }</span> <Spinner size={ 20 } duration={ 3000 } />
 				</div>
 			);
@@ -476,11 +476,11 @@ const LoggedInForm = React.createClass( {
 	render() {
 		const { authorizeSuccess } = this.props.jetpackConnectAuthorize;
 		return (
-			<div className="jetpack-connect-logged-in-form">
+			<div className="jetpack-connect__logged-in-form">
 				{ this.renderFormHeader( authorizeSuccess ) }
 				<Card>
 					<Gravatar user={ this.props.user } size={ 64 } />
-					<p className="jetpack-connect-logged-in-form__user-text">{ this.getUserText() }</p>
+					<p className="jetpack-connect__logged-in-form-user-text">{ this.getUserText() }</p>
 					{ this.renderNotices() }
 					{ this.renderStateAction() }
 				</Card>

--- a/client/signup/jetpack-connect/connect-header.jsx
+++ b/client/signup/jetpack-connect/connect-header.jsx
@@ -14,13 +14,13 @@ export default React.createClass( {
 		return {
 			showLogo: true,
 			label: ''
-		}
+		};
 	},
 
 	renderJetpackLogo() {
 		return (
 			<img
-				className="jetpack-logo"
+				className="jetpack-connect__jetpack-logo"
 				src="/calypso/images/jetpack/jetpack-logo.svg"
 				width={ 18 }
 				height={ 18 } />

--- a/client/signup/jetpack-connect/exampleComponents/jetpack-activate.jsx
+++ b/client/signup/jetpack-connect/exampleComponents/jetpack-activate.jsx
@@ -41,7 +41,7 @@ export default React.createClass( {
 						<div className="jetpack-connect__browser-chrome-dot"></div>
 						<div className="jetpack-connect__browser-chrome-dot"></div>
 					</div>
-					<div className="site-address-container">
+					<div className="jetpack-connect__site-address-container">
 						<Gridicon
 							size={ 24 }
 							icon="globe" />

--- a/client/signup/jetpack-connect/exampleComponents/jetpack-connect.jsx
+++ b/client/signup/jetpack-connect/exampleComponents/jetpack-connect.jsx
@@ -18,7 +18,7 @@ export default React.createClass( {
 						<div className="jetpack-connect__browser-chrome-dot"></div>
 						<div className="jetpack-connect__browser-chrome-dot"></div>
 					</div>
-					<div className="site-address-container">
+					<div className="jetpack-connect__site-address-container">
 						<Gridicon
 							size={ 24 }
 							icon="globe" />

--- a/client/signup/jetpack-connect/exampleComponents/jetpack-install.jsx
+++ b/client/signup/jetpack-connect/exampleComponents/jetpack-install.jsx
@@ -18,7 +18,7 @@ export default React.createClass( {
 						<div className="jetpack-connect__browser-chrome-dot"></div>
 						<div className="jetpack-connect__browser-chrome-dot"></div>
 					</div>
-					<div className="site-address-container">
+					<div className="jetpack-connect__site-address-container">
 						<Gridicon
 							size={ 24 }
 							icon="globe" />

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -105,7 +105,10 @@ export default React.createClass( {
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'alreadyConnectedByOtherUser' ) {
-			noticeValues.text = this.translate( 'This site is already connected to a different WordPress.com user, you need to disconnect that user before you can connect another.' );
+			noticeValues.text = this.translate(
+				'This site is already connected to a different WordPress.com user, ' +
+				'you need to disconnect that user before you can connect another.'
+			);
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'notice';
 			return noticeValues;

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -153,7 +153,7 @@ const Plans = React.createClass( {
 							step={ 1 }
 							steps={ 3 } />
 
-						<div id="plans" className="plans has-sidebar">
+						<div id="plans">
 							<PlansFeaturesMain
 								site={ selectedSite }
 								isInSignup={ true }

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -86,7 +86,7 @@ export default React.createClass( {
 		return (
 			<div>
 				<FormLabel htmlFor="siteUrl">{ this.translate( 'Site Address' ) }</FormLabel>
-				<div className="site-address-container">
+				<div className="jetpack-connect__site-address-container">
 					<Gridicon
 						size={ 24 }
 						icon="globe" />

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -31,7 +31,7 @@
 .jetpack-connect__header-container {
 	text-align: center;
 
-	.jetpack-logo {
+	.jetpack-connect__jetpack-logo {
 		width: 72px;
 		height: 72px;
 	}

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -52,7 +52,7 @@
 
 .jetpack-connect__site-url-input-container {
 
-	.site-address-container {
+	.jetpack-connect__site-address-container {
 		position: relative;
 
 		.gridicon {
@@ -284,7 +284,7 @@
 	text-decoration: underline;
 }
 
-.jetpack-connect__site-url-input-container .site-address-container .jetpack-connect__browser-chrome-url {
+.jetpack-connect__site-url-input-container .jetpack-connect__site-address-container .jetpack-connect__browser-chrome-url {
 	height: 40px;
 	font-size: 12px;
 	color: $gray;

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -86,8 +86,8 @@
 	}
 }
 
-.jetpack-connect-logged-in-form {
-	.jetpack-connect-logged-in-form__user-text {
+.jetpack-connect__logged-in-form {
+	.jetpack-connect__logged-in-form-user-text {
 		text-align: center;
 	}
 
@@ -322,7 +322,7 @@
 	width: 100%;
 }
 
-.jetpack-connect-logged-in-form__loading {
+.jetpack-connect__logged-in-form-loading {
 	text-align: center;
 
 	span {


### PR DESCRIPTION
### Purpose

This PR addresses all of the current ESLint warnings within `/client/signup/jetpack-connect` which currently include:

* Incompatible classNames with the CSS guidelines
* Too long lines
* Missing semicolons

### Notes
* The PR does not address the ESLint warnings within the `exampleComponents`.
* The PR gets rid of the incompatible plans CSS classes, which currently do nothing within JPC. New, compatible class(es) will be introduced afterwards in https://github.com/Automattic/wp-calypso/issues/7552.

### ESLint preview
![](https://cldup.com/3w9HtEmzOb.png)

### To test

* Checkout this branch
* Verify there are no ESLint warnings within any of the Jetpack Connect subcomponents.
* Verify there are no regressions within JPC.

Test live: https://calypso.live/?branch=fix/jetpack-connect-various-eslint-warnings