### PR TITLE
Framework: Lower the number of chunks a modules needs to appear in to promote it to commons

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,7 +100,7 @@ if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( 'vendor', '[name].[hash].js' ) );
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( {
 		children: true,
-		minChunks: Math.floor( sectionCount * 0.25 ),
+		minChunks: 6,
 		async: true,
 		filename: 'commons.[hash].js'
 	} ) );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,6 @@ var webpack = require( 'webpack' ),
  * Internal dependencies
  */
 var config = require( './server/config' ),
-	sections = require( './client/sections' ),
 	ChunkFileNamePlugin = require( './server/bundler/plugin' ),
 	HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
@@ -21,8 +20,6 @@ var config = require( './server/config' ),
 var CALYPSO_ENV = process.env.CALYPSO_ENV || 'development',
 	jsLoader,
 	webpackConfig;
-
-const sectionCount = sections.length;
 
 webpackConfig = {
 	bail: CALYPSO_ENV !== 'development',
@@ -100,7 +97,7 @@ if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( 'vendor', '[name].[hash].js' ) );
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( {
 		children: true,
-		minChunks: 6,
+		minChunks: 4,
 		async: true,
 		filename: 'commons.[hash].js'
 	} ) );


### PR DESCRIPTION
Since we've added so many more chunks, using a 1/4 as the boundary is resulting in many modules including lots of duplicated commponents. Reader, for instance, has ballooned up quite a bit.