### PR TITLE
Reader: add FeaturedAsset component to reader stream

### DIFF
--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -35,13 +35,15 @@ export default class FeaturedAsset extends React.Component {
 
 		return (
 			<div
-				className="reader-full-post__featured-image"
-				onClick={ this.props.onClick } >
-				<img className="reader__post-featured-image-image"
-					ref="featuredImage"
-					src={ this.state.featuredImage }
-					style={ this.props.featuredSize }
-				/>
+				className="reader-full-post__featured-image" >
+				{ this.state.featuredImage
+				? <img className="reader__post-featured-image-image"
+						ref="featuredImage"
+						src={ this.state.featuredImage }
+						style={ this.props.featuredSize }
+					/>
+				: null
+				}
 			</div>
 		);
 	}

--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -12,7 +12,7 @@ export default class FeaturedAsset extends React.Component {
 		};
 	}
 
-	componentDidMount() {
+	_loadImage() {
 		if ( this.props.featuredImage ) {
 			const img = new Image();
 			img.onload = () => this.setState( { featuredImage: this.props.featuredImage } );
@@ -21,6 +21,21 @@ export default class FeaturedAsset extends React.Component {
 			img.onerror = () => this.setState( { useFeaturedEmbed: this.props.featuredEmbed } );
 			img.src = this.props.featuredImage;
 		}
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.setState( {
+			featuredImage: '',
+			useFeaturedEmbed: nextProps.useFeaturedEmbed
+		} );
+	}
+
+	componentDidMount() {
+		this._loadImage();
+	}
+
+	componentDidUpdate() {
+		this._loadImage();
 	}
 
 	render() {

--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -1,0 +1,55 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+export default class FeaturedAsset extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			featuredImage: '',
+			useFeaturedEmbed: props.useFeaturedEmbed
+		};
+	}
+
+	componentDidMount() {
+		if ( this.props.featuredImage ) {
+			const img = new Image();
+			img.onload = () => this.setState( { featuredImage: this.props.featuredImage } );
+
+			// use featured embed if featured image is not available
+			img.onerror = () => this.setState( { useFeaturedEmbed: this.props.featuredEmbed } );
+			img.src = this.props.featuredImage;
+		}
+	}
+
+	render() {
+		if ( this.state.useFeaturedEmbed ) {
+			return (
+				<div ref="featuredEmbed"
+					className="reader__post-featured-video"
+					key="featuredVideo"
+					dangerouslySetInnerHTML={ { __html: this.props.featuredEmbed.iframe } } />   //eslint-disable-line react/no-danger
+			);
+		}
+
+		return (
+			<div
+				className="reader-full-post__featured-image"
+				onClick={ this.props.onClick } >
+				<img className="reader__post-featured-image-image"
+					ref="featuredImage"
+					src={ this.state.featuredImage }
+					style={ this.props.featuredSize }
+				/>
+			</div>
+		);
+	}
+}
+
+FeaturedAsset.propTypes = {
+	featuredEmbed: React.PropTypes.object,
+	featuredImage: React.PropTypes.string,
+	featuredSize: React.PropTypes.object,
+	onClick: React.PropTypes.func,
+};

--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -17,7 +17,7 @@ export default class FeaturedAsset extends React.Component {
 			const img = new Image();
 			img.onload = () => this.setState( { featuredImage: this.props.featuredImage } );
 
-			// use featured embed if featured image is not available
+			// try using featured embed if featured image is not available
 			img.onerror = () => this.setState( { useFeaturedEmbed: this.props.featuredEmbed } );
 			img.src = this.props.featuredImage;
 		}

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -51,7 +51,8 @@ const
 	FeedPostStore = require( 'lib/feed-post-store' ),
 	FeedPostStoreActions = require( 'lib/feed-post-store/actions' ),
 	Gridicon = require( 'components/gridicon' ),
-	smartSetState = require( 'lib/react-smart-set-state' );
+	smartSetState = require( 'lib/react-smart-set-state' ),
+	FeaturedAsset = require( 'reader/stream/featured-asset' );
 
 const Post = React.createClass( {
 
@@ -204,25 +205,8 @@ const Post = React.createClass( {
 
 			featuredSize = this.getFeaturedSize( maxWidth );
 		}
-
-		return useFeaturedEmbed
-			? <div
-					ref="featuredEmbed"
-					className="reader__post-featured-video"
-					key="featuredVideo"
-					dangerouslySetInnerHTML={ { __html: featuredEmbed.iframe } } />  //eslint-disable-line react/no-danger
-			: <div
-					className="reader__post-featured-image"
-					onClick={ this.handlePermalinkClick }>
-				{ featuredSize
-					? <img className="reader__post-featured-image-image"
-							ref="featuredImage"
-							src={ featuredImage }
-							style={ featuredSize }
-						/>
-					: <img className="reader__post-featured-image-image" src={ featuredImage } />
-				}
-			</div>;
+		const props = { featuredImage, featuredSize, featuredEmbed, useFeaturedEmbed };
+    return <FeaturedAsset {...props} />
 	},
 
 	updateFeatureSize: function() {


### PR DESCRIPTION
Companion to #8185 

This handles missing featured images in the reader stream. It will fall back to the featured embed if available. Otherwise it will not display a featured asset.

before with featured embed and missing featured image:
![screen shot 2016-09-26 at 10 22 24 am](https://cloud.githubusercontent.com/assets/744755/18845016/bdc67df4-83d4-11e6-93a1-66cc23f5c95c.png)

after with featured embed :
![screen shot 2016-09-26 at 10 14 40 am](https://cloud.githubusercontent.com/assets/744755/18845017/c0b2ad12-83d4-11e6-979e-90369cf4a923.png)

after without featured embed: 
![screen shot 2016-09-26 at 10 30 38 am](https://cloud.githubusercontent.com/assets/744755/18845039/d4954290-83d4-11e6-8ba4-c362767d6b56.png)

I just did a light touch in `post.jsx` since the reader redesign project should be churning through that way soon.  
