### PR TITLE
	Plans: Allow redirecting logged out users to the login page if for=jetpack is set in query args

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -326,7 +326,7 @@ function reduxStoreReady( reduxStore ) {
 	if ( ! user.get() ) {
 		// Dead-end the sections the user can't access when logged out
 		page( '*', function( context, next ) {
-			var isValidSection = some( validSections, function( validPath ) {
+			const isValidSection = some( validSections, function( validPath ) {
 				return startsWith( context.path, validPath );
 			} );
 
@@ -341,8 +341,13 @@ function reduxStoreReady( reduxStore ) {
 
 			//see server/pages/index for prod redirect
 			if ( '/plans' === context.pathname ) {
-				// pricing page is outside of Calypso, needs a full page load
-				window.location = 'https://wordpress.com/pricing';
+				const queryFor = context.query && context.query.for;
+				if ( queryFor && 'jetpack' === queryFor ) {
+					window.location = 'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans';
+				} else {
+					// pricing page is outside of Calypso, needs a full page load
+					window.location = 'https://wordpress.com/pricing';
+				}
 				return;
 			}
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -318,7 +318,12 @@ module.exports = function() {
 
 		app.get( '/plans', function( req, res, next ) {
 			if ( ! req.cookies.wordpress_logged_in ) {
-				res.redirect( 'https://wordpress.com/pricing' );
+				const queryFor = req.query && req.query.for;
+				if ( queryFor && 'jetpack' === queryFor ) {
+					res.redirect( 'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans' );
+				} else {
+					res.redirect( 'https://wordpress.com/pricing' );
+				}
 			} else {
 				next();
 			}


### PR DESCRIPTION
This PR adds the `/jetpack/plans` route to change the redirect behavior of the `/plans` route. Currently, the `/plans` route redirects to `wordpress.com/pricing`. We'd like to redirect logged out users to the login page.

To test:

- Checkout `update/plans-jetpack-redirect` branch
- While logged out, go to `/plans?for=jetpack`.
- You should be redirect to the WP.com login page, and once you login, you should be redirected back to `wordpress.com/plans`.
- Login
- Go to `/plans?for=jetpack`
- You should be redirect to `/plans`

This does seem a bit hacky, but it is only a temporary solution so that we JPOP growth can run a test starting Monday.

cc @Viper007Bond 