### PR TITLE
Add touch support to Image Editor Crop

### DIFF
--- a/client/components/draggable/index.jsx
+++ b/client/components/draggable/index.jsx
@@ -41,14 +41,13 @@ export default class Draggable extends Component {
 			y: this.props.y
 		};
 
-		this.onTouchStart = this.onTouchStart.bind( this );
-		this.onMouseDown = this.onMouseDown.bind( this );
+		this.onTouchStartHandler = this.onTouchStartHandler.bind( this );
+		this.onMouseDownHandler = this.onMouseDownHandler.bind( this );
 
-		this.draggingStarted = this.draggingStarted.bind( this );
-		this.dragging = this.dragging.bind( this );
-		this.draggingEnded = this.draggingEnded.bind( this );
+		this.draggingHandler = this.draggingHandler.bind( this );
+		this.draggingEndedHandler = this.draggingEndedHandler.bind( this );
+
 		this.update = this.update.bind( this );
-		this.removeListeners = this.removeListeners.bind( this );
 	}
 
 	componentWillReceiveProps( newProps ) {
@@ -64,7 +63,7 @@ export default class Draggable extends Component {
 		this.removeListeners();
 	}
 
-	draggingStarted( event ) {
+	draggingStartedHandler( event ) {
 		this.dragging = true;
 
 		let coords = event;
@@ -89,10 +88,8 @@ export default class Draggable extends Component {
 		);
 	}
 
-	dragging( event ) {
+	draggingHandler( event ) {
 		let coords = event;
-
-		console.log('on dragging');
 
 		if ( this.isTouchEvent( event ) ) {
 			coords = event.touches[ 0 ];
@@ -104,11 +101,9 @@ export default class Draggable extends Component {
 		this.mousePos = { x, y };
 	}
 
-	draggingEnded( ) {
+	draggingEndedHandler( ) {
 		this.dragging = false;
 		this.mousePos = null;
-
-		console.log('on dragging end');
 
 		cancelAnimationFrame( this.frameRequestId );
 
@@ -117,26 +112,22 @@ export default class Draggable extends Component {
 		this.props.onStop();
 	}
 
-	onTouchStart( event ) {
+	onTouchStartHandler( event ) {
 		event.preventDefault();
 
-		console.log('on touch start');
+		document.addEventListener( 'touchmove', this.draggingHandler );
+		document.addEventListener( 'touchend', this.draggingEndedHandler );
 
-		document.addEventListener( 'touchmove', this.dragging );
-		document.addEventListener( 'touchend', this.draggingEnded );
-
-		this.draggingStarted( event );
+		this.draggingStartedHandler( event );
 	}
 
-	onMouseDown( event ) {
+	onMouseDownHandler( event ) {
 		event.preventDefault();
 
-		console.log('on mouse down');
+		document.addEventListener( 'mousemove', this.draggingHandler );
+		document.addEventListener( 'mouseup', this.draggingEndedHandler );
 
-		document.addEventListener( 'mousemove', this.dragging );
-		document.addEventListener( 'mouseup', this.draggingEnded );
-
-		this.draggingStarted( event );
+		this.draggingStartedHandler( event );
 	}
 
 	update() {
@@ -166,11 +157,11 @@ export default class Draggable extends Component {
 	}
 
 	removeListeners() {
-		document.removeEventListener( 'mousemove', this.dragging );
-		document.removeEventListener( 'mouseup', this.draggingEnded );
+		document.removeEventListener( 'mousemove', this.draggingHandler );
+		document.removeEventListener( 'mouseup', this.draggingEndedHandler );
 
-		document.removeEventListener( 'touchmove', this.dragging );
-		document.removeEventListener( 'touchend', this.draggingEnded );
+		document.removeEventListener( 'touchmove', this.draggingHandler );
+		document.removeEventListener( 'touchend', this.draggingEndedHandler );
 	}
 
 	render() {
@@ -188,8 +179,8 @@ export default class Draggable extends Component {
 			<div
 				{ ...elementProps }
 				style={ style }
-				onMouseDown={ this.onMouseDown }
-				onTouchStart={ this.onTouchStart }
+				onMouseDown={ this.onMouseDownHandler }
+				onTouchStart={ this.onTouchStartHandler }
 			>
 			</div>
 		);

--- a/client/components/draggable/index.jsx
+++ b/client/components/draggable/index.jsx
@@ -1,48 +1,55 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import noop from 'lodash/noop';
 import omit from 'lodash/omit';
 
-export default React.createClass( {
-	displayName: 'Draggable',
-
-	propTypes: {
-		onDrag: React.PropTypes.func,
-		onStop: React.PropTypes.func,
-		width: React.PropTypes.number,
-		height: React.PropTypes.number,
-		x: React.PropTypes.number,
-		y: React.PropTypes.number,
-		controlled: React.PropTypes.bool,
-		bounds: React.PropTypes.shape( {
-			top: React.PropTypes.number,
-			left: React.PropTypes.number,
-			bottom: React.PropTypes.number,
-			right: React.PropTypes.number
+export default class Draggable extends Component {
+	static propTypes = {
+		onDrag: PropTypes.func,
+		onStop: PropTypes.func,
+		width: PropTypes.number,
+		height: PropTypes.number,
+		x: PropTypes.number,
+		y: PropTypes.number,
+		controlled: PropTypes.bool,
+		bounds: PropTypes.shape( {
+			top: PropTypes.number,
+			left: PropTypes.number,
+			bottom: PropTypes.number,
+			right: PropTypes.number
 		} )
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			onDrag: noop,
-			onStop: noop,
-			width: 0,
-			height: 0,
-			x: 0,
-			y: 0,
-			controlled: false,
-			bounds: null
-		};
-	},
+	static defaultProps = {
+		onDrag: noop,
+		onStop: noop,
+		width: 0,
+		height: 0,
+		x: 0,
+		y: 0,
+		controlled: false,
+		bounds: null
+	};
 
-	getInitialState() {
-		return {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
 			x: this.props.x,
 			y: this.props.y
 		};
-	},
+
+		this.onTouchStart = this.onTouchStart.bind( this );
+		this.onMouseDown = this.onMouseDown.bind( this );
+
+		this.draggingStarted = this.draggingStarted.bind( this );
+		this.dragging = this.dragging.bind( this );
+		this.draggingEnded = this.draggingEnded.bind( this );
+		this.update = this.update.bind( this );
+		this.removeListeners = this.removeListeners.bind( this );
+	}
 
 	componentWillReceiveProps( newProps ) {
 		if ( this.state.x !== newProps.x || this.state.y !== newProps.y ) {
@@ -51,11 +58,11 @@ export default React.createClass( {
 				y: newProps.y
 			} );
 		}
-	},
+	}
 
 	componentWillUnmount() {
 		this.removeListeners();
-	},
+	}
 
 	draggingStarted( event ) {
 		this.dragging = true;
@@ -73,14 +80,14 @@ export default React.createClass( {
 
 		cancelAnimationFrame( this.frameRequestId );
 		this.frameRequestId = requestAnimationFrame( this.update );
-	},
+	}
 
 	isTouchEvent( event ) {
 		return (
 			( ! event.pageX || ! event.pageY ) &&
 			( event.targetTouches && event.targetTouches.length )
 		);
-	},
+	}
 
 	dragging( event ) {
 		let coords = event;
@@ -95,7 +102,7 @@ export default React.createClass( {
 			y = coords.pageY - this.relativePos.y;
 
 		this.mousePos = { x, y };
-	},
+	}
 
 	draggingEnded( ) {
 		this.dragging = false;
@@ -108,7 +115,7 @@ export default React.createClass( {
 		this.removeListeners();
 
 		this.props.onStop();
-	},
+	}
 
 	onTouchStart( event ) {
 		event.preventDefault();
@@ -119,7 +126,7 @@ export default React.createClass( {
 		document.addEventListener( 'touchend', this.draggingEnded );
 
 		this.draggingStarted( event );
-	},
+	}
 
 	onMouseDown( event ) {
 		event.preventDefault();
@@ -130,7 +137,7 @@ export default React.createClass( {
 		document.addEventListener( 'mouseup', this.draggingEnded );
 
 		this.draggingStarted( event );
-	},
+	}
 
 	update() {
 		if ( ! this.mousePos ) {
@@ -156,7 +163,7 @@ export default React.createClass( {
 		}
 
 		this.setState( { x, y } );
-	},
+	}
 
 	removeListeners() {
 		document.removeEventListener( 'mousemove', this.dragging );
@@ -164,7 +171,7 @@ export default React.createClass( {
 
 		document.removeEventListener( 'touchmove', this.dragging );
 		document.removeEventListener( 'touchend', this.draggingEnded );
-	},
+	}
 
 	render() {
 		const elementProps = omit( this.props, Object.keys( this.constructor.propTypes ) ),
@@ -187,4 +194,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -102,9 +102,24 @@
 
 .editor-media-modal-detail__edit {
 	font-weight: bold;
-	position: absolute;
-	top: 8px;
-	right: 8px;
+	display: none;
+	&.is-desktop {
+		@include breakpoint( ">480px" ) {
+			display: block;
+			position: absolute;
+			top: 8px;
+			right: 8px;
+		}
+	}
+
+	&.is-mobile {
+		@include breakpoint( "<480px" ) {
+			display: block;
+			width: 100%;
+ 			margin-bottom: 16px;
+		}
+	}
+
 }
 
 .editor-media-modal-detail__sidebar {

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -53,7 +53,7 @@ module.exports = React.createClass( {
 		return ! isDesktop() || hasTouch();
 	},
 
-	renderEditButton: function() {
+	renderEditButton: function( className ) {
 		const { item, onEdit, site } = this.props;
 
 		// Do not render edit button for private sites
@@ -79,7 +79,7 @@ module.exports = React.createClass( {
 
 		return (
 			<Button
-				className="is-desktop editor-media-modal-detail__edit"
+				className={ classNames( 'editor-media-modal-detail__edit', className ) }
 				onClick={ onEdit }>
 				<Gridicon icon="pencil" size={ 36 } /> { this.translate( 'Edit Image' ) }
 			</Button>
@@ -163,11 +163,12 @@ module.exports = React.createClass( {
 				<div className="editor-media-modal-detail__content editor-media-modal__content">
 					<div className="editor-media-modal-detail__preview-wrapper">
 						{ this.renderItem() }
-						{ this.renderEditButton() }
+						{ this.renderEditButton( 'is-desktop' ) }
 						{ this.renderPreviousItemButton() }
 						{ this.renderNextItemButton() }
 					</div>
 					<div className="editor-media-modal-detail__sidebar">
+						{ this.renderEditButton( 'is-mobile' ) }
 						{ this.renderFields() }
 						<EditorMediaModalDetailFileInfo
 							item={ this.props.item } />

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -22,9 +22,6 @@ var EditorMediaModalDetailFields = require( './detail-fields' ),
 	MediaUtils = require( 'lib/media/utils' ),
 	config = require( 'config' );
 
-import { isDesktop } from 'lib/viewport';
-import { hasTouch } from 'lib/touch-detect';
-
 module.exports = React.createClass( {
 	displayName: 'EditorMediaModalDetailItem',
 
@@ -48,11 +45,6 @@ module.exports = React.createClass( {
 		};
 	},
 
-	isMobileTouchDevice() {
-		return false;
-		return ! isDesktop() || hasTouch();
-	},
-
 	renderEditButton: function( className ) {
 		const { item, onEdit, site } = this.props;
 
@@ -65,7 +57,6 @@ module.exports = React.createClass( {
 			! config.isEnabled( 'post-editor/image-editor' ) ||
 			! userCan( 'upload_files', site ) ||
 			isJetpack( site ) ||
-			this.isMobileTouchDevice() ||
 			! item
 		) {
 			return;

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -49,6 +49,7 @@ module.exports = React.createClass( {
 	},
 
 	isMobileTouchDevice() {
+		return false;
 		return ! isDesktop() || hasTouch();
 	},
 


### PR DESCRIPTION
Adds touch support to `Draggable` component. Part of #8044.

## Testing

1. Either use a mobile device (with touch support) or simulate it with dev tools;
2. Navigate to Image Editor and try to use crop feature;
3. Try to move the crop box;
4. Is it all working fine? No strange things?

## Todo:

- [x] Squash commits and write nicer messages (not "WIP") @lamosty
- [x] Test on iPhone @artpi
- [x] Test on Android @lamosty
- [ ] ~~Test on MS devices (will probably not work as they use `Pointer` events)~~
- [x] Show Edit Image button for touch/mobile devices @lamosty
- [x] Bring back Edit image button @artpi 

/cc @gwwar @artpi @obenland @retrofox @adambbecker 