### PR TITLE
Signup: remove Theme Demo Preview A/B

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -73,14 +73,6 @@ module.exports = {
 		defaultVariation: 'pressable',
 		allowExistingUsers: false,
 	},
-	signupThemePreview: {
-		datestamp: '20160727',
-		variations: {
-			showThemePreview: 20,
-			hideThemePreview: 80,
-		},
-		defaultVariation: 'hideThemePreview',
-	},
 	readerSearchSuggestions: {
 		datestamp: '20160804',
 		variations: {

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -10,9 +10,7 @@ import analytics from 'lib/analytics';
 import SignupActions from 'lib/signup/actions';
 import SignupThemesList from './signup-themes-list';
 import StepWrapper from 'signup/step-wrapper';
-import ThemePreview from 'my-sites/themes/theme-preview';
 import Button from 'components/button';
-import { abtest } from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'ThemeSelection',
@@ -22,13 +20,6 @@ module.exports = React.createClass( {
 		stepName: React.PropTypes.string.isRequired,
 		goToNextStep: React.PropTypes.func.isRequired,
 		signupDependencies: React.PropTypes.object.isRequired,
-	},
-
-	getInitialState() {
-		return {
-			previewTheme: {},
-			isPreviewVisible: false,
-		};
 	},
 
 	getDefaultProps() {
@@ -56,30 +47,8 @@ module.exports = React.createClass( {
 		this.props.goToNextStep();
 	},
 
-	showPreview( theme ) {
-		this.setState( {
-			previewTheme: theme,
-			isPreviewVisible: true,
-		} );
-	},
-
-	handleThemePreviewButtonClick() {
-		this.pickTheme( this.state.previewTheme );
-	},
-
-	handleThemePreviewCloseClick() {
-		this.setState( {
-			previewTheme: {},
-			isPreviewVisible: false,
-		} );
-	},
-
 	handleScreenshotClick( theme ) {
-		if ( abtest( 'signupThemePreview' ) === 'showThemePreview' ) {
-			this.showPreview( theme );
-		} else {
-			this.pickTheme( theme );
-		}
+		this.pickTheme( theme );
 	},
 
 	renderThemesList() {
@@ -96,28 +65,6 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderThemePreview() {
-		return (
-			<ThemePreview
-				showPreview={ this.state.isPreviewVisible }
-				showExternal={ false }
-				theme={ this.state.previewTheme }
-				primaryButtonLabel={ this.translate( 'Pick this Theme' ) }
-				onClose={ this.handleThemePreviewCloseClick }
-				onPrimaryButtonClick={ this.handleThemePreviewButtonClick }>
-			</ThemePreview>
-		);
-	},
-
-	renderStepContent() {
-		return (
-			<div>
-				{ this.renderThemesList() }
-				{ this.renderThemePreview() }
-			</div>
-		);
-	},
-
 	render() {
 		const defaultDependencies = this.props.useHeadstart ? { theme: 'pub/twentysixteen' } : undefined;
 		return (
@@ -125,7 +72,7 @@ module.exports = React.createClass( {
 				fallbackHeaderText={ this.translate( 'Choose a theme.' ) }
 				fallbackSubHeaderText={ this.translate( 'No need to overthink it. You can always switch to a different theme later.' ) }
 				subHeaderText={ this.translate( 'Choose a theme. You can always switch to a different theme later.' ) }
-				stepContent={ this.renderStepContent() }
+				stepContent={ this.renderThemesList() }
 				defaultDependencies={ defaultDependencies }
 				headerButton={ this.renderJetpackButton() }
 				{ ...this.props } />

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -9,7 +9,6 @@ import noop from 'lodash/noop';
  */
 import getThemes from 'lib/signup/themes';
 import ThemesList from 'components/themes-list';
-import { abtest } from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'SignupThemesList',
@@ -41,8 +40,7 @@ module.exports = React.createClass( {
 	},
 
 	render() {
-		const actionLabel = ( abtest( 'signupThemePreview' ) === 'showThemePreview' )
-			? this.translate( 'Preview' ) : this.translate( 'Pick' );
+		const actionLabel = this.translate( 'Pick' );
 		const getActionLabel = () => actionLabel;
 		const themes = this.getComputedThemes().map( theme => {
 			return Object.assign( theme, {


### PR DESCRIPTION
After adding demo site previews to Signup in #6958 and #7084, we saw a drop in step completion (somewhat expected), a possibly correlated Signup completion drop, and essentially flat retention. We've decided to remove the functionality for the time being, to possibly be revisited at a future point in time.

## Testing
- Run through Signup either logged-in or logged-out
- On the `themes` step, make sure that the label on the screenshot says "Pick" and that no previews are shown
- After Signup, make sure that the correct theme has been set and that Headstart ran (the new site should look like the screenshot from the `themes` step) 

Test live: https://calypso.live/start/?branch=remove/signup-theme-preview-abtest