### PR TITLE
Reader: in new full post, site name should sit on same baseline as title when avatar and author name are missing

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -40,7 +40,7 @@ const AuthorCompactProfile = React.createClass( {
 		const hasMatchingAuthorAndSiteNames = hasAuthorName && siteName.toLowerCase() === author.name.toLowerCase();
 		const classes = classnames( 'author-compact-profile', {
 			'has-author-link': ! hasMatchingAuthorAndSiteNames,
-			'has-author-icon': siteIcon || feedIcon
+			'has-author-icon': siteIcon || feedIcon || ( author && author.has_avatar )
 		} );
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const authorNameBlacklist = [ 'admin' ];
@@ -50,7 +50,7 @@ const AuthorCompactProfile = React.createClass( {
 
 		return (
 			<div className={ classes }>
-				<a href={ streamUrl }>
+				<a href={ streamUrl } className="author-compact-profile__avatar-link">
 					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
 				</a>
 				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames && ! includes( authorNameBlacklist, author.name.toLowerCase() ) &&

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -39,7 +39,8 @@ const AuthorCompactProfile = React.createClass( {
 		const hasAuthorName = has( author, 'name' );
 		const hasMatchingAuthorAndSiteNames = hasAuthorName && siteName.toLowerCase() === author.name.toLowerCase();
 		const classes = classnames( 'author-compact-profile', {
-			'has-author-link': ! hasMatchingAuthorAndSiteNames
+			'has-author-link': ! hasMatchingAuthorAndSiteNames,
+			'has-author-icon': siteIcon || feedIcon
 		} );
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const authorNameBlacklist = [ 'admin' ];

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -247,29 +247,32 @@
 	}
 }
 
-// Align site name/author with title
-.reader-full-post .has-author-link.has-author-icon .author-compact-profile__avatar-link{
-	display: block;
-}
-
+// Align meta info and post title
 .reader-full-post .has-author-link .author-compact-profile__avatar-link {
 	display: none;
+}
+
+.reader-full-post .has-author-link.has-author-icon {
+	margin-top: 5px;
+
+	.reader-author-link {
+		margin-top: 0;
+	}
+
+	.author-compact-profile__avatar-link {
+		display: block;
+	}
 }
 
 .reader-full-post .has-author-link {
 	margin-top: 14px;
 }
 
-.reader-full-post .has-author-link.has-author-icon {
-	margin-top: 5px;
-}
-
 .reader-full-post .has-author-link .reader-author-link {
-	margin-top: 4px;
-}
 
-.reader-full-post .has-author-link.has-author-icon .reader-author-link {
-	margin-top: 0;
+	@include breakpoint( ">660px" ) {
+		margin-top: 4px;
+	}
 }
 
 // For posts without a title

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -56,22 +56,25 @@
 .reader-full-post__sidebar {
 	width: 220px;
 	position: fixed;
+	text-align: center;
+
 	@include breakpoint( ">1280px" ) {
 		left: calc( 50% - 490px );
 	}
+
 	@include breakpoint( "1040px-1280px" ) {
 		left: calc( 50% - 480px );
 	}
+
 	@include breakpoint( "660px-1040px" ) {
 		left: 20px;
 	}
+
 	@include breakpoint( "<660px" ) {
 		position: static;
 		width: auto;
 		text-align: left;
 	}
-	text-align: center;
-	margin-top: 4px;
 }
 
 .reader-full-post__story {
@@ -109,10 +112,6 @@
 
 	.reader-author-link {
 		margin-top: 0;
-
-		@include breakpoint( ">660px" ) {
-			margin-top: -4px; // Aligns baseline of author name with baseline of title if no avatar
-		}
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -246,6 +245,31 @@
 	.comment-button__label-status {
 		display: none;
 	}
+}
+
+// Align site name/author with title
+.reader-full-post .has-author-link.has-author-icon .author-compact-profile__avatar-link{
+	display: block;
+}
+
+.reader-full-post .has-author-link .author-compact-profile__avatar-link {
+	display: none;
+}
+
+.reader-full-post .has-author-link {
+	margin-top: 14px;
+}
+
+.reader-full-post .has-author-link.has-author-icon {
+	margin-top: 5px;
+}
+
+.reader-full-post .has-author-link .reader-author-link {
+	margin-top: 4px;
+}
+
+.reader-full-post .has-author-link.has-author-icon .reader-author-link {
+	margin-top: 0;
 }
 
 // For posts without a title
@@ -382,7 +406,7 @@
 }
 
 .reader-full-post__featured-image {
-	margin: 27px 0 26px;
+	margin: 28px 0 26px;
 }
 
 .reader-full-post__story-content img:first-child {


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/8360#issuecomment-250627598, @fraying requested that the site name should sit on the same baseline as the title when the avatar and author name are missing:

![4535d22c-8668-11e6-98ed-80ff765395ba](https://cloud.githubusercontent.com/assets/17325/18976980/5a599c26-866b-11e6-87f9-55683c10c3d0.png)

cc @jancavan 