### PR TITLE
Checkout: Add loading placeholder for cart

### DIFF
--- a/client/my-sites/upgrades/cart/cart-body.jsx
+++ b/client/my-sites/upgrades/cart/cart-body.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,15 +14,8 @@ const CartBody = ( {
 	cart,
 	collapse,
 	selectedSite,
-	showCoupon,
-	translate
+	showCoupon
 } ) => {
-	if ( ! cart.hasLoadedFromServer ) {
-		return <div className="cart-body">
-			{ translate( 'Loading…', { context: 'Upgrades: Loading cart' } ) }
-		</div>;
-	}
-
 	return (
 		<div className="cart-body">
 			<CartItems
@@ -45,4 +37,4 @@ CartBody.defaultProps = {
 	showCoupon: false
 };
 
-export default localize( CartBody );
+export default CartBody;

--- a/client/my-sites/upgrades/cart/cart-body/loading-placeholder.jsx
+++ b/client/my-sites/upgrades/cart/cart-body/loading-placeholder.jsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CartItemLoadingPlaceholder from 'my-sites/upgrades/cart/cart-item/loading-placeholder';
+
+const CartBodyLoadingPlaceholder = () => (
+	<div className="cart-body__loading-placeholder cart-body">
+		<ul className="cart-items">
+			<CartItemLoadingPlaceholder />
+			<CartItemLoadingPlaceholder />
+		</ul>
+	</div>
+);
+
+export default CartBodyLoadingPlaceholder;

--- a/client/my-sites/upgrades/cart/cart-item/loading-placeholder.jsx
+++ b/client/my-sites/upgrades/cart/cart-item/loading-placeholder.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const CartItemLoadingPlaceholder = () => (
+	<div className="cart-item__loading-placeholder cart-item">
+		<div className="primary-details">
+			<span className="product-name"></span>
+			<span className="product-domain"></span>
+		</div>
+		<div className="secondary-details">
+			<span className="product-price"></span>
+			<Button className="cart-item__loading-placeholder-remove-item remove-item" />
+		</div>
+	</div>
+);
+
+export default CartItemLoadingPlaceholder;

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import CartBody from './cart-body';
+import CartBodyLoadingPlaceholder from './cart-body/loading-placeholder';
 import CartMessagesMixin from './cart-messages-mixin';
 import CartButtons from './cart-buttons';
 import Popover from 'components/popover';
@@ -100,9 +101,11 @@ var PopoverCart = React.createClass( {
 	},
 
 	cartBody: function() {
-		var cartEmpty = this.props.cart.hasLoadedFromServer && ! this.props.cart.products.length;
+		if ( ! this.props.cart.hasLoadedFromServer ) {
+			return <CartBodyLoadingPlaceholder />;
+		}
 
-		if ( cartEmpty ) {
+		if ( ! this.props.cart.products.length ) {
 			return (
 				<CartEmpty selectedSite={ this.props.selectedSite } path={ this.props.path } />
 			);

--- a/client/my-sites/upgrades/cart/secondary-cart.jsx
+++ b/client/my-sites/upgrades/cart/secondary-cart.jsx
@@ -13,12 +13,22 @@ var CartBody = require( 'my-sites/upgrades/cart/cart-body' ),
 	CartPlanDiscountAd = require( './cart-plan-discount-ad' ),
 	Sidebar = require( 'layout/sidebar' ),
 	observe = require( 'lib/mixins/data-observe' );
+import CartBodyLoadingPlaceholder from 'my-sites/upgrades/cart/cart-body/loading-placeholder';
 
 var SecondaryCart = React.createClass( {
 	mixins: [ CartMessagesMixin, observe( 'sites' ) ],
 
 	render: function() {
 		const { cart, selectedSite } = this.props;
+
+		if ( ! cart.hasLoadedFromServer ) {
+			return (
+				<Sidebar className="secondary-cart">
+					<CartSummaryBar additionalClasses="cart-header" />
+					<CartBodyLoadingPlaceholder />
+				</Sidebar>
+			);
+		}
 
 		return (
 			<Sidebar className="secondary-cart">

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -62,7 +62,7 @@
 			display: block;
 			font-size: 13px;
 		}
-		 
+
 		.product-monthly-price {
 			color: $gray;
 			display: block;
@@ -82,6 +82,13 @@
 			position: absolute;
 			right: 0;
 			top: 0;
+		}
+	}
+
+	.cart-item__loading-placeholder {
+		.remove-item {
+			@include placeholder(23%);
+			width: 25px;
 		}
 	}
 
@@ -334,4 +341,23 @@ div.popover-cart__popover {
 
 .secondary-cart {
 	background: $white;
+}
+
+.cart-item__loading-placeholder {
+	span {
+		@include placeholder(23%);
+		margin-bottom: 1px;
+	}
+
+	.product-name {
+		width: 55%;
+	}
+
+	.product-domain {
+		width: 40%;
+	}
+
+	.product-price {
+		width: 20%;
+	}
 }

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -88,6 +88,7 @@
 	.cart-item__loading-placeholder {
 		.remove-item {
 			@include placeholder(23%);
+			border-radius: 0;
 			width: 25px;
 		}
 	}


### PR DESCRIPTION
Fixes #3891.

The the cart loading state still needs placeholders.

#### Plans, Domains, Google Apps pages 

###### Before
![screen shot 2016-09-05 at 09 02 45](https://cloud.githubusercontent.com/assets/699132/18239741/92e4e99c-7347-11e6-9bf2-09ad656b16eb.png)

###### After
![screen shot 2016-09-05 at 09 04 12](https://cloud.githubusercontent.com/assets/699132/18239782/cda3164e-7347-11e6-9b64-9d9f684ab352.png)

![screen shot 2016-09-05 at 09 06 01](https://cloud.githubusercontent.com/assets/699132/18239814/012eb342-7348-11e6-8f45-364e2c087d59.png)


#### Cart page
###### Before
![screen shot 2016-09-05 at 09 01 31](https://cloud.githubusercontent.com/assets/699132/18239751/9c6e3dba-7347-11e6-800a-d004103d770e.png)

###### After
![screen shot 2016-09-05 at 09 23 38](https://cloud.githubusercontent.com/assets/699132/18240197/84c06140-734a-11e6-9d22-97c1c50a402d.png)

### Testing
Test live: https://calypso.live/?branch=update/cart-add-loading-placeholder

1. Select a site.
2. Go to Plans page.
3. Add something to cart.
4. If you don't see loading placeholder on the Cart page. You can try by refreshing the page.
5. Go back to plans page.
6. Click the cart button when page is loading.
7. You should see loading placeholder in the tooltip.