### PR TITLE
Happychat Support Page

### DIFF
--- a/client/me/chat/index.jsx
+++ b/client/me/chat/index.jsx
@@ -1,0 +1,25 @@
+/*
+	External Deps
+*/
+import React from 'react';
+import page from 'page';
+
+/*
+	Internal deps
+*/
+import { renderWithReduxStore } from 'lib/react-helpers';
+import controller from 'me/controller';
+import LiveChat from 'components/happychat/page';
+
+const renderChat = ( context, next ) => {
+	renderWithReduxStore(
+		<LiveChat />,
+		document.getElementById( 'primary' ),
+		context.store
+	);
+	next();
+};
+
+export default () => {
+	page( '/me/chat', controller.sidebar, renderChat );
+};

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -61,7 +61,8 @@ const MeSidebar = React.createClass( {
 			'/me/notifications/subscriptions': 'notifications',
 			'/help/contact': 'help',
 			'/purchases': 'billing',
-			'/me/billing': 'billing'
+			'/me/billing': 'billing',
+			'/me/chat': 'happychat'
 		};
 		const filteredPath = context.path.replace( /\/\d+$/, '' ); // Remove ID from end of path
 		let selected;
@@ -160,6 +161,15 @@ const MeSidebar = React.createClass( {
 							onNavigate={ this.onNavigate }
 							preloadSectionName="help"
 						/>
+						{ config.isEnabled( 'happychat' )
+							? <SidebarItem
+								selected= { selected === 'happychat' }
+								link="/me/chat"
+								icon="comment"
+								label= { this.translate( 'Support Chat' ) }
+								onNavigate={ this.onNavigate } />
+							: null
+						}
 					</ul>
 				</SidebarMenu>
 			</Sidebar>

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -67,6 +67,13 @@ sections = [
 		secondary: true
 	},
 	{
+		name: 'chat',
+		paths: [ '/me/chat' ],
+		module: 'me/chat',
+		group: 'me',
+		secondary: true
+	},
+	{
 		name: 'media',
 		paths: [ '/media' ],
 		module: 'my-sites/media',

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -67,13 +67,6 @@ sections = [
 		secondary: true
 	},
 	{
-		name: 'chat',
-		paths: [ '/me/chat' ],
-		module: 'me/chat',
-		group: 'me',
-		secondary: true
-	},
-	{
 		name: 'media',
 		paths: [ '/media' ],
 		module: 'my-sites/media',
@@ -378,6 +371,16 @@ if ( config.isEnabled( 'manage/custom-post-types' ) ) {
 		module: 'my-sites/types',
 		secondary: true,
 		group: 'sites'
+	} );
+}
+
+if ( config.isEnabled( 'happychat' ) ) {
+	sections.push( {
+		name: 'chat',
+		paths: [ '/me/chat' ],
+		module: 'me/chat',
+		group: 'me',
+		secondary: true
 	} );
 }
 


### PR DESCRIPTION
Adds a happychat support page with a full page chat client.

Mobile clients are sent to this page instead of using the docked sidebar.

Depends on:

- #7758 
- #7760 

For more context see #7757 

Test live: https://calypso.live/?branch=add/happychat-page