### PR TITLE
Billing History: Update styling for empty card message

### DIFF
--- a/client/me/credit-cards/credit-cards.scss
+++ b/client/me/credit-cards/credit-cards.scss
@@ -1,6 +1,10 @@
 .credit-cards__no-results {
 	display: block;
-	text-align: center;
+	color: $gray;
+
+	@include breakpoint( "<480px" ) {
+		padding: 8px;
+	}
 }
 
 .credit-cards__single-card {


### PR DESCRIPTION
This is a quick fix for #8566. It updates the color and padding on the Billing History screen so the empty message that appears when a user doesn't have any saved cards ("You have no saved cards") is consistent with the rest of the page.

I also added `8px` of additional padding at `<480px`. This lets the messaging look consistent across the page on mobile devices. Both the "No upcoming charges" and "No receipts found" use table cells with a consistent 24px padding across all screen sizes. The empty credit card messaging uses the `Card` component, which [has a padding of 24px at screens >480px and 16px on smaller screens.](https://github.com/Automattic/wp-calypso/blob/master/client/components/card/style.scss#L15)

Here's a screenshot illustration:

**Without padding adjustment**

![padding comparison](https://cloud.githubusercontent.com/assets/7240478/19210000/e04539e4-8cd3-11e6-83f8-c9fefeea2eff.png)

## To test

Load this branch and visit `http://calypso.localhost:3000/me/billing` an account that doesn't have any saved cards or billing history.

## Screenshots

**iPhone**

![iphone](https://cloud.githubusercontent.com/assets/7240478/19210023/4bcd4cf6-8cd4-11e6-9f5d-61044f04838a.png)

**iPad**

![ipad](https://cloud.githubusercontent.com/assets/7240478/19210024/50017982-8cd4-11e6-805d-18e7014fea1e.png)

**Desktop**

![desktop](https://cloud.githubusercontent.com/assets/7240478/19210026/54e4754e-8cd4-11e6-9fb9-1f33154afc6b.png)

Fix for #8566.