### PR TITLE
Domains: Show Transfer tab when a domain is pending-transfer

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -120,7 +120,7 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	getVerticalNav() {
-		if ( this.props.domain.expired || this.props.domain.pendingTransfer ) {
+		if ( this.props.domain.expired ) {
 			return null;
 		}
 
@@ -135,6 +135,10 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	emailNavItem() {
+		if ( this.props.domain.pendingTransfer ) {
+			return null;
+		}
+
 		const path = paths.domainManagementEmail(
 			this.props.selectedSite.slug,
 			this.props.domain.name
@@ -148,6 +152,10 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	nameServersNavItem() {
+		if ( this.props.domain.pendingTransfer ) {
+			return null;
+		}
+
 		const path = paths.domainManagementNameServers(
 			this.props.selectedSite.slug,
 			this.props.domain.name
@@ -161,6 +169,10 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	contactsPrivacyNavItem() {
+		if ( this.props.domain.pendingTransfer ) {
+			return null;
+		}
+
 		const path = paths.domainManagementContactsPrivacy(
 			this.props.selectedSite.slug,
 			this.props.domain.name


### PR DESCRIPTION
Users didn't have a way to cancel a pending transfer, as the whole menu was hidden. Now the Transfer tab is still there, so it's possible to cancel the transfer.