### PR TITLE
Advanced SEO: Fix missing labels in title format editor

### DIFF
--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -72,7 +72,7 @@ export class MetaTitleEditor extends Component {
 						key={ type.value }
 						disabled={ disabled }
 						onChange={ this.updateTitleFormat }
-						type={ disabled ? { label: '' } : type }
+						type={ type }
 						titleFormats={ get( titleFormats, type.value, [] ) }
 						tokens={ getTokensForType( type.value, translate ) }
 					/>


### PR DESCRIPTION
Always pass the `type` through, even if we're disabled so that the labels still show on the form.

cc @dmsnell I'm not sure why we wanted the `label` to be empty, I might be missing something.

Fixes #8046