### PR TITLE
Components: Omit unnecessary props from Shortcode iframe spread

### DIFF
--- a/client/components/resizable-iframe/index.jsx
+++ b/client/components/resizable-iframe/index.jsx
@@ -166,7 +166,7 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		const omitProps = [ 'siteId', 'shortcode', 'filterRenderResult', 'styles', 'onResize' ];
+		const omitProps = [ 'onResize' ];
 		return (
 			<iframe
 				ref="iframe"

--- a/client/components/resizable-iframe/index.jsx
+++ b/client/components/resizable-iframe/index.jsx
@@ -4,6 +4,7 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import debugFactory from 'debug';
+import { omit } from 'lodash';
 
 /**
  * Globals
@@ -70,7 +71,7 @@ export default React.createClass( {
 			return;
 		}
 
-		let script = document.createElement( 'script' );
+		const script = document.createElement( 'script' );
 		script.innerHTML = `
 			( function() {
 				var observer;
@@ -165,10 +166,11 @@ export default React.createClass( {
 	},
 
 	render: function() {
+		const omitProps = [ 'siteId', 'shortcode', 'filterRenderResult', 'styles', 'onResize' ];
 		return (
 			<iframe
 				ref="iframe"
-				{ ...this.props }
+				{ ...omit( this.props, omitProps ) }
 				onLoad={ this.onLoad }
 				width={ this.props.width || this.state.width }
 				height={ this.props.height || this.state.height } />

--- a/client/components/shortcode/data.jsx
+++ b/client/components/shortcode/data.jsx
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import { cloneElement, Component, PropTypes } from 'react';
 import { Container } from 'flux/utils';
 import pick from 'lodash/pick';
 
 /**
  * Internal dependencies
  */
-import passToChildren from 'lib/react-pass-to-children';
 import ShortcodesStore from 'lib/shortcodes/store';
 
 class ShortcodeData extends Component {
@@ -25,8 +24,9 @@ class ShortcodeData extends Component {
 	}
 
 	render() {
+		const { children, filterRenderResult } = this.props;
 		const props = pick( this.state.data, 'body', 'scripts', 'styles' );
-		return passToChildren( this, this.props.filterRenderResult( props ) );
+		return cloneElement( children, filterRenderResult( props ) );
 	}
 }
 

--- a/client/components/shortcode/frame.jsx
+++ b/client/components/shortcode/frame.jsx
@@ -79,7 +79,7 @@ export default React.createClass( {
 		return (
 			<ResizableIframe
 				key={ key }
-				{ ...omit( this.props, 'body', 'scripts', 'style', 'siteId', 'shortcode', 'filterRenderResult', 'styles' ) }
+				{ ...omit( this.props, 'body', 'scripts', 'styles' ) }
 				src="https://wpcomwidgets.com/render/"
 				onLoad={ this.onFrameLoad }
 				frameBorder="0"

--- a/client/components/shortcode/frame.jsx
+++ b/client/components/shortcode/frame.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import generateEmbedFrameMarkup from 'lib/embed-frame-markup';
-import ResizableIframe from 'components/resizable-iframe'
+import ResizableIframe from 'components/resizable-iframe';
 
 export default React.createClass( {
 	displayName: 'ShortcodeFrame',
@@ -26,7 +26,7 @@ export default React.createClass( {
 	getDefaultProps() {
 		return {
 			onLoad: () => {}
-		}
+		};
 	},
 
 	getInitialState: function() {
@@ -79,7 +79,7 @@ export default React.createClass( {
 		return (
 			<ResizableIframe
 				key={ key }
-				{ ...omit( this.props, 'body', 'scripts', 'style' ) }
+				{ ...omit( this.props, 'body', 'scripts', 'style', 'siteId', 'shortcode', 'filterRenderResult', 'styles' ) }
 				src="https://wpcomwidgets.com/render/"
 				onLoad={ this.onFrameLoad }
 				frameBorder="0"


### PR DESCRIPTION
This PR clears some JS warnings emitted by the `ResizableIframe` component - caused by several props being spread to the `<iframe />` tag. It also fixes a minor ESLint warning.

Note: this PR is part of the unknown prop warning resolve PR series: #7413.

To test:

* Checkout this branch.
* Go to `/post/$site/$postId`, where `$site` is one of your sites, and `$postId` is the ID of a post that has a gallery shortcode with several images.
* Verify that there are no JS warnings caused by `ResizableIframe`.

/cc @aduth