### PR TITLE
Signup: Allow passing premium themes to the site creation API call.

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -93,7 +93,7 @@ const DomainsStep = React.createClass( {
 
 	getThemeArgs: function() {
 		const themeSlug = this.getThemeSlug(),
-			themeSlugWithRepo = this.getThemeSlugWithRepo(),
+			themeSlugWithRepo = this.getThemeSlugWithRepo( themeSlug ),
 			themeItem = this.isPurchasingTheme()
 			? cartItems.themeItem( themeSlug, 'signup-with-theme' )
 			: undefined;
@@ -101,13 +101,12 @@ const DomainsStep = React.createClass( {
 		return { themeSlug, themeSlugWithRepo, themeItem };
 	},
 
-	getThemeSlugWithRepo: function() {
-		const themeSlug = this.getThemeSlug();
+	getThemeSlugWithRepo: function( themeSlug ) {
 		if ( ! themeSlug ) {
 			return undefined;
 		}
-		// Only allow free themes for now; a valid theme value here (free or premium) will cause a theme_switch by Headstart.
-		return this.isPurchasingTheme() ? undefined : 'pub/' + themeSlug;
+		const repo = this.isPurchasingTheme() ? 'premium' : 'pub';
+		return `${repo}/${themeSlug}`;
 	},
 
 	submitWithDomain: function( googleAppsCartItem ) {

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -38,16 +38,19 @@ module.exports = React.createClass( {
 	},
 
 	pickTheme( theme ) {
-		const themeSlug = theme.id;
+		const repoSlug = `${ theme.repo }/${ theme.slug }`;
 
-		analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
+		analytics.tracks.recordEvent( 'calypso_signup_theme_select', {
+			theme: repoSlug,
+			headstart: true
+		} );
 
 		SignupActions.submitSignupStep( {
 			stepName: this.props.stepName,
 			processingMessage: this.translate( 'Adding your theme' ),
-			themeSlug
+			repoSlug
 		}, null, {
-			theme: 'pub/' + themeSlug
+			theme: repoSlug
 		} );
 
 		this.props.goToNextStep();

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -36,8 +36,8 @@ module.exports = React.createClass( {
 		return getThemes( this.props.surveyQuestion, this.props.designType );
 	},
 
-	getScreenshotUrl( slug ) {
-		return 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + slug + '/screenshot.png?w=660';
+	getScreenshotUrl( theme ) {
+		return `https://i1.wp.com/s0.wp.com/wp-content/themes/${ theme.repo }/${ theme.slug }/screenshot.png?w=660`;
 	},
 
 	render() {
@@ -45,12 +45,10 @@ module.exports = React.createClass( {
 			? this.translate( 'Preview' ) : this.translate( 'Pick' );
 		const getActionLabel = () => actionLabel;
 		const themes = this.getComputedThemes().map( theme => {
-			return {
+			return Object.assign( theme, {
 				id: theme.slug,
-				name: theme.name,
-				demo_uri: theme.demo_uri,
-				screenshot: this.getScreenshotUrl( theme.slug ),
-			};
+				screenshot: this.getScreenshotUrl( theme )
+			} );
 		} );
 		return (
 			<ThemesList


### PR DESCRIPTION
This is in preparation for Headstart to handle premium themes.

**Testing**

1. Add a `debugger` call to the start of `addDomainItemsToCart()` in `lib/signup/step-actions.js`.
2. Run through signup normally. Verify `dependencies. theme` has a `pub` prefix, eg. `pub/rebalance`.
3. Run signup with the URL `http://calypso.localhost:3000/start/with-theme/?theme=luxury&premium=true`. Verify `themeSlugWithRepo` is `premium/luxury`.
4. Change a theme in `lib/signup/themes-data.js` to have a `repo` value of `premium`. Select that theme in signup (don't worry that the screenshot is 404), and verify that `dependencies.theme` shows your theme with a `premium/` prefix.

Test live: https://calypso.live/?branch=update/signup-headstart-premium-support