### PR TITLE
Skip over tokens in the title editor

### DIFF
--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -171,7 +171,7 @@ const emptyBlockMap = {
  * @param {object} tokens available tokens, e.g. { siteName: 'Site Name', tagline: 'Tagline' }
  * @returns {string} translated chip name
  */
-const tokenTitle = ( type, tokens ) => get( tokens, type, '' );
+const tokenTitle = ( type, tokens ) => ` ${ get( tokens, type, '' ).trim() } `;
 
 /**
  * Creates a new entity reference for a blockMap

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -42,9 +42,8 @@
 }
 
 .title-format-editor__token {
-	display: inline-flex;
 	align-items: center;
-	padding: 2px 6px;
+	padding: 2px 0px;
 	background-color: darken( $gray, 20% );
 	color: $white;
 	border-radius: 3px;

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -42,7 +42,6 @@
 }
 
 .title-format-editor__token {
-	align-items: center;
 	padding: 2px 0px;
 	background-color: darken( $gray, 20% );
 	color: $white;

--- a/client/components/title-format-editor/token.jsx
+++ b/client/components/title-format-editor/token.jsx
@@ -8,10 +8,10 @@ export const Token = props => {
 	// the way the component renders in
 	// the draft-js editor
 	return (
-		<div
+		<span
 			className="title-format-editor__token"
 			onClick={ onClick( props.entityKey ) }
-		>{ props.children }</div>
+		>{ props.children }</span>
 	);
 };
 


### PR DESCRIPTION
Resolves #7887 

We don't want to allow the cursor to float over tokens in the custom title editor. This PR should intercept editor updates to make sure that we don't allow the cursor to be moved onto a token. This work should prevent accidentally mangling tokens and prevent confusion as to their role.

**Testing**

Navigate to **My Sites** > **Settings** > **SEO** for a site with at least the business plan level and edit the title formats. Attempt to move the cursor into a token. It should skip to the other side of the token.

cc: @roundhill @rodrigoi 