### PR TITLE
Blocks: add JetpackUpdatesPopover component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -14,18 +14,24 @@
 @import 'blocks/author-selector/style';
 @import 'blocks/comment-button/style';
 @import 'blocks/comments/style';
+@import 'blocks/credit-card-form/style';
+@import 'blocks/design-menu/style';
 @import 'blocks/dismissible-card/style';
 @import 'blocks/domain-to-plan-nudge/style';
+@import 'blocks/jetpack-updates-popover/style';
 @import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';
 @import 'blocks/post-relative-time/style';
 @import 'blocks/post-status/style';
+@import 'blocks/product-purchase-features/product-purchase-features-list/style';
 @import 'blocks/reader-avatar/style';
 @import 'blocks/reader-full-post/style';
 @import 'blocks/reader-related-card/style';
 @import 'blocks/reader-related-card-v2/style';
 @import 'blocks/reader-search-card/style';
+@import 'blocks/site/style';
+@import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/accordion/style';
 @import 'components/animate/style';
 @import 'components/bulk-select/style';
@@ -94,7 +100,6 @@
 @import 'components/payment-logo/style';
 @import 'components/plans/plan-icon/style';
 @import 'components/plans/plan-price/style';
-@import 'blocks/product-purchase-features/product-purchase-features-list/style';
 @import 'components/plans/premium-popover/style';
 @import 'components/popover/style';
 @import 'components/post-excerpt/style';
@@ -115,7 +120,6 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
-@import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';
 @import 'components/signup-form/style';
 @import 'components/site-icon/style';
@@ -147,7 +151,6 @@
 @import 'components/vertical-nav/item/style';
 @import 'components/vertical-menu/style';
 @import 'components/web-preview/style';
-@import 'blocks/credit-card-form/style';
 @import 'devdocs/style';
 @import 'layout/guided-tours/style';
 @import 'components/happychat/style';
@@ -297,7 +300,6 @@
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';
 @import 'my-sites/importer/style';
-@import 'blocks/site/style';
 @import 'my-sites/sites/style';
 @import 'my-sites/stats/style';
 @import 'my-sites/stats/all-time/style';
@@ -415,6 +417,5 @@
 @import 'signup/steps/site/style';
 @import 'signup/validation-fieldset/style';
 @import 'support/support-user/style';
-@import 'blocks/design-menu/style';
 @import 'my-sites/design-preview/style';
 @import 'vip/vip-logs/style';

--- a/client/blocks/jetpack-updates-popover/index.jsx
+++ b/client/blocks/jetpack-updates-popover/index.jsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import QuerySiteUpdates from 'components/data/query-site-updates';
+import {
+	renderWPComTemplate,
+	renderPluginsTemplate,
+	renderThemesTemplate,
+} from './update-templates';
+import { isFinished as isJetpackPluginsFinished } from 'state/plugins/premium/selectors';
+import {
+	getUpdatesBySiteId,
+	hasWordPressUpdate,
+	hasUpdates as siteHasUpdate,
+	getSectionsToUpdate,
+} from 'state/sites/updates/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import { canCurrentUser } from 'state/current-user/selectors';
+import Popover from 'components/popover';
+
+class JetpackUpdatesPopover extends Component {
+	static propTypes = {
+		isJetpack: React.PropTypes.bool,
+		isVisible: React.PropTypes.bool,
+		hasWPUpdate: PropTypes.bool,
+		hasUpdates: PropTypes.bool,
+		onClose: PropTypes.func,
+		site: PropTypes.object,
+		updates: PropTypes.object
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showPopover: false
+		};
+	}
+
+	toggleJetpackNotificatonsPopover() {
+		this.setState( { showPopover: ! this.state.showPopover } );
+	}
+
+	hideJetpackNotificatonsPopover() {
+		this.setState( { showPopover: false } );
+	}
+
+	handleWPCOMUpdate( ev ) {
+		ev.preventDefault();
+	}
+
+	render() {
+		const { context, isVisible, onClose, position, site } = this.props;
+
+		return (
+			<Popover
+				className="jetpack-updates-popover"
+				id="popover__jetpack-notifications"
+				isVisible={ isVisible }
+				onClose={ onClose }
+				position={ position }
+				context={ context }
+			>
+				<QuerySiteUpdates siteId={ site.ID } />
+
+				{ renderWPComTemplate( this.props ) }
+				{ renderPluginsTemplate( this.props ) }
+				{ renderThemesTemplate( this.props ) }
+			</Popover>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	const siteId = ownProps.site && ownProps.site.ID ? ownProps.site.ID : null;
+
+	return {
+		isJetpack: isJetpackSite( state, siteId ),
+		hasUpdates: siteHasUpdate( state, siteId ),
+		hasWPUpdate: hasWordPressUpdate( state, siteId ),
+		canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
+		pausedJetpackPluginsSetup: ! isJetpackPluginsFinished( state, siteId ),
+		updates: getUpdatesBySiteId( state, siteId ),
+		sectionsToUpdate: getSectionsToUpdate( state, siteId ),
+	};
+} )( localize( JetpackUpdatesPopover ) );
+

--- a/client/blocks/jetpack-updates-popover/style.scss
+++ b/client/blocks/jetpack-updates-popover/style.scss
@@ -1,0 +1,58 @@
+
+@include breakpoint( "<660px" ) {
+	.jetpack-updates-popover {
+		display: none;
+	}
+}
+
+.popover.jetpack-updates-popover {
+	hr {
+		color: $gray-light;
+	}
+
+	.popover__inner {
+		max-width: 200px;
+	    padding: 5px;
+	    text-align: left;
+	}
+}
+
+.jetpack-updates-popover__block {
+	display: flex;
+	margin-top: 8px;
+	margin-bottom: 16px;
+
+	&:last-child {
+		margin-bottom: 8px;
+	}
+}
+
+.jetpack-updates-popover__block > .gridicon {
+	display: inline-block;
+	flex-shrink: 0;
+	color: $gray;
+	margin-right: 4px;
+}
+
+.jetpack-updates-popover__text {
+	display: inline-block;
+}
+
+.jetpack-updates-popover__link {
+	font-size: 11px;
+	font-weight: 600;
+	margin-left: 4px;
+	text-decoration: underline;
+	text-transform: uppercase;
+
+	&:hover,
+	&:active,
+	&:focus {
+		text-decoration: none;
+	}
+}
+
+.jetpack-updates-popover__link .gridicon {
+	margin-left: 4px;
+	vertical-align: top;
+}

--- a/client/blocks/jetpack-updates-popover/update-templates.jsx
+++ b/client/blocks/jetpack-updates-popover/update-templates.jsx
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+const handleWPCOMUpdate = ( event ) => {
+	event.preventDefault();
+};
+
+export const renderWPComTemplate = ( { translate, updates } ) => {
+	// just for testing purpose
+	if ( config.isEnabled( 'gm2016/jetpack-plugin-updates-trashpickup' ) ) {
+		updates.wordpress = 1;
+		updates.wp_update_version = '5.0.0';
+	}
+
+	if ( ! (
+		config.isEnabled( 'jetpack_core_inline_update' ) &&
+		updates.wordpress &&
+		updates.wp_update_version
+	) ) {
+		return null;
+	}
+
+	return (
+		<div className="jetpack-updates-popover__block">
+			<Gridicon icon="my-sites" size={ 18 } />
+			<div className="jetpack-updates-popover__text">
+				{ translate( 'A newer version of WordPress is available.' ) }
+				<a
+					className="jetpack-updates-popover__link"
+					href="#"
+					onClick={ handleWPCOMUpdate }
+				>
+					{
+						translate( 'Update to %(version)s', {
+							args: {
+								version: updates.wp_update_version
+							}
+						} )
+					}
+					<Gridicon icon="external" size={ 12 } />
+				</a>
+			</div>
+		</div>
+	);
+};
+
+export const renderPluginsTemplate = ( { onClose, site, translate, updates } ) => {
+	if ( ! site.canUpdateFiles || ! updates.plugins ) {
+		return null;
+	}
+
+	return (
+		<div className="jetpack-updates-popover__block">
+			<Gridicon icon="plugins" size={ 18 } />
+			<div className="jetpack-updates-popover__text">
+				{
+					translate(
+						'There is %(total)d plugin update available.',
+						'There are %(total)d plugin updates available.',
+						{
+							count: updates.plugins,
+							args: {
+								total: updates.plugins
+							}
+						}
+					)
+				}
+				<a
+					className="jetpack-updates-popover__link"
+					onClick={ onClose }
+					href={ '/plugins/updates/' + site.slug }>
+					{ translate( 'View' ) }
+					<Gridicon icon="external" size={ 12 } />
+				</a>
+			</div>
+		</div>
+	);
+};
+
+export const renderThemesTemplate = ( { onClose, updates, site, translate } ) => {
+	if ( ! updates.themes ) {
+		return null;
+	}
+
+	return (
+		<div className="jetpack-updates-popover__block">
+			<Gridicon icon="themes" size={ 18 } />
+			<div className="jetpack-updates-popover__text">
+				{
+					translate(
+						'There is %(total)d theme update available. {{link}}View{{/link}}',
+						'There are %(total)d theme updates available. {{link}}View{{/link}}',
+						{
+							components: {
+								link:
+									<a
+										className="jetpack-updates-popover__link"
+										onClick={ onClose }
+										target="_blanck"
+										href={ site.options.admin_url + 'update-core.php#update-themes-table' }
+									>
+										<Gridicon icon="external" size={ 12 } />
+									</a>
+							},
+							count: updates.themes,
+							args: {
+								total: updates.themes
+							}
+						}
+					)
+				}
+			</div>
+		</div>
+	);
+};


### PR DESCRIPTION
This PR adds the `<JetpackUpdatesPopover />` block component.

The behaviour is pretty similar to `<Popover />` but the goal here is that the popover content is filled automatically in function of the data gotten from the state tree so we don't have to concern about its content.

``` es6
import JetpackUpdatesPopover from 'blocks/jetpack-updates-popover';

<JetpackUpdatesPopover
    site={ site }
    isVisible={ showJetpackPopover }
    onClose={ this.hideJetpackNotificatonsPopover }
    position="bottom"
    context={ this.refs && this.refs.popoverJetpackNotifications }
/>
```

![image](https://cloud.githubusercontent.com/assets/77539/18687534/5f68745e-7f35-11e6-8931-c60901166056.png)
