### PR TITLE
Fixed Theme Showcase Screenshot scrolling issue

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -88,13 +88,13 @@
 
 .theme__sheet-screenshot {
 	display: block;
-	position: absolute;
-	top: 90px;
-	width: 49%;
+	position: relative;
+	top: -156px;
+	width: 98%;
 	box-shadow: 0px 2px 8px 0px rgba(46,68,83,0.45);
 	background-color: transparentize( white, 0.5 );
 
-	// with width: 49%, gives 4:3 ratio before the image loads
+	// with width: 98%, gives 4:3 ratio before the image loads
 	// also x-browser issues, so it's smaller than 4:3 proper
 	min-height: 36.15vw; // 36.75vw would be correct, but Safari is slightly off
 


### PR DESCRIPTION
I fixed the issue with #8646 Theme Showcase: Right column cut off when longer than left column on larger screens

I changed css for the screenshot to be relative instead of absolute and change the top offset to negative to achieve the same effect.  The absolute positioning was preventing the parent div from expanding to the full size of the image.

This is my first pull request with Automattic, so if I'm not following the proper procedures, please let me know.

