### PR TITLE
Jetpack connect selectors state

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -636,9 +636,11 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 export default connect(
 	state => {
-		const site = state.jetpackConnect.jetpackConnectAuthorize &&
-				state.jetpackConnect.jetpackConnectAuthorize.queryObject &&
-				state.jetpackConnect.jetpackConnectAuthorize.queryObject.site
+		const queryObjectSite = state.jetpackConnect.jetpackConnectAuthorize &&
+			state.jetpackConnect.jetpackConnectAuthorize.queryObject &&
+			state.jetpackConnect.jetpackConnectAuthorize.queryObject.site;
+
+		const site = queryObjectSite
 			? getSiteByUrl( state, state.jetpackConnect.jetpackConnectAuthorize.queryObject.site )
 			: null;
 		const requestHasXmlrpcError = () => {
@@ -647,13 +649,14 @@ export default connect(
 		const isFetchingSites = () => {
 			return isRequestingSites( state );
 		};
+
 		return {
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
 			jetpackSSOSessions: state.jetpackConnect.jetpackSSOSessions,
 			isAlreadyOnSitesList: !! site,
 			isFetchingSites,
 			requestHasXmlrpcError,
-			calypsoStartedConnection: isCalypsoStartedConnection( state, site )
+			calypsoStartedConnection: isCalypsoStartedConnection( state, queryObjectSite )
 		};
 	},
 	dispatch => bindActionCreators( { requestSites,

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -611,8 +611,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		const props = Object.assign( {}, this.props, {
 			user: user
 		} );
-		const calypsoStartedConnection = isCalypsoStartedConnection(
-			this.props.jetpackConnectSessions,
+		const calypsoStartedConnection = this.props.isCalypsoStartedConnection(
 			this.props.jetpackConnectAuthorize.queryObject.site
 		);
 
@@ -646,7 +645,7 @@ export default connect(
 			? getSiteByUrl( state, state.jetpackConnect.jetpackConnectAuthorize.queryObject.site )
 			: null;
 		const requestHasXmlrpcError = () => {
-			return hasXmlrpcError( state.jetpackConnect.jetpackConnectAuthorize );
+			return hasXmlrpcError( state );
 		};
 		const isFetchingSites = () => {
 			return isRequestingSites( state );
@@ -654,10 +653,10 @@ export default connect(
 		return {
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
 			jetpackSSOSessions: state.jetpackConnect.jetpackSSOSessions,
-			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions,
 			isAlreadyOnSitesList: !! site,
 			isFetchingSites,
-			requestHasXmlrpcError
+			requestHasXmlrpcError,
+			isCalypsoStartedConnection: isCalypsoStartedConnection.bind( state )
 		};
 	},
 	dispatch => bindActionCreators( { requestSites,

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -611,13 +611,10 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		const props = Object.assign( {}, this.props, {
 			user: user
 		} );
-		const calypsoStartedConnection = this.props.isCalypsoStartedConnection(
-			this.props.jetpackConnectAuthorize.queryObject.site
-		);
 
 		return (
 			( user )
-				? <LoggedInForm { ...props } calypsoStartedConnection={ calypsoStartedConnection } isSSO={ this.isSSO() } />
+				? <LoggedInForm { ...props } calypsoStartedConnection={ this.props.calypsoStartedConnection } isSSO={ this.isSSO() } />
 				: <LoggedOutForm { ...props } isSSO={ this.isSSO() } />
 		);
 	},
@@ -656,7 +653,7 @@ export default connect(
 			isAlreadyOnSitesList: !! site,
 			isFetchingSites,
 			requestHasXmlrpcError,
-			isCalypsoStartedConnection: isCalypsoStartedConnection.bind( state )
+			calypsoStartedConnection: isCalypsoStartedConnection( state, site )
 		};
 	},
 	dispatch => bindActionCreators( { requestSites,

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -101,7 +101,7 @@ const Plans = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_submit_free', {
 			user: this.props.userId
 		} );
-		if ( isCalypsoStartedConnection( this.props.jetpackConnectSessions, selectedSite.slug ) ) {
+		if ( this.props.isCalypsoStartedConnection( selectedSite.slug ) ) {
 			page.redirect( CALYPSO_REDIRECTION_PAGE + selectedSite.slug );
 		} else {
 			const { queryObject } = this.props.jetpackConnectAuthorize;
@@ -179,13 +179,13 @@ export default connect(
 
 		return {
 			sitePlans: getPlansBySite( state, selectedSite ),
-			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions,
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
 			userId: user ? user.ID : null,
 			canPurchasePlans: userCan( 'manage_options', selectedSite ),
-			flowType: getFlowType( state.jetpackConnect.jetpackConnectSessions, selectedSite ),
+			flowType: getFlowType( state, selectedSite ),
 			isRequestingPlans: isRequestingPlans( state ),
-			getPlanBySlug: searchPlanBySlug
+			getPlanBySlug: searchPlanBySlug,
+			isCalypsoStartedConnection: isCalypsoStartedConnection.bind( state )
 		};
 	},
 	( dispatch ) => {

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -57,11 +57,11 @@ const Plans = React.createClass( {
 		}
 	},
 
-	componentWillReceiveProps( props ) {
+	componentDidUpdate() {
 		if ( this.hasPlan( this.props.selectedSite ) ) {
 			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
 		}
-		if ( ! props.canPurchasePlans ) {
+		if ( ! this.props.canPurchasePlans ) {
 			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
 		}
 

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -178,7 +178,7 @@ export default connect(
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
 			userId: user ? user.ID : null,
 			canPurchasePlans: userCan( 'manage_options', selectedSite ),
-			flowType: getFlowType( state, selectedSite ),
+			flowType: getFlowType( state, selectedSite && selectedSite.slug ),
 			isRequestingPlans: isRequestingPlans( state ),
 			getPlanBySlug: searchPlanBySlug,
 			isCalypsoStartedConnection: isCalypsoStartedConnection.bind( state )

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -99,7 +99,7 @@ const Plans = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_submit_free', {
 			user: this.props.userId
 		} );
-		if ( this.props.isCalypsoStartedConnection( this.props.selectedSite.slug ) ) {
+		if ( this.props.calypsoStartedConnection ) {
 			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
 		} else {
 			const { queryObject } = this.props.jetpackConnectAuthorize;
@@ -181,7 +181,7 @@ export default connect(
 			flowType: getFlowType( state, selectedSite && selectedSite.slug ),
 			isRequestingPlans: isRequestingPlans( state ),
 			getPlanBySlug: searchPlanBySlug,
-			isCalypsoStartedConnection: isCalypsoStartedConnection.bind( state )
+			calypsoStartedConnection: isCalypsoStartedConnection( state, selectedSite.slug )
 		};
 	},
 	( dispatch ) => {

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -58,12 +58,11 @@ const Plans = React.createClass( {
 	},
 
 	componentWillReceiveProps( props ) {
-		const selectedSite = props.sites.getSelectedSite();
-		if ( this.hasPlan( selectedSite ) ) {
-			page.redirect( CALYPSO_REDIRECTION_PAGE + selectedSite.slug );
+		if ( this.hasPlan( this.props.selectedSite ) ) {
+			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
 		}
 		if ( ! props.canPurchasePlans ) {
-			page.redirect( CALYPSO_REDIRECTION_PAGE + selectedSite.slug );
+			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
 		}
 
 		if ( ! this.props.isRequestingPlans && ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) ) {
@@ -97,12 +96,11 @@ const Plans = React.createClass( {
 	},
 
 	selectFreeJetpackPlan() {
-		const selectedSite = this.props.sites.getSelectedSite();
 		this.props.recordTracksEvent( 'calypso_jpc_plans_submit_free', {
 			user: this.props.userId
 		} );
-		if ( this.props.isCalypsoStartedConnection( selectedSite.slug ) ) {
-			page.redirect( CALYPSO_REDIRECTION_PAGE + selectedSite.slug );
+		if ( this.props.isCalypsoStartedConnection( this.props.selectedSite.slug ) ) {
+			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
 		} else {
 			const { queryObject } = this.props.jetpackConnectAuthorize;
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
@@ -110,8 +108,7 @@ const Plans = React.createClass( {
 	},
 
 	selectPlan( cartItem ) {
-		const selectedSite = this.props.sites.getSelectedSite();
-		const checkoutPath = `/checkout/${ selectedSite.slug }`;
+		const checkoutPath = `/checkout/${ this.props.selectedSite.slug }`;
 		if ( cartItem.product_slug === 'jetpack_free' ) {
 			return this.selectFreeJetpackPlan();
 		}
@@ -134,9 +131,7 @@ const Plans = React.createClass( {
 			return null;
 		}
 
-		const selectedSite = this.props.sites.getSelectedSite();
-
-		if ( ! this.props.canPurchasePlans || this.hasPlan( selectedSite ) ) {
+		if ( ! this.props.canPurchasePlans || this.hasPlan( this.props.selectedSite ) ) {
 			return null;
 		}
 
@@ -144,7 +139,7 @@ const Plans = React.createClass( {
 			<div>
 				<Main wideLayout>
 					<QueryPlans />
-					<QuerySitePlans siteId={ selectedSite.ID } />
+					<QuerySitePlans siteId={ this.props.selectedSite.ID } />
 					<div className="jetpack-connect__plans">
 						<ConnectHeader
 							showLogo={ false }
@@ -155,7 +150,7 @@ const Plans = React.createClass( {
 
 						<div id="plans">
 							<PlansFeaturesMain
-								site={ selectedSite }
+								site={ this.props.selectedSite }
 								isInSignup={ true }
 								isInJetpackConnect={ true }
 								onUpgradeClick={ this.selectPlan }
@@ -178,6 +173,7 @@ export default connect(
 		};
 
 		return {
+			selectedSite,
 			sitePlans: getPlansBySite( state, selectedSite ),
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
 			userId: user ? user.ID : null,

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -15,10 +15,10 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 	return false;
 };
 
-const getFlowType = function( state, site ) {
+const getFlowType = function( state, siteSlug ) {
 	const sessions = state.jetpackConnect.jetpackConnectSessions;
-	if ( sessions && sessions[ site.slug ] ) {
-		return sessions[ site.slug ].flowType;
+	if ( sessions && siteSlug && sessions[ siteSlug ] ) {
+		return sessions[ siteSlug ].flowType;
 	}
 	return false;
 };
@@ -27,8 +27,8 @@ const getFlowType = function( state, site ) {
  * XMLRPC errors can be identified by the presence of an error message, the presence of an authorization code
  * and if the error message contains the string 'error'
  *
- * @param state
- * @returns {Boolean}
+ * @param {object} state Global state tree
+ * @returns {Boolean} If there's an xmlrpc error or not
  */
 const hasXmlrpcError = function( state ) {
 	const authorizeData = state.jetpackConnect.jetpackConnectAuthorize;

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -16,11 +16,9 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 };
 
 const getFlowType = function( state, site ) {
-	const siteSlug = site.slug.replace( /.*?:\/\//g, '' );
 	const sessions = state.jetpackConnect.jetpackConnectSessions;
-
-	if ( sessions && sessions[ siteSlug ] ) {
-		return sessions[ siteSlug ].flowType;
+	if ( sessions && sessions[ site.slug ] ) {
+		return sessions[ site.slug ].flowType;
 	}
 	return false;
 };

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -5,9 +5,11 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 		return false;
 	}
 	const site = siteSlug.replace( /.*?:\/\//g, '' );
-	if ( state && state[ site ] ) {
+	const sessions = state.jetpackConnect.jetpackConnectSessions;
+
+	if ( sessions && sessions[ site ] ) {
 		const currentTime = ( new Date() ).getTime();
-		return ( currentTime - state[ site ].timestamp < JETPACK_CONNECT_TTL );
+		return ( currentTime - sessions[ site ].timestamp < JETPACK_CONNECT_TTL );
 	}
 
 	return false;
@@ -15,8 +17,10 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 
 const getFlowType = function( state, site ) {
 	const siteSlug = site.slug.replace( /.*?:\/\//g, '' );
-	if ( state && state[ siteSlug ] ) {
-		return state[ siteSlug ].flowType;
+	const sessions = state.jetpackConnect.jetpackConnectSessions;
+
+	if ( sessions && sessions[ siteSlug ] ) {
+		return sessions[ siteSlug ].flowType;
 	}
 	return false;
 };
@@ -29,11 +33,14 @@ const getFlowType = function( state, site ) {
  * @returns {Boolean}
  */
 const hasXmlrpcError = function( state ) {
+	const authorizeData = state.jetpackConnect.jetpackConnectAuthorize;
+
 	return (
-		state.authorizeError &&
-		state.authorizeError.message &&
-		state.authorizationCode &&
-		state.authorizeError.message.indexOf( 'error' ) > -1
+		authorizeData &&
+		authorizeData.authorizeError &&
+		authorizeData.authorizeError.message &&
+		authorizeData.authorizationCode &&
+		authorizeData.authorizeError.message.indexOf( 'error' ) > -1
 	);
 };
 

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -7,7 +7,7 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 	const site = siteSlug.replace( /.*?:\/\//g, '' );
 	const sessions = state.jetpackConnect.jetpackConnectSessions;
 
-	if ( sessions && sessions[ site ] ) {
+	if ( sessions[ site ] ) {
 		const currentTime = ( new Date() ).getTime();
 		return ( currentTime - sessions[ site ].timestamp < JETPACK_CONNECT_TTL );
 	}
@@ -17,7 +17,7 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 
 const getFlowType = function( state, siteSlug ) {
 	const sessions = state.jetpackConnect.jetpackConnectSessions;
-	if ( sessions && siteSlug && sessions[ siteSlug ] ) {
+	if ( siteSlug && sessions[ siteSlug ] ) {
 		return sessions[ siteSlug ].flowType;
 	}
 	return false;

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -9,86 +9,112 @@ import { expect } from 'chai';
 import { isCalypsoStartedConnection, getFlowType, hasXmlrpcError } from '../selectors';
 
 const stateHasXmlrpcError = {
-	authorizeError: {
-		message: 'transport error - HTTP status code was not 200 (502)'
-	},
-	authorizationCode: 'xxxx'
+	jetpackConnect: {
+		jetpackConnectAuthorize: {
+			authorizeError: {
+				message: 'transport error - HTTP status code was not 200 (502)'
+			},
+			authorizationCode: 'xxxx'
+		}
+	}
 };
 
 const stateHasNoError = {
-	authorizeError: false
+	jetpackConnect: {
+		jetpackConnectAuthorize: {
+			authorizeError: false
+		}
+	}
 };
 
 const stateHasNoAuthorizationCode = {
-	authorizeError: {
-		message: 'Could not verify your request.'
+	jetpackConnect: {
+		jetpackConnectAuthorize: {
+			authorizeError: {
+				message: 'Could not verify your request.'
+			}
+		}
 	}
 };
 
 const stateHasOtherError = {
-	authorizeError: {
-		message: 'Jetpack: [already_connected] User already connected.'
-	},
-	authorizationCode: 'xxxx'
+	jetpackConnect: {
+		jetpackConnectAuthorize: {
+			authorizeError: {
+				message: 'Jetpack: [already_connected] User already connected.'
+			},
+			authorizationCode: 'xxxx'
+		}
+	}
 };
 
 describe( 'selectors', () => {
 	describe( '#isCalypsoStartedConnection()', () => {
 		it( 'should return true if the user have started a session in calypso less than an hour ago', () => {
 			const state = {
-				jetpackConnectSessions: {
-					sitetest: {
-						timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
-						flowType: ''
+				jetpackConnect: {
+					jetpackConnectSessions: {
+						sitetest: {
+							timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
+							flowType: ''
+						}
 					}
 				}
 			};
-			expect( isCalypsoStartedConnection( state.jetpackConnectSessions, 'sitetest' ) ).to.be.true;
+			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.true;
 		} );
 		it( 'should return false if the user haven\'t started a session in calypso  ', () => {
 			const state = {
-				jetpackConnectSessions: {
-					sitetest: {}
+				jetpackConnect: {
+					jetpackConnectSessions: {
+						sitetest: {}
+					}
 				}
 			};
-			expect( isCalypsoStartedConnection( state.jetpackConnectSessions, 'sitetest' ) ).to.be.false;
+			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.false;
 		} );
 
 		it( 'should return false if the user started a session in calypso more than an hour ago', () => {
 			const state = {
-				jetpackConnectSessions: {
-					sitetest: {
-						timestamp: new Date( Date.now() - 60 * 60 * 1000 ).getTime(),
-						flow: ''
+				jetpackConnect: {
+					jetpackConnectSessions: {
+						sitetest: {
+							timestamp: new Date( Date.now() - 60 * 60 * 1000 ).getTime(),
+							flow: ''
+						}
 					}
 				}
 			};
-			expect( isCalypsoStartedConnection( state.jetpackConnectSessions, 'sitetest' ) ).to.be.false;
+			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.false;
 		} );
 	} );
 	describe( '#getFlowType()', () => {
 		it( 'should return the flow of the session for a site', () => {
 			const state = {
-				jetpackConnectSessions: {
-					sitetest: {
-						timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
-						flowType: 'pro'
+				jetpackConnect: {
+					jetpackConnectSessions: {
+						sitetest: {
+							timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
+							flowType: 'pro'
+						}
 					}
 				}
 			};
-			expect( getFlowType( state.jetpackConnectSessions, { slug: 'sitetest' } ) ).to.eql( 'pro' );
+			expect( getFlowType( state, { slug: 'sitetest' } ) ).to.eql( 'pro' );
 		} );
 
 		it( 'should return the false if there\'s no session for a site', () => {
 			const state = {
-				jetpackConnectSessions: {}
+				jetpackConnect: {
+					jetpackConnectSessions: {}
+				}
 			};
-			expect( getFlowType( state.jetpackConnectSessions, { slug: 'sitetest' } ) ).to.be.false;
+			expect( getFlowType( state, { slug: 'sitetest' } ) ).to.be.false;
 		} );
 	} );
 	describe( '#hasXmlrpcError', () => {
 		it( 'should be undefined when there is an empty state', () => {
-			const hasError = hasXmlrpcError( {} );
+			const hasError = hasXmlrpcError( { jetpackConnect: {} } );
 			expect( hasError ).to.be.undefined;
 		} );
 		it( 'should be false when there is no error', () => {

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -100,7 +100,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			expect( getFlowType( state, { slug: 'sitetest' } ) ).to.eql( 'pro' );
+			expect( getFlowType( state, 'sitetest' ) ).to.eql( 'pro' );
 		} );
 
 		it( 'should return the false if there\'s no session for a site', () => {


### PR DESCRIPTION
As @aduth notes [here](https://github.com/Automattic/wp-calypso/pull/6460#discussion_r80930230), we are using a state subtree in the Jetpack Connect selectors instead of using the global state tree as we specify in our data style guide. 

This PRs change the selectors to use the global state tree. There should be no changes in the UI at all

How to test
=========
1. Go to http://calypso.localhost:3000/jetpack/connect and make sure you can complete a jetpack site connection  (plan selection included)
2. That's it 

ping @aduth @tyxla 