### PR TITLE
Guided Tours: Add Site Title tour

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -5,9 +5,11 @@ import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/main-tour';
 import { DesignShowcaseWelcomeTour } from 'layout/guided-tours/design-showcase-welcome-tour';
 import { ThemeSheetWelcomeTour } from 'layout/guided-tours/theme-sheet-welcome-tour';
+import { SiteTitleTour } from 'layout/guided-tours/site-title-tour';
 
 export default combineTours( {
 	main: MainTour,
 	designShowcaseWelcome: DesignShowcaseWelcomeTour,
 	themeSheetWelcomeTour: ThemeSheetWelcomeTour,
+	siteTitle: SiteTitleTour,
 } );

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -32,11 +32,11 @@ const helpers = {
 	yBelow: ( bottom ) => {
 		return bottom + DIALOG_PADDING;
 	},
-	xAboveBelow: ( left, right ) => {
+	xAboveBelow: ( left, right, width ) => {
 		if ( ( left + DIALOG_WIDTH + DIALOG_PADDING ) < document.documentElement.clientWidth ) {
 			return left + DIALOG_PADDING;
 		} else if ( right - DIALOG_WIDTH - DIALOG_PADDING > 0 ) {
-			return right - DIALOG_WIDTH - DIALOG_PADDING;
+			return right - ( DIALOG_WIDTH - width );
 		}
 		return DIALOG_PADDING;
 	},
@@ -44,13 +44,13 @@ const helpers = {
 
 const dialogPositioners = {
 	below: ( rect ) => {
-		const x = helpers.xAboveBelow( rect.left, rect.right );
+		const x = helpers.xAboveBelow( rect.left, rect.right, rect.width );
 		const y = helpers.yBelow( rect.bottom );
 
 		return { x, y };
 	},
 	above: ( rect ) => {
-		const x = helpers.xAboveBelow( rect.left, rect.right );
+		const x = helpers.xAboveBelow( rect.left, rect.right, rect.width );
 		const y = helpers.yAbove( rect.top );
 
 		return { x, y };

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -22,12 +22,11 @@ export const SiteTitleTour = makeTour(
 		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">
 			<p className="guided-tours__step-text">
 				{
-					translate( "We noticed you haven't changed the title of your site yet. It's quick and easy to do " +
-											"and we'd love to show you how to do that." )
+					translate( "We noticed you haven't changed the title of your site yet. Do you want to change it?" )
 				}
 			</p>
 			<div className="guided-tours__choice-button-row">
-				<Next step="click-settings">{ translate( "Let's go!" ) }</Next>
+				<Next step="click-settings">{ translate( "Let's change it!" ) }</Next>
 				<Quit>{ translate( 'No thanks.' ) }</Quit>
 			</div>
 		</Step>
@@ -42,7 +41,7 @@ export const SiteTitleTour = makeTour(
 			<div className="guided-tours__actionstep-instructions">
 				<Continue target="settings" step="site-title-input" click>
 					{
-						translate( 'Click the {{strong}}{{GridIcon/}} Settings{{/strong}} to continue.', {
+						translate( 'Click {{strong}}{{GridIcon/}} Settings{{/strong}} to continue.', {
 							components: {
 								GridIcon: <Gridicon icon="cog" size={ 24 } />,
 								strong: <strong />,
@@ -89,7 +88,7 @@ export const SiteTitleTour = makeTour(
 		>
 			<p className="guided-tours__step-text">
 				{
-					translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.", {
+					translate( "{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.", {
 						components: {
 							strong: <strong />,
 						}

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import { overEvery as and } from 'lodash';
+
+import {
+	makeTour,
+	Tour,
+	Step,
+	Next,
+	Quit,
+	Continue,
+	Link,
+} from 'layout/guided-tours/config-elements';
+import {
+	isNewUser,
+	isEnabled,
+	selectedSiteIsPreviewable,
+	selectedSiteIsCustomizable,
+	previewIsNotShowing,
+	previewIsShowing,
+	inSection,
+} from 'state/ui/guided-tours/contexts';
+import { getScrollableSidebar } from 'layout/guided-tours/positioning';
+import Gridicon from 'components/gridicon';
+import scrollTo from 'lib/scroll-to';
+
+const scrollSidebarToTop = () =>
+	scrollTo( { y: 0, container: getScrollableSidebar() } );
+
+export const SiteTitleTour = makeTour(
+	<Tour name="siteTitle" version="20161010" path="/" when={ and( /* TODO (markehrabe): user has unchanged title */isEnabled( 'guided-tours/site-title' ) ) }>
+		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">
+			<p className="guided-tours__step-text">
+				{
+					translate( "We noticed you haven't changed the title of your site yet. It's quick and easy to do " +
+											"and we'd love to show you how to do that." )
+				}
+			</p>
+			<div className="guided-tours__choice-button-row">
+				<Next step="click-settings">{ translate( "Let's go!" ) }</Next>
+				<Quit>{ translate( 'No thanks.' ) }</Quit>
+			</div>
+		</Step>
+
+		<Step name="click-settings"
+			target="settings"
+			arrow="bottom-left"
+			placement="above"
+			scrollContainer=".sidebar__region"
+			next="site-title-input"
+			shouldScrollTo
+		>
+			<div className="guided-tours__actionstep-instructions">
+				<Continue target="settings" step="site-title-input" click>
+					{
+						translate( 'Click the {{strong}}{{GridIcon/}} Settings{{/strong}} to continue.', {
+							components: {
+								GridIcon: <Gridicon icon="cog" size={ 24 } />,
+								strong: <strong />,
+							}
+						} )
+					}
+				</Continue>
+			</div>
+		</Step>
+
+		<Step name="site-title-input"
+			target="site-title-input"
+			arrow="top-left"
+			placement="below"
+			when={ inSection( 'settings' ) }
+			next="site-title"
+		>
+			<p className="guided-tours__step-text">
+				{
+					translate( 'Go ahead and change the title to whatever you want!' )
+				}
+			</p>
+			{/* TODO (marekhrabe): change to either onChange of the input or just click */}
+			<div className="guided-tours__choice-button-row">
+				<Next step="finish" when={inSection('settings')} hidden />
+				<Quit />
+			</div>
+		</Step>
+
+		<Step name="finish"
+			placement="center"
+			className="guided-tours__step-finish"
+		>
+			<p className="guided-tours__step-text">
+				{
+					translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.", {
+						components: {
+							strong: <strong />,
+						}
+					} )
+				}
+			</p>
+			<div className="guided-tours__single-button-row">
+				<Quit onClick={ scrollSidebarToTop } primary>
+					{ translate( "We're all done!" ) }
+				</Quit>
+			</div>
+			<Link href="https://learn.wordpress.com">
+				{ translate( 'Learn more about WordPress.com' ) }
+			</Link>
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -41,10 +41,9 @@ export const SiteTitleTour = makeTour(
 
 		<Step name="click-settings"
 			target="settings"
-			arrow="bottom-left"
-			placement="above"
+			arrow="left-middle"
+			placement="beside"
 			scrollContainer=".sidebar__region"
-			next="site-title-input"
 			shouldScrollTo
 		>
 			<div className="guided-tours__actionstep-instructions">
@@ -65,19 +64,30 @@ export const SiteTitleTour = makeTour(
 			target="site-title-input"
 			arrow="top-left"
 			placement="below"
-			next="site-title"
 		>
 			<p className="guided-tours__step-text">
 				{
 					translate( 'Go ahead and change the title to whatever you want!' )
 				}
 			</p>
-			{/* TODO (marekhrabe): change to either onChange of the input or just click
 			<div className="guided-tours__choice-button-row">
-				<Next step="finish" when={ inSection( 'settings' ) } hidden />
+				<Next step="click-save">{ translate( 'Looks Good' ) }</Next>
 				<Quit />
 			</div>
-			*/}
+		</Step>
+
+		<Step name="click-save"
+			target="settings-site-profile-save"
+			arrow="top-right"
+			placement="below"
+			next="site-title"
+		>
+			<p className="guided-tours__step-text">
+				{
+					translate( "Don't forget to save your new settings." )
+				}
+			</p>
+			<Continue target="settings-site-profile-save" step="finish" click hidden />
 		</Step>
 
 		<Step name="finish"

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -45,7 +45,7 @@ export const SiteTitleTour = makeTour(
 
 		<Step name="click-settings"
 			target="settings"
-			arrow="left-middle"
+			arrow="left-top"
 			placement="beside"
 			scrollContainer=".sidebar__region"
 			shouldScrollTo

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -14,19 +14,23 @@ import {
 import {
 	selectedSiteHasDefaultSiteTitle,
 	userIsOlderThan,
+	isEnabled,
+	inSection,
 } from 'state/ui/guided-tours/contexts';
 import Gridicon from 'components/gridicon';
 
 const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 
-// TODO (markehrabe): user has unchanged title
-// TODO (markehrabe): what path to use?
 export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
 		version="20161010"
-		path="/stats/day/marekhrabe.wordpress.com"
-		when={ and( selectedSiteHasDefaultSiteTitle, userIsOlderThan( TWO_DAYS_IN_MILLISECONDS ) ) }>
+		path=""
+		when={ and( inSection( 'stats' ),
+						isEnabled( 'guided-tours/site-title' ),
+						selectedSiteHasDefaultSiteTitle,
+						userIsOlderThan( TWO_DAYS_IN_MILLISECONDS ) )
+		}>
 		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">
 			<p className="guided-tours__step-text">
 				{

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
-import { overEvery as and } from 'lodash';
 
 import {
 	makeTour,
@@ -12,20 +11,14 @@ import {
 	Link,
 } from 'layout/guided-tours/config-elements';
 import {
-	isEnabled,
-	// inSection,
+	selectedSiteHasDefaultSiteTitle,
 } from 'state/ui/guided-tours/contexts';
-import { getScrollableSidebar } from 'layout/guided-tours/positioning';
 import Gridicon from 'components/gridicon';
-import scrollTo from 'lib/scroll-to';
-
-const scrollSidebarToTop = () =>
-	scrollTo( { y: 0, container: getScrollableSidebar() } );
 
 // TODO (markehrabe): user has unchanged title
 // TODO (markehrabe): what path to use?
 export const SiteTitleTour = makeTour(
-	<Tour name="siteTitle" version="20161010" path="/" when={ and( isEnabled( 'guided-tours/site-title' ) ) }>
+	<Tour name="siteTitle" version="20161010" path="/stats/day/marekhrabe.wordpress.com" when={ selectedSiteHasDefaultSiteTitle }>
 		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">
 			<p className="guided-tours__step-text">
 				{
@@ -104,7 +97,7 @@ export const SiteTitleTour = makeTour(
 				}
 			</p>
 			<div className="guided-tours__single-button-row">
-				<Quit onClick={ scrollSidebarToTop } primary>
+				<Quit primary>
 					{ translate( "We're all done!" ) }
 				</Quit>
 			</div>

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -13,7 +13,7 @@ import {
 } from 'layout/guided-tours/config-elements';
 import {
 	isEnabled,
-	inSection,
+	// inSection,
 } from 'state/ui/guided-tours/contexts';
 import { getScrollableSidebar } from 'layout/guided-tours/positioning';
 import Gridicon from 'components/gridicon';
@@ -65,7 +65,6 @@ export const SiteTitleTour = makeTour(
 			target="site-title-input"
 			arrow="top-left"
 			placement="below"
-			when={ inSection( 'settings' ) }
 			next="site-title"
 		>
 			<p className="guided-tours__step-text">
@@ -73,11 +72,12 @@ export const SiteTitleTour = makeTour(
 					translate( 'Go ahead and change the title to whatever you want!' )
 				}
 			</p>
-			{/* TODO (marekhrabe): change to either onChange of the input or just click */}
+			{/* TODO (marekhrabe): change to either onChange of the input or just click
 			<div className="guided-tours__choice-button-row">
 				<Next step="finish" when={ inSection( 'settings' ) } hidden />
 				<Quit />
 			</div>
+			*/}
 		</Step>
 
 		<Step name="finish"

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -71,12 +71,29 @@ export const SiteTitleTour = makeTour(
 		>
 			<p className="guided-tours__step-text">
 				{
-					translate( 'You can change the site title here. The site title and tagline ' +
-						'tells people about your site and appears in places like the top of your web browser and in search results.' )
+					translate( 'You can change the site title here. The site title appears in places like the top ' +
+						'of your web browser and in search results.' )
 				}
 			</p>
 			<div className="guided-tours__choice-button-row">
-				<Next step="click-save">{ translate( 'Looks Good' ) }</Next>
+				<Next step="site-tagline-input">{ translate( 'Looks Good' ) }</Next>
+				<Quit>Cancel</Quit>
+			</div>
+		</Step>
+
+		<Step name="site-tagline-input"
+			target="site-tagline-input"
+			arrow="top-left"
+			placement="below"
+		>
+			<p className="guided-tours__step-text">
+				{
+					translate( 'This is the tagline of your site. It should explain what your site is about in few words. ' +
+						'It usually appears right bellow your site title.' )
+				}
+			</p>
+			<div className="guided-tours__choice-button-row">
+				<Next step="click-save">{ translate( 'Continue' ) }</Next>
 				<Quit>Cancel</Quit>
 			</div>
 		</Step>
@@ -87,12 +104,13 @@ export const SiteTitleTour = makeTour(
 			placement="below"
 			next="site-title"
 		>
-			<p className="guided-tours__step-text">
-				{
-					translate( "Don't forget to save your new settings!" )
-				}
-			</p>
-			<Continue target="settings-site-profile-save" step="finish" click />
+			<div className="guided-tours__actionstep-instructions">
+				<Continue target="settings-site-profile-save" step="finish" click>
+					{
+						translate( "Don't forget to save your new settings!" )
+					}
+				</Continue>
+			</div>
 		</Step>
 
 		<Step name="finish"

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
+import { overEvery as and } from 'lodash';
 
 import {
 	makeTour,
@@ -12,13 +13,20 @@ import {
 } from 'layout/guided-tours/config-elements';
 import {
 	selectedSiteHasDefaultSiteTitle,
+	userIsOlderThan,
 } from 'state/ui/guided-tours/contexts';
 import Gridicon from 'components/gridicon';
+
+const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 
 // TODO (markehrabe): user has unchanged title
 // TODO (markehrabe): what path to use?
 export const SiteTitleTour = makeTour(
-	<Tour name="siteTitle" version="20161010" path="/stats/day/marekhrabe.wordpress.com" when={ selectedSiteHasDefaultSiteTitle }>
+	<Tour
+		name="siteTitle"
+		version="20161010"
+		path="/stats/day/marekhrabe.wordpress.com"
+		when={ and( selectedSiteHasDefaultSiteTitle, userIsOlderThan( TWO_DAYS_IN_MILLISECONDS ) ) }>
 		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">
 			<p className="guided-tours__step-text">
 				{

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -15,7 +15,6 @@ import {
 	selectedSiteHasDefaultSiteTitle,
 	userIsOlderThan,
 	isEnabled,
-	inSection,
 } from 'state/ui/guided-tours/contexts';
 import Gridicon from 'components/gridicon';
 
@@ -26,20 +25,21 @@ export const SiteTitleTour = makeTour(
 		name="siteTitle"
 		version="20161010"
 		path=""
-		when={ and( inSection( 'stats' ),
+		when={ and(
 						isEnabled( 'guided-tours/site-title' ),
 						selectedSiteHasDefaultSiteTitle,
-						userIsOlderThan( TWO_DAYS_IN_MILLISECONDS ) )
+						userIsOlderThan( TWO_DAYS_IN_MILLISECONDS )
+					)
 		}>
 		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">
 			<p className="guided-tours__step-text">
 				{
-					translate( "We noticed you haven't changed the title of your site yet. Do you want to change it?" )
+					translate( "Hey there! We noticed you haven't changed the title of your site yet. Want to change it? " )
 				}
 			</p>
 			<div className="guided-tours__choice-button-row">
-				<Next step="click-settings">{ translate( "Let's change it!" ) }</Next>
-				<Quit>{ translate( 'No thanks.' ) }</Quit>
+				<Next step="click-settings">{ translate( 'Yes, please!' ) }</Next>
+				<Quit>{ translate( 'No thanks' ) }</Quit>
 			</div>
 		</Step>
 
@@ -71,12 +71,13 @@ export const SiteTitleTour = makeTour(
 		>
 			<p className="guided-tours__step-text">
 				{
-					translate( 'Go ahead and change the title to whatever you want!' )
+					translate( 'You can change the site title here. The site title and tagline ' +
+						'tells people about your site and appears in places like the top of your web browser and in search results.' )
 				}
 			</p>
 			<div className="guided-tours__choice-button-row">
 				<Next step="click-save">{ translate( 'Looks Good' ) }</Next>
-				<Quit />
+				<Quit>Cancel</Quit>
 			</div>
 		</Step>
 
@@ -88,7 +89,7 @@ export const SiteTitleTour = makeTour(
 		>
 			<p className="guided-tours__step-text">
 				{
-					translate( "Don't forget to save your new settings." )
+					translate( "Don't forget to save your new settings!" )
 				}
 			</p>
 			<Continue target="settings-site-profile-save" step="finish" click />

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -87,7 +87,7 @@ export const SiteTitleTour = makeTour(
 					translate( "Don't forget to save your new settings." )
 				}
 			</p>
-			<Continue target="settings-site-profile-save" step="finish" click hidden />
+			<Continue target="settings-site-profile-save" step="finish" click />
 		</Step>
 
 		<Step name="finish"

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -12,12 +12,7 @@ import {
 	Link,
 } from 'layout/guided-tours/config-elements';
 import {
-	isNewUser,
 	isEnabled,
-	selectedSiteIsPreviewable,
-	selectedSiteIsCustomizable,
-	previewIsNotShowing,
-	previewIsShowing,
 	inSection,
 } from 'state/ui/guided-tours/contexts';
 import { getScrollableSidebar } from 'layout/guided-tours/positioning';
@@ -27,8 +22,10 @@ import scrollTo from 'lib/scroll-to';
 const scrollSidebarToTop = () =>
 	scrollTo( { y: 0, container: getScrollableSidebar() } );
 
+// TODO (markehrabe): user has unchanged title
+// TODO (markehrabe): what path to use?
 export const SiteTitleTour = makeTour(
-	<Tour name="siteTitle" version="20161010" path="/" when={ and( /* TODO (markehrabe): user has unchanged title */isEnabled( 'guided-tours/site-title' ) ) }>
+	<Tour name="siteTitle" version="20161010" path="/" when={ and( isEnabled( 'guided-tours/site-title' ) ) }>
 		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">
 			<p className="guided-tours__step-text">
 				{
@@ -78,7 +75,7 @@ export const SiteTitleTour = makeTour(
 			</p>
 			{/* TODO (marekhrabe): change to either onChange of the input or just click */}
 			<div className="guided-tours__choice-button-row">
-				<Next step="finish" when={inSection('settings')} hidden />
+				<Next step="finish" when={ inSection( 'settings' ) } hidden />
 				<Quit />
 			</div>
 		</Step>

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -1,7 +1,13 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
 import {
 	makeTour,
 	Tour,

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -26,6 +26,7 @@ import {
 	isAbTestInVariant,
 } from 'state/ui/guided-tours/contexts';
 import Gridicon from 'components/gridicon';
+import { isDesktop } from 'lib/viewport';
 
 const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 
@@ -36,6 +37,7 @@ export const SiteTitleTour = makeTour(
 		path="/stats"
 		when={ and(
 						isEnabled( 'guided-tours/site-title' ),
+						isDesktop,
 						hasSelectedSiteDefaultSiteTitle,
 						canUserEditSettingsOfSelectedSite,
 						isUserOlderThan( TWO_DAYS_IN_MILLISECONDS ),

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -85,7 +85,7 @@ export const SiteTitleTour = makeTour(
 				}
 			</p>
 			<ButtonRow>
-				<Next step="site-tagline-input">{ translate( 'Looks Good' ) }</Next>
+				<Next step="site-tagline-input">{ translate( 'Looks Good!' ) }</Next>
 				<Quit>{ translate( 'Cancel' ) }</Quit>
 			</ButtonRow>
 		</Step>
@@ -102,7 +102,7 @@ export const SiteTitleTour = makeTour(
 				}
 			</p>
 			<ButtonRow>
-				<Next step="click-save">{ translate( 'Continue' ) }</Next>
+				<Next step="click-save">{ translate( 'Great!' ) }</Next>
 				<Quit>{ translate( 'Cancel' ) }</Quit>
 			</ButtonRow>
 		</Step>
@@ -114,7 +114,7 @@ export const SiteTitleTour = makeTour(
 		>
 			<Continue target="settings-site-profile-save" step="finish" click>
 				{
-					translate( "Don't forget to save your new settings!" )
+					translate( "Don't forget to save your changes." )
 				}
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -10,6 +10,7 @@ import {
 	Quit,
 	Continue,
 	Link,
+	ButtonRow,
 } from 'layout/guided-tours/config-elements';
 import {
 	selectedSiteHasDefaultSiteTitle,
@@ -35,16 +36,16 @@ export const SiteTitleTour = makeTour(
 						isAbTestInVariant( 'siteTitleTour', 'enabled' )
 					)
 		}>
-		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">
-			<p className="guided-tours__step-text">
+		<Step name="init" placement="right" next="click-settings">
+			<p>
 				{
 					translate( "Hey there! We noticed you haven't changed the title of your site yet. Want to change it? " )
 				}
 			</p>
-			<div className="guided-tours__choice-button-row">
+			<ButtonRow>
 				<Next step="click-settings">{ translate( 'Yes, please!' ) }</Next>
 				<Quit>{ translate( 'No thanks' ) }</Quit>
-			</div>
+			</ButtonRow>
 		</Step>
 
 		<Step name="click-settings"
@@ -54,18 +55,16 @@ export const SiteTitleTour = makeTour(
 			scrollContainer=".sidebar__region"
 			shouldScrollTo
 		>
-			<div className="guided-tours__actionstep-instructions">
-				<Continue target="settings" step="site-title-input" click>
-					{
-						translate( 'Click {{strong}}{{GridIcon/}} Settings{{/strong}} to continue.', {
-							components: {
-								GridIcon: <Gridicon icon="cog" size={ 24 } />,
-								strong: <strong />,
-							}
-						} )
-					}
-				</Continue>
-			</div>
+			<Continue target="settings" step="site-title-input" click>
+				{
+					translate( 'Click {{strong}}{{GridIcon/}} Settings{{/strong}} to continue.', {
+						components: {
+							GridIcon: <Gridicon icon="cog" size={ 24 } />,
+							strong: <strong />,
+						}
+					} )
+				}
+			</Continue>
 		</Step>
 
 		<Step name="site-title-input"
@@ -73,16 +72,16 @@ export const SiteTitleTour = makeTour(
 			arrow="top-left"
 			placement="below"
 		>
-			<p className="guided-tours__step-text">
+			<p>
 				{
 					translate( 'You can change the site title here. The site title appears in places like the top ' +
 						'of your web browser and in search results.' )
 				}
 			</p>
-			<div className="guided-tours__choice-button-row">
+			<ButtonRow>
 				<Next step="site-tagline-input">{ translate( 'Looks Good' ) }</Next>
-				<Quit>Cancel</Quit>
-			</div>
+				<Quit>{ translate( 'Cancel' ) }</Quit>
+			</ButtonRow>
 		</Step>
 
 		<Step name="site-tagline-input"
@@ -90,38 +89,32 @@ export const SiteTitleTour = makeTour(
 			arrow="top-left"
 			placement="below"
 		>
-			<p className="guided-tours__step-text">
+			<p>
 				{
 					translate( 'This is the tagline of your site. It should explain what your site is about in few words. ' +
 						'It usually appears right bellow your site title.' )
 				}
 			</p>
-			<div className="guided-tours__choice-button-row">
+			<ButtonRow>
 				<Next step="click-save">{ translate( 'Continue' ) }</Next>
-				<Quit>Cancel</Quit>
-			</div>
+				<Quit>{ translate( 'Cancel' ) }</Quit>
+			</ButtonRow>
 		</Step>
 
 		<Step name="click-save"
 			target="settings-site-profile-save"
 			arrow="top-right"
 			placement="below"
-			next="site-title"
 		>
-			<div className="guided-tours__actionstep-instructions">
-				<Continue target="settings-site-profile-save" step="finish" click>
-					{
-						translate( "Don't forget to save your new settings!" )
-					}
-				</Continue>
-			</div>
+			<Continue target="settings-site-profile-save" step="finish" click>
+				{
+					translate( "Don't forget to save your new settings!" )
+				}
+			</Continue>
 		</Step>
 
-		<Step name="finish"
-			placement="center"
-			className="guided-tours__step-finish"
-		>
-			<p className="guided-tours__step-text">
+		<Step name="finish"	placement="center">
+			<p>
 				{
 					translate( "{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.", {
 						components: {
@@ -130,11 +123,9 @@ export const SiteTitleTour = makeTour(
 					} )
 				}
 			</p>
-			<div className="guided-tours__single-button-row">
-				<Quit primary>
-					{ translate( "We're all done!" ) }
-				</Quit>
-			</div>
+			<ButtonRow>
+				<Quit primary>{ translate( "We're all done!" ) }</Quit>
+			</ButtonRow>
 			<Link href="https://learn.wordpress.com">
 				{ translate( 'Learn more about WordPress.com' ) }
 			</Link>

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -33,7 +33,7 @@ export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
 		version="20161010"
-		path=""
+		path="/stats"
 		when={ and(
 						isEnabled( 'guided-tours/site-title' ),
 						hasSelectedSiteDefaultSiteTitle,

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -15,6 +15,7 @@ import {
 	selectedSiteHasDefaultSiteTitle,
 	userIsOlderThan,
 	isEnabled,
+	userCanEditSettingsOfSelectedSite,
 } from 'state/ui/guided-tours/contexts';
 import Gridicon from 'components/gridicon';
 
@@ -28,7 +29,8 @@ export const SiteTitleTour = makeTour(
 		when={ and(
 						isEnabled( 'guided-tours/site-title' ),
 						selectedSiteHasDefaultSiteTitle,
-						userIsOlderThan( TWO_DAYS_IN_MILLISECONDS )
+						userIsOlderThan( TWO_DAYS_IN_MILLISECONDS ),
+						userCanEditSettingsOfSelectedSite,
 					)
 		}>
 		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -19,10 +19,10 @@ import {
 	ButtonRow,
 } from 'layout/guided-tours/config-elements';
 import {
-	selectedSiteHasDefaultSiteTitle,
-	userIsOlderThan,
+	hasSelectedSiteDefaultSiteTitle,
+	isUserOlderThan,
 	isEnabled,
-	userCanEditSettingsOfSelectedSite,
+	canUserEditSettingsOfSelectedSite,
 	isAbTestInVariant,
 } from 'state/ui/guided-tours/contexts';
 import Gridicon from 'components/gridicon';
@@ -36,9 +36,9 @@ export const SiteTitleTour = makeTour(
 		path=""
 		when={ and(
 						isEnabled( 'guided-tours/site-title' ),
-						selectedSiteHasDefaultSiteTitle,
-						userCanEditSettingsOfSelectedSite,
-						userIsOlderThan( TWO_DAYS_IN_MILLISECONDS ),
+						hasSelectedSiteDefaultSiteTitle,
+						canUserEditSettingsOfSelectedSite,
+						isUserOlderThan( TWO_DAYS_IN_MILLISECONDS ),
 						isAbTestInVariant( 'siteTitleTour', 'enabled' )
 					)
 		}>

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -16,6 +16,7 @@ import {
 	userIsOlderThan,
 	isEnabled,
 	userCanEditSettingsOfSelectedSite,
+	isAbTestInVariant,
 } from 'state/ui/guided-tours/contexts';
 import Gridicon from 'components/gridicon';
 
@@ -29,8 +30,9 @@ export const SiteTitleTour = makeTour(
 		when={ and(
 						isEnabled( 'guided-tours/site-title' ),
 						selectedSiteHasDefaultSiteTitle,
-						userIsOlderThan( TWO_DAYS_IN_MILLISECONDS ),
 						userCanEditSettingsOfSelectedSite,
+						userIsOlderThan( TWO_DAYS_IN_MILLISECONDS ),
+						isAbTestInVariant( 'siteTitleTour', 'enabled' )
 					)
 		}>
 		<Step name="init" placement="right" next="click-settings" className="guided-tours__step-first">

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -33,7 +33,7 @@ const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
-		version="20161010"
+		version="20161207"
 		path="/stats"
 		when={ and(
 			isEnabled( 'guided-tours/site-title' ),

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -109,8 +109,7 @@ export const SiteTitleTour = makeTour(
 
 		<Step name="finish" placement="center">
 			<p>
-				<strong>That's it!</strong>
-				Your visitors can now easily identify your website by its title.
+				<strong>That's it!</strong> Your visitors can now easily identify your website by its title.
 			</p>
 			<ButtonRow>
 				<Quit primary>{ translate( "We're all done!" ) }</Quit>

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -65,9 +65,9 @@ export const SiteTitleTour = makeTour(
 		>
 			<Continue target="settings" step="site-title-input" click>
 				{
-					translate( 'Click {{strong}}{{GridIcon/}} Settings{{/strong}} to continue.', {
+					translate( 'Click {{strong}}{{Gridicon/}} Settings{{/strong}} to continue.', {
 						components: {
-							GridIcon: <Gridicon icon="cog" size={ 24 } />,
+							Gridicon: <Gridicon icon="cog" size={ 24 } />,
 							strong: <strong />,
 						}
 					} )
@@ -121,7 +121,7 @@ export const SiteTitleTour = makeTour(
 			</Continue>
 		</Step>
 
-		<Step name="finish"	placement="center">
+		<Step name="finish" placement="center">
 			<p>
 				{
 					translate( "{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.", {

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -46,13 +46,12 @@ export const SiteTitleTour = makeTour(
 	>
 		<Step name="init" placement="right" next="click-settings">
 			<p>
-				{
-					translate( "Hey there! We noticed you haven't changed the title of your site yet. Want to change it? " )
-				}
+				Hey there! We noticed you haven't changed the title of your site yet.
+				Want to change it?
 			</p>
 			<ButtonRow>
-				<Next step="click-settings">{ translate( 'Yes, please!' ) }</Next>
-				<Quit>{ translate( 'No thanks' ) }</Quit>
+				<Next step="click-settings">Yes, please!</Next>
+				<Quit>No thanks</Quit>
 			</ButtonRow>
 		</Step>
 
@@ -64,14 +63,7 @@ export const SiteTitleTour = makeTour(
 			shouldScrollTo
 		>
 			<Continue target="settings" step="site-title-input" click>
-				{
-					translate( 'Click {{strong}}{{Gridicon/}} Settings{{/strong}} to continue.', {
-						components: {
-							Gridicon: <Gridicon icon="cog" size={ 24 } />,
-							strong: <strong />,
-						}
-					} )
-				}
+				Click <strong><Gridicon icon="cog" size={ 24 } /> Settings</strong> to continue.
 			</Continue>
 		</Step>
 
@@ -81,14 +73,12 @@ export const SiteTitleTour = makeTour(
 			placement="below"
 		>
 			<p>
-				{
-					translate( 'You can change the site title here. The site title appears in places like the top ' +
-						'of your web browser and in search results.' )
-				}
+				You can change the site title here. The site title appears in places
+				like the top of your web browser and in search results.
 			</p>
 			<ButtonRow>
-				<Next step="site-tagline-input">{ translate( 'Looks Good!' ) }</Next>
-				<Quit>{ translate( 'Cancel' ) }</Quit>
+				<Next step="site-tagline-input">Looks Good!</Next>
+				<Quit>Cancel</Quit>
 			</ButtonRow>
 		</Step>
 
@@ -98,14 +88,12 @@ export const SiteTitleTour = makeTour(
 			placement="below"
 		>
 			<p>
-				{
-					translate( 'This is the tagline of your site. It should explain what your site is about in few words. ' +
-						'It usually appears right bellow your site title.' )
-				}
+				This is the tagline of your site. It should explain what your site
+				is about in few words. It usually appears right bellow your site title.
 			</p>
 			<ButtonRow>
-				<Next step="click-save">{ translate( 'Great!' ) }</Next>
-				<Quit>{ translate( 'Cancel' ) }</Quit>
+				<Next step="click-save">Great!</Next>
+				<Quit>Cancel</Quit>
 			</ButtonRow>
 		</Step>
 
@@ -115,21 +103,14 @@ export const SiteTitleTour = makeTour(
 			placement="below"
 		>
 			<Continue target="settings-site-profile-save" step="finish" click>
-				{
-					translate( "Don't forget to save your changes." )
-				}
+				Don't forget to save your changes.
 			</Continue>
 		</Step>
 
 		<Step name="finish" placement="center">
 			<p>
-				{
-					translate( "{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.", {
-						components: {
-							strong: <strong />,
-						}
-					} )
-				}
+				<strong>That's it!</strong>
+				Your visitors can now easily identify your website by its title.
 			</p>
 			<ButtonRow>
 				<Quit primary>{ translate( "We're all done!" ) }</Quit>

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -9,14 +9,14 @@ import { overEvery as and } from 'lodash';
  * Internal dependencies
  */
 import {
-	makeTour,
-	Tour,
-	Step,
-	Next,
-	Quit,
+	ButtonRow,
 	Continue,
 	Link,
-	ButtonRow,
+	makeTour,
+	Next,
+	Quit,
+	Step,
+	Tour,
 } from 'layout/guided-tours/config-elements';
 import {
 	hasSelectedSiteDefaultSiteTitle,

--- a/client/layout/guided-tours/site-title-tour.js
+++ b/client/layout/guided-tours/site-title-tour.js
@@ -36,14 +36,14 @@ export const SiteTitleTour = makeTour(
 		version="20161010"
 		path="/stats"
 		when={ and(
-						isEnabled( 'guided-tours/site-title' ),
-						isDesktop,
-						hasSelectedSiteDefaultSiteTitle,
-						canUserEditSettingsOfSelectedSite,
-						isUserOlderThan( TWO_DAYS_IN_MILLISECONDS ),
-						isAbTestInVariant( 'siteTitleTour', 'enabled' )
-					)
-		}>
+			isEnabled( 'guided-tours/site-title' ),
+			isDesktop,
+			hasSelectedSiteDefaultSiteTitle,
+			canUserEditSettingsOfSelectedSite,
+			isUserOlderThan( TWO_DAYS_IN_MILLISECONDS ),
+			isAbTestInVariant( 'siteTitleTour', 'enabled' )
+		) }
+	>
 		<Step name="init" placement="right" next="click-settings">
 			<p>
 				{

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -100,10 +100,12 @@
 	color: lighten( $gray, 10 );
 	margin-bottom: 0;
 	font-style: italic;
+	line-height: 24px;
+	min-height: 24px;
 
 	.gridicon {
-		position: relative;
-		top: 7px;
+		vertical-align: middle;
+		margin-top: -4px;
 	}
 
 	.external-link {
@@ -113,10 +115,6 @@
 		padding-top: 12px;
 		margin-top: 16px;
 	}
-}
-
-.guided-tours__actionstep-instructions {
-	margin-top: -7px;
 }
 
 // style the pure text representation of the actionstep icon

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -20,6 +20,10 @@
 		strong {
 			color: $white;
 		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	.gridicon[height="16"] {

--- a/client/layout/guided-tours/wait.js
+++ b/client/layout/guided-tours/wait.js
@@ -2,12 +2,16 @@
  * External dependencies
  */
 import noop from 'lodash/noop';
+import debugFactory from 'debug';
 
 const WAIT_INITIAL = 1; // initial wait in milliseconds
 const WAIT_MULTIPLIER = 2;
 const WAIT_MAX = 2048; // give up waiting when delay has grown to ~4 seconds
+const debug = debugFactory( 'calypso:guided-tours' );
 
 const wait = ( { condition, consequence, delay = 0, onError = noop } ) => {
+	debug( 'wait.js: condition, consequence, delay', condition, consequence, delay );
+
 	if ( condition() ) {
 		consequence();
 		return;

--- a/client/layout/guided-tours/wait.js
+++ b/client/layout/guided-tours/wait.js
@@ -2,16 +2,12 @@
  * External dependencies
  */
 import noop from 'lodash/noop';
-import debugFactory from 'debug';
 
 const WAIT_INITIAL = 1; // initial wait in milliseconds
 const WAIT_MULTIPLIER = 2;
 const WAIT_MAX = 2048; // give up waiting when delay has grown to ~4 seconds
-const debug = debugFactory( 'calypso:guided-tours' );
 
 const wait = ( { condition, consequence, delay = 0, onError = noop } ) => {
-	debug( 'wait.js: condition, consequence, delay', condition, consequence, delay );
-
 	if ( condition() ) {
 		consequence();
 		return;

--- a/client/layout/sidebar/button.jsx
+++ b/client/layout/sidebar/button.jsx
@@ -41,6 +41,7 @@ export default React.createClass( {
 				target={ isExternal( this.props.href ) ? '_blank' : null }
 				className="sidebar__button"
 				onMouseEnter={ this.preload }
+				data-tip-target={ this.props.tipTarget }
 			>
 				{ this.props.children || this.translate( 'Add' ) }
 			</a>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -132,8 +132,8 @@ module.exports = {
 	siteTitleTour: {
 		datestamp: '20161130',
 		variations: {
-			disabled: 50,
-			enabled: 50,
+			disabled: 1,
+			enabled: 0,
 		},
 		defaultVariation: 'disabled',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -130,9 +130,9 @@ module.exports = {
 	},
 
 	siteTitleTour: {
-		datestamp: '20161130',
+		datestamp: '20161207',
 		variations: {
-			disabled: 1,
+			disabled: 100,
 			enabled: 0,
 		},
 		defaultVariation: 'disabled',

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -127,5 +127,15 @@ module.exports = {
 		},
 		defaultVariation: 'showSurveyStep',
 		allowAnyLocale: true,
-	}
+	},
+
+	siteTitleTour: {
+		datestamp: '20161130',
+		variations: {
+			disabled: 50,
+			enabled: 50,
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -497,7 +497,8 @@ export class MySitesSidebar extends Component {
 				link={ siteSettingsLink }
 				onNavigate={ this.onNavigate }
 				icon="cog"
-				preloadSectionName="settings" />
+				preloadSectionName="settings"
+				tipTarget="settings" />
 		);
 	}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -140,7 +140,8 @@ const FormGeneral = React.createClass( {
 							valueLink={ this.linkState( 'blogname' ) }
 							disabled={ this.state.fetchingSettings }
 							onClick={ this.onRecordEvent( 'Clicked Site Title Field' ) }
-							onKeyPress={ this.onRecordEventOnce( 'typedTitle', 'Typed in Site Title Field' ) } />
+							onKeyPress={ this.onRecordEventOnce( 'typedTitle', 'Typed in Site Title Field' ) }
+							data-tip-target="site-title-input" />
 					</FormFieldset>
 					<FormFieldset>
 						<FormLabel htmlFor="blogdescription">{ this.translate( 'Site Tagline' ) }</FormLabel>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -574,7 +574,7 @@ const FormGeneral = React.createClass( {
 						compact={ true }
 						onClick={ this.handleSubmitForm }
 						primary={ true }
-
+						data-tip-target="settings-site-profile-save"
 						type="submit"
 						disabled={ this.state.fetchingSettings || this.state.submittingForm }>
 							{ this.state.submittingForm

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -152,7 +152,8 @@ const FormGeneral = React.createClass( {
 							valueLink={ this.linkState( 'blogdescription' ) }
 							disabled={ this.state.fetchingSettings }
 							onClick={ this.onRecordEvent( 'Clicked Site Site Tagline Field' ) }
-							onKeyPress={ this.onRecordEventOnce( 'typedTagline', 'Typed in Site Site Tagline Field' ) } />
+							onKeyPress={ this.onRecordEventOnce( 'typedTagline', 'Typed in Site Site Tagline Field' ) }
+							data-tip-target="site-tagline-input" />
 						<FormSettingExplanation>
 							{ this.translate( 'In a few words, explain what this site is about.' ) }
 						</FormSettingExplanation>

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -999,5 +999,5 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
 		return null;
 	}
 	const slug = getSiteSlug( state, siteId );
-	return site.name === 'Site Title' || slug.indexOf( site.name ) === 0;
+	return site.name === i18n.translate( 'Site Title' ) || slug.indexOf( site.name ) === 0;
 };

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -985,3 +985,19 @@ export function getCustomizerUrl( state, siteId ) {
 		'return': returnUrl
 	}, adminUrl );
 }
+
+/*
+ * Returns true if the site has unchanged site title
+ *
+ * @param {Object} state Global state tree
+ * @param {Object} siteId Site ID
+ * @return {Boolean} True if site title is default, false otherwise.
+ */
+export const hasDefaultSiteTitle = ( state, siteId ) => {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+	const slug = getSiteSlug( state, siteId );
+	return site.name === 'Site Title' || slug.indexOf( site.name ) === 0;
+};

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -14,6 +14,7 @@ import {
 	some,
 	split,
 	includes,
+	startsWith,
 } from 'lodash';
 import i18n from 'i18n-calypso';
 
@@ -1000,5 +1001,5 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
 	}
 	const slug = getSiteSlug( state, siteId );
 	// we are using startsWith here, as getSiteSlug returns "slug.wordpress.com"
-	return site.name === i18n.translate( 'Site Title' ) || slug.startsWith( site.name );
+	return site.name === i18n.translate( 'Site Title' ) || startsWith( slug, site.name );
 };

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -999,5 +999,6 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
 		return null;
 	}
 	const slug = getSiteSlug( state, siteId );
-	return site.name === i18n.translate( 'Site Title' ) || slug.indexOf( site.name ) === 0;
+	// we are using startsWith here, as getSiteSlug returns "slug.wordpress.com"
+	return site.name === i18n.translate( 'Site Title' ) || slug.startsWith( site.name );
 };

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -28,12 +28,12 @@ const timeSinceUserRegistration = state => {
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 export const isNewUser = state => {
 	const userAge = timeSinceUserRegistration( state );
-	return userAge ? userAge <= WEEK_IN_MILLISECONDS : false;
+	return ! isNaN( userAge ) ? userAge <= WEEK_IN_MILLISECONDS : false;
 };
 
 export const isUserOlderThan = age => state => {
 	const userAge = timeSinceUserRegistration( state );
-	return userAge ? userAge >= age : false;
+	return ! isNaN( userAge ) ? userAge >= age : false;
 };
 
 export const hasUserInteractedWithComponent = componentName => state =>

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -19,25 +19,20 @@ export const isPreviewNotShowing = state =>
 export const isPreviewShowing = state =>
 	isPreviewShowingSelector( state );
 
+const timeSinceUserRegistration = state => {
+	const user = getCurrentUser( state );
+	return user ? ( Date.now() - Date.parse( user.date ) ) : false;
+};
+
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 export const isNewUser = state => {
-	const user = getCurrentUser( state );
-	if ( ! user ) {
-		return false;
-	}
-
-	const creation = Date.parse( user.date );
-	return ( Date.now() - creation ) <= WEEK_IN_MILLISECONDS;
+	const userAge = timeSinceUserRegistration( state );
+	return userAge ? userAge <= WEEK_IN_MILLISECONDS : false;
 };
 
 export const userIsOlderThan = age => state => {
-	const user = getCurrentUser( state );
-	if ( ! user ) {
-		return false;
-	}
-
-	const creation = Date.parse( user.date );
-	return ( Date.now() - creation ) >= age;
+	const userAge = timeSinceUserRegistration( state );
+	return userAge ? userAge >= age : false;
 };
 
 export const hasUserInteractedWithComponent = componentName => state =>

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -4,7 +4,7 @@
 import config from 'config';
 import { getSectionName, isPreviewShowing as isPreviewShowingSelector, getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser, canCurrentUser } from 'state/current-user/selectors';
 import { abtest } from 'lib/abtest';
 import { hasDefaultSiteTitle } from 'state/sites/selectors';
 
@@ -56,4 +56,9 @@ export const isAbTestInVariant = ( testName, variant ) => () =>
 export const selectedSiteHasDefaultSiteTitle = state => {
 	const siteId = getSelectedSiteId( state );
 	return siteId ? hasDefaultSiteTitle( state, siteId ) : false;
+};
+
+export const userCanEditSettingsOfSelectedSite = state => {
+	const siteId = getSelectedSiteId( state );
+	return siteId ? canCurrentUser( state, siteId, 'manage_options' ) : false;
 };

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import config from 'config';
+import { abtest } from 'lib/abtest';
 import { getSectionName, isPreviewShowing as isPreviewShowingSelector, getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser, canCurrentUser } from 'state/current-user/selectors';
@@ -30,7 +31,7 @@ export const isNewUser = state => {
 	return userAge ? userAge <= WEEK_IN_MILLISECONDS : false;
 };
 
-export const userIsOlderThan = age => state => {
+export const isUserOlderThan = age => state => {
 	const userAge = timeSinceUserRegistration( state );
 	return userAge ? userAge >= age : false;
 };
@@ -47,12 +48,12 @@ export const isSelectedSiteCustomizable = state =>
 export const isAbTestInVariant = ( testName, variant ) => () =>
 	abtest( testName ) === variant;
 
-export const selectedSiteHasDefaultSiteTitle = state => {
+export const hasSelectedSiteDefaultSiteTitle = state => {
 	const siteId = getSelectedSiteId( state );
 	return siteId ? hasDefaultSiteTitle( state, siteId ) : false;
 };
 
-export const userCanEditSettingsOfSelectedSite = state => {
+export const canUserEditSettingsOfSelectedSite = state => {
 	const siteId = getSelectedSiteId( state );
 	return siteId ? canCurrentUser( state, siteId, 'manage_options' ) : false;
 };

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -5,7 +5,6 @@ import config from 'config';
 import { getSectionName, isPreviewShowing as isPreviewShowingSelector, getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser, canCurrentUser } from 'state/current-user/selectors';
-import { abtest } from 'lib/abtest';
 import { hasDefaultSiteTitle } from 'state/sites/selectors';
 
 export const inSection = sectionName => state =>
@@ -61,8 +60,4 @@ export const selectedSiteHasDefaultSiteTitle = state => {
 export const userCanEditSettingsOfSelectedSite = state => {
 	const siteId = getSelectedSiteId( state );
 	return siteId ? canCurrentUser( state, siteId, 'manage_options' ) : false;
-};
-
-export const isAbTestInVariant = ( testName, variant ) => () => {
-	return abtest( testName ) === variant;
 };

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -62,3 +62,7 @@ export const userCanEditSettingsOfSelectedSite = state => {
 	const siteId = getSelectedSiteId( state );
 	return siteId ? canCurrentUser( state, siteId, 'manage_options' ) : false;
 };
+
+export const isAbTestInVariant = ( testName, variant ) => () => {
+	return abtest( testName ) === variant;
+};

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -31,6 +31,16 @@ export const isNewUser = state => {
 	return ( Date.now() - creation ) <= WEEK_IN_MILLISECONDS;
 };
 
+export const userIsOlderThan = age => state => {
+	const user = getCurrentUser( state );
+	if ( ! user ) {
+		return false;
+	}
+
+	const creation = Date.parse( user.date );
+	return ( Date.now() - creation ) >= age;
+};
+
 export const hasUserInteractedWithComponent = componentName => state =>
 	getLastAction( state ).component === componentName;
 

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -2,10 +2,11 @@
  * Internal dependencies
  */
 import config from 'config';
-import { getSectionName, isPreviewShowing as isPreviewShowingSelector, getSelectedSite } from 'state/ui/selectors';
+import { getSectionName, isPreviewShowing as isPreviewShowingSelector, getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { abtest } from 'lib/abtest';
+import { hasDefaultSiteTitle } from 'state/sites/selectors';
 
 export const inSection = sectionName => state =>
 	getSectionName( state ) === sectionName;
@@ -41,3 +42,8 @@ export const isSelectedSiteCustomizable = state =>
 
 export const isAbTestInVariant = ( testName, variant ) => () =>
 	abtest( testName ) === variant;
+
+export const selectedSiteHasDefaultSiteTitle = state => {
+	const siteId = getSelectedSiteId( state );
+	return siteId ? hasDefaultSiteTitle( state, siteId ) : false;
+};

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -3,7 +3,12 @@
  */
 import config from 'config';
 import { abtest } from 'lib/abtest';
-import { getSectionName, isPreviewShowing as isPreviewShowingSelector, getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import {
+	getSectionName,
+	getSelectedSite,
+	getSelectedSiteId,
+	isPreviewShowing as isPreviewShowingSelector,
+} from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser, canCurrentUser } from 'state/current-user/selectors';
 import { hasDefaultSiteTitle } from 'state/sites/selectors';

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -27,18 +27,19 @@ export const isPreviewShowing = state =>
 
 const timeSinceUserRegistration = state => {
 	const user = getCurrentUser( state );
-	return user ? ( Date.now() - Date.parse( user.date ) ) : false;
+	const registrationDate = user && Date.parse( user.date );
+	return registrationDate ? ( Date.now() - registrationDate ) : false;
 };
 
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 export const isNewUser = state => {
 	const userAge = timeSinceUserRegistration( state );
-	return ! isNaN( userAge ) ? userAge <= WEEK_IN_MILLISECONDS : false;
+	return userAge !== false ? userAge <= WEEK_IN_MILLISECONDS : false;
 };
 
 export const isUserOlderThan = age => state => {
 	const userAge = timeSinceUserRegistration( state );
-	return ! isNaN( userAge ) ? userAge >= age : false;
+	return userAge !== false ? userAge >= age : false;
 };
 
 export const hasUserInteractedWithComponent = componentName => state =>

--- a/config/development.json
+++ b/config/development.json
@@ -44,6 +44,7 @@
 		"guided-tours": true,
 		"guided-tours/main": true,
 		"guided-tours/design-showcase-welcome": true,
+		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
 		"guided-tours/themes": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,6 +27,7 @@
 		"guided-tours": true,
 		"guided-tours/main": false,
 		"guided-tours/design-showcase-welcome": true,
+		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
 		"guided-tours/themes": true,
 		"help": true,


### PR DESCRIPTION
This tour is an experiment I'm making to help battle test Guided Tours API. 

The intention is to show this to users that didn't change their site title yet. That can be recognized by the fact their title is equal to either `"Site Title"` or to the slug of their site.
