### PR TITLE
Framework: split the sites selector into multiple files

### DIFF
--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -1,0 +1,15 @@
+/** @ssr-ready **/
+
+// These could be rewritten as `export * from`, pending resolution of Babel
+// transform bug: http://phabricator.babeljs.io/T2877
+import * as jetpack from './jetpack';
+import * as plan from './plan';
+import * as site from './site';
+import * as sites from './sites';
+
+export default {
+	...jetpack,
+	...plan,
+	...site,
+	...sites
+};

--- a/client/state/sites/selectors/jetpack.js
+++ b/client/state/sites/selectors/jetpack.js
@@ -1,0 +1,72 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getRawSite, getSiteOption } from './site';
+import versionCompare from 'lib/version-compare';
+
+/**
+ * Returns true if site is a Jetpack site, false if the site is hosted on
+ * WordPress.com, or null if the site is unknown.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is a Jetpack site
+ */
+export function isJetpackSite( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	return site.jetpack;
+}
+
+/**
+ * Returns true if the site is a Jetpack site with the specified module active,
+ * or false if the module is not active. Returns null if the site is not known
+ * or is not a Jetpack site.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @param  {String}   slug   Module slug
+ * @return {?Boolean}        Whether site has Jetpack module active
+ */
+export function isJetpackModuleActive( state, siteId, slug ) {
+	const modules = getSiteOption( state, siteId, 'active_modules' );
+	if ( ! modules ) {
+		return null;
+	}
+
+	return includes( modules, slug );
+}
+
+/**
+ * Returns true if the Jetpack site is running a version meeting the specified
+ * minimum, or false if the Jetpack site is running an older version. Returns
+ * null if the version cannot be determined or if not a Jetpack site.
+ *
+ * @param  {Object}   state   Global state tree
+ * @param  {Number}   siteId  Site ID
+ * @param  {String}   version Minimum version
+ * @return {?Boolean}         Whether running minimum version
+ */
+export function isJetpackMinimumVersion( state, siteId, version ) {
+	const isJetpack = isJetpackSite( state, siteId );
+	if ( ! isJetpack ) {
+		return null;
+	}
+
+	const siteVersion = getSiteOption( state, siteId, 'jetpack_version' );
+	if ( ! siteVersion ) {
+		return null;
+	}
+
+	return versionCompare( siteVersion, version, '>=' );
+}

--- a/client/state/sites/selectors/plan.js
+++ b/client/state/sites/selectors/plan.js
@@ -1,0 +1,91 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getRawSite } from './site';
+
+/**
+ * Returns a site's plan object by site ID.
+ *
+ * The difference between this selector and sites/plans/getPlansBySite is that the latter selectors works
+ * with the /sites/$site/plans endpoint while the former selectors works with /sites/$site endpoint.
+ * Query these endpoints to see if you need the first or the second one.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Object}        Site's plan object
+ */
+export function getSitePlan( state, siteId ) {
+	const site = getRawSite( state, siteId );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	if ( get( site.plan, 'expired', false ) ) {
+		if ( site.jetpack ) {
+			return {
+				product_id: 2002,
+				product_slug: 'jetpack_free',
+				product_name_short: 'Free',
+				free_trial: false,
+				expired: false
+			};
+		}
+
+		return {
+			product_id: 1,
+			product_slug: 'free_plan',
+			product_name_short: 'Free',
+			free_trial: false,
+			expired: false
+		};
+	}
+
+	return site.plan;
+}
+
+/**
+ * Returns true if the current site plan is a paid one
+ *
+ * @param  {Object}   state         Global state tree
+ * @param  {Number}   siteId        Site ID
+ * @return {?Boolean}               Whether the current plan is paid
+ */
+export function isCurrentPlanPaid( state, siteId ) {
+	const sitePlan = getSitePlan( state, siteId );
+
+	if ( ! sitePlan ) {
+		return null;
+	}
+
+	return sitePlan.product_id !== 1 && sitePlan.product_id !== 2002;
+}
+
+/**
+ * Returns true if site is currently subscribed to supplied plan and false otherwise.
+ *
+ * @param  {Object}   state         Global state tree
+ * @param  {Number}   siteId        Site ID
+ * @param  {Number}   planProductId Plan product_id
+ * @return {?Boolean}               Whether site's plan matches supplied plan
+ */
+export function isCurrentSitePlan( state, siteId, planProductId ) {
+	if ( planProductId === undefined ) {
+		return null;
+	}
+
+	const sitePlan = getSitePlan( state, siteId );
+
+	if ( ! sitePlan ) {
+		return null;
+	}
+
+	return sitePlan.product_id === planProductId;
+}

--- a/client/state/sites/selectors/site.js
+++ b/client/state/sites/selectors/site.js
@@ -20,15 +20,10 @@ import {
  * Internal dependencies
  */
 import config from 'config';
-import { isHttps, withoutHttp } from 'lib/url';
-
-/**
- * Internal dependencies
- */
 import createSelector from 'lib/create-selector';
 import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
-import versionCompare from 'lib/version-compare';
 import getComputedAttributes from 'lib/site/computed-attributes';
+import { isHttps, withoutHttp } from 'lib/url';
 
 /**
  * Returns a raw site object by its ID.
@@ -70,6 +65,26 @@ export const getSite = createSelector(
 	},
 	( state ) => state.sites.items
 );
+
+/**
+ * Returns a site object by its URL.
+ *
+ * @param  {Object}  state Global state tree
+ * @param  {String}  url   Site URL
+ * @return {?Object}       Site object
+ */
+export function getSiteByUrl( state, url ) {
+	const slug = withoutHttp( url ).replace( /\//g, '::' );
+	const site = find( state.sites.items, ( item, siteId ) => {
+		return getSiteSlug( state, siteId ) === slug;
+	} );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return site;
+}
 
 /**
  * Returns a filtered array of WordPress.com site IDs where a Jetpack site
@@ -114,66 +129,6 @@ export function isSiteConflicting( state, siteId ) {
  */
 export function isSingleUserSite( state, siteId ) {
 	return get( getSite( state, siteId ), 'single_user_site', null );
-}
-
-/**
- * Returns true if site is a Jetpack site, false if the site is hosted on
- * WordPress.com, or null if the site is unknown.
- *
- * @param  {Object}   state  Global state tree
- * @param  {Number}   siteId Site ID
- * @return {?Boolean}        Whether site is a Jetpack site
- */
-export function isJetpackSite( state, siteId ) {
-	const site = getRawSite( state, siteId );
-	if ( ! site ) {
-		return null;
-	}
-
-	return site.jetpack;
-}
-
-/**
- * Returns true if the site is a Jetpack site with the specified module active,
- * or false if the module is not active. Returns null if the site is not known
- * or is not a Jetpack site.
- *
- * @param  {Object}   state  Global state tree
- * @param  {Number}   siteId Site ID
- * @param  {String}   slug   Module slug
- * @return {?Boolean}        Whether site has Jetpack module active
- */
-export function isJetpackModuleActive( state, siteId, slug ) {
-	const modules = getSiteOption( state, siteId, 'active_modules' );
-	if ( ! modules ) {
-		return null;
-	}
-
-	return includes( modules, slug );
-}
-
-/**
- * Returns true if the Jetpack site is running a version meeting the specified
- * minimum, or false if the Jetpack site is running an older version. Returns
- * null if the version cannot be determined or if not a Jetpack site.
- *
- * @param  {Object}   state   Global state tree
- * @param  {Number}   siteId  Site ID
- * @param  {String}   version Minimum version
- * @return {?Boolean}         Whether running minimum version
- */
-export function isJetpackMinimumVersion( state, siteId, version ) {
-	const isJetpack = isJetpackSite( state, siteId );
-	if ( ! isJetpack ) {
-		return null;
-	}
-
-	const siteVersion = getSiteOption( state, siteId, 'jetpack_version' );
-	if ( ! siteVersion ) {
-		return null;
-	}
-
-	return versionCompare( siteVersion, version, '>=' );
 }
 
 /**
@@ -283,15 +238,6 @@ export function getSiteOption( state, siteId, optionName ) {
 }
 
 /**
- * Returns true if we are requesting all sites.
- * @param {Object}    state  Global state tree
- * @return {Boolean}        Request State
- */
-export function isRequestingSites( state ) {
-	return !! state.sites.requestingAll;
-}
-
-/**
  * Returns true if a network request is in progress to fetch the specified, or
  * false otherwise.
  *
@@ -393,26 +339,6 @@ export const getSeoTitle = ( state, type, data ) => {
 };
 
 /**
- * Returns a site object by its URL.
- *
- * @param  {Object}  state Global state tree
- * @param  {String}  url   Site URL
- * @return {?Object}       Site object
- */
-export function getSiteByUrl( state, url ) {
-	const slug = withoutHttp( url ).replace( /\//g, '::' );
-	const site = find( state.sites.items, ( item, siteId ) => {
-		return getSiteSlug( state, siteId ) === slug;
-	} );
-
-	if ( ! site ) {
-		return null;
-	}
-
-	return site;
-}
-
-/**
  * Returns a site's theme showcase path.
  *
  * @param  {Object}  state  Global state tree
@@ -436,84 +362,4 @@ export function getSiteThemeShowcasePath( state, siteId ) {
 	return type === 'premium'
 		? `/theme/${ slug }/setup/${ siteSlug }`
 		: `/theme/${ slug }/${ siteSlug }`;
-}
-
-/**
- * Returns a site's plan object by site ID.
- *
- * The difference between this selector and sites/plans/getPlansBySite is that the latter selectors works
- * with the /sites/$site/plans endpoint while the former selectors works with /sites/$site endpoint.
- * Query these endpoints to see if you need the first or the second one.
- *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @return {?Object}        Site's plan object
- */
-export function getSitePlan( state, siteId ) {
-	const site = getRawSite( state, siteId );
-
-	if ( ! site ) {
-		return null;
-	}
-
-	if ( get( site.plan, 'expired', false ) ) {
-		if ( site.jetpack ) {
-			return {
-				product_id: 2002,
-				product_slug: 'jetpack_free',
-				product_name_short: 'Free',
-				free_trial: false,
-				expired: false
-			};
-		}
-
-		return {
-			product_id: 1,
-			product_slug: 'free_plan',
-			product_name_short: 'Free',
-			free_trial: false,
-			expired: false
-		};
-	}
-
-	return site.plan;
-}
-
-/**
- * Returns true if the current site plan is a paid one
- *
- * @param  {Object}   state         Global state tree
- * @param  {Number}   siteId        Site ID
- * @return {?Boolean}               Whether the current plan is paid
- */
-export function isCurrentPlanPaid( state, siteId ) {
-	const sitePlan = getSitePlan( state, siteId );
-
-	if ( ! sitePlan ) {
-		return null;
-	}
-
-	return sitePlan.product_id !== 1 && sitePlan.product_id !== 2002;
-}
-
-/**
- * Returns true if site is currently subscribed to supplied plan and false otherwise.
- *
- * @param  {Object}   state         Global state tree
- * @param  {Number}   siteId        Site ID
- * @param  {Number}   planProductId Plan product_id
- * @return {?Boolean}               Whether site's plan matches supplied plan
- */
-export function isCurrentSitePlan( state, siteId, planProductId ) {
-	if ( planProductId === undefined ) {
-		return null;
-	}
-
-	const sitePlan = getSitePlan( state, siteId );
-
-	if ( ! sitePlan ) {
-		return null;
-	}
-
-	return sitePlan.product_id === planProductId;
 }

--- a/client/state/sites/selectors/sites.js
+++ b/client/state/sites/selectors/sites.js
@@ -1,0 +1,43 @@
+/** @ssr-ready **/
+
+export const getSites = ( state ) => {
+	return state.sites.items;
+};
+
+/**
+ * Returns true if we are requesting all sites.
+ * @param {Object}    state  Global state tree
+ * @return {Boolean}        Request State
+ */
+export function isRequestingSites( state ) {
+	return !! state.sites.requestingAll;
+}
+
+export const getJetpackSites = ( state ) => {
+	return getSites( state ).filter( function( site ) {
+		return site.jetpack;
+	} );
+};
+
+export const getPublicSites = ( state ) => {
+	return getSites( state ).filter( function( site ) {
+		return ! site.is_private;
+	} );
+};
+
+/**
+ * Get sites that are marked as visible
+ *
+ * @api public
+ **/
+export const getVisibleSites = ( state ) => {
+	return getSites( state ).filter( function( site ) {
+		return site.visible === true;
+	} );
+};
+
+export const getUpgradeableSites = ( state ) => {
+	return getSites( state ).filter( function( site ) {
+		return site.is_upgradable;
+	} );
+};


### PR DESCRIPTION
This PR splits `client/state/sites/selectors.js` into multiple files in `client/state/sites/selectors/`.

The idea behind this split is that this file is already quite large and will only get larger as we move sites completely to the redux store.

/cc @aduth @gwwar
