### PR TITLE
Reader: fix ESC shortcut in new full post view

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -39,6 +39,7 @@ import Comments from 'blocks/comments';
 import scrollTo from 'lib/scroll-to';
 import PostExcerptLink from 'reader/post-excerpt-link';
 import { siteNameFromSiteAndPost } from 'reader/utils';
+import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 
 export class FullPostView extends React.Component {
 	constructor( props ) {
@@ -48,11 +49,19 @@ export class FullPostView extends React.Component {
 		} );
 	}
 
+	componentDidMount() {
+		KeyboardShortcuts.on( 'close-full-post', this.handleBack );
+	}
+
+	componentWillUnmount() {
+		KeyboardShortcuts.off( 'close-full-post', this.handleBack );
+	}
+
 	handleBack() {
 		this.props.onClose && this.props.onClose();
 	}
 
-	handleCommentClick( ) {
+	handleCommentClick() {
 		recordAction( 'click_comments' );
 		recordGaEvent( 'Clicked Post Comment Button' );
 		recordTrackForPost( 'calypso_reader_full_post_comments_button_clicked', this.props.post );

--- a/client/lib/keyboard-shortcuts/key-bindings.js
+++ b/client/lib/keyboard-shortcuts/key-bindings.js
@@ -1,5 +1,5 @@
-var i18n = require( 'i18n-calypso' ),
-	Emitter = require( 'lib/mixins/emitter' );
+import i18n from 'i18n-calypso';
+import Emitter from 'lib/mixins/emitter';
 
 function KeyBindings() {
 	i18n.on( 'change', this.emitLanguageChange.bind( this ) );
@@ -15,7 +15,7 @@ KeyBindings.prototype.emitLanguageChange = function() {
 };
 
 KeyBindings.prototype.get = function() {
-	var descriptionCtrlKey = 'ctrl';
+	let descriptionCtrlKey = 'ctrl';
 
 	if ( typeof navigator !== 'undefined' && navigator.userAgent.indexOf( 'Mac OS X' ) !== -1 ) {
 		// the ctrl key in the description is platform dependent and displays the command symbol on OS X
@@ -63,7 +63,7 @@ KeyBindings.prototype.get = function() {
 				eventName: 'open-keyboard-shortcuts-menu',
 				keys: [
 					[ 'shift', '/' ],
-					[ 'shift', ',']
+					[ 'shift', ',' ]
 				],
 				// On Win/Webkit `?` is incorrectly identified as upside-down
 				// question mark. https://bugs.webkit.org/show_bug.cgi?id=19906

--- a/client/lib/keyboard-shortcuts/key-bindings.js
+++ b/client/lib/keyboard-shortcuts/key-bindings.js
@@ -165,6 +165,14 @@ KeyBindings.prototype.get = function() {
 					keys: [ descriptionCtrlKey, 'enter' ],
 					text: i18n.translate( 'Reply to post' )
 				}
+			},
+			{
+				eventName: 'close-full-post',
+				keys: [ 'esc' ],
+				description: {
+					keys: [ 'esc' ],
+					text: i18n.translate( 'Close full post' )
+				}
 			}
 		],
 


### PR DESCRIPTION
As per #7421, fix the ESC keyboard shortcut in the new Reader full post view block.

The behaviour of <kbd>esc</kbd> should be the same as hitting the 'Back' link at the top left.

## To test

Head to a site stream, e.g. http://calypso.localhost:3000/read/feeds/40474296. Open a full post, then hit <kbd>esc</kbd>. You should be returned to the site stream.

cc @fraying 

Test live: https://calypso.live/?branch=fix/reader/esc-shortcut-new-full-post-view