### PR TITLE
Signup: increase percentage for Verticals v2 AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -72,10 +72,10 @@ module.exports = {
 		allowExistingUsers: false,
 	},
 	signupSurveyStep: {
-		datestamp: '20161005',
+		datestamp: '20161009',
 		variations: {
-			surveyStepV1: 95,
-			surveyStepV2: 5,
+			surveyStepV1: 80,
+			surveyStepV2: 20,
 		},
 		defaultVariation: 'surveyStepV1'
 	},


### PR DESCRIPTION
After soft launching the new Signup survey step (Verticals v2) in #7700 and fixing a few issues in #8570 and #8608, this PR restarts the `signupSurveyStep` AB with a higher percentage for the new variant.

_[Still needs test details/description]_