### PR TITLE
Editor: Avoid double-encoding sourcecode shortcode content

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -412,7 +412,8 @@ module.exports = React.createClass( {
 
 	setEditorContent: function( content, args ) {
 		if ( this._editor ) {
-			this._editor.setContent( formatting.wpautop( content ), args );
+			const { mode } = this.props;
+			this._editor.setContent( formatting.wpautop( content ), { ...args, mode } );
 
 			// clear the undo stack to ensure that we don't have any leftovers
 			this._editor.undoManager.clear();

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -407,7 +407,12 @@ module.exports = React.createClass( {
 	},
 
 	setTextAreaContent: function( content ) {
-		this.setState( { content }, this.doAutosizeUpdate );
+		const event = { content };
+		if ( this._editor ) {
+			this._editor.fire( 'BeforeSetTextAreaContent', event );
+		}
+
+		this.setState( { content: event.content }, this.doAutosizeUpdate );
 	},
 
 	setEditorContent: function( content, args ) {

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -410,9 +410,9 @@ module.exports = React.createClass( {
 		this.setState( { content }, this.doAutosizeUpdate );
 	},
 
-	setEditorContent: function( content ) {
+	setEditorContent: function( content, args ) {
 		if ( this._editor ) {
-			this._editor.setContent( formatting.wpautop( content ) );
+			this._editor.setContent( formatting.wpautop( content ), args );
 
 			// clear the undo stack to ensure that we don't have any leftovers
 			this._editor.undoManager.clear();

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -66,11 +66,11 @@ import insertMenuPlugin from './plugins/insert-menu/plugin';
 /**
  * Internal Dependencies
  */
-const formatting = require( 'lib/formatting' ),
-	user = require( 'lib/user' )(),
+const user = require( 'lib/user' )(),
 	i18n = require( './i18n' ),
 	viewport = require( 'lib/viewport' ),
 	config = require( 'config' );
+import { decodeEntities, wpautop, removep } from 'lib/formatting';
 
 /**
  * Internal Variables
@@ -393,7 +393,7 @@ module.exports = React.createClass( {
 			// TODO: fix code duplication between the wordpress plugin and the React component
 			content = content.replace( /<p>(?:<br ?\/?>|\u00a0|\uFEFF| )*<\/p>/g, '<p>&nbsp;</p>' );
 
-			content = formatting.removep( content );
+			content = removep( content );
 		}
 
 		return content;
@@ -407,18 +407,15 @@ module.exports = React.createClass( {
 	},
 
 	setTextAreaContent: function( content ) {
-		const event = { content };
-		if ( this._editor ) {
-			this._editor.fire( 'BeforeSetTextAreaContent', event );
-		}
-
-		this.setState( { content: event.content }, this.doAutosizeUpdate );
+		this.setState( {
+			content: decodeEntities( content )
+		}, this.doAutosizeUpdate );
 	},
 
 	setEditorContent: function( content, args ) {
 		if ( this._editor ) {
 			const { mode } = this.props;
-			this._editor.setContent( formatting.wpautop( content ), { ...args, mode } );
+			this._editor.setContent( wpautop( content ), { ...args, mode } );
 
 			// clear the undo stack to ensure that we don't have any leftovers
 			this._editor.undoManager.clear();

--- a/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
@@ -8,12 +8,22 @@ import tinymce from 'tinymce/tinymce';
  */
 const REGEXP_CODE_SHORTCODE = new RegExp( '(?:<p>\\s*)?(?:<pre>\\s*)?(\\[(code|sourcecode)[^\\]]*\\][\\s\\S]*?\\[\\/\\2\\])(?:\\s*<\\/pre>)?(?:\\s*<\\/p>)?', 'gi' );
 
-export function wrapPre( content, initial ) {
+export function wrapPre( { content, initial, load } ) {
 	return content = content.replace( REGEXP_CODE_SHORTCODE, function( match, shortcode ) {
 		shortcode = shortcode.replace( /\r/, '' );
 		shortcode = shortcode.replace( /<br ?\/?>\n?/g, '\n' ).replace( /<\/?p( [^>]*)?>\n?/g, '\n' );
 
-		if ( ! initial ) {
+		// Ensure shortcode contents hit TinyMCE with characters escaped, else
+		// they'll be rendered as DOM nodes.
+		//
+		// See: https://github.com/tinymce/tinymce/blob/a9561a4/js/tinymce/classes/Editor.js#L1619
+		//
+		// Event arguments:
+		//  - `initial`: When calling `setContent` on a TinyMCE component
+		//    instance, value is assumed to already be escaped
+		//  - `load`: When TinyMCE loads, it sets content from the underlying
+		//    textarea, whose value is decoded and needs entities replaced
+		if ( ! initial || load ) {
 			shortcode = shortcode.replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
 		}
 
@@ -21,7 +31,7 @@ export function wrapPre( content, initial ) {
 	} );
 }
 
-export function unwrapPre( content ) {
+export function unwrapPre( { content } ) {
 	if ( ! content || content.indexOf( '[' ) === -1 ) {
 		return content;
 	}
@@ -39,7 +49,7 @@ function sourcecode( editor ) {
 			return;
 		}
 
-		event.content = wrapPre( event.content, event.initial );
+		event.content = wrapPre( event );
 	} );
 
 	editor.on( 'GetContent', ( event ) => {
@@ -47,7 +57,7 @@ function sourcecode( editor ) {
 			return;
 		}
 
-		event.content = unwrapPre( event.content );
+		event.content = unwrapPre( event );
 	} );
 
 	editor.on( 'PostProcess', ( event ) => {
@@ -55,7 +65,7 @@ function sourcecode( editor ) {
 			return;
 		}
 
-		event.content = unwrapPre( event.content );
+		event.content = unwrapPre( event );
 	} );
 }
 

--- a/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
@@ -21,17 +21,13 @@ export function wrapPre( content, initial ) {
 	} );
 }
 
-export function unwrapPre( content, mode ) {
+export function unwrapPre( content ) {
 	if ( ! content || content.indexOf( '[' ) === -1 ) {
 		return content;
 	}
 
 	return content.replace( REGEXP_CODE_SHORTCODE, function( match, shortcode ) {
 		shortcode = shortcode.replace( /&lt;/g, '<' ).replace( /&gt;/g, '>' ).replace( /&amp;/g, '&' );
-
-		if ( 'html' === mode ) {
-			return shortcode;
-		}
 
 		return `<p>${ shortcode }</p>`;
 	} );
@@ -44,10 +40,6 @@ function sourcecode( editor ) {
 		}
 
 		event.content = wrapPre( event.content, event.initial );
-	} );
-
-	editor.on( 'BeforeSetTextAreaContent', ( event ) => {
-		event.content = unwrapPre( event.content, 'html' );
 	} );
 
 	editor.on( 'GetContent', ( event ) => {

--- a/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
@@ -21,13 +21,17 @@ export function wrapPre( content, initial ) {
 	} );
 }
 
-export function unwrapPre( content ) {
+export function unwrapPre( content, mode ) {
 	if ( ! content || content.indexOf( '[' ) === -1 ) {
 		return content;
 	}
 
 	return content.replace( REGEXP_CODE_SHORTCODE, function( match, shortcode ) {
 		shortcode = shortcode.replace( /&lt;/g, '<' ).replace( /&gt;/g, '>' ).replace( /&amp;/g, '&' );
+
+		if ( 'html' === mode ) {
+			return shortcode;
+		}
 
 		return `<p>${ shortcode }</p>`;
 	} );
@@ -43,7 +47,7 @@ function sourcecode( editor ) {
 	} );
 
 	editor.on( 'BeforeSetTextAreaContent', ( event ) => {
-		event.content = unwrapPre( event.content );
+		event.content = unwrapPre( event.content, 'html' );
 	} );
 
 	editor.on( 'GetContent', ( event ) => {

--- a/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
@@ -42,6 +42,10 @@ function sourcecode( editor ) {
 		event.content = wrapPre( event.content, event.initial );
 	} );
 
+	editor.on( 'BeforeSetTextAreaContent', ( event ) => {
+		event.content = unwrapPre( event.content );
+	} );
+
 	editor.on( 'GetContent', ( event ) => {
 		if ( event.format !== 'raw' || ! event.content || event.selection ) {
 			return;

--- a/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
@@ -21,30 +21,64 @@ describe( 'wpcom-sourcecode', () => {
 
 	describe( '#wrapPre()', () => {
 		it( 'should wrap a code shortcode', () => {
-			const wrapped = wrapPre( '[code lang="javascript"]var foo;[/code]' );
-			expect( wrapped ).to.equal( '<pre>[code lang="javascript"]var foo;[/code]</pre>' );
+			const wrapped = wrapPre( {
+				content: '[code lang="javascript"]const noop = () => {};[/code]'
+			} );
+
+			expect( wrapped ).to.equal( '<pre>[code lang="javascript"]const noop = () =&gt; {};[/code]</pre>' );
+		} );
+
+		it( 'should not encode entities when initial non-load', () => {
+			const wrapped = wrapPre( {
+				content: '[code lang="javascript"]const noop = () =&gt; {};[/code]',
+				initial: true
+			} );
+
+			expect( wrapped ).to.equal( '<pre>[code lang="javascript"]const noop = () =&gt; {};[/code]</pre>' );
+		} );
+
+		it( 'should encode entities when initial load', () => {
+			const wrapped = wrapPre( {
+				content: '[code lang="javascript"]const noop = () => {};[/code]',
+				initial: true,
+				load: true
+			} );
+
+			expect( wrapped ).to.equal( '<pre>[code lang="javascript"]const noop = () =&gt; {};[/code]</pre>' );
 		} );
 
 		it( 'should wrap a sourcecode shortcode', () => {
-			const wrapped = wrapPre( '[sourcecode lang="javascript"]var foo;[/sourcecode]' );
-			expect( wrapped ).to.equal( '<pre>[sourcecode lang="javascript"]var foo;[/sourcecode]</pre>' );
+			const wrapped = wrapPre( {
+				content: '[sourcecode lang="javascript"]const noop = () => {};[/sourcecode]'
+			} );
+
+			expect( wrapped ).to.equal( '<pre>[sourcecode lang="javascript"]const noop = () =&gt; {};[/sourcecode]</pre>' );
 		} );
 	} );
 
 	describe( '#unwrapPre()', () => {
 		it( 'should unwrap a code shortcode', () => {
-			const unwrapped = unwrapPre( '<pre>[code lang="javascript"]var foo;[/code]</pre>' );
-			expect( unwrapped ).to.equal( '<p>[code lang="javascript"]var foo;[/code]</p>' );
+			const unwrapped = unwrapPre( {
+				content: '<pre>[code lang="javascript"]const noop = () =&gt; {};[/code]</pre>'
+			} );
+
+			expect( unwrapped ).to.equal( '<p>[code lang="javascript"]const noop = () => {};[/code]</p>' );
 		} );
 
 		it( 'should unwrap a sourcecode shortcode', () => {
-			const unwrapped = unwrapPre( '<pre>[sourcecode lang="javascript"]var foo;[/sourcecode]</pre>' );
-			expect( unwrapped ).to.equal( '<p>[sourcecode lang="javascript"]var foo;[/sourcecode]</p>' );
+			const unwrapped = unwrapPre( {
+				content: '<pre>[sourcecode lang="javascript"]const noop = () =&gt; {};[/sourcecode]</pre>'
+			} );
+
+			expect( unwrapped ).to.equal( '<p>[sourcecode lang="javascript"]const noop = () => {};[/sourcecode]</p>' );
 		} );
 
 		it( 'should gracefully handle surrounding content', () => {
-			const unwrapped = unwrapPre( '<p>foo</p><p><pre>[sourcecode lang="javascript"]var foo;[/sourcecode]</pre></p><p>bar</p>' );
-			expect( unwrapped ).to.equal( '<p>foo</p><p>[sourcecode lang="javascript"]var foo;[/sourcecode]</p><p>bar</p>' );
+			const unwrapped = unwrapPre( {
+				content: '<p>foo</p><p><pre>[sourcecode lang="javascript"]const noop = () =&gt; {};[/sourcecode]</pre></p><p>bar</p>'
+			} );
+
+			expect( unwrapped ).to.equal( '<p>foo</p><p>[sourcecode lang="javascript"]const noop = () => {};[/sourcecode]</p><p>bar</p>' );
 		} );
 	} );
 } );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -133,7 +133,7 @@ const PostEditor = React.createClass( {
 		debug( 'PostEditor react component mounted.' );
 		// if content is passed in, e.g., through url param
 		if ( this.state.post && this.state.post.content ) {
-			this.refs.editor.setEditorContent( this.state.post.content );
+			this.refs.editor.setEditorContent( this.state.post.content, { initial: true } );
 		}
 	},
 
@@ -390,7 +390,7 @@ const PostEditor = React.createClass( {
 			}
 			this.setState( postEditState, function() {
 				if ( didLoad || this.state.isLoadingAutosave ) {
-					this.refs.editor.setEditorContent( this.state.post.content );
+					this.refs.editor.setEditorContent( this.state.post.content, { initial: true } );
 				}
 
 				if ( this.state.isLoadingAutosave ) {


### PR DESCRIPTION
Fixes #1426 

This pull request seeks to resolve an issue which sometimes causes content of a [`[sourcecode]` shortcode](https://en.support.wordpress.com/code/posting-source-code/) to be double-encoded. 

This happens because:

- We were not passing an accurate `initial` value into the `setContent` arguments when assigning content to TinyMCE from a post which is loaded or a post which had been edited previously within the same Calypso session
- The textarea content was not filtered to decode entities from the received post content

__Testing Instructions:__

Repeat testing instructions from https://github.com/Automattic/wp-calypso/issues/1426#issuecomment-245455022

Also verify that code appears correct when switching between editing modes, and when refreshing while viewing either editing mode (specifically verifying that HTML content is decoded upon load).

cc @alisterscott @azaozz 