### PR TITLE
State: Refactor UI state into own combined reducer

### DIFF
--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -23,6 +23,7 @@ import actionLog from './action-log/reducer';
 import layoutFocus from './layout-focus/reducer';
 import preview from './preview/reducer';
 import happychat from './happychat/reducer';
+import section from './section/reducer';
 
 /**
  * Tracks the currently selected site ID.
@@ -37,15 +38,6 @@ export function selectedSiteId( state = null, action ) {
 			return action.siteId || null;
 	}
 
-	return state;
-}
-
-//TODO: do we really want to mix strings and booleans?
-export function section( state = false, action ) {
-	switch ( action.type ) {
-		case SECTION_SET:
-			return ( action.section !== undefined ) ? action.section : state;
-	}
 	return state;
 }
 

--- a/client/state/ui/section/reducer.js
+++ b/client/state/ui/section/reducer.js
@@ -37,7 +37,8 @@ export const paths = createSectionReducer( [], 'paths' );
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const module = createSectionReducer( null, 'module' );
+const moduleReducer = createSectionReducer( null, 'module' );
+export { moduleReducer as module };
 
 /**
  * Returns the updated section logged-out enabled state after an action has
@@ -95,7 +96,7 @@ export const title = createSectionReducer( null, 'title' );
 export default combineReducers( {
 	name,
 	paths,
-	module,
+	module: moduleReducer,
 	enableLoggedOut,
 	secondary,
 	group,

--- a/client/state/ui/section/reducer.js
+++ b/client/state/ui/section/reducer.js
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { createSectionReducer } from './utils';
+
+/**
+ * Returns the updated section name state after an action has been dispatched.
+ * The state reflects the current section name.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const name = createSectionReducer( null, 'name' );
+
+/**
+ * Returns the updated section paths state after an action has been dispatched.
+ * The state reflects the set of path fragments matched by the current section.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const paths = createSectionReducer( [], 'paths' );
+
+/**
+ * Returns the updated section module state after an action has been
+ * dispatched. The state reflects the Node module to be required in
+ * navigating to the section.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const module = createSectionReducer( null, 'module' );
+
+/**
+ * Returns the updated section logged-out enabled state after an action has
+ * been dispatched. The state reflects whether the section is available for
+ * logged-out usage.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const enableLoggedOut = createSectionReducer( false, 'enableLoggedOut' );
+
+/**
+ * Returns the updated section secondary state after an action has been
+ * dispatched. The state reflects whether the secondary (sidebar) element
+ * should be present while this section is active.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const secondary = createSectionReducer( false, 'secondary' );
+
+/**
+ * Returns the updated section group state after an action has been dispatched.
+ * The state reflects a group of sections to which the current section belongs.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const group = createSectionReducer( null, 'group' );
+
+/**
+ * Returns the updated section isomorphic state after an action has been
+ * dispatched. The state reflects whether the current section supports
+ * server-side rendering.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const isomorphic = createSectionReducer( false, 'isomorphic' );
+
+/**
+ * Returns the updated section title state after an action has been dispatched.
+ * The state reflects the title to be shown in server-side rendered layouts.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const title = createSectionReducer( null, 'title' );
+
+export default combineReducers( {
+	name,
+	paths,
+	module,
+	enableLoggedOut,
+	secondary,
+	group,
+	isomorphic,
+	title
+} );

--- a/client/state/ui/section/test/reducer.js
+++ b/client/state/ui/section/test/reducer.js
@@ -1,0 +1,186 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { SECTION_SET } from 'state/action-types';
+import reducer, {
+	name,
+	paths,
+	module,
+	enableLoggedOut,
+	secondary,
+	group,
+	isomorphic,
+	title
+} from '../reducer';
+
+describe( 'reducer', () => {
+	it( 'should include expected keys in return value', () => {
+		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'name',
+			'paths',
+			'module',
+			'enableLoggedOut',
+			'secondary',
+			'group',
+			'isomorphic',
+			'title'
+		] );
+	} );
+
+	describe( 'name()', () => {
+		it( 'should default to null', () => {
+			const state = name( undefined, {} );
+
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should change its value when specified on action section object', () => {
+			const state = name( null, {
+				type: SECTION_SET,
+				section: {
+					name: 'sites'
+				}
+			} );
+
+			expect( state ).to.equal( 'sites' );
+		} );
+	} );
+
+	describe( 'paths()', () => {
+		it( 'should default to an empty array', () => {
+			const state = paths( undefined, {} );
+
+			expect( state ).to.eql( [] );
+		} );
+
+		it( 'should change its value when specified on action section object', () => {
+			const state = paths( [], {
+				type: SECTION_SET,
+				section: {
+					paths: [ '/sites' ]
+				}
+			} );
+
+			expect( state ).to.eql( [ '/sites' ] );
+		} );
+	} );
+
+	describe( 'module()', () => {
+		it( 'should default to null', () => {
+			const state = module( undefined, {} );
+
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should change its value when specified on action section object', () => {
+			const state = module( null, {
+				type: SECTION_SET,
+				section: {
+					module: 'my-sites'
+				}
+			} );
+
+			expect( state ).to.equal( 'my-sites' );
+		} );
+	} );
+
+	describe( 'enableLoggedOut()', () => {
+		it( 'should default to false', () => {
+			const state = enableLoggedOut( undefined, {} );
+
+			expect( state ).to.be.false;
+		} );
+
+		it( 'should change its value when specified on action section object', () => {
+			const state = enableLoggedOut( false, {
+				type: SECTION_SET,
+				section: {
+					enableLoggedOut: true
+				}
+			} );
+
+			expect( state ).to.be.true;
+		} );
+	} );
+
+	describe( 'secondary()', () => {
+		it( 'should default to false', () => {
+			const state = secondary( undefined, {} );
+
+			expect( state ).to.be.false;
+		} );
+
+		it( 'should change its value when specified on action section object', () => {
+			const state = secondary( false, {
+				type: SECTION_SET,
+				section: {
+					secondary: true
+				}
+			} );
+
+			expect( state ).to.be.true;
+		} );
+	} );
+
+	describe( 'group()', () => {
+		it( 'should default to null', () => {
+			const state = group( undefined, {} );
+
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should change its value when specified on action section object', () => {
+			const state = group( null, {
+				type: SECTION_SET,
+				section: {
+					group: 'sites'
+				}
+			} );
+
+			expect( state ).to.equal( 'sites' );
+		} );
+	} );
+
+	describe( 'isomorphic()', () => {
+		it( 'should default to false', () => {
+			const state = isomorphic( undefined, {} );
+
+			expect( state ).to.be.false;
+		} );
+
+		it( 'should change its value when specified on action section object', () => {
+			const state = isomorphic( false, {
+				type: SECTION_SET,
+				section: {
+					isomorphic: true
+				}
+			} );
+
+			expect( state ).to.be.true;
+		} );
+	} );
+
+	describe( 'title()', () => {
+		it( 'should default to null', () => {
+			const state = title( undefined, {} );
+
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should change its value when specified on action section object', () => {
+			const state = title( null, {
+				type: SECTION_SET,
+				section: {
+					title: 'Themes'
+				}
+			} );
+
+			expect( state ).to.equal( 'Themes' );
+		} );
+	} );
+} );

--- a/client/state/ui/section/test/reducer.js
+++ b/client/state/ui/section/test/reducer.js
@@ -10,7 +10,7 @@ import { SECTION_SET } from 'state/action-types';
 import reducer, {
 	name,
 	paths,
-	module,
+	module as moduleReducer,
 	enableLoggedOut,
 	secondary,
 	group,
@@ -72,13 +72,13 @@ describe( 'reducer', () => {
 
 	describe( 'module()', () => {
 		it( 'should default to null', () => {
-			const state = module( undefined, {} );
+			const state = moduleReducer( undefined, {} );
 
 			expect( state ).to.be.null;
 		} );
 
 		it( 'should change its value when specified on action section object', () => {
-			const state = module( null, {
+			const state = moduleReducer( null, {
 				type: SECTION_SET,
 				section: {
 					module: 'my-sites'

--- a/client/state/ui/section/test/utils.js
+++ b/client/state/ui/section/test/utils.js
@@ -26,17 +26,6 @@ describe( 'utils', () => {
 			expect( state ).to.be.null;
 		} );
 
-		it( 'should return the same state if action section doesn\'t include key', () => {
-			const state = reducer( null, {
-				type: SECTION_SET,
-				section: {
-					baz: 'qux'
-				}
-			} );
-
-			expect( state ).to.be.null;
-		} );
-
 		it( 'should return the new value if action section includes key', () => {
 			const state = reducer( null, {
 				type: SECTION_SET,
@@ -46,6 +35,24 @@ describe( 'utils', () => {
 			} );
 
 			expect( state ).to.equal( 'bar' );
+		} );
+
+		it( 'should return the same state if action section doesn\'t include key', () => {
+			const originalState = reducer( null, {
+				type: SECTION_SET,
+				section: {
+					foo: 'bar'
+				}
+			} );
+
+			const state = reducer( originalState, {
+				type: SECTION_SET,
+				section: {
+					baz: 'qux'
+				}
+			} );
+
+			expect( state ).to.equal( originalState );
 		} );
 	} );
 } );

--- a/client/state/ui/section/test/utils.js
+++ b/client/state/ui/section/test/utils.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { SECTION_SET } from 'state/action-types';
+import { createSectionReducer } from '../utils';
+
+describe( 'utils', () => {
+	describe( 'createSectionReducer()', () => {
+		let reducer;
+		beforeEach( () => {
+			reducer = createSectionReducer( null, 'foo' );
+		} );
+
+		it( 'should return a function', () => {
+			expect( reducer ).to.be.a( 'function' );
+		} );
+
+		it( 'should default to the provided initial state', () => {
+			const state = reducer( undefined, {} );
+
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should return the same state if action section doesn\'t include key', () => {
+			const state = reducer( null, {
+				type: SECTION_SET,
+				section: {
+					baz: 'qux'
+				}
+			} );
+
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should return the new value if action section includes key', () => {
+			const state = reducer( null, {
+				type: SECTION_SET,
+				section: {
+					foo: 'bar'
+				}
+			} );
+
+			expect( state ).to.equal( 'bar' );
+		} );
+	} );
+} );

--- a/client/state/ui/section/utils.js
+++ b/client/state/ui/section/utils.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { createReducer } from 'state/utils';
+import { SECTION_SET } from 'state/action-types';
+
+/**
+ * Given an initial state and section object key to manage, returns a reducer
+ * function which manages state for the section key.
+ *
+ * @param  {*}        initialState Initial state value
+ * @param  {String}   key          Section object key
+ * @return {Function}              Section reducer
+ */
+export function createSectionReducer( initialState, key ) {
+	return createReducer( initialState, {
+		[ SECTION_SET ]: ( state, { section } ) => {
+			if ( section && section.hasOwnProperty( key ) ) {
+				return section[ key ];
+			}
+
+			return state;
+		}
+	} );
+}


### PR DESCRIPTION
This pull request seeks to split `state.ui.section` from the `state/ui/reducer.js` file into its own combined reducer at `state/ui/section/reducer.js`. Because `section` state value is an object, the benefit of creating a separate combined reducer is:
1. Better understanding of the shape of `state.ui.section`
2. Optimizations when no change in value occurs for nested properties

To the latter point, because we always return the action `section` property when setting section, and because this is always a new object from the action creator, there may be cases where the reducer returns a new reference when in fact none of its own property values have changed.

**Testing Instructions:**

Verify that there are no regressions in setting sections, particularly those outside the norm (i.e. isomorphic, logged-out capable, etc). 

Ensure that Mocha tests pass:

```
npm run test-client client/state/ui/section
```

**Follow-up Tasks:**

There's a few other improvements I'd like to make to sections state:
1. Create a `getSection` selector used both in other selectors and in all places throughout the app where current section is currently pathed manually in `connect`
2. Ensure that `setSection` is called consistently as an action creator ([this is problematic](https://github.com/Automattic/wp-calypso/blob/58ff2317ca313ba8cab0327928a4c707a73bdaae/server/bundler/loader.js#L90))
3. Break off `setSectionOptions` where `isLoading` and `hasSidebar` are managed separately (related to second point where not all section-related updates are changing the section state itself)
