### PR TITLE
Extract PlanFeaturesPrice to my-sites/plan-price

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -231,6 +231,7 @@
 @import 'my-sites/people/people-notices/style';
 @import 'my-sites/plan-compare-card/style';
 @import 'my-sites/plan-features/style';
+@import 'my-sites/plan-price/style';
 @import 'my-sites/plans-features-main/style';
 @import 'my-sites/plan-storage/style';
 @import 'my-sites/plans/style';

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -37,6 +37,7 @@ import ReaderFullPostHeader from 'blocks/reader-full-post/docs/header-example';
 import AuthorCompactProfile from 'blocks/author-compact-profile/docs/example';
 import RelatedPostCard from 'blocks/reader-related-card/docs/example';
 import SearchPostCard from 'blocks/reader-search-card/docs/example';
+import PlanPrice from 'my-sites/plan-price/docs/example';
 
 export default React.createClass( {
 
@@ -95,6 +96,7 @@ export default React.createClass( {
 					<ReaderSiteStreamLink />
 					<ReaderFullPostHeader />
 					<AuthorCompactProfile />
+					<PlanPrice />
 				</Collection>
 			</div>
 		);

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import Ribbon from 'components/ribbon';
-import PlanFeaturesPrice from 'my-sites/plan-price';
+import PlanPrice from 'my-sites/plan-price';
 import {
 	PLAN_FREE,
 	PLAN_PREMIUM,
@@ -159,8 +159,8 @@ class PlanFeaturesHeader extends Component {
 		if ( discountPrice ) {
 			return (
 				<span className="plan-features__header-price-group">
-					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ rawPrice } original />
-					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ discountPrice } discounted />
+					<PlanPrice currencyCode={ currencyCode } rawPrice={ rawPrice } original />
+					<PlanPrice currencyCode={ currencyCode } rawPrice={ discountPrice } discounted />
 				</span>
 			);
 		}
@@ -169,14 +169,14 @@ class PlanFeaturesHeader extends Component {
 			const originalPrice = relatedMonthlyPlan.raw_price * 12;
 			return (
 				<span className="plan-features__header-price-group">
-					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ originalPrice } original />
-					<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ rawPrice } discounted />
+					<PlanPrice currencyCode={ currencyCode } rawPrice={ originalPrice } original />
+					<PlanPrice currencyCode={ currencyCode } rawPrice={ rawPrice } discounted />
 				</span>
 			);
 		}
 
 		return (
-			<PlanFeaturesPrice currencyCode={ currencyCode } rawPrice={ rawPrice } />
+			<PlanPrice currencyCode={ currencyCode } rawPrice={ rawPrice } />
 		);
 	}
 }

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import Ribbon from 'components/ribbon';
-import PlanFeaturesPrice from './price';
+import PlanFeaturesPrice from 'my-sites/plan-price';
 import {
 	PLAN_FREE,
 	PLAN_PREMIUM,

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -215,7 +215,6 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-
 .plan-features__header-checkmark {
 	position: absolute;
 	top: -3px;
@@ -247,8 +246,6 @@ $plan-features-sidebar-width: 272px;
 	display: flex;
 	flex-flow: row wrap;
 }
-
-
 
 .plan-features__header-timeframe {
 	margin-bottom: 1.4em;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -243,77 +243,12 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.plan-features__price {
-	margin: 0;
-	font-size: 28px;
-	line-height: 1.5;
-	color: $gray-dark;
-
-	&.is-placeholder {
-		@include placeholder( 23% );
-		width: 60px;
-		margin: 10px 0;
-		height: 21px;
-	}
-
-	@include breakpoint( "<960px" ) {
-		font-size: 24px;
-	}
-}
-
-.plan-features__price.is-original {
-	color: $gray;
-}
-
-.plan-features__price.is-discounted {
-	color: $alert-green;
-}
-
-.plan-features__price.is-discounted,
-.plan-features__price.is-original {
-	position: relative;
-	align-items: stretch;
-	margin-right: 8px;
-}
-
-.plan-features__price.is-original:before {
-	position: absolute;
-	content: "";
-	left: 0;
-	top: 50%;
-	right: 0;
-	border-top: 2px solid $orange-fire;
-	transform: rotate( -16deg );
-	opacity: .9;
-}
-
-.plan-features__price-currency-symbol,
-.plan-features__price-fraction {
-	vertical-align: super;
-	font-size: 12px;
-}
-
 .plan-features__header-price-group {
 	display: flex;
 	flex-flow: row wrap;
 }
 
-.plan-features__price.is-discounted .plan-features__price-currency-symbol {
-	color: $alert-green;
-}
 
-.plan-features__price-currency-symbol {
-	color: $gray;
-}
-
-.plan-features__price-integer {
-	margin: 0 1px;
-	font-weight: 400;
-}
-
-.plan-features__price-fraction {
-	font-weight: 500;
-}
 
 .plan-features__header-timeframe {
 	margin-bottom: 1.4em;

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -1,0 +1,39 @@
+PlanPrice Component
+=============
+
+PlanPrice component is a React component used to display plan's price with a currency and a discount, if any.
+It can be used anywhere where a plan's price is required.
+
+If you want to emphasize that a plan's price is discounted, use two `<PlanPrice>` components as below and wrap them in a
+flexbox container.
+
+## Usage
+
+```jsx
+import PlanPrice from 'my-sites/plan-price';
+
+export default React.createClass( {
+	displayName: 'MyPlanPrice',
+
+	render() {
+		return (
+            <span className="my-plan-price-with-flexbox">
+                <PlanPrice rawPrice={ 99 } original />
+                <PlanPrice rawPrice={ 30 } discounted />
+            </span>
+		);
+	}
+} );
+
+```
+
+## Props
+
+| Prop         | Type   | Description                                               |
+| ----         | -------| -----------                                               |
+| rawPrice     | number | Price of the plan                                         |
+| original     | bool   | Is the price discounted and this is the original one?     |
+| discounted     | bool   | Is the price discounted and this is the discounted one?   |
+| currencyCode | string | Currency of the price                                     |
+| className    | string | If you need to add additional classes                     |
+

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -17,10 +17,10 @@ export default React.createClass( {
 
 	render() {
 		return (
-            <span className="my-plan-price-with-flexbox">
-                <PlanPrice rawPrice={ 99 } original />
-                <PlanPrice rawPrice={ 30 } discounted />
-            </span>
+			<span className="my-plan-price-with-flexbox">
+				<PlanPrice rawPrice={ 99 } original />
+				<PlanPrice rawPrice={ 30 } discounted />
+			</span>
 		);
 	}
 } );

--- a/client/my-sites/plan-price/docs/example.jsx
+++ b/client/my-sites/plan-price/docs/example.jsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PlanPrice from '../';
+
+export default React.createClass( {
+	displayName: 'PlanPrice',
+
+	render() {
+		return (
+			<div className="docs__design-assets-group">
+				<h2>
+					<a href="/devdocs/blocks/plan-price">Plan Price</a>
+				</h2>
+
+				<h3>Plan with standard price</h3>
+				<PlanPrice rawPrice={ 99 } />
+
+				<h3>Plan with discounted price</h3>
+				<span style={ { display: 'flex' } }>
+					<PlanPrice rawPrice={ 8.25 } original />
+					<PlanPrice rawPrice={ 2.25 } discounted />
+				</span>
+			</div>
+		);
+	}
+} );
+

--- a/client/my-sites/plan-price/docs/example.jsx
+++ b/client/my-sites/plan-price/docs/example.jsx
@@ -8,26 +8,26 @@ import React from 'react';
  */
 import PlanPrice from '../';
 
-export default React.createClass( {
-	displayName: 'PlanPrice',
+function PlanPriceExample() {
+	return (
+		<div className="docs__design-assets-group">
+			<h2>
+				<a href="/devdocs/blocks/plan-price">Plan Price</a>
+			</h2>
 
-	render() {
-		return (
-			<div className="docs__design-assets-group">
-				<h2>
-					<a href="/devdocs/blocks/plan-price">Plan Price</a>
-				</h2>
+			<h3>Plan with standard price</h3>
+			<PlanPrice rawPrice={ 99 } />
 
-				<h3>Plan with standard price</h3>
-				<PlanPrice rawPrice={ 99 } />
+			<h3>Plan with discounted price</h3>
+			<span style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ 8.25 } original />
+				<PlanPrice rawPrice={ 2.25 } discounted />
+			</span>
+		</div>
+	);
+}
 
-				<h3>Plan with discounted price</h3>
-				<span style={ { display: 'flex' } }>
-					<PlanPrice rawPrice={ 8.25 } original />
-					<PlanPrice rawPrice={ 2.25 } discounted />
-				</span>
-			</div>
-		);
-	}
-} );
+PlanPriceExample.displayName = 'PlanPrice';
+
+export default PlanPriceExample;
 

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -9,27 +9,36 @@ import classNames from 'classnames';
  **/
 import { getCurrencyObject } from 'lib/format-currency';
 
-export default class PlanFeaturesPrice extends Component {
+export default class PlanPrice extends Component {
 
 	render() {
-		const { currencyCode, rawPrice, original, discounted } = this.props;
+		const {
+			currencyCode,
+			rawPrice,
+			original,
+			discounted,
+			className
+		} = this.props;
+
 		if ( ! currencyCode || ( rawPrice !== 0 && ! rawPrice ) ) {
 			return null;
 		}
 		const price = getCurrencyObject( rawPrice, currencyCode );
-		const classes = classNames( 'plan-features__price', {
+
+		const classes = classNames( 'plan-price', className, {
 			'is-original': original,
 			'is-discounted': discounted
 		} );
+
 		return (
 			<h4 className={ classes }>
-				<sup className="plan-features__price-currency-symbol">
+				<sup className="plan-price__currency-symbol">
 					{ price.symbol }
 				</sup>
-				<span className="plan-features__price-integer">
+				<span className="plan-price__integer">
 					{ price.integer }
 				</span>
-				<sup className="plan-features__price-fraction">
+				<sup className="plan-price__fraction">
 					{ rawPrice > 0 && price.fraction }
 				</sup>
 			</h4>
@@ -37,15 +46,17 @@ export default class PlanFeaturesPrice extends Component {
 	}
 }
 
-PlanFeaturesPrice.propTypes = {
+PlanPrice.propTypes = {
 	rawPrice: PropTypes.number,
 	original: PropTypes.bool,
 	discount: PropTypes.bool,
-	currencyCode: PropTypes.string
+	currencyCode: PropTypes.string,
+	className: PropTypes.string
 };
 
-PlanFeaturesPrice.defaultProps = {
+PlanPrice.defaultProps = {
 	currencyCode: 'USD',
 	original: false,
-	discounted: false
+	discounted: false,
+	className: ''
 };

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -49,7 +49,7 @@ export default class PlanPrice extends Component {
 PlanPrice.propTypes = {
 	rawPrice: PropTypes.number,
 	original: PropTypes.bool,
-	discount: PropTypes.bool,
+	discounted: PropTypes.bool,
 	currencyCode: PropTypes.string,
 	className: PropTypes.string
 };

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -1,4 +1,4 @@
-.plan-features__price {
+.plan-price {
 	margin: 0;
 	font-size: 28px;
 	line-height: 1.5;
@@ -16,22 +16,22 @@
 	}
 }
 
-.plan-features__price.is-original {
+.plan-price.is-original {
 	color: $gray;
 }
 
-.plan-features__price.is-discounted {
+.plan-price.is-discounted {
 	color: $alert-green;
 }
 
-.plan-features__price.is-discounted,
-.plan-features__price.is-original {
+.plan-price.is-discounted,
+.plan-price.is-original {
 	position: relative;
 	align-items: stretch;
 	margin-right: 8px;
 }
 
-.plan-features__price.is-original:before {
+.plan-price.is-original:before {
 	position: absolute;
 	content: "";
 	left: 0;
@@ -42,25 +42,25 @@
 	opacity: .9;
 }
 
-.plan-features__price-currency-symbol,
-.plan-features__price-fraction {
+.plan-price__currency-symbol,
+.plan-price__fraction {
 	vertical-align: super;
 	font-size: 12px;
 }
 
-.plan-features__price.is-discounted .plan-features__price-currency-symbol {
+.plan-price.is-discounted .plan-price__currency-symbol {
 	color: $alert-green;
 }
 
-.plan-features__price-currency-symbol {
+.plan-price__currency-symbol {
 	color: $gray;
 }
 
-.plan-features__price-integer {
+.plan-price__integer {
 	margin: 0 1px;
 	font-weight: 400;
 }
 
-.plan-features__price-fraction {
+.plan-price__fraction {
 	font-weight: 500;
 }

--- a/client/my-sites/plan-price/styles.scss
+++ b/client/my-sites/plan-price/styles.scss
@@ -1,0 +1,66 @@
+.plan-features__price {
+	margin: 0;
+	font-size: 28px;
+	line-height: 1.5;
+	color: $gray-dark;
+
+	&.is-placeholder {
+		@include placeholder( 23% );
+		width: 60px;
+		margin: 10px 0;
+		height: 21px;
+	}
+
+	@include breakpoint( "<960px" ) {
+		font-size: 24px;
+	}
+}
+
+.plan-features__price.is-original {
+	color: $gray;
+}
+
+.plan-features__price.is-discounted {
+	color: $alert-green;
+}
+
+.plan-features__price.is-discounted,
+.plan-features__price.is-original {
+	position: relative;
+	align-items: stretch;
+	margin-right: 8px;
+}
+
+.plan-features__price.is-original:before {
+	position: absolute;
+	content: "";
+	left: 0;
+	top: 50%;
+	right: 0;
+	border-top: 2px solid $orange-fire;
+	transform: rotate( -16deg );
+	opacity: .9;
+}
+
+.plan-features__price-currency-symbol,
+.plan-features__price-fraction {
+	vertical-align: super;
+	font-size: 12px;
+}
+
+.plan-features__price.is-discounted .plan-features__price-currency-symbol {
+	color: $alert-green;
+}
+
+.plan-features__price-currency-symbol {
+	color: $gray;
+}
+
+.plan-features__price-integer {
+	margin: 0 1px;
+	font-weight: 400;
+}
+
+.plan-features__price-fraction {
+	font-weight: 500;
+}


### PR DESCRIPTION
This helps to make the component reusable outside of /plans page. Part of #7678.

Big props to @gwwar as she built the component originally. I just copy-pasted with small edits. :)

## Testing Instructions

1. Navigate to /plans;
2. Verify that there are no visual or functional changes of plans prices;
3. Navigate to http://calypso.localhost:3000/devdocs/blocks/plan-price;
4. Does it look like on the screenshot below?
5. Is it nice?

## Screenshots

![selection_144](https://cloud.githubusercontent.com/assets/4988512/18060676/dd2e26ee-6e1f-11e6-96c8-ba6b16cd3a66.png)

/cc @gwwar @mtias 

Test live: https://calypso.live/?branch=add/my-sites-plan-price-component