### PR TITLE
Notice: Add unit tests, Round 2

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -5,8 +5,9 @@ const React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	page = require( 'page' ),
 	times = require( 'lodash/times' ),
-	includes = require( 'lodash/includes' ),
-	Notice = require( 'components/notice' );
+	includes = require( 'lodash/includes' );
+
+import Notice from 'components/notice';
 
 /**
  * Internal dependencies

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -9,13 +9,14 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var cartItems = require( 'lib/cart-values' ).cartItems,
-	Notice = require( 'components/notice' ),
 	{ getFixedDomainSearch, canMap, canRegister } = require( 'lib/domains' ),
 	DomainRegistrationSuggestion = require( 'components/domains/domain-registration-suggestion' ),
 	DomainProductPrice = require( 'components/domains/domain-product-price' ),
 	analyticsMixin = require( 'lib/mixins/analytics' ),
 	{ getCurrentUser } = require( 'state/current-user/selectors' ),
 	support = require( 'lib/url/support' );
+
+import Notice from 'components/notice';
 
 var MapDomainStep = React.createClass( {
 	mixins: [ analyticsMixin( 'mapDomain' ) ],

--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -7,8 +7,8 @@ var React = require( 'react' ),
 /**
 * Internal dependencies
 */
-var NoticeAction = require( 'components/notice/notice-action' ),
-	Notice = require( 'components/notice' );
+var NoticeAction = require( 'components/notice/notice-action' );
+import Notice from 'components/notice';
 
 var Notices = React.createClass( {
 	mixins: [ PureRenderMixin ],

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -11,8 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import Gridicon from 'components/gridicon';
 
-export const UnwrappedNotice = React.createClass( {
-	displayName: 'Notice',
+export const Notice = React.createClass( {
 	dismissTimeout: null,
 
 	getDefaultProps() {
@@ -133,4 +132,4 @@ export const UnwrappedNotice = React.createClass( {
 	}
 } );
 
-export default localize( UnwrappedNotice );
+export default localize( Notice );

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -4,13 +4,14 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import noop from 'lodash/noop';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
 
-export default React.createClass( {
+export const UnwrappedNotice = React.createClass( {
 	displayName: 'Notice',
 	dismissTimeout: null,
 
@@ -115,7 +116,7 @@ export default React.createClass( {
 			dismiss = (
 				<span tabIndex="0" className="notice__dismiss" onClick={ this.props.onDismissClick } >
 					<Gridicon icon="cross" size={ 24 } />
-					<span className="screen-reader-text">{ this.translate( 'Dismiss' ) }</span>
+					<span className="screen-reader-text">{ this.props.translate( 'Dismiss' ) }</span>
 				</span>
 				);
 		}
@@ -131,3 +132,5 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default localize( UnwrappedNotice );

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -14,37 +14,36 @@ import { Notice } from '../index';
 describe( 'Notice', function() {
 	it( 'should output the component', function() {
 		const wrapper = shallow( <Notice translate={ identity } /> );
-		assert.isOk( true, wrapper.find( '.notice' ).length );
+		assert.isOk( wrapper.find( '.notice' ).length );
 	} );
 
 	it( 'should have dismiss button when showDismiss passed as true', function() {
 		const wrapper = shallow( <Notice showDismiss={ true } translate={ identity } /> );
-		assert.isOk( true, wrapper.find( '.is-dismissable' ).length );
+		assert.isOk( wrapper.find( '.is-dismissable' ).length );
 	} );
 
 	it( 'should have compact look when isCompact passed as true', function() {
 		const wrapper = shallow( <Notice isCompact={ true } translate={ identity } /> );
-		assert.isOk( true, wrapper.find( '.is-compact' ).length );
+		assert.isOk( wrapper.find( '.is-compact' ).length );
 	} );
 
 	it( 'should have proper class for is-info status parameter', function() {
 		const wrapper = shallow( <Notice status="is-info" translate={ identity } /> );
-		assert.isOk( true, wrapper.find( '.is-info' ).length );
+		assert.isOk( wrapper.find( '.is-info' ).length );
 	} );
 
 	it( 'should have proper class for is-success status parameter', function() {
 		const wrapper = shallow( <Notice status="is-success" translate={ identity } /> );
-		assert.equal( true, wrapper.find( '.is-success' ).length );
+		assert.isOk( wrapper.find( '.is-success' ).length );
 	} );
 
 	it( 'should have proper class for is-error status parameter', function() {
 		const wrapper = shallow( <Notice status="is-error" translate={ identity } /> );
-		assert.equal( true, wrapper.find( '.is-error' ).length );
+		assert.isOk( wrapper.find( '.is-error' ).length );
 	} );
 
 	it( 'should have proper class for is-warning status parameter', function() {
 		const wrapper = shallow( <Notice status="is-warning" translate={ identity } /> );
-		assert.isOk( true, wrapper.find( '.is-warning' ).length );
+		assert.isOk( wrapper.find( '.is-warning' ).length );
 	} );
-
 } );

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -9,49 +9,42 @@ import { identity } from 'lodash';
 /**
  * Internal dependencies
  */
-import { UnwrappedNotice } from '../index';
+import { Notice } from '../index';
 
 describe( 'index', function() {
-	require( 'test/helpers/use-fake-dom' )();
 	it( 'should output the component', function() {
-		const wrapper = shallow( <UnwrappedNotice translate={ identity } /> );
+		const wrapper = shallow( <Notice translate={ identity } /> );
 		assert.equal( true, wrapper.find( '.notice' ).length );
 	} );
 
 	it( 'should have dismiss button when showDismiss passed as true', function() {
-		const wrapper = shallow( <UnwrappedNotice showDismiss={ true } translate={ identity } /> );
+		const wrapper = shallow( <Notice showDismiss={ true } translate={ identity } /> );
 		assert.equal( true, wrapper.find( '.is-dismissable' ).length );
 	} );
 
 	it( 'should have compact look when isCompact passed as true', function() {
-		const wrapper = shallow( <UnwrappedNotice isCompact={ true } translate={ identity } /> );
+		const wrapper = shallow( <Notice isCompact={ true } translate={ identity } /> );
 		assert.equal( true, wrapper.find( '.is-compact' ).length );
 	} );
 
-	it( 'should have proper class and icon for is-info status parameter', function() {
-		const wrapper = shallow( <UnwrappedNotice status="is-info" translate={ identity } /> );
+	it( 'should have proper class for is-info status parameter', function() {
+		const wrapper = shallow( <Notice status="is-info" translate={ identity } /> );
 		assert.equal( true, wrapper.find( '.is-info' ).length );
+	} );
 
-		console.log( wrapper.children().nodes );
-		
-		/*expect( wrapper.children().contains( [
-			<svg />,
-		] ) ).to.equal( true ); */
-		//	<svg className="gridicon gridicons-info notice__icon" height="24" width="24" />,
-
-
-		//assert.equal( true, wrapper.find( 'svg' ).length );
-		//assert.equal( true, wrapper.children().find( '.gridicons-info' ).length );
-		//console.log( wrapper.children() );
-
-/*		const wrapper = shallow( <UnwrappedNotice status="is-success" translate={ identity } /> );
+	it( 'should have proper class for is-success status parameter', function() {
+		const wrapper = shallow( <Notice status="is-success" translate={ identity } /> );
 		assert.equal( true, wrapper.find( '.is-success' ).length );
+	} );
 
-		const wrapper = shallow( <UnwrappedNotice status="is-error" translate={ identity } /> );
+	it( 'should have proper class for is-error status parameter', function() {
+		const wrapper = shallow( <Notice status="is-error" translate={ identity } /> );
 		assert.equal( true, wrapper.find( '.is-error' ).length );
+	} );
 
-		const wrapper = shallow( <UnwrappedNotice status="is-warning" translate={ identity } /> );
-		assert.equal( true, wrapper.find( '.is-warning' ).length ); */
+	it( 'should have proper class for is-warning status parameter', function() {
+		const wrapper = shallow( <Notice status="is-warning" translate={ identity } /> );
+		assert.equal( true, wrapper.find( '.is-warning' ).length );
 	} );
 
 } );

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -18,4 +18,40 @@ describe( 'index', function() {
 		assert.equal( true, wrapper.find( '.notice' ).length );
 	} );
 
+	it( 'should have dismiss button when showDismiss passed as true', function() {
+		const wrapper = shallow( <UnwrappedNotice showDismiss={ true } translate={ identity } /> );
+		assert.equal( true, wrapper.find( '.is-dismissable' ).length );
+	} );
+
+	it( 'should have compact look when isCompact passed as true', function() {
+		const wrapper = shallow( <UnwrappedNotice isCompact={ true } translate={ identity } /> );
+		assert.equal( true, wrapper.find( '.is-compact' ).length );
+	} );
+
+	it( 'should have proper class and icon for is-info status parameter', function() {
+		const wrapper = shallow( <UnwrappedNotice status="is-info" translate={ identity } /> );
+		assert.equal( true, wrapper.find( '.is-info' ).length );
+
+		console.log( wrapper.children().nodes );
+		
+		/*expect( wrapper.children().contains( [
+			<svg />,
+		] ) ).to.equal( true ); */
+		//	<svg className="gridicon gridicons-info notice__icon" height="24" width="24" />,
+
+
+		//assert.equal( true, wrapper.find( 'svg' ).length );
+		//assert.equal( true, wrapper.children().find( '.gridicons-info' ).length );
+		//console.log( wrapper.children() );
+
+/*		const wrapper = shallow( <UnwrappedNotice status="is-success" translate={ identity } /> );
+		assert.equal( true, wrapper.find( '.is-success' ).length );
+
+		const wrapper = shallow( <UnwrappedNotice status="is-error" translate={ identity } /> );
+		assert.equal( true, wrapper.find( '.is-error' ).length );
+
+		const wrapper = shallow( <UnwrappedNotice status="is-warning" translate={ identity } /> );
+		assert.equal( true, wrapper.find( '.is-warning' ).length ); */
+	} );
+
 } );

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { UnwrappedNotice } from '../index';
+
+describe( 'index', function() {
+	require( 'test/helpers/use-fake-dom' )();
+	it( 'should output the component', function() {
+		const wrapper = shallow( <UnwrappedNotice translate={ identity } /> );
+		assert.equal( true, wrapper.find( '.notice' ).length );
+	} );
+
+} );

--- a/client/components/notice/test/index.js
+++ b/client/components/notice/test/index.js
@@ -11,25 +11,25 @@ import { identity } from 'lodash';
  */
 import { Notice } from '../index';
 
-describe( 'index', function() {
+describe( 'Notice', function() {
 	it( 'should output the component', function() {
 		const wrapper = shallow( <Notice translate={ identity } /> );
-		assert.equal( true, wrapper.find( '.notice' ).length );
+		assert.isOk( true, wrapper.find( '.notice' ).length );
 	} );
 
 	it( 'should have dismiss button when showDismiss passed as true', function() {
 		const wrapper = shallow( <Notice showDismiss={ true } translate={ identity } /> );
-		assert.equal( true, wrapper.find( '.is-dismissable' ).length );
+		assert.isOk( true, wrapper.find( '.is-dismissable' ).length );
 	} );
 
 	it( 'should have compact look when isCompact passed as true', function() {
 		const wrapper = shallow( <Notice isCompact={ true } translate={ identity } /> );
-		assert.equal( true, wrapper.find( '.is-compact' ).length );
+		assert.isOk( true, wrapper.find( '.is-compact' ).length );
 	} );
 
 	it( 'should have proper class for is-info status parameter', function() {
 		const wrapper = shallow( <Notice status="is-info" translate={ identity } /> );
-		assert.equal( true, wrapper.find( '.is-info' ).length );
+		assert.isOk( true, wrapper.find( '.is-info' ).length );
 	} );
 
 	it( 'should have proper class for is-success status parameter', function() {
@@ -44,7 +44,7 @@ describe( 'index', function() {
 
 	it( 'should have proper class for is-warning status parameter', function() {
 		const wrapper = shallow( <Notice status="is-warning" translate={ identity } /> );
-		assert.equal( true, wrapper.find( '.is-warning' ).length );
+		assert.isOk( true, wrapper.find( '.is-warning' ).length );
 	} );
 
 } );

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -17,10 +17,11 @@ var Dialog = require( 'components/dialog' ),
 	FormButtonsBar = require( 'components/forms/form-buttons-bar' ),
 	FormInputValidation = require( 'components/forms/form-input-validation' ),
 	observe = require( 'lib/mixins/data-observe' ),
-	Notice = require( 'components/notice' ),
 	eventRecorder = require( 'me/event-recorder' ),
 	userUtilities = require( 'lib/user/utils' ),
 	constants = require( 'me/constants' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -12,8 +12,9 @@ var	FormButton = require( 'components/forms/form-button' ),
 	FormButtonBar = require( 'components/forms/form-buttons-bar' ),
 	FormCheckbox = require( 'components/forms/form-checkbox' ),
 	FormLabel = require( 'components/forms/form-label' ),
-	config = require( 'config' ),
-	Notice = require( 'components/notice' );
+	config = require( 'config' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -12,10 +12,11 @@ var FormButton = require( 'components/forms/form-button' ),
 	FormFieldset = require( 'components/forms/form-fieldset' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormTelInput = require( 'components/forms/form-tel-input' ),
-	Notice = require( 'components/notice' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	analytics = require( 'lib/analytics' ),
 	constants = require( 'me/constants' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -13,8 +13,9 @@ var Security2faBackupCodesPrompt = require( 'me/security-2fa-backup-codes-prompt
 	Card = require( 'components/card' ),
 	eventRecorder = require( 'me/event-recorder' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	Security2faBackupCodesList = require( 'me/security-2fa-backup-codes-list' ),
-	Notice = require( 'components/notice' );
+	Security2faBackupCodesList = require( 'me/security-2fa-backup-codes-list' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -13,11 +13,12 @@ var FormButton = require( 'components/forms/form-button' ),
 	FormFieldset = require( 'components/forms/form-fieldset' ),
 	FormSettingExplanation = require( 'components/forms/form-setting-explanation' ),
 	FormTelInput = require( 'components/forms/form-tel-input' ),
-	Notice = require( 'components/notice' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	analytics = require( 'lib/analytics' ),
 	constants = require( 'me/constants' ),
 	FormButtonsBar = require( 'components/forms/form-buttons-bar' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -14,12 +14,13 @@ var FormButton = require( 'components/forms/form-button' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormSettingExplanation = require( 'components/forms/form-setting-explanation' ),
 	FormTelInput = require( 'components/forms/form-tel-input' ),
-	Notice = require( 'components/notice' ),
 	Security2faProgress = require( 'me/security-2fa-progress' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	analytics = require( 'lib/analytics' ),
 	constants = require( 'me/constants' ),
 	FormButtonsBar = require( 'components/forms/form-buttons-bar' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -7,12 +7,13 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var Notice = require( 'components/notice' ),
-	Security2faBackupCodesList = require( 'me/security-2fa-backup-codes-list' ),
+var Security2faBackupCodesList = require( 'me/security-2fa-backup-codes-list' ),
 	Security2faProgress = require( 'me/security-2fa-progress' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	eventRecorder = require( 'me/event-recorder' ),
 	support = require( 'lib/url/support' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -14,10 +14,11 @@ var countriesList = require( 'lib/countries-list' ).forSms(),
 	formBase = require( 'me/form-base' ),
 	FormButton = require( 'components/forms/form-button' ),
 	FormButtonsBar = require( 'components/forms/form-buttons-bar' ),
-	Notice = require( 'components/notice' ),
 	protectForm = require( 'lib/mixins/protect-form' ),
 	Security2faProgress = require( 'me/security-2fa-progress' ),
 	analytics = require( 'lib/analytics' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -11,7 +11,6 @@ var React = require( 'react' ),
  */
 var CompactCard = require( 'components/card/compact' ),
 	Gridicon = require( 'components/gridicon' ),
-	Notice = require( 'components/notice' ),
 	NoticeAction = require( 'components/notice/notice-action' ),
 	SiteIcon = require( 'components/site-icon' ),
 	PostRelativeTimeStatus = require( 'my-sites/post-relative-time-status' ),
@@ -24,6 +23,7 @@ var CompactCard = require( 'components/card/compact' ),
 
 import Gravatar from 'components/gravatar';
 import photon from 'photon';
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 

--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -10,8 +10,9 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var Dialog = require( 'components/dialog' ),
-	AccountDialogAccount = require( './account-dialog-account' ),
-	Notice = require( 'components/notice' );
+	AccountDialogAccount = require( './account-dialog-account' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 	displayName: 'AccountDialog',

--- a/client/my-sites/upgrades/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/upgrades/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -21,7 +21,6 @@ const analyticsMixin = require( 'lib/mixins/analytics' ),
 	FormTextInputWithAffixes = require( 'components/forms/form-text-input-with-affixes' ),
 	cartItems = require( 'lib/cart-values' ).cartItems,
 	paths = require( 'my-sites/upgrades/paths' ),
-	Notice = require( 'components/notice' ),
 	ValidationErrorList = require( 'notices/validation-error-list' ),
 	upgradesActions = require( 'lib/upgrades/actions' ),
 	{ hasGoogleApps, getGoogleAppsSupportedDomains } = require( 'lib/domains' ),
@@ -29,6 +28,8 @@ const analyticsMixin = require( 'lib/mixins/analytics' ),
 	validateUsers = googleAppsLibrary.validate,
 	filterUsers = googleAppsLibrary.filter,
 	DomainsSelect = require( './domains-select' );
+
+import Notice from 'components/notice';
 
 const AddEmailAddressesCard = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'addGoogleApps' ) ],

--- a/client/my-sites/upgrades/domain-management/site-redirect/notice.jsx
+++ b/client/my-sites/upgrades/domain-management/site-redirect/notice.jsx
@@ -6,9 +6,10 @@ var React = require( 'react' );
 /**
  * Internal dependencies
  */
-var Notice = require( 'components/notice' ),
-	notices = require( 'notices' ),
+var notices = require( 'notices' ),
 	upgradesActions = require( 'lib/upgrades/actions' );
+
+import Notice from 'components/notice';
 
 var SiteRedirectNotice = React.createClass( {
 	propTypes: {

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -10,7 +10,6 @@ var page = require( 'page' ),
  * Internal dependencies
  */
 var HeaderCake = require( 'components/header-cake' ),
-	Notice = require( 'components/notice' ),
 	MapDomainStep = require( 'components/domains/map-domain-step' ),
 	{ currentUserHasFlag } = require( 'state/current-user/selectors' ),
 	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
@@ -19,6 +18,8 @@ var HeaderCake = require( 'components/header-cake' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	wpcom = require( 'lib/wp' ).undocumented(),
 	paths = require( 'my-sites/upgrades/paths' );
+
+import Notice from 'components/notice';
 
 var MapDomain = React.createClass( {
 	mixins: [ observe( 'productsList', 'sites' ) ],

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -9,9 +9,10 @@ const React = require( 'react' ),
  */
 const PostActions = require( 'lib/posts/actions' ),
 	EditorDrawerWell = require( 'post-editor/editor-drawer-well' ),
-	Notice = require( 'components/notice' ),
 	stats = require( 'lib/posts/stats' ),
 	EditorLocationSearch = require( './search' );
+
+import Notice from 'components/notice';
 
 /**
  * Module variables

--- a/client/reader/post-errors/index.jsx
+++ b/client/reader/post-errors/index.jsx
@@ -7,11 +7,12 @@ var React = require( 'react' ),
 var FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions/index' ),
 	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' ),
 	FeedSubscriptionStoreErrorTypes = require( 'lib/reader-feed-subscriptions/constants' ).error,
-	Notice = require( 'components/notice' ),
 	SiteBlockStore = require( 'lib/reader-site-blocks/index' ),
 	SiteBlockActions = require( 'lib/reader-site-blocks/actions' ),
 	SiteBlockStoreErrorTypes = require( 'lib/reader-site-blocks/constants' ).error,
 	stats = require( 'reader/stats' );
+
+import Notice from 'components/notice';
 
 var PostErrors = React.createClass( {
 

--- a/client/signup/locale-suggestions/index.jsx
+++ b/client/signup/locale-suggestions/index.jsx
@@ -10,8 +10,9 @@ var i18n = require( 'i18n-calypso'),
  */
 var i18nUtils = require( 'lib/i18n-utils' ),
 	switchLocale = require( 'lib/i18n-utils/switch-locale' ),
-	LocaleSuggestionStore = require( 'lib/locale-suggestions' ),
-	Notice = require( 'components/notice' );
+	LocaleSuggestionStore = require( 'lib/locale-suggestions' );
+
+import Notice from 'components/notice';
 
 module.exports = React.createClass( {
 	displayName: 'LocaleSuggestions',

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -17,12 +17,13 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	MapDomainStep = require( 'components/domains/map-domain-step' ),
 	RegisterDomainStep = require( 'components/domains/register-domain-step' ),
 	GoogleApps = require( 'components/upgrades/google-apps' ),
-	Notice = require( 'components/notice' ),
 	{ getCurrentUser, currentUserHasFlag } = require( 'state/current-user/selectors' ),
 	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
 	analyticsMixin = require( 'lib/mixins/analytics' ),
 	signupUtils = require( 'signup/utils' ),
 	abtest = require( 'lib/abtest' ).abtest;
+
+import Notice from 'components/notice';
 
 const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
 	mapDomainAnalytics = analyticsMixin( 'mapDomain' );


### PR DESCRIPTION
This is a fresh pull request containing a merged, rebased version of the code in https://github.com/Automattic/wp-calypso/pull/8536. That old PR was reverted due to errors in devdocs on production, but the original intention was to fix #7941.

The error occurred on the [UI Components docs page](https://wpcalypso.wordpress.com/devdocs/design), and looked like this: 

```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. Check the render method of 'Notices'
```

This PR contains the same issue, and some more warnings:

```
warning.js:36 Warning: React.createElement: type should not be null, undefined, boolean, or number. It should be a string (for DOM elements) or a ReactClass (for composite components). Check the render method of `Notices`.
```

Error can be tested on http://calypso.localhost:3000/devdocs

Hoping to fix the error and reinstate the Notice component translate refactor, as well as the tests. CC: @aduth and because you expressed interest yesterday, @lamosty.
