### PR TITLE
People: fix email field getting wider than parent container on smaller screens

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -245,6 +245,7 @@
 @import 'my-sites/people/people-list-item/style';
 @import 'my-sites/people/people-profile/style';
 @import 'my-sites/people/people-notices/style';
+@import 'my-sites/people/invite-people/style';
 @import 'my-sites/plan-compare-card/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/plan-price/style';

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -286,7 +286,12 @@ const InvitePeople = React.createClass( {
 
 	renderRoleExplanation() {
 		return (
-			<a target="_blank" rel="noopener noreferrer" href="http://en.support.wordpress.com/user-roles/" onClick={ this.onClickRoleExplanation }>
+			<a
+				target="_blank"
+				rel="noopener noreferrer"
+				href="http://en.support.wordpress.com/user-roles/"
+				onClick={ this.onClickRoleExplanation }
+			>
 				{ this.translate( 'Learn more about roles' ) }
 			</a>
 		);
@@ -315,7 +320,7 @@ const InvitePeople = React.createClass( {
 				<Card>
 					<EmailVerificationGate>
 						<form onSubmit={ this.submitForm } >
-							<FormFieldset>
+							<div role="group" className="invite-people__token-field-wrapper">
 								<FormLabel>{ this.translate( 'Usernames or Emails' ) }</FormLabel>
 								<TokenField
 									isBorderless
@@ -326,14 +331,14 @@ const InvitePeople = React.createClass( {
 									value={ this.getTokensWithStatus() }
 									onChange={ this.onTokensChange }
 									onFocus={ this.onFocusTokenField }
-									disabled={ this.state.sendingInvites }/>
+									disabled={ this.state.sendingInvites } />
 								<FormSettingExplanation>
 									{ this.translate(
 										'Invite up to 10 email addresses and/or WordPress.com usernames. ' +
 										'Those needing a username will be sent instructions on how to create one.'
 									) }
 								</FormSettingExplanation>
-							</FormFieldset>
+							</div>
 
 							<RoleSelect
 								id="role"

--- a/client/my-sites/people/invite-people/style.scss
+++ b/client/my-sites/people/invite-people/style.scss
@@ -1,0 +1,4 @@
+.invite-people__token-field-wrapper {
+	clear: both;
+	margin-bottom: 20px;
+}


### PR DESCRIPTION
Fixes #5228

I explicitly added a `min-width: 0` to the `.form-fieldset` selector to override the browser default of `min-width: -webkit-min-content`. I couldn't change the display property to block because there seems to be a bug in some browsers where it doesn't seem to work when applied to fieldset elements.

Before | After
------- | ----
![before](https://cloud.githubusercontent.com/assets/661330/19123133/64644ce8-8b25-11e6-8ef6-f760fd597d63.png) | ![after](https://cloud.githubusercontent.com/assets/661330/19123138/672faeb8-8b25-11e6-9471-ca7ed830041a.png)


See:
https://bugzilla.mozilla.org/show_bug.cgi?id=504622
https://bugs.webkit.org/show_bug.cgi?id=123507