### PR TITLE
Server Side Rendering: Fix

### DIFF
--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -15,7 +15,7 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 		const { store, primary, secondary, tertiary } = context;
 
 		// On server, only render LoggedOutLayout when logged-out.
-		if ( ! context.isServerSide || getCurrentUser( context.store.getState() ) ) {
+		if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
 			context.layout = (
 				<LayoutComponent store={ store }
 					primary={ primary }


### PR DESCRIPTION
SSR was broken by #5081, where I flipped the check for logged-out to logged-in:
https://github.com/Automattic/wp-calypso/pull/5081/files#diff-2ff5c9f67cfab8b6325e63706e3f4970R18 misses the negation that was previously present at
https://github.com/Automattic/wp-calypso/pull/5081/files#diff-a3600f12cca835b2ea80190a8243a8cbL26.
This PR adds it back.

To test: Compare `master` to this branch, doing the following:
* Incognito window
* Disable JavaScript
* http://calypso.localhost:3000/theme/twentysixteen

`master` should only show the "Please turn on JS" bottom banner, while this branch will also render the theme sheet for Twenty Sixteen.

/cc @seear @budzanowski @ehg for review 

Test live: https://calypso.live/?branch=fix/server-side-rendering