### PR TITLE
Reader Refresh - fullpost stats fix

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -26,11 +26,12 @@ const AuthorCompactProfile = React.createClass( {
 		feedId: React.PropTypes.number,
 		siteId: React.PropTypes.number,
 		siteIcon: React.PropTypes.string,
-		feedIcon: React.PropTypes.string
+		feedIcon: React.PropTypes.string,
+		post: React.PropTypes.object,
 	},
 
 	render() {
-		const { author, siteIcon, feedIcon, siteName, siteUrl, feedUrl, followCount, feedId, siteId } = this.props;
+		const { author, siteIcon, feedIcon, siteName, siteUrl, feedUrl, followCount, feedId, siteId, post } = this.props;
 
 		if ( ! author ) {
 			return null;
@@ -54,9 +55,9 @@ const AuthorCompactProfile = React.createClass( {
 					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
 				</a>
 				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames && ! includes( authorNameBlacklist, author.name.toLowerCase() ) &&
-					<ReaderAuthorLink author={ author } siteUrl={ streamUrl }>{ author.name }</ReaderAuthorLink> }
+					<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>{ author.name }</ReaderAuthorLink> }
 				{ siteName &&
-					<ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId }>
+					<ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId } post={ post } >
 						{ siteName }
 					</ReaderSiteStreamLink> }
 

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import noop from 'lodash/noop';
+import partial from 'lodash/partial';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -98,14 +99,16 @@ export function RelatedPostCard( { post, site, onPostClick = noop, onSiteClick =
 	return (
 		<Card className={ classes }>
 			<AuthorAndSiteFollow post={ post } site={ site } />
-			<a href={ postLink } className="reader-related-card-v2__post reader-related-card-v2__link-block">
-				{ featuredImage && <FeaturedImage image={ featuredImage } href={ post.URL } /> }
-				<div className="reader-related-card-v2__site-info">
-					<h1 className="reader-related-card-v2__title">{ post.title }</h1>
-					<div className="reader-related-card-v2__excerpt post-excerpt">
-						{ featuredImage ? post.short_excerpt : post.excerpt }
+			<a href={ postLink } className="reader-related-card-v2__post reader-related-card-v2__link-block"
+				onClick={ partial( onPostClick, post ) } >
+					{ featuredImage && <FeaturedImage image={ featuredImage } href={ post.URL }
+						onClick={ partial( onPostClick, post ) } /> }
+					<div className="reader-related-card-v2__site-info">
+						<h1 className="reader-related-card-v2__title">{ post.title }</h1>
+						<div className="reader-related-card-v2__excerpt post-excerpt">
+							{ featuredImage ? post.short_excerpt : post.excerpt }
+						</div>
 					</div>
-				</div>
 			</a>
 		</Card>
 	);

--- a/client/blocks/reader-site-stream-link/index.jsx
+++ b/client/blocks/reader-site-stream-link/index.jsx
@@ -27,7 +27,7 @@ const ReaderSiteStreamLink = React.createClass( {
 
 	render() {
 		const link = getStreamUrl( this.props.feedId, this.props.siteId );
-		const omitProps = [ 'feedId', 'siteId' ];
+		const omitProps = [ 'feedId', 'siteId', 'post' ];
 
 		return (
 			<a { ...omit( this.props, omitProps ) } href={ link } onClick={ this.recordClick }>{ this.props.children }</a>

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -2,8 +2,9 @@ const React = require( 'react' );
 
 const postStore = require( 'lib/feed-post-store' );
 
-const LikeButtonContainer = require( 'blocks/like-button' ),
-	stats = require( 'reader/stats' );
+const LikeButtonContainer = require( 'blocks/like-button' );
+
+import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
 const ReaderLikeButton = React.createClass( {
 
@@ -12,9 +13,11 @@ const ReaderLikeButton = React.createClass( {
 			blogId: this.props.siteId,
 			postId: this.props.postId
 		} );
-		stats.recordAction( liked ? 'liked_post' : 'unliked_post' );
-		stats.recordGaEvent( liked ? 'Clicked Like Post' : 'Clicked Unlike Post' );
-		stats.recordTrackForPost( liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked', post, { context: this.props.fullPost ? 'full-post' : 'card' } );
+
+		recordAction( liked ? 'liked_post' : 'unliked_post' );
+		recordGaEvent( liked ? 'Clicked Like Post' : 'Clicked Unlike Post' );
+		recordTrackForPost( liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked', post,
+				{ context: this.props.fullPost ? 'full-post' : 'card' } );
 	},
 
 	render: function() {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -99,13 +99,15 @@ export function recordTrack( eventName, eventProperties ) {
 
 const tracksRailcarEventWhitelist = new Set();
 tracksRailcarEventWhitelist
-	.add( 'calypso_reader_related_post_clicked' )
+	.add( 'calypso_reader_related_post_from_same_site_clicked' )
+	.add( 'calypso_reader_related_post_from_other_site_clicked' )
 	.add( 'calypso_reader_related_post_site_clicked' )
 	.add( 'calypso_reader_article_liked' )
 	.add( 'calypso_reader_article_commented_on' )
 	.add( 'calypso_reader_article_opened' )
 	.add( 'calypso_reader_startcard_clicked' )
 	.add( 'calypso_reader_searchcard_clicked' )
+	.add( 'calypso_reader_author_link_clicked' )
 ;
 
 export function recordTracksRailcar( action, eventName, railcar ) {


### PR DESCRIPTION
Stats to fix:

1. [x] calypso_reader_article_closed 
1. [X] calypso_reader_full_post_like_button_clicked --> This shouldn't have existed
1. [x] calypso_reader_related_post_clicked -->{ `calypso_reader_related_post_from_same_site_clicked`, `calypso_reader_related_post_from_other_site_clicked` }
1. [X] calypso_reader_related_post_site_clicked -- This never worked
1. [x] calypso_reader_author_link_clicked 
1. [x] calypso_reader_feed_link_clicked 

Fixes #8300.