### PR TITLE
Emit plan purchase/refund and other events in Google Analytics

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -215,6 +215,7 @@ ABTest.prototype.assignVariation = function() {
 
 ABTest.prototype.recordVariation = function( variation ) {
 	analytics.tracks.recordEvent( 'calypso_abtest_start', { abtest_name: this.experimentId, abtest_variation: variation } );
+	analytics.ga.recordEvent( 'ABTest', 'calypso_abtest_start', `${ this.experimentId }: ${ variation }` );
 };
 
 ABTest.prototype.saveVariation = function( variation ) {

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -215,7 +215,12 @@ ABTest.prototype.assignVariation = function() {
 
 ABTest.prototype.recordVariation = function( variation ) {
 	analytics.tracks.recordEvent( 'calypso_abtest_start', { abtest_name: this.experimentId, abtest_variation: variation } );
-	analytics.ga.recordEvent( 'ABTest', 'calypso_abtest_start', `${ this.experimentId }: ${ variation }` );
+	analytics.ga.recordEventObject( {
+		eventCategory: 'ABTest',
+		eventAction: 'calypso_abtest_start',
+		expId: this.experimentId,
+		expVar: variation,
+	} );
 };
 
 ABTest.prototype.saveVariation = function( variation ) {

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -277,17 +277,13 @@ var analytics = {
 
 		recordEvent: function( category, action, label, value ) {
 			analytics.ga.initialize();
-
-			var debugText = 'Recording Event ~ [Category: ' + category + '] [Action: ' + action + ']';
-
+			let debugText = `Recording Event ~ [Category: ${ category }] [Action: ${ action }]`;
 			if ( 'undefined' !== typeof label ) {
-				debugText += ' [Option Label: ' + label + ']';
+				debugText += ` [Option Label: ${ label }]`;
 			}
-
 			if ( 'undefined' !== typeof value ) {
-				debugText += ' [Option Value: ' + value + ']';
+				debugText += ` [Option Value: ${ value }]`;
 			}
-
 			debug( debugText );
 
 			if ( config( 'google_analytics_enabled' ) ) {

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -285,9 +285,17 @@ var analytics = {
 				debugText += ` [Option Value: ${ value }]`;
 			}
 			debug( debugText );
+			this.recordEventObject( {
+				eventCategory: category,
+				eventAction: action,
+				eventLabel: label,
+				eventValue: value,
+			} );
+		},
 
+		recordEventObject: function( eventObj ) {
 			if ( config( 'google_analytics_enabled' ) ) {
-				window.ga( 'send', 'event', category, action, label, value );
+				window.ga( 'send', 'event', eventObj );
 			}
 		},
 

--- a/client/lib/cart/store/cart-analytics.js
+++ b/client/lib/cart/store/cart-analytics.js
@@ -17,6 +17,8 @@ function recordEvents( previousCart, nextCart ) {
 
 function recordAddEvent( cartItem ) {
 	analytics.tracks.recordEvent( 'calypso_cart_product_add', cartItem );
+	analytics.ga.recordEvent( 'Checkout', 'calypso_cart_product_add',
+		`${ cartItem.product_id } ${ cartItem.product_slug }` );
 	recordAddToCart( cartItem );
 }
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -165,6 +165,14 @@ const CancelPurchaseButton = React.createClass( {
 					}
 				), { persistent: true } );
 
+				const { productSlug } = purchase;
+
+				analytics.tracks.recordEvent(
+					'calypso_purchases_cancel',
+						{ product_slug: productSlug }
+				);
+				analytics.ga.recordEvent( 'Purchases', 'calypso_purchases_cancel', `${ productSlug }` );
+
 				page( paths.purchasesRoot() );
 			} else {
 				notices.error( this.translate(
@@ -208,10 +216,13 @@ const CancelPurchaseButton = React.createClass( {
 
 		this.props.clearPurchases();
 
+		const { productSlug } = this.props.purchase;
+
 		analytics.tracks.recordEvent(
-			'calypso_purchases_cancel_form_submit',
-			{ product_slug: this.props.purchase.productSlug }
+			'calypso_purchases_refund',
+			{ product_slug: productSlug }
 		);
+		analytics.ga.recordEvent( 'Purchases', 'calypso_purchases_refund', `${ productSlug }` );
 
 		page.redirect( paths.purchasesRoot() );
 	},

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -105,6 +105,12 @@ var TransactionStepsMixin = {
 
 					cartValue.products.forEach( function( cartItem ) {
 						analytics.tracks.recordEvent( 'calypso_checkout_product_purchase', cartItem );
+						analytics.ga.recordEvent(
+							'Checkout',
+							'calypso_checkout_product_purchase',
+							`${ cartItem.product_slug } cost: ${ cartItem.cost } curr: ${ cartItem.currency }` +
+								` per: ${ cartItem.bill_period }`
+						);
 					} );
 
 					this._recordDomainRegistrationAnalytics( {

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -96,12 +96,20 @@ var TransactionStepsMixin = {
 						adTracking.recordOrder( cartValue, step.data.receipt_id );
 					}
 
+					const paymentMethod = this.props.transaction.payment.paymentMethod;
+
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {
 						coupon_code: cartValue.coupon,
 						currency: cartValue.currency,
-						payment_method: this.props.transaction.payment.paymentMethod,
+						payment_method: paymentMethod,
 						total_cost: cartValue.total_cost
 					} );
+					analytics.ga.recordEvent(
+						'Checkout',
+						'calypso_checkout_payment_success',
+						`total_cost: ${ cartValue.total_cost } curr: ${ cartValue.currency }` +
+							` coupon_code: ${ cartValue.coupon } payment_method: ${ paymentMethod }`
+					);
 
 					cartValue.products.forEach( function( cartItem ) {
 						analytics.tracks.recordEvent( 'calypso_checkout_product_purchase', cartItem );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -74,7 +74,7 @@ const Signup = React.createClass( {
 	},
 
 	loadProgressFromStore() {
-		var newProgress = SignupProgressStore.get(),
+		const newProgress = SignupProgressStore.get(),
 			invalidSteps = some( newProgress, matchesProperty( 'status', 'invalid' ) ),
 			waitingForServer = ! invalidSteps && this.isEveryStepSubmitted(),
 			startLoadingScreen = waitingForServer && ! this.state.loadingScreenStartTime;
@@ -251,7 +251,7 @@ const Signup = React.createClass( {
 	},
 
 	loginRedirectTo( path ) {
-		var redirectTo;
+		let redirectTo;
 
 		if ( startsWith( path, 'https://' ) || startsWith( path, 'http://' ) ) {
 			return path;
@@ -340,7 +340,7 @@ const Signup = React.createClass( {
 	},
 
 	goToFirstInvalidStep() {
-		var firstInvalidStep = find( SignupProgressStore.get(), { status: 'invalid' } );
+		const firstInvalidStep = find( SignupProgressStore.get(), { status: 'invalid' } );
 
 		if ( firstInvalidStep ) {
 			analytics.tracks.recordEvent( 'calypso_signup_goto_invalid_step', {
@@ -369,18 +369,18 @@ const Signup = React.createClass( {
 	},
 
 	localeSuggestions() {
-		return 0 === this.positionInFlow() && ! user.get() ?
-			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } /> :
-			null;
+		return 0 === this.positionInFlow() && ! user.get()
+			? <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+			: null;
 	},
 
 	loginForm() {
-		return this.state.bearerToken ?
-			<WpcomLoginForm
+		return this.state.bearerToken
+			? <WpcomLoginForm
 				authorization={ 'Bearer ' + this.state.bearerToken }
 				log={ this.state.username }
-				redirectTo={ this.state.redirectTo } /> :
-			null;
+				redirectTo={ this.state.redirectTo } />
+			: null;
 	},
 
 	pageTitle() {
@@ -389,7 +389,7 @@ const Signup = React.createClass( {
 	},
 
 	currentStep() {
-		let currentStepProgress = find( this.state.progress, { stepName: this.props.stepName } ),
+		const currentStepProgress = find( this.state.progress, { stepName: this.props.stepName } ),
 			CurrentComponent = stepComponents[ this.props.stepName ],
 			propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props ),
 			stepKey = this.state.loadingScreenStartTime ? 'processing' : this.props.stepName,
@@ -442,12 +442,12 @@ const Signup = React.createClass( {
 		return (
 			<span>
 				<DocumentHead title={ this.pageTitle() } />
-				{
-					this.state.loadingScreenStartTime ?
-					null :
-					<FlowProgressIndicator
+				{ this.state.loadingScreenStartTime
+					? null
+					: <FlowProgressIndicator
 						positionInFlow={ this.positionInFlow() }
-						flowName={ this.props.flowName } />
+						flowName={ this.props.flowName }
+					/>
 				}
 				<ReactCSSTransitionGroup
 					className="signup__steps"

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -201,7 +201,10 @@ const Signup = React.createClass( {
 	handleFlowComplete( dependencies, destination ) {
 		debug( 'The flow is completed. Logging you in...' );
 
-		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
+		const {	flowName } = this.props;
+
+		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: flowName } );
+		analytics.ga.recordEvent( 'Signup', 'calypso_signup_complete', `Flow: ${ flowName }` );
 
 		this.signupFlowController.reset();
 		if ( dependencies.cartItem || dependencies.domainItem ) {


### PR DESCRIPTION
Fixes #7209. While we record plan purchase/refund and other events in Tracks, it would be nice to be able to cross-check the data in a separate platform. GA also offers some ways to slice our data differently than tracks.

Note: as GA doesn't allow to send arbitrary number of properties (only category, action and label), I'm sending additional details (such as abtest variation) in the label field. If I need to send multiple pieces of data (such as abtest name and abtest variation), I format the label field to include these (e.g. <abtest name>: <abtest variation>).
## Included Events
1. `calypso_signup_complete`;
2. `calypso_abtest_start`;
3. `calypso_cart_product_add`;
4. `calypso_checkout_product_purchase`;
5. `calypso_checkout_payment_success`;
6. `calypso_purchases_cancel_form_submit`.

Regarding refunds: the only event which contains the "refund" word directly is `wpcom_product_refund`. However, that's server-side event, not Calypso one. In Calypso, we have `calypso_purchases_cancel_form_submit` when a purchase is cancelled and (probably) refunded. Hard for me to test this as I would need to purchase a product with my real cc and then refund. **Edit:** we have a fn [here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/upgrades/actions/purchases.js#L26-L26) which sends the cancel and refund request. I could send a brand new Tracks/GA event here.

**Edit2**: actually, I can purchase and refund products thanks to sandboxing the store without using real cc. Will look into where we could add the brand new event for tracking refunds.
## Testing Instructions
1. Run `localStorage.setItem('debug', 'calypso:analytics');` in your browser's dev console and do full reload;
2. Try to trigger one of the included events mentioned above. As an example, go through the signup flow;
3. After triggering some event, you can observe the calls being made with the analytics module in your dev console. Example: 

![selection_027](https://cloud.githubusercontent.com/assets/4988512/18202441/2e9b9f1e-7110-11e6-8e32-40a38e03cbe9.jpg)
## Todo
- [x] Add new event for tracking refunds (we don't have any)

/cc @rralian @gwwar 

Test live: https://calypso.live/?branch=add/emit-plan-purchase-refund-ga-events
