### PR TITLE
Plans: Add advertising for live courses throughout Business signup

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -79,7 +79,6 @@ export default class ProductPurchaseFeaturesList extends Component {
 				key="customizeThemeFeature"
 			/>,
 			<LiveCourses
-				isBusinessPlan
 				key="attendLiveCourses"
 			/>,
 			<VideoAudioPosts

--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -24,6 +24,7 @@ import GoogleVouchers from './google-vouchers';
 import CustomizeTheme from './customize-theme';
 import VideoAudioPosts from './video-audio-posts';
 import MonetizeSite from './monetize-site';
+import LiveCourses from './live-courses';
 import CustomDomain from './custom-domain';
 import GoogleAnalyticsStats from './google-analytics-stats';
 import JetpackAntiSpam from './jetpack-anti-spam';
@@ -76,6 +77,10 @@ export default class ProductPurchaseFeaturesList extends Component {
 			<CustomizeTheme
 				selectedSite={ selectedSite }
 				key="customizeThemeFeature"
+			/>,
+			<LiveCourses
+				isBusinessPlan
+				key="attendLiveCourses"
 			/>,
 			<VideoAudioPosts
 				selectedSite={ selectedSite }

--- a/client/blocks/product-purchase-features/product-purchase-features-list/live-courses.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/live-courses.jsx
@@ -7,8 +7,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import PurchaseDetail from 'components/purchase-detail';
 import support from 'lib/url/support';
+
+function trackCoursesButtonClick() {
+	analytics.tracks.recordEvent( 'calypso_plan_features_courses_click' );
+}
 
 export default localize( ( { translate } ) => {
 	return (
@@ -23,6 +28,7 @@ export default localize( ( { translate } ) => {
 				}
 				buttonText={ translate( 'Register for a course' ) }
 				href={ support.CALYPSO_COURSES }
+				onClick={ trackCoursesButtonClick }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features/product-purchase-features-list/live-courses.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/live-courses.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+import support from 'lib/url/support';
+
+export default localize( ( { translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				icon="help"
+				title={ translate( 'Attend live courses' ) }
+				description={
+					translate(
+						'Register for one of our live courses led by Happiness Engineers to get the most out of your site.'
+					)
+				}
+				buttonText={ translate( 'Register for a course' ) }
+				href={ support.CALYPSO_COURSES }
+			/>
+		</div>
+	);
+} );

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -157,8 +157,8 @@ export const plansList = {
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ], plan ),
 		getPathSlug: () => 'business',
 		getDescription: () => i18n.translate(
-			'Everything included with Premium, as well as live chat support, live courses,' +
-			' unlimited access to premium themes, and Google Analytics.'
+			'Everything included with Premium, as well as live chat support, live courses, ' +
+			'unlimited access to premium themes, and Google Analytics.'
 		),
 		getTargetedDescription: () => i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
 			' business website with unlimited premium and business theme templates, Google Analytics support, unlimited' +
@@ -422,9 +422,8 @@ export const featuresList = {
 		getSlug: () => FEATURE_LIVE_COURSES,
 		getTitle: () => i18n.translate( 'Attend live courses' ),
 		getDescription: () => i18n.translate(
-			"Attend live courses led by Happiness Engineers to get the most out of your site."
+			'Attend live courses led by Happiness Engineers to get the most out of your site.'
 		),
-		getStoreSlug: () => 'live_courses',
 		plans: [ PLAN_BUSINESS ]
 	},
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -51,6 +51,7 @@ export const FEATURE_VIDEO_UPLOADS = 'video-upload';
 export const FEATURE_WORDADS_INSTANT = 'wordads-instant';
 export const FEATURE_NO_BRANDING = 'no-wp-branding';
 export const FEATURE_ADVANCED_SEO = 'advanced-seo';
+export const FEATURE_LIVE_COURSES = 'live-courses';
 
 // jetpack features constants
 export const FEATURE_STANDARD_SECURITY_TOOLS = 'standard-security-tools';
@@ -156,7 +157,7 @@ export const plansList = {
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ], plan ),
 		getPathSlug: () => 'business',
 		getDescription: () => i18n.translate(
-			'Everything included with Premium, as well as live chat support,' +
+			'Everything included with Premium, as well as live chat support, live courses,' +
 			' unlimited access to premium themes, and Google Analytics.'
 		),
 		getTargetedDescription: () => i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
@@ -168,6 +169,7 @@ export const plansList = {
 			} ),
 		getFeatures: () => compact( [ // pay attention to ordering, it is used on /plan page
 			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_LIVE_COURSES,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 			FEATURE_UNLIMITED_PREMIUM_THEMES,
 			FEATURE_ADVANCED_DESIGN,
@@ -185,7 +187,8 @@ export const plansList = {
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_NO_ADS,
 			FEATURE_ADVANCED_DESIGN,
-			FEATURE_VIDEO_UPLOADS
+			FEATURE_VIDEO_UPLOADS,
+			FEATURE_LIVE_COURSES
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
@@ -412,6 +415,16 @@ export const featuresList = {
 			"Keep the focus on your site's brand by removing the WordPress.com footer branding."
 		),
 		getStoreSlug: () => 'no-adverts/no-adverts.php',
+		plans: [ PLAN_BUSINESS ]
+	},
+
+	[ FEATURE_LIVE_COURSES ]: {
+		getSlug: () => FEATURE_LIVE_COURSES,
+		getTitle: () => i18n.translate( 'Attend live courses' ),
+		getDescription: () => i18n.translate(
+			"Attend live courses led by Happiness Engineers to get the most out of your site."
+		),
+		getStoreSlug: () => 'live_courses',
 		plans: [ PLAN_BUSINESS ]
 	},
 

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -13,6 +13,7 @@ export default {
 	COMMUNITY_TRANSLATOR: `${root}/community-translator`,
 	COMPLETING_GOOGLE_APPS_SIGNUP: `${root}/adding-google-apps-to-your-site/#completing-sign-up`,
 	CALYPSO_CONTACT: '/help/contact',
+	CALYPSO_COURSES: '/help/courses',
 	CUSTOM_DNS: `${root}/domains/custom-dns`,
 	DOMAIN_HELPER_PREFIX: `${root}/domain-helper/?host=`,
 	DOMAINS: `${root}/domains`,

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -8,10 +8,15 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import { isBusiness } from 'lib/products-values';
 import PurchaseDetail from 'components/purchase-detail';
 import support from 'lib/url/support';
+
+function trackCoursesButtonClick() {
+	analytics.tracks.recordEvent( 'calypso_checkout_thank_you_courses_click' );
+}
 
 const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 	const plan = find( sitePlans.data, isBusiness );
@@ -30,7 +35,8 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 					'to get the most out of your site.'
 				) }
 				buttonText={ i18n.translate( 'Register for a course' ) }
-				href={ support.CALYPSO_COURSES } />
+				href={ support.CALYPSO_COURSES }
+				onClick={ trackCoursesButtonClick } />
 
 			{ ! selectedFeature &&
 				<PurchaseDetail

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -11,6 +11,7 @@ import i18n from 'i18n-calypso';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import { isBusiness } from 'lib/products-values';
 import PurchaseDetail from 'components/purchase-detail';
+import support from 'lib/url/support';
 
 const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 	const plan = find( sitePlans.data, isBusiness );
@@ -21,6 +22,15 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 				selectedSite={ selectedSite }
 				hasDomainCredit={ plan && plan.hasDomainCredit }
 			/>
+
+			<PurchaseDetail
+				icon="help"
+				title={ i18n.translate( 'Attend a live course' ) }
+				description={ i18n.translate( 'Register for one of our live courses led by Happiness Engineers ' +
+					'to get the most out of your site.'
+				) }
+				buttonText={ i18n.translate( 'Register for a course' ) }
+				href={ support.CALYPSO_COURSES } />
 
 			{ ! selectedFeature &&
 				<PurchaseDetail


### PR DESCRIPTION
**Note:** This is dependent on the addition of the new /courses page ([milestone](https://github.com/Automattic/wp-calypso/milestone/121)). Let's wait to merge until the /courses page is up and running.

The new live courses at `wordpress.com/help/courses` will only be available to Business customers. This PR adds mention of live courses at several places throughout the Business signup so that Business customers are aware of the feature and how to take advantage. Discussion in p3fqKv-3uP-p2.

## To test

1. Checkout this branch
2. Upgrade a site to Business
3. Look at the three screens mentioned below to make sure the copy is appearing correctly.
4. While running the branch, also take a look at a site with a Personal or Premium bundle. You shouldn't see the live courses feature mentioned below.

Specifically, it adds mention of the feature in three places:

**On the /my-plan/ page**
Example: `http://calypso.localhost:3000/plans/my-plan/site.wordpress.com`

![screen shot 2016-08-31 at 2 58 30 pm](https://cloud.githubusercontent.com/assets/7240478/18146140/66fbd846-6f8b-11e6-9d5a-2207027f0c6c.png)

**As a feature on /plans**
Example: `http://calypso.localhost:3000/plans/site.wordpress.com`

![screen shot 2016-08-31 at 2 59 15 pm](https://cloud.githubusercontent.com/assets/7240478/18146172/822395fa-6f8b-11e6-9124-013b1d1681a5.png)

**On the Thank You page after checkout**
Example: `http://calypso.localhost:3000/checkout/thank-you/site.wordpress.com/555555`

![screen shot 2016-08-31 at 2 59 45 pm](https://cloud.githubusercontent.com/assets/7240478/18146199/a942ffea-6f8b-11e6-8d14-8b5140d09723.png)


Test live: https://calypso.live/?branch=add/courses-page-business-signup