### PR TITLE
Buttons: Remove transparent border for Firefox

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -239,7 +239,7 @@ button {
 
 // Buttons within sentences sit on the text baseline.
 .layout__content p .button {
-	vertical-align: baseline
+	vertical-align: baseline;
 }
 
 // Firefox Junk
@@ -247,10 +247,8 @@ button {
 .layout__content input[type=reset]::-moz-focus-inner,
 .layout__content input[type=button]::-moz-focus-inner,
 .layout__content input[type=submit]::-moz-focus-inner {
-	border-width: 1px 0;
-	border-style: solid none;
-	border-color: transparent;
-	padding: 0
+	border: 0;
+	padding: 0;
 }
 
 // ==========================================================================


### PR DESCRIPTION
This issue was reported in #8567.

We have transparent border for buttons in Firefox that increase its height. And that's causing a misalignment when a button and a link sit next each other.

**Before:**
![before](https://cloud.githubusercontent.com/assets/908665/19187504/b870e2e2-8c83-11e6-963d-af97f52cd77c.jpg)

I'm not sure why we have it but, by removing the border, the height of button becomes as intended and we can fix the misalignment.

**After:**
![after](https://cloud.githubusercontent.com/assets/908665/19187509/c1087438-8c83-11e6-9050-cdd0b17ae6be.jpg)

Other buttons look good and more look the same as on other browsers like Chrome.

![screen shot 2016-10-07 at 13 10 51](https://cloud.githubusercontent.com/assets/908665/19189407/c8ab13ce-8c8f-11e6-9081-bbd84b23a792.png)

![screen shot 2016-10-07 at 13 11 05](https://cloud.githubusercontent.com/assets/908665/19189412/cede22b8-8c8f-11e6-811f-829a0d558dce.png)
