### PR TITLE
ImageEditor: Handle when image fails to load

### DIFF
--- a/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
@@ -36,7 +36,8 @@ const MediaModalImageEditorCanvas = React.createClass( {
 			widthRatio: React.PropTypes.number,
 			heightRatio: React.PropTypes.number,
 		} ),
-		setImageEditorCropBounds: React.PropTypes.func
+		setImageEditorCropBounds: React.PropTypes.func,
+		onLoadError: React.PropTypes.func
 	},
 
 	getInitialState() {
@@ -58,7 +59,8 @@ const MediaModalImageEditorCanvas = React.createClass( {
 				cropWidthRatio: 1,
 				cropHeightRatio: 1,
 			},
-			setImageEditorCropBounds: noop
+			setImageEditorCropBounds: noop,
+			onLoadError: noop,
 		};
 	},
 
@@ -67,13 +69,17 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	},
 
 	getImage( url ) {
+		const { onLoadError, mimeType } = this.props;
+
 		const req = new XMLHttpRequest();
 		req.open( 'GET', url, true );
 		req.responseType = 'arraybuffer';
 		req.onload = () => {
-			const objectURL = window.URL.createObjectURL( new Blob( [ req.response ], { type: this.props.mimeType } ) );
+			const objectURL = window.URL.createObjectURL( new Blob( [ req.response ], { type: mimeType } ) );
 			this.initImage( objectURL );
 		};
+
+		req.onerror = error => onLoadError( error );
 		req.send();
 	},
 

--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Notice from 'components/notice';
 import EditCanvas from './image-editor-canvas';
 import EditToolbar from './image-editor-toolbar';
 import EditButtons from './image-editor-buttons';
@@ -45,6 +46,12 @@ const MediaModalImageEditor = React.createClass( {
 			selectedIndex: 0,
 			onImageEditorClose: noop,
 			onImageEditorCancel: noop
+		};
+	},
+
+	getInitialState() {
+		return {
+			canvasError: null
 		};
 	},
 
@@ -126,12 +133,32 @@ const MediaModalImageEditor = React.createClass( {
 		return ! transfer.types || -1 !== Array.prototype.indexOf.call( transfer.types, 'Files' );
 	},
 
+	onLoadCanvasError() {
+		this.setState( { canvasError: this.translate( 'We are unable to edit this image.' ) } );
+	},
+
+	renderError() {
+		return (
+			<Notice
+				status="is-error"
+				showDismiss={ true }
+				text={ this.state.canvasError }
+				isCompact={ false }
+				onDismissClick={ this.props.onImageEditorCancel } 	/>
+		);
+	},
+
 	render() {
 		return (
-			<div className="editor-media-modal-image-editor">
+			<div className="image-editor">
+				{ this.state.canvasError && this.renderError() }
+
 				<figure>
 					<div className="editor-media-modal-image-editor__content editor-media-modal__content" >
-						<EditCanvas ref="editCanvas" />
+						<EditCanvas
+							ref="editCanvas"
+							onLoadError={ this.onLoadCanvasError }
+							/>
 						<EditToolbar />
 						<EditButtons
 							onCancel={ this.props.onImageEditorCancel }


### PR DESCRIPTION
This PR suggests a solution for this issue #7971.

<img src="https://cloud.githubusercontent.com/assets/77539/18391942/3fe82a14-7686-11e6-9d05-a1381095f4d3.png" width="400px" />

* When the image can't be loaded ImageEditorCanvas will execute the bound function tied to its `onLoadError` property:

```es6
getImage( url ) {
		const { onLoadError, mimeType } = this.props;

		// ...
		req.onerror = error => onLoadError( error );
		req.send();
```

```es6
<EditCanvas onLoadError={ this.onLoadCanvasError } />
```

* The `onLoadCanvasError()` show an inline error.

~~* The modal dialog will be closed automatically after passing 8 seconds.~~

### Testing

Updated: After merge #7977 we are hiding the `Edit Image` button for private sites to avoid this situation. For this reason I've added a testing flag just to jump this improvement and in this way can test the error handling. Once this PR is ready to merge let's remove this flag

run calypso with:

```cli
> ENABLE_FEATURES=image-editor/force-show-edit-image-button make run
```

1. Create / edit a new post from a private site
2. Add media to the post
3. Start to edit an image (bottom left button)
4. Try to edit the image (top right button)

You should get the inline error

<img src="https://cloud.githubusercontent.com/assets/77539/18440483/ae76ba76-78df-11e6-8115-8940a2bc75bc.gif" width="500px" />




cc @gwwar @obenland @rralian 