### PR TITLE
People: Add support for pasting in TokenField

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -233,7 +233,7 @@ var TokenField = React.createClass( {
 		const items = text.split( separator );
 
 		if ( items.length > 1 ) {
-			this._addNewToken( items.slice( 0, -1 ), { isBatchOperation: true } );
+			this._addNewTokens( items.slice( 0, -1 ) );
 		}
 
 		this.setState( {
@@ -473,27 +473,28 @@ var TokenField = React.createClass( {
 		} );
 	},
 
-	_addNewToken: function( token, { isBatchOperation = false } = {} ) {
-		const tokens = uniq(
-			( Array.isArray( token ) ? token : [ token ] )
+	_addNewTokens: function( tokens ) {
+		const tokensToAdd = uniq(
+			tokens
 				.map( this.props.saveTransform )
 				.filter( Boolean )
 				.filter( token => ! this._valueContainsToken( token ) )
 		);
+		debug( '_addNewTokens: tokensToAdd', tokensToAdd );
 
-		if ( tokens.length > 0 ) {
+		if ( tokensToAdd.length > 0 ) {
 			const newValue = clone( this.props.value );
 			newValue.splice.apply(
 				newValue,
-				[ this._getIndexOfInput(), 0 ].concat( tokens )
+				[ this._getIndexOfInput(), 0 ].concat( tokensToAdd )
 			);
-			debug( '_addNewToken: onChange', newValue );
+			debug( '_addNewTokens: onChange', newValue );
 			this.props.onChange( newValue );
 		}
+	},
 
-		if ( isBatchOperation ) {
-			return;
-		}
+	_addNewToken: function( token ) {
+		this._addNewTokens( [ token ] );
 
 		this.setState( {
 			incompleteTokenValue: '',

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -227,7 +227,9 @@ var TokenField = React.createClass( {
 	},
 
 	_handlePaste( text ) {
-		const items = text.split( /[ ,]+/ );
+		const separator = this.props.tokenizeOnSpace ? /[ ,]+/ : /,+/;
+		const items = text.split( separator );
+
 		const tokenizableItems = items
 			.slice( 0, -1 )
 			.filter( item => !! this.props.saveTransform( item ).length );

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -229,7 +229,7 @@ var TokenField = React.createClass( {
 
 	_onInputChange: function( event ) {
 		const text = event.value;
-		const separator = this.props.tokenizeOnSpace ? /[ ,]+/ : /,+/;
+		const separator = this.props.tokenizeOnSpace ? /[ ,\n\t]+/ : /[,\n\t]+/;
 		const items = text.split( separator );
 
 		if ( items.length > 1 ) {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -229,7 +229,7 @@ var TokenField = React.createClass( {
 
 	_onInputChange: function( event ) {
 		const text = event.value;
-		const separator = this.props.tokenizeOnSpace ? /[ ,\n\t]+/ : /[,\n\t]+/;
+		const separator = this.props.tokenizeOnSpace ? /[ ,\t]+/ : /[,\t]+/;
 		const items = text.split( separator );
 
 		if ( items.length > 1 ) {

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import map from 'lodash/map';
-import filter from 'lodash/filter';
-import { expect } from 'chai';
 import React from 'react';
+import { expect } from 'chai';
+import { filter, map } from 'lodash';
 import { test } from 'sinon';
 
 /**
@@ -93,7 +92,7 @@ describe( 'TokenField', function() {
 	}
 
 	function getSelectedSuggestion() {
-		var selectedSuggestions = getSuggestionsText( '.token-field__suggestion.is-selected' );
+		const selectedSuggestions = getSuggestionsText( '.token-field__suggestion.is-selected' );
 
 		return selectedSuggestions[ 0 ] || null;
 	}
@@ -411,6 +410,27 @@ describe( 'TokenField', function() {
 			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'of' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
+		} );
+
+		it( 'should add multiple comma-separated tokens when pasting', function() {
+			setText( 'baz, quux, wut' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux' ] );
+			expect( textInputNode.prop( 'value' ) ).to.equal( ' wut' );
+			setText( 'wut,' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux', 'wut' ] );
+			expect( textInputNode.prop( 'value' ) ).to.equal( '' );
+		} );
+
+		it( 'should add multiple newline-separated tokens when pasting', function() {
+			setText( 'baz\nquux\nwut' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux' ] );
+			expect( textInputNode.prop( 'value' ) ).to.equal( 'wut' );
+		} );
+
+		it( 'should add multiple tab-separated tokens when pasting', function() {
+			setText( 'baz\tquux\twut' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux' ] );
+			expect( textInputNode.prop( 'value' ) ).to.equal( 'wut' );
 		} );
 	} );
 

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -411,7 +411,9 @@ describe( 'TokenField', function() {
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'of' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
 		} );
+	} );
 
+	describe( 'adding multiple tokens when pasting', function() {
 		it( 'should add multiple comma-separated tokens when pasting', function() {
 			setText( 'baz, quux, wut' );
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux' ] );
@@ -431,6 +433,36 @@ describe( 'TokenField', function() {
 			setText( 'baz\tquux\twut' );
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux' ] );
 			expect( textInputNode.prop( 'value' ) ).to.equal( 'wut' );
+		} );
+
+		it( 'should not duplicate tokens when pasting', function() {
+			setText( 'baz \tbaz,  quux \nquux,quux , wut  \twut, wut' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux', 'wut' ] );
+			expect( textInputNode.prop( 'value' ) ).to.equal( ' wut' );
+		} );
+
+		it( 'should skip empty tokens at the beginning of a paste', function() {
+			setText( ',  ,\n \t  ,,baz, quux' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
+			expect( textInputNode.prop( 'value' ) ).to.equal( ' quux' );
+		} );
+
+		it( 'should skip empty tokens at the beginning of a paste', function() {
+			setText( ',  ,\n \t  ,,baz, quux' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
+			expect( textInputNode.prop( 'value' ) ).to.equal( ' quux' );
+		} );
+
+		it( 'should skip empty tokens in the middle of a paste', function() {
+			setText( 'baz,  ,\n \t  ,,quux' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
+			expect( textInputNode.prop( 'value' ) ).to.equal( 'quux' );
+		} );
+
+		it( 'should skip empty tokens at the end of a paste', function() {
+			setText( 'baz, quux,  ,\n \t  ,,   ' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux' ] );
+			expect( textInputNode.prop( 'value' ) ).to.equal( '   ' );
 		} );
 	} );
 

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -423,12 +423,6 @@ describe( 'TokenField', function() {
 			expect( textInputNode.prop( 'value' ) ).to.equal( '' );
 		} );
 
-		it( 'should add multiple newline-separated tokens when pasting', function() {
-			setText( 'baz\nquux\nwut' );
-			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux' ] );
-			expect( textInputNode.prop( 'value' ) ).to.equal( 'wut' );
-		} );
-
 		it( 'should add multiple tab-separated tokens when pasting', function() {
 			setText( 'baz\tquux\twut' );
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux' ] );
@@ -436,31 +430,31 @@ describe( 'TokenField', function() {
 		} );
 
 		it( 'should not duplicate tokens when pasting', function() {
-			setText( 'baz \tbaz,  quux \nquux,quux , wut  \twut, wut' );
+			setText( 'baz \tbaz,  quux \tquux,quux , wut  \twut, wut' );
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux', 'wut' ] );
 			expect( textInputNode.prop( 'value' ) ).to.equal( ' wut' );
 		} );
 
 		it( 'should skip empty tokens at the beginning of a paste', function() {
-			setText( ',  ,\n \t  ,,baz, quux' );
+			setText( ',  ,\t \t  ,,baz, quux' );
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
 			expect( textInputNode.prop( 'value' ) ).to.equal( ' quux' );
 		} );
 
 		it( 'should skip empty tokens at the beginning of a paste', function() {
-			setText( ',  ,\n \t  ,,baz, quux' );
+			setText( ',  ,\t \t  ,,baz, quux' );
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
 			expect( textInputNode.prop( 'value' ) ).to.equal( ' quux' );
 		} );
 
 		it( 'should skip empty tokens in the middle of a paste', function() {
-			setText( 'baz,  ,\n \t  ,,quux' );
+			setText( 'baz,  ,\t \t  ,,quux' );
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
 			expect( textInputNode.prop( 'value' ) ).to.equal( 'quux' );
 		} );
 
 		it( 'should skip empty tokens at the end of a paste', function() {
-			setText( 'baz, quux,  ,\n \t  ,,   ' );
+			setText( 'baz, quux,  ,\t \t  ,,   ' );
 			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz', 'quux' ] );
 			expect( textInputNode.prop( 'value' ) ).to.equal( '   ' );
 		} );


### PR DESCRIPTION
# Issue

Right now, pasting a list of usernames (comma- and/or space-separated) is broken in _People > Add_. Pasting results in one unique list being treated as a (obviously invalid) username:

![fix-invite-paste-broken](https://cloud.githubusercontent.com/assets/150562/19089897/03515204-8a74-11e6-88b2-cd05d69c50c7.gif)
# Fix

By scanning the value of `onChange` events for comma- and/or space-separated items, and manually adding potential tokens, pasting is supported:

![fix-invite-paste](https://cloud.githubusercontent.com/assets/150562/19089634/136a5f24-8a73-11e6-8f2d-73c65ea52e04.gif)

See p3Ex-1PZ-p2

/cc @nylen, as you seem to have touched `TokenField` the most: do you expect this to break somewhere else?
/cc @marekhrabe 
