### PR TITLE
Comments block: show form if post is a commentable Discover post

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -25,6 +25,7 @@ import {
 	recordGaEvent,
 	recordTrackForPost
 } from 'reader/stats';
+import { isCommentableDiscoverPost } from 'blocks/comments/helper';
 
 class PostCommentForm extends React.Component {
 	constructor( props ) {
@@ -171,7 +172,7 @@ class PostCommentForm extends React.Component {
 		const post = this.props.post;
 
 		// Don't display the form if comments are closed
-		if ( post && post.discussion && post.discussion.comments_open === false ) {
+		if ( post && post.discussion && post.discussion.comments_open === false && ! isCommentableDiscoverPost( post ) ) {
 			// If we already have some comments, show a 'comments closed message'
 			if ( post.discussion.comment_count && post.discussion.comment_count > 0 ) {
 				return <p className="comments__form-closed">{ translate( 'Comments are closed.' ) }</p>;
@@ -197,8 +198,8 @@ class PostCommentForm extends React.Component {
 				<fieldset>
 					<Gravatar user={ this.props.currentUser } />
 					<label>
-						<div className={ expandingAreaClasses } >
-							<pre><span>{ this.state.commentText }</span><br/></pre>
+						<div className={ expandingAreaClasses }>
+							<pre><span>{ this.state.commentText }</span><br /></pre>
 							<textarea
 								value={ this.state.commentText }
 								placeholder={ translate( 'Enter your comment here…' ) }

--- a/client/blocks/comments/helper.jsx
+++ b/client/blocks/comments/helper.jsx
@@ -3,19 +3,26 @@
  */
 import * as DiscoverHelper from 'reader/discover/helper';
 
-module.exports = {
-	shouldShowComments( post ) {
-		let showComments = false;
-		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
-
-		if ( isDiscoverPost ) {
-			if ( DiscoverHelper.isInternalDiscoverPost( post ) && ! DiscoverHelper.isDiscoverSitePick( post ) ) {
-				showComments = true;
-			}
-		} else if ( ! post.is_jetpack && post.discussion && ( post.discussion.comments_open || post.discussion.comment_count > 0 ) ) {
-			showComments = true;
-		}
-
-		return showComments;
+export function shouldShowComments( post ) {
+	if ( isCommentableDiscoverPost( post ) ) {
+		return true;
 	}
-};
+
+	if ( ! post.is_jetpack && post.discussion && ( post.discussion.comments_open || post.discussion.comment_count > 0 ) ) {
+		return true;
+	}
+
+	return false;
+}
+
+export function isCommentableDiscoverPost( post ) {
+	const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
+
+	if ( isDiscoverPost ) {
+		if ( DiscoverHelper.isInternalDiscoverPost( post ) && ! DiscoverHelper.isDiscoverSitePick( post ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}


### PR DESCRIPTION
@jancavan noticed in https://github.com/Automattic/wp-calypso/issues/8216 that Discover posts sometimes had a missing comment form.

Discover posts are a special case, and we always want to show the comment form unless it's a site pick.

I've restructured the comments helper and now pull in the `isCommentableDiscoverPost` function to check whether we should show the comment form.

To test: verify that the comment form appears on http://calypso.localhost:3000/read/feeds/41325786/posts/1167388432.

Fixes #8216.