### PR TITLE
Layout: replace top-level preview focus with `UrlPreview`

### DIFF
--- a/client/blocks/url-preview/README.md
+++ b/client/blocks/url-preview/README.md
@@ -1,0 +1,17 @@
+# urlPreview
+
+A Higher Order Component for an instance of `WebPreview` that can show a preview with a particular URL.
+
+```javascript
+const UrlPreview = urlPreview( WebPreview );
+<UrlPreview showPreview={ true } />
+```
+
+You shouldn't need to use this manually, as it is included in the layout for all my-sites routes. It can be activated using a Redux action like this:
+
+```javascript
+setLayoutFocus( 'preview' );
+```
+
+You can change the URL which is loaded in the preview frame by using the Redux action `setPreviewUrl()`. Otherwise, the front page of the current site is shown.
+

--- a/client/blocks/url-preview/index.jsx
+++ b/client/blocks/url-preview/index.jsx
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { clearPreviewUrl } from 'state/ui/preview/actions';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getPreviewUrl } from 'state/ui/preview/selectors';
+import { getSiteOption } from 'state/sites/selectors';
+import addQueryArgs from 'lib/route/add-query-args';
+import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+
+const debug = debugFactory( 'calypso:design-preview' );
+
+export default function urlPreview( WebPreview ) {
+	class UrlPreview extends React.Component {
+		constructor( props ) {
+			super( props );
+			this.state = { previewCount: 0 };
+			this.previewCounter = 0;
+			this.onClosePreview = this.onClosePreview.bind( this );
+			this.getPreviewUrl = this.getPreviewUrl.bind( this );
+			this.getBasePreviewUrl = this.getBasePreviewUrl.bind( this );
+		}
+
+		componentWillReceiveProps( nextProps ) {
+			if ( this.props.selectedSiteId && this.props.selectedSiteId !== nextProps.selectedSiteId ) {
+				this.previewCounter = 0;
+			}
+
+			if ( ! this.props.showPreview && nextProps.showPreview ) {
+				debug( 'forcing refresh' );
+				this.previewCounter > 0 && this.setState( { previewCount: this.previewCounter } );
+				this.previewCounter += 1;
+			}
+		}
+
+		onClosePreview() {
+			this.props.clearPreviewUrl( this.props.selectedSiteId );
+			this.props.setLayoutFocus( 'sidebar' );
+		}
+
+		getPreviewUrl() {
+			if ( ! this.props.selectedSiteUrl && ! this.props.previewUrl ) {
+				debug( 'no preview url and no site url were found for this site' );
+				return null;
+			}
+			const previewUrl = addQueryArgs( {
+				iframe: true,
+				theme_preview: true,
+				'frame-nonce': this.props.selectedSiteNonce,
+				cachebust: this.state.previewCount,
+			}, this.getBasePreviewUrl() );
+			debug( 'using this preview url', previewUrl );
+			return previewUrl;
+		}
+
+		getBasePreviewUrl() {
+			return this.props.previewUrl || this.props.selectedSiteUrl;
+		}
+
+		render() {
+			if ( ! this.props.selectedSite || ! this.props.selectedSite.is_previewable ) {
+				debug( 'a preview is not available for this site' );
+				return null;
+			}
+
+			return (
+				<WebPreview
+					className={ this.props.className }
+					previewUrl={ this.getPreviewUrl() }
+					externalUrl={ this.getBasePreviewUrl() }
+					showExternal={ true }
+					showClose={ true }
+					showPreview={ this.props.showPreview }
+					onClose={ this.onClosePreview }
+				/>
+			);
+		}
+	}
+
+	UrlPreview.propTypes = {
+		className: PropTypes.string,
+		showPreview: PropTypes.bool,
+		previewUrl: PropTypes.string,
+		selectedSite: PropTypes.object,
+		selectedSiteId: PropTypes.number,
+		selectedSiteNonce: PropTypes.string,
+		selectedSiteUrl: PropTypes.string,
+		setLayoutFocus: PropTypes.func.isRequired,
+		clearPreviewUrl: PropTypes.func.isRequired,
+	};
+
+	function mapStateToProps( state ) {
+		const selectedSiteId = getSelectedSiteId( state );
+		return {
+			selectedSite: getSelectedSite( state ),
+			selectedSiteId,
+			selectedSiteUrl: getSiteOption( state, selectedSiteId, 'unmapped_url' ),
+			selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ),
+			previewUrl: getPreviewUrl( state ),
+		};
+	}
+
+	return connect(
+		mapStateToProps,
+		{ clearPreviewUrl, setLayoutFocus }
+	)( UrlPreview );
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -38,9 +38,12 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 
 import { isOffline } from 'state/application/selectors';
 import { hasSidebar } from 'state/ui/selectors';
-import DesignPreview from 'my-sites/design-preview';
+import urlPreview from 'blocks/url-preview';
+import WebPreview from 'components/web-preview';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import DocumentHead from 'components/data/document-head';
+
+const UrlPreview = urlPreview( WebPreview );
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -172,11 +175,7 @@ Layout = React.createClass( {
 	renderPreview() {
 		if ( config.isEnabled( 'preview-layout' ) && this.props.section.group === 'sites' ) {
 			return (
-				<DesignPreview
-					className="layout__preview"
-					showPreview={ this.props.currentLayoutFocus === 'preview' }
-					defaultViewportDevice="computer"
-				/>
+				<UrlPreview showPreview={ this.props.currentLayoutFocus === 'preview' } />
 			);
 		}
 	},

--- a/client/my-sites/design-preview/README.md
+++ b/client/my-sites/design-preview/README.md
@@ -1,12 +1,23 @@
-# DesignPreview
+# designPreview
 
-A wrapper for the always-available instance of `WebPreview` that's activated when `layoutFocus` is set to `preview`.
+A Higher Order Component for an instance of `WebPreview` that can be customized.
 
-The `DesignPreview` component can render raw markup to a preview and then apply customizations to that preview. This PR adds a data layer for the preview markup and the customizations.
+```javascript
+const DesignPreview = designPreview( WebPreview );
+<DesignPreview showPreview={ true } />
+```
 
-The raw markup is fetched from the REST API and saved as `previewMarkup` in the Redux state tree (one for each site). When it is rendered, the method `updatePreviewWithChanges()` in `lib/design-preview` will be called with the arguments:
+The `DesignPreview` component can render raw markup to a preview and then apply customizations to that preview. The raw markup is fetched from the REST API and saved as `previewMarkup` in the Redux state tree (one for each site). When it is rendered, the method `updatePreviewWithChanges()` in `lib/design-preview` will be called with the arguments:
 
 1. The document object of the iframe.
 2. The current value of the `customizations` object from the Redux state tree for this site.
 
 The `customizations` object and the `previewMarkup` used by the preview are stored in the Redux state tree under the `preview` key for a given site. The state also keeps track of the "saved" status of the customizations and a history of all customization changes (enabling an "undo" feature).
+
+# Global Preview
+
+The designPreview-wrapped WebPreview is intended to be a singleton; only one should ever be rendered.
+
+Activating the global preview is done using the Redux action `setLayoutFocus( 'preview' )`.
+
+You can change the URL which is loaded in the preview frame by using the Redux action `setPreviewUrl()`. Otherwise, the front page of the current site is shown.

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -1,17 +1,13 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import noop from 'lodash/noop';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-import config from 'config';
-import WebPreview from 'components/web-preview';
-import { clearPreviewUrl } from 'state/ui/preview/actions';
 import { fetchPreviewMarkup, undoCustomization, clearCustomizations } from 'state/preview/actions';
 import accept from 'lib/accept';
 import { updatePreviewWithChanges } from 'lib/design-preview';
@@ -19,221 +15,161 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getPreviewUrl } from 'state/ui/preview/selectors';
 import { getSiteOption } from 'state/sites/selectors';
 import { getPreviewMarkup, getPreviewCustomizations, isPreviewUnsaved } from 'state/preview/selectors';
-import addQueryArgs from 'lib/route/add-query-args';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 
 const debug = debugFactory( 'calypso:design-preview' );
 
-const DesignPreview = React.createClass( {
-	previewCounter: 0,
+export default function designPreview( WebPreview ) {
+	class DesignPreview extends React.Component {
+		constructor( props ) {
+			super( props );
+			this.getCustomizations = this.getCustomizations.bind( this );
+			this.haveCustomizationsBeenRemoved = this.haveCustomizationsBeenRemoved.bind( this );
+			this.loadPreview = this.loadPreview.bind( this );
+			this.undoCustomization = this.undoCustomization.bind( this );
+			this.onLoad = this.onLoad.bind( this );
+			this.onClosePreview = this.onClosePreview.bind( this );
+			this.cleanAndClosePreview = this.cleanAndClosePreview.bind( this );
+			this.onPreviewClick = this.onPreviewClick.bind( this );
+		}
 
-	propTypes: {
-		// Any additional classNames to set on this wrapper
-		className: React.PropTypes.string,
-		// True to show the preview; same as WebPreview.
-		showPreview: React.PropTypes.bool,
-		// The viewport device to show initially; same as WebPreview but defaults to 'tablet'.
-		defaultViewportDevice: React.PropTypes.string,
-		// Show close button; same as WebPreview.
-		showClose: React.PropTypes.bool,
-		// Elements to render on the right side of the toolbar; same as WebPreview.
-		children: React.PropTypes.node,
-		// A function to run when the preview has loaded. Will be passed a ref to the iframe document object.
-		onLoad: React.PropTypes.func,
-		// These are all provided by the state
-		selectedSiteUrl: React.PropTypes.string,
-		selectedSiteNonce: React.PropTypes.string,
-		selectedSite: React.PropTypes.object,
-		selectedSiteId: React.PropTypes.number,
-		previewUrl: React.PropTypes.string,
-		previewMarkup: React.PropTypes.string,
-		customizations: React.PropTypes.object,
-		isUnsaved: React.PropTypes.bool,
-		fetchPreviewMarkup: React.PropTypes.func.isRequired,
-		undoCustomization: React.PropTypes.func.isRequired,
-		clearCustomizations: React.PropTypes.func.isRequired,
-		clearPreviewUrl: React.PropTypes.func.isRequired,
-	},
+		componentDidMount() {
+			this.loadPreview();
+		}
 
-	getInitialState() {
-		return {
-			previewCount: 0
-		};
-	},
-
-	getDefaultProps() {
-		return {
-			showPreview: false,
-			defaultViewportDevice: 'tablet',
-			showClose: true,
-			customizations: {},
-			isUnsaved: false,
-			onLoad: noop,
-			previewUrl: null,
-		};
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		if ( ! config.isEnabled( 'preview-endpoint' ) ) {
-			if ( this.props.selectedSiteId && this.props.selectedSiteId !== nextProps.selectedSiteId ) {
-				this.previewCounter = 0;
+		componentDidUpdate( prevProps ) {
+			// If there is no markup or the site has changed, fetch it
+			if ( ! this.props.previewMarkup || this.props.selectedSiteId !== prevProps.selectedSiteId ) {
+				this.loadPreview();
 			}
-
-			if ( ! this.props.showPreview && nextProps.showPreview ) {
-				debug( 'forcing refresh' );
-				this.previewCounter > 0 && this.setState( { previewCount: this.previewCounter } );
-				this.previewCounter += 1;
+			// Refresh the preview when it is being shown (since this component is
+			// always present but not always visible, this is similar to loading the
+			// preview when mounting).
+			if ( this.props.showPreview && ! prevProps.showPreview ) {
+				this.loadPreview();
+			}
+			// If the customizations have been removed, restore the original markup
+			if ( this.haveCustomizationsBeenRemoved( prevProps ) ) {
+				// Force the initial markup to be restored because the DOM may have been
+				// changed, and simply not applying customizations will not restore it.
+				debug( 'restoring original markup' );
+				this.loadPreview();
+			}
+			// Apply customizations
+			if ( this.getCustomizations() && this.previewDocument ) {
+				debug( 'updating preview with customizations', this.getCustomizations() );
+				updatePreviewWithChanges( this.previewDocument, this.getCustomizations() );
 			}
 		}
-	},
 
-	componentDidMount() {
-		this.loadPreview();
-	},
-
-	componentDidUpdate( prevProps ) {
-		if ( ! config.isEnabled( 'preview-endpoint' ) ) {
-			return;
+		getCustomizations() {
+			return this.props.customizations || {};
 		}
 
-		// If there is no markup or the site has changed, fetch it
-		if ( ! this.props.previewMarkup || this.props.selectedSiteId !== prevProps.selectedSiteId ) {
-			this.loadPreview();
-		}
-		// Refresh the preview when it is being shown (since this component is
-		// always present but not always visible, this is similar to loading the
-		// preview when mounting).
-		if ( this.props.showPreview && ! prevProps.showPreview ) {
-			this.loadPreview();
-		}
-		// If the customizations have been removed, restore the original markup
-		if ( this.haveCustomizationsBeenRemoved( prevProps ) ) {
-			// Force the initial markup to be restored because the DOM may have been
-			// changed, and simply not applying customizations will not restore it.
-			debug( 'restoring original markup' );
-			this.loadPreview();
-		}
-		// Apply customizations
-		if ( this.props.customizations && this.previewDocument ) {
-			debug( 'updating preview with customizations', this.props.customizations );
-			updatePreviewWithChanges( this.previewDocument, this.props.customizations );
-		}
-	},
-
-	haveCustomizationsBeenRemoved( prevProps ) {
-		return ( this.props.previewMarkup &&
-			this.props.customizations &&
-			this.props.previewMarkup === prevProps.previewMarkup &&
-			prevProps.customizations &&
-			Object.keys( this.props.customizations ).length === 0 &&
-			Object.keys( prevProps.customizations ).length > 0
-		);
-	},
-
-	loadPreview() {
-		if ( ! config.isEnabled( 'preview-endpoint' ) || ! this.props.selectedSite ) {
-			return;
-		}
-		debug( 'loading preview with customizations', this.props.customizations );
-		this.props.fetchPreviewMarkup( this.props.selectedSiteId, this.props.previewUrl, this.props.customizations );
-	},
-
-	undoCustomization() {
-		this.props.undoCustomization( this.props.selectedSiteId );
-	},
-
-	onLoad( previewDocument ) {
-		this.previewDocument = previewDocument;
-		previewDocument.body.onclick = this.onPreviewClick;
-		this.props.onLoad( previewDocument );
-	},
-
-	onClosePreview() {
-		if ( this.props.customizations && this.props.isUnsaved ) {
-			return accept( this.translate( 'You have unsaved changes. Are you sure you want to close the preview?' ), accepted => {
-				if ( accepted ) {
-					this.props.clearPreviewUrl( this.props.selectedSiteId );
-					this.props.clearCustomizations( this.props.selectedSiteId );
-					this.props.setLayoutFocus( 'sidebar' );
-				}
-			} );
-		}
-		this.props.clearPreviewUrl( this.props.selectedSiteId );
-		this.props.clearCustomizations( this.props.selectedSiteId );
-		this.props.setLayoutFocus( 'sidebar' );
-	},
-
-	onPreviewClick( event ) {
-		debug( 'click detected for element', event.target );
-		if ( ! event.target.href ) {
-			return;
-		}
-		event.preventDefault();
-	},
-
-	getPreviewUrl() {
-		if ( ! this.props.selectedSiteUrl && ! this.props.previewUrl ) {
-			debug( 'no preview url and no site url were found for this site' );
-			return null;
-		}
-		const previewUrl = addQueryArgs( {
-			iframe: true,
-			theme_preview: true,
-			'frame-nonce': this.props.selectedSiteNonce,
-			cachebust: this.state.previewCount,
-		}, this.getBasePreviewUrl() );
-		debug( 'using this preview url', previewUrl );
-		return previewUrl;
-	},
-
-	getBasePreviewUrl() {
-		return this.props.previewUrl || this.props.selectedSiteUrl;
-	},
-
-	render() {
-		const useEndpoint = config.isEnabled( 'preview-endpoint' );
-
-		if ( ! this.props.selectedSite || ! this.props.selectedSite.is_previewable ) {
-			debug( 'a preview is not available for this site' );
-			return null;
+		haveCustomizationsBeenRemoved( prevProps ) {
+			return ( this.props.previewMarkup &&
+				this.getCustomizations() &&
+				this.props.previewMarkup === prevProps.previewMarkup &&
+				prevProps.customizations &&
+				Object.keys( this.getCustomizations() ).length === 0 &&
+				Object.keys( prevProps.customizations ).length > 0
+			);
 		}
 
-		return (
-			<WebPreview
-				className={ this.props.className }
-				previewUrl={ useEndpoint ? null : this.getPreviewUrl() }
-				externalUrl={ this.getBasePreviewUrl() }
-				showExternal={ true }
-				showClose={ this.props.showClose }
-				showPreview={ this.props.showPreview }
-				defaultViewportDevice={ this.props.defaultViewportDevice }
-				previewMarkup={ useEndpoint ? this.props.previewMarkup : null }
-				onClose={ this.onClosePreview }
-				onLoad={ useEndpoint ? this.onLoad : noop }
-			>
-				{ this.props.children }
-			</WebPreview>
-		);
+		loadPreview() {
+			if ( ! this.props.selectedSite ) {
+				return;
+			}
+			debug( 'loading preview with customizations', this.getCustomizations() );
+			this.props.fetchPreviewMarkup( this.props.selectedSiteId, this.props.previewUrl, this.getCustomizations() );
+		}
+
+		undoCustomization() {
+			this.props.undoCustomization( this.props.selectedSiteId );
+		}
+
+		onLoad( previewDocument ) {
+			this.previewDocument = previewDocument;
+			previewDocument.body.onclick = this.onPreviewClick;
+		}
+
+		onClosePreview() {
+			if ( this.getCustomizations() && this.props.isUnsaved ) {
+				return accept( this.translate( 'You have unsaved changes. Are you sure you want to close the preview?' ), accepted => {
+					if ( accepted ) {
+						this.cleanAndClosePreview();
+					}
+				} );
+			}
+			this.cleanAndClosePreview();
+		}
+
+		cleanAndClosePreview() {
+			this.props.clearCustomizations( this.props.selectedSiteId );
+			this.props.setLayoutFocus( 'sidebar' );
+		}
+
+		onPreviewClick( event ) {
+			debug( 'click detected for element', event.target );
+			if ( ! event.target.href ) {
+				return;
+			}
+			event.preventDefault();
+		}
+
+		render() {
+			if ( ! this.props.selectedSite || ! this.props.selectedSite.is_previewable ) {
+				debug( 'a preview is not available for this site' );
+				return null;
+			}
+
+			return (
+				<WebPreview
+					className={ this.props.className }
+					showPreview={ this.props.showPreview }
+					showExternal={ false }
+					showClose={ false }
+					hasSidebar={ true }
+					previewMarkup={ this.props.previewMarkup }
+					onClose={ this.onClosePreview }
+					onLoad={ this.onLoad }
+					/>
+			);
+		}
 	}
-} );
 
-function mapStateToProps( state ) {
-	const selectedSite = getSelectedSite( state );
-	const selectedSiteId = getSelectedSiteId( state );
-
-	return {
-		selectedSite,
-		selectedSiteId,
-		selectedSiteUrl: getSiteOption( state, selectedSiteId, 'unmapped_url' ),
-		selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ),
-		previewUrl: getPreviewUrl( state ),
-		previewMarkup: getPreviewMarkup( state, selectedSiteId ),
-		customizations: getPreviewCustomizations( state, selectedSiteId ),
-		isUnsaved: isPreviewUnsaved( state, selectedSiteId ),
+	DesignPreview.propTypes = {
+		className: PropTypes.string,
+		showPreview: PropTypes.bool,
+		customizations: PropTypes.object,
+		isUnsaved: PropTypes.bool,
+		previewMarkup: PropTypes.string,
+		previewUrl: PropTypes.string,
+		selectedSite: PropTypes.object,
+		selectedSiteId: PropTypes.number,
+		undoCustomization: PropTypes.func.isRequired,
+		fetchPreviewMarkup: PropTypes.func.isRequired,
+		clearCustomizations: PropTypes.func.isRequired,
+		setLayoutFocus: PropTypes.func.isRequired,
 	};
-}
 
-export default connect(
-	mapStateToProps,
-	{ fetchPreviewMarkup, undoCustomization, clearCustomizations, clearPreviewUrl, setLayoutFocus }
-)( DesignPreview );
+	function mapStateToProps( state ) {
+		const selectedSite = getSelectedSite( state );
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			selectedSite,
+			selectedSiteId,
+			selectedSiteUrl: getSiteOption( state, selectedSiteId, 'unmapped_url' ),
+			previewUrl: getPreviewUrl( state ),
+			previewMarkup: getPreviewMarkup( state, selectedSiteId ),
+			customizations: getPreviewCustomizations( state, selectedSiteId ),
+			isUnsaved: isPreviewUnsaved( state, selectedSiteId ),
+		};
+	}
+
+	return connect(
+		mapStateToProps,
+		{ fetchPreviewMarkup, undoCustomization, clearCustomizations, setLayoutFocus }
+	)( DesignPreview );
+}

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -66,7 +66,6 @@
 		"post-editor/author-selector": true,
 		"press-this": false,
 		"preview-layout": true,
-		"preview-endpoint": false,
 		"reader": true,
 		"reader/full-errors": false,
 		"resume-editing": true,

--- a/config/development.json
+++ b/config/development.json
@@ -97,7 +97,6 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"preview-layout": true,
-		"preview-endpoint": false,
 		"network-connection": true,
 		"notifications2beta": true,
 		"oauth": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -75,7 +75,6 @@
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,
-		"preview-endpoint": false,
 		"reader": true,
 		"reader/related-posts": true,
 		"reader/search": true,

--- a/config/production.json
+++ b/config/production.json
@@ -71,7 +71,6 @@
 		"post-editor/author-selector": true,
 		"press-this": true,
 		"preview-layout": true,
-		"preview-endpoint": false,
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -76,7 +76,6 @@
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,
-		"preview-endpoint": false,
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -85,7 +85,6 @@
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,
-		"preview-endpoint": false,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/recommendations/posts": true,


### PR DESCRIPTION
This PR extracts the two uses of `DesignPreview` into two separate Higher Order
Components. The customizable, markup-rendered preview is still `DesignPreview`
and the simpler, url-based preview is now `UrlPreview`.

Extracted from #7477 

This PR effectively removes `DesignPreview` from all active code. It will be re-added in a later PR when it a component uses it.

# Testing

Two views are affected by this change: 

1. Test the "regular" preview functionality by visiting any page under my-sites like `/posts/my/[your site here]` and clicking the icon next to your site title:

<img width="250" alt="screen_shot_2016-08-16_at_4_32_06_pm" src="https://cloud.githubusercontent.com/assets/2036909/17714754/1893c2d0-63cf-11e6-81fe-107f521d6abf.png">

The preview should appear as normal.

<img width="940" alt="screen shot 2016-08-16 at 4 36 02 pm" src="https://cloud.githubusercontent.com/assets/2036909/17714847/8d9f2ea2-63cf-11e6-9141-49bd0d7c5166.png">

2. Visit a post type page like: `/types/post/drafts/[your site here]` and click the "..." menu next to a post. Click "Preview":

<img width="926" alt="screen_shot_2016-08-19_at_4_55_27_pm" src="https://cloud.githubusercontent.com/assets/2036909/17824084/e0f1b8f8-662d-11e6-8211-9e4c6db00287.png">

Make sure the preview of *that post* (not the front page of your site) appears:

<img width="936" alt="screen shot 2016-08-23 at 2 04 24 pm" src="https://cloud.githubusercontent.com/assets/2036909/17903736/8da6c2b4-693a-11e6-9bee-45428f7f7622.png">

Test live: https://calypso.live/?branch=update/design-preview-as-hoc