### PR TITLE
Domains: Fix domain mapping availability success notice

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -56,7 +56,6 @@ var DomainSearchResults = React.createClass( {
 			// should use real notice component or custom class
 			availabilityElement = (
 				<Notice
-					className="domain-search-results__domain-availability-copy"
 					status="is-success"
 					showDismiss={ false }>
 					{
@@ -115,7 +114,6 @@ var DomainSearchResults = React.createClass( {
 			if ( this.props.offerMappingOption ) {
 				availabilityElement = (
 					<Notice
-						className="domain-search-results__domain-availability-copy"
 						status="is-warning"
 						showDismiss={ false }>
 						{ domainUnavailableMessage } { mappingOffer }

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -112,7 +112,6 @@ var MapDomainStep = React.createClass( {
 		return (
 			<div className="domain-search-results__domain-availability is-mapping-suggestion">
 				<Notice
-					className="domain-search-results__domain-availability-copy"
 					status="is-success"
 					showDismiss={ false }>
 					{

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -111,14 +111,17 @@ var MapDomainStep = React.createClass( {
 
 		return (
 			<div className="domain-search-results__domain-availability is-mapping-suggestion">
-				<div className="domain-search-results__domain-availability-copy notice is-success">
+				<Notice
+					className="domain-search-results__domain-availability-copy"
+					status="is-success"
+					showDismiss={ false }>
 					{
 						this.translate(
 							'%(domain)s is available!',
 							{ args: { domain: suggestion.domain_name } }
 						)
 					}
-				</div>
+				</Notice>
 				<DomainRegistrationSuggestion
 					suggestion={ suggestion }
 					selectedSite={ this.props.selectedSite }


### PR DESCRIPTION
## Purpose
This PR fixes a visual issue with the domain mapping screen when a non-existing domain is submitted.

## The issue

To reproduce the issue, go to `/domains/add/mapping/$site`, input a non-existing domain like `thisissomeexamplefreedomain.com` and click the "Add" button. You will be presented with the following availability notice (the green one) that does not look very friendly:

![](https://cldup.com/KQG35Ners6-3000x3000.png)

For comparison, the same notice in `/domains/add/$site` looks better in terms of spacing, and includes a success icon:

![](https://cldup.com/ZQU_mkTfex-3000x3000.png)

## Solution

This PR proposes that we use a `Notice` here, just like in the `/domains/add/$site` screen. It also includes a success icon, so it appears to be the obvious way to solve this issue. Here is how it looks with the `Notice`:

![](https://cldup.com/MrMkPoqMkO-2000x2000.png)

The PR also removes an obsolete CSS class - `.domain-search-results__domain-availability-copy`

## Testing

* Checkout this branch
* Go to `/domains/add/mapping/$site`.
* Input a domain that has not been registered yet, e.g. `thisissomeexamplefreedomain.com`
* Click the "Add" button.
* Verify that the screen presents an improved availability notice, just like on the last screenshot above. 

## Review

/cc @rickybanister for design sanity check and @ryelle, @roccotrip for code review

Test live: https://calypso.live/?branch=fix/domain-mapping-availability-notice-appearance