### PR TITLE
Do not init PN support if SU is active

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -43,9 +43,6 @@ import {
 	recordTracksEvent,
 	bumpStat
 } from 'state/analytics/actions';
-import {
-	isSupportUserSession,
-} from 'lib/user/support-user-interop';
 
 const debug = debugFactory( 'calypso:push-notifications' );
 const DAYS_BEFORE_FORCING_REGISTRATION_REFRESH = 15;
@@ -55,6 +52,10 @@ const serviceWorkerOptions = {
 
 export function init() {
 	return dispatch => {
+		// require `lib/user/support-user-interop` here so that unit tests don't
+		// fail because of lack of `window` global when importing this module
+		// from test (before a chance to mock things is possible)
+		const isSupportUserSession = require( 'lib/user/support-user-interop' ).isSupportUserSession;
 		if ( isSupportUserSession() ) {
 			debug( 'Push Notifications are not supported when SU is active' );
 			dispatch( apiNotReady() );

--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -43,6 +43,9 @@ import {
 	recordTracksEvent,
 	bumpStat
 } from 'state/analytics/actions';
+import {
+	isSupportUserSession,
+} from 'lib/user/support-user-interop';
 
 const debug = debugFactory( 'calypso:push-notifications' );
 const DAYS_BEFORE_FORCING_REGISTRATION_REFRESH = 15;
@@ -52,6 +55,12 @@ const serviceWorkerOptions = {
 
 export function init() {
 	return dispatch => {
+		if ( isSupportUserSession() ) {
+			debug( 'Push Notifications are not supported when SU is active' );
+			dispatch( apiNotReady() );
+			return;
+		}
+
 		// Only continue if the service worker supports notifications
 		if ( ! isPushNotificationsSupported() ) {
 			debug( 'Push Notifications are not supported' );


### PR DESCRIPTION
This PR fixes the bug where a SU user would "steal" the normal user's browser notifications.

Steps to repro bug:

* Enable PNs for yourself on WordPress.com
* Use WP.com normally for some period of time (optional)
* Switch to another user by using user switching - PCYsg-7uD-p2
* Take no other action as that user (close the tab)
* Cause that user to receive a notification
* Notice you'll receive that user's push notifications

Acceptance criteria for fix:

- Given a WordPress.com user with Browser Notifications enabled,
- When I switch to another user by user switching, and trigger notifications for that user,
- Then I do not get notifications for that user.

Test live: https://calypso.live/?branch=fix/su-stealing-pns