### PR TITLE
Image Editor: window.onResize for crop box

### DIFF
--- a/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
@@ -101,7 +101,7 @@ const MediaModalImageEditorCanvas = React.createClass( {
 		this.drawImage();
 		this.updateCanvasPosition();
 		this.onWindowResize = throttle( this.updateCanvasPosition, 200 );
-		if ( window ) {
+		if ( typeof window !== 'undefined' ) {
 			window.addEventListener( 'resize', this.onWindowResize );
 		}
 
@@ -111,7 +111,7 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	},
 
 	componentWillUnmount: function() {
-		if ( window && this.onWindowResize ) {
+		if ( typeof window !== 'undefined' && this.onWindowResize ) {
 			window.removeEventListener( 'resize', this.onWindowResize );
 			this.onWindowResize = null;
 		}

--- a/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
@@ -6,6 +6,7 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
+import throttle from 'lodash/throttle';
 
 /**
  * Internal dependencies
@@ -21,6 +22,8 @@ import { setImageEditorCropBounds } from 'state/ui/editor/image-editor/actions';
 
 const MediaModalImageEditorCanvas = React.createClass( {
 	displayName: 'MediaModalImageEditorCanvas',
+
+	onWindowResize: null,
 
 	propTypes: {
 		src: React.PropTypes.string,
@@ -97,12 +100,22 @@ const MediaModalImageEditorCanvas = React.createClass( {
 
 		this.drawImage();
 		this.updateCanvasPosition();
+		this.onWindowResize = throttle( this.updateCanvasPosition, 200 );
+		if ( window ) {
+			window.addEventListener( 'resize', this.onWindowResize );
+		}
 
 		this.setState( {
 			imageLoaded: true
 		} );
 	},
 
+	componentWillUnmount: function() {
+		if ( window && this.onWindowResize ) {
+			window.removeEventListener( 'resize', this.onWindowResize );
+			this.onWindowResize = null;
+		}
+	},
 	componentDidUpdate() {
 		this.drawImage();
 		this.updateCanvasPosition();


### PR DESCRIPTION
Fixes #7983

Adds `window.onResize` event to align crop box to content.

## Testing

- Start editing an image
- Resize the browser window
- Observe that crop box stays aligned

CC @lamosty @rralian @gwwar 