### PR TITLE
Reader: Align Author name and post title if no avatar

### DIFF
--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -4,6 +4,10 @@
 	flex-direction: column;
 	width: 100%;
 
+	.reader-avatar {
+		margin-bottom: 18px;
+	}
+
 	.gravatar, .site-icon {
 		margin: auto;
 	}
@@ -79,7 +83,6 @@
 .author-compact-profile .reader-author-link,
 .author-compact-profile__site-link {
 	font-weight: 600;
-	margin-top: 18px;
 }
 
 .author-compact-profile__follow {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -94,6 +94,10 @@
 	flex-direction: column;
 	z-index: z-index( '.masterbar', '.reader-profile' );
 
+	.reader-author-link {
+		margin-top: -4px; // Aligns baseline of author name with baseline of title if no avatar
+	}
+
 	@include breakpoint( "<660px" ) {
 		flex-direction: row;
 		margin-top: 20px;
@@ -145,16 +149,24 @@
 		.reader-author-link {
 			font-weight: 700;
 			display: inline;
+			margin: 0 10px 0 0;
 		}
 
 		.reader-author-link,
 		.author-compact-profile__site-link {
-			margin: 0 0 0 10px;
 			padding-top: 5px;
+
+			@include breakpoint( "<660px" ) {
+				margin-bottom: 35px;
+			}
 		}
 
 		.author-compact-profile__site-link {
 			display: inline;
+
+			@include breakpoint( "<660px" ) {
+				margin-top: 0;
+			}
 		}
 
 		.author-compact-profile__follow .follow-button {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -95,7 +95,11 @@
 	z-index: z-index( '.masterbar', '.reader-profile' );
 
 	.reader-author-link {
-		margin-top: -4px; // Aligns baseline of author name with baseline of title if no avatar
+		margin-top: 0;
+
+		@include breakpoint( ">660px" ) {
+			margin-top: -4px; // Aligns baseline of author name with baseline of title if no avatar
+		}
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -104,7 +108,13 @@
 
 		.reader-avatar {
 			flex: 1;
-			margin-bottom: 40px;
+			margin: 0 0 0 -9px;
+
+			&.has-site-and-author-icon,
+			&.has-site-icon,
+			&.has-gravatar {
+				margin: 0 10px 40px 0;
+			}
 
 			&.has-gravatar {
 
@@ -149,15 +159,9 @@
 		.reader-author-link {
 			font-weight: 700;
 			display: inline;
-			margin: 0 10px 0 0;
-		}
-
-		.reader-author-link,
-		.author-compact-profile__site-link {
-			padding-top: 5px;
 
 			@include breakpoint( "<660px" ) {
-				margin-bottom: 35px;
+				margin-right: 10px;
 			}
 		}
 
@@ -166,6 +170,15 @@
 
 			@include breakpoint( "<660px" ) {
 				margin-top: 0;
+			}
+		}
+
+		.reader-author-link,
+		.author-compact-profile__site-link {
+			padding-top: 5px;
+
+			@include breakpoint( "<660px" ) {
+				margin-bottom: 35px;
 			}
 		}
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8073

**Before:**
![screenshot 2016-09-15 11 28 10](https://cloud.githubusercontent.com/assets/4924246/18567144/b5b21f7e-7b4b-11e6-8e2b-908757b8d807.png)

**After:**
![screenshot 2016-09-15 11 28 31](https://cloud.githubusercontent.com/assets/4924246/18567150/b8ca61e4-7b4b-11e6-95a9-99739bfd032d.png)

Related: https://github.com/Automattic/wp-calypso/pull/8086