### PR TITLE
Reader: Add space below featured image

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -382,7 +382,7 @@
 }
 
 .reader-full-post__featured-image {
-	margin-top: 27px;
+	margin: 27px 0 26px;
 }
 
 .reader-full-post__story-content img:first-child {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8247

**Before:**
![screenshot 2016-09-29 16 23 28](https://cloud.githubusercontent.com/assets/4924246/18975718/15b4a232-8661-11e6-924f-33c204a0dc22.png)

**After:**
![screenshot 2016-09-29 16 23 34](https://cloud.githubusercontent.com/assets/4924246/18975726/1db02588-8661-11e6-8e87-181ca507225a.png)
