### PR TITLE
Plugins: Remove release date from plugin detail page placeholder

### DIFF
--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -156,7 +156,6 @@ export default React.createClass( {
 									? <Version version={ this.props.pluginVersion } icon="plugins" className="plugin-information__version" />
 									: null
 								}
-								{ this.renderLastUpdated() }
 							</div>
 							<div className="plugin-information__version-shell">
 								{ this.renderSiteVersion() }


### PR DESCRIPTION
This PR removes the last updated/released date from the plugin detail page placeholder, as reported in #8225. 

How the placeholder looks after the change:
![](https://cldup.com/xB6MYDMHGv.thumb.jpg)

/cc @rickybanister

Fixes #8225.