### PR TITLE
Domains: Update the copy for the domain's owner

### DIFF
--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -459,7 +459,8 @@ export default React.createClass( {
 
 		if ( domains.length === 1 ) {
 			const fullMessage = this.translate(
-				'The domain {{strong}}%(domain)s{{/strong}} may be suspended because the owner ({{strong}}%(owner)s{{/strong}}) has not verified their contact information.',
+				'The domain {{strong}}%(domain)s{{/strong}} may be suspended because the owner, ' +
+					'{{strong}}%(owner)s{{/strong}}, has not verified their contact information.',
 				{
 					components: { strong: <strong /> },
 					args: {


### PR DESCRIPTION
The `owner` string will now include the username (to differentiate users who have the same display name) in the format `Display Name (username)`. So putting that inside another brackets doesn't look good - I've opted to use commas instead.

Hat tip to @aidvu for the suggestion.

Use `D2960-code` to test this new format.

/cc @aidvu @umurkontaci 