### PR TITLE
Jetpack Connect: Convert Connect example to a stateless function component

### DIFF
--- a/client/signup/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/signup/jetpack-connect/example-components/jetpack-connect.jsx
@@ -9,72 +9,69 @@ import classNames from 'classnames';
  */
 import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
 
-export default React.createClass( {
-	displayName: 'JetpackConnectExampleConnect',
-
-	propTypes: {
-		isLegacy: React.PropTypes.bool,
-		url: React.PropTypes.string
-	},
-
-	getDefaultProps() {
-		return {
-			isLegacy: false,
-			url: ''
-		};
-	},
-
-	render() {
-		const contentClassName = classNames( 'example-components__content', 'example-components__connect-jetpack', {
-			'is-legacy': this.props.isLegacy
-		} );
-		return (
-			<div className="example-components__main">
-				<div className="example-components__browser-chrome example-components__site-url-input-container">
-					<div className="example-components__browser-chrome-dots">
-						<div className="example-components__browser-chrome-dot"></div>
-						<div className="example-components__browser-chrome-dot"></div>
-						<div className="example-components__browser-chrome-dot"></div>
-					</div>
-					<div className="example-components__site-address-container">
-						<Gridicon
-							size={ 24 }
-							icon="globe" />
-						<FormTextInput
-							className="example-components__browser-chrome-url"
-							disabled="true"
-							placeholder={ this.props.url } />
-					</div>
+const JetpackConnectExampleConnect = ( { isLegacy, url, translate } ) => {
+	const contentClassName = classNames( 'example-components__content', 'example-components__connect-jetpack', {
+		'is-legacy': isLegacy
+	} );
+	return (
+		<div className="example-components__main">
+			<div className="example-components__browser-chrome example-components__site-url-input-container">
+				<div className="example-components__browser-chrome-dots">
+					<div className="example-components__browser-chrome-dot"></div>
+					<div className="example-components__browser-chrome-dot"></div>
+					<div className="example-components__browser-chrome-dot"></div>
 				</div>
-				<div className={ contentClassName }>
-					<div className="example-components__content-wp-admin-masterbar"></div>
-					<div className="example-components__content-wp-admin-sidebar"></div>
-					<div className="example-components__content-wp-admin-main">
-						<div className="example-components__content-wp-admin-connect-banner">
-							{ ! this.props.isLegacy
-								? (
-									<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
-										{ this.translate( 'Your Jetpack is almost ready!',
-											{
-												context: 'Jetpack Connect activate plugin instructions, connection banner headline'
-											}
-										) }
-									</div>
-								)
-								: null
-							}
-							<div className="example-components__content-wp-admin-connect-button" aria-hidden="true">
-								{ this.translate( 'Connect to WordPress.com',
-									{
-										context: 'Jetpack Connect post-plugin-activation step, Connect to WordPress.com button'
-									}
-								) }
-							</div>
+				<div className="example-components__site-address-container">
+					<Gridicon
+						size={ 24 }
+						icon="globe" />
+					<FormTextInput
+						className="example-components__browser-chrome-url"
+						disabled="true"
+						placeholder={ url } />
+				</div>
+			</div>
+			<div className={ contentClassName }>
+				<div className="example-components__content-wp-admin-masterbar"></div>
+				<div className="example-components__content-wp-admin-sidebar"></div>
+				<div className="example-components__content-wp-admin-main">
+					<div className="example-components__content-wp-admin-connect-banner">
+						{ ! isLegacy
+							? (
+								<div className="example-components__content-wp-admin-plugin-name" aria-hidden="true">
+									{ translate( 'Your Jetpack is almost ready!',
+										{
+											context: 'Jetpack Connect activate plugin instructions, connection banner headline'
+										}
+									) }
+								</div>
+							)
+							: null
+						}
+						<div className="example-components__content-wp-admin-connect-button" aria-hidden="true">
+							{ translate( 'Connect to WordPress.com',
+								{
+									context: 'Jetpack Connect post-plugin-activation step, Connect to WordPress.com button'
+								}
+							) }
 						</div>
 					</div>
 				</div>
 			</div>
-		);
-	}
-} );
+		</div>
+	);
+};
+
+JetpackConnectExampleConnect.propTypes = {
+	isLegacy: React.PropTypes.bool,
+	url: React.PropTypes.string
+};
+
+JetpackConnectExampleConnect.defaultProps = {
+	isLegacy: false,
+	url: ''
+};
+
+export default localize( JetpackConnectExampleConnect );


### PR DESCRIPTION
This PR converts the `JetpackConnectExampleConnect` component to a stateless function component.

To test:

* Checkout this branch locally
* Run `http://calypso.localhost:3000/jetpack/connect`
* Verify there are no changes/regressions in the example screens when testing with:
  * Site without Jetpack installed
  * Site with Jetpack < 4.2 installed, but not activated
  * Site with Jetpack >= 4.2 installed, but not activated

/cc @roccotripaldi @ockham 