### PR TITLE
Billing History: Expect transaction items to not exist

### DIFF
--- a/client/me/billing-history/table-rows.js
+++ b/client/me/billing-history/table-rows.js
@@ -14,7 +14,8 @@ function formatDate( date ) {
 
 function getSearchableStrings( transaction ) {
 	var rootStrings = values( omit( transaction, 'items' ) ),
-		itemStrings = flatten( transaction.items.map( values ) );
+		transactionItems = transaction.items || [],
+		itemStrings = flatten( transactionItems.map( values ) );
 
 	return rootStrings.concat( itemStrings );
 }


### PR DESCRIPTION
This PR fixes #7575, where the the Upcoming Charges search form does not work due to the fact that `items` do not exist for upcoming charge transactions.

To test: 

* Checkout this branch.
* Head to: `/me/billing`.
* Make sure you have at least one upcoming charge.
* Type anything in the search form within the "Upcoming Charges" card.
* Verify the Upcoming Charges search form works correctly, and results are presented accordingly
* Verify the top transaction search form works as expected, too.

/cc @ryelle @oskosk 

Test live: https://calypso.live/?branch=fix/billing-history-upcoming-charges-searchform