### PR TITLE
Editor: enables image-editing in wpcalypso and horizon

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -111,7 +111,7 @@
 		"post-editor-github-link": false,
 		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,
-		"post-editor/media-advanced": true,
+		"post-editor/media-advanced": false,
 		"press-this": true,
 		"push-notifications": true,
 		"reader": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -77,6 +77,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -87,6 +87,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,


### PR DESCRIPTION
This PR just enables image editing in wpcalypso and horizon so we can get some more dedicated testing of the feature.

I am also _disabling_ the image editing stub that was currently in the editor. The v1 for image editing right now doesn't allow for editing directly from the post, so it makes it a little confusing to have that edit button in development that doesn't point to the image-editing feature we're about to launch. We'll follow through to enable this properly as a follow-on feature. But for now image-editing must happen in the "add media" modal. /cc @aduth 