### PR TITLE
Stats: Quell the IE11 spinner beast

### DIFF
--- a/client/my-sites/stats/stats-module/placeholder.jsx
+++ b/client/my-sites/stats/stats-module/placeholder.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -9,13 +9,11 @@ import classNames from 'classnames';
  */
 import Spinner from 'components/spinner';
 
-export default React.createClass( {
-	displayName: 'StatsModulePlaceholder',
-
-	propTypes: {
+export default class StatsModulePlaceholder extends PureComponent {
+	static propTypes = {
 		className: PropTypes.string,
 		isLoading: PropTypes.bool
-	},
+	};
 
 	render() {
 		const { className, isLoading } = this.props;
@@ -32,4 +30,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/my-sites/stats/stats-module/placeholder.jsx
+++ b/client/my-sites/stats/stats-module/placeholder.jsx
@@ -26,6 +26,10 @@ export default React.createClass( {
 
 		const classes = classNames( 'stats-module__placeholder', 'is-void', className );
 
-		return ( <Spinner className={ classes } /> );
+		return (
+			<div className={ classes }>
+				<Spinner />
+			</div>
+		);
 	}
 } );


### PR DESCRIPTION
This pull request seeks to resolve an issue which occurs when the stats module placeholder is shown in IE11, causing the displayed spinner to appear distorted.

Before|After
---|---
![monster](https://cloud.githubusercontent.com/assets/1779930/17826433/d0ea4d7e-663e-11e6-85ea-19dd31744051.gif)|![quelled](https://cloud.githubusercontent.com/assets/1779930/17826434/d419937e-663e-11e6-9b06-9594b18cfeaa.gif)

__Testing instructions:__

Verify that the stats placeholder spinner displays as expected in both your default browser and in IE11.

1. Navigate to [stats insights](http://calypso.localhost:3000/stats/insights)
2. Select a site
3. Note in "Latest Post Summary" that the spinner displays centered at its default size

/cc @timmyc 

Test live: https://calypso.live/?branch=fix/ie11-spinner-monster