### PR TITLE
Update: podcast stats naming convention 

### DIFF
--- a/client/lib/stats/stats-list/index.js
+++ b/client/lib/stats/stats-list/index.js
@@ -16,7 +16,7 @@ var responseHandler,
 	buildExportArray,
 	trackExtraStats = false,
 	documentedEndpoints = [ 'statsVideo', 'statsPublicize', 'statsStreak', 'statsFollowers', 'statsCommentFollowers', 'statsTopAuthors', 'statsTags', 'statsComments', 'statsPostViews', 'statsVideoPlays', 'stats', 'statsVisits', 'statsReferrers', 'statsTopPosts', 'statsClicks', 'statsCountryViews', 'statsSearchTerms' ],
-	undocumentedEndpoints = [ 'statsEvents', 'statsInsights', 'statsPodcastListens' ];
+	undocumentedEndpoints = [ 'statsEvents', 'statsInsights', 'statsPodcastDownloads' ];
 
 responseHandler = function() {
 	return function( error, data ) {

--- a/client/lib/stats/stats-list/stats-parser.js
+++ b/client/lib/stats/stats-list/stats-parser.js
@@ -579,18 +579,18 @@ StatsParser.prototype.statsVideoPlays = function( payload ) {
 	return response;
 };
 
-StatsParser.prototype.statsPodcastListens = function( payload ) {
+StatsParser.prototype.statsPodcastDownloads = function( payload ) {
 	var response = { data: [] },
 		periodRange = rangeOfPeriod( this.options.period, this.options.date ),
 		startDate = periodRange.startOf.format( 'YYYY-MM-DD' );
 
 	if ( payload && payload.date && payload.days && payload.days[ startDate ] ) {
-		response.data = payload.days[ startDate ].listens.map( function( item ) {
-			var detailPage = '/stats/' + this.options.period + '/podcastlistens/' + this.options.domain + '?post=' + item.post_id;
+		response.data = payload.days[ startDate ].downloads.map( function( item ) {
+			var detailPage = '/stats/' + this.options.period + '/podcastdownloads/' + this.options.domain + '?post=' + item.post_id;
 			return {
 				label: item.title,
 				page: detailPage,
-				value: item.listens,
+				value: item.downloads,
 				actions: [ {
 					type: 'link',
 					data: item.url
@@ -598,12 +598,12 @@ StatsParser.prototype.statsPodcastListens = function( payload ) {
 			};
 		}, this );
 
-		if ( payload.days[ startDate ].other_listens ) {
-			response.summaryPage = this.options ? '/stats/' + this.options.period + '/podcastlistens/' + this.options.domain + '?startDate=' + startDate : null;
+		if ( payload.days[ startDate ].other_downloads ) {
+			response.summaryPage = this.options ? '/stats/' + this.options.period + '/podcastdownloads/' + this.options.domain + '?startDate=' + startDate : null;
 		}
 
-		if ( payload.days[ startDate ].total_listens ) {
-			response.total = payload.days[ startDate ].total_listens;
+		if ( payload.days[ startDate ].total_downloads ) {
+			response.total = payload.days[ startDate ].total_downloads;
 		}
 	}
 

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -16,7 +16,7 @@ var Export = require( './export' );
 var resources = [
 	[ 'statsEvents', 'posts/' ],
 	[ 'statsInsights', 'stats/insights', '1.1' ],
-	[ 'statsPodcastListens', 'stats/podcast-listens', '1.1' ],
+	[ 'statsPodcastDownloads', 'stats/podcast-downloads', '1.1' ],
 	[ 'sshCredentialsNew', 'ssh-credentials/new', '1.1', 'post' ],
 	[ 'sshCredentialsMine', 'ssh-credentials/mine', '1.1' ],
 	[ 'sshCredentialsMineDelete', 'ssh-credentials/mine/delete', '1.1', 'post' ],

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -402,8 +402,8 @@ module.exports = {
 				siteID: siteId, statType: 'statsCountryViews', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const videoPlaysList = new StatsList( {
 				siteID: siteId, statType: 'statsVideoPlays', period: activeFilter.period, date: endDate, domain: siteDomain } );
-			const podcastListensList = new StatsList( {
-				siteID: siteId, statType: 'statsPodcastListens', period: activeFilter.period, date: endDate, domain: siteDomain } );
+			const podcastDownloadsList = new StatsList( {
+				siteID: siteId, statType: 'statsPodcastDownloads', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const searchTermsList = new StatsList( {
 				siteID: siteId, statType: 'statsSearchTerms', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const tagsList = new StatsList( { siteID: siteId, statType: 'statsTags', domain: siteDomain } );
@@ -434,7 +434,7 @@ module.exports = {
 					authorsList: authorsList,
 					countriesList: countriesList,
 					videoPlaysList: videoPlaysList,
-					podcastListensList: podcastListensList,
+					podcastDownloadsList: podcastDownloadsList,
 					siteId: siteId,
 					period: period,
 					chartPeriod: chartPeriod,
@@ -479,7 +479,7 @@ module.exports = {
 		let summaryList;
 		let visitsList;
 		const followList = new FollowList();
-		const validModules = [ 'posts', 'referrers', 'clicks', 'countryviews', 'authors', 'videoplays', 'videodetails', 'podcastlistens', 'searchterms' ];
+		const validModules = [ 'posts', 'referrers', 'clicks', 'countryviews', 'authors', 'videoplays', 'videodetails', 'podcastdownloads', 'searchterms' ];
 		let momentSiteZone = i18n.moment();
 		const basePath = route.sectionify( context.path );
 
@@ -570,8 +570,8 @@ module.exports = {
 						period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 
-				case 'podcastlistens':
-					summaryList = new StatsList( { statType: 'statsPodcastListens', siteID: siteId,
+				case 'podcastdownloads':
+					summaryList = new StatsList( { statType: 'statsPodcastDownloads', siteID: siteId,
 						period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 			}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -134,10 +134,10 @@ module.exports = React.createClass( {
 			}
 			if ( config.isEnabled( 'manage/stats/podcasts' ) && site.options.podcasting_archive ) {
 				podcastList = <StatsModule
-					path={ 'podcastlistens' }
-					moduleStrings={ moduleStrings.podcastlistens }
+					path={ 'podcastdownloads' }
+					moduleStrings={ moduleStrings.podcastdownloads }
 					site={ site }
-					dataList={ this.props.podcastListensList }
+					dataList={ this.props.podcastDownloadsList }
 					period={ this.props.period }
 					date={ queryDate }
 					beforeNavigate={ this.updateScrollPosition } />;

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -45,7 +45,7 @@ module.exports = function() {
 		empty: i18n.translate( 'No videos played', { context: 'Stats: Info box label when the Videos module is empty' } )
 	};
 
-	statsStrings.podcastlistens = {
+	statsStrings.podcastdownloads = {
 		title: i18n.translate( 'Podcasts', { context: 'Stats: title of module' } ),
 		item: i18n.translate( 'Episodes', { context: 'Stats: module row header for podcast.' } ),
 		value: i18n.translate( 'Downloads', { context: 'Stats: module row header for number of downloads per podcast episode.' } ),

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -150,12 +150,12 @@ module.exports = React.createClass( {
 					summary={ true } />;
 				break;
 
-			case 'podcastlistens':
+			case 'podcastdownloads':
 				title = this.translate( 'Podcasts' );
 				summaryView = <StatsModule
-					key="podcastlistens-summary"
-					path={ 'podcastlistens' }
-					moduleStrings={ StatsStrings.podcastlistens }
+					key="podcastldownloads-summary"
+					path={ 'podcastldownloads' }
+					moduleStrings={ StatsStrings.podcastldownloads }
 					site={ site }
 					dataList={ this.props.summaryList }
 					period={ this.props.period }


### PR DESCRIPTION
This replaces `listen` with `download` as the resource name to access podcast stats.

cc @seear , @georgeh 