### PR TITLE
Advanced SEO: show front page meta description in previews

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -86,7 +86,7 @@ const getSeoExcerptForSite = ( site ) => {
 	}
 
 	return formatExcerpt( find( [
-		get( site, 'options.seo_meta_description' ),
+		get( site, 'options.advanced_seo_front_page_description' ),
 		site.description
 	], identity ) );
 };


### PR DESCRIPTION
After the introduction of grandfathering, front page meta description
was not being shown correctly in previews. The reason behind that was
the introduction of new option name, that was not included in previews.