### PR TITLE
Framework: Move section require into middleware

### DIFF
--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -135,14 +135,11 @@ function requireTemplate( section ) {
 		return acc.concat( [
 			'page( ' + pathRegex + ', function( context, next ) {',
 			'	controller.setSection( ' + JSON.stringify( section ) + ' )( context );',
+			'	require( ' + JSON.stringify( section.module ) + ' )( controller.clientRouter );',
 			'	next();',
 			'} );\n'
 		] );
 	}, [] );
-
-	result.push(
-		'require( ' + JSON.stringify( section.module ) + ' )( controller.clientRouter );\n\n'
-	);
 
 	return result.join( '\n' );
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-desktop/issues/235

In the section loading code in the non code-splitting path, the require call for the section is outside of the middleware definitions, meaning the section-specific middlewares are hooked up _before_ the global middlewares in client/boot. This means that important stuff in the global middleware is not happening in non-code-split envs such as Desktop.

Note how this change moves the require call inside of the middlewares, [matching](https://github.com/Automattic/wp-calypso/pull/8010/files#diff-00a18019630327287f73e8cf7bbb1547R104) the code-splitting environments.

**To Test**
* build with `code-splitting: false` and check routing, especially _themes_ and theme info page
* build the [Desktop app](https://github.com/Automattic/wp-desktop) and test the use case in https://github.com/Automattic/wp-desktop/issues/235
