### PR TITLE
Checkout / Post-Checkout: activate paid NUX streamlining A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -102,8 +102,8 @@ module.exports = {
 	paidNuxStreamlined: {
 		datestamp: '20160912',
 		variations: {
-			original: 100,
-			streamlined: 0,
+			original: 50,
+			streamlined: 50,
 		},
 		defaultVariation: 'original',
 	},


### PR DESCRIPTION
This PR sets the desired percentages for the `paidNuxStreamlined` A/B test that is set to start `20160912`. 