### PR TITLE
Advanced SEO: Enable the new title editor in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -33,6 +33,7 @@
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
+		"manage/advanced-seo/custom-title": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,


### PR DESCRIPTION
@roundhill I did not test this since I was in a rush

Test live: https://calypso.live/?branch=enable/title-editor-on-staging