### PR TITLE
Update the Dockerfile for building and testing Calypso

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git
 node_modules
+build
+public

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,6 @@ RUN        true \
                  make \
            # Sometimes "npm install" fails the first time when the
            # cache is empty, so we retry once if it failed
-           && rm -rf node_modules \
-           && rm -rf build \
-           && rm -rf public \
            && npm install --production || npm install --production \
            && CALYPSO_ENV=wpcalypso make build-wpcalypso \
            && CALYPSO_ENV=horizon make build-horizon \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,12 @@ RUN        true \
            && apt-get remove -y \
                  git \
            && apt-get autoremove -y \
-		   && rm -rf /var/lib/apt/lists/* \
-		   && rm -rf /var/lib/dpkg/info/* \
-		   && rm -rf /tmp/* \
-		   && rm -rf /var/tmp/* \
-		   && rm -rf /usr/share/{doc,doc-base,info,locale,man}/* \
-		   && rm -rf /root/.npm \
+    	   && rm -rf /var/lib/apt/lists/* \
+    	   && rm -rf /var/lib/dpkg/info/* \
+    	   && rm -rf /tmp/* \
+    	   && rm -rf /var/tmp/* \
+    	   && rm -rf /usr/share/{doc,doc-base,info,locale,man}/* \
+    	   && rm -rf /root/.npm \
            && true
 
 USER       nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM	   node:6.7.0-slim
+FROM       node:6.7.0-slim
 MAINTAINER Automattic
 
 WORKDIR    /calypso
@@ -38,12 +38,12 @@ RUN        true \
            && apt-get remove -y \
                  git \
            && apt-get autoremove -y \
-    	   && rm -rf /var/lib/apt/lists/* \
-    	   && rm -rf /var/lib/dpkg/info/* \
-    	   && rm -rf /tmp/* \
-    	   && rm -rf /var/tmp/* \
-    	   && rm -rf /usr/share/{doc,doc-base,info,locale,man}/* \
-    	   && rm -rf /root/.npm \
+           && rm -rf /var/lib/apt/lists/* \
+           && rm -rf /var/lib/dpkg/info/* \
+           && rm -rf /tmp/* \
+           && rm -rf /var/tmp/* \
+           && rm -rf /usr/share/{doc,doc-base,info,locale,man}/* \
+           && rm -rf /root/.npm \
            && true
 
 USER       nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,50 @@
-FROM	debian:wheezy
-
+FROM	   node:6.7.0-slim
 MAINTAINER Automattic
 
-WORKDIR /calypso
+WORKDIR    /calypso
 
-RUN     mkdir -p /tmp
-COPY    ./env-config.sh /tmp/
-RUN     bash /tmp/env-config.sh
-RUN     apt-get -y update && apt-get -y install \
-          wget \
-          git \
-          python \
-          make \
-          build-essential
+# includes three key files plus everything else
+#   - env-config.sh
+#      used by systems to overwrite some defaults
+#      such as the apt and npm mirrors
+#
+#   - package.json
+#      provides the build scripts needed by npm
+#
+#   - npm-shrinkwrap.json
+#      provides the actual node dependencies for the project
+COPY       . /calypso
 
-ENV NODE_VERSION 6.7.0
+ENV        NODE_PATH=/calypso/server:/calypso/client
 
-RUN     wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz && \
-          tar -zxf node-v$NODE_VERSION-linux-x64.tar.gz -C /usr/local && \
-          ln -sf /usr/local/node-v$NODE_VERSION-linux-x64 /usr/local/node && \
-          ln -sf /usr/local/node/bin/npm /usr/local/bin/ && \
-          ln -sf /usr/local/node/bin/node /usr/local/bin/ && \
-          rm node-v$NODE_VERSION-linux-x64.tar.gz
+RUN        true \
+           && mv ./env-config.sh /tmp/env-config.sh \
+           && apt-get -y update \
+           && apt-get -y install \
+                 git \
+                 make \
+           # Sometimes "npm install" fails the first time when the
+           # cache is empty, so we retry once if it failed
+           && rm -rf node_modules \
+           && rm -rf build \
+           && rm -rf public \
+           && npm install --production || npm install --production \
+           && CALYPSO_ENV=wpcalypso make build-wpcalypso \
+           && CALYPSO_ENV=horizon make build-horizon \
+           && CALYPSO_ENV=stage make build-stage \
+           && CALYPSO_ENV=production make build-production \
+           && chown -R nobody /calypso \
+           # Clean up the dependencies we no longer need
+           && apt-get remove -y \
+                 git \
+           && apt-get autoremove -y \
+		   && rm -rf /var/lib/apt/lists/* \
+		   && rm -rf /var/lib/dpkg/info/* \
+		   && rm -rf /tmp/* \
+		   && rm -rf /var/tmp/* \
+		   && rm -rf /usr/share/{doc,doc-base,info,locale,man}/* \
+		   && rm -rf /root/.npm \
+           && true
 
-# npmrc is created by env-config.sh. For local testing, an empty one is generated
-RUN     touch /usr/local/etc/npmrc && \
-          mkdir /usr/local/node/etc && \
-          cp /usr/local/etc/npmrc /usr/local/node/etc/npmrc
-
-ENV     NODE_PATH /calypso/server:/calypso/client
-
-# Install base npm packages to take advantage of the docker cache
-COPY    ./package.json /calypso/package.json
-COPY    ./npm-shrinkwrap.json /calypso/npm-shrinkwrap.json
-# Sometimes "npm install" fails the first time when the cache is empty, so we retry once if it failed
-RUN     npm install --production || npm install --production
-
-COPY     . /calypso
-
-# Build javascript bundles for each environment and change ownership
-RUN     CALYPSO_ENV=wpcalypso make build-wpcalypso && \
-          CALYPSO_ENV=horizon make build-horizon && \
-          CALYPSO_ENV=stage make build-stage && \
-          CALYPSO_ENV=production make build-production && \
-          chown -R nobody /calypso
-
-USER    nobody
-CMD     NODE_ENV=production node build/bundle-$CALYPSO_ENV.js
+USER       nobody
+CMD        NODE_ENV=production node build/bundle-$CALYPSO_ENV.js


### PR DESCRIPTION
Previously the project `Dockerfile` was build from a Debian base image
and took a wihle to build and the final image ended up around 1 GB in
size.

Now we build from an official node image which lets us skip installing
node inside the image build process and I have combined many operations
into fewer commands which reduces the number of layers in the final
image. Each layer adds significant overhead to any operations that need
to read or write to the filesystem.

This should not change the functionality of the Docker image. It is
meant to simply update the build process to be more efficient.

**Testing**
Build the Docker image and attempt to run it just like before.

```bash
docker build -t wp-calypso .
docker run --rm -it --name wp-calypso -p 80:3000 -e NODE_ENV='wpcalypso' -e CALYPSO_ENV='wpcalypso' wp-calypso
```

Sandbox `wpcalypso` to `127.0.0.1`
Open a browser (without proxy/with direct networking access) to `wpcalypso.wordpress.com`

cc: @gwwar @lamosty @mtias 