### PR TITLE
SSR: Remove redundant stat

### DIFF
--- a/server/render/index.js
+++ b/server/render/index.js
@@ -57,10 +57,6 @@ export function render( element, key = JSON.stringify( element ) ) {
 		const rtsTimeMs = Date.now() - startTime;
 		debug( 'Server render time (ms)', rtsTimeMs );
 
-		if ( rtsTimeMs > 15 ) {
-			// legacy stat from when we only had very simple server-renders
-			bumpStat( 'calypso-ssr', 'loggedout-design-over-15ms-rendertostring' );
-		}
 		if ( rtsTimeMs > 100 ) {
 			// Server renders should probably never take longer than 100ms
 			bumpStat( 'calypso-ssr', 'over-100ms-rendertostring' );


### PR DESCRIPTION
No visual change.

Remove the >15ms server-render-time stat now that we regularly have server renders that take longer than this. The >15ms stat always shadows the cache miss stat, and the >100ms stat is more useful for spotting unexpected behavior.

Test live: https://calypso.live/?branch=update/theme-ssr-stats