### PR TITLE
Jetpack Connect: Update tests for jetpackSSOSessions() reducer

### DIFF
--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -313,6 +313,30 @@ describe( 'reducer', () => {
 			expect( state[ 'website.com' ] ).to.have.property( 'timestamp' )
 				.to.be.at.least( nowTime );
 		} );
+
+		it( 'should persist state', () => {
+			const originalState = deepFreeze( {
+				ssoUrl: 'https://website.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
+				siteUrl: 'https://website.com'
+			} );
+			const state = jetpackSSOSessions( originalState, {
+				type: SERIALIZE
+			} );
+
+			expect( state ).to.be.eql( originalState );
+		} );
+
+		it( 'should load valid persisted state', () => {
+			const originalState = deepFreeze( {
+				ssoUrl: 'https://website.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
+				siteUrl: 'https://website.com'
+			} );
+			const state = jetpackSSOSessions( originalState, {
+				type: DESERIALIZE
+			} );
+
+			expect( state ).to.be.eql( originalState );
+		} );
 	} );
 
 	describe( '#jetpackConnectAuthorize()', () => {

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -296,7 +296,7 @@ describe( 'reducer', () => {
 
 	describe( '#jetpackSSOSessions()', () => {
 		it( 'should default to an empty object', () => {
-			const state = jetpackConnectAuthorize( undefined, {} );
+			const state = jetpackSSOSessions( undefined, {} );
 			expect( state ).to.eql( {} );
 		} );
 


### PR DESCRIPTION
This PR adds persistence tests for the Jetpack Connect `jetpackSSOSessions()` reducer. It also fixes the first test to actually test the right method.

To test:

* Checkout this branch at your Calypso development environment.
* In your command line terminal, navigate to your Calypso directory and run the following command: `npm run test-client -- --grep "state jetpack-connect reducer"`. 
* Verify all tests are passing ✅ .

/cc @roccotripaldi 

Test live: https://calypso.live/?branch=update/jetpack-connect-sso-sessions-tests