### PR TITLE
DevDocs: Fixed links on various components on the Blocks page

### DIFF
--- a/client/blocks/comment-button/docs/example.jsx
+++ b/client/blocks/comment-button/docs/example.jsx
@@ -10,7 +10,7 @@ import CommentButton from 'blocks/comment-button';
 import Card from 'components/card';
 
 export default React.createClass( {
-	displayName: 'CommentButtonExample',
+	displayName: 'CommentButton',
 
 	render() {
 		return(

--- a/client/blocks/post-edit-button/docs/example.jsx
+++ b/client/blocks/post-edit-button/docs/example.jsx
@@ -21,7 +21,7 @@ export default React.createClass( {
 		return (
 			<div className="design-assets__group">
 				<h2>
-					<a href="/devdocs/design/edit-button">Post Edit Button</a>
+					<a href="/devdocs/blocks/post-edit-button">Post Edit Button</a>
 				</h2>
 				<PostEditButton post={ post } site={ site } />
 			</div>

--- a/client/blocks/reader-related-card-v2/docs/example.jsx
+++ b/client/blocks/reader-related-card-v2/docs/example.jsx
@@ -55,13 +55,13 @@ const smallItems = [
 ];
 
 const RelatedPostCards = React.createClass( {
-	displayName: 'RelatedPostCardv2',
+	displayName: 'ReaderRelatedCardV2',
 
 	render: function() {
 		return (
 			<div className="design-assets__group">
 				<h2>
-					<a href="/devdocs/blocks/post-card">More in Site</a>
+					<a href="/devdocs/blocks/reader-related-card-v2">More in Site</a>
 				</h2>
 				<div className="reader-related-card-v2__container">
 					<h1 className="reader-related-card-v2__heading">More in <a href="#" className="reader-related-card-v2__link">Cats and Cats</a></h1>
@@ -71,7 +71,7 @@ const RelatedPostCards = React.createClass( {
 				</div>
 
 				<h2>
-					<a href="/devdocs/blocks/post-card">More in WordPress.com</a>
+					<a href="/devdocs/blocks/reader-related-card-v2">More in WordPress.com</a>
 				</h2>
 				<div className="reader-related-card-v2__container">
 					<h1 className="reader-related-card-v2__heading">More in <a href="#" className="reader-related-card-v2__link">WordPress.com</a></h1>

--- a/client/blocks/reader-related-card/docs/example.jsx
+++ b/client/blocks/reader-related-card/docs/example.jsx
@@ -84,13 +84,13 @@ const smallItems = [
 ];
 
 const RelatedPostCards = React.createClass( {
-	displayName: 'RelatedPostCard',
+	displayName: 'ReaderRelatedCard',
 
 	render: function() {
 		return (
 			<div className="design-assets__group">
 				<h2>
-					<a href="/devdocs/blocks/post-card">Related Post Cards</a>
+					<a href="/devdocs/blocks/reader-related-card">Related Post Cards</a>
 				</h2>
 				<div>
 					{ smallItems.map( item => <RelatedPostCard key={ item.post.global_ID } post={ item.post } site={ item.site } /> ) }

--- a/client/blocks/reader-search-card/docs/example.jsx
+++ b/client/blocks/reader-search-card/docs/example.jsx
@@ -80,13 +80,13 @@ const searchItems = [
 ];
 
 const SearchCards = React.createClass( {
-	displayName: 'SearchCard',
+	displayName: 'ReaderSearchCard',
 
 	render: function() {
 		return (
 			<div className="design-assets__group">
 				<h2>
-					<a href="/devdocs/blocks/post-card">Search Cards</a>
+					<a href="/devdocs/blocks/reader-search-card">Search Cards</a>
 				</h2>
 
 				<div>


### PR DESCRIPTION
Several components on the Blocks page had bad links and/or displayName settings that prevented them from loading individually when clicking on the header link.  I'm reworking that section of the visual diff tests to use that feature, so this PR fixes it.

Components:
* Comment Button
* Post Edit Button
* Related Post Cards
* More in Site / WordPress.com (related post cards v2)
* Search Cards