### PR TITLE
Plugins: Fix analytics event that is fired multiple times on render

### DIFF
--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -46,11 +46,14 @@ export default React.createClass( {
 	renderRatingTier( ratingTier ) {
 		const { ratings, slug, numRatings } = this.props;
 		const numberOfRatings = ( ratings && ratings[ ratingTier ] ) ? ratings[ ratingTier ] : 0;
+		const onClickPluginRatingsLink = () => {
+			analytics.ga.recordEvent( 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', slug );
+		};
 
 		return (
 			<div className="plugin-ratings__rating-tier" key={ `plugins-ratings__tier-${ ratingTier }` }>
 				<a className="plugin-ratings__rating-container" target="_blank" rel="noopener noreferrer"
-					onClick={ analytics.ga.recordEvent( 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', slug ) }
+					onClick={ onClickPluginRatingsLink }
 					href={ this.buildReviewUrl( ratingTier ) }
 				>
 					<span className="plugin-ratings__rating-tier-text">


### PR DESCRIPTION
In 94e95c2be4bb36a3187fcb3654ebf50d16a29d23, we inadvertently broke analytics for clicking on the plugin ratings link. The analytics event was firing multiple times on render instead of `onClick`. This was due to removing the `bind` in 94e95c2be4bb36a3187fcb3654ebf50d16a29d23.

![screen shot 2016-09-29 at 3 54 56 pm](https://cloud.githubusercontent.com/assets/1126811/18972581/5e8c3fee-865f-11e6-8062-b0d838dcc0e0.png)

To test:

- Checkout `fix/plugins-click-plugin-ratings-link-stat` branch
- In console, `localStorage.setItem( 'debug', 'calypso:analytics' );
- Load `/plugins/jetpack`
- Ensure that the `Clicked Plugin Ratings Link` event does not fire
- Click a plugin rating link and ensure event fires

![screen shot 2016-09-29 at 4 12 27 pm](https://cloud.githubusercontent.com/assets/1126811/18972617/930dc2e2-865f-11e6-8fb3-138f03f6337b.png)

cc @tyxla for review.