### PR TITLE
Enable draft-js title format editor in wpcalypso and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -30,6 +30,7 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/advanced-seo/custom-title": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/drafts": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,6 +38,7 @@
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
+		"manage/advanced-seo/custom-title": true,
 		"manage/customize": true,
 		"manage/custom-post-types": true,
 		"manage/drafts": true,


### PR DESCRIPTION
@gwwar I forgot to add this to the previous PR in #7313 

Test live: https://calypso.live/?branch=enable/draft-js-wpcalypso-horizon