### PR TITLE
Preview: Fix infinite-scroll by using primary domain

### DIFF
--- a/client/blocks/url-preview/index.jsx
+++ b/client/blocks/url-preview/index.jsx
@@ -11,7 +11,7 @@ import debugFactory from 'debug';
 import { closePreview } from 'state/ui/preview/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getPreviewUrl } from 'state/ui/preview/selectors';
-import { getSiteOption } from 'state/sites/selectors';
+import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
 
 const debug = debugFactory( 'calypso:design-preview' );
@@ -98,7 +98,7 @@ export default function urlPreview( WebPreview ) {
 		return {
 			selectedSite: getSelectedSite( state ),
 			selectedSiteId,
-			selectedSiteUrl: getSiteOption( state, selectedSiteId, 'unmapped_url' ),
+			selectedSiteUrl: 'https://' + getSiteSlug( state, selectedSiteId ),
 			selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ),
 			previewUrl: getPreviewUrl( state ),
 		};

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -17,7 +17,7 @@ import accept from 'lib/accept';
 import { updatePreviewWithChanges } from 'lib/design-preview';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getPreviewUrl } from 'state/ui/preview/selectors';
-import { getSiteOption } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { getPreviewMarkup, getPreviewCustomizations, isPreviewUnsaved } from 'state/preview/selectors';
 import { closePreview } from 'state/ui/preview/actions';
 import DesignMenu from 'blocks/design-menu';
@@ -204,7 +204,7 @@ export default function designPreview( WebPreview ) {
 		return {
 			selectedSite,
 			selectedSiteId,
-			selectedSiteUrl: getSiteOption( state, selectedSiteId, 'unmapped_url' ),
+			selectedSiteUrl: 'https://' + getSiteSlug( state, selectedSiteId ),
 			previewUrl: getPreviewUrl( state ),
 			previewMarkup: getPreviewMarkup( state, selectedSiteId ),
 			customizations: getPreviewCustomizations( state, selectedSiteId ),


### PR DESCRIPTION
Fixes #6346

Unmapped domain was in use to prevent preview failure with insecure content errors on http domains.

Infinite-scroll only works with primary domain.

All mapped domains should now be [using https](https://en.blog.wordpress.com/2016/04/08/https-everywhere-encryption-for-all-wordpress-com-sites/), so should be safe to use mapped domains for preview.

Not sure about:
* Adding the 'https://' onto the slugs manually—is there a better way to do this?
* What is the difference between url-preview and design-preview and what are the use cases?

