### PR TITLE
Search / Popover / Reader: Prevent premature scrolling by deferring focus

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -162,7 +162,9 @@ const Search = React.createClass( {
 	},
 
 	focus: function() {
-		ReactDom.findDOMNode( this.refs.searchInput ).focus();
+		// if we call focus before the element has been entirely synced up with the DOM, we stand a decent chance of
+		// causing the browser to scroll somewhere odd. Instead, defer the focus until a future turn of the event loop.
+		setTimeout( () => this.refs.searchInput && ReactDom.findDOMNode( this.refs.searchInput ).focus(), 0 );
 	},
 
 	blur: function() {


### PR DESCRIPTION
If the focus is granted before the component has been fully synced and positioned (often the case with Popovers)
focusing the element will cause the browser to scroll to an unexpected position, often the top of the window.

Instead, defer the focus event, which gives everything a chance to get positioned properly.

To test, pull up the reader with a user with more than 6 sites, scroll down, and click on the share button. With this brach, the share menu will appear with the search box focused. On production, the browser will scroll up to the top of the page.

Users with six of fewer sites will not see the problem, as they do not see a search box in the share menu.

Test live: https://calypso.live/?branch=fix/popover/premature-focus-results-in-scrolling