### PR TITLE
Prepend http:// if no http in url for site redirects

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -87,7 +87,7 @@ function canRedirect( siteId, domainName, onComplete ) {
 		return;
 	}
 
-	if ( ! domainName.match(/^https?:\/\//)) {
+	if ( ! domainName.match( /^https?:\/\// ) ) {
 		domainName = 'http://' + domainName;
 	}
 

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -87,7 +87,7 @@ function canRedirect( siteId, domainName, onComplete ) {
 		return;
 	}
 
-	if ( ! domainName.match( /^https?:\/\// ) ) {
+	if ( ! domainName.match( /^https?:\/\//i ) ) {
 		domainName = 'http://' + domainName;
 	}
 

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -87,7 +87,7 @@ function canRedirect( siteId, domainName, onComplete ) {
 		return;
 	}
 
-	if ( ! domainName.match(/^(http)/) ) {
+	if ( ! domainName.match(/^https?:\/\//)) {
 		domainName = 'http://' + domainName;
 	}
 

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -87,6 +87,10 @@ function canRedirect( siteId, domainName, onComplete ) {
 		return;
 	}
 
+	if ( ! domainName.match(/^(http)/) ) {
+		domainName = 'http://' + domainName;
+	}
+
 	wpcom.undocumented().canRedirect( siteId, domainName, function( serverError, data ) {
 		if ( serverError ) {
 			onComplete( new ValidationError( serverError.error ) );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -344,7 +344,7 @@ Undocumented.prototype.isDomainAvailable = function( domain, fn ) {
  * @api public
  */
 Undocumented.prototype.canRedirect = function( siteId, domain, fn ) {
-	domain = encodeURIComponent( domain );
+	domain = encodeURIComponent( domain.toLowerCase() );
 
 	this.wpcom.req.get( { path: '/domains/' + siteId + '/' + domain + '/can-redirect' }, fn );
 };
@@ -806,7 +806,7 @@ Undocumented.prototype.createConnection = function( keyringConnectionId, siteId,
  * @param {int}       postId            The post ID
  * @param {String}    message           Message for social media
  * @param {Array(int)}skipped           CKeyring connection ids to skip publicizing
- * 
+ *
  * @returns {Promise}
  */
 Undocumented.prototype.publicizePost = function( siteId, postId, message, skippedConnections, fn ) {


### PR DESCRIPTION
Users who entered a url with example.com/sub for site redirects would get a bad extension error because it was checking for http(s)://.

This prepends http:// if no http(s):// is found.

This is related to issue #7281.

cc: @klimeryk 