### PR TITLE
Help: Show different buttons on help courses page for non business users

### DIFF
--- a/client/me/help/help-courses/course-list.jsx
+++ b/client/me/help/help-courses/course-list.jsx
@@ -12,12 +12,12 @@ import Card from 'components/card';
 
 class CourseList extends Component {
 	render() {
-		const { courses, showRecentCourseRecordings } = this.props;
+		const { courses, isBusinessPlanUser } = this.props;
 
 		return (
 			<div className="help-courses__course-list">
 				{ courses.map( ( course, key ) => {
-					return <Course { ...course } key={ key } showRecentCourseRecordings={ showRecentCourseRecordings }/>;
+					return <Course { ...course } key={ key } isBusinessPlanUser={ isBusinessPlanUser }/>;
 				} ) }
 			</div>
 		);

--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -15,6 +15,7 @@ export default localize( ( props ) => {
 	const {
 		date,
 		registrationUrl,
+		isBusinessPlanUser,
 		translate
 	} = props;
 
@@ -32,11 +33,16 @@ export default localize( ( props ) => {
 				}
 			</p>
 			<div className="help-courses__course-schedule-item-buttons">
-				<Button className="help-courses__course-schedule-item-register-button"
-					target="_blank"
-					href={ registrationUrl }>
-					{ translate( 'Register' ) }
-				</Button>
+				{ isBusinessPlanUser
+					? ( <Button className="help-courses__course-schedule-item-register-button"
+						target="_blank"
+						href={ registrationUrl }>
+						{ translate( 'Register' ) }
+					</Button> )
+					: ( <div className="help-courses__course-schedule-item-businessplan-button">
+						{ translate( 'Only on Business Plan' ) }
+					</div> )
+				}
 			</div>
 		</Card>
 	);

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -9,15 +9,24 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import CourseScheduleItem from './course-schedule-item';
+import HelpTeaserButton from '../help-teaser-button';
+import sitesList from 'lib/sites-list';
+
+/**
+ * Module variables
+ */
+const sites = sitesList();
 
 export default localize( ( props ) => {
 	const {
 		title,
 		description,
 		schedule,
-		showRecentCourseRecordings,
+		isBusinessPlanUser,
 		translate
 	} = props;
+
+	const { slug } = sites.getPrimary();
 
 	return (
 		<div className="help-courses__course">
@@ -25,10 +34,15 @@ export default localize( ( props ) => {
 			<Card compact>
 				<h1 className="help-courses__course-title">{ title }</h1>
 				<p className="help-courses__course-description">{ description }</p>
+				{ ! isBusinessPlanUser &&
+					<HelpTeaserButton
+						href={ `/plans/${ slug }` }
+						title={ translate( 'Join this course with Business Plan' ) }
+						description={ translate( 'Upgrade to access webinars and courses to learn how to make the most of your site' ) }/> }
 			</Card>
-			{ schedule.map( ( item, key ) => <CourseScheduleItem { ...item } key={ key } /> ) }
+			{ schedule.map( ( item, key ) => <CourseScheduleItem { ...item } key={ key } isBusinessPlanUser={ isBusinessPlanUser } /> ) }
 			{
-				showRecentCourseRecordings &&
+				isBusinessPlanUser &&
 				<Card className="help-courses__course-recording">
 					Show most recent recording here
 				</Card>

--- a/client/me/help/help-courses/courses.jsx
+++ b/client/me/help/help-courses/courses.jsx
@@ -16,7 +16,7 @@ class Courses extends Component {
 		const {
 			translate,
 			userId,
-			showRecentCourseRecordings,
+			isBusinessPlanUser,
 			courses,
 			isLoading
 		} = this.props;
@@ -28,7 +28,7 @@ class Courses extends Component {
 				</HeaderCake>
 				{ isLoading
 					? <CourseListPlaceholder />
-					: <CourseList courses={ courses } showRecentCourseRecordings={ showRecentCourseRecordings } /> }
+					: <CourseList courses={ courses } isBusinessPlanUser={ isBusinessPlanUser } /> }
 
 				<QueryUserPurchases userId={ userId } />
 			</Main>

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -53,7 +53,7 @@ function getCourses() {
 function mapStateToProps( state ) {
 	const userId = getCurrentUserId( state );
 	const purchases = getUserPurchases( state, userId );
-	const showRecentCourseRecordings = purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS );
+	const isBusinessPlanUser = purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS );
 	const isLoading = ! hasLoadedUserPurchasesFromServer( state );
 	const courses = getCourses();
 
@@ -61,7 +61,7 @@ function mapStateToProps( state ) {
 
 	return {
 		isLoading,
-		showRecentCourseRecordings,
+		isBusinessPlanUser,
 		userId,
 		courses
 	};

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -9,6 +9,14 @@
 	&.is-placeholder {
 		@include placeholder( 23% );
 	}
+
+	.help__help-teaser-button-icon {
+		color: $alert-yellow !important;
+	}
+
+	.help__help-teaser-button .card {
+		border-color: $alert-yellow !important;
+	}
 }
 
 .help-courses__header-cake .header-cake__title,
@@ -70,6 +78,16 @@
 
 .help-courses__course-schedule-item-buttons {
 	margin-left: auto;
+}
+
+.help-courses__course-schedule-item-businessplan-button {
+	background-color: $gray-dark;
+	border-radius: 3px;
+	color: $gray-light;
+	padding: 5px 12px;
+	cursor: default;
+	font-size: 14px;
+	white-space: nowrap;
 }
 
 .help-courses__course-recording {

--- a/client/me/help/help-teaser-button.jsx
+++ b/client/me/help/help-teaser-button.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import Card from 'components/card';
+
+export default localize( ( { title, description, href } ) => {
+	return (
+		<div className="help__help-teaser-button">
+			<Card href={ href }>
+				<Gridicon className="help__help-teaser-button-icon" icon="help" size={ 36 } />
+				<div className="help__help-teaser-text">
+					<span className="help__help-teaser-button-title">
+						{ title }
+					</span>
+					<span className="help__help-teaser-button-description">
+						{ description }
+					</span>
+				</div>
+			</Card>
+		</div>
+	);
+} );

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -15,11 +15,10 @@ const Main = require( 'components/main' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	HelpSearch = require( './help-search' ),
 	CompactCard = require( 'components/card/compact' ),
-	Card = require( 'components/card' ),
-	Gridicon = require( 'components/gridicon' ),
 	Button = require( 'components/button' ),
 	SectionHeader = require( 'components/section-header' ),
 	HelpResult = require( './help-results/item' ),
+	HelpTeaserButton = require( './help-teaser-button' ),
 	HelpUnverifiedWarning = require( './help-unverified-warning' );
 
 const Help = React.createClass( {
@@ -108,19 +107,10 @@ const Help = React.createClass( {
 
 	getCoursesTeaser: function() {
 		return (
-			<div className="help__course-teaser">
-				<Card href="/help/courses">
-					<Gridicon className="help__course-teaser-icon" icon="help" size={ 36 } />
-					<div>
-						<span className="help__course-teaser-title">
-							{ this.translate( 'Courses' ) }
-						</span>
-						<span className="help__course-teaser-description">
-							{ this.translate( 'Learn how to make the most of your site with these courses and webinars' ) }
-						</span>
-					</div>
-				</Card>
-			</div>
+			<HelpTeaserButton
+				href="/help/courses"
+				title={ this.translate( 'Courses' ) }
+				description={ this.translate( 'Learn how to make the most of your site with these courses and webinars' ) }/>
 		);
 	},
 

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -47,7 +47,7 @@
 	color: $gray-dark;
 }
 
-.help__course-teaser .card {
+.help__help-teaser-button .card {
 	border-left: 3px solid $blue-wordpress;
 	display: flex;
 	margin: 16px 0;
@@ -62,7 +62,11 @@
 	}
 }
 
-.help__course-teaser-icon {
+.help__help-teaser-text {
+	padding-right: 10px;
+}
+
+.help__help-teaser-button-icon {
 	color: $blue-wordpress;
 	border-radius: 50%;
 	margin-right: 16px;
@@ -70,13 +74,13 @@
 	align-self: center;
 }
 
-.help__course-teaser-title {
+.help__help-teaser-button-title {
 	color: $gray-dark;
 	font-size: 14px;
 	font-weight: 500;
 }
 
-.help__course-teaser-description {
+.help__help-teaser-button-description {
 	color: $gray;
 	font-size: 12px;
 	display: block;


### PR DESCRIPTION
This pull request changes the courses page for non business plan users
1. A new upgrade button appears under the course description
2. The registration button is now disabled

## Testing
1. As a non business plan, navigate to https://calypso.live/help/courses?branch=add/help-courses-non-business-plan
2. Notice that the "Register" buttons are now disabled and are labeled "Only on business plan"
3. Also notice a new "Join this course with a business plan" button that navigates to the plan comparison page.

### What to expect
**Business plan users**
![screen shot 2016-08-24 at 3 51 11 pm](https://cloud.githubusercontent.com/assets/1854440/17945682/e48057a2-6a12-11e6-9442-49f6dac9c257.png)

**Non business plan users**
![screen shot 2016-08-24 at 3 49 39 pm](https://cloud.githubusercontent.com/assets/1854440/17945646/c28cd17a-6a12-11e6-8148-e7223c4a1bec.png)


Test live: https://calypso.live/?branch=add/help-courses-non-business-plan