### PR TITLE
Add component playground to devdocs

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -151,6 +151,7 @@
 @import 'blocks/credit-card-form/style';
 @import 'devdocs/style';
 @import 'devdocs/docs-example/style';
+@import 'devdocs/playground/style';
 @import 'layout/guided-tours/style';
 @import 'components/happychat/style';
 @import 'components/happychat/agent-w/style';

--- a/client/components/accordion/docs/example.txt
+++ b/client/components/accordion/docs/example.txt
@@ -1,0 +1,14 @@
+<div><Accordion
+	title="Section Four"
+	subtitle={ "With a Very Long Subtitle to Demonstrate the Fade Effect" }
+>
+	Drumstick ham tongue flank doner pork chop picanha.
+</Accordion>
+<Accordion
+	title="Section Five"
+	subtitle={ null }
+	icon={ <Gridicon icon="time" /> }
+>
+	Etiam dictum odio elit, id faucibus urna elementum ac. Mauris in est nec tortor luctus auctor ut a velit. sodales venenatis.
+</Accordion>
+</div>

--- a/client/components/button-group/docs/example.txt
+++ b/client/components/button-group/docs/example.txt
@@ -1,0 +1,4 @@
+<ButtonGroup>
+	<Button compact={ true }>Do thing</Button>
+	<Button compact={ true }>Do another thing</Button>
+</ButtonGroup>

--- a/client/components/button/docs/example.txt
+++ b/client/components/button/docs/example.txt
@@ -1,0 +1,1 @@
+<Button>Hello There!</Button>

--- a/client/components/card/docs/example.txt
+++ b/client/components/card/docs/example.txt
@@ -1,0 +1,1 @@
+<Card href="#cards">I am a linkable Card</Card>

--- a/client/components/gridicon/docs/example.txt
+++ b/client/components/gridicon/docs/example.txt
@@ -1,6 +1,5 @@
-<div>
+<Main>
 <Gridicon icon="add-image" size={ 48 }  />
 <Gridicon icon="add-outline" size={ 24 }  />
 <Gridicon icon="add" size={ 16 }  />
-</div>
-
+</Main>

--- a/client/components/gridicon/docs/example.txt
+++ b/client/components/gridicon/docs/example.txt
@@ -1,0 +1,6 @@
+<div>
+<Gridicon icon="add-image" size={ 48 }  />
+<Gridicon icon="add-outline" size={ 24 }  />
+<Gridicon icon="add" size={ 16 }  />
+</div>
+

--- a/client/components/notice/docs/example.txt
+++ b/client/components/notice/docs/example.txt
@@ -1,0 +1,5 @@
+<Notice
+	showDismiss={ false }
+	isCompact={ false }>
+	I'm a notice with no status and <a>a link</a>.
+</Notice>

--- a/client/components/notice/docs/example.txt
+++ b/client/components/notice/docs/example.txt
@@ -1,4 +1,5 @@
 <Notice
+	status="is-info"
 	showDismiss={ false }
 	isCompact={ false }>
 	I'm a notice with no status and <a>a link</a>.

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -8,7 +8,6 @@ import debounce from 'lodash/debounce';
 import page from 'page';
 import { Provider as ReduxProvider } from 'react-redux';
 import url from 'url';
-import assign from 'lodash/assign';
 
 /**
  * Internal dependencies
@@ -24,16 +23,6 @@ import Sidebar from './sidebar';
 import FormStateExamplesComponent from './form-state-examples';
 import EmptyContent from 'components/empty-content';
 import { loadScript } from 'lib/load-script';
-
-function loadCSS( cssUrl ) {
-	const link = assign( document.createElement( 'link' ), {
-		rel: 'stylesheet',
-		type: 'text/css',
-		href: cssUrl
-	} );
-
-	document.head.appendChild( link );
-}
 
 const devdocs = {
 
@@ -119,8 +108,6 @@ const devdocs = {
 		// load code mirror code
 		loadScript( '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js' );
 		loadScript( '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js' );
-		loadCSS( '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.css' );
-		loadCSS( '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/theme/material.min.css' );
 
 		ReactDom.render(
 			React.createElement( ReduxProvider, { store: context.store },

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -8,6 +8,7 @@ import debounce from 'lodash/debounce';
 import page from 'page';
 import { Provider as ReduxProvider } from 'react-redux';
 import url from 'url';
+import assign from 'lodash/assign';
 
 /**
  * Internal dependencies
@@ -15,12 +16,24 @@ import url from 'url';
 import DocsComponent from './main';
 import SingleDocComponent from './doc';
 import DesignAssetsComponent from './design';
+import Playground from './playground/';
 import Blocks from './design/blocks';
 import Typography from './design/typography';
 import DevWelcome from './welcome';
 import Sidebar from './sidebar';
 import FormStateExamplesComponent from './form-state-examples';
 import EmptyContent from 'components/empty-content';
+import { loadScript } from 'lib/load-script';
+
+function loadCSS( cssUrl ) {
+	const link = assign( document.createElement( 'link' ), {
+		rel: 'stylesheet',
+		type: 'text/css',
+		href: cssUrl
+	} );
+
+	document.head.appendChild( link );
+}
 
 const devdocs = {
 
@@ -101,7 +114,23 @@ const devdocs = {
 			document.getElementById( 'primary' )
 		);
 	},
+	// UI components
+	playground: function( context ) {
+		// load code mirror code
+		loadScript( '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js' );
+		loadScript( '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js' );
+		loadCSS( '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.css' );
+		loadCSS( '//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/theme/material.min.css' );
 
+		ReactDom.render(
+			React.createElement( ReduxProvider, { store: context.store },
+				React.createElement( Playground, {
+					component: context.params.component
+				} )
+			),
+			document.getElementById( 'primary' )
+		);
+	},
 	// App Blocks
 	blocks: function( context ) {
 		ReactDom.render(

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -15,6 +15,7 @@ export default function() {
 		page( '/devdocs/form-state-examples/:component?', controller.sidebar, controller.formStateExamples );
 		page( '/devdocs/design/typography', controller.sidebar, controller.typography );
 		page( '/devdocs/design/:component?', controller.sidebar, controller.design );
+		page( '/devdocs/playground/:component?', controller.sidebar, controller.playground );
 		page( '/devdocs/app-components/:component?',
 			( context ) => page.redirect( '/devdocs/blocks/' + ( context.params.component || '' ) ) );
 		page( '/devdocs/app-components', '/devdocs/blocks' );

--- a/client/devdocs/playground/example.txt
+++ b/client/devdocs/playground/example.txt
@@ -6,7 +6,7 @@
 		Welcome to the playground!
 	</Notice>
 	<Card>
-		<Card>Go ahead and start messing with the code above and watch as your changes are immediately reflected in the preview panel below. Try removing some props and adding some content of your own.</Card>
+		<Card>Go ahead and start messing with the code above and watch as your changes are immediately reflected in the preview panel below. Try removing some props and adding some content of your own. Try playing in the <a href="/devdocs/playground/button">button playground</a>.</Card>
 		<Button primary><Gridicon icon="star" /> Like</Button>
 	</Card>
 </div>

--- a/client/devdocs/playground/example.txt
+++ b/client/devdocs/playground/example.txt
@@ -1,0 +1,3 @@
+<div><Button>Hello</Button>
+<Notice ></Notice>
+</div>

--- a/client/devdocs/playground/example.txt
+++ b/client/devdocs/playground/example.txt
@@ -1,3 +1,12 @@
-<div><Button>Hello</Button>
-<Notice ></Notice>
+<div>
+	<Notice
+		status="is-info"
+		icon="heart"
+		showDismiss={ false }>
+		Welcome to the playground!
+	</Notice>
+	<Card>
+		<Card>Go ahead and start messing with the code above and watch as your changes are immediately reflected in the preview panel below. Try removing some props and adding some content of your own.</Card>
+		<Button primary><Gridicon icon="star" /> Like</Button>
+	</Card>
 </div>

--- a/client/devdocs/playground/index.jsx
+++ b/client/devdocs/playground/index.jsx
@@ -36,15 +36,6 @@ const docClass = {
 	none: null,
 };
 
-const PlayGroundPreview = React.createClass( {
-	displayName: 'PlayGroundPreview',
-	render() {
-		return (
-			<Main><code>Preview</code>{ this.props.children }</Main>
-		);
-	}
-} );
-
 const DesignPlayGround = React.createClass( {
 	displayName: 'DesignPlayGround',
 
@@ -66,7 +57,6 @@ const DesignPlayGround = React.createClass( {
 						Gridicon: Gridicon,
 						Notice: Notice
 					} }
-					previewComponent={ PlayGroundPreview }
 					noRender={ true } />
 			</Main>
 		);

--- a/client/devdocs/playground/index.jsx
+++ b/client/devdocs/playground/index.jsx
@@ -11,40 +11,62 @@ import Main from 'components/main';
 
 import Accordion from 'components/accordion';
 import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
+import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import Notice from 'components/notice';
 
 const component = {
 	accordion: require( 'raw!./../../components/accordion/docs/example.txt' ),
 	button: require( 'raw!./../../components/button/docs/example.txt' ),
+	'button-group': require( 'raw!./../../components/button-group/docs/example.txt' ),
+	card: require( 'raw!./../../components/card/docs/example.txt' ),
 	gridicon: require( 'raw!./../../components/gridicon/docs/example.txt' ),
-	notice: require( 'raw!./../../components/notice/docs/example.txt' )
+	notice: require( 'raw!./../../components/notice/docs/example.txt' ),
+	none: require( 'raw!./example.txt' ),
 };
 
 const docClass = {
-	notice: Notice,
-	button: Button,
 	accordion: Accordion,
+	button: Button,
+	'button-group': ButtonGroup,
+	card: Card,
 	gridicon: Gridicon,
+	notice: Notice,
+	none: null,
 };
+
+const PlayGroundPreview = React.createClass( {
+	displayName: 'PlayGroundPreview',
+	render() {
+		return (
+			<Main><code>Preview</code>{ this.props.children }</Main>
+		);
+	}
+} );
 
 const DesignPlayGround = React.createClass( {
 	displayName: 'DesignPlayGround',
 
 	render() {
+		const path = this.props.component ? this.props.component : 'none';
+		console.log( path );
 		return (
 			<Main>
 				<Playground
-					codeText={ component[ this.props.component ] }
-					docClass={ docClass[ this.props.component ] }
+					codeText={ component[ path ] }
+					docClass={ docClass[ path ] }
 					theme="material"
 					scope={ {
 						React: React,
 						Accordion: Accordion,
 						Button: Button,
+						ButtonGroup: ButtonGroup,
+						Card: Card,
 						Gridicon: Gridicon,
 						Notice: Notice
 					} }
+					previewComponent={ PlayGroundPreview }
 					noRender={ true } />
 			</Main>
 		);

--- a/client/devdocs/playground/index.jsx
+++ b/client/devdocs/playground/index.jsx
@@ -8,19 +8,44 @@ import Playground from 'component-playground';
  * Internal dependencies
  */
 import Main from 'components/main';
+
+import Accordion from 'components/accordion';
 import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 import Notice from 'components/notice';
 
-var componentExample = require( "raw!./../../components/notice/docs/example.txt" );
+const component = {
+	accordion: require( 'raw!./../../components/accordion/docs/example.txt' ),
+	button: require( 'raw!./../../components/button/docs/example.txt' ),
+	gridicon: require( 'raw!./../../components/gridicon/docs/example.txt' ),
+	notice: require( 'raw!./../../components/notice/docs/example.txt' )
+};
 
+const docClass = {
+	notice: Notice,
+	button: Button,
+	accordion: Accordion,
+	gridicon: Gridicon,
+};
 
-let DesignPlayGround = React.createClass( {
+const DesignPlayGround = React.createClass( {
 	displayName: 'DesignPlayGround',
 
 	render() {
 		return (
-			<Main className="design">
-				<Playground codeText={ componentExample } theme="material" scope={ { React: React, Button: Button, Notice: Notice } } noRender={ true } />
+			<Main>
+				<Playground
+					codeText={ component[ this.props.component ] }
+					docClass={ docClass[ this.props.component ] }
+					theme="material"
+					scope={ {
+						React: React,
+						Accordion: Accordion,
+						Button: Button,
+						Gridicon: Gridicon,
+						Notice: Notice
+					} }
+					noRender={ true } />
 			</Main>
 		);
 	}

--- a/client/devdocs/playground/index.jsx
+++ b/client/devdocs/playground/index.jsx
@@ -9,6 +9,10 @@ import Playground from 'component-playground';
  */
 import Main from 'components/main';
 import Button from 'components/button';
+import Notice from 'components/notice';
+
+var componentExample = require( "raw!./../../components/notice/docs/example.txt" );
+
 
 let DesignPlayGround = React.createClass( {
 	displayName: 'DesignPlayGround',
@@ -16,7 +20,7 @@ let DesignPlayGround = React.createClass( {
 	render() {
 		return (
 			<Main className="design">
-				<Playground codeText={ "<Button>hello</Button>" } theme="material" scope={ { React: React, Button: Button } } noRender={ true } />
+				<Playground codeText={ componentExample } theme="material" scope={ { React: React, Button: Button, Notice: Notice } } noRender={ true } />
 			</Main>
 		);
 	}

--- a/client/devdocs/playground/index.jsx
+++ b/client/devdocs/playground/index.jsx
@@ -41,7 +41,6 @@ const DesignPlayGround = React.createClass( {
 
 	render() {
 		const path = this.props.component ? this.props.component : 'none';
-		console.log( path );
 		return (
 			<Main>
 				<Playground

--- a/client/devdocs/playground/index.jsx
+++ b/client/devdocs/playground/index.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Playground from 'component-playground';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import Button from 'components/button';
+
+let DesignPlayGround = React.createClass( {
+	displayName: 'DesignPlayGround',
+
+	render() {
+		return (
+			<Main className="design">
+				<Playground codeText={ "<Button>hello</Button>" } theme="material" scope={ { React: React, Button: Button } } noRender={ true } />
+			</Main>
+		);
+	}
+} );
+
+export default DesignPlayGround;

--- a/client/devdocs/playground/style.scss
+++ b/client/devdocs/playground/style.scss
@@ -1,3 +1,26 @@
 .previewArea {
-	margin-top:16px;
+	background: #fff;
+	border: 1px solid lighten( $gray, 10% );
+	border-top-width: 0;
+	padding: 24px;
+}
+
+.playground .CodeMirror {
+	background: $gray-light;
+	font-size: 14px;
+	color: $gray;
+	height: auto;
+	padding: 24px;
+	border: 1px solid lighten( $gray, 10% );
+}
+
+.playgroundError {
+	padding: 15px 16px 16px;
+	background: lighten( $gray, 30% );
+	border: 1px solid lighten( $gray, 10% );
+	border-top-width: 0;
+	color: $gray;
+	color: darken( $gray, 10% );
+	font-size: 12px;
+	white-space: pre;
 }

--- a/client/devdocs/playground/style.scss
+++ b/client/devdocs/playground/style.scss
@@ -1,11 +1,57 @@
-.playground .CodeMirror {
+// Playground styles
+.playground {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: stretch;
+}
+
+.playgroundCode {
+	background: $gray-light;
+	border: 1px solid lighten( $gray, 10% );
+	order: 1;
+	flex-grow: 1;
+}
+
+.playground .CodeMirror, {
 	background: $gray-light;
 	font-size: 14px;
 	color: darken( $gray, 10% );
 	height: auto;
 	padding: 24px;
-	border: 1px solid lighten( $gray, 10% );
 }
+
+.cm-string {
+	color: $alert-green;
+}
+.cm-atom {
+	color: $blue-medium;
+}
+
+// Proptype styles
+.playground > div:not(.playgroundCode):first-child {
+	border: 1px solid lighten( $gray, 10% );
+	border-left-width: 0;
+	padding: 24px;
+	order: 2;
+	color: 	darken( $gray, 10% );
+
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		font-size: 14px;
+	}
+
+	b {
+		font-weight: 500;
+	}
+
+	i {
+		color: $gray;
+	}
+}
+
+// Error styles
 
 .playgroundError {
 	padding: 15px 16px 16px;
@@ -15,7 +61,16 @@
 	color: $gray;
 	color: darken( $gray, 10% );
 	font-size: 12px;
-	white-space: pre;
+	white-space: pre-wrap;
+	order: 3;
+	flex-basis: 100%;
+}
+
+// Preview styles
+
+.playgroundPreview {
+	order: 3;
+	flex-basis: 100%;
 }
 
 .previewArea {
@@ -28,13 +83,6 @@
 	linear-gradient( 90deg, lighten( $gray, 30% ) 1px, transparent 1px );
 	background-size: 64px 64px, 64px 64px, 8px 8px, 8px 8px;
 	background-position: -1px -1px, -1px -1px, -1px -1px, -1px -1px;
-}
-
-.cm-string {
-	color: $alert-green;
-}
-.cm-atom {
-	color: $blue-medium;
 }
 
 // CodeMirror code

--- a/client/devdocs/playground/style.scss
+++ b/client/devdocs/playground/style.scss
@@ -29,3 +29,10 @@
 	background-size: 64px 64px, 64px 64px, 8px 8px, 8px 8px;
 	background-position: -1px -1px, -1px -1px, -1px -1px, -1px -1px;
 }
+
+.cm-string {
+	color: $alert-green;
+}
+.cm-atom {
+	color: $blue-medium;
+}

--- a/client/devdocs/playground/style.scss
+++ b/client/devdocs/playground/style.scss
@@ -1,14 +1,7 @@
-.previewArea {
-	background: #fff;
-	border: 1px solid lighten( $gray, 10% );
-	border-top-width: 0;
-	padding: 24px;
-}
-
 .playground .CodeMirror {
 	background: $gray-light;
 	font-size: 14px;
-	color: $gray;
+	color: darken( $gray, 10% );
 	height: auto;
 	padding: 24px;
 	border: 1px solid lighten( $gray, 10% );
@@ -23,4 +16,16 @@
 	color: darken( $gray, 10% );
 	font-size: 12px;
 	white-space: pre;
+}
+
+.previewArea {
+	border: 1px solid lighten( $gray, 10% );
+	border-top-width: 0;
+	padding: 24px;
+	background-image: linear-gradient( lighten( $gray, 25% ) 1px, transparent 1px ),
+	linear-gradient( 90deg, lighten( $gray, 25% ) 1px, transparent 1px ),
+	linear-gradient( lighten( $gray, 30% ) 1px, transparent 1px ),
+	linear-gradient( 90deg, lighten( $gray, 30% ) 1px, transparent 1px );
+	background-size: 64px 64px, 64px 64px, 8px 8px, 8px 8px;
+	background-position: -1px -1px, -1px -1px, -1px -1px, -1px -1px;
 }

--- a/client/devdocs/playground/style.scss
+++ b/client/devdocs/playground/style.scss
@@ -36,3 +36,315 @@
 .cm-atom {
 	color: $blue-medium;
 }
+
+// CodeMirror code
+
+.CodeMirror {
+		font-family: monospace;
+		height: 300px;
+		color: #000
+}
+
+.CodeMirror-lines {
+		padding: 4px 0
+}
+
+.CodeMirror pre {
+		padding: 0 4px
+}
+
+.CodeMirror-gutter-filler,
+.CodeMirror-scrollbar-filler {
+		background-color: #fff
+}
+
+.CodeMirror-gutters {
+		border-right: 1px solid #ddd;
+		background-color: #f7f7f7;
+		white-space: nowrap
+}
+
+.CodeMirror-linenumber {
+		padding: 0 3px 0 5px;
+		min-width: 20px;
+		text-align: right;
+		color: #999;
+		-moz-box-sizing: content-box;
+		box-sizing: content-box
+}
+
+.CodeMirror-guttermarker {
+		color: #000
+}
+
+.CodeMirror-guttermarker-subtle {
+		color: #999
+}
+
+.CodeMirror div.CodeMirror-cursor {
+		border-left: 1px solid #000
+}
+
+.CodeMirror div.CodeMirror-secondarycursor {
+		border-left: 1px solid silver
+}
+
+.cm-tab {
+		display: inline-block;
+		text-decoration: inherit
+}
+
+.CodeMirror-ruler {
+		border-left: 1px solid #ccc;
+		position: absolute
+}
+
+.cm-negative {
+		color: #d44
+}
+
+.cm-positive {
+		color: #292
+}
+
+.cm-header,
+.cm-strong {
+		font-weight: 700
+}
+
+.cm-em {
+		font-style: italic
+}
+
+.cm-link {
+		text-decoration: underline
+}
+
+.cm-strikethrough {
+		text-decoration: line-through
+}
+
+.cm-invalidchar,
+.cm-s-default .cm-error {
+		color: red
+}
+
+div.CodeMirror span.CodeMirror-matchingbracket {
+		color: #0f0
+}
+
+div.CodeMirror span.CodeMirror-nonmatchingbracket {
+		color: #f22
+}
+
+.CodeMirror-matchingtag {
+		background: rgba(255, 150, 0, .3)
+}
+
+.CodeMirror-activeline-background {
+		background: #e8f2ff
+}
+
+.CodeMirror {
+		position: relative;
+		overflow: hidden;
+		background: #fff
+}
+.CodeMirror-scroll {
+		overflow: scroll!important;
+		margin-bottom: -30px;
+		margin-right: -30px;
+		padding-bottom: 30px;
+		height: 100%;
+		outline: 0;
+		position: relative;
+		-moz-box-sizing: content-box;
+		box-sizing: content-box
+}
+
+.CodeMirror-sizer {
+		position: relative;
+		border-right: 30px solid transparent;
+		-moz-box-sizing: content-box;
+		box-sizing: content-box
+}
+
+.CodeMirror-gutter-filler,
+.CodeMirror-hscrollbar,
+.CodeMirror-scrollbar-filler,
+.CodeMirror-vscrollbar {
+		position: absolute;
+		z-index: 6;
+		display: none
+}
+
+.CodeMirror-vscrollbar {
+		right: 0;
+		top: 0;
+		overflow-x: hidden;
+		overflow-y: scroll
+}
+
+.CodeMirror-hscrollbar {
+		bottom: 0;
+		left: 0;
+		overflow-y: hidden;
+		overflow-x: scroll
+}
+
+.CodeMirror-scrollbar-filler {
+		right: 0;
+		bottom: 0
+}
+
+.CodeMirror-gutter-filler {
+		left: 0;
+		bottom: 0
+}
+
+.CodeMirror-gutters {
+		position: absolute;
+		left: 0;
+		top: 0;
+		z-index: 3
+}
+
+.CodeMirror-gutter {
+		white-space: normal;
+		height: 100%;
+		-moz-box-sizing: content-box;
+		box-sizing: content-box;
+		display: inline-block;
+		margin-bottom: -30px
+}
+
+.CodeMirror-gutter-wrapper {
+		position: absolute;
+		z-index: 4;
+		height: 100%
+}
+
+.CodeMirror-gutter-elt {
+		position: absolute;
+		cursor: default;
+		z-index: 4
+}
+
+.CodeMirror-gutter-wrapper {
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		user-select: none
+}
+
+.CodeMirror-lines {
+		cursor: text;
+		min-height: 1px
+}
+
+.CodeMirror pre {
+		-moz-border-radius: 0;
+		-webkit-border-radius: 0;
+		border-radius: 0;
+		border-width: 0;
+		background: 0 0;
+		font-family: inherit;
+		font-size: inherit;
+		margin: 0;
+		white-space: pre;
+		word-wrap: normal;
+		line-height: inherit;
+		color: inherit;
+		z-index: 2;
+		position: relative;
+		overflow: visible;
+		-webkit-tap-highlight-color: transparent
+}
+
+.CodeMirror-wrap pre {
+		word-wrap: break-word;
+		white-space: pre-wrap;
+		word-break: normal
+}
+
+.CodeMirror-linebackground {
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: 0;
+		z-index: 0
+}
+
+.CodeMirror-linewidget {
+		position: relative;
+		z-index: 2;
+		overflow: auto
+}
+.CodeMirror-code {
+		outline: 0
+}
+
+.CodeMirror-measure {
+		position: absolute;
+		width: 100%;
+		height: 0;
+		overflow: hidden;
+		visibility: hidden
+}
+
+.CodeMirror-measure pre {
+		position: static
+}
+
+.CodeMirror div.CodeMirror-cursor {
+		position: absolute;
+		border-right: none;
+		width: 0
+}
+
+div.CodeMirror-cursors {
+		visibility: hidden;
+		position: relative;
+		z-index: 3
+}
+
+.CodeMirror-focused div.CodeMirror-cursors {
+		visibility: visible
+}
+
+.CodeMirror-selected {
+		background: #d9d9d9
+}
+
+.CodeMirror-focused .CodeMirror-selected {
+		background: #d7d4f0
+}
+
+.CodeMirror-crosshair {
+		cursor: crosshair
+}
+
+.CodeMirror::selection {
+		background: #d7d4f0
+}
+
+.CodeMirror::-moz-selection {
+		background: #d7d4f0
+}
+
+.cm-searching {
+		background: #ffa;
+		background: rgba(255, 255, 0, .4)
+}
+
+.cm-force-border {
+		padding-right: .1px
+}
+
+.cm-tab-wrap-hack:after {
+		content: ''
+}
+
+span.CodeMirror-selectedtext {
+		background: 0 0
+}

--- a/client/devdocs/playground/style.scss
+++ b/client/devdocs/playground/style.scss
@@ -1,0 +1,3 @@
+.previewArea {
+	margin-top:16px;
+}

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -54,6 +54,13 @@ export default React.createClass( {
 					<ul>
 						<SidebarItem
 							className="devdocs__navigation-item"
+							icon="code"
+							label="Playground"
+							link="/devdocs/playground"
+							selected={ '/devdocs/playground' === this.props.path }
+						/>
+						<SidebarItem
+							className="devdocs__navigation-item"
 							icon="layout-blocks"
 							label="UI Components"
 							link="/devdocs/design"

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "mockery": "1.4.0",
     "nock": "2.17.0",
     "nodemon": "1.4.1",
+    "raw-loader": "0.5.1",
     "react-addons-test-utils": "15.3.0",
     "react-hot-loader": "1.3.0",
     "react-test-env": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "blanket": "1.1.6",
     "chai": "3.5.0",
     "chai-enzyme": "0.5.0",
+    "component-playground": "1.3.1",
     "deep-freeze": "0.0.1",
     "enzyme": "2.4.1",
     "esformatter": "0.7.3",


### PR DESCRIPTION
This is a try of a devdocs component playground. Probably not the best way forward but more of a proof of concept. In order to get some feedback

[component-playground](http://stack.formidable.com/component-playground/) npm package does most of the heavy lifting. It also uses codemirror for the editor. 

To try it out load up this branch and go to http://calypso.localhost:3000/devdocs/playground

This is what it looks like right now:
![image](https://cloud.githubusercontent.com/assets/1123119/18942016/9ebdbe5c-85ca-11e6-8e04-9970bfd02a1d.png)

cc @MichaelArestad and @retrofox, @mcsf 
