### PR TITLE
SiteList: Stop creating a new array when getting a site by ID

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -388,13 +388,13 @@ SitesList.prototype.getSite = function( siteID ) {
 		return false;
 	}
 
-	return this.get().filter( function( site ) {
+	return find( this.get(), function( site ) {
 		// We need to check `slug` before `domain` to grab the correct site on certain
 		// clashes between a domain redirect and a Jetpack site, as well as domains
 		// on subfolders, but we also need to look for the `domain` as a last resort
 		// to cover mapped domains for regular WP.com sites.
 		return site.ID === siteID || site.slug === siteID || site.domain === siteID || site.wpcom_url === siteID;
-	}, this ).shift();
+	} );
 };
 
 /**


### PR DESCRIPTION
The current code uses  to grab the first element, but this has the unfortunate side effect of creating a new array, in addition to getting the first element. This results in a lot of unnecessary time spent in the GC collecting garbage.

Since getSite gets called so much, this seems to avoid creating a bunch of garbage.

To test, use the app, especially digging through anything that uses the site picker.

To verify the perf boost, profile the app (in production mode) with and without this change.