### PR TITLE
Fix notifications preferences with disabled service workers

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -96,8 +96,6 @@ export function init() {
 		if ( isPushNotificationsDenied() ) {
 			debug( 'Push Notifications have been denied' );
 			dispatch( block() );
-			dispatch( apiReady() );
-			return;
 		}
 
 		dispatch( fetchAndLoadServiceWorker() );

--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -38,7 +38,6 @@ import {
 	getOperaVersion,
 } from './utils';
 import {
-	isServiceWorkerSupported,
 	registerServerWorker,
 } from 'lib/service-worker';
 import {
@@ -134,10 +133,6 @@ export function apiReady() {
 
 export function fetchAndLoadServiceWorker() {
 	return dispatch => {
-		if ( ! isServiceWorkerSupported() ) {
-			debug( 'Service workers are not supported' );
-			return;
-		}
 		debug( 'Registering service worker' );
 
 		registerServerWorker( serviceWorkerOptions )


### PR DESCRIPTION
This PR seeks to fix the notification preferences dialog which turns up under rare and special circumstances: if browser notifications are denied and service workers are not functional in the browser.

The following screenshot was taken on a locally running Calypso instance, where service workers were not working due to the site served via HTTP only (more details below the image):

![screen shot 2016-09-02 at 11 26 08 pm](https://cloud.githubusercontent.com/assets/1017839/18218715/f78d0864-7164-11e6-9a31-2ebca02b848a.png)

Service workers only run over HTTPS, for security reasons. Just because service workers are supported in the browser it does not mean they are functional: if a site is not served via HTTPS, service workers are disabled. 

At the moment, we only check if service workers are supported before checking for the `denied` notification state. We then display the notification settings stating that notifications are blocked, and providing instructions how to enable them while in reality they cannot always be enabled: if service workers are disabled then as soon as we try to enable push notifications, we run into an error.

This PR adds the missing check: proceed to trying to load the service worker, and call `apiReady()`/`apiNotReady()` based on the outcome.

It also remove a redundant check: defensive programming here makes the already convoluted states and state transitions worse, and provides questionable benefit.

-------------

## Testing instructions

#### Test with disabled service workers

- Check out and run this Calypso branch locally
- Make sure service workers are disabled: this is the case in Chrome by default, and in Firefox if the developer tools are not open
- Set notifications to "Blocked by you" (Chrome) or "Block" (Firefox) in your browser
- Visit `http://calypso.localhost:3000/me/notifications`
- Verify that the notification settings are not visible, and you are not asked to allow notifications
- Repeat these steps with "Allow" and "Ask by Default" notification settings as well

#### Test for regressions

Use calypso.live for testing: https://calypso.live/?branch=fix/notifications-preferences-with-disabled-service-workers

It is served via https so service workers are enabled there.

Some scenarios worth testing (feel free to test more!):

- Visit `http://calypso.localhost:3000/me/notifications`, and make sure notifications are disabled
- Set notifications to "Ask by default" in your browser
- Visit `http://calypso.localhost:3000/me/notifications`, and hit Enable
- Verify that you are asked for consent, and after allowing them, notifications are reported enabled. Verify that you receive notifications, and that you can Disable/Enable them

-------------

- Visit `http://calypso.localhost:3000/me/notifications`, and make sure notifications are disabled
- Set notifications to "Ask by default" in your browser
- Visit `http://calypso.localhost:3000/me/notifications`, and hit Enable
- Verify that you are asked for consent, and after blocking them, notifications are reported blocked. Follow the instructions and make sure you can re-enable them

------------

- Make sure you have notifications enabled and you receive them, then log out and back in.
- Verify that the correct (Enabled) state is reported, and you still receive notifications


Test live: https://calypso.live/?branch=fix/notifications-preferences-with-disabled-service-workers