### PR TITLE
Convert the :: in Jetpack URLs back to a / in purchases

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -37,7 +37,6 @@ function getPurchasesBySite( purchases, sites ) {
 			const siteObject = find( sites, { ID: currentValue.siteId } );
 
 			result = result.concat( {
-				domain: currentValue.domain,
 				id: currentValue.siteId,
 				name: currentValue.siteName,
 				/* if the purchase is attached to a deleted site,
@@ -45,7 +44,8 @@ function getPurchasesBySite( purchases, sites ) {
 				 * we fall back on the domain. */
 				slug: siteObject ? siteObject.slug : currentValue.domain,
 				title: currentValue.siteName || currentValue.domain || '',
-				purchases: [ currentValue ]
+				purchases: [ currentValue ],
+				domain: siteObject ? siteObject.domain : currentValue.domain
 			} );
 		}
 

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -50,6 +50,7 @@ const PurchasesList = React.createClass( {
 					<PurchasesSite
 						key={ site.id }
 						name={ site.title }
+						domain={ site.domain }
 						slug={ site.slug }
 						purchases={ site.purchases } />
 				)

--- a/client/me/purchases/list/site/index.jsx
+++ b/client/me/purchases/list/site/index.jsx
@@ -12,7 +12,7 @@ import i18n from 'i18n-calypso';
 import PurchaseItem from '../item';
 import SectionHeader from 'components/section-header';
 
-const PurchasesSite = ( { isPlaceholder, name, purchases, slug } ) => {
+const PurchasesSite = ( { isPlaceholder, name, purchases, slug, domain } ) => {
 	let items, label = name;
 
 	if ( isPlaceholder ) {
@@ -34,7 +34,7 @@ const PurchasesSite = ( { isPlaceholder, name, purchases, slug } ) => {
 	return (
 		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>
 			<SectionHeader label={ label }>
-				<span className="purchases-site__slug">{ slug }</span>
+				<span className="purchases-site__slug">{ domain }</span>
 			</SectionHeader>
 
 			{ items }
@@ -43,6 +43,7 @@ const PurchasesSite = ( { isPlaceholder, name, purchases, slug } ) => {
 };
 
 PurchasesSite.propTypes = {
+	domain: React.PropTypes.string,
 	isPlaceholder: React.PropTypes.bool,
 	name: React.PropTypes.string,
 	purchases: React.PropTypes.array,


### PR DESCRIPTION
This pull request converts the `::` in the Jetpack site slug back into a `/` on the purchase screen, to make it more readable.
    
<img width="616" alt="screen shot 2016-10-07 at 12 42 00" src="https://cloud.githubusercontent.com/assets/275961/19188710/7ce29718-8c8b-11e6-810f-58cc5a853caf.png">

I expected that there would already be a function for this, but I couldn't find one, so I just did it like this for now.

#### Testing instructions
  
1. Run `git checkout fix/jetpack-slug` and start your server, or open a [live branch](https://delphin.live/?branch=fix/jetpack-slug)
2. Open the [`Purchases` page](http://calypso.localhost:3000/purchases) for a site with a Jetpack plan
3. Check that the URL in the purchases header has a `/` instead of the `::`.
    
#### Reviews
  
- [ ] Code
- [ ] Product
   
@Automattic/sdev-feed