### PR TITLE
Support: Fix capitalization error

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -103,7 +103,7 @@ const Help = React.createClass( {
 				<CompactCard className="help__support-link" href="https://dailypost.wordpress.com/blogging-university/" target="__blank">
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">
-							{ this.translate( 'Self-Guided email courses for site owners and bloggers' ) }
+							{ this.translate( 'Self-guided email courses for site owners and bloggers' ) }
 						</h2>
 						<p className="help__support-link-content">
 							{ this.translate( 'Pick from our ever-growing list of free email courses to improve your knowledge.' ) }


### PR DESCRIPTION
Fixes a small capitalization discrepancy that I introduced in #8397. 😞 

I'll be more careful next time around!

Current:

<img width="731" alt="screen shot 2016-10-07 at 15 41 04" src="https://cloud.githubusercontent.com/assets/7240478/19206268/e4f6e0f2-8ca4-11e6-8ab4-c07004e1040d.png">

Update:

<img width="736" alt="screen shot 2016-10-07 at 3 40 39 pm" src="https://cloud.githubusercontent.com/assets/7240478/19206270/e98440e2-8ca4-11e6-9cbd-452bf1291c00.png">
