### PR TITLE
Guided Transfer: Use price from API

### DIFF
--- a/client/my-sites/exporter/guided-transfer-card/index.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/index.jsx
@@ -10,11 +10,13 @@ import { connect } from 'react-redux';
  */
 import CompactCard from 'components/card/compact';
 import QuerySiteGuidedTransfer from 'components/data/query-site-guided-transfer';
+import QueryProductsList from 'components/data/query-products-list';
 import Gridicon from 'components/gridicon';
 import Button from 'components/forms/form-button';
 import { isGuidedTransferAvailableForAllSites } from 'state/sites/guided-transfer/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getProductDisplayCost } from 'state/products-list/selectors';
 import InfoPopover from 'components/info-popover';
 
 const Feature = ( { children } ) =>
@@ -51,18 +53,22 @@ class GuidedTransferCard extends Component {
 			translate,
 			isAvailable,
 			siteId,
+			cost,
 		} = this.props;
 
 		return <div>
 			<CompactCard>
 				<QuerySiteGuidedTransfer siteId={ siteId } />
+				<QueryProductsList />
 				<div className="guided-transfer-card__options">
 					<div className="guided-transfer-card__options-header-title-container">
 						<h1 className="guided-transfer-card__title">
 							{ translate( 'Guided Transfer' ) }
 						</h1>
 						<h2 className="guided-transfer-card__subtitle">
-							<span className="guided-transfer-card__price">$129</span>
+							<span className="guided-transfer-card__price">
+								{ cost }
+							</span>
 							&nbsp;
 							{ translate( 'One-time expense' ) }
 						</h2>
@@ -109,6 +115,7 @@ class GuidedTransferCard extends Component {
 }
 
 const mapStateToProps = state => ( {
+	cost: getProductDisplayCost( state, 'guided_transfer' ),
 	siteId: getSelectedSiteId( state ),
 	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) ),
 	isAvailable: isGuidedTransferAvailableForAllSites( state, getSelectedSiteId( state ) ),

--- a/client/my-sites/exporter/guided-transfer-card/index.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/index.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
  */
 import CompactCard from 'components/card/compact';
 import QuerySiteGuidedTransfer from 'components/data/query-site-guided-transfer';
-import QueryProductsList from 'components/data/query-products-list';
 import Gridicon from 'components/gridicon';
 import Button from 'components/forms/form-button';
 import { isGuidedTransferAvailableForAllSites } from 'state/sites/guided-transfer/selectors';
@@ -37,9 +36,9 @@ const UnavailableInfo = localize( ( { translate } ) =>
 	<div className="guided-transfer-card__unavailable-notice">
 		<span>{ translate( 'Guided Transfer unavailable' ) }</span>
 		<InfoPopover className="guided-transfer-card__unavailable-info-icon" position="left">
-			{ translate( `Guided Transfer is unavailable at the moment. We'll
-				be back as soon as possible! In the meantime, you can transfer your
-				WordPress.com blog elsewhere by following {{a}}these steps{{/a}}`,
+			{ translate( "Guided Transfer is unavailable at the moment. We'll " +
+				'be back as soon as possible! In the meantime, you can transfer your ' +
+				'WordPress.com blog elsewhere by following {{a}}these steps{{/a}}',
 				{ components: {
 					a: <a href="https://move.wordpress.com/" />
 				} } ) }
@@ -59,7 +58,6 @@ class GuidedTransferCard extends Component {
 		return <div>
 			<CompactCard>
 				<QuerySiteGuidedTransfer siteId={ siteId } />
-				<QueryProductsList />
 				<div className="guided-transfer-card__options">
 					<div className="guided-transfer-card__options-header-title-container">
 						<h1 className="guided-transfer-card__title">
@@ -92,7 +90,7 @@ class GuidedTransferCard extends Component {
 							'site{{/strong}} to a self-hosted WordPress.org installation with ' +
 							'one of our hosting partners.', { components: { strong: <strong /> } }
 						) }
-						<br/>
+						<br />
 						<a href="https://en.support.wordpress.com/guided-transfer/" >
 							{ translate( 'Learn more.' ) }
 						</a>

--- a/client/my-sites/exporter/guided-transfer-card/index.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/index.jsx
@@ -17,6 +17,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getProductDisplayCost } from 'state/products-list/selectors';
 import InfoPopover from 'components/info-popover';
+import SUPPORT_URLS from 'lib/url/support';
 
 const Feature = ( { children } ) =>
 	<li className="guided-transfer-card__feature-list-item">
@@ -91,7 +92,7 @@ class GuidedTransferCard extends Component {
 							'one of our hosting partners.', { components: { strong: <strong /> } }
 						) }
 						<br />
-						<a href="https://en.support.wordpress.com/guided-transfer/" >
+						<a href={ SUPPORT_URLS.GUIDED_TRANSFER } >
 							{ translate( 'Learn more.' ) }
 						</a>
 					</div>
@@ -101,7 +102,7 @@ class GuidedTransferCard extends Component {
 						<Feature>
 							{ translate( 'Switch your domain over {{link}}and more!{{/link}}', {
 								components: {
-									link: <a href="https://en.support.wordpress.com/guided-transfer/" />
+									link: <a href={ SUPPORT_URLS.GUIDED_TRANSFER } />
 								}
 							} ) }
 						</Feature>

--- a/client/my-sites/exporter/guided-transfer-card/index.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/index.jsx
@@ -65,11 +65,11 @@ class GuidedTransferCard extends Component {
 							{ translate( 'Guided Transfer' ) }
 						</h1>
 						<h2 className="guided-transfer-card__subtitle">
-							<span className="guided-transfer-card__price">
-								{ cost }
-							</span>
-							&nbsp;
-							{ translate( 'One-time expense' ) }
+							{ translate( '{{cost/}} One-time expense', {
+								components: {
+									cost: <span className="guided-transfer-card__price">{ cost }</span>
+								}
+							} ) }
 						</h2>
 					</div>
 					<div className="guided-transfer-card__options-header-button-container">

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -11,6 +11,7 @@ import i18n from 'i18n-calypso';
  */
 import Main from 'components/main';
 import notices from 'notices';
+import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getSitePurchases, hasLoadedSitePurchasesFromServer, getPurchasesError } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -90,7 +91,7 @@ export class SiteSettingsComponent extends Component {
 			case 'import':
 				return <ImportSettings site={ site } />;
 			case 'export':
-				return <ExportSettings site={ site }/>;
+				return <ExportSettings site={ site } />;
 			case 'guidedTransfer':
 				return <GuidedTransfer hostSlug={ hostSlug } />;
 		}
@@ -104,6 +105,7 @@ export class SiteSettingsComponent extends Component {
 			<Main className="site-settings">
 					<SidebarNavigation />
 					<SiteSettingsNavigation site={ site } section={ section } />
+					<QueryProductsList />
 					{ site && <QuerySitePurchases siteId={ site.ID } /> }
 					{ site && this.getSection() }
 			</Main>

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -1,3 +1,19 @@
 export function isProductsListFetching( state ) {
 	return state.productsList.isFetching;
 }
+
+/**
+ * Returns the display price of a product
+ *
+ * @param {Object} state The Redux state tree
+ * @param {string} productSlug The internal product slug, eg 'jetpack_premium'
+ * @return {string} The display price formatted in the user's currency, eg "A$29.00"
+ */
+export function getProductDisplayCost( state, productSlug ) {
+	const product = state.productsList.items && state.productsList.items[ productSlug ];
+	if ( ! product ) {
+		return null;
+	}
+
+	return product.cost_display;
+}

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -10,7 +10,7 @@ export function isProductsListFetching( state ) {
  * @return {string} The display price formatted in the user's currency, eg "A$29.00"
  */
 export function getProductDisplayCost( state, productSlug ) {
-	const product = state.productsList.items && state.productsList.items[ productSlug ];
+	const product = state.productsList.items[ productSlug ];
 	if ( ! product ) {
 		return null;
 	}

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -7,10 +7,13 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { getProductDisplayCost } from '../selectors';
+import {
+	getProductDisplayCost,
+	isProductsListFetching,
+} from '../selectors';
 
 describe( 'selectors', () => {
-	describe( 'getProductDisplayCost()', () => {
+	describe( '#getProductDisplayCost()', () => {
 		it( 'should return null when the products list has not been fetched', () => {
 			const state = deepFreeze( { productsList: { items: {} } } );
 
@@ -29,6 +32,18 @@ describe( 'selectors', () => {
 			} );
 
 			expect( getProductDisplayCost( state, 'guided_transfer' ) ).to.equal( 'A$169.00' );
+		} );
+	} );
+
+	describe( '#isProductsListFetching()', () => {
+		it( 'should return false when productsList.isFetching is false', () => {
+			const state = { productsList: { isFetching: false } };
+			expect( isProductsListFetching( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when productsList.isFetching is true', () => {
+			const state = { productsList: { isFetching: true } };
+			expect( isProductsListFetching( state ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { getProductDisplayCost } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'getProductDisplayCost()', () => {
+		it( 'should return null when the products list has not been fetched', () => {
+			const state = deepFreeze( { productsList: { items: {} } } );
+
+			expect( getProductDisplayCost( state, 'guided_transfer' ) ).to.be.null;
+		} );
+
+		it( 'should return the display cost', () => {
+			const state = deepFreeze( {
+				productsList: {
+					items: {
+						guided_transfer: {
+							cost_display: 'A$169.00'
+						}
+					}
+				}
+			} );
+
+			expect( getProductDisplayCost( state, 'guided_transfer' ) ).to.equal( 'A$169.00' );
+		} );
+	} );
+} );


### PR DESCRIPTION
This replaces the hardcoded display price for Guided Transfers with the price fetched from the products list API endpoint in the Redux store:

| Before | After |
| --- | --- |
| ![before](https://cloud.githubusercontent.com/assets/416133/18300713/20f9de54-750f-11e6-878e-ed33923c00b2.png) | ![screen shot 2016-09-07 at 3 02 16 pm](https://cloud.githubusercontent.com/assets/416133/18301006/46faa988-7511-11e6-97c3-73aefaad9959.png) |
#### Other currencies are now displayed

![screen shot 2016-09-07 at 3 00 15 pm](https://cloud.githubusercontent.com/assets/416133/18301003/457a208e-7511-11e6-8054-80085a39fbf7.png)
![screen shot 2016-09-07 at 3 01 12 pm](https://cloud.githubusercontent.com/assets/416133/18301004/46217f8c-7511-11e6-97a1-daef17b23aba.png)
### How to test
1. If your account is using USD, switch to another currency using Store Admin
2. Go to **My Sites > Settings > Export**
3. Check that the Guided Transfer displays in your account's currency

Run the automated tests:

``` sh
npm run test-client client/state/products-list/test
```

Test live: https://calypso.live/?branch=update/guided-transfer/price-from-store
