### PR TITLE
Reader: in new full-post block, enable scroll to comments using #comments anchor

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -97,6 +97,11 @@ export class FullPostView extends React.Component {
 		}
 
 		this.checkForCommentAnchor();
+
+		// If we have a comment anchor, scroll to comments
+		if ( this.hasCommentAnchor && ! this.hasScrolledToCommentAnchor ) {
+			this.scrollToComments();
+		}
 	}
 
 	componentWillReceiveProps( newProps ) {
@@ -144,7 +149,7 @@ export class FullPostView extends React.Component {
 
 	// Scroll to the top of the comments section.
 	scrollToComments() {
-		//setTimeout( () => {
+		setTimeout( () => {
 			const commentsNode = ReactDom.findDOMNode( this.refs.commentsList );
 			if ( commentsNode && commentsNode.offsetTop ) {
 				scrollTo( {
@@ -156,7 +161,7 @@ export class FullPostView extends React.Component {
 					this.hasScrolledToCommentAnchor = true;
 				}
 			}
-		//}, 0 );
+		}, 0 );
 	}
 
 	parseEmoji() {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -64,6 +64,7 @@ export class FullPostView extends React.Component {
 		].forEach( fn => {
 			this[ fn ] = this[ fn ].bind( this );
 		} );
+		this.hasScrolledToCommentAnchor = false;
 	}
 
 	componentDidMount() {
@@ -75,6 +76,7 @@ export class FullPostView extends React.Component {
 		this.hasSentPageView = false;
 		this.hasLoaded = false;
 		this.attemptToSendPageView();
+		this.checkForCommentAnchor();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -88,6 +90,14 @@ export class FullPostView extends React.Component {
 			this.hasLoaded = false;
 			this.attemptToSendPageView();
 		}
+
+		this.checkForCommentAnchor();
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.shouldShowComments ) {
+			this.checkForCommentAnchor();
+		}
 	}
 
 	componentWillUnmount() {
@@ -97,6 +107,10 @@ export class FullPostView extends React.Component {
 
 	handleBack() {
 		this.props.onClose && this.props.onClose();
+	}
+
+	bindComments( node ) {
+		this.comments = node;
 	}
 
 	handleCommentClick() {
@@ -124,10 +138,31 @@ export class FullPostView extends React.Component {
 
 	bindComments( node ) {
 		this.comments = node;
+		this.scrollToComments();
 	}
 
+	// Does the URL contain the anchor #comments? If so, scroll to comments if we're not already there.
 	checkForCommentAnchor() {
+		const hash = window.location.hash.substr( 1 );
+		if ( this.comments && hash.indexOf( 'comments' ) > -1 && ! this.hasScrolledToCommentAnchor ) {
+			this.scrollToComments();
+		}
+	}
 
+	// Scroll to the top of the comments section.
+	scrollToComments() {
+		if ( ! this.comments ) {
+			return;
+		}
+		const commentsNode = ReactDom.findDOMNode( this.comments );
+		if ( commentsNode ) {
+			scrollTo( {
+				x: 0,
+				y: commentsNode.offsetTop - 48,
+				duration: 300
+			} );
+			this.hasScrolledToCommentAnchor = true;
+		}
 	}
 
 	parseEmoji() {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -96,6 +96,7 @@ export class FullPostView extends React.Component {
 
 	componentWillReceiveProps( newProps ) {
 		if ( newProps.shouldShowComments ) {
+			this.hasScrolledToCommentAnchor = false;
 			this.checkForCommentAnchor();
 		}
 	}
@@ -144,25 +145,24 @@ export class FullPostView extends React.Component {
 	// Does the URL contain the anchor #comments? If so, scroll to comments if we're not already there.
 	checkForCommentAnchor() {
 		const hash = window.location.hash.substr( 1 );
-		if ( this.comments && hash.indexOf( 'comments' ) > -1 && ! this.hasScrolledToCommentAnchor ) {
+		if ( hash.indexOf( 'comments' ) > -1 && ! this.hasScrolledToCommentAnchor ) {
 			this.scrollToComments();
 		}
 	}
 
 	// Scroll to the top of the comments section.
 	scrollToComments() {
-		if ( ! this.comments ) {
-			return;
-		}
-		const commentsNode = ReactDom.findDOMNode( this.comments );
-		if ( commentsNode ) {
-			scrollTo( {
-				x: 0,
-				y: commentsNode.offsetTop - 48,
-				duration: 300
-			} );
-			this.hasScrolledToCommentAnchor = true;
-		}
+		setTimeout( () => {
+			const commentsNode = ReactDom.findDOMNode( this.refs.commentList );
+			if ( commentsNode && commentsNode.offsetTop ) {
+				scrollTo( {
+					x: 0,
+					y: commentsNode.offsetTop - 48,
+					duration: 300
+				} );
+				this.hasScrolledToCommentAnchor = true;
+			}
+		}, 0 );
 	}
 
 	parseEmoji() {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -115,19 +115,11 @@ export class FullPostView extends React.Component {
 		this.props.onClose && this.props.onClose();
 	}
 
-	bindComments( node ) {
-		this.comments = node;
-	}
-
 	handleCommentClick() {
 		recordAction( 'click_comments' );
 		recordGaEvent( 'Clicked Post Comment Button' );
 		recordTrackForPost( 'calypso_reader_full_post_comments_button_clicked', this.props.post );
-		scrollTo( {
-			x: 0,
-			y: ReactDom.findDOMNode( this.comments ).offsetTop - 48,
-			duration: 300
-		} );
+		this.scrollToComments();
 	}
 
 	handleLike() {
@@ -153,14 +145,16 @@ export class FullPostView extends React.Component {
 	// Scroll to the top of the comments section.
 	scrollToComments() {
 		//setTimeout( () => {
-			const commentsNode = this.refs.commentsList;
+			const commentsNode = ReactDom.findDOMNode( this.refs.commentsList );
 			if ( commentsNode && commentsNode.offsetTop ) {
 				scrollTo( {
 					x: 0,
 					y: commentsNode.offsetTop - 48,
 					duration: 300
 				} );
-				this.hasScrolledToCommentAnchor = true;
+				if ( this.hasCommentAnchor ) {
+					this.hasScrolledToCommentAnchor = true;
+				}
 			}
 		//}, 0 );
 	}
@@ -293,7 +287,8 @@ export class FullPostView extends React.Component {
 							? <Comments ref="commentsList"
 									post={ post }
 									initialSize={ 25 }
-									pageSize={ 25 } />
+									pageSize={ 25 }
+									onCommentsUpdate={ this.checkForCommentAnchor } />
 							: null
 						}
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -149,6 +149,16 @@ export class FullPostView extends React.Component {
 
 	// Scroll to the top of the comments section.
 	scrollToComments() {
+		if ( ! this.props.post ) {
+			return;
+		}
+		if ( this.props.post._state ) {
+			return;
+		}
+		if ( this._scrolling ) {
+			return;
+		}
+		this._scrolling = true;
 		setTimeout( () => {
 			const commentsNode = ReactDom.findDOMNode( this.refs.commentsWrapper );
 			if ( commentsNode && commentsNode.offsetTop ) {
@@ -163,6 +173,7 @@ export class FullPostView extends React.Component {
 						if ( commentsNodeAfterScroll && commentsNodeAfterScroll.offsetTop ) {
 							window.scrollTo( 0, commentsNodeAfterScroll.offsetTop - 48 );
 						}
+						this._scrolling = false;
 					}
 				} );
 				if ( this.hasCommentAnchor ) {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -150,7 +150,7 @@ export class FullPostView extends React.Component {
 	// Scroll to the top of the comments section.
 	scrollToComments() {
 		setTimeout( () => {
-			const commentsNode = ReactDom.findDOMNode( this.refs.commentsList );
+			const commentsNode = ReactDom.findDOMNode( this.refs.commentsWrapper );
 			if ( commentsNode && commentsNode.offsetTop ) {
 				scrollTo( {
 					x: 0,
@@ -288,14 +288,16 @@ export class FullPostView extends React.Component {
 								className="is-same-site" />
 						}
 
-						{ shouldShowComments( post )
-							? <Comments ref="commentsList"
-									post={ post }
-									initialSize={ 25 }
-									pageSize={ 25 }
-									onCommentsUpdate={ this.checkForCommentAnchor } />
-							: null
-						}
+						<div className="reader-full-post__comments-wrapper" ref="commentsWrapper">
+							{ shouldShowComments( post )
+								? <Comments ref="commentsList"
+										post={ post }
+										initialSize={ 25 }
+										pageSize={ 25 }
+										onCommentsUpdate={ this.checkForCommentAnchor } />
+								: null
+							}
+						</div>
 
 						{ showRelatedPosts &&
 							<RelatedPostsFromOtherSites siteId={ post.site_ID } postId={ post.ID }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -155,7 +155,15 @@ export class FullPostView extends React.Component {
 				scrollTo( {
 					x: 0,
 					y: commentsNode.offsetTop - 48,
-					duration: 300
+					duration: 300,
+					onComplete: () => {
+						// check to see if the comment node moved while we were scrolling
+						// and scroll to the end position
+						const commentsNodeAfterScroll = ReactDom.findDOMNode( this.refs.commentsWrapper );
+						if ( commentsNodeAfterScroll && commentsNodeAfterScroll.offsetTop ) {
+							window.scrollTo( 0, commentsNodeAfterScroll.offsetTop - 48 );
+						}
+					}
 				} );
 				if ( this.hasCommentAnchor ) {
 					this.hasScrolledToCommentAnchor = true;

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -59,8 +59,7 @@ export class FullPostView extends React.Component {
 		[
 			'handleBack',
 			'handleCommentClick',
-			'handleLike',
-			'bindComments'
+			'handleLike'
 		].forEach( fn => {
 			this[ fn ] = this[ fn ].bind( this );
 		} );
@@ -76,7 +75,13 @@ export class FullPostView extends React.Component {
 		this.hasSentPageView = false;
 		this.hasLoaded = false;
 		this.attemptToSendPageView();
+
 		this.checkForCommentAnchor();
+
+		// If we have a comment anchor, scroll to comments
+		if ( this.hasCommentAnchor && ! this.hasScrolledToCommentAnchor ) {
+			this.scrollToComments();
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -137,23 +142,18 @@ export class FullPostView extends React.Component {
 		}
 	}
 
-	bindComments( node ) {
-		this.comments = node;
-		this.scrollToComments();
-	}
-
 	// Does the URL contain the anchor #comments? If so, scroll to comments if we're not already there.
 	checkForCommentAnchor() {
 		const hash = window.location.hash.substr( 1 );
-		if ( hash.indexOf( 'comments' ) > -1 && ! this.hasScrolledToCommentAnchor ) {
-			this.scrollToComments();
+		if ( hash.indexOf( 'comments' ) > -1 ) {
+			this.hasCommentAnchor = true;
 		}
 	}
 
 	// Scroll to the top of the comments section.
 	scrollToComments() {
-		setTimeout( () => {
-			const commentsNode = ReactDom.findDOMNode( this.refs.commentList );
+		//setTimeout( () => {
+			const commentsNode = this.refs.commentsList;
 			if ( commentsNode && commentsNode.offsetTop ) {
 				scrollTo( {
 					x: 0,
@@ -162,7 +162,7 @@ export class FullPostView extends React.Component {
 				} );
 				this.hasScrolledToCommentAnchor = true;
 			}
-		}, 0 );
+		//}, 0 );
 	}
 
 	parseEmoji() {
@@ -290,11 +290,10 @@ export class FullPostView extends React.Component {
 						}
 
 						{ shouldShowComments( post )
-							? <Comments ref={ this.bindComments }
+							? <Comments ref="commentsList"
 									post={ post }
 									initialSize={ 25 }
-									pageSize={ 25 }
-									onCommentsUpdate={ this.checkForCommentAnchor } />
+									pageSize={ 25 } />
 							: null
 						}
 


### PR DESCRIPTION
In the existing full post view, adding the `#comments` to the URL scrolls to the comments section.

This PR adds the same functionality to the new reader-full-post block.

Fixes #7840.

Test live: https://calypso.live/?branch=add/reader/new-full-post-scroll-to-comments