### PR TITLE
Add email unsubscribe description for `digest` category.

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -111,6 +111,8 @@ const MainComponent = React.createClass( {
 			return this.translate( 'Opportunities to participate in WordPress.com research & surveys.' );
 		} else if ( 'community' === this.props.category ) {
 			return this.translate( 'Information on WordPress.com courses and events (online & in-person).' );
+		} else if ( 'digest' === this.props.category ) {
+			return this.translate( 'Reading & writing digests, tailored for you.' );
 		}
 
 		return null;

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -99,6 +99,8 @@ const MainComponent = React.createClass( {
 			return this.translate( 'Research' );
 		} else if ( 'community' === this.props.category ) {
 			return this.translate( 'Community' );
+		} else if ( 'digest' === this.props.category ) {
+			return this.translate( 'Digests' );
 		}
 
 		return this.props.category;


### PR DESCRIPTION
This pull request adds name and description for the `digest` category which was added in https://github.com/Automattic/wp-calypso/pull/8573

Before:

<img width="734" alt="before" src="https://cloud.githubusercontent.com/assets/1017839/19200503/3b7beba6-8c7e-11e6-8986-77193424661c.png">

After:

<img width="737" alt="after" src="https://cloud.githubusercontent.com/assets/1017839/19200826/d7904dce-8c7f-11e6-9b62-fbe6e3a20a4c.png">
