### PR TITLE
Jetpack Connect: Convert Connect Header component to a stateless function component

### DIFF
--- a/client/signup/jetpack-connect/connect-header.jsx
+++ b/client/signup/jetpack-connect/connect-header.jsx
@@ -1,40 +1,40 @@
+/**
+ * External Dependencies
+ */
 import React, { PropTypes } from 'react';
 
+/**
+ * Internal dependencies
+ */
 import StepHeader from '../step-header';
 
-export default React.createClass( {
-	displayName: 'JetpackConnectHeader',
+const JetpackConnectHeader = ( props ) => {
+	return (
+		<div className="jetpack-connect__header-container">
+			{ props.showLogo
+				? (
+					<img
+						className="jetpack-connect__jetpack-logo"
+						src="/calypso/images/jetpack/jetpack-logo.svg"
+						width={ 18 }
+						height={ 18 }
+					/>
+				)
+				: null
+			}
+			<StepHeader { ...props } />
+		</div>
+	);
+};
 
-	propTypes: {
-		showLogo: PropTypes.bool,
-		label: PropTypes.string
-	},
+JetpackConnectHeader.propTypes = {
+	showLogo: PropTypes.bool,
+	label: PropTypes.string
+};
 
-	getDefaultProps() {
-		return {
-			showLogo: true,
-			label: ''
-		};
-	},
+JetpackConnectHeader.defaultProps = {
+	showLogo: true,
+	label: ''
+};
 
-	renderJetpackLogo() {
-		return (
-			<img
-				className="jetpack-connect__jetpack-logo"
-				src="/calypso/images/jetpack/jetpack-logo.svg"
-				width={ 18 }
-				height={ 18 } />
-		);
-	},
-
-	render() {
-		return (
-			<div className="jetpack-connect__header-container">
-				{ this.props.showLogo
-					? this.renderJetpackLogo()
-					: null }
-				<StepHeader { ...this.props } />
-			</div>
-		);
-	}
-} );
+export default JetpackConnectHeader;


### PR DESCRIPTION
This PR converts the `JetpackConnectHeader` component to a stateless function component.

To test:

* Checkout this branch locally
* Run `http://calypso.localhost:3000/jetpack/connect`
* Verify there are no changes/regressions to the title section in the JPC flow screens

/cc @roccotripaldi @ockham 