### PR TITLE
Themes: Add filter validation middleware

### DIFF
--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -6,7 +6,8 @@ import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
 import { makeNavigation, siteSelection } from 'my-sites/controller';
 import { singleSite, multiSite, loggedOut } from './controller';
-import { getSubjects } from './theme-filters.js';
+import { getSubjects } from './theme-filters';
+import validateFilters from './validate-filters';
 
 export default function( router ) {
 	const user = userFactory();
@@ -25,15 +26,18 @@ export default function( router ) {
 			);
 			router(
 				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
-				siteSelection, multiSite, makeNavigation, makeLayout
+				validateFilters, siteSelection, multiSite, makeNavigation, makeLayout
 			);
 			router(
 				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id`,
-				siteSelection, singleSite, makeNavigation, makeLayout
+				validateFilters, siteSelection, singleSite, makeNavigation, makeLayout
 			);
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, loggedOut, makeLayout );
+			router(
+				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
+				validateFilters, loggedOut, makeLayout
+			);
 		}
 	}
 }

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -275,3 +275,7 @@ export function stripFilters( input ) {
 export function getSubjects() {
 	return taxonomies.subject;
 }
+
+export function isValidTerm( term ) {
+	return !! getTermTable()[ term ];
+}

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -16,7 +16,10 @@ module.exports = function validateFilter( context, next ) {
 
 	if ( sortedValidFilters !== filterParam ) {
 		const path = context.path;
-		const newPath = path.replace( `/filter/${ filterParam }`, `/filter/${ sortedValidFilters }` );
+		const newPath = path.replace(
+			`/filter/${ filterParam }`,
+			sortedValidFilters ? `/filter/${ sortedValidFilters }` : ''
+		);
 		page.redirect( newPath );
 	}
 

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -1,3 +1,6 @@
+// TODO (seear): This middleware should be made isomorphic once we
+// have a solution for isomorphic redirects.
+
 /**
  * External dependencies
  */

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { isValidTerm, sortFilterTerms } from './theme-filters';
+
+// Reorder and remove invalid filters to redirect to canonical URL
+module.exports = function validateFilter( context, next ) {
+	const filterParam = context.params.filter;
+	const validFilters = filterParam.split( ',' ).filter( isValidTerm );
+	const sortedValidFilters = sortFilterTerms( validFilters ).join( ',' );
+
+	if ( sortedValidFilters !== filterParam ) {
+		const path = context.path;
+		const newPath = path.replace( `/filter/${ filterParam }`, `/filter/${ sortedValidFilters }` );
+		page.redirect( newPath );
+	}
+
+	next();
+};
+


### PR DESCRIPTION
Addresses #7225

Add a middleware function that checks the filters supplied via the URL to the theme search page at /design.

* Removes invalid filters
* Reorders remaining filters to the [canonical order](https://github.com/Automattic/wp-calypso/blob/e5d252ab300af253c8a54bd05d37f5e3a8799372/client/my-sites/themes/theme-filters.js#L244)
* Redirects if resulting URL is different to original

**To Test**
* Check that filters containing terms not in [this list](https://github.com/Automattic/wp-calypso/blob/e5d252ab300af253c8a54bd05d37f5ehttps://github.com/Automattic/wp-calypso/blob/e5d252ab300af253c8a54bd05d37f5e3a8799372/client/my-sites/themes/theme-filters.js#L244) are removed from the URL
* Chech that filters are reordered to an alpha sort on the [complete _taxonomy:term_ string](https://github.com/Automattic/wp-calypso/blob/e5d252ab300af253c8a54bd05d37f5e3a8799372/client/my-sites/themes/theme-filters.js#L244)
* For example, entering the URL http://calypso.localhost:3000/design/filter/red,nonsense,blue should redirect to http://calypso.localhost:3000/design/filter/blue,red

