### PR TITLE
Plans: Redirect to primary site if none selected

### DIFF
--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -16,8 +16,8 @@ export default function() {
 	if ( config.isEnabled( 'manage/plans' ) ) {
 		page(
 			'/plans',
-			controller.siteSelection,
-			controller.sites
+			controller.navigation,
+			controller.redirectToPrimary
 		);
 
 		page(


### PR DESCRIPTION
- Resolves #7812 
- Introduces `redirectToPrimary` controller to use when necessary
- Redirects `/plans` to `plans/primarySite`

## Testing
- go to `/plans`
- see that you are redirected to `/plans/yourPrimarySite`
- log in account with only 1 site
- go to /settings
- see that you are redirected to `/settings/primarySite`

## Doubts

I am not quite sure this is the way to go. I am confused why `fieldguide` is my primary site and I havo no idea how to change this.

Also, I believe that /plans should work without selected site. We should rearrange the page to work logged-out and ultimately present that when user is not logged in or no site is selected.
Ultimately I would like us to:
1. Merge this PR because it solves existing problem
2. End all pricing tests
3. Hardcode pricing to calypso - that would be the final piece to present all `/plans` logged-out
4. Make `/plans` work without a site or a user (NO placeholders)
5. Present that on `/pricing` and `/plans` instead of this redirect.

Since doing this properly requires a lot of work, we need to first merge this and then take i from here.

CC @rralian @lamosty @gwwar @supernovia
