### PR TITLE
Editor: Show the "revert to draft" button on private posts

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -88,13 +88,14 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		var isSticky, isPublished, isPending, canPublish, isScheduled;
+		var isSticky, isPublished, isPending, canPublish, isScheduled, isPrivate;
 
 		if ( this.props.post ) {
 			isSticky = this.props.post.sticky;
 			isPending = postUtils.isPending( this.props.post );
 			isPublished = this.props.savedPost.status === 'publish';
 			isScheduled = this.props.savedPost.status === 'future';
+			isPrivate = this.props.savedPost.status === 'private';
 			canPublish = siteUtils.userCan( 'publish_posts', this.props.site );
 		}
 
@@ -162,7 +163,7 @@ export default React.createClass( {
 						/>
 					</label>
 				}
-				{ ( isPublished || isScheduled || isPending && ! canPublish ) &&
+				{ ( isPublished || isPrivate || isScheduled || isPending && ! canPublish ) &&
 					<Button
 						className="edit-post-status__revert-to-draft"
 						onClick={ this.revertToDraft }

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -62,9 +62,9 @@ class EditPostStatus extends Component {
 		recordStat( stickyStat );
 		recordEvent( 'Changed Sticky Setting', stickyEventLabel );
 
-		this.props.editPost( this.props.siteId, this.props.postId,
-			{ sticky: ! this.props.post.sticky }
-		);
+		this.props.editPost( this.props.siteId, this.props.postId, {
+			sticky: ! this.props.post.sticky
+		} );
 	};
 
 	togglePendingStatus = () => {
@@ -73,9 +73,9 @@ class EditPostStatus extends Component {
 		recordStat( 'status_changed' );
 		recordEvent( 'Changed Pending Status', pending ? 'Marked Draft' : 'Marked Pending' );
 
-		this.props.editPost( this.props.siteId, this.props.postId,
-			{ status: pending ? 'draft' : 'pending' }
-		);
+		this.props.editPost( this.props.siteId, this.props.postId, {
+			status: pending ? 'draft' : 'pending'
+		} );
 	};
 
 	togglePostSchedulePopover = () => {

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -4,11 +4,11 @@
 import React, { PropTypes, Component } from 'react';
 import noop from 'lodash/noop';
 import { moment, translate } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import actions from 'lib/posts/actions';
 import Button from 'components/button';
 import FormToggle from 'components/forms/form-toggle/compact';
 import Revisions from 'post-editor/editor-revisions';
@@ -21,6 +21,10 @@ import PostSchedule from 'components/post-schedule';
 import postScheduleUtils from 'components/post-schedule/utils';
 import siteUtils from 'lib/site/utils';
 import { recordStat, recordEvent } from 'lib/posts/stats';
+import { editPost } from 'state/posts/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPost } from 'state/posts/selectors';
 
 class EditPostStatus extends Component {
 
@@ -56,8 +60,9 @@ class EditPostStatus extends Component {
 		recordStat( stickyStat );
 		recordEvent( 'Changed Sticky Setting', stickyEventLabel );
 
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.edit( { sticky: ! this.props.post.sticky } );
+		this.props.editPost( this.props.siteId, this.props.postId,
+			{ sticky: ! this.props.post.sticky }
+		);
 	};
 
 	togglePendingStatus = () => {
@@ -66,8 +71,9 @@ class EditPostStatus extends Component {
 		recordStat( 'status_changed' );
 		recordEvent( 'Changed Pending Status', pending ? 'Marked Draft' : 'Marked Pending' );
 
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.edit( { status: pending ? 'draft' : 'pending' } );
+		this.props.editPost( this.props.siteId, this.props.postId,
+			{ status: pending ? 'draft' : 'pending' }
+		);
 	};
 
 	togglePostSchedulePopover = () => {
@@ -236,4 +242,17 @@ class EditPostStatus extends Component {
 	}
 }
 
-export default EditPostStatus;
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const post = getEditedPost( state, siteId, postId );
+
+		return {
+			siteId,
+			postId,
+			post
+		};
+	},
+	{ editPost }
+)( EditPostStatus );

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes, Component } from 'react';
-import noop from 'lodash/noop';
-import { moment, translate } from 'i18n-calypso';
+import { noop } from 'lodash';
+import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -29,12 +29,14 @@ import { getEditedPost } from 'state/posts/selectors';
 class EditPostStatus extends Component {
 
 	static propTypes = {
+		moment: PropTypes.func,
+		onDateChange: PropTypes.func,
+		onSave: PropTypes.func,
 		post: PropTypes.object,
 		savedPost: PropTypes.object,
-		type: PropTypes.string,
-		onSave: PropTypes.func,
-		onDateChange: PropTypes.func,
-		site: PropTypes.object
+		site: PropTypes.object,
+		translate: PropTypes.func,
+		type: PropTypes.string
 	};
 
 	constructor( props ) {
@@ -96,6 +98,7 @@ class EditPostStatus extends Component {
 
 	render() {
 		let isSticky, isPublished, isPending, canPublish, isScheduled;
+		const { translate } = this.props;
 
 		if ( this.props.post ) {
 			isSticky = this.props.post.sticky;
@@ -186,7 +189,7 @@ class EditPostStatus extends Component {
 		const tz = siteUtils.timezone( this.props.site ),
 			gmt = siteUtils.gmtOffset( this.props.site ),
 			selectedDay = this.props.post && this.props.post.date
-				? moment( this.props.post.date )
+				? this.props.moment( this.props.post.date )
 				: null;
 
 		return (
@@ -255,4 +258,4 @@ export default connect(
 		};
 	},
 	{ editPost }
-)( EditPostStatus );
+)( localize( EditPostStatus ) );

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -1,48 +1,49 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	noop = require( 'lodash/noop' );
+import React, { PropTypes, Component } from 'react';
+import noop from 'lodash/noop';
+import { moment, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-const actions = require( 'lib/posts/actions' ),
-	Button = require( 'components/button' ),
-	FormToggle = require( 'components/forms/form-toggle/compact' ),
-	Revisions = require( 'post-editor/editor-revisions' ),
-	Gridicon = require( 'components/gridicon' ),
-	postUtils = require( 'lib/posts/utils' ),
-	Popover = require( 'components/popover' ),
-	InfoPopover = require( 'components/info-popover' ),
-	Tooltip = require( 'components/tooltip' ),
-	PostSchedule = require( 'components/post-schedule' ),
-	postScheduleUtils = require( 'components/post-schedule/utils' ),
-	siteUtils = require( 'lib/site/utils' ),
-	stats = require( 'lib/posts/stats' );
+import actions from 'lib/posts/actions';
+import Button from 'components/button';
+import FormToggle from 'components/forms/form-toggle/compact';
+import Revisions from 'post-editor/editor-revisions';
+import Gridicon from 'components/gridicon';
+import postUtils from 'lib/posts/utils';
+import Popover from 'components/popover';
+import InfoPopover from 'components/info-popover';
+import Tooltip from 'components/tooltip';
+import PostSchedule from 'components/post-schedule';
+import postScheduleUtils from 'components/post-schedule/utils';
+import siteUtils from 'lib/site/utils';
+import { recordStat, recordEvent } from 'lib/posts/stats';
 
-export default React.createClass( {
-	displayName: 'EditPostStatus',
+class EditPostStatus extends Component {
 
-	propTypes: {
-		post: React.PropTypes.object,
-		savedPost: React.PropTypes.object,
-		type: React.PropTypes.string,
-		onSave: React.PropTypes.func,
-		onDateChange: React.PropTypes.func,
-		site: React.PropTypes.object
-	},
+	static propTypes = {
+		post: PropTypes.object,
+		savedPost: PropTypes.object,
+		type: PropTypes.string,
+		onSave: PropTypes.func,
+		onDateChange: PropTypes.func,
+		site: PropTypes.object
+	};
 
-	getInitialState: function() {
-		return {
+	constructor( props ) {
+		super( props );
+		this.state = {
 			showTZTooltip: false,
 			showPostSchedulePopover: false,
 			onDateChange: noop
 		};
-	},
+	}
 
-	toggleStickyStatus: function() {
-		var stickyStat, stickyEventLabel;
+	toggleStickyStatus = () => {
+		let stickyStat, stickyEventLabel;
 
 		if ( ! this.props.post.sticky ) {
 			stickyStat = 'advanced_sticky_enabled';
@@ -52,50 +53,49 @@ export default React.createClass( {
 			stickyEventLabel = 'Off';
 		}
 
-		stats.recordStat( stickyStat );
-		stats.recordEvent( 'Changed Sticky Setting', stickyEventLabel );
+		recordStat( stickyStat );
+		recordEvent( 'Changed Sticky Setting', stickyEventLabel );
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( { sticky: ! this.props.post.sticky } );
-	},
+	};
 
-	togglePendingStatus: function() {
-		var pending = this.props.post.status === 'pending';
+	togglePendingStatus = () => {
+		const pending = this.props.post.status === 'pending';
 
-		stats.recordStat( 'status_changed' );
-		stats.recordEvent( 'Changed Pending Status', pending ? 'Marked Draft' : 'Marked Pending' );
+		recordStat( 'status_changed' );
+		recordEvent( 'Changed Pending Status', pending ? 'Marked Draft' : 'Marked Pending' );
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( { status: pending ? 'draft' : 'pending' } );
-	},
+	};
 
-	togglePostSchedulePopover: function() {
+	togglePostSchedulePopover = () => {
 		this.setState( {
 			showPostSchedulePopover: ! this.state.showPostSchedulePopover
 		} );
-	},
+	};
 
-	revertToDraft: function() {
+	revertToDraft = () => {
 		this.props.onSave( 'draft' );
-	},
+	};
 
-	showTZTooltip: function() {
+	showTZTooltip = () => {
 		this.setState( { showTZTooltip: true } );
-	},
+	};
 
-	hideTZTooltip: function() {
+	hideTZTooltip = () => {
 		this.setState( { showTZTooltip: false } );
-	},
+	};
 
-	render: function() {
-		var isSticky, isPublished, isPending, canPublish, isScheduled, isPrivate;
+	render() {
+		let isSticky, isPublished, isPending, canPublish, isScheduled;
 
 		if ( this.props.post ) {
 			isSticky = this.props.post.sticky;
 			isPending = postUtils.isPending( this.props.post );
-			isPublished = this.props.savedPost.status === 'publish';
+			isPublished = postUtils.isPublished( this.props.savedPost );
 			isScheduled = this.props.savedPost.status === 'future';
-			isPrivate = this.props.savedPost.status === 'private';
 			canPublish = siteUtils.userCan( 'publish_posts', this.props.site );
 		}
 
@@ -121,7 +121,7 @@ export default React.createClass( {
 					{
 						postUtils.isFutureDated( this.props.savedPost )
 							? <span className="edit-post-status__future-label">
-									{ this.translate( 'Future' ) }
+									{ translate( 'Future' ) }
 								</span>
 							: <Gridicon icon="time" size={ 18 } />
 					}
@@ -136,51 +136,51 @@ export default React.createClass( {
 				{ this.props.type === 'post' &&
 					<label className="edit-post-status__sticky">
 						<span className="edit-post-status__label-text">
-							{ this.translate( 'Stick to the front page' ) }
+							{ translate( 'Stick to the front page' ) }
 							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
-								{ this.translate( 'Sticky posts will appear at the top of the posts listing.' ) }
+								{ translate( 'Sticky posts will appear at the top of the posts listing.' ) }
 							</InfoPopover>
 						</span>
 						<FormToggle
 							checked={ isSticky }
 							onChange={ this.toggleStickyStatus }
-							aria-label={ this.translate( 'Stick post to the front page' ) }
+							aria-label={ translate( 'Stick post to the front page' ) }
 						/>
 					</label>
 				}
 				{ ( ! isPublished && ! isScheduled && canPublish ) &&
 					<label className="edit-post-status__pending-review">
 						<span className="edit-post-status__label-text">
-							{ this.translate( 'Pending review' ) }
+							{ translate( 'Pending review' ) }
 							<InfoPopover position="top right">
-								{ this.translate( 'Flag this post to be reviewed for approval.' ) }
+								{ translate( 'Flag this post to be reviewed for approval.' ) }
 							</InfoPopover>
 						</span>
 						<FormToggle
 							checked={ isPending }
 							onChange={ this.togglePendingStatus }
-							aria-label={ this.translate( 'Request review for post' ) }
+							aria-label={ translate( 'Request review for post' ) }
 						/>
 					</label>
 				}
-				{ ( isPublished || isPrivate || isScheduled || isPending && ! canPublish ) &&
+				{ ( isPublished || isScheduled || isPending && ! canPublish ) &&
 					<Button
 						className="edit-post-status__revert-to-draft"
 						onClick={ this.revertToDraft }
 						compact={ true }
 					>
-						<Gridicon icon="undo" size={ 18 } /> { this.translate( 'Revert to draft' ) }
+						<Gridicon icon="undo" size={ 18 } /> { translate( 'Revert to draft' ) }
 					</Button>
 				}
 			</div>
 		);
-	},
+	}
 
-	renderPostSchedulePopover: function() {
-		var tz = siteUtils.timezone( this.props.site ),
+	renderPostSchedulePopover() {
+		const tz = siteUtils.timezone( this.props.site ),
 			gmt = siteUtils.gmtOffset( this.props.site ),
 			selectedDay = this.props.post && this.props.post.date
-				? this.moment( this.props.post.date )
+				? moment( this.props.post.date )
 				: null;
 
 		return (
@@ -200,10 +200,10 @@ export default React.createClass( {
 				</div>
 			</Popover>
 		);
-	},
+	}
 
-	renderTZTooltop: function() {
-		var timezone = siteUtils.timezone( this.props.site ),
+	renderTZTooltop() {
+		const timezone = siteUtils.timezone( this.props.site ),
 			gmtOffset = siteUtils.gmtOffset( this.props.site );
 
 		if ( ! ( timezone || postScheduleUtils.isValidGMTOffset( gmtOffset ) ) ) {
@@ -234,4 +234,6 @@ export default React.createClass( {
 			</Tooltip>
 		);
 	}
-} );
+}
+
+export default EditPostStatus;

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -58,7 +58,7 @@ export default React.createClass( {
 		};
 
 		return (
-			<EditorVisibility {...props} />
+			<EditorVisibility { ...props } />
 		);
 	},
 
@@ -72,7 +72,7 @@ export default React.createClass( {
 				</div>
 				<EditorPostType />
 				<div className="editor-action-bar__last-group">
-					{ this.props.post && this.props.type === 'post' && <EditorSticky post={ this.props.post } /> }
+					{ this.props.post && this.props.type === 'post' && <EditorSticky /> }
 					{ this.renderPostVisibility() }
 					<EditorDeletePost
 						post={ this.props.post }

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -228,7 +228,7 @@ export default React.createClass( {
 
 	closeSchedulePopover: function( wasCanceled ) {
 		if ( wasCanceled ) {
-			let date = this.props.savedPost && this.props.savedPost.date
+			const date = this.props.savedPost && this.props.savedPost.date
 				? this.moment( this.props.savedPost.date )
 				: null;
 
@@ -239,7 +239,7 @@ export default React.createClass( {
 	},
 
 	renderPostScheduler: function() {
-		var tz = siteUtils.timezone( this.props.site ),
+		const tz = siteUtils.timezone( this.props.site ),
 			gmtOffset = siteUtils.gmtOffset( this.props.site ),
 			postDate = this.props.post && this.props.post.date
 				? this.props.post.date
@@ -257,7 +257,7 @@ export default React.createClass( {
 	},
 
 	schedulePostPopover: function() {
-		var postScheduler = this.renderPostScheduler();
+		const postScheduler = this.renderPostScheduler();
 
 		return (
 			<Popover
@@ -286,7 +286,7 @@ export default React.createClass( {
 	},
 
 	getFirstDayOfTheMonth: function( date ) {
-		var tz = siteUtils.timezone( this.props.site );
+		const tz = siteUtils.timezone( this.props.site );
 		date = date || this.moment();
 
 		return postUtils.getOffsetDate( date, tz ).set( {
@@ -421,7 +421,6 @@ export default React.createClass( {
 				{
 					this.state.showAdvanceStatus &&
 						<EditPostStatus
-							post={ this.props.post }
 							savedPost={ this.props.savedPost }
 							type={ this.props.type }
 							onSave={ this.props.onSave }
@@ -473,7 +472,9 @@ export default React.createClass( {
 				</div>
 				{
 					this.state.needsVerification &&
-					<div className="editor-ground-control__email-verification-notice" tabIndex={ 7 } onClick={ this.props.onMoreInfoAboutEmailVerify }>
+					<div className="editor-ground-control__email-verification-notice"
+						tabIndex={ 7 }
+						onClick={ this.props.onMoreInfoAboutEmailVerify }>
 						<Gridicon
 							icon="info"
 							className="editor-ground-control__email-verification-notice-icon" />

--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -21,7 +21,9 @@ const EditorSticky = React.createClass( {
 	displayName: 'EditorSticky',
 
 	propTypes: {
-		post: React.PropTypes.object
+		postId: React.PropTypes.number,
+		siteId: React.PropTypes.number,
+		sticky: React.PropTypes.bool
 	},
 
 	getInitialState: function() {
@@ -45,8 +47,9 @@ const EditorSticky = React.createClass( {
 		recordStat( stickyStat );
 		recordEvent( 'Changed Sticky Setting', stickyEventLabel );
 
-		this.props.editPost( this.props.siteId, this.props.postId,
-			{ sticky: ! this.props.sticky } );
+		this.props.editPost( this.props.siteId, this.props.postId, {
+			sticky: ! this.props.sticky
+		} );
 		this.setState( { tooltip: false } );
 	},
 

--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -3,17 +3,21 @@
  */
 import React from 'react';
 import classnames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import postActions from 'lib/posts/actions';
 import Tooltip from 'components/tooltip';
 import Gridicon from 'components/gridicon';
 import Button from 'components/button';
 import { recordStat, recordEvent } from 'lib/posts/stats';
+import { editPost } from 'state/posts/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
 
-export default React.createClass( {
+const EditorSticky = React.createClass( {
 	displayName: 'EditorSticky',
 
 	propTypes: {
@@ -30,7 +34,7 @@ export default React.createClass( {
 		let stickyStat;
 		let stickyEventLabel;
 
-		if ( ! this.props.post.sticky ) {
+		if ( ! this.props.sticky ) {
 			stickyStat = 'advanced_sticky_enabled_toolbar';
 			stickyEventLabel = 'On';
 		} else {
@@ -41,15 +45,15 @@ export default React.createClass( {
 		recordStat( stickyStat );
 		recordEvent( 'Changed Sticky Setting', stickyEventLabel );
 
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		postActions.edit( { sticky: ! this.props.post.sticky } );
+		this.props.editPost( this.props.siteId, this.props.postId,
+			{ sticky: ! this.props.sticky } );
 		this.setState( { tooltip: false } );
 	},
 
 	render: function() {
 		const classes = classnames(
 			'editor-sticky',
-			{ 'is-sticky': this.props.post && this.props.post.sticky }
+			{ 'is-sticky': this.props.sticky }
 		);
 
 		return (
@@ -69,7 +73,7 @@ export default React.createClass( {
 					isVisible={ this.state.tooltip }
 					position="bottom left"
 				>
-					{ this.props.post && this.props.post.sticky
+					{ this.props.sticky
 						? <span>{ this.translate( 'Marked as sticky' ) }</span>
 						: <div>
 							{ this.translate( 'Mark as sticky' ) }
@@ -83,3 +87,18 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	( state ) => {
+		const postId = getEditorPostId( state );
+		const siteId = getSelectedSiteId( state );
+		const sticky = getEditedPostValue( state, siteId, postId, 'sticky' );
+
+		return {
+			postId,
+			siteId,
+			sticky
+		};
+	},
+	{ editPost }
+)( EditorSticky );


### PR DESCRIPTION
It's difficult to get back to the "draft" status for private posts.
We had to toggle visibility to public and then click the "revert to draft" button.
With this PR, I just display the button for private posts as well.

closes #1770

**Testing instructions**

* Publish a private post
* Click on the "⚙ Published privately" 
* You should see the "Revert to draft" Button
* Click on the button to get back to the "draft" status.

cc @timmyc 