### PR TITLE
Reader: Disqualify featured images that fail to load

### DIFF
--- a/client/blocks/reader-full-post/featured-image.jsx
+++ b/client/blocks/reader-full-post/featured-image.jsx
@@ -4,15 +4,18 @@
 import React from 'react';
 
 export default class FeaturedImage extends React.Component {
-	constructor() {
+	constructor( props ) {
 		super();
-		this.state = { src: '' };
+		this.state = { src: props.src };
+		this.handleImageError = () => {
+			this.setState( { src: '' } );
+		};
 	}
 
-	componentDidMount() {
-		const img = new Image();
-		img.onload = () => this.setState( { src: this.props.src } );
-		img.src = this.props.src;
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.src !== this.props.src ) {
+			this.setState( { src: nextProps.src } );
+		}
 	}
 
 	render() {
@@ -22,7 +25,7 @@ export default class FeaturedImage extends React.Component {
 
 		return (
 			<div className="reader-full-post__featured-image">
-				<img src={ this.state.src } />
+				<img src={ this.state.src } onError={ this.handleImageError } />
 			</div>
 		);
 	}

--- a/client/blocks/reader-full-post/test/featured-image.jsx
+++ b/client/blocks/reader-full-post/test/featured-image.jsx
@@ -1,34 +1,21 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { assert } from 'chai';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
  */
-import useFakeDom from 'test/helpers/use-fake-dom';
-
+import FeaturedImage from '../featured-image';
 
 describe( 'FeaturedImage', () => {
-	let React, FeaturedImage, imageStub;
 
-	useFakeDom();
-
-	before( () => {
-		React = require('react');
-		FeaturedImage = require( '../featured-image' );
-		imageStub = {};
-		global.Image = () => imageStub;
-	} );
-
-	after( () => {
-		global.Image = null;
-	} );
-
-	it( 'renders null if the image does not exist', () => {
-		 const nonExistantImage = 'http://sketchy-feed.com/missing-image-2.jpg';
-		 const wrapper = mount( <FeaturedImage src={ nonExistantImage } /> );
-		 assert.isNull( wrapper.html() );
+	it( 'sets the source to an empty string if the image fails to load', () => {
+		const nonExistantImage = 'http://sketchy-feed.com/missing-image-2.jpg';
+		const wrapper = shallow( <FeaturedImage src={ nonExistantImage } /> );
+		wrapper.instance().handleImageError();
+		assert.equal( '', wrapper.state( 'src' ) );
 	} );
 } );

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -30,7 +30,9 @@ function candidateForCanonicalImage( image ) {
 
 export default function pickCanonicalImage( post ) {
 	let canonicalImage;
-	post.canonical_image = null;
+	if ( post.canonical_image ) {
+		post.canonical_image = null;
+	}
 	if ( post.images ) {
 		canonicalImage = filter( post.images, candidateForCanonicalImage )[ 0 ];
 		if ( canonicalImage ) {

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -30,6 +30,7 @@ function candidateForCanonicalImage( image ) {
 
 export default function pickCanonicalImage( post ) {
 	let canonicalImage;
+	post.canonical_image = null;
 	if ( post.images ) {
 		canonicalImage = filter( post.images, candidateForCanonicalImage )[ 0 ];
 		if ( canonicalImage ) {

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -45,6 +45,13 @@ const promiseForURL = flow( imageForURL, promiseForImage );
 export default function waitForImagesToLoad( post ) {
 	return new Promise( ( resolve ) => {
 		function acceptLoadedImages( images ) {
+			if ( post.featured_image ) {
+				if ( ! find( images, { src: post.featured_image } ) ) {
+					// featured image didn't load, nix it
+					post.featured_image = null;
+				}
+			}
+
 			post.images = map( images, convertImageToObject );
 
 			post.content_images = filter( map( post.content_images, function( image ) {

--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -1,0 +1,82 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+export default class FeaturedAsset extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			suppressFeaturedImage: false,
+			useFeaturedEmbed: props.useFeaturedEmbed
+		};
+		[ 'handleImageError' ].forEach( method => {
+			this[ method ] = this[ method ].bind( this );
+		} );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		// if the next set of props
+		if ( nextProps.featuredImage !== this.props.featuredImage ) {
+			this.setState( {
+				suppressFeaturedImage: false,
+				useFeaturedEmbed: nextProps.useFeaturedEmbed
+			} );
+		}
+	}
+
+	componentWillMount() {
+		this._unmounted = false;
+	}
+
+	componentWillUnmount() {
+		this._unmounted = true;
+	}
+
+	handleImageError() {
+		// You might be wondering, if the src of the img tag below changes while the image is loading, what happens?
+		// Does error fire and then the new load start? Does the error get suppressed?
+		// It appears that any events tied to a loading image are swallowed if the src changes. See
+		// http://jsbin.com/merulogozu/edit?js,console for a test of changing the src after the image starts to load
+		if ( ! this._umounted ) {
+			this.setState( {
+				suppressFeaturedImage: true,
+				useFeaturedEmbed: !! this.props.featuredEmbed // turn on the featured embed if it exists
+			} );
+		}
+	}
+
+	render() {
+		if ( this.state.useFeaturedEmbed ) {
+			return (
+				<div ref="featuredEmbed"
+					className="reader__post-featured-video"
+					key="featuredVideo"
+					dangerouslySetInnerHTML={ { __html: this.props.featuredEmbed.iframe } } />   //eslint-disable-line react/no-danger
+			);
+		}
+
+		return (
+			<div
+				className="reader-full-post__featured-image" >
+				{
+				! this.state.suppressFeaturedImage
+				? <img className="reader__post-featured-image-image"
+						ref="featuredImage"
+						src={ this.props.featuredImage }
+						style={ this.props.featuredSize }
+						onError={ this.handleImageError }
+					/>
+				: null
+				}
+			</div>
+		);
+	}
+}
+
+FeaturedAsset.propTypes = {
+	featuredEmbed: React.PropTypes.object,
+	featuredImage: React.PropTypes.string,
+	featuredSize: React.PropTypes.object,
+	onClick: React.PropTypes.func,
+};

--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -78,5 +78,5 @@ FeaturedAsset.propTypes = {
 	featuredEmbed: React.PropTypes.object,
 	featuredImage: React.PropTypes.string,
 	featuredSize: React.PropTypes.object,
-	onClick: React.PropTypes.func,
+	useFeaturedEmbed: React.PropTypes.bool,
 };

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -51,7 +51,8 @@ const
 	FeedPostStore = require( 'lib/feed-post-store' ),
 	FeedPostStoreActions = require( 'lib/feed-post-store/actions' ),
 	Gridicon = require( 'components/gridicon' ),
-	smartSetState = require( 'lib/react-smart-set-state' );
+	smartSetState = require( 'lib/react-smart-set-state' ),
+	FeaturedAsset = require( 'reader/stream/featured-asset' );
 
 const Post = React.createClass( {
 
@@ -204,25 +205,13 @@ const Post = React.createClass( {
 
 			featuredSize = this.getFeaturedSize( maxWidth );
 		}
-
-		return useFeaturedEmbed
-			? <div
-					ref="featuredEmbed"
-					className="reader__post-featured-video"
-					key="featuredVideo"
-					dangerouslySetInnerHTML={ { __html: featuredEmbed.iframe } } />  //eslint-disable-line react/no-danger
-			: <div
-					className="reader__post-featured-image"
-					onClick={ this.handlePermalinkClick }>
-				{ featuredSize
-					? <img className="reader__post-featured-image-image"
-							ref="featuredImage"
-							src={ featuredImage }
-							style={ featuredSize }
-						/>
-					: <img className="reader__post-featured-image-image" src={ featuredImage } />
-				}
-			</div>;
+		const featuredAssetProps = {
+			featuredImage,
+			featuredSize,
+			featuredEmbed,
+			useFeaturedEmbed
+		};
+		return <FeaturedAsset { ...featuredAssetProps } />;
 	},
 
 	updateFeatureSize: function() {


### PR DESCRIPTION
When we load images to see if they're valid, we should disqualify the featured image if it fails to load. 

We currently have some problems with Jetpack sites, where the featured image url is the post of the attachment instead of the actual image URL. This patch prevents us from trying to use that URL as the feature.

see http://calypso.localhost:3000/read/feeds/12098 v https://wordpress.com/read/feeds/12098
for the behavioral difference