### PR TITLE
Framework: Fix EventEmitter memory leak

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -431,7 +431,6 @@ function reduxStoreReady( reduxStore ) {
 			debug( 'Unmounting multi-tree layout' );
 			ReactDom.unmountComponentAtNode( document.getElementById( 'primary' ) );
 			ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-			ReactDom.unmountComponentAtNode( document.getElementById( 'wpcom' ) );
 		}
 		next();
 	} );

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -429,6 +429,8 @@ function reduxStoreReady( reduxStore ) {
 			renderLayout( context.store );
 		} else if ( ! isMultiTreeLayout && ! previousLayoutIsSingleTree ) {
 			debug( 'Unmounting multi-tree layout' );
+			ReactDom.unmountComponentAtNode( document.getElementById( 'primary' ) );
+			ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 			ReactDom.unmountComponentAtNode( document.getElementById( 'wpcom' ) );
 		}
 		next();


### PR DESCRIPTION
Fixes console warning seen on navigation:
`(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.`

Cleanly unmounts all mount-points in the multi-tree layout.

Previously only the base mount-point was being unmounted, leaving
all listeners dangling in #primary and #secondary.

**Todo**
- [x] ~~`#secondary` is not always in place, may need to check for presence before unmount~~ No problems when unmounting a layout (such as /start) with no sidebar

**To Test**
* Repeatedly switch between _Menus_ and _Themes_ links on sidebar. Should never see the `(node) warning` above
* Check that http://calypso.localhost:3000/start and _Switch site->new Wordpress_ work ok
