### PR TITLE
Reader: Fix captioned images alignment

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -225,6 +225,24 @@
 		position: relative;
 		max-width: 100%;
 
+		&.alignright {
+			float: right;
+		}
+
+		&.alignleft {
+			float: left;
+		}
+
+		&.alignright,
+		&.alignleft {
+			max-width: 50%;
+
+			img.alignright,
+			img.alignleft {
+				float: none;
+			}
+		}
+
 		img {
 			display: block;
 			margin: 0 auto;

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -235,7 +235,11 @@
 
 		&.alignright,
 		&.alignleft {
-			max-width: 50%;
+			max-width: 100%;
+
+			@include breakpoint( ">660px" ) {
+				max-width: 50%;
+			}
 
 			img.alignright,
 			img.alignleft {


### PR DESCRIPTION
This PR fixes`.wp-caption` sections that are aligned right (with an `.alignright` class) or left (`.alignleft`) in Reader as they display incorrectly.

**Before:**
![screenshot 2016-09-20 17 46 45](https://cloud.githubusercontent.com/assets/4924246/18693968/de3074f6-7f5a-11e6-858a-e9488574012f.png)

**After:**
![screenshot 2016-09-20 17 47 05](https://cloud.githubusercontent.com/assets/4924246/18693971/e24bcbc6-7f5a-11e6-9bbb-62cd2cf6aa45.png)

Example post: http://calypso.dev:3000/read/feeds/34114/posts/1148935347
