### PR TITLE
Plans: update domain to plan nudge to link to checkout

### DIFF
--- a/client/blocks/domain-to-plan-nudge/docs/example.jsx
+++ b/client/blocks/domain-to-plan-nudge/docs/example.jsx
@@ -15,10 +15,6 @@ import QuerySites from 'components/data/query-sites';
 function DomainToPlanNudgeExample( { siteId } ) {
 	return (
 		<div className="docs__design-assets-group">
-			<h2>
-				<a href="/devdocs/blocks/domain-to-plan-nudge">Domain To Plan Nudge</a>
-			</h2>
-			<p> Warning! Clicking on "Upgrade Now" will charge your stored credit card </p>
 			<QuerySites siteId={ siteId } />
 			<DomainToPlanNudge siteId={ siteId } />
 		</div>

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-import debugFactory from 'debug';
 import React, { PropTypes, Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 import page from 'page';
 
 /**
@@ -17,16 +15,10 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isCurrentSitePlan } from 'state/sites/selectors';
 import { plansList, PLAN_FREE, PLAN_PERSONAL } from 'lib/plans/constants';
-import { storedCardPayment } from 'lib/store-transactions';
-import { emptyCart } from 'lib/cart-values';
-import { add as addCartItem } from 'lib/cart-values/cart-items';
-import { submitTransaction } from 'lib/upgrades/actions/checkout';
 import PlanPrice from 'my-sites/plan-price';
 import PlanIcon from 'components/plans/plan-icon';
 import Gridicon from 'components/gridicon';
-import { errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { recordOrder } from 'lib/analytics/ad-tracking';
 import {
 	getSitePlanRawPrice,
 	getPlanDiscountedRawPrice,
@@ -37,31 +29,21 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import formatCurrency from 'lib/format-currency';
 import { canCurrentUser } from 'state/current-user/selectors';
 
-const debug = debugFactory( 'calypso:domain-to-plan-nudge' );
-
 class DomainToPlanNudge extends Component {
 
 	constructor() {
 		super( ...arguments );
-		this.oneClickUpgrade = this.oneClickUpgrade.bind( this );
-		this.handleTransactionComplete = this.handleTransactionComplete.bind( this );
-		this.state = {
-			isSubmitting: false,
-			noticeId: null
-		};
+		this.personalCheckout = this.personalCheckout.bind( this );
 	}
 
 	static propTypes = {
 		discountedRawPrice: PropTypes.number,
-		errorNotice: PropTypes.func,
 		hasFreePlan: PropTypes.bool,
-		infoNotice: PropTypes.func,
 		productId: PropTypes.number,
 		productSlug: PropTypes.string,
 		rawDiscount: PropTypes.number,
 		rawPrice: PropTypes.number,
 		recordTracksEvent: PropTypes.func,
-		removeNotice: PropTypes.func,
 		site: PropTypes.object,
 		siteId: PropTypes.number,
 		sitePlans: PropTypes.object,
@@ -86,103 +68,24 @@ class DomainToPlanNudge extends Component {
 			hasFreePlan;      //has a free wpcom plan
 	}
 
-	getCartItem() {
-		const {
-			productSlug,
-			productId
-		} = this.props;
+	personalCheckout() {
+		const { siteId } = this.props;
 
-		return {
-			product_id: productId,
-			product_slug: productSlug,
-			free_trial: false,
-			is_domain_registration: false
-		};
-	}
-
-	handleTransactionComplete( error, data ) {
-		const { siteId, translate, userCurrency, rawPrice, discountedRawPrice } = this.props;
-
-		const price = discountedRawPrice || rawPrice;
-
-		debug( 'transaction complete', error, data );
-		// see transaction-steps-mixin for matching checkout analytics
-		if ( error ) {
-			if ( this.state.noticeId ) {
-				this.props.removeNotice( this.state.noticeId );
-			}
-			const noticeAction = this.props.errorNotice(
-				translate( 'There was a problem completing the purchase. Please try again.' )
-			);
-			this.setState( {
-				isSubmitting: false,
-				noticeId: get( noticeAction, 'notice.noticeId' )
-			} );
-			this.props.recordTracksEvent(
-				'calypso_checkout_payment_error',
-				{ reason: error.message }
-			);
-			return;
-		}
-
-		const receiptId = data.receipt_id;
-
-		// ad tracking
-		const product = { ...this.getCartItem(), currency: userCurrency, cost: price, volume: 1 };
-		const cart = { products: [ product ], total_cost: price, currency: userCurrency };
-		recordOrder( cart, receiptId );
-
-		// tracks
-		this.props.recordTracksEvent( 'calypso_checkout_payment_success', {
-			coupon_code: '',
-			currency: userCurrency,
-			payment_method: storedCardPayment().paymentMethod,
-			total_cost: price
+		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
+			cta_name: 'domain_to_personal_nudge',
+			cta_feature: 'no-adverts',
+			cta_size: 'banner'
 		} );
 
-		this.props.recordTracksEvent( 'calypso_checkout_product_purchase', this.getCartItem() );
-
-		// redirect to thank you
-		page( `/checkout/thank-you/${ siteId }/${ receiptId }` );
-	}
-
-	oneClickUpgrade() {
-		const { siteId, storedCard, translate } = this.props;
-		const newPayment = storedCardPayment( storedCard );
-		const transaction = {
-			payment: newPayment
-		};
-
-		// set this to temporary so we don't clear the existing user cart on the server
-		let cart = emptyCart( siteId, { temporary: true } );
-
-		const personalCartItem = this.getCartItem();
-		cart = addCartItem( personalCartItem )( cart );
-
-		debug( 'purchasing with', cart, transaction );
-
-		if ( this.state.noticeId ) {
-			this.props.removeNotice( this.state.noticeId );
-		}
-		const noticeAction = this.props.infoNotice( translate( 'Submitting payment' ) );
-		this.setState( {
-			isSubmitting: true,
-			noticeId: get( noticeAction, 'notice.noticeId' )
-		} );
-
-		submitTransaction( { cart, transaction }, this.handleTransactionComplete );
+		page( `/checkout/${ siteId }/personal` );
 	}
 
 	renderCard() {
-		const { isSubmitting } = this.state;
-
 		const {
 			discountedRawPrice,
 			productSlug,
 			rawDiscount,
 			rawPrice,
-			siteId,
-			storedCard,
 			translate,
 			userCurrency
 		} = this.props;
@@ -229,16 +132,6 @@ class DomainToPlanNudge extends Component {
 										icon="checkmark"
 										size={ 24 }
 									/>
-									{ translate( 'Upload up to 3GB of photos and documents' ) }
-								</div>
-							</li>
-							<li>
-								<div className="domain-to-plan-nudge__header-features-item">
-									<Gridicon
-										className="domain-to-plan-nudge__header-features-item-checkmark"
-										icon="checkmark"
-										size={ 24 }
-									/>
 									{ translate( 'Bundled with your domain for the best value!' ) }
 								</div>
 							</li>
@@ -274,28 +167,15 @@ class DomainToPlanNudge extends Component {
 					</div>
 					<div className="domain-to-plan-nudge__upgrade-group">
 						<Button
-							onClick={ this.oneClickUpgrade }
-							disabled={ ! storedCard || isSubmitting }
+							onClick={ this.personalCheckout }
 							primary
 						>
-							{ isSubmitting
-								? translate( 'Completing your purchase' )
-								: translate( 'Upgrade Now for %s', {
+							{
+								translate( 'Upgrade Now for %s', {
 									args: formatCurrency( discountedRawPrice || rawPrice, userCurrency )
 								} )
 							}
 						</Button>
-						<div className="domain-to-plan-nudge__credit-card-info">
-							<a
-								className="domain-to-plan-nudge__credit-card-info-link"
-								href={ `/checkout/${ siteId }/personal` }>
-								{
-									translate( 'Using credit card ****%s', {
-										args: storedCard ? storedCard.card : 'xxxx'
-									} )
-								}
-							</a>
-						</div>
 					</div>
 				</div>
 			</DismissibleCard>
@@ -339,9 +219,6 @@ export default connect(
 		};
 	},
 	{
-		infoNotice,
-		errorNotice,
-		recordTracksEvent,
-		removeNotice
+		recordTracksEvent
 	}
 )( localize( DomainToPlanNudge ) );

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -28,6 +28,7 @@ import {
 import QuerySitePlans from 'components/data/query-site-plans';
 import formatCurrency from 'lib/format-currency';
 import { canCurrentUser } from 'state/current-user/selectors';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 class DomainToPlanNudge extends Component {
 
@@ -96,6 +97,13 @@ class DomainToPlanNudge extends Component {
 				preferenceName="domain-to-plan-nudge"
 				temporary
 			>
+			<TrackComponentView
+				eventName={ 'calypso_upgrade_nudge_impression' }
+				eventProperties={ {
+					cta_name: 'domain_to_personal_nudge',
+					cta_feature: 'no-adverts',
+					cta_size: 'banner'
+				} } />
 				<div className="domain-to-plan-nudge__header">
 					<div className="domain-to-plan-nudge__header-icon">
 						<PlanIcon plan={ productSlug } />

--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -18,8 +18,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isCurrentSitePlan } from 'state/sites/selectors';
 import { plansList, PLAN_FREE, PLAN_PERSONAL } from 'lib/plans/constants';
 import { storedCardPayment } from 'lib/store-transactions';
-import { getStoredCards } from 'state/stored-cards/selectors';
-import QueryStoredCards from 'components/data/query-stored-cards';
 import { emptyCart } from 'lib/cart-values';
 import { add as addCartItem } from 'lib/cart-values/cart-items';
 import { submitTransaction } from 'lib/upgrades/actions/checkout';
@@ -67,7 +65,6 @@ class DomainToPlanNudge extends Component {
 		site: PropTypes.object,
 		siteId: PropTypes.number,
 		sitePlans: PropTypes.object,
-		storedCard: PropTypes.object,
 		translate: PropTypes.func,
 		userCurrency: PropTypes.string
 	};
@@ -79,11 +76,9 @@ class DomainToPlanNudge extends Component {
 			rawPrice,
 			site,
 			sitePlans,
-			storedCard
 		} = this.props;
 
 		return sitePlans.hasLoadedFromServer &&
-			storedCard &&     //has a payment option
 			canManage &&      //can manage site
 			rawPrice &&       //plans info has loaded
 			site &&           //site exists
@@ -312,7 +307,6 @@ class DomainToPlanNudge extends Component {
 
 		return (
 			<div className="domain-to-plan-nudge">
-				<QueryStoredCards />
 				<QuerySitePlans siteId={ siteId } />
 				{ this.isSiteEligible() && this.renderCard() }
 			</div>
@@ -341,7 +335,6 @@ export default connect(
 			site: getSite( state, siteId ),
 			siteId,
 			sitePlans: getPlansBySiteId( state, siteId ),
-			storedCard: get( getStoredCards( state ), '0' ),
 			userCurrency: getCurrentUserCurrencyCode( state ) //populated by either plans endpoint
 		};
 	},

--- a/client/blocks/domain-to-plan-nudge/style.scss
+++ b/client/blocks/domain-to-plan-nudge/style.scss
@@ -62,15 +62,10 @@
 	}
 }
 
-.domain-to-plan-nudge__plan-price-timeframe,
-.domain-to-plan-nudge__credit-card-info {
+.domain-to-plan-nudge__plan-price-timeframe {
 	font-size: 12px;
 	color: $gray;
 	white-space: nowrap;
-}
-.domain-to-plan-nudge__credit-card-info-link,
-.domain-to-plan-nudge__credit-card-info-link:visited {
-	color: $gray;
 }
 
 .domain-to-plan-nudge__discount-value {
@@ -103,14 +98,5 @@
 	@include breakpoint( "<960px" ) {
 		text-align: center;
 		margin-top: 30px;
-	}
-}
-
-.domain-to-plan-nudge__credit-card-info {
-	margin-top: 2px;
-	text-align: center;
-
-	@include breakpoint( ">960px" ) {
-		text-align: right;
 	}
 }

--- a/client/lib/analytics/track-component-view/index.jsx
+++ b/client/lib/analytics/track-component-view/index.jsx
@@ -1,38 +1,41 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { recordTracksEvent } from 'state/analytics/actions';
 
-export default React.createClass( {
-
-	displayName: 'TrackComponentView',
-
-	propTypes: {
+class TrackComponentView extends Component {
+	static propTypes = {
 		eventName: PropTypes.string,
-		eventProperties: PropTypes.object
-	},
+		eventProperties: PropTypes.object,
+		recordTracksEvent: PropTypes.func
+	};
 
-	getDefaultProps() {
-		return {
-			eventName: null,
-			eventProperties: {}
-		}
-	},
+	static defaultProps = {
+		eventName: null,
+		eventProperties: {},
+		recordTracksEvent: () => {}
+	};
 
 	componentWillMount() {
 		if ( this.props.eventName ) {
-			analytics.tracks.recordEvent( this.props.eventName, this.props.eventProperties );
+			this.props.recordTracksEvent( this.props.eventName, this.props.eventProperties );
 		}
-	},
+	}
 
 	render() {
 		return null;
 	}
 
-} );
+}
+
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( TrackComponentView );
 


### PR DESCRIPTION
<img width="754" alt="screen shot 2016-10-03 at 5 04 20 pm" src="https://cloud.githubusercontent.com/assets/1270189/19058353/744bb074-898b-11e6-8322-6a6d4bf8f4de.png">

As part of feedback this PR:
- Removes the bullet point about storage space
- Changes the surprising one-click upgrade to instead direct you to checkout with a personal plan in cart
- This PR also tidies up TrackComponentView to use a redux action for easier component testing

## Testing Instructions
- Navigate to http://calypso.localhost:3000/devdocs/blocks/domain-to-plan-nudge
- Set debug to `localStorage.debug = 'calypso:analytics'`
- This is visible with a site on a free plan that has a paid domain
- We should see a event like the following when it's rendered:
<img width="1318" alt="screen shot 2016-10-03 at 4 56 38 pm" src="https://cloud.githubusercontent.com/assets/1270189/19058223/6e21e778-898a-11e6-8d56-54a587ee01a0.png">
- Click on the "Upgrade Now" button and we should the following analytics fire:
<img width="982" alt="screen shot 2016-10-03 at 5 01 13 pm" src="https://cloud.githubusercontent.com/assets/1270189/19058341/4edd6d96-898b-11e6-9bb4-65a1ad3931b1.png">
- We should be redirected to checkout, with a Personal Plan in cart

cc @lamosty @obenland @artpi @retrofox @rralian 