### PR TITLE
Plans: Auto Redirect to checkout for premium

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -52,6 +52,15 @@ module.exports = {
 		defaultVariation: 'ascendingPriceSubtleDescription',
 		allowExistingUsers: false,
 	},
+	signupCheckoutRedirect: {
+		datestamp: '20160826',
+		variations: {
+			auto: 50,
+			manual: 50,
+		},
+		defaultVariation: 'manual',
+		allowExistingUsers: false,
+	},
 	signupStore: {
 		datestamp: '20160727',
 		variations: {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -41,6 +41,7 @@ import utils from './utils';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import * as oauthToken from 'lib/oauth-token';
+import { abtest } from 'lib/abtest';
 
 /**
  * Constants
@@ -105,7 +106,7 @@ const Signup = React.createClass( {
 					: undefined;
 				const filteredDestination = utils.getDestination( destination, dependencies, this.props.flowName );
 				let loadingScreenDelay;
-				if ( dependencies.cartItem ) {
+				if ( dependencies.cartItem && abtest( 'signupCheckoutRedirect' ) === 'auto' ) {
 					loadingScreenDelay = MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_PREMIUM;
 				} else {
 					loadingScreenDelay = MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_FREE;
@@ -177,7 +178,7 @@ const Signup = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
 
 		this.signupFlowController.reset();
-		if ( dependencies.cartItem ) {
+		if ( dependencies.cartItem && abtest( 'signupCheckoutRedirect' ) === 'auto' ) {
 			this.handleLogin( dependencies, destination );
 		} else {
 			this.setState( {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -170,7 +170,7 @@ const Signup = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
 
 		this.signupFlowController.reset();
-
+		this.handleLogin( dependencies, destination );
 		this.setState( {
 			loginHandler: this.handleLogin.bind( this, dependencies, destination )
 		} );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -170,10 +170,13 @@ const Signup = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
 
 		this.signupFlowController.reset();
-		this.handleLogin( dependencies, destination );
-		this.setState( {
-			loginHandler: this.handleLogin.bind( this, dependencies, destination )
-		} );
+		if ( dependencies.cartItem ) {
+			this.handleLogin( dependencies, destination );
+		} else {
+			this.setState( {
+				loginHandler: this.handleLogin.bind( this, dependencies, destination )
+			} );
+		}
 	},
 
 	handleLogin( dependencies, destination ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -45,7 +45,8 @@ import * as oauthToken from 'lib/oauth-token';
 /**
  * Constants
  */
-const MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED = 8000;
+const MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_FREE = 8000;
+const MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_PREMIUM = 3000;
 
 const Signup = React.createClass( {
 	displayName: 'Signup',
@@ -103,11 +104,17 @@ const Signup = React.createClass( {
 					? Date.now() - this.state.loadingScreenStartTime
 					: undefined;
 				const filteredDestination = utils.getDestination( destination, dependencies, this.props.flowName );
+				let loadingScreenDelay;
+				if ( dependencies.cartItem ) {
+					loadingScreenDelay = MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_PREMIUM;
+				} else {
+					loadingScreenDelay = MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_FREE;
+				}
 
-				if ( timeSinceLoading && timeSinceLoading < MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED ) {
+				if ( timeSinceLoading && timeSinceLoading < loadingScreenDelay ) {
 					return delay(
 						this.handleFlowComplete.bind( this, dependencies, filteredDestination ),
-						MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED - timeSinceLoading
+						loadingScreenDelay - timeSinceLoading
 					);
 				}
 				return this.handleFlowComplete( dependencies, filteredDestination );


### PR DESCRIPTION
# Problem

Currently in the checkout flow, there are following (amongst others)  steps:
1. Choose a plan
2. Choose login, pwd, email
3. Wait 8+ seconds while watching "we're setting up your site"
4. CLICK A BUTTON WHILE BEING DISTRACTED BY ENCOURAGEMENT TO CHECK YOUR EMAIL
5. Provide CC info to actually give us money

# Solution

This PR removes 5 if you have selected a plan
[Video demo](https://cloudup.com/cSZSnYmyGQD)

# Testing 

1. Use incognito (to be a new user)
2. Assign yourself signupCheckoutRedirect:auto test
3. Go through checkout, selecting a free plan
4. See that behaviour is not changed
5. Go through checkout, selecting any plan
6. See that button "clicks itself"

CC @rralian @lamosty @gwwar @shaunandrews 
