### PR TITLE
Editor: avoid to reset the undo/redo history when switching Editor Mode

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -416,9 +416,11 @@ module.exports = React.createClass( {
 		if ( this._editor ) {
 			const { mode } = this.props;
 			this._editor.setContent( wpautop( content ), { ...args, mode } );
-
-			// clear the undo stack to ensure that we don't have any leftovers
-			this._editor.undoManager.clear();
+			const resetHistory = args && args.initial;
+			if ( resetHistory ) {
+				// clear the undo stack to ensure that we don't have any leftovers
+				this._editor.undoManager.clear();
+			}
 		}
 
 		this.setTextAreaContent( content );

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -412,13 +412,12 @@ module.exports = React.createClass( {
 		}, this.doAutosizeUpdate );
 	},
 
-	setEditorContent: function( content, args ) {
+	setEditorContent: function( content, args = {} ) {
 		if ( this._editor ) {
 			const { mode } = this.props;
 			this._editor.setContent( wpautop( content ), { ...args, mode } );
-			const resetHistory = args && args.initial;
-			if ( resetHistory ) {
-				// clear the undo stack to ensure that we don't have any leftovers
+			if ( args.initial ) {
+				// Clear the undo stack when initially setting content
 				this._editor.undoManager.clear();
 			}
 		}


### PR DESCRIPTION
When we switch the editor mode, there's a call to `setEditorContent` that resets undoManager
This is useful when switching posts but not when switching editorMode.

closes #1811

cc @aduth  

**testing instructions**

 * start from https://wordpress.com/post
 * type something in editor
 * switch to html, type some text and go back to visual editor
 * ensure that the undo/redo is still working
 * type some text
 * switch to another draft
 * make sure there's no remaining undo/redo history
