### PR TITLE
Jetpack Autoconfig: Only return whitelisted plugins for `nextPlugin`

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -503,6 +503,11 @@ export default connect(
 			return true;
 		} );
 
+		let nextPlugin = getNextPlugin( state, siteId );
+		if ( !! ownProps.whitelist && plugins.length ) {
+			nextPlugin = ( ( 'wait' === plugins[ 0 ].status ) && ( plugins[ 0 ].error === null ) ) ? plugins[ 0 ] : false;
+		}
+
 		return {
 			wporg: state.plugins.wporg.items,
 			isRequesting: isRequesting( state, siteId ),
@@ -511,7 +516,7 @@ export default connect(
 			isFinished: isFinished( state, siteId ),
 			plugins,
 			activePlugin: getActivePlugin( state, siteId ),
-			nextPlugin: getNextPlugin( state, siteId ),
+			nextPlugin,
 			selectedSite: site && site.jetpack ? JetpackSite( site ) : site,
 			siteId
 		};

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -216,7 +216,7 @@ const PlansSetup = React.createClass( {
 	},
 
 	renderPluginsPlaceholders() {
-		const placeholderCount = 3;
+		const placeholderCount = !! this.props.whitelist ? 1 : 3;
 		return range( placeholderCount ).map( i => <PluginItem key={ 'placeholder-' + i } /> );
 	},
 
@@ -494,29 +494,17 @@ export default connect(
 	( state, ownProps ) => {
 		const siteId = getSelectedSiteId( state );
 		const site = sites.getSelectedSite();
-
-		// Filter out only the plugins whitelisted (if we're whitelisting)
-		const plugins = filter( getPluginsForSite( state, siteId ), ( plugin ) => {
-			if ( !! ownProps.whitelist ) {
-				return ( ownProps.whitelist === plugin.slug );
-			}
-			return true;
-		} );
-
-		let nextPlugin = getNextPlugin( state, siteId );
-		if ( !! ownProps.whitelist && plugins.length ) {
-			nextPlugin = ( ( 'wait' === plugins[ 0 ].status ) && ( plugins[ 0 ].error === null ) ) ? plugins[ 0 ] : false;
-		}
+		const whitelist = ownProps.whitelist || false;
 
 		return {
 			wporg: state.plugins.wporg.items,
 			isRequesting: isRequesting( state, siteId ),
 			hasRequested: hasRequested( state, siteId ),
-			isInstalling: isInstalling( state, siteId ),
-			isFinished: isFinished( state, siteId ),
-			plugins,
-			activePlugin: getActivePlugin( state, siteId ),
-			nextPlugin,
+			isInstalling: isInstalling( state, siteId, whitelist ),
+			isFinished: isFinished( state, siteId, whitelist ),
+			plugins: getPluginsForSite( state, siteId, whitelist ),
+			activePlugin: getActivePlugin( state, siteId, whitelist ),
+			nextPlugin: getNextPlugin( state, siteId, whitelist ),
 			selectedSite: site && site.jetpack ? JetpackSite( site ) : site,
 			siteId
 		};

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -17,16 +17,21 @@ const hasRequested = function( state, siteId ) {
 	return state.plugins.premium.hasRequested[ siteId ];
 };
 
-const getPluginsForSite = function( state, siteId ) {
-	let pluginList = state.plugins.premium.plugins[ siteId ];
+const getPluginsForSite = function( state, siteId, whitelist = false ) {
+	const pluginList = state.plugins.premium.plugins[ siteId ];
 	if ( typeof pluginList === 'undefined' ) {
 		return [];
 	}
-	return pluginList;
+	return filter( pluginList, ( plugin ) => {
+		if ( !! whitelist ) {
+			return ( whitelist === plugin.slug );
+		}
+		return true;
+	} );
 };
 
-const isFinished = function( state, siteId ) {
-	let pluginList = getPluginsForSite( state, siteId );
+const isFinished = function( state, siteId, whitelist = false ) {
+	let pluginList = getPluginsForSite( state, siteId, whitelist );
 	if ( pluginList.length === 0 ) {
 		return true;
 	}
@@ -36,22 +41,22 @@ const isFinished = function( state, siteId ) {
 	return ( pluginList.length === 0 );
 };
 
-const isInstalling = function( state, siteId ) {
-	let pluginList = getPluginsForSite( state, siteId );
+const isInstalling = function( state, siteId, whitelist = false ) {
+	let pluginList = getPluginsForSite( state, siteId, whitelist );
 	if ( pluginList.length === 0 ) {
 		return false;
 	}
 	pluginList = filter( pluginList, ( item ) => {
-		return ( ( -1 === [ 'done', 'wait'].indexOf( item.status ) ) && ( item.error === null ) );
+		return ( ( -1 === [ 'done', 'wait' ].indexOf( item.status ) ) && ( item.error === null ) );
 	} );
 	// If any plugin is not done/waiting/error'd, it's in an installing state.
 	return ( pluginList.length > 0 );
 };
 
-const getActivePlugin = function( state, siteId ) {
-	let pluginList = getPluginsForSite( state, siteId );
-	let plugin = find( pluginList, ( item ) => {
-		return ( ( -1 === [ 'done', 'wait'].indexOf( item.status ) ) && ( item.error === null ) );
+const getActivePlugin = function( state, siteId, whitelist = false ) {
+	const pluginList = getPluginsForSite( state, siteId, whitelist );
+	const plugin = find( pluginList, ( item ) => {
+		return ( ( -1 === [ 'done', 'wait' ].indexOf( item.status ) ) && ( item.error === null ) );
 	} );
 	if ( typeof plugin === 'undefined' ) {
 		return false;
@@ -59,9 +64,9 @@ const getActivePlugin = function( state, siteId ) {
 	return plugin;
 };
 
-const getNextPlugin = function( state, siteId ) {
-	let pluginList = getPluginsForSite( state, siteId );
-	let plugin = find( pluginList, ( item ) => {
+const getNextPlugin = function( state, siteId, whitelist = false ) {
+	const pluginList = getPluginsForSite( state, siteId, whitelist );
+	const plugin = find( pluginList, ( item ) => {
 		return ( ( 'wait' === item.status ) && ( item.error === null ) );
 	} );
 	if ( typeof plugin === 'undefined' ) {


### PR DESCRIPTION
Currently we're still installing all the plugins, despite telling the user we're only installing one. (something must have changed, I know I tested this?)

This is because `getNextPlugin` still gets the data from the state, rather than our whitelist. So we'll just bypass that when we have a whitelisted plugin.

**To Test**

1. On a site with no premium plugins, go through the single-plugin autoconfig flow at `/plugins/setup/$site?only=vaultpress`
2. Make sure only VaultPress is installed and activated

cc @johnHackworth @roccotripaldi (and @dereksmart, since this is a followup to #7340)

Test live: https://calypso.live/?branch=fix/single-plugin-setup