### PR TITLE
Reader: add placeholder for reader-related-card-v2

### DIFF
--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -91,9 +91,9 @@ export function RelatedPostCard( { post, site, onPostClick = noop, onSiteClick =
 		'has-thumbnail': !! featuredImage
 	} );
 
-	//if ( ! post || post.state == 'pending' ) {
+	if ( ! post || post._state === 'minimal' || post._state === 'pending' ) {
 		return <RelatedPostCardPlaceholder />;
-	//}
+	}
 
 	return (
 		<Card className={ classes }>

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -50,6 +50,37 @@ function AuthorAndSiteFollow( { post, site } ) {
 	);
 }
 
+function AuthorAndSiteFollowPlaceholder() {
+	return (
+		<div className="reader-related-card-v2__meta is-placeholder">
+			<Gravatar user={ null } />
+			<div className="reader-related-card-v2__byline">
+				<span className="reader-related-card-v2__byline-author">
+					Author name
+				</span>
+				<span className="reader-related-card-v2__byline-site">
+					Site title
+				</span>
+			</div>
+		</div>
+	);
+}
+
+function RelatedPostCardPlaceholder() {
+	return (
+		<Card className="reader-related-card-v2 is-placeholder">
+			<AuthorAndSiteFollowPlaceholder />
+			<a className="reader-related-card-v2__post reader-related-card-v2__link-block">
+				<div className="reader-related-card-v2__featured-image"></div>
+				<div className="reader-related-card-v2__site-info">
+					<h1 className="reader-related-card-v2__title">Title</h1>
+					<div className="reader-related-card-v2__excerpt post-excerpt">Excerpt</div>
+				</div>
+			</a>
+		</Card>
+	);
+}
+
 /* eslint-disable no-unused-vars */
 export function RelatedPostCard( { post, site, onPostClick = noop, onSiteClick = noop } ) {
 // onSiteClick is not being used
@@ -59,6 +90,10 @@ export function RelatedPostCard( { post, site, onPostClick = noop, onSiteClick =
 	const classes = classnames( 'reader-related-card-v2', {
 		'has-thumbnail': !! featuredImage
 	} );
+
+	//if ( ! post || post.state == 'pending' ) {
+		return <RelatedPostCardPlaceholder />;
+	//}
 
 	return (
 		<Card className={ classes }>

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -443,6 +443,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 }
 
+// Placeholders
 .reader-related-card-v2.is-placeholder {
 	.reader-related-card-v2__title,
 	.reader-related-card-v2__excerpt,
@@ -451,7 +452,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 		// Clobber the long-content-fade
 		&::after {
-			content: none !important;
+			content: none;
+		}
+	}
+
+	.reader-related-card-v2__post {
+		// Clobber the long-content-fade
+		&::after {
+			content: none;
 		}
 	}
 }
@@ -463,7 +471,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 		// Clobber the long-content-fade
 		&::after {
-			content: none !important;
+			content: none;
 		}
 	}
 

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -442,3 +442,32 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		max-height: none;
 	}
 }
+
+.reader-related-card-v2.is-placeholder {
+	.reader-related-card-v2__title,
+	.reader-related-card-v2__excerpt,
+	.reader-related-card-v2__featured-image {
+		@include placeholder;
+
+		// Clobber the long-content-fade
+		&::after {
+			content: none !important;
+		}
+	}
+}
+
+.reader-related-card-v2__meta.is-placeholder {
+	.reader-related-card-v2__byline-author,
+	.reader-related-card-v2__byline-site {
+		@include placeholder;
+
+		// Clobber the long-content-fade
+		&::after {
+			content: none !important;
+		}
+	}
+
+	.reader-related-card-v2__byline-site {
+		margin-top: 4px;
+	}
+}

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -456,6 +456,17 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 	}
 
+	.reader-related-card-v2__site-info {
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			flex: 2;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			flex: 2;
+		}
+	}
+
 	.reader-related-card-v2__post {
 		// Clobber the long-content-fade
 		&::after {


### PR DESCRIPTION
Add a placeholder when related posts blocks are loading in the new Reader full post view.

This will help us when we need to scroll to a specific spot on the page before everything's loaded (e.g. for comments anchor https://github.com/Automattic/wp-calypso/pull/7892).

Outstanding tasks:
- [x] Turn off long content fade (cc @jancavan)
- [x] Uncomment logic to only use placeholder when post is missing or still in `pending` state