### PR TITLE
Reader: Refresh post card CSS cleanup

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -18,12 +18,12 @@ import ExternalLink from 'components/external-link';
 
 function FeaturedImage( { image, href } ) {
 	return (
-		<div className="reader-post-card__featured-image" href={ href } style={ {
+		<a className="reader-post-card__featured-image" href={ href } style={ {
 			backgroundImage: 'url(' + image.uri + ')',
 			backgroundSize: 'cover',
 			backgroundRepeat: 'no-repeat',
 			backgroundPosition: '50% 50%'
-		} } ></div> );
+		} } ></a> );
 }
 
 function PostByline( { post } ) {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -18,12 +18,12 @@ import ExternalLink from 'components/external-link';
 
 function FeaturedImage( { image, href } ) {
 	return (
-		<a className="reader-post-card__featured-image" href={ href } style={ {
+		<div className="reader-post-card__featured-image" href={ href } style={ {
 			backgroundImage: 'url(' + image.uri + ')',
 			backgroundSize: 'cover',
 			backgroundRepeat: 'no-repeat',
 			backgroundPosition: '50% 50%'
-		} } ></a> );
+		} } ></div> );
 }
 
 function PostByline( { post } ) {
@@ -64,35 +64,35 @@ export function RefreshPostCard( { post, site, feed, onClick = noop, onCommentCl
 						<a className="reader-post-card__title-link" href={ post.URL }>{ title }</a>
 					</h1>
 					<div className="reader-post-card__excerpt">{ post.short_excerpt }</div>
+					<ul className="reader-post-card__social ignore-click">
+						<li className="reader-post-card__visit">
+							<ExternalLink icon={ true }>Visit</ExternalLink>
+						</li>
+						<li className="reader-post-card__share">
+							<Gridicon icon="share" />
+							<span className="reader-share__button-label">Share</span>
+						</li>
+						<li className="reader-post-card__comments">
+							<CommentButton
+								commentCount={ post.discussion.comment_count }
+								tagName="span"
+								showLabel={ true }
+								onClick={ onCommentClick } />
+						</li>
+						<li className="reader-post-card__likes">
+							<LikeButton
+								siteId={ post.site_ID }
+								postId={ post.ID }
+								tagName="span"
+								showZeroCount={ true }
+								showLabel={ true } />
+						</li>
+						<li className="reader-post-card__post-options">
+							<Gridicon icon="ellipsis" />
+						</li>
+					</ul>
 				</div>
 			</div>
-			<ul className="reader-post-card__social ignore-click">
-				<li className="reader-post-card__visit">
-					<ExternalLink icon={ true }>Visit</ExternalLink>
-				</li>
-				<li className="reader-post-card__share">
-					<Gridicon icon="share" />
-					<span className="reader-share__button-label">Share</span>
-				</li>
-				<li className="reader-post-card__comments">
-					<CommentButton
-						commentCount={ post.discussion.comment_count }
-						tagName="span"
-						showLabel={ true }
-						onClick={ onCommentClick } />
-				</li>
-				<li className="reader-post-card__likes">
-					<LikeButton
-						siteId={ post.site_ID }
-						postId={ post.ID }
-						tagName="span"
-						showZeroCount={ true }
-						showLabel={ true } />
-				</li>
-				<li className="reader-post-card__post-options">
-					<Gridicon icon="ellipsis" />
-				</li>
-			</ul>
 		</Card>
 	);
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -25,6 +25,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				padding-left: 205px;
 			}
 
+			@include breakpoint( "<960px" ) {
+				padding-left: 205px;
+			}
+
 			@media #{$reader-post-card-breakpoint-medium} {
 				padding-left: 0;
 			}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -88,10 +88,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		flex-basis: auto;
 		flex-grow: 1;
 		margin-right: 20px;
-		max-width: 250px;
+		max-width: 190px;
 
-		@include breakpoint( "<960px" ) {
-			max-width: 190px;
+		@include breakpoint( ">960px" ) {
+			max-width: 250px;
 		}
 
 		@media #{$reader-post-card-breakpoint-medium} {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -25,10 +25,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				padding-left: 205px;
 			}
 
-			@include breakpoint( "<960px" ) {
-				padding-left: 205px;
-			}
-
 			@media #{$reader-post-card-breakpoint-medium} {
 				padding-left: 0;
 			}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -8,10 +8,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader-post-card.card {
 	border-bottom: 1px solid lighten( $gray, 30% );
 	box-shadow: none;
-	padding: 16px 0 0;
+	padding: 16px;
 
-	@include breakpoint( "<660px" ) {
-		margin: 16px;
+	@include breakpoint( ">660px" ) {
+		margin: 16px 0 0;
 	}
 
 	&.has-thumbnail {
@@ -25,7 +25,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				padding-left: 205px;
 			}
 
-			@include breakpoint( "660px-960px" ) {
+			@include breakpoint( "<960px" ) {
+				padding-left: 205px;
+			}
+
+			@media #{$reader-post-card-breakpoint-medium} {
 				padding-left: 0;
 			}
 
@@ -33,7 +37,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				padding-left: 205px;
 			}
 
-			@include breakpoint( "<480px" ) {
+			@media #{$reader-post-card-breakpoint-small} {
 				padding-left: 0;
 			}
 		}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -90,6 +90,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin-right: 20px;
 		max-width: 250px;
 
+		@include breakpoint( "<960px" ) {
+			max-width: 190px;
+		}
+
 		@media #{$reader-post-card-breakpoint-medium} {
 			height: 100px;
 			max-width: none;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -8,38 +8,17 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader-post-card.card {
 	border-bottom: 1px solid lighten( $gray, 30% );
 	box-shadow: none;
-	padding: 16px;
+	margin: 10px;
+	padding: 20px 10px;
 
 	@include breakpoint( ">660px" ) {
-		margin: 16px 0 0;
+		padding: 20px 0;
 	}
 
 	&.has-thumbnail {
 
-		.reader-post-card__post-details {
-			flex: 1;
-			margin-top: -13px;
-			padding-left: 265px;
-
-			@media #{$reader-post-card-breakpoint-large} {
-				padding-left: 205px;
-			}
-
-			@include breakpoint( "<960px" ) {
-				padding-left: 205px;
-			}
-
-			@media #{$reader-post-card-breakpoint-medium} {
-				padding-left: 0;
-			}
-
-			@include breakpoint( "<660px" ) {
-				padding-left: 205px;
-			}
-
-			@media #{$reader-post-card-breakpoint-small} {
-				padding-left: 0;
-			}
+		.reader-post-card__excerpt {
+			margin-bottom: 20px;
 		}
 
 		.reader-post-card__social {
@@ -50,61 +29,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			height: 22px;
 			list-style-type: none;
 			margin: 0;
-			padding: 20px 0 37px 265px;
 			width: 100%;
-
-			@media #{$reader-post-card-breakpoint-large} {
-				padding-left: 206px;
-			}
-
-			@include breakpoint( "<960px" ) {
-				padding-left: 206px;
-			}
-
-			@media #{$reader-post-card-breakpoint-medium}  {
-				padding-left: 0;
-			}
-
-			@media #{$reader-post-card-breakpoint-small} {
-				padding-left: 0;
-			}
 
 			.gridicon {
 				fill: lighten( $gray, 10% );
 			}
 		}
-	}
-}
-
-.reader-post-card__featured-image {
-	display: block;
-	height: calc( 100% - 92px );
-	margin-right: 15px;
-	position: absolute;
-		bottom: 6px;
-		top: 62px;
-	width: 250px;
-
-	@media #{$reader-post-card-breakpoint-large} {
-		width: 190px;
-	}
-
-	@include breakpoint( "<960px" ) {
-		width: 190px;
-	}
-
-	@media #{$reader-post-card-breakpoint-medium} {
-		width: 100%;
-		height: 100px;
-	}
-
-	@include breakpoint( "<660px" ) {
-		width: 190px;
-	}
-
-	@media #{$reader-post-card-breakpoint-small} {
-		width: 100%;
-		height: 100px;
 	}
 }
 
@@ -150,39 +80,43 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__post {
-	align-items: flex-start;
 	display: flex;
+	flex-wrap: wrap;
+	flex-direction: row;
+
+	.reader-post-card__featured-image {
+		flex-basis: auto;
+		flex-grow: 1;
+		margin-right: 20px;
+		max-width: 250px;
+
+		@media #{$reader-post-card-breakpoint-medium} {
+			height: 100px;
+			max-width: none;
+			width: 100%;
+		}
+
+		@media #{$reader-post-card-breakpoint-small} {
+			height: 100px;
+			max-width: none;
+			width: 100%;
+		}
+	}
+
+	.reader-post-card__post-details {
+		flex: 1;
+	}
+
+	@media #{$reader-post-card-breakpoint-large} {
+		flex-direction: row;
+	}
 
 	@media #{$reader-post-card-breakpoint-medium} {
 		flex-direction: column;
 	}
 
-	.reader-post-card__featured-image {
-		@media #{$reader-post-card-breakpoint-medium} {
-			position: static;
-		}
-	}
-
-	.reader-post-card__post-details {
-		@media #{$reader-post-card-breakpoint-medium} {
-			padding-left: 0;
-		}
-	}
-
 	@media #{$reader-post-card-breakpoint-small} {
 		flex-direction: column;
-	}
-
-	.reader-post-card__featured-image {
-		@media #{$reader-post-card-breakpoint-small} {
-			position: static;
-		}
-	}
-
-	.reader-post-card__post-details {
-		@media #{$reader-post-card-breakpoint-small} {
-			padding-left: 0;
-		}
 	}
 }
 
@@ -192,15 +126,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .reader-post-card__title {
 	line-height: 1.3;
-	margin: 10px 0;
-
-	@media #{$reader-post-card-breakpoint-medium} {
-		margin: 30px 0 10px;
-	}
-
-	@media #{$reader-post-card-breakpoint-small} {
-		margin: 30px 0 10px;
-	}
 }
 
 // Needs to overwrite .reader__content a
@@ -224,9 +149,9 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__social {
+	font-family: $sans;
 	display: flex;
 	margin: 10px 0 0;
-	padding-bottom: 20px;
 }
 
 .reader-post-card__visit,


### PR DESCRIPTION
This is to address: https://github.com/Automattic/wp-calypso/pull/8463/files/27416c5b4d5561008831da8bf166b887c19d9840#r83154742

@dmsnell I actually had to remove that particular breakpoint declaration because it was no longer necessary and I had to fix this issue that I hadn't noticed earlier:

**Before:**
![screenshot 2016-10-13 08 05 53](https://cloud.githubusercontent.com/assets/4924246/19355066/cb64c168-911d-11e6-87e0-303785b5994a.png)

**After:**
![screenshot 2016-10-13 08 06 48](https://cloud.githubusercontent.com/assets/4924246/19355219/78d6547e-911e-11e6-8ae9-0ffd18fdd705.png)

I also had to leave `<960px` and `<660px` as it is instead of replacing it with `>960px` / `>660px`. Otherwise, anything outside those breakpoints and anything above the custom breakpoint `@media #{$reader-post-card-breakpoint-large}` will be getting the incorrect padding.