### PR TITLE
Payment Methods: Deploy new Add Credit Card page to all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -40,6 +40,7 @@
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/pages": true,
+		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -36,6 +36,7 @@
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
+		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,6 +41,7 @@
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
+		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,6 +50,7 @@
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
+		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,


### PR DESCRIPTION
This PR enables Add Credit Card page for Connect for WooCommerce (see #6971 for more details) in all envs.

### After deploy testing
__Actually we can't test anything until we start deploy process here.__
1. Go to https://wordpress.com/me/billing.
2. You should see the Add Credit Card button in the Credit Cards section header.
![screen shot 2016-08-29 at 10 44 56](https://cloud.githubusercontent.com/assets/699132/18045927/a5830042-6dd5-11e6-8482-88c98fe05571.png)
3. Click on the button, Add Credit Card form should load for you.
![screen shot 2016-08-29 at 10 45 08](https://cloud.githubusercontent.com/assets/699132/18045932/ad2ee5d6-6dd5-11e6-918d-89cb65678966.png)
4. Play with the form :)

Test live: https://calypso.live/?branch=update/deploy-add-credit-card