### PR TITLE
Jetpack plugins: Fix action labels for long strings

### DIFF
--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -64,22 +64,7 @@
 
 .plugin-meta__detail {
 	position: relative;
-	width: 100%;
 	flex-grow: 1;
-
-	@include breakpoint( '>480px' ) {
-		max-width: calc(100% - 150px);
-
-		.has-button & {
-			max-width: 100%;
-		}
-	}
-
-	@include breakpoint( '>660px' ) {
-		.has-button & {
-			max-width: calc(100% - 150px);
-		}
-	}
 }
 
 .plugin-meta__meta {
@@ -128,10 +113,25 @@
 
 }
 
+.plugin-meta__actions .form-toggle__label {
+	display: flex;
+		justify-content: flex-end;
+
+	.form-toggle__switch {
+		float: none;
+		order: 2;
+	}
+}
+
 .plugin-meta__actions .plugin-action__label {
 	@include breakpoint( '<480px' ) {
+		flex-grow: 2;
 		color: $gray-dark;
 		font-size: 11px;
+	}
+	@include breakpoint( '<780px' ) {
+		display: block;
+		padding-right: 16px;
 	}
 }
 


### PR DESCRIPTION
Trash pickup day!

This is how the action labels look like when you have spanish as your WordPress.com language:

![image](https://cloud.githubusercontent.com/assets/1554855/18998965/402c355e-873b-11e6-9943-a8c31206f082.png)


And this is how they look after this PR:

![image](https://cloud.githubusercontent.com/assets/1554855/18998971/4dc9b09c-873b-11e6-9712-0b21f209f75b.png)


:es:-all-the-things