### PR TITLE
Help: Remove past live course dates from Help page

### DIFF
--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -31,10 +31,6 @@ function getCourses() {
 			),
 			schedule: [
 				{
-					date: i18n.moment( new Date( 'Mon, 12 Sep 2016 21:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/08c4eff0906b1da4d746f627e8486654'
-				},
-				{
 					date: i18n.moment( new Date( 'Fri, 23 Sep 2016 18:00:00 +0000' ) ),
 					registrationUrl: 'https://zoom.us/webinar/register/732df6652d490ab0dc2040ba88984b7b'
 				},


### PR DESCRIPTION
The September 12th course is now past so we should remove the signup link since it's dead anyway. We don't have additional courses to add at the moment so this just removes the past course.

To test:
1. Boot up this branch
2. Visit http://calypso.localhost:3000/help/courses. Make sure you have a site with a Business upgrade (courses are only available for Business users)

You should only see three dates (Sep 23, 27, and 29) as shown here:

<img width="758" alt="screen shot 2016-09-16 at 2 37 00 pm" src="https://cloud.githubusercontent.com/assets/7240478/18604584/3403081a-7c33-11e6-8ab7-76bce3b37a8f.png">