### PR TITLE
Jetpack Connect Authorization

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -221,7 +221,7 @@ const LoggedInForm = React.createClass( {
 				this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 			}
 		} else if ( siteReceived && ! isActivating ) {
-			this.activateManage();
+			this.activateManageAndRedirect();
 		}
 	},
 
@@ -248,10 +248,15 @@ const LoggedInForm = React.createClass( {
 		);
 	},
 
-	activateManage() {
+	activateManageAndRedirect() {
 		const { queryObject, activateManageSecret } = this.props.jetpackConnectAuthorize;
+		debug( 'Activating Manage module and calculating redirection', queryObject );
 		this.props.activateManage( queryObject.client_id, queryObject.state, activateManageSecret );
-		page.redirect( this.getRedirectionTarget() );
+		if ( 'jpo' === queryObject.from || this.props.isSSO ) {
+			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
+		} else {
+			page.redirect( this.getRedirectionTarget() );
+		}
 	},
 
 	handleSubmit() {
@@ -267,7 +272,7 @@ const LoggedInForm = React.createClass( {
 			return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		}
 		if ( activateManageSecret && ! manageActivated ) {
-			return this.activateManage();
+			return this.activateManageAndRedirect();
 		}
 		if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
 			window.location.href = queryObject.site + authUrl;


### PR DESCRIPTION
This PR solves #7752 by:

- renaming `activateManage` method to `activateManageAndRedirect` for clarification
- redirect to plans page only if we are not in SSO and the request did not originate from JPO

With Jetpack On-boarding ( JPO ), we don't need to prompt folks to select a plan. We can just send them back to wp-admin. As a side-effect, this may also solve an issue where, in certain cases, folks  would see the plans page during SSO.

To test:
- get this branch going locally
- on a disconnected jetpack site using JPO, start the on-boarding wizard
- when you connect, you may need to add `&jetpack_connect_test=calypso&calypso_env=development` to the legacy connection screen
- after connecting in calypso, ensure you are redirected back to wp-admin

Ensure there are no regressions:
- There should be no changes for non-JPO connections.

cc: @johnHackworth @ebinnion 

Test live: https://calypso.live/?branch=fix/7752-jpc-and-jpo