### PR TITLE
CountedTextarea: fix unknown prop warning

### DIFF
--- a/client/components/forms/counted-textarea/index.jsx
+++ b/client/components/forms/counted-textarea/index.jsx
@@ -70,7 +70,14 @@ export default React.createClass( {
 		return (
 			<div className={ classes }>
 				<FormTextarea
-					{ ...omit( this.props, 'className', 'acceptableLength', 'showRemainingCharacters', 'children' ) }
+					{ ...omit(
+						this.props,
+						'className',
+						'acceptableLength',
+						'showRemainingCharacters',
+						'children',
+						'countPlaceholderLength'
+					) }
 					className="counted-textarea__input" />
 				{ this.renderCountPanel() }
 			</div>


### PR DESCRIPTION
Omit `countPlaceholderLength` from `<textarea>` props.

See: https://github.com/Automattic/wp-calypso/issues/7413

Test live: https://calypso.live/?branch=fix/counted-textarea-props-warnings