### PR TITLE
Site Settings: Highlight support docs on Empty Site page

### DIFF
--- a/client/my-sites/site-settings/action-panel/style.scss
+++ b/client/my-sites/site-settings/action-panel/style.scss
@@ -76,3 +76,9 @@ a.settings-action-panel__body-text-link {
 .settings-action-panel__support-button .gridicon {
 	margin-left: 8px;
 }
+
+.settings-action-panel__support-button {
+	&.is-external {
+		margin-right: 8px;
+	}
+}

--- a/client/my-sites/site-settings/start-over/index.jsx
+++ b/client/my-sites/site-settings/start-over/index.jsx
@@ -15,6 +15,7 @@ var HeaderCake = require( 'components/header-cake' ),
 	ActionPanelFigure = require( 'my-sites/site-settings/action-panel/figure' ),
 	ActionPanelFooter = require( 'my-sites/site-settings/action-panel/footer' ),
 	Button = require( 'components/button' ),
+	Gridicon = require( 'components/gridicon' ),
 	support = require( 'lib/url/support' );
 
 module.exports = React.createClass( {
@@ -39,7 +40,8 @@ module.exports = React.createClass( {
 	render: function() {
 		var strings = {
 			startOver: this.translate( 'Start Over' ),
-			contactSupport: this.translate( 'Contact Support' )
+			contactSupport: this.translate( 'Contact Support' ),
+			emptySite: this.translate( 'Follow the Steps' )
 		};
 
 		return (
@@ -60,16 +62,16 @@ module.exports = React.createClass( {
 								'creation. Just contact us to have your current content cleared out.' )
 						}</p>
 						<p>{
-							this.translate( 'Alternatively, you can delete all content from your site by following {{link}}the steps here{{/link}}.',
-								{
-									components: {
-										link: <a href={ support.EMPTY_SITE } target="_blank" rel="noopener noreferrer" />
-									}
-								}
-						)
+							this.translate( 'Alternatively, you can delete all content from your site by following the steps here.' )
 						}</p>
 					</ActionPanelBody>
 					<ActionPanelFooter>
+						<Button
+							className="settings-action-panel__support-button is-external"
+							href={ support.EMPTY_SITE }>
+							{ strings.emptySite }
+							<Gridicon icon="external" size={ 48 } />
+						</Button>
 						<Button
 							className="settings-action-panel__support-button"
 							href="/help/contact">


### PR DESCRIPTION
Currently, we have [an empty site support page](https://support.wordpress.com/empty-site/) that instructs users how to delete posts and pages. However, on the Empty Site page for a given site, those instructions aren't very apparent. This PR adds a button to highlight those instructions.

To test, checkout this branch and visit http://calypso.localhost:3000/settings/start-over/site.wordpress.com for your given site.

Previously, we just had a "Contact Support" link:

![screen shot 2016-08-31 at 12 50 34 pm](https://cloud.githubusercontent.com/assets/7240478/18142165/8d6d70aa-6f79-11e6-8f09-a27009aaae86.png)

The updated version will have a primary Empty Site link to our support doc.

![screen shot 2016-08-31 at 12 51 11 pm](https://cloud.githubusercontent.com/assets/7240478/18142176/9c8597ac-6f79-11e6-9e2a-94dd900b0f98.png)

Meant to address #7594.

Test live: https://calypso.live/?branch=fix/7594-start-over-button