### PR TITLE
Revert Fix/plans screaming case revert

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -14,7 +14,8 @@ import DismissibleCard from 'blocks/dismissible-card';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isCurrentSitePlan } from 'state/sites/selectors';
-import { plansList, PLAN_FREE, PLAN_PERSONAL } from 'lib/plans/constants';
+import { PLAN_FREE, PLAN_PERSONAL } from 'lib/plans/constants';
+import { getPlan } from 'lib/plans';
 import PlanPrice from 'my-sites/plan-price';
 import PlanIcon from 'components/plans/plan-icon';
 import Gridicon from 'components/gridicon';
@@ -209,7 +210,7 @@ export default connect(
 	( state, props ) => {
 		const siteId = props.siteId || getSelectedSiteId( state ),
 			productSlug = PLAN_PERSONAL,
-			productId = plansList[ PLAN_PERSONAL ].getProductId();
+			productId = getPlan( PLAN_PERSONAL ).getProductId();
 
 		return {
 			canManage: canCurrentUser( state, siteId, 'manage_options' ),
@@ -217,7 +218,7 @@ export default connect(
 			hasFreePlan: isCurrentSitePlan(
 				state,
 				siteId,
-				plansList[ PLAN_FREE ].getProductId()
+				getPlan( PLAN_FREE ).getProductId()
 			),
 			productId,
 			productSlug,

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -14,7 +14,7 @@ import { getRawSite } from 'state/sites/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { plansList } from 'lib/plans/constants';
+import { getPlan } from 'lib/plans';
 import formatCurrency from 'lib/format-currency';
 
 class PlanThankYouCard extends Component {
@@ -45,7 +45,7 @@ class PlanThankYouCard extends Component {
 						: <div>
 								<div className="plan-thank-you-card__plan-name">
 								{ translate( '%(planName)s Plan', {
-									args: { planName: plansList[ plan.productSlug ].getTitle() }
+									args: { planName: getPlan( plan.productSlug ).getTitle() }
 								} ) }
 								</div>
 								<div className="plan-thank-you-card__plan-price">

--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -18,9 +18,9 @@ import PlanCompareCardItem from 'my-sites/plan-compare-card/item';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import formatCurrency from 'lib/format-currency';
 import { preventWidows } from 'lib/formatting';
-import { getFeatureTitle } from 'lib/plans';
+import { getFeatureTitle, getPlan } from 'lib/plans';
 import { getPlanBySlug } from 'state/plans/selectors';
-import { PLAN_PERSONAL, plansList } from 'lib/plans/constants';
+import { PLAN_PERSONAL } from 'lib/plans/constants';
 import { getSitePlan } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -137,7 +137,7 @@ UpgradeNudgeExpanded.propTypes = {
 const mapStateToProps = ( state, { plan = PLAN_PERSONAL } ) => ( {
 	plan: getPlanBySlug( state, plan ),
 	currentPlan: getSitePlan( state, getSelectedSiteId( state ) ),
-	planConstants: plansList[ plan ],
+	planConstants: getPlan( plan ),
 	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
 } );
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -310,8 +310,7 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			'Track website statistics with Google Analytics for a ' +
 			'deeper understanding of your website visitors and customers.'
-		),
-		//plans: [ PLAN_BUSINESS ]
+		)
 	},
 
 	[ FEATURE_UNLIMITED_STORAGE ]: {
@@ -325,8 +324,7 @@ export const FEATURES_LIST = {
 			"With increased storage space you'll be able to upload " +
 			'more images, videos, audio, and documents to your website.'
 		),
-		getStoreSlug: () => 'unlimited_space',
-		plans: [ PLAN_BUSINESS ]
+		getStoreSlug: () => 'unlimited_space'
 	},
 
 	[ FEATURE_CUSTOM_DOMAIN ]: {
@@ -335,8 +333,7 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			'Get a free custom domain name (example.com) with this plan ' +
 			'to use for your website.'
-		),
-		plans: ALL_WPCOM_PAID_PLANS
+		)
 	},
 
 	[ FEATURE_JETPACK_ESSENTIAL ]: {
@@ -360,8 +357,7 @@ export const FEATURES_LIST = {
 			'Unlimited access to all of our advanced premium theme templates, ' +
 			'including templates specifically tailored for businesses.'
 		),
-		getStoreSlug: () => 'unlimited_themes',
-		plans: [ PLAN_BUSINESS ]
+		getStoreSlug: () => 'unlimited_themes'
 	},
 
 	[ FEATURE_VIDEO_UPLOADS ]: {
@@ -371,8 +367,7 @@ export const FEATURES_LIST = {
 			'The easiest way to upload videos to your website and display them ' +
 			'using a fast, unbranded, customizable player with rich stats.'
 		),
-		getStoreSlug: () => 'videopress',
-		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ]
+		getStoreSlug: () => 'videopress'
 	},
 
 	[ FEATURE_AUDIO_UPLOADS ]: {
@@ -381,8 +376,7 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			'The easiest way to upload audio files that use any major audio file format. '
 		),
-		getStoreSlug: () => 'videopress',
-		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ]
+		getStoreSlug: () => 'videopress'
 	},
 
 	[ FEATURE_BASIC_DESIGN ]: {
@@ -392,8 +386,7 @@ export const FEATURES_LIST = {
 			'Customize your selected theme template with pre-set color schemes, ' +
 			'background designs, and font styles.'
 		),
-		getStoreSlug: () => FEATURE_ADVANCED_DESIGN,
-		plans: [ PLAN_FREE, PLAN_PERSONAL ]
+		getStoreSlug: () => FEATURE_ADVANCED_DESIGN
 	},
 
 	[ FEATURE_ADVANCED_DESIGN ]: {
@@ -407,8 +400,7 @@ export const FEATURES_LIST = {
 			'Customize your selected theme template with extended color schemes, ' +
 			'background designs, and complete control over website CSS.'
 		),
-		getStoreSlug: () => FEATURE_ADVANCED_DESIGN,
-		plans: ALL_WPCOM_PAID_PLANS
+		getStoreSlug: () => FEATURE_ADVANCED_DESIGN
 	},
 
 	[ FEATURE_NO_ADS ]: {
@@ -418,8 +410,7 @@ export const FEATURES_LIST = {
 			'Allow your visitors to visit and read your website without ' +
 			'seeing any WordPress.com advertising.'
 		),
-		getStoreSlug: () => 'no-adverts/no-adverts.php',
-		plans: ALL_WPCOM_PAID_PLANS
+		getStoreSlug: () => 'no-adverts/no-adverts.php'
 	},
 
 	[ FEATURE_NO_BRANDING ]: {
@@ -428,8 +419,7 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			"Keep the focus on your site's brand by removing the WordPress.com footer branding."
 		),
-		getStoreSlug: () => 'no-adverts/no-adverts.php',
-		plans: [ PLAN_BUSINESS ]
+		getStoreSlug: () => 'no-adverts/no-adverts.php'
 	},
 
 	[ FEATURE_LIVE_COURSES ]: {
@@ -437,8 +427,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Attend live courses' ),
 		getDescription: () => i18n.translate(
 			'Attend live courses led by Happiness Engineers to get the most out of your site.'
-		),
-		plans: [ PLAN_BUSINESS ]
+		)
 	},
 
 	[ FEATURE_ADVANCED_SEO ]: {
@@ -450,8 +439,7 @@ export const FEATURES_LIST = {
 		} ),
 		getDescription: () => i18n.translate(
 			'Adds tools to enhance your site\'s content for better results on search engines and social media.'
-		),
-		plans: [ PLAN_BUSINESS ]
+		)
 	},
 
 	[ FEATURE_WORDADS_INSTANT ]: {
@@ -459,8 +447,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Monetize Your Site' ),
 		getDescription: () => i18n.translate(
 			'Add advertising to your site through our WordAds program and earn money from impressions.'
-		),
-		plans: [ PLAN_PREMIUM, PLAN_BUSINESS ]
+		)
 	},
 
 	[ FEATURE_WP_SUBDOMAIN ]: {
@@ -468,8 +455,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'WordPress.com Subdomain' ),
 		getDescription: () => i18n.translate(
 			'Your site address will use a WordPress.com subdomain (sitename.wordpress.com).'
-		),
-		plans: [ PLAN_FREE ]
+		)
 	},
 
 	[ FEATURE_FREE_THEMES ]: {
@@ -478,8 +464,7 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			'Access to a wide range of professional theme templates ' +
 			"for your website so you can find the exact design you're looking for."
-		),
-		plans: [ PLAN_FREE, PLAN_PREMIUM ]
+		)
 	},
 
 	[ FEATURE_3GB_STORAGE ]: {
@@ -487,8 +472,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( '3GB Storage Space' ),
 		getDescription: () => i18n.translate(
 			"Storage space for adding images and documents to your website."
-		),
-		plans: [ PLAN_FREE, PLAN_PERSONAL ]
+		)
 	},
 
 	[ FEATURE_13GB_STORAGE ]: {
@@ -501,8 +485,7 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			"With increased storage space you'll be able to upload " +
 			'more images, videos, audio, and documents to your website.'
-		),
-		plans: [ PLAN_PREMIUM ]
+		)
 	},
 
 	[ FEATURE_COMMUNITY_SUPPORT ]: {
@@ -511,8 +494,7 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			'Get support through our ' +
 			'user community forums.'
-		),
-		plans: [ PLAN_FREE ]
+		)
 	},
 
 	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT ]: {
@@ -521,8 +503,7 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			'High quality support to help you get your website up ' +
 			'and running and working how you want it.'
-		),
-		plans: ALL_WPCOM_PAID_PLANS
+		)
 	},
 	[ FEATURE_STANDARD_SECURITY_TOOLS ]: {
 		getSlug: () => FEATURE_STANDARD_SECURITY_TOOLS,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -302,7 +302,7 @@ export const ALL_WPCOM_PAID_PLANS = [
 	PLAN_BUSINESS
 ];
 
-export const featuresList = {
+export const FEATURES_LIST = {
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
 		getSlug: () => FEATURE_GOOGLE_ANALYTICS,
 		getTitle: () => i18n.translate( 'Google Analytics Integration' ),
@@ -637,7 +637,7 @@ export const getPlanObject = planName => {
 
 export const getPlanFeaturesObject = planFeaturesList => {
 	return planFeaturesList.map( featuresConst =>
-		featuresList[ featuresConst ]
+		FEATURES_LIST[ featuresConst ]
 	);
 };
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -297,12 +297,6 @@ export const PLANS_LIST = {
 	}
 };
 
-export const ALL_WPCOM_PAID_PLANS = [
-	PLAN_PERSONAL,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS
-];
-
 export const FEATURES_LIST = {
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
 		getSlug: () => FEATURE_GOOGLE_ANALYTICS,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -302,13 +302,6 @@ export const allPaidPlans = [
 	PLAN_BUSINESS
 ];
 
-export const allWpcomPlans = [
-	PLAN_FREE,
-	PLAN_PERSONAL,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS
-];
-
 export const featuresList = {
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
 		getSlug: () => FEATURE_GOOGLE_ANALYTICS,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -74,7 +74,7 @@ export const FEATURE_ONE_CLICK_THREAT_RESOLUTION = 'one-click-threat-resolution'
 export const FEATURE_POLLS_PRO = 'polls-pro';
 
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
-export const plansList = {
+export const PLANS_LIST = {
 	[ PLAN_FREE ]: {
 		getTitle: () => i18n.translate( 'Free' ),
 		getPriceTitle: () => i18n.translate( 'Free for life' ), //TODO: DO NOT USE
@@ -626,7 +626,7 @@ export const FEATURES_LIST = {
 };
 
 export const getPlanObject = planName => {
-	const plan = plansList[ planName ];
+	const plan = PLANS_LIST[ planName ];
 	const objectPlan = {};
 	Object.keys( plan ).forEach( key => {
 		const objectKey = key.substr( 3 ).charAt( 0 ).toLowerCase() + key.slice( 4 );

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -296,7 +296,7 @@ export const plansList = {
 	}
 };
 
-export const allPaidPlans = [
+export const ALL_WPCOM_PAID_PLANS = [
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS
@@ -335,7 +335,7 @@ export const featuresList = {
 			'Get a free custom domain name (example.com) with this plan ' +
 			'to use for your website.'
 		),
-		plans: allPaidPlans
+		plans: ALL_WPCOM_PAID_PLANS
 	},
 
 	[ FEATURE_JETPACK_ESSENTIAL ]: {
@@ -407,7 +407,7 @@ export const featuresList = {
 			'background designs, and complete control over website CSS.'
 		),
 		getStoreSlug: () => FEATURE_ADVANCED_DESIGN,
-		plans: allPaidPlans
+		plans: ALL_WPCOM_PAID_PLANS
 	},
 
 	[ FEATURE_NO_ADS ]: {
@@ -418,7 +418,7 @@ export const featuresList = {
 			'seeing any WordPress.com advertising.'
 		),
 		getStoreSlug: () => 'no-adverts/no-adverts.php',
-		plans: allPaidPlans
+		plans: ALL_WPCOM_PAID_PLANS
 	},
 
 	[ FEATURE_NO_BRANDING ]: {
@@ -521,7 +521,7 @@ export const featuresList = {
 			'High quality support to help you get your website up ' +
 			'and running and working how you want it.'
 		),
-		plans: allPaidPlans
+		plans: ALL_WPCOM_PAID_PLANS
 	},
 	[ FEATURE_STANDARD_SECURITY_TOOLS ]: {
 		getSlug: () => FEATURE_STANDARD_SECURITY_TOOLS,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -73,6 +73,7 @@ export const FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND = 'malware-scanning-da
 export const FEATURE_ONE_CLICK_THREAT_RESOLUTION = 'one-click-threat-resolution';
 export const FEATURE_POLLS_PRO = 'polls-pro';
 
+// DO NOT import. Use `getPlan` from `lib/plans` instead.
 export const plansList = {
 	[ PLAN_FREE ]: {
 		getTitle: () => i18n.translate( 'Free' ),

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -336,8 +336,7 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			'Jetpack is a powerful plugin that includes SEO, spam protection, ' +
 			'social sharing, site stats, and more.'
-		),
-		plans: allPaidPlans
+		)
 	},
 
 	[ FEATURE_UNLIMITED_PREMIUM_THEMES ]: {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -75,7 +75,7 @@ export function getSitePlanSlug( siteID ) {
 
 export function canUpgradeToPlan( planKey, site = sitesList.getSelectedSite() ) {
 	const plan = get( site, [ 'plan', 'expired' ], false ) ? PLAN_FREE : get( site, [ 'plan', 'product_slug' ], PLAN_FREE );
-	return get( PLANS_LIST, [ planKey, 'availableFor' ], () => false )( plan );
+	return get( getPlan( planKey ), 'availableFor', () => false )( plan );
 }
 
 export function getUpgradePlanSlugFromPath( path, siteID ) {
@@ -87,11 +87,11 @@ export function getUpgradePlanSlugFromPath( path, siteID ) {
 }
 
 export function getPlanPath( plan ) {
-	return get( PLANS_LIST, [ plan, 'getPathSlug' ], () => undefined )();
+	return get( getPlan( plan ), 'getPathSlug', () => undefined )();
 }
 
 export function planHasFeature( plan, feature ) {
-	return includes( get( PLANS_LIST, [ plan, 'getFeatures' ], () => [] )(), feature );
+	return includes( get( getPlan( plan ), 'getFeatures', () => [] )(), feature );
 }
 
 export function hasFeature( feature, siteID ) {
@@ -205,8 +205,8 @@ export function plansLink( url, site, intervalType ) {
 }
 
 export function applyTestFiltersToPlansList( planName ) {
-	const filteredPlanConstantObj = { ...PLANS_LIST[ planName ] };
-	const filteredPlanFeaturesConstantList = PLANS_LIST[ planName ].getFeatures();
+	const filteredPlanConstantObj = { ...getPlan( planName ) };
+	const filteredPlanFeaturesConstantList = getPlan( planName ).getFeatures();
 
 	// these becomes no-ops when we removed some of the abtest overrides, but
 	// we're leaving the code in place for future tests

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -24,7 +24,7 @@ import {
 } from 'lib/products-values';
 import {
 	FEATURES_LIST,
-	plansList,
+	PLANS_LIST,
 	PLAN_FREE,
 	PLAN_JETPACK_FREE,
 	PLAN_PERSONAL
@@ -44,7 +44,7 @@ export function isFreePlan( plan ) {
 }
 
 export function getPlan( plan ) {
-	return plansList[ plan ];
+	return PLANS_LIST[ plan ];
 }
 
 export function getValidFeatureKeys() {
@@ -75,19 +75,19 @@ export function getSitePlanSlug( siteID ) {
 
 export function canUpgradeToPlan( planKey, site = sitesList.getSelectedSite() ) {
 	const plan = get( site, [ 'plan', 'expired' ], false ) ? PLAN_FREE : get( site, [ 'plan', 'product_slug' ], PLAN_FREE );
-	return get( plansList, [ planKey, 'availableFor' ], () => false )( plan );
+	return get( PLANS_LIST, [ planKey, 'availableFor' ], () => false )( plan );
 }
 
 export function getUpgradePlanSlugFromPath( path, siteID ) {
 	const site = siteID ? sitesList.getSite( siteID ) : sitesList.getSelectedSite();
-	return find( Object.keys( plansList ), planKey => (
+	return find( Object.keys( PLANS_LIST ), planKey => (
 		( planKey === path || getPlanPath( planKey ) === path ) &&
 		canUpgradeToPlan( planKey, site )
 	) );
 }
 
 export function getPlanPath( plan ) {
-	return get( plansList, [ plan, 'getPathSlug' ], () => undefined )();
+	return get( PLANS_LIST, [ plan, 'getPathSlug' ], () => undefined )();
 }
 
 export function planHasFeature( plan, feature ) {
@@ -205,8 +205,8 @@ export function plansLink( url, site, intervalType ) {
 }
 
 export function applyTestFiltersToPlansList( planName ) {
-	const filteredPlanConstantObj = { ...plansList[ planName ] };
-	const filteredPlanFeaturesConstantList = plansList[ planName ].getFeatures();
+	const filteredPlanConstantObj = { ...PLANS_LIST[ planName ] };
+	const filteredPlanFeaturesConstantList = PLANS_LIST[ planName ].getFeatures();
 
 	// these becomes no-ops when we removed some of the abtest overrides, but
 	// we're leaving the code in place for future tests

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -91,7 +91,7 @@ export function getPlanPath( plan ) {
 }
 
 export function planHasFeature( plan, feature ) {
-	return includes( get( PLANS_LIST, [ plan, 'getFeatures' ], () => [] ), feature );
+	return includes( get( PLANS_LIST, [ plan, 'getFeatures' ], () => [] )(), feature );
 }
 
 export function hasFeature( feature, siteID ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -23,10 +23,10 @@ import {
 	isMonthly
 } from 'lib/products-values';
 import {
-	featuresList,
+	FEATURES_LIST,
 	plansList,
 	PLAN_FREE,
-	PLAN_JETPACK_FREE, 
+	PLAN_JETPACK_FREE,
 	PLAN_PERSONAL
 } from 'lib/plans/constants';
 import { createSitePlanObject } from 'state/sites/plans/assembler';
@@ -48,19 +48,19 @@ export function getPlan( plan ) {
 }
 
 export function getValidFeatureKeys() {
-	return Object.keys( featuresList );
+	return Object.keys( FEATURES_LIST );
 }
 
 export function isValidFeatureKey( feature ) {
-	return !! featuresList[ feature ];
+	return !! FEATURES_LIST[ feature ];
 }
 
 export function getFeatureByKey( feature ) {
-	return featuresList[ feature ];
+	return FEATURES_LIST[ feature ];
 }
 
 export function getFeatureTitle( feature ) {
-	return invoke( featuresList, [ feature, 'getTitle' ] );
+	return invoke( FEATURES_LIST, [ feature, 'getTitle' ] );
 }
 
 export function getSitePlanSlug( siteID ) {
@@ -91,7 +91,7 @@ export function getPlanPath( plan ) {
 }
 
 export function planHasFeature( plan, feature ) {
-	return includes( get( featuresList, [ feature, 'plans' ] ), plan );
+	return includes( get( FEATURES_LIST, [ feature, 'plans' ] ), plan );
 }
 
 export function hasFeature( feature, siteID ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -91,7 +91,7 @@ export function getPlanPath( plan ) {
 }
 
 export function planHasFeature( plan, feature ) {
-	return includes( get( FEATURES_LIST, [ feature, 'plans' ] ), plan );
+	return includes( get( PLANS_LIST, [ plan, 'getFeatures' ], () => [] ), feature );
 }
 
 export function hasFeature( feature, siteID ) {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -22,7 +22,8 @@ import ProductPurchaseFeaturesList from 'blocks/product-purchase-features/produc
 import CurrentPlanHeader from './header';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { plansList, PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { getPlan } from 'lib/plans';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
@@ -44,7 +45,7 @@ class CurrentPlan extends Component {
 	getHeaderWording( plan ) {
 		const { translate } = this.props;
 
-		const planConstObj = plansList[ plan ],
+		const planConstObj = getPlan( plan ),
 			title = translate( 'Your site is on a %(planName)s plan', {
 				args: {
 					planName: planConstObj.getTitle()


### PR DESCRIPTION
This is a second attempt at #8409 reverted in #8722 because it destroyed staging
Read the story in: p4TIVU-4NN-p2
Fix in 22d1aa2078e0a9c651bcd65bb4198dc1dfdbe977

## Original Description 

Resolves #7502

- Refactors  plansList to PLANS_LIST; featuresList to FEATURES_LIST
- Removes allPaidPlans and allWpcomPlans entirely
- changes plan/feature detection to be solely contained within plan object, not scattered all over
- Uses getPlan getter whenever applicable instead of using planFeatures[ feature ]

No functional changes

## Testing
- Make sure /plans work properly
- Make sure that NUX works properly
- make sure nudges appear properly
-- nudge in /design/:site all < premium
-- nudge in settings/analytics/:site for all < business
-- nudge in stats/insights/:site for all < personal

CC @lamosty @gwwar 