### PR TITLE
Jetpack Plugins: Use pluralization in button text to fix i18n

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -166,14 +166,22 @@ export default React.createClass( {
 
 		if ( ! this.props.isBulkManagementActive ) {
 			if ( 0 < this.props.pluginUpdateCount ) {
-				const textUpdate = this.translate( 'Update', { context: 'button label' } );
-				const textNumber = this.numberFormat( this.props.pluginUpdateCount );
-				const textPlugin = this.translate( 1 < this.props.pluginUpdateCount ? 'Plugins' : 'Plugin', { context: 'button label' } );
-
 				rightSideButtons.push(
 					<ButtonGroup key="plugin-list-header__buttons-update-all">
 						<Button compact primary onClick={ this.props.updateAllPlugins } >
-							{ `${textUpdate} ${textNumber} ${textPlugin}` }
+							{
+								this.translate(
+									'Update Plugin',
+									'Update %(numUpdates)d Plugins',
+									{
+										context: 'button label',
+										count: this.props.pluginUpdateCount,
+										args: {
+											numUpdates: this.props.pluginUpdateCount
+										}
+									}
+								)
+							}
 						</Button>
 					</ButtonGroup>
 				);

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -171,7 +171,7 @@ export default React.createClass( {
 						<Button compact primary onClick={ this.props.updateAllPlugins } >
 							{
 								this.translate(
-									'Update Plugin',
+									'Update %(numUpdates)d Plugin',
 									'Update %(numUpdates)d Plugins',
 									{
 										context: 'button label',


### PR DESCRIPTION
Use plugralization instead of what was done in https://github.com/Automattic/wp-calypso/pull/8114
