### PR TITLE
WordAds Instant: Copy Update

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -430,7 +430,7 @@ export const featuresList = {
 		getSlug: () => FEATURE_WORDADS_INSTANT,
 		getTitle: () => i18n.translate( 'Monetize Your Site' ),
 		getDescription: () => i18n.translate(
-			'Add your own advertising to your site through our WordAds program and earn money from impressions.'
+			'Add advertising to your site through our WordAds program and earn money from impressions.'
 		),
 		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ]
 	},


### PR DESCRIPTION
Removing 'your own' to avoid implication user can run arbitrary ad code.

Test live: https://calypso.live/?branch=update/wordads-instant-copy