### PR TITLE
Makefile: add install dependency to dashboard task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ install: node_modules
 run: welcome githooks install build
 	@$(NODE) build/bundle-$(CALYPSO_ENV).js
 
-dashboard:
+dashboard: install
 	@$(NODE_BIN)/webpack-dashboard -- make run
 
 # a helper rule to ensure that a specific module is installed,


### PR DESCRIPTION
Previously, running `make dashboard` would result in the following error message if the `webpack-dashboard` module wasn't installed yet: `node_modules/.bin/webpack-dashboard: No such file or directory`.

This adds a dependency to the `install` task to the `dashboard` task, so that modules are installed before trying to run Calypso using the dashboard module. 

To test:

- run  `make clean distclean` and then verify that `make dashboard` installs all necessary node modules and starts Calypso properly using the `dashboard` variation
- make sure this doesn't try and run `npm install` every time we run `make dashboard` (i.e. don't try to install modules if they've been installed already)