### PR TITLE
Bump the `phone` module version up to 1.0.4-12

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2512,9 +2512,9 @@
       "version": "0.2.0"
     },
     "phone": {
-      "version": "1.0.4-11",
-      "from": "git+https://github.com/Automattic/node-phone.git#3161829eba3dbab67c69a3795f74765026d4337a",
-      "resolved": "git+https://github.com/Automattic/node-phone.git#3161829eba3dbab67c69a3795f74765026d4337a"
+      "version": "1.0.4-12",
+      "from": "git+https://github.com/Automattic/node-phone.git#f80b55251b54ab729f94c04f33ae1c7b2b2b0932",
+      "resolved": "git+https://github.com/Automattic/node-phone.git#f80b55251b54ab729f94c04f33ae1c7b2b2b0932"
     },
     "photon": {
       "version": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "page": "1.6.4",
     "path-parser": "1.0.2",
     "percentage-regex": "3.0.0",
-    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-11",
+    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-12",
     "photon": "2.0.0",
     "postcss-cli": "2.5.1",
     "q": "1.0.1",


### PR DESCRIPTION
This update of `phone` module is specifically for correctly validating phone numbers from Trinidad and Tobago. The number format is +1 868 xxxxxxx.

### How to test

1. Go to http://calypso.localhost:3000/me/security/two-step
1. Choose Trinidad and Tobago as the country
1. Enter 1234567. The number should be validated correctly, while it will fail before this patch.

Test live: https://calypso.live/?branch=update/bump-node-phone-version