### PR TITLE
Editor: Keep the resize buttons enabled even if we have a custom size

### DIFF
--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -111,7 +111,7 @@ export default React.createClass( {
 				PostActions.blockSave( 'MEDIA_MODAL_TRANSIENT_INSERT' );
 			}
 
-			onInsertMedia( markup.get( selectedItems[ 0 ] ) );
+			onInsertMedia( markup.get( site, selectedItems[ 0 ] ) );
 			MediaActions.setLibrarySelectedItems( site.ID, [] );
 		} else {
 			// In all other cases, show the media modal list view

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -283,7 +283,7 @@ function mediaButton( editor ) {
 				}
 
 				// Use markup utility to generate replacement element
-				markup = MediaMarkup.get( merged, options );
+				markup = MediaMarkup.get( selectedSite, merged, options );
 
 				// If a media includes a caption shortcode, we can get the HTML markup of the shortcode with
 				// the following method.
@@ -540,7 +540,7 @@ function mediaButton( editor ) {
 		const size = findFn( SIZE_ORDER, isMatchingSize ) || SIZE_ORDER[ SIZE_ORDER.length - 1 ];
 
 		// Generate updated markup
-		const markup = MediaMarkup.get( media, assign( parsed.appearance, { size } ) );
+		const markup = MediaMarkup.get( selectedSite, media, assign( parsed.appearance, { size } ) );
 
 		// Replace selected content
 		editor.selection.setContent( markup );

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -515,16 +515,16 @@ function mediaButton( editor ) {
 
 		// Determine the next usable size
 		const sizeRatios = SIZE_ORDER
-			.map( size => MediaUtils.getThumbnailSizeDimensions( size, site ) )
-			.map( computeRatio );
+			.map( size => computeRatio( MediaUtils.getThumbnailSizeDimensions( size, site ) ) );
 		const sizeIndex = SIZE_ORDER.indexOf( parsed.appearance.size );
 		const displayedRatio = sizeIndex !== -1 ? sizeRatios[ sizeIndex ] : computeRatio( parsed.media );
 		const possibleSizes = SIZE_ORDER
-			.filter( ( size, index ) => sizeRatios[ index ] <= 1 )
 			.filter( ( size, index ) => {
-				return increment > 0
-					? sizeRatios[ index ] > displayedRatio
-					: sizeRatios[ index ] < displayedRatio;
+				return sizeRatios[ index ] <= 1 && (
+					increment > 0
+						? sizeRatios[ index ] > displayedRatio
+						: sizeRatios[ index ] < displayedRatio
+					);
 			} );
 		let size;
 		if ( possibleSizes.length ) {

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -15,7 +15,6 @@ import closest from 'component-closest';
  * Internal dependencies
  */
 import SiteListFactory from 'lib/sites-list';
-const sites = SiteListFactory();
 import PostActions from 'lib/posts/actions';
 import PostEditStore from 'lib/posts/post-edit-store';
 import MediaConstants from 'lib/media/constants';
@@ -23,7 +22,6 @@ import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
 import { deserialize } from 'lib/media-serialization';
 import MediaMarkup from 'post-editor/media-modal/markup';
-import { ModalViews } from 'post-editor/media-modal/constants';
 import MediaStore from 'lib/media/store';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import EditorMediaModal from 'post-editor/media-modal';
@@ -35,12 +33,14 @@ import Gridicon from 'components/gridicon';
 import config from 'config';
 import { getSelectedSite } from 'state/ui/selectors';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
+import { ModalViews } from 'state/ui/media-modal/constants';
 
 /**
  * Module variables
  */
 const REGEXP_IMG = /<img\s[^>]*\/?>/ig,
-	SIZE_ORDER = [ 'thumbnail', 'medium', 'large', 'full' ];
+	SIZE_ORDER = [ 'thumbnail', 'medium', 'large', 'full' ],
+	sites = SiteListFactory();
 
 let lastDirtyImage = null,
 	numOfImagesToUpdate = null;
@@ -52,22 +52,20 @@ function mediaButton( editor ) {
 		return;
 	}
 
-	const { getState, subscribe } = store;
+	const { getState } = store;
 
 	let nodes = {},
 		resizeEditor,
-		selectedSite = getSelectedSite( getState() ),
 		updateMedia;
 
-	subscribe( () => {
-		selectedSite = getSelectedSite( getState() );
-	} );
+	const getSelectedSiteFromState = () => getSelectedSite( getState() );
 
 	function insertMedia( markup ) {
 		editor.execCommand( 'mceInsertContent', false, markup );
 	}
 
 	function renderModal( props = {}, options = {} ) {
+		const selectedSite = getSelectedSiteFromState();
 		if ( ! selectedSite ) {
 			return;
 		}
@@ -152,7 +150,7 @@ function mediaButton( editor ) {
 		let isTransientDetected = false,
 			transients = 0,
 			content, images;
-
+		const selectedSite = getSelectedSiteFromState();
 		if ( ! selectedSite ) {
 			return;
 		}
@@ -269,7 +267,7 @@ function mediaButton( editor ) {
 						useMediaSize ? 'height' : ''
 					),
 					{
-						transient: !! media.transient
+						'transient': !! media.transient
 					}
 				);
 				const options = assign( {}, current.appearance, {
@@ -394,6 +392,7 @@ function mediaButton( editor ) {
 	}
 
 	editor.addCommand( 'wpcomAddMedia', () => {
+		const selectedSite = getSelectedSiteFromState();
 		if ( selectedSite ) {
 			MediaActions.clearValidationErrors( selectedSite.ID );
 		}
@@ -425,7 +424,8 @@ function mediaButton( editor ) {
 		stateSelector: '.wp-caption',
 		onclick: function() {
 			const node = editor.selection.getStart(),
-				parsed = deserialize( node );
+				parsed = deserialize( node ),
+				selectedSite = getSelectedSiteFromState();
 			let content;
 
 			if ( ! parsed || ! selectedSite ) {
@@ -491,9 +491,9 @@ function mediaButton( editor ) {
 	} );
 
 	function resize( increment ) {
-		const node = editor.selection.getStart();
-		const parsed = deserialize( node );
-
+		const node = editor.selection.getStart(),
+			parsed = deserialize( node ),
+			selectedSite = getSelectedSiteFromState();
 		if ( ! parsed || ! selectedSite ) {
 			return;
 		}
@@ -560,6 +560,7 @@ function mediaButton( editor ) {
 	}
 
 	function toggleSizingControls( increase, event ) {
+		const selectedSite = getSelectedSiteFromState();
 		if ( ! event.element || 'IMG' !== event.element.nodeName || ! selectedSite ) {
 			return;
 		}
@@ -617,6 +618,7 @@ function mediaButton( editor ) {
 	} );
 
 	editor.addCommand( 'wpcomEditGallery', function( content ) {
+		const selectedSite = getSelectedSiteFromState();
 		if ( ! selectedSite ) {
 			return;
 		}
@@ -675,6 +677,7 @@ function mediaButton( editor ) {
 	}
 
 	function fetchUnknownImages( event ) {
+		const selectedSite = getSelectedSiteFromState();
 		if ( ! selectedSite ) {
 			return;
 		}

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -21,6 +21,7 @@ import {
 	GalleryDefaultAttrs
 } from './constants';
 import Shortcode from 'lib/shortcode';
+import versionCompare from 'lib/version-compare';
 
 /**
  * Module variables
@@ -235,7 +236,7 @@ const MediaUtils = {
 	 * @return {Boolean}      Site allowed file types are accurate
 	 */
 	isSiteAllowedFileTypesToBeTrusted: function( site ) {
-		return ! site || ! site.jetpack || site.versionCompare( '3.8.1', '>=' );
+		return ! site || ! site.jetpack || versionCompare( site.options.jetpack_version, '3.8.1', '>=' );
 	},
 
 	/**

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -186,5 +186,9 @@ export default {
 		}
 
 		return site.domain !== site.wpcom_url;
+	},
+
+	isModuleActive( site, moduleId ) {
+		return site.modules && site.modules.indexOf( moduleId ) > -1;
 	}
 };

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -189,6 +189,6 @@ export default {
 	},
 
 	isModuleActive( site, moduleId ) {
-		return site.modules && site.modules.indexOf( moduleId ) > -1;
+		return site.options.active_modules && site.options.active_modules.indexOf( moduleId ) > -1;
 	}
 };

--- a/client/post-editor/editor-media-advanced/index.jsx
+++ b/client/post-editor/editor-media-advanced/index.jsx
@@ -26,7 +26,7 @@ class EditorMediaAdvanced extends Component {
 
 	save() {
 		const { media, appearance } = this.props.item;
-		const markup = MediaMarkup.get( this.props.site, Object.assign( {}, media, {
+		const markup = MediaMarkup.get( this.props.selectedSite, Object.assign( {}, media, {
 			alt: ReactDom.findDOMNode( this.refs.alt ).value
 		} ), appearance );
 

--- a/client/post-editor/editor-media-advanced/index.jsx
+++ b/client/post-editor/editor-media-advanced/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,6 +15,7 @@ import Dialog from 'components/dialog';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
+import { getSelectedSite } from 'state/ui/selectors';
 
 class EditorMediaAdvanced extends Component {
 	constructor() {
@@ -24,7 +26,7 @@ class EditorMediaAdvanced extends Component {
 
 	save() {
 		const { media, appearance } = this.props.item;
-		const markup = MediaMarkup.get( Object.assign( {}, media, {
+		const markup = MediaMarkup.get( this.props.site, Object.assign( {}, media, {
 			alt: ReactDom.findDOMNode( this.refs.alt ).value
 		} ), appearance );
 
@@ -70,4 +72,10 @@ EditorMediaAdvanced.defaultProps = {
 	insertMedia: () => {}
 };
 
-export default localize( EditorMediaAdvanced );
+export default connect(
+	state => {
+		return {
+			selectedSite: getSelectedSite( state )
+		};
+	}
+)( localize( EditorMediaAdvanced ) );

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -17,6 +17,7 @@ import SelectDropdown from 'components/select-dropdown';
 import SelectDropdownItem from 'components/select-dropdown/item';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'lib/media/constants';
+import { isModuleActive } from 'lib/site/utils';
 
 export const EditorMediaModalGalleryFields = React.createClass( {
 
@@ -43,7 +44,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 			'default': this.props.translate( 'Thumbnail Grid' )
 		};
 
-		if ( site && ( ! site.jetpack || site.isModuleActive( 'tiled-gallery' ) ) ) {
+		if ( site && ( ! site.jetpack || isModuleActive( site, 'tiled-gallery' ) ) ) {
 			assign( options, {
 				rectangular: this.props.translate( 'Tiled Mosaic' ),
 				square: this.props.translate( 'Square Tiles' ),
@@ -52,7 +53,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 			} );
 		}
 
-		if ( site && ( ! site.jetpack || site.isModuleActive( 'shortcodes' ) ) ) {
+		if ( site && ( ! site.jetpack || isModuleActive( site, 'shortcodes' ) ) ) {
 			assign( options, {
 				slideshow: this.props.translate( 'Slideshow' )
 			} );

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -16,6 +16,7 @@ import EditorMediaModalGalleryPreview from './preview';
 import { GalleryDefaultAttrs } from 'lib/media/constants';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
+import { isModuleActive } from 'lib/site/utils';
 
 const EditorMediaModalGallery = React.createClass( {
 	propTypes: {
@@ -95,7 +96,7 @@ const EditorMediaModalGallery = React.createClass( {
 
 		let defaultSettings = assign( {}, GalleryDefaultAttrs, { items } );
 
-		if ( site && ( ! site.jetpack || site.isModuleActive( 'tiled-gallery' ) ) ) {
+		if ( site && ( ! site.jetpack || isModuleActive( site, 'tiled-gallery' ) ) ) {
 			defaultSettings.type = 'rectangular';
 		}
 

--- a/client/post-editor/media-modal/gallery/preview-individual.jsx
+++ b/client/post-editor/media-modal/gallery/preview-individual.jsx
@@ -2,25 +2,26 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import markup from '../markup';
+import { getSelectedSite } from 'state/ui/selectors';
 
-export default React.createClass( {
-	displayName: 'EditorMediaModalGalleryPreviewIndividual',
-
+const EditorMediaModalGalleryPreviewIndividual = React.createClass( {
 	propTypes: {
-		items: PropTypes.arrayOf( PropTypes.object )
+		items: PropTypes.arrayOf( PropTypes.object ),
+		site: PropTypes.object
 	},
 
 	render() {
 		const items = this.props.items.map( ( item ) => {
-			const caption = markup.caption( item );
+			const caption = markup.caption( this.props.site, item );
 
 			if ( null === caption ) {
-				return <div key={ item.ID } dangerouslySetInnerHTML={ { __html: markup.get( item ) } } />; //eslint-disable-line react/no-danger
+				return <div key={ item.ID } dangerouslySetInnerHTML={ { __html: markup.get( this.props.site, item ) } } />; //eslint-disable-line react/no-danger
 			}
 
 			return React.cloneElement( caption, { key: item.ID } );
@@ -36,3 +37,11 @@ export default React.createClass( {
 	}
 
 } );
+
+export default connect(
+	state => {
+		return {
+			site: getSelectedSite( state )
+		};
+	}
+)( EditorMediaModalGalleryPreviewIndividual );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -106,6 +106,7 @@ export const EditorMediaModal = React.createClass( {
 		var selectedItems = this.props.mediaLibrarySelectedItems,
 			gallerySettings = this.state.gallerySettings,
 			media, stat;
+		const site = this.props.site;
 
 		if ( ! this.props.visible ) {
 			return;
@@ -113,13 +114,13 @@ export const EditorMediaModal = React.createClass( {
 
 		if ( ModalViews.GALLERY === this.props.view ) {
 			if ( gallerySettings && 'individual' === gallerySettings.type ) {
-				media = gallerySettings.items.map( markup.get ).join( '' );
+				media = gallerySettings.items.map( item => markup.get( site, item ) ).join( '' );
 			} else {
 				media = MediaUtils.generateGalleryShortcode( gallerySettings );
 			}
 			stat = 'insert_gallery';
 		} else {
-			media = selectedItems.map( markup.get ).join( '' );
+			media = selectedItems.map( item => markup.get( site, item ) ).join( '' );
 			stat = 'insert_item';
 		}
 

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -11,8 +11,7 @@ var ReactDomServer = require( 'react-dom/server' ),
  */
 var Shortcode = require( 'lib/shortcode' ),
 	MediaUtils = require( 'lib/media/utils' ),
-	MediaSerialization = require( 'lib/media-serialization' ),
-	sites = require( 'lib/sites-list' )();
+	MediaSerialization = require( 'lib/media-serialization' );
 
 /**
  * Module variables
@@ -21,14 +20,15 @@ var Markup;
 
 Markup = {
 	/**
-	 * Given a media object, returns a markup string representing that object
+	 * Given a media object and a site, returns a markup string representing that object
 	 * as HTML.
 	 *
+	 * @param  {Object} site    A site object
 	 * @param  {Object} media   A media object
 	 * @param  {Object} options Appearance options
 	 * @return {string}         A markup string
 	 */
-	get: function( media, options ) {
+	get: function( site, media, options ) {
 		var mimePrefix;
 
 		if ( ! media ) {
@@ -40,7 +40,7 @@ Markup = {
 		// Attempt to find a matching function in the mimeTypes object using
 		// the MIME type prefix
 		if ( mimePrefix && 'function' === typeof Markup.mimeTypes[ mimePrefix ] ) {
-			return Markup.mimeTypes[ mimePrefix ]( media, options );
+			return Markup.mimeTypes[ mimePrefix ]( site, media, options );
 		}
 
 		return Markup.link( media );
@@ -63,7 +63,7 @@ Markup = {
 	},
 
 	/**
-	 * Given a media object or markup string, returns a caption React element.
+	 * Given a media object or markup string and a site, returns a caption React element.
 	 *
 	 * Adapted from WordPress.
 	 *
@@ -71,15 +71,16 @@ Markup = {
 	 * @license See CREDITS.md.
 	 * @see https://github.com/WordPress/WordPress/blob/4.3/wp-includes/js/tinymce/plugins/wpeditimage/plugin.js#L97-L157
 	 *
+	 * @param  {Object} site           A site object
 	 * @param  {(Object|String)} media A media object or markup string
 	 * @return {String}                A caption React element, or null if not
 	 *                                 a captioned item.
 	 */
-	caption: function( media ) {
+	caption: function( site, media ) {
 		var parsed, match, img, caption, width;
 
 		if ( 'string' !== typeof media ) {
-			media = Markup.get( media );
+			media = Markup.get( site, media );
 		}
 
 		parsed = Shortcode.parse( media );
@@ -110,16 +111,15 @@ Markup = {
 
 	mimeTypes: {
 		/**
-		 * Given an image media object, returns a markup string representing that
+		 * Given an image media object and a site, returns a markup string representing that
 		 * image object as HTML.
 		 *
+		 * @param  {Object} site    A site object
 		 * @param  {Object} media   An image media object
 	 	 * @param  {Object} options Appearance options
 		 * @return {string}         An image markup string
 		 */
-		image: function( media, options ) {
-			const site = sites.getSelectedSite();
-
+		image: function( site, media, options ) {
 			options = assign( {
 				size: 'full',
 				align: 'none',

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -13,7 +13,7 @@ import useMockery from 'test/helpers/use-mockery';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'markup', function() {
-	let sandbox, markup, sites;
+	let sandbox, markup, site;
 
 	useFakeDom();
 	useSandbox( ( newSandbox ) => sandbox = newSandbox );
@@ -27,7 +27,7 @@ describe( 'markup', function() {
 
 	before( () => {
 		markup = require( '../markup' );
-		sites = require( 'lib/sites-list' )();
+		site = {};
 	} );
 
 	beforeEach( () => {
@@ -36,21 +36,21 @@ describe( 'markup', function() {
 
 	describe( '#get()', function() {
 		it( 'should return an empty string if not passed any arguments', function() {
-			var value = markup.get();
+			var value = markup.get( site );
 
 			expect( value ).to.equal( '' );
 		} );
 
 		it( 'should defer to a specific mime type handler if one exists', function() {
 			sandbox.stub( markup.mimeTypes, 'image' );
-			markup.get( { mime_type: 'image/png' } );
+			markup.get( site, { mime_type: 'image/png' } );
 
 			expect( markup.mimeTypes.image ).to.have.been.called;
 		} );
 
 		it( 'should return a link for a mime type prefix without a specific handler', function() {
 			sandbox.stub( markup, 'link' );
-			markup.get( { mime_type: 'application/pdf' } );
+			markup.get( site, { mime_type: 'application/pdf' } );
 
 			expect( markup.link ).to.have.been.called;
 		} );
@@ -69,7 +69,7 @@ describe( 'markup', function() {
 
 	describe( '#caption()', function() {
 		it( 'should accept a media object, returning a caption element', function() {
-			var value = markup.caption( {
+			var value = markup.caption( site, {
 				ID: 1,
 				URL: 'https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png',
 				alt: 'Automattic',
@@ -83,7 +83,7 @@ describe( 'markup', function() {
 		} );
 
 		it( 'should accept a non-captioned image, returning null', function() {
-			var value = markup.caption( {
+			var value = markup.caption( site, {
 				ID: 1,
 				URL: 'https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png',
 				alt: 'Automattic',
@@ -95,7 +95,7 @@ describe( 'markup', function() {
 		} );
 
 		it( 'should accept a captioned string, returning a React element', function() {
-			var value = markup.caption( '[caption id="attachment_1627" align="aligncenter" width="660"]<img class="size-full wp-image-1627" src="https://andrewmduthietest.files.wordpress.com/2015/01/img_0372.jpg" alt="Example" width="660" height="660" /> Ceramic[/caption]' );
+			var value = markup.caption( site, '[caption id="attachment_1627" align="aligncenter" width="660"]<img class="size-full wp-image-1627" src="https://andrewmduthietest.files.wordpress.com/2015/01/img_0372.jpg" alt="Example" width="660" height="660" /> Ceramic[/caption]' );
 
 			expect( value.type ).to.equal( 'dl' );
 			expect( ReactDomServer.renderToStaticMarkup( value ) ).to.equal( '<dl class="wp-caption aligncenter" style="width:660px;"><dt class="wp-caption-dt"><img class="size-full wp-image-1627" src="https://andrewmduthietest.files.wordpress.com/2015/01/img_0372.jpg" alt="Example" width="660" height="660" /></dt><dd class="wp-caption-dd">Ceramic</dd></dl>' );
@@ -104,14 +104,8 @@ describe( 'markup', function() {
 
 	describe( '.mimeTypes', function() {
 		describe( '#image()', function() {
-			beforeEach( function() {
-				sandbox.stub( sites, 'getSelectedSite', function() {
-					return {};
-				} );
-			} );
-
 			it( 'should not set width auto if media width cannot be determined', function() {
-				var value = markup.mimeTypes.image( {
+				var value = markup.mimeTypes.image( site, {
 					ID: 'media-4',
 					URL: 'blob:http%3A//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71',
 					thumbnails: {}
@@ -121,7 +115,7 @@ describe( 'markup', function() {
 			} );
 
 			it( 'should return an img element for an image', function() {
-				var value = markup.mimeTypes.image( {
+				var value = markup.mimeTypes.image( site, {
 					ID: 1,
 					URL: 'https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png',
 					alt: 'Automattic',
@@ -133,17 +127,14 @@ describe( 'markup', function() {
 			} );
 
 			it( 'should respect the max width for a site size', function() {
-				sites.getSelectedSite.restore();
-				sandbox.stub( sites, 'getSelectedSite', function() {
-					return {
-						options: {
-							image_large_width: 1024,
-							image_large_height: 1024
-						}
-					};
-				} );
+				const siteWithLargeSize = {
+					options: {
+						image_large_width: 1024,
+						image_large_height: 1024
+					}
+				};
 
-				const value = markup.mimeTypes.image( {
+				const value = markup.mimeTypes.image( siteWithLargeSize, {
 					ID: 1,
 					URL: 'http://example.com/image.png',
 					thumbnails: {},
@@ -151,23 +142,18 @@ describe( 'markup', function() {
 					height: 2000
 				}, { size: 'large' } );
 
-				sites.getSelectedSite.restore();
-
 				expect( value ).to.equal( '<img src="http://example.com/image.png?w=1024" width="1024" height="410" class="alignnone size-large wp-image-1"/>' );
 			} );
 
 			it( 'should respect the max height for a site size', function() {
-				sites.getSelectedSite.restore();
-				sandbox.stub( sites, 'getSelectedSite', function() {
-					return {
-						options: {
-							image_large_width: 1024,
-							image_large_height: 1024
-						}
-					};
-				} );
+				const siteWithLargeSize = {
+					options: {
+						image_large_width: 1024,
+						image_large_height: 1024
+					}
+				};
 
-				const value = markup.mimeTypes.image( {
+				const value = markup.mimeTypes.image( siteWithLargeSize, {
 					ID: 1,
 					URL: 'http://example.com/image.png',
 					thumbnails: {},
@@ -175,13 +161,11 @@ describe( 'markup', function() {
 					height: 5000
 				}, { size: 'large' } );
 
-				sites.getSelectedSite.restore();
-
 				expect( value ).to.equal( '<img src="http://example.com/image.png?w=410" width="410" height="1024" class="alignnone size-large wp-image-1"/>' );
 			} );
 
 			it( 'should include a resize parameter if forceResize option passed', function() {
-				var value = markup.mimeTypes.image( {
+				var value = markup.mimeTypes.image( site, {
 					ID: 1,
 					URL: 'https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png',
 					alt: 'Automattic',
@@ -193,7 +177,7 @@ describe( 'markup', function() {
 			} );
 
 			it( 'should avoid XSS because React', function() {
-				var value = markup.mimeTypes.image( {
+				var value = markup.mimeTypes.image( site, {
 					ID: 1,
 					URL: '""><SCRIPT>alert("XSS")</SCRIPT>"',
 					thumbnails: {},
@@ -205,17 +189,13 @@ describe( 'markup', function() {
 
 			it( 'should attempt to find the site\'s thumbnail width if a size is specified', function() {
 				var value;
+				const siteWithWidth = {
+					options: {
+						image_large_width: 200
+					}
+				};
 
-				sites.getSelectedSite.restore();
-				sandbox.stub( sites, 'getSelectedSite', function() {
-					return {
-						options: {
-							image_large_width: 200
-						}
-					};
-				} );
-
-				value = markup.mimeTypes.image( {
+				value = markup.mimeTypes.image( siteWithWidth, {
 					ID: 1,
 					URL: 'https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png',
 					alt: 'Automattic',
@@ -223,20 +203,14 @@ describe( 'markup', function() {
 					width: 276
 				}, { size: 'large' } );
 
-				sites.getSelectedSite.restore();
-
 				expect( value ).to.equal( '<img src="https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png?w=200" alt="Automattic" width="200" class="alignnone size-large wp-image-1"/>' );
 			} );
 
 			it( 'should attempt to find the media\'s own thumbnail width if a size is specified', function() {
 				var value;
+				const jetpackSite = { jetpack: true };
 
-				sites.getSelectedSite.restore();
-				sandbox.stub( sites, 'getSelectedSite', function() {
-					return { jetpack: true };
-				} );
-
-				value = markup.mimeTypes.image( {
+				value = markup.mimeTypes.image( jetpackSite, {
 					ID: 1,
 					URL: 'http://example.com/wp-content/uploads/2015/05/logo11w.png',
 					alt: 'WordPress',
@@ -246,13 +220,11 @@ describe( 'markup', function() {
 					width: 5380
 				}, { size: 'large' } );
 
-				sites.getSelectedSite.restore();
-
 				expect( value ).to.equal( '<img src="http://example.com/wp-content/uploads/2015/05/logo11w-1024x1024.png" alt="WordPress" width="1024" class="alignnone size-large wp-image-1"/>' );
 			} );
 
 			it( 'should wrap a captioned image in a caption shortcode', function() {
-				var value = markup.mimeTypes.image( {
+				var value = markup.mimeTypes.image( site, {
 					ID: 1,
 					URL: 'https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png',
 					alt: 'Automattic',
@@ -265,7 +237,7 @@ describe( 'markup', function() {
 			} );
 
 			it( 'should calculate the height when specifying a size', function() {
-				var value = markup.mimeTypes.image( {
+				var value = markup.mimeTypes.image( site, {
 					ID: 1,
 					URL: 'https://s1.wp.com/wp-content/themes/a8c/automattic-2011/images/automattic-logo.png',
 					alt: 'Automattic',


### PR DESCRIPTION
When we resize an image manually, we keep the resize buttons visible on the toolbar.
And once clicked, we compute the closest possible "known" size to go to.
We also disable hiding the buttons when the size is smaller than the smallest thumb since we can increase the size using the buttons.

The behavior stays the same if you use only "known" sizes.

Since it's not only a bug fix, but also a small change of the behavior of these buttons, I would need a "functional" validation

closes #1120

**testing instructions**
- start from https://wordpress.com/post
- add a media to the editor
- Resize the media using the buttons +/-
- Resize the media manually
- The resizing buttons are still shown and we can still use them to resize the media

cc @timmyc  
