### PR TITLE
Jetpack: Make the cancellation text for Jetpack plans more specific to Jetpack

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
 import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import { getName, getSubscriptionEndDate, isOneTimePurchase, isRefundable, isSubscription } from 'lib/purchases';
-import { isDomainRegistration, isTheme, isGoogleApps } from 'lib/products-values';
+import { isDomainRegistration, isTheme, isGoogleApps, isJetpackPlan } from 'lib/products-values';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
@@ -269,6 +269,17 @@ const CancelPurchaseButton = React.createClass( {
 			cancelationEffectText = this.translate(
 				'You will be refunded %(cost)s, but your Google Apps account will continue working without interruption. ' +
 				'You will be able to manage your Google Apps billing directly through Google.', {
+					args: {
+						cost: refundText
+					}
+				}
+			);
+		}
+
+		if ( isJetpackPlan( this.props.purchase ) ) {
+			cancelationEffectText = this.translate(
+				'All plan features - spam filtering, backups, and security screening - will be removed from your site ' +
+				'and you will be refunded %(cost)s.', {
 					args: {
 						cost: refundText
 					}


### PR DESCRIPTION
This pull request fixes #8253 by making the cancellation text for Jetpack plans more specific:
  
<img width="526" alt="screen shot 2016-10-10 at 15 11 14" src="https://cloud.githubusercontent.com/assets/275961/19239066/5af76e62-8efc-11e6-82e6-58dfd9eefea5.png">
  
#### Testing instructions
  
1. Run `git checkout update/jetpack-cancel-text` and start your server, or open a [live branch](https://delphin.live/?branch=update/jetpack-cancel-text)
2. Open the [`Purchases` page](http://calypso.localhost:3000/) for a user who has a Jetpack plan
3. Open the Jetpack Plan purchase
4. Click on "Cancel subscription and refund"
5. Click on the "Cancel subscription and refund" button
6. Select reasons for cancelling and click on "Next"
7. Check that the text says "All plan features - spam filtering, backups, and security screening - will be removed from your site"
  
cc @kraftbj who raised this initially.
  
#### Reviews
  
- [x] Code
- [x] Product
- [x] Tests
   
@Automattic/sdev-feed