### PR TITLE
Add what will happen to my content after upgrade FAQ

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -209,7 +209,13 @@ class PlansFeaturesMain extends Component {
 						' domains purchased through WordPress.com or your own existing domain that you can map' +
 						' to your WordPress.com site. {{a}}Find out more about domains.{{/a}}',
 						{
-							components: { a: <a href="https://en.support.wordpress.com/all-about-domains/" target="_blank" rel="noopener noreferrer" /> }
+							components: {
+								a: <a
+									href="https://en.support.wordpress.com/all-about-domains/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							}
 						}
 					) }
 				/>
@@ -256,7 +262,13 @@ class PlansFeaturesMain extends Component {
 						' add Google apps for work. You can also set up email forwarding for any custom domain' +
 						' registered through WordPress.com. {{a}}Find out more about email{{/a}}.',
 						{
-							components: { a: <a href="https://en.support.wordpress.com/add-email/" target="_blank" rel="noopener noreferrer" /> }
+							components: {
+								a: <a
+									href="https://en.support.wordpress.com/add-email/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							}
 						}
 					) }
 				/>
@@ -269,8 +281,23 @@ class PlansFeaturesMain extends Component {
 						' more precise control of your site’s' +
 						' design. {{a}}Find out more about custom design{{/a}}.',
 						{
-							components: { a: <a href="https://en.support.wordpress.com/custom-design/" target="_blank" rel="noopener noreferrer" /> }
+							components: {
+								a: <a
+									href="https://en.support.wordpress.com/custom-design/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							}
 						}
+					) }
+				/>
+
+				<FAQItem
+					question={ translate( 'Will upgrading affect my content?' ) }
+					answer={ translate(
+						'Plans add extra features to your site, but they do not affect the content of your site' +
+						" or your site's followers. You will never lose content by upgrading or downgrading" +
+						" your site's plan."
 					) }
 				/>
 


### PR DESCRIPTION
Fixes #7912. Adds a new FAQ item to `/plans/:siteId` about what will happen to user's content after upgrading to a new plan.

## Testing

1. Navigate to `/plans/:siteId` and scroll down to FAQ section;
2. Verify that the new FAQ item is there and has the same content as in the #7912 issue.

## Screenshot

![selection_020](https://cloud.githubusercontent.com/assets/4988512/18843671/50d111c8-841a-11e6-937c-b7359339ada0.jpg)

## Questions

1. Do we want this FAQ item to be the first one?
2. The FAQ item is quite lengthy and breaks the design a bit. Is it okay?

Props @adambbecker, @KokkieH and @rralian for the content.

/cc @gwwar @adambbecker 