### PR TITLE
Reader: Fix height of /following/edit sort button

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -90,10 +90,13 @@
 	}
 
 	select {
+		box-sizing: content-box;
 		font-size: 12px;
+		height: 12px;
+		line-height: 12px;
 		color: $gray;
-		padding-top: 2px;
-		padding-bottom: 2px;
+		padding-top: 7px;    // matches .button.is-compact
+		padding-bottom: 7px; // matches .button.is-compact
 		padding-left: 10px;
 		margin: 0;
 


### PR DESCRIPTION
This works by matching the necessary padding and height values against the `.button.is-compact` styles.  Also switches to `box-sizing: content-box` so that we don't have to add the padding and border heights into the `height` value.

Screenshots below are from latest Chrome.  In Safari the current appearance is not as bad - the height looks to be off by 1px or 2px, and the fix works fine there too.

### Before

![image](https://cloud.githubusercontent.com/assets/227022/18767081/13b8eedc-80d2-11e6-84c7-2fc79b6ceedf.png)

### After

![image](https://cloud.githubusercontent.com/assets/227022/18767087/18aa2f0a-80d2-11e6-868d-4c8ae17b80dc.png)

### To test

Go to `/following/edit` and look at dat button.