### PR TITLE
State: move ui.currentPreviewUrl to ui.preview.currentPreviewUrl

### DIFF
--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -11,11 +11,12 @@ import debugFactory from 'debug';
  */
 import config from 'config';
 import WebPreview from 'components/web-preview';
-import { clearPreviewUrl } from 'state/ui/actions';
+import { clearPreviewUrl } from 'state/ui/preview/actions';
 import { fetchPreviewMarkup, undoCustomization, clearCustomizations } from 'state/preview/actions';
 import accept from 'lib/accept';
 import { updatePreviewWithChanges } from 'lib/design-preview';
-import { getSelectedSite, getSelectedSiteId, getPreviewUrl } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getPreviewUrl } from 'state/ui/preview/selectors';
 import { getSiteOption } from 'state/sites/selectors';
 import { getPreviewMarkup, getPreviewCustomizations, isPreviewUnsaved } from 'state/preview/selectors';
 import addQueryArgs from 'lib/route/add-query-args';

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -13,7 +13,7 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import { mc } from 'lib/analytics';
 import { getPost, getPostPreviewUrl } from 'state/posts/selectors';
 import { isSitePreviewable } from 'state/sites/selectors';
-import { setPreviewUrl } from 'state/ui/actions';
+import { setPreviewUrl } from 'state/ui/preview/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 
 class PostActionsEllipsisMenuView extends Component {

--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -8,8 +8,6 @@ import {
 	ROUTE_SET,
 	SECTION_SET,
 	PREVIEW_IS_SHOWING,
-	PREVIEW_URL_SET,
-	PREVIEW_URL_CLEAR,
 } from 'state/action-types';
 
 /**
@@ -67,18 +65,5 @@ export function setPreviewShowing( isShowing ) {
 	return {
 		type: PREVIEW_IS_SHOWING,
 		isShowing,
-	};
-}
-
-export function setPreviewUrl( url ) {
-	return {
-		type: PREVIEW_URL_SET,
-		url,
-	};
-}
-
-export function clearPreviewUrl() {
-	return {
-		type: PREVIEW_URL_CLEAR,
 	};
 }

--- a/client/state/ui/preview/actions.js
+++ b/client/state/ui/preview/actions.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import {
+	PREVIEW_URL_CLEAR,
+	PREVIEW_URL_SET,
+} from 'state/action-types';
+
+export function setPreviewUrl( url ) {
+	return {
+		type: PREVIEW_URL_SET,
+		url,
+	};
+}
+
+export function clearPreviewUrl() {
+	return {
+		type: PREVIEW_URL_CLEAR,
+	};
+}

--- a/client/state/ui/preview/reducer.js
+++ b/client/state/ui/preview/reducer.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import {
+	PREVIEW_URL_CLEAR,
+	PREVIEW_URL_SET,
+} from 'state/action-types';
+
+export function currentPreviewUrl( state = null, action ) {
+	switch ( action.type ) {
+		case PREVIEW_URL_SET:
+			return action.url;
+		case PREVIEW_URL_CLEAR:
+			return null;
+	}
+	return state;
+}
+
+export default combineReducers( {
+	currentPreviewUrl,
+} );

--- a/client/state/ui/preview/selectors.js
+++ b/client/state/ui/preview/selectors.js
@@ -1,0 +1,12 @@
+/**
+ * Returns the URL if SitePreview currently has one.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}  The url or null
+ *
+ * @see client/components/design-preview
+ */
+export function getPreviewUrl( state ) {
+	return state.ui.preview.currentPreviewUrl;
+}
+

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -10,8 +10,6 @@ import {
 	SELECTED_SITE_SET,
 	SECTION_SET,
 	PREVIEW_IS_SHOWING,
-	PREVIEW_URL_CLEAR,
-	PREVIEW_URL_SET,
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
@@ -23,6 +21,7 @@ import reader from './reader/reducer';
 import olark from './olark/reducer';
 import actionLog from './action-log/reducer';
 import layoutFocus from './layout-focus/reducer';
+import preview from './preview/reducer';
 
 /**
  * Tracks the currently selected site ID.
@@ -90,23 +89,12 @@ export const isPreviewShowing = createReducer( false, {
 		isShowing !== undefined ? isShowing : state,
 } );
 
-export function currentPreviewUrl( state = null, action ) {
-	switch ( action.type ) {
-		case PREVIEW_URL_SET:
-			return action.url;
-		case PREVIEW_URL_CLEAR:
-			return null;
-	}
-	return state;
-}
-
 const reducer = combineReducers( {
 	section,
 	isLoading,
 	layoutFocus,
 	hasSidebar,
 	isPreviewShowing,
-	currentPreviewUrl,
 	queryArguments,
 	selectedSiteId,
 	recentlySelectedSiteIds,
@@ -114,6 +102,7 @@ const reducer = combineReducers( {
 	editor,
 	reader,
 	olark,
+	preview,
 	actionLog,
 } );
 

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -99,18 +99,6 @@ export function isPreviewShowing( state ) {
 	return get( state.ui, 'isPreviewShowing', false );
 }
 
-/**
- * Returns the URL if DesignPreview currently has one.
- *
- * @param  {Object}  state Global state tree
- * @return {?String}  The url or null
- *
- * @see client/components/design-preview
- */
-export function getPreviewUrl( state ) {
-	return state.ui.currentPreviewUrl;
-}
-
 export function getInitialQueryArguments( state ) {
 	return state.ui.queryArguments.initial;
 }


### PR DESCRIPTION
Adds a `state.ui.preview` tree to make it easier to add more preview-related UI state reducers in the future.

Partially extracted from #7477

### Testing

Two views are affected by this change: `DesignPreview` and `PostActionsEllipsisMenuView`

1. Test the "regular" preview functionality by visiting any page under my-sites like `/posts/my/[your site here]` and clicking the icon next to your site title:

<img width="250" alt="screen_shot_2016-08-16_at_4_32_06_pm" src="https://cloud.githubusercontent.com/assets/2036909/17714754/1893c2d0-63cf-11e6-81fe-107f521d6abf.png">

The preview should appear as normal.

<img width="940" alt="screen shot 2016-08-16 at 4 36 02 pm" src="https://cloud.githubusercontent.com/assets/2036909/17714847/8d9f2ea2-63cf-11e6-9141-49bd0d7c5166.png">

2. Visit a post type page like: `/types/post/drafts/[your site here]` and click the "..." menu next to a post. Click "Preview":

<img width="926" alt="screen_shot_2016-08-19_at_4_55_27_pm" src="https://cloud.githubusercontent.com/assets/2036909/17824084/e0f1b8f8-662d-11e6-8211-9e4c6db00287.png">

Make sure the preview of *that post* (not the front page of your site) appears:

<img width="936" alt="screen shot 2016-08-23 at 2 04 24 pm" src="https://cloud.githubusercontent.com/assets/2036909/17903736/8da6c2b4-693a-11e6-9bee-45428f7f7622.png">



Test live: https://calypso.live/?branch=add/state-ui-preview