### PR TITLE
Reader: Fix RP getting cropped in mobile browsers

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -246,7 +246,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			max-height: 205px;
 
 			@include breakpoint( "<960px" ) {
-				max-height: 245px;
+				max-height: 249px;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
@@ -254,7 +254,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 150px;
+				max-height: 142px;
 			}
 		}
 
@@ -273,6 +273,10 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 			.reader-related-card-v2__post {
 				max-height: 200px;
+
+				@media #{$reader-related-card-v2-breakpoint-small} {
+					max-height: 150px;
+				}
 			}
 		}
 


### PR DESCRIPTION
This fixes Related Posts text getting cropped in Chrome and Safari mobile.

**Recs that all have images:**

Before:
![img_3049](https://cloud.githubusercontent.com/assets/4924246/18455476/06982ba8-78ff-11e6-9768-34cd8d254c23.PNG)

After:
![img_3050](https://cloud.githubusercontent.com/assets/4924246/18455482/09d6ed86-78ff-11e6-837e-6fc570656bba.PNG)

**Image and text-only recs:**

Before:
![img_3051](https://cloud.githubusercontent.com/assets/4924246/18455520/3b4b4088-78ff-11e6-8334-96da5c031263.PNG)

After:
![img_3052](https://cloud.githubusercontent.com/assets/4924246/18455525/3fb917c6-78ff-11e6-9104-64a5088c34dd.PNG)



