### PR TITLE
Advanced SEO: Fix alignment of icon and label in preview toolbar

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -138,8 +138,6 @@
 	}
 
 	&.web-preview__seo-button {
-		display: flex;
-		align-items: center;
 		padding: 0 14px;
 
 		&.is-showing-device-switcher {
@@ -151,6 +149,7 @@
 
 .web-preview__seo-label {
 	margin-left: 6px;
+	vertical-align: middle;
 }
 
 .web-preview__back-to-preview-button {


### PR DESCRIPTION
Removed flex from button to fix rendering issue on Firefox.

I verified that it still looks ok in Safari, Chrome and IE 11.

<img width="99" alt="screen shot 2016-09-12 at 3 25 04 pm" src="https://cloud.githubusercontent.com/assets/789137/18455483/0a4cf0ee-78ff-11e6-8540-bfc7cbcdc188.png">

Fixes #8050