### PR TITLE
Components: Remove React warning - Unknown prop `autofocus`

### DIFF
--- a/client/components/upgrades/credit-card-form/index.jsx
+++ b/client/components/upgrades/credit-card-form/index.jsx
@@ -58,7 +58,7 @@ const CreditCardForm = React.createClass( {
 			<div className="credit-card-form">
 				{ this.field( 'name', Input, {
 					labelClass: 'credit-card-form__label',
-					autofocus: true,
+					autoFocus: true,
 					label: this.translate( 'Name on Card', {
 						context: 'Card holder name label on credit card form'
 					} )

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -187,7 +187,7 @@ export default React.createClass( {
 		return (
 			<div>
 				<Input
-					autofocus
+					autoFocus
 					label={ this.translate( 'First Name', { textOnly } ) }
 					{ ...fieldProps( 'first-name' ) }/>
 

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -19,12 +19,12 @@ export default React.createClass( {
 	displayName: 'Input',
 
 	getDefaultProps() {
-		return { autofocus: false };
+		return { autoFocus: false };
 	},
 
 	componentDidMount() {
 		this.setupInputModeHandlers();
-		this.autofocusInput();
+		this.autoFocusInput();
 	},
 
 	setupInputModeHandlers() {
@@ -48,7 +48,7 @@ export default React.createClass( {
 		if ( oldProps.disabled && ! this.props.disabled ) {
 			// We focus when the state goes from disabled to enabled. This is needed because we show a disabled input
 			// until we receive data from the server.
-			this.autofocusInput();
+			this.autoFocusInput();
 		}
 	},
 
@@ -58,8 +58,8 @@ export default React.createClass( {
 		scrollIntoViewport( node );
 	},
 
-	autofocusInput() {
-		if ( this.props.autofocus ) {
+	autoFocusInput() {
+		if ( this.props.autoFocus ) {
 			this.focus();
 		}
 	},
@@ -82,7 +82,7 @@ export default React.createClass( {
 					value={ this.props.value }
 					name={ this.props.name }
 					ref="input"
-					autofocus={ this.props.autofocus }
+					autoFocus={ this.props.autoFocus }
 					disabled={ this.props.disabled }
 					maxLength={ this.props.maxLength }
 					onChange={ this.props.onChange }

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -105,7 +105,7 @@ const EditContactInfoFormCard = React.createClass( {
 					<div className="edit-contact-info-form-card__form-content">
 						{ this.getField( FormInput, {
 							name: 'first-name',
-							autofocus: true,
+							autoFocus: true,
 							label: this.translate( 'First Name', {
 								context: 'Domain Edit Contact Info form.',
 								textOnly: true


### PR DESCRIPTION
Part of #7413.

Removes React warning - Unknown prop `autofocus`.

### Testing
1. Go to Manage Purchases page (http://calypso.localhost:3000/purchases).
2. Select a purchase paid with credit card.
3. Click on Edit Payment Method link.
4. Make sure there are nor warnings on the JS console complaining about `autofocus`.
5. Make sure that focus is on the first form element as before :)

Test live: https://calypso.live/?branch=fix/autofocus-prop-warning