### PR TITLE
Connect ProductPurchaseFeaturesList to Redux state; use selectors

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { find } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -32,19 +32,15 @@ import JetpackBackupSecurity from './jetpack-backup-security';
 import JetpackReturnToDashboard from './jetpack-return-to-dashboard';
 import JetpackSurveysPolls from './jetpack-surveys-polls';
 import JetpackWordPressCom from './jetpack-wordpress-com';
-import {
-	isPremium as isWpcomPremium,
-	isBusiness as isWpcomBusiness
-} from 'lib/products-values';
 import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
+import { hasDomainCredit } from 'state/sites/plans/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
-export default class ProductPurchaseFeaturesList extends Component {
+class ProductPurchaseFeaturesList extends Component {
 	static propTypes = {
 		plan: PropTypes
 			.oneOf( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ] )
 			.isRequired,
-		selectedSite: PropTypes.object,
-		sitePlans: PropTypes.object,
 		isPlaceholder: PropTypes.bool
 	};
 
@@ -55,15 +51,13 @@ export default class ProductPurchaseFeaturesList extends Component {
 	getBusinessFeatures() {
 		const {
 			selectedSite,
-			sitePlans,
+			planHasDomainCredit
 		} = this.props;
-
-		const plan = find( sitePlans.data, isWpcomBusiness );
 
 		return [
 			<CustomDomain
 				selectedSite={ selectedSite }
-				hasDomainCredit={ plan && plan.hasDomainCredit }
+				hasDomainCredit={ planHasDomainCredit }
 				key="customDomainFeature"
 			/>,
 			<AdvertisingRemoved
@@ -105,15 +99,13 @@ export default class ProductPurchaseFeaturesList extends Component {
 	getPremiumFeatures() {
 		const {
 			selectedSite,
-			sitePlans,
+			planHasDomainCredit
 		} = this.props;
-
-		const plan = find( sitePlans.data, isWpcomPremium );
 
 		return [
 			<CustomDomain
 				selectedSite={ selectedSite }
-				hasDomainCredit={ plan && plan.hasDomainCredit }
+				hasDomainCredit={ planHasDomainCredit }
 				key="customDomainFeature"
 			/>,
 			<AdvertisingRemoved
@@ -144,15 +136,13 @@ export default class ProductPurchaseFeaturesList extends Component {
 	getPersonalFeatures() {
 		const {
 			selectedSite,
-			sitePlans,
+			planHasDomainCredit
 		} = this.props;
-
-		const plan = find( sitePlans.data, isWpcomPremium );
 
 		return [
 			<CustomDomain
 				selectedSite={ selectedSite }
-				hasDomainCredit={ plan && plan.hasDomainCredit }
+				hasDomainCredit={ planHasDomainCredit }
 				key="customDomainFeature"
 			/>,
 			<AdvertisingRemoved
@@ -257,3 +247,15 @@ export default class ProductPurchaseFeaturesList extends Component {
 		);
 	}
 }
+
+export default connect(
+	( state ) => {
+		const selectedSite = getSelectedSite( state ),
+			selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			selectedSite,
+			planHasDomainCredit: hasDomainCredit( state, selectedSiteId )
+		};
+	}
+)( ProductPurchaseFeaturesList );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -99,8 +99,6 @@ class CurrentPlan extends Component {
 					/>
 					<ProductPurchaseFeaturesList
 						plan={ currentPlanSlug }
-						selectedSite={ selectedSite }
-						sitePlans={ sitePlans }
 						isPlaceholder={ isLoading }
 					/>
 				</ProductPurchaseFeatures>


### PR DESCRIPTION
Fixes an issue raised in [7860](https://github.com/Automattic/wp-calypso/pull/7860#discussion_r77684274). Connects `ProductPurchaseFeaturesList` to Redux state tree and selects data from it using suitable selectors instead of getting it through props and/or manually getting the data out of larger objects.

Props @gwwar for the suggestion!