### PR TITLE
Editor: Resolve unresponsive editor when "Meta" category assigned

### DIFF
--- a/client/post-editor/editor-categories-tags/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/accordion.jsx
@@ -92,19 +92,23 @@ export class EditorCategoriesTagsAccordion extends Component {
 	getCategoriesSubtitle() {
 		const { translate, postTerms, defaultCategory } = this.props;
 		const categories = toArray( get( postTerms, 'category' ) );
-		const categoriesCount = categories.length;
 
-		switch ( categoriesCount ) {
-			case 0:
-				return defaultCategory ? defaultCategory.name : null;
-			case 1:
-				return unescapeString( categories[ 0 ].name );
-			default:
-				return translate(
-					'%d category',
-					'%d categories',
-					{ args: [ categoriesCount ], count: categoriesCount }
-				);
+		if ( categories.length > 1 ) {
+			return translate( '%d category', '%d categories', {
+				args: [ categories.length ],
+				count: categories.length
+			} );
+		}
+
+		let category;
+		if ( categories.length > 0 ) {
+			category = categories[ 0 ];
+		} else {
+			category = defaultCategory;
+		}
+
+		if ( category ) {
+			return unescapeString( category.name );
 		}
 	}
 

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -266,8 +266,7 @@ describe( 'reducer', () => {
 				ID: 841,
 				site_ID: 2916284,
 				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-				title: 'Hello World',
-				meta: null
+				title: 'Hello World'
 			} ] );
 		} );
 

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -91,8 +91,9 @@ describe( 'utils', () => {
 				meta: {},
 				terms: {
 					category: {
-						Code: {
-							ID: 6,
+						meta: {
+							ID: 171,
+							name: 'Meta',
 							meta: {}
 						}
 					}
@@ -103,12 +104,11 @@ describe( 'utils', () => {
 			expect( revised ).to.not.equal( original );
 			expect( revised ).to.eql( {
 				ID: 814,
-				meta: null,
 				terms: {
 					category: {
-						Code: {
-							ID: 6,
-							meta: null
+						meta: {
+							ID: 171,
+							name: 'Meta'
 						}
 					}
 				}

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -93,9 +93,36 @@ describe( 'utils', () => {
 					category: {
 						meta: {
 							ID: 171,
-							name: 'Meta',
+							name: 'meta',
 							meta: {}
 						}
+					},
+					post_tag: {
+						meta: {
+							ID: 171,
+							name: 'meta',
+							meta: {}
+						}
+					}
+				},
+				categories: {
+					meta: {
+						ID: 171,
+						name: 'meta',
+						meta: {}
+					}
+				},
+				tags: {
+					meta: {
+						ID: 171,
+						name: 'meta',
+						meta: {}
+					}
+				},
+				attachments: {
+					14209: {
+						ID: 14209,
+						meta: {}
 					}
 				}
 			} );
@@ -108,8 +135,31 @@ describe( 'utils', () => {
 					category: {
 						meta: {
 							ID: 171,
-							name: 'Meta'
+							name: 'meta'
 						}
+					},
+					post_tag: {
+						meta: {
+							ID: 171,
+							name: 'meta'
+						}
+					}
+				},
+				categories: {
+					meta: {
+						ID: 171,
+						name: 'meta'
+					}
+				},
+				tags: {
+					meta: {
+						ID: 171,
+						name: 'meta'
+					}
+				},
+				attachments: {
+					14209: {
+						ID: 14209
 					}
 				}
 			} );

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -13,11 +13,11 @@ import {
 	reduce,
 	toArray,
 	cloneDeep,
-	cloneDeepWith,
 	pickBy,
 	isString,
 	every
 } from 'lodash';
+import { dissocPath } from 'lodash/fp';
 
 /**
  * Internal dependencies
@@ -166,11 +166,15 @@ export function normalizePostForEditing( post ) {
  * @return {Object}      Normalized post object
  */
 export function normalizePostForState( post ) {
-	return cloneDeepWith( post, ( value, key ) => {
-		if ( 'meta' === key ) {
-			return null;
-		}
-	} );
+	return reduce( [
+		[],
+		...reduce( post.terms, ( memo, terms, taxonomy ) => (
+			memo.concat( map( terms, ( term, slug ) => [ 'terms', taxonomy, slug ] ) )
+		), [] ),
+		...map( post.categories, ( category, slug ) => [ 'category', slug ] ),
+		...map( post.tags, ( tag, slug ) => [ 'tags', slug ] ),
+		...map( post.attachments, ( attachment, id ) => [ 'attachments', id ] )
+	], ( memo, path ) => dissocPath( path.concat( 'meta' ), memo ), post );
 }
 
 /**

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -171,7 +171,7 @@ export function normalizePostForState( post ) {
 		...reduce( post.terms, ( memo, terms, taxonomy ) => (
 			memo.concat( map( terms, ( term, slug ) => [ 'terms', taxonomy, slug ] ) )
 		), [] ),
-		...map( post.categories, ( category, slug ) => [ 'category', slug ] ),
+		...map( post.categories, ( category, slug ) => [ 'categories', slug ] ),
 		...map( post.tags, ( tag, slug ) => [ 'tags', slug ] ),
 		...map( post.attachments, ( attachment, id ) => [ 'attachments', id ] )
 	], ( memo, path ) => dissocPath( path.concat( 'meta' ), memo ), post );


### PR DESCRIPTION
Regression introduced in #7141 (e0d4fd5bb590c994b026bba9803c772d8b30470d)

This pull request seeks to resolve an issue where the post editor becomes unresponsive if a category named "Meta" exists for a site and is assigned to the post. The issue exists because in #7141, logic was introduced to blindly unset all properties of a post object with a key of "meta". The structure of a post object response is such that the `post.categories` and `post.terms.category` values are objects where each key is the slug of a term. If a "Meta" (`meta` slug) category exists, it would be unset, and the accordion would try to access its `name` property.

__Implementation notes:__

Two changes are included:

- Ensure that the accordion doesn't attempt to access the `name` property on an empty value (fed993a)
- Still include meta unsetting logic, but explicitly target the terms, categories, tags, and attachments to unset

__Open questions:__

The unsetting logic was included originally to reduce the size of state being stored. Because the logic has become increasingly complex (and apparently error-prone), we might consider whether it's worthwhile to include.

__Testing instructions:__

Repeat testing instructions from #7247, verifying that accordion continues to behave as expected, including when a "Meta" category exists and is assigned to a post.

cc @timmyc , @ashercantrell , @samjhamdy , @codebykat 
Ref: p47NkD-Ad-p2