### PR TITLE
Export: Fix duplicate default export

### DIFF
--- a/client/my-sites/exporter/export-card/select.jsx
+++ b/client/my-sites/exporter/export-card/select.jsx
@@ -18,7 +18,7 @@ import {
 } from 'state/site-settings/exporter/actions';
 import { localize } from 'i18n-calypso';
 
-export default class Select extends Component {
+class Select extends Component {
 	constructor( props ) {
 		super( props );
 		this.setValue = this.setValue.bind( this );


### PR DESCRIPTION
#5850 introduced a second default export in `client/my-sites/exporter/export-card/select.jsx`, which blew up Webpack.

This removes the unused default export.

cc @aduth @gwwar 

Test live: https://calypso.live/?branch=fix/exporter/double-default-export