### PR TITLE
Stats: Trash pickup of old localStore usage.

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -3,7 +3,6 @@
  */
 import page from 'page';
 import React from 'react';
-import store from 'store';
 import debugFactory from 'debug';
 
 /**
@@ -65,16 +64,10 @@ module.exports = React.createClass( {
 
 	componentDidMount: function() {
 		const scrollPosition = this.state.scrollPosition;
-		const localKey = 'statsHide' + this.props.siteId;
-		const hiddenSiteModules = store.get( localKey ) || [];
 
 		setTimeout( function() {
 			window.scrollTo( 0, scrollPosition );
 		} );
-
-		if ( hiddenSiteModules.length ) {
-			analytics.mc.bumpStat( 'calypso_stats_mod_hidden', hiddenSiteModules.length );
-		}
 	},
 
 	updateScrollPosition: function() {
@@ -85,12 +78,6 @@ module.exports = React.createClass( {
 	// When user clicks on a bar, set the date to the bar's period
 	chartBarClick: function( bar ) {
 		page.redirect( this.props.path + '?startDate=' + bar.period );
-	},
-
-	trackOldStats: function() {
-		const oldStatsLocation = ( 'wp-admin' === store.get( 'oldStatsLink' ) ) ? 'wp-admin' : 'my-stats';
-		analytics.mc.bumpStat( 'calypso_stats_return', oldStatsLocation );
-		analytics.ga.recordEvent( 'Stats', 'Clicked Visit Old Stats Page Button', oldStatsLocation );
 	},
 
 	barClick: function( bar ) {

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ export default React.createClass( {
 
 	getInitialState: function() {
 		var activeTab = this.getActiveTab(),
-			activeCharts = activeTab.legendOptions.slice() || [];
+			activeCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
 
 		return {
 			activeLegendCharts: activeCharts,
@@ -157,11 +158,8 @@ export default React.createClass( {
 	},
 
 	getActiveTab: function( nextProps ) {
-		var props = nextProps || this.props;
-
-		return props.charts.filter( function( chart ) {
-			return chart.attr === props.chartTab;
-		}, this ).shift();
+		const props = nextProps || this.props;
+		return find( props.charts, { attr: props.chartTab } ) || props.charts[ 0 ];
 	},
 
 	buildChartData: function() {


### PR DESCRIPTION
This PR seeks to remove a few remaining uses of `store` within Stats code.  At one point we wanted to keep track of the dates users had been visiting stats pages - `statsVisitDates` is no longer used and has been removed from the controller logic here.

The other bit of logic is to track which tab in the stats chart was last focused.  As we do further redux work in stats, we might consider adding a `ui` state tree for this aspect of stats, but I feel defaulting to 'Views' in the stats chart is fine personally.

__To Test__
- Load up the stats overview page http://calypso.localhost:3000/stats - ensure it loads as expected
- Click through to a site listed there, ensure the site stats page loads properly