### PR TITLE
Advanced SEO: tweaking styles in title editor

### DIFF
--- a/client/components/title-format-editor/parser.js
+++ b/client/components/title-format-editor/parser.js
@@ -134,7 +134,7 @@ const emptyBlockMap = {
  * @param {string} title - Token's title
  * @returns string - Processed title
  */
-export const mapTokenTitleForEditor = title => `\u205f${ title }\u205f`;
+export const mapTokenTitleForEditor = title => `\u205f\u205f${ title }\u205f\u205f`;
 
 /**
  * Returns the translated name for the chip

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -44,7 +44,6 @@
 }
 
 .title-format-editor__token {
-	padding: 0 4px 0 6px;
 	display: inline-block;
 	background-color: darken( $gray, 20% );
 	color: $white;

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -10,7 +10,8 @@
 }
 
 .title-format-editor__title {
-	font-weight: bold;
+	font-weight: 600;
+	font-size: 14px;
 	flex: 1;
 	margin-right: auto;
 }
@@ -37,15 +38,17 @@
 }
 
 .title-format-editor__editor-wrapper {
-	border: 1px solid $gray;
-	padding: 6px 12px;
+	border: 1px solid lighten( $gray, 10% );
+	padding: 7px 14px;
+	line-height: 24px;
 }
 
 .title-format-editor__token {
-	padding: 2px 0px;
+	padding: 0 4px 0 6px;
+	display: inline-block;
 	background-color: darken( $gray, 20% );
 	color: $white;
-	border-radius: 3px;
+	border-radius: 4px;
 	cursor: pointer;
 	transition: all 0.3s ease;
 


### PR DESCRIPTION
Tweaks styling to be more consistent with other components:

- input border color
- text size and weight of label
- padding on token and input field

fixes #8328 

Before:
![screen shot 2016-09-30 at 11 19 12 am](https://cloud.githubusercontent.com/assets/618551/19000445/42630a38-8708-11e6-8e26-71f63b64ac79.png)


After:
![screen shot 2016-09-30 at 12 19 11 pm](https://cloud.githubusercontent.com/assets/618551/19000433/311fa1c8-8708-11e6-9f64-f7a65f0db42f.png)


