### PR TITLE
Reader: Fix Visit and Likes button line break

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -207,9 +207,9 @@
 
 // Custom breakpoints that drop action labels text
 // to prevent Likes text from breaking onto a new line
-.is-group-reader .reader-share__button-label,
-.is-group-reader .comment-button__label-status,
-.is-group-reader .like-button__label-status {
+.reader-share__button-label,
+.comment-button__label-status,
+.like-button__label-status {
 	@media( max-width: 530px ) {
 		display: none;
 	}


### PR DESCRIPTION
Supposedly fixed in: https://github.com/Automattic/wp-calypso/pull/7504, but a regression brought the issue back.

**Before:**
![screenshot 2016-09-27 14 53 41](https://cloud.githubusercontent.com/assets/4924246/18893394/985932ca-84c2-11e6-9d10-1afbd0c78844.png)

**After:**
![screenshot 2016-09-27 14 57 07](https://cloud.githubusercontent.com/assets/4924246/18893434/be516e02-84c2-11e6-8bc9-7d70e52ef592.png)

/cc @bluefuton 
