### PR TITLE
Framework: Fix visible sidebar on theme info in Safari

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -19,7 +19,6 @@ var React = require( 'react' ),
 	qs = require( 'querystring' ),
 	injectTapEventPlugin = require( 'react-tap-event-plugin' ),
 	i18n = require( 'i18n-calypso' ),
-	isEmpty = require( 'lodash/isEmpty' ),
 	includes = require( 'lodash/includes' );
 
 /**
@@ -406,9 +405,9 @@ function reduxStoreReady( reduxStore ) {
 	 * make this unnecessary.
 	 */
 	page( '*', function( context, next ) {
-		const previousLayoutIsSingleTree = ! isEmpty(
-			document.getElementsByClassName( 'wp-singletree-layout' )
-		);
+		const previousLayoutIsSingleTree = document.getElementsByClassName(
+			'wp-singletree-layout'
+		).length;
 
 		const singleTreeSections = [ 'theme', 'themes' ];
 		const sectionName = getSectionName( context.store.getState() );

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -405,9 +405,9 @@ function reduxStoreReady( reduxStore ) {
 	 * make this unnecessary.
 	 */
 	page( '*', function( context, next ) {
-		const previousLayoutIsSingleTree = document.getElementsByClassName(
-			'wp-singletree-layout'
-		).length;
+		const previousLayoutIsSingleTree = !! (
+			document.getElementsByClassName( 'wp-singletree-layout' ).length
+		);
 
 		const singleTreeSections = [ 'theme', 'themes' ];
 		const sectionName = getSectionName( context.store.getState() );


### PR DESCRIPTION
Fixes #7530

`isEmpty()` is not a suitable method for testing return value of `getElementsByClassName` across all browsers, since type of [returned collection](https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByClassName) differs. Testing `length` property works for all return types.

**To Test**
Test this [use case](https://github.com/Automattic/wp-calypso/issues/7530#issuecomment-245574209)


