### PR TITLE
Reader: add new reader-post-options-menu block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -28,6 +28,7 @@
 @import 'blocks/reader-full-post/style';
 @import 'blocks/reader-post-actions/style';
 @import 'blocks/reader-post-card/style';
+@import 'blocks/reader-post-options-menu/style';
 @import 'blocks/reader-related-card/style';
 @import 'blocks/reader-related-card-v2/style';
 @import 'blocks/reader-search-card/style';

--- a/client/blocks/reader-post-options-menu/README.md
+++ b/client/blocks/reader-post-options-menu/README.md
@@ -1,0 +1,36 @@
+# Reader Post Options Menu
+
+The button and overlay for the "ellipsis" options menu attached to a post.
+
+## Props
+
+- `post`: A reader post object
+- `onBlock`: a callback to invoke when a post or site is blocked
+
+## Usage
+
+```jsx
+function MyMenu() {
+	return <ReaderPostOptionsMenu post={ post } />;
+}
+```
+
+## Props
+
+### `post`
+
+<table>
+	<tr><th>Type</th><td>Object</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+A Reader post object.
+
+### `onBlock`
+
+<table>
+	<tr><th>Type</th><td>Function</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+A callback to invoke when a post or site is blocked.

--- a/client/blocks/reader-post-options-menu/docs/example.jsx
+++ b/client/blocks/reader-post-options-menu/docs/example.jsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
+
+export default React.createClass( {
+
+	displayName: 'ReaderPostOptionsMenu',
+
+	render() {
+		const post = {
+			site_URL: 'http://discover.wordpress.com'
+		};
+
+		// Narrow container so popover appears in a reasonable spot
+		const wrapperStyles = {
+			width: '30px'
+		};
+
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/blocks/reader-post-options-menu">Reader Post Options Menu</a>
+				</h2>
+				<div style={ wrapperStyles }>
+					<ReaderPostOptionsMenu position="bottom left" post={ post } />
+				</div>
+			</div>
+		);
+	}
+} );

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -132,7 +132,7 @@ const ReaderPostOptionsMenu = React.createClass( {
 	},
 
 	closePopoverMenu() {
-		if ( this.isMounted() ) {
+		if ( this.state.showPopoverMenu ) {
 			this.setState( { showPopoverMenu: false } );
 		}
 	},
@@ -194,7 +194,8 @@ const ReaderPostOptionsMenu = React.createClass( {
 				<PopoverMenu isVisible={ this.state.showPopoverMenu }
 						onClose={ this.closePopoverMenu }
 						position={ this.state.popoverPosition }
-						context={ this.refs && this.refs.popoverMenuButton }>
+						context={ this.refs && this.refs.popoverMenuButton }
+						className="reader-post-options-menu__popover">
 
 					<FollowButton tagName={ PopoverMenuItem } siteUrl={ this.state.followUrl } />
 

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -120,7 +120,7 @@ const ReaderPostOptionsMenu = React.createClass( {
 		return feed;
 	},
 
-	_showPopoverMenu() {
+	showPopoverMenu() {
 		const newState = ! this.state.showPopoverMenu;
 		this.setState( {
 			showPopover: false,
@@ -131,7 +131,7 @@ const ReaderPostOptionsMenu = React.createClass( {
 		stats.recordTrackForPost( 'calypso_reader_post_options_menu_' + ( newState ? 'opened' : 'closed' ), this.props.post );
 	},
 
-	_closePopoverMenu() {
+	closePopoverMenu() {
 		if ( this.isMounted() ) {
 			this.setState( { showPopoverMenu: false } );
 		}
@@ -184,7 +184,7 @@ const ReaderPostOptionsMenu = React.createClass( {
 			<span className="reader-post-options-menu">
 				<span className={ triggerClasses }
 						ref="popoverMenuButton"
-						onClick={ this._showPopoverMenu }>
+						onClick={ this.showPopoverMenu }>
 					<svg className="gridicon gridicon__ellipsis" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 						<g><circle cx="5" cy="12" r="2" /><circle cx="19" cy="12" r="2" /><circle cx="12" cy="12" r="2" /></g>
 					</svg>
@@ -192,7 +192,7 @@ const ReaderPostOptionsMenu = React.createClass( {
 				</span>
 
 				<PopoverMenu isVisible={ this.state.showPopoverMenu }
-						onClose={ this._closePopoverMenu }
+						onClose={ this.closePopoverMenu }
 						position={ this.state.popoverPosition }
 						context={ this.refs && this.refs.popoverMenuButton }>
 

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -21,6 +21,7 @@ import FollowButton from 'reader/follow-button';
 import * as DiscoverHelper from 'reader/discover/helper';
 import smartSetState from 'lib/react-smart-set-state';
 import * as stats from 'reader/stats';
+import Gridicon from 'components/gridicon';
 
 const ReaderPostOptionsMenu = React.createClass( {
 
@@ -185,9 +186,7 @@ const ReaderPostOptionsMenu = React.createClass( {
 				<span className={ triggerClasses }
 						ref="popoverMenuButton"
 						onClick={ this.showPopoverMenu }>
-					<svg className="gridicon gridicon__ellipsis" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-						<g><circle cx="5" cy="12" r="2" /><circle cx="19" cy="12" r="2" /><circle cx="12" cy="12" r="2" /></g>
-					</svg>
+					<Gridicon icon="ellipsis" size={ 24 } />
 					<span className="reader-post-options-menu__label">{ this.translate( 'More' ) }</span>
 				</span>
 
@@ -200,9 +199,7 @@ const ReaderPostOptionsMenu = React.createClass( {
 					<FollowButton tagName={ PopoverMenuItem } siteUrl={ this.state.followUrl } />
 
 					{ isEditPossible ? <PopoverMenuItem onClick={ this.editPost } className="reader-post-options-menu__edit has-icon">
-						<svg className="gridicon gridicon__edit" height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-							<g><path d="M4 15v5h5l9-9-5-5-9 9zM16 3l-2 2 5 5 2-2-5-5z" /></g>
-						</svg>
+						<Gridicon icon="pencil" size={ 18 } />
 						{ this.translate( 'Edit Post' ) }
 					</PopoverMenuItem> : null }
 

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -1,0 +1,218 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { noop, get } from 'lodash';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import PopoverMenu from 'components/popover/menu';
+import PopoverMenuItem from 'components/popover/menu-item';
+import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
+import SiteStore from 'lib/reader-site-store';
+import FeedStore from 'lib/feed-store';
+import FeedStoreActions from 'lib/feed-store/actions';
+import SiteBlockStore from 'lib/reader-site-blocks';
+import SiteBlockActions from 'lib/reader-site-blocks/actions';
+import PostUtils from 'lib/posts/utils';
+import FollowButton from 'reader/follow-button';
+import * as DiscoverHelper from 'reader/discover/helper';
+import smartSetState from 'lib/react-smart-set-state';
+import * as stats from 'reader/stats';
+
+const ReaderPostOptionsMenu = React.createClass( {
+
+	propTypes: {
+		post: React.PropTypes.object.isRequired,
+		onBlock: React.PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+			onBlock: noop,
+			position: 'top left'
+		};
+	},
+
+	smartSetState: smartSetState,
+
+	getInitialState() {
+		const state = this.getStateFromStores();
+		state.popoverPosition = this.props.position;
+		state.showPopoverMenu = false;
+		return state;
+	},
+
+	componentDidMount() {
+		SiteBlockStore.on( 'change', this.updateState );
+		FeedSubscriptionStore.on( 'change', this.updateState );
+		FeedStore.on( 'change', this.updateState );
+	},
+
+	componentWillUnmount() {
+		SiteBlockStore.off( 'change', this.updateState );
+		FeedSubscriptionStore.off( 'change', this.updateState );
+		FeedStore.off( 'change', this.updateState );
+	},
+
+	getStateFromStores() {
+		const siteId = this.props.post.site_ID,
+			feed = this.getFeed(),
+			followUrl = this.getFollowUrl( feed );
+
+		return {
+			isBlocked: SiteBlockStore.getIsBlocked( siteId ),
+			blockError: SiteBlockStore.getLastErrorBySite( siteId ),
+			feed: this.getFeed(),
+			followUrl: followUrl,
+			followError: FeedSubscriptionStore.getLastErrorBySiteUrl( followUrl )
+		};
+	},
+
+	updateState() {
+		this.smartSetState( this.getStateFromStores() );
+
+		// Hide the popover menu if there's an error
+		// Error message will be displayed on the post card
+		if ( this.state.blockError || this.state.followError ) {
+			this.state.showPopoverMenu = false;
+		}
+	},
+
+	blockSite() {
+		stats.recordAction( 'blocked_blog' );
+		stats.recordGaEvent( 'Clicked Block Site' );
+		stats.recordTrackForPost( 'calypso_reader_block_site', this.props.post );
+		SiteBlockActions.block( this.props.post.site_ID );
+		this.props.onBlock();
+	},
+
+	reportPost() {
+		if ( ! this.props.post || ! this.props.post.URL ) {
+			return;
+		}
+
+		stats.recordAction( 'report_post' );
+		stats.recordGaEvent( 'Clicked Report Post', 'post_options' );
+		stats.recordTrackForPost( 'calypso_reader_post_reported', this.props.post );
+
+		window.open( 'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ), '_blank' );
+	},
+
+	getFollowUrl( feed ) {
+		return feed ? feed.get( 'feed_URL' ) : this.props.post.site_URL;
+	},
+
+	getFeed() {
+		const feedId = get( this.props, 'post.feed_ID' );
+		if ( ! feedId || feedId < 1 ) {
+			return;
+		}
+
+		const feed = FeedStore.get( feedId );
+
+		if ( ! feed ) {
+			FeedStoreActions.fetch( feedId );
+		}
+
+		return feed;
+	},
+
+	_showPopoverMenu() {
+		const newState = ! this.state.showPopoverMenu;
+		this.setState( {
+			showPopover: false,
+			showPopoverMenu: newState
+		} );
+		stats.recordAction( newState ? 'open_post_options_menu' : 'close_post_options_menu' );
+		stats.recordGaEvent( newState ? 'Open Post Options Menu' : 'Close Post Options Menu' );
+		stats.recordTrackForPost( 'calypso_reader_post_options_menu_' + ( newState ? 'opened' : 'closed' ), this.props.post );
+	},
+
+	_closePopoverMenu() {
+		if ( this.isMounted() ) {
+			this.setState( { showPopoverMenu: false } );
+		}
+	},
+
+	editPost( closeMenu ) {
+		const post = this.props.post,
+			site = SiteStore.get( this.props.post.site_ID );
+		let editUrl = '//wordpress.com/post/' + post.site_ID + '/' + post.ID + '/';
+
+		closeMenu();
+
+		if ( site && site.get( 'slug' ) ) {
+			editUrl = PostUtils.getEditURL( post, site.toJS() );
+		}
+
+		stats.recordAction( 'edit_post' );
+		stats.recordGaEvent( 'Clicked Edit Post', 'post_options' );
+		stats.recordTrackForPost( 'calypso_reader_edit_post_clicked', this.props.post );
+
+		setTimeout( function() { // give the analytics a chance to escape
+			if ( editUrl.indexOf( '//' ) === 0 ) {
+				window.location.href = editUrl;
+			} else {
+				page( editUrl );
+			}
+		}, 100 );
+	},
+
+	render() {
+		const post = this.props.post,
+			isEditPossible = PostUtils.userCan( 'edit_post', post ),
+			isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
+
+		let triggerClasses = [ 'reader-post-options-menu__trigger', 'ignore-click' ],
+			isBlockPossible = false;
+
+		if ( this.state.showPopoverMenu ) {
+			triggerClasses.push( 'is-triggered' );
+		}
+
+		triggerClasses = triggerClasses.join( ' ' );
+
+		// Should we show the 'block' option?
+		if ( post.site_ID && ! post.is_external && ! post.is_jetpack && ! isEditPossible && ! isDiscoverPost ) {
+			isBlockPossible = true;
+		}
+
+		return (
+			<span className="reader-post-options-menu">
+				<span className={ triggerClasses }
+						ref="popoverMenuButton"
+						onClick={ this._showPopoverMenu }>
+					<svg className="gridicon gridicon__ellipsis" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<g><circle cx="5" cy="12" r="2" /><circle cx="19" cy="12" r="2" /><circle cx="12" cy="12" r="2" /></g>
+					</svg>
+					<span className="reader-post-options-menu__label">{ this.translate( 'More' ) }</span>
+				</span>
+
+				<PopoverMenu isVisible={ this.state.showPopoverMenu }
+						onClose={ this._closePopoverMenu }
+						position={ this.state.popoverPosition }
+						context={ this.refs && this.refs.popoverMenuButton }>
+
+					<FollowButton tagName={ PopoverMenuItem } siteUrl={ this.state.followUrl } />
+
+					{ isEditPossible ? <PopoverMenuItem onClick={ this.editPost } className="reader-post-options-menu__edit has-icon">
+						<svg className="gridicon gridicon__edit" height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+							<g><path d="M4 15v5h5l9-9-5-5-9 9zM16 3l-2 2 5 5 2-2-5-5z" /></g>
+						</svg>
+						{ this.translate( 'Edit Post' ) }
+					</PopoverMenuItem> : null }
+
+					{ isBlockPossible || isDiscoverPost ? <hr className="reader-post-options-menu__hr" /> : null }
+					{ isBlockPossible ? <PopoverMenuItem onClick={ this.blockSite }>{ this.translate( 'Block Site' ) }</PopoverMenuItem> : null }
+					{ isBlockPossible || isDiscoverPost ? <PopoverMenuItem onClick={ this.reportPost }>{ this.translate( 'Report this Post' ) }</PopoverMenuItem> : null }
+				</PopoverMenu>
+			</span>
+		);
+	}
+
+} );
+
+export default ReaderPostOptionsMenu;

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -54,8 +54,7 @@
 	}
 }
 
-.popover__menu .follow-button {
-
+.reader-post-options-menu__popover .popover__menu .follow-button {
 	.gridicon {
 		position: absolute;
 			left: 14px;
@@ -86,6 +85,6 @@
 	}
 }
 
-.popover__menu .follow-button__label {
+.reader-post-options-menu__popover .popover__menu .follow-button__label {
 	display: inline-block;
 }

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -1,76 +1,9 @@
-.reader-post-options-menu__trigger {
-	display: block;
-	cursor: pointer;
-	color: lighten( $gray, 10 );
-	border-radius: 4px;
-
-	.gridicon__ellipsis {
-		display: block;
-		padding: 2px 4px;
-		fill: lighten( $gray, 10 );
-		transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-	}
-
-	.reader-post-options-menu__label {
-		display: none;
-	}
-
-	&:hover {
-		.gridicon__ellipsis {
-			fill: $blue-light;
-		}
-	}
-
-	&.is-triggered {
-		color: $blue-medium;
-
-		.gridicon__ellipsis {
-			fill: $blue-dark;
-			transform: rotate( 90deg );
-		}
-	}
-}
-
 .reader-post-options-menu__hr {
 	margin: 8px 0;
 	background: lighten( $gray, 30 );
 }
 
-.reader-post-options-menu__reblog,
-.reader-post-options-menu__save,
-.reader-post-options-menu__edit,
-.reader-post-options-menu__view {
-	.gridicon {
-		position: absolute;
-		top: 7px;
-		left: 13px;
-		fill: lighten( $gray, 10 );
-		transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-	}
-
-	&:hover .gridicon,
-	&:focus .gridicon {
-		fill: $white;
-	}
-}
-
-.reader-post-options-menu__popover .popover__menu .follow-button {
-	.gridicon {
-		position: absolute;
-			left: 14px;
-			top: 11px;
-	}
-
-	&:hover,
-	&:focus {
-		background-color: $blue-medium;
-		color: white;
-
-		.gridicon {
-			fill: $white;
-		}
-	}
-
+.reader-post-options-menu__ellipsis-menu .follow-button {
 	&.is-following {
 
 		&:hover,
@@ -83,8 +16,4 @@
 			}
 		}
 	}
-}
-
-.reader-post-options-menu__popover .popover__menu .follow-button__label {
-	display: inline-block;
 }

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -1,0 +1,91 @@
+.reader-post-options-menu__trigger {
+	display: block;
+	cursor: pointer;
+	color: lighten( $gray, 10 );
+	border-radius: 4px;
+
+	.gridicon__ellipsis {
+		display: block;
+		padding: 2px 4px;
+		fill: lighten( $gray, 10 );
+		transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	}
+
+	.reader-post-options-menu__label {
+		display: none;
+	}
+
+	&:hover {
+		.gridicon__ellipsis {
+			fill: $blue-light;
+		}
+	}
+
+	&.is-triggered {
+		color: $blue-medium;
+
+		.gridicon__ellipsis {
+			fill: $blue-dark;
+			transform: rotate( 90deg );
+		}
+	}
+}
+
+.reader-post-options-menu__hr {
+	margin: 8px 0;
+	background: lighten( $gray, 30 );
+}
+
+.reader-post-options-menu__reblog,
+.reader-post-options-menu__save,
+.reader-post-options-menu__edit,
+.reader-post-options-menu__view {
+	.gridicon {
+		position: absolute;
+		top: 7px;
+		left: 13px;
+		fill: lighten( $gray, 10 );
+		transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	}
+
+	&:hover .gridicon,
+	&:focus .gridicon {
+		fill: $white;
+	}
+}
+
+.popover__menu .follow-button {
+
+	.gridicon {
+		position: absolute;
+			left: 14px;
+			top: 11px;
+	}
+
+	&:hover,
+	&:focus {
+		background-color: $blue-medium;
+		color: white;
+
+		.gridicon {
+			fill: $white;
+		}
+	}
+
+	&.is-following {
+
+		&:hover,
+		&:focus {
+			color: $white;
+			background: $alert-green;
+
+			.gridicon {
+				fill: $white;
+			}
+		}
+	}
+}
+
+.popover__menu .follow-button__label {
+	display: inline-block;
+}

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +20,12 @@ class EllipsisMenu extends Component {
 		position: PropTypes.string,
 		children: PropTypes.node,
 		disabled: PropTypes.bool,
+		onToggle: PropTypes.func
 	};
+
+	static defaultProps = {
+		onToggle: noop
+	}
 
 	constructor() {
 		super( ...arguments );
@@ -44,6 +50,7 @@ class EllipsisMenu extends Component {
 	toggleMenu( isMenuVisible ) {
 		if ( ! this.props.disabled ) {
 			this.setState( { isMenuVisible } );
+			this.props.onToggle( isMenuVisible );
 		}
 	}
 

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -52,7 +52,6 @@ import ReaderAvatar from 'blocks/reader-avatar/docs/example';
 import ImageEditor from 'blocks/image-editor/docs/example';
 import RefreshPostCard from 'blocks/reader-post-card/docs/example';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu/docs/example';
-import DomainToPlanNudge from 'blocks/domain-to-plan-nudge/docs/example';
 
 export default React.createClass( {
 
@@ -125,7 +124,6 @@ export default React.createClass( {
 					<DismissibleCard />
 					<ReaderAvatar />
 					<ReaderPostOptionsMenu />
-					<DomainToPlanNudge />
 				</Collection>
 			</Main>
 		);

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -51,6 +51,8 @@ import PostEditButton from 'blocks/post-edit-button/docs/example';
 import ReaderAvatar from 'blocks/reader-avatar/docs/example';
 import ImageEditor from 'blocks/image-editor/docs/example';
 import RefreshPostCard from 'blocks/reader-post-card/docs/example';
+import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu/docs/example';
+import DomainToPlanNudge from 'blocks/domain-to-plan-nudge/docs/example';
 
 export default React.createClass( {
 
@@ -122,6 +124,8 @@ export default React.createClass( {
 					<PlanThankYouCard />
 					<DismissibleCard />
 					<ReaderAvatar />
+					<ReaderPostOptionsMenu />
+					<DomainToPlanNudge />
 				</Collection>
 			</Main>
 		);


### PR DESCRIPTION
We currently have a menu called post options (at `reader/post-options`) that's used in stream post cards and the old full post view.

This PR moves the component to a new block (`blocks/reader-post-options-menu`), cleans it up and adds a devdocs example. The new block will be used in the new post cards being produced for the Stream Refresh.

Part of #8524.

<img width="298" alt="screen shot 2016-10-07 at 16 02 14" src="https://cloud.githubusercontent.com/assets/17325/19177789/d0ee7b8e-8ca8-11e6-8cb8-d928e91e5a39.png">

## To test

Visit http://calypso.localhost:3000/devdocs/blocks/reader-post-options-menu.