### PR TITLE
Reader: Fix avatar size on search cards

### DIFF
--- a/client/blocks/reader-search-card/style.scss
+++ b/client/blocks/reader-search-card/style.scss
@@ -239,8 +239,6 @@
 	.gravatar {
 		vertical-align: text-bottom;
 		margin: 0 4px 0 0;
-		width: 80px;
-		height: 80px;
 	}
 }
 


### PR DESCRIPTION
before 
<img width="745" alt="parenting_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/18449387/ef93b00a-78fc-11e6-9ec6-aa1a43541501.png">

after
<img width="753" alt="parenting_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/18449370/e136a15c-78fc-11e6-84bd-ee562f58b806.png">

