### PR TITLE
Reader: Make video embeds full-width in full-post

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -415,14 +415,12 @@
 .reader-full-post .embed-youtube,
 .reader-full-post .embed-vimeo {
 	display: block;
-	height: 0;
 	position: relative;
 	padding: 25px 0 56.25%;
 
 	iframe {
 		height: 100%;
 		position: absolute;
-			left: 0;
 			top: 0;
 		width: 100%;
 	}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -412,6 +412,26 @@
 	margin: 28px 0 26px;
 }
 
+.reader-full-post .embed-youtube,
+.reader-full-post .embed-vimeo {
+	display: block;
+	height: 0;
+	position: relative;
+	padding: 25px 0 56.25%;
+
+	iframe {
+		height: 100%;
+		position: absolute;
+			left: 0;
+			top: 0;
+		width: 100%;
+	}
+}
+
+.reader-full-post .embed-vimeo {
+	margin-bottom: 33px;
+}
+
 .reader-full-post__story-content img:first-child {
 	margin-top: 0;
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8489

Example Vimeo: http://calypso.dev:3000/read/blogs/116884128/posts/211

**Before:**
![screenshot 2016-10-05 12 45 59](https://cloud.githubusercontent.com/assets/4924246/19128846/f4385796-8af9-11e6-86ad-7814ac3944ae.png)

**After:**
![screenshot 2016-10-05 12 46 03](https://cloud.githubusercontent.com/assets/4924246/19128849/f8f12cd6-8af9-11e6-96c2-63a2702a5773.png)

Example YouTube: http://calypso.dev:3000/read/blogs/56906793/posts/18365

**Before:**
![screenshot 2016-10-05 12 46 11](https://cloud.githubusercontent.com/assets/4924246/19128919/2ea14ece-8afa-11e6-8a2f-868012449d11.png)

**After:**
![screenshot 2016-10-05 12 46 23](https://cloud.githubusercontent.com/assets/4924246/19128928/31a230c0-8afa-11e6-8570-b97de2dcca32.png)
 
