### PR TITLE
Framework: update premium popover to remove SitesList and PlansList usage

### DIFF
--- a/client/components/plans/premium-popover/index.jsx
+++ b/client/components/plans/premium-popover/index.jsx
@@ -15,11 +15,10 @@ import Gridicon from 'components/gridicon';
 import PlanPrice from 'components/plans/plan-price';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { shouldFetchSitePlans } from 'lib/plans';
-import { getPlansBySite } from 'state/sites/plans/selectors';
-import SitesList from 'lib/sites-list';
+import { getPlansBySiteId } from 'state/sites/plans/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import PlansList from 'lib/plans-list';
 const plansList = PlansList();
-const sitesList = SitesList();
 
 let exclusiveViewLock = null;
 
@@ -140,8 +139,9 @@ const PremiumPopover = React.createClass( {
 } );
 
 export default connect( ( state ) => {
+	const selectedSiteId = getSelectedSiteId( state );
 	return {
-		sitePlans: getPlansBySite( state, sitesList.getSelectedSite() ),
+		sitePlans: getPlansBySiteId( state, selectedSiteId ),
 		plans: plansList.get()
 	};
 }, ( dispatch ) => {

--- a/client/components/plans/premium-popover/index.jsx
+++ b/client/components/plans/premium-popover/index.jsx
@@ -13,12 +13,11 @@ import { connect } from 'react-redux';
 import Popover from 'components/popover';
 import Gridicon from 'components/gridicon';
 import PlanPrice from 'components/plans/plan-price';
-import { fetchSitePlans } from 'state/sites/plans/actions';
-import { shouldFetchSitePlans } from 'lib/plans';
 import { getPlansBySiteId } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import PlansList from 'lib/plans-list';
-const plansList = PlansList();
+import { getPlans } from 'state/plans/selectors';
+import QuerySitePlans from 'components/data/query-site-plans';
+import QueryPlans from 'components/data/query-plans';
 
 let exclusiveViewLock = null;
 
@@ -35,13 +34,6 @@ const PremiumPopover = React.createClass( {
 			visibleByClick: false,
 			visibleByHover: false
 		};
-	},
-	componentDidMount() {
-		this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
-		this.props.fetchPlans();
-	},
-	componentWillReceiveProps( nextProps ) {
-		this.props.fetchSitePlans( nextProps.sitePlans, nextProps.selectedSite );
 	},
 	isVisible() {
 		return (
@@ -90,12 +82,15 @@ const PremiumPopover = React.createClass( {
 		}
 	},
 	render() {
+		const { selectedSiteId } = this.props;
 		const premiumPlan = find( this.props.plans, ( plan => plan.product_slug === 'value_bundle' ) );
 		const popoverClasses = classNames( this.props.className, 'premium-popover popover' );
 		const context = this.refs && this.refs[ 'popover-premium-reference' ];
 
 		return (
 			<div>
+				<QueryPlans />
+				<QuerySitePlans siteId={ selectedSiteId } />
 				<span
 					onClick={ this.handleClick }
 					onMouseEnter={ this.handleMouseEnter }
@@ -141,18 +136,8 @@ const PremiumPopover = React.createClass( {
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
+		selectedSiteId,
 		sitePlans: getPlansBySiteId( state, selectedSiteId ),
-		plans: plansList.get()
-	};
-}, ( dispatch ) => {
-	return {
-		fetchSitePlans( sitePlans, site ) {
-			if ( shouldFetchSitePlans( sitePlans, site ) ) {
-				dispatch( fetchSitePlans( site.ID ) );
-			}
-		},
-		fetchPlans() {
-			plansList.fetch();
-		}
+		plans: getPlans( state )
 	};
 } )( PremiumPopover );

--- a/client/components/plans/premium-popover/index.jsx
+++ b/client/components/plans/premium-popover/index.jsx
@@ -111,7 +111,7 @@ const PremiumPopover = React.createClass( {
 						<div className="premium-popover__header">
 							<h3>{ this.translate( 'Premium', { context: 'Premium Plan' } ) }</h3>
 							{ premiumPlan
-								? <PlanPrice plan={ premiumPlan } sitePlan={ this.getSitePlan() }/>
+								? <PlanPrice plan={ premiumPlan } sitePlan={ this.getSitePlan() } />
 								: <h5>Loading</h5> }
 						</div>
 						<ul className="premium-popover__items">
@@ -122,7 +122,7 @@ const PremiumPopover = React.createClass( {
 								this.translate( 'Video Uploads' ),
 								this.translate( 'No Ads' ),
 								this.translate( 'Email and live chat support' )
-							].map( ( message, i ) => <li key={ i }><Gridicon icon="checkmark" size={ 18 }/> { message }
+							].map( ( message, i ) => <li key={ i }><Gridicon icon="checkmark" size={ 18 } /> { message }
 							</li> ) }
 						</ul>
 					</div>

--- a/client/components/plans/premium-popover/index.jsx
+++ b/client/components/plans/premium-popover/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import omit from 'lodash/omit';
-import find from 'lodash/find';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
@@ -13,9 +12,10 @@ import { connect } from 'react-redux';
 import Popover from 'components/popover';
 import Gridicon from 'components/gridicon';
 import PlanPrice from 'components/plans/plan-price';
-import { getPlansBySiteId } from 'state/sites/plans/selectors';
+import { getSitePlan } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getPlans } from 'state/plans/selectors';
+import { getPlanBySlug } from 'state/plans/selectors';
+import { PLAN_PREMIUM } from 'lib/plans/constants';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QueryPlans from 'components/data/query-plans';
 
@@ -49,9 +49,6 @@ const PremiumPopover = React.createClass( {
 			components: { small: <small /> }
 		} );
 	},
-	getSitePlan() {
-		return find( ( this.props.sitePlans.data || [] ), ( plan => plan.product_slug === 'value_bundle' ) );
-	},
 	componentWillUnmount() {
 		if ( exclusiveViewLock === this ) {
 			exclusiveViewLock = null;
@@ -82,8 +79,7 @@ const PremiumPopover = React.createClass( {
 		}
 	},
 	render() {
-		const { selectedSiteId } = this.props;
-		const premiumPlan = find( this.props.plans, ( plan => plan.product_slug === 'value_bundle' ) );
+		const { selectedSiteId, premiumPlan, premiumSitePlan } = this.props;
 		const popoverClasses = classNames( this.props.className, 'premium-popover popover' );
 		const context = this.refs && this.refs[ 'popover-premium-reference' ];
 
@@ -111,7 +107,7 @@ const PremiumPopover = React.createClass( {
 						<div className="premium-popover__header">
 							<h3>{ this.translate( 'Premium', { context: 'Premium Plan' } ) }</h3>
 							{ premiumPlan
-								? <PlanPrice plan={ premiumPlan } sitePlan={ this.getSitePlan() } />
+								? <PlanPrice plan={ premiumPlan } sitePlan={ premiumSitePlan } />
 								: <h5>Loading</h5> }
 						</div>
 						<ul className="premium-popover__items">
@@ -137,7 +133,7 @@ export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		selectedSiteId,
-		sitePlans: getPlansBySiteId( state, selectedSiteId ),
-		plans: getPlans( state )
+		premiumPlan: getPlanBySlug( state, PLAN_PREMIUM ),
+		premiumSitePlan: getSitePlan( state, selectedSiteId, PLAN_PREMIUM )
 	};
 } )( PremiumPopover );


### PR DESCRIPTION
This updates the premium popover in /domains/add to use global redux state instead of calling sitesList and plansList.

<img width="583" alt="screen shot 2016-10-12 at 11 50 46 am" src="https://cloud.githubusercontent.com/assets/1270189/19324242/7f0033be-9075-11e6-8708-6c357b39eeb1.png">

## Testing Instructions
- Navigate to http://calypso.localhost:3000/domains/add
- Select a free wpcom site
- Set abtest to `domainSuggestionPopover`
- There's a number of other requirements that need to be met for this to be displayed, so I ended up hardcoding https://github.com/Automattic/wp-calypso/blob/master/client/components/domains/domain-product-price/index.jsx#L97 to return `return showPopover && this.renderIncludedInPremium();`
- No functional changes
- From a fresh browser state `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` should still load popovers

cc @bisko  @umurkontaci @mtias 