### PR TITLE
Themes: Enable magic-search flag on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -69,6 +69,7 @@
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
+		"manage/themes/magic-search": true,
 		"me/account": true,
 		"me/billing-history": true,
 		"me/find-friends": false,


### PR DESCRIPTION
Switch magic search feature flag on on wpcalypso.wordpress.com, so we can share/demo incremental improvements. Only difference so far are the free/premium/all buttons instead of the dropdown, and removal of the _More_ button:

**Before**
![screen shot 2016-09-01 at 18 07 33](https://cloud.githubusercontent.com/assets/7767559/18176782/16aba350-706f-11e6-8c4e-d9adcc2c3678.png)

**After** (wpcalypso.wordpress.com only)
![screen shot 2016-09-01 at 18 07 12](https://cloud.githubusercontent.com/assets/7767559/18176787/1f050a50-706f-11e6-8732-66a7c66b1674.png)


Test live: https://calypso.live/?branch=add/theme-magic-search-wpcalypso