### PR TITLE
Editor: Drafts count relies on QueryPosts instead of QueryPostCounts

### DIFF
--- a/client/my-sites/drafts/author-filter.jsx
+++ b/client/my-sites/drafts/author-filter.jsx
@@ -13,7 +13,7 @@ import NavSegmented from 'components/section-nav/segmented';
 import NavItem from 'components/section-nav/item';
 import { getCurrentUser } from 'state/current-user/selectors';
 
-function AuthorSelector( { onChange, selectedScope, translate, user } ) {
+function DraftsAuthorFilter( { onChange, selectedScope, translate, user } ) {
 	const scopes = [
 		{
 			id: 'me',
@@ -28,7 +28,7 @@ function AuthorSelector( { onChange, selectedScope, translate, user } ) {
 	];
 
 	return (
-		<div className="drafts__author-selector">
+		<div className="drafts__author-filter">
 			<NavSegmented
 				label={ translate( 'Author', { context: 'Filter group label for segmented' } ) }
 			>
@@ -55,4 +55,4 @@ export default connect( state => {
 	return {
 		user: getCurrentUser( state )
 	};
-} )( localize( AuthorSelector ) );
+} )( localize( DraftsAuthorFilter ) );

--- a/client/my-sites/drafts/author-selector.jsx
+++ b/client/my-sites/drafts/author-selector.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gravatar from 'components/gravatar';
+import NavSegmented from 'components/section-nav/segmented';
+import NavItem from 'components/section-nav/item';
+import userLib from 'lib/user';
+const user = userLib();
+
+function AuthorSelector( { selectedScope, onChange } ) {
+	const scopes = [
+		{
+			id: 'me',
+			caption: i18n.translate( 'Me', { context: 'Filter label for posts list' } ),
+			showGravatar: true
+		},
+		{
+			id: 'everyone',
+			caption: i18n.translate( 'Everyone', { context: 'Filter label for posts list' } ),
+			showGravatar: false
+		}
+	];
+
+	return (
+		<div className="drafts__author-selector">
+			<NavSegmented
+				label={ i18n.translate( 'Author', { context: 'Filter group label for segmented' } ) }
+			>
+				{ scopes.map( scope => {
+					const selectScope = () => onChange( scope.id );
+
+					return (
+						<NavItem
+							key={ 'authorSegmented' + scope.id }
+							selected={ selectedScope === scope.id }
+							onClick={ selectScope }
+						>
+							{ scope.caption }
+							{ scope.showGravatar && <Gravatar size={ 16 } user={ user.get() } /> }
+						</NavItem>
+					);
+				} ) }
+			</NavSegmented>
+		</div>
+	);
+}
+
+export default AuthorSelector;

--- a/client/my-sites/drafts/author-selector.jsx
+++ b/client/my-sites/drafts/author-selector.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -10,19 +11,18 @@ import i18n from 'i18n-calypso';
 import Gravatar from 'components/gravatar';
 import NavSegmented from 'components/section-nav/segmented';
 import NavItem from 'components/section-nav/item';
-import userLib from 'lib/user';
-const user = userLib();
+import { getCurrentUser } from 'state/current-user/selectors';
 
-function AuthorSelector( { selectedScope, onChange } ) {
+function AuthorSelector( { onChange, selectedScope, translate, user } ) {
 	const scopes = [
 		{
 			id: 'me',
-			caption: i18n.translate( 'Me', { context: 'Filter label for posts list' } ),
+			caption: translate( 'Me', { context: 'Filter label for posts list' } ),
 			showGravatar: true
 		},
 		{
 			id: 'everyone',
-			caption: i18n.translate( 'Everyone', { context: 'Filter label for posts list' } ),
+			caption: translate( 'Everyone', { context: 'Filter label for posts list' } ),
 			showGravatar: false
 		}
 	];
@@ -30,7 +30,7 @@ function AuthorSelector( { selectedScope, onChange } ) {
 	return (
 		<div className="drafts__author-selector">
 			<NavSegmented
-				label={ i18n.translate( 'Author', { context: 'Filter group label for segmented' } ) }
+				label={ translate( 'Author', { context: 'Filter group label for segmented' } ) }
 			>
 				{ scopes.map( scope => {
 					const selectScope = () => onChange( scope.id );
@@ -42,7 +42,7 @@ function AuthorSelector( { selectedScope, onChange } ) {
 							onClick={ selectScope }
 						>
 							{ scope.caption }
-							{ scope.showGravatar && <Gravatar size={ 16 } user={ user.get() } /> }
+							{ scope.showGravatar && <Gravatar size={ 16 } user={ user } /> }
 						</NavItem>
 					);
 				} ) }
@@ -51,4 +51,8 @@ function AuthorSelector( { selectedScope, onChange } ) {
 	);
 }
 
-export default AuthorSelector;
+export default connect( state => {
+	return {
+		user: getCurrentUser( state )
+	};
+} )( localize( AuthorSelector ) );

--- a/client/my-sites/drafts/controller.js
+++ b/client/my-sites/drafts/controller.js
@@ -17,17 +17,17 @@ const sites = sitesFactory();
 module.exports = {
 
 	drafts: function( context ) {
-		var Drafts = require( 'my-sites/drafts/main' ),
-			siteID = route.getSiteFragment( context.path );
+		const Drafts = require( 'my-sites/drafts/main' ),
+			siteId = route.getSiteFragment( context.path );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Drafts', { textOnly: true } ) ) );
 
 		renderWithReduxStore(
 			React.createElement( Drafts, {
-				siteID: siteID,
-				sites: sites,
-				trackScrollPage: function() {}
+				trackScrollPage: function() {},
+				siteId,
+				sites
 			} ),
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/my-sites/drafts/draft-list.jsx
+++ b/client/my-sites/drafts/draft-list.jsx
@@ -7,33 +7,35 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import AuthorSelector from './author-selector';
+import DraftsAuthorFilter from './author-filter';
 import Count from 'components/count';
 import Draft from 'my-sites/draft';
 import EmptyContent from 'components/empty-content';
 import PostListFetcher from 'components/post-list-fetcher';
 import QueryPostCounts from 'components/data/query-post-counts';
 import {
-	getNormalizedPostCounts,
-	getNormalizedMyPostCounts,
+	getMyPostCount,
+	getAllPostCount,
 	isRequestingPostCounts
 } from 'state/posts/counts/selectors';
 import actions from 'lib/posts/actions';
 import { hasTouch } from 'lib/touch-detect';
 import infiniteScroll from 'lib/mixins/infinite-scroll';
 import observe from 'lib/mixins/data-observe';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 class DraftList extends Component {
 
 	static propTypes = {
 		search: PropTypes.string,
 		sites: PropTypes.object,
-		siteID: PropTypes.any,
+		siteId: PropTypes.any,
 		trackScrollPage: PropTypes.func,
 		onTitleClick: PropTypes.func,
 		showAllActionsMenu: PropTypes.bool,
-		selectedId: PropTypes.number
+		selectedId: PropTypes.number,
+		myCount: React.PropTypes.number,
+		allCount: React.PropTypes.number
 	};
 
 	static defaultProps = {
@@ -53,22 +55,22 @@ class DraftList extends Component {
 	}
 
 	render() {
-		const { siteID, myCounts, everyoneCounts, isRequestingCounts, selectedId, user } = this.props;
+		const { siteId, myCount, allCount, isRequestingCounts, selectedId, userId } = this.props;
 		const { authorFilter } = this.state;
-		const author = authorFilter === 'me' ? user.ID : null;
-		const count = authorFilter === 'me' ? myCounts.draft : everyoneCounts.draft;
-		const showCount = siteID && ( ! isRequestingCounts || count );
+		const author = authorFilter === 'me' ? userId : null;
+		const count = authorFilter === 'me' ? myCount : allCount;
+		const showCount = siteId && ( ! isRequestingCounts || count );
 
 		return (
 			<div>
-				{ siteID && <QueryPostCounts siteId={ siteID } type="post" /> }
+				{ siteId && <QueryPostCounts siteId={ siteId } type="post" /> }
 				<div className="drafts__header">
-					<AuthorSelector selectedScope={ authorFilter }
+					<DraftsAuthorFilter selectedScope={ authorFilter }
 						onChange={ this.setAuthorFilter } />
 					{ showCount && <Count count={ count } /> }
 				</div>
 				<PostListFetcher
-					siteID={ this.props.siteID }
+					siteID={ this.props.siteId }
 					status="draft,pending"
 					author={ author }
 					withImages
@@ -100,7 +102,7 @@ const Drafts = React.createClass( {
 		posts: React.PropTypes.array.isRequired,
 		postImages: React.PropTypes.object.isRequired,
 		search: React.PropTypes.string,
-		siteID: React.PropTypes.any,
+		siteId: React.PropTypes.any,
 		showAllActionsMenu: React.PropTypes.bool,
 		selectedId: React.PropTypes.number
 	},
@@ -182,11 +184,11 @@ const Drafts = React.createClass( {
 	}
 } );
 
-module.exports = connect( ( state, { siteID } ) => {
+export default connect( ( state, { siteId } ) => {
 	return {
-		isRequestingCounts: isRequestingPostCounts( state, siteID, 'post' ),
-		myCounts: getNormalizedMyPostCounts( state, siteID, 'post' ),
-		everyoneCounts: getNormalizedPostCounts( state, siteID, 'post' ),
-		user: getCurrentUser( state )
+		isRequestingCounts: isRequestingPostCounts( state, siteId, 'post' ),
+		myCount: getMyPostCount( state, siteId, 'post', 'draft' ),
+		allCount: getAllPostCount( state, siteId, 'post', 'draft' ),
+		userId: getCurrentUserId( state )
 	};
 } )( DraftList );

--- a/client/my-sites/drafts/style.scss
+++ b/client/my-sites/drafts/style.scss
@@ -5,6 +5,7 @@
 	font-weight: bold;
 	margin: 0 0 30px;
 }
+
 .drafts .search {
 	margin-bottom: 24px;
 	position: static;
@@ -12,4 +13,27 @@
 	input {
 		display: block;
 	}
+}
+
+.drafts__header {
+	display: flex;
+	flex-shrink: 0;
+	justify-content: flex-end;
+	align-items: center;
+	padding: 0 14px 14px 6px;
+
+	@include breakpoint( ">660px" ) {
+		justify-content: space-between;
+	}
+}
+
+.drafts__header .section-nav-group {
+	display: inline-block;
+	width: auto;
+	margin-top: 0;
+}
+
+.drafts__author-selector .gravatar {
+	margin-left: 6px;
+	vertical-align: middle;
 }

--- a/client/my-sites/drafts/style.scss
+++ b/client/my-sites/drafts/style.scss
@@ -33,7 +33,7 @@
 	margin-top: 0;
 }
 
-.drafts__author-selector .gravatar {
+.drafts__author-filter .gravatar {
 	margin-left: 6px;
 	vertical-align: middle;
 }

--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -9,7 +9,6 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Count from 'components/count';
 import QueryPostCounts from 'components/data/query-post-counts';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -28,10 +27,9 @@ function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText } ) {
 				<QueryPostCounts siteId={ siteId } type="post" />
 			) }
 			{ ! hideText && <span>{ translate( 'Drafts' ) }</span> }
-			{ count && ! jetpack ? <Count count={ count } /> : null }
 		</Button>
 	);
-};
+}
 
 EditorDraftsButton.propTypes = {
 	count: PropTypes.number,

--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -10,12 +10,12 @@ import { translate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Count from 'components/count';
-import QueryPostCounts from 'components/data/query-post-counts';
+import QueryPosts from 'components/data/query-posts';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { getAllPostCount } from 'state/posts/counts/selectors';
+import { getSitePostsForQuery } from 'state/posts/selectors';
 
-function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText } ) {
+function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText, query } ) {
 	return (
 		<Button
 			compact borderless
@@ -25,28 +25,34 @@ function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText } ) {
 			aria-label={ translate( 'View all drafts' ) }
 		>
 			{ siteId && (
-				<QueryPostCounts siteId={ siteId } type="post" />
+				<QueryPosts
+					siteId={ siteId }
+					query={ query } />
 			) }
 			{ ! hideText && <span>{ translate( 'Drafts' ) }</span> }
 			{ count && ! jetpack ? <Count count={ count } /> : null }
 		</Button>
 	);
-};
+}
 
 EditorDraftsButton.propTypes = {
 	count: PropTypes.number,
 	onClick: PropTypes.func,
 	jetpack: PropTypes.bool,
 	siteId: PropTypes.number,
-	hideText: PropTypes.bool
+	hideText: PropTypes.bool,
+	query: PropTypes.object
 };
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
+	const query = { status: 'draft,pending' };
+	const posts = getSitePostsForQuery( state, siteId, query );
 
 	return {
 		jetpack: isJetpackSite( state, siteId ),
-		count: getAllPostCount( state, siteId, 'post', 'draft' ),
-		siteId
+		count: posts ? posts.length : 0,
+		siteId,
+		query
 	};
 } )( EditorDraftsButton );

--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -10,12 +10,12 @@ import { translate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Count from 'components/count';
-import QueryPosts from 'components/data/query-posts';
+import QueryPostCounts from 'components/data/query-post-counts';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { getSitePostsForQuery } from 'state/posts/selectors';
+import { getAllPostCount } from 'state/posts/counts/selectors';
 
-function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText, query } ) {
+function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText } ) {
 	return (
 		<Button
 			compact borderless
@@ -25,34 +25,28 @@ function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText, query 
 			aria-label={ translate( 'View all drafts' ) }
 		>
 			{ siteId && (
-				<QueryPosts
-					siteId={ siteId }
-					query={ query } />
+				<QueryPostCounts siteId={ siteId } type="post" />
 			) }
 			{ ! hideText && <span>{ translate( 'Drafts' ) }</span> }
 			{ count && ! jetpack ? <Count count={ count } /> : null }
 		</Button>
 	);
-}
+};
 
 EditorDraftsButton.propTypes = {
 	count: PropTypes.number,
 	onClick: PropTypes.func,
 	jetpack: PropTypes.bool,
 	siteId: PropTypes.number,
-	hideText: PropTypes.bool,
-	query: PropTypes.object
+	hideText: PropTypes.bool
 };
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const query = { status: 'draft,pending' };
-	const posts = getSitePostsForQuery( state, siteId, query );
 
 	return {
 		jetpack: isJetpackSite( state, siteId ),
-		count: posts ? posts.length : 0,
-		siteId,
-		query
+		count: getAllPostCount( state, siteId, 'post', 'draft' ),
+		siteId
 	};
 } )( EditorDraftsButton );

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -45,7 +45,7 @@ export default class EditorSidebar extends Component {
 				sites={ this.props.sites }
 				onTitleClick={ this.props.onTitleClick }
 				showAllActionsMenu={ false }
-				siteID={ this.props.site ? this.props.site.ID : null }
+				siteId={ this.props.site ? this.props.site.ID : null }
 				selectedId={ this.props.post ? this.props.post.ID : null }
 			/>
 		);


### PR DESCRIPTION
The draft list shows a list of drafts that can be edited by the current user.
However, the count is computed used the Post Counts API and always shows the total.
This commit updated the count to show the exact same number of displayed drafts for the current user.

The DraftList is still using the `PostListFetcher`. Next, it would be good if we change the `DraftList` component to rely on the `QueryPosts` either.

closes #1806

**Edit:**

This PR has evolved to adding an "author" selector above the Draft List on the editor as shown on the screenshot here.

<img width="274" alt="capture d ecran 2016-10-13 a 10 27 40 am" src="https://cloud.githubusercontent.com/assets/272444/19343851/d8dffd14-912f-11e6-88f8-5fc4d0b0eeeb.png">

**Testing instructions**
- Create drafts using an "admin" user and an "author". 
- verify that the behavior of the Draft List is the same between `/posts` and the editor Sidepanel: A toggle to switch the draft's author

cc @timmyc 
