### PR TITLE
State: Use useSandbox test helper for stubbing console

### DIFF
--- a/client/state/post-types/test/reducer.js
+++ b/client/state/post-types/test/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -17,14 +16,11 @@ import {
 	DESERIALIZE
 } from 'state/action-types';
 import reducer, { requesting, items } from '../reducer';
+import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'reducer', () => {
-	before( () => {
-		sinon.stub( console, 'warn' );
-	} );
-
-	after( () => {
-		console.warn.restore();
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
 	} );
 
 	it( 'should include expected keys in return value', () => {


### PR DESCRIPTION
This pull request seeks to update post types state tests to use the `useSandbox` test helper for mocking `console.warn`. Not only does this reduce boilerplate in not needing to clean up mocks after tests have concluded, it ensures that the `calledOnce` assertion is better tested in isolation (at least against `console.warn` invoked in other tests).

__Testing instructions:__

This should not impact the Calypso running application. Verify instead that tests continue to pass:

```
npm run test-client client/state/post-types/test/reducer.js
```

Test live: https://calypso.live/?branch=update/state-post-types-sandbox