### PR TITLE
People: Eslint fixes and use "Remove" user wording when appropriate

### DIFF
--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -1,42 +1,45 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	debug = require( 'debug' )( 'calypso:my-sites:people:edit-team-member-form' ),
-	omit = require( 'lodash/omit' ),
-	assign = require( 'lodash/assign' ),
-	filter = require( 'lodash/filter' ),
-	pick = require( 'lodash/pick' ),
-	page = require( 'page' );
+import React from 'react';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
+import PureRenderMixin from 'react-pure-render/mixin';
+import debugModule from 'debug';
+import omit from 'lodash/omit';
+import assign from 'lodash/assign';
+import filter from 'lodash/filter';
+import pick from 'lodash/pick';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-var Main = require( 'components/main' ),
-	HeaderCake = require( 'components/header-cake' ),
-	Card = require( 'components/card' ),
-	FormLabel = require( 'components/forms/form-label' ),
-	FormFieldset = require( 'components/forms/form-fieldset' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
-	FormButton = require( 'components/forms/form-button' ),
-	FormButtonsBar = require( 'components/forms/form-buttons-bar' ),
-	PeopleProfile = require( 'my-sites/people/people-profile' ),
-	UsersStore = require( 'lib/users/store' ),
-	UsersActions = require( 'lib/users/actions' ),
-	user = require( 'lib/user' )(),
-	protectForm = require( 'lib/mixins/protect-form' ),
-	DeleteUser = require( 'my-sites/people/delete-user' ),
-	PeopleNotices = require( 'my-sites/people/people-notices' ),
-	PeopleLog = require( 'lib/people/log-store' ),
-	analytics = require( 'lib/analytics' ),
-	RoleSelect = require( 'my-sites/people/role-select' );
+import Main from 'components/main';
+import HeaderCake from 'components/header-cake';
+import Card from 'components/card';
+import FormLabel from 'components/forms/form-label';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormTextInput from 'components/forms/form-text-input';
+import FormButton from 'components/forms/form-button';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
+import PeopleProfile from 'my-sites/people/people-profile';
+import UsersStore from 'lib/users/store';
+import UsersActions from 'lib/users/actions';
+import userModule from 'lib/user';
+import protectForm from 'lib/mixins/protect-form';
+import DeleteUser from 'my-sites/people/delete-user';
+import PeopleNotices from 'my-sites/people/people-notices';
+import PeopleLog from 'lib/people/log-store';
+import analytics from 'lib/analytics';
+import RoleSelect from 'my-sites/people/role-select';
 
 /**
  * Module Variables
  */
-var EditUserForm = React.createClass( {
+const debug = debugModule( 'calypso:my-sites:people:edit-team-member-form' );
+const user = userModule();
+
+const EditUserForm = React.createClass( {
 	displayName: 'EditUserForm',
 
 	mixins: [ LinkedStateMixin, PureRenderMixin ],
@@ -50,12 +53,12 @@ var EditUserForm = React.createClass( {
 	},
 
 	getRole: function( roles ) {
-		return roles && roles[0] ? roles[0] : null;
+		return roles && roles[ 0 ] ? roles[ 0 ] : null;
 	},
 
 	getStateObject: function( props ) {
 		props = 'undefined' !== typeof props ? props : this.props;
-		let role = this.getRole( props.roles );
+		const role = this.getRole( props.roles );
 		return assign(
 			omit( props, 'site' ),
 			{ roles: role }
@@ -63,10 +66,8 @@ var EditUserForm = React.createClass( {
 	},
 
 	getChangedSettings: function() {
-		var originalUser = this.getStateObject( this.props.user ),
-			changedKeys;
-
-		changedKeys = filter( this.getAllowedSettingsToChange(), function( setting ) {
+		const originalUser = this.getStateObject( this.props.user );
+		const changedKeys = filter( this.getAllowedSettingsToChange(), function( setting ) {
 			return 'undefined' !== typeof originalUser[ setting ] &&
 				'undefined' !== typeof this.state[ setting ] &&
 				originalUser[ setting ] !== this.state[ setting ];
@@ -76,8 +77,8 @@ var EditUserForm = React.createClass( {
 	},
 
 	getAllowedSettingsToChange: function() {
-		var allowedSettings = [],
-			currentUser = user.get();
+		const currentUser = user.get();
+		let allowedSettings = []; // eslint-disable-line
 
 		if ( ! this.state.ID ) {
 			return allowedSettings;
@@ -104,10 +105,9 @@ var EditUserForm = React.createClass( {
 	},
 
 	updateUser: function( event ) {
-		var changedSettings;
 		event.preventDefault();
 
-		changedSettings = this.getChangedSettings();
+		const changedSettings = this.getChangedSettings();
 		debug( 'Changed settings: ' + JSON.stringify( changedSettings ) );
 
 		this.props.markSaved();
@@ -128,7 +128,7 @@ var EditUserForm = React.createClass( {
 	},
 
 	renderField: function( fieldId ) {
-		var returnField = null;
+		let returnField = null;
 		switch ( fieldId ) {
 			case 'roles':
 				returnField = (
@@ -193,7 +193,7 @@ var EditUserForm = React.createClass( {
 	},
 
 	render: function() {
-		var editableFields;
+		let editableFields;
 		if ( ! this.state.ID ) {
 			return null;
 		}
@@ -204,18 +204,18 @@ var EditUserForm = React.createClass( {
 			return null;
 		}
 
+		editableFields = editableFields.map( ( fieldId ) => {
+			return this.renderField( fieldId );
+		} );
+
 		return (
 			<form
-				className="edit-team-member-form__form"
+				className="edit-team-member-form"
 				disabled={ this.props.disabled }
 				onSubmit={ this.updateUser }
 				onChange={ this.props.markChanged }
 			>
-				{
-					editableFields.map( function( fieldId ) {
-						return this.renderField( fieldId );
-					}.bind( this ) )
-				}
+				{ editableFields }
 				<FormButtonsBar>
 					<FormButton disabled={ ! this.hasUnsavedSettings() }>
 						{ this.translate( 'Save changes', { context: 'Button label that prompts user to save form' } ) }
@@ -256,7 +256,7 @@ module.exports = React.createClass( {
 	},
 
 	refreshUser: function( nextProps ) {
-		var siteId = nextProps && nextProps.siteId ? nextProps.siteId : this.props.siteId;
+		const siteId = nextProps && nextProps.siteId ? nextProps.siteId : this.props.siteId;
 
 		this.setState( {
 			user: UsersStore.getUserByLogin( siteId, this.props.userLogin )
@@ -268,7 +268,7 @@ module.exports = React.createClass( {
 			return;
 		}
 
-		let removeUserSuccessful = PeopleLog.getCompleted( function( log ) {
+		const removeUserSuccessful = PeopleLog.getCompleted( function( log ) {
 			return 'RECEIVE_DELETE_SITE_USER_SUCCESS' === log.action &&
 				this.props.siteId === log.siteId &&
 				this.props.userLogin === log.user.login;
@@ -276,11 +276,11 @@ module.exports = React.createClass( {
 
 		if ( removeUserSuccessful.length ) {
 			this.markSaved();
-			let redirect = this.props.siteSlug ? '/people/team/' + this.props.siteSlug : '/people/team';
+			const redirect = this.props.siteSlug ? '/people/team/' + this.props.siteSlug : '/people/team';
 			page.redirect( redirect );
 		}
 
-		let removeUserInProgress = PeopleLog.getInProgress( function( log ) {
+		const removeUserInProgress = PeopleLog.getInProgress( function( log ) {
 			return 'DELETE_SITE_USER' === log.action &&
 				this.props.siteId === log.siteId &&
 				this.props.userLogin === log.user.login;
@@ -296,7 +296,7 @@ module.exports = React.createClass( {
 	goBack: function() {
 		analytics.ga.recordEvent( 'People', 'Clicked Back Button on User Edit' );
 		if ( this.props.siteSlug ) {
-			let teamBack = '/people/team/' + this.props.siteSlug,
+			const teamBack = '/people/team/' + this.props.siteSlug,
 				readersBack = '/people/readers/' + this.props.siteSlug;
 			if ( this.props.prevPath === teamBack ) {
 				page.back( teamBack );
@@ -336,13 +336,12 @@ module.exports = React.createClass( {
 					/>
 				</Card>
 				{
-					this.state.user ?
+					this.state.user &&
 					<DeleteUser
 						{ ...pick( this.props, [ 'siteId', 'isJetpack', 'isMultisite' ] ) }
 						currentUser={ user.get() }
 						user={ this.state.user }
-					/> :
-					null
+					/>
 				}
 			</Main>
 		);

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -315,7 +315,7 @@ module.exports = React.createClass( {
 			return;
 		}
 		return (
-			<PeopleNotices siteId={ this.props.siteId } user={ this.state.user }/>
+			<PeopleNotices user={ this.state.user } />
 		);
 	},
 

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -210,7 +210,7 @@ const EditUserForm = React.createClass( {
 
 		return (
 			<form
-				className="edit-team-member-form"
+				className="edit-team-member-form__form" // eslint-disable-line
 				disabled={ this.props.disabled }
 				onSubmit={ this.updateUser }
 				onChange={ this.props.markChanged }

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -67,11 +67,11 @@ const EditUserForm = React.createClass( {
 
 	getChangedSettings: function() {
 		const originalUser = this.getStateObject( this.props.user );
-		const changedKeys = filter( this.getAllowedSettingsToChange(), function( setting ) {
+		const changedKeys = filter( this.getAllowedSettingsToChange(), ( setting ) => {
 			return 'undefined' !== typeof originalUser[ setting ] &&
 				'undefined' !== typeof this.state[ setting ] &&
 				originalUser[ setting ] !== this.state[ setting ];
-		}.bind( this ) );
+		} );
 
 		return pick( this.state, changedKeys );
 	},
@@ -268,11 +268,11 @@ module.exports = React.createClass( {
 			return;
 		}
 
-		const removeUserSuccessful = PeopleLog.getCompleted( function( log ) {
+		const removeUserSuccessful = PeopleLog.getCompleted( ( log ) => {
 			return 'RECEIVE_DELETE_SITE_USER_SUCCESS' === log.action &&
 				this.props.siteId === log.siteId &&
 				this.props.userLogin === log.user.login;
-		}.bind( this ) );
+		} );
 
 		if ( removeUserSuccessful.length ) {
 			this.markSaved();

--- a/client/my-sites/people/edit-team-member-form/style.scss
+++ b/client/my-sites/people/edit-team-member-form/style.scss
@@ -1,4 +1,4 @@
-.edit-team-member-form__form {
+.edit-team-member-form {
 	border-top: 1px solid lighten( $gray, 30% );
 	padding-top: 24px;
 	margin-top: 24px;

--- a/client/my-sites/people/edit-team-member-form/style.scss
+++ b/client/my-sites/people/edit-team-member-form/style.scss
@@ -1,4 +1,4 @@
-.edit-team-member-form {
+.edit-team-member-form__form {
 	border-top: 1px solid lighten( $gray, 30% );
 	padding-top: 24px;
 	margin-top: 24px;

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -1,25 +1,30 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	omit = require( 'lodash/omit' ),
-	debug = require( 'debug' )( 'calypso:my-sites:people:main' );
+import React from 'react';
+import omit from 'lodash/omit';
+import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
-var Main = require( 'components/main' ),
-	FollowersList = require( './followers-list' ),
-	ViewersList = require( './viewers-list' ),
-	TeamList = require( 'my-sites/people/team-list' ),
-	EmptyContent = require( 'components/empty-content' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	PeopleNotices = require( 'my-sites/people/people-notices' ),
-	JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' ),
-	PeopleSectionNav = require( 'my-sites/people/people-section-nav' ),
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' );
+import Main from 'components/main';
+import FollowersList from './followers-list';
+import ViewersList from './viewers-list';
+import TeamList from 'my-sites/people/team-list';
+import EmptyContent from 'components/empty-content';
+import observe from 'lib/mixins/data-observe';
+import PeopleNotices from 'my-sites/people/people-notices';
+import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import PeopleSectionNav from 'my-sites/people/people-section-nav';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
-module.exports = React.createClass( {
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:my-sites:people:main' );
+
+export default React.createClass( {
 
 	displayName: 'People',
 
@@ -33,13 +38,14 @@ module.exports = React.createClass( {
 		switch ( this.props.filter ) {
 			case 'team':
 				return <TeamList site={ site } search={ this.props.search } />;
-				break;
 			case 'followers':
 				return <FollowersList site={ site } label={ this.translate( 'Followers' ) } />;
-				break;
 			case 'email-followers':
-				return <FollowersList site={ site } search={ this.props.search } label={ this.translate( 'Email Followers' ) } type="email" />;
-				break;
+				return <FollowersList
+					site={ site }
+					search={ this.props.search }
+					label={ this.translate( 'Email Followers' ) }
+					type="email" />;
 			case 'viewers':
 				return <ViewersList site={ site } label={ this.translate( 'Viewers' ) } />;
 			default:
@@ -48,7 +54,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var site = this.props.sites.getSelectedSite();
+		const site = this.props.sites.getSelectedSite();
 
 		// Jetpack 3.7 is necessary to manage people
 		if ( site && site.jetpack && site.versionCompare( '3.7.0-beta', '<' ) ) {
@@ -79,7 +85,7 @@ module.exports = React.createClass( {
 				<SidebarNavigation />
 				<div>
 					{ <PeopleSectionNav { ...omit( this.props, [ 'sites' ] ) } site={ site } /> }
-					<PeopleNotices siteId={ site && site.ID } />
+					<PeopleNotices />
 					{ this.renderPeopleList( site ) }
 				</div>
 			</Main>

--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -1,25 +1,25 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	i18n = require( 'i18n-calypso' );
+import React from 'react';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var PeopleLog = require( 'lib/people/log-store' ),
-	PeopleActions = require( 'lib/people/actions' ),
-	Notice = require( 'components/notice' );
+import PeopleLog from 'lib/people/log-store';
+import PeopleActions from 'lib/people/actions';
+import Notice from 'components/notice';
 
-let isSameSite = ( siteId, log ) => siteId && log.siteId && log.siteId === siteId;
+const isSameSite = ( siteId, log ) => siteId && log.siteId && log.siteId === siteId;
 
-let isSameUser = ( userId, log ) => userId && log.user && log.user.ID === userId;
+const isSameUser = ( userId, log ) => userId && log.user && log.user.ID === userId;
 
-let translateArg = ( log ) => {
-	return { user: 'string' === typeof log.user ? log.user : log.user.login }
+const translateArg = ( log ) => {
+	return { user: 'string' === typeof log.user ? log.user : log.user.login };
 };
 
-let filterBy = ( siteId, userId, log ) => {
+const filterBy = ( siteId, userId, log ) => {
 	if ( ! siteId && ! userId ) {
 		return true;
 	}
@@ -33,7 +33,7 @@ let filterBy = ( siteId, userId, log ) => {
 	return false;
 };
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'PeopleNotices',
 
@@ -50,7 +50,7 @@ module.exports = React.createClass( {
 	},
 
 	getState() {
-		let siteId = this.props.siteId,
+		const siteId = this.props.siteId,
 			userId = this.props.user && this.props.user.ID;
 		return {
 			errors: PeopleLog.getErrors( filterBy.bind( this, siteId, userId ) ),
@@ -64,23 +64,43 @@ module.exports = React.createClass( {
 	},
 
 	inProgressMessage() {
-		let log = this.state.inProgress[0];
+		const log = this.state.inProgress[ 0 ];
 		switch ( log.action ) {
 			case 'UPDATE_SITE_USER':
-				return i18n.translate( 'Updating @%(user)s', { args: translateArg( log ), context: 'In progress message while a site is performing actions on users.' } );
+				return i18n.translate(
+					'Updating @%(user)s', {
+						args: translateArg( log ),
+						context: 'In progress message while a site is performing actions on users.'
+					}
+				);
 			case 'DELETE_SITE_USER':
-				return i18n.translate( 'Deleting @%(user)s', { args: translateArg( log ), context: 'In progress message while a site is performing actions on users.' } );
+				return i18n.translate(
+					'Deleting @%(user)s', {
+						args: translateArg( log ),
+						context: 'In progress message while a site is performing actions on users.'
+					}
+				);
 		}
 	},
 
 	errorMessage() {
-		let log = this.state.errors[ this.state.errors.length - 1 ];
+		const log = this.state.errors[ this.state.errors.length - 1 ];
 		switch ( log.action ) {
 			case 'RECEIVE_UPDATE_SITE_USER_FAILURE':
 				// Generic update error. Use `localStorage.setItem( 'debug', 'calypso:users:actions' ) for a more detailed error.
-				return i18n.translate( 'There was an error updating @%(user)s', { args: translateArg( log ), context: 'Error message after A site has failed to perform actions on a user.' } );
+				return i18n.translate(
+					'There was an error updating @%(user)s', {
+						args: translateArg( log ),
+						context: 'Error message after A site has failed to perform actions on a user.'
+					}
+				);
 			case 'RECEIVE_DELETE_SITE_USER_FAILURE':
-				return i18n.translate( 'There was an error deleting @%(user)s', { args: translateArg( log ), context: 'Error message after A site has failed to perform actions on a user.' } );
+				return i18n.translate(
+					'There was an error deleting @%(user)s', {
+						args: translateArg( log ),
+						context: 'Error message after A site has failed to perform actions on a user.'
+					}
+				);
 			case 'RECEIVE_USERS':
 				return i18n.translate( 'There was an error retrieving users' );
 			case 'RECEIVE_FOLLOWERS':
@@ -93,25 +113,42 @@ module.exports = React.createClass( {
 	},
 
 	successMessage() {
-		let log = this.state.completed[ this.state.completed.length - 1 ];
+		const log = this.state.completed[ this.state.completed.length - 1 ];
 		switch ( log.action ) {
 			case 'RECEIVE_UPDATE_SITE_USER_SUCCESS':
-				return i18n.translate( 'Successfully updated @%(user)s', { args: translateArg( log ), context: 'Success message after a user has been modified.' } );
+				return i18n.translate(
+					'Successfully updated @%(user)s', {
+						args: translateArg( log ),
+						context: 'Success message after a user has been modified.'
+					}
+				);
 			case 'RECEIVE_DELETE_SITE_USER_SUCCESS':
-				return i18n.translate( 'Successfully deleted @%(user)s', { args: translateArg( log ), context: 'Success message after a user has been modified.' } );
+				return i18n.translate(
+					'Successfully deleted @%(user)s', {
+						args: translateArg( log ),
+						context: 'Success message after a user has been modified.'
+					}
+				);
 		}
 	},
 
 	render() {
-		let logNotices = this.state,
-			notice = null,
+		const logNotices = this.state,
+			onDismissErrorNotice = () => {
+				PeopleActions.removePeopleNotices( logNotices.errors );
+			},
+			onDismissSuccessNotice = () => {
+				PeopleActions.removePeopleNotices( logNotices.completed );
+			};
+
+		let notice = null,
 			message;
 
 		if ( logNotices.inProgress.length > 0 ) {
 			message = this.inProgressMessage();
 			if ( message ) {
 				notice = (
-					<Notice showDismiss={ false } className="people-notice">
+					<Notice showDismiss={ false } className="people-notices__notice">
 						{ message }
 					</Notice>
 				);
@@ -121,7 +158,10 @@ module.exports = React.createClass( {
 			message = this.errorMessage();
 			if ( message ) {
 				notice = (
-					<Notice status="is-error" className="people-notice" onDismissClick={ PeopleActions.removePeopleNotices.bind( this, logNotices.errors ) }>
+					<Notice
+						status="is-error"
+						className="people-notices__notice"
+						onDismissClick={ onDismissErrorNotice }>
 						{ message }
 					</Notice>
 				);
@@ -130,7 +170,10 @@ module.exports = React.createClass( {
 			message = this.successMessage();
 			if ( message ) {
 				notice = (
-					<Notice status="is-success" className="people-notice" onDismissClick={ PeopleActions.removePeopleNotices.bind( this, logNotices.completed ) }>
+					<Notice
+						status="is-success"
+						className="people-notices__notice"
+						onDismissClick={ onDismissSuccessNotice }>
 						{ message }
 					</Notice>
 				);

--- a/client/my-sites/people/people-notices/style.scss
+++ b/client/my-sites/people/people-notices/style.scss
@@ -1,3 +1,3 @@
-.people-notice.notice {
+.people-notices__notice.notice {
 	margin-bottom: 0px;
 }


### PR DESCRIPTION
Fixes #8220

In #8220, @mattyza reported that using "delete" as a success notice when we are actually removing a user could be confusing to users. We hadn't previously distinguished between the two because both actions called a delete user endpoint, but on multisites, we actually remove instead of delete.

Because of this, if we're deleting a user on a multisite, I updated phrasing to user "remove".

I also made several ESLint fixes as I went through the code, which made the PR a bit bigger than it probably needed to be. 

To test:

- Checkout `update/adjust-remove-user-wording` branch
- Go to `/people/team/$site` where `$site` is a single site installation
- Edit a user and ensure there are no errors
- Delete the user and ensure you get the "delete" wording
- Do the same for a multisite install, but ensure you get the "remove" wording

cc @lezama for code review and @rickybanister for a design review