### PR TITLE
WP.com Plugins: show we are running Jetpack.

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -48,7 +48,7 @@ export const PluginPanel = React.createClass( {
 			siteSlug
 		} = this.props;
 
-		const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
+		const standardPluginsLink = `/plugins/jetpack/${ siteSlug }`;
 		const purchaseLink = `/plans/${ siteSlug }`;
 
 		const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
@@ -74,7 +74,7 @@ export const PluginPanel = React.createClass( {
 				</Card>
 				<StandardPluginsPanel plugins={ standardPlugins } displayCount={ 9 } />
 				<Card className="wpcom-plugin-panel__panel-footer" href={ standardPluginsLink }>
-					{ this.translate( 'View all standard plugins' ) }
+					{ this.translate( 'View all' ) }
 				</Card>
 				<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium } { ...{ purchaseLink } } />
 				<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness } { ...{ purchaseLink } } />

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -18,8 +18,8 @@ export const PluginsList = React.createClass( {
 
 		return (
 			<div className="wpcom-plugin-panel wpcom-plugins-expanded">
-				<PageViewTracker path="/plugins/standard/:site" title="Plugins > WPCOM Site > Standard Plugins" />
-				<HeaderCake backHref={ backHref } onClick={ noop }>Standard Plugins</HeaderCake>
+				<PageViewTracker path="/plugins/jetpack/:site" title="Plugins > WPCOM Site > Standard Plugins" />
+				<HeaderCake backHref={ backHref } onClick={ noop }>Jetpack & other plugins</HeaderCake>
 				<StandardPluginsPanel plugins={ defaultStandardPlugins } />
 			</div>
 		);

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -29,7 +29,7 @@ export const StandardPluginsPanel = React.createClass( {
 
 		return (
 			<div>
-				<SectionHeader label={ this.translate( 'Standard Plugins' ) }>
+				<SectionHeader label={ this.translate( 'Jetpack & other plugins' ) }>
 					<Button className="is-active-plugin" compact borderless>
 						<Gridicon icon="checkmark" />{ this.translate( 'Active' ) }
 					</Button>
@@ -67,7 +67,7 @@ const trackClick = name => recordTracksEvent(
 	'calypso_plugin_wpcom_click',
 	{
 		plugin_name: name,
-		plugin_plan: 'standard'
+		plugin_plan: 'jetpack'
 	}
 );
 

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -175,7 +175,7 @@ function renderProvisionPlugins( context ) {
 
 const controller = {
 	validateFilters( filter, context, next ) {
-		const wpcomFilter = 'standard';
+		const wpcomFilter = 'jetpack';
 		const siteUrl = route.getSiteFragment( context.path );
 		const site = sites.getSelectedSite();
 		const appliedFilter = ( filter ? filter : context.params.plugin ).toLowerCase();


### PR DESCRIPTION
In Progress...

Updates URL from `/plugins/standard` to `/plugins/jetpack`.

![image](https://cloud.githubusercontent.com/assets/548849/19317665/12864e86-90a6-11e6-9b87-63515a4e8b72.png)
