### PR TITLE
Framework: Render controller elements with store context

### DIFF
--- a/client/mailing-lists/controller.js
+++ b/client/mailing-lists/controller.js
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import omit from 'lodash/omit';
-import ReactDom from 'react-dom';
 import React from 'react';
 import { setSection } from 'state/ui/actions';
 
@@ -10,6 +9,7 @@ import { setSection } from 'state/ui/actions';
  * Internal Dependencies
  */
 import MainComponent from './main';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 export default {
 	unsubscribe( context ) {
@@ -18,14 +18,15 @@ export default {
 			hasSidebar: false
 		} ) );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( MainComponent, {
 				email: context.query.email,
 				category: context.query.category,
 				hmac: context.query.hmac,
 				context: omit( context.query, [ 'email', 'category', 'hmac' ] )
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 };

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -4,7 +4,6 @@
 import page from 'page';
 import ReactDom from 'react-dom';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 import i18n from 'i18n-calypso';
 
 /**
@@ -29,6 +28,7 @@ import siteStatsStickyTabActions from 'lib/site-stats-sticky-tab/actions';
 import utils from 'lib/site/utils';
 import trackScrollPage from 'lib/track-scroll-page';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 /**
  * Module vars
@@ -51,13 +51,11 @@ function createNavigation( context ) {
 	}
 
 	return (
-		<ReduxProvider store={ context.store }>
-			<NavigationComponent path={ context.path }
-				allSitesPath={ basePath }
-				siteBasePath={ basePath }
-				user={ user }
-				sites={ sites } />
-		</ReduxProvider>
+		<NavigationComponent path={ context.path }
+			allSitesPath={ basePath }
+			siteBasePath={ basePath }
+			user={ user }
+			sites={ sites } />
 	);
 }
 
@@ -74,9 +72,10 @@ function renderEmptySites( context ) {
 
 	removeSidebar( context );
 
-	ReactDom.render(
+	renderWithReduxStore(
 		React.createElement( NoSitesMessage ),
-		document.getElementById( 'primary' )
+		document.getElementById( 'primary' ),
+		context.store
 	);
 }
 
@@ -88,7 +87,7 @@ function renderNoVisibleSites( context ) {
 
 	removeSidebar( context );
 
-	ReactDom.render(
+	renderWithReduxStore(
 		React.createElement( EmptyContentComponent, {
 			title: i18n.translate( 'You have %(hidden)d hidden WordPress site.', 'You have %(hidden)d hidden WordPress sites.', {
 				count: hiddenSites,
@@ -104,7 +103,8 @@ function renderNoVisibleSites( context ) {
 			secondaryAction: i18n.translate( 'Create New Site' ),
 			secondaryActionURL: `${ signup_url }?ref=calypso-nosites`
 		} ),
-		document.getElementById( 'primary' )
+		document.getElementById( 'primary' ),
+		context.store
 	);
 }
 
@@ -265,9 +265,10 @@ module.exports = {
 
 	navigation: function( context, next ) {
 		// Render the My Sites navigation in #secondary
-		ReactDom.render(
+		renderWithReduxStore(
 			createNavigation( context ),
-			document.getElementById( 'secondary' )
+			document.getElementById( 'secondary' ),
+			context.store
 		);
 		next();
 	},
@@ -279,14 +280,14 @@ module.exports = {
 		const selectedSite = sites.getSelectedSite();
 
 		if ( selectedSite && selectedSite.jetpack ) {
-			ReactDom.render( (
+			renderWithReduxStore( (
 				<Main>
 					<JetpackManageErrorPage
 						template="noDomainsOnJetpack"
 						site={ sites.getSelectedSite() }
 					/>
 				</Main>
-			), document.getElementById( 'primary' ) );
+			), document.getElementById( 'primary' ), context.store );
 
 			analytics.pageView.record( basePath, '> No Domains On Jetpack' );
 		} else {
@@ -314,7 +315,7 @@ module.exports = {
 
 		analytics.pageView.record( basePath, analyticsPageTitle );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( SitesComponent, {
 				sites,
 				path: context.path,
@@ -328,7 +329,8 @@ module.exports = {
 					'Sites'
 				)
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 };

--- a/client/my-sites/drafts/controller.js
+++ b/client/my-sites/drafts/controller.js
@@ -1,8 +1,7 @@
 /**
  * External Dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react'),
+var React = require( 'react'),
 	i18n = require( 'i18n-calypso' );
 
 /**
@@ -11,6 +10,7 @@ var ReactDom = require( 'react-dom' ),
 var sites = require( 'lib/sites-list' )(),
 	route = require( 'lib/route' );
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 module.exports = {
 
@@ -21,13 +21,14 @@ module.exports = {
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Drafts', { textOnly: true } ) ) );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( Drafts, {
 				siteID: siteID,
 				sites: sites,
 				trackScrollPage: function() {}
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 

--- a/client/my-sites/drafts/controller.js
+++ b/client/my-sites/drafts/controller.js
@@ -1,16 +1,18 @@
 /**
  * External Dependencies
  */
-var React = require( 'react'),
-	i18n = require( 'i18n-calypso' );
+import React from 'react';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-var sites = require( 'lib/sites-list' )(),
-	route = require( 'lib/route' );
+import sitesFactory from 'lib/sites-list';
+import route from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
+
+const sites = sitesFactory();
 
 module.exports = {
 

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -1,8 +1,7 @@
 /**
  * External Dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react'),
+var React = require( 'react' ),
 	i18n = require( 'i18n-calypso' );
 
 /**
@@ -12,6 +11,7 @@ var sites = require( 'lib/sites-list' )(),
 	route = require( 'lib/route' ),
 	analytics = require( 'lib/analytics' );
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 module.exports = {
 
@@ -32,13 +32,14 @@ module.exports = {
 		context.store.dispatch( setTitle( i18n.translate( 'Media', { textOnly: true } ) ) );
 
 		// Render
-		ReactDom.render(
+		renderWithReduxStore(
 			React.createElement( MediaComponent, {
 				sites: sites,
 				filter: filter,
 				search: search
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -1,17 +1,19 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' ),
-	i18n = require( 'i18n-calypso' );
+import React from 'react';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-var sites = require( 'lib/sites-list' )(),
-	route = require( 'lib/route' ),
-	analytics = require( 'lib/analytics' );
+import sitesFactory from 'lib/sites-list';
+import route from 'lib/route';
+import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
+
+const sites = sitesFactory();
 
 module.exports = {
 

--- a/client/my-sites/menus/controller.js
+++ b/client/my-sites/menus/controller.js
@@ -1,25 +1,25 @@
 /**
  * External Dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react'),
-	i18n = require( 'i18n-calypso' ),
-	ReactRedux = require( 'react-redux' );
+import React from 'react';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-var sites = require( 'lib/sites-list' )(),
-	route = require( 'lib/route' ),
-	analytics = require( 'lib/analytics' ),
-	MainComponent = require( 'components/main' ),
-	JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' ),
-	itemTypes = require( 'my-sites/menus/menu-item-types' ),
-	MenusComponent = require( 'my-sites/menus/main' ),
-	notices = require( 'notices' ),
-	siteMenus = require( 'lib/menu-data' );
+import sitesFactory from 'lib/sites-list';
+import route from 'lib/route';
+import analytics from 'lib/analytics';
+import MainComponent from 'components/main';
+import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import itemTypes from 'my-sites/menus/menu-item-types';
+import MenusComponent from 'my-sites/menus/main';
+import notices from 'notices';
+import siteMenus from 'lib/menu-data';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
+
+const sites = sitesFactory();
 
 var controller = {
 
@@ -68,16 +68,15 @@ var controller = {
 
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-		ReactDom.render(
-			React.createElement( ReactRedux.Provider, { store: context.store },
-				React.createElement( MenusComponent, {
-					siteMenus: siteMenus,
-					itemTypes: itemTypes,
-					key: siteMenus.siteID,
-					site: site
-				} )
-			),
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			React.createElement( MenusComponent, {
+				siteMenus: siteMenus,
+				itemTypes: itemTypes,
+				key: siteMenus.siteID,
+				site: site
+			} ),
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	}
 

--- a/client/my-sites/menus/controller.js
+++ b/client/my-sites/menus/controller.js
@@ -19,6 +19,7 @@ var sites = require( 'lib/sites-list' )(),
 	notices = require( 'notices' ),
 	siteMenus = require( 'lib/menu-data' );
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 var controller = {
 
@@ -37,7 +38,7 @@ var controller = {
 		context.store.dispatch( setTitle( i18n.translate( 'Menus', { textOnly: true } ) ) );
 
 		function renderJetpackUpgradeMessage() {
-			ReactDom.render(
+			renderWithReduxStore(
 				React.createElement( MainComponent, null,
 					React.createElement( JetpackManageErrorPage, {
 						template: 'updateJetpack',
@@ -49,7 +50,8 @@ var controller = {
 						secondaryActionTarget: '_blank'
 					} )
 				),
-				document.getElementById( 'primary' )
+				document.getElementById( 'primary' ),
+				context.store
 			);
 		}
 

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -3,7 +3,6 @@
  */
 import page from 'page';
 import React from 'react';
-import ReactDom from 'react-dom';
 import i18n from 'i18n-calypso';
 
 /**
@@ -35,7 +34,7 @@ export default {
 		if ( site && site.jetpack && ! isEnabled( 'manage/jetpack-plans' ) ) {
 			analytics.pageView.record( basePath + '/jetpack/:site', analyticsPageTitle + ' > Jetpack Plans Not Available' );
 
-			ReactDom.render(
+			renderWithReduxStore(
 				React.createElement( MainComponent, null,
 					React.createElement( EmptyContentComponent, {
 						title: i18n.translate( 'Plans are not available for Jetpack sites yet.' ),
@@ -45,7 +44,8 @@ export default {
 						illustration: '/calypso/images/drake/drake-nomenus.svg'
 					} )
 				),
-				document.getElementById( 'primary' )
+				document.getElementById( 'primary' ),
+				context.store
 			);
 			return;
 		}

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -142,7 +142,7 @@ module.exports = {
 
 		analytics.pageView.record( '/domains/add/:site/google-apps', 'Domain Search > Domain Registration > Google Apps' );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			(
 				<Main>
 					<CartData>
@@ -155,7 +155,8 @@ module.exports = {
 					</CartData>
 				</Main>
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 


### PR DESCRIPTION
This pull request is effectively the cherry-picked 152e2d25db9b97d2b198aeb591b73380e13a575d commit from #7478, with merge conflict resolutions. #7478 was reverted in #7556 for reasons unrelated to the context provider wrapping. Since this was a general maintenance change and effort is in-progress for the reintroducing the changes from #7478, I thought it made sense to create a separate pull request for these changes.

__Testing instructions:__

Ensure that there are no regressions in the affected sections of these changes:
- Mailing list
- My sites (sidebar)
- Drafts
- Media
- Menus
- Plans
- Upgrades

/cc @gwwar, @sirbrillig, @ockham (merge conflicts with #7224)

Test live: https://calypso.live/?branch=update/redux-provider-controllers