### PR TITLE
Components: Improve reliability of ResizableIframe resizing after image loads

### DIFF
--- a/client/components/resizable-iframe/index.jsx
+++ b/client/components/resizable-iframe/index.jsx
@@ -97,6 +97,8 @@ export default React.createClass( {
 					subtree: true
 				} );
 
+				window.addEventListener( 'load', sendResize, true );
+
 				// Hack: Remove viewport unit styles, as these are relative
 				// the iframe root and interfere with our mechanism for
 				// determining the unconstrained page bounds.


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/issues/3389#issuecomment-249720660
Related: r142756-wpcom
Related: 11124-gh-calypso-pre-oss

This pull request seeks to improve the reliability of `<ResizableIframe />` resizes by triggering the resize postMessage when a `load` event occurs within the rendered frame. The logic is duplicated from our server-side render sandbox to the `<ResizableIframe />` component for components which we can trust to not be sandboxed (e.g. oEmbed results). While the changes in #3389 should resolve cases where the gallery preview could be wrongly cropped, the expected result of the changes here should help cases where oEmbed frames might be wrongly sized.

__Testing instructions:__

I could not find any open issues for this, so simply verify that existing editor oEmbed previews (e.g. Twitter, YouTube) remain unaffected.