### PR TITLE
Fix/reader/discover full post styles

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -323,62 +323,37 @@
 
 	blockquote.sidenote {
 		margin: 0;
-		padding: 0;
+		padding: 16px;
 		border: none;
 		background: none;
 		font-size: 13px;
 		width: 175px;
 
-		@media ( min-width: 1132px ) {
-			position: absolute;
+		&.left,
+		&.alignleft {
+			float: left;
+			padding: 0 16px 16px 0;
+		}
 
+		@media ( min-width: 1400px ) {
 			&.right,
 			&.alignright {
+				position: absolute;
 				right: -( 175px + 32px );
 				margin-right: 0;
 			}
-
-			&.left,
-			&.alignleft {
-				left: -( 175px + 32px );
-				margin-left: 0;
-			}
 		}
 
-		@media ( max-width: 1132px ) {
+		@media ( max-width: 1400px ) {
 			&.right,
 			&.alignright,
 			&.left,
 			&.alignleft {
-				background: lighten( $gray, 30 );
-				margin: 0 0 24px 0;
-				padding: 16px;
-				width: auto;
-			}
-		}
-
-		@include breakpoint( "<960px" ) {
-			&.right,
-			&.alignright {
-				float: right;
-			}
-
-			&.left,
-			&.alignleft {
-				float: left;
-			}
-		}
-
-		@include breakpoint( "<480px" ) {
-		  &.alignleft,
-			&.alignright,
-			&.right,
-			&.left {
-				width: auto;
 				float: none;
-				margin: 0 0 24px 0;
 				background: lighten( $gray, 30 );
+				margin: 0 0 24px 0;
 				padding: 16px;
+				width: auto;
 
 				img {
 					display: block;

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -387,15 +387,6 @@
 			}
 		}
 	}
-
-	.fullbleed {
-		@media ( min-width: 1132px ) {
-			position: relative;
-			left: -( 175px + 32px );
-			width: ( 668px + 414px );
-			max-width: ( 668px + 414px );
-		}
-	}
 }
 
 // Daily Post-Specific Full Post View Styles


### PR DESCRIPTION
Fixes #8330

The fix for the `.fullbleed` image is simple: we just need to remove those styles and prevent it from extending beyond the edges of the text. 

As for the notes in the gutter, I think we need to just treat the left-hand ones as normal floated elements, and adjust the styles for the right-hand notes to mimic the (non-broken) right hand note styles that The Daily Post uses ( [example here](https://wordpress.com/read/feeds/27030/posts/1170950508) ).

---

Before:

<img width="1440" alt="screen shot 2016-09-29 at 2 27 36 pm" src="https://cloud.githubusercontent.com/assets/1202812/18966883/10b04ad0-8651-11e6-928a-8d31bd3cad54.png">

After:

<img width="1440" alt="screen shot 2016-09-29 at 2 27 45 pm" src="https://cloud.githubusercontent.com/assets/1202812/18966881/0dc08aba-8651-11e6-9ad8-32e2114e70b5.png">
