### PR TITLE
Framework: make prototype method warnings much more visible

### DIFF
--- a/client/lib/wrap-es6-functions/index.js
+++ b/client/lib/wrap-es6-functions/index.js
@@ -1,18 +1,28 @@
-import partial from 'lodash/partial';
-import isFunction from 'lodash/isFunction';
+/**
+ * External dependencies
+ */
+import { partial, isFunction } from 'lodash';
 
 function wrapFnWithWarning( fn, name ) {
-	const consoleFn = ( console.error || console.log ).bind( console );
 	return function() {
-		const err = new Error( `${ name } is not supported on all browsers. You must use a replacement method from lodash.` );
-		consoleFn( err );
+		/* eslint-disable no-console */
+		if ( typeof console !== 'undefined' && console.log ) {
+			console.log(
+				`%c${ name } is not supported on all browsers. ` + 'We currently ' +
+				'do not polyfill prototype methods due to bundle size concerns. ' +
+				'You must use a replacement method from lodash. ' +
+				'See: https://github.com/Automattic/wp-calypso/pull/6117',
+				'background: yellow; font-size: x-large'
+			);
+		}
+		/* eslint-enable no-console */
 		return fn.apply( this, arguments );
-	}
+	};
 }
 
 function wrapObjectFn( obj, objectName, key ) {
 	if ( isFunction( obj[ key ] ) ) {
-		Object.defineProperty( obj, key, { value: wrapFnWithWarning( obj[ key ], `${ objectName }${ key}` ) } );
+		Object.defineProperty( obj, key, { value: wrapFnWithWarning( obj[ key ], `${ objectName }${ key }` ) } );
 	}
 }
 
@@ -24,5 +34,4 @@ export default function() {
 		.map( partial( wrapObjectFn, String.prototype, 'String#' ) );
 
 	[ 'flags' ].map( partial( wrapObjectFn, RegExp.prototype, 'RegExp#' ) );
-
 }

--- a/client/lib/wrap-es6-functions/test/index.js
+++ b/client/lib/wrap-es6-functions/test/index.js
@@ -35,7 +35,7 @@ describe( 'wrapping', () => {
 
 	useSandbox( newSandbox => sandbox = newSandbox );
 	before( () => {
-		consoleSpy = sandbox.stub( console, 'error' );
+		consoleSpy = sandbox.stub( console, 'log' );
 		installSpies( arrayProps, Array.prototype );
 		installSpies( stringProps, String.prototype );
 		installSpies( regExpProps, RegExp.prototype );


### PR DESCRIPTION
As a follow up to #6117, this makes any calls to non-polyfilled methods much louder in the console. This also updates behavior so we won't throw an error locally while doing this.

## Testing Instructions
- Navigate to http://calypso.localhost:3000
- In the console execute: `[].keys()`
- You should see something like the following:
<img width="1384" alt="screen shot 2016-09-12 at 4 28 12 pm" src="https://cloud.githubusercontent.com/assets/1270189/18456563/c6ea5f82-7906-11e6-99be-5f81236d5004.png">
