### PR TITLE
Plans: Display Upgrade plan button only for the plan owner

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -13,6 +13,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 
 const PlanFeaturesActions = ( {
+	canPurchase,
 	className,
 	available = true,
 	current = false,
@@ -38,7 +39,7 @@ const PlanFeaturesActions = ( {
 		upgradeButton = (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				<Gridicon size={ 18 } icon="checkmark" />
-				{ translate( 'Your plan' ) }
+				{ canPurchase ? translate( 'Your plan' ) : translate( 'Current plan' ) }
 			</Button>
 		);
 	} else if ( available || isPlaceholder ) {
@@ -67,6 +68,7 @@ const PlanFeaturesActions = ( {
 };
 
 PlanFeaturesActions.propTypes = {
+	canPurchase: PropTypes.bool.isRequired,
 	className: PropTypes.string,
 	primaryUpgrade: PropTypes.bool,
 	current: PropTypes.bool,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -124,7 +124,9 @@ class PlanFeatures extends Component {
 	}
 
 	renderMobileView() {
-		const { isPlaceholder, translate, planProperties, isInSignup, intervalType, site, isInJetpackConnect } = this.props;
+		const {
+			canPurchase, isPlaceholder, translate, planProperties, isInSignup, intervalType, site, isInJetpackConnect
+		} = this.props;
 
 		// move any free plan to last place in mobile view
 		let freePlanProperties;
@@ -177,6 +179,7 @@ class PlanFeatures extends Component {
 						{ planConstantObj.getDescription() }
 					</p>
 					<PlanFeaturesActions
+						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
 						primaryUpgrade={ primaryUpgrade }
@@ -270,7 +273,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderTopButtons() {
-		const { planProperties, isPlaceholder, isInSignup, site } = this.props;
+		const { canPurchase, planProperties, isPlaceholder, isInSignup, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -290,6 +293,7 @@ class PlanFeatures extends Component {
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
+						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
 						available = { available }
@@ -416,7 +420,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderBottomButtons() {
-		const { planProperties, isPlaceholder, isInSignup, site } = this.props;
+		const { canPurchase, planProperties, isPlaceholder, isInSignup, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -434,6 +438,7 @@ class PlanFeatures extends Component {
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
+						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
 						available = { available }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -76,30 +76,32 @@ class PlanFeatures extends Component {
 			`has-${ planProperties.length }-cols` );
 
 		return (
-			<div className="plan-features">
+			<div>
 				{ this.renderUpgradeDisabledNotice() }
-				<div className="plan-features__mobile">
-					{ this.renderMobileView() }
-				</div>
-				<table className={ tableClasses }>
-					<tbody>
-						<tr>
-							{ this.renderPlanHeaders() }
-						</tr>
-						<tr>
-							{ this.renderPlanDescriptions() }
-						</tr>
-						<tr>
-							{ this.renderTopButtons() }
-						</tr>
-							{ this.renderPlanFeatureRows() }
-						<tr>
-							{ this.renderBottomButtons() }
-						</tr>
-					</tbody>
-				</table>
+				<div className="plan-features__content">
+					<div className="plan-features__mobile">
+						{ this.renderMobileView() }
+					</div>
+					<table className={ tableClasses }>
+						<tbody>
+							<tr>
+								{ this.renderPlanHeaders() }
+							</tr>
+							<tr>
+								{ this.renderPlanDescriptions() }
+							</tr>
+							<tr>
+								{ this.renderTopButtons() }
+							</tr>
+								{ this.renderPlanFeatureRows() }
+							<tr>
+								{ this.renderBottomButtons() }
+							</tr>
+						</tbody>
+					</table>
 
-				{ this.renderFeaturePopover() }
+					{ this.renderFeaturePopover() }
+				</div>
 			</div>
 		);
 	}
@@ -114,7 +116,8 @@ class PlanFeatures extends Component {
 		return (
 			<Notice
 				className="plan-features__notice"
-				showDismiss={ false }>
+				showDismiss={ false }
+				status="is-info">
 				{ translate( 'You need to be the plan owner to manage this site.' ) }
 			</Notice>
 		);

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -15,6 +15,12 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
+
+.plan-features__notice {
+	border-spacing: 16px 0;
+	margin-top: -16px;
+}
+
 .plan-features__mobile {
 	color: $gray;
 	margin: 0 16px;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -3,7 +3,7 @@ $plan-features-sidebar-width: 272px;
 
 /* Breakpoints 1150px, */
 
-.plan-features {
+.plan-features__content {
 	margin: -16px -16px 0 -16px;
 	padding-top: $plan-features-header-banner-height;
 }
@@ -15,10 +15,13 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-
 .plan-features__notice {
-	border-spacing: 16px 0;
-	margin-top: -16px;
+	margin-bottom: 16px;
+
+	@include breakpoint( ">1040px" ) {
+		margin-bottom: 32px;
+		margin-top: -19px;
+	}
 }
 
 .plan-features__mobile {

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -188,3 +188,16 @@ export function isCurrentPlanExpiring( state, siteId ) {
 	const expiration = get( currentPlan, 'userFacingExpiryMoment', null );
 	return expiration < moment().add( 30, 'days' );
 }
+
+/**
+ * Returns true if current user is also a current plan owner.
+ *
+ * @param  {Object}  state        global state
+ * @param  {Number}  siteId       the site id
+ * @return {Boolean}			  True when user is a plan owner
+ */
+export function isCurrentUserCurrentPlanOwner( state, siteId ) {
+	const currentPlan = getCurrentPlan( state, siteId );
+
+	return get( currentPlan, 'userIsOwner', false );
+}

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -14,6 +14,7 @@ import {
 	getPlansBySite,
 	getPlansBySiteId,
 	hasDomainCredit,
+	isCurrentUserCurrentPlanOwner,
 	isRequestingSitePlans,
 	isSitePlanDiscounted
 } from '../selectors';
@@ -558,6 +559,29 @@ describe( 'selectors', () => {
 			};
 			const isDiscounted = isSitePlanDiscounted( state, 77203074, 'diamond' );
 			expect( isDiscounted ).to.equal( null );
+		} );
+	} );
+
+	describe( '#isCurrentUserCurrentPlanOwner()', () => {
+		const state = {
+			sites: {
+				plans: {
+					2916284: {
+						data: [ { currentPlan: false }, { currentPlan: false }, { currentPlan: true } ]
+					},
+					77203074: {
+						data: [ { currentPlan: false }, { currentPlan: true, userIsOwner: true }, { currentPlan: false } ]
+					}
+				}
+			}
+		};
+
+		it( 'should return false if user is not a plan owner', () => {
+			expect( isCurrentUserCurrentPlanOwner( state, 2916284 ) ).to.be.false;
+		} );
+
+		it( 'should return true if user is a plan owner', () => {
+			expect( isCurrentUserCurrentPlanOwner( state, 77203074 ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -51,7 +51,8 @@ export const sitesSchema = {
 						product_slug: { type: 'string' },
 						product_name_short: { type: 'string' },
 						free_trial: { type: 'boolean' },
-						expired: { type: 'boolean' }
+						expired: { type: 'boolean' },
+						user_is_owner: { type: 'boolean' }
 					}
 				},
 				single_user_site: { type: 'boolean' }


### PR DESCRIPTION
This PR tries to fix one of the issues we had for some time. We block plan upgrades on the server side and display error message to the user at the end of the checkout flow. To improve user experience we want to hide `Upgrade` button to make it clear at a very early stage that it can be done only by the plan owner.

### Testing
1. ~~Apply backend patch `D2913`.~~ It's now deployed.
2. Create or find a site with plan upgrade and make sure it has 2 users with administrator roles.
3. Log in as a plan owner and go to plans page.
4. You should see Upgrade buttons and be able to upgrade your plan to a more expensive plan.
5. Log in as another user and go to the same site's plans page.
6. You should not see Upgrade buttons and shouldn't be able to upgrade site's plan.

##### Plans's owner
![screen shot 2016-09-27 at 14 23 05](https://cloud.githubusercontent.com/assets/699132/18873521/2eaaf9e6-84c0-11e6-9145-bda0a6730999.png)

##### User who doesn't own a plan upgrade for a selected site
![screen shot 2016-09-29 at 17 00 35](https://cloud.githubusercontent.com/assets/699132/18960064/a9f716e4-8668-11e6-9c9f-2893aa6a0d5d.png)

