### PR TITLE
Advanced SEO: Update title editor to use new API format

### DIFF
--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -2,7 +2,7 @@
 
 // Maps between different title format formats
 //
-// raw is a string like: '%site_name% | %tagline%'
+// raw is a string like: '%_site_name% | %_tagline%'
 //                        \_________/   \_______/
 //                             |            |
 //                             \------------\- tags
@@ -42,17 +42,17 @@ import {
 export const removeBlanks = values => reject( values, matchesProperty( 'value', '' ) );
 
 // %site_name%, %tagline%, etc…
-const tagPattern = /(%[a-zA-Z_]+%)/;
+const tagPattern = /(%_[a-zA-Z_]+%)/;
 const isTag = s => tagPattern.test( s );
 
 const tagToToken = s =>
 	isTag( s )
-		? { type: camelCase( s.slice( 1, -1 ) ) } // %site_name% -> type: siteName
+		? { type: camelCase( s.slice( 2, -1 ) ) } // %_site_name% -> type: siteName
 		: { type: 'string', value: s };           // arbitrary text passes through
 
 const tokenToTag = n =>
 	'string' !== n.type
-		? `%${ snakeCase( n.type ) }%` // siteName -> %site_name%
+		? `%_${ snakeCase( n.type ) }%` // siteName -> %site_name%
 		: n.value;                     // arbitrary text passes through
 
 export const rawToNative = r => removeBlanks( map( split( r, tagPattern ), tagToToken ) );

--- a/client/components/seo/meta-title-editor/test/index.js
+++ b/client/components/seo/meta-title-editor/test/index.js
@@ -27,7 +27,7 @@ describe( 'SEO', () => {
 						{ type: 'string', value: ' | ' },
 						{ type: 'postTitle' }
 					] )
-				).to.equal( '%site_name% | %post_title%' ) );
+				).to.equal( '%_site_name% | %_post_title%' ) );
 			} );
 
 			describe( '#rawToNative', () => {
@@ -40,7 +40,7 @@ describe( 'SEO', () => {
 				).to.eql( [ { type: 'string', value: 'just a string' } ] ) );
 
 				it( 'should handle placeholders', () => expect(
-					rawToNative( '%site_name% | %post_title%' )
+					rawToNative( '%_site_name% | %_post_title%' )
 				).to.eql( [
 					{ type: 'siteName' },
 					{ type: 'string', value: ' | ' },


### PR DESCRIPTION
Updates api format for title editor to `%_token_name%` format. I also updated the tests.


cc @dmsnell, needs review! Hopefully I haven't missed anything.

Test live: https://calypso.live/?branch=update/advanced-seo-title-api-format