### PR TITLE
Components: fix spelling of DismissibleCard

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -13,7 +13,7 @@
 @import 'blocks/author-selector/style';
 @import 'blocks/comment-button/style';
 @import 'blocks/comments/style';
-@import 'blocks/dismissable-card/style';
+@import 'blocks/dismissible-card/style';
 @import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';

--- a/client/blocks/dismissible-card/README.md
+++ b/client/blocks/dismissible-card/README.md
@@ -1,4 +1,4 @@
-Dismissable Card
+Dismissible Card
 =========
 This is a card component that can be dismissed for a single page load or be hidden
 via user preference.
@@ -6,14 +6,14 @@ via user preference.
 #### How to use:
 
 ```js
-import DismissableCard from 'blocks/dismissable-card';
+import DismissibleCard from 'blocks/dismissible-card';
 
 render: function() {
   return (
     <div className="your-stuff">
-      <DismissableCard preferenceName="my-unique-preference-name">
+      <DismissibleCard preferenceName="my-unique-preference-name">
         <span>Your stuff in a Card</span>
-      </DismissableCard>
+      </DismissibleCard>
     </div>
   );
 }
@@ -52,7 +52,7 @@ This function will fire when a user clicks on the cross icon
 </table>
 
 The user preference name that we store a boolean against. 
-Note that we prefix this value with 'dismissable-card-' to avoid namespace collisions.
+Note that we prefix this value with 'dismissible-card-' to avoid namespace collisions.
 
 ### `temporary`
 

--- a/client/blocks/dismissible-card/docs/example.jsx
+++ b/client/blocks/dismissible-card/docs/example.jsx
@@ -10,35 +10,35 @@ import { partial } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
-import DismissableCard from '../';
+import DismissibleCard from '../';
 import { savePreference } from 'state/preferences/actions';
 
-function DismissableCardExample( { clearPreference } ) {
+function DismissibleCardExample( { clearPreference } ) {
 	return (
 		<div className="docs__design-assets-group">
 			<h2>
-				<a href="/devdocs/blocks/dismissable-card">Dismissable Card</a>
+				<a href="/devdocs/blocks/dismissible-card">Dismissible Card</a>
 			</h2>
-			<DismissableCard
+			<DismissibleCard
 				preferenceName="example-local"
 				temporary>
 				<span>I will be dismissed for a page load</span>
-			</DismissableCard>
-			<DismissableCard
+			</DismissibleCard>
+			<DismissibleCard
 				preferenceName="example"
 			>
 				<span>I can be dismissed forever!</span>
-			</DismissableCard>
+			</DismissibleCard>
 			<Button onClick={ clearPreference }>Reset Dismiss Preference</Button>
 		</div>
 	);
 }
 
-const ConnectedDismissableCardExample = connect( 
+const ConnectedDismissibleCardExample = connect(
 	null,
-	{ clearPreference: partial( savePreference, 'dismissable-card-example', null ) }
-)( DismissableCardExample );
+	{ clearPreference: partial( savePreference, 'dismissible-card-example', null ) }
+)( DismissibleCardExample );
 
-ConnectedDismissableCardExample.displayName = 'DismissableCard';
+ConnectedDismissibleCardExample.displayName = 'DismissibleCard';
 
-export default ConnectedDismissableCardExample;
+export default ConnectedDismissibleCardExample;

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -15,9 +15,9 @@ import QueryPreferences from 'components/data/query-preferences';
 import { savePreference, setPreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 
-const PREFERENCE_PREFIX = 'dismissable-card-';
+const PREFERENCE_PREFIX = 'dismissible-card-';
 
-class DismissableCard extends Component {
+class DismissibleCard extends Component {
 
 	static propTypes = {
 		className: PropTypes.string,
@@ -44,7 +44,7 @@ class DismissableCard extends Component {
 				<QueryPreferences />
 				<Gridicon
 					icon="cross"
-					className="dismissable-card__close-icon"
+					className="dismissible-card__close-icon"
 					onClick={ flow( onClick, dismissCard ) }
 				/>
 				{ this.props.children }
@@ -69,5 +69,5 @@ export default connect(
 			return savePreference( preference, true );
 		}
 	}, dispatch )
-)( DismissableCard );
+)( DismissibleCard );
 

--- a/client/blocks/dismissible-card/style.scss
+++ b/client/blocks/dismissible-card/style.scss
@@ -1,4 +1,4 @@
-.dismissable-card__close-icon {
+.dismissible-card__close-icon {
 	position: absolute;
 	top: 16px;
 	right: 16px;

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -40,7 +40,7 @@ import RelatedPostCard from 'blocks/reader-related-card/docs/example';
 import SearchPostCard from 'blocks/reader-search-card/docs/example';
 import PlanPrice from 'my-sites/plan-price/docs/example';
 import PlanThankYouCard from 'blocks/plan-thank-you-card/docs/example';
-import DismissableCard from 'blocks/dismissable-card/docs/example';
+import DismissibleCard from 'blocks/dismissible-card/docs/example';
 import PostEditButton from 'blocks/post-edit-button/docs/example';
 
 export default React.createClass( {
@@ -104,7 +104,7 @@ export default React.createClass( {
 					<AuthorCompactProfile />
 					<PlanPrice />
 					<PlanThankYouCard />
-					<DismissableCard />
+					<DismissibleCard />
 				</Collection>
 			</div>
 		);

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -3,7 +3,7 @@
 export const remoteValuesSchema = {
 	type: [ 'null', 'object' ],
 	patternProperties: {
-		'^dismissable-card-.+$': {
+		'^dismissible-card-.+$': {
 			type: 'boolean'
 		}
 	},


### PR DESCRIPTION
Fixes spelling of new component added in #7797

## Testing Instructions:
- Navigate to http://calypso.localhost:3000/devdocs/blocks/dismissible-card
- You can dismiss both cards
- Refreshing the page will render only the top card
- Dismissible is spelled with an `i` vs `a`
- No other functional changes since there are no usages yet in Calypso

cc @lamosty 

Test live: https://calypso.live/?branch=fix/dismissible-card