### PR TITLE
Add Image Editor loading placeholders

### DIFF
--- a/assets/stylesheets/shared/mixins/_placeholder.scss
+++ b/assets/stylesheets/shared/mixins/_placeholder.scss
@@ -12,3 +12,13 @@
 		content: '\00a0';
 	}
 }
+
+@mixin placeholder-dark( $darken-percentage: 30% ) {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background-color: darken( $gray, $darken-percentage );
+	color: transparent;
+
+	&:after {
+		content: '\00a0';
+	}
+}

--- a/client/post-editor/media-modal/image-editor/_style.scss
+++ b/client/post-editor/media-modal/image-editor/_style.scss
@@ -46,7 +46,7 @@
 	z-index: z-index( '.dialog__backdrop', '.editor-media-modal-image-editor__canvas' );
 
 	&.is-placeholder {
-		@include placeholder();
+		@include placeholder-dark();
 	}
 }
 

--- a/client/post-editor/media-modal/image-editor/_style.scss
+++ b/client/post-editor/media-modal/image-editor/_style.scss
@@ -44,6 +44,10 @@
 	top: 50%;
 	left: 50%;
 	z-index: z-index( '.dialog__backdrop', '.editor-media-modal-image-editor__canvas' );
+
+	&.is-placeholder {
+		@include placeholder();
+	}
 }
 
 .editor-media-modal-image-editor__crop {

--- a/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
@@ -63,17 +63,7 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	},
 
 	componentWillReceiveProps( newProps ) {
-		if ( this.props.src !== newProps.src ) {
-			this.getImage( newProps.src );
-		}
-	},
-
-	componentDidMount() {
-		if ( ! this.props.src ) {
-			return;
-		}
-
-		this.getImage( this.props.src );
+		this.getImage( newProps.src );
 	},
 
 	getImage( url ) {
@@ -83,10 +73,6 @@ const MediaModalImageEditorCanvas = React.createClass( {
 		req.onload = () => {
 			const objectURL = window.URL.createObjectURL( new Blob( [ req.response ], { type: this.props.mimeType } ) );
 			this.initImage( objectURL );
-
-			this.setState( {
-				imageLoaded: true
-			} );
 		};
 		req.send();
 	},
@@ -105,6 +91,10 @@ const MediaModalImageEditorCanvas = React.createClass( {
 
 		this.drawImage();
 		this.updateCanvasPosition();
+
+		this.setState( {
+			imageLoaded: true
+		} );
 	},
 
 	componentDidUpdate() {
@@ -188,10 +178,6 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	},
 
 	renderCrop() {
-		if ( ! this.props.src ) {
-			return;
-		}
-
 		return ( <Crop /> );
 	},
 

--- a/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import noop from 'lodash/noop';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -36,6 +37,12 @@ const MediaModalImageEditorCanvas = React.createClass( {
 			heightRatio: React.PropTypes.number,
 		} ),
 		setImageEditorCropBounds: React.PropTypes.func
+	},
+
+	getInitialState() {
+		return {
+			imageLoaded: false
+		};
 	},
 
 	getDefaultProps() {
@@ -76,6 +83,10 @@ const MediaModalImageEditorCanvas = React.createClass( {
 		req.onload = () => {
 			const objectURL = window.URL.createObjectURL( new Blob( [ req.response ], { type: this.props.mimeType } ) );
 			this.initImage( objectURL );
+
+			this.setState( {
+				imageLoaded: true
+			} );
 		};
 		req.send();
 	},
@@ -194,14 +205,20 @@ const MediaModalImageEditorCanvas = React.createClass( {
 			maxHeight: ( 85 / this.props.crop.heightRatio ) + '%'
 		};
 
+		const { imageLoaded } = this.state;
+
+		const canvasClasses = classNames( 'editor-media-modal-image-editor__canvas', {
+			'is-placeholder': ! imageLoaded
+		} );
+
 		return (
 			<div className="editor-media-modal-image-editor__canvas-container">
-				{ this.renderCrop() }
+				{ imageLoaded && this.renderCrop() }
 				<canvas
 					ref="canvas"
 					style={ canvasStyle }
 					onMouseDown={ this.preventDrag }
-					className="editor-media-modal-image-editor__canvas" />
+					className={ canvasClasses } />
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes #7376. Adds a simple placeholder over the `<canvas>` until an image is not fully loaded. Removes previously shown image upon editing a new image as well.

/cc @gwwar 

Test live: https://calypso.live/?branch=add/image-editor-loading-placeholders