### PR TITLE
Ad Tracking: Remove one of the One by AOL tracking pixels

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -33,7 +33,6 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 	CRITEO_TRACKING_SCRIPT_URL = 'https://static.criteo.net/js/ld/ld.js',
 	GOOGLE_CONVERSION_ID = config( 'google_adwords_conversion_id' ),
 	ONE_BY_AOL_CONVERSION_PIXEL_URL = 'https://secure.ace-tag.advertising.com/action/type=132958/bins=1/rich=0/Mnum=1516/',
-	ONE_BY_AOL_LEADBACK_PIXEL_URL = 'https://secure.leadback.advertising.com/adcedge/lb?site=695501&srvc=1&betr=60802=1827432[8760]',
 	ONE_BY_AOL_AUDIENCE_BUILDING_PIXEL_URL = 'https://secure.leadback.advertising.com/adcedge/lb' +
 		'?site=695501&betr=sslbet_1472760417=[+]ssprlb_1472760417[720]|sslbet_1472760452=[+]ssprlb_1472760452[8760]',
 	TRACKING_IDS = {
@@ -183,7 +182,6 @@ function retarget() {
 	} );
 
 	// One by AOL
-	new Image().src = ONE_BY_AOL_LEADBACK_PIXEL_URL;
 	new Image().src = ONE_BY_AOL_AUDIENCE_BUILDING_PIXEL_URL;
 }
 


### PR DESCRIPTION
We recently added two One by AOL tracking pixels to Calypso in #7848.

After further discussions with AOL, one of the pixels is no longer needed:

Me:

> Which pages would you recommend placing this pixel on?
>
> https://secure.leadback.advertising.com/adcedge/lb?site=695501&srvc=1&betr=60802=1827432[8760]

AOL:

> That pixel does not need to be placed on any pages since we're piggybacking it off the conversion pixel

Because of the simple nature of this PR, I'm skipping a review.

Test live: https://calypso.live/?branch=update/one-by-aol-pixel