### PR TITLE
Jetpack Connect: Convert HelpButton to a stateless function component

### DIFF
--- a/client/signup/jetpack-connect/help-button.jsx
+++ b/client/signup/jetpack-connect/help-button.jsx
@@ -8,19 +8,18 @@ import React from 'react';
  */
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
 
-export default React.createClass( {
-	displayName: 'JetpackConnectHelpButton',
+const JetpackConnectHelpButton = ( { translate } ) => {
+	return (
+		<LoggedOutFormLinkItem
+			className="jetpack-connect__help-button"
+			href="https://jetpack.com/contact-support"
+			target="_blank" rel="noopener noreferrer"
+		>
+			<Gridicon icon="help-outline" /> { translate( 'Get help connecting your site' ) }
+		</LoggedOutFormLinkItem>
+	);
+};
 
-	render() {
-		return (
-			<LoggedOutFormLinkItem
-				className="jetpack-connect__help-button"
-				href="https://jetpack.com/contact-support"
-				target="_blank" rel="noopener noreferrer"
-			>
-				<Gridicon icon="help-outline" /> { this.translate( 'Get help connecting your site' ) }
-			</LoggedOutFormLinkItem>
-		);
-	}
-} );
+export default localize( JetpackConnectHelpButton );


### PR DESCRIPTION
This PR converts the `JetpackConnectHelpButton` component to a stateless function component.

To test:

* Checkout this branch locally
* Run `http://calypso.localhost:3000/jetpack/connect`
* Verify there are no regressions with the help button on the JPC flows

/cc @roccotripaldi @ockham 