### PR TITLE
Ad Tracking: Update Criteo tracking

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -363,7 +363,7 @@ function recordOrderInCriteo( cart, orderId ) {
 	recordInCriteo( 'viewBasket', {
 		id: orderId,
 		currency: cart.currency,
-		items: cartToCriteoItems( cart )
+		item: cartToCriteoItems( cart )
 	} );
 }
 
@@ -381,7 +381,7 @@ function recordViewCheckoutInCriteo( cart ) {
 	// Note that unlike `recordOrderInCriteo` above, this doesn't include the order id
 	recordInCriteo( 'viewBasket', {
 		currency: cart.currency,
-		items: cartToCriteoItems( cart )
+		item: cartToCriteoItems( cart )
 	} );
 }
 

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -181,6 +181,17 @@ function retarget() {
 }
 
 /**
+ * A generic function that we can export and call to track plans page views with our ad partners
+ */
+function retargetViewPlans() {
+	if ( ! config.isEnabled( 'ad-tracking' ) ) {
+		return;
+	}
+
+	recordPlansViewInCriteo();
+}
+
+/**
  * Records that an item was added to the cart
  *
  * @param {Object} cartItem - The item added to the cart
@@ -402,6 +413,19 @@ function cartToCriteoItems( cart ) {
 }
 
 /**
+ * Records in Criteo that the visitor viewed the plans page
+ */
+function recordPlansViewInCriteo() {
+	if ( ! config.isEnabled( 'ad-tracking' ) ) {
+		return;
+	}
+
+	recordInCriteo( 'viewItem', {
+		item: '1'
+	} );
+}
+
+/**
  * Records an event in Criteo
  *
  * @param {String} eventName - The name of the 'event' property such as 'viewItem' or 'viewBasket'
@@ -507,6 +531,7 @@ module.exports = {
 		nextFunction();
 	},
 
+	retargetViewPlans,
 	recordAddToCart,
 	recordViewCheckout,
 	recordPurchase,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -44,6 +44,7 @@ import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import SpinnerLine from 'components/spinner-line';
 import FoldableCard from 'components/foldable-card';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { retargetViewPlans } from 'lib/analytics/ad-tracking';
 
 class PlanFeatures extends Component {
 
@@ -424,6 +425,7 @@ class PlanFeatures extends Component {
 
 	componentWillMount() {
 		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
+		retargetViewPlans();
 	}
 }
 

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -71,8 +71,9 @@ const Checkout = React.createClass( {
 			this.addProductToCart();
 		}
 
-		if ( this.props.cart.hasPendingServerUpdates && ! nextProps.cart.hasPendingServerUpdates ) {
-			// We only want to track the page view when the cart has finished loading the products
+		// Note that `hasPendingServerUpdates` will go from `null` to `false` on NUX checkout
+		// and from `true` to `false` on post-NUX checkout
+		if ( this.props.cart.hasPendingServerUpdates !== false && nextProps.cart.hasPendingServerUpdates === false ) {
 			this.trackPageView( nextProps );
 		}
 	},


### PR DESCRIPTION
This PR makes two updates to Criteo's retargeting tracking code per their feedback:

Testing pre-requisites:

1) In `development.json`, set `ad-tracking` to `true`.
2) Turn on logging for the ad-tracking module: `localStorage.setItem( 'debug', 'calypso:ad-tracking' );`

## 1. We now fire a viewItem event on the plans page

To test:

1) Load an account's plans page
2) Verify that a `viewItem` event was triggered where `item: "1"`:

![screen shot 2016-09-02 at 10 12 15 am](https://cloud.githubusercontent.com/assets/44436/18206704/cfa990ac-70f5-11e6-9108-5dbc67f06bbc.png)

## 2. I renamed _items_ to _item_ per the documentation

To test:

1) Select a plan to go to the checkout page
2) Verify that the `viewBasket` log says `item` instead of `items`:

![screen shot 2016-09-02 at 10 14 16 am](https://cloud.githubusercontent.com/assets/44436/18206770/2b4911a8-70f6-11e6-88d9-cbc8881af69a.png)

3) Purchase that item using credits or a test credit card
4) Verify that the `viewBasket` log also says `item` instead of `items`:

![screen shot 2016-09-02 at 10 16 31 am](https://cloud.githubusercontent.com/assets/44436/18206815/6090c6f8-70f6-11e6-8bc0-e41d08e15b2a.png)

## 3. We now fire the `viewBasket` event in the NUX checkout

Previously it would only fire in post-NUX checkout due to a subtle bug with the way the cart loads in the NUX checkout.

To test:

1) Sign up for a new test account
2) Select a plan during the NUX and proceed to checkout
3) Verify the presence of the `viewBasket` log:

<img width="689" alt="screen shot 2016-09-05 at 10 17 16 am" src="https://cloud.githubusercontent.com/assets/44436/18250540/f6626b0c-7351-11e6-9231-ddf0e2461c47.png">

4) In Calypso go to Site > Plans > select a plan, and verify the same `viewBasket` log entry is present

Note that this bug would have also caused the `calypso_checkout_page_view` not to get fired correctly.

Test live: https://calypso.live/?branch=update/criteo-tracking