### PR TITLE
Guided Transfer: Use affiliate links

### DIFF
--- a/client/my-sites/guided-transfer/guided-transfer.jsx
+++ b/client/my-sites/guided-transfer/guided-transfer.jsx
@@ -20,12 +20,12 @@ const guidedTransferHosts = {
 	bluehost: {
 		label: i18n.translate( 'Bluehost' ),
 		logo: '/calypso/images/guided-transfer/bluehost-logo.png',
-		url: '#bluehost',
+		url: 'https://bluehost.com/track/wpgt?page=/web-hosting/signup',
 	},
 	siteground: {
 		logo: '/calypso/images/guided-transfer/siteground-logo.png',
 		label: i18n.translate( 'SiteGround' ),
-		url: '#siteground'
+		url: 'https://www.siteground.com/wordpress-hosting.htm?afcode=134c903505c0a2296bd25772edebf669'
 	}
 };
 

--- a/client/my-sites/guided-transfer/host-select.jsx
+++ b/client/my-sites/guided-transfer/host-select.jsx
@@ -30,9 +30,8 @@ export default React.createClass( {
 				<Card>
 					<p>{ this.translate(
 '{{strong}}Please choose{{/strong}} one of our Guided Transfer compatible ' +
-'{{partner_link}}partner hosts{{/partner_link}}. You must have a hosting account ' +
-'with one of them to be able to move your site. Visit them {{lobby_link}}Guided ' +
-'Transfer Lobby{{/lobby_link}} if you have any question before starting, or ' +
+'{{partner_link}}partner hosts{{/partner_link}}. Visit the {{lobby_link}}Guided ' +
+'Transfer Lobby{{/lobby_link}} if you have any questions before starting, or ' +
 '{{learn_link}}learn more{{/learn_link}} about the process.',
 						{
 							components: {


### PR DESCRIPTION
This updates the 'Create new account' links to use our affiliate links. These affiliate links help the destination hosts prepare for an incoming transfer to make the process smoother.

![testsite2982_ _wordpress_com_](https://cloud.githubusercontent.com/assets/416133/17884419/8642a878-695b-11e6-8764-2b7289cfe860.png)

I've also changed the wording on the prior page to remove the following sentence, as it might prevent the user from proceeding to the next step (which contains the signup link):
> You must have a hosting account with one of them to be able to move your site.

### How to test
1. Go to **My Sites > Settings > Export**
2. Click **Purchase a Guided Transfer**
3. Choose Bluehost
4. Click the 'Create one' link and ensure you're sent to Bluehost's signup page
5. Go back and choose SiteGround, click the signup link
6. Ensure you're sent SiteGround's signup page

Test live: https://calypso.live/?branch=update/guided-transfer/use-affiliate-links