### PR TITLE
SEO: Adds `x` to tokens to better indicate they can be deleted

### DIFF
--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -58,7 +58,7 @@
 }
 
 .title-format-editor__token {
-	padding: 2px 0px;
+	padding: 2px 0;
 	background-color: darken( $gray, 20% );
 	color: $white;
 	border-radius: 3px;
@@ -71,9 +71,8 @@
 }
 
 .title-format-editor__token-close {
-	margin-left: 10px;
-	color: lighten( $gray, 10% );
-	font-size: 10px;
+	margin-left: -4px;
+	margin-bottom: -5px;
 }
 
 .title-format-editor__preview {

--- a/client/components/title-format-editor/token.jsx
+++ b/client/components/title-format-editor/token.jsx
@@ -1,18 +1,51 @@
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 
-export const Token = props => {
-	const { onClick } = props;
+import Gridicon from 'components/gridicon';
 
-	// please ignore the formatting below
-	// if we allow spaces it will mess up
-	// the way the component renders in
-	// the draft-js editor
-	return (
-		<span
-			className="title-format-editor__token"
-			onClick={ onClick( props.entityKey ) }
-		>{ props.children }</span>
-	);
-};
+export class Token extends Component {
+	static propTypes = {
+		onClick: PropTypes.func,
+		onMouseEnter: PropTypes.func,
+		onMouseLeave: PropTypes.func,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isActive: false,
+		};
+	}
+
+	activate = () => this.setState( { isActive: true }, this.props.onMouseEnter );
+	deactivate = () => this.setState( { isActive: false }, this.props.onMouseLeave );
+
+	render() {
+		const {
+			children,
+			entityKey,
+			onClick,
+		} = this.props;
+		const { isActive } = this.state;
+
+		// please ignore the formatting below
+		// if we allow spaces it will mess up
+		// the way the component renders in
+		// the draft-js editor
+		return (
+			<span
+				className="title-format-editor__token"
+				onClick={ onClick( entityKey ) }
+				onMouseEnter={ this.activate }
+				onMouseLeave={ this.deactivate }
+			>{ children }{ isActive &&
+				<Gridicon
+					className="title-format-editor__token-close"
+					icon="cross-small"
+				/>
+			}</span>
+		);
+	}
+}
 
 export default Token;


### PR DESCRIPTION
Related to #8337 

Previously, the tokens in the title format editor simply turned red when
hovering over them with the mouse. This behavior was to indicate that by
clicking on the token it would be removed.

Because there are issues changing the contents of those tokens inside of
the draft-js editor, we did not provide the token from the get-go.

Now, I have added in a prototype (poorly-styled) `x` on hover and have
set the editor to _read-only_ during that hover state. By doing this we
can take control of the token without causing the cursor glitches there
when the content inside of the token is expanded.

**Further work before merging**
 - [ ] Fix styling issues
 - [ ] Decide if show-on-hover is the right idiom for interaction here

**Testing**
Open up the custom title format editor under **My Sites** > **Settings** > **SEO** for a site with a plan having at least the business level.

Edit a title format and include some tokens. Hover over the tokens and delete them by clicking on them. Pay attention to the way the `x` appears and disappears and if the behavior feels right and natural.

**Before**
![withouttokenxs](https://cloud.githubusercontent.com/assets/5431237/19096329/6bf3dd96-8a50-11e6-82d1-de4d98daa118.gif)

**After**
![withtokenxs](https://cloud.githubusercontent.com/assets/5431237/19096328/684c856c-8a50-11e6-96fa-d46f804c50a1.gif)

cc: @roundhill @drw158 @vindl @mtias @folletto 