### PR TITLE
Advanced SEO: Hide SEO button on Theme Preview

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -232,6 +232,8 @@ WebPreview.propTypes = {
 	showExternal: PropTypes.bool,
 	// Show close button
 	showClose: PropTypes.bool,
+	// Show SEO button
+	showSEO: PropTypes.bool,
 	// Show device viewport switcher
 	showDeviceSwitcher: PropTypes.bool,
 	// The URL that should be displayed in the iframe
@@ -260,6 +262,7 @@ WebPreview.propTypes = {
 WebPreview.defaultProps = {
 	showExternal: true,
 	showClose: true,
+	showSEO: true,
 	showDeviceSwitcher: true,
 	previewUrl: null,
 	previewMarkup: null,

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -39,7 +39,7 @@ export const PreviewToolbar = props => {
 		showClose,
 		showDeviceSwitcher,
 		showExternal,
-		showSeo,
+		showSEO,
 		translate
 	} = props;
 
@@ -81,7 +81,7 @@ export const PreviewToolbar = props => {
 					) ) }
 				</div>
 			}
-			{ showSeo &&
+			{ showSEO &&
 			<button
 				aria-hidden={ true }
 				key={ 'back-to-preview' }
@@ -95,7 +95,7 @@ export const PreviewToolbar = props => {
 				<Gridicon icon="phone" />
 			</button>
 			}
-			{ showSeo &&
+			{ showSEO &&
 				<button
 					aria-label={ translate( 'Show SEO and search previews' ) }
 					className={ classNames(
@@ -126,6 +126,8 @@ PreviewToolbar.propTypes = {
 	showExternal: PropTypes.bool,
 	// Show close button
 	showClose: PropTypes.bool,
+	// Show SEO button
+	showSEO: PropTypes.bool,
 	// The device to display, used for setting preview dimensions
 	device: PropTypes.string,
 	// Elements to render on the right side of the toolbar
@@ -136,12 +138,18 @@ PreviewToolbar.propTypes = {
 	onClose: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = state => {
-	const site = getSelectedSite( state );
-	const showSeo = ( site && site.plan && hasBusinessPlan( site.plan ) && isEnabled( 'manage/advanced-seo' ) ) ||
-		( isEnabled( 'manage/advanced-seo' ) && isEnabled( 'manage/advanced-seo/preview-nudge' ) );
+PreviewToolbar.defaultProps = {
+	showSEO: true
+};
 
-	return { showSeo };
+const mapStateToProps = ( state, ownProps ) => {
+	const site = getSelectedSite( state );
+	const showSEO = ownProps.showSEO && (
+		( site && site.plan && hasBusinessPlan( site.plan ) && isEnabled( 'manage/advanced-seo' ) ) ||
+		( isEnabled( 'manage/advanced-seo' ) && isEnabled( 'manage/advanced-seo/preview-nudge' ) )
+	);
+
+	return { showSEO };
 };
 
 export default connect( mapStateToProps )( localize( PreviewToolbar ) );

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -65,8 +65,10 @@ export default React.createClass( {
 		const buttonHref = this.props.getPrimaryButtonHref ? this.props.getPrimaryButtonHref( this.props.theme ) : null;
 
 		return (
-			<WebPreview showPreview={ this.props.showPreview }
+			<WebPreview
+				showPreview={ this.props.showPreview }
 				showExternal={ this.props.showExternal }
+				showSEO={ false }
 				onClose={ this.props.onClose }
 				previewUrl={ previewUrl }
 				externalUrl={ this.props.theme.demo_uri } >


### PR DESCRIPTION
Adds a `showSEO` prop to the Web Preview component that defaults to `true`. By using this new prop we can hide the __SEO__ button on the Theme Preview.

This follows the pattern of having a _show_ prop for every section of the `WebPreview` toolbar.

cc: @drw158 @dmsnell 