### PR TITLE
Remove not user-facing status translations from Page component

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -31,9 +31,7 @@ function getReadableStatus( status ) {
 		'pending': i18n.translate( 'Pending' ),
 		'future': i18n.translate( 'Future' ),
 		'private': i18n.translate( 'Private' ),
-		'trash': i18n.translate( 'Trashed' ),
-		'auto-draft': i18n.translate( 'Draft' ),
-		'inherit': i18n.translate( 'Inherited' )
+		'trash': i18n.translate( 'Trashed' )
 	};
 
 	return humanReadableStatus [ status ] || status;


### PR DESCRIPTION
According to the #2639 issue, I removed the last two ('auto-draft' and 'inherit') translations from Page component file. Of course, I tested it firstly. 

Go to `Pages` in sidebar menu: 
<img width="279" alt="screen shot 2016-09-30 at 13 06 18" src="https://cloud.githubusercontent.com/assets/14272775/18989875/c3dfaa84-870e-11e6-8832-999b24ad980b.png">

Notice, that every page has its own status which is visible for every user:
![imageedit_2_7329417631](https://cloud.githubusercontent.com/assets/14272775/18990095/07b9b5be-8710-11e6-95b9-03d1fe41c13e.jpg)
In the picture in the red ellipse, there we can see this user-facing status. While testing, any of these pages had the 'Inherited' status. However, their user-facing status was `Draft` in some cases, but according to their Redux state (in react dev tools console) their property `status` was set to `draft` and not `auto-draft`. 
Therefore I think, that those last two translations (https://github.com/Automattic/wp-calypso/blob/d0141897e584c621ad5d82071a4190b9740e999b/client/my-sites/pages/page.jsx#L35-L36) are useless because those two statuses really aren't user-facing. Exactly as mtias mentioned in the Issue #2639.

I tested (I hope) all possible cases before and after deleting the translations and any console error appeared. 
I created a page, moved to trash, restored, made it public, scheduled, deleted, published with `private`, `public` and `password protected` status and also made it pending. I did that everything a lot of times and in different orders.