### PR TITLE
People: clear JS error from email-followers flux store

### DIFF
--- a/client/lib/email-followers/store.js
+++ b/client/lib/email-followers/store.js
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:email-followers-store' ),
-	omit = require( 'lodash/omit' );
+import omit from 'lodash/omit';
+const debug = require( 'debug' )( 'calypso:email-followers-store' );
 
 /**
  * Internal dependencies
  */
-var Dispatcher = require( 'dispatcher' ),
-	emitter = require( 'lib/mixins/emitter' ),
-	deterministicStringify = require( 'lib/deterministic-stringify' );
+import Dispatcher from 'dispatcher';
+import emitter from 'lib/mixins/emitter';
+import deterministicStringify from 'lib/deterministic-stringify';
 
-var _fetchingFollowersByNamespace = {}, // store fetching state (boolean)
+const _fetchingFollowersByNamespace = {}, // store fetching state (boolean)
 	_followersBySite = {}, // store user objects
 	_totalFollowersByNamespace = {}, // store total found for params
 	_followersFetchedByNamespace = {}, // store fetch progress
@@ -19,10 +19,10 @@ var _fetchingFollowersByNamespace = {}, // store fetching state (boolean)
 	_followerIDsByNamespace = {}, // store user order
 	_removingFromSite = {};
 
-var EmailFollowersStore = {
+const EmailFollowersStore = {
 	// This data may help with infinite scrolling
 	getPaginationData: function( fetchOptions ) {
-		var namespace = getNamespace( fetchOptions );
+		const namespace = getNamespace( fetchOptions );
 		debug( 'getPaginationData:', namespace );
 		return {
 			fetchInitialized: _followersFetchedByNamespace.hasOwnProperty( namespace ),
@@ -39,8 +39,9 @@ var EmailFollowersStore = {
 	},
 
 	getFollowers: function( fetchOptions ) {
-		var namespace = getNamespace( fetchOptions ),
-			siteId = fetchOptions.siteId;
+		const namespace = getNamespace( fetchOptions ),
+			siteId = fetchOptions.siteId,
+			followers = [];
 
 		debug( 'getFollowers:', namespace );
 
@@ -50,7 +51,6 @@ var EmailFollowersStore = {
 		if ( ! _followerIDsByNamespace[ namespace ] ) {
 			return false;
 		}
-		let followers = [];
 		_followerIDsByNamespace[ namespace ].forEach( followerId => {
 			if ( _followersBySite[ siteId ][ followerId ] ) {
 				followers.push( _followersBySite[ siteId ][ followerId ] );
@@ -78,7 +78,7 @@ function updateFollower( siteId, id, follower ) {
 }
 
 function updateFollowers( fetchOptions, followers, total ) {
-	var namespace = getNamespace( fetchOptions ),
+	const namespace = getNamespace( fetchOptions ),
 		page = fetchOptions.page;
 
 	debug( 'updateFollowers:', namespace );
@@ -139,8 +139,8 @@ function removeFollowerFromNamespaces( siteId, followerId ) {
 }
 
 EmailFollowersStore.dispatchToken = Dispatcher.register( function( payload ) {
-	var action = payload.action,
-		namespace;
+	const action = payload.action;
+	let namespace;
 	debug( 'register event Type', action.type, payload );
 
 	switch ( action.type ) {

--- a/client/lib/email-followers/store.js
+++ b/client/lib/email-followers/store.js
@@ -104,7 +104,7 @@ function getNamespace( fetchOptions ) {
 
 function decrementPaginationData( siteId, followerId ) {
 	Object.keys( _followerIDsByNamespace ).forEach( function( namespace ) {
-		if ( namespace.includes( 'siteId=' + siteId + '&' ) && _followerIDsByNamespace[ namespace ].has( followerId ) ) {
+		if ( namespace.indexOf( 'siteId=' + siteId + '&' ) !== -1 && _followerIDsByNamespace[ namespace ].has( followerId ) ) {
 			_totalFollowersByNamespace[ namespace ]--;
 			_followersFetchedByNamespace[ namespace ]--;
 			_pageByNamespace[ namespace ]--;
@@ -114,7 +114,7 @@ function decrementPaginationData( siteId, followerId ) {
 
 function incrementPaginationData( siteId, followerId ) {
 	Object.keys( _followerIDsByNamespace ).forEach( function( namespace ) {
-		if ( namespace.includes( 'siteId=' + siteId + '&' ) && _followerIDsByNamespace[ namespace ].has( followerId ) ) {
+		if ( namespace.indexOf( 'siteId=' + siteId + '&' ) !== -1 && _followerIDsByNamespace[ namespace ].has( followerId ) ) {
 			_totalFollowersByNamespace[ namespace ]++;
 			_followersFetchedByNamespace[ namespace ]++;
 			_pageByNamespace[ namespace ]++;
@@ -132,7 +132,7 @@ function removeFollowerFromSite( siteId, followerId ) {
 
 function removeFollowerFromNamespaces( siteId, followerId ) {
 	Object.keys( _followerIDsByNamespace ).forEach( function( namespace ) {
-		if ( namespace.includes( 'siteId=' + siteId + '&' ) && _followerIDsByNamespace[ namespace ].has( followerId ) ) {
+		if ( namespace.indexOf( 'siteId=' + siteId + '&' ) !== -1 && _followerIDsByNamespace[ namespace ].has( followerId ) ) {
 			delete _followerIDsByNamespace[ namespace ][ followerId ];
 		}
 	} );


### PR DESCRIPTION
This PR clears a JS emitted by the email followers flux store, as well as clears up some ES lint warnings.

To reproduce the error:
- run the latest master at calypso.localhost:3000
- select a site ( that has email followers ) and go to People > Email Followers
- try to delete a follower
- the follower will indeed be deleted, but you'll see this in the JS console

<img width="980" alt="screen shot 2016-10-10 at 2 38 47 pm" src="https://cloud.githubusercontent.com/assets/2694219/19247699/6d0bded2-8efa-11e6-9613-ccee83ce5830.png">

To test:
- check out this branch to your local instance
- repeat the steps of removing an email follower from a site
- note the lack of console errors

Part of the clean up effort at #7413 

cc: @lezama @ebinnion 
