### PR TITLE
Advanced SEO: Fix polyfill loading for draft-js

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -97,8 +97,13 @@ const {
 	SelectionState,
 } = require( 'draft-js' );
 
+// Parser also requires draft-js. Lets load it after the polyfills are created too.
+const {
+	fromEditor,
+	toEditor,
+} = require( './parser' );
+
 import Token from './token';
-import { fromEditor, toEditor } from './parser';
 import { buildSeoTitle } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { localize } from 'i18n-calypso';


### PR DESCRIPTION
Closes #8052

The draft-js polyfills were created after draft-js was loaded,
resulting in errors on IE 11. Since `parser.js` imports `draft-js` too,
we need to load it after the polyfills are created.