### PR TITLE
SSO: EmailVerification: Do not allow SSO if a user has not verified email

### DIFF
--- a/client/components/email-verification/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-unverified-notice.jsx
@@ -36,6 +36,16 @@ export default class EmailUnverifiedNotice extends React.Component {
 		};
 	}
 
+	static propTypes = {
+		noticeText: React.PropTypes.node,
+		noticeStatus: React.PropTypes.string
+	};
+
+	static defaultProps = {
+		noticeText: null,
+		noticeStatus: ''
+	};
+
 	componentWillMount() {
 		user.on( 'change', this.updateVerificationState );
 		user.on( 'verify', this.updateVerificationState );
@@ -141,46 +151,64 @@ export default class EmailUnverifiedNotice extends React.Component {
 			return this.renderEmailSendSuccess();
 		}
 
-		let noticeText = ( <div>
-			<p>
-				<strong>{
-					i18n.getLocaleSlug() === 'en'
-					? i18n.translate( 'To continue, please confirm your email address' )
-					: i18n.translate( 'Please confirm your email address' )
-				}</strong>
-			</p>
-			<p>
-				{ i18n.getLocaleSlug() === 'en'
-					? i18n.translate(
-						'Click the link in the email we sent to %(email)s.',
-						{ args: { email: user.get().email } } )
-					: i18n.translate(
-						'To post and keep using WordPress.com you need to confirm your email address. ' +
-						'Please click the link in the email we sent at %(email)s.',
-						{ args: { email: user.get().email } } )
-				}
-			</p>
-			<p>
-				{
-					i18n.getLocaleSlug() === 'en'
-					? i18n.translate(
-						'Didn\'t get it? {{requestButton}}Resend Confirmation Email{{/requestButton}} ' +
-						'or {{changeButton}}Change Account Email Address{{/changeButton}}', {
-							components: {
-								requestButton: <a href="#" tabIndex="0" onClick={ this.handleSendVerificationEmail } />,
-								changeButton: <a href="#" tabIndex="0" onClick={ this.handleChangeEmail } />
-							} } )
-					: i18n.translate(
-						'{{requestButton}}Re-send your confirmation email{{/requestButton}} ' +
-						'or {{changeButton}}change the email address on your account{{/changeButton}}.', {
-							components: {
-								requestButton: <a href="#" tabIndex="0" onClick={ this.handleSendVerificationEmail } />,
-								changeButton: <a href="#" tabIndex="0" onClick={ this.handleChangeEmail } />
-							} } )
-				}
-			</p>
-		</div> );
+		const noticeText = this.props.noticeText
+			? this.props.noticeText
+			: (
+				<div>
+					<p>
+						<strong>{
+							i18n.getLocaleSlug() === 'en'
+							? i18n.translate( 'To continue, please confirm your email address' )
+							: i18n.translate( 'Please confirm your email address' )
+						}</strong>
+					</p>
+					<p>
+						{ i18n.getLocaleSlug() === 'en'
+							? i18n.translate(
+								'Click the link in the email we sent to %(email)s.',
+								{ args: { email: user.get().email } } )
+							: i18n.translate(
+								'To post and keep using WordPress.com you need to confirm your email address. ' +
+								'Please click the link in the email we sent at %(email)s.',
+								{ args: { email: user.get().email } } )
+						}
+					</p>
+					<p>
+						{
+							i18n.getLocaleSlug() === 'en'
+							? i18n.translate(
+								'Didn\'t get it? {{requestButton}}Resend Confirmation Email{{/requestButton}} ' +
+								'or {{changeButton}}Change Account Email Address{{/changeButton}}', {
+									components: {
+										requestButton: <a href="#" tabIndex="0" onClick={ this.handleSendVerificationEmail } />,
+										changeButton: <a href="#" tabIndex="0" onClick={ this.handleChangeEmail } />
+									} } )
+							: i18n.translate(
+								'{{requestButton}}Re-send your confirmation email{{/requestButton}} ' +
+								'or {{changeButton}}change the email address on your account{{/changeButton}}.', {
+									components: {
+										requestButton: <a href="#" tabIndex="0" onClick={ this.handleSendVerificationEmail } />,
+										changeButton: <a href="#" tabIndex="0" onClick={ this.handleChangeEmail } />
+									} } )
+						}
+					</p>
+				</div>
+			);
 
-		return <Notice text={ noticeText } icon="info" showDismiss={ false } className="email-unverified-notice" />;
+		return (
+			<Notice
+				text={ noticeText }
+				icon="info"
+				showDismiss={ false }
+				status={ this.props.noticeStatus }
+				className="email-unverified-notice">
+				{
+					this.props.noticeText &&
+					<NoticeAction onClick={ this.handleSendVerificationEmail }>
+						{ i18n.translate( 'Resend Email' ) }
+					</NoticeAction>
+				}
+			</Notice>
+		);
 	}
 }

--- a/client/components/email-verification/email-verification-gate.jsx
+++ b/client/components/email-verification/email-verification-gate.jsx
@@ -16,6 +16,15 @@ const sites = sitesFactory();
 const user = userFactory();
 
 export default class EmailVerificationGate extends React.Component {
+	static propTypes = {
+		noticeText: React.PropTypes.node,
+		noticeStatus: React.PropTypes.string
+	};
+
+	static defaultProps = {
+		noticeText: null,
+		noticeStatus: ''
+	};
 
 	constructor( props ) {
 		super( props );
@@ -54,9 +63,11 @@ export default class EmailVerificationGate extends React.Component {
 		if ( this.state.needsVerification ) {
 			return (
 				<div tabIndex="-1" className="email-verification-gate" onFocus={ this.handleFocus }>
-					<EmailUnverifiedNotice />
+					<EmailUnverifiedNotice
+						noticeText={ this.props.noticeText }
+						noticeStatus={ this.props.noticeStatus } />
 					<div className="email-verification-gate__content">
-						{	this.props.children }
+						{ this.props.children }
 					</div>
 				</div>
 			);

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -35,6 +35,7 @@ import Dialog from 'components/dialog';
 import analytics from 'lib/analytics';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
+import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 
 /*
  * Module variables
@@ -123,8 +124,9 @@ const JetpackSSOForm = React.createClass( {
 	},
 
 	isButtonDisabled() {
+		const user = this.props.userModule.get();
 		const { nonceValid, isAuthorizing, isValidating, ssoUrl, authorizationError } = this.props;
-		return !! ( ! nonceValid || isAuthorizing || isValidating || ssoUrl || authorizationError );
+		return !! ( ! nonceValid || isAuthorizing || isValidating || ssoUrl || authorizationError || ! user.email_verified );
 	},
 
 	getSignInLink() {
@@ -404,39 +406,43 @@ const JetpackSSOForm = React.createClass( {
 
 					{ this.renderSiteCard() }
 
-					<Card>
-						{ this.maybeRenderErrorNotice() }
-						<div className="jetpack-connect__sso-user-profile">
-							<Gravatar user={ user } size={ 120 } imgSize={ 400 } />
-							<h3 className="jetpack-connect__sso-log-in-as">
-								{ this.translate(
-									'Log in as {{strong}}%s{{/strong}}',
-									{
-										args: user.display_name,
-										components: {
-											strong: <strong className="jetpack-connect__sso-display-name" />
-										}
-									}
-								) }
-							</h3>
-							<div className="jetpack-connect__sso-user-email">
-								{ user.email }
-							</div>
-						</div>
+					<EmailVerificationGate
+						noticeText={ this.translate( 'You must verify your email to sign in with WordPress.com.' ) }
+						noticeStatus="is-info">
+						<Card>
+							{ user.email_verified && this.maybeRenderErrorNotice() }
+								<div className="jetpack-connect__sso-user-profile">
+									<Gravatar user={ user } size={ 120 } imgSize={ 400 } />
+									<h3 className="jetpack-connect__sso-log-in-as">
+										{ this.translate(
+											'Log in as {{strong}}%s{{/strong}}',
+											{
+												args: user.display_name,
+												components: {
+													strong: <strong className="jetpack-connect__sso-display-name" />
+												}
+											}
+										) }
+									</h3>
+									<div className="jetpack-connect__sso-user-email">
+										{ user.email }
+									</div>
+								</div>
 
-						<LoggedOutFormFooter className="jetpack-connect__sso-actions">
-							<p className="jetpack-connect__tos-link">
-								{ this.getTOSText() }
-							</p>
+								<LoggedOutFormFooter className="jetpack-connect__sso-actions">
+									<p className="jetpack-connect__tos-link">
+										{ this.getTOSText() }
+									</p>
 
-							<Button
-								primary
-								onClick={ this.onApproveSSO }
-								disabled={ this.isButtonDisabled() }>
-								{ this.translate( 'Log in' ) }
-							</Button>
-						</LoggedOutFormFooter>
-					</Card>
+									<Button
+										primary
+										onClick={ this.onApproveSSO }
+										disabled={ this.isButtonDisabled() }>
+										{ this.translate( 'Log in' ) }
+									</Button>
+								</LoggedOutFormFooter>
+						</Card>
+					</EmailVerificationGate>
 
 					<LoggedOutFormLinks>
 						<LoggedOutFormLinkItem href={ this.getSignInLink() } onClick={ this.onClickSignInDifferentUser }>

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -454,6 +454,15 @@
 	color: transparent;
 }
 
+.jetpack-connect__sso .email-verification-gate .notice {
+	margin-bottom: 0;
+}
+
+.jetpack-connect__sso .email-verification-gate .notice__text {
+	word-wrap: break-word;
+	word-break: break-word;
+}
+
 .jetpack-connect__help-button {
 	.gridicon {
 		width: 18px;


### PR DESCRIPTION
Fixes: Automattic/jetpack#4965. At least for the WPCOM side.

Currently, if a user attempts to use SSO with an unverified WP.com account, they'll get this vague notice on the Jetpack site:

![error_invalid_repsonse_data](https://cloud.githubusercontent.com/assets/1126811/18403324/b3b21b9e-76a9-11e6-92b1-e6bc97df87ff.png)

This is partly due to us not checking if the user has verified their email on the WP.com side. We do in the API, but not in Calypso.

This changeset adds in the `EmailVerificationGate` component to tell the user to verify their email.

It looks like this:

![screen shot 2016-09-09 at 4 17 01 pm](https://cloud.githubusercontent.com/assets/1126811/18403360/e6ff6c72-76a9-11e6-8985-885d28a00b17.png)

Clicking resend shows a notice like this:

![screen shot 2016-09-09 at 4 17 06 pm](https://cloud.githubusercontent.com/assets/1126811/18403365/ee9af30c-76a9-11e6-9d75-9bc2d6bad755.png)

Dismissing that notice shows the first one again.

Note: There was a bit of refactoring of the `EmailVerificationGate` functionality so that we could pass in our own notice text and status. To handle that, the email verification notice now shows the `Resend` action as a `NoticeAction` if the text has been passed in. Developer can choose to link to `/me/account` to prompt users to change their email through the `noticeText` prop

If we're OK with these changes, I'd suggest we merge and I can handle the documentation in a follow-up PR.

To test

- Checkout `update/sso-unverified-email` branch
- Create new user only account at `/start/account/user` and do not verify email
- Go to one of your test sites and try to login with SSO
- You should see the above
- Test that it works as expected
- Verify account
- Ensure that you can now SSO without notice

cc @rickybanister @lezama for review

