### PR TITLE
Domains: Update notices that start with 'Sorry but'

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -202,25 +202,25 @@ var MapDomainStep = React.createClass( {
 				severity = 'info';
 				break;
 			case 'not_mappable':
-				message = this.translate( 'Sorry but %(domain)s has not been registered yet therefore cannot be mapped.', {
+				message = this.translate( 'Sorry, %(domain)s has not been registered yet therefore cannot be mapped.', {
 					args: { domain: domain }
 				} );
 				break;
 
 			case 'invalid_domain':
-				message = this.translate( 'Sorry but %(domain)s does not appear to be a valid domain name.', {
+				message = this.translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
 					args: { domain: domain }
 				} );
 				break;
 
 			case 'mapped_domain':
-				message = this.translate( 'Sorry but %(domain)s is already mapped to a WordPress.com blog.', {
+				message = this.translate( 'Sorry, %(domain)s is already mapped to a WordPress.com blog.', {
 					args: { domain: domain }
 				} );
 				break;
 
 			case 'restricted_domain':
-				message = this.translate( 'Sorry but WordPress.com domains cannot be mapped to a WordPress.com blog.' );
+				message = this.translate( 'Sorry, WordPress.com domains cannot be mapped to a WordPress.com blog.' );
 				break;
 
 			case 'blacklisted_domain':
@@ -236,20 +236,20 @@ var MapDomainStep = React.createClass( {
 						}
 					);
 				} else {
-					message = this.translate( 'Sorry but %(domain)s cannot be mapped to a WordPress.com blog.', {
+					message = this.translate( 'Sorry, %(domain)s cannot be mapped to a WordPress.com blog.', {
 						args: { domain: domain }
 					} );
 				}
 				break;
 
 			case 'forbidden_domain':
-				message = this.translate( 'Sorry but you do not have the correct permissions to map %(domain)s.', {
+				message = this.translate( 'Sorry, you do not have the correct permissions to map %(domain)s.', {
 					args: { domain: domain }
 				} );
 				break;
 
 			case 'invalid_tld':
-				message = this.translate( 'Sorry but %(domain)s does not end with a valid domain extension.', {
+				message = this.translate( 'Sorry, %(domain)s does not end with a valid domain extension.', {
 					args: { domain: domain }
 				} );
 				break;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -609,13 +609,13 @@ const RegisterDomainStep = React.createClass( {
 				break;
 
 			case 'invalid_query':
-				message = this.translate( 'Sorry but %(domain)s does not appear to be a valid domain name.', {
+				message = this.translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
 					args: { domain: domain }
 				} );
 				break;
 
 			case 'server_error':
-				message = this.translate( 'Sorry but there was a problem processing your request. Please try again in a few minutes.' );
+				message = this.translate( 'Sorry, there was a problem processing your request. Please try again in a few minutes.' );
 				break;
 
 			case 'mappable_but_recently_mapped':

--- a/client/my-sites/upgrades/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/upgrades/domain-search/site-redirect-step.jsx
@@ -115,12 +115,12 @@ var SiteRedirectStep = React.createClass( {
 	getValidationErrorMessage: function( domain, error ) {
 		switch ( error.code ) {
 			case 'invalid_domain':
-				return this.translate( 'Sorry but %(domain)s does not appear to be a valid domain name.', {
+				return this.translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
 					args: { domain: domain }
 				} );
 
 			case 'invalid_tld':
-				return this.translate( 'Sorry but %(domain)s does not end with a valid domain extension.', {
+				return this.translate( 'Sorry, %(domain)s does not end with a valid domain extension.', {
 					args: { domain: domain }
 				} );
 


### PR DESCRIPTION
This PR updates the notice wording within domains where 11 notices start with `Sorry but`, as suggested here: https://github.com/Automattic/wp-calypso/pull/7800#issuecomment-244077408. 

As we discussed with @rickybanister, we're replacing `but` with a comma everywhere to make the sentences more readable.

/cc @rickybanister

Test live: https://calypso.live/?branch=update/domains-notices-starting-with-sorry