### PR TITLE
Blocks: Hide HelloVote notice for Jetpack sites

### DIFF
--- a/client/blocks/hello-vote-notice/index.jsx
+++ b/client/blocks/hello-vote-notice/index.jsx
@@ -15,7 +15,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { canCurrentUser, getCurrentUserDate } from 'state/current-user/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { isSiteSection, getSectionName, getSelectedSiteId } from 'state/ui/selectors';
 import { getPreference, hasReceivedRemotePreferences } from 'state/preferences/selectors';
 import { savePreference } from 'state/preferences/actions';
@@ -68,6 +68,7 @@ export default connect(
 			siteSlug,
 			visibleIfUnitedStates: (
 				siteSlug &&
+				! isJetpackSite( state, selectedSiteId ) &&
 				isSiteSection( state ) &&
 				'settings' !== getSectionName( state ) &&
 				canCurrentUser( state, selectedSiteId, 'manage_options' ) &&


### PR DESCRIPTION
This pull request seeks to avoid display the `<HelloVoteNotice />` block component for Jetpack sites, as the setting cannot be managed for these sites.

__Testing Instructions:__

Verify that the `<HelloVoteNotice />` is displayed only for WordPress.com sites on site-specific screens.

1. Navigate to My Sites
2. Select a site
3. Note that...
 - If the site is a WordPress.com site and the notice hasn't yet been dismissed, it will be shown
 - Otherwise, the notice is not shown

If you need to reset your preference, navigate to the [API console](https://developer.wordpress.com/docs/api/console/), enter `POST /me/settings` as the path, and the following body:

```
calypso_preferences={"helloVoteNoticeDismissed":null}
```

cc @nylen 