### PR TITLE
Posts: Cleaner Post Controls component

### DIFF
--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -53,18 +53,18 @@ class PostControls extends PureComponent {
 	}
 
 	buildControls( controls ) {
-		return controls.map( ( item, i ) => {
+		return controls.map( ( control, i ) => {
 			return (
 				<li key={ `controls-${this.props.post.ID}-${i}` }>
 					<a
-						href={ item.href }
-						className={ `post-controls__${item.className}` }
-						onClick={ item.onClick }
-						target={ item.target ? item.target : null }
+						href={ control.href }
+						className={ `post-controls__${control.className}` }
+						onClick={ control.onClick }
+						target={ control.target ? control.target : null }
 					>
-						<Gridicon icon={ item.icon } size={ 18 } />
+						<Gridicon icon={ control.icon } size={ 18 } />
 						<span>
-							{ item.text }
+							{ control.text }
 						</span>
 					</a>
 				</li>
@@ -73,8 +73,7 @@ class PostControls extends PureComponent {
 	}
 
 	setControls() {
-		const post = this.props.post;
-		const translate = this.props.translate;
+		const { post, translate } = this.props;
 		const controls = {
 			main: [],
 			more: [],

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import PureComponent from 'react-pure-render/component';
+import React, { PureComponent, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 
@@ -28,10 +27,6 @@ class PostControls extends PureComponent {
 		translate: PropTypes.func,
 	};
 
-	constructor() {
-		super( ...arguments );
-	}
-
 	view() {
 		ga.recordEvent( 'Posts', 'Clicked View Post' );
 	}
@@ -55,10 +50,10 @@ class PostControls extends PureComponent {
 	buildControls( controls ) {
 		return controls.map( ( control, i ) => {
 			return (
-				<li key={ `controls-${this.props.post.ID}-${i}` }>
+				<li key={ `controls-${ this.props.post.ID }-${ i }` }>
 					<a
 						href={ control.href }
-						className={ `post-controls__${control.className}` }
+						className={ `post-controls__${ control.className }` }
 						onClick={ control.onClick }
 						target={ control.target ? control.target : null }
 					>
@@ -105,9 +100,9 @@ class PostControls extends PureComponent {
 
 			let statsUrl;
 			if ( config.isEnabled( 'manage/stats' ) ) {
-				statsUrl = `/stats/post/${post.ID}/${this.props.site.slug}`;
+				statsUrl = `/stats/post/${ post.ID }/${ this.props.site.slug }`;
 			} else {
-				statsUrl = `//wordpress.com/my-stats/?view=post&post=${post.ID}&blog=${post.site_ID}`;
+				statsUrl = `//wordpress.com/my-stats/?view=post&post=${ post.ID }&blog=${ post.site_ID }`;
 			}
 			controls.main.push( {
 				text: translate( 'Stats' ),

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -4,6 +4,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import url from 'url';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -39,15 +40,11 @@ class PostControls extends PureComponent {
 		ga.recordEvent( 'Posts', 'Clicked Edit Post' );
 	}
 
-	copy() {
-		ga.recordEvent( 'Posts', 'Clicked Copy Post' );
-	}
-
 	viewStats() {
 		ga.recordEvent( 'Posts', 'Clicked View Post Stats' );
 	}
 
-	buildControls( controls ) {
+	getControlElements( controls ) {
 		return controls.map( ( control, i ) => {
 			return (
 				<li key={ `controls-${ this.props.post.ID }-${ i }` }>
@@ -67,7 +64,7 @@ class PostControls extends PureComponent {
 		} );
 	}
 
-	setControls() {
+	getAvailableControls() {
 		const { post, translate } = this.props;
 		const controls = {
 			main: [],
@@ -161,16 +158,6 @@ class PostControls extends PureComponent {
 			}
 		}
 
-		if ( 'publish' === post.status && utils.userCan( 'edit_post', post ) ) {
-			controls.main.push( {
-				text: translate( 'Copy' ),
-				className: 'copy',
-				href: `/post/${ this.props.site.slug }?copy=${ post.ID }`,
-				onClick: this.copy,
-				icon: 'clipboard',
-			} );
-		}
-
 		// More Controls (behind ... more link)
 		if ( ( controls.main.length > 2 && ! this.props.fullWidth ) || ( controls.main.length > 4 && this.props.fullWidth ) ) {
 			const moreControlsSpliceIndex = ( ! this.props.fullWidth ) ? 2 : 4;
@@ -203,30 +190,28 @@ class PostControls extends PureComponent {
 	}
 
 	render() {
-		const controls = this.setControls();
-		let postControlsClass = 'post-controls';
+		const controls = this.getAvailableControls();
+		const className = classNames( 'post-controls', {
+			'post-controls--desk-nomore': controls.more.length <= 2
+		} );
 
 		if ( controls.more.length ) {
-			if ( controls.more.length <= 2 ) {
-				postControlsClass += ' post-controls--desk-nomore';
-			}
-
 			return (
-				<div className={ postControlsClass }>
+				<div className={ className }>
 					<ul className="posts__post-controls post-controls__pane post-controls__more-options">
-						{ this.buildControls( controls.more ) }
+						{ this.getControlElements( controls.more ) }
 					</ul>
 					<ul className="posts__post-controls post-controls__pane post-controls__main-options">
-						{ this.buildControls( controls.main ) }
+						{ this.getControlElements( controls.main ) }
 					</ul>
 				</div>
 			);
 		}
 
 		return (
-			<div className={ postControlsClass }>
+			<div className={ className }>
 				<ul className="posts__post-controls post-controls__pane post-controls__main-options">
-					{ this.buildControls( controls.main ) }
+					{ this.getControlElements( controls.main ) }
 				</ul>
 			</div>
 		);


### PR DESCRIPTION
cc @aduth, @nb  (see: https://github.com/Automattic/wp-calypso/pull/7451#discussion_r74931463)

I rewrote the component in ES6 and moved the controls logic out of the `render` method for improved readability.
There is also a Copy control ready for the Copy Post functionality, so that this refactor could be merged right after the Copy Post merge.
