### PR TITLE
Purchases: Fix default value for Select Country combo box

### DIFF
--- a/client/components/forms/form-select/index.jsx
+++ b/client/components/forms/form-select/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import omit from 'lodash/omit';
 
 const FormSelect = React.createClass( {
 	getDefaultProps() {
@@ -13,12 +12,13 @@ const FormSelect = React.createClass( {
 	},
 
 	render() {
-		const classes = classNames( this.props.className, 'form-select', {
-			'is-error': this.props.isError,
-		} );
+		const { className, isError, ...props } = this.props,
+			classes = classNames( className, 'form-select', {
+				'is-error': isError,
+			} );
 
 		return (
-			<select { ...omit( this.props, 'className' ) } className={ classes } >
+			<select { ...props } className={ classes }>
 				{ this.props.children }
 			</select>
 		);

--- a/client/my-sites/upgrades/components/form/country-select.jsx
+++ b/client/my-sites/upgrades/components/form/country-select.jsx
@@ -44,7 +44,7 @@ export default React.createClass( {
 			options.push( { key: 'loading', label: this.translate( 'Loading…' ), disabled: 'disabled' } );
 		} else {
 			options = options.concat( [
-				{ key: 'select-country', label: this.translate( 'Select Country' ) },
+				{ key: 'select-country', label: this.translate( 'Select Country' ), value: '' },
 				{ key: 'divider1', label: '', disabled: 'disabled' }
 			] );
 


### PR DESCRIPTION
Two issues fixed in this PR:
1. React warnings won't show up on the JS console because of unknown prop `isError` for `<select>` element.
2. Default value will be set to `Select Country` where Credit Card form loads without any value provided.

### Before
![screen shot 2016-08-19 at 18 23 46](https://cloud.githubusercontent.com/assets/699132/17818213/ddf91b54-6642-11e6-9fcb-2328d3a5a430.png)

### After
![screen shot 2016-08-19 at 19 22 41](https://cloud.githubusercontent.com/assets/699132/17818225/e2ecbb3e-6642-11e6-8049-bd57ea10cf79.png)

### Testing
1. Go to Manage Purchases page (http://calypso.localhost:3000/purchases).
2. Select a purchase paid with credit card.
3. Click on Edit Payment Method link.
4. Check if `Select Country` is set as a default value.
5. Make sure there are no React warnings related to `<select>` element (there were unrelated warnings last time I checked).



Test live: https://calypso.live/?branch=fix/default-value-select-country