### PR TITLE
Advanced SEO: Social Preview Fixes

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -123,7 +123,7 @@ const GoogleSite = site => (
 
 const GooglePost = ( site, post ) => (
 	<SearchPreview
-		title={ post.title }
+		title={ post.seoTitle }
 		url={ post.URL }
 		snippet={ getSeoExcerptForPost( post ) }
 	/>
@@ -141,7 +141,7 @@ const FacebookSite = site => (
 
 const FacebookPost = ( site, post ) => (
 	<FacebookPreview
-		title={ post.title }
+		title={ post.seoTitle }
 		url={ post.URL }
 		type="article"
 		description={ getSeoExcerptForPost( post ) }
@@ -162,7 +162,7 @@ const TwitterSite = site => (
 
 const TwitterPost = ( site, post ) => (
 	<TwitterPreview
-		title={ post.title }
+		title={ post.seoTitle }
 		url={ post.URL }
 		type="large_image_summary"
 		description={ getSeoExcerptForPost( post ) }
@@ -261,7 +261,7 @@ const mapStateToProps = state => {
 		},
 		post: isEditorShowing && {
 			...post,
-			title: getSeoTitle( state, 'posts', { site, post } )
+			seoTitle: getSeoTitle( state, 'posts', { site, post } )
 		},
 		showNudge: site && site.plan && ! hasBusinessPlan( site.plan )
 	};

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -55,7 +55,8 @@ export function formatExcerpt( content ) {
 		}
 	} );
 
-	const betterExcerpt = trim( dom.innerHTML );
+	// trim and replace &nbsp; entities
+	const betterExcerpt = trim( dom.innerHTML.replace( /&nbsp;/g, '' ) );
 	dom.innerHTML = '';
 	return betterExcerpt;
 }

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -56,7 +56,7 @@ export function formatExcerpt( content ) {
 	} );
 
 	// trim and replace &nbsp; entities
-	const betterExcerpt = trim( dom.innerHTML.replace( /&nbsp;/g, '' ) );
+	const betterExcerpt = trim( dom.innerHTML.replace( /&nbsp;/g, ' ' ) );
 	dom.innerHTML = '';
 	return betterExcerpt;
 }

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -347,14 +347,14 @@ export const getSeoTitle = ( state, type, { site, post = {} } ) => {
 			return buildTitle( 'frontPage', {
 				siteName: site.name,
 				tagline: site.description
-			} );
+			} ) || site.name;
 
 		case 'posts':
 			return buildTitle( 'posts', {
 				siteName: site.name,
 				tagline: site.description,
 				postTitle: post.title
-			} );
+			} ) || post.title;
 
 		default:
 			return post.title || site.name;


### PR DESCRIPTION
Fixes #7784

**To test**
*  Preview a post in the SEO pane, without ever setting a custom title format. You should see the post title for all previews (Google, Facebook, etc)
*  Preview a post that has a custom title format set, the custom format should show on all of the previews _except_ the ReaderPreview.
*  Add a `&nbsp;` entity to a post, you should not see it any of the previews.

cc @dmsnell 

Test live: https://calypso.live/?branch=fix/7784-advanced-seo-titles