### PR TITLE
Advanced SEO: Add label and border to preview SEO button

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -132,8 +132,19 @@
 	}
 
 	&.web-preview__seo-button {
-		display: block;
+		display: flex;
+		align-items: center;
+		padding: 0 14px;
+
+		&.is-showing-device-switcher {
+			border-left: 1px solid lighten( $gray, 20% );
+			margin-left: 8px;
+		}
 	}
+}
+
+.web-preview__seo-label {
+	margin-left: 6px;
 }
 
 .web-preview__back-to-preview-button {

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -100,11 +100,15 @@ export const PreviewToolbar = props => {
 					className={ classNames(
 						'web-preview__seo-button',
 						'web-preview__device-button', {
-						'is-active': 'seo' === currentDevice
+						'is-active': 'seo' === currentDevice,
+						'is-showing-device-switcher': showDeviceSwitcher
 					} ) }
 					onClick={ selectSeoPreview }
 				>
 					<Gridicon icon="globe" />
+					<span className="web-preview__seo-label">
+						{ translate( 'SEO' ) }
+					</span>
 				</button>
 			}
 			<div className="web-preview__toolbar-tray">


### PR DESCRIPTION
Updates the icon to have a text label and a border, based on design feedback.

<img width="415" alt="screen shot 2016-08-24 at 2 24 05 pm" src="https://cloud.githubusercontent.com/assets/789137/17948703/c406454c-6a06-11e6-8a77-7d99ac81e648.png">
<img width="433" alt="screen shot 2016-08-24 at 2 23 49 pm" src="https://cloud.githubusercontent.com/assets/789137/17948704/c407b364-6a06-11e6-843b-34364b88afca.png">

cc @melchoyce @apeatling 

Refs #7480

Test live: https://calypso.live/?branch=update/advanced-seo-preview-icon