### PR TITLE
Increase click/tap target size for crop handles.

### DIFF
--- a/client/post-editor/media-modal/image-editor/_style.scss
+++ b/client/post-editor/media-modal/image-editor/_style.scss
@@ -74,6 +74,15 @@
 	border-radius: 50%;
 	border: 2px solid $white;
 	background: darken($gray, 52%);
+
+	&:before {
+		border-radius: 100%;
+		content: ' ';
+		display: block;
+		height: 24px;
+		margin: -8px auto auto -8px;
+		width: 24px;
+	}
 }
 
 .editor-media-modal-image-editor__crop-handle-nesw {


### PR DESCRIPTION
Makes it easier to drag the crop handles in the Image Editor.

Before:
![screen shot 2016-09-26 at 12 06 58 pm](https://cloud.githubusercontent.com/assets/1398304/18848123/d686ea56-83e1-11e6-99aa-dcc46e45d9be.png)

After:
![screen shot 2016-09-26 at 12 07 16 pm](https://cloud.githubusercontent.com/assets/1398304/18848128/dc1a72c6-83e1-11e6-9bd6-136324898100.png)


Fixes #8065.