### PR TITLE
Jetpack: Plugins: Add inline number to "All Plugins" button

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -166,10 +166,20 @@ export default React.createClass( {
 
 		if ( ! this.props.isBulkManagementActive ) {
 			if ( 0 < this.props.pluginUpdateCount ) {
+				var buttonText = this.translate( 'Update', { context: 'button label' } );
+				
+				buttonText += ' ' + this.numberFormat( this.props.pluginUpdateCount ) + ' ';
+
+				if ( this.props.pluginUpdateCount > 1 ) {
+					buttonText += this.translate( 'Plugins', { context: 'button label' } );
+				} else {
+					buttonText += this.translate( 'Plugin', { context: 'button label' } );
+				}
+
 				rightSideButtons.push(
 					<ButtonGroup key="plugin-list-header__buttons-update-all">
 						<Button compact primary onClick={ this.props.updateAllPlugins } >
-							{ this.translate( 'Update All', { context: 'button label' } ) }
+							{ buttonText }
 						</Button>
 					</ButtonGroup>
 				);

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -166,20 +166,14 @@ export default React.createClass( {
 
 		if ( ! this.props.isBulkManagementActive ) {
 			if ( 0 < this.props.pluginUpdateCount ) {
-				var buttonText = this.translate( 'Update', { context: 'button label' } );
-				
-				buttonText += ' ' + this.numberFormat( this.props.pluginUpdateCount ) + ' ';
-
-				if ( this.props.pluginUpdateCount > 1 ) {
-					buttonText += this.translate( 'Plugins', { context: 'button label' } );
-				} else {
-					buttonText += this.translate( 'Plugin', { context: 'button label' } );
-				}
+				const textUpdate = this.translate( 'Update', { context: 'button label' } );
+				const textNumber = this.numberFormat( this.props.pluginUpdateCount );
+				const textPlugin = this.translate( 1 < this.props.pluginUpdateCount ? 'Plugins' : 'Plugin', { context: 'button label' } );
 
 				rightSideButtons.push(
 					<ButtonGroup key="plugin-list-header__buttons-update-all">
 						<Button compact primary onClick={ this.props.updateAllPlugins } >
-							{ buttonText }
+							{ `${textUpdate} ${textNumber} ${textPlugin}` }
 						</Button>
 					</ButtonGroup>
 				);


### PR DESCRIPTION
## Hypothesis
This should help users feel more comfortable clicking on the "Update All", since they are more aware of what will take place when the button is clicked.

## Before
<img width="691" alt="screen shot 2016-09-16 at 4 45 50 pm" src="https://cloud.githubusercontent.com/assets/5528445/18604112/4557e83e-7c2d-11e6-9d44-75e8b06351f9.png">

## After
<img width="695" alt="screen shot 2016-09-16 at 4 45 05 pm" src="https://cloud.githubusercontent.com/assets/5528445/18604113/4ca975e4-7c2d-11e6-9750-8f2d2f4d4dfd.png">

@retrofox @rickybanister @aheckler @psealock 