### PR TITLE
Add FormTextInputWithAction component.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -73,6 +73,7 @@
 @import 'components/forms/form-setting-explanation/style';
 @import 'components/forms/form-tel-input/style';
 @import 'components/forms/form-text-input/style';
+@import 'components/forms/form-text-input-with-action/style';
 @import 'components/forms/form-text-input-with-affixes/style';
 @import 'components/forms/form-toggle/style';
 @import 'components/forms/range/style';

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -27,6 +27,7 @@ var countriesList = require( 'lib/countries-list' ).forSms(),
 	FormTelInput = require( 'components/forms/form-tel-input' ),
 	FormTextarea = require( 'components/forms/form-textarea' ),
 	FormTextInput = require( 'components/forms/form-text-input' ),
+	FormTextInputWithAction = require( 'components/forms/form-text-input-with-action' ),
 	FormTextInputWithAffixes = require( 'components/forms/form-text-input-with-affixes' ),
 	FormToggle = require( 'components/forms/form-toggle' ),
 	CompactFormToggle = require( 'components/forms/form-toggle/compact' );
@@ -54,6 +55,10 @@ var FormFields = React.createClass( {
 
 	handleCompactToggle: function() {
 		this.setState( { compactToggled: ! this.state.compactToggled } );
+	},
+
+	handleAction: function() {
+		alert( 'Thank you.' );
 	},
 
 	render: function() {
@@ -121,6 +126,16 @@ var FormFields = React.createClass( {
 							placeholder="Placeholder text..."
 						/>
 						<FormInputValidation isError text="Your text is too short." />
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="text_with_affixes">Form Text Input With Action</FormLabel>
+						<FormTextInputWithAction
+							placeholder="Enter a name for your site"
+							action="Continue"
+							onAction={ this.handleAction }
+							/>
+						<FormSettingExplanation>Action becomes avaliable when filled. Can be triggered by clicking button or pressing enter.</FormSettingExplanation>
 					</FormFieldset>
 
 					<FormFieldset>

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+import { keys, omit, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormTextInput from 'components/forms/form-text-input';
+import FormButton from 'components/forms/form-button';
+
+export default React.createClass( {
+	displayName: 'FormTextInputWithAction',
+
+	propTypes: {
+		action: React.PropTypes.element,
+		inputRef: React.PropTypes.function,
+		onFocus: React.PropTypes.function,
+		onBlur: React.PropTypes.function,
+		onKeyDown: React.PropTypes.function,
+		onChange: React.PropTypes.function,
+		onAction: React.PropTypes.function,
+		defaultValue: React.PropTypes.defaultValue,
+		disabled: React.PropTypes.bool,
+	},
+
+	getDefaultProps() {
+		return {
+			defaultValue: '',
+			onFocus: noop,
+			onBlur: noop,
+			onKeyDown: noop,
+			onChange: noop,
+			onAction: noop,
+		};
+	},
+
+	getInitialState() {
+		return {
+			focused: false,
+			value: null,
+		};
+	},
+
+	handleFocus( e ) {
+		this.props.onFocus( e );
+		if ( e.defaultPrevented ) {
+			return;
+		}
+		this.setState( {
+			focused: true,
+		} );
+	},
+
+	handleBlur( e ) {
+		this.props.onBlur( e );
+		if ( e.defaultPrevented ) {
+			return;
+		}
+		this.setState( {
+			focused: false,
+		} );
+	},
+
+	handleKeyDown( e ) {
+		this.props.onKeyDown( e );
+		if ( e.defaultPrevented ) {
+			return;
+		}
+		if ( e.which === 13 ) {
+			this.props.onAction( e );
+		}
+	},
+
+	handleChange( e ) {
+		this.props.onChange( e );
+		if ( e.defaultPrevented ) {
+			return;
+		}
+		this.setState( {
+			value: e.target.value,
+		} );
+	},
+
+	getValue() {
+		if ( this.state.value === null ) {
+			return this.props.defaultValue;
+		}
+		return this.state.value;
+	},
+
+	render() {
+		return (
+			<div
+				className={ classNames( 'form-text-input-with-action', {
+					'is-focused': this.state.focused,
+					'is-disabled': this.props.disabled
+				} ) }
+			>
+				<FormTextInput
+					className="form-text-input-with-action__input"
+					ref={ this.props.inputRef }
+					disabled={ this.props.disabled }
+					defaultValue={ this.props.defaultValue }
+					onChange={ this.handleChange }
+					onFocus={ this.handleFocus }
+					onBlur={ this.handleBlur }
+					onKeyDown={ this.handleKeyDown }
+					{ ...omit( this.props, keys( this.constructor.propTypes ) ) }
+				/>
+				<FormButton
+					className="form-text-input-with-action__button is-compact"
+					disabled={ this.props.disabled || this.getValue() === '' }
+					onClick={ this.props.onAction }
+				>
+					{ this.props.action }
+				</FormButton>
+			</div>
+		);
+	}
+} );

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -102,6 +102,7 @@ const FormTextInputWithAction = React.createClass( {
 					'is-error': this.props.isError,
 					'is-valid': this.props.isValid,
 				} ) }
+				role="group"
 			>
 				<FormTextInput
 					className="form-text-input-with-action__input"

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { keys, omit, noop } from 'lodash';
 
@@ -15,17 +15,17 @@ export default React.createClass( {
 	displayName: 'FormTextInputWithAction',
 
 	propTypes: {
-		action: React.PropTypes.node,
-		inputRef: React.PropTypes.func,
-		onFocus: React.PropTypes.func,
-		onBlur: React.PropTypes.func,
-		onKeyDown: React.PropTypes.func,
-		onChange: React.PropTypes.func,
-		onAction: React.PropTypes.func,
-		defaultValue: React.PropTypes.string,
-		disabled: React.PropTypes.bool,
-		isError: React.PropTypes.bool,
-		isValid: React.PropTypes.bool,
+		action: PropTypes.node,
+		inputRef: PropTypes.func,
+		onFocus: PropTypes.func,
+		onBlur: PropTypes.func,
+		onKeyDown: PropTypes.func,
+		onChange: PropTypes.func,
+		onAction: PropTypes.func,
+		defaultValue: PropTypes.string,
+		disabled: PropTypes.bool,
+		isError: PropTypes.bool,
+		isValid: PropTypes.bool,
 	},
 
 	getDefaultProps() {

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -69,7 +69,7 @@ export default React.createClass( {
 		if ( e.defaultPrevented ) {
 			return;
 		}
-		if ( e.which === 13 ) {
+		if ( e.which === 13 && this.getValue() !== '' ) {
 			this.props.onAction( e );
 		}
 	},

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
 import classNames from 'classnames';
 import { keys, omit, noop } from 'lodash';
 
@@ -11,8 +11,8 @@ import { keys, omit, noop } from 'lodash';
 import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 
-const FormTextInputWithAction = React.createClass( {
-	propTypes: {
+export default class FormTextInputWithAction extends Component {
+	static propTypes = {
 		action: PropTypes.node,
 		inputRef: PropTypes.func,
 		onFocus: PropTypes.func,
@@ -24,29 +24,28 @@ const FormTextInputWithAction = React.createClass( {
 		disabled: PropTypes.bool,
 		isError: PropTypes.bool,
 		isValid: PropTypes.bool,
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			defaultValue: '',
-			onFocus: noop,
-			onBlur: noop,
-			onKeyDown: noop,
-			onChange: noop,
-			onAction: noop,
-			isError: false,
-			isValid: false,
-		};
-	},
+	static defaultProps = {
+		defaultValue: '',
+		onFocus: noop,
+		onBlur: noop,
+		onKeyDown: noop,
+		onChange: noop,
+		onAction: noop,
+		isError: false,
+		isValid: false,
+	};
 
-	getInitialState() {
-		return {
+	constructor() {
+		super();
+		this.state = {
 			focused: false,
 			value: null,
 		};
-	},
+	};
 
-	handleFocus( e ) {
+	handleFocus = ( e ) => {
 		this.props.onFocus( e );
 		if ( e.defaultPrevented ) {
 			return;
@@ -54,9 +53,9 @@ const FormTextInputWithAction = React.createClass( {
 		this.setState( {
 			focused: true,
 		} );
-	},
+	};
 
-	handleBlur( e ) {
+	handleBlur = ( e ) => {
 		this.props.onBlur( e );
 		if ( e.defaultPrevented ) {
 			return;
@@ -64,9 +63,9 @@ const FormTextInputWithAction = React.createClass( {
 		this.setState( {
 			focused: false,
 		} );
-	},
+	};
 
-	handleKeyDown( e ) {
+	handleKeyDown = ( e ) => {
 		this.props.onKeyDown( e );
 		if ( e.defaultPrevented ) {
 			return;
@@ -74,9 +73,9 @@ const FormTextInputWithAction = React.createClass( {
 		if ( e.which === 13 && this.getValue() !== '' ) {
 			this.props.onAction( e );
 		}
-	},
+	};
 
-	handleChange( e ) {
+	handleChange = ( e ) => {
 		this.props.onChange( e );
 		if ( e.defaultPrevented ) {
 			return;
@@ -84,14 +83,14 @@ const FormTextInputWithAction = React.createClass( {
 		this.setState( {
 			value: e.target.value,
 		} );
-	},
+	};
 
 	getValue() {
 		if ( this.state.value === null ) {
 			return this.props.defaultValue;
 		}
 		return this.state.value;
-	},
+	};
 
 	render() {
 		return (
@@ -124,7 +123,5 @@ const FormTextInputWithAction = React.createClass( {
 				</FormButton>
 			</div>
 		);
-	}
-} );
-
-export default FormTextInputWithAction;
+	};
+}

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -11,7 +11,7 @@ import { keys, omit, noop } from 'lodash';
 import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 
-let FormTextInputWithAction = React.createClass( {
+const FormTextInputWithAction = React.createClass( {
 	propTypes: {
 		action: PropTypes.node,
 		inputRef: PropTypes.func,

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -15,14 +15,14 @@ export default React.createClass( {
 	displayName: 'FormTextInputWithAction',
 
 	propTypes: {
-		action: React.PropTypes.element,
-		inputRef: React.PropTypes.function,
-		onFocus: React.PropTypes.function,
-		onBlur: React.PropTypes.function,
-		onKeyDown: React.PropTypes.function,
-		onChange: React.PropTypes.function,
-		onAction: React.PropTypes.function,
-		defaultValue: React.PropTypes.defaultValue,
+		action: React.PropTypes.node,
+		inputRef: React.PropTypes.func,
+		onFocus: React.PropTypes.func,
+		onBlur: React.PropTypes.func,
+		onKeyDown: React.PropTypes.func,
+		onChange: React.PropTypes.func,
+		onAction: React.PropTypes.func,
+		defaultValue: React.PropTypes.string,
 		disabled: React.PropTypes.bool,
 	},
 

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -24,6 +24,8 @@ export default React.createClass( {
 		onAction: React.PropTypes.func,
 		defaultValue: React.PropTypes.string,
 		disabled: React.PropTypes.bool,
+		isError: React.PropTypes.bool,
+		isValid: React.PropTypes.bool,
 	},
 
 	getDefaultProps() {
@@ -34,6 +36,8 @@ export default React.createClass( {
 			onKeyDown: noop,
 			onChange: noop,
 			onAction: noop,
+			isError: false,
+			isValid: false,
 		};
 	},
 
@@ -96,7 +100,9 @@ export default React.createClass( {
 			<div
 				className={ classNames( 'form-text-input-with-action', {
 					'is-focused': this.state.focused,
-					'is-disabled': this.props.disabled
+					'is-disabled': this.props.disabled,
+					'is-error': this.props.isError,
+					'is-valid': this.props.isValid,
 				} ) }
 			>
 				<FormTextInput

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -11,9 +11,7 @@ import { keys, omit, noop } from 'lodash';
 import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 
-export default React.createClass( {
-	displayName: 'FormTextInputWithAction',
-
+let FormTextInputWithAction = React.createClass( {
 	propTypes: {
 		action: PropTypes.node,
 		inputRef: PropTypes.func,
@@ -127,3 +125,5 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default FormTextInputWithAction;

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -43,7 +43,7 @@ export default class FormTextInputWithAction extends Component {
 			focused: false,
 			value: null,
 		};
-	};
+	}
 
 	handleFocus = ( e ) => {
 		this.props.onFocus( e );
@@ -90,7 +90,7 @@ export default class FormTextInputWithAction extends Component {
 			return this.props.defaultValue;
 		}
 		return this.state.value;
-	};
+	}
 
 	render() {
 		return (
@@ -123,5 +123,5 @@ export default class FormTextInputWithAction extends Component {
 				</FormButton>
 			</div>
 		);
-	};
+	}
 }

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -27,7 +27,7 @@
 }
 
 .form-text-input-with-action__button.is-compact {
-	flex: 1 0 auto;
+	flex: 0 0 auto;
 	margin: 4px;
 	text-transform: none;
 }

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -24,19 +24,18 @@
 			color: lighten( $gray, 10% );
 		}
 	}
-
 }
 
 .form-text-input-with-action__button.is-compact {
-	flex-grow: 0;
+	flex: 1 0 auto;
 	margin: 4px;
 	text-transform: none;
 }
 
 input[type="text"].form-text-input-with-action__input {
+	flex: 1 1 0;
 	border: none;
-	flex-basis: 0;
-	flex-grow: 1;
+	min-width: 0;
 }
 
 input[type="text"].form-text-input-with-action__input:focus {

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -1,0 +1,45 @@
+.form-text-input-with-action {
+	@extend %form-field;
+	display: flex;
+	padding: 0;
+
+	&.is-focused {
+		border-color: $blue-wordpress;
+		outline: none;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+
+	&.is-disabled {
+		background: $gray-light;
+		border-color: lighten( $gray, 30% );
+		color: lighten( $gray, 10% );
+		opacity: 1;
+		-webkit-text-fill-color: lighten( $gray, 10% );
+
+		&:hover {
+			cursor: default;
+		}
+
+		&::placeholder {
+			color: lighten( $gray, 10% );
+		}
+	}
+
+}
+
+.form-text-input-with-action__button.is-compact {
+	flex-grow: 0;
+	margin: 4px;
+	text-transform: none;
+}
+
+input[type="text"].form-text-input-with-action__input {
+	border: none;
+	flex-basis: 0;
+	flex-grow: 1;
+}
+
+input[type="text"].form-text-input-with-action__input:focus {
+	border: none;
+	box-shadow: none;
+}

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -7,6 +7,22 @@
 		border-color: $blue-wordpress;
 		outline: none;
 		box-shadow: 0 0 0 2px $blue-light;
+
+		&.is-valid {
+			box-shadow: 0 0 0 2px lighten( $alert-green, 35 );
+		}
+
+		&.is-valid:hover {
+			box-shadow: 0 0 0 2px lighten( $alert-green, 25 );
+		}
+
+		&.is-error {
+			box-shadow: 0 0 0 2px lighten( $alert-red, 35 );
+		}
+
+		&.is-error:hover {
+			box-shadow: 0 0 0 2px lighten( $alert-red, 25 );
+		}
 	}
 
 	&.is-disabled {
@@ -23,6 +39,22 @@
 		&::placeholder {
 			color: lighten( $gray, 10% );
 		}
+	}
+
+	&.is-valid {
+		border-color: $alert-green;
+	}
+
+	&.is-valid:hover {
+		border-color: darken( $alert-green, 10 );
+	}
+
+	&.is-error {
+		border-color: $alert-red;
+	}
+
+	&.is-error:hover {
+		border-color: darken( $alert-red, 10 );
 	}
 }
 


### PR DESCRIPTION
## Description

This PR adds a `FormTextInputWithAction` component.

This component implements a recurring pattern in the newer signup steps, appearing in Verticals V2, the Site Title picker, as well as the Store step (albeit there with a slightly different design). Basically, it represents a single input field that, when filled, allows you to perform an action by clicking on a button (or pressing enter). The button is disabled otherwise.

We use a `FormTextInput`, a `FormButton` and wrap both in a `display: flex` container to get the appropriate layout regardless of i18n. (An issue originally pointed out by @iamtakashi in #7700) The focus ring is applied to the container by hooking up to `onFocus` and `onBlur` events.

**Since this is my first reusable, general purpose component, I'd appreciate some feedback on the structure of the code. Thanks!**
## Screenshots

<img width="921" alt="screen shot 2016-10-11 at 01 30 21" src="https://cloud.githubusercontent.com/assets/418473/19258858/6dd4ca6a-8f52-11e6-87ee-9933080a2d67.png">

<img width="925" alt="screen shot 2016-10-11 at 01 30 31" src="https://cloud.githubusercontent.com/assets/418473/19258857/6da9f830-8f52-11e6-80b2-1b67a1a7719b.png">
## Testing

To test, head to:
https://calypso.live/devdocs/design/form-fields?branch=add/form-text-input-with-action

And fill in the field/click the action button/hit enter to submit
