### PR TITLE
Components: Use Children.count in FormsButton component

### DIFF
--- a/client/components/forms/form-button/index.jsx
+++ b/client/components/forms/form-button/index.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { isEmpty, omit } from 'lodash';
-import React from 'react';
+import { omit } from 'lodash';
+import React, { Children } from 'react';
 
 /**
  * Internal dependencies
@@ -37,7 +37,7 @@ export default React.createClass( {
 				{ ...omit( props, 'isSubmitting' ) }
 				primary={ isPrimary }
 				className={ buttonClasses }>
-				{ isEmpty( children ) ? this.getDefaultButtonAction() : children }
+				{ Children.count( children ) ? children : this.getDefaultButtonAction() }
 			</Button>
 		);
 	}


### PR DESCRIPTION
Follow up for #7572

It fixes one more issue pointed out by @aduth:

> Unrelated to this pull request since it existed previously, but I wonder:
> - Is `children` valid to be specified as a `getDefaultProps` value?
> - Otherwise, the more correct way to check emptiness of children is probably `React.Children.count( children ) > 0` ([docs](https://facebook.github.io/react/docs/top-level-api.html#react.children.count)), given its "opaque data structure"

I preferred second solution because default button depends on props, so most likely it wouldn't work properly. 

### Testing
There are multiplay ways to check it. One of them:
1. Go to Manage Purchases page (http://calypso.localhost:3000/purchases).
2. Select a purchase paid with credit card.
3. Click on Edit Payment Method link.
4. Make sure there are no warnings on the JS console complaining about unknown props `isSubmitting` and `isPrimary` in `<FormsButton />` component.

Test live: https://calypso.live/?branch=fix/forms-button-children