### PR TITLE
State: update Array.find usage to use lodash

### DIFF
--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -1,3 +1,11 @@
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
 import createSelector from 'lib/create-selector';
 import purchasesAssembler from 'lib/purchases/assembler';
 import { isSubscription } from 'lib/purchases';
@@ -65,7 +73,7 @@ export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
 
 	const { includedDomain } = subscriptionPurchase;
 	const sitePurchases = getSitePurchases( state, subscriptionPurchase.siteId );
-	const domainPurchase = sitePurchases.find( purchase => ( isDomainMapping( purchase ) ||
+	const domainPurchase = find( sitePurchases, purchase => ( isDomainMapping( purchase ) ||
 															isDomainRegistration( purchase ) ) &&
 															includedDomain === purchase.meta );
 


### PR DESCRIPTION
This fixes an Array.find usage. We don't have a full polyfill solution for prototype methods (see #6117 ) so this will break in IE

## Testing Instructions
- Test pass
- Navigate to http://calypso.localhost:3000/purchases
- No warnings are thrown while cancelling a purchase

cc @yurynix 


Test live: https://calypso.live/?branch=fix/ie-find