### PR TITLE
Editor: add links to theme help in sidebar

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -357,6 +357,7 @@
 @import 'post-editor/editor-more-options/style';
 @import 'post-editor/editor-page-parent/style';
 @import 'post-editor/editor-page-order/style';
+@import 'post-editor/editor-page-templates/style';
 @import 'post-editor/editor-permalink/style';
 @import 'post-editor/editor-post-formats/style';
 @import 'post-editor/editor-post-type/style';

--- a/client/post-editor/editor-page-templates/index.jsx
+++ b/client/post-editor/editor-page-templates/index.jsx
@@ -19,6 +19,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import { getPageTemplates } from 'state/page-templates/selectors';
 import { editPost } from 'state/posts/actions';
+import EditorThemeHelp from 'post-editor/editor-theme-help';
 
 class EditorPageTemplates extends Component {
 	static propTypes = {
@@ -77,6 +78,7 @@ class EditorPageTemplates extends Component {
 				{ size( templates ) > 1 && (
 					<AccordionSection>
 						<EditorDrawerLabel labelText={ translate( 'Page Template' ) }>
+							<EditorThemeHelp className="editor-page-templates__help-link" />
 							<SelectDropdown selectedText={ this.getSelectedTemplateText() }>
 								{ map( templates, ( { file, label } ) => (
 									/* eslint-disable react/jsx-no-bind */

--- a/client/post-editor/editor-page-templates/style.scss
+++ b/client/post-editor/editor-page-templates/style.scss
@@ -1,0 +1,5 @@
+.editor-page-templates__help-link {
+	font-size: 14px;
+	display: inline-block;
+	margin-bottom: 6px;
+}

--- a/client/post-editor/editor-post-formats/index.jsx
+++ b/client/post-editor/editor-post-formats/index.jsx
@@ -11,6 +11,7 @@ const FormRadio = require( 'components/forms/form-radio' ),
 	PostActions = require( 'lib/posts/actions' ),
 	stats = require( 'lib/posts/stats' ),
 	AccordionSection = require( 'components/accordion/section' );
+import EditorThemeHelp from 'post-editor/editor-theme-help';
 
 export default React.createClass( {
 	displayName: 'EditorPostFormats',
@@ -116,6 +117,7 @@ export default React.createClass( {
 	render: function() {
 		return (
 			<AccordionSection>
+				<EditorThemeHelp className="editor-post-formats__help-link" />
 				<ul className="editor-post-formats">
 					{ this.renderPostFormats() }
 				</ul>

--- a/client/post-editor/editor-post-formats/style.scss
+++ b/client/post-editor/editor-post-formats/style.scss
@@ -27,3 +27,7 @@
 		margin-top: 3px;
 	}
 }
+
+.editor-post-formats__help-link {
+	font-size: 14px;
+}

--- a/client/post-editor/editor-post-formats/style.scss
+++ b/client/post-editor/editor-post-formats/style.scss
@@ -29,5 +29,5 @@
 }
 
 .editor-post-formats__help-link {
-	font-size: 14px;
+	font-size: 12px;
 }

--- a/client/post-editor/editor-theme-help/index.jsx
+++ b/client/post-editor/editor-theme-help/index.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteThemeShowcasePath } from 'state/sites/selectors';
+
+class EditorThemeHelp extends PureComponent {
+	static propTypes = {
+		themeHelpPath: PropTypes.string,
+		classname: PropTypes.string,
+	};
+
+	render() {
+		const { translate, themeHelpPath, className } = this.props;
+
+		if ( ! themeHelpPath ) {
+			return null;
+		}
+
+		return (
+			<a className={ className } href={ themeHelpPath }>
+				{ translate( 'Need help setting up your site?' ) }
+			</a>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			themeHelpPath: getSiteThemeShowcasePath( state, siteId )
+		};
+	}
+)( localize( EditorThemeHelp ) );

--- a/client/post-editor/editor-theme-help/index.jsx
+++ b/client/post-editor/editor-theme-help/index.jsx
@@ -10,12 +10,22 @@ import { localize } from 'i18n-calypso';
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteThemeShowcasePath } from 'state/sites/selectors';
+import { recordStat } from 'lib/posts/stats';
 
 class EditorThemeHelp extends PureComponent {
 	static propTypes = {
 		themeHelpPath: PropTypes.string,
 		classname: PropTypes.string,
 	};
+
+	constructor( props ) {
+		super( props );
+		this.recordClick = this.recordClick.bind( this );
+	}
+
+	recordClick() {
+		recordStat( 'clicked_theme_help_link' );
+	}
 
 	render() {
 		const { translate, themeHelpPath, className } = this.props;
@@ -25,7 +35,7 @@ class EditorThemeHelp extends PureComponent {
 		}
 
 		return (
-			<a className={ className } href={ themeHelpPath }>
+			<a className={ className } href={ themeHelpPath } onClick={ this.recordClick } >
 				{ translate( 'Need help setting up your site?' ) }
 			</a>
 		);


### PR DESCRIPTION
This branch adds in some new links to the editor sidebar to provide quick access to theme setup info ( discussion pNEWy-860-p2 ).

__Link in Editor Sidebar__
<img width="256" alt="new_post_ _fly_fishers_place_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/18149994/ab5d47e2-6f98-11e6-9288-6bc55e95bbcc.png">

__Link in Page Editor Sidebar__
<img width="260" alt="new_page_ _fly_fishers_place_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/18150013/ce59da3a-6f98-11e6-8694-a2a496a210aa.png">

__To Test__
The links should be shown as above when using the editor on a WPCOM site ( links hidden on JP sites ).  The Page editor link requires the theme to support page templates - if the theme does not support it, the link is not rendered.

- Open the page editor, verify the link is shown
- Click on the help link.  The link should open the theme showcase page for the given site.  If the active theme on the site is a premium theme, the page should be `http://calypso.localhost:3000/theme/$themeSlug/setup/$siteSlug` - for non-premium themes `http://calypso.localhost:3000/theme/$themeSlug/$siteSlug`

/cc @karmatosed not sure if you want to work on the styling here at all.

Test live: https://calypso.live/?branch=add/editor/theme-help-links