### PR TITLE
State: Use nock test helper consistently

### DIFF
--- a/client/state/domains/suggestions/test/actions.js
+++ b/client/state/domains/suggestions/test/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -17,7 +16,7 @@ import {
 	receiveDomainsSuggestions,
 	requestDomainsSuggestions
 } from '../actions';
-
+import useNock from 'test/helpers/use-nock';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'actions', () => {
@@ -61,7 +60,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestDomainsSuggestions()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/domains/suggestions' )
@@ -73,10 +72,6 @@ describe( 'actions', () => {
 					error: 'authorization_required',
 					message: 'An active access token must be used to access domains suggestions.'
 				} );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch fetch action when thunk triggered', () => {

--- a/client/state/google-apps-users/test/actions.js
+++ b/client/state/google-apps-users/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -17,16 +16,13 @@ import {
 	fetchByDomain,
 	fetchBySiteId
 } from '../actions';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	const spy = sinon.spy();
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	describe( '#fetchByDomain', () => {
@@ -55,7 +51,7 @@ describe( 'actions', () => {
 				}
 			};
 
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( `/rest/v1.1/domains/${noUpgradeDomain}/google-apps` )

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -26,7 +25,7 @@ import {
 	JETPACK_CONNECT_ACTIVATE_MANAGE,
 	JETPACK_CONNECT_ACTIVATE_MANAGE_RECEIVE
 } from 'state/action-types';
-
+import useNock from 'test/helpers/use-nock';
 import useFakeDom from 'test/helpers/use-fake-dom';
 import { useSandbox } from 'test/helpers/use-sinon';
 import path from 'lib/route/path';
@@ -163,7 +162,7 @@ describe( 'actions', () => {
 		const { _wp_nonce, client_id, redirect_uri, scope, secret, state } = queryObject;
 
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/' + client_id + '/jetpack-login' )
@@ -206,10 +205,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch authorize request action when thunk triggered', () => {
@@ -268,7 +263,7 @@ describe( 'actions', () => {
 		} );
 
 		describe( 'failure', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/' + client_id + '/jetpack-login' )
@@ -284,10 +279,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch authorize receive action when request completes', () => {
@@ -338,7 +329,7 @@ describe( 'actions', () => {
 		};
 
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/sso-validate', {
@@ -351,10 +342,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch validate action when thunk triggered', () => {
@@ -382,7 +369,7 @@ describe( 'actions', () => {
 		} );
 
 		describe( 'failure', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/sso-validate', {
@@ -394,10 +381,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch receive action when request completes', () => {
@@ -423,7 +406,7 @@ describe( 'actions', () => {
 		const ssoUrl = 'http://example.wordpress.com';
 
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/sso-authorize', {
@@ -434,10 +417,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch validate action when thunk triggered', () => {
@@ -464,7 +443,7 @@ describe( 'actions', () => {
 		} );
 
 		describe( 'failure', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/sso-authorize', {
@@ -476,10 +455,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch receive action when request completes', () => {
@@ -505,7 +480,7 @@ describe( 'actions', () => {
 		const secret = 'abcdefgh12345678';
 
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/activate-manage', {
@@ -517,10 +492,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch activate manage action when thunk triggered', () => {
@@ -549,7 +520,7 @@ describe( 'actions', () => {
 		} );
 
 		describe( 'failure', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/activate-manage', {
@@ -562,10 +533,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch receive action when request completes', () => {

--- a/client/state/jetpack-sync/test/actions.js
+++ b/client/state/jetpack-sync/test/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -15,6 +14,7 @@ import {
 	JETPACK_SYNC_STATUS_SUCCESS,
 	JETPACK_SYNC_STATUS_ERROR,
 } from 'state/action-types';
+import useNock from 'test/helpers/use-nock';
 
 import { useSandbox } from 'test/helpers/use-sinon';
 
@@ -63,15 +63,11 @@ describe( 'actions', () => {
 		const reply = Object.assign( {}, data );
 
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.get( '/rest/v1.1/sites/' + siteId + '/sync/status' )
 					.reply( 200, reply );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch request action when thunk triggered', () => {
@@ -98,7 +94,7 @@ describe( 'actions', () => {
 		} );
 
 		describe( 'failure', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.get( '/rest/v1.1/sites/' + siteId + '/sync/status' )
@@ -108,10 +104,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch receive action when request completes', () => {
@@ -140,15 +132,11 @@ describe( 'actions', () => {
 		const reply = Object.assign( {}, data );
 
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/sites/' + siteId + '/sync' )
 					.reply( 200, reply );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch request action when thunk triggered', () => {
@@ -175,7 +163,7 @@ describe( 'actions', () => {
 		} );
 
 		describe( 'failure', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/sites/' + siteId + '/sync' )
@@ -185,10 +173,6 @@ describe( 'actions', () => {
 					}, {
 						'Content-Type': 'application/json'
 					} );
-			} );
-
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch receive action when request completes', () => {

--- a/client/state/page-templates/test/actions.js
+++ b/client/state/page-templates/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import { match } from 'sinon';
 import { expect } from 'chai';
 
@@ -19,14 +18,11 @@ import {
 	receivePageTemplates,
 	requestPageTemplates
 } from '../actions';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	let spy;
 	useSandbox( ( sandbox ) => spy = sandbox.spy() );
-
-	after( () => {
-		nock.cleanAll();
-	} );
 
 	describe( 'receivePageTemplates()', () => {
 		it( 'should return an action object', () => {
@@ -45,7 +41,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'requestPageTemplates()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/sites/2916284/page-templates' )

--- a/client/state/plans/test/actions.js
+++ b/client/state/plans/test/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -14,7 +13,7 @@ import {
 	plansRequestFailureAction,
 	requestPlans
 } from '../actions';
-
+import useNock from 'test/helpers/use-nock';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 /**
@@ -61,15 +60,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestPlans() - success', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.4/plans' )
 				.reply( 200, wpcomResponse );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch REQUEST action when thunk triggered', () => {

--- a/client/state/post-types/taxonomies/test/actions.js
+++ b/client/state/post-types/taxonomies/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -18,16 +17,13 @@ import {
 	receivePostTypeTaxonomies,
 	requestPostTypeTaxonomies
 } from '../actions';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	const spy = sinon.spy();
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	describe( '#receivePostTypeTaxonomies()', () => {
@@ -46,7 +42,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestPostTypeTaxonomies()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/sites/2916284/post-types/post/taxonomies' )

--- a/client/state/post-types/test/actions.js
+++ b/client/state/post-types/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -18,16 +17,13 @@ import {
 	receivePostTypes,
 	requestPostTypes
 } from '../actions';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	const spy = sinon.spy();
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	describe( '#receivePostTypes()', () => {
@@ -45,7 +41,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestPostTypes()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/sites/2916284/post-types' )

--- a/client/state/posts/counts/test/actions.js
+++ b/client/state/posts/counts/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -18,16 +17,13 @@ import {
 	receivePostCounts,
 	requestPostCounts
 } from '../actions';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	const spy = sinon.spy();
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	describe( '#receivePostCounts()', () => {
@@ -48,7 +44,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestPostCounts()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/wpcom/v2/sites/2916284/post-counts/post' )

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -43,16 +42,13 @@ import {
 	restorePost,
 	addTermForPost
 } from '../actions';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	const spy = sinon.spy();
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	describe( '#receivePost()', () => {
@@ -80,7 +76,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestSitePosts()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/sites/2916284/posts' )
@@ -168,7 +164,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestPosts()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/me/posts' )
@@ -195,7 +191,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestSitePost()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/sites/2916284/posts/413' )
@@ -291,7 +287,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'savePost()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.2/sites/2916284/posts/new', {
@@ -443,7 +439,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'deletePost()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/sites/2916284/posts/13640/delete' )
@@ -491,7 +487,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'restorePost()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/sites/2916284/posts/13640/restore' )
@@ -548,7 +544,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'addTermForPost()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/sites/2916284/taxonomies/jetpack-portfolio/terms/new' )

--- a/client/state/preferences/test/actions.js
+++ b/client/state/preferences/test/actions.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import sinon from 'sinon';
-import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -21,6 +20,7 @@ import {
 import { useSandbox } from 'test/helpers/use-sinon';
 import { DEFAULT_PREFERENCES, USER_SETTING_KEY } from '../constants';
 import { receivePreferences, fetchPreferences, savePreference, setPreference } from '../actions';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	let sandbox, spy;
@@ -47,15 +47,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'fetchPreferences()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/me/settings' )
 				.reply( 200, responseShape );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch fetch action when thunk triggered', () => {
@@ -76,15 +72,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'fetchPreferences()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/me/settings' )
 				.reply( 404 );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch fail action when request fails', () => {
@@ -107,7 +99,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'savePreference()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/me/settings/', {
@@ -124,10 +116,6 @@ describe( 'actions', () => {
 					error: 'authorization_required',
 					message: 'An active access token must be used to query information about the current user.'
 				} );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch PREFERENCES_SET action when thunk triggered', () => {

--- a/client/state/products-list/test/actions.js
+++ b/client/state/products-list/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -17,16 +16,13 @@ import {
 	receiveProductsList,
 	requestProductsList,
 } from '../actions';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	const spy = sinon.spy();
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	const guided_transfer = {
@@ -52,7 +48,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestProductsList()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.1/products' )
 				.twice().reply( 200, { guided_transfer } )

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -1,6 +1,5 @@
 // External dependencies
 import { expect } from 'chai';
-import { nock, useNock } from 'test/helpers/use-nock';
 import sinon from 'sinon';
 
 // Internal dependencies
@@ -15,14 +14,13 @@ import {
 	PURCHASE_REMOVE_COMPLETED,
 } from 'state/action-types';
 import useMockery from 'test/helpers/use-mockery';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	const purchases = [ { ID: 1 } ],
 		userId = 1337,
 		siteId = 1234,
 		purchaseId = 31337;
-
-	useNock();
 
 	let cancelPrivateRegistration,
 		clearPurchases,
@@ -58,7 +56,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#cancelPrivateRegistration', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( `/rest/v1.1/upgrades/${ purchaseId }/cancel-privacy-protection` )
 				.reply( 200, { upgrade: purchases[ 0 ] } );
@@ -82,7 +80,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#fetchSitePurchases', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( `/rest/v1.1/sites/${ siteId }/purchases` )
 				.reply( 200, purchases );
@@ -107,7 +105,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#fetchUserPurchases', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.1/me/purchases' )
 				.reply( 200, purchases );
@@ -133,7 +131,7 @@ describe( 'actions', () => {
 	describe( '#removePurchase', () => {
 		const response = { purchases };
 
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( `/rest/v1.1/me/purchases/${ purchaseId }/delete` )
 				.reply( 200, response );

--- a/client/state/push-notifications/test/actions.js
+++ b/client/state/push-notifications/test/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -17,7 +16,7 @@ import {
 	receiveUnregisterDevice,
 	sendSubscriptionToWPCOM,
 } from '../actions';
-
+import useNock from 'test/helpers/use-nock';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 const API_DOMAIN = 'https://public-api.wordpress.com:443';
@@ -32,10 +31,6 @@ describe( 'actions', () => {
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	describe( 'receiveUnregisterDevice()', () => {
@@ -71,14 +66,11 @@ describe( 'actions', () => {
 		const getState = () => ( { pushNotifications: { settings: {}, system: {} } } );
 
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( API_DOMAIN )
 					.persist()
 					.post( `/rest/v1.1/devices/new` )
 					.reply( 200, { ID: 123, settings: {} } );
-			} );
-			after( () => {
-				nock.cleanAll();
 			} );
 
 			it( 'should dispatch receive action when request completes', () => {

--- a/client/state/reader/feeds/test/actions.js
+++ b/client/state/reader/feeds/test/actions.js
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import { useNock } from 'test/helpers/use-nock';
 import sinon from 'sinon';
 import { assert, expect } from 'chai';
-
 
 /**
  * Internal deps
@@ -15,6 +13,7 @@ import {
 	READER_FEED_REQUEST_SUCCESS,
 	READER_FEED_REQUEST_FAILURE
 } from 'state/action-types';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	describe( 'a valid fetch', () => {

--- a/client/state/reader/lists/test/actions.js
+++ b/client/state/reader/lists/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { nock, useNock } from 'test/helpers/use-nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -19,7 +18,7 @@ import {
 	READER_LIST_UPDATE_TITLE,
 	READER_LIST_UPDATE_DESCRIPTION
 } from 'state/action-types';
-
+import useNock from 'test/helpers/use-nock';
 import {
 	receiveLists,
 	requestList,
@@ -33,8 +32,6 @@ import {
 } from '../actions';
 
 describe( 'actions', () => {
-	useNock();
-
 	const spy = sinon.spy();
 
 	beforeEach( () => {
@@ -54,7 +51,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestList()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.2/read/lists/listowner/listslug' )
 				.reply( 200, {
@@ -75,7 +72,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestSubscribedLists()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.2/read/lists' )
@@ -110,7 +107,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#followList()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.2/read/lists/restapitests/testlist/follow' )
 				.reply( 200, {
@@ -130,7 +127,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#unfollowList()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.2/read/lists/restapitests/testlist/unfollow' )
 				.reply( 200, {
@@ -150,7 +147,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#updateListDetails()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.2/read/lists/restapitests/testlist/update' )
 				.reply( 200, {

--- a/client/state/reader/related-posts/test/actions.js
+++ b/client/state/reader/related-posts/test/actions.js
@@ -2,14 +2,13 @@
  * External Dependencies
  */
 import { expect } from 'chai';
-import useNock from 'test/helpers/use-nock';
-import useMockery from 'test/helpers/use-mockery';
 import sinon from 'sinon';
 
 /**
  * Internal Dependencies
  */
-
+import useNock from 'test/helpers/use-nock';
+import useMockery from 'test/helpers/use-mockery';
 import {
 	READER_RELATED_POSTS_REQUEST,
 	READER_RELATED_POSTS_REQUEST_SUCCESS,

--- a/client/state/reader/sites/test/actions.js
+++ b/client/state/reader/sites/test/actions.js
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import { useNock } from 'test/helpers/use-nock';
 import sinon from 'sinon';
 import { assert, expect } from 'chai';
-
 
 /**
  * Internal deps
@@ -15,6 +13,7 @@ import {
 	READER_SITE_REQUEST_SUCCESS,
 	READER_SITE_REQUEST_FAILURE
 } from 'state/action-types';
+import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
 	describe( 'a valid fetch', () => {

--- a/client/state/reader/start/test/actions.js
+++ b/client/state/reader/start/test/actions.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-import { useNock } from 'test/helpers/use-nock';
-import useMockery from 'test/helpers/use-mockery';
 import sinon from 'sinon';
 import { assert, expect } from 'chai';
 import deepFreeze from 'deep-freeze';
@@ -10,6 +8,8 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
+import useMockery from 'test/helpers/use-mockery';
 import {
 	READER_START_RECOMMENDATIONS_RECEIVE,
 	READER_START_RECOMMENDATIONS_REQUEST,

--- a/client/state/sharing/publicize/test/actions.js
+++ b/client/state/sharing/publicize/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -18,11 +17,12 @@ import {
 	receiveConnections,
 	failConnectionsRequest
 } from '../actions';
+import useNock from 'test/helpers/use-nock';
 
 describe( '#fetchConnections()', () => {
 	const spy = sinon.spy();
 
-	before( () => {
+	useNock( ( nock ) => {
 		nock( 'https://public-api.wordpress.com:443' )
 			.persist()
 			.get( '/rest/v1.1/sites/2916284/publicize-connections' )
@@ -40,10 +40,6 @@ describe( '#fetchConnections()', () => {
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	it( 'should dispatch fetch action when thunk triggered', () => {

--- a/client/state/site-settings/exporter/test/actions.js
+++ b/client/state/site-settings/exporter/test/actions.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
 import {
 	EXPORT_ADVANCED_SETTINGS_FETCH,
 	EXPORT_ADVANCED_SETTINGS_FETCH_FAIL,
@@ -56,7 +56,7 @@ describe( 'actions', () => {
 		} }
 	} );
 
-	before( () => {
+	useNock( ( nock ) => {
 		nock( 'https://public-api.wordpress.com:443' )
 			.persist()
 			.get( '/rest/v1.1/sites/100658273/exports/settings' )
@@ -77,10 +77,6 @@ describe( 'actions', () => {
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	describe( '#advancedSettingsFetch()', () => {

--- a/client/state/sites/domains/test/actions.js
+++ b/client/state/sites/domains/test/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -14,7 +13,7 @@ import {
 	domainsRequestFailureAction,
 	fetchSiteDomains
 } from '../actions';
-
+import useNock from 'test/helpers/use-nock';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 /**
@@ -63,15 +62,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#fetchSiteDomains() - success', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( `/rest/v1.1/sites/${ siteId }/domains` )
 				.reply( 200, wpcomResponse );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch REQUEST action when thunk triggered', () => {
@@ -91,15 +86,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#fetchSiteDomains() - failure', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( `/rest/v1.1/sites/${ siteId }/domains` )
 				.reply( 403, wpcomErrorResponse );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch REQUEST_FAILURE action when request failed', () => {

--- a/client/state/sites/guided-transfer/test/actions.js
+++ b/client/state/sites/guided-transfer/test/actions.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
 import {
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE,
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE_FAILURE,
@@ -28,10 +28,6 @@ describe( 'actions', () => {
 
 	beforeEach( () => {
 		spy.reset();
-	} );
-
-	after( () => {
-		nock.cleanAll();
 	} );
 
 	const sampleSiteId = 100658273;
@@ -63,8 +59,9 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestGuidedTransferStatus()', () => {
-		beforeEach( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
 				.get( `/wpcom/v2/sites/${ sampleSiteId }/transfer` )
 				.reply( 200, sampleStatus )
 				.get( `/wpcom/v2/sites/${ sampleSiteIdFail }/transfer` )
@@ -114,8 +111,9 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#saveHostDetails()', () => {
-		beforeEach( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
 				.post( `/wpcom/v2/sites/${ sampleSiteId }/transfer` )
 				.reply( 200, sampleStatus )
 				.post( `/wpcom/v2/sites/${ sampleSiteIdSave }/transfer` )

--- a/client/state/sites/media-storage/test/actions.js
+++ b/client/state/sites/media-storage/test/actions.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
 import {
 	SITE_MEDIA_STORAGE_RECEIVE,
 	SITE_MEDIA_STORAGE_REQUEST,
@@ -45,7 +45,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#receiveMediaStorage()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/sites/2916284/media-storage' )
@@ -58,10 +58,6 @@ describe( 'actions', () => {
 					error: 'authorization_required',
 					message: 'An active access token must be used to access media-storage.'
 				} );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch fetch action when thunk triggered', () => {

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -3,11 +3,11 @@
  */
 import { match } from 'sinon';
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
 import {
 	SITE_RECEIVE,
 	SITE_REQUEST,
@@ -61,7 +61,7 @@ describe( 'actions', () => {
 	} );
 	describe( '#requestSites()', () => {
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.get( '/rest/v1.1/me/sites?site_visibility=all' )
@@ -72,9 +72,7 @@ describe( 'actions', () => {
 						]
 					} );
 			} );
-			after( () => {
-				nock.cleanAll();
-			} );
+
 			it( 'should dispatch request action when thunk triggered', () => {
 				requestSites()( spy );
 				expect( spy ).to.have.been.calledWith( {
@@ -101,7 +99,7 @@ describe( 'actions', () => {
 			} );
 		} );
 		describe( 'failure', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.get( '/rest/v1.1/me/sites?site_visibility=all' )
@@ -110,9 +108,7 @@ describe( 'actions', () => {
 						message: 'An active access token must be used to access sites.'
 					} );
 			} );
-			after( () => {
-				nock.cleanAll();
-			} );
+
 			it( 'should dispatch fail action when request fails', () => {
 				return requestSites()( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
@@ -125,7 +121,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'requestSite()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/sites/2916284' )

--- a/client/state/sites/vouchers/test/actions.js
+++ b/client/state/sites/vouchers/test/actions.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
- * Action types
+ * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
 import {
 	SITE_VOUCHERS_ASSIGN_RECEIVE,
 	SITE_VOUCHERS_ASSIGN_REQUEST,
@@ -17,10 +17,6 @@ import {
 	SITE_VOUCHERS_REQUEST_SUCCESS,
 	SITE_VOUCHERS_REQUEST_FAILURE
 } from 'state/action-types';
-
-/**
- * Actions
- */
 import {
 	vouchersAssignReceiveAction,
 	vouchersAssignRequestAction,
@@ -33,12 +29,7 @@ import {
 	assignSiteVoucher,
 	requestSiteVouchers
 } from '../actions';
-
 import { useSandbox } from 'test/helpers/use-sinon';
-
-/**
- * Fixture data
- */
 import {
 	SITE_ID_0 as siteId,
 	REST_API_RESPONSE as wpcomResponse,
@@ -134,15 +125,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestSiteVouchers() - success', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( `/wpcom/v2/sites/${ siteId }/vouchers` )
 				.reply( 200, wpcomResponse );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch REQUEST action when thunk triggered', () => {
@@ -162,15 +149,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#assignSiteVoucher() - success', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( `/wpcom/v2/sites/${ siteId }/vouchers/${ oneOfOurServiceTypes }/assign` )
 				.reply( 200, wpcomAssignResponse );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch REQUEST action when thunk triggered', () => {
@@ -190,15 +173,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestSiteVouchers() - failure', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( `/wpcom/v2/sites/${ siteId }/vouchers` )
 				.reply( 403, wpcomErrorResponse );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch REQUEST_FAILURE action when request failed', () => {
@@ -216,15 +195,11 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#assignSiteVoucher() - failure', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( `/wpcom/v2/sites/${ siteId }/vouchers/${ oneOfOurServiceTypes }/assign` )
 				.reply( 403, wpcomErrorResponse );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch assign_FAILURE action when assign failed', () => {

--- a/client/state/stats/lists/test/actions.js
+++ b/client/state/stats/lists/test/actions.js
@@ -3,11 +3,11 @@
  */
 import sinon from 'sinon';
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
 import {
 	SITE_STATS_RECEIVE,
 	SITE_STATS_REQUEST,
@@ -38,10 +38,6 @@ describe( 'actions', () => {
 		spy.reset();
 	} );
 
-	after( () => {
-		nock.cleanAll();
-	} );
-
 	describe( 'receiveSiteStats()', () => {
 		it( 'should return an action object', () => {
 			const action = receiveSiteStats(
@@ -62,7 +58,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'requestSiteStats()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( `/rest/v1.1/sites/${ SITE_ID }/stats/streak?startDate=2015-06-01&endDate=2016-06-01` )

--- a/client/state/stats/posts/test/actions.js
+++ b/client/state/stats/posts/test/actions.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import nock from 'nock';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
 import {
 	POST_STATS_RECEIVE,
 	POST_STATS_REQUEST,
@@ -26,10 +26,6 @@ describe( 'actions', () => {
 		spy.reset();
 	} );
 
-	after( () => {
-		nock.cleanAll();
-	} );
-
 	describe( '#receivePostStat()', () => {
 		it( 'should return an action object', () => {
 			const action = receivePostStat( 'views', 2916284, 2454, 2 );
@@ -45,7 +41,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestPostStat()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/sites/2916284/stats/post/2454?fields=views' )

--- a/client/state/stored-cards/test/actions.js
+++ b/client/state/stored-cards/test/actions.js
@@ -1,9 +1,13 @@
-// External dependencies
+/**
+ * External dependencies
+ */
 import { expect } from 'chai';
-import { nock, useNock } from 'test/helpers/use-nock';
 import sinon from 'sinon';
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
+import useNock from 'test/helpers/use-nock';
 import {
 	addStoredCard,
 	deleteStoredCard,
@@ -22,8 +26,6 @@ import { useSandbox } from 'test/helpers/use-sinon';
 import wp from 'lib/wp';
 
 describe( 'actions', () => {
-	useNock();
-
 	const spy = sinon.spy();
 
 	beforeEach( () => {
@@ -67,7 +69,7 @@ describe( 'actions', () => {
 		];
 
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.get( '/rest/v1.1/me/stored-cards' )
 					.reply( 200, cards );
@@ -90,7 +92,7 @@ describe( 'actions', () => {
 		} );
 
 		describe( 'fail', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.get( '/rest/v1.1/me/stored-cards' )
 					.reply( 403, error );
@@ -119,7 +121,7 @@ describe( 'actions', () => {
 		};
 
 		describe( 'success', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.post( `/rest/v1.1/me/stored-cards/${ card.stored_details_id }/delete` )
 					.reply( 200, { success: true } );
@@ -142,7 +144,7 @@ describe( 'actions', () => {
 		} );
 
 		describe( 'fail', () => {
-			before( () => {
+			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.post( `/rest/v1.1/me/stored-cards/${ card.stored_details_id }/delete` )
 					.reply( 403, error );

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -3,11 +3,11 @@
  */
 import sinon from 'sinon';
 import { expect } from 'chai';
-import nock from 'nock';
 
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
 import {
 	TERM_REMOVE,
 	TERMS_RECEIVE,
@@ -40,12 +40,8 @@ describe( 'actions', () => {
 		spy.reset();
 	} );
 
-	after( () => {
-		nock.cleanAll();
-	} );
-
 	describe( 'addTerm()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( `/rest/v1.1/sites/${ siteId }/taxonomies/${ taxonomyName }/terms/new` )
@@ -176,7 +172,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestSiteTerms()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( `/rest/v1.1/sites/${ siteId }/taxonomies/${ taxonomyName }/terms` )

--- a/client/state/wordads/approve/test/actions.js
+++ b/client/state/wordads/approve/test/actions.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import nock from 'nock';
 import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
 import {
 	WORDADS_SITE_APPROVE_REQUEST,
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
@@ -56,7 +56,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestWordAdsApproval()', () => {
-		before( () => {
+		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/sites/2916284/wordads/approve' )
@@ -68,10 +68,6 @@ describe( 'actions', () => {
 					error: 'authorization_required',
 					message: 'An active access token must be used to approve wordads.'
 				} );
-		} );
-
-		after( () => {
-			nock.cleanAll();
 		} );
 
 		it( 'should dispatch fetch action when thunk triggered', () => {


### PR DESCRIPTION
This pull request seeks to update tests mocking network requests within the state directory to consistently use the `use-nock` test helper. The test helper provides conveniences for restoring default network behavior after the tests have run, which helps avoid unintended errors and reduces boilerplate. In the process of updating these tests, I had found several tests which were not properly cleaning up mocked requests after the test had finished.

__Testing instructions:__

There should be no impact on the Calypso application. Verify instead that tests continue to pass as expected:

```
npm test
```

Test live: https://calypso.live/?branch=update/state-nock-consistency