### PR TITLE
Components: remove animate__appear animation usage

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -61,7 +61,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		if renderedLayout
 			#wpcom.wpcom-site!= renderedLayout
 		else
-			#wpcom.wpcom-site.animate__appear
+			#wpcom.wpcom-site
 				.wpcom-site__logo.noticon.noticon-wordpress
 		if badge
 			div.environment-badge


### PR DESCRIPTION
This PR removes an animate__appear animation that was added in #7713 

In non-chrome browsers, we were seeing the masterbar "pop" into position during page load and in subsequent page refreshes.

## Testing Instructions
- Load Calypso in FF, Safari or IE
- Does Calypso appear to load normally?

Test live: https://calypso.live/?branch=fix/remove-animation