### PR TITLE
Happiness Support: Update Happiness Engineers list

### DIFF
--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -21,8 +21,8 @@ const HappinessSupport = React.createClass( {
 	getInitialState() {
 		return {
 			user: sample( [
-				{ display_name: 'Erica', avatar_URL: '//gravatar.com/avatar/066a6509253d682f4e0d05b048b08b2c' },
-				{ display_name: 'Paolo', avatar_URL: '//gravatar.com/avatar/3cb9afe63d364690c0e188fb16473277' }
+				{ display_name: 'Spencer', avatar_URL: '//gravatar.com/avatar/368dd11821ca7e9293d1707ab838f5c7' },
+				{ display_name: 'Luca', avatar_URL: '//gravatar.com/avatar/7f7ba3ba8305287770e0cba76d1eb3db' }
 			] )
 		};
 	},


### PR DESCRIPTION
This pull request removes Erica and Paolo from the Happiness Support section. They have been replaced by new candidates: [Luca](https://secure.gravatar.com/avatar/7f7ba3ba8305287770e0cba76d1eb3db) and [Spencer](https://secure.gravatar.com/avatar/368dd11821ca7e9293d1707ab838f5c7)!
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/18946877/1f547266-8631-11e6-8947-abb13ce6793e.png)
  
#### Testing instructions
 
1. Run `git checkout remove/erica-and-paolo` and start your server, or open a [live branch](https://calypso.live/?branch=remove/erica-and-paolo)
2. Open the [`Documentation` page](http://calypso.localhost:3000/devdocs/blocks/happiness-support) that shows the Happiness Support block
3. Check that only Luca and Spencer are ever displayed, even when you refresh the page
 
#### Reviews
 
- [x] Code
- [x] Product
 
@Automattic/sdev-feed