### PR TITLE
ImagePreloader: add simple docs example

### DIFF
--- a/client/components/image-preloader/docs/example.jsx
+++ b/client/components/image-preloader/docs/example.jsx
@@ -1,0 +1,17 @@
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ImagePreloader from 'components/image-preloader';
+
+const ImagePreloaderExample = () =>
+		<ImagePreloader
+			placeholder={ <div>Loading...</div> }
+			src="https://en-blog.files.wordpress.com/2016/08/photo-1441109296207-fd911f7cd5e5.jpg" />;
+
+export default ImagePreloaderExample;

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -49,6 +49,7 @@ import SpinnerLine from 'components/spinner-line/docs/example';
 import Rating from 'components/rating/docs/example';
 import DatePicker from 'components/date-picker/docs/example';
 import InputChrono from 'components/input-chrono/docs/example';
+import ImagePreloader from 'components/image-preloader/docs/example';
 import Ribbon from 'components/ribbon/docs/example';
 import Timezone from 'components/timezone/docs/example';
 import ClipboardButtons from 'components/forms/clipboard-button/docs/example';
@@ -135,6 +136,7 @@ let DesignAssets = React.createClass( {
 					<Gravatar />
 					<Gridicons />
 					<Headers />
+					<ImagePreloader />
 					<InfoPopover />
 					<Tooltip />
 					<InputChrono />


### PR DESCRIPTION
This PR just adds a simple doc example into devdocs/design page.

<img src="https://cloud.githubusercontent.com/assets/77539/18311744/65111996-74dc-11e6-88c0-6b67c73a97c0.png" width="500px" />

### Testing

Navigate to http://calypso.localhost:3000/devdocs/design/image-preloader. You should see the uploaded image.

Test live: https://calypso.live/?branch=add/image-preloader-example