### PR TITLE
Plans: auto open for plans descriptions (refact)

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -41,6 +41,15 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
+	plansDescriptions: {
+		datestamp: '20160901',
+		variations: {
+			auto: 50,
+			click: 50,
+		},
+		defaultVariation: 'click',
+		allowExistingUsers: false,
+	},
 	signupStore: {
 		datestamp: '20160727',
 		variations: {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -44,6 +44,7 @@ import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import SpinnerLine from 'components/spinner-line';
 import FoldableCard from 'components/foldable-card';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { abtest } from 'lib/abtest';
 
 class PlanFeatures extends Component {
 
@@ -321,18 +322,32 @@ class PlanFeatures extends Component {
 	}
 
 	renderFeatureItem( feature, index ) {
+		const title = feature.getTitle();
+		const description = feature.getDescription
+			? feature.getDescription()
+			: null;
+
+		if ( abtest( 'plansDescriptions' ) === 'auto' ) {
+			return (
+				<PlanFeaturesItem
+					key={ index }
+					description={ description }
+					onMouseEnter={ this.showFeaturePopover }
+					onMouseLeave={ this.closeFeaturePopover }
+					onTouchStart={ this.swapFeaturePopover }
+				>
+					{ title }
+				</PlanFeaturesItem>
+			);
+		}
+
 		return (
 			<PlanFeaturesItem
 				key={ index }
-				description={ feature.getDescription
-					? feature.getDescription()
-					: null
-				}
-				onMouseEnter={ this.showFeaturePopover }
-				onMouseLeave={ this.closeFeaturePopover }
-				onTouchStart={ this.swapFeaturePopover }
+				description={ description }
+				onClick={ this.swapFeaturePopover }
 			>
-				{ feature.getTitle() }
+				{ title }
 			</PlanFeaturesItem>
 		);
 	}

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -8,23 +8,33 @@ import React from 'react';
  */
 import Gridicon from 'components/gridicon';
 
+/**
+ * Module variables
+ */
+const noop = () => {};
+
 export default function PlanFeaturesItem( {
 	children,
 	description,
-	onMouseEnter,
-	onMouseLeave,
-	onTouchStart,
+	onClick = noop,
+	onMouseEnter = noop,
+	onMouseLeave = noop,
+	onTouchStart = noop,
 } ) {
-	const handleOnTouchStart = ( event ) => {
-		onTouchStart( event.currentTarget, description );
+	const handleOnClick = ( { currentTarget } ) => {
+		onClick( currentTarget, description );
 	};
 
-	const handleOnMouseEvent = ( event ) => {
-		onMouseEnter( event.currentTarget, description );
+	const handleOnTouchStart = ( { currentTarget } ) => {
+		onTouchStart( currentTarget, description );
 	};
 
-	const handleOnMouseLeave = ( event ) => {
-		onMouseLeave( event.currentTarget, description );
+	const handleOnMouseEvent = ( { currentTarget } ) => {
+		onMouseEnter( currentTarget, description );
+	};
+
+	const handleOnMouseLeave = ( { currentTarget } ) => {
+		onMouseLeave( currentTarget, description );
 	};
 
 	return (
@@ -37,6 +47,7 @@ export default function PlanFeaturesItem( {
 				onMouseEnter={ handleOnMouseEvent }
 				onMouseLeave={ handleOnMouseLeave }
 				onTouchStart={ handleOnTouchStart }
+				onClick={ handleOnClick }
 				className="plan-features__item-tip-info"
 			>
 				<Gridicon icon="info-outline" size={ 18 } />


### PR DESCRIPTION
Introduces test mentioned in #6997.
Also this PR tries to reach out the same purpose that #7465. I didn't rebased the `new/plans-hover-tooltip` branch in order to avoid override the code that @artpi  wrote right there.

## Testing

1) Find, activate and deactivate the test from ABTEST option in dev menu.

<img src="https://cloud.githubusercontent.com/assets/77539/17894585/3e3e332a-6920-11e6-8bcd-56daaecb6961.gif" width="400px" />

2) See how the InfoPopover is shown when the user does a `click` or `mouseEnter/mouseLeave` event in function of the test previously selected.