### PR TITLE
Me: ES6ify the Profile Links components

### DIFF
--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -1,25 +1,24 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var ActionRemove = require( 'me/action-remove' ),
-	safeProtocolUrl = require( 'lib/safe-protocol-url' ),
-	eventRecorder = require( 'me/event-recorder' );
-
+import ActionRemove from 'me/action-remove';
+import safeProtocolUrl from 'lib/safe-protocol-url';
+import eventRecorder from 'me/event-recorder';
 import { withoutHttp } from 'lib/url';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'ProfileLink',
 
 	mixins: [ eventRecorder ],
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			imageSize: 100,
 			title: '',
@@ -36,7 +35,7 @@ module.exports = React.createClass( {
 		slug: React.PropTypes.string.isRequired
 	},
 
-	renderRemove: function() {
+	renderRemove() {
 		return (
 			<ActionRemove
 				className="profile-link__remove"
@@ -45,8 +44,8 @@ module.exports = React.createClass( {
 		);
 	},
 
-	render: function() {
-		var classes = classNames( {
+	render() {
+		const classes = classNames( {
 				'profile-link': true,
 				'is-placeholder': this.props.isPlaceholder
 			} ),

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -1,25 +1,25 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	LinkedStateMixin = require( 'react-addons-linked-state-mixin' );
+import React from 'react';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
 
 /**
  * Internal dependencies
  */
-var FormFieldset = require( 'components/forms/form-fieldset' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
-	FormButton = require( 'components/forms/form-button' ),
-	eventRecorder = require( 'me/event-recorder' ),
-	Notice = require( 'components/notice' );
+import FormFieldset from 'components/forms/form-fieldset';
+import FormTextInput from 'components/forms/form-text-input';
+import FormButton from 'components/forms/form-button';
+import eventRecorder from 'me/event-recorder';
+import Notice from 'components/notice';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'ProfileLinksAddOther',
 
 	mixins: [ LinkedStateMixin, eventRecorder ],
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			title: '',
 			value: '',
@@ -30,8 +30,8 @@ module.exports = React.createClass( {
 	// As the user types, the component state changes thanks to the LinkedStateMixin.
 	// This function, called in render, validates their input on each state change
 	// and is used to decide whether or not to enable the Add Site button
-	getFormDisabled: function() {
-		var trimmedValue = this.state.value.trim();
+	getFormDisabled() {
+		const trimmedValue = this.state.value.trim();
 
 		if ( ! this.state.title.trim() || ! trimmedValue ) {
 			return true;
@@ -57,7 +57,7 @@ module.exports = React.createClass( {
 		return false;
 	},
 
-	onSubmit: function( event ) {
+	onSubmit( event ) {
 		event.preventDefault();
 
 		// When the form's submit button is disabled, the form's onSubmit does not
@@ -76,12 +76,12 @@ module.exports = React.createClass( {
 		);
 	},
 
-	onCancel: function( event ) {
+	onCancel( event ) {
 		event.preventDefault();
 		this.props.onCancel();
 	},
 
-	onSubmitResponse: function( error, data ) {
+	onSubmitResponse( error, data ) {
 		if ( error ) {
 			this.setState(
 				{
@@ -105,11 +105,13 @@ module.exports = React.createClass( {
 		}
 	},
 
-	clearLastError: function() {
-		this.setState( { lastError: false } );
+	clearLastError() {
+		this.setState( {
+			lastError: false
+		} );
 	},
 
-	possiblyRenderError: function() {
+	possiblyRenderError() {
 		if ( ! this.state.lastError ) {
 			return null;
 		}
@@ -124,7 +126,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	render: function() {
+	render() {
 		return (
 			<form className="profile-links-add-other" onSubmit={ this.onSubmit }>
 				<p>

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -52,7 +52,7 @@ export default React.createClass( {
 	},
 
 	onAddableSubmit( event ) {
-		let links = [];
+		const links = [];
 		let siteID, site, inputName;
 
 		event.preventDefault();

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -1,19 +1,21 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	FormButton = require( 'components/forms/form-button' ),
-	Notice = require( 'components/notice' ),
-	Site = require( 'blocks/site' ),
-	sites = require( 'lib/sites-list' )(),
-	eventRecorder = require( 'me/event-recorder' );
+import config from 'config';
+import FormButton from 'components/forms/form-button';
+import Notice from 'components/notice';
+import Site from 'blocks/site';
+import sitesFactory from 'lib/sites-list';
+import eventRecorder from 'me/event-recorder';
 
-module.exports = React.createClass( {
+const sites = sitesFactory();
+
+export default React.createClass( {
 
 	displayName: 'ProfileLinksAddWordPress',
 
@@ -21,24 +23,24 @@ module.exports = React.createClass( {
 
 	// an empty initial state is required to keep render and handleCheckedChange
 	// code simpler / easier to maintain
-	getInitialState: function() {
+	getInitialState() {
 		return {};
 	},
 
-	handleCheckedChanged: function( event ) {
+	handleCheckedChanged( event ) {
 		var updates = {};
 		updates[ event.target.name ] = event.target.checked;
 		this.setState( updates );
 	},
 
-	onSelect: function( inputName, event ) {
+	onSelect( inputName, event ) {
 		var updates = {};
 		event.preventDefault();
 		updates[ inputName ] = ! this.state[ inputName ];
 		this.setState( updates );
 	},
 
-	getCheckedCount: function() {
+	getCheckedCount() {
 		var inputName;
 		var checkedCount = 0;
 		for ( inputName in this.state ) {
@@ -49,7 +51,7 @@ module.exports = React.createClass( {
 		return checkedCount;
 	},
 
-	onAddableSubmit: function( event ) {
+	onAddableSubmit( event ) {
 		var links = [];
 		var inputName, siteID, site;
 		event.preventDefault();
@@ -58,31 +60,34 @@ module.exports = React.createClass( {
 			if ( 'site-' === inputName.substr( 0, 5 ) && this.state[inputName] ) {
 				siteID = parseInt( inputName.substr( 5 ), 10 ); // strip leading "site-" from inputName to get siteID
 				site = sites.getSite( siteID );
-				links.push( { title: site.name, value: site.URL } );
+				links.push( {
+					title: site.name,
+					value: site.URL
+				} );
 			}
 		}
 
 		this.props.userProfileLinks.addProfileLinks( links, this.onSubmitResponse );
 	},
 
-	onCancel: function( event ) {
+	onCancel( event ) {
 		event.preventDefault();
 		this.props.onCancel();
 	},
 
-	onCreateSite: function( event ) {
+	onCreateSite( event ) {
 		event.preventDefault();
 		window.open( config( 'signup_url' ) + '?ref=me-profile-links' );
 		this.props.onCancel();
 	},
 
-	onJetpackMe: function( event ) {
+	onJetpackMe( event ) {
 		event.preventDefault();
 		window.open( 'http://jetpack.me/' );
 		this.props.onCancel();
 	},
 
-	onSubmitResponse: function( error, data ) {
+	onSubmitResponse( error, data ) {
 		if ( error ) {
 			this.setState(
 				{
@@ -105,11 +110,13 @@ module.exports = React.createClass( {
 		this.props.onSuccess();
 	},
 
-	clearLastError: function() {
-		this.setState( { lastError: false } );
+	clearLastError() {
+		this.setState( {
+			lastError: false
+		} );
 	},
 
-	possiblyRenderError: function() {
+	possiblyRenderError() {
 		if ( ! this.state.lastError ) {
 			return null;
 		}
@@ -124,10 +131,10 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderAddableSites: function() {
+	renderAddableSites() {
 		return (
-			sites.getPublic().map( function( site ) {
-				var inputName, checkedState;
+			sites.getPublic().map( ( site ) => {
+				let inputName, checkedState;
 
 				if ( this.props.userProfileLinks.isSiteInProfileLinks( site ) ) {
 					return null;
@@ -150,12 +157,12 @@ module.exports = React.createClass( {
 							onSelect={ this.onSelect.bind( this, inputName ) } />
 					</li>
 				);
-			}.bind( this ) )
+			} )
 		);
 	},
 
-	renderAddableSitesForm: function() {
-		var checkedCount = this.getCheckedCount();
+	renderAddableSitesForm() {
+		const checkedCount = this.getCheckedCount();
 
 		return (
 			<form className="profile-links-add-wordpress" onSubmit={ this.onAddableSubmit }>
@@ -183,7 +190,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderInvitationForm: function() {
+	renderInvitationForm() {
 		return (
 			<form>
 				<p>
@@ -194,7 +201,11 @@ module.exports = React.createClass( {
 							'sites here after installing {{jetpackLink}}Jetpack{{/jetpackLink}} on them.',
 							{
 								components: {
-									jetpackLink: <a href="#" className="profile-links-add-wordpress__jetpack-link" onClick={ this.recordClickEvent( 'Jetpack Link in Profile Links', this.onJetpackMe ) }/>
+									jetpackLink: <a
+													href="#"
+													className="profile-links-add-wordpress__jetpack-link"
+													onClick={ this.recordClickEvent( 'Jetpack Link in Profile Links', this.onJetpackMe ) }
+												 />
 								}
 							}
 						)
@@ -216,7 +227,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	render: function() {
+	render() {
 		return (
 			<div>
 				{ 0 === sites.getPublic().length ? this.renderInvitationForm() : this.renderAddableSitesForm() }

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -28,21 +28,21 @@ export default React.createClass( {
 	},
 
 	handleCheckedChanged( event ) {
-		var updates = {};
+		const updates = {};
 		updates[ event.target.name ] = event.target.checked;
 		this.setState( updates );
 	},
 
 	onSelect( inputName, event ) {
-		var updates = {};
+		const updates = {};
 		event.preventDefault();
 		updates[ inputName ] = ! this.state[ inputName ];
 		this.setState( updates );
 	},
 
 	getCheckedCount() {
-		var inputName;
-		var checkedCount = 0;
+		let checkedCount = 0;
+		let inputName;
 		for ( inputName in this.state ) {
 			if ( this.state[ inputName ] ) {
 				checkedCount++;
@@ -52,12 +52,13 @@ export default React.createClass( {
 	},
 
 	onAddableSubmit( event ) {
-		var links = [];
-		var inputName, siteID, site;
+		let links = [];
+		let siteID, site, inputName;
+
 		event.preventDefault();
 
 		for ( inputName in this.state ) {
-			if ( 'site-' === inputName.substr( 0, 5 ) && this.state[inputName] ) {
+			if ( 'site-' === inputName.substr( 0, 5 ) && this.state[ inputName ] ) {
 				siteID = parseInt( inputName.substr( 5 ), 10 ); // strip leading "site-" from inputName to get siteID
 				site = sites.getSite( siteID );
 				links.push( {
@@ -134,17 +135,19 @@ export default React.createClass( {
 	renderAddableSites() {
 		return (
 			sites.getPublic().map( ( site ) => {
-				let inputName, checkedState;
+				const inputName = 'site-' + site.ID;
+				const checkedState = this.state[ inputName ];
 
 				if ( this.props.userProfileLinks.isSiteInProfileLinks( site ) ) {
 					return null;
 				}
 
-				inputName = 'site-' + site.ID;
-				checkedState = this.state[ inputName ];
-
 				return (
-					<li key={ site.ID } className="profile-links-add-wordpress__item" onClick={ this.recordCheckboxEvent( 'Add WordPress Site' ) }>
+					<li
+						key={ site.ID }
+						className="profile-links-add-wordpress__item"
+						onClick={ this.recordCheckboxEvent( 'Add WordPress Site' ) }
+					>
 						<input
 							className="profile-links-add-wordpress__checkbox"
 							type="checkbox"
@@ -205,7 +208,7 @@ export default React.createClass( {
 													href="#"
 													className="profile-links-add-wordpress__jetpack-link"
 													onClick={ this.recordClickEvent( 'Jetpack Link in Profile Links', this.onJetpackMe ) }
-												 />
+												/>
 								}
 							}
 						)

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -1,42 +1,42 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	times = require( 'lodash/times' );
+import React from 'react';
+import times from 'lodash/times';
 
 /**
  * Internal dependencies
  */
-var ProfileLink = require( 'me/profile-link' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	AddProfileLinksButtons = require( 'me/profile-links/add-buttons' ),
-	SectionHeader = require( 'components/section-header' ),
-	Card = require( 'components/card' ),
-	Notice = require( 'components/notice' ),
-	eventRecorder = require( 'me/event-recorder' ),
-	ProfileLinksAddWordPress = require( 'me/profile-links-add-wordpress' ),
-	ProfileLinksAddOther = require( 'me/profile-links-add-other' );
+import ProfileLink from 'me/profile-link';
+import observe from 'lib/mixins/data-observe';
+import AddProfileLinksButtons from 'me/profile-links/add-buttons';
+import SectionHeader from 'components/section-header';
+import Card from 'components/card';
+import Notice from 'components/notice';
+import eventRecorder from 'me/event-recorder';
+import ProfileLinksAddWordPress from 'me/profile-links-add-wordpress';
+import ProfileLinksAddOther from 'me/profile-links-add-other';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'ProfileLinks',
 
 	mixins: [ observe( 'userProfileLinks' ), eventRecorder ],
 
-	componentDidMount: function() {
+	componentDidMount() {
 		this.props.userProfileLinks.getProfileLinks();
 		if ( typeof document.hidden !== 'undefined' ) {
 			document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
 		}
 	},
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		if ( typeof document.hidden !== 'undefined' ) {
 			document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );
 		}
 	},
 
-	handleVisibilityChange: function() {
+	handleVisibilityChange() {
 		// if we're visible now, fetch the links again in case they
 		// changed (added/removed) something while the component this tab
 		// is on was hidden
@@ -45,7 +45,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			userProfileLinks: {
 				initialized: false
@@ -53,7 +53,7 @@ module.exports = React.createClass( {
 		};
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			showingForm: false,
 			lastError: false,
@@ -61,91 +61,108 @@ module.exports = React.createClass( {
 		};
 	},
 
-	showAddWordPress: function() {
-		this.setState( { showingForm: 'wordpress', showPopoverMenu: false } );
+	showAddWordPress() {
+		this.setState( {
+			showingForm: 'wordpress',
+			showPopoverMenu: false
+		} );
 	},
 
-	showAddOther: function() {
-		this.setState( { showingForm: 'other', showPopoverMenu: false } );
+	showAddOther() {
+		this.setState( {
+			showingForm: 'other',
+			showPopoverMenu: false
+		} );
 	},
 
-	showPopoverMenu: function() {
+	showPopoverMenu() {
 		this.setState( {
 			showPopoverMenu: ! this.state.showPopoverMenu
 		} );
 	},
 
-	closePopoverMenu: function() {
-		this.setState( { showPopoverMenu: false } );
+	closePopoverMenu() {
+		this.setState( {
+			showPopoverMenu: false
+		} );
 	},
 
-	hideForms: function() {
-		this.setState( { showingForm: false } );
+	hideForms() {
+		this.setState( {
+			showingForm: false
+		} );
 	},
 
-	onRemoveLinkResponse: function( error ) {
+	onRemoveLinkResponse( error ) {
 		if ( error ) {
-			this.setState( { lastError: error } );
+			this.setState( {
+				lastError: error
+			} );
 		} else {
-			this.setState( { lastError: false } );
+			this.setState( {
+				lastError: false
+			} );
 		}
 	},
 
-	clearLastError: function() {
-		this.setState( { lastError: false } );
+	clearLastError() {
+		this.setState( {
+			lastError: false
+		} );
 	},
 
-	onRemoveLink: function( profileLink ) {
+	onRemoveLink( profileLink ) {
 		this.props.userProfileLinks.deleteProfileLinkBySlug( profileLink.link_slug, this.onRemoveLinkResponse );
 	},
 
-	possiblyRenderError: function() {
+	possiblyRenderError() {
 		if ( ! this.state.lastError ) {
 			return null;
 		}
 
 		return (
-				<Notice className="profile-links__error"
-					status="is-error"
-					onDismissClick={ this.clearLastError }>
-					{ this.translate( 'An error occurred while attempting to remove the link. Please try again later.' ) }
-				</Notice>
+			<Notice className="profile-links__error"
+				status="is-error"
+				onDismissClick={ this.clearLastError }>
+				{ this.translate( 'An error occurred while attempting to remove the link. Please try again later.' ) }
+			</Notice>
 		);
 	},
 
-	renderProfileLinksList: function() {
+	renderProfileLinksList() {
 		return (
 			<ul className="profile-links__list">
-				{ this.props.userProfileLinks.getProfileLinks().map( function( profileLink ) {
-					return (
-						<ProfileLink
-							key={ profileLink.link_slug }
-							title={ profileLink.title }
-							url={ profileLink.value }
-							slug={ profileLink.link_slug }
-							onRemoveLink={ this.onRemoveLink.bind( this, profileLink ) } />
-					);
-				}, this )
-			}
+				{
+					this.props.userProfileLinks.getProfileLinks().map( ( profileLink ) =>
+						(
+							<ProfileLink
+								key={ profileLink.link_slug }
+								title={ profileLink.title }
+								url={ profileLink.value }
+								slug={ profileLink.link_slug }
+								onRemoveLink={ this.onRemoveLink.bind( this, profileLink ) } />
+						)
+					)
+				}
 			</ul>
 		);
 	},
 
-	renderNoProfileLinks: function() {
+	renderNoProfileLinks() {
 		return (
 			<p className="profile-links__no-links">
 				{
-					this.translate( 'You have no sites in your profile links. You may add sites if you\'d like.' )
+					this.translate( `You have no sites in your profile links. You may add sites if you'd like.` )
 				}
 			</p>
 		);
 	},
 
-	renderPlaceholders: function() {
+	renderPlaceholders() {
 		return (
 			<ul className="profile-links__list">
-				{ times( 2, function( index ) {
-					return (
+				{ times( 2, ( index ) =>
+					(
 						<ProfileLink
 							title="Loading Profile Links"
 							url="http://wordpress.com"
@@ -153,16 +170,16 @@ module.exports = React.createClass( {
 							isPlaceholder
 							key={ index }
 						/>
-					);
-				} ) }
+					)
+				) }
 			</ul>
 		);
 	},
 
 	renderProfileLinks() {
-		let links,
-			initialized = this.props.userProfileLinks.initialized,
+		const initialized = this.props.userProfileLinks.initialized,
 			countLinks = this.props.userProfileLinks.getProfileLinks().length;
+		let links;
 
 		if ( ! initialized ) {
 			links = this.renderPlaceholders();
@@ -202,7 +219,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	render: function() {
+	render() {
 		return(
 			<div>
 				<SectionHeader label={ this.translate( 'Profile Links' ) }>

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -152,7 +152,7 @@ export default React.createClass( {
 		return (
 			<p className="profile-links__no-links">
 				{
-					this.translate( `You have no sites in your profile links. You may add sites if you'd like.` )
+					this.translate( 'You have no sites in your profile links. You may add sites if you\'d like.' )
 				}
 			</p>
 		);
@@ -220,7 +220,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		return(
+		return (
 			<div>
 				<SectionHeader label={ this.translate( 'Profile Links' ) }>
 					<AddProfileLinksButtons
@@ -230,7 +230,8 @@ export default React.createClass( {
 						showPopoverMenu={ this.state.showPopoverMenu }
 						onShowAddWordPress={ this.showAddWordPress }
 						onShowPopoverMenu={ this.showPopoverMenu }
-						onClosePopoverMenu={ this.closePopoverMenu }/>
+						onClosePopoverMenu={ this.closePopoverMenu }
+					/>
 				</SectionHeader>
 				<Card>
 					{ !! this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }


### PR DESCRIPTION
This PR ES6ifies the Profile Links components (`profile-link`, `profile-links`, `profile-links-add-other` and `profile-links-add-wordpress`):

* Replacing `require` with `import`
* Replacing `module.exports` with `export default`
* Replacing `var` with `let` or `const`
* Using method shorthand
* Using `this` instead of `this.constructor`
* Improving spacing and formatting here and there
* Fixing too long lines

These components are used in `/me`, in the **Profile Links** card.

Note: there are `target="_blank"` occurrences which are to be fixed in a separate PR: https://github.com/Automattic/wp-calypso/pull/7680.

To test:
* Get this branch going
* Go to `/me`
* Inspect the **Profile Links** card and verify there are no regressions in its functionality and appearance, including:
  * Verify adding a WordPress link works and stores it properly
  * Verify adding another URL works and stores it properly
  * Verify deleting a link works properly
  * Verify existing links are rendered properly
  * Verify the proper message is displayed when there are no profile links

/cc @roccotripaldi

Test live: https://calypso.live/?branch=update/es6ify-me-profile-link