### PR TITLE
Decouple image editor from media modal

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -182,10 +182,6 @@ $z-layers: (
 		'.editor-media-modal .section-nav': 10,
 		'.editor-media-modal .notice': 10,
 		'.editor-media-modal-gallery__preview-toggle': 100,
-		'.image-editor__canvas': 100,
-		'.image-editor__crop-background': 200,
-		'.image-editor__crop': 300,
-		'.image-editor__crop-handle': 400,
 		'.editor-contact-form-modal .section-nav': 10
 	),
 	'.following-edit': ( //aka 'main'

--- a/client/blocks/image-editor/README.md
+++ b/client/blocks/image-editor/README.md
@@ -36,23 +36,37 @@ It can also contain these optional properties (with defaults if not set):
 - `media.mime_type` `{string}`: the MIME of the edited image (e.g. `image/jpeg`), defaults to `image/png`
 - `media.title` `{string}`: the title of the edited image (e.g. `some image file`), defaults to `default`
 
-### `onImageEditorSave`
+### `onImageExtracted`
 
 <table>
 	<tr><th>Type</th><td>Function</td></tr>
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-A function which will get called on saving an edited image (closing with saving).
+A function which will get called on extracting an edited image. It receives two arguments:
+- the extracted image in form of `Blob` object
+- the props of the image editor which include image meta and functions to reset image editor state (for the full list,
+have a look into the `image-editor/index` file)
 
-### `onImageEditorCancel`
+### `onCancel`
 
 <table>
 	<tr><th>Type</th><td>Function</td></tr>
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-A function which will get called on cancelling the image editor (closing without saving).
+A function which will get called on clicking the "Cancel" image editor button. If this prop is omitted, the "Cancel"
+button won't be rendered. The function receives one argument: the props of the image editor. 
+
+### `onReset`
+
+<table>
+	<tr><th>Type</th><td>Function</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+A function which will get called on clicking the "Reset" image editor button. The function is called after image editor's
+ state is reset. The function receives one argument: the props of the image editor. 
 
 ### `className`
 

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -31,14 +31,16 @@ function ImageEditorExample( { primarySiteId } ) {
 					onImageExtracted={ onImageExtracted }
 				/>
 			</div>
-			
-			<img 
-				id="devdocs-example-image-editor-result"
-				style={ {
-					display: 'block',
-					margin: '10px auto'
-				} }
-			/>
+			<div style={ { 
+				textAlign: 'center',
+				marginTop: '15px'
+			} }>
+				<h4>Changes to the image above are shown below</h4>
+				<img
+					id="devdocs-example-image-editor-result"
+					src={ media.URL }
+				/>
+			</div>
 		</div>
 	);
 }

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -16,10 +16,16 @@ function ImageEditorExample( { primarySiteId } ) {
 		URL: 'https://cldup.com/mA_hqNVj0w.jpg'
 	};
 	
+	const getTestingImage = () => document.querySelector( "#devdocs-example-image-editor-result" );
+	
 	const onImageExtracted = ( blob ) => {
 		const imageUrl = window.URL.createObjectURL( blob );
 		
-		document.querySelector( "#devdocs-example-image-editor-result" ).src = imageUrl;
+		getTestingImage().src = imageUrl;
+	};
+	
+	const onImageEditorReset = () => {
+		getTestingImage().src = media.URL;
 	};
 	
 	return (
@@ -29,6 +35,7 @@ function ImageEditorExample( { primarySiteId } ) {
 					siteId={ primarySiteId }
 					media={ media }
 					onImageExtracted={ onImageExtracted }
+					onReset={ onImageEditorReset }
 				/>
 			</div>
 			<div style={ { 

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -16,11 +16,28 @@ function ImageEditorExample( { primarySiteId } ) {
 		URL: 'https://cldup.com/mA_hqNVj0w.jpg'
 	};
 	
+	const onImageExtracted = ( blob ) => {
+		const imageUrl = window.URL.createObjectURL( blob );
+		
+		document.querySelector( "#devdocs-example-image-editor-result" ).src = imageUrl;
+	};
+	
 	return (
-		<div style={ { height: '80vh' } }>
-			<ImageEditor
-				siteId={ primarySiteId }
-				media={ media }
+		<div>
+			<div style={ { height: '80vh' } }>
+				<ImageEditor
+					siteId={ primarySiteId }
+					media={ media }
+					onImageExtracted={ onImageExtracted }
+				/>
+			</div>
+			
+			<img 
+				id="devdocs-example-image-editor-result"
+				style={ {
+					display: 'block',
+					margin: '10px auto'
+				} }
 			/>
 		</div>
 	);

--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -46,12 +46,14 @@ class ImageEditorButtons extends Component {
 
 		return (
 			<div className="image-editor__buttons">
-				<Button
-					className="image-editor__buttons-button"
-					onClick={ onCancel }
-				>
-					{ translate( 'Cancel' ) }
-				</Button>
+				{ onCancel &&
+					<Button
+						className="image-editor__buttons-button"
+						onClick={ onCancel }
+					>
+						{ translate( 'Cancel' ) }
+					</Button>
+				}
 				<Button
 					className="image-editor__buttons-button"
 					disabled={ ! hasChanges }

--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -11,9 +11,6 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import {
-	resetImageEditorState
-} from 'state/ui/editor/image-editor/actions';
-import {
 	getImageEditorFileInfo,
 	imageEditorHasChanges
 } from 'state/ui/editor/image-editor/selectors';
@@ -24,7 +21,8 @@ class ImageEditorButtons extends Component {
 		hasChanges: PropTypes.bool,
 		resetImageEditorState: PropTypes.func,
 		onDone: PropTypes.func,
-		onCancel: PropTypes.func
+		onCancel: PropTypes.func,
+		onReset: PropTypes.func
 	};
 
 	static defaultProps = {
@@ -32,7 +30,8 @@ class ImageEditorButtons extends Component {
 		hasChanges: false,
 		resetImageEditorState: noop,
 		onDone: noop,
-		onCancel: noop
+		onCancel: noop,
+		onReset: noop
 	};
 
 	render() {
@@ -41,6 +40,7 @@ class ImageEditorButtons extends Component {
 			onCancel,
 			src,
 			onDone,
+			onReset,
 			translate
 		} = this.props;
 
@@ -57,7 +57,7 @@ class ImageEditorButtons extends Component {
 				<Button
 					className="image-editor__buttons-button"
 					disabled={ ! hasChanges }
-					onClick={ this.props.resetImageEditorState }
+					onClick={ onReset }
 				>
 					{ translate( 'Reset' ) }
 				</Button>
@@ -83,8 +83,5 @@ export default connect(
 			src,
 			hasChanges
 		};
-	},
-	{
-		resetImageEditorState
 	}
 )( localize( ImageEditorButtons ) );

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -248,12 +248,13 @@ class ImageEditorCanvas extends Component {
 
 		return (
 			<div className="image-editor__canvas-container">
-				{ imageLoaded && <ImageEditorCrop /> }
 				<canvas
 					ref="canvas"
 					style={ canvasStyle }
 					onMouseDown={ this.preventDrag }
-					className={ canvasClasses } />
+					className={ canvasClasses }
+				/>
+				{ imageLoaded && <ImageEditorCrop /> }
 			</div>
 		);
 	}

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -64,6 +64,7 @@ class ImageEditorCanvas extends Component {
 		this.onWindowResize = null;
 
 		this.onLoadComplete = this.onLoadComplete.bind( this );
+		this.updateCanvasPosition = this.updateCanvasPosition.bind( this );
 	}
 
 	componentWillReceiveProps( newProps ) {

--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -390,8 +390,8 @@ class ImageEditorCrop extends Component {
 					bounds={ {
 						bottom,
 						right,
-						top: topBound - 1,
-						left: leftBound - 1
+						top: topBound,
+						left: leftBound
 					} }
 					ref="topLeft"
 					className={ classNames( handleClassName, handleClassName + '-nwse' ) }
@@ -405,8 +405,8 @@ class ImageEditorCrop extends Component {
 					bounds={ {
 						bottom,
 						left,
-						top: topBound - 1,
-						right: rightBound - 1
+						top: topBound,
+						right: rightBound
 					} }
 					ref="topRight"
 					className={ classNames( handleClassName, handleClassName + '-nesw' ) }
@@ -420,8 +420,8 @@ class ImageEditorCrop extends Component {
 					bounds={ {
 						top,
 						left,
-						bottom: bottomBound - 1,
-						right: rightBound - 1
+						bottom: bottomBound,
+						right: rightBound
 					} }
 					ref="bottomRight"
 					className={ classNames( handleClassName, handleClassName + '-nwse' ) }
@@ -435,8 +435,8 @@ class ImageEditorCrop extends Component {
 					bounds={ {
 						top,
 						right,
-						bottom: bottomBound - 1,
-						left: leftBound - 1
+						bottom: bottomBound,
+						left: leftBound
 					} }
 					ref="bottomLeft"
 					className={ classNames( handleClassName, handleClassName + '-nesw' ) }

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -96,9 +96,7 @@ const ImageEditor = React.createClass( {
 	},
 
 	onCancel() {
-		this.props.resetAllImageEditorState();
-
-		this.props.onImageEditorCancel();
+		this.props.onImageEditorCancel( this.props );
 	},
 
 	onLoadCanvasError() {

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -78,9 +78,12 @@ const ImageEditor = React.createClass( {
 			src = MediaUtils.url( media, {
 				photon: site && ! site.is_private
 			} );
+
 			fileName = media.file || path.basename( src );
-			mimeType = MediaUtils.getMimeType( media );
-			title = media.title;
+
+			mimeType = MediaUtils.getMimeType( media ) || mimeType;
+
+			title = media.title || title;
 		}
 
 		this.props.resetImageEditorState();

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -103,29 +103,6 @@ const ImageEditor = React.createClass( {
 		this.props.onImageEditorCancel();
 	},
 
-	isValidTransfer: function( transfer ) {
-		if ( ! transfer ) {
-			return false;
-		}
-
-		// Firefox will claim that images dragged from within the same page are
-		// files, but will also identify them with a `mozSourceNode` attribute.
-		// This value will be `null` for files dragged from outside the page.
-		//
-		// See: https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/mozSourceNode
-		if ( transfer.mozSourceNode ) {
-			return false;
-		}
-
-		// `types` is a DOMStringList, which is treated as an array in Chrome,
-		// but as an array-like object in Firefox. Therefore, we call `indexOf`
-		// using the Array prototype. Safari may pass types as `null` which
-		// makes detection impossible, so we err on allowing the transfer.
-		//
-		// See: http://www.w3.org/html/wg/drafts/html/master/editing.html#the-datatransfer-interface
-		return ! transfer.types || -1 !== Array.prototype.indexOf.call( transfer.types, 'Files' );
-	},
-
 	onLoadCanvasError() {
 		this.setState( { canvasError: this.translate( 'We are unable to edit this image.' ) } );
 	},

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -37,7 +37,7 @@ const ImageEditor = React.createClass( {
 		media: PropTypes.object,
 		siteId: PropTypes.number,
 		onImageExtracted: PropTypes.func,
-		onImageEditorCancel: PropTypes.func,
+		onCancel: PropTypes.func,
 		className: PropTypes.string,
 
 		// Redux props
@@ -51,7 +51,7 @@ const ImageEditor = React.createClass( {
 		return {
 			media: null,
 			onImageExtracted: noop,
-			onImageEditorCancel: null
+			onCancel: null
 		};
 	},
 
@@ -96,7 +96,7 @@ const ImageEditor = React.createClass( {
 	},
 
 	onCancel() {
-		this.props.onImageEditorCancel( this.props );
+		this.props.onCancel( this.props );
 	},
 
 	onLoadCanvasError() {
@@ -121,8 +121,7 @@ const ImageEditor = React.createClass( {
 	render() {
 		const {
 			className,
-			siteId,
-			onImageEditorCancel
+			siteId
 		} = this.props;
 
 		const classes = classNames(
@@ -144,7 +143,7 @@ const ImageEditor = React.createClass( {
 						/>
 						<ImageEditorToolbar />
 						<ImageEditorButtons
-							onCancel={ onImageEditorCancel && this.onCancel }
+							onCancel={ this.props.onCancel && this.onCancel }
 							onDone={ this.onDone }
 						/>
 					</div>

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -38,6 +38,7 @@ const ImageEditor = React.createClass( {
 		siteId: PropTypes.number,
 		onImageExtracted: PropTypes.func,
 		onCancel: PropTypes.func,
+		onReset: PropTypes.func,
 		className: PropTypes.string,
 
 		// Redux props
@@ -51,7 +52,8 @@ const ImageEditor = React.createClass( {
 		return {
 			media: null,
 			onImageExtracted: noop,
-			onCancel: null
+			onCancel: null,
+			onReset: noop
 		};
 	},
 
@@ -97,6 +99,12 @@ const ImageEditor = React.createClass( {
 
 	onCancel() {
 		this.props.onCancel( this.props );
+	},
+
+	onReset() {
+		this.props.resetImageEditorState();
+
+		this.props.onReset( this.props );
 	},
 
 	onLoadCanvasError() {
@@ -145,6 +153,7 @@ const ImageEditor = React.createClass( {
 						<ImageEditorButtons
 							onCancel={ this.props.onCancel && this.onCancel }
 							onDone={ this.onDone }
+							onReset={ this.onReset }
 						/>
 					</div>
 				</figure>

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -104,7 +104,11 @@ const ImageEditor = React.createClass( {
 	},
 
 	onLoadCanvasError() {
-		this.setState( { canvasError: this.translate( 'We are unable to edit this image.' ) } );
+		const { translate } = this.props;
+
+		this.setState( {
+			canvasError: translate( 'We are unable to edit this image.' )
+		} );
 	},
 
 	renderError() {

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -93,18 +93,37 @@ const ImageEditor = React.createClass( {
 		canvasComponent.toBlob( ( blob ) => {
 			const {	onImageExtracted } = this.props;
 
-			onImageExtracted( blob, this.props );
+			onImageExtracted( blob, this.getImageEditorProps() );
 		} );
 	},
 
 	onCancel() {
-		this.props.onCancel( this.props );
+		this.props.onCancel( this.getImageEditorProps() );
 	},
 
 	onReset() {
 		this.props.resetImageEditorState();
 
-		this.props.onReset( this.props );
+		this.props.onReset( this.getImageEditorProps() );
+	},
+
+	getImageEditorProps() {
+		const {
+			src,
+			fileName,
+			mimeType,
+			title,
+			site
+		} = this.props;
+
+		return {
+			src,
+			fileName,
+			mimeType,
+			title,
+			site,
+			resetAllImageEditorState: this.props.resetAllImageEditorState
+		};
 	},
 
 	onLoadCanvasError() {

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -51,7 +51,7 @@ const ImageEditor = React.createClass( {
 		return {
 			media: null,
 			onImageExtracted: noop,
-			onImageEditorCancel: noop
+			onImageEditorCancel: null
 		};
 	},
 
@@ -121,7 +121,8 @@ const ImageEditor = React.createClass( {
 	render() {
 		const {
 			className,
-			siteId
+			siteId,
+			onImageEditorCancel
 		} = this.props;
 
 		const classes = classNames(
@@ -143,7 +144,7 @@ const ImageEditor = React.createClass( {
 						/>
 						<ImageEditorToolbar />
 						<ImageEditorButtons
-							onCancel={ this.onCancel }
+							onCancel={ onImageEditorCancel && this.onCancel }
 							onDone={ this.onDone }
 						/>
 					</div>

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -92,8 +92,6 @@ const ImageEditor = React.createClass( {
 			const {	onImageExtracted } = this.props;
 
 			onImageExtracted( blob, this.props );
-
-			this.props.resetAllImageEditorState();
 		} );
 	},
 

--- a/client/blocks/image-editor/style.scss
+++ b/client/blocks/image-editor/style.scss
@@ -54,7 +54,6 @@
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	z-index: z-index( '.dialog__backdrop', '.image-editor__canvas' );
 
 	&.is-placeholder {
 		@include placeholder-dark();
@@ -63,7 +62,6 @@
 
 .image-editor__crop {
 	position: absolute;
-	z-index: z-index( '.dialog__backdrop', '.image-editor__crop' );
 	border: 1px solid $gray;
 	cursor: move;
 }
@@ -72,14 +70,12 @@
 	position: absolute;
 	background: darken($gray, 52%);
 	opacity: 0.5;
-	z-index: z-index( '.dialog__backdrop', '.image-editor__crop-background' );
 }
 
 .image-editor__crop-handle {
 	position: absolute;
 	width: 8px;
 	height: 8px;
-	z-index: z-index( '.dialog__backdrop', '.image-editor__crop-handle' );
 	margin-top: -4px;
 	margin-left: -4px;
 	border-radius: 50%;

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -251,8 +251,11 @@ module.exports = React.createClass( {
 		this.setView( ModalViews.LIST );
 	},
 
-	onImageEditorCancel: function() {
+	onImageEditorCancel: function( imageEditorProps ) {
 		const item = this.props.mediaLibrarySelectedItems[ this.getDetailSelectedIndex() ];
+
+		imageEditorProps.resetAllImageEditorState();
+
 		if ( ! item ) {
 			this.setView( ModalViews.LIST );
 			return;

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -213,7 +213,8 @@ module.exports = React.createClass( {
 	onImageExtracted( blob, imageEditorProps ) {
 		const {
 			fileName,
-			site
+			site,
+			resetAllImageEditorState
 		} = imageEditorProps;
 
 		const mimeType = MediaUtils.getMimeType( fileName );
@@ -243,6 +244,8 @@ module.exports = React.createClass( {
 			title: title,
 			mimeType: mimeType
 		} );
+
+		resetAllImageEditorState();
 
 		MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
 		this.setView( ModalViews.LIST );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -252,15 +252,19 @@ module.exports = React.createClass( {
 	},
 
 	onImageEditorCancel: function( imageEditorProps ) {
-		const item = this.props.mediaLibrarySelectedItems[ this.getDetailSelectedIndex() ];
+		const { mediaLibrarySelectedItems } = this.props;
 
-		imageEditorProps.resetAllImageEditorState();
+		const item = mediaLibrarySelectedItems[ this.getDetailSelectedIndex() ];
 
 		if ( ! item ) {
 			this.setView( ModalViews.LIST );
 			return;
 		}
 		this.setView( ModalViews.DETAIL );
+
+		const {	resetAllImageEditorState } = imageEditorProps;
+
+		resetAllImageEditorState();
 	},
 
 	getDetailSelectedIndex() {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -210,7 +210,40 @@ module.exports = React.createClass( {
 		this.setView( ModalViews.IMAGE_EDITOR );
 	},
 
-	onImageEditorSave: function() {
+	onImageExtracted( blob, imageEditorProps ) {
+		const {
+			fileName,
+			site
+		} = imageEditorProps;
+
+		const mimeType = MediaUtils.getMimeType( fileName );
+
+		// check if a title is already post-fixed with '(edited copy)'
+		const editedCopyText = this.translate(
+			'%(title)s (edited copy)', {
+				args: {
+					title: ''
+				}
+			} );
+
+		let { title } = imageEditorProps;
+
+		if ( title.indexOf( editedCopyText ) === -1 ) {
+			title = this.translate(
+				'%(title)s (edited copy)', {
+					args: {
+						title: title
+					}
+				} );
+		}
+
+		MediaActions.add( site.ID, {
+			fileName: fileName,
+			fileContents: blob,
+			title: title,
+			mimeType: mimeType
+		} );
+
 		MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
 		this.setView( ModalViews.LIST );
 	},
@@ -408,7 +441,7 @@ module.exports = React.createClass( {
 					<ImageEditor
 						siteId={ site && site.ID }
 						media={ media }
-						onImageEditorSave={ this.onImageEditorSave }
+						onImageExtracted={ this.onImageExtracted }
 						onImageEditorCancel={ this.onImageEditorCancel }
 					/>
 				);

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -448,7 +448,7 @@ module.exports = React.createClass( {
 						siteId={ site && site.ID }
 						media={ media }
 						onImageExtracted={ this.onImageExtracted }
-						onImageEditorCancel={ this.onImageEditorCancel }
+						onCancel={ this.onImageEditorCancel }
 					/>
 				);
 				break;


### PR DESCRIPTION
Follow-up of #8499. While we managed to extract the image editor to `blocks/image-editor` in that PR, it is still tied to media modal. Let's decouple it even more in this PR.

## Testing instructions

1. Test whether the image editor works as before in media modal;
2. Navigate to http://calypso.localhost:3000/devdocs/blocks/image-editor and test whether the image editor works properly there as well;

Do you think the image editor could be decoupled even more? What could we improve even more?

/cc @gwwar @artpi @retrofox @aduth 