### PR TITLE
Reader full post: actually show placeholders for related posts

### DIFF
--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -66,7 +66,7 @@ function AuthorAndSiteFollowPlaceholder() {
 	);
 }
 
-function RelatedPostCardPlaceholder() {
+export function RelatedPostCardPlaceholder() {
 	return (
 		<Card className="reader-related-card-v2 is-placeholder">
 			<AuthorAndSiteFollowPlaceholder />
@@ -85,15 +85,15 @@ function RelatedPostCardPlaceholder() {
 export function RelatedPostCard( { post, site, onPostClick = noop, onSiteClick = noop } ) {
 // onSiteClick is not being used
 /* eslint-enable no-unused-vars */
+	if ( ! post || post._state === 'minimal' || post._state === 'pending' ) {
+		return <RelatedPostCardPlaceholder />;
+	}
+
 	const featuredImage = post.canonical_image;
 	const postLink = getPostUrl( post );
 	const classes = classnames( 'reader-related-card-v2', {
 		'has-thumbnail': !! featuredImage
 	} );
-
-	if ( ! post || post._state === 'minimal' || post._state === 'pending' ) {
-		return <RelatedPostCardPlaceholder />;
-	}
 
 	return (
 		<Card className={ classes }>

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -66,7 +66,7 @@ function AuthorAndSiteFollowPlaceholder() {
 	);
 }
 
-export function RelatedPostCardPlaceholder() {
+function RelatedPostCardPlaceholder() {
 	return (
 		<Card className="reader-related-card-v2 is-placeholder">
 			<AuthorAndSiteFollowPlaceholder />

--- a/client/components/related-posts-v2/index.jsx
+++ b/client/components/related-posts-v2/index.jsx
@@ -17,7 +17,7 @@ import QueryReaderRelatedPosts from 'components/data/query-reader-related-posts'
 function RelatedPosts( { siteId, postId, posts, title, scope, className = '', onPostClick = noop, onSiteClick = noop } ) {
 	let listItems;
 
-	if ( ! posts || ! posts.length ) {
+	if ( ! posts ) {
 		// Placeholders
 		listItems = times( 2, i => {
 			return (
@@ -26,6 +26,8 @@ function RelatedPosts( { siteId, postId, posts, title, scope, className = '', on
 				</li>
 			);
 		} );
+	} else if ( posts.length === 0 ) {
+		return null;
 	} else {
 		listItems = posts.map( post_id => {
 			return (

--- a/client/components/related-posts-v2/index.jsx
+++ b/client/components/related-posts-v2/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import noop from 'lodash/noop';
+import { noop, times } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -15,22 +15,33 @@ import RelatedPost from 'blocks/reader-related-card-v2';
 import QueryReaderRelatedPosts from 'components/data/query-reader-related-posts';
 
 function RelatedPosts( { siteId, postId, posts, title, scope, className = '', onPostClick = noop, onSiteClick = noop } ) {
-	if ( ! posts ) {
-		return <QueryReaderRelatedPosts siteId={ siteId } postId={ postId } scope={ scope } />;
+	let listItems;
+
+	if ( ! posts || ! posts.length ) {
+		// Placeholders
+		listItems = times( 2, i => {
+			return (
+				<li className="reader-related-card-v2__list-item" key={ 'related-post-placeholder-' + i }>
+					<RelatedPost post={ null } />
+				</li>
+			);
+		} );
+	} else {
+		listItems = posts.map( post_id => {
+			return (
+				<li key={ post_id } className="reader-related-card-v2__list-item">
+					<RelatedPost post={ post_id } onPostClick={ onPostClick } onSiteClick={ onSiteClick } />
+				</li>
+			);
+		} );
 	}
-	if ( ! posts.length ) {
-		return null;
-	}
+
 	return (
 		<div className={ classnames( 'reader-related-card-v2__blocks', className ) }>
+			{ ! posts && <QueryReaderRelatedPosts siteId={ siteId } postId={ postId } scope={ scope } /> }
 			<h1 className="reader-related-card-v2__heading">{ title }</h1>
 			<ul className="reader-related-card-v2__list">
-				{ posts.map( post_id => {
-					return ( <li key={ post_id } className="reader-related-card-v2__list-item">
-							<RelatedPost post={ post_id } onPostClick={ onPostClick } onSiteClick={ onSiteClick } />
-						</li> );
-				} )
-				}
+				{ listItems }
 			</ul>
 		</div>
 	);

--- a/client/state/reader/related-posts/actions.js
+++ b/client/state/reader/related-posts/actions.js
@@ -65,7 +65,7 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL ) {
 							siteId,
 							postId,
 							scope,
-							posts: response && response.posts
+							posts: ( response && response.posts ) || []
 						}
 					} );
 				} );
@@ -75,6 +75,16 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL ) {
 					type: READER_RELATED_POSTS_REQUEST_FAILURE,
 					payload: { siteId, postId, scope, error: err },
 					error: true
+				} );
+
+				dispatch( {
+					type: READER_RELATED_POSTS_RECEIVE,
+					payload: {
+						siteId,
+						postId,
+						scope,
+						posts: []
+					}
 				} );
 			}
 		);

--- a/client/state/reader/related-posts/selectors.js
+++ b/client/state/reader/related-posts/selectors.js
@@ -8,7 +8,8 @@
 import { key, SCOPE_ALL } from './utils';
 
 export function shouldFetchRelated( state, siteId, postId, scope = SCOPE_ALL ) {
-	return ! state.reader.relatedPosts.queuedRequests[ key( siteId, postId, scope ) ];
+	return state.reader.relatedPosts.items[ key( siteId, postId, scope ) ] === undefined &&
+		! state.reader.relatedPosts.queuedRequests[ key( siteId, postId, scope ) ];
 }
 
 export function relatedPostsForPost( state, siteId, postId, scope = SCOPE_ALL ) {

--- a/client/state/reader/related-posts/test/actions.js
+++ b/client/state/reader/related-posts/test/actions.js
@@ -34,11 +34,11 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.2/read/site/1/post/1/related?meta=site' )
 				.reply( 200, {
-					posts: {
+					posts: [ {
 						ID: 1,
 						global_ID: 1,
 						site_ID: 1
-					}
+					} ]
 				} );
 		} );
 
@@ -69,11 +69,11 @@ describe( 'actions', () => {
 						siteId: 1,
 						postId: 1,
 						scope: 'all',
-						posts: {
+						posts: [ {
 							ID: 1,
 							global_ID: 1,
 							site_ID: 1
-						}
+						} ]
 					}
 				} );
 			} );
@@ -114,6 +114,18 @@ describe( 'actions', () => {
 					siteId: 1,
 					postId: 1,
 					scope: 'all'
+				}
+			} );
+		} );
+
+		it( 'should have dispatched receive with an empty array', () => {
+			expect( fakeDispatch ).to.have.been.calledWith( {
+				type: READER_RELATED_POSTS_RECEIVE,
+				payload: {
+					siteId: 1,
+					postId: 1,
+					scope: 'all',
+					posts: []
 				}
 			} );
 		} );

--- a/client/state/reader/related-posts/test/selectors.js
+++ b/client/state/reader/related-posts/test/selectors.js
@@ -17,6 +17,9 @@ describe( 'selectors', () => {
 					relatedPosts: {
 						queuedRequests: {
 
+						},
+						items: {
+
 						}
 					}
 				}
@@ -28,6 +31,23 @@ describe( 'selectors', () => {
 					relatedPosts: {
 						queuedRequests: {
 							'1-1-all': true
+						},
+						items: {
+
+						}
+					}
+				}
+			}, 1, 1 ) ).to.be.false;
+		} );
+
+		it( 'should return false if we have a value', () => {
+			expect( shouldFetchRelated( {
+				reader: {
+					relatedPosts: {
+						queuedRequests: {
+						},
+						items: {
+							'1-1-all': []
 						}
 					}
 				}


### PR DESCRIPTION
We added some nice new placeholders for the Related Posts blocks in https://github.com/Automattic/wp-calypso/pull/8334, but unfortunately the logic in the parent component ensured that they were never actually displayed. Oops.

This PR ensures that the placeholders are displayed when the related posts haven't arrived yet.

cc @blowery 