### PR TITLE
Reader: Fix Share button misaligned in stream and full-post

### DIFF
--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -2,7 +2,7 @@
 	align-items: center;
 	display: inline-flex;
 	padding: 4px;
-	color: lighten( $gray, 10 );;
+	color: lighten( $gray, 10 );
 	position: relative;
 	box-sizing: border-box;
 	transition: color 0.15s linear;

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -1,12 +1,11 @@
-.reader-share {
-	display: inline-block;
-	padding: 4px 4px 4px 32px;
-	color: lighten( $gray, 10 );
-	position: relative;
+.reader-share_button {
+	align-items: center;
 	box-sizing: border-box;
+	color: lighten( $gray, 10 );
+	display: inline-flex;
+	padding: 4px;
+	position: relative;
 	transition: color 0.15s linear;
-	cursor: pointer;
-	min-height: 32px;
 
 	&:hover, &:focus, &:active {
 		cursor: pointer;
@@ -15,13 +14,6 @@
 
 	.gridicon {
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-		position: absolute;
-			top: 3px;
-			left: 3px;
-
-		@include breakpoint( "<480px" ) {
-			left: 6px;
-		}
 	}
 
 	.is-active {
@@ -34,6 +26,7 @@
 }
 
 .reader-share__button-label {
+	margin-left: 6px;
 
 	@include breakpoint( "<480px" ) {
 		display: none;


### PR DESCRIPTION
This PR fixes the Share button which is misaligned with the rest of the action icons both in the streams and full-post page.

Also used flexbox instead.

**Before (Stream):**
![screenshot 2016-09-21 11 12 00](https://cloud.githubusercontent.com/assets/4924246/18723237/a4d6a260-7fec-11e6-80dd-6367503ea343.png)

**Before (Full-post):**
![screenshot 2016-09-21 11 14 12](https://cloud.githubusercontent.com/assets/4924246/18723253/b28cbe8a-7fec-11e6-8356-d01312d92e7c.png)

**After (Stream):**
![screenshot 2016-09-21 11 16 28](https://cloud.githubusercontent.com/assets/4924246/18723343/0310752c-7fed-11e6-920a-776d44bb420a.png)

**After (Full-post):**
![screenshot 2016-09-21 11 16 32](https://cloud.githubusercontent.com/assets/4924246/18723348/09df4fc2-7fed-11e6-8c1c-d6dc74da7bb6.png)


