### PR TITLE
Plans: fix footer credit nudge copy

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -588,7 +588,7 @@ const FormGeneral = React.createClass( {
 						{ ! isBusiness( site.plan ) && <UpgradeNudge
 							className="site-settings__footer-credit-nudge"
 							feature={ FEATURE_NO_BRANDING }
-							title={ this.translate( 'Remove the footer credit entirely with Business Plan' ) }
+							title={ this.translate( 'Remove the footer credit entirely with WordPress.com Business' ) }
 							message={ this.translate( 'Upgrade to remove the footer credit, add Google Analytics and more' ) }
 							icon="customize"
 						/> }


### PR DESCRIPTION
This PR fixes #8486 so we have more delightful copy in our nudge, as suggested by @michelleweber

Before:
<img width="746" alt="daba6c08-8ae2-11e6-98bc-2247ee4a7b8f" src="https://cloud.githubusercontent.com/assets/1270189/19136216/add13658-8b1f-11e6-927b-be2a99984704.png">

After:
<img width="729" alt="screen shot 2016-10-05 at 5 17 18 pm" src="https://cloud.githubusercontent.com/assets/1270189/19136220/bb07e970-8b1f-11e6-8670-5f57148867ea.png">

## Testing Instructions
- Navigate to http://calypso.localhost:3000/settings/general
- Select a free site
- Scroll down to verify the nudge copy

cc @artpi @lamosty @retrofox @obenland 