### PR TITLE
Advanced SEO: Fix Title Format Editor focus after adding a token

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -158,7 +158,7 @@ export class TitleFormatEditor extends Component {
 		this.setState(
 			{ editorState },
 			() => {
-				editorState.lastChangeType === 'add-token' && this.focusEditor();
+				editorState.getLastChangeType() === 'add-token' && this.focusEditor();
 				onChange( type.value, fromEditor( currentContent ) );
 			}
 		);


### PR DESCRIPTION
Fixes accessing the `lastChangeType` of the drafts-js editor to fix focusing the field after adding a token.

To verify fix:
1) Load `/settings/seo`
2) Click on any button to add a token to a title editor field
3) The field should receive focus and allow typing normally.

Fixes #7931

cc @dmsnell for review!