### PR TITLE
Add placeholder for prices in PlanFeaturesHeader component

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -147,12 +147,19 @@ class PlanFeaturesHeader extends Component {
 			discountPrice,
 			rawPrice,
 			isPlaceholder,
-			relatedMonthlyPlan
+			relatedMonthlyPlan,
+			site
 		} = this.props;
 
 		if ( isPlaceholder ) {
+			const isJetpackSite = !! site.jetpack;
+			const classes = classNames( 'is-placeholder', {
+				'plan-features__price': ! isJetpackSite,
+				'plan-features__price-jetpack': isJetpackSite
+			} );
+
 			return (
-				<div className="plan-features__price is-placeholder"></div>
+				<div className={ classes } ></div>
 			);
 		}
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -267,8 +267,37 @@ $plan-features-sidebar-width: 272px;
 
 	&.is-placeholder {
 		@include placeholder( 23% );
-		width: 100px;
+		width: 140px;
 		height: 12px;
+		margin-bottom: 15px;
+
+		@include breakpoint( "<960px" ) {
+			margin-bottom: 9px;
+		}
+	}
+}
+
+.plan-features__price {
+	&.is-placeholder {
+		@include placeholder( 23% );
+		width: 45px;
+		height: 25px;
+		margin-top: 9px;
+		margin-bottom: 5px;
+	}
+}
+
+.plan-features__price-jetpack {
+	&.is-placeholder {
+		@include placeholder( 23% );
+		height: 32px;
+		margin-top: 5px;
+		margin-bottom: 5px;
+		width: 140px;
+
+		@include breakpoint( "<960px" ) {
+			height: 26px;
+		}
 	}
 }
 


### PR DESCRIPTION
There are some ways to fix this #8203. 

Do we want to display placeholders only for prices (in the square)? Or also for billing timeframe (in the oval)? 
![imageedit_20_7094482682](https://cloud.githubusercontent.com/assets/14272775/19050564/6d81e834-89af-11e6-91e6-c9b37ded27ee.jpg) 
In my PR, I'm displaying placeholders for prices both on jetpack plans site and the other plans site. And placeholder for timeframe on the normal plans site. 
Those placeholders are height enough to make `<PlanFeaturesHeader>`'s height the same while and after price loading. 

There is a difference between price height on jetpack plans site and price height on the other plans site. So I added there a condition when displaying a placeholder for a price. And according to this condition made styles for jetpack price placeholder and for the original site placeholders.