### PR TITLE
Site Settings: Display CPT fields with upgrade notice for older Jetpack

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -190,7 +190,7 @@ const SiteSettingsFormWriting = React.createClass( {
 					}
 				</Card>
 
-				{ config.isEnabled( 'manage/custom-post-types' ) && this.props.jetpackVersionSupportsCustomTypes && (
+				{ config.isEnabled( 'manage/custom-post-types' ) && (
 					<div>
 						{ this.renderSectionHeader( this.translate( 'Custom Content Types' ) ) }
 						<Card className="site-settings">


### PR DESCRIPTION
This pull request effectively reverts #7466, which disabled the display of custom post types writing settings field for Jetpack versions older than 4.2, since at the time the latest version had not yet been released.

With these changes, Jetpack sites running older than version 4.2 will be prompted to upgrade their plugin, with the fields shown as disabled.

![Prompt](https://cloud.githubusercontent.com/assets/1779930/17146515/ce8fa062-532c-11e6-8a56-1276918716d9.png)

**Caveats:**

The experience of upgrading is non-ideal, for two reasons:
- When clicking Back after upgrading the plugin, the path is not correct so a blank screen is shown
- When arriving at the writing settings screen immediately after upgrading, the upgrade notice may still be shown. Only a full refresh will allow control over the toggles.

I would likely consider these bugs to be blockers for the merging of this pull request.

**Testing instructions:**

Verify that there are no regressions in current use of [custom post types writing settings](http://calypso.localhost:3000/settings/writing) for WordPress.com sites and sites running Jetpack 4.2 and newer. Ensure that an upgrade prompt is shown when the site is running Jetpack 4.1.1 or older ([zip download](https://downloads.wordpress.org/plugin/jetpack.4.1.1.zip)).

Test live: https://calypso.live/?branch=update/cpt-settings-enable-jetpack
