### PR TITLE
Reader: Add avatar component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -19,6 +19,7 @@
 @import 'blocks/post-item/style';
 @import 'blocks/post-relative-time/style';
 @import 'blocks/post-status/style';
+@import 'blocks/reader-avatar/style';
 @import 'blocks/reader-full-post/style';
 @import 'blocks/reader-related-card/style';
 @import 'blocks/reader-search-card/style';

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -21,11 +21,13 @@ const AuthorCompactProfile = React.createClass( {
 		siteUrl: React.PropTypes.string,
 		followCount: React.PropTypes.number,
 		feedId: React.PropTypes.number,
-		siteId: React.PropTypes.number
+		siteId: React.PropTypes.number,
+		siteIcon: React.PropTypes.string,
+		feedIcon: React.PropTypes.string
 	},
 
 	render() {
-		const { author, siteName, siteUrl, followCount, feedId, siteId } = this.props;
+		const { author, siteIcon, feedIcon, siteName, siteUrl, followCount, feedId, siteId } = this.props;
 
 		if ( ! author ) {
 			return null;
@@ -40,7 +42,7 @@ const AuthorCompactProfile = React.createClass( {
 		return (
 			<div className={ classes }>
 				<a href={ streamUrl }>
-					<ReaderAvatar showGravatar={ true } />
+					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
 				</a>
 				{ ! hasMatchingAuthorAndSiteNames &&
 					<ReaderAuthorLink author={ author } siteUrl={ streamUrl }>{ author.name }</ReaderAuthorLink> }

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Gravatar from 'components/gravatar';
+import ReaderAvatar from 'blocks/reader-avatar';
 import ReaderAuthorLink from 'blocks/reader-author-link';
 import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import ReaderFollowButton from 'reader/follow-button';
@@ -40,7 +40,7 @@ const AuthorCompactProfile = React.createClass( {
 		return (
 			<div className={ classes }>
 				<a href={ streamUrl }>
-					<Gravatar size={ 96 } user={ author } />
+					<ReaderAvatar showGravatar={ true } />
 				</a>
 				{ ! hasMatchingAuthorAndSiteNames &&
 					<ReaderAuthorLink author={ author } siteUrl={ streamUrl }>{ author.name }</ReaderAuthorLink> }

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -1,5 +1,7 @@
 .author-compact-profile {
 	font-size: 14px;
+	display: flex;
+	flex-direction: column;
 
 	.gravatar {
 		display: flex;

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -3,8 +3,7 @@
 	display: flex;
 	flex-direction: column;
 
-	.gravatar {
-		display: flex;
+	.gravatar, .site-icon {
 		margin: auto;
 	}
 

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -2,6 +2,7 @@
 	font-size: 14px;
 	display: flex;
 	flex-direction: column;
+	width: 100%;
 
 	.gravatar, .site-icon {
 		margin: auto;

--- a/client/blocks/reader-avatar/docs/example.jsx
+++ b/client/blocks/reader-avatar/docs/example.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ReaderAvatar from 'blocks/reader-avatar';
+
+export default React.createClass( {
+
+	displayName: 'ReaderAvatar',
+
+	render() {
+		const author = {
+			avatar_URL: 'https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=identicon',
+			name: 'Bob The Tester',
+			URL: 'http://wpcalypso.wordpress.com'
+		};
+
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/blocks/reader-avatar">Reader Avatar</a>
+				</h2>
+				<ReaderAvatar />
+			</div>
+		);
+	}
+} );

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gravatar from 'components/gravatar';
+import SiteIcon from 'components/site-icon';
+import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
+
+const ReaderAvatar = React.createClass( {
+	propTypes: {
+		author: React.PropTypes.object.isRequired
+	},
+
+	render() {
+		const { author } = this.props;
+		const classes = classnames(
+			'reader-avatar',
+			'has-site-and-author-icon',
+			{
+				//'has-site-icon': hasSiteIcon,
+				//'has-gravatar': hasAvatar
+			}
+		);
+
+
+		return (
+			<div className={ classes }>
+				<SiteIcon size={ 96 } />
+				<Gravatar user={ author } />
+			</div>
+		);
+	}
+
+} );
+
+export default localize( ReaderAvatar );

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -13,25 +13,44 @@ import classnames from 'classnames';
 
 const ReaderAvatar = React.createClass( {
 	propTypes: {
-		author: React.PropTypes.object.isRequired
+		author: React.PropTypes.object.isRequired,
+		siteIcon: React.PropTypes.string,
+		feedIcon: React.PropTypes.string
 	},
 
 	render() {
-		const { author } = this.props;
+		const { author, siteIcon, feedIcon } = this.props;
+
+		let fakeSite;
+		if ( siteIcon ) {
+			fakeSite = {
+				icon: {
+					img: siteIcon
+				}
+			};
+		} else if ( feedIcon ) {
+			fakeSite = {
+				icon: {
+					img: feedIcon
+				}
+			};
+		}
+
+		const hasBothIcons = !! ( siteIcon && author.has_avatar );
+
 		const classes = classnames(
 			'reader-avatar',
-			'has-site-and-author-icon',
 			{
-				//'has-site-icon': hasSiteIcon,
-				//'has-gravatar': hasAvatar
+				'has-site-and-author-icon': hasBothIcons,
+				'has-site-icon': !! siteIcon,
+				'has-gravatar': !! author.has_avatar
 			}
 		);
 
-
 		return (
 			<div className={ classes }>
-				<SiteIcon size={ 96 } />
-				<Gravatar user={ author } />
+				{ fakeSite && <SiteIcon size={ 96 } site={ fakeSite } /> }
+				{ author.has_avatar && <Gravatar user={ author } size={ hasBothIcons ? 32 : 96 } /> }
 			</div>
 		);
 	}

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,21 +37,32 @@ const ReaderAvatar = React.createClass( {
 			};
 		}
 
-		const hasBothIcons = !! ( siteIcon && author.has_avatar );
+		const hasSiteIcon = !! siteIcon;
+		let hasAvatar = !! author.has_avatar;
+
+		if ( hasSiteIcon && hasAvatar ) {
+			// do these both reference the same image? disregard querystring params.
+			const [ withoutQuery, ] = siteIcon.split( '?' );
+			if ( startsWith( author.avatar_URL, withoutQuery ) ) {
+				hasAvatar = false;
+			}
+		}
+
+		const hasBothIcons = hasSiteIcon && hasAvatar;
 
 		const classes = classnames(
 			'reader-avatar',
 			{
 				'has-site-and-author-icon': hasBothIcons,
-				'has-site-icon': !! siteIcon,
-				'has-gravatar': !! author.has_avatar
+				'has-site-icon': hasSiteIcon,
+				'has-gravatar': hasAvatar
 			}
 		);
 
 		return (
 			<div className={ classes }>
-				{ fakeSite && <SiteIcon size={ 96 } site={ fakeSite } /> }
-				{ author.has_avatar && <Gravatar user={ author } size={ hasBothIcons ? 32 : 96 } /> }
+				{ hasSiteIcon && <SiteIcon size={ 96 } site={ fakeSite } /> }
+				{ hasAvatar && <Gravatar user={ author } size={ hasBothIcons ? 32 : 96 } /> }
 			</div>
 		);
 	}

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -1,0 +1,29 @@
+.reader-avatar {
+	margin: 0 auto;
+	max-height: 105px;
+}
+
+.reader-avatar {
+
+	&.has-site-and-author-icon {
+
+		.site-icon {
+			height: 96px;
+			width: 96px;
+
+			.gridicon {
+				height: 96px;
+				width: 96px;
+			}
+		}
+	}
+
+	.gravatar {
+		border: 2px solid $white;
+		height: 80px;
+		position: relative;
+			left: 30px;
+			top: -75px;
+		width: 80px;
+	}
+}

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -16,14 +16,14 @@
 				width: 96px;
 			}
 		}
-	}
 
-	.gravatar {
-		border: 2px solid $white;
-		height: 80px;
-		position: relative;
-			left: 30px;
-			top: -75px;
-		width: 80px;
+		.gravatar {
+			border: 2px solid $white;
+			height: 80px;
+			position: relative;
+				left: 30px;
+				top: -75px;
+			width: 80px;
+		}
 	}
 }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -128,7 +128,7 @@ export class FullPostView extends React.Component {
 	}
 
 	render() {
-		const { post, site } = this.props;
+		const { post, site, feed } = this.props;
 		const siteName = siteNameFromSiteAndPost( site, post );
 		const classes = { 'reader-full-post': true };
 		if ( post.site_ID ) {
@@ -150,12 +150,14 @@ export class FullPostView extends React.Component {
 					<div className="reader-full-post__sidebar">
 						{ post.author &&
 							<AuthorCompactProfile
-							author={ post.author }
-							siteName={ post.site_name }
-							siteUrl= { post.site_URL }
-							followCount={ site && site.subscribers_count }
-							feedId={ +post.feed_ID }
-							siteId={ +post.site_ID } />
+								author={ post.author }
+								siteIcon={ get( site, 'icon.img' ) }
+								feedIcon={ get( feed, 'image' ) }
+								siteName={ post.site_name }
+								siteUrl= { post.site_URL }
+								followCount={ site && site.subscribers_count }
+								feedId={ +post.feed_ID }
+								siteId={ +post.site_ID } />
 						}
 						{ shouldShowComments( post ) &&
 							<CommentButton key="comment-button"

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -83,28 +83,63 @@
 		font-size: 15px;
 		line-height: 24px;
 	}
+
+	@include breakpoint( "<660px" ) {
+		margin-top: -35px;
+	}
 }
 
 .reader-full-post .author-compact-profile {
+	display: inline-flex;
+	flex-direction: column;
 	z-index: z-index( '.masterbar', '.reader-profile' );
+
 	@include breakpoint( "<660px" ) {
+		flex-direction: row;
 		margin-top: 20px;
-		.gravatar {
-			display: inline-block;
-			vertical-align: bottom;
-			height: 24px;
-			width: 24px;
-			margin-right: 1em;
+
+		.reader-avatar {
+			flex: 1;
+
+			.site-icon {
+				height: 32px!important;
+				width: 32px!important;
+
+				.gridicon {
+
+					@include breakpoint( "<660px" ) {
+						height: 32px!important;
+						width: 32px!important;
+					}
+				}
+			}
 		}
+
+		.gravatar {
+			height: 24px!important;
+			margin-right: 1em;
+			position: relative;
+				left: 18px;
+				top: -18px;
+			vertical-align: bottom;
+			width: 24px!important;
+		}
+
 		.reader-author-link {
 			font-weight: 700;
 			display: inline;
-			margin: 0;
 		}
+
+		.reader-author-link,
+		.author-compact-profile__site-link {
+			margin: 0 0 0 1em;
+			padding-top: 5px;
+		}
+
 		.author-compact-profile__site-link {
 			display: inline;
-			margin-left: 1em;
 		}
+
 		.author-compact-profile__follow .follow-button {
 			position: fixed;
 			top: 10px;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -97,6 +97,7 @@
 	@include breakpoint( "<660px" ) {
 		flex-direction: row;
 		margin-top: 20px;
+		margin-bottom: 20px;
 
 		.reader-avatar {
 			flex: 1;
@@ -104,12 +105,16 @@
 			.site-icon {
 				height: 32px!important;
 				width: 32px!important;
+				line-height: 32px!important;
+				font-size: 32px!important;
 
 				.gridicon {
 
 					@include breakpoint( "<660px" ) {
 						height: 32px!important;
 						width: 32px!important;
+						line-height: 32px!important;
+						font-size: 32px!important;
 					}
 				}
 			}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -97,10 +97,32 @@
 	@include breakpoint( "<660px" ) {
 		flex-direction: row;
 		margin-top: 20px;
-		margin-bottom: 20px;
 
 		.reader-avatar {
 			flex: 1;
+			margin-bottom: 40px;
+
+			&.has-gravatar {
+
+				.gravatar {
+					height: 32px!important;
+					width: 32px!important;
+				}
+			}
+
+			&.has-site-and-author-icon.has-site-icon.has-gravatar {
+				margin-bottom: 20px;
+
+				.gravatar {
+					height: 24px!important;
+					margin-right: 1em;
+					position: relative;
+						left: 18px;
+						top: -18px;
+					vertical-align: bottom;
+					width: 24px!important;
+				}
+			}
 
 			.site-icon {
 				height: 32px!important;
@@ -120,16 +142,6 @@
 			}
 		}
 
-		.gravatar {
-			height: 24px!important;
-			margin-right: 1em;
-			position: relative;
-				left: 18px;
-				top: -18px;
-			vertical-align: bottom;
-			width: 24px!important;
-		}
-
 		.reader-author-link {
 			font-weight: 700;
 			display: inline;
@@ -137,7 +149,7 @@
 
 		.reader-author-link,
 		.author-compact-profile__site-link {
-			margin: 0 0 0 1em;
+			margin: 0 0 0 10px;
 			padding-top: 5px;
 		}
 
@@ -186,6 +198,7 @@
 
 .reader-full-post__sidebar .comment-button {
 	margin-right: 18px;
+
 	@include breakpoint( "<660px" ) {
 		position: fixed;
 			top: 10px;

--- a/client/blocks/reader-search-card/style.scss
+++ b/client/blocks/reader-search-card/style.scss
@@ -239,6 +239,8 @@
 	.gravatar {
 		vertical-align: text-bottom;
 		margin: 0 4px 0 0;
+		width: 80px;
+		height: 80px;
 	}
 }
 

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -42,6 +42,7 @@ import PlanPrice from 'my-sites/plan-price/docs/example';
 import PlanThankYouCard from 'blocks/plan-thank-you-card/docs/example';
 import DismissibleCard from 'blocks/dismissible-card/docs/example';
 import PostEditButton from 'blocks/post-edit-button/docs/example';
+import ReaderAvatar from 'blocks/reader-avatar/docs/example';
 
 export default React.createClass( {
 
@@ -105,6 +106,7 @@ export default React.createClass( {
 					<PlanPrice />
 					<PlanThankYouCard />
 					<DismissibleCard />
+					<ReaderAvatar />
 				</Collection>
 			</div>
 		);


### PR DESCRIPTION
This PR adds the full-post avatar component.

**Has gravatar, no blavatar:**
![gravblav-grav](https://cloud.githubusercontent.com/assets/4924246/18218983/12eee158-711b-11e6-81aa-248930c1e5e6.jpg)

**Has blavatar, no gravatar:**
![gravblav-blav](https://cloud.githubusercontent.com/assets/4924246/18218989/1c68b5f6-711b-11e6-9065-7d7063462e98.jpg)

**Has both:**
![gravblav-both](https://cloud.githubusercontent.com/assets/4924246/18218994/22495282-711b-11e6-87a1-08c6ec1fe563.jpg)

**Has neither:**
![nogravblav1](https://cloud.githubusercontent.com/assets/4924246/18219000/2d312652-711b-11e6-9a5c-9ef22cbe80a6.jpg)



Test live: https://calypso.live/?branch=add/reader/avatar-component