### PR TITLE
i18n: Enable the i18n-no-newlines rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -76,6 +76,7 @@ module.exports = {
 		'valid-jsdoc': [ 1, { requireReturn: false } ],
 		'wpcalypso/i18n-ellipsis': 1,
 		'wpcalypso/i18n-no-variables': 1,
+		'wpcalypso/i18n-no-newlines': 1,
 		'wpcalypso/i18n-no-placeholders-only': 1,
 		'wpcalypso/i18n-mismatched-placeholders': 1,
 		'wpcalypso/i18n-named-placeholders': 1,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -384,7 +384,7 @@
       "version": "0.1.2"
     },
     "base64-js": {
-      "version": "0.0.8"
+      "version": "1.1.2"
     },
     "base64id": {
       "version": "0.1.0"
@@ -460,10 +460,10 @@
       "version": "0.1.4"
     },
     "browserslist": {
-      "version": "1.3.5"
+      "version": "1.3.6"
     },
     "buffer": {
-      "version": "3.6.0"
+      "version": "4.9.1"
     },
     "builtin-modules": {
       "version": "1.1.1"
@@ -498,7 +498,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000524"
+      "version": "1.0.30000525"
     },
     "caseless": {
       "version": "0.11.0"
@@ -670,7 +670,7 @@
       "version": "0.3.2",
       "dependencies": {
         "graceful-fs": {
-          "version": "3.0.9"
+          "version": "3.0.10"
         },
         "object-assign": {
           "version": "2.1.1"
@@ -864,7 +864,7 @@
       "version": "2.0.0"
     },
     "doctrine": {
-      "version": "1.2.3"
+      "version": "1.3.0"
     },
     "doctypes": {
       "version": "1.1.0"
@@ -1009,7 +1009,7 @@
       "version": "1.3.0"
     },
     "es-abstract": {
-      "version": "1.5.1"
+      "version": "1.6.1"
     },
     "es-to-primitive": {
       "version": "1.1.1"
@@ -1148,7 +1148,7 @@
       "version": "5.2.2"
     },
     "eslint-plugin-wpcalypso": {
-      "version": "1.3.3"
+      "version": "1.4.1"
     },
     "espree": {
       "version": "3.1.7"
@@ -1318,7 +1318,7 @@
       }
     },
     "fizzy-ui-utils": {
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     "flat-cache": {
       "version": "1.2.1"
@@ -1464,7 +1464,7 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.5"
+      "version": "4.1.6"
     },
     "graceful-readlink": {
       "version": "1.0.1"
@@ -2213,6 +2213,9 @@
     "nan": {
       "version": "2.4.0"
     },
+    "natives": {
+      "version": "1.0.1"
+    },
     "ncname": {
       "version": "1.0.0"
     },
@@ -2254,7 +2257,7 @@
       }
     },
     "node-libs-browser": {
-      "version": "0.5.3",
+      "version": "0.6.0",
       "dependencies": {
         "isarray": {
           "version": "0.0.1"
@@ -2649,7 +2652,7 @@
           "version": "1.2.7"
         },
         "fbjs": {
-          "version": "0.8.3"
+          "version": "0.8.4"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "eslint": "2.13.1",
     "eslint-config-wpcalypso": "0.2.0",
     "eslint-plugin-react": "5.2.2",
-    "eslint-plugin-wpcalypso": "1.3.3",
+    "eslint-plugin-wpcalypso": "1.4.1",
     "glob": "7.0.3",
     "localStorage": "1.0.2",
     "lodash-deep": "1.5.3",


### PR DESCRIPTION
In order to do so, we need to upgrade to `eslint-plugin-wpcalypso` 1.4.1. `make shrinkwrap` was executed and is included in the PR.

```
$ ./node_modules/eslint/bin/eslint.js client/my-sites/guided-transfer/transfer-unavailable-card.jsx

./client/my-sites/guided-transfer/transfer-unavailable-card.jsx
  40:19  warning  Translations usually don't contain newlines  wpcalypso/i18n-no-newlines
  46:21  warning  Translations usually don't contain newlines  wpcalypso/i18n-no-newlines
  54:21  warning  Translations usually don't contain newlines  wpcalypso/i18n-no-newlines
  66:20  warning  Translations usually don't contain newlines  wpcalypso/i18n-no-newlines

✖ 4 problems (0 errors, 4 warnings)
```

(note there is a [stray console.log in eslint-plugin-wpcalypso](https://github.com/Automattic/eslint-plugin-wpcalypso/blob/77b5936d01936d50e8b19e47a553b419cfc2bff3/lib/rules/i18n-no-newlines.js#L29) that [will be removed](https://github.com/Automattic/eslint-plugin-wpcalypso/commit/502df45c9861124644d9c41b9cc0aa29bcbd36bd) in the next version)

Test live: https://calypso.live/?branch=enable/lint-no-newlines