### PR TITLE
JS Errors: Enable on prod

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -14,7 +14,7 @@
 		"accept-invite": true,
 		"ad-tracking": true,
 		"brazil-survey-invitation": false,
-		"catch-js-errors": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,


### PR DESCRIPTION
We have previously disabled JS-Error logging on prod because of the JS Error endpoint bonanza, We re-enabled it here: pMz3w-5VV-p2

Now we seek to open the floodgates again. for everyone.

## Testing

1. Break something in code
2. Build with catch js errors flag `ENABLE_FEATURES=catch-js-errors make run`
3. Navigate to the place you broke stuff
4. See that there is a call to `js-error` endpoint in console
5. Navigate to ac61f9619e91b6cbc515b990a473a9e5-logstash and see your error

CC @rralian @nylen @gwwar @klimeryk @lamosty 



Test live: https://calypso.live/?branch=update/js-errors-enable