### PR TITLE
devdocs: do not render filtered component instance.

### DIFF
--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -21,10 +21,16 @@ const Hider = React.createClass( {
 	},
 
 	render() {
+		if ( this.props.hide ) {
+			return null;
+		}
+
 		return (
 			<div
-				className={ config.isEnabled( 'devdocs/usage-counts' ) ? 'design-assets__group' : null }
-				style={ this.props.hide ? { display: 'none' } : {} }
+				className={ config.isEnabled( 'devdocs/usage-counts' )
+					? 'design-assets__group'
+					: null
+				}
 			>
 				{ this.props.children }
 			</div>


### PR DESCRIPTION
Do not render filtered instances instead of hiding them through css styles.

It will improve component isolation when we have to test it. For instance, right now, you will see a lot of react Warnings beyond of what is the current component (#7413).
Also it will improve the performance since we won't be creating unneeded instances.

cc @aduth 

Test live: https://calypso.live/?branch=improve/devdocs-design-page