### PR TITLE
CPT: Enable custom post types in desktop environment

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -27,6 +27,7 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/jetpack": true,


### PR DESCRIPTION
Closes Automattic/wp-desktop#233
Related: #7384

This pull request seeks to enable the custom post types feature in desktop environments. This feature was enabled in web production as of #7384.

cc @timmyc @rachelmcr @defries

Test live: https://calypso.live/?branch=update/cpt-desktop-config