### PR TITLE
Plans: add one-click personal plan upgrade nudge

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -15,6 +15,7 @@
 @import 'blocks/comment-button/style';
 @import 'blocks/comments/style';
 @import 'blocks/dismissible-card/style';
+@import 'blocks/domain-to-plan-nudge/style';
 @import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';

--- a/client/blocks/domain-to-plan-nudge/README.md
+++ b/client/blocks/domain-to-plan-nudge/README.md
@@ -1,0 +1,34 @@
+Domain to Plan Nudge
+=========
+This is a upgrade nudge that targets users with a site that has a free plan,
+paid domain, and has a stored CC on file.
+
+#### How to use:
+
+```js
+
+import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
+
+render: function() {
+  return (
+    <div className="your-stuff">
+      <DomainToPlanNudge />
+    </div>
+  );
+}
+```
+
+## Props
+
+Below is a list of supported props.
+
+### `siteId`
+
+<table>
+	<tr><td>Type</td><td>Number</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>selected site</code></td></tr>
+</table>
+
+Check for the requirements above using this siteId, 
+otherwise we default to the currently selected site.

--- a/client/blocks/domain-to-plan-nudge/README.md
+++ b/client/blocks/domain-to-plan-nudge/README.md
@@ -1,6 +1,6 @@
 Domain to Plan Nudge
 =========
-This is a upgrade nudge that targets users with a site that has a free plan,
+This is an upgrade nudge that targets users with a site that has a free plan,
 paid domain, and has a stored CC on file.
 
 #### How to use:

--- a/client/blocks/domain-to-plan-nudge/docs/example.jsx
+++ b/client/blocks/domain-to-plan-nudge/docs/example.jsx
@@ -18,7 +18,8 @@ function DomainToPlanNudgeExample( { siteId } ) {
 			<h2>
 				<a href="/devdocs/blocks/domain-to-plan-nudge">Domain To Plan Nudge</a>
 			</h2>
-			{ siteId && <QuerySites siteId={ siteId } /> }
+			<p> Warning! Clicking on "Upgrade Now" will charge your stored credit card </p>
+			<QuerySites siteId={ siteId } />
 			<DomainToPlanNudge siteId={ siteId } />
 		</div>
 	);

--- a/client/blocks/domain-to-plan-nudge/docs/example.jsx
+++ b/client/blocks/domain-to-plan-nudge/docs/example.jsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import DomainToPlanNudge from '../';
+import { getCurrentUser } from 'state/current-user/selectors';
+import QuerySites from 'components/data/query-sites';
+
+function DomainToPlanNudgeExample( { siteId } ) {
+	return (
+		<div className="docs__design-assets-group">
+			<h2>
+				<a href="/devdocs/blocks/domain-to-plan-nudge">Domain To Plan Nudge</a>
+			</h2>
+			{ siteId && <QuerySites siteId={ siteId } /> }
+			<DomainToPlanNudge siteId={ siteId } />
+		</div>
+	);
+}
+
+const ConnectedDomainToPlanNudge = connect( ( state ) => {
+	const user = getCurrentUser( state );
+	return {
+		siteId: get( user, 'primary_blog', null )
+	};
+} )( DomainToPlanNudgeExample );
+
+ConnectedDomainToPlanNudge.displayName = 'DomainToPlanNudge';
+
+export default ConnectedDomainToPlanNudge;

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -6,6 +6,7 @@ import React, { PropTypes, Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -34,6 +35,7 @@ class DomainToPlanNudge extends Component {
 		super( ...arguments );
 		this.oneClickUpgrade = this.oneClickUpgrade.bind( this );
 		this.handleTransactionComplete = this.handleTransactionComplete.bind( this );
+		this.state = { isSubmitting: false };
 	}
 
 	static propTypes = {
@@ -50,9 +52,15 @@ class DomainToPlanNudge extends Component {
 			hasFreePlan;        //has a free wpcom plan
 	}
 
-	handleTransactionComplete( error ) {
+	handleTransactionComplete( error, data ) {
+		const { siteId } = this.props;
 		//TODO: match expected analytics calls
 		debug( 'transaction complete', error );
+		if ( error ) {
+			//TODO: show error notice
+			this.setState( { isSubmitting: false } );
+		}
+		page( `/checkout/thank-you/${ siteId }/${ data.receipt_id }` );
 	}
 
 	oneClickUpgrade() {
@@ -75,6 +83,7 @@ class DomainToPlanNudge extends Component {
 
 		debug( 'purchasing with', cart, transaction );
 
+		this.setState( { isSubmitting: true } );
 		submitTransaction( { cart, transaction }, this.handleTransactionComplete );
 	}
 
@@ -83,6 +92,7 @@ class DomainToPlanNudge extends Component {
 			return null;
 		}
 
+		const { isSubmitting } = this.state;
 		const { translate, storedCard } = this.props;
 
 		return (
@@ -155,10 +165,12 @@ class DomainToPlanNudge extends Component {
 					<div className="domain-to-plan-nudge__upgrade-group">
 						<Button
 							onClick={ this.oneClickUpgrade }
-							disabled={ ! storedCard }
+							disabled={ ! storedCard || isSubmitting }
 							primary
 						>
-							{ translate( 'Upgrade Now for xx.xx' ) }
+							{
+								isSubmitting ? translate( 'Completing your purchase' ) : translate( 'Upgrade Now for xx.xx' )
+							}
 						</Button>
 						<div className="domain-to-plan-nudge__credit-card-info">
 							{ translate( 'Using credit card ****%s', { args: storedCard.card } ) }

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { get, forEach } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSite, isCurrentSitePlan } from 'state/sites/selectors';
+import { plansList, PLAN_FREE, PLAN_PERSONAL } from 'lib/plans/constants';
+import storeTransactions from 'lib/store-transactions';
+import upgradesActions from 'lib/upgrades/actions';
+import { getStoredCards } from 'state/stored-cards/selectors';
+import QueryStoredCards from 'components/data/query-stored-cards';
+import TransactionStepsMixin from 'my-sites/upgrades/checkout/transaction-steps-mixin';
+import { fillInAllCartItemAttributes } from 'lib/cart-values';
+import { add, remove, getItemForPlan } from 'lib/cart-values/cart-items';
+import { submitTransaction } from 'lib/upgrades/actions/checkout';
+
+//use the redux store instead:
+import productsListFactory from 'lib/products-list';
+const productsList = productsListFactory();
+
+const DomainToPlanNudge = React.createClass( {
+
+	//verify if we need this mixin
+	mixins: [ TransactionStepsMixin ],
+
+	propTypes: {
+		cart: PropTypes.object,       //from CheckoutData
+		hasFreePlan: PropTypes.bool,
+		site: PropTypes.object,
+		siteId: PropTypes.number,
+		translate: PropTypes.func,
+		transaction: PropTypes.object //from CheckoutData
+	},
+
+	componentWillMount: function() {
+		upgradesActions.resetTransaction();
+	},
+
+	isVisible() {
+		const { site, hasFreePlan } = this.props;
+		return site &&			//site exists
+			site.wpcom_url &&   //has a mapped domain
+			hasFreePlan;        //has a free wpcom plan
+	},
+
+	oneClickUpgrade() {
+		//we might not need checkout data, since we use a fresh transaction
+		//check free-trials.js for example
+		const { storedCard, cart } = this.props;
+		const newPayment = storeTransactions.storedCardPayment( storedCard );
+		const transaction = {
+			payment: newPayment
+		};
+
+		//clear cart (maybe use a temp cart instead via emptyCart ?)
+		let newCart = cart;
+		forEach( cart.products, ( item ) => {
+			newCart = remove( item )( newCart );
+		} );
+
+		const personalCartItem = getItemForPlan( { product_slug: PLAN_PERSONAL } );
+		newCart = add( personalCartItem )( newCart );
+
+		newCart = fillInAllCartItemAttributes( newCart, productsList.get() );
+
+		console.log( 'purchasing with', newCart, transaction );
+
+		//fix analytics error
+		submitTransaction( { cart, transaction }, ( error ) => {
+			console.log( 'transaction done for', cart, transaction, error );
+		} );
+	},
+
+	render() {
+		if ( ! this.isVisible() ) {
+			return null;
+		}
+
+		const { siteId, translate } = this.props;
+		return (
+			<Card>
+				<QueryStoredCards />
+				<h3>{ translate( 'Upgrade to a Personal Plan and Save!' ) }</h3>
+				<Button
+					onClick={ this.oneClickUpgrade }>
+					{ translate( 'One Click Checkout' ) }
+				</Button>
+				<Button href={ `/checkout/${ siteId }/personal` }>
+					{ translate( 'Change CC' ) }
+				</Button>
+			</Card>
+		);
+	}
+} );
+
+export default connect(
+	( state, props ) => {
+		const siteId = props.siteId || getSelectedSiteId( state );
+		return {
+			hasFreePlan: isCurrentSitePlan(
+				state,
+				siteId,
+				plansList[ PLAN_FREE ].getProductId()
+			),
+			storedCard: get( getStoredCards( state ), '0' ),
+			site: getSite( state, siteId ),
+			siteId
+		};
+	},
+	{
+		recordTracksEvent
+	}
+)( localize( DomainToPlanNudge ) );

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -53,10 +53,22 @@ class DomainToPlanNudge extends Component {
 	}
 
 	static propTypes = {
+		discountedRawPrice: PropTypes.number,
+		errorNotice: PropTypes.func,
 		hasFreePlan: PropTypes.bool,
+		infoNotice: PropTypes.func,
+		productId: PropTypes.number,
+		productSlug: PropTypes.string,
+		rawDiscount: PropTypes.number,
+		rawPrice: PropTypes.number,
+		recordTracksEvent: PropTypes.func,
+		removeNotice: PropTypes.func,
 		site: PropTypes.object,
 		siteId: PropTypes.number,
-		translate: PropTypes.func
+		sitePlans: PropTypes.array,
+		storedCard: PropTypes.object,
+		translate: PropTypes.func,
+		userCurrency: PropTypes.string
 	};
 
 	isSiteEligible() {
@@ -307,21 +319,21 @@ export default connect(
 			productId = plansList[ PLAN_PERSONAL ].getProductId();
 
 		return {
-			siteId,
-			productSlug,
-			productId,
+			discountedRawPrice: getPlanDiscountedRawPrice( state, siteId, productSlug ),
 			hasFreePlan: isCurrentSitePlan(
 				state,
 				siteId,
 				plansList[ PLAN_FREE ].getProductId()
 			),
-			storedCard: get( getStoredCards( state ), '0' ),
-			site: getSite( state, siteId ),
-			userCurrency: getCurrentUserCurrencyCode( state ), //populated by either plans endpoint
-			rawPrice: getPlanRawPrice( state, productId ),
-			discountedRawPrice: getPlanDiscountedRawPrice( state, siteId, productSlug ),
+			productId,
+			productSlug,
 			rawDiscount: getPlanRawDiscount( state, siteId, productSlug ),
-			sitePlans: getPlansBySiteId( state, siteId )
+			rawPrice: getPlanRawPrice( state, productId ),
+			site: getSite( state, siteId ),
+			siteId,
+			sitePlans: getPlansBySiteId( state, siteId ),
+			storedCard: get( getStoredCards( state ), '0' ),
+			userCurrency: getCurrentUserCurrencyCode( state ) //populated by either plans endpoint
 		};
 	},
 	{

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -29,8 +29,8 @@ import Gridicon from 'components/gridicon';
 import { errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { recordOrder } from 'lib/analytics/ad-tracking';
-import { getPlanRawPrice } from 'state/plans/selectors';
 import {
+	getSitePlanRawPrice,
 	getPlanDiscountedRawPrice,
 	getPlanRawDiscount,
 	getPlansBySiteId
@@ -65,7 +65,7 @@ class DomainToPlanNudge extends Component {
 		removeNotice: PropTypes.func,
 		site: PropTypes.object,
 		siteId: PropTypes.number,
-		sitePlans: PropTypes.array,
+		sitePlans: PropTypes.object,
 		storedCard: PropTypes.object,
 		translate: PropTypes.func,
 		userCurrency: PropTypes.string
@@ -175,11 +175,7 @@ class DomainToPlanNudge extends Component {
 		submitTransaction( { cart, transaction }, this.handleTransactionComplete );
 	}
 
-	render() {
-		if ( ! this.isSiteEligible() ) {
-			return null;
-		}
-
+	renderCard() {
 		const { isSubmitting } = this.state;
 
 		const {
@@ -195,13 +191,10 @@ class DomainToPlanNudge extends Component {
 
 		return (
 			<DismissibleCard
-				className="domain-to-plan-nudge"
+				className="domain-to-plan-nudge__card"
 				preferenceName="domain-to-plan-nudge"
 				temporary
 			>
-				<QueryStoredCards />
-				{ siteId && <QuerySitePlans siteId={ siteId } /> }
-
 				<div className="domain-to-plan-nudge__header">
 					<div className="domain-to-plan-nudge__header-icon">
 						<PlanIcon plan={ productSlug } />
@@ -310,6 +303,18 @@ class DomainToPlanNudge extends Component {
 			</DismissibleCard>
 		);
 	}
+
+	render() {
+		const { siteId } = this.props;
+
+		return (
+			<div className="domain-to-plan-nudge">
+				<QueryStoredCards />
+				<QuerySitePlans siteId={ siteId } />
+				{ this.isSiteEligible() && this.renderCard() }
+			</div>
+		);
+	}
 }
 
 export default connect(
@@ -327,8 +332,8 @@ export default connect(
 			),
 			productId,
 			productSlug,
-			rawDiscount: getPlanRawDiscount( state, siteId, productSlug ),
-			rawPrice: getPlanRawPrice( state, productId ),
+			rawDiscount: getPlanRawDiscount( state, siteId, productSlug ) || 0,
+			rawPrice: getSitePlanRawPrice( state, siteId, productSlug ),
 			site: getSite( state, siteId ),
 			siteId,
 			sitePlans: getPlansBySiteId( state, siteId ),

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -11,8 +11,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import Button from 'components/button';
+import DismissibleCard from 'blocks/dismissible-card';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isCurrentSitePlan } from 'state/sites/selectors';
@@ -176,20 +176,23 @@ class DomainToPlanNudge extends Component {
 		const { isSubmitting } = this.state;
 
 		const {
-			translate,
-			storedCard,
-			rawPrice,
 			discountedRawPrice,
+			productSlug,
 			rawDiscount,
+			rawPrice,
 			siteId,
-			userCurrency,
-			productSlug
+			storedCard,
+			translate,
+			userCurrency
 		} = this.props;
 
 		return (
-			<Card className="domain-to-plan-nudge">
+			<DismissibleCard
+				className="domain-to-plan-nudge"
+				preferenceName="domain-to-plan-nudge"
+				temporary
+			>
 				<QueryStoredCards />
-
 				{ siteId && <QuerySitePlans siteId={ siteId } /> }
 
 				<div className="domain-to-plan-nudge__header">
@@ -228,7 +231,7 @@ class DomainToPlanNudge extends Component {
 										icon="checkmark"
 										size={ 24 }
 									/>
-									{ translate( 'Upload up to 3GB of photos and videos' ) }
+									{ translate( 'Upload up to 3GB of photos and documents' ) }
 								</div>
 							</li>
 							<li>
@@ -283,7 +286,7 @@ class DomainToPlanNudge extends Component {
 						</div>
 					</div>
 				</div>
-			</Card>
+			</DismissibleCard>
 		);
 	}
 }

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -21,7 +21,7 @@ import { storedCardPayment } from 'lib/store-transactions';
 import { getStoredCards } from 'state/stored-cards/selectors';
 import QueryStoredCards from 'components/data/query-stored-cards';
 import { emptyCart } from 'lib/cart-values';
-import { add } from 'lib/cart-values/cart-items';
+import { add as addCartItem } from 'lib/cart-values/cart-items';
 import { submitTransaction } from 'lib/upgrades/actions/checkout';
 import PlanPrice from 'my-sites/plan-price';
 import PlanIcon from 'components/plans/plan-icon';
@@ -159,7 +159,7 @@ class DomainToPlanNudge extends Component {
 		let cart = emptyCart( siteId, { temporary: true } );
 
 		const personalCartItem = this.getCartItem();
-		cart = add( personalCartItem )( cart );
+		cart = addCartItem( personalCartItem )( cart );
 
 		debug( 'purchasing with', cart, transaction );
 

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -22,6 +22,9 @@ import QueryStoredCards from 'components/data/query-stored-cards';
 import { emptyCart } from 'lib/cart-values';
 import { add } from 'lib/cart-values/cart-items';
 import { submitTransaction } from 'lib/upgrades/actions/checkout';
+import PlanPrice from 'my-sites/plan-price';
+import PlanIcon from 'components/plans/plan-icon';
+import Gridicon from 'components/gridicon';
 
 const debug = debugFactory( 'calypso:domain-to-plan-nudge' );
 
@@ -80,19 +83,88 @@ class DomainToPlanNudge extends Component {
 			return null;
 		}
 
-		const { siteId, translate, storedCard } = this.props;
+		const { translate, storedCard } = this.props;
+
 		return (
-			<Card>
+			<Card className="domain-to-plan-nudge">
 				<QueryStoredCards />
-				<h3>{ translate( 'Upgrade to a Personal Plan and Save!' ) }</h3>
-				<Button
-					onClick={ this.oneClickUpgrade }
-					disabled={ ! storedCard } >
-					{ translate( 'One Click Checkout' ) }
-				</Button>
-				<Button href={ `/checkout/${ siteId }/personal` }>
-					{ translate( 'Change CC' ) }
-				</Button>
+
+				<div className="domain-to-plan-nudge__header">
+					<div className="domain-to-plan-nudge__header-icon">
+						<PlanIcon plan="personal-bundle" />
+					</div>
+					<div className="domain-to-plan-nudge__header-copy">
+						<h3 className="domain-to-plan-nudge__header-title">
+							{ translate( 'Upgrade to a Personal Plan and Save!' ) }
+						</h3>
+						<ul className="domain-to-plan-nudge__header-features">
+							<li>
+								<div className="domain-to-plan-nudge__header-features-item">
+									<Gridicon
+										className="domain-to-plan-nudge__header-features-item-checkmark"
+										icon="checkmark"
+										size="22"
+									/>
+									{ translate( 'Remove all WordPress.com advertising from your website' ) }
+								</div>
+							</li>
+							<li>
+								<div className="domain-to-plan-nudge__header-features-item">
+									<Gridicon
+										className="domain-to-plan-nudge__header-features-item-checkmark"
+										icon="checkmark"
+										size="22"
+									/>
+									{ translate( 'Get high quality live chat and priority email support' ) }
+								</div>
+							</li>
+							<li>
+								<div className="domain-to-plan-nudge__header-features-item">
+									<Gridicon
+										className="domain-to-plan-nudge__header-features-item-checkmark"
+										icon="checkmark"
+										size="22"
+									/>
+									{ translate( 'Upload up to 3GB of photos and videos' ) }
+								</div>
+							</li>
+							<li>
+								<div className="domain-to-plan-nudge__header-features-item">
+									<Gridicon
+										className="domain-to-plan-nudge__header-features-item-checkmark"
+										icon="checkmark"
+										size="22"
+									/>
+									{ translate( 'Bundled with your domain for the best value!' ) }
+								</div>
+							</li>
+						</ul>
+					</div>
+				</div>
+				<div className="domain-to-plan-nudge__actions-group">
+					<div className="domain-to-plan-nudge__plan-price-group">
+						<div className="domain-to-plan-nudge__discount-percentage">
+							Save 25%
+						</div>
+						<PlanPrice rawPrice="35.88" original />
+						<PlanPrice rawPrice="29.88" discounted />
+						<div className="domain-to-plan-nudge__plan-price-timeframe">
+							{ translate( 'for one year subscription' ) }
+						</div>
+					</div>
+					<div className="domain-to-plan-nudge__upgrade-group">
+						<Button
+							onClick={ this.oneClickUpgrade }
+							disabled={ ! storedCard }
+							primary
+						>
+							{ translate( 'Upgrade Now for xx.xx' ) }
+						</Button>
+						<div className="domain-to-plan-nudge__credit-card-info">
+							{ translate( 'Using credit card ****%s', { args: storedCard.card } ) }
+						</div>
+					</div>
+				</div>
 			</Card>
 		);
 	}

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -59,7 +59,7 @@ class DomainToPlanNudge extends Component {
 		translate: PropTypes.func
 	};
 
-	isVisible() {
+	isSiteEligible() {
 		const {
 			site,
 			hasFreePlan,
@@ -164,7 +164,7 @@ class DomainToPlanNudge extends Component {
 	}
 
 	render() {
-		if ( ! this.isVisible() ) {
+		if ( ! this.isSiteEligible() ) {
 			return null;
 		}
 

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -37,6 +37,7 @@ import {
 } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
 import formatCurrency from 'lib/format-currency';
+import { canCurrentUser } from 'state/current-user/selectors';
 
 const debug = debugFactory( 'calypso:domain-to-plan-nudge' );
 
@@ -73,16 +74,18 @@ class DomainToPlanNudge extends Component {
 
 	isSiteEligible() {
 		const {
-			site,
+			canManage,
 			hasFreePlan,
+			rawPrice,
+			site,
 			sitePlans,
-			storedCard,
-			rawPrice
+			storedCard
 		} = this.props;
 
 		return sitePlans.hasLoadedFromServer &&
-			storedCard &&
-			rawPrice &&
+			storedCard &&     //has a payment option
+			canManage &&      //can manage site
+			rawPrice &&       //plans info has loaded
 			site &&           //site exists
 			site.wpcom_url && //has a mapped domain
 			hasFreePlan;      //has a free wpcom plan
@@ -324,6 +327,7 @@ export default connect(
 			productId = plansList[ PLAN_PERSONAL ].getProductId();
 
 		return {
+			canManage: canCurrentUser( state, siteId, 'manage_options' ),
 			discountedRawPrice: getPlanDiscountedRawPrice( state, siteId, productSlug ),
 			hasFreePlan: isCurrentSitePlan(
 				state,

--- a/client/blocks/domain-to-plan-nudge/style.scss
+++ b/client/blocks/domain-to-plan-nudge/style.scss
@@ -39,17 +39,27 @@
 }
 
 .domain-to-plan-nudge__actions-group {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
 	margin: 0 -24px -24px;
-	padding: 13px 24px;
+	padding: 24px;
 	box-shadow: 0 -1px 0 0 transparentize( lighten( $gray, 20% ), .5 );
+
+	@include breakpoint( ">960px" ) {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		padding: 13px 24px;
+	}
+
 }
 
 .domain-to-plan-nudge__plan-price-group {
 	display: flex;
 	align-items: center;
+
+	@include breakpoint( "<960px" ) {
+		justify-content: center;
+	}
 }
 
 .domain-to-plan-nudge__plan-price-timeframe,
@@ -59,21 +69,16 @@
 	white-space: nowrap;
 }
 
-.domain-to-plan-nudge__credit-card-info {
-	margin-top: 2px;
-	text-align: right;
-}
-
-.domain-to-plan-nudge__discount-percentage {
+.domain-to-plan-nudge__discount-value {
 	font-size: 12px;
 	text-transform: uppercase;
 	border-radius: 3px 0 0 3px;
 	background-color: #4ab866;
-	width: 74px;
+	width: 68px;
 	height: 18px;
 	color: $white;
 	letter-spacing: 1px;
-	padding: 3px 0;
+	padding: 3px 0 3px 12px;
 	text-align: right;
 	position: relative;
 	margin-right: 24px;
@@ -88,5 +93,21 @@
 		position: absolute;
 		top: 0;
 		right: -14px;
+	}
+}
+
+.domain-to-plan-nudge__upgrade-group {
+	@include breakpoint( "<960px" ) {
+		text-align: center;
+		margin-top: 30px;
+	}
+}
+
+.domain-to-plan-nudge__credit-card-info {
+	margin-top: 2px;
+	text-align: center;
+
+	@include breakpoint( ">960px" ) {
+		text-align: right;
 	}
 }

--- a/client/blocks/domain-to-plan-nudge/style.scss
+++ b/client/blocks/domain-to-plan-nudge/style.scss
@@ -1,0 +1,92 @@
+.domain-to-plan-nudge.card {
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% ), 0 -3px 0 0 $alert-yellow;
+}
+
+.domain-to-plan-nudge__header {
+	display: flex;
+}
+
+.domain-to-plan-nudge__header-icon {
+	width: 58px;
+	height: 58px;
+}
+
+.domain-to-plan-nudge__header-copy {
+	margin-left: 20px;
+}
+
+.domain-to-plan-nudge__header-title {
+	font-size: 22px;
+	color: $blue-wordpress;
+}
+
+.domain-to-plan-nudge__header-features {
+	margin: 14px 0 30px 0;
+	list-style: none;
+}
+
+.domain-to-plan-nudge__header-features-item {
+	position: relative;
+	padding: 8px 0 0 28px;
+}
+
+.domain-to-plan-nudge__header-features-item-checkmark.gridicon {
+	position: absolute;
+	left: 0;
+	top: 8px;
+	fill: $alert-green;
+}
+
+.domain-to-plan-nudge__actions-group {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin: 0 -24px -24px;
+	padding: 13px 24px;
+	box-shadow: 0 -1px 0 0 transparentize( lighten( $gray, 20% ), .5 );
+}
+
+.domain-to-plan-nudge__plan-price-group {
+	display: flex;
+	align-items: center;
+}
+
+.domain-to-plan-nudge__plan-price-timeframe,
+.domain-to-plan-nudge__credit-card-info {
+	font-size: 12px;
+	color: $gray;
+	white-space: nowrap;
+}
+
+.domain-to-plan-nudge__credit-card-info {
+	margin-top: 2px;
+	text-align: right;
+}
+
+.domain-to-plan-nudge__discount-percentage {
+	font-size: 12px;
+	text-transform: uppercase;
+	border-radius: 3px 0 0 3px;
+	background-color: #4ab866;
+	width: 74px;
+	height: 18px;
+	color: $white;
+	letter-spacing: 1px;
+	padding: 3px 0;
+	text-align: right;
+	position: relative;
+	margin-right: 24px;
+
+	&:after {
+		content:"";
+		width: 0;
+		height: 0;
+		border-left: 14px solid $alert-green;
+		border-top: 12px solid transparent;
+		border-bottom: 12px solid transparent;
+		position: absolute;
+		top: 0;
+		right: -14px;
+	}
+}

--- a/client/blocks/domain-to-plan-nudge/style.scss
+++ b/client/blocks/domain-to-plan-nudge/style.scss
@@ -68,18 +68,21 @@
 	color: $gray;
 	white-space: nowrap;
 }
+.domain-to-plan-nudge__credit-card-info-link,
+.domain-to-plan-nudge__credit-card-info-link:visited {
+	color: $gray;
+}
 
 .domain-to-plan-nudge__discount-value {
 	font-size: 12px;
 	text-transform: uppercase;
 	border-radius: 3px 0 0 3px;
 	background-color: #4ab866;
-	width: 68px;
 	height: 18px;
 	color: $white;
 	letter-spacing: 1px;
 	padding: 3px 0 3px 12px;
-	text-align: right;
+	text-align: left;
 	position: relative;
 	margin-right: 24px;
 

--- a/client/blocks/domain-to-plan-nudge/style.scss
+++ b/client/blocks/domain-to-plan-nudge/style.scss
@@ -1,4 +1,4 @@
-.domain-to-plan-nudge.card {
+.domain-to-plan-nudge__card.card {
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% ), 0 -3px 0 0 $alert-yellow;
 }

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -44,6 +44,7 @@ import PlanThankYouCard from 'blocks/plan-thank-you-card/docs/example';
 import DismissibleCard from 'blocks/dismissible-card/docs/example';
 import PostEditButton from 'blocks/post-edit-button/docs/example';
 import ReaderAvatar from 'blocks/reader-avatar/docs/example';
+import DomainToPlanNudge from 'blocks/domain-to-plan-nudge/docs/example';
 
 export default React.createClass( {
 
@@ -109,6 +110,7 @@ export default React.createClass( {
 					<PlanThankYouCard />
 					<DismissibleCard />
 					<ReaderAvatar />
+					<DomainToPlanNudge />
 				</Collection>
 			</div>
 		);

--- a/client/lib/upgrades/actions/checkout.js
+++ b/client/lib/upgrades/actions/checkout.js
@@ -43,7 +43,7 @@ function submitTransaction( { cart, transaction }, onComplete ) {
 		} );
 
 		if ( onComplete && step.name === 'received-wpcom-response' ) {
-			onComplete( step.error );
+			onComplete( step.error, step.data );
 		}
 	} );
 }

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -23,6 +23,8 @@ import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
 import Main from 'components/main';
 import StatsFirstView from '../stats-first-view';
+import CheckoutData from 'components/data/checkout';
+import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 
 export default React.createClass( {
 	displayName: 'StatsInsights',
@@ -77,6 +79,9 @@ export default React.createClass( {
 			<Main>
 				<StatsFirstView />
 				<SidebarNavigation />
+				<CheckoutData>
+					<DomainToPlanNudge />
+				</CheckoutData>
 				<StatsNavigation section="insights" site={ site } />
 				<div id="my-stats-content">
 					<PostingActivity />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -23,7 +23,6 @@ import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
 import Main from 'components/main';
 import StatsFirstView from '../stats-first-view';
-import CheckoutData from 'components/data/checkout';
 import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 
 export default React.createClass( {
@@ -79,9 +78,7 @@ export default React.createClass( {
 			<Main>
 				<StatsFirstView />
 				<SidebarNavigation />
-				<CheckoutData>
-					<DomainToPlanNudge />
-				</CheckoutData>
+				<DomainToPlanNudge />
 				<StatsNavigation section="insights" site={ site } />
 				<div id="my-stats-content">
 					<PostingActivity />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -23,7 +23,6 @@ import LatestPostSummary from '../post-performance';
 import DomainTip from 'my-sites/domain-tip';
 import Main from 'components/main';
 import StatsFirstView from '../stats-first-view';
-import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 
 export default React.createClass( {
 	displayName: 'StatsInsights',
@@ -78,7 +77,6 @@ export default React.createClass( {
 			<Main>
 				<StatsFirstView />
 				<SidebarNavigation />
-				<DomainToPlanNudge />
 				<StatsNavigation section="insights" site={ site } />
 				<div id="my-stats-content">
 					<PostingActivity />


### PR DESCRIPTION
This PR is part of #7329 and adds an upgrade nudge that allows users with a domain and a free plan to upgrade to the Personal Plan using a stored credit card. All the major functionality is here in this PR, but the component needs additional polish. I want to get this in as a WIP, and follow up with smaller PRs.

Functionality wise:
- Clicking on the 'x' will close the nudge for a page load
- Clicking on "Upgrade now" will charge your credit card, upgrade your site to a Personal Plan, and redirect you to the checkout thank you page
- Any errors during the transaction should display as a global error notice
- Clicking on the credit card info, will take you to checkout with a personal plan in cart. This should allow users to choose a different CC

<img width="753" alt="screen shot 2016-09-07 at 3 12 12 pm" src="https://cloud.githubusercontent.com/assets/1270189/18330679/dbdc79bc-750e-11e6-866d-694781cb0627.png">

A few things to note:
- Discounts are still incorrect from domains-only to Personal Plan upgrade. This should be fixed by D2633-code
- I've updated the signature in `client/lib/upgrades/actions/checkout` to return errors _and_ data on the complete callback
- We use a temporary cart to handle the upgrade. If you click on the upgrade button, don't forget to cancel your sub and refund yourself.
- Default styling on the devdocs page will override styles on this component

## Testing Instructions
- Verify that we have no functional changes, since we have no usages yet

Testing is a bit tricky, we'll need the following things:
- A site with a _free_ plan, but has a _paid_ domain
- Make sure your user has a stored credit card
- Set this site as your primary site
- Clear out your Calypso persisted state. Chome dev tools > Application > IndexedDB > Calypso
- Visit http://calypso.localhost:3000/devdocs/blocks/domain-to-plan-nudge
- Clicking on the button should take us to the checkout thank you page
- This _will_ charge your stored CC. If you want to avoid this, comment out the `submitTransaction` call, and directly call the success handler instead.

cc @rralian @lamosty @artpi @retrofox @obenland 

Test live: https://calypso.live/?branch=add/one-click-upgrade