### PR TITLE
Reader: Full Post: Prefer the blavatar, then feed icon, then gravatar

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -12,6 +12,8 @@ import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import ReaderFollowButton from 'reader/follow-button';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
+import safeImageUrl from 'lib/safe-image-url';
+import resizeImageUrl from 'lib/resize-image-url';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
@@ -24,7 +26,7 @@ const AuthorCompactProfile = React.createClass( {
 	},
 
 	render() {
-		const { author, siteName, siteUrl, followCount, feedId, siteId } = this.props;
+		const { author, siteName, siteUrl, siteIcon, followCount, feedId, siteId } = this.props;
 
 		if ( ! author ) {
 			return null;
@@ -37,7 +39,10 @@ const AuthorCompactProfile = React.createClass( {
 
 		return (
 			<div className={ classes }>
-				<Gravatar size={ 96 } user={ author } />
+				{ siteIcon
+					? <img src={ resizeImageUrl( safeImageUrl( siteIcon ), { w: 96, h: 96 } ) } className="author-compact-profile__icon" />
+					: <Gravatar size={ 96 } user={ author } />
+				}
 				{ ! hasMatchingAuthorAndSiteNames &&
 					<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>{ author.name }</ReaderAuthorLink> }
 				{ siteName &&

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -52,6 +52,11 @@
 		}
 	}
 
+	.author-compact-profile__icon {
+		max-width: 96px;
+		max-height: 96px;
+	}
+
 	// If there's an author link, present site stream link in normal font weight
 	&.has-author-link {
 		.author-compact-profile__site-link {

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -55,6 +55,7 @@
 	.author-compact-profile__icon {
 		max-width: 96px;
 		max-height: 96px;
+		border-radius: 48px;
 	}
 
 	// If there's an author link, present site stream link in normal font weight

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -6,6 +6,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { translate } from 'i18n-calypso';
+import { get } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -81,7 +82,7 @@ export class FullPostView extends React.Component {
 	}
 
 	render() {
-		const { post, site } = this.props;
+		const { post, site, feed } = this.props;
 		const siteName = siteNameFromSiteAndPost( site, post );
 		const classes = { 'reader-full-post': true };
 		if ( post.site_ID ) {
@@ -107,7 +108,9 @@ export class FullPostView extends React.Component {
 							siteUrl= { post.site_URL }
 							followCount={ site && site.subscribers_count }
 							feedId={ post.feed_ID }
-							siteId={ post.site_ID } />
+							siteId={ post.site_ID }
+							siteIcon={ get( site, 'icon.img' ) || get( feed, 'image' ) }
+						/>
 						{ shouldShowComments( post ) &&
 							<CommentButton key="comment-button"
 								commentCount={ post.discussion.comment_count }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -89,7 +89,7 @@
 	z-index: z-index( '.masterbar', '.reader-profile' );
 	@include breakpoint( "<660px" ) {
 		margin-top: 20px;
-		.gravatar {
+		.gravatar, .author-compact-profile__icon {
 			display: inline-block;
 			vertical-align: bottom;
 			height: 24px;


### PR DESCRIPTION
This only applies for the refresh. 

The full post view shows an icon in the sidebar, which currently is always the gravatar. However, many sites don't have good gravatars, especially higher traffic sites, like VIPs. Instead, try to show the blavatar instead, followed by the feed icon, followed by the gravatar.

Test live: https://calypso.live/?branch=update/reader-refresh/full-post-icon-selection