### PR TITLE
Fix the line height for select lists in Chrome

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -211,7 +211,6 @@ select {
 	outline: 0;
 	overflow: hidden;
 	font-size: 14px;
-	line-height: 21px;
 	font-weight: 600;
 	text-overflow: ellipsis;
 	text-decoration: none;


### PR DESCRIPTION
Fixes #8469 which means select lists cut-off vertically in Chrome

**Before PR (Chrome)**

![before pr](https://cloud.githubusercontent.com/assets/128826/19102029/447f4802-8b10-11e6-875f-6472dd1d56f3.png)

**After PR (Chrome)**

![after chrome](https://cloud.githubusercontent.com/assets/128826/19101742/235825a6-8b0e-11e6-83c2-17ef1af5e1f4.png)

**Testing Instructions**

Visit https://calypso.live/me/account?branch=fix/select-list-line-height-for-chrome in Chrome and check that English shows the full word now - compare to https://wordpress.com/me/account

Check other browsers are still displaying select lists with correct heights - I have checked Firefox, Safari, MS Edge, MS IE 11, and iOS Safari.