### PR TITLE
Author dropdown corners correction.

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -18,6 +18,7 @@
 		display: flex;
 		align-items: center;
 		background-color: $white;
+		border-radius: inherit;
 		height: 100%;
 	}
 
@@ -78,6 +79,7 @@
 	z-index: z-index( '.search', '.search__input' );
 	top: 0;
 	border: none;
+	border-radius: inherit;
 	height: 100%;
 	background: $white;
 	appearance: none;
@@ -120,13 +122,16 @@
 		flex: 1 1 auto;
 		height: 100%;
 		position: relative;
+		border-radius: inherit;
 		&::before {
 			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+			border-radius: inherit;
 		}
 
 		&.ltr { /*rtl:ignore*/
 			&::before {
 				@include long-content-fade( $direction: right, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+				border-radius: inherit;
 			}
 		}
 	}


### PR DESCRIPTION
Inherit border radius to get nice corners when needed.
What was:
![bad-corners](https://cloud.githubusercontent.com/assets/17271089/18332361/d2054f84-751a-11e6-82aa-c474bb4096a6.png)
What is:
![good-corners](https://cloud.githubusercontent.com/assets/17271089/18332364/d73c0e70-751a-11e6-81d2-af20b292bc9a.png)

To test compare PR with current production in /posts 