### PR TITLE
Comments: Disable manual resizing of comments textarea

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -43,7 +43,6 @@
 			min-height: 33px;
 			margin: 0;
 			padding: 5px 60px 5px 5px;
-			resize: vertical;
 			font-size: 14px;
 			font-family: $serif;
 			line-height: 21px;
@@ -57,6 +56,7 @@
 				top: 0;
 				left: 0;
 			height: 100%;
+			resize: none;
 		}
 
 		pre {

--- a/client/reader/comments/style.scss
+++ b/client/reader/comments/style.scss
@@ -42,7 +42,6 @@
 			min-height: 33px;
 			margin: 0;
 			padding: 5px 60px 5px 5px;
-			resize: vertical;
 			font-size: 14px;
 			font-family: $serif;
 			line-height: 21px;
@@ -56,6 +55,7 @@
 				top: 0;
 				left: 0;
 			height: 100%;
+			resize: none;
 		}
 
 		pre {


### PR DESCRIPTION
This PR fixes #8035, where there is an overflow issue with the manual resizing of a comments textarea. The PR basically disables manual resizing of the comments textarea, as it is unnecessary - the height is automatically updated when the user types more (or less) lines within their comment.

#### To test:
_My Sites > Posts_

1. Go to `/posts/$site` where `$site` is one of your sites
2. Click the Comment icon of a post.
3. Verify the comments textarea can't be expanded manually, but it expands properly when typing more lines of text.

_Reader_

1. Go to `/read/blogs/$blogId/posts/$postId` where `$siteId` is the ID of a site, and `$postId` is a valid post ID
2. Click the Comment icon of a post.
3. Verify the comments textarea can't be expanded manually, but it expands properly when typing more lines of text.

/cc @blowery @bluefuton 
