### PR TITLE
Using UTC rather than local time for the post-streak

### DIFF
--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -14,6 +14,7 @@ import Month from './month';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
+import { getSiteOption } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	isRequestingSiteStatsForQuery,
@@ -183,6 +184,7 @@ export default connect( ( state ) => {
 	const query = {
 		startDate: i18n.moment().locale( 'en' ).subtract( 1, 'year' ).startOf( 'month' ).format( 'YYYY-MM-DD' ),
 		endDate: i18n.moment().locale( 'en' ).endOf( 'month' ).format( 'YYYY-MM-DD' ),
+		gmtOffset: getSiteOption( state, siteId, 'gmt_offset' ),
 		max: 3000
 	};
 

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -561,5 +561,3 @@ describe( 'selectors', () => {
 		} );
 	} );
 } );
-
-// get current plan missing

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -561,3 +561,5 @@ describe( 'selectors', () => {
 		} );
 	} );
 } );
+
+// get current plan missing

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -9,6 +9,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+import { getSite } from 'state/sites/selectors';
 import {
 	getSerializedStatsQuery,
 	normalizers
@@ -55,13 +56,15 @@ export function getSiteStatsForQuery( state, siteId, statType, query ) {
  */
 export const getSiteStatsPostStreakData = createSelector(
 	( state, siteId, query ) => {
+		const site = getSite( state, siteId );
 		const response = {};
 		const streakData = getSiteStatsForQuery( state, siteId, 'statsStreak', query );
 
 		if ( streakData && streakData.data ) {
 			Object.keys( streakData.data ).forEach( ( timestamp ) => {
-				const postDay = i18n.moment.unix( timestamp ).locale( 'en' );
-				const datestamp = postDay.utc().format( 'YYYY-MM-DD' );
+				const postDay = i18n.moment.unix( timestamp );
+				const datestamp = postDay.utcOffset( site.options.gmt_offset ).format( 'YYYY-MM-DD' );
+
 				if ( 'undefined' === typeof( response[ datestamp ] ) ) {
 					response[ datestamp ] = 0;
 				}

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -9,7 +9,6 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { getSite } from 'state/sites/selectors';
 import {
 	getSerializedStatsQuery,
 	normalizers
@@ -49,21 +48,21 @@ export function getSiteStatsForQuery( state, siteId, statType, query ) {
  * Returns a parsed object of statsStreak data for a given query, or default "empty" object
  * if no statsStreak data has been received for that site.
  *
- * @param  {Object}  state    Global state tree
- * @param  {Number}  siteId   Site ID
- * @param  {Object}  query    Stats query object
- * @return {Object}           Parsed Data for the query
+ * @param  {Object}  state    			Global state tree
+ * @param  {Number}  siteId   			Site ID
+ * @param  {Object}  query    			Stats query object
+ * @param  {?Number} query.gmtOffset    GMT offset of the queried site
+ * @return {Object}           			Parsed Data for the query
  */
 export const getSiteStatsPostStreakData = createSelector(
 	( state, siteId, query ) => {
-		const site = getSite( state, siteId );
+		const { gmtOffset = 0 } = query;
 		const response = {};
 		const streakData = getSiteStatsForQuery( state, siteId, 'statsStreak', query );
-
 		if ( streakData && streakData.data ) {
 			Object.keys( streakData.data ).forEach( ( timestamp ) => {
-				const postDay = i18n.moment.unix( timestamp );
-				const datestamp = postDay.utcOffset( site.options.gmt_offset ).format( 'YYYY-MM-DD' );
+				const postDay = i18n.moment.unix( timestamp ).locale( 'en' );
+				const datestamp = postDay.utcOffset( gmtOffset ).format( 'YYYY-MM-DD' );
 
 				if ( 'undefined' === typeof( response[ datestamp ] ) ) {
 					response[ datestamp ] = 0;

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -61,7 +61,7 @@ export const getSiteStatsPostStreakData = createSelector(
 		if ( streakData && streakData.data ) {
 			Object.keys( streakData.data ).forEach( ( timestamp ) => {
 				const postDay = i18n.moment.unix( timestamp ).locale( 'en' );
-				const datestamp = postDay.format( 'YYYY-MM-DD' );
+				const datestamp = postDay.utc().format( 'YYYY-MM-DD' );
 				if ( 'undefined' === typeof( response[ datestamp ] ) ) {
 					response[ datestamp ] = 0;
 				}

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -115,6 +115,16 @@ describe( 'selectors', () => {
 	describe( 'getSiteStatsPostStreakData()', () => {
 		it( 'should return an empty object if no matching query results exist', () => {
 			const stats = getSiteStatsPostStreakData( {
+				sites: {
+					items: {
+						2916284: {
+							options: {
+								gmt_offset: 0
+							},
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
 				stats: {
 					lists: {
 						items: {}
@@ -127,6 +137,16 @@ describe( 'selectors', () => {
 
 		it( 'should return properly formatted data if matching data for query exists', () => {
 			const stats = getSiteStatsPostStreakData( {
+				sites: {
+					items: {
+						2916284: {
+							options: {
+								gmt_offset: 0
+							},
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
 				stats: {
 					lists: {
 						items: {
@@ -157,6 +177,16 @@ describe( 'selectors', () => {
 	describe( 'getSiteStatsMaxPostsByDay()', () => {
 		it( 'should return null if no matching query results exist', () => {
 			const stats = getSiteStatsMaxPostsByDay( {
+				sites: {
+					items: {
+						2916284: {
+							options: {
+								gmt_offset: 0
+							},
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
 				stats: {
 					lists: {
 						items: {}
@@ -169,6 +199,16 @@ describe( 'selectors', () => {
 
 		it( 'should properly correct number of max posts grouped by day', () => {
 			const stats = getSiteStatsMaxPostsByDay( {
+				sites: {
+					items: {
+						2916284: {
+							options: {
+								gmt_offset: 0
+							},
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
 				stats: {
 					lists: {
 						items: {
@@ -193,6 +233,16 @@ describe( 'selectors', () => {
 
 		it( 'should compare numerically rather than lexically', () => {
 			const stats = getSiteStatsMaxPostsByDay( {
+				sites: {
+					items: {
+						2916284: {
+							options: {
+								gmt_offset: 0
+							},
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
 				stats: {
 					lists: {
 						items: {
@@ -218,6 +268,16 @@ describe( 'selectors', () => {
 	describe( 'getSiteStatsPostsCountByDay()', () => {
 		it( 'should return null if no matching query results exist', () => {
 			const stats = getSiteStatsPostsCountByDay( {
+				sites: {
+					items: {
+						2916284: {
+							options: {
+								gmt_offset: 0
+							},
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
 				stats: {
 					lists: {
 						items: {}
@@ -230,6 +290,16 @@ describe( 'selectors', () => {
 
 		it( 'should properly correct number of max posts for a day', () => {
 			const stats = getSiteStatsPostsCountByDay( {
+				sites: {
+					items: {
+						2916284: {
+							options: {
+								gmt_offset: 0
+							},
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
 				stats: {
 					lists: {
 						items: {

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -93,9 +93,9 @@ describe( 'selectors', () => {
 							2916284: {
 								statsStreak: {
 									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
-										1461961382: 1,
-										1464110402: 1,
-										1464110448: 1
+										1461889800: 1,	// 2016-04-29 00:30:00 (UTC)
+										1461972600: 1,	// 2016-04-29 23:30:00 (UTC)
+										1462059000: 1 	// 2016-04-30 23:30:00 (UTC)
 									}
 								}
 							}
@@ -105,9 +105,9 @@ describe( 'selectors', () => {
 			}, 2916284, 'statsStreak', { startDate: '2015-06-01', endDate: '2016-06-01' } );
 
 			expect( stats ).to.eql( {
-				1461961382: 1,
-				1464110402: 1,
-				1464110448: 1
+				1461889800: 1,
+				1461972600: 1,
+				1462059000: 1
 			} );
 		} );
 	} );
@@ -115,16 +115,6 @@ describe( 'selectors', () => {
 	describe( 'getSiteStatsPostStreakData()', () => {
 		it( 'should return an empty object if no matching query results exist', () => {
 			const stats = getSiteStatsPostStreakData( {
-				sites: {
-					items: {
-						2916284: {
-							options: {
-								gmt_offset: 0
-							},
-							URL: 'https://example.wordpress.com'
-						}
-					}
-				},
 				stats: {
 					lists: {
 						items: {}
@@ -137,16 +127,6 @@ describe( 'selectors', () => {
 
 		it( 'should return properly formatted data if matching data for query exists', () => {
 			const stats = getSiteStatsPostStreakData( {
-				sites: {
-					items: {
-						2916284: {
-							options: {
-								gmt_offset: 0
-							},
-							URL: 'https://example.wordpress.com'
-						}
-					}
-				},
 				stats: {
 					lists: {
 						items: {
@@ -155,9 +135,9 @@ describe( 'selectors', () => {
 									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
 										streak: {},
 										data: {
-											1461961382: 1,
-											1464110402: 1,
-											1464110448: 1
+											1461889800: 1,	// 2016-04-29 00:30:00 (UTC)
+											1461972600: 1,	// 2016-04-29 23:30:00 (UTC)
+											1462059000: 1 	// 2016-04-30 23:30:00 (UTC)
 										}
 									}
 								}
@@ -168,8 +148,82 @@ describe( 'selectors', () => {
 			}, 2916284, { startDate: '2015-06-01', endDate: '2016-06-01' } );
 
 			expect( stats ).to.eql( {
+				'2016-04-29': 2,
+				'2016-04-30': 1
+			} );
+		} );
+
+		it( 'should return post streak data based on the GMT offset of the current site', () => {
+			const state = {
+				stats: {
+					lists: {
+						items: {
+							2916284: {
+								statsStreak: {
+									[ '[["endDate","2016-06-01"],["gmtOffset",-10],["startDate","2015-06-01"]]' ]: {
+										streak: {},
+										data: {
+											1461889800: 1,	// 2016-04-29 00:30:00 (UTC)
+											1461972600: 1,	// 2016-04-29 23:30:00 (UTC)
+											1462059000: 1 	// 2016-04-30 23:30:00 (UTC)
+										}
+									},
+									[ '[["endDate","2016-06-01"],["gmtOffset",0],["startDate","2015-06-01"]]' ]: {
+										streak: {},
+										data: {
+											1461889800: 1,	// 2016-04-29 00:30:00 (UTC)
+											1461972600: 1,	// 2016-04-29 23:30:00 (UTC)
+											1462059000: 1 	// 2016-04-30 23:30:00 (UTC)
+										}
+									},
+									[ '[["endDate","2016-06-01"],["gmtOffset",10],["startDate","2015-06-01"]]' ]: {
+										streak: {},
+										data: {
+											1461889800: 1,	// 2016-04-29 00:30:00 (UTC)
+											1461972600: 1,	// 2016-04-29 23:30:00 (UTC)
+											1462059000: 1 	// 2016-04-30 23:30:00 (UTC)
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			};
+
+			const stats1 = getSiteStatsPostStreakData( state, 2916284, {
+				startDate: '2015-06-01',
+				endDate: '2016-06-01',
+				gmtOffset: -10
+			} );
+
+			const stats2 = getSiteStatsPostStreakData( state, 2916284, {
+				startDate: '2015-06-01',
+				endDate: '2016-06-01',
+				gmtOffset: 0
+			} );
+
+			const stats3 = getSiteStatsPostStreakData( state, 2916284, {
+				startDate: '2015-06-01',
+				endDate: '2016-06-01',
+				gmtOffset: 10
+			} );
+
+			expect( stats1 ).to.eql( {
+				'2016-04-28': 1,
 				'2016-04-29': 1,
-				'2016-05-24': 2
+				'2016-04-30': 1
+			} );
+
+			expect( stats2 ).to.eql( {
+				'2016-04-29': 2,
+				'2016-04-30': 1
+			} );
+
+			expect( stats3 ).to.eql( {
+				'2016-04-29': 1,
+				'2016-04-30': 1,
+				'2016-05-01': 1
 			} );
 		} );
 	} );
@@ -177,16 +231,6 @@ describe( 'selectors', () => {
 	describe( 'getSiteStatsMaxPostsByDay()', () => {
 		it( 'should return null if no matching query results exist', () => {
 			const stats = getSiteStatsMaxPostsByDay( {
-				sites: {
-					items: {
-						2916284: {
-							options: {
-								gmt_offset: 0
-							},
-							URL: 'https://example.wordpress.com'
-						}
-					}
-				},
 				stats: {
 					lists: {
 						items: {}
@@ -199,16 +243,6 @@ describe( 'selectors', () => {
 
 		it( 'should properly correct number of max posts grouped by day', () => {
 			const stats = getSiteStatsMaxPostsByDay( {
-				sites: {
-					items: {
-						2916284: {
-							options: {
-								gmt_offset: 0
-							},
-							URL: 'https://example.wordpress.com'
-						}
-					}
-				},
 				stats: {
 					lists: {
 						items: {
@@ -216,9 +250,9 @@ describe( 'selectors', () => {
 								statsStreak: {
 									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
 										data: {
-											1461961382: 1,
-											1464110402: 1,
-											1464110448: 1
+											1461889800: 1, // 2016-04-29 00:30:00 (UTC)
+											1461972600: 1, // 2016-04-29 23:30:00 (UTC)
+											1462059000: 1  // 2016-04-30 23:30:00 (UTC)
 										}
 									}
 								}
@@ -233,16 +267,6 @@ describe( 'selectors', () => {
 
 		it( 'should compare numerically rather than lexically', () => {
 			const stats = getSiteStatsMaxPostsByDay( {
-				sites: {
-					items: {
-						2916284: {
-							options: {
-								gmt_offset: 0
-							},
-							URL: 'https://example.wordpress.com'
-						}
-					}
-				},
 				stats: {
 					lists: {
 						items: {
@@ -250,8 +274,8 @@ describe( 'selectors', () => {
 								statsStreak: {
 									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
 										data: {
-											1461961382: 12,
-											1464110402: 2
+											1461889800: 12, // 2016-04-29 00:30:00 (UTC)
+											1462059000: 2 	// 2016-04-30 23:30:00 (UTC)
 										}
 									}
 								}
@@ -268,16 +292,6 @@ describe( 'selectors', () => {
 	describe( 'getSiteStatsPostsCountByDay()', () => {
 		it( 'should return null if no matching query results exist', () => {
 			const stats = getSiteStatsPostsCountByDay( {
-				sites: {
-					items: {
-						2916284: {
-							options: {
-								gmt_offset: 0
-							},
-							URL: 'https://example.wordpress.com'
-						}
-					}
-				},
 				stats: {
 					lists: {
 						items: {}
@@ -290,16 +304,6 @@ describe( 'selectors', () => {
 
 		it( 'should properly correct number of max posts for a day', () => {
 			const stats = getSiteStatsPostsCountByDay( {
-				sites: {
-					items: {
-						2916284: {
-							options: {
-								gmt_offset: 0
-							},
-							URL: 'https://example.wordpress.com'
-						}
-					}
-				},
 				stats: {
 					lists: {
 						items: {
@@ -307,9 +311,9 @@ describe( 'selectors', () => {
 								statsStreak: {
 									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
 										data: {
-											1461961382: 1,
-											1464110402: 1,
-											1464110448: 1
+											1461889800: 1,	// 2016-04-29 00:30:00 (UTC)
+											1461972600: 1,	// 2016-04-29 23:30:00 (UTC)
+											1462059000: 1	// 2016-04-30 23:30:00 (UTC)
 										}
 									}
 								}
@@ -317,7 +321,7 @@ describe( 'selectors', () => {
 						}
 					}
 				}
-			}, 2916284, { startDate: '2015-06-01', endDate: '2016-06-01' }, '2016-05-24' );
+			}, 2916284, { startDate: '2015-06-01', endDate: '2016-06-01' }, '2016-04-29' );
 
 			expect( stats ).to.eql( 2 );
 		} );


### PR DESCRIPTION
Hi All!

I'm running unit tests here in Australia and finding that certain tests fail due to my timezone.
Investigating these tests have led to finding a couple of potential bugs.

### Issue

It appears that when posts are shown on the post-streak graph, they are done so relative to the user's current time-zone. If the user changes their time zone or another account member looks at this graph in a different location there could be inconsistencies.

For example, when testing this I posted 2 posts yesterday, one was earlier than 11PM local time, one was shortly after 11PM local time (both on the 3rd of Oct).

When I changed my time-zone to be 1 hour ahead of my local time-zone the 11PM+ post appeared on the graph as being published on the 4th of Oct (In the future!) as shown below:

Actual local time:

<img width="208" alt="local-time" src="https://cloud.githubusercontent.com/assets/4335450/19091437/543cc7e8-8ace-11e6-93e0-902f61ea234f.png">

Manually set TZ to 1 hour ahead:

<img width="207" alt="one-hour-ahead" src="https://cloud.githubusercontent.com/assets/4335450/19091445/5d63e68a-8ace-11e6-95be-bb616906c3a0.png">

### Reproducing Functionality

Post a number of posts at different times (over different hours)

Note that these posts will appear on your graph as being posted on the same day as each other as expected.

Change your timezone to be far enough ahead of the last post time to push this in to the next day (if you posted at 14:30, make sure the TZ is 10 hours ahead of your local TZ)

Now note that that post is now listed as being authored the next day.

### Reproducing Failing Tests.

Manually set your timezone to be far in to the Western hemisphere (choosing Eastern Australia would be a exact match).

run client tests (npm run test-client)

Note that some tests now fail.

### Solution

To fix this I've updated the the line where moment.js is used to compare utc-based times rather than the local with the UTC value from the server.
This fixes the tests and, I believe, the functionality.

### Notes:

There will still be 1 test failing after applying this PR as this only fixes 2 out of 3.
I have a PR up for the other 1 @ #8462 