### PR TITLE
Post-checkout: Adjust PlanThankYouCard for mobile devices

### DIFF
--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -5,37 +5,58 @@
 	background-color: darken( $alert-green, 10 );
 	border-radius: 8px 8px 6px 6px;
 	overflow: hidden;
-	margin: 56px auto 24px;
+	margin: 0 auto 24px;
 	color: $white;
 	font-family: $sans;
 	text-align: center;
+
+	@include breakpoint( ">480px" ) {
+		margin-top: 56px;
+	}
 }
 
 .plan-thank-you-card__header {
 	background-color: $alert-green;
-	padding: 75px 0 30px;
+	padding: 24px 0;
 	position: relative;
 	line-height: 1.2;
 	border-radius: 6px 6px 0 0;
+	overflow: hidden;
+
+	@include breakpoint( ">480px" ) {
+		padding: 75px 0 30px;
+	}
 }
 
 .plan-thank-you-card__body {
-	padding: 40px;
+	padding: 24px;
+
+	@include breakpoint( ">480px" ) {
+		padding: 40px;
+	}
 }
 
 .plan-thank-you-card__heading {
-	font-size: 22px;
+	font-size: 18px;
 	font-weight: 600;
 	margin-bottom: 8px;
+
+	@include breakpoint( ">480px" ) {
+		font-size: 22px;
+	}
 }
 
 .plan-thank-you-card__description {
-	font-size: 15px;
+	font-size: 13px;
 	font-weight: 400;
 	width: 280px;
 	max-width: 100%;
 	margin: 0 auto 30px;
 	line-height: 20px;
+
+	@include breakpoint( ">480px" ) {
+		font-size: 15px;
+	}
 }
 
 .plan-thank-you-card__button,
@@ -47,7 +68,9 @@
 	font-size: 14px;
 	height: 40px;
 	line-height: 40px;
-	padding: 0 60px;
+	padding: 0;
+	width: 280px;
+	margin: 0 auto;
 	border-style: solid;
 	border-color: darken( $alert-green, 20 );
 	border-width: 1px 1px 2px;
@@ -186,5 +209,15 @@
 		top: 161px;
 		left: 77.6%;
 		animation-delay: random(10) + s;
+	}
+}
+
+.plan-thank-you-card__main-icon {
+	width: 100px;
+	height: 100px;
+
+	@include breakpoint( ">480px" ) {
+		width: 140px;
+		height: 140px;
 	}
 }


### PR DESCRIPTION
This PR adjusts styles for PlanThankYouCard on mobile. 

- few font sizes adjusted
- main icon size lowered
- much smaller paddings

I made those changes and added `>480px` breakpoint to set them back to their original value, so desktop look is not altered.

### Testing

- Go to https://calypso.live/devdocs/design?branch=fix/plan-thank-you-card-responsive
- From sidebar, select Blocks and scroll to the bottom of page to see PlanThankYouCard
- Make sure it looks good on desktop and also on mobile (I tested 320 width)

(Until #7907 is merged, you need to take several steps to get to the component like outlined above, otherwise it work to visit directly https://calypso.live/devdocs/blocks/plan-thank-you-card?branch=fix/plan-thank-you-card-responsive)

### Screenshots

| Before this PR | After this PR |
| -------------- | ------------- |
| <img width="353" alt="screen shot 2016-09-09 at 12 57 56" src="https://cloud.githubusercontent.com/assets/156676/18384834/232100d4-768d-11e6-8907-196a5a3e6f58.png"> | <img width="359" alt="screen shot 2016-09-09 at 12 57 08" src="https://cloud.githubusercontent.com/assets/156676/18384796/f6580692-768c-11e6-9598-49963f0774a9.png"> |
