### PR TITLE
Fixed devdocs link for Gravatar component

### DIFF
--- a/client/components/gravatar/docs/example.jsx
+++ b/client/components/gravatar/docs/example.jsx
@@ -18,7 +18,7 @@ const GravatarExample = React.createClass( {
 		return (
 			<div className="design-assets__group">
 				<h2>
-					<a href="/devdocs/components/gravatar">Gravatar</a>
+					<a href="/devdocs/design/gravatar">Gravatar</a>
 				</h2>
 				<Gravatar user={ this.props.currentUser } size={ 96 } />
 			</div>

--- a/client/components/gravatar/docs/example.jsx
+++ b/client/components/gravatar/docs/example.jsx
@@ -10,24 +10,29 @@ import { connect } from 'react-redux';
 import Gravatar from 'components/gravatar';
 import { getCurrentUser } from 'state/current-user/selectors';
 
-const GravatarExample = React.createClass( {
+function GravatarExample( { currentUser } ) {
+	return (
+		<div className="design-assets__group">
+			<h2>
+				<a href="/devdocs/design/gravatar">Gravatar</a>
+			</h2>
+			<Gravatar user={ currentUser } size={ 96 } />
+		</div>
+	);
+}
 
-	displayName: 'Gravatar',
+const ConnectedGravatarExample = connect( ( state ) => {
+	const currentUser = getCurrentUser( state );
 
-	render() {
-		return (
-			<div className="design-assets__group">
-				<h2>
-					<a href="/devdocs/design/gravatar">Gravatar</a>
-				</h2>
-				<Gravatar user={ this.props.currentUser } size={ 96 } />
-			</div>
-		);
+	if ( ! currentUser ) {
+		return {};
 	}
-} );
 
-export default connect( ( state ) => {
 	return {
-		currentUser: getCurrentUser( state )
+		currentUser
 	};
 } )( GravatarExample );
+
+ConnectedGravatarExample.displayName = 'Gravatar';
+
+export default ConnectedGravatarExample;


### PR DESCRIPTION
PR #7541 added the Gravatar component to the `/devdocs/design` page, but the link in the href element is pointing to the wrong location.  I updated it here in this PR, and the link now looks right, but the gravatar isn't being displayed on the individual element page and I'm not sure why.

<img width="706" alt="screen shot 2016-08-19 at 12 16 14 pm" src="https://cloud.githubusercontent.com/assets/7233112/17816352/c268ea72-6606-11e6-92fb-ec59b7fc5337.png">

cc: @bluefuton 

Test live: https://calypso.live/?branch=fix/devdocs-gravatar-link