### PR TITLE
Recent sites: remove sites that are not longer connected

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -357,6 +357,10 @@ const SiteSelector = React.createClass( {
 	},
 
 	renderSite( site ) {
+		if ( ! site ) {
+			return null;
+		}
+
 		this.visibleSites.push( site );
 
 		const isHighlighted = this.isHighlighted( site );
@@ -376,7 +380,7 @@ const SiteSelector = React.createClass( {
 
 	renderRecentSites() {
 		const sitesById = keyBy( this.props.sites.get(), 'ID' );
-		const sites = this.props.recentSites.map( siteId => sitesById[ siteId ] ).filter( site => site );
+		const sites = this.props.recentSites.map( siteId => sitesById[ siteId ] );
 
 		if ( ! sites || this.state.search || ! this.shouldShowGroups() || this.props.visibleSiteCount <= 11 ) {
 			return null;

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -251,8 +251,8 @@ const SiteSelector = React.createClass( {
 	},
 
 	getSiteBasePath( site ) {
-		var siteBasePath = this.props.siteBasePath,
-			postsBase = ( site.jetpack || site.single_user_site ) ? '/posts' : '/posts/my';
+		let siteBasePath = this.props.siteBasePath;
+		const postsBase = ( site.jetpack || site.single_user_site ) ? '/posts' : '/posts/my';
 
 		// Default posts to /posts/my when possible and /posts when not
 		siteBasePath = siteBasePath.replace( /^\/posts\b(\/my)?/, postsBase );
@@ -285,7 +285,7 @@ const SiteSelector = React.createClass( {
 	},
 
 	isSelected( site ) {
-		var selectedSite = this.props.selected || this.props.sites.selected;
+		const selectedSite = this.props.selected || this.props.sites.selected;
 		return (
 			( site === ALL_SITES && selectedSite === null ) ||
 			( selectedSite === site.domain ) ||
@@ -302,7 +302,7 @@ const SiteSelector = React.createClass( {
 	},
 
 	renderSites() {
-		var sites, siteElements;
+		let sites;
 
 		if ( ! this.props.sites.initialized ) {
 			return <SitePlaceholder key="site-placeholder" />;
@@ -328,7 +328,7 @@ const SiteSelector = React.createClass( {
 		}
 
 		// Render sites
-		siteElements = map( sites, this.renderSite, this );
+		const siteElements = map( sites, this.renderSite, this );
 
 		if ( ! siteElements.length ) {
 			return <div className="site-selector__no-results">{ this.translate( 'No sites found' ) }</div>;
@@ -376,7 +376,7 @@ const SiteSelector = React.createClass( {
 
 	renderRecentSites() {
 		const sitesById = keyBy( this.props.sites.get(), 'ID' );
-		const sites = this.props.recentSites.map( siteId => sitesById[ siteId ] );
+		const sites = this.props.recentSites.map( siteId => sitesById[ siteId ] ).filter( site => site );
 
 		if ( ! sites || this.state.search || ! this.shouldShowGroups() || this.props.visibleSiteCount <= 11 ) {
 			return null;


### PR DESCRIPTION
This PR solves a fatal bug that is breaking calypso for anyone who disconnects a site that is in their recent sites list. Right now, if you disconnect a site that is in your recent sites list, when calypso tries to render the site selector component, receives the id of the disconnected site and add it as "undefined" to the recent sites list (since it can't be found in users' sites). This breaks the component down the line, when it try to access to the properties of this 'undefined' site.

How to test
=========

1. Go to your account and select a jetpack site
2. Go to that jetpack site wp-admin and disconnect the site
3. Back to calypso, refresh and make sure that you are not getting any javascript errors

