### PR TITLE
Editor: Prevent iframe mixed content failure from causing content not to be set

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -148,11 +148,13 @@ export class WebPreview extends Component {
 		}
 
 		debug( 'setIframeUrl', iframeUrl );
-		this.iframe.contentWindow.location.replace( iframeUrl );
-		this.setState( {
-			loaded: false,
-			iframeUrl: iframeUrl,
-		} );
+		try {
+			this.iframe.contentWindow.location.replace( iframeUrl );
+			this.setState( {
+				loaded: false,
+				iframeUrl: iframeUrl,
+			} );
+		} catch ( e ) {}
 	}
 
 	shouldRenderIframe() {


### PR DESCRIPTION
This pull request seeks to resolve an issue affecting sites configured neither to be Jetpack nor a mapped domain, but still have an HTTP `URL`. For these sites, when loading an existing post in the editor in Firefox, the content will fail to be set because the background iframe throws an error when attempting to replace the `src` with an HTTP URL, a mixed content violation in HTTPS environments. The changes herein cause this error to be silently swallowed, allowing the content to be set as expected.

Separately, we should seek to prevent these HTTP URLs from being used as the iframe preview `src`. We could consider [`postUtils.getPreviewURL`](https://github.com/Automattic/wp-calypso/blob/4f5b25a5039d4d32592f7745493c473f4e218879/client/lib/posts/utils.js#L27-L59) to always use the `options.unmapped_url` when known, instead of only for mapped domain sites.

__Testing instructions:__

Verify that previews are unaffected on a WordPress.com, Jetpack, and/or mapped domain site. Then verify that WordPress.com sites with HTTP home URL (internal only) allow content to be set in the editor. Because this is an issue with mixed content, testing must be performed in an HTTPS environment to be verified. For this purpose, check in https://calypso.live/?branch=fix/editor-firefox-http-url , not locally (unless you have configured a self-signed SSL certificate in your local environment).

__Caveats:__

This will not resolve the preview not being shown for these sites, but at least will allow the edited content to be set.

Ref: p1472492243000003-slack-calypso-editor , cc @stambizzle 