### PR TITLE
Jetpack Sync: First pass at adding sync disabled error notice

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -44,7 +44,13 @@ const JetpackSyncPanel = React.createClass( {
 	isErrored() {
 		const syncRequestError = get( this.props, 'fullSyncRequest.error' );
 		const syncStatusErrorCount = get( this.props, 'syncStatus.errorCounter', 0 );
+
 		return !! ( syncRequestError || ( syncStatusErrorCount >= SYNC_STATUS_ERROR_NOTICE_THRESHOLD ) );
+	},
+
+	isSyncDisabled() {
+		const syncDisabled = 'sync_disabled' === get( this.props, 'syncStatus.error.error' );
+		return !! syncDisabled;
 	},
 
 	shouldDisableSync() {
@@ -81,7 +87,18 @@ const JetpackSyncPanel = React.createClass( {
 			syncStatusErrorCount = get( this.props, 'syncStatus.errorCounter', 0 );
 
 		let errorNotice = null;
-		if ( syncStatusErrorCount >= SYNC_STATUS_ERROR_NOTICE_THRESHOLD ) {
+
+		if ( 'sync_disabled' === get( this.props, 'syncStatus.error.error' ) ) {
+			errorNotice = (
+				<Notice isCompact status="is-error" classNAme="jetpack-sync-pane_error-notice">
+					{ this.translate( 'Sync is disabled on %(site)s.', {
+						args: {
+							site: get( this.props, 'site.name' )
+						}
+					} ) }
+				</Notice>
+			);
+		} else if ( syncStatusErrorCount >= SYNC_STATUS_ERROR_NOTICE_THRESHOLD ) {
 			const adminUrl = get( this.props, 'site.options.admin_url' );
 			errorNotice = (
 				<Notice isCompact status="is-error" className="jetpack-sync-panel__error-notice">
@@ -185,7 +202,9 @@ const JetpackSyncPanel = React.createClass( {
 					</div>
 
 					<div className="jetpack-sync-panel__action">
-						<Button onClick={ this.onSyncRequestButtonClick } disabled={ this.shouldDisableSync() }>
+						<Button
+							onClick={ this.onSyncRequestButtonClick }
+							disabled={ this.isSyncDisabled() || this.shouldDisableSync() }>
 							{ this.translate( 'Perform full sync', { context: 'Button' } ) }
 						</Button>
 					</div>


### PR DESCRIPTION
This PR is a first pass at handling the case where sync has been disabled for a site. This was added  to Jetpack Sync after the sync panel was first created.

To test:
- Checkout `update/jetpack-sync-show-disabled-error` branch in Calypso
- Checkout Automattic/jetpack#5260 on Jetpack site
- Disable sync for site
- Go to `/settings/general/$site`
- Ensure that error notice is displayed and sync button is disabled
- Enable sync
- Ensure sync panel works

cc @rickybanister for design review

<img width="741" alt="screen shot 2016-10-04 at 10 45 23 pm" src="https://cloud.githubusercontent.com/assets/1126811/19099422/40b8d5d0-8a84-11e6-94ce-5efe76efb928.png">

Note: This is functional, but could probably use some refactoring in the `renderErrorNotice` method and maybe adding some selectors instead of relying on `get()` so much.
