### PR TITLE
Checkout: Add notice to checkout when purchasing domain from `get-dot-blog` signup

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -367,13 +367,16 @@ function businessPlan( slug, properties ) {
  *
  * @param {Object} productSlug - the unique string that identifies the product
  * @param {string} domain - domain name
+ * @param {string} source - optional source for the domain item, e.g. `getdotblog`.
  * @returns {Object} the new item as `CartItemValue` object
  */
-function domainItem( productSlug, domain ) {
-	return {
+function domainItem( productSlug, domain, source ) {
+	var extra = source ? { extra: { source: source } } : undefined;
+
+	return Object.assign( {
 		product_slug: productSlug,
 		meta: domain
-	};
+	}, extra );
 }
 
 function themeItem( themeSlug, source ) {
@@ -393,7 +396,7 @@ function themeItem( themeSlug, source ) {
  * @returns {Object} the new item as `CartItemValue` object
  */
 function domainRegistration( properties ) {
-	return assign( domainItem( properties.productSlug, properties.domain ), { is_domain_registration: true } );
+	return assign( domainItem( properties.productSlug, properties.domain, properties.source ), { is_domain_registration: true } );
 }
 
 /**
@@ -403,7 +406,7 @@ function domainRegistration( properties ) {
  * @returns {Object} the new item as `CartItemValue` object
  */
 function domainMapping( properties ) {
-	return domainItem( 'domain_map', properties.domain );
+	return domainItem( 'domain_map', properties.domain, properties.source );
 }
 
 /**
@@ -413,7 +416,7 @@ function domainMapping( properties ) {
  * @returns {Object} the new item as `CartItemValue` object
  */
 function siteRedirect( properties ) {
-	return domainItem( 'offsite_redirect', properties.domain );
+	return domainItem( 'offsite_redirect', properties.domain, properties.source );
 }
 
 /**
@@ -423,7 +426,7 @@ function siteRedirect( properties ) {
  * @returns {Object} the new item as `CartItemValue` object
  */
 function domainPrivacyProtection( properties ) {
-	return domainItem( 'private_whois', properties.domain );
+	return domainItem( 'private_whois', properties.domain, properties.source );
 }
 
 /**
@@ -433,7 +436,7 @@ function domainPrivacyProtection( properties ) {
  * @returns {Object} the new item as `CartItemValue` object
  */
 function domainRedemption( properties ) {
-	return domainItem( 'domain_redemption', properties.domain );
+	return domainItem( 'domain_redemption', properties.domain, properties.source );
 }
 
 function googleApps( properties ) {
@@ -443,7 +446,7 @@ function googleApps( properties ) {
 }
 
 function googleAppsExtraLicenses( properties ) {
-	var item = domainItem( 'gapps_extra_license', properties.domain );
+	var item = domainItem( 'gapps_extra_license', properties.domain, properties.source );
 
 	return assign( item, { extra: { google_apps_users: properties.users } } );
 }
@@ -573,7 +576,7 @@ function getRenewalItemFromProduct( product, properties ) {
 	let cartItem;
 
 	if ( isDomainProduct( product ) ) {
-		cartItem = domainItem( product.product_slug, properties.domain );
+		cartItem = domainItem( product.product_slug, properties.domain, properties.source );
 	}
 
 	if ( isPlan( product ) ) {

--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { defer } from 'lodash';
+import { find, defer } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +26,8 @@ import cartValues, {
 	isFree,
 	cartItems
 } from 'lib/cart-values';
+import Notice from 'components/notice';
+import { preventWidows } from 'lib/formatting';
 
 /**
  * Module variables
@@ -197,6 +199,23 @@ const SecurePaymentForm = React.createClass( {
 		);
 	},
 
+	renderGetDotBlogNotice() {
+		const hasProductFromGetDotBlogSignup = find( this.props.cart.products, product => (
+			product.extra && product.extra.source === 'get-dot-blog-signup'
+		) );
+
+		if ( this.state.visiblePaymentBox !== 'credit-card' || ! hasProductFromGetDotBlogSignup ) {
+			return;
+		}
+
+		return (
+			<Notice icon="notice" showDismiss={ false }>
+				{ preventWidows( this.translate( 'This is the payment information you entered on get.blog, ' +
+					'a WordPress.com service. Confirm your order below.' ), 4 ) }
+			</Notice>
+		);
+	},
+
 	renderPaymentBox() {
 		const { visiblePaymentBox } = this.state;
 		debug( 'getting %o payment box ...', visiblePaymentBox );
@@ -236,6 +255,7 @@ const SecurePaymentForm = React.createClass( {
 
 		return (
 			<div className="secure-payment-form">
+				{ this.renderGetDotBlogNotice() }
 				{ this.renderPaymentBox() }
 			</div>
 		);

--- a/client/signup/steps/get-dot-blog-plans/index.jsx
+++ b/client/signup/steps/get-dot-blog-plans/index.jsx
@@ -9,7 +9,10 @@ const GetDotBlogPlansStep = ( { queryObject, ...props } ) => (
 	<PlansStep
 		additionalStepData={ {
 			isPurchasingItem: true,
-			domainItem: cartItems.domainMapping( { domain: queryObject.domain } ),
+			domainItem: cartItems.domainMapping( {
+				domain: queryObject.domain,
+				source: 'get-dot-blog-signup'
+			} ),
 			siteUrl: queryObject.domain.replace( /\W+/g, '' )
 		} }
 		{ ...props }


### PR DESCRIPTION
<img width="753" alt="screen shot 2016-10-04 at 4 03 29 pm" src="https://cloud.githubusercontent.com/assets/1130674/19096293/0ab65496-8a50-11e6-8a7c-7f412043a61b.png">

This PR adds an optional `source` property to `domainItem` (following pattern established by `themeItem`) and uses it to display a notice to users that have purchased a domain through the `get-dot-blog` signup flow.

**Note:** The first eight commits in this PR are from #8431. Once that is merged, these commits can be removed and this will be ready for review.

**Testing**
- While logged in, visit http://calypso.localhost:3000/start/get-dot-blog?domain=example.com
- Proceed through signup. 
- When you land in checkout, assert that you see the above notice above your payment details.

- [x] Code
- [x] Product