### PR TITLE
Guided Tours: Use Lodash map for seen tours history

### DIFF
--- a/client/state/ui/guided-tours/selectors.js
+++ b/client/state/ui/guided-tours/selectors.js
@@ -53,10 +53,7 @@ const getToursFromFeaturesReached = createSelector(
  * recently and in the past.
  */
 const getToursSeen = createSelector(
-	state => uniq(
-		getToursHistory( state )
-			.map( ( { tourName } ) => tourName )
-	),
+	state => uniq( map( getToursHistory( state ), 'tourName' ) ),
 	getToursHistory
 );
 


### PR DESCRIPTION
Possibly related: #7566

This pull request seeks to resolve an error which is being logged for Safari browsers across multiple screens, in which an attempt is made to call `Array#map` on a null value. It's not yet clear to me why the return value of `getToursHistory` would ever be null, as the [logic of the `getPreference` selector](https://github.com/Automattic/wp-calypso/blob/90bcc2cbbe75f2ff3a1319764603bf12775d4490/client/state/preferences/selectors.js#L15-L30) is such that it should be using the [defined default value](https://github.com/Automattic/wp-calypso/blob/90bcc2cbbe75f2ff3a1319764603bf12775d4490/client/state/preferences/constants.js#L10) unless set in local or remote preferences. There is only [one instance of the `guided-tours-history` preference value being set](https://github.com/Automattic/wp-calypso/blob/90bcc2cbbe75f2ff3a1319764603bf12775d4490/client/state/ui/guided-tours/actions.js#L63-L70), which would never be set to anything aside from an array. That it only appears to affect Safari browser is additionally confusing, but could potentially be related to its use of WebSQLStorage as the localForage driver for state persistence.

__Implementation notes:__

Lodash `map` will gracefully handle `null` and `undefined` input values, returning an empty array.

__Testing instructions:__

Verify that Mocha tests pass.

```
npm run test-client client/state/ui/guided-tours
```

I did not find any tests specifically for this selector, but it may already be covered by tests for the exported `findEligibleTour` selector.

cc @ehg @lsinger 

Ref: p1472048716000420-slack-calypso-editor

Test live: https://calypso.live/?branch=fix/guided-tours-map-null