### PR TITLE
Editor: updating language of recent draft 'restore' dialog

### DIFF
--- a/client/post-editor/restore-post-dialog.jsx
+++ b/client/post-editor/restore-post-dialog.jsx
@@ -50,7 +50,7 @@ export default React.createClass( {
 				key="back"
 				isPrimary={ false }
 				onClick={ this.props.onClose }>
-					{ this.translate( 'Close' ) }
+					{ this.translate( 'Don\'t Restore' ) }
 			</FormButton>
 		];
 	},

--- a/client/post-editor/restore-post-dialog.jsx
+++ b/client/post-editor/restore-post-dialog.jsx
@@ -50,7 +50,7 @@ export default React.createClass( {
 				key="back"
 				isPrimary={ false }
 				onClick={ this.props.onClose }>
-					{ this.translate( 'Don\'t Restore' ) }
+					{ this.translate( "Don't restore" ) }
 			</FormButton>
 		];
 	},


### PR DESCRIPTION
The 'close' option was ambiguous—would I close the editor or the dialog? Which version would I be editing?

I made the secondary action 'Don't Restore' which feels more explicit.

Before:

<img width="419" alt="screen shot 2016-09-01 at 2 19 13 pm" src="https://cloud.githubusercontent.com/assets/437258/18179357/1062673c-7050-11e6-8297-81daa677b213.png">


After:

<img width="415" alt="screen shot 2016-09-01 at 2 23 14 pm" src="https://cloud.githubusercontent.com/assets/437258/18179369/178b2b34-7050-11e6-9fa2-f0c104812426.png">

cc @kellychoffman @MichaelArestad  @mtias 

Test live: https://calypso.live/?branch=fix/restore-dialog-language