### PR TITLE
State: Sync sites-list to Redux state

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -91,7 +91,8 @@ const middleware = [ thunkMiddleware, noticesMiddleware, postsEditMiddleware ];
 if ( typeof window === 'object' ) {
 	// Browser-specific middlewares
 	middleware.push(
-		require( './analytics/middleware.js' ).analyticsMiddleware
+		require( './analytics/middleware.js' ).analyticsMiddleware,
+		require( './sites/middleware.js' )
 	);
 }
 

--- a/client/state/sites/middleware.js
+++ b/client/state/sites/middleware.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import sitesList from 'lib/sites-list';
+import { receiveSites } from 'state/sites/actions';
+
+export default ( { dispatch } ) => {
+	const sites = sitesList();
+	sites.on( 'change', () => {
+		dispatch( receiveSites( sites.get() ) );
+	} );
+
+	return ( next ) => ( action ) => next( action );
+};

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -33,7 +33,6 @@ export const sitesSchema = {
 				is_private: { type: 'boolean' },
 				is_following: { type: 'boolean' },
 				options: { type: 'object' },
-				meta: { type: 'object' },
 				user_can_manage: { type: 'boolean' },
 				is_vip: { type: 'boolean' },
 				is_multisite: { type: 'boolean' },

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -44,7 +44,7 @@ export const sitesSchema = {
 				},
 				plan: {
 					type: 'object',
-					required: [ 'product_id', 'product_slug', 'expired' ],
+					required: [ 'product_id', 'product_slug' ],
 					properties: {
 						product_id: { type: 'number' },
 						product_slug: { type: 'string' },


### PR DESCRIPTION
This pull request seeks to sync sites data from the legacy store to Redux state in an attempt to facilitate migration toward removing `lib/sites-list` altogether.

There has been previous discussions (p4TIVU-3B9-p2) and attempts (#2167) to address the need for all sites within Redux state. While the data duplication resulting from the migratory sync is not ideal (memory usage, potential for lack of follow-through), I'd argue there's not been presented a compelling alternative.

__Implementation notes:__

A few additional minor changes were included:

- The site `meta` property was removed from its schema, so as to avoid persisting this. Because we are likely storing much more data (especially for users with many sites), storage quotas become a concern. The `meta` property should likely never be necessary to have in the context of Calypso.
- The `plan.expired` property was set as required, but this property is not always present for some sites (notably, VIP sites). See r135973-wpcom, cc @eoigal, @gwwar 

__Testing instructions:__

There are no visual changes in this pull request. It's easiest to verify expected behavior using the [Redux DevTools Chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en). After loading the Calypso application, open the Chrome DevTools to the Redux tab, enter `SITES_RECEIVE` as a filter (or look for this action within the list). Note that the dispatched action includes an array of all sites received via the `lib/sites-list` request and that the affected state includes updating `state.sites.items` and `state.currentUser.capabilities` for the received sites.

cc @mtias 

Test live: https://calypso.live/?branch=add/sites-list-redux-sync