### PR TITLE
Themes: Prefix ambiguous filter terms with taxonomy

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -51,6 +51,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import { decodeEntities } from 'lib/formatting';
 import { getThemeDetails } from 'state/themes/theme-details/selectors';
+import { isValidTerm } from 'my-sites/themes/theme-filters';
 
 const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -297,9 +298,10 @@ const ThemeSheet = React.createClass( {
 		const { siteSlug, taxonomies } = this.props;
 		const themeFeatures = taxonomies && taxonomies.theme_feature instanceof Array
 		? taxonomies.theme_feature.map( function( item ) {
+			const term = isValidTerm( item.slug ) ? item.slug : `feature:${ item.slug }`;
 			return (
 				<li key={ 'theme-features-item-' + item.slug }>
-					<a href={ `/design/filter/${ item.slug }/${ siteSlug || '' }` }>{ item.name }</a>
+					<a href={ `/design/filter/${ term }/${ siteSlug || '' }` }>{ item.name }</a>
 				</li>
 			);
 		} ) : [];

--- a/client/my-sites/themes/test/theme-filters.js
+++ b/client/my-sites/themes/test/theme-filters.js
@@ -15,6 +15,8 @@ import {
 	getSortedFilterTerms,
 	stripFilters,
 	sortFilterTerms,
+	filterIsValid,
+	isValidTerm,
 } from '../theme-filters.js';
 
 describe( 'theme-filters', () => {
@@ -79,6 +81,35 @@ describe( 'theme-filters', () => {
 		it( 'should still strip invalid filters', () => {
 			const remaining = stripFilters( 'color:blue twenty color:lazer-puce' );
 			assert.equal( remaining, 'twenty' );
+		} );
+	} );
+
+	describe( 'filterIsValid', () => {
+		it( 'should return true for a valid filter string', () => {
+			assert.isTrue( filterIsValid( 'subject:music' ) );
+		} );
+
+		it( 'should return false for an invalid filter string', () => {
+			assert.isFalse( filterIsValid( 'subject' ) );
+			assert.isFalse( filterIsValid( 'music' ) );
+			assert.isFalse( filterIsValid( '' ) );
+			assert.isFalse( filterIsValid( 'subject:' ) );
+			assert.isFalse( filterIsValid( ':music' ) );
+			assert.isFalse( filterIsValid( ':' ) );
+		} );
+	} );
+
+	describe( 'isValidTerm', () => {
+		it( 'should return true for a valid term string', () => {
+			assert.isTrue( isValidTerm( 'music' ) );
+			assert.isTrue( isValidTerm( 'feature:video' ) );
+		} );
+
+		it( 'should return false for an invalid filter string', () => {
+			assert.isFalse( isValidTerm( 'video' ) );
+			assert.isFalse( isValidTerm( '' ) );
+			assert.isFalse( isValidTerm( ':video' ) );
+			assert.isFalse( isValidTerm( ':' ) );
 		} );
 	} );
 } );

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -190,7 +190,7 @@ function getTermTable() {
 		termTable = {};
 		forIn( taxonomies, ( terms, taxonomy ) => {
 			terms.forEach( ( term ) => {
-				const key = isTermAmbiguous( term ) ? `${ taxonomy }__${ term }` : term;
+				const key = isTermAmbiguous( term ) ? `${ taxonomy }:${ term }` : term;
 				termTable[ key ] = taxonomy;
 			} );
 		} );
@@ -231,13 +231,13 @@ function splitFilter( filter, group ) {
 function getTerm( filter ) {
 	const term = splitFilter( filter, FILTER_TERM_GROUP );
 	if ( isTermAmbiguous( term ) ) {
-		return `${ getTaxonomy( filter ) }__${ term }`;
+		return `${ getTaxonomy( filter ) }:${ term }`;
 	}
 	return term;
 }
 
 function stripTermPrefix( term ) {
-	return term.replace( /^\w+__/, '' );
+	return term.replace( /^\w+:/, '' );
 }
 
 // return taxonomy from a taxonomy:term string
@@ -250,7 +250,7 @@ function getTaxonomy( filter ) {
  * in "taxonomy:term" search-box format.
  *
  * Supplied terms that belong to more than one taxonomy must be
- * prefixed with taxonomy: taxonomy__term
+ * prefixed taxonomy:term
  *
  * @param {string} term - the term slug
  * @return {string} - complete taxonomy:term filter, or empty string if term is not valid
@@ -280,8 +280,8 @@ export function filterIsValid( filter ) {
  * Sort is alphabetical on the complete "taxonomy:term" string.
  *
  * Supplied terms that belong to more than one taxonomy must be
- * prefixed with taxonomy: taxonomy__term. Returned terms will
- * keep the prefix.
+ * prefixed taxonomy:term. Returned terms will
+ * keep this prefix.
  *
  * @param {array} terms - Array of term strings
  * @return {array} sorted array
@@ -296,7 +296,7 @@ export function sortFilterTerms( terms ) {
  * terms (which will be ignored) as well as filters.
  *
  * Returned terms that belong to more than one taxonomy will be
- * prefixed with taxonomy: taxonomy__term
+ * prefixed taxonomy:term
  *
  * @param {string} input - the string to parse
  * @return {string} comma-seperated list of valid filters
@@ -328,7 +328,7 @@ export function getSubjects() {
  * Returns true for valid term.
  *
  * Supplied terms that belong to more than one taxonomy must be
- * prefixed with taxonomy: taxonomy__term
+ * prefixed with taxonomy:term
  *
  * @param {string} term - term to validate
  * @return {bool} true if term is valid

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -229,10 +229,9 @@ function splitFilter( filter, group ) {
 
 // return term from a taxonomy:term string
 function getTerm( filter ) {
-	const taxonomy = getTaxonomy( filter );
 	const term = splitFilter( filter, FILTER_TERM_GROUP );
 	if ( isTermAmbiguous( term ) ) {
-		return `${ taxonomy }__${ term }`;
+		return `${ getTaxonomy( filter ) }__${ term }`;
 	}
 	return term;
 }

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
 * Functions for working with theme search filters. The filter syntax is
 * {taxonomy}:{term}


### PR DESCRIPTION
Some theme filter terms, for example _video_, _light_, and _dark_, belong to more than one taxonomy. We can disambiguate these terms by prefixing them with the taxonomy in the URL.

**Before**

![screen shot 2016-10-11 at 16 38 36](https://cloud.githubusercontent.com/assets/7767559/19277367/51fb1a5e-8fd1-11e6-94c4-d9c5c85e2f22.png)

**After**

![screen shot 2016-10-12 at 17 19 25](https://cloud.githubusercontent.com/assets/7767559/19318309/19d5e166-90a0-11e6-96d0-b46af6b9619b.png)


**Todo**
- [x] unit test
- [x] associated API change to handle prefixes

Needs associated endpoint change D3019-code

cc @budzanowski 