### PR TITLE
Add Cold Start v3 config key to client.json

### DIFF
--- a/config/client.json
+++ b/config/client.json
@@ -31,5 +31,6 @@
   "sync-handler-defaults",
   "project",
   "reader_cold_start_graduation_threshold",
+  "reader_cold_start_graduation_threshold_with_autofollows",
   "happychat_url"
 ]


### PR DESCRIPTION
Add missing `reader_cold_start_graduation_threshold_with_autofollows` key to client.json.

Test live: https://calypso.live/?branch=add/reader/cold-start-v3-config-key