### PR TITLE
Cancel expandedNudge abtest

### DIFF
--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -26,7 +26,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import PlanIcon from 'components/plans/plan-icon';
-import { abtest } from 'lib/abtest';
 
 class UpgradeNudgeExpanded extends Component {
 	constructor( props ) {
@@ -61,10 +60,6 @@ class UpgradeNudgeExpanded extends Component {
 		const features = this.props.planConstants.getPromotedFeatures().filter(
 			feature => feature !== this.props.highlightedFeature
 		).slice( 0, 6 );
-
-		if ( this.props.testedRegularNudge && abtest( 'expandedNudge' ) === 'regular' ) {
-			return this.props.testedRegularNudge;
-		}
 
 		return (
 			<Card className="upgrade-nudge-expanded">
@@ -136,8 +131,7 @@ UpgradeNudgeExpanded.propTypes = {
 	eventName: PropTypes.string,
 	event: PropTypes.string,
 	siteSlug: PropTypes.string,
-	recordTracksEvent: PropTypes.func.isRequired,
-	testedRegularNudge: PropTypes.element
+	recordTracksEvent: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ( state, { plan = PLAN_PERSONAL } ) => ( {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -33,15 +33,6 @@ module.exports = {
 		},
 		defaultVariation: 'clickableButton'
 	},
-	expandedNudge: {
-		datestamp: '20160927',
-		variations: {
-			expanded: 50,
-			regular: 50,
-		},
-		defaultVariation: 'regular',
-		allowExistingUsers: true,
-	},
 	multiDomainRegistrationV1: {
 		datestamp: '20200721',
 		variations: {

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -8,8 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
-import { PLAN_PREMIUM, FEATURE_VIDEO_UPLOADS, FEATURE_AUDIO_UPLOADS } from 'lib/plans/constants';
+import { FEATURE_VIDEO_UPLOADS, FEATURE_AUDIO_UPLOADS } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import ListPlanPromo from './list-plan-promo';
 
@@ -29,64 +28,20 @@ function getSubtitle( filter, translate ) {
 	return translate( 'By upgrading to a Premium Plan you\'ll enable VideoPress support on your site.' );
 }
 
-function getBenefits( filter, translate ) {
-	if ( filter === 'audio' ) {
-		return [
-			translate(
-				'Add support for podcasting to your site, including a built-in audio player.',
-				{ comment: 'Perk for upgrading to premium plan' }
-			),
-			translate(
-				'Upload audio files that use any major audio file format.',
-				{ comment: 'Perk for upgrading to premium plan' }
-			),
-			translate(
-				'Get more than four times the storage space for all of your media files.',
-				{ comment: 'Perk for upgrading to premium plan' }
-			)
-		];
-	}
-
-	return [
-		translate(
-			'Upload videos to your site with an interface designed specifically for WordPress.',
-			{ comment: 'Perk for upgrading to premium plan' }
-		),
-		translate(
-			'Present videos using a lightweight and responsive player that is ad-free and unbranded.',
-			{ comment: 'Perk for upgrading to premium plan' }
-		),
-		translate(
-			'See where your videos have been shared as well as stats for individual and overall video plays.',
-			{ comment: 'Perk for upgrading to premium plan' }
-		)
-	];
-}
-
 export const MediaLibraryUpgradeNudge = ( { translate, filter, site } ) => (
 	<div className="media-library__videopress-nudge-container">
-		<UpgradeNudgeExpanded
-			plan={ PLAN_PREMIUM }
-			title={ getTitle( filter, translate ) }
-			subtitle={ getSubtitle( filter, translate ) }
-			highlightedFeature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
-			event="calypso_media_uploads_upgrade_nudge"
-			benefits={ getBenefits( filter, translate ) }
-			testedRegularNudge={
-				<ListPlanPromo
-					site={ site }
-					filter={ filter }
-				>
-					<UpgradeNudge
-						className="media-library__videopress-nudge-regular"
-						title={ getTitle( filter, translate ) }
-						message={ getSubtitle( filter, translate ) }
-						feature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
-						event="calypso_media_uploads_upgrade_nudge"
-					/>
-				</ListPlanPromo>
-			}
-		/>
+		<ListPlanPromo
+			site={ site }
+			filter={ filter }
+			>
+			<UpgradeNudge
+				className="media-library__videopress-nudge-regular"
+				title={ getTitle( filter, translate ) }
+				message={ getSubtitle( filter, translate ) }
+				feature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
+				event="calypso_media_uploads_upgrade_nudge"
+			/>
+		</ListPlanPromo>
 	</div>
 );
 

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -15,9 +15,7 @@ import Card from 'components/card';
 import Button from 'components/button';
 import SectionHeader from 'components/section-header';
 import ExternalLink from 'components/external-link';
-import GoogleAnalyticsUpgradeNudge from 'blocks/upgrade-nudge-expanded';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
-import { PLAN_BUSINESS, FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
 
 const debug = debugFactory( 'calypso:my-sites:site-settings' );
 
@@ -181,34 +179,12 @@ export default React.createClass( {
 		debug( 'Google analitics is not enabled. adding nudge ...' );
 
 		return (
-			<GoogleAnalyticsUpgradeNudge
-				plan={ PLAN_BUSINESS }
-				title={ this.translate( 'Upgrade to a Business Plan and Enable Google Analytics' ) }
-				subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable Google Analytics Tracking on your site.' ) }
-				highlightedFeature={ FEATURE_GOOGLE_ANALYTICS }
-				event={ "google_analytics_settings" }
-				benefits={ [
-					this.translate(
-						'Analyze visitor traffic and paint a complete picture of your audience and their needs.'
-					),
-					this.translate(
-						'Track the routes people take to reach you and the devices they use to get there with ' +
-						'reporting tools like Traffic Sources.'
-					),
-					this.translate(
-						'Learn what people are looking for and what they like with In-Page Analytics. ' +
-						'Then tailor your marketing and site content for maximum impact.'
-					)
-				] }
-				testedRegularNudge={
-					<UpgradeNudge
-						title={ this.translate( 'Add Google Analytics' ) }
-						message={ this.translate( 'Upgrade to the business plan and include your own analytics tracking ID.' ) }
-						feature="google-analytics"
-						event="google_analytics_settings"
-						icon="stats-alt"
-					/>
-				}
+			<UpgradeNudge
+				title={ this.translate( 'Add Google Analytics' ) }
+				message={ this.translate( 'Upgrade to the business plan and include your own analytics tracking ID.' ) }
+				feature="google-analytics"
+				event="google_analytics_settings"
+				icon="stats-alt"
 			/>
 		);
 	},

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -448,8 +448,8 @@ export const SeoForm = React.createClass( {
 					<UpgradeNudge
 						feature={ FEATURE_ADVANCED_SEO }
 						title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
-						message={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
-						event={ "calypso_seo_settings_upgrade_nudge" }
+						message={ this.translate( `By upgrading to a Business Plan you'll enable advanced SEO features on your site.` ) }
+						event={ 'calypso_seo_settings_upgrade_nudge' }
 					/>
 				}
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -32,7 +32,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
-import SeoSettingsUpgradeNudge from 'blocks/upgrade-nudge-expanded';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import config from 'config';
@@ -44,9 +43,7 @@ import SearchPreview from 'components/seo/search-preview';
 import WebPreview from 'components/web-preview';
 import { requestSite } from 'state/sites/actions';
 import { isBusiness, isEnterprise } from 'lib/products-values';
-import {
-	PLAN_BUSINESS, FEATURE_ADVANCED_SEO
-} from 'lib/plans/constants';
+import { FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
 
 const serviceIds = {
 	google: 'google-site-verification',
@@ -338,7 +335,7 @@ export const SeoForm = React.createClass( {
 	},
 
 	render() {
-		const { showAdvancedSeo, showWebsiteMeta, showUpgradeNudge, upgradeToBusiness } = this.props;
+		const { showAdvancedSeo, showWebsiteMeta, showUpgradeNudge } = this.props;
 		const {
 			description: siteDescription,
 			slug = '',
@@ -448,38 +445,11 @@ export const SeoForm = React.createClass( {
 				}
 
 				{ showUpgradeNudge &&
-					<SeoSettingsUpgradeNudge
-						plan={ PLAN_BUSINESS }
-						upgrade={ upgradeToBusiness }
+					<UpgradeNudge
+						feature={ FEATURE_ADVANCED_SEO }
 						title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
-						subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
-						highlightedFeature={ FEATURE_ADVANCED_SEO }
-						event={ 'calypso_seo_settings_upgrade_nudge' }
-						benefits={ [
-							this.translate(
-								'Preview your site\'s posts and pages as they will appear ' +
-								'when shared on Facebook, Twitter and the WordPress.com Reader.'
-							),
-							this.translate(
-								'Allow you to control how page titles will appear on Google ' +
-								'search results, or when shared on social networks.'
-							),
-							this.translate(
-								'Modify front page meta data in order to customize ' +
-								'how your site appears to search engines.'
-							)
-						] }
-						testedRegularNudge={
-							<UpgradeNudge
-								feature={ FEATURE_ADVANCED_SEO }
-								title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
-								message={ this.translate(
-									'By upgrading to a Business Plan you\'ll enable advanced SEO ' +
-									'features on your site.'
-								) }
-								event={ 'calypso_seo_settings_upgrade_nudge' }
-							/>
-						}
+						message={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
+						event={ "calypso_seo_settings_upgrade_nudge" }
 					/>
 				}
 


### PR DESCRIPTION
Removes `expandedNudge` abtest introduced in #7853 and refined in #8218
The test went horribly for the expandedNudge. This reintroduces old nudges.

Here is a test post draft and test results: tritonp2-draft-14044

## Testing

- Use Free site
- Go to `/settings/seo/:site`
- See regular nudge
- Go to `/settings/analytics/:site`
- See regular nudge
- Create post, open "Video" tab in media modal
- See regular nudge

CC @lamosty @vindl @dmsnell @roundhill @gwwar @rralian @mtias 
