### PR TITLE
For z-index documentation point to Chrome extension tool instead of gist

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -16,13 +16,14 @@
 // So before adding a new z-index:
 // 1. You'll want to make sure the element actually creates a stacking context
 // 2. Look up what its parent stacking context is
-// You can run this handy gist: https://gist.github.com/gwwar/2f661deec7b99a1a418b in the console to find both.
+// There's a Chrome devtools extension that can help you find both:
+// https://chrome.google.com/webstore/detail/z-context/jigamimbjojkdgnlldajknogfgncplbh
 //
 // For readability please sort values from lowest to highest.
 //
 // Usage:
 // .environment-badge {
-//     z-index: z-index( 'root' '.environment-badge' );
+//     z-index: z-index( 'root', '.environment-badge' );
 // }
 //
 // For a refresher on stacking contexts see:

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -305,9 +305,9 @@ So, to add a new z-index:
    stacking context as the initial key and the element's full CSS selector as 
    the final key.
 
-You can run this handy
-[gist](https://gist.github.com/gwwar/2f661deec7b99a1a418b) in the console to
-find the stacking contexts of both the element and its parent.
+You can use this handy Chrome
+[extension](https://chrome.google.com/webstore/detail/z-context/jigamimbjojkdgnlldajknogfgncplbh)
+to find the stacking contexts of both the element and its parent.
 
 As a simple example, imagine that we have a page with the following markup:
 


### PR DESCRIPTION
As a follow up to https://github.com/Automattic/wp-calypso/pull/8317#issuecomment-250508158 this updates the z-index documentation to point at this [Chrome extension](https://chrome.google.com/webstore/detail/z-context/jigamimbjojkdgnlldajknogfgncplbh) that allows us to more easily find the parent stacking context.

cc @jasmussen