### PR TITLE
Component: Fix a typo in the PopoverMenu render

### DIFF
--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -39,7 +39,7 @@ var PopoverMenu = React.createClass( {
 				position={ this.props.position }
 				onClose={ this._onClose }
 				onShow={ this._onShow }
-				className={ this.props.className }>
+				className={ this.props.className }
 				rootClassName={ this.props.rootClassName }>
 				<div ref="menu" role="menu" className="popover__menu" onKeyDown={ this._onKeyDown } tabIndex="-1">
 					{ children }


### PR DESCRIPTION
An extra > was present in the render of the Popover tag.
This caused the rootClassName to not be parsed correctly.

cc @retrofox 

Test live: https://calypso.live/?branch=fix/popovermenu-jsx-tag-rootclassname