### PR TITLE
Fix schema validation error

### DIFF
--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -4,7 +4,6 @@
 import { combineReducers } from 'redux';
 import debugFactory from 'debug';
 import omit from 'lodash/omit';
-import pick from 'lodash/pick';
 
 /**
  * Internal dependencies
@@ -108,7 +107,9 @@ function system( state = {}, action ) {
 			}
 
 			return Object.assign( {}, state, {
-				wpcomSubscription: Object.assign( {}, pick( data, [ 'ID', 'settings' ] ) )
+				wpcomSubscription: {
+					ID: data.ID.toString(),
+					settings: data.settings }
 			} );
 		}
 	}

--- a/client/state/push-notifications/test/reducer.js
+++ b/client/state/push-notifications/test/reducer.js
@@ -9,13 +9,13 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	SERIALIZE,
-	DESERIALIZE
+	DESERIALIZE,
+	PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE
 } from 'state/action-types';
 import reducer, {} from '../reducer';
 
 const wpcomSubscription = {
 	ID: '42',
-	lastUpdated: '2016-06-16T14:41:09+02:00',
 	settings: {
 		comments: {
 			desc: 'Comments',
@@ -81,6 +81,19 @@ describe( 'system reducer', () => {
 		expect( newState.system ).to.eql( {
 			wpcomSubscription: wpcomSubscriptionId,
 		} );
+	} );
+
+	it( 'should accept an integer for wpcomSubscription ID and store it as string', () => {
+		const action = {
+			type: PUSH_NOTIFICATIONS_RECEIVE_REGISTER_DEVICE,
+			data: {
+				ID: parseInt( wpcomSubscription.ID ),
+				settings: wpcomSubscription.settings
+			}
+		};
+		const newState = reducer( {}, action );
+
+		expect( newState.system ).to.eql( { wpcomSubscription } );
 	} );
 } );
 


### PR DESCRIPTION
This PR seeks to fix a browser push notification schema validation error.

### Testing instructions

Follow these steps in Firefox and Chrome:

1. Load https://calypso.live/?branch=fix/browser-notifications-schema-validation-error
2. Make sure Calypso debugging is enabled. To turn on debug mode for all modules, type the following in the browser console: `localStorage.setItem( 'debug', '*' );`
2. Disable browser notifications in `/me/notifications`
3. Enable notifications
4. Verify in the console that you do not get messages with 'state validation failed' or 'INVALID system state'
5. Reload the `/me/notifications` page
6. Verify in the console that you do not get messages with 'state validation failed' or 'INVALID system state'