### PR TITLE
Redesign checkout-thank-you page to use two layout column

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import find from 'lodash/find';
 import page from 'page';
 import React from 'react';
+import { overSome, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -179,6 +180,33 @@ const CheckoutThankYou = React.createClass( {
 				</Card>
 			</Main>
 		);
+	},
+
+	getPlanSlug() {
+		const purchase = get( getPurchases( this.props ), '[0]', null );
+
+		if ( ! purchase ) {
+			return null;
+		}
+
+		const isValidPurchaseFn = overSome( [
+			isJetpackPlan,
+			isPersonal,
+			isPremium,
+			isBusiness,
+			isDomainRegistration,
+			isGoogleApps,
+			isDomainMapping,
+			isSiteRedirect,
+			isChargeback,
+			isGuidedTransfer
+		] );
+
+		if ( isValidPurchaseFn( purchase ) ) {
+			return purchase.productSlug;
+		}
+
+		return null;
 	},
 
 	/**


### PR DESCRIPTION
Complementary to #6758. WIP.

## Todo/Ideas:

- [ ] Move/create features from `upgrades/checkout-thank-you` to `blocks/product-purchase-features`
- [ ] Use `ProductPurchaseFeatures` in `checkout-thank-you` to render the page in two columns

cc @rralian @gwwar for ideas and whether this is the right approach + do we want this to happen or leave checkout-thank-you as it is? (Please see #7538 for the approach I'll be taking here).

Test live: https://calypso.live/?branch=update/checkout-thank-you-page-redesign