### PR TITLE
Taxonomies: Basic TaxonomyManager Component

### DIFF
--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SectionHeader from 'components/section-header';
+import Card from 'components/card';
+import SearchCard from 'components/search-card';
+import Button from 'components/button';
+
+export class TaxonomyManager extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		taxonomy: PropTypes.string,
+	};
+
+	render() {
+		return (
+			<div>
+				<SectionHeader label={ this.props.translate( 'Categories' ) }>
+					<Button compact primary>
+						{ this.props.translate( 'Add Category' ) }
+					</Button>
+				</SectionHeader>
+				<Card>
+					<SearchCard onSearch={ () => {} } />
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( TaxonomyManager );

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -21,6 +21,7 @@ import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
 import QueryTerms from 'components/data/query-terms';
+import TaxonomyManager from 'blocks/taxonomy-manager';
 import { isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
@@ -215,8 +216,8 @@ const SiteSettingsFormWriting = React.createClass( {
 						</FormFieldset>
 					}
 				</Card>
+				{ config.isEnabled( 'manage/site-settings/categories' ) && <TaxonomyManager taxonomy="category" /> }
 			</form>
-
 		);
 	}
 } );

--- a/config/development.json
+++ b/config/development.json
@@ -84,6 +84,7 @@
 		"manage/seo": true,
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
+		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
 		"manage/site-settings/site-icon": true,
 		"manage/stats": true,


### PR DESCRIPTION
Closes #8632

This branch adds in a basic component and feature flag to allow further work on the "TaxonomyManager" in Calypso.  Project details can be seen here https://github.com/Automattic/wp-calypso/projects/11#card-389727

__To Test__
Open a site settings page, click on the writing tab, verify the Categories Card is shown at the bottom of the screen.