### PR TITLE
Reader: record page view from new full post block

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -247,7 +247,7 @@ export class FullPostFluxContainer extends React.Component {
 				fetchFeed( post.feed_ID );
 			}
 		}
-		if ( post && post.site_ID ) {
+		if ( post && post.site_ID && ! post.is_external ) {
 			site = SiteStore.get( post.site_ID );
 			if ( ! site ) {
 				fetchSite( post.site_ID );


### PR DESCRIPTION
When a full post is opening, push a page view and record the event in Tracks.

Matches behaviour of existing full post view.

Fixes #7817.

### To test

From a post stream, open a full post view e.g. http://calypso.localhost:3000/read/feeds/8938633/posts/1146915107.

Enable analytics debug in the console (`localStorage.setItem('debug', 'calypso:analytics*');`) and look for the following events to fire:

<img width="984" alt="screen shot 2016-09-08 at 11 57 07" src="https://cloud.githubusercontent.com/assets/17325/18347060/6f88ef18-75bb-11e6-8ca7-662d2b10c02b.png">



