### PR TITLE
Add a locale parameter to the support forums submit

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1799,10 +1799,10 @@ Undocumented.prototype.getOlarkConfiguration = function( client, fn ) {
 	}, fn );
 };
 
-Undocumented.prototype.submitSupportForumsTopic = function( subject, message, client, fn ) {
+Undocumented.prototype.submitSupportForumsTopic = function( subject, message, locale, client, fn ) {
 	this.wpcom.req.post( {
 		path: '/help/forums/support/topics/new',
-		body: { subject, message, client }
+		body: { subject, message, locale, client }
 	}, fn );
 };
 

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -167,10 +167,11 @@ const HelpContact = React.createClass( {
 
 	submitSupportForumsTopic: function( contactForm ) {
 		const { subject, message } = contactForm;
+		const { locale } = this.state.olark;
 
 		this.setState( { isSubmitting: true } );
 
-		wpcom.submitSupportForumsTopic( subject, message, this.props.clientSlug, ( error, data ) => {
+		wpcom.submitSupportForumsTopic( subject, message, locale, this.props.clientSlug, ( error, data ) => {
 			if ( error ) {
 				// TODO: bump a stat here
 				notices.error( error.message );


### PR DESCRIPTION
At present, all support requests that go to the forums go to the English forums. We'd like to be able to route requests for languages we offer staff-supported forum support to into the appropriate localized forums. For tickets, we've long passed a `locale` parameter that lets us route tickets differently. This PR adds the same parameter to requests that would create forum requests. The REST API is already updated to route these requests to the relevant forums as needed.

**To Test:**
1. Assure that no Portuguese chat operators are online or sandbox the REST API and disable the Portuguese chat group.
2. Log in as a user with pt-br as the account language.
3. Go to https://calypso.live/help/contact?branch=update/add-locale-to-forum-submit
4. Enable the network console in your browser.
5. Submit a forum request (if you see a chat or ticket prompt, you didn't disable the Portuguese group properly)

You should see in the network console that a request to `https://public-api.wordpress.com/rest/v1.1/help/forums/support/topics/new` looks like this, with the `locale` parameter:

![screen shot 2016-08-29 at 8 15 38 am](https://cloud.githubusercontent.com/assets/2738252/18052647/957778b0-6dc9-11e6-9ae1-5732ef39f1d1.png)

The post should also land in the support forum at https://br.forums.wordpress.com/ (please delete it after).

Before the change, the request looks like this and lands in en.forums.wordpress.com:

![screen shot 2016-08-29 at 8 11 48 am](https://cloud.githubusercontent.com/assets/2738252/18052665/af5c0f0c-6dc9-11e6-8c8b-505cacff9c54.png)

Note that there seems to be some caching of the locale or something, so if you try to test the English flow after the Portuguese, it may still submit Portuguese until the locale state is fully refreshed.