### PR TITLE
Framework: Add Webpack JSON output option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 !*.swf
 .eslintcache
 test-results*.xml
+/stats.json
 
 # script used during docker build that is specific to the environment
 env-config.sh

--- a/server/bundler/README.md
+++ b/server/bundler/README.md
@@ -83,3 +83,14 @@ There are two different modes of operation:
 ### Caching
 
 In most of the environments that Calypso is deployed to, the static assets are served and cached by nginx. Each filename includes a hash that is calculated by Webpack, which means that we can cache assets for all the various versions of Calpso that may be in active use. The hash also busts the cache on the client-side.
+
+### Webpack Stats
+
+Webpack stats can be serialized as JSON for the purposes of analyzing the results of a build. This can be used with tools like [Webpack Analyze](https://webpack.github.io/analyse/) or [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/) to visualize the modules and dependencies comprising a build. To generate a JSON file during a build, use the `WEBPACK_OUTPUT_JSON` environment variable flag:
+
+```bash
+WEBPACK_OUTPUT_JSON=1 NODE_ENV=production make build
+```
+
+This will cause a JSON file `stats.json` to be written to the root project directory once the build succeeds.
+

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -70,6 +70,12 @@ webpack( webpackConfig, function( error, stats ) {
 	}
 
 	process.stdout.write( stats.toString( outputOptions ) + "\n");
+	if ( process.env.WEBPACK_OUTPUT_JSON ) {
+		fs.writeFile(
+			path.join( process.cwd(), 'stats.json' ),
+			JSON.stringify( stats.toJson() )
+		);
+	}
 
 	assets = utils.getAssets( stats.toJson() );
 


### PR DESCRIPTION
This pull request seeks to facilitate generating JSON output of Webpack stats, which can be used in build analysis tools like [Webpack Analyse](https://webpack.github.io/analyse/) or [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/). With these changes, when generating a build, if a `WEBPACK_OUTPUT_JSON` environment variable flag is present, a `stats.json` file will be written to the project root directory upon successful build.

__Testing instructions:__

Run the following command:

```
WEBPACK_OUTPUT_JSON=1 NODE_ENV=production make build
```

Note that after the build succeeds, a `stats.json` file is generated and can be uploaded for analysis to one of the tools above.

cc @dmsnell @blowery 
Ref: p1471462693004266-slack-calypso