### PR TITLE
layout/logged-out: Read secondary setting from sections.js

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import MasterbarLoggedOut from 'layout/masterbar/logged-out';
+import { hasSidebar } from 'state/ui/selectors';
 
 const LayoutLoggedOut = ( {
 	primary,
@@ -22,7 +23,7 @@ const LayoutLoggedOut = ( {
 		[ 'is-group-' + section.group ]: !! section,
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
-		'has-no-sidebar': true, // Logged-out never has a sidebar
+		'has-no-sidebar': ! this.props.hasSidebar,
 		'wp-singletree-layout': !! primary,
 	} );
 
@@ -57,6 +58,7 @@ LayoutLoggedOut.propTypes = {
 
 export default connect(
 	state => ( {
-		section: state.ui.section
+		section: state.ui.section,
+		hasSidebar: hasSidebar( state )
 	} )
 )( LayoutLoggedOut );

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var config = require( 'config' );
+var user = require( 'lib/user' );
 
 /**
  * Module variables
@@ -156,7 +157,7 @@ sections = [
 		paths: [ '/theme' ],
 		module: 'my-sites/theme',
 		enableLoggedOut: true,
-		secondary: false,
+		secondary: !! user.get(),
 		group: 'sites',
 		isomorphic: true,
 		title: 'Themes'


### PR DESCRIPTION
As discussed on Slack.

Little surprisingly, this doesn't work since it chokes on the ES6 in `lib/user` b/c of `server/bundler/loader` :-/

cc @mtias @folletto @seear
