### PR TITLE
Reader: move post action links to a new block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -25,6 +25,7 @@
 @import 'blocks/post-status/style';
 @import 'blocks/reader-avatar/style';
 @import 'blocks/reader-full-post/style';
+@import 'blocks/reader-post-actions/style';
 @import 'blocks/reader-related-card/style';
 @import 'blocks/reader-related-card-v2/style';
 @import 'blocks/reader-search-card/style';

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -43,7 +43,7 @@ import scrollTo from 'lib/scroll-to';
 import PostExcerptLink from 'reader/post-excerpt-link';
 import { siteNameFromSiteAndPost } from 'reader/utils';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
-import ReaderFullPostActionLinks from './action-links';
+import ReaderPostActions from 'blocks/reader-post-actions';
 import { state as SiteState } from 'lib/reader-site-store/constants';
 import PostStoreActions from 'lib/feed-post-store/actions';
 import { RelatedPostsFromSameSite, RelatedPostsFromOtherSites } from 'components/related-posts-v2';
@@ -314,7 +314,7 @@ export class FullPostView extends React.Component {
 							: null
 						}
 
-						<ReaderFullPostActionLinks post={ post } site={ site } onCommentClick={ this.handleCommentClick } />
+						<ReaderPostActions post={ post } site={ site } onCommentClick={ this.handleCommentClick } />
 
 						{ showRelatedPosts &&
 							<RelatedPostsFromSameSite siteId={ +post.site_ID } postId={ +post.ID }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -461,28 +461,3 @@
 	}
 }
 
-.reader-full-post__action-links {
-	list-style-type: none;
-	display: flex;
-	flex-direction: row;
-	justify-content: flex-end;
-	margin: 10px 0 25px;
-	clear: both;
-}
-
-.reader-full-post__action-links-item {
-	display: inline;
-	margin-right: 10px;
-
-	.reader-share__button-label {
-		font-size: 14px;
-	}
-
-	.reader-share .gridicon {
-		top: 7px;
-
-		@include breakpoint( "<480px" ) {
-			top: 5px;
-		}
-	}
-}

--- a/client/blocks/reader-post-actions/README.md
+++ b/client/blocks/reader-post-actions/README.md
@@ -1,0 +1,49 @@
+# Reader Post Actions
+
+A selection of action buttons typically displayed at the end of a post in the Reader.
+
+## Usage
+
+```jsx
+function MyPostActions() {
+	return <ReaderPostActions post={ post } site={ site } />;
+}
+```
+
+## Props
+
+### `post`
+
+<table>
+	<tr><th>Type</th><td>Object</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The post object being displayed.
+
+### `site`
+
+<table>
+	<tr><th>Type</th><td>Object</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Where available, the site object for the current post. This will only be available for wordpress.com and Jetpack posts. It is used to determine whether the user has permission to edit the current post.
+
+### `onCommentClick`
+
+<table>
+	<tr><th>Type</th><td>Function</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+A function to be fired when the comment button is clicked.
+
+### `showEdit`
+
+<table>
+	<tr><th>Type</th><td>Boolean</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Should we show the Edit button?

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -16,7 +16,7 @@ import { shouldShowShare } from 'reader/share/helper';
 import { userCan } from 'lib/posts/utils';
 import * as stats from 'reader/stats';
 
-const ReaderFullPostActionLinks = ( { post, site, onCommentClick } ) => {
+const ReaderPostActions = ( { post, site, onCommentClick, showEdit } ) => {
 	const onEditClick = () => {
 		stats.recordAction( 'edit_post' );
 		stats.recordGaEvent( 'Clicked Edit Post', 'full_post' );
@@ -24,19 +24,19 @@ const ReaderFullPostActionLinks = ( { post, site, onCommentClick } ) => {
 	};
 
 	return (
-		<ul className="reader-full-post__action-links">
-			{ site && userCan( 'edit_post', post ) &&
-				<li className="reader-full-post__action-links-item">
+		<ul className="reader-post-actions">
+			{ showEdit && site && userCan( 'edit_post', post ) &&
+				<li className="reader-post-actions__item">
 					<PostEditButton post={ post } site={ site } onClick={ onEditClick } />
 				</li>
 			}
 			{ shouldShowShare( post ) &&
-				<li className="reader-full-post__action-links-item">
+				<li className="reader-post-actions__item">
 					<ShareButton post={ post } position="bottom" tagName="div" />
 				</li>
 			}
 			{ shouldShowComments( post ) &&
-				<li className="reader-full-post__action-links-item">
+				<li className="reader-post-actions__item">
 					<CommentButton
 						key="comment-button"
 						commentCount={ post.discussion.comment_count }
@@ -45,7 +45,7 @@ const ReaderFullPostActionLinks = ( { post, site, onCommentClick } ) => {
 				</li>
 			}
 			{ shouldShowLikes( post ) &&
-				<li className="reader-full-post__action-links-item">
+				<li className="reader-post-actions__item">
 					<LikeButton
 						key="like-button"
 						siteId={ +post.site_ID }
@@ -59,10 +59,15 @@ const ReaderFullPostActionLinks = ( { post, site, onCommentClick } ) => {
 	);
 };
 
-ReaderFullPostActionLinks.propTypes = {
+ReaderPostActions.propTypes = {
 	post: React.PropTypes.object.isRequired,
 	site: React.PropTypes.object,
-	onCommentClick: React.PropTypes.func
+	onCommentClick: React.PropTypes.func,
+	showEdit: React.PropTypes.bool
 };
 
-export default ReaderFullPostActionLinks;
+ReaderPostActions.defaultProps = {
+	showEdit: true
+};
+
+export default ReaderPostActions;

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -1,0 +1,25 @@
+.reader-post-actions {
+	list-style-type: none;
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-end;
+	margin: 10px 0 25px;
+	clear: both;
+}
+
+.reader-post-actions__item {
+	display: inline;
+	margin-right: 10px;
+
+	.reader-share__button-label {
+		font-size: 14px;
+	}
+
+	.reader-share .gridicon {
+		top: 7px;
+
+		@include breakpoint( "<480px" ) {
+			top: 5px;
+		}
+	}
+}


### PR DESCRIPTION
The new Reader full post view has a selection of action links: edit, share, comment and like.

This PR extracts these action links to a new block called `reader-post-actions`, which is used in the new full post and will also be added later to the new post cards in the Stream Refresh (https://github.com/Automattic/wp-calypso/projects/10).

<img width="342" alt="screen shot 2016-10-07 at 11 59 38" src="https://cloud.githubusercontent.com/assets/17325/19173681/906332e4-8c85-11e6-91fe-fcc9eb014de6.png">

## To test

Visit the new full post view (e.g. http://calypso.localhost:3000/read/feeds/40474296/posts/1140926311) and make sure that the edit, share, comment and like buttons at the bottom of the post display correctly.