### PR TITLE
Components: Add site selector "Add Site" popover menu with Jetpack site support

### DIFF
--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -79,10 +79,10 @@ const SiteSelectorAddSite = React.createClass( {
 						context={ this.refs && this.refs.popoverMenuTarget }
 						>
 						<PopoverMenuItem href={ this.getAddNewSiteUrl() } onClick={ this.recordPopoverAddNewSite }>
-							{ this.translate( 'Start a new WordPress.com site' ) }
+							{ this.translate( 'New WordPress.com site' ) }
 						</PopoverMenuItem>
 						<PopoverMenuItem href="/jetpack/connect" onClick={ this.recordPopoverAddJetpackSite }>
-							{ this.translate( 'Add a self-hosted WordPress site' ) }
+							{ this.translate( 'Self-hosted WordPress site' ) }
 						</PopoverMenuItem>
 					</PopoverMenu>
 

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -14,6 +14,7 @@ import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
+import { abtest } from 'lib/abtest';
 
 const SiteSelectorAddSite = React.createClass( {
 	getInitialState() {
@@ -92,7 +93,11 @@ const SiteSelectorAddSite = React.createClass( {
 	},
 
 	render() {
-		return this.renderButtonWithPopover();
+		if ( abtest( 'siteSelectorAddSitePopover' ) === 'showPopover' ) {
+			return this.renderButtonWithPopover();
+		}
+
+		return this.renderButton();
 	}
 } );
 

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -14,7 +14,9 @@ import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
-import { abtest } from 'lib/abtest';
+import sitesFactory from 'lib/sites-list';
+
+const sites = sitesFactory();
 
 const SiteSelectorAddSite = React.createClass( {
 	getInitialState() {
@@ -95,7 +97,7 @@ const SiteSelectorAddSite = React.createClass( {
 	},
 
 	render() {
-		if ( abtest( 'siteSelectorAddSitePopover' ) === 'showPopover' ) {
+		if ( sites.getJetpack().length ) {
 			return this.renderButtonWithPopover();
 		}
 

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import { recordTracksEvent } from 'state/analytics/actions';
+import config from 'config';
+
+const SiteSelectorAddSite = React.createClass( {
+	recordAddNewSite() {
+		this.props.recordTracksEvent( 'calypso_add_new_wordpress_click' );
+	},
+
+	renderButton() {
+		return (
+			<span className="site-selector__add-new-site">
+				<Button compact borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' } onClick={ this.recordAddNewSite }>
+					<Gridicon icon="add-outline" /> { this.translate( 'Add New Site' ) }
+				</Button>
+			</span>
+		);
+	},
+
+	render() {
+		return this.renderButton();
+	}
+} );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( {
+		recordTracksEvent
+	}, dispatch )
+)( SiteSelectorAddSite );

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -10,26 +10,89 @@ import { bindActionCreators } from 'redux';
  */
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
+import PopoverMenu from 'components/popover/menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
 
 const SiteSelectorAddSite = React.createClass( {
+	getInitialState() {
+		return {
+			showPopoverMenu: false,
+			popoverPosition: 'top'
+		};
+	},
+
+	getAddNewSiteUrl() {
+		return config( 'signup_url' ) + '?ref=calypso-selector';
+	},
+
+	handleShowPopover( isShowing ) {
+		const action = isShowing ? 'show' : 'hide';
+
+		this.setState( {
+			showPopoverMenu: isShowing
+		} );
+
+		this.props.recordTracksEvent( 'calypso_add_site_popover', { action } );
+	},
+
+	onPopoverButtonClick() {
+		this.handleShowPopover( ! this.state.showPopoverMenu );
+	},
+
+	onClosePopover() {
+		this.handleShowPopover( false );
+	},
+
 	recordAddNewSite() {
 		this.props.recordTracksEvent( 'calypso_add_new_wordpress_click' );
+	},
+
+	recordPopoverAddNewSite() {
+		this.props.recordTracksEvent( 'calypso_add_new_wordpress_popover_click' );
+	},
+
+	recordPopoverAddJetpackSite() {
+		this.props.recordTracksEvent( 'calypso_add_jetpack_site_popover_click' );
 	},
 
 	renderButton() {
 		return (
 			<span className="site-selector__add-new-site">
-				<Button compact borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' } onClick={ this.recordAddNewSite }>
+				<Button compact borderless href={ this.getAddNewSiteUrl() } onClick={ this.recordAddNewSite }>
 					<Gridicon icon="add-outline" /> { this.translate( 'Add New Site' ) }
 				</Button>
 			</span>
 		);
 	},
 
+	renderButtonWithPopover() {
+		return (
+			<span className="site-selector__add-new-site">
+				<PopoverMenu
+					isVisible={ this.state.showPopoverMenu }
+					onClose={ this.onClosePopover }
+					position={ this.state.popoverPosition }
+					context={ this.refs && this.refs.popoverMenuButton }
+					>
+					<PopoverMenuItem href={ this.getAddNewSiteUrl() } onClick={ this.recordPopoverAddNewSite }>
+						{ this.translate( 'Start a new WordPress.com site' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem href="/jetpack/connect" onClick={ this.recordPopoverAddJetpackSite }>
+						{ this.translate( 'Add a self-hosted WordPress site' ) }
+					</PopoverMenuItem>
+				</PopoverMenu>
+
+				<Button compact borderless onClick={ this.onPopoverButtonClick } ref="popoverMenuButton">
+					<Gridicon icon="add-outline" /> { this.translate( 'Add WordPress Site' ) }
+				</Button>
+			</span>
+		);
+	},
+
 	render() {
-		return this.renderButton();
+		return this.renderButtonWithPopover();
 	}
 } );
 

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -87,7 +87,7 @@ const SiteSelectorAddSite = React.createClass( {
 					</PopoverMenu>
 
 					<Button compact borderless onClick={ this.onPopoverButtonClick }>
-						<Gridicon icon="add-outline" /> { this.translate( 'Add WordPress Site' ) }
+						<Gridicon icon="add-outline" /> { this.translate( 'Add Site' ) }
 					</Button>
 				</span>
 			</span>

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -71,23 +71,25 @@ const SiteSelectorAddSite = React.createClass( {
 	renderButtonWithPopover() {
 		return (
 			<span className="site-selector__add-new-site">
-				<PopoverMenu
-					isVisible={ this.state.showPopoverMenu }
-					onClose={ this.onClosePopover }
-					position={ this.state.popoverPosition }
-					context={ this.refs && this.refs.popoverMenuButton }
-					>
-					<PopoverMenuItem href={ this.getAddNewSiteUrl() } onClick={ this.recordPopoverAddNewSite }>
-						{ this.translate( 'Start a new WordPress.com site' ) }
-					</PopoverMenuItem>
-					<PopoverMenuItem href="/jetpack/connect" onClick={ this.recordPopoverAddJetpackSite }>
-						{ this.translate( 'Add a self-hosted WordPress site' ) }
-					</PopoverMenuItem>
-				</PopoverMenu>
+				<span className="site-selector__popover-target" ref="popoverMenuTarget">
+					<PopoverMenu
+						isVisible={ this.state.showPopoverMenu }
+						onClose={ this.onClosePopover }
+						position={ this.state.popoverPosition }
+						context={ this.refs && this.refs.popoverMenuTarget }
+						>
+						<PopoverMenuItem href={ this.getAddNewSiteUrl() } onClick={ this.recordPopoverAddNewSite }>
+							{ this.translate( 'Start a new WordPress.com site' ) }
+						</PopoverMenuItem>
+						<PopoverMenuItem href="/jetpack/connect" onClick={ this.recordPopoverAddJetpackSite }>
+							{ this.translate( 'Add a self-hosted WordPress site' ) }
+						</PopoverMenuItem>
+					</PopoverMenu>
 
-				<Button compact borderless onClick={ this.onPopoverButtonClick } ref="popoverMenuButton">
-					<Gridicon icon="add-outline" /> { this.translate( 'Add WordPress Site' ) }
-				</Button>
+					<Button compact borderless onClick={ this.onPopoverButtonClick }>
+						<Gridicon icon="add-outline" /> { this.translate( 'Add WordPress Site' ) }
+					</Button>
+				</span>
 			</span>
 		);
 	},

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -63,7 +63,7 @@ const SiteSelectorAddSite = React.createClass( {
 	renderButton() {
 		return (
 			<span className="site-selector__add-new-site">
-				<Button compact borderless href={ this.getAddNewSiteUrl() } onClick={ this.recordAddNewSite }>
+				<Button borderless href={ this.getAddNewSiteUrl() } onClick={ this.recordAddNewSite }>
 					<Gridicon icon="add-outline" /> { this.translate( 'Add New Site' ) }
 				</Button>
 			</span>
@@ -72,26 +72,24 @@ const SiteSelectorAddSite = React.createClass( {
 
 	renderButtonWithPopover() {
 		return (
-			<span className="site-selector__add-new-site">
-				<span className="site-selector__popover-target" ref="popoverMenuTarget">
-					<PopoverMenu
-						isVisible={ this.state.showPopoverMenu }
-						onClose={ this.onClosePopover }
-						position={ this.state.popoverPosition }
-						context={ this.refs && this.refs.popoverMenuTarget }
-						>
-						<PopoverMenuItem href={ this.getAddNewSiteUrl() } onClick={ this.recordPopoverAddNewSite }>
-							{ this.translate( 'New WordPress.com site' ) }
-						</PopoverMenuItem>
-						<PopoverMenuItem href="/jetpack/connect" onClick={ this.recordPopoverAddJetpackSite }>
-							{ this.translate( 'Self-hosted WordPress site' ) }
-						</PopoverMenuItem>
-					</PopoverMenu>
+			<span className="site-selector__add-new-site" ref="popoverMenuTarget">
+				<PopoverMenu
+					isVisible={ this.state.showPopoverMenu }
+					onClose={ this.onClosePopover }
+					position={ this.state.popoverPosition }
+					context={ this.refs && this.refs.popoverMenuTarget }
+					>
+					<PopoverMenuItem href={ this.getAddNewSiteUrl() } onClick={ this.recordPopoverAddNewSite }>
+						{ this.translate( 'New WordPress.com site' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem href="/jetpack/connect" onClick={ this.recordPopoverAddJetpackSite }>
+						{ this.translate( 'Self-hosted WordPress site' ) }
+					</PopoverMenuItem>
+				</PopoverMenu>
 
-					<Button compact borderless onClick={ this.onPopoverButtonClick }>
-						<Gridicon icon="add-outline" /> { this.translate( 'Add Site' ) }
-					</Button>
-				</span>
+				<Button borderless onClick={ this.onPopoverButtonClick }>
+					<Gridicon icon="add-outline" /> { this.translate( 'Add Site' ) }
+				</Button>
 			</span>
 		);
 	},

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,17 +19,26 @@ import sitesFactory from 'lib/sites-list';
 
 const sites = sitesFactory();
 
-const SiteSelectorAddSite = React.createClass( {
-	getInitialState() {
-		return {
+class SiteSelectorAddSite extends Component {
+	constructor() {
+		super();
+
+		this.state = {
 			showPopoverMenu: false,
 			popoverPosition: 'top'
 		};
-	},
+
+		this.handleShowPopover = this.handleShowPopover.bind( this );
+		this.onPopoverButtonClick = this.onPopoverButtonClick.bind( this );
+		this.onClosePopover = this.onClosePopover.bind( this );
+		this.recordAddNewSite = this.recordAddNewSite.bind( this );
+		this.recordPopoverAddNewSite = this.recordPopoverAddNewSite.bind( this );
+		this.recordPopoverAddJetpackSite = this.recordPopoverAddJetpackSite.bind( this );
+	}
 
 	getAddNewSiteUrl() {
 		return config( 'signup_url' ) + '?ref=calypso-selector';
-	},
+	}
 
 	handleShowPopover( isShowing ) {
 		const action = isShowing ? 'show' : 'hide';
@@ -38,39 +48,41 @@ const SiteSelectorAddSite = React.createClass( {
 		} );
 
 		this.props.recordTracksEvent( 'calypso_add_site_popover', { action } );
-	},
+	}
 
 	onPopoverButtonClick() {
 		this.handleShowPopover( ! this.state.showPopoverMenu );
-	},
+	}
 
 	onClosePopover() {
 		this.handleShowPopover( false );
-	},
+	}
 
 	recordAddNewSite() {
 		this.props.recordTracksEvent( 'calypso_add_new_wordpress_click' );
-	},
+	}
 
 	recordPopoverAddNewSite() {
 		this.props.recordTracksEvent( 'calypso_add_new_wordpress_popover_click' );
-	},
+	}
 
 	recordPopoverAddJetpackSite() {
 		this.props.recordTracksEvent( 'calypso_add_jetpack_site_popover_click' );
-	},
+	}
 
 	renderButton() {
+		const { translate } = this.props;
 		return (
 			<span className="site-selector__add-new-site">
 				<Button borderless href={ this.getAddNewSiteUrl() } onClick={ this.recordAddNewSite }>
-					<Gridicon icon="add-outline" /> { this.translate( 'Add New Site' ) }
+					<Gridicon icon="add-outline" /> { translate( 'Add New Site' ) }
 				</Button>
 			</span>
 		);
-	},
+	}
 
 	renderButtonWithPopover() {
+		const { translate } = this.props;
 		return (
 			<span className="site-selector__add-new-site" ref="popoverMenuTarget">
 				<PopoverMenu
@@ -80,19 +92,19 @@ const SiteSelectorAddSite = React.createClass( {
 					context={ this.refs && this.refs.popoverMenuTarget }
 					>
 					<PopoverMenuItem href={ this.getAddNewSiteUrl() } onClick={ this.recordPopoverAddNewSite }>
-						{ this.translate( 'New WordPress.com site' ) }
+						{ translate( 'New WordPress.com site' ) }
 					</PopoverMenuItem>
 					<PopoverMenuItem href="/jetpack/connect" onClick={ this.recordPopoverAddJetpackSite }>
-						{ this.translate( 'Self-hosted WordPress site' ) }
+						{ translate( 'Self-hosted WordPress site' ) }
 					</PopoverMenuItem>
 				</PopoverMenu>
 
 				<Button borderless onClick={ this.onPopoverButtonClick }>
-					<Gridicon icon="add-outline" /> { this.translate( 'Add Site' ) }
+					<Gridicon icon="add-outline" /> { translate( 'Add Site' ) }
 				</Button>
 			</span>
 		);
-	},
+	}
 
 	render() {
 		if ( sites.getJetpack().length ) {
@@ -101,11 +113,11 @@ const SiteSelectorAddSite = React.createClass( {
 
 		return this.renderButton();
 	}
-} );
+}
 
 export default connect(
 	null,
 	dispatch => bindActionCreators( {
 		recordTracksEvent
 	}, dispatch )
-)( SiteSelectorAddSite );
+)( localize( SiteSelectorAddSite ) );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -17,13 +17,10 @@ import { getPreference } from 'state/preferences/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import observe from 'lib/mixins/data-observe';
 import AllSites from 'my-sites/all-sites';
-import analytics from 'lib/analytics';
-import Button from 'components/button';
-import Gridicon from 'components/gridicon';
 import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import Search from 'components/search';
-import config from 'config';
+import SiteSelectorAddSite from './add-site';
 
 const noop = () => {};
 const ALL_SITES = 'ALL_SITES';
@@ -236,20 +233,6 @@ const SiteSelector = React.createClass( {
 		}
 	},
 
-	recordAddNewSite() {
-		analytics.tracks.recordEvent( 'calypso_add_new_wordpress_click' );
-	},
-
-	renderNewSiteButton() {
-		return (
-			<span className="site-selector__add-new-site">
-				<Button borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' } onClick={ this.recordAddNewSite }>
-					<Gridicon icon="add-outline" /> { this.translate( 'Add New Site' ) }
-				</Button>
-			</span>
-		);
-	},
-
 	getSiteBasePath( site ) {
 		let siteBasePath = this.props.siteBasePath;
 		const postsBase = ( site.jetpack || site.single_user_site ) ? '/posts' : '/posts/my';
@@ -443,7 +426,7 @@ const SiteSelector = React.createClass( {
 						</span>
 					}
 				</div>
-				{ this.props.showAddNewSite && this.renderNewSiteButton() }
+				{ this.props.showAddNewSite && <SiteSelectorAddSite /> }
 			</div>
 		);
 	}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -135,6 +135,9 @@
 		margin-top: 16px;
 	}
 
+	.site-selector__popover-target {
+		display: block;
+	}
 }
 
 .site-selector__add-new-site .button {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -134,10 +134,6 @@
 	@include breakpoint( "<660px" ) {
 		margin-top: 16px;
 	}
-
-	.site-selector__popover-target {
-		display: block;
-	}
 }
 
 .site-selector__add-new-site .button {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -107,15 +107,6 @@ module.exports = {
 		defaultVariation: 'hideSiteTitleStep',
 		allowExistingUsers: false
 	},
-	siteSelectorAddSitePopover: {
-		datestamp: '20161011',
-		variations: {
-			showPopover: 10,
-			hidePopover: 90
-		},
-		defaultVariation: 'hidePopover',
-		allowExistingUsers: true
-	},
 	domainToPersonalPlanNudge2: {
 		datestamp: '20161018',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -107,6 +107,15 @@ module.exports = {
 		defaultVariation: 'hideSiteTitleStep',
 		allowExistingUsers: false
 	},
+	siteSelectorAddSitePopover: {
+		datestamp: '20161011',
+		variations: {
+			showPopover: 10,
+			hidePopover: 90
+		},
+		defaultVariation: 'hidePopover',
+		allowExistingUsers: true
+	},
 	domainToPersonalPlanNudge2: {
 		datestamp: '20161018',
 		variations: {


### PR DESCRIPTION
### Summary

This PR fixes #6400, where it was suggested that we introduce a popover menu to the **Add New WordPress** button in the bottom of the site selector. The main purpose of this popover menu is to introduce another way to reach the self-hosted site connection flow (Jetpack Connect).

### What this PR does

1. Moves the add site button to a separate component, paving the way for the popover menu.
2. Introduces the popover menu to the new component, hooks the JPC functionality and adds some  events that allow granular tracking of the new feature.
3. Adds an A/B test that will show the new popover to only 10% of all users (cc @rickybanister for double-checking if this percentage makes sense for this feature).

### Preview

Before:
![](https://cldup.com/MkKzRCxv73.png)

After:
![](https://cldup.com/7Fv2-ONDVm-2000x2000.png)

### Testing instructions

1. Checkout this branch.
2. Click on "My Sites".
3. Click on "Switch Site".
4. Verify the old "Add New WordPress" button looks works just like before. 
5. Verify the new button (currently saying "Add WordPress Site") opens a popover on click with 2 options, and they work as expected:
 * __Start a new WordPress.com site__ - should lead to `/start` or `/start/survey`;
 * __Add a self-hosted WordPress site__ - should lead to `/jetpack/connect`.

### Testing notes

1. To force the A/B test to use the old button, you can type the following in your console: `localStorage.setItem('ABTests','{"siteSelectorAddSitePopover_20161011":"hidePopover"}')`

2. To force the A/B test to use the new button with popover, you can type this in the console: `localStorage.setItem('ABTests','{"siteSelectorAddSitePopover_20161011":"showPopover"}')`

### Review

/cc: 
@rickybanister, @keoshi, @meremagee for design and wording review;
@johnHackworth, @mtias for code review.