### PR TITLE
Image editor: reduce icon size

### DIFF
--- a/client/post-editor/media-modal/image-editor/_style.scss
+++ b/client/post-editor/media-modal/image-editor/_style.scss
@@ -8,6 +8,8 @@
 
 .editor-media-modal-image-editor__toolbar {
 	flex: 1;
+	display: flex;
+	justify-content: center;
 	position: relative;
 	bottom: 0;
 	width: 100%;

--- a/client/post-editor/media-modal/image-editor/image-editor-toolbar.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-toolbar.jsx
@@ -148,7 +148,7 @@ const MediaModalImageEditorToolbar = React.createClass( {
 					ref={ button.ref }
 					className={ 'editor-media-modal-image-editor__toolbar-button' }
 					onClick={ button.onClick } >
-					<Gridicon icon={ button.icon } size={ 36 } />
+					<Gridicon icon={ button.icon } />
 					<span>{ button.text }</span>
 				</button>
 			) );


### PR DESCRIPTION
Removing the icon size parameter and centering the icons within its container.

fixes #8077 

Before:

![screen shot 2016-09-27 at 12 10 29 pm](https://cloud.githubusercontent.com/assets/618551/18884057/6f4e0eee-84ab-11e6-9807-29508e47467b.png)


After:

![screen shot 2016-09-27 at 12 07 04 pm](https://cloud.githubusercontent.com/assets/618551/18884009/395f07a2-84ab-11e6-854d-c9ae03e50b8b.png)

# To test:

Make sure the new flexbox css works in browsers.
