### PR TITLE
Support Chat: Remove avatars

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -202,8 +202,8 @@
 	flex: 1;
 	padding: 8px 12px;
 	border-radius: 8px 8px 8px 0;
-	color: $white;
-	background: $blue-medium;
+	color: $gray-dark;
+	background: $white;
 	position: relative;
 
 	overflow-wrap: break-word;
@@ -229,13 +229,13 @@
 		// draw a triangle
 		width: 0;
 		height: 0;
-		border-bottom: 8px solid $blue-medium;
+		border-bottom: 8px solid $white;
 		border-left: 8px solid transparent;
 	}
 
 	.is-user-message & {
-		background: $white;
-		color: $gray-dark;
+		color: $white;
+		background: $blue-medium;
 		border-radius: 8px 8px 0 8px;
 
 		&:after {
@@ -245,7 +245,7 @@
 			// draw a triangle
 			width: 0;
 			height: 0;
-			border-bottom: 8px solid $white;
+			border-bottom: 8px solid $blue-medium;
 			border-left: none;
 			border-right: 8px solid transparent;
 		}
@@ -337,6 +337,7 @@
 
 	.happychat__container.is-open {
 		position: fixed;
+		z-index: 0; // place it under the notifications drawer
 		height: calc( 100% - 47px );
 		bottom: 0;
 		right: 0;

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -161,6 +161,7 @@
 		min-height: initial;
 		align-self: stretch;
 		resize: none;
+		height: 100%;
 
 		&:focus, &:active {
 			outline: none;

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -199,7 +199,7 @@
 .happychat__message-text {
 	font-size: 14px;
 	flex: 1;
-	padding: 8px;
+	padding: 8px 12px;
 	border-radius: 8px 8px 8px 0;
 	color: $white;
 	background: $blue-medium;
@@ -223,13 +223,13 @@
 		display: block;
 		position: absolute;
 		bottom: 0;
-		left: -6px;
+		left: -8px;
 
 		// draw a triangle
 		width: 0;
 		height: 0;
-		border-bottom: 6px solid $blue-medium;
-		border-left: 6px solid transparent;
+		border-bottom: 8px solid $blue-medium;
+		border-left: 8px solid transparent;
 	}
 
 	.is-user-message & {
@@ -239,14 +239,14 @@
 
 		&:after {
 			left: auto;
-			right: -6px;
+			right: -8px;
 
 			// draw a triangle
 			width: 0;
 			height: 0;
-			border-bottom: 6px solid $white;
+			border-bottom: 8px solid $white;
 			border-left: none;
-			border-right: 6px solid transparent;
+			border-right: 8px solid transparent;
 		}
 	}
 }
@@ -277,7 +277,7 @@
 	flex: 0 0 auto;
 	display: flex;
 	flex-direction: row-reverse;
-	padding: 0 8px;
+	padding: 0 10px;
 	margin: 6px 0;
 
 	a {

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -14,11 +14,9 @@ import { connect } from 'react-redux';
 import {
 	first,
 	when,
-	forEach,
-	propExists
+	forEach
 } from './functional';
 import autoscroll from './autoscroll';
-import AgentW from 'components/happychat/agent-w';
 import scrollbleed from './scrollbleed';
 import { translate } from 'i18n-calypso';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -58,7 +56,6 @@ const messageWithLinks = ( { message, key, links } ) => {
  * Otherwise just return a single paragraph with the text.
  */
 const messageText = when( linksNotEmpty, messageWithLinks, messageParagraph );
-const messageAvatar = when( propExists( 'image' ), ( { image, name } ) => <img alt={ name } src={ image } /> );
 
 /*
  * Group messages based on user so when any user sends multiple messages they will be grouped
@@ -66,7 +63,6 @@ const messageAvatar = when( propExists( 'image' ), ( { image, name } ) => <img a
  */
 const renderGroupedMessages = ( { item, isCurrentUser }, index ) => {
 	const [ event, ... rest ] = item;
-	const userAvatar = messageAvatar( event );
 	return (
 		<div className={ classnames( 'happychat__timeline-message', { 'is-user-message': isCurrentUser } ) } key={ event.id || index }>
 			<div className="happychat__message-text">
@@ -77,11 +73,6 @@ const renderGroupedMessages = ( { item, isCurrentUser }, index ) => {
 					links: event.links
 				} ) }
 				{ rest.map( ( { message, id: key, links } ) => messageText( { message, key, links } ) ) }
-			</div>
-			<div className="happychat__message-meta">
-				<div className="happychat__message-avatar">
-				{ isCurrentUser ? userAvatar : <AgentW /> }
-				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
In a recent discussion we decided to remove avatars from the chat interface for launch. This is in great part due to the fact that avatars took up a lot of space on an already cramped interface. 

This PR removes avatars from the chat. It now looks far more like iMessage. The removal of avatars also allowed us to relax the paddings just a little bit, which this PR also does. Finally it fixes a teensy issue on responsive chat windows where long messages would break the layout.

How to test:

- `make run`, then click the Support Chat link in the bottom of the sidebar
- Type in a message or question, verify that there are no avatars.
- Try to type a long message, see that the layout doesn't break.
- If you would like a reply from support (and it isn't online yet), log in as a proxied Automattician on https://happychat.io/ and pick up your chat.

Screenshot:

<img width="351" alt="screen shot 2016-10-03 at 12 55 11" src="https://cloud.githubusercontent.com/assets/1204802/19035326/366e4cf2-8969-11e6-9b8a-f9560b4c798b.png">
