### PR TITLE
SEO: Bugfix - Updates title format editor when sites switch

### DIFF
--- a/client/components/seo/meta-title-editor/index.jsx
+++ b/client/components/seo/meta-title-editor/index.jsx
@@ -41,13 +41,25 @@ const tokenMap = {
 
 const getTokensForType = ( type, translate ) => {
 	return get( tokenMap, type, [] )
-				.reduce( ( allTokens, name ) => ( {
-					...allTokens,
-					[ name ]: get( getValidTokens( translate ), name, '' )
-				} ), {} );
+		.reduce( ( allTokens, name ) => ( {
+			...allTokens,
+			[ name ]: get( getValidTokens( translate ), name, '' )
+		} ), {} );
 };
 
 export class MetaTitleEditor extends Component {
+	static propTypes = {
+		disabled: PropTypes.bool,
+		onChange: PropTypes.func,
+		titleFormats: PropTypes.object.isRequired,
+	};
+
+	static defaultProps = {
+		disabled: false,
+		onChange: noop,
+		translate: identity
+	};
+
 	constructor( props ) {
 		super( props );
 		this.updateTitleFormat = this.updateTitleFormat.bind( this );
@@ -63,7 +75,12 @@ export class MetaTitleEditor extends Component {
 	}
 
 	render() {
-		const { disabled, titleFormats, translate } = this.props;
+		const {
+			disabled,
+			site,
+			titleFormats,
+			translate,
+		} = this.props;
 
 		return (
 			<div className="meta-title-editor">
@@ -72,6 +89,7 @@ export class MetaTitleEditor extends Component {
 						key={ type.value }
 						disabled={ disabled }
 						onChange={ this.updateTitleFormat }
+						placeholder={ site && site.title }
 						type={ type }
 						titleFormats={ get( titleFormats, type.value, [] ) }
 						tokens={ getTokensForType( type.value, translate ) }
@@ -81,17 +99,5 @@ export class MetaTitleEditor extends Component {
 		);
 	}
 }
-
-MetaTitleEditor.propTypes = {
-	disabled: PropTypes.bool,
-	onChange: PropTypes.func,
-	titleFormats: PropTypes.object.isRequired,
-};
-
-MetaTitleEditor.defaultProps = {
-	disabled: false,
-	onChange: noop,
-	translate: identity
-};
 
 export default localize( MetaTitleEditor );

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -5,6 +5,7 @@ import {
 	map,
 	max,
 	min,
+	noop,
 } from 'lodash';
 
 // The following polyfills exist for the draft-js editor, since
@@ -44,7 +45,6 @@ if ( ! String.prototype.startsWith ) {
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
 if ( ! Array.prototype.fill ) {
 	Array.prototype.fill = function( value ) {
-
 		// Steps 1-2.
 		if ( this === null ) {
 			throw new TypeError( 'this is null or not defined' );
@@ -112,9 +112,16 @@ const Chip = onClick => props => <Token { ...props } onClick={ onClick } />;
 
 export class TitleFormatEditor extends Component {
 	static propTypes = {
+		disabled: PropTypes.bool,
+		placeholder: PropTypes.string,
 		type: PropTypes.object.isRequired,
 		tokens: PropTypes.object.isRequired,
-		onChange: PropTypes.func.isRequired
+		onChange: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		disabled: false,
+		placeholder: '',
 	};
 
 	constructor( props ) {
@@ -148,11 +155,13 @@ export class TitleFormatEditor extends Component {
 	}
 
 	editorStateFrom( props ) {
+		const { disabled } = props;
+
 		return EditorState.createWithContent(
 			toEditor( props.titleFormats, props.tokens ),
 			new CompositeDecorator( [ {
 				strategy: this.renderTokens,
-				component: Chip( this.removeToken )
+				component: Chip( disabled ? noop : this.removeToken )
 			} ] )
 		);
 	}
@@ -325,6 +334,8 @@ export class TitleFormatEditor extends Component {
 	render() {
 		const { editorState } = this.state;
 		const {
+			disabled,
+			placeholder,
 			titleData,
 			translate,
 			tokens,
@@ -347,7 +358,7 @@ export class TitleFormatEditor extends Component {
 						<span
 							key={ name }
 							className="title-format-editor__button"
-							onClick={ this.addToken( title, name ) }
+							onClick={ disabled ? noop : this.addToken( title, name ) }
 						>
 							{ title }
 						</span>
@@ -356,7 +367,8 @@ export class TitleFormatEditor extends Component {
 				<div className="title-format-editor__editor-wrapper">
 					<Editor
 						editorState={ editorState }
-						onChange={ this.updateEditor }
+						onChange={ disabled ? noop : this.updateEditor }
+						placeholder={ placeholder }
 						ref={ this.storeEditorReference }
 					/>
 				</div>

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -130,7 +130,20 @@ export const SeoForm = React.createClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
+		const { selectedSite: prevSite } = this.props;
+		const { selectedSite: nextSite } = nextProps;
 		const { dirtyFields } = this.state;
+
+		// if we are changing sites, everything goes
+		if ( prevSite.ID !== nextSite.ID ) {
+			return this.setState( {
+				...stateForSite( nextSite ),
+				seoTitleFormats: nextProps.storedTitleFormats,
+				invalidatedSiteObject: nextSite,
+				isRefreshingSiteData: true,
+				dirtyFields: Set(),
+			}, this.refreshCustomTitles );
+		}
 
 		let nextState = {
 			...stateForSite( nextProps.site ),


### PR DESCRIPTION
Resolves #7966 

Previously the custom title format editor would not update the values
inside of the editor when switching sites inside of Calypso. The reason
for this was due to an issue where state was being stored inside of the
SEO form's `this.state` data and not clearing out for new sites.

Now, the form component explicitly checks for site ID changes and will
clear out all local state when that happens and trigger a refresh of the
site data.

This PR reveals more motivation to fix the sites-list in
https://github.com/Automattic/wp-calypso/projects/3

Missing from this PR is a decent loading or disabled state for the editor, which we have a great need for (filed under #8026). In the transition between sites and before the site data is refreshed, the editor will be disabled but it's currently not indicated as such.

**Testing**
Open the editor and switch between sites. The sites will both need to have the business plan enabled, but it's worth trying with non-business-plan sites as well. The data should swap out after the delay caused by re-fetching the site data.

**Todo**
Create a separate PR to see if we couldn't switch this editor to use the site data in the state tree even though the transition isn't yet complete.

cc: @roundhill @rodrigoi @vindl