### PR TITLE
Framework: Upgrade Lodash from 4.5.0 to 4.15.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -210,12 +210,7 @@
       "version": "6.8.0"
     },
     "babel-plugin-lodash": {
-      "version": "3.2.0",
-      "dependencies": {
-        "lodash": {
-          "version": "4.15.0"
-        }
-      }
+      "version": "3.2.0"
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0"
@@ -369,7 +364,7 @@
       "version": "6.13.0"
     },
     "babylon": {
-      "version": "6.9.0"
+      "version": "6.9.1"
     },
     "backo2": {
       "version": "1.0.2"
@@ -995,12 +990,7 @@
       "version": "1.0.0"
     },
     "enzyme": {
-      "version": "2.4.1",
-      "dependencies": {
-        "lodash": {
-          "version": "4.15.0"
-        }
-      }
+      "version": "2.4.1"
     },
     "errno": {
       "version": "0.1.4"
@@ -1051,7 +1041,7 @@
       "version": "1.8.1",
       "dependencies": {
         "esprima": {
-          "version": "2.7.2"
+          "version": "2.7.3"
         },
         "estraverse": {
           "version": "1.9.3"
@@ -1094,7 +1084,7 @@
       "version": "0.1.0",
       "dependencies": {
         "esprima": {
-          "version": "2.7.2"
+          "version": "2.7.3"
         },
         "rocambole": {
           "version": "0.5.1"
@@ -1105,7 +1095,7 @@
       "version": "1.3.1",
       "dependencies": {
         "esprima": {
-          "version": "2.7.2"
+          "version": "2.7.3"
         },
         "rocambole": {
           "version": "0.6.0"
@@ -1900,7 +1890,7 @@
       "version": "3.6.1",
       "dependencies": {
         "esprima": {
-          "version": "2.7.2"
+          "version": "2.7.3"
         }
       }
     },
@@ -2016,7 +2006,7 @@
       "version": "1.0.2"
     },
     "lodash": {
-      "version": "4.5.0"
+      "version": "4.15.0"
     },
     "lodash-deep": {
       "version": "1.5.3"
@@ -2214,7 +2204,7 @@
       "version": "2.4.0"
     },
     "natives": {
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "ncname": {
       "version": "1.0.0"
@@ -2684,12 +2674,7 @@
       "version": "15.3.0"
     },
     "react-element-to-jsx-string": {
-      "version": "3.2.0",
-      "dependencies": {
-        "lodash": {
-          "version": "4.15.0"
-        }
-      }
+      "version": "3.2.0"
     },
     "react-helmet": {
       "version": "2.2.0",
@@ -2907,7 +2892,7 @@
       "version": "0.7.0",
       "dependencies": {
         "esprima": {
-          "version": "2.7.2"
+          "version": "2.7.3"
         }
       }
     },
@@ -3710,9 +3695,6 @@
       "dependencies": {
         "babylon": {
           "version": "6.8.4"
-        },
-        "lodash": {
-          "version": "4.15.0"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "key-mirror": "1.0.1",
     "keymaster": "1.6.2",
     "localforage": "1.4.0",
-    "lodash": "4.5.0",
+    "lodash": "4.15.0",
     "lunr": "0.5.7",
     "marked": "0.3.5",
     "moment": "2.10.6",


### PR DESCRIPTION
This pull request seeks to update our Lodash dependency from 4.5.0 to 4.15.0. There have been a few intermittent cases (particularly Safari) of `getPreference` returning unexpected values (#7639, #7642). Based upon the [implementation of `getPreference`](https://github.com/Automattic/wp-calypso/blob/7cdd79c19803b947fb7d66f34c67b55f07c93f88/client/state/preferences/selectors.js#L15-L30), it's suspected that the following bugfix from the [4.8.0 changelog](https://github.com/lodash/lodash/wiki/Changelog#v480) could potentially be related (since `remoteValues` is `null` until a response is received from the REST API):

>Ensured `_.has` returns `false` for nested nullish object values

See also: lodash/lodash#2190

__Testing instructions:__

Lodash follows semver, so the version bump is not expected to bring with it any breaking changes. Verify that tests pass and that the application loads and navigates without any noticeable regressions.

```
npm test
```

__Follow-up tasks:__

- Check to see whether error rates are mitigated by this upgrade.

/cc @timmyc 

Test live: https://calypso.live/?branch=update/lodash-4-15