### PR TITLE
Don't autocapitalize username input.

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -170,13 +170,13 @@ var TokenField = React.createClass( {
 		const { autoCapitalize, autoComplete, maxLength, value } = this.props;
 
 		let props = {
+			autoCapitalize,
+			autoComplete,
 			ref: 'input',
 			key: 'input',
 			disabled: this.props.disabled,
 			value: this.state.incompleteTokenValue,
 			onBlur: this._onBlur,
-			autoCapitalize,
-			autoComplete,
 		};
 
 		if ( ! ( maxLength && value.length >= maxLength ) ) {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -167,7 +167,7 @@ var TokenField = React.createClass( {
 	},
 
 	_renderInput: function() {
-		const { autoCapitalize, maxLength, value } = this.props;
+		const { autoCapitalize, autoComplete, maxLength, value } = this.props;
 
 		let props = {
 			ref: 'input',
@@ -176,6 +176,7 @@ var TokenField = React.createClass( {
 			value: this.state.incompleteTokenValue,
 			onBlur: this._onBlur,
 			autoCapitalize,
+			autoComplete,
 		};
 
 		if ( ! ( maxLength && value.length >= maxLength ) ) {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -175,18 +175,11 @@ var TokenField = React.createClass( {
 			disabled: this.props.disabled,
 			value: this.state.incompleteTokenValue,
 			onBlur: this._onBlur,
+			autoCapitalize,
 		};
 
 		if ( ! ( maxLength && value.length >= maxLength ) ) {
-			Object.assign( props, {
-				onChange: this._onInputChange
-			} );
-		}
-
-		if ( autoCapitalize ) {
-			Object.assign( props, {
-				autoCapitalize: autoCapitalize
-			} );
+			props = { ...props, onChange: this._onInputChange };
 		}
 
 		return (

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -167,7 +167,7 @@ var TokenField = React.createClass( {
 	},
 
 	_renderInput: function() {
-		const { maxLength, value } = this.props;
+		const { autoCapitalize, maxLength, value } = this.props;
 
 		let props = {
 			ref: 'input',
@@ -180,6 +180,12 @@ var TokenField = React.createClass( {
 		if ( ! ( maxLength && value.length >= maxLength ) ) {
 			Object.assign( props, {
 				onChange: this._onInputChange
+			} );
+		}
+
+		if ( autoCapitalize ) {
+			Object.assign( props, {
+				autoCapitalize: autoCapitalize
 			} );
 		}
 

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	omit = require( 'lodash/omit' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 var TokenInput = React.createClass( {
@@ -24,14 +25,14 @@ var TokenInput = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	render: function() {
+		const props = omit( this.props, 'onChange' );
+
 		return (
 			<input
 				ref="input"
 				type="text"
-				disabled={ this.props.disabled }
-				value={ this.props.value }
+				{ ...props }
 				size={ this.props.value.length + 1 }
-				onBlur={ this.props.onBlur }
 				onChange={ this._onChange }
 				className="token-field__input"
 			/>

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	omit = require( 'lodash/omit' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 var TokenInput = React.createClass( {
@@ -25,7 +24,7 @@ var TokenInput = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	render: function() {
-		const props = omit( this.props, 'onChange' );
+		const props = { ...this.props, onChange: this._onChange };
 
 		return (
 			<input
@@ -33,7 +32,6 @@ var TokenInput = React.createClass( {
 				type="text"
 				{ ...props }
 				size={ this.props.value.length + 1 }
-				onChange={ this._onChange }
 				className="token-field__input"
 			/>
 		);

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -320,6 +320,7 @@ const InvitePeople = React.createClass( {
 								<TokenField
 									isBorderless
 									tokenizeOnSpace
+									autoCapitalize="none"
 									maxLength={ 10 }
 									value={ this.getTokensWithStatus() }
 									onChange={ this.onTokensChange }

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -321,6 +321,7 @@ const InvitePeople = React.createClass( {
 									isBorderless
 									tokenizeOnSpace
 									autoCapitalize="none"
+									autoComplete="off"
 									maxLength={ 10 }
 									value={ this.getTokensWithStatus() }
 									onChange={ this.onTokensChange }


### PR DESCRIPTION
The `autocapitalize` attribute should help prevent iOS from
automatically capitalizing usernames. See
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-aut
ocapitalize

This only spreads props in `TokenInput` and maintains the whitelist in
`TokenField`. Would love to hear feedback on the approach, anything I
can do better or differently?

/@aduth @gwwar

Fixes #4106.

Test live: https://calypso.live/?branch=fix/uppercase-username