### PR TITLE
PostTypes: Always use latest taxonomies from API response

### DIFF
--- a/client/state/post-types/taxonomies/reducer.js
+++ b/client/state/post-types/taxonomies/reducer.js
@@ -58,7 +58,7 @@ export function requesting( state = {}, action ) {
 export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case POST_TYPES_TAXONOMIES_RECEIVE:
-			return merge( {}, state, {
+			return Object.assign( {}, state, {
 				[ action.siteId ]: {
 					[ action.postType ]: keyBy( action.taxonomies, 'name' )
 				}

--- a/client/state/post-types/taxonomies/test/reducer.js
+++ b/client/state/post-types/taxonomies/test/reducer.js
@@ -217,6 +217,30 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should replace state with latest payload', () => {
+			const state = items( undefined, {
+				type: POST_TYPES_TAXONOMIES_RECEIVE,
+				siteId: 2916284,
+				postType: 'page',
+				taxonomies: [
+					{ name: 'post_tag', label: 'Tags' }
+				]
+			} );
+
+			const updatedState = items( state, {
+				type: POST_TYPES_TAXONOMIES_RECEIVE,
+				siteId: 2916284,
+				postType: 'page',
+				taxonomies: []
+			} );
+
+			expect( updatedState ).to.eql( {
+				2916284: {
+					page: {}
+				}
+			} );
+		} );
+
 		it( 'should persist state', () => {
 			const original = deepFreeze( {
 				2916284: {


### PR DESCRIPTION
This branch seeks to resolve a bug I encountered while working on #7849 - the current reducer logic for `PostTypes.taxonomies` utilizes `_.merge` and as such accumulates post type taxonomies if a site's theme switches.  The bug I noticed was a site was showing post tags in the editor for a page when the theme did not support tags on pages.

You can see the issue on production by taking the following steps:

1. Set a site's theme to use Sketch, which allows `post_tag`s on pages
2. Open up a page in the editor for the site, verify that the Tags accordion shows
3. Change the theme for the site to a theme that does not support Tags - like Twentyfifteen
4. Open up the same page in the editor and you will see that the tags accordion is still shown
5. You can manually clear out the state via `indexedDB.deleteDatabase('calypso');`  refresh and see that post tags are no longer shown

__To Test the fix__
- Do the same steps as above, but verify at step 4 that the tags accordion is no longer shown
- Ensure the tests pass `npm run test-client client/state/post-types`