### PR TITLE
Domains signup: fix "Add" button being truncated for longer translations

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -79,7 +79,7 @@ var MapDomainStep = React.createClass( {
 						rule={ cartItems.getDomainPriceRule( this.props.domainsWithPlansOnly, this.props.selectedSite, this.props.cart, suggestion ) }
 						price={ price } />
 
-					<fieldset>
+					<div className="map-domain-step__add-domain">
 						<input
 							className="map-domain-step__external-domain"
 							type="text"
@@ -95,7 +95,7 @@ var MapDomainStep = React.createClass( {
 								context: 'Upgrades: Label for mapping an existing domain'
 							} ) }
 						</button>
-					</fieldset>
+					</div>
 
 					{ this.domainRegistrationUpsell() }
 				</form>

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -79,7 +79,7 @@ var MapDomainStep = React.createClass( {
 						rule={ cartItems.getDomainPriceRule( this.props.domainsWithPlansOnly, this.props.selectedSite, this.props.cart, suggestion ) }
 						price={ price } />
 
-					<div className="map-domain-step__add-domain">
+					<div className="map-domain-step__add-domain" role="group">
 						<input
 							className="map-domain-step__external-domain"
 							type="text"

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -1,10 +1,6 @@
 .map-domain-step {
 	padding: 0;
 
-	fieldset {
-		clear: left;
-	}
-
 	form.map-domain-step__form {
 		padding: 20px;
 		margin-bottom: 9px;
@@ -43,20 +39,27 @@
 	}
 }
 
-input.map-domain-step__external-domain {
-	@include breakpoint( ">660px" ) {
-		float: left;
-		width: calc( 100% - 90px );
-	}
-}
-
-.map-domain-step__go {
-	margin: 10px 0 0 0;
+.map-domain-step__add-domain {
+	display: flex;
+	flex-flow: column;
 	width: 100%;
 
 	@include breakpoint( ">660px" ) {
-		float: right;
-		margin: 0;
-		width: 80px;
+		flex-flow: row;
+	}
+}
+
+input.map-domain-step__external-domain {
+	flex-grow: 1;
+	width: auto;
+}
+
+.map-domain-step__go {
+	flex-grow: 1;
+	margin: 10px 0 0 0;
+
+	@include breakpoint( ">660px" ) {
+		flex-grow: 0;
+		margin: 0 0 0 10px;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/2412.

Replaced the `<fieldset>` with a simple `<div>` to allow the use of `flexbox` for the "Enter domain" / "Add" form.

Before | After
------------ | -------------
![domains-signup-before](https://cloud.githubusercontent.com/assets/2070010/18814881/032b56b8-8320-11e6-992b-e719c90c9409.png) | ![domains-signup-after](https://cloud.githubusercontent.com/assets/2070010/18814880/fce6d4bc-831f-11e6-9cd3-b56460c833e5.png)

Tested also on Internet Explorer 11 and Edge.

--- 
Apparently, browsers don't render fieldsets as normal elements, so the `display` rule doesn't always behave as expected.
See:
https://bugzilla.mozilla.org/show_bug.cgi?id=292736
https://bugs.chromium.org/p/chromium/issues/detail?id=262679