### PR TITLE
Components: Fix unknown prop warning in ProfileLink

### DIFF
--- a/client/me/action-remove/index.jsx
+++ b/client/me/action-remove/index.jsx
@@ -1,34 +1,18 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' ),
-	omit = require( 'lodash/omit' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
+import omit from 'lodash/omit';
+import { localize } from 'i18n-calypso';
 
-module.exports = React.createClass( {
+const ActionRemove = ( props ) =>
+	<button
+		title={ props.translate( 'Remove', { textOnly: true } ) }
+		{ ...omit( props, 'moment', 'numberFormat', 'translate' ) }
+		className={ classNames( 'action-remove', props.className ) }
+	>
+		{ props.children }
+	</button>;
 
-	displayName: 'ActionRemove',
-
-	getDefaultProps: function() {
-		return {
-			isSubmitting: false,
-			isPrimary: true
-		};
-	},
-
-	render: function() {
-		var buttonClasses = classNames( {
-			'action-remove': true
-		} );
-
-		return (
-			<button
-				title={ this.translate( 'Remove', { textOnly: true } ) }
-				{ ...omit( this.props, 'className' ) }
-				className={ classnames( this.props.className, buttonClasses ) } >
-				{ this.props.children }
-			</button>
-		);
-	}
-} );
+export default localize( ActionRemove );


### PR DESCRIPTION
This PR clears JS warnings emitted by the `ProfileLink` component. They were actually caused by `ActionRemove`, which is used in `ProfileLink`. The default props of `ActionRemove` were not used at all, so we could simply remove them. 

As a bonus, this PR ES6-ifies `ActionRemove`.

Note: this PR is part of the unknown prop warning resolve PR series: https://github.com/Automattic/wp-calypso/issues/7413.

To test:

* Checkout this branch
* Visit `/me`
* Open the console and verify you see no JS warnings related to `ActionRemove` or `ProfileLink`.

/cc @aduth

Test live: https://calypso.live/?branch=fix/js-warnings-profile-link-action-remove