### PR TITLE
Plans: Fix alignment of plan features

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -136,7 +136,7 @@ export const plansList = {
 					strong: <strong className="plan-features__targeted-description-heading" />
 				}
 			} ),
-		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getFeatures: () => [ // pay attention to ordering, shared features should align on /plan page
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 			FEATURE_FREE_THEMES,
@@ -167,9 +167,8 @@ export const plansList = {
 					strong: <strong className="plan-features__targeted-description-heading" />
 				}
 			} ),
-		getFeatures: () => compact( [ // pay attention to ordering, it is used on /plan page
+		getFeatures: () => compact( [ // pay attention to ordering, shared features should align on /plan page
 			FEATURE_CUSTOM_DOMAIN,
-			FEATURE_LIVE_COURSES,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 			FEATURE_UNLIMITED_PREMIUM_THEMES,
 			FEATURE_ADVANCED_DESIGN,
@@ -177,6 +176,7 @@ export const plansList = {
 			FEATURE_NO_ADS,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS,
+			FEATURE_LIVE_COURSES,
 			isEnabled( 'manage/advanced-seo' ) && FEATURE_ADVANCED_SEO,
 			FEATURE_GOOGLE_ANALYTICS,
 			FEATURE_NO_BRANDING


### PR DESCRIPTION
I accidentally [added the new live courses offering](https://github.com/Automattic/wp-calypso/pull/7792) higher up in the Business plan feature list not realizing that the /plans page was specifically ordered to compare across plans. I just reordered the list to bump it farther down.

Current production:

![screen shot 2016-09-02 at 12 02 57](https://cloud.githubusercontent.com/assets/7240478/18213395/361d8582-7105-11e6-9521-a56cab4cdfd3.png)

Updated:

![screen shot 2016-09-02 at 12 03 53](https://cloud.githubusercontent.com/assets/7240478/18213418/597da2fa-7105-11e6-826b-7ec859d83e36.png)

cc @rralian thanks for the heads up

Test live: https://calypso.live/?branch=fix/plans-course-feature-alignment