### PR TITLE
Plugins redux: Trigger plugin update on site fetch if needed

### DIFF
--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -145,7 +145,9 @@ export function enableAutoupdatePlugin( siteId, plugin ) {
 
 		const successCallback = ( data ) => {
 			dispatch( { ...defaultAction, type: PLUGIN_AUTOUPDATE_ENABLE_REQUEST_SUCCESS, data } );
-			updatePlugin( siteId, plugin )( dispatch );
+			if ( data.update ) {
+				updatePlugin( siteId, data )( dispatch );
+			}
 		};
 
 		const errorCallback = ( error ) => {
@@ -311,6 +313,12 @@ export function fetchPlugins( sites ) {
 			const receivePluginsDispatchSuccess = ( data ) => {
 				dispatch( { ...defaultAction, type: PLUGINS_RECEIVE } );
 				dispatch( { ...defaultAction, type: PLUGINS_REQUEST_SUCCESS, data: data.plugins } );
+
+				data.plugins.map( plugin => {
+					if ( plugin.update && plugin.autoupdate ) {
+						updatePlugin( site.ID, plugin )( dispatch );
+					}
+				} );
 			};
 
 			const receivePluginsDispatchFail = ( error ) => {

--- a/client/state/plugins/installed/test/actions.js
+++ b/client/state/plugins/installed/test/actions.js
@@ -75,7 +75,9 @@ describe( 'actions', () => {
 				.reply( 403, {
 					error: 'unauthorized',
 					message: 'This endpoint is only available for Jetpack powered Sites'
-				} );
+				} )
+				.post( '/rest/v1.1/sites/2916284/plugins/jetpack%2Fjetpack/update' )
+				.reply( 200, jetpackUpdated );
 		} );
 
 		it( 'should dispatch fetch action when triggered', () => {
@@ -115,6 +117,18 @@ describe( 'actions', () => {
 					type: PLUGINS_REQUEST_FAILURE,
 					siteId: 77203074,
 					error: sinon.match( { message: 'This endpoint is only available for Jetpack powered Sites' } )
+				} );
+			} );
+		} );
+
+		it( 'should dispatch plugin update request if any site plugins need updating', () => {
+			const responses = fetchPlugins( [ { ID: 2916284, jetpack: true } ] )( spy );
+			return Promise.all( responses ).then( () => {
+				expect( spy ).to.have.been.calledWith( {
+					type: PLUGIN_UPDATE_REQUEST,
+					action: UPDATE_PLUGIN,
+					siteId: 2916284,
+					pluginId: 'jetpack/jetpack'
 				} );
 			} );
 		} );

--- a/client/state/plugins/installed/test/fixtures/plugins.js
+++ b/client/state/plugins/installed/test/fixtures/plugins.js
@@ -39,7 +39,7 @@ export const jetpack = {
 	author: 'Automattic',
 	author_url: 'http://jetpack.com',
 	network: false,
-	autoupdate: false,
+	autoupdate: true,
 	update: {
 		id: '20101',
 		slug: 'jetpack',


### PR DESCRIPTION
This is a follow-up to #8206 

In the current flux implementation, we update plugins immediately after they're loaded from the API. This was missing from the redux action, so this PR adds it back. [See comment on original PR](https://github.com/Automattic/wp-calypso/pull/8206#issuecomment-249954497).

To test:

- Run action tests: `npm run test-client client/state/plugins/installed/test/actions.js`
- See that the fetch action succeeds on "should dispatch plugin update request if any site plugins need updating"

cc @johnHackworth @tyxla 