### PR TITLE
Advanced SEO: Fix update request for site verification services

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -225,7 +225,9 @@ export const SeoForm = React.createClass( {
 		const {
 			site,
 			storedTitleFormats,
-			trackSubmission
+			trackSubmission,
+			showAdvancedSeo,
+			showWebsiteMeta
 		} = this.props;
 
 		const { dirtyFields } = this.state;
@@ -275,9 +277,15 @@ export const SeoForm = React.createClass( {
 			advanced_seo_title_formats: seoTitleToApi(
 				pickBy( this.state.seoTitleFormats, hasChanges )
 			),
-			advanced_seo_front_page_description: this.state.frontPageMetaDescription,
 			verification_services_codes: filteredCodes
 		};
+
+		// Update this option only if advanced SEO is enabled or grandfathered in order to
+		// avoid request errors on non-business sites when they attempt site verification
+		// services update
+		if ( showAdvancedSeo || showWebsiteMeta ) {
+			updatedOptions.advanced_seo_front_page_description = this.state.frontPageMetaDescription;
+		}
 
 		site.saveSettings( updatedOptions, error => {
 			if ( error ) {


### PR DESCRIPTION
The SEO form was always submitting Front page meta description on save,
even for non-business users that didn't see that feature. That caused the
update request for site verification services to fail, since it was triggering 
the business plan check on the API side.

Testing: 
1. Navigate to SEO settings page of a non-business test site.
2. Attempt to save site verification code and verify that the request succeeds. 


