### PR TITLE
SEO: Guard post properties when showing previews

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -103,12 +103,15 @@ const ReaderPost = ( site, post ) => {
 			siteTitle={ site.name }
 			siteSlug={ site.slug }
 			siteIcon={ `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=32` }
-			postTitle={ post.title }
-			postExcerpt={ formatExcerpt( post.excerpt || post.content ) }
+			postTitle={ get( post, 'title', '' ) }
+			postExcerpt={ formatExcerpt(
+				get( post, 'excerpt', false ) ||
+				get( post, 'content', false )
+			) }
 			postImage={ getPostImage( post ) }
-			postDate={ post.date }
-			authorName={ post.author.name }
-			authorIcon={ post.author.avatar_URL }
+			postDate={ get( post, 'date', (new Date()).toISOString() ) }
+			authorName={ get( post, 'author.name', '' ) }
+			authorIcon={ get( post, 'author.avatar_URL', '' ) }
 		/>
 	);
 };
@@ -123,8 +126,8 @@ const GoogleSite = site => (
 
 const GooglePost = ( site, post ) => (
 	<SearchPreview
-		title={ post.seoTitle }
-		url={ post.URL }
+		title={ get( post, 'seoTitle', '' ) }
+		url={ get( post, 'URL', '' ) }
 		snippet={ getSeoExcerptForPost( post ) }
 	/>
 );
@@ -141,12 +144,12 @@ const FacebookSite = site => (
 
 const FacebookPost = ( site, post ) => (
 	<FacebookPreview
-		title={ post.seoTitle }
-		url={ post.URL }
+		title={ get( post, 'seoTitle', '' ) }
+		url={ get( post, 'URL', '' ) }
 		type="article"
 		description={ getSeoExcerptForPost( post ) }
 		image={ getPostImage( post ) }
-		author={ post.author.name }
+		author={ get( post, 'author.name', '' ) }
 	/>
 );
 
@@ -162,8 +165,8 @@ const TwitterSite = site => (
 
 const TwitterPost = ( site, post ) => (
 	<TwitterPreview
-		title={ post.seoTitle }
-		url={ post.URL }
+		title={ get( post, 'seoTitle', '' ) }
+		url={ get( post, 'URL', '' ) }
 		type="large_image_summary"
 		description={ getSeoExcerptForPost( post ) }
 		image={ getPostImage( post ) }

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -353,14 +353,14 @@ export const buildSeoTitle = ( titleFormats, type, { site, post = {}, tag = '', 
 			return buildTitle( 'posts', {
 				siteName: site.name,
 				tagline: site.description,
-				postTitle: post.title
-			} ) || post.title;
+				postTitle: get( post, 'title', '' )
+			} ) || get( post, 'title', '' );
 
 		case 'pages':
 			return buildTitle( 'pages', {
 				siteName: site.name,
 				tagline: site.description,
-				pageTitle: post.title
+				pageTitle: get( post, 'title', '' )
 			} );
 
 		case 'groups':


### PR DESCRIPTION
Resolves #8027 

Previously, when opening the post editor to a new post from the SEO tab,
we noticed that the editor crashed. The reason is that we were trying to
access nested properties which did not yet exist.

This patch guards all of those property accesses with safe-defaulting
getters so that no crash will occur. Real posts should load in or
refresh quickly enough that the blank string defaults won't be visible.

**Testing**
Navigate to the custom title editor in **My Sites** > **Settings** > **SEO**. Once there, in **master** if you try and create a new post by clicking on the button in the master bar, it will crash.

In this branch, clicking should be successful and the post editor should open as expected without any console errors.

cc: @roundhill 