### PR TITLE
Reader: Fix action bar elements overlapping

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -92,7 +92,6 @@
 .reader-full-post .author-compact-profile {
 	display: inline-flex;
 	flex-direction: column;
-	z-index: z-index( '.masterbar', '.reader-profile' );
 
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 35px;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8245

**Before:**
![img_3079](https://cloud.githubusercontent.com/assets/4924246/18965904/e8f8cd2c-8633-11e6-9aca-e0dd82bd5f82.jpg)

**After:**
![img_3078](https://cloud.githubusercontent.com/assets/4924246/18965907/ee7b75ba-8633-11e6-8b7c-638342eaeae4.jpg)

/cc @designsimply 

