### PR TITLE
WebPreview: add prop to allow space for a sidebar

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -184,6 +184,7 @@ export class WebPreview extends Component {
 
 		const className = classNames( this.props.className, 'web-preview', {
 			'is-touch': this._hasTouch,
+			'is-with-sidebar': this.props.hasSidebar,
 			'is-visible': this.props.showPreview,
 			'is-computer': this.state.device === 'computer',
 			'is-tablet': this.state.device === 'tablet',
@@ -263,7 +264,9 @@ WebPreview.propTypes = {
 	// Optional loading message to display during loading
 	loadingMessage: PropTypes.string,
 	// The iframe's title element, used for accessibility purposes
-	iframeTitle: PropTypes.string
+	iframeTitle: PropTypes.string,
+	// Makes room for a sidebar if desired
+	hasSidebar: React.PropTypes.bool,
 };
 
 WebPreview.defaultProps = {
@@ -273,7 +276,8 @@ WebPreview.defaultProps = {
 	previewUrl: null,
 	previewMarkup: null,
 	onLoad: noop,
-	onClose: noop
+	onClose: noop,
+	hasSidebar: false,
 };
 
 export default connect( null, { setPreviewShowing } )( localize( WebPreview ) );

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -21,7 +21,9 @@
 	}
 
 	&.is-with-sidebar {
-		left: 273px;
+		@include breakpoint( ">660px" ) {
+			left: 273px;
+		}
 	}
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -19,6 +19,10 @@
 			transform: translateY( 0 ) scale( 1 );
 		}
 	}
+
+	&.is-with-sidebar {
+		left: 273px;
+	}
 }
 
 .web-preview__backdrop {


### PR DESCRIPTION
Adds `hasSidebar` prop to `WebPreview`, which adjusts the position of the preview over a bit to make space for a sidebar. 

This is extracted from #7477 and #7508, the latter of which actually adds a sidebar.

### Testing

There's no way to trigger this directly right now, but you can edit the source to do it manually.

First, make sure regular previews still work: click the site preview button in the my-sites view and make sure the site preview shows up correctly.

<img width="250" alt="screen_shot_2016-08-16_at_4_32_06_pm" src="https://cloud.githubusercontent.com/assets/2036909/17863814/4fd6cac8-6869-11e6-9532-c83f391a1cb3.png">

<img src="https://cloud.githubusercontent.com/assets/2036909/17714847/8d9f2ea2-63cf-11e6-9141-49bd0d7c5166.png">

Second, edit the source of [DesignPreview](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/design-preview/index.js) and in the `render` method, add `hasSidebar={true}`.

Repeat the first test above and be sure that the preview is shifted to the right a bit.

<img src="https://cloud.githubusercontent.com/assets/2036909/17714819/74df1300-63cf-11e6-8c58-8fe55cadaa24.png">

Test live: https://calypso.live/?branch=add/web-preview-sidebar-space