### PR TITLE
Stats: add rel=noopener to stats list actions.

### DIFF
--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -34,7 +34,7 @@ class StatsActionLink extends PureComponent {
 				<a href={ href }
 					onClick={ this.onClick }
 					target="_blank"
-					rel="noopener"
+					rel="noopener noreferrer"
 					className="module-content-list-item-action-wrapper"
 					title={ translate( 'View content in a new window', {
 						textOnly: true, context: 'Stats action tooltip: View content in a new window'

--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -1,32 +1,55 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { PureComponent, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
-	Gridicon = require( 'components/gridicon' );
+import analytics from 'lib/analytics';
+import Gridicon from 'components/gridicon';
 
-module.exports = React.createClass( {
-	displayName: 'StatsActionLink',
+class StatsActionLink extends PureComponent {
+	static propTypes = {
+		href: PropTypes.string,
+		moduleName: PropTypes.string,
+		translate: PropTypes.func,
+	};
 
-	clickHandler: function( event ) {
+	constructor( props ) {
+		super( props );
+		this.onClick = this.onClick.bind( this );
+	}
+
+	onClick( event ) {
 		event.stopPropagation();
-		event.preventDefault();
 		analytics.ga.recordEvent( 'Stats', 'Clicked on External Link in ' + this.props.moduleName + ' List Action Menu' );
-		window.open( this.props.href );
-	},
+	}
 
-	render: function() {
+	render() {
+		const { href, translate } = this.props;
 		return (
-			<li className='module-content-list-item-action'>
-				<a href={ this.props.href } onClick={ this.clickHandler } target="_blank" className='module-content-list-item-action-wrapper' title={ this.translate( 'View content in a new window', { textOnly: true, context: 'Stats action tooltip: View content in a new window' } ) } aria-label={ this.translate( 'View content in a new window', { textOnly: true, context: 'Stats ARIA label: View content in new window action' } ) } >
+			<li className="module-content-list-item-action">
+				<a href={ href }
+					onClick={ this.onClick }
+					target="_blank"
+					rel="noopener"
+					className="module-content-list-item-action-wrapper"
+					title={ translate( 'View content in a new window', {
+						textOnly: true, context: 'Stats action tooltip: View content in a new window'
+					} ) }
+					aria-label={ translate( 'View content in a new window', {
+						textOnly: true, context: 'Stats ARIA label: View content in new window action'
+					} ) } >
 					<Gridicon icon="external" size={ 18 } />
-					<span className='module-content-list-item-action-label module-content-list-item-action-label-view'>{ this.translate( 'View', { context: 'Stats: List item action to view content' } ) }</span>
+					<span className="module-content-list-item-action-label module-content-list-item-action-label-view">
+						{ translate( 'View', { context: 'Stats: List item action to view content' } ) }
+					</span>
 				</a>
 			</li>
 		);
 	}
-} );
+}
+
+export default localize( StatsActionLink );


### PR DESCRIPTION
This branch adds `rel=noopener` to external links in stats lists.  While doing the update, I updated the component to ES6 syntax and removed `React.createClass`.

__To Test__
- Open up a site stats page for a period ( day, week, month etc )
- Click on an external link icon under Posts & Pages
- Verify the page or post opens in a new tab and the calypso page remains the same

/cc @bluefuton 

Test live: https://calypso.live/?branch=update/stats/noopener