### PR TITLE
Enable the /help/courses page on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,6 +27,7 @@
 		"guided-tours/main": false,
 		"guided-tours/themes": true,
 		"help": true,
+		"help/courses": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,


### PR DESCRIPTION
This pull request enables /help/course on wpcalypso