### PR TITLE
Plans: "Manage" link in plans card

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -20,7 +20,6 @@ const PlanFeaturesActions = ( {
 	freePlan = false,
 	onUpgradeClick = noop,
 	isPlaceholder = false,
-	manageHref = '',
 	isInSignup,
 	translate
 } ) => {
@@ -60,9 +59,6 @@ const PlanFeaturesActions = ( {
 	return (
 		<div className="plan-features__actions">
 			<div className="plan-features__actions-buttons">
-				{ ! isInSignup && current && manageHref.length > 0 &&
-					<Button className="plan-features__actions-button" href={ manageHref }>{ translate( 'Manage Plan' ) }</Button>
-				}
 				{ upgradeButton }
 			</div>
 		</div>
@@ -76,8 +72,7 @@ PlanFeaturesActions.propTypes = {
 	available: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	freePlan: PropTypes.bool,
-	isPlaceholder: PropTypes.bool,
-	manageHref: PropTypes.string
+	isPlaceholder: PropTypes.bool
 };
 
 export default localize( PlanFeaturesActions );

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -21,7 +21,8 @@ const PlanFeaturesActions = ( {
 	onUpgradeClick = noop,
 	isPlaceholder = false,
 	isInSignup,
-	translate
+	translate,
+	manageHref
 } ) => {
 	let upgradeButton;
 	const classes = classNames(
@@ -35,7 +36,7 @@ const PlanFeaturesActions = ( {
 
 	if ( current && ! isInSignup ) {
 		upgradeButton = (
-			<Button className={ classes } disabled>
+			<Button className={ classes } href={ manageHref }>
 				<Gridicon size={ 18 } icon="checkmark" />
 				{ translate( 'Your plan' ) }
 			</Button>

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -20,6 +20,7 @@ const PlanFeaturesActions = ( {
 	freePlan = false,
 	onUpgradeClick = noop,
 	isPlaceholder = false,
+	manageHref = '',
 	isInSignup,
 	translate
 } ) => {
@@ -59,6 +60,9 @@ const PlanFeaturesActions = ( {
 	return (
 		<div className="plan-features__actions">
 			<div className="plan-features__actions-buttons">
+				{ ! isInSignup && current && manageHref.length > 0 &&
+					<Button className="plan-features__actions-button" href={ manageHref }>{ translate( 'Manage Plan' ) }</Button>
+				}
 				{ upgradeButton }
 			</div>
 		</div>
@@ -72,7 +76,8 @@ PlanFeaturesActions.propTypes = {
 	available: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	freePlan: PropTypes.bool,
-	isPlaceholder: PropTypes.bool
+	isPlaceholder: PropTypes.bool,
+	manageHref: PropTypes.string
 };
 
 export default localize( PlanFeaturesActions );

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -36,7 +36,7 @@ const PlanFeaturesActions = ( {
 
 	if ( current && ! isInSignup ) {
 		upgradeButton = (
-			<Button className={ classes } href={ manageHref }>
+			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				<Gridicon size={ 18 } icon="checkmark" />
 				{ translate( 'Your plan' ) }
 			</Button>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -390,7 +390,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderBottomButtons() {
-		const { planProperties, isPlaceholder, isInSignup } = this.props;
+		const { planProperties, isPlaceholder, isInSignup, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -416,6 +416,7 @@ class PlanFeatures extends Component {
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
+						manageHref={ `/plans/my-sites/${ site.slug }` }
 					/>
 				</td>
 			);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -390,7 +390,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderBottomButtons() {
-		const { planProperties, isPlaceholder, isInSignup } = this.props;
+		const { planProperties, isPlaceholder, isInSignup, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -416,6 +416,7 @@ class PlanFeatures extends Component {
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
+						manageHref={ `/plans/my-plan/${ site.slug }` }
 					/>
 				</td>
 			);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -390,7 +390,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderBottomButtons() {
-		const { planProperties, isPlaceholder, isInSignup, site } = this.props;
+		const { planProperties, isPlaceholder, isInSignup } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -416,7 +416,6 @@ class PlanFeatures extends Component {
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
-						manageHref={ `/plans/my-plan/${ site.slug }` }
 					/>
 				</td>
 			);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -417,7 +417,7 @@ class PlanFeatures extends Component {
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
-						manageHref={ `/plans/my-sites/${ site.slug }` }
+						manageHref={ `/plans/my-plan/${ site.slug }` }
 					/>
 				</td>
 			);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -245,7 +245,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderTopButtons() {
-		const { planProperties, isPlaceholder, isInSignup } = this.props;
+		const { planProperties, isPlaceholder, isInSignup, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -273,6 +273,7 @@ class PlanFeatures extends Component {
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
+						manageHref={ `/plans/my-plan/${ site.slug }` }
 					/>
 				</td>
 			);

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -158,7 +158,6 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__table-item.is-bottom-buttons {
 	padding-top: 33px;
-	vertical-align: bottom;
 }
 
 .plan-features__table-item.is-top-buttons {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -158,6 +158,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__table-item.is-bottom-buttons {
 	padding-top: 33px;
+	vertical-align: bottom;
 }
 
 .plan-features__table-item.is-top-buttons {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -379,11 +379,6 @@ $plan-features-sidebar-width: 272px;
 	margin-top: 8px;
 
 	&.is-current {
-		border-bottom-width: 1px;
-		border-color: lighten( $gray, 27% );
-		background: transparent;
-		font-weight: 400;
-		color: $gray;
 
 		.gridicon {
 			fill: $alert-green;


### PR DESCRIPTION
Related to #5796

## Problem:

In the old /plans we had "Manage" link at the bottom. We lost it after plans-redesign:
https://cloud.githubusercontent.com/assets/548849/15832843/56e5839e-2c24-11e6-93a6-1ce210bdf2e4.png

# Solution

## Premium

<img width="970" alt="zrzut ekranu 2016-08-31 o 09 31 20" src="https://cloud.githubusercontent.com/assets/3775068/18138061/ceee5e8c-6f5f-11e6-9be8-e0bddce89363.png">

## Business

<img width="979" alt="zrzut ekranu 2016-08-31 o 09 31 52" src="https://cloud.githubusercontent.com/assets/3775068/18138068/d484c3ae-6f5f-11e6-9d90-ba4d13e62b33.png">

Link added.

## Testing

- Go to /plans, 
- verify that your plan has "Manage your plan"
- click it

CC @rralian @lamosty @gwwar @apeatling 

Test live: https://calypso.live/?branch=new/your-plan-link