### PR TITLE
Reader: Look for post_thumbnail when picking features

### DIFF
--- a/client/lib/post-normalizer/rule-first-pass-canonical-image.js
+++ b/client/lib/post-normalizer/rule-first-pass-canonical-image.js
@@ -12,13 +12,21 @@ import startsWith from 'lodash/startsWith';
 import { imageSizeFromAttachments } from './utils';
 
 export default function firstPassCanonicalImage( post ) {
-	if ( post.featured_image ) {
+	if ( post.post_thumbnail ) {
+		const { URL: url, width, height } = post.post_thumbnail;
+		post.canonical_image = {
+			uri: url,
+			width,
+			height,
+			type: 'image'
+		};
+	} else if ( post.featured_image ) {
 		post.canonical_image = assign( {
 			uri: post.featured_image,
 			type: 'image'
 		}, imageSizeFromAttachments( post.featured_image ) );
 	} else {
-		let candidate = head( filter( post.attachments, function( attachment ) {
+		const candidate = head( filter( post.attachments, function( attachment ) {
 			return startsWith( attachment.mime_type, 'image/' );
 		} ) );
 

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -38,6 +38,12 @@ export default function pickCanonicalImage( post ) {
 				height: canonicalImage.naturalHeight
 			};
 		}
+	} else if ( post.post_thumbnail ) {
+		canonicalImage = {
+			uri: post.post_thumbnail.URL,
+			width: post.post_thumbnail.width,
+			height: post.post_thumbnail.height
+		};
 	} else if ( post.featured_image ) {
 		canonicalImage = {
 			uri: post.featured_image,

--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -13,6 +13,9 @@ export default function safeImagePropertiesForWidth( maxWidth ) {
 	return function safeImageProperties( post ) {
 		makeImageURLSafe( post.author, 'avatar_URL', maxWidth );
 		makeImageURLSafe( post, 'featured_image', maxWidth, post.URL );
+		if ( post.post_thumbnail ) {
+			makeImageURLSafe( post.post_thumbnail, 'URL', maxWidth, post.URL );
+		}
 		if ( post.featured_media && post.featured_media.type === 'image' ) {
 			makeImageURLSafe( post.featured_media, 'uri', maxWidth, post.URL );
 		}

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -22,7 +22,7 @@ function convertImageToObject( image ) {
 }
 
 function imageForURL( imageUrl ) {
-	var img = new Image();
+	const img = new Image();
 	img.src = imageUrl;
 	return img;
 }
@@ -53,7 +53,9 @@ export default function waitForImagesToLoad( post ) {
 
 		let imagesToCheck = [];
 
-		if ( post.featured_image ) {
+		if ( post.post_thumbnail ) {
+			imagesToCheck.push( post.post_thumbnail.URL );
+		} else if ( post.featured_image ) {
 			imagesToCheck.push( post.featured_image );
 		}
 

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -217,6 +217,12 @@ describe( 'index', function() {
 					uri: 'http://example.com/media.jpg',
 					type: 'image'
 				},
+				post_thumbnail: {
+					URL: 'http://example.com/thumb.jpg',
+					height: 1000,
+					width: 1000,
+					mime_type: ''
+				},
 				attachments: {
 					1234: {
 						mime_type: 'image/png',
@@ -231,6 +237,7 @@ describe( 'index', function() {
 			normalizer( post, [ normalizer.safeImageProperties( 200 ) ], function( err, normalized ) {
 				assert.strictEqual( normalized.author.avatar_URL, 'http://example.com/me.jpg-SAFE?w=200&quality=80&strip=info' );
 				assert.strictEqual( normalized.featured_image, 'http://foo.bar/-SAFE?w=200&quality=80&strip=info' );
+				assert.strictEqual( normalized.post_thumbnail.URL, 'http://example.com/thumb.jpg-SAFE?w=200&quality=80&strip=info' );
 				assert.strictEqual( normalized.featured_media.uri, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' );
 				assert.strictEqual( normalized.attachments[ '1234' ].URL, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' );
 				assert.strictEqual( normalized.attachments[ '3456' ].URL, 'http://example.com/media.jpg' );
@@ -638,6 +645,23 @@ describe( 'index', function() {
 				},
 				[ normalizer.pickCanonicalImage ], function( err, normalized ) {
 					assert.strictEqual( normalized.canonical_image.uri, 'http://example.com/featured.jpg' );
+					done( err );
+				}
+			);
+		} );
+
+		it( 'will pick post_thumbnail over featured_image if present and images missing', function( done ) {
+			normalizer(
+				{
+					featured_image: 'http://example.com/featured.jpg',
+					post_thumbnail: { URL: 'http://example.com/thumb.jpg', width: 1000, height: 1000, mime_type: '' },
+					featured_media: {
+						type: 'image',
+						uri: 'http://example.com/media.jpg'
+					}
+				},
+				[ normalizer.pickCanonicalImage ], function( err, normalized ) {
+					assert.strictEqual( normalized.canonical_image.uri, 'http://example.com/thumb.jpg' );
 					done( err );
 				}
 			);


### PR DESCRIPTION
post_thumbnail is more reliable than featured_image and already has the size info.

To test, pull up http://calypso.localhost:3000/read/feeds/23259639 and compare to production. Notice the features are being pulled from the post_thumb, not from the image in the content.

Test live: https://calypso.live/?branch=update/reader/post-thumbs-as-features