### PR TITLE
Site Settings: Reduxify the default category form

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -3,8 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import each from 'lodash/each';
-import pick from 'lodash/pick';
+import { each, pick, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -142,7 +141,7 @@ const SiteSettingsFormWriting = React.createClass( {
 							valueLink={ this.linkState( 'default_category' ) }
 							disabled={ this.props.isRequestingCategories }
 							onClick={ this.recordEvent.bind( this, 'Selected Default Post Category' ) }>
-							{ this.props.categories.map( category => {
+							{ map(this.props.categories, category => {
 								return <option value={ category.ID } key={ 'post-category-' + category.ID }>{ category.name }</option>;
 							} ) }
 						</FormSelect>
@@ -226,7 +225,7 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const isRequestingCategories = isRequestingTermsForQuery( state, siteId, 'category', {} );
-		const categories = getTerms( state, siteId, 'category' ) || [];
+		const categories = getTerms( state, siteId, 'category' );
 
 		return {
 			jetpackCustomTypesModuleActive: false !== isJetpackModuleActive( state, siteId, 'custom-content-types' ),

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -21,23 +21,24 @@ import FormLabel from 'components/forms/form-label';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
+import QueryTerms from 'components/data/query-terms';
 import { isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
+import { isRequestingTermsForQuery, getTerms } from 'state/terms/selectors';
 import CustomPostTypeFieldset from './custom-post-types-fieldset';
 
 const SiteSettingsFormWriting = React.createClass( {
 	mixins: [ dirtyLinkedState, protectForm.mixin, formBase ],
 
 	getSettingsFromSite: function( site ) {
-		var writingAttributes = [
-				'default_category',
-				'post_categories',
-				'default_post_format',
-				'wpcom_publish_posts_with_markdown',
-				'markdown_supported',
-			],
-			settings = {};
+		let writingAttributes = [
+			'default_category',
+			'default_post_format',
+			'wpcom_publish_posts_with_markdown',
+			'markdown_supported',
+		];
+		const settings = {};
 
 		site = site || this.props.site;
 
@@ -54,7 +55,6 @@ const SiteSettingsFormWriting = React.createClass( {
 			}, this );
 		}
 		settings.fetchingSettings = site.fetchingSettings;
-		settings.post_categories = settings.post_categories || [];
 
 		return settings;
 	},
@@ -70,7 +70,6 @@ const SiteSettingsFormWriting = React.createClass( {
 		this.replaceState( {
 			fetchingSettings: true,
 			default_category: '',
-			post_categories: [],
 			default_post_format: '',
 		} );
 	},
@@ -133,6 +132,7 @@ const SiteSettingsFormWriting = React.createClass( {
 				</SectionHeader>
 				<Card className="site-settings">
 					<FormFieldset>
+						<QueryTerms siteId={ this.props.siteId } taxonomy="category" />
 						<FormLabel htmlFor="default_category">
 							{ this.translate( 'Default Post Category' ) }
 						</FormLabel>
@@ -140,10 +140,10 @@ const SiteSettingsFormWriting = React.createClass( {
 							name="default_category"
 							id="default_category"
 							valueLink={ this.linkState( 'default_category' ) }
-							disabled={ this.state.fetchingSettings }
+							disabled={ this.props.isRequestingCategories }
 							onClick={ this.recordEvent.bind( this, 'Selected Default Post Category' ) }>
-							{ this.state.post_categories.map( function( category ) {
-								return <option value={ category.value } key={ 'post-category-' + category.value }>{ category.name }</option>;
+							{ this.props.categories.map( category => {
+								return <option value={ category.ID } key={ 'post-category-' + category.ID }>{ category.name }</option>;
 							} ) }
 						</FormSelect>
 						<FormLabel htmlFor="default_post_format">
@@ -225,10 +225,15 @@ const SiteSettingsFormWriting = React.createClass( {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
+		const isRequestingCategories = isRequestingTermsForQuery( state, siteId, 'category', {} );
+		const categories = getTerms( state, siteId, 'category' ) || [];
 
 		return {
 			jetpackCustomTypesModuleActive: false !== isJetpackModuleActive( state, siteId, 'custom-content-types' ),
-			jetpackVersionSupportsCustomTypes: false !== isJetpackMinimumVersion( state, siteId, '4.2.0' )
+			jetpackVersionSupportsCustomTypes: false !== isJetpackMinimumVersion( state, siteId, '4.2.0' ),
+			categories,
+			isRequestingCategories,
+			siteId
 		};
 	},
 	{ requestPostTypes },


### PR DESCRIPTION
Fetch categories using QueryTerms instead of post_categories from site settings API.
I searched for the "post_categories" settings from siteSettings and looks like it's not used anymore in Calypso, we should drop it from the API.

closes #8576 

**Testing instructions**

 * start from https://wordpress.com/settings/writing
 * set a default category
 * save
 * refresh and check that it persists correctly
 * retry after clearing localstorage and all caches

cc @timmyc 