### PR TITLE
People: fix unknown prop JS warnings

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -85,16 +85,15 @@ const InvitePeople = React.createClass( {
 			analytics.tracks.recordEvent( 'calypso_invite_people_form_refresh_initial' );
 			debug( 'Submit successful. Resetting form.' );
 		} else {
-			const sendInvitesErrored = InvitesSentStore.getErrors( this.state.formId );
-			const errors = get( sendInvitesErrored, 'errors', {} );
-
-			let updatedState = { sendingInvites: false };
+			const sendInvitesErrored = InvitesSentStore.getErrors( this.state.formId ),
+				errors = get( sendInvitesErrored, 'errors', {} ),
+				updatedState = { sendingInvites: false };
 			if ( ! isEmpty( errors ) && 'object' === typeof errors ) {
 				const errorKeys = Object.keys( errors );
 				Object.assign( updatedState, {
 					usernamesOrEmails: errorKeys,
-					errorToDisplay: errorKeys[0],
-					errors,
+					errorToDisplay: errorKeys[ 0 ],
+					errors
 				} );
 			}
 
@@ -171,7 +170,7 @@ const InvitePeople = React.createClass( {
 		const errors = InvitesCreateValidationStore.getErrors( this.props.site.ID, this.state.role ) || {},
 			success = InvitesCreateValidationStore.getSuccess( this.props.site.ID, this.state.role ) || [],
 			errorsKeys = Object.keys( errors ),
-			errorToDisplay = this.state.errorToDisplay || ( errorsKeys.length > 0 && errorsKeys[0] );
+			errorToDisplay = this.state.errorToDisplay || ( errorsKeys.length > 0 && errorsKeys[ 0 ] );
 
 		this.setState( {
 			errorToDisplay,
@@ -337,7 +336,6 @@ const InvitePeople = React.createClass( {
 							<RoleSelect
 								id="role"
 								name="role"
-								key={ this.props.site.ID }
 								includeFollower
 								siteId={ this.props.site.ID }
 								onChange={ this.onRoleChange }
@@ -361,7 +359,8 @@ const InvitePeople = React.createClass( {
 									disabled={ this.state.sendingInvites } />
 								<FormSettingExplanation>
 									{ this.translate(
-										'(Optional) You can enter a custom message of up to 500 characters that will be included in the invitation to the user(s).'
+										'(Optional) You can enter a custom message of up to 500 characters ' +
+										'that will be included in the invitation to the user(s).'
 									) }
 								</FormSettingExplanation>
 							</FormFieldset>

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -1,18 +1,18 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	classNames = require( 'classnames' ),
-	omit = require( 'lodash/omit' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import classNames from 'classnames';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
  */
-const CompactCard = require( 'components/card/compact' ),
-	PeopleProfile = require( 'my-sites/people/people-profile' ),
-	analytics = require( 'lib/analytics' ),
-	config = require( 'config' );
+import CompactCard from 'components/card/compact';
+import PeopleProfile from 'my-sites/people/people-profile';
+import analytics from 'lib/analytics';
+import config from 'config';
 
 export default React.createClass( {
 

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -48,7 +48,7 @@ export default React.createClass( {
 		const canLinkToProfile = this.canLinkToProfile();
 		return (
 			<CompactCard
-				{ ...omit( this.props, 'className' ) }
+				{ ...omit( this.props, 'className', 'user', 'site', 'isSelectable', 'onRemove' ) }
 				className={ classNames( 'people-list-item', this.props.className ) }
 				tagName="a"
 				href={ canLinkToProfile && '/people/edit/' + this.props.user.login + '/' + this.props.site.slug }

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -1,36 +1,36 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	classNames = require( 'classnames' ),
-	omit = require( 'lodash/omit' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import classNames from 'classnames';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
  */
-var Gravatar = require( 'components/gravatar' );
+import Gravatar from 'components/gravatar';
 
 module.exports = React.createClass( {
 	displayName: 'PeopleProfile',
 
 	mixins: [ PureRenderMixin ],
 
-	getRole: function() {
-		var user = this.props.user;
+	getRole() {
+		const user = this.props.user;
 		if ( ! user ) {
 			return 'subscriber';
 		}
 
-		if ( user && user.roles && user.roles[0] ) {
-			return this.props.user.roles[0];
+		if ( user && user.roles && user.roles[ 0 ] ) {
+			return this.props.user.roles[ 0 ];
 		}
 
 		return;
 	},
 
-	getRoleBadgeText: function( role ) {
-		var text;
+	getRoleBadgeText( role ) {
+		let text;
 		role = 'undefined' === typeof role ? this.getRole() : role;
 
 		switch ( role ) {
@@ -59,13 +59,14 @@ module.exports = React.createClass( {
 		return text;
 	},
 
-	getRoleBadgeClass: function( role ) {
+	getRoleBadgeClass( role ) {
 		role = 'undefined' === typeof role ? this.getRole() : role;
 		return 'role-' + role;
 	},
 
-	renderName: function() {
-		let name, user = this.props.user;
+	renderName() {
+		const user = this.props.user;
+		let name;
 		if ( ! user ) {
 			name = this.translate( 'Loading Users', { context: 'Placeholder text while fetching users.' } );
 		} else if ( user.name ) {
@@ -85,8 +86,8 @@ module.exports = React.createClass( {
 		return name;
 	},
 
-	renderLogin: function() {
-		var login;
+	renderLogin() {
+		let login;
 		if ( ! this.props.user ) {
 			login = this.translate( 'Loading Users', { context: 'Placeholder text while fetching users.' } );
 		} else if ( this.props.user.login ) {
@@ -104,8 +105,8 @@ module.exports = React.createClass( {
 		return login;
 	},
 
-	renderRole: function() {
-		var superAdminBadge,
+	renderRole() {
+		let superAdminBadge,
 			roleBadge;
 
 		if ( this.props.user && this.props.user.is_super_admin ) {
@@ -136,7 +137,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderSubscribedDate: function() {
+	renderSubscribedDate() {
 		if ( ! this.props.user || ! this.props.user.date_subscribed ) {
 			return;
 		}
@@ -155,12 +156,12 @@ module.exports = React.createClass( {
 		);
 	},
 
-	isFollowerType: function() {
+	isFollowerType() {
 		return this.props.user && ! this.props.user.roles && this.props.user.date_subscribed;
 	},
 
 	render: function() {
-		var user = this.props.user,
+		const user = this.props.user,
 			classes = classNames( 'people-profile', {
 				'is-placeholder': ! user
 			} );

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -166,7 +166,7 @@ module.exports = React.createClass( {
 			} );
 
 		return (
-			<div { ...omit( this.props, 'className' ) } className={ classes }>
+			<div { ...omit( this.props, 'className', 'user' ) } className={ classes }>
 				<div className="people-profile__gravatar">
 					<Gravatar user={ user } size={ 72 } />
 				</div>

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -56,7 +56,7 @@ export default React.createClass( {
 	getWPCOMFollowerRole( siteId ) {
 		siteId = siteId ? siteId : this.props.siteId;
 
-		let site = sites.getSite( siteId ),
+		const site = sites.getSite( siteId ),
 			displayName = site.is_private
 			? this.translate( 'Viewer', { context: 'Role that is displayed in a select' } )
 			: this.translate( 'Follower', { context: 'Role that is displayed in a select' } );

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -76,7 +76,7 @@ export default React.createClass( {
 			let siteRoles = RolesStore.getRoles( siteId );
 
 			if ( this.props.includeFollower ) {
-				siteRoles = Object.assign( {}, this.getWPCOMFollowerRole(), siteRoles )
+				siteRoles = Object.assign( {}, this.getWPCOMFollowerRole(), siteRoles );
 			}
 
 			this.setState( {
@@ -117,7 +117,7 @@ export default React.createClass( {
 						context: 'Text that is displayed in a label of a form.'
 					} ) }
 				</FormLabel>
-				<FormSelect { ...omit( this.props, [ 'site', 'key' ] ) }>
+				<FormSelect { ...omit( this.props, [ 'site', 'key', 'siteId' ] ) }>
 					{
 						map( this.state.roles, ( roleObject, key ) => {
 							return (

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -111,13 +111,13 @@ export default React.createClass( {
 	render() {
 		const roleKeys = Object.keys( this.state.roles );
 		return (
-			<FormFieldset key={ this.props.key } disabled={ ! roleKeys.length }>
+			<FormFieldset key={ this.props.siteId } disabled={ ! roleKeys.length }>
 				<FormLabel htmlFor={ this.props.id }>
 					{ this.translate( 'Role', {
 						context: 'Text that is displayed in a label of a form.'
 					} ) }
 				</FormLabel>
-				<FormSelect { ...omit( this.props, [ 'site', 'key', 'siteId' ] ) }>
+				<FormSelect { ...omit( this.props, [ 'site', 'key', 'siteId', 'includeFollower', 'explanation' ] ) }>
 					{
 						map( this.state.roles, ( roleObject, key ) => {
 							return (


### PR DESCRIPTION
The intent of this PR is to fix JS warnings emitted in the People section.
While I was at it, I also fixed ES6 lint warnings in the affected files.

To reproduce:
- run master branch at calypso.localhost:3000
- go to /people/team/$site
- note the JS warnings emitted by `Card` and `PeopleProfile`
- go to /people/edit/$user/$site
- note the JS warnings emitted by `PeopleProfile`, `FormSelect`, and `RoleSelect`
- go to /people/new/$site
- note the JS warnings emitted by `FormSelect`

To test:
- checkout this branch
- ensure that the above JS errors are gone

Note:
This PR does not address the `valueLink` errors. That's a whole different ball of wax that can be addressed in an other PR.

cc: @ebinnion @tyxla @johnHackworth 
Test live: https://calypso.live/?branch=fix/unknown-prop-warnings-people