### PR TITLE
SEO: Replace spacing around tokens with mathematical medium space

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -260,7 +260,7 @@ export class TitleFormatEditor extends Component {
 			const contentState = Modifier.replaceText(
 				editorState.getCurrentContent(),
 				currentSelection,
-				` ${ title } `,
+				`\u205f${ title }\u205f`,
 				null,
 				tokenEntity
 			);

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -100,6 +100,7 @@ const {
 // Parser also requires draft-js. Lets load it after the polyfills are created too.
 const {
 	fromEditor,
+	mapTokenTitleForEditor,
 	toEditor,
 } = require( './parser' );
 
@@ -260,7 +261,7 @@ export class TitleFormatEditor extends Component {
 			const contentState = Modifier.replaceText(
 				editorState.getCurrentContent(),
 				currentSelection,
-				`\u205f${ title }\u205f`,
+				mapTokenTitleForEditor( title ),
 				null,
 				tokenEntity
 			);

--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -119,13 +119,31 @@ const emptyBlockMap = {
 };
 
 /**
+ * Preprocesses token title for display in editor.
+ *
+ * Explicit spacing is required here in order to make
+ * the display of the tokens look right. Simply adding
+ * CSS to a trimmed title leads to cursor and spacing
+ * inconsistencies.
+ *
+ * \u205f is a mathematical medium space. A normal space
+ * was being trimmed implicitly somewhere in WebKit and
+ * raising exceptions and causing visual glitches.
+ * See #8047
+ *
+ * @param {string} title - Token's title
+ * @returns string - Processed title
+ */
+export const mapTokenTitleForEditor = title => `\u205f${ title }\u205f`;
+
+/**
  * Returns the translated name for the chip
  *
  * @param {string} type chip name, e.g. 'siteName'
  * @param {object} tokens available tokens, e.g. { siteName: 'Site Name', tagline: 'Tagline' }
  * @returns {string} translated chip name
  */
-const tokenTitle = ( type, tokens ) => `\u205f${ get( tokens, type, '' ).trim() }\u205f`;
+const tokenTitle = ( type, tokens ) => mapTokenTitleForEditor( get( tokens, type, '' ).trim() );
 
 /**
  * Creates a new entity reference for a blockMap

--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -125,7 +125,7 @@ const emptyBlockMap = {
  * @param {object} tokens available tokens, e.g. { siteName: 'Site Name', tagline: 'Tagline' }
  * @returns {string} translated chip name
  */
-const tokenTitle = ( type, tokens ) => ` ${ get( tokens, type, '' ).trim() } `;
+const tokenTitle = ( type, tokens ) => `\u205f${ get( tokens, type, '' ).trim() }\u205f`;
 
 /**
  * Creates a new entity reference for a blockMap


### PR DESCRIPTION
Resolves #8047

There was a nasty bug in Safari only where the tokens and the cursor in
the custom title format editor were broken. Safari was throwing
`IndexSizeError`s because the length index passed in to a function was
greater than the text snippet given.

This appears to be a bug with WebKit but I could not track down exactly
where or why it was happening. What I was able to infer is that Safari
was somehow trimming the content inside of a given `<span>` while the
data model in the draft-js editor did not lose the wrapping spaces.

This resolution replaces a simple space with an invisible unicode
character semantically indicating visual space - the mathematical medium
space. Safari is _not_ stripping these spaces from the tokens, meaning
that the given content and the expected content in the draft-js editor
are the same and thus preserving the navigation and thus raising no
errors.

**Testing**
In **master** if you attempt to load the advanced SEO custom title format editor in Safari (or maybe  inside any WebKit browser) _and_ there are tokens in any of the fields (`Site Name`, `Post Title`, etc…) _then_ the browser should throw an error in the console and the editor won't work properly. See #8047 for some more details on the bug or [this video](https://cloudup.com/cpaoJKsVvqM) in which @roundhill demonstrated one consequence of it.

> Note: The SEO settings tab is only active for sites with at least the business-level plan or higher

In this branch, nothing should be broken like this in Safari. The behavior should match Chrome's and Firefox's behaviors.

 - Click in the end of the editor field and start typing. Does the tag extend with each keystroke?
 - Move the cursor across the input field using the arrow keys. Does it properly jump over the tokens as one might expect it to?
 - Load the page and also move the cursor across the tokens. Do console errors emerge?

cc: @roundhill