### PR TITLE
Jetpack Connect Plans: Always hide sidebar

### DIFF
--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -36,14 +36,18 @@ const sites = sitesFactory();
 const debug = new Debug( 'calypso:jetpack-connect:controller' );
 const userModule = userFactory();
 
-const jetpackConnectFirstStep = ( context, type ) => {
+const removeSidebar = ( context ) => {
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-
-	userModule.fetch();
 
 	context.store.dispatch( setSection( { name: 'jetpackConnect' }, {
 		hasSidebar: false
 	} ) );
+};
+
+const jetpackConnectFirstStep = ( context, type ) => {
+	removeSidebar( context );
+
+	userModule.fetch();
 
 	renderWithReduxStore(
 		React.createElement( JetpackConnect, {
@@ -131,10 +135,7 @@ export default {
 		const analyticsBasePath = 'jetpack/connect/authorize',
 			analyticsPageTitle = 'Jetpack Authorize';
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-		context.store.dispatch( setSection( { name: 'jetpack-connect' }, {
-			hasSidebar: false
-		} ) );
+		removeSidebar( context );
 
 		userModule.fetch();
 
@@ -155,10 +156,7 @@ export default {
 		const analyticsBasePath = '/jetpack/sso',
 			analyticsPageTitle = 'Jetpack SSO';
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-		context.store.dispatch( setSection( { name: 'jetpackConnect' }, {
-			hasSidebar: false
-		} ) );
+		removeSidebar( context );
 
 		userModule.fetch();
 
@@ -189,10 +187,7 @@ export default {
 			return;
 		}
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-		context.store.dispatch( setSection( { name: 'jetpackConnect' }, {
-			hasSidebar: false
-		} ) );
+		removeSidebar( context );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Plans', { textOnly: true } ) ) );

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -189,6 +189,11 @@ export default {
 			return;
 		}
 
+		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		context.store.dispatch( setSection( { name: 'jetpackConnect' }, {
+			hasSidebar: false
+		} ) );
+
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Plans', { textOnly: true } ) ) );
 


### PR DESCRIPTION
This PR addresses an issue with Jetpack Connect Plans, where sidebar can be visible in some cases. In this PR we make sure that the sidebar will always be hidden in the Jetpack Connect Plans page, like it is in the rest of the JPC flow. 

In addition, this PR enhances the code for removing the sidebar in the JPC flow by dedicating a method for that, and propagating that method where appropriate.

This PR fixes #7552.

To test:

* Checkout this branch
* Go to `/jetpack/connect/plans/$site`, where `$site` is a Jetpack site.
* Click on "My Sites" in the top navigation menu
* Hit your browser's "Back" button.
* Make sure you're viewing the JPC plans page.
* Verify that the sidebar is NOT visible.

/cc @roccotripaldi @johnHackworth

Test live: https://calypso.live/?branch=fix/jetpack-connect-plans-always-hide-sidebar