### PR TITLE
Chat component: Add contrast to links

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -284,10 +284,25 @@
 	padding: 0 8px;
 	margin: 6px 0;
 
+	a {
+		color: lighten( $blue-light, 10% );
+		text-decoration: underline;
+	}
+
+	a:hover {
+		text-decoration: none;
+	}
+
 	&.is-user-message {
 		flex-direction: row;
 		margin-left: auto;
+
+		a {
+			color: $blue-medium;
+		}
+
 	}
+
 }
 
 .support-browser {
@@ -371,22 +386,22 @@
 			box-shadow: 0 1px 2px rgba( 0,0,0,.2 ), 0 1px 10px rgba( 0,0,0, .1 );
 			width: 280px;
 		}
-	
+
 		.happychat__container.is-open .happychat__title {
 			height: 32px;
 			line-height: 32px;
 			border-radius: 0;
-	
+
 			.happychat__active-toolbar {
-		
+
 				> div {
 					padding: 4px 11px;
 				}
-		
+
 			}
-	
+
 		}
-	
+
 		.happychat__message {
 			height: 48px;
 		}
@@ -394,7 +409,7 @@
 		.happychat__message > textarea {
 			padding: 12px;
 		}
-	
+
 		.happychat__conversation {
 			min-height: 160px;
 			max-height: 220px;
@@ -403,4 +418,3 @@
 	}
 
 }
-

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -2,7 +2,6 @@
  * Live Chat
  */
 
-
 .happychat__title {
 	cursor: pointer;
 	padding: 0 12px;
@@ -41,10 +40,10 @@
 
 }
 
+
 /**
  * Base styles
  */
-
 
 .happychat__container {
 	overflow: hidden;
@@ -188,7 +187,6 @@
 	&:hover {
 		background: lighten( $blue-medium, 10% );
 	}
-
 }
 
 .happychat__timeline-join-message {
@@ -251,7 +249,6 @@
 			border-right: 6px solid transparent;
 		}
 	}
-
 }
 
 .happychat__message-meta {
@@ -274,7 +271,6 @@
 		width: 100%;
 		height: auto;
 	}
-
 }
 
 .happychat__timeline-message {
@@ -302,7 +298,6 @@
 		}
 
 	}
-
 }
 
 .support-browser {
@@ -330,8 +325,8 @@
 		height: 100%;
 		background: hsla( 0, 0%, 0%, 0.1 );
 	}
-
 }
+
 
 /**
  * Sidebar mode
@@ -371,7 +366,6 @@
 	.has-chat.is-group-editor .layout__content {
 		padding: 0 304px 0 0;
 	}
-
 }
 
 
@@ -416,5 +410,4 @@
 		}
 
 	}
-
 }


### PR DESCRIPTION
This is a tiny PR to adjust the link colors for responses in the chat to show more contrast against their background.

Instructions:

- `make run` Calypso
- Open "Support Chat" in the bottom of the sidebar
- Type a message
- In a separate browser window, as a proxied Automattician, log into https://happychat.io, pick up the chat
- Type out a hyperlink as a chat message
- Tab back to the Calypso tab and verify link contrast is legible in the blue chat bubble from Support

Screenshot: 

![screen shot 2016-09-28 at 16 17 34](https://cloud.githubusercontent.com/assets/1204802/18917125/18f71dbe-8597-11e6-80b3-653f03fba77a.png)
