### PR TITLE
Fire calypso_user_registration_complete on new user registration

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -18,6 +18,7 @@ import { getSavedVariations } from 'lib/abtest';
 import SignupCart from 'lib/signup/cart';
 import { startFreeTrial } from 'lib/upgrades/actions';
 import { PLAN_PREMIUM } from 'lib/plans/constants';
+import analytics from 'lib/analytics';
 
 function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsCartItem, isPurchasingItem, siteUrl, themeSlug, themeSlugWithRepo, themeItem } ) {
 	wpcom.undocumented().sitesNew( {
@@ -178,6 +179,12 @@ module.exports = {
 		), ( error, response ) => {
 			var errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined,
 				bearerToken = error && error.error ? {} : { bearer_token: response.bearer_token };
+
+			if ( ! errors ) {
+				// Fire after a new user registers.
+				analytics.tracks.recordEvent( 'calypso_user_registration_complete' );
+				analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
+			}
 
 			callback( errors, assign( {}, { username: userData.username }, bearerToken ) );
 		} );


### PR DESCRIPTION
Fixes #7826. Adds a new Tracks/Google Analytics event which is fired after a new user registers. No additional data is sent with the event.

## Testing Instructions

1. Navigate to calypso.localhost:3000/start in an incognito window;
2. Turn on analytics JS debugging by running `localStorage.setItem('debug', 'calypso:analytics');` in your browser's dev console followed by full page reload;
3. Go through the signup flow;
4. After completing the new user signup form, look at your dev console for `calypso_user_registration_complete` event logging;
5. When reviewing the code, verify that the event is fired only after creating a brand new user account and only after it has been successfully created.

/cc @rralian 

Test live: https://calypso.live/?branch=add/new-user-creation-tracking-event