### PR TITLE
State: add allSites prop to QuerySites to prevent accidental all site fetches

### DIFF
--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -32,7 +32,7 @@ class PlanThankYouCard extends Component {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
 			<div className="plan-thank-you-card">
-				{ siteId && <QuerySites siteId={ siteId } /> }
+				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />
 				<div className="plan-thank-you-card__header">
 					<Gridicon className="plan-thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />

--- a/client/blocks/post-item/docs/example.jsx
+++ b/client/blocks/post-item/docs/example.jsx
@@ -20,7 +20,7 @@ function PostItemExample( { primarySiteId, globalId } ) {
 			<h2>
 				<a href="/devdocs/blocks/post-item">Post Item</a>
 			</h2>
-			{ primarySiteId && <QuerySites siteId={ primarySiteId } /> }
+			<QuerySites siteId={ primarySiteId } />
 			{ primarySiteId && (
 				<QueryPosts
 					siteId={ primarySiteId }

--- a/client/components/data/query-sites/README.md
+++ b/client/components/data/query-sites/README.md
@@ -9,7 +9,7 @@ Render the component, optionally passing a site ID. The component does not accep
 
 ```jsx
 function AllSites() {
-	return <QuerySites />;
+	return <QuerySites allSites />;
 }
 
 function SingleSite() {
@@ -26,4 +26,13 @@ function SingleSite() {
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-An optional prop specifying a single site to be requested. If omitted, all sites for the current user will be requested.
+An optional prop specifying a single site to be requested.
+
+### `allSites`
+
+<table>
+	<tr><th>Type</th><td>Boolean</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+An optional prop specifying all sites to be requested. If true, all sites for the current user will be requested.

--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -22,7 +22,7 @@ class QuerySites extends Component {
 	}
 
 	request( props ) {
-		if ( ! props.siteId && ! props.requestingSites ) {
+		if ( props.allSites && ! props.requestingSites ) {
 			props.requestSites();
 		}
 
@@ -37,6 +37,7 @@ class QuerySites extends Component {
 }
 
 QuerySites.propTypes = {
+	allSites: PropTypes.bool,
 	siteId: PropTypes.number,
 	requestingSites: PropTypes.bool,
 	requestingSite: PropTypes.bool,
@@ -45,6 +46,7 @@ QuerySites.propTypes = {
 };
 
 QuerySites.defaultProps = {
+	allSites: false,
 	requestSites: () => {},
 	requestSite: () => {}
 };

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -78,7 +78,7 @@ class CurrentPlan extends Component {
 
 		return (
 			<Main className="current-plan" wideLayout>
-				{ selectedSiteId && <QuerySites siteId={ selectedSiteId } /> }
+				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 
 				<PlansNavigation

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -302,7 +302,7 @@ const JetpackConnectMain = React.createClass( {
 			<MainWrapper>
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
-					<QuerySites />
+					<QuerySites allSites />
 					<ConnectHeader
 						showLogo={ false }
 						headerText={ this.getTexts().headerTitle }


### PR DESCRIPTION
As a follow up to [this discussion]( https://github.com/Automattic/wp-calypso/pull/7195/files/048300535517f640ebc0daaa495df53732da5e83#r73036019 ) This PR updates `<QuerySites />` to add an an allSites parameter. This is quite easy to miss in PRs [like this](https://github.com/Automattic/wp-calypso/pull/7606#discussion_r77381077), since other query components can handle falsey values without side effects.

Usage now looks like:

All Sites:
```javascript
<QuerySites allSites /> 
```
Single Site:
```javascript
//siteId can be falsey now without triggering an allSites request 
<QuerySites siteId={ siteId } /> 
```

## Testing
- No functional changes to Calypso. ~~There should not be any usages of an all sites request yet since site list hasn't been fully ported~~ There's one in jetpack-connect?
- Single site requests load normally.
- Navigate to http://calypso.localhost:3000/plans/my-plan
- Select a site with a paid plan
- Observe that `SITE_RECEIVE` and `SITE_REQUEST_SUCCESS` Redux events fire in the Redux dev tools

cc @mtias @aduth @lamosty @johnHackworth 

Test live: https://calypso.live/?branch=update/query-sites