### PR TITLE
Jetpack Plugins: Fix SCSS warning about using invalid responsive breakpoint value

### DIFF
--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -129,7 +129,7 @@
 		color: $gray-dark;
 		font-size: 11px;
 	}
-	@include breakpoint( '<780px' ) {
+	@include breakpoint( '<660px' ) {
 		display: block;
 		padding-right: 16px;
 	}


### PR DESCRIPTION
This PR tries to remove the following warning from the `make run` output:

> WARNING: ERROR in breakpoint( <780px ): You can only use these sizes[  480px 660px 960px 1040px 1280px ] using the following syntax [ <480px >480px 480px-660px ]
Backtrace:
        assets/stylesheets/shared/mixins/_breakpoints.scss:48, in mixin `breakpoint`
        client/my-sites/plugins/plugin-meta/style.scss:132

