### PR TITLE
Search styling overlay

### DIFF
--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -54,6 +54,11 @@ Currently supports forcing a LTR field in a RTL language, but not the other way 
 
 Supported values are `'ltr'` and `undefined` (the default, which uses the current global writing direction of the app).
 
+### styleOverlay (optional) function ( default noop )
+Implement this function to add markup to the content of the search box. Current content is supplied as a parameter. Return a string containing the same text but with markup added.
+
+For example, add `<span/>`s around tokens in the content, then add CSS elsewhere to style the `<span/>`s.
+
 ## Methods
 
 ### getCurrentSearchValue()

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -167,7 +167,7 @@ const Search = React.createClass( {
 	scrollOverlay: function() {
 		const _this = this;
 
-		window.requestAnimationFrame(function() {
+		window.requestAnimationFrame( function() {
 			console.log( 'init_tokens: ' + _this.refs.overlay.scrollLeft );
 			console.log( 'init_input: ' + _this.refs.searchInput.scrollLeft );
 			_this.refs.overlay.scrollLeft = _this.refs.searchInput.scrollLeft;
@@ -329,7 +329,7 @@ const Search = React.createClass( {
 				</div>
 				<div className={ fadeDivClass }>
 					<input
-						type="text"
+						type="search"
 						id={ 'search-component-' + this.state.instanceId }
 						className={ inputClass }
 						placeholder={ placeholder }

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -52,6 +52,7 @@ const Search = React.createClass( {
 		onSearchOpen: PropTypes.func,
 		onSearchClose: PropTypes.func,
 		analyticsGroup: PropTypes.string,
+		overlayStyling: PropTypes.func,
 		autoFocus: PropTypes.bool,
 		disabled: PropTypes.bool,
 		onKeyDown: PropTypes.func,
@@ -84,6 +85,7 @@ const Search = React.createClass( {
 			onSearchOpen: noop,
 			onSearchClose: noop,
 			onKeyDown: noop,
+			overlayStyling: noop,
 			disableAutocorrect: false,
 			searching: false,
 			isOpen: false,
@@ -149,6 +151,8 @@ const Search = React.createClass( {
 			this.props.onSearch( this.state.keyword );
 		}
 		this.props.onSearchChange( this.state.keyword );
+
+		this.scrollOverlay()
 	},
 
 	componentDidMount: function() {
@@ -159,6 +163,17 @@ const Search = React.createClass( {
 		if ( this.props.autoFocus ) {
 			this.focus();
 		}
+	},
+
+	scrollOverlay: function() {
+		const _this = this;
+		window.requestAnimationFrame(function() {
+			console.log( 'init_tokens: ' + _this.refs.overlay.scrollLeft );
+			console.log( 'init_input: ' + _this.refs.searchInput.scrollLeft );
+			_this.refs.overlay.scrollLeft = _this.refs.searchInput.scrollLeft;
+			console.log( 'after_tokens: ' + _this.refs.overlay.scrollLeft );
+			console.log( 'after_input: ' + _this.refs.searchInput.scrollLeft );
+		} );
 	},
 
 	focus: function() {
@@ -331,6 +346,9 @@ const Search = React.createClass( {
 						maxLength={ this.props.maxLength }
 						{ ...autocorrect }
 					/>
+					<div className="search_text-overlay" ref="overlay">
+						{ this.props.overlayStyling( this.state.keyword ) }
+					</div>
 				</div>
 				{ this.closeButton() }
 			</div>

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -125,6 +125,7 @@ const Search = React.createClass( {
 	},
 
 	componentDidUpdate: function( prevProps, prevState ) {
+		this.scrollOverlay();
 		// Focus if the search box was opened or the autoFocus prop has changed
 		if (
 			( this.state.isOpen && ! prevState.isOpen ) ||
@@ -151,8 +152,6 @@ const Search = React.createClass( {
 			this.props.onSearch( this.state.keyword );
 		}
 		this.props.onSearchChange( this.state.keyword );
-
-		this.scrollOverlay()
 	},
 
 	componentDidMount: function() {
@@ -167,6 +166,7 @@ const Search = React.createClass( {
 
 	scrollOverlay: function() {
 		const _this = this;
+
 		window.requestAnimationFrame(function() {
 			console.log( 'init_tokens: ' + _this.refs.overlay.scrollLeft );
 			console.log( 'init_input: ' + _this.refs.searchInput.scrollLeft );
@@ -257,9 +257,11 @@ const Search = React.createClass( {
 		if ( event.key === 'Escape' ) {
 			this.closeSearch( event );
 		}
+		this.scrollOverlay();
 	},
 
 	keyDown: function( event ) {
+		this.scrollOverlay();
 		if ( event.key === 'Escape' && event.target.value === '' ) {
 			this.closeSearch( event );
 		}
@@ -327,7 +329,7 @@ const Search = React.createClass( {
 				</div>
 				<div className={ fadeDivClass }>
 					<input
-						type="search"
+						type="text"
 						id={ 'search-component-' + this.state.instanceId }
 						className={ inputClass }
 						placeholder={ placeholder }
@@ -346,7 +348,7 @@ const Search = React.createClass( {
 						maxLength={ this.props.maxLength }
 						{ ...autocorrect }
 					/>
-					<div className="search_text-overlay" ref="overlay">
+					<div className="search__text-overlay" ref="overlay">
 						{ this.props.overlayStyling( this.state.keyword ) }
 					</div>
 				</div>

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -165,14 +165,8 @@ const Search = React.createClass( {
 	},
 
 	scrollOverlay: function() {
-		const _this = this;
-
-		window.requestAnimationFrame( function() {
-			console.log( 'init_tokens: ' + _this.refs.overlay.scrollLeft );
-			console.log( 'init_input: ' + _this.refs.searchInput.scrollLeft );
-			_this.refs.overlay.scrollLeft = _this.refs.searchInput.scrollLeft;
-			console.log( 'after_tokens: ' + _this.refs.overlay.scrollLeft );
-			console.log( 'after_input: ' + _this.refs.searchInput.scrollLeft );
+		window.requestAnimationFrame( () => {
+			this.refs.overlay.scrollLeft = this.refs.searchInput.scrollLeft;
 		} );
 	},
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -67,13 +67,13 @@
 		display: flex;
 	}
 
-	.search__input[type="search"] {
+	.search__input[type="text"] {
 		flex: 1 1 auto;
 		display: flex;
 	}
 }
 
-.search__input[type="search"] {
+.search__input[type="text"] {
 	flex: 1 1 auto;
 	display: none;
 	z-index: z-index( '.search', '.search__input' );
@@ -122,19 +122,36 @@
 		flex: 1 1 auto;
 		height: 100%;
 		position: relative;
+		font-size: 16px;
 		border-radius: inherit;
 		&::before {
-			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 2 );
 			border-radius: inherit;
 		}
 
 		&.ltr { /*rtl:ignore*/
 			&::before {
-				@include long-content-fade( $direction: right, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
+				@include long-content-fade( $direction: right, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 2 );
 				border-radius: inherit;
 			}
 		}
 	}
+}
+
+.search__input-fade .search__text-overlay {
+	position: absolute;
+	pointer-events: none;
+	white-space: nowrap;
+	display: flex;
+	align-items: center;
+	flex: 1 1 auto;
+	overflow: hidden;
+	font: inherit;
+	width: 100%;
+	height: 100%;
+	top: 0px;
+	left: 0px;
+	z-index: z-index( '.search', '.search__input' ) + 1;
 }
 
 .search .spinner {

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -67,13 +67,13 @@
 		display: flex;
 	}
 
-	.search__input[type="text"] {
+	.search__input[type="search"] {
 		flex: 1 1 auto;
 		display: flex;
 	}
 }
 
-.search__input[type="text"] {
+.search__input[type="search"] {
 	flex: 1 1 auto;
 	display: none;
 	z-index: z-index( '.search', '.search__input' );
@@ -139,6 +139,7 @@
 }
 
 .search__input-fade .search__text-overlay {
+	color: transparent;
 	position: absolute;
 	pointer-events: none;
 	white-space: nowrap;

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -229,7 +229,7 @@ export function getFilter( term ) {
  * @param {string} filter - filter in form taxonomy:term
  * @return {boolean} true if filter pair is valid
  */
-function filterIsValid( filter ) {
+export function filterIsValid( filter ) {
 	return getTermTable()[ getTerm( filter ) ] === getTaxonomy( filter );
 }
 

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -13,10 +13,7 @@ import SegmentedControl from 'components/segmented-control';
 import { trackClick } from '../helpers';
 import config from 'config';
 import { isMobile } from 'lib/viewport';
-
-import {
-	filterIsValid,
-} from '../theme-filters.js';
+import { filterIsValid } from '../theme-filters.js';
 
 const ThemesMagicSearchCard = React.createClass( {
 	propTypes: {
@@ -70,19 +67,19 @@ const ThemesMagicSearchCard = React.createClass( {
 	},
 
 	searchTokens( input ) {
-		const tokens = input.split(/(\s+)/);
-		let cls;
+		const tokens = input.split( /(\s+)/ );
+
 		return (
 			tokens.map( ( token, i ) => {
-				if( token.trim() === '' ) {
-					cls = "search-tokens__white-space";
+				let classname = 'search-tokens__text';
+
+				if ( token.trim() === '' ) {
+					classname = 'search-tokens__white-space';
 				} else if ( filterIsValid( token ) ) {
-					cls = "search-tokens__token";
-				} else {
-					cls = "search-tokens__text";
+					classname = 'search-tokens__token';
 				}
 
-				return <span className={ cls } key={ i }>{ token }</span>; // use shortid for key
+				return <span className={ classname } key={ i }>{ token }</span>; // use shortid for key
 			} )
 		);
 	},

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -65,6 +65,18 @@ const ThemesMagicSearchCard = React.createClass( {
 		this.setState( { searchIsOpen: false } );
 	},
 
+	searchTokens( input ) {
+		const tokens = input.split(/(\s+)/);
+		return (
+			tokens.map( ( token, i ) => {
+				const cls = token.trim() === ''
+				? "search-tokens__white-space"
+				: "search-tokens__token";
+					return <span className={ cls } key={ i }>{ token }</span>; // use shortid for key
+			} )
+		);
+	},
+
 	render() {
 		const isJetpack = this.props.site && this.props.site.jetpack;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
@@ -85,6 +97,7 @@ const ThemesMagicSearchCard = React.createClass( {
 				delaySearch={ true }
 				onSearchOpen={ this.onSearchOpen }
 				onSearchClose={ this.onSearchClose }
+				overlayStyling={ this.searchTokens }
 				onBlur={ this.onBlur }
 				fitsContainer={ this.state.isMobile && this.state.searchIsOpen }
 				hideClose={ isMobile() }

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -14,6 +14,10 @@ import { trackClick } from '../helpers';
 import config from 'config';
 import { isMobile } from 'lib/viewport';
 
+import {
+	filterIsValid,
+} from '../theme-filters.js';
+
 const ThemesMagicSearchCard = React.createClass( {
 	propTypes: {
 		tier: React.PropTypes.string,
@@ -67,12 +71,18 @@ const ThemesMagicSearchCard = React.createClass( {
 
 	searchTokens( input ) {
 		const tokens = input.split(/(\s+)/);
+		let cls;
 		return (
 			tokens.map( ( token, i ) => {
-				const cls = token.trim() === ''
-				? "search-tokens__white-space"
-				: "search-tokens__token";
-					return <span className={ cls } key={ i }>{ token }</span>; // use shortid for key
+				if( token.trim() === '' ) {
+					cls = "search-tokens__white-space";
+				} else if ( filterIsValid( token ) ) {
+					cls = "search-tokens__token";
+				} else {
+					cls = "search-tokens__text";
+				}
+
+				return <span className={ cls } key={ i }>{ token }</span>; // use shortid for key
 			} )
 		);
 	},

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -47,8 +47,14 @@
 .search-tokens__token {
 	font: inherit;
 	pointer-events: none;
+	color: rgba(0, 0, 0, 0.2);
+	background-color: rgba(0, 0, 255, 0.2);
+}
+
+.search-tokens__text{
+	font: inherit;
+	pointer-events: none;
 	color: rgba(1, 0, 0, 0.2);
-	background-color: blue;
 }
 
 .search-tokens__white-space {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -47,14 +47,12 @@
 .search-tokens__token {
 	font: inherit;
 	pointer-events: none;
-	color: rgba(0, 0, 0, 0.2);
 	background-color: rgba(0, 0, 255, 0.2);
 }
 
 .search-tokens__text{
 	font: inherit;
 	pointer-events: none;
-	color: rgba(1, 0, 0, 0.2);
 }
 
 .search-tokens__white-space {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -43,3 +43,16 @@
 	}
 
 }
+
+.search-tokens__token {
+	font: inherit;
+	pointer-events: none;
+	color: rgba(1, 0, 0, 0.2);
+	background-color: blue;
+}
+
+.search-tokens__white-space {
+	font: inherit;
+	pointer-events: none;
+	white-space: pre;
+}


### PR DESCRIPTION
Create a styling overlay over Search component input field.

This is a div positioned over input that allows to insert other elements like for example span with CSS with background modifications that will style the text.

The Search component has now a new prop `overlyaStyling`. You can pass here a function that will receive current Search input content and based on that string it will generate styling.

Below is possible example where sting in format `taxonomy:term` is highlighted. 

![image](https://cloud.githubusercontent.com/assets/17271089/19017659/c32d6dc6-8842-11e6-8990-7ac12f808923.png)

Code for this highlight is also committed in themes-magic-search-card.jsx - this is intermediate work for new style Search in Themes Showcase. It is not visible in production - hidden after a flag and it is committed to accelerate development. Effects are visible in `/design` for dev and wpcalypso. 