### PR TITLE
GuidedTours: (blanket) exit by guessing user intent

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */
@@ -6,11 +8,13 @@ import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import {
 	debounce,
+	defer,
 	find,
 	mapValues,
 	omit,
 	property,
 } from 'lodash';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -18,15 +22,17 @@ import {
 import Card from 'components/card';
 import Button from 'components/button';
 import ExternalLink from 'components/external-link';
+import { ROUTE_SET } from 'state/action-types';
 import { tourBranching } from './config-parsing';
 import {
 	posToCss,
 	getStepPosition,
 	getValidatedArrowPosition,
 	query,
-	targetForSlug
+	targetForSlug,
 } from './positioning';
 
+const debug = debugFactory( 'calypso:guided-tours' );
 const contextTypes = Object.freeze( {
 	branching: PropTypes.object.isRequired,
 	next: PropTypes.func.isRequired,
@@ -35,6 +41,7 @@ const contextTypes = Object.freeze( {
 	tour: PropTypes.string.isRequired,
 	tourVersion: PropTypes.string.isRequired,
 	step: PropTypes.string.isRequired,
+	lastAction: PropTypes.object,
 } );
 
 export class Tour extends Component {
@@ -48,8 +55,8 @@ export class Tour extends Component {
 	static childContextTypes = contextTypes;
 
 	getChildContext() {
-		const { branching, next, quit, isValid, tour, tourVersion, step } = this.tourMeta;
-		return { branching, next, quit, isValid, tour, tourVersion, step };
+		const { branching, next, quit, isValid, lastAction, tour, tourVersion, step } = this.tourMeta;
+		return { branching, next, quit, isValid, lastAction, tour, tourVersion, step };
 	}
 
 	constructor( props, context ) {
@@ -62,8 +69,8 @@ export class Tour extends Component {
 	}
 
 	setTourMeta( props ) {
-		const { branching, next, quit, isValid, name, version, stepName } = props;
-		this.tourMeta = { branching, next, quit, isValid, tour: name, tourVersion: version, step: stepName };
+		const { branching, next, quit, isValid, lastAction, name, version, stepName } = props;
+		this.tourMeta = { branching, next, quit, isValid, lastAction, tour: name, tourVersion: version, step: stepName };
 	}
 
 	render() {
@@ -103,6 +110,14 @@ export class Step extends Component {
 
 	constructor( props, context ) {
 		super( props, context );
+
+		// keep track of current section for "blanket exit"
+		// (i.e. quitIfInvalidRoute in `Step` and `Continue`)
+		// TODO(mcsf,lsinger): works only in a few cases and could be more elegant
+		// e.g. doesn't work when switching from reader start to discover
+		// as the Step gets re-created anew
+		// (better than false positives, though)
+		this.section = this.pathToSection( location.pathname );
 	}
 
 	componentWillMount() {
@@ -117,6 +132,7 @@ export class Step extends Component {
 
 	componentWillReceiveProps( nextProps, nextContext ) {
 		this.skipIfInvalidContext( nextProps, nextContext );
+		this.quitIfInvalidRoute( nextProps, nextContext );
 		this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
 		this.scrollContainer = query( nextProps.scrollContainer )[ 0 ] || global.window;
 		this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
@@ -129,10 +145,45 @@ export class Step extends Component {
 		this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
 	}
 
+	quitIfInvalidRoute( props, context ) {
+		const { step, branching, lastAction } = context;
+		const hasContinue = !! branching[ step ].continue;
+		const hasJustNavigated = lastAction.type === ROUTE_SET;
+
+		debug( 'Step.quitIfInvalidRoute',
+			'step', step,
+			'previousStep', this.context.step,
+			'hasContinue', hasContinue,
+			'hasJustNavigated', hasJustNavigated,
+			'lastAction', lastAction,
+			'path', lastAction.path,
+			'isDifferentSection', this.isDifferentSection( lastAction.path ) );
+
+		if ( ! hasContinue && hasJustNavigated &&
+				this.isDifferentSection( lastAction.path ) ) {
+			defer( () => {
+				debug( 'Step.quitIfInvalidRoute: quitting' );
+				this.context.quit();
+			} );
+		} else {
+			debug( 'Step.quitIfInvalidRoute: not quitting' );
+		}
+	}
+
+	isDifferentSection( path ) {
+		debug( 'isDifferentSection', this.section, path );
+		return this.section && path &&
+			this.section !== this.pathToSection( path );
+	}
+
+	pathToSection( path ) {
+		return path && path.split( '/' ).slice( 0, 2 ).join( '/' );
+	}
+
 	skipIfInvalidContext( props, context ) {
 		const { when, next } = props;
 		if ( when && ! context.isValid( when ) ) {
-			this.context.next( this.tour, next ); //TODO(ehg): use future branching code get next step
+			this.context.next( this.tour, next );
 		}
 	}
 
@@ -249,6 +300,7 @@ export class Continue extends Component {
 
 	componentDidMount() {
 		! this.props.hidden && this.addTargetListener();
+		this.quitIfInvalidRoute( this.props, this.context );
 	}
 
 	componentWillUnmount() {
@@ -264,7 +316,23 @@ export class Continue extends Component {
 	}
 
 	componentDidUpdate() {
+		this.quitIfInvalidRoute( this.props, this.context );
 		this.addTargetListener();
+	}
+
+	quitIfInvalidRoute( props ) {
+		debug( 'Continue.quitIfInvalidRoute' );
+		defer( () => {
+			const quit = this.context.quit;
+			const target = targetForSlug( props.target );
+			// quit if we have a target but cant find it
+			if ( props.target && ! target ) {
+				debug( 'Continue.quitIfInvalidRoute: quitting' );
+				quit();
+			} else {
+				debug( 'Continue.quitIfInvalidRoute: not quitting' );
+			}
+		} );
 	}
 
 	onContinue = () => {
@@ -277,6 +345,7 @@ export class Continue extends Component {
 
 		if ( click && ! when && targetNode && targetNode.addEventListener ) {
 			targetNode.addEventListener( 'click', this.onContinue );
+			targetNode.addEventListener( 'touchstart', this.onContinue );
 		}
 	}
 
@@ -286,6 +355,7 @@ export class Continue extends Component {
 
 		if ( click && ! when && targetNode && targetNode.removeEventListener ) {
 			targetNode.removeEventListener( 'click', this.onContinue );
+			targetNode.removeEventListener( 'touchstart', this.onContinue );
 		}
 	}
 
@@ -316,15 +386,16 @@ export class Link extends Component {
 
 //FIXME: where do these functions belong?
 export const makeTour = tree => {
-	const tour = ( { stepName, isValid, next, quit } ) =>
+	const tour = ( { stepName, isValid, lastAction, next, quit } ) =>
 		React.cloneElement( tree, {
-			stepName, isValid, next, quit,
+			stepName, isValid, lastAction, next, quit,
 			branching: tourBranching( tree ),
 		} );
 
 	tour.propTypes = {
 		stepName: PropTypes.string.isRequired,
 		isValid: PropTypes.func.isRequired,
+		lastAction: PropTypes.object,
 		next: PropTypes.func.isRequired,
 		quit: PropTypes.func.isRequired,
 		branching: PropTypes.object.isRequired,

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -14,6 +14,7 @@ import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { getActionLog } from 'state/ui/action-log/selectors';
+import { isSectionLoading } from 'state/ui/selectors';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
 
 class GuidedTours extends Component {
@@ -55,6 +56,7 @@ class GuidedTours extends Component {
 				<div className="guided-tours">
 					<QueryPreferences />
 					<AllTours
+							shouldPause={ this.props.isSectionLoading }
 							tourName={ tourName }
 							stepName={ stepName }
 							lastAction={ this.props.lastAction }
@@ -68,8 +70,10 @@ class GuidedTours extends Component {
 }
 
 export default connect( ( state ) => ( {
+	isSectionLoading: isSectionLoading( state ),
 	tourState: getGuidedTourState( state ),
 	isValid: ( when ) => !! when( state ),
+	// TODO(mcsf): make it a cached selector:
 	lastAction: last( getActionLog( state ) ),
 } ), {
 	nextGuidedTourStep,

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { last } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,13 +13,10 @@ import AllTours from 'layout/guided-tours/config';
 import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
+import { getActionLog } from 'state/ui/action-log/selectors';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
 
 class GuidedTours extends Component {
-	constructor() {
-		super();
-	}
-
 	shouldComponentUpdate( nextProps ) {
 		return this.props.tourState !== nextProps.tourState;
 	}
@@ -59,6 +57,7 @@ class GuidedTours extends Component {
 					<AllTours
 							tourName={ tourName }
 							stepName={ stepName }
+							lastAction={ this.props.lastAction }
 							isValid={ this.props.isValid }
 							next={ this.next }
 							quit={ this.quit } />
@@ -71,6 +70,7 @@ class GuidedTours extends Component {
 export default connect( ( state ) => ( {
 	tourState: getGuidedTourState( state ),
 	isValid: ( when ) => !! when( state ),
+	lastAction: last( getActionLog( state ) ),
 } ), {
 	nextGuidedTourStep,
 	quitGuidedTour,

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { last } from 'lodash';
+import { defer, last } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,9 +23,11 @@ class GuidedTours extends Component {
 	}
 
 	next = ( tour, nextStepName ) => {
-		this.props.nextGuidedTourStep( {
-			stepName: nextStepName,
-			tour: tour,
+		defer( () => {
+			this.props.nextGuidedTourStep( {
+				stepName: nextStepName,
+				tour: tour,
+			} );
 		} );
 	}
 

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { defer, last } from 'lodash';
+import { defer } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ import AllTours from 'layout/guided-tours/config';
 import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
-import { getActionLog } from 'state/ui/action-log/selectors';
+import { getLastAction } from 'state/ui/action-log/selectors';
 import { getSectionName, isSectionLoading } from 'state/ui/selectors';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
 
@@ -77,8 +77,7 @@ export default connect( ( state ) => ( {
 	isSectionLoading: isSectionLoading( state ),
 	tourState: getGuidedTourState( state ),
 	isValid: ( when ) => !! when( state ),
-	// TODO(mcsf): make it a cached selector:
-	lastAction: last( getActionLog( state ) ),
+	lastAction: getLastAction( state ),
 } ), {
 	nextGuidedTourStep,
 	quitGuidedTour,

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -14,7 +14,7 @@ import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { getActionLog } from 'state/ui/action-log/selectors';
-import { isSectionLoading } from 'state/ui/selectors';
+import { getSectionName, isSectionLoading } from 'state/ui/selectors';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
 
 class GuidedTours extends Component {
@@ -58,6 +58,7 @@ class GuidedTours extends Component {
 				<div className="guided-tours">
 					<QueryPreferences />
 					<AllTours
+							sectionName={ this.props.sectionName }
 							shouldPause={ this.props.isSectionLoading }
 							tourName={ tourName }
 							stepName={ stepName }
@@ -72,6 +73,7 @@ class GuidedTours extends Component {
 }
 
 export default connect( ( state ) => ( {
+	sectionName: getSectionName( state ),
 	isSectionLoading: isSectionLoading( state ),
 	tourState: getGuidedTourState( state ),
 	isValid: ( when ) => !! when( state ),

--- a/client/state/ui/action-log/selectors.js
+++ b/client/state/ui/action-log/selectors.js
@@ -1,6 +1,16 @@
 /** @ssr-ready **/
 
 /**
+ * External dependencies
+ */
+import { last } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+
+/**
  * Returns a log of actions from certain types that have previously been
  * dispatched for the current user.
  *
@@ -14,3 +24,14 @@
 export function getActionLog( state ) {
 	return state.ui.actionLog;
 }
+
+/**
+ * Returns the last item from the action log.
+ *
+ * @param  {Object}   state      Global state tree
+ * @return {Object}              The matching dispatched action
+ */
+export const getLastAction = createSelector(
+	( state ) => last( state.ui.actionLog ),
+	( state ) => [ state.ui.actionLog ]
+);

--- a/client/state/ui/action-log/test/selectors.js
+++ b/client/state/ui/action-log/test/selectors.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getActionLog,
+	getLastAction,
 } from '../selectors';
 
 import {
@@ -16,7 +17,7 @@ import {
 } from 'state/action-types';
 
 describe( 'selectors', () => {
-	describe( 'actionLog', () => {
+	describe( 'getActionLog', () => {
 		it( 'should initially return one empty list', () => {
 			const log = getActionLog( {
 				ui: {
@@ -45,6 +46,30 @@ describe( 'selectors', () => {
 			} );
 
 			expect( log ).to.eql( actions );
+		} );
+	} );
+
+	describe( 'getLastAction', () => {
+		it( 'should return undefined for an empty action log', () => {
+			const action = getLastAction( {
+				ui: {
+					actionLog: [],
+				}
+			} );
+
+			expect( action ).to.be.undefined;
+		} );
+
+		it( 'should retrieve the last action from the action log', () => {
+			const navToMenus = { type: 'ROUTE_SET', path: '/menus', timestamp: 0 };
+			const navToDesign = { type: 'ROUTE_SET', path: '/design', timestamp: 1 };
+			const action = getLastAction( {
+				ui: {
+					actionLog: [ navToMenus, navToDesign ],
+				}
+			} );
+
+			expect( action ).to.equal( navToDesign );
 		} );
 	} );
 } );

--- a/client/state/ui/guided-tours/selectors.js
+++ b/client/state/ui/guided-tours/selectors.js
@@ -10,7 +10,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { ROUTE_SET } from 'state/action-types';
-import { isSectionLoading, getInitialQueryArguments } from 'state/ui/selectors';
+import { getInitialQueryArguments } from 'state/ui/selectors';
 import { getActionLog } from 'state/ui/action-log/selectors';
 import { getPreference } from 'state/preferences/selectors';
 import GuidedToursConfig from 'layout/guided-tours/config';
@@ -144,7 +144,7 @@ export const getGuidedTourState = createSelector(
 	state => {
 		const tourState = getRawGuidedTourState( state );
 		const tour = findEligibleTour( state );
-		const shouldReallyShow = !! tour;
+		const shouldShow = !! tour;
 
 		debug(
 			'tours: reached', getToursFromFeaturesReached( state ),
@@ -158,16 +158,11 @@ export const getGuidedTourState = createSelector(
 			};
 		}
 
-		const shouldShow = !! (
-			! isSectionLoading( state ) &&
-			shouldReallyShow
-		);
-
 		return {
 			...tourState,
 			tour,
 			shouldShow,
 		};
 	},
-	[ getRawGuidedTourState, isSectionLoading, getActionLog ]
+	[ getRawGuidedTourState, getActionLog ]
 );


### PR DESCRIPTION
Sometimes, a user just wants to navigate away from a Guided Tour without necessarily clicking the correct "Exit Tour" button. Still, we'd like to quit in those cases where user intent is reasonably clear.

This change quits a currently running tour in the following cases:

- The step has a "target" element that it points to or expects an interaction with, but the user navigates to a new route where the target isn't available anymore.
- The step waits for the user the click "Next", but the user navigates to a different route.

This doesn't work in all cases. We'd rather have false negatives (trouble quitting a tour without clicking the "Exit Tour" button) than any false positives (unintended quits).

This closes #5787 and #5861. 

### To do

- [x] Consuming `sections.js` to fix `pathToSection`; also, that method could be a standalone function, preferably somewhere reusable
- [x] Use a cached version of `compose( last, getActionLog )`
- [x] **Rebase**
- ~~[ ] Analytics, the bare minimum to collect automated quits~~ (_in a subsequent PR_)

### To test

- go to http://calypso.localhost:3000/?tour=main or https://calypso.live/?branch=add/guided-tours-blanket-exit-only&tour=main
- click on "My Sites"
- ensure the tour doesn't appear again
- go back to http://calypso.localhost:3000/?tour=main or https://calypso.live/?branch=add/guided-tours-blanket-exit-only&tour=main (with a proper new load or reload)
- click through the tour until the step that says "This shows your currently selected site's name and address. Click your site's name to continue."
- click on "Reader"
- ensure the tour doesn't appear again
- go back to http://calypso.localhost:3000/?tour=main or https://calypso.live/?branch=add/guided-tours-blanket-exit-only&tour=main (with a proper new load or reload)
- go through the tour normally, following all the instructions
- ensure the tour steps all work and you get to the step that says "That's it! Now that you know a few of the basics, feel free to wander around." at the end

Test live: https://calypso.live/?branch=add/guided-tours-blanket-exit-only