### PR TITLE
Advanced SEO: Change scrollbar behavior on title editor

### DIFF
--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -2,9 +2,8 @@
 	margin-bottom: 20px;
 
 	.public-DraftStyleDefault-block.public-DraftStyleDefault-ltr {
-		overflow-x: auto;
-		overflow-y: hidden;
 		white-space: nowrap;
+		overflow-x: hidden;
 	}
 }
 

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -2,7 +2,8 @@
 	margin-bottom: 20px;
 
 	.public-DraftStyleDefault-block.public-DraftStyleDefault-ltr {
-		overflow: scroll;
+		overflow-x: auto;
+		overflow-y: hidden;
 		white-space: nowrap;
 	}
 }

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -1,10 +1,5 @@
 .title-format-editor {
 	margin-bottom: 20px;
-
-	.public-DraftStyleDefault-block.public-DraftStyleDefault-ltr {
-		white-space: nowrap;
-		overflow-x: hidden;
-	}
 }
 
 .title-format-editor__header {


### PR DESCRIPTION
Fixes #8063 by using `auto` for the horizontal scroll in the title format editor field. The scrollbars won't show until the text overflows.

<img width="626" alt="screen shot 2016-09-28 at 3 24 14 pm" src="https://cloud.githubusercontent.com/assets/789137/18934683/f7639972-858f-11e6-8144-b75ab5d0db51.png">

<img width="626" alt="screen shot 2016-09-28 at 3 24 31 pm" src="https://cloud.githubusercontent.com/assets/789137/18934684/f77f67c4-858f-11e6-9e5e-bd5d70dc1652.png">

Another option is to not allow overflow at all, and then the text and tokens will wrap which might actually be a better UX.

Also fixes #8237.

cc @folletto & @dmsnell 