### PR TITLE
Components: Remove React warnings triggered by FormsButton compontnet

### DIFF
--- a/client/components/forms/form-button/index.jsx
+++ b/client/components/forms/form-button/index.jsx
@@ -1,22 +1,20 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' ),
-	classNames = require( 'classnames' ),
-	omit = require( 'lodash/omit' ),
-	isEmpty = require( 'lodash/isEmpty' );
+import classNames from 'classnames';
+import { isEmpty, omit } from 'lodash';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var Button = require( 'components/button' );
+import Button from 'components/button';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'FormsButton',
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			isSubmitting: false,
 			isPrimary: true,
@@ -24,21 +22,22 @@ module.exports = React.createClass( {
 		};
 	},
 
-	getDefaultButtonAction: function() {
+	getDefaultButtonAction() {
 		return this.props.isSubmitting ? this.translate( 'Saving…' ) : this.translate( 'Save Settings' );
 	},
 
-	render: function() {
-		var buttonClasses = classNames( {
-			'form-button': true
-		} );
+	render() {
+		const { children, className, isPrimary, ...props } = this.props,
+			buttonClasses = classNames( className, {
+				'form-button': true
+			} );
 
 		return (
 			<Button
-				{ ...omit( this.props, 'className' ) }
-				primary={ this.props.isPrimary }
-				className={ classnames( this.props.className, buttonClasses ) }>
-				{ isEmpty( this.props.children ) ? this.getDefaultButtonAction() : this.props.children }
+				{ ...omit( props, 'isSubmitting' ) }
+				primary={ isPrimary }
+				className={ buttonClasses }>
+				{ isEmpty( children ) ? this.getDefaultButtonAction() : children }
 			</Button>
 		);
 	}


### PR DESCRIPTION
Part of #7413.

Removes React warnings - Unknown props `isSubmitting` and `isPrimary`.
I also updated code to use ES6 syntax and removed Eslint warnings.

### Testing
There are multiplay ways to check it. One of them:
1. Go to Manage Purchases page (http://calypso.localhost:3000/purchases).
2. Select a purchase paid with credit card.
3. Click on Edit Payment Method link.
4. Make sure there are no warnings on the JS console complaining about unknown props `isSubmitting` and `isPrimary` in `<FormsButton />` component.

Test live: https://calypso.live/?branch=fix/forms-button-warnings