### PR TITLE
Help: Create page at /help/courses with placeholders for course content and…

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -162,6 +162,7 @@
 @import 'me/help/help-contact-confirmation/style';
 @import 'me/help/help-contact/style';
 @import 'me/help/help-contact-form/style';
+@import 'me/help/help-courses/style';
 @import 'me/help/help-unverified-warning/style';
 @import 'me/help/help-happiness-engineers/style';
 @import 'me/help/help-results/style';

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -14,26 +14,41 @@ import route from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import config from 'config';
 import { renderWithReduxStore } from 'lib/react-helpers';
+import HelpComponent from './main';
+import CoursesComponent from './help-courses';
+import ContactComponent from './help-contact';
 
-module.exports = {
-	help: function( context ) {
-		var Help = require( './main' ),
-			basePath = route.sectionify( context.path );
+export default {
+	help( context ) {
+		const basePath = route.sectionify( context.path );
 
-		context.store.dispatch( setTitle( i18n.translate( 'Help', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Help', { textOnly: true } ) ) );
 
 		analytics.pageView.record( basePath, 'Help' );
 
 		renderWithReduxStore(
-			React.createElement( Help ),
+			React.createElement( HelpComponent ),
 			document.getElementById( 'primary' ),
 			context.store
 		);
 	},
 
-	contact: function( context ) {
-		var ContactComponent = require( './help-contact' ),
-			basePath = route.sectionify( context.path );
+	courses( context ) {
+		const basePath = route.sectionify( context.path );
+
+		analytics.pageView.record( basePath, 'Help > Courses' );
+
+		ReactDom.render(
+			<ReduxProvider store={ context.store } >
+				<CoursesComponent />
+			</ReduxProvider>,
+			document.getElementById( 'primary' )
+		);
+	},
+
+	contact( context ) {
+		const basePath = route.sectionify( context.path );
 
 		analytics.pageView.record( basePath, 'Help > Contact' );
 

--- a/client/me/help/help-courses/course-list.jsx
+++ b/client/me/help/help-courses/course-list.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+
+class CourseList extends Component {
+	render() {
+		return (
+			<Card className="help-courses__course-list">
+				Course list: visible to all
+			</Card>
+		);
+	}
+}
+
+export const CourseListPlaceholder = () => {
+	return <Card className="help-courses__course-list is-placeholder"></Card>;
+};
+
+export default localize( CourseList );

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import Card from 'components/card';
+
+class Course extends Component {
+	render() {
+		return (
+			<Card className="help-courses__course">
+				Latest course: Only visible for users with the business plan
+			</Card>
+		);
+	}
+}
+
+export const CoursePlaceholder = () => {
+	return (
+		<Card className="help-courses__course is-placeholder"></Card>
+	);
+};
+
+export default localize( Course );

--- a/client/me/help/help-courses/courses.jsx
+++ b/client/me/help/help-courses/courses.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import HeaderCake from 'components/header-cake';
+import CourseList, { CourseListPlaceholder } from './course-list';
+import Course, { CoursePlaceholder } from './course';
+import QueryUserPurchases from 'components/data/query-user-purchases';
+
+class Courses extends Component {
+	render() {
+		const {
+			translate,
+			userId,
+			isBusinessPlanUser,
+			isLoading
+		} = this.props;
+
+		return (
+			<Main className="help-courses">
+				<HeaderCake backHref="/help" isCompact={ false }>{ translate( 'Courses' ) }</HeaderCake>
+				{ isLoading
+					? <CourseListPlaceholder />
+					: <CourseList /> }
+
+				{ isLoading
+					? <CoursePlaceholder />
+					: isBusinessPlanUser && <Course /> }
+
+				<QueryUserPurchases userId={ userId } />
+			</Main>
+		);
+	}
+}
+
+export default Courses;

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Courses from './courses';
+import {
+	getUserPurchases,
+	hasLoadedUserPurchasesFromServer
+} from 'state/purchases/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
+
+function mapStateToProps( state ) {
+	const userId = getCurrentUserId( state );
+	const purchases = getUserPurchases( state, userId );
+	const isBusinessPlanUser = purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS );
+	const isLoading = ! hasLoadedUserPurchasesFromServer( state );
+
+	return {
+		isLoading,
+		isBusinessPlanUser,
+		userId
+	};
+}
+
+export default connect( mapStateToProps )( localize( Courses ) );

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -1,0 +1,12 @@
+.help-courses__course-list{
+	&.is-placeholder {
+		@include placeholder( 23% );
+		height: 300px;
+	}
+}
+
+.help-courses__course{
+	&.is-placeholder {
+		@include placeholder( 23% );
+	}
+}

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -1,8 +1,13 @@
 var page = require( 'page' ),
+	config = require( 'config' ),
 	meController = require( 'me/controller' ),
 	helpController = require( './controller' );
 
 module.exports = function() {
 	page( '/help', meController.sidebar, helpController.help );
 	page( '/help/contact', meController.sidebar, helpController.contact );
+
+	if ( config.isEnabled( 'help/courses' ) ) {
+		page( '/help/courses', meController.sidebar, helpController.courses );
+	}
 };

--- a/config/development.json
+++ b/config/development.json
@@ -41,6 +41,7 @@
 		"guided-tours/main": true,
 		"guided-tours/themes": false,
 		"help": true,
+		"help/courses": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,
 		"jetpack_core_inline_update": true,


### PR DESCRIPTION
This pull requests adds a new page to calypso at /help/courses controlled by a feature flag. The aim here is to create a page with the business rules we will use later to fill in content. No design review is really needed here as the placeholder labels will be replaced with real content in a future pull request. The business rules are as follows:
 * Allow all logged in users to view /help/courses.
 * Allow all users to see the "Course List" area of the page
 * Restrict access to the "Latest Course" area to users who've purchased the "Business Plan" upgrade.

## How to test:
### Place holders
Upon initial load of the /help/courses page a query will have to be made to the server to determine if the user is a business plan user or not. During this time we'll show some [place holders](https://cloud.githubusercontent.com/assets/1854440/17870431/8d6dc29e-6885-11e6-9962-acd24b066d89.png)
 1. Navigate directly to https://calypso.live/help/courses?branch=add/help-courses-page
 2. Notice that there are two place holder sections blinking while data is loading.
 3. Wait a few seconds, the placeholders should eventually be replaced with actual content.

### Business rules
Note that there is no content currently in the sections, only labels describing what will be there in a future PR.
 1. Navigate directly to https://calypso.live/help/courses?branch=add/help-courses-page
 2. Wait for the placeholders to finish blinking.
 3. If you are a business plan user you should see two cards as seen [here](https://cloud.githubusercontent.com/assets/1854440/17870394/6036ca64-6885-11e6-9f8a-9de6a3416396.png). If you are any other type of user you should only see the section labeled "Visible to all" as seen [here](https://cloud.githubusercontent.com/assets/1854440/17870423/83ac1e90-6885-11e6-93da-a5cb9439bb8e.png)

### What to expect
**Page loading**
![screen shot 2016-08-22 at 4 26 02 pm](https://cloud.githubusercontent.com/assets/1854440/17870431/8d6dc29e-6885-11e6-9962-acd24b066d89.png)

**Business Users should see**
![screen shot 2016-08-22 at 4 25 02 pm](https://cloud.githubusercontent.com/assets/1854440/17870394/6036ca64-6885-11e6-9f8a-9de6a3416396.png)

**Non-Business Users should see**
![screen shot 2016-08-22 at 4 27 04 pm](https://cloud.githubusercontent.com/assets/1854440/17870423/83ac1e90-6885-11e6-93da-a5cb9439bb8e.png)



