### PR TITLE
Refactor blog posts page; move your latest posts label

### DIFF
--- a/client/my-sites/pages/blog-posts-page.jsx
+++ b/client/my-sites/pages/blog-posts-page.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import Gridicon from 'components/gridicon';
+
+const BlogPostsPage = React.createClass( {
+	render() {
+		return (
+			<CompactCard className="pages__blog-posts-page">
+				<span className="pages__blog-posts-page__title" href="">
+					<Gridicon icon="house" size={ 18 } />
+					{ this.translate( 'Blog Posts' ) }
+				</span>
+				<div className="pages__blog-posts-page__info">
+					{ this.translate( 'Your latest posts' ) }
+				</div>
+			</CompactCard>
+		);
+	}
+} );
+
+export default BlogPostsPage;

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -22,6 +22,7 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	mapStatus = require( 'lib/route' ).mapPostStatus;
 
 import Gridicon from 'components/gridicon';
+import BlogPostsPage from './blog-posts-page';
 
 var PageList = React.createClass( {
 
@@ -200,20 +201,6 @@ var Pages = React.createClass( {
 		}
 	},
 
-	blogPostsPage: function() {
-		return (
-			<CompactCard className="page" key="blog-posts-page">
-				<span className="page__title" href="">
-					<Gridicon icon="house" size={ 18 } />
-					{ this.translate( 'Blog Posts' ) }
-				</span>
-				<span className="page__info">
-					{ this.translate( 'Your latest posts' ) }
-				</span>
-			</CompactCard>
-		);
-	},
-
 	render: function() {
 		var pages = this.props.posts,
 			rows = [];
@@ -245,7 +232,7 @@ var Pages = React.createClass( {
 			const status = this.props.status || 'published';
 
 			if ( status === 'published' && get( site, 'options.show_on_front' ) === 'posts' ) {
-				rows.push( this.blogPostsPage() );
+				rows.push( <BlogPostsPage key="blog-posts-page" /> );
 			}
 		} else if ( ( ! this.props.loading ) && this.props.sites.initialized ) {
 			rows.push( <div key="page-list-no-results">{ this.getNoContentMessage() }</div> );

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -18,10 +18,8 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	NoResults = require( 'my-sites/no-results' ),
 	actions = require( 'lib/posts/actions' ),
 	Placeholder = require( './placeholder' ),
-	CompactCard = require( 'components/card/compact' ),
 	mapStatus = require( 'lib/route' ).mapPostStatus;
 
-import Gridicon from 'components/gridicon';
 import BlogPostsPage from './blog-posts-page';
 
 var PageList = React.createClass( {

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -35,7 +35,8 @@
 }
 
 // <Page> component
-.page {
+.page,
+.pages__blog-posts-page {
 
 	.site-icon {
 		display: none;
@@ -50,7 +51,9 @@
 }
 
 .page__title,
-.page__title:visited {
+.page__title:visited,
+.pages__blog-posts-page__title,
+.pages__blog-posts-page__title:visited {
 	display: inline;
 	color: $gray-dark;
 	font-weight: 500;
@@ -95,12 +98,12 @@
 	text-align: left;
 }
 
-.page__info {
+.pages__blog-posts-page__info {
 	color: $gray;
 	font-size: 12px;
 	max-width: 300px;
-	float: right;
 	line-height: 24px;
+	margin: -6px 33px 0px 26px;
 }
 
 .page__delete-item.popover__menu-item {


### PR DESCRIPTION
This PR is part of a larger epic focused on allowing the user to set their home page from the Pages screen.

This PR refactored the blog posts page, to pull it into its own file/component, which will make further enhancements cleaner. In addition, it moves the "your latest posts" info label to the left for the Blog Posts page list item, which is part of the design and necessary once this list item gains an ellipsis menu.

<img width="713" alt="screencapture at fri oct 7 13 37 46 edt 2016" src="https://cloud.githubusercontent.com/assets/2098816/19199705/52124972-8c93-11e6-986f-bc4828a57080.png">

To test:
- Make sure that other than the "you latest posts" being moved to the left, that the Pages screen works/looks as it did previously. At this point there should be no functionality changes.

@iamtakashi The layout of this state (Blog Posts set as homepage) wasn't fully specified in the mockups that we had done before you started working with our team. If you have any tweaks you would like made, let me know.