### PR TITLE
DatePicker: fix unknown prop warning

### DIFF
--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -68,7 +68,7 @@ module.exports = React.createClass( {
 			localeData = moment().localeData(),
 			locale = {
 				formatDay: function( date ) {
-					return moment( date ).format( 'D' );
+					return moment( date ).format( 'llll' );
 				},
 
 				formatMonthTitle: function( date ) {

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -67,6 +67,10 @@ module.exports = React.createClass( {
 		var moment = this.moment,
 			localeData = moment().localeData(),
 			locale = {
+				formatDay: function( date ) {
+					return moment( date ).format( 'D' );
+				},
+
 				formatMonthTitle: function( date ) {
 					return moment( date ).format( 'MMMM YYYY' );
 				},

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -384,7 +384,7 @@
       "version": "0.1.2"
     },
     "base64-js": {
-      "version": "0.0.8"
+      "version": "1.1.2"
     },
     "base64id": {
       "version": "0.1.0"
@@ -463,7 +463,7 @@
       "version": "1.3.5"
     },
     "buffer": {
-      "version": "3.6.0"
+      "version": "4.9.1"
     },
     "builtin-modules": {
       "version": "1.1.1"
@@ -498,7 +498,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000524"
+      "version": "1.0.30000525"
     },
     "caseless": {
       "version": "0.11.0"
@@ -1009,7 +1009,7 @@
       "version": "1.3.0"
     },
     "es-abstract": {
-      "version": "1.5.1"
+      "version": "1.6.1"
     },
     "es-to-primitive": {
       "version": "1.1.1"
@@ -1318,7 +1318,7 @@
       }
     },
     "fizzy-ui-utils": {
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     "flat-cache": {
       "version": "1.2.1"
@@ -1464,7 +1464,7 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.5"
+      "version": "4.1.6"
     },
     "graceful-readlink": {
       "version": "1.0.1"
@@ -2254,7 +2254,7 @@
       }
     },
     "node-libs-browser": {
-      "version": "0.5.3",
+      "version": "0.6.0",
       "dependencies": {
         "isarray": {
           "version": "0.0.1"
@@ -2649,7 +2649,7 @@
           "version": "1.2.7"
         },
         "fbjs": {
-          "version": "0.8.3"
+          "version": "0.8.4"
         }
       }
     },
@@ -2675,7 +2675,7 @@
       "version": "2.1.0"
     },
     "react-day-picker": {
-      "version": "1.3.2"
+      "version": "2.4.1"
     },
     "react-dom": {
       "version": "15.3.0"
@@ -2709,6 +2709,9 @@
           "version": "0.4.4"
         }
       }
+    },
+    "react-is-deprecated": {
+      "version": "0.1.2"
     },
     "react-masonry-component": {
       "version": "4.0.4"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-addons-shallow-compare": "15.3.0",
     "react-addons-update": "15.3.0",
     "react-click-outside": "2.1.0",
-    "react-day-picker": "1.3.2",
+    "react-day-picker": "2.4.1",
     "react-dom": "15.3.0",
     "react-helmet": "2.2.0",
     "react-masonry-component": "4.0.4",


### PR DESCRIPTION
Updated `react-day-picker` to last version and added a `locale.formatDay()` to avoid a fatal error in the external component.

See: https://github.com/Automattic/wp-calypso/issues/7413

Test live: https://calypso.live/?branch=fix/date-picker-props-warnings