### PR TITLE
Reader: Fix JP Related Posts in full-post

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -404,6 +404,18 @@
 	}
 }
 
+// JP Related Post
+.reader-full-post .jp-relatedposts {
+	background: none;
+	list-style-type: none;
+	margin: 0;
+	padding: 0;
+}
+
+.reader-full-post .jp-relatedposts li {
+	margin-top: 10px;
+}
+
 .detail-page__backdrop {
 	padding: 1px; // this fixes a strange rendering bug at the bottom of the full post card in safari and chrome -shaun
 	z-index: z-index( 'root', '.detail-page__backdrop' ); // above the masterbar

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -404,16 +404,10 @@
 	}
 }
 
-// JP Related Post
+// Hides Jetpack RP in Reader
+.reader-full-post .jp-relatedposts-headline,
 .reader-full-post .jp-relatedposts {
-	background: none;
-	list-style-type: none;
-	margin: 0;
-	padding: 0;
-}
-
-.reader-full-post .jp-relatedposts li {
-	margin-top: 10px;
+	display: none;
 }
 
 .detail-page__backdrop {


### PR DESCRIPTION
JP Related Posts currently look ugly in full-post view:
![screenshot 2016-09-30 15 20 10](https://cloud.githubusercontent.com/assets/4924246/19008632/65bd6bcc-8721-11e6-864c-150c601ed76d.png)

They are also cropped on mobile:
![screenshot 2016-09-30 15 19 25](https://cloud.githubusercontent.com/assets/4924246/19008614/48cbfb50-8721-11e6-8e8a-911dac8df399.png)

This PR fixes that:
![screenshot 2016-09-30 15 20 28](https://cloud.githubusercontent.com/assets/4924246/19008643/6d9f13a4-8721-11e6-9fc5-15d9fb882ed6.png)

![screenshot 2016-09-30 15 20 45](https://cloud.githubusercontent.com/assets/4924246/19008649/787c24c4-8721-11e6-93c8-142da4c735eb.png)

Example: http://calypso.dev:3000/read/feeds/12098/posts/1172507115


