### PR TITLE
Framework: Reset title (document head) state after navigating

### DIFF
--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { forEach, isEqual, map } from 'lodash';
+import { debounce, forEach, isEqual, map } from 'lodash';
 
 /**
  * Internal dependencies.
@@ -46,8 +46,7 @@ class DocumentHead extends Component {
 	}
 
 	componentDidMount() {
-		const { formattedTitle } = this.props;
-		document.title = formattedTitle;
+		this.setFormattedTitle( this.props.formattedTitle );
 
 		this.refreshHeadTags();
 	}
@@ -70,7 +69,7 @@ class DocumentHead extends Component {
 		}
 
 		if ( nextProps.formattedTitle !== this.props.formattedTitle ) {
-			document.title = nextProps.formattedTitle;
+			this.setFormattedTitle( nextProps.formattedTitle );
 		}
 
 		this.refreshHeadTags( nextProps );
@@ -103,6 +102,10 @@ class DocumentHead extends Component {
 			head.appendChild( newTag );
 		}
 	}
+
+	setFormattedTitle = debounce( ( title ) => {
+		document.title = title;
+	} )
 
 	render() {
 		return null;

--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -103,6 +103,10 @@ class DocumentHead extends Component {
 		}
 	}
 
+	componentWillUnmount() {
+		this.setFormattedTitle.cancel();
+	}
+
 	setFormattedTitle = debounce( ( title ) => {
 		document.title = title;
 	} )

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -10,13 +10,20 @@ import {
 	DOCUMENT_HEAD_META_SET,
 	DOCUMENT_HEAD_TITLE_SET,
 	DOCUMENT_HEAD_UNREAD_COUNT_SET,
+	ROUTE_SET
 } from 'state/action-types';
 import { titleSchema, unreadCountSchema, linkSchema, metaSchema } from './schema';
+
+/**
+ * Constants
+ */
+export const DEFAULT_META_STATE = [ { property: 'og:site_name', content: 'WordPress.com' } ];
 
 export const title = createReducer(
 	'',
 	{
 		[ DOCUMENT_HEAD_TITLE_SET ]: ( state, action ) => action.title,
+		[ ROUTE_SET ]: () => ''
 	},
 	titleSchema
 );
@@ -25,6 +32,7 @@ export const unreadCount = createReducer(
 	0,
 	{
 		[ DOCUMENT_HEAD_UNREAD_COUNT_SET ]: ( state, action ) => action.count,
+		[ ROUTE_SET ]: () => 0
 	},
 	unreadCountSchema
 );
@@ -33,6 +41,7 @@ export const meta = createReducer(
 	[ { property: 'og:site_name', content: 'WordPress.com' } ],
 	{
 		[ DOCUMENT_HEAD_META_SET ]: ( state, action ) => action.meta,
+		[ ROUTE_SET ]: () => DEFAULT_META_STATE
 	},
 	metaSchema
 );
@@ -41,6 +50,7 @@ export const link = createReducer(
 	[],
 	{
 		[ DOCUMENT_HEAD_LINK_SET ]: ( state, action ) => action.link,
+		[ ROUTE_SET ]: () => []
 	},
 	linkSchema
 );

--- a/client/state/document-head/test/reducer.js
+++ b/client/state/document-head/test/reducer.js
@@ -9,13 +9,21 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { link, meta, title, unreadCount } from '../reducer';
 import {
 	DOCUMENT_HEAD_LINK_SET,
 	DOCUMENT_HEAD_META_SET,
 	DOCUMENT_HEAD_TITLE_SET,
 	DOCUMENT_HEAD_UNREAD_COUNT_SET,
+	ROUTE_SET
 } from 'state/action-types';
+
+import {
+	DEFAULT_META_STATE,
+	link,
+	meta,
+	title,
+	unreadCount,
+} from '../reducer';
 
 describe( 'reducer', () => {
 	describe( '#title()', () => {
@@ -29,6 +37,13 @@ describe( 'reducer', () => {
 			const newState = title( undefined, { type: DOCUMENT_HEAD_TITLE_SET, title: 'new title' } );
 
 			expect( newState ).to.equal( 'new title' );
+		} );
+
+		it( 'should return initial state on route set action', () => {
+			const original = 'new title';
+			const state = title( original, { type: ROUTE_SET } );
+
+			expect( state ).to.equal( '' );
 		} );
 	} );
 
@@ -47,13 +62,20 @@ describe( 'reducer', () => {
 
 			expect( newState ).to.equal( 123 );
 		} );
+
+		it( 'should return initial state on route set action', () => {
+			const original = 123;
+			const state = unreadCount( original, { type: ROUTE_SET } );
+
+			expect( state ).to.equal( 0 );
+		} );
 	} );
 
 	describe( '#meta()', () => {
 		test( 'should default to "og:site_name" set to "WordPress.com" array', () => {
 			const state = meta( undefined, {} );
 
-			expect( state ).to.eql( [ { property: 'og:site_name', content: 'WordPress.com' } ] );
+			expect( state ).to.eql( DEFAULT_META_STATE );
 		} );
 
 		test( 'should set a new meta tag', () => {
@@ -71,6 +93,13 @@ describe( 'reducer', () => {
 			const expectedState = [ { content: 'another content', type: 'another type' } ];
 
 			expect( newState ).to.eql( expectedState );
+		} );
+
+		it( 'should return initial state on route set action', () => {
+			const original = deepFreeze( [ { content: 'some content', type: 'some type' } ] );
+			const state = meta( original, { type: ROUTE_SET } );
+
+			expect( state ).to.eql( DEFAULT_META_STATE );
 		} );
 	} );
 
@@ -96,6 +125,13 @@ describe( 'reducer', () => {
 			const expectedState = [ { rel: 'another-rel', href: 'https://automattic.com' } ];
 
 			expect( newState ).to.eql( expectedState );
+		} );
+
+		it( 'should return initial state on route set action', () => {
+			const original = deepFreeze( [ { rel: 'some-rel', href: 'https://wordpress.org' } ] );
+			const state = link( original, { type: ROUTE_SET } );
+
+			expect( state ).to.eql( [] );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to resolve an issue where document head state is not properly reset when navigating between screens. For example, if while viewing the Reader an unread count is assigned into the title, if I then navigate away from the Reader, that count will become stuck in the title.

**Testing Instructions:**

This is easiest to test if you have the [Chrome Redux DevTools extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en) installed
1. Navigate to any [Calypso screen locally](http://calypso.localhost:3000/)
2. Click the Redux tab in the Chrome DevTools
3. Toggle the Dispatcher by clicking Dispatcher in the bottom row of buttons in the Redux tab
4. Dispatch an action to set the document head count
   - `{ type: 'DOCUMENT_HEAD_UNREAD_COUNT_SET', count: 10 }`
5. Note that the title of the tab is now prefixed with `(10)`
6. Navigate to another screen in Calypso
7. Note that the title of the tab is no longer prefixed with `(10)`

**Open Questions:**

A side effect of these changes is that the title is briefly reset to a default value when navigating between sections until updated by that section's controller. Are there other options we could explore to avoid this?

cc @ockham 
