### PR TITLE
Framework: Update my-sites/plans to use the sites redux store

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -3,74 +3,22 @@
  */
 import page from 'page';
 import React from 'react';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-import analytics from 'lib/analytics';
-import { isEnabled } from 'config';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import route from 'lib/route';
-import sitesFactory from 'lib/sites-list';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import get from 'lodash/get';
 import { isValidFeatureKey } from 'lib/plans';
-
-const sites = sitesFactory();
 
 export default {
 	plans( context ) {
 		const Plans = require( 'my-sites/plans/main' ),
-			CheckoutData = require( 'components/data/checkout' ),
-			MainComponent = require( 'components/main' ),
-			EmptyContentComponent = require( 'components/empty-content' ),
-			site = sites.getSelectedSite(),
-			analyticsPageTitle = 'Plans',
-			basePath = route.sectionify( context.path );
-		let analyticsBasePath;
-
-		// Don't show plans for Jetpack sites
-		if ( site && site.jetpack && ! isEnabled( 'manage/jetpack-plans' ) ) {
-			analytics.pageView.record( basePath + '/jetpack/:site', analyticsPageTitle + ' > Jetpack Plans Not Available' );
-
-			renderWithReduxStore(
-				React.createElement( MainComponent, null,
-					React.createElement( EmptyContentComponent, {
-						title: i18n.translate( 'Plans are not available for Jetpack sites yet.' ),
-						line: i18n.translate( 'Looking for spam protection?' ),
-						action: i18n.translate( 'Try Akismet' ),
-						actionURL: '//akismet.com/plans/?ref=calypso-plans',
-						illustration: '/calypso/images/drake/drake-nomenus.svg'
-					} )
-				),
-				document.getElementById( 'primary' ),
-				context.store
-			);
-			return;
-		}
-
-		if ( site ) {
-			analyticsBasePath = basePath + '/:site';
-		} else {
-			analyticsBasePath = basePath;
-		}
-
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Plans', { textOnly: true } ) ) );
-
-		analytics.tracks.recordEvent( 'calypso_plans_view' );
-		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
-
-		// Scroll to the top
-		if ( typeof window !== 'undefined' ) {
-			window.scrollTo( 0, 0 );
-		}
+			CheckoutData = require( 'components/data/checkout' );
 
 		renderWithReduxStore(
 			<CheckoutData>
 				<Plans
-					sites={ sites }
 					context={ context }
 					intervalType={ context.params.intervalType }
 					destinationType={ context.params.destinationType }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 
 /**
@@ -70,9 +70,9 @@ const Plans = React.createClass( {
 		return (
 			<MainComponent>
 				<EmptyContentComponent
-					title={ i18n.translate( 'Plans are not available for Jetpack sites yet.' ) }
-					line={ i18n.translate( 'Looking for spam protection?' ) }
-					action={ i18n.translate( 'Try Akismet' ) }
+					title={ this.props.translate( 'Plans are not available for Jetpack sites yet.' ) }
+					line={ this.props.translate( 'Looking for spam protection?' ) }
+					action={ this.props.translate( 'Try Akismet' ) }
 					actionURL={ '//akismet.com/plans/?ref=calypso-plans' }
 					illustration={ '/calypso/images/drake/drake-nomenus.svg' }
 				/>
@@ -89,7 +89,7 @@ const Plans = React.createClass( {
 
 		return (
 			<div>
-				<DocumentHead title={ i18n.translate( 'Plans', { textOnly: true } ) } />
+				<DocumentHead title={ this.props.translate( 'Plans', { textOnly: true } ) } />
 				<Main wideLayout={ true } >
 					<SidebarNavigation />
 
@@ -126,4 +126,4 @@ export default connect(
 			selectedSiteId: selectedSiteId
 		};
 	}
-)( Plans );
+)( localize( Plans ) );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -10,13 +10,10 @@ import React from 'react';
  */
 import analytics from 'lib/analytics';
 import DocumentHead from 'components/data/document-head';
-import EmptyContentComponent from 'components/empty-content';
 import { getPlansBySiteId } from 'state/sites/plans/selectors';
 import { getPlans } from 'state/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isEnabled } from 'config';
 import Main from 'components/main';
-import MainComponent from 'components/main';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import route from 'lib/route';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -41,24 +38,14 @@ const Plans = React.createClass( {
 		};
 	},
 
-	shouldDisplayJetpackPlansDisabled() {
-		const { selectedSite } = this.props;
-
-		return selectedSite && selectedSite.jetpack && ! isEnabled( 'manage/jetpack-plans' );
-	},
-
 	componentDidMount() {
 		const { context, selectedSite } = this.props,
 			analyticsPageTitle = 'Plans',
 			basePath = route.sectionify( context.path ),
 			analyticsBasePath = ( selectedSite ) ? basePath + '/:site' : basePath;
 
-		if ( this.shouldDisplayJetpackPlansDisabled() ) {
-			analytics.pageView.record( basePath + '/jetpack/:site', analyticsPageTitle + ' > Jetpack Plans Not Available' );
-		} else {
-			analytics.tracks.recordEvent( 'calypso_plans_view' );
-			analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
-		}
+		analytics.tracks.recordEvent( 'calypso_plans_view' );
+		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {
@@ -66,30 +53,12 @@ const Plans = React.createClass( {
 		}
 	},
 
-	renderJetpackPlansDisabled() {
-		return (
-			<MainComponent>
-				<EmptyContentComponent
-					title={ this.props.translate( 'Plans are not available for Jetpack sites yet.' ) }
-					line={ this.props.translate( 'Looking for spam protection?' ) }
-					action={ this.props.translate( 'Try Akismet' ) }
-					actionURL={ '//akismet.com/plans/?ref=calypso-plans' }
-					illustration={ '/calypso/images/drake/drake-nomenus.svg' }
-				/>
-			</MainComponent>
-		);
-	},
-
 	render() {
-		const { selectedSite, selectedSiteId } = this.props;
-
-		if ( this.shouldDisplayJetpackPlansDisabled() ) {
-			this.renderJetpackPlansDisabled();
-		}
+		const { selectedSite, selectedSiteId, translate } = this.props;
 
 		return (
 			<div>
-				<DocumentHead title={ this.props.translate( 'Plans', { textOnly: true } ) } />
+				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<Main wideLayout={ true } >
 					<SidebarNavigation />
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -9,6 +9,7 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import DocumentHead from 'components/data/document-head';
 import EmptyContentComponent from 'components/empty-content';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getPlans } from 'state/plans/selectors';
@@ -18,7 +19,6 @@ import Main from 'components/main';
 import MainComponent from 'components/main';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import route from 'lib/route';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import QueryPlans from 'components/data/query-plans';
@@ -52,9 +52,6 @@ const Plans = React.createClass( {
 			analyticsPageTitle = 'Plans',
 			basePath = route.sectionify( context.path ),
 			analyticsBasePath = ( selectedSite ) ? basePath + '/:site' : basePath;
-
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Plans', { textOnly: true } ) ) );
 
 		if ( this.shouldDisplayJetpackPlansDisabled() ) {
 			analytics.pageView.record( basePath + '/jetpack/:site', analyticsPageTitle + ' > Jetpack Plans Not Available' );
@@ -92,6 +89,7 @@ const Plans = React.createClass( {
 
 		return (
 			<div>
+				<DocumentHead title={ i18n.translate( 'Plans', { textOnly: true } ) } />
 				<Main wideLayout={ true } >
 					<SidebarNavigation />
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import analytics from 'lib/analytics';
 import DocumentHead from 'components/data/document-head';
 import EmptyContentComponent from 'components/empty-content';
-import { getPlansBySite } from 'state/sites/plans/selectors';
+import { getPlansBySiteId } from 'state/sites/plans/selectors';
 import { getPlans } from 'state/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isEnabled } from 'config';
@@ -117,10 +117,13 @@ const Plans = React.createClass( {
 } );
 
 export default connect(
-	( state ) => ( {
-		plans: getPlans( state ),
-		sitePlans: getPlansBySite( state, getSelectedSiteId( state ) ),
-		selectedSite: getSelectedSite( state ),
-		selectedSiteId: getSelectedSiteId( state )
-	} )
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		return {
+			plans: getPlans( state ),
+			sitePlans: getPlansBySiteId( state, selectedSiteId ),
+			selectedSite: getSelectedSite( state ),
+			selectedSiteId: selectedSiteId
+		};
+	}
 )( Plans );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -8,15 +8,15 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import DocumentHead from 'components/data/document-head';
 import { getPlansBySiteId } from 'state/sites/plans/selectors';
 import { getPlans } from 'state/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
-import route from 'lib/route';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import TrackComponentView from 'lib/analytics/track-component-view';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -39,14 +39,6 @@ const Plans = React.createClass( {
 	},
 
 	componentDidMount() {
-		const { context, selectedSite } = this.props,
-			analyticsPageTitle = 'Plans',
-			basePath = route.sectionify( context.path ),
-			analyticsBasePath = ( selectedSite ) ? basePath + '/:site' : basePath;
-
-		analytics.tracks.recordEvent( 'calypso_plans_view' );
-		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
-
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {
 			window.scrollTo( 0, 0 );
@@ -59,6 +51,8 @@ const Plans = React.createClass( {
 		return (
 			<div>
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
+				<PageViewTracker path="/plans/:site" title="Plans" />
+				<TrackComponentView eventName="calypso_plans_view" />
 				<Main wideLayout={ true } >
 					<SidebarNavigation />
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -9,9 +9,8 @@ import React from 'react';
  */
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getPlans } from 'state/plans/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
-import observe from 'lib/mixins/data-observe';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
@@ -19,14 +18,13 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 
 const Plans = React.createClass( {
-	mixins: [ observe( 'sites' ) ],
-
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
 		context: React.PropTypes.object.isRequired,
 		intervalType: React.PropTypes.string,
 		plans: React.PropTypes.array.isRequired,
-		sites: React.PropTypes.object.isRequired,
+		selectedSite: React.PropTypes.object.isRequired,
+		selectedSiteId: React.PropTypes.number.isRequired,
 		sitePlans: React.PropTypes.object.isRequired
 	},
 
@@ -37,9 +35,6 @@ const Plans = React.createClass( {
 	},
 
 	render() {
-		const selectedSite = this.props.sites.getSelectedSite(),
-			siteId = this.props.siteId;
-
 		return (
 			<div>
 				<Main wideLayout={ true } >
@@ -50,30 +45,29 @@ const Plans = React.createClass( {
 							sitePlans={ this.props.sitePlans }
 							path={ this.props.context.path }
 							cart={ this.props.cart }
-							selectedSite={ selectedSite } />
+							selectedSite={ this.props.site } />
 
 						<QueryPlans />
-						<QuerySitePlans siteId={ siteId } />
+						<QuerySitePlans siteId={ this.props.siteId } />
 
 						<PlansFeaturesMain
-							site={ selectedSite }
+							site={ this.props.selectedSite }
 							intervalType={ this.props.intervalType }
 							hideFreePlan={ true }
 							selectedFeature={ this.props.selectedFeature }
 						/>
 					</div>
-				</Main>
+				</Main> 
 			</div>
 		);
 	}
 } );
 
 export default connect(
-	( state, props ) => {
-		return {
-			plans: getPlans( state ),
-			sitePlans: getPlansBySite( state, props.sites.getSelectedSite() ),
-			siteId: getSelectedSiteId( state )
-		};
-	}
+	( state ) => ( {
+		plans: getPlans( state ),
+		sitePlans: getPlansBySite( state, getSelectedSiteId( state ) ),
+		selectedSite: getSelectedSite( state ),
+		selectedSiteId: getSelectedSiteId( state )
+	} )
 )( Plans );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -2,16 +2,23 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import i18n from 'i18n-calypso';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import EmptyContentComponent from 'components/empty-content';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getPlans } from 'state/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isEnabled } from 'config';
 import Main from 'components/main';
+import MainComponent from 'components/main';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
+import route from 'lib/route';
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import QueryPlans from 'components/data/query-plans';
@@ -34,7 +41,55 @@ const Plans = React.createClass( {
 		};
 	},
 
+	shouldDisplayJetpackPlansDisabled() {
+		const { selectedSite } = this.props;
+
+		return selectedSite && selectedSite.jetpack && ! isEnabled( 'manage/jetpack-plans' );
+	},
+
+	componentDidMount() {
+		const { context, selectedSite } = this.props,
+			analyticsPageTitle = 'Plans',
+			basePath = route.sectionify( context.path ),
+			analyticsBasePath = ( selectedSite ) ? basePath + '/:site' : basePath;
+
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Plans', { textOnly: true } ) ) );
+
+		if ( this.shouldDisplayJetpackPlansDisabled() ) {
+			analytics.pageView.record( basePath + '/jetpack/:site', analyticsPageTitle + ' > Jetpack Plans Not Available' );
+		} else {
+			analytics.tracks.recordEvent( 'calypso_plans_view' );
+			analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
+		}
+
+		// Scroll to the top
+		if ( typeof window !== 'undefined' ) {
+			window.scrollTo( 0, 0 );
+		}
+	},
+
+	renderJetpackPlansDisabled() {
+		return (
+			<MainComponent>
+				<EmptyContentComponent
+					title={ i18n.translate( 'Plans are not available for Jetpack sites yet.' ) }
+					line={ i18n.translate( 'Looking for spam protection?' ) }
+					action={ i18n.translate( 'Try Akismet' ) }
+					actionURL={ '//akismet.com/plans/?ref=calypso-plans' }
+					illustration={ '/calypso/images/drake/drake-nomenus.svg' }
+				/>
+			</MainComponent>
+		);
+	},
+
 	render() {
+		const { selectedSite, selectedSiteId } = this.props;
+
+		if ( this.shouldDisplayJetpackPlansDisabled() ) {
+			this.renderJetpackPlansDisabled();
+		}
+
 		return (
 			<div>
 				<Main wideLayout={ true } >
@@ -45,19 +100,19 @@ const Plans = React.createClass( {
 							sitePlans={ this.props.sitePlans }
 							path={ this.props.context.path }
 							cart={ this.props.cart }
-							selectedSite={ this.props.site } />
+							selectedSite={ selectedSite } />
 
 						<QueryPlans />
-						<QuerySitePlans siteId={ this.props.siteId } />
+						<QuerySitePlans siteId={ selectedSiteId } />
 
 						<PlansFeaturesMain
-							site={ this.props.selectedSite }
+							site={ selectedSite }
 							intervalType={ this.props.intervalType }
 							hideFreePlan={ true }
 							selectedFeature={ this.props.selectedFeature }
 						/>
 					</div>
-				</Main> 
+				</Main>
 			</div>
 		);
 	}

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -26,7 +26,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/jetpack": true,
-		"manage/jetpack-plans": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -32,7 +32,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/jetpack": true,
-		"manage/jetpack-plans": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/development.json
+++ b/config/development.json
@@ -64,7 +64,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
-		"manage/jetpack-plans": true,
 		"manage/media": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -41,7 +41,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
-		"manage/jetpack-plans": true,
 		"manage/media": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -37,7 +37,6 @@
 		"manage/edit-user": true,
 		"manage/export": true,
 		"manage/jetpack": true,
-		"manage/jetpack-plans": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -40,7 +40,6 @@
 		"manage/edit-user": true,
 		"manage/export": true,
 		"manage/jetpack": true,
-		"manage/jetpack-plans": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/test.json
+++ b/config/test.json
@@ -50,7 +50,6 @@
 		"manage/edit-user": true,
 		"manage/export": true,
 		"manage/jetpack": true,
-		"manage/jetpack-plans": true,
 		"manage/media": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -49,7 +49,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
-		"manage/jetpack-plans": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": true,


### PR DESCRIPTION
This PR updates the remaining components in `my-sites/plans` to use the redux reducer instead of listening to change events on the `sitesList`. This is part of the effort to remove sitesList from calypso https://github.com/Automattic/wp-calypso/issues/8726

### Testing Instructions
- `git checkout update/siteslist-plans` and `make run` of use [calypso.live](https://calypso.live/plans??branch=update/siteslist-plans)
- Navigate to `/plans/:yoursite`
- Check that the page loads correctly and that you can select a plan for your site
- Check that you can switch site

### Reviews
- [ ] Code
- [ ] Product
