### PR TITLE
Themes: Make feature pills clickable links to feature search

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -294,9 +294,14 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderFeaturesCard() {
-		const themeFeatures = this.props.taxonomies && this.props.taxonomies.theme_feature instanceof Array
-		? this.props.taxonomies.theme_feature.map( function( item ) {
-			return ( <li key={ 'theme-features-item-' + item.slug }><span>{ item.name }</span></li> );
+		const { siteSlug, taxonomies } = this.props;
+		const themeFeatures = taxonomies && taxonomies.theme_feature instanceof Array
+		? taxonomies.theme_feature.map( function( item ) {
+			return (
+				<li key={ 'theme-features-item-' + item.slug }>
+					<a href={ `/design/filter/${ item.slug }/${ siteSlug || '' }` }>{ item.name }</a>
+				</li>
+			);
 		} ) : [];
 
 		return (

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -275,19 +275,18 @@
 	margin: -0.78em 0;
 	padding: 0;
 
+	a {
+		color: $gray-dark;
+	}
+
 	li {
 		list-style: none;
 		display: inline-block;
-		// background: lighten( $gray, 30% ); // To be restored once made clickable
-		color: $gray-dark;
+		background: lighten( $gray, 30% );
 		font-size: 0.925em;
 		margin: 0.38em 0.37rem;
 		padding: 0.25em 0.7em;
 		border-radius: 3px;
-
-		span {
-			display: block;
-		}
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -272,21 +272,50 @@
 
 .theme__sheet-features-list {
 	text-align: center;
-	margin: -0.78em 0;
+	margin: -10px;
 	padding: 0;
 
 	a {
+		display: inline-block;
+		position: relative;
+		background: lighten( $gray, 30% );
 		color: $gray-dark;
+		margin: 4px;
+		padding: 2px 12px;
+		border-radius: 3px;
+		transition: all 100ms ease-in;
+
+		&:after {
+			content: "";
+			pointer-events: none;
+			position: absolute;
+			width: 100%;
+			height: 100%;
+			border-radius: 3px;
+			background: $blue-dark;
+			top: 0;
+			left: 0;
+			padding: 0;
+			z-index: -1;
+			transform: scale(0.9, 0.9);
+			transition: transform 300ms, opacity 400ms;
+		}
+
+		&:hover {
+			color: $white;
+			background-color: $blue-dark;
+
+			&:after {
+				transform: scale(1.07, 1.16);
+			}
+		}
 	}
 
 	li {
 		list-style: none;
 		display: inline-block;
-		background: lighten( $gray, 30% );
-		font-size: 0.925em;
-		margin: 0.38em 0.37rem;
-		padding: 0.25em 0.7em;
-		border-radius: 3px;
+		position: relative;
+		z-index: 0;
 	}
 }
 


### PR DESCRIPTION
Addresses #7355

**Before**
![screen shot 2016-09-29 at 13 10 52](https://cloud.githubusercontent.com/assets/7767559/18953416/4f10889a-8646-11e6-8842-08a7d4a10462.png)

**After**
![screen shot 2016-09-29 at 13 11 07](https://cloud.githubusercontent.com/assets/7767559/18953422/53f90d1e-8646-11e6-984a-ec23943ef501.png)

**On click**
![screen shot 2016-09-29 at 13 11 31](https://cloud.githubusercontent.com/assets/7767559/18953430/592fc804-8646-11e6-9a41-8ba10de46763.png)

**To Test**
* Visit a theme info page, for example http://calypso.localhost:3000/theme/karuna
* Check that clicking on one of the _Features_ pills takes you to the search page filtered on that feature
* Try with a site selected, check that site selection is maintained in the search page
