### PR TITLE
Fix ignore-click rule for links with more than one value for rel=""

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -53,7 +53,7 @@ const SearchCardAdapter = React.createClass( {
 		}
 
 		// declarative ignore
-		if ( closest( event.target, '.ignore-click, [rel=external]', true, rootNode ) ) {
+		if ( closest( event.target, '.ignore-click, [rel~=external]', true, rootNode ) ) {
 			return;
 		}
 

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -276,7 +276,7 @@ const Post = React.createClass( {
 		}
 
 		// declarative ignore
-		if ( closest( event.target, '.ignore-click, [rel=external]', true, rootNode ) ) {
+		if ( closest( event.target, '.ignore-click, [rel~=external]', true, rootNode ) ) {
 			return;
 		}
 


### PR DESCRIPTION
We recently merged #7680, which added rel="noopener noreferrer" wherever target="_blank" is used. As a result, external links on Reader cards stopped working, because we we're ignoring such clicks with the following rule:

![screen shot 2016-09-02 at 14 30 00](https://cloud.githubusercontent.com/assets/17325/18205413/bff18d30-7119-11e6-884a-5b858854a807.png)

This PR now looks for links whose `rel` attribute _contains_ "external", rather than equals "external".

Fixes https://github.com/Automattic/wp-calypso/issues/7832 (cc @mgalbritton)

Test live: https://calypso.live/?branch=fix/reader/external-links-on-cards