### PR TITLE
Fix the plugin reviews tier rating links and ES6ify the PluginRatings component

### DIFF
--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -1,18 +1,14 @@
 /**
- * External depe;ndencies
+ * External dependencies
  */
 import React from 'react';
+
 /**
  * Internal dependencies
  */
 import ProgressBar from 'components/progress-bar';
 import Rating from 'components/rating';
 import analytics from 'lib/analytics';
-
-/**
- * Constants
- */
-const REVIEW_URL = 'https://wordpress.org/support/view/plugin-reviews/';
 
 module.exports = React.createClass( {
 	displayName: 'PluginRatings',
@@ -31,6 +27,10 @@ module.exports = React.createClass( {
 		return { barWidth: 88 };
 	},
 
+	buildReviewUrl: function( ratingTier ) {
+		return `https://wordpress.org/support/plugin/${ this.props.slug }/reviews/?filter=${ ratingTier }`;
+	},
+
 	renderPlaceholder: function() {
 		return (
 		<div className="plugin-ratings is-placeholder">
@@ -46,7 +46,7 @@ module.exports = React.createClass( {
 			<div className="plugin-ratings__rating-tier" key={ 'plugins-ratings__tier-' + ratingTier }>
 				<a className="plugin-ratings__rating-container" target="_blank" rel="noopener noreferrer"
 					onClick={ analytics.ga.recordEvent.bind( this, 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', this.props.slug ) }
-					href={ REVIEW_URL + this.props.slug }>
+					href={ this.buildReviewUrl( ratingTier ) }>
 					<span className="plugin-ratings__rating-tier-text"> { this.translate( '%(ratingTier)s stars', { args: { ratingTier: ratingTier } } ) } </span>
 					<span className="plugin_ratings__bar">
 						<ProgressBar value={ numberOfRatings }

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -28,7 +28,8 @@ export default React.createClass( {
 	},
 
 	buildReviewUrl( ratingTier ) {
-		return `https://wordpress.org/support/plugin/${ this.props.slug }/reviews/?filter=${ ratingTier }`;
+		const { slug } = this.props;
+		return `https://wordpress.org/support/plugin/${ slug }/reviews/?filter=${ ratingTier }`;
 	},
 
 	renderPlaceholder() {
@@ -43,23 +44,25 @@ export default React.createClass( {
 	},
 
 	renderRatingTier( ratingTier ) {
-		const numberOfRatings = ( this.props.ratings && this.props.ratings[ ratingTier ] ) ? this.props.ratings[ ratingTier ] : 0;
+		const { ratings, slug, numRatings } = this.props;
+		const numberOfRatings = ( ratings && ratings[ ratingTier ] ) ? ratings[ ratingTier ] : 0;
+
 		return (
 			<div className="plugin-ratings__rating-tier" key={ `plugins-ratings__tier-${ ratingTier }` }>
 				<a className="plugin-ratings__rating-container" target="_blank" rel="noopener noreferrer"
-					onClick={ analytics.ga.recordEvent( 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', this.props.slug ) }
+					onClick={ analytics.ga.recordEvent( 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', slug ) }
 					href={ this.buildReviewUrl( ratingTier ) }
 				>
 					<span className="plugin-ratings__rating-tier-text">
 						{
 							this.translate( '%(ratingTier)s stars', {
-								args: { ratingTier: ratingTier }
+								args: { ratingTier }
 							} )
 						}
 					</span>
 					<span className="plugin_ratings__bar">
 						<ProgressBar value={ numberOfRatings }
-							total={ this.props.numRatings }
+							total={ numRatings }
 							title={ this.translate( '%(numberOfRatings)s ratings', { args: { numberOfRatings } } ) }
 						/>
 					</span>
@@ -90,11 +93,13 @@ export default React.createClass( {
 	},
 
 	render() {
-		if ( this.props.placeholder ) {
+		const { placeholder, ratings, rating, numRatings } = this.props;
+
+		if ( placeholder ) {
 			return this.renderPlaceholder();
 		}
 
-		if ( ! this.props.ratings ) {
+		if ( ! ratings ) {
 			return null;
 		}
 
@@ -102,12 +107,12 @@ export default React.createClass( {
 		return (
 			<div className="plugin-ratings">
 				<div className="plugin-ratings__rating-stars">
-					<Rating rating={ this.props.rating } />
+					<Rating rating={ rating } />
 				</div>
 				<div className="plugin-ratings__rating-text">
 					{ this.translate( 'Based on %(ratingsNumber)s rating', 'Based on %(ratingsNumber)s ratings', {
-						count: this.props.numRatings,
-						args: { ratingsNumber: this.props.numRatings }
+						count: numRatings,
+						args: { ratingsNumber: numRatings }
 					} ) }
 				</div>
 				{ tierViews }

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -10,7 +10,7 @@ import ProgressBar from 'components/progress-bar';
 import Rating from 'components/rating';
 import analytics from 'lib/analytics';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'PluginRatings',
 
 	propTypes: {
@@ -18,48 +18,58 @@ module.exports = React.createClass( {
 		ratings: React.PropTypes.object,
 		downloaded: React.PropTypes.number,
 		slug: React.PropTypes.string,
-		numRatings: React.PropTypes.number,
+		numRatings: React.PropTypes.number
 	},
 
 	ratingTiers: [ 5, 4, 3, 2, 1 ],
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return { barWidth: 88 };
 	},
 
-	buildReviewUrl: function( ratingTier ) {
+	buildReviewUrl( ratingTier ) {
 		return `https://wordpress.org/support/plugin/${ this.props.slug }/reviews/?filter=${ ratingTier }`;
 	},
 
-	renderPlaceholder: function() {
+	renderPlaceholder() {
 		return (
-		<div className="plugin-ratings is-placeholder">
-			<div className="plugin-ratings__rating-stars"><Rating rating={ 0 } /></div>
-			<div className="plugin-ratings__rating-text">Based on</div>
-		</div>
+			<div className="plugin-ratings is-placeholder">
+				<div className="plugin-ratings__rating-stars">
+					<Rating rating={ 0 } />
+				</div>
+				<div className="plugin-ratings__rating-text">{ this.translate( 'Based on' ) }</div>
+			</div>
 		);
 	},
 
-	renderRatingTier: function( ratingTier ) {
-		var numberOfRatings = ( this.props.ratings && this.props.ratings[ ratingTier ] ) ? this.props.ratings[ ratingTier ] : 0;
+	renderRatingTier( ratingTier ) {
+		const numberOfRatings = ( this.props.ratings && this.props.ratings[ ratingTier ] ) ? this.props.ratings[ ratingTier ] : 0;
 		return (
-			<div className="plugin-ratings__rating-tier" key={ 'plugins-ratings__tier-' + ratingTier }>
+			<div className="plugin-ratings__rating-tier" key={ `plugins-ratings__tier-${ ratingTier }` }>
 				<a className="plugin-ratings__rating-container" target="_blank" rel="noopener noreferrer"
-					onClick={ analytics.ga.recordEvent.bind( this, 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', this.props.slug ) }
-					href={ this.buildReviewUrl( ratingTier ) }>
-					<span className="plugin-ratings__rating-tier-text"> { this.translate( '%(ratingTier)s stars', { args: { ratingTier: ratingTier } } ) } </span>
+					onClick={ analytics.ga.recordEvent( 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', this.props.slug ) }
+					href={ this.buildReviewUrl( ratingTier ) }
+				>
+					<span className="plugin-ratings__rating-tier-text">
+						{
+							this.translate( '%(ratingTier)s stars', {
+								args: { ratingTier: ratingTier }
+							} )
+						}
+					</span>
 					<span className="plugin_ratings__bar">
 						<ProgressBar value={ numberOfRatings }
 							total={ this.props.numRatings }
-							title={ this.translate( '%(numberOfRatings)s ratings', { args: { numberOfRatings } } ) } />
+							title={ this.translate( '%(numberOfRatings)s ratings', { args: { numberOfRatings } } ) }
+						/>
 					</span>
 				</a>
 			</div>
 		);
 	},
 
-	renderDownloaded: function() {
-		var downloaded = this.props.downloaded;
+	renderDownloaded() {
+		let downloaded = this.props.downloaded;
 		if ( downloaded > 100000 ) {
 			downloaded = this.numberFormat( Math.floor( downloaded / 10000 ) * 10000 ) + '+';
 		} else if ( downloaded > 10000 ) {
@@ -68,12 +78,18 @@ module.exports = React.createClass( {
 			downloaded = this.numberFormat( downloaded );
 		}
 
-		return <div className="plugin-ratings__downloads">{ this.translate( '%(installs)s downloads', { args: { installs: downloaded } } ) }</div>;
+		return (
+			<div className="plugin-ratings__downloads">
+				{
+					this.translate( '%(installs)s downloads', {
+						args: { installs: downloaded }
+					} )
+				}
+			</div>
+		);
 	},
 
-	render: function() {
-		var tierViews;
-
+	render() {
 		if ( this.props.placeholder ) {
 			return this.renderPlaceholder();
 		}
@@ -82,12 +98,12 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		tierViews = this.ratingTiers.map( function( tierLevel ) {
-			return this.renderRatingTier( tierLevel );
-		}, this );
+		const tierViews = this.ratingTiers.map( tierLevel => this.renderRatingTier( tierLevel ) );
 		return (
 			<div className="plugin-ratings">
-				<div className="plugin-ratings__rating-stars"><Rating rating={ this.props.rating } /></div>
+				<div className="plugin-ratings__rating-stars">
+					<Rating rating={ this.props.rating } />
+				</div>
 				<div className="plugin-ratings__rating-text">
 					{ this.translate( 'Based on %(ratingsNumber)s rating', 'Based on %(ratingsNumber)s ratings', {
 						count: this.props.numRatings,


### PR DESCRIPTION
### The issue

If you go to `/plugins/$pluginSlug/$siteSlug`, and click on any of the rating tier links, you will be directed to a 404 page. Note: `$pluginSlug` has to be the slug of a valid plugin installed on your site, and `$siteSlug` is the slug of a connected Jetpack site that has this plugin installed.

### What this PR does

* Fixes the URL of each rating tier link.
* Updates the links so they actually lead to the review page with the corresponding number of stars. 
* ES6ifies the `PluginRatings` component and improves code formatting.

### Testing

* Checkout this branch.
* Go to `/plugins/$pluginSlug/$siteSlug`.
* Click on all of the rating tier links and verify they work correctly, leading to the page with reviews with the corresponding number of stars.
* Verify there are no regressions caused by the ES6ification.

### Review

/cc @ryelle @oskosk 

Test live: https://calypso.live/?branch=update/plugin-ratings-review-url