### PR TITLE
GuidedTours: remove unused import

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -11,7 +11,6 @@ import i18n from 'i18n-calypso';
  */
 import { abtest } from 'lib/abtest';
 import config from 'config';
-import { isOutsideCalypso } from 'lib/url';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
 


### PR DESCRIPTION
This unused import was overlooked in #6858 when we removed the initial GuidedTours A/B test.

To test:
- You could try to make sure `flows.js` is still fine by going through a few signup variations. I'm unsure how one would test this better. 

/cc @michaeldcain 

Test live: https://calypso.live/?branch=fix/guided-tours-abtest-remove-unused-import