### PR TITLE
Pages: Set Blog Posts as homepage

### DIFF
--- a/client/my-sites/pages/blog-posts-page.jsx
+++ b/client/my-sites/pages/blog-posts-page.jsx
@@ -3,14 +3,19 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
 import Gridicon from 'components/gridicon';
+import PopoverMenu from 'components/popover/menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 import { isEnabled } from 'config';
 import { getSiteFrontPageType, getSitePostsPage } from 'state/sites/selectors';
+import { setFrontPage } from 'state/sites/actions';
 
 const BlogPostsPage = React.createClass( {
 	propTypes() {
@@ -20,9 +25,49 @@ const BlogPostsPage = React.createClass( {
 		};
 	},
 
+	getInitialState: function() {
+		return {
+			showPageActions: false
+		};
+	},
+
+	togglePageActions: function() {
+		this.setState( { showPageActions: ! this.state.showPageActions } );
+	},
+
+	setAsHomepage: function() {
+		this.setState( { showPageActions: false } );
+		this.props.setFrontPage( this.props.siteId, 0 );
+	},
+
+	getSetAsHomepageItem: function() {
+		if ( this.props.isFrontPage ) {
+			return null;
+		}
+
+		return (
+			<PopoverMenuItem onClick={ this.setAsHomepage }>
+				<Gridicon icon="house" size={ 18 } />
+				{ this.translate( 'Set as Homepage' ) }
+			</PopoverMenuItem>
+		);
+	},
+
+	getFrontPageInfo: function() {
+		if ( ! this.props.isFrontPage ) {
+			return null;
+		}
+
+		return (
+			<div className="pages__blog-posts-page__popover-more-info">
+				{ this.translate( 'This page is set as your site\'s homepage' ) }
+			</div>
+		);
+	},
+
 	render() {
 		const isStaticHomePageWithNoPostsPage = this.props.frontPageType === 'page' && ! this.props.postsPage;
-		const shouldShow = this.props.frontPageType === 'posts' ||
+		const shouldShow = this.props.isFrontPage ||
 			( isEnabled( 'manage/pages/set-homepage' ) && isStaticHomePageWithNoPostsPage );
 
 		if ( ! shouldShow ) {
@@ -52,6 +97,23 @@ const BlogPostsPage = React.createClass( {
 				<div className="pages__blog-posts-page__info">
 					{ this.translate( 'Your latest posts' ) }
 				</div>
+				<Gridicon
+					icon="ellipsis"
+					className={ classNames( {
+						'page__actions-toggle': true,
+						'is-active': this.state.showPageActions
+					} ) }
+					onClick={ this.togglePageActions }
+					ref="popoverMenuButton" />
+				<PopoverMenu
+					isVisible={ this.state.showPageActions }
+					onClose={ this.togglePageActions }
+					position={ 'bottom left' }
+					context={ this.refs && this.refs.popoverMenuButton }
+				>
+					{ this.getSetAsHomepageItem() }
+					{ this.getFrontPageInfo() }
+				</PopoverMenu>
 			</CompactCard>
 		);
 	}
@@ -61,7 +123,11 @@ export default connect(
 	( state, props ) => {
 		return {
 			frontPageType: getSiteFrontPageType( state, props.siteId ),
+			isFrontPage: getSiteFrontPageType( state, props.siteId ) === 'posts',
 			postsPage: getSitePostsPage( state, props.siteId )
 		};
-	}
+	},
+	( dispatch ) => bindActionCreators( {
+		setFrontPage
+	}, dispatch )
 )( BlogPostsPage );

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -231,7 +231,7 @@ var Pages = React.createClass( {
 				rows.push(
 					<BlogPostsPage
 						key="blog-posts-page"
-						siteId={ site.ID }
+						site={ site }
 					/>
 				);
 			}

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -90,12 +90,17 @@
 	}
 }
 
-.page__popover-more-info {
+.page__popover-more-info,
+.pages__blog-posts-page__popover-more-info {
 	color: $gray;
 	padding: 4px 16px 8px;
 	font-size: 12px;
 	max-width: 200px;
 	text-align: left;
+}
+
+.pages__blog-posts-page__popover-more-info {
+	padding: 8px 16px;
 }
 
 .pages__blog-posts-page__not-used-label {


### PR DESCRIPTION
This PR makes it possible to set Blog Posts as the homepage, if a static page is current set as the homepage (see #8617). It is part of a larger epic and is behind a feature flag, `manage/pages/set-homepage`, that is only enabled in `development`.

An option to set Blog Posts as the homepage for a site is now available:

<img width="712" alt="screencapture at thu oct 13 09 50 43 edt 2016" src="https://cloud.githubusercontent.com/assets/2098816/19351638/9402a778-912a-11e6-999a-a1ec17d66be4.png">

If Blog Posts are already set as the homepage for a site, the menu will not be shown at all:

<img width="714" alt="screencapture at thu oct 13 14 05 00 edt 2016" src="https://cloud.githubusercontent.com/assets/2098816/19360816/13c816e6-914e-11e6-8947-74e095c0b11d.png">

To test:
- Try changing the home page using the popover menu for a static page and make sure it changes. Verify in wp-admin and by viewing the site.
- Change things back to the default (blog posts instead of a static page as the homepage) and make sure it changes. Verify in wp-admin and by viewing the site.
- Verify menu item does not appear when user does not have capability (Editor role).
- Disable the feature flag and make sure thing behave as previously (`DISABLE_FEATURES=manage/pages/set-homepage make run`)