### PR TITLE
Image editor: fix cancel using esc button shouldn't close the "whole"…

### DIFF
--- a/client/post-editor/media-modal/image-editor/index.jsx
+++ b/client/post-editor/media-modal/image-editor/index.jsx
@@ -16,6 +16,7 @@ import EditToolbar from './image-editor-toolbar';
 import EditButtons from './image-editor-buttons';
 import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
+import closeOnEsc from 'lib/mixins/close-on-esc';
 import {
 	resetImageEditorState,
 	setImageEditorFileInfo
@@ -25,6 +26,8 @@ import {
 } from 'state/ui/editor/image-editor/selectors';
 
 const MediaModalImageEditor = React.createClass( {
+	mixins: [ closeOnEsc( '_close' ) ],
+
 	displayName: 'MediaModalImageEditor',
 
 	propTypes: {
@@ -167,6 +170,12 @@ const MediaModalImageEditor = React.createClass( {
 				</figure>
 			</div>
 		);
+	},
+
+	_close: function() {
+		if ( this.props.onImageEditorCancel ) {
+			this.props.onImageEditorCancel();
+		}
 	}
 } );
 


### PR DESCRIPTION
Took the idea from [this code](https://github.com/Automattic/wp-calypso/blob/master/client/components/dialog/dialog-base.jsx#L19)

@retrofox  please help to review it 😄 

Closes #8084 