### PR TITLE
Billing History: Display proper message when filter/search returns no results

### DIFF
--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -50,12 +50,14 @@ const BillingHistoryTable = React.createClass( {
 				components: { link: <a href="/plans" /> }
 			}
 		);
+		const noFilterResultsText = this.translate( 'No receipts found.' );
 		return (
 			<TransactionsTable
 				{ ...this.props }
 				initialFilter={ { date: { newest: 5 } } }
 				header
 				emptyTableText={ emptyTableText }
+				noFilterResultsText={ noFilterResultsText }
 				transactionRenderer={ this.renderTransaction } />
 		);
 	},

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -146,9 +146,15 @@ var TransactionsTable = React.createClass( {
 		}
 
 		if ( isEmpty( this.state.transactions ) ) {
+			let noResultsText;
+			if ( this.state.filter !== this.props.initialFilter ) {
+				noResultsText = this.props.noFilterResultsText;
+			} else {
+				noResultsText = this.props.emptyTableText;
+			}
 			return (
 				<tr className="billing-history__no-results">
-					<td className="billing-history__no-results-cell" colSpan="3">{ this.props.emptyTableText }</td>
+					<td className="billing-history__no-results-cell" colSpan="3">{ noResultsText }</td>
 				</tr>
 			);
 		}

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -27,6 +27,7 @@ module.exports = React.createClass( {
 				components: { link: <a href="/purchases" /> }
 			}
 		);
+		const noFilterResultsText = this.translate( 'No upcoming charges found.' );
 
 		if ( this.props.sites.initialized ) {
 			// `TransactionsTable` will render a loading state until the transactions are present
@@ -38,6 +39,7 @@ module.exports = React.createClass( {
 				transactions={ transactions }
 				initialFilter={ { date: { newest: 20 } } }
 				emptyTableText={ emptyTableText }
+				noFilterResultsText={ noFilterResultsText }
 				transactionRenderer={ this.renderTransaction } />
 		);
 	},


### PR DESCRIPTION
### The problem

In `/me/billing`, when you use any of the the transaction search forms or filters, if there are no results found, the displayed message is confusing. In that case we should display a message that indicates specifically that there are no results found.

**Current receipts table with no results**

![](https://cldup.com/KqLrfuaEPJ.png)

**Current upcoming charges table with no results**

![](https://cldup.com/goCZe90RHp.png)

### Proposed solution

If a filter or a search query is applied, let's display a specific message when no results are found.

**Proposed message for receipts table with no results when filtering/searching**

![](https://cldup.com/WWlT5dhHqk.png)

**Proposed message for upcoming charges table with no results when searching**

![](https://cldup.com/CR1aO-lT-K.png)

**Note:** This does not affect the case when there are no transactions initially - the original message that we use currently will still be displayed in that case.

### Testing

* Checkout this branch
* Go to `/me/billing`
* Test with a user with no purchases and upcoming charges
  * Verify that the original `You do not currently have any upgrades....` message is displayed in the purchases table.
  * Verify that the original `The upgrades on your account will not renew automatically....` message is displayed in the upcoming charges table.
* Test with a user with at least one purchase and at least one upcoming charge
  * Input some nonsense in the purchases search form and verify that the `No receipts found.` message is displayed.
  * Input some nonsense in the upcoming charges form and verify that the `No upcoming charges found.` message is displayed.

/cc @rickybanister for design review and @roccotripaldi for code review

Test live: https://calypso.live/?branch=update/me-billing-hitory-filter-not-found-text