### PR TITLE
Signup: don't show email nudge before checkout

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -94,5 +94,13 @@ module.exports = {
 			targetedWording: 50
 		},
 		defaultVariation: 'originalWording'
-	}
+	},
+	paidNuxStreamlined: {
+		datestamp: '20160825',
+		variations: {
+			original: 100,
+			streamlined: 0,
+		},
+		defaultVariation: 'original',
+	},
 };

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -64,7 +64,8 @@ const Signup = React.createClass( {
 			loadingScreenStartTime: undefined,
 			resumingStep: undefined,
 			user: user.get(),
-			loginHandler: null
+			loginHandler: null,
+			hasCartItems: false,
 		};
 	},
 
@@ -132,16 +133,30 @@ const Signup = React.createClass( {
 			);
 		}
 
+		this.checkForCartItems( this.props.signupDependencies );
+
 		this.recordStep();
 	},
 
-	componentWillReceiveProps( { stepName } ) {
+	componentWillReceiveProps( { signupDependencies, stepName } ) {
 		if ( this.props.stepName !== stepName ) {
 			this.recordStep( stepName );
 		}
 
 		if ( stepName === this.state.resumingStep ) {
 			this.setState( { resumingStep: undefined } );
+		}
+
+		this.checkForCartItems( signupDependencies );
+	},
+
+	checkForCartItems( signupDependencies ) {
+		const dependenciesContainCartItem = ( dependencies ) => {
+			return dependencies && ( dependencies.cartItem || dependencies.domainItem || dependencies.themeItem );
+		};
+
+		if ( dependenciesContainCartItem( signupDependencies ) ) {
+			this.setState( { hasCartItems: true } );
 		}
 	},
 
@@ -327,9 +342,13 @@ const Signup = React.createClass( {
 			<div className="signup__step" key={ stepKey }>
 				{ this.localeSuggestions() }
 				{
-					this.state.loadingScreenStartTime ?
-					<SignupProcessingScreen steps={ this.state.progress } user={ this.state.user } loginHandler={ this.state.loginHandler }/> :
-					<CurrentComponent
+					this.state.loadingScreenStartTime
+					? <SignupProcessingScreen
+						hasCartItems={ this.state.hasCartItems }
+						steps={ this.state.progress }
+						user={ this.state.user }
+						loginHandler={ this.state.loginHandler }/>
+					: <CurrentComponent
 						path={ this.props.path }
 						step={ currentStepProgress }
 						steps={ flow.steps }

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies
  */
@@ -7,11 +6,20 @@ var React = require( 'react' ),
 	Gridicon = require( 'components/gridicon' ),
 	Notice = require( 'components/notice' );
 
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+
 module.exports = React.createClass( {
 	displayName: 'SignupProcessingScreen',
 
 	renderConfirmationNotice: function() {
 		if ( this.props.user && this.props.user.email_verified ) {
+			return;
+		}
+
+		if ( this.props.hasCartItems && abtest( 'paidNuxStreamlined' ) === 'streamlined' ) {
 			return;
 		}
 


### PR DESCRIPTION
Currently, both paying and free users are shown the "please verify your email" nudge in the "processing" screen. If a user has a plan in their cart, verifying their email before they have completed checkout might divert them from checkout. This changes the email nudge to be shown only if there is nothing in the cart. For these users, a separate change will re-introduce the nudge on the thank-you page after checkout.

TODO:

- [x] add A/B test
- [x] fix: when "processing" is done, the cart gets emptied, props get updated, and components re-rendered ... making the nudge re-appear even though it was hidden before (and should stay hidden)
- [x] write "to test:" instructions

To test:

- open an incognito window and go to http://calypso.localhost:3000/start
- from the A/B tests dropdown, select `paidNuxStreamlined: streamlined`
- go through signup
- choose a paid plan or the free plan
- when you reach the processing screen, make sure:
	- if you chose the free plan the email nudge should be there
	- if you chose the paid plan there should be no email nudge

with the nudge: 

![nudge](https://cloud.githubusercontent.com/assets/23619/17962664/2b8e9074-6ab2-11e6-91d9-b32cb507deef.gif)

without the nudge:

![no-nudge](https://cloud.githubusercontent.com/assets/23619/17962671/308d3012-6ab2-11e6-9d3f-41a1f9ba78f6.gif)

Test live: https://calypso.live/?branch=update/signup-dont-show-email-nudge-before-checkout
