### PR TITLE
Author compact profile: format follower number

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -13,6 +13,7 @@ import ReaderFollowButton from 'reader/follow-button';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 import { getStreamUrl } from 'reader/route';
+import { numberFormat } from 'i18n-calypso';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
@@ -55,12 +56,12 @@ const AuthorCompactProfile = React.createClass( {
 				{ followCount
 					? <div className="author-compact-profile__follow-count">
 					{ this.props.translate(
-						'%(followCount)d follower',
-						'%(followCount)d followers',
+						'%(followCount)s follower',
+						'%(followCount)s followers',
 						{
 							count: followCount,
 							args: {
-								followCount: followCount
+								followCount: numberFormat( followCount )
 							}
 						}
 					) }


### PR DESCRIPTION
@kjellr noticed that we are not formatting the follower count in the `AuthorCompactProfile` block.

This PR runs the follower count through `i18n.numberFormat`, as we do elsewhere in the Reader. This adds the appropriate separator for the locale (a comma in English).

Fixes #8205.

<img width="255" alt="screen shot 2016-09-26 at 15 38 13" src="https://cloud.githubusercontent.com/assets/17325/18854304/47c56dba-83ff-11e6-85dd-672ef7f2a479.png">
