### PR TITLE
Checkout: Add domain mapping to cart from URL

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -736,17 +736,6 @@ function shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggesti
 		( ! selectedSite || ( selectedSite && selectedSite.plan.product_slug === 'free_plan' ) ); // site has a plan
 }
 
-function bundleItemWithPlan( cartItem, planSlug = 'value_bundle' ) {
-	return [ cartItem, planItem( planSlug, false ) ];
-}
-
-function bundleItemWithPlanIfNecessary( cartItem, withPlansOnly, selectedSite, cart, planSlug = 'value_bundle' ) {
-	if ( shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, cartItem ) ) {
-		return bundleItemWithPlan( cartItem, planSlug );
-	}
-	return [ cartItem ];
-}
-
 function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion ) {
 	if ( ! suggestion.product_slug || suggestion.cost === 'Free' ) {
 		return 'FREE_DOMAIN';
@@ -770,8 +759,6 @@ function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion ) {
 module.exports = {
 	add,
 	addPrivacyToAllDomains,
-	bundleItemWithPlan,
-	bundleItemWithPlanIfNecessary,
 	businessPlan,
 	customDesignItem,
 	domainMapping,

--- a/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
+++ b/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
@@ -8,16 +8,17 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var notices = require( 'notices' ),
-	getNewMessages = require( 'lib/cart-values' ).getNewMessages,
-	CartStore = require( 'lib/cart/store' );
+	getNewMessages = require( 'lib/cart-values' ).getNewMessages;
 
 module.exports = {
-	componentDidMount: function() {
-		CartStore.on( 'change', this.displayCartMessages );
-	},
+	componentWillReceiveProps( nextProps ) {
+		if ( ! nextProps.cart.hasLoadedFromServer ) {
+			return;
+		}
 
-	componentWillUnmount: function() {
-		CartStore.off( 'change', this.displayCartMessages );
+		if ( this.props.cart.messages !== nextProps.cart.messages ) {
+			this.displayCartMessages( nextProps.cart );
+		}
 	},
 
 	getChargebackErrorMessage: function() {
@@ -59,9 +60,8 @@ module.exports = {
 		}, this );
 	},
 
-	displayCartMessages: function() {
-		var newCart = this.props.cart,
-			previousCart = ( this.state ) ? this.state.previousCart : null,
+	displayCartMessages: function( newCart ) {
+		var previousCart = ( this.state ) ? this.state.previousCart : null,
 			messages = getNewMessages( previousCart, newCart );
 
 		messages.errors = this.getPrettyErrorMessages( messages.errors );

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var connect = require( 'react-redux' ).connect,
+const connect = require( 'react-redux' ).connect,
 	forEach = require( 'lodash/forEach' ),
 	find = require( 'lodash/find' ),
 	i18n = require( 'i18n-calypso' ),
@@ -15,7 +15,7 @@ var connect = require( 'react-redux' ).connect,
 /**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
+const analytics = require( 'lib/analytics' ),
 	cartItems = require( 'lib/cart-values' ).cartItems,
 	clearSitePlans = require( 'state/sites/plans/actions' ).clearSitePlans,
 	clearPurchases = require( 'state/purchases/actions' ).clearPurchases,
@@ -87,13 +87,12 @@ const Checkout = React.createClass( {
 	},
 
 	componentDidUpdate: function() {
-		var previousCart, nextCart;
 		if ( ! this.props.cart.hasLoadedFromServer ) {
 			return false;
 		}
 
-		previousCart = this.state.previousCart;
-		nextCart = this.props.cart;
+		const previousCart = this.state.previousCart,
+			nextCart = this.props.cart;
 
 		if ( ! isEqual( previousCart, nextCart ) ) {
 			this.redirectIfEmptyCart();
@@ -113,8 +112,9 @@ const Checkout = React.createClass( {
 	},
 
 	addProductToCart: function() {
-		var planSlug = getUpgradePlanSlugFromPath( this.props.product ),
-			cartItem,
+		const planSlug = getUpgradePlanSlugFromPath( this.props.product );
+
+		let cartItem,
 			cartMeta;
 
 		if ( planSlug ) {
@@ -137,7 +137,7 @@ const Checkout = React.createClass( {
 	},
 
 	redirectIfEmptyCart: function() {
-		var redirectTo = '/plans/';
+		let redirectTo = '/plans/';
 
 		if ( ! this.state.previousCart && this.props.product ) {
 			// the plan hasn't been added to the cart yet
@@ -162,8 +162,9 @@ const Checkout = React.createClass( {
 	},
 
 	getPurchasesFromReceipt: function() {
-		var purchases = this.props.transaction.step.data.purchases,
-			flatPurchases = [];
+		const purchases = this.props.transaction.step.data.purchases;
+
+		let flatPurchases = [];
 
 		// purchases are of the format { [siteId]: [ { product_id: ... } ] },
 		// so we need to flatten them to get a list of purchases
@@ -175,11 +176,12 @@ const Checkout = React.createClass( {
 	},
 
 	getCheckoutCompleteRedirectPath: function() {
-		var product,
+		let product,
 			purchasedProducts,
 			renewalItem,
-			receipt = this.props.transaction.step.data,
 			receiptId = ':receiptId';
+
+		const receipt = this.props.transaction.step.data;
 
 		this.props.clearPurchases();
 
@@ -196,26 +198,30 @@ const Checkout = React.createClass( {
 
 			if ( product && product.will_auto_renew ) {
 				notices.success(
-					this.translate( '%(productName)s has been renewed and will now auto renew in the future. {{a}}Learn more{{/a}}', {
-						args: {
-							productName: renewalItem.product_name
-						},
-						components: {
-							a: <a href={ supportPaths.AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
+					this.translate( '%(productName)s has been renewed and will now auto renew in the future. ' +
+						'{{a}}Learn more{{/a}}', {
+							args: {
+								productName: renewalItem.product_name
+							},
+							components: {
+								a: <a href={ supportPaths.AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
+							}
 						}
-					} ),
+					),
 					{ persistent: true }
 				);
 			} else if ( product ) {
 				notices.success(
-					this.translate( 'Success! You renewed %(productName)s for %(duration)s, until %(date)s. We sent your receipt to %(email)s.', {
-						args: {
-							productName: renewalItem.product_name,
-							duration: i18n.moment.duration( renewalItem.bill_period, 'days' ).humanize(),
-							date: i18n.moment( product.expiry ).format( 'MMM DD, YYYY' ),
-							email: product.user_email
+					this.translate( 'Success! You renewed %(productName)s for %(duration)s, until %(date)s. ' +
+						'We sent your receipt to %(email)s.', {
+							args: {
+								productName: renewalItem.product_name,
+								duration: i18n.moment.duration( renewalItem.bill_period, 'days' ).humanize(),
+								date: i18n.moment( product.expiry ).format( 'MMM DD, YYYY' ),
+								email: product.user_email
+							}
 						}
-					} ),
+					),
 					{ persistent: true }
 				);
 			}
@@ -237,12 +243,12 @@ const Checkout = React.createClass( {
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
-			? `/checkout/thank-you/features/${this.props.selectedFeature}/${ this.props.sites.getSelectedSite().slug }/${ receiptId }`
+			? `/checkout/thank-you/features/${ this.props.selectedFeature }/${ this.props.sites.getSelectedSite().slug }/${ receiptId }`
 			: `/checkout/thank-you/${ this.props.sites.getSelectedSite().slug }/${ receiptId }`;
 	},
 
 	content: function() {
-		var selectedSite = this.props.sites.getSelectedSite();
+		const selectedSite = this.props.sites.getSelectedSite();
 
 		if ( ! this.isLoading() && this.needsDomainDetails() ) {
 			return (
@@ -270,14 +276,14 @@ const Checkout = React.createClass( {
 	},
 
 	isLoading: function() {
-		var isLoadingCart = ! this.props.cart.hasLoadedFromServer,
+		const isLoadingCart = ! this.props.cart.hasLoadedFromServer,
 			isLoadingProducts = ! this.props.productsList.hasLoadedFromServer();
 
 		return isLoadingCart || isLoadingProducts;
 	},
 
 	needsDomainDetails: function() {
-		var cart = this.props.cart,
+		const cart = this.props.cart,
 			transaction = this.props.transaction;
 
 		if ( cart && cartItems.hasOnlyRenewalItems( cart ) ) {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -9,7 +9,8 @@ var connect = require( 'react-redux' ).connect,
 	isEqual = require( 'lodash/isEqual' ),
 	page = require( 'page' ),
 	React = require( 'react' ),
-	reduce = require( 'lodash/reduce' );
+	reduce = require( 'lodash/reduce' ),
+	startsWith = require( 'lodash/startsWith' );
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ var analytics = require( 'lib/analytics' ),
 	clearSitePlans = require( 'state/sites/plans/actions' ).clearSitePlans,
 	clearPurchases = require( 'state/purchases/actions' ).clearPurchases,
 	DomainDetailsForm = require( './domain-details-form' ),
+	domainMapping = require( 'lib/cart-values/cart-items' ).domainMapping,
 	fetchReceiptCompleted = require( 'state/receipts/actions' ).fetchReceiptCompleted,
 	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
 	getStoredCards = require( 'state/stored-cards/selectors' ).getStoredCards,
@@ -119,9 +121,14 @@ const Checkout = React.createClass( {
 			cartItem = getCartItemForPlan( planSlug );
 		}
 
-		if ( this.props.product.indexOf( 'theme' ) === 0 ) {
-			cartMeta = this.props.product.split( ':' )[1];
+		if ( startsWith( this.props.product, 'theme' ) ) {
+			cartMeta = this.props.product.split( ':' )[ 1 ];
 			cartItem = themeItem( cartMeta );
+		}
+
+		if ( startsWith( this.props.product, 'domain-mapping' ) ) {
+			cartMeta = this.props.product.split( ':' )[ 1 ];
+			cartItem = domainMapping( { domain: cartMeta } );
 		}
 
 		if ( cartItem ) {

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -85,20 +85,11 @@ var DomainSearch = React.createClass( {
 
 	addDomain( suggestion ) {
 		this.recordEvent( 'addDomainButtonClick', suggestion.domain_name, 'domains' );
-		let items = [];
+		const items = [
+			cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } )
+		];
 
-		const shouldBundleDomainWithPlan = cartItems.shouldBundleDomainWithPlan( this.props.domainsWithPlansOnly, this.props.sites.getSelectedSite(), this.props.cart, suggestion );
-		if ( shouldBundleDomainWithPlan ) {
-			const domain = cartItems.domainRegistration( {
-				domain: suggestion.domain_name,
-				productSlug: suggestion.product_slug
-			} );
-			items = items.concat( cartItems.bundleItemWithPlan( domain ) );
-		} else {
-			items.push( cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } ) );
-		}
-
-		if ( cartItems.isNextDomainFree( this.props.cart ) || shouldBundleDomainWithPlan ) {
+		if ( cartItems.isNextDomainFree( this.props.cart ) ) {
 			items.push( cartItems.domainPrivacyProtection( {
 				domain: suggestion.domain_name
 			} ) );

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -79,16 +79,12 @@ var MapDomain = React.createClass( {
 	},
 
 	handleRegisterDomain( suggestion ) {
-		const items = cartItems.bundleItemWithPlanIfNecessary(
+		upgradesActions.addItem(
 			cartItems.domainRegistration( {
 				productSlug: suggestion.product_slug,
 				domain: suggestion.domain
-			} ),
-			this.props.domainsWithPlansOnly,
-			this.props.sites.getSelectedSite(),
-			this.props.cart
+			} )
 		);
-		upgradesActions.addItems( items );
 
 		if ( this.isMounted() ) {
 			page( '/checkout/' + this.props.sites.getSelectedSite().slug );
@@ -110,14 +106,7 @@ var MapDomain = React.createClass( {
 			return;
 		}
 
-		const items = cartItems.bundleItemWithPlanIfNecessary(
-			cartItems.domainMapping( { domain } ),
-			this.props.domainsWithPlansOnly,
-			selectedSite,
-			this.props.cart
-		);
-
-		upgradesActions.addItems( items );
+		upgradesActions.addItem( cartItems.domainMapping( { domain } ) );
 
 		if ( this.isMounted() ) {
 			page( '/checkout/' + selectedSite.slug );


### PR DESCRIPTION
Makes it possible to add a domain mapping to the cart from the URL.
  
#### Testing instructions
  
1. Run `git checkout add/checkout-domain-mapping` and start your server, or open a [live branch](https://calypso.live/?branch=add/checkout-domain-mapping)
2. Open the [`Checkout` page](http://calypso.localhost:3000/checkout/[domain]/domain-mapping:[domain-to-map]) with the domain name selected (replace `[domain]` with your sites primary domain and `[domain-to-map]` with the domain you want to purchase a domain mapping for.
3. Check that the domain mapping is added to you cart
4. Check that when you checkout the domain mapping is added to your site
  
#### Reviews
  
- [x] Code
- [ ] Product
   
@Automattic/sdev-feed