### PR TITLE
Don't limit button width.

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/style.scss
@@ -75,10 +75,6 @@
 	text-align: right;
 	padding: 15px;
 	margin: 0px -25px -25px;
-
-	.button {
-		width: 100px;
-	}
 }
 
 .google-vouchers-dialog__cancel-button {


### PR DESCRIPTION
Fixes a bug where longer translations of confirm button would wrap to a
new line.

Introduced in 4460378e8f3ae626fbf49eba8b23941ec928c6e3.
Fixes #6361.

Test live: https://calypso.live/?branch=fix/adwords-confirm-button