### PR TITLE
Like Button: Close code tags in docs code example.

### DIFF
--- a/client/blocks/like-button/README.md
+++ b/client/blocks/like-button/README.md
@@ -40,6 +40,7 @@ render: function() {
 handleLikeToggle: function( newState ) {
 	// save the state somehow
 }
+```
 
 #### Props
 


### PR DESCRIPTION
Closes a code block to properly display the rest of the readme.

[Before](https://github.com/Automattic/wp-calypso/blob/53785d089f8b758b87415e8a63ece291362b895b/client/blocks/like-button/README.md) / [After](https://github.com/Automattic/wp-calypso/blob/3e5a7c21abba75bc02c390b388f8e3e91c755b82/client/blocks/like-button/README.md)