### PR TITLE
Sites: add selector to get a site's theme showcase/help path

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -432,13 +432,10 @@ export function getSiteThemeShowcasePath( state, siteId ) {
 		return null;
 	}
 
-	const pathParts = [ '', 'theme', slug ];
-
-	if ( type === 'premium' ) {
-		pathParts.push( 'setup' );
-	}
-	pathParts.push( getSiteSlug( state, siteId ) );
-	return pathParts.join( '/' );
+	const siteSlug = getSiteSlug( state, siteId );
+	return type === 'premium'
+		? `/theme/${ slug }/setup/${ siteSlug }`
+		: `/theme/${ slug }/${ siteSlug }`;
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -12,6 +12,7 @@ import {
 	map,
 	partialRight,
 	some,
+	split,
 	includes,
 } from 'lodash';
 
@@ -409,6 +410,35 @@ export function getSiteByUrl( state, url ) {
 	}
 
 	return site;
+}
+
+/**
+ * Returns a site's theme showcase path.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId SiteId
+ * @return {?String}        Theme showcase path
+ */
+export function getSiteThemeShowcasePath( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site || site.jetpack ) {
+		return null;
+	}
+
+	const [ type, slug ] = split( getSiteOption( state, siteId, 'theme_slug' ), '/', 2 );
+
+	// to accomodate a8c and other theme types
+	if ( ! includes( [ 'pub', 'premium' ], type ) ) {
+		return null;
+	}
+
+	const pathParts = [ '', 'theme', slug ];
+
+	if ( type === 'premium' ) {
+		pathParts.push( 'setup' );
+	}
+	pathParts.push( getSiteSlug( state, siteId ) );
+	return pathParts.join( '/' );
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -19,6 +19,7 @@ import {
 	getSiteSlug,
 	getSiteDomain,
 	getSiteTitle,
+	getSiteThemeShowcasePath,
 	isSitePreviewable,
 	isRequestingSites,
 	isRequestingSite,
@@ -966,6 +967,84 @@ describe( 'selectors', () => {
 			}, 77203074, 1003 );
 
 			expect( isPaid ).to.equal( null );
+		} );
+	} );
+
+	describe( 'getSiteThemeShowcasePath()', () => {
+		it( 'it should return null if site is not tracked', () => {
+			const showcasePath = getSiteThemeShowcasePath( {
+				sites: {
+					items: {}
+				}
+			}, 77203074 );
+
+			expect( showcasePath ).to.be.null;
+		} );
+
+		it( 'it should return null if site is jetpack', () => {
+			const showcasePath = getSiteThemeShowcasePath( {
+				sites: {
+					items: {
+						77203074: { ID: 77203074, URL: 'https://example.net', jetpack: true }
+					}
+				}
+			}, 77203074, 1003 );
+
+			expect( showcasePath ).to.be.null;
+		} );
+
+		it( 'it should return null if theme_slug is not pub or premium', () => {
+			const showcasePath = getSiteThemeShowcasePath( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.net',
+							options: {
+								theme_slug: 'a8c/ribs'
+							}
+						}
+					}
+				}
+			}, 77203074, 1003 );
+
+			expect( showcasePath ).to.be.null;
+		} );
+
+		it( 'it should return the theme showcase path on non-premium themes', () => {
+			const showcasePath = getSiteThemeShowcasePath( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							options: {
+								theme_slug: 'pub/motif'
+							}
+						}
+					}
+				}
+			}, 77203074, 1003 );
+
+			expect( showcasePath ).to.eql( '/theme/motif/testonesite2014.wordpress.com' );
+		} );
+
+		it( 'it should return the theme setup path on premium themes', () => {
+			const showcasePath = getSiteThemeShowcasePath( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							options: {
+								theme_slug: 'premium/journalistic'
+							}
+						}
+					}
+				}
+			}, 77203074, 1003 );
+
+			expect( showcasePath ).to.eql( '/theme/journalistic/setup/testonesite2014.wordpress.com' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This branch adds in a new site selector which builds a path to the appropriate theme showcase page for a given site.  Some background on the _why_ behind this selector can be seen at pNEWy-860-p2 and related customizer updates in 1555d-pb, but ultimately we will have some quick links to help users dial-in their theme:

<img width="1005" alt="2016-08-31 at 17 19" src="https://cloud.githubusercontent.com/assets/22080/18139472/8735e842-6f66-11e6-8725-81dadc5ac442.png">

__To Test__
- Validate the tests pass `npm run test-client client/state/sites`

Test live: https://calypso.live/?branch=add/theme/setup-links