### PR TITLE
Image Editor: disable for Jetpack

### DIFF
--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -18,6 +18,7 @@ var EditorMediaModalDetailFields = require( './detail-fields' ),
 	Button = require( 'components/button' ),
 	Gridicon = require( 'components/gridicon' ),
 	userCan = require( 'lib/site/utils' ).userCan,
+	isJetpack = require( 'lib/site/utils' ).isJetpack,
 	MediaUtils = require( 'lib/media/utils' ),
 	config = require( 'config' );
 
@@ -62,6 +63,7 @@ module.exports = React.createClass( {
 		if (
 			! config.isEnabled( 'post-editor/image-editor' ) ||
 			! userCan( 'upload_files', site ) ||
+			isJetpack( site ) ||
 			this.isMobileTouchDevice() ||
 			! item
 		) {


### PR DESCRIPTION
Somewhat addresses #8214.

Because Jetpack does not provide proper endpoints to save the image, for now we are disabling image editor functionality for jetpack now 😢 

## Testing

- Open image details for public non-jetpack site
- See "Edit image" button
- Open image details for public jetpack connected site where you are an admin
- See that there is no "Edit image" button

CC @gwwar @lamosty @retrofox 