### PR TITLE
Build: Run SSR pragma checker plugin on server build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ test:
   pre:
     - NODE_ENV=test make client/config/index.js:
         parallel: true
+    - NODE_ENV=test make build-server:
+        parallel: true
   override:
     - bin/run-lint :
         parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,9 @@ test:
   pre:
     - NODE_ENV=test make client/config/index.js:
         parallel: true
+  override:
     - NODE_ENV=test make build-server:
         parallel: true
-  override:
     - bin/run-lint :
         parallel: true
         files:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ test:
   pre:
     - NODE_ENV=test make client/config/index.js:
         parallel: true
-    - case $CIRCLE_NODE_INDEX 0) NODE_ENV=test make build-server ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) NODE_ENV=test make build-server ;; esac:
         parallel: true
   override:
     - bin/run-lint :

--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,9 @@ test:
   pre:
     - NODE_ENV=test make client/config/index.js:
         parallel: true
-  override:
-    - NODE_ENV=test make build-server:
+    - case $CIRCLE_NODE_INDEX 0) NODE_ENV=test make build-server ;; esac:
         parallel: true
+  override:
     - bin/run-lint :
         parallel: true
         files:

--- a/client/components/empty-component/index.jsx
+++ b/client/components/empty-component/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -32,9 +32,13 @@ Here's how your module's `package.json` should look, if you really want to do th
 }
 ```
 
+You may also need to add the module to the SSR pragma `IGNORED_MODULES` [list](https://github.com/Automattic/wp-calypso/blob/master/server/pragma-checker/index.js), since the client-specific parts cannot be marked `/** @ssr-ready **/`.
+
 ### Marking your code as compatible with server-side rendering
 
 When you're satisfied that your component or library will render on the server, mark it and its dependencies as SSR-ready by inserting `/** @ssr-ready **/` at the top of the file. This will signal to the `PragmaChecker` webpack plugin that your file's dependencies should be checked. It also communicates to other developers that your code is going to be rendered on the server, so should be modified with care.
+
+If you know that your code will never be called on the server, instead of adding `/** @ssr-ready **/`, you can stub-out the module using `NormalModuleReplacementPlugin` in the [config file](https://github.com/Automattic/wp-calypso/blob/master/webpack.config.node.js).
 
 ### I want to server-side render my components!
 

--- a/server/pragma-checker/index.js
+++ b/server/pragma-checker/index.js
@@ -14,17 +14,7 @@ var IGNORED_MODULES = [
 	'config', // Different modules on client & server
 	'lib/wp', // Different modules on client & server
 	'lib/formatting', // Different modules on client & server
-	'lib/analytics', // nooped on the server until we develop an isomorphic version
-	'lib/route', // nooped on the server until we can extract the isomorphic bits
-	'lib/post-normalizer/rule-create-better-excerpt', // nooped on the server until we develop an isomorphic version
-	'lib/upgrades/actions', // nooped on the server as it still uses the singleton Flux architecture
 	'i18n-calypso', // ignore this until we make it work properly on the server
-	'components/seo/preview-upgrade-nudge', // nooped until all the dependencies are @ssr-ready
-	'my-sites/themes/thanks-modal', // stubbed on the server until we develop an isomorphic version
-	'my-sites/themes/themes-site-selector-modal', // stubbed on the server until we develop an isomorphic version
-	'state/ui/editor/selectors', // stubbed on the server until all the dependencies are @ssr-ready
-	'state/posts/selectors', // stubbed on the server until all the dependencies are @ssr-ready
-	'layout/guided-tours/config', // should never run on the server
 ];
 
 function PragmaCheckPlugin( options ) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,16 +4,14 @@
  * External dependencies
  */
 var webpack = require( 'webpack' ),
-	path = require( 'path' ),
-	config = require( 'config' );
+	path = require( 'path' );
 
 /**
  * Internal dependencies
  */
 var config = require( './server/config' ),
 	sections = require( './client/sections' ),
-	ChunkFileNamePlugin = require( './server/bundler/plugin' ),
-	PragmaCheckPlugin = require( 'server/pragma-checker' );
+	ChunkFileNamePlugin = require( './server/bundler/plugin' );
 
 /**
  * Internal variables
@@ -117,7 +115,6 @@ jsLoader = {
 };
 
 if ( CALYPSO_ENV === 'development' ) {
-	webpackConfig.plugins.push( new PragmaCheckPlugin() );
 	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
 	webpackConfig.entry[ 'build-' + CALYPSO_ENV ] = [
 		'webpack-dev-server/client?/',

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -102,7 +102,7 @@ module.exports = {
 	externals: getExternals()
 };
 
-if ( process.env.CALYPSO_ENV === 'development' ) {
+if ( process.env.CALYPSO_ENV === 'development' || process.env.CALYPSO_ENV === 'test' ) {
 	module.exports.plugins.push( new PragmaCheckPlugin );
 }
 

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -96,7 +96,7 @@ module.exports = {
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^state\/ui\/editor\/selectors$/, 'lodash/noop' ), // will never be called server-side
-//		new webpack.NormalModuleReplacementPlugin( /^state\/posts\/selectors$/, 'lodash/noop' ), // will never be called server-side
+		new webpack.NormalModuleReplacementPlugin( /^state\/posts\/selectors$/, 'lodash/noop' ), // will never be called server-side
 		new webpack.NormalModuleReplacementPlugin( /^client\/layout\/guided-tours\/config$/, 'components/empty-component' ) // should never be required server side
 	],
 	externals: getExternals()

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -96,7 +96,7 @@ module.exports = {
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^state\/ui\/editor\/selectors$/, 'lodash/noop' ), // will never be called server-side
-		new webpack.NormalModuleReplacementPlugin( /^state\/posts\/selectors$/, 'lodash/noop' ), // will never be called server-side
+//		new webpack.NormalModuleReplacementPlugin( /^state\/posts\/selectors$/, 'lodash/noop' ), // will never be called server-side
 		new webpack.NormalModuleReplacementPlugin( /^client\/layout\/guided-tours\/config$/, 'components/empty-component' ) // should never be required server side
 	],
 	externals: getExternals()

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -8,6 +8,11 @@ var webpack = require( 'webpack' ),
 	fs = require( 'fs' );
 
 /**
+ * Internal dependencies
+ */
+var	PragmaCheckPlugin = require( 'server/pragma-checker' );
+
+/**
  * This lists modules that must use commonJS `require()`s
  * All modules listed here need to be ES5.
  *
@@ -20,24 +25,24 @@ function getExternals() {
 	// with modules that are incompatible with webpack bundling.
 	fs.readdirSync( 'node_modules' )
 		.filter( function( module ) {
-			return ['.bin'].indexOf( module ) === -1;
+			return [ '.bin' ].indexOf( module ) === -1;
 		} )
 		.forEach( function( module ) {
-			externals[module] = 'commonjs ' + module;
+			externals[ module ] = 'commonjs ' + module;
 		} );
 
 	// Don't bundle webpack.config, as it depends on absolute paths (__dirname)
-	externals['webpack.config'] = 'commonjs webpack.config';
+	externals[ 'webpack.config' ] = 'commonjs webpack.config';
 	// Exclude hot-reloader, as webpack will try and resolve this in production builds,
 	// and error.
 	// TODO: use WebpackDefinePlugin for CALYPSO_ENV, so we can make conditional requires work
-	externals['bundler/hot-reloader'] = 'commonjs bundler/hot-reloader';
+	externals[ 'bundler/hot-reloader' ] = 'commonjs bundler/hot-reloader';
 	// Exclude the devdocs search-index, as it's huge.
-	externals['devdocs/search-index'] = 'commonjs devdocs/search-index';
+	externals[ 'devdocs/search-index' ] = 'commonjs devdocs/search-index';
 	// Exclude the devdocs components usage stats data
-	externals['devdocs/components-usage-stats.json'] = 'commonjs devdocs/components-usage-stats.json';
+	externals[ 'devdocs/components-usage-stats.json' ] = 'commonjs devdocs/components-usage-stats.json';
 	// Exclude server/bundler/assets, since the files it requires don't exist until the bundler has run
-	externals['bundler/assets'] = 'commonjs bundler/assets';
+	externals[ 'bundler/assets' ] = 'commonjs bundler/assets';
 
 	return externals;
 }
@@ -96,3 +101,8 @@ module.exports = {
 	],
 	externals: getExternals()
 };
+
+if ( process.env.CALYPSO_ENV === 'development' ) {
+	module.exports.plugins.push( new PragmaCheckPlugin );
+}
+


### PR DESCRIPTION
Running SSR checker on the server build instead of the client build means that any modules that are stubbed on the server are ignored, eliminating the need to place stubbed modules in the ignore list.

Test live: https://calypso.live/?branch=update/pragma-checker