### PR TITLE
GuidedTours: remove an unused variable

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -12,7 +12,6 @@ import AllTours from 'layout/guided-tours/config';
 import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
-import { getScrollableSidebar } from './positioning';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
 
 class GuidedTours extends Component {

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -157,8 +157,6 @@ function validatePlacement( placement, target ) {
 }
 
 function scrollIntoView( target ) {
-	const targetSlug = target && target.dataset && target.dataset.tipTarget;
-
 	const container = getScrollableSidebar();
 	const { top, bottom } = target.getBoundingClientRect();
 	const clientHeight = viewport.isMobile() ? document.documentElement.clientHeight : container.clientHeight;


### PR DESCRIPTION
This removes unused variables that slipped into `master` and are now causing build failures. 

The PR that got merged in hadn't been rebased for a few weeks, so didn't exhibit any build failures because this rule wasn't set to result in an error yet. 

**Always** rebase before you merge. 😄 

Test live: https://calypso.live/?branch=fix/guided-tours-scroll-resize-positioning-linting-fix