### PR TITLE
Me: ES6ify the main Profile component

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -1,46 +1,48 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
-	debug = require( 'debug' )( 'calypso:me:profile' );
+import React from 'react';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-var MeSidebarNavigation = require( 'me/sidebar-navigation' ),
-	protectForm = require( 'lib/mixins/protect-form' ),
-	formBase = require( 'me/form-base' ),
-	FormButton = require( 'components/forms/form-button' ),
-	FormFieldset = require( 'components/forms/form-fieldset' ),
-	FormLabel = require( 'components/forms/form-label' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
-	FormTextarea = require( 'components/forms/form-textarea' ),
-	ProfileLinks = require( 'me/profile-links' ),
-	userProfileLinks = require( 'lib/user-profile-links' ),
-	ReauthRequired = require( 'me/reauth-required' ),
-	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	Card = require( 'components/card' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	eventRecorder = require( 'me/event-recorder' ),
-	Main = require( 'components/main' );
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import protectForm from 'lib/mixins/protect-form';
+import formBase from 'me/form-base';
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
+import ProfileLinks from 'me/profile-links';
+import userProfileLinks from 'lib/user-profile-links';
+import ReauthRequired from 'me/reauth-required';
+import twoStepAuthorization from 'lib/two-step-authorization';
+import Card from 'components/card';
+import observe from 'lib/mixins/data-observe';
+import eventRecorder from 'me/event-recorder';
+import Main from 'components/main';
 
-module.exports = React.createClass( {
+const debug = debugFactory( 'calypso:me:profile' );
+
+export default React.createClass( {
 
 	displayName: 'Profile',
 
 	mixins: [ formBase, LinkedStateMixin, protectForm.mixin, observe( 'userSettings' ), eventRecorder ],
 
-	componentDidMount: function() {
-		debug( this.constructor.displayName + ' component is mounted.' );
+	componentDidMount() {
+		debug( this.displayName + ' component is mounted.' );
 	},
 
-	componentWillUnmount: function() {
-		debug( this.constructor.displayName + ' component is unmounting.' );
+	componentWillUnmount() {
+		debug( this.displayName + ' component is unmounting.' );
 	},
 
-	render: function() {
-		var gravatarProfileLink = 'https://gravatar.com/' + this.props.userSettings.getSetting( 'user_login' );
+	render() {
+		const gravatarProfileLink = 'https://gravatar.com/' + this.props.userSettings.getSetting( 'user_login' );
 
 		return (
 			<Main className="profile">


### PR DESCRIPTION
This PR ES6ifies the Profile component:

* Replacing `require` with `import`
* Replacing `module.exports` with `export default`
* Replacing `var` with `let` or `const`
* Using method shorthand
* Using `this` instead of `this.constructor`

This component is used in `/me`.

Note: although the `valueLink` could also be fixed here, I believe it belongs to another PR, together with the rest of its occurrences throughout Calypso.

/cc @roccotripaldi @ryelle

Test live: https://calypso.live/?branch=update/me-profile-es6ify