### PR TITLE
Support: Update live course schedule

### DIFF
--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -31,16 +31,20 @@ function getCourses() {
 			),
 			schedule: [
 				{
-					date: i18n.moment( new Date( 'Fri, 23 Sep 2016 18:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/732df6652d490ab0dc2040ba88984b7b'
+					date: i18n.moment( new Date( 'Tues, 4 Oct 2016 16:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/0f18c67948202a1f7510d14dfea9e911'
 				},
 				{
-					date: i18n.moment( new Date( 'Tue, 27 Sep 2016 17:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/c14f7c38c388111466858a512be5123a'
+					date: i18n.moment( new Date( 'Thur, 6 Oct 2016 20:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/2389ab7d02e4772d8c34be5db4a05ad8'
 				},
 				{
-					date: i18n.moment( new Date( 'Thur, 29 Sep 2016 20:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/e70a34c1ca8c13dac5b9141539e44ee6'
+					date: i18n.moment( new Date( 'Tues, 11 Oct 2016 16:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/c9f211b28c427b6066858a512be5123a'
+				},
+				{
+					date: i18n.moment( new Date( 'Thur, 13 Oct 2016 20:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/8aa25fd3a2bda6a28c34be5db4a05ad8'
 				},
 			],
 			videos: [


### PR DESCRIPTION
This PR seeks to remove past dates and update the live courses page with future dates. See the comment section here for discussion p7DVsv-w1-p2. The dates and URLs should match this (along with the existing 9/29 course):

- Tuesday 10/4 @ 9am PDT:
https://zoom.us/webinar/register/0f18c67948202a1f7510d14dfea9e911
- Thursday 10/6 @ 1pm PDT:
https://zoom.us/webinar/register/2389ab7d02e4772d8c34be5db4a05ad8
- Tuesday 10/11 @ 9am PDT:
https://zoom.us/webinar/register/c9f211b28c427b6066858a512be5123a
- Thursday 10/13 @ 1pm PDT:
https://zoom.us/webinar/register/8aa25fd3a2bda6a28c34be5db4a05ad8

To test, load up this branch and visit wordpress.com/help/courses on an account with a Business upgrade. You should see the dates and times localized to your timezone:

<img width="724" alt="screen shot 2016-09-27 at 4 20 53 pm" src="https://cloud.githubusercontent.com/assets/7240478/18894890/e886cef0-84d2-11e6-92ad-855a0a75e2b3.png">