### PR TITLE
Help: Show the help contact closed message when the isClosed flag is set

### DIFF
--- a/client/lib/olark-store/actions.js
+++ b/client/lib/olark-store/actions.js
@@ -45,6 +45,13 @@ const olarkActions = {
 		} );
 	},
 
+	setClosed( isSupportClosed ) {
+		dispatcher.handleServerAction( {
+			isSupportClosed,
+			type: ActionTypes.OLARK_SET_CLOSED
+		} );
+	},
+
 	setExpanded( isOlarkExpanded ) {
 		dispatcher.handleServerAction( {
 			isOlarkExpanded,

--- a/client/lib/olark-store/constants.js
+++ b/client/lib/olark-store/constants.js
@@ -13,5 +13,6 @@ export const action = keyMirror( {
 	OLARK_DETAILS: null,
 	OLARK_LOCALE: null,
 	OLARK_USER_ELIGIBILITY: null,
+	OLARK_SET_CLOSED: null,
 	OLARK_SET_EXPANDED: null
 } );

--- a/client/lib/olark-store/index.js
+++ b/client/lib/olark-store/index.js
@@ -12,6 +12,7 @@ const initialState = {
 	isOlarkReady: false,
 	isUserEligible: false,
 	isOlarkExpanded: false,
+	isSupportClosed: false,
 	locale: 'en',
 	details: {}
 };
@@ -41,6 +42,9 @@ const olarkStore = createReducerStore( function( state, payload ) {
 			break;
 		case ActionTypes.OLARK_DETAILS:
 			stateChanges = { details: action.details };
+			break;
+		case ActionTypes.OLARK_SET_CLOSED:
+			stateChanges = { isSupportClosed: action.isSupportClosed };
 			break;
 	}
 

--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -191,6 +191,7 @@ const olark = {
 		olarkApi.configure( 'system.mask_credit_cards', true );
 
 		olarkActions.setUserEligibility( isUserEligible );
+		olarkActions.setClosed( wpcomOlarkConfig.isClosed );
 
 		if ( wpcomOlarkConfig.locale ) {
 			olarkActions.setLocale( wpcomOlarkConfig.locale );

--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -41,8 +41,7 @@ export default localize( ( props ) => {
 			</p>
 			<HelpContactClosedDetail icon="help">
 				{ translate(
-					'The {{link}}forums{{/link}} remain open and staffed during this time, ' +
-					'and you can post a support request using the form below.', {
+					'The {{link}}forums{{/link}} remain open and staffed during this time.', {
 						components: {
 							link: <a href="https://forums.wordpress.com/" target="_blank" rel="noopener noreferrer" />
 						}

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -16,6 +16,7 @@ import olarkActions from 'lib/olark-store/actions';
 import olarkEvents from 'lib/olark-events';
 import olarkApi from 'lib/olark-api';
 import HelpContactForm from 'me/help/help-contact-form';
+import HelpContactClosed from 'me/help/help-contact-closed';
 import HelpContactConfirmation from 'me/help/help-contact-confirmation';
 import HeaderCake from 'components/header-cake';
 import wpcomLib from 'lib/wp';
@@ -374,6 +375,10 @@ const HelpContact = React.createClass( {
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;
+		}
+
+		if ( olark.isSupportClosed ) {
+			return <HelpContactClosed />;
 		}
 
 		if ( ! ( olark.isOlarkReady && sitesInitialized ) && ! this.props.olarkTimedOut ) {


### PR DESCRIPTION
This pull request adds the `isClosed` flag returned by the olark api endpoint to the redux store and uses it to control the display of the `HelpContactClosed` component added in #7940 

## How to test
**preliminary steps to simulate turned off support**
1. Sandbox public-api.wordpress.com 
2. Add the pastebin code at /pb/15e20 to your sandbox

### As a free plan user or aged user
1. Navigate to http://calypso.localhost:3000/help/contact
2. Notice that the "Limited support week" message is shown

![screen shot 2016-09-07 at 3 32 48 pm](https://cloud.githubusercontent.com/assets/1854440/18374516/a466a45e-761b-11e6-9963-5e9c7c906f28.png)

### As a user with recent purchase (< 30 days)
1. Navigate to http://calypso.localhost:3000/help/contact
2. Notice that the contact form ***is*** displayed. *Note that during the grand meetup, chat will not be staffed and the user will see the email support flavor of the contact form*

![screen shot 2016-09-08 at 11 32 16 pm](https://cloud.githubusercontent.com/assets/1854440/18374623/8e61485c-761c-11e6-8bde-3218857bf81a.png)



