### PR TITLE
Enables the SEO settings tab for Jetpack sites.

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -205,7 +205,8 @@ export const PLANS_LIST = {
 			FEATURE_STANDARD_SECURITY_TOOLS,
 			FEATURE_SITE_STATS,
 			FEATURE_TRAFFIC_TOOLS,
-			FEATURE_MANAGE
+			FEATURE_MANAGE,
+			FEATURE_ADVANCED_SEO
 		],
 		getBillingTimeFrame: () => i18n.translate( 'for life' )
 	},
@@ -226,7 +227,8 @@ export const PLANS_LIST = {
 			FEATURE_AUTOMATED_RESTORES,
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_EMAIL_LIVE_CHAT_SUPPORT
+			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+			FEATURE_ADVANCED_SEO
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
@@ -246,7 +248,8 @@ export const PLANS_LIST = {
 			FEATURE_AUTOMATED_RESTORES,
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_EMAIL_LIVE_CHAT_SUPPORT
+			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+			FEATURE_ADVANCED_SEO
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -268,7 +268,8 @@ export const PLANS_LIST = {
 			FEATURE_EASY_SITE_MIGRATION,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
-			FEATURE_POLLS_PRO
+			FEATURE_POLLS_PRO,
+			FEATURE_ADVANCED_SEO
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 
@@ -291,7 +292,8 @@ export const PLANS_LIST = {
 			FEATURE_EASY_SITE_MIGRATION,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
-			FEATURE_POLLS_PRO
+			FEATURE_POLLS_PRO,
+			FEATURE_ADVANCED_SEO
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	}

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -205,8 +205,7 @@ export const PLANS_LIST = {
 			FEATURE_STANDARD_SECURITY_TOOLS,
 			FEATURE_SITE_STATS,
 			FEATURE_TRAFFIC_TOOLS,
-			FEATURE_MANAGE,
-			FEATURE_ADVANCED_SEO
+			FEATURE_MANAGE
 		],
 		getBillingTimeFrame: () => i18n.translate( 'for life' )
 	},
@@ -227,8 +226,7 @@ export const PLANS_LIST = {
 			FEATURE_AUTOMATED_RESTORES,
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
-			FEATURE_ADVANCED_SEO
+			FEATURE_EMAIL_LIVE_CHAT_SUPPORT
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
@@ -248,8 +246,7 @@ export const PLANS_LIST = {
 			FEATURE_AUTOMATED_RESTORES,
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
-			FEATURE_ADVANCED_SEO
+			FEATURE_EMAIL_LIVE_CHAT_SUPPORT
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -95,7 +95,9 @@ export default React.createClass( {
 							</NavItem>
 					}
 
-					{ config.isEnabled( 'manage/seo' ) &&
+					{
+						( ! site.jetpack && config.isEnabled( 'manage/seo' ) ||
+							site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) ) &&
 						<NavItem
 							path={ `/settings/seo/${ site.slug }` }
 							selected={ section === 'seo' } >

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -97,7 +97,7 @@ export default React.createClass( {
 
 					{
 						( ! site.jetpack && config.isEnabled( 'manage/seo' ) ||
-							site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) ) && site.isModuleActive( 'seo-tools' ) &&
+							site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) && site.isModuleActive( 'seo-tools' ) ) &&
 						<NavItem
 							path={ `/settings/seo/${ site.slug }` }
 							selected={ section === 'seo' } >

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -97,7 +97,7 @@ export default React.createClass( {
 
 					{
 						( ! site.jetpack && config.isEnabled( 'manage/seo' ) ||
-							site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) && site.isModuleActive( 'seo-tools' ) ) &&
+							site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) ) &&
 						<NavItem
 							path={ `/settings/seo/${ site.slug }` }
 							selected={ section === 'seo' } >

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -95,7 +95,7 @@ export default React.createClass( {
 							</NavItem>
 					}
 
-					{ ! site.jetpack && config.isEnabled( 'manage/seo' ) &&
+					{ config.isEnabled( 'manage/seo' ) &&
 						<NavItem
 							path={ `/settings/seo/${ site.slug }` }
 							selected={ section === 'seo' } >

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -97,7 +97,7 @@ export default React.createClass( {
 
 					{
 						( ! site.jetpack && config.isEnabled( 'manage/seo' ) ||
-							site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) ) &&
+							site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) ) && site.isModuleActive( 'seo-tools' ) &&
 						<NavItem
 							path={ `/settings/seo/${ site.slug }` }
 							selected={ section === 'seo' } >

--- a/client/my-sites/site-settings/seo-settings/controller.js
+++ b/client/my-sites/site-settings/seo-settings/controller.js
@@ -9,6 +9,7 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import config from 'config';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import route from 'lib/route';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
@@ -31,6 +32,12 @@ export default {
 		// if site loaded, but user cannot manage site, redirect
 		if ( site && ! utils.userCan( 'manage_options', site ) ) {
 			page.redirect( '/stats' );
+			return;
+		}
+
+		// redirect SEO to general if SEO tools are not enabled for Jetpack sites
+		if ( site.jetpack && ! config.isEnabled( 'jetpack/seo-tools' ) ) {
+			page.redirect( '/settings/general/' + site.slug );
 			return;
 		}
 

--- a/client/my-sites/site-settings/seo-settings/controller.js
+++ b/client/my-sites/site-settings/seo-settings/controller.js
@@ -36,7 +36,7 @@ export default {
 		}
 
 		// redirect SEO to general if SEO tools are not enabled for Jetpack sites
-		if ( site.jetpack && ( ! config.isEnabled( 'jetpack/seo-tools' ) || ! site.isModuleActive( 'seo-tools' ) ) ) {
+		if ( site.jetpack && ! config.isEnabled( 'jetpack/seo-tools' ) ) {
 			page.redirect( '/settings/general/' + site.slug );
 			return;
 		}

--- a/client/my-sites/site-settings/seo-settings/controller.js
+++ b/client/my-sites/site-settings/seo-settings/controller.js
@@ -34,8 +34,8 @@ export default {
 			return;
 		}
 
-		// redirect seo and analytics tabs to general for Jetpack sites
-		if ( site.jetpack ) {
+		// redirect analytics tab to general for Jetpack sites
+		if ( site.jetpack && basePath === '/settings/analytics' ) {
 			page.redirect( '/settings/general/' + site.slug );
 			return;
 		}

--- a/client/my-sites/site-settings/seo-settings/controller.js
+++ b/client/my-sites/site-settings/seo-settings/controller.js
@@ -34,12 +34,6 @@ export default {
 			return;
 		}
 
-		// redirect analytics tab to general for Jetpack sites
-		if ( site.jetpack && basePath === '/settings/analytics' ) {
-			page.redirect( '/settings/general/' + site.slug );
-			return;
-		}
-
 		if ( ! site.latestSettings || new Date().getTime() - site.latestSettings > ( fiveMinutes ) ) {
 			if ( sites.initialized ) {
 				site.fetchSettings();

--- a/client/my-sites/site-settings/seo-settings/controller.js
+++ b/client/my-sites/site-settings/seo-settings/controller.js
@@ -36,7 +36,7 @@ export default {
 		}
 
 		// redirect SEO to general if SEO tools are not enabled for Jetpack sites
-		if ( site.jetpack && ! config.isEnabled( 'jetpack/seo-tools' ) ) {
+		if ( site.jetpack && ( ! config.isEnabled( 'jetpack/seo-tools' ) || ! site.isModuleActive( 'seo-tools' ) ) ) {
 			page.redirect( '/settings/general/' + site.slug );
 			return;
 		}

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -465,22 +465,25 @@ export const SeoForm = React.createClass( {
 					/>
 				}
 
-				<SectionHeader label={ this.translate( 'Search Engine Optimization' ) }>
-				</SectionHeader>
-				<Card>
-					{ this.translate(
-						'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
-						'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
-						'these settings if you\'d like more advanced control. Read more about what you can do ' +
-						'to {{a}}optimize your site\'s SEO{{/a}}.',
-						{
-							components: {
-								a: <a href={ 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/' } />,
-								b: <strong />
-							}
-						}
-					) }
-				</Card>
+				{ ! jetpack &&
+					<div>
+						<SectionHeader label={ this.translate( 'Search Engine Optimization' ) } />
+						<Card>
+							{ this.translate(
+								'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
+								'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
+								'these settings if you\'d like more advanced control. Read more about what you can do ' +
+								'to {{a}}optimize your site\'s SEO{{/a}}.',
+								{
+									components: {
+										a: <a href={ 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/' } />,
+										b: <strong />
+									}
+								}
+							) }
+						</Card>
+					</div>
+				}
 
 				<form onChange={ this.markChanged } className="seo-settings__seo-form">
 					{ showAdvancedSeo && config.isEnabled( 'manage/advanced-seo/custom-title' ) &&

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -401,8 +401,8 @@ export const SeoForm = React.createClass( {
 		};
 
 		const nudgeTitle = jetpack
-			? this.translate( 'Enable Advanced SEO features by Upgrading to Jetpack Pro' )
-			: this.translate( 'Enable Advanced SEO features by Upgrading to the Business Plan' );
+			? this.translate( 'Enable Advanced SEO Features by Upgrading to Jetpack Pro' )
+			: this.translate( 'Enable Advanced SEO Features by Upgrading to the Business Plan' );
 
 		const submitButton = (
 			<Button

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -363,6 +363,7 @@ export const SeoForm = React.createClass( {
 			settings: {
 				blog_public = 1
 			} = {},
+			jetpack = false,
 		} = this.props.site;
 
 		const {
@@ -398,6 +399,10 @@ export const SeoForm = React.createClass( {
 		const hasError = function( service ) {
 			return includes( invalidCodes, service );
 		};
+
+		const nudgeTitle = jetpack
+			? this.translate( 'Enable Advanced SEO features by Upgrading to Jetpack Pro' )
+			: this.translate( 'Enable Advanced SEO features by Upgrading to the Business Plan' );
 
 		const submitButton = (
 			<Button
@@ -436,7 +441,7 @@ export const SeoForm = React.createClass( {
 					</Notice>
 				}
 
-				{ isJetpackUnsupported &&
+				{ showAdvancedSeo && isJetpackUnsupported &&
 					<Notice
 						status="is-warning"
 						showDismiss={ false }
@@ -456,6 +461,7 @@ export const SeoForm = React.createClass( {
 						title={ this.translate( 'Enable SEO Tools by Upgrading to the Business Plan' ) }
 						message={ this.translate( `Adds tools to optimize your site for search engines and social media sharing.` ) }
 						event={ 'calypso_seo_settings_upgrade_nudge' }
+						jetpack={ jetpack }
 					/>
 				}
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -508,7 +508,7 @@ export const SeoForm = React.createClass( {
 						</div>
 					}
 
-					{ ( showAdvancedSeo || showWebsiteMeta ) &&
+					{ ( showAdvancedSeo || ( ! jetpack && showWebsiteMeta ) ) &&
 						<div>
 							<SectionHeader label={ this.translate( 'Website Meta' ) }>
 								{ submitButton }
@@ -693,12 +693,13 @@ export const SeoForm = React.createClass( {
 
 const mapStateToProps = ( state, ownProps ) => {
 	const { site } = ownProps;
-	// SEO Tools are available with Business plan on WordPress.com, and with Free plan on Jetpack sites
+	// SEO Tools are available with Business plan on WordPress.com, and with Premium plan on Jetpack sites
 	const isAdvancedSeoEligible = site && site.plan && hasBusinessPlan( site.plan );
+	const siteId = get( site, 'ID', 0 );
+	const jetpackVersionSupportsSeo = isJetpackMinimumVersion( state, siteId, '4.4.0' );
 	const seoFeatureEnabled = site &&
 		( ! site.jetpack && config.isEnabled( 'manage/advanced-seo' ) ||
-			site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) && site.isModuleActive( 'seo-tools' ) );
-	const siteId = get( site, 'ID', 0 );
+			site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) && jetpackVersionSupportsSeo && site.isModuleActive( 'seo-tools' ) );
 
 	return {
 		selectedSite: getSelectedSite( state ),
@@ -706,7 +707,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		showAdvancedSeo: isAdvancedSeoEligible && seoFeatureEnabled,
 		showWebsiteMeta: !! get( site, 'options.advanced_seo_front_page_description', '' ),
 		showUpgradeNudge: config.isEnabled( 'manage/advanced-seo' ),
-		jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4.0' ),
+		jetpackVersionSupportsSeo: jetpackVersionSupportsSeo,
 	};
 };
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -696,7 +696,8 @@ const mapStateToProps = ( state, ownProps ) => {
 	// SEO Tools are available with Business plan on WordPress.com, and with Free plan on Jetpack sites
 	const isAdvancedSeoEligible = site && site.plan && hasBusinessPlan( site.plan );
 	const seoFeatureEnabled = site &&
-		( ! site.jetpack && config.isEnabled( 'manage/advanced-seo' ) || site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) );
+		( ! site.jetpack && config.isEnabled( 'manage/advanced-seo' ) ||
+			site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) && site.isModuleActive( 'seo-tools' ) );
 	const siteId = get( site, 'ID', 0 );
 
 	return {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -41,7 +41,11 @@ import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mapping
 import { recordTracksEvent } from 'state/analytics/actions';
 import WebPreview from 'components/web-preview';
 import { requestSite } from 'state/sites/actions';
-import { isBusiness, isEnterprise } from 'lib/products-values';
+import {
+	isBusiness,
+	isEnterprise,
+	isJetpackBusiness
+} from 'lib/products-values';
 import { FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
 
 const serviceIds = {
@@ -55,7 +59,7 @@ const serviceIds = {
 // Not perfect but meets the needs of this component well
 const anyHtmlTag = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
 
-const hasBusinessPlan = overSome( isBusiness, isEnterprise );
+const hasBusinessPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness );
 
 function getGeneralTabUrl( slug ) {
 	return `/settings/general/${ slug }`;

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -43,7 +43,8 @@ import WebPreview from 'components/web-preview';
 import { requestSite } from 'state/sites/actions';
 import {
 	isBusiness,
-	isEnterprise
+	isEnterprise,
+	isJetpackBusiness
 } from 'lib/products-values';
 import { FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
 
@@ -58,7 +59,7 @@ const serviceIds = {
 // Not perfect but meets the needs of this component well
 const anyHtmlTag = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
 
-const hasBusinessPlan = overSome( isBusiness, isEnterprise );
+const hasBusinessPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness );
 
 function getGeneralTabUrl( slug ) {
 	return `/settings/general/${ slug }`;
@@ -396,6 +397,10 @@ export const SeoForm = React.createClass( {
 			return includes( invalidCodes, service );
 		};
 
+		const nudgeTitle = jetpack
+			? this.translate( 'Enable SEO Tools Features by Upgrading to Jetpack Pro' )
+			: this.translate( 'Enable SEO Tools Features by Upgrading to the Business Plan' );
+
 		const submitButton = (
 			<Button
 				compact={ true }
@@ -450,7 +455,7 @@ export const SeoForm = React.createClass( {
 				{ showUpgradeNudge &&
 					<UpgradeNudge
 						feature={ FEATURE_ADVANCED_SEO }
-						title={ this.translate( 'Enable SEO Tools Features by Upgrading to the Business Plan' ) }
+						title={ nudgeTitle }
 						message={ this.translate( 'Adds tools to optimize your site for search engines and social media sharing.' ) }
 						event={ 'calypso_seo_settings_upgrade_nudge' }
 						jetpack={ jetpack }
@@ -689,9 +694,9 @@ export const SeoForm = React.createClass( {
 const mapStateToProps = ( state, ownProps ) => {
 	const { site } = ownProps;
 	// SEO Tools are available with Business plan on WordPress.com, and with Free plan on Jetpack sites
-	const isAdvancedSeoEligible = site && ( site.plan && hasBusinessPlan( site.plan ) || site.jetpack );
-	const seoFeatureEnabled = site && ( ! site.jetpack && config.isEnabled( 'manage/advanced-seo' ) ||
-										site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) );
+	const isAdvancedSeoEligible = site && site.plan && hasBusinessPlan( site.plan );
+	const seoFeatureEnabled = site &&
+		( ! site.jetpack && config.isEnabled( 'manage/advanced-seo' ) || site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) );
 	const siteId = get( site, 'ID', 0 );
 
 	return {

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -231,7 +231,15 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderSeo: function() {
-		if ( ! config.isEnabled( 'manage/advanced-seo' ) || ! this.props.site ) {
+		if ( ! this.props.site ) {
+			return;
+		}
+
+		if ( ! this.props.site.jetpack && ! config.isEnabled( 'manage/advanced-seo' ) ) {
+			return;
+		}
+
+		if ( this.props.site.jetpack && ! config.isEnabled( 'jetpack/seo-tools' ) ) {
 			return;
 		}
 

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -231,6 +231,8 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderSeo: function() {
+		const { jetpackVersionSupportsSeo } = this.props;
+
 		if ( ! this.props.site ) {
 			return;
 		}
@@ -240,7 +242,9 @@ const EditorDrawer = React.createClass( {
 		}
 
 		if ( this.props.site.jetpack ) {
-			if ( ! config.isEnabled( 'jetpack/seo-tools' ) || ! this.props.site.isModuleActive( 'seo-tools' ) ) {
+			if ( ! config.isEnabled( 'jetpack/seo-tools' ) ||
+				! this.props.site.isModuleActive( 'seo-tools' ) ||
+				! jetpackVersionSupportsSeo ) {
 				return;
 			}
 		}
@@ -318,6 +322,7 @@ export default connect(
 
 		return {
 			canJetpackUseTaxonomies: isJetpackMinimumVersion( state, siteId, '4.1' ),
+			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4.0' ),
 			typeObject: getPostType( state, siteId, type )
 		};
 	},

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -239,7 +239,7 @@ const EditorDrawer = React.createClass( {
 			return;
 		}
 
-		if ( this.props.site.jetpack && ! config.isEnabled( 'jetpack/seo-tools' ) ) {
+		if ( this.props.site.jetpack && ( ! config.isEnabled( 'jetpack/seo-tools' ) || ! this.props.site.isModuleActive( 'seo-tools' ) ) ) {
 			return;
 		}
 

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -245,7 +245,7 @@ const EditorDrawer = React.createClass( {
 
 		const { plan } = this.props.site;
 		const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
-		if ( ! this.props.site.jetpack && ! hasBusinessPlan ) {
+		if ( ! hasBusinessPlan ) {
 			return;
 		}
 

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -239,8 +239,10 @@ const EditorDrawer = React.createClass( {
 			return;
 		}
 
-		if ( this.props.site.jetpack && ( ! config.isEnabled( 'jetpack/seo-tools' ) || ! this.props.site.isModuleActive( 'seo-tools' ) ) ) {
-			return;
+		if ( this.props.site.jetpack ) {
+			if ( ! config.isEnabled( 'jetpack/seo-tools' ) || ! this.props.site.isModuleActive( 'seo-tools' ) ) {
+				return;
+			}
 		}
 
 		const { plan } = this.props.site;

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -245,7 +245,7 @@ const EditorDrawer = React.createClass( {
 
 		const { plan } = this.props.site;
 		const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
-		if ( ! hasBusinessPlan ) {
+		if ( ! this.props.site.jetpack && ! hasBusinessPlan ) {
 			return;
 		}
 

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -1,46 +1,101 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import identity from 'lodash/identity';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Accordion from 'components/accordion';
+import Button from 'components/button';
 import AccordionSection from 'components/accordion/section';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Gridicon from 'components/gridicon';
 import PostActions from 'lib/posts/actions';
 import EditorDrawerLabel from 'post-editor/editor-drawer/label';
+import WebPreview from 'components/web-preview';
+import { isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-function EditorSeoAccordion( { translate, metaDescription = '' } ) {
-	return (
-		<Accordion
-			title={ translate( 'SEO Description' ) }
-			icon={ <Gridicon icon="search" /> }
-			className="editor-seo-accordion"
-		>
-			<AccordionSection>
-				<EditorDrawerLabel
-					helpText={ translate(
-						'Craft a description of your post for search engine results. ' +
-						'The post content is used by default.'
-					) }
-					labelText={ translate( 'Meta Description' ) }
-				>
-					<CountedTextarea
-						maxLength="300"
-						acceptableLength={ 159 }
-						placeholder={ translate( 'Write a description…' ) }
-						aria-label={ translate( 'Write a description…' ) }
-						value={ metaDescription }
-						onChange={ onMetaChange }
-					/>
-				</EditorDrawerLabel>
-			</AccordionSection>
-		</Accordion>
-	);
+class EditorSeoAccordion extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		metaDescription: PropTypes.string
+	};
+
+	static defaultProps = {
+		metaDescription: '',
+		translate: identity
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.showPreview = this.showPreview.bind( this );
+		this.hidePreview = this.hidePreview.bind( this );
+
+		this.state = { showPreview: false };
+	}
+
+	showPreview() {
+		this.setState( { showPreview: true } );
+	}
+
+	hidePreview() {
+		this.setState( { showPreview: false } );
+	}
+
+	render() {
+		const { translate, metaDescription, isJetpack } = this.props;
+		const { showPreview } = this.state;
+
+		return (
+			<Accordion
+				title={ translate( 'SEO Description' ) }
+				icon={ <Gridicon icon="search" /> }
+				className="editor-seo-accordion"
+			>
+				<AccordionSection>
+					<EditorDrawerLabel
+						helpText={ translate(
+							'Craft a description of your post for search engine results. ' +
+							'The post content is used by default.'
+						) }
+						labelText={ translate( 'Meta Description' ) }
+					>
+						<CountedTextarea
+							maxLength="300"
+							acceptableLength={ 159 }
+							placeholder={ translate( 'Write a description…' ) }
+							aria-label={ translate( 'Write a description…' ) }
+							value={ metaDescription }
+							onChange={ onMetaChange }
+						/>
+					</EditorDrawerLabel>
+					{ isJetpack &&
+						<div>
+							<Button
+								className="editor-seo-accordion__preview-button"
+								onClick={ this.showPreview }
+							>
+								{ translate( 'Preview' ) }
+							</Button>
+							<WebPreview
+								showPreview={ showPreview }
+								onClose={ this.hidePreview }
+								showDeviceSwitcher={ false }
+								showExternal={ false }
+								defaultViewportDevice="seo"
+							/>
+						</div>
+					}
+				</AccordionSection>
+			</Accordion>
+		);
+	}
 }
 
 function onMetaChange( event ) {
@@ -49,9 +104,17 @@ function onMetaChange( event ) {
 	} );
 }
 
-EditorSeoAccordion.propTypes = {
-	translate: PropTypes.func,
-	metaDescription: PropTypes.string
+const mapStateToProps = ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		isJetpack: isJetpackSite( state, siteId )
+	};
 };
 
-export default localize( EditorSeoAccordion );
+export default connect(
+	mapStateToProps,
+	null,
+	null,
+	{ pure: false } // defaults to true, but this component has internal state
+)( localize( EditorSeoAccordion ) );

--- a/client/post-editor/editor-seo-accordion/style.scss
+++ b/client/post-editor/editor-seo-accordion/style.scss
@@ -8,4 +8,9 @@
 		background-color: lighten( $gray, 10% );
 		padding: 0 6px;
 	}
+
+	.editor-seo-accordion__preview-button {
+		margin-top: 10px;
+		width: 100%;
+	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -45,6 +45,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
+		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/sync-panel": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -25,6 +25,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
+		"jetpack/seo-tools": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"manage/add-people": true,

--- a/config/production.json
+++ b/config/production.json
@@ -23,6 +23,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
+		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,
 		"mailing-lists/unsubscribe": true,

--- a/config/production.json
+++ b/config/production.json
@@ -23,7 +23,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
-		"jetpack/seo-tools": true,
+		"jetpack/seo-tools": false,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,
 		"mailing-lists/unsubscribe": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -25,6 +25,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
+		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,
 		"jetpack_core_inline_update": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -30,6 +30,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
+		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,
 		"jetpack_core_inline_update": true,


### PR DESCRIPTION
Run this branch alongside https://github.com/Automattic/jetpack/pull/5307 to get settings saving from calypso to the Jetpack site.

cc @vindl 
