### PR TITLE
Editor: Avoid the possibility to enter 24 on the hours input when scheduling a post

### DIFF
--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -68,7 +68,7 @@ class PostScheduleClock extends Component {
 			hour = checkTimeValue( this.refs.timeHourRef.value ),
 			minute = checkTimeValue( this.refs.timeMinuteRef.value );
 
-		if ( false !== hour && hour <= 24 ) {
+		if ( false !== hour && hour < 24 ) {
 			modifiers.hour = Number( hour );
 		}
 


### PR DESCRIPTION
We used to be able to enter 24 which switched the date to the next day.
In this PR, I just disable the possibility to set 24 on the hour's input. This is the same behaviour we have for numbers > 24.

closes #1775

**testing instructions**

 * start from https://wordpress.com/post
 * click on the "calendar icon" to schedule the post
 * select a desired day
 * type "24" on the hour's input
 * the day should not change, when we type 24

cc @aduth 