### PR TITLE
Framework: fix indentation errors reported by `mixedindentlint`

### DIFF
--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
- import { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 const CommentCount = ( { count, translate } ) => {
 	let countPhrase;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -122,7 +122,7 @@
 
 	&.is-root {
 		margin-top: 0 !important; // the !important can go when the old reader/comments is retired
- 	}
+	}
 
 	&.is-children {
 		margin-left: -2px;

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -36,8 +36,8 @@
 }
 
 @keyframes progress-bar-animation {
-  0%   { background-position: 100px 0; }
-  100% {  }
+	0%   { background-position: 100px 0; }
+	100% {  }
 }
 
 /* Percentage bar */

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -111,7 +111,7 @@ const ReaderPost = ( site, post ) => {
 			authorIcon={ post.author.avatar_URL }
 		/>
 	);
- };
+};
 
 const GoogleSite = site => (
 	<SearchPreview

--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -26,7 +26,7 @@
 
 		.vertical-menu__items.is-selected {
 			border-left: 0;
-    		border-bottom: 3px solid #0087be;
+			border-bottom: 3px solid #0087be;
 		}
 
 		.vertical-menu__items__social-label {

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -305,8 +305,8 @@
 
 		.reader-post-byline__author .gravatar {
 			height: 16px;
-    		width: 16px;
-    		top: 4px;
+			width: 16px;
+			top: 4px;
 		}
 	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -74,7 +74,7 @@
 }
 
 .site-selector .search {
- 	margin: 8px;
+	margin: 8px;
 	width: auto;
 	height: 33px;
 	border: 1px solid lighten( $gray, 20% );
@@ -91,7 +91,7 @@
 		height: 18px;
 	}
 
- }
+}
 
 // The actual list of sites
 .site-selector__sites {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -159,8 +159,8 @@
 
 .site-settings__footer-credit-explanation {
 	display:flex;
-    flex-direction: row;
-    justify-content: space-between;
+	flex-direction: row;
+	justify-content: space-between;
 }
 
 

--- a/client/my-sites/upgrades/checkout-thank-you/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/style.scss
@@ -222,9 +222,9 @@
 }
 
 .checkout-thank-you__verification-notice {
-  max-width: 500px;
-  text-align: left;
-  margin: 0 auto;
+	max-width: 500px;
+	text-align: left;
+	margin: 0 auto;
 }
 
 .checkout-thank-you__verification-notice-email {

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -1,5 +1,5 @@
 .is-group-reader-refresh .layout__content {
- 	padding-top: 0;
+	padding-top: 0;
 }
 
 .is-group-reader-refresh .reader__content,

--- a/client/reader/daily-post/test/helper.js
+++ b/client/reader/daily-post/test/helper.js
@@ -1,12 +1,11 @@
 /**
  * External Dependencies
  */
- import { assert } from 'chai';
+import { assert } from 'chai';
 
 /**
  * Internal Dependencies
  */
-
 import * as posts from './fixtures';
 import * as helper from '../helper';
 

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
- import React from 'react';
- import classNames from 'classnames';
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
- import { translate } from 'i18n-calypso';
- import FollowButton from 'reader/follow-button';
- import { getLinkProps } from './helper';
- import * as discoverStats from './stats';
+import { translate } from 'i18n-calypso';
+import FollowButton from 'reader/follow-button';
+import { getLinkProps } from './helper';
+import * as discoverStats from './stats';
 
 // var DiscoverSiteAttribution = React.createClass( {
 class DiscoverSiteAttribution extends React.Component {

--- a/client/reader/discover/stats.js
+++ b/client/reader/discover/stats.js
@@ -5,7 +5,7 @@ import {
 	recordAction,
 	recordGaEvent,
 	recordTrack
- } from 'reader/stats';
+} from 'reader/stats';
 
 export function recordAuthorClick( author ) {
 	recordGaEvent( 'Clicked Discover Card Attribution Author' );

--- a/client/reader/post-byline/index.jsx
+++ b/client/reader/post-byline/index.jsx
@@ -16,7 +16,7 @@ import {
 	recordGaEvent,
 	recordTrackForPost,
 	recordPermalinkClick
- } from 'reader/stats';
+} from 'reader/stats';
 
 class PostByline extends React.Component {
 

--- a/client/reader/post-byline/test/index.jsx
+++ b/client/reader/post-byline/test/index.jsx
@@ -10,8 +10,8 @@ import { each, omit } from 'lodash';
 /**
  * Internal dependencies
  */
- import useMockery from 'test/helpers/use-mockery';
- import { post } from './fixtures';
+import useMockery from 'test/helpers/use-mockery';
+import { post } from './fixtures';
 
 describe( 'PostByline', () => {
 	let PostByline;

--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -610,13 +610,13 @@
 
 @keyframes slideIn {
 
-    0% {
-    	opacity: 0%;
-    	transform: translateY( 80px );
-    }
+	0% {
+		opacity: 0%;
+		transform: translateY( 80px );
+	}
 
-    100% {
-    	opacity: 100%;
-    	transform: translateY( -20px );
-    }
+	100% {
+		opacity: 100%;
+		transform: translateY( -20px );
+	}
 }


### PR DESCRIPTION
This fixes all the indentation errors currently reported by `mixedindentlint`, which is run as part of `make lint`. 

At least for me, running `make lint` exits if `mixedindentlint` throws errors, and never gets to `bin/run-lint`. So it would be nice to have `mixedindentlint` error-free. 

Test live: https://calypso.live/?branch=fix/mixedindentlint-indentation-errors