### PR TITLE
Framework: Remove selected site reset in boot

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -362,17 +362,6 @@ function reduxStoreReady( reduxStore ) {
 		} );
 	}
 
-	page( '*', function( context, next ) {
-		// Reset the selected site before each route is executed. This needs to
-		// occur after the sections routes execute to avoid a brief flash where
-		// sites are reset but the next section is waiting to be loaded.
-		if ( ! route.getSiteFragment( context.path ) && sites.getSelectedSite() ) {
-			sites.resetSelectedSite();
-		}
-
-		next();
-	} );
-
 	require( 'my-sites' )();
 
 	// clear notices

--- a/client/lib/site-stats-sticky-tab/store.js
+++ b/client/lib/site-stats-sticky-tab/store.js
@@ -54,6 +54,10 @@ function saveMyPlace( tab, slug ) {
 			newPlace.tab = 'day';
 		}
 
+		if ( newPlace.slug === '' && _cachedPlace.tab === 'insights' && ! newPlace.tab ) {
+			newPlace.tab = 'day';
+		}
+
 		// Something changed, update the in-memory copy
 		_cachedPlace = merge( _cachedPlace, newPlace );
 

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -33,7 +33,6 @@ function SitesList() {
 	this.fetched = false; // false until data comes from api
 	this.fetching = false;
 	this.selected = null;
-	this.lastSelected = null;
 	this.propagateChange = this.propagateChange.bind( this );
 }
 
@@ -328,15 +327,6 @@ SitesList.prototype.getSelectedOrAll = function() {
  */
 SitesList.prototype.getSelectedSite = function() {
 	return this.getSite( this.selected );
-};
-
-/**
- * Return the last selected site or false
- *
- * @api public
- */
-SitesList.prototype.getLastSelectedSite = function() {
-	return this.getSite( this.lastSelected );
 };
 
 /**

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -340,21 +340,6 @@ SitesList.prototype.getLastSelectedSite = function() {
 };
 
 /**
- * Resets the selected site
- *
- * @api public
- */
-SitesList.prototype.resetSelectedSite = function() {
-	if ( ! this.selected ) {
-		return;
-	}
-
-	this.lastSelected = this.selected;
-	this.selected = null;
-	this.emit( 'change' );
-};
-
-/**
  * Set selected site
  *
  * @param {number} Site ID

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -70,7 +70,7 @@ module.exports = React.createClass( {
 	 * @return {Object} An object representing our initial state
 	 */
 	getInitialState: function() {
-		const site = sites.getLastSelectedSite() || sites.getPrimary();
+		const site = sites.getSelectedSite() || sites.getPrimary();
 
 		return this.props.valueLink.value || {
 			howCanWeHelp: 'gettingStarted',

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -80,6 +80,18 @@ export const HelpContactForm = React.createClass( {
 		};
 	},
 
+	componentWillReceiveProps( nextProps ) {
+		if ( ! nextProps.valueLink.value || isEqual( nextProps.valueLink.value, this.state ) ) {
+			return;
+		}
+
+		this.setState( nextProps.valueLink.value );
+	},
+
+	componentDidUpdate() {
+		this.props.valueLink.requestChange( this.state );
+	},
+
 	getSiteSlug() {
 		if ( this.props.selectedSiteSlug ) {
 			return this.props.selectedSiteSlug;
@@ -91,18 +103,6 @@ export const HelpContactForm = React.createClass( {
 		}
 
 		return null;
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.valueLink.value || isEqual( nextProps.valueLink.value, this.state ) ) {
-			return;
-		}
-
-		this.setState( nextProps.valueLink.value );
-	},
-
-	componentDidUpdate() {
-		this.props.valueLink.requestChange( this.state );
 	},
 
 	setSite( siteSlug ) {

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { isEqual, find } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -20,15 +21,14 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
 import siteList from 'lib/sites-list';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 /**
  * Module variables
  */
 const sites = siteList();
 
-module.exports = React.createClass( {
-	displayName: 'HelpContactForm',
-
+export const HelpContactForm = React.createClass( {
 	mixins: [ LinkedStateMixin, PureRenderMixin ],
 
 	propTypes: {
@@ -62,7 +62,7 @@ module.exports = React.createClass( {
 				value: null,
 				requestChange: () => {}
 			}
-		}
+		};
 	},
 
 	/**
@@ -70,15 +70,26 @@ module.exports = React.createClass( {
 	 * @return {Object} An object representing our initial state
 	 */
 	getInitialState: function() {
-		const site = sites.getSelectedSite() || sites.getPrimary();
-
 		return this.props.valueLink.value || {
 			howCanWeHelp: 'gettingStarted',
 			howYouFeel: 'unspecified',
 			message: '',
 			subject: '',
-			siteSlug: site ? site.slug : null
+			siteSlug: this.getSiteSlug()
 		};
+	},
+
+	getSiteSlug: function() {
+		if ( this.props.selectedSiteSlug ) {
+			return this.props.selectedSiteSlug;
+		}
+
+		const primarySite = sites.getPrimary();
+		if ( primarySite ) {
+			return primarySite.slug;
+		}
+
+		return null;
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
@@ -253,3 +264,9 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	return {
+		selectedSiteSlug: getSelectedSiteSlug( state )
+	};
+} )( HelpContactForm );

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { isEqual, find } from 'lodash';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -32,24 +33,24 @@ export const HelpContactForm = React.createClass( {
 	mixins: [ LinkedStateMixin, PureRenderMixin ],
 
 	propTypes: {
-		formDescription: React.PropTypes.node,
-		buttonLabel: React.PropTypes.string.isRequired,
-		onSubmit: React.PropTypes.func.isRequired,
-		showHowCanWeHelpField: React.PropTypes.bool,
-		showHowYouFeelField: React.PropTypes.bool,
-		showSubjectField: React.PropTypes.bool,
-		showSiteField: React.PropTypes.bool,
-		showHelpLanguagePrompt: React.PropTypes.bool,
-		siteFilter: React.PropTypes.func,
-		siteList: React.PropTypes.object,
-		disabled: React.PropTypes.bool,
-		valueLink: React.PropTypes.shape( {
-			value: React.PropTypes.any,
-			requestChange: React.PropTypes.func.isRequired
+		formDescription: PropTypes.node,
+		buttonLabel: PropTypes.string.isRequired,
+		onSubmit: PropTypes.func.isRequired,
+		showHowCanWeHelpField: PropTypes.bool,
+		showHowYouFeelField: PropTypes.bool,
+		showSubjectField: PropTypes.bool,
+		showSiteField: PropTypes.bool,
+		showHelpLanguagePrompt: PropTypes.bool,
+		siteFilter: PropTypes.func,
+		siteList: PropTypes.object,
+		disabled: PropTypes.bool,
+		valueLink: PropTypes.shape( {
+			value: PropTypes.any,
+			requestChange: PropTypes.func.isRequired
 		} ),
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			formDescription: '',
 			showHowCanWeHelpField: false,
@@ -69,7 +70,7 @@ export const HelpContactForm = React.createClass( {
 	 * Setup our initial state
 	 * @return {Object} An object representing our initial state
 	 */
-	getInitialState: function() {
+	getInitialState() {
 		return this.props.valueLink.value || {
 			howCanWeHelp: 'gettingStarted',
 			howYouFeel: 'unspecified',
@@ -79,7 +80,7 @@ export const HelpContactForm = React.createClass( {
 		};
 	},
 
-	getSiteSlug: function() {
+	getSiteSlug() {
 		if ( this.props.selectedSiteSlug ) {
 			return this.props.selectedSiteSlug;
 		}
@@ -92,7 +93,7 @@ export const HelpContactForm = React.createClass( {
 		return null;
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( ! nextProps.valueLink.value || isEqual( nextProps.valueLink.value, this.state ) ) {
 			return;
 		}
@@ -100,15 +101,15 @@ export const HelpContactForm = React.createClass( {
 		this.setState( nextProps.valueLink.value );
 	},
 
-	componentDidUpdate: function() {
+	componentDidUpdate() {
 		this.props.valueLink.requestChange( this.state );
 	},
 
-	setSite: function( siteSlug ) {
+	setSite( siteSlug ) {
 		this.setState( { siteSlug } );
 	},
 
-	trackClickStats: function( selectionName, selectedOption ) {
+	trackClickStats( selectionName, selectedOption ) {
 		const tracksEvent = {
 			howCanWeHelp: 'calypso_help_how_can_we_help_click',
 			howYouFeel: 'calypso_help_how_you_feel_click'
@@ -125,13 +126,14 @@ export const HelpContactForm = React.createClass( {
 	 * The SegmentedControl is used for desktop and the SelectDropdown is used for mobile.
 	 * CSS will control which one is displayed to the user.
 	 *
-	 * @param  {string} selectionName    The name that will be used to store the value of a selected option that appears in selectionOptions.
+	 * @param  {string} selectionName    The name that will be used to store the value of a selected option appearing in selectionOptions.
 	 * @param  {object} selectionOptions An array of objects consisting of a value and a label. It can also have a property called subtext
 	 *                                   value is used when setting state, label is used for display in the selection component, and subtext
 	 *                                   is used for the second line of text displayed in the SegmentedControl
 	 * @return {object}                  A JSX object containing both the SegmentedControl and the SelectDropdown.
 	 */
-	renderFormSelection: function( selectionName, selectionOptions ) {
+	renderFormSelection( selectionName, selectionOptions ) {
+		const { translate } = this.props;
 		const options = selectionOptions.map( option => ( {
 			label: option.label,
 			subtext: option.subtext ? <span className="help-contact-form__selection-subtext">{ option.subtext }</span> : null,
@@ -146,7 +148,6 @@ export const HelpContactForm = React.createClass( {
 				}
 			}
 		} ) );
-
 		const selectedItem = find( options, 'props.selected' );
 
 		return (
@@ -154,7 +155,7 @@ export const HelpContactForm = React.createClass( {
 				<SegmentedControl primary>
 					{ options.map( option => <ControlItem { ...option.props }>{ option.label }{ option.subtext }</ControlItem> ) }
 				</SegmentedControl>
-				<SelectDropdown selectedText={ selectedItem ? selectedItem.label : this.translate( 'Select an option' ) }>
+				<SelectDropdown selectedText={ selectedItem ? selectedItem.label : translate( 'Select an option' ) }>
 					{ options.map( option => <DropdownItem { ...option.props }>{ option.label }</DropdownItem> ) }
 				</SelectDropdown>
 			</div>
@@ -165,7 +166,7 @@ export const HelpContactForm = React.createClass( {
 	 * Determine if this form is ready to submit
 	 * @return {bool}	Return true if this form can be submitted
 	 */
-	canSubmitForm: function() {
+	canSubmitForm() {
 		const { disabled, showSubjectField } = this.props;
 		const { subject, message } = this.state;
 
@@ -184,7 +185,7 @@ export const HelpContactForm = React.createClass( {
 	 * Start a chat using the info set in state
 	 * @param  {object} event Event object
 	 */
-	submitForm: function() {
+	submitForm() {
 		this.props.onSubmit( this.state );
 	},
 
@@ -192,21 +193,7 @@ export const HelpContactForm = React.createClass( {
 	 * Render the contact form
 	 * @return {object} ReactJS JSX object
 	 */
-	render: function() {
-		var howCanWeHelpOptions = [
-				{ value: 'gettingStarted', label: this.translate( 'Help getting started' ), subtext: this.translate( 'Can you show me how to…' ) },
-				{ value: 'somethingBroken', label: this.translate( 'Something is broken' ), subtext: this.translate( 'Can you check this out…' ) },
-				{ value: 'suggestion', label: this.translate( 'I have a suggestion' ), subtext: this.translate( 'I think it would be cool if…' ) }
-			],
-			howYouFeelOptions = [
-				{ value: 'unspecified', label: this.translate( "I'd rather not" ) },
-				{ value: 'happy', label: this.translate( 'Happy' ) },
-				{ value: 'confused', label: this.translate( 'Confused' ) },
-				{ value: 'discouraged', label: this.translate( 'Discouraged' ) },
-				{ value: 'upset', label: this.translate( 'Upset' ) },
-				{ value: 'panicked', label: this.translate( 'Panicked' ) }
-			];
-
+	render() {
 		const {
 			formDescription,
 			buttonLabel,
@@ -215,7 +202,21 @@ export const HelpContactForm = React.createClass( {
 			showSubjectField,
 			showSiteField,
 			showHelpLanguagePrompt,
+			translate,
 		} = this.props;
+		const howCanWeHelpOptions = [
+			{ value: 'gettingStarted', label: translate( 'Help getting started' ), subtext: translate( 'Can you show me how to…' ) },
+			{ value: 'somethingBroken', label: translate( 'Something is broken' ), subtext: translate( 'Can you check this out…' ) },
+			{ value: 'suggestion', label: translate( 'I have a suggestion' ), subtext: translate( 'I think it would be cool if…' ) }
+		];
+		const howYouFeelOptions = [
+			{ value: 'unspecified', label: translate( "I'd rather not" ) },
+			{ value: 'happy', label: translate( 'Happy' ) },
+			{ value: 'confused', label: translate( 'Confused' ) },
+			{ value: 'discouraged', label: translate( 'Discouraged' ) },
+			{ value: 'upset', label: translate( 'Upset' ) },
+			{ value: 'panicked', label: translate( 'Panicked' ) }
+		];
 
 		return (
 			<div className="help-contact-form">
@@ -223,21 +224,21 @@ export const HelpContactForm = React.createClass( {
 
 				{ showHowCanWeHelpField && (
 					<div>
-						<FormLabel>{ this.translate( 'How can we help?' ) }</FormLabel>
+						<FormLabel>{ translate( 'How can we help?' ) }</FormLabel>
 						{ this.renderFormSelection( 'howCanWeHelp', howCanWeHelpOptions ) }
 					</div>
 				) }
 
 				{ showHowYouFeelField && (
 					<div>
-						<FormLabel>{ this.translate( 'Mind sharing how you feel?' ) }</FormLabel>
+						<FormLabel>{ translate( 'Mind sharing how you feel?' ) }</FormLabel>
 						{ this.renderFormSelection( 'howYouFeel', howYouFeelOptions ) }
 					</div>
 				) }
 
 				{ showSiteField && (
 					<div className="help-contact-form__site-selection">
-						<FormLabel>{ this.translate( 'Which site do you need help with?' ) }</FormLabel>
+						<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
 						<SitesDropdown
 							selected={ this.state.siteSlug }
 							onSiteSelect={ this.setSite } />
@@ -246,17 +247,17 @@ export const HelpContactForm = React.createClass( {
 
 				{ showSubjectField && (
 					<div className="help-contact-form__subject">
-						<FormLabel>{ this.translate( 'Subject' ) }</FormLabel>
+						<FormLabel>{ translate( 'Subject' ) }</FormLabel>
 						<FormTextInput valueLink={ this.linkState( 'subject' ) } />
 					</div>
 				) }
 
-				<FormLabel>{ this.translate( 'What are you trying to do?' ) }</FormLabel>
-				<FormTextarea valueLink={ this.linkState( 'message' ) } placeholder={ this.translate( 'Please be descriptive' ) }></FormTextarea>
+				<FormLabel>{ translate( 'What are you trying to do?' ) }</FormLabel>
+				<FormTextarea valueLink={ this.linkState( 'message' ) } placeholder={ translate( 'Please be descriptive' ) } />
 
 				{ showHelpLanguagePrompt && (
 					<strong className="help-contact-form__help-language-prompt">
-						{ this.translate( 'Note: Support is only available in English at the moment.' ) }
+						{ translate( 'Note: Support is only available in English at the moment.' ) }
 					</strong>
 				) }
 				<FormButton disabled={ ! this.canSubmitForm() } type="button" onClick={ this.submitForm }>{ buttonLabel }</FormButton>
@@ -269,4 +270,4 @@ export default connect( ( state ) => {
 	return {
 		selectedSiteSlug: getSelectedSiteSlug( state )
 	};
-} )( HelpContactForm );
+} )( localize( HelpContactForm ) );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -162,6 +162,7 @@ module.exports = {
 		if ( ! siteID ) {
 			sites.selectAll();
 			context.store.dispatch( setAllSitesSelected() );
+			siteStatsStickyTabActions.saveFilterAndSlug( false, '' );
 			return next();
 		}
 

--- a/client/state/ui/README.md
+++ b/client/state/ui/README.md
@@ -38,3 +38,13 @@ import { getSelectedSite } from 'state/ui/selectors';
 
 const selectedSite = getSelectedSite( store.getState() );
 ```
+
+### `getSelectedSiteSlug( state: Object )`
+
+Returns the currently selected site slug.
+
+```js
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+const selectedSiteSlug = getSelectedSiteSlug( store.getState() );
+```

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -8,7 +8,7 @@ import { includes, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getSite } from 'state/sites/selectors';
+import { getSite, getSiteSlug } from 'state/sites/selectors';
 
 /**
  * Returns the site object for the currently selected site.
@@ -33,6 +33,22 @@ export function getSelectedSite( state ) {
  */
 export function getSelectedSiteId( state ) {
 	return state.ui.selectedSiteId;
+}
+
+/**
+ * Returns the slug of the currently selected site,
+ * or null if no site is selected.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}       Selected site slug
+ */
+export function getSelectedSiteSlug( state ) {
+	const siteId = getSelectedSiteId( state );
+	if ( ! siteId ) {
+		return null;
+	}
+
+	return getSiteSlug( state, siteId );
 }
 
 /**

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
+	getSelectedSiteSlug,
 	getSectionName,
 	getSectionGroup,
 	isSiteSection,
@@ -76,6 +77,37 @@ describe( 'selectors', () => {
 			} );
 
 			expect( selected ).to.eql( 2916284 );
+		} );
+	} );
+
+	describe( '#getSelectedSiteSlug()', () => {
+		it( 'should return null if no site is selected', () => {
+			const slug = getSelectedSiteSlug( {
+				ui: {
+					selectedSiteSlug: null
+				}
+			} );
+
+			expect( slug ).to.be.null;
+		} );
+
+		it( 'should return slug for the selected site', () => {
+			const slug = getSelectedSiteSlug( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							name: 'WordPress.com Example Blog',
+							URL: 'https://example.com'
+						}
+					}
+				},
+				ui: {
+					selectedSiteId: 2916284
+				}
+			} );
+
+			expect( slug ).to.eql( 'example.com' );
 		} );
 	} );
 


### PR DESCRIPTION
This PR removes the code that resets the selected site before executing each route. Previously, this was necessary to fix a glitch with site selection (see 7633-gh-calypso-pre-oss and 8102-gh-calypso-pre-oss).

However, the resetting no longer appears to be necessary. If we remove it, it will take care of edge cases when we go from a site-specific page to a non-site specific page (like #8215). 

This PR also removes the now obsolete `SitesList.prototype.resetSelectedSite`.

Fixes #8215.

To test:

### Test case 1
* Navigate to My Sites
* Confirm that a site is selected from the sidebar site picker
* Navigate to Reader
* Click New Post in the master bar
* Verify that the site selector popover is shown

### Test case 2
* In a fresh Calypso page session, navigate to My Sites
* Select a site if one isn't already selected
* Click your profile image to the right of the master bar (i.e. `/me`)
* Verify that the current My Sites view maintains the selected site until after `/me` loads

### Test case 3
* Ensure you are logged in to wp.com
* In wp-admin for a disconnected, non-premium Jetpack site, click "Connect Jetpack"
* Click 'Approve'
* On the plans page, click any element in the top nav, eg 'Reader' or profile link
* Verify you're directed to the Reader and everything works smoothly without any crashes.

/cc @aduth @johnHackworth 
