### PR TITLE
Reader full post: fix prop type warnings for LikeButton

### DIFF
--- a/client/blocks/reader-full-post/action-links.jsx
+++ b/client/blocks/reader-full-post/action-links.jsx
@@ -48,8 +48,8 @@ const ReaderFullPostActionLinks = ( { post, site, onCommentClick } ) => {
 				<li className="reader-full-post__action-links-item">
 					<LikeButton
 						key="like-button"
-						siteId={ post.site_ID }
-						postId={ post.ID }
+						siteId={ +post.site_ID }
+						postId={ +post.ID }
 						fullPost={ true }
 						tagName="div"
 						forceCounter={ true } />

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -276,8 +276,8 @@ export class FullPostView extends React.Component {
 								tagName="div" />
 						}
 						{ shouldShowLikes( post ) &&
-							<LikeButton siteId={ post.site_ID }
-								postId={ post.ID }
+							<LikeButton siteId={ +post.site_ID }
+								postId={ +post.ID }
 								fullPost={ true }
 								tagName="div" />
 						}


### PR DESCRIPTION
Fixes #8375.

## To test

Pull up a full post in the refreshed full post view (e.g. http://calypso.localhost:3000/read/blogs/48500948/posts/6718), and ensure that you don't get any prop type warnings in your JS console.