### PR TITLE
Always send Web Push subscription to WPCOM

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import moment from 'moment';
 import wpcom from 'lib/wp';
 
 /**
@@ -24,7 +23,6 @@ import {
 import {
 	isApiReady,
 	getDeviceId,
-	getLastUpdated,
 	getStatus,
 	isBlocked,
 	isEnabled,
@@ -46,7 +44,6 @@ import {
 } from 'state/analytics/actions';
 
 const debug = debugFactory( 'calypso:push-notifications' );
-const DAYS_BEFORE_FORCING_REGISTRATION_REFRESH = 15;
 const serviceWorkerOptions = {
 	path: '/service-worker.js',
 };
@@ -223,24 +220,10 @@ export function fetchPushManagerSubscription() {
 }
 
 export function sendSubscriptionToWPCOM( pushSubscription ) {
-	return ( dispatch, getState ) => {
+	return ( dispatch ) => {
 		if ( ! pushSubscription ) {
 			debug( 'No subscription to send to WPCOM' );
 			return;
-		}
-		const state = getState();
-		const lastUpdated = getLastUpdated( state );
-		debug( 'Subscription last updated: ' + lastUpdated );
-
-		let age;
-
-		if ( lastUpdated ) {
-			age = moment().diff( moment( lastUpdated ), 'days' );
-			if ( age < DAYS_BEFORE_FORCING_REGISTRATION_REFRESH ) {
-				debug( 'Subscription did not need updating.', age );
-				return;
-			}
-			debug( 'Subscription needed updating.', age );
 		}
 
 		debug( 'Sending subscription to WPCOM', pushSubscription );

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -3,7 +3,6 @@
  */
 import { combineReducers } from 'redux';
 import debugFactory from 'debug';
-import moment from 'moment';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
@@ -100,8 +99,7 @@ function system( state = {}, action ) {
 		}
 
 		case PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE: {
-			let lastUpdated;
-			const { data, headers } = action;
+			const { data } = action;
 
 			debug( 'Received WPCOM device registration results', data );
 
@@ -109,20 +107,8 @@ function system( state = {}, action ) {
 				return state;
 			}
 
-			if ( headers && headers.Date ) {
-				lastUpdated = new Date( headers.Date );
-
-				if ( lastUpdated.getTime() ) {
-					// Calling moment with non-ISO date strings is deprecated
-					// see: https://github.com/moment/moment/issues/1407
-					lastUpdated = lastUpdated.toISOString();
-				}
-			}
-
 			return Object.assign( {}, state, {
-				wpcomSubscription: Object.assign( {}, pick( data, [ 'ID', 'settings' ] ), {
-					lastUpdated: moment( lastUpdated ).format()
-				} )
+				wpcomSubscription: Object.assign( {}, pick( data, [ 'ID', 'settings' ] ) )
 			} );
 		}
 	}

--- a/client/state/push-notifications/schema.js
+++ b/client/state/push-notifications/schema.js
@@ -24,7 +24,6 @@ export const systemSchema = {
 		wpcomSubscription: {
 			type: 'object',
 			properties: {
-				lastUpdated: stringType,
 				ID: stringType,
 				settings: {
 					type: 'object',

--- a/client/state/push-notifications/selectors.js
+++ b/client/state/push-notifications/selectors.js
@@ -19,14 +19,6 @@ export function getDeviceId( state ) {
 	return subscription.ID;
 }
 
-export function getLastUpdated( state ) {
-	const wpcomSubscription = getSavedWPCOMSubscription( state );
-	if ( ! wpcomSubscription ) {
-		return;
-	}
-	return wpcomSubscription.lastUpdated;
-}
-
 export function getStatus( state ) {
 	if ( ! isApiReady( state ) ) {
 		return 'unknown';


### PR DESCRIPTION
This PR addresses the following bug:

> When the browser permission state is changed from "Allowed by default" to "Ask by default", Chrome reloads the page, and displays the permission popup. If "Allowed by default" is selected, a new subscription is created. (For debugging, the new subscription can be logged in `sendSubscriptionToWPCOM`, and compared to the one in wpcom.)
> 
> `sendSubscriptionToWPCOM` checks the last update of the subscription, and if it finds that the subscription does not need update, then the server side subscription will become superseded. The issue seems to be caused by the server side subscription not being invalidated when the permission state goes from "Allowed by default" to "Ask by default".

Steps to test (in Chrome):

- If it's not already open, open the network requests tab in the developer console and filter by XHR requests.
- Make sure notifications are enabled (you can disable/enable cycle them to create a fresh subscription).
- Change notification preferences to "Ask by default" in the browser's UI.
- After the page reloads, grant permissions. Verify a request is made to /rest/v1.1/devices/new
- Trigger a notification to the user you are testing with. Verify the notification is received.
- In the Calypso UI select Disable and then Enable. Verify that the XHR request is made.
- Trigger a notification to your user. Verify it works properly.

Also test in Firefox to verify that no regressions were introduced.