### PR TITLE
Components: Resolve PopoverMenuItem prop warnings

### DIFF
--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -14,7 +14,6 @@ export default React.createClass( {
 
 	propTypes: {
 		href: PropTypes.string,
-		isVisible: PropTypes.bool,
 		className: PropTypes.string,
 		icon: PropTypes.string,
 		focusOnHover: PropTypes.bool,
@@ -23,7 +22,6 @@ export default React.createClass( {
 
 	getDefaultProps() {
 		return {
-			isVisible: false,
 			className: '',
 			focusOnHover: true
 		};

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +23,6 @@ export default React.createClass( {
 
 	getDefaultProps() {
 		return {
-			className: '',
 			focusOnHover: true
 		};
 	},
@@ -37,7 +37,7 @@ export default React.createClass( {
 				role="menuitem"
 				onMouseOver={ onMouseOver }
 				tabIndex="-1"
-				{ ...this.props }
+				{ ...omit( this.props, 'icon', 'focusOnHover' ) }
 				className={ classnames( 'popover__menu-item', className ) }>
 				{ icon && <Gridicon icon={ icon } size={ 18 } /> }
 				{ children }


### PR DESCRIPTION
Related: #7413

This pull request seeks to resolve warnings which occur when a `<PopoverMenuItem />` component is rendered due to the spread of the component's own props to its rendered child.

It also removes an unused `isVisible` prop from the component.

__Testing instructions:__

Verify that there are no regressions in the use of a popover menu item.

1. Navigate to the [custom post types list screen](http://calypso.localhost:3000/types/post)
2. Select a site
3. Toggle the ellipsis menu for a post
4. Note that each menu item displays and behaves without issue

Test live: https://calypso.live/?branch=fix/popover-menu-item-props-warning