### PR TITLE
Add getPlanRawDiscount selector

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -19,7 +19,7 @@ import { isCurrentPlanPaid, isCurrentSitePlan } from 'state/sites/selectors';
 import { getPlansBySiteId } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getPlanDiscountPrice } from 'state/sites/plans/selectors';
+import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
 import {
 	getPlanRawPrice,
 	getPlan,
@@ -472,7 +472,7 @@ export default connect(
 				available: available,
 				currencyCode: getCurrentUserCurrencyCode( state ),
 				current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
-				discountPrice: getPlanDiscountPrice( state, selectedSiteId, plan, showMonthly ),
+				discountPrice: getPlanDiscountedRawPrice( state, selectedSiteId, plan, showMonthly ),
 				features: getPlanFeaturesObject( planConstantObj.getFeatures() ),
 				onUpgradeClick: onUpgradeClick
 					? () => {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -472,7 +472,7 @@ export default connect(
 				available: available,
 				currencyCode: getCurrentUserCurrencyCode( state ),
 				current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
-				discountPrice: getPlanDiscountedRawPrice( state, selectedSiteId, plan, showMonthly ),
+				discountPrice: getPlanDiscountedRawPrice( state, selectedSiteId, plan, { isMonthly: showMonthly } ),
 				features: getPlanFeaturesObject( planConstantObj.getFeatures() ),
 				onUpgradeClick: onUpgradeClick
 					? () => {

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -70,14 +70,14 @@ export const getSitePlan = createSelector(
 );
 
 /**
- * Returns a plan discount price
+ * Returns a plan discounted price
  * @param  {Object}  state         global state
  * @param  {Number}  siteId       the site id
  * @param  {String}  productSlug   the plan product slug
  * @param  {Boolean} isMonthly     if true, returns monthly price
- * @return {Number}  plan discount price
+ * @return {Number}  plan discounted raw price
  */
-export function getPlanDiscountPrice( state, siteId, productSlug, isMonthly = false ) {
+export function getPlanDiscountedRawPrice( state, siteId, productSlug, isMonthly = false ) {
 	const plan = getSitePlan( state, siteId, productSlug );
 
 	if ( get( plan, 'rawPrice', -1 ) < 0 || get( plan, 'rawDiscount', -1 ) <= 0 ) {

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -89,6 +89,27 @@ export function getPlanDiscountedRawPrice( state, siteId, productSlug, isMonthly
 	return isMonthly ? parseFloat( ( discountPrice / 12 ).toFixed( 2 ) ) : discountPrice;
 }
 
+/**
+ * Returns a plan raw discount. It's the value which was subtracted from the plan's original raw price.
+ * Use getPlanDiscountedRawPrice if you need a plan's raw price after applying the discount.
+ * @param  {Object}  state         global state
+ * @param  {Number}  siteId       the site id
+ * @param  {String}  productSlug   the plan product slug
+ * @param  {Boolean} isMonthly     if true, returns monthly price
+ * @return {Number}  plan raw discount
+ */
+export function getPlanRawDiscount( state, siteId, productSlug, isMonthly = false ) {
+	const plan = getSitePlan( state, siteId, productSlug );
+
+	if ( get( plan, 'rawDiscount', -1 ) <= 0 ) {
+		return null;
+	}
+
+	return isMonthly
+		? parseFloat( ( plan.rawDiscount / 12 ).toFixed( 2 ) )
+		: plan.rawDiscount;
+}
+
 export function hasDomainCredit( state, siteId ) {
 	if ( ! siteId ) {
 		return initialSiteState;

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -71,13 +71,21 @@ export const getSitePlan = createSelector(
 
 /**
  * Returns a plan discounted price
+ *
  * @param  {Object}  state         global state
- * @param  {Number}  siteId       the site id
+ * @param  {Number}  siteId        the site id
  * @param  {String}  productSlug   the plan product slug
  * @param  {Boolean} isMonthly     if true, returns monthly price
- * @return {Number}  plan discounted raw price
+ * @return {Number}                plan discounted raw price
  */
-export function getPlanDiscountedRawPrice( state, siteId, productSlug, isMonthly = false ) {
+export function getPlanDiscountedRawPrice(
+	state,
+	siteId,
+	productSlug,
+	{
+		isMonthly = false
+	} = {}
+) {
 	const plan = getSitePlan( state, siteId, productSlug );
 
 	if ( get( plan, 'rawPrice', -1 ) < 0 || get( plan, 'rawDiscount', -1 ) <= 0 ) {
@@ -92,13 +100,21 @@ export function getPlanDiscountedRawPrice( state, siteId, productSlug, isMonthly
 /**
  * Returns a plan raw discount. It's the value which was subtracted from the plan's original raw price.
  * Use getPlanDiscountedRawPrice if you need a plan's raw price after applying the discount.
- * @param  {Object}  state         global state
+ *
+ * @param  {Object}  state        global state
  * @param  {Number}  siteId       the site id
- * @param  {String}  productSlug   the plan product slug
- * @param  {Boolean} isMonthly     if true, returns monthly price
- * @return {Number}  plan raw discount
+ * @param  {String}  productSlug  the plan product slug
+ * @param  {Boolean} isMonthly    if true, returns monthly price
+ * @return {Number}               plan raw discount
  */
-export function getPlanRawDiscount( state, siteId, productSlug, isMonthly = false ) {
+export function getPlanRawDiscount(
+	state,
+	siteId,
+	productSlug,
+	{
+		isMonthly = false
+	} = {}
+) {
 	const plan = getSitePlan( state, siteId, productSlug );
 
 	if ( get( plan, 'rawDiscount', -1 ) <= 0 ) {

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import {
 	getSitePlan,
 	getPlanDiscountedRawPrice,
+	getPlanRawDiscount,
 	getPlansBySite,
 	getPlansBySiteId,
 	hasDomainCredit,
@@ -230,6 +231,108 @@ describe( 'selectors', () => {
 			expect( discountPrice ).to.equal( null );
 		} );
 	} );
+
+	describe( '#getPlanRawDiscount()', () => {
+		it( 'should return a raw discount', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+
+			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'bronze' );
+
+			expect( planRawDiscount ).to.equal( 100 );
+		} );
+
+		it( 'should return a monthly raw discount', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+
+			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'bronze', true );
+
+			expect( planRawDiscount ).to.equal( 8.33 );
+		} );
+
+		it( 'should return null, if no raw discount is available', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+
+			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'silver', true );
+
+			expect( planRawDiscount ).to.equal( null );
+		} );
+	} );
+
 	describe( '#hasDomainCredit()', () => {
 		it( 'should return true if plan has domain credit', () => {
 			const state = {

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getSitePlan,
-	getPlanDiscountPrice,
+	getPlanDiscountedRawPrice,
 	getPlansBySite,
 	getPlansBySiteId,
 	hasDomainCredit,
@@ -141,7 +141,7 @@ describe( 'selectors', () => {
 			expect( plan ).to.eql( null );
 		} );
 	} );
-	describe( '#getPlanDiscountPrice()', () => {
+	describe( '#getPlanDiscountedRawPrice()', () => {
 		it( 'should return a discount price', () => {
 			const plans = {
 				data: [ {
@@ -168,7 +168,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = getPlanDiscountPrice( state, 77203074, 'bronze' );
+			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'bronze' );
 			expect( discountPrice ).to.equal( 99 );
 		} );
 		it( 'should return a monthly discount price', () => {
@@ -197,7 +197,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = getPlanDiscountPrice( state, 77203074, 'bronze', true );
+			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'bronze', true );
 			expect( discountPrice ).to.equal( 8.25 );
 		} );
 		it( 'should return null, if no discount is available', () => {
@@ -226,7 +226,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = getPlanDiscountPrice( state, 77203074, 'silver', true );
+			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'silver', true );
 			expect( discountPrice ).to.equal( null );
 		} );
 	} );

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -198,7 +198,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'bronze', true );
+			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'bronze', { isMonthly: true } );
 			expect( discountPrice ).to.equal( 8.25 );
 		} );
 		it( 'should return null, if no discount is available', () => {
@@ -227,7 +227,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'silver', true );
+			const discountPrice = getPlanDiscountedRawPrice( state, 77203074, 'silver', { isMonthly: true } );
 			expect( discountPrice ).to.equal( null );
 		} );
 	} );
@@ -294,7 +294,7 @@ describe( 'selectors', () => {
 				}
 			};
 
-			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'bronze', true );
+			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'bronze', { isMonthly: true } );
 
 			expect( planRawDiscount ).to.equal( 8.33 );
 		} );
@@ -327,7 +327,7 @@ describe( 'selectors', () => {
 				}
 			};
 
-			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'silver', true );
+			const planRawDiscount = getPlanRawDiscount( state, 77203074, 'silver', { isMonthly: true } );
 
 			expect( planRawDiscount ).to.equal( null );
 		} );


### PR DESCRIPTION
Helps to solve #7678. This PR has two purposes:

1. Add `getPlanRawDiscount` selector to get the value which was subtracted from a plan's original price;
2. Rename `getPlanDiscountPrice` to `getPlanDiscountedRawPrice`. I think this new name makes more sense because:
2.1. There are now two selectors concerning plan discounts. We need to be able to easily distinguish between what these two do
2.2. We use `getPlanRawPrice` to get a plan's original price. Therefore, we should also include the word "raw" in the `getPlanDiscountedRawPrice` selector to signify that it's a raw value (ie not formatted with currency) and to be consistent.

## Testing Instructions

1. Run `npm run test-client client/state/sites/plans/test` and get a green light;
2. Navigate to `/plans` and verify that the prices display correctly with discounts.

/cc @gwwar 

Test live: https://calypso.live/?branch=add/get-plan-raw-discount