### PR TITLE
Fix crash in custom title editor when adding tokens in different fields

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -216,7 +216,7 @@ export class TitleFormatEditor extends Component {
 		);
 	}
 
-	updateEditor( rawEditorState ) {
+	updateEditor( rawEditorState, { doFocus = false } = {} ) {
 		const { onChange, type } = this.props;
 		const currentContent = rawEditorState.getCurrentContent();
 
@@ -230,7 +230,7 @@ export class TitleFormatEditor extends Component {
 		this.setState(
 			{ editorState },
 			() => {
-				editorState.getLastChangeType() === 'add-token' && this.focusEditor();
+				doFocus && this.focusEditor();
 				onChange( type.value, fromEditor( currentContent ) );
 			}
 		);
@@ -255,7 +255,7 @@ export class TitleFormatEditor extends Component {
 				editorState,
 				contentState,
 				'add-token'
-			) );
+			), { doFocus: true } );
 		};
 	}
 


### PR DESCRIPTION
Resolves #7967 

Previously there was a race condition when adding a token into one field
and then another field on the custom title editor in **My Sites** >
**Settings** > **SEO**

What would happen is that if you clicked to add a token on one field and
then immediately clicked to add a token in another field, the editor
would spin in an infinite loop trying to focus the field.

The focus-after-token-insertion was intended to allow one to continue
typing after clicking on a token and have the keystrokes update the
title field. Unfortunately, the bug appeared through assumptions about
the editor updates. The focus event triggers a new state update on the
editor. The update function was setting focus after the last _type_ of
state update was `add-token`. The critical assumption was that each
update set or reset the last edit type. In reality, the focus state
updates were allowing `getLastChangeType()` to carry through from the
`add-token` event and retriggering a focus update in a loop.

This has been fixed by triggering the focus update on a new optional
parameter to `this.updateState`, the `doFocus` boolean. `addToken` now
calls the update with this set to true so that focus gets updated only
when adding tokens.

**Before**
Notice how in this (slightly modified) original code we can see the cursor dancing between the different title fields. The dancing is caused by focus events retriggering focus events.
![brokentitleeditor](https://cloud.githubusercontent.com/assets/5431237/18368929/6b036088-75d7-11e6-8924-3b6fe7edeb94.gif)


**After**
Afterwards the focus events only get triggered after clicking on the add-token buttons.
![fixedtitleeditor](https://cloud.githubusercontent.com/assets/5431237/18368568/83dee76e-75d5-11e6-8e8d-0d0b7633a3c1.gif)

**Testing**
On **master** the editor should get stuck in an infinite loop, effectively crashing the browser _if_ you click to add a token in one field and then immediately click to add a token in another field.

In this branch, the behavior should be fixed.

cc: @roundhill @rodrigoi 