### PR TITLE
Reader: Fix gravatar/timestamp alignment in full-post comments

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -179,9 +179,13 @@
 
 	.gravatar {
 		position: absolute;
-			top: 1px;
+			top: 14px;
 			left: -41px;
 		border-radius: 48px;
+
+		@include breakpoint( "<480px" ) {
+			top: 12px;
+		}
 	}
 }
 
@@ -219,7 +223,11 @@ a.comments__comment-username {
 }
 
 .comments__comment-timestamp {
-	margin-top: -6px;
+	margin-top: -8px;
+
+	@include breakpoint( "<480px" ) {
+		margin-top: -4px;
+	}
 }
 
 .comments__comment-timestamp a {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -174,7 +174,7 @@
 }
 
 .comments__comment-author {
-	font-weight: bold;
+	font-weight: 600;
 	color: darken( $gray, 30% );
 
 	.gravatar {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/7667

**Before:**
![screenshot 2016-08-25 19 56 59](https://cloud.githubusercontent.com/assets/4924246/17992629/19a99524-6afe-11e6-9ecf-eb383e263bbf.png)

**After:**
![screenshot 2016-08-25 19 57 21](https://cloud.githubusercontent.com/assets/4924246/17992635/25df61f2-6afe-11e6-921b-1f1dff235917.png)

/cc @fraying 

Test live: https://calypso.live/?branch=fix/reader/comment-align-gravatar