### PR TITLE
Disable image editor on image being uploaded + add util isItemBeingUploaded fn

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -569,4 +569,22 @@ describe( 'MediaUtils', function() {
 			expect( MediaUtils.canUserDeleteItem( item, user, site ) ).to.be.true;
 		} );
 	} );
+
+	describe( '#isItemBeingUploaded()', () => {
+		it( 'should return null if item was not specified', () => {
+			expect( MediaUtils.isItemBeingUploaded() ).to.be.null;
+		} );
+
+		it( 'should return true if the item is currently being uploaded', () => {
+			const item = { 'transient': true };
+
+			expect( MediaUtils.isItemBeingUploaded( item ) ).to.be.true;
+		} );
+
+		it( 'should return false if the item is not being uploaded', () => {
+			const item = {};
+
+			expect( MediaUtils.isItemBeingUploaded( item ) ).to.be.false;
+		} );
+	} );
 } );

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -482,6 +482,20 @@ const MediaUtils = {
 		}
 
 		canvas.toBlob( callback, type, quality );
+	},
+
+	/**
+	 * Returns true if specified item is currently being uploaded (i.e. is transient).
+	 *
+	 * @param  {Object}  item Media item
+	 * @return {Boolean}      Whether item is being uploaded
+	 */
+	isItemBeingUploaded( item ) {
+		if ( ! item ) {
+			return null;
+		}
+
+		return !! item.transient;
 	}
 };
 

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -1,56 +1,61 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	noop = require( 'lodash/noop' ),
-	debug = require( 'debug' )( 'calypso:post-editor:media:detail-item' );
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import { noop } from 'lodash';
+import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var EditorMediaModalDetailFields = require( './detail-fields' ),
-	EditorMediaModalDetailFileInfo = require( './detail-file-info' ),
-	EditorMediaModalDetailPreviewImage = require( './detail-preview-image' ),
-	EditorMediaModalDetailPreviewVideo = require( './detail-preview-video' ),
-	EditorMediaModalDetailPreviewAudio = require( './detail-preview-audio' ),
-	EditorMediaModalDetailPreviewDocument = require( './detail-preview-document' ),
-	Button = require( 'components/button' ),
-	Gridicon = require( 'components/gridicon' ),
-	userCan = require( 'lib/site/utils' ).userCan,
-	isJetpack = require( 'lib/site/utils' ).isJetpack,
-	MediaUtils = require( 'lib/media/utils' ),
-	config = require( 'config' );
+import EditorMediaModalDetailFields from './detail-fields';
+import EditorMediaModalDetailFileInfo from './detail-file-info';
+import EditorMediaModalDetailPreviewImage from './detail-preview-image';
+import EditorMediaModalDetailPreviewVideo from './detail-preview-video';
+import EditorMediaModalDetailPreviewAudio from './detail-preview-audio';
+import EditorMediaModalDetailPreviewDocument from './detail-preview-document';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import { userCan, isJetpack } from 'lib/site/utils';
+import MediaUtils from 'lib/media/utils';
+import config from 'config';
 
-module.exports = React.createClass( {
-	displayName: 'EditorMediaModalDetailItem',
+const debug = debugFactory( 'calypso:post-editor:media:detail-item' );
 
-	propTypes: {
-		site: React.PropTypes.object,
-		item: React.PropTypes.object,
-		hasPreviousItem: React.PropTypes.bool,
-		hasNextItem: React.PropTypes.bool,
-		onShowPreviousItem: React.PropTypes.func,
-		onShowNextItem: React.PropTypes.func,
-		onEdit: React.PropTypes.func
-	},
+class EditorMediaModalDetailItem extends Component {
+	static propTypes = {
+		site: PropTypes.object,
+		item: PropTypes.object,
+		hasPreviousItem: PropTypes.bool,
+		hasNextItem: PropTypes.bool,
+		onShowPreviousItem: PropTypes.func,
+		onShowNextItem: PropTypes.func,
+		onEdit: PropTypes.func
+	};
 
-	getDefaultProps: function() {
-		return {
-			hasPreviousItem: false,
-			hasNextItem: false,
-			onShowPreviousItem: noop,
-			onShowNextItem: noop,
-			onEdit: noop
-		};
-	},
+	static defaultProps = {
+		hasPreviousItem: false,
+		hasNextItem: false,
+		onShowPreviousItem: noop,
+		onShowNextItem: noop,
+		onEdit: noop
+	};
 
-	renderEditButton: function( className ) {
-		const { item, onEdit, site } = this.props;
+	renderEditButton( className ) {
+		const {
+			item,
+			onEdit,
+			site,
+			translate
+		} = this.props;
 
 		// Do not render edit button for private sites
 		if ( site.is_private ) {
-			return debug( 'Do not show `Edit button` for private sites' );
+			debug( 'Do not show `Edit button` for private sites' );
+
+			return null;
 		}
 
 		if (
@@ -59,94 +64,116 @@ module.exports = React.createClass( {
 			isJetpack( site ) ||
 			! item
 		) {
-			return;
+			return null;
 		}
 
 		const mimePrefix = MediaUtils.getMimePrefix( item );
 
 		if ( 'image' !== mimePrefix ) {
-			return;
+			return null;
 		}
 
 		return (
 			<Button
 				className={ classNames( 'editor-media-modal-detail__edit', className ) }
 				onClick={ onEdit }>
-				<Gridicon icon="pencil" size={ 36 } /> { this.translate( 'Edit Image' ) }
+				<Gridicon icon="pencil" size={ 36 } /> { translate( 'Edit Image' ) }
 			</Button>
 		);
-	},
+	}
 
-	renderFields: function() {
-		if ( ! userCan( 'upload_files', this.props.site ) ) {
-			return;
+	renderFields() {
+		const { site, item } = this.props;
+
+		if ( ! userCan( 'upload_files', site ) ) {
+			return null;
 		}
 
 		return (
 			<EditorMediaModalDetailFields
-				site={ this.props.site }
-				item={ this.props.item } />
+				site={ site }
+				item={ item } />
 		);
-	},
+	}
 
-	renderPreviousItemButton: function() {
-		if ( ! this.props.hasPreviousItem ) {
-			return;
+	renderPreviousItemButton() {
+		const {
+			hasPreviousItem,
+			onShowPreviousItem,
+			translate
+		} = this.props;
+
+		if ( ! hasPreviousItem ) {
+			return null;
 		}
 
 		return (
 			<button
-				onClick={ this.props.onShowPreviousItem }
+				onClick={ onShowPreviousItem }
 				className="editor-media-modal-detail__previous">
 				<Gridicon icon="chevron-left" size={ 36 } />
 				<span className="screen-reader-text">
-					{ this.translate( 'Previous' ) }
+					{ translate( 'Previous' ) }
 				</span>
 			</button>
 		);
-	},
+	}
 
-	renderNextItemButton: function() {
-		if ( ! this.props.hasNextItem ) {
-			return;
+	renderNextItemButton() {
+		const {
+			hasNextItem,
+			onShowNextItem,
+			translate
+		} = this.props;
+
+		if ( ! hasNextItem ) {
+			return null;
 		}
 
 		return (
 			<button
-				onClick={ this.props.onShowNextItem }
+				onClick={ onShowNextItem }
 				className="editor-media-modal-detail__next">
 				<Gridicon icon="chevron-right" size={ 36 } />
 				<span className="screen-reader-text">
-					{ this.translate( 'Next' ) }
+					{ translate( 'Next' ) }
 				</span>
 			</button>
 		);
-	},
+	}
 
-	renderItem: function() {
-		var mimePrefix, Component;
+	renderItem() {
+		const {
+			item,
+			site
+		} = this.props;
 
-		if ( ! this.props.item ) {
-			return;
+		if ( ! item ) {
+			return null;
 		}
 
-		mimePrefix = MediaUtils.getMimePrefix( this.props.item );
+		const mimePrefix = MediaUtils.getMimePrefix( item );
+
+		let Item;
+
 		switch ( mimePrefix ) {
-			case 'image': Component = EditorMediaModalDetailPreviewImage; break;
-			case 'video': Component = EditorMediaModalDetailPreviewVideo; break;
-			case 'audio': Component = EditorMediaModalDetailPreviewAudio; break;
-			default: Component = EditorMediaModalDetailPreviewDocument; break;
+			case 'image': Item = EditorMediaModalDetailPreviewImage; break;
+			case 'video': Item = EditorMediaModalDetailPreviewVideo; break;
+			case 'audio': Item = EditorMediaModalDetailPreviewAudio; break;
+			default: Item = EditorMediaModalDetailPreviewDocument; break;
 		}
 
-		return React.createElement( Component, {
-			site: this.props.site,
-			item: this.props.item
+		return React.createElement( Item, {
+			site: site,
+			item: item
 		} );
-	},
+	}
 
-	render: function() {
-		var classes = classNames( 'editor-media-modal-detail__item', {
-			'is-loading': ! this.props.item
+	render() {
+		const { item } = this.props;
+
+		const classes = classNames( 'editor-media-modal-detail__item', {
+			'is-loading': ! item
 		} );
 
 		return (
@@ -162,10 +189,12 @@ module.exports = React.createClass( {
 						{ this.renderEditButton( 'is-mobile' ) }
 						{ this.renderFields() }
 						<EditorMediaModalDetailFileInfo
-							item={ this.props.item } />
+							item={ item } />
 					</div>
 				</div>
 			</figure>
 		);
 	}
-} );
+}
+
+export default localize( EditorMediaModalDetailItem );

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -19,7 +19,7 @@ import EditorMediaModalDetailPreviewDocument from './detail-preview-document';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { userCan, isJetpack } from 'lib/site/utils';
-import MediaUtils from 'lib/media/utils';
+import MediaUtils, { isItemBeingUploaded } from 'lib/media/utils';
 import config from 'config';
 
 const debug = debugFactory( 'calypso:post-editor:media:detail-item' );
@@ -76,7 +76,9 @@ class EditorMediaModalDetailItem extends Component {
 		return (
 			<Button
 				className={ classNames( 'editor-media-modal-detail__edit', className ) }
-				onClick={ onEdit }>
+				onClick={ onEdit }
+				disabled={ isItemBeingUploaded( item ) }
+			>
 				<Gridicon icon="pencil" size={ 36 } /> { translate( 'Edit Image' ) }
 			</Button>
 		);


### PR DESCRIPTION
Fixes #8452. After editing an image, it is being uploaded to our servers. However, users are still able to preview and modify meta properties of this image. In the PR, we add `disabled` attr to Edit Image btn while the image is being uploaded. We remove the attr after uploading is finished.

We also add a utility function for checking whether a media item is being uploaded. Tests are included as well.

## Testing

1. Open image editor on some image;
2. Click on "Done" so that the image is saved and being uploaded;
3. Click Edit on the image which is currently being uploaded;
4. Is the Edit Image button disabled? Does its `disabled` state changes to normal after the image is uploaded?

## Screenshot

![selection_027](https://cloud.githubusercontent.com/assets/4988512/19111722/5d0e3a9a-8b01-11e6-96dc-8ef1f2840829.jpg)

/cc @gwwar @artpi 

## Additional issue

In our team hangout, we thought that you can edit meta data of the image which is currently being uploaded. While that's true, after the image is uploaded, the meta is discarded and replaced with empty one. Q: should we still pursue the above approach of disabling image editor in currently uploaded image? If yes, before enabling image editor on prod, we need to have the issue fixed.