### PR TITLE
Framework: Downgrade to immutable 3.7.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -996,12 +996,7 @@
       "version": "1.1.2"
     },
     "draft-js": {
-      "version": "0.8.1",
-      "dependencies": {
-        "immutable": {
-          "version": "3.7.6"
-        }
-      }
+      "version": "0.8.1"
     },
     "duplexer": {
       "version": "0.1.1",
@@ -1816,7 +1811,7 @@
       "version": "4.1.1"
     },
     "immutable": {
-      "version": "3.8.1"
+      "version": "3.7.6"
     },
     "imports-loader": {
       "version": "0.6.5"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1022,7 +1022,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.1.5",
+          "version": "2.2.1",
           "dev": true
         }
       }
@@ -2389,7 +2389,7 @@
           "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.1.5"
+          "version": "2.2.1"
         }
       }
     },
@@ -2870,7 +2870,7 @@
       "dev": true
     },
     "postcss-selector-parser": {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dev": true
     },
     "postcss-value-parser": {
@@ -3084,7 +3084,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.1.5",
+          "version": "2.2.1",
           "dev": true
         }
       }
@@ -3111,7 +3111,7 @@
           "version": "3.0.3"
         },
         "readable-stream": {
-          "version": "2.1.5"
+          "version": "2.2.1"
         }
       }
     },
@@ -3640,7 +3640,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.1.5",
+          "version": "2.2.1",
           "dev": true
         },
         "resolve-from": {
@@ -3673,7 +3673,7 @@
           "version": "6.3.0"
         },
         "readable-stream": {
-          "version": "2.1.5"
+          "version": "2.2.1"
         }
       }
     },
@@ -3741,7 +3741,7 @@
           "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.1.5"
+          "version": "2.2.1"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "he": "0.5.0",
     "html-loader": "0.4.0",
     "i18n-calypso": "1.6.2",
-    "immutable": "3.8.1",
+    "immutable": "3.7.6",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",
     "is-my-json-valid": "2.13.1",


### PR DESCRIPTION
Matches draft-js and shrinks the bundle that uses draft-js by quite a bit.
