### PR TITLE
Settings: Add site setting for HelloVote voter registration form

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -53,6 +53,7 @@ const FormGeneral = React.createClass( {
 			settings.timezone_string = site.settings.timezone_string;
 			settings.jetpack_relatedposts_allowed = site.settings.jetpack_relatedposts_allowed;
 			settings.jetpack_sync_non_public_post_stati = site.settings.jetpack_sync_non_public_post_stati;
+			settings.hello_vote_enabled = site.settings.hello_vote_enabled;
 
 			if ( settings.jetpack_relatedposts_allowed ) {
 				settings.jetpack_relatedposts_enabled = ( site.settings.jetpack_relatedposts_enabled ) ? 1 : 0;
@@ -103,7 +104,8 @@ const FormGeneral = React.createClass( {
 			jetpack_relatedposts_show_headline: false,
 			jetpack_relatedposts_show_thumbnails: false,
 			jetpack_sync_non_public_post_stati: false,
-			holidaysnow: false
+			holidaysnow: false,
+			hello_vote_enabled: false,
 		} );
 	},
 
@@ -442,6 +444,42 @@ const FormGeneral = React.createClass( {
 		);
 	},
 
+	helloVoteOption() {
+		const site = this.props.site;
+
+		if ( site.jetpack ) {
+			return null;
+		}
+
+		return (
+			<FormFieldset>
+				<legend>{ this.translate( 'US Voter Registration Form' ) }</legend>
+				<ul>
+					<li>
+						<FormLabel>
+							<FormCheckbox
+								name="hello_vote_enabled"
+								checked={ this.state.hello_vote_enabled }
+								onChange={ this.onHelloVoteSettingChanged }
+							/>
+							<span>{ this.translate( 'Encourage your US-based users to register to vote by adding a subtle prompt to your site' ) }</span>
+						</FormLabel>
+					</li>
+				</ul>
+			</FormFieldset>
+		);
+	},
+
+	onHelloVoteSettingChanged( event ) {
+		const newValue = event.target.checked;
+		if ( newValue ) {
+			analytics.mc.bumpStat( 'hello-vote', 'calypso-option-enabled' );
+		} else {
+			analytics.mc.bumpStat( 'hello-vote', 'calypso-option-disabled' );
+		}
+		this.linkState( 'hello_vote_enabled' ).requestChange( newValue );
+	},
+
 	Timezone() {
 		if ( this.props.site.jetpack ) {
 			return;
@@ -511,6 +549,7 @@ const FormGeneral = React.createClass( {
 						{ this.languageOptions() }
 						{ this.Timezone() }
 						{ this.holidaySnowOption() }
+						{ this.helloVoteOption() }
 					</form>
 				</Card>
 


### PR DESCRIPTION
This adds a new setting that enables a voter registration form powered by [https://www.hello.vote/](HelloVote) on the site frontend, visible to US-based users (discussion: pb6Nl-bjq-p2).

Screenshot of the new setting:

![image](https://cloud.githubusercontent.com/assets/227022/19062466/63dd2bea-89c8-11e6-9cbe-3ef566efe97c.png)

Screenshot of the form once it is enabled:

![image](https://cloud.githubusercontent.com/assets/227022/19062477/7b5461f8-89c8-11e6-9aed-8deac5afeee8.png)

This uses a new `hello_vote_enabled` setting which has been added to the WP.com site settings endpoint.

### To test

1. Go to `/settings/general/$site`
2. Verify that toggling the option on or off controls whether the voter registration form is shown on the front-end of your site (currently it is only visible to logged-in Automattic users)
3. Verify that the option state persists on reloading the page

See also #8423 which adds a notice to prompt site admins to enable this feature.

### Questions

Is it possible to link directly to this new setting from the opt-in notice, and emphasize it somehow, possibly by flashing it yellow for a few seconds?