### PR TITLE
Help: Redirect /help to support.wordpress.com for logged out users

### DIFF
--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -1,15 +1,30 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:user:utilities' ),
-	config = require( 'config' );
+import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
-var user = require( 'lib/user' )();
+import config from 'config';
+import userModule from 'lib/user';
+import { addQueryArgs } from 'lib/url';
+
+/**
+ * Module Variables
+ */
+const user = userModule();
+const debug = debugModule( 'calypso:user:utilities' );
 
 var userUtils = {
+	getLoginUrl: function( redirect ) {
+		const url = config( 'login_url' );
+
+		return redirect
+			? addQueryArgs( { redirect_to: redirect }, url )
+			: url;
+	},
+
 	getLogoutUrl: function( redirect ) {
 		var url = '/logout',
 			userData = user.get(),

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -17,8 +17,23 @@ import { renderPage } from 'lib/react-helpers';
 import HelpComponent from './main';
 import CoursesComponent from './help-courses';
 import ContactComponent from './help-contact';
+import userUtils from 'lib/user/utils';
+import support from 'lib/url/support';
 
 export default {
+	loggedOut( context, next ) {
+		if ( userUtils.isLoggedIn() ) {
+			return next();
+		}
+
+		const url = ( context.path === '/help' )
+			? support.SUPPORT_ROOT
+			: userUtils.getLoginUrl( window.location.href );
+
+		// Not using the page library here since this is an external URL
+		window.location.href = url;
+	},
+
 	help( context ) {
 		const basePath = route.sectionify( context.path );
 

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -4,10 +4,10 @@ var page = require( 'page' ),
 	helpController = require( './controller' );
 
 module.exports = function() {
-	page( '/help', meController.sidebar, helpController.help );
-	page( '/help/contact', meController.sidebar, helpController.contact );
+	page( '/help', helpController.loggedOut, meController.sidebar, helpController.help );
+	page( '/help/contact', helpController.loggedOut, meController.sidebar, helpController.contact );
 
 	if ( config.isEnabled( 'help/courses' ) ) {
-		page( '/help/courses', meController.sidebar, helpController.courses );
+		page( '/help/courses', helpController.loggedOut, meController.sidebar, helpController.courses );
 	}
 };

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -340,6 +340,7 @@ if ( config.isEnabled( 'help' ) ) {
 		paths: [ '/help' ],
 		module: 'me/help',
 		secondary: true,
+		enableLoggedOut: true,
 		group: 'me'
 	} );
 }


### PR DESCRIPTION
This pull request adds changes that will redirect logged out users that hit http://wordpress.com/help to https://support.wordpress.com.
## How to test
### As a logged out user
1. Navigate directly to http://calypso.localhost:3000/help
2. Notice that you've been redirected to https://en.support.wordpress.com
### As a logged in user
1. Navigate directly to http://calypso.localhost:3000/help
2. Notice that you see the normal help screen.
### Regression

This pull request also touches code that handles the routes for /help/contact and /help/courses so lets test to make sure thats working correctly
#### As a logged out user
1. Navigate directly to http://calypso.localhost:3000/help/contact
2. Confirm you are taken to the login screen
3. log in
4. Confirm you are redirected back to /help/contact where you can see the contact form
5. Repeat above steps 1 - 4 for http://calypso.localhost:3000/help/courses
#### As a logged in user
1. Navigate directly to http://calypso.localhost:3000/help/contact
2. Confirm that you see the help contact form
3. Navigate directly to http://calypso.localhost:3000/help/courses
4. Confirm that you see the help courses page
