### PR TITLE
Jetpack Connect: Convert Activate example to a stateless function component

### DIFF
--- a/client/signup/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/signup/jetpack-connect/example-components/jetpack-activate.jsx
@@ -8,71 +8,66 @@ import React from 'react';
  */
 import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
 
-export default React.createClass( {
-	displayName: 'JetpackConnectExampleActivate',
-
-	renderActivate() {
-		if ( this.props.isInstall ) {
-			return (
-				<div className="example-components__content-wp-admin-activate-view">
-					<div className="example-components__content-wp-admin-activate-link" aria-hidden="true">
-						{ this.translate( 'Activate Plugin',
-							{
-								context: 'Jetpack Connect activate plugin instructions, activate link'
-							}
-						) }
-					</div>
+const JetpackConnectExampleActivate = ( { isInstall, url, translate } ) => {
+	return (
+		<div className="example-components__main">
+			<div className="example-components__browser-chrome example-components__site-url-input-container">
+				<div className="example-components__browser-chrome-dots">
+					<div className="example-components__browser-chrome-dot"></div>
+					<div className="example-components__browser-chrome-dot"></div>
+					<div className="example-components__browser-chrome-dot"></div>
 				</div>
-			);
-		}
-		return (
-			<div className="example-components__content-wp-admin-plugin-card">
-				<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
-					{ this.translate( 'Jetpack by WordPress.com',
-						{
-							context: 'Jetpack Connect activate plugin instructions, plugin title'
-						}
-					) }
-				</div>
-				<div className="example-components__content-wp-admin-plugin-activate-link" aria-hidden="true">
-					{ this.translate( 'Activate',
-						{
-							context: 'Jetpack Connect activate plugin instructions, activate link'
-						}
-					) }
+				<div className="example-components__site-address-container">
+					<Gridicon
+						size={ 24 }
+						icon="globe" />
+					<FormTextInput
+						className="example-components__browser-chrome-url"
+						disabled="true"
+						placeholder={ url } />
 				</div>
 			</div>
-		);
-	},
-
-	render() {
-		return (
-			<div className="example-components__main">
-				<div className="example-components__browser-chrome example-components__site-url-input-container">
-					<div className="example-components__browser-chrome-dots">
-						<div className="example-components__browser-chrome-dot"></div>
-						<div className="example-components__browser-chrome-dot"></div>
-						<div className="example-components__browser-chrome-dot"></div>
-					</div>
-					<div className="example-components__site-address-container">
-						<Gridicon
-							size={ 24 }
-							icon="globe" />
-						<FormTextInput
-							className="example-components__browser-chrome-url"
-							disabled="true"
-							placeholder={ this.props.url } />
-					</div>
-				</div>
-				<div className="example-components__content example-components__activate-jetpack">
-					<div className="example-components__content-wp-admin-masterbar"></div>
-					<div className="example-components__content-wp-admin-sidebar"></div>
-					<div className="example-components__content-wp-admin-main">
-						{ this.renderActivate() }
-					</div>
+			<div className="example-components__content example-components__activate-jetpack">
+				<div className="example-components__content-wp-admin-masterbar"></div>
+				<div className="example-components__content-wp-admin-sidebar"></div>
+				<div className="example-components__content-wp-admin-main">
+					{ isInstall
+						? (
+							<div className="example-components__content-wp-admin-activate-view">
+								<div className="example-components__content-wp-admin-activate-link" aria-hidden="true">
+									{ translate( 'Activate Plugin',
+										{
+											context: 'Jetpack Connect activate plugin instructions, activate link'
+										}
+									) }
+								</div>
+							</div>
+						)
+						: (
+							<div className="example-components__content-wp-admin-plugin-card">
+								<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
+									{ translate( 'Jetpack by WordPress.com',
+										{
+											context: 'Jetpack Connect activate plugin instructions, plugin title'
+										}
+									) }
+								</div>
+								<div className="example-components__content-wp-admin-plugin-activate-link" aria-hidden="true">
+									{ translate( 'Activate',
+										{
+											context: 'Jetpack Connect activate plugin instructions, activate link'
+										}
+									) }
+								</div>
+							</div>
+						)
+					}
 				</div>
 			</div>
-		);
-	}
-} );
+		</div>
+	);
+};
+
+export default localize( JetpackConnectExampleActivate );


### PR DESCRIPTION
This PR converts the `JetpackConnectExampleActivate` component to a stateless function component.

To test:

* Checkout this branch locally
* Run `http://calypso.localhost:3000/jetpack/connect`
* Verify there are no changes/regressions in the example screens when testing with:
  * Site without Jetpack installed
  * Site with Jetpack installed, but not activated

/cc @roccotripaldi @ockham 