### PR TITLE
Search: Prevent unnecessary animation frame requests

### DIFF
--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -54,7 +54,7 @@ Currently supports forcing a LTR field in a RTL language, but not the other way 
 
 Supported values are `'ltr'` and `undefined` (the default, which uses the current global writing direction of the app).
 
-### styleOverlay (optional) function ( default noop )
+### styleOverlay (optional) function ( default undefined )
 Implement this function to add markup to the content of the search box. Current content is supplied as a parameter. Return a string containing the same text but with markup added.
 
 For example, add `<span/>`s around tokens in the content, then add CSS elsewhere to style the `<span/>`s.

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -85,7 +85,6 @@ const Search = React.createClass( {
 			onSearchOpen: noop,
 			onSearchClose: noop,
 			onKeyDown: noop,
-			overlayStyling: noop,
 			disableAutocorrect: false,
 			searching: false,
 			isOpen: false,
@@ -344,11 +343,17 @@ const Search = React.createClass( {
 						maxLength={ this.props.maxLength }
 						{ ...autocorrect }
 					/>
-					<div className="search__text-overlay" ref="overlay">
-						{ this.props.overlayStyling( this.state.keyword ) }
-					</div>
+					{ this.props.overlayStyling && this.renderStylingDiv() }
 				</div>
 				{ this.closeButton() }
+			</div>
+		);
+	},
+
+	renderStylingDiv: function() {
+		return (
+			<div className="search__text-overlay" ref="overlay">
+				{ this.props.overlayStyling( this.state.keyword ) }
 			</div>
 		);
 	},


### PR DESCRIPTION
Only do the styling overlay scroll if there is any styling present. This should make sure that there is no performance impact when not styling the search text.

**To test**
* Go to http://calypso.localhost:3000/design/filter/blue,post-slider
* The text in the search box should still have styling

@mtias @blowery I'm not seeing enough lag in the site search to be able to tell if this makes a difference to the slow site search or not. Earlier this week I was seeing more lag. This PR is probably sensible either way. The animation frame callbacks could be interfering with the site list render.
