### PR TITLE
WP.com Plugins: adding Advanced SEO to page

### DIFF
--- a/client/my-sites/plugins-wpcom/default-plugins.js
+++ b/client/my-sites/plugins-wpcom/default-plugins.js
@@ -193,7 +193,7 @@ export const defaultBusinessPlugins = [
 	},
 	{
 		name: i18n.translate( 'Google Analytics' ),
-		descriptionLink: '/plans/{siteSlug}/?feature=google-analytics',
+		descriptionLink: 'https://en.support.wordpress.com/google-analytics/',
 		icon: 'stats',
 		category: 'Business',
 		description: i18n.translate( 'Advanced features to complement WordPress.com stats. Funnel reports, goal conversion, and more.' )

--- a/client/my-sites/plugins-wpcom/default-plugins.js
+++ b/client/my-sites/plugins-wpcom/default-plugins.js
@@ -185,6 +185,13 @@ export const defaultPremiumPlugins = [
  */
 export const defaultBusinessPlugins = [
 	{
+		name: i18n.translate( 'Advanced SEO' ),
+		descriptionLink: 'https://support.wordpress.com/advanced-seo/',
+		icon: 'search',
+		category: 'Traffic Growth',
+		description: i18n.translate( 'Custom meta descriptions, social media previews, and more.' )
+	},
+	{
 		name: i18n.translate( 'Google Analytics' ),
 		descriptionLink: '/plans/{siteSlug}/?feature=google-analytics',
 		icon: 'stats',

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -47,10 +47,18 @@
 	}
 }
 
-// Special styles for displaying only one plugin
+// Special styles for displaying only two plugins
 .wpcom-plugins__business-panel .wpcom-plugins__plugin-item {
 	width: 100%;
-	border: none;
+	
+	&:last-child {
+		border-right: none;
+	}
+	
+	@include breakpoint( ">960px" ) {
+		width: 50%;
+		border-right: 1px solid lighten( $gray, 20% );
+	}
 }
 
 .wpcom-plugins__plugin-item a {


### PR DESCRIPTION
Advanced SEO is a new feature and it should be added to the Plugins page. Currently links to the support doc.

Fixes #8507 

Before:

![screen shot 2016-10-06 at 10 19 10 am](https://cloud.githubusercontent.com/assets/618551/19159776/3dcc94f8-8bb3-11e6-85bf-a1551a3ea39b.png)

After:

![screen shot 2016-10-06 at 10 51 14 am](https://cloud.githubusercontent.com/assets/618551/19159789/43ee5c04-8bb3-11e6-8784-8823f9d45e59.png)