### PR TITLE
Data component: add <QuerySiteUpdates /> component

### DIFF
--- a/client/components/data/query-site-updates/index.js
+++ b/client/components/data/query-site-updates/index.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingSiteUpdates } from 'state/sites/updates/selectors';
+import { requestSiteUpdates as requestUpdates } from 'state/sites/updates/utils';
+
+class QuerySiteUpdates extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		requestingSiteUpdates: PropTypes.bool,
+		requestUpdates: PropTypes.func
+	};
+
+	static defaultProps = {
+		requestUpdates: () => {}
+	};
+
+	constructor( props ) {
+		super( props );
+		this.requestUpdates = this.requestUpdates.bind( this );
+	}
+
+	componentWillMount() {
+		this.requestUpdates();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if (
+			nextProps.requestingSiteUpdates ||
+			! nextProps.siteId ||
+			( this.props.siteId === nextProps.siteId )
+		) {
+			return;
+		}
+
+		this.requestUpdates( nextProps );
+	}
+
+	requestUpdates( props = this.props ) {
+		if ( ! props.requestingSiteUpdates && props.siteId ) {
+			props.requestUpdates( props.siteId );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			requestingSiteUpdates: isRequestingSiteUpdates( state, ownProps.siteId )
+		};
+	},
+	{ requestUpdates }
+)( QuerySiteUpdates );


### PR DESCRIPTION
This PR adds `<QuerySiteUpdates />` components to be used to get `updates` object into the component properties.

### How to use it

```es6
import QuerySiteUpdates from 'components/data/query-site-updates';

// ...

class YourReactComponent extends Component {
  render() {
    return(
      <div class="your-react-component__container">
        <QuerySiteUpdates siteId={ site.ID } />

      </div>
    );
}
```