### PR TITLE
Fixed classname on popover devdocs example to match convention again

### DIFF
--- a/client/components/popover/docs/example.jsx
+++ b/client/components/popover/docs/example.jsx
@@ -296,7 +296,7 @@ const Popovers = React.createClass( {
 
 	render() {
 		return (
-			<div className="docs__design-assets__group">
+			<div className="docs__design-assets-group">
 				<h2>
 					<a href="/devdocs/design/popovers">Popovers</a>
 				</h2>


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/7770 reverted the changes in https://github.com/Automattic/wp-calypso/pull/7505, but introduced a typo - it should be `docs__design-assets-group`, not `docs__design-assets__group`

This PR _should_ fix that...but I'd appreciate @mtias and @retrofox giving it another look, since we all missed it on the last run through.

Test live: https://calypso.live/?branch=fix/popover-devdocs-classname-again