### PR TITLE
Jetpack Plugins: Auto focus search box when clicking "Add Plugin"

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -23,6 +23,7 @@ import URLSearch from 'lib/mixins/url-search';
 import infiniteScroll from 'lib/mixins/infinite-scroll';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import FeatureExample from 'components/feature-example';
+import { hasTouch } from 'lib/touch-detect';
 
 module.exports = React.createClass( {
 
@@ -179,6 +180,7 @@ module.exports = React.createClass( {
 
 		return (
 			<SearchCard
+				autoFocus={ ! hasTouch() }
 				onSearch={ this.doSearch }
 				initialValue={ this.props.search }
 				placeholder={ this.translate( 'Search Plugins' ) }


### PR DESCRIPTION
This PR fixes #8352 - going to the plugins browser now automatically focuses the search field:

![](https://cloud.githubusercontent.com/assets/437258/18972630/ff8381d4-8667-11e6-997a-e7dea8a86223.png)

To test:

1. Checkout this branch
2. Go to `/plugins/browse/$site` where `$site` is a Jetpack site
3. Verify that the search form field is automatically focused.

/cc @rickybanister @johnHackworth  