### PR TITLE
Reader: in new full post, add styles for posts missing a title

### DIFF
--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { keys } from 'lodash';
+import { keys, trim } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -23,9 +24,14 @@ const ReaderFullPostHeader = ( { post } ) => {
 		recordGaEvent( 'Clicked Post Permalink', 'timestamp' );
 	};
 
+	const classes = { 'reader-full-post__header': true };
+	if ( ! post.title || trim( post.title ).length < 1 ) {
+		classes[ 'is-missing-title' ] = true;
+	}
+
 	/* eslint-disable react/jsx-no-target-blank */
 	return (
-		<div className="reader-full-post__header">
+		<div className={ classNames( classes ) }>
 			{ post.title
 				? <h1 className="reader-full-post__header-title" onClick={ handlePermalinkClick }>
 					<ExternalLink className="reader-full-post__header-title-link" href={ post.URL } target="_blank" icon={ false }>

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -158,6 +158,15 @@
 	}
 }
 
+// For posts without a title
+.reader-full-post__header.is-missing-title {
+	margin-top: 60px;
+
+	.reader-full-post__header-meta {
+		margin-bottom: 20px;
+	}
+}
+
 .reader-full-post__header-title {
 	clear: none;
 	color: $gray-dark;


### PR DESCRIPTION
Posts without titles look a bit silly right now. This PR makes them look 💯

For example: http://calypso.localhost:3000/read/feeds/52421555/posts/1146175179

Before:
<img width="1049" alt="76ef893e-7506-11e6-82ac-900a0f3601e7" src="https://cloud.githubusercontent.com/assets/17325/18362809/2d0e745c-75ff-11e6-89e8-89e56f4220b0.png">


After:
<img width="1020" alt="screen shot 2016-09-08 at 20 02 00" src="https://cloud.githubusercontent.com/assets/17325/18362795/244f2032-75ff-11e6-88b5-a6db3713952a.png">

Lovely.

Fixes #7949.