### PR TITLE
Framework: Change 'users' to 'visitors' in HelloVote notice and setting

### DIFF
--- a/client/blocks/hello-vote-notice/index.jsx
+++ b/client/blocks/hello-vote-notice/index.jsx
@@ -36,7 +36,7 @@ function HelloVoteNotice( { translate, visibleIfUnitedStates, isUnitedStates, si
 					className="hello-vote-notice"
 					key="notice"
 					status="is-info"
-					text={ translate( 'Encourage your US-based users to register to vote by adding a subtle prompt to your site' ) }
+					text={ translate( 'Encourage your US-based visitors to register to vote by adding a subtle prompt to your site' ) }
 					onDismissClick={ onDismiss }>
 					<NoticeAction
 						onClick={ onActionClick }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -464,7 +464,7 @@ const FormGeneral = React.createClass( {
 								checked={ this.state.hello_vote_enabled }
 								onChange={ this.onHelloVoteSettingChanged }
 							/>
-							<span>{ this.translate( 'Encourage your US-based users to register to vote by adding a subtle prompt to your site' ) }</span>
+							<span>{ this.translate( 'Encourage your US-based visitors to register to vote by adding a subtle prompt to your site' ) }</span>
 						</FormLabel>
 					</li>
 				</ul>


### PR DESCRIPTION
Now that the HelloVote voter registration form is shown to logged-out users on enabled sites, we should change the wording in the notice and the setting from 'users' to 'visitors'.

Very straightforward change, the easiest way to test it it to go to `/settings/general/$site` and verify that this option now says 'visitors' instead of 'users':

![image](https://cloud.githubusercontent.com/assets/227022/19166699/3939a23a-8bce-11e6-9827-13fa89cf2e7a.png)

and the same for the notice introduced by #8423 (full testing instructions over there).