### PR TITLE
Domains: Show full list of countries, including the top ones

### DIFF
--- a/client/my-sites/upgrades/components/form/country-select.jsx
+++ b/client/my-sites/upgrades/components/form/country-select.jsx
@@ -48,12 +48,12 @@ export default React.createClass( {
 				{ key: 'divider1', label: '', disabled: 'disabled' }
 			] );
 
-			options = options.concat( countriesList.map( country => {
+			options = options.concat( countriesList.map( ( country, index ) => {
 				if ( isEmpty( country.code ) ) {
 					return { key: 'divider2', label: '', disabled: 'disabled' };
 				}
 
-				return { key: country.code, label: country.name, value: country.code };
+				return { key: `country-select-${ index }-${ country.code }`, label: country.name, value: country.code };
 			} ) );
 		}
 


### PR DESCRIPTION
When filling out the domain contact information form, the coutries list has the most popular countries listed on top, following by an alphabetical list of the rest of the countries (excluding the top ones).

This can be confusing for some users - they might be automatically searching for their country (for example, USA) at the bottom of the list. It might take them a while to notice that USA is ("conveniently") at the top of the list, they might select something else that sounds similar (popular choice is "United States Minor Outlying Islands") or just give up altogether.

This change ensures that the full list is rendered by providing each `option` with an unique `key`.

This needs `D2591-code` on the backend for full effect :)

/cc @aidvu 

Test live: https://calypso.live/?branch=fix/full-domain-registration-countries-list