### PR TITLE
Signup: Updates Survey step to handle users coming from get.blog

### DIFF
--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -43,6 +43,30 @@ export default React.createClass( {
 		};
 	},
 
+	renderHeaderText() {
+		if ( ( this.props.flowName === 'get-dot-blog' ) || ( this.props.surveySiteType === 'blog' ) ) {
+			const { domain } = this.props.signupDependencies;
+
+			if ( domain ) {
+				return this.translate( 'Start blogging on %(domain)s today!', {
+					args: { domain }
+				} );
+			}
+
+			return this.translate( 'Create your blog today!' );
+		}
+
+		return this.translate( 'Create your site today!' );
+	},
+
+	renderSubHeaderText() {
+		if ( this.props.flowName === 'get-dot-blog' ) {
+			return this.translate( 'WordPress.com is the best place for your WordPress blog.' );
+		}
+
+		return this.translate( 'WordPress.com is the best place for your WordPress blog or website.' );
+	},
+
 	renderStepTwoVertical( vertical ) {
 		const stepTwoClickHandler = ( event ) => {
 			event.preventDefault();
@@ -76,8 +100,11 @@ export default React.createClass( {
 	},
 
 	renderOptionList() {
-		const blogLabel = this.translate( 'What is your blog about?' );
-		const siteLabel = this.translate( 'What is your website about?' );
+		let label = this.translate( 'What is your website about?' );
+
+		if ( ( this.props.flowName === 'get-dot-blog' ) || ( this.props.surveySiteType === 'blog' ) ) {
+			label = this.translate( 'What is your blog about?' );
+		}
 
 		let verticalsClasses = classNames(
 				'survey-step__verticals',
@@ -92,7 +119,7 @@ export default React.createClass( {
 				<div className="survey-step__verticals-wrapper">
 					<div className={ verticalsClasses }>
 						<CompactCard className="survey-step__question">
-							<label>{ this.props.surveySiteType === 'blog' ? blogLabel : siteLabel }</label>
+							<label>{ label }</label>
 						</CompactCard>
 						{ this.state.verticalList.map( this.renderStepOneVertical ) }
 					</div>
@@ -107,16 +134,14 @@ export default React.createClass( {
 	},
 
 	render() {
-		const blogHeaderText = this.translate( 'Create your blog today!' );
-		const siteHeaderText = this.translate( 'Create your site today!' );
 		return (
 			<div className="survey-step__section-wrapper">
 				<StepWrapper
 					flowName={ this.props.flowName }
 					stepName={ this.props.stepName }
 					positionInFlow={ this.props.positionInFlow }
-					headerText={ this.props.surveySiteType === 'blog' ? blogHeaderText : siteHeaderText }
-					subHeaderText={ this.translate( 'WordPress.com is the best place for your WordPress blog or website.' ) }
+					headerText={ this.renderHeaderText() }
+					subHeaderText={ this.renderSubHeaderText() }
 					signupProgressStore={ this.props.signupProgressStore }
 					stepContent={ this.renderOptionList() } />
 			</div>


### PR DESCRIPTION
This pull request updates the `Survey` step in the signup flow to handle users coming from get.blog by customizing its copy (according to p7G0UL-6J-p2/#comment-139).
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/19072813/9bf478a2-8a37-11e6-96cb-38b62fe7372b.png)

#### Testing instructions
 
1. Run `git checkout update/survey-step` and start your server, or open a [live branch](https://calypso.live/?branch=update/survey-step)
2. Open the [`Signup` page](http://calypso.localhost:3000/start/get-dot-blog?domain=example.blog) for get.blog
3. Check that the copy now focuses exclusively on _blogs_ (as opposed to _sites_)
4. Check that the domain name purchased on get.blog appears in the heading
 
#### Reviews
 
- [ ] Code
- [ ] Product
- [ ] Tests
 
@Automattic/sdev-feed