### PR TITLE
FormTextInputWithAffixes: fix unknown prop warning

### DIFF
--- a/client/components/forms/form-text-input-with-affixes/index.jsx
+++ b/client/components/forms/form-text-input-with-affixes/index.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from  'classnames';
-import omit from 'lodash/omit';
+import classNames from 'classnames';
+import { keys, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +28,7 @@ export default React.createClass( {
 					</span>
 				) }
 
-				<FormTextInput { ...omit( this.props, this.constructor.propTypes ) } />
+				<FormTextInput { ...omit( this.props, keys( this.constructor.propTypes ) ) } />
 
 				{ this.props.suffix && (
 					<span className="form-text-input-with-affixes__suffix">


### PR DESCRIPTION
Changed second `_.omit` argument to be an array of strings (object keys) instead of an object.

See: https://github.com/Automattic/wp-calypso/issues/7413

Test live: https://calypso.live/?branch=fix/form-text-input-with-affixes-props-warnings