### PR TITLE
Pages: Only show Set Homepage menu item if capable and config allows

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -27,6 +27,8 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 import MenuSeparator from 'components/popover/menu-separator';
 import { isFrontPage } from 'state/pages/selectors';
 import { setFrontPage } from 'state/sites/actions';
+import { userCan } from 'lib/site/utils';
+
 
 function recordEvent( eventAction ) {
 	analytics.ga.recordEvent( 'Pages', eventAction );
@@ -109,7 +111,9 @@ const Page = React.createClass( {
 	getSetAsHomepageItem: function() {
 		const isPublished = this.props.page.status === 'publish';
 
-		if ( ! isPublished || this.props.isFrontPage ) {
+		if ( ! isPublished || this.props.isFrontPage ||
+			! config.isEnabled( 'manage/pages/set-homepage' ) ||
+			! userCan( 'edit_theme_options', this.props.site ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR updates things to only allow the "Set as Homepage" menu item for pages (see #8617) if the user has the capability to make the change and if the config allows it. It is part of a larger epic and is behind a feature flag, `manage/pages/set-homepage`, that is only enabled in `development`.

To test:
- Verify menu item appears when user has capability (Administrator)
- Verify menu item does not appear when user does not have capability (Editor role)
- Disable the feature flag and make sure thing behave as previously (`DISABLE_FEATURES=manage/pages/set-homepage make run`)

A separate PR will be created to handle the "Set as Homepage" menu item for the Blog Posts list item.