### PR TITLE
Plans/My-Plan : better auto renew information

### DIFF
--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -66,7 +66,7 @@ class CurrentPlanHeader extends Component {
 			<Card className="current-plan__header-purchase-info-wrapper" compact>
 				<div className={ classes }>
 					<span className="current-plan__header-expires-in">
-						{ hasAutoRenew
+						{ hasAutoRenew && currentPlan.autoRenewDateMoment && typeof currentPlan.autoRenewDateMoment.format === 'function'
 							? translate( 'Set to Auto Renew on %s.', { args: currentPlan.autoRenewDateMoment.format( 'LL' ) } )
 							: translate( 'Expires on %s.', { args: currentPlan.userFacingExpiryMoment.format( 'LL' ) } )
 						}

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -67,7 +67,7 @@ class CurrentPlanHeader extends Component {
 				<div className={ classes }>
 					<span className="current-plan__header-expires-in">
 						{ hasAutoRenew
-							? translate( 'Set to Auto Renew on %s.', { args: currentPlan.userFacingExpiryMoment.format( 'LL' ) } )
+							? translate( 'Set to Auto Renew on %s.', { args: currentPlan.autoRenewDateMoment.format( 'LL' ) } )
 							: translate( 'Expires on %s.', { args: currentPlan.userFacingExpiryMoment.format( 'LL' ) } )
 						}
 					</span>

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -10,6 +10,7 @@ const createSitePlanObject = ( plan ) => {
 
 	return {
 		autoRenew: Boolean( plan.auto_renew ), // Always true for plans paid with credits.
+		autoRenewDateMoment: plan.auto_renew_date ? moment( plan.auto_renew_date ).startOf( 'day' ) : null,
 		canStartTrial: Boolean( plan.can_start_trial ),
 		currentPlan: Boolean( plan.current_plan ),
 		currencyCode: plan.currency_code,


### PR DESCRIPTION
Fixes #8533 by passing proderty introduced in D3030-code
We displayed expiry date in place of renewal date in my-plan page.

## Testing

- Sandbox
- Apply D3030-code
- Build this PR
- http://calypso.localhost:3000/plans/my-plan/:site renew date should match date on http://calypso.localhost:3000/purchases for that plan

CC @mtias @lamosty @gwwar 