### PR TITLE
Guided Transfer: Enable in wp-calypso and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,6 +36,7 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/export": true,
+		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,6 +44,7 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/export": true,
+		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,


### PR DESCRIPTION
Enables the Guided Transfer box in the wpcalypso and horizon environments:

**My sites > Settings > Export**
![screen shot 2016-09-07 at 4 38 12 pm](https://cloud.githubusercontent.com/assets/416133/18302220/d7cd427e-7519-11e6-90bf-d115ba649ff3.png)

cc @dllh 

~~Test live: https://calypso.live/?branch=update/guided-transfer/enable-in-wpcalypso-horizon~~