### PR TITLE
Framework: Try out HardSourceWebpackPlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.webpack-cache
 .sass-cache
 .vagrant
 .unison

--- a/config/development.json
+++ b/config/development.json
@@ -148,6 +148,7 @@
 		"vip/billing": true,
 		"vip/deploys": true,
 		"vip/logs": true,
-		"vip/support": true
+		"vip/support": true,
+		"webpack/persistent-caching": true
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -149,6 +149,6 @@
 		"vip/deploys": true,
 		"vip/logs": true,
 		"vip/support": true,
-		"webpack/persistent-caching": true
+		"webpack/persistent-caching": false
 	}
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,6 +8,9 @@
     "abbrev": {
       "version": "1.0.9"
     },
+    "abstract-leveldown": {
+      "version": "2.4.1"
+    },
     "accepts": {
       "version": "1.2.13"
     },
@@ -21,7 +24,7 @@
       "version": "3.0.1"
     },
     "after": {
-      "version": "0.8.1"
+      "version": "0.8.2"
     },
     "ajv": {
       "version": "4.7.7"
@@ -35,6 +38,9 @@
     "amdefine": {
       "version": "1.0.0"
     },
+    "ansi": {
+      "version": "0.3.1"
+    },
     "ansi-escapes": {
       "version": "1.4.0"
     },
@@ -46,9 +52,6 @@
     },
     "anymatch": {
       "version": "1.3.0"
-    },
-    "aproba": {
-      "version": "1.0.4"
     },
     "are-we-there-yet": {
       "version": "1.1.2"
@@ -406,8 +409,19 @@
     "binary-extensions": {
       "version": "1.7.0"
     },
+    "bindings": {
+      "version": "1.2.1"
+    },
     "bl": {
-      "version": "1.1.2"
+      "version": "1.0.3",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.0.6"
+        }
+      }
     },
     "blessed": {
       "version": "0.1.81"
@@ -417,6 +431,9 @@
     },
     "block-stream": {
       "version": "0.0.9"
+    },
+    "bluebird": {
+      "version": "3.4.6"
     },
     "body-parser": {
       "version": "1.15.2",
@@ -454,7 +471,15 @@
       "version": "1.3.6"
     },
     "buffer": {
-      "version": "4.9.1"
+      "version": "4.9.1",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "buffer-shims": {
+      "version": "1.0.0"
     },
     "builtin-modules": {
       "version": "1.1.1"
@@ -489,7 +514,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000547"
+      "version": "1.0.30000548"
     },
     "caseless": {
       "version": "0.11.0"
@@ -650,7 +675,15 @@
       "version": "0.0.1"
     },
     "concat-stream": {
-      "version": "1.5.2"
+      "version": "1.5.2",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.0.6"
+        }
+      }
     },
     "configstore": {
       "version": "0.3.2",
@@ -667,9 +700,6 @@
       "version": "1.1.0"
     },
     "console-browserify": {
-      "version": "1.1.0"
-    },
-    "console-control-strings": {
       "version": "1.1.0"
     },
     "constant-case": {
@@ -745,15 +775,7 @@
       "version": "1.2.0"
     },
     "css-tokenize": {
-      "version": "1.0.1",
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.1.14"
-        }
-      }
+      "version": "1.0.1"
     },
     "css-what": {
       "version": "2.1.0"
@@ -815,6 +837,9 @@
         }
       }
     },
+    "deferred-leveldown": {
+      "version": "1.2.1"
+    },
     "define-properties": {
       "version": "1.1.2"
     },
@@ -859,7 +884,12 @@
       "version": "2.0.0"
     },
     "doctrine": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
     },
     "doctypes": {
       "version": "1.1.0"
@@ -916,18 +946,24 @@
       "version": "0.1.1"
     },
     "duplexer2": {
-      "version": "0.0.2",
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.1.14"
-        }
-      }
+      "version": "0.0.2"
     },
     "duplexify": {
-      "version": "3.4.5"
+      "version": "3.4.5",
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.0.0"
+        },
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "once": {
+          "version": "1.3.3"
+        },
+        "readable-stream": {
+          "version": "2.1.5"
+        }
+      }
     },
     "editions": {
       "version": "1.1.2"
@@ -948,7 +984,7 @@
       "version": "0.1.12"
     },
     "end-of-stream": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "once": {
           "version": "1.3.3"
@@ -983,11 +1019,11 @@
     "engine.io-parser": {
       "version": "1.2.4",
       "dependencies": {
+        "after": {
+          "version": "0.8.1"
+        },
         "has-binary": {
           "version": "0.1.6"
-        },
-        "isarray": {
-          "version": "0.0.1"
         }
       }
     },
@@ -1002,11 +1038,19 @@
     "entities": {
       "version": "1.0.0"
     },
+    "env-hash": {
+      "version": "1.1.0"
+    },
     "enzyme": {
       "version": "2.4.1"
     },
     "errno": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "dependencies": {
+        "prr": {
+          "version": "0.0.0"
+        }
+      }
     },
     "error-ex": {
       "version": "1.3.0"
@@ -1136,9 +1180,6 @@
         "strip-bom": {
           "version": "3.0.0"
         },
-        "strip-json-comments": {
-          "version": "1.0.4"
-        },
         "supports-color": {
           "version": "2.0.0"
         },
@@ -1219,6 +1260,9 @@
     "expand-range": {
       "version": "1.8.2"
     },
+    "expand-template": {
+      "version": "1.0.3"
+    },
     "expand-year": {
       "version": "1.0.0"
     },
@@ -1247,6 +1291,9 @@
     },
     "extsprintf": {
       "version": "1.0.2"
+    },
+    "fast-future": {
+      "version": "1.0.1"
     },
     "fast-levenshtein": {
       "version": "2.0.5"
@@ -1381,7 +1428,7 @@
       "version": "1.0.0"
     },
     "gauge": {
-      "version": "2.6.0"
+      "version": "1.2.7"
     },
     "gaze": {
       "version": "1.1.2"
@@ -1411,6 +1458,18 @@
           "version": "1.0.0"
         }
       }
+    },
+    "ghreleases": {
+      "version": "1.0.5"
+    },
+    "ghrepos": {
+      "version": "2.0.0"
+    },
+    "ghutils": {
+      "version": "3.2.0"
+    },
+    "github-from-package": {
+      "version": "0.0.0"
     },
     "glob": {
       "version": "7.0.3"
@@ -1489,6 +1548,14 @@
         }
       }
     },
+    "hard-source-webpack-plugin": {
+      "version": "0.0.42",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6"
+        }
+      }
+    },
     "has": {
       "version": "1.0.1"
     },
@@ -1496,14 +1563,6 @@
       "version": "2.0.0"
     },
     "has-binary": {
-      "version": "0.1.7",
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        }
-      }
-    },
-    "has-color": {
       "version": "0.1.7"
     },
     "has-cors": {
@@ -1568,15 +1627,7 @@
       "version": "1.1.1"
     },
     "htmlparser2": {
-      "version": "3.8.3",
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.1.14"
-        }
-      }
+      "version": "3.8.3"
     },
     "http-browserify": {
       "version": "1.7.0"
@@ -1592,6 +1643,9 @@
     },
     "https-browserify": {
       "version": "0.0.0"
+    },
+    "hyperquest": {
+      "version": "1.2.0"
     },
     "i18n-calypso": {
       "version": "1.6.2",
@@ -1801,13 +1855,18 @@
       "version": "1.0.0"
     },
     "isarray": {
-      "version": "1.0.0"
+      "version": "0.0.1"
     },
     "isexe": {
       "version": "1.1.2"
     },
     "isobject": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
     },
     "isomorphic-fetch": {
       "version": "2.2.1"
@@ -1935,6 +1994,9 @@
     "jsonify": {
       "version": "0.0.0"
     },
+    "jsonist": {
+      "version": "1.2.0"
+    },
     "jsonparse": {
       "version": "0.0.5"
     },
@@ -1976,6 +2038,27 @@
     },
     "ldjson-stream": {
       "version": "1.2.1"
+    },
+    "level": {
+      "version": "1.4.0"
+    },
+    "level-codec": {
+      "version": "6.1.0"
+    },
+    "level-errors": {
+      "version": "1.0.4"
+    },
+    "level-iterator-stream": {
+      "version": "1.3.1"
+    },
+    "level-packager": {
+      "version": "1.2.0"
+    },
+    "leveldown": {
+      "version": "1.4.6"
+    },
+    "levelup": {
+      "version": "1.3.2"
     },
     "levn": {
       "version": "0.3.0"
@@ -2038,6 +2121,15 @@
     "lodash.keys": {
       "version": "3.1.2"
     },
+    "lodash.pad": {
+      "version": "4.5.1"
+    },
+    "lodash.padend": {
+      "version": "4.6.1"
+    },
+    "lodash.padstart": {
+      "version": "4.6.1"
+    },
     "lodash.pickby": {
       "version": "4.6.0"
     },
@@ -2095,7 +2187,15 @@
       "version": "0.3.0"
     },
     "memory-fs": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.1.5"
+        }
+      }
     },
     "meow": {
       "version": "3.7.0"
@@ -2193,7 +2293,7 @@
       "version": "0.0.5"
     },
     "nan": {
-      "version": "2.4.0"
+      "version": "2.3.5"
     },
     "natives": {
       "version": "1.1.0"
@@ -2236,13 +2336,13 @@
       }
     },
     "node-libs-browser": {
-      "version": "0.6.0",
+      "version": "0.6.0"
+    },
+    "node-ninja": {
+      "version": "1.0.2",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.1.14"
+        "minimatch": {
+          "version": "3.0.3"
         }
       }
     },
@@ -2271,6 +2371,9 @@
         }
       }
     },
+    "noop-logger": {
+      "version": "0.1.1"
+    },
     "nopt": {
       "version": "3.0.6"
     },
@@ -2293,7 +2396,7 @@
       "version": "1.1.1"
     },
     "npmlog": {
-      "version": "3.1.2"
+      "version": "2.0.4"
     },
     "nth-check": {
       "version": "1.0.1"
@@ -2386,9 +2489,6 @@
     "page": {
       "version": "1.6.4",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
         "path-to-regexp": {
           "version": "1.2.1"
         }
@@ -2529,6 +2629,14 @@
     "postcss-value-parser": {
       "version": "3.3.0"
     },
+    "prebuild": {
+      "version": "4.2.2",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2"
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2"
     },
@@ -2566,13 +2674,16 @@
       "version": "1.0.10"
     },
     "prr": {
-      "version": "0.0.0"
+      "version": "1.0.1"
     },
     "ps-tree": {
       "version": "0.0.3"
     },
     "pseudomap": {
       "version": "1.0.2"
+    },
+    "pump": {
+      "version": "1.0.1"
     },
     "punycode": {
       "version": "1.4.1"
@@ -2608,12 +2719,7 @@
       "version": "2.1.7"
     },
     "rc": {
-      "version": "1.1.6",
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "1.0.4"
-        }
-      }
+      "version": "1.1.6"
     },
     "react": {
       "version": "15.3.0"
@@ -2702,7 +2808,15 @@
       }
     },
     "read-all-stream": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.1.5"
+        }
+      }
     },
     "read-file-stdin": {
       "version": "0.2.1"
@@ -2714,13 +2828,19 @@
       "version": "1.0.1"
     },
     "readable-stream": {
-      "version": "2.0.6"
+      "version": "1.1.14"
     },
     "readdirp": {
       "version": "2.1.0",
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
         "minimatch": {
           "version": "3.0.3"
+        },
+        "readable-stream": {
+          "version": "2.1.5"
         }
       }
     },
@@ -2791,8 +2911,17 @@
     "request": {
       "version": "2.75.0",
       "dependencies": {
+        "bl": {
+          "version": "1.1.2"
+        },
+        "isarray": {
+          "version": "1.0.0"
+        },
         "qs": {
           "version": "6.2.1"
+        },
+        "readable-stream": {
+          "version": "2.0.6"
         }
       }
     },
@@ -2874,7 +3003,12 @@
       "version": "1.0.0"
     },
     "rtlcss": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1"
+        }
+      }
     },
     "run-async": {
       "version": "0.1.0"
@@ -2995,6 +3129,12 @@
     "signal-exit": {
       "version": "3.0.1"
     },
+    "simple-get": {
+      "version": "1.4.3"
+    },
+    "simple-mime": {
+      "version": "0.1.0"
+    },
     "sinon": {
       "version": "1.17.6"
     },
@@ -3022,9 +3162,6 @@
         "component-emitter": {
           "version": "1.1.2"
         },
-        "isarray": {
-          "version": "0.0.1"
-        },
         "json3": {
           "version": "3.2.6"
         },
@@ -3046,9 +3183,6 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.1.2"
-        },
-        "isarray": {
-          "version": "0.0.1"
         }
       }
     },
@@ -3111,15 +3245,7 @@
       "version": "1.3.16"
     },
     "stream-browserify": {
-      "version": "1.0.0",
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.1.14"
-        }
-      }
+      "version": "1.0.0"
     },
     "stream-cache": {
       "version": "0.0.2"
@@ -3155,7 +3281,7 @@
       "version": "1.0.1"
     },
     "strip-json-comments": {
-      "version": "2.0.1"
+      "version": "1.0.4"
     },
     "striptags": {
       "version": "2.1.1"
@@ -3189,6 +3315,12 @@
         "htmlparser2": {
           "version": "3.9.1"
         },
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.1.5"
+        },
         "resolve-from": {
           "version": "2.0.0"
         },
@@ -3209,8 +3341,14 @@
         "form-data": {
           "version": "1.0.0-rc4"
         },
+        "isarray": {
+          "version": "1.0.0"
+        },
         "qs": {
           "version": "6.2.1"
+        },
+        "readable-stream": {
+          "version": "2.1.5"
         }
       }
     },
@@ -3252,6 +3390,20 @@
     "tar": {
       "version": "2.2.1"
     },
+    "tar-fs": {
+      "version": "1.13.2"
+    },
+    "tar-stream": {
+      "version": "1.5.2",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.1.5"
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0"
     },
@@ -3261,9 +3413,6 @@
     "through2": {
       "version": "0.6.5",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
         "readable-stream": {
           "version": "1.0.34"
         }
@@ -3398,6 +3547,9 @@
     "unquoted-property-validator": {
       "version": "1.0.0"
     },
+    "unzip-response": {
+      "version": "1.0.1"
+    },
     "update-notifier": {
       "version": "0.3.2"
     },
@@ -3417,6 +3569,9 @@
           "version": "1.3.2"
         }
       }
+    },
+    "url-template": {
+      "version": "2.0.8"
     },
     "user-home": {
       "version": "1.1.1"
@@ -3494,45 +3649,50 @@
       "version": "0.2.0",
       "dependencies": {
         "accepts": {
-          "version": "1.1.4"
+          "version": "1.3.3"
+        },
+        "after": {
+          "version": "0.8.1"
+        },
+        "base64-arraybuffer": {
+          "version": "0.1.5"
         },
         "commander": {
           "version": "2.9.0"
         },
         "engine.io": {
-          "version": "1.6.11"
+          "version": "1.7.0"
         },
         "engine.io-client": {
-          "version": "1.6.11",
+          "version": "1.7.0",
           "dependencies": {
             "component-emitter": {
               "version": "1.1.2"
-            },
-            "ws": {
-              "version": "1.0.1"
+            }
+          }
+        },
+        "engine.io-parser": {
+          "version": "1.3.0",
+          "dependencies": {
+            "has-binary": {
+              "version": "0.1.6"
             }
           }
         },
         "filesize": {
           "version": "3.3.0"
         },
-        "mime-db": {
-          "version": "1.12.0"
-        },
-        "mime-types": {
-          "version": "2.0.14"
-        },
         "negotiator": {
-          "version": "0.4.9"
+          "version": "0.6.1"
         },
         "socket.io": {
-          "version": "1.4.8"
+          "version": "1.5.0"
         },
         "socket.io-client": {
-          "version": "1.4.8"
+          "version": "1.5.0"
         },
         "ws": {
-          "version": "1.1.0"
+          "version": "1.1.1"
         }
       }
     },
@@ -3547,6 +3707,14 @@
     "webpack-dev-server": {
       "version": "1.11.0"
     },
+    "webpack-sources": {
+      "version": "0.1.2",
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6"
+        }
+      }
+    },
     "whatwg-fetch": {
       "version": "1.0.0"
     },
@@ -3558,9 +3726,6 @@
     },
     "which-module": {
       "version": "1.0.0"
-    },
-    "wide-align": {
-      "version": "1.1.0"
     },
     "window-size": {
       "version": "0.1.0"
@@ -3631,6 +3796,9 @@
     },
     "ws": {
       "version": "1.0.1"
+    },
+    "wtf-8": {
+      "version": "1.0.0"
     },
     "xdg-basedir": {
       "version": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "express": "4.13.3",
     "filesize": "3.2.1",
     "flux": "2.1.1",
+    "hard-source-webpack-plugin": "0.0.42",
     "he": "0.5.0",
     "html-loader": "0.4.0",
     "i18n-calypso": "1.6.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,8 @@ var webpack = require( 'webpack' ),
  */
 var config = require( './server/config' ),
 	sections = require( './client/sections' ),
-	ChunkFileNamePlugin = require( './server/bundler/plugin' );
+	ChunkFileNamePlugin = require( './server/bundler/plugin' ),
+	HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
 /**
  * Internal variables
@@ -148,6 +149,11 @@ if ( CALYPSO_ENV === 'production' ) {
 		/^debug$/,
 		path.join( __dirname, 'client', 'lib', 'debug-noop' )
 	) );
+}
+
+if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
+	webpackConfig.recordsPath = path.join( __dirname, '.webpack-cache', 'client-records.json' ),
+	webpackConfig.plugins.unshift( new HardSourceWebpackPlugin( { cacheDirectory: path.join( __dirname, '.webpack-cache', 'client' ) } ) );
 }
 
 webpackConfig.module.loaders = [ jsLoader ].concat( webpackConfig.module.loaders );

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -5,12 +5,14 @@
  */
 var webpack = require( 'webpack' ),
 	path = require( 'path' ),
+	HardSourceWebpackPlugin = require('hard-source-webpack-plugin'),
 	fs = require( 'fs' );
 
 /**
  * Internal dependencies
  */
 var	PragmaCheckPlugin = require( 'server/pragma-checker' );
+var config = require( 'config' );
 
 /**
  * This lists modules that must use commonJS `require()`s
@@ -47,7 +49,7 @@ function getExternals() {
 	return externals;
 }
 
-module.exports = {
+var webpackConfig = {
 	devtool: 'source-map',
 	entry: 'index.js',
 	target: 'node',
@@ -103,5 +105,12 @@ module.exports = {
 };
 
 if ( process.env.CALYPSO_ENV === 'development' || process.env.CALYPSO_ENV === 'test' ) {
-	module.exports.plugins.push( new PragmaCheckPlugin );
+	webpackConfig.plugins.push( new PragmaCheckPlugin );
 }
+
+if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
+	webpackConfig.recordsPath = path.join( __dirname, '.webpack-cache', 'server-records.json' ),
+	webpackConfig.plugins.unshift( new HardSourceWebpackPlugin( { cacheDirectory: path.join( __dirname, '.webpack-cache', 'server' ) } ) );
+}
+
+module.exports = webpackConfig;


### PR DESCRIPTION
Use [HardSourceWebpackPlugin](https://www.npmjs.com/package/hard-source-webpack-plugin) to cache built modules to disk. This cuts subsequent build time from ~60s to ~6. 

**Before**
```
Hash: e64996f437b15819a3a7
Version: webpack 1.13.1
Time: 16340ms
                    Asset     Size  Chunks             Chunk Names
    bundle-development.js  2.28 MB       0  [emitted]  main
bundle-development.js.map  2.94 MB       0  [emitted]  main
    + 992 hidden modules
wp-calypso booted in 947ms - http://calypso.localhost:3000

Getting bundles ready, hold on...
Hash: f5013d1657a7dd4dbe5e
Time: 41971ms
```

**After** (Subsequent builds)
```
Hash: 312d2ad1e6c28a59d8f3
Version: webpack 1.13.1
Time: 2243ms
                    Asset     Size  Chunks             Chunk Names
    bundle-development.js  2.19 MB       0  [emitted]  main
bundle-development.js.map  2.82 MB       0  [emitted]  main
    + 961 hidden modules
wp-calypso booted in 1015ms - http://calypso.localhost:3000

Getting bundles ready, hold on...
Hash: fcb94d6985acde5c9a4c
Time: 5276ms
```

**To Do**
- [x] update plugin version
- [x] further testing?
- [ ] ~~documentation?~~ Wait until turned on by default

/cc @seear @ockham 

Test live: https://calypso.live/?branch=try/webpack-caching