### PR TITLE
Reader: Fix the check for using a excerpt

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -124,7 +124,7 @@ export class FullPostView extends React.Component {
 								</EmbedContainer>
 						}
 
-						{ post.show_excerpt && ! isDiscoverPost( post )
+						{ post.use_excerpt && ! isDiscoverPost( post )
 							? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
 							: null
 						}

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -52,7 +52,7 @@ const PostExcerptLink = React.createClass( {
 
 		return (
 			<div className={ classes }>
-				{ this.translate( 'Visit {{siteName/}} for the full post', { components: { siteName } } ) }
+				{ this.translate( 'Visit {{siteName/}} for the full post.', { components: { siteName } } ) }
 				<svg onClick={ this.toggleNotice } className="gridicon gridicon__help ignore-click" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" enableBackground="new 0 0 24 24"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm2.003-6.41c-.23.36-.6.704-1.108 1.028-.43.28-.7.482-.808.61-.108.13-.163.283-.163.46V13H11.04v-.528c0-.4.08-.74.245-1.017.163-.276.454-.546.872-.808.332-.21.57-.397.716-.565.145-.168.217-.36.217-.577 0-.172-.077-.308-.233-.41-.156-.1-.358-.15-.608-.15-.62 0-1.342.22-2.17.658l-.854-1.67c1.02-.58 2.084-.872 3.194-.872.913 0 1.63.202 2.15.603.52.4.78.948.78 1.64 0 .495-.116.924-.347 1.286z"/></svg>
 				<p className="post-excerpt-link__helper">
 					{ this.translate( 'The owner of this site only allows us to show a brief summary of their content. To view the full post, you\'ll have to visit their site.' ) }

--- a/client/reader/post-excerpt-link/style.scss
+++ b/client/reader/post-excerpt-link/style.scss
@@ -2,12 +2,10 @@
 	background: $gray-light;
 	color: darken( $gray, 20 );
 	padding: 16px 48px 16px 24px;
-	margin: 20px -24px 8px -24px;
+	margin: 20px 0 8px;
 	position: relative;
 
 	@include breakpoint( "<480px" ) {
-		margin-left: -16px;
-		margin-right: -16px;
 		padding-left: 16px;
 	}
 


### PR DESCRIPTION
Fixes how we show the excerpt notice.

Fixes #7673

Test live: https://calypso.live/?branch=add/reader-refresh/full-post-summary-notice

To test, visit http://calypso.localhost:3000/read/feeds/34575 and click through into a post. Notice the new notice below the post excerpt that lets you know you can see the full post on the actual site, just like in prod. 

http://calypso.localhost:3000/read/feeds/34575/posts/1136173740 