### PR TITLE
Components: Omit submitting prop from FormPasswordInput input spread

### DIFF
--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -50,7 +50,7 @@ module.exports = React.createClass( {
 
 		return (
 			<div className="form-password-input">
-				<FormTextInput { ...omit( this.props, 'hideToggle' ) }
+				<FormTextInput { ...omit( this.props, 'hideToggle', 'submitting' ) }
 					autoComplete="off"
 					ref="textField"
 					type={ this.hidden() ? 'password' : 'text' } />


### PR DESCRIPTION
This PR clears some more JS warnings emitted by the `FormTextInput` component - caused by the `submitting` prop being spread to the `<input />` tag. This is a continuation of #7411.

Note: this PR is part of the unknown prop warning resolve PR series: #7413.

To test:

* Checkout this branch.
* Go to `/me/security`.
* Verify that there are no JS warnings caused by `FormTextInput`.

/cc @aduth