### PR TITLE
Make vertical order stick across page lifetime

### DIFF
--- a/client/signup/steps/survey/verticals.js
+++ b/client/signup/steps/survey/verticals.js
@@ -115,11 +115,16 @@ function shuffleVerticals( elements ) {
 	return newVerticals;
 }
 
+let shuffledVerticals = null;
+
 export default {
 	get() {
+		if ( shuffledVerticals ) {
+			return shuffledVerticals;
+		}
 		switch ( abtest( 'signupSurveyStep' ) ) {
-			case 'surveyStepV1': return shuffleVerticals( verticalsV1 );
-			case 'surveyStepV2': return shuffleVerticals( verticalsV2 );
+			case 'surveyStepV1': return shuffledVerticals = shuffleVerticals( verticalsV1 );
+			case 'surveyStepV2': return shuffledVerticals = shuffleVerticals( verticalsV2 );
 			default: throw new Error( 'Unknown variation' );
 		}
 	}


### PR DESCRIPTION
This PR will make it so that the vertical order doesn't change when you go forward/back in the signup flow