### PR TITLE
Post-checkout: Fix PlanThankYouCard error when site not available

### DIFF
--- a/client/blocks/plan-thank-you-card/README.md
+++ b/client/blocks/plan-thank-you-card/README.md
@@ -1,6 +1,6 @@
 # Plan Thank You Card
 
-This is a component that shows thank you card after purchasing a plan for a site. It requires the site object to be present and if site plans are not available in Redux state, it fetches them.
+This is a component that shows thank you card after purchasing a plan for a site. It requires siteId as the only prop and it fetches the rest of data to redux state.
 
 ## Props
 

--- a/client/blocks/plan-thank-you-card/docs/example.jsx
+++ b/client/blocks/plan-thank-you-card/docs/example.jsx
@@ -10,7 +10,6 @@ import { get } from 'lodash';
  */
 import PlanThankYouCard from '../';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { getSitePosts } from 'state/posts/selectors';
 
 function PlanThankYouCardExample( { primarySiteId } ) {
 	return (
@@ -24,7 +23,7 @@ function PlanThankYouCardExample( { primarySiteId } ) {
 }
 
 const ConnectedPlanThankYouCard = connect( ( state ) => {
-	const primarySiteId = get( getCurrentUser( state ), 'primary_blog' );
+	const primarySiteId = get( getCurrentUser( state ), 'primary_blog', null );
 
 	return {
 		primarySiteId,

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -75,7 +76,7 @@ class PlanThankYouCard extends Component {
 						{ translate( "Now that we've taken care of the plan, it's time to see your new site." ) }
 					</div>
 					<a
-						className="plan-thank-you-card__button"
+						className={ classnames( 'plan-thank-you-card__button', { 'is-placeholder': ! siteURL } ) }
 						href={ siteURL }>
 						{ translate( 'Visit Your Site' ) }
 					</a>
@@ -92,6 +93,6 @@ export default connect( ( state, ownProps ) => {
 
 	return {
 		plan,
-		siteURL: site.URL
+		siteURL: site && site.URL
 	};
 } )( localize( PlanThankYouCard ) );

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -53,6 +53,15 @@
 	border-width: 1px 1px 2px;
 }
 
+.plan-thank-you-card__button.is-placeholder,
+.plan-thank-you-card__button.is-placeholder:visited {
+	@include placeholder();
+	pointer-events: none;
+	background-color: lighten( $alert-green, 40 );
+	border-color: transparent;
+	border-radius: 0;
+}
+
 .plan-thank-you-card__button:hover {
 	border-color: darken( $alert-green, 30 );
 	color: darken( $alert-green, 10 );


### PR DESCRIPTION
After this change, the block doesn't expect the site object to be preloaded. It also adds a placeholder state to the CTA button, before we have the URL fetched. 

Fixes #7874 


Test live: https://calypso.live/?branch=fix/plan-thank-you-card-devdocs