### PR TITLE
Revert "Search styling overlay"

### DIFF
--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -54,11 +54,6 @@ Currently supports forcing a LTR field in a RTL language, but not the other way 
 
 Supported values are `'ltr'` and `undefined` (the default, which uses the current global writing direction of the app).
 
-### styleOverlay (optional) function ( default noop )
-Implement this function to add markup to the content of the search box. Current content is supplied as a parameter. Return a string containing the same text but with markup added.
-
-For example, add `<span/>`s around tokens in the content, then add CSS elsewhere to style the `<span/>`s.
-
 ## Methods
 
 ### getCurrentSearchValue()

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -52,7 +52,6 @@ const Search = React.createClass( {
 		onSearchOpen: PropTypes.func,
 		onSearchClose: PropTypes.func,
 		analyticsGroup: PropTypes.string,
-		overlayStyling: PropTypes.func,
 		autoFocus: PropTypes.bool,
 		disabled: PropTypes.bool,
 		onKeyDown: PropTypes.func,
@@ -85,7 +84,6 @@ const Search = React.createClass( {
 			onSearchOpen: noop,
 			onSearchClose: noop,
 			onKeyDown: noop,
-			overlayStyling: noop,
 			disableAutocorrect: false,
 			searching: false,
 			isOpen: false,
@@ -125,7 +123,6 @@ const Search = React.createClass( {
 	},
 
 	componentDidUpdate: function( prevProps, prevState ) {
-		this.scrollOverlay();
 		// Focus if the search box was opened or the autoFocus prop has changed
 		if (
 			( this.state.isOpen && ! prevState.isOpen ) ||
@@ -162,12 +159,6 @@ const Search = React.createClass( {
 		if ( this.props.autoFocus ) {
 			this.focus();
 		}
-	},
-
-	scrollOverlay: function() {
-		window.requestAnimationFrame( () => {
-			this.refs.overlay.scrollLeft = this.refs.searchInput.scrollLeft;
-		} );
 	},
 
 	focus: function() {
@@ -251,11 +242,9 @@ const Search = React.createClass( {
 		if ( event.key === 'Escape' ) {
 			this.closeSearch( event );
 		}
-		this.scrollOverlay();
 	},
 
 	keyDown: function( event ) {
-		this.scrollOverlay();
 		if ( event.key === 'Escape' && event.target.value === '' ) {
 			this.closeSearch( event );
 		}
@@ -342,9 +331,6 @@ const Search = React.createClass( {
 						maxLength={ this.props.maxLength }
 						{ ...autocorrect }
 					/>
-					<div className="search__text-overlay" ref="overlay">
-						{ this.props.overlayStyling( this.state.keyword ) }
-					</div>
 				</div>
 				{ this.closeButton() }
 			</div>

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -122,37 +122,19 @@
 		flex: 1 1 auto;
 		height: 100%;
 		position: relative;
-		font-size: 16px;
 		border-radius: inherit;
 		&::before {
-			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 2 );
+			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
 			border-radius: inherit;
 		}
 
 		&.ltr { /*rtl:ignore*/
 			&::before {
-				@include long-content-fade( $direction: right, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 2 );
+				@include long-content-fade( $direction: right, $size: 32px, $color: $white, $z-index: z-index( '.search', '.search__input' ) + 1 );
 				border-radius: inherit;
 			}
 		}
 	}
-}
-
-.search__input-fade .search__text-overlay {
-	color: transparent;
-	position: absolute;
-	pointer-events: none;
-	white-space: nowrap;
-	display: flex;
-	align-items: center;
-	flex: 1 1 auto;
-	overflow: hidden;
-	font: inherit;
-	width: 100%;
-	height: 100%;
-	top: 0px;
-	left: 0px;
-	z-index: z-index( '.search', '.search__input' ) + 1;
 }
 
 .search .spinner {

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -230,7 +230,7 @@ export function getFilter( term ) {
  * @param {string} filter - filter in form taxonomy:term
  * @return {boolean} true if filter pair is valid
  */
-export function filterIsValid( filter ) {
+function filterIsValid( filter ) {
 	return getTermTable()[ getTerm( filter ) ] === getTaxonomy( filter );
 }
 

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -13,7 +13,6 @@ import SegmentedControl from 'components/segmented-control';
 import { trackClick } from '../helpers';
 import config from 'config';
 import { isMobile } from 'lib/viewport';
-import { filterIsValid } from '../theme-filters.js';
 
 const ThemesMagicSearchCard = React.createClass( {
 	propTypes: {
@@ -66,24 +65,6 @@ const ThemesMagicSearchCard = React.createClass( {
 		this.setState( { searchIsOpen: false } );
 	},
 
-	searchTokens( input ) {
-		const tokens = input.split( /(\s+)/ );
-
-		return (
-			tokens.map( ( token, i ) => {
-				let classname = 'search-tokens__text';
-
-				if ( token.trim() === '' ) {
-					classname = 'search-tokens__white-space';
-				} else if ( filterIsValid( token ) ) {
-					classname = 'search-tokens__token';
-				}
-
-				return <span className={ classname } key={ i }>{ token }</span>; // use shortid for key
-			} )
-		);
-	},
-
 	render() {
 		const isJetpack = this.props.site && this.props.site.jetpack;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
@@ -104,7 +85,6 @@ const ThemesMagicSearchCard = React.createClass( {
 				delaySearch={ true }
 				onSearchOpen={ this.onSearchOpen }
 				onSearchClose={ this.onSearchClose }
-				overlayStyling={ this.searchTokens }
 				onBlur={ this.onBlur }
 				fitsContainer={ this.state.isMobile && this.state.searchIsOpen }
 				hideClose={ isMobile() }

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -43,20 +43,3 @@
 	}
 
 }
-
-.search-tokens__token {
-	font: inherit;
-	pointer-events: none;
-	background-color: rgba(0, 0, 255, 0.2);
-}
-
-.search-tokens__text{
-	font: inherit;
-	pointer-events: none;
-}
-
-.search-tokens__white-space {
-	font: inherit;
-	pointer-events: none;
-	white-space: pre;
-}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#8395

fixes `Uncaught TypeError: Cannot read property 'scrollLeft' of undefined`
