### PR TITLE
Reader: fix trackbacks appearance in new full post block

### DIFF
--- a/client/blocks/comments/post-trackback.jsx
+++ b/client/blocks/comments/post-trackback.jsx
@@ -27,14 +27,14 @@ export default class PostTrackback extends React.Component {
 					</div>
 
 					{ comment.author.URL
-						? <a href={ comment.author.URL } target="_blank" rel="noopener noreferrer" className="comments__comment-username">{ unescapedAuthorName }<Gridicon icon="external" /></a>
+						? <a href={ comment.author.URL } target="_blank" rel="noopener noreferrer" className="comments__comment-username">{ unescapedAuthorName }</a>
 						: <strong className="comments__comment-username">{ unescapedAuthorName }</strong> }
 
-					<small className="comments__comment-timestamp">
+					<div className="comments__comment-timestamp">
 						<a href={ comment.URL }>
 							<PostTime date={ comment.date } />
 						</a>
-					</small>
+					</div>
 				</div>
 
 			</li>

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -191,7 +191,7 @@
 
 .comments__comment-trackbackicon {
 	position: absolute;
-		top: 1px;
+		top: 12px;
 		left: 8px;
 	border-radius: 50%;
 	background-color: $gray-light;


### PR DESCRIPTION
Fixes #7882.

Before:

![1c3cda38-741f-11e6-9812-556c8cad9097](https://cloud.githubusercontent.com/assets/17325/18316529/e2e9d778-7512-11e6-9f79-b38cd2204a68.png)

After:

![screen shot 2016-09-07 at 15 50 44](https://cloud.githubusercontent.com/assets/17325/18316540/ed130e90-7512-11e6-808f-7035d18668ec.png)



Test live: https://calypso.live/?branch=fix/reader/new-full-post-trackbacks-appearance