### PR TITLE
Component: Change Credit Card Form styles to make room for inline error mesages

### DIFF
--- a/client/blocks/credit-card-form/README.md
+++ b/client/blocks/credit-card-form/README.md
@@ -11,11 +11,11 @@ import CreditCardForm from 'blocks/credit-card-form';
 render() {
 	return (
 		<CreditCardForm
-			createPaygateToken={ ( cardDetails, callback ) => callback( null, 'token' ) }
-			initialValues={ { name: 'John Doe' } }
-			recordFormSubmitEvent={ () => {} }
-			saveStoredCard={ () => Promise.reject( { message: 'This is only example!' } ) }
-			successCallback={ () => {} } />
+			createPaygateToken={ createPaygateToken }
+			initialValues={ initialValues }
+			recordFormSubmitEvent={ noop }
+			saveStoredCard={ saveStoredCard }
+			successCallback={ noop } />
 	);
 }
 ```

--- a/client/blocks/credit-card-form/README.md
+++ b/client/blocks/credit-card-form/README.md
@@ -11,6 +11,7 @@ import CreditCardForm from 'blocks/credit-card-form';
 render() {
 	return (
 		<CreditCardForm
+			createPaygateToken={ ( cardDetails, callback ) => callback( null, 'token' ) }
 			initialValues={ { name: 'John Doe' } }
 			recordFormSubmitEvent={ () => {} }
 			saveStoredCard={ () => Promise.reject( { message: 'This is only example!' } ) }
@@ -21,6 +22,7 @@ render() {
 
 #### Props
 
+* `createPaygateToken`: Function to be executed when a valid form is submitted. It is responsible of a Paygate token creation which is the part of the flow.
 * `initialValues`: Optional object containing initial values for the form fields. At the moment only `name` is supported.
 * `recordFormSubmitEvent`: Function to be executed when the user clicks the _Save Card_ button.
 * `saveStoredCard`: Optional function returning _Promise_ to be executed when a Paygate token is created after the user clicked the _Save Card_ button. By default `wpcom.updateCreditCard` Redux action is executed because of legacy reasons.

--- a/client/blocks/credit-card-form/docs/example.jsx
+++ b/client/blocks/credit-card-form/docs/example.jsx
@@ -14,12 +14,14 @@ const CreditCardFormExample = () => {
 		name: 'John Doe'
 	};
 
+	const createPaygateToken = ( cardDetails, callback ) => callback( null, 'token' );
+
 	return (
 		<CreditCardForm
-			actionType="test"
+			createPaygateToken={ createPaygateToken }
 			initialValues={ initialValues }
 			recordFormSubmitEvent={ noop }
-			saveStoredCard={ () => Promise.reject( { message: 'This is only example' } ) }
+			saveStoredCard={ () => Promise.reject( { message: 'This is an example error.' } ) }
 			successCallback={ noop } />
 	);
 };

--- a/client/blocks/credit-card-form/docs/example.jsx
+++ b/client/blocks/credit-card-form/docs/example.jsx
@@ -16,6 +16,7 @@ const CreditCardFormExample = () => {
 
 	return (
 		<CreditCardForm
+			actionType="test"
 			initialValues={ initialValues }
 			recordFormSubmitEvent={ noop }
 			saveStoredCard={ () => Promise.reject( { message: 'This is only example' } ) }

--- a/client/blocks/credit-card-form/docs/example.jsx
+++ b/client/blocks/credit-card-form/docs/example.jsx
@@ -9,19 +9,20 @@ import React from 'react';
  */
 import CreditCardForm from 'blocks/credit-card-form';
 
+const createPaygateToken = ( cardDetails, callback ) => callback( null, 'token' );
+const saveStoredCard = () => Promise.reject( { message: 'This is an example error.' } );
+
 const CreditCardFormExample = () => {
 	const initialValues = {
 		name: 'John Doe'
 	};
-
-	const createPaygateToken = ( cardDetails, callback ) => callback( null, 'token' );
 
 	return (
 		<CreditCardForm
 			createPaygateToken={ createPaygateToken }
 			initialValues={ initialValues }
 			recordFormSubmitEvent={ noop }
-			saveStoredCard={ () => Promise.reject( { message: 'This is an example error.' } ) }
+			saveStoredCard={ saveStoredCard }
 			successCallback={ noop } />
 	);
 };

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -9,7 +9,6 @@ import React, { PropTypes } from 'react';
 import camelCase from 'lodash/camelCase';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
-import { createPaygateToken } from 'lib/store-transactions';
 import CreditCardFormFields from 'components/credit-card-form-fields';
 import CountriesList from 'lib/countries-list';
 import FormButton from 'components/forms/form-button';
@@ -30,8 +29,8 @@ const wpcom = wpcomFactory.undocumented();
 
 const CreditCardForm = React.createClass( {
 	propTypes: {
-		actionType: PropTypes.string.isRequired,
 		apiParams: PropTypes.object,
+		createPaygateToken: PropTypes.func.isRequired,
 		initialValues: PropTypes.object,
 		recordFormSubmitEvent: PropTypes.func.isRequired,
 		saveStoredCard: PropTypes.func,
@@ -150,7 +149,7 @@ const CreditCardForm = React.createClass( {
 	saveCreditCard() {
 		const cardDetails = this.getCardDetails();
 
-		createPaygateToken( this.props.actionType, cardDetails, ( paygateError, paygateToken ) => {
+		this.props.createPaygateToken( cardDetails, ( paygateError, paygateToken ) => {
 			if ( ! this._mounted ) {
 				return;
 			}

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -30,12 +30,12 @@ const wpcom = wpcomFactory.undocumented();
 
 const CreditCardForm = React.createClass( {
 	propTypes: {
+		actionType: PropTypes.string.isRequired,
 		apiParams: PropTypes.object,
 		initialValues: PropTypes.object,
 		recordFormSubmitEvent: PropTypes.func.isRequired,
 		saveStoredCard: PropTypes.func,
-		successCallback: PropTypes.func.isRequired,
-		actionType: PropTypes.string.isRequired
+		successCallback: PropTypes.func.isRequired
 	},
 
 	getInitialState() {
@@ -176,9 +176,8 @@ const CreditCardForm = React.createClass( {
 					if ( typeof message === 'object' ) {
 						notices.error( <ValidationErrorList messages={ values( message ) } /> );
 					} else {
-						notices.error( message )
+						notices.error( message );
 					}
-
 				} );
 			} else {
 				const apiParams = this.getParamsForApi( cardDetails, paygateToken, this.props.apiParams );
@@ -264,7 +263,9 @@ const CreditCardForm = React.createClass( {
 								{
 									components: {
 										tosLink: <a href="//wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />,
-										autoRenewalSupportPage: <a href={ support.AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />,
+										autoRenewalSupportPage: <a href={ support.AUTO_RENEWAL }
+											target="_blank"
+											rel="noopener noreferrer" />,
 										managePurchasesSupportPage: <a href={ support.MANAGE_PURCHASES }
 											target="_blank"
 											rel="noopener noreferrer" />

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -4,32 +4,32 @@
 	justify-content: space-between;
 	margin-left: -15px;
 
-	.credit-card-form-fields__field,
-	.credit-card-form-fields__label {
+	.credit-card-form-fields__field {
+		flex-basis: calc( 100% - 15px );
+		flex-grow: 1;
+		flex-shrink: 0;
 		margin-left: 15px;
 	}
 
-	.cvv,
-	.expiration-date {
-		flex-basis: 6em;
-		flex-grow: 1;
-		flex-shrink: 0;
-	}
-
 	.country {
-		flex-basis: auto;
-		flex-grow: 3;
-		flex-shrink: 0;
-
 		label {
 			display: none;
 		}
 	}
 
-	.postal-code {
-		flex-basis: 8em;
-		flex-grow: 2;
-		flex-shrink: 0;
+	@include breakpoint( ">480px" ) {
+		.cvv,
+		.expiration-date {
+			flex-basis: calc( 50% - 15px );
+		}
+
+		.country {
+			flex-basis: auto;
+		}
+
+		.postal-code {
+			flex-basis: 8em;
+		}
 	}
 }
 

--- a/client/me/payment-methods/add-credit-card/index.jsx
+++ b/client/me/payment-methods/add-credit-card/index.jsx
@@ -11,6 +11,7 @@ import React, { Component, PropTypes } from 'react';
 import { addStoredCard } from 'state/stored-cards/actions';
 import analytics from 'lib/analytics';
 import { concatTitle } from 'lib/react-helpers';
+import { createPaygateToken } from 'lib/store-transactions';
 import CreditCardForm from 'blocks/credit-card-form';
 import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake' ;
@@ -38,10 +39,10 @@ class AddCreditCard extends Component {
 				<HeaderCake onClick={ this.goToBillingHistory }>{ titles.addCreditCard }</HeaderCake>
 
 				<CreditCardForm
+					createPaygateToken={ createPaygateToken( 'card_add' ) }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
 					saveStoredCard={ this.props.addStoredCard }
-					successCallback={ this.goToBillingHistory }
-					actionType="card_add" />
+					successCallback={ this.goToBillingHistory } />
 			</Main>
 		);
 	}

--- a/client/me/payment-methods/add-credit-card/index.jsx
+++ b/client/me/payment-methods/add-credit-card/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { curry } from 'lodash';
 import page from 'page';
 import React, { Component, PropTypes } from 'react';
 
@@ -23,6 +24,11 @@ class AddCreditCard extends Component {
 		addStoredCard: PropTypes.func.isRequired
 	};
 
+	constructor( props ) {
+		super( props );
+		this.createPaygateToken = curry( createPaygateToken )( 'card_add' );
+	}
+
 	goToBillingHistory() {
 		page( '/me/billing' );
 	}
@@ -39,7 +45,7 @@ class AddCreditCard extends Component {
 				<HeaderCake onClick={ this.goToBillingHistory }>{ titles.addCreditCard }</HeaderCake>
 
 				<CreditCardForm
-					createPaygateToken={ createPaygateToken( 'card_add' ) }
+					createPaygateToken={ this.createPaygateToken }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
 					saveStoredCard={ this.props.addStoredCard }
 					successCallback={ this.goToBillingHistory } />

--- a/client/me/purchases/components/purchase-card-details/index.jsx
+++ b/client/me/purchases/components/purchase-card-details/index.jsx
@@ -3,17 +3,20 @@
  */
 import page from 'page';
 import { Component } from 'react';
+import { curry } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import analytics from 'lib/analytics';
+import { createPaygateToken } from 'lib/store-transactions';
 import { getPurchase, goToManagePurchase, isDataLoading } from 'me/purchases/utils';
 import paths from 'me/purchases/paths';
 
 class PurchaseCardDetails extends Component {
 	constructor( props ) {
 		super( props );
+		this.createPaygateToken = curry( createPaygateToken )( 'card_update' );
 		this.goToManagePurchase = this.goToManagePurchase.bind( this );
 		this.recordFormSubmitEvent = this.recordFormSubmitEvent.bind( this );
 		this.successCallback = this.successCallback.bind( this );

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -8,6 +8,7 @@ import React, { PropTypes } from 'react';
  * Internal Dependencies
  */
 import { clearPurchases } from 'state/purchases/actions';
+import { createPaygateToken } from 'lib/store-transactions';
 import CreditCardForm from 'blocks/credit-card-form';
 import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
@@ -64,9 +65,9 @@ class AddCardDetails extends PurchaseCardDetails {
 
 				<CreditCardForm
 					apiParams={ this.getApiParams() }
+					createPaygateToken={ createPaygateToken( 'card_update' ) }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
-					successCallback={ this.successCallback }
-					actionType='card_update' />
+					successCallback={ this.successCallback } />
 			</Main>
 		);
 	}

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -8,7 +8,6 @@ import React, { PropTypes } from 'react';
  * Internal Dependencies
  */
 import { clearPurchases } from 'state/purchases/actions';
-import { createPaygateToken } from 'lib/store-transactions';
 import CreditCardForm from 'blocks/credit-card-form';
 import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
@@ -65,7 +64,7 @@ class AddCardDetails extends PurchaseCardDetails {
 
 				<CreditCardForm
 					apiParams={ this.getApiParams() }
-					createPaygateToken={ createPaygateToken( 'card_update' ) }
+					createPaygateToken={ this.createPaygateToken }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
 					successCallback={ this.successCallback } />
 			</Main>

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -8,6 +8,7 @@ import React, { PropTypes } from 'react';
  * Internal Dependencies
  */
 import { clearPurchases } from 'state/purchases/actions';
+import { createPaygateToken } from 'lib/store-transactions';
 import CreditCardForm from 'blocks/credit-card-form';
 import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
@@ -70,10 +71,10 @@ class EditCardDetails extends PurchaseCardDetails {
 
 				<CreditCardForm
 					apiParams={ this.getApiParams() }
+					createPaygateToken={ createPaygateToken( 'card_update' ) }
 					initialValues={ this.props.card }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
-					successCallback={ this.successCallback }
-					actionType="card_update" />
+					successCallback={ this.successCallback } />
 			</Main>
 		);
 	}

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -8,7 +8,6 @@ import React, { PropTypes } from 'react';
  * Internal Dependencies
  */
 import { clearPurchases } from 'state/purchases/actions';
-import { createPaygateToken } from 'lib/store-transactions';
 import CreditCardForm from 'blocks/credit-card-form';
 import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
@@ -71,7 +70,7 @@ class EditCardDetails extends PurchaseCardDetails {
 
 				<CreditCardForm
 					apiParams={ this.getApiParams() }
-					createPaygateToken={ createPaygateToken( 'card_update' ) }
+					createPaygateToken={ this.createPaygateToken }
 					initialValues={ this.props.card }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
 					successCallback={ this.successCallback } />

--- a/client/my-sites/upgrades/components/form/country-select.jsx
+++ b/client/my-sites/upgrades/components/form/country-select.jsx
@@ -69,7 +69,7 @@ export default React.createClass( {
 						ref="input"
 						onChange={ this.props.onChange }
 						onClick={ this.recordCountrySelectClick }
-						isError={ this.props.isError } >
+						isError={ this.props.isError }>
 						{ options.map( option => (
 							<option
 								key={ option.key }

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -53,7 +53,7 @@ export default React.createClass( {
 	},
 
 	focus() {
-		var node = ReactDom.findDOMNode( this.refs.input );
+		const node = ReactDom.findDOMNode( this.refs.input );
 		node.focus();
 		scrollIntoViewport( node );
 	},


### PR DESCRIPTION
Part of #863.

From @breezyskies:
> The simplest option here would probably be moving country and postal code to their own line, giving both a bit more room for inline validation, all fields going to full width at the <480px breakpoint. A quick inspector mockup:
<img width="608" alt="7194dd68-8c5d-11e6-8f86-18717ff251aa" src="https://cloud.githubusercontent.com/assets/699132/19300727/20ce9a38-905c-11e6-9ebf-ae672a4028fa.png">


_I included also code refactoring which allows us to skip creating Paygate token on the server side when we tests Credit Card form on the Devdocs page._

### Before
This is how the current form would look like with inline error messages:
![57f0bbba-8c8b-11e6-9b4d-f121cff8d599](https://cloud.githubusercontent.com/assets/699132/19300606/741347f8-905b-11e6-97ec-4eb9f1b122ab.png)


### After changes

We should have more space to to add inline messages.

##### Mobile
![screen shot 2016-10-12 at 09 01 29](https://cloud.githubusercontent.com/assets/699132/19300527/12645484-905b-11e6-83a0-2bd2f826260d.png)

##### Tablet
![screen shot 2016-10-12 at 09 01 49](https://cloud.githubusercontent.com/assets/699132/19300638/a88f5814-905b-11e6-9a79-9b1f33c35fc2.png)


##### Desktop
![screen shot 2016-10-12 at 09 02 06](https://cloud.githubusercontent.com/assets/699132/19300646/ac894402-905b-11e6-8fa6-4f23b87df67b.png)

### Testing
1. Go to
  * http://calypso.localhost:3000/payment-methods/add-credit-card
  * or http://calypso.localhost:3000/devdocs/blocks
  * or go through checkout flow
2. Play with the updated Credit Card form.
3. Go to http://calypso.localhost:3000/payment-methods/add-credit-card and try to add a new card. Make sure it works as before.
4. Go through checkout flow and make sure it works as before.

/cc @breezyskies @fabianapsimoes 

