### PR TITLE
jetpack connect: plans selection view with an already selected plan

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -40,7 +40,15 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 class ProductPurchaseFeaturesList extends Component {
 	static propTypes = {
 		plan: PropTypes
-			.oneOf( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ] )
+			.oneOf( [ PLAN_FREE,
+				PLAN_PERSONAL,
+				PLAN_PREMIUM,
+				PLAN_BUSINESS,
+				PLAN_JETPACK_FREE,
+				PLAN_JETPACK_BUSINESS,
+				PLAN_JETPACK_BUSINESS_MONTHLY,
+				PLAN_JETPACK_PREMIUM,
+				PLAN_JETPACK_PREMIUM_MONTHLY ] )
 			.isRequired,
 		isPlaceholder: PropTypes.bool
 	};

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -60,7 +60,7 @@ const Plans = React.createClass( {
 	},
 
 	componentDidUpdate() {
-		if ( this.hasPlan( this.props.selectedSite ) ) {
+		if ( this.props.hasPaidPlan ) {
 			page.redirect( CALYPSO_PLAN_PAGE + this.props.selectedSite.slug );
 		}
 		if ( ! this.props.canPurchasePlans ) {
@@ -70,12 +70,6 @@ const Plans = React.createClass( {
 		if ( ! this.props.isRequestingPlans && ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) ) {
 			return this.autoselectPlan();
 		}
-	},
-
-	hasPlan( site ) {
-		return site &&
-			site.plan &&
-			( site.plan.product_slug === 'jetpack_business' || site.plan.product_slug === 'jetpack_premium' );
 	},
 
 	autoselectPlan() {
@@ -133,7 +127,7 @@ const Plans = React.createClass( {
 			return null;
 		}
 
-		if ( ! this.props.canPurchasePlans || this.hasPlan( this.props.selectedSite ) ) {
+		if ( ! this.props.canPurchasePlans || this.props.hasPaidPlan ) {
 			return null;
 		}
 

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -60,15 +60,20 @@ const Plans = React.createClass( {
 	},
 
 	componentDidUpdate() {
-		if ( this.props.hasPaidPlan ) {
-			page.redirect( CALYPSO_PLAN_PAGE + this.props.selectedSite.slug );
-		}
-		if ( ! this.props.canPurchasePlans ) {
-			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
-		}
+		if ( this.props.calypsoStartedConnection ) {
+			if ( this.props.hasPaidPlan ) {
+				page.redirect( CALYPSO_PLAN_PAGE + this.props.selectedSite.slug );
+			}
+			if ( ! this.props.canPurchasePlans ) {
+				page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
+			}
 
-		if ( ! this.props.isRequestingPlans && ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) ) {
-			return this.autoselectPlan();
+			if ( ! this.props.isRequestingPlans && ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) ) {
+				return this.autoselectPlan();
+			}
+		} else if ( this.props.hasPaidPlan || ! this.props.canPurchasePlans ) {
+			const { queryObject } = this.props.jetpackConnectAuthorize;
+			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		}
 	},
 
@@ -96,7 +101,7 @@ const Plans = React.createClass( {
 			user: this.props.userId
 		} );
 		if ( this.props.calypsoStartedConnection ) {
-			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
+			page.redirect( CALYPSO_PLAN_PAGE + this.props.selectedSite.slug );
 		} else {
 			const { queryObject } = this.props.jetpackConnectAuthorize;
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -172,7 +172,7 @@ export default connect(
 			return getPlanBySlug( state, planSlug );
 		};
 
-		const hasPaidPlan = isCurrentPlanPaid( state, selectedSite.id );
+		const hasPaidPlan = isCurrentPlanPaid( state, selectedSite.ID );
 
 		return {
 			selectedSite,

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -150,7 +150,7 @@ const Plans = React.createClass( {
 						<div id="plans">
 							<PlansFeaturesMain
 								site={ this.props.selectedSite }
-								isInSignup={ true }
+								isInSignup={ false }
 								isInJetpackConnect={ true }
 								onUpgradeClick={ this.selectPlan }
 								intervalType={ this.props.intervalType } />

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -10,6 +10,7 @@ import { bindActionCreators } from 'redux';
  * Internal dependencies
  */
 import { getPlansBySite } from 'state/sites/plans/selectors';
+import { isCurrentPlanPaid } from 'state/sites/selectors';
 import { getFlowType } from 'state/jetpack-connect/selectors';
 import Main from 'components/main';
 import StepHeader from '../step-header';
@@ -28,6 +29,7 @@ import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
+const CALYPSO_PLAN_PAGE = '/plans/my-plan/';
 
 const Plans = React.createClass( {
 	mixins: [ observe( 'plans' ) ],
@@ -59,7 +61,7 @@ const Plans = React.createClass( {
 
 	componentDidUpdate() {
 		if ( this.hasPlan( this.props.selectedSite ) ) {
-			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
+			page.redirect( CALYPSO_PLAN_PAGE + this.props.selectedSite.slug );
 		}
 		if ( ! this.props.canPurchasePlans ) {
 			page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
@@ -150,7 +152,7 @@ const Plans = React.createClass( {
 						<div id="plans">
 							<PlansFeaturesMain
 								site={ this.props.selectedSite }
-								isInSignup={ false }
+								isInSignup={ ! this.props.hasPaidPlan }
 								isInJetpackConnect={ true }
 								onUpgradeClick={ this.selectPlan }
 								intervalType={ this.props.intervalType } />
@@ -171,8 +173,11 @@ export default connect(
 			return getPlanBySlug( state, planSlug );
 		};
 
+		const hasPaidPlan = isCurrentPlanPaid( state, selectedSite.id );
+
 		return {
 			selectedSite,
+			hasPaidPlan: hasPaidPlan,
 			sitePlans: getPlansBySite( state, selectedSite ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),
 			userId: user ? user.ID : null,


### PR DESCRIPTION
In the current master branch, when you are reconnecting a jetpack site with a monthly plan, you end in the plans selection page with all the buttons shown ready for a purchase, as if you didn't have a plan already. 
![image](https://cloud.githubusercontent.com/assets/1554855/19119938/a2aaffbe-8b21-11e6-8661-6ee4f5e5cd3d.png)

This happens only with monthly plans because of a fault in the way we were checking if the currently selected plan is a paid one.

With this PR, when you are connecting a site that already has a plan, you will always be redirected to /my-plan page in case you started the connection in calypso, or back to your wp-admin if you started from there.

![image](https://cloud.githubusercontent.com/assets/1554855/19120604/a201c37a-8b23-11e6-94a3-31cf0b9b7d2c.png)
# how to test
1. You need a jetpack site with a paid monthly plan
2. Disconnect jetpack and go to http://calypso.localhost:3000/jetpack/connect and connect it again
3. After the connection is done, you should end in /plans/my-plan

2b. You can also try this reconnecting the site from wp-admin, but for this you will need to have your jetpack pointing to your .com sandbox and modify it to make sure the auth flow is redirected to your local calypso. If you really want to test this, ask me or @roccotripaldi  in slack how to do it.
3b. After the connection is done, you should end in your wp-admin again

ping @rickybanister  @roccotripaldi  @kraftbj @tyxla 
