### PR TITLE
Editor: hide "remove image buttons" from 2 pictures galleries

### DIFF
--- a/client/post-editor/media-modal/gallery/edit-item.jsx
+++ b/client/post-editor/media-modal/gallery/edit-item.jsx
@@ -16,7 +16,14 @@ export default React.createClass( {
 
 	propTypes: {
 		site: PropTypes.object,
-		item: PropTypes.object
+		item: PropTypes.object,
+		showRemoveButton: PropTypes.bool
+	},
+
+	getDefaultProps: function() {
+		return {
+			showRemoveButton: true
+		};
 	},
 
 	renderCaption() {
@@ -33,7 +40,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { site, item, showRemoveButton = true } = this.props;
+		const { site, item, showRemoveButton } = this.props;
 
 		return (
 			<div className="editor-media-modal-gallery__edit-item">

--- a/client/post-editor/media-modal/gallery/edit-item.jsx
+++ b/client/post-editor/media-modal/gallery/edit-item.jsx
@@ -33,7 +33,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { site, item } = this.props;
+		const { site, item, showRemoveButton = true } = this.props;
 
 		return (
 			<div className="editor-media-modal-gallery__edit-item">
@@ -42,9 +42,12 @@ export default React.createClass( {
 					scale={ 1 }
 					photon={ false } />
 				{ this.renderCaption() }
-				<EditorMediaModalGalleryRemoveButton
-					siteId={ site.ID }
-					itemId={ item.ID } />
+				{ showRemoveButton &&
+					<EditorMediaModalGalleryRemoveButton
+						siteId={ site.ID }
+						itemId={ item.ID }
+					/>
+				}
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/gallery/edit.jsx
+++ b/client/post-editor/media-modal/gallery/edit.jsx
@@ -27,7 +27,7 @@ export default React.createClass( {
 	},
 
 	onOrderChanged: function( order ) {
-		var items = [];
+		const items = [];
 
 		this.props.settings.items.forEach( ( item, i ) => {
 			items[ order[ i ] ] = item;
@@ -53,7 +53,8 @@ export default React.createClass( {
 						<EditorMediaModalGalleryEditItem
 							key={ item.ID }
 							site={ site }
-							item={ item } />
+							item={ item }
+							showRemoveButton={ settings.items.length > 2 } />
 					);
 				} ) }
 			</SortableList>


### PR DESCRIPTION
This fixes a small bug on Image galleries where we could create galleries with 0/1 images.
To avoid this, I hide the removal button when we reach 2 pictures on a gallery.

closes #1809

**Testing instructions**

* Create an image gallery
* Click the "edit" icon on this gallery
* Try to delete images from this gallery
* We should not be able to go under two images in a gallery.

cc @nylen 