### PR TITLE
SEO: Title Format: Improve visual handling of long lines

### DIFF
--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -1,5 +1,10 @@
 .title-format-editor {
 	margin-bottom: 20px;
+
+	.public-DraftStyleDefault-block.public-DraftStyleDefault-ltr {
+		overflow: scroll;
+		white-space: nowrap;
+	}
 }
 
 .title-format-editor__header {


### PR DESCRIPTION
Resolves #7888

Previously, long lines in the custom title editor wrapped around and
expanded the editor window itself.

Now, the text is prevented from wrapping and scrolls for overflow.

**Before**
![brokentitlefield](https://cloud.githubusercontent.com/assets/5431237/18371947/561e88a8-75ed-11e6-8602-ac27a626421d.gif)

**After**
![overflowingtitlefield](https://cloud.githubusercontent.com/assets/5431237/18371950/5b472c36-75ed-11e6-8f65-fb76cc550f58.gif)

**Testing**
Write a long title format and see if it wraps. It shouldn't.

cc: @roundhill @rodrigoi 