### PR TITLE
Support Chat: Update header, fix message alignment.

### DIFF
--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -57,7 +57,7 @@ const connectingTitle = ( { onCloseChat } ) => {
  */
 const connectedTitle = ( { onCloseChat } ) => (
 	<div className="happychat__active-toolbar">
-	<h4>{ translate( 'Support Chat' ) }</h4>
+	<h4>{ translate( 'WP.com' ) }</h4>
 		<div onClick={ onCloseChat }>
 			<GridIcon icon="cross" />
 		</div>

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -279,7 +279,10 @@
 	display: flex;
 	flex-direction: row-reverse;
 	padding: 0 10px;
-	margin: 6px 0;
+	margin-top: 6px;
+	margin-bottom: 6px;
+	margin-right: auto;
+	margin-left: 0;
 
 	a {
 		color: $blue-medium;
@@ -293,6 +296,7 @@
 	&.is-user-message {
 		flex-direction: row;
 		margin-left: auto;
+		margin-right: 0;
 
 		a {
 			color: lighten( $blue-light, 10% );


### PR DESCRIPTION
- Updates header to reflect that you're chatting with "WP.com".
- Update CSS to fix regression in message width and alignment of support bubbles.

How to test:

- `make run`, then click the support chat link in the bottom of the sidebar
- Type a message, and receive one. Verify that bubbles look good in both cases

Screenshot:

<img width="299" alt="screen shot 2016-10-10 at 11 23 32" src="https://cloud.githubusercontent.com/assets/1204802/19231880/d90bdd8a-8edc-11e6-8632-17767375b703.png">
