### PR TITLE
Snake case tracks property names so they dont land in the rejects table

### DIFF
--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -21,7 +21,10 @@ export default localize( ( props ) => {
 	} = props;
 
 	const trackRegistrationClick = () => {
-		analytics.tracks.recordEvent( 'calypso_help_course_registration_click', { registrationUrl, isBusinessPlanUser } );
+		analytics.tracks.recordEvent( 'calypso_help_course_registration_click', {
+			registration_url: registrationUrl,
+			is_business_plan_user: isBusinessPlanUser
+		} );
 	};
 
 	return (

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -25,7 +25,9 @@ class Course extends Component {
 			isBusinessPlanUser
 		} = this.props;
 
-		analytics.tracks.recordEvent( 'calypso_help_course_pageview', { isBusinessPlanUser } );
+		analytics.tracks.recordEvent( 'calypso_help_course_pageview', {
+			is_business_plan_user: isBusinessPlanUser
+		} );
 	}
 
 	render() {

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -137,7 +137,9 @@ const Help = React.createClass( {
 
 	trackCoursesButtonClick() {
 		const { isBusinessPlanUser } = this.props;
-		analytics.tracks.recordEvent( 'calypso_help_courses_click', { isBusinessPlanUser } );
+		analytics.tracks.recordEvent( 'calypso_help_courses_click', {
+			is_business_plan_user: isBusinessPlanUser
+		} );
 	},
 
 	getPlaceholders() {


### PR DESCRIPTION
This pull request fixes the property names of the following tracks pings being made in the help courses area: `calypso_help_course_registration_click`, `calypso_help_course_pageview`, and `calypso_help_courses_click`

Test live: https://calypso.live/?branch=fix/help-courses-tracks-pings