### PR TITLE
Editor: Use Redux preferences for advanced toolbar toggle

### DIFF
--- a/client/components/tinymce/plugins/advanced/plugin.jsx
+++ b/client/components/tinymce/plugins/advanced/plugin.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import tinymce from 'tinymce/tinymce';
-import throttle from 'lodash/throttle';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -30,7 +29,7 @@ function advanced( editor ) {
 	let isAdvancedVisible = getVisibleState();
 	let menuButton;
 
-	const updateVisibleState = throttle( function() {
+	function updateVisibleState() {
 		const toolbars = editor.theme.panel.find( '.toolbar:not(.menubar)' );
 		const isSmallViewport = isWithinBreakpoint( '<960px' );
 		let containerPadding = 0;
@@ -56,7 +55,7 @@ function advanced( editor ) {
 		if ( menuButton ) {
 			menuButton.active( isAdvancedVisible );
 		}
-	}, 500 );
+	}
 
 	editor.addButton( 'wpcom_advanced', {
 		text: translate( 'Toggle Advanced' ),

--- a/client/components/tinymce/plugins/advanced/plugin.jsx
+++ b/client/components/tinymce/plugins/advanced/plugin.jsx
@@ -31,12 +31,12 @@ function advanced( editor ) {
 	let menuButton;
 
 	const updateVisibleState = throttle( function() {
-		var toolbars = editor.theme.panel.find( '.toolbar:not(.menubar)' ),
-			isSmallViewport = isWithinBreakpoint( '<960px' ),
-			containerPadding = 0;
+		const toolbars = editor.theme.panel.find( '.toolbar:not(.menubar)' );
+		const isSmallViewport = isWithinBreakpoint( '<960px' );
+		let containerPadding = 0;
 
 		toolbars.each( function( toolbar, i ) {
-			var isToolbarVisible = isSmallViewport || i === 0 || isAdvancedVisible;
+			const isToolbarVisible = isSmallViewport || i === 0 || isAdvancedVisible;
 
 			toolbar.visible( isToolbarVisible );
 
@@ -107,6 +107,6 @@ function advanced( editor ) {
 	} );
 }
 
-module.exports = function() {
+export default function() {
 	tinymce.PluginManager.add( 'wpcom/advanced', advanced );
-};
+}

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -2,6 +2,7 @@
 .mce-inline-toolbar-grp {
 
 	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu {
+		height: 36px;
 		margin: 0;
 
 		&:hover .mce-open i.mce-caret,

--- a/client/state/preferences/constants.js
+++ b/client/state/preferences/constants.js
@@ -9,5 +9,6 @@ export const DEFAULT_PREFERENCE_VALUES = {
 	mediaModalGalleryInstructionsDismissedForSession: false,
 	'guided-tours-history': [],
 	recentSites: [],
-	mediaScale: 0.157
+	mediaScale: 0.157,
+	editorAdvancedVisible: false
 };

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -50,6 +50,9 @@ export const remoteValuesSchema = {
 			type: 'number',
 			minimum: 0,
 			maximum: 1
+		},
+		editorAdvancedVisible: {
+			type: 'boolean'
 		}
 	}
 };


### PR DESCRIPTION
Related: #5046

This pull request seeks to migrate the editor advanced toolbar plugin from using the deprecated `lib/preferences` module to using Redux state.

__Testing instructions:__

Verify that there are no regressions in the toggling of the advanced toolbar in the editor. Particularly:

- Visibility of advanced options on toggle
- Calculated padding of editor content by toolbar presence (mobile and desktop viewports)
- Persistence between refresh