### PR TITLE
Themes: Fix prop warning for QueryUserPurchases component

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -396,7 +396,7 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const { name: themeName, description } = this.props;
+		const {  name: themeName, description, currentUserId } = this.props;
 		const title = i18n.translate( '%(themeName)s Theme', {
 			args: { themeName }
 		} );
@@ -410,7 +410,7 @@ const ThemeSheet = React.createClass( {
 				canonicalUrl={ canonicalUrl }
 				image={ this.props.screenshot }>
 				<QueryThemeDetails id={ this.props.id } siteId={ siteID } />
-				<QueryUserPurchases userId={ this.props.currentUserId } />
+				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				<Main className="theme__sheet">
 					<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 						{ this.renderBar() }


### PR DESCRIPTION

![screen shot 2016-10-03 at 15 35 11](https://cloud.githubusercontent.com/assets/7767559/19041246/3c09a402-897f-11e6-8c20-dcdffab5ff14.png)

Only use `<QueryUserPurchases>` component in theme info sheet if there is a current user id available.

**To Test**
* Check that the 'need extra help' card still shows for logged-in paying users on a theme info sheet, for example: http://calypso.localhost:3000/theme/mood/support
![screen shot 2016-10-03 at 15 34 18](https://cloud.githubusercontent.com/assets/7767559/19041222/225a91ce-897f-11e6-879b-a47b4cf47376.png)

