### PR TITLE
Update/image editor canvas zero changes

### DIFF
--- a/client/post-editor/media-modal/image-editor/image-editor-buttons.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-buttons.jsx
@@ -47,12 +47,11 @@ const MediaModalImageEditorButtons = React.createClass( {
 					{ this.translate( 'Cancel' ) }
 				</Button>
 				<Button
-					disabled={ ! this.props.hasChanges }
 					onClick={ this.props.resetImageEditorState } >
 					{ this.translate( 'Reset' ) }
 				</Button>
 				<Button
-					disabled={ ! this.props.src }
+					disabled={ ! this.props.src || ! this.props.hasChanges }
 					primary
 					onClick={ this.props.onDone } >
 					{ this.translate( ' Done ' ) }


### PR DESCRIPTION
This PR tries to achieve the changes detection when the user uses Image Editor.
The idea is that we have a default object with the initial values of `transform` and `crop`. The new gotten values are compared with these initial ones and if exists a difference at least in one of them then the `Done` button is enabled.
I've had to add a threshold for window crop values since sometimes it's tricky for the user gets back to the inicial ones.

![image-editor-canvas-changes](https://cloud.githubusercontent.com/assets/77539/18436551/5e65b2e0-78cf-11e6-803c-b2d2445612ce.gif)


### Issues

#7989

### Testing

1) Create/Edit a new post
2) Add a media image
3) Start to edit the image meta data (bottom left button)
4) Start to edit the image (top right button)
6) Play with transform (`rotate`, `aspect`, and `flip`) and crop resizing the area to cut the image.

The `Done` button should be enabled/disabled depending of if image must be generated.

cc @gwwar @alisterscott 
