### PR TITLE
Domains: A/B Test Domain Search Delay

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -19,6 +19,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 import { getFixedDomainSearch, canRegister } from 'lib/domains';
@@ -44,7 +45,8 @@ const SUGGESTION_QUANTITY = 10;
 const INITIAL_SUGGESTION_QUANTITY = 2;
 
 const analytics = analyticsMixin( 'registerDomain' ),
-	searchVendor = 'domainsbot';
+	searchVendor = 'domainsbot',
+	searchDelay = parseInt( abtest( 'domainSearchDelay' ) );
 
 let searchQueue = [],
 	searchStackTimer = null,
@@ -263,7 +265,7 @@ const RegisterDomainStep = React.createClass( {
 					placeholder={ this.translate( 'Enter a domain or keyword', { textOnly: true } ) }
 					autoFocus={ true }
 					delaySearch={ true }
-					delayTimeout={ 1000 }
+					delayTimeout={ searchDelay }
 					dir="ltr"
 					maxLength={ 60 }
 				/>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,5 +123,14 @@ module.exports = {
 			hideVerticalScreenshots: 50,
 		},
 		defaultVariation: 'hideVerticalScreenshots',
+	},
+	domainSearchDelay: {
+		datestamp: '20160907',
+		variations: {
+			// variations are time in milliseconds, we then use parseInt to get a number value
+			1000: 90,
+			5000: 10,
+		},
+		defaultVariation: '1000',
 	}
 };


### PR DESCRIPTION
The amount of suggestion queries we send is huge. We believe this is because of the low delay on the SearchCard.
We want to A/B test the delay and check if it will impact the conversion rates.

Test live: https://calypso.live/?branch=add/abtest-domain-search-delay