### PR TITLE
ReaderSidebar: Fixed issue where AppPromo would flash in and out.

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -254,12 +254,19 @@ ReaderSidebar.defaultProps = {
 };
 
 export const shouldRenderAppPromo = ( options = { } ) => {
+	// Until the user settings have loaded we'll indicate the user is is a
+	// desktop app user because until the user settings have loaded
+	// userSettings.getSetting( 'is_desktop_app_user' ) will return false which
+	// makes the app think the user isn't a desktop app user for a few seconds
+	// resulting in the AppPromo potentially flashing in then out as soon as
+	// the user settings does properly indicate that the user is one.
+	const haveUserSettingsLoaded = userSettings.getSetting( ' is_desktop_app_user' ) === null;
 	const {
 		isDesktopPromoDisabled = store.get( 'desktop_promo_disabled' ),
 		isViewportMobile = viewport.isMobile(),
 		isUserLocaleEnglish = 'en' === userUtils.getLocaleSlug(),
 		isDesktopPromoConfiguredToRun = config.isEnabled( 'desktop-promo' ),
-		isUserDesktopAppUser = userSettings.getSetting( 'is_desktop_app_user' ),
+		isUserDesktopAppUser = haveUserSettingsLoaded || userSettings.getSetting( 'is_desktop_app_user' ),
 		isUserOnChromeOs = /\bCrOS\b/.test( navigator.userAgent )
 	} = options;
 


### PR DESCRIPTION
To Test:

1. Ensure that localStorage doesn't have `desktop_promo_disabled` set to true.
2. Load up master and open up the Reader.
3. Observe that on bottom portion of the `ReaderSidebar` the `AppPromo` will flash in and out.
4. Refresh the page and re-observe that the `AppPromo` flashes in and out.
5. Load up this branch(`fix/app-promo-flashing-in-and-out`).
6. Load up the Reader and observe that on the bottom portion of the `ReaderSidebar` no `AppPromo` flashes in and out.
7. Refresh the page and verify that the `AppPromo` doesn't flash in and out.

cc @dmsnell  