### PR TITLE
Stats: optimize Posting Activity component

### DIFF
--- a/client/my-sites/stats/post-trends/day.jsx
+++ b/client/my-sites/stats/post-trends/day.jsx
@@ -67,8 +67,8 @@ export default React.createClass( {
 
 		return (
 			<div className={ classNames( 'post-trends__day', hoveredClass, className ) }
-				onMouseEnter={ this.mouseEnter }
-				onMouseLeave={ this.mouseLeave }
+				onMouseEnter={ postCount > 0 ? this.mouseEnter : null }
+				onMouseLeave={ postCount > 0 ? this.mouseLeave : null }
 				ref="day">
 				{ ( postCount > 0 ) &&
 					<Tooltip

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -16,9 +16,9 @@ import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
-	isRequestingSiteStatsForQuery,
 	getSiteStatsPostStreakData,
-	getSiteStatsMaxPostsByDay
+	getSiteStatsMaxPostsByDay,
+	getSiteStatsTotalPostsForStreakQuery
 } from 'state/stats/lists/selectors';
 
 const PostTrends = React.createClass( {
@@ -55,6 +55,12 @@ const PostTrends = React.createClass( {
 	// Remove listener
 	componentWillUnmount: function() {
 		window.removeEventListener( 'resize', this.resize );
+	},
+
+	shouldComponentUpdate: function( nextProps ) {
+		// only update if the total number of posts, or query.endDate has changed
+		return nextProps.totalPosts !== this.props.totalPosts ||
+			nextProps.query.endDate !== this.props.query.endDate;
 	},
 
 	resize: function() {
@@ -130,27 +136,19 @@ const PostTrends = React.createClass( {
 	},
 
 	render: function() {
-		var leftClass,
-			rightClass,
-			containerClass;
+		const { siteId, query } = this.props;
 
-		const { siteId, query, requesting } = this.props;
-
-		leftClass = classNames( 'post-trends__scroll-left', {
+		const leftClass = classNames( 'post-trends__scroll-left', {
 			'is-active': this.state.canScrollLeft
 		} );
 
-		rightClass = classNames( 'post-trends__scroll-right', {
+		const rightClass = classNames( 'post-trends__scroll-right', {
 			'is-active': this.state.canScrollRight
-		} );
-
-		containerClass = classNames( 'post-trends', {
-			'is-loading': requesting
 		} );
 
 		return (
 
-			<div className={ containerClass }>
+			<div className="post-trends">
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
 				<SectionHeader label={ this.translate( 'Posting Activity' ) }></SectionHeader>
 				<Card>
@@ -187,9 +185,9 @@ export default connect( ( state ) => {
 	};
 
 	return {
-		requesting: isRequestingSiteStatsForQuery( state, siteId, 'statsStreak', query ),
 		streakData: getSiteStatsPostStreakData( state, siteId, query ),
 		max: getSiteStatsMaxPostsByDay( state, siteId, query ),
+		totalPosts: getSiteStatsTotalPostsForStreakQuery( state, siteId, query ),
 		query,
 		siteId
 	};

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import forOwn from 'lodash/forOwn';
-import get from 'lodash/get';
+import { forOwn, get, reduce } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -98,6 +97,27 @@ export const getSiteStatsMaxPostsByDay = createSelector(
 		} );
 
 		return max || null;
+	},
+	( state, siteId, query ) => getSiteStatsForQuery( state, siteId, 'statsStreak', query ),
+	( state, siteId, query ) => {
+		const serializedQuery = getSerializedStatsQuery( query );
+		return [ siteId, 'statsStreakMax', serializedQuery ].join();
+	}
+);
+
+/**
+ * Returns the total number of posts per streak data for a query
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {Object}  query    Stats query object
+ * @return {?Number}          Max number of posts by day
+ */
+export const getSiteStatsTotalPostsForStreakQuery = createSelector(
+	( state, siteId, query ) => {
+		return reduce( getSiteStatsPostStreakData( state, siteId, query ), ( posts, sum ) => {
+			return sum + posts;
+		}, 0 );
 	},
 	( state, siteId, query ) => getSiteStatsForQuery( state, siteId, 'statsStreak', query ),
 	( state, siteId, query ) => {

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -11,6 +11,7 @@ import {
 	getSiteStatsForQuery,
 	getSiteStatsPostStreakData,
 	getSiteStatsPostsCountByDay,
+	getSiteStatsTotalPostsForStreakQuery,
 	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery
 } from '../selectors';
@@ -19,6 +20,7 @@ describe( 'selectors', () => {
 	beforeEach( () => {
 		getSiteStatsPostStreakData.memoizedSelector.cache.clear();
 		getSiteStatsMaxPostsByDay.memoizedSelector.cache.clear();
+		getSiteStatsTotalPostsForStreakQuery.memoizedSelector.cache.clear();
 		getSiteStatsNormalizedData.memoizedSelector.cache.clear();
 	} );
 
@@ -151,6 +153,44 @@ describe( 'selectors', () => {
 				'2016-04-29': 1,
 				'2016-05-24': 2
 			} );
+		} );
+	} );
+
+	describe( 'getSiteStatsTotalPostsForStreakQuery()', () => {
+		it( 'should return null if no matching query results exist', () => {
+			const stats = getSiteStatsTotalPostsForStreakQuery( {
+				stats: {
+					lists: {
+						items: {}
+					}
+				}
+			}, 2916284, {} );
+
+			expect( stats ).to.eql( 0 );
+		} );
+
+		it( 'should properly correct number of total posts', () => {
+			const stats = getSiteStatsTotalPostsForStreakQuery( {
+				stats: {
+					lists: {
+						items: {
+							2916284: {
+								statsStreak: {
+									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
+										data: {
+											1461961382: 1,
+											1464110402: 1,
+											1464110448: 1
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, { startDate: '2015-06-01', endDate: '2016-06-01' } );
+
+			expect( stats ).to.eql( 3 );
 		} );
 	} );
 


### PR DESCRIPTION
While investigating timeouts in various browsers this week - I continually was noticing the slow loading/performance of the `<PostTrends />` component.  `<PostTrends />` is the component that builds out the GitHub-esque streak visualization seen at the top of the Insights page:

![stats_ _trout_bummin_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/18971744/17141bb4-864b-11e6-952c-02ec394c3101.png)

__The Problem__
The component is `connect`ed at the root level in `index.jsx`.  This connect statement grabs the requisite data for the state tree and renders all child components, which in this case is comprised of `<Month />` ( 12 total ), `<Week />` ( 52ish ) and `<Day />`s ( typically over 430 ).  That is a **massive** number of child components!

On a fresh load of the stats insights page, the render method on `<PostTrends />` is called 25 times.  Twenty. Five.  At the bottom of this tree `<Day />` does utilize the pure-render mixin, but 25 times to render is obviously not right.

Furthermore when navigating away from the Insights page, `render()` on `<PostTrends />` fires a few more times.  When toggling back to the insights page from "Day" or "Week" of stats, `render()` is called 18 times.

__Solution__
This branch aims to stop the madness by creation of a new selector `getSiteStatsTotalPostsForStreakQuery` which simply returns a sum of the post counts for a given `statsStreak` query.  With this figure in hand, we can then utilize `shouldComponentUpdate()` to only return `true` if the total number of posts have changed - or if the `query.endDate` is different ( which signals a change in period ).

In my testing with this new logic `<PostTrends />` render() is only called twice on the initial load of the Insights page, and when navigating away to different stats pages, then back to insights, it is only called once.

I also added some minor optimizations to `<Day />` - specifically I changed the binding of `onMouseEnter/Leave` to only happen on `<Day />`s that have data associated with them - otherwise we don't even build a tooltip - so why fire state change events on these "empty" days?

__To Test__
- Interact with the Insights page on various browsers/devices
- Ensure data loads as expected ( note Post Trends is hidden on mobile viewports )

/cc @mtias 