### PR TITLE
Reader: Increase height of textarea in Comments

### DIFF
--- a/client/reader/comments/style.scss
+++ b/client/reader/comments/style.scss
@@ -34,12 +34,11 @@
 	// The inner working of these styles is covered here: http://alistapart.com/article/expanding-text-areas-made-elegant
 	.expanding-area {
 		position: relative;
-		$initial-focused-height: 70px;
 
 		pre,
 		textarea {
 			max-height: 400px;
-			min-height: 33px;
+			min-height: 80px;
 			margin: 0;
 			padding: 5px 60px 5px 5px;
 			font-size: 14px;
@@ -63,10 +62,6 @@
 			box-sizing: border-box;
 			display: block;
 			visibility: hidden;
-		}
-
-		&.focused {
-			min-height: $initial-focused-height;
 		}
 	}
 


### PR DESCRIPTION
One of most common feedback we've received from the Call for Testing post was how the comment box gets a bit lots in between RPs.

To help address that, we've increased its height from a single-liner to being able to accommodate multiple lines by default.

**Before:**
![screenshot 2016-09-26 14 16 56](https://cloud.githubusercontent.com/assets/4924246/18852233/6926cf68-83f4-11e6-88e0-395f5daeae7a.png)

**After:**
![screenshot 2016-09-26 14 16 33](https://cloud.githubusercontent.com/assets/4924246/18852243/724e5d36-83f4-11e6-83c7-1128fc7df797.png)
