### PR TITLE
reader-site-stream-link: omit siteId and feedId from props applied to link

### DIFF
--- a/client/blocks/reader-site-stream-link/index.jsx
+++ b/client/blocks/reader-site-stream-link/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,9 +27,10 @@ const ReaderSiteStreamLink = React.createClass( {
 
 	render() {
 		const link = getStreamUrl( this.props.feedId, this.props.siteId );
+		const omitProps = [ 'feedId', 'siteId' ];
 
 		return (
-			<a { ...this.props } href={ link } onClick={ this.recordClick }>{ this.props.children }</a>
+			<a { ...omit( this.props, omitProps ) } href={ link } onClick={ this.recordClick }>{ this.props.children }</a>
 		);
 	}
 


### PR DESCRIPTION
We're currently seeing a lot of this warning for reader-site-stream-link:

![screen shot 2016-08-31 at 20 42 18](https://cloud.githubusercontent.com/assets/17325/18144016/83eec446-6fbc-11e6-8f6b-7919f390fc03.png)

This PR omits `feedId` and `siteId` from the props applied to the link.

Test live: https://calypso.live/?branch=fix/reader/site-stream-link-omit-props