### PR TITLE
Jetpack Connect: fix siteIcon bug

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -65,7 +65,8 @@ const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
 const SiteCard = React.createClass( {
 	render() {
 		const { site_icon, blogname, home_url, site_url } = this.props.queryObject;
-		const siteIcon = site_icon ? { img: safeImageUrl( site_icon ) } : false;
+		const safeIconUrl = site_icon ? safeImageUrl( site_icon ) : false;
+		const siteIcon = safeIconUrl ? { img: safeIconUrl } : false;
 		const url = decodeEntities( home_url );
 		const parsedUrl = urlModule.parse( url );
 		const path = ( parsedUrl.path === '/' ) ? '' : parsedUrl.path;


### PR DESCRIPTION
This PR fixes a bug reported this morning where certain sites would see a broken calypso when connecting their Jetpack site 😱 

I traced the error to jetpack sites that are sending a site_icon url that contains url $_GET parameters.

To reproduce the bug:
- on a disconnected jetpack site, use a site icon image that contains url params, eg http://site.com/image.jpg?quality=80
- click connect, and you should see a frozen calypso screen 😱 


To test this PR:
- get this PR going locally
- on a disconnected jetpack site, use a site icon image that contains url params, eg http://site.com/image.jpg?quality=80
- force the jetpack connection process into the development enviornment ( ping me if you need hints )
- ensure that you can complete the connection.

cc: @johnHackworth @david-binda 
