### PR TITLE
Post-Checkout: Thank You Page: Reduce to two CTAs

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -13,6 +13,7 @@
 @import 'blocks/comment-button/style';
 @import 'blocks/comments/style';
 @import 'blocks/author-selector/style';
+@import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-item/style';
 @import 'blocks/post-relative-time/style';
 @import 'blocks/post-status/style';
@@ -403,4 +404,3 @@
 @import 'signup/validation-fieldset/style';
 @import 'support/support-user/style';
 @import 'vip/vip-logs/style';
-@import 'blocks/plan-thank-you-card/style'

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -403,3 +403,4 @@
 @import 'signup/validation-fieldset/style';
 @import 'support/support-user/style';
 @import 'vip/vip-logs/style';
+@import 'blocks/plan-thank-you-card/style'

--- a/client/blocks/plan-thank-you-card/README.md
+++ b/client/blocks/plan-thank-you-card/README.md
@@ -1,0 +1,7 @@
+# Plan Thank You Card
+
+This is a component that shows thank you card after purchasing a plan for a site. It requires the site object to be present and if site plans are not available in Redux state, it fetches them.
+
+## Props
+
+- `selectedSite`: Site object

--- a/client/blocks/plan-thank-you-card/README.md
+++ b/client/blocks/plan-thank-you-card/README.md
@@ -4,4 +4,11 @@ This is a component that shows thank you card after purchasing a plan for a site
 
 ## Props
 
-- `selectedSite`: Site object
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+Required property that controls what site is the card rendered for.

--- a/client/blocks/plan-thank-you-card/docs/example.jsx
+++ b/client/blocks/plan-thank-you-card/docs/example.jsx
@@ -2,27 +2,35 @@
 * External dependencies
 */
 import React from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import sitesList from 'lib/sites-list';
-import PlanThankYouCard from 'blocks/plan-thank-you-card';
+import PlanThankYouCard from '../';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { getSitePosts } from 'state/posts/selectors';
 
-const sites = sitesList();
+function PlanThankYouCardExample( { primarySiteId, globalId } ) {
+	return (
+		<div className="design-assets__group">
+			<h2>
+				<a href="/devdocs/blocks/plan-thank-you-card">Plan Thank You Card</a>
+			</h2>
+			<PlanThankYouCard siteId={ primarySiteId } />
+		</div>
+	);
+}
 
-const PlanThankYouCardExample = React.createClass( {
-	displayName: 'PlanThankYouCard',
-	render() {
-		return (
-			<div className="design-assets__group">
-				<h2>
-					<a href="/devdocs/blocks/plan-thank-you-card">Plan Thank You Card</a>
-				</h2>
-				<PlanThankYouCard selectedSite={ sites.getPrimary() } />
-			</div>
-		);
-	}
-} );
+const ConnectedPlanThankYouCard = connect( ( state ) => {
+	const primarySiteId = get( getCurrentUser( state ), 'primary_blog' );
 
-module.exports = PlanThankYouCardExample;
+	return {
+		primarySiteId,
+	};
+} )( PlanThankYouCardExample );
+
+ConnectedPlanThankYouCard.displayName = 'PlanThankYouCard';
+
+export default ConnectedPlanThankYouCard;

--- a/client/blocks/plan-thank-you-card/docs/example.jsx
+++ b/client/blocks/plan-thank-you-card/docs/example.jsx
@@ -1,0 +1,28 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import sitesList from 'lib/sites-list';
+import PlanThankYouCard from 'blocks/plan-thank-you-card';
+
+const sites = sitesList();
+
+const PlanThankYouCardExample = React.createClass( {
+	displayName: 'PlanThankYouCard',
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/blocks/plan-thank-you-card">Plan Thank You Card</a>
+				</h2>
+				<PlanThankYouCard selectedSite={ sites.getPrimary() } />
+			</div>
+		);
+	}
+} );
+
+module.exports = PlanThankYouCardExample;

--- a/client/blocks/plan-thank-you-card/docs/example.jsx
+++ b/client/blocks/plan-thank-you-card/docs/example.jsx
@@ -12,7 +12,7 @@ import PlanThankYouCard from '../';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSitePosts } from 'state/posts/selectors';
 
-function PlanThankYouCardExample( { primarySiteId, globalId } ) {
+function PlanThankYouCardExample( { primarySiteId } ) {
 	return (
 		<div className="design-assets__group">
 			<h2>

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+import Gridicon from 'components/gridicon';
+
+class PlanThankYouCard extends Component {
+	static propTypes = {
+		selectedSite: PropTypes.object
+	};
+
+	render() {
+		// Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
+		/* eslint-disable wpcalypso/jsx-gridicon-size */
+		return (
+			<div className="plan-thank-you-card">
+				<div className="plan-thank-you-card__header">
+					<Gridicon className="plan-thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
+					<div className="plan-thank-you-card__plan-name">{ this.props.selectedSite.plan.product_name_short }</div>
+					<div className="plan-thank-you-card__background-icons">
+						<Gridicon icon="heart" size={ 52 } />
+						<Gridicon icon="heart" size={ 20 } />
+						<Gridicon icon="heart" size={ 52 } />
+						<Gridicon icon="heart" size={ 41 } />
+						<Gridicon icon="heart" size={ 26 } />
+						<Gridicon icon="status" size={ 52 } />
+						<Gridicon icon="status" size={ 38 } />
+						<Gridicon icon="status" size={ 28 } />
+						<Gridicon icon="status" size={ 65 } />
+						<Gridicon icon="star" size={ 57 } />
+						<Gridicon icon="star" size={ 33 } />
+						<Gridicon icon="star" size={ 45 } />
+					</div>
+				</div>
+				<div className="plan-thank-you-card__body">
+					<div className="plan-thank-you-card__heading">
+						{ this.props.translate( 'Thank you for your purchase!' ) }
+					</div>
+					<div className="plan-thank-you-card__description">
+						{ this.props.translate( 'Now that we’ve taken care of the plan, its time to see your new site.' ) }
+					</div>
+					<a
+						className="plan-thank-you-card__button"
+						href={ this.props.selectedSite.URL }>
+						{ this.props.translate( 'Visit your site' ) }
+					</a>
+				</div>
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-gridicon-size */
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	let selectedSite = getSelectedSite( state );
+
+	if ( ownProps.selectedSite && ! selectedSite ) {
+		selectedSite = ownProps.selectedSite;
+	}
+
+	return {
+		selectedSite
+	};
+} )( localize( PlanThankYouCard ) );

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
-import { getSite } from 'state/sites/selectors';
+import { getRawSite } from 'state/sites/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -24,29 +24,33 @@ class PlanThankYouCard extends Component {
 	render() {
 		const {
 			plan,
-			site,
 			translate,
-			siteId
+			siteId,
+			siteURL,
 		} = this.props;
 		// Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
 			<div className="plan-thank-you-card">
-				<QuerySites siteId={ siteId } />
+				{ siteId && <QuerySites siteId={ siteId } /> }
 				<QuerySitePlans siteId={ siteId } />
 				<div className="plan-thank-you-card__header">
 					<Gridicon className="plan-thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
-					{ ! site
-						? <div className="plan-thank-you-card__plan-name is-placeholder"></div>
-						: <div className="plan-thank-you-card__plan-name">
-								{ translate( '%(planName)s Plan', {
-									args: { planName: plansList[ site.plan.product_slug ].getTitle() }
-								} ) }
-							</div>
-					}
 					{ ! plan
-						? <div className="plan-thank-you-card__plan-price is-placeholder"></div>
-						: <div className="plan-thank-you-card__plan-price">{ formatCurrency( plan.rawPrice, plan.currencyCode ) }</div>
+						? <div>
+								<div className="plan-thank-you-card__plan-name is-placeholder"></div>
+								<div className="plan-thank-you-card__plan-price is-placeholder"></div>
+							</div>
+						: <div>
+								<div className="plan-thank-you-card__plan-name">
+								{ translate( '%(planName)s Plan', {
+									args: { planName: plansList[ plan.productSlug ].getTitle() }
+								} ) }
+								</div>
+								<div className="plan-thank-you-card__plan-price">
+									{ formatCurrency( plan.rawPrice, plan.currencyCode ) }
+								</div>
+							</div>
 					}
 					<div className="plan-thank-you-card__background-icons">
 						<Gridicon icon="audio" size={ 52 } />
@@ -72,7 +76,7 @@ class PlanThankYouCard extends Component {
 					</div>
 					<a
 						className="plan-thank-you-card__button"
-						href={ site.URL }>
+						href={ siteURL }>
 						{ translate( 'Visit your site' ) }
 					</a>
 				</div>
@@ -83,11 +87,11 @@ class PlanThankYouCard extends Component {
 }
 
 export default connect( ( state, ownProps ) => {
-	const site = getSite( state, ownProps.siteId );
+	const site = getRawSite( state, ownProps.siteId );
 	const plan = getCurrentPlan( state, ownProps.siteId );
 
 	return {
-		site,
 		plan,
+		siteURL: site.URL
 	};
 } )( localize( PlanThankYouCard ) );

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -11,11 +11,18 @@ import { connect } from 'react-redux';
 import { getSelectedSite } from 'state/ui/selectors';
 import Gridicon from 'components/gridicon';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { fetchSitePlans } from 'state/sites/plans/actions';
 
 class PlanThankYouCard extends Component {
 	static propTypes = {
 		selectedSite: PropTypes.object
 	};
+
+	componentDidMount() {
+		if ( ! this.props.plan ) {
+			this.props.fetchSitePlans( this.props.selectedSite );
+		}
+	}
 
 	render() {
 		// Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
@@ -29,7 +36,11 @@ class PlanThankYouCard extends Component {
 							args: { planName: this.props.selectedSite.plan.product_name_short }
 						} ) }
 					</div>
-					<div className="plan-thank-you-card__plan-price">{ this.props.plan.formattedPrice }</div>
+					{ ( ! this.props.plan ) ? (
+						<div className="plan-thank-you-card__plan-price is-placeholder"></div>
+					) : (
+						<div className="plan-thank-you-card__plan-price">{ this.props.plan.formattedPrice }</div>
+					) }
 					<div className="plan-thank-you-card__background-icons">
 						<Gridicon icon="heart" size={ 52 } />
 						<Gridicon icon="heart" size={ 20 } />
@@ -64,15 +75,24 @@ class PlanThankYouCard extends Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	let selectedSite = getSelectedSite( state );
+export default connect(
+	( state, ownProps ) => {
+		let selectedSite = getSelectedSite( state );
 
-	if ( ownProps.selectedSite && ! selectedSite ) {
-		selectedSite = ownProps.selectedSite;
+		if ( ownProps.selectedSite && ! selectedSite ) {
+			selectedSite = ownProps.selectedSite;
+		}
+
+		return {
+			selectedSite,
+			plan: getCurrentPlan( state, selectedSite.ID )
+		};
+	},
+	( dispatch ) => {
+		return {
+			fetchSitePlans( site ) {
+				dispatch( fetchSitePlans( site.ID ) );
+			},
+		};
 	}
-
-	return {
-		selectedSite,
-		plan: getCurrentPlan( state, selectedSite.ID )
-	};
-} )( localize( PlanThankYouCard ) );
+)( localize( PlanThankYouCard ) );

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -8,46 +8,38 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getSelectedSite } from 'state/ui/selectors';
 import Gridicon from 'components/gridicon';
+import { getSite } from 'state/sites/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { fetchSitePlans } from 'state/sites/plans/actions';
-import { getPlanBySlug, getPlans } from 'state/plans/selectors';
-import { requestPlans } from 'state/plans/actions';
+import QuerySites from 'components/data/query-sites';
+import QuerySitePlans from 'components/data/query-site-plans';
+import { plansList } from 'lib/plans/constants';
 
 class PlanThankYouCard extends Component {
 	static propTypes = {
-		selectedSite: PropTypes.object
+		siteId: PropTypes.number.isRequired
 	};
-
-	componentDidMount() {
-		if ( ! this.props.plan ) {
-			this.props.fetchSitePlans( this.props.selectedSite );
-		}
-
-		if ( ! this.props.plansFetched ) {
-			this.props.requestPlans();
-		}
-	}
 
 	render() {
 		const {
 			plan,
-			planDetails,
-			selectedSite,
-			translate
+			site,
+			translate,
+			siteId
 		} = this.props;
 		// Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
 			<div className="plan-thank-you-card">
+				<QuerySites siteId={ siteId } />
+				<QuerySitePlans siteId={ siteId } />
 				<div className="plan-thank-you-card__header">
 					<Gridicon className="plan-thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
-					{ ! planDetails
+					{ ! site
 						? <div className="plan-thank-you-card__plan-name is-placeholder"></div>
 						: <div className="plan-thank-you-card__plan-name">
 								{ translate( '%(planName)s Plan', {
-									args: { planName: planDetails.product_name_short }
+									args: { planName: plansList[ site.plan.product_slug ].getTitle() }
 								} ) }
 							</div>
 					}
@@ -79,7 +71,7 @@ class PlanThankYouCard extends Component {
 					</div>
 					<a
 						className="plan-thank-you-card__button"
-						href={ selectedSite.URL }>
+						href={ site.URL }>
 						{ translate( 'Visit your site' ) }
 					</a>
 				</div>
@@ -89,36 +81,12 @@ class PlanThankYouCard extends Component {
 	}
 }
 
-export default connect(
-	( state, ownProps ) => {
-		let selectedSite = getSelectedSite( state );
+export default connect( ( state, ownProps ) => {
+	const site = getSite( state, ownProps.siteId );
+	const plan = getCurrentPlan( state, ownProps.siteId );
 
-		if ( ownProps.selectedSite && ! selectedSite ) {
-			selectedSite = ownProps.selectedSite;
-		}
-
-		const plan = getCurrentPlan( state, selectedSite.ID );
-
-		let planDetails = null;
-		if ( plan ) {
-			planDetails = getPlanBySlug( state, plan.productSlug );
-		}
-
-		return {
-			selectedSite,
-			plan,
-			planDetails,
-			plansFetched: getPlans( state ).length !== 0
-		};
-	},
-	( dispatch ) => {
-		return {
-			fetchSitePlans( site ) {
-				dispatch( fetchSitePlans( site.ID ) );
-			},
-			requestPlans() {
-				dispatch( requestPlans() );
-			}
-		};
-	}
-)( localize( PlanThankYouCard ) );
+	return {
+		site,
+		plan,
+	};
+} )( localize( PlanThankYouCard ) );

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -12,6 +12,8 @@ import { getSelectedSite } from 'state/ui/selectors';
 import Gridicon from 'components/gridicon';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { fetchSitePlans } from 'state/sites/plans/actions';
+import { getPlanBySlug, getPlans } from 'state/plans/selectors';
+import { requestPlans } from 'state/plans/actions';
 
 class PlanThankYouCard extends Component {
 	static propTypes = {
@@ -21,6 +23,10 @@ class PlanThankYouCard extends Component {
 	componentDidMount() {
 		if ( ! this.props.plan ) {
 			this.props.fetchSitePlans( this.props.selectedSite );
+		}
+
+		if ( ! this.props.plansFetched ) {
+			this.props.requestPlans();
 		}
 	}
 
@@ -32,10 +38,17 @@ class PlanThankYouCard extends Component {
 				<div className="plan-thank-you-card__header">
 					<Gridicon className="plan-thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
 					<div className="plan-thank-you-card__plan-name">
-						{ this.props.translate( '%(planName)s Plan', {
-							args: { planName: this.props.selectedSite.plan.product_name_short }
-						} ) }
+
 					</div>
+					{ ( ! this.props.planDetails ) ? (
+						<div className="plan-thank-you-card__plan-name is-placeholder"></div>
+					) : (
+						<div className="plan-thank-you-card__plan-name">
+							{ this.props.translate( '%(planName)s Plan', {
+								args: { planName: this.props.planDetails.product_name_short }
+							} ) }
+						</div>
+					) }
 					{ ( ! this.props.plan ) ? (
 						<div className="plan-thank-you-card__plan-price is-placeholder"></div>
 					) : (
@@ -83,9 +96,18 @@ export default connect(
 			selectedSite = ownProps.selectedSite;
 		}
 
+		const plan = getCurrentPlan( state, selectedSite.ID );
+
+		let planDetails = null;
+		if ( plan ) {
+			planDetails = getPlanBySlug( state, plan.productSlug );
+		}
+
 		return {
 			selectedSite,
-			plan: getCurrentPlan( state, selectedSite.ID )
+			plan,
+			planDetails,
+			plansFetched: getPlans( state ).length !== 0
 		};
 	},
 	( dispatch ) => {
@@ -93,6 +115,9 @@ export default connect(
 			fetchSitePlans( site ) {
 				dispatch( fetchSitePlans( site.ID ) );
 			},
+			requestPlans() {
+				dispatch( requestPlans() );
+			}
 		};
 	}
 )( localize( PlanThankYouCard ) );

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -31,29 +31,30 @@ class PlanThankYouCard extends Component {
 	}
 
 	render() {
+		const {
+			plan,
+			planDetails,
+			selectedSite,
+			translate
+		} = this.props;
 		// Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
 			<div className="plan-thank-you-card">
 				<div className="plan-thank-you-card__header">
 					<Gridicon className="plan-thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
-					<div className="plan-thank-you-card__plan-name">
-
-					</div>
-					{ ( ! this.props.planDetails ) ? (
-						<div className="plan-thank-you-card__plan-name is-placeholder"></div>
-					) : (
-						<div className="plan-thank-you-card__plan-name">
-							{ this.props.translate( '%(planName)s Plan', {
-								args: { planName: this.props.planDetails.product_name_short }
-							} ) }
-						</div>
-					) }
-					{ ( ! this.props.plan ) ? (
-						<div className="plan-thank-you-card__plan-price is-placeholder"></div>
-					) : (
-						<div className="plan-thank-you-card__plan-price">{ this.props.plan.formattedPrice }</div>
-					) }
+					{ ! planDetails
+						? <div className="plan-thank-you-card__plan-name is-placeholder"></div>
+						: <div className="plan-thank-you-card__plan-name">
+								{ translate( '%(planName)s Plan', {
+									args: { planName: planDetails.product_name_short }
+								} ) }
+							</div>
+					}
+					{ ! plan
+						? <div className="plan-thank-you-card__plan-price is-placeholder"></div>
+						: <div className="plan-thank-you-card__plan-price">{ plan.formattedPrice }</div>
+					}
 					<div className="plan-thank-you-card__background-icons">
 						<Gridicon icon="audio" size={ 52 } />
 						<Gridicon icon="audio" size={ 20 } />
@@ -71,15 +72,15 @@ class PlanThankYouCard extends Component {
 				</div>
 				<div className="plan-thank-you-card__body">
 					<div className="plan-thank-you-card__heading">
-						{ this.props.translate( 'Thank you for your purchase!' ) }
+						{ translate( 'Thank you for your purchase!' ) }
 					</div>
 					<div className="plan-thank-you-card__description">
-						{ this.props.translate( 'Now that we’ve taken care of the plan, its time to see your new site.' ) }
+						{ translate( 'Now that we’ve taken care of the plan, its time to see your new site.' ) }
 					</div>
 					<a
 						className="plan-thank-you-card__button"
-						href={ this.props.selectedSite.URL }>
-						{ this.props.translate( 'Visit your site' ) }
+						href={ selectedSite.URL }>
+						{ translate( 'Visit your site' ) }
 					</a>
 				</div>
 			</div>

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -72,12 +72,12 @@ class PlanThankYouCard extends Component {
 						{ translate( 'Thank you for your purchase!' ) }
 					</div>
 					<div className="plan-thank-you-card__description">
-						{ translate( 'Now that we’ve taken care of the plan, its time to see your new site.' ) }
+						{ translate( "Now that we've taken care of the plan, it's time to see your new site." ) }
 					</div>
 					<a
 						className="plan-thank-you-card__button"
 						href={ siteURL }>
-						{ translate( 'Visit your site' ) }
+						{ translate( 'Visit Your Site' ) }
 					</a>
 				</div>
 			</div>

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import { getSelectedSite } from 'state/ui/selectors';
 import Gridicon from 'components/gridicon';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
 
 class PlanThankYouCard extends Component {
 	static propTypes = {
@@ -23,7 +24,12 @@ class PlanThankYouCard extends Component {
 			<div className="plan-thank-you-card">
 				<div className="plan-thank-you-card__header">
 					<Gridicon className="plan-thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
-					<div className="plan-thank-you-card__plan-name">{ this.props.selectedSite.plan.product_name_short }</div>
+					<div className="plan-thank-you-card__plan-name">
+						{ this.props.translate( '%(planName)s Plan', {
+							args: { planName: this.props.selectedSite.plan.product_name_short }
+						} ) }
+					</div>
+					<div className="plan-thank-you-card__plan-price">{ this.props.plan.formattedPrice }</div>
 					<div className="plan-thank-you-card__background-icons">
 						<Gridicon icon="heart" size={ 52 } />
 						<Gridicon icon="heart" size={ 20 } />
@@ -66,6 +72,7 @@ export default connect( ( state, ownProps ) => {
 	}
 
 	return {
-		selectedSite
+		selectedSite,
+		plan: getCurrentPlan( state, selectedSite.ID )
 	};
 } )( localize( PlanThankYouCard ) );

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -42,13 +42,13 @@ class PlanThankYouCard extends Component {
 						<div className="plan-thank-you-card__plan-price">{ this.props.plan.formattedPrice }</div>
 					) }
 					<div className="plan-thank-you-card__background-icons">
-						<Gridicon icon="heart" size={ 52 } />
-						<Gridicon icon="heart" size={ 20 } />
+						<Gridicon icon="audio" size={ 52 } />
+						<Gridicon icon="audio" size={ 20 } />
 						<Gridicon icon="heart" size={ 52 } />
 						<Gridicon icon="heart" size={ 41 } />
-						<Gridicon icon="heart" size={ 26 } />
+						<Gridicon icon="star" size={ 26 } />
 						<Gridicon icon="status" size={ 52 } />
-						<Gridicon icon="status" size={ 38 } />
+						<Gridicon icon="audio" size={ 38 } />
 						<Gridicon icon="status" size={ 28 } />
 						<Gridicon icon="status" size={ 65 } />
 						<Gridicon icon="star" size={ 57 } />

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -14,6 +14,7 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { plansList } from 'lib/plans/constants';
+import formatCurrency from 'lib/format-currency';
 
 class PlanThankYouCard extends Component {
 	static propTypes = {
@@ -45,7 +46,7 @@ class PlanThankYouCard extends Component {
 					}
 					{ ! plan
 						? <div className="plan-thank-you-card__plan-price is-placeholder"></div>
-						: <div className="plan-thank-you-card__plan-price">{ plan.formattedPrice }</div>
+						: <div className="plan-thank-you-card__plan-price">{ formatCurrency( plan.rawPrice, plan.currencyCode ) }</div>
 					}
 					<div className="plan-thank-you-card__background-icons">
 						<Gridicon icon="audio" size={ 52 } />

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -1,0 +1,150 @@
+.plan-thank-you-card {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  background-color: #328246;
+  border-radius: 6px;
+  overflow: hidden;
+  margin: 56px auto 24px;
+  color: $white;
+  font-family: $sans;
+
+  @media ( max-width: 500px ) {
+    margin-top: 0;
+  }
+}
+
+.plan-thank-you-card__header {
+  background-color: #4AB866;
+  padding: 75px 0 30px;
+  position: relative;
+  z-index: 1;
+}
+
+.plan-thank-you-card__body {
+  padding: 40px;
+}
+
+.plan-thank-you-card__heading {
+  font-size: 22px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.plan-thank-you-card__description {
+  font-size: 15px;
+  font-weight: 400;
+  width: 280px;
+  max-width: 100%;
+  margin: 0 auto 30px;
+  line-height: 20px;
+}
+
+.plan-thank-you-card__button {
+  display: inline-block;
+  border-radius: 4px;
+  background-color: $white;
+  color: #194324;
+  font-size: 14px;
+  height: 40px;
+  line-height: 40px;
+  padding: 0 60px;
+  box-shadow: 0px 1px 0px 1px rgba(0, 0, 0, .3);
+
+  @media ( max-width: 320px) {
+    padding: 0;
+    width: 100%;
+    text-align: center;
+  }
+}
+
+.plan-thank-you-card__button:hover {
+  box-shadow: 0px 1px 0px 1px rgba(0, 0, 0, .5);
+  color: #194324;
+}
+
+.plan-thank-you-card__plan-name {
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.plan-thank-you-card__background-icons {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  color: #72D58B;
+
+  svg {
+    position: absolute;
+
+    @media ( max-width: 430px ) {
+      path {
+        transform: scale(.7);
+      }
+    }
+  }
+
+  svg:nth-child(1) {
+    top: 18px;
+    left: 14.8%;
+    transform: rotate(14deg);
+  }
+  svg:nth-child(2) {
+    top: 118px;
+    left: 67.4%;
+    transform: rotate(42deg);
+  }
+  svg:nth-child(3) {
+    top: 108px;
+    left: 86.2%;
+    transform: rotate(-19deg);
+  }
+  svg:nth-child(4) {
+    top: 190px;
+    left: 8.4%;
+    transform: rotate(-223deg);
+  }
+  svg:nth-child(5) {
+    top: 233px;
+    left: 70.6%;
+    transform: rotate(-66deg);
+  }
+  svg:nth-child(6) {
+    top: 83px;
+    left: 4.2%;
+    transform: rotate(40deg);
+  }
+  svg:nth-child(7) {
+    top: 213px;
+    left: 23.8%;
+    transform: rotate(30deg);
+  }
+  svg:nth-child(8) {
+    top: 30px;
+    left: 37.8%;
+    transform: rotate(114deg);
+  }
+  svg:nth-child(9) {
+    top: 26px;
+    left: 78.4%;
+    transform: rotate(-11deg);
+  }
+  svg:nth-child(10) {
+    top: 101px;
+    left: 21%;
+    transform: rotate(-9deg);
+  }
+  svg:nth-child(11) {
+    top: 21px;
+    left: 62%;
+    transform: rotate(-33deg);
+  }
+  svg:nth-child(12) {
+    top: 161px;
+    left: 77.6%;
+    transform: rotate(-43deg);
+  }
+}

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -81,7 +81,7 @@
 	&.is-placeholder {
 		@include placeholder();
 
-		background-color: #DAF0E0;
+		background-color: lighten( $alert-green, 40 );
 		margin-left: auto;
 		margin-right: auto;
 		width: 35%;
@@ -91,12 +91,12 @@
 .plan-thank-you-card__plan-price {
 	font-size: 15px;
 	font-weight: 500;
-	color: #DAF0E0;
+	color: lighten( $alert-green, 40 );
 
 	&.is-placeholder {
 		@include placeholder();
 
-		background-color: #DAF0E0;
+		background-color: lighten( $alert-green, 40 );
 		margin-left: auto;
 		margin-right: auto;
 		width: 10%;

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -1,166 +1,166 @@
 .plan-thank-you-card {
-  position: relative;
-  width: 100%;
-  max-width: 500px;
-  background-color: #328246;
-  border-radius: 6px;
-  overflow: hidden;
-  margin: 56px auto 24px;
-  color: $white;
-  font-family: $sans;
-  text-align: center;
+	position: relative;
+	width: 100%;
+	max-width: 500px;
+	background-color: #328246;
+	border-radius: 6px;
+	overflow: hidden;
+	margin: 56px auto 24px;
+	color: $white;
+	font-family: $sans;
+	text-align: center;
 
-  @media ( max-width: 500px ) {
-    margin-top: 0;
-  }
+	@media ( max-width: 500px ) {
+		margin-top: 0;
+	}
 }
 
 .plan-thank-you-card__header {
-  background-color: #4AB866;
-  padding: 75px 0 30px;
-  position: relative;
-  z-index: 1;
+	background-color: #4AB866;
+	padding: 75px 0 30px;
+	position: relative;
+	z-index: 1;
 }
 
 .plan-thank-you-card__body {
-  padding: 40px;
+	padding: 40px;
 }
 
 .plan-thank-you-card__heading {
-  font-size: 22px;
-  font-weight: 600;
-  margin-bottom: 8px;
+	font-size: 22px;
+	font-weight: 600;
+	margin-bottom: 8px;
 }
 
 .plan-thank-you-card__description {
-  font-size: 15px;
-  font-weight: 400;
-  width: 280px;
-  max-width: 100%;
-  margin: 0 auto 30px;
-  line-height: 20px;
+	font-size: 15px;
+	font-weight: 400;
+	width: 280px;
+	max-width: 100%;
+	margin: 0 auto 30px;
+	line-height: 20px;
 }
 
 .plan-thank-you-card__button {
-  display: inline-block;
-  border-radius: 4px;
-  background-color: $white;
-  color: #194324;
-  font-size: 14px;
-  height: 40px;
-  line-height: 40px;
-  padding: 0 60px;
-  box-shadow: 0px 1px 0px 1px rgba(0, 0, 0, .3);
+	display: inline-block;
+	border-radius: 4px;
+	background-color: $white;
+	color: #194324;
+	font-size: 14px;
+	height: 40px;
+	line-height: 40px;
+	padding: 0 60px;
+	box-shadow: 0px 1px 0px 1px rgba(0, 0, 0, .3);
 
-  @media ( max-width: 320px) {
-    padding: 0;
-    width: 100%;
-    text-align: center;
-  }
+	@media ( max-width: 320px) {
+		padding: 0;
+		width: 100%;
+		text-align: center;
+	}
 }
 
 .plan-thank-you-card__button:hover {
-  box-shadow: 0px 1px 0px 1px rgba(0, 0, 0, .5);
-  color: #194324;
+	box-shadow: 0px 1px 0px 1px rgba(0, 0, 0, .5);
+	color: #194324;
 }
 
 .plan-thank-you-card__plan-name {
-  font-size: 18px;
-  font-weight: 500;
+	font-size: 18px;
+	font-weight: 500;
 }
 
 .plan-thank-you-card__plan-price {
-  font-size: 15px;
-  font-weight: 500;
-  color: #DAF0E0;
+	font-size: 15px;
+	font-weight: 500;
+	color: #DAF0E0;
 
-  &.is-placeholder {
-    @include placeholder();
+	&.is-placeholder {
+		@include placeholder();
 
-    background-color: #DAF0E0;
+		background-color: #DAF0E0;
 		margin-left: auto;
 		margin-right: auto;
 		width: 10%;
-  }
+	}
 }
 
 .plan-thank-you-card__background-icons {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -1;
-  color: #72D58B;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	z-index: -1;
+	color: #72D58B;
 
-  svg {
-    position: absolute;
+	svg {
+		position: absolute;
 
-    @media ( max-width: 430px ) {
-      path {
-        transform: scale(.7);
-      }
-    }
-  }
+		@media ( max-width: 430px ) {
+			path {
+				transform: scale(.7);
+			}
+		}
+	}
 
-  svg:nth-child(1) {
-    top: 18px;
-    left: 14.8%;
-    transform: rotate(14deg);
-  }
-  svg:nth-child(2) {
-    top: 118px;
-    left: 67.4%;
-    transform: rotate(42deg);
-  }
-  svg:nth-child(3) {
-    top: 108px;
-    left: 86.2%;
-    transform: rotate(-19deg);
-  }
-  svg:nth-child(4) {
-    top: 190px;
-    left: 8.4%;
-    transform: rotate(-223deg);
-  }
-  svg:nth-child(5) {
-    top: 233px;
-    left: 70.6%;
-    transform: rotate(-66deg);
-  }
-  svg:nth-child(6) {
-    top: 83px;
-    left: 4.2%;
-    transform: rotate(40deg);
-  }
-  svg:nth-child(7) {
-    top: 213px;
-    left: 23.8%;
-    transform: rotate(30deg);
-  }
-  svg:nth-child(8) {
-    top: 30px;
-    left: 37.8%;
-    transform: rotate(114deg);
-  }
-  svg:nth-child(9) {
-    top: 26px;
-    left: 78.4%;
-    transform: rotate(-11deg);
-  }
-  svg:nth-child(10) {
-    top: 101px;
-    left: 21%;
-    transform: rotate(-9deg);
-  }
-  svg:nth-child(11) {
-    top: 21px;
-    left: 62%;
-    transform: rotate(-33deg);
-  }
-  svg:nth-child(12) {
-    top: 161px;
-    left: 77.6%;
-    transform: rotate(-43deg);
-  }
+	svg:nth-child(1) {
+		top: 18px;
+		left: 14.8%;
+		transform: rotate(14deg);
+	}
+	svg:nth-child(2) {
+		top: 118px;
+		left: 67.4%;
+		transform: rotate(42deg);
+	}
+	svg:nth-child(3) {
+		top: 108px;
+		left: 86.2%;
+		transform: rotate(-19deg);
+	}
+	svg:nth-child(4) {
+		top: 190px;
+		left: 8.4%;
+		transform: rotate(-223deg);
+	}
+	svg:nth-child(5) {
+		top: 233px;
+		left: 70.6%;
+		transform: rotate(-66deg);
+	}
+	svg:nth-child(6) {
+		top: 83px;
+		left: 4.2%;
+		transform: rotate(40deg);
+	}
+	svg:nth-child(7) {
+		top: 213px;
+		left: 23.8%;
+		transform: rotate(30deg);
+	}
+	svg:nth-child(8) {
+		top: 30px;
+		left: 37.8%;
+		transform: rotate(114deg);
+	}
+	svg:nth-child(9) {
+		top: 26px;
+		left: 78.4%;
+		transform: rotate(-11deg);
+	}
+	svg:nth-child(10) {
+		top: 101px;
+		left: 21%;
+		transform: rotate(-9deg);
+	}
+	svg:nth-child(11) {
+		top: 21px;
+		left: 62%;
+		transform: rotate(-33deg);
+	}
+	svg:nth-child(12) {
+		top: 161px;
+		left: 77.6%;
+		transform: rotate(-43deg);
+	}
 }

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -2,8 +2,8 @@
 	position: relative;
 	width: 100%;
 	max-width: 500px;
-	background-color: #328246;
-	border-radius: 6px;
+	background-color: darken( $alert-green, 10 );
+	border-radius: 8px 8px 6px 6px;
 	overflow: hidden;
 	margin: 56px auto 24px;
 	color: $white;
@@ -16,10 +16,12 @@
 }
 
 .plan-thank-you-card__header {
-	background-color: #4AB866;
+	background-color: $alert-green;
 	padding: 75px 0 30px;
 	position: relative;
 	z-index: 1;
+	line-height: 1.2;
+	border-radius: 6px 6px 0 0;
 }
 
 .plan-thank-you-card__body {
@@ -45,12 +47,17 @@
 	display: inline-block;
 	border-radius: 4px;
 	background-color: $white;
-	color: #194324;
+	color: darken( $alert-green, 30 );
 	font-size: 14px;
 	height: 40px;
 	line-height: 40px;
 	padding: 0 60px;
-	box-shadow: 0px 1px 0px 1px rgba(0, 0, 0, .3);
+	border-style: solid;
+	border-color: darken( $alert-green, 20 );
+	border-width: 1px 1px 2px;
+	
+	//box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3),
+	//			0 2px 0 0 rgba(0, 0, 0, 0.3);
 
 	@media ( max-width: 320px) {
 		padding: 0;
@@ -60,8 +67,22 @@
 }
 
 .plan-thank-you-card__button:hover {
-	box-shadow: 0px 1px 0px 1px rgba(0, 0, 0, .5);
-	color: #194324;
+	//box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4),
+	//			0 2px 0 0 rgba(0, 0, 0, 0.4);
+	border-color: darken( $alert-green, 30 );
+	color: darken( $alert-green, 10 );
+}
+
+.plan-thank-you-card__button:focus {
+	color: darken( $alert-green, 10 );
+	outline: 1px dotted $white;	
+}
+
+.plan-thank-you-card__button:active {
+	//box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2),
+	//			0 -2px 0 0 rgba(0, 0, 0, 0.2);
+	border-width: 2px 1px 1px;
+	color: darken( $alert-green, 30 );
 }
 
 .plan-thank-you-card__plan-name {
@@ -84,6 +105,21 @@
 	}
 }
 
+@keyframes floating {
+	0% {
+		opacity: 0;
+		transform: translateY( 0 ) translateX( 0 ) rotate( 0 );
+	}
+	70% {
+		opacity: 1;
+		transform: translateY( 5px ) translateX( 5px ) rotate( -20deg );
+	}
+	100% {
+		opacity: 0;
+		transform: translateY( 0 ) translateX( 0 ) rotate( 0 );
+	}
+}
+
 .plan-thank-you-card__background-icons {
 	position: absolute;
 	top: 0;
@@ -91,10 +127,12 @@
 	width: 100%;
 	height: 100%;
 	z-index: -1;
-	color: #72D58B;
+	color: rgba( $white, 0.4 );
 
 	svg {
 		position: absolute;
+		opacity: 0;
+		animation: floating 10s infinite ease-in-out;
 
 		@media ( max-width: 430px ) {
 			path {
@@ -107,60 +145,72 @@
 		top: 18px;
 		left: 14.8%;
 		transform: rotate(14deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(2) {
 		top: 118px;
 		left: 67.4%;
 		transform: rotate(42deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(3) {
 		top: 108px;
 		left: 86.2%;
 		transform: rotate(-19deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(4) {
 		top: 190px;
 		left: 8.4%;
 		transform: rotate(-223deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(5) {
 		top: 233px;
 		left: 70.6%;
 		transform: rotate(-66deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(6) {
 		top: 83px;
 		left: 4.2%;
 		transform: rotate(40deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(7) {
 		top: 213px;
 		left: 23.8%;
 		transform: rotate(30deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(8) {
 		top: 30px;
 		left: 37.8%;
 		transform: rotate(114deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(9) {
 		top: 26px;
 		left: 78.4%;
 		transform: rotate(-11deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(10) {
 		top: 101px;
 		left: 21%;
 		transform: rotate(-9deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(11) {
 		top: 21px;
 		left: 62%;
 		transform: rotate(-33deg);
+		animation-delay: random(10) + s;
 	}
 	svg:nth-child(12) {
 		top: 161px;
 		left: 77.6%;
 		transform: rotate(-43deg);
+		animation-delay: random(10) + s;
 	}
 }

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -19,7 +19,6 @@
 	background-color: $alert-green;
 	padding: 75px 0 30px;
 	position: relative;
-	z-index: 1;
 	line-height: 1.2;
 	border-radius: 6px 6px 0 0;
 }
@@ -129,7 +128,6 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-	z-index: -1;
 	color: rgba( $white, 0.4 );
 
 	svg {

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -8,6 +8,7 @@
   margin: 56px auto 24px;
   color: $white;
   font-family: $sans;
+  text-align: center;
 
   @media ( max-width: 500px ) {
     margin-top: 0;
@@ -66,6 +67,12 @@
 .plan-thank-you-card__plan-name {
   font-size: 18px;
   font-weight: 500;
+}
+
+.plan-thank-you-card__plan-price {
+  font-size: 15px;
+  font-weight: 500;
+  color: #DAF0E0;
 }
 
 .plan-thank-you-card__background-icons {

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -73,6 +73,15 @@
   font-size: 15px;
   font-weight: 500;
   color: #DAF0E0;
+
+  &.is-placeholder {
+    @include placeholder();
+
+    background-color: #DAF0E0;
+		margin-left: auto;
+		margin-right: auto;
+		width: 10%;
+  }
 }
 
 .plan-thank-you-card__background-icons {

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -38,7 +38,8 @@
 	line-height: 20px;
 }
 
-.plan-thank-you-card__button {
+.plan-thank-you-card__button,
+.plan-thank-you-card__button:visited {
 	display: inline-block;
 	border-radius: 4px;
 	background-color: $white;

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -51,12 +51,6 @@
 	border-style: solid;
 	border-color: darken( $alert-green, 20 );
 	border-width: 1px 1px 2px;
-
-	@media ( max-width: 320px) {
-		padding: 0;
-		width: 100%;
-		text-align: center;
-	}
 }
 
 .plan-thank-you-card__button:hover {

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -56,9 +56,6 @@
 	border-color: darken( $alert-green, 20 );
 	border-width: 1px 1px 2px;
 
-	//box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3),
-	//			0 2px 0 0 rgba(0, 0, 0, 0.3);
-
 	@media ( max-width: 320px) {
 		padding: 0;
 		width: 100%;
@@ -67,8 +64,6 @@
 }
 
 .plan-thank-you-card__button:hover {
-	//box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4),
-	//			0 2px 0 0 rgba(0, 0, 0, 0.4);
 	border-color: darken( $alert-green, 30 );
 	color: darken( $alert-green, 10 );
 }
@@ -79,8 +74,6 @@
 }
 
 .plan-thank-you-card__button:active {
-	//box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2),
-	//			0 -2px 0 0 rgba(0, 0, 0, 0.2);
 	border-width: 2px 1px 1px;
 	color: darken( $alert-green, 30 );
 }

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -88,7 +88,7 @@
 .plan-thank-you-card__plan-name {
 	font-size: 18px;
 	font-weight: 500;
-	margin-bottom: 10px;
+	margin-bottom: 5px;
 
 	&.is-placeholder {
 		@include placeholder();

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -9,10 +9,6 @@
 	color: $white;
 	font-family: $sans;
 	text-align: center;
-
-	@media ( max-width: 500px ) {
-		margin-top: 0;
-	}
 }
 
 .plan-thank-you-card__header {
@@ -130,88 +126,70 @@
 	height: 100%;
 	color: rgba( $white, 0.4 );
 
-	svg {
+	.gridicon {
 		position: absolute;
 		opacity: 0;
 		animation: floating 10s infinite ease-in-out;
-
-		@media ( max-width: 430px ) {
-			path {
-				transform: scale(.7);
-			}
-		}
 	}
 
-	svg:nth-child(1) {
+	.gridicon:nth-child(1) {
 		top: 18px;
 		left: 14.8%;
-		transform: rotate(14deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(2) {
+	.gridicon:nth-child(2) {
 		top: 118px;
 		left: 67.4%;
-		transform: rotate(42deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(3) {
+	.gridicon:nth-child(3) {
 		top: 108px;
 		left: 86.2%;
-		transform: rotate(-19deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(4) {
+	.gridicon:nth-child(4) {
 		top: 190px;
 		left: 8.4%;
-		transform: rotate(-223deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(5) {
+	.gridicon:nth-child(5) {
 		top: 233px;
 		left: 70.6%;
-		transform: rotate(-66deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(6) {
+	.gridicon:nth-child(6) {
 		top: 83px;
 		left: 4.2%;
-		transform: rotate(40deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(7) {
+	.gridicon:nth-child(7) {
 		top: 213px;
 		left: 23.8%;
-		transform: rotate(30deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(8) {
+	.gridicon:nth-child(8) {
 		top: 30px;
 		left: 37.8%;
-		transform: rotate(114deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(9) {
+	.gridicon:nth-child(9) {
 		top: 26px;
 		left: 78.4%;
-		transform: rotate(-11deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(10) {
+	.gridicon:nth-child(10) {
 		top: 101px;
 		left: 21%;
-		transform: rotate(-9deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(11) {
+	.gridicon:nth-child(11) {
 		top: 21px;
 		left: 62%;
-		transform: rotate(-33deg);
 		animation-delay: random(10) + s;
 	}
-	svg:nth-child(12) {
+	.gridicon:nth-child(12) {
 		top: 161px;
 		left: 77.6%;
-		transform: rotate(-43deg);
 		animation-delay: random(10) + s;
 	}
 }

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -55,7 +55,7 @@
 	border-style: solid;
 	border-color: darken( $alert-green, 20 );
 	border-width: 1px 1px 2px;
-	
+
 	//box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3),
 	//			0 2px 0 0 rgba(0, 0, 0, 0.3);
 
@@ -75,7 +75,7 @@
 
 .plan-thank-you-card__button:focus {
 	color: darken( $alert-green, 10 );
-	outline: 1px dotted $white;	
+	outline: 1px dotted $white;
 }
 
 .plan-thank-you-card__button:active {
@@ -88,6 +88,16 @@
 .plan-thank-you-card__plan-name {
 	font-size: 18px;
 	font-weight: 500;
+	margin-bottom: 10px;
+
+	&.is-placeholder {
+		@include placeholder();
+
+		background-color: #DAF0E0;
+		margin-left: auto;
+		margin-right: auto;
+		width: 35%;
+	}
 }
 
 .plan-thank-you-card__plan-price {

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -38,6 +38,7 @@ import AuthorCompactProfile from 'blocks/author-compact-profile/docs/example';
 import RelatedPostCard from 'blocks/reader-related-card/docs/example';
 import SearchPostCard from 'blocks/reader-search-card/docs/example';
 import PlanPrice from 'my-sites/plan-price/docs/example';
+import PlanThankYouCard from 'blocks/plan-thank-you-card/docs/example';
 
 export default React.createClass( {
 
@@ -97,6 +98,7 @@ export default React.createClass( {
 					<ReaderFullPostHeader />
 					<AuthorCompactProfile />
 					<PlanPrice />
+					<PlanThankYouCard />
 				</Collection>
 			</div>
 		);

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,6 +81,14 @@ module.exports = {
 		},
 		defaultVariation: 'hideThemePreview',
 	},
+	checkoutThanksPageAfterSignup: {
+		datestamp: '20160828',
+		variations: {
+			singleCTA: 50,
+			allFeatures: 50
+		},
+		defaultVariation: 'allFeatures'
+	},
 	readerSearchSuggestions: {
 		datestamp: '20160804',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,14 +81,6 @@ module.exports = {
 		},
 		defaultVariation: 'hideThemePreview',
 	},
-	checkoutThanksPageAfterSignup: {
-		datestamp: '20160828',
-		variations: {
-			singleCTA: 50,
-			allFeatures: 50
-		},
-		defaultVariation: 'allFeatures'
-	},
 	readerSearchSuggestions: {
 		datestamp: '20160804',
 		variations: {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -55,6 +55,7 @@ import { getFeatureByKey, shouldFetchSitePlans } from 'lib/plans';
 import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
 import upgradesPaths from 'my-sites/upgrades/paths';
+import { abtest } from 'lib/abtest';
 
 function getPurchases( props ) {
 	return props.receipt.data.purchases;
@@ -185,7 +186,7 @@ const CheckoutThankYou = React.createClass( {
 		const createdAt = moment( this.props.selectedSite.options.created_at );
 		// TODO(marekhrabe): set time to a reasonable amount
 		const isRecent = createdAt.isAfter( moment().subtract( 10, 'hour' ) );
-		const isInAbTest = true;
+		const isInAbTest = abtest( 'paidNuxStreamlined' ) === 'streamlined';
 
 		if ( isInAbTest && isRecent && wasOnlyDotcomPlanPurchased ) {
 			return (

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -119,7 +119,7 @@ const CheckoutThankYou = React.createClass( {
 
 		return (
 			<Notice className="checkout-thank-you__verification-notice" showDismiss={ false }>
-				{ this.translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. Please use this time to confirm your email address.', {
+				{ this.translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. Please check your email to confirm your address.', {
 					args: { email: this.props.user.email },
 					components: { strong: <strong />
 				} } ) }

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -183,12 +183,22 @@ const CheckoutThankYou = React.createClass( {
 			wasOnlyDotcomPlanPurchased = purchases.every( isPlan );
 		}
 
-		const createdAt = moment( this.props.selectedSite.options.created_at );
-		// TODO(marekhrabe): set time to a reasonable amount
-		const isRecent = createdAt.isAfter( moment().subtract( 10, 'hour' ) );
+		const userCreatedMoment = moment( this.props.user.date );
+		const isNewUser = userCreatedMoment.isAfter( moment().subtract( 2, 'hours' ) );
 		const isInAbTest = abtest( 'paidNuxStreamlined' ) === 'streamlined';
 
-		if ( isInAbTest && isRecent && wasOnlyDotcomPlanPurchased ) {
+		// placeholder
+		if ( ! this.isDataLoaded() && ! this.isGenericReceipt() ) {
+			// disabled because we use global loader icon
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
+			return (
+				<div className="wpcom-site__logo noticon noticon-wordpress"></div>
+			);
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
+		}
+
+		// streamlined paid NUX thanks page
+		if ( isInAbTest && isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
 				<Main className={ classes }>
 					<PlanThankYouCard selectedSite={ this.props.selectedSite } />
@@ -197,6 +207,7 @@ const CheckoutThankYou = React.createClass( {
 			);
 		}
 
+		// standard thanks page
 		return (
 			<Main className={ classes }>
 				<HeaderCake

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import find from 'lodash/find';
 import page from 'page';
@@ -170,10 +169,6 @@ const CheckoutThankYou = React.createClass( {
 	},
 
 	render() {
-		const classes = classNames( 'checkout-thank-you', {
-			'is-placeholder': ! this.isDataLoaded()
-		} );
-
 		let purchases = null,
 			wasJetpackPlanPurchased = false,
 			wasOnlyDotcomPlanPurchased = false;
@@ -187,8 +182,8 @@ const CheckoutThankYou = React.createClass( {
 		const isNewUser = userCreatedMoment.isAfter( moment().subtract( 2, 'hours' ) );
 		const isPaidNuxStreamlinedAbTest = abtest( 'paidNuxStreamlined' ) === 'streamlined';
 
-		// placeholder
-		if ( ! this.isDataLoaded() && ! this.isGenericReceipt() ) {
+		// this placeholder is using just wp logo here because two possible states do not share a common layout
+		if ( ! purchases && ! this.isGenericReceipt() ) {
 			// disabled because we use global loader icon
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
@@ -200,7 +195,7 @@ const CheckoutThankYou = React.createClass( {
 		// streamlined paid NUX thanks page
 		if ( isPaidNuxStreamlinedAbTest && isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
-				<Main className={ classes }>
+				<Main className="checkout-thank-you">
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />
 					{ this.renderConfirmationNotice() }
 				</Main>
@@ -209,7 +204,7 @@ const CheckoutThankYou = React.createClass( {
 
 		// standard thanks page
 		return (
-			<Main className={ classes }>
+			<Main className="checkout-thank-you">
 				<HeaderCake
 					onClick={ this.goBack }
 					isCompact
@@ -220,9 +215,7 @@ const CheckoutThankYou = React.createClass( {
 				</Card>
 
 				<Card className="checkout-thank-you__footer">
-					<HappinessSupport
-						isJetpack={ wasJetpackPlanPurchased }
-						isPlaceholder={ ! this.isDataLoaded() && ! this.isGenericReceipt() } />
+					<HappinessSupport isJetpack={ wasJetpackPlanPurchased } />
 				</Card>
 			</Main>
 		);

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -185,7 +185,7 @@ const CheckoutThankYou = React.createClass( {
 
 		const userCreatedMoment = moment( this.props.user.date );
 		const isNewUser = userCreatedMoment.isAfter( moment().subtract( 2, 'hours' ) );
-		const isInAbTest = abtest( 'paidNuxStreamlined' ) === 'streamlined';
+		const isPaidNuxStreamlinedAbTest = abtest( 'paidNuxStreamlined' ) === 'streamlined';
 
 		// placeholder
 		if ( ! this.isDataLoaded() && ! this.isGenericReceipt() ) {
@@ -198,7 +198,7 @@ const CheckoutThankYou = React.createClass( {
 		}
 
 		// streamlined paid NUX thanks page
-		if ( isInAbTest && isNewUser && wasOnlyDotcomPlanPurchased ) {
+		if ( isPaidNuxStreamlinedAbTest && isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
 				<Main className={ classes }>
 					<PlanThankYouCard selectedSite={ this.props.selectedSite } />

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -113,7 +113,7 @@ const CheckoutThankYou = React.createClass( {
 
 	renderConfirmationNotice: function() {
 		if ( ! this.props.user || ! this.props.user.email || this.props.email_verified ) {
-			return;
+			return null;
 		}
 
 		return (

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -118,9 +118,10 @@ const CheckoutThankYou = React.createClass( {
 
 		return (
 			<Notice className="checkout-thank-you__verification-notice" showDismiss={ false }>
-				{ this.translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. Please check your email to confirm your address.', {
-					args: { email: this.props.user.email },
-					components: { strong: <strong />
+				{ this.translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. ' +
+					'Please check your email to confirm your address.', {
+						args: { email: this.props.user.email },
+						components: { strong: <strong className="checkout-thank-you__verification-notice-email" />
 				} } ) }
 			</Notice>
 		);

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -22,7 +22,7 @@ import { fetchReceipt } from 'state/receipts/actions';
 import { fetchSitePlans, refreshSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getReceiptById } from 'state/receipts/selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser, getCurrentUserDate } from 'state/current-user/selectors';
 import GoogleAppsDetails from './google-apps-details';
 import GuidedTransferDetails from './guided-transfer-details';
 import HappinessSupport from 'components/happiness-support';
@@ -179,7 +179,7 @@ const CheckoutThankYou = React.createClass( {
 			wasOnlyDotcomPlanPurchased = purchases.every( isPlan );
 		}
 
-		const userCreatedMoment = moment( this.props.user.date );
+		const userCreatedMoment = moment( this.props.userDate );
 		const isNewUser = userCreatedMoment.isAfter( moment().subtract( 2, 'hours' ) );
 		const isPaidNuxStreamlinedAbTest = abtest( 'paidNuxStreamlined' ) === 'streamlined';
 
@@ -321,7 +321,8 @@ export default connect(
 		return {
 			receipt: getReceiptById( state, props.receiptId ),
 			sitePlans: getPlansBySite( state, props.selectedSite ),
-			user: getCurrentUser( state )
+			user: getCurrentUser( state ),
+			userDate: getCurrentUserDate( state ),
 		};
 	},
 	( dispatch ) => {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -201,7 +201,7 @@ const CheckoutThankYou = React.createClass( {
 		if ( isPaidNuxStreamlinedAbTest && isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
 				<Main className={ classes }>
-					<PlanThankYouCard selectedSite={ this.props.selectedSite } />
+					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />
 					{ this.renderConfirmationNotice() }
 				</Main>
 			);

--- a/client/my-sites/upgrades/checkout-thank-you/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/style.scss
@@ -220,3 +220,13 @@
 		max-width: 634px;
 	}
 }
+
+.checkout-thank-you__verification-notice {
+  max-width: 500px;
+  text-align: left;
+  margin: 0 auto;
+
+	strong {
+		white-space: nowrap;
+	}
+}

--- a/client/my-sites/upgrades/checkout-thank-you/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/style.scss
@@ -225,8 +225,8 @@
   max-width: 500px;
   text-align: left;
   margin: 0 auto;
+}
 
-	strong {
-		white-space: nowrap;
-	}
+.checkout-thank-you__verification-notice-email {
+	white-space: nowrap;
 }


### PR DESCRIPTION
We want to improve our current thanks page that people land on after signup and checkout. 

We simply want to thank them, remind that they should check their e-mail for verification and finally offer a single call-to-action button that will take them to the Trampoline.

At the moment there is a lot going on in this part of Calypso. Namely, #7589 and #7587. Not conflicting, just good to keep an eye on them.

There is an another proposal #7558 that kinda addresses this issue, but it's more about polishing the old version. I think we would rather go with this simplified solution, at least for this use-case.

Testing:
- use sandboxed store, so you don't have to spend real 💸 
- open an incognito window and go to signup on [calypso.localhost](http://calypso.localhost:3000/start) or [calypso.live](https://calypso.live/start?branch=update/thanks-page-paid-nux)
- from the A/B tests dropdown, select `paidNuxStreamlined: streamlined`
- go through signup and choose a paid plan
- purchase it
- you will end up on a new thanks page from this PR

The condition to show this new green thanks page is that the _user age is less than 2 hours_. That makes sure, this will only be showed for new users.

You can also test the component outside of signup flow in devdocs ([calypso.localhost](http://calypso.localhost:3000/devdocs/blocks/plan-thank-you-card) or [calypso.live](http://calypso.live/devdocs/blocks/plan-thank-you-card?branch=update/thanks-page-paid-nux)). It will use your primary site and its plan to render the card.

Test live: https://calypso.live/start?branch=update/thanks-page-paid-nux