### PR TITLE
WIP - Image Editor animations

### DIFF
--- a/client/post-editor/media-modal/image-editor/_style.scss
+++ b/client/post-editor/media-modal/image-editor/_style.scss
@@ -42,6 +42,7 @@
 }
 
 .editor-media-modal-image-editor__canvas {
+	display: none;
 	position: absolute;
 	top: 50%;
 	left: 50%;
@@ -50,6 +51,20 @@
 	&.is-placeholder {
 		@include placeholder-dark();
 	}
+}
+
+.editor-media-modal-image-editor__image {
+	position: absolute;
+	max-width: none;
+	z-index: z-index( '.dialog__backdrop', '.editor-media-modal-image-editor__canvas' );
+	opacity: 0.5;
+	transform-origin: 0 0;
+}
+
+.editor-media-modal-image-editor__crop-container {
+	position: relative;
+	width: 100%;
+	height: 100%;
 }
 
 .editor-media-modal-image-editor__crop {

--- a/client/post-editor/media-modal/image-editor/_style.scss
+++ b/client/post-editor/media-modal/image-editor/_style.scss
@@ -53,6 +53,15 @@
 	}
 }
 
+.editor-media-modal-image-editor__canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .editor-media-modal-image-editor__image {
 	position: absolute;
 	max-width: none;

--- a/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-canvas.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import noop from 'lodash/noop';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -25,7 +24,7 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	propTypes: {
 		src: React.PropTypes.string,
 		mimeType: React.PropTypes.string,
-		transform: React.PropTypes.shape( {
+		transfrom: React.PropTypes.shape( {
 			degrees: React.PropTypes.number,
 			scaleX: React.PropTypes.number,
 			scaleY: React.PropTypes.number
@@ -36,14 +35,7 @@ const MediaModalImageEditorCanvas = React.createClass( {
 			widthRatio: React.PropTypes.number,
 			heightRatio: React.PropTypes.number,
 		} ),
-		setImageEditorCropBounds: React.PropTypes.func,
-		onLoadError: React.PropTypes.func
-	},
-
-	getInitialState() {
-		return {
-			imageLoaded: false
-		};
+		setImageEditorCropBounds: React.PropTypes.func
 	},
 
 	getDefaultProps() {
@@ -59,28 +51,22 @@ const MediaModalImageEditorCanvas = React.createClass( {
 				cropWidthRatio: 1,
 				cropHeightRatio: 1,
 			},
-			setImageEditorCropBounds: noop,
-			onLoadError: noop,
+			setImageEditorCropBounds: noop
 		};
 	},
 
 	componentWillReceiveProps( newProps ) {
-		this.getImage( newProps.src );
+		if ( this.props.src !== newProps.src ) {
+			this.initImage( newProps.src );
+		}
 	},
 
-	getImage( url ) {
-		const { onLoadError, mimeType } = this.props;
+	componentDidMount() {
+		if ( ! this.props.src ) {
+			return;
+		}
 
-		const req = new XMLHttpRequest();
-		req.open( 'GET', url + '?', true ); // Fix #7991 by forcing Safari to ignore cache and perform valid CORS request
-		req.responseType = 'arraybuffer';
-		req.onload = () => {
-			const objectURL = window.URL.createObjectURL( new Blob( [ req.response ], { type: mimeType } ) );
-			this.initImage( objectURL );
-		};
-
-		req.onerror = error => onLoadError( error );
-		req.send();
+		this.initImage( this.props.src );
 	},
 
 	initImage( src ) {
@@ -97,10 +83,6 @@ const MediaModalImageEditorCanvas = React.createClass( {
 
 		this.drawImage();
 		this.updateCanvasPosition();
-
-		this.setState( {
-			imageLoaded: true
-		} );
 	},
 
 	componentDidUpdate() {
@@ -135,6 +117,8 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	},
 
 	drawImage() {
+		return;
+
 		if ( ! this.image ) {
 			return;
 		}
@@ -167,6 +151,8 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	},
 
 	updateCanvasPosition() {
+		return;
+
 		const canvas = ReactDom.findDOMNode( this.refs.canvas );
 		const canvasX = - 50 * this.props.crop.widthRatio - 100 * this.props.crop.leftRatio;
 		const canvasY = - 50 * this.props.crop.heightRatio - 100 * this.props.crop.topRatio;
@@ -184,33 +170,17 @@ const MediaModalImageEditorCanvas = React.createClass( {
 	},
 
 	renderCrop() {
+		if ( ! this.props.src ) {
+			return;
+		}
+
 		return ( <Crop /> );
 	},
 
 	render() {
-		const canvasX = - 50 * this.props.crop.widthRatio - 100 * this.props.crop.leftRatio;
-		const canvasY = - 50 * this.props.crop.heightRatio - 100 * this.props.crop.topRatio;
-
-		const canvasStyle = {
-			transform: 'translate(' + canvasX + '%, ' + canvasY + '%)',
-			maxWidth: ( 85 / this.props.crop.widthRatio ) + '%',
-			maxHeight: ( 85 / this.props.crop.heightRatio ) + '%'
-		};
-
-		const { imageLoaded } = this.state;
-
-		const canvasClasses = classNames( 'editor-media-modal-image-editor__canvas', {
-			'is-placeholder': ! imageLoaded
-		} );
-
 		return (
 			<div className="editor-media-modal-image-editor__canvas-container">
-				{ imageLoaded && this.renderCrop() }
-				<canvas
-					ref="canvas"
-					style={ canvasStyle }
-					onMouseDown={ this.preventDrag }
-					className={ canvasClasses } />
+				{ this.renderCrop() }
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/image-editor/image-editor-crop.jsx
+++ b/client/post-editor/media-modal/image-editor/image-editor-crop.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import isEqual from 'lodash/isEqual';
+import clone from 'lodash/clone';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
 
@@ -12,7 +12,7 @@ import classNames from 'classnames';
  */
 import Draggable from 'components/draggable';
 import {
-	getImageEditorCropBounds,
+	getImageEditorFileInfo,
 	getImageEditorAspectRatio,
 	getImageEditorTransform,
 	getImageEditorCrop
@@ -24,12 +24,7 @@ const MediaModalImageEditorCrop = React.createClass( {
 
 	propTypes: {
 		degrees: React.PropTypes.number,
-		bounds: React.PropTypes.shape( {
-			topBound: React.PropTypes.number,
-			leftBound: React.PropTypes.number,
-			bottomBound: React.PropTypes.number,
-			rightBound: React.PropTypes.number,
-		} ),
+		src: React.PropTypes.string,
 		crop: React.PropTypes.shape( {
 			topRatio: React.PropTypes.number,
 			leftRatio: React.PropTypes.number,
@@ -37,111 +32,111 @@ const MediaModalImageEditorCrop = React.createClass( {
 			heightRatio: React.PropTypes.number,
 		} ),
 		aspectRatio: React.PropTypes.string,
-		imageEditorCrop: React.PropTypes.func,
-		minCropSize: React.PropTypes.shape( {
-			width: React.PropTypes.number,
-			height: React.PropTypes.number
-		} )
+		imageEditorCrop: React.PropTypes.func
 	},
 
 	getDefaultProps() {
 		return {
 			degrees: 0,
-			bounds: {
-				topBound: 0,
-				leftBound: 0,
-				bottomBound: 100,
-				rightBound: 100,
-			},
-			imageEditorCrop: noop,
-			minCropSize: {
-				width: 50,
-				height: 50
-			}
+			src: null,
+			imageEditorCrop: noop
 		};
 	},
 
 	getInitialState() {
-		return this.getDefaultState( this.props );
-	},
-
-	getDefaultState( props ) {
 		return {
-			top: props.bounds.topBound,
-			left: props.bounds.leftBound,
-			bottom: props.bounds.bottomBound,
-			right: props.bounds.rightBound
+			top: 0,
+			left: 0,
+			bottom: 0,
+			right: 0,
+			widthRatio: 1,
+			heightRatio: 1,
+			bounds: {
+				top: 0,
+				left: 0,
+				bottom: 0,
+				right: 0
+			}
 		};
 	},
 
-	componentWillReceiveProps( newProps ) {
-		if ( ! isEqual( this.props.bounds, newProps.bounds ) ) {
-			const imageWidth = newProps.bounds.rightBound - newProps.bounds.leftBound;
-			const imageHeight = newProps.bounds.bottomBound - newProps.bounds.topBound;
-			const newTop = newProps.bounds.topBound + newProps.crop.topRatio * imageHeight;
-			const newLeft = newProps.bounds.leftBound + newProps.crop.leftRatio * imageWidth;
-			const newBottom = newTop + newProps.crop.heightRatio * imageHeight;
-			const newRight = newLeft + newProps.crop.widthRatio * imageWidth;
+	// componentWillReceiveProps( newProps ) {
+	// 	if ( ! isEqual( this.props.bounds, newProps.bounds ) ) {
+	// 		const imageWidth = newProps.bounds.rightBound - newProps.bounds.leftBound;
+	// 		const imageHeight = newProps.bounds.bottomBound - newProps.bounds.topBound;
+	// 		const newTop = newProps.bounds.topBound + newProps.crop.topRatio * imageHeight;
+	// 		const newLeft = newProps.bounds.leftBound + newProps.crop.leftRatio * imageWidth;
+	// 		const newBottom = newTop + newProps.crop.heightRatio * imageHeight;
+	// 		const newRight = newLeft + newProps.crop.widthRatio * imageWidth;
+	//
+	// 		this.setState( {
+	// 			top: newTop,
+	// 			left: newLeft,
+	// 			bottom: newBottom,
+	// 			right: newRight
+	// 		} );
+	// 	}
+	//
+	// 	if ( this.props.aspectRatio !== newProps.aspectRatio ) {
+	// 		this.updateCrop( this.getDefaultState( newProps ), newProps, this.applyCrop );
+	// 	}
+	// },
 
-			this.setState( {
-				top: newTop,
-				left: newLeft,
-				bottom: newBottom,
-				right: newRight
-			} );
-		}
-
-		if ( this.props.aspectRatio !== newProps.aspectRatio ) {
-			this.updateCrop( this.getDefaultState( newProps ), newProps, this.applyCrop );
-		}
-	},
-
-	updateCrop( newValues, props, callback ) {
+	/**
+	 * Ensures that the crop box adheres to the rules (min size, aspect ratio) as it is being updated
+	 * @param newValues - changed values of the crop box
+	 * @param props
+	 * @returns {*} - recalculated newValues
+	 */
+	updateCrop( newValues, props ) {
 		props = props || this.props;
 
 		const aspectRatio = props.aspectRatio;
 
-		if ( aspectRatio === AspectRatios.FREE ) {
-			this.setState( newValues, callback );
-			return;
-		}
-
 		const rotated = props.degrees % 180 !== 0;
-		const bounds = props.bounds;
+		const bounds = this.state.bounds;
+		const boundsWidth = bounds.right - bounds.left;
+		const boundsHeight = bounds.bottom - bounds.top;
 		const newState = Object.assign( {}, this.state, newValues );
-		const newWidth = newState.right - newState.left;
-		const newHeight = newState.bottom - newState.top;
-		let ratio,
-			finalWidth = newWidth,
-			finalHeight = newHeight,
-			imageWidth, imageHeight;
+
+		//limits the min crop to one hundredth of the original image or at least one px
+		const onePx = boundsWidth / this.state.imageWidth;
+		const oneHundredth = Math.min( this.state.imageWidth / 100, this.state.imageHeight / 100 ) * onePx;
+		const newWidth = Math.max( 1, onePx, oneHundredth, newState.right - newState.left );
+		const newHeight = Math.max( 1, onePx, oneHundredth, newState.bottom - newState.top );
+
+		let aspectWidth, aspectHeight;
 
 		switch ( aspectRatio ) {
+			case AspectRatios.FREE:
+				aspectWidth = newWidth;
+				aspectHeight = newHeight;
+				break;
 			case AspectRatios.ORIGINAL:
-				imageWidth = bounds.rightBound - bounds.leftBound;
-				imageHeight = bounds.bottomBound - bounds.topBound;
+				aspectWidth = boundsWidth;
+				aspectHeight = boundsHeight;
 				break;
 			case AspectRatios.ASPECT_1X1:
-				imageWidth = 1;
-				imageHeight = 1;
+				aspectWidth = 1;
+				aspectHeight = 1;
 				break;
 			case AspectRatios.ASPECT_16X9:
-				imageWidth = rotated ? 9 : 16;
-				imageHeight = rotated ? 16 : 9;
+				aspectWidth = rotated ? 9 : 16;
+				aspectHeight = rotated ? 16 : 9;
 				break;
 			case AspectRatios.ASPECT_4X3:
-				imageWidth = rotated ? 3 : 4;
-				imageHeight = rotated ? 4 : 3;
+				aspectWidth = rotated ? 3 : 4;
+				aspectHeight = rotated ? 4 : 3;
 				break;
 			case AspectRatios.ASPECT_3X2:
-				imageWidth = rotated ? 2 : 3;
-				imageHeight = rotated ? 3 : 2;
+				aspectWidth = rotated ? 2 : 3;
+				aspectHeight = rotated ? 3 : 2;
 				break;
 		}
 
-		ratio = Math.min( newWidth / imageWidth, newHeight / imageHeight );
-		finalWidth = imageWidth * ratio;
-		finalHeight = imageHeight * ratio;
+		const ratio = Math.min( newWidth / aspectWidth, newHeight / aspectHeight );
+		const finalWidth = aspectWidth * ratio;
+		const finalHeight = aspectHeight * ratio;
 
 		if ( newValues.hasOwnProperty( 'top' ) ) {
 			newValues.top = newState.bottom - finalHeight;
@@ -155,119 +150,286 @@ const MediaModalImageEditorCrop = React.createClass( {
 			newValues.right = newState.left + finalWidth;
 		}
 
-		this.setState( newValues, callback );
+		newValues.bounds = {
+			top: this.initialBoundsTop,
+			left: this.initialBoundsLeft,
+			right: this.initialBoundsRight,
+			bottom: this.initialBoundsBottom
+		};
+
+		return newValues;
+	},
+
+	onDragStart() {
+		this.initialBounds = clone( this.state.bounds );
+		this.initialTop = this.state.top;
+		this.initialLeft = this.state.left;
+		this.initialBottom = this.state.bottom;
+		this.initialRight = this.state.right;
+		this.initialBoundsTop = this.state.bounds.top;
+		this.initialBoundsLeft = this.state.bounds.left;
+		this.initialBoundsBottom = this.state.bounds.bottom;
+		this.initialBoundsRight = this.state.bounds.right;
 	},
 
 	onTopLeftDrag( x, y ) {
-		const { right, bottom } = this.state;
-		const { minCropSize } = this.props;
-
-		let top = y,
-			left = x;
-
-		if ( right - left <= minCropSize.width	) {
-			left = right - minCropSize.width;
-		}
-
-		if ( bottom - top <= minCropSize.height ) {
-			top = bottom - minCropSize.height;
-		}
-
-		this.updateCrop( {
-			top,
-			left
+		const newState = this.updateCrop( {
+			top: y,
+			left: x
 		} );
+
+		// if ( newState.left < this.initialLeft ) {
+		// 	const deltaX = newState.left - this.initialLeft;
+		// 	//const deltaRight = this.state.right - this.initialRight;
+		//
+		// 	//newState.right = this.initialRight - deltaRight;
+		// 	newState.bottom = this.initialBottom + deltaX / 2;
+		// 	console.log(deltaX)
+		//
+		// 	newState.bounds.top -= deltaX / 2;
+		// 	newState.bounds.left -= deltaX;
+		// 	//newState.bounds.right -= deltaRight;
+		// 	newState.bounds.bottom -= deltaX / 2;
+		// }
+		//
+		// // if ( newState.top < this.initialTop ) {
+		// // 	const deltaY = newState.top - this.initialTop;
+		// // 	const deltaBottom = this.state.bottom - this.initialBottom;
+		// //
+		// // 	if ( newState.bottom ) {
+		// // 		newState.bottom -= deltaBottom;
+		// // 	} else {
+		// // 		newState.bottom = this.initialBottom - deltaBottom;
+		// // 	}
+		// //
+		// // 	if ( newState.right ) {
+		// // 		newState.right -= deltaBottom;
+		// // 	} else {
+		// // 		newState.right = this.initialRight - deltaBottom;
+		// // 	}
+		// //
+		// // 	newState.bounds.top -= deltaY;
+		// // 	newState.bounds.bottom -= deltaBottom;
+		// // }
+		if ( newState.left < this.initialLeft || newState.top < this.initialTop ) {
+			const deltaX = newState.left - this.initialLeft;
+
+			newState.right = this.initialRight - deltaX;
+			newState.bounds.left = this.initialBoundsLeft - deltaX;
+			newState.bounds.right = this.initialBoundsRight - deltaX;
+		} else {
+			newState.right = this.initialRight;
+			newState.bounds.left = this.initialBoundsLeft;
+			newState.bounds.right = this.initialBoundsRight;
+		}
+
+		if ( newState.top < this.initialTop ) {
+			const deltaY = newState.top - this.initialTop;
+
+			newState.bottom = this.initialBottom - deltaY;
+			newState.bounds.top = this.initialBoundsTop - deltaY;
+			newState.bounds.bottom = this.initialBoundsBottom - deltaY;
+		} else {
+			newState.bottom = this.initialBottom;
+			newState.bounds.top = this.initialBoundsTop;
+			newState.bounds.bottom = this.initialBoundsBottom;
+		}
+
+		this.setState( newState );
 	},
 
 	onTopRightDrag( x, y ) {
-		const { left, bottom } = this.state;
-		const { minCropSize } = this.props;
-
-		let top = y,
-			right = x;
-
-		if ( right - left <= minCropSize.width	) {
-			right = left + minCropSize.width;
-		}
-
-		if ( bottom - top <= minCropSize.height ) {
-			top = bottom - minCropSize.height;
-		}
-
-		this.updateCrop( {
-			top,
-			right
+		const newState = this.updateCrop( {
+			top: y,
+			right: x
 		} );
+
+		if ( newState.right > this.initialRight || newState.top < this.initialTop ) {
+			const deltaX = newState.right - this.initialRight;
+			const deltaY = newState.top - this.initialTop;
+
+			this.setState( {
+				top: newState.top,
+				left: this.initialLeft - deltaX,
+				right: newState.right,
+				bottom: this.initialBottom - deltaY,
+				bounds: {
+					top: this.initialBoundsTop - deltaY,
+					left: this.initialBoundsLeft - deltaX,
+					right: this.initialBoundsRight - deltaX,
+					bottom: this.initialBoundsBottom - deltaY
+				}
+			} );
+
+			return;
+		}
+
+		this.setState( newState );
 	},
 
 	onBottomRightDrag( x, y ) {
-		const { left, top } = this.state;
-		const { minCropSize } = this.props;
-
-		let bottom = y,
-			right = x;
-
-		if ( right - left <= minCropSize.width	) {
-			right = left + minCropSize.width;
-		}
-
-		if ( bottom - top <= minCropSize.height ) {
-			bottom = top + minCropSize.height;
-		}
-
-		this.updateCrop( {
-			bottom,
-			right
+		const newState = this.updateCrop( {
+			bottom: y,
+			right: x
 		} );
+
+		this.setState( newState );
 	},
 
 	onBottomLeftDrag( x, y ) {
-		const { right, top } = this.state;
-		const { minCropSize } = this.props;
-
-		let bottom = y,
-			left = x;
-
-		if ( right - left <= minCropSize.width	) {
-			left = right - minCropSize.width;
-		}
-
-		if ( bottom - top <= minCropSize.height ) {
-			bottom = top + minCropSize.height;
-		}
-
-		this.updateCrop( {
-			bottom,
-			left
+		const newState = this.updateCrop( {
+			bottom: y,
+			left: x
 		} );
+
+		this.setState( newState );
 	},
 
-	onBorderDrag( x, y ) {
-		const { top, left, right, bottom } = this.state,
-			width = right - left,
-			height = bottom - top;
+	onBorderDrag( x, y, dx, dy ) {
+		const boundsHeight = this.initialBounds.bottom - this.initialBounds.top;
+		const boundsWidth = this.initialBounds.right - this.initialBounds.left;
+
+		let top = Math.min( this.state.top, this.initialBounds.top + dy );
+		if ( top + boundsHeight <= this.state.bottom ) {
+			top = this.state.bottom - boundsHeight;
+		}
+
+		let left = Math.min( this.state.left, this.initialBounds.left + dx );
+		if ( left + boundsWidth <= this.state.right ) {
+			left = this.state.right - boundsWidth;
+		}
+
+		const bottom = top + boundsHeight;
+		const right = left + boundsWidth;
 
 		this.setState( {
-			top: y,
-			left: x,
-			bottom: y + height,
-			right: x + width
+			bounds: { top, left, bottom, right }
 		} );
 	},
 
 	applyCrop() {
-		const currentTop = this.state.top - this.props.bounds.topBound;
-		const currentLeft = this.state.left - this.props.bounds.leftBound;
-		const currentWidth = this.state.right - this.state.left;
-		const currentHeight = this.state.bottom - this.state.top;
-		const imageWidth = this.props.bounds.rightBound - this.props.bounds.leftBound;
-		const imageHeight = this.props.bounds.bottomBound - this.props.bounds.topBound;
+		const container = this.refs.container;
+		const containerWidth = container.offsetWidth;
+		const containerHeight = container.offsetHeight;
 
-		this.props.imageEditorCrop(
-			currentTop / imageHeight,
-			currentLeft / imageWidth,
-			currentWidth / imageWidth,
-			currentHeight / imageHeight );
+		const boxWidth = this.state.right - this.state.left;
+		const boxHeight = this.state.bottom - this.state.top;
+
+		const ratio = Math.min( 0.85 * containerWidth / boxWidth, 0.85 * containerHeight / boxHeight );
+
+		//1. scale
+		let boundsTop = this.state.bounds.top;
+		let boundsLeft = this.state.bounds.left;
+		let boundsRight = boundsLeft + ( this.state.bounds.right - this.state.bounds.left ) * ratio;
+		let boundsBottom = boundsTop + ( this.state.bounds.bottom - this.state.bounds.top ) * ratio;
+
+		let boxTop = this.state.bounds.top + ( this.state.top - this.state.bounds.top ) * ratio;
+		let boxLeft = this.state.bounds.left + ( this.state.left - this.state.bounds.left ) * ratio;
+		let boxRight = boxLeft + boxWidth * ratio;
+		let boxBottom = boxTop + boxHeight * ratio;
+
+		//2. translate
+		const deltaX = ( containerWidth / 2 - ( ratio * boxWidth ) / 2 ) - boxLeft;
+		boundsLeft += deltaX;
+		boundsRight += deltaX;
+		boxLeft += deltaX;
+		boxRight += deltaX;
+
+		const deltaY = ( containerHeight / 2 - ( ratio * boxHeight ) / 2 ) - boxTop;
+		boundsTop += deltaY;
+		boundsBottom += deltaY;
+		boxTop += deltaY;
+		boxBottom += deltaY;
+
+		this.setState( {
+			top: boxTop,
+			left: boxLeft,
+			right: boxRight,
+			bottom: boxBottom,
+			bounds: {
+				top: boundsTop,
+				left: boundsLeft,
+				right: boundsRight,
+				bottom: boundsBottom
+			}
+		} );
+	},
+
+	onImageLoaded( event ) {
+		const img = event.target;
+		const imageWidth = img.naturalWidth;
+		const imageHeight = img.naturalHeight;
+
+		const container = this.refs.container;
+		const containerWidth = container.offsetWidth;
+		const containerHeight = container.offsetHeight;
+
+		const width = Math.min( 0.85 * containerWidth, imageWidth );
+		const height = Math.min( 0.85 * containerHeight, imageHeight );
+		const ratio = Math.min( width / imageWidth, height / imageHeight );
+
+		const top = containerHeight / 2 - ( ratio * imageHeight ) / 2;
+		const left = containerWidth / 2 - ( ratio * imageWidth ) / 2;
+		const bottom = top + ratio * imageHeight;
+		const right = left + ratio * imageWidth;
+
+		this.setState( {
+			loaded: true,
+			top,
+			left,
+			bottom,
+			right,
+			imageWidth,
+			imageHeight,
+			bounds: {
+				top,
+				left,
+				bottom,
+				right
+			}
+		} );
+	},
+
+	renderImage() {
+		if ( ! this.props.src ) {
+			return;
+		}
+
+		const imageStyle = {};
+
+		if ( this.state.loaded ) {
+			const boundsRatio = ( this.state.bounds.right - this.state.bounds.left ) / this.state.imageWidth;
+			imageStyle.transform = 'translate(' +
+				this.state.bounds.left + 'px, ' +
+				this.state.bounds.top + 'px) scale(' + boundsRatio + ')';
+		}
+
+		if ( false ) {
+			imageStyle.display = 'none';
+
+			return (
+				<div style={ {
+					position: 'absolute',
+					top: this.state.bounds.top + 'px',
+					left: this.state.bounds.left + 'px',
+					width: ( this.state.bounds.right - this.state.bounds.left ) + 'px',
+					height: ( this.state.bounds.bottom - this.state.bounds.top ) + 'px',
+					background: '#5958af'
+				} }>
+					<img
+						onLoad={ this.onImageLoaded }
+						src={ this.props.src }
+						style={ imageStyle }
+						className="editor-media-modal-image-editor__image"/>
+				</div>
+			);
+		} else {
+			return ( <img
+				onLoad={ this.onImageLoaded }
+				src={ this.props.src }
+				style={ imageStyle }
+				className="editor-media-modal-image-editor__image"/> );
+		}
 	},
 
 	render() {
@@ -277,88 +439,57 @@ const MediaModalImageEditorCrop = React.createClass( {
 		const handleClassName = 'editor-media-modal-image-editor__crop-handle';
 
 		return (
-			<div>
-				<div
-					className="editor-media-modal-image-editor__crop-background"
-					style={ {
-						top: this.props.bounds.topBound + 'px',
-						left: left + 'px',
-						width: width + 'px',
-						height: Math.max( 0, top - this.props.bounds.topBound ) + 'px'
-					} }/>
-				<div
-					className="editor-media-modal-image-editor__crop-background"
-					style={ {
-						top: this.props.bounds.topBound + 'px',
-						left: this.props.bounds.leftBound + 'px',
-						width: Math.max( 0, left - this.props.bounds.leftBound ) + 'px',
-						height: Math.max( 0, this.props.bounds.bottomBound - this.props.bounds.topBound ) + 'px'
-					} }/>
-				<div
-					className="editor-media-modal-image-editor__crop-background"
-					style={ {
-						top: bottom + 'px',
-						left: left + 'px',
-						width: width + 'px',
-						height: Math.max( 0, this.props.bounds.bottomBound - bottom ) + 'px'
-					} }/>
-				<div
-					className="editor-media-modal-image-editor__crop-background"
-					style={ {
-						top: this.props.bounds.topBound + 'px',
-						left: right + 'px',
-						width: Math.max( 0, this.props.bounds.rightBound - right ) + 'px',
-						height: Math.max( 0, this.props.bounds.bottomBound - this.props.bounds.topBound ) + 'px'
-					} }/>
+			<div className="editor-media-modal-image-editor__crop-container" ref="container">
+				{ this.renderImage() }
 				<Draggable
 					ref="border"
+					onStart={ this.onDragStart }
 					onDrag={ this.onBorderDrag }
 					onStop={ this.applyCrop }
 					x={ left }
 					y={ top }
 					width={ width }
 					height={ height }
-					bounds={ {
-						top: this.props.bounds.topBound,
-						left: this.props.bounds.leftBound,
-						bottom: this.props.bounds.bottomBound,
-						right: this.props.bounds.rightBound
-					} }
+					controlled
 					className="editor-media-modal-image-editor__crop" />
 				<Draggable
+					onStart={ this.onDragStart }
 					onDrag={ this.onTopLeftDrag }
 					onStop={ this.applyCrop }
 					x={ left }
 					y={ top }
 					controlled
-					bounds={ { top: this.props.bounds.topBound - 1, left: this.props.bounds.leftBound - 1, bottom, right } }
+					bounds={ { top: this.state.bounds.top - 1, left: this.state.bounds.left - 1, bottom, right } }
 					ref="topLeft"
 					className={ classNames( handleClassName, handleClassName + '-nwse' ) }/>
 				<Draggable
+					onStart={ this.onDragStart }
 					onDrag={ this.onTopRightDrag }
 					onStop={ this.applyCrop }
 					y={ top }
 					x={ right }
 					controlled
-					bounds={ { top: this.props.bounds.topBound - 1, right: this.props.bounds.rightBound - 1, bottom, left } }
+					bounds={ { top: this.state.bounds.top - 1, right: this.state.bounds.right - 1, bottom, left } }
 					ref="topRight"
 					className={ classNames( handleClassName, handleClassName + '-nesw' ) } />
 				<Draggable
+					onStart={ this.onDragStart }
 					onDrag={ this.onBottomRightDrag }
 					onStop={ this.applyCrop }
 					y={ bottom }
 					x={ right }
 					controlled
-					bounds={ { bottom: this.props.bounds.bottomBound - 1, right: this.props.bounds.rightBound - 1, top, left } }
+					bounds={ { bottom: this.state.bounds.bottom - 1, right: this.state.bounds.right - 1, top, left } }
 					ref="bottomRight"
 					className={ classNames( handleClassName, handleClassName + '-nwse' ) } />
 				<Draggable
+					onStart={ this.onDragStart }
 					onDrag={ this.onBottomLeftDrag }
 					onStop={ this.applyCrop }
 					y={ bottom }
 					x={ left }
 					controlled
-					bounds={ { bottom: this.props.bounds.bottomBound - 1, left: this.props.bounds.leftBound - 1, top, right } }
+					bounds={ { bottom: this.state.bounds.bottom - 1, left: this.state.bounds.left - 1, top, right } }
 					ref="bottomLeft"
 					className={ classNames( handleClassName, handleClassName + '-nesw' ) } />
 			</div>
@@ -368,12 +499,12 @@ const MediaModalImageEditorCrop = React.createClass( {
 
 export default connect(
 	( state ) => {
-		const bounds = getImageEditorCropBounds( state );
 		const crop = getImageEditorCrop( state );
 		const aspectRatio = getImageEditorAspectRatio( state );
 		const { degrees } = getImageEditorTransform( state );
+		const { src } = getImageEditorFileInfo( state );
 
-		return { bounds, crop, aspectRatio, degrees };
+		return { src, crop, aspectRatio, degrees };
 	},
 	{ imageEditorCrop }
 )( MediaModalImageEditorCrop );


### PR DESCRIPTION
Please don't review the code, I know it's messy. The purpose of this PR is to archive my work on the image editor crop animations. The editor has been moved to a different place and cleaned up since I started this work, but with the comparison tools, the code from here could still be moved over.

This mainly adds the crop animations:
![imgedit](https://cloud.githubusercontent.com/assets/800604/19310892/31660f0c-9084-11e6-97b4-d19865b7d407.gif)

The good:
- rewrote the DOM structure of the editor - now the greyed out background is represented by an `img` element, similar to other editors across the web
- moving the crop area actually moves the image below, similar to other editors
- added the minimum crop size (10% of the original image)
- shrinking the crop area works well, 

The bad:
- expanding the crop area still needs work
- saving the image and the redux state don't work, but it should be easy to wire them up again
- the `canvas` element doesn't load the image when the editor is opened for the first time, but closing it and reopening makes it work - should be an easy fix

CC @gwwar @lamosty 
