### PR TITLE
Reader: For testing, add support for feed search and followed search on wp.com/following/edit

### DIFF
--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -34,7 +34,10 @@ import FollowingImportButton from './import-button';
 import FeedDisplayHelper from 'reader/lib/feed-display-helper';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
+import ListItem from 'reader/list-item';
 const stats = require( 'reader/stats' );
+
+const config = require( 'config' );
 
 const initialLoadFeedCount = 20;
 
@@ -75,7 +78,12 @@ const FollowingEdit = React.createClass( {
 		};
 
 		if ( props.search ) {
-			newState.subscriptions = this.searchSubscriptions( newState.subscriptions, props.search );
+			if ( ! config.isEnabled( 'reader/follow-feed-search' ) ) {
+				newState.subscriptions = this.searchSubscriptions( newState.subscriptions, props.search );
+			} else {
+				var params = { q: props.search };
+				wpcom.undocumented().readFollowingMine( params, this.searchCallback );
+			}
 		}
 
 		if ( this.state && this.state.sortOrder ) {
@@ -83,6 +91,11 @@ const FollowingEdit = React.createClass( {
 		}
 
 		return newState;
+	},
+
+	searchCallback: function( error, data ) {
+		const newState = { newSubscriptions: data.subscriptions };
+		this.smartSetState( newState );
 	},
 
 	// Add change listeners to stores
@@ -489,7 +502,8 @@ const FollowingEdit = React.createClass( {
 		let subscriptions = this.state.subscriptions,
 			subscriptionsToDisplay = [],
 			searchPlaceholder = '',
-			hasNoSubscriptions = false;
+			hasNoSubscriptions = false,
+			subscriptionRender = [];
 
 		// We're only interested in showing subscriptions with an ID (i.e. those that came from the API)
 		// At this point we may have some kicking around that just have a URL, such as those added when
@@ -514,6 +528,17 @@ const FollowingEdit = React.createClass( {
 			'is-searching': this.state.isSearching,
 			'has-no-subscriptions': hasNoSubscriptions
 		}, 'following-edit' );
+
+		if ( config.isEnabled( 'reader/follow-feed-search' ) && this.state.newSubscriptions ) {
+			this.state.newSubscriptions.forEach( function( sub ) {
+				subscriptionRender.push(
+					<div className="subscription-list-item__header-content"
+							 key={ 'subscription-list-feed-item-' + sub.ID }>
+						<ListItem>{ sub.URL }</ListItem>
+					</div>
+				);
+			} );
+		}
 
 		return (
 			<Main className={ containerClasses }>
@@ -569,7 +594,8 @@ const FollowingEdit = React.createClass( {
 					ref="url-search" /> : null }
 
 				{ this.state.isAttemptingFollow && ! this.state.lastError ? <SubscriptionPlaceholder key={ 'placeholder-add-feed' } /> : null }
-				{ subscriptionsToDisplay.length === 0 && this.props.search && ! this.state.isLoading
+				{ subscriptionRender.length > 0 ? subscriptionRender
+					: subscriptionsToDisplay.length === 0 && this.props.search && ! this.state.isLoading
 					? <NoResults text={ this.translate( 'No subscriptions match that search.' ) } />
 					: <InfiniteList className="following-edit__sites"
 						items={ subscriptionsToDisplay }

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -36,7 +36,7 @@ import SectionHeader from 'components/section-header';
 import Button from 'components/button';
 import ListItem from 'reader/list-item';
 const stats = require( 'reader/stats' );
-
+const wpcom = require( 'lib/wp' );
 const config = require( 'config' );
 
 const initialLoadFeedCount = 20;

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -8,7 +8,11 @@ const SearchCard = require( 'components/search-card' ),
 	FollowingEditSubscribeFormResult = require( './subscribe-form-result' ),
 	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' );
 
-const minSearchLength = 8; // includes protocol
+import ListItem from 'reader/list-item';
+
+var minSearchLength = 8; // includes protocol
+
+const config = require( 'config' );
 
 var FollowingEditSubscribeForm = React.createClass( {
 
@@ -66,8 +70,34 @@ var FollowingEditSubscribeForm = React.createClass( {
 			return;
 		}
 
-		this.verifySearchString( searchString );
-		this.props.onSearch( searchString );
+		if ( ! config.isEnabled( 'reader/follow-feed-search' ) ) {
+			this.verifySearchString( searchString );
+			this.props.onSearch( searchString );
+		} else {
+			minSearchLength = 3;
+
+			if ( searchString.length > minSearchLength ) {
+				// should also have a type-search delay
+				this.setState( {
+					searchString: searchString,
+					isWellFormedFeedUrl: true
+				} );
+
+				var params = { q: searchString };
+				wpcom.undocumented().discoverFeed( params, this.searchCallback );
+			} else {
+				// need to reset the search box when no text or search is canceled (X)
+				this.setState( {
+					searchString: searchString,
+					isWellFormedFeedUrl: searchString.length > minSearchLength
+				} );
+			}
+		}
+	},
+
+	searchCallback: function( error, data ) {
+		const newState = { newFeeds: data.feeds };
+		this.setState( newState );
 	},
 
 	handleSearchClose: function() {
@@ -129,11 +159,23 @@ var FollowingEditSubscribeForm = React.createClass( {
 		}
 
 		if ( showSearchResult ) {
-			searchResult = ( <FollowingEditSubscribeFormResult
-				isValid={ isWellFormedFeedUrl }
-				url={ searchString }
-				onFollowToggle={ handleFollowToggle } />
-			);
+			if ( ! config.isEnabled( 'reader/follow-feed-search' ) ) {
+				searchResult = ( <FollowingEditSubscribeFormResult
+					isValid={ isWellFormedFeedUrl }
+					url={ searchString }
+					onFollowToggle={ handleFollowToggle } />
+				);
+			} else if ( this.state.newFeeds ) {
+				console.log( this.state.newFeeds );
+				searchResult = this.state.newFeeds.map( function( item ) {
+				 		return ( <div className="subscription-list-item__header-content"
+											key={ 'subscription-list-feed-item-' + item.feed_ID }>
+											<ListItem className='is-search-result'>
+												{ item.title + ' ' + item.URL }
+										 	</ListItem>
+										 </div> );
+				} );
+			}
 		}
 
 		return (

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -170,7 +170,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 				console.log( this.state.newFeeds );
 				searchResult = this.state.newFeeds.map( function( item ) {
 				 		return ( <div className="subscription-list-item__header-content"
-											key={ 'subscription-list-feed-item-' + item.feed_ID }>
+											key={ 'subscription-list-feed-item-' + item.URL }>
 											<ListItem className='is-search-result'>
 												{ item.title + ' ' + item.URL }
 										 	</ListItem>

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -167,7 +167,6 @@ var FollowingEditSubscribeForm = React.createClass( {
 					onFollowToggle={ handleFollowToggle } />
 				);
 			} else if ( this.state.newFeeds ) {
-				console.log( this.state.newFeeds );
 				searchResult = this.state.newFeeds.map( function( item ) {
 				 		return ( <div className="subscription-list-item__header-content"
 											key={ 'subscription-list-feed-item-' + item.URL }>

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -1,7 +1,8 @@
 // External dependencies
 const React = require( 'react' ),
 	url = require( 'url' ),
-	noop = require( 'lodash/noop' );
+	noop = require( 'lodash/noop' ),
+	wpcom = require( 'lib/wp' );
 
 // Internal dependencies
 const SearchCard = require( 'components/search-card' ),

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -171,7 +171,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 				searchResult = this.state.newFeeds.map( function( item ) {
 				 		return ( <div className="subscription-list-item__header-content"
 											key={ 'subscription-list-feed-item-' + item.URL }>
-											<ListItem className='is-search-result'>
+											<ListItem>
 												{ item.title + ' ' + item.URL }
 										 	</ListItem>
 										 </div> );

--- a/config/development.json
+++ b/config/development.json
@@ -120,6 +120,7 @@
 		"reader/search": true,
 		"reader/start": true,
 		"reader/tags-with-elasticsearch": true,
+		"reader/follow-feed-search": false,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/development.json
+++ b/config/development.json
@@ -120,7 +120,7 @@
 		"reader/search": true,
 		"reader/start": true,
 		"reader/tags-with-elasticsearch": true,
-		"reader/follow-feed-search": false,
+		"reader/follow-feed-search": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,6 +93,7 @@
 		"reader/search": true,
 		"reader/start": true,
 		"reader/tags-with-elasticsearch": true,
+		"reader/follow-feed-search": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,


### PR DESCRIPTION
This is the placeholder test UI to call the new WPCOM API for feed search and followed search.

There are two entrypoints. The Top Box (aka feed search) provides a way to search for external RSS feeds. Previously it only tries to parse the URL you enter, now it does Instant Search.

The second opens when you click on the search magnifying glass button – the Followed Box provides a way to search for blogs/sites/feeds you have followed. The result is sorted by the es query score.

New behavior is under feature tag 'reader/follow-feed-search'
To run: $ ENABLE_FEATURES=reader/follow-feed-search make run

Known issues:
~~1. I couldn’t figure out how to get multiple results for the Top Box (aka feed search) to show up; only one is there right now (the last one I think, because of how the ListItem is rendered) – instead you can see the full result list in the Javascript console.~~ (fixed, see below)
2. UI is very rough – again the goal is to make it accessible. It does not represent any real user experience.
3. Code changes is taking a bunch of shortcuts to get it to work. FeedSubscriptionStore and associates are fairly tightly integrated so instead here we have a separate path added to access the WPCOM API directly.

cc: @gibrown @bluefuton

Test live: https://calypso.live/?branch=try/reader/follow-feed-search
