### PR TITLE
Open notes panel when clicking on Firefox PN

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -189,8 +189,9 @@ var Notifications = React.createClass( {
 
 	receiveServiceWorkerMessage: function( event ) {
 		// Receives messages from the service worker
-		// Firefox sets event.origin to "" for service worker messages
-		if ( event.origin && event.origin !== document.origin ) {
+		// Older Firefox versions (pre v48) set event.origin to "" for service worker messages
+		// Firefox does not support document.origin; we can use location.origin instead
+		if ( event.origin && event.origin !== location.origin ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR fixes the following bug:

> If you click on a browser notification in Firefox, it opens the WordPress.com site, but does not open the notifications pane.

To test (in both Firefox and Chrome):

- Run branch
- Generate a notification for your user
- Click on notification
- Verify that Calypso browser window/tab is focused and notification panel is opened