### PR TITLE
Themes: Add '/vertical' section to URL

### DIFF
--- a/client/components/data/themes-list-fetcher/index.jsx
+++ b/client/components/data/themes-list-fetcher/index.jsx
@@ -29,6 +29,7 @@ const ThemesListFetcher = React.createClass( {
 		search: React.PropTypes.string,
 		tier: React.PropTypes.string,
 		filter: React.PropTypes.string,
+		vertical: React.PropTypes.string,
 		onRealScroll: React.PropTypes.func,
 		onLastPage: React.PropTypes.func,
 		// Connected props

--- a/client/components/data/themes-list-fetcher/index.jsx
+++ b/client/components/data/themes-list-fetcher/index.jsx
@@ -29,7 +29,6 @@ const ThemesListFetcher = React.createClass( {
 		search: React.PropTypes.string,
 		tier: React.PropTypes.string,
 		filter: React.PropTypes.string,
-		vertical: React.PropTypes.string,
 		onRealScroll: React.PropTypes.func,
 		onLastPage: React.PropTypes.func,
 		// Connected props

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -31,7 +31,7 @@ function makeElement( ThemesComponent, Head, store, props ) {
 }
 
 function getProps( context ) {
-	const { tier, filter, site_id: siteId } = context.params;
+	const { tier, filter, vertical, site_id: siteId } = context.params;
 
 	const { basePath, analyticsPageTitle } = getAnalyticsData(
 		context.path,
@@ -51,6 +51,7 @@ function getProps( context ) {
 		title: i18n.translate( 'Themes', { textOnly: true } ),
 		tier,
 		filter,
+		vertical,
 		analyticsPageTitle,
 		analyticsPath: basePath,
 		search: context.query.s,

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -3,15 +3,18 @@
  */
 import config from 'config';
 import { makeLayout } from 'controller';
+import { getSubjects } from './theme-filters.js';
 
 // `logged-out` middleware isn't SSR-compliant yet, but we can at least render
 // the layout.
 // FIXME: Also create loggedOut/multiSite/singleSite elements, depending on route.
 
 export default function( router ) {
+	const verticals = getSubjects().join( '|' );
+
 	if ( config.isEnabled( 'manage/themes' ) ) {
-		router( '/design/:tier(free|premium)?', makeLayout );
-		router( '/design/:tier(free|premium)?/filter/:filter', makeLayout );
+		router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
+		router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );
 		router( '/design/*', makeLayout ); // Needed so direct hits don't result in a 404.
 	}
 }

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -6,20 +6,22 @@ import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
 import { makeNavigation, siteSelection } from 'my-sites/controller';
 import { singleSite, multiSite, loggedOut } from './controller';
+import { getSubjects } from './theme-filters.js';
 
 export default function( router ) {
 	const user = userFactory();
 	const isLoggedIn = !! user.get();
+	const verticals = getSubjects().join( '|' );
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
-			router( '/design/:tier(free|premium)?', multiSite, makeNavigation, makeLayout );
-			router( '/design/:tier(free|premium)?/:site_id', siteSelection, singleSite, makeNavigation, makeLayout );
-			router( '/design/:tier(free|premium)?/filter/:filter', siteSelection, multiSite, makeNavigation, makeLayout );
-			router( '/design/:tier(free|premium)?/filter/:filter/:site_id', siteSelection, singleSite, makeNavigation, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, multiSite, makeNavigation, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/:site_id`, siteSelection, singleSite, makeNavigation, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, siteSelection, multiSite, makeNavigation, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id`, siteSelection, singleSite, makeNavigation, makeLayout );
 		} else {
-			router( '/design/:tier(free|premium)?', loggedOut, makeLayout );
-			router( '/design/:tier(free|premium)?/filter/:filter', loggedOut, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, loggedOut, makeLayout );
 		}
 	}
 }

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -15,10 +15,22 @@ export default function( router ) {
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, multiSite, makeNavigation, makeLayout );
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/:site_id`, siteSelection, singleSite, makeNavigation, makeLayout );
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, siteSelection, multiSite, makeNavigation, makeLayout );
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id`, siteSelection, singleSite, makeNavigation, makeLayout );
+			router(
+				`/design/:vertical(${ verticals })?/:tier(free|premium)?`,
+				multiSite, makeNavigation, makeLayout
+			);
+			router(
+				`/design/:vertical(${ verticals })?/:tier(free|premium)?/:site_id`,
+				siteSelection, singleSite, makeNavigation, makeLayout
+			);
+			router(
+				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
+				siteSelection, multiSite, makeNavigation, makeLayout
+			);
+			router(
+				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id`,
+				siteSelection, singleSite, makeNavigation, makeLayout
+			);
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, loggedOut, makeLayout );

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -271,3 +271,7 @@ export function getSortedFilterTerms( input ) {
 export function stripFilters( input ) {
 	return input.replace( FILTER_REGEX_GLOBAL, '' ).trim();
 }
+
+export function getSubjects() {
+	return taxonomies.subject;
+}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -132,6 +132,7 @@ const ThemeShowcase = React.createClass( {
 					trackScrollPage={ this.props.trackScrollPage }
 					tier={ this.props.tier }
 					filter={ this.props.filter }
+					vertical={ this.props.vertical }
 					queryParams={ this.props.queryParams }
 					themesList={ this.props.themesList } />
 			</Main>

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -38,6 +38,8 @@ const ThemesSelection = React.createClass( {
 		themesList: PropTypes.array.isRequired,
 		getActionLabel: React.PropTypes.func,
 		tier: React.PropTypes.string,
+		filter: React.PropTypes.string,
+		vertical: React.PropTypes.string,
 	},
 
 	getDefaultProps() {
@@ -89,11 +91,14 @@ const ThemesSelection = React.createClass( {
 	},
 
 	updateUrl( tier, filter, searchString = this.props.search ) {
-		const siteId = this.props.siteId ? `/${this.props.siteId}` : '';
+		const { siteId, vertical } = this.props;
+
+		const siteIdSection = siteId ? `/${ siteId }` : '';
+		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = tier === 'all' ? '' : `/${ tier }`;
 		const filterSection = filter ? `/filter/${ filter }` : '';
-		const url = `/design${ tierSection }${ filterSection }${siteId}`;
 
+		const url = `/design${ verticalSection }${ tierSection }${ filterSection }${siteIdSection}`;
 		page( buildUrl( url, searchString ) );
 	},
 
@@ -106,7 +111,14 @@ const ThemesSelection = React.createClass( {
 	},
 
 	render() {
-		const site = this.props.selectedSite;
+		const { selectedSite: site, vertical }  = this.props;
+		let filter = this.props.filter || '';
+		if ( filter && vertical ) {
+			filter += ',';
+		}
+		if ( vertical ) {
+			filter += vertical;
+		}
 
 		return (
 			<div className="themes__selection">
@@ -123,7 +135,7 @@ const ThemesSelection = React.createClass( {
 						isMultisite={ ! this.props.siteId } // Not the same as `! site` !
 						search={ this.props.search }
 						tier={ this.props.tier }
-						filter={ this.props.filter }
+						filter={ filter }
 						onRealScroll={ this.trackScrollPage }
 						onLastPage={ this.trackLastPage } >
 					<ThemesList getButtonOptions={ this.props.getOptions }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import page from 'page';
+import compact from 'lodash/compact';
 
 /**
  * Internal dependencies
@@ -98,7 +99,7 @@ const ThemesSelection = React.createClass( {
 		const tierSection = tier === 'all' ? '' : `/${ tier }`;
 		const filterSection = filter ? `/filter/${ filter }` : '';
 
-		const url = `/design${ verticalSection }${ tierSection }${ filterSection }${siteIdSection}`;
+		const url = `/design${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
 		page( buildUrl( url, searchString ) );
 	},
 
@@ -112,12 +113,7 @@ const ThemesSelection = React.createClass( {
 
 	addVerticalToFilters() {
 		const { vertical, filter } = this.props;
-		const result = [];
-
-		filter && result.push( filter );
-		vertical && result.push( vertical );
-
-		return result.join( ',' );
+		return compact( [ filter, vertical ] ).join( ',' );
 	},
 
 	render() {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -111,7 +111,7 @@ const ThemesSelection = React.createClass( {
 	},
 
 	render() {
-		const { selectedSite: site, vertical }  = this.props;
+		const { selectedSite: site, vertical } = this.props;
 		let filter = this.props.filter || '';
 		if ( filter && vertical ) {
 			filter += ',';

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -110,15 +110,18 @@ const ThemesSelection = React.createClass( {
 		this.props.onScreenshotClick && this.props.onScreenshotClick( theme );
 	},
 
+	addVerticalToFilters() {
+		const { vertical, filter } = this.props;
+		const result = [];
+
+		filter && result.push( filter );
+		vertical && result.push( vertical );
+
+		return result.join( ',' );
+	},
+
 	render() {
-		const { selectedSite: site, vertical } = this.props;
-		let filter = this.props.filter || '';
-		if ( filter && vertical ) {
-			filter += ',';
-		}
-		if ( vertical ) {
-			filter += vertical;
-		}
+		const site = this.props.selectedSite;
 
 		return (
 			<div className="themes__selection">
@@ -135,7 +138,7 @@ const ThemesSelection = React.createClass( {
 						isMultisite={ ! this.props.siteId } // Not the same as `! site` !
 						search={ this.props.search }
 						tier={ this.props.tier }
-						filter={ filter }
+						filter={ this.addVerticalToFilters() }
 						onRealScroll={ this.trackScrollPage }
 						onLastPage={ this.trackLastPage } >
 					<ThemesList getButtonOptions={ this.props.getOptions }


### PR DESCRIPTION
Implements #6922 

![screen shot 2016-08-23 at 15 15 22](https://cloud.githubusercontent.com/assets/7767559/17895291/8abe5684-6944-11e6-9282-c84cf7d16076.png)

Adds optional _vertical_ segment to the showcase URL before _tier_, which can take the value of any one of the _subject_ taxonomy terms:

```
    "subject": [
        "announcement",
        "art",
        "artwork",
        "blog",
        "business",
        "cartoon",
        "collaboration",
        "craft",
        "design",
        "education",
        "fashion",
        "food",
        "gaming",
        "holiday",
        "hotel",
        "journal",
        "lifestream",
        "magazine",
        "major-league-baseball",
        "mlb",
        "music",
        "nature",
        "news",
        "outdoors",
        "partner",
        "photoblogging",
        "photography",
        "portfolio",
        "productivity",
        "real-estate",
        "school",
        "scrapbooking",
        "seasonal",
        "sports",
        "travel",
        "tumblelog",
        "video",
        "wedding"
    ],
```

**To Test**

Try adding one of the above values to a showcase url, for example: 
`http://calypso.localhost:3000/design/wedding`
The list of themes should be the same as entering the filter `subject:wedding` into the search box

* Check that a URL with a vertical component still works with filters, for example add filter `color:blue` in search box
* Check that a URL with a vertical component works when selecting _free_ or _premium_ in the dropdown next to the search box


Test live: https://calypso.live/?branch=add/themes-verticals