### PR TITLE
Plugins: Resolve back behavior when having navigated from other section

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -264,6 +264,12 @@ const controller = {
 
 	setupPlugins( context ) {
 		renderProvisionPlugins( context );
+	},
+
+	resetHistory( context, next ) {
+		lastPluginsListVisited = null;
+		lastPluginsQuerystring = null;
+		next();
 	}
 };
 

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -51,12 +51,19 @@ function renderSinglePlugin( context, siteUrl ) {
 	// Scroll to the top
 	window.scrollTo( 0, 0 );
 
+	let prevPath;
+	if ( lastPluginsListVisited ) {
+		prevPath = lastPluginsListVisited;
+	} else if ( context.prevPath ) {
+		prevPath = route.sectionify( context.prevPath );
+	}
+
 	// Render single plugin component
 	renderWithReduxStore(
 		React.createElement( PluginComponent, {
 			path: context.path,
-			prevPath: lastPluginsListVisited || context.prevPath,
 			prevQuerystring: lastPluginsQuerystring,
+			prevPath,
 			sites,
 			pluginSlug,
 			siteUrl,

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -27,5 +27,6 @@ module.exports = function() {
 		} );
 
 		page( '/plugins/:plugin/:business_plugin?/:site_id?', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, null ), pluginsController.plugin );
+		page.exit( '/plugins*', pluginsController.resetHistory );
 	}
 };


### PR DESCRIPTION
Related: #7593

This pull request seeks to resolve an issue where the Back button on a plugin detail page may navigate to an invalid path if the user had navigated to the detail page from another site-specific Calypso section. For example, in #7593, after clicking Back, the user is navigated to `/settings/writing/example.wordpress.com/example.wordpress.com` . This is because the [plugin "go back" logic](https://github.com/Automattic/wp-calypso/blob/69394d0850edac76503f238dedc5447173be4db1/client/my-sites/plugins/plugin.jsx#L142-L159) assumes that the incoming previous path has already had the site fragment removed.

In implementing this, I'd also observed another issue: If starting on the plugins screen for a site, then navigating to a screen which directs you back to the plugin detail screen, clicking the Back button will return you to the initial plugins screen, not the page to which you had later navigated, because the internal routing state (`lastPluginsListVisited`) is never reset. A fix has been included with the changes here.

__Implementation notes:__

I'd suggest two additional revisions be made in the future:

- Try to leverage a simple `page.back()` history call instead. I'm not sure why we need to track internal plugin history the way we do.
- Consider using [`route.addSiteFragment`](https://github.com/Automattic/wp-calypso/blob/69394d0850edac76503f238dedc5447173be4db1/client/lib/route/path.js#L50-L64) instead of the custom logic in `getPreviousListUrl`

cc @enejb @johnHackworth 

__Testing instructions:__

It's easiest to test in the context of #7593. After switching branches, I'd suggest cherry-picking the commit to reenable the upgrade notice:

```
git cherry-pick c18a36c0c084103d08fbdf25f3f18554257ed21e
```

Testing #7593 assumes a Jetpack site running 4.1.1 or older ([zip download](https://downloads.wordpress.org/plugin/jetpack.4.1.1.zip)).

1. Navigate to My Sites
2. Switch to your Jetpack site
3. Navigate to Plugins in the sidebar
4. Navigate to Settings in the sidebar
5. Switch to Writing tab
6. Click "Update" in notice prompt shown
7. (Optional) Update the plugin
8. Click "Back" in plugin detail Header Cake
9. Note that you are returned to the site writing settings

cc @timmyc 

Test live: https://calypso.live/?branch=fix/jetpack-plugins-back