### PR TITLE
Comment Button: Add context to the button caption

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -39,22 +39,32 @@ const CommentButton = React.createClass( {
 	render() {
 		let label;
 		const containerTag = this.props.tagName,
-			commentCount = this.props.commentCount;
+			commentCount = this.props.commentCount,
+			commentCountComponent = <span className="comment-button__label-count">
+				{ commentCount }
+			</span>;
 
 		if ( commentCount === 0 ) {
-			label = this.translate( 'Comment' );
+			label = <span className="comment-button__label-status">
+				{ this.translate( 'Comment', { context: 'verb' } ) }
+			</span>;
 		} else {
 			label = this.translate(
-				'Comment',
-				'Comments', {
+				'{{count/}}{{span}}Comment{{/span}}',
+				'{{count/}}{{span}}Comments{{/span}}', {
+					components: {
+						count: commentCountComponent,
+						span: <span className="comment-button__label-status" />
+					},
 					count: commentCount,
 				}
 			);
 		}
 
+		// If the label is to be shown, output the label from above,
+		// otherwise just show the count if it's > 0.
 		const labelElement = ( <span className="comment-button__label">
-			{ commentCount > 0 ? <span className="comment-button__label-count">{ commentCount }</span> : null }
-			{ this.props.showLabel && <span className="comment-button__label-status">{ label }</span> }
+			{ this.props.showLabel ? label : commentCount > 0 && commentCountComponent }
 		</span> );
 
 		return React.createElement(


### PR DESCRIPTION
Follow-up to #3816.

The comment button has two states:
 * There are no comments yet: "Comment"
 * There are some comments already: "1 Comment" or "2 Comments"

In English this is fine because comment can be a noun or a verb. In other languages you need to distinguish between the two. E.g. in Portuguese, when it just says "Comment" you need to translate it as "Comentar" (because it means something like "Comment Now"), while when it's a number of comments it needs to be translated as "Comentario" or "Comentarios".

To fix this, I added a context `verb` to the first label.

Unfortunately that's not enough. Because we are using Gettext, originals are distinguished by the singular form. In this button this is also "Comment" which wouldn't clash with the first label anymore but with other translations on WordPress.com. That's the reason I am adding another context there.