### PR TITLE
Sites: Display site actions as EllipsisMenu

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -127,14 +127,6 @@ export default React.createClass( {
 		);
 	},
 
-	getHref() {
-		if ( this.state.showMoreActions || ! this.props.site ) {
-			return null;
-		}
-
-		return this.props.homeLink ? this.props.site.URL : this.props.href;
-	},
-
 	closeActions() {
 		this.setState( { showMoreActions: false } );
 	},

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -130,87 +130,11 @@
 }
 
 .site__toggle-more-options {
-	color: $gray;
-	cursor: pointer;
-	padding-right: 16px;
-	line-height: 0;
-	.gridicon {
-		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-	}
-	&:hover {
-		.gridicon {
-			color: darken( $gray, 20% );
-		}
-	}
+	padding: 9px 16px 7px 0;
 }
 
-.site.is-toggled {
-	.site__toggle-more-options .gridicon {
-		transform: rotate( 90deg );
-	}
-	.site-indicator {
-		display: none;
-	}
-}
-
-.site.is-toggled.has-edit-capabilities {
-	.site-icon {
-		border: 1px dashed $gray-dark;
-		opacity: 0.8;
-	}
-}
-
-.site__actions {
-	align-items: center;
-	display: flex;
-	flex: 1 0 0;
-	justify-content: flex-end;
-	animation: appear .3s ease-in-out;
-}
-
-.site__edit-icon-text {
-	animation: appear .3s ease-in-out;
-	font-size: 10px;
-	max-width: 60px;
-}
-
-.site__edit-icon,
-.site__edit-icon:visited {
-	color: darken( $gray, 10% );
-	font-weight: 600;
-	font-size: 11px;
-	text-transform: uppercase;
-	display: flex;
-	align-items: center;
-	&:hover {
-		color: $blue-medium;
-	}
-	.gridicons-external {
-		top: -1px;
-	}
-}
-
-.site__star {
-	color: $gray;
-	cursor: pointer;
-	line-height: 0;
-
-	&:hover .gridicons-star-outline {
-		color: $alert-yellow;
-	}
-
-	.gridicons-star {
-		color: $alert-yellow;
-	}
-}
-
-a.site__cog {
-	color: $gray;
-	line-height: 0;
-
-	&:hover {
-		color: darken( $gray, 20% );
-	}
+.site__edit-icon-external {
+	margin-left: 8px;
 }
 
 .site__badge {

--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -63,3 +63,13 @@ Menu children to be rendered.
 </table>
 
 If `true`, then the menu icon will be displayed in light gray and will not be clickable.
+
+### `onToggle`
+
+<table>
+	<tr><td>Type</td><td><code>Function</code></td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>() => {}</code></td></tr>
+</table>
+
+Function callback to be invoked when visibility of the menu changes, passing a boolean argument indicating whether the menu is visible.

--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -73,3 +73,12 @@ If `true`, then the menu icon will be displayed in light gray and will not be cl
 </table>
 
 Function callback to be invoked when visibility of the menu changes, passing a boolean argument indicating whether the menu is visible.
+
+### `className`
+
+<table>
+	<tr><td>Type</td><td><code>String</code></td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Additional class name to be applied to the rendered component.

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -20,6 +20,7 @@ class EllipsisMenu extends Component {
 		children: PropTypes.node,
 		disabled: PropTypes.bool,
 		onToggle: PropTypes.func,
+		className: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -56,9 +57,9 @@ class EllipsisMenu extends Component {
 	}
 
 	render() {
-		const { toggleTitle, translate, position, children, disabled } = this.props;
+		const { toggleTitle, translate, position, children, disabled, className } = this.props;
 		const { isMenuVisible, popoverContext } = this.state;
-		const classes = classnames( 'ellipsis-menu', {
+		const classes = classnames( 'ellipsis-menu', className, {
 			'is-menu-visible': isMenuVisible,
 			'is-disabled': disabled
 		} );

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -19,6 +19,11 @@ class EllipsisMenu extends Component {
 		position: PropTypes.string,
 		children: PropTypes.node,
 		disabled: PropTypes.bool,
+		onToggle: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onToggle: () => {}
 	};
 
 	constructor() {
@@ -42,9 +47,12 @@ class EllipsisMenu extends Component {
 	}
 
 	toggleMenu( isMenuVisible ) {
-		if ( ! this.props.disabled ) {
-			this.setState( { isMenuVisible } );
+		if ( this.props.disabled ) {
+			return;
 		}
+
+		this.setState( { isMenuVisible } );
+		this.props.onToggle( isMenuVisible );
 	}
 
 	render() {

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -3,6 +3,7 @@
 */
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' );
+import { over } from 'lodash';
 
 /**
 * Internal dependencies
@@ -57,7 +58,7 @@ var PopoverMenu = React.createClass( {
 			onClick = boundOnClose;
 
 		if ( child.props.onClick ) {
-			onClick = child.props.onClick.bind( null, boundOnClose );
+			onClick = over( [ child.props.onClick, boundOnClose ] );
 		}
 
 		return React.cloneElement( child, {


### PR DESCRIPTION
Closes #7332
Part of [Site Icon milestone](https://github.com/Automattic/wp-calypso/milestone/119)

This pull request seeks to display the `<Site />` component actions using an [`<EllipsisMenu />` component](https://github.com/Automattic/wp-calypso/tree/master/client/components/ellipsis-menu) instead of as an editable variant of the component. The goal with this change is to bring consistency of expectations with the ellipsis menu behavior in the application, and to open possibility of additional action options to be added.

Before|After
---|---
![before](https://cloud.githubusercontent.com/assets/1779930/17900037/8f32bf70-692b-11e6-8453-bdb2f14dcb10.gif)|![after](https://cloud.githubusercontent.com/assets/1779930/17900036/8f2ac48c-692b-11e6-9f45-4dc052cfa984.gif)

__Implementation notes:__

- Previously, `<PopoverMenu />` would override the `onClick` of a menu item child with a new function by binding it with the popover's close handler as the first argument. This seemed unexpected and was changed in 2d2295f to ensure both close handlers are called with the same argument (i.e. `event`). cc @mattsherman re: 3048-gh-calypso-pre-oss
- I discovered a `<ReaderPreview />` component which [renders with the assumption that `<Site />` component classes are already defined](https://github.com/Automattic/wp-calypso/blob/fb942c0e70821f5133aefe6791911b578db5c761/client/components/seo/reader-preview/index.js#L30-L40) (specifically the `.has-edit-capabilities` modifier class), instead of using the `<Site />` component itself. I'm fairly certain this will break with these changes, but I don't believe `<ReaderPreview />` should be rendering this way anyways. cc @roundhill re: #7338 

__Testing instructions:__

Verify that there is no regressions in the display and usage of the `<Site />` component, especially:
- Different contexts (there are no actions to be displayed in the site selector context)
- With and without indicator present (e.g. Jetpack plugin update available)
- Jetpack Site Icon link should navigate to the Customize screen on the Jetpack site, while WordPress.com sites should navigate to `options-general.php` in wp-admin

/cc @mtias @hugobaeta 

Test live: https://calypso.live/?branch=update/site-ellipsis-menu