### PR TITLE
Components: Fix unknown prop warnings in DisconnectJetpackButton

### DIFF
--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import assign from 'lodash/assign';
-import classNames from 'classnames';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,20 +32,16 @@ export default React.createClass( {
 
 	render() {
 		const { site, redirect, linkDisplay } = this.props;
-		const buttonElement = linkDisplay ? 'button' : Button;
 
-		const buttonClasses = classNames( {
-			button: true,
-			'disconnect-jetpack-button': true,
-			'is-link': linkDisplay
-		} );
-
-		const buttonProps = assign( {}, this.props, {
+		const omitProps = [ 'site', 'redirect', 'isMock', 'linkDisplay', 'text' ];
+		const buttonProps = {
+			...omit( this.props, omitProps ),
 			id: `disconnect-jetpack-${ site.ID }`,
-			className: buttonClasses,
+			className: 'disconnect-jetpack-button',
 			compact: true,
 			disabled: this.props.disabled,
 			scary: true,
+			borderless: linkDisplay,
 			onClick: ( event ) => {
 				event.preventDefault();
 				if ( this.props.isMock ) {
@@ -55,10 +50,9 @@ export default React.createClass( {
 				this.refs.dialog.open();
 				analytics.ga.recordEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
 			}
-		} );
+		};
 
 		let { text } = this.props;
-		let buttonChildren;
 
 		if ( ! text ) {
 			text = this.translate( 'Disconnect', {
@@ -66,13 +60,13 @@ export default React.createClass( {
 			} );
 		}
 
-		buttonChildren = (
+		const buttonChildren = (
 			<div>
 				{ text }
 				<DisconnectJetpackDialog site={ site } ref="dialog" redirect={ redirect } />
 			</div>
 		);
 
-		return React.createElement( buttonElement, buttonProps, buttonChildren );
+		return React.createElement( Button, buttonProps, buttonChildren );
 	}
 } );

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -1,5 +1,6 @@
 .plugin-activate-toggle .disconnect-jetpack-button {
 	font-size: 11px;
+	font-weight: 400;
 	color: $alert-red;
 	text-transform: uppercase;
 


### PR DESCRIPTION
This PR clears JS warnings emitted by the `DisconnectJetpackButton` component - they were caused by unnecessary props being specified to the `Button` component. It also does very basic cleanup to remove an ESLint warning, and always use the `Button` component instead of the `<button>` tag.

Note: this PR is part of the unknown prop warning resolve PR series: #7413.

To test:

* Get this branch going locally.
* Go to `/settings/general/$site`, where `$site` is one of your Jetpack sites.
* Go to `/plugins/$site`, where `$site` is one of your Jetpack sites.
* Go to `/plugins/jetpack/$site`, where `$site` is one of your Jetpack sites.
* In the top 3 cases, verify that there are no JS warnings caused by `DisconnectJetpackButton`, and there are no visual/functional changes to the `DisconnectJetpackButton` component.

/cc @aduth @gwwar 