### PR TITLE
Revert "SSR: Use document-head to populate `title`, `meta`s, and `link`s; drop `Helmet`"

### DIFF
--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -1,5 +1,3 @@
-/** @ssr-ready **/
-
 /**
  * External dependencies.
  */
@@ -11,9 +9,10 @@ import isEqual from 'lodash/isEqual';
 /**
  * Internal dependencies.
  */
-import { getDocumentHeadFormattedTitle } from 'state/document-head/selectors';
+import { getFormattedTitle } from 'state/document-head/selectors';
 import {
 	setDocumentHeadTitle as setTitle,
+	setDocumentHeadDescription as setDescription,
 	addDocumentHeadLink as addLink,
 	addDocumentHeadMeta as addMeta,
 	setDocumentHeadUnreadCount as setUnreadCount
@@ -23,14 +22,19 @@ class DocumentHead extends Component {
 	componentWillMount() {
 		const {
 			title,
+			description,
 			unreadCount
 		} = this.props;
 
-		if ( this.props.title !== undefined ) {
+		if ( 'title' in this.props ) {
 			this.props.setTitle( title );
 		}
 
-		if ( this.props.unreadCount !== undefined ) {
+		if ( 'description' in this.props ) {
+			this.props.setDescription( description );
+		}
+
+		if ( 'unreadCount' in this.props ) {
 			this.props.setUnreadCount( unreadCount );
 		}
 
@@ -49,11 +53,15 @@ class DocumentHead extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.title !== undefined && this.props.title !== nextProps.title ) {
+		if ( this.props.title !== nextProps.title ) {
 			this.props.setTitle( nextProps.title );
 		}
 
-		if ( nextProps.unreadCount !== undefined && this.props.unreadCount !== nextProps.unreadCount ) {
+		if ( this.props.description !== nextProps.description ) {
+			this.props.setDescription( nextProps.description );
+		}
+
+		if ( this.props.unreadCount !== nextProps.unreadCount ) {
 			this.props.setUnreadCount( nextProps.unreadCount );
 		}
 
@@ -81,10 +89,12 @@ class DocumentHead extends Component {
 
 DocumentHead.propTypes = {
 	title: PropTypes.string,
+	description: PropTypes.string,
 	unreadCount: PropTypes.number,
 	link: PropTypes.array,
 	meta: PropTypes.array,
 	setTitle: PropTypes.func.isRequired,
+	setDescription: PropTypes.func.isRequired,
 	addLink: PropTypes.func.isRequired,
 	addMeta: PropTypes.func.isRequired,
 	setUnreadCount: PropTypes.func.isRequired
@@ -92,10 +102,11 @@ DocumentHead.propTypes = {
 
 export default connect(
 	state => ( {
-		formattedTitle: getDocumentHeadFormattedTitle( state )
+		formattedTitle: getFormattedTitle( state )
 	} ),
 	{
 		setTitle,
+		setDescription,
 		addLink,
 		addMeta,
 		setUnreadCount

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
  * Internal Dependencies
  */
 import Gridicon from 'components/gridicon';
-import { getDocumentHeadTitle } from 'state/document-head/selectors';
+import { getTitle } from 'state/document-head/selectors';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 
 class SidebarNavigation extends React.Component {
@@ -48,7 +48,7 @@ SidebarNavigation.propTypes = {
 
 export default connect(
 	state => ( {
-		title: getDocumentHeadTitle( state )
+		title: getTitle( state )
 	} ),
 	{ setLayoutFocus }
 )( SidebarNavigation );

--- a/client/layout/head/README.md
+++ b/client/layout/head/README.md
@@ -1,0 +1,33 @@
+Head
+====
+
+A generic component for layouts and Calypso sections, `Head` has
+isomorphism in mind. It allows a parent component to define the document
+title, as well as other data important for SEO — namely, a page's
+description and its canonical URL. It is, essentially, a wrapper for
+[`react-helmet`][helmet].
+
+It should work out of the box on both client- and server-side code,
+allowing e.g. a Calypso section to just declare its SEO-oriented meta.
+If SEO is not a concern for you, `Head` still has the benefit of
+providing a React-minded interface for setting document title.
+
+# Usage
+
+```js
+// In `my-sites/foo/controller.js`:
+<Head
+		title="Foo — WordPress.com"
+		description="Awesome foos for your WordPressen!"
+		canonicalUrl="https://wordpress.com/foo">
+	<FooMain />
+</Head>
+```
+
+# Next
+
+- This is a newborn component whose status is still uncertain. There
+  have been discussions about extending `Main` from `components/main` to
+  take the props shown in the example above, rendering `Head` obsolete.
+
+[helmet]: https://github.com/nfl/react-helmet

--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -1,0 +1,46 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Helmet from 'react-helmet';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:layout:head' );
+
+const Head = ( { title, description, canonicalUrl, type, siteName, image, children } ) => (
+	<div>
+		<Helmet
+			title={ title }
+			meta={ [
+				description ? { name: 'description', property: 'og:description', content: description } : {},
+				title ? { property: 'og:title', content: title } : {},
+				canonicalUrl ? { property: 'og:url', content: canonicalUrl } : {},
+				type ? { property: 'og:type', content: type } : {},
+				siteName ? { property: 'og:site_name', content: siteName } : {},
+				image ? { property: 'og:image', content: image } : {},
+			] }
+			link={ [
+				canonicalUrl ? { rel: 'canonical', href: canonicalUrl } : {}
+			] }
+			onChangeClientState={ debug }
+		/>
+		{ children }
+	</div>
+);
+
+Head.displayName = 'Head';
+Head.propTypes = {
+	title: React.PropTypes.string,
+	description: React.PropTypes.string,
+	canonicalUrl: React.PropTypes.string,
+	type: React.PropTypes.string,
+	siteName: React.PropTypes.string,
+	image: React.PropTypes.string,
+	children: React.PropTypes.node,
+};
+
+Head.defaultProps = { site_name: 'WordPress.com' };
+
+export default Head;

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -48,7 +48,7 @@ import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import ThemePreview from 'my-sites/themes/theme-preview';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import DocumentHead from 'components/data/document-head';
+import Head from 'layout/head';
 import { decodeEntities } from 'lib/formatting';
 import { getThemeDetails } from 'state/themes/theme-details/selectors';
 
@@ -397,60 +397,47 @@ const ThemeSheet = React.createClass( {
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
 		const { name: themeName, description } = this.props;
-		const title = themeName && i18n.translate( '%(themeName)s Theme', {
+		const title = i18n.translate( '%(themeName)s Theme', {
 			args: { themeName }
 		} );
 		const canonicalUrl = `https://wordpress.com/theme/${ this.props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
 
-		const metas = [
-			{ property: 'og:url', content: canonicalUrl },
-			{ property: 'og:image', content: this.props.screenshot },
-			{ property: 'og:type', content: 'website' }
-		];
-
-		if ( description ) {
-			metas.push( {
-				name: 'description',
-				property: 'og:description',
-				content: decodeEntities( description )
-			} );
-		}
-
-		const links = [ { rel: 'canonical', href: canonicalUrl } ];
-
 		return (
-			<Main className="theme__sheet">
+			<Head
+				title= { themeName && decodeEntities( title ) + ' — WordPress.com' }
+				description={ description && decodeEntities( description ) }
+				type={ 'website' }
+				canonicalUrl={ canonicalUrl }
+				image={ this.props.screenshot }>
 				<QueryThemeDetails id={ this.props.id } siteId={ siteID } />
 				<QueryUserPurchases userId={ this.props.currentUserId } />
-				<DocumentHead
-					title={ title }
-					meta={ metas }
-					link={ links } />
-				<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
-					{ this.renderBar() }
-					{ siteID && <QueryCurrentTheme siteId={ siteID } /> }
-				<ThanksModal
-					site={ this.props.selectedSite }
-					source={ 'details' } />
-				{ this.state.showPreview && this.renderPreview() }
-				<HeaderCake className="theme__sheet-action-bar"
-							backHref={ this.props.backPath }
-							backText={ i18n.translate( 'All Themes' ) }>
-					{ this.renderButton() }
-				</HeaderCake>
-				<div className="theme__sheet-columns">
-					<div className="theme__sheet-column-left">
-						<div className="theme__sheet-content">
-							{ this.renderSectionNav( section ) }
-							{ this.renderSectionContent( section ) }
-							<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
+				<Main className="theme__sheet">
+					<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
+						{ this.renderBar() }
+						{ siteID && <QueryCurrentTheme siteId={ siteID } /> }
+					<ThanksModal
+						site={ this.props.selectedSite }
+						source={ 'details' } />
+					{ this.state.showPreview && this.renderPreview() }
+					<HeaderCake className="theme__sheet-action-bar"
+								backHref={ this.props.backPath }
+								backText={ i18n.translate( 'All Themes' ) }>
+						{ this.renderButton() }
+					</HeaderCake>
+					<div className="theme__sheet-columns">
+						<div className="theme__sheet-column-left">
+							<div className="theme__sheet-content">
+								{ this.renderSectionNav( section ) }
+								{ this.renderSectionContent( section ) }
+								<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
+							</div>
+						</div>
+						<div className="theme__sheet-column-right">
+							{ this.renderScreenshot() }
 						</div>
 					</div>
-					<div className="theme__sheet-column-right">
-						{ this.renderScreenshot() }
-					</div>
-				</div>
-			</Main>
+				</Main>
+			</Head>
 		);
 	},
 

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -2,6 +2,8 @@
  * External Dependencies
  */
 import React from 'react';
+import i18n from 'i18n-calypso';
+import omit from 'lodash/omit';
 
 /**
  * Internal Dependencies
@@ -11,6 +13,22 @@ import MultiSiteComponent from './multi-site';
 import LoggedOutComponent from './logged-out';
 import trackScrollPage from 'lib/track-scroll-page';
 import { getAnalyticsData } from './helpers';
+import DocumentHead from 'components/data/document-head';
+
+function makeElement( ThemesComponent, Head, store, props ) {
+	return (
+		<Head
+			title={ props.title }
+			description={ props.description }
+			type={ 'website' }
+			canonicalUrl={ props.canonicalUrl }
+			image={ props.image }
+			tier={ props.tier || 'all' }>
+			<DocumentHead title={ props.title } />
+			<ThemesComponent { ...omit( props, [ 'title' ] ) } />
+		</Head>
+	);
+}
 
 function getProps( context ) {
 	const { tier, filter, vertical, site_id: siteId } = context.params;
@@ -30,6 +48,7 @@ function getProps( context ) {
 	};
 
 	return {
+		title: i18n.translate( 'Themes', { textOnly: true } ),
 		tier,
 		filter,
 		vertical,
@@ -41,6 +60,7 @@ function getProps( context ) {
 }
 
 export function singleSite( context, next ) {
+	const Head = require( 'layout/head' );
 	const { site_id: siteId } = context.params;
 	const props = getProps( context );
 
@@ -52,11 +72,12 @@ export function singleSite( context, next ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <SingleSiteComponent { ...props } />;
+	context.primary = makeElement( SingleSiteComponent, Head, context.store, props );
 	next();
 }
 
 export function multiSite( context, next ) {
+	const Head = require( 'layout/head' );
 	const props = getProps( context );
 
 	// Scroll to the top
@@ -64,13 +85,14 @@ export function multiSite( context, next ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <MultiSiteComponent { ...props } />;
+	context.primary = makeElement( MultiSiteComponent, Head, context.store, props );
 	next();
 }
 
 export function loggedOut( context, next ) {
+	const Head = require( 'my-sites/themes/head' );
 	const props = getProps( context );
 
-	context.primary = <LoggedOutComponent { ...props } />;
+	context.primary = makeElement( LoggedOutComponent, Head, context.store, props );
 	next();
 }

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -1,0 +1,54 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Head from 'layout/head';
+
+const ThemesHead = ( { title, description, canonicalUrl, type, image, tier, children } ) => (
+	<Head
+		title={ title ? title : get( 'title', tier ) }
+		description={ description ? description : get( 'description', tier ) }
+		canonicalUrl={ canonicalUrl ? canonicalUrl : get( 'canonicalUrl', tier ) }
+		type={ type ? type : 'website' }
+		siteName={ 'WordPress.com' }
+		image={ image ? image : {} } >
+		{ children }
+	</Head>
+);
+
+ThemesHead.propTypes = {
+	title: React.PropTypes.string,
+	tier: React.PropTypes.string
+};
+
+const themesMeta = {
+	all: {
+		title: 'WordPress Themes — WordPress.com',
+		description: 'Beautiful, responsive, free and premium WordPress themes for your photography site, portfolio, magazine, business website, or blog.',
+		canonicalUrl: 'https://wordpress.com/design',
+	},
+	free: {
+		title: 'Free WordPress Themes — WordPress.com',
+		description: 'Discover Free WordPress Themes on the WordPress.com Theme Showcase.',
+		canonicalUrl: 'https://wordpress.com/design/free',
+	},
+	premium: {
+		title: 'Premium WordPress Themes — WordPress.com',
+		description: 'Discover Premium WordPress Themes on the WordPress.com Theme Showcase.',
+		canonicalUrl: 'https://wordpress.com/design/premium',
+	}
+};
+
+function get( key, tier ) {
+	return tier in themesMeta && key in themesMeta[ tier ]
+	? themesMeta[ tier ][ key ]
+	: '';
+}
+
+export default ThemesHead;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -15,26 +15,6 @@ import ThemesSelection from './themes-selection';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 import { addTracking } from './helpers';
-import DocumentHead from 'components/data/document-head';
-
-const themesMeta = {
-	'': {
-		title: 'WordPress Themes',
-		description: 'Beautiful, responsive, free and premium WordPress themes \
-			for your photography site, portfolio, magazine, business website, or blog.',
-		canonicalUrl: 'https://wordpress.com/design',
-	},
-	free: {
-		title: 'Free WordPress Themes',
-		description: 'Discover Free WordPress Themes on the WordPress.com Theme Showcase.',
-		canonicalUrl: 'https://wordpress.com/design/free',
-	},
-	premium: {
-		title: 'Premium WordPress Themes',
-		description: 'Discover Premium WordPress Themes on the WordPress.com Theme Showcase.',
-		canonicalUrl: 'https://wordpress.com/design/premium',
-	}
-};
 
 const optionShape = PropTypes.shape( {
 	label: PropTypes.string,
@@ -45,18 +25,16 @@ const optionShape = PropTypes.shape( {
 
 const ThemeShowcase = React.createClass( {
 	propTypes: {
-		tier: PropTypes.oneOf( [ '', 'free', 'premium' ] ),
 		// Connected props
 		options: PropTypes.objectOf( optionShape ),
 		defaultOption: optionShape,
 		secondaryOption: optionShape,
-		getScreenshotOption: PropTypes.func,
+		getScreenshotOption: PropTypes.func
 	},
 
 	getDefaultProps() {
 		return {
-			selectedSite: false,
-			tier: ''
+			selectedSite: false
 		};
 	},
 
@@ -104,7 +82,7 @@ const ThemeShowcase = React.createClass( {
 	},
 
 	render() {
-		const { options, getScreenshotOption, secondaryOption, tier } = this.props;
+		const { options, getScreenshotOption, secondaryOption } = this.props;
 		const primaryOption = this.getPrimaryOption();
 
 		// If a preview action is passed, use that. Otherwise, use our own.
@@ -112,16 +90,8 @@ const ThemeShowcase = React.createClass( {
 			options.preview.action = theme => this.togglePreview( theme );
 		}
 
-		const metas = [
-			{ name: 'description', property: 'og:description', content: themesMeta[ tier ].description },
-			{ property: 'og:url', content: themesMeta[ tier ].canonicalUrl },
-			{ property: 'og:type', content: 'website' }
-		];
-
-		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<Main className="themes">
-				<DocumentHead title={ themesMeta[ tier ].title } meta={ metas } />
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle } />
 				{ this.props.children }
 				{ this.state.showPreview &&

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -16,7 +16,7 @@ import {
 	setPageTitle,
 	trackPageLoad
 } from 'reader/controller-helper';
-import { getDocumentHeadTitle as getTitle } from 'state/document-head/selectors';
+import { getTitle } from 'state/document-head/selectors';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import FullPostDialog from './main';
 import ReaderFullPost from 'blocks/reader-full-post';

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -12,7 +12,7 @@ import classnames from 'classnames';
  */
 import DocumentHead from 'components/data/document-head';
 import Gridicon from 'components/gridicon';
-import { getDocumentHeadCappedUnreadCount } from 'state/document-head/selectors';
+import { getCappedUnreadCount } from 'state/document-head/selectors';
 
 const UpdateNotice = React.createClass( {
 	mixins: [ PureRenderMixin ],
@@ -51,6 +51,6 @@ const UpdateNotice = React.createClass( {
 
 export default connect(
 	state => ( {
-		cappedUnreadCount: getDocumentHeadCappedUnreadCount( state )
+		cappedUnreadCount: getCappedUnreadCount( state )
 	} )
 )( UpdateNotice );

--- a/client/state/document-head/actions.js
+++ b/client/state/document-head/actions.js
@@ -1,5 +1,3 @@
-/** @ssr-ready **/
-
 /**
  * Internal dependencies
  */
@@ -36,6 +34,20 @@ export function setDocumentHeadUnreadCount( count ) {
 		type: DOCUMENT_HEAD_UNREAD_COUNT_SET,
 		count
 	};
+}
+
+/**
+ * Returns an action object used in signalling that the document head
+ * description meta should be assigned to the specified value.
+ *
+ * @param  {String} description Document description
+ * @return {Object}             Action object
+ */
+export function setDocumentHeadDescription( description ) {
+	return addDocumentHeadMeta( {
+		name: 'description',
+		content: description
+	} );
 }
 
 /**

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -33,7 +33,7 @@ export function unreadCount( state = 0, action ) {
 	return state;
 }
 
-export function meta( state = [ { property: 'og:site_name', content: 'WordPress.com' } ], action ) {
+export function meta( state = [], action ) {
 	switch ( action.type ) {
 		case DOCUMENT_HEAD_META_ADD:
 			return [ ...state, action.meta ];

--- a/client/state/document-head/selectors.js
+++ b/client/state/document-head/selectors.js
@@ -1,5 +1,3 @@
-/** @ssr-ready **/
-
 /**
  * External dependencies
  */
@@ -21,7 +19,7 @@ const UNREAD_COUNT_CAP = 40;
  * @param  {Object}  state  Global state tree
  * @return {?String}        Document title
  */
-export function getDocumentHeadTitle( state ) {
+export function getTitle( state ) {
 	return state.documentHead.title;
 }
 
@@ -31,7 +29,7 @@ export function getDocumentHeadTitle( state ) {
  * @param  {Object}  state  Global state tree
  * @return {?String}        Unread count (string because it can be e.g. '40+')
  */
-export function getDocumentHeadUnreadCount( state ) {
+export function getUnreadCount( state ) {
 	return state.documentHead.unreadCount;
 }
 
@@ -43,8 +41,8 @@ export function getDocumentHeadUnreadCount( state ) {
  * @param  {Object}  state  Global state tree
  * @return {String}         Unread count (string because it can be e.g. '40+')
  */
-export function getDocumentHeadCappedUnreadCount( state ) {
-	const unreadCount = getDocumentHeadUnreadCount( state );
+export function getCappedUnreadCount( state ) {
+	const unreadCount = getUnreadCount( state );
 	if ( ! unreadCount ) {
 		return '';
 	}
@@ -61,16 +59,16 @@ export function getDocumentHeadCappedUnreadCount( state ) {
  * @param  {Object}  state  Global state tree
  * @return {String}         Formatted title
  */
-export function getDocumentHeadFormattedTitle( state ) {
+export function getFormattedTitle( state ) {
 	let title = '';
 
-	const unreadCount = getDocumentHeadCappedUnreadCount( state );
+	const unreadCount = getCappedUnreadCount( state );
 	if ( unreadCount ) {
 		title += `(${ unreadCount }) `;
 	}
 
 	title += compact( [
-		getDocumentHeadTitle( state ),
+		getTitle( state ),
 		isSiteSection( state ) && getSiteTitle( state, getSelectedSiteId( state ) )
 	] ).join( ' ‹ ' );
 
@@ -79,26 +77,4 @@ export function getDocumentHeadFormattedTitle( state ) {
 	}
 
 	return title + 'WordPress.com';
-}
-
-/**
- * Returns an array of document meta objects as set by the DocumentHead
- * component or addDocumentHeadMeta action.
- *
- * @param  {Object}  state  Global state tree
- * @return {Object[]}       Array of meta objects
- */
-export function getDocumentHeadMeta( state ) {
-	return state.documentHead.meta;
-}
-
-/**
- * Returns an array of document link objects as set by the DocumentHead
- * component or addDocumentHeadLink action.
- *
- * @param  {Object}  state  Global state tree
- * @return {Object[]}       Array of link objects
- */
-export function getDocumentHeadLink( state ) {
-	return state.documentHead.link;
 }

--- a/client/state/document-head/test/actions.js
+++ b/client/state/document-head/test/actions.js
@@ -15,6 +15,7 @@ import {
 
 import {
 	setDocumentHeadTitle,
+	setDocumentHeadDescription,
 	addDocumentHeadLink,
 	addDocumentHeadMeta,
 	setDocumentHeadUnreadCount
@@ -28,6 +29,20 @@ describe( 'actions', () => {
 			expect( action ).to.eql( {
 				type: DOCUMENT_HEAD_TITLE_SET,
 				title: 'Home'
+			} );
+		} );
+	} );
+
+	describe( '#setDocumentHeadDescription()', () => {
+		it( 'should return an action object', () => {
+			const action = setDocumentHeadDescription( 'Lorem ipsum dolor sit amet.' );
+
+			expect( action ).to.eql( {
+				type: DOCUMENT_HEAD_META_ADD,
+				meta: {
+					name: 'description',
+					content: 'Lorem ipsum dolor sit amet.'
+				}
 			} );
 		} );
 	} );

--- a/client/state/document-head/test/reducer.js
+++ b/client/state/document-head/test/reducer.js
@@ -51,10 +51,10 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#meta()', () => {
-		it( 'should default to "og:site_name" set to "WordPress.com" array', () => {
+		it( 'should default to an empty array', () => {
 			const state = meta( undefined, {} );
 
-			expect( state ).to.eql( [ { property: 'og:site_name', content: 'WordPress.com' } ] );
+			expect( state ).to.eql( [] );
 		} );
 
 		it( 'should add a new meta tag', () => {

--- a/client/state/document-head/test/selectors.js
+++ b/client/state/document-head/test/selectors.js
@@ -7,18 +7,16 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	getDocumentHeadTitle,
-	getDocumentHeadUnreadCount,
-	getDocumentHeadCappedUnreadCount,
-	getDocumentHeadFormattedTitle,
-	getDocumentHeadMeta,
-	getDocumentHeadLink
+	getTitle,
+	getUnreadCount,
+	getCappedUnreadCount,
+	getFormattedTitle
 } from '../selectors';
 
 describe( 'selectors', () => {
-	describe( '#getDocumentHeadTitle()', () => {
+	describe( '#getTitle()', () => {
 		it( 'should return the currently set title', () => {
-			const title = getDocumentHeadTitle( {
+			const title = getTitle( {
 				documentHead: {
 					title: 'My Section Title'
 				}
@@ -28,9 +26,9 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getDocumentHeadUnreadCount()', () => {
+	describe( '#getUnreadCount()', () => {
 		it( 'should return the unread posts counter', () => {
-			const unreadCount = getDocumentHeadUnreadCount( {
+			const unreadCount = getUnreadCount( {
 				documentHead: {
 					unreadCount: 3
 				}
@@ -40,9 +38,9 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getDocumentHeadCappedUnreadCount()', () => {
+	describe( '#getCappedUnreadCount()', () => {
 		it( 'should return the capped unread posts counter', () => {
-			const unreadCount = getDocumentHeadCappedUnreadCount( {
+			const unreadCount = getCappedUnreadCount( {
 				documentHead: {
 					unreadCount: 45
 				}
@@ -52,10 +50,10 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getDocumentHeadFormattedTitle()', () => {
+	describe( '#getFormattedTitle()', () => {
 		describe( 'for site-agnostic section', () => {
 			it( 'should return only "WordPress.com" if no title is set', () => {
-				const formattedTitle = getDocumentHeadFormattedTitle( {
+				const formattedTitle = getFormattedTitle( {
 					documentHead: {},
 					sites: {
 						items: {
@@ -78,7 +76,7 @@ describe( 'selectors', () => {
 			} );
 
 			it( 'should return formatted title made up of section but not site name', () => {
-				const formattedTitle = getDocumentHeadFormattedTitle( {
+				const formattedTitle = getFormattedTitle( {
 					documentHead: {
 						title: 'Reader',
 					},
@@ -103,7 +101,7 @@ describe( 'selectors', () => {
 			} );
 
 			it( 'should return formatted title made up of section and unread count but not site name', () => {
-				const formattedTitle = getDocumentHeadFormattedTitle( {
+				const formattedTitle = getFormattedTitle( {
 					documentHead: {
 						title: 'Reader',
 						unreadCount: '12'
@@ -131,7 +129,7 @@ describe( 'selectors', () => {
 
 		describe( 'for site-specific section', () => {
 			it( 'should return only "WordPress.com", if no title is set and no site is selected', () => {
-				const formattedTitle = getDocumentHeadFormattedTitle( {
+				const formattedTitle = getFormattedTitle( {
 					documentHead: {},
 					sites: {
 						items: {
@@ -154,7 +152,7 @@ describe( 'selectors', () => {
 			} );
 
 			it( 'should return formatted title made up of section only, for no selected site', () => {
-				const formattedTitle = getDocumentHeadFormattedTitle( {
+				const formattedTitle = getFormattedTitle( {
 					documentHead: {
 						title: 'Themes',
 					},
@@ -179,7 +177,7 @@ describe( 'selectors', () => {
 			} );
 
 			it( 'should return formatted title made up of site only, for unset title', () => {
-				const formattedTitle = getDocumentHeadFormattedTitle( {
+				const formattedTitle = getFormattedTitle( {
 					documentHead: {
 					},
 					sites: {
@@ -203,7 +201,7 @@ describe( 'selectors', () => {
 			} );
 
 			it( 'should return formatted title made up of section and site name', () => {
-				const formattedTitle = getDocumentHeadFormattedTitle( {
+				const formattedTitle = getFormattedTitle( {
 					documentHead: {
 						title: 'Themes',
 					},
@@ -226,40 +224,6 @@ describe( 'selectors', () => {
 
 				expect( formattedTitle ).to.equal( 'Themes ‹ WordPress.com Example Blog — WordPress.com' );
 			} );
-		} );
-	} );
-
-	describe( '#getDocumentHeadMeta()', () => {
-		it( 'should return the currently set metas', () => {
-			const meta = getDocumentHeadMeta( {
-				documentHead: {
-					meta: [
-						{ property: 'og:site_name', content: 'WordPress.com' },
-						{ property: 'og:type', content: 'website' }
-					]
-				}
-			} );
-
-			expect( meta ).to.eql( [
-				{ property: 'og:site_name', content: 'WordPress.com' },
-				{ property: 'og:type', content: 'website' }
-			] );
-		} );
-	} );
-
-	describe( '#getDocumentHeadLink()', () => {
-		it( 'should return the currently set links', () => {
-			const link = getDocumentHeadLink( {
-				documentHead: {
-					link: [
-						{ rel: 'canonical', href: 'https://wordpress.com' }
-					]
-				}
-			} );
-
-			expect( link ).to.eql( [
-				{ rel: 'canonical', href: 'https://wordpress.com' }
-			] );
 		} );
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2023,8 +2023,20 @@
     "lodash-deep": {
       "version": "1.5.3"
     },
+    "lodash._getnative": {
+      "version": "3.9.1"
+    },
     "lodash.assign": {
       "version": "4.2.0"
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0"
+    },
+    "lodash.isarray": {
+      "version": "3.0.4"
+    },
+    "lodash.keys": {
+      "version": "3.1.2"
     },
     "lodash.pickby": {
       "version": "4.6.0"
@@ -2676,6 +2688,17 @@
     "react-element-to-jsx-string": {
       "version": "3.2.0"
     },
+    "react-helmet": {
+      "version": "2.2.0",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.6"
+        },
+        "invariant": {
+          "version": "2.1.2"
+        }
+      }
+    },
     "react-hot-api": {
       "version": "0.4.7"
     },
@@ -2698,6 +2721,20 @@
     },
     "react-redux": {
       "version": "4.4.5"
+    },
+    "react-side-effect": {
+      "version": "1.0.2",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7"
+        },
+        "fbjs": {
+          "version": "0.1.0-alpha.10"
+        },
+        "whatwg-fetch": {
+          "version": "0.9.0"
+        }
+      }
     },
     "react-tap-event-plugin": {
       "version": "1.0.0",
@@ -3010,6 +3047,9 @@
     },
     "sha.js": {
       "version": "2.2.6"
+    },
+    "shallowequal": {
+      "version": "0.2.2"
     },
     "shebang-regex": {
       "version": "1.0.0"
@@ -3506,6 +3546,9 @@
     },
     "walk": {
       "version": "2.3.4"
+    },
+    "warning": {
+      "version": "2.1.0"
     },
     "watchpack": {
       "version": "0.2.9"

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "react-click-outside": "2.1.0",
     "react-day-picker": "2.4.1",
     "react-dom": "15.3.0",
+    "react-helmet": "2.2.0",
     "react-masonry-component": "4.0.4",
     "react-pure-render": "1.0.2",
     "react-redux": "4.4.5",

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { serverRender } from 'render';
+import { createReduxStore } from 'state';
 import { setSection as setSectionMiddlewareFactory } from '../../client/controller';
 
 export function serverRouter( expressApp, setUpRoute, section ) {
@@ -35,7 +36,8 @@ function getEnhancedContext( req ) {
 		path: req.url,
 		pathname: req.path,
 		params: req.params,
-		query: req.query
+		query: req.query,
+		store: createReduxStore()
 	} );
 }
 

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -11,8 +11,10 @@ doctype html
 
 html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width' : '')
 	head
-		title
-			!= head.title
+		if helmetTitle
+			!= helmetTitle
+		else
+			title WordPress.com
 		meta(charset='utf-8')
 		meta(http-equiv='X-UA-Compatible' content='IE=Edge')
 		meta(name='viewport', content='width=device-width, initial-scale=1, maximum-scale=1')
@@ -21,11 +23,11 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		meta(name='apple-mobile-web-app-capable', content='yes')
 		meta(name='referrer', content='origin')
 
-		each meta in head.metas
-			meta(name=meta.name, property=meta.property, content=meta.content)
+		if helmetMeta
+			!= helmetMeta
 
-		each link in head.links
-			link(rel=link.rel, href=link.href)
+		if helmetLink
+			!= helmetLink
 
 		link(rel='shortcut icon', type='image/vnd.microsoft.icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -1,26 +1,17 @@
-/**
- * External dependencies
- */
-import express from 'express';
-import fs from 'fs';
-import crypto from 'crypto';
-import qs from 'qs';
-import { execSync } from 'child_process';
-import cookieParser from 'cookie-parser';
-import debugFactory from 'debug';
+var express = require( 'express' ),
+	fs = require( 'fs' ),
+	crypto = require( 'crypto' ),
+	qs = require( 'qs' ),
+	execSync = require( 'child_process' ).execSync,
+	cookieParser = require( 'cookie-parser' ),
+	debug = require( 'debug' )( 'calypso:pages' );
 
-/**
- * Internal dependencies
- */
-import config from 'config';
-import sanitize from 'sanitize';
-import utils from 'bundler/utils';
-import sectionsModule from '../../client/sections';
-import { serverRouter } from 'isomorphic-routing';
-import { serverRender } from 'render';
-import { createReduxStore } from 'state';
-
-const debug = debugFactory( 'calypso:pages' );
+var config = require( 'config' ),
+	sanitize = require( 'sanitize' ),
+	utils = require( 'bundler/utils' ),
+	sectionsModule = require( '../../client/sections' ),
+	serverRouter = require( 'isomorphic-routing' ).serverRouter,
+	serverRender = require( 'render' ).serverRender;
 
 var HASH_LENGTH = 10,
 	URL_BASE_PATH = '/calypso',
@@ -128,8 +119,7 @@ function getDefaultContext( request ) {
 		faviconURL: '//s1.wp.com/i/favicon.ico',
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
-		devDocsURL: '/devdocs',
-		store: createReduxStore()
+		devDocsURL: '/devdocs'
 	} );
 
 	context.app = {

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import ReactDomServer from 'react-dom/server';
+import Helmet from 'react-helmet';
 import superagent from 'superagent';
 import Lru from 'lru-cache';
 import pick from 'lodash/pick';
@@ -11,12 +12,6 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import config from 'config';
-import { isSectionIsomorphic } from 'state/ui/selectors';
-import {
-	getDocumentHeadFormattedTitle,
-	getDocumentHeadMeta,
-	getDocumentHeadLink
-} from 'client/state/document-head/selectors';
 
 const debug = debugFactory( 'calypso:server-render' );
 const markupCache = new Lru( { max: 3000 } );
@@ -49,6 +44,14 @@ export function render( element, key = JSON.stringify( element ) ) {
 			const renderedLayout = ReactDomServer.renderToString( element );
 			context = { renderedLayout };
 
+			if ( Helmet.peek() ) {
+				const helmetData = Helmet.rewind();
+				Object.assign( context, {
+					helmetTitle: helmetData.title,
+					helmetMeta: helmetData.meta,
+					helmetLink: helmetData.link,
+				} );
+			}
 			markupCache.set( key, context );
 		}
 		const rtsTimeMs = Date.now() - startTime;
@@ -70,31 +73,19 @@ export function render( element, key = JSON.stringify( element ) ) {
 
 export function serverRender( req, res ) {
 	const context = req.context;
-	let title, metas = [], links = [];
 
 	if ( context.lang !== config( 'i18n_default_locale_slug' ) ) {
 		context.i18nLocaleScript = '//widgets.wp.com/languages/calypso/' + context.lang + '.js';
 	}
 
-	if ( config.isEnabled( 'server-side-rendering' ) && context.layout && ! context.user ) {
+	if ( config.isEnabled( 'server-side-rendering' ) &&
+		context.store &&
+		context.layout &&
+		! context.user ) {
+		context.initialReduxState = pick( context.store.getState(), 'ui', 'themes' );
 		const key = context.renderCacheKey || JSON.stringify( context.layout );
 		Object.assign( context, render( context.layout, key ) );
 	}
-
-	if ( context.store ) {
-		title = getDocumentHeadFormattedTitle( context.store.getState() );
-		metas = getDocumentHeadMeta( context.store.getState() );
-		links = getDocumentHeadLink( context.store.getState() );
-
-		let reduxSubtrees = [ 'documentHead' ];
-		if ( isSectionIsomorphic( context.store.getState() ) ) {
-			reduxSubtrees = reduxSubtrees.concat( [ 'ui', 'themes' ] );
-		}
-
-		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
-	}
-
-	context.head = { title, metas, links };
 
 	if ( config.isEnabled( 'desktop' ) ) {
 		res.render( 'desktop.jade', context );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#7600

Rationale -- possible cause for https://github.com/Automattic/wp-calypso/issues/8419

cc @cainm