### PR TITLE
Advanced SEO: Fix border height on web preview toolbar

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -139,6 +139,7 @@
 
 	&.web-preview__seo-button {
 		padding: 0 14px;
+		height: 100%;
 
 		&.is-showing-device-switcher {
 			border-left: 1px solid lighten( $gray, 20% );


### PR DESCRIPTION
Ensure SEO button fills 100% of the height in the toolbar.

**To test**
Ensure your site has the business plan, and view the post or site preview window. The border on the SEO button should be full height and fill up the bar.

Before:
<img width="137" alt="screen shot 2016-09-30 at 3 52 57 pm" src="https://cloud.githubusercontent.com/assets/789137/19009269/cf02e198-8726-11e6-8610-b5070489d998.png">

After:
<img width="136" alt="screen shot 2016-09-30 at 3 53 47 pm" src="https://cloud.githubusercontent.com/assets/789137/19009272/d3b4d232-8726-11e6-9eee-6d24b1e6610d.png">
