### PR TITLE
Image Editor: disable on non-desktop/touch devices

### DIFF
--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -21,6 +21,9 @@ var EditorMediaModalDetailFields = require( './detail-fields' ),
 	MediaUtils = require( 'lib/media/utils' ),
 	config = require( 'config' );
 
+import { isDesktop } from 'lib/viewport';
+import { hasTouch } from 'lib/touch-detect';
+
 module.exports = React.createClass( {
 	displayName: 'EditorMediaModalDetailItem',
 
@@ -44,6 +47,10 @@ module.exports = React.createClass( {
 		};
 	},
 
+	isMobileTouchDevice() {
+		return ! isDesktop() || hasTouch();
+	},
+
 	renderEditButton: function() {
 		const { item, onEdit, site } = this.props;
 
@@ -52,9 +59,12 @@ module.exports = React.createClass( {
 			return debug( 'Do not show `Edit button` for private sites' );
 		}
 
-		if ( ! config.isEnabled( 'post-editor/image-editor' ) ||
+		if (
+			! config.isEnabled( 'post-editor/image-editor' ) ||
 			! userCan( 'upload_files', site ) ||
-			! item ) {
+			this.isMobileTouchDevice() ||
+			! item
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #7979.

The image editor doesn't yet support touch events. Let's disable it for mobiles/touch devices until we got it supported.

## Testing Instructions

1. In browser: In media modal, select an image and click on Edit;
2. Do you see "Edit image" button? Can you edit the image?
3. Either use a mobile device or just simulate it with dev tools: enable touch and/or resize browser window to <= 960px and reload the page;
4. Is the "Edit Image" button hidden? Is it not possible for you to edit the image?

Note: some desktop devices support touch events (e.g. Dell XPS 15). Image editor is disabled on them too. Maybe we could enable it on screen widths >960px, however some mobile devices might have this large screen and the image editor wouldn't still be usable. Any ideas?

/cc @gwwar @rralian @retrofox 