### PR TITLE
Updating button styles

### DIFF
--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -11,6 +11,7 @@
 	display: flex;
 	align-items: baseline;
 	justify-content: flex-end;
+	flex-wrap: wrap-reverse;
 	margin-bottom: 6px;
 }
 
@@ -22,12 +23,14 @@
 
 .title-format-editor__button {
 	border-radius: 3px;
-	background-color: lighten( $gray, 30% );
+	background-color: $white;
 	color: darken( $gray, 30% );
-	padding: 4px 8px;
+	border: 1px solid lighten( $gray, 20% );
+	padding: 3px 8px 3px 8px;
 	margin-left: 10px;
+	margin-top: 3px;
 	font-size: 12px;
-	font-weight: bold;
+	font-weight: 600;
 	cursor: pointer;
 
 	&:before {
@@ -37,7 +40,7 @@
 	}
 
 	&:hover {
-		background-color: lighten( $gray, 20% );
+		color: $blue-medium;
 	}
 }
 


### PR DESCRIPTION
Updates the button styles on Advanced SEO title editor. This aligns the style with the buttons found in the sidebar.

Also, notice I changed how the buttons wrap on small widths.

fixes #8331 

## Before:
![screen shot 2016-09-29 at 1 48 15 pm](https://cloud.githubusercontent.com/assets/618551/18967619/8625c412-864b-11e6-9a27-46b62530ad08.png)

## After:
![screen shot 2016-09-29 at 1 46 50 pm](https://cloud.githubusercontent.com/assets/618551/18967624/8c52ac7e-864b-11e6-8c45-eae103e8c02e.png)
