### PR TITLE
Reader: ColdStart v4 - using Elasticsearch to recommended posts

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -18,8 +18,9 @@ module.exports = {
 	coldStartReader: {
 		datestamp: '20160804',
 		variations: {
-			noEmailColdStart: 20,
-			noChanges: 80
+			noEmailColdStartv3: 25,
+			noEmailColdStartv4: 25,
+			noChanges: 50
 		},
 		defaultVariation: 'noChanges',
 		allowExistingUsers: false,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1172,7 +1172,7 @@ Undocumented.prototype.fetchSiteRecommendations = function( query, fn ) {
 };
 
 Undocumented.prototype.readRecommendationsStart = function( query, fn ) {
-	return this.wpcom.req.get( '/read/recommendations/start', query, fn );
+	return this.wpcom.req.get( '/read/recommendations/posts', query, fn );
 };
 
 Undocumented.prototype.graduateNewReader = function( fn ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1031,8 +1031,10 @@ Undocumented.prototype.readTagPosts = function( query, fn ) {
 
 Undocumented.prototype.readRecommendedPosts = function( query, fn ) {
 	debug( '/recommendations/posts' );
-	query.apiVersion = '1.2';
-	this.wpcom.req.get( '/read/recommendations/posts', query, fn );
+	if ( !query.apiVersion ){
+		query.apiVersion = '1.2';
+	}
+	return this.wpcom.req.get( '/read/recommendations/posts', query, fn );
 };
 
 Undocumented.prototype.followReaderTag = function( tag, fn ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1172,7 +1172,7 @@ Undocumented.prototype.fetchSiteRecommendations = function( query, fn ) {
 };
 
 Undocumented.prototype.readRecommendationsStart = function( query, fn ) {
-	return this.wpcom.req.get( '/read/recommendations/posts', query, fn );
+	return this.wpcom.req.get( '/read/recommendations/start', query, fn );
 };
 
 Undocumented.prototype.graduateNewReader = function( fn ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -62,8 +62,7 @@ export default React.createClass( {
 
 		if ( config.isEnabled( 'reader/start' ) ) {
 			// User is participating in Reader Cold Start
-			if ( abtest( 'coldStartReader' ) === 'noEmailColdStart' ) {
-				userData.follow_default_blogs = false;
+			if ( abtest( 'coldStartReader' ) === 'noEmailColdStartv3' ) {
 				userData.subscription_delivery_email_default = 'never';
 				userData.is_new_reader = true;
 			}

--- a/client/state/reader/start/actions.js
+++ b/client/state/reader/start/actions.js
@@ -82,6 +82,7 @@ export function requestRecommendations( originSiteId, originPostId, limit ) {
 		}
 
 		const query = {
+			apiVersion: '1.3',
 			meta: 'site,post',
 			origin_site_ID: originSiteId,
 			origin_post_ID: originPostId,

--- a/client/state/reader/start/actions.js
+++ b/client/state/reader/start/actions.js
@@ -6,6 +6,7 @@ import map from 'lodash/map';
 import omit from 'lodash/omit';
 import property from 'lodash/property';
 import debugModule from 'debug';
+import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -81,8 +82,9 @@ export function requestRecommendations( originSiteId, originPostId, limit ) {
 			limit = 20;
 		}
 
-		const query = {
-			apiVersion: '1.3',
+		var getRecommendations;
+
+		var query = {
 			meta: 'site,post',
 			origin_site_ID: originSiteId,
 			origin_post_ID: originPostId,
@@ -92,7 +94,17 @@ export function requestRecommendations( originSiteId, originPostId, limit ) {
 		debug( 'Requesting recommendations for site ' + originSiteId +
 				' and post ' + originPostId );
 
-		return wpcom.undocumented().readRecommendationsStart( query )
+		// Participates in the ColdStart v4 (endpoint: readRecommendedPosts)
+		if ( abtest( 'coldStartReader' ) === 'noEmailColdStartv4' ) {
+			query.apiVersion = '1.3';
+			getRecommendations = wpcom.undocumented().readRecommendedPosts( query );
+		}
+		// Defaults to ColdStart v3 (endpoint: readRecommendationsStart)
+		else {
+			getRecommendations = wpcom.undocumented().readRecommendationsStart( query );
+		}
+
+		return getRecommendations
 			.then( ( data ) => {
 				// Collect sites and posts from meta, and receive them separately
 				const sites = map( data.recommendations, property( 'meta.data.site' ) );


### PR DESCRIPTION
Creating a new A/B test for ColdStart v4. The test split the newly signed up users into three group:

1. 50% to no ColdStart
2. 25% to ColdStart calling the API v1.2/read/recommendations/start
3. 25% to ColdStart calling the API v1.3/read/recommendations/posts

ColdStart v4 exists at the new API endpoint: /v1.3/read/recommendations/posts
The arc patch at D2692-code needs to be applied in order to test this endpoint.

Test live: https://calypso.live/?branch=add/reader/cold-start-v4