### PR TITLE
Email Verification: General cleanup

### DIFF
--- a/client/components/email-verification/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-unverified-notice.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -26,7 +25,6 @@ export default class EmailUnverifiedNotice extends React.Component {
 		this.updateVerificationState = this.updateVerificationState.bind( this );
 		this.handleDismiss = this.handleDismiss.bind( this );
 		this.handleSendVerificationEmail = this.handleSendVerificationEmail.bind( this );
-		this.handleChangeEmail = this.handleChangeEmail.bind( this );
 
 		this.state = {
 			needsVerification: userUtils.needsVerificationForSite( sites.getSelectedSite() ),
@@ -66,11 +64,6 @@ export default class EmailUnverifiedNotice extends React.Component {
 
 	handleDismiss() {
 		this.setState( { error: null, emailSent: false } );
-	}
-
-	handleChangeEmail( e ) {
-		e.preventDefault();
-		page( '/me/account' );
 	}
 
 	handleSendVerificationEmail( e ) {
@@ -178,8 +171,8 @@ export default class EmailUnverifiedNotice extends React.Component {
 								'{{requestButton}}Re-send your confirmation email{{/requestButton}} ' +
 								'or {{changeButton}}change the email address on your account{{/changeButton}}.', {
 									components: {
-										requestButton: <a href="#" tabIndex="0" onClick={ this.handleSendVerificationEmail } />,
-										changeButton: <a href="#" tabIndex="0" onClick={ this.handleChangeEmail } />
+										requestButton: <a href="#" onClick={ this.handleSendVerificationEmail } />,
+										changeButton: <a href="/me/account" />
 									}
 								}
 							)

--- a/client/components/email-verification/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-unverified-notice.jsx
@@ -98,7 +98,7 @@ export default class EmailUnverifiedNotice extends React.Component {
 			<Notice
 				icon="mail"
 				showDismiss={ false }
-				text={ i18n.translate( 'Sending...' ) }>
+				text={ i18n.translate( 'Sending…' ) }>
 				<NoticeAction><Spinner /></NoticeAction>
 			</Notice>
 		);

--- a/client/components/email-verification/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-unverified-notice.jsx
@@ -156,40 +156,33 @@ export default class EmailUnverifiedNotice extends React.Component {
 			: (
 				<div>
 					<p>
-						<strong>{
-							i18n.getLocaleSlug() === 'en'
-							? i18n.translate( 'To continue, please confirm your email address' )
-							: i18n.translate( 'Please confirm your email address' )
-						}</strong>
+						<strong>
+							{ i18n.translate( 'Please confirm your email address' ) }
+						</strong>
 					</p>
 					<p>
-						{ i18n.getLocaleSlug() === 'en'
-							? i18n.translate(
-								'Click the link in the email we sent to %(email)s.',
-								{ args: { email: user.get().email } } )
-							: i18n.translate(
+						{
+							i18n.translate(
 								'To post and keep using WordPress.com you need to confirm your email address. ' +
-								'Please click the link in the email we sent at %(email)s.',
-								{ args: { email: user.get().email } } )
+								'Please click the link in the email we sent at %(email)s.', {
+									args: {
+										email: user.get().email
+									}
+								}
+							)
 						}
 					</p>
 					<p>
 						{
-							i18n.getLocaleSlug() === 'en'
-							? i18n.translate(
-								'Didn\'t get it? {{requestButton}}Resend Confirmation Email{{/requestButton}} ' +
-								'or {{changeButton}}Change Account Email Address{{/changeButton}}', {
-									components: {
-										requestButton: <a href="#" tabIndex="0" onClick={ this.handleSendVerificationEmail } />,
-										changeButton: <a href="#" tabIndex="0" onClick={ this.handleChangeEmail } />
-									} } )
-							: i18n.translate(
+							i18n.translate(
 								'{{requestButton}}Re-send your confirmation email{{/requestButton}} ' +
 								'or {{changeButton}}change the email address on your account{{/changeButton}}.', {
 									components: {
 										requestButton: <a href="#" tabIndex="0" onClick={ this.handleSendVerificationEmail } />,
 										changeButton: <a href="#" tabIndex="0" onClick={ this.handleChangeEmail } />
-									} } )
+									}
+								}
+							)
 						}
 					</p>
 				</div>

--- a/client/components/email-verification/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-unverified-notice.jsx
@@ -105,7 +105,7 @@ export default class EmailUnverifiedNotice extends React.Component {
 	}
 
 	renderEmailSendSuccess() {
-		let noticeText = i18n.translate(
+		const noticeText = i18n.translate(
 			'We sent another confirmation email to %(email)s.',
 			{ args: { email: user.get().email } }
 		);
@@ -120,7 +120,7 @@ export default class EmailUnverifiedNotice extends React.Component {
 	}
 
 	renderEmailSendError() {
-		let noticeText = [
+		const noticeText = [
 			<strong>{ i18n.translate( 'The email could not be sent.' ) }</strong>,
 			' ',
 			this.state.error.message,


### PR DESCRIPTION
Closes #8232

This PR fixes some issues that came up while working on the email verification functionality. The biggest change here is not using strings for English users only. Besides that, the rest of the changes are smaller changes that do not change functionality.

To test:

- Checkout `update/email-verification-notice-trash-pickup` branch
- Create an account and do no verify the email
- Go to `/people/new/site`
- Ensure that email verification is displayed and is functional

cc @enejb and @coreh for review