### PR TITLE
fix checkbox not checked when label clicked

### DIFF
--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -93,7 +93,7 @@ const EditorMediaModalGalleryHelp =  React.createClass( {
 					<div className="editor-media-modal__gallery-help-actions">
 						<label className="editor-media-modal__gallery-help-remember-dismiss">
 							<FormCheckbox checked={ this.state.rememberDismiss } onChange={ this.toggleRememberDismiss } />
-							<span onClick={ this.toggleRememberDismiss }>
+							<span>
 								{ this.translate( 'Don\'t show again' ) }
 							</span>
 						</label>


### PR DESCRIPTION
Fixes #8287

```
<label className="editor-media-modal__gallery-help-remember-dismiss">
	<FormCheckbox checked={ this.state.rememberDismiss } onChange={ this.toggleRememberDismiss } /> ehehehe 
	<span onClick={ this.toggleRememberDismiss }>
		{ this.translate( 'Don\'t show again' ) }
	</span>
</label>
```

Actually clicking on the `label` supposed to work but it was cancelled immediately. When the `text` is clicked, it triggered both `onClick` on the `span` element and `onChange` on the `checkbox` hence it was cancelling the "checked"

I remove `onClick` on the `span` element to solve this problem. I have no idea the purpose of `onClick` as it's already exist since "Initial commit of wp-calypso"

cc @artpi 