### PR TITLE
SiteSelector: display search with less than 6 sites but more hidden ones

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -264,12 +264,11 @@ const SiteSelector = React.createClass( {
 	},
 
 	render() {
+		const hiddenSitesCount = this.props.siteCount - this.props.visibleSiteCount;
 		const selectorClass = classNames( 'site-selector', 'sites-list', {
-			'is-large': this.props.siteCount > 6,
+			'is-large': this.props.siteCount > 6 || hiddenSitesCount > 0,
 			'is-single': this.props.visibleSiteCount === 1
 		} );
-
-		const hiddenSitesCount = this.props.siteCount - this.props.visibleSiteCount;
 
 		return (
 			<div className={ selectorClass }>


### PR DESCRIPTION
QoL update so that people have access to search if they have hidden sites but less than 6 visible sites.

cc @aduth 

Test live: https://calypso.live/?branch=update/site-selector-search-display-logic