### PR TITLE
Jetpack Connect: Convert Install example to a stateless function component

### DIFF
--- a/client/signup/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/signup/jetpack-connect/example-components/jetpack-install.jsx
@@ -8,43 +8,42 @@ import React from 'react';
  */
 import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
 
-export default React.createClass( {
-	displayName: 'JetpackConnectExampleInstall',
-
-	render() {
-		return (
-			<div className="example-components__main">
-				<div className="example-components__browser-chrome example-components__site-url-input-container">
-					<div className="example-components__browser-chrome-dots">
-						<div className="example-components__browser-chrome-dot"></div>
-						<div className="example-components__browser-chrome-dot"></div>
-						<div className="example-components__browser-chrome-dot"></div>
-					</div>
-					<div className="example-components__site-address-container">
-						<Gridicon
-							size={ 24 }
-							icon="globe" />
-						<FormTextInput
-							className="example-components__browser-chrome-url"
-							disabled="true"
-							placeholder={ this.props.url } />
-					</div>
+const JetpackConnectExampleInstall = ( { url, translate } ) => {
+	return (
+		<div className="example-components__main">
+			<div className="example-components__browser-chrome example-components__site-url-input-container">
+				<div className="example-components__browser-chrome-dots">
+					<div className="example-components__browser-chrome-dot"></div>
+					<div className="example-components__browser-chrome-dot"></div>
+					<div className="example-components__browser-chrome-dot"></div>
 				</div>
-				<div className="example-components__content example-components__install-jetpack">
-					<div className="example-components__install-plugin-header"></div>
-					<div className="example-components__install-plugin-body"></div>
-					<div className="example-components__install-plugin-footer">
-						<div className="example-components__install-plugin-footer-button" aria-hidden="true">
-							{ this.translate( 'Install Now',
-								{
-									context: 'Jetpack Connect install plugin instructions, install button'
-								}
-							) }
-						</div>
+				<div className="example-components__site-address-container">
+					<Gridicon
+						size={ 24 }
+						icon="globe" />
+					<FormTextInput
+						className="example-components__browser-chrome-url"
+						disabled="true"
+						placeholder={ url } />
+				</div>
+			</div>
+			<div className="example-components__content example-components__install-jetpack">
+				<div className="example-components__install-plugin-header"></div>
+				<div className="example-components__install-plugin-body"></div>
+				<div className="example-components__install-plugin-footer">
+					<div className="example-components__install-plugin-footer-button" aria-hidden="true">
+						{ translate( 'Install Now',
+							{
+								context: 'Jetpack Connect install plugin instructions, install button'
+							}
+						) }
 					</div>
 				</div>
 			</div>
-		);
-	}
-} );
+		</div>
+	);
+};
+
+export default localize( JetpackConnectExampleInstall );


### PR DESCRIPTION
This PR converts the `JetpackConnectExampleInstall` component to a stateless function component.

To test:

* Checkout this branch locally
* Run `http://calypso.localhost:3000/jetpack/connect`
* Verify there are no changes/regressions in the example screens when testing with a site without Jetpack installed

/cc @roccotripaldi @ockham 