### PR TITLE
Reader: Add padding to Search suggestions text

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -23,4 +23,8 @@
 	color: $gray;
 	margin-top: 0;
 	text-align:left;
+
+	@include breakpoint( "<660px" ) {
+		padding-left: 16px;
+	}
 }


### PR DESCRIPTION
Happens in `<660px`:

**Before:**
![screenshot 2016-08-24 11 58 12](https://cloud.githubusercontent.com/assets/4924246/17943934/5dafb666-69f2-11e6-9eb2-d5dcf8f90431.png)

**After:**
![screenshot 2016-08-24 11 58 17](https://cloud.githubusercontent.com/assets/4924246/17943938/61ad5b2e-69f2-11e6-9dd3-0915676ce6fa.png)


Test live: https://calypso.live/?branch=fix/reader/search-suggestions-text