### PR TITLE
Add/webpack dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ install: node_modules
 
 # Simply running `make run` will spawn the Node.js server instance.
 run: welcome githooks install build
-	@$(NODE) build/bundle-$(CALYPSO_ENV).js
+	@$(NODE_BIN)/webpack-dashboard -- $(NODE) build/bundle-$(CALYPSO_ENV).js
 
 # a helper rule to ensure that a specific module is installed,
 # without relying on a generic `npm install` command

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ install: node_modules
 
 # Simply running `make run` will spawn the Node.js server instance.
 run: welcome githooks install build
-	@$(NODE_BIN)/webpack-dashboard -- $(NODE) build/bundle-$(CALYPSO_ENV).js
+	@$(NODE_BIN)/webpack-dashboard -m -- $(NODE) build/bundle-$(CALYPSO_ENV).js
 
 # a helper rule to ensure that a specific module is installed,
 # without relying on a generic `npm install` command

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,10 @@ install: node_modules
 
 # Simply running `make run` will spawn the Node.js server instance.
 run: welcome githooks install build
-	@$(NODE_BIN)/webpack-dashboard -m -- $(NODE) build/bundle-$(CALYPSO_ENV).js
+	@$(NODE) build/bundle-$(CALYPSO_ENV).js
+
+dashboard:
+	@$(NODE_BIN)/webpack-dashboard -- make run
 
 # a helper rule to ensure that a specific module is installed,
 # without relying on a generic `npm install` command

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can try out the user-side of Calypso on [WordPress.com](https://wordpress.co
 1.	Make sure you have `git`, `node`, and `npm` installed.
 2.	Clone this repository locally.
 3.	Add `127.0.0.1 calypso.localhost` to your local hosts file.
-4.	Execute `make run` from the root directory of the repository.
+4.	Execute `make run` or `make dashboard` (for a more visually-oriented interface) from the root directory of the repository.
 5.	Open `calypso.localhost:3000` in your browser.
 
 Need more detailed installation instructions? [We have them](docs/install.md).

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -436,6 +436,9 @@
         }
       }
     },
+    "blessed": {
+      "version": "0.1.81"
+    },
     "blob": {
       "version": "0.0.4"
     },
@@ -742,6 +745,9 @@
     },
     "creditcards": {
       "version": "1.1.1"
+    },
+    "cross-spawn": {
+      "version": "4.0.2"
     },
     "cross-spawn-async": {
       "version": "2.2.4"
@@ -1290,7 +1296,7 @@
       "version": "2.1.1"
     },
     "fbjs": {
-      "version": "0.8.4",
+      "version": "0.8.5",
       "dependencies": {
         "core-js": {
           "version": "1.2.7"
@@ -1413,7 +1419,7 @@
       "version": "2.6.0"
     },
     "gaze": {
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     "generate-function": {
       "version": "2.0.0"
@@ -3589,6 +3595,52 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4"
+        }
+      }
+    },
+    "webpack-dashboard": {
+      "version": "0.2.0",
+      "dependencies": {
+        "accepts": {
+          "version": "1.1.4"
+        },
+        "commander": {
+          "version": "2.9.0"
+        },
+        "engine.io": {
+          "version": "1.6.11"
+        },
+        "engine.io-client": {
+          "version": "1.6.11",
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.1.2"
+            },
+            "ws": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "filesize": {
+          "version": "3.3.0"
+        },
+        "mime-db": {
+          "version": "1.12.0"
+        },
+        "mime-types": {
+          "version": "2.0.14"
+        },
+        "negotiator": {
+          "version": "0.4.9"
+        },
+        "socket.io": {
+          "version": "1.4.8"
+        },
+        "socket.io-client": {
+          "version": "1.4.8"
+        },
+        "ws": {
+          "version": "1.1.0"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "socket.io": "1.4.5",
     "stylelint": "^6.5.1",
     "supertest": "^1.1.0",
+    "webpack-dashboard": "0.2.0",
     "webpack-dev-server": "1.11.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,8 @@
  * External dependencies
  */
 var webpack = require( 'webpack' ),
-	path = require( 'path' );
+	path = require( 'path' ),
+	DashboardPlugin = require('webpack-dashboard/plugin');
 
 /**
  * Internal dependencies
@@ -80,6 +81,7 @@ webpackConfig = {
 		fs: 'empty'
 	},
 	plugins: [
+		new DashboardPlugin(),
 		new webpack.DefinePlugin( {
 			'process.env': {
 				NODE_ENV: JSON.stringify( config( 'env' ) )


### PR DESCRIPTION
Replaces #7476 

See: https://github.com/FormidableLabs/webpack-dashboard

This PR is an attempt to start using the new webpack dashboard plugin
which organizes the webpack output into a windowed console UI, showing
additional information beyond build status such as bundle and asset
sizes and also clean error messages.

The updated dashboard communicates to **webpack** via sockets and has resolved most of the issues preventing me from incorporating it earlier (stdout output).

There are two display modes: the standard mode shows bundle sizes and modules while the minified mode hides these. I have chosen the minimal mode as the default thinking it makes a better use of screen space for most development operations. For some time I tried to allow some command-line environment-variable override but I could not get this working how I wanted to in the `Makefile`

If someone with better **Make** skills than I have would like to clean this up it would help considerably. In the meantime, in order to see the more verbose output, one can simply remove the `-m` from the `Makefile` inside of the `run:` target.

Additionally we could create a second make target but that didn't seem appropriate here.

**Minimum Dashboard**
![minimumdashboard](https://cloud.githubusercontent.com/assets/5431237/18902760/d5eb7e3a-8509-11e6-8cb0-649eeeddaa56.gif)

**Verbose Dashboard**
![verbosedashboard](https://cloud.githubusercontent.com/assets/5431237/18902772/e76f1202-8509-11e6-9f89-880a726eea83.gif)

cc: @aduth @blowery @mtias