### PR TITLE
Using UTC rather than local time to determine whether or not first-vi…

### DIFF
--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -41,7 +41,7 @@ export function isUserEligible( state, config ) {
 		return false;
 	}
 
-	return moment( userStartDate ).isAfter( config.startDate );
+	return moment.utc( userStartDate ).isAfter( moment.utc( config.startDate ) );
 }
 
 export function isQueryStringEnabled( state, config ) {


### PR DESCRIPTION
Hi All!

I'm running unit tests here in Aus and finding that certain tests fail due to my timezone.
Investigating these tests have led to finding a couple of potential bugs.
### Issue

The issues arise when a date has a specific time that is 14:00 or later.
This is because Australian Eastern TZ is 10 hours ahead of UTC and when the time difference is accounted for making 14:00 becomes 24:00, thus the next day.
### Reproducing Functionality

I've not been able to see the issue in the flesh, it seems difficult to reproduce!
I'll try again to reproduce the behaviour this evening but, logically, I see this having a similar effect as my previous PR, whereby the user would be able to change the time zone and change the behaviour (as 'first-view/selectors:isUserEligible' could be true or false at the same 'time', depending on the set local time).

I'm hoping somebody who knows more about the 'first-view' could take a look in the mean-time, but no worries if not.
### Reproducing Failing Tests.

Manually set your timezone to be far in to the Western hemisphere (choosing Eastern Australia would be a exact match).

run client tests (npm run test-client)

Note that some tests now fail including a test for 'isUserEligible' in 'first-view/selectors/'
### Solution

To fix this I've updated the the line where moment.js is used to compare the users start date with the config start date to compare with UTC.
This fixes the tests and, possibly, the functionality.

Notes:

There may still be 2 tests failing after applying this PR as this only fixes 1 out of 3.
I have a PR for the other 2 @  #8458 
