### PR TITLE
Help: Update Tracks props on contact form

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -119,7 +119,9 @@ const HelpContact = React.createClass( {
 
 		notifications.forEach( olarkActions.sendNotificationToOperator );
 
-		analytics.tracks.recordEvent( 'calypso_help_live_chat_begin' );
+		analytics.tracks.recordEvent( 'calypso_help_live_chat_begin', {
+			site_plan_product_id: ( site ? site.plan.product_id : null )
+		} );
 
 		this.sendMessageToOperator( message );
 
@@ -156,12 +158,15 @@ const HelpContact = React.createClass( {
 					title: this.translate( 'We\'re on it!' ),
 					message: this.translate(
 						'We\'ve received your message, and you\'ll hear back from ' +
-						'one of our Happiness Engineers shortly.' 
+						'one of our Happiness Engineers shortly.'
 					)
 				}
 			} );
 
-			analytics.tracks.recordEvent( 'calypso_help_contact_submit', { ticket_type: 'kayako' } );
+			analytics.tracks.recordEvent( 'calypso_help_contact_submit', {
+				ticket_type: 'kayako',
+				site_plan_product_id: ( site ? site.plan.product_id : null )
+			} );
 		} );
 
 		this.clearSavedContactForm();
@@ -333,7 +338,10 @@ const HelpContact = React.createClass( {
 		if ( ! isUserEligible || isOlarkReady ) {
 			return;
 		}
-		notices.warning( this.translate( 'Our chat tools did not load. If you have an adblocker please disable it and refresh this page.' ) );
+		notices.warning( this.translate(
+			'Our chat tools did not load. If you have an adblocker ' +
+			'please disable it and refresh this page.'
+		) );
 	},
 
 	/**


### PR DESCRIPTION
Every Tracks event currently has `site_plan_id` passed along as [a super prop.](https://github.com/Automattic/wp-calypso/blob/3712e77187e7b5796e54d01673917baf672f2658/client/lib/analytics/super-props.js) The `/help/contact` page isn't specific to a site though meaning no `blog_id` is passed along and the site plan isn't registered for events on the contact form. This adds in a prop of `site_plan` so we can track live chats and Kayako tickets created per plan.

### To test

1. Open the console and run `localStorage.setItem('debug', 'calypso:analytics');` to turn on analytics tracking in the console.
2. Load up this branch. Visit /help/contact with a site that has a plan of some sort (Jetpack or WP.com). 
3. Enter some test content into the form and click either A) start a chat or B) send an email.
4. There might be a better way to test this particularly with a sandbox, but I prevented starting an actual live chat or Kayako ticket by disabling pieces of the functions [here](https://github.com/Automattic/wp-calypso/blob/131273e4075569dee1ae6ca1f126377a1c5a3474/client/me/help/help-contact/index.jsx#L109) and [here](https://github.com/Automattic/wp-calypso/blob/131273e4075569dee1ae6ca1f126377a1c5a3474/client/me/help/help-contact/index.jsx#L144).

In the console, the site plan should be tracked alongside the associated actions of `calypso_help_live_chat_begin` and `calypso_help_contact_submit`. 

Related discussion: p1475167065000286-slack-dotcom-strategery

(I also fixed a line length warning from ESLint)

cc @kriskarkoski 