### PR TITLE
Pages: record Tracks and bump stat on homepage change

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -15,6 +15,10 @@ import {
 	SITES_REQUEST_SUCCESS,
 	SITES_REQUEST_FAILURE
 } from 'state/action-types';
+import {
+	bumpStat,
+	recordTracksEvent,
+} from 'state/analytics/actions';
 import { omit } from 'lodash';
 
 /**
@@ -112,12 +116,18 @@ export function setFrontPage( siteId, pageId ) {
 		};
 
 		return wpcom.undocumented().setSiteHomepageSettings( siteId, requestData ).then( () => {
+			dispatch( recordTracksEvent( 'calypso_front_page_set', {
+				siteId,
+				pageId,
+			} ) );
+			dispatch( bumpStat( 'calypso_front_page_set', 'success' ) );
 			dispatch( {
 				type: SITE_FRONT_PAGE_SET_SUCCESS,
 				siteId,
 				pageId
 			} );
 		} ).catch( ( error ) => {
+			dispatch( bumpStat( 'calypso_front_page_set', 'failure' ) );
 			dispatch( {
 				type: SITE_FRONT_PAGE_SET_FAILURE,
 				siteId,


### PR DESCRIPTION
This pull request records Tracks events and bumps a stat after setting the homepage for a site from Calypso Pages. It is part of a larger epic and is behind a feature flag, `manage/pages/set-homepage`, that is only enabled in `development`.

<img width="719" alt="screencapture at wed oct 12 12 52 45 edt 2016" src="https://cloud.githubusercontent.com/assets/2098816/19319593/8231fbac-907b-11e6-8749-6566731ca1e2.png">


To test:
* Checkout branch and `make run`.
* Visit http://calypso.localhost:3000/pages/ and select a site using the site-selector.
* In your console, set debug: `localStorage.setItem( 'debug', 'calypso:analytics' )`.
* Using the ellipsis next to one of your pages, set it as the homepage.
* Verify the debug statements exist in the console for bumping the stats and the Tracks event. They should look like this: 
![image](https://cloud.githubusercontent.com/assets/363749/19368533/07bc7906-9166-11e6-8e59-109e082768b4.png)
