### PR TITLE
Settings: Add AMP Box

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -170,6 +170,10 @@ var Customize = React.createClass( {
 			query.autofocus = panels[ panel ];
 		}
 
+		if ( panel === 'amp' ) {
+			query.customize_amp = 1;
+		}
+
 		return Qs.stringify( query );
 	},
 

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -164,6 +164,7 @@ var Customize = React.createClass( {
 			fonts: { section: 'jetpack_fonts' },
 			identity: { section: 'title_tagline' },
 			'custom-css': { section: 'jetpack_custom_css' },
+			amp: { section: 'amp_design' },
 		};
 
 		if ( panels.hasOwnProperty( panel ) ) {

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -103,14 +103,14 @@ export default React.createClass( {
 		}
 
 		return (
-			<form id="site-settings" onSubmit={ this.submitForm } onChange={ this.markChanged }>
+			<form id="site-settings" onSubmit={ this.handleSubmitForm } onChange={ this.markChanged }>
 				{ this.renderNudge() }
 				<SectionHeader label={ this.translate( 'Analytics Settings' ) }>
 					<Button
 						primary
 						compact
 						disabled={ this.isSubmitButtonDisabled() }
-						onClick={ this.submitForm }
+						onClick={ this.handleSubmitForm }
 						>{
 							this.state.submittingForm
 									? this.translate( 'Saving…' )

--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -133,12 +133,17 @@ module.exports = {
 		this.recordEvent( `Clicked to ${event} Jetpack ${module}` );
 	},
 
-	submitForm( event ) {
-		const { site } = this.props;
-
+	handleSubmitForm( event ) {
 		if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
 			event.preventDefault();
 		}
+
+		this.submitForm();
+		this.recordEvent( 'Clicked Save Settings Button' );
+	},
+
+	submitForm() {
+		const { site } = this.props;
 
 		notices.clearNotices( 'notices' );
 
@@ -168,7 +173,5 @@ module.exports = {
 				this.onSaveComplete( error );
 			}
 		} );
-
-		this.recordEvent( 'Clicked Save Settings Button' );
 	}
 };

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -428,13 +428,13 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 
-			<form id="site-settings" onSubmit={ this.submitForm } onChange={ this.markChanged }>
+			<form id="site-settings" onSubmit={ this.handleSubmitForm } onChange={ this.markChanged }>
 				<SectionHeader label={ this.translate( 'Discussion Settings' ) }>
 					<Button
 						primary
 						compact
 						disabled={ this.state.fetchingSettings || this.state.submittingForm }
-						onClick={ this.submitForm }>
+						onClick={ this.handleSubmitForm }>
 						{ this.state.submittingForm ? this.translate( 'Saving…' ) : this.translate( 'Save Settings' ) }
 					</Button>
 				</SectionHeader>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -354,7 +354,9 @@ const FormGeneral = React.createClass( {
 							'on phones and tablets. {{a}}Learn More{{/a}}.',
 							{
 								components: {
-									a: <a href="https://www.ampproject.org/" target="_blank" rel="noopener noreferrer" />
+									a: <a
+										href="https://support.wordpress.com/google-amp-accelerated-mobile-pages/"
+										target="_blank" rel="noopener noreferrer" />
 								}
 							}
 						) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -339,7 +339,7 @@ const FormGeneral = React.createClass( {
 						compact
 						disabled={ isCustomizeDisabled }
 						onClick={ this.handleAmpCustomize }>
-						{ this.translate( 'Customize' ) }
+						{ this.translate( 'Edit Design' ) }
 					</Button>
 					<FormToggle
 						checked={ amp_is_enabled }
@@ -349,7 +349,7 @@ const FormGeneral = React.createClass( {
 				<Card className="site-settings__amp-explanation">
 					<p>
 						{ this.translate(
-							'Your WordPress.com site supports {{a}}Accelarated Mobile Pages (AMP){{/a}}, ' +
+							'Your WordPress.com site supports {{a}}Accelerated Mobile Pages (AMP){{/a}}, ' +
 							'a new Google-led initiative that dramatically improves loading speeds ' +
 							'on phones and tablets. {{a}}Learn More{{/a}}.',
 							{

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -25,6 +26,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormCheckbox from 'components/forms/form-checkbox';
+import FormToggle from 'components/forms/form-toggle';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Timezone from 'components/timezone';
 import JetpackSyncPanel from './jetpack-sync-panel';
@@ -54,6 +56,9 @@ const FormGeneral = React.createClass( {
 			settings.jetpack_relatedposts_allowed = site.settings.jetpack_relatedposts_allowed;
 			settings.jetpack_sync_non_public_post_stati = site.settings.jetpack_sync_non_public_post_stati;
 			settings.hello_vote_enabled = site.settings.hello_vote_enabled;
+
+			settings.amp_is_supported = site.settings.amp_is_supported;
+			settings.amp_is_enabled = site.settings.amp_is_enabled;
 
 			if ( settings.jetpack_relatedposts_allowed ) {
 				settings.jetpack_relatedposts_enabled = ( site.settings.jetpack_relatedposts_enabled ) ? 1 : 0;
@@ -106,6 +111,8 @@ const FormGeneral = React.createClass( {
 			jetpack_sync_non_public_post_stati: false,
 			holidaysnow: false,
 			hello_vote_enabled: false,
+			amp_is_supported: false,
+			amp_is_enabled: false,
 		} );
 	},
 
@@ -289,6 +296,71 @@ const FormGeneral = React.createClass( {
 				}
 
 			</FormFieldset>
+		);
+	},
+
+	handleAmpToggle() {
+		this.setState( { amp_is_enabled: ! this.state.amp_is_enabled }, () => {
+			this.submitForm();
+			this.onRecordEvent( 'Clicked AMP Toggle' );
+		} );
+	},
+
+	handleAmpCustomize() {
+		this.onRecordEvent( 'Clicked AMP Customize button' );
+		page( '/customize/amp/' + this.props.site.slug );
+	},
+
+	renderAmpSection() {
+		const { site } = this.props;
+
+		if ( site.jetpack ) {
+			return;
+		}
+
+		const {
+			fetchingSettings,
+			submittingForm,
+			amp_is_supported,
+			amp_is_enabled,
+		} = this.state;
+
+		const isDisabled = fetchingSettings || submittingForm;
+		const isCustomizeDisabled = isDisabled || ! amp_is_enabled;
+
+		if ( ! amp_is_supported ) {
+			return null;
+		}
+
+		return (
+			<div className="site-settings__amp">
+				<SectionHeader label={ this.translate( 'AMP' ) }>
+					<Button
+						compact
+						disabled={ isCustomizeDisabled }
+						onClick={ this.handleAmpCustomize }>
+						{ this.translate( 'Customize' ) }
+					</Button>
+					<FormToggle
+						checked={ amp_is_enabled }
+						onChange={ this.handleAmpToggle }
+						disabled={ isDisabled } />
+				</SectionHeader>
+				<Card className="site-settings__amp-explanation">
+					<p>
+						{ this.translate(
+							'Your WordPress.com site supports {{a}}Accelarated Mobile Pages (AMP){{/a}}, ' +
+							'a new Google-led initiative that dramatically improves loading speeds ' +
+							'on phones and tablets. {{a}}Learn More{{/a}}.',
+							{
+								components: {
+									a: <a href="https://www.ampproject.org/" target="_blank" rel="noopener noreferrer" />
+								}
+							}
+						) }
+					</p>
+				</Card>
+			</div>
 		);
 	},
 
@@ -572,6 +644,9 @@ const FormGeneral = React.createClass( {
 						{ this.visibilityOptions() }
 					</form>
 				</Card>
+
+				{ this.renderAmpSection() }
+
 				{
 					! this.props.site.jetpack && <div className="site-settings__footer-credit-container">
 						<SectionHeader label={ this.translate( 'Footer Credit' ) } />

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -531,7 +531,7 @@ const FormGeneral = React.createClass( {
 				<SectionHeader label={ this.translate( 'Site Profile' ) }>
 					<Button
 						compact={ true }
-						onClick={ this.submitForm }
+						onClick={ this.handleSubmitForm }
 						primary={ true }
 
 						type="submit"
@@ -556,7 +556,7 @@ const FormGeneral = React.createClass( {
 				<SectionHeader label={ this.translate( 'Privacy' ) }>
 					<Button
 						compact={ true }
-						onClick={ this.submitForm }
+						onClick={ this.handleSubmitForm }
 						primary={ true }
 
 						type="submit"
@@ -597,7 +597,7 @@ const FormGeneral = React.createClass( {
 				<SectionHeader label={ this.translate( 'Related Posts' ) }>
 					<Button
 						compact={ true }
-						onClick={ this.submitForm }
+						onClick={ this.handleSubmitForm }
 						primary={ true }
 
 						type="submit"
@@ -621,7 +621,7 @@ const FormGeneral = React.createClass( {
 							{ this.showPublicPostTypesCheckbox()
 								? <Button
 									compact={ true }
-									onClick={ this.submitForm }
+									onClick={ this.handleSubmitForm }
 									primary={ true }
 									type="submit"
 									disabled={ this.state.fetchingSettings || this.state.submittingForm }>

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -154,7 +154,7 @@ module.exports = React.createClass( {
 				<Button
 					compact
 					primary
-					onClick={ this.submitForm }
+					onClick={ this.handleSubmitForm }
 					>
 					{ this.state.submittingForm ? this.translate( 'Saving…' ) : this.translate( 'Save Settings' ) }
 				</Button>

--- a/client/my-sites/site-settings/form-jetpack-protect.jsx
+++ b/client/my-sites/site-settings/form-jetpack-protect.jsx
@@ -85,7 +85,7 @@ module.exports = React.createClass( {
 
 	settings: function() {
 		return (
-			<form id="protect-settings" onChange={ this.markChanged } onSubmit={ this.submitForm }>
+			<form id="protect-settings" onChange={ this.markChanged } onSubmit={ this.handleSubmitForm }>
 				<FormLegend>{ this.translate( 'IP Address Whitelist' ) }</FormLegend>
 
 				<FormLabel>
@@ -134,7 +134,7 @@ module.exports = React.createClass( {
 					disabled={ this.disableForm() }
 					compact
 					primary
-					onClick={ this.submitForm }
+					onClick={ this.handleSubmitForm }
 					>
 					{ this.state.submittingForm ? this.translate( 'Saving…' ) : this.translate( 'Save Settings' ) }
 				</Button>

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -92,7 +92,7 @@ const SiteSettingsFormWriting = React.createClass( {
 	},
 
 	submitFormAndActivateCustomContentModule( event ) {
-		this.submitForm( event );
+		this.handleSubmitForm( event );
 
 		// Only need to activate module for Jetpack sites
 		if ( ! this.props.site || ! this.props.site.jetpack ) {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -144,6 +144,16 @@
 	}
 }
 
+.site-settings__amp {
+	.section-header__actions {
+		display: flex;
+
+		button {
+			margin-left: 15px;
+		}
+	}
+}
+
 .site-settings__footer-credit-container {
 	margin-bottom: 16px;
 }
@@ -329,4 +339,3 @@
 .site-settings__jetpack-prompt-text {
 	flex: 4;
 }
-


### PR DESCRIPTION
Adds a new box to `My Site > Settings > General` for managing the AMP settings for your WordPress.com site.

## To Test

### Form Submit

This PR also makes a change to how form submit is handled for the settings sections to allow for settings to be saved when the AMP toggle is clicked.

Verify that clicking through the various settings sections and hitting save works.

### Jetpack

- Switch to a Jetpack site.
- Goto `My Site > Settings > General`.
- Verify that the AMP box doesn't show up.

### WordPress.com site (Hidden or Private)

- Switch to a site set to hidden or private.
- Goto `My Site > Settings > General`.
- Verify that the AMP box doesn't show up.

### WordPress.com site (Public)

- Switch to a WP.com site with the privacy setting set to public.
- Goto `My Site > Settings > General`.
- Verify that:
 - AMP box is displayed
 - Toggling on / off works
 - The "Customize" button is disabled when AMP is off.
 - The "Customize" button is enabled when AMP is on.
 - Clicking "Customize" launches the customizer and the AMP version of recent post is displayed with various controls for tweaking the AMP view (color scheme; header colors).

## Screenshot(s)

![site_settings_ _photos_ _wordpress_com](https://cloud.githubusercontent.com/assets/86105/19027726/311331d6-8901-11e6-9cb7-313755dab1c3.png)

![customizer_ _my_blog__sandbox__ _wordpress_com](https://cloud.githubusercontent.com/assets/86105/19142927/daee0356-8b6e-11e6-8f39-8ac2e14e6a33.png)
