### PR TITLE
Reader: Fix tag fade in full-post

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -197,6 +197,10 @@
 	max-width: 750px;
 }
 
+.reader-full-post__header-date {
+	line-height: 1.4;
+}
+
 .reader-full-post__header-date-link {
 	margin-right: 25px;
 }
@@ -220,6 +224,10 @@
 		margin-right: 5px;
 		position: relative;
 			top: 4px;
+
+		@include breakpoint( "<480px" ) {
+			top: 2px;
+		}
 	}
 }
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -191,12 +191,10 @@
 }
 
 .reader-full-post__header-meta {
+	display: flex;
+	flex-direction: row;
 	font-size: 15px;
 	max-width: 750px;
-}
-
-.reader-full-post__header-date {
-	display: inline-flex;
 }
 
 .reader-full-post__header-date-link {
@@ -214,6 +212,7 @@
 
 .reader-full-post__header-tags {
 	display: inline-flex;
+	flex: 1;
 	width: calc(100% - 120px);
 
 	.gridicon {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/7419

**Before:**
![screenshot 2016-08-22 19 27 40](https://cloud.githubusercontent.com/assets/4924246/17878443/885851d8-689f-11e6-8459-7b662ba5f874.png)

**After:**
![screenshot 2016-08-22 19 31 01](https://cloud.githubusercontent.com/assets/4924246/17878440/8544b838-689f-11e6-8dbf-b5576ca0452b.png)

/cc @bluefuton @fraying 

Test live: https://calypso.live/?branch=fix/reader/full-post-tag-fade