### PR TITLE
Docs: Include instructions to reset Redux persistence

### DIFF
--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -8,6 +8,9 @@ This document aims to provide a list of things to check and test whenever you ar
 * Test scenarios where your feature intentionally doesn't work (e.g. not supported on Jetpack)
 * Explicitly test with a Jetpack-powered site. Calypso features should all work with Jetpack sites unless they are strictly WordPress.com-only.
 * Test different user privileges (admin, editor, author). How does your code behave?
+* Your code should work well with an empty initial state
+  * Start a new session in private browsing mode, or run `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` in your browser's developer tools console, then refresh the page
+  * To disable state persistence, start Calypso with `DISABLE_FEATURES=persist-redux make run`
 * Run `localStorage.clear()`! Your code needs to handle an empty slate, plus incoming data.
 * How are you communicating 'loading' and 'empty' states? See how we approach [reactivity](reactivity.md).
 

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -8,7 +8,7 @@ This document aims to provide a list of things to check and test whenever you ar
 * Test scenarios where your feature intentionally doesn't work (e.g. not supported on Jetpack)
 * Explicitly test with a Jetpack-powered site. Calypso features should all work with Jetpack sites unless they are strictly WordPress.com-only.
 * Test different user privileges (admin, editor, author). How does your code behave?
-* Your code should work well with an empty initial state
+* Your code should work well with an empty initial state. It's easy to overlook that data cached via [state persistence](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#data-persistence--2754-) may not be present when a user logs in for the first time, clears their browser history, or visits with a different browser. Errors can occur if you've introduced code which operates on this data without checking for its existence.
   * Start a new session in private browsing mode, or run `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` in your browser's developer tools console, then refresh the page
   * To disable state persistence, start Calypso with `DISABLE_FEATURES=persist-redux make run`
 * How are you communicating 'loading' and 'empty' states? See how we approach [reactivity](reactivity.md).

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -11,7 +11,6 @@ This document aims to provide a list of things to check and test whenever you ar
 * Your code should work well with an empty initial state
   * Start a new session in private browsing mode, or run `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` in your browser's developer tools console, then refresh the page
   * To disable state persistence, start Calypso with `DISABLE_FEATURES=persist-redux make run`
-* Run `localStorage.clear()`! Your code needs to handle an empty slate, plus incoming data.
 * How are you communicating 'loading' and 'empty' states? See how we approach [reactivity](reactivity.md).
 
 It's also important to keep the general WP.com commit checklist at hand (modified for Calypso):


### PR DESCRIPTION
This pull request seeks to update our merge checklist documentation instructions for resetting initial state to include steps to ensure that Redux persisted state is also reset. Not accounting for an empty initial Redux state has been an occasional source of bugs, and we are increasingly relying on indexedDB through `localForage` to manage data in browser storage.

cc @mtias @nb @gwwar 