### PR TITLE
Editor: Remove excess padding on search input

### DIFF
--- a/client/post-editor/editor-location/style.scss
+++ b/client/post-editor/editor-location/style.scss
@@ -19,10 +19,6 @@
 	height: 40px;
 }
 
-.editor-location__search .search__input {
-	padding: 0 40px 0 40px;
-}
-
 .editor-location__search .search__close-icon {
 	width: 40px;
 }


### PR DESCRIPTION
This is a quick PR that removes some extra padding around the search input for location on the Editor. The input field should now match styling on the rest of the Editor (left aligned). Since the right padding was removed as well, long inputs now fade when they overflow. 

This padding was added as part of 11585-gh-calypso-pre-oss, but I can't exactly figure out what has changed since then.

## To test

Load up this PR and visit the Editor. The search placeholder under More Options -> Location should now be left aligned. For overflow text, the field should use a fade.

## Screenshots

**Current**

<img width="337" alt="screen shot 2016-10-11 at 3 53 13 pm" src="https://cloud.githubusercontent.com/assets/7240478/19290038/dafe27a8-8fca-11e6-937a-7f6b0d0e6c7e.png">

**Updated Placeholder**

![screen shot 2016-10-11 at 3 47 11 pm](https://cloud.githubusercontent.com/assets/7240478/19290046/e4934302-8fca-11e6-8052-6db815b38050.png)

**Updated long input with fade**

![screen shot 2016-10-11 at 3 47 21 pm](https://cloud.githubusercontent.com/assets/7240478/19290073/097f4e22-8fcb-11e6-9690-0d65a3a0edd6.png)

**Updated with result**

![screen shot 2016-10-11 at 3 47 34 pm](https://cloud.githubusercontent.com/assets/7240478/19290054/f4659e06-8fca-11e6-8c1b-1bb89999a1a8.png)



Addresses #8604.