### PR TITLE
ThemeQueryManager: Add

### DIFF
--- a/client/lib/query-manager/theme/constants.js
+++ b/client/lib/query-manager/theme/constants.js
@@ -1,0 +1,8 @@
+export const DEFAULT_THEME_QUERY = {
+	search: '',
+	tier: '',
+	filter: '',
+	number: 20,
+	offset: 0,
+	page: 1
+};

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -25,7 +25,7 @@ export default class ThemeQueryManager extends PaginatedQueryManager {
 	 */
 
 	matches( query, theme ) {
-		const queryWithDefaults = Object.assign( {}, DEFAULT_THEME_QUERY, query );
+		const queryWithDefaults = { ...DEFAULT_THEME_QUERY, ...query };
 		return every( queryWithDefaults, ( value, key ) => {
 			switch ( key ) {
 				case 'search':

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import { every, some, includes, startsWith } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import PaginatedQueryManager from '../paginated';
+import ThemeQueryKey from './key';
+import { DEFAULT_THEME_QUERY } from './constants';
+
+/**
+ * ThemeQueryManager manages themes which can be queried
+ */
+export default class ThemeQueryManager extends PaginatedQueryManager {
+	/**
+	 * Returns true if the theme matches the given query, or false otherwise.
+	 *
+	 * @param  {Object}  query Query object
+	 * @param  {Object}  theme Item to consider
+	 * @return {Boolean}       Whether theme matches query
+	 */
+
+	matches( query, theme ) {
+		const queryWithDefaults = Object.assign( {}, DEFAULT_THEME_QUERY, query );
+		return every( queryWithDefaults, ( value, key ) => {
+			switch ( key ) {
+				case 'search':
+					if ( ! value ) {
+						return true;
+					}
+
+					const search = value.toLowerCase();
+
+					const taxonomiesToSearch = [ 'subject', 'feature', 'color', 'style', 'column', 'layout' ];
+					const foundInTaxonomies = some( taxonomiesToSearch, ( taxonomy ) => (
+						some( theme.taxonomies[ 'theme_' + taxonomy ], ( { name } ) => (
+							includes( name.toLowerCase(), search )
+						) )
+					) );
+
+					return foundInTaxonomies || (
+						( theme.name && includes( theme.name.toLowerCase(), search ) ) ||
+						( theme.author && includes( theme.author.toLowerCase(), search ) ) ||
+						( theme.descriptionLong && includes( theme.descriptionLong.toLowerCase(), search ) )
+					);
+
+				case 'filters':
+					// TODO: Change filters object shape to be more like post's terms, i.e.
+					// { color: 'blue,red', feature: 'post-slider' }
+					const filters = value.split( ',' );
+					return every( filters, ( filter ) => (
+						some( theme.taxonomies, ( terms ) => (
+							some( terms, ( { slug } ) => (
+								slug === filter
+							) )
+						) )
+					) );
+
+				case 'tier':
+					if ( ! value ) {
+						return true;
+					}
+					// TODO: Use isPremium() helper here once its module has fewer dependencies (SSR!)
+					const queryingForPremium = value === 'premium';
+					const isPremiumTheme = startsWith( theme.stylesheet, 'premium/' );
+					return queryingForPremium === isPremiumTheme;
+			}
+
+			return true;
+		} );
+	}
+}
+
+ThemeQueryManager.QueryKey = ThemeQueryKey;
+
+ThemeQueryManager.DEFAULT_QUERY = DEFAULT_THEME_QUERY;

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -53,9 +53,7 @@ export default class ThemeQueryManager extends PaginatedQueryManager {
 					const filters = value.split( ',' );
 					return every( filters, ( filter ) => (
 						some( theme.taxonomies, ( terms ) => (
-							some( terms, ( { slug } ) => (
-								slug === filter
-							) )
+							some( terms, { slug: filter } )
 						) )
 					) );
 

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -10,6 +10,8 @@ import PaginatedQueryManager from '../paginated';
 import ThemeQueryKey from './key';
 import { DEFAULT_THEME_QUERY } from './constants';
 
+const SEARCH_TAXONOMIES = [ 'subject', 'feature', 'color', 'style', 'column', 'layout' ];
+
 /**
  * ThemeQueryManager manages themes which can be queried
  */
@@ -33,8 +35,7 @@ export default class ThemeQueryManager extends PaginatedQueryManager {
 
 					const search = value.toLowerCase();
 
-					const taxonomiesToSearch = [ 'subject', 'feature', 'color', 'style', 'column', 'layout' ];
-					const foundInTaxonomies = some( taxonomiesToSearch, ( taxonomy ) => (
+					const foundInTaxonomies = some( SEARCH_TAXONOMIES, ( taxonomy ) => (
 						some( theme.taxonomies[ 'theme_' + taxonomy ], ( { name } ) => (
 							includes( name.toLowerCase(), search )
 						) )

--- a/client/lib/query-manager/theme/key.js
+++ b/client/lib/query-manager/theme/key.js
@@ -19,7 +19,7 @@ import { DEFAULT_THEME_QUERY } from './constants';
  */
 function isDefaultOrNullQueryValue( value, key ) {
 	return (
-		null == value || // Double-equals null checks undefined, null
+		value === undefined || value === null ||
 		DEFAULT_THEME_QUERY[ key ] === value
 	);
 }

--- a/client/lib/query-manager/theme/key.js
+++ b/client/lib/query-manager/theme/key.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import omitBy from 'lodash/omitBy';
+import { omitBy } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/lib/query-manager/theme/key.js
+++ b/client/lib/query-manager/theme/key.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import omitBy from 'lodash/omitBy';
+
+/**
+ * Internal dependencies
+ */
+import PaginatedQueryKey from '../paginated/key';
+import { DEFAULT_THEME_QUERY } from './constants';
+
+/**
+ * Returns true if the specified key value query pair is identical to that of
+ * the default theme query, is null, or is undefined.
+ *
+ * @param  {*}       value Value to check
+ * @param  {String}  key   Key to check
+ * @return {Boolean}       Whether key value matches default query or is null
+ */
+function isDefaultOrNullQueryValue( value, key ) {
+	return (
+		null == value || // Double-equals null checks undefined, null
+		DEFAULT_THEME_QUERY[ key ] === value
+	);
+}
+
+/**
+ * ThemeQueryKey manages the serialization and deserialization of a query key
+ * for use in tracking query results in an instance of ThemeQueryManager.
+ */
+export default class ThemeQueryKey extends PaginatedQueryKey {
+	/**
+	 * Returns a serialized query, given a query object
+	 *
+	 * @param  {Object} query Query object
+	 * @return {String}       Serialized query
+	 */
+	static stringify( query ) {
+		return super.stringify( omitBy( query, isDefaultOrNullQueryValue ) );
+	}
+
+	/**
+	 * Returns a query object, given a serialized query
+	 *
+	 * @param  {String} key Serialized query
+	 * @return {Object}     Query object
+	 */
+	static parse( key ) {
+		return omitBy( super.parse( key ), isDefaultOrNullQueryValue );
+	}
+}

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -131,8 +131,6 @@ describe( 'ThemeQueryManager', () => {
 
 				expect( isMatch ).to.be.false;
 			} );
-
-			// search terms
 		} );
 
 		context( 'query.filters', () => {

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -100,6 +100,22 @@ describe( 'ThemeQueryManager', () => {
 				expect( isMatch ).to.be.true;
 			} );
 
+			it( 'should return true for a matching author search', () => {
+				const isMatch = manager.matches( {
+					search: 'team'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for a matching filter search', () => {
+				const isMatch = manager.matches( {
+					search: 'journal'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
 			it( 'should search case-insensitive', () => {
 				const isMatch = manager.matches( {
 					search: 'Sidebar'

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -1,0 +1,208 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import ThemeQueryManager from '../';
+
+/**
+ * Constants
+ */
+const DEFAULT_THEME = {
+	name: 'Twenty Something',
+	author: 'the WordPress team',
+	screenshot: 'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysomething/screenshot.png',
+	screenshots: [ 'https://i0.wp.com/theme.files.wordpress.com/2015/12/twentysomething-featured-image.jpg?ssl=1' ],
+	stylesheet: 'pub/twentysomething',
+	taxonomies: {
+		theme_subject: [
+			{
+				name: 'Blog',
+				slug: 'blog',
+				term_id: '273'
+			},
+			{
+				name: 'Lifestream',
+				slug: 'lifestream',
+				term_id: '652270'
+			},
+			{
+				name: 'Journal',
+				slug: 'journal',
+				term_id: '96'
+			}
+		],
+		theme_color: [
+			{
+				name: 'Black',
+				slug: 'black',
+				term_id: '59007'
+			},
+			{
+				name: 'Blue',
+				slug: 'blue',
+				term_id: '9150'
+			},
+			{
+				name: 'Gray',
+				slug: 'gray',
+				term_id: '147520'
+			}
+		]
+	},
+	demo_uri: 'https://twentysomethingdemo.wordpress.com/',
+	descriptionLong: 'The annual WordPress theme for this year is a modern take on an ever-popular layout. ' +
+		'The horizontal header area with an optional right sidebar works perfectly for both blogs <em>and</em> websites.',
+	description: 'This is a modernized take on an ever-popular WordPress layout' +
+		' — the horizontal masthead with an optional right sidebar that works perfectly for blogs and websites.'
+};
+
+describe( 'ThemeQueryManager', () => {
+	let manager;
+	beforeEach( () => {
+		manager = new ThemeQueryManager();
+	} );
+
+	describe( '#matches()', () => {
+		context( 'query.search', () => {
+			it( 'should return false for a non-matching search', () => {
+				const isMatch = manager.matches( {
+					search: 'nonexisting'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true for a matching title search', () => {
+				const isMatch = manager.matches( {
+					search: 'Twenty'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for a falsey title search', () => {
+				const isMatch = manager.matches( {
+					search: null
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for a matching content search', () => {
+				const isMatch = manager.matches( {
+					search: 'modern'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should search case-insensitive', () => {
+				const isMatch = manager.matches( {
+					search: 'Sidebar'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should separately test title and content fields', () => {
+				const isMatch = manager.matches( {
+					search: 'TwentyThe'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			// search terms
+		} );
+
+		context( 'query.filters', () => {
+			it( 'should return false if theme does not include filter', () => {
+				const isMatch = manager.matches( {
+					filters: 'nosuchfilter'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return false on a partial match', () => {
+				const isMatch = manager.matches( {
+					filters: 'ourna'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true if theme includes filter', () => {
+				const isMatch = manager.matches( {
+					filters: 'journal'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			context( 'with multiple filters from a single taxonomy', () => {
+				it( 'should return false if theme doesn\'t match all filters', () => {
+					const isMatch = manager.matches( {
+						filters: 'journal,business'
+					}, DEFAULT_THEME );
+
+					expect( isMatch ).to.be.false;
+				} );
+				it( 'should return true if theme matches all filters', () => {
+					const isMatch = manager.matches( {
+						filters: 'journal,blog'
+					}, DEFAULT_THEME );
+
+					expect( isMatch ).to.be.true;
+				} );
+			} );
+
+			context( 'with multiple filters from different taxonomies', () => {
+				it( 'should return false if theme doesn\'t match all filters', () => {
+					const isMatch = manager.matches( {
+						filters: 'journal,green'
+					}, DEFAULT_THEME );
+
+					expect( isMatch ).to.be.false;
+				} );
+				it( 'should return true if theme matches all filters', () => {
+					const isMatch = manager.matches( {
+						filters: 'journal,black'
+					}, DEFAULT_THEME );
+
+					expect( isMatch ).to.be.true;
+				} );
+			} );
+		} );
+
+		context( 'query.tier', () => {
+			it( 'should return true for a free theme when querying for all themes', () => {
+				const isMatch = manager.matches( {
+					tier: ''
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for a free theme when querying for free themes', () => {
+				const isMatch = manager.matches( {
+					tier: 'free'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return false for a free theme when querying for premium themes', () => {
+				const isMatch = manager.matches( {
+					tier: 'premium'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.false;
+			} );
+		} );
+	} );
+} );

--- a/client/lib/query-manager/theme/test/key.js
+++ b/client/lib/query-manager/theme/test/key.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import ThemeQueryKey from '../key';
+
+describe( 'ThemeQueryKey', () => {
+	describe( '.stringify()', () => {
+		it( 'should return a JSON string of the object', () => {
+			const key = ThemeQueryKey.stringify( { ok: true } );
+
+			expect( key ).to.equal( '[["ok",true]]' );
+		} );
+
+		it( 'should omit default theme query parameters', () => {
+			const key = ThemeQueryKey.stringify( { ok: true, tier: '' } );
+
+			expect( key ).to.equal( '[["ok",true]]' );
+		} );
+
+		it( 'should omit null query values', () => {
+			const key = ThemeQueryKey.stringify( { ok: true, search: null } );
+
+			expect( key ).to.equal( '[["ok",true]]' );
+		} );
+
+		it( 'should omit undefined query values', () => {
+			const key = ThemeQueryKey.stringify( { ok: true, search: undefined } );
+
+			expect( key ).to.equal( '[["ok",true]]' );
+		} );
+	} );
+
+	describe( '.parse()', () => {
+		it( 'should return an object of the JSON string', () => {
+			const query = ThemeQueryKey.parse( '[["ok",true]]' );
+
+			expect( query ).to.eql( { ok: true } );
+		} );
+
+		it( 'should omit default theme query parameters', () => {
+			const query = ThemeQueryKey.parse( '[["ok",true],["tier",""]]' );
+
+			expect( query ).to.eql( { ok: true } );
+		} );
+
+		it( 'should omit null query values', () => {
+			const query = ThemeQueryKey.parse( '[["ok",true],["search",null]]' );
+
+			expect( query ).to.eql( { ok: true } );
+		} );
+	} );
+} );


### PR DESCRIPTION
Creates a [`QueryManager`](https://github.com/Automattic/wp-calypso/tree/master/client/lib/query-manager#query-manager) for themes that's supposed to eventually serve as a basis for a better data architecture to aid our improved Theme Showcase experience for Jetpack sites project.

In the spirit of quickly iterating, I'm setting this to 'Needs Review' and will refine later when needed.

To test -- since this isn't used anywhere yet, we should be covered by unit tests for now.

cc'ing `QueryManager` guru @aduth 