### PR TITLE
Jetpack: Sync panel to production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -22,6 +22,7 @@
 		"help": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,
+		"jetpack/sync-panel": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
 		"manage/ads": true,


### PR DESCRIPTION
The sync panel is currently only in staging. Enable it in production.

Test live: https://calypso.live/?branch=update/sync-panel-to-production