### PR TITLE
Post Status: Add component tests

### DIFF
--- a/client/blocks/post-status/index.jsx
+++ b/client/blocks/post-status/index.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import { getNormalizedPost } from 'state/posts/selectors';
 
-function PostStatus( { translate, post } ) {
+export function PostStatus( { translate, post } ) {
 	if ( ! post ) {
 		return null;
 	}
@@ -55,6 +55,8 @@ function PostStatus( { translate, post } ) {
 		</span>
 	);
 }
+
+PostStatus.displayName = 'PostStatus';
 
 PostStatus.propTypes = {
 	globalId: PropTypes.string,

--- a/client/blocks/post-status/test/index.jsx
+++ b/client/blocks/post-status/test/index.jsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import identity from 'lodash/identity';
+import Gridicon from 'components/gridicon';
+
+describe( 'PostStatus', ( ) => {
+	let PostStatus;
+
+	before( ( ) => {
+		PostStatus = require( '..' ).PostStatus;
+	} );
+
+	context( 'no post', ( ) => {
+		it( 'should be empty', ( ) => {
+			const PostStatusComponent = ( <PostStatus translate={ identity } /> );
+			const wrapper = shallow( PostStatusComponent );
+
+			expect( wrapper ).to.be.empty;
+		} );
+	} );
+
+	context( 'post', ( ) => {
+		context( 'sticky', ( ) => {
+			it( 'should render the primary components', ( ) => {
+				const PostStatusComponent = ( <PostStatus post={ { sticky: true } } translate={ identity } /> );
+				const wrapper = shallow( PostStatusComponent );
+
+				expect( wrapper ).to.have.descendants( 'span' );
+				expect( wrapper ).to.have.className( 'is-sticky' );
+				expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
+				expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'bookmark-outline' );
+				expect( wrapper.childAt( 1 ) ).to.have.tagName( 'span' ).to.have.text( 'Sticky' );
+			} );
+		} );
+
+		context( 'not sticky', ( ) => {
+			context( 'pending', ( ) => {
+				it( 'should render the primary components', ( ) => {
+					const PostStatusComponent = ( <PostStatus post={ { sticky: false, status: 'pending' } } translate={ identity } /> );
+					const wrapper = shallow( PostStatusComponent );
+
+					expect( wrapper ).to.have.descendants( 'span' );
+					expect( wrapper ).to.have.className( 'is-pending' );
+					expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
+					expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'aside' );
+					expect( wrapper.childAt( 1 ) ).to.have.tagName( 'span' ).to.have.text( 'Pending Review' );
+				} );
+			} );
+
+			context( 'future', ( ) => {
+				it( 'should render the primary components', ( ) => {
+					const PostStatusComponent = ( <PostStatus post={ { sticky: false, status: 'future' } } translate={ identity } /> );
+					const wrapper = shallow( PostStatusComponent );
+
+					expect( wrapper ).to.have.descendants( 'span' );
+					expect( wrapper ).to.have.className( 'is-scheduled' );
+					expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
+					expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'calendar' );
+					expect( wrapper.childAt( 1 ) ).to.have.tagName( 'span' ).to.have.text( 'Scheduled' );
+				} );
+			} );
+
+			context( 'trash', ( ) => {
+				it( 'should render the primary components', ( ) => {
+					const PostStatusComponent = ( <PostStatus post={ { sticky: false, status: 'trash' } } translate={ identity } /> );
+					const wrapper = shallow( PostStatusComponent );
+
+					expect( wrapper ).to.have.descendants( 'span' );
+					expect( wrapper ).to.have.className( 'is-trash' );
+					expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
+					expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'trash' );
+					expect( wrapper.childAt( 1 ) ).to.have.tagName( 'span' ).to.have.text( 'Trashed' );
+				} );
+			} );
+
+			context( 'unhandled status', ( ) => {
+				it( 'should be empty', ( ) => {
+					const PostStatusComponent = ( <PostStatus post={ { sticky: false, status: 'wow' } } translate={ identity } /> );
+					const wrapper = shallow( PostStatusComponent );
+
+					expect( wrapper ).to.be.empty;
+				} );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR adds tests for the Post Status component as described in #7942.

To test, run `npm run test-client client/blocks/post-status/` and verify that all of the tests pass.

Additionally, review the Post Status component and ensure that the test covers all of the relevant conditions.