### PR TITLE
Signup: AB test Site Title step

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -117,9 +117,10 @@ module.exports = {
 	siteTitleStep: {
 		datestamp: '20160928',
 		variations: {
-			showSiteTitleStep: 95,
-			hideSiteTitleStep: 5,
+			showSiteTitleStep: 5,
+			hideSiteTitleStep: 95,
 		},
-		defaultVariation: 'hideSiteTitleStep'
+		defaultVariation: 'hideSiteTitleStep',
+		allowExistingUsers: false
 	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -113,5 +113,12 @@ module.exports = {
 		},
 		defaultVariation: 'current',
 		allowExistingUsers: true
+	siteTitleStep: {
+		datestamp: '20160928',
+		variations: {
+			showSiteTitleStep: 95,
+			hideSiteTitleStep: 5,
+		},
+		defaultVariation: 'hideSiteTitleStep'
 	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -113,6 +113,7 @@ module.exports = {
 		},
 		defaultVariation: 'current',
 		allowExistingUsers: true
+	},
 	siteTitleStep: {
 		datestamp: '20160928',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -297,10 +297,11 @@ const Flows = {
 		// Only do this on the main flow
 		if ( 'main' === flowName ) {
 			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
-
-				// insert `site-title` step in the flow, after `survey`
-				const indexOfSurvey = updatedFlow.steps.indexOf( 'survey' );
-				updatedFlow.steps.splice( indexOfSurvey + 1, 0, 'site-title' );
+				if ( -1 === updatedFlow.steps.indexOf( 'site-title' )) {
+					// insert `site-title` step in the flow, after `survey`
+					const indexOfSurvey = updatedFlow.steps.indexOf( 'survey' );
+					updatedFlow.steps.splice( indexOfSurvey + 1, 0, 'site-title' );
+				}
 			}
 		}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -9,7 +9,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
@@ -238,11 +238,41 @@ const Flows = {
 			flow = filterDesignTypeInFlow( flow );
 		}
 
-		return flow;
+		return Flows.getABTestFilteredFlow( flowName, flow );
 	},
 
 	getFlows() {
 		return flows;
+	},
+
+	/**
+	 * Return a flow that is modified according to the ABTest rules.
+	 *
+	 * Useful when testing new steps in the signup flows.
+	 *
+	 * Example usage: Inject or remove a step in the flow if a user is part of an ABTest.
+	 *
+	 * @param {String} flowName The current flow name
+	 * @param {Object} flow The flow object
+	 */
+	getABTestFilteredFlow( flowName, flow ){
+		const updatedFlow = Object.assign( {}, flow );
+
+		/**
+		 * Filter according to running ABTests
+		 */
+
+		// Only do this on the main flow
+		if ( 'main' === flowName ) {
+			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
+
+				// insert `site-title` step in the flow, after `survey`
+				const indexOfSurvey = updatedFlow.steps.indexOf( 'survey' );
+				updatedFlow.steps.splice( indexOfSurvey + 1, 0, 'site-title' );
+			}
+		}
+
+		return updatedFlow;
 	}
 };
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, includes, reject, cloneDeep } from 'lodash';
+import { assign, includes, reject } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -333,11 +333,19 @@ const Flows = {
 		if ( -1 === flow.steps.indexOf( stepName ) ) {
 			const steps = flow.steps.slice();
 			const afterStepIndex = steps.indexOf( afterStep );
-			steps.splice( afterStepIndex + 1, 0, stepName );
 
-			return {
-				...flow,
-				steps,
+			/**
+			 * Only insert the step if
+			 * `afterStep` is empty ( insert at start )
+			 * or if `afterStep` is found in the flow. ( insert after `afterStep` )
+			 */
+			if (afterStepIndex > -1 || '' === afterStep ) {
+				steps.splice( afterStepIndex + 1, 0, stepName );
+
+				return {
+					...flow,
+					steps,
+				}
 			}
 		}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -305,20 +305,22 @@ const Flows = {
 	 * @param {Object} flow The flow object
 	 */
 	getABTestFilteredFlow( flowName, flow ){
-		const updatedFlow = cloneDeep( flow );
-
 		/**
 		 * Filter according to running ABTests
 		 */
 
 		// Only do this on the main flow
 		if ( 'main' === flowName ) {
+			const updatedFlow = cloneDeep( flow );
+			
 			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
 				Flows.insertStepIntoFlow( 'survey', 'site-title', updatedFlow );
 			}
+
+			return updatedFlow;
 		}
 
-		return updatedFlow;
+		return flow;
 	},
 
 	insertStepIntoFlow( afterStep, stepName, flow ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import assign from 'lodash/assign';
-import includes from 'lodash/includes';
-import reject from 'lodash/reject';
+import { assign, includes, reject, cloneDeep } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -307,7 +305,7 @@ const Flows = {
 	 * @param {Object} flow The flow object
 	 */
 	getABTestFilteredFlow( flowName, flow ){
-		const updatedFlow = Object.assign( {}, flow );
+		const updatedFlow = cloneDeep( flow );
 
 		/**
 		 * Filter according to running ABTests

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -305,7 +305,7 @@ const Flows = {
 	},
 
 	insertStepIntoFlow( afterStep, stepName, flow ) {
-		if ( - 1 === flow.steps.indexOf( stepName ) ) {
+		if ( -1 === flow.steps.indexOf( stepName ) ) {
 			const afterStepIndex = flow.steps.indexOf( afterStep );
 			flow.steps.splice( afterStepIndex + 1, 0, stepName );
 		}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -226,6 +226,7 @@ const Flows = {
 	filterDestination,
 
 	defaultFlowName: 'main',
+	resumingFlow: false,
 
 	getFlow( flowName ) {
 		let flow = Flows.getFlows()[ flowName ];
@@ -243,6 +244,37 @@ const Flows = {
 
 	getFlows() {
 		return flows;
+	},
+
+	/**
+	 * Preload AB Test variations after a certain step has been completed.
+	 *
+	 * This gives the option to set the AB variation as late as possible in the
+	 * signup flow.
+	 *
+	 * Currently only the `main` flow is whitelisted.
+	 *
+	 * @param {String} flowName The current flow
+	 * @param {String} stepName The step that is being completed right now
+	 */
+	preloadABTestVariationsForStep( flowName, stepName ) {
+
+		/**
+		 * In cases where the flow is being resumed, the flow must not be changed from what the user
+		 * has seen before.
+		 *
+		 * E.g. A user is resuming signup from before the test was added. There is no need
+		 * to add a step somewhere back in the line.
+		 */
+		if ( Flows.resumingFlow ) {
+			return;
+		}
+
+		if ( 'main' === flowName ) {
+			if ( 'survey' === stepName ) {
+				abtest( 'siteTitleStep' );
+			}
+		}
 	},
 
 	/**

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -228,7 +228,20 @@ const Flows = {
 	defaultFlowName: 'main',
 	resumingFlow: false,
 
-	getFlow( flowName ) {
+	/**
+	 * Get certain flow from the flows configuration.
+	 *
+	 * The returned flow is modified according to several filters here.
+	 *
+	 * `currentStepName` is the current step in the signup flow. It is used
+	 * to determine if any AB variations should be assigned after it is completed.
+	 * Example use case: To determine if a new signup step should be part of the flow or not.
+	 *
+	 * @param {String} flowName The name of the flow to return
+	 * @param {String} currentStepName The current step. See description above
+	 * @returns {Object} A flow object
+	 */
+	getFlow( flowName, currentStepName = '' ) {
 		let flow = Flows.getFlows()[ flowName ];
 
 		if ( user.get() ) {
@@ -237,6 +250,12 @@ const Flows = {
 
 		if ( ! user.get() && 'en' === i18n.getLocaleSlug() ) {
 			flow = filterDesignTypeInFlow( flow );
+		}
+
+		if ( ! user.get() ) {
+			// Preload the AB tests before going forward in the flow.
+			// Only valid for logged out users.
+			Flows.preloadABTestVariationsForStep( flowName, currentStepName );
 		}
 
 		return Flows.getABTestFilteredFlow( flowName, flow );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -91,7 +91,7 @@ const flows = {
 		lastModified: '2016-05-23'
 	},
 
-	'sitetitle': {
+	sitetitle: {
 		steps: [ 'survey', 'site-title', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
@@ -229,7 +229,7 @@ const Flows = {
 	/**
 	 * Get certain flow from the flows configuration.
 	 *
-	 * The returned flow is modified according to several filters here.
+	 * The returned flow is modified according to several filters.
 	 *
 	 * `currentStepName` is the current step in the signup flow. It is used
 	 * to determine if any AB variations should be assigned after it is completed.
@@ -250,11 +250,7 @@ const Flows = {
 			flow = filterDesignTypeInFlow( flow );
 		}
 
-		if ( ! user.get() ) {
-			// Preload the AB tests before going forward in the flow.
-			// Only valid for logged out users.
-			Flows.preloadABTestVariationsForStep( flowName, currentStepName );
-		}
+		Flows.preloadABTestVariationsForStep( flowName, currentStepName );
 
 		return Flows.getABTestFilteredFlow( flowName, flow );
 	},
@@ -275,7 +271,6 @@ const Flows = {
 	 * @param {String} stepName The step that is being completed right now
 	 */
 	preloadABTestVariationsForStep( flowName, stepName ) {
-
 		/**
 		 * In cases where the flow is being resumed, the flow must not be changed from what the user
 		 * has seen before.
@@ -303,12 +298,10 @@ const Flows = {
 	 *
 	 * @param {String} flowName The current flow name
 	 * @param {Object} flow The flow object
+	 *
+	 * @return {Object} A filtered flow object
 	 */
-	getABTestFilteredFlow( flowName, flow ){
-		/**
-		 * Filter according to running ABTests
-		 */
-
+	getABTestFilteredFlow( flowName, flow ) {
 		// Only do this on the main flow
 		if ( 'main' === flowName ) {
 			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
@@ -327,9 +320,9 @@ const Flows = {
 	 * @param {String} afterStep After which step to insert the new step.
 	 * 							 If left blank, the step will be added in the beginning.
 	 *
-	 * @returns {Object}
+	 * @returns {Object} A flow object with inserted step
 	 */
-	insertStepIntoFlow( stepName, flow, afterStep = '') {
+	insertStepIntoFlow( stepName, flow, afterStep = '' ) {
 		if ( -1 === flow.steps.indexOf( stepName ) ) {
 			const steps = flow.steps.slice();
 			const afterStepIndex = steps.indexOf( afterStep );
@@ -339,13 +332,13 @@ const Flows = {
 			 * `afterStep` is empty ( insert at start )
 			 * or if `afterStep` is found in the flow. ( insert after `afterStep` )
 			 */
-			if (afterStepIndex > -1 || '' === afterStep ) {
+			if ( afterStepIndex > -1 || '' === afterStep ) {
 				steps.splice( afterStepIndex + 1, 0, stepName );
 
 				return {
 					...flow,
 					steps,
-				}
+				};
 			}
 		}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -311,23 +311,37 @@ const Flows = {
 
 		// Only do this on the main flow
 		if ( 'main' === flowName ) {
-			const updatedFlow = cloneDeep( flow );
-			
 			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
-				Flows.insertStepIntoFlow( 'survey', 'site-title', updatedFlow );
+				return Flows.insertStepIntoFlow( 'site-title', flow, 'survey' );
 			}
-
-			return updatedFlow;
 		}
 
 		return flow;
 	},
 
-	insertStepIntoFlow( afterStep, stepName, flow ) {
+	/**
+	 * Insert a step into the flow.
+	 *
+	 * @param {String} stepName The step to insert into the flow
+	 * @param {Object} flow The flow that the step will be inserted into
+	 * @param {String} afterStep After which step to insert the new step.
+	 * 							 If left blank, the step will be added in the beginning.
+	 *
+	 * @returns {Object}
+	 */
+	insertStepIntoFlow( stepName, flow, afterStep = '') {
 		if ( -1 === flow.steps.indexOf( stepName ) ) {
-			const afterStepIndex = flow.steps.indexOf( afterStep );
-			flow.steps.splice( afterStepIndex + 1, 0, stepName );
+			const steps = flow.steps.slice();
+			const afterStepIndex = steps.indexOf( afterStep );
+			steps.splice( afterStepIndex + 1, 0, stepName );
+
+			return {
+				...flow,
+				steps,
+			}
 		}
+
+		return flow;
 	}
 };
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -297,15 +297,18 @@ const Flows = {
 		// Only do this on the main flow
 		if ( 'main' === flowName ) {
 			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
-				if ( -1 === updatedFlow.steps.indexOf( 'site-title' )) {
-					// insert `site-title` step in the flow, after `survey`
-					const indexOfSurvey = updatedFlow.steps.indexOf( 'survey' );
-					updatedFlow.steps.splice( indexOfSurvey + 1, 0, 'site-title' );
-				}
+				Flows.insertStepIntoFlow( 'survey', 'site-title', updatedFlow );
 			}
 		}
 
 		return updatedFlow;
+	},
+
+	insertStepIntoFlow( afterStep, stepName, flow ) {
+		if ( - 1 === flow.steps.indexOf( stepName ) ) {
+			const afterStepIndex = flow.steps.indexOf( afterStep );
+			flow.steps.splice( afterStepIndex + 1, 0, stepName );
+		}
 	}
 };
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -278,10 +278,7 @@ const Signup = React.createClass( {
 	},
 
 	loadNextStep() {
-		// preload the AB tests before going forward in the flow
-		flows.preloadABTestVariationsForStep( this.props.flowName, this.props.stepName );
-
-		const flowSteps = flows.getFlow( this.props.flowName ).steps,
+		const flowSteps = flows.getFlow( this.props.flowName, this.props.stepName ).steps,
 			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
 			nextStepName = flowSteps[ currentStepIndex + 1 ],
 			nextProgressItem = this.state.progress[ currentStepIndex + 1 ],

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -240,6 +240,9 @@ const Signup = React.createClass( {
 	},
 
 	resumeProgress() {
+		// Update the Flows object to know that the signup flow is being resumed.
+		flows.resumingFlow = true;
+
 		const signupProgress = SignupProgressStore.get(),
 			lastUpdatedStep = sortBy( signupProgress, 'lastUpdated' ).reverse()[ 0 ],
 			lastUpdatedStepName = lastUpdatedStep.stepName,
@@ -275,7 +278,10 @@ const Signup = React.createClass( {
 	},
 
 	loadNextStep() {
-		var flowSteps = flows.getFlow( this.props.flowName ).steps,
+		// preload the AB tests before going forward in the flow
+		flows.preloadABTestVariationsForStep( this.props.flowName, this.props.stepName );
+
+		const flowSteps = flows.getFlow( this.props.flowName ).steps,
 			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
 			nextStepName = flowSteps[ currentStepIndex + 1 ],
 			nextProgressItem = this.state.progress[ currentStepIndex + 1 ],

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -3,7 +3,7 @@
  */
 import assert from 'assert';
 import sinon from 'sinon';
-
+import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -12,36 +12,130 @@ import useMockery from 'test/helpers/use-mockery';
 import useFakeDom from 'test/helpers/use-fake-dom';
 import mockedFlows from './fixtures/flows';
 
-describe( 'flows', function() {
-	let flows, user;
+describe( 'Signup Flows Configuration', () => {
+	describe( 'getFlow', () => {
+		let flows, user;
 
-	useFakeDom();
-	useFilesystemMocks( __dirname );
+		useFakeDom();
+		useFilesystemMocks( __dirname );
 
-	useMockery( ( mockery ) => {
-		mockery.registerMock( 'lib/abtest', {
-			abtest: () => ''
+		useMockery( ( mockery ) => {
+			mockery.registerMock( 'lib/abtest', {
+				abtest: noop,
+			} );
+		} );
+
+		before( () => {
+			user = require( 'lib/user' )();
+
+			flows = require( 'signup/config/flows' );
+			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
+			sinon.stub( flows, 'getABTestFilteredFlow', ( flowName, flow ) => {
+				return flow;
+			} );
+		} );
+
+		it( 'should return the full flow when the user is not logged in', () => {
+			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user', 'site' ] );
+		} );
+
+		it( 'should remove the user step from the flow when the user is not logged in', () => {
+			user.setLoggedIn( true );
+			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'site' ] );
+			user.setLoggedIn( false );
 		} );
 	} );
 
-	before( () => {
-		user = require( 'lib/user' )();
+	describe( 'getABTestFilteredFlow', () => {
+		let flows;
 
-		flows = require( 'signup/config/flows' );
-		sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
-		sinon.stub( flows, 'preloadABTestVariationsForStep', ()=>{} );
-		sinon.stub( flows, 'getABTestFilteredFlow', ( flowName, flow ) => {
-			return flow;
+		useFakeDom();
+		useFilesystemMocks( __dirname );
+
+		const ABTestMock = {
+			abtest: noop,
+			getABTestVariation: noop,
+		};
+
+		const getABTestVariationSpy = sinon.stub( ABTestMock, 'getABTestVariation' );
+
+		getABTestVariationSpy.onCall( 0 ).returns( 'notSiteTitle' );
+		getABTestVariationSpy.onCall( 1 ).returns( 'showSiteTitleStep' );
+
+		useMockery( ( mockery ) => {
+			mockery.registerMock( 'lib/abtest', ABTestMock );
+		} );
+
+		before( () => {
+			flows = require( 'signup/config/flows' );
+			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
+			sinon.stub( flows, 'insertStepIntoFlow', ( stepName, flow ) => {
+				return flow;
+			} );
+		} );
+
+		it( 'should return flow unmodified if not in main flow', () => {
+			assert.equal( flows.getABTestFilteredFlow( 'test', 'testflow' ), 'testflow' );
+			assert.equal( getABTestVariationSpy.callCount, 0 );
+			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
+		} );
+
+		it( 'should check AB variation in main flow', () => {
+			assert.equal( flows.getABTestFilteredFlow( 'main', 'testflow' ), 'testflow' );
+			assert.equal( getABTestVariationSpy.callCount, 1 );
+			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
+		} );
+
+		it( 'should return flow unmodified if variation is not valid', () => {
+			const myFlow = {
+				name: 'test flow name',
+				steps: [ 1, 2, 3 ]
+			};
+
+			assert.equal( flows.getABTestFilteredFlow( 'main', myFlow ), myFlow );
+			assert.equal( getABTestVariationSpy.callCount, 2 );
+			assert.equal( flows.insertStepIntoFlow.callCount, 1 );
 		} );
 	} );
 
-	it( 'should return the full flow when the user is not logged in', function() {
-		assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user', 'site' ] );
-	} );
+	describe( 'insertStepIntoFlow', () => {
+		let flows;
 
-	it( 'should remove the user step from the flow when the user is not logged in', function() {
-		user.setLoggedIn( true );
-		assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'site' ] );
-		user.setLoggedIn( false );
+		useFakeDom();
+		useFilesystemMocks( __dirname );
+
+		const myFlow = {
+			name: 'test flow name',
+			steps: [ 'step1', 'step2', 'step3', 'step4' ]
+		};
+
+		Object.freeze( myFlow );
+
+		before( () => {
+			flows = require( 'signup/config/flows' );
+		} );
+
+		it( 'should return flow unmodified if afterStep is not found', () => {
+			const result = flows.insertStepIntoFlow( 'mystep', myFlow, 'test-step' );
+
+			assert.equal( myFlow, result );
+			assert.equal( myFlow.steps, result.steps );
+		} );
+
+		it( 'should add step at the beginning of flow if afterStep is empty', () => {
+			const result = flows.insertStepIntoFlow( 'mystep', myFlow );
+
+			assert.notStrictEqual( myFlow, result );
+			assert.notStrictEqual( myFlow.steps, result.steps );
+			assert.deepEqual( [ 'mystep', 'step1', 'step2', 'step3', 'step4' ], result.steps );
+		} );
+
+		it( 'should insert step after afterStep', () => {
+			const result = flows.insertStepIntoFlow( 'mystep', myFlow, 'step2' );
+
+			assert.notStrictEqual( myFlow, result );
+			assert.notStrictEqual( myFlow.steps, result.steps );
+			assert.deepEqual( [ 'step1', 'step2', 'mystep', 'step3', 'step4' ], result.steps );
+		} );
 	} );
 } );

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -29,6 +29,7 @@ describe( 'flows', function() {
 
 		flows = require( 'signup/config/flows' );
 		sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
+		sinon.stub( flows, 'preloadABTestVariationsForStep', ()=>{} );
 		sinon.stub( flows, 'getABTestFilteredFlow', ( flowName, flow ) => {
 			return flow;
 		} );

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -29,6 +29,9 @@ describe( 'flows', function() {
 
 		flows = require( 'signup/config/flows' );
 		sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
+		sinon.stub( flows, 'getABTestFilteredFlow', ( flowName, flow ) => {
+			return flow;
+		} );
 	} );
 
 	it( 'should return the full flow when the user is not logged in', function() {

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -36,6 +36,7 @@ describe( 'utils', function() {
 		flows = require( 'signup/config/flows' );
 
 		sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
+		sinon.stub( flows, 'preloadABTestVariationsForStep', ()=>{} );
 		sinon.stub( flows, 'getABTestFilteredFlow', ( flowName, flow ) => {
 			return flow;
 		} );

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -34,7 +34,12 @@ describe( 'utils', function() {
 
 	before( () => {
 		flows = require( 'signup/config/flows' );
+
 		sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
+		sinon.stub( flows, 'getABTestFilteredFlow', ( flowName, flow ) => {
+			return flow;
+		} );
+
 		utils = require( '../utils' );
 	} );
 


### PR DESCRIPTION
This PR allows for AB test of a new Signup step, in this case the `Site Title` step.

It adds the ability to inject a step during Signup and not have the steps predefined in the beginning, before the flow has started.

How to test:

1. Checkout branch or use the Calypso.live link below.
2. Start Signup in the `main` flow: `/start/`
3. Go through Signup and see if the Site Title step appears
4. Finish Signup and see if the step is working properly, i.e. the newly created site gets the Site Title you set.
5. Reset and start from 2 :) 
6. Test a variation of the AB test without the Site Title step. This would be `hideSiteTitleStep`. 
7. In the case where the Site Title step is missing or you leave it blank/skip it, the site's tile should be set to a localized version of `Site Title`
8. Also try resuming signup at any point during signup to see how it's behaving. There shouldn't be any change to the behavior from what you were seeing.

Several things to note here:

* It would probably break if you start in the `showSiteTitleStep` variation and then later change it to `hideSiteTitleStep` variation, after you have finished the step. If you ever happen to break signup, just clear out `localStorage` and start fresh.
* The variation is set to 95% to `showSiteTitleStep`. This is just for the test and will be updated before release. Percentages TBD.

TODO:

- [x] Unit tests
- [x] Disable AB variation assignment of new steps to logged in users

cc @michaeldcain @meremagee 