### PR TITLE
Editor: fix undefined error in private publish dialog.

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -92,7 +92,7 @@ export default React.createClass( {
 	closePopover( event ) {
 		var stateChanges = {};
 
-		if ( this.showingAcceptDialog ) {
+		if ( this.showingAcceptDialog && event ) {
 			event.preventDefault();
 			return;
 		}


### PR DESCRIPTION
Stumbled upon this issue while testing out #8342.

__To Reproduce Issue__
- Open up a new draft in the editor
- Add a title and some content
- Click the visibility "eye", select "Private"
- When the dialog to privately publish opens, click anywhere ( either action buttons or outside of the dialog ) and the exception is thrown

Test out this branch by performing the same steps above.