### PR TITLE
Checkout: Record Apple Pay status when entering checkout

### DIFF
--- a/client/lib/apple-pay/index.js
+++ b/client/lib/apple-pay/index.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+const MERCHANT_IDENTIFIER = 'merchant.com.wordpress';
+
+const recordApplePayStatusEvent = canMakePaymentsWithActiveCard => recordTracksEvent( 'calypso_apple_pay_status', {
+	canMakePaymentsWithActiveCard
+} );
+
+export const recordApplePayStatus = () => dispatch => {
+	if ( ! config.isEnabled( 'apple-pay' ) ) {
+		return;
+	}
+
+	if ( typeof window === 'undefined' || ! window.ApplePaySession ) {
+		dispatch( recordApplePayStatusEvent( false ) );
+		return;
+	}
+
+	window.ApplePaySession.canMakePaymentsWithActiveCard( MERCHANT_IDENTIFIER )
+		.then( canMakePaymentsWithActiveCard => dispatch( recordApplePayStatusEvent( canMakePaymentsWithActiveCard ) ) )
+		.catch( () => dispatch( recordApplePayStatusEvent( false ) ) );
+};

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -40,6 +40,7 @@ import {
 } from 'lib/plans';
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
+import { recordApplePayStatus } from 'lib/apple-pay';
 
 const Checkout = React.createClass( {
 	mixins: [ observe( 'sites', 'productsList' ) ],
@@ -55,6 +56,8 @@ const Checkout = React.createClass( {
 
 	componentWillMount: function() {
 		upgradesActions.resetTransaction();
+
+		this.props.recordApplePayStatus();
 	},
 
 	componentDidMount: function() {
@@ -299,6 +302,7 @@ module.exports = connect(
 	{
 		clearPurchases,
 		clearSitePlans,
-		fetchReceiptCompleted
+		fetchReceiptCompleted,
+		recordApplePayStatus
 	}
 )( Checkout );

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -13,6 +13,7 @@
 	"features": {
 		"ad-tracking": true,
 		"always_use_logout_url": true,
+		"apple-pay": false,
 		"code-splitting": false,
 		"community-translator": true,
 		"desktop": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -13,6 +13,7 @@
 	"features": {
 		"ad-tracking": true,
 		"always_use_logout_url": true,
+		"apple-pay": false,
 		"catch-js-errors": false,
 		"code-splitting": false,
 		"community-translator": true,

--- a/config/development.json
+++ b/config/development.json
@@ -29,6 +29,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"apple-pay": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"css-hot-reload": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -15,6 +15,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"apple-pay": false,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/production.json
+++ b/config/production.json
@@ -13,6 +13,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": true,
+		"apple-pay": false,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -15,6 +15,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"apple-pay": false,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/test.json
+++ b/config/test.json
@@ -29,6 +29,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"apple-pay": true,
 		"catch-js-errors": false,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,6 +15,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"apple-pay": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,


### PR DESCRIPTION
This PR implements a really great idea shared by @p3ob7o. He suggested to add simple Tracks event fired on the checkout page. It's going allow us to collect information how many users (in %) would be able to use `Apple Pay`. Which in return gives an idea of the priority of the project.

This feature is put behind the feature flag named: `apple-pay`. At the moment enabled only for `development`, `test` and `wpcalypso`. I plan to enable it on `stage`, `horizon` and `production` once we confirm it works proper on other envs. There is no plan to enable it for desktop, because it uses `Chromium` as a browser so there is no chance it would work at the moment.

### Testing requirements
1. **macOS 10.12**. Apple Pay JavaScript is supported in Safari. The user must have an iPhone or Apple Watch that can authorize the payment.
2. **iOS 10**. Apple Pay JavaScript is supported on all iOS devices with a Secure Element. It is supported both in Safari and in SFSafariViewController objects.
3. All pages that include Apple Pay must be served over HTTPS - it's not possible to test in locally, but we can use calypso.live!
4. Apple Pay participating banks: [Canada and the United States](https://support.apple.com/pl-pl/ht204916), [Europe](https://support.apple.com/pl-pl/HT206637) and [Asia-Pacific](https://support.apple.com/pl-pl/ht206638) - we need at least one person that has a credit card added to Apple Pay Wallet :) 

### Test 
1. Open Safari browser.
2. Go to https://calypso.live/?branch=add/record-apple-pay-status.
3. Enabled console debugging: ```localStorage.setItem( 'debug', 'calypso:*' );```
4. Refresh the page.
5. Add any upgrade to the cart.
6. You should see the following entries on the JS console:
![screen shot 2016-10-11 at 10 52 58](https://cloud.githubusercontent.com/assets/699132/19264406/f666261e-8fa0-11e6-97e3-84596ed2df6c.png)
7. If you have a credit card added to your Apple Pay Wallet, then you should see `canMakePaymentsWithActiveCard` property set to true in the `calypso_apple_pay_status` event.
