### PR TITLE
Purchases: Redirect users to support to cancel a domain renewal

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -32,6 +32,7 @@ function createPurchaseObject( purchase ) {
 		isRedeemable: Boolean( purchase.is_redeemable ),
 		isRefundable: Boolean( purchase.is_refundable ),
 		isRenewable: Boolean( purchase.is_renewable ),
+		isRenewal: Boolean( purchase.is_renewal ),
 		meta: purchase.meta,
 		priceText: `${ purchase.currency_symbol }${ purchase.amount }`,
 		payment: {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -163,6 +163,10 @@ function isRenewable( purchase ) {
 	return purchase.isRenewable;
 }
 
+function isRenewal( purchase ) {
+	return purchase.isRenewal;
+}
+
 function isRenewing( purchase ) {
 	return includes( [ 'active', 'autoRenewing' ], purchase.expiryStatus );
 }
@@ -251,6 +255,7 @@ export {
 	isRefundable,
 	isRemovable,
 	isRenewable,
+	isRenewal,
 	isRenewing,
 	isSubscription,
 	paymentLogoType,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -29,6 +29,7 @@ import {
 	isRedeemable,
 	isRefundable,
 	isRenewable,
+	isRenewal,
 	isRenewing,
 	isSubscription,
 	paymentLogoType,
@@ -507,11 +508,16 @@ const ManagePurchase = React.createClass( {
 			return null;
 		}
 
-		let text;
+		let text, link = paths.cancelPurchase( this.props.selectedSite.slug, id );
 
 		if ( isRefundable( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
-				text = this.translate( 'Cancel Domain and Refund' );
+				if ( isRenewal( purchase ) ) {
+					text = this.translate( 'Contact Support to Cancel Domain and Refund' );
+					link = support.CALYPSO_CONTACT;
+				} else {
+					text = this.translate( 'Cancel Domain and Refund' );
+				}
 			}
 
 			if ( isSubscription( purchase ) ) {
@@ -532,7 +538,7 @@ const ManagePurchase = React.createClass( {
 		}
 
 		return (
-			<CompactCard href={ paths.cancelPurchase( this.props.selectedSite.slug, id ) }>
+			<CompactCard href={ link }>
 				{ text }
 			</CompactCard>
 		);

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -85,6 +85,7 @@ describe( 'selectors', () => {
 				isRedeemable: false,
 				isRefundable: false,
 				isRenewable: false,
+				isRenewal: false,
 				meta: undefined,
 				payment: {
 					countryCode: undefined,


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/8266 by offering a new option  on the `Manage Purchase` page to invite users to contact support in order to get a refund for a domain registration that has just been renewed:
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/19191153/741f1b5e-8ca1-11e6-9c66-546e73b4a7f3.png)

#### Testing instructions

This pull requests works with a server patch. Please refer to D2977-code for testing instructions.

#### Reviews
 
- [x] Code
- [x] Product
- [x] Tests
 
@Automattic/sdev-feed