### PR TITLE
State: Document, test, and improve schema for geo state

### DIFF
--- a/client/components/data/query-geo/README.md
+++ b/client/components/data/query-geo/README.md
@@ -1,0 +1,18 @@
+Query Sites
+===========
+
+`<QueryGeo />` is a React component used in managing network requests for browser IP geolocation.
+
+## Usage
+
+Render the component. The component does not accept any children, nor does it render any of its own.
+
+```jsx
+function MyComponent() {
+	return <QueryGeo />
+}
+```
+
+## Props
+
+This component does not accept any props.

--- a/client/state/geo/actions.js
+++ b/client/state/geo/actions.js
@@ -14,6 +14,13 @@ import {
  */
 export const GEO_ENDPOINT = 'https://public-api.wordpress.com/geo/';
 
+/**
+ * Returns an action object used in signalling that the current browser IP
+ * geolocation has been received.
+ *
+ * @param  {Object} geo Geolocation data
+ * @return {Object}     Action object
+ */
 export function receiveGeo( geo ) {
 	return {
 		type: GEO_RECEIVE,
@@ -21,6 +28,12 @@ export function receiveGeo( geo ) {
 	};
 }
 
+/**
+ * Returns a function which, when invoked, triggers a network request to fetch
+ * browser IP geolocation.
+ *
+ * @return {Function} Action thunk
+ */
 export function requestGeo() {
 	return ( dispatch ) => {
 		dispatch( { type: GEO_REQUEST } );

--- a/client/state/geo/reducer.js
+++ b/client/state/geo/reducer.js
@@ -15,12 +15,28 @@ import {
 import { createReducer } from 'state/utils';
 import { geoSchema } from './schema';
 
+/**
+ * Returns the updated requesting state after an action has been dispatched.
+ * Requesting state tracks whether a geolocation request is in progress.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action object
+ * @return {Object}        Updated state
+ */
 export const requesting = createReducer( false, {
 	[ GEO_REQUEST ]: () => true,
 	[ GEO_REQUEST_FAILURE ]: () => false,
 	[ GEO_REQUEST_SUCCESS ]: () => false
 } );
 
+/**
+ * Returns the updated requesting state after an action has been dispatched.
+ * Requesting state tracks current browser IP geolocation.
+ *
+ * @param  {?Object} state  Current state
+ * @param  {Object}  action Action object
+ * @return {?Object}        Updated state
+ */
 export const geo = createReducer( null, {
 	[ GEO_RECEIVE ]: ( state, action ) => action.geo
 }, geoSchema );

--- a/client/state/geo/schema.js
+++ b/client/state/geo/schema.js
@@ -1,5 +1,5 @@
 export const geoSchema = {
-	type: 'object',
+	type: [ 'object', 'null' ],
 	properties: {
 		latitude: { type: 'string' },
 		longitude: { type: 'string' },

--- a/client/state/geo/selectors.js
+++ b/client/state/geo/selectors.js
@@ -3,14 +3,32 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Returns whether a browser IP geolocation request is in progress.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {Boolean}       Whether request is in progress
+ */
 export function isRequestingGeo( state ) {
 	return state.geo.requesting;
 }
 
+/**
+ * Returns the current browser IP geolocation data.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?Object}       Current browser IP geolocation data
+ */
 export function getGeo( state ) {
 	return state.geo.geo;
 }
 
+/**
+ * Returns the current browser IP geolocation full country name.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}       Current browser IP geolocation data
+ */
 export function getGeoCountry( state ) {
 	return get( getGeo( state ), 'country_long', null );
 }

--- a/client/state/geo/test/actions.js
+++ b/client/state/geo/test/actions.js
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import { match } from 'sinon';
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	GEO_RECEIVE,
+	GEO_REQUEST,
+	GEO_REQUEST_SUCCESS,
+	GEO_REQUEST_FAILURE
+} from 'state/action-types';
+import {
+	receiveGeo,
+	requestGeo
+} from '../actions';
+import { useSandbox } from 'test/helpers/use-sinon';
+import useNock from 'test/helpers/use-nock';
+
+describe( 'actions', () => {
+	let spy;
+	useSandbox( ( sandbox ) => spy = sandbox.spy() );
+
+	describe( 'receiveGeo()', () => {
+		it( 'should return an action object', () => {
+			const action = receiveGeo( {
+				latitude: '39.36006',
+				longitude: '-84.30994',
+				country_short: 'US',
+				country_long: 'United States',
+				region: 'Ohio',
+				city: 'Mason'
+			} );
+
+			expect( action ).to.eql( {
+				type: GEO_RECEIVE,
+				geo: {
+					latitude: '39.36006',
+					longitude: '-84.30994',
+					country_short: 'US',
+					country_long: 'United States',
+					region: 'Ohio',
+					city: 'Mason'
+				}
+			} );
+		} );
+	} );
+
+	describe( 'requestGeo()', () => {
+		it( 'should dispatch fetch action when thunk triggered', () => {
+			requestGeo()( spy );
+
+			expect( spy ).to.have.been.calledWith( {
+				type: GEO_REQUEST
+			} );
+		} );
+
+		context( 'success', () => {
+			useNock( ( nock ) => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.persist()
+					.get( '/geo/' )
+					.reply( 200, {
+						latitude: '39.36006',
+						longitude: '-84.30994',
+						country_short: 'US',
+						country_long: 'United States',
+						region: 'Ohio',
+						city: 'Mason'
+					} );
+			} );
+
+			it( 'should dispatch receive action when request completes', () => {
+				return requestGeo()( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith(
+						receiveGeo( {
+							latitude: '39.36006',
+							longitude: '-84.30994',
+							country_short: 'US',
+							country_long: 'United States',
+							region: 'Ohio',
+							city: 'Mason'
+						} )
+					);
+				} );
+			} );
+
+			it( 'should dispatch request success action when request completes', () => {
+				return requestGeo()( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: GEO_REQUEST_SUCCESS,
+					} );
+				} );
+			} );
+		} );
+
+		context( 'failure', () => {
+			useNock( ( nock ) => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.persist()
+					.get( '/geo/' )
+					.reply( 500 );
+			} );
+
+			it( 'should dispatch fail action when request fails', () => {
+				return requestGeo()( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: GEO_REQUEST_FAILURE,
+						error: match( { message: 'Internal Server Error' } )
+					} );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/state/geo/test/reducer.js
+++ b/client/state/geo/test/reducer.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { useSandbox } from 'test/helpers/use-sinon';
+import {
+	GEO_RECEIVE,
+	GEO_REQUEST,
+	GEO_REQUEST_FAILURE,
+	GEO_REQUEST_SUCCESS,
+	DESERIALIZE
+} from 'state/action-types';
+import reducer, { requesting, geo } from '../reducer';
+
+describe( 'reducer', () => {
+	useSandbox( ( sandbox ) => sandbox.stub( console, 'warn' ) );
+
+	it( 'should include expected keys in return value', () => {
+		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'requesting',
+			'geo'
+		] );
+	} );
+
+	describe( 'requesting()', () => {
+		it( 'should default to false', () => {
+			const state = requesting( undefined, {} );
+
+			expect( state ).to.be.false;
+		} );
+
+		it( 'should set site ID to true value if request in progress', () => {
+			const state = requesting( undefined, {
+				type: GEO_REQUEST
+			} );
+
+			expect( state ).to.eql( true );
+		} );
+
+		it( 'should set site ID to false if request succeeds', () => {
+			const state = requesting( true, {
+				type: GEO_REQUEST_SUCCESS
+			} );
+
+			expect( state ).to.eql( false );
+		} );
+
+		it( 'should set site ID to false if request fails', () => {
+			const state = requesting( true, {
+				type: GEO_REQUEST_FAILURE
+			} );
+
+			expect( state ).to.eql( false );
+		} );
+	} );
+
+	describe( 'geo()', () => {
+		it( 'should default to null', () => {
+			const state = geo( undefined, {} );
+
+			expect( state ).to.be.null;
+		} );
+
+		it( 'should track received geo data', () => {
+			const state = geo( undefined, {
+				type: GEO_RECEIVE,
+				geo: {
+					latitude: '39.36006',
+					longitude: '-84.30994',
+					country_short: 'US',
+					country_long: 'United States',
+					region: 'Ohio',
+					city: 'Mason'
+				}
+			} );
+
+			expect( state ).to.eql( {
+				latitude: '39.36006',
+				longitude: '-84.30994',
+				country_short: 'US',
+				country_long: 'United States',
+				region: 'Ohio',
+				city: 'Mason'
+			} );
+		} );
+
+		it( 'should load valid persisted state', () => {
+			const original = deepFreeze( {
+				latitude: '39.36006',
+				longitude: '-84.30994',
+				country_short: 'US',
+				country_long: 'United States',
+				region: 'Ohio',
+				city: 'Mason'
+			} );
+			const state = geo( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( {
+				latitude: '39.36006',
+				longitude: '-84.30994',
+				country_short: 'US',
+				country_long: 'United States',
+				region: 'Ohio',
+				city: 'Mason'
+			} );
+		} );
+
+		it( 'should not load invalid persisted state', () => {
+			const original = deepFreeze( {
+				country_short: true
+			} );
+			const state = geo( original, { type: DESERIALIZE } );
+
+			expect( state ).to.be.null;
+			expect( console.warn ).to.have.been.called; // eslint-disable-line no-console
+		} );
+	} );
+} );

--- a/client/state/geo/test/selectors.js
+++ b/client/state/geo/test/selectors.js
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingGeo, getGeo, getGeoCountry } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'isRequestingGeo()', () => {
+		it( 'should return requesting state', () => {
+			const isRequesting = isRequestingGeo( {
+				geo: {
+					requesting: true
+				}
+			} );
+
+			expect( isRequesting ).to.be.true;
+		} );
+	} );
+
+	describe( 'getGeo()', () => {
+		it( 'should return geo data state', () => {
+			const geo = getGeo( {
+				geo: {
+					geo: {
+						latitude: '39.36006',
+						longitude: '-84.30994',
+						country_short: 'US',
+						country_long: 'United States',
+						region: 'Ohio',
+						city: 'Mason'
+					}
+				}
+			} );
+
+			expect( geo ).to.eql( {
+				latitude: '39.36006',
+				longitude: '-84.30994',
+				country_short: 'US',
+				country_long: 'United States',
+				region: 'Ohio',
+				city: 'Mason'
+			} );
+		} );
+	} );
+
+	describe( 'getGeoCountry()', () => {
+		it( 'should return null if no geo data state', () => {
+			const country = getGeoCountry( {
+				geo: {
+					geo: null
+				}
+			} );
+
+			expect( country ).to.be.null;
+		} );
+
+		it( 'should return full country name of geo data state', () => {
+			const country = getGeoCountry( {
+				geo: {
+					geo: {
+						latitude: '39.36006',
+						longitude: '-84.30994',
+						country_short: 'US',
+						country_long: 'United States',
+						region: 'Ohio',
+						city: 'Mason'
+					}
+				}
+			} );
+
+			expect( country ).to.equal( 'United States' );
+		} );
+	} );
+} );


### PR DESCRIPTION
This pull request seeks to:

- Resolve state validation warning when geo is persisted as `null`
- Document geo actions, reducer, and selectors
- Test geo actions, reducer, and selectors

__Testing Instructions:__

Ensure that Mocha tests pass:

```
npm run test-client
```

cc @gwwar , @umurkontaci (re: https://github.com/Automattic/wp-calypso/pull/7457#issuecomment-251810924)