### PR TITLE
Plans: Implement InfoPopover component

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
 import config from 'config';
 import PlanFeaturesHeader from './header';
 import PlanFeaturesItem from './item';
-import Popover from 'components/popover';
 import PlanFeaturesActions from './actions';
 import { isCurrentPlanPaid, isCurrentSitePlan, getSitePlan, getSiteSlug } from 'state/sites/selectors';
 import { isCurrentUserCurrentPlanOwner, getPlansBySiteId } from 'state/sites/plans/selectors';
@@ -55,24 +54,6 @@ import { retargetViewPlans } from 'lib/analytics/ad-tracking';
 
 class PlanFeatures extends Component {
 
-	static getFeaturePopoverHiddenState() {
-		return {
-			showPopover: false,
-			popoverReference: null,
-			popoverDescription: ''
-		};
-	}
-
-	constructor() {
-		super();
-
-		this.state = PlanFeatures.getFeaturePopoverHiddenState();
-
-		this.closeFeaturePopover = this.closeFeaturePopover.bind( this );
-		this.showFeaturePopover = this.showFeaturePopover.bind( this );
-		this.swapFeaturePopover = this.swapFeaturePopover.bind( this );
-	}
-
 	render() {
 		const { planProperties } = this.props;
 
@@ -103,8 +84,6 @@ class PlanFeatures extends Component {
 							</tr>
 						</tbody>
 					</table>
-
-					{ this.renderFeaturePopover() }
 				</div>
 			</div>
 		);
@@ -345,25 +324,6 @@ class PlanFeatures extends Component {
 		} );
 	}
 
-	renderFeaturePopover() {
-		return (
-			<Popover
-				showDelay={ 100 }
-				id="popover__plan-features"
-				isVisible={ this.state.showPopover }
-				context={ this.state.popoverReference }
-				position="right"
-				onClose={ this.closeFeaturePopover }
-				className={ classNames(
-						'info-popover__tooltip',
-						'popover__plan-features'
-					) }
-				>
-					{ this.state.popoverDescription }
-			</Popover>
-		);
-	}
-
 	renderFeatureItem( feature, index ) {
 		return (
 			<PlanFeaturesItem
@@ -372,33 +332,10 @@ class PlanFeatures extends Component {
 					? feature.getDescription()
 					: null
 				}
-				onMouseEnter={ this.showFeaturePopover }
-				onMouseLeave={ this.closeFeaturePopover }
-				onTouchStart={ this.swapFeaturePopover }
 			>
-				{ feature.getTitle() }
+				<span className="plan-features__item-title">{ feature.getTitle() }</span>
 			</PlanFeaturesItem>
 		);
-	}
-
-	showFeaturePopover( el, popoverDescription ) {
-		this.setState( {
-			showPopover: true,
-			popoverDescription,
-			popoverReference: el
-		} );
-	}
-
-	closeFeaturePopover() {
-		this.setState( PlanFeatures.getFeaturePopoverHiddenState() );
-	}
-
-	swapFeaturePopover( el, popoverDescription ) {
-		if ( this.state.showPopover ) {
-			this.closeFeaturePopover();
-		} else {
-			this.showFeaturePopover( el, popoverDescription );
-		}
 	}
 
 	renderPlanFeatureColumns( rowIndex ) {
@@ -576,4 +513,3 @@ export default connect(
 		recordTracksEvent
 	}
 )( localize( PlanFeatures ) );
-

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -7,40 +7,24 @@ import React from 'react';
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
+import InfoPopover from 'components/info-popover';
+import viewport from 'lib/viewport';
 
 export default function PlanFeaturesItem( {
 	children,
-	description,
-	onMouseEnter,
-	onMouseLeave,
-	onTouchStart,
+	description
 } ) {
-	const handleOnTouchStart = ( event ) => {
-		onTouchStart( event.currentTarget, description );
-	};
-
-	const handleOnMouseEvent = ( event ) => {
-		onMouseEnter( event.currentTarget, description );
-	};
-
-	const handleOnMouseLeave = ( event ) => {
-		onMouseLeave( event.currentTarget, description );
-	};
-
 	return (
 		<div className="plan-features__item">
 			<Gridicon
 				className="plan-features__item-checkmark"
 				size={ 18 } icon="checkmark" />
 			{ children }
-			<span
-				onMouseEnter={ handleOnMouseEvent }
-				onMouseLeave={ handleOnMouseLeave }
-				onTouchStart={ handleOnTouchStart }
+			<InfoPopover
 				className="plan-features__item-tip-info"
-			>
-				<Gridicon icon="info-outline" size={ 18 } />
-			</span>
+				position={ viewport.isMobile() ? 'top' : 'right' }>
+				{ description }
+			</InfoPopover>
 		</div>
 	);
 }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -351,42 +351,33 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__item {
-	position: relative;
+	display: flex;
+	flex: none;
 	margin: 0 24px;
-	padding: 12px 20px 12px 30px;
+	padding: 12px 0;
 	font-size: 14px;
 	color: $gray-dark;
-
-	@include breakpoint( "<1040px" ) {
-		margin: 0 12px;
-	}
 
 	@include breakpoint( "<960px" ) {
 		font-size: 12px;
 	}
+
+	@include breakpoint( "<1040px" ) {
+		margin: 0 12px;
+	}
+}
+
+.plan-features__item-title {
+	flex: 1 0 0;
+	margin-left: 10px;
 }
 
 .plan-features__item-checkmark {
-	position: absolute;
-	left: 0;
-	top: 14px;
 	fill: $blue-wordpress;
 }
 
 .plan-features__item-tip-info {
-	position: absolute;
-	right: 0;
-	top: 14px;
-	width: 18px;
-	height: 18px;
-	margin-top: 0px;
-	color: lighten( $gray, 20% );
-	cursor: pointer;
-
-	&:hover,
-	&:focus {
-		color: $gray-dark;
-	}
+	align-self: center;
 }
 
 .popover__plan-features {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -352,7 +352,6 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__item {
 	display: flex;
-	flex: none;
 	margin: 0 24px;
 	padding: 12px 0;
 	font-size: 14px;
@@ -370,13 +369,16 @@ $plan-features-sidebar-width: 272px;
 .plan-features__item-title {
 	flex: 1 0 0;
 	margin-left: 10px;
+	width: 100%;
 }
 
 .plan-features__item-checkmark {
+	flex: 0 1 auto;
 	fill: $blue-wordpress;
 }
 
 .plan-features__item-tip-info {
+	flex: 0 1 auto;
 	align-self: center;
 }
 


### PR DESCRIPTION
Removes the custom popover from the Plans page in favor of the `<InfoPopover />` component. These changes affect both the NUX and the Plans page.

Fixes #8688 

cc: @roundhill @rralian 
