### PR TITLE
Revert "Editor: Make the AddTerm Component more reusable (#8588)"

### DIFF
--- a/client/post-editor/editor-term-selector/index.jsx
+++ b/client/post-editor/editor-term-selector/index.jsx
@@ -10,7 +10,7 @@ import { cloneDeep, findIndex, map, toArray } from 'lodash';
  */
 import TermTreeSelector from 'my-sites/term-tree-selector';
 import AddTerm from 'my-sites/term-tree-selector/add-term';
-import { editPost, addTermForPost } from 'state/posts/actions';
+import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
@@ -29,11 +29,6 @@ class EditorTermSelector extends Component {
 	constructor( props ) {
 		super( props );
 		this.boundOnTermsChange = this.onTermsChange.bind( this );
-	}
-
-	onAddTerm = ( term ) => {
-		const { postId, taxonomyName, siteId } = this.props;
-		this.props.addTermForPost( siteId, taxonomyName, term, postId );
 	}
 
 	onTermsChange( selectedTerm ) {
@@ -63,7 +58,7 @@ class EditorTermSelector extends Component {
 	}
 
 	render() {
-		const { postType, siteId, taxonomyName, canEditTerms } = this.props;
+		const { postType, postId, siteId, taxonomyName, canEditTerms } = this.props;
 
 		return (
 			<div>
@@ -75,12 +70,7 @@ class EditorTermSelector extends Component {
 					siteId={ siteId }
 					multiple={ true }
 				/>
-				{ canEditTerms &&
-					<AddTerm
-						taxonomy={ taxonomyName }
-						postType={ postType }
-						onSuccess={ this.onAddTerm } />
-				}
+				{ canEditTerms && <AddTerm taxonomy={ taxonomyName } postType={ postType } postId={ postId } /> }
 			</div>
 		);
 	}
@@ -99,5 +89,5 @@ export default connect(
 			postId
 		};
 	},
-	{ editPost, addTermForPost }
+	{ editPost }
 )( EditorTermSelector );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -8,6 +8,7 @@ import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
  * Internal dependencies
  */
 import noticesMiddleware from './notices/middleware';
+import postsEditMiddleware from './posts/middleware';
 import application from './application/reducer';
 import comments from './comments/reducer';
 import componentsUsageStats from './components-usage-stats/reducer';
@@ -93,7 +94,7 @@ export const reducer = combineReducers( {
 	wordads
 } );
 
-const middleware = [ thunkMiddleware, noticesMiddleware ];
+const middleware = [ thunkMiddleware, noticesMiddleware, postsEditMiddleware ];
 
 if ( typeof window === 'object' ) {
 	// Browser-specific middlewares

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -1,14 +1,10 @@
 /**
- * External dependencies
- */
-import { isNumber, toArray } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
+import { extendAction } from 'state/utils';
 import { normalizePostForApi } from './utils';
-import { getEditedPost } from 'state/posts/selectors';
+import { addTerm } from 'state/terms/actions';
 import {
 	POST_DELETE,
 	POST_DELETE_SUCCESS,
@@ -301,7 +297,9 @@ export function restorePost( siteId, postId ) {
 }
 
 /**
- * Returns an action thunk which, when dispatched, adds a term to the current edited post
+ * Returns an action thunk which, when dispatched, triggers a network request
+ * to create a new term. All actions dispatched by the thunk will include meta
+ * to associate it with the specified post ID.
  *
  * @param  {Number}   siteId   Site ID
  * @param  {String}   taxonomy Taxonomy Slug
@@ -310,25 +308,5 @@ export function restorePost( siteId, postId ) {
  * @return {Function}          Action thunk
  */
 export function addTermForPost( siteId, taxonomy, term, postId ) {
-	return ( dispatch, getState ) => {
-		const state = getState();
-		const post = getEditedPost( state, siteId, postId );
-
-		// if there is no post, no term, or term is temporary, bail
-		if ( ! post || ! term || ! isNumber( term.ID ) ) {
-			return;
-		}
-
-		const postTerms = post.terms || {};
-
-		// ensure we have an array since API returns an object
-		const taxonomyTerms = toArray( postTerms[ taxonomy ] );
-		taxonomyTerms.push( term );
-
-		dispatch( editPost( siteId, postId, {
-			terms: {
-				[ taxonomy ]: taxonomyTerms
-			}
-		} ) );
-	};
+	return extendAction( addTerm( siteId, taxonomy, term ), { postId } );
 }

--- a/client/state/posts/middleware.js
+++ b/client/state/posts/middleware.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { isNumber, toArray } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { TERMS_RECEIVE } from 'state/action-types';
+import { getEditedPost } from 'state/posts/selectors';
+import { editPost } from 'state/posts/actions';
+
+/**
+ * Dispatches editPost when a new term has been added
+ * that also has a postId on the action
+ *
+ * @param  {Function} dispatch  Dispatch method
+ * @param  {Object}   state     Global state tree
+ * @param  {Object}   action    Action object
+ */
+export function onTermsReceive( dispatch, state, action ) {
+	const { postId, taxonomy, terms, siteId } = action;
+	const post = getEditedPost( state, siteId, postId );
+	const newTerm = terms[ 0 ];
+
+	// if there is no post, no term, or term is temporary, bail
+	if ( ! post || ! newTerm || ! isNumber( newTerm.ID ) ) {
+		return;
+	}
+
+	const postTerms = post.terms || {};
+
+	// ensure we have an array since API returns an object
+	const taxonomyTerms = toArray( postTerms[ taxonomy ] );
+	taxonomyTerms.push( newTerm );
+
+	dispatch( editPost( siteId, postId, {
+		terms: {
+			[ taxonomy ]: taxonomyTerms
+		}
+	} ) );
+}
+
+export default ( { dispatch, getState } ) => ( next ) => ( action ) => {
+	if ( TERMS_RECEIVE === action.type && action.hasOwnProperty( 'postId' ) ) {
+		onTermsReceive( dispatch, getState(), action );
+	}
+	return next( action );
+};

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -7,7 +7,6 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import PostQueryManager from 'lib/query-manager/post';
 import {
 	POST_DELETE,
 	POST_DELETE_SUCCESS,
@@ -26,7 +25,8 @@ import {
 	POSTS_RECEIVE,
 	POSTS_REQUEST,
 	POSTS_REQUEST_SUCCESS,
-	POSTS_REQUEST_FAILURE
+	POSTS_REQUEST_FAILURE,
+	TERMS_RECEIVE
 } from 'state/action-types';
 import {
 	receivePost,
@@ -544,58 +544,31 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'addTermForPost()', () => {
-		const postObject = {
-			ID: 841,
-			site_ID: 2916284,
-			global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-			title: 'Hello World'
-		};
-		const getState = () => {
-			return {
-				posts: {
-					items: {
-						'3d097cb7c5473c169bba0eb8e3c6cb64': [ 2916284, 841 ]
-					},
-					queries: {
-						2916284: new PostQueryManager( {
-							items: { 841: postObject }
-						} )
-					},
-					edits: {}
-				}
-			};
-		};
+		useNock( ( nock ) => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.post( '/rest/v1.1/sites/2916284/taxonomies/jetpack-portfolio/terms/new' )
+				.reply( 200, {
+					ID: 123,
+					name: 'ribs',
+					description: ''
+				} );
+		} );
 
-		it( 'should dispatch a EDIT_POST event with the new term', () => {
-			addTermForPost( 2916284, 'jetpack-portfolio', { ID: 123, name: 'ribs' }, 841 )( spy, getState );
-			expect( spy ).to.have.been.calledWith( {
-				post: {
-					terms: {
-						'jetpack-portfolio': [ {
-							ID: 123,
-							name: 'ribs'
-						} ]
-					}
-				},
-				postId: 841,
-				siteId: 2916284,
-				type: POST_EDIT
+		it( 'should dispatch a TERMS_RECEIVE event on success with post meta', () => {
+			return addTermForPost( 2916284, 'jetpack-portfolio', { name: 'ribs' }, 13640 )( spy ).then( () => {
+				expect( spy ).to.have.been.calledWith( {
+					type: TERMS_RECEIVE,
+					siteId: 2916284,
+					taxonomy: 'jetpack-portfolio',
+					terms: [ {
+						ID: 123,
+						name: 'ribs',
+						description: ''
+					} ],
+					postId: 13640
+				} );
 			} );
-		} );
-
-		it( 'should not dispatch anything if no post', () => {
-			addTermForPost( 2916284, 'jetpack-portfolio', { ID: 123, name: 'ribs' }, 3434 )( spy, getState );
-			expect( spy ).not.to.have.been.called;
-		} );
-
-		it( 'should not dispatch anything if no term', () => {
-			addTermForPost( 2916284, 'jetpack-portfolio', null, 841 )( spy, getState );
-			expect( spy ).not.to.have.been.called;
-		} );
-
-		it( 'should not dispatch anything if the term is temporary', () => {
-			addTermForPost( 2916284, 'jetpack-portfolio', { id: 'temporary' }, 841 )( spy, getState );
-			expect( spy ).not.to.have.been.called;
 		} );
 	} );
 } );

--- a/client/state/posts/test/middleware.js
+++ b/client/state/posts/test/middleware.js
@@ -1,0 +1,161 @@
+/**
+ * External dependencies
+ */
+import sinon from 'sinon';
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import {
+	POST_EDIT
+} from 'state/action-types';
+import { onTermsReceive } from '../middleware';
+import PostQueryManager from 'lib/query-manager/post';
+
+describe( 'middleware', () => {
+	const spy = sinon.spy();
+
+	beforeEach( () => {
+		spy.reset();
+	} );
+
+	describe( 'onTermsReceive()', () => {
+		it( 'postEdit should not dispatch when no matching post exists', () => {
+			const action = {
+				site: 2916284,
+				taxonomy: 'category',
+				postId: 111,
+				terms: [ {
+					ID: 777,
+					name: 'chicken'
+				} ]
+			};
+			onTermsReceive( spy, { posts: { queries: {}, items: {}, edits: {} } }, action );
+			expect( spy ).to.not.have.been.called;
+		} );
+
+		it( 'should not dispatch a postEdit when a temporary term is added', () => {
+			const action = {
+				siteId: 2916284,
+				taxonomy: 'category',
+				postId: 841,
+				terms: [ {
+					ID: 'temporary1',
+					name: 'meat'
+				} ]
+			};
+
+			onTermsReceive( spy, { posts: { queries: {}, items: {}, edits: {} } }, action );
+			expect( spy ).to.not.have.been.called;
+		} );
+
+		it( 'should dispatch a postEdit when a post exists', () => {
+			const action = {
+				siteId: 2916284,
+				taxonomy: 'category',
+				postId: 841,
+				terms: [ {
+					ID: 777,
+					name: 'meat'
+				} ]
+			};
+
+			const postObject = {
+				ID: 841,
+				site_ID: 2916284,
+				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+				title: 'Ribs &amp; Chicken'
+			};
+
+			const state = deepFreeze( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': [ 2916284, 841 ]
+					},
+					queries: {
+						2916284: new PostQueryManager( {
+							items: { 841: postObject }
+						} )
+					},
+					edits: {}
+				}
+			} );
+
+			onTermsReceive( spy, state, action );
+			expect( spy ).to.have.been.calledWith( {
+				type: POST_EDIT,
+				post: {
+					terms: {
+						category: [ {
+							ID: 777,
+							name: 'meat'
+						} ]
+					}
+				},
+				siteId: 2916284,
+				postId: 841
+			} );
+		} );
+
+		it( 'should dispatch a postEdit with accumulated terms by taxonomy', () => {
+			const action = {
+				siteId: 2916284,
+				taxonomy: 'category',
+				postId: 841,
+				terms: [ {
+					ID: 790,
+					name: 'yummy'
+				} ]
+			};
+
+			const postObject = {
+				ID: 841,
+				site_ID: 2916284,
+				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+				title: 'Ribs &amp; Chicken',
+				terms: {
+					category: {
+						meat: {
+							ID: 777,
+							name: 'meat'
+						}
+					}
+				}
+			};
+
+			const state = deepFreeze( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': [ 2916284, 841 ]
+					},
+					queries: {
+						2916284: new PostQueryManager( {
+							items: { 841: postObject }
+						} )
+					},
+					edits: {}
+				}
+			} );
+
+			onTermsReceive( spy, state, action );
+			expect( spy ).to.have.been.calledWith( {
+				type: POST_EDIT,
+				post: {
+					terms: {
+						category: [ {
+							ID: 777,
+							name: 'meat'
+						}, {
+							ID: 790,
+							name: 'yummy'
+						} ]
+					}
+				},
+				siteId: 2916284,
+				postId: 841
+			} );
+		} );
+	} );
+} );

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -34,15 +34,9 @@ export function addTerm( siteId, taxonomy, term ) {
 		} ) );
 
 		return wpcom.site( siteId ).taxonomy( taxonomy ).term().add( term ).then(
-			( data ) => {
-				dispatch( receiveTerm( siteId, taxonomy, data ) );
-				return data;
-			},
+			( data ) => dispatch( receiveTerm( siteId, taxonomy, data ) ),
 			() => Promise.resolve() // Silently ignore failure so we can proceed to remove temporary
-		).then( data => {
-			dispatch( removeTerm( siteId, taxonomy, temporaryId ) );
-			return data;
-		} );
+		).then( () => dispatch( removeTerm( siteId, taxonomy, temporaryId ) ) );
 	};
 }
 


### PR DESCRIPTION
A user noticed "Can not read hierarchical of null" error when loading the editor

This reverts commit 7d6f7a09d85793e2bccd1abf7a1c4a48bfa6081d.
![screen shot 2016-10-11 at 4 49 37 pm](https://cloud.githubusercontent.com/assets/272444/19266518/c70fcff4-8fa1-11e6-96b2-c9058a894d2e.png)

I can not reproduce on my side, but I'm reverting and I'll check later why this happens.