### PR TITLE
Sites: Only filter recent sites if more than 12 visible

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -155,7 +155,7 @@ const SiteSelector = React.createClass( {
 			sites = this.props.sites.getVisible();
 
 			const { recentSites } = this.props;
-			if ( this.shouldShowGroups() && size( recentSites ) ) {
+			if ( this.shouldShowGroups() && size( recentSites ) && user.get().visible_site_count >= 12 ) {
 				sites = filter( sites, ( { ID: siteId } ) => ! includes( recentSites, siteId ) );
 			}
 		}


### PR DESCRIPTION
This pull request seeks to resolve an issue where the site selector may not show site options if there are fewer than 12 visible sites for the current user.

Test live: https://calypso.live/?branch=fix/site-selector