### PR TITLE
Reader: Only use post thumbs that appear to be images

### DIFF
--- a/client/lib/post-normalizer/rule-first-pass-canonical-image.js
+++ b/client/lib/post-normalizer/rule-first-pass-canonical-image.js
@@ -1,18 +1,15 @@
 /**
  * External Dependencies
  */
-import assign from 'lodash/assign';
-import filter from 'lodash/filter';
-import head from 'lodash/head';
-import startsWith from 'lodash/startsWith';
+import { assign, filter, head, startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-import { imageSizeFromAttachments } from './utils';
+import { imageSizeFromAttachments, thumbIsLikelyImage } from './utils';
 
 export default function firstPassCanonicalImage( post ) {
-	if ( post.post_thumbnail ) {
+	if ( thumbIsLikelyImage( post.post_thumbnail ) ) {
 		const { URL: url, width, height } = post.post_thumbnail;
 		post.canonical_image = {
 			uri: url,

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -1,12 +1,13 @@
 /**
  * External Dependencies
  */
-import filter from 'lodash/filter';
+import { filter } from 'lodash';
 import debugFactory from 'debug';
 
 /**
  * Internal Dependencies
  */
+import { thumbIsLikelyImage } from './utils';
 
 const debug = debugFactory( 'calypso:post-normalizer:pick-canonical-image' );
 
@@ -28,7 +29,7 @@ function candidateForCanonicalImage( image ) {
 }
 
 export default function pickCanonicalImage( post ) {
-	var canonicalImage;
+	let canonicalImage;
 	if ( post.images ) {
 		canonicalImage = filter( post.images, candidateForCanonicalImage )[ 0 ];
 		if ( canonicalImage ) {
@@ -38,7 +39,7 @@ export default function pickCanonicalImage( post ) {
 				height: canonicalImage.naturalHeight
 			};
 		}
-	} else if ( post.post_thumbnail ) {
+	} else if ( thumbIsLikelyImage( post.post_thumbnail ) ) {
 		canonicalImage = {
 			uri: post.post_thumbnail.URL,
 			width: post.post_thumbnail.width,

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -1,18 +1,21 @@
 /**
  * External Dependencies
  */
-import filter from 'lodash/filter';
-import find from 'lodash/find';
-import flow from 'lodash/flow';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import pick from 'lodash/pick';
-import pull from 'lodash/pull';
-import uniq from 'lodash/uniq';
+import {
+	filter,
+	find,
+	flow,
+	forEach,
+	map,
+	pick,
+	pull,
+	uniq
+} from 'lodash';
 
 /**
  * Internal Dependencies
  */
+import { thumbIsLikelyImage } from './utils';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:post-normalizer:wait-for-images-to-load' );
@@ -53,7 +56,7 @@ export default function waitForImagesToLoad( post ) {
 
 		let imagesToCheck = [];
 
-		if ( post.post_thumbnail ) {
+		if ( thumbIsLikelyImage( post.post_thumbnail ) ) {
 			imagesToCheck.push( post.post_thumbnail.URL );
 		} else if ( post.featured_image ) {
 			imagesToCheck.push( post.featured_image );

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -1,8 +1,7 @@
 /**
  * External Dependencies
  */
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
+import { find, forEach, some, endsWith, startsWith } from 'lodash';
 import url from 'url';
 
 /**
@@ -36,14 +35,13 @@ export function maxWidthPhotonishURL( imageURL, width ) {
 		return imageURL;
 	}
 
-	let parsedURL = url.parse( imageURL, true, true ), // true, true means allow protocol-less hosts and parse the querystring
-		isGravatar, sizeParam;
+	const parsedURL = url.parse( imageURL, true, true ); // true, true means allow protocol-less hosts and parse the querystring
 
 	if ( ! parsedURL.host ) {
 		return imageURL;
 	}
 
-	isGravatar = parsedURL.host.indexOf( 'gravatar.com' ) !== -1;
+	const isGravatar = parsedURL.host.indexOf( 'gravatar.com' ) !== -1;
 
 	delete parsedURL.search;
 	// strip other sizing params
@@ -51,7 +49,7 @@ export function maxWidthPhotonishURL( imageURL, width ) {
 		delete parsedURL.query[ param ];
 	} );
 
-	sizeParam = isGravatar ? 's' : 'w';
+	const sizeParam = isGravatar ? 's' : 'w';
 	parsedURL.query[ sizeParam ] = width * IMAGE_SCALE_FACTOR;
 
 	if ( ! isGravatar ) {
@@ -86,4 +84,19 @@ export function domForHtml( html ) {
 		dom.innerHTML = html;
 	}
 	return dom;
+}
+
+export function thumbIsLikelyImage( thumb ) {
+	if ( ! thumb ) {
+		return false;
+	}
+
+	if ( startsWith( thumb.mime_type, 'image/' ) ) {
+		return true;
+	}
+
+	const { path } = url.parse( thumb.URL, true, true );
+	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], function( ext ) {
+		return endsWith( path, ext );
+	} );
 }

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { find, forEach, some, endsWith, startsWith } from 'lodash';
+import { find, forEach, some, endsWith } from 'lodash';
 import url from 'url';
 
 /**
@@ -86,17 +86,23 @@ export function domForHtml( html ) {
 	return dom;
 }
 
+/**
+ * Determine if a post thumbnail is likely an image
+ * @param  {object} thumb the thumbnail object from a post
+ * @return {boolean}       whether or not we think this is an image
+ */
 export function thumbIsLikelyImage( thumb ) {
 	if ( ! thumb ) {
 		return false;
 	}
+	// this doesn't work because jetpack 4.2 lies
+	// normally I wouldn't leave commented code in, but it's the best way to explain what not to do
+	//if ( startsWith( thumb.mime_type, 'image/' ) ) {
+	//	return true;
+	// }
 
-	if ( startsWith( thumb.mime_type, 'image/' ) ) {
-		return true;
-	}
-
-	const { path } = url.parse( thumb.URL, true, true );
+	const { pathname } = url.parse( thumb.URL, true, true );
 	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], function( ext ) {
-		return endsWith( path, ext );
+		return endsWith( pathname, ext );
 	} );
 }

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -189,7 +189,7 @@ const Post = React.createClass( {
 		//   - there is an available embed
 		//
 		useFeaturedEmbed = featuredEmbed &&
-			( ! featuredImage || ( featuredImage !== post.featured_image ) );
+			( ! featuredImage || ( featuredImage !== post.featured_image && featuredImage !== get( post, 'post_thumbnail.URL' ) ) );
 		if ( useFeaturedEmbed ) {
 			this.featuredSizingStrategy = EmbedHelper.getEmbedSizingFunction( featuredEmbed );
 		} else if ( featuredImage && post.canonical_image.width >= maxWidth ) {


### PR DESCRIPTION
There are some problems with how these are synced in Jetpack 4.2, so we end up with some odd values from time to time. Add a sanity check that tries to ensure the post thumb is actually an image before using it. Affects Laughing Squid.

See http://calypso.localhost:3000/read/feeds/12098

Test live: https://calypso.live/?branch=fix/reader/post-thumbs-are-sometimes-bad