### PR TITLE
UpgradeNudge: Better events for expandedNudge abtest

### DIFF
--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -26,6 +26,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import PlanIcon from 'components/plans/plan-icon';
+import { abtest } from 'lib/abtest';
 
 class UpgradeNudgeExpanded extends Component {
 	constructor( props ) {
@@ -60,6 +61,10 @@ class UpgradeNudgeExpanded extends Component {
 		const features = this.props.planConstants.getPromotedFeatures().filter(
 			feature => feature !== this.props.highlightedFeature
 		).slice( 0, 6 );
+
+		if ( this.props.testedRegularNudge && abtest( 'expandedNudge' ) === 'regular' ) {
+			return this.props.testedRegularNudge;
+		}
 
 		return (
 			<Card className="upgrade-nudge-expanded">
@@ -131,7 +136,8 @@ UpgradeNudgeExpanded.propTypes = {
 	eventName: PropTypes.string,
 	event: PropTypes.string,
 	siteSlug: PropTypes.string,
-	recordTracksEvent: PropTypes.func.isRequired
+	recordTracksEvent: PropTypes.func.isRequired,
+	testedRegularNudge: PropTypes.element
 };
 
 const mapStateToProps = ( state, { plan = PLAN_PERSONAL } ) => ( {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -34,7 +34,7 @@ module.exports = {
 		defaultVariation: 'clickableButton'
 	},
 	expandedNudge: {
-		datestamp: '20160922',
+		datestamp: '20160927',
 		variations: {
 			expanded: 50,
 			regular: 50,

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -75,7 +75,7 @@ module.exports = React.createClass( {
 			<EmptyContent
 				title={ this.getTitle() }
 				line={ this.getSummary() }
-				action={ action }
+				action={ this.props.children || action }
 				illustration={ '' } />
 		);
 	}

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -70,7 +70,7 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter, site } ) => (
 			title={ getTitle( filter, translate ) }
 			subtitle={ getSubtitle( filter, translate ) }
 			highlightedFeature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
-			eventName="calypso_media_uploads_upgrade_nudge_impression"
+			event="calypso_media_uploads_upgrade_nudge_impression"
 			benefits={ getBenefits( filter, translate ) }
 			testedRegularNudge={
 				<ListPlanPromo

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
 import { PLAN_PREMIUM, FEATURE_VIDEO_UPLOADS, FEATURE_AUDIO_UPLOADS } from 'lib/plans/constants';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 
 function getTitle( filter, translate ) {
 	if ( filter === 'audio' ) {
@@ -70,6 +71,14 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter } ) => (
 			highlightedFeature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
 			eventName="calypso_media_uploads_upgrade_nudge_impression"
 			benefits={ getBenefits( filter, translate ) }
+			testedRegularNudge={
+				<UpgradeNudge
+					title={ getTitle( filter, translate ) }
+					message={ getSubtitle( filter, translate ) }
+					feature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
+					event="calypso_media_uploads_upgrade_nudge_impression"
+				/>
+			}
 		/>
 	</div>
 );

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -70,7 +70,7 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter, site } ) => (
 			title={ getTitle( filter, translate ) }
 			subtitle={ getSubtitle( filter, translate ) }
 			highlightedFeature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
-			event="calypso_media_uploads_upgrade_nudge_impression"
+			event="calypso_media_uploads_upgrade_nudge"
 			benefits={ getBenefits( filter, translate ) }
 			testedRegularNudge={
 				<ListPlanPromo
@@ -82,7 +82,7 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter, site } ) => (
 						title={ getTitle( filter, translate ) }
 						message={ getSubtitle( filter, translate ) }
 						feature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
-						event="calypso_media_uploads_upgrade_nudge_impression"
+						event="calypso_media_uploads_upgrade_nudge"
 					/>
 				</ListPlanPromo>
 			}

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
 import { PLAN_PREMIUM, FEATURE_VIDEO_UPLOADS, FEATURE_AUDIO_UPLOADS } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import ListPlanPromo from './list-plan-promo';
 
 function getTitle( filter, translate ) {
 	if ( filter === 'audio' ) {
@@ -62,7 +63,7 @@ function getBenefits( filter, translate ) {
 	];
 }
 
-export const MediaLibraryUpgradeNudge = ( { translate, filter } ) => (
+export const MediaLibraryUpgradeNudge = ( { translate, filter, site } ) => (
 	<div className="media-library__videopress-nudge-container">
 		<UpgradeNudgeExpanded
 			plan={ PLAN_PREMIUM }
@@ -72,18 +73,25 @@ export const MediaLibraryUpgradeNudge = ( { translate, filter } ) => (
 			eventName="calypso_media_uploads_upgrade_nudge_impression"
 			benefits={ getBenefits( filter, translate ) }
 			testedRegularNudge={
-				<UpgradeNudge
-					title={ getTitle( filter, translate ) }
-					message={ getSubtitle( filter, translate ) }
-					feature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
-					event="calypso_media_uploads_upgrade_nudge_impression"
-				/>
+				<ListPlanPromo
+					site={ site }
+					filter={ filter }
+				>
+					<UpgradeNudge
+						className="media-library__videopress-nudge-regular"
+						title={ getTitle( filter, translate ) }
+						message={ getSubtitle( filter, translate ) }
+						feature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
+						event="calypso_media_uploads_upgrade_nudge_impression"
+					/>
+				</ListPlanPromo>
 			}
 		/>
 	</div>
 );
 
 MediaLibraryUpgradeNudge.propTypes = {
+	site: PropTypes.object,
 	translate: PropTypes.func,
 	filter: React.PropTypes.string
 };

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -16,12 +16,10 @@ var MediaActions = require( 'lib/media/actions' ),
 	ListItem = require( './list-item' ),
 	ListNoResults = require( './list-no-results' ),
 	ListNoContent = require( './list-no-content' ),
-	ListPlanPromo = require( './list-plan-promo' ),
 	InfiniteList = require( 'components/infinite-list' ),
 	user = require( 'lib/user' )();
 
 import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
-import { abtest } from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'MediaLibraryList',
@@ -201,11 +199,7 @@ module.exports = React.createClass( {
 		var onFetchNextPage;
 
 		if ( this.props.filterRequiresUpgrade ) {
-			if( abtest( 'expandedNudge' ) === 'expanded' ) {
-				return <ListPlanUpgradeNudge filter={ this.props.filter } />;
-			}
-
-			return <ListPlanPromo site={ this.props.site } filter={ this.props.filter } />;
+			return <ListPlanUpgradeNudge filter={ this.props.filter } />;
 		}
 
 		if ( ! this.props.mediaHasNextPage && this.props.media && 0 === this.props.media.length ) {

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -199,7 +199,7 @@ module.exports = React.createClass( {
 		var onFetchNextPage;
 
 		if ( this.props.filterRequiresUpgrade ) {
-			return <ListPlanUpgradeNudge filter={ this.props.filter } />;
+			return <ListPlanUpgradeNudge filter={ this.props.filter } site={ this.props.site } />;
 		}
 
 		if ( ! this.props.mediaHasNextPage && this.props.media && 0 === this.props.media.length ) {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -139,3 +139,11 @@
 		transform: translateY(-50%);
 	}
 }
+
+.empty-content .media-library__videopress-nudge-regular.card.upgrade-nudge {
+	margin-left: auto;
+	margin-right: auto;
+	text-align: left;
+	width: 70%;
+	text-decoration: none;
+}

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -208,7 +208,7 @@ export default React.createClass( {
 				title={ this.translate( 'Upgrade to a Business Plan and Enable Google Analytics' ) }
 				subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable Google Analytics Tracking on your site.' ) }
 				highlightedFeature={ FEATURE_GOOGLE_ANALYTICS }
-				eventName={ "calypso_google_analytics_upgrade_nudge_impression" }
+				event={ "google_analytics_settings" }
 				benefits={ [
 					this.translate(
 						'Analyze visitor traffic and paint a complete picture of your audience and their needs.'

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -202,40 +202,37 @@ export default React.createClass( {
 
 		debug( 'Google analitics is not enabled. adding nudge ...' );
 
-		if( abtest( 'expandedNudge' ) === 'expanded' ) {
-			return (
-				<GoogleAnalyticsUpgradeNudge
-					plan={ PLAN_BUSINESS }
-					title={ this.translate( 'Upgrade to a Business Plan and Enable Google Analytics' ) }
-					subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable Google Analytics Tracking on your site.' ) }
-					highlightedFeature={ FEATURE_GOOGLE_ANALYTICS }
-					eventName={ "calypso_google_analytics_upgrade_nudge_impression" }
-					benefits={ [
-						this.translate(
-							'Analyze visitor traffic and paint a complete picture of your audience and their needs.'
-						),
-						this.translate(
-							'Track the routes people take to reach you and the devices they use to get there with ' +
-							'reporting tools like Traffic Sources.'
-						),
-						this.translate(
-							'Learn what people are looking for and what they like with In-Page Analytics. ' +
-							'Then tailor your marketing and site content for maximum impact.'
-						)
-					] }
-				/>
-			);
-		} else {
-			return (
-				<UpgradeNudge
-					title={ this.translate( 'Add Google Analytics' ) }
-					message={ this.translate( 'Upgrade to the business plan and include your own analytics tracking ID.' ) }
-					feature="google-analytics"
-					event="google_analytics_settings"
-					icon="stats-alt"
-				/>
-			);	
-		}
+		return (
+			<GoogleAnalyticsUpgradeNudge
+				plan={ PLAN_BUSINESS }
+				title={ this.translate( 'Upgrade to a Business Plan and Enable Google Analytics' ) }
+				subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable Google Analytics Tracking on your site.' ) }
+				highlightedFeature={ FEATURE_GOOGLE_ANALYTICS }
+				eventName={ "calypso_google_analytics_upgrade_nudge_impression" }
+				benefits={ [
+					this.translate(
+						'Analyze visitor traffic and paint a complete picture of your audience and their needs.'
+					),
+					this.translate(
+						'Track the routes people take to reach you and the devices they use to get there with ' +
+						'reporting tools like Traffic Sources.'
+					),
+					this.translate(
+						'Learn what people are looking for and what they like with In-Page Analytics. ' +
+						'Then tailor your marketing and site content for maximum impact.'
+					)
+				] }
+				testedRegularNudge={
+					<UpgradeNudge
+						title={ this.translate( 'Add Google Analytics' ) }
+						message={ this.translate( 'Upgrade to the business plan and include your own analytics tracking ID.' ) }
+						feature="google-analytics"
+						event="google_analytics_settings"
+						icon="stats-alt"
+					/>
+				}
+			/>
+		);
 	},
 
 	render() {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -47,7 +47,6 @@ import { isBusiness, isEnterprise } from 'lib/products-values';
 import {
 	PLAN_BUSINESS, FEATURE_ADVANCED_SEO
 } from 'lib/plans/constants';
-import { abtest } from 'lib/abtest';
 
 const serviceIds = {
 	google: 'google-site-verification',
@@ -435,28 +434,27 @@ export const SeoForm = React.createClass( {
 					</Notice>
 				}
 
-				{ showUpgradeNudge && abtest( 'expandedNudge' ) === 'expanded' &&
+				{ showUpgradeNudge &&
 					<SeoSettingsUpgradeNudge
 						plan={ PLAN_BUSINESS }
 						upgrade={ upgradeToBusiness }
 						title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
 						subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
 						highlightedFeature={ FEATURE_ADVANCED_SEO }
-						eventName={ "calypso_seo_settings_upgrade_nudge_impression" }
+						event={ "calypso_seo_settings_upgrade_nudge_impression" }
 						benefits={ [
 							this.translate( "Preview your site's posts and pages as they will appear when shared on Facebook, Twitter and the WordPress.com Reader." ),
 							this.translate( 'Allow you to control how page titles will appear on Google search results, or when shared on social networks.' ),
 							this.translate( 'Modify front page meta data in order to customize how your site appears to search engines.' )
 						] }
-					/>
-				}
-
-				{ showUpgradeNudge && abtest( 'expandedNudge' ) === 'regular' &&
-					<UpgradeNudge
-						feature={ FEATURE_ADVANCED_SEO }
-						title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
-						message={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
-						event={ "calypso_seo_settings_upgrade_nudge_impression" }
+						testedRegularNudge={
+							<UpgradeNudge
+								feature={ FEATURE_ADVANCED_SEO }
+								title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
+								message={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
+								event={ "calypso_seo_settings_upgrade_nudge_impression" }
+							/>
+						}
 					/>
 				}
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -441,7 +441,7 @@ export const SeoForm = React.createClass( {
 						title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
 						subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
 						highlightedFeature={ FEATURE_ADVANCED_SEO }
-						event={ "calypso_seo_settings_upgrade_nudge_impression" }
+						event={ "calypso_seo_settings_upgrade_nudge" }
 						benefits={ [
 							this.translate( "Preview your site's posts and pages as they will appear when shared on Facebook, Twitter and the WordPress.com Reader." ),
 							this.translate( 'Allow you to control how page titles will appear on Google search results, or when shared on social networks.' ),
@@ -452,7 +452,7 @@ export const SeoForm = React.createClass( {
 								feature={ FEATURE_ADVANCED_SEO }
 								title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
 								message={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
-								event={ "calypso_seo_settings_upgrade_nudge_impression" }
+								event={ "calypso_seo_settings_upgrade_nudge" }
 							/>
 						}
 					/>

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -53,7 +53,8 @@ export default React.createClass( {
 		if ( this.props.event || this.props.feature ) {
 			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
 				cta_name: this.props.event,
-				cta_feature: this.props.feature
+				cta_feature: this.props.feature,
+				cta_size: 'regular'
 			} );
 		}
 		this.props.onClick();
@@ -130,7 +131,8 @@ export default React.createClass( {
 				{ ( this.props.event || this.props.feature ) &&
 					<TrackComponentView eventName={ 'calypso_upgrade_nudge_impression' } eventProperties={ {
 						cta_name: this.props.event,
-						cta_feature: this.props.feature
+						cta_feature: this.props.feature,
+						cta_size: 'regular'
 					} } />
 				}
 			</Card>


### PR DESCRIPTION
This PR fixes poorly implemented events from #7777 . I dod a poor job with making the events consistent and trackable and introduced too much noise to build proper funnels.

This PR fixes that.
There are no major changes.

## Testing

- Use Free site
- Assign yourself `expandedNudge`: `regular`ABtest
- Go to `/settings/seo/:site`
- See regular nudge
- See that `calypso_upgrade_nudge_impression ` event goes out with cta_name: `calypso_seo_settings_upgrade_nudge `
- Click the nudge
- See that `calypso_upgrade_nudge_cta_click ` event goes out with cta_name: `calypso_seo_settings_upgrade_nudge `

- Go to `/settings/analytics/:site`
- See regular nudge
- See that `calypso_upgrade_nudge_impression ` event goes out with cta_name: `google_analytics_settings `
- Click the nudge
- See that `calypso_upgrade_nudge_cta_click ` event goes out with cta_name: `google_analytics_settings `

- Assign yourself `expandedNudge`: `expanded`ABtest
- Go to `/settings/seo/:site`
- See expanded nudge
- See that `calypso_upgrade_nudge_impression ` event goes out with cta_name: `calypso_seo_settings_upgrade_nudge ` AND *cta_size:expanded*
- Click the nudge
- See that `calypso_upgrade_nudge_cta_click ` event goes out with cta_name: `calypso_seo_settings_upgrade_nudge ` AND *cta_size:expanded*

- Go to `/settings/analytics/:site`
- See expanded nudge
- Assign yourself `expandedNudge`: `expanded`ABtest
- Create post, open "Video" tab in media modal
- See expanded nudge
- See that `calypso_upgrade_nudge_impression ` event goes out with cta_name: `google_analytics_settings ` AND *cta_size:expanded*
- Click the nudge
- See that `calypso_upgrade_nudge_cta_click ` event goes out with cta_name: `google_analytics_settings ` AND *cta_size:expanded*


- Assign yourself `expandedNudge`: `regular`ABtest
- Create post, open "Video" tab in media modal
- See regular nudge
- See that `calypso_upgrade_nudge_impression ` event goes out with cta_name: `calypso_media_uploads_upgrade_nudge `
- Click the nudge
- See that `calypso_upgrade_nudge_cta_click ` event goes out with cta_name: `calypso_media_uploads_upgrade_nudge `
- Assign yourself `expandedNudge`: `expanded`ABtest
- See that `calypso_upgrade_nudge_impression ` event goes out with cta_name: `calypso_media_uploads_upgrade_nudge ` AND *cta_size:expanded*
- Click the nudge
- See that `calypso_upgrade_nudge_cta_click ` event goes out with cta_name: `calypso_media_uploads_upgrade_nudge ` AND *cta_size:expanded*

CC @vindl @rralian @gwwar @mtias @lamosty 