### PR TITLE
Signup: remove price from translations in Pressable step

### DIFF
--- a/client/signup/steps/design-type-with-store/pressable-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/pressable-store/index.jsx
@@ -86,7 +86,9 @@ class PressableStoreStep extends Component {
 					<HeroImage />
 
 					<FormSectionHeading className="pressable-store__heading">
-						{ translate( 'Get your store for as low as $25 / month' ) }
+						{ translate( 'Get your store for as low as %(price)s / month', {
+							args: { price: '$25' }
+						} ) }
 					</FormSectionHeading>
 					<p className="pressable-store__copy">
 						{ translate( 'We\'ve partnered with Pressable, a top-notch WordPress hosting provider,' +

--- a/client/signup/steps/theme-selection/pressable-theme/index.jsx
+++ b/client/signup/steps/theme-selection/pressable-theme/index.jsx
@@ -84,7 +84,11 @@ export default React.createClass( {
 				<LoggedOutForm className="pressable-theme__form" onSubmit={ this.onSubmit }>
 					<HeroImage />
 
-					<FormSectionHeading className="pressable-theme__heading">{ this.translate( 'Host your WordPress site, and use your own theme for as low as $25 / month' ) }</FormSectionHeading>
+					<FormSectionHeading className="pressable-theme__heading">
+						{ this.translate( 'Host your WordPress site, and use your own theme for as low as %(price)s / month', {
+							args: { price: '$25' }
+						} ) }
+					</FormSectionHeading>
 					<p className="pressable-theme__copy">{ this.translate( 'We\'ve partnered with Pressable, a top-notch WordPress hosting provider, to make setting up your WordPress site with your own theme a snap.' ) }</p>
 
 					<LoggedOutFormFooter>


### PR DESCRIPTION
Remove prices from translated strings in Pressable theme upload step,
and Pressable eCommerce store step.