### PR TITLE
Add verticals v2 back button

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -68,7 +68,7 @@ const NavigationLink = React.createClass( {
 	},
 
 	render() {
-		if ( this.props.positionInFlow === 0 && this.props.direction === 'back' ) {
+		if ( this.props.positionInFlow === 0 && this.props.direction === 'back' && !this.props.stepSectionName ) {
 			return null;
 		}
 

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -68,7 +68,7 @@ const NavigationLink = React.createClass( {
 	},
 
 	render() {
-		if ( this.props.positionInFlow === 0 && this.props.direction === 'back' && !this.props.stepSectionName ) {
+		if ( this.props.positionInFlow === 0 && this.props.direction === 'back' && ! this.props.stepSectionName ) {
 			return null;
 		}
 

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -21,6 +21,7 @@ export default React.createClass( {
 				flowName={ this.props.flowName }
 				positionInFlow={ this.props.positionInFlow }
 				stepName={ this.props.stepName }
+				stepSectionName={ this.props.stepSectionName }
 				backUrl={ this.props.backUrl }
 				signupProgressStore={ this.props.signupProgressStore } />
 		);

--- a/client/signup/steps/survey/survey-step-v2.jsx
+++ b/client/signup/steps/survey/survey-step-v2.jsx
@@ -32,9 +32,14 @@ export default React.createClass( {
 
 	getInitialState() {
 		return {
-			otherWriteIn: get( find( this.props.signupProgressStore, { stepName: this.props.stepName } ), 'otherWriteIn', '' ),
+			otherWriteIn: '',
 			verticalList: verticals.get(),
 		};
+	},
+
+	getOtherWriteIn() {
+		return this.state.otherWriteIn ||
+			get( find( this.props.signupProgressStore, { stepName: this.props.stepName } ), 'otherWriteIn', '' );
 	},
 
 	renderVertical( vertical ) {
@@ -59,15 +64,16 @@ export default React.createClass( {
 	},
 
 	renderOther() {
+		const otherWriteIn = this.getOtherWriteIn();
 		return (
 			<div className="survey__other">
 				<TextInput className="survey__other-write-in"
 					placeholder={ this.translate( 'Please describe what your site is about' ) }
-					defaultValue={ this.state.otherWriteIn }
+					defaultValue={ otherWriteIn }
 					onChange={ this.handleOtherWriteIn }
 					ref={ ( input ) => input && input.focus() } />
 				<Button className="survey__other-button" primary compact
-					disabled={ this.state.otherWriteIn.length === 0 }
+					disabled={ otherWriteIn.length === 0 }
 					data-value="a8c.24"
 					data-label="Uncategorized"
 					onClick={ this.handleNextStep }
@@ -127,18 +133,19 @@ export default React.createClass( {
 
 	handleNextStep( e ) {
 		const { value, label } = e.target.dataset;
+		const otherWriteIn = this.getOtherWriteIn();
 		analytics.tracks.recordEvent( 'calypso_survey_site_type', { type: this.props.surveySiteType } );
 		analytics.tracks.recordEvent( 'calypso_survey_category_chosen', {
 			category_id: value,
 			category_label: label,
-			category_write_in: ( this.state.otherWriteIn.length !== 0 ? this.state.otherWriteIn : undefined ),
+			category_write_in: ( otherWriteIn.length !== 0 ? otherWriteIn : undefined ),
 			survey_version: '2',
 		} );
 		SignupActions.submitSignupStep(
 			{
 				stepName: this.props.stepName,
 				stepSectionName: this.props.stepSectionName,
-				otherWriteIn: this.state.otherWriteIn,
+				otherWriteIn: otherWriteIn,
 			},
 			[],
 			{ surveySiteType: this.props.surveySiteType, surveyQuestion: value }

--- a/client/signup/steps/survey/survey-step-v2.jsx
+++ b/client/signup/steps/survey/survey-step-v2.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,8 +32,7 @@ export default React.createClass( {
 
 	getInitialState() {
 		return {
-			shouldShowOther: false,
-			otherWriteIn: '',
+			otherWriteIn: get( find( this.props.signupProgressStore, { stepName: this.props.stepName } ), 'otherWriteIn', '' ),
 			verticalList: verticals.get(),
 		};
 	},
@@ -60,12 +59,11 @@ export default React.createClass( {
 	},
 
 	renderOther() {
-		page( signupUtils.getStepUrl( this.props.flowName, this.props.stepName, 'survey-other', this.props.locale ) );
-
 		return (
 			<div className="survey__other">
 				<TextInput className="survey__other-write-in"
 					placeholder={ this.translate( 'Please describe what your site is about' ) }
+					defaultValue={ this.state.otherWriteIn }
 					onChange={ this.handleOtherWriteIn }
 					ref={ ( input ) => input && input.focus() } />
 				<Button className="survey__other-button" primary compact
@@ -100,19 +98,20 @@ export default React.createClass( {
 		const siteSubHeaderText = this.translate( 'To get started, tell us what your blog or website is about.' );
 
 		const backUrl = this.props.stepSectionName
-			? signupUtils.getStepUrl( this.props.flowName, this.props.stepName, undefined, i18n.getLocaleSlug() )
+			? signupUtils.getStepUrl( this.props.flowName, this.props.stepName, undefined, this.props.locale )
 			: undefined;
 
 		return (
 			<StepWrapper
 					flowName={ this.props.flowName }
 					stepName={ this.props.stepName }
+					stepSectionName={ this.props.stepSectionName }
 					backUrl={ backUrl }
 					positionInFlow={ this.props.positionInFlow }
 					headerText={ this.props.surveySiteType === 'blog' ? blogHeaderText : siteHeaderText }
 					subHeaderText={ this.props.surveySiteType === 'blog' ? blogSubHeaderText : siteSubHeaderText }
 					signupProgressStore={ this.props.signupProgressStore }
-					stepContent={ this.state.shouldShowOther ? this.renderOther() : this.renderOptionList() } />
+					stepContent={ this.props.stepSectionName === 'other' ? this.renderOther() : this.renderOptionList() } />
 		);
 	},
 
@@ -123,9 +122,7 @@ export default React.createClass( {
 	},
 
 	handleOther() {
-		this.setState( {
-			shouldShowOther: true
-		} );
+		page( signupUtils.getStepUrl( this.props.flowName, this.props.stepName, 'other', this.props.locale ) );
 	},
 
 	handleNextStep( e ) {
@@ -138,7 +135,11 @@ export default React.createClass( {
 			survey_version: '2',
 		} );
 		SignupActions.submitSignupStep(
-			{ stepName: this.props.stepName },
+			{
+				stepName: this.props.stepName,
+				stepSectionName: this.props.stepSectionName,
+				otherWriteIn: this.state.otherWriteIn,
+			},
 			[],
 			{ surveySiteType: this.props.surveySiteType, surveyQuestion: value }
 		);

--- a/client/signup/steps/survey/survey-step-v2.jsx
+++ b/client/signup/steps/survey/survey-step-v2.jsx
@@ -133,14 +133,18 @@ export default React.createClass( {
 
 	handleNextStep( e ) {
 		const { value, label } = e.target.dataset;
-		const otherWriteIn = this.getOtherWriteIn();
+		const otherWriteIn = ( value === 'a8c.24' && this.getOtherWriteIn().length !== 0 )
+			? this.getOtherWriteIn()
+			: undefined;
+
 		analytics.tracks.recordEvent( 'calypso_survey_site_type', { type: this.props.surveySiteType } );
 		analytics.tracks.recordEvent( 'calypso_survey_category_chosen', {
 			category_id: value,
 			category_label: label,
-			category_write_in: ( otherWriteIn.length !== 0 ? otherWriteIn : undefined ),
+			category_write_in: otherWriteIn,
 			survey_version: '2',
 		} );
+
 		SignupActions.submitSignupStep(
 			{
 				stepName: this.props.stepName,
@@ -150,6 +154,7 @@ export default React.createClass( {
 			[],
 			{ surveySiteType: this.props.surveySiteType, surveyQuestion: value }
 		);
+
 		this.props.goToNextStep();
 	}
 } );

--- a/client/signup/steps/survey/survey-step-v2.jsx
+++ b/client/signup/steps/survey/survey-step-v2.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,6 +15,7 @@ import verticals from './verticals';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import TextInput from 'components/forms/form-text-input';
+import signupUtils from 'signup/utils';
 
 export default React.createClass( {
 	displayName: 'SurveyStepV2',
@@ -57,6 +60,8 @@ export default React.createClass( {
 	},
 
 	renderOther() {
+		page( signupUtils.getStepUrl( this.props.flowName, this.props.stepName, 'survey-other', this.props.locale ) );
+
 		return (
 			<div className="survey__other">
 				<TextInput className="survey__other-write-in"
@@ -93,10 +98,16 @@ export default React.createClass( {
 		const siteHeaderText = this.translate( 'Let\'s create your new WordPress.com site!' );
 		const blogSubHeaderText = this.translate( 'To get started, tell us what your blog is about.' );
 		const siteSubHeaderText = this.translate( 'To get started, tell us what your blog or website is about.' );
+
+		const backUrl = this.props.stepSectionName
+			? signupUtils.getStepUrl( this.props.flowName, this.props.stepName, undefined, i18n.getLocaleSlug() )
+			: undefined;
+
 		return (
 			<StepWrapper
 					flowName={ this.props.flowName }
 					stepName={ this.props.stepName }
+					backUrl={ backUrl }
 					positionInFlow={ this.props.positionInFlow }
 					headerText={ this.props.surveySiteType === 'blog' ? blogHeaderText : siteHeaderText }
 					subHeaderText={ this.props.surveySiteType === 'blog' ? blogSubHeaderText : siteSubHeaderText }


### PR DESCRIPTION
This PR switches to using `stepSection` to switch between the main and "other" views of the survey step, and enables the back button from `StepWrapper`.


<img width="571" alt="screen shot 2016-10-07 at 18 35 03" src="https://cloud.githubusercontent.com/assets/418473/19206075/e56cfd56-8cbc-11e6-824f-bbbbe74d69bf.png">

## Testing Instructions
* Visit calypso.localhost:3000/start/
* Set the `signupSurveyStep` AB test to the `surveyStepV2` variant
* Click the "other" option in the new survey step
* Try using the "back" arrow to visit the survey screen with all of the options