### PR TITLE
Fix 'no results found' message in Reader Search

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -165,12 +165,6 @@ const FeedStream = React.createClass( {
 			? <EmptyContent query={ this.props.query } />
 			: blankContent;
 
-		// Override showing of EmptyContent in Reader stream
-		let showEmptyContent = true;
-		if ( this.props.showBlankContent === false || this.props.query ) {
-			showEmptyContent = false;
-		}
-
 		const store = this.props.store || emptyStore;
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
@@ -182,7 +176,7 @@ const FeedStream = React.createClass( {
 			<Stream { ...this.props } store={ store }
 				listName={ this.translate( 'Search' ) }
 				emptyContent={ emptyContent }
-				showEmptyContent={ showEmptyContent }
+				showDefaultEmptyContentIfMissing={ this.props.showBlankContent }
 				showFollowInHeader={ true }
 				cardFactory={ this.cardFactory }
 				className="search-stream" >

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -48,7 +48,7 @@ module.exports = React.createClass( {
 		onUpdatesShown: React.PropTypes.func,
 		emptyContent: React.PropTypes.object,
 		className: React.PropTypes.string,
-		showEmptyContent: React.PropTypes.bool,
+		showDefaultEmptyContentIfMissing: React.PropTypes.bool,
 		showPrimaryFollowButtonOnCards: React.PropTypes.bool,
 		showMobileBackToSidebar: React.PropTypes.bool
 	},
@@ -60,7 +60,7 @@ module.exports = React.createClass( {
 			showFollowInHeader: false,
 			onShowUpdates: noop,
 			className: '',
-			showEmptyContent: true,
+			showDefaultEmptyContentIfMissing: true,
 			showPrimaryFollowButtonOnCards: false,
 			showMobileBackToSidebar: true
 		};
@@ -439,7 +439,10 @@ module.exports = React.createClass( {
 			body, showingStream;
 
 		if ( hasNoPosts || store.hasRecentError( 'invalid_tag' ) ) {
-			body = this.props.showEmptyContent ? ( this.props.emptyContent || ( <EmptyContent /> ) ) : null;
+			body = this.props.emptyContent;
+			if ( ! body && this.props.showDefaultEmptyContentIfMissing ) {
+				body = ( <EmptyContent /> );
+			}
 			showingStream = false;
 		} else {
 			body = ( <InfiniteList


### PR DESCRIPTION
Restore the missing 'no results found' message when a query generates no results in Reader Search:

![895ca256-62f9-11e6-9aaf-8fb1e4e0ddd0](https://cloud.githubusercontent.com/assets/17325/17925956/5f998388-69ef-11e6-8b5f-4b06bbda259d.png)

Fixes #7468.

### To test

Ensure that search works as expected in both Reader Search:

http://calypso.localhost:3000/read/search

and Cold Start:

http://calypso.localhost:3000/recommendations/start

Test live: https://calypso.live/?branch=fix/reader/search-no-results-message