### PR TITLE
Reader full post: blacklist 'admin' as an author name

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 import { getStreamUrl } from 'reader/route';
 import { numberFormat } from 'i18n-calypso';
-import { has } from 'lodash';
+import { has, includes } from 'lodash';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
@@ -41,13 +41,14 @@ const AuthorCompactProfile = React.createClass( {
 			'has-author-link': ! hasMatchingAuthorAndSiteNames
 		} );
 		const streamUrl = getStreamUrl( feedId, siteId );
+		const authorNameBlacklist = [ 'admin' ];
 
 		return (
 			<div className={ classes }>
 				<a href={ streamUrl }>
 					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
 				</a>
-				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames &&
+				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames && ! includes( authorNameBlacklist, author.name.toLowerCase() ) &&
 					<ReaderAuthorLink author={ author } siteUrl={ streamUrl }>{ author.name }</ReaderAuthorLink> }
 				{ siteName &&
 					<ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId }>


### PR DESCRIPTION
Some sites have the pretty meaningless author name 'admin', such as the New York Times:

http://calypso.localhost:3000/read/blogs/730811/posts/928283

@fraying has suggested that we blacklist this particular author name in the full post view.

This PR does just that. If author name is 'admin', we will not display the author name. Otherwise, we will!

Fixes #8356.