### PR TITLE
Comments block tweaks

### DIFF
--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+const CommentCount = ( { count } ) => {
+	const countPhrase = count + ' comments'; // needs translation and phrase logic
+	return (
+		<div className="comments__comment-count">
+			{ countPhrase }
+		</div>
+	);
+};
+
+CommentCount.propTypes = {
+	count: React.PropTypes.number.isRequired
+};
+
+export default CommentCount;

--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -28,7 +28,7 @@ const CommentCount = ( { count, translate } ) => {
 	return (
 		<div className="comments__comment-count">
 			<span className="comments__comment-count-phrase">{ countPhrase }</span>
-			{ count === 0 && translate( ' - add the first! ' ) }
+			{ count === 0 && translate( ' - Add the first! ' ) }
 		</div>
 	);
 };

--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -6,12 +6,29 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+ import { localize } from 'i18n-calypso';
 
-const CommentCount = ( { count } ) => {
-	const countPhrase = count + ' comments'; // needs translation and phrase logic
+const CommentCount = ( { count, translate } ) => {
+	let countPhrase;
+	if ( count > 0 ) {
+		countPhrase = translate(
+			'%(commentCount)d comment',
+			'%(commentCount)d comments',
+			{
+				count,
+				args: {
+					commentCount: count
+				}
+			}
+		);
+	} else {
+		countPhrase = translate( 'No comments' );
+	}
+
 	return (
 		<div className="comments__comment-count">
-			{ countPhrase }
+			<span className="comments__comment-count-phrase">{ countPhrase }</span>
+			{ count === 0 && translate( ' - add the first! ' ) }
 		</div>
 	);
 };
@@ -20,4 +37,4 @@ CommentCount.propTypes = {
 	count: React.PropTypes.number.isRequired
 };
 
-export default CommentCount;
+export default localize( CommentCount );

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -190,7 +189,7 @@ class PostCommentList extends React.Component {
 
 		return (
 			<div className="comments__comment-list">
-				{ ( this.props.showCommentCount || showViewEarlier ) && <div className={ classNames( 'comments__info-bar', { 'is-no-comments': displayedCommentsCount === 0 } ) }>
+				{ ( this.props.showCommentCount || showViewEarlier ) && <div className="comments__info-bar">
 					{ this.props.showCommentCount && <CommentCount count={ totalCommentsCount } /> }
 					{ showViewEarlier ? <span className="comments__view-earlier" onClick={ this.viewEarlierCommentsHandler }>
 						{

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -26,6 +26,7 @@ import {
 } from 'reader/stats';
 import PostComment from './post-comment';
 import PostCommentForm from './form';
+import CommentCount from './comment-count';
 
 class PostCommentList extends React.Component {
 	constructor( props ) {
@@ -189,7 +190,8 @@ class PostCommentList extends React.Component {
 
 		return (
 			<div className="comments__comment-list">
-				<div className={ classNames( 'comments__top-bar', { 'is-no-comments': displayedCommentsCount === 0 } ) }>
+				{ ( this.props.showCommentCount || showViewEarlier ) && <div className={ classNames( 'comments__info-bar', { 'is-no-comments': displayedCommentsCount === 0 } ) }>
+					{ this.props.showCommentCount && <CommentCount count={ totalCommentsCount } /> }
 					{ showViewEarlier ? <span className="comments__view-earlier" onClick={ this.viewEarlierCommentsHandler }>
 						{
 							translate( 'View earlier comments (Showing %(shown)d of %(total)d)', {
@@ -199,7 +201,7 @@ class PostCommentList extends React.Component {
 								}
 							} )
 						}</span> : null }
-				</div>
+				</div> }
 				{ this.renderCommentsList( displayedComments ) }
 				{ this.renderCommentForm() }
 			</div>
@@ -215,6 +217,7 @@ PostCommentList.propTypes = {
 	onCommentsUpdate: React.PropTypes.func.isRequired,
 	pageSize: React.PropTypes.number,
 	initialSize: React.PropTypes.number,
+	showCommentCount: React.PropTypes.bool,
 
 	// connect()ed props:
 	commentsTree: React.PropTypes.object, //TODO: Find a lib that provides immutable shape
@@ -226,7 +229,8 @@ PostCommentList.propTypes = {
 PostCommentList.defaultProps = {
 	pageSize: NUMBER_OF_COMMENTS_PER_FETCH,
 	initialSize: NUMBER_OF_COMMENTS_PER_FETCH,
-	haveMoreCommentsToFetch: false
+	haveMoreCommentsToFetch: false,
+	showCommentCount: true
 };
 
 export default connect(

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -191,7 +191,7 @@ class PostComment extends React.Component {
 					<Gravatar user={ comment.author } />
 
 					{ comment.author.URL
-						? <a href={ comment.author.URL } target="_blank" className="comments__comment-username" onClick={ this.handleAuthorClick }>{ comment.author.name }<Gridicon icon="external" /></a>
+						? <a href={ comment.author.URL } target="_blank" className="comments__comment-username" onClick={ this.handleAuthorClick }>{ comment.author.name }</a>
 						: <strong className="comments__comment-username">{ comment.author.name }</strong> }
 					<small className="comments__comment-timestamp">
 						<a href={ comment.URL }>

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -197,13 +197,13 @@ class PostComment extends React.Component {
 			<li className={ 'comments__comment depth-' + this.props.depth }>
 				<div className="comments__comment-author">
 					{ authorUrl
-						? <a href={ authorUrl } target="_blank" onClick={ this.handleAuthorClick }>
+						? <a href={ authorUrl } onClick={ this.handleAuthorClick }>
 							<Gravatar user={ comment.author } />
 						</a>
 						: <Gravatar user={ comment.author } /> }
 
 					{ authorUrl
-						? <a href={ authorUrl } target="_blank" className="comments__comment-username" onClick={ this.handleAuthorClick }>{ comment.author.name }</a>
+						? <a href={ authorUrl } className="comments__comment-username" onClick={ this.handleAuthorClick }>{ comment.author.name }</a>
 						: <strong className="comments__comment-username">{ comment.author.name }</strong> }
 					<div className="comments__comment-timestamp">
 						<a href={ comment.URL }>

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -193,11 +193,11 @@ class PostComment extends React.Component {
 					{ comment.author.URL
 						? <a href={ comment.author.URL } target="_blank" className="comments__comment-username" onClick={ this.handleAuthorClick }>{ comment.author.name }</a>
 						: <strong className="comments__comment-username">{ comment.author.name }</strong> }
-					<small className="comments__comment-timestamp">
+					<div className="comments__comment-timestamp">
 						<a href={ comment.URL }>
 							<PostTime date={ comment.date } />
 						</a>
-					</small>
+					</div>
 				</div>
 
 				{ comment.status && comment.status === 'unapproved'

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -20,7 +20,7 @@ import {
 	recordGaEvent,
 	recordTrack
 } from 'reader/stats';
-
+import { getStreamUrl } from 'reader/route';
 import CommentLikeButtonContainer from './comment-likes';
 import PostCommentContent from './post-comment-content';
 import PostCommentForm from './form';
@@ -53,14 +53,14 @@ class PostComment extends React.Component {
 		this.setState( { showReplies: true } ); // show the comments when replying
 	}
 
-	handleAuthorClick() {
+	handleAuthorClick( event ) {
 		recordAction( 'comment_author_click' );
 		recordGaEvent( 'Clicked Author Name' );
 		recordTrack( 'calypso_reader_comment_author_click', {
 			blog_id: this.props.post.site_ID,
 			post_id: this.props.post.ID,
-			comment_id: this.props.comment.ID,
-			author_url: this.props.comment.author.URL
+			comment_id: this.props.commentId,
+			author_url: event.target.href
 		} );
 	}
 
@@ -185,13 +185,25 @@ class PostComment extends React.Component {
 			return <PostTrackback { ...this.props } />;
 		}
 
+		// Author URL
+		let authorUrl;
+		if ( comment.author.site_ID ) {
+			authorUrl = getStreamUrl( null, comment.author.site_ID );
+		} else if ( comment.author.URL ) {
+			authorUrl = comment.author.URL;
+		}
+
 		return (
 			<li className={ 'comments__comment depth-' + this.props.depth }>
 				<div className="comments__comment-author">
-					<Gravatar user={ comment.author } />
+					{ authorUrl
+						? <a href={ authorUrl } target="_blank" onClick={ this.handleAuthorClick }>
+							<Gravatar user={ comment.author } />
+						</a>
+						: <Gravatar user={ comment.author } /> }
 
-					{ comment.author.URL
-						? <a href={ comment.author.URL } target="_blank" className="comments__comment-username" onClick={ this.handleAuthorClick }>{ comment.author.name }</a>
+					{ authorUrl
+						? <a href={ authorUrl } target="_blank" className="comments__comment-username" onClick={ this.handleAuthorClick }>{ comment.author.name }</a>
 						: <strong className="comments__comment-username">{ comment.author.name }</strong> }
 					<div className="comments__comment-timestamp">
 						<a href={ comment.URL }>

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -207,18 +207,14 @@
 
 .comments__comment-username {
 	font-size: 15px;
+	color: darken( $gray, 30% );
+}
+
+a.comments__comment-username {
 	color: $blue-medium;
 
-	.gridicon {
-		height: 16px;
-		fill: lighten( $gray, 10% );
-		margin-left: 2px;
-		position: relative;
-			top: 2px;
-	}
-
-	&:hover .gridicon {
-		fill: $link-highlight;
+	&:hover {
+		color: $blue-light;
 	}
 }
 
@@ -336,6 +332,10 @@
 	display: inline-block;
 	font-size: 14px;
 	margin-bottom: 0 !important; // the !important can go when the old reader/comments is retired
+
+	&:hover {
+		color: $blue-light;
+	}
 }
 
 .comments__view-replies-btn {
@@ -357,7 +357,7 @@
 
 .comments__comment-count {
 	color: lighten( $gray, 10% );
-	size: 13px;
+	font-size: 14px;
 }
 
 .comments__comment-count-phrase {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -205,7 +205,8 @@
 }
 
 .comments__comment-username {
-	font-size: 16px;
+	font-size: 15px;
+	color: $blue-medium;
 
 	.gridicon {
 		height: 16px;
@@ -220,11 +221,14 @@
 	}
 }
 
+.comments__comment-timestamp {
+	margin-top: -6px;
+}
+
 .comments__comment-timestamp a {
 	font-weight: normal;
 	font-size: 13px;
-	color: lighten( $gray, 10% );
-	margin-left: 8px;
+	color: lighten( $gray, 20% );
 	text-decoration: none;
 
 	&:hover {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -121,8 +121,8 @@
 	margin: 0;
 
 	&.is-root {
-		margin-top: 32px;
-	}
+		margin-top: 0 !important; // the !important can go when the old reader/comments is retired
+ 	}
 
 	&.is-children {
 		margin-left: -2px;
@@ -147,6 +147,7 @@
 
 	&.depth-0, &.depth-1, &.depth-2 {
 		padding-left: 48px;
+		margin-top: 12px;
 
 		> .comments__comment-author .gravatar {
 			left: 8px;
@@ -320,8 +321,8 @@
 	}
 }
 
-.comments__top-bar {
-	margin: 24px 48px 24px 0;
+.comments__info-bar {
+	margin: 12px 24px 0 0;
 	overflow: auto;
 
 	&.is-no-comments {
@@ -334,7 +335,7 @@
 	cursor: pointer;
 	display: inline-block;
 	font-size: 14px;
-	margin-bottom: 10px;
+	margin-bottom: 0 !important; // the !important can go when the old reader/comments is retired
 }
 
 .comments__view-replies-btn {
@@ -352,4 +353,10 @@
 		margin-right: 4px;
 		transform: rotate( 180deg );
 	}
+}
+
+.comments__comment-count {
+	color: lighten( $gray, 10% );
+	size: 13px;
+	text-transform: uppercase;
 }

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -267,7 +267,6 @@
 // Actions for Individual Comments
 .comments__comment-actions {
 	list-style: none;
-	margin-top: 8px;
 	margin-left: -4px;
 	color: $gray;
 	font-size: 14px;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -358,5 +358,8 @@
 .comments__comment-count {
 	color: lighten( $gray, 10% );
 	size: 13px;
+}
+
+.comments__comment-count-phrase {
 	text-transform: uppercase;
 }


### PR DESCRIPTION
As per @fraying's issue #7423, this PR will make comments delightful in the following ways:

- [x] Add header showing total number of comments
- [x] Fix author link colours
- ~~Show site title where available (have to check if we have this information)~~ for a later PR
- [x] If the commenter has a URL, the gravatar should be linked, too.
- [x] Remove extra space above Reply and Like
- [x] Remove "open in new window" icon
- [x] Links on the commenter's name and site to open their feed stream in Reader
- [x] Drop date and time to new line

Fixes #7423.

Test live: https://calypso.live/?branch=update/blocks/comments-layout