### PR TITLE
Post-checkout: Fix email nudge responsive problem

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/style.scss
@@ -222,6 +222,7 @@
 }
 
 .checkout-thank-you__verification-notice {
+	width: 100%;
 	max-width: 500px;
 	text-align: left;
 	margin: 0 auto;
@@ -229,4 +230,5 @@
 
 .checkout-thank-you__verification-notice-email {
 	white-space: nowrap;
+	word-break: break-word;
 }

--- a/client/my-sites/upgrades/checkout-thank-you/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/style.scss
@@ -229,6 +229,5 @@
 }
 
 .checkout-thank-you__verification-notice-email {
-	white-space: nowrap;
 	word-break: break-word;
 }


### PR DESCRIPTION
This fixes e-mail nudge in a way that prevents text overflow in the notice. 

Testing:

- use sandboxed store, so you don't have to spend real 💸
- open an incognito window and go to signup on [calypso.localhost](http://calypso.localhost:3000/start) or [calypso.live](https://calypso.live/start?branch=fix/responsive-thanks-page-email-nudge) 
- from the A/B tests dropdown, select paidNuxStreamlined: streamlined
- go through signup with paid plan and make your e-mail long (eg. `asdasdasdasdasdasdasd+username@gmail.com`)
- purchase it
- you will end up on a new thanks page with this e-mail nudge at the bottom
- test in usual mobile situations (like 320 width)

| Before | After |
| --- | --- |
| <img width="381" alt="screen shot 2016-09-09 at 16 41 51" src="https://cloud.githubusercontent.com/assets/156676/18390993/bd084b84-76ac-11e6-8bc6-2aee2d6f891a.png"> | <img width="369" alt="screen shot 2016-09-09 at 16 42 21" src="https://cloud.githubusercontent.com/assets/156676/18391003/c2d1cdb0-76ac-11e6-8b84-2ff2d9fa2ac2.png"> |

