### PR TITLE
Menus: Display empty options list message not only for pages

### DIFF
--- a/client/my-sites/menus/item-options/empty-placeholder.jsx
+++ b/client/my-sites/menus/item-options/empty-placeholder.jsx
@@ -9,8 +9,8 @@ import React, { PropTypes } from 'react';
 const EmptyPlaceholder = React.createClass( {
 	propTypes: {
 		typeName: PropTypes.string.isRequired,
-		typeFamily: PropTypes.string.isRequired,
 		createLink: PropTypes.string.isRequired,
+		notFoundLabel: PropTypes.string.isRequired,
 		isSearch: PropTypes.bool
 	},
 

--- a/client/my-sites/menus/item-options/empty-placeholder.jsx
+++ b/client/my-sites/menus/item-options/empty-placeholder.jsx
@@ -2,14 +2,6 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
-import { endsWith } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { getPostTypes } from 'state/post-types/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Component
@@ -51,7 +43,7 @@ const EmptyPlaceholder = React.createClass( {
 					context: 'Menus: item search/listing results',
 					comment: 'Used when no posts match the given search, or if there are no posts at all.',
 					components: {
-						a: <a className="create-link" href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
+						a: <a className="create-link" href={ this.props.createLink } />
 					}
 				} );
 			case 'page':
@@ -59,7 +51,7 @@ const EmptyPlaceholder = React.createClass( {
 					context: 'Menus: item search/listing results',
 					comment: 'Used when no pages match the given search, or if there are no pages at all.',
 					components: {
-						a: <a className="create-link" href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
+						a: <a className="create-link" href={ this.props.createLink } />
 					}
 				} );
 			default:
@@ -67,32 +59,14 @@ const EmptyPlaceholder = React.createClass( {
 					context: 'Menus: item search/listing results',
 					comment: 'Used when no results are found for the given search, or if there are no results of the given item type.',
 					components: {
-						a: <a className="create-link" href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
+						a: <a className="create-link" href={ this.props.createLink } />
 					}
 				} );
 		}
 	},
 
 	noOptionsMessage() {
-		if ( this.props.typeFamily === 'post_type' ) {
-			const postTypes = this.props.postTypes;
-			if ( postTypes[ this.props.typeName ] && postTypes[ this.props.typeName ].labels.not_found ) {
-				let message = postTypes[ this.props.typeName ].labels.not_found;
-				if ( ! endsWith( message, '.' ) ) {
-					message += '.';
-				}
-				return message;
-			}
-		}
-
-		switch ( this.props.typeName ) {
-			case 'category':
-				return this.translate( 'No categories found.' );
-			case 'post_tag':
-				return this.translate( 'No tags found.' );
-			default:
-				return this.translate( 'Nothing found.' );
-		}
+		return this.props.notFoundLabel;
 	},
 
 	noSearchResultsMessage() {
@@ -107,19 +81,10 @@ const EmptyPlaceholder = React.createClass( {
 					: this.noOptionsMessage()
 				}
 				&nbsp;
-				{ this.props.typeName !== 'post_tag'
-					? this.createOptionMessage()
-					: null
-				}
+				{ this.props.typeName !== 'post_tag' && this.createOptionMessage() }
 			</span>
 		);
 	},
 } );
 
-export default connect(
-	state => {
-		return {
-			postTypes: getPostTypes( state, getSelectedSiteId( state ) )
-		};
-	}
-)( EmptyPlaceholder );
+export default EmptyPlaceholder;

--- a/client/my-sites/menus/item-options/empty-placeholder.jsx
+++ b/client/my-sites/menus/item-options/empty-placeholder.jsx
@@ -1,91 +1,107 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { endsWith } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPostTypes } from 'state/post-types/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Component
  */
-var EmptyPlaceholder = React.createClass( {
+const EmptyPlaceholder = React.createClass( {
 	propTypes: {
-		typeName: React.PropTypes.string.isRequired,
-		createLink: React.PropTypes.string.isRequired,
-		isSearch: React.PropTypes.bool
+		typeName: PropTypes.string.isRequired,
+		typeFamily: PropTypes.string.isRequired,
+		createLink: PropTypes.string.isRequired,
+		isSearch: PropTypes.bool
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			isSearch: false
 		};
 	},
 
-	createOptionMessage: function() {
+	createOptionMessage() {
 		switch ( this.props.typeName ) {
 			case 'category':
 				return this.translate( 'You may want to {{a}}create a new category{{/a}}.', {
 					context: 'Menus: item search/listing results',
-					comment: 'This is used when no categories match the given search, or if there are no categories at all.',
+					comment: 'Used when no categories match the given search, or if there are no categories at all.',
 					components: {
-						a: <a className='create-link' href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
+						a: <a className="create-link" href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
 					}
 				} );
 			case 'post_tag':
 				return this.translate( 'You may want to {{a}}create a new tag{{/a}}.', {
 					context: 'Menus: item search/listing results',
-					comment: 'This is used when no tags match the given search, or if there are no tags at all.',
+					comment: 'Used when no tags match the given search, or if there are no tags at all.',
 					components: {
-						a: <a className='create-link' href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
+						a: <a className="create-link" href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
 					}
 				} );
 			case 'post':
 				return this.translate( 'You may want to {{a}}create a new post{{/a}}.', {
 					context: 'Menus: item search/listing results',
-					comment: 'This is used when no posts match the given search, or if there are no posts at all.',
+					comment: 'Used when no posts match the given search, or if there are no posts at all.',
 					components: {
-						a: <a className='create-link' href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
+						a: <a className="create-link" href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
 					}
 				} );
 			case 'page':
 				return this.translate( 'You may want to {{a}}create a new page{{/a}}.', {
 					context: 'Menus: item search/listing results',
-					comment: 'This is used when no pages match the given search, or if there are no pages at all.',
+					comment: 'Used when no pages match the given search, or if there are no pages at all.',
 					components: {
-						a: <a className='create-link' href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
+						a: <a className="create-link" href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
 					}
 				} );
 			default:
 				return this.translate( 'You may want to {{a}}create a new one{{/a}}.', {
 					context: 'Menus: item search/listing results',
-					comment: 'This is used when no results are found for the given search, or if there are no results of the given item type at all.',
+					comment: 'Used when no results are found for the given search, or if there are no results of the given item type.',
 					components: {
-						a: <a className='create-link' href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
+						a: <a className="create-link" href={ this.props.createLink } target="_blank" rel="noopener noreferrer" />
 					}
 				} );
 		}
 	},
 
-	noOptionsMessage: function() {
+	noOptionsMessage() {
+		if ( this.props.typeFamily === 'post_type' ) {
+			const postTypes = this.props.postTypes;
+			if ( postTypes[ this.props.typeName ] && postTypes[ this.props.typeName ].labels.not_found ) {
+				let message = postTypes[ this.props.typeName ].labels.not_found;
+				if ( ! endsWith( message, '.' ) ) {
+					message += '.';
+				}
+				return message;
+			}
+		}
+
 		switch ( this.props.typeName ) {
 			case 'category':
 				return this.translate( 'No categories found.' );
 			case 'post_tag':
 				return this.translate( 'No tags found.' );
-			case 'post':
-				return this.translate( 'No posts found.' );
-			case 'page':
-				return this.translate( 'No pages found.' );
 			default:
 				return this.translate( 'Nothing found.' );
 		}
 	},
 
-	noSearchResultsMessage: function() {
+	noSearchResultsMessage() {
 		return this.translate( 'No results. Please try a different search.' );
 	},
 
-	render: function() {
+	render() {
 		return (
-			<span className='is-empty-content'>
+			<span className="is-empty-content">
 				{ this.props.isSearch
 					? this.noSearchResultsMessage()
 					: this.noOptionsMessage()
@@ -100,4 +116,10 @@ var EmptyPlaceholder = React.createClass( {
 	},
 } );
 
-module.exports = EmptyPlaceholder;
+export default connect(
+	state => {
+		return {
+			postTypes: getPostTypes( state, getSelectedSiteId( state ) )
+		};
+	}
+)( EmptyPlaceholder );

--- a/client/my-sites/menus/item-options/empty-placeholder.jsx
+++ b/client/my-sites/menus/item-options/empty-placeholder.jsx
@@ -65,7 +65,18 @@ var EmptyPlaceholder = React.createClass( {
 	},
 
 	noOptionsMessage: function() {
-		return this.translate( 'Nothing found.' );
+		switch ( this.props.typeName ) {
+			case 'category':
+				return this.translate( 'No categories found.' );
+			case 'post_tag':
+				return this.translate( 'No tags found.' );
+			case 'post':
+				return this.translate( 'No posts found.' );
+			case 'page':
+				return this.translate( 'No pages found.' );
+			default:
+				return this.translate( 'Nothing found.' );
+		}
 	},
 
 	noSearchResultsMessage: function() {
@@ -75,8 +86,15 @@ var EmptyPlaceholder = React.createClass( {
 	render: function() {
 		return (
 			<span className='is-empty-content'>
-				{ this.props.isSearch ? this.noSearchResultsMessage() : this.noOptionsMessage() }
-				&nbsp;{ this.createOptionMessage() }
+				{ this.props.isSearch
+					? this.noSearchResultsMessage()
+					: this.noOptionsMessage()
+				}
+				&nbsp;
+				{ this.props.typeName !== 'post_tag'
+					? this.createOptionMessage()
+					: null
+				}
 			</span>
 		);
 	},

--- a/client/my-sites/menus/item-options/option-list.jsx
+++ b/client/my-sites/menus/item-options/option-list.jsx
@@ -97,7 +97,6 @@ var OptionList = React.createClass( {
 					{ this.props.children }
 					{ this.props.isLoading && <LoadingPlaceholder/> }
 					{ this.props.isEmpty &&
-						this.props.itemType === 'page' &&
 						<EmptyPlaceholder isSearch={ !! ( this.state.searchTerm && this.state.searchTerm.length ) }
 							createLink={ this.props.itemType.createLink }
 							typeName={ this.props.itemType.name } />

--- a/client/my-sites/menus/item-options/option-list.jsx
+++ b/client/my-sites/menus/item-options/option-list.jsx
@@ -100,7 +100,6 @@ var OptionList = React.createClass( {
 						<EmptyPlaceholder isSearch={ !! ( this.state.searchTerm && this.state.searchTerm.length ) }
 							notFoundLabel={ this.props.itemType.notFoundLabel }
 							createLink={ this.props.itemType.createLink }
-							typeFamily= { this.props.itemType.family }
 							typeName={ this.props.itemType.name } />
 					}
 				</form>

--- a/client/my-sites/menus/item-options/option-list.jsx
+++ b/client/my-sites/menus/item-options/option-list.jsx
@@ -99,6 +99,7 @@ var OptionList = React.createClass( {
 					{ this.props.isEmpty &&
 						<EmptyPlaceholder isSearch={ !! ( this.state.searchTerm && this.state.searchTerm.length ) }
 							createLink={ this.props.itemType.createLink }
+							typeFamily= { this.props.itemType.family }
 							typeName={ this.props.itemType.name } />
 					}
 				</form>

--- a/client/my-sites/menus/item-options/option-list.jsx
+++ b/client/my-sites/menus/item-options/option-list.jsx
@@ -98,6 +98,7 @@ var OptionList = React.createClass( {
 					{ this.props.isLoading && <LoadingPlaceholder/> }
 					{ this.props.isEmpty &&
 						<EmptyPlaceholder isSearch={ !! ( this.state.searchTerm && this.state.searchTerm.length ) }
+							notFoundLabel={ this.props.itemType.notFoundLabel }
 							createLink={ this.props.itemType.createLink }
 							typeFamily= { this.props.itemType.family }
 							typeName={ this.props.itemType.name } />

--- a/client/my-sites/menus/menu-item-types.js
+++ b/client/my-sites/menus/menu-item-types.js
@@ -195,7 +195,7 @@ MenuItemTypes.prototype.parse = function() {
 			show: true,
 			label: type.label, //FIXME: how do we handle i18n here?
 			notFoundLabel: notFoundLabel && endsWith( notFoundLabel, '.' ) ? notFoundLabel : notFoundLabel + '.',
-			createLink: `/edit/${ type.name }/${ this.site.slug }`,
+			createLink: `/edit/${ type.name }/${ this.site.slug }`, // TODO: Use the getEditorNewPostPath() selector.
 			gaEventLabel: type.label
 		} );
 	}, this );

--- a/client/my-sites/menus/menu-item-types.js
+++ b/client/my-sites/menus/menu-item-types.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-var find = require( 'lodash/find'),
+var find = require( 'lodash/find' ),
+	get = require( 'lodash/get' ),
+	endsWith = require( 'lodash/endsWith' ),
 	i18n = require( 'i18n-calypso' );
 
 /**
@@ -77,7 +79,8 @@ MenuItemTypes.prototype.initializeDefaultTypes = function() {
 				renderer: 'renderPostOptions',
 				show: true,
 				label: i18n.translate( 'Page' ),
-				createLink: '//wordpress.com/page/' + this.site.ID  + '/new',
+				notFoundLabel: i18n.translate( 'No pages found.' ),
+				createLink: '/page/' + this.site.ID + '/new',
 				gaEventLabel: 'Page'
 			},
 			{
@@ -96,6 +99,7 @@ MenuItemTypes.prototype.initializeDefaultTypes = function() {
 				renderer: 'renderCategoryOptions',
 				show: true,
 				label: i18n.translate( 'Category' ),
+				notFoundLabel: i18n.translate( 'No categories found.' ),
 				createLink: this.site.options.admin_url + 'edit-tags.php?taxonomy=category',
 				gaEventLabel: 'Category'
 			},
@@ -107,6 +111,7 @@ MenuItemTypes.prototype.initializeDefaultTypes = function() {
 				renderer: 'renderTaxonomyOptions',
 				show: true,
 				label: i18n.translate( 'Tag' ),
+				notFoundLabel: i18n.translate( 'No tags found.' ),
 				createLink: this.site.options.admin_url + 'edit-tags.php?taxonomy=post_tag',
 				gaEventLabel: 'Tag'
 			},
@@ -117,6 +122,7 @@ MenuItemTypes.prototype.initializeDefaultTypes = function() {
 				renderer: 'renderTaxonomyContents',
 				show: false,
 				label: i18n.translate( 'Post Format' ),
+				notFoundLabel: i18n.translate( 'No post formats found.' ),
 				gaEventLabel: 'Post Format'
 			},
 			{
@@ -126,7 +132,8 @@ MenuItemTypes.prototype.initializeDefaultTypes = function() {
 				renderer: 'renderPostOptions',
 				show: true,
 				label: i18n.translate( 'Post' ),
-				createLink: '//wordpress.com/post/' + this.site.ID  + '/new',
+				notFoundLabel: i18n.translate( 'No posts found.' ),
+				createLink: '/post/' + this.site.ID + '/new',
 				gaEventLabel: 'Post'
 			}
 	];
@@ -179,6 +186,7 @@ MenuItemTypes.prototype.parse = function() {
 	debug( 'Found some new types', newTypes );
 
 	newTypes.forEach( function( type ) {
+		const notFoundLabel = get( type, [ 'labels', 'not_found' ], '' );
 		this.data.push( {
 			name: type.name,
 			family: 'post_type',
@@ -186,6 +194,7 @@ MenuItemTypes.prototype.parse = function() {
 			renderer: 'renderPostOptions',
 			show: true,
 			label: type.label, //FIXME: how do we handle i18n here?
+			notFoundLabel: notFoundLabel && endsWith( notFoundLabel, '.' ) ? notFoundLabel : notFoundLabel + '.',
 			createLink: `/edit/${ type.name }/${ this.site.slug }`,
 			gaEventLabel: type.label
 		} );

--- a/client/my-sites/menus/menu-item-types.js
+++ b/client/my-sites/menus/menu-item-types.js
@@ -186,7 +186,7 @@ MenuItemTypes.prototype.parse = function() {
 			renderer: 'renderPostOptions',
 			show: true,
 			label: type.label, //FIXME: how do we handle i18n here?
-			createLink: this.site.options.admin_url + 'post-new.php?post_type=' + type.name,
+			createLink: `/edit/${ type.name }/${ this.site.slug }`,
 			gaEventLabel: type.label
 		} );
 	}, this );


### PR DESCRIPTION
When adding a new menu item or editing one, if the options list is empty, the corresponding "empty" message is displayed only for pages, but not for tags, posts, or other post types that have no entries at this time.

![](https://cldup.com/Ch0Lq7W0lN.png)

This PR removes the "page only" check, allowing the empty message to be displayed for all other menu item option lists when they are empty:

![](https://cldup.com/uO5pbFqrL8.png)

This was introduced in https://github.com/Automattic/wp-calypso/pull/4034

To test:
1. Checkout this branch
2. Go to `/menus/$site` where `$site` is the slug of one of your sites
3. Make sure you have no tags and no posts
4. Open an existing menu item, or add a new one.
5. Click the "Tag" tab and verify that the proper "empty" message is displayed.
6. Click the "Post" tab and verify that the proper "empty" message is displayed.
7. Verify the same works with custom post types (e.g. Jetpack testimonials or portfolio)

/cc @artpi



