### PR TITLE
Ad Tracking: Update Criteo purchase event name

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -393,7 +393,7 @@ function recordOrderInCriteo( cart, orderId ) {
 		return;
 	}
 
-	recordInCriteo( 'viewBasket', {
+	recordInCriteo( 'trackTransaction', {
 		id: orderId,
 		currency: cart.currency,
 		item: cartToCriteoItems( cart )


### PR DESCRIPTION
This PR updates the Criteo purchase event name from `viewBasket` to `trackTransaction` per an email conversation with them:

> ViewBasket indicates an basket/cart event. The event name for conversion is "trackTransaction", can you please change that viewBasket to trackTransaction?

Here's what the post-purchase logs look like now when ad tracking is turned on:

![screen shot 2016-09-09 at 9 26 22 am](https://cloud.githubusercontent.com/assets/44436/18388460/bcb0f420-766f-11e6-8c28-c4a1c369f228.png)
