### PR TITLE
Plugins wpcom: check icon is not aligned 

### DIFF
--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -75,6 +75,7 @@
 .wpcom-plugins__plugin-icon .gridicons-checkmark-circle {
 	position: absolute;
 		bottom: -5px;
+		right: -8px;
 	border-radius: 100%;
 	fill: $alert-green;
 	background: $white;


### PR DESCRIPTION
In Chrome, the check icon is not aligned for some reason. Fine in Safari and FF.

After:
![screen shot 2016-09-29 at 3 51 48 pm](https://cloud.githubusercontent.com/assets/618551/18971995/f4c343fc-865c-11e6-86bb-9cc54691951e.png)

Before:
![screen shot 2016-09-29 at 3 51 05 pm](https://cloud.githubusercontent.com/assets/618551/18971999/f8020260-865c-11e6-8e90-e2f94234d6a9.png)
