### PR TITLE
Editor: Disable preview button on published non-dirty posts.

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -318,6 +318,7 @@ export default React.createClass( {
 	isPreviewEnabled: function() {
 		return this.props.hasContent &&
 			! ( this.props.isNew && ! this.props.isDirty ) &&
+			! ( postUtils.isPublished( this.props.savedPost ) && ! this.props.isDirty ) &&
 			! this.props.isSaveBlocked;
 	},
 


### PR DESCRIPTION
This branch seeks to close #1804, and/or rekindle discussion on whether or not it should be changed at all.  Currently, the "Preview" button in Editor Ground Control is always enabled on published posts, even when the post is not dirty.

The original report in #1804 is that the button should only be enabled when there are changes to "Preview".  Looking at wp-admin, the Preview button is always enabled as well.

After making this branch and testing things out, I think we should close #1804 as a won't fix but figured I'd open up this PR for other feedback.

Thoughts @aduth?

**To Test**
- Open up a published post in the editor, note the preview button is disabled
- Make changes to the post and the preview button will be re-enabled
