### PR TITLE
Add focus highlight to ThemesSearch

### DIFF
--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -11,6 +11,10 @@ Callback to fire to obtain search results. By default this gets called `onChange
 ### onSearchChange (optional)
 This is only necessary if `delaySearch` is being used to delay a fetch callback, but you want to respond immediately to the updated value (e.g., show that the user is currently searching). Passes in a string matching the value of the field or `false` when the search field is closed.
 
+### onSearchClose (optional)
+Callback to fire when search input is closed. Useful for styling of elements and used
+to detect that the user wants to finish searching without expecting results.
+
 ### analyticsGroup
 We track usage of the search component, so we need to know where search is being used. E.g., "Posts" for the search instance in the Posts page.
 
@@ -49,6 +53,9 @@ Whether to force a specific writing direction for the search field, regardless o
 Currently supports forcing a LTR field in a RTL language, but not the other way around.
 
 Supported values are `'ltr'` and `undefined` (the default, which uses the current global writing direction of the app).
+
+### disableHighlight (optional) ( default false )
+Whether to disable `<Search>` highlight on focus. This is useful for styling in scenarios where `<Search>` focus highlight would break page design.
 
 ## Methods
 

--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -54,9 +54,6 @@ Currently supports forcing a LTR field in a RTL language, but not the other way 
 
 Supported values are `'ltr'` and `undefined` (the default, which uses the current global writing direction of the app).
 
-### disableHighlight (optional) ( default false )
-Whether to disable `<Search>` highlight on focus. This is useful for styling in scenarios where `<Search>` focus highlight would break page design.
-
 ## Methods
 
 ### getCurrentSearchValue()

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -62,6 +62,7 @@ const Search = React.createClass( {
 		dir: PropTypes.oneOf( [ 'ltr', 'rtl' ] ),
 		fitsContainer: PropTypes.bool,
 		maxLength: PropTypes.number,
+		highlightOnFocus: PropTypes.bool,
 		hideClose: PropTypes.bool
 	},
 
@@ -89,6 +90,7 @@ const Search = React.createClass( {
 			isOpen: false,
 			dir: undefined,
 			fitsContainer: false,
+			highlightOnFocus: true,
 			hideClose: false
 		};
 	},
@@ -285,7 +287,7 @@ const Search = React.createClass( {
 			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
-			'has-focus': this.state.hasFocus,
+			'has-focus': this.state.hasFocus && this.props.highlightOnFocus,
 			search: true
 		} );
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -62,7 +62,7 @@ const Search = React.createClass( {
 		dir: PropTypes.oneOf( [ 'ltr', 'rtl' ] ),
 		fitsContainer: PropTypes.bool,
 		maxLength: PropTypes.number,
-		highlightOnFocus: PropTypes.bool,
+		disableHighlight: PropTypes.bool,
 		hideClose: PropTypes.bool
 	},
 
@@ -90,7 +90,7 @@ const Search = React.createClass( {
 			isOpen: false,
 			dir: undefined,
 			fitsContainer: false,
-			highlightOnFocus: true,
+			disableHighlight: false,
 			hideClose: false
 		};
 	},
@@ -287,7 +287,7 @@ const Search = React.createClass( {
 			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
-			'has-focus': this.state.hasFocus && this.props.highlightOnFocus,
+			'has-focus': this.state.hasFocus && ! this.props.disableHighlight,
 			search: true
 		} );
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -62,7 +62,6 @@ const Search = React.createClass( {
 		dir: PropTypes.oneOf( [ 'ltr', 'rtl' ] ),
 		fitsContainer: PropTypes.bool,
 		maxLength: PropTypes.number,
-		disableHighlight: PropTypes.bool,
 		hideClose: PropTypes.bool
 	},
 
@@ -90,7 +89,6 @@ const Search = React.createClass( {
 			isOpen: false,
 			dir: undefined,
 			fitsContainer: false,
-			disableHighlight: false,
 			hideClose: false
 		};
 	},
@@ -287,7 +285,7 @@ const Search = React.createClass( {
 			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
-			'has-focus': this.state.hasFocus && ! this.props.disableHighlight,
+			'has-focus': this.state.hasFocus,
 			search: true
 		} );
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -11,7 +11,7 @@
 	align-items: center;
 	// places search above filters
 	z-index: z-index( 'root', '.search' );
-	transition: box-shadow 0.15s;
+	transition: all 0.15s ease-in-out;
 
 	.search__icon-navigation {
 		flex: 0 0 auto;

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -87,7 +87,6 @@ const ThemesMagicSearchCard = React.createClass( {
 				onSearchClose={ this.onSearchClose }
 				onBlur={ this.onBlur }
 				fitsContainer={ this.state.isMobile && this.state.searchIsOpen }
-				disableHighlight={ true }
 				hideClose={ isMobile() }
 			/>
 		);

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import debounce from 'lodash/debounce';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -61,9 +62,7 @@ const ThemesMagicSearchCard = React.createClass( {
 	},
 
 	onBlur() {
-		if ( this.state.isMobile ) {
-			this.setState( { searchIsOpen: false } );
-		}
+		this.setState( { searchIsOpen: false } );
 	},
 
 	render() {
@@ -88,12 +87,17 @@ const ThemesMagicSearchCard = React.createClass( {
 				onSearchClose={ this.onSearchClose }
 				onBlur={ this.onBlur }
 				fitsContainer={ this.state.isMobile && this.state.searchIsOpen }
+				highlightOnFocus={ false }
 				hideClose={ isMobile() }
 			/>
 		);
 
+		const themesSearchClass = classNames( 'themes-magic-search-card', {
+			'has-highlight': this.state.searchIsOpen
+		} );
+
 		return (
-			<div className="themes-magic-search-card" data-tip-target="themes-search-card">
+			<div className={ themesSearchClass } data-tip-target="themes-search-card">
 				{ searchField }
 				{ isPremiumThemesEnabled && ! isJetpack &&
 					<SegmentedControl

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -87,7 +87,7 @@ const ThemesMagicSearchCard = React.createClass( {
 				onSearchClose={ this.onSearchClose }
 				onBlur={ this.onBlur }
 				fitsContainer={ this.state.isMobile && this.state.searchIsOpen }
-				highlightOnFocus={ false }
+				disableHighlight={ true }
 				hideClose={ isMobile() }
 			/>
 		);

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -3,6 +3,7 @@
 	align-items: center;
 	background: white;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
+	transition: all 0.15s ease-in-out;
 
 	&.has-highlight {
 		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -4,6 +4,10 @@
 	background: white;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
 
+	&.has-highlight {
+		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+	}
+
 	.search {
 		flex: 0 1 auto;
 		margin: 0;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -12,6 +12,9 @@
 	.search {
 		flex: 0 1 auto;
 		margin: 0;
+		&.has-focus {
+			box-shadow: none;
+		}
 	}
 
 	.section-nav {


### PR DESCRIPTION
Previously highlight on search focus was only added around search input:
![highligh-search-only](https://cloud.githubusercontent.com/assets/17271089/18269170/dbdfb746-73db-11e6-90da-4df6bf5ccead.png)
Now whole ThemesSearch is highlighted for improved visuals.
![highligh-full](https://cloud.githubusercontent.com/assets/17271089/18269241/2cb3ccac-73dc-11e6-8771-fa29b1b969bf.png)

The Search component was modified by adding a prop that allows to disable Search only highlight.


Test live: https://calypso.live/design?branch=update/add-highlight-to-themes-search