### PR TITLE
Jetpack Connect: Access state only through selectors

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -27,8 +27,8 @@ import {
 	goToXmlrpcErrorFallbackUrl
 } from 'state/jetpack-connect/actions';
 import {
-	getAuthorize,
-	getAuthorizeSite,
+	getAuthorizationData,
+	getAuthorizationRemoteUrl,
 	getSSOSessions,
 	isCalypsoStartedConnection,
 	hasXmlrpcError
@@ -642,9 +642,9 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 export default connect(
 	state => {
-		const authorizeSite = getAuthorizeSite( state );
-		const site = authorizeSite
-			? getSiteByUrl( state, authorizeSite )
+		const remoteUrl = getAuthorizationRemoteUrl( state );
+		const site = remoteUrl
+			? getSiteByUrl( state, remoteUrl )
 			: null;
 
 		const requestHasXmlrpcError = () => {
@@ -656,12 +656,12 @@ export default connect(
 		};
 
 		return {
-			jetpackConnectAuthorize: getAuthorize( state ),
+			jetpackConnectAuthorize: getAuthorizationData( state ),
 			jetpackSSOSessions: getSSOSessions( state ),
 			isAlreadyOnSitesList: !! site,
 			isFetchingSites,
 			requestHasXmlrpcError,
-			calypsoStartedConnection: isCalypsoStartedConnection( state, authorizeSite )
+			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteUrl )
 		};
 	},
 	dispatch => bindActionCreators( {

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -26,7 +26,13 @@ import {
 	activateManage,
 	goToXmlrpcErrorFallbackUrl
 } from 'state/jetpack-connect/actions';
-import { isCalypsoStartedConnection, hasXmlrpcError } from 'state/jetpack-connect/selectors';
+import {
+	getAuthorize,
+	getAuthorizeSite,
+	getSSOSessions,
+	isCalypsoStartedConnection,
+	hasXmlrpcError
+} from 'state/jetpack-connect/selectors';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import observe from 'lib/mixins/data-observe';
 import userUtilities from 'lib/user/utils';
@@ -636,34 +642,35 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 export default connect(
 	state => {
-		const queryObjectSite = state.jetpackConnect.jetpackConnectAuthorize &&
-			state.jetpackConnect.jetpackConnectAuthorize.queryObject &&
-			state.jetpackConnect.jetpackConnectAuthorize.queryObject.site;
-
-		const site = queryObjectSite
-			? getSiteByUrl( state, state.jetpackConnect.jetpackConnectAuthorize.queryObject.site )
+		const authorizeSite = getAuthorizeSite( state );
+		const site = authorizeSite
+			? getSiteByUrl( state, authorizeSite )
 			: null;
+
 		const requestHasXmlrpcError = () => {
 			return hasXmlrpcError( state );
 		};
+
 		const isFetchingSites = () => {
 			return isRequestingSites( state );
 		};
 
 		return {
-			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
-			jetpackSSOSessions: state.jetpackConnect.jetpackSSOSessions,
+			jetpackConnectAuthorize: getAuthorize( state ),
+			jetpackSSOSessions: getSSOSessions( state ),
 			isAlreadyOnSitesList: !! site,
 			isFetchingSites,
 			requestHasXmlrpcError,
-			calypsoStartedConnection: isCalypsoStartedConnection( state, queryObjectSite )
+			calypsoStartedConnection: isCalypsoStartedConnection( state, authorizeSite )
 		};
 	},
-	dispatch => bindActionCreators( { requestSites,
+	dispatch => bindActionCreators( {
+		requestSites,
 		recordTracksEvent,
 		authorize,
 		createAccount,
 		activateManage,
 		goBackToWpAdmin,
-		goToXmlrpcErrorFallbackUrl }, dispatch )
+		goToXmlrpcErrorFallbackUrl
+	}, dispatch )
 )( JetpackConnectAuthorizeForm );

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -28,7 +28,7 @@ import {
 } from 'state/jetpack-connect/actions';
 import {
 	getAuthorizationData,
-	getAuthorizationRemoteUrl,
+	getAuthorizationRemoteSite,
 	getSSOSessions,
 	isCalypsoStartedConnection,
 	hasXmlrpcError
@@ -42,7 +42,6 @@ import Gravatar from 'components/gravatar';
 import Gridicon from 'components/gridicon';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSiteByUrl } from 'state/sites/selectors';
 import Spinner from 'components/spinner';
 import Site from 'blocks/site';
 import { decodeEntities } from 'lib/formatting';
@@ -642,10 +641,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 export default connect(
 	state => {
-		const remoteUrl = getAuthorizationRemoteUrl( state );
-		const site = remoteUrl
-			? getSiteByUrl( state, remoteUrl )
-			: null;
+		const remoteSite = getAuthorizationRemoteSite( state );
 
 		const requestHasXmlrpcError = () => {
 			return hasXmlrpcError( state );
@@ -658,10 +654,10 @@ export default connect(
 		return {
 			jetpackConnectAuthorize: getAuthorizationData( state ),
 			jetpackSSOSessions: getSSOSessions( state ),
-			isAlreadyOnSitesList: !! site,
+			isAlreadyOnSitesList: !! remoteSite,
 			isFetchingSites,
 			requestHasXmlrpcError,
-			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteUrl )
+			calypsoStartedConnection: remoteSite && isCalypsoStartedConnection( state, remoteSite.URL )
 		};
 	},
 	dispatch => bindActionCreators( {

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -15,7 +15,7 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
-import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
+import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import QuerySites from 'components/data/query-sites';
 import JetpackInstallStep from './install-step';
 import versionCompare from 'lib/version-compare';
@@ -397,7 +397,7 @@ export default connect(
 		};
 
 		return {
-			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite,
+			jetpackConnectSite: getConnectingSite( state ),
 			getJetpackSiteByUrl: getJetpackSite
 		};
 	},

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -19,7 +19,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import * as upgradesActions from 'lib/upgrades/actions';
 import { userCan } from 'lib/site/utils';
-import { isCalypsoStartedConnection } from 'state/jetpack-connect/selectors';
+import { getAuthorize, isCalypsoStartedConnection } from 'state/jetpack-connect/selectors';
 import { goBackToWpAdmin } from 'state/jetpack-connect/actions';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -175,7 +175,7 @@ export default connect(
 		return {
 			selectedSite,
 			sitePlans: getPlansBySite( state, selectedSite ),
-			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
+			jetpackConnectAuthorize: getAuthorize( state ),
 			userId: user ? user.ID : null,
 			canPurchasePlans: userCan( 'manage_options', selectedSite ),
 			flowType: getFlowType( state, selectedSite && selectedSite.slug ),

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -19,7 +19,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import * as upgradesActions from 'lib/upgrades/actions';
 import { userCan } from 'lib/site/utils';
-import { getAuthorize, isCalypsoStartedConnection } from 'state/jetpack-connect/selectors';
+import { getAuthorizationData, isCalypsoStartedConnection } from 'state/jetpack-connect/selectors';
 import { goBackToWpAdmin } from 'state/jetpack-connect/actions';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -175,7 +175,7 @@ export default connect(
 		return {
 			selectedSite,
 			sitePlans: getPlansBySite( state, selectedSite ),
-			jetpackConnectAuthorize: getAuthorize( state ),
+			jetpackConnectAuthorize: getAuthorizationData( state ),
 			userId: user ? user.ID : null,
 			canPurchasePlans: userCan( 'manage_options', selectedSite ),
 			flowType: getFlowType( state, selectedSite && selectedSite.slug ),

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -21,6 +21,7 @@ import Button from 'components/button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import { validateSSONonce, authorizeSSO } from 'state/jetpack-connect/actions';
+import { getSSO } from 'state/jetpack-connect/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
 import config from 'config';
 import EmptyContent from 'components/empty-content';
@@ -463,7 +464,7 @@ const JetpackSSOForm = React.createClass( {
 
 export default connect(
 	state => {
-		const { jetpackSSO } = state.jetpackConnect;
+		const jetpackSSO = getSSO( state );
 		return {
 			ssoUrl: get( jetpackSSO, 'ssoUrl' ),
 			isAuthorizing: get( jetpackSSO, 'isAuthorizing' ),
@@ -475,5 +476,8 @@ export default connect(
 			sharedDetails: get( jetpackSSO, 'sharedDetails' )
 		};
 	},
-	dispatch => bindActionCreators( { authorizeSSO, validateSSONonce }, dispatch )
+	dispatch => bindActionCreators( {
+		authorizeSSO,
+		validateSSONonce
+	}, dispatch )
 )( JetpackSSOForm );

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -14,16 +14,16 @@ const getConnectingSite = ( state ) => {
 	return get( state, [ 'jetpackConnect', 'jetpackConnectSite' ] );
 };
 
-const getAuthorize = ( state ) => {
+const getAuthorizationData = ( state ) => {
 	return get( state, [ 'jetpackConnect', 'jetpackConnectAuthorize' ] );
 };
 
-const getAuthorizeQuery = ( state ) => {
-	return get( getAuthorize( state ), [ 'queryObject' ] );
+const getAuthorizationRemoteQueryData = ( state ) => {
+	return get( getAuthorizationData( state ), [ 'queryObject' ] );
 };
 
-const getAuthorizeSite = ( state ) => {
-	return get( getAuthorizeQuery( state ), [ 'site' ] );
+const getAuthorizationRemoteUrl = ( state ) => {
+	return get( getAuthorizationRemoteQueryData( state ), [ 'site' ] );
 };
 
 const getSessions = ( state ) => {
@@ -77,7 +77,7 @@ const getJetpackSiteByUrl = ( state, url ) => {
  * @returns {Boolean} If there's an xmlrpc error or not
  */
 const hasXmlrpcError = function( state ) {
-	const authorizeData = getAuthorize( state );
+	const authorizeData = getAuthorizationData( state );
 
 	return (
 		authorizeData &&
@@ -90,9 +90,9 @@ const hasXmlrpcError = function( state ) {
 
 export default {
 	getConnectingSite,
-	getAuthorize,
-	getAuthorizeQuery,
-	getAuthorizeSite,
+	getAuthorizationData,
+	getAuthorizationRemoteQueryData,
+	getAuthorizationRemoteUrl,
 	getSessions,
 	getSSOSessions,
 	getSSO,

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -22,8 +22,14 @@ const getAuthorizationRemoteQueryData = ( state ) => {
 	return get( getAuthorizationData( state ), [ 'queryObject' ] );
 };
 
-const getAuthorizationRemoteUrl = ( state ) => {
-	return get( getAuthorizationRemoteQueryData( state ), [ 'site' ] );
+const getAuthorizationRemoteSite = ( state ) => {
+	const remoteUrl = get( getAuthorizationRemoteQueryData( state ), [ 'site' ] );
+
+	if ( ! remoteUrl ) {
+		return null;
+	}
+
+	return getSiteByUrl( state, remoteUrl );
 };
 
 const getSessions = ( state ) => {
@@ -92,7 +98,7 @@ export default {
 	getConnectingSite,
 	getAuthorizationData,
 	getAuthorizationRemoteQueryData,
-	getAuthorizationRemoteUrl,
+	getAuthorizationRemoteSite,
 	getSessions,
 	getSSOSessions,
 	getSSO,

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -1,16 +1,49 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { getSiteByUrl } from 'state/sites/selectors';
 
 const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // an hour
 
+const getConnectingSite = ( state ) => {
+	return get( state, [ 'jetpackConnect', 'jetpackConnectSite' ] );
+};
+
+const getAuthorize = ( state ) => {
+	return get( state, [ 'jetpackConnect', 'jetpackConnectAuthorize' ] );
+};
+
+const getAuthorizeQuery = ( state ) => {
+	return get( getAuthorize( state ), [ 'queryObject' ] );
+};
+
+const getAuthorizeSite = ( state ) => {
+	return get( getAuthorizeQuery( state ), [ 'site' ] );
+};
+
+const getSessions = ( state ) => {
+	return get( state, [ 'jetpackConnect', 'jetpackConnectSessions' ] );
+};
+
+const getSSOSessions = ( state ) => {
+	return get( state, [ 'jetpackConnect', 'jetpackSSOSessions' ] );
+};
+
+const getSSO = ( state ) => {
+	return get( state, [ 'jetpackConnect', 'jetpackSSO' ] );
+};
+
 const isCalypsoStartedConnection = function( state, siteSlug ) {
 	if ( ! siteSlug ) {
 		return false;
 	}
 	const site = siteSlug.replace( /.*?:\/\//g, '' );
-	const sessions = state.jetpackConnect.jetpackConnectSessions;
+	const sessions = getSessions( state );
 
 	if ( sessions[ site ] ) {
 		const currentTime = ( new Date() ).getTime();
@@ -21,7 +54,7 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 };
 
 const getFlowType = function( state, siteSlug ) {
-	const sessions = state.jetpackConnect.jetpackConnectSessions;
+	const sessions = getSessions( state );
 	if ( siteSlug && sessions[ siteSlug ] ) {
 		return sessions[ siteSlug ].flowType;
 	}
@@ -44,7 +77,7 @@ const getJetpackSiteByUrl = ( state, url ) => {
  * @returns {Boolean} If there's an xmlrpc error or not
  */
 const hasXmlrpcError = function( state ) {
-	const authorizeData = state.jetpackConnect.jetpackConnectAuthorize;
+	const authorizeData = getAuthorize( state );
 
 	return (
 		authorizeData &&
@@ -55,4 +88,16 @@ const hasXmlrpcError = function( state ) {
 	);
 };
 
-export default { isCalypsoStartedConnection, getFlowType, getJetpackSiteByUrl, hasXmlrpcError };
+export default {
+	getConnectingSite,
+	getAuthorize,
+	getAuthorizeQuery,
+	getAuthorizeSite,
+	getSessions,
+	getSSOSessions,
+	getSSO,
+	isCalypsoStartedConnection,
+	getFlowType,
+	getJetpackSiteByUrl,
+	hasXmlrpcError
+};

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -6,7 +6,19 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isCalypsoStartedConnection, getFlowType, getJetpackSiteByUrl, hasXmlrpcError } from '../selectors';
+import {
+	getConnectingSite,
+	getAuthorize,
+	getAuthorizeQuery,
+	getAuthorizeSite,
+	getSessions,
+	getSSOSessions,
+	getSSO,
+	isCalypsoStartedConnection,
+	getFlowType,
+	getJetpackSiteByUrl,
+	hasXmlrpcError
+} from '../selectors';
 
 const stateHasXmlrpcError = {
 	jetpackConnect: {
@@ -49,6 +61,242 @@ const stateHasOtherError = {
 };
 
 describe( 'selectors', () => {
+	describe( '#getConnectingSite()', () => {
+		it( 'should return undefined if user has not started connecting a site', () => {
+			const state = {
+				jetpackConnect: {}
+			};
+
+			expect( getConnectingSite( state ) ).to.be.undefined;
+		} );
+
+		it( 'should return the current connecting site if there is such', () => {
+			const jetpackConnectSite = {
+				url: '',
+				isFetching: true,
+				isFetched: false,
+				isRedirecting: false,
+				installConfirmedByUser: true,
+				isDismissed: false,
+				data: {
+					isDotCom: false,
+					notExists: false,
+					notWordPress: false,
+					notJetpack: false,
+					jetpackVersion: '4.3.1',
+					outdatedJetpack: false,
+					notActiveJetpack: false,
+					notConnectedJetpack: true,
+					alreadyOwned: true,
+					alreadyConnected: false
+				}
+			};
+			const state = {
+				jetpackConnect: {
+					jetpackConnectSite
+				}
+			};
+
+			expect( getConnectingSite( state ) ).to.eql( jetpackConnectSite );
+		} );
+	} );
+
+	describe( '#getAuthorize()', () => {
+		it( 'should return undefined if user has not started the authorization flow', () => {
+			const state = {
+				jetpackConnect: {}
+			};
+
+			expect( getAuthorize( state ) ).to.be.undefined;
+		} );
+
+		it( 'should return the current authorize object if there is such', () => {
+			const jetpackConnectAuthorize = {
+				authorizationCode: 'abcdefgh12345678',
+				isAuthorizing: false,
+				queryObject: {},
+			};
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize
+				}
+			};
+
+			expect( getAuthorize( state ) ).to.eql( jetpackConnectAuthorize );
+		} );
+	} );
+
+	describe( '#getAuthorizeQuery()', () => {
+		it( 'should return undefined if user has not started the authorization flow', () => {
+			const state = {
+				jetpackConnect: {}
+			};
+
+			expect( getAuthorizeQuery( state ) ).to.be.undefined;
+		} );
+
+		it( 'should return the current authorize query object if there is such', () => {
+			const queryObject = {
+				_wp_nonce: 'nonce',
+				client_id: '12345678',
+				redirect_uri: 'https://wordpress.com/',
+				scope: 'auth',
+				secret: '1234abcd',
+				state: 12345678
+			};
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize: {
+						queryObject
+					}
+				}
+			};
+
+			expect( getAuthorizeQuery( state ) ).to.eql( queryObject );
+		} );
+	} );
+
+	describe( '#getAuthorizeSite()', () => {
+		it( 'should return undefined if user has not started the authorization flow', () => {
+			const state = {
+				jetpackConnect: {}
+			};
+
+			expect( getAuthorizeSite( state ) ).to.be.undefined;
+		} );
+
+		it( 'should return the current authorize site if there is such', () => {
+			const site = 'wordpress.com';
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize: {
+						queryObject: {
+							_wp_nonce: 'nonce',
+							client_id: '12345678',
+							redirect_uri: 'https://wordpress.com/',
+							scope: 'auth',
+							secret: '1234abcd',
+							state: 12345678,
+							site
+						}
+					}
+				}
+			};
+
+			expect( getAuthorizeSite( state ) ).to.eql( site );
+		} );
+	} );
+
+	describe( '#getSessions()', () => {
+		it( 'should return undefined if user has not started any jetpack connect sessions', () => {
+			const state = {
+				jetpackConnect: {}
+			};
+
+			expect( getSessions( state ) ).to.be.undefined;
+		} );
+
+		it( 'should return all of the user\'s single sign-on sessions', () => {
+			const jetpackConnectSessions = {
+				'wordpress.com': {
+					timestamp: 1234567890,
+					flowType: 'premium'
+				},
+				'jetpack.me': {
+					timestamp: 2345678901,
+					flowType: 'pro'
+				}
+			};
+			const state = {
+				jetpackConnect: {
+					jetpackConnectSessions
+				}
+			};
+
+			expect( getSessions( state ) ).to.eql( jetpackConnectSessions );
+		} );
+	} );
+
+	describe( '#getSSOSessions()', () => {
+		it( 'should return undefined if user has not started any single sign-on sessions', () => {
+			const state = {
+				jetpackConnect: {}
+			};
+
+			expect( getSSOSessions( state ) ).to.be.undefined;
+		} );
+
+		it( 'should return all of the user\'s single sign-on sessions', () => {
+			const jetpackSSOSessions = {
+				'wordpress.com': {
+					timestamp: 1234567890,
+					flowType: 'premium'
+				},
+				'jetpack.me': {
+					timestamp: 2345678901,
+					flowType: 'pro'
+				}
+			};
+			const state = {
+				jetpackConnect: {
+					jetpackSSOSessions
+				}
+			};
+
+			expect( getSSOSessions( state ) ).to.eql( jetpackSSOSessions );
+		} );
+	} );
+
+	describe( '#getSSO()', () => {
+		it( 'should return undefined if user has not yet started the single sign-on flow', () => {
+			const state = {
+				jetpackConnect: {}
+			};
+
+			expect( getSSO( state ) ).to.be.undefined;
+		} );
+
+		it( 'should return the current state of the single sign-on object', () => {
+			const jetpackSSO = {
+				ssoUrl: 'https://wordpress.com/',
+				isAuthorizing: false,
+				isValidating: false,
+				nonceValid: true,
+				authorizationError: false,
+				validationError: false,
+				blogDetails: {
+					URL: 'https://wordpress.com/',
+					admin_url: 'https://wordpress.com/wp-admin/',
+					domain: 'wordpress.com',
+					icon: {
+						img: 'https://wordpress.com/example.jpg',
+						ico: 'https://wordpress.com/example.ico',
+					},
+					title: 'Example Site Title',
+				},
+				sharedDetails: {
+					ID: 1234,
+					login: 'test',
+					email: 'test@wordpress.com',
+					url: 'https://wordpress.com',
+					first_name: 'Example',
+					last_name: 'Test',
+					display_name: 'Example Test',
+					description: 'User bio here',
+					two_step_enabled: false,
+					external_user_id: 1
+				}
+			};
+			const state = {
+				jetpackConnect: {
+					jetpackSSO
+				}
+			};
+
+			expect( getSSO( state ) ).to.eql( jetpackSSO );
+		} );
+	} );
+
 	describe( '#isCalypsoStartedConnection()', () => {
 		it( 'should return true if the user have started a session in calypso less than an hour ago', () => {
 			const state = {

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -8,9 +8,9 @@ import { expect } from 'chai';
  */
 import {
 	getConnectingSite,
-	getAuthorize,
-	getAuthorizeQuery,
-	getAuthorizeSite,
+	getAuthorizationData,
+	getAuthorizationRemoteQueryData,
+	getAuthorizationRemoteUrl,
 	getSessions,
 	getSSOSessions,
 	getSSO,
@@ -61,13 +61,13 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getAuthorize()', () => {
+	describe( '#getAuthorizationData()', () => {
 		it( 'should return undefined if user has not started the authorization flow', () => {
 			const state = {
 				jetpackConnect: {}
 			};
 
-			expect( getAuthorize( state ) ).to.be.undefined;
+			expect( getAuthorizationData( state ) ).to.be.undefined;
 		} );
 
 		it( 'should return the current authorize object if there is such', () => {
@@ -82,17 +82,17 @@ describe( 'selectors', () => {
 				}
 			};
 
-			expect( getAuthorize( state ) ).to.eql( jetpackConnectAuthorize );
+			expect( getAuthorizationData( state ) ).to.eql( jetpackConnectAuthorize );
 		} );
 	} );
 
-	describe( '#getAuthorizeQuery()', () => {
+	describe( '#getAuthorizationRemoteQueryData()', () => {
 		it( 'should return undefined if user has not started the authorization flow', () => {
 			const state = {
 				jetpackConnect: {}
 			};
 
-			expect( getAuthorizeQuery( state ) ).to.be.undefined;
+			expect( getAuthorizationRemoteQueryData( state ) ).to.be.undefined;
 		} );
 
 		it( 'should return the current authorize query object if there is such', () => {
@@ -112,17 +112,17 @@ describe( 'selectors', () => {
 				}
 			};
 
-			expect( getAuthorizeQuery( state ) ).to.eql( queryObject );
+			expect( getAuthorizationRemoteQueryData( state ) ).to.eql( queryObject );
 		} );
 	} );
 
-	describe( '#getAuthorizeSite()', () => {
+	describe( '#getAuthorizationRemoteUrl()', () => {
 		it( 'should return undefined if user has not started the authorization flow', () => {
 			const state = {
 				jetpackConnect: {}
 			};
 
-			expect( getAuthorizeSite( state ) ).to.be.undefined;
+			expect( getAuthorizationRemoteUrl( state ) ).to.be.undefined;
 		} );
 
 		it( 'should return the current authorize site if there is such', () => {
@@ -143,7 +143,7 @@ describe( 'selectors', () => {
 				}
 			};
 
-			expect( getAuthorizeSite( state ) ).to.eql( site );
+			expect( getAuthorizationRemoteUrl( state ) ).to.eql( site );
 		} );
 	} );
 

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -10,7 +10,7 @@ import {
 	getConnectingSite,
 	getAuthorizationData,
 	getAuthorizationRemoteQueryData,
-	getAuthorizationRemoteUrl,
+	getAuthorizationRemoteSite,
 	getSessions,
 	getSSOSessions,
 	getSSO,
@@ -70,7 +70,7 @@ describe( 'selectors', () => {
 			expect( getAuthorizationData( state ) ).to.be.undefined;
 		} );
 
-		it( 'should return the current authorize object if there is such', () => {
+		it( 'should return the current authorization object if there is such', () => {
 			const jetpackConnectAuthorize = {
 				authorizationCode: 'abcdefgh12345678',
 				isAuthorizing: false,
@@ -95,7 +95,7 @@ describe( 'selectors', () => {
 			expect( getAuthorizationRemoteQueryData( state ) ).to.be.undefined;
 		} );
 
-		it( 'should return the current authorize query object if there is such', () => {
+		it( 'should return the current authorization query object if there is such', () => {
 			const queryObject = {
 				_wp_nonce: 'nonce',
 				client_id: '12345678',
@@ -116,18 +116,25 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getAuthorizationRemoteUrl()', () => {
-		it( 'should return undefined if user has not started the authorization flow', () => {
+	describe( '#getAuthorizationRemoteSite()', () => {
+		it( 'should return null if user has not started the authorization flow', () => {
 			const state = {
 				jetpackConnect: {}
 			};
 
-			expect( getAuthorizationRemoteUrl( state ) ).to.be.undefined;
+			expect( getAuthorizationRemoteSite( state ) ).to.be.null;
 		} );
 
-		it( 'should return the current authorize site if there is such', () => {
-			const site = 'wordpress.com';
+		it( 'should return the current authorization site if there is such', () => {
 			const state = {
+				sites: {
+					items: {
+						12345678: {
+							ID: 12345678,
+							URL: 'https://wordpress.com/'
+						}
+					}
+				},
 				jetpackConnect: {
 					jetpackConnectAuthorize: {
 						queryObject: {
@@ -137,13 +144,13 @@ describe( 'selectors', () => {
 							scope: 'auth',
 							secret: '1234abcd',
 							state: 12345678,
-							site
+							site: 'https://wordpress.com/'
 						}
 					}
 				}
 			};
 
-			expect( getAuthorizationRemoteUrl( state ) ).to.eql( site );
+			expect( getAuthorizationRemoteSite( state ) ).to.eql( state.sites.items[ 12345678 ] );
 		} );
 	} );
 

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -20,46 +20,6 @@ import {
 	hasXmlrpcError
 } from '../selectors';
 
-const stateHasXmlrpcError = {
-	jetpackConnect: {
-		jetpackConnectAuthorize: {
-			authorizeError: {
-				message: 'transport error - HTTP status code was not 200 (502)'
-			},
-			authorizationCode: 'xxxx'
-		}
-	}
-};
-
-const stateHasNoError = {
-	jetpackConnect: {
-		jetpackConnectAuthorize: {
-			authorizeError: false
-		}
-	}
-};
-
-const stateHasNoAuthorizationCode = {
-	jetpackConnect: {
-		jetpackConnectAuthorize: {
-			authorizeError: {
-				message: 'Could not verify your request.'
-			}
-		}
-	}
-};
-
-const stateHasOtherError = {
-	jetpackConnect: {
-		jetpackConnectAuthorize: {
-			authorizeError: {
-				message: 'Jetpack: [already_connected] User already connected.'
-			},
-			authorizationCode: 'xxxx'
-		}
-	}
-};
-
 describe( 'selectors', () => {
 	describe( '#getConnectingSite()', () => {
 		it( 'should return undefined if user has not started connecting a site', () => {
@@ -309,8 +269,10 @@ describe( 'selectors', () => {
 					}
 				}
 			};
+
 			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.true;
 		} );
+
 		it( 'should return false if the user haven\'t started a session in calypso  ', () => {
 			const state = {
 				jetpackConnect: {
@@ -319,6 +281,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
+
 			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.false;
 		} );
 
@@ -333,9 +296,11 @@ describe( 'selectors', () => {
 					}
 				}
 			};
+
 			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.false;
 		} );
 	} );
+
 	describe( '#getFlowType()', () => {
 		it( 'should return the flow of the session for a site', () => {
 			const state = {
@@ -348,6 +313,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
+
 			expect( getFlowType( state, 'sitetest' ) ).to.eql( 'pro' );
 		} );
 
@@ -357,6 +323,7 @@ describe( 'selectors', () => {
 					jetpackConnectSessions: {}
 				}
 			};
+
 			expect( getFlowType( state, { slug: 'sitetest' } ) ).to.be.false;
 		} );
 	} );
@@ -406,25 +373,69 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#hasXmlrpcError', () => {
+		const stateHasXmlrpcError = {
+			jetpackConnect: {
+				jetpackConnectAuthorize: {
+					authorizeError: {
+						message: 'transport error - HTTP status code was not 200 (502)'
+					},
+					authorizationCode: 'xxxx'
+				}
+			}
+		};
+
+		const stateHasNoError = {
+			jetpackConnect: {
+				jetpackConnectAuthorize: {
+					authorizeError: false
+				}
+			}
+		};
+
+		const stateHasNoAuthorizationCode = {
+			jetpackConnect: {
+				jetpackConnectAuthorize: {
+					authorizeError: {
+						message: 'Could not verify your request.'
+					}
+				}
+			}
+		};
+
+		const stateHasOtherError = {
+			jetpackConnect: {
+				jetpackConnectAuthorize: {
+					authorizeError: {
+						message: 'Jetpack: [already_connected] User already connected.'
+					},
+					authorizationCode: 'xxxx'
+				}
+			}
+		};
+
 		it( 'should be undefined when there is an empty state', () => {
 			const hasError = hasXmlrpcError( { jetpackConnect: {} } );
 			expect( hasError ).to.be.undefined;
 		} );
+
 		it( 'should be false when there is no error', () => {
 			const hasError = hasXmlrpcError( stateHasNoError );
 			expect( hasError ).to.be.false;
 		} );
+
 		it( 'should be undefined when there is no authorization code', () => {
 			// An authorization code is received during the jetpack.login portion of the connection
 			// XMLRPC errors happen only during jetpack.authorize which only happens after jetpack.login is succesful
 			const hasError = hasXmlrpcError( stateHasNoAuthorizationCode );
 			expect( hasError ).to.be.undefined;
 		} );
+
 		it( 'should be false if a non-xmlrpc error is found', () => {
 			// eg a user is already connected, or they've taken too long and their secret expired
 			const hasError = hasXmlrpcError( stateHasOtherError );
 			expect( hasError ).to.be.false;
 		} );
+
 		it( 'should be true if all the conditions are met', () => {
 			const hasError = hasXmlrpcError( stateHasXmlrpcError );
 			expect( hasError ).to.be.true;


### PR DESCRIPTION
This PR aims to change the Jetpack Connect components to access the state only by using selectors. Currently, there are many places where state is being manipulated directly.

To achieve this, the PR introduces several more selectors and integrates them within the JPC flows.  Tests are also included.

To test:

* Checkout this branch.
* Verify that there are no regressions within any of the JPC flows.
* Verify that all JPC state tests pass: `npm run test-client client/state/jetpack-connect/`.