### PR TITLE
Framework: update Array.find usage to use lodash

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -4,8 +4,7 @@
 import debugModule from 'debug';
 import React from 'react';
 import i18n from 'i18n-calypso';
-
-const debug = debugModule( 'calypso:community-translator' );
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,8 @@ import User from 'lib/user';
 import userSettings from 'lib/user-settings';
 import { isMobile } from 'lib/viewport';
 import analytics from 'lib/analytics';
+
+const debug = debugModule( 'calypso:community-translator' );
 
 const user = new User(),
 	communityTranslatorBaseUrl = 'https://widgets.wp.com/community-translator/',
@@ -165,7 +166,7 @@ const communityTranslatorJumpstart = {
 			translationDataFromPage.pluralForms;
 		translationDataFromPage.currentUserId = user.data.ID;
 
-		const currentLocale = languages.find( lang => lang.langSlug === localeCode );
+		const currentLocale = find( languages, lang => lang.langSlug === localeCode );
 		if ( currentLocale ) {
 			translationDataFromPage.languageName = currentLocale.name.replace( /^(?:[a-z]{2,3}|[a-z]{2}-[a-z]{2})\s+-\s+/, '' );
 		}

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -75,7 +75,7 @@ const ThemesSearchCard = React.createClass( {
 	renderMobile( tiers ) {
 		const isJetpack = this.props.site && this.props.site.jetpack;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
-		const selectedTiers = isPremiumThemesEnabled ? tiers : [ tiers.find( tier => tier.value === 'free' ) ];
+		const selectedTiers = isPremiumThemesEnabled ? tiers : [ find( tiers, tier => tier.value === 'free' ) ];
 
 		return (
 			<div className="themes__search-card" data-tip-target="themes-search-card">


### PR DESCRIPTION
This fixes an Array.find usage. We don't have a full polyfill solution for prototype methods (see #6117 ) so this will break in IE

## Testing Instructions

- Test pass
- Translator jumpstart works as expected
- Mobile theme search works

cc @seear @yoavf 