### PR TITLE
SiteSelector: pass siteId when a site is selected

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -70,9 +70,9 @@ const SiteSelector = React.createClass( {
 		this.setState( { search: terms } );
 	},
 
-	onSiteSelect( siteSlug, event ) {
+	onSiteSelect( siteSlug, siteId, event ) {
 		this.closeSelector();
-		const handledByHost = this.props.onSiteSelect( siteSlug );
+		const handledByHost = this.props.onSiteSelect( siteSlug, siteId );
 		this.props.onClose( event );
 
 		let node = ReactDom.findDOMNode( this.refs.selector );
@@ -185,7 +185,7 @@ const SiteSelector = React.createClass( {
 					href={ this.props.siteBasePath ? siteHref : null }
 					key={ 'site-' + site.ID }
 					indicator={ this.props.indicator }
-					onSelect={ this.onSiteSelect.bind( this, site.slug ) }
+					onSelect={ this.onSiteSelect.bind( this, site.slug, site.ID ) }
 					isSelected={ isSelected }
 				/>
 			);
@@ -254,7 +254,7 @@ const SiteSelector = React.createClass( {
 							href={ siteHref }
 							key={ 'site-' + site.ID }
 							indicator={ this.props.indicator }
-							onSelect={ this.onSiteSelect.bind( this, site.slug ) }
+							onSelect={ this.onSiteSelect.bind( this, site.slug, site.ID ) }
 							isSelected={ this.isSelected( site ) }
 						/>
 					);

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -55,8 +55,8 @@ export default React.createClass( {
 		return sites.getSite( this.state.selected );
 	},
 
-	selectSite( siteSlug ) {
-		this.props.onSiteSelect( siteSlug );
+	selectSite( siteSlug, siteId ) {
+		this.props.onSiteSelect( siteSlug, siteId );
 		this.setState( {
 			selected: siteSlug,
 			open: false


### PR DESCRIPTION
In this PR I've changed the code to pass the `siteId` when a site is selected in the `<SiteSelector />` component. Also, I've propagated this behaviour to `<SitesDropdown />` as well.
So now if you need to know the siteId, beyond to know the site slug, you can get it in the second parameter of the function.

``` es6

import SiteSelector form 'components/site-selector';

class MyClass extends Component {

  // ...

  setSiteId( siteSlug, siteId ) {
    this.setState( { siteId } );
  }

  render() {
    <SiteSelector onSelecSite={ this.setSiteId } />
  }
}
```
