### PR TITLE
Plans: Nux checkout auto-follow for all

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -44,15 +44,6 @@ module.exports = {
 		defaultVariation: 'ascendingPriceSubtleDescription',
 		allowExistingUsers: false,
 	},
-	signupCheckoutRedirect: {
-		datestamp: '20160826',
-		variations: {
-			auto: 50,
-			manual: 50,
-		},
-		defaultVariation: 'manual',
-		allowExistingUsers: false,
-	},
 	signupStore: {
 		datestamp: '20160727',
 		variations: {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -170,7 +170,7 @@ const Signup = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
 
 		this.signupFlowController.reset();
-		if ( dependencies.cartItem ) {
+		if ( dependencies.cartItem || dependencies.domainItem ) {
 			this.handleLogin( dependencies, destination );
 		} else {
 			this.setState( {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -45,8 +45,7 @@ import * as oauthToken from 'lib/oauth-token';
 /**
  * Constants
  */
-const MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_FREE = 8000;
-const MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_PREMIUM = 3000;
+const MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED = 3000;
 
 const Signup = React.createClass( {
 	displayName: 'Signup',
@@ -104,17 +103,11 @@ const Signup = React.createClass( {
 					? Date.now() - this.state.loadingScreenStartTime
 					: undefined;
 				const filteredDestination = utils.getDestination( destination, dependencies, this.props.flowName );
-				let loadingScreenDelay;
-				if ( dependencies.cartItem ) {
-					loadingScreenDelay = MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_PREMIUM;
-				} else {
-					loadingScreenDelay = MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_FREE;
-				}
 
-				if ( timeSinceLoading && timeSinceLoading < loadingScreenDelay ) {
+				if ( timeSinceLoading && timeSinceLoading < MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED ) {
 					return delay(
 						this.handleFlowComplete.bind( this, dependencies, filteredDestination ),
-						loadingScreenDelay - timeSinceLoading
+						MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED - timeSinceLoading
 					);
 				}
 				return this.handleFlowComplete( dependencies, filteredDestination );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -41,7 +41,6 @@ import utils from './utils';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import * as oauthToken from 'lib/oauth-token';
-import { abtest } from 'lib/abtest';
 
 /**
  * Constants
@@ -106,7 +105,7 @@ const Signup = React.createClass( {
 					: undefined;
 				const filteredDestination = utils.getDestination( destination, dependencies, this.props.flowName );
 				let loadingScreenDelay;
-				if ( dependencies.cartItem && abtest( 'signupCheckoutRedirect' ) === 'auto' ) {
+				if ( dependencies.cartItem ) {
 					loadingScreenDelay = MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_PREMIUM;
 				} else {
 					loadingScreenDelay = MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED_FREE;
@@ -178,7 +177,7 @@ const Signup = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
 
 		this.signupFlowController.reset();
-		if ( dependencies.cartItem && abtest( 'signupCheckoutRedirect' ) === 'auto' ) {
+		if ( dependencies.cartItem ) {
 			this.handleLogin( dependencies, destination );
 		} else {
 			this.setState( {


### PR DESCRIPTION
Ends the test introduced in https://github.com/Automattic/wp-calypso/pull/7589 and enables the behavior for all users

More about the test in testing post:
p3fqKv-3rT-p2

## Testing

- Use incognito (to be a new user)
- Go through checkout, selecting a free plan
- See that behaviour is not changed
- Go through checkout, selecting any plan
- See that button "clicks itself"
- using your existing user name, log in
- create new site **with paid domain and a free plan**
- see that button clicks itself

CC @lamosty @meremagee @rralian @gwwar 

Test live: https://calypso.live/?branch=update/nux-auto-redirect