### PR TITLE
Update wording of help closed page to reflect changes requested in p2

### DIFF
--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -36,7 +36,7 @@ export default localize( ( props ) => {
 				{ translate(
 					'Why? Once a year, the WordPress.com Happiness Engineers and the rest of the WordPress.com family get together ' +
 					'to work on improving our services, building new features, and learning how to better serve you, our users. ' +
-					'But never fear! if you need help in the meantime:'
+					'But never fear! If you need help in the meantime:'
 				) }
 			</p>
 			<HelpContactClosedDetail icon="help">
@@ -61,13 +61,11 @@ export default localize( ( props ) => {
 			<HelpContactClosedDetail icon="book">
 				{ translate(
 					'If you are new to WordPress.com we have a step-by-step {{guide_link}}guide{{/guide_link}} to all things WordPress. ' +
-					'Our helpful {{forums_link}}forums{{/forums_link}} remain open and you can find more details in our ' +
-					'{{support_doc_link}}support documentation{{/support_doc_link}}. There we have ' +
+					'You can find more details in our {{support_doc_link}}support documentation{{/support_doc_link}}. There we have ' +
 					'guides on {{get_started_link}}getting started{{/get_started_link}}, {{first_post_link}}writing your first ' +
 					'post{{/first_post_link}}, and {{find_readers_link}}finding your readers{{/find_readers_link}}.', {
 						components: {
 							guide_link: <a href="https://learn.wordpress.com/" target="_blank" rel="noopener noreferrer" />,
-							forums_link: <a href="https://forums.wordpress.com/" target="_blank" rel="noopener noreferrer" />,
 							support_doc_link: <a href={ supportUrls.SUPPORT_ROOT } target="_blank" rel="noopener noreferrer" />,
 							get_started_link: <a href={ supportUrls.START } target="_blank" rel="noopener noreferrer" />,
 							first_post_link: <a href={ supportUrls.CREATE } target="_blank" rel="noopener noreferrer" />,

--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -50,7 +50,7 @@ export default localize( ( props ) => {
 			</HelpContactClosedDetail>
 			<HelpContactClosedDetail icon="credit-card">
 				{ translate(
-					'If you require a refund, you can request one directly from your {{link}}Manage Purchases{{/link}} ' +
+					'If you require a refund, you can still request one directly from your {{link}}Purchases{{/link}} ' +
 					'screen.', {
 						components: {
 							link: <a href="/purchases" />
@@ -61,11 +61,13 @@ export default localize( ( props ) => {
 			<HelpContactClosedDetail icon="book">
 				{ translate(
 					'If you are new to WordPress.com we have a step-by-step {{guide_link}}guide{{/guide_link}} to all things WordPress. ' +
-					'You can find more details in our {{support_doc_link}}support documentation{{/support_doc_link}}. There we have ' +
+					'Our helpful {{forums_link}}forums{{/forums_link}} remain open and you can find more details in our ' +
+					'{{support_doc_link}}support documentation{{/support_doc_link}}. There we have ' +
 					'guides on {{get_started_link}}getting started{{/get_started_link}}, {{first_post_link}}writing your first ' +
 					'post{{/first_post_link}}, and {{find_readers_link}}finding your readers{{/find_readers_link}}.', {
 						components: {
 							guide_link: <a href="https://learn.wordpress.com/" target="_blank" rel="noopener noreferrer" />,
+							forums_link: <a href="https://forums.wordpress.com/" target="_blank" rel="noopener noreferrer" />,
 							support_doc_link: <a href={ supportUrls.SUPPORT_ROOT } target="_blank" rel="noopener noreferrer" />,
 							get_started_link: <a href={ supportUrls.START } target="_blank" rel="noopener noreferrer" />,
 							first_post_link: <a href={ supportUrls.CREATE } target="_blank" rel="noopener noreferrer" />,
@@ -74,7 +76,6 @@ export default localize( ( props ) => {
 					}
 				) }
 			</HelpContactClosedDetail>
-
 		</div>
 	);
 } );


### PR DESCRIPTION
This pull request updates the text on the help closed page with changes mentioned in the p2.

## How to test
1. Login as a user with no upgrades 
2. Navigate to http://calypso.localhost:3000/help/contact
3. Notice the updated text in the last two paragraphs on the page.

### What to expect
**Before**
![screen shot 2016-09-13 at 11 25 12 am](https://cloud.githubusercontent.com/assets/1854440/18479937/d3060b88-79a4-11e6-9f6a-ff27f8b95642.png)


**After**
![screen shot 2016-09-13 at 11 24 37 am](https://cloud.githubusercontent.com/assets/1854440/18479911/b8a94336-79a4-11e6-8396-2d722f2473a8.png)
