### PR TITLE
Plugins: Make sure an image can be found

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -112,7 +112,7 @@ PluginUtils = {
 			const img = li.querySelectorAll( 'img' );
 			const captionP = li.querySelectorAll( 'p' );
 
-			if ( img[ 0 ].src ) {
+			if ( img[ 0 ] && img[ 0 ].src ) {
 				return {
 					url: img[ 0 ].src,
 					caption: captionP[ 0 ] ? captionP[ 0 ].textContent : null


### PR DESCRIPTION
Fixes an issue where we thought that a particular wordpress.org plugin
doesn't exists in the .org repo but we just ran into a problem parsing
the data.

Before:
![image](https://cloud.githubusercontent.com/assets/115071/18961339/9085f686-8621-11e6-8b14-7b00d7067c06.png)
After:
<img width="802" alt="screen shot 2016-09-29 at 08 48 19" src="https://cloud.githubusercontent.com/assets/115071/18961349/9de079b4-8621-11e6-84f3-888c87066bb1.png">

