### PR TITLE
Purchases: Customize the successful renewal notice to make it more personal

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -3,10 +3,13 @@
  */
 var connect = require( 'react-redux' ).connect,
 	forEach = require( 'lodash/forEach' ),
+	find = require( 'lodash/find' ),
+	i18n = require( 'i18n-calypso' ),
 	isEmpty = require( 'lodash/isEmpty' ),
 	isEqual = require( 'lodash/isEqual' ),
 	page = require( 'page' ),
-	React = require( 'react' );
+	React = require( 'react' ),
+	reduce = require( 'lodash/reduce' );
 
 /**
  * Internal dependencies
@@ -162,25 +165,50 @@ const Checkout = React.createClass( {
 	},
 
 	getCheckoutCompleteRedirectPath: function() {
-		var renewalItem,
+		var product,
+			purchasedProducts,
+			renewalItem,
+			receipt = this.props.transaction.step.data,
 			receiptId = ':receiptId';
 
 		this.props.clearPurchases();
 
 		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
 			renewalItem = cartItems.getRenewalItems( this.props.cart )[ 0 ];
+			// group all purchases into an array
+			purchasedProducts = reduce( receipt && receipt.purchases || {}, function( result, value ) {
+				return result.concat( value );
+			}, [] );
+			// and take the first product which matches the product id of the renewalItem
+			product = find( purchasedProducts, function( item ) {
+				return item.product_id === renewalItem.product_id;
+			} );
 
-			notices.success(
-				this.translate( '%(productName)s has been renewed and will now auto renew in the future. {{a}}Learn more{{/a}}', {
-					args: {
-						productName: renewalItem.product_name
-					},
-					components: {
-						a: <a href={ supportPaths.AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
-					}
-				} ),
-				{ persistent: true }
-			);
+			if ( product && product.will_auto_renew ) {
+				notices.success(
+					this.translate( '%(productName)s has been renewed and will now auto renew in the future. {{a}}Learn more{{/a}}', {
+						args: {
+							productName: renewalItem.product_name
+						},
+						components: {
+							a: <a href={ supportPaths.AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
+						}
+					} ),
+					{ persistent: true }
+				);
+			} else if ( product ) {
+				notices.success(
+					this.translate( 'Success! You renewed %(productName)s for %(duration)s, until %(date)s. We sent your receipt to %(email)s.', {
+						args: {
+							productName: renewalItem.product_name,
+							duration: i18n.moment.duration( renewalItem.bill_period, 'days' ).humanize(),
+							date: i18n.moment( product.expiry ).format( 'MMM DD, YYYY' ),
+							email: product.user_email
+						}
+					} ),
+					{ persistent: true }
+				);
+			}
 
 			return purchasePaths.managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
 		} else if ( cartItems.hasFreeTrial( this.props.cart ) ) {
@@ -189,8 +217,8 @@ const Checkout = React.createClass( {
 			return `/plans/${ this.props.sites.getSelectedSite().slug }/thank-you`;
 		}
 
-		if ( this.props.transaction.step.data && this.props.transaction.step.data.receipt_id ) {
-			receiptId = this.props.transaction.step.data.receipt_id;
+		if ( receipt && receipt.receipt_id ) {
+			receiptId = receipt.receipt_id;
 
 			this.props.fetchReceiptCompleted( receiptId, {
 				receiptId: receiptId,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/5888

Requires D2822-code.

### Testing Instructions
- Apply server-side patch and checkout this branch `git checkout update/renewal-confimation-notice`

#### Auto-renew disabled
- Go to http://calypso.localhost:3000/purchases and find a purchase which cannot auto renew (make one using free credits if you have none)
- Click on "Renew Now" and complete the purchase using free credits
- You should see the message `Success! You renewed %(productName)s for %(duration)s, until %(date)s. We sent your receipt to %(email)s.`

This is how the new message looks like:

![image](https://cloud.githubusercontent.com/assets/230230/18472396/8ae27bd0-79b7-11e6-8966-3f0a800a42e0.png)

#### Auto-renew enabled (shouldn't change)
- Go to http://calypso.localhost:3000/purchases and find a purchase which cannot auto renew (make one using free credits if you have none or use the one from the previous step)
- Click on "Renew Now" and complete the purchase entering new (test) credit card information
- You should see the message `%(productName)s has been renewed and will now auto renew in the future. {{a}}Learn more{{/a}}`


#### Bonus
- Test with other locales (for the duration and the date format especially)
- Test with other products than domain mappings as well as with more than 1 renewable product in the cart

### Reviews
- [x] Code
- [ ] Product
