### PR TITLE
Popover: update main popover class name

### DIFF
--- a/client/components/popover/docs/example.jsx
+++ b/client/components/popover/docs/example.jsx
@@ -296,7 +296,7 @@ const Popovers = React.createClass( {
 
 	render() {
 		return (
-			<div className="design-assets__group">
+			<div className="docs__design-assets__group">
 				<h2>
 					<a href="/devdocs/design/popovers">Popovers</a>
 				</h2>


### PR DESCRIPTION
It rolls back changes done in #7505 since tests have been updated thanks to @hoverduck https://github.com/Automattic/wp-calypso/pull/7505#issuecomment-243478169

![image](https://cloud.githubusercontent.com/assets/77539/18128681/68c63dac-6f5d-11e6-974c-6703b7f5cb78.png)

cc @mtias @hoverduck 



Test live: https://calypso.live/?branch=update/popover-instance-component