### PR TITLE
Editor: Allow galleries to contain only one image

### DIFF
--- a/client/post-editor/media-modal/gallery/edit.jsx
+++ b/client/post-editor/media-modal/gallery/edit.jsx
@@ -54,7 +54,7 @@ export default React.createClass( {
 							key={ item.ID }
 							site={ site }
 							item={ item }
-							showRemoveButton={ settings.items.length > 2 } />
+							showRemoveButton={ settings.items.length > 1 } />
 					);
 				} ) }
 			</SortableList>


### PR DESCRIPTION
Some users like the way a "single image gallery" looks
so we keep the "Remove Button" visible unless the gallery contains only one image

refs #1809

**Two pictures Gallery**
<img width="641" alt="capture d ecran 2016-10-13 a 9 36 45 am" src="https://cloud.githubusercontent.com/assets/272444/19342312/310bf990-9129-11e6-8682-5be864395a5d.png">

**One picture Gallery**
<img width="641" alt="capture d ecran 2016-10-13 a 9 37 09 am" src="https://cloud.githubusercontent.com/assets/272444/19342313/3112d738-9129-11e6-8851-1b791d964fa5.png">

**Testing instructions**

Ensure the "Remove button" stays visible while editing Galleries unless the gallery contains only one image

cc @folletto 