### PR TITLE
PlanFeatures: handle info popover through of click event

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -321,18 +321,18 @@ class PlanFeatures extends Component {
 	}
 
 	renderFeatureItem( feature, index ) {
+		const title = feature.getTitle();
+		const description = feature.getDescription
+			? feature.getDescription()
+			: null;
+
 		return (
 			<PlanFeaturesItem
 				key={ index }
-				description={ feature.getDescription
-					? feature.getDescription()
-					: null
-				}
-				onMouseEnter={ this.showFeaturePopover }
-				onMouseLeave={ this.closeFeaturePopover }
-				onTouchStart={ this.swapFeaturePopover }
+				description={ description }
+				onClick={ this.swapFeaturePopover }
 			>
-				{ feature.getTitle() }
+				{ title }
 			</PlanFeaturesItem>
 		);
 	}

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -8,23 +8,33 @@ import React from 'react';
  */
 import Gridicon from 'components/gridicon';
 
+/**
+ * Module variables
+ */
+const noop = () => {};
+
 export default function PlanFeaturesItem( {
 	children,
 	description,
-	onMouseEnter,
-	onMouseLeave,
-	onTouchStart,
+	onClick = noop,
+	onMouseEnter = noop,
+	onMouseLeave = noop,
+	onTouchStart = noop,
 } ) {
-	const handleOnTouchStart = ( event ) => {
-		onTouchStart( event.currentTarget, description );
+	const handleOnClick = ( { currentTarget } ) => {
+		onClick( currentTarget, description );
 	};
 
-	const handleOnMouseEvent = ( event ) => {
-		onMouseEnter( event.currentTarget, description );
+	const handleOnTouchStart = ( { currentTarget } ) => {
+		onTouchStart( currentTarget, description );
 	};
 
-	const handleOnMouseLeave = ( event ) => {
-		onMouseLeave( event.currentTarget, description );
+	const handleOnMouseEvent = ( { currentTarget } ) => {
+		onMouseEnter( currentTarget, description );
+	};
+
+	const handleOnMouseLeave = ( { currentTarget } ) => {
+		onMouseLeave( currentTarget, description );
 	};
 
 	return (
@@ -37,6 +47,7 @@ export default function PlanFeaturesItem( {
 				onMouseEnter={ handleOnMouseEvent }
 				onMouseLeave={ handleOnMouseLeave }
 				onTouchStart={ handleOnTouchStart }
+				onClick={ handleOnClick }
 				className="plan-features__item-tip-info"
 			>
 				<Gridicon icon="info-outline" size={ 18 } />


### PR DESCRIPTION
This PR changes the way in how the InfoPopover feature is shown/hidden rolling back to `click` event instead of `mouseEnter/mouseLeave`. `mouseEnter/mouseLeave` were introduced in this PR: https://github.com/Automattic/wp-calypso/pull/7544

###Testing

1) Open plans-features page: `http://calypso.localhost:3000/plans/<site-id>`
2) Confirm that the Feature Popover is shown/hidden by clicking in the (i) icon.
![image](https://cloud.githubusercontent.com/assets/77539/17896029/7b345f02-6925-11e6-8eb5-cf8029ec7ef2.png)



Test live: https://calypso.live/?branch=update/plan-features-open-info-popover