### PR TITLE
Jetpack: Plugins: prioritize jetpack plugins for updates

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,5 +106,13 @@ module.exports = {
 			hideVerticalScreenshots: 50,
 		},
 		defaultVariation: 'hideVerticalScreenshots',
+	},
+	pluginUpdatesAtTop: {
+		datestamp: '20160924',
+		variations: {
+			updatesAtTop: 50,
+			regularSorted: 50,
+		},
+		defaultVariation: 'regularSorted',
 	}
 };

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -200,7 +200,7 @@ PluginsStore = {
 			return;
 		}
 		plugins = sortBy( plugins, function( plugin ) {
-			return plugin.slug;
+			return plugin.name;
 		} );
 		if ( ! plugins ) {
 			return [];

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -11,6 +11,7 @@ import isEqual from 'lodash/isEqual';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
+import Card from 'components/card';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginsActions from 'lib/plugins/actions';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
@@ -67,12 +68,6 @@ module.exports = React.createClass( {
 
 	ago( date ) {
 		return i18n.moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
-	},
-
-	hasUpdate() {
-		return this.props.sites.some( function( site ) {
-			return site.plugin && site.plugin.update && site.canUpdateFiles;
-		} );
 	},
 
 	doing() {
@@ -160,7 +155,7 @@ module.exports = React.createClass( {
 				);
 			}
 		}
-		if ( this.hasUpdate() ) {
+		if ( this.props.hasUpdate( pluginData ) ) {
 			return this.renderUpdateFlag();
 		}
 
@@ -264,7 +259,7 @@ module.exports = React.createClass( {
 			numberOfWarningIcons++;
 		}
 
-		if ( this.hasUpdate() ) {
+		if ( this.props.hasUpdate( plugin ) ) {
 			numberOfWarningIcons++;
 		}
 
@@ -295,9 +290,11 @@ module.exports = React.createClass( {
 				</div>
 			);
 		}
+
+		const CardType = this.props.isCompact ? CompactCard : Card;
 		return (
 			<div>
-				<CompactCard className="plugin-item">
+				<CardType className="plugin-item">
 					{ ! this.props.isSelectable
 						? null
 						: <input className="plugin-item__checkbox"
@@ -313,7 +310,7 @@ module.exports = React.createClass( {
 						{ this.pluginMeta( plugin ) }
 					</a>
 					{ this.props.selectedSite ? this.renderActions() : this.renderSiteCount() }
-				</CompactCard>
+				</CardType>
 				{ errorNotices }
 			</div>
 		);


### PR DESCRIPTION
### Hypothesis

By reordering plugins at http://calypso.localhost:3000/plugins in the presence of Jetpack enabled sites in such a way that plugins requiring updates are at the top of the list, users will be more likely to address updates.
### What it looked like before

<img width="804" alt="screen shot 2016-09-16 at 3 31 22 pm" src="https://cloud.githubusercontent.com/assets/1922453/18603062/35e37eb8-7c23-11e6-8eca-192a9318221c.png">
### What it looks like after

<img width="838" alt="screen shot 2016-09-16 at 3 30 50 pm" src="https://cloud.githubusercontent.com/assets/1922453/18603072/431c5852-7c23-11e6-9b1a-5960f6035e10.png">
### Notes

All other aspects of the order remain the same

@retrofox @rcoll @rickybanister @aheckler 
