### PR TITLE
Help: enable /help/courses on all environments and set course video

### DIFF
--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -28,7 +28,7 @@ export default {
 		analytics.pageView.record( basePath, 'Help' );
 
 		renderWithReduxStore(
-			<HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) }/>,
+			<HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) } />,
 			document.getElementById( 'primary' ),
 			context.store
 		);

--- a/client/me/help/help-courses/course-video.jsx
+++ b/client/me/help/help-courses/course-video.jsx
@@ -23,15 +23,15 @@ export default localize( ( props ) => {
 			<div className="help-courses__course-video-embed">
 				<iframe
 					className="help-courses__course-video-embed-iframe"
-					src={ `https://www.youtube.com/embed/${ youtubeId }` }
-					allowFullScreen/>
+					src={ `https://www.youtube.com/embed/${ youtubeId }?rel=0&showinfo=0` }
+					allowFullScreen />
 			</div>
 			<Card compact>
 				<h1 className="help-courses__course-video-title">{ title }</h1>
 				<p className="help-courses__course-video-description">{ description }</p>
 			</Card>
 			<Card compact className="help-courses__course-video-date">
-				<Gridicon className="help-courses__course-video-date-icon" icon="time" size={ 18 }/>
+				<Gridicon className="help-courses__course-video-date-icon" icon="time" size={ 18 } />
 				{ date.fromNow() }
 			</Card>
 		</div>

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -43,7 +43,7 @@ function getCourses() {
 			],
 			videos: [
 				{
-					date: i18n.moment( new Date( 'Thu, 25 Aug 2016 01:00:00 +0000' ) ),
+					date: i18n.moment( new Date( 'Fri, 2 Sep 2016 01:00:00 +0000' ) ),
 					title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
 					description: i18n.translate(
 						'A 60-minute overview course with two of our Happiness Engineers. In this live group session, ' +
@@ -51,7 +51,7 @@ function getCourses() {
 						'plan, provide a basic setup overview to help you get started with your site, and show you ' +
 						'where to find additional resources and help in the future.'
 					),
-					youtubeId: 'f44-4TgnWTs'
+					youtubeId: 'S2h_mV0OAcU'
 				}
 			]
 		}

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -20,6 +20,7 @@
 		"desktop-promo": false,
 		"fluid-width": true,
 		"help": true,
+		"help/courses": true,
 		"guided-tours": true,
 		"jetpack/connect": true,
 		"mailing-lists/unsubscribe": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -23,6 +23,7 @@
 		"guided-tours": true,
 		"happychat": false,
 		"help": true,
+		"help/courses": true,
 		"jetpack/connect": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -21,6 +21,7 @@
 		"guided-tours": true,
 		"happychat": false,
 		"help": true,
+		"help/courses": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -23,6 +23,7 @@
 		"guided-tours": true,
 		"happychat": true,
 		"help": true,
+		"help/courses": true,
 		"jetpack/connect": true,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,


### PR DESCRIPTION
This pull request removes the `help/courses` feature flag enabling /help/courses for all environments.

## How to test
There shouldn't be any noticeable change.

### As a business plan user
1. Navigate to http://calypso.dev/help
2. Click the "Courses" button
3. Notice that the courses page is now showing

### As a free plan user
1. Navigate to http://calypso.dev/help
2. Notice there is no "Courses" button for you to click on
3. Navigate to http://calypso.dev/help/courses
4. Note that you can only view the courses page by navigating directly to it


Test live: https://calypso.live/?branch=update/help-courses-launch