### PR TITLE
TaxonomyManager: add VirtualScroll list of terms.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -31,6 +31,7 @@
 @import 'blocks/reader-related-card/style';
 @import 'blocks/reader-related-card-v2/style';
 @import 'blocks/reader-search-card/style';
+@import 'blocks/taxonomy-manager/style';
 @import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';
 @import 'components/accordion/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -304,6 +304,7 @@
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';
 @import 'my-sites/site-settings/site-icon-setting/style';
+@import 'my-sites/site-settings/taxonomies/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'my-sites/sites/style';

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -15,20 +15,22 @@ import Button from 'components/button';
 import TermsList from './list';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
+import QueryTaxonomies from 'components/data/query-taxonomies';
 
 export class TaxonomyManager extends Component {
 	static propTypes = {
 		taxonomy: PropTypes.string,
 		labels: PropTypes.object,
 		postType: PropTypes.string,
+		siteId: PropTypes.number,
 	};
 
 	static defaultProps = {
 		postType: 'post'
 	};
 
-	constructor() {
-		super( ...arguments );
+	constructor( props ) {
+		super( props );
 		this.state = {
 			search: null
 		};
@@ -36,7 +38,7 @@ export class TaxonomyManager extends Component {
 		this.onSearch = this.onSearch.bind( this );
 	}
 
-	onSearch( searchTerm ) {
+	onSearch = searchTerm => {
 		if ( searchTerm !== this.state.search ) {
 			this.setState( {
 				search: searchTerm
@@ -46,6 +48,7 @@ export class TaxonomyManager extends Component {
 
 	render() {
 		const { search } = this.state;
+		const { siteId, postType, labels, taxonomy } = this.props;
 		const query = {};
 		if ( search && search.length ) {
 			query.search = search;
@@ -53,14 +56,15 @@ export class TaxonomyManager extends Component {
 
 		return (
 			<div>
-				<SectionHeader label={ this.props.labels.name }>
+				{ siteId && <QueryTaxonomies { ...{ siteId, postType } } /> }
+				<SectionHeader label={ labels.name }>
 					<Button compact primary>
-						{ this.props.labels.add_new_item }
+						{ labels.add_new_item }
 					</Button>
 				</SectionHeader>
 				<Card>
 					<SearchCard onSearch={ this.onSearch } className="taxonomy-manager__search" />
-					<TermsList query={ query } taxonomy={ this.props.taxonomy } />
+					<TermsList query={ query } taxonomy={ taxonomy } />
 				</Card>
 			</div>
 		);
@@ -71,7 +75,7 @@ export default connect(
 	( state, ownProps ) => {
 		const { taxonomy, postType } = ownProps;
 		const siteId = getSelectedSiteId( state );
-		const labels = get( getPostTypeTaxonomy( state, siteId, postType || 'post', taxonomy ), 'labels', {} );
-		return { labels };
+		const labels = get( getPostTypeTaxonomy( state, siteId, postType, taxonomy ), 'labels', {} );
+		return { labels, siteId };
 	}
 )( TaxonomyManager );

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,27 +12,66 @@ import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import SearchCard from 'components/search-card';
 import Button from 'components/button';
+import TermsList from './list';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 
 export class TaxonomyManager extends Component {
 	static propTypes = {
-		translate: PropTypes.func,
 		taxonomy: PropTypes.string,
+		labels: PropTypes.object,
+		postType: PropTypes.string,
 	};
 
+	static defaultProps = {
+		postType: 'post'
+	};
+
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			search: null
+		};
+
+		this.onSearch = this.onSearch.bind( this );
+	}
+
+	onSearch( searchTerm ) {
+		if ( searchTerm !== this.state.search ) {
+			this.setState( {
+				search: searchTerm
+			} );
+		}
+	}
+
 	render() {
+		const { search } = this.state;
+		const query = {};
+		if ( search && search.length ) {
+			query.search = search;
+		}
+
 		return (
 			<div>
-				<SectionHeader label={ this.props.translate( 'Categories' ) }>
+				<SectionHeader label={ this.props.labels.name }>
 					<Button compact primary>
-						{ this.props.translate( 'Add Category' ) }
+						{ this.props.labels.add_new_item }
 					</Button>
 				</SectionHeader>
 				<Card>
-					<SearchCard onSearch={ () => {} } />
+					<SearchCard onSearch={ this.onSearch } className="taxonomy-manager__search" />
+					<TermsList query={ query } taxonomy={ this.props.taxonomy } />
 				</Card>
 			</div>
 		);
 	}
 }
 
-export default localize( TaxonomyManager );
+export default connect(
+	( state, ownProps ) => {
+		const { taxonomy, postType } = ownProps;
+		const siteId = getSelectedSiteId( state );
+		const labels = get( getPostTypeTaxonomy( state, siteId, postType || 'post', taxonomy ), 'labels', {} );
+		return { labels };
+	}
+)( TaxonomyManager );

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { debounce, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,8 +16,6 @@ import TermsList from './list';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import QueryTaxonomies from 'components/data/query-taxonomies';
-
-const SEARCH_DEBOUNCE_WAIT = 200;
 
 export class TaxonomyManager extends Component {
 	static propTypes = {
@@ -35,13 +33,13 @@ export class TaxonomyManager extends Component {
 		search: null
 	};
 
-	onSearch = debounce( searchTerm => {
+	onSearch = searchTerm => {
 		if ( searchTerm !== this.state.search ) {
 			this.setState( {
 				search: searchTerm
 			} );
 		}
-	}, SEARCH_DEBOUNCE_WAIT );
+	};
 
 	render() {
 		const { search } = this.state;
@@ -60,7 +58,7 @@ export class TaxonomyManager extends Component {
 					</Button>
 				</SectionHeader>
 				<Card>
-					<SearchCard onSearch={ this.onSearch } className="taxonomy-manager__search" />
+					<SearchCard onSearch={ this.onSearch } className="taxonomy-manager__search" delaySearch />
 					<TermsList query={ query } taxonomy={ taxonomy } />
 				</Card>
 			</div>

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -8,8 +8,6 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import SectionHeader from 'components/section-header';
-import Card from 'components/card';
 import SearchCard from 'components/search-card';
 import Button from 'components/button';
 import TermsList from './list';
@@ -52,15 +50,15 @@ export class TaxonomyManager extends Component {
 		return (
 			<div>
 				{ siteId && <QueryTaxonomies { ...{ siteId, postType } } /> }
-				<SectionHeader label={ labels.name }>
-					<Button compact primary>
-						{ labels.add_new_item }
-					</Button>
-				</SectionHeader>
-				<Card>
-					<SearchCard onSearch={ this.onSearch } className="taxonomy-manager__search" delaySearch />
-					<TermsList query={ query } taxonomy={ taxonomy } />
-				</Card>
+				<div className="taxonomy-manager__header">
+					<SearchCard onSearch={ this.onSearch } delaySearch />
+					<div className="taxonomy-manager__actions">
+						<Button compact primary>
+							{ labels.add_new_item }
+						</Button>
+					</div>
+				</div>
+				<TermsList query={ query } taxonomy={ taxonomy } />
 			</div>
 		);
 	}

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { debounce, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,8 @@ import TermsList from './list';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import QueryTaxonomies from 'components/data/query-taxonomies';
+
+const SEARCH_DEBOUNCE_WAIT = 200;
 
 export class TaxonomyManager extends Component {
 	static propTypes = {
@@ -33,13 +35,13 @@ export class TaxonomyManager extends Component {
 		search: null
 	};
 
-	onSearch = searchTerm => {
+	onSearch = debounce( searchTerm => {
 		if ( searchTerm !== this.state.search ) {
 			this.setState( {
 				search: searchTerm
 			} );
 		}
-	}
+	}, SEARCH_DEBOUNCE_WAIT );
 
 	render() {
 		const { search } = this.state;

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -29,14 +29,9 @@ export class TaxonomyManager extends Component {
 		postType: 'post'
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			search: null
-		};
-
-		this.onSearch = this.onSearch.bind( this );
-	}
+	state = {
+		search: null
+	};
 
 	onSearch = searchTerm => {
 		if ( searchTerm !== this.state.search ) {

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PopoverMenu from 'components/popover/menu';
+import PopoverMenuItem from 'components/popover/menu-item';
+import Gridicon from 'components/gridicon';
+
+class TaxonomyManagerListItem extends Component {
+	static propTypes = {
+		name: PropTypes.string,
+		translate: PropTypes.func,
+		onClick: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onClick: () => {}
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			popoverMenuOpen: false
+		};
+	}
+
+	togglePopoverMenu = () => {
+		this.setState( {
+			popoverMenuOpen: ! this.state.popoverMenuOpen
+		} )
+	}
+
+	render() {
+		const { name, translate } = this.props;
+
+		return (
+			<div>
+				<span className="taxonomy-manager__label">{ name }</span>
+				<Gridicon
+					icon="ellipsis"
+					className={ classNames( {
+						'taxonomy-manager__list-item-toggle': true,
+						'is-active': this.state.popoverMenuOpen
+					} ) }
+					onClick={ this.togglePopoverMenu }
+					ref="popoverMenuButton" />
+				<PopoverMenu
+					isVisible={ this.state.popoverMenuOpen }
+					onClose={ this.togglePopoverMenu }
+					position={ 'bottom left' }
+					context={ this.refs && this.refs.popoverMenuButton }
+				>
+					<PopoverMenuItem onClick={ this.props.onClick }>
+						<Gridicon icon="pencil" size={ 18 } />
+						{ translate( 'Edit' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem>
+						<Gridicon icon="trash" size={ 18 } />
+						{ translate( 'Delete' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem>
+						<Gridicon icon="external" size={ 18 } />
+						{ translate( 'View Posts' ) }
+					</PopoverMenuItem>
+				</PopoverMenu>
+			</div>
+		);
+	}
+}
+
+export default localize( TaxonomyManagerListItem );

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -1,0 +1,341 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import VirtualScroll from 'react-virtualized/VirtualScroll';
+import {
+	debounce,
+	difference,
+	includes,
+	filter,
+	map,
+	memoize,
+	range,
+	reduce,
+} from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import { decodeEntities } from 'lib/formatting';
+import QueryTerms from 'components/data/query-terms';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isRequestingTermsForQueryIgnoringPage,
+	getTermsLastPageForQuery,
+	getTermsForQueryIgnoringPage,
+} from 'state/terms/selectors';
+
+/**
+ * Constants
+ */
+const DEFAULT_TERMS_PER_PAGE = 100;
+const LOAD_OFFSET = 10;
+const ITEM_HEIGHT = 55;
+
+const TaxonomyManagerList = React.createClass( {
+
+	propTypes: {
+		terms: PropTypes.array,
+		taxonomy: PropTypes.string,
+		search: PropTypes.string,
+		siteId: PropTypes.number,
+		translate: PropTypes.func,
+		lastPage: PropTypes.number,
+	},
+
+	getInitialState() {
+		return {
+			requestedPages: [ 1 ]
+		};
+	},
+
+	getDefaultProps() {
+		return {
+			analyticsPrefix: 'Category Selector',
+			searchThreshold: 8,
+			loading: true,
+			terms: [],
+			onNextPage: () => {}
+		};
+	},
+
+	componentWillMount() {
+		this.itemHeights = {};
+		this.hasPerformedSearch = false;
+		this.virtualScroll = null;
+
+		this.termIds = map( this.props.terms, 'ID' );
+		this.getTermChildren = memoize( this.getTermChildren );
+		this.queueRecomputeRowHeights = debounce( this.recomputeRowHeights );
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.taxonomy !== this.props.taxonomy ) {
+			this.setState( this.getInitialState() );
+		}
+
+		if ( this.props.terms !== nextProps.terms ) {
+			this.getTermChildren.cache.clear();
+			this.termIds = map( nextProps.terms, 'ID' );
+		}
+	},
+
+	componentDidUpdate( prevProps ) {
+		const forceUpdate = (
+			prevProps.loading && ! this.props.loading ||
+			( ! prevProps.terms && this.props.terms )
+		);
+
+		if ( forceUpdate ) {
+			this.virtualScroll.forceUpdate();
+		}
+
+		if ( this.props.terms !== prevProps.terms ) {
+			this.recomputeRowHeights();
+		}
+	},
+
+	recomputeRowHeights: function() {
+		if ( ! this.virtualScroll ) {
+			return;
+		}
+
+		this.virtualScroll.recomputeRowHeights();
+		this.virtualScroll.forceUpdate();
+	},
+
+	setSelectorRef( selectorRef ) {
+		if ( ! selectorRef ) {
+			return;
+		}
+
+		this.setState( { selectorRef } );
+	},
+
+	getPageForIndex( index ) {
+		const { query, lastPage } = this.props;
+		const perPage = query.number || DEFAULT_TERMS_PER_PAGE;
+		const page = Math.ceil( index / perPage );
+
+		return Math.max( Math.min( page, lastPage || Infinity ), 1 );
+	},
+
+	setRequestedPages( { startIndex, stopIndex } ) {
+		const { requestedPages } = this.state;
+		const pagesToRequest = difference( range(
+			this.getPageForIndex( startIndex - LOAD_OFFSET ),
+			this.getPageForIndex( stopIndex + LOAD_OFFSET ) + 1
+		), requestedPages );
+
+		if ( ! pagesToRequest.length ) {
+			return;
+		}
+
+		this.setState( {
+			requestedPages: requestedPages.concat( pagesToRequest )
+		} );
+	},
+
+	setItemRef( item, itemRef ) {
+		if ( ! itemRef || ! item ) {
+			return;
+		}
+
+		// By falling back to the item height constant, we avoid an unnecessary
+		// forced update if all of the items match our guessed height
+		const height = this.itemHeights[ item.ID ] || ITEM_HEIGHT;
+
+		const nextHeight = itemRef.clientHeight;
+		this.itemHeights[ item.ID ] = nextHeight;
+
+		// If height changes, wait until the end of the current call stack and
+		// fire a single forced update to recompute the row heights
+		if ( height !== nextHeight ) {
+			this.queueRecomputeRowHeights();
+		}
+	},
+
+	hasNoSearchResults() {
+		return ! this.props.loading &&
+			( this.props.terms && ! this.props.terms.length ) &&
+			( this.props.query.search && !! this.props.query.search.length );
+	},
+
+	hasNoTerms() {
+		return ! this.props.loading && ( this.props.terms && ! this.props.terms.length );
+	},
+
+	getItem( index ) {
+		if ( this.props.terms ) {
+			return this.props.terms[ index ];
+		}
+	},
+
+	isRowLoaded( { index } ) {
+		return this.props.lastPage || !! this.getItem( index );
+	},
+
+	getTermChildren( termId ) {
+		const { terms } = this.props;
+		return filter( terms, ( { parent } ) => parent === termId );
+	},
+
+	getItemHeight( item, _recurse = false ) {
+		if ( ! item ) {
+			return ITEM_HEIGHT;
+		}
+
+		// if item has a parent, and parent is in payload, height is already part of parent
+		if ( item.parent && ! _recurse && includes( this.termIds, item.parent ) ) {
+			return 0;
+		}
+
+		if ( this.itemHeights[ item.ID ] ) {
+			return this.itemHeights[ item.ID ];
+		}
+
+		return reduce( this.getTermChildren( item.ID ), ( memo, childItem ) => {
+			return memo + this.getItemHeight( childItem, true );
+		}, ITEM_HEIGHT );
+	},
+
+	getRowHeight( { index } ) {
+		return this.getItemHeight( this.getItem( index ) );
+	},
+
+	getCompactContainerHeight() {
+		return range( 0, this.getRowCount() ).reduce( ( memo, index ) => {
+			return memo + this.getRowHeight( { index } );
+		}, 0 );
+	},
+
+	getResultsWidth() {
+		const { selectorRef } = this.state;
+		if ( selectorRef ) {
+			return selectorRef.clientWidth;
+		}
+
+		return 0;
+	},
+
+	getRowCount() {
+		let count = 0;
+
+		if ( this.props.terms ) {
+			count += this.props.terms.length;
+		}
+
+		if ( this.props.loading || ! this.props.terms ) {
+			count += 1;
+		}
+
+		return count;
+	},
+
+	setVirtualScrollRef( ref ) {
+		this.virtualScroll = ref;
+	},
+
+	renderItem( item, _recurse = false ) {
+		// if item has a parent and it is in current props.terms, do not render
+		if ( item.parent && ! _recurse && includes( this.termIds, item.parent ) ) {
+			return;
+		}
+
+		const setItemRef = ( ...args ) => this.setItemRef( item, ...args );
+		const children = this.getTermChildren( item.ID );
+
+		const { translate } = this.props;
+		const itemId = item.ID;
+		const name = decodeEntities( item.name ) || translate( 'Untitled' );
+
+		return (
+			<div key={ 'term-wrapper-' + itemId } className="taxonomy-manager__list-item">
+				<CompactCard
+					key={ itemId }
+					ref={ setItemRef }>
+						<span className="taxonomy-manager__label">{ name }</span>
+				</CompactCard>
+				{ children.length > 0 && (
+					<div className="taxonomy-manager__nested-list">
+						{ children.map( ( child ) => this.renderItem( child, true ) ) }
+					</div>
+				) }
+			</div>
+		);
+	},
+
+	renderNoResults() {
+		if ( this.hasNoTerms() ) {
+			return (
+				<div key="no-results" className="taxonomy-manager__list-item is-empty">
+					No Results Found
+				</div>
+			);
+		}
+	},
+
+	renderRow( { index } ) {
+		const item = this.getItem( index );
+		if ( item ) {
+			return this.renderItem( item );
+		}
+
+		return (
+			<CompactCard className="taxonomy-manager__list-item is-placeholder">
+				<span className="taxonomy-manager__label">
+					{ this.props.translate( 'Loading…' ) }
+				</span>
+			</CompactCard>
+		);
+	},
+
+	render() {
+		const rowCount = this.getRowCount();
+		const { className, loading, siteId, taxonomy, query } = this.props;
+		const classes = classNames( 'taxonomy-manager', className, {
+			'is-loading': loading
+		} );
+
+		return (
+			<div ref={ this.setSelectorRef } className={ classes }>
+				{ this.state.requestedPages.map( ( page ) => (
+					<QueryTerms
+						key={ `query-${ page }` }
+						siteId={ siteId }
+						taxonomy={ taxonomy }
+						query={ { ...query, page } } />
+				) ) }
+				<VirtualScroll
+					ref={ this.setVirtualScrollRef }
+					width={ this.getResultsWidth() }
+					height={ 300 }
+					onRowsRendered={ this.setRequestedPages }
+					rowCount={ rowCount }
+					estimatedRowSize={ ITEM_HEIGHT }
+					rowHeight={ this.getRowHeight }
+					rowRenderer={ this.renderRow }
+					noRowsRenderer={ this.renderNoResults }
+					className="taxonomy-manager__results" />
+			</div>
+		);
+	}
+} );
+
+export default connect( ( state, ownProps ) => {
+	const siteId = getSelectedSiteId( state );
+	const { taxonomy, query } = ownProps;
+
+	return {
+		loading: isRequestingTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
+		terms: getTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
+		lastPage: getTermsLastPageForQuery( state, siteId, taxonomy, query ),
+		siteId,
+		query
+	};
+} )( localize( TaxonomyManagerList ) );

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -166,6 +166,7 @@ export class TaxonomyManagerList extends Component {
 						taxonomy={ taxonomy }
 						query={ { ...query, page } } />
 				) ) }
+
 				<VirtualList
 					items={ terms }
 					lastPage={ lastPage }
@@ -176,7 +177,7 @@ export class TaxonomyManagerList extends Component {
 					perPage={ DEFAULT_TERMS_PER_PAGE }
 					loadOffset={ LOAD_OFFSET }
 					searching={ query.search && query.search.length }
-					defaultItemHeight={ ITEM_HEIGHT }
+					defaultRowHeight={ ITEM_HEIGHT }
 				/>
 			</div>
 		);

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -9,7 +9,6 @@ import {
 	includes,
 	filter,
 	map,
-	memoize,
 	noop,
 	reduce,
 	union,
@@ -60,13 +59,18 @@ export class TaxonomyManagerList extends Component {
 	};
 
 	componentWillMount() {
-		this.itemIds = map( this.props.terms, 'ID' );
-		this.getTermChildren = memoize( this.getTermChildren );
+		this.termIds = map( this.props.terms, 'ID' );
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.terms !== this.props.terms ) {
+			this.termIds = map( this.props.terms, 'ID' );
+		}
 	}
 
 	getTermChildren( termId ) {
 		const { terms } = this.props;
-		return filter( terms, ( { parent } ) => parent === termId );
+		return filter( terms, { parent: termId } );
 	}
 
 	getItemHeight = ( item, _recurse = false ) => {
@@ -156,11 +160,11 @@ export class TaxonomyManagerList extends Component {
 		return (
 			<div className={ classes }>
 				{ this.state.requestedPages.map( page => (
-						<QueryTerms
-							key={ `query-${ page }` }
-							siteId={ siteId }
-							taxonomy={ taxonomy }
-							query={ { ...query, page } } />
+					<QueryTerms
+						key={ `query-${ page }` }
+						siteId={ siteId }
+						taxonomy={ taxonomy }
+						query={ { ...query, page } } />
 				) ) }
 				<VirtualList
 					items={ terms }

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -1,0 +1,16 @@
+.taxonomy-manager {
+	position: relative;
+	border: 1px solid lighten( $gray, 20% );
+}
+
+.taxonomy-manager__search {
+	margin-bottom: 0;
+}
+
+.taxonomy-manager__nested-list {
+	margin-left: 2em;
+}
+
+.taxonomy-manager__list-item {
+	background-color: $gray-light;
+}

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -14,3 +14,35 @@
 .taxonomy-manager__list-item {
 	background-color: $gray-light;
 }
+
+.taxonomy-manager__list-item-card {
+	cursor: pointer;
+}
+
+.taxonomy-manager__list-item-toggle {
+	color: $gray;
+	cursor: pointer;
+	font-size: 24px;
+	margin: 17px 28px;
+	position: absolute;
+		right: 0;
+		top: 0;
+	transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+	&.is-active {
+		color: $blue-medium;
+		transform: rotate( 90deg );
+	}
+}
+
+.taxonomy-manager__label {
+	position: relative;
+	display: flex;
+	justify-content: space-between;
+
+	.taxonomy-manager__list-item.is-placeholder & {
+		color: transparent;
+		background-color: lighten( $gray, 30% );
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
+}

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -46,3 +46,8 @@
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }
+
+.taxonomy-manager .virtual-list__list-row.is-empty {
+	padding: 16px 24px;
+	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+}

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -1,10 +1,30 @@
 .taxonomy-manager {
-	position: relative;
-	border: 1px solid lighten( $gray, 20% );
+	height: 300px;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
 }
 
-.taxonomy-manager__search {
-	margin-bottom: 0;
+.taxonomy-manager__header {
+	display: flex;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+	background: $white;
+}
+
+.taxonomy-manager__header .search-card {
+	margin-bottom: 1px;
+	display: flex;
+	flex-grow: 1;
+	box-shadow: none;
+}
+
+.taxonomy-manager__header .search-card .search {
+	height: 58px;
+}
+
+.taxonomy-manager__actions {
+	flex-grow: 0;
+	padding: 16px 24px;
 }
 
 .taxonomy-manager__nested-list {

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -1,0 +1,197 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, Component } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import VirtualScroll from 'react-virtualized/VirtualScroll';
+import {
+	debounce,
+	difference,
+	noop,
+	range,
+} from 'lodash';
+
+export class VirtualList extends Component {
+	static propTypes = {
+		items: PropTypes.array,
+		lastPage: PropTypes.number,
+		loading: PropTypes.boolean,
+		getItemHeight: PropTypes.func,
+		renderItem: PropTypes.func,
+		renderQuery: PropTypes.func,
+		perPage: PropTypes.number,
+		loadOffset: PropTypes.number,
+		query: PropTypes.object,
+		defaultItemHeight: PropTypes.number,
+		height: PropTypes.number,
+	};
+
+	static defaultProps = {
+		items: [],
+		lastPage: 0,
+		loading: false,
+		getItemHeight: noop,
+		renderItem: noop,
+		perPage: 100,
+		loadOffset: 10,
+		height: 300,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			requestedPages: [ 1 ]
+		};
+	}
+
+	componentWillMount() {
+		this.itemHeights = {};
+		this.virtualScroll = null;
+
+		this.queueRecomputeRowHeights = debounce( this.recomputeRowHeights );
+	}
+
+	componentDidUpdate( prevProps ) {
+		const forceUpdate = (
+			prevProps.loading && ! this.props.loading ||
+			( ! prevProps.items && this.props.items )
+		);
+
+		if ( forceUpdate ) {
+			this.virtualScroll.forceUpdate();
+		}
+
+		if ( this.props.items !== prevProps.items ) {
+			this.recomputeRowHeights();
+		}
+	}
+
+	recomputeRowHeights() {
+		if ( ! this.virtualScroll ) {
+			return;
+		}
+
+		this.virtualScroll.recomputeRowHeights();
+		this.virtualScroll.forceUpdate();
+	}
+
+	setSelectorRef = selectorRef => {
+		if ( ! selectorRef ) {
+			return;
+		}
+
+		this.setState( { selectorRef } );
+	}
+
+	getPageForIndex( index ) {
+		const { query, lastPage, perPage } = this.props;
+		const itemsPerPage = query.number || perPage;
+		const page = Math.ceil( index / itemsPerPage );
+
+		return Math.max( Math.min( page, lastPage || Infinity ), 1 );
+	}
+
+	setRequestedPages = ( { startIndex, stopIndex } ) => {
+		const { requestedPages } = this.state;
+		const { loadOffset } = this.props;
+		const pagesToRequest = difference( range(
+			this.getPageForIndex( startIndex - loadOffset ),
+			this.getPageForIndex( stopIndex + loadOffset ) + 1
+		), requestedPages );
+
+		if ( ! pagesToRequest.length ) {
+			return;
+		}
+
+		this.setState( {
+			requestedPages: requestedPages.concat( pagesToRequest )
+		} );
+	}
+
+	hasNoSearchResults() {
+		return ! this.props.loading &&
+			( this.props.items && ! this.props.items.length ) &&
+			( this.props.query.search && !! this.props.query.search.length );
+	}
+
+	hasNoItems() {
+		return ! this.props.loading && ( this.props.items && ! this.props.items.length );
+	}
+
+	getItem( index ) {
+		if ( this.props.items ) {
+			return this.props.items[ index ];
+		}
+	}
+
+	isRowLoaded( { index } ) {
+		return this.props.lastPage || !! this.getItem( index );
+	}
+
+	getResultsWidth() {
+		const { selectorRef } = this.state;
+		if ( selectorRef ) {
+			return selectorRef.clientWidth;
+		}
+
+		return 0;
+	}
+
+	getRowCount() {
+		let count = 0;
+
+		if ( this.props.items ) {
+			count += this.props.items.length;
+		}
+
+		if ( this.props.loading || ! this.props.items ) {
+			count += 1;
+		}
+
+		return count;
+	}
+
+	setVirtualScrollRef = ref => {
+		this.virtualScroll = ref;
+	}
+
+	renderNoResults = () => {
+		if ( this.hasNoItems() ) {
+			return (
+				<div key="no-results" className="virtual-list__list-item is-empty">
+					No Results Found
+				</div>
+			);
+		}
+	}
+
+	render() {
+		const rowCount = this.getRowCount();
+		const { className, loading, renderQuery, height, defaultItemHeight, getRowHeight } = this.props;
+		const classes = classNames( 'virtual-list', className, {
+			'is-loading': loading
+		} );
+
+		return (
+			<div ref={ this.setSelectorRef } className={ classes }>
+				{ this.state.requestedPages.map( ( page ) => (
+					renderQuery( page )
+				) ) }
+				<VirtualScroll
+					ref={ this.setVirtualScrollRef }
+					width={ this.getResultsWidth() }
+					height={ height }
+					onRowsRendered={ this.setRequestedPages }
+					rowCount={ rowCount }
+					estimatedRowSize={ defaultItemHeight }
+					rowHeight={ getRowHeight }
+					rowRenderer={ this.props.renderRow }
+					noRowsRenderer={ this.renderNoResults }
+					className={ className } />
+			</div>
+		);
+	}
+}
+
+export default localize( VirtualList );

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -155,7 +155,7 @@ export class VirtualList extends Component {
 
 		// By falling back to the row height constant, we avoid an unnecessary
 		// forced update if all of the rows match our guessed height
-		const height = this.rowHeights[ index ] || this.this.props.defaultRowHeight;
+		const height = this.rowHeights[ index ] || this.props.defaultRowHeight;
 		const nextHeight = rowRef.clientHeight;
 		this.rowHeights[ index ] = nextHeight;
 
@@ -168,8 +168,10 @@ export class VirtualList extends Component {
 
 	renderRow = props => {
 		const element = this.props.renderRow( props );
+		if ( ! element ) {
+			return element;
+		}
 		const setRowRef = ( ...args ) => this.setRowRef( props.index, ...args );
-
 		return React.cloneElement( element, { ref: setRowRef } );
 	};
 

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -148,6 +148,31 @@ export class VirtualList extends Component {
 		}
 	}
 
+	setRowRef = ( index, rowRef ) => {
+		if ( ! rowRef ) {
+			return;
+		}
+
+		// By falling back to the row height constant, we avoid an unnecessary
+		// forced update if all of the rows match our guessed height
+		const height = this.rowHeights[ index ] || this.this.props.defaultRowHeight;
+		const nextHeight = rowRef.clientHeight;
+		this.rowHeights[ index ] = nextHeight;
+
+		// If height changes, wait until the end of the current call stack and
+		// fire a single forced update to recompute the row heights
+		if ( height !== nextHeight ) {
+			this.queueRecomputeRowHeights();
+		}
+	};
+
+	renderRow = props => {
+		const element = this.props.renderRow( props );
+		const setRowRef = ( ...args ) => this.setRowRef( props.index, ...args );
+
+		return React.cloneElement( element, { ref: setRowRef } );
+	};
+
 	render() {
 		const rowCount = this.getRowCount();
 		const { className, loading, height, defaultRowHeight, getRowHeight } = this.props;
@@ -165,7 +190,7 @@ export class VirtualList extends Component {
 					rowCount={ rowCount }
 					estimatedRowSize={ defaultRowHeight }
 					rowHeight={ getRowHeight }
-					rowRenderer={ this.props.renderRow }
+					rowRenderer={ this.renderRow }
 					noRowsRenderer={ this.renderNoResults }
 					className={ className } />
 			</div>

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -16,7 +16,7 @@ export class VirtualList extends Component {
 	static propTypes = {
 		items: PropTypes.array,
 		lastPage: PropTypes.number,
-		loading: PropTypes.boolean,
+		loading: PropTypes.bool,
 		getItemHeight: PropTypes.func,
 		renderItem: PropTypes.func,
 		renderQuery: PropTypes.func,
@@ -36,6 +36,7 @@ export class VirtualList extends Component {
 		perPage: 100,
 		loadOffset: 10,
 		height: 300,
+		query: {}
 	};
 
 	constructor( props ) {

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -5,6 +5,7 @@ import React, { PropTypes, Component } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import VirtualScroll from 'react-virtualized/VirtualScroll';
+import AutoSizer from 'react-virtualized/AutoSizer';
 import {
 	debounce,
 	noop,
@@ -22,8 +23,7 @@ export class VirtualList extends Component {
 		perPage: PropTypes.number,
 		loadOffset: PropTypes.number,
 		query: PropTypes.object,
-		defaultRowHeight: PropTypes.number,
-		height: PropTypes.number,
+		defaultRowHeight: PropTypes.number
 	};
 
 	static defaultProps = {
@@ -34,7 +34,6 @@ export class VirtualList extends Component {
 		renderRow: noop,
 		perPage: 100,
 		loadOffset: 10,
-		height: 300,
 		query: {}
 	};
 
@@ -71,14 +70,6 @@ export class VirtualList extends Component {
 		this.virtualScroll.forceUpdate();
 	}
 
-	setSelectorRef = selectorRef => {
-		if ( ! selectorRef ) {
-			return;
-		}
-
-		this.setState( { selectorRef } );
-	}
-
 	getPageForIndex( index ) {
 		const { query, lastPage, perPage } = this.props;
 		const rowsPerPage = query.number || perPage;
@@ -109,15 +100,6 @@ export class VirtualList extends Component {
 
 	hasNoRows() {
 		return ! this.props.loading && ( this.props.items && ! this.props.items.length );
-	}
-
-	getResultsWidth() {
-		const { selectorRef } = this.state;
-		if ( selectorRef ) {
-			return selectorRef.clientWidth;
-		}
-
-		return 0;
 	}
 
 	getRowCount() {
@@ -177,25 +159,30 @@ export class VirtualList extends Component {
 
 	render() {
 		const rowCount = this.getRowCount();
-		const { className, loading, height, defaultRowHeight, getRowHeight } = this.props;
+		const { className, loading, defaultRowHeight, getRowHeight } = this.props;
 		const classes = classNames( 'virtual-list', className, {
 			'is-loading': loading
 		} );
 
 		return (
-			<div ref={ this.setSelectorRef } className={ classes }>
-				<VirtualScroll
-					ref={ this.setVirtualScrollRef }
-					width={ this.getResultsWidth() }
-					height={ height }
-					onRowsRendered={ this.setRequestedPages }
-					rowCount={ rowCount }
-					estimatedRowSize={ defaultRowHeight }
-					rowHeight={ getRowHeight }
-					rowRenderer={ this.renderRow }
-					noRowsRenderer={ this.renderNoResults }
-					className={ className } />
-			</div>
+			<AutoSizer>
+				{ ( { height, width } ) => (
+					<div className={ classes }>
+						<VirtualScroll
+							ref={ this.setVirtualScrollRef }
+							onRowsRendered={ this.setRequestedPages }
+							rowCount={ rowCount }
+							estimatedRowSize={ defaultRowHeight }
+							rowHeight={ getRowHeight }
+							rowRenderer={ this.renderRow }
+							noRowsRenderer={ this.renderNoResults }
+							className={ className }
+							width={ width }
+							height={ height }
+						/>
+					</div>
+				) }
+			</AutoSizer>
 		);
 	}
 }

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -18,6 +18,7 @@ import { sectionify } from 'lib/route/path';
 import SiteSettingsComponent from 'my-sites/site-settings/main';
 import sitesFactory from 'lib/sites-list';
 import StartOver from './start-over';
+import Taxonomies from './taxonomies';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import titlecase from 'to-title-case';
 import utils from 'lib/site/utils';
@@ -168,6 +169,13 @@ module.exports = {
 		renderPage(
 			context,
 			<StartOver sites={ sites } path={ context.path } />
+		);
+	},
+
+	taxonomies( context ) {
+		renderPage(
+			context,
+			<Taxonomies taxonomy={ context.params.taxonomy } postType="post" />
 		);
 	},
 

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -216,7 +216,7 @@ const SiteSettingsFormWriting = React.createClass( {
 						</FormFieldset>
 					}
 				</Card>
-				{ config.isEnabled( 'manage/site-settings/categories' ) && <TaxonomyManager taxonomy="category" /> }
+				{ config.isEnabled( 'manage/site-settings/categories' ) && <TaxonomyManager taxonomy="category" postType="post" /> }
 			</form>
 		);
 	}

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -21,7 +21,7 @@ import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
 import QueryTerms from 'components/data/query-terms';
-import TaxonomyManager from 'blocks/taxonomy-manager';
+import TaxonomyCard from './taxonomies/taxonomy-card';
 import { isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
@@ -121,6 +121,12 @@ const SiteSettingsFormWriting = React.createClass( {
 		const markdownSupported = this.state.markdown_supported;
 		return (
 			<form id="site-settings" onSubmit={ this.submitFormAndActivateCustomContentModule } onChange={ this.markChanged }>
+				{ config.isEnabled( 'manage/site-settings/categories' ) &&
+					<div className="site-settings__taxonomies">
+						<TaxonomyCard taxonomy="category" postType="post" />
+						<TaxonomyCard taxonomy="post_tag" postType="post" />
+					</div>
+				}
 				<SectionHeader label={ this.translate( 'Writing Settings' ) }>
 					<Button
 						compact
@@ -216,7 +222,6 @@ const SiteSettingsFormWriting = React.createClass( {
 						</FormFieldset>
 					}
 				</Card>
-				{ config.isEnabled( 'manage/site-settings/categories' ) && <TaxonomyManager taxonomy="category" postType="post" /> }
 			</form>
 		);
 	}

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -33,5 +33,9 @@ module.exports = function() {
 		page( '/settings/start-over/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.startOver );
 	}
 
+	if ( config.isEnabled( 'manage/site-settings/categories' ) ) {
+		page( '/settings/taxonomies/:site_id/:taxonomy', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.taxonomies );
+	}
+
 	page( '/settings/:section', settingsController.legacyRedirects, controller.siteSelection, controller.sites );
 };

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -343,3 +343,7 @@
 .site-settings__jetpack-prompt-text {
 	flex: 4;
 }
+
+.site-settings__taxonomies {
+	margin-bottom: 17px;
+}

--- a/client/my-sites/site-settings/taxonomies/index.jsx
+++ b/client/my-sites/site-settings/taxonomies/index.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'components/header-cake';
+import TaxonomyManager from 'blocks/taxonomy-manager';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
+
+const Taxonomies = ( { labels, postType, site, taxonomy } ) => {
+	const goBack = () => {
+		page( '/settings/writing/' + site.slug );
+	};
+
+	return (
+		<div className="main main-column" role="main">
+			<HeaderCake onClick={ goBack }>
+				<h1>{ labels.name }</h1>
+			</HeaderCake>
+			<TaxonomyManager taxonomy={ taxonomy } postType={ postType } />
+		</div>
+	);
+};
+
+export default connect(
+	( state, { taxonomy, postType } ) => {
+		const siteId = getSelectedSiteId( state );
+		const site = getSelectedSite( state );
+		const labels = get( getPostTypeTaxonomy( state, siteId, postType, taxonomy ), 'labels', {} );
+		return {
+			site,
+			labels
+		};
+	}
+)( Taxonomies );

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -1,0 +1,5 @@
+.taxonomies__card-title {
+	font-size: 16px;
+	line-height: 24px;
+	color: $gray-dark;
+}

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
+import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
+
+import CompactCard from 'components/card/compact';
+
+const TaxonomyCard = ( { labels, site, taxonomy } ) => {
+	const settingsLink = `/settings/taxonomies/${ site.slug }/${ taxonomy }`;
+	return (
+		<CompactCard href={ settingsLink }>
+				<h2 className="taxonomies__card-title">{ labels.name }</h2>
+		</CompactCard>
+	);
+};
+
+export default connect(
+	( state, { taxonomy, postType } ) => {
+		const siteId = getSelectedSiteId( state );
+		const site = getSelectedSite( state );
+		const labels = get( getPostTypeTaxonomy( state, siteId, postType, taxonomy ), 'labels', {} );
+		return {
+			labels,
+			site
+		};
+	}
+)( TaxonomyCard );


### PR DESCRIPTION
This branch seeks to add live term data to the `<TaxonomyManager />` component.  Much like the `<TermTreeSelector />` - this component leverages `<VirtualScroll />` to create an infinite list of terms.

![site_settings_ _testingtimmy2_wordpress_com_ _wordpress_com 3](https://cloud.githubusercontent.com/assets/22080/19292554/c03fcd70-8fd1-11e6-9170-7e65443824cf.png)

**To Test**
Open settings for a site, and click on the "Writing" tab.  Currently the search box is functional, but no click events are wired up.

Before I get too far along in this branch - I'm marking it as Design Review in hopes for some feedback on the initial look above.  The eventual idea is to include an `<ElipsisMenu />` on each term card in the list.  The default action when clicking on a term would be to open an edit dialog for the term.

/cc @youknowriad 
