### PR TITLE
Domains: Don't show DomainWarnings on Jetpack sites

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -39,7 +39,7 @@ const CurrentSite = React.createClass( {
 	componentWillMount() {
 		const selectedSite = this.getSelectedSite();
 
-		if ( selectedSite ) {
+		if ( selectedSite && ! selectedSite.jetpack ) {
 			UpgradesActions.fetchDomains( selectedSite.ID );
 		}
 		this.prevSelectedSite = selectedSite;
@@ -60,7 +60,7 @@ const CurrentSite = React.createClass( {
 	componentWillUpdate() {
 		const selectedSite = this.getSelectedSite();
 
-		if ( selectedSite && this.prevSelectedSite !== selectedSite ) {
+		if ( selectedSite && this.prevSelectedSite !== selectedSite && ! selectedSite.jetpack ) {
 			UpgradesActions.fetchDomains( selectedSite.ID );
 		}
 		this.prevSelectedSite = selectedSite;
@@ -107,14 +107,6 @@ const CurrentSite = React.createClass( {
 					'expiringDomainsCannotManage',
 					'wrongNSMappedDomains'
 				] } />
-		);
-	},
-
-	getSiteNotices: function() {
-		return (
-			<div>
-				{ this.getDomainWarnings() }
-			</div>
 		);
 	},
 
@@ -172,7 +164,7 @@ const CurrentSite = React.createClass( {
 						ref="site" />
 					: <AllSites sites={ this.props.sites.get() } />
 				}
-				{ this.getSiteNotices( site ) }
+				{ ! site.jetpack && this.getDomainWarnings() }
 				<SiteNotice site={ site } />
 			</Card>
 		);

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -100,10 +100,6 @@ export default React.createClass( {
 	wrongNSMappedDomains() {
 		debug( 'Rendering wrongNSMappedDomains' );
 
-		if ( this.props.selectedSite && this.props.selectedSite.jetpack ) {
-			return null;
-		}
-
 		const wrongMappedDomains = this.getDomains().filter( domain =>
 			domain.type === domainTypes.MAPPED && ! domain.pointsToWpcom );
 


### PR DESCRIPTION
As `DomainWarnings` are wpcom-specific, it doesn't make sense to show them for Jetpack sites (and they can be confusing, see https://github.com/Automattic/wp-calypso/pull/7471).
Plus, they require an unnecessary call to the `domains` endpoint.

Testing
Verify that the `domains` endpoint is queried for non-Jetpack sites and that the domain warnings are being shown under the current site (and, of course, in domain management).
Same for Jetpack sites - but no fetch of `domains`, no domain warnings :)

/cc @aidvu @umurkontaci 