### PR TITLE
Stats: fix exception in video details and update to es6.

### DIFF
--- a/client/my-sites/stats/stats-video-details/index.jsx
+++ b/client/my-sites/stats/stats-video-details/index.jsx
@@ -1,54 +1,43 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var StatsList = require( '../stats-list' ),
-	StatsListLegend = require( '../stats-list/legend' ),
-	StatsModulePlaceholder = require( '../stats-module/placeholder' ),
-	Card = require( 'components/card' );
+import StatsList from '../stats-list';
+import StatsListLegend from '../stats-list/legend';
+import StatsModulePlaceholder from '../stats-module/placeholder';
+import StatsModuleHeader from '../stats-module/header';
+import Card from 'components/card';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'StatModuleVideoDetails',
 
-	data: function( nextProps ) {
-		var props = nextProps || this.props;
-
-		return props.summaryList.data;
-	},
-
 	render: function() {
-		var classes,
-			isLoading = this.props.summaryList.isLoading();
+		const isLoading = this.props.summaryList.isLoading();
 
-		classes = [
+		const classes = classNames(
 			'stats-module',
 			'is-expanded',
 			'summary',
-			'is-video-details',
 			{
 				'is-loading': isLoading,
-				'is-showing-info': this.state.showInfo,
 				'has-no-data': this.props.summaryList.isEmpty()
 			}
-		];
+		);
 
 		return (
-			<Card className={ classNames.apply( null, classes ) }>
-				<div className="videoplays">
-					<div className="module-header">
-						<h4 className="module-header-title">{ this.translate( 'Video Embeds' ) }</h4>
-					</div>
-					<div className="module-content">
-						<StatsListLegend label={ this.translate( 'Page' ) } />
-						<StatsModulePlaceholder isLoading={ isLoading } />
-						<StatsList moduleName="Video Details" data={ this.props.summaryList.response.pages ? this.props.summaryList.response.pages : [] } />
-					</div>
-				</div>
+			<Card className={ classes }>
+				<StatsModuleHeader title={ this.translate( 'Video Embeds' ) } showActions={ false } />
+				<StatsListLegend label={ this.translate( 'Page' ) } />
+				<StatsModulePlaceholder isLoading={ isLoading } />
+				<StatsList
+					moduleName="Video Details"
+					data={ this.props.summaryList.response.pages ? this.props.summaryList.response.pages : [] }
+				/>
 			</Card>
 		);
 	}


### PR DESCRIPTION
While testing #8142 I encountered an exception when viewing a video details page.  It appears this may have been introduced way back in #4612 :( - so I have fixed the problem here and updated the video details component to ES6.

__To Test__
- Open a site stats page for a site that has video content.  en.blog.wordpress.com works well for this
- Click on a video name in the video stats component
- Validate the video detail page opens and no errors are thrown

/cc @youknowriad for review