### PR TITLE
Devdocs: fix devdocs page under IE11

### DIFF
--- a/client/components/image-preloader/docs/example.jsx
+++ b/client/components/image-preloader/docs/example.jsx
@@ -14,4 +14,6 @@ const ImagePreloaderExample = () =>
 			placeholder={ <div>Loading...</div> }
 			src="https://en-blog.files.wordpress.com/2016/08/photo-1441109296207-fd911f7cd5e5.jpg" />;
 
+ImagePreloaderExample.displayName = 'ImagePreloaderExample';
+
 export default ImagePreloaderExample;

--- a/client/devdocs/docs-example/util.js
+++ b/client/devdocs/docs-example/util.js
@@ -4,17 +4,34 @@ const getComponentName = docsExample => {
 		return '';
 	}
 
+	if (
+		! docsExample.type ||
+		( ! docsExample.type.displayName && ! docsExample.type.name )
+	) {
+		return console.trace( 'Component must be defined' );
+	}
+
 	return ( docsExample.type.displayName || docsExample.type.name )
 		.replace( /Example$/, '' );
 };
 
 const slugToCamelCase = name => {
+	if ( ! name ) {
+		console.warn( 'name is not defined' );
+		return console.trace();
+	}
+
 	return name
-	.replace( /-([a-z])/g, s => s[ 1 ].toUpperCase() )
-	.replace( /^\w/, s => s.toUpperCase() );
+		.replace( /-([a-z])/g, s => s[ 1 ].toUpperCase() )
+		.replace( /^\w/, s => s.toUpperCase() );
 };
 
 const camelCaseToSlug = name => {
+	if ( ! name ) {
+		console.warn( 'name is not defined' );
+		return console.trace();
+	}
+
 	return name
 		.replace( /\.?([A-Z])/g, ( x, y ) => '-' + y.toLowerCase() )
 		.replace( /^-/, '' );


### PR DESCRIPTION
Issue: #8338

For some reason, `IE11` can't read the `docsExample.type.displayName` or `docsExample.type.name` when the component is built using a stateless function. Specifically, I've added `dislayName` to `<ImagePreloader />` example component and it partially fixs the whole devdocs page.

Also I've added some console.trace() to follow the issues:

![image](https://cloud.githubusercontent.com/assets/77539/18995675/91857a38-8703-11e6-9a32-f365070fda9b.png)

![image](https://cloud.githubusercontent.com/assets/77539/18996538/0c63cc5c-8707-11e6-9aef-ccebddeb2fae.png)

So I suggest now merge this PR to fix the devdocs page and then start to fix the component instances one by one.