### PR TITLE
Help: Hide the courses button on the help page for non business users

### DIFF
--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -11,7 +11,7 @@ import { find } from 'lodash';
 import Courses from './courses';
 import {
 	getUserPurchases,
-	hasLoadedUserPurchasesFromServer
+	isFetchingUserPurchases
 } from 'state/purchases/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
@@ -54,7 +54,7 @@ function mapStateToProps( state ) {
 	const userId = getCurrentUserId( state );
 	const purchases = getUserPurchases( state, userId );
 	const isBusinessPlanUser = purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS );
-	const isLoading = ! hasLoadedUserPurchasesFromServer( state );
+	const isLoading = isFetchingUserPurchases( state );
 	const courses = getCourses();
 
 	//TODO: Add tracks pings

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -1,5 +1,11 @@
 .help-results {
 	margin-bottom: 16px;
+
+	&.is-placeholder {
+		@include placeholder();
+		height: 380px;
+		margin-bottom: 15px;
+	}
 }
 
 .help-results__header.card.is-compact,

--- a/client/me/help/help-search/style.scss
+++ b/client/me/help/help-search/style.scss
@@ -1,5 +1,11 @@
 .help-search {
 	margin-bottom: 16px;
+
+	&.is-placeholder {
+		@include placeholder();
+		height: 50px;
+		margin-bottom: 15px;
+	}
 }
 
 .help-search .no-results {

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -1,3 +1,11 @@
+.help__support-links {
+	&.is-placeholder {
+		@include placeholder();
+		height: 250px;
+		margin-bottom: 15px;
+	}
+}
+
 .help__support-link {
 	display: flex;
 }
@@ -45,6 +53,14 @@
 	margin-bottom: 0;
 	font-size: 14px;
 	color: $gray-dark;
+}
+
+.help__help-teaser-button {
+	&.is-placeholder {
+		@include placeholder();
+		height: 64px;
+		margin-bottom: 15px;
+	}
 }
 
 .help__help-teaser-button .card {


### PR DESCRIPTION
This pull request hides the courses button for users without the business plan.

### How to test this
1. Navigate to https://calypso.live/help?branch=update/help-courses-hide-for-non-business-users
2. Notice the blinking placeholder.
3. If you are a business plan user the "Courses" button will appear. In other cases the placeholder will just disappear.

**Before**
![screen shot 2016-08-24 at 8 01 49 pm](https://cloud.githubusercontent.com/assets/1854440/17952141/c7b5befa-6a35-11e6-85ee-afc3df9e83cb.png)

**After**
![screen shot 2016-08-24 at 8 02 00 pm](https://cloud.githubusercontent.com/assets/1854440/17952146/d359406a-6a35-11e6-9fad-c9cae0d51441.png)


Test live: https://calypso.live/?branch=update/help-courses-hide-for-non-business-users