### PR TITLE
Support: Update live course dates

### DIFF
--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -31,20 +31,20 @@ function getCourses() {
 			),
 			schedule: [
 				{
-					date: i18n.moment( new Date( 'Tues, 4 Oct 2016 16:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/0f18c67948202a1f7510d14dfea9e911'
-				},
-				{
-					date: i18n.moment( new Date( 'Thur, 6 Oct 2016 20:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/2389ab7d02e4772d8c34be5db4a05ad8'
-				},
-				{
 					date: i18n.moment( new Date( 'Tues, 11 Oct 2016 16:00:00 +0000' ) ),
 					registrationUrl: 'https://zoom.us/webinar/register/c9f211b28c427b6066858a512be5123a'
 				},
 				{
 					date: i18n.moment( new Date( 'Thur, 13 Oct 2016 20:00:00 +0000' ) ),
 					registrationUrl: 'https://zoom.us/webinar/register/8aa25fd3a2bda6a28c34be5db4a05ad8'
+				},
+				{
+					date: i18n.moment( new Date( 'Tues, 18 Oct 2016 16:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/a89296c68ee6a3d2cde7dc3c8da9331e'
+				},
+				{
+					date: i18n.moment( new Date( 'Thur, 20 Oct 2016 20:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/76eebd735e6172cd7c24e00bf0acd2b8'
 				},
 			],
 			videos: [


### PR DESCRIPTION
This PR updates the live course dates shown on wordpress.com/help/courses for Business users. It removes two past dates and adds the following upcoming dates:

- Tuesday Oct 18, 2016 9am PDT:  https://zoom.us/webinar/register/a89296c68ee6a3d2cde7dc3c8da9331e

- Thursday Oct 20, 2016 1pm PDT: https://zoom.us/webinar/register/76eebd735e6172cd7c24e00bf0acd2b8

## To test

Load up this branch and visit http://calypso.localhost:3000/help/courses with a site on the Business plan. You should see the above dates and times localized to your timezone:

<img width="786" alt="screen shot 2016-10-06 at 8 45 07 pm" src="https://cloud.githubusercontent.com/assets/7240478/19177366/cc17f84a-8c05-11e6-9231-d1d240a42d28.png">

See discussion in p1475787650000162-slack-business-concierge for related discussion. [Updating these links will be API-driven soon](https://github.com/Automattic/wp-calypso/pull/7753) 😄 