### PR TITLE
Support Chat: Fix link color regression

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -282,7 +282,7 @@
 	margin: 6px 0;
 
 	a {
-		color: lighten( $blue-light, 10% );
+		color: $blue-medium;
 		text-decoration: underline;
 	}
 
@@ -295,7 +295,7 @@
 		margin-left: auto;
 
 		a {
-			color: $blue-medium;
+			color: lighten( $blue-light, 10% );
 		}
 
 	}


### PR DESCRIPTION
In a PR yesterday I swapped out chat bubble background colors. However I failed to remember to update the link colors for proper contrast. This PR fixes that.

How to test:

- `make run`, then click the "Support Chat" link at the bottom of the sidebar. 
- Verity that colors of hyperlinks pasted into chat and sent are legible. 

Screenshot:

<img width="261" alt="screen shot 2016-10-06 at 11 21 06" src="https://cloud.githubusercontent.com/assets/1204802/19147201/598c13f4-8bb7-11e6-9475-f2d9defde2a6.png">
