### PR TITLE
Update/image editor private site

### DIFF
--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -3,7 +3,8 @@
  */
 var React = require( 'react' ),
 	classNames = require( 'classnames' ),
-	noop = require( 'lodash/noop' );
+	noop = require( 'lodash/noop' ),
+	debug = require( 'debug' )( 'calypso:post-editor:media:detail-item' );
 
 /**
  * Internal dependencies
@@ -44,13 +45,20 @@ module.exports = React.createClass( {
 	},
 
 	renderEditButton: function() {
+		const { item, onEdit, site } = this.props;
+
+		// Do not render edit button for private sites
+		if ( site.is_private ) {
+			return debug( 'Do not show `Edit button` for private sites' );
+		}
+
 		if ( ! config.isEnabled( 'post-editor/image-editor' ) ||
-			! userCan( 'upload_files', this.props.site ) ||
-			! this.props.item ) {
+			! userCan( 'upload_files', site ) ||
+			! item ) {
 			return;
 		}
 
-		const mimePrefix = MediaUtils.getMimePrefix( this.props.item );
+		const mimePrefix = MediaUtils.getMimePrefix( item );
 
 		if ( 'image' !== mimePrefix ) {
 			return;
@@ -59,7 +67,7 @@ module.exports = React.createClass( {
 		return (
 			<Button
 				className="is-desktop editor-media-modal-detail__edit"
-				onClick={ this.props.onEdit }>
+				onClick={ onEdit }>
 				<Gridicon icon="pencil" size={ 36 } /> { this.translate( 'Edit Image' ) }
 			</Button>
 		);


### PR DESCRIPTION
Let's disable image edition for non-public sites for now. We have some remaining issues to solve related with photon, CORS, and security.

The main commit is this one: https://github.com/Automattic/wp-calypso/commit/301ca4e2bc5f8fb13c64b4ccd6d651e27e0224d7. The second one just re-implements the element component as a stateless component.

### Issues

#7878, #5099 

### Testing

The site can be set like `public`, `hidden` and `private` from site settings page:
`http://calypso.localhost:3000/settings/general/<your-testing-site>`

<img src="https://cloud.githubusercontent.com/assets/77539/18364129/92565de6-75e3-11e6-8b5c-2bbdb78c9db4.png" width="400px" />

#### Check edition for public site.

1) Create/edit a new post for a public site.

2) Upload an image is it's needed and make focus on this

![image](https://cloud.githubusercontent.com/assets/77539/18364179/d1f19736-75e3-11e6-915f-e1bbd94f8cd9.png)

3) Click in `Edit` button (bottom left)

4) You should see the `Image Edit` button.

<img src="https://cloud.githubusercontent.com/assets/77539/18364518/0002c9be-75e5-11e6-9826-793626461634.png" width="400px" />

#### Check edition for non public site.

1) Create/edit a new post for a `non public` site.

2) Same that above

3) Same that above

4) You shouldn't see the `Image Edit` button

<img src="https://cloud.githubusercontent.com/assets/77539/18364552/17bab594-75e5-11e6-81f5-bf41daa58885.png" width="400px" />

cc @gwwar 