### PR TITLE
Reader: Get the following button on full post view to update properly

### DIFF
--- a/client/components/follow-button/index.jsx
+++ b/client/components/follow-button/index.jsx
@@ -28,8 +28,8 @@ const FollowButtonContainer = React.createClass( {
 		return this.getStateFromStores();
 	},
 
-	getStateFromStores() {
-		return { following: FeedSubscriptionStore.getIsFollowingBySiteUrl( this.props.siteUrl ) };
+	getStateFromStores( props = this.props ) {
+		return { following: FeedSubscriptionStore.getIsFollowingBySiteUrl( props.siteUrl ) };
 	},
 
 	componentDidMount() {
@@ -40,11 +40,19 @@ const FollowButtonContainer = React.createClass( {
 		FeedSubscriptionStore.off( 'change', this.onStoreChange );
 	},
 
-	onStoreChange() {
-		const newState = this.getStateFromStores();
+	componentWillReceiveProps( nextProps ) {
+		this.updateState( nextProps );
+	},
+
+	updateState( props = this.props ) {
+		const newState = this.getStateFromStores( props );
 		if ( newState.following !== this.state.following ) {
 			this.setState( newState );
 		}
+	},
+
+	onStoreChange() {
+		this.updateState();
 	},
 
 	handleFollowToggle( following ) {
@@ -59,7 +67,7 @@ const FollowButtonContainer = React.createClass( {
 				onFollowToggle={ this.handleFollowToggle }
 				iconSize={ this.props.iconSize }
 				tagName={ this.props.tagName }
-				disabled={ this.props.disabled }/>
+				disabled={ this.props.disabled } />
 		);
 	}
 } );

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -58,5 +58,7 @@ export default connect(
 	( dispatch ) => bindActionCreators( {
 		recordFollow,
 		recordUnfollow
-	}, dispatch )
+	}, dispatch ),
+	null,
+	{ pure: false } // we are not pure from the standpoint of the redux state tree
 )( ReaderFollowButton );


### PR DESCRIPTION
When moving from one full post to another, like via related posts, the following button would not accept the new props and update it's state properly. This teaches the following button container to update its state when new props arrive.

Fixes #8725