### PR TITLE
Editor: Add missing translations

### DIFF
--- a/client/components/tinymce/i18n.js
+++ b/client/components/tinymce/i18n.js
@@ -5,6 +5,7 @@ const i18n = require( 'i18n-calypso' );
 
 /**
  * @see wp_mce_translation() in src/wp-includes/class-wp-editor.php from WordPress
+ * In short, TinyMCE uses these strings to translate its internal strings
  */
 module.exports = {
 
@@ -73,6 +74,8 @@ module.exports = {
 	// Tooltip for the 'remove' button in the image toolbar
 	Remove: i18n.translate( 'Remove' ),
 	// Tooltip for the 'edit' button in the image toolbar
-	'Edit ': i18n.translate( 'Edit' ) // eslint-disable-line
-
+	'Edit ': i18n.translate( 'Edit' ), // eslint-disable-line
+	'Horizontal line': i18n.translate( 'Horizontal line' ),
+	'Text color': i18n.translate( 'Text color' ),
+	'Paste as text': i18n.translate( 'Paste as text' )
 };

--- a/client/components/tinymce/i18n.js
+++ b/client/components/tinymce/i18n.js
@@ -67,8 +67,6 @@ module.exports = {
 	'Toolbar Toggle': i18n.translate( 'Toolbar Toggle' ),
 	'Insert Read More tag': i18n.translate( 'Insert Read More tag' ),
 	'Insert Page Break tag': i18n.translate( 'Insert Page Break tag' ),
-	// Title on the placeholder inside the editor
-	'Read more...': i18n.translate( 'Read more...' ),
 	// Tooltip for the 'alignnone' button in the image toolbar
 	'No alignment': i18n.translate( 'No alignment' ),
 	// Tooltip for the 'remove' button in the image toolbar

--- a/client/components/tinymce/plugins/advanced/plugin.jsx
+++ b/client/components/tinymce/plugins/advanced/plugin.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import tinymce from 'tinymce/tinymce';
 import throttle from 'lodash/throttle';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -54,8 +55,8 @@ function advanced( editor ) {
 	}, 500 );
 
 	editor.addButton( 'wpcom_advanced', {
-		text: 'Toggle Advanced',
-		tooltip: 'Toggle Advanced',
+		text: translate( 'Toggle Advanced' ),
+		tooltip: translate( 'Toggle Advanced' ),
 		classes: 'btn wpcom-icon-button advanced',
 		cmd: 'WPCOM_ToggleAdvancedVisible',
 		onPostRender: function() {

--- a/client/components/tinymce/plugins/contact-form/dialog/locales.js
+++ b/client/components/tinymce/plugins/contact-form/dialog/locales.js
@@ -1,4 +1,4 @@
-import i18n from 'i18n-calypso'
+import i18n from 'i18n-calypso';
 
 const labels = {
 	name() {

--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -9,6 +9,7 @@
  * External dependencies
  */
 var tinymce = require( 'tinymce/tinymce' );
+var translate = require( 'i18n-calypso' ).translate;
 
 /**
  * Internal dependencies
@@ -19,7 +20,6 @@ var formatting = require( 'lib/formatting' );
 function wpcomPlugin( editor ) {
 	var DOM = tinymce.DOM,
 		each = tinymce.each,
-		__ = editor.editorManager.i18n.translate,
 		style;
 
 	editor.on( 'focus', function() {
@@ -32,7 +32,7 @@ function wpcomPlugin( editor ) {
 
 		if ( event.content ) {
 			if ( event.content.indexOf( '<!--more' ) !== -1 ) {
-				title = __( 'Read more...' );
+				title = translate( 'Read more…' );
 
 				event.content = event.content.replace( /<!--more(.*?)-->/g, function( match, moretext ) {
 					return '<img src="' + tinymce.Env.transparentSrc + '" data-wp-more="more" data-wp-more-text="' + moretext + '" ' +
@@ -41,7 +41,7 @@ function wpcomPlugin( editor ) {
 			}
 
 			if ( event.content.indexOf( '<!--nextpage-->' ) !== -1 ) {
-				title = __( 'Page break' );
+				title = translate( 'Page break' );
 
 				event.content = event.content.replace( /<!--nextpage-->/g,
 					'<img src="' + tinymce.Env.transparentSrc + '" data-wp-more="nextpage" class="wp-more-tag mce-wp-nextpage" ' +
@@ -93,8 +93,9 @@ function wpcomPlugin( editor ) {
 
 		tag = tag || 'more';
 		classname += ' mce-wp-' + tag;
-		title = tag === 'more' ? 'Read more...' : 'Next page';
-		title = __( title );
+		title = tag === 'more'
+			? translate( 'Read more…' )
+			: translate( 'Next page' );
 		html = '<img src="' + tinymce.Env.transparentSrc + '" title="' + title + '" class="' + classname + '" ' +
 			'data-wp-more="' + tag + '" data-mce-resize="false" data-mce-placeholder="1" />';
 
@@ -134,39 +135,39 @@ function wpcomPlugin( editor ) {
 
 	// Register buttons
 	editor.addButton( 'wp_more', {
-		tooltip: 'Insert Read More tag',
+		tooltip: translate( 'Insert Read More tag' ),
 		onclick: function() {
 			editor.execCommand( 'WP_More', 'more' );
 		}
 	} );
 
 	editor.addButton( 'wp_page', {
-		tooltip: 'Page break',
+		tooltip: translate( 'Page break' ),
 		onclick: function() {
 			editor.execCommand( 'WP_More', 'nextpage' );
 		}
 	} );
 
 	editor.addButton( 'wp_help', {
-		tooltip: 'Keyboard Shortcuts',
+		tooltip: translate( 'Keyboard Shortcuts' ),
 		cmd: 'WP_Help'
 	} );
 
 	editor.addButton( 'wp_charmap', {
 		icon: 'charmap',
-		tooltip: 'Special Characters',
+		tooltip: translate( 'Special Characters' ),
 		cmd: 'Wpcom_CharMap'
 	} );
 
 	editor.addButton( 'wp_code', {
-		tooltip: 'Code',
+		tooltip: translate( 'Code' ),
 		cmd: 'WP_Code',
 		stateSelector: 'code'
 	} );
 
 	// Insert "Read More..."
 	editor.addMenuItem( 'wp_more', {
-		text: 'Insert Read More tag',
+		text: translate( 'Insert Read More tag' ),
 		icon: 'wp_more',
 		context: 'insert',
 		onclick: function() {
@@ -176,7 +177,7 @@ function wpcomPlugin( editor ) {
 
 	// Insert "Next Page"
 	editor.addMenuItem( 'wp_page', {
-		text: 'Page break',
+		text: translate( 'Page break' ),
 		icon: 'wp_page',
 		context: 'insert',
 		onclick: function() {

--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -10,7 +10,8 @@
  */
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
-	tinymce = require( 'tinymce/tinymce' );
+	tinymce = require( 'tinymce/tinymce' ),
+	translate = require( 'i18n-calypso' ).translate;
 
 import { Provider as ReduxProvider } from 'react-redux';
 
@@ -62,7 +63,7 @@ function wpLink( editor ) {
 
 	editor.addButton( 'link', {
 		icon: 'link',
-		tooltip: 'Insert/edit link',
+		tooltip: translate( 'Insert/edit link' ),
 		cmd: 'WP_Link',
 		stateSelector: 'a[href]'
 	} );
@@ -75,7 +76,7 @@ function wpLink( editor ) {
 
 	editor.addMenuItem( 'link', {
 		icon: 'link',
-		text: 'Insert/edit link',
+		text: translate( 'Insert/edit link' ),
 		cmd: 'WP_Link',
 		stateSelector: 'a[href]',
 		context: 'insert',

--- a/client/state/ui/editor/contact-form/constants.js
+++ b/client/state/ui/editor/contact-form/constants.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
 export const CONTACT_FORM_FIELD_TYPES = {
 	name: 'name',
 	email: 'email',
@@ -11,15 +16,30 @@ export const CONTACT_FORM_FIELD_TYPES = {
 
 export const CONTACT_FORM_DEFAULT = {
 	fields: [
-		{ label: 'Name', type: CONTACT_FORM_FIELD_TYPES.name, required: true },
-		{ label: 'Email', type: CONTACT_FORM_FIELD_TYPES.email, required: true },
-		{ label: 'Website', type: CONTACT_FORM_FIELD_TYPES.website },
-		{ label: 'Comment', type: CONTACT_FORM_FIELD_TYPES.textarea, required: true }
+		{
+			label: translate( 'Name' ),
+			type: CONTACT_FORM_FIELD_TYPES.name,
+			required: true
+		},
+		{
+			label: translate( 'Email' ),
+			type: CONTACT_FORM_FIELD_TYPES.email,
+			required: true
+		},
+		{
+			label: translate( 'Website' ),
+			type: CONTACT_FORM_FIELD_TYPES.website
+		},
+		{
+			label: translate( 'Comment' ),
+			type: CONTACT_FORM_FIELD_TYPES.textarea,
+			required: true
+		}
 	]
 };
 
 export const CONTACT_FORM_DEFAULT_NEW_FIELD = {
-	label: 'Text',
+	label: translate( 'Text' ),
 	type: CONTACT_FORM_FIELD_TYPES.text,
 	isExpanded: true
 };


### PR DESCRIPTION
This PR Fixes #8307, along with a couple of other issues I noticed along the way.

There were 3 different problems:

1.  We were missing several translations for TinyMCE's internal strings
2. We were missing some translate wrappers around strings in our TinyMCE plugins
3. We were missing translate wrappers around some strings that we were using to build the contact form

Oh, and I fixed a pair of ellipses while I was in there, because that's my idea of fun :)

### Testing
`Insert/edit link` and `Keyboard Shortcuts` should be fixed immediately, as they're already in the translations we're serving.

For verifying the rest, we need to check:
1. That the strings will get translated: Compare the `calypso-strings.pot` generated by `make translate` before and after the change, and verify that the missing strings are added (this includes `Toggle Advanced`, `Horizontal line`, `Text Color`, `Paste as text`, `Special characters`) .
2. That the translations will be used: This is a bit tricky.  The easiest way is probably to edit the strings where the translate calls are occurring (say, by appending '(yay!)' onto them) and verifying that these are the strings that TinyMCE is using for the tooltips in question.

The ideal test is to circle back the day after the change is deployed and verify that the strings are translated. Most of the translations are already in GlotPress, and just not included in the calypso translations bundle, but `Toggle Advanced` will need to go out to translators before the translations go up.

cc @rodrigoi 
