### PR TITLE
Components: Update documentation and example of ProgressBar with isPulsing

### DIFF
--- a/client/components/progress-bar/README.md
+++ b/client/components/progress-bar/README.md
@@ -28,3 +28,4 @@ render: function() {
 * `title`: a string for the title attribute (optional).
 * `compact`: If true, displays as a compact progress bar (optional).
 * `className`: You can add classes to either (optional).
+* `isPulsing`: If true, will add a barber pole animation to the value part of the bar (optional).

--- a/client/components/progress-bar/docs/example.jsx
+++ b/client/components/progress-bar/docs/example.jsx
@@ -37,6 +37,7 @@ module.exports = React.createClass( {
 				<ProgressBar value={ 0 } title="0% complete" compact={ this.state.compact } />
 				<ProgressBar value={ 55 } total={ 100 } compact={ this.state.compact } />
 				<ProgressBar value={ 100 } color="#1BABDA" compact={ this.state.compact } />
+				<ProgressBar value={ 75 } compact={ this.state.compact } isPulsing />
 			</div>
 		);
 	}

--- a/client/components/progress-bar/docs/example.jsx
+++ b/client/components/progress-bar/docs/example.jsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-var ProgressBar = require( 'components/progress-bar' );
+import ProgressBar from 'components/progress-bar';
 
 module.exports = React.createClass( {
 
@@ -18,7 +18,7 @@ module.exports = React.createClass( {
 	getInitialState() {
 		return {
 			compact: false
-		}
+		};
 	},
 
 	toggleCompact() {


### PR DESCRIPTION
Closes #7278

Updates documentation and adds example to devdocs for the `isPulsing` property of `ProgressBar`, which was added in #7258 and #7379.

To test:

- Check README for formatting
- Go to `calypso.localhost:3000/devdocs/design/progress-bar` and check example

Test live: https://calypso.live/?branch=update/document-progress-bar-pulsing

cc @lezama or @rickybanister for review.