### PR TITLE
Plans: add and update personal 3G storage

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -467,9 +467,9 @@ export const featuresList = {
 		getTitle: () => i18n.translate( '3GB Storage Space' ),
 		getDescription: () => i18n.translate(
 			"With increased storage space you'll be able to upload " +
-			'more images, videos, audio, and documents to your website.'
+			'more images and documents to your website.'
 		),
-		plans: [ PLAN_FREE ]
+		plans: [ PLAN_FREE, PLAN_PERSONAL ]
 	},
 
 	[ FEATURE_13GB_STORAGE ]: {


### PR DESCRIPTION
This PR fixes #7744 issue.

### Testing

Hover over `3GB Storage Space` feature and check that `audio/video` isn't there anymore for `Personal` plan.

Pages to test:

* `http://calypso.localhost:3000/start/plans`
* `http://calypso.localhost:3000/plans/<site-id>`

![image](https://cloud.githubusercontent.com/assets/77539/18093810/9a6f6bf0-6ea7-11e6-8408-3b5b58efc4bb.png)

cc @lamosty

Test live: https://calypso.live/?branch=fix/plan-3g-storage-feature