### PR TITLE
Reader: Use the new state passed when updating full post state

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -291,8 +291,8 @@ export class FullPostFluxContainer extends React.Component {
 		};
 	}
 
-	updateState() {
-		this.smartSetState( this.getStateFromStores() );
+	updateState( newState = this.getStateFromStores() ) {
+		this.smartSetState( newState );
 	}
 
 	componentWillMount() {


### PR DESCRIPTION
Fixes the double click required to load related posts