### PR TITLE
Conversion: Add Expanded Google Analytics Nudge

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -13,10 +13,11 @@ import productsValues from 'lib/products-values';
 import protectForm from 'lib/mixins/protect-form';
 import Card from 'components/card';
 import Button from 'components/button';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
 import SectionHeader from 'components/section-header';
 import ExternalLink from 'components/external-link';
+import GoogleAnalyticsUpgradeNudge from 'blocks/upgrade-nudge-expanded';
 import { abtest } from 'lib/abtest';
+import { PLAN_BUSINESS, FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
 
 const debug = debugFactory( 'calypso:my-sites:site-settings' );
 
@@ -126,6 +127,7 @@ export default React.createClass( {
 
 		return (
 			<form id="site-settings" onSubmit={ this.submitForm } onChange={ this.markChanged }>
+				{ this.renderNudge() }
 				<SectionHeader label={ this.translate( 'Analytics Settings' ) }>
 					<Button
 						primary
@@ -140,7 +142,6 @@ export default React.createClass( {
 					</Button>
 				</SectionHeader>
 				<Card className="analytics-settings">
-					{ this.renderNudge() }
 					<fieldset>
 						<label htmlFor="wgaCode">{ this.translate( 'Google Analytics Tracking ID', { context: 'site setting' } ) }</label>
 						<input
@@ -178,7 +179,7 @@ export default React.createClass( {
 					{ this.translate( 'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
 						{
 							components: {
-								a: <a href="http://en.support.wordpress.com/google-analytics/" target="_blank" />
+								a: <a href="http://en.support.wordpress.com/google-analytics/" target="_blank" rel="noopener noreferrer" />
 							}
 						}
 					) }
@@ -197,15 +198,27 @@ export default React.createClass( {
 			return;
 		}
 
+		const { upgradeToBusiness } = this.props;
+
 		debug( 'Google analitics is not enabled. adding nudge ...' );
 
 		return (
-			<UpgradeNudge
-				title={ this.translate( 'Add Google Analytics' ) }
-				message={ this.translate( 'Upgrade to the business plan and include your own analytics tracking ID.' ) }
-				feature="google-analytics"
-				event="google_analytics_settings"
-				icon="stats-alt"
+			<GoogleAnalyticsUpgradeNudge
+				plan={ PLAN_BUSINESS }
+				upgrade={ upgradeToBusiness }
+				title={ this.translate( 'Upgrade to a Business Plan and Enable Google Analytics' ) }
+				subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable Google Analytics Tracking on your site.' ) }
+				highlightedFeature={ FEATURE_GOOGLE_ANALYTICS }
+				eventName={ "calypso_google_analytics_upgrade_nudge_impression" }
+				benefits={ [
+					this.translate( 'Analyze visitor traffic and paint a complete picture of your audience and their needs.' ),
+					this.translate(
+						'Track the routes people take to reach you and the devices they use to get there with ' +
+						'reporting tools like Traffic Sources.' ),
+					this.translate(
+						'Learn what people are looking for and what they like with In-Page Analytics. ' +
+						'Then tailor your marketing and site content for maximum impact.')
+				] }
 			/>
 		);
 	},

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -198,26 +198,27 @@ export default React.createClass( {
 			return;
 		}
 
-		const { upgradeToBusiness } = this.props;
-
 		debug( 'Google analitics is not enabled. adding nudge ...' );
 
 		return (
 			<GoogleAnalyticsUpgradeNudge
 				plan={ PLAN_BUSINESS }
-				upgrade={ upgradeToBusiness }
 				title={ this.translate( 'Upgrade to a Business Plan and Enable Google Analytics' ) }
 				subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable Google Analytics Tracking on your site.' ) }
 				highlightedFeature={ FEATURE_GOOGLE_ANALYTICS }
 				eventName={ "calypso_google_analytics_upgrade_nudge_impression" }
 				benefits={ [
-					this.translate( 'Analyze visitor traffic and paint a complete picture of your audience and their needs.' ),
+					this.translate(
+						'Analyze visitor traffic and paint a complete picture of your audience and their needs.'
+					),
 					this.translate(
 						'Track the routes people take to reach you and the devices they use to get there with ' +
-						'reporting tools like Traffic Sources.' ),
+						'reporting tools like Traffic Sources.'
+					),
 					this.translate(
 						'Learn what people are looking for and what they like with In-Page Analytics. ' +
-						'Then tailor your marketing and site content for maximum impact.')
+						'Then tailor your marketing and site content for maximum impact.'
+					)
 				] }
 			/>
 		);


### PR DESCRIPTION
Expands Google Analytics nudge in order to make it more informative. Old nudge is replaced with new `UpgradeNudgeExpanded` component.

Closes #7647

Test live: https://calypso.live/?branch=add/expanded-google-analytics-nudge

**Before:**

![googleanalyticsbefore](https://cloud.githubusercontent.com/assets/1182160/18096900/1d456924-6edc-11e6-91f9-e997f3bcc28a.png)

**After:** 

![googleanalyticsafter](https://cloud.githubusercontent.com/assets/1182160/18096915/24a3bf86-6edc-11e6-8f47-68de30ac5fd7.jpg)
