### PR TITLE
State: add isPlanDiscounted and getPlanRawPrice selectors

### DIFF
--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -77,7 +77,7 @@ export const getSitePlan = createSelector(
  * @param  {String}   productSlug   the plan product slug
  * @return {?Boolean}              true if a plan has a discount
  */
-export function isPlanDiscounted(
+export function isSitePlanDiscounted(
 	state,
 	siteId,
 	productSlug
@@ -108,7 +108,7 @@ export function getPlanDiscountedRawPrice(
 ) {
 	const plan = getSitePlan( state, siteId, productSlug );
 
-	if ( get( plan, 'rawPrice', -1 ) < 0 || ! isPlanDiscounted( state, siteId, productSlug ) ) {
+	if ( get( plan, 'rawPrice', -1 ) < 0 || ! isSitePlanDiscounted( state, siteId, productSlug ) ) {
 		return null;
 	}
 
@@ -126,7 +126,7 @@ export function getPlanDiscountedRawPrice(
  * @param  {Boolean} isMonthly     if true, returns monthly price
  * @return {Number}                plan raw price
  */
-export function getPlanRawPrice(
+export function getSitePlanRawPrice(
 	state,
 	siteId,
 	productSlug,
@@ -161,7 +161,7 @@ export function getPlanRawDiscount(
 ) {
 	const plan = getSitePlan( state, siteId, productSlug );
 
-	if ( ! isPlanDiscounted( state, siteId, productSlug ) ) {
+	if ( ! isSitePlanDiscounted( state, siteId, productSlug ) ) {
 		return null;
 	}
 

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -8,14 +8,14 @@ import { expect } from 'chai';
  */
 import {
 	getSitePlan,
-	getPlanRawPrice,
+	getSitePlanRawPrice,
 	getPlanDiscountedRawPrice,
 	getPlanRawDiscount,
 	getPlansBySite,
 	getPlansBySiteId,
 	hasDomainCredit,
 	isRequestingSitePlans,
-	isPlanDiscounted
+	isSitePlanDiscounted
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -171,8 +171,8 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = getPlanRawPrice( state, 77203074, 'bronze' );
-			expect( discountPrice ).to.equal( 199 );
+			const rawPrice = getSitePlanRawPrice( state, 77203074, 'bronze' );
+			expect( rawPrice ).to.equal( 199 );
 		} );
 		it( 'should return a monthly price', () => {
 			const plans = {
@@ -200,8 +200,8 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = getPlanRawPrice( state, 77203074, 'bronze', { isMonthly: true } );
-			expect( discountPrice ).to.equal( 16.58 );
+			const rawPrice = getSitePlanRawPrice( state, 77203074, 'bronze', { isMonthly: true } );
+			expect( rawPrice ).to.equal( 16.58 );
 		} );
 		it( 'should return raw price, if no discount is available', () => {
 			const plans = {
@@ -229,8 +229,8 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = getPlanRawPrice( state, 77203074, 'silver', { isMonthly: false } );
-			expect( discountPrice ).to.equal( 199 );
+			const rawPrice = getSitePlanRawPrice( state, 77203074, 'silver', { isMonthly: false } );
+			expect( rawPrice ).to.equal( 199 );
 		} );
 	} );
 	describe( '#getPlanDiscountedRawPrice()', () => {
@@ -498,7 +498,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = isPlanDiscounted( state, 77203074, 'silver' );
+			const discountPrice = isSitePlanDiscounted( state, 77203074, 'silver' );
 			expect( discountPrice ).to.equal( false );
 		} );
 		it( 'should return true, if discount is available', () => {
@@ -527,8 +527,8 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = isPlanDiscounted( state, 77203074, 'bronze' );
-			expect( discountPrice ).to.equal( true );
+			const isDiscounted = isSitePlanDiscounted( state, 77203074, 'bronze' );
+			expect( isDiscounted ).to.equal( true );
 		} );
 		it( 'should return null, if plan is unknown', () => {
 			const plans = {
@@ -556,8 +556,8 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const discountPrice = isPlanDiscounted( state, 77203074, 'diamond' );
-			expect( discountPrice ).to.equal( null );
+			const isDiscounted = isSitePlanDiscounted( state, 77203074, 'diamond' );
+			expect( isDiscounted ).to.equal( null );
 		} );
 	} );
 } );

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -8,12 +8,14 @@ import { expect } from 'chai';
  */
 import {
 	getSitePlan,
+	getPlanRawPrice,
 	getPlanDiscountedRawPrice,
 	getPlanRawDiscount,
 	getPlansBySite,
 	getPlansBySiteId,
 	hasDomainCredit,
-	isRequestingSitePlans
+	isRequestingSitePlans,
+	isPlanDiscounted
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -140,6 +142,95 @@ describe( 'selectors', () => {
 			};
 			const plan = getSitePlan( state, 77203074, 'gold' );
 			expect( plan ).to.eql( null );
+		} );
+	} );
+	describe( '#getPlanRawPrice()', () => {
+		it( 'should return a plan price', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+			const discountPrice = getPlanRawPrice( state, 77203074, 'bronze' );
+			expect( discountPrice ).to.equal( 199 );
+		} );
+		it( 'should return a monthly price', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+			const discountPrice = getPlanRawPrice( state, 77203074, 'bronze', { isMonthly: true } );
+			expect( discountPrice ).to.equal( 16.58 );
+		} );
+		it( 'should return raw price, if no discount is available', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+			const discountPrice = getPlanRawPrice( state, 77203074, 'silver', { isMonthly: false } );
+			expect( discountPrice ).to.equal( 199 );
 		} );
 	} );
 	describe( '#getPlanDiscountedRawPrice()', () => {
@@ -378,6 +469,95 @@ describe( 'selectors', () => {
 			expect( isRequestingSitePlans( state, 2916284 ) ).to.equal( true );
 			expect( isRequestingSitePlans( state, 77203074 ) ).to.equal( false );
 			expect( isRequestingSitePlans( state, 'unknown' ) ).to.equal( false );
+		} );
+	} );
+	describe( '#isPlanDiscounted', () => {
+		it( 'should return false, if no discount is available', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+			const discountPrice = isPlanDiscounted( state, 77203074, 'silver' );
+			expect( discountPrice ).to.equal( false );
+		} );
+		it( 'should return true, if discount is available', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+			const discountPrice = isPlanDiscounted( state, 77203074, 'bronze' );
+			expect( discountPrice ).to.equal( true );
+		} );
+		it( 'should return null, if plan is unknown', () => {
+			const plans = {
+				data: [ {
+					currentPlan: false,
+					productSlug: 'gold',
+					rawPrice: 299,
+					rawDiscount: 0
+				}, {
+					currentPlan: false,
+					productSlug: 'silver',
+					rawPrice: 199,
+					rawDiscount: 0
+				}, {
+					currentPlan: true,
+					productSlug: 'bronze',
+					rawPrice: 99,
+					rawDiscount: 100
+				} ]
+			};
+			const state = {
+				sites: {
+					plans: {
+						77203074: plans
+					}
+				}
+			};
+			const discountPrice = isPlanDiscounted( state, 77203074, 'diamond' );
+			expect( discountPrice ).to.equal( null );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds two new selectors `isSitePlanDiscounted` and `getSitePlanRawPrice` to `state/sites/plans/selectors`. This allows us to more easily see when a plan has a discount and get the plan price _before_ discount using just the site plans specific endpoint. 

## Testing Instructions
- Tests pass
- Discounted plans on the http://calypso.localhost:3000/plans/:siteId: page look correct
- No functional changes

cc @lamosty @rralian @retrofox 