### PR TITLE
Jetpack: Plugins: Use consistent update notice on all plugins pages

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -158,19 +158,6 @@ module.exports = React.createClass( {
 		);
 	},
 
-	// @todo - This is duplicated from plugin-meta/index.jsx. Can we get rid of the duplication?
-	handlePluginUpdatesSingleSite( event ) {
-		event.preventDefault();
-		PluginsActions.updatePlugin( this.props.sites[ 0 ], this.props.sites[ 0 ].plugin );
-
-		analytics.ga.recordEvent( 'Plugins', 'Clicked Update Selected Site Plugin', 'Plugin Name', this.props.pluginSlug );
-		analytics.tracks.recordEvent( 'calypso_plugins_actions_update_plugin', {
-			site: this.props.sites[ 0 ].ID,
-			plugin: this.props.sites[ 0 ].plugin.slug,
-			selected_site: this.props.sites[ 0 ].ID
-		} );
-	},
-
 	pluginMeta( pluginData ) {
 		if ( this.props.progress.length ) {
 			const message = this.doing();

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -17,6 +17,7 @@ import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
 import Count from 'components/count';
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 import PluginNotices from 'lib/plugins/notices';
 import analytics from 'lib/analytics';
 
@@ -127,6 +128,7 @@ module.exports = React.createClass( {
 	},
 
 	renderUpdateFlag() {
+		const newVersions = this.getAvailableNewVersions();
 		const recentlyUpdated = this.props.sites.some( function( site ) {
 			return site.plugin &&
 				site.plugin.update &&
@@ -142,13 +144,51 @@ module.exports = React.createClass( {
 					text={ this.translate( 'Updated' ) } />
 			);
 		}
+
+		const textVersion = this.translate( 'Version' );
+		const textIsAvailable = this.translate( 'is available' );
+		
 		return (
 			<Notice isCompact
 				icon="sync"
 				status="is-warning"
 				inline={ true }
-				text={ this.translate( 'A newer version is available' ) } />
+				text={ `${ textVersion } ${ newVersions[ 0 ].newVersion } ${ textIsAvailable }` }>
+				<NoticeAction onClick={ this.handlePluginUpdatesSingleSite }>
+					{ this.translate( 'Update' ) }
+				</NoticeAction>
+			</Notice>
 		);
+	},
+
+	// @todo - This is duplicated from plugin-info/index.jsx. Can we get rid of the duplication?
+	handlePluginUpdatesSingleSite( event ) {
+		event.preventDefault();
+		PluginsActions.updatePlugin( this.props.sites[ 0 ], this.props.sites[ 0 ].plugin );
+
+		analytics.ga.recordEvent( 'Plugins', 'Clicked Update Selected Site Plugin', 'Plugin Name', this.props.pluginSlug );
+		analytics.tracks.recordEvent( 'calypso_plugins_actions_update_plugin', {
+			site: this.props.sites[ 0 ].ID,
+			plugin: this.props.sites[ 0 ].plugin.slug,
+			selected_site: this.props.sites[ 0 ].ID
+		} );
+	},
+
+	// @todo - This is duplicated from plugin-info/index.jsx. Can we get rid of the duplication?
+	getAvailableNewVersions() {
+		return this.props.sites.map( site => {
+			if ( ! site.canUpdateFiles ) {
+				return null;
+			}
+			if ( site.plugin && site.plugin.update ) {
+				if ( 'error' !== site.plugin.update && site.plugin.update.new_version ) {
+					return {
+						title: site.title,
+						newVersion: site.plugin.update.new_version
+					};
+				}
+			}
+		} ).filter( newVersions => newVersions );
 	},
 
 	pluginMeta( pluginData ) {

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -20,6 +20,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import PluginNotices from 'lib/plugins/notices';
 import analytics from 'lib/analytics';
+import { getAvailableNewVersions } from 'my-sites/plugins/plugin-meta';
 
 function checkPropsChange( nextProps, propArr ) {
 	let i;
@@ -77,7 +78,7 @@ module.exports = React.createClass( {
 	},
 
 	doing() {
-		const progress = this.props.progress ? this.props.progress : [],
+		const progress = this.props.progress || [],
 			log = progress[ 0 ],
 			uniqLogs = uniqBy( progress, function( uniqLog ) {
 				return uniqLog.site.ID;
@@ -128,7 +129,7 @@ module.exports = React.createClass( {
 	},
 
 	renderUpdateFlag() {
-		const newVersions = this.getAvailableNewVersions();
+		const newVersions = getAvailableNewVersions( this.props );
 		const recentlyUpdated = this.props.sites.some( function( site ) {
 			return site.plugin &&
 				site.plugin.update &&
@@ -147,7 +148,7 @@ module.exports = React.createClass( {
 
 		const textVersion = this.translate( 'Version' );
 		const textIsAvailable = this.translate( 'is available' );
-		
+
 		return (
 			<Notice isCompact
 				icon="sync"
@@ -161,7 +162,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	// @todo - This is duplicated from plugin-info/index.jsx. Can we get rid of the duplication?
+	// @todo - This is duplicated from plugin-meta/index.jsx. Can we get rid of the duplication?
 	handlePluginUpdatesSingleSite( event ) {
 		event.preventDefault();
 		PluginsActions.updatePlugin( this.props.sites[ 0 ], this.props.sites[ 0 ].plugin );
@@ -172,23 +173,6 @@ module.exports = React.createClass( {
 			plugin: this.props.sites[ 0 ].plugin.slug,
 			selected_site: this.props.sites[ 0 ].ID
 		} );
-	},
-
-	// @todo - This is duplicated from plugin-info/index.jsx. Can we get rid of the duplication?
-	getAvailableNewVersions() {
-		return this.props.sites.map( site => {
-			if ( ! site.canUpdateFiles ) {
-				return null;
-			}
-			if ( site.plugin && site.plugin.update ) {
-				if ( 'error' !== site.plugin.update && site.plugin.update.new_version ) {
-					return {
-						title: site.title,
-						newVersion: site.plugin.update.new_version
-					};
-				}
-			}
-		} ).filter( newVersions => newVersions );
 	},
 
 	pluginMeta( pluginData ) {

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -17,7 +17,6 @@ import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
 import Count from 'components/count';
 import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 import PluginNotices from 'lib/plugins/notices';
 import analytics from 'lib/analytics';
 import { getAvailableNewVersions } from 'my-sites/plugins/plugin-meta';
@@ -155,9 +154,6 @@ module.exports = React.createClass( {
 				status="is-warning"
 				inline={ true }
 				text={ `${ textVersion } ${ newVersions[ 0 ].newVersion } ${ textIsAvailable }` }>
-				<NoticeAction onClick={ this.handlePluginUpdatesSingleSite }>
-					{ this.translate( 'Update' ) }
-				</NoticeAction>
 			</Notice>
 		);
 	},

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -145,15 +145,12 @@ module.exports = React.createClass( {
 			);
 		}
 
-		const textVersion = this.translate( 'Version' );
-		const textIsAvailable = this.translate( 'is available' );
-
 		return (
 			<Notice isCompact
 				icon="sync"
 				status="is-warning"
 				inline={ true }
-				text={ `${ textVersion } ${ newVersions[ 0 ].newVersion } ${ textIsAvailable }` }>
+				text={ this.translate( 'Version %(newVersion)s is available', { args: { newVersion: newVersions[ 0 ].newVersion } } ) }>
 			</Notice>
 		);
 	},

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -234,22 +234,6 @@ export default React.createClass( {
 		}
 	},
 
-	// getAvailableNewVersions() {
-	// 	return this.props.sites.map( site => {
-	// 		if ( ! site.canUpdateFiles ) {
-	// 			return null;
-	// 		}
-	// 		if ( site.plugin && site.plugin.update ) {
-	// 			if ( 'error' !== site.plugin.update && site.plugin.update.new_version ) {
-	// 				return {
-	// 					title: site.title,
-	// 					newVersion: site.plugin.update.new_version
-	// 				};
-	// 			}
-	// 		}
-	// 	} ).filter( newVersions => newVersions );
-	// },
-
 	handlePluginUpdatesSingleSite( event ) {
 		event.preventDefault();
 		PluginsActions.updatePlugin( this.props.sites[ 0 ], this.props.sites[ 0 ].plugin );

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -26,6 +26,22 @@ import PluginSettingsLink from 'my-sites/plugins/plugin-settings-link';
 import PluginInformation from 'my-sites/plugins/plugin-information';
 import { userCan } from 'lib/site/utils';
 
+export function getAvailableNewVersions( props ) {
+	return props.sites.map( site => {
+		if ( ! site.canUpdateFiles ) {
+			return null;
+		}
+		if ( site.plugin && site.plugin.update ) {
+			if ( 'error' !== site.plugin.update && site.plugin.update.new_version ) {
+				return {
+					title: site.title,
+					newVersion: site.plugin.update.new_version
+				};
+			}
+		}
+	} ).filter( newVersions => newVersions );
+}
+
 export default React.createClass( {
 	OUT_OF_DATE_YEARS: 2,
 
@@ -133,7 +149,7 @@ export default React.createClass( {
 	},
 
 	getVersionWarning() {
-		const newVersions = this.getAvailableNewVersions();
+		const newVersions = getAvailableNewVersions( this.props );
 		if ( this.isOutOfDate() && newVersions.length === 0 ) {
 			return <Notice
 				className="plugin-meta__version-notice"
@@ -150,12 +166,12 @@ export default React.createClass( {
 	},
 
 	getUpdateWarning() {
-		const newVersions = this.getAvailableNewVersions();
+		const newVersions = getAvailableNewVersions( this.props );
 		if ( newVersions.length > 0 ) {
 			if ( this.props.selectedSite ) {
 				const textVersion = this.translate( 'Version' );
 				const textIsAvailable = this.translate( 'is available' );
-			
+
 				return (
 					<Notice
 						status="is-warning"
@@ -218,21 +234,21 @@ export default React.createClass( {
 		}
 	},
 
-	getAvailableNewVersions() {
-		return this.props.sites.map( site => {
-			if ( ! site.canUpdateFiles ) {
-				return null;
-			}
-			if ( site.plugin && site.plugin.update ) {
-				if ( 'error' !== site.plugin.update && site.plugin.update.new_version ) {
-					return {
-						title: site.title,
-						newVersion: site.plugin.update.new_version
-					};
-				}
-			}
-		} ).filter( newVersions => newVersions );
-	},
+	// getAvailableNewVersions() {
+	// 	return this.props.sites.map( site => {
+	// 		if ( ! site.canUpdateFiles ) {
+	// 			return null;
+	// 		}
+	// 		if ( site.plugin && site.plugin.update ) {
+	// 			if ( 'error' !== site.plugin.update && site.plugin.update.new_version ) {
+	// 				return {
+	// 					title: site.title,
+	// 					newVersion: site.plugin.update.new_version
+	// 				};
+	// 			}
+	// 		}
+	// 	} ).filter( newVersions => newVersions );
+	// },
 
 	handlePluginUpdatesSingleSite( event ) {
 		event.preventDefault();
@@ -293,7 +309,7 @@ export default React.createClass( {
 						site={ this.props.selectedSite }
 						pluginVersion={ plugin && plugin.version }
 						siteVersion={ this.props.selectedSite && this.props.selectedSite.options.software_version }
-						hasUpdate={ this.getAvailableNewVersions().length > 0 } /> }
+						hasUpdate={ getAvailableNewVersions( this.props ).length > 0 } /> }
 
 				</Card>
 				{ this.getVersionWarning() }

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -153,15 +153,18 @@ export default React.createClass( {
 		const newVersions = this.getAvailableNewVersions();
 		if ( newVersions.length > 0 ) {
 			if ( this.props.selectedSite ) {
+				const textVersion = this.translate( 'Version' );
+				const textIsAvailable = this.translate( 'is available' );
+			
 				return (
 					<Notice
 						status="is-warning"
 						className="plugin-meta__version-notice"
 						showDismiss={ false }
 						icon="sync"
-						text={ i18n.translate( 'A new version is available.' ) }>
+						text={ `${ textVersion } ${ newVersions[ 0 ].newVersion } ${ textIsAvailable }` }>
 						<NoticeAction onClick={ this.handlePluginUpdatesSingleSite }>
-							{ i18n.translate( 'Update to %(newPluginVersion)s', { args: { newPluginVersion: newVersions[ 0 ].newVersion } } ) }
+							{ this.translate( 'Update' ) }
 						</NoticeAction>
 					</Notice>
 				);


### PR DESCRIPTION
- Use identical update messaging and Notice/NoticeActions throughout the plugin pages.

This can be tested by checking the update notices that appear in the plugin list at /plugins. This branch should show the latest version number.
### Before

<img width="211" alt="screen shot 2016-09-20 at 12 18 24 pm" src="https://cloud.githubusercontent.com/assets/5528445/18685427/cfd562aa-7f2c-11e6-800e-a343ef48df92.png">
### After

<img width="182" alt="screen shot 2016-09-20 at 12 20 55 pm" src="https://cloud.githubusercontent.com/assets/5528445/18685429/d57a7600-7f2c-11e6-9502-a47f629939a2.png">
