### PR TITLE
Advanced SEO: Disable title format editor fields when site is private

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import {
 	head,
@@ -351,8 +352,12 @@ export class TitleFormatEditor extends Component {
 			? `${ translate( 'Preview' ) }: ${ previewText }`
 			: '';
 
+		const editorClassNames = classNames( 'title-format-editor', {
+			disabled
+		} );
+
 		return (
-			<div className="title-format-editor">
+			<div className={ editorClassNames }>
 				<div className="title-format-editor__header">
 					<span className="title-format-editor__title">{ type.label }</span>
 					{ map( tokens, ( title, name ) => (
@@ -367,6 +372,7 @@ export class TitleFormatEditor extends Component {
 				</div>
 				<div className="title-format-editor__editor-wrapper">
 					<Editor
+						readOnly={ disabled }
 						editorState={ editorState }
 						onChange={ disabled ? noop : this.updateEditor }
 						placeholder={ placeholder }

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -16,6 +16,21 @@
 
 .title-format-editor {
 	margin-bottom: 20px;
+
+	&.disabled {
+		.title-format-editor__editor-wrapper {
+			border: 1px solid lighten( $gray, 20% );
+			background-color: $gray-light;
+		}
+
+		.title-format-editor__token, .title-format-editor__button {
+			pointer-events: none;
+		}
+
+		.title-format-editor__token {
+			background-color: $gray;
+		}
+	}
 }
 
 .title-format-editor__header {


### PR DESCRIPTION
Hook into `readOnly` prop of drafts editor to disable it when site is set to private.

Adds some CSS to disable tokens and buttons when site is private and form is disabled.

To verify fix:
Visit `settings/seo` for a site that is set to private (you can change it in the general tab). You shouldn't be able to edit the field or click any of the chipkens or buttons. Also verify that a non-private site is editable as expected.

<img width="691" alt="screen shot 2016-09-08 at 2 22 13 pm" src="https://cloud.githubusercontent.com/assets/789137/18367469/251f7982-75d0-11e6-8b02-17dcaaca6792.png">

Fixes #7968

cc @dmsnell 
