### PR TITLE
Reader: Turn off stream refresh feature flag in dev

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -126,7 +126,7 @@
 		"reader/related-posts": true,
 		"reader/refresh/full-post-ab-test": true,
 		"reader/refresh/force-full-post": false,
-		"reader/refresh/stream": true,
+		"reader/refresh/stream": false,
 		"reader/search": true,
 		"reader/start": true,
 		"reader/tags-with-elasticsearch": true,


### PR DESCRIPTION
At least until the stream is functional.

To test, pull up http://calypso.localhost:3000 and ensure the reader is the "old" reader. 