### PR TITLE
CurrentPlan: update display of payment actions.

### DIFF
--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -90,8 +90,8 @@
 	}
 }
 
-.current-plan__header-purchase-info-wrapper {
-	margin-top: 20px;
+.current-plan__header-purchase-info-wrapper.card.is-compact {
+	margin: 24px -32px -32px;
 }
 
 .current-plan__header-purchase-info {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/548849/18048093/7a160d9a-6de0-11e6-9dde-2ad99d9287b4.png)

Fixes #7706.

@lamosty By the way, `current-plan__header-item` and `product-purchase-features-list__item` should be Cards in this page. They have incorrect padding values and border color.

I would also move the breakpoint for single column earlier.

Test live: https://calypso.live/?branch=update/current-plan-actions