### PR TITLE
Component: Update components dependent on Popover to use rootClassName

### DIFF
--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -19,6 +19,7 @@ export default React.createClass( {
 		id: React.PropTypes.string,
 		position: React.PropTypes.string,
 		className: React.PropTypes.string,
+		rootClassName: React.PropTypes.string,
 		gaEventCategory: React.PropTypes.string,
 		popoverName: React.PropTypes.string,
 		ignoreContext: React.PropTypes.shape( {
@@ -62,6 +63,7 @@ export default React.createClass( {
 							'info-popover__tooltip',
 							this.props.className
 						) }
+					rootClassName={ this.props.rootClassName }
 					>
 						{ this.props.children }
 				</Popover>

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -14,7 +14,8 @@ var PopoverMenu = React.createClass( {
 		isVisible: React.PropTypes.bool.isRequired,
 		onClose: React.PropTypes.func.isRequired,
 		position: React.PropTypes.string,
-		className: React.PropTypes.string
+		className: React.PropTypes.string,
+		rootClassName: React.PropTypes.string
 	},
 
 	getDefaultProps: function() {
@@ -39,6 +40,7 @@ var PopoverMenu = React.createClass( {
 				onClose={ this._onClose }
 				onShow={ this._onShow }
 				className={ this.props.className }>
+				rootClassName={ this.props.rootClassName }>
 				<div ref="menu" role="menu" className="popover__menu" onKeyDown={ this._onKeyDown } tabIndex="-1">
 					{ children }
 				</div>

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -22,6 +22,7 @@ class Tooltip extends Component {
 		id: PropTypes.string,
 		isVisible: PropTypes.bool,
 		position: PropTypes.string,
+		rootClassName: PropTypes.string,
 		status: PropTypes.string,
 		showDelay: PropTypes.number,
 		showOnMobile: PropTypes.bool
@@ -49,6 +50,7 @@ class Tooltip extends Component {
 			<Popover
 				autoPosition= { this.props.autoPosition }
 				className={ classes }
+				rootClassName={ this.props.rootClassName }
 				context={ this.props.context }
 				id={ this.props.id }
 				isVisible={ this.props.isVisible }


### PR DESCRIPTION
Several components are more refined Popover components:
 * InfoPopover
 * PopoverMenu
 * Tooltip

These components are general purpose and need support to
set CSS classes on RootChild just as Popover does. This is
especially useful for sequestering Calypso scss @imports as
is required for pages within wp-admin.

cc @retrofox 

Test live: https://calypso.live/?branch=update/popover-dependents-root-class-name