### PR TITLE
Site: Do not show preview when handling plugin updates

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -242,7 +242,7 @@ export default React.createClass( {
 						</div>
 				}
 				{ this.props.indicator
-					? <SiteIndicator site={ site } onSelect={ this.props.onSelect } />
+					? <SiteIndicator site={ site } />
 					: null
 				}
 				{ this.props.enableActions &&

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import config from 'config';
 import classNames from 'classnames';
-import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
@@ -20,14 +19,7 @@ export default React.createClass( {
 	displayName: 'SiteIndicator',
 
 	propTypes: {
-		site: React.PropTypes.object.isRequired,
-		onSelect: React.PropTypes.func
-	},
-
-	getDefaultProps() {
-		return {
-			onSelect: noop
-		};
+		site: React.PropTypes.object.isRequired
 	},
 
 	getInitialState() {
@@ -148,9 +140,9 @@ export default React.createClass( {
 		}.bind( this ), 15000 );
 	},
 
-	handlePluginsUpdate( event ) {
+	handlePluginsUpdate() {
 		window.scrollTo( 0, 0 );
-		this.props.onSelect( event );
+		this.setState( { expand: false } );
 		analytics.ga.recordEvent( 'Site-Indicator', 'Clicked updates available link to plugins updates', 'Total Updates', this.props.site.update && this.props.site.update.total );
 	},
 


### PR DESCRIPTION
In #7513, it was reported by @m that clicking plugins upgrade noticing resulted in a preview being shown but not an upgrade being done.

I was able to reproduce this by downgrading one of my plugins and then clicking the yellow upgrade indicator in the "My Sites" sidebar.

I was able to track this down to a click handler that called `this.props.onSelect`. If we follow that up the tree, we eventually land in `my-sites/sidebar/sidebar.jsx` where there is some logic to show a preview or not.

It appears that the logic behind `onSelect` has changed since we originally used it to [track a homepage click](https://github.com/Automattic/wp-calypso/blob/a4867d9f30c4cd85757d384ebf376ee620d33847/client/my-sites/current-site/index.jsx#L202).

Because of this, I decided to remove the `onSelect` prop from being passed to `SiteIndicator` and to no longer call `this.props.onSelect()` in the `handlePluginsUpdate()` method.

To test:

- Checkout `fix/preview-shown-on-plugins-update` branch
- Be sure to downgrade a plugin
- Go to `/stats/$site`
- Click the yellow indicator
- Click the "There is a plugin update available" link
- Ensure that you are sent to something like `/plugins/updates/$site`.

cc @beaulebens who pinged on the issue. cc @lezama and @johnHackworth to review.