### PR TITLE
Reader: Fix Follow button alignment in full-post

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -107,7 +107,7 @@
 		}
 		.author-compact-profile__follow .follow-button {
 			position: fixed;
-			top: 15px;
+			top: 10px;
 			right: 180px;
 			z-index: z-index( '.masterbar', '.reader-profile' )
 		}


### PR DESCRIPTION
**Before:** (Follow button not aligned with the rest of the icons)
![screenshot 2016-08-24 10 26 12](https://cloud.githubusercontent.com/assets/4924246/17941553/b5ca2912-69e8-11e6-89ee-4eb47289a58c.png)

**After:**
![screenshot 2016-08-24 10 28 32](https://cloud.githubusercontent.com/assets/4924246/17941558/bd4277d0-69e8-11e6-88f1-11ec34679722.png)

I think this bug was introduced after fixing: https://github.com/Automattic/wp-calypso/pull/7624

Test live: https://calypso.live/?branch=reader/fix/follow-button-alignment-full-post