### PR TITLE
Editor: Use https for google maps geolocation urls

### DIFF
--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -16,7 +16,7 @@ const PostActions = require( 'lib/posts/actions' ),
 /**
  * Module variables
  */
-const GOOGLE_MAPS_BASE_URL = 'http://maps.google.com/maps/api/staticmap?';
+const GOOGLE_MAPS_BASE_URL = 'https://maps.google.com/maps/api/staticmap?';
 
 export default React.createClass( {
 	displayName: 'EditorLocation',
@@ -95,13 +95,11 @@ export default React.createClass( {
 	},
 
 	renderCurrentLocation: function() {
-		var src;
-
 		if ( ! this.props.coordinates ) {
 			return;
 		}
 
-		src = GOOGLE_MAPS_BASE_URL + qs.stringify( {
+		const src = GOOGLE_MAPS_BASE_URL + qs.stringify( {
 			markers: this.props.coordinates.join( ',' ),
 			zoom: 8,
 			size: '400x300'


### PR DESCRIPTION
Non-secure URLs were causing a bug on Safari
since it started blocking mixed contents on Safari 9

closes #8239

**Test Instructions**

* Starting at URL: wordPress.com/post/
* Click More Options -> Get Current Location while using Safari 10
* The map should be displayed correctly

cc @aduth 