### PR TITLE
Plans: Removes domain claim box for non-plan owners

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -12,22 +12,24 @@ import { hasCustomDomain } from 'lib/site/utils';
 
 const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate } ) => {
 	const renderClaimCustomDomain = () =>
-		<PurchaseDetail
-			icon="globe"
-			title={ translate( 'Select Your Custom Domain' ) }
-			description={
-				translate(
-					'Your plan includes a free custom domain. Replace {{em}}%(siteDomain)s{{/em}} ' +
-					'with a custom domain to personalize your site.',
-					{
-						args: { siteDomain: selectedSite.domain },
-						components: { em: <em /> }
-					}
-				)
-			}
-			buttonText={ translate( 'Claim your free domain' ) }
-			href={ `/domains/add/${ selectedSite.slug }` }
-		/>;
+		selectedSite.plan.user_is_owner
+			? <PurchaseDetail
+				icon="globe"
+				title={ translate( 'Select Your Custom Domain' ) }
+				description={
+					translate(
+						'Your plan includes a free custom domain. Replace {{em}}%(siteDomain)s{{/em}} ' +
+						'with a custom domain to personalize your site.',
+						{
+							args: { siteDomain: selectedSite.domain },
+							components: { em: <em /> }
+						}
+					)
+				}
+				buttonText={ translate( 'Claim your free domain' ) }
+				href={ `/domains/add/${ selectedSite.slug }` }
+			/>
+			: null;
 
 	const renderHasCustomDomain = () =>
 		<PurchaseDetail


### PR DESCRIPTION
As described in #8442, we should only display the Claim Domain box on the My Plan page when the user is also the owner of the corresponding plan. Otherwise, we shouldn't show the box. However, non-plan owners can still manage the domains on a site at the admin user role so we _should_ display the Manage Domain box in those cases.

Four cases to consider:

Site has a domain credit available:
- Owner should see claim domain panel
- Other users (including admins) should not see the panel

Site is currently using domain credit:
- Owner should see manage option
- Admins should see manage option

To accomplish this, I added a ternary to `renderClaimCustomDomain` that checks for `selectedSite.plan.user_is_owner`. If it returns `true`, the claim box is displayed. Otherwise, it returns `null`. A more complex option would be to turn this into a site capability and [use `userCan`](https://github.com/Automattic/wp-calypso/blob/fcf789ebb43b7d8fe9a912d8fa82d5bee66573b5/client/lib/site/utils.js#L9). I think this simpler solution works though.

## To test
1. Load this branch and visit http://calypso.localhost:3000/plans/my-plan/ for a site with a plan. You'll want to open two separate tabs—one as the plan owner and another as an admin but not bundle owner.
2. Make sure the domain credit on your plan is being used. Check to make sure you see the manage domain option on both pages.
3. Empty the domain credit on your bundle so you have a fresh credit available. Reload the my-plan page. Confirm that you only see the claim domain box as the plan owner.

## Screenshots

**Owners and non-owners with credit being used**

![screen shot 2016-10-08 at 12 59 17 pm](https://cloud.githubusercontent.com/assets/7240478/19215403/4d4fb2e0-8d5a-11e6-8213-6498e0868278.png)

**Owners with free domain credit**

![screen shot 2016-10-08 at 1 01 37 pm](https://cloud.githubusercontent.com/assets/7240478/19215405/62d7c1de-8d5a-11e6-82d7-55113ceb5fc3.png)

**Admins with free domain credit**

![screen shot 2016-10-08 at 1 01 28 pm](https://cloud.githubusercontent.com/assets/7240478/19215407/67bb9cac-8d5a-11e6-9393-62c8b0b1f809.png)
