### PR TITLE
Reader: Fix long site name and title

### DIFF
--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -8,7 +8,8 @@
 		margin-bottom: 18px;
 	}
 
-	.gravatar, .site-icon {
+	.gravatar,
+	.site-icon {
 		margin: auto;
 	}
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -94,6 +94,20 @@
 	flex-direction: column;
 	z-index: z-index( '.masterbar', '.reader-profile' );
 
+	@include breakpoint( "<660px" ) {
+		margin-bottom: 35px;
+		overflow: hidden;
+		text-overflow: clip;
+		padding-right: 10px;
+		position: relative;
+		white-space: nowrap;
+
+		&::after {
+			@include long-content-fade( $size: 15% );
+			height: 40px;
+		}
+	}
+
 	.reader-author-link {
 		margin-top: 0;
 
@@ -113,7 +127,7 @@
 			&.has-site-and-author-icon,
 			&.has-site-icon,
 			&.has-gravatar {
-				margin: 0 10px 40px 0;
+				margin: 0 10px 5px 0;
 			}
 
 			&.has-gravatar {
@@ -126,7 +140,7 @@
 			}
 
 			&.has-site-and-author-icon.has-site-icon.has-gravatar {
-				margin-bottom: 20px;
+				margin-bottom: -15px;
 
 				.gravatar {
 					height: 24px!important;
@@ -160,6 +174,12 @@
 		.reader-author-link {
 			font-weight: 700;
 			display: inline;
+			margin-right: 5px;
+
+			&::after {
+				content: ',';
+				font-weight: normal;
+			}
 		}
 
 		.author-compact-profile__site-link {
@@ -173,20 +193,6 @@
 		.reader-author-link,
 		.author-compact-profile__site-link {
 			padding-top: 5px;
-
-			@include breakpoint( "<660px" ) {
-				margin-bottom: 35px;
-				overflow: hidden;
-				text-overflow: clip;
-				padding-right: 10px;
-				position: relative;
-				white-space: nowrap;
-
-				&::after {
-					@include long-content-fade( $size: 15% );
-					height: 40px;
-				}
-			}
 		}
 
 		.author-compact-profile__follow .follow-button {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -121,6 +121,7 @@
 				.gravatar {
 					height: 32px!important;
 					width: 32px!important;
+					max-width: none;
 				}
 			}
 
@@ -159,10 +160,6 @@
 		.reader-author-link {
 			font-weight: 700;
 			display: inline;
-
-			@include breakpoint( "<660px" ) {
-				margin-right: 10px;
-			}
 		}
 
 		.author-compact-profile__site-link {
@@ -179,6 +176,16 @@
 
 			@include breakpoint( "<660px" ) {
 				margin-bottom: 35px;
+				overflow: hidden;
+				text-overflow: clip;
+				padding-right: 10px;
+				position: relative;
+				white-space: nowrap;
+
+				&::after {
+					@include long-content-fade( $size: 15% );
+					height: 40px;
+				}
 			}
 		}
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8096

**Before:**
![screenshot 2016-09-22 11 15 40](https://cloud.githubusercontent.com/assets/4924246/18760443/eb6d1686-80b5-11e6-8721-9c0b8d6a8841.png)

**After:**
![screenshot 2016-09-22 11 22 38](https://cloud.githubusercontent.com/assets/4924246/18760672/e3270094-80b6-11e6-9d32-9e9bdbc2762b.png)

Example: http://calypso.dev:3000/read/blogs/7181346/posts/11570