### PR TITLE
Stats: remove stats-list localStorage persistence.

### DIFF
--- a/client/lib/stats/stats-list/index.js
+++ b/client/lib/stats/stats-list/index.js
@@ -8,7 +8,6 @@ var Emitter = require( 'lib/mixins/emitter'),
  * Internal dependencies
  */
 var wpcom = require( 'lib/wp' ),
-	LocalList = require( 'lib/local-list' ),
 	statsParser = require( './stats-parser' )(),
 	analytics = require( 'lib/analytics' );
 
@@ -76,8 +75,6 @@ responseHandler = function() {
 			analytics.mc.bumpStat( 'calypso_stats_empty', this.statType.replace( /^stats/, '' ) );
 		}
 
-		// cache data in local store
-		this.local.set( this.localKey, parsedData );
 		this.response = parsedData;
 		debug( 'updated data', this );
 		this.emit( 'change' );
@@ -141,21 +138,6 @@ function StatsList( options ) {
 	this.performRetry = true;
 	this.startedAt = null;
 	this.isDocumentedEndpoint = ( documentedEndpoints.indexOf( this.statType ) >= 0 );
-
-	this.localStoreKey = this.statType + this.siteID;
-
-	// For LocalList
-	this.local = new LocalList( { localStoreKey: this.localStoreKey } );
-	this.localKey = Object.keys( this.options ).map( function( key ) { return this.options[ key ]; }, this ).join( ':' );
-
-	// check for a local cache
-	var localData = this.local.find( this.localKey );
-	if ( localData && ! Array.isArray( localData ) ){
-		debug( 'local cached found', localData.data );
-		this.loading = false;
-		this.response = localData.data;
-	}
-
 	this.fetch();
 
 	return this;

--- a/client/lib/stats/stats-list/test/index.js
+++ b/client/lib/stats/stats-list/test/index.js
@@ -82,10 +82,6 @@ describe( 'StatList', () => {
 			assert.equal( statList.statType, 'statsClicks', 'should set the statType' );
 		} );
 
-		it( 'should set localStoreKey', () => {
-			assert.equal( statList.localStoreKey, statList.statType + statList.siteID, 'should set the localStoreKey' );
-		} );
-
 		it( 'should default performRetry to true', () => {
 			assert.isTrue( statList.performRetry, 'should performRetry' );
 		} );


### PR DESCRIPTION
There is a hard to reproduce bug that happens on the Stats insights page that the current fix is to clear `localStore`.  Given that I personally have yet to experience this bug, I can't fully say this branch will prevent it from happening, but it _should_.

The proposed fix in this branch is to remove the localStore persistence for the legacy `stats-list`.  This writing of new stats data to the localStore is removed, as are all attempts to read/load persisted data.  This, of course, will result in more loading states being seen on stats pages after a hard refresh/page load, but it should alleviate the load on localStore substantially.

__To Test__
Testing this branch requires viewing all stats pages and ensuring nothing has changed ( except of course data not being persisted between full page loads ).  So view the Stats Insights page, Period pages ( day, week, month, year ), and click through to summary pages on all stats lists.

/cc @mtias 