### PR TITLE
Jetpack Connect: Add persistence tests for the JetpackSSO() reducer

### DIFF
--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -784,5 +784,29 @@ describe( 'reducer', () => {
 
 			expect( state ).to.have.property( 'ssoUrl', action.ssoUrl );
 		} );
+
+		it( 'should not persist state', () => {
+			const originalState = deepFreeze( {
+				ssoUrl: 'http://website.com',
+				siteUrl: 'http://website.com'
+			} );
+			const state = jetpackSSO( originalState, {
+				type: SERIALIZE
+			} );
+
+			expect( state ).to.be.eql( {} );
+		} );
+
+		it( 'should not load persisted state', () => {
+			const originalState = deepFreeze( {
+				ssoUrl: 'http://website.com',
+				siteUrl: 'http://website.com'
+			} );
+			const state = jetpackSSO( originalState, {
+				type: DESERIALIZE
+			} );
+
+			expect( state ).to.be.eql( {} );
+		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds persistence tests for the Jetpack Connect `jetpackSSO()` reducer. 

To test:

* Checkout this branch at your Calypso development environment.
* In your command line terminal, navigate to your Calypso directory and run the following command: `npm run test-client -- --grep "state jetpack-connect reducer"`. 
* Verify all tests are passing ✅ .

/cc @roccotripaldi 

Test live: https://calypso.live/?branch=add/jetpack-connect-sso-reducer-persistence-tests