### PR TITLE
Site Settings: Fix unknown prop warnings in PressThisLink

### DIFF
--- a/client/my-sites/site-settings/press-this-link.jsx
+++ b/client/my-sites/site-settings/press-this-link.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,8 +85,9 @@ class PressThisLink extends React.Component {
 	}
 
 	render() {
+		const omitProps = [ 'site' ];
 		return (
-			<a {...this.props} href={ this.buildPressThisLink() }>
+			<a { ...omit( this.props, omitProps ) } href={ this.buildPressThisLink() }>
 				{ this.props.children }
 			</a>
 		);


### PR DESCRIPTION
This PR clears JS warnings emitted by the `PressThisLink` component - they were caused by unnecessary props being specified to the `<a />` tag. 

Note: this PR is part of the unknown prop warning resolve PR series: #7413.

To test:

* Checkout this branch.
* Go to `/settings/writing/$site`.
* Verify that there are no JS warnings caused by `PressThisLink`.

/cc @aduth