### PR TITLE
Removes CSS %container @extends as they were only used once. Also @ex…

### DIFF
--- a/assets/stylesheets/shared/_extends.scss
+++ b/assets/stylesheets/shared/_extends.scss
@@ -5,37 +5,6 @@
 	vertical-align: middle;
 }
 
-%container {
-	position: relative;
-	margin-bottom: 6%;
-	padding: 0 20px 12px;
-	background: $white;
-	box-shadow: 0 1px 2px rgba(0,0,0,0.075);
-
-	@include clear-fix;
-
-	ul,
-	ol {
-		font-size: 14px;
-		margin-bottom: 4px;
-	}
-
-	@include breakpoint( "<480px" ) {
-		margin-left: .25em;
-		margin-right: .25em;
-	}
-}
-
-%container-header {
-	background: $gray-light;
-	padding: 13px 20px 10px;
-	margin: 0 -20px;
-	min-height: 37px;
-	font-size: 14px;
-	line-height: 135%;
-	border-bottom: 1px solid #EBF0F2;
-}
-
 %placeholder {
 
 	.stats-module.is-loading & * {

--- a/assets/stylesheets/shared/_welcome.scss
+++ b/assets/stylesheets/shared/_welcome.scss
@@ -3,11 +3,25 @@
 */
 
 .welcome-message {
-	@extend %container;
+	@include clear-fix;
+
+	box-shadow: 0 1px 2px rgba(0,0,0,0.075);
 	position: relative;
 	background: $gray-light;
 	margin-bottom: 6%;
 	padding: 16px;
+
+
+	ul,
+	ol {
+		font-size: 14px;
+		margin-bottom: 4px;
+	}
+
+	@include breakpoint( "<480px" ) {
+		margin-left: .25em;
+		margin-right: .25em;
+	}
 
 	.close-button {
 		position: absolute;


### PR DESCRIPTION
Also, @extends are bad. There should be no visual changes.

I'm not sure how to test this one. It's used on the posts and welcome page according to the sass comment, but I think it's only used once in the NUX.

```
/**
* Welcome Messages (currently on stats and post pages)
*/
```
