### PR TITLE
State: fix preferences schema

### DIFF
--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -35,9 +35,7 @@ export const remoteValuesSchema = {
 				additionalProperties: false,
 			}
 		},
-	},
-	recentSites: {
-		schema: {
+		recentSites: {
 			type: 'array',
 			items: {
 				type: 'number'


### PR DESCRIPTION
This PR fixes the recentSites definition in the preferences schema. This likely occurred from a bad rebase.

## Testing Instructions
- Navigate to http://calypso.localhost:3000
- No schema validation warnings appear
- To test that this schema is used, update `client/state/preferences/schema.js` to expect a different type, for example:
```
recentSites: {
			type: 'array',
			items: {
				type: 'null' //null instead of number
			}
		}
```
- verify that we see a related schema validation warning
<img width="1290" alt="screen shot 2016-08-31 at 2 38 08 pm" src="https://cloud.githubusercontent.com/assets/1270189/18147360/236dc064-6f89-11e6-946e-c801b2348eac.png">


cc @aduth

Test live: https://calypso.live/?branch=fix/preferences-schema