### PR TITLE
Support User: Only show popup for users with flag

### DIFF
--- a/client/support/support-user/index.jsx
+++ b/client/support/support-user/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import flowRight from 'lodash/flowRight';
 
 /**
  * Internal dependencies
@@ -27,19 +26,19 @@ const SupportUser = React.createClass( {
 	},
 
 	onKeyboardShortcut: function( e ) {
+		if ( this.props.isSupportUser ) {
+			rebootNormally();
+		}
+
 		if ( ! this.props.isEnabledForUser ) {
-			return false;
+			return;
 		}
 
 		// Because the username field is auto-focused, this prevents
 		// the shortcut key being entered into the field
 		e.preventDefault();
 
-		if ( this.props.isSupportUser ) {
-			this.props.supportUserRestore();
-		} else {
-			this.props.supportUserToggleDialog();
-		}
+		this.props.supportUserToggleDialog();
 	},
 
 	render: function() {
@@ -51,7 +50,7 @@ const SupportUser = React.createClass( {
 				errorMessage={ this.props.errorMessage }
 
 				onCloseDialog={ this.props.supportUserToggleDialog }
-				onChangeUser={ this.props.supportUserTokenFetch }
+				onChangeUser={ fetchToken }
 			/>
 		);
 	}
@@ -65,10 +64,8 @@ const mapStateToProps = state => ( {
 	errorMessage: state.support.errorMessage,
 } );
 
-const mapDispatchToProps = dispatch => ( {
-	supportUserTokenFetch: fetchToken,
-	supportUserRestore: rebootNormally,
-	supportUserToggleDialog: flowRight( dispatch, supportUserToggleDialog ),
-} );
+const mapDispatchToProps = {
+	supportUserToggleDialog,
+};
 
 export default connect( mapStateToProps, mapDispatchToProps )( SupportUser );

--- a/client/support/support-user/index.jsx
+++ b/client/support/support-user/index.jsx
@@ -57,22 +57,18 @@ const SupportUser = React.createClass( {
 	}
 } );
 
-const mapStateToProps = ( state ) => {
-	return {
-		isEnabledForUser: currentUserHasFlag( state, 'calypso_support_user' ),
-		isSupportUser: state.support.isSupportUser,
-		isTransitioning: state.support.isTransitioning,
-		showDialog: state.support.showDialog,
-		errorMessage: state.support.errorMessage,
-	};
-};
+const mapStateToProps = state => ( {
+	isEnabledForUser: currentUserHasFlag( state, 'calypso_support_user' ),
+	isSupportUser: state.support.isSupportUser,
+	isTransitioning: state.support.isTransitioning,
+	showDialog: state.support.showDialog,
+	errorMessage: state.support.errorMessage,
+} );
 
-const mapDispatchToProps = ( dispatch ) => {
-	return {
-		supportUserTokenFetch: fetchToken,
-		supportUserRestore: rebootNormally,
-		supportUserToggleDialog: flowRight( dispatch, supportUserToggleDialog ),
-	};
-}
+const mapDispatchToProps = dispatch => ( {
+	supportUserTokenFetch: fetchToken,
+	supportUserRestore: rebootNormally,
+	supportUserToggleDialog: flowRight( dispatch, supportUserToggleDialog ),
+} );
 
 export default connect( mapStateToProps, mapDispatchToProps )( SupportUser );

--- a/client/support/support-user/index.jsx
+++ b/client/support/support-user/index.jsx
@@ -11,6 +11,7 @@ import flowRight from 'lodash/flowRight';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import SupportUserLoginDialog from './login-dialog';
 import { fetchToken, rebootNormally } from 'lib/user/support-user-interop';
+import { currentUserHasFlag } from 'state/current-user/selectors';
 
 import { supportUserToggleDialog } from 'state/support/actions';
 
@@ -26,6 +27,10 @@ const SupportUser = React.createClass( {
 	},
 
 	onKeyboardShortcut: function( e ) {
+		if ( ! this.props.isEnabledForUser ) {
+			return false;
+		}
+
 		// Because the username field is auto-focused, this prevents
 		// the shortcut key being entered into the field
 		e.preventDefault();
@@ -54,12 +59,13 @@ const SupportUser = React.createClass( {
 
 const mapStateToProps = ( state ) => {
 	return {
+		isEnabledForUser: currentUserHasFlag( state, 'calypso_support_user' ),
 		isSupportUser: state.support.isSupportUser,
 		isTransitioning: state.support.isTransitioning,
 		showDialog: state.support.showDialog,
 		errorMessage: state.support.errorMessage,
 	};
-}
+};
 
 const mapDispatchToProps = ( dispatch ) => {
 	return {


### PR DESCRIPTION
This prevents the support user login popup appearing for users without the relevant flag. Some users were accidentally toggling the login dialog which resulted in a confusing experience. Flag added in r142350-wpcom & r142351-wpcom.
### How to test
1. ~~Apply D2837~~
2. Checkout this PR's branch
3. Open Calypso, then use the support user keyboard shortcut to open the login popup
4. The popup should only appear for a12s

cc @dllh @omarjackman @gwwar 
