### PR TITLE
Update Dockerfile adding back in `public` directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 node_modules
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ RUN        true \
            && apt-get -y install \
                  git \
                  make \
+           && apt-get autoremove -y \
+           && rm -rf /tmp/* \
+           && rm -rf /var/tmp/* \
+           && rm -rf /usr/share/{doc,doc-base,info,locale,man}/* \
+           && rm -rf /var/lib/apt/lists/* \
+           && rm -rf /var/lib/dpkg/info/* \
            && true
 
 # Build a "dependencies" layer
@@ -35,7 +41,10 @@ RUN        true \
 # Sometimes "npm install" fails the first time when the
 # cache is empty, so we retry once if it failed
 COPY       ./package.json ./npm-shrinkwrap.json /calypso/
-RUN        npm install --production || npm install --production
+RUN        true \
+           && npm install --production || npm install --production \
+           && rm -rf /root/.npm \
+           && true
 
 # Build the final layer
 #
@@ -48,16 +57,6 @@ RUN        true \
            && CALYPSO_ENV=stage make build-stage \
            && CALYPSO_ENV=production make build-production \
            && chown -R nobody /calypso \
-           # Clean up the dependencies we no longer need
-           && apt-get remove -y \
-                 git \
-           && apt-get autoremove -y \
-           && rm -rf /var/lib/apt/lists/* \
-           && rm -rf /var/lib/dpkg/info/* \
-           && rm -rf /tmp/* \
-           && rm -rf /var/tmp/* \
-           && rm -rf /usr/share/{doc,doc-base,info,locale,man}/* \
-           && rm -rf /root/.npm \
            && true
 
 USER       nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,48 @@
-FROM	debian:wheezy
-
+FROM       node:6.9.0-slim
 MAINTAINER Automattic
 
-WORKDIR /calypso
+WORKDIR    /calypso
 
-RUN     mkdir -p /tmp
-COPY    ./env-config.sh /tmp/
-RUN     bash /tmp/env-config.sh
-RUN     apt-get -y update && apt-get -y install \
-          wget \
-          git \
-          python \
-          make \
-          build-essential
+# includes three key files plus everything else
+#   - env-config.sh
+#      used by systems to overwrite some defaults
+#      such as the apt and npm mirrors
+#
+#   - package.json
+#      provides the build scripts needed by npm
+#
+#   - npm-shrinkwrap.json
+#      provides the actual node dependencies for the project
+COPY       . /calypso
 
-ENV NODE_VERSION 6.9.0
+ENV        NODE_PATH=/calypso/server:/calypso/client
 
-RUN     wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz && \
-          tar -zxf node-v$NODE_VERSION-linux-x64.tar.gz -C /usr/local && \
-          ln -sf /usr/local/node-v$NODE_VERSION-linux-x64 /usr/local/node && \
-          ln -sf /usr/local/node/bin/npm /usr/local/bin/ && \
-          ln -sf /usr/local/node/bin/node /usr/local/bin/ && \
-          rm node-v$NODE_VERSION-linux-x64.tar.gz
+RUN        true \
+           && mv ./env-config.sh /tmp/env-config.sh \
+           && bash /tmp/env-config.sh \
+           && apt-get -y update \
+           && apt-get -y install \
+                 git \
+                 make \
+           # Sometimes "npm install" fails the first time when the
+           # cache is empty, so we retry once if it failed
+           && npm install --production || npm install --production \
+           && CALYPSO_ENV=wpcalypso make build-wpcalypso \
+           && CALYPSO_ENV=horizon make build-horizon \
+           && CALYPSO_ENV=stage make build-stage \
+           && CALYPSO_ENV=production make build-production \
+           && chown -R nobody /calypso \
+           # Clean up the dependencies we no longer need
+           && apt-get remove -y \
+                 git \
+           && apt-get autoremove -y \
+           && rm -rf /var/lib/apt/lists/* \
+           && rm -rf /var/lib/dpkg/info/* \
+           && rm -rf /tmp/* \
+           && rm -rf /var/tmp/* \
+           && rm -rf /usr/share/{doc,doc-base,info,locale,man}/* \
+           && rm -rf /root/.npm \
+           && true
 
-# npmrc is created by env-config.sh. For local testing, an empty one is generated
-RUN     touch /usr/local/etc/npmrc && \
-          mkdir /usr/local/node/etc && \
-          cp /usr/local/etc/npmrc /usr/local/node/etc/npmrc
-
-ENV     NODE_PATH /calypso/server:/calypso/client
-
-# Install base npm packages to take advantage of the docker cache
-COPY    ./package.json /calypso/package.json
-COPY    ./npm-shrinkwrap.json /calypso/npm-shrinkwrap.json
-# Sometimes "npm install" fails the first time when the cache is empty, so we retry once if it failed
-RUN     npm install --production || npm install --production
-
-COPY     . /calypso
-
-# Build javascript bundles for each environment and change ownership
-RUN     CALYPSO_ENV=wpcalypso make build-wpcalypso && \
-          CALYPSO_ENV=horizon make build-horizon && \
-          CALYPSO_ENV=stage make build-stage && \
-          CALYPSO_ENV=production make build-production && \
-          chown -R nobody /calypso
-
-USER    nobody
-CMD     NODE_ENV=production node build/bundle-$CALYPSO_ENV.js
+USER       nobody
+CMD        NODE_ENV=production node build/bundle-$CALYPSO_ENV.js


### PR DESCRIPTION
See #8516

In the build I mistakenly prevented copying in the `public` directory
thinking that it was generated during the build process.

Actually it held our static assets and needed to be there. Images were
missing, for example.

The same Dockerfile has been updated again but this time I have not
prevented Docker from incorporating the `public` directory

Further I have added back the execution of `/tmp/env-config.sh` which I somehow accidentally removed before.

**Testing**
You can build the Docker image and run it locally. Yesterday it all seemed to deploy fine at least, so we have a certain level of confidence that this will go smoothly.

**WRONG: Omitting `public`**
<img width="556" alt="screen shot 2016-10-07 at 12 04 59 pm" src="https://cloud.githubusercontent.com/assets/5431237/19202963/da93e95e-8c89-11e6-9a29-d450caab5202.png">

**Right: _not_ omitting `public`**
<img width="567" alt="screen shot 2016-10-07 at 12 25 23 pm" src="https://cloud.githubusercontent.com/assets/5431237/19203164/a2d6c3c8-8c8a-11e6-9617-60f32663a77a.png">

cc: @gwwar @alisterscott @umurkontaci @nylen 