### PR TITLE
Update node-phone version to 1.8.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2567,9 +2567,9 @@
       "version": "0.2.0"
     },
     "phone": {
-      "version": "1.0.4-12",
-      "from": "git+https://github.com/Automattic/node-phone.git#f80b55251b54ab729f94c04f33ae1c7b2b2b0932",
-      "resolved": "git+https://github.com/Automattic/node-phone.git#f80b55251b54ab729f94c04f33ae1c7b2b2b0932"
+      "version": "1.0.8",
+      "from": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e",
+      "resolved": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e"
     },
     "photon": {
       "version": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "page": "1.6.4",
     "path-parser": "1.0.2",
     "percentage-regex": "3.0.0",
-    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-12",
+    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.8",
     "photon": "2.0.0",
     "postcss-cli": "2.5.1",
     "q": "1.0.1",


### PR DESCRIPTION
This brings in upstream changes to node-phone to fix p2UL9c-2Z7-p2

~~Package URI will be updated when Automattic/node-phone#15 is merged and tagged~~

### How to test

1. Using a test account, go to **Me > Security > Two-step Authentication**
2. Try incorrect variations of your phone number (add/subtract a digit, change the first digit etc)
3. Confirm that these variations aren't allowed.
4. Enter your actual phone number and confirm that you are able to proceed.