### PR TITLE
Help: Update course dates throughout September

### DIFF
--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -31,16 +31,20 @@ function getCourses() {
 			),
 			schedule: [
 				{
-					date: i18n.moment( new Date( 'Tue, 6 Sep 2016 15:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/7b4295069e316cb28c34be5db4a05ad8'
-				},
-				{
 					date: i18n.moment( new Date( 'Mon, 12 Sep 2016 21:00:00 +0000' ) ),
 					registrationUrl: 'https://zoom.us/webinar/register/08c4eff0906b1da4d746f627e8486654'
 				},
 				{
 					date: i18n.moment( new Date( 'Fri, 23 Sep 2016 18:00:00 +0000' ) ),
 					registrationUrl: 'https://zoom.us/webinar/register/732df6652d490ab0dc2040ba88984b7b'
+				},
+				{
+					date: i18n.moment( new Date( 'Tue, 27 Sep 2016 17:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/c14f7c38c388111466858a512be5123a'
+				},
+				{
+					date: i18n.moment( new Date( 'Thur, 29 Sep 2016 20:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/e70a34c1ca8c13dac5b9141539e44ee6'
 				},
 			],
 			videos: [


### PR DESCRIPTION
This updates the list of live course days and times throughout September. The days and times should be as follows:

- Monday 9/12 2pm PDT
- Friday 9/23 11am PDT
- Tuesday 9/27 10am PDT
- Thursday 9/29 1pm PDT

I also removed the 9/6/16 course as it was completed today. 

See Slack discussion: p1473190066000087-business-concierge

Screenshot with changes:

![screen shot 2016-09-06 at 4 08 19 pm](https://cloud.githubusercontent.com/assets/7240478/18292759/28869a36-744c-11e6-8fab-64b13da416a6.png)

cc @omarjackman 

Test live: https://calypso.live/?branch=update/add-course-dates-september