### PR TITLE
Guided Transfer: Prevent unavailability notice flashing up before load

### DIFF
--- a/client/my-sites/exporter/guided-transfer-card/index.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/index.jsx
@@ -12,7 +12,10 @@ import Gridicon from 'gridicons';
 import CompactCard from 'components/card/compact';
 import QuerySiteGuidedTransfer from 'components/data/query-site-guided-transfer';
 import Button from 'components/forms/form-button';
-import { isGuidedTransferAvailableForAllSites } from 'state/sites/guided-transfer/selectors';
+import {
+	isGuidedTransferAvailableForAllSites,
+	isRequestingGuidedTransferStatus,
+} from 'state/sites/guided-transfer/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getProductDisplayCost } from 'state/products-list/selectors';
@@ -27,8 +30,8 @@ const Feature = ( { children } ) =>
 		</span>
 	</li>;
 
-const PurchaseButton = localize( ( { siteSlug, translate } ) =>
-	<Button href={ `/settings/export/guided/${ siteSlug }` } isPrimary={ true } >
+const PurchaseButton = localize( ( { siteSlug, translate, disabled } ) =>
+	<Button href={ `/settings/export/guided/${ siteSlug }` } isPrimary={ true } disabled={ disabled } >
 		{ translate( 'Purchase a Guided Transfer' ) }
 	</Button>
 );
@@ -52,6 +55,7 @@ class GuidedTransferCard extends Component {
 		const {
 			translate,
 			isAvailable,
+			isRequestingStatus,
 			siteId,
 			cost,
 		} = this.props;
@@ -73,8 +77,8 @@ class GuidedTransferCard extends Component {
 						</h2>
 					</div>
 					<div className="guided-transfer-card__options-header-button-container">
-						{ isAvailable
-							? <PurchaseButton siteSlug={ this.props.siteSlug } />
+						{ isAvailable || isRequestingStatus
+							? <PurchaseButton siteSlug={ this.props.siteSlug } disabled={ isRequestingStatus } />
 							: <UnavailableInfo />
 						}
 					</div>
@@ -117,6 +121,7 @@ const mapStateToProps = state => ( {
 	cost: getProductDisplayCost( state, 'guided_transfer' ),
 	siteId: getSelectedSiteId( state ),
 	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) ),
+	isRequestingStatus: isRequestingGuidedTransferStatus( state, getSelectedSiteId( state ) ),
 	isAvailable: isGuidedTransferAvailableForAllSites( state, getSelectedSiteId( state ) ),
 } );
 


### PR DESCRIPTION
Fixes #7828 

cc @rickybanister 

This prevents the flash of the "Guided Transfer unavailable" message before we've actually loaded the status. Instead, it disables the Purchase button until the status arrives.
### How to test
1. Go to **My Sites > Settings > Export**
2. Notice that when loading the page, the "Purchase Guided Transfer" button is displayed but disabled. After a few moments, the button should become enabled.
3. On master, the "Guided Transfer unavailable" notice is displayed on the very first load during those few moments, even if Guided Transfer is available.
### Before

![Before animation](https://cloud.githubusercontent.com/assets/416133/18191161/7a6bde2c-710b-11e6-84ab-49aee8ec7e31.gif)
### After

![guided_loading](https://cloud.githubusercontent.com/assets/416133/18339127/03cc1b1c-75e1-11e6-9724-662a2b1a9f6e.gif)
### After (when GT is actually unavailable)

![guided_unavailable](https://cloud.githubusercontent.com/assets/416133/18339131/0d4d1510-75e1-11e6-9ad6-6dc796144cb4.gif)

cc 
