### PR TITLE
SEO: Update title format to match new API format

### DIFF
--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -2,10 +2,20 @@
 
 // Maps between different title format formats
 //
-// raw is a string like: '%site_name% | %tagline%'
-//                        \_________/   \_______/
-//                             |            |
-//                             \------------\- tags
+// raw from API is
+// {
+// 	"advanced_seo_title_formats": {
+// 		"pages": [
+// 			{ "type": "token", "value": "page_title" },
+// 			{ "type": "string", "value": " is awesome!" }
+// 		],
+// 		"posts": [
+// 			{ "type": "token", "value": "post_title" },
+// 			{ "type": "string", "value": " | " },
+// 			{ "type": "token", "value": "site_name" }
+// 		],
+// 	}
+// }
 //
 // native is an array of plain-text strings and tokens
 //   [ { type: 'postTitle' }, { type: 'string', value: ' on ' }, { type: 'siteName' } ]
@@ -27,36 +37,65 @@
 import {
 	camelCase,
 	flowRight as compose,
-	join,
+	get,
+	identity,
+	initial,
+	last,
 	map,
 	mapKeys,
 	mapValues,
-	matchesProperty,
 	partialRight,
 	rearg,
-	reject,
+	reduce,
 	snakeCase,
-	split
 } from 'lodash';
 
-export const removeBlanks = values => reject( values, matchesProperty( 'value', '' ) );
+const mergeStringPieces = ( a, b ) => ( {
+	type: 'string',
+	value: a.value + b.value,
+} );
 
-// %site_name%, %tagline%, etc…
-const tagPattern = /(%[a-zA-Z_]+%)/;
-const isTag = s => tagPattern.test( s );
+/**
+ * Converts an individual title format
+ * from the API representation to a
+ * Calypso-native format
+ *
+ * @param {Array} r List of raw format pieces
+ * @returns {Array} List of native format pieces
+ */
+export const rawToNative = compose(
+	partialRight( map, p => Object.assign( {},
+		{ type: 'string' === p.type ? 'string' : camelCase( p.value ) },
+		'string' === p.type && { value: p.value },
+	) ),
+	identity, // @TODO figure out why this breaks without identity here (https://github.com/lodash/lodash/issues/2632)
+);
 
-const tagToToken = s =>
-	isTag( s )
-		? { type: camelCase( s.slice( 1, -1 ) ) } // %site_name% -> type: siteName
-		: { type: 'string', value: s };           // arbitrary text passes through
+/**
+ * Converts an individual title format
+ * from the Calypso-native representation
+ * to a Calypso-native format
+ *
+ * @param {Array} n List of native format pieces
+ * @returns {Array} List of raw format pieces
+ */
+export const nativeToRaw = compose(
+	// combine adjacent strings
+	partialRight( reduce, ( format, piece ) => {
+		const lastPiece = last( format );
 
-const tokenToTag = n =>
-	'string' !== n.type
-		? `%${ snakeCase( n.type ) }%` // siteName -> %site_name%
-		: n.value;                     // arbitrary text passes through
+		if ( lastPiece && 'string' === lastPiece.type && 'string' === piece.type ) {
+			return [ ...initial( format ), mergeStringPieces( lastPiece, piece ) ];
+		}
 
-export const rawToNative = r => removeBlanks( map( split( r, tagPattern ), tagToToken ) );
-export const nativeToRaw = n => join( map( n, tokenToTag ), '' );
+		return [ ...format, piece ];
+	}, [] ),
+	partialRight( map, p => ( {
+		type: p.type === 'string' ? 'string' : 'token',
+		value: get( p, 'value', snakeCase( p.type ) )
+	} ) ),
+	identity, // @TODO figure out why this breaks without identity here (https://github.com/lodash/lodash/issues/2632)
+);
 
 // Not only are the format strings themselves stored differently
 // than on the server, but the API expects a different structure
@@ -66,14 +105,14 @@ export const nativeToRaw = n => join( map( n, tokenToTag ), '' );
 // title format strings.
 //
 //  - Rename keys: `front_page` -> `frontPage`
-//  - Translate formats: `%page_title%` -> [ { type: 'pageTitle' } ]
+//  - Translate formats: see above
 
 export const toApi = compose(
 	partialRight( mapKeys, rearg( snakeCase, 1 ) ), // 1 -> key from ( value, key )
-	partialRight( mapValues, nativeToRaw )          // native objects to raw strings
+	partialRight( mapValues, nativeToRaw ),         // native objects to raw objects
 );
 
 export const fromApi = compose(
 	partialRight( mapKeys, rearg( camelCase, 1 ) ), // 1 -> key from ( value, key )
-	partialRight( mapValues, rawToNative )          // raw strings to native objects
+	partialRight( mapValues, rawToNative ),         // raw objects to native objects
 );

--- a/client/components/seo/meta-title-editor/mappings.js
+++ b/client/components/seo/meta-title-editor/mappings.js
@@ -38,7 +38,6 @@ import {
 	camelCase,
 	flowRight as compose,
 	get,
-	identity,
 	initial,
 	last,
 	map,
@@ -48,6 +47,7 @@ import {
 	rearg,
 	reduce,
 	snakeCase,
+	unary,
 } from 'lodash';
 
 const mergeStringPieces = ( a, b ) => ( {
@@ -63,12 +63,11 @@ const mergeStringPieces = ( a, b ) => ( {
  * @param {Array} r List of raw format pieces
  * @returns {Array} List of native format pieces
  */
-export const rawToNative = compose(
+export const rawToNative = unary(
 	partialRight( map, p => Object.assign( {},
 		{ type: 'string' === p.type ? 'string' : camelCase( p.value ) },
 		'string' === p.type && { value: p.value },
 	) ),
-	identity, // @TODO figure out why this breaks without identity here (https://github.com/lodash/lodash/issues/2632)
 );
 
 /**
@@ -79,7 +78,7 @@ export const rawToNative = compose(
  * @param {Array} n List of native format pieces
  * @returns {Array} List of raw format pieces
  */
-export const nativeToRaw = compose(
+export const nativeToRaw = unary( compose(
 	// combine adjacent strings
 	partialRight( reduce, ( format, piece ) => {
 		const lastPiece = last( format );
@@ -94,8 +93,7 @@ export const nativeToRaw = compose(
 		type: p.type === 'string' ? 'string' : 'token',
 		value: get( p, 'value', snakeCase( p.type ) )
 	} ) ),
-	identity, // @TODO figure out why this breaks without identity here (https://github.com/lodash/lodash/issues/2632)
-);
+) );
 
 // Not only are the format strings themselves stored differently
 // than on the server, but the API expects a different structure

--- a/client/components/seo/meta-title-editor/test/index.js
+++ b/client/components/seo/meta-title-editor/test/index.js
@@ -2,51 +2,119 @@ import { expect } from 'chai';
 
 import {
 	nativeToRaw,
-	rawToNative
+	rawToNative,
+	fromApi,
+	toApi,
 } from '../mappings';
 
 describe( 'SEO', () => {
-	describe( 'Meta', () => {
-		describe( 'Title Format Editor', () => {
-			describe( '#nativeToRaw', () => {
-				it( 'should produce empty strings', () => expect(
-					nativeToRaw( [] )
-				).to.equal( '' ) );
+	describe( 'Title Format Editor', () => {
+		describe( '#nativeToRaw', () => {
+			it( 'should produce empty formats', () => expect(
+				nativeToRaw( [] )
+			).to.eql( [] ) );
 
-				it( 'should produce plain-text strings', () => expect(
-					nativeToRaw( [
-						{ type: 'string', value: 'just' },
-						{ type: 'string', value: ' a ' },
-						{ type: 'string', value: 'string' }
-					] )
-				).to.equal( 'just a string' ) );
+			it( 'should produce plain-text strings', () => expect(
+				nativeToRaw( [
+					{ type: 'string', value: 'just' },
+					{ type: 'string', value: ' a ' },
+					{ type: 'string', value: 'string' },
+				] )
+			).to.eql( [ { type: 'string', value: 'just a string' } ] ) );
 
-				it( 'should produce placeholders', () => expect(
-					nativeToRaw( [
-						{ type: 'siteName' },
-						{ type: 'string', value: ' | ' },
-						{ type: 'postTitle' }
-					] )
-				).to.equal( '%site_name% | %post_title%' ) );
-			} );
-
-			describe( '#rawToNative', () => {
-				it( 'should handle empty strings', () => expect(
-					rawToNative( '' )
-				).to.eql( [] ) );
-
-				it( 'should handle plain strings', () => expect(
-					rawToNative( 'just a string' )
-				).to.eql( [ { type: 'string', value: 'just a string' } ] ) );
-
-				it( 'should handle placeholders', () => expect(
-					rawToNative( '%site_name% | %post_title%' )
-				).to.eql( [
+			it( 'should convert token formats', () => expect(
+				nativeToRaw( [
 					{ type: 'siteName' },
 					{ type: 'string', value: ' | ' },
 					{ type: 'postTitle' }
-				] ) );
-			} );
+				] )
+			).to.eql( [
+				{ type: 'token', value: 'site_name' },
+				{ type: 'string', value: ' | ' },
+				{ type: 'token', value: 'post_title' },
+			] ) );
+		} );
+
+		describe( '#rawToNative', () => {
+			it( 'should handle empty strings', () => expect(
+				rawToNative( [] )
+			).to.eql( [] ) );
+
+			it( 'should handle plain strings', () => expect(
+				rawToNative( [ { type: 'string', value: 'just a string' } ] )
+			).to.eql( [ { type: 'string', value: 'just a string' } ] ) );
+
+			it( 'should convert token formats', () => expect(
+				rawToNative( [
+					{ type: 'token', value: 'site_name' },
+					{ type: 'string', value: ' | ' },
+					{ type: 'token', value: 'post_title' },
+				] )
+			).to.eql( [
+				{ type: 'siteName' },
+				{ type: 'string', value: ' | ' },
+				{ type: 'postTitle' },
+			] ) );
+		} );
+
+		describe( '#fromApi', () => {
+			it( 'should produce empty formats', () => expect(
+				fromApi( {} )
+			).to.eql( {} ) );
+
+			it( 'should remap keys and values', () => expect(
+				fromApi( {
+					front_page: [
+						{ type: 'token', value: 'site_name' },
+						{ type: 'string', value: ' is awesome!' },
+					],
+					posts: [
+						{ type: 'token', value: 'post_title' },
+						{ type: 'string', value: ' | ' },
+						{ type: 'token', value: 'site_name' },
+					],
+				} )
+			).to.eql( {
+				frontPage: [
+					{ type: 'siteName' },
+					{ type: 'string', value: ' is awesome!' },
+				],
+				posts: [
+					{ type: 'postTitle' },
+					{ type: 'string', value: ' | ' },
+					{ type: 'siteName' },
+				],
+			} ) );
+		} );
+
+		describe( '#toApi', () => {
+			it( 'should produce empty formats', () => expect(
+				toApi( {} )
+			).to.eql( {} ) );
+
+			it( 'should remap keys and values', () => expect(
+				toApi( {
+					frontPage: [
+						{ type: 'siteName' },
+						{ type: 'string', value: ' is awesome!' },
+					],
+					posts: [
+						{ type: 'postTitle' },
+						{ type: 'string', value: ' | ' },
+						{ type: 'siteName' },
+					],
+				} )
+			).to.eql( {
+				front_page: [
+					{ type: 'token', value: 'site_name' },
+					{ type: 'string', value: ' is awesome!' },
+				],
+				posts: [
+					{ type: 'token', value: 'post_title' },
+					{ type: 'string', value: ' | ' },
+					{ type: 'token', value: 'site_name' },
+				],
+			} ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
**Needs to coordinate with server API changes in D2523!**

Previously we had build the mapping/normalization between the Calypso
way of storing title mappings with the original version of that used by
the server in the API.

The API format changed and this patch updates Calypso to map to and from
the new formats.

There are no visual changes to this PR.

**Testing**

Navigate to **My Sites** > **Settings** > **SEO** on a site with at least the business plan or higher and try to change around the title formats. After saving and reloading the values should reflect what you updated.

cc: @roundhill @vindl (@gwwar the tests for the mapping have been added here)

Test live: https://calypso.live/settings/seo/?branch=update/title-format-api-mapping