### PR TITLE
Reader: Fix featured asset size

### DIFF
--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -44,7 +44,7 @@ export default class FeaturedAsset extends React.Component {
 			this.setImageSizingStrategy( nextProps.featuredImage );
 		}
 
-		if( nextProps.featuredEmbed !== this.props.featuredEmbed ) {
+		if ( nextProps.featuredEmbed !== this.props.featuredEmbed ) {
 			this.setEmbedSizingStrategy( nextProps.featuredEmbed );
 		}
 	}
@@ -90,17 +90,15 @@ export default class FeaturedAsset extends React.Component {
 		if ( featuredImage && featuredImage.width >= maxWidth() ) {
 			sizingFunction = ( available = this.getMaxFeaturedWidthSize() ) => {
 				const aspectRatio = featuredImage.width / featuredImage.height,
-					height = `${Math.floor( available / aspectRatio )}px`,
-					width = `${ available}px`;
-				console.log( 'aspectRatio' );
+					height = `${ Math.floor( available / aspectRatio ) }px`,
+					width = `${ available }px`;
 				return { width, height };
-			}
+			};
 		}
 		this.getImageSize = sizingFunction;
 	}
 
 	updateFeatureSize() {
-
 		if ( this.refs.featuredImage ) {
 			const img = ReactDom.findDOMNode( this.refs.featuredImage );
 			assign( img.style, this.getImageSize() );

--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -22,7 +22,6 @@ export default class FeaturedAsset extends React.Component {
 
 		[ 'handleImageError',
 			'updateFeatureSize',
-			'getFeaturedSize',
 			'getMaxFeaturedWidthSize',
 			'setEmbedSizingStrategy',
 			'handleResize'
@@ -70,10 +69,6 @@ export default class FeaturedAsset extends React.Component {
 
 	getMaxFeaturedWidthSize() {
 		return ReactDom.findDOMNode( this ).parentNode.offsetWidth;
-	}
-
-	getFeaturedSize( available ) {
-		return this.props.sizingStrategy( available || this.getMaxFeaturedWidthSize() );
 	}
 
 	setEmbedSizingStrategy( featuredEmbed ) {

--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -110,7 +110,7 @@ export default class FeaturedAsset extends React.Component {
 		// Does error fire and then the new load start? Does the error get suppressed?
 		// It appears that any events tied to a loading image are swallowed if the src changes. See
 		// http://jsbin.com/merulogozu/edit?js,console for a test of changing the src after the image starts to load
-		if ( ! this._umounted ) {
+		if ( ! this._unmounted ) {
 			this.setState( {
 				suppressFeaturedImage: true,
 				useFeaturedEmbed: !! this.props.featuredEmbed // turn on the featured embed if it exists

--- a/client/reader/stream/featured-asset.jsx
+++ b/client/reader/stream/featured-asset.jsx
@@ -20,7 +20,7 @@ export default class FeaturedAsset extends React.Component {
 			useFeaturedEmbed: props.useFeaturedEmbed
 		};
 
-		[ 'handleImageError',
+		[	'handleImageError',
 			'updateFeatureSize',
 			'getMaxFeaturedWidthSize',
 			'setEmbedSizingStrategy',

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -181,7 +181,6 @@ const Post = React.createClass( {
 			// don't feature embeds for excerpts
 			featuredEmbed = null;
 		}
-		console.log( featuredImage );
 		if ( ! ( featuredImage || featuredEmbed ) ) {
 			return null;
 		}

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -14,7 +14,8 @@ const ReactDom = require( 'react-dom' ),
 	startsWith = require( 'lodash/startsWith' ),
 	twemoji = require( 'twemoji' ),
 	get = require( 'lodash/get' ),
-	page = require( 'page' );
+	page = require( 'page' ),
+	pick = require( 'lodash/pick' );
 
 /**
  * Internal Dependencies
@@ -169,7 +170,7 @@ const Post = React.createClass( {
 	},
 
 	featuredImageComponent: function( post ) {
-		var featuredImage = ( post.canonical_image && post.canonical_image.uri ),
+		var featuredImage = ( post.canonical_image && pick( post.canonical_image, [ 'uri', 'width', 'height' ] ) ),
 			featuredEmbed = head( filter( post.content_embeds, ( embed ) => {
 				return ! startsWith( embed.type, 'special-' );
 			} ) ),
@@ -180,7 +181,7 @@ const Post = React.createClass( {
 			// don't feature embeds for excerpts
 			featuredEmbed = null;
 		}
-
+		console.log( featuredImage );
 		if ( ! ( featuredImage || featuredEmbed ) ) {
 			return null;
 		}
@@ -207,7 +208,6 @@ const Post = React.createClass( {
 		}
 		const featuredAssetProps = {
 			featuredImage,
-			featuredSize,
 			featuredEmbed,
 			useFeaturedEmbed
 		};


### PR DESCRIPTION
Fixes #8265 

This moves the featured asset sizing mechanism from `reader/stream/post` to the `FeaturedAsset` component.

The assets sizing behavior should be the same as before #8230 

**Verification**

The sizing behavior should be the same for both of these calypso.live sites:

https://calypso.live/?branch=try/reader/revert-featured-asset
https://calypso.live/?branch=fix/reader/featured-asset-size