### PR TITLE
Revert the support wording change we put in place for the grand meetup.

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -155,10 +155,8 @@ const HelpContact = React.createClass( {
 				confirmation: {
 					title: this.translate( 'We\'re on it!' ),
 					message: this.translate(
-						'Thank you for your message! We\'re currently away on our ' +
-						'annual company meetup where we are working to improve WordPress ' +
-						'for you. We will be answering your questions but responses ' +
-						'may be slower than normal.'
+						'We\'ve received your message, and you\'ll hear back from ' +
+						'one of our Happiness Engineers shortly.' 
 					)
 				}
 			} );


### PR DESCRIPTION
While away at the all-hands meetup in September, we put up a wording change to the post-submit screen for the contact form as sort of a stopgap. We're overdue to revert that. This reverts the change pushed in #8118.

To test:

1. Log in as a user not eligible for chat.
2. Submit an email ticket via /help/contact

The post-submit screen should show this message:

![screen shot 2016-10-01 at 11 58 24 am](https://cloud.githubusercontent.com/assets/2738252/19015253/c57fbb0c-87ce-11e6-9ed3-3e4acaa6611c.png)

Cc @omarjackman @jordwest @jeremeylduvall for a quick review so I can push this out.