### PR TITLE
Open external chat links in new window

### DIFF
--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -24,6 +24,7 @@ import {
 	getHappychatConnectionStatus,
 	getHappychatTimeline
 } from 'state/happychat/selectors';
+import { isExternal } from 'lib/url';
 
 const debug = require( 'debug' )( 'calypso:happychat:timeline' );
 
@@ -37,10 +38,19 @@ const messageParagraph = ( { message, key } ) => <p key={ key }>{ message }</p>;
  */
 const messageWithLinks = ( { message, key, links } ) => {
 	const children = links.reduce( ( { parts, last }, [ url, startIndex, length ] ) => {
+		let rel = null;
+		let target = null;
+		if ( isExternal( url ) ) {
+			rel = 'noopener noreferrer';
+			target = '_blank';
+		}
+
 		if ( last < startIndex ) {
 			parts = parts.concat( <span key={ parts.length }>{ message.slice( last, startIndex ) }</span> );
 		}
-		parts = parts.concat( <a key={ parts.length } href={ url } rel="noopener noreferrer" target="_blank">{ url }</a> );
+
+		parts = parts.concat( <a key={ parts.length } href={ url } rel={ rel } target={ target }>{ url }</a> );
+
 		return { parts, last: startIndex + length };
 	}, { parts: [], last: 0 } );
 

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -25,7 +25,7 @@ function isOutsideCalypso( url ) {
 }
 
 function isExternal( url ) {
-	const { hostname } = parseUrl( url );
+	const { hostname } = parseUrl( url, false, true ); // no qs needed, and slashesDenoteHost to handle protocol-relative URLs
 
 	if ( ! hostname ) {
 		return false;

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -3,7 +3,13 @@
 /**
  * External dependencies
  */
+import { parse as parseUrl } from 'url';
 import startsWith from 'lodash/startsWith';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
 
 /**
  * Check if a URL is located outside of Calypso.
@@ -19,7 +25,17 @@ function isOutsideCalypso( url ) {
 }
 
 function isExternal( url ) {
-	return isOutsideCalypso( url ) && ! startsWith( url, '//wordpress.com' );
+	const { hostname } = parseUrl( url );
+
+	if ( ! hostname ) {
+		return false;
+	}
+
+	if ( typeof window !== 'undefined' ) {
+		return hostname !== window.location.hostname;
+	}
+
+	return hostname !== config( 'hostname' );
 }
 
 function isHttps( url ) {

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { withoutHttp } from '../';
+import { isExternal, withoutHttp } from '../';
 
 describe( 'withoutHttp', () => {
 	it( 'should return null if URL is not provided', () => {
@@ -44,5 +44,33 @@ describe( 'withoutHttp', () => {
 		const urlEmptyString = '';
 
 		expect( withoutHttp( urlEmptyString ) ).to.equal( '' );
+	} );
+} );
+
+describe( 'isExternal', () => {
+	it( 'should return false for url without hostname', () => {
+		const source = '/relative';
+
+		const actual = isExternal( source );
+
+		expect( actual ).to.be.false;
+	} );
+
+	describe( 'without global.window', () => {
+		it( 'should return true when not matching config hostname', () => {
+			const source = 'https://not.localhost/me';
+
+			const actual = isExternal( source );
+
+			expect( actual ).to.be.true;
+		} );
+
+		it( 'should return false when matching config hostname', () => {
+			const source = 'https://calypso.localhost/me';
+
+			const actual = isExternal( source );
+
+			expect( actual ).to.be.false;
+		} );
 	} );
 } );

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -56,6 +56,14 @@ describe( 'isExternal', () => {
 		expect( actual ).to.be.false;
 	} );
 
+	it( 'should return true when matching an external url with no protocol', () => {
+		const source = '//some-other-site.com';
+
+		const actual = isExternal( source );
+
+		expect( actual ).to.be.true;
+	} );
+
 	describe( 'without global.window', () => {
 		it( 'should return true when not matching config hostname', () => {
 			const source = 'https://not.localhost/me';

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -6,6 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
+import useFakeDom from 'test/helpers/use-fake-dom';
 import { isExternal, withoutHttp } from '../';
 
 describe( 'withoutHttp', () => {
@@ -48,7 +49,7 @@ describe( 'withoutHttp', () => {
 } );
 
 describe( 'isExternal', () => {
-	it( 'should return false for url without hostname', () => {
+	it( 'should return false for relative path-only url', () => {
 		const source = '/relative';
 
 		const actual = isExternal( source );
@@ -56,29 +57,82 @@ describe( 'isExternal', () => {
 		expect( actual ).to.be.false;
 	} );
 
-	it( 'should return true when matching an external url with no protocol', () => {
-		const source = '//some-other-site.com';
+	it( 'should return false for relative query-only url', () => {
+		const source = '?foo=bar';
 
 		const actual = isExternal( source );
 
-		expect( actual ).to.be.true;
+		expect( actual ).to.be.false;
 	} );
 
-	describe( 'without global.window', () => {
-		it( 'should return true when not matching config hostname', () => {
-			const source = 'https://not.localhost/me';
+	describe( 'with global.window (test against window.location.hostname)', () => {
+		// window.location.hostname === 'example.com'
+		useFakeDom();
+
+		it( 'should return false for for internal protocol-relative url', () => {
+			const source = '//example.com';
+
+			const actual = isExternal( source );
+
+			expect( actual ).to.be.false;
+		} );
+
+		it( 'should return true for for external protocol-relative url', () => {
+			const source = '//some-other-site.com';
 
 			const actual = isExternal( source );
 
 			expect( actual ).to.be.true;
 		} );
 
-		it( 'should return false when matching config hostname', () => {
+		it( 'should return false for internal url', () => {
+			const source = 'https://example.com';
+
+			const actual = isExternal( source );
+
+			expect( actual ).to.be.false;
+		} );
+
+		it( 'should return true for external url', () => {
+			const source = 'https://not-example.com';
+
+			const actual = isExternal( source );
+
+			expect( actual ).to.be.true;
+		} );
+	} );
+
+	describe( 'without global.window (test against config hostname)', () => {
+		it( 'should return false for internal protocol-relative url', () => {
+			const source = '//calypso.localhost';
+
+			const actual = isExternal( source );
+
+			expect( actual ).to.be.false;
+		} );
+
+		it( 'should return true for external protocol-relative url', () => {
+			const source = '//some-other-site.com';
+
+			const actual = isExternal( source );
+
+			expect( actual ).to.be.true;
+		} );
+
+		it( 'should return false for internal url', () => {
 			const source = 'https://calypso.localhost/me';
 
 			const actual = isExternal( source );
 
 			expect( actual ).to.be.false;
+		} );
+
+		it( 'should return true for external url', () => {
+			const source = 'https://not.localhost/me';
+
+			const actual = isExternal( source );
+
+			expect( actual ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
Append `target=_blank` only to external links.

This PR updates the logic in the `isExternal` helper method so cc-ing @ockham who originally wrote the function. I included very basic tests but open to feedback as I wasn't totally sure how to mock the `config` module and `window` object.

## How to Test (Happychat update)

- Toggle "Support Chat".
- Send yourself an internal link (`https://wordpress.com/me`) and an external link (`https://google.com`).
- Click on both.
- Verify that internal link keeps you in Calypso.
- Verify that external link is opened in new window.

## How to Test (isExternal regressions)

- Switch to a Jetpack site
- Click through various external links in the sidebar like "Customize", "Edit Site Icon".
- Verify they open in a new window

/cc @beaucollins @georgeh @andreabadgley 

Fixes https://github.com/tinkertinker/wp-calypso/issues/48