### PR TITLE
Jetpack Connect Plans: Minor formatting & punctuation updates

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -501,7 +501,7 @@ export const featuresList = {
 		getSlug: () => FEATURE_STANDARD_SECURITY_TOOLS,
 		getTitle: () => i18n.translate( 'Standard Security Tools' ),
 		getDescription: () => i18n.translate(
-			'Brute force protection, uptime monitoring, secure sign on,' +
+			'Brute force protection, uptime monitoring, secure sign on, ' +
 			'and automatic updates for your plugins.'
 		)
 	},

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -149,7 +149,7 @@ const Plans = React.createClass( {
 						<ConnectHeader
 							showLogo={ false }
 							headerText={ this.translate( 'Your site is now connected!' ) }
-							subHeaderText={ this.translate( 'Now pick a plan that\'s right for you' ) }
+							subHeaderText={ this.translate( 'Now pick a plan that\'s right for you.' ) }
 							step={ 1 }
 							steps={ 3 } />
 


### PR DESCRIPTION
This PR applies small textual (formatting and punctuation) updates to .org Plans.

### 1 - Space after the comma after `secure sign on`.

**Before:**
![](https://cldup.com/qaswjxQJW9.png)

**After:**
![](https://cldup.com/7D0d83skAH.png)

### 2 - Full stop at the end of the description text `Now pick a plan that's right for you`.

**Before:**
![](https://cldup.com/ZDOD7cK74x-3000x3000.png)

**After:**
![](https://cldup.com/vv5qawYcrf.png)

Both enhancements can be seen on `/jetpack/connect/plans/$site`.

/cc @roccotripaldi @ryelle

Test live: https://calypso.live/?branch=update/jetpack-connect-minor-punctuation-fixes