### PR TITLE
Add translator comment to string

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -180,7 +180,8 @@ class DomainToPlanNudge extends Component {
 						>
 							{
 								translate( 'Upgrade Now for %s', {
-									args: formatCurrency( discountedRawPrice || rawPrice, userCurrency )
+									args: formatCurrency( discountedRawPrice || rawPrice, userCurrency ),
+									comment: '%s will be replaced by a formatted price, i.e $9.9'
 								} )
 							}
 						</Button>


### PR DESCRIPTION
Following a translator question, clarify the purpose of the variable in the string.