### PR TITLE
Trim whitespace and punctuation on "Other" vertical write in

### DIFF
--- a/client/signup/steps/survey/survey-step-v2.jsx
+++ b/client/signup/steps/survey/survey-step-v2.jsx
@@ -123,7 +123,7 @@ export default React.createClass( {
 
 	handleOtherWriteIn( e ) {
 		this.setState( {
-			otherWriteIn: e.target.value
+			otherWriteIn: e.target.value.replace( /^(\s|\.|\,|\:|\!|\?)+|(\s|\.|\,|\:|\!|\?)+$/g, '' ),
 		} );
 	},
 

--- a/client/signup/steps/survey/survey-step-v2.jsx
+++ b/client/signup/steps/survey/survey-step-v2.jsx
@@ -123,7 +123,7 @@ export default React.createClass( {
 
 	handleOtherWriteIn( e ) {
 		this.setState( {
-			otherWriteIn: e.target.value.replace( /^(\s|\.|\,|\:|\!|\?)+|(\s|\.|\,|\:|\!|\?)+$/g, '' ),
+			otherWriteIn: e.target.value.replace( /^\W+|\W+$/g, '' ),
 		} );
 	},
 


### PR DESCRIPTION
This PR adds logic to trim both whitespace as well as punctuation from the beginning and end of the typed text on the "Other" write in option.