### PR TITLE
Sidebar Footer: Add new, more flexible, layout

### DIFF
--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -28,8 +28,11 @@ class HappychatButton extends Component {
 	render() {
 		const { translate } = this.props;
 		return (
-			<Button compact borderless onClick={ this.onOpenChat }>
-				<Gridicon icon="comment" /> { translate( 'Support Chat' ) }
+			<Button
+				className="sidebar__footer__support-chat"
+				borderless onClick={ this.onOpenChat }
+				title={ translate( 'Support Chat' ) }>
+				<Gridicon icon="chat" /> { translate( 'Support Chat' ) }
 			</Button>
 		);
 	}

--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -29,10 +29,11 @@ class HappychatButton extends Component {
 		const { translate } = this.props;
 		return (
 			<Button
-				className="sidebar__footer__support-chat"
-				borderless onClick={ this.onOpenChat }
+				className="sidebar__footer-chat"
+				borderless
+				onClick={ this.onOpenChat }
 				title={ translate( 'Support Chat' ) }>
-				<Gridicon icon="chat" /> { translate( 'Support Chat' ) }
+				<Gridicon icon="chat" />
 			</Button>
 		);
 	}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -243,7 +243,7 @@ const SiteSelector = React.createClass( {
 	renderNewSiteButton() {
 		return (
 			<span className="site-selector__add-new-site">
-				<Button compact borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' } onClick={ this.recordAddNewSite }>
+				<Button borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' } onClick={ this.recordAddNewSite }>
 					<Gridicon icon="add-outline" /> { this.translate( 'Add New Site' ) }
 				</Button>
 			</span>

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -109,7 +109,7 @@
 
 // The actual list of sites
 .site-selector__sites {
-	max-height: calc( 100% - 89px );
+	max-height: calc( 100% - 93px );
 	overflow-y: auto;
 }
 
@@ -120,9 +120,44 @@
 }
 
 .site-selector__add-new-site {
-	padding: 8px 9px;
-	display: block;
-	border-top: 1px solid lighten( $gray, 20% );
+	padding: 0;
+	border-top: 1px solid darken( $sidebar-bg-color, 10% );
+	margin: auto 0 0;
+	display: flex;
+	flex-direction: row;
+	padding-left: 10px;
+
+	@include breakpoint( "<660px" ) {
+		margin-top: 16px;
+	}
+
+}
+
+.site-selector__add-new-site .button {
+	box-sizing: border-box;
+	display: inline-block;
+	text-transform: uppercase;
+	font-size: 11px;
+	font-weight: 600;
+	padding: 8px;
+	color: darken( $gray, 10% );
+	line-height: 2.1;
+
+	&:hover {
+		color: $gray-dark;
+	}
+
+	@include breakpoint( "<660px" ) {
+		padding: 16px;
+	}
+
+	.gridicon {
+		display: block;
+		float: left;
+		margin-right: 6px;
+		top: auto;
+		margin-top: auto;
+	}
 }
 
 // Containers in the list of sites are larger

--- a/client/layout/sidebar/footer.jsx
+++ b/client/layout/sidebar/footer.jsx
@@ -15,9 +15,6 @@ import HappychatButton from 'components/happychat/button';
 const SidebarFooter = ( { translate, children } ) => (
 	<div className="sidebar__footer">
 		{ children }
-		<Button borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' }>
-			<Gridicon icon="add-outline" /> { translate( 'Add New Site' ) }
-		</Button>
 		<Button className="sidebar__footer-help" borderless href="/help" title={ translate( 'Help' ) }>
 			<Gridicon icon="help-outline" />
 		</Button>

--- a/client/layout/sidebar/footer.jsx
+++ b/client/layout/sidebar/footer.jsx
@@ -15,8 +15,11 @@ import HappychatButton from 'components/happychat/button';
 const SidebarFooter = ( { translate, children } ) => (
 	<div className="sidebar__footer">
 		{ children }
-		<Button compact borderless href="/help">
-			<Gridicon icon="help-outline" /> { translate( 'Help' ) }
+		<Button borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' }>
+			<Gridicon icon="add-outline" /> { translate( 'Add New Site' ) }
+		</Button>
+		<Button className="sidebar__footer__help" borderless href="/help" title={ translate( 'Help' ) }>
+			<Gridicon icon="help-outline" />
 		</Button>
 		{ config.isEnabled( 'happychat' ) && <HappychatButton /> }
 	</div>

--- a/client/layout/sidebar/footer.jsx
+++ b/client/layout/sidebar/footer.jsx
@@ -18,7 +18,7 @@ const SidebarFooter = ( { translate, children } ) => (
 		<Button borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' }>
 			<Gridicon icon="add-outline" /> { translate( 'Add New Site' ) }
 		</Button>
-		<Button className="sidebar__footer__help" borderless href="/help" title={ translate( 'Help' ) }>
+		<Button className="sidebar__footer-help" borderless href="/help" title={ translate( 'Help' ) }>
 			<Gridicon icon="help-outline" />
 		</Button>
 		{ config.isEnabled( 'happychat' ) && <HappychatButton /> }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -366,6 +366,25 @@ a.sidebar__button {
 
 	}
 
+	&.sidebar__footer__support-chat-unread {
+		color: $gray-dark;
+		position: relative;
+
+		&:after {
+			content: "";
+			display: block;
+			position: absolute;
+			top: 6px;
+			left: 3px;
+			width: 10px;
+			height: 10px;
+			border: 2px solid lighten( $gray, 30% );
+			border-radius: 50%;
+			background: $orange-jazzy;
+		}
+
+	}
+
 	&:hover {
 		color: $gray-dark;
 	}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -333,6 +333,8 @@ a.sidebar__button {
 	padding: 0;
 	border-top: 1px solid darken( $sidebar-bg-color, 10% );
 	margin: auto 0 0;
+	display: flex;
+	flex-direction: row;
 
 	@include breakpoint( "<660px" ) {
 		margin-top: 16px;
@@ -346,9 +348,23 @@ a.sidebar__button {
 	text-transform: uppercase;
 	font-size: 11px;
 	font-weight: 600;
-	padding: 11px 6px;
+	padding: 8px;
 	color: darken( $gray, 10% );
-	margin-right: 4px;
+	line-height: 2.1;
+	margin-right: auto;
+
+	&.sidebar__footer__help,
+	&.sidebar__footer__support-chat {
+		border-left: 1px solid darken( $sidebar-bg-color, 10% );
+		flex: 0 1 40px;
+		margin-right: 0;
+		margin-left: 0;
+
+		@include breakpoint( "<660px" ) {
+			flex: 0 1 56px;
+		}
+
+	}
 
 	&:hover {
 		color: $gray-dark;
@@ -356,6 +372,14 @@ a.sidebar__button {
 
 	@include breakpoint( "<660px" ) {
 		padding: 16px;
+	}
+
+	.gridicon {
+		display: block;
+		float: left;
+		margin-right: 6px;
+		top: auto;
+		margin-top: auto;
 	}
 
 }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -381,6 +381,12 @@ a.sidebar__button {
 			border: 2px solid lighten( $gray, 30% );
 			border-radius: 50%;
 			background: $orange-jazzy;
+
+			@include breakpoint( "<660px" ) {
+				top: 14px;
+				left: 11px;
+			}
+
 		}
 
 	}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -335,6 +335,7 @@ a.sidebar__button {
 	margin: auto 0 0;
 	display: flex;
 	flex-direction: row;
+	padding-left: 10px;
 
 	@include breakpoint( "<660px" ) {
 		margin-top: 16px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -367,6 +367,10 @@ a.sidebar__button {
 
 	}
 
+	&.sidebar__footer-help {
+		margin-left: auto;
+	}
+
 	&.sidebar__footer-chat.has-unread {
 		color: $gray-dark;
 		position: relative;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -354,8 +354,8 @@ a.sidebar__button {
 	line-height: 2.1;
 	margin-right: auto;
 
-	&.sidebar__footer__help,
-	&.sidebar__footer__support-chat {
+	&.sidebar__footer-help,
+	&.sidebar__footer-chat {
 		border-left: 1px solid darken( $sidebar-bg-color, 10% );
 		flex: 0 1 40px;
 		margin-right: 0;
@@ -367,7 +367,7 @@ a.sidebar__button {
 
 	}
 
-	&.sidebar__footer__support-chat-unread {
+	&.sidebar__footer-chat.has-unread {
 		color: $gray-dark;
 		position: relative;
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -670,7 +670,7 @@ export const MySitesSidebar = React.createClass( {
 		}
 
 		return (
-			<Button compact borderless
+			<Button borderless
 				className="my-sites-sidebar__add-new-site"
 				href={ config( 'signup_url' ) + '?ref=calypso-selector' }
 				onClick={ this.focusContent }


### PR DESCRIPTION
This PR <strike>starts work on</strike> fixes #8461. It:

- Adjusts the layout to fit the mockups
- Adds the "Add new site" button to sit there permanently, so we don't have to have a separate switchin layout for the site selector.

Still lots to do.

- [x] <strike>Tracks for "Add new site" wasn't ported.</strike> — irrelevant now
- [x] Multisite switcher needs to work with this new design.
- [x] Unread dot design for chat button.
- [x] Currently the SVG is included directly, instead of referring to a gridicon. Pending PR: https://github.com/Automattic/wp-calypso/pull/8579

Screenshot:

![screen shot 2016-10-07 at 12 27 54](https://cloud.githubusercontent.com/assets/1204802/19187037/97bb08ba-8c89-11e6-8307-b449010876ec.png)
