### PR TITLE
Reader: Add fade to long site name in Related Posts block

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -22,8 +22,18 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	color: lighten( $gray, 10% );
 	font-size: 14px;
 	font-weight: 600;
-	margin-bottom: 11px;
+	margin-bottom: 20px;
+	display: -webkit-box;
+    max-height: 22px;
+    overflow: hidden;
+    position: relative;
 	text-transform: uppercase;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+
+    &::after{
+    	@include long-content-fade( $size: 10% );
+    }
 
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 0;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -24,12 +24,12 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	font-weight: 600;
 	margin-bottom: 20px;
 	display: -webkit-box;
-    max-height: 22px;
-    overflow: hidden;
-    position: relative;
+	max-height: 22px;
+	overflow: hidden;
+	position: relative;
 	text-transform: uppercase;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
+	-webkit-line-clamp: 1;
+	-webkit-box-orient: vertical;
 
     &::after{
     	@include long-content-fade( $size: 10% );

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -31,9 +31,9 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	-webkit-line-clamp: 1;
 	-webkit-box-orient: vertical;
 
-    &::after{
-    	@include long-content-fade( $size: 10% );
-    }
+	&::after{
+		@include long-content-fade( $size: 10% );
+	}
 
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 0;
@@ -71,7 +71,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2__list-item {
-    flex-basis: 0;
+	flex-basis: 0;
 	flex-grow: 1;
 	list-style-type: none;
 	margin-top: -3px;
@@ -396,17 +396,17 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	display: block;
 	height: 80px;
 
-    @media #{$reader-related-card-v2-breakpoint-small} {
-    	flex: 1;
-    	height: auto;
-    	margin: 0 15px 0 0;
-    }
+	@media #{$reader-related-card-v2-breakpoint-small} {
+		flex: 1;
+		height: auto;
+		margin: 0 15px 0 0;
+	}
 
-    @media #{$reader-related-card-v2-breakpoint-medium} {
-    	height: auto;
-    	flex: 1;
-    	margin: 0 15px 0 0;
-    }
+	@media #{$reader-related-card-v2-breakpoint-medium} {
+		height: auto;
+		flex: 1;
+		margin: 0 15px 0 0;
+	}
 }
 
 .reader-related-card-v2__title,
@@ -423,22 +423,22 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2__excerpt {
-    line-height: 1.6;
+	line-height: 1.6;
 	word-break: break-word;
 
-    &::after {
-    	@include long-content-fade( $size: 20% );
-    	height: 22px;
-    	top: inherit;
-    }
+	&::after {
+		@include long-content-fade( $size: 20% );
+		height: 22px;
+		top: inherit;
+	}
 
-    &.post-excerpt {
-    	font-size: 14px;
+	&.post-excerpt {
+		font-size: 14px;
 		overflow : hidden;
 		text-overflow: ellipsis;
 		display: -webkit-box;
 		-webkit-line-clamp: 10;
 		-webkit-box-orient: vertical;
 		max-height: none;
-    }
+	}
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8072

**Before:**
![screenshot 2016-09-14 15 46 07](https://cloud.githubusercontent.com/assets/4924246/18532724/d3066698-7a92-11e6-83d7-0980de906dad.png)

**After:**
![screenshot 2016-09-14 15 45 35](https://cloud.githubusercontent.com/assets/4924246/18532727/d7180f84-7a92-11e6-9f30-50454eb46191.png)

