### PR TITLE
Reader post card: use stateless functional component for docs

### DIFF
--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -43,13 +43,13 @@ const searchItems = [
 const RefreshCards = () => (
 	<div className="design-assets__group">
 		<div>
-			{ searchItems.map( item =>
+			{ searchItems.map( item => (
 				<RefreshPostCard
 					key={ item.post.global_ID }
 					post={ item.post }
 					site={ item.site }
 				/>
-			) }
+			) ) }
 		</div>
 	</div>
 );

--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -41,18 +41,13 @@ const searchItems = [
 	}
 ];
 
-const RefreshCards = React.createClass( {
-	displayName: 'RefreshCard',
+const RefreshCards = () => (
+	<div className="design-assets__group">
+		<div>
+			{ searchItems.map( item => <RefreshPostCard key={ item.post.global_ID } post={ item.post } site={ item.site } /> ) }
+		</div>
+	</div>
+);
 
-	render: function() {
-		return (
-			<div className="design-assets__group">
-				<div>
-					{ searchItems.map( item => <RefreshPostCard key={ item.post.global_ID } post={ item.post } site={ item.site } /> ) }
-				</div>
-			</div>
-		);
-	}
-} );
+export default RefreshCards;
 
-module.exports = RefreshCards;

--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -7,7 +7,6 @@ import React from 'react';
  * Internal dependencies
  */
 import RefreshPostCard from 'blocks/reader-post-card';
-import DisplayTypes from 'state/reader/posts/display-types';
 
 const searchItems = [
 	{
@@ -44,7 +43,13 @@ const searchItems = [
 const RefreshCards = () => (
 	<div className="design-assets__group">
 		<div>
-			{ searchItems.map( item => <RefreshPostCard key={ item.post.global_ID } post={ item.post } site={ item.site } /> ) }
+			{ searchItems.map( item =>
+				<RefreshPostCard
+					key={ item.post.global_ID }
+					post={ item.post }
+					site={ item.site }
+				/>
+			) }
 		</div>
 	</div>
 );


### PR DESCRIPTION
As per https://github.com/Automattic/wp-calypso/pull/8463#discussion_r83154183, use a stateless functional component rather than `React.createClass` for the Reader post card example in devdocs.

cc @dmsnell @lamosty @SpenUK

### To test

Visit http://calypso.localhost:3000/devdocs/blocks and ensure 'RefreshCards' section is present.

<img width="650" alt="screen shot 2016-10-14 at 17 27 10" src="https://cloud.githubusercontent.com/assets/17325/19375743/cba0cab6-9233-11e6-81b7-2b057cb2ef75.png">

Note: action buttons may still look a bit wonky, as per screenshot. Will be fixed when https://github.com/Automattic/wp-calypso/pull/8662 lands.