### PR TITLE
Add a latest courses section to the /help/courses page

### DIFF
--- a/client/me/help/help-courses/course-video.jsx
+++ b/client/me/help/help-courses/course-video.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import Gridicon from 'components/gridicon';
+import Card from 'components/card';
+
+export default localize( ( props ) => {
+	const {
+		title,
+		description,
+		date,
+		youtubeId
+	} = props;
+
+	return (
+		<div className="help-courses__course-video">
+			<div className="help-courses__course-video-embed">
+				<iframe
+					className="help-courses__course-video-embed-iframe"
+					src={ `https://www.youtube.com/embed/${ youtubeId }` }
+					allowFullScreen/>
+			</div>
+			<Card compact>
+				<h1 className="help-courses__course-video-title">{ title }</h1>
+				<p className="help-courses__course-video-description">{ description }</p>
+			</Card>
+			<Card compact className="help-courses__course-video-date">
+				<Gridicon className="help-courses__course-video-date-icon" icon="time" size={ 18 }/>
+				{ date.fromNow() }
+			</Card>
+		</div>
+	);
+} );

--- a/client/me/help/help-courses/course-videos.jsx
+++ b/client/me/help/help-courses/course-videos.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import CourseVideo from './course-video';
+import Card from 'components/card';
+
+export default localize( ( props ) => {
+	const {	videos, translate } = props;
+
+	if ( videos.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="help-courses__course-videos">
+			<Card compact className="help-courses__course-videos-label">{ translate( 'Latest course' ) }</Card>
+			{ videos.map( ( video, key ) => <CourseVideo { ...video } key={ key }/> ) }
+		</div>
+	);
+} );

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import CourseScheduleItem from './course-schedule-item';
 import HelpTeaserButton from '../help-teaser-button';
+import CourseVideos from './course-videos';
 import sitesList from 'lib/sites-list';
 
 /**
@@ -23,6 +24,7 @@ export default localize( ( props ) => {
 		description,
 		schedule,
 		isBusinessPlanUser,
+		videos,
 		translate
 	} = props;
 
@@ -41,12 +43,7 @@ export default localize( ( props ) => {
 						description={ translate( 'Upgrade to access webinars and courses to learn how to make the most of your site' ) }/> }
 			</Card>
 			{ schedule.map( ( item, key ) => <CourseScheduleItem { ...item } key={ key } isBusinessPlanUser={ isBusinessPlanUser } /> ) }
-			{
-				isBusinessPlanUser &&
-				<Card className="help-courses__course-recording">
-					Show most recent recording here
-				</Card>
-			}
+			{ isBusinessPlanUser && <CourseVideos videos={ videos } /> }
 		</div>
 	);
 } );

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -40,10 +40,16 @@ function getCourses() {
 					registrationUrl: 'http://wordpress.com'
 				},
 			],
-			recent: [
+			videos: [
 				{
-					date: i18n.moment( new Date( 'Mon, 01 Aug 2016 17:30:00 +0000' ) ),
-					video: 'http://wordpress.com/some-video.mp4'
+					date: i18n.moment( new Date( 'Thu, 25 Aug 2016 01:00:00 +0000' ) ),
+					title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
+					description: i18n.translate(
+						'Bacon ipsum dolor amet sirloin bresaola leberkas, strip steak hamburger short ribs beef pork. ' +
+						'Tenderloin salami sausage tongue capicola. Hamburger tenderloin prosciutto venison pork loin, ' +
+						'bresaola tri-tip shank.'
+					),
+					youtubeId: 'f44-4TgnWTs'
 				}
 			]
 		}

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -19,11 +19,13 @@
 	}
 }
 
+.help-courses__course-videos-label,
 .help-courses__header-cake .header-cake__title,
 .help-courses__course-label {
 	color: $gray;
 }
 
+.help-courses__course-video-title,
 .help-courses__course-title {
 	@extend %content-font;
 	color: $gray-dark;
@@ -41,6 +43,7 @@
 	}
 }
 
+.help-courses__course-video-description,
 .help-courses__course-description {
 	@extend %content-font;
 	font-size: 15px;
@@ -70,6 +73,7 @@
 	}
 }
 
+.help-courses__course-video-date-icon,
 .help-courses__course-schedule-item-icon {
 	align-self: center;
 	margin-right: 5px;
@@ -90,7 +94,32 @@
 	white-space: nowrap;
 }
 
-.help-courses__course-recording {
+.help-courses__course-videos {
 	margin-top: 16px;
 }
 
+.help-courses__course-video-date {
+	color: $gray;
+	font-size: 13px;
+}
+
+.help-courses__course-video-embed {
+	/*Maintain a 16:9 aspect ratio*/
+	position: relative;
+	&:before {
+		display: block;
+		content: "";
+		width: 100%;
+		padding-top: ( 9 / 16 ) * 100%;
+		background-color: #000;
+	}
+}
+
+.help-courses__course-video-embed-iframe {
+	border: none;
+	display: block;
+	position: absolute;
+	height: 100%;
+	width: 100%;
+	top: 0;
+}


### PR DESCRIPTION
This pull request adds a new section at the bottom of the /help/courses page that shows a recent course video along with date, title and description.

### How to test this
1. As a business plan user, navigate to https://calypso.live/help/courses?branch=add/help-courses-latest-course-video
2. Notice the video that now appears at the bottom of the page.
3. Resize the browser a few times to make sure the video is responsive and keeps its 16:9 ratio.

#### What to expect
![screen shot 2016-08-25 at 2 09 51 pm](https://cloud.githubusercontent.com/assets/1854440/17980522/b06d436a-6acd-11e6-849e-50ac7ecec2bb.png)

