### PR TITLE
SEO Settings: fix navigation issue when site is unselected

### DIFF
--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -58,7 +58,7 @@ export class SeoSettings extends Component {
 				<SidebarNavigation />
 				<SiteSettingsNavigation site={ site } section="seo" />
 				{ site && <QuerySitePurchases siteId={ site.ID } /> }
-				<SeoForm { ...{ site, upgradeToBusiness } } />
+				{ site && <SeoForm { ...{ site, upgradeToBusiness } } /> }
 			</Main>
 		);
 	}


### PR DESCRIPTION
A re-render occurs with site not being set, which causes an error down the tree.

Test live: https://calypso.live/?branch=fix/seo-settings-navigation