### PR TITLE
Theme Sheet: Obtain Data from Redux State instead of page.js Context

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -374,6 +374,7 @@ function reduxStoreReady( reduxStore ) {
 	page( '*', function( context, next ) {
 		context.store.dispatch( setRouteAction(
 					context.pathname,
+					context.params,
 					context.query ) );
 		next();
 	} );

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -10,7 +10,6 @@ import startsWith from 'lodash/startsWith';
  */
 import ThemeSheetComponent from './main';
 import ThemeDetailsComponent from 'components/data/theme-details';
-import { getCurrentUser } from 'state/current-user/selectors';
 import {
 	receiveThemeDetails,
 	receiveThemeDetailsFailure,
@@ -57,19 +56,18 @@ export function fetchThemeDetailsData( context, next ) {
 
 export function details( context, next ) {
 	const { slug } = context.params;
-	const user = getCurrentUser( context.store.getState() );
 
 	if ( startsWith( context.prevPath, '/design' ) ) {
 		context.store.dispatch( setBackPath( context.prevPath ) );
 	}
 
-	const ConnectedComponent = ( { themeSlug, isLoggedIn } ) => (
+	const ConnectedComponent = ( { themeSlug } ) => (
 		<ThemeDetailsComponent id={ themeSlug } >
-			<ThemeSheetComponent isLoggedIn={ isLoggedIn } />
+			<ThemeSheetComponent />
 		</ThemeDetailsComponent>
 	);
 
-	context.primary = ConnectedComponent( { themeSlug: slug, isLoggedIn: !! user } );
+	context.primary = ConnectedComponent( { themeSlug: slug } );
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();
 }

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -63,13 +63,13 @@ export function details( context, next ) {
 		context.store.dispatch( setBackPath( context.prevPath ) );
 	}
 
-	const ConnectedComponent = ( { themeSlug, contentSection, isLoggedIn } ) => (
+	const ConnectedComponent = ( { themeSlug, isLoggedIn } ) => (
 		<ThemeDetailsComponent id={ themeSlug } >
-			<ThemeSheetComponent section={ contentSection } isLoggedIn={ isLoggedIn } />
+			<ThemeSheetComponent isLoggedIn={ isLoggedIn } />
 		</ThemeDetailsComponent>
 	);
 
-	context.primary = ConnectedComponent( { themeSlug: slug, contentSection: context.params.section, isLoggedIn: !! user } );
+	context.primary = ConnectedComponent( { themeSlug: slug, isLoggedIn: !! user } );
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();
 }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -509,6 +509,7 @@ export default connect(
 			currentUserId,
 			isCurrentUserPaid,
 			section,
+			isLoggedIn: !! currentUserId,
 		};
 	},
 	bindDefaultOptionToDispatch,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -50,6 +50,7 @@ import ThemePreview from 'my-sites/themes/theme-preview';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Head from 'layout/head';
 import { decodeEntities } from 'lib/formatting';
+import { getParam } from 'state/ui/route/selectors';
 
 const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -499,6 +500,7 @@ export default connect(
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
+		const section = getParam( state, 'section' );
 
 		return {
 			selectedSite,
@@ -506,6 +508,7 @@ export default connect(
 			backPath,
 			currentUserId,
 			isCurrentUserPaid,
+			section,
 		};
 	},
 	bindDefaultOptionToDispatch,

--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -40,14 +40,16 @@ export function setAllSitesSelected() {
 /**
  * Returns an action object signalling that the current route is to be changed
  *
- * @param  {String} path    Route path
- * @param  {Object} [query] Query arguments
- * @return {Object}         Action object
+ * @param  {String} path     Route path
+ * @param  {Object} [params] Route params
+ * @param  {Object} [query]  Query arguments
+ * @return {Object}          Action object
  */
-export function setRoute( path, query = {} ) {
+export function setRoute( path, params = {}, query = {} ) {
 	return {
 		type: ROUTE_SET,
 		path,
+		params,
 		query,
 	};
 }

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -17,6 +17,7 @@ import { createReducer } from 'state/utils';
 import editor from './editor/reducer';
 import guidedTour from './guided-tours/reducer';
 import queryArguments from './query-arguments/reducer';
+import route from './route/reducer';
 import reader from './reader/reducer';
 import olark from './olark/reducer';
 import actionLog from './action-log/reducer';
@@ -84,7 +85,8 @@ const reducer = combineReducers( {
 	olark,
 	preview,
 	actionLog,
-	happychat
+	happychat,
+	route
 } );
 
 export default function( state, action ) {

--- a/client/state/ui/route/reducer.js
+++ b/client/state/ui/route/reducer.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { createReducer } from 'state/utils';
+import { ROUTE_SET } from 'state/action-types';
+
+export const path = createReducer( '', {
+	[ ROUTE_SET ]: ( state, { path = '' } ) =>
+		path
+} );
+
+export const params = createReducer( {}, {
+	[ ROUTE_SET ]: ( state, { params = {} } ) =>
+		params
+} );
+
+export default combineReducers( {
+	path,
+	params
+} );

--- a/client/state/ui/route/selectors.js
+++ b/client/state/ui/route/selectors.js
@@ -1,0 +1,10 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export function getParam( state, param ) {
+	return get( state.ui.route, [ 'params', param ], '' );
+}

--- a/client/state/ui/route/test/reducer.js
+++ b/client/state/ui/route/test/reducer.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { ROUTE_SET } from 'state/action-types';
+import { path, params } from '../reducer';
+
+describe( 'reducer', () => {
+	describe( '#path()', () => {
+		it( 'should default to an empty string', () => {
+			const state = path( undefined, {} );
+
+			expect( state ).to.equal( '' );
+		} );
+
+		it( 'should properly set path', () => {
+			const newState = path( undefined, { type: ROUTE_SET, path: '/foo' } );
+
+			expect( newState ).to.equal( '/foo' );
+		} );
+	} );
+
+	describe( '#params()', () => {
+		it( 'should default to an empty object', () => {
+			const state = params( undefined, {} );
+
+			expect( state ).to.be.empty;
+		} );
+
+		it( 'should properly set params', () => {
+			const newState = params( undefined, { type: ROUTE_SET, params: { foo: 'bar' } } );
+
+			expect( newState ).to.eql( { foo: 'bar' } );
+		} );
+	} );
+} );

--- a/client/state/ui/route/test/selectors.js
+++ b/client/state/ui/route/test/selectors.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getParam } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '#getParams()', () => {
+		it( 'should return an empty string if the param cannot be found', () => {
+			const param = getParam( {
+				ui: {
+					route: {
+						params: { foo: 'bar' }
+					}
+				}
+			}, 'spam' );
+
+			expect( param ).to.be.empty;
+		} );
+
+		it( 'should return the route\'s params', () => {
+			const param = getParam( {
+				ui: {
+					route: {
+						params: { foo: 'bar' }
+					}
+				}
+			}, 'foo' );
+
+			expect( param ).to.eql( 'bar' );
+		} );
+	} );
+} );

--- a/client/state/ui/test/actions.js
+++ b/client/state/ui/test/actions.js
@@ -28,6 +28,7 @@ describe( 'actions', () => {
 			expect( action ).to.eql( {
 				type: ROUTE_SET,
 				path: '/foo',
+				params: {},
 				query: {}
 			} );
 		} );


### PR DESCRIPTION
WIP, currently broken. Requires #8140 and some rebasing on top of that.

This is a preparatory PR for better single-tree rendering syntax that will allow us to pass a single component tree to a middleware in order to have it rendered, instead of populating `context.primary` and `context.secondary`.

To do that, our component tree will need to have information available that right now we obtain from `context` (notably, `context.params`, i.e. the route params). This PR creates a new `route` Redux subtree in `state/ui` to reflect those.

Open questions:
- Is `state/ui` the proper place for the `route` subtree to go? Note that there's already `state/ui/query-parameters` subtree. Not sure if/how that should fit into the picture.
- There's a perf issue with passing route data through Redux. Try landing at https://wpcalypso.wordpress.com/theme/attache/setup -- it will first show the 'Overview' section and only after a noticeable delay switch to the 'Setup' one.

cc @ehg 
