### PR TITLE
Domains: Use availability check result instead of suggestions

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -442,7 +442,7 @@ const RegisterDomainStep = React.createClass( {
 			isSearchedDomain = function( suggestion ) {
 				return suggestion.domain_name === lastDomainSearched;
 			},
-			availableDomain = find( this.state.searchResults, isSearchedDomain );
+			availableDomain = this.state.lastDomainError ? undefined : find( this.state.searchResults, isSearchedDomain );
 		let suggestions = reject( this.state.searchResults, isSearchedDomain ),
 			onAddMapping;
 


### PR DESCRIPTION
We only checked if a domain we searched for is in suggestions, and those are often not up to date.
We have truthy info in our availability endpoint which is now used in addition to the suggestions.

Test live: https://calypso.live/?branch=update/fix-domain-available-when-not