### PR TITLE
Plans: Close plansDescriptions test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -51,17 +51,6 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
-	plansDescriptions: {
-		datestamp: '20160826',
-		variations: {
-			ascendingPriceSubtleDescription: 25,
-			ascendingPriceEagerDescription: 25,
-			descendingPriceSubtleDescription: 25,
-			descendingPriceEagerDescription: 25
-		},
-		defaultVariation: 'ascendingPriceSubtleDescription',
-		allowExistingUsers: false,
-	},
 	signupStore: {
 		datestamp: '20160727',
 		variations: {

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -7,7 +7,6 @@ import React from 'react';
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
-import { abtest } from 'lib/abtest';
 
 export default function PlanFeaturesItem( {
 	children,
@@ -28,25 +27,15 @@ export default function PlanFeaturesItem( {
 		onMouseLeave( event.currentTarget, description );
 	};
 
-	const mouseEvents = {
-		onMouseEnter: handleOnMouseEvent,
-		onMouseLeave: handleOnMouseLeave
-	};
-	const hoverOnRow = (
-		abtest( 'plansDescriptions' ) === 'ascendingPriceEagerDescription' ||
-		abtest( 'plansDescriptions' ) === 'descendingPriceEagerDescription'
-	);
-
 	return (
-		<div className="plan-features__item"
-			{ ...( hoverOnRow && mouseEvents ) }
-		>
+		<div className="plan-features__item">
 			<Gridicon
 				className="plan-features__item-checkmark"
 				size={ 18 } icon="checkmark" />
 			{ children }
 			<span
-				{ ...( ! hoverOnRow && mouseEvents ) }
+				onMouseEnter={ handleOnMouseEvent }
+				onMouseLeave={ handleOnMouseLeave }
 				onTouchStart={ handleOnTouchStart }
 				className="plan-features__item-tip-info"
 			>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -23,7 +23,6 @@ import {
 import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 import { isEnabled } from 'config';
-import { abtest } from 'lib/abtest';
 
 class PlansFeaturesMain extends Component {
 
@@ -84,31 +83,15 @@ class PlansFeaturesMain extends Component {
 			);
 		}
 
-		let plans;
-		if (
-			abtest( 'plansDescriptions' ) === 'descendingPriceSubtleDescription' ||
-			abtest( 'plansDescriptions' ) === 'descendingPriceEagerDescription'
-		) {
-			plans = filter(
-				[
-					PLAN_BUSINESS,
-					PLAN_PREMIUM,
-					isPersonalPlanEnabled ? PLAN_PERSONAL : null,
-					hideFreePlan ? null : PLAN_FREE,
-				],
-				value => !! value
-			);
-		} else {
-			plans = filter(
-				[
-					hideFreePlan ? null : PLAN_FREE,
-					isPersonalPlanEnabled ? PLAN_PERSONAL : null,
-					PLAN_PREMIUM,
-					PLAN_BUSINESS
-				],
-				value => !! value
-			);
-		}
+		const plans = filter(
+			[
+				hideFreePlan ? null : PLAN_FREE,
+				isPersonalPlanEnabled ? PLAN_PERSONAL : null,
+				PLAN_PREMIUM,
+				PLAN_BUSINESS
+			],
+			value => !! value
+		);
 
 		return (
 			<div className="plans-features-main__group">


### PR DESCRIPTION
Closes test introduced in #7463. This test had 2 changes:
- Highlighted business plan by presenting plans in descending price order on /plans
- Presented plans descriptions on hover

None of these changes proved to be beneficial, se we're reverting all the plan changes.
This reverts commit 70b90470810a97ac1ebdc1730ddbd41fbe4d472a.

Prepared test results: tritonp2-draft-13891

# Testing
- Open /plans
- See that plans are sorted in ascending price order
- See that descriptions dont open when you hover a row
- See that `plansDescriptions` test is not there any more
- Repeat in NUX

CC @rralian @lamosty @meremagee @gwwar 