### PR TITLE
Support Chat: Fix issues that chat sidebar causes on theme page.

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -362,6 +362,19 @@
 		padding: 32px 304px;
 	}
 
+	// adjust themes page to accomodate docked sidebar
+	.has-chat.is-section-theme .layout__content {
+		padding: 32px 0;
+	}
+
+	.has-chat.is-section-theme .theme__sheet {
+		margin-right: 272px;
+	}
+
+	.has-chat.is-section-theme .theme__sheet-screenshot {
+		width: calc( 49% - 182px );
+	}
+
 	// add space in the editor for the docked sidebar
 	.has-chat.is-group-editor .layout__content {
 		padding: 0 272px 0 0;
@@ -396,7 +409,6 @@
 	    display: block;
 	    overflow: hidden;
 	}
-
 }
 
 


### PR DESCRIPTION
This PR fixes issues that the support chat docked sidebar introduces on theme pages.

To test:

- Starting at URL: https://wordpress.com/design
- Select a site and click the Support Chat link to start chatting
- Click on a theme to view the theme info page
- Verify that the layout looks right, even with docked sidebar open

Screenshot, before:

![before](https://cloud.githubusercontent.com/assets/1204802/18952415/be6fbaf0-8649-11e6-8f16-d0cc308b7c41.png)

Screenshot, after:

![after](https://cloud.githubusercontent.com/assets/1204802/18952421/c17d34de-8649-11e6-8bff-c073b4b60787.png)
