### PR TITLE
Image editor: "Edit image" button top right

### DIFF
--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -101,9 +101,10 @@
 }
 
 .editor-media-modal-detail__edit {
-	width: 100%;
-	margin-bottom: 16px;
 	font-weight: bold;
+	position: absolute;
+	top: 8px;
+	right: 8px;
 }
 
 .editor-media-modal-detail__sidebar {

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -160,11 +160,11 @@ module.exports = React.createClass( {
 				<div className="editor-media-modal-detail__content editor-media-modal__content">
 					<div className="editor-media-modal-detail__preview-wrapper">
 						{ this.renderItem() }
+						{ this.renderEditButton() }
 						{ this.renderPreviousItemButton() }
 						{ this.renderNextItemButton() }
 					</div>
 					<div className="editor-media-modal-detail__sidebar">
-						{ this.renderEditButton() }
 						{ this.renderFields() }
 						<EditorMediaModalDetailFileInfo
 							item={ this.props.item } />


### PR DESCRIPTION
Resolves #8083

## Pics or it didn't happen!

<img width="1023" alt="zrzut ekranu 2016-09-26 o 14 14 15" src="https://cloud.githubusercontent.com/assets/3775068/18852947/a913d9f6-83f7-11e6-8275-7848c71188ce.png">
<img width="1018" alt="zrzut ekranu 2016-09-26 o 14 14 31" src="https://cloud.githubusercontent.com/assets/3775068/18852951/ab1bb818-83f7-11e6-9686-38e236d1c600.png">

## Testing

- Go to Media overlay
- See that "Edit image" is top right on image

CC @drw158 @gwwar 
