### PR TITLE
Jetpack Connect: Add more tests for jetpackConnectAuthorize() reducer

### DIFF
--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -21,6 +21,18 @@ import {
 	JETPACK_CONNECT_DISMISS_URL_STATUS,
 	JETPACK_CONNECT_REDIRECT,
 	JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
+	JETPACK_CONNECT_AUTHORIZE,
+	JETPACK_CONNECT_AUTHORIZE_RECEIVE,
+	JETPACK_CONNECT_AUTHORIZE_LOGIN_COMPLETE,
+	JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
+	JETPACK_CONNECT_ACTIVATE_MANAGE,
+	JETPACK_CONNECT_ACTIVATE_MANAGE_RECEIVE,
+	JETPACK_CONNECT_QUERY_SET,
+	JETPACK_CONNECT_QUERY_UPDATE,
+	JETPACK_CONNECT_CREATE_ACCOUNT,
+	JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE,
+	JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL,
+	JETPACK_CONNECT_REDIRECT_WP_ADMIN,
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
@@ -319,6 +331,323 @@ describe( 'reducer', () => {
 		it( 'should default to an empty object', () => {
 			const state = jetpackConnectAuthorize( undefined, {} );
 			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should set isAuthorizing to true when starting authorization', () => {
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_AUTHORIZE
+			} );
+
+			expect( state ).to.have.property( 'isAuthorizing' )
+				.to.be.true;
+			expect( state ).to.have.property( 'authorizeSuccess' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeError' )
+				.to.be.false;
+			expect( state ).to.have.property( 'isRedirectingToWpAdmin' )
+				.to.be.false;
+			expect( state ).to.have.property( 'autoAuthorize' )
+				.to.be.false;
+		} );
+
+		it( 'should omit userData and bearerToken when starting authorization', () => {
+			const state = jetpackConnectAuthorize( {
+				userData: {
+					ID: 123,
+					email: 'example@example.com'
+				},
+				bearerToken: 'abcd1234'
+			}, {
+				type: JETPACK_CONNECT_AUTHORIZE
+			} );
+
+			expect( state ).to.not.have.property( 'userData' );
+			expect( state ).to.not.have.property( 'bearerToken' );
+		} );
+
+		it( 'should set authorizeSuccess to true when completed authorization successfully', () => {
+			const data = {
+				plans_url: 'https://wordpress.com/jetpack/connect/plans/',
+				activate_manage: 'abcdefghi12345678'
+			};
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
+				data
+			} );
+
+			expect( state ).to.have.property( 'authorizeError' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeSuccess' )
+				.to.be.true;
+			expect( state ).to.have.property( 'autoAuthorize' )
+				.to.be.false;
+			expect( state ).to.have.property( 'plansUrl' )
+				.to.eql( data.plans_url );
+			expect( state ).to.have.property( 'siteReceived' )
+				.to.be.false;
+			expect( state ).to.have.property( 'activateManageSecret' )
+				.to.eql( data.activate_manage );
+		} );
+
+		it( 'should set authorizeSuccess to false when an error occured during authorization', () => {
+			const error = 'You need to stay logged in to your WordPress blog while you authorize Jetpack.';
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
+				error
+			} );
+
+			expect( state ).to.have.property( 'isAuthorizing' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeError' )
+				.to.eql( error );
+			expect( state ).to.have.property( 'authorizeSuccess' )
+				.to.be.false;
+			expect( state ).to.have.property( 'autoAuthorize' )
+				.to.be.false;
+		} );
+
+		it( 'should set authorization code when login is completed', () => {
+			const code = 'abcd1234efgh5678';
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_AUTHORIZE_LOGIN_COMPLETE,
+				data: {
+					code
+				}
+			} );
+
+			expect( state ).to.have.property( 'authorizationCode' )
+				.to.eql( code );
+		} );
+
+		it( 'should set siteReceived to true and omit some query object properties when received site list', () => {
+			const state = jetpackConnectAuthorize( {
+				queryObject: {
+					_wp_nonce: 'testnonce',
+					client_id: 'example.com',
+					redirect_uri: 'https://example.com/',
+					scope: 'auth',
+					secret: 'abcd1234',
+					site: 'https://example.com/',
+					state: 1234567890
+				}
+			}, {
+				type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST
+			} );
+
+			expect( state ).to.have.property( 'siteReceived' )
+				.to.be.true;
+			expect( state ).to.have.property( 'isAuthorizing' )
+				.to.be.false;
+			expect( state ).to.have.property( 'queryObject' )
+				.to.eql( {
+					client_id: 'example.com',
+					redirect_uri: 'https://example.com/',
+					site: 'https://example.com/',
+					state: 1234567890
+				} );
+		} );
+
+		it( 'should set isActivating to true when manage is being activated', () => {
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_ACTIVATE_MANAGE
+			} );
+
+			expect( state ).to.have.property( 'isActivating' )
+				.to.be.true;
+		} );
+
+		it( 'should mark manage as activated when request completes', () => {
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_ACTIVATE_MANAGE_RECEIVE,
+				data: {
+					result: true
+				}
+			} );
+
+			expect( state ).to.have.property( 'isActivating' )
+				.to.be.false;
+			expect( state ).to.have.property( 'manageActivated' )
+				.to.be.true;
+			expect( state ).to.have.property( 'manageActivatedError' )
+				.to.be.undefined;
+			expect( state ).to.have.property( 'activateManageSecret' )
+				.to.be.false;
+		} );
+
+		it( 'should store the error if an error occurs during manage activation', () => {
+			const error = 'There was an error while activating the module.';
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_ACTIVATE_MANAGE_RECEIVE,
+				error
+			} );
+
+			expect( state ).to.have.property( 'isActivating' )
+				.to.be.false;
+			expect( state ).to.have.property( 'manageActivated' )
+				.to.be.true;
+			expect( state ).to.have.property( 'manageActivatedError' )
+				.to.eql( error );
+			expect( state ).to.have.property( 'activateManageSecret' )
+				.to.be.false;
+		} );
+
+		it( 'should use default authorize state when setting an empty connect query', () => {
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_QUERY_SET
+			} );
+
+			expect( state ).to.have.property( 'queryObject' )
+				.to.eql( {} );
+			expect( state ).to.have.property( 'isAuthorizing' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeSuccess' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeError' )
+				.to.be.false;
+		} );
+
+		it( 'should use new query object over default authorize state when setting a connect query', () => {
+			const queryObject = {
+				redirect_uri: 'https://somewebsite.com'
+			};
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_QUERY_SET,
+				queryObject
+			} );
+
+			expect( state ).to.have.property( 'queryObject' )
+				.to.eql( queryObject );
+			expect( state ).to.have.property( 'isAuthorizing' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeSuccess' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeError' )
+				.to.be.false;
+		} );
+
+		it( 'should update only the specified query object property when updating a connect query', () => {
+			const state = jetpackConnectAuthorize( {
+				queryObject: {
+					client_id: 'example.com',
+					redirect_uri: 'https://example.com/',
+				}
+			}, {
+				type: JETPACK_CONNECT_QUERY_UPDATE,
+				property: 'redirect_uri',
+				value: 'https://anotherwebsite.com/'
+			} );
+
+			expect( state ).to.have.property( 'queryObject' )
+				.to.eql( {
+					client_id: 'example.com',
+					redirect_uri: 'https://anotherwebsite.com/'
+				} );
+		} );
+
+		it( 'should set isAuthorizing and autoAuthorize to true when initiating an account creation', () => {
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_CREATE_ACCOUNT
+			} );
+
+			expect( state ).to.have.property( 'isAuthorizing' )
+				.to.be.true;
+			expect( state ).to.have.property( 'authorizeSuccess' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeError' )
+				.to.be.false;
+			expect( state ).to.have.property( 'autoAuthorize' )
+				.to.be.true;
+		} );
+
+		it( 'should receive userData and bearer_token on successful account creation', () => {
+			const userData = {
+				ID: 123,
+				email: 'example@example.com'
+			};
+			const bearer_token = 'abcd1234';
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE,
+				userData,
+				data: {
+					bearer_token
+				}
+			} );
+
+			expect( state ).to.have.property( 'isAuthorizing' )
+				.to.be.true;
+			expect( state ).to.have.property( 'authorizeSuccess' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeError' )
+				.to.be.false;
+			expect( state ).to.have.property( 'autoAuthorize' )
+				.to.be.true;
+			expect( state ).to.have.property( 'userData' )
+				.to.eql( userData );
+			expect( state ).to.have.property( 'bearerToken' )
+				.to.eql( bearer_token );
+		} );
+
+		it( 'should mark authorizeError as true on unsuccessful account creation', () => {
+			const error = 'Sorry, that username already exists!';
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE,
+				error
+			} );
+
+			expect( state ).to.have.property( 'isAuthorizing' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeSuccess' )
+				.to.be.false;
+			expect( state ).to.have.property( 'authorizeError' )
+				.to.be.true;
+			expect( state ).to.have.property( 'autoAuthorize' )
+				.to.be.false;
+		} );
+
+		it( 'should set isRedirectingToWpAdmin to true when an xmlrpc error occurs', () => {
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL
+			} );
+
+			expect( state ).to.have.property( 'isRedirectingToWpAdmin' )
+				.to.be.true;
+		} );
+
+		it( 'should set isRedirectingToWpAdmin to true when a redirect to wp admin is triggered', () => {
+			const state = jetpackConnectAuthorize( undefined, {
+				type: JETPACK_CONNECT_REDIRECT_WP_ADMIN
+			} );
+
+			expect( state ).to.have.property( 'isRedirectingToWpAdmin' )
+				.to.be.true;
+		} );
+
+		it( 'should persist state', () => {
+			const originalState = deepFreeze( {
+				queryObject: {
+					client_id: 'example.com',
+					redirect_uri: 'https://example.com/',
+				}
+			} );
+			const state = jetpackConnectAuthorize( originalState, {
+				type: SERIALIZE
+			} );
+
+			expect( state ).to.be.eql( originalState );
+		} );
+
+		it( 'should load valid persisted state', () => {
+			const originalState = deepFreeze( {
+				queryObject: {
+					client_id: 'example.com',
+					redirect_uri: 'https://example.com/',
+				}
+			} );
+			const state = jetpackConnectAuthorize( originalState, {
+				type: DESERIALIZE
+			} );
+
+			expect( state ).to.be.eql( originalState );
 		} );
 	} );
 

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -389,7 +389,7 @@ describe( 'reducer', () => {
 				.to.eql( data.activate_manage );
 		} );
 
-		it( 'should set authorizeSuccess to false when an error occured during authorization', () => {
+		it( 'should set authorizeSuccess to false when an error occurred during authorization', () => {
 			const error = 'You need to stay logged in to your WordPress blog while you authorize Jetpack.';
 			const state = jetpackConnectAuthorize( undefined, {
 				type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
@@ -559,7 +559,7 @@ describe( 'reducer', () => {
 				.to.be.true;
 		} );
 
-		it( 'should receive userData and bearer_token on successful account creation', () => {
+		it( 'should receive userData and bearerToken on successful account creation', () => {
 			const userData = {
 				ID: 123,
 				email: 'example@example.com'
@@ -613,7 +613,7 @@ describe( 'reducer', () => {
 				.to.be.true;
 		} );
 
-		it( 'should set isRedirectingToWpAdmin to true when a redirect to wp admin is triggered', () => {
+		it( 'should set isRedirectingToWpAdmin to true when a redirect to wp-admin is triggered', () => {
 			const state = jetpackConnectAuthorize( undefined, {
 				type: JETPACK_CONNECT_REDIRECT_WP_ADMIN
 			} );


### PR DESCRIPTION
This PR adds some missing tests for the Jetpack Connect `jetpackConnectAuthorize()` reducer. 

To test:

* Checkout this branch at your Calypso development environment.
* In your command line terminal, navigate to your Calypso directory and run the following command: `npm run test-client -- --grep "state jetpack-connect reducer"`. 
* Verify all tests are passing ✅ .

![](https://cldup.com/DHDToG4EEt.png)

/cc @roccotripaldi 

Test live: https://calypso.live/?branch=add/jetpack-connect-authorize-more-reducer-tests