### PR TITLE
Editor: Ensure throttled autosave is canceled on unmount

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -106,7 +106,8 @@ const PostEditor = React.createClass( {
 	componentWillMount: function() {
 		PostEditStore.on( 'change', this.onEditedPostChange );
 		this.debouncedSaveRawContent = debounce( this.saveRawContent, 200 );
-		this.debouncedAutosave = debounce( throttle( this.autosave, 20000 ), 3000 );
+		this.throttledAutosave = throttle( this.autosave, 20000 );
+		this.debouncedAutosave = debounce( this.throttledAutosave, 3000 );
 		this.switchEditorVisualMode = this.switchEditorMode.bind( this, 'tinymce' );
 		this.switchEditorHtmlMode = this.switchEditorMode.bind( this, 'html' );
 
@@ -146,6 +147,7 @@ const PostEditor = React.createClass( {
 		actions.stopEditing();
 
 		this.debouncedAutosave.cancel();
+		this.throttledAutosave.cancel();
 		this.debouncedSaveRawContent.cancel();
 		this._previewWindow = null;
 		clearTimeout( this._switchEditorTimeout );


### PR DESCRIPTION
Fixes #7356

This pull request seeks to resolve an error which can occur after navigating away from the editor.

```
Cannot read property 'getContent' of undefined
```

The cause of this error is that the autosave is both debounced and throttled, but only the debounce is canceled when the component is unmounted.

__Testing instructions:__

Repeat the [steps to reproduce](https://github.com/Automattic/wp-calypso/issues/7356#issuecomment-242215850), noting that no error is logged to the console after navigating away from the editor. Observe that there are no regressions in the autosave behavior.

/cc @timmyc 

Test live: https://calypso.live/?branch=fix/editor-get-content-error