### PR TITLE
Framework: Update eslint to 3.6.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23,6 +23,12 @@
     "after": {
       "version": "0.8.1"
     },
+    "ajv": {
+      "version": "4.7.4"
+    },
+    "ajv-keywords": {
+      "version": "1.1.1"
+    },
     "align-text": {
       "version": "0.1.4"
     },
@@ -87,7 +93,7 @@
       "version": "1.0.1"
     },
     "asap": {
-      "version": "2.0.4"
+      "version": "2.0.5"
     },
     "asn1": {
       "version": "0.2.3"
@@ -102,7 +108,7 @@
       "version": "1.0.2"
     },
     "ast-types": {
-      "version": "0.6.16"
+      "version": "0.9.0"
     },
     "async": {
       "version": "0.9.0"
@@ -112,6 +118,9 @@
     },
     "async-foreach": {
       "version": "0.1.3"
+    },
+    "asynckit": {
+      "version": "0.4.0"
     },
     "atob": {
       "version": "1.1.2"
@@ -159,7 +168,7 @@
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.8.0"
+      "version": "6.15.0"
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.9.0"
@@ -246,7 +255,7 @@
       "version": "6.8.0"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.14.0"
+      "version": "6.15.0"
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.14.0"
@@ -366,16 +375,16 @@
       "version": "6.11.6"
     },
     "babel-template": {
-      "version": "6.14.0"
+      "version": "6.15.0"
     },
     "babel-traverse": {
-      "version": "6.14.0"
+      "version": "6.15.0"
     },
     "babel-types": {
-      "version": "6.14.0"
+      "version": "6.15.0"
     },
     "babylon": {
-      "version": "6.9.1"
+      "version": "6.11.2"
     },
     "backo2": {
       "version": "1.0.2"
@@ -390,7 +399,7 @@
       "version": "0.1.2"
     },
     "base64-js": {
-      "version": "1.1.2"
+      "version": "1.2.0"
     },
     "base64id": {
       "version": "0.1.0"
@@ -411,7 +420,7 @@
       "version": "3.1.3"
     },
     "binary-extensions": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "bl": {
       "version": "1.1.2"
@@ -432,9 +441,6 @@
     },
     "block-stream": {
       "version": "0.0.9"
-    },
-    "bluebird": {
-      "version": "3.4.3"
     },
     "body-parser": {
       "version": "1.15.2",
@@ -504,7 +510,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000527"
+      "version": "1.0.30000540"
     },
     "caseless": {
       "version": "0.11.0"
@@ -573,7 +579,7 @@
       "version": "1.1.1"
     },
     "clean-css": {
-      "version": "3.4.19",
+      "version": "3.4.20",
       "dependencies": {
         "commander": {
           "version": "2.8.1"
@@ -604,8 +610,8 @@
     "clone-regexp": {
       "version": "1.0.0"
     },
-    "closest": {
-      "version": "0.0.1"
+    "co": {
+      "version": "4.6.0"
     },
     "code-point-at": {
       "version": "1.0.0"
@@ -670,13 +676,13 @@
       "version": "0.0.1"
     },
     "concat-stream": {
-      "version": "1.5.1"
+      "version": "1.5.2"
     },
     "configstore": {
       "version": "0.3.2",
       "dependencies": {
         "graceful-fs": {
-          "version": "3.0.10"
+          "version": "3.0.11"
         },
         "object-assign": {
           "version": "2.1.1"
@@ -846,7 +852,12 @@
       "version": "1.0.0"
     },
     "delegate": {
-      "version": "3.0.1"
+      "version": "3.0.2",
+      "dependencies": {
+        "component-closest": {
+          "version": "1.0.1"
+        }
+      }
     },
     "delegates": {
       "version": "1.0.0"
@@ -870,13 +881,13 @@
       "version": "2.0.0"
     },
     "doctrine": {
-      "version": "1.3.0"
+      "version": "1.4.0"
     },
     "doctypes": {
       "version": "1.1.0"
     },
     "doiuse": {
-      "version": "2.4.1",
+      "version": "2.5.0",
       "dependencies": {
         "source-map": {
           "version": "0.4.4"
@@ -920,6 +931,14 @@
         }
       }
     },
+    "draft-js": {
+      "version": "0.8.1",
+      "dependencies": {
+        "immutable": {
+          "version": "3.7.6"
+        }
+      }
+    },
     "duplexer": {
       "version": "0.1.1"
     },
@@ -956,7 +975,12 @@
       "version": "0.1.12"
     },
     "end-of-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "once": {
+          "version": "1.3.3"
+        }
+      }
     },
     "engine.io": {
       "version": "1.6.8",
@@ -1036,7 +1060,7 @@
       "version": "3.1.0"
     },
     "es6-templates": {
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     "es6-weak-map": {
       "version": "2.0.1"
@@ -1128,13 +1152,13 @@
       "version": "1.0.1"
     },
     "eslint": {
-      "version": "3.4.0",
+      "version": "3.6.1",
       "dependencies": {
         "chalk": {
           "version": "1.1.3"
         },
         "globals": {
-          "version": "9.9.0"
+          "version": "9.10.0"
         },
         "strip-bom": {
           "version": "3.0.0"
@@ -1160,10 +1184,15 @@
       "version": "2.0.0"
     },
     "espree": {
-      "version": "3.1.7"
+      "version": "3.3.1",
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.3"
+        }
+      }
     },
-    "esprima-fb": {
-      "version": "10001.1.0-dev-harmony-fb"
+    "esprima": {
+      "version": "3.0.0"
     },
     "esrecurse": {
       "version": "4.1.0",
@@ -1252,30 +1281,19 @@
       }
     },
     "fast-levenshtein": {
-      "version": "1.1.4"
+      "version": "2.0.4"
     },
     "fastparse": {
       "version": "1.1.1"
     },
     "fbemitter": {
-      "version": "2.0.2",
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7"
-        },
-        "fbjs": {
-          "version": "0.7.2"
-        }
-      }
+      "version": "2.1.1"
     },
     "fbjs": {
-      "version": "0.1.0-alpha.7",
+      "version": "0.8.4",
       "dependencies": {
         "core-js": {
           "version": "1.2.7"
-        },
-        "whatwg-fetch": {
-          "version": "0.9.0"
         }
       }
     },
@@ -1336,10 +1354,21 @@
       "version": "1.0.2"
     },
     "flux": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7"
+        },
+        "fbjs": {
+          "version": "0.1.0-alpha.7"
+        },
+        "whatwg-fetch": {
+          "version": "0.9.0"
+        }
+      }
     },
     "for-in": {
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "for-own": {
       "version": "0.1.4"
@@ -1354,12 +1383,7 @@
       "version": "0.6.1"
     },
     "form-data": {
-      "version": "1.0.1",
-      "dependencies": {
-        "async": {
-          "version": "2.0.1"
-        }
-      }
+      "version": "2.0.0"
     },
     "formatio": {
       "version": "1.1.1"
@@ -1449,6 +1473,9 @@
     "globule": {
       "version": "1.0.0",
       "dependencies": {
+        "glob": {
+          "version": "7.0.6"
+        },
         "lodash": {
           "version": "4.9.0"
         },
@@ -1458,7 +1485,7 @@
       }
     },
     "good-listener": {
-      "version": "1.1.7"
+      "version": "1.1.8"
     },
     "got": {
       "version": "3.3.1",
@@ -1469,7 +1496,7 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.6"
+      "version": "4.1.8"
     },
     "graceful-readlink": {
       "version": "1.0.1"
@@ -1598,7 +1625,7 @@
       "version": "1.5.0"
     },
     "http-proxy": {
-      "version": "1.14.0"
+      "version": "1.15.1"
     },
     "http-signature": {
       "version": "1.1.1"
@@ -1922,7 +1949,7 @@
       "version": "0.5.4"
     },
     "json-schema": {
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     "json-stable-stringify": {
       "version": "1.0.1"
@@ -1952,7 +1979,7 @@
       "version": "0.8.4"
     },
     "jsprim": {
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     "jstimezonedetect": {
       "version": "1.0.5"
@@ -1991,7 +2018,7 @@
       "version": "1.1.0"
     },
     "loader-utils": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "json5": {
           "version": "0.5.0"
@@ -2080,9 +2107,6 @@
     "masonry-layout": {
       "version": "4.1.1"
     },
-    "matches-selector": {
-      "version": "0.0.1"
-    },
     "media-typer": {
       "version": "0.3.0"
     },
@@ -2105,10 +2129,10 @@
       "version": "1.3.4"
     },
     "mime-db": {
-      "version": "1.23.0"
+      "version": "1.24.0"
     },
     "mime-types": {
-      "version": "2.1.11"
+      "version": "2.1.12"
     },
     "minimatch": {
       "version": "2.0.10"
@@ -2211,7 +2235,7 @@
       "version": "2.4.0"
     },
     "natives": {
-      "version": "1.0.2"
+      "version": "1.1.0"
     },
     "natural-compare": {
       "version": "1.4.0"
@@ -2246,7 +2270,7 @@
       "version": "1.0.0"
     },
     "node-fetch": {
-      "version": "1.6.0"
+      "version": "1.6.3"
     },
     "node-gyp": {
       "version": "3.4.0",
@@ -2361,7 +2385,7 @@
       "version": "2.3.0"
     },
     "once": {
-      "version": "1.3.3"
+      "version": "1.4.0"
     },
     "onecolor": {
       "version": "3.0.4"
@@ -2378,7 +2402,7 @@
       }
     },
     "optionator": {
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0"
@@ -2484,7 +2508,7 @@
       "version": "1.0.0"
     },
     "path-is-inside": {
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "path-parser": {
       "version": "1.0.2"
@@ -2531,7 +2555,7 @@
       "version": "1.2.1"
     },
     "postcss": {
-      "version": "5.1.2",
+      "version": "5.2.2",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -2572,7 +2596,7 @@
       "version": "0.1.6"
     },
     "process": {
-      "version": "0.11.8"
+      "version": "0.11.9"
     },
     "process-nextick-args": {
       "version": "1.0.7"
@@ -2646,15 +2670,7 @@
       }
     },
     "react": {
-      "version": "15.3.0",
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7"
-        },
-        "fbjs": {
-          "version": "0.8.4"
-        }
-      }
+      "version": "15.3.0"
     },
     "react-addons-create-fragment": {
       "version": "15.3.0"
@@ -2791,10 +2807,10 @@
       "version": "1.0.1"
     },
     "recast": {
-      "version": "0.9.18",
+      "version": "0.11.14",
       "dependencies": {
         "source-map": {
-          "version": "0.1.43"
+          "version": "0.5.6"
         }
       }
     },
@@ -2847,7 +2863,7 @@
       "version": "1.1.3"
     },
     "request": {
-      "version": "2.74.0",
+      "version": "2.75.0",
       "dependencies": {
         "qs": {
           "version": "6.2.1"
@@ -2888,7 +2904,7 @@
       "version": "2.5.4",
       "dependencies": {
         "glob": {
-          "version": "7.0.6"
+          "version": "7.1.0"
         },
         "minimatch": {
           "version": "3.0.3"
@@ -3054,7 +3070,7 @@
       "version": "1.0.1"
     },
     "signal-exit": {
-      "version": "3.0.0"
+      "version": "3.0.1"
     },
     "sinon": {
       "version": "1.12.2"
@@ -3264,7 +3280,7 @@
       }
     },
     "sugarss": {
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     "superagent": {
       "version": "2.1.0",
@@ -3325,7 +3341,7 @@
       "version": "1.0.1"
     },
     "table": {
-      "version": "3.7.8",
+      "version": "3.8.0",
       "dependencies": {
         "chalk": {
           "version": "1.1.3"
@@ -3430,9 +3446,6 @@
     },
     "tunnel-agent": {
       "version": "0.4.3"
-    },
-    "tv4": {
-      "version": "1.2.7"
     },
     "tween.js": {
       "version": "16.3.1"
@@ -3597,7 +3610,7 @@
       "version": "3.0.0"
     },
     "which": {
-      "version": "1.2.10"
+      "version": "1.2.11"
     },
     "which-module": {
       "version": "1.0.0"
@@ -3698,9 +3711,6 @@
     "xmlhttprequest-ssl": {
       "version": "1.5.1"
     },
-    "xregexp": {
-      "version": "3.1.1"
-    },
     "xtend": {
       "version": "4.0.1"
     },
@@ -3723,52 +3733,6 @@
     },
     "yeast": {
       "version": "0.1.2"
-    },
-    "draft-js": {
-      "version": "0.8.1",
-      "dependencies": {
-        "fbjs": {
-          "version": "0.8.4",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7"
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "dependencies": {
-                "node-fetch": {
-                  "version": "1.6.0",
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12"
-                    },
-                    "is-stream": {
-                      "version": "1.1.0"
-                    }
-                  }
-                },
-                "whatwg-fetch": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "promise": {
-              "version": "7.1.1",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.4"
-                }
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.10"
-            }
-          }
-        },
-        "immutable": {
-          "version": "3.7.6"
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "esformatter-quotes": "1.0.3",
     "esformatter-semicolons": "1.1.1",
     "esformatter-special-bangs": "1.0.1",
-    "eslint": "3.4.0",
+    "eslint": "3.6.1",
     "eslint-config-wpcalypso": "0.5.0",
     "eslint-plugin-react": "6.2.0",
     "eslint-plugin-wpcalypso": "2.0.0",


### PR DESCRIPTION
I've been recently seeing a lot of "Error: Cannot mark location in editor for (no-multiple-empty-lines)" errors in Atom.
https://github.com/AtomLinter/linter-eslint/issues/700 claims that this can be fixed by updating eslint to >= 3.5.0.
After doing so (and restarting Atom), Atom seems to be able to mark the correct location with the corresponding warning again, and the error is gone.