### PR TITLE
Conversion: Add Expanded VideoPress nudge

### DIFF
--- a/client/blocks/upgrade-nudge-expanded/style.scss
+++ b/client/blocks/upgrade-nudge-expanded/style.scss
@@ -44,13 +44,21 @@
 	}
 
 	.upgrade-nudge-expanded__title-plan-icon {
-		width: 54px;
-		height: 54px;
+		width: 55px;
+		height: 55px;
 		margin: 1px;
-		background: no-repeat;
+		background-repeat: no-repeat;
 
 		&.is-business-plan {
-			background: url('/calypso/images/plans/plan-business.svg')
+			background-image: url('/calypso/images/plans/plan-business.svg');
+		}
+
+		&.is-premium-plan {
+			background-image: url( '/calypso/images/plans/plan-premium.svg' );
+		}
+
+		&.is-personal-plan {
+			background-image: url('/calypso/images/plans/plan-personal.svg');
 		}
 	}
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -33,6 +33,15 @@ module.exports = {
 		},
 		defaultVariation: 'clickableButton'
 	},
+	expandedNudge: {
+		datestamp: '20160904',
+		variations: {
+			expanded: 50,
+			regular: 50,
+		},
+		defaultVariation: 'regular',
+		allowExistingUsers: true,
+	},
 	multiDomainRegistrationV1: {
 		datestamp: '20200721',
 		variations: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -48,6 +48,7 @@ export const FEATURE_GOOGLE_ANALYTICS = 'google-analytics';
 export const FEATURE_LIVE_CHAT_SUPPORT = 'live-chat-support';
 export const FEATURE_NO_ADS = 'no-adverts';
 export const FEATURE_VIDEO_UPLOADS = 'video-upload';
+export const FEATURE_AUDIO_UPLOADS = 'audio-upload';
 export const FEATURE_WORDADS_INSTANT = 'wordads-instant';
 export const FEATURE_NO_BRANDING = 'no-wp-branding';
 export const FEATURE_ADVANCED_SEO = 'advanced-seo';
@@ -145,6 +146,12 @@ export const plansList = {
 			FEATURE_NO_ADS,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS
+		],
+		getPromotedFeatures: () => [
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_NO_ADS,
+			FEATURE_ADVANCED_DESIGN,
+			FEATURE_13GB_STORAGE
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
@@ -366,6 +373,16 @@ export const featuresList = {
 		getDescription: () => i18n.translate(
 			'The easiest way to upload videos to your website and display them ' +
 			'using a fast, unbranded, customizable player with rich stats.'
+		),
+		getStoreSlug: () => 'videopress',
+		plans: allPaidPlans
+	},
+
+	[ FEATURE_AUDIO_UPLOADS ]: {
+		getSlug: () => FEATURE_AUDIO_UPLOADS,
+		getTitle: () => i18n.translate( 'Audio Upload Support' ),
+		getDescription: () => i18n.translate(
+			'The easiest way to upload audio files that use any major audio file format. '
 		),
 		getStoreSlug: () => 'videopress',
 		plans: allPaidPlans

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -375,7 +375,7 @@ export const featuresList = {
 			'using a fast, unbranded, customizable player with rich stats.'
 		),
 		getStoreSlug: () => 'videopress',
-		plans: allPaidPlans
+		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_AUDIO_UPLOADS ]: {
@@ -385,7 +385,7 @@ export const featuresList = {
 			'The easiest way to upload audio files that use any major audio file format. '
 		),
 		getStoreSlug: () => 'videopress',
-		plans: allPaidPlans
+		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ]
 	},
 
 	[ FEATURE_BASIC_DESIGN ]: {

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -3,11 +3,11 @@
  */
 import React, { PropTypes } from 'react';
 import { identity } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
 import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
 import { PLAN_PREMIUM, FEATURE_VIDEO_UPLOADS, FEATURE_AUDIO_UPLOADS } from 'lib/plans/constants';
 

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -11,30 +11,25 @@ import { localize } from 'i18n-calypso';
 import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
 import { PLAN_PREMIUM, FEATURE_VIDEO_UPLOADS, FEATURE_AUDIO_UPLOADS } from 'lib/plans/constants';
 
-export const MediaLibraryUpgradeNudge = ( { translate, filter } ) => {
-	let title = translate( 'Upgrade to a Premium Plan and Enable VideoPress' );
-	let subtitle = translate( `By upgrading to a Premium Plan you'll enable VideoPress support on your site.` );
-	let highlightedFeature = FEATURE_VIDEO_UPLOADS;
-	let benefits = [
-		translate(
-			'Upload videos to your site with an interface designed specifically for WordPress.',
-			{ comment: 'Perk for upgrading to premium plan' }
-		),
-		translate(
-			'Present videos using a lightweight and responsive player that is ad-free and unbranded.',
-			{ comment: 'Perk for upgrading to premium plan' }
-		),
-		translate(
-			'See where your videos have been shared as well as stats for individual and overall video plays.',
-			{ comment: 'Perk for upgrading to premium plan' }
-		)
-	];
+function getTitle( filter, translate ) {
+	if ( filter === 'audio' ) {
+		return translate( 'Upgrade to the Premium Plan and Enable Audio Uploads' );
+	}
 
-	if ( 'audio' === filter ) {
-		title = translate( 'Upgrade to the Premium Plan and Enable Audio Uploads' );
-		subtitle = translate( `By upgrading to the Premium plan you'll enable audio upload support on your site.` );
-		highlightedFeature = FEATURE_AUDIO_UPLOADS;
-		benefits = [
+	return translate( 'Upgrade to a Premium Plan and Enable VideoPress' );
+}
+
+function getSubtitle( filter, translate ) {
+	if ( filter === 'audio' ) {
+		return translate( 'By upgrading to the Premium plan you\'ll enable audio upload support on your site.' );
+	}
+
+	return translate( 'By upgrading to a Premium Plan you\'ll enable VideoPress support on your site.' );
+}
+
+function getBenefits( filter, translate ) {
+	if ( filter === 'audio' ) {
+		return [
 			translate(
 				'Add support for podcasting to your site, including a built-in audio player.',
 				{ comment: 'Perk for upgrading to premium plan' }
@@ -50,19 +45,34 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter } ) => {
 		];
 	}
 
-	return (
-		<div className="media-library__videopress-nudge-container">
-			<UpgradeNudgeExpanded
-				plan={ PLAN_PREMIUM }
-				title={ title }
-				subtitle={ subtitle }
-				highlightedFeature={ highlightedFeature }
-				eventName="calypso_media_uploads_upgrade_nudge_impression"
-				benefits={ benefits }
-			/>
-		</div>
-	);
-};
+	return [
+		translate(
+			'Upload videos to your site with an interface designed specifically for WordPress.',
+			{ comment: 'Perk for upgrading to premium plan' }
+		),
+		translate(
+			'Present videos using a lightweight and responsive player that is ad-free and unbranded.',
+			{ comment: 'Perk for upgrading to premium plan' }
+		),
+		translate(
+			'See where your videos have been shared as well as stats for individual and overall video plays.',
+			{ comment: 'Perk for upgrading to premium plan' }
+		)
+	];
+}
+
+export const MediaLibraryUpgradeNudge = ( { translate, filter } ) => (
+	<div className="media-library__videopress-nudge-container">
+		<UpgradeNudgeExpanded
+			plan={ PLAN_PREMIUM }
+			title={ getTitle( filter, translate ) }
+			subtitle={ getSubtitle( filter, translate ) }
+			highlightedFeature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
+			eventName="calypso_media_uploads_upgrade_nudge_impression"
+			benefits={ getBenefits( filter, translate ) }
+		/>
+	</div>
+);
 
 MediaLibraryUpgradeNudge.propTypes = {
 	translate: PropTypes.func,

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
+import { PLAN_PREMIUM, FEATURE_VIDEO_UPLOADS, FEATURE_AUDIO_UPLOADS } from 'lib/plans/constants';
+
+export const MediaLibraryUpgradeNudge = ( { translate, filter } ) => {
+	let title = translate( 'Upgrade to a Premium Plan and Enable VideoPress' );
+	let subtitle = translate( `By upgrading to a Premium Plan you'll enable VideoPress support on your site.` );
+	let highlightedFeature = FEATURE_VIDEO_UPLOADS;
+	let benefits = [
+		translate(
+			'Upload videos to your site with an interface designed specifically for WordPress.',
+			{ comment: 'Perk for upgrading to premium plan' }
+		),
+		translate(
+			'Present videos using a lightweight and responsive player that is ad-free and unbranded.',
+			{ comment: 'Perk for upgrading to premium plan' }
+		),
+		translate(
+			'See where your videos have been shared as well as stats for individual and overall video plays.',
+			{ comment: 'Perk for upgrading to premium plan' }
+		)
+	];
+
+	if ( 'audio' === filter ) {
+		title = translate( 'Upgrade to the Premium Plan and Enable Audio Uploads' );
+		subtitle = translate( `By upgrading to the Premium plan you'll enable audio upload support on your site.` );
+		highlightedFeature = FEATURE_AUDIO_UPLOADS;
+		benefits = [
+			translate(
+				'Add support for podcasting to your site, including a built-in audio player.',
+				{ comment: 'Perk for upgrading to premium plan' }
+			),
+			translate(
+				'Upload audio files that use any major audio file format.',
+				{ comment: 'Perk for upgrading to premium plan' }
+			),
+			translate(
+				'Get more than four times the storage space for all of your media files.',
+				{ comment: 'Perk for upgrading to premium plan' }
+			)
+		];
+	}
+
+	return (
+		<div className="media-library__videopress-nudge-container">
+			<UpgradeNudgeExpanded
+				plan={ PLAN_PREMIUM }
+				title={ title }
+				subtitle={ subtitle }
+				highlightedFeature={ highlightedFeature }
+				eventName="calypso_media_uploads_upgrade_nudge_impression"
+				benefits={ benefits }
+			/>
+		</div>
+	);
+};
+
+MediaLibraryUpgradeNudge.propTypes = {
+	translate: PropTypes.func,
+	filter: React.PropTypes.string
+};
+
+MediaLibraryUpgradeNudge.defaultProps = {
+	translate: identity,
+	filter: 'video'
+};
+
+export default localize( MediaLibraryUpgradeNudge );

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -201,11 +201,11 @@ module.exports = React.createClass( {
 		var onFetchNextPage;
 
 		if ( this.props.filterRequiresUpgrade ) {
-			if( 'expanded' === abtest( 'expandedNudge' ) ) {
+			if( abtest( 'expandedNudge' ) === 'expanded' ) {
 				return <ListPlanUpgradeNudge filter={ this.props.filter } />;
-			} else {
-				return <ListPlanPromo site={ this.props.site } filter={ this.props.filter } />;
 			}
+
+			return <ListPlanPromo site={ this.props.site } filter={ this.props.filter } />;
 		}
 
 		if ( ! this.props.mediaHasNextPage && this.props.media && 0 === this.props.media.length ) {

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -20,6 +20,9 @@ var MediaActions = require( 'lib/media/actions' ),
 	InfiniteList = require( 'components/infinite-list' ),
 	user = require( 'lib/user' )();
 
+import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
+import { abtest } from 'lib/abtest';
+
 module.exports = React.createClass( {
 	displayName: 'MediaLibraryList',
 
@@ -198,9 +201,11 @@ module.exports = React.createClass( {
 		var onFetchNextPage;
 
 		if ( this.props.filterRequiresUpgrade ) {
-			return (
-				<ListPlanPromo site={ this.props.site } filter={ this.props.filter } />
-			);
+			if( 'expanded' === abtest( 'expandedNudge' ) ) {
+				return <ListPlanUpgradeNudge filter={ this.props.filter } />;
+			} else {
+				return <ListPlanPromo site={ this.props.site } filter={ this.props.filter } />;
+			}
 		}
 
 		if ( ! this.props.mediaHasNextPage && this.props.media && 0 === this.props.media.length ) {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -115,3 +115,27 @@
 .media-library__list-item.is-small .media-library__list-item-file-extension {
 	display: none;
 }
+
+.media-library__videopress-nudge-container {
+	display: block;
+	overflow-y: auto;
+	position: absolute;
+	top: 50px;
+	bottom: 72px;
+	right: 0;
+	left: 0;
+	margin: 0;
+}
+
+.media-library__videopress-nudge-container .upgrade-nudge-expanded {
+	position: absolute;
+	left: 0;
+	right: 0;
+	box-shadow: none;
+	margin: 0;
+
+	@include breakpoint( ">960px") {
+		top: 50%;
+		transform: translateY(-50%);
+	}
+}

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -16,6 +16,7 @@ import Button from 'components/button';
 import SectionHeader from 'components/section-header';
 import ExternalLink from 'components/external-link';
 import GoogleAnalyticsUpgradeNudge from 'blocks/upgrade-nudge-expanded';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { abtest } from 'lib/abtest';
 import { PLAN_BUSINESS, FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
 
@@ -201,28 +202,40 @@ export default React.createClass( {
 
 		debug( 'Google analitics is not enabled. adding nudge ...' );
 
-		return (
-			<GoogleAnalyticsUpgradeNudge
-				plan={ PLAN_BUSINESS }
-				title={ this.translate( 'Upgrade to a Business Plan and Enable Google Analytics' ) }
-				subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable Google Analytics Tracking on your site.' ) }
-				highlightedFeature={ FEATURE_GOOGLE_ANALYTICS }
-				eventName={ "calypso_google_analytics_upgrade_nudge_impression" }
-				benefits={ [
-					this.translate(
-						'Analyze visitor traffic and paint a complete picture of your audience and their needs.'
-					),
-					this.translate(
-						'Track the routes people take to reach you and the devices they use to get there with ' +
-						'reporting tools like Traffic Sources.'
-					),
-					this.translate(
-						'Learn what people are looking for and what they like with In-Page Analytics. ' +
-						'Then tailor your marketing and site content for maximum impact.'
-					)
-				] }
-			/>
-		);
+		if( abtest( 'expandedNudge' ) === 'expanded' ) {
+			return (
+				<GoogleAnalyticsUpgradeNudge
+					plan={ PLAN_BUSINESS }
+					title={ this.translate( 'Upgrade to a Business Plan and Enable Google Analytics' ) }
+					subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable Google Analytics Tracking on your site.' ) }
+					highlightedFeature={ FEATURE_GOOGLE_ANALYTICS }
+					eventName={ "calypso_google_analytics_upgrade_nudge_impression" }
+					benefits={ [
+						this.translate(
+							'Analyze visitor traffic and paint a complete picture of your audience and their needs.'
+						),
+						this.translate(
+							'Track the routes people take to reach you and the devices they use to get there with ' +
+							'reporting tools like Traffic Sources.'
+						),
+						this.translate(
+							'Learn what people are looking for and what they like with In-Page Analytics. ' +
+							'Then tailor your marketing and site content for maximum impact.'
+						)
+					] }
+				/>
+			);
+		} else {
+			return (
+				<UpgradeNudge
+					title={ this.translate( 'Add Google Analytics' ) }
+					message={ this.translate( 'Upgrade to the business plan and include your own analytics tracking ID.' ) }
+					feature="google-analytics"
+					event="google_analytics_settings"
+					icon="stats-alt"
+				/>
+			);	
+		}
 	},
 
 	render() {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -33,6 +33,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import SeoSettingsUpgradeNudge from 'blocks/upgrade-nudge-expanded';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import config from 'config';
 import { getSeoTitleFormatsForSite } from 'state/sites/selectors';
@@ -46,6 +47,7 @@ import { isBusiness, isEnterprise } from 'lib/products-values';
 import {
 	PLAN_BUSINESS, FEATURE_ADVANCED_SEO
 } from 'lib/plans/constants';
+import abtest from 'lib/abtest';
 
 const serviceIds = {
 	google: 'google-site-verification',
@@ -393,7 +395,7 @@ export const SeoForm = React.createClass( {
 					</Notice>
 				}
 
-				{ showUpgradeNudge &&
+				{ showUpgradeNudge && abtest( 'expandedNudge' ) === 'expanded' &&
 					<SeoSettingsUpgradeNudge
 						plan={ PLAN_BUSINESS }
 						upgrade={ upgradeToBusiness }
@@ -406,6 +408,15 @@ export const SeoForm = React.createClass( {
 							this.translate( 'Allow you to control how page titles will appear on Google search results, or when shared on social networks.' ),
 							this.translate( 'Modify front page meta data in order to customize how your site appears to search engines.' )
 						] }
+					/>
+				}
+
+				{ showUpgradeNudge && abtest( 'expandedNudge' ) === 'regular' &&
+					<UpgradeNudge
+						feature={ FEATURE_ADVANCED_SEO }
+						title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
+						message={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
+						event={ "calypso_seo_settings_upgrade_nudge_impression" }
 					/>
 				}
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -47,7 +47,7 @@ import { isBusiness, isEnterprise } from 'lib/products-values';
 import {
 	PLAN_BUSINESS, FEATURE_ADVANCED_SEO
 } from 'lib/plans/constants';
-import abtest from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 
 const serviceIds = {
 	google: 'google-site-verification',


### PR DESCRIPTION
Expands VideoPress nudge in order to make it more informative. 

Closes  #7648 

**Before:**

![videobefore](https://cloud.githubusercontent.com/assets/1182160/18210287/1f06d104-7138-11e6-9716-ab82ecd6c49a.png)

**After:** 

![videoafter](https://cloud.githubusercontent.com/assets/1182160/18210125/5bf715a2-7137-11e6-89e8-9a5ba2e6cfb8.png)

- Added icons for Premium and Personal plan to `UpgradeNudgeExpanded` component.
- Fixed minor issue with plan icon display in `UpgradeNudgeExpanded` component - background `no-repeat` property was not applied properly, and repeated icon was visible in the right part of the circle. 

![iconbug](https://cloud.githubusercontent.com/assets/1182160/18210449/d1a12472-7138-11e6-98f8-ab9f8f14b9bc.png)


Test live: https://calypso.live/?branch=add/expanded-videopress-nudge