### PR TITLE
Support: Update links on Help page

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -100,11 +100,21 @@ const Help = React.createClass( {
 						</p>
 					</div>
 				</CompactCard>
-				<CompactCard className="help__support-link" href="https://dailypost.wordpress.com/" target="__blank">
+				<CompactCard className="help__support-link" href="https://dailypost.wordpress.com/blogging-university/" target="__blank">
 					<div className="help__support-link-section">
-						<h2 className="help__support-link-title">{ this.translate( 'The Daily Post' ) }</h2>
+						<h2 className="help__support-link-title">
+							{ this.translate( 'Self-Guided email courses for site owners and bloggers' ) }
+						</h2>
 						<p className="help__support-link-content">
-							{ this.translate( 'Get daily tips for your blog and connect with others to share your journey.' ) }
+							{ this.translate( 'Pick from our ever-growing list of free email courses to improve your knowledge.' ) }
+						</p>
+					</div>
+				</CompactCard>
+				<CompactCard className="help__support-link" href="https://learn.wordpress.com" target="__blank">
+					<div className="help__support-link-section">
+						<h2 className="help__support-link-title">{ this.translate( 'Self-guided online tutorial' ) }</h2>
+						<p className="help__support-link-content">
+							{ this.translate( 'A step-by-step guide to getting familiar with the platform.' ) }
 						</p>
 					</div>
 				</CompactCard>
@@ -112,7 +122,7 @@ const Help = React.createClass( {
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">{ this.translate( 'Get in touch' ) }</h2>
 						<p className="help__support-link-content">
-							{ this.translate( `Can't find the answer? Drop us a line and we'll lend a hand.` ) }
+							{ this.translate( 'Can\'t find the answer? Drop us a line and we\'ll lend a hand.' ) }
 						</p>
 					</div>
 					<Button className="help__support-link-button" primary>{ this.translate( 'Contact Us' ) }</Button>
@@ -146,10 +156,10 @@ const Help = React.createClass( {
 		return (
 			<Main className="help">
 				<MeSidebarNavigation />
-				<div className="help-search is-placeholder"/>
-				<div className="help__help-teaser-button is-placeholder"/>
-				<div className="help-results is-placeholder"/>
-				<div className="help__support-links is-placeholder"/>
+				<div className="help-search is-placeholder" />
+				<div className="help__help-teaser-button is-placeholder" />
+				<div className="help-results is-placeholder" />
+				<div className="help__support-links is-placeholder" />
 			</Main>
 		);
 	},


### PR DESCRIPTION
On `/help`, we currently link to The Daily Post. Per #8250, this PR:
- Removes the link to the Daily Post
- Adds a link to https://dailypost.wordpress.com/blogging-university/
- Adds a link to learn.wordpress.com
- Addresses a few minor ESLint errors

## To test

1. Load up this branch
2. Visit http://calypso.localhost:3000/help

You can see screenshot comparisons below. My only issue with this is that "Self-Guided email courses for site owners and bloggers" wraps onto the next line on iPads and iPhones. Not really a huge deal, but maybe we could remove "and bloggers"? cc @sararosso 

## Screenshots

**Before:** 

<img width="822" alt="screen shot 2016-10-01 at 9 04 38 pm" src="https://cloud.githubusercontent.com/assets/7240478/19018350/b4c403da-881a-11e6-807a-ccfb9d8f7568.png">

**After:**

Desktop
<img width="1005" alt="screen shot 2016-10-01 at 8 54 04 pm" src="https://cloud.githubusercontent.com/assets/7240478/19018351/bc522cc6-881a-11e6-9a82-3afde02a9b23.png">

iPhone 6
<img width="374" alt="screen shot 2016-10-01 at 8 54 15 pm" src="https://cloud.githubusercontent.com/assets/7240478/19018355/c9422152-881a-11e6-9644-999f415b0ff2.png">

iPad portrait
<img width="581" alt="screen shot 2016-10-01 at 9 09 01 pm" src="https://cloud.githubusercontent.com/assets/7240478/19018367/5182e8bc-881b-11e6-9e75-6fbe77f8151c.png">
