### PR TITLE
Reader full post: reformat Daily Post and Discover pullquotes for new full post view

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -277,3 +277,44 @@
 .reader-full-post__story-content img:first-child {
 	margin-top: 0;
 }
+
+// Daily Post-Specific Full Post View Styles
+.is-group-reader-refresh .blog-489937 .reader__full-post-content {
+	blockquote.left,
+	blockquote.alignleft,
+	blockquote.align-left,
+	blockquote.left-align {
+		margin: 0;
+		padding: 0;
+		border: none;
+		background: none;
+		font-size: 13px;
+		width: 175px;
+		position: relative;
+
+		@media ( min-width: 1400px ) {
+			position: absolute;
+			left: inherit;
+			right: -( 175px + 32px );
+			margin-left: 0;
+		}
+
+		@media ( max-width: 1400px ) {
+			background: lighten( $gray, 30 );
+			margin: 0 0 24px 0;
+			padding: 16px;
+			width: calc( 100% - 32px );
+		}
+
+		@include breakpoint( "<480px" ) {
+			margin: 0 0 24px 0;
+			background: lighten( $gray, 30 );
+			padding: 16px;
+
+			img {
+				display: block;
+				margin-bottom: 8px;
+			}
+		}
+	}
+}

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -377,18 +377,31 @@
 }
 
 // Daily Post-Specific Full Post View Styles
-.blog-489937 .reader__full-post-content {
+.is-group-reader .blog-489937 .reader__full-post-content {
 
 	blockquote.left,
 	blockquote.alignleft,
 	blockquote.align-left,
 	blockquote.left-align {
+		margin: 0;
+		padding: 0;
 		border: none;
+		background: none;
 		font-size: 13px;
-		background: lighten( $gray, 30 );
-		margin: 0 0 24px 0;
-		padding: 16px;
-		width: calc( 100% - 32px );
+		width: 175px;
+
+		@media ( min-width: 1132px ) {
+			position: absolute;
+			left: -( 175px + 32px );
+			margin-left: 0;
+		}
+
+		@media ( max-width: 1132px ) {
+			background: lighten( $gray, 30 );
+			margin: 0 0 24px 0;
+			padding: 16px;
+			width: calc( 100% - 32px );
+		}
 
 		@include breakpoint( "<480px" ) {
 			margin: 0 0 24px 0;

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -383,25 +383,12 @@
 	blockquote.alignleft,
 	blockquote.align-left,
 	blockquote.left-align {
-		margin: 0;
-		padding: 0;
 		border: none;
-		background: none;
 		font-size: 13px;
-		width: 175px;
-
-		@media ( min-width: 1132px ) {
-			position: absolute;
-			left: -( 175px + 32px );
-			margin-left: 0;
-		}
-
-		@media ( max-width: 1132px ) {
-			background: lighten( $gray, 30 );
-			margin: 0 0 24px 0;
-			padding: 16px;
-			width: calc( 100% - 32px );
-		}
+		background: lighten( $gray, 30 );
+		margin: 0 0 24px 0;
+		padding: 16px;
+		width: calc( 100% - 32px );
 
 		@include breakpoint( "<480px" ) {
 			margin: 0 0 24px 0;


### PR DESCRIPTION
In the current full post view, we show pullquotes in the left column on large screens (>1132px) but now we have the author profile in the left column, they sometimes overlap (see #7630).

This PR changes all Daily Post pullquotes to appear in the main body text at all screen sizes, like so:

![screen shot 2016-08-29 at 15 59 21](https://cloud.githubusercontent.com/assets/17325/18055892/99d4bbb0-6e01-11e6-94bb-366edcb9b73d.png)

Fixes #7630.

Test live: https://calypso.live/?branch=fix/reader/show-pullquotes-in-article