### PR TITLE
Sharing: Fix untranslated display of Post-Types

### DIFF
--- a/client/lib/post-types-list/list.js
+++ b/client/lib/post-types-list/list.js
@@ -52,6 +52,7 @@ PostTypesList.prototype.fetch = function( siteId ) {
 
 		debug( 'getting PostTypesList from api' );
 		wpcom
+		.withLocale()
 		.site( siteId )
 		.postTypesList( function( error, data ) {
 			if ( error ) {


### PR DESCRIPTION
The sharing buttons retrieve the post-types not with the locale appended, thus they are displayed in English:

![screenshot-wordpress com_2016-10-07_14-17-07](https://cloud.githubusercontent.com/assets/203408/19199964/db27d71c-8cc6-11e6-95af-5e39bf583542.png)

![screen shot 2016-10-07 at 19 45 29](https://cloud.githubusercontent.com/assets/203408/19199966/de120a56-8cc6-11e6-9a0f-58b4f9cd0145.png)

This adds the locale to the API call.