### PR TITLE
Reader: Make subscription reception more defensive.

### DIFF
--- a/client/lib/reader-comment-email-subscriptions/index.js
+++ b/client/lib/reader-comment-email-subscriptions/index.js
@@ -18,13 +18,13 @@ const Emitter = require( 'lib/mixins/emitter' ),
 	States = require( './constants' ).state,
 	FeedSubscriptionActionTypes = require( 'lib/reader-feed-subscriptions/constants' ).action;
 
-var subscriptions = {},
+let subscriptions = {},
 	errors = [],
 	subscriptionTemplate = Immutable.Map( { // eslint-disable-line
 		state: States.SUBSCRIBED
 	} );
 
-var CommentEmailSubscriptionStore = {
+const CommentEmailSubscriptionStore = {
 
 	// Tentatively add the new subscription
 	// We haven't received confirmation from the API yet, but we want to update the UI
@@ -47,7 +47,7 @@ var CommentEmailSubscriptionStore = {
 	},
 
 	receiveSubscribeResponse: function( action ) {
-		var updatedSubscriptionInfo;
+		let updatedSubscriptionInfo;
 
 		if ( ! action.error && action.data && action.data.subscribed ) {
 			// The subscribe worked - discard any existing errors for this site
@@ -121,7 +121,7 @@ var CommentEmailSubscriptionStore = {
 	},
 
 	removeErrorsForBlog: function( blogId ) {
-		var newErrors = reject( errors, { blogId: blogId } );
+		const newErrors = reject( errors, { blogId: blogId } );
 
 		if ( newErrors.length === errors.length ) {
 			return false;
@@ -147,10 +147,11 @@ var CommentEmailSubscriptionStore = {
 
 	// Receive incoming subscriptions from feed subscription API response
 	receiveFeedSubscriptions: function( action ) {
-		var addedSubscriptionCount = 0,
+		let addedSubscriptionCount = 0,
 			emailSubscription;
 
-		if ( action.data && ( action.data.errors || ! action.data.subscriptions ) ) {
+		if ( ! action.data || (
+			action.data && ( action.data.errors || ! action.data.subscriptions ) ) ) {
 			return;
 		}
 
@@ -235,7 +236,7 @@ Emitter( CommentEmailSubscriptionStore ); // eslint-disable-line
 CommentEmailSubscriptionStore.setMaxListeners( 200 );
 
 CommentEmailSubscriptionStore.dispatchToken = Dispatcher.register( function( payload ) {
-	var action = payload.action;
+	const action = payload.action;
 
 	if ( ! action ) {
 		return;

--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -26,7 +26,7 @@ const subscriptionsTemplate = {
 	count: 0
 };
 
-var subscriptions = clone( subscriptionsTemplate ),
+let subscriptions = clone( subscriptionsTemplate ),
 	errors = [],
 	perPage = 50,
 	currentPage = 0,
@@ -37,12 +37,12 @@ var subscriptions = clone( subscriptionsTemplate ),
 		state: States.SUBSCRIBED
 	} );
 
-var FeedSubscriptionStore = {
+const FeedSubscriptionStore = {
 
 	// Tentatively add the new subscription
 	// We haven't received confirmation from the API yet, but we want to update the UI
 	receiveFollow: function( action ) {
-		var subscription = { URL: action.data.url };
+		const subscription = { URL: action.data.url };
 		debug( 'receiveFollow: ' + action.data.url );
 		if ( addSubscription( subscription ) ) {
 			FeedSubscriptionStore.emit( 'change' );
@@ -60,7 +60,7 @@ var FeedSubscriptionStore = {
 	},
 
 	receiveFollowResponse: function( action ) {
-		var updatedSubscriptionInfo;
+		let updatedSubscriptionInfo;
 
 		const siteUrl = FeedSubscriptionHelper.prepareSiteUrl( action.url );
 		debug( 'receiveFollowResponse: ' + siteUrl );
@@ -125,7 +125,7 @@ var FeedSubscriptionStore = {
 	},
 
 	receiveSubscriptions: function( data ) {
-		if ( ! data.subscriptions ) {
+		if ( ! ( data && data.subscriptions ) ) {
 			return;
 		}
 
@@ -209,7 +209,7 @@ var FeedSubscriptionStore = {
 	},
 
 	removeErrorsForSiteUrl: function( siteUrl ) {
-		var newErrors = reject( errors, { URL: FeedSubscriptionHelper.prepareSiteUrl( siteUrl ) } );
+		const newErrors = reject( errors, { URL: FeedSubscriptionHelper.prepareSiteUrl( siteUrl ) } );
 
 		if ( newErrors.length === errors.length ) {
 			return false;
@@ -364,7 +364,7 @@ Emitter( FeedSubscriptionStore ); // eslint-disable-line
 FeedSubscriptionStore.setMaxListeners( 100 );
 
 FeedSubscriptionStore.dispatchToken = Dispatcher.register( function( payload ) {
-	var action = payload.action;
+	const action = payload.action;
 
 	if ( ! action ) {
 		return;

--- a/client/lib/reader-post-email-subscriptions/index.js
+++ b/client/lib/reader-post-email-subscriptions/index.js
@@ -16,18 +16,18 @@ const Emitter = require( 'lib/mixins/emitter' ),
 	States = require( './constants' ).state,
 	FeedSubscriptionActionTypes = require( 'lib/reader-feed-subscriptions/constants' ).action;
 
-var subscriptions = {},
+let subscriptions = {},
 	errors = [],
 	subscriptionTemplate = Immutable.Map( { // eslint-disable-line
 		state: States.SUBSCRIBED
 	} );
 
-var PostEmailSubscriptionStore = {
+const PostEmailSubscriptionStore = {
 
 	// Tentatively add the new subscription
 	// We haven't received confirmation from the API yet, but we want to update the UI
 	receiveSubscribe: function( action ) {
-		var deliveryFrequency = 'instantly';
+		let deliveryFrequency = 'instantly';
 		if ( action.delivery_frequency ) {
 			deliveryFrequency = action.delivery_frequency;
 		}
@@ -50,7 +50,7 @@ var PostEmailSubscriptionStore = {
 	},
 
 	receiveSubscribeResponse: function( action ) {
-		var updatedSubscriptionInfo;
+		let updatedSubscriptionInfo;
 
 		if ( ! action.error && action.data && action.data.subscribed ) {
 			// The subscribe worked - discard any existing errors for this site
@@ -160,7 +160,7 @@ var PostEmailSubscriptionStore = {
 	},
 
 	removeErrorsForBlog: function( blogId ) {
-		var newErrors = reject( errors, { blogId: blogId } );
+		const newErrors = reject( errors, { blogId: blogId } );
 
 		if ( newErrors.length === errors.length ) {
 			return false;
@@ -186,10 +186,11 @@ var PostEmailSubscriptionStore = {
 
 	// Receive incoming subscriptions from feed subscription API response
 	receiveFeedSubscriptions: function( action ) {
-		var addedSubscriptionCount = 0,
+		let addedSubscriptionCount = 0,
 			postEmailSubscription;
 
-		if ( action.data && ( action.data.errors || ! action.data.subscriptions ) ) {
+		if ( ! action.data ||
+			( action.data && ( action.data.errors || ! action.data.subscriptions ) ) ) {
 			return;
 		}
 
@@ -279,7 +280,7 @@ Emitter( PostEmailSubscriptionStore ); // eslint-disable-line
 PostEmailSubscriptionStore.setMaxListeners( 200 );
 
 PostEmailSubscriptionStore.dispatchToken = Dispatcher.register( function( payload ) {
-	var action = payload.action;
+	const action = payload.action;
 
 	if ( ! action ) {
 		return;


### PR DESCRIPTION
Shouldn't throw when we get back missing sub data. Sometimes seen when an auth token half expires, like when a 2fa code invalidates.