### PR TITLE
Janitorial: Set defaultProp of onClose to noop

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -39,8 +39,7 @@ class Popover extends Component {
 		position: PropTypes.string,
 		rootClassName: PropTypes.string,
 		showDelay: PropTypes.number,
-
-		onClose: PropTypes.func.isRequired,
+		onClose: PropTypes.func,
 		onShow: PropTypes.func,
 	};
 
@@ -51,7 +50,7 @@ class Popover extends Component {
 		isVisible: false,
 		position: 'top',
 		showDelay: 0,
-
+		onClose: noop,
 		onShow: noop,
 	}
 


### PR DESCRIPTION
This branch seeks to close out the janitorial issue #2549 - by setting the default prop of `onClose` to `noop`.  To Test, interact with the popover component in devdocs http://calypso.localhost:3000/devdocs/design

/cc @retrofox 