### PR TITLE
Support Chat: Fix margins when chat open in post editor.

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -364,8 +364,39 @@
 
 	// add space in the editor for the docked sidebar
 	.has-chat.is-group-editor .layout__content {
-		padding: 0 304px 0 0;
+		padding: 0 272px 0 0;
 	}
+
+	.has-chat.is-group-editor .editor__header,
+	.has-chat.is-group-editor .editor .mce-edit-area {
+	    padding: 0 16px;
+	}
+
+	.has-chat.is-group-editor .editor-title {
+	    margin-left: 52px;
+	}
+
+	.has-chat.is-group-editor .editor__header {
+		padding-bottom: 27px;
+	}
+
+	.has-chat.is-group-editor .mce-toolbar-grp .mce-stack-layout-item {
+	    display: inline-block;
+	    overflow: hidden;
+	}
+
+	.has-chat.is-group-editor .editor__switch-mode {
+	    right: 32px;
+	}
+}
+
+@include breakpoint( ">1280px" ) {
+
+	.has-chat.is-group-editor .mce-toolbar-grp .mce-stack-layout-item {
+	    display: block;
+	    overflow: hidden;
+	}
+
 }
 
 


### PR DESCRIPTION
This PR improves the way the open support chat box looks, while editing a post.

To test:

- Open support chat by clicking link in bottom of footer
- Navigate to edit a post
- Resize window to see that panel and editor looks good at all sizes.

Screenshot, before:

![before](https://cloud.githubusercontent.com/assets/1204802/18951623/6c601be0-8646-11e6-9d39-02e365a5c74e.png)

Screenshot, after:

![after](https://cloud.githubusercontent.com/assets/1204802/18951625/7075edb8-8646-11e6-8400-8db624df8121.png)
