### PR TITLE
Reader: Turn off excerpts for wpcom sites

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -246,6 +246,8 @@ export class FullPostView extends React.Component {
 			classes[ 'feed-' + post.feed_ID ] = true;
 		}
 
+		const useExcerpt = post && post.use_excerpt && post.is_jetpack;
+
 		/*eslint-disable react/no-danger*/
 		return (
 			<ReaderMain className={ classNames( classes ) }>
@@ -289,7 +291,7 @@ export class FullPostView extends React.Component {
 						{ post.featured_image && ( ! ( post.display_type & CANONICAL_IN_CONTENT ) ) &&
 							<FeaturedImage src={ post.featured_image } />
 						}
-						{ post.use_excerpt
+						{ useExcerpt
 							? <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
 							: <EmbedContainer>
 									<div
@@ -298,7 +300,7 @@ export class FullPostView extends React.Component {
 								</EmbedContainer>
 						}
 
-						{ post.use_excerpt && ! isDiscoverPost( post )
+						{ useExcerpt && ! isDiscoverPost( post )
 							? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
 							: null
 						}

--- a/client/reader/full-post/main.jsx
+++ b/client/reader/full-post/main.jsx
@@ -162,7 +162,7 @@ FullPostView = React.createClass( {
 				post.canonical_image &&
 				! ( post.display_type & DISPLAY_TYPES.CANONICAL_IN_CONTENT ),
 			articleClasses = [ 'reader__full-post', 'is-group-reader' ],
-			shouldShowExcerptOnly = ( post && post.use_excerpt ? post.use_excerpt : false ),
+			shouldShowExcerptOnly = !! ( post && post.use_excerpt && post.is_jetpack ),
 			siteName = utils.siteNameFromSiteAndPost( site, post ),
 			isDiscoverPost = DiscoverHelper.isDiscoverPost( post ),
 			isDiscoverSitePick = DiscoverHelper.isDiscoverSitePick( post ),
@@ -224,7 +224,7 @@ FullPostView = React.createClass( {
 
 					<PostByline post={ post } site={ site } icon={ true } isDiscoverPost={ isDiscoverPost }/>
 
-					{ post && post.use_excerpt
+					{ shouldShowExcerptOnly
 						? <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
 						: <EmbedContainer>
 								<div className="reader__full-post-content" dangerouslySetInnerHTML={ { __html: post.content } } />


### PR DESCRIPTION
Always show full content for posts from WordPress.com. Keep on showing excerpts when requested for Jetpack.

Needs testing with VIP content to see how it responds.