### PR TITLE
Framework: use optimize-js in addition to uglify2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23,6 +23,12 @@
     "after": {
       "version": "0.8.1"
     },
+    "ajv": {
+      "version": "4.7.4"
+    },
+    "ajv-keywords": {
+      "version": "1.1.1"
+    },
     "align-text": {
       "version": "0.1.4"
     },
@@ -87,7 +93,7 @@
       "version": "1.0.1"
     },
     "asap": {
-      "version": "2.0.4"
+      "version": "2.0.5"
     },
     "asn1": {
       "version": "0.2.3"
@@ -102,7 +108,7 @@
       "version": "1.0.2"
     },
     "ast-types": {
-      "version": "0.6.16"
+      "version": "0.9.0"
     },
     "async": {
       "version": "0.9.0"
@@ -112,6 +118,9 @@
     },
     "async-foreach": {
       "version": "0.1.3"
+    },
+    "asynckit": {
+      "version": "0.4.0"
     },
     "atob": {
       "version": "1.1.2"
@@ -159,7 +168,7 @@
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.8.0"
+      "version": "6.15.0"
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.9.0"
@@ -246,7 +255,7 @@
       "version": "6.8.0"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.14.0"
+      "version": "6.15.0"
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.14.0"
@@ -366,16 +375,16 @@
       "version": "6.11.6"
     },
     "babel-template": {
-      "version": "6.14.0"
+      "version": "6.15.0"
     },
     "babel-traverse": {
-      "version": "6.14.0"
+      "version": "6.15.0"
     },
     "babel-types": {
-      "version": "6.14.0"
+      "version": "6.15.0"
     },
     "babylon": {
-      "version": "6.9.1"
+      "version": "6.11.2"
     },
     "backo2": {
       "version": "1.0.2"
@@ -390,7 +399,7 @@
       "version": "0.1.2"
     },
     "base64-js": {
-      "version": "1.1.2"
+      "version": "1.2.0"
     },
     "base64id": {
       "version": "0.1.0"
@@ -411,7 +420,7 @@
       "version": "3.1.3"
     },
     "binary-extensions": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "bl": {
       "version": "1.1.2"
@@ -432,9 +441,6 @@
     },
     "block-stream": {
       "version": "0.0.9"
-    },
-    "bluebird": {
-      "version": "3.4.3"
     },
     "body-parser": {
       "version": "1.15.2",
@@ -504,7 +510,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000527"
+      "version": "1.0.30000539"
     },
     "caseless": {
       "version": "0.11.0"
@@ -573,7 +579,7 @@
       "version": "1.1.1"
     },
     "clean-css": {
-      "version": "3.4.19",
+      "version": "3.4.20",
       "dependencies": {
         "commander": {
           "version": "2.8.1"
@@ -604,8 +610,8 @@
     "clone-regexp": {
       "version": "1.0.0"
     },
-    "closest": {
-      "version": "0.0.1"
+    "co": {
+      "version": "4.6.0"
     },
     "code-point-at": {
       "version": "1.0.0"
@@ -670,13 +676,13 @@
       "version": "0.0.1"
     },
     "concat-stream": {
-      "version": "1.5.1"
+      "version": "1.5.2"
     },
     "configstore": {
       "version": "0.3.2",
       "dependencies": {
         "graceful-fs": {
-          "version": "3.0.10"
+          "version": "3.0.11"
         },
         "object-assign": {
           "version": "2.1.1"
@@ -846,7 +852,12 @@
       "version": "1.0.0"
     },
     "delegate": {
-      "version": "3.0.1"
+      "version": "3.0.2",
+      "dependencies": {
+        "component-closest": {
+          "version": "1.0.1"
+        }
+      }
     },
     "delegates": {
       "version": "1.0.0"
@@ -870,13 +881,13 @@
       "version": "2.0.0"
     },
     "doctrine": {
-      "version": "1.3.0"
+      "version": "1.4.0"
     },
     "doctypes": {
       "version": "1.1.0"
     },
     "doiuse": {
-      "version": "2.4.1",
+      "version": "2.5.0",
       "dependencies": {
         "source-map": {
           "version": "0.4.4"
@@ -920,6 +931,14 @@
         }
       }
     },
+    "draft-js": {
+      "version": "0.8.1",
+      "dependencies": {
+        "immutable": {
+          "version": "3.7.6"
+        }
+      }
+    },
     "duplexer": {
       "version": "0.1.1"
     },
@@ -956,7 +975,12 @@
       "version": "0.1.12"
     },
     "end-of-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "once": {
+          "version": "1.3.3"
+        }
+      }
     },
     "engine.io": {
       "version": "1.6.8",
@@ -1036,7 +1060,7 @@
       "version": "3.1.0"
     },
     "es6-templates": {
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     "es6-weak-map": {
       "version": "2.0.1"
@@ -1134,7 +1158,7 @@
           "version": "1.1.3"
         },
         "globals": {
-          "version": "9.9.0"
+          "version": "9.10.0"
         },
         "strip-bom": {
           "version": "3.0.0"
@@ -1160,10 +1184,15 @@
       "version": "2.0.0"
     },
     "espree": {
-      "version": "3.1.7"
+      "version": "3.3.0",
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.3"
+        }
+      }
     },
-    "esprima-fb": {
-      "version": "10001.1.0-dev-harmony-fb"
+    "esprima": {
+      "version": "3.0.0"
     },
     "esrecurse": {
       "version": "4.1.0",
@@ -1252,30 +1281,19 @@
       }
     },
     "fast-levenshtein": {
-      "version": "1.1.4"
+      "version": "2.0.4"
     },
     "fastparse": {
       "version": "1.1.1"
     },
     "fbemitter": {
-      "version": "2.0.2",
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7"
-        },
-        "fbjs": {
-          "version": "0.7.2"
-        }
-      }
+      "version": "2.1.1"
     },
     "fbjs": {
-      "version": "0.1.0-alpha.7",
+      "version": "0.8.4",
       "dependencies": {
         "core-js": {
           "version": "1.2.7"
-        },
-        "whatwg-fetch": {
-          "version": "0.9.0"
         }
       }
     },
@@ -1336,10 +1354,21 @@
       "version": "1.0.2"
     },
     "flux": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7"
+        },
+        "fbjs": {
+          "version": "0.1.0-alpha.7"
+        },
+        "whatwg-fetch": {
+          "version": "0.9.0"
+        }
+      }
     },
     "for-in": {
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "for-own": {
       "version": "0.1.4"
@@ -1354,12 +1383,7 @@
       "version": "0.6.1"
     },
     "form-data": {
-      "version": "1.0.1",
-      "dependencies": {
-        "async": {
-          "version": "2.0.1"
-        }
-      }
+      "version": "2.0.0"
     },
     "formatio": {
       "version": "1.1.1"
@@ -1449,6 +1473,9 @@
     "globule": {
       "version": "1.0.0",
       "dependencies": {
+        "glob": {
+          "version": "7.0.6"
+        },
         "lodash": {
           "version": "4.9.0"
         },
@@ -1458,7 +1485,7 @@
       }
     },
     "good-listener": {
-      "version": "1.1.7"
+      "version": "1.1.8"
     },
     "got": {
       "version": "3.3.1",
@@ -1598,7 +1625,7 @@
       "version": "1.5.0"
     },
     "http-proxy": {
-      "version": "1.14.0"
+      "version": "1.15.1"
     },
     "http-signature": {
       "version": "1.1.1"
@@ -1922,7 +1949,7 @@
       "version": "0.5.4"
     },
     "json-schema": {
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     "json-stable-stringify": {
       "version": "1.0.1"
@@ -1952,7 +1979,7 @@
       "version": "0.8.4"
     },
     "jsprim": {
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     "jstimezonedetect": {
       "version": "1.0.5"
@@ -1991,7 +2018,7 @@
       "version": "1.1.0"
     },
     "loader-utils": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "json5": {
           "version": "0.5.0"
@@ -2071,6 +2098,9 @@
     "lunr": {
       "version": "0.5.7"
     },
+    "magic-string": {
+      "version": "0.16.0"
+    },
     "map-obj": {
       "version": "1.0.1"
     },
@@ -2079,9 +2109,6 @@
     },
     "masonry-layout": {
       "version": "4.1.1"
-    },
-    "matches-selector": {
-      "version": "0.0.1"
     },
     "media-typer": {
       "version": "0.3.0"
@@ -2105,10 +2132,10 @@
       "version": "1.3.4"
     },
     "mime-db": {
-      "version": "1.23.0"
+      "version": "1.24.0"
     },
     "mime-types": {
-      "version": "2.1.11"
+      "version": "2.1.12"
     },
     "minimatch": {
       "version": "2.0.10"
@@ -2211,7 +2238,7 @@
       "version": "2.4.0"
     },
     "natives": {
-      "version": "1.0.2"
+      "version": "1.1.0"
     },
     "natural-compare": {
       "version": "1.4.0"
@@ -2246,7 +2273,7 @@
       "version": "1.0.0"
     },
     "node-fetch": {
-      "version": "1.6.0"
+      "version": "1.6.3"
     },
     "node-gyp": {
       "version": "3.4.0",
@@ -2361,7 +2388,7 @@
       "version": "2.3.0"
     },
     "once": {
-      "version": "1.3.3"
+      "version": "1.4.0"
     },
     "onecolor": {
       "version": "3.0.4"
@@ -2377,8 +2404,22 @@
         }
       }
     },
+    "optimize-js": {
+      "version": "1.0.1",
+      "dependencies": {
+        "cliui": {
+          "version": "3.2.0"
+        },
+        "window-size": {
+          "version": "0.2.0"
+        },
+        "yargs": {
+          "version": "4.8.1"
+        }
+      }
+    },
     "optionator": {
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0"
@@ -2484,7 +2525,7 @@
       "version": "1.0.0"
     },
     "path-is-inside": {
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "path-parser": {
       "version": "1.0.2"
@@ -2531,7 +2572,7 @@
       "version": "1.2.1"
     },
     "postcss": {
-      "version": "5.1.2",
+      "version": "5.2.2",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -2572,7 +2613,7 @@
       "version": "0.1.6"
     },
     "process": {
-      "version": "0.11.8"
+      "version": "0.11.9"
     },
     "process-nextick-args": {
       "version": "1.0.7"
@@ -2646,15 +2687,7 @@
       }
     },
     "react": {
-      "version": "15.3.0",
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7"
-        },
-        "fbjs": {
-          "version": "0.8.4"
-        }
-      }
+      "version": "15.3.0"
     },
     "react-addons-create-fragment": {
       "version": "15.3.0"
@@ -2791,10 +2824,10 @@
       "version": "1.0.1"
     },
     "recast": {
-      "version": "0.9.18",
+      "version": "0.11.14",
       "dependencies": {
         "source-map": {
-          "version": "0.1.43"
+          "version": "0.5.6"
         }
       }
     },
@@ -2847,7 +2880,7 @@
       "version": "1.1.3"
     },
     "request": {
-      "version": "2.74.0",
+      "version": "2.75.0",
       "dependencies": {
         "qs": {
           "version": "6.2.1"
@@ -2888,7 +2921,7 @@
       "version": "2.5.4",
       "dependencies": {
         "glob": {
-          "version": "7.0.6"
+          "version": "7.1.0"
         },
         "minimatch": {
           "version": "3.0.3"
@@ -3054,7 +3087,7 @@
       "version": "1.0.1"
     },
     "signal-exit": {
-      "version": "3.0.0"
+      "version": "3.0.1"
     },
     "sinon": {
       "version": "1.12.2"
@@ -3264,7 +3297,7 @@
       }
     },
     "sugarss": {
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "superagent": {
       "version": "2.1.0",
@@ -3325,7 +3358,7 @@
       "version": "1.0.1"
     },
     "table": {
-      "version": "3.7.8",
+      "version": "3.8.0",
       "dependencies": {
         "chalk": {
           "version": "1.1.3"
@@ -3431,9 +3464,6 @@
     "tunnel-agent": {
       "version": "0.4.3"
     },
-    "tv4": {
-      "version": "1.2.7"
-    },
     "tween.js": {
       "version": "16.3.1"
     },
@@ -3534,6 +3564,9 @@
     "verror": {
       "version": "1.3.6"
     },
+    "vlq": {
+      "version": "0.2.1"
+    },
     "vm-browserify": {
       "version": "0.0.4"
     },
@@ -3542,6 +3575,9 @@
     },
     "walk": {
       "version": "2.3.4"
+    },
+    "walk-ast": {
+      "version": "0.0.2"
     },
     "warning": {
       "version": "2.1.0"
@@ -3597,7 +3633,7 @@
       "version": "3.0.0"
     },
     "which": {
-      "version": "1.2.10"
+      "version": "1.2.11"
     },
     "which-module": {
       "version": "1.0.0"
@@ -3698,9 +3734,6 @@
     "xmlhttprequest-ssl": {
       "version": "1.5.1"
     },
-    "xregexp": {
-      "version": "3.1.1"
-    },
     "xtend": {
       "version": "4.0.1"
     },
@@ -3723,52 +3756,6 @@
     },
     "yeast": {
       "version": "0.1.2"
-    },
-    "draft-js": {
-      "version": "0.8.1",
-      "dependencies": {
-        "fbjs": {
-          "version": "0.8.4",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7"
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "dependencies": {
-                "node-fetch": {
-                  "version": "1.6.0",
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12"
-                    },
-                    "is-stream": {
-                      "version": "1.1.0"
-                    }
-                  }
-                },
-                "whatwg-fetch": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "promise": {
-              "version": "7.1.1",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.4"
-                }
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.10"
-            }
-          }
-        },
-        "immutable": {
-          "version": "3.7.6"
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "mockery": "1.4.0",
     "nock": "2.17.0",
     "nodemon": "1.4.1",
+    "optimize-js": "1.0.1",
     "react-addons-test-utils": "15.3.0",
     "react-hot-loader": "1.3.0",
     "react-test-env": "0.2.0",

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -31,26 +31,66 @@ outputOptions = {
 };
 
 function minify( files ) {
-	files.forEach( function( file ) {
-		var child;
+	return new Promise( function( resolve ) {
+		const minifiedFiles = [];
+		files.forEach( function( file ) {
+			var child;
 
-		if ( /\.map$/.test( file ) ) {
-			return;
-		}
-
-		child = cp.spawn( path.join( 'node_modules', '.bin', 'uglifyjs' ), [ '--output', file.replace( '.js', '.min.js' ), file ] );
-
-		_children.push( child );
-
-		child.once( 'exit', function() {
-			_children.splice( _children.indexOf( child ), 1 );
-			if ( _children.length === 0 ) {
-				console.log( 'Minification of all bundles completed.' );
-				console.log( 'Total build time: ' + ( new Date().getTime() - start ) + 'ms' );
+			if ( /\.map$/.test( file ) ) {
+				return;
 			}
+
+			const minifiedPath = file.replace( '.js', '.min.js' );
+
+			child = cp.spawn( path.join( 'node_modules', '.bin', 'uglifyjs' ), [ '--output', minifiedPath, file ] );
+
+			minifiedFiles.push( minifiedPath );
+
+			_children.push( child );
+
+			child.once( 'exit', function() {
+				_children.splice( _children.indexOf( child ), 1 );
+				if ( _children.length === 0 ) {
+					console.log( 'Minification of all bundles completed.' );
+					resolve( minifiedFiles );
+				}
+			} );
 		} );
 	} );
 }
+
+function optimize( files ) {
+	return new Promise( function( resolve ) {
+		files.forEach( function( file ) {
+			var child;
+
+			if ( /\.map$/.test( file ) ) {
+				return;
+			}
+
+			child = cp.spawn(
+				path.join( 'node_modules', '.bin', 'optimize-js' ),
+				[ file ], {
+					stdio: [
+						'pipe',
+						fs.openSync( file.replace( '.js', '.optimize.js' ), 'w' ),
+					 	'pipe'
+					]
+				} );
+
+			_children.push( child );
+
+			child.once( 'exit', function() {
+				_children.splice( _children.indexOf( child ), 1 );
+				if ( _children.length === 0 ) {
+					console.log( 'optimize-js of all bundles completed.' );
+					resolve();
+				}
+			} );
+		} );
+	} );
+}
+
 
 Error.stackTrackLimit = 30;
 
@@ -85,5 +125,7 @@ webpack( webpackConfig, function( error, stats ) {
 		return path.join( process.cwd(), 'public', chunk.file );
 	} );
 
-	minify( files );
+	minify( files ).then( optimize ).then( function() {
+		console.log( 'Total build time: ' + ( new Date().getTime() - start ) + 'ms' );
+	} );
 });

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -1,4 +1,4 @@
-var express = require( 'express' ),
+let express = require( 'express' ),
 	fs = require( 'fs' ),
 	crypto = require( 'crypto' ),
 	qs = require( 'qs' ),
@@ -6,19 +6,19 @@ var express = require( 'express' ),
 	cookieParser = require( 'cookie-parser' ),
 	debug = require( 'debug' )( 'calypso:pages' );
 
-var config = require( 'config' ),
+let config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
 	sectionsModule = require( '../../client/sections' ),
 	serverRouter = require( 'isomorphic-routing' ).serverRouter,
 	serverRender = require( 'render' ).serverRender;
 
-var HASH_LENGTH = 10,
+let HASH_LENGTH = 10,
 	URL_BASE_PATH = '/calypso',
 	SERVER_BASE_PATH = '/public',
 	CALYPSO_ENV = process.env.CALYPSO_ENV || process.env.NODE_ENV || 'development';
 
-var staticFiles = [
+const staticFiles = [
 	{ path: 'style.css' },
 	{ path: 'editor.css' },
 	{ path: 'tinymce/skins/wordpress/wp-content.css' },
@@ -26,7 +26,7 @@ var staticFiles = [
 	{ path: 'style-rtl.css' }
 ];
 
-var sections = sectionsModule.get();
+let sections = sectionsModule.get();
 
 /**
  * Generates a hash of a files contents to be used as a version parameter on asset requests.
@@ -34,7 +34,7 @@ var sections = sectionsModule.get();
  * @returns {String} A shortened md5 hash of the contents of the file file or a timestamp in the case of failure.
  **/
 function hashFile( path ) {
-	var data, hash,
+	let data, hash,
 		md5 = crypto.createHash( 'md5' );
 
 	try {
@@ -56,7 +56,7 @@ function hashFile( path ) {
  * @returns {Object} Map of asset names to urls
  **/
 function generateStaticUrls( request ) {
-	var urls = {}, assets;
+	let urls = {}, assets;
 
 	function getUrl( filename, hash ) {
 		return URL_BASE_PATH + '/' + filename + '?' + qs.stringify( {
@@ -81,7 +81,7 @@ function generateStaticUrls( request ) {
 		}
 		urls[ name ] = asset.url;
 		if ( config( 'env' ) !== 'development' ) {
-			urls[ name + '-min' ] = asset.url.replace( '.js', '.min.js' );
+			urls[ name + '-min' ] = asset.url.replace( '.js', '.optimize.min.js' );
 		}
 	} );
 
@@ -105,7 +105,7 @@ function getCurrentCommitShortChecksum() {
 }
 
 function getDefaultContext( request ) {
-	var context = Object.assign( {}, request.context, {
+	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,
 		urls: generateStaticUrls( request ),
 		user: false,
@@ -171,7 +171,7 @@ function setUpLoggedOutRoute( req, res, next ) {
 }
 
 function setUpLoggedInRoute( req, res, next ) {
-	var redirectUrl, protocol, start, context;
+	let redirectUrl, protocol, start, context;
 
 	res.set( {
 		'X-Frame-Options': 'SAMEORIGIN'
@@ -199,7 +199,7 @@ function setUpLoggedInRoute( req, res, next ) {
 
 		debug( 'Issuing API call to fetch user object' );
 		user( req.get( 'Cookie' ), function( error, data ) {
-			var end, searchParam, errorMessage;
+			let end, searchParam, errorMessage;
 
 			if ( error ) {
 				if ( error.error === 'authorization_required' ) {
@@ -275,7 +275,7 @@ function render404( request, response ) {
 }
 
 module.exports = function() {
-	var app = express();
+	const app = express();
 
 	app.set( 'views', __dirname );
 
@@ -292,7 +292,7 @@ module.exports = function() {
 
 	// redirects to handle old newdash formats
 	app.use( '/sites/:site/:section', function( req, res, next ) {
-		var redirectUrl;
+		let redirectUrl;
 		sections = [ 'posts', 'pages', 'sharing', 'upgrade', 'checkout', 'change-theme' ];
 
 		if ( -1 === sections.indexOf( req.params.section ) ) {


### PR DESCRIPTION
Try out adding [optimize-js](https://github.com/nolanlawson/optimize-js) as a post-build step for production builds. They claim it can help with parse speed (and hence boot time) in Chrome and Firefox. 

Need to figure out how to benchmark this and see if there any diffs for us.
