### PR TITLE
Reader: Increase space in between timestamp/tags and post content

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -352,6 +352,10 @@
 	margin-top: 0;
 }
 
+.is-group-reader-refresh .reader__full-post-content {
+	padding-top: 0!important;
+}
+
 // Daily Post-Specific Full Post View Styles
 .is-group-reader-refresh .blog-489937 .reader__full-post-content {
 	blockquote.left,

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -229,7 +229,7 @@
 	font-size: 26px;
 	font-weight: 700;
 	line-height: 34px;
-	margin: 56px 0 8px;
+	margin: 56px 0 0;
 	max-width: 750px;
 
 	@include breakpoint( ">960px" ) {
@@ -260,7 +260,11 @@
 }
 
 .reader-full-post__header-date {
-	line-height: 1.4;
+	line-height: 1.6;
+
+	@include breakpoint( "<480px" ) {
+		line-height: 1.4;
+	}
 }
 
 .reader-full-post__header-date-link {
@@ -334,6 +338,14 @@
 	&:hover {
 		color: $blue-light;
 	}
+}
+
+.reader-full-post__header {
+	margin-bottom: 23px;
+}
+
+.reader-full-post__featured-image {
+	margin-top: 27px;
 }
 
 .reader-full-post__story-content img:first-child {

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -112,7 +112,6 @@
 .reader__full-post-content {
 	@extend %content-font;
 	margin: 0;
-	padding-top: 16px;
 	position: relative;
 
 	font-size: 16px;

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -112,6 +112,7 @@
 .reader__full-post-content {
 	@extend %content-font;
 	margin: 0;
+	padding-top: 16px;
 	position: relative;
 
 	font-size: 16px;


### PR DESCRIPTION
Fixed a few things in this PR:
- Increased gap in between timestamp/tags and post content.
- Fixed alignment issue mentioned in: https://github.com/Automattic/wp-calypso/issues/7669:

**Before:**

With featured image:
![screenshot 2016-09-13 15 28 33](https://cloud.githubusercontent.com/assets/4924246/18493760/0a279326-79c7-11e6-8cb2-0db95685b1c3.png)

No featured image:
![screenshot 2016-09-13 15 28 41](https://cloud.githubusercontent.com/assets/4924246/18493766/0fb9b3dc-79c7-11e6-97e1-aaca8dbeebd7.png)

Excerpt only:
![screenshot 2016-09-13 15 28 48](https://cloud.githubusercontent.com/assets/4924246/18493767/132e5f5e-79c7-11e6-88a8-65b8ece8c429.png)

**After:**

With featured image:
![screenshot 2016-09-13 15 32 30](https://cloud.githubusercontent.com/assets/4924246/18493817/573cabd8-79c7-11e6-8215-72308a9cc136.png)

No featured image:
![screenshot 2016-09-13 15 33 09](https://cloud.githubusercontent.com/assets/4924246/18493827/67011bf8-79c7-11e6-954b-9a0be4eceb7d.png)

Excerpt only:
![screenshot 2016-09-13 15 33 13](https://cloud.githubusercontent.com/assets/4924246/18493830/6cf9c992-79c7-11e6-8a5f-d1c48c7c4fae.png)

- Fixed alignment of timestamp and tag list:

**Before:**
![screenshot-2016-09-13-13 34 39](https://cloud.githubusercontent.com/assets/4924246/18493877/aa9e5114-79c7-11e6-8fe8-601abfe54edb.jpg)

**After:**
![screenshot 2016-09-13 15 34 52](https://cloud.githubusercontent.com/assets/4924246/18493882/aff739c8-79c7-11e6-80ee-f415bf34e60c.png)


