### PR TITLE
Reader: Update max-height in full-post

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -208,19 +208,22 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			margin: 0 0 19px;
 		}
 
-		.reader-related-card-v2__post {
-			max-height: 200px;
+		.has-thumbnail {
 
-			@include breakpoint( "<960px" ) {
-				max-height: 240px;
-			}
+			.reader-related-card-v2__post {
+				max-height: 200px;
 
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 120px;
-			}
+				@include breakpoint( "<960px" ) {
+					max-height: 240px;
+				}
 
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 120px;
+				@media #{$reader-related-card-v2-breakpoint-medium} {
+					max-height: 120px;
+				}
+
+				@media #{$reader-related-card-v2-breakpoint-small} {
+					max-height: 120px;
+				}
 			}
 		}
 	}
@@ -281,6 +284,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 
 		.reader-related-card-v2__post {
+			max-height: 120px;
 
 			&::after {
 				@include long-content-fade( $size: 30% );
@@ -392,18 +396,10 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2__title {
-	font-size: 18px;
+	font-size: 16px;
 	font-weight: 700;
 	line-height: 1.4;
 	margin-bottom: 10px;
-
-	@media #{$reader-related-card-v2-breakpoint-medium} {
-		font-size: 16px;
-	}
-
-	@media #{$reader-related-card-v2-breakpoint-small} {
-		font-size: 16px;
-	}
 }
 
 .reader-related-card-v2__excerpt {
@@ -416,20 +412,12 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
     }
 
     &.post-excerpt {
-    	font-size: 16px;
+    	font-size: 14px;
 		overflow : hidden;
 		text-overflow: ellipsis;
 		display: -webkit-box;
 		-webkit-line-clamp: 10;
 		-webkit-box-orient: vertical;
 		max-height: none;
-
-		@media #{$reader-related-card-v2-breakpoint-medium} {
-			font-size: 14px;
-		}
-
-		@media #{$reader-related-card-v2-breakpoint-small} {
-			font-size: 14px;
-		}
     }
 }

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -127,7 +127,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 	.reader-related-card-v2__post {
 		display: block;
-		max-height: none;
 		overflow: hidden;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
@@ -251,6 +250,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 
 		.reader-related-card-v2__post {
+			max-height: 200px;
+
+			@include breakpoint( "<960px" ) {
+				max-height: 245px;
+			}
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
 				max-height: 150px;


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/7628, I've removed the max-height set when cards have no thumbnails. But since we're user longer excerpts now (update in https://github.com/Automattic/wp-calypso/commit/913485deb0260dd6f15cfa95e624e98d9d93a9a8), we'd need to revert to using max-height for no-thumbnail posts.

**Before:**
![screenshot 2016-09-09 15 22 41](https://cloud.githubusercontent.com/assets/4924246/18404747/459a990e-76a1-11e6-9066-8a7278e1d597.png)

**After:**
![screenshot 2016-09-09 15 21 37](https://cloud.githubusercontent.com/assets/4924246/18404719/1f21ae0c-76a1-11e6-86d6-fef12c75fd2c.png)

