### PR TITLE
Add support for Mastercard 2-Series BIN

### DIFF
--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -37,5 +37,43 @@ describe( 'index', function() {
 				assert.equal( null, creditCardDetails.getCreditCardType( '622926' ) );
 			} );
 		} );
+
+		describe( 'Mastercard: range 2221-2720', function () {
+			it( 'should return null for 2220990000000000', function () {
+				assert.equal( null, creditCardDetails.getCreditCardType( '2220990000000000' ) );
+			} );
+
+			it( 'should return `mastercard` for 2221000000000000', function () {
+				assert.equal( 'mastercard', creditCardDetails.getCreditCardType( '2221000000000000' ) );
+			} );
+
+			it( 'should return `mastercard` for 2720990000000000', function () {
+				assert.equal( 'mastercard', creditCardDetails.getCreditCardType( '2720990000000000' ) );
+			} );
+
+			it( 'should return null for 2721000000000000', function () {
+				assert.equal( null, creditCardDetails.getCreditCardType( '2721000000000000' ) );
+			} );
+
+		} );
+
+		describe( 'Mastercard: range 51-55', function () {
+			it( 'should return null for 5099999999999999', function () {
+				assert.equal( null, creditCardDetails.getCreditCardType( '5099999999999999' ) );
+			} );
+
+			it( 'should return `mastercard` for 5100000000000000', function () {
+				assert.equal( 'mastercard', creditCardDetails.getCreditCardType( '5599000000000000' ) );
+			} );
+
+			it( 'should return `mastercard` for 5599000000000000', function () {
+				assert.equal( 'mastercard', creditCardDetails.getCreditCardType( '5599000000000000' ) );
+			} );
+
+			it( 'should return null for 5600000000000000', function () {
+				assert.equal( null, creditCardDetails.getCreditCardType( '5600000000000000' ) );
+			} );
+
+		} );
 	} );
 } );

--- a/client/lib/credit-card-details/test/validation.js
+++ b/client/lib/credit-card-details/test/validation.js
@@ -37,5 +37,17 @@ describe( 'validation', function() {
 				}
 			} );
 		} );
+
+		it( 'should return error when cvv is the wrong length', function() {
+			const invalidCVVCard = { ...validCard, 'cvv': '12345' };
+
+			const result = validateCardDetails( invalidCVVCard );
+
+			expect( result ).to.be.eql( {
+				errors: {
+					'cvv': [ 'Credit card cvv code is invalid' ]
+				}
+			} );
+		} );
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -480,7 +480,7 @@
       "version": "0.2.0"
     },
     "camel-case": {
-      "version": "0.1.0"
+      "version": "1.2.2"
     },
     "camelcase": {
       "version": "1.2.1"
@@ -526,15 +526,7 @@
       }
     },
     "change-case": {
-      "version": "2.3.1",
-      "dependencies": {
-        "camel-case": {
-          "version": "1.2.2"
-        },
-        "sentence-case": {
-          "version": "1.1.3"
-        }
-      }
+      "version": "2.3.1"
     },
     "char-spinner": {
       "version": "1.0.1"
@@ -725,7 +717,10 @@
       "version": "0.2.2"
     },
     "creditcards": {
-      "version": "1.1.1"
+      "version": "2.1.2"
+    },
+    "creditcards-types": {
+      "version": "1.6.0"
     },
     "cross-spawn-async": {
       "version": "2.2.4"
@@ -908,12 +903,7 @@
       "version": "1.5.1"
     },
     "dot-case": {
-      "version": "1.1.2",
-      "dependencies": {
-        "sentence-case": {
-          "version": "1.1.3"
-        }
-      }
+      "version": "1.1.2"
     },
     "draft-js": {
       "version": "0.8.1",
@@ -1230,6 +1220,9 @@
     "expand-range": {
       "version": "1.8.2"
     },
+    "expand-year": {
+      "version": "1.0.0"
+    },
     "exports-loader": {
       "version": "0.6.2"
     },
@@ -1266,6 +1259,9 @@
     },
     "fast-levenshtein": {
       "version": "2.0.5"
+    },
+    "fast-luhn": {
+      "version": "1.0.3"
     },
     "fastparse": {
       "version": "1.1.1"
@@ -1741,6 +1737,9 @@
     "is-glob": {
       "version": "2.0.1"
     },
+    "is-integer": {
+      "version": "1.0.6"
+    },
     "is-lower-case": {
       "version": "1.1.3"
     },
@@ -1817,6 +1816,9 @@
     },
     "is-utf8": {
       "version": "0.2.1"
+    },
+    "is-valid-month": {
+      "version": "1.0.0"
     },
     "isarray": {
       "version": "1.0.0"
@@ -2423,18 +2425,19 @@
       "version": "0.2.9"
     },
     "param-case": {
-      "version": "1.1.2",
-      "dependencies": {
-        "sentence-case": {
-          "version": "1.1.3"
-        }
-      }
+      "version": "1.1.2"
     },
     "parse-glob": {
       "version": "3.0.4"
     },
+    "parse-int": {
+      "version": "1.0.2"
+    },
     "parse-json": {
       "version": "2.2.0"
+    },
+    "parse-year": {
+      "version": "1.0.0"
     },
     "parse5": {
       "version": "1.5.1"
@@ -2452,15 +2455,7 @@
       "version": "1.3.1"
     },
     "pascal-case": {
-      "version": "1.1.2",
-      "dependencies": {
-        "camel-case": {
-          "version": "1.2.2"
-        },
-        "sentence-case": {
-          "version": "1.1.3"
-        }
-      }
+      "version": "1.1.2"
     },
     "path-array": {
       "version": "1.0.1"
@@ -2469,12 +2464,7 @@
       "version": "0.0.0"
     },
     "path-case": {
-      "version": "1.1.2",
-      "dependencies": {
-        "sentence-case": {
-          "version": "1.1.3"
-        }
-      }
+      "version": "1.1.2"
     },
     "path-exists": {
       "version": "1.0.0"
@@ -2969,7 +2959,7 @@
       }
     },
     "sentence-case": {
-      "version": "0.1.2"
+      "version": "1.1.3"
     },
     "serializerr": {
       "version": "1.0.3"
@@ -3045,12 +3035,7 @@
       "version": "0.0.4"
     },
     "snake-case": {
-      "version": "1.1.2",
-      "dependencies": {
-        "sentence-case": {
-          "version": "1.1.3"
-        }
-      }
+      "version": "1.1.2"
     },
     "sntp": {
       "version": "1.0.9"
@@ -3347,12 +3332,7 @@
       "version": "4.3.12"
     },
     "title-case": {
-      "version": "1.1.2",
-      "dependencies": {
-        "sentence-case": {
-          "version": "1.1.3"
-        }
-      }
+      "version": "1.1.2"
     },
     "title-case-minors": {
       "version": "0.0.2"
@@ -3360,14 +3340,25 @@
     "to-array": {
       "version": "0.1.4"
     },
+    "to-camel-case": {
+      "version": "1.0.0"
+    },
     "to-capital-case": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "dependencies": {
+        "to-no-case": {
+          "version": "0.1.1"
+        }
+      }
     },
     "to-fast-properties": {
       "version": "1.0.2"
     },
     "to-no-case": {
-      "version": "0.1.1"
+      "version": "1.0.1"
+    },
+    "to-space-case": {
+      "version": "1.0.0"
     },
     "to-title-case": {
       "version": "0.1.5"
@@ -3690,6 +3681,9 @@
     },
     "yeast": {
       "version": "0.1.2"
+    },
+    "zero-fill": {
+      "version": "2.2.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "component-uid": "0.0.2",
     "cookie": "0.1.2",
     "cookie-parser": "1.3.2",
-    "creditcards": "1.1.1",
+    "creditcards": "2.1.2",
     "debug": "2.2.0",
     "dom-helpers": "2.4.0",
     "dom-scroll-into-view": "1.0.1",


### PR DESCRIPTION
Introduce support for Mastercard's soon to be released 2-Series BIN.  See https://www.mastercard.us/en-us/issuers/get-support/2-series-bin-expansion.html.

The new BIN series introduces the range of 2221 - 2720 as valid numbers for Mastercard.

To test:
`npm run test-client client/lib/credit-card-details`