### PR TITLE
Fix product purchase features custom domain logic

### DIFF
--- a/client/blocks/product-purchase-features/index.jsx
+++ b/client/blocks/product-purchase-features/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 
-export default class PlanPurchaseFeatures extends Component {
+export default class ProductPurchaseFeatures extends Component {
 	render() {
 		return (
 			<div className="product-purchase-features">

--- a/client/blocks/product-purchase-features/product-purchase-features-list/custom-domain.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/custom-domain.jsx
@@ -2,32 +2,19 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import PurchaseDetail from 'components/purchase-detail';
+import CustomDomainPurchaseDetail from 'my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default ( { selectedSite, hasDomainCredit } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
-			<PurchaseDetail
-				icon="globe"
-				title={ translate( 'Get your custom domain' ) }
-				description={
-					translate(
-						"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
-						'A free domain is included with your plan.',
-						{
-							args: { siteDomain: selectedSite.slug },
-							components: { em: <em /> }
-						}
-					)
-				}
-				buttonText={ translate( 'Claim your free domain' ) }
-				href={ '/domains/add/' + selectedSite.slug }
+			<CustomDomainPurchaseDetail
+				selectedSite={ selectedSite }
+				hasDomainCredit={ hasDomainCredit }
 			/>
 		</div>
 	);
-} );
+};

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -23,6 +23,9 @@ import CurrentPlanHeader from './header';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { plansList, PLAN_BUSINESS } from 'lib/plans/constants';
+import QuerySiteDomains from 'components/data/query-site-domains';
+import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
+import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -61,6 +64,31 @@ class CurrentPlan extends Component {
 		};
 	}
 
+	renderDomainWarnings() {
+		const {
+			domains,
+			selectedSite,
+			hasDomainsLoaded
+		} = this.props;
+
+		if ( hasDomainsLoaded ) {
+			return (
+				<DomainWarnings
+					domains={ domains }
+					selectedSite={ selectedSite }
+					ruleWhiteList={ [
+						'newDomainsWithPrimary',
+						'newDomains',
+						'unverifiedDomainsCanManage',
+						'pendingGappsTosAcceptanceDomains',
+						'unverifiedDomainsCannotManage',
+						'wrongNSMappedDomains'
+					] }
+				/>
+			);
+		}
+	}
+
 	render() {
 		const {
 			selectedSite,
@@ -80,12 +108,15 @@ class CurrentPlan extends Component {
 			<Main className="current-plan" wideLayout>
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
+				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
 				<PlansNavigation
 					sitePlans={ sitePlans }
 					path={ context.path }
 					selectedSite={ selectedSite }
 				/>
+
+				{ this.renderDomainWarnings() }
 
 				<ProductPurchaseFeatures>
 					<CurrentPlanHeader
@@ -111,15 +142,18 @@ class CurrentPlan extends Component {
 
 export default connect(
 	( state, ownProps ) => {
-		const selectedSite = getSelectedSite( state );
+		const selectedSite = getSelectedSite( state ),
+			selectedSiteId = getSelectedSiteId( state );
 
 		return {
 			selectedSite,
-			selectedSiteId: getSelectedSiteId( state ),
+			selectedSiteId,
 			sitePlans: getPlansBySite( state, selectedSite ),
 			context: ownProps.context,
 			currentPlan: getCurrentPlan( state, getSelectedSiteId( state ) ),
-			isExpiring: isCurrentPlanExpiring( state, getSelectedSiteId( state ) )
+			isExpiring: isCurrentPlanExpiring( state, getSelectedSiteId( state ) ),
+			domains: getDecoratedSiteDomains( state, selectedSiteId ),
+			hasDomainsLoaded: ! isRequestingSiteDomains( state, selectedSiteId )
 		};
 	}
 )( localize( CurrentPlan ) );


### PR DESCRIPTION
Fixes #7857 and #7177.

## Testing Instructions

To be able to test successfully, we need #7965 to land first. In the meantime, checkout the specific files from that branch into this one or just rebase on top of it.

1. With Personal site which has domain credit, navigate to /plans/my-plan and claim your free domain;
2. After claiming the free domain, navigate back to /plans/my-plan and check whether it shows either that you have a custom domain or doesn't show anything domain related at all.

After a domain is purchased/claimed, we don't immediately know that and therefore, users won't see anything domain related in `/plans/my-plan` for a few minutes after they claim a custom domain. More info/discussion in #7311.

/cc @mtias @meremagee @gwwar 

Test live: https://calypso.live/?branch=fix/product-purchase-features-custom-domain-logic