### PR TITLE
Reader full post: use feed URL for follow button in author compact profile

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -20,6 +20,7 @@ const AuthorCompactProfile = React.createClass( {
 	propTypes: {
 		author: React.PropTypes.object.isRequired,
 		siteName: React.PropTypes.string,
+		siteUrl: React.PropTypes.string,
 		feedUrl: React.PropTypes.string,
 		followCount: React.PropTypes.number,
 		feedId: React.PropTypes.number,
@@ -29,7 +30,7 @@ const AuthorCompactProfile = React.createClass( {
 	},
 
 	render() {
-		const { author, siteIcon, feedIcon, siteName, feedUrl, followCount, feedId, siteId } = this.props;
+		const { author, siteIcon, feedIcon, siteName, siteUrl, feedUrl, followCount, feedId, siteId } = this.props;
 
 		if ( ! author ) {
 			return null;
@@ -41,6 +42,9 @@ const AuthorCompactProfile = React.createClass( {
 			'has-author-link': ! hasMatchingAuthorAndSiteNames
 		} );
 		const streamUrl = getStreamUrl( feedId, siteId );
+
+		// If we have a feed URL, use that for the follow button in preference to the site URL
+		const followUrl = feedUrl ? feedUrl : siteUrl;
 
 		return (
 			<div className={ classes }>
@@ -69,7 +73,7 @@ const AuthorCompactProfile = React.createClass( {
 					) }
 					</div> : null }
 
-					{ feedUrl && <ReaderFollowButton siteUrl={ feedUrl } /> }
+					{ followUrl && <ReaderFollowButton siteUrl={ followUrl } /> }
 				</div>
 			</div>
 		);

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -44,7 +44,7 @@ const AuthorCompactProfile = React.createClass( {
 		const streamUrl = getStreamUrl( feedId, siteId );
 
 		// If we have a feed URL, use that for the follow button in preference to the site URL
-		const followUrl = feedUrl ? feedUrl : siteUrl;
+		const followUrl = feedUrl || siteUrl;
 
 		return (
 			<div className={ classes }>

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -20,7 +20,7 @@ const AuthorCompactProfile = React.createClass( {
 	propTypes: {
 		author: React.PropTypes.object.isRequired,
 		siteName: React.PropTypes.string,
-		siteUrl: React.PropTypes.string,
+		feedUrl: React.PropTypes.string,
 		followCount: React.PropTypes.number,
 		feedId: React.PropTypes.number,
 		siteId: React.PropTypes.number,
@@ -29,7 +29,7 @@ const AuthorCompactProfile = React.createClass( {
 	},
 
 	render() {
-		const { author, siteIcon, feedIcon, siteName, siteUrl, followCount, feedId, siteId } = this.props;
+		const { author, siteIcon, feedIcon, siteName, feedUrl, followCount, feedId, siteId } = this.props;
 
 		if ( ! author ) {
 			return null;
@@ -69,7 +69,7 @@ const AuthorCompactProfile = React.createClass( {
 					) }
 					</div> : null }
 
-					<ReaderFollowButton siteUrl={ siteUrl } />
+					{ feedUrl && <ReaderFollowButton siteUrl={ feedUrl } /> }
 				</div>
 			</div>
 		);

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -189,7 +189,7 @@ export class FullPostView extends React.Component {
 								siteIcon={ get( site, 'icon.img' ) }
 								feedIcon={ get( feed, 'image' ) }
 								siteName={ post.site_name }
-								siteUrl= { post.site_URL }
+								feedUrl= { get( feed, 'feed_URL' ) }
 								followCount={ site && site.subscribers_count }
 								feedId={ +post.feed_ID }
 								siteId={ +post.site_ID } />

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -189,6 +189,7 @@ export class FullPostView extends React.Component {
 								siteIcon={ get( site, 'icon.img' ) }
 								feedIcon={ get( feed, 'image' ) }
 								siteName={ post.site_name }
+								siteUrl={ post.site_URL }
 								feedUrl= { get( feed, 'feed_URL' ) }
 								followCount={ site && site.subscribers_count }
 								feedId={ +post.feed_ID }


### PR DESCRIPTION
Fixes #8097.

The current full post view uses feed URL to power the follow button, but until now the refreshed full post view used site URL instead. These don't always match, so the correct following state wasn't always shown.

### To test

1. Follow http://calypso.localhost:3000/read/feeds/8878742 from Manage Following
2. Visit a post and ensure that the correct following state is shown in the sidebar (e.g. http://calypso.localhost:3000/read/feeds/8878742/posts/1123381012).

<img width="905" alt="screen shot 2016-09-29 at 14 20 42 copy" src="https://cloud.githubusercontent.com/assets/17325/18972949/024271f4-8650-11e6-8ea9-869813352ecb.png">


