### PR TITLE
Search: use accessible focus class to toggle highlight.

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -44,7 +44,7 @@
 		transition: opacity .2s ease-in;
 	}
 
-	&.has-focus {
+	.accessible-focus &.has-focus {
 		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
 	}
 }


### PR DESCRIPTION
The current blu halo in every search is a bit too heavy handed. The `accessible-focus` class was created to allow us to do indicate focus without necessarily making it a general visual effect across the UI.

Test live: https://calypso.live/?branch=update/use-accessible-focus-for-search