### PR TITLE
Site Settings: Restore the security route & fix a prop type warning

### DIFF
--- a/client/my-sites/site-settings/form-jetpack-scan.jsx
+++ b/client/my-sites/site-settings/form-jetpack-scan.jsx
@@ -423,8 +423,9 @@ module.exports = React.createClass( {
 					<p>
 						<FormInput
 							valueLink={ this.linkState( 'publicKeyString' ) }
-							selectOnFocus="true"
-							readOnly="readonly" />
+							selectOnFocus
+							readOnly
+						/>
 					</p>
 				</div>
 			</Dialog>

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -16,6 +16,7 @@ module.exports = function() {
 	page( '/settings/writing/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
 	page( '/settings/discussion/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
 	page( '/settings/analytics/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
+	page( '/settings/security/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
 
 	page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
 


### PR DESCRIPTION
### Background
In https://github.com/Automattic/wp-calypso/pull/7688 the SEO settings were split into their own chunk, so the rest of the settings routes have been listed specifically in `client/my-sites/site-settings/index.js`. However, the route for `security` section was not added. This broke the Security settings section of Jetpack sites.

### The issue
To reproduce the issue, go to `/settings/general/$site`, where $site is a Jetpack site. Then click on the **Security** nav item. You will be directed to a blank page.

### Solution
This PR specifically adds the security route, like the rest of the routes were added. Going to the security section was triggering a warning on using `selectOnFocus` with a non-boolean value, which has also been addressed in this PR.

### Testing
* Checkout this branch.
* Go to `/settings/general/$site`, where $site is a Jetpack site.
* Click on "Security".
* Verify that the Security page is properly displayed along with its cards.
* Verify that there is no console warning triggered by `selectOnFocus`.

### Review

/cc @mtias @dmsnell 

Test live: https://calypso.live/?branch=fix/site-settings-restore-security-route