### PR TITLE
Ad Tracking: Add Yahoo purchase conversion tracking

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -37,6 +37,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		'?site=695501&betr=sslbet_1472760417=[+]ssprlb_1472760417[720]|sslbet_1472760452=[+]ssprlb_1472760452[8760]',
 	PANDORA_CONVERSION_PIXEL_URL = 'https://data.adxcel-ec2.com/pixel/' +
 		'?ad_log=referer&action=purchase&pixid=7efc5994-458b-494f-94b3-31862eee9e26',
+	YAHOO_TRACKING_SCRIPT_URL = 'https://s.yimg.com/wi/ytc.js',
 	TRACKING_IDS = {
 		bingInit: '4074038',
 		facebookInit: '823166884443641',
@@ -44,7 +45,9 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		googleConversionLabelJetpack: '0fwbCL35xGIQqv3svgM',
 		atlasUniveralTagId: '11187200770563',
 		criteo: '31321',
-		quantcast: 'p-3Ma3jHaQMB_bS'
+		quantcast: 'p-3Ma3jHaQMB_bS',
+		yahooProjectId: '10000',
+		yahooPixelId: '10014088'
 	},
 
 	// For converting other currencies into USD for tracking purposes
@@ -118,6 +121,9 @@ function loadTrackingScripts( callback ) {
 		},
 		function( onComplete ) {
 			loadScript.loadScript( quantcastAsynchronousTagURL(), onComplete );
+		},
+		function( onComplete ) {
+			loadScript.loadScript( YAHOO_TRACKING_SCRIPT_URL, onComplete );
 		}
 	], function( errors ) {
 		if ( ! some( errors ) ) {
@@ -334,9 +340,9 @@ function recordProduct( product, orderId ) {
 			} );
 		}
 
-		// Quantcast
-		// Note that all properties have to be strings or they won't get tracked
 		if ( isSupportedCurrency( product.currency ) ) {
+			// Quantcast
+			// Note that all properties have to be strings or they won't get tracked
 			window._qevents.push( {
 				qacct: TRACKING_IDS.quantcast,
 				labels: '_fp.event.Purchase Confirmation,_fp.pcat.' + product.product_slug,
@@ -344,6 +350,25 @@ function recordProduct( product, orderId ) {
 				revenue: costUSD.toString(),
 				event: 'refresh'
 			} );
+
+			// Yahoo
+			// Like the Quantcast tracking above, the price has to be passed as a string
+			// See: https://developer.yahoo.com/gemini/guide/dottags/installing-tags/
+
+			/*global YAHOO*/
+			YAHOO.ywa.I13N.fireBeacon( [ {
+				projectId: TRACKING_IDS.yahooProjectId,
+				properties: {
+					pixelId: TRACKING_IDS.yahooPixelId,
+					qstrings: {
+						et: 'custom',
+						ec: 'wordpress.com',
+						ea: 'purchase',
+						el: product.product_slug,
+						gv: costUSD.toString()
+					}
+				}
+			} ] );
 		}
 	} catch ( err ) {
 		debug( 'Unable to save purchase tracking data', err );


### PR DESCRIPTION
This PR adds purchase conversion tracking for Yahoo's ad network. It will allow us to measure how much revenue we make off of WordPress.com ads we show on Yahoo's ad network.

## Reverse engineering Yahoo's JavaScript tracking

Before you begin, read this [Installing Dot Tags](https://developer.yahoo.com/gemini/guide/dottags/installing-tags/) guide by Yahoo.

Yahoo's tracking implementation instructions in that guide aren't compatible with Calypso's architecture so I had to figure out a different way to do this.

Here are the changes I made and why.

Yahoo provides a tracking script that they want us to drop on every page. Here's the one for our account:

![screen shot 2016-10-13 at 1 50 53 pm](https://cloud.githubusercontent.com/assets/44436/19360338/1d1b7294-914c-11e6-8c8c-5945366f755e.png)

```
<script type="application/javascript">(function(w,d,t,r,u){w[u]=w[u]||[];w[u].push({'projectId':'10000','properties':{'pixelId':'10014088'}});var s=d.createElement(t);s.src=r;s.async=true;s.onload=s.onreadystatechange=function(){var y,rs=this.readyState,c=w[u];if(rs&&rs!="complete"&&rs!="loaded"){return}try{y=YAHOO.ywa.I13N.fireBeacon;w[u]=[];w[u].push=function(p){y([p])};y(c)}catch(e){}};var scr=d.getElementsByTagName(t)[0],par=scr.parentNode;par.insertBefore(s,scr)})(window,document,"script","https://s.yimg.com/wi/ytc.js","dotq");</script>
```

We can't just copy and paste this into Calypso though, hence the need to figure out a different way to do it.

[Unminifying that code](http://unminify.com/), we get:

```
< script type = "application/javascript" > (function(w, d, t, r, u) {
		w[u] = w[u] || [];
		w[u].push({
				'projectId': '10000',
				'properties': {
						'pixelId': '10014088'
				}
		});
		var s = d.createElement(t);
		s.src = r;
		s.async = true;
		s.onload = s.onreadystatechange = function() {
				var y, rs = this.readyState,
						c = w[u];
				if (rs && rs != "complete" && rs != "loaded") {
						return
				}
				try {
						y = YAHOO.ywa.I13N.fireBeacon;
						w[u] = [];
						w[u].push = function(p) {
								y([p])
						};
						y(c)
				} catch (e) {}
		};
		var scr = d.getElementsByTagName(t)[0],
				par = scr.parentNode;
		par.insertBefore(s, scr)
})(window, document, "script", "https://s.yimg.com/wi/ytc.js", "dotq"); < /script>
```

It's a little hard to follow, but here's the idea:

Under normal circumstances, there would be a global array that we push events to:

```
window.dotq = window.dotq || [];
window.dotq.push( { ... } );
```

What their code does is it loads https://s.yimg.com/wi/ytc.js, then when it's done loading, it calls `YAHOO.ywa.I13N.fireBeacon` with anything that's _already_ in `window.dotq` (in case the site tracked something before the lib loaded), then overwrites the global array's `push` method so that anytime we push events to it in the future, it calls `YAHOO.ywa.I13N.fireBeacon` directly.

Because we're only tracking purchases in Calypso and the Yahoo ad script will already be loaded by the time the event tracking is called, we can skip using that global array entirely and just call `YAHOO.ywa.I13N.fireBeacon` with the event details instead. Check out the code to see how I did this.

## How to test

1) In `development.js`, set `ad-tracking` to `true`.
2) Load any page in Calypso and verify in Chrome's Network tab for `ytc.js` and verify it is loaded:

![screen shot 2016-10-13 at 1 33 58 pm](https://cloud.githubusercontent.com/assets/44436/19360130/2e5ed772-914b-11e6-9b04-da89652ad185.png)
 
3) Purchase a plan
4) Search Chrome's Network tab again, this time for `yahoo` and verify the request was fired:

![screen shot 2016-10-13 at 1 35 19 pm](https://cloud.githubusercontent.com/assets/44436/19360158/4f8b6028-914b-11e6-82c7-4a95c222784c.png)

5) [Decoding](http://www.motobit.com/util/url-decoder.asp) the request URL should look something like this:

```http://sp.analytics.yahoo.com/sp.pl?a=10000&jsonp=YAHOO.ywa.I13N.handleJSONResponse&d=Thu, 13 Oct 2016 17:34:56 GMT&n=4d&b=Checkout ‹ Site Title — WordPress.com&.yp=10014088&f=http://calypso.localhost:3000/checkout/mhmazur20161013v1.wordpress.com/personal&enc=UTF-8&et=custom&ec=wordpress.com&ea=purchase&el=personal-bundle&gv=35.880```

Notice that `et` is set to `custom`, `ec` to `wordpress.com`, `ea` to `purchase`, `el` to the product slug (`personal-bundle` for my test), and `gv` to the price of the plan (`35.88` for me). 

Verify these values make sense based on Installing Dot Tags guidance linked to above.