### PR TITLE
Enabling Advanced SEO flags for production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -29,6 +29,7 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/production.json
+++ b/config/production.json
@@ -28,6 +28,8 @@
 		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
+		"manage/advanced-seo": true,
+		"manage/advanced-seo/custom-title": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,


### PR DESCRIPTION
Allows for Advanced SEO features in production. Also noticed that horizon was missing it so I added it there as well.

When everything looks good we can remove both of the Advanced SEO feature flags.