### PR TITLE
Help: Add mock data and display it at /help/courses

### DIFF
--- a/client/me/help/help-courses/course-list.jsx
+++ b/client/me/help/help-courses/course-list.jsx
@@ -7,14 +7,19 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Course from './course';
 import Card from 'components/card';
 
 class CourseList extends Component {
 	render() {
+		const { courses, showRecentCourseRecordings } = this.props;
+
 		return (
-			<Card className="help-courses__course-list">
-				Course list: visible to all
-			</Card>
+			<div className="help-courses__course-list">
+				{ courses.map( ( course, key ) => {
+					return <Course { ...course } key={ key } showRecentCourseRecordings={ showRecentCourseRecordings }/>;
+				} ) }
+			</div>
 		);
 	}
 }

--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Button from 'components/button';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import Gridicon from 'components/gridicon';
+import Card from 'components/card';
+
+export default localize( ( props ) => {
+	const {
+		date,
+		registrationUrl,
+		translate
+	} = props;
+
+	return (
+		<Card compact className="help-courses__course-schedule-item">
+			<p className="help-courses__course-schedule-item-date">
+				<Gridicon className="help-courses__course-schedule-item-icon" icon="time" size={ 18 }/>
+				{
+					translate( '%(date)s at %(time)s', {
+						args: {
+							date: date.format( 'dddd, MMMM D' ),
+							time: date.format( 'LT zz' )
+						}
+					} )
+				}
+			</p>
+			<div className="help-courses__course-schedule-item-buttons">
+				<Button className="help-courses__course-schedule-item-register-button"
+					target="_blank"
+					href={ registrationUrl }>
+					{ translate( 'Register' ) }
+				</Button>
+			</div>
+		</Card>
+	);
+} );

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -1,24 +1,44 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
-import Card from 'components/card';
 
-class Course extends Component {
-	render() {
-		return (
-			<Card className="help-courses__course">
-				Latest course: Only visible for users with the business plan
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import CourseScheduleItem from './course-schedule-item';
+
+export default localize( ( props ) => {
+	const {
+		title,
+		description,
+		schedule,
+		showRecentCourseRecordings,
+		translate
+	} = props;
+
+	return (
+		<div className="help-courses__course">
+			<Card compact className="help-courses__course-label">{ translate( 'Next course' ) }</Card>
+			<Card compact>
+				<h1 className="help-courses__course-title">{ title }</h1>
+				<p className="help-courses__course-description">{ description }</p>
 			</Card>
-		);
-	}
-}
+			{ schedule.map( ( item, key ) => <CourseScheduleItem { ...item } key={ key } /> ) }
+			{
+				showRecentCourseRecordings &&
+				<Card className="help-courses__course-recording">
+					Show most recent recording here
+				</Card>
+			}
+		</div>
+	);
+} );
 
 export const CoursePlaceholder = () => {
 	return (
-		<Card className="help-courses__course is-placeholder"></Card>
+		<div className="help-courses__course is-placeholder"></div>
 	);
 };
-
-export default localize( Course );

--- a/client/me/help/help-courses/courses.jsx
+++ b/client/me/help/help-courses/courses.jsx
@@ -9,7 +9,6 @@ import React, { Component } from 'react';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import CourseList, { CourseListPlaceholder } from './course-list';
-import Course, { CoursePlaceholder } from './course';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 
 class Courses extends Component {
@@ -17,20 +16,19 @@ class Courses extends Component {
 		const {
 			translate,
 			userId,
-			isBusinessPlanUser,
+			showRecentCourseRecordings,
+			courses,
 			isLoading
 		} = this.props;
 
 		return (
 			<Main className="help-courses">
-				<HeaderCake backHref="/help" isCompact={ false }>{ translate( 'Courses' ) }</HeaderCake>
+				<HeaderCake backHref="/help" isCompact={ false } className="help-courses__header-cake">
+					{ translate( 'Courses' ) }
+				</HeaderCake>
 				{ isLoading
 					? <CourseListPlaceholder />
-					: <CourseList /> }
-
-				{ isLoading
-					? <CoursePlaceholder />
-					: isBusinessPlanUser && <Course /> }
+					: <CourseList courses={ courses } showRecentCourseRecordings={ showRecentCourseRecordings } /> }
 
 				<QueryUserPurchases userId={ userId } />
 			</Main>

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 
 /**
@@ -16,16 +16,54 @@ import {
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 
+function getCourses() {
+	return [
+		{
+			title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
+			description: i18n.translate(
+				'A 60-minute overview course with two of our Happiness Engineers. In this live group session, ' +
+				'we will provide an overview of WordPress.com, discuss features of the WordPress.com Business ' +
+				'plan, provide a basic setup overview to help you get started with your site, and show you ' +
+				'where to find additional resources and help in the future.'
+			),
+			schedule: [
+				{
+					date: i18n.moment( new Date( 'Thu, 25 Aug 2016 20:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/09d8d987acc52235c5b9141539e44ee6'
+				},
+				{
+					date: i18n.moment( new Date( 'Sat, 27 Aug 2016 16:00:00 +0000' ) ),
+					registrationUrl: 'http://wordpress.com'
+				},
+				{
+					date: i18n.moment( new Date( 'Wed, 31 Aug 2016 17:30:00 +0000' ) ),
+					registrationUrl: 'http://wordpress.com'
+				},
+			],
+			recent: [
+				{
+					date: i18n.moment( new Date( 'Mon, 01 Aug 2016 17:30:00 +0000' ) ),
+					video: 'http://wordpress.com/some-video.mp4'
+				}
+			]
+		}
+	];
+}
+
 function mapStateToProps( state ) {
 	const userId = getCurrentUserId( state );
 	const purchases = getUserPurchases( state, userId );
-	const isBusinessPlanUser = purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS );
+	const showRecentCourseRecordings = purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS );
 	const isLoading = ! hasLoadedUserPurchasesFromServer( state );
+	const courses = getCourses();
+
+	//TODO: Add tracks pings
 
 	return {
 		isLoading,
-		isBusinessPlanUser,
-		userId
+		showRecentCourseRecordings,
+		userId,
+		courses
 	};
 }
 

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -10,3 +10,69 @@
 		@include placeholder( 23% );
 	}
 }
+
+.help-courses__header-cake .header-cake__title,
+.help-courses__course-label {
+	color: $gray;
+}
+
+.help-courses__course-title {
+	@extend %content-font;
+	color: $gray-dark;
+	font-weight: 700;
+	font-size: 21px;
+	line-height: 1.3;
+
+	margin-bottom: 8px;
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+
+	@include breakpoint( ">480px" ) {
+		font-size: 24px;
+		line-height: 1.416;
+	}
+}
+
+.help-courses__course-description {
+	@extend %content-font;
+	font-size: 15px;
+	line-height: 22px;
+	margin-bottom: 0px;
+
+	@include breakpoint( ">480px" ) {
+		font-size: 16px;
+		line-height: 1.618;
+	}
+}
+
+.help-courses__course-schedule-item {
+	color: $gray;
+	display: flex;
+	align-items: center;
+}
+
+.help-courses__course-schedule-item-date {
+	font-size: 13px;
+	display: inline-block;
+	margin: 0px 10px 0px 0px;
+	white-space: normal;
+
+	@include breakpoint( ">480px" ) {
+		font-size: 15px;
+	}
+}
+
+.help-courses__course-schedule-item-icon {
+	align-self: center;
+	margin-right: 5px;
+	margin-bottom: -3px;
+}
+
+.help-courses__course-schedule-item-buttons {
+	margin-left: auto;
+}
+
+.help-courses__course-recording {
+	margin-top: 16px;
+}
+


### PR DESCRIPTION
This pull request aims at rendering the top portion of the page at /help/courses. It does so by doing the following:
 1. Add some mock data in a non traditional way in the interest of saving dev time for the first pass at this feature.
 2. Render the first part of the courses page using the title, description, course times and registration link.

## How to test
### Visual
 1. Navigate to https://calypso.live/help?branch=add/help-courses-course-list
 2. Click the "Courses" button.
 3. You should see a new page listing a single course with multiple times along with register buttons next to them.
 4. Clicking on a register button opens a new browser tab to wordpress.com (We don't have real registration links yet).

### Timezone
 1. Navigate to https://calypso.live/help?branch=add/help-courses-course-list
 2. Click the "Courses" button.
 3. You should see a new page listing a single course with multiple times with register buttons next to them.
 4. Notice that each time listed is in your current timezone. Verify that the times are in the order displayed:
  1. 8/25/2016 1:00 pm PDT
  2. 8/27/2016 9:00 am PDT
  3. 8/31/2016 10:30 am PDT

### What to expect 
![screen shot 2016-08-23 at 7 15 21 pm](https://cloud.githubusercontent.com/assets/1854440/17913124/0a2b3128-6966-11e6-99d6-a2c4dd58cf98.png)

![screen shot 2016-08-23 at 7 23 03 pm](https://cloud.githubusercontent.com/assets/1854440/17913319/19bc8974-6967-11e6-830f-06265edf537b.png)




Test live: https://calypso.live/?branch=add/help-courses-course-list