### PR TITLE
Update/plans add missing tests for get current plan

### DIFF
--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import {
 	getPlanRawDiscount,
 	getPlansBySite,
 	getPlansBySiteId,
+	getCurrentPlan,
 	hasDomainCredit,
 	isRequestingSitePlans,
 	isSitePlanDiscounted
@@ -53,6 +55,73 @@ describe( 'selectors', () => {
 			expect( plans ).to.eql( plans1 );
 		} );
 	} );
+	describe( '#getCurrentPlan()', () => {
+		context( 'when no plan data is found for the given siteId', () => {
+			const siteId = 77203074;
+			const state = deepFreeze( {
+				sites: {
+					plans: {
+						[ siteId ]: {}
+					}
+				}
+			} );
+
+			it( 'returns null', () => {
+				const plan = getCurrentPlan( state, siteId );
+				expect( plan ).to.eql( null );
+			} );
+		} );
+
+		context( 'when plans are found for the given siteId', () => {
+			context( 'when those plans include a \'currentPlan\'', () => {
+				const siteId = 77203074;
+				const plan1 = { currentPlan: true };
+				const state = deepFreeze( {
+					sites: {
+						plans: {
+							[ siteId ]: {
+								data: [ plan1 ]
+							}
+						},
+						items: {
+							[ siteId ]: {
+								URL: 'https://example.wordpress.com'
+							}
+						}
+					}
+				} );
+
+				it( 'returns the currentPlan', () => {
+					const plan = getCurrentPlan( state, siteId );
+					expect( plan ).to.eql( plan1 );
+				} );
+			} );
+
+			context( 'when those plans do not include a \'currentPlan\'', () => {
+				const siteId = 77203074;
+				const plan1 = { currentPlan: false };
+				const state = deepFreeze( {
+					sites: {
+						plans: {
+							[ siteId ]: {
+								data: [ plan1 ]
+							}
+						},
+						items: {
+							[ siteId ]: {
+								URL: 'https://example.wordpress.com'
+							}
+						}
+					}
+				} );
+
+				it( 'returns a new sitePlanObject', () => {
+					const plan = getCurrentPlan( state, siteId );
+					expect( plan ).to.eql( {} );
+				} );
+			} );
+		} );
+	} );
 	describe( '#getSitePlan()', () => {
 		it( 'should return plans by site and plan slug', () => {
 			const plans1 = {
@@ -64,6 +133,7 @@ describe( 'selectors', () => {
 					productSlug: 'silver'
 				}, { currentPlan: true, productSlug: 'bronze' } ]
 			};
+
 			const plans2 = {
 				data: [ {
 					currentPlan: true,


### PR DESCRIPTION
I was rooting around the plans selectors while working on another PR and noticed that 'getCurrentPlan' was not covered in the unit tests.

This is my first crack at using mockery & useMockery so please do let me know if I can improve on this :D
I've used it only in the case where the mocked method would be called, but can make a quick change to apply it before any 'getCurrentPlan' tests for the sake of consistency :)

Also I've used context(...) as this is a pattern I personally like but I've seen a mix of tests in the project that do take that approach and that don't take that approach and instead just have longer descriptions - happy to change if one is preferred over the other!

TIA!

cc @retrofox , @gwwar