### PR TITLE
Testing: Get rid of more double callback warnings

### DIFF
--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -11,7 +11,7 @@ import sinon from 'sinon';
 import useMockery from 'test/helpers/use-mockery';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
-let	ReactDom, React, TestUtils, SectionNav;
+let ReactDom, React, TestUtils, SectionNav;
 
 function createComponent( component, props, children ) {
 	const shallowRenderer = TestUtils.createRenderer();

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { noop, toArray } from 'lodash';
 import React from 'react';
-import toArray from 'lodash/toArray';
 import mockery from 'mockery';
 
 /**
@@ -38,6 +38,15 @@ describe( 'MediaLibraryList item selection', function() {
 	}
 
 	before( function() {
+		mockery.registerMock( 'lib/wp', {
+			me: () => ( {
+				get: noop
+			} )
+		} );
+		mockery.registerMock( 'components/infinite-list', EmptyComponent );
+		mockery.registerMock( './list-item', EmptyComponent );
+		mockery.registerMock( './list-plan-upgrade-nudge', EmptyComponent );
+
 		mount = require( 'enzyme' ).mount;
 		MediaLibrarySelectedData = require( 'components/data/media-library-selected-data' );
 		MediaLibrarySelectedStore = require( 'lib/media/library-selected-store' );
@@ -51,9 +60,6 @@ describe( 'MediaLibraryList item selection', function() {
 			data: fixtures
 		} );
 
-		mockery.registerMock( 'components/infinite-list', EmptyComponent );
-		mockery.registerMock( './list-item', EmptyComponent );
-		mockery.registerMock( './list-plan-upgrade-nudge', EmptyComponent );
 		MediaList = require( '../list' );
 	} );
 

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
 */
 import { expect } from 'chai';
+import { noop } from 'lodash';
 
 /*
  * Internal dependencies
@@ -24,6 +25,7 @@ describe( 'PluginsList', () => {
 		mockery.registerMock( 'my-sites/plugins/plugin-item/plugin-item', emptyComponent );
 		mockery.registerMock( 'my-sites/plugins/plugin-list-header', emptyComponent );
 
+		mockery.registerMock( 'lib/analytics', { ga: { recordEvent: noop }} );
 		mockery.registerMock( 'lib/sites-list', () => siteListMock );
 	} );
 

--- a/client/my-sites/upgrades/domain-management/edit/test/mapped-domain.js
+++ b/client/my-sites/upgrades/domain-management/edit/test/mapped-domain.js
@@ -31,7 +31,9 @@ describe( 'mapped-domain', () => {
 	} );
 
 	useFakeDom.withContainer();
-	useMockery();
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/analytics', {} );
+	} );
 
 	before( () => {
 		React = require( 'react' );

--- a/client/my-sites/upgrades/domain-management/list/test/index.js
+++ b/client/my-sites/upgrades/domain-management/list/test/index.js
@@ -3,6 +3,7 @@
  */
 import deepFreeze from 'deep-freeze';
 import assert from 'assert';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +29,19 @@ describe( 'index', function() {
 		require( 'test/helpers/mocks/data-poller' )( mockery );
 		mockery.registerMock( 'components/section-nav', EmptyComponent );
 		mockery.registerMock( 'components/sidebar-navigation', EmptyComponent );
+		mockery.registerMock( 'lib/analytics/ad-tracking', noop );
+		mockery.registerMock( 'lib/analytics/track-component-view', EmptyComponent );
+		mockery.registerMock( 'lib/mixins/analytics', () => ( {
+			recordEvent: noop
+		} ) );
+		mockery.registerMock( 'lib/wp', {
+			me: () => ( {
+				get: noop
+			} ),
+			undocumented: () => ( {
+				getProducts: noop
+			} )
+		} );
 	} );
 
 	before( () => {

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import moment from 'moment';
+import { noop } from 'lodash';
 import React from 'react';
 import sinon from 'sinon';
 import mockery from 'mockery';
@@ -50,7 +51,13 @@ describe( 'EditorGroundControl', function() {
 		mockery.registerMock( 'post-editor/edit-post-status', EmptyComponent );
 		mockery.registerMock( 'post-editor/editor-status-label', EmptyComponent );
 		mockery.registerMock( 'components/sticky-panel', EmptyComponent );
+		mockery.registerMock( 'components/post-list-fetcher', EmptyComponent );
 		mockery.registerMock( 'components/post-schedule', EmptyComponent );
+		mockery.registerMock( 'lib/posts/actions', { edit: noop } );
+		mockery.registerMock( 'lib/posts/stats', {
+			recordEvent: noop,
+			recordStat: noop
+		} );
 		mockery.registerMock( 'lib/user/utils', {
 			needsVerificationForSite: () => ! MOCK_USER.email_verified,
 		} );

--- a/client/post-editor/editor-sharing/test/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/test/publicize-connection.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { noop } from 'lodash';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { expect } from 'chai';
@@ -9,6 +10,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
 
 /**
  * Module variables
@@ -27,7 +29,16 @@ describe( 'PublicizeConnection', function() {
 
 	useFakeDom();
 
-	before( () => {
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/posts/actions', {
+			deleteMetadata: noop,
+			updateMetadata: noop
+		} );
+		mockery.registerMock( 'lib/posts/stats', {
+			recordEvent: noop,
+			recordState: noop
+		} );
+
 		PublicizeConnection = require( '../publicize-connection' );
 	} );
 

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { identity, noop } from 'lodash';
 import React from 'react';
 import { shallow } from 'enzyme';
 import mockery from 'mockery';
@@ -46,12 +47,19 @@ describe( 'EditorMediaModal', function() {
 		mockery.registerMock( 'my-sites/media-library', EMPTY_COMPONENT );
 		mockery.registerMock( './detail', EMPTY_COMPONENT );
 		mockery.registerMock( './gallery', EMPTY_COMPONENT );
+		mockery.registerMock( './markup', { get: identity } );
 		mockery.registerMock( './secondary-actions', EMPTY_COMPONENT );
 		mockery.registerMock( 'components/dialog', EMPTY_COMPONENT );
 		mockery.registerMock( 'components/popover', EMPTY_COMPONENT );
 		mockery.registerMock( 'lib/accept', accept );
+		mockery.registerMock( 'lib/analytics', { mc: { bumpStat: noop } } );
 		mockery.registerMock( 'component-closest', {} );
 		mockery.registerMock( 'lib/media/actions', { delete: deleteMedia } );
+		mockery.registerMock( 'lib/posts/actions', { blockSave: noop } );
+		mockery.registerMock( 'lib/posts/stats', {
+			recordEvent: noop,
+			recordState: noop
+		} );
 
 		EditorMediaModal = require( '../' );
 		EditorMediaModal.prototype.translate = i18n.translate;

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -3,11 +3,13 @@
  */
 import ReactDomServer from 'react-dom/server';
 import { expect } from 'chai';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'markup', function() {
@@ -15,6 +17,13 @@ describe( 'markup', function() {
 
 	useFakeDom();
 	useSandbox( ( newSandbox ) => sandbox = newSandbox );
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/wp', {
+			me: () => ( {
+				get: noop
+			} )
+		} );
+	} );
 
 	before( () => {
 		markup = require( '../markup' );

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import mockery from 'mockery';
 import { expect } from 'chai';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -55,6 +56,14 @@ describe( 'PostEditor', function() {
 		mockery.registerMock( './editor-preview', MOCK_COMPONENT );
 		mockery.registerMock( 'my-sites/drafts/draft-list', MOCK_COMPONENT );
 		mockery.registerMock( 'lib/preferences/actions', { set() {} } );
+		mockery.registerMock( 'lib/wp', {
+			me: () => ( {
+				get: noop
+			} ),
+			undocumented: () => ( {
+
+			} )
+		} );
 		// TODO: REDUX - add proper tests when whole post-editor is reduxified
 		mockery.registerMock( 'react-redux', {
 			connect: () => ( component ) => component

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -60,9 +60,7 @@ describe( 'PostEditor', function() {
 			me: () => ( {
 				get: noop
 			} ),
-			undocumented: () => ( {
-
-			} )
+			undocumented: noop
 		} );
 		// TODO: REDUX - add proper tests when whole post-editor is reduxified
 		mockery.registerMock( 'react-redux', {

--- a/client/reader/sidebar/test/index.jsx
+++ b/client/reader/sidebar/test/index.jsx
@@ -1,8 +1,15 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 import { expect } from 'chai';
+import { noop } from 'lodash';
 import { shallow } from 'enzyme';
 import { stub } from 'sinon';
 
+/**
+ * Internal dependencies
+ */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
 
@@ -27,6 +34,16 @@ describe( 'ReaderSidebar', ( ) => {
 
 	useMockery( ( mockery ) => {
 		mockery.registerMock( 'component-closest', stub() );
+		mockery.registerMock( 'lib/wp', {
+			batch: () => ( {
+				add: noop,
+				run: noop
+			} ),
+			me: () => ( {
+				get: noop
+			} ),
+			undocumented: noop
+		} );
 	} );
 
 	before( ( ) => {


### PR DESCRIPTION
Partially fixes #4206.

It removes couple of double callback warnings related to Analytics or wpcom.js libraries usage. It looks like there are triggered network requests behind the scenes that aren't prevented/handled by `nock` properly.

### Testing
Run:
* `npm run test-client client/my-sites/`
* `npm run test-client client/post-editor/`
* `npm run test-client client/reader/`

There should be __no__ `double callback` warnings printed on the console.

Test live: https://calypso.live/?branch=remove/double-callback-warning