### PR TITLE
Signup: adjust Store and eCommerce variants percentages

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -63,21 +63,21 @@ module.exports = {
 		allowExistingUsers: false,
 	},
 	signupStore: {
-		datestamp: '20160727',
+		datestamp: '20160927',
 		variations: {
-			designTypeWithoutStore: 80,
-			designTypeWithStore: 20,
+			designTypeWithoutStore: 0,
+			designTypeWithStore: 100,
 		},
-		defaultVariation: 'designTypeWithoutStore',
+		defaultVariation: 'designTypeWithStore',
 		allowExistingUsers: false,
 	},
 	signupStoreBenchmarking: {
-		datestamp: '20160817',
+		datestamp: '20160927',
 		variations: {
-			pressable: 94,
-			bluehost: 2,
-			bluehostWithWoo: 2,
-			siteground: 2
+			pressable: 97,
+			bluehost: 1,
+			bluehostWithWoo: 1,
+			siteground: 1
 		},
 		defaultVariation: 'pressable',
 		allowExistingUsers: false,

--- a/client/signup/steps/design-type-with-store/bluehost-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/bluehost-store/index.jsx
@@ -29,7 +29,7 @@ export const BluehostStoreStep = props => {
 	);
 
 	let subHeaderText = translate( 'Our partners at BlueHost are here for you.'	);
-	let partnerUrl = 'https://www.bluehost.com/track/wp/dotcomsans1?page=/wordpress';
+	let partnerUrl = 'https://www.bluehost.com/track/wp/dotcomsans2?page=/wordpress';
 	let price = '$2.95';
 
 	if ( 'Bluehost with WooCommerce' === partnerName ) {
@@ -40,7 +40,7 @@ export const BluehostStoreStep = props => {
 		);
 
 		subHeaderText = translate( 'Our partners at BlueHost and WooCommerce are here for you.' );
-		partnerUrl = 'https://www.bluehost.com/track/wp/dotcomwoo1?page=/wordpress-woocommerce';
+		partnerUrl = 'https://www.bluehost.com/track/wp/dotcomwoo2?page=/wordpress-woocommerce';
 		price = '$11.95';
 	}
 

--- a/client/signup/steps/design-type-with-store/pressable-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/pressable-store/index.jsx
@@ -70,7 +70,7 @@ export default React.createClass( {
 
 		analytics.tracks.recordEvent( 'calypso_triforce_partner_redirect', { partner_name: 'Pressable' } );
 
-		window.open( `https://my.pressable.com/signup/ecommerce-five-sites?email=${ encodeURIComponent( this.state.email ) }&utm_source=wordpresscom&utm_medium=signupref&utm_campaign=wpcomecomm2` );
+		window.open( `https://my.pressable.com/signup/ecommerce-five-sites?email=${ encodeURIComponent( this.state.email ) }&utm_source=wordpresscom&utm_medium=signupref&utm_campaign=wpcomecomm3` );
 	},
 
 	onEmailInputRef( input ) {

--- a/client/signup/steps/design-type-with-store/siteground-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/siteground-store/index.jsx
@@ -49,7 +49,7 @@ export const SitegroundStoreStep = ( { onBackClick, translate, partnerClickRecor
 						className="design-type-with-store__button"
 						target="_blank"
 						rel="noopener noreferrer"
-						href="https://www.siteground.com/go/wordpress-ecommerce"
+						href="https://www.siteground.com/go/wordpress-ecommerce2"
 						onClick={ partnerClickRecorder }
 					>
 						{ translate( 'Create Store' ) }


### PR DESCRIPTION
* Direct all users with EN locale to design type with store variant.
* Adjust eCommerce partner variants percentages.
* Update test dates and campaign UTMs where applicable.