### PR TITLE
Push Notifications: disable PNs for Opera

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -30,10 +30,12 @@ import {
 	isEnabled,
 } from './selectors';
 import {
+	isOpera,
 	isPushNotificationsDenied,
 	isPushNotificationsSupported,
 	isUnsupportedChromeVersion,
-	getChromeVersion
+	getChromeVersion,
+	getOperaVersion,
 } from './utils';
 import {
 	isServiceWorkerSupported,
@@ -64,6 +66,18 @@ export function init() {
 			const chromeVersion = getChromeVersion();
 			dispatch( bumpStat( 'calypso_push_notif_unsup_chrome',
 				( chromeVersion > 39 && chromeVersion < 50 ) ? chromeVersion : 'other' )
+			);
+			dispatch( apiNotReady() );
+			return;
+		}
+
+		// Opera claims to support PNs, but doesn't
+		// http://forums.opera.com/discussion/1868659/opera-push-notifications/p1
+		if ( isOpera() ) {
+			debug( 'Push Notifications are not supported in Opera' );
+			const operaVersion = getOperaVersion();
+			dispatch( bumpStat( 'calypso_push_notif_unsup_opera',
+				( operaVersion > 15 && operaVersion < 100 ) ? operaVersion : 'other' )
 			);
 			dispatch( apiNotReady() );
 			return;

--- a/client/state/push-notifications/utils.js
+++ b/client/state/push-notifications/utils.js
@@ -31,3 +31,15 @@ export function isPushNotificationsDenied() {
 		'denied' === window.Notification.permission
 	);
 }
+
+export function isOpera() {
+	return getOperaVersion() !== -1
+}
+
+export function getOperaVersion() {
+	if ( window && window.navigator && window.navigator.appVersion ) {
+		const match = window.navigator.appVersion.match( /OPR\/(\d+)/ );
+		return match ? match[ 1 ] : -1;
+	}
+	return -1;
+}


### PR DESCRIPTION
All the feature-detection in place for Push Notifications in Opera passes, however, the feature ultimately fails when attempting to ask for permission.

It has been [reported to Opera](http://forums.opera.com/discussion/1868659/opera-push-notifications/p1), but there is not yet a response other than acknowledgement of the issue.

This PR disables the prompts for Opera by sniffing the UA string. Unfortunately this is the only thing we can do, as we cannot detect the feature is broken until we attempt to prompt the user for permission.

* In Opera, view the branch in calypso.live: https://calypso.live/?branch=update/push-notifications/opera-prompts
* In your console: `localStorage.setItem( 'debug', 'calypso:push-notifications' );`
* Visit https://calypso.live/me/notifications
* Make sure you see this message in the console: `Push Notifications are not supported in Opera`
* Make sure you do not see the prompt to enable notifications
* In the latest version of Chrome, visit https://calypso.live/me/notifications
* Make sure the preferences dialog for Push Notifications appears
* In the latest version of  Firefox, visit https://calypso.live/me/notifications
* Make sure the preferences dialog for Push Notifications appears