### PR TITLE
Site state: add jetpack selectors

### DIFF
--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -28,7 +28,7 @@ import {
 	isCurrentSitePlan,
 	isCurrentPlanPaid,
 	siteHasMinimumJetpackVersion,
-	isMainNetworkSite
+	isMainNetworkSite,
 } from '../selectors';
 
 /**
@@ -1074,7 +1074,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#siteHasMinimumJetpackVersion()', () => {
-		it( 'it should return null for a non-existing site', () => {
+		it( 'it should return `null` for a non-existing site', () => {
 			const state = {
 				sites: {
 					items: {}
@@ -1086,7 +1086,7 @@ describe( 'selectors', () => {
 			expect( hasMinimumVersion ).to.equal( null );
 		} );
 
-		it( 'it should return null for a non jetpack site', () => {
+		it( 'it should return `null` for a non jetpack site', () => {
 			const siteId = 77203074;
 
 			const state = {
@@ -1104,7 +1104,7 @@ describe( 'selectors', () => {
 			expect( hasMinimumVersion ).to.equal( null );
 		} );
 
-		it( 'it should return true if jetpack version is greater that minimum version', () => {
+		it( 'it should return `true` if jetpack version is greater that minimum version', () => {
 			const jetpackMinVersion = config( 'jetpack_min_version' );
 			const greaterVersion = changeVersion( jetpackMinVersion );
 			const siteId = 77203074;
@@ -1127,7 +1127,7 @@ describe( 'selectors', () => {
 			expect( hasMinimumVersion ).to.equal( true );
 		} );
 
-		it( 'it should return true if jetpack version is equal to minimum version', () => {
+		it( 'it should return `true` if jetpack version is equal to minimum version', () => {
 			const jetpackMinVersion = config( 'jetpack_min_version' );
 			const greaterVersion = jetpackMinVersion;
 			const siteId = 77203074;
@@ -1150,7 +1150,7 @@ describe( 'selectors', () => {
 			expect( hasMinimumVersion ).to.equal( true );
 		} );
 
-		it( 'it should return false if jetpack version is smaller than minimum version', () => {
+		it( 'it should return `false` if jetpack version is smaller than minimum version', () => {
 			const jetpackMinVersion = config( 'jetpack_min_version' );
 			const smallerVersion = changeVersion( jetpackMinVersion, -1 );
 			const siteId = 77203074;
@@ -1171,6 +1171,125 @@ describe( 'selectors', () => {
 
 			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
 			expect( hasMinimumVersion ).to.equal( false );
+		} );
+	} );
+
+	describe( '#isMainNetworkSite()', () => {
+		it( 'should return `null` for a non-existing site', () => {
+			const state = {
+				sites: {
+					items: {}
+				}
+			};
+			let siteId;
+
+			const isMainNetwork = isMainNetworkSite( state, siteId );
+			expect( isMainNetwork ).to.equal( null );
+		} );
+
+		it( 'it should return `false` for multi-network sites', () => {
+			const siteId = 77203074;
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							URL: 'https://jetpacksite.me',
+							options: {
+								is_multi_network: true
+							}
+						}
+					}
+				}
+			};
+
+			const isMainNetwork = isMainNetworkSite( state, siteId );
+			expect( isMainNetwork ).to.equal( false );
+		} );
+
+		it( 'it should return `true` for non multisite site', () => {
+			const siteId = 77203074;
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							URL: 'https://jetpacksite.me',
+							is_multisite: false,
+						}
+					}
+				}
+			};
+
+			const isMainNetwork = isMainNetworkSite( state, siteId );
+			expect( isMainNetwork ).to.equal( true );
+		} );
+
+		it( 'it should return `false` for multisite sites without unmapped url', () => {
+			const siteId = 77203074;
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							URL: 'https://jetpacksite.me',
+							is_multisite: true,
+							options: {
+								is_multi_network: false,
+								main_network_site: 'https://example.wordpress.com'
+							}
+						}
+					}
+				}
+			};
+
+			const isMainNetwork = isMainNetworkSite( state, siteId );
+			expect( isMainNetwork ).to.equal( false );
+		} );
+
+		it( 'it should return `false` for multisite sites without main_network_site', () => {
+			const siteId = 77203074;
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							URL: 'https://jetpacksite.me',
+							is_multisite: true,
+							options: {
+								is_multi_network: false,
+								unmapped_url: 'https://example.wordpress.com'
+							}
+						}
+					}
+				}
+			};
+
+			const isMainNetwork = isMainNetworkSite( state, siteId );
+			expect( isMainNetwork ).to.equal( false );
+		} );
+
+		it( 'it should return `true` for multisite sites and unmapped_url matches with main_network_site', () => {
+			const siteId = 77203074;
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							URL: 'https://jetpacksite.me',
+							is_multisite: true,
+							options: {
+								is_multi_network: false,
+								unmapped_url: 'https://example.wordpress.com',
+								main_network_site: 'https://example.wordpress.com'
+							}
+						}
+					}
+				}
+			};
+
+			const isMainNetwork = isMainNetworkSite( state, siteId );
+			expect( isMainNetwork ).to.equal( true );
 		} );
 	} );
 } );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -26,8 +26,33 @@ import {
 	getSiteByUrl,
 	getSitePlan,
 	isCurrentSitePlan,
-	isCurrentPlanPaid
+	isCurrentPlanPaid,
+	siteHasMinimumJetpackVersion,
+	isMainNetworkSite
 } from '../selectors';
+
+/**
+ * Simple util function to increase/decrease a version with `x.x.x` format
+ * @param  {String} version - version reference
+ * @param  {Number} operator - increase/decrease given version
+ * @return {String} new version string
+ */
+function changeVersion( version, operator = 1 ) {
+	const splitVersion = version.split( '.' );
+
+	if ( operator >= 1 ) {
+		splitVersion[ splitVersion.length - 1 ]++;
+		return splitVersion.join( '.' );
+	}
+
+	if ( splitVersion[ splitVersion.length - 1 ] === '0' ) {
+		splitVersion[ splitVersion.length - 2 ]--;
+	} else {
+		splitVersion[ splitVersion.length - 1 ]--;
+	}
+
+	return splitVersion.join( '.' );
+}
 
 describe( 'selectors', () => {
 	beforeEach( () => {
@@ -1045,6 +1070,107 @@ describe( 'selectors', () => {
 			}, 77203074, 1003 );
 
 			expect( showcasePath ).to.eql( '/theme/journalistic/setup/testonesite2014.wordpress.com' );
+		} );
+	} );
+
+	describe( '#siteHasMinimumJetpackVersion()', () => {
+		it( 'it should return null for a non-existing site', () => {
+			const state = {
+				sites: {
+					items: {}
+				}
+			};
+			let siteId;
+
+			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
+			expect( hasMinimumVersion ).to.equal( null );
+		} );
+
+		it( 'it should return null for a non jetpack site', () => {
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: false,
+						}
+					}
+				}
+			};
+
+			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
+			expect( hasMinimumVersion ).to.equal( null );
+		} );
+
+		it( 'it should return true if jetpack version is greater that minimum version', () => {
+			const jetpackMinVersion = config( 'jetpack_min_version' );
+			const greaterVersion = changeVersion( jetpackMinVersion );
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: true,
+							options: {
+								jetpack_version: greaterVersion
+							}
+						}
+					}
+				}
+			};
+
+			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
+			expect( hasMinimumVersion ).to.equal( true );
+		} );
+
+		it( 'it should return true if jetpack version is equal to minimum version', () => {
+			const jetpackMinVersion = config( 'jetpack_min_version' );
+			const greaterVersion = jetpackMinVersion;
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: true,
+							options: {
+								jetpack_version: greaterVersion
+							}
+						}
+					}
+				}
+			};
+
+			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
+			expect( hasMinimumVersion ).to.equal( true );
+		} );
+
+		it( 'it should return false if jetpack version is smaller than minimum version', () => {
+			const jetpackMinVersion = config( 'jetpack_min_version' );
+			const smallerVersion = changeVersion( jetpackMinVersion, -1 );
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: true,
+							options: {
+								jetpack_version: smallerVersion
+							}
+						}
+					}
+				}
+			};
+
+			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
+			expect( hasMinimumVersion ).to.equal( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR add some selectors to get data from `state.site` subtree. These selectors have been written bassed on libs that we already have into `client/lib/site/utils.js` and `client/lib/site/jetpack.js`.

Selector | util function
------------ | -------------
[siteCanUpdateFiles()](https://github.com/Automattic/wp-calypso/blob/fe83917c5ddfcdc45e593fc6546d2aa7f39d4e1d/client/state/sites/selectors.js#L522) | site/utils.js - [canUploadFiles()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/utils.js#L97)
[isMainNetworkSite](https://github.com/Automattic/wp-calypso/blob/fe83917c5ddfcdc45e593fc6546d2aa7f39d4e1d/client/state/sites/selectors.js#L560) | site/utils.js - [isMainNetworkSite()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/utils.js#L148)
[siteHasMinimumJetpackVersion](https://github.com/Automattic/wp-calypso/blob/fe83917c5ddfcdc45e593fc6546d2aa7f39d4e1d/client/state/sites/selectors.js#L599) | site/jetpack.js - [hasMinimumJetpackVersion](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/jetpack.js#L33)

### Testing

The best way to test these functions is running the tests paying attention to each of them since some cases has several different options to check.

You could run a specific test through of the using of --grep parameter, thus:

```cli
> npm run test-client client/state/sites/test/selectors.js -- --grep 'siteCanUpdateFiles'
```

```cli
> npm run test-client client/state/sites/test/selectors.js -- --grep 'isMainNetworkSite'
```
```cli
> npm run test-client client/state/sites/test/selectors.js -- --grep 'siteHasMinimumJetpackVersion'
```

<img src="https://cloud.githubusercontent.com/assets/77539/18841677/79b9eb12-83e0-11e6-82b4-cc4d27e7fceb.png" width="600px" />

cc @enej @johnHackworth 
