### PR TITLE
Image Editor: Fix #7991 #8080 Cannot edit images in Safari

### DIFF
--- a/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
@@ -72,7 +72,7 @@ const MediaModalImageEditorCanvas = React.createClass( {
 		const { onLoadError, mimeType } = this.props;
 
 		const req = new XMLHttpRequest();
-		req.open( 'GET', url, true );
+		req.open( 'GET', url + '?', true ); // Fix #7991 by forcing Safari to ignore cache and perform valid CORS request
 		req.responseType = 'arraybuffer';
 		req.onload = () => {
 			const objectURL = window.URL.createObjectURL( new Blob( [ req.response ], { type: mimeType } ) );


### PR DESCRIPTION
Mildly entertaining. 

The CDN serves images without **Access-Control-Allow-Origin** unless they're requested with an **Origin** header. Now the image is initially requested (and cached) without an **Origin**. As a result, subsequent CORS requests trigger an error in Safari.

There is a relevant WebKit bug: 
https://bugs.chromium.org/p/chromium/issues/detail?id=409090

Solution is to modify the image url just for image editor, so that the cache is ignored.