### PR TITLE
Comments block: kick off a comment request when the siteId/postId props change

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { translate } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,6 +44,14 @@ class PostCommentList extends React.Component {
 		const postId = this.props.post.ID;
 
 		this.props.requestPostComments( siteId, postId );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		const nextSiteId = get( nextProps, 'post.site_ID' );
+		const nextPostId = get( nextProps, 'post.ID' );
+		if ( nextSiteId && nextPostId && ( this.props.post.site_ID !== nextSiteId || this.props.post.ID !== nextPostId ) ) {
+			this.props.requestPostComments( nextSiteId, nextPostId );
+		}
 	}
 
 	renderComment( commentId ) {


### PR DESCRIPTION
We ran into a bug in the Reader Related Posts block where, when switching to a new related post, the comments were not always loaded (https://github.com/Automattic/wp-calypso/issues/8171#issuecomment-249730734).

It appears that the `PostCommentsList` component was not being remounted when the post switched, so a request to fetch the new comments was never kicked off.

This PR adds a `componentWillReceiveProps` lifecycle method to `PostCommentsList`, which checks for a change in the site ID or post ID and if there is one, fires off a new comment request.

Fixes #8171.

## To test

Starting at https://calypso.localhost:3000/read/blogs/48500948/posts/6718, click a related post under the main article, and continue visiting related posts of each post. 

Ensure that the comments load in for each post where applicable (at least a comment reply box should appear if there are no comments yet).

cc @alisterscott @blowery