### PR TITLE
Site Settings: Add feature-flagged site icon fieldset setting

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -296,6 +296,7 @@
 @import 'my-sites/site-settings/delete-site-options/style';
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';
+@import 'my-sites/site-settings/site-icon-setting/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'my-sites/sites/style';

--- a/client/components/site-icon/index.jsx
+++ b/client/components/site-icon/index.jsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import url from 'url';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
+import { getSite } from 'state/sites/selectors';
 import Gridicon from 'components/gridicon';
 
 const SiteIcon = React.createClass( {
@@ -22,6 +24,7 @@ const SiteIcon = React.createClass( {
 
 	propTypes: {
 		imgSize: React.PropTypes.number,
+		siteId: React.PropTypes.number,
 		site: React.PropTypes.object,
 		size: React.PropTypes.number
 	},
@@ -72,4 +75,6 @@ const SiteIcon = React.createClass( {
 	}
 } );
 
-export default SiteIcon;
+export default connect( ( state, { siteId } ) => (
+	siteId ? { site: getSite( state, siteId ) } : {}
+) )( SiteIcon );

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -28,6 +28,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Timezone from 'components/timezone';
 import JetpackSyncPanel from './jetpack-sync-panel';
+import SiteIconSetting from './site-icon-setting';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING } from 'lib/plans/constants';
@@ -149,6 +150,7 @@ const FormGeneral = React.createClass( {
 						{ this.translate( 'In a few words, explain what this site is about.' ) }
 					</FormSettingExplanation>
 				</FormFieldset>
+				<SiteIconSetting />
 			</div>
 		);
 	},

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SiteIcon from 'components/site-icon';
+import Button from 'components/button';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isEnabled } from 'config';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+function SiteIconSetting( { translate, siteId } ) {
+	if ( ! isEnabled( 'manage/site-settings/site-icon' ) ) {
+		return null;
+	}
+
+	return (
+		<FormFieldset className="site-icon-setting">
+			<FormLabel>{ translate( 'Site Icon' ) }</FormLabel>
+			<div className="site-icon-setting__controls">
+				<SiteIcon size={ 64 } siteId={ siteId } />
+				<Button className="site-icon-setting__change-button">
+					{ translate( 'Change site icon' ) }
+				</Button>
+			</div>
+			<FormSettingExplanation>
+				{ translate( 'The Site Icon is used as a browser and app icon for your site.' ) }
+			</FormSettingExplanation>
+		</FormFieldset>
+	);
+}
+
+SiteIconSetting.propTypes = {
+	translate: PropTypes.func,
+	siteId: PropTypes.number
+};
+
+export default connect( ( state ) => ( {
+	siteId: getSelectedSiteId( state )
+} ) )( localize( SiteIconSetting ) );

--- a/client/my-sites/site-settings/site-icon-setting/style.scss
+++ b/client/my-sites/site-settings/site-icon-setting/style.scss
@@ -1,0 +1,8 @@
+.site-icon-setting__controls {
+	display: flex;
+	align-items: center;
+}
+
+.site-icon-setting__change-button {
+	margin-left: 8px;
+}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -142,6 +142,10 @@
 		float: left;
 		line-height: 40px;
 	}
+
+	fieldset.site-icon-setting {
+		margin-bottom: 24px;
+	}
 }
 
 .site-settings__footer-credit-container {

--- a/config/development.json
+++ b/config/development.json
@@ -84,6 +84,7 @@
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,
+		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
This pull request seeks to add a non-functional, mostly unstyled site icon field to the [Calypso site settings screen](https://wordpress.com/settings/general/). The field is feature flagged behind a new `manage/site-settings/site-icon` feature flag, enabled only in development. This is part of the Site Icon milestone.

![Site Icon](https://cloud.githubusercontent.com/assets/1779930/18881684/4ebe86d2-84aa-11e6-822a-93a0acff8e4c.png)

__Testing Instructions:__

Verify there are no regressions from changes to `<SiteIcon />` component in optionally accepting a site ID (notably, the `<Site />` component used in site selectors and sidebar selected site detail).

Verify that a Site Icon field is shown in the [site settings screen](http://calypso.localhost:3000/settings/general), only when the `manage/site-settings/site-icon` feature is enabled. You can disable the feature in development either by editing `client/config/index.js` directly, or restarting the Calypso process with `DISABLE_FEATURES=manage/site-settings/site-icon make run`.

cc @mtias 