### PR TITLE
ImageEditor: move cancel button to the side of reset button

### DIFF
--- a/client/post-editor/media-modal/image-editor/_style.scss
+++ b/client/post-editor/media-modal/image-editor/_style.scss
@@ -93,7 +93,3 @@
 .editor-media-modal-image-editor__buttons button {
 	margin-left: 10px;
 }
-
-.editor-media-modal-image-editor__buttons-cancel {
-	float: left;
-}


### PR DESCRIPTION
Addresses #8024. Just moving the cancel button to sit alongside the other buttons on the bottom right of the modal.

![cancel button](https://cloudup.com/cUKFblhO4Nb+)