### PR TITLE
Signup: Make Site Title "Site Title" again.

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -22,12 +22,7 @@ import { PLAN_PREMIUM } from 'lib/plans/constants';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 
 function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsCartItem, isPurchasingItem, siteUrl, themeSlug, themeSlugWithRepo, themeItem } ) {
-
-	let siteTitle = getSiteTitle( this._reduxStore.getState() ).trim();
-
-	if ( '' === siteTitle ) {
-		siteTitle = siteUrl;
-	}
+	const siteTitle = getSiteTitle( this._reduxStore.getState() ).trim();
 
 	wpcom.undocumented().sitesNew( {
 		blog_name: siteUrl,


### PR DESCRIPTION
By merging #7386 I broke the way the default "Site Title" title for new sites work. The result was the reappearance of the blog address instead of "Site Title"

This PR fixes the behavior and properly restores "Site Title" to its glory.

To test:

1. Checkout branch or use the `calypso.live` link
2. Go through signup
3. See if the newly created site has a localized version of "Site Title" for the site title. 

cc @meremagee @michaeldcain 