### PR TITLE
Purchases: Remove unnecessary top margin in form in Edit Card Details page

### DIFF
--- a/client/components/upgrades/credit-card-form/style.scss
+++ b/client/components/upgrades/credit-card-form/style.scss
@@ -34,7 +34,7 @@
 }
 
 .credit-card-form__field {
-	margin-top: 15px;
+	margin-bottom: 15px;
 	position: relative;
 
 	select {

--- a/client/me/purchases/components/credit-card-page/style.scss
+++ b/client/me/purchases/components/credit-card-page/style.scss
@@ -4,7 +4,7 @@
 
 .credit-card-page__card-terms {
 	color: darken( $gray, 10% );
-	margin: 20px 0 0 0;
+	margin: 5px 0 0 0;
 	padding: 0;
 	text-align: center;
 

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -325,7 +325,6 @@
 			max-height: 500px;
 			margin-bottom: 0;
 			padding-top: 15px;
-			padding-bottom: 15px;
 		}
 
 		.new-card-toggle {
@@ -338,6 +337,7 @@
 		.new-card-header {
 			color: $blue-medium;
 			font-weight: 400;
+			margin-bottom: 15px;
 		}
 
 		.all-fields-required {


### PR DESCRIPTION
Fixes #839.

This PR removes the additional top margin on the `Edit Card Details` page.

### Before
![screen shot 2016-08-19 at 18 24 37](https://cloud.githubusercontent.com/assets/699132/17817214/b6f6cac4-663d-11e6-974f-0d004da92744.png)
![screen shot 2016-08-19 at 18 24 51](https://cloud.githubusercontent.com/assets/699132/17817213/b6f37b76-663d-11e6-8ec9-70464e1454c4.png)

### After
![screen shot 2016-08-19 at 18 23 46](https://cloud.githubusercontent.com/assets/699132/17817226/bc41cf92-663d-11e6-8251-9df1bbe51cc0.png)
![screen shot 2016-08-19 at 18 24 01]
(https://cloud.githubusercontent.com/assets/699132/17817227/bc4b53aa-663d-11e6-8a52-eb5b2e1062c4.png)

### No change
![screen shot 2016-08-19 at 19 02 10](https://cloud.githubusercontent.com/assets/699132/17817618/aac492ac-663f-11e6-9b58-3b6c43aece88.png)

### Testing
1. Go to Manage Purchases page (http://calypso.localhost:3000/purchases).
2. Select a purchase paid with credit card.
3. Click on Edit Payment Method link.
4. Check if top margin was removed.
5. You can also test if credit card form in the checkout flow looks properly.

Test live: https://calypso.live/?branch=fix/839-margin-credit-card