### PR TITLE
Framework: Replace inappropriate filter usage with find, some, every

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -2,9 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:chart' ),
-	noop = require( 'lodash/noop' ),
-	throttle = require( 'lodash/throttle' );
+	debug = require( 'debug' )( 'calypso:chart' );
+import { some, noop, throttle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -110,11 +109,7 @@ module.exports = React.createClass( {
 	},
 
 	isEmptyChart: function( values ) {
-		values = values.filter( function( value ) {
-			return value > 0;
-		}, this );
-
-		return values.length === 0;
+		return ! some( values, ( value ) => value > 0 );
 	},
 
 	render: function() {

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -4,6 +4,7 @@
 var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	debug = require( 'debug' )( 'calypso:module-chart:legend' );
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -64,9 +65,7 @@ var Legend = React.createClass( {
 				checked = ( -1 !== this.props.activeCharts.indexOf( legendItem ) ),
 				tab;
 
-			tab = this.props.tabs.filter( function( tab ) {
-				return tab.attr === legendItem;
-			} ).shift();
+			tab = find( this.props.tabs, { attr: legendItem } );
 
 			return <LegendItem key={ index } className={ colorClass } label={ tab.label } attr={ tab.attr } changeHandler={ this.onFilterChange } checked={ checked } />;
 		}, this );

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	noop = require( 'lodash/noop' ),
-	head = require( 'lodash/head' ),
-	filter = require( 'lodash/filter' );
+var React = require( 'react' );
+import { noop, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -95,9 +93,9 @@ module.exports = React.createClass( {
 
 	_getCountryData: function() {
 		// TODO: move this to country-list or CountrySelect
-		return head( filter( this.props.countriesList.get(), {
+		return find( this.props.countriesList.get(), {
 			code: this.state.countryCode
-		} ) );
+		} );
 	},
 
 	_handleCountryChange: function( newValue ) {

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import map from 'lodash/map';
-import forEach from 'lodash/forEach';
-import head from 'lodash/head';
-import includes from 'lodash/includes';
-import keys from 'lodash/keys';
+import { map, forEach, head, includes, keys, find } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
 import i18n from 'i18n-calypso';
@@ -69,9 +65,9 @@ export default React.createClass( {
 
 	autoFillUsername( form ) {
 		const steps = getFlowSteps( this.props.flowName );
-		const domainSteps = steps.filter( step => step.match( /^domain/ ) );
+		const domainStep = find( steps, step => step.match( /^domain/ ) );
 		let domainName = getValueFromProgressStore( {
-			stepName: domainSteps[0] || null,
+			stepName: domainStep || null,
 			fieldName: 'siteUrl',
 			signupProgressStore: this.props.signupProgressStore
 		} );

--- a/client/lib/billing-history-data/index.js
+++ b/client/lib/billing-history-data/index.js
@@ -4,8 +4,8 @@
 var debug = require( 'debug' )( 'calypso:my-sites:billing-history:billing-data' ),
 	Emitter = require( 'lib/mixins/emitter' ),
 	store = require( 'store' ),
-	assign = require( 'lodash/assign'),
 	i18n = require( 'i18n-calypso' );
+import { assign, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -66,9 +66,7 @@ BillingData.prototype.getTransaction = function( id ) {
 		return null;
 	}
 
-	return this.data.billingHistory.filter( function( transaction ) {
-		return id === transaction.id;
-	} )[ 0 ];
+	return find( this.data.billingHistory, { id } );
 };
 
 module.exports = new BillingData();

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -3,18 +3,8 @@
 /**
  * External dependencies
  */
-var update = require( 'react-addons-update' ),
-	every = require( 'lodash/every' ),
-	assign = require( 'lodash/assign' ),
-	flow = require( 'lodash/flow' ),
-	isEqual = require( 'lodash/isEqual' ),
-	merge = require( 'lodash/merge' ),
-	reject = require( 'lodash/reject' ),
-	tail = require( 'lodash/tail' ),
-	some = require( 'lodash/some' ),
-	uniq = require( 'lodash/uniq' ),
-	flatten = require( 'lodash/flatten' ),
-	filter = require( 'lodash/filter' );
+var update = require( 'react-addons-update' );
+import { every, assign, flow, isEqual, merge, reject, tail, some, uniq, flatten, filter, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -535,7 +525,7 @@ function getItemForPlan( plan, properties ) {
  * @returns {Object} the corresponding item in the shopping cart as `CartItemValue` object
  */
 function findFreeTrial( cart ) {
-	return filter( getAll( cart ), { free_trial: true } )[ 0 ];
+	return find( getAll( cart ), { free_trial: true } );
 }
 
 /**

--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -1,16 +1,7 @@
 /**
  * External dependencies
  */
-import endsWith from 'lodash/endsWith';
-import filter from 'lodash/filter';
-import find from 'lodash/find';
-import includes from 'lodash/includes';
-import mapValues from 'lodash/mapValues';
-import startsWith from 'lodash/startsWith';
-import trimStart from 'lodash/trimStart';
-import without from 'lodash/without';
-import matches from 'lodash/matches';
-import negate from 'lodash/negate';
+import { endsWith, filter, find, includes, mapValues, startsWith, trimStart, without, matches, negate, some } from 'lodash';
 
 function validateAllFields( fieldValues, domainName ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
@@ -154,9 +145,7 @@ function removeDuplicateWpcomRecords( domain, records ) {
 }
 
 function addMissingWpcomRecords( domain, records ) {
-	const rootARecords = filter( records, isRootARecord( domain ) );
-
-	if ( rootARecords.length === 0 ) {
+	if ( ! some( records, isRootARecord( domain ) ) ) {
 		const defaultRootARecord = {
 			domain,
 			id: `wpcom:A:${domain}.:${domain}`,

--- a/client/lib/follow-list/index.js
+++ b/client/lib/follow-list/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
  * Internal dependencies
  */
 var FollowListSite = require( './site.js' );
@@ -29,10 +34,7 @@ FollowList.prototype.add = function( object ) {
 };
 
 FollowList.prototype.siteExists = function( site_id ) {
-	var match = this.data.filter( function( followListSite ) {
-		return followListSite.site_id === site_id;
-	} );
-	return match.length ? match[ 0 ] : false;
+	return find( this.data, { site_id } ) || false;
 };
 
 module.exports = FollowList;

--- a/client/lib/keyboard-shortcuts/index.js
+++ b/client/lib/keyboard-shortcuts/index.js
@@ -114,6 +114,7 @@ KeyboardShortcuts.prototype.bindShortcut = function( eventName, keys, type, chec
 				// https://bugs.webkit.org/show_bug.cgi?id=19906
 				if ( checkKeys && checkKeys.length > 0 ) {
 					keyValue = self._getKey( event );
+					// TODO: Could this be replaced by Array#some ?
 					matches = checkKeys.filter( function( key ) {
 						return key === keyValue;
 					} );

--- a/client/lib/local-list/index.js
+++ b/client/lib/local-list/index.js
@@ -3,6 +3,7 @@
  */
 var debug = require( 'debug' )( 'calypso:stats-data:local-list' ),
 	store = require( 'store' );
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -89,18 +90,7 @@ StatsDataLocalList.prototype.set = function( key, value ) {
  * @api public
  */
 StatsDataLocalList.prototype.find = function( key ) {
-	var matchedRecord;
-
-	matchedRecord = this.getData().filter( function( cachedRecord ) {
-		return cachedRecord && ( cachedRecord.key === key );
-	} );
-
-	if ( matchedRecord.length > 0  ) {
-		debug( 'found local record for ' + key , matchedRecord[ 0 ] );
-		return matchedRecord[ 0 ];
-	} else {
-		return false;
-	}
+	return find( this.getData(), { key } ) || false;
 };
 
 /**

--- a/client/lib/plans-list/index.js
+++ b/client/lib/plans-list/index.js
@@ -3,6 +3,7 @@
  */
 import debugFactory from 'debug';
 import store from 'store';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -111,13 +112,8 @@ PlansList.prototype.getPlanBySlug = function( slug ) {
 	if ( ! this.data ) {
 		return null;
 	}
-	const filteredPlans = this.data.filter( ( plan ) => {
-		if ( plan && plan.product_slug === slug ) {
-			return plan;
-		}
-	} );
 
-	return filteredPlans[ 0 ];
+	return find( this.data, { product_slug: slug } );
 };
 
 // Save the plans to memory to save them being fetched

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -1,13 +1,8 @@
 /**
  * External dependencies
  */
-var assign = require( 'lodash/assign' ),
-	isArray = require( 'lodash/isArray' ),
-	debug = require( 'debug' )( 'calypso:sites-plugins:sites-plugins-store' ),
-	sortBy = require( 'lodash/sortBy' ),
-	uniq = require( 'lodash/uniq' ),
-	compact = require( 'lodash/compact' ),
-	values = require( 'lodash/values' );
+var debug = require( 'debug' )( 'calypso:sites-plugins:sites-plugins-store' );
+import { assign, isArray, sortBy, uniq, compact, values, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -236,8 +231,8 @@ PluginsStore = {
 		if ( ! plugins ) {
 			return plugins;
 		}
-		plugins = plugins.filter( _filters.isEqual.bind( this, pluginSlug ) );
-		return plugins[ 0 ];
+
+		return find( plugins, _filters.isEqual.bind( this, pluginSlug ) );
 	},
 
 	// Array of sites with a particular plugin.
@@ -248,8 +243,8 @@ PluginsStore = {
 		if ( ! plugins ) {
 			return;
 		}
-		plugins = plugins.filter( _filters.isEqual.bind( this, pluginSlug ) );
-		plugin = plugins.pop();
+
+		plugin = find( plugins, _filters.isEqual.bind( this, pluginSlug ) );
 		if ( ! plugin ) {
 			return null;
 		}

--- a/client/lib/post-normalizer/rule-first-pass-canonical-image.js
+++ b/client/lib/post-normalizer/rule-first-pass-canonical-image.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { assign, filter, head, startsWith } from 'lodash';
+import { assign, find, startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -23,9 +23,7 @@ export default function firstPassCanonicalImage( post ) {
 			type: 'image'
 		}, imageSizeFromAttachments( post.featured_image ) );
 	} else {
-		const candidate = head( filter( post.attachments, function( attachment ) {
-			return startsWith( attachment.mime_type, 'image/' );
-		} ) );
+		const candidate = find( post.attachments, ( { mime_type } ) => startsWith( mime_type, 'image/' ) );
 
 		if ( candidate ) {
 			post.canonical_image = {

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { filter } from 'lodash';
+import { find } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -34,7 +34,7 @@ export default function pickCanonicalImage( post ) {
 		post.canonical_image = null;
 	}
 	if ( post.images ) {
-		canonicalImage = filter( post.images, candidateForCanonicalImage )[ 0 ];
+		canonicalImage = find( post.images, candidateForCanonicalImage );
 		if ( canonicalImage ) {
 			canonicalImage = {
 				uri: canonicalImage.src,

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -403,9 +403,7 @@ SitesList.prototype.getSite = function( siteID ) {
  * @api public
  **/
 SitesList.prototype.getPrimary = function() {
-	return this.get().filter( function( site ) {
-		return site.primary === true;
-	}, this ).shift();
+	return find( this.get(), 'primary' );
 };
 
 /**

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import PureRenderMixin from 'react-pure-render/mixin';
-import isEqual from 'lodash/isEqual';
+import { isEqual, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -136,7 +136,7 @@ module.exports = React.createClass( {
 			}
 		} ) );
 
-		const selectedItem = options.filter( o => o.props.selected )[0];
+		const selectedItem = find( options, 'props.selected' );
 
 		return (
 			<div className="help-contact-form__selection">

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import filter from 'lodash/filter';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -120,9 +120,8 @@ module.exports = React.createClass( {
 
 	checkForSubscriptions( event ) {
 		trackDeleteSiteOption( 'delete-site' );
-		const activeSubscriptions = filter( this.props.sitePurchases, 'active' );
 
-		if ( ! activeSubscriptions.length ) {
+		if ( ! some( this.props.sitePurchases, 'active' ) ) {
 			return true;
 		}
 

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import debugFactory from 'debug';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import page from 'page';
-import property from 'lodash/property';
+import { some } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -212,15 +212,13 @@ export const DeleteSite = React.createClass( {
 	},
 
 	handleDeleteSiteClick: function( event ) {
-		var hasActiveSubscriptions;
-
 		event.preventDefault();
 
 		if ( ! this.props.hasLoadedSitePurchasesFromServer ) {
 			return;
 		}
 
-		hasActiveSubscriptions = this.props.sitePurchases.filter( property( 'active' ) ).length > 0;
+		const hasActiveSubscriptions = some( this.props.sitePurchases, 'active' );
 
 		if ( hasActiveSubscriptions ) {
 			this.setState( { showWarningDialog: true } );

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';
+import { find } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -184,16 +185,14 @@ module.exports = {
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Stats', { textOnly: true } ) ) );
 
-		let activeFilter = filters().filter( function( filter ) {
+		const activeFilter = find( filters(), ( filter ) => {
 			return context.pathname === filter.path || ( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) );
-		}, this );
+		} );
 
 		// Validate that date filter is legit
-		if ( 0 === activeFilter.length ) {
+		if ( ! activeFilter ) {
 			next();
 		} else {
-			activeFilter = activeFilter.shift();
-
 			analytics.mc.bumpStat( 'calypso_stats_overview_period', activeFilter.period );
 			analytics.pageView.record( basePath, analyticsPageTitle + ' > ' + titlecase( activeFilter.period ) );
 
@@ -252,11 +251,11 @@ module.exports = {
 		}
 		siteId = currentSite ? ( currentSite.ID || 0 ) : 0;
 
-		let activeFilter = filters().filter( function( filter ) {
+		const activeFilter = find( filters(), ( filter ) => {
 			return context.pathname === filter.path || ( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) );
-		}, this );
+		} );
 
-		if ( ( ! siteFragment ) || ( 0 === activeFilter.length ) ) {
+		if ( ! siteFragment || ! activeFilter ) {
 			next();
 		} else {
 			if ( 0 === siteId ) {
@@ -278,7 +277,6 @@ module.exports = {
 				siteOffset = currentSite.options.gmt_offset;
 			}
 			momentSiteZone = i18n.moment().utcOffset( siteOffset );
-			activeFilter = activeFilter.shift();
 			chartDate = rangeOfPeriod( activeFilter.period, momentSiteZone.clone().locale( 'en' ) ).endOf;
 			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid ) {
 				date = i18n.moment( queryOptions.startDate ).locale( 'en' );
@@ -449,9 +447,9 @@ module.exports = {
 		}
 		siteId = site ? ( site.ID || 0 ) : 0;
 
-		let activeFilter = filters().filter( function( filter ) {
+		const activeFilter = find( filters(), ( filter ) => {
 			return context.pathname === filter.path || ( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) );
-		}, this );
+		} );
 
 		// if we have a siteFragment, but no siteId, wait for the sites list
 		if ( siteFragment && 0 === siteId ) {
@@ -463,13 +461,12 @@ module.exports = {
 				// site is not in the user's site list
 				window.location = '/stats';
 			}
-		} else if ( 0 === activeFilter.length || -1 === validModules.indexOf( context.params.module ) ) {
+		} else if ( ! activeFilter || -1 === validModules.indexOf( context.params.module ) ) {
 			next();
 		} else {
 			if ( 'object' === typeof( site.options ) && 'undefined' !== typeof( site.options.gmt_offset ) ) {
 				momentSiteZone = i18n.moment().utcOffset( site.options.gmt_offset );
 			}
-			activeFilter = activeFilter.shift();
 			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid ) {
 				date = i18n.moment( queryOptions.startDate );
 			} else {

--- a/client/my-sites/stats/stats-summary-chart/index.jsx
+++ b/client/my-sites/stats/stats-summary-chart/index.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	isEqual = require( 'lodash/isEqual' );
+	classNames = require( 'classnames' );
+import { isEqual, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -50,9 +50,7 @@ module.exports = React.createClass( {
 	},
 
 	barClick: function( bar ) {
-		var selectedBar = this.props.dataList.response.data.filter( function( data ) {
-			return isEqual( data, bar.data );
-		}, this ).shift();
+		const selectedBar = find( this.props.dataList.response.data, ( data ) => isEqual( data, bar.data ) );
 
 		analytics.ga.recordEvent( 'Stats', 'Clicked Summary Chart Bar' );
 		this.setState( {

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,13 +28,7 @@ export default React.createClass( {
 		let statsTabs;
 
 		if ( dataList ) {
-			let data = dataList.response.data.filter( function( item ) {
-				return item[ activeKey ] === activeIndex;
-			} );
-
-			if ( data.length ) {
-				data = data.pop();
-			}
+			const data = find( dataList.response.data, { [ activeKey ]: activeIndex } );
 
 			statsTabs = tabs.map( function( tab ) {
 				const hasData = data && ( data[ tab.attr ] >= 0 ) && ( data[ tab.attr ] !== null );

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import page from 'page';
 import debugFactory from 'debug';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,9 +28,9 @@ module.exports = React.createClass( {
 	mixins: [ observe( 'sites', 'summaryList' ) ],
 
 	getActiveFilter: function() {
-		return this.props.filters().filter( function( filter ) {
+		return find( this.props.filters(), ( filter ) => {
 			return this.props.path === filter.path || ( filter.altPaths && -1 !== filter.altPaths.indexOf( this.props.path ) );
-		}, this ).shift();
+		} );
 	},
 
 	goBack: function() {

--- a/client/my-sites/upgrades/checkout/credit-card-selector.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-selector.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	filter = require( 'lodash/filter' ),
 	classNames = require( 'classnames' );
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -86,7 +86,7 @@ var CreditCardSelector = React.createClass({
 	},
 
 	getStoredCardDetails: function( section ) {
-		return filter( this.props.cards, { stored_details_id: section } )[ 0 ];
+		return find( this.props.cards, { stored_details_id: section } );
 	}
 } );
 

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -4,9 +4,7 @@
 import React from 'react';
 import _debug from 'debug';
 import moment from 'moment';
-import intersection from 'lodash/intersection';
-import map from 'lodash/map';
-import every from 'lodash/every';
+import { intersection, map, every, find } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -522,13 +520,11 @@ export default React.createClass( {
 	},
 
 	pendingTransfer() {
-		const domains = this.getDomains().filter( domain => domain.pendingTransfer );
+		const domain = find( this.getDomains(), 'pendingTransfer' );
 
-		if ( domains.length !== 1 ) {
+		if ( ! domain ) {
 			return null;
 		}
-
-		const domain = domains[ 0 ];
 
 		const compactNotice = this.translate( '{{strong}}%(domain)s{{/strong}} is pending transfer.', {
 				components: { strong: <strong /> },

--- a/client/state/plans/selectors.js
+++ b/client/state/plans/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import get from 'lodash/get';
+import { get, find } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -35,7 +35,7 @@ export const isRequestingPlans = state => {
  * @return {Object} the matching plan
  */
 export const getPlan = createSelector(
-	( state, productId ) => getPlans( state ).filter( plan => plan.product_id === productId ).shift(),
+	( state, productId ) => find( getPlans( state ), { product_id: productId } ),
 	( state ) => getPlans( state )
 );
 
@@ -46,7 +46,7 @@ export const getPlan = createSelector(
  * @return {Object} the matching plan
  */
 export const getPlanBySlug = createSelector(
-	( state, planSlug ) => getPlans( state ).filter( plan => plan.product_slug === planSlug ).shift(),
+	( state, planSlug ) => find( getPlans( state ), { product_slug: planSlug } ),
 	( state ) => getPlans( state )
 );
 

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -1,5 +1,7 @@
-import find from 'lodash/find';
-import filter from 'lodash/filter';
+/**
+ * External dependencies
+ */
+import { find, filter, some } from 'lodash';
 
 const isRequesting = function( state, siteId ) {
 	// if the `isRequesting` attribute doesn't exist yet,
@@ -35,10 +37,10 @@ const isFinished = function( state, siteId, whitelist = false ) {
 	if ( pluginList.length === 0 ) {
 		return true;
 	}
-	pluginList = filter( pluginList, ( item ) => {
+
+	return ! some( pluginList, ( item ) => {
 		return ( ( 'done' !== item.status ) && ( item.error === null ) );
 	} );
-	return ( pluginList.length === 0 );
 };
 
 const isInstalling = function( state, siteId, whitelist = false ) {
@@ -46,11 +48,11 @@ const isInstalling = function( state, siteId, whitelist = false ) {
 	if ( pluginList.length === 0 ) {
 		return false;
 	}
-	pluginList = filter( pluginList, ( item ) => {
+
+	// If any plugin is not done/waiting/error'd, it's in an installing state.
+	return some( pluginList, ( item ) => {
 		return ( ( -1 === [ 'done', 'wait' ].indexOf( item.status ) ) && ( item.error === null ) );
 	} );
-	// If any plugin is not done/waiting/error'd, it's in an installing state.
-	return ( pluginList.length > 0 );
 };
 
 const getActivePlugin = function( state, siteId, whitelist = false ) {

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -3,12 +3,8 @@
 /**
  * External dependencies
  */
-import filter from 'lodash/filter';
-import last from 'lodash/last';
 import moment from 'moment';
-import some from 'lodash/some';
-import startsWith from 'lodash/startsWith';
-import takeRightWhile from 'lodash/takeRightWhile';
+import { some, startsWith, takeRightWhile, find, findLast } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,11 +17,11 @@ import { FIRST_VIEW_HIDE, ROUTE_SET } from 'state/action-types';
 import { getCurrentUserDate } from 'state/current-user/selectors';
 
 export function getConfigForCurrentView( state ) {
-	const currentRoute = last( filter( getActionLog( state ), { type: ROUTE_SET } ) );
+	const currentRoute = findLast( getActionLog( state ), { type: ROUTE_SET } );
 	const path = currentRoute.path ? currentRoute.path : '';
-	const config = FIRST_VIEW_CONFIG.filter( entry => some( entry.paths, entryPath => startsWith( path, entryPath ) ) );
+	const config = find( FIRST_VIEW_CONFIG, ( entry => some( entry.paths, entryPath => startsWith( path, entryPath ) ) ) );
 
-	return config.pop() || false;
+	return config || false;
 }
 
 export function isUserEligible( state, config ) {
@@ -57,8 +53,7 @@ export function isViewEnabled( state, config ) {
 		return false;
 	}
 
-	const firstViewHistory = filter( getPreference( state, 'firstViewHistory' ), entry => entry.view === config.name );
-	const latestFirstViewHistory = [ ...firstViewHistory ].pop();
+	const latestFirstViewHistory = findLast( getPreference( state, 'firstViewHistory' ), { view: config.name } );
 	const isViewDisabled = latestFirstViewHistory ? ( !! latestFirstViewHistory.disabled ) : false;
 
 	// If the view is disabled, we want to return false, regardless of state
@@ -96,8 +91,7 @@ export function shouldViewBeVisible( state ) {
 }
 
 export function secondsSpentOnCurrentView( state, now = Date.now() ) {
-	const routeSets = filter( getActionLog( state ), { type: ROUTE_SET } );
-	const currentRoute = last( routeSets );
+	const currentRoute = findLast( getActionLog( state ), { type: ROUTE_SET } );
 	return currentRoute ? ( now - currentRoute.timestamp ) / 1000 : -1;
 }
 


### PR DESCRIPTION
This pull request seeks to replace array filtering with more appropriate alternatives where one exists. In general, we should use [Lodash's `_.find`](lodash.com/docs/4.16.2#find) when trying to locate a single item in a collection, and [`Array#every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) or [`Array#some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) when testing whether any/all items in the collection are a match. This helps avoid unnecessary array allocation and avoids looping over the remainder of a collection after a result has been determined. In some cases, this may have a noticeable performance impact, especially on hot code paths (e.g. `SitesList#getPrimary` is a very common function).

__Testing Instructions:__

These changes touch all areas of the application. Verify that affected sections and behaviors continue to act as expected. Also ensure that tests pass:

```
make test
```

cc @blowery 