### PR TITLE
Media: wrap selected detail index in getter

### DIFF
--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -38,6 +38,10 @@ const MediaUtils = {
 	 * @return {string}         URL to the media
 	 */
 	url: function( media, options ) {
+		if ( ! media ) {
+			return;
+		}
+
 		if ( media.transient ) {
 			return media.URL;
 		}

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -157,9 +157,9 @@ module.exports = React.createClass( {
 		if ( 1 === this.props.mediaLibrarySelectedItems.length ) {
 			// If this is the only selected item, return user to the list
 			this.setView( ModalViews.LIST );
-		} else if ( this.state.detailSelectedIndex === this.props.mediaLibrarySelectedItems.length - 1 ) {
+		} else if ( this.getDetailSelectedIndex() === this.props.mediaLibrarySelectedItems.length - 1 ) {
 			// If this is the last selected item, decrement to the previous
-			this.setDetailSelectedIndex( this.state.detailSelectedIndex - 1 );
+			this.setDetailSelectedIndex( Math.max( this.getDetailSelectedIndex() - 1, 0 ) );
 		}
 	},
 
@@ -172,7 +172,7 @@ module.exports = React.createClass( {
 
 		let toDelete = mediaLibrarySelectedItems;
 		if ( ModalViews.DETAIL === this.state.activeView ) {
-			toDelete = toDelete[ this.state.detailSelectedIndex ];
+			toDelete = toDelete[ this.getDetailSelectedIndex() ];
 			this.setNextAvailableDetailView();
 		}
 
@@ -215,12 +215,21 @@ module.exports = React.createClass( {
 	},
 
 	onImageEditorCancel: function() {
-		const item = this.props.mediaLibrarySelectedItems[ this.state.detailSelectedIndex ];
+		const item = this.props.mediaLibrarySelectedItems[ this.getDetailSelectedIndex() ];
 		if ( ! item ) {
 			this.setView( ModalViews.LIST );
 			return;
 		}
 		this.setView( ModalViews.DETAIL );
+	},
+
+	getDetailSelectedIndex() {
+		const { mediaLibrarySelectedItems } = this.props;
+		const { detailSelectedIndex } = this.state;
+		if ( detailSelectedIndex >= mediaLibrarySelectedItems.length ) {
+			return 0;
+		}
+		return detailSelectedIndex;
 	},
 
 	onFilterChange: function( filter ) {
@@ -367,7 +376,7 @@ module.exports = React.createClass( {
 					<MediaModalDetail
 						site={ this.props.site }
 						items={ this.props.mediaLibrarySelectedItems }
-						selectedIndex={ this.state.detailSelectedIndex }
+						selectedIndex={ this.getDetailSelectedIndex() }
 						onSelectedIndexChange={ this.setDetailSelectedIndex }
 						onChangeView={ this.setView }
 						onEdit={ this.setView.bind( this, ModalViews.IMAGE_EDITOR ) } />
@@ -390,7 +399,7 @@ module.exports = React.createClass( {
 					<MediaModalImageEditor
 						site={ this.props.site }
 						items={ this.props.mediaLibrarySelectedItems }
-						selectedIndex={ this.state.detailSelectedIndex }
+						selectedIndex={ this.getDetailSelectedIndex() }
 						onImageEditorClose={ this.onImageEditorClose }
 						onImageEditorCancel={ this.onImageEditorCancel }
 					/>


### PR DESCRIPTION
Fixes #8005 where the media modal would become unresponsive if the `detailSelectedIndex` is out of bounds in all selected items ( `mediaLibrarySelectedItems` ). This can get out of sync because `detailSelectedIndex` is component state, and any selections/deselections on media items updates the `mediaLibrarySelectedItems` list but not the `detailSelectedIndex`.

#### Steps to reproduce
1. Starting at URL: https://calypso.localhost:300/post
2. Select a site
3. Click the Add Media button
4. Select two or more images and click Edit at the bottom left
5. Click the right arrow to proceed to the next image
6. Click the Media Library return button at the upper left
7. Deselect one of the images
8. Attempt to edit the remaining image
9. Attempt to cancel the media modal

cc @hoverduck @aduth @lamosty @artpi @retrofox 