### PR TITLE
Me: ES6ify the Profile Gravatar component

### DIFF
--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -22,7 +22,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const profileURL = '//gravatar.com/' + this.props.user.username;
+		const profileURL = `//gravatar.com/${ this.props.user.username }`;
 
 		return (
 			<div className="profile-gravatar">

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -1,27 +1,28 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:me:sidebar-gravatar' );
+import React from 'react';
+import _debug from 'debug';
 
 /**
  * Internal dependencies
  */
-var Gravatar = require( 'components/gravatar' ),
-	eventRecorder = require( 'me/event-recorder' );
+import Gravatar from 'components/gravatar';
+import eventRecorder from 'me/event-recorder';
 
-module.exports = React.createClass( {
+const debug = _debug( 'calypso:me:sidebar-gravatar' );
 
+export default React.createClass( {
 	displayName: 'ProfileGravatar',
 
 	mixins: [ eventRecorder ],
 
-	componentDidMount: function() {
+	componentDidMount() {
 		debug( 'The ProfileGravatar component is mounted.' );
 	},
 
-	render: function() {
-		var profileURL = '//gravatar.com/' + this.props.user.username;
+	render() {
+		const profileURL = '//gravatar.com/' + this.props.user.username;
 
 		return (
 			<div className="profile-gravatar">

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import _debug from 'debug';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -10,7 +10,7 @@ import _debug from 'debug';
 import Gravatar from 'components/gravatar';
 import eventRecorder from 'me/event-recorder';
 
-const debug = _debug( 'calypso:me:sidebar-gravatar' );
+const debug = debugFactory( 'calypso:me:sidebar-gravatar' );
 
 export default React.createClass( {
 	displayName: 'ProfileGravatar',


### PR DESCRIPTION
This PR ES6ifies the Profile Gravatar component:
* Replacing `require` with `import`
* Replacing `module.exports` with `export default`
* Replacing `var` with `let` or `const`
* Using method shorthand
* Using template literals

This component is displayed in the top of the left sidebar in `/me`.

/cc @roccotripaldi @ryelle 

Test live: https://calypso.live/?branch=update/me-profile-gravatar-es6ify