### PR TITLE
Checkout: Enable Apple Pay status tracking on stage env

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -15,7 +15,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
-		"apple-pay": false,
+		"apple-pay": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,


### PR DESCRIPTION
Enabling Apple Pay stats collecting implemented in #8641 also on `stage` to make it easier to test.