### PR TITLE
Editor: remove hierarchical taxonomies from terms object

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -21,6 +21,7 @@ var wpcom = require( 'lib/wp' ),
 	versionCompare = require( 'lib/version-compare' ),
 	Dispatcher = require( 'dispatcher' ),
 	stats = require( './stats' );
+import { omit } from 'lodash';
 
 var PostActions;
 
@@ -83,6 +84,7 @@ function handleMetadataOperation( key, value, operation ) {
  */
 function normalizeApiAttributes( attributes ) {
 	attributes = clone( attributes );
+	attributes = omit( attributes, 'terms' );
 
 	if ( attributes.author ) {
 		attributes.author = attributes.author.ID;

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -21,7 +21,7 @@ var wpcom = require( 'lib/wp' ),
 	versionCompare = require( 'lib/version-compare' ),
 	Dispatcher = require( 'dispatcher' ),
 	stats = require( './stats' );
-import { omit } from 'lodash';
+import { normalizePostForApi } from 'state/posts/utils';
 
 var PostActions;
 
@@ -84,7 +84,7 @@ function handleMetadataOperation( key, value, operation ) {
  */
 function normalizeApiAttributes( attributes ) {
 	attributes = clone( attributes );
-	attributes = omit( attributes, 'terms' );
+	attributes = normalizePostForApi( attributes );
 
 	if ( attributes.author ) {
 		attributes.author = attributes.author.ID;

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -21,7 +21,7 @@ var wpcom = require( 'lib/wp' ),
 	versionCompare = require( 'lib/version-compare' ),
 	Dispatcher = require( 'dispatcher' ),
 	stats = require( './stats' );
-import { normalizePostForApi } from 'state/posts/utils';
+import { normalizeTermsForApi } from 'state/posts/utils';
 
 var PostActions;
 
@@ -84,7 +84,7 @@ function handleMetadataOperation( key, value, operation ) {
  */
 function normalizeApiAttributes( attributes ) {
 	attributes = clone( attributes );
-	attributes = normalizePostForApi( attributes );
+	attributes = normalizeTermsForApi( attributes );
 
 	if ( attributes.author ) {
 		attributes.author = attributes.author.ID;

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -210,7 +210,13 @@ describe( 'actions', function() {
 				author: {
 					ID: 3
 				},
-				title: 'OMG Unicorns'
+				title: 'OMG Unicorns',
+				terms: {
+					category: [ {
+						ID: 7,
+						name: 'ribs'
+					} ]
+				}
 			};
 			sandbox.stub( PostEditStore, 'getChangedAttributes' ).returns( changedAttributes );
 

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -235,7 +235,8 @@ describe( 'actions', function() {
 					ID: 777,
 					site_ID: 123,
 					author: 3,
-					title: 'OMG Unicorns'
+					title: 'OMG Unicorns',
+					terms: {}
 				};
 
 				expect( Dispatcher.handleViewAction ).to.have.been.calledTwice;

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -3,6 +3,7 @@
  */
 import wpcom from 'lib/wp';
 import { extendAction } from 'state/utils';
+import { normalizePostForAPI } from './utils';
 import { addTerm } from 'state/terms/actions';
 import {
 	POST_DELETE,
@@ -193,8 +194,9 @@ export function savePost( siteId, postId = null, post ) {
 		} );
 
 		let postHandle = wpcom.site( siteId ).post( postId );
+		const normalizedPost = normalizePostForAPI( post );
 		postHandle = postHandle[ postId ? 'update' : 'add' ].bind( postHandle );
-		return postHandle( { apiVersion: '1.2' }, post ).then( ( savedPost ) => {
+		return postHandle( { apiVersion: '1.2' }, normalizedPost ).then( ( savedPost ) => {
 			dispatch( {
 				type: POST_SAVE_SUCCESS,
 				siteId,

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -3,7 +3,7 @@
  */
 import wpcom from 'lib/wp';
 import { extendAction } from 'state/utils';
-import { normalizePostForAPI } from './utils';
+import { normalizePostForApi } from './utils';
 import { addTerm } from 'state/terms/actions';
 import {
 	POST_DELETE,
@@ -194,7 +194,7 @@ export function savePost( siteId, postId = null, post ) {
 		} );
 
 		let postHandle = wpcom.site( siteId ).post( postId );
-		const normalizedPost = normalizePostForAPI( post );
+		const normalizedPost = normalizePostForApi( post );
 		postHandle = postHandle[ postId ? 'update' : 'add' ].bind( postHandle );
 		return postHandle( { apiVersion: '1.2' }, normalizedPost ).then( ( savedPost ) => {
 			dispatch( {

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -10,6 +10,7 @@ import deepFreeze from 'deep-freeze';
 import {
 	normalizePostForDisplay,
 	normalizePostForState,
+	normalizePostForAPI,
 	getNormalizedPostsQuery,
 	getSerializedPostsQuery,
 	getDeserializedPostsQueryDetails,
@@ -19,6 +20,31 @@ import {
 } from '../utils';
 
 describe( 'utils', () => {
+	describe( 'normalizePostForAPI()', () => {
+		it( 'should return null if post is falsey', () => {
+			const normalizedPost = normalizePostForAPI();
+			expect( normalizedPost ).to.be.null;
+		} );
+
+		it( 'should return a normalized post object', () => {
+			const post = {
+				ID: 841,
+				site_ID: 2916284,
+				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+				title: 'Ribs &amp; Chicken',
+				terms: {}
+			};
+
+			const normalizedPost = normalizePostForAPI( post );
+			expect( normalizedPost ).to.eql( {
+				ID: 841,
+				site_ID: 2916284,
+				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+				title: 'Ribs &amp; Chicken'
+			} );
+		} );
+	} );
+
 	describe( 'normalizePostForDisplay()', () => {
 		it( 'should return null if post is falsey', () => {
 			const normalizedPost = normalizePostForDisplay();

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -32,7 +32,10 @@ describe( 'utils', () => {
 				site_ID: 2916284,
 				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
 				title: 'Ribs &amp; Chicken',
-				terms: {}
+				terms: {
+					category: [ { ID: 777, name: 'recipes' } ],
+					post_tag: [ 'super', 'yummy', 'stuff' ]
+				}
 			};
 
 			const normalizedPost = normalizePostForApi( post );
@@ -40,7 +43,10 @@ describe( 'utils', () => {
 				ID: 841,
 				site_ID: 2916284,
 				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-				title: 'Ribs &amp; Chicken'
+				title: 'Ribs &amp; Chicken',
+				terms: {
+					post_tag: [ 'super', 'yummy', 'stuff' ]
+				}
 			} );
 		} );
 	} );

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -10,7 +10,7 @@ import deepFreeze from 'deep-freeze';
 import {
 	normalizePostForDisplay,
 	normalizePostForState,
-	normalizePostForAPI,
+	normalizePostForApi,
 	getNormalizedPostsQuery,
 	getSerializedPostsQuery,
 	getDeserializedPostsQueryDetails,
@@ -20,9 +20,9 @@ import {
 } from '../utils';
 
 describe( 'utils', () => {
-	describe( 'normalizePostForAPI()', () => {
+	describe( 'normalizePostForApi()', () => {
 		it( 'should return null if post is falsey', () => {
-			const normalizedPost = normalizePostForAPI();
+			const normalizedPost = normalizePostForApi();
 			expect( normalizedPost ).to.be.null;
 		} );
 
@@ -35,7 +35,7 @@ describe( 'utils', () => {
 				terms: {}
 			};
 
-			const normalizedPost = normalizePostForAPI( post );
+			const normalizedPost = normalizePostForApi( post );
 			expect( normalizedPost ).to.eql( {
 				ID: 841,
 				site_ID: 2916284,

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -208,3 +208,17 @@ export function getTermIdsFromEdits( post ) {
 		} )
 	};
 }
+
+/**
+ * Returns a normalized post object for sending to the API
+ *
+ * @param  {Object} post Raw post object
+ * @return {Object}      Normalized post object
+ */
+export function normalizePostForAPI( post ) {
+	if ( ! post ) {
+		return null;
+	}
+
+	return omit( post, 'terms' );
+}

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -13,7 +13,9 @@ import {
 	reduce,
 	toArray,
 	cloneDeep,
-	cloneDeepWith
+	cloneDeepWith,
+	pickBy,
+	isString
 } from 'lodash';
 
 /**
@@ -220,5 +222,10 @@ export function normalizePostForApi( post ) {
 		return null;
 	}
 
-	return omit( post, 'terms' );
+	return {
+		...post,
+		terms: pickBy( post.terms, ( terms ) => {
+			return terms.length && isString( terms[ 0 ] );
+		} )
+	};
 }

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -215,7 +215,7 @@ export function getTermIdsFromEdits( post ) {
  * @param  {Object} post Raw post object
  * @return {Object}      Normalized post object
  */
-export function normalizePostForAPI( post ) {
+export function normalizePostForApi( post ) {
 	if ( ! post ) {
 		return null;
 	}

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -40,6 +40,10 @@ const normalizeEditedFlow = flow( [
 	getTermIdsFromEdits
 ] );
 
+const normalizeApiFlow = flow( [
+	normalizeTermsForApi
+] );
+
 const normalizeDisplayFlow = flow( [
 	firstPassCanonicalImage,
 	decodeEntities,
@@ -212,6 +216,25 @@ export function getTermIdsFromEdits( post ) {
 }
 
 /**
+ * Returns a normalized post terms object for sending to the API
+ *
+ * @param  {Object} post Raw post object
+ * @return {Object}      Normalized post object
+ */
+export function normalizeTermsForApi( post ) {
+	if ( ! post || ! post.terms ) {
+		return post;
+	}
+
+	return {
+		...post,
+		terms: pickBy( post.terms, ( terms ) => {
+			return terms.length && isString( terms[ 0 ] );
+		} )
+	};
+}
+
+/**
  * Returns a normalized post object for sending to the API
  *
  * @param  {Object} post Raw post object
@@ -222,10 +245,5 @@ export function normalizePostForApi( post ) {
 		return null;
 	}
 
-	return {
-		...post,
-		terms: pickBy( post.terms, ( terms ) => {
-			return terms.length && isString( terms[ 0 ] );
-		} )
-	};
+	return normalizeApiFlow( post );
 }

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -15,7 +15,8 @@ import {
 	cloneDeep,
 	cloneDeepWith,
 	pickBy,
-	isString
+	isString,
+	every
 } from 'lodash';
 
 /**
@@ -229,7 +230,7 @@ export function normalizeTermsForApi( post ) {
 	return {
 		...post,
 		terms: pickBy( post.terms, ( terms ) => {
-			return terms.length && isString( terms[ 0 ] );
+			return terms.length && every( terms, isString );
 		} )
 	};
 }


### PR DESCRIPTION
This branch is a result of an API error that was occurring when the full `terms` object was being `POST`ed to the API.  The API is expecting terms to be an array of strings, while we were passing an array of full term objects ( like what is returned from the posts endpoint ).  See D2607-code for details.

Since we are using `terms_by_id` to persist term changes, we no longer need to send the full terms objects to the API, and this branch `omit`s the object from the flux and redux actions prior to saving.

__Testing__
- Verify that both post test suites pass `npm run test-client client/state/posts && npm run test-client client/lib/posts`
- Open a post in the editor, add some categories and terms to the post, save, refresh and verify your changes are saved as expected

Test live: https://calypso.live/?branch=update/posts/remove-terms