### PR TITLE
Reader Related Posts: Link up 'More on Wordpress.com'

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -157,6 +157,15 @@ export class FullPostView extends React.Component {
 		const siteName = siteNameFromSiteAndPost( site, post );
 		const classes = { 'reader-full-post': true };
 		const showRelatedPosts = ! post.is_external && post.site_ID;
+		const relatedPostsFromOtherSitesTitle = translate(
+			'More on {{wpLink}}WordPress.com{{/wpLink}}',
+			{
+				components: {
+					wpLink: <a href="/" className="reader-related-card-v2__link" />
+				}
+			}
+		);
+
 		if ( post.site_ID ) {
 			classes[ 'blog-' + post.site_ID ] = true;
 		}
@@ -255,7 +264,7 @@ export class FullPostView extends React.Component {
 
 						{ showRelatedPosts &&
 							<RelatedPostsFromOtherSites siteId={ post.site_ID } postId={ post.ID }
-								title={ translate( 'More on WordPress.com' ) }
+								title={ relatedPostsFromOtherSitesTitle }
 								className="is-other-site" />
 						}
 					</article>


### PR DESCRIPTION
@fraying requested that we link 'wordpress.com' in the Reader full post related posts block:

<img width="740" alt="screen shot 2016-09-28 at 16 50 31" src="https://cloud.githubusercontent.com/assets/17325/18936386/b9a4066a-859b-11e6-8b3e-b3fcc1f87812.png">

Fixes #8023.