### PR TITLE
Support Chat: Fix responsiveness and z-index issues

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -103,6 +103,7 @@ $z-layers: (
 		'.layout__loader': 200,
 		'.offline-status': 200,
 		'.reader-post-images__full-list': 200,
+		'.happychat__container.is-open': 999,
 		'.environment-badge': 999,
 		'.customizer-loading-panel__placeholder-change-theme': 999,
 		'.module-overlay': 1000,

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -63,7 +63,7 @@
 		display: block;
 		background: lighten( $gray, 30% );
 		bottom: 0;
-		z-index: 1020;
+		z-index: z-index( 'root', '.happychat__container.is-open' );
 
 		.happychat__title {
 			cursor: default;

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -425,7 +425,7 @@
 
 @include breakpoint( "480px-1040px" ) {
 
-	.wp:not( .is-section-chat ) {
+	.layout:not( .is-section-chat ) {
 		.happychat__container.is-open {
 			box-shadow: 0 1px 2px rgba( 0,0,0,.2 ), 0 1px 10px rgba( 0,0,0, .1 );
 			width: 280px;
@@ -454,10 +454,24 @@
 			padding: 12px;
 		}
 
-		.happychat__conversation {
+		.happychat__conversation,
+		.happychat__welcome {
 			min-height: 160px;
 			max-height: 220px;
 		}
+	}
+}
 
+@include breakpoint( "<480px" ) {
+	.layout:not( .is-section-chat ) {
+		.happychat__container.is-open {
+			right: 0;
+		}
+
+		.happychat__conversation,
+		.happychat__welcome {
+			min-height: 160px;
+			max-height: 220px;
+		}
 	}
 }

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -63,7 +63,7 @@
 		display: block;
 		background: lighten( $gray, 30% );
 		bottom: 0;
-		z-index: 10;
+		z-index: 1020;
 
 		.happychat__title {
 			cursor: default;


### PR DESCRIPTION
This PR fixes two issues:

1. Panel responsiveness
2. Z-index issues.

To test 1:

- Click support chat link in bottom of the sidebar
- Make the window small so the new right-most sidebar pane becomes a small panel
- Verify that the panel has a drop shadow and a consistent sensible size

To test 2:

- Open the panel like above
- Visit My Sites > Stats > Insights
- Make the browser window short, so the panel overlaps the posting activity. The posting activity has a gradient that would previously overlap the panel, it shouldn't anymore.

Screenshots:

![screen shot 2016-09-29 at 11 59 25](https://cloud.githubusercontent.com/assets/1204802/18949581/4d48c1e4-863c-11e6-9391-d04b6e92e20d.png)


![screen shot 2016-09-29 at 11 55 44](https://cloud.githubusercontent.com/assets/1204802/18949578/4a9fdeaa-863c-11e6-8150-744d93c36a97.png)

*Note*: I read the [CSS guidelines](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md#z-index) on using `$z-index` to fix issue 2, but wasn't able to get this working. If that's a requirement, I would appreciate help on getting this working. I kept getting various versions of this error message:

```
WARNING: No layer found for `.happychat .happychat__container` of `['.happychat" ".happychat__container']` in $z-layers map. Property omitted.
```