### PR TITLE
Reader: Fix Follow count and button wrapping in full-post

### DIFF
--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -1,96 +1,96 @@
 .author-compact-profile {
-    font-size: 14px;
+	font-size: 14px;
 
-    .gravatar {
-        display: flex;
-        margin: auto;
-    }
+	.gravatar {
+		display: flex;
+		margin: auto;
+	}
 
-    .follow-button {
-        border: 0;
-        border-radius: 0;
-        padding: 0;
+	.follow-button {
+		border: 0;
+		border-radius: 0;
+		padding: 0;
 
-        .gridicon__follow {
-            fill: $blue-medium;
-        }
+		.gridicon__follow {
+			fill: $blue-medium;
+		}
 
-        .follow-button__label {
-            color: $blue-medium;
+		.follow-button__label {
+			color: $blue-medium;
 
 
-            @include breakpoint( "<660px" ) {
-                display: inline-block;
-            }
-        }
+			@include breakpoint( "<660px" ) {
+				display: inline-block;
+			}
+		}
 
-        &.is-following .follow-button__label {
-            color: $alert-green;
-        }
+		&.is-following .follow-button__label {
+			color: $alert-green;
+		}
 
-        &:hover {
-            .gridicon__follow {
-                fill: lighten( $gray, 10% );
-            }
+		&:hover {
+			.gridicon__follow {
+				fill: lighten( $gray, 10% );
+			}
 
-            .follow-button__label {
-                color: lighten( $gray, 10% );
-            }
-        }
+			.follow-button__label {
+				color: lighten( $gray, 10% );
+			}
+		}
 
-        // No hover if already following
-        &.is-following {
-            &:hover {
-                .gridicon__follow {
-                    fill: $alert-green;
-                }
+		// No hover if already following
+		&.is-following {
+			&:hover {
+				.gridicon__follow {
+					fill: $alert-green;
+				}
 
-                .follow-button__label {
-                    color: $alert-green;
-                }
-            }
-        }
-    }
+				.follow-button__label {
+					color: $alert-green;
+				}
+			}
+		}
+	}
 
-    // If there's an author link, present site stream link in normal font weight
-    &.has-author-link {
-        .author-compact-profile__site-link {
-            font-weight: inherit;
-            margin-top: 4px;
-        }
-    }
+	// If there's an author link, present site stream link in normal font weight
+	&.has-author-link {
+		.author-compact-profile__site-link {
+			font-weight: inherit;
+			margin-top: 4px;
+		}
+	}
 }
 
 .author-compact-profile .external-link,
 .author-compact-profile__site-link,
 .author-compact-profile__follow {
-    align-items: center;
-    color: $blue-medium;
-    display: flex;
-    justify-content: center;
+	align-items: center;
+	color: $blue-medium;
+	display: flex;
+	justify-content: center;
 
-    &:hover {
-        color: lighten( $gray, 10% );
-    }
+	&:hover {
+		color: lighten( $gray, 10% );
+	}
 }
 
 .author-compact-profile .reader-author-link,
 .author-compact-profile__site-link {
-    font-weight: 600;
-    margin-top: 18px;
+	font-weight: 600;
+	margin-top: 18px;
 }
 
 .author-compact-profile__follow {
-    display: flex;
-    flex-wrap: wrap;
-    margin: 11px 0;
+	display: flex;
+	flex-wrap: wrap;
+	margin: 11px 0;
 
-    .follow-button {
-        padding: 5px;
-    }
+	.follow-button {
+		padding: 5px;
+	}
 }
 
 .author-compact-profile__follow-count {
-    color: lighten( $gray, 10% );
-    padding: 5px;
+	color: lighten( $gray, 10% );
+	padding: 5px;
 }

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -1,42 +1,42 @@
 .author-compact-profile {
-	font-size: 14px;
+    font-size: 14px;
 
-	.gravatar {
-    	display: flex;
-    	margin: auto;
+    .gravatar {
+        display: flex;
+        margin: auto;
     }
 
     .follow-button {
-    	border: 0;
-    	border-radius: 0;
-    	padding: 0;
+        border: 0;
+        border-radius: 0;
+        padding: 0;
 
-    	.gridicon__follow {
-    		fill: $blue-medium;
-    	}
+        .gridicon__follow {
+            fill: $blue-medium;
+        }
 
-    	.follow-button__label {
-    		color: $blue-medium;
+        .follow-button__label {
+            color: $blue-medium;
 
 
-    		@include breakpoint( "<660px" ) {
-    			display: inline-block;
-    		}
-    	}
+            @include breakpoint( "<660px" ) {
+                display: inline-block;
+            }
+        }
 
-		&.is-following .follow-button__label {
-			color: $alert-green;
-		}
+        &.is-following .follow-button__label {
+            color: $alert-green;
+        }
 
-		&:hover {
-			.gridicon__follow {
-				fill: lighten( $gray, 10% );
-			}
+        &:hover {
+            .gridicon__follow {
+                fill: lighten( $gray, 10% );
+            }
 
-			.follow-button__label {
-				color: lighten( $gray, 10% );
-			}
-		}
+            .follow-button__label {
+                color: lighten( $gray, 10% );
+            }
+        }
 
         // No hover if already following
         &.is-following {
@@ -70,25 +70,27 @@
     justify-content: center;
 
     &:hover {
-    	color: lighten( $gray, 10% );
+        color: lighten( $gray, 10% );
     }
 }
 
 .author-compact-profile .reader-author-link,
 .author-compact-profile__site-link {
-	font-weight: 600;
-	margin-top: 18px;
+    font-weight: 600;
+    margin-top: 18px;
 }
 
 .author-compact-profile__follow {
-	margin: 11px 0;
+    display: flex;
+    flex-wrap: wrap;
+    margin: 11px 0;
+
+    .follow-button {
+        padding: 5px;
+    }
 }
 
 .author-compact-profile__follow-count {
-	display: inline-flex;
-}
-
-.author-compact-profile__follow-count {
-	color: lighten( $gray, 10% );
-	margin-right: 15px;
+    color: lighten( $gray, 10% );
+    padding: 5px;
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/7424

If Follow count is high:

**Before:**
![screenshot 2016-08-23 13 47 30](https://cloud.githubusercontent.com/assets/4924246/17909180/27b8848a-6938-11e6-94fd-77190fcdf1d1.png)

**After:**
![screenshot 2016-08-23 13 46 55](https://cloud.githubusercontent.com/assets/4924246/17909164/144e26e8-6938-11e6-900e-1b9c8b5ae1cc.png)

If Follow count is low, both items remain in the same line:

![screenshot 2016-08-23 13 52 10](https://cloud.githubusercontent.com/assets/4924246/17909309/d221b0b8-6938-11e6-9fdc-bd27ec3398e6.png)

![screenshot 2016-08-23 13 52 15](https://cloud.githubusercontent.com/assets/4924246/17909312/d4d5450e-6938-11e6-9b5b-ee1e17eb28bd.png)

/cc @bluefuton @fraying 

Test live: https://calypso.live/?branch=fix/reader/follow-count-button-wrapping