### PR TITLE
Clarify support ticket form wording

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -416,7 +416,7 @@ const HelpContact = React.createClass( {
 			},
 			showKayakoVariation && {
 				onSubmit: this.submitKayakoTicket,
-				buttonLabel: isSubmitting ? this.translate( 'Submitting support ticket' ) : this.translate( 'Submit support ticket' )
+				buttonLabel: isSubmitting ? this.translate( 'Sending email' ) : this.translate( 'Email us' )
 			},
 			showForumsVariation && {
 				onSubmit: this.submitSupportForumsTopic,


### PR DESCRIPTION
Since we've disabled chat for now, we're seeing a much increased ticket volume. In some cases, we're seeing people submit many tickets with very brief messages, in such a way that it's clear that they think the form will still initiate a chat. We're then having to merge these tickets, which takes time away from actually answering async requests. It's also a bad experience for these users, some of whom are saying things like "where are you?" or "I've been waiting for a half hour for a reply."

The distinction between a chat and a ticket is clear to us but may not be to users. In this PR, I propose a slight wording change in hopes that specifying "email" will help us do a better job of setting expectations.

Before:

<img width="730" alt="support-ticket" src="https://cloud.githubusercontent.com/assets/2738252/18475438/60ac4e18-7994-11e6-96b7-5ee3602dbf99.png">

After:

<img width="715" alt="support-email" src="https://cloud.githubusercontent.com/assets/2738252/18475448/66e9c9d6-7994-11e6-8845-e7940a58fc16.png">

To test:

1. Log in as a user with upgrades.
2. Go to http://calypso.localhost:3000/help/contact/ or https://calypso.live/help/contact/?branch=update/help-ticket-wording
3. Observe the wording on the blue button.