### PR TITLE
Add buttons instead of dropdown in /design.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -306,6 +306,7 @@
 @import 'my-sites/themes/current-theme/style';
 @import 'my-sites/themes/style';
 @import 'my-sites/themes/themes-search-card/style';
+@import 'my-sites/themes/themes-magic-search-card/style';
 @import 'my-sites/upgrade-nudge/style';
 @import 'my-sites/upgrades/cart/style';
 @import 'my-sites/upgrades/checkout/stored-card';

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import debounce from 'lodash/debounce';
+
+/**
+ * Internal dependencies
+ */
+import Search from 'components/search';
+import SegmentedControl from 'components/segmented-control';
+import { trackClick } from '../helpers';
+import config from 'config';
+import { isMobile } from 'lib/viewport';
+
+const ThemesMagicSearchCard = React.createClass( {
+	propTypes: {
+		tier: React.PropTypes.string,
+		select: React.PropTypes.func.isRequired,
+		site: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool
+		] ).isRequired,
+		onSearch: React.PropTypes.func.isRequired,
+		search: React.PropTypes.string
+	},
+
+	trackClick: trackClick.bind( null, 'search bar' ),
+
+	componentWillMount() {
+		this.onResize = debounce( () => {
+			this.setState( { isMobile: isMobile() } );
+		}, 250 );
+	},
+
+	componentDidMount() {
+		window.addEventListener( 'resize', this.onResize );
+	},
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.onResize );
+	},
+
+	getInitialState() {
+		return {
+			isMobile: isMobile(),
+			searchIsOpen: false
+		};
+	},
+
+	getDefaultProps() {
+		return { tier: 'all' };
+	},
+
+	onSearchOpen() {
+		this.setState( { searchIsOpen: true } );
+	},
+
+	onSearchClose() {
+		this.setState( { searchIsOpen: false } );
+	},
+
+	onBlur() {
+		if ( this.state.isMobile ) {
+			this.setState( { searchIsOpen: false } );
+		}
+	},
+
+	render() {
+		const isJetpack = this.props.site && this.props.site.jetpack;
+		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
+
+		const tiers = [
+			{ value: 'all', label: this.translate( 'All' ) },
+			{ value: 'free', label: this.translate( 'Free' ) },
+			{ value: 'premium', label: this.translate( 'Premium' ) },
+		];
+
+		const searchField = (
+			<Search
+				onSearch={ this.props.onSearch }
+				initialValue={ this.props.search }
+				ref="url-search"
+				placeholder={ this.translate( 'What kind of theme are you looking for?' ) }
+				analyticsGroup="Themes"
+				delaySearch={ true }
+				onSearchOpen={ this.onSearchOpen }
+				onSearchClose={ this.onSearchClose }
+				onBlur={ this.onBlur }
+				fitsContainer={ this.state.isMobile && this.state.searchIsOpen }
+				hideClose={ isMobile() }
+			/>
+		);
+
+		return (
+			<div className="themes-magic-search-card" data-tip-target="themes-search-card">
+				{ searchField }
+				{ isPremiumThemesEnabled && ! isJetpack &&
+					<SegmentedControl
+						initialSelected={ this.props.tier }
+						options={ tiers }
+						onSelect={ this.props.select }
+					/>
+				}
+			</div>
+		);
+	}
+} );
+
+export default ThemesMagicSearchCard;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -1,0 +1,37 @@
+.themes-magic-search-card {
+	display: flex;
+	align-items: center;
+	background: white;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
+
+	.search {
+		flex: 0 1 auto;
+		margin: 0;
+	}
+
+	.section-nav {
+		margin: 0;
+	}
+
+	.search .search-open__icon {
+		color: lighten( $gray, 10% );
+	}
+
+	.segmented-control {
+		flex: 0 0 auto;
+		min-width: 0;
+		padding: 11px 14px 11px;
+
+		.segmented-control__item,
+		.segmented-control__link,
+		.segmented-control__text {
+			min-width: inherit;
+		}
+	}
+
+	.more {
+		flex: 0 1 auto;
+		padding: 8px 14px 8px;
+	}
+
+}

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -6,7 +6,7 @@
 
 	.search {
 		flex: 0 1 auto;
-		margin: 0;
+		margin: 0 0 0 8px;
 	}
 
 	.section-nav {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -6,7 +6,7 @@
 
 	.search {
 		flex: 0 1 auto;
-		margin: 0 0 0 8px;
+		margin: 0;
 	}
 
 	.section-nav {

--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -5,7 +5,7 @@
 
 	.search {
 		flex: 1 1 auto;
-		margin: 0 0 0 8px;
+		margin: 0;
 	}
 
 	.section-nav {

--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -5,7 +5,7 @@
 
 	.search {
 		flex: 1 1 auto;
-		margin: 0;
+		margin: 0 0 0 8px;
 	}
 
 	.section-nav {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -20,7 +20,7 @@ import {
 } from './theme-filters.js';
 import config from 'config';
 
-const ThemesSearchCard = config.isEnabled( 'manage/themes/magic_search' )
+const ThemesSearchCard = config.isEnabled( 'manage/themes/magic-search' )
 	? require( './themes-magic-search-card' )
 	: require( './themes-search-card' );
 

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -8,7 +8,6 @@ import page from 'page';
  * Internal dependencies
  */
 import { trackClick } from './helpers';
-import ThemesSearchCard from './themes-search-card';
 import ThemesData from 'components/data/themes-list-fetcher';
 import ThemesList from 'components/themes-list';
 import StickyPanel from 'components/sticky-panel';
@@ -19,6 +18,11 @@ import {
 	getSortedFilterTerms,
 	stripFilters,
 } from './theme-filters.js';
+import config from 'config';
+
+const ThemesSearchCard = config.isEnabled( 'manage/themes/magic_search' )
+	? require( './themes-magic-search-card' )
+	: require( './themes-search-card' );
 
 const ThemesSelection = React.createClass( {
 	propTypes: {

--- a/config/development.json
+++ b/config/development.json
@@ -87,7 +87,7 @@
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
-		"manage/themes/magic_search": true,
+		"manage/themes/magic-search": true,
 		"me/account": true,
 		"me/billing-history": true,
 		"me/find-friends": false,

--- a/config/development.json
+++ b/config/development.json
@@ -87,6 +87,7 @@
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
+		"manage/themes/magic_search": true,
 		"me/account": true,
 		"me/billing-history": true,
 		"me/find-friends": false,


### PR DESCRIPTION
Old:
![image](https://cloud.githubusercontent.com/assets/17271089/17963585/880afe42-6ab6-11e6-9470-84ed639e3b47.png)
New:
![image](https://cloud.githubusercontent.com/assets/17271089/17963665/f90d2264-6ab6-11e6-862e-67f57c382455.png)
This new look is hidden behind "manage/themes/magic_search" flag and visible only in dev.

I have chosen to create the change in form of a new module because amount of changes and necesity to hide the code behind feature flag was making the code unreadable. This way the implementation is clean and the flag is in only one place. This approach does not increase technical debt as the old module will be not needed and deleted when the new one is mature enough. This is also a good location to continue further work on Magic Search.


Test live: https://calypso.live/?branch=update/change-dropdown-to-buttons-in-design