### PR TITLE
Components: add dismissable-card

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -10,9 +10,10 @@
 
 @import 'auth/style';
 @import 'blocks/author-compact-profile/style';
+@import 'blocks/author-selector/style';
 @import 'blocks/comment-button/style';
 @import 'blocks/comments/style';
-@import 'blocks/author-selector/style';
+@import 'blocks/dismissable-card/style';
 @import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-item/style';
 @import 'blocks/post-relative-time/style';

--- a/client/blocks/dismissable-card/README.md
+++ b/client/blocks/dismissable-card/README.md
@@ -1,0 +1,67 @@
+Dismissable Card
+=========
+This is a card component that can be dismissed for a single page load or be hidden
+via user preference.
+
+#### How to use:
+
+```js
+import DismissableCard from 'blocks/dismissable-card';
+import QueryPreferences from 'components/data/query-preferences';
+
+render: function() {
+  return (
+    <div className="your-stuff">
+      <QueryPreferences />
+      <DismissableCard preferenceName="my-unique-preference-name">
+        <span>Your stuff in a Card</span>
+      </DismissableCard>
+    </div>
+  );
+}
+```
+
+## Props
+
+Below is a list of supported props.
+
+### `className`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>undefined</code></td></tr>
+</table>
+
+Any addition classes to pass to the card component.
+
+### `onClick`
+
+<table>
+	<tr><td>Type</td><td>Function</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>lodash/noop</code></td></tr>
+</table>
+
+This function will fire when a user clicks on the cross icon
+
+### `preferenceName`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>Yes</td></tr>
+	<tr><td>Default</td><td><code>n/a</code></td></tr>
+</table>
+
+The user preference name that we store a boolean against. 
+Note that we prefix this value with 'dismissable-card-' to avoid namespace collisions.
+
+### `temporary`
+
+<table>
+	<tr><td>Type</td><td>Boolean</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>undefined</code></td></tr>
+</table>
+
+When true, clicking on the cross will dismiss the card for the current page load.

--- a/client/blocks/dismissable-card/README.md
+++ b/client/blocks/dismissable-card/README.md
@@ -7,12 +7,10 @@ via user preference.
 
 ```js
 import DismissableCard from 'blocks/dismissable-card';
-import QueryPreferences from 'components/data/query-preferences';
 
 render: function() {
   return (
     <div className="your-stuff">
-      <QueryPreferences />
       <DismissableCard preferenceName="my-unique-preference-name">
         <span>Your stuff in a Card</span>
       </DismissableCard>

--- a/client/blocks/dismissable-card/docs/example.jsx
+++ b/client/blocks/dismissable-card/docs/example.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import DismissableCard from '../';
+import QueryPreferences from 'components/data/query-preferences';
+import { savePreference } from 'state/preferences/actions';
+
+function DismissableCardExample( { clearPreference } ) {
+	return (
+		<div className="docs__design-assets-group">
+			<QueryPreferences />
+			<h2>
+				<a href="/devdocs/blocks/dissmissable-card">Dismissable Card</a>
+			</h2>
+			<DismissableCard
+				preferenceName="example-local"
+				temporary>
+				<span>I will be dismissed for a page load</span>
+			</DismissableCard>
+			<DismissableCard
+				preferenceName="example"
+			>
+				<span>I can be dismissed forever!</span>
+			</DismissableCard>
+			<Button onClick={ clearPreference }>Reset Dismiss Preference</Button>
+		</div>
+	);
+}
+
+const ConnectedDismissableCardExample = connect( 
+	( state ) => { return {}; },
+	( dispatch ) => bindActionCreators( {
+		clearPreference: () => {
+			return savePreference( 'dismissable-card-example', null );
+		}
+	}, dispatch )
+)( DismissableCardExample );
+
+ConnectedDismissableCardExample.displayName = 'DismissableCard';
+
+export default ConnectedDismissableCardExample;

--- a/client/blocks/dismissable-card/docs/example.jsx
+++ b/client/blocks/dismissable-card/docs/example.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,12 +37,8 @@ function DismissableCardExample( { clearPreference } ) {
 }
 
 const ConnectedDismissableCardExample = connect( 
-	( state ) => { return {}; },
-	( dispatch ) => bindActionCreators( {
-		clearPreference: () => {
-			return savePreference( 'dismissable-card-example', null );
-		}
-	}, dispatch )
+	null,
+	{ clearPreference: partial( savePreference, 'dismissable-card-example', null ) }
 )( DismissableCardExample );
 
 ConnectedDismissableCardExample.displayName = 'DismissableCard';

--- a/client/blocks/dismissable-card/docs/example.jsx
+++ b/client/blocks/dismissable-card/docs/example.jsx
@@ -17,7 +17,7 @@ function DismissableCardExample( { clearPreference } ) {
 	return (
 		<div className="docs__design-assets-group">
 			<h2>
-				<a href="/devdocs/blocks/dissmissable-card">Dismissable Card</a>
+				<a href="/devdocs/blocks/dismissable-card">Dismissable Card</a>
 			</h2>
 			<DismissableCard
 				preferenceName="example-local"

--- a/client/blocks/dismissable-card/docs/example.jsx
+++ b/client/blocks/dismissable-card/docs/example.jsx
@@ -11,13 +11,11 @@ import { partial } from 'lodash';
  */
 import Button from 'components/button';
 import DismissableCard from '../';
-import QueryPreferences from 'components/data/query-preferences';
 import { savePreference } from 'state/preferences/actions';
 
 function DismissableCardExample( { clearPreference } ) {
 	return (
 		<div className="docs__design-assets-group">
-			<QueryPreferences />
 			<h2>
 				<a href="/devdocs/blocks/dissmissable-card">Dismissable Card</a>
 			</h2>

--- a/client/blocks/dismissable-card/index.jsx
+++ b/client/blocks/dismissable-card/index.jsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { noop, flow } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import { savePreference, setPreference } from 'state/preferences/actions';
+import { getPreference } from 'state/preferences/selectors';
+
+const PREFERENCE_PREFIX = 'dismissable-card-';
+
+class DismissableCard extends Component {
+
+	static propTypes = {
+		className: PropTypes.string,
+		dismissCard: PropTypes.func,
+		isDismissed: PropTypes.bool,
+		temporary: PropTypes.bool,
+		onClick: PropTypes.func,
+		preferenceName: PropTypes.string.isRequired
+	};
+
+	static defaultProps = {
+		onClick: noop
+	};
+
+	render() {
+		const { className, isDismissed, onClick, dismissCard } = this.props;
+
+		if ( isDismissed ) {
+			return null;
+		}
+
+		return (
+			<Card className={ className }>
+				<Gridicon
+					icon="cross"
+					className="dismissable-card__close-icon"
+					onClick={ flow( onClick, dismissCard ) }
+				/>
+				{ this.props.children }
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => {
+		const preference = `${ PREFERENCE_PREFIX }${ ownProps.preferenceName }`;
+		return {
+			isDismissed: getPreference( state, preference )
+		};
+	},
+	( dispatch, ownProps ) => bindActionCreators( {
+		dismissCard: () => {
+			const preference = `${ PREFERENCE_PREFIX }${ ownProps.preferenceName }`;
+			if ( ownProps.temporary ) {
+				return setPreference( preference, true );
+			}
+			return savePreference( preference, true );
+		}
+	}, dispatch )
+)( DismissableCard );
+

--- a/client/blocks/dismissable-card/index.jsx
+++ b/client/blocks/dismissable-card/index.jsx
@@ -11,6 +11,7 @@ import { noop, flow } from 'lodash';
  */
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
+import QueryPreferences from 'components/data/query-preferences';
 import { savePreference, setPreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 
@@ -40,6 +41,7 @@ class DismissableCard extends Component {
 
 		return (
 			<Card className={ className }>
+				<QueryPreferences />
 				<Gridicon
 					icon="cross"
 					className="dismissable-card__close-icon"

--- a/client/blocks/dismissable-card/style.scss
+++ b/client/blocks/dismissable-card/style.scss
@@ -1,0 +1,6 @@
+.dismissable-card__close-icon {
+	position: absolute;
+	top: 16px;
+	right: 16px;
+	color: $gray;
+}

--- a/client/blocks/dismissable-card/style.scss
+++ b/client/blocks/dismissable-card/style.scss
@@ -3,4 +3,5 @@
 	top: 16px;
 	right: 16px;
 	color: $gray;
+	cursor: pointer;
 }

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -40,6 +40,7 @@ import RelatedPostCard from 'blocks/reader-related-card/docs/example';
 import SearchPostCard from 'blocks/reader-search-card/docs/example';
 import PlanPrice from 'my-sites/plan-price/docs/example';
 import PlanThankYouCard from 'blocks/plan-thank-you-card/docs/example';
+import DismissableCard from 'blocks/dismissable-card/docs/example';
 
 export default React.createClass( {
 
@@ -101,6 +102,7 @@ export default React.createClass( {
 					<AuthorCompactProfile />
 					<PlanPrice />
 					<PlanThankYouCard />
+					<DismissableCard />
 				</Collection>
 			</div>
 		);

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -2,6 +2,11 @@
 
 export const remoteValuesSchema = {
 	type: [ 'null', 'object' ],
+	patternProperties: {
+		'^dismissable-card-.+$': {
+			type: 'boolean'
+		}
+	},
 	properties: {
 		'editor-mode': {
 			type: 'string',


### PR DESCRIPTION
As part of #7329 This PR adds a new block component. This is a card that remembers when it's been dismissed. You can configure this to dismiss it for the current page load, or forever (saved as a user preference).

![dismiss](https://cloud.githubusercontent.com/assets/1270189/18151403/d0a6c66c-6fa3-11e6-9f7c-eb8600d383db.gif)

## Testing Instructions
- Navigate to http://calypso.localhost:3000/devdocs/blocks/dismissable-card
- You can dismiss both cards
- Refreshing the page will render only the top card
- No other functional changes since there are no usages yet in Calypso

cc @lamosty @artpi @aduth 

Test live: https://calypso.live/?branch=add/dismissable-card