### PR TITLE
Jetpack Plugins: picking up trash and small improvements

### DIFF
--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -80,8 +80,8 @@ export default React.createClass( {
 			const syncIcon = this.props.hasUpdate ? <Gridicon icon="sync" size={ 18 } /> : null;
 
 			return <div className="plugin-information__last-updated">
-				{ this.translate( 'Released %(dateFromNow)s', { args: { dateFromNow } } ) }
 				{ syncIcon }
+				{ this.translate( 'Released %(dateFromNow)s', { args: { dateFromNow } } ) }
 			</div>;
 		}
 	},

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -1,11 +1,16 @@
 .plugin-information {
 	display: flex;
 	flex-wrap: wrap;
-	border-top: 1px solid #E9EFF3;
+	border-top: 1px solid lighten( $gray, 30% );
 	margin-top: 16px;
 	padding-top: 16px;
 	position: relative;
 	overflow: hidden;
+
+	@include breakpoint( '>480px' ) {
+		margin-top: 24px;
+		padding-top: 24px;
+	}
 }
 
 .plugin-information__description {
@@ -14,10 +19,6 @@
 
 .plugin-information__wrapper {
 	flex-grow: 1;
-
-	@include breakpoint( '>480px' ) {
-
-	}
 }
 
 .plugin-information__version-shell {
@@ -35,9 +36,9 @@
 }
 
 .plugin-information__last-updated .gridicons-sync {
-	vertical-align: text-bottom;
+	float: left;
 	color: $alert-yellow;
-	margin-left: 8px;
+	margin-right: 4px;
 }
 
 .plugin-information__version-info {

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -11,6 +11,7 @@ import some from 'lodash/some';
  */
 import analytics from 'lib/analytics';
 import Card from 'components/card';
+import Count from 'components/count';
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
@@ -51,7 +52,21 @@ export default React.createClass( {
 
 	renderActions() {
 		if ( ! this.props.selectedSite ) {
-			return;
+			return (
+				<div className="plugin-meta__actions">
+					<div className="plugin-item__count">
+						{
+							this.translate( 'Sites {{count/}}',
+								{
+									components: {
+										count: <Count count={ this.props.sites.length } />
+									}
+								}
+							)
+						}
+					</div>
+				</div>
+			);
 		}
 
 		if ( this.props.isPlaceholder ) {

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -68,9 +68,7 @@
 	flex-grow: 1;
 
 	@include breakpoint( '>480px' ) {
-		.has-site & {
-			max-width: calc(100% - 150px);
-		}
+		max-width: calc(100% - 150px);
 
 		.has-button & {
 			max-width: 100%;
@@ -116,6 +114,8 @@
 		margin: 0;
 		padding: 0;
 		text-align: right;
+		justify-content: flex-end;
+		align-self: center;
 
 		.plugin-action {
 			margin-top: 16px;
@@ -141,4 +141,8 @@
 	@include breakpoint ( ">480px" ) {
 		margin-top: -15px;
 	}
+}
+
+.plugin-meta__actions .plugin-item__count {
+	padding: 0;
 }


### PR DESCRIPTION
The All Sites view of the Plugins page was in need of some cleanup. 

* I moved the update icon to the left of the release date and fixed an alignment issue with it
* I fixed some inconsistent margins/padding
* I swapped a very old hex code reference for a color variable 
* I Added the 'site count' to the All Sites plugin detail view so you can see how many sites the plugin has been installed on

**Before:**
<img width="745" alt="screen shot 2016-09-19 at 11 27 30 am" src="https://cloud.githubusercontent.com/assets/437258/18643921/17401d1e-7e5c-11e6-99a1-b6b803591883.png">

**After:**
<img width="735" alt="screen shot 2016-09-19 at 11 28 19 am" src="https://cloud.githubusercontent.com/assets/437258/18643944/2dc10530-7e5c-11e6-9200-3597662c4727.png">
