### PR TITLE
Reader: Fix gravatar and follow alignment in More on WP block

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -317,7 +317,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	flex: 1;
 	flex-direction: column;
 	font-size: 14px;
-	margin-top: 5px;
+	margin-top: 3px;
 }
 
 .reader-related-card-v2__byline-author {
@@ -349,7 +349,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	border: 0;
 	border-radius: 0;
 	margin-bottom: 12px;
-	margin-left: auto;
+	margin-top: -3px;
 	padding: 0;
 
 	.gridicon__follow {

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -335,7 +335,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	display: -webkit-box;
 	-webkit-line-clamp: 1;
 	-webkit-box-orient: vertical;
-	max-height: 22px;
+	max-height: 23px;
 	overflow: hidden;
 	position: relative;
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8087

**Before:**
![before](https://cloud.githubusercontent.com/assets/4924246/18728325/a0bb0c10-8001-11e6-8a2d-7a60a3e7678c.jpg)

**After:**
![after](https://cloud.githubusercontent.com/assets/4924246/18728332/a4f5d508-8001-11e6-8bb6-e057483041eb.jpg)
