### PR TITLE
Fix React prop warnings for author profile in full post block

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -101,13 +101,15 @@ export class FullPostView extends React.Component {
 				</div>
 				<div className="reader-full-post__content">
 					<div className="reader-full-post__sidebar">
-						<AuthorCompactProfile
+						{ post.author &&
+							<AuthorCompactProfile
 							author={ post.author }
 							siteName={ post.site_name }
 							siteUrl= { post.site_URL }
 							followCount={ site && site.subscribers_count }
-							feedId={ post.feed_ID }
-							siteId={ post.site_ID } />
+							feedId={ +post.feed_ID }
+							siteId={ +post.site_ID } />
+						}
 						{ shouldShowComments( post ) &&
 							<CommentButton key="comment-button"
 								commentCount={ post.discussion.comment_count }


### PR DESCRIPTION
Fixes:
- required object `author` not provided (component is now only rendered if post.author exists)
- coerce feedId and siteId to numbers before passed to component

## To test 

Load the new full post view locally, and ensure there are no prop-related errors in the console.

http://calypso.localhost:3000/read/feeds/8938633/posts/1140954039

Test live: https://calypso.live/?branch=fix/reader/prop-warnings-full-post-block