### PR TITLE
Reader author profile: link avatar, site link and author link to stream

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -12,6 +12,7 @@ import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import ReaderFollowButton from 'reader/follow-button';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
+import { getStreamUrl } from 'reader/route';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
@@ -34,12 +35,15 @@ const AuthorCompactProfile = React.createClass( {
 		const classes = classnames( 'author-compact-profile', {
 			'has-author-link': ! hasMatchingAuthorAndSiteNames
 		} );
+		const streamUrl = getStreamUrl( feedId, siteId );
 
 		return (
 			<div className={ classes }>
-				<Gravatar size={ 96 } user={ author } />
+				<a href={ streamUrl }>
+					<Gravatar size={ 96 } user={ author } />
+				</a>
 				{ ! hasMatchingAuthorAndSiteNames &&
-					<ReaderAuthorLink author={ author } siteUrl={ siteUrl }>{ author.name }</ReaderAuthorLink> }
+					<ReaderAuthorLink author={ author } siteUrl={ streamUrl }>{ author.name }</ReaderAuthorLink> }
 				{ siteName &&
 					<ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId }>
 						{ siteName }

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -61,7 +61,7 @@
 	}
 }
 
-.author-compact-profile .external-link,
+.author-compact-profile .reader-author-link,
 .author-compact-profile__site-link,
 .author-compact-profile__follow {
 	align-items: center;

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
 const ReaderAuthorLink = ( { author, post, siteUrl, children } ) => {
@@ -18,29 +17,26 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children } ) => {
 		}
 	};
 
-	let linkUrl = author.URL;
-	if ( ! linkUrl ) {
-		linkUrl = siteUrl;
+	if ( ! siteUrl ) {
+		siteUrl = author.URL;
 	}
 
 	// If we have neither author.URL or siteUrl, just return children
-	if ( ! linkUrl ) {
+	if ( ! siteUrl ) {
 		return children;
 	}
 
-	/* eslint-disable react/jsx-no-target-blank */
 	return (
-		<ExternalLink className="reader-author-link" href={ linkUrl } target="_blank" onClick={ recordAuthorClick }>
+		<a className="reader-author-link" href={ siteUrl } onClick={ recordAuthorClick }>
 			{ children }
-		</ExternalLink>
+		</a>
 	);
-	/* eslint-enable react/jsx-no-target-blank */
 };
 
 ReaderAuthorLink.propTypes = {
 	author: React.PropTypes.object.isRequired,
 	post: React.PropTypes.object, // for stats only,
-	siteUrl: React.PropTypes.string // used as fallback if author.URL is missing
+	siteUrl: React.PropTypes.string // used instead of author.URL if present
 };
 
 export default ReaderAuthorLink;


### PR DESCRIPTION
@fraying requested:

> In the fullpost sidebar, the links on the author name, gravatar, and site name should link to the site the post came from in the Reader.

This PR does just that.

Fixes #7897.

Test live: https://calypso.live/?branch=fix/reader/full-post-sidebar-links