### PR TITLE
Plans: Close targeted descriptions test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,14 +100,6 @@ module.exports = {
 		defaultVariation: 'showPopover',
 		allowExistingUsers: false,
 	},
-	plansWording: {
-		datestamp: '20160817',
-		variations: {
-			originalWording: 50,
-			targetedWording: 50
-		},
-		defaultVariation: 'originalWording'
-	},
 	paidNuxStreamlined: {
 		datestamp: '20160912',
 		variations: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -78,11 +78,7 @@ export const plansList = {
 		getProductId: () => 1,
 		getStoreSlug: () => PLAN_FREE,
 		getPathSlug: () => 'beginner',
-		getDescription: () => i18n.translate(
-			'Get a free blog and be on your way to publishing your first post' +
-			' in less than five minutes.'
-		),
-		getTargetedDescription: () => i18n.translate( 'Get a free website and be on your way to publishing your ' +
+		getDescription: () => i18n.translate( 'Get a free website and be on your way to publishing your ' +
 			'first post in less than five minutes.' ),
 		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
 			FEATURE_WP_SUBDOMAIN,
@@ -100,8 +96,7 @@ export const plansList = {
 		getStoreSlug: () => PLAN_PERSONAL,
 		availableFor: ( plan ) => includes( [ PLAN_FREE ], plan ),
 		getPathSlug: () => 'personal',
-		getDescription: () => i18n.translate( 'Use your own domain and establish your online presence without ads.' ),
-		getTargetedDescription: () => i18n.translate( '{{strong}}Best for Personal Use:{{/strong}} Boost your' +
+		getDescription: () => i18n.translate( '{{strong}}Best for Personal Use:{{/strong}} Boost your' +
 			' website with a custom domain name, and remove all WordPress.com advertising. ' +
 			'Get access to high quality email and live chat support.', {
 				components: {
@@ -126,10 +121,7 @@ export const plansList = {
 		getPathSlug: () => 'premium',
 		getStoreSlug: () => PLAN_PREMIUM,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
-		getDescription: () => i18n.translate( 'Your own domain name, powerful' +
-			' customization options, easy monetization with WordAds, and lots of space for audio and video.'
-		),
-		getTargetedDescription: () => i18n.translate( '{{strong}}Best for Entrepreneurs & Freelancers:{{/strong}}' +
+		getDescription: () => i18n.translate( '{{strong}}Best for Entrepreneurs & Freelancers:{{/strong}}' +
 			' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
 			' and the ability to monetize your site with ads.', {
 				components: {
@@ -156,11 +148,7 @@ export const plansList = {
 		getStoreSlug: () => PLAN_BUSINESS,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ], plan ),
 		getPathSlug: () => 'business',
-		getDescription: () => i18n.translate(
-			'Everything included with Premium, as well as live chat support, live courses, ' +
-			'unlimited access to premium themes, and Google Analytics.'
-		),
-		getTargetedDescription: () => i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
+		getDescription: () => i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
 			' business website with unlimited premium and business theme templates, Google Analytics support, unlimited' +
 			' storage, and the ability to remove WordPress.com branding.', {
 				components: {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -27,12 +27,10 @@ import {
 	plansList,
 	PLAN_FREE,
 	PLAN_JETPACK_FREE, 
-	PLAN_PERSONAL,
-	allWpcomPlans
+	PLAN_PERSONAL
 } from 'lib/plans/constants';
 import { createSitePlanObject } from 'state/sites/plans/assembler';
 import SitesList from 'lib/sites-list';
-import { abtest } from 'lib/abtest';
 
 /**
  * Module vars
@@ -193,9 +191,6 @@ export const isPlanFeaturesEnabled = () => {
 	return isEnabled( 'manage/plan-features' );
 };
 
-export const isPlansWordingEnabled = () => {
-	return abtest( 'plansWording' ) === 'targetedWording';
-};
 
 export function plansLink( url, site, intervalType ) {
 	if ( 'monthly' === intervalType ) {
@@ -217,11 +212,7 @@ export function applyTestFiltersToPlansList( planName ) {
 	// we're leaving the code in place for future tests
 	const removeDisabledFeatures = () => {};
 
-	const updatePlanDescriptions = () => {
-		if ( isPlansWordingEnabled() && includes( allWpcomPlans, planName ) ) {
-			filteredPlanConstantObj.getDescription = plansList[ planName ].getTargetedDescription;
-		}
-	};
+	const updatePlanDescriptions = () => {};
 
 	const updatePlanFeatures = () => {};
 


### PR DESCRIPTION
Resolves #7824 by introducing closing out test introduced in #7091 and opening functionality to all

## Pics!

<img width="867" alt="zrzut ekranu 2016-09-05 o 12 43 44" src="https://cloud.githubusercontent.com/assets/3775068/18256245/76a3271a-7367-11e6-8141-f6e5e5b08b7e.png">

This version was deemed as better

Do not merge until we have time to coordinate with @josemarques 

CC @lamosty @rralian @gwwar 

Test live: https://calypso.live/?branch=update/plans-descriptions-all