### PR TITLE
Reader: add twemoji parsing to new full post block

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { translate } from 'i18n-calypso';
 import classNames from 'classnames';
-import config from 'config';
+//import config from 'config';
 import twemoji from 'twemoji';
 
 /**
@@ -46,7 +46,7 @@ import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 export class FullPostView extends React.Component {
 	constructor( props ) {
 		super( props );
-		[ 'handleBack', 'handleCommentClick', 'bindComments' ].forEach( fn => {
+		[ 'handleBack', 'handleCommentClick', 'bindComments', 'parseEmoji' ].forEach( fn => {
 			this[ fn ] = this[ fn ].bind( this );
 		} );
 	}
@@ -56,9 +56,12 @@ export class FullPostView extends React.Component {
 		this.parseEmoji();
 	}
 
+	componentDidUpdate() {
+		this.parseEmoji();
+	}
+
 	componentWillUnmount() {
 		KeyboardShortcuts.off( 'close-full-post', this.handleBack );
-		this.parseEmoji();
 	}
 
 	handleBack() {
@@ -86,7 +89,7 @@ export class FullPostView extends React.Component {
 
 	parseEmoji() {
 		twemoji.parse( ReactDom.findDOMNode( this.refs.article ), {
-			base: config( 'twemoji_cdn_url' )
+			//base: config( 'twemoji_cdn_url' )
 		} );
 	}
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -7,6 +7,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { translate } from 'i18n-calypso';
 import classNames from 'classnames';
+import config from 'config';
+import twemoji from 'twemoji';
 
 /**
  * Internal Dependencies
@@ -51,10 +53,12 @@ export class FullPostView extends React.Component {
 
 	componentDidMount() {
 		KeyboardShortcuts.on( 'close-full-post', this.handleBack );
+		this.parseEmoji();
 	}
 
 	componentWillUnmount() {
 		KeyboardShortcuts.off( 'close-full-post', this.handleBack );
+		this.parseEmoji();
 	}
 
 	handleBack() {
@@ -78,6 +82,12 @@ export class FullPostView extends React.Component {
 
 	checkForCommentAnchor() {
 
+	}
+
+	parseEmoji() {
+		twemoji.parse( ReactDom.findDOMNode( this.refs.article ), {
+			base: config( 'twemoji_cdn_url' )
+		} );
 	}
 
 	render() {
@@ -122,7 +132,7 @@ export class FullPostView extends React.Component {
 						}
 
 					</div>
-					<div className="reader-full-post__story">
+					<article className="reader-full-post__story" ref="article">
 						<ReaderFullPostHeader post={ post } />
 						{ post.use_excerpt
 							? <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
@@ -156,7 +166,7 @@ export class FullPostView extends React.Component {
 								onCommentsUpdate={ this.checkForCommentAnchor } />
 						: null
 					}
-					</div>
+					</article>
 				</div>
 			</ReaderMain>
 		);

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { translate } from 'i18n-calypso';
 import classNames from 'classnames';
-//import config from 'config';
+import config from 'config';
 import twemoji from 'twemoji';
 
 /**
@@ -46,7 +46,7 @@ import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 export class FullPostView extends React.Component {
 	constructor( props ) {
 		super( props );
-		[ 'handleBack', 'handleCommentClick', 'bindComments', 'parseEmoji' ].forEach( fn => {
+		[ 'handleBack', 'handleCommentClick', 'bindComments' ].forEach( fn => {
 			this[ fn ] = this[ fn ].bind( this );
 		} );
 	}
@@ -88,8 +88,8 @@ export class FullPostView extends React.Component {
 	}
 
 	parseEmoji() {
-		twemoji.parse( ReactDom.findDOMNode( this.refs.article ), {
-			//base: config( 'twemoji_cdn_url' )
+		twemoji.parse( this.refs.article, {
+			base: config( 'twemoji_cdn_url' )
 		} );
 	}
 

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -4,8 +4,7 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import twemoji from 'twemoji';
-
-const baseCDNUrl = '//s0.wp.com/wp-content/mu-plugins/emoji/twemoji/';
+import config from 'config';
 
 export default React.createClass( {
 	displayName: 'Emojify',
@@ -39,7 +38,7 @@ export default React.createClass( {
 		const { size, className } = this.props;
 
 		twemoji.parse( this.refs.emojified, {
-			base: baseCDNUrl,
+			base: config( 'twemoji_cdn_url' ),
 			size: size,
 			className: className
 		} );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -146,5 +146,6 @@
 	],
 	"project": "wordpress-com",
 	"reader_cold_start_graduation_threshold": 2,
-	"reader_cold_start_graduation_threshold_with_autofollows": 6
+	"reader_cold_start_graduation_threshold_with_autofollows": 6,
+	"twemoji_cdn_url": "//s0.wp.com/wp-content/mu-plugins/emoji/twemoji/"
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -147,5 +147,5 @@
 	"project": "wordpress-com",
 	"reader_cold_start_graduation_threshold": 2,
 	"reader_cold_start_graduation_threshold_with_autofollows": 6,
-	"twemoji_cdn_url": "//s0.wp.com/wp-content/mu-plugins/emoji/twemoji/"
+	"twemoji_cdn_url": "//s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/"
 }

--- a/config/client.json
+++ b/config/client.json
@@ -32,5 +32,6 @@
   "project",
   "reader_cold_start_graduation_threshold",
   "reader_cold_start_graduation_threshold_with_autofollows",
-  "happychat_url"
+  "happychat_url",
+  "twemoji_cdn_url"
 ]


### PR DESCRIPTION
Parse emoji using https://github.com/twitter/twemoji, as we currently do in the full post view.

Marvellous 🐵  test post available for your enjoyment here:

http://calypso.localhost:3000/read/feeds/40474296/posts/1140926311

Test live: https://calypso.live/?branch=add/reader/refreshed-full-post-emoji-parsing