### PR TITLE
Signup: Fix stepSectionName error

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -13,6 +13,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { submitSignupStep } from 'lib/signup/actions';
 import signupUtils from 'signup/utils';
+import { get } from 'lodash';
 
 const NavigationLink = React.createClass( {
 	propTypes: {
@@ -34,8 +35,9 @@ const NavigationLink = React.createClass( {
 			return this.props.backUrl;
 		}
 
-		const previousStepName = signupUtils.getPreviousStepName( this.props.flowName, this.props.stepName ),
-			{ stepSectionName } = find( this.props.signupProgressStore, { stepName: previousStepName } );
+		const previousStepName = signupUtils.getPreviousStepName( this.props.flowName, this.props.stepName );
+
+		const stepSectionName = get( find( this.props.signupProgressStore, { stepName: previousStepName } ), 'stepSectionName', '' );
 
 		return signupUtils.getStepUrl( this.props.flowName, previousStepName, stepSectionName, i18n.getLocaleSlug() );
 	},


### PR DESCRIPTION
Steps to reproduce: 

1. Open a new incognito window
2. Navigate to `http://calypso.localhost:3000/start/design-type`
3. `index.jsx:70 Uncaught (in promise) TypeError: Cannot read property 'stepSectionName' of undefined` appears in Console. 

After applying this patch verify that the error from step 3 is no longer present.