### PR TITLE
Framework: import PureComponent direclty from react core

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureComponent from 'react-pure-render/component';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import {

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -3,9 +3,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import PureComponent from 'react-pure-render/component';
-import compact from 'lodash/compact'
+import React, { PropTypes, PureComponent } from 'react';
+import compact from 'lodash/compact';
 
 import {
 	firstValid,

--- a/client/components/seo/reader-preview/index.js
+++ b/client/components/seo/reader-preview/index.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import PureComponent from 'react-pure-render/component';
+import React, { PropTypes, PureComponent } from 'react';
 
 /**
  * Internal dependencies

--- a/client/components/seo/twitter-preview/index.jsx
+++ b/client/components/seo/twitter-preview/index.jsx
@@ -1,6 +1,5 @@
 /** @ssr-ready **/
-import React, { PropTypes } from 'react';
-import PureComponent from 'react-pure-render/component';
+import React, { PropTypes, PureComponent } from 'react';
 
 const baseDomain = url =>
 	url

--- a/client/components/spinner-line/docs/example.jsx
+++ b/client/components/spinner-line/docs/example.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureComponent from 'react-pure-render/component';
+import React, { PureComponent } from 'react';
 
 /**
  * Internal dependencies

--- a/client/components/spinner-line/index.jsx
+++ b/client/components/spinner-line/index.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import PureComponent from 'react-pure-render/component';
+import React, { PropTypes, PureComponent } from 'react';
 import classnames from 'classnames';
 
 export default class SpinnerLine extends PureComponent {

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -3,9 +3,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import PureComponent from 'react-pure-render/component';
 
 /**
  * Constants

--- a/client/components/vertical-menu/index.jsx
+++ b/client/components/vertical-menu/index.jsx
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import PureComponent from 'react-pure-render/component';
+import React, { PropTypes, PureComponent } from 'react';
 import {
 	identity,
 	partial

--- a/client/my-sites/stats/stats-module/expand.jsx
+++ b/client/my-sites/stats/stats-module/expand.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureComponent from 'react-pure-render/component';
+import React, { PureComponent } from 'react';
 
 export default class StatsModuleExpand extends PureComponent {
 	static propTypes = {


### PR DESCRIPTION
In this PR we import `PureComponent` directly from `react` core library. 

### Issues

#7590

### Testing

We have to test all pages where we applying this change.

- [ ] client/components/seo-preview-pane/index.jsx
- [ ] client/components/seo/facebook-preview/index.jsx
- [ ] client/components/seo/reader-preview/index.js
- [ ] client/components/seo/twitter-preview/index.jsx
- [ ] client/components/spinner-line/docs/example.jsx
- [ ] client/components/spinner-line/index.jsx
- [ ] client/components/spinner/index.jsx
- [ ] client/components/vertical-menu/index.jsx
- [ ] client/my-sites/stats/stats-module/expand.jsx

Test live: https://calypso.live/?branch=update/pure-component-dependency