### PR TITLE
Sites: Use Redux state preference for recent sites (2nd Attempt Edition)

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -3,12 +3,16 @@
  */
 import React from 'react';
 import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 import page from 'page';
 import classNames from 'classnames';
+import { filter, size, keyBy, map, includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { getPreference } from 'state/preferences/selectors';
+import observe from 'lib/mixins/data-observe';
 import AllSites from 'my-sites/all-sites';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
@@ -18,13 +22,12 @@ import SitePlaceholder from 'blocks/site/placeholder';
 import Search from 'components/search';
 import userModule from 'lib/user';
 import config from 'config';
-import PreferencesData from 'components/data/preferences-data';
 
 const user = userModule();
 const noop = () => {};
 
-export default React.createClass( {
-	displayName: 'SiteSelector',
+const SiteSelector = React.createClass( {
+	mixins: [ observe( 'sites' ) ],
 
 	propTypes: {
 		sites: React.PropTypes.object,
@@ -38,7 +41,8 @@ export default React.createClass( {
 		hideSelected: React.PropTypes.bool,
 		filter: React.PropTypes.func,
 		groups: React.PropTypes.bool,
-		onSiteSelect: React.PropTypes.func
+		onSiteSelect: React.PropTypes.func,
+		recentSites: React.PropTypes.array
 	},
 
 	getDefaultProps() {
@@ -149,9 +153,12 @@ export default React.createClass( {
 		if ( this.state.search ) {
 			sites = this.props.sites.search( this.state.search );
 		} else {
-			sites = this.shouldShowGroups()
-				? this.props.sites.getVisibleAndNotRecent()
-				: this.props.sites.getVisible();
+			sites = this.props.sites.getVisible();
+
+			const { recentSites } = this.props;
+			if ( this.shouldShowGroups() && size( recentSites ) ) {
+				sites = filter( sites, ( { ID: siteId } ) => ! includes( recentSites, siteId ) );
+			}
 		}
 
 		if ( this.props.filter ) {
@@ -222,38 +229,38 @@ export default React.createClass( {
 	},
 
 	renderRecentSites() {
-		const sites = this.props.sites.getRecentlySelected();
-
-		if ( ! sites || this.state.search || ! this.shouldShowGroups() ) {
-			return null;
+		if ( this.state.search || ! this.shouldShowGroups() ) {
+			return;
 		}
 
-		const recentSites = sites.map( function( site ) {
-			var siteHref;
+		const sitesById = keyBy( this.props.sites.get(), 'ID' );
 
-			if ( this.props.siteBasePath ) {
-				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
-			}
+		return (
+			<div className="site-selector__recent">
+				{ map( this.props.recentSites, ( siteId ) => {
+					const site = sitesById[ siteId ];
+					if ( ! site ) {
+						return;
+					}
 
-			const isSelected = this.isSelected( site );
+					let siteHref;
+					if ( this.props.siteBasePath ) {
+						siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
+					}
 
-			return (
-				<Site
-					site={ site }
-					href={ siteHref }
-					key={ 'site-' + site.ID }
-					indicator={ this.props.indicator }
-					onSelect={ this.onSiteSelect.bind( this, site.slug ) }
-					isSelected={ isSelected }
-				/>
-			);
-		}, this );
-
-		if ( ! recentSites ) {
-			return null;
-		}
-
-		return <div className="site-selector__recent">{ recentSites }</div>;
+					return (
+						<Site
+							site={ site }
+							href={ siteHref }
+							key={ 'site-' + site.ID }
+							indicator={ this.props.indicator }
+							onSelect={ this.onSiteSelect.bind( this, site.slug ) }
+							isSelected={ this.isSelected( site ) }
+						/>
+					);
+				} ) }
+			</div>
+		);
 	},
 
 	render() {
@@ -263,22 +270,26 @@ export default React.createClass( {
 		} );
 
 		return (
-			<PreferencesData>
-				<div className={ selectorClass }>
-					<Search
-						ref="siteSearch"
-						onSearch={ this.onSearch }
-						autoFocus={ this.props.autoFocus }
-						disabled={ ! this.props.sites.initialized }
-						onSearchClose={ this.props.onClose }
-					/>
-					<div className="site-selector__sites" ref="selector">
-						{ this.renderAllSites() }
-						{ this.renderSites() }
-					</div>
-					{ this.props.showAddNewSite && this.addNewSite() }
+			<div className={ selectorClass }>
+				<Search
+					ref="siteSearch"
+					onSearch={ this.onSearch }
+					autoFocus={ this.props.autoFocus }
+					disabled={ ! this.props.sites.initialized }
+					onSearchClose={ this.props.onClose }
+				/>
+				<div className="site-selector__sites" ref="selector">
+					{ this.renderAllSites() }
+					{ this.renderSites() }
 				</div>
-			</PreferencesData>
+				{ this.props.showAddNewSite && this.addNewSite() }
+			</div>
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	return {
+		recentSites: getPreference( state, 'recentSites' )
+	};
+} )( SiteSelector );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -6,12 +6,13 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import page from 'page';
 import classNames from 'classnames';
-import { filter, size, keyBy, map, includes } from 'lodash';
+import { get, filter, size, keyBy, map, includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getPreference } from 'state/preferences/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 import observe from 'lib/mixins/data-observe';
 import AllSites from 'my-sites/all-sites';
 import analytics from 'lib/analytics';
@@ -42,6 +43,7 @@ const SiteSelector = React.createClass( {
 		filter: React.PropTypes.func,
 		groups: React.PropTypes.bool,
 		onSiteSelect: React.PropTypes.func,
+		showRecentSites: React.PropTypes.bool,
 		recentSites: React.PropTypes.array
 	},
 
@@ -155,8 +157,8 @@ const SiteSelector = React.createClass( {
 		} else {
 			sites = this.props.sites.getVisible();
 
-			const { recentSites } = this.props;
-			if ( this.shouldShowGroups() && size( recentSites ) ) {
+			const { showRecentSites, recentSites } = this.props;
+			if ( showRecentSites && this.shouldShowGroups() && size( recentSites ) ) {
 				sites = filter( sites, ( { ID: siteId } ) => ! includes( recentSites, siteId ) );
 			}
 		}
@@ -198,7 +200,7 @@ const SiteSelector = React.createClass( {
 		if ( this.shouldShowGroups() && ! this.state.search ) {
 			return (
 				<div>
-					{ user.get().visible_site_count > 11 && this.renderRecentSites() }
+					{ this.props.showRecentSites && this.renderRecentSites() }
 					{ siteElements }
 				</div>
 			);
@@ -290,6 +292,7 @@ const SiteSelector = React.createClass( {
 
 export default connect( ( state ) => {
 	return {
+		showRecentSites: get( getCurrentUser( state ), 'visible_site_count', 0 ) > 11,
 		recentSites: getPreference( state, 'recentSites' )
 	};
 } )( SiteSelector );

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -170,4 +170,8 @@
 
 .site-selector__recent {
 	border-bottom: 1px solid lighten( $gray, 30% );
+
+	&:empty {
+		border-bottom-width: 0;
+	}
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -139,7 +139,7 @@
 	}
 
 	.site-selector__recent {
-		border-bottom: 1px solid lighten( $gray, 20% );
+		border-bottom-color: lighten( $gray, 20% );
 	}
 }
 

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -17,9 +17,6 @@ var wpcom = require( 'lib/wp' ),
 	Searchable = require( 'lib/mixins/searchable' ),
 	Emitter = require( 'lib/mixins/emitter' ),
 	isPlan = require( 'lib/products-values' ).isPlan,
-	PreferencesActions = require( 'lib/preferences/actions' ),
-	PreferencesStore = require( 'lib/preferences/store' ),
-	user = require( 'lib/user' )(),
 	userUtils = require( 'lib/user/utils' );
 
 /**
@@ -38,7 +35,6 @@ function SitesList() {
 	this.selected = null;
 	this.lastSelected = null;
 	this.propagateChange = this.propagateChange.bind( this );
-	this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
 }
 
 /**
@@ -383,55 +379,6 @@ SitesList.prototype.isSelected = function( site ) {
 };
 
 /**
- * Set recently selected site
- *
- * @param {number} Site ID
- * @api private
- */
-SitesList.prototype.setRecentlySelectedSite = function( siteID ) {
-	if ( ! this.recentlySelected || this.recentlySelected.length === 0 ) {
-		this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
-	}
-
-	if ( ! siteID || ! this.initialized ) {
-		return;
-	}
-
-	const index = this.recentlySelected.indexOf( siteID );
-
-	// do not add duplicates
-	if ( index !== -1 ) {
-		this.recentlySelected.splice( index, 1 );
-	}
-
-	this.recentlySelected.unshift( siteID );
-
-	const sites = this.recentlySelected.slice( 0, 3 );
-	PreferencesActions.set( 'recentSites', sites );
-
-	this.emit( 'change' );
-};
-
-SitesList.prototype.getRecentlySelected = function() {
-	this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
-
-	if ( ! this.recentlySelected.length || ! this.initialized ) {
-		return false;
-	}
-
-	let sites = [];
-
-	this.recentlySelected.forEach( function( id, index ) {
-		sites[ index ] = this.get().filter( function( site ) {
-			return id === site.ID;
-		}, this )[ 0 ];
-	}, this );
-
-	// remove undefined sites
-	return sites.filter( site => site );
-};
-
-/**
  * Get a single site object from a numeric ID or domain ID
  *
  * @api public
@@ -516,22 +463,6 @@ SitesList.prototype.getPublic = function() {
 SitesList.prototype.getVisible = function() {
 	return this.get().filter( function( site ) {
 		return site.visible === true;
-	}, this );
-};
-
-/**
- * Get sites that are marked as visible and not recently selected
- *
- * @api public
- **/
-SitesList.prototype.getVisibleAndNotRecent = function() {
-	this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
-	return this.get().filter( function( site ) {
-		if ( user.get().visible_site_count < 12 ) {
-			return site.visible === true;
-		}
-
-		return site.visible === true && this.recentlySelected && this.recentlySelected.indexOf( site.ID ) === -1;
 	}, this );
 };
 

--- a/client/state/preferences/constants.js
+++ b/client/state/preferences/constants.js
@@ -7,5 +7,6 @@ export const DEFAULT_PREFERENCE_VALUES = {
 	firstViewHistory: [],
 	mediaModalGalleryInstructionsDismissed: false,
 	mediaModalGalleryInstructionsDismissedForSession: false,
-	'guided-tours-history': []
+	'guided-tours-history': [],
+	recentSites: []
 };

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -35,5 +35,13 @@ export const remoteValuesSchema = {
 				additionalProperties: false,
 			}
 		},
+	},
+	recentSites: {
+		schema: {
+			type: 'array',
+			items: {
+				type: 'number'
+			}
+		}
 	}
 };

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -39,26 +39,6 @@ export function selectedSiteId( state = null, action ) {
 	return state;
 }
 
-/**
- * Tracks the four most recently selected site IDs.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
- */
-export function recentlySelectedSiteIds( state = [], action ) {
-	switch ( action.type ) {
-		case SELECTED_SITE_SET:
-			state = [ action.siteId, ...state ];
-			if ( state.length === 3 ) {
-				state.pop();
-			}
-			return state;
-	}
-
-	return state;
-}
-
 //TODO: do we really want to mix strings and booleans?
 export function section( state = false, action ) {
 	switch ( action.type ) {
@@ -97,7 +77,6 @@ const reducer = combineReducers( {
 	isPreviewShowing,
 	queryArguments,
 	selectedSiteId,
-	recentlySelectedSiteIds,
 	guidedTour,
 	editor,
 	reader,

--- a/client/state/ui/test/reducer.js
+++ b/client/state/ui/test/reducer.js
@@ -14,6 +14,24 @@ import {
 import reducer, { selectedSiteId } from '../reducer';
 
 describe( 'reducer', () => {
+	it( 'should include expected keys in return value', () => {
+		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'section',
+			'isLoading',
+			'layoutFocus',
+			'hasSidebar',
+			'isPreviewShowing',
+			'queryArguments',
+			'selectedSiteId',
+			'guidedTour',
+			'editor',
+			'reader',
+			'olark',
+			'preview',
+			'actionLog'
+		] );
+	} );
+
 	it( 'should refuse to persist any state', () => {
 		const state = reducer( {
 			selectedSiteId: 2916284


### PR DESCRIPTION
Related: #7478, #7566, #7580

This pull request seeks to effect the same changes as in #7478, with the following reconsiderations:

- In #7478, the recent sites preference would never have been set for a user if they did not already have a valid preference. This is fixed here in ee581fc using the `hasReceivedRemotePreferences` selector introduced in #7566 as the means for determining whether it is okay to set the preference, instead of a truthy check on the preference value itself (which would never be true for a user who had never set the preference)
- #7478 did not account for users with less than 12 visible sites, which are not shown recent sites in the site selector. This caused issues where the site selector would not list any of the user's sites. This is fixed in 8e401ef  by adding a new prop to the `connect` selector, `showRecentSites`.
- Removed controller Redux `<Provider />` wrapping, as this was merged separately in #7580 

__Testing instructions:__

Repeat testing instructions from #7478

/cc @gwwar 

Test live: https://calypso.live/?branch=update/site-selector-preferences-2