### PR TITLE
First View: utilizie _.filter to prevent null error

### DIFF
--- a/client/state/ui/first-view/actions.js
+++ b/client/state/ui/first-view/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import {
@@ -45,7 +50,7 @@ export function hideView( { enabled } ) {
 
 function persistToPreferences( { getState, view, disabled } ) {
 	return savePreference( 'firstViewHistory', [
-		...getPreference( getState(), 'firstViewHistory' ).filter( item => item.view !== view ), {
+		...filter( getPreference( getState(), 'firstViewHistory' ), item => item.view !== view ), {
 			view,
 			timestamp: Date.now(),
 			disabled,

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -57,7 +57,7 @@ export function isViewEnabled( state, config ) {
 		return false;
 	}
 
-	const firstViewHistory = getPreference( state, 'firstViewHistory' ).filter( entry => entry.view === config.name );
+	const firstViewHistory = filter( getPreference( state, 'firstViewHistory' ), entry => entry.view === config.name );
 	const latestFirstViewHistory = [ ...firstViewHistory ].pop();
 	const isViewDisabled = latestFirstViewHistory ? ( !! latestFirstViewHistory.disabled ) : false;
 


### PR DESCRIPTION
While testing out #7639 and looking into errors, I noticed the following exception being thrown on the stats insights page frequently:

> TypeError: null is not an object (evaluating '(0,_selectors.getPreference)(getState(),"firstViewHistory").filter')

Again this seems to be perhaps related to #7566 as `firstViewHistory` _should_ default to `[]`.  So this is another band-aid fix of sorts, but I do believe it is still prudent to use `_.filter` in cases like this since it handles the nulls gracefully.

__To Test__
To best test the functionality of the first view, you will need to create a new account and follow the steps in the original PR #6717

/cc @aduth 

Test live: https://calypso.live/?branch=fix/first-view/filter-error