### PR TITLE
Reader: add FeaturedImage component to reader full post view

### DIFF
--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -1,0 +1,33 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+export default class FeaturedImage extends React.Component {
+	constructor() {
+		super();
+		this.state = { src: '' };
+	}
+
+	componentDidMount() {
+		const img = new Image();
+		img.onload = () => this.setState( { src: this.props.src } );
+		img.src = this.props.src;
+	}
+
+	render() {
+		if ( ! this.state.src ) {
+			return null;
+		}
+
+		return (
+			<div className="reader-full-post__featured-image">
+				<img src={ this.state.src } />
+			</div>
+		);
+	}
+}
+
+FeaturedImage.propTypes = {
+	src: React.PropTypes.string
+};

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -51,6 +51,7 @@ import { getStreamUrlFromPost } from 'reader/route';
 import { CANONICAL_IN_CONTENT } from 'state/reader/posts/display-types';
 import { likePost, unlikePost } from 'lib/like-store/actions';
 import LikeStore from 'lib/like-store/like-store';
+import FeaturedImage from 'blocks/reader-full-post/featured-image';
 
 export class FullPostView extends React.Component {
 	constructor( props ) {
@@ -202,9 +203,7 @@ export class FullPostView extends React.Component {
 						<ReaderFullPostHeader post={ post } />
 
 						{ post.featured_image && ( ! ( post.display_type & CANONICAL_IN_CONTENT ) ) &&
-							<div className="reader-full-post__featured-image">
-									<img src={ post.featured_image } />
-							</div>
+							<FeaturedImage src={ post.featured_image } />
 						}
 						{ post.use_excerpt
 							? <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />

--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+
+
+describe( 'FeaturedImage', () => {
+	let React, FeaturedImage, imageStub;
+
+	useFakeDom();
+
+	before( () => {
+		React = require('react');
+		FeaturedImage = require( '../featured-image' );
+		imageStub = {};
+		global.Image = () => imageStub;
+	} );
+
+	after( () => {
+		global.Image = null;
+	} );
+
+	it( 'renders null if the image does not exist', () => {
+		 const nonExistantImage = 'http://sketchy-feed.com/missing-image-2.jpg';
+		 const wrapper = mount( <FeaturedImage src={ nonExistantImage } /> );
+		 assert.isNull( wrapper.html() );
+	} );
+} );


### PR DESCRIPTION
This gracefully handles missing featured images on full post views. It will only render if the image can be found.

before:
![screen shot 2016-09-23 at 4 43 00 pm](https://cloud.githubusercontent.com/assets/744755/18804220/03483a90-81ad-11e6-9ccd-4586cfd56c9b.png)

after:
![screen shot 2016-09-23 at 4 41 43 pm](https://cloud.githubusercontent.com/assets/744755/18804223/08eb4460-81ad-11e6-9250-43498900ea01.png)

**test**

``` npm run test-client client/blocks/reader-full-post```

**note**
I got stumped on trying to test the happy path where the image is found. I kept running into 
```  Invariant Violation: dangerouslyReplaceNodeWithMarkup(...): Cannot render markup in a worker thread. Make sure `window` and `document` are available globally before requiring React when unit testing or use ReactDOMServer.renderToString() for server rendering.```
errors when triggering the `setState` call via `img.onload()`. Any pointers would be appreciated.