### PR TITLE
Site Settings: fix Form React warnings

### DIFF
--- a/client/components/forms/language-selector.jsx
+++ b/client/components/forms/language-selector.jsx
@@ -1,22 +1,25 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:forms:language-selector' );
+import React from 'react';
+import { omit } from 'lodash';
+import debugFactory from 'debug';
+const	debug = debugFactory( 'calypso:forms:language-selector' );
+
 /**
  * Internal dependencies
  */
-var SelectOptGroups = require( 'components/forms/select-opt-groups' );
+import SelectOptGroups from 'components/forms/select-opt-groups';
 
 function coerceToOptions( data, valueKey ) {
 	valueKey = 'undefined' === typeof valueKey ? 'value' : valueKey;
 
-	return data.map( function( language ){
+	return data.map( function( language ) {
 		return { value: language[ valueKey ], label: language.name };
 	} );
 }
 
-var LanguageSelector = React.createClass( {
+const LanguageSelector = React.createClass( {
 
 	displayName: 'LanguageSelector',
 
@@ -25,32 +28,32 @@ var LanguageSelector = React.createClass( {
 	},
 
 	languageOptGroups: function() {
-		var allLanguages, popularLanguages;
+		let popularLanguages;
+		const allLanguages = coerceToOptions( this.props.languages, this.props.valueKey );
 
-		allLanguages = coerceToOptions( this.props.languages, this.props.valueKey );
-
-		popularLanguages = this.props.languages.filter( function( language ) { return language.popular; } );
-		popularLanguages.sort( function( a, b ) { return a.popular - b.popular; } );
+		popularLanguages = this.props.languages.filter( language => language.popular );
+		popularLanguages.sort( ( a, b ) => a.popular - b.popular );
 		popularLanguages = coerceToOptions( popularLanguages, this.props.valueKey );
 
 		return [
-		{
-			label: this.translate( 'Popular languages', { textOnly: true } ),
-			options: popularLanguages
-		},
-		{
-			label: this.translate( 'All languages', { textOnly: true } ),
-			options: allLanguages
-		}
+			{
+				label: this.translate( 'Popular languages', { textOnly: true } ),
+				options: popularLanguages
+			},
+			{
+				label: this.translate( 'All languages', { textOnly: true } ),
+				options: allLanguages
+			}
 		];
-
 	},
 
 	render: function() {
+		const props = omit( this.props, 'languages' );
+
 		return (
-			<SelectOptGroups optGroups={ this.languageOptGroups() } {...this.props} />
+			<SelectOptGroups optGroups={ this.languageOptGroups() } { ...props } />
 		);
 	}
-});
+} );
 
 module.exports = LanguageSelector;

--- a/client/components/forms/select-opt-groups.jsx
+++ b/client/components/forms/select-opt-groups.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:forms:select-opt-groups' );
+import React from 'react';
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:forms:select-opt-groups' );
 
-var SelectOptGroups = React.createClass( {
+const SelectOptGroups = React.createClass( {
 
 	displayName: 'SelectOptGroups',
 
@@ -13,20 +14,22 @@ var SelectOptGroups = React.createClass( {
 	},
 
 	render: function() {
+		const { optGroups, ...props } = this.props;
+
 		return (
-			<select {...this.props} >
-			{ this.props.optGroups.map( function( optGroup ) {
+			<select { ...props } >
+			{ optGroups.map( function( optGroup ) {
 				return (
 					<optgroup label={ optGroup.label } key={ 'optgroup-' + optGroup.label } >
 					{ optGroup.options.map( function( option ) {
 						return <option value={ option.value } key={ 'option-' + optGroup.label + option.label } >{ option.label }</option>;
-					})}
+					} ) }
 					</optgroup>
 				);
 			} ) }
 			</select>
 		);
 	}
-});
+} );
 
 module.exports = SelectOptGroups;

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -84,7 +84,7 @@ class Timezone extends Component {
 	render() {
 		const { selectedZone } = this.props;
 		return (
-			<select onChange={ this.onSelect } value={ selectedZone || null }>
+			<select onChange={ this.onSelect } value={ selectedZone || '' }>
 				{ this.renderOptionsByContinent() }
 				<optgroup label="UTC">
 					<option value="UTC">UTC</option>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -404,7 +404,7 @@ const FormGeneral = React.createClass( {
 								<FormLabel>
 									<FormCheckbox
 										name="jetpack_relatedposts_show_headline"
-										checkedLink={ this.linkState( 'jetpack_relatedposts_show_headline' ) }/>
+										checkedLink={ this.linkState( 'jetpack_relatedposts_show_headline' ) } />
 									<span>
 										{ this.translate(
 											'Show a "Related" header to more clearly separate the related section from posts'
@@ -416,7 +416,7 @@ const FormGeneral = React.createClass( {
 								<FormLabel>
 									<FormCheckbox
 										name="jetpack_relatedposts_show_thumbnails"
-										checkedLink={ this.linkState( 'jetpack_relatedposts_show_thumbnails' ) }/>
+										checkedLink={ this.linkState( 'jetpack_relatedposts_show_thumbnails' ) } />
 									<span>{ this.translate( 'Use a large and visually striking layout' ) }</span>
 								</FormLabel>
 							</li>
@@ -473,13 +473,12 @@ const FormGeneral = React.createClass( {
 
 	jetpackDisconnectOption() {
 		const { site } = this.props;
-		let disconnectText;
 
 		if ( ! site.jetpack ) {
 			return null;
 		}
 
-		disconnectText = this.translate( 'Disconnect Site', {
+		const disconnectText = this.translate( 'Disconnect Site', {
 			context: 'Jetpack: Action user takes to disconnect Jetpack site from .com link in general site settings'
 		} );
 
@@ -511,7 +510,7 @@ const FormGeneral = React.createClass( {
 				<ul>
 					<li>
 						<FormLabel>
-							<FormCheckbox name="holidaysnow" checkedLink={ this.linkState( 'holidaysnow' ) }/>
+							<FormCheckbox name="holidaysnow" checkedLink={ this.linkState( 'holidaysnow' ) } />
 							<span>{ this.translate( 'Show falling snow on my blog until January 4th.' ) }</span>
 						</FormLabel>
 					</li>


### PR DESCRIPTION
While reviewing #8582, I noticed some warnings on the general settings Page. This is a small PR that fixes some of them. Most of these warnings were related to extra props passed to selects.

However, there are still some remaining warnings related to the `ReactLink` mixin.

**Testing instructions**

 * navigate to https://wordpress.com/settings/general/
 * make sure the component works correctly (switch timezones, languages)
 * On the console, we can still notice these warnings, but not other warnings related to Select Props or anything else.

<img width="1280" alt="capture d ecran 2016-10-10 a 1 08 25 pm" src="https://cloud.githubusercontent.com/assets/272444/19235722/64bcb68e-8eeb-11e6-9c53-a390c46d14da.png">

cc @aduth 
