### PR TITLE
Components: Get rid of React warning `value` prop on `input` should not be null

### DIFF
--- a/client/me/purchases/components/credit-card-page/index.jsx
+++ b/client/me/purchases/components/credit-card-page/index.jsx
@@ -61,7 +61,9 @@ const CreditCardPage = React.createClass( {
 	componentWillMount() {
 		this._mounted = true;
 
-		const fields = formState.createNullFieldValues( this.fieldNames );
+		const fields = this.fieldNames.reduce( ( result, fieldName ) => {
+			return { ...result, [ fieldName ]: undefined };
+		}, {} );
 
 		if ( this.props.initialValues ) {
 			fields.name = this.props.initialValues.name;


### PR DESCRIPTION
Part of #7413.

Last warning found in the Purchases section.

This PR removes React warning created by `<CreditCardForm />`:

> Warning: `value` prop on `input` should not be null. Consider using the empty string to clear the component or `undefined` for uncontrolled components.

### Testing
There are multiplay ways to check it. One of them:
1. Go to Manage Purchases page (http://calypso.localhost:3000/purchases).
2. Select a purchase paid with credit card.
3. Click on Edit Payment Method link.
4. Make sure there are no warnings.

Test live: https://calypso.live/?branch=fix/warning-null-value-input