### PR TITLE
Stats: turn on podcast stats on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,6 +67,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
+		"manage/stats/podcasts": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,


### PR DESCRIPTION
Turn on functionality added in #8148 on wpcalypso.wordpress.com.
