### PR TITLE
Reader: Catch invalid srcset attributes and remove them

### DIFF
--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -66,7 +66,7 @@ describe( 'index', function() {
 	} );
 
 	it( 'should return a copy of what it was passed', function( done ) {
-		var post = {};
+		const post = {};
 		normalizer( post, [ identifyTransform ], function( err, normalized ) {
 			assert.notStrictEqual( normalized, post );
 			done( err );
@@ -74,7 +74,7 @@ describe( 'index', function() {
 	} );
 
 	it( 'should leave an empty object alone', function( done ) {
-		var post = {};
+		const post = {};
 		normalizer( post, allTransforms, function( err, normalized ) {
 			assert.deepEqual( normalized, post );
 			done( err );
@@ -82,7 +82,7 @@ describe( 'index', function() {
 	} );
 
 	it( 'should support async transforms', function( done ) {
-		var post = {
+		const post = {
 			title: 'title'
 		};
 		normalizer( post, [ asyncTransform, asyncTransform ], function( err, normalized ) {
@@ -118,7 +118,7 @@ describe( 'index', function() {
 	} );
 
 	it( 'can decode entities', function( done ) {
-		var post = {
+		const post = {
 			title: 'title <i>&amp; bar</i>',
 			excerpt: 'excerpt &amp; bar',
 			author: {
@@ -139,7 +139,7 @@ describe( 'index', function() {
 	} );
 
 	it( 'can prevent widows', function( done ) {
-		var post = {
+		const post = {
 			excerpt: 'this is a longer excerpt bar'
 		};
 
@@ -152,7 +152,7 @@ describe( 'index', function() {
 	} );
 
 	it( 'can prevent widows in empty strings', function( done ) {
-		var post = {
+		const post = {
 			excerpt: '   '
 		};
 
@@ -165,7 +165,7 @@ describe( 'index', function() {
 	} );
 
 	it( 'can remove html tags', function( done ) {
-		var post = {
+		const post = {
 			title: 'title <b>bar</b>',
 			excerpt: 'excerpt <b style="foo">bar</style>',
 			author: {
@@ -208,7 +208,7 @@ describe( 'index', function() {
 
 	describe( 'safeImageProperties', function() {
 		it( 'can make image properties safe', function( done ) {
-			var post = {
+			const post = {
 				author: {
 					avatar_URL: 'http://example.com/me.jpg'
 				},
@@ -246,7 +246,7 @@ describe( 'index', function() {
 		} );
 
 		it( 'will ignore featured_media that is not of type "image"', function( done ) {
-			var post = {
+			const post = {
 				featured_media: {
 					uri: 'http://example.com/media.jpg'
 				}
@@ -260,7 +260,7 @@ describe( 'index', function() {
 
 	describe( 'pickPrimaryTag', function() {
 		it( 'can pick the primary tag by taking the tag with the highest post_count as the primary', function( done ) {
-			var post = {
+			const post = {
 				tags: {
 					first: {
 						name: 'first',
@@ -280,7 +280,7 @@ describe( 'index', function() {
 		} );
 
 		it( 'can pick the primary tag by taking the first tag as primary if there is a tie', function( done ) {
-			var post = {
+			const post = {
 				tags: {
 					first: {
 						name: 'first',
@@ -330,7 +330,7 @@ describe( 'index', function() {
 
 	describe( 'the content normalizer (withContentDOM)', function() {
 		it( 'should not call nested transforms if content is blank', function( done ) {
-			var post = {
+			const post = {
 				content: ''
 			};
 			normalizer(
@@ -475,6 +475,18 @@ describe( 'index', function() {
 				}
 			);
 		} );
+
+		it( 'removes invalid srcsets', function( done ) {
+			normalizer(
+				{
+					content: '<img src="http://example.com/example.jpg" srcset="http://example.com/example-100-and-a-half.jpg 100.5w, http://example.com/example-600.jpg 600w">'
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages() ] ) ], function( err, normalized ) {
+					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE">' );
+					done( err );
+				}
+			);
+		} );
 	} );
 
 	describe( 'content.wordCountAndReadingTime', function() {
@@ -532,7 +544,7 @@ describe( 'index', function() {
 	describe( 'waitForImagesToLoad', function() {
 		it.skip( 'should fire when all images have loaded or errored', function( done ) {
 			// these need to be objects that mimic the Image object
-			var completeImage = {
+			let completeImage = {
 					complete: true,
 					src: 'http://example.com/one'
 				},
@@ -568,7 +580,7 @@ describe( 'index', function() {
 		} );
 
 		it.skip( 'should dedupe the images to check', function( done ) {
-			var first = {
+			let first = {
 					complete: true,
 					src: 'http://example.com/one'
 				},
@@ -597,7 +609,7 @@ describe( 'index', function() {
 
 	describe( 'canonical image picker', function() {
 		it( 'can pick the canonical image from images', function( done ) {
-			var postRunThroughWaitForImagesToLoad = {
+			const postRunThroughWaitForImagesToLoad = {
 				images: [
 					null, // null reference
 					{
@@ -759,7 +771,7 @@ describe( 'index', function() {
 					content: '<iframe width="100" height="50" src="https://youtube.com"></iframe>'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectEmbeds ] ) ], function( err, normalized ) {
-					var embed;
+					let embed;
 					assert.lengthOf( normalized.content_embeds, 1 );
 
 					embed = normalized.content_embeds[ 0 ];
@@ -779,7 +791,7 @@ describe( 'index', function() {
 					content: '<iframe width="100" height="50" src="https://embed.spotify.com"></iframe>'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectEmbeds ] ) ], function( err, normalized ) {
-					var embed;
+					let embed;
 					assert.lengthOf( normalized.content_embeds, 1 );
 
 					embed = normalized.content_embeds[ 0 ];


### PR DESCRIPTION
Fixes a leaked exception that kills the reader. Try http://calypso.localhost:3000/read/feeds/45663806 for a test.

Test live: https://calypso.live/?branch=fix/reader/catch-bad-srcsets