### PR TITLE
Jetpack SSO: Fix usage of HelpButton

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -380,9 +380,6 @@ const JetpackSSOForm = React.createClass( {
 					action={ this.translate( 'Read Single Sign-On Documentation' ) }
 					actionURL="https://jetpack.com/support/sso/"
 				/>
-				<LoggedOutFormLinks>
-					<HelpButton />
-				</LoggedOutFormLinks>
 			</Main>
 		);
 	},
@@ -454,13 +451,11 @@ const JetpackSSOForm = React.createClass( {
 							onClick={ this.onCancelClick }>
 							{ this.getReturnToSiteText() }
 						</LoggedOutFormLinkItem>
+						<HelpButton />
 					</LoggedOutFormLinks>
 				</div>
 
 				{ this.renderSharedDetailsDialog() }
-				<LoggedOutFormLinks>
-					<HelpButton />
-				</LoggedOutFormLinks>
 			</MainWrapper>
 		);
 	}


### PR DESCRIPTION
When logging in via SSO today, I noticed this:

![screen shot 2016-10-04 at 8 47 48 pm](https://cloud.githubusercontent.com/assets/1126811/19097747/1f22a5d6-8a75-11e6-87c8-5df628b97e2f.png)

Notice the missing line between the help link and the return to site link.

I also noticed that the `HelpButton` component looked a bit janky when there are bad path args.

![screen shot 2016-10-04 at 8 53 22 pm](https://cloud.githubusercontent.com/assets/1126811/19097759/39c028aa-8a75-11e6-9c98-ede25f353f1d.png)

This PR removes the `HelpButton` component for bad path args and moves the `HelpButton` component so that it's with the other and gets the line separator treatment. It looks like this:

![screen shot 2016-10-04 at 8 53 10 pm](https://cloud.githubusercontent.com/assets/1126811/19097779/550f8d3a-8a75-11e6-838b-4b23b60d0236.png)


cc @tyxla and @roccotripaldi for review.
cc @rickybanister to verify the changes from a design perspective.

To test:

- Checkout `fix/sso-help-button-usage` branch
- Go to `$site/wp-admin` where `$site` is a Jetpack site
- Click "Login with WordPress.com" button
- Change `wordpress.com` in URL to be `calypso.localhost:3000`
- Verify help link has separator above it
- Go to `calypso.localhost:3000/sso` and verify that help button is not displayed.