### PR TITLE
Fix/reader/stream featured image size

### DIFF
--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -58,7 +58,7 @@ export default class FeaturedAsset extends React.Component {
 
 		return (
 			<div
-				className="reader-full-post__featured-image" >
+				className="reader__post-featured-image" >
 				{
 				! this.state.suppressFeaturedImage
 				? <img className="reader__post-featured-image-image"

--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -64,7 +64,6 @@ export default class FeaturedAsset extends React.Component {
 				? <img className="reader__post-featured-image-image"
 						ref="featuredImage"
 						src={ this.props.featuredImage }
-						style={ this.props.featuredSize }
 						onError={ this.handleImageError }
 					/>
 				: null

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -39,7 +39,6 @@ const
 	utils = require( 'reader/utils' ),
 	PostCommentHelper = require( 'reader/comments/helper' ),
 	LikeHelper = require( 'reader/like-helper' ),
-	EmbedHelper = require( 'reader/embed-helper' ),
 	readerRoute = require( 'reader/route' ),
 	stats = require( 'reader/stats' ),
 	PostPermalink = require( 'reader/post-permalink' ),
@@ -173,8 +172,7 @@ const Post = React.createClass( {
 			featuredEmbed = head( filter( post.content_embeds, ( embed ) => {
 				return ! startsWith( embed.type, 'special-' );
 			} ) ),
-			maxWidth = Math.min( 653, window.innerWidth ),
-			featuredSize, useFeaturedEmbed;
+			useFeaturedEmbed;
 
 		if ( post.use_excerpt ) {
 			// don't feature embeds for excerpts
@@ -191,23 +189,9 @@ const Post = React.createClass( {
 		//
 		useFeaturedEmbed = featuredEmbed &&
 			( ! featuredImage || ( featuredImage !== post.featured_image && featuredImage !== get( post, 'post_thumbnail.URL' ) ) );
-		if ( useFeaturedEmbed ) {
-			this.featuredSizingStrategy = EmbedHelper.getEmbedSizingFunction( featuredEmbed );
-		} else if ( featuredImage && post.canonical_image.width >= maxWidth ) {
-			this.featuredSizingStrategy = function featuredImageSizingFunction( availible ) {
-				var aspectRatio = post.canonical_image.width / post.canonical_image.height;
 
-				return {
-					width: availible + 'px',
-					height: Math.floor( availible / aspectRatio ) + 'px'
-				};
-			};
-
-			featuredSize = this.getFeaturedSize( maxWidth );
-		}
 		const featuredAssetProps = {
 			featuredImage,
-			featuredSize,
 			featuredEmbed,
 			useFeaturedEmbed
 		};


### PR DESCRIPTION
Fixes #8265 

We are setting the featured image/embed width property to `auto !important` [here](https://github.com/Automattic/wp-calypso/blob/master/client/reader/stream/_style.scss#L223) so the sizing strategy was not being applied.

The issue showed up due to an incorrect class name.

This fixes the class name and removes the unnecessary sizing strategy. 