### PR TITLE
Plans: business upgrade button primary for premium

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -16,7 +16,7 @@ const PlanFeaturesActions = ( {
 	className,
 	available = true,
 	current = false,
-	popular = false,
+	primaryUpgrade = false,
 	freePlan = false,
 	onUpgradeClick = noop,
 	isPlaceholder = false,
@@ -28,7 +28,7 @@ const PlanFeaturesActions = ( {
 		'plan-features__actions-button',
 		{
 			'is-current': current,
-			'is-primary': popular && ! isPlaceholder
+			'is-primary': primaryUpgrade && ! isPlaceholder
 		},
 		className
 	);
@@ -67,7 +67,7 @@ const PlanFeaturesActions = ( {
 
 PlanFeaturesActions.propTypes = {
 	className: PropTypes.string,
-	popular: PropTypes.bool,
+	primaryUpgrade: PropTypes.bool,
 	current: PropTypes.bool,
 	available: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -31,7 +31,10 @@ import {
 	isMonthly,
 	getPlanFeaturesObject,
 	getPlanClass,
-	getMonthlyPlanByYearly
+	getMonthlyPlanByYearly,
+	plansList,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS
 } from 'lib/plans/constants';
 import { isFreePlan } from 'lib/plans';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -128,7 +131,8 @@ class PlanFeatures extends Component {
 				planName,
 				popular,
 				rawPrice,
-				relatedMonthlyPlan
+				relatedMonthlyPlan,
+				primaryUpgrade
 			} = properties;
 
 			return (
@@ -154,7 +158,7 @@ class PlanFeatures extends Component {
 					<PlanFeaturesActions
 						className={ getPlanClass( planName ) }
 						current={ current }
-						popular={ popular }
+						primaryUpgrade={ primaryUpgrade }
 						available = { available }
 						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
@@ -253,7 +257,7 @@ class PlanFeatures extends Component {
 				current,
 				onUpgradeClick,
 				planName,
-				popular
+				primaryUpgrade
 			} = properties;
 
 			const classes = classNames(
@@ -268,7 +272,7 @@ class PlanFeatures extends Component {
 						className={ getPlanClass( planName ) }
 						current={ current }
 						available = { available }
-						popular={ popular }
+						primaryUpgrade={ primaryUpgrade }
 						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
@@ -398,7 +402,7 @@ class PlanFeatures extends Component {
 				current,
 				onUpgradeClick,
 				planName,
-				popular
+				primaryUpgrade
 			} = properties;
 			const classes = classNames(
 				'plan-features__table-item',
@@ -411,7 +415,7 @@ class PlanFeatures extends Component {
 						className={ getPlanClass( planName ) }
 						current={ current }
 						available = { available }
-						popular={ popular }
+						primaryUpgrade={ primaryUpgrade }
 						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
@@ -463,6 +467,8 @@ export default connect(
 			const showMonthly = ! isMonthly( plan );
 			const available = isInSignup ? true : canUpgradeToPlan( plan );
 			const relatedMonthlyPlan = showMonthly ? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) ) : null;
+			const isCurrentlyPremium = isCurrentSitePlan( state, selectedSiteId, plansList[ PLAN_PREMIUM ].getProductId() );
+			const popular = isPopular( plan ) && ! isPaid;
 
 			if ( placeholder || ! planObject || isLoadingSitePlans ) {
 				isPlaceholder = true;
@@ -491,7 +497,8 @@ export default connect(
 				planConstantObj,
 				planName: plan,
 				planObject: planObject,
-				popular: isPopular( plan ) && ! isPaid,
+				popular: popular,
+				primaryUpgrade: ( isCurrentlyPremium && plan === PLAN_BUSINESS ) || popular,
 				rawPrice: getPlanRawPrice( state, planProductId, ! relatedMonthlyPlan && showMonthly ),
 				relatedMonthlyPlan: relatedMonthlyPlan
 			};

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -15,7 +15,7 @@ import PlanFeaturesHeader from './header';
 import PlanFeaturesItem from './item';
 import Popover from 'components/popover';
 import PlanFeaturesActions from './actions';
-import { isCurrentPlanPaid, isCurrentSitePlan } from 'state/sites/selectors';
+import { isCurrentPlanPaid, isCurrentSitePlan, getSitePlan } from 'state/sites/selectors';
 import { getPlansBySiteId } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
@@ -32,7 +32,7 @@ import {
 	getPlanFeaturesObject,
 	getPlanClass,
 	getMonthlyPlanByYearly,
-	plansList,
+	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS
 } from 'lib/plans/constants';
@@ -467,8 +467,8 @@ export default connect(
 			const showMonthly = ! isMonthly( plan );
 			const available = isInSignup ? true : canUpgradeToPlan( plan );
 			const relatedMonthlyPlan = showMonthly ? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) ) : null;
-			const isCurrentlyPremium = isCurrentSitePlan( state, selectedSiteId, plansList[ PLAN_PREMIUM ].getProductId() );
 			const popular = isPopular( plan ) && ! isPaid;
+			const currentPlan = getSitePlan( state, selectedSiteId ) && getSitePlan( state, selectedSiteId ).product_slug;
 
 			if ( placeholder || ! planObject || isLoadingSitePlans ) {
 				isPlaceholder = true;
@@ -498,7 +498,7 @@ export default connect(
 				planName: plan,
 				planObject: planObject,
 				popular: popular,
-				primaryUpgrade: ( isCurrentlyPremium && plan === PLAN_BUSINESS ) || popular,
+				primaryUpgrade: ( ( currentPlan === PLAN_PERSONAL && plan === PLAN_PREMIUM ) || ( currentPlan === PLAN_PREMIUM && plan === PLAN_BUSINESS ) || popular ),
 				rawPrice: getPlanRawPrice( state, planProductId, ! relatedMonthlyPlan && showMonthly ),
 				relatedMonthlyPlan: relatedMonthlyPlan
 			};

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -498,7 +498,11 @@ export default connect(
 				planName: plan,
 				planObject: planObject,
 				popular: popular,
-				primaryUpgrade: ( ( currentPlan === PLAN_PERSONAL && plan === PLAN_PREMIUM ) || ( currentPlan === PLAN_PREMIUM && plan === PLAN_BUSINESS ) || popular ),
+				primaryUpgrade: (
+					( currentPlan === PLAN_PERSONAL && plan === PLAN_PREMIUM ) ||
+					( currentPlan === PLAN_PREMIUM && plan === PLAN_BUSINESS ) ||
+					popular
+				),
 				rawPrice: getPlanRawPrice( state, planProductId, ! relatedMonthlyPlan && showMonthly ),
 				relatedMonthlyPlan: relatedMonthlyPlan
 			};


### PR DESCRIPTION
Resolves #7825

Introduces business plan "upgrade" button as primary if user already has premium plan

## Free site

<img width="868" alt="zrzut ekranu 2016-09-04 o 22 51 26" src="https://cloud.githubusercontent.com/assets/3775068/18238594/494a2454-72f3-11e6-800e-c7d8e10942be.png">

## Premium site

<img width="866" alt="zrzut ekranu 2016-09-04 o 22 51 44" src="https://cloud.githubusercontent.com/assets/3775068/18238606/609306bc-72f3-11e6-8918-705898e113f0.png">


### Testing

- Go to a free site
- go to /plans/:site
- see that "upgrade" button is primary on premium plan
- switch to premium site
- see that "upgrade" button is prymary for business site

CC @lamosty @apeatling @rralian @gwwar @rickybanister 



Test live: https://calypso.live/?branch=update/primary-plan-button