### PR TITLE
Components: Resolve warnings logged from AuthorSelector component

### DIFF
--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import { omit } from 'lodash';
 
@@ -10,47 +10,43 @@ import { omit } from 'lodash';
  */
 import Gridicon from 'components/gridicon';
 
-const handlerMouseOver = ( event ) => {
-	event.target.focus();
-};
+export default class PopoverMenuItem extends Component {
+	static propTypes = {
+		href: PropTypes.string,
+		className: PropTypes.string,
+		icon: PropTypes.string,
+		focusOnHover: PropTypes.bool,
+		children: PropTypes.node
+	};
 
-const PopoverItem = ( props ) => {
-	const {
-		focusOnHover,
-		className,
-		href,
-		icon,
-		children
-	} = props;
+	static defaultProps = {
+		focusOnHover: true
+	};
 
-	const Component = href ? 'a' : 'button';
+	focus( event ) {
+		event.target.focus();
+	}
 
-	return (
-		<Component
-			role="menuitem"
-			onMouseOver={ focusOnHover ? handlerMouseOver : null }
-			tabIndex="-1"
-			{ ...omit( props, 'icon', 'focusOnHover' ) }
-			className={ classnames( 'popover__menu-item', className ) }
-		>
-			{ icon && <Gridicon icon={ icon } size={ 18 } /> }
-			{ children }
-		</Component>
-	);
-};
+	render() {
+		const { className, href, focusOnHover, icon, children } = this.props;
+		const classes = classnames( 'popover__menu-item', className );
+		const ItemComponent = href ? 'a' : 'button';
 
-PopoverItem.displayName = 'PopoverMenuItem';
+		let hoverHandler;
+		if ( focusOnHover ) {
+			hoverHandler = this.focus;
+		}
 
-PopoverItem.propTypes = {
-	href: PropTypes.string,
-	className: PropTypes.string,
-	icon: PropTypes.string,
-	focusOnHover: PropTypes.bool,
-	children: PropTypes.node
-};
-
-PopoverItem.defaultProps = {
-	focusOnHover: true
-};
-
-export default PopoverItem;
+		return (
+			<ItemComponent
+				role="menuitem"
+				onMouseOver={ hoverHandler }
+				tabIndex="-1"
+				{ ...omit( this.props, 'icon', 'focusOnHover' ) }
+				className={ classes }>
+				{ icon && <Gridicon icon={ icon } size={ 18 } /> }
+				{ children }
+			</ItemComponent>
+		);
+	}
+}


### PR DESCRIPTION
Related: #7413

This pull request seeks to resolve warnings logged to the console when the AuthorSelector component is rendered.

![Warnings](https://cloud.githubusercontent.com/assets/1779930/19328697/ea4fc440-90a2-11e6-8ebc-50fbc09b9a32.png)

Specifically, it resolves:

- An unknown `namespace` prop being passed to a rendered `div` element, per #7413 
- Refs being assigned to a stateless function component (used by the `<InfiniteList />` component)

The `<PopoverMenuItem />` component was refactored into a stateless function component in #7866, but unfortunately stateless function components cannot be assigned refs. A `ref` is for items rendered in an `<InfiniteList />` is necessary to be able to calculate its bounds for rendering. Therefore, the changes here rewrite `<PopoverMenuItem />` to a `Component` class. In the future, we may consider dropping `<InfiniteList />` in favor of `<ReactVirtualized />`, used elsewhere for infinite scrolling.

__Testing Instructions:__

Verify that there are no regressions in the display and behavior of the `<AuthorSelector />` component. Notably, you'll find this on the post editor when there are multiple users for a site.

cc @retrofox @hoverduck 