### PR TITLE
Signup: Updates Survey step for better customisation with users who want a blog

### DIFF
--- a/client/signup/steps/get-dot-blog-survey/index.jsx
+++ b/client/signup/steps/get-dot-blog-survey/index.jsx
@@ -6,7 +6,7 @@ import page from 'page';
 // Internal dependencies
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getStepUrl } from 'signup/utils';
-import SurveyStep from 'signup/steps/survey';
+import SurveyStepV1 from 'signup/steps/survey/survey-step-v1';
 
 class GetDotBlogSurvey extends Component {
 	constructor( props ) {
@@ -25,7 +25,7 @@ class GetDotBlogSurvey extends Component {
 
 	render() {
 		return (
-			<SurveyStep { ...this.props } />
+			<SurveyStepV1 { ...this.props } />
 		);
 	}
 }

--- a/client/signup/steps/survey/survey-step-v1.jsx
+++ b/client/signup/steps/survey/survey-step-v1.jsx
@@ -106,17 +106,27 @@ export default React.createClass( {
 		);
 	},
 
+	renderHeaderText() {
+		return this.props.surveySiteType === 'blog'
+			? this.translate( 'Create your blog today!' )
+			: this.translate( 'Create your site today!' );
+	},
+
+	renderSubHeaderText() {
+		return this.props.surveySiteType === 'blog'
+			? this.translate( 'WordPress.com is the best place for your WordPress blog.' )
+			: this.translate( 'WordPress.com is the best place for your WordPress blog or website.' );
+	},
+
 	render() {
-		const blogHeaderText = this.translate( 'Create your blog today!' );
-		const siteHeaderText = this.translate( 'Create your site today!' );
 		return (
 			<div className="survey-step__section-wrapper">
 				<StepWrapper
 					flowName={ this.props.flowName }
 					stepName={ this.props.stepName }
 					positionInFlow={ this.props.positionInFlow }
-					headerText={ this.props.surveySiteType === 'blog' ? blogHeaderText : siteHeaderText }
-					subHeaderText={ this.translate( 'WordPress.com is the best place for your WordPress blog or website.' ) }
+					headerText={ this.renderHeaderText() }
+					subHeaderText={ this.renderSubHeaderText() }
 					signupProgressStore={ this.props.signupProgressStore }
 					stepContent={ this.renderOptionList() } />
 			</div>

--- a/client/signup/steps/survey/survey-step-v1.jsx
+++ b/client/signup/steps/survey/survey-step-v1.jsx
@@ -109,9 +109,19 @@ export default React.createClass( {
 	},
 
 	renderHeaderText() {
-		return this.props.surveySiteType === 'blog'
-			? this.translate( 'Create your blog today!' )
-			: this.translate( 'Create your site today!' );
+		if ( this.props.surveySiteType === 'blog' ) {
+			const domain = this.props.queryObject && this.props.queryObject.domain;
+
+			if ( domain ) {
+				return this.translate( 'Start blogging on %(domain)s today!', {
+					args: { domain }
+				} );
+			}
+
+			return this.translate( 'Create your blog today!' );
+		}
+
+		return this.translate( 'Create your site today!' );
 	},
 
 	renderSubHeaderText() {

--- a/client/signup/steps/survey/survey-step-v1.jsx
+++ b/client/signup/steps/survey/survey-step-v1.jsx
@@ -69,7 +69,7 @@ export default React.createClass( {
 		};
 		return (
 			<Card className="survey-step__vertical" key={ 'step-one-' + vertical.value } href="#" onClick={ stepOneClickHandler }>
-				<Gridicon icon={ icon } className="survey-step__vertical__icon"/>
+				<Gridicon icon={ icon } className="survey-step__vertical__icon" />
 				<label className="survey-step__label">{ vertical.label }</label>
 			</Card>
 		);
@@ -79,11 +79,11 @@ export default React.createClass( {
 		const blogLabel = this.translate( 'What is your blog about?' );
 		const siteLabel = this.translate( 'What is your website about?' );
 
-		let verticalsClasses = classNames(
+		const verticalsClasses = classNames(
 				'survey-step__verticals',
 				{ active: ! this.state.stepOne } );
 
-		let subVerticalsClasses = classNames(
+		const subVerticalsClasses = classNames(
 				'survey-step__sub-verticals',
 				{ active: this.state.stepOne } );
 

--- a/client/signup/steps/survey/survey-step-v1.jsx
+++ b/client/signup/steps/survey/survey-step-v1.jsx
@@ -98,7 +98,9 @@ export default React.createClass( {
 					</div>
 
 					<Card className={ subVerticalsClasses }>
-						<BackButton isCompact className="survey-step__title" onClick={ this.showStepOne }>{ this.state.stepOne && this.state.stepOne.label }</BackButton>
+						<BackButton isCompact className="survey-step__title" onClick={ this.showStepOne }>
+							{ this.state.stepOne && this.state.stepOne.label }
+						</BackButton>
 						{ this.state.stepTwo.map( this.renderStepTwoVertical ) }
 					</Card>
 				</div>
@@ -170,7 +172,11 @@ export default React.createClass( {
 				category_label: label
 			} );
 		}
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { surveySiteType: this.props.surveySiteType, surveyQuestion: vertical.value } );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			[],
+			{ surveySiteType: this.props.surveySiteType, surveyQuestion: vertical.value }
+		);
 		this.props.goToNextStep();
 	}
 } );


### PR DESCRIPTION
This pull request updates the `Survey` step in the signup flow to handle users coming from get.blog by customizing its copy (according to p7G0UL-6J-p2/#comment-139).
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/19072813/9bf478a2-8a37-11e6-96cb-38b62fe7372b.png)

#### Testing instructions
 
1. Run `git checkout update/survey-step` and start your server, or open a [live branch](https://calypso.live/?branch=update/survey-step)
2. Open the [`Signup` page](http://calypso.localhost:3000/start/get-dot-blog?domain=example.blog) for get.blog
3. Check that the copy now focuses exclusively on _blogs_ (as opposed to _sites_)
4. Check that the domain name purchased on get.blog appears in the heading
 
#### Reviews
 
- [x] Code
- [x] Product

@Automattic/sdev-feed