### PR TITLE
Help: add tracks pings to the help courses area

### DIFF
--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -10,6 +10,7 @@ import Button from 'components/button';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import Card from 'components/card';
+import analytics from 'lib/analytics';
 
 export default localize( ( props ) => {
 	const {
@@ -19,10 +20,14 @@ export default localize( ( props ) => {
 		translate
 	} = props;
 
+	const trackRegistrationClick = () => {
+		analytics.tracks.recordEvent( 'calypso_help_course_registration_click', { registrationUrl, isBusinessPlanUser } );
+	};
+
 	return (
 		<Card compact className="help-courses__course-schedule-item">
 			<p className="help-courses__course-schedule-item-date">
-				<Gridicon className="help-courses__course-schedule-item-icon" icon="time" size={ 18 }/>
+				<Gridicon className="help-courses__course-schedule-item-icon" icon="time" size={ 18 } />
 				{
 					translate( '%(date)s at %(time)s', {
 						args: {
@@ -35,7 +40,9 @@ export default localize( ( props ) => {
 			<div className="help-courses__course-schedule-item-buttons">
 				{ isBusinessPlanUser
 					? ( <Button className="help-courses__course-schedule-item-register-button"
+						onClick={ trackRegistrationClick }
 						target="_blank"
+						rel="noopener noreferrer"
 						href={ registrationUrl }>
 						{ translate( 'Register' ) }
 					</Button> )

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,41 +12,60 @@ import CourseScheduleItem from './course-schedule-item';
 import HelpTeaserButton from '../help-teaser-button';
 import CourseVideos from './course-videos';
 import sitesList from 'lib/sites-list';
+import analytics from 'lib/analytics';
 
 /**
  * Module variables
  */
 const sites = sitesList();
 
-export default localize( ( props ) => {
-	const {
-		title,
-		description,
-		schedule,
-		isBusinessPlanUser,
-		videos,
-		translate
-	} = props;
+class Course extends Component {
+	componentDidMount() {
+		const {
+			isBusinessPlanUser
+		} = this.props;
 
-	const { slug } = sites.getPrimary();
+		analytics.tracks.recordEvent( 'calypso_help_course_pageview', { isBusinessPlanUser } );
+	}
 
-	return (
-		<div className="help-courses__course">
-			<Card compact className="help-courses__course-label">{ translate( 'Next course' ) }</Card>
-			<Card compact>
-				<h1 className="help-courses__course-title">{ title }</h1>
-				<p className="help-courses__course-description">{ description }</p>
-				{ ! isBusinessPlanUser &&
-					<HelpTeaserButton
-						href={ `/plans/${ slug }` }
-						title={ translate( 'Join this course with Business Plan' ) }
-						description={ translate( 'Upgrade to access webinars and courses to learn how to make the most of your site' ) }/> }
-			</Card>
-			{ schedule.map( ( item, key ) => <CourseScheduleItem { ...item } key={ key } isBusinessPlanUser={ isBusinessPlanUser } /> ) }
-			{ isBusinessPlanUser && <CourseVideos videos={ videos } /> }
-		</div>
-	);
-} );
+	render() {
+		const {
+			title,
+			description,
+			schedule,
+			isBusinessPlanUser,
+			videos,
+			translate
+		} = this.props;
+
+		const { slug } = sites.getPrimary();
+
+		return (
+			<div className="help-courses__course">
+				<Card compact className="help-courses__course-label">{ translate( 'Next course' ) }</Card>
+				<Card compact>
+					<h1 className="help-courses__course-title">{ title }</h1>
+					<p className="help-courses__course-description">{ description }</p>
+					{ ! isBusinessPlanUser &&
+						<HelpTeaserButton
+							href={ `/plans/${ slug }` }
+							title={ translate( 'Join this course with the Business Plan.' ) }
+							description={
+								translate( 'Upgrade to access webinars and courses to learn how to make the most of your site' )
+							}
+						/>
+					}
+				</Card>
+				{ schedule.map( ( item, key ) => {
+					return ( <CourseScheduleItem { ...item } key={ key } isBusinessPlanUser={ isBusinessPlanUser } /> );
+				} ) }
+				{ isBusinessPlanUser && <CourseVideos videos={ videos } /> }
+			</div>
+		);
+	}
+}
+
+export default localize( Course );
 
 export const CoursePlaceholder = () => {
 	return (

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -11,7 +11,8 @@ import { find } from 'lodash';
 import Courses from './courses';
 import {
 	getUserPurchases,
-	isFetchingUserPurchases
+	isFetchingUserPurchases,
+	hasLoadedUserPurchasesFromServer
 } from 'state/purchases/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
@@ -61,7 +62,7 @@ function mapStateToProps( state ) {
 	const userId = getCurrentUserId( state );
 	const purchases = getUserPurchases( state, userId );
 	const isBusinessPlanUser = purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS );
-	const isLoading = isFetchingUserPurchases( state );
+	const isLoading = isFetchingUserPurchases( state ) || ! hasLoadedUserPurchasesFromServer( state );
 	const courses = getCourses();
 
 	//TODO: Add tracks pings

--- a/client/me/help/help-teaser-button.jsx
+++ b/client/me/help/help-teaser-button.jsx
@@ -10,10 +10,10 @@ import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import Card from 'components/card';
 
-export default localize( ( { title, description, href } ) => {
+export default localize( ( { title, description, href, onClick } ) => {
 	return (
 		<div className="help__help-teaser-button">
-			<Card href={ href }>
+			<Card href={ href } onClick={ onClick }>
 				<Gridicon className="help__help-teaser-button-icon" icon="help" size={ 36 } />
 				<div className="help__help-teaser-text">
 					<span className="help__help-teaser-button-title">

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -128,10 +128,16 @@ const Help = React.createClass( {
 
 		return (
 			<HelpTeaserButton
+				onClick={ this.trackCoursesButtonClick }
 				href="/help/courses"
 				title={ this.translate( 'Courses' ) }
-				description={ this.translate( 'Learn how to make the most of your site with these courses and webinars' ) }/>
+				description={ this.translate( 'Learn how to make the most of your site with these courses and webinars' ) } />
 		);
+	},
+
+	trackCoursesButtonClick() {
+		const { isBusinessPlanUser } = this.props;
+		analytics.tracks.recordEvent( 'calypso_help_courses_click', { isBusinessPlanUser } );
 	},
 
 	getPlaceholders() {
@@ -178,14 +184,12 @@ export default connect(
 		const userId = getCurrentUserId( state );
 		const purchases = getUserPurchases( state, userId );
 		const isLoading = isFetchingUserPurchases( state );
-		const showCoursesTeaser = (
-			ownProps.isCoursesEnabled &&
-			purchases &&
-			!! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS )
-		);
+		const isBusinessPlanUser = purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS );
+		const showCoursesTeaser = ownProps.isCoursesEnabled && isBusinessPlanUser;
 
 		return {
 			userId,
+			isBusinessPlanUser,
 			showCoursesTeaser,
 			isLoading,
 			isEmailVerified,


### PR DESCRIPTION
This pull request adds tracks pings for the courses button at /help and the registration buttons at /help/courses. It also tracks page views segregated by `isBussinessPlanUser`

Note: This pull request also fixes a bug that caused the page view pings to happen twice for every page view 62333ea.

## How to test

### Business Plan user
1. Navigate to https://calypso.live/help?branch=add/help-courses-tracks-pings or http://calpso.dev:3000/help as a business plan user
2. Make sure your console is showing network traffic
3. Click on the "Courses" button
4. Notice that a tracks ping has been made and looks like below:
    
    ![screen shot 2016-08-29 at 10 18 15 pm](https://cloud.githubusercontent.com/assets/1854440/18073807/99c4ac4a-6e36-11e6-9b81-c804131ddb98.png)
5. Click on one of the register buttons.
6. Notice that a tracks ping has been made and looks like below:
    
    ![screen shot 2016-08-29 at 10 51 20 pm](https://cloud.githubusercontent.com/assets/1854440/18074518/302e254a-6e3b-11e6-9f35-5e2668df2145.png)


### Free user
1. Make sure your console is showing network traffic
2. Navigate to https://calypso.live/help/courses?branch=add/help-courses-tracks-pings or http://calpso.dev:3000/help/courses as a business plan user
3. Notice that a ping has been made and looks like below:
    
    ![screen shot 2016-08-29 at 10 22 37 pm](https://cloud.githubusercontent.com/assets/1854440/18074210/202a5076-6e39-11e6-92ee-bde7bd720985.png)




Test live: https://calypso.live/?branch=add/help-courses-tracks-pings