### PR TITLE
Editor: Contact Form: Add hover text to Edit button

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -90,7 +90,10 @@ var FoldableCard = React.createClass( {
 			const iconSize = 24;
 			const screenReaderText = this.props.screenReaderText || this.translate( 'More' );
 			return (
-				<button disabled={ this.props.disabled } className="foldable-card__action foldable-card__expand" onClick={ clickAction }>
+				<button
+					disabled={ this.props.disabled }
+					className="foldable-card__action foldable-card__expand"
+					onClick={ clickAction }>
 					<span className="screen-reader-text">{ screenReaderText }</span>
 					<Gridicon icon={ this.props.icon } size={ iconSize } />
 				</button>

--- a/client/components/tinymce/plugins/contact-form/dialog/field-edit-button.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field-edit-button.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import Popover from 'components/popover';
+
+class ContactFormDialogFieldEditButton extends PureComponent {
+	static propTypes = {
+		expanded: PropTypes.bool.isRequired
+	};
+
+	constructor() {
+		super( ...arguments );
+		this.state = { showTooltip: false };
+		this.handleMouseEnter = this.handleMouseEnter.bind( this );
+		this.handleMouseLeave = this.handleMouseLeave.bind( this );
+	}
+
+	handleMouseEnter() {
+		this.setState( { showTooltip: true } );
+	}
+
+	handleMouseLeave() {
+		this.setState( { showTooltip: false } );
+	}
+
+	render() {
+		const { expanded, translate } = this.props;
+		const classes = classNames( 'editor-contact-form-modal-field__edit', {
+			'is-expanded': expanded
+		} );
+
+		return (
+			<div className="editor-contact-form-modal-field__edit-wrapper foldable-card__expand" >
+				<Button
+					className="editor-contact-form-modal-field__edit-wrapper-button"
+					ref="editField"
+					borderless
+					onMouseEnter={ this.handleMouseEnter }
+					onMouseLeave={ this.handleMouseLeave }
+				>
+						<Gridicon icon="pencil" className={ classes } />
+				</Button>
+				<Popover
+					isVisible={ this.state.showTooltip }
+					context={ this.refs && this.refs.editField }
+					onClose={ noop }
+					position="bottom"
+					className="popover tooltip is-dialog-visible"
+				>
+						{ translate( 'Edit Field', { context: 'button tooltip' } ) }
+				</Popover>
+			</div>
+		);
+	}
+}
+
+export default localize( ContactFormDialogFieldEditButton );

--- a/client/components/tinymce/plugins/contact-form/dialog/field.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field.jsx
@@ -20,6 +20,7 @@ import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import TokenField from 'components/token-field';
 import FieldRemoveButton from './field-remove-button';
+import FieldEditButton from './field-edit-button';
 import getLabel from './locales';
 
 /**
@@ -57,8 +58,15 @@ export default React.createClass( {
 				<FormLabel>{ this.translate( 'Options' ) }</FormLabel>
 				<TokenField
 					value={ options }
-					onChange={ tokens => this.props.onUpdate( { options: tokens.join() } ) }/>
-				{ optionsValidationError && <FormTextValidation isError={ true } text={ this.translate( 'Options can not be empty.' ) } /> }
+					onChange={ tokens => this.props.onUpdate( { options: tokens.join() } ) }
+				/>
+				{
+					optionsValidationError &&
+						<FormTextValidation
+							isError={ true }
+							text={ this.translate( 'Options can not be empty.' ) }
+						/>
+				}
 				<FormSettingExplanation>Insert an option and press enter.</FormSettingExplanation>
 			</FormFieldset>
 		);
@@ -66,6 +74,14 @@ export default React.createClass( {
 
 	onLabelChange( event ) {
 		this.props.onUpdate( { label: event.target.value } );
+	},
+
+	handleCardOpen() {
+		this.props.onUpdate( { isExpanded: true } );
+	},
+
+	handleCardClose() {
+		this.props.onUpdate( { isExpanded: false } );
 	},
 
 	render() {
@@ -77,10 +93,11 @@ export default React.createClass( {
 				header={ <FieldHeader { ...omit( this.props, [ 'onUpdate' ] ) } /> }
 				summary={ remove }
 				expandedSummary={ remove }
-				icon="pencil"
 				expanded={ this.props.isExpanded }
-				onOpen={ () => this.props.onUpdate( { isExpanded: true } ) }
-				onClose={ () => this.props.onUpdate( { isExpanded: false } ) }>
+				onClose={ this.handleCardClose }
+				onOpen={ this.handleCardOpen }
+				actionButton={ <FieldEditButton expanded={ false } /> }
+				actionButtonExpanded={ <FieldEditButton expanded={ true } /> }>
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Field Label' ) }</FormLabel>
 					<FormTextInput value={ this.props.label } onChange={ this.onLabelChange } isError={ fielLabelValidationError } />

--- a/client/components/tinymce/plugins/contact-form/style.scss
+++ b/client/components/tinymce/plugins/contact-form/style.scss
@@ -78,3 +78,22 @@
 		color: $orange-fire;
 	}
 }
+
+.editor-contact-form-modal-field__edit-wrapper {
+	height: 100%;
+}
+
+.editor-contact-form-modal-field__edit-wrapper-button {
+	width: 100%;
+	margin-top: 15px;
+	margin-bottom: 20px;
+}
+
+.editor-contact-form-modal-field__edit-wrapper.foldable-card__expand .editor-contact-form-modal-field__edit {
+	width: 100%;
+	padding-bottom: 6px;
+
+	&.is-expanded {
+		transform: rotate(0);
+	}
+}


### PR DESCRIPTION
Hi,

I fixed the bug #4116 . I came up with 4 solutions, but decided to use the following one. 
I wrapped the `<Gridicon>` component in a new `<div>` and styled the `<div>` with paddings. Exactly like the remove button located in 'components/tinymce/plugins/contact-form/dialog/field-remove-button.jsx' which is on the left side of edit button. 
If there wouldn't be paddings, the hover text would appear not in the same line as the hover text for remove button. I added a Popover component to the edit button. If there would be problem with ES6 import which I added, I can rewrite it to es5 or the others rewrite to es6.