### PR TITLE
AuthorCompactProfile: don't assume we have an author name

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 import { getStreamUrl } from 'reader/route';
 import { numberFormat } from 'i18n-calypso';
+import { has } from 'lodash';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
@@ -34,7 +35,8 @@ const AuthorCompactProfile = React.createClass( {
 			return null;
 		}
 
-		const hasMatchingAuthorAndSiteNames = siteName.toLowerCase() === author.name.toLowerCase();
+		const hasAuthorName = has( author, 'name' );
+		const hasMatchingAuthorAndSiteNames = hasAuthorName && siteName.toLowerCase() === author.name.toLowerCase();
 		const classes = classnames( 'author-compact-profile', {
 			'has-author-link': ! hasMatchingAuthorAndSiteNames
 		} );
@@ -45,7 +47,7 @@ const AuthorCompactProfile = React.createClass( {
 				<a href={ streamUrl }>
 					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
 				</a>
-				{ ! hasMatchingAuthorAndSiteNames &&
+				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames &&
 					<ReaderAuthorLink author={ author } siteUrl={ streamUrl }>{ author.name }</ReaderAuthorLink> }
 				{ siteName &&
 					<ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId }>


### PR DESCRIPTION
@aduth discovered that there are some cases where the API does provide an `author` object, but without a `name` key. For example:

http://calypso.localhost:3000/read/feeds/51578155/posts/1164666517

This PR is more defensive when dealing with an `author` object and doesn't assume that a name key is present.

Sidenote: it does look like the API endpoint providing the post could give more author information, so we should take a look at why we only get `{has_avatar: false}` back from the endpoint in this case.

### To test

1. Visit http://calypso.localhost:3000/read/feeds/51578155/posts/1164666517
2. Ensure that the post renders and the author compact profile looks like this:

<img width="242" alt="screen shot 2016-09-26 at 18 54 38" src="https://cloud.githubusercontent.com/assets/17325/18857659/b83da33a-841a-11e6-836d-852db5ae54c2.png">
