### PR TITLE
Reader: apply special pullquote styles to existing full post view

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -377,7 +377,7 @@
 }
 
 // Daily Post-Specific Full Post View Styles
-.is-group-reader .blog-489937 .reader__full-post-content {
+.is-group-reader.blog-489937 .reader__full-post-content {
 
 	blockquote.left,
 	blockquote.alignleft,

--- a/client/reader/full-post/main.jsx
+++ b/client/reader/full-post/main.jsx
@@ -12,8 +12,7 @@ var ReactDom = require( 'react-dom' ),
 	twemoji = require( 'twemoji' ),
 	page = require( 'page' ),
 	bindActionCreators = require( 'redux' ).bindActionCreators,
-	connect = require( 'react-redux' ).connect,
-	config = require( 'config' );
+	connect = require( 'react-redux' ).connect;
 
 /**
  * Internal Dependencies
@@ -162,7 +161,7 @@ FullPostView = React.createClass( {
 			hasFeaturedImage = post &&
 				post.canonical_image &&
 				! ( post.display_type & DISPLAY_TYPES.CANONICAL_IN_CONTENT ),
-			articleClasses = [ 'reader__full-post' ],
+			articleClasses = [ 'reader__full-post', 'is-group-reader' ],
 			shouldShowExcerptOnly = ( post && post.use_excerpt ? post.use_excerpt : false ),
 			siteName = utils.siteNameFromSiteAndPost( site, post ),
 			isDiscoverPost = DiscoverHelper.isDiscoverPost( post ),
@@ -193,12 +192,6 @@ FullPostView = React.createClass( {
 
 		if ( hasFeaturedImage ) {
 			articleClasses.push( 'has-featured-image' );
-		}
-
-		if ( config.isEnabled( 'reader/refresh-2016-07' ) ) {
-			articleClasses.push( 'is-group-reader-refresh' );
-		} else {
-			articleClasses.push( 'is-group-reader' );
 		}
 
 		articleClasses = articleClasses.join( ' ' );

--- a/client/reader/full-post/main.jsx
+++ b/client/reader/full-post/main.jsx
@@ -12,7 +12,8 @@ var ReactDom = require( 'react-dom' ),
 	twemoji = require( 'twemoji' ),
 	page = require( 'page' ),
 	bindActionCreators = require( 'redux' ).bindActionCreators,
-	connect = require( 'react-redux' ).connect;
+	connect = require( 'react-redux' ).connect,
+	config = require( 'config' );
 
 /**
  * Internal Dependencies
@@ -192,6 +193,12 @@ FullPostView = React.createClass( {
 
 		if ( hasFeaturedImage ) {
 			articleClasses.push( 'has-featured-image' );
+		}
+
+		if ( config.isEnabled( 'reader/refresh-2016-07' ) ) {
+			articleClasses.push( 'is-group-reader-refresh' );
+		} else {
+			articleClasses.push( 'is-group-reader' );
 		}
 
 		articleClasses = articleClasses.join( ' ' );


### PR DESCRIPTION
#7630 added new pullquote styles for the refreshed Reader full post view.

It also clobbered the existing pullquote styles for the current full post view. This PR fixes them. They should look like this:

![screen shot 2016-09-01 at 15 36 57](https://cloud.githubusercontent.com/assets/17325/18171726/df9f0262-705a-11e6-9d90-c2805df5d424.png)

If you're testing in development, you'll have to disable the Reader refresh feature flag (`"reader/refresh-2016-07": false`) in development.json.

Example post: http://calypso.localhost:3000/read/feeds/27030/posts/1117210232

Test live: https://calypso.live/?branch=fix/reader/pullquotes-discover-daily-post-existing-full-post