### PR TITLE
Framework: Hide HelloVote notice in 'customize' and 'upgrades' sections

### DIFF
--- a/client/blocks/hello-vote-notice/index.jsx
+++ b/client/blocks/hello-vote-notice/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { mapValues } from 'lodash';
+import { includes, mapValues } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -70,7 +70,7 @@ export default connect(
 				siteSlug &&
 				! isJetpackSite( state, selectedSiteId ) &&
 				isSiteSection( state ) &&
-				'settings' !== getSectionName( state ) &&
+				! includes( [ 'customize', 'settings', 'upgrades' ], getSectionName( state ) ) &&
 				canCurrentUser( state, selectedSiteId, 'manage_options' ) &&
 				moment( getCurrentUserDate( state ) ).isBefore( moment().subtract( 1, 'weeks' ) ) &&
 				hasReceivedRemotePreferences( state ) &&


### PR DESCRIPTION
We shouldn't show the notice to enable the HelloVote voter registration form in the `customize` or `upgrades` (checkout) sections.

### To test

See #8423 for testing instructions for the notice itself, including how to re-enable the notice if you've already dismissed it.

- `customize` - Navigate to `/customize/$site`.  Verify that the notice does not appear at the top of the page.  (Currently, the notice is rendered, but obscured by the customizer overlay unless it fails to load; you can verify this with `document.querySelector( '.hello-vote-notice' )` in the console.  This PR avoids rendering it at all.)
- `upgrades` - Navigate to `/plans/$site` and click **Upgrade**.  Verify that the notice does not appear at the top of the page (URL `/checkout/$site/$plan`).