### PR TITLE
Devdocs: fix error thrown by Reader Avatar component

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -38,7 +38,7 @@ const ReaderAvatar = React.createClass( {
 		}
 
 		const hasSiteIcon = !! siteIcon;
-		let hasAvatar = !! author.has_avatar;
+		let hasAvatar = !! ( author && author.has_avatar );
 
 		if ( hasSiteIcon && hasAvatar ) {
 			// do these both reference the same image? disregard querystring params.


### PR DESCRIPTION
At least in devdocs/blocks, the ReaderAvatar component throws an error
because the author is null. This change adds a check for a null author.