### PR TITLE
Ad Tracking: Add Pandora pixel and refactor tracking logic

### DIFF
--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -93,12 +93,7 @@ var TransactionStepsMixin = {
 					// Makes sure free trials are not recorded as purchases in ad trackers since they are products with
 					// zero-value cost and would thus lead to a wrong computation of conversions
 					if ( ! cartItems.hasFreeTrial( cartValue ) ) {
-						cartValue.products.forEach( product => {
-							adTracking.recordPurchase( product, step.data.receipt_id );
-						} );
-						adTracking.recordOrderInAtlas( cartValue, step.data.receipt_id );
-						adTracking.recordOrderInCriteo( cartValue, step.data.receipt_id );
-						adTracking.recordConversionInOneByAOL();
+						adTracking.recordOrder( cartValue, step.data.receipt_id );
 					}
 
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {


### PR DESCRIPTION
This PR adds the Pandora conversion pixel to Calypso.

From an email exchange with them:

> Pixel code for event 2:
>
> &lt;img src="https://data.adxcel-ec2.com/pixel/?ad_log=referer&action=purchase&pixid=7efc5994-458b-494f-94b3-31862eee9e26" width="1" height="1" border="0"&gt;

To test:

1) Set `ad-tracking` to `true` in `development.json`
2) Make a purchase, verify that a request is made to the pixel URL above:

![screen shot 2016-09-07 at 11 48 31 am](https://cloud.githubusercontent.com/assets/44436/18318792/0c21585e-74f1-11e6-91ae-3458c6aea491.png)

3) This PR also refactors the code that tracks purchase conversions. Previously we were calling each service directly from `transaction-steps-mixin.jsx`, but this was getting unwieldy because we've added a lot of tracking scripts recently. Now it calls a single `recordOrder` method which takes care of everything from the ad tracking module. To verify that everything is still working well, search the network logs for the following and verify requests are still being made:

* Atlas: `ad.atdmt.com`
* AdWords: `googleadservices.com`
* Bing: `bat.bing.com`
* Criteo: `widget.criteo.com/event`
* Facebook: `facebook.com/tr`
* One by AOL: `advertising.com`

Test live: https://calypso.live/?branch=add/pandora-tracking-pixel