### PR TITLE
Help: Fix a text overflow issue that occurs in the help teaser button

### DIFF
--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -94,10 +94,12 @@
 	color: $gray-dark;
 	font-size: 14px;
 	font-weight: 500;
+	padding-right: 15px;
 }
 
 .help__help-teaser-button-description {
 	color: $gray;
 	font-size: 12px;
 	display: block;
+	padding-right: 15px;
 }


### PR DESCRIPTION
Fix a text overflow issue that occurs when the help teaser button is squished while it has lots of text in it

### How to test.

1. As a business plan user navigate to https://calypso.live/help?branch=fix/help-course-teaser-button-text-overflow
2. Shrink the browser window so that the text in the button wraps.
3. Make sure that the text doesn't overflow on top of the button arrow.

#### What to expect
**Before**
![screen shot 2016-08-25 at 2 33 10 pm](https://cloud.githubusercontent.com/assets/1854440/17981489/f38c9dae-6ad1-11e6-8076-a31796da2b01.png)

**After**
![screen shot 2016-08-25 at 2 41 19 pm](https://cloud.githubusercontent.com/assets/1854440/17981519/0c0a50ec-6ad2-11e6-9389-845b88b0e432.png)



