### PR TITLE
Signup: Make the get-dot-blog signup flow live for production

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -173,6 +173,13 @@ const flows = {
 	jetpack: {
 		steps: [ 'jetpack-user' ],
 		destination: '/'
+	},
+
+	'get-dot-blog': {
+		steps: [ 'get-dot-blog-survey', 'get-dot-blog-themes', 'get-dot-blog-plans' ],
+		destination: getSiteDestination,
+		description: 'Used by `get.blog` users that connect their site to WordPress.com',
+		lastModified: '2016-10-03'
 	}
 };
 
@@ -182,13 +189,6 @@ if ( config( 'env' ) === 'development' ) {
 		destination: getSiteDestination,
 		description: 'This flow is used to test plans choice in signup',
 		lastModified: '2016-06-30'
-	};
-
-	flows[ 'get-dot-blog' ] = {
-		steps: [ 'get-dot-blog-survey', 'get-dot-blog-themes', 'get-dot-blog-plans' ],
-		destination: getSiteDestination, 
-		description: 'Used by `get.blog` users that connect their site to WordPress.com',
-		lastModified: '2016-10-03'
 	};
 }
 


### PR DESCRIPTION
This makes the new `get-dot-blog` signup flow, which will be used by http://get.blog, live in production, not just development, so we can start using it.
  
I am not sure how to test this. When you I try to run Calypso in production mode (`CALYPSO_ENV=production make run`) I am always logged out. It might be easiest to just merge it and test in `wpcalypos` and `staging` since this is a simple change.

#### Reviews
  
- [x] Code
- [ ] Product
   
@Automattic/sdev-feed