### PR TITLE
SEO Settings: Restores the site meta description box

### DIFF
--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -427,41 +427,39 @@ export const SeoForm = React.createClass( {
 						</div>
 					}
 
-					{ showAdvancedSeo &&
-						<div>
-							<SectionHeader label={ this.translate( 'Website Meta' ) }>
-								{ submitButton }
-							</SectionHeader>
-							<Card>
-								<p>
-									{ this.translate(
-										'Craft a description of your Website up to 160 characters that will be used in ' +
-										'search engine results for your front page, and when your website is shared ' +
-										'on social media sites.'
-									) }
-								</p>
-								<p>
-									<FormLabel htmlFor="seo_meta_description">
-										{ this.translate( 'Front Page Meta Description' ) }
-									</FormLabel>
-									<CountedTextarea
-										name="seo_meta_description"
-										type="text"
-										id="seo_meta_description"
-										value={ seoMetaDescription || '' }
-										disabled={ isDisabled }
-										maxLength="300"
-										acceptableLength={ 159 }
-										onChange={ this.handleMetaChange }
-									/>
-									{ hasHtmlTagError &&
-										<FormInputValidation isError={ true } text={ this.translate( 'HTML tags are not allowed.' ) } />
-									}
-								</p>
-								{ preview }
-							</Card>
-						</div>
-					}
+					<div>
+						<SectionHeader label={ this.translate( 'Website Meta' ) }>
+							{ submitButton }
+						</SectionHeader>
+						<Card>
+							<p>
+								{ this.translate(
+									'Craft a description of your Website up to 160 characters that will be used in ' +
+									'search engine results for your front page, and when your website is shared ' +
+									'on social media sites.'
+								) }
+							</p>
+							<p>
+								<FormLabel htmlFor="seo_meta_description">
+									{ this.translate( 'Front Page Meta Description' ) }
+								</FormLabel>
+								<CountedTextarea
+									name="seo_meta_description"
+									type="text"
+									id="seo_meta_description"
+									value={ seoMetaDescription || '' }
+									disabled={ isDisabled }
+									maxLength="300"
+									acceptableLength={ 159 }
+									onChange={ this.handleMetaChange }
+								/>
+								{ hasHtmlTagError &&
+									<FormInputValidation isError={ true } text={ this.translate( 'HTML tags are not allowed.' ) } />
+								}
+							</p>
+							{ preview }
+						</Card>
+					</div>
 
 					<SectionHeader label={ this.translate( 'Site Verification Services' ) }>
 						{ submitButton }


### PR DESCRIPTION
Removes the `showAdvancedSeo` check. It was set to business plan flag prematurely, it should still show for all sites for now.

Test live: https://calypso.live/?branch=fix/seo-meta-description-visibility