### PR TITLE
Components: Add expired date error handling for Credit Card form

### DIFF
--- a/client/lib/credit-card-details/test/validation.js
+++ b/client/lib/credit-card-details/test/validation.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { validateCardDetails } from '../validation';
+
+describe( 'validation', function() {
+	const validCard = {
+		name: 'John Doe',
+		number: '4111111111111111',
+		'expiration-date': '01/' + moment().add( 1, 'years' ).format( 'YY' ),
+		cvv: '111',
+		country: 'US',
+		'postal-code': '90210'
+	};
+
+	describe( '#validateCardDetails', () => {
+		it( 'should return no errors when card is valid', function() {
+			const result = validateCardDetails( validCard );
+
+			expect( result ).to.be.eql( { errors: {} } );
+		} );
+
+		it( 'should return error when card has expiration date in the past', function() {
+			const expiredCard = { ...validCard, 'expiration-date': '01/01' };
+
+			const result = validateCardDetails( expiredCard );
+
+			expect( result ).to.be.eql( {
+				errors: {
+					'expiration-date': [ 'Credit card expiration date is invalid' ]
+				}
+			} );
+		} );
+	} );
+} );

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -72,14 +72,27 @@ validators.validCreditCardNumber = creditCardValidator( 'validCardNumber' );
 validators.validCvvNumber = creditCardValidator( 'validCvc' );
 
 validators.validExpirationDate = creditCardValidator(
+	'notExpired',
 	'validExpirationMonth',
-	'validExpirationYear'
+	'validExpirationYear',
 );
+
+validators.required = {
+	isValid: function( value ) {
+		return ! isEmpty( value );
+	},
+
+	error: function( description ) {
+		return i18n.translate( 'Missing required %(description)s field', {
+			args: { description: description }
+		} );
+	}
+};
 
 function validateCreditCard( cardDetails ) {
 	var expirationDate = cardDetails[ 'expiration-date' ] || '/',
 		expirationMonth = parseInt( expirationDate.split( '/' )[0], 10 ),
-		expirationYear = parseInt( expirationDate.split( '/' )[1], 10 );
+		expirationYear = 2000 + parseInt( expirationDate.split( '/' )[1], 10 );
 
 	return creditcards.validate( {
 		number: cardDetails.number,
@@ -102,6 +115,10 @@ function creditCardValidator( /* validationProperties... */ ) {
 			validationResult = validateCreditCard( cardDetails );
 
 			return validationProperties.every( function( property ) {
+				if ( property === 'notExpired' ) {
+					return ! validationResult[ 'expired' ]
+				}
+
 				return validationResult[ property ];
 			} );
 		},

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-var creditcards = require( 'creditcards' ),
-	compact = require( 'lodash/compact' ),
-	isArray = require( 'lodash/isArray' ),
-	isEmpty = require( 'lodash/isEmpty' ),
-	toArray = require( 'lodash/toArray' ),
-	inRange = require( 'lodash/inRange' ),
-	capitalize = require( 'lodash/capitalize' ),
-	i18n = require( 'i18n-calypso' );
+import creditcards from 'creditcards';
+import {
+	capitalize,
+	compact,
+	inRange,
+	isArray,
+	isEmpty
+} from 'lodash';
+import i18n from 'i18n-calypso';
 
 function creditCardFieldRules() {
 	return {
@@ -53,7 +54,7 @@ function creditCardFieldRules() {
 	};
 }
 
-var validators = {};
+const validators = {};
 
 validators.required = {
 	isValid: function( value ) {
@@ -77,22 +78,10 @@ validators.validExpirationDate = creditCardValidator(
 	'validExpirationYear',
 );
 
-validators.required = {
-	isValid: function( value ) {
-		return ! isEmpty( value );
-	},
-
-	error: function( description ) {
-		return i18n.translate( 'Missing required %(description)s field', {
-			args: { description: description }
-		} );
-	}
-};
-
 function validateCreditCard( cardDetails ) {
-	var expirationDate = cardDetails[ 'expiration-date' ] || '/',
-		expirationMonth = parseInt( expirationDate.split( '/' )[0], 10 ),
-		expirationYear = 2000 + parseInt( expirationDate.split( '/' )[1], 10 );
+	const expirationDate = cardDetails[ 'expiration-date' ] || '/',
+		expirationMonth = parseInt( expirationDate.split( '/' )[ 0 ], 10 ),
+		expirationYear = 2000 + parseInt( expirationDate.split( '/' )[ 1 ], 10 );
 
 	return creditcards.validate( {
 		number: cardDetails.number,
@@ -102,21 +91,18 @@ function validateCreditCard( cardDetails ) {
 	} );
 }
 
-function creditCardValidator( /* validationProperties... */ ) {
-	var validationProperties = toArray( arguments );
-
+function creditCardValidator( ...validationProperties ) {
 	return {
 		isValid: function( value, cardDetails ) {
-			var validationResult;
 			if ( ! value ) {
 				return false;
 			}
 
-			validationResult = validateCreditCard( cardDetails );
+			const validationResult = validateCreditCard( cardDetails );
 
 			return validationProperties.every( function( property ) {
 				if ( property === 'notExpired' ) {
-					return ! validationResult[ 'expired' ]
+					return ! validationResult.expired;
 				}
 
 				return validationResult[ property ];
@@ -131,24 +117,21 @@ function creditCardValidator( /* validationProperties... */ ) {
 	};
 }
 
-
 function validateCardDetails( cardDetails ) {
-	var rules = creditCardFieldRules(),
+	const rules = creditCardFieldRules(),
 		errors = Object.keys( rules ).reduce( function( allErrors, fieldName ) {
-		var field = rules[ fieldName ],
-			newErrors = getErrors( field, cardDetails[ fieldName ], cardDetails );
+			const field = rules[ fieldName ],
+				newErrors = getErrors( field, cardDetails[ fieldName ], cardDetails );
 
-		if ( newErrors.length ) {
-			allErrors[ fieldName ] = newErrors;
-		}
+			if ( newErrors.length ) {
+				allErrors[ fieldName ] = newErrors;
+			}
 
-		return allErrors;
-	}, {} );
+			return allErrors;
+		}, {} );
 
 	return { errors: errors };
 }
-
-
 
 /**
  * Retrieves the type of credit card from the specified number.
@@ -182,7 +165,7 @@ function getCreditCardType( number ) {
 
 function getErrors( field, value, cardDetails ) {
 	return compact( field.rules.map( function( rule ) {
-		var validator = getValidator( rule );
+		const validator = getValidator( rule );
 
 		if ( ! validator.isValid( value, cardDetails ) ) {
 			return validator.error( field.description );
@@ -193,9 +176,9 @@ function getErrors( field, value, cardDetails ) {
 function getValidator( rule ) {
 	if ( isArray( rule ) ) {
 		return validators[ rule[ 0 ] ].apply( null, rule.slice( 1 ) );
-	} else {
-		return validators[ rule ];
 	}
+
+	return validators[ rule ];
 }
 
 module.exports = {


### PR DESCRIPTION
This PR adds additional error handling to credit card validation. It is not possible to charge credit card that has expiration date in the past. It was possible to no longer valid date in the Credit Card form. With this patch we are showing proper error message to the user:

![screen shot 2016-08-26 at 16 49 10](https://cloud.githubusercontent.com/assets/699132/18009866/526a21ca-6bae-11e6-97f6-fcae025d96d9.png)

### Testing
Can be tested on any of pages that has Credit Card Form.
1. Setup calyps.live branch using link below.
2. Open Add Credit Card page (https://calypso.live/payment-methods/add-credit-card).
3. Enter expiration date in the past and change focus to another field. There should error message show up.
4. Enter valid expiration date and change focus to another field. Error message should disappear.

Test live: https://calypso.live/?branch=fix/credit-card-date-field