### PR TITLE
Reader: Fix no comments missing white space

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -2,7 +2,7 @@
 .comments__comment-list {
 	border-top: 1px solid lighten( $gray, 20% );
 	clear: both;
-	margin: 36px 0 40px;
+	margin: 36px 0 0;
 	padding-top: 11px;
 }
 

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -206,7 +206,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2__blocks {
 	border-top: 1px solid lighten( $gray, 20% );
-	margin-top: 12px;
 	padding-top: 11px;
 
 	.reader-related-card-v2__post {
@@ -252,6 +251,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	&.is-other-site {
+		margin-top: 40px;
 
 		.reader-related-card-v2__post {
 			max-height: 205px;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8428

**No comments (Before):**
![screenshot 2016-10-03 17 33 52](https://cloud.githubusercontent.com/assets/4924246/19058838/9050e7fe-898f-11e6-9582-2ec89f9d6051.png)

**No comments (After):**
![screenshot 2016-10-03 17 34 20](https://cloud.githubusercontent.com/assets/4924246/19058847/a0512c18-898f-11e6-8cd7-6c98298cc062.png)

Example: https://wordpress.com/read/feeds/22973954/posts/1172524384

@fraying It's a tiny bit more than `40px` for those without comments which results from the existing `line-height` set for the text.

Space still exists for posts with comments:

![screenshot 2016-10-03 17 35 14](https://cloud.githubusercontent.com/assets/4924246/19058861/c0f84d2a-898f-11e6-8faf-237ed0e78c5f.png)

Example: https://wordpress.com/read/feeds/23059853/posts/1065907171
