### PR TITLE
Jetpack Plugins: Recommend plugins when search form yields no results

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -25,7 +25,6 @@ import Search from 'components/search';
 import URLSearch from 'lib/mixins/url-search';
 import EmptyContent from 'components/empty-content';
 import PluginsStore from 'lib/plugins/store';
-import { recordTracksEvent } from 'state/analytics/actions';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
 import WporgPluginsSelectors from 'state/plugins/wporg/selectors';
 import FeatureExample from 'components/feature-example';
@@ -259,10 +258,6 @@ const PluginsMain = React.createClass( {
 
 		if ( isEmpty( plugins ) && ! this.isFetchingPlugins() ) {
 			if ( this.props.search ) {
-				this.props.recordTracksEvent( 'calypso_plugins_search_noresults_recommendations_show', {
-					search_query: this.props.search
-				} );
-
 				const searchTitle = this.translate( 'Suggested plugins for: %(searchQuery)s', {
 					textOnly: true,
 					args: {
@@ -431,7 +426,6 @@ export default connect(
 		};
 	},
 	dispatch => bindActionCreators( {
-		wporgFetchPluginData,
-		recordTracksEvent
+		wporgFetchPluginData
 	}, dispatch )
 )( PluginsMain );

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -174,7 +174,7 @@ const PluginsMain = React.createClass( {
 	},
 
 	getEmptyContentUpdateData() {
-		let emptyContentData = { illustration: '/calypso/images/drake/drake-ok.svg' },
+		const emptyContentData = { illustration: '/calypso/images/drake/drake-ok.svg' },
 			selectedSite = this.props.sites.getSelectedSite();
 
 		if ( selectedSite ) {
@@ -266,7 +266,7 @@ const PluginsMain = React.createClass( {
 						sites={ this.props.sites }
 						search={ this.props.search }
 						store={ this.context.store }
-					/>
+					/>;
 			}
 
 			const emptyContentData = this.getEmptyContentData();
@@ -275,7 +275,7 @@ const PluginsMain = React.createClass( {
 					title={ emptyContentData.title }
 					illustration={ emptyContentData.illustration }
 					actionURL={ emptyContentData.actionURL }
-					action={ emptyContentData.action } />
+					action={ emptyContentData.action } />;
 			}
 		}
 		return (
@@ -321,7 +321,7 @@ const PluginsMain = React.createClass( {
 				sites={ [] }
 				selectedSite={ selectedSite }
 				progress={ [] }
-				isMock={ true } />
+				isMock={ true } />;
 		} );
 	},
 
@@ -342,7 +342,10 @@ const PluginsMain = React.createClass( {
 				<Main>
 					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
-					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
+					{ this.state.accessError.featureExample
+						? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample>
+						: null
+					}
 				</Main>
 			);
 		}
@@ -377,7 +380,7 @@ const PluginsMain = React.createClass( {
 								return null;
 							}
 
-							let attr = {
+							const attr = {
 								key: filterItem.id,
 								path: filterItem.path,
 								selected: filterItem.id === this.props.filter,

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -263,6 +263,13 @@ const PluginsMain = React.createClass( {
 					search_query: this.props.search
 				} );
 
+				const searchTitle = this.translate( 'Suggested plugins for: %(searchQuery)s', {
+					textOnly: true,
+					args: {
+						searchQuery: this.props.search
+					}
+				} );
+
 				return <PluginsBrowser
 						hideSearchForm
 						site={ selectedSite ? selectedSite.slug : null }
@@ -270,6 +277,7 @@ const PluginsMain = React.createClass( {
 						sites={ this.props.sites }
 						search={ this.props.search }
 						store={ this.context.store }
+						searchTitle={ searchTitle }
 					/>;
 			}
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -25,7 +25,7 @@ import Search from 'components/search';
 import URLSearch from 'lib/mixins/url-search';
 import EmptyContent from 'components/empty-content';
 import PluginsStore from 'lib/plugins/store';
-
+import { recordTracksEvent } from 'state/analytics/actions';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
 import WporgPluginsSelectors from 'state/plugins/wporg/selectors';
 import FeatureExample from 'components/feature-example';
@@ -259,6 +259,10 @@ const PluginsMain = React.createClass( {
 
 		if ( isEmpty( plugins ) && ! this.isFetchingPlugins() ) {
 			if ( this.props.search ) {
+				this.props.recordTracksEvent( 'calypso_plugins_search_noresults_recommendations_show', {
+					search_query: this.props.search
+				} );
+
 				return <PluginsBrowser
 						hideSearchForm
 						site={ selectedSite ? selectedSite.slug : null }
@@ -418,5 +422,8 @@ export default connect(
 			wporgPlugins: state.plugins.wporg.items
 		};
 	},
-	dispatch => bindActionCreators( { wporgFetchPluginData }, dispatch )
+	dispatch => bindActionCreators( {
+		wporgFetchPluginData,
+		recordTracksEvent
+	}, dispatch )
 )( PluginsMain );

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -21,7 +21,6 @@ import PluginItem from './plugin-item/plugin-item';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
-import NoResults from 'my-sites/no-results';
 import Search from 'components/search';
 import URLSearch from 'lib/mixins/url-search';
 import EmptyContent from 'components/empty-content';
@@ -33,6 +32,7 @@ import FeatureExample from 'components/feature-example';
 import PluginsList from './plugins-list';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import WpcomPluginPanel from 'my-sites/plugins-wpcom';
+import PluginsBrowser from './plugins-browser';
 
 /**
  * Module variables
@@ -255,13 +255,18 @@ const PluginsMain = React.createClass( {
 
 	renderPluginsContent() {
 		const plugins = this.state.plugins || [];
+		const selectedSite = this.props.sites.getSelectedSite();
 
 		if ( isEmpty( plugins ) && ! this.isFetchingPlugins() ) {
 			if ( this.props.search ) {
-				return <NoResults text={ this.translate( 'No plugins match your search for {{searchTerm/}}.', {
-					textOnly: true,
-					components: { searchTerm: <em>{ this.props.search }</em> }
-				} ) } />
+				return <PluginsBrowser
+						hideSearchForm
+						site={ selectedSite ? selectedSite.slug : null }
+						path={ this.context.path }
+						sites={ this.props.sites }
+						search={ this.props.search }
+						store={ this.context.store }
+					/>
 			}
 
 			const emptyContentData = this.getEmptyContentData();

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -8,7 +8,8 @@ var React = require( 'react' );
  */
 var PluginIcon = require( 'my-sites/plugins/plugin-icon/plugin-icon' ),
 	PluginsStore = require( 'lib/plugins/store' ),
-	Rating = require( 'components/rating/' );
+	Rating = require( 'components/rating/' ),
+	analytics = require( 'lib/analytics' );
 
 module.exports = React.createClass( {
 
@@ -33,6 +34,13 @@ module.exports = React.createClass( {
 			return PluginsStore.getSites( this.props.currentSites, this.props.plugin.slug );
 		}
 		return [];
+	},
+
+	trackPluginLinkClick: function() {
+		analytics.tracks.recordEvent( 'calypso_plugin_browser_item_click', {
+			site: this.props.site,
+			plugin: this.props.plugin.slug
+		} );
 	},
 
 	renderInstalledIn: function() {
@@ -68,7 +76,7 @@ module.exports = React.createClass( {
 		}
 		return (
 			<li className="plugins-browser-item">
-				<a href={ this.getPluginLink() } className="plugins-browser-item__link" >
+				<a href={ this.getPluginLink() } className="plugins-browser-item__link" onClick={ this.trackPluginLinkClick }>
 					<div className="plugins-browser-item__info">
 						<PluginIcon size={ this.props.iconSize } image={ this.props.plugin.icon } isPlaceholder={ this.props.isPlaceholder } />
 						<div className="plugins-browser-item__title">{ this.props.plugin.name }</div>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -134,7 +134,12 @@ module.exports = React.createClass( {
 	getSearchListView( searchTerm ) {
 		const isFetching = this.state.fullLists.search ? !! this.state.fullLists.search.fetching : true;
 		if ( this.getPluginsFullList( 'search' ).length > 0 || isFetching ) {
-			const searchTitle = this.translate( 'Results for: %(searchTerm)s', { textOnly: true, args: { searchTerm } } );
+			const searchTitle = this.props.searchTitle || this.translate( 'Results for: %(searchTerm)s', {
+				textOnly: true,
+				args: {
+					searchTerm
+				}
+			} );
 			return <PluginsBrowserList
 				plugins={ this.getPluginsFullList( 'search' ) }
 				listName={ searchTerm }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -206,6 +206,11 @@ module.exports = React.createClass( {
 		if ( this.props.category ) {
 			return this.getNavigationBar();
 		}
+
+		if ( this.props.hideSearchForm ) {
+			return;
+		}
+
 		return (
 			<div className="plugins-browser__main-header">
 				{ this.getSearchBox( false ) }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -24,8 +26,9 @@ import infiniteScroll from 'lib/mixins/infinite-scroll';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import FeatureExample from 'components/feature-example';
 import { hasTouch } from 'lib/touch-detect';
+import { recordTracksEvent } from 'state/analytics/actions';
 
-module.exports = React.createClass( {
+const PluginsBrowser = React.createClass( {
 
 	displayName: 'PluginsBrowser',
 	_SHORT_LIST_LENGTH: 6,
@@ -37,6 +40,12 @@ module.exports = React.createClass( {
 	componentDidMount() {
 		PluginsListStore.on( 'change', this.refreshLists );
 		this.props.sites.on( 'change', this.refreshLists );
+
+		if ( this.props.search && this.props.searchTitle ) {
+			this.props.recordTracksEvent( 'calypso_plugins_search_noresults_recommendations_show', {
+				search_query: this.props.search
+			} );
+		}
 	},
 
 	getInitialState() {
@@ -310,3 +319,10 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( {
+		recordTracksEvent
+	}, dispatch )
+)( PluginsBrowser );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -57,7 +57,7 @@ module.exports = React.createClass( {
 	},
 
 	fetchNextPagePlugins() {
-		var doSearch = true;
+		let doSearch = true;
 
 		if ( this.state.fullLists.search && this.state.fullLists.search.fetching ) {
 			doSearch = false;
@@ -75,7 +75,7 @@ module.exports = React.createClass( {
 	},
 
 	getPluginsLists( search ) {
-		var shortLists = {},
+		const shortLists = {},
 			fullLists = {};
 		this.visibleCategories.forEach( category => {
 			shortLists[ category ] = PluginsListStore.getShortList( category );
@@ -119,17 +119,29 @@ module.exports = React.createClass( {
 	},
 
 	getFullListView( category ) {
-		var isFetching = this.state.fullLists[ category ] ? !! this.state.fullLists[ category ].fetching : true;
+		const isFetching = this.state.fullLists[ category ] ? !! this.state.fullLists[ category ].fetching : true;
 		if ( this.getPluginsFullList( category ).length > 0 || isFetching ) {
-			return <PluginsBrowserList plugins={ this.getPluginsFullList( category ) } listName={ category } title={ this.translateCategory( category ) } site={ this.props.site } showPlaceholders={ isFetching } currentSites={ this.props.sites.getSelectedOrAllJetpackCanManage() } />;
+			return <PluginsBrowserList
+				plugins={ this.getPluginsFullList( category ) }
+				listName={ category }
+				title={ this.translateCategory( category ) }
+				site={ this.props.site }
+				showPlaceholders={ isFetching }
+				currentSites={ this.props.sites.getSelectedOrAllJetpackCanManage() } />;
 		}
 	},
 
 	getSearchListView( searchTerm ) {
-		var isFetching = this.state.fullLists.search ? !! this.state.fullLists.search.fetching : true;
+		const isFetching = this.state.fullLists.search ? !! this.state.fullLists.search.fetching : true;
 		if ( this.getPluginsFullList( 'search' ).length > 0 || isFetching ) {
-			let searchTitle = this.translate( 'Results for: %(searchTerm)s', { textOnly: true, args: { searchTerm } } );
-			return <PluginsBrowserList plugins={ this.getPluginsFullList( 'search' ) } listName={ searchTerm } title={ searchTitle } site={ this.props.site } showPlaceholders={ isFetching } currentSites={ this.props.sites.getSelectedOrAllJetpackCanManage() } />;
+			const searchTitle = this.translate( 'Results for: %(searchTerm)s', { textOnly: true, args: { searchTerm } } );
+			return <PluginsBrowserList
+				plugins={ this.getPluginsFullList( 'search' ) }
+				listName={ searchTerm }
+				title={ searchTitle }
+				site={ this.props.site }
+				showPlaceholders={ isFetching }
+				currentSites={ this.props.sites.getSelectedOrAllJetpackCanManage() } />;
 		}
 		return (
 			<NoResults
@@ -143,14 +155,15 @@ module.exports = React.createClass( {
 	},
 
 	getPluginSingleListView( category ) {
+		const listLink = '/plugins/browse/' + category + '/';
 		return <PluginsBrowserList
 			plugins={ this.getPluginsShortList( category ) }
 			listName={ category }
 			title={ this.translateCategory( category ) }
 			site={ this.props.site }
-			expandedListLink={ this.getPluginsFullList( category ).length > this._SHORT_LIST_LENGTH ? '/plugins/browse/' + category + '/' : false }
+			expandedListLink={ this.getPluginsFullList( category ).length > this._SHORT_LIST_LENGTH ? listLink : false }
 			size={ this._SHORT_LIST_LENGTH }
-			showPlaceholders={ this.state.fullLists[ category].fetching !== false }
+			showPlaceholders={ this.state.fullLists[ category ].fetching !== false }
 			currentSites={ this.props.sites.getSelectedOrAllJetpackCanManage() } />;
 	},
 
@@ -190,13 +203,33 @@ module.exports = React.createClass( {
 	},
 
 	getNavigationBar() {
-		var site = this.props.site ? '/' + this.props.site : '';
+		const site = this.props.site ? '/' + this.props.site : '';
 		return <SectionNav selectedText={ this.translate( 'Category', { context: 'Category of plugins to be filtered by' } ) }>
-			<NavTabs label="Category" >
-				<NavItem path={ '/plugins/browse' + site } selected={ false }>{ this.translate( 'All', { context: 'Filter all plugins' } ) } </NavItem>
-				<NavItem path={ '/plugins/browse/featured' + site } selected={ this.props.path === ( '/plugins/browse/featured' + site ) } > { this.translate( 'Featured', { context: 'Filter featured plugins' } ) } </NavItem>
-				<NavItem path={ '/plugins/browse/popular' + site } selected={ this.props.path === ( '/plugins/browse/popular' + site ) } > { this.translate( 'Popular', { context: 'Filter popular plugins' } ) } </NavItem>
-				<NavItem path={ '/plugins/browse/new' + site } selected={ this.props.path === ( '/plugins/browse/new' + site ) } > { this.translate( 'New', { context: 'Filter new plugins' } ) } </NavItem>
+			<NavTabs label="Category">
+				<NavItem
+					path={ '/plugins/browse' + site }
+					selected={ false }
+				>
+					{ this.translate( 'All', { context: 'Filter all plugins' } ) }
+				</NavItem>
+				<NavItem
+					path={ '/plugins/browse/featured' + site }
+					selected={ this.props.path === ( '/plugins/browse/featured' + site ) }
+				>
+					{ this.translate( 'Featured', { context: 'Filter featured plugins' } ) }
+				</NavItem>
+				<NavItem
+					path={ '/plugins/browse/popular' + site }
+					selected={ this.props.path === ( '/plugins/browse/popular' + site ) }
+				>
+					{ this.translate( 'Popular', { context: 'Filter popular plugins' } ) }
+				</NavItem>
+				<NavItem
+					path={ '/plugins/browse/new' + site }
+					selected={ this.props.path === ( '/plugins/browse/new' + site ) }
+				>
+					{ this.translate( 'New', { context: 'Filter new plugins' } ) }
+				</NavItem>
 			</NavTabs>
 			{ this.getSearchBox( true ) }
 		</SectionNav>;
@@ -232,7 +265,10 @@ module.exports = React.createClass( {
 				<MainComponent>
 					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
-					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
+					{ this.state.accessError.featureExample
+						? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample>
+						: null
+					}
 				</MainComponent>
 			);
 		}


### PR DESCRIPTION
As stated in #8351, currently, in the list of Jetpack site plugins when a search yields no results, a "No plugins match your search" message is displayed:

![](https://cloud.githubusercontent.com/assets/437258/18972255/731a12b8-8666-11e6-8840-903624c20e2e.png)

This PR suggests that we display plugins that can be installed instead (like the plugin browser does):

![](https://cloud.githubusercontent.com/assets/437258/18972345/c746fe46-8666-11e6-8b59-2b4c19813ae4.png)

This PR also fixes all ESLint warnings that existed in the target files.

To test:

* Checkout this branch
* Go to `/plugins/$site`, where `$site` is a Jetpack site.
* Search for an installed plugin and verify it is displayed within a list of matching installed plugins.
* Search for anything that does not match any of the active plugins and verify it displays the plugin browser with matching plugins that you can install.

/cc @rickybanister @johnHackworth 

Fixes #8351.