### PR TITLE
NUX: use appropriate page titles during signup

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -7,7 +7,6 @@ import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 import qs from 'qs';
 import isEmpty from 'lodash/isEmpty';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -18,7 +17,6 @@ import analytics from 'lib/analytics';
 import SignupComponent from './main';
 import utils from './utils';
 import userModule from 'lib/user';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 
 const user = userModule();
@@ -87,8 +85,6 @@ export default {
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		context.store.dispatch( setLayoutFocus( 'content' ) );
 
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Create an account' ) ) );
 		ReactDom.render(
 			React.createElement( ReduxProvider, { store: context.store },
 				React.createElement( SignupComponent, {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -42,7 +42,7 @@ import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import * as oauthToken from 'lib/oauth-token';
 import DocumentHead from 'components/data/document-head';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Constants
@@ -336,7 +336,7 @@ const Signup = React.createClass( {
 
 	pageTitle() {
 		const accountFlowName = 'account';
-		return this.props.flowName === accountFlowName ? i18n.translate( 'Create an account' ) : i18n.translate( 'Create a site' );
+		return this.props.flowName === accountFlowName ? translate( 'Create an account' ) : translate( 'Create a site' );
 	},
 
 	currentStep() {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -41,6 +41,8 @@ import utils from './utils';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import * as oauthToken from 'lib/oauth-token';
+import DocumentHead from 'components/data/document-head';
+import i18n from 'i18n-calypso';
 
 /**
  * Constants
@@ -332,6 +334,11 @@ const Signup = React.createClass( {
 			null;
 	},
 
+	pageTitle() {
+		const accountFlowName = 'account';
+		return this.props.flowName === accountFlowName ? i18n.translate( 'Create an account' ) : i18n.translate( 'Create a site' );
+	},
+
 	currentStep() {
 		let currentStepProgress = find( this.state.progress, { stepName: this.props.stepName } ),
 			CurrentComponent = stepComponents[ this.props.stepName ],
@@ -385,6 +392,7 @@ const Signup = React.createClass( {
 
 		return (
 			<span>
+				<DocumentHead title={ this.pageTitle() } />
 				{
 					this.state.loadingScreenStartTime ?
 					null :


### PR DESCRIPTION
Fixes #3173 

Each step of the signup will now have the correct page title, and the account signup flow will have a different title

*****

**Creating an Account BEFORE**

![before account](https://cloud.githubusercontent.com/assets/128826/19139856/641ea6e2-8bcb-11e6-8354-277cdcb16079.png)

**Creating an Account AFTER**

![after account](https://cloud.githubusercontent.com/assets/128826/19139887/8d04c302-8bcb-11e6-8748-966003342bb7.png)

*****

**Creating a Site (new user) BEFORE**

![before site](https://cloud.githubusercontent.com/assets/128826/19139870/75429776-8bcb-11e6-8134-85df62b2d88d.png)

**Creating a Site (new user) AFTER**

![after site](https://cloud.githubusercontent.com/assets/128826/19139895/922e8868-8bcb-11e6-89e4-18f4bead8139.png)

*****

**Creating a Site (existing user signed in) BEFORE**

![create account signed in before](https://cloud.githubusercontent.com/assets/128826/19139917/d09dfe30-8bcb-11e6-9a02-3f4ccc31fb9c.png)

**Creating a Site (existing user signed in) AFTER**

![create account signed in after](https://cloud.githubusercontent.com/assets/128826/19139922/dc6a0f38-8bcb-11e6-91dc-08bb2af58000.png)