### PR TITLE
Editor: Perform embed reversal on-demand when pasting markup

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -40,6 +40,7 @@ import afterTheDeadlinePlugin from './plugins/after-the-deadline/plugin';
 import wptextpatternPlugin from './plugins/wptextpattern/plugin';
 import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
 import insertMenuPlugin from './plugins/insert-menu/plugin';
+import embedReversalPlugin from './plugins/embed-reversal/plugin';
 
 [
 	wpcomPlugin,
@@ -60,7 +61,8 @@ import insertMenuPlugin from './plugins/insert-menu/plugin';
 	contactFormPlugin,
 	afterTheDeadlinePlugin,
 	wptextpatternPlugin,
-	toolbarPinPlugin
+	toolbarPinPlugin,
+	embedReversalPlugin
 ].forEach( ( initializePlugin ) => initializePlugin() );
 
 /**
@@ -125,6 +127,7 @@ const PLUGINS = [
 	'wpcom/toolbarpin',
 	'wpcom/contactform',
 	'wpcom/sourcecode',
+	'wpcom/embedreversal'
 ];
 
 if ( config.isEnabled( 'post-editor/insert-menu' ) ) {
@@ -271,6 +274,7 @@ module.exports = React.createClass( {
 			keep_styles: false,
 			wpeditimage_html5_captions: true,
 			redux_store: this.context.store,
+			textarea: this.refs.text,
 
 			// Limit the preview styles in the menu/toolbar
 			preview_styles: 'font-family font-size font-weight font-style text-decoration text-transform',

--- a/client/components/tinymce/plugins/embed-reversal/plugin.js
+++ b/client/components/tinymce/plugins/embed-reversal/plugin.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+import { includes, partial } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import PostEditStore from 'lib/posts/post-edit-store';
+import wpcom from 'lib/wp';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+function embedReversal( editor ) {
+	const store = editor.getParam( 'redux_store' );
+	if ( ! store ) {
+		return;
+	}
+
+	function replaceMarkup( markup, result ) {
+		if ( ! result || ! editor ) {
+			return;
+		}
+
+		const isVisualEditMode = ! editor.isHidden();
+
+		if ( isVisualEditMode ) {
+			// Check textContent of all elements in Visual editor body
+			for ( const element of editor.getBody().querySelectorAll( '*' ) ) {
+				if ( includes( element.textContent, markup ) ) {
+					element.textContent = element.textContent.replace( markup, result.result );
+					editor.undoManager.add();
+					break;
+				}
+			}
+		} else {
+			// Else set the textarea content from store raw content
+			let content = PostEditStore.getRawContent();
+			if ( ! includes( content, markup ) ) {
+				return;
+			}
+
+			content = content.replace( markup, result.result );
+			editor.fire( 'SetTextAreaContent', { content } );
+		}
+
+		// Trigger an editor change so that dirty detection and autosave
+		// take effect
+		editor.fire( 'change' );
+	}
+
+	function onPaste( event ) {
+		let markup;
+		if ( event.clipboardData ) {
+			markup = event.clipboardData.getData( 'text/plain' );
+		} else if ( window.clipboardData ) {
+			markup = window.clipboardData.getData( 'Text' ); // IE11
+		}
+
+		// Check whether pasted content looks like markup
+		if ( ! markup || ! /^<.*>$/.test( markup ) ) {
+			return;
+		}
+
+		// If so, queue a request for reversal
+		wpcom.undocumented()
+			.site( getSelectedSiteId( store.getState() ) )
+			.embedReversal( markup )
+			.then( partial( replaceMarkup, markup ) )
+			.catch( () => {} );
+	}
+
+	// Bind paste event listeners to both Visual and HTML editors
+	editor.on( 'paste', onPaste );
+	const textarea = editor.getParam( 'textarea' );
+	if ( textarea ) {
+		textarea.addEventListener( 'paste', onPaste );
+	}
+}
+
+export default () => {
+	tinymce.PluginManager.add( 'wpcom/embedreversal', embedReversal );
+};

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -113,6 +113,12 @@ UndocumentedSite.prototype.embeds = function( attributes, callback ) {
 	return this.wpcom.req.get( url, attributes, callback );
 };
 
+UndocumentedSite.prototype.embedReversal = function( markup, callback ) {
+	return this.wpcom.req.post( `/sites/${ this._id }/embeds/reversal`, {
+		maybe_embed: markup
+	}, callback );
+};
+
 UndocumentedSite.prototype.shortcodes = function( attributes, callback ) {
 	return this.wpcom.req.get( '/sites/' + this._id + '/shortcodes/render', attributes, callback );
 };


### PR DESCRIPTION
Fixes: #1640 

This pull request seeks to perform embed reversal on-demand when a user pastes markup text into the editor, whether in the HTML or Visual mode. In the following animation, after pasting Getty images embed markup, it is subsequently replaced automatically with the equivalent shortcode:

![Reversal](https://cloud.githubusercontent.com/assets/1779930/18932361/0b8997f4-859e-11e6-9197-dd5b04b8d33e.gif)

**Implementation Notes:**

I originally took the approach of managing embeds to be replaced in Redux state (see f119bee), but later decided that this added additional complexity without much benefit. It's assumed that embed markup will probably not ever be reused and therefore does not provide value to include in Redux state. Instead, I chose to make a wpcom.js request directly within the plugin itself. One potential benefit of this is that it could simplify migrating this plugin upstream to WordPress.com wp-admin if desired.

**Testing Instructions:**
1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Paste a reversible markup (e.g. Getty) or any HTML
4. Note that...
   - If markup can be reversed to a shortcode, it is replaced after paste
   - If markup cannot be reversed, nothing happens

cc @sararosso @thehenrybyrd @alaczek 
