### PR TITLE
Theme Page: fixes double border

### DIFF
--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -125,4 +125,8 @@ $current-theme-border: 1px solid lighten( $gray, 20% );
 .current-theme__info {
 	border-left: $current-theme-border;
 	border-right: $current-theme-border;
+
+	&:last-child {
+		border-right: none;
+	}
 }


### PR DESCRIPTION
On the current themes page `/design/*site*`, if the *info* button is the last visible on the "Current Theme" bar, a visual double border appears.

**Before**
![screen shot 2016-09-28 at 2 23 00 pm](https://cloud.githubusercontent.com/assets/1427136/18926937/aa3ce408-8587-11e6-83f9-306724da45d8.png)

**After**
![screen shot 2016-09-28 at 2 23 12 pm](https://cloud.githubusercontent.com/assets/1427136/18926944/b196a7c0-8587-11e6-89ab-bac8d66d742a.png)

/cc @mtias 