### PR TITLE
WebPreview: Update logic for setting src.

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -138,7 +138,7 @@ export class WebPreview extends Component {
 			return;
 		}
 
-		if ( ! this.iframe ) {
+		if ( ! this.iframe || ! this.state.iframeUrl ) {
 			return;
 		}
 
@@ -160,7 +160,11 @@ export class WebPreview extends Component {
 	shouldRenderIframe() {
 		// Don't preload iframe on mobile devices as bandwidth is typically more limited and
 		// the preview causes weird issues
-		return ! this._isMobile || this.props.showPreview;
+		if ( this._isMobile && ! this.props.showPreview ) {
+			return false;
+		}
+
+		return this.props.showPreview;
 	}
 
 	setDeviceViewport( device = 'computer' ) {
@@ -218,16 +222,14 @@ export class WebPreview extends Component {
 									}
 								</div>
 							}
-							{ this.shouldRenderIframe() &&
-								<iframe
-									ref={ this.setIframeInstance }
-									className="web-preview__frame"
-									style={ { display: ('seo' === this.state.device ? 'none' : 'inherit') } }
-									src="about:blank"
-									onLoad={ this.setLoaded }
-									title={ this.props.iframeTitle || translate( 'Preview' ) }
-								/>
-							}
+							<iframe
+								ref={ this.setIframeInstance }
+								className="web-preview__frame"
+								style={ { display: ('seo' === this.state.device ? 'none' : 'inherit') } }
+								src="about:blank"
+								onLoad={ this.setLoaded }
+								title={ this.props.iframeTitle || translate( 'Preview' ) }
+							/>
 							{ 'seo' === this.state.device &&
 								<SeoPreviewPane />
 							}

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -43,7 +43,6 @@ export class WebPreview extends Component {
 		this.setDeviceViewport = this.setDeviceViewport.bind( this );
 		this.setIframeMarkup = this.setIframeMarkup.bind( this );
 		this.setIframeUrl = this.setIframeUrl.bind( this );
-		this.shouldRenderIframe = this.shouldRenderIframe.bind( this );
 		this.setLoaded = this.setLoaded.bind( this );
 	}
 
@@ -79,7 +78,7 @@ export class WebPreview extends Component {
 			this.props.setPreviewShowing( showPreview );
 		}
 
-		if ( ! this.shouldRenderIframe() ) {
+		if ( ! this.props.showPreview ) {
 			this.setState( {
 				iframeUrl: null,
 				loaded: false,
@@ -133,12 +132,7 @@ export class WebPreview extends Component {
 	}
 
 	setIframeUrl( iframeUrl ) {
-		// Bail if iframe isn't rendered
-		if ( ! this.shouldRenderIframe() ) {
-			return;
-		}
-
-		if ( ! this.iframe || ! this.state.iframeUrl ) {
+		if ( ! this.props.showPreview || ! this.iframe ) {
 			return;
 		}
 
@@ -155,16 +149,6 @@ export class WebPreview extends Component {
 				iframeUrl: iframeUrl,
 			} );
 		} catch ( e ) {}
-	}
-
-	shouldRenderIframe() {
-		// Don't preload iframe on mobile devices as bandwidth is typically more limited and
-		// the preview causes weird issues
-		if ( this._isMobile && ! this.props.showPreview ) {
-			return false;
-		}
-
-		return this.props.showPreview;
 	}
 
 	setDeviceViewport( device = 'computer' ) {


### PR DESCRIPTION
There have been growing reports of the My Sites page being unresponsive for many users.  One approach at a fix was to disable caching of stats data in `localStorage` in #8142 - but the issues still kept happening.

@dmsnell brought up in Slack that he had tracked a performance issue down to a jQuery plugin that was loading in the `WebPreview` component for one of his sites.  I too was finally able to get a browser/OS combination where I could consistently experience the slow down ( Firefox 43.0.1 on Windows 10, and MS Edge on Windows 10 ).

The current logic in `WebPreview` pivots on rendering and setting the `src` of the iframe preview based upon if `this.props.showPreview` is truthy _OR_ if the viewport is not mobile.  As such, even though `<SitePreview />` explicitly passes `showPreview = false`, if the device is not a mobile viewport, the iframe src is set to the homepage of the current site.

In this branch I have shifted the logic of `shouldRenderIframe()` a bit.  Now if the viewport is mobile _and_ `showPreview` is false, the src of the iframe is not set.  If the viewport is not mobile, the statement simply returns the value of `showPreview`.  Doing this change alone fixed the issues I was experiencing on Windows 10 / Firefox - but the site preview was no longer operational when clicking on the site blavatar in the sidebar.

This was happening because the rendering of the iframe ( with the default "blank" source ) was also conditionally rendered based upon `shouldRenderIframe`.  As such I removed that conditional logic so the iframe with the blank src is always rendered - and now `setIframeUrl` is in charge of all logic of setting the src accordingly.

__To Test__
Ideally, try to get a browser/OS combo where you can experience a slow down or unresponsive script in production.  For @dmsnell it seems using the Pique theme did the trick - for me it was as simple as using a slower device ( Windows Tablet, or under-powered mobile devices ).

Then test this branch using the same device/browser combos.  At the same time, make sure previews work as expected by clicking the blavatar in the sidebar, and doing other things like the editor preview.

/cc @mtias 