### PR TITLE
Do not send blog title to the API when creating a new site. 

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -22,7 +22,7 @@ import { PLAN_PREMIUM } from 'lib/plans/constants';
 function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsCartItem, isPurchasingItem, siteUrl, themeSlug, themeSlugWithRepo, themeItem } ) {
 	wpcom.undocumented().sitesNew( {
 		blog_name: siteUrl,
-		blog_title: siteUrl,
+		blog_title: '',
 		options: {
 			theme: dependencies.theme || themeSlugWithRepo,
 			vertical: dependencies.surveyQuestion || undefined
@@ -186,7 +186,7 @@ module.exports = {
 	createSite( callback, { theme }, { site } ) {
 		var data = {
 			blog_name: site,
-			blog_title: site,
+			blog_title: '',
 			options: { theme },
 			validate: false
 		};


### PR DESCRIPTION
The introduction of the interim fix to move away from the practice to automatically set the site title to be the blog name/address broke the mobile applications, which actually sent site title to the API. 

This PR is an interim solution until we merge #7386 and shouldn't change any behaviour that is currently in place. 

To test:

* Checkout branch or use Calypso.live
* Apply D2525-code
* Complete signup
* Check if the site title is sill set to `Site Title`


cc @michaeldcain @kwonye 

Test live: https://calypso.live/?branch=fix/dont_send_site_title_to_api_on_signup