### PR TITLE
SiteSelector: don't show hidden sites message when searching.

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -282,7 +282,7 @@ const SiteSelector = React.createClass( {
 				<div className="site-selector__sites" ref="selector">
 					{ this.renderAllSites() }
 					{ this.renderSites() }
-					{ hiddenSitesCount > 0 &&
+					{ hiddenSitesCount > 0 && ! this.state.search &&
 						<span className="site-selector__hidden-sites-message">
 							{ this.translate(
 								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',


### PR DESCRIPTION
Do not display the message when searching:

![image](https://cloud.githubusercontent.com/assets/548849/18315773/7b20835c-7518-11e6-9737-389f4aee96f0.png)


Test live: https://calypso.live/?branch=update/hidden-site-notice-when-searching