### PR TITLE
Editor: Insert VideoPress media as link for oEmbed preview

### DIFF
--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -196,11 +196,7 @@ Markup = {
 		 */
 		video: function( media ) {
 			if ( MediaUtils.isVideoPressItem( media ) ) {
-				return Shortcode.stringify( {
-					tag: 'wpvideo',
-					attrs: [ media.videopress_guid ],
-					type: 'single'
-				} );
+				return `https://videopress.com/v/${ media.videopress_guid }`;
 			}
 
 			return Shortcode.stringify( {

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -289,12 +289,12 @@ describe( 'markup', function() {
 		} );
 
 		describe( '#video()', function() {
-			it( 'should return a `wpvideo` shortcode for a VideoPress video', function() {
-				var value = markup.mimeTypes.video( {
+			it( 'should return a VideoPress URL for a VideoPress video', function() {
+				const value = markup.mimeTypes.video( {
 					videopress_guid: '11acMj3O'
 				} );
 
-				expect( value ).to.equal( '[wpvideo 11acMj3O]' );
+				expect( value ).to.equal( 'https://videopress.com/v/11acMj3O' );
 			} );
 
 			it( 'should return a `video` shortcode for a video', function() {


### PR DESCRIPTION
Related: #8342, #2267

This pull request seeks to insert a VideoPress media item into the post editor by generating a VideoPress link instead of a shortcode. By doing so, it leverages existing oEmbed behavior for previews. This is a complementary pull request to #8342, solving the desire for VideoPress previews in the editor, though it does not address previews for existing posts.

![image](https://cloud.githubusercontent.com/assets/1779930/19126689/e9e92fc6-8b09-11e6-9fef-5e24209e57b2.png)

**Testing Instructions:**

Verify that when inserting a VideoPress media item, it is inserted into the post content and transformed into a preview of the video automatically.
1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click the Add Media button in the editor toolbar
4. Insert a video item
5. Note that after inserted, it is transformed into a preview
