### PR TITLE
Jetpack Connect: Add getJetpackSiteByUrl selector

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -15,7 +15,7 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
-import { getSiteByUrl } from 'state/sites/selectors';
+import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import QuerySites from 'components/data/query-sites';
 import JetpackInstallStep from './install-step';
 import versionCompare from 'lib/version-compare';
@@ -392,16 +392,13 @@ const JetpackConnectMain = React.createClass( {
 
 export default connect(
 	state => {
-		const getJetpackSiteByUrl = ( url ) => {
-			const site = getSiteByUrl( state, url );
-			if ( site && ! site.jetpack ) {
-				return false;
-			}
-			return site;
+		const getJetpackSite = ( url ) => {
+			return getJetpackSiteByUrl( state, url );
 		};
+
 		return {
 			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite,
-			getJetpackSiteByUrl
+			getJetpackSiteByUrl: getJetpackSite
 		};
 	},
 	dispatch => bindActionCreators( {

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { getSiteByUrl } from 'state/sites/selectors';
+
 const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // an hour
 
 const isCalypsoStartedConnection = function( state, siteSlug ) {
@@ -23,6 +28,14 @@ const getFlowType = function( state, siteSlug ) {
 	return false;
 };
 
+const getJetpackSiteByUrl = ( state, url ) => {
+	const site = getSiteByUrl( state, url );
+	if ( site && ! site.jetpack ) {
+		return false;
+	}
+	return site;
+};
+
 /**
  * XMLRPC errors can be identified by the presence of an error message, the presence of an authorization code
  * and if the error message contains the string 'error'
@@ -42,4 +55,4 @@ const hasXmlrpcError = function( state ) {
 	);
 };
 
-export default { isCalypsoStartedConnection, getFlowType, hasXmlrpcError };
+export default { isCalypsoStartedConnection, getFlowType, getJetpackSiteByUrl, hasXmlrpcError };

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -31,7 +31,7 @@ const getFlowType = function( state, siteSlug ) {
 const getJetpackSiteByUrl = ( state, url ) => {
 	const site = getSiteByUrl( state, url );
 	if ( site && ! site.jetpack ) {
-		return false;
+		return null;
 	}
 	return site;
 };

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isCalypsoStartedConnection, getFlowType, hasXmlrpcError } from '../selectors';
+import { isCalypsoStartedConnection, getFlowType, getJetpackSiteByUrl, hasXmlrpcError } from '../selectors';
 
 const stateHasXmlrpcError = {
 	jetpackConnect: {
@@ -112,6 +112,51 @@ describe( 'selectors', () => {
 			expect( getFlowType( state, { slug: 'sitetest' } ) ).to.be.false;
 		} );
 	} );
+
+	describe( '#getJetpackSiteByUrl()', () => {
+		it( 'should return null if site is not found', () => {
+			const state = {
+				sites: {
+					items: {}
+				}
+			};
+
+			expect( getJetpackSiteByUrl( state, 'example.wordpress.com' ) ).to.be.null;
+		} );
+
+		it( 'should return false if the site is not a jetpack site', () => {
+			const state = {
+				sites: {
+					items: {
+						12345678: {
+							ID: 12345678,
+							URL: 'https://example.wordpress.com/',
+							jetpack: false
+						}
+					}
+				}
+			};
+
+			expect( getJetpackSiteByUrl( state, 'https://example.wordpress.com/' ) ).to.be.null;
+		} );
+
+		it( 'should return the site object if the site is a jetpack site', () => {
+			const state = {
+				sites: {
+					items: {
+						12345678: {
+							ID: 12345678,
+							URL: 'https://example.wordpress.com/',
+							jetpack: true
+						}
+					}
+				}
+			};
+
+			expect( getJetpackSiteByUrl( state, 'https://example.wordpress.com/' ) ).to.eql( state.sites.items[ 12345678 ] );
+		} );
+	} );
+
 	describe( '#hasXmlrpcError', () => {
 		it( 'should be undefined when there is an empty state', () => {
 			const hasError = hasXmlrpcError( { jetpackConnect: {} } );


### PR DESCRIPTION
This PR moves `getJetpackSiteByUrl()` in a separate selector and adds tests. It also slightly improves the formatting (mostly newlines) within the JPC selector tests.

To test:

1. Verify that `/jetpack/connect` works properly and has no regressions.
2. Verify that tests pass - `npm run test-client client/state/jetpack-connect/test/selectors.js -- --grep="getJetpackSiteByUrl"`

/cc @johnHackworth @roccotripaldi 