### PR TITLE
Update post-ticket submit wording in /help/contact

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -155,8 +155,11 @@ const HelpContact = React.createClass( {
 				confirmation: {
 					title: this.translate( 'We\'re on it!' ),
 					message: this.translate(
-						'We\'ve received your message, and you\'ll hear back from ' +
-						'one of our Happiness Engineers shortly.' )
+						'Thank your for your message! We\'re currently away on our ' +
+						'annual company meetup where we are working to improve WordPress ' +
+						'for you. We will be answering your questions but responses ' +
+						'may be slower than normal.'
+					)
 				}
 			} );
 


### PR DESCRIPTION
We're not doing a great job of setting expectations for users when we have reduced availability of support. At present, the wording of the screen you see after submitting reads as follows:

> We've received your message, and you'll hear back from one of our Happiness Engineers shortly.

With this change, it looks like this:

<img width="420" alt="screen shot 2016-09-16 at 9 26 34 pm" src="https://cloud.githubusercontent.com/assets/2738252/18606154/c547b82a-7c5b-11e6-90c1-4b63c58dbbff.png">

*To Test:*

1. As a user with recent upgrades, load https://calypso.local/help/contact
2. Submit a ticket.
3. Observe the submit confirmation message.