### PR TITLE
Support Chat: Fix sidebar overlaying stats insights

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -411,11 +411,9 @@
 	}
 
 	// adjust when scoll arrows show up in stats insights when panel is open
-	.has-chat.is-section-stats {
-		.post-trends__scroll-left,
-		.post-trends__scroll-right {
+	.has-chat.is-section-stats .post-trends__scroll-left,
+	.has-chat.is-section-stats .post-trends__scroll-right {
 			display: block;
-		}
 	}
 }
 

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -409,6 +409,14 @@
 	    display: block;
 	    overflow: hidden;
 	}
+
+	// adjust when scoll arrows show up in stats insights when panel is open
+	.has-chat.is-section-stats {
+		.post-trends__scroll-left,
+		.post-trends__scroll-right {
+			display: block;
+		}
+	}
 }
 
 

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -362,6 +362,12 @@
 		padding: 32px 304px;
 	}
 
+	// adjust when scoll arrows show up in stats insights when panel is open
+	.has-chat.is-section-stats .post-trends__scroll-left,
+	.has-chat.is-section-stats .post-trends__scroll-right {
+			display: block;
+	}
+
 	// adjust themes page to accomodate docked sidebar
 	.has-chat.is-section-theme .layout__content {
 		padding: 32px 0;
@@ -410,11 +416,6 @@
 	    overflow: hidden;
 	}
 
-	// adjust when scoll arrows show up in stats insights when panel is open
-	.has-chat.is-section-stats .post-trends__scroll-left,
-	.has-chat.is-section-stats .post-trends__scroll-right {
-			display: block;
-	}
 }
 
 

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -168,7 +168,7 @@
 	}
 }
 
-@include breakpoint( ">960px" ) {
+@include breakpoint( ">1040px" ) {
 
 	.post-trends__scroll-left,
 	.post-trends__scroll-right {


### PR DESCRIPTION
This PR fixes an issue where when you have the chat sidebar panel open, it would cause the scroll-arrows for posting activity to not appear until smaller breakpoints. The fix causes the scroll arrows to always be visible when the sidebar panel is open.

Steps to reproduce:

- Visit My Sites > Stats > Insights
- Open the support chat in the bottom of the sidebar
- Verify the scroll arrows are visible in the posting activity, and that they work

Screenshot:

![screen shot 2016-09-29 at 10 20 17](https://cloud.githubusercontent.com/assets/1204802/18946397/006b0592-862f-11e6-98dc-f860ec17ce47.png)
