### PR TITLE
Advanced SEO: Don't show the preview text if the editor is empty

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -343,7 +343,7 @@ export class TitleFormatEditor extends Component {
 			type
 		} = this.props;
 
-		const previewText = type.value
+		const previewText = type.value && editorState.getCurrentContent().hasText()
 			? buildSeoTitle( { [ type.value ]: fromEditor( editorState.getCurrentContent() ) }, type.value, titleData )
 			: '';
 


### PR DESCRIPTION
**To test**
Visit `/settings/seo` for a site that has the business plan, and clear out the text for one of the title format fields. It should not show the `Preview:` text.

Refs #7930

cc @drw158 @dmsnell 