### PR TITLE
Reader: update coldStartReader A/B test, enabling auto-follows

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -16,7 +16,7 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	coldStartReader: {
-		datestamp: '20160804',
+		datestamp: '20160824',
 		variations: {
 			noEmailColdStart: 20,
 			noChanges: 80

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -16,10 +16,11 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	coldStartReader: {
-		datestamp: '20160824',
+		datestamp: '20160901',
 		variations: {
-			noEmailColdStart: 20,
-			noChanges: 80
+			noEmailColdStart: 33,
+			noEmailColdStartWithAutofollows: 33,
+			noChanges: 34
 		},
 		defaultVariation: 'noChanges',
 		allowExistingUsers: false,

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -12,7 +12,7 @@ import defer from 'lodash/defer';
 /**
  * Internal Dependencies
  */
-import abtest from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 import route from 'lib/route';
 import feedStreamFactory from 'lib/feed-stream-store';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage, setPageTitle } from './controller-helper';

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -135,6 +135,13 @@ module.exports = {
 		const FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' );
 		const user = getCurrentUser( context.store.getState() );
 		const numberofTries = 3;
+		let graduationThreshold;
+
+		if ( abtest( 'coldStartReader' ) === 'noEmailColdStartWithAutofollows' ) {
+			graduationThreshold = config( 'reader_cold_start_graduation_threshold_with_autofollows' );
+		} else {
+			graduationThreshold = config( 'reader_cold_start_graduation_threshold' );
+		}
 
 		if ( ! user ) {
 			next();
@@ -149,7 +156,7 @@ module.exports = {
 		function checkSubCount( tries ) {
 			if ( FeedSubscriptionStore.getCurrentPage() > 0 || FeedSubscriptionStore.isLastPage() ) {
 				// we have total subs now, make the decision
-				if ( FeedSubscriptionStore.getTotalSubscriptions() < config( 'reader_cold_start_graduation_threshold' ) ) {
+				if ( FeedSubscriptionStore.getTotalSubscriptions() < graduationThreshold ) {
 					defer( page.redirect.bind( page, '/recommendations/start' ) );
 				} else {
 					if ( ! isRequestingGraduation( context.store.getState() ) ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -63,7 +63,7 @@ export default React.createClass( {
 		if ( config.isEnabled( 'reader/start' ) ) {
 			// User is participating in Reader Cold Start
 			if ( abtest( 'coldStartReader' ) === 'noEmailColdStart' ) {
-				userData.follow_default_blogs = false;
+				userData.follow_default_blogs = true;
 				userData.subscription_delivery_email_default = 'never';
 				userData.is_new_reader = true;
 			}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -62,10 +62,16 @@ export default React.createClass( {
 
 		if ( config.isEnabled( 'reader/start' ) ) {
 			// User is participating in Reader Cold Start
-			if ( abtest( 'coldStartReader' ) === 'noEmailColdStart' ) {
-				userData.follow_default_blogs = true;
+			const coldStartVariant = abtest( 'coldStartReader' );
+
+			if ( coldStartVariant === 'noEmailColdStart' || coldStartVariant === 'noEmailColdStartWithAutofollows' ) {
 				userData.subscription_delivery_email_default = 'never';
 				userData.is_new_reader = true;
+			}
+
+			// Autofollows are on by default
+			if ( coldStartVariant === 'noEmailColdStart' ) {
+				userData.follow_default_blogs = false;
 			}
 		}
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -145,5 +145,6 @@
 		{ "value": 452, "langSlug": "zh-tw", "name": "zh-tw - 繁體中文", "wpLocale": "zh_TW", "popular": 14 }
 	],
 	"project": "wordpress-com",
-	"reader_cold_start_graduation_threshold": 2
+	"reader_cold_start_graduation_threshold": 2,
+	"reader_cold_start_graduation_threshold_with_autofollows": 6
 }


### PR DESCRIPTION
Prior to the Cold Start experiment, we autofollowed new Readers to the "big 4": Daily Post, Discover, Longreads, and WordPress.com News.

This PR updates the experiment to re-introduce autofollowing, but otherwise keeps Cold Start the same.

Test live: https://calypso.live/?branch=add/reader/cold-start-v3