### PR TITLE
Reader: Only setState in PostOptions when it changes

### DIFF
--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -20,6 +20,7 @@ import SiteBlockActions from 'lib/reader-site-blocks/actions';
 import PostUtils from 'lib/posts/utils';
 import FollowButton from 'reader/follow-button';
 import * as DiscoverHelper from 'reader/discover/helper';
+import smartSetState from 'lib/react-smart-set-state';
 
 const stats = require( 'reader/stats' );
 
@@ -36,6 +37,8 @@ const PostOptions = React.createClass( {
 			position: 'top left'
 		};
 	},
+
+	smartSetState: smartSetState,
 
 	getInitialState() {
 		const state = this.getStateFromStores();
@@ -71,7 +74,7 @@ const PostOptions = React.createClass( {
 	},
 
 	updateState() {
-		this.setState( this.getStateFromStores() );
+		this.smartSetState( this.getStateFromStores() );
 
 		// Hide the popover menu if there's an error
 		// Error message will be displayed on the post card
@@ -185,7 +188,7 @@ const PostOptions = React.createClass( {
 						ref="popoverMenuButton"
 						onClick={ this._showPopoverMenu }>
 					<svg className="gridicon gridicon__ellipsis" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-						<g><circle cx="5" cy="12" r="2"/><circle cx="19" cy="12" r="2"/><circle cx="12" cy="12" r="2"/></g>
+						<g><circle cx="5" cy="12" r="2" /><circle cx="19" cy="12" r="2" /><circle cx="12" cy="12" r="2" /></g>
 					</svg>
 					<span className="post-options__label">{ this.translate( 'More' ) }</span>
 				</span>
@@ -199,7 +202,7 @@ const PostOptions = React.createClass( {
 
 					{ isEditPossible ? <PopoverMenuItem onClick={ this.editPost } className="post-options__edit has-icon">
 						<svg className="gridicon gridicon__edit" height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-							<g><path d="M4 15v5h5l9-9-5-5-9 9zM16 3l-2 2 5 5 2-2-5-5z"/></g>
+							<g><path d="M4 15v5h5l9-9-5-5-9 9zM16 3l-2 2 5 5 2-2-5-5z" /></g>
 						</svg>
 						{ this.translate( 'Edit Post' ) }
 					</PopoverMenuItem> : null }


### PR DESCRIPTION
Use smartSetState to avoid unnecessary setState calls, which force renders.

Currently, whenever the feed store changes, we reset the state, even if the entry we care about didn't change. Use smartSetState to only update state when it changes.