### PR TITLE
Components: Add tests for Button component

### DIFF
--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../';
+import Gridicon from 'components/gridicon';
+
+describe( 'Button', () => {
+	describe( 'renders', () => {
+		it( 'with modifiers', () => {
+			const button = shallow( <Button scary primary borderless compact /> );
+			expect( button ).to.have.className( 'is-compact' );
+			expect( button ).to.have.className( 'is-primary' );
+			expect( button ).to.have.className( 'is-scary' );
+			expect( button ).to.have.className( 'is-borderless' );
+		} );
+
+		it( 'without modifiers', () => {
+			const button = shallow( <Button /> );
+			expect( button ).to.have.className( 'button' );
+			expect( button ).to.not.have.className( 'is-compact' );
+			expect( button ).to.not.have.className( 'is-primary' );
+			expect( button ).to.not.have.className( 'is-scary' );
+			expect( button ).to.not.have.className( 'is-borderless' );
+		} );
+
+		it( 'disabled', () => {
+			const button = shallow( <Button disabled /> );
+			expect( button ).to.be.disabled;
+		} );
+
+		it( 'with child', () => {
+			const iconType = 'arrow-left';
+			const icon = <Gridicon size={ 18 } icon={ iconType } />;
+			const button = shallow( <Button>{ icon }</Button> );
+			expect( button ).to.contain( icon );
+			expect( button.find( Gridicon ) ).to.have.prop( 'icon' ).equal( iconType );
+		} );
+	} );
+
+	describe( 'link', () => {
+		const blank = '_blank';
+		const relString = 'noopener noreferrer';
+
+		describe( '< a > element', () => {
+			const address = 'https://wordpress.com/';
+			const button = shallow( <Button href={ address } target={ blank } rel={ relString } type='submit' /> );
+
+			it( 'is rendered', () => {
+				expect( button ).to.match( 'a' );
+			} );
+
+			it( 'omits type property', () => {
+				expect( button ).to.not.have.prop( 'type' );
+			} );
+
+			it( 'has href, target and rel property', () => {
+				expect( button ).to.have.prop( 'href' ).equal( address );
+				expect( button ).to.have.prop( 'target' ).equal( blank );
+				expect( button ).to.have.prop( 'rel' ).equal( relString );
+			} );
+		} );
+
+		describe( '< button > element', () => {
+			const button = shallow( <Button target={ blank } rel={ relString } /> );
+
+			it( 'is rendered', () => {
+				expect( button ).to.match( 'button' );
+			} );
+
+			it( 'renders with `type` prop assigned to `button` by default', () => {
+				expect( button ).to.have.prop( 'type' ).equal( 'button' );
+			} );
+
+			it( '`type` prop changes when overridden', () => {
+				const typeProp = 'submit';
+				const submitButton = shallow( <Button target={ blank } rel={ relString } type={ typeProp } /> );
+
+				expect( submitButton ).to.have.prop( 'type' ).equal( typeProp );
+			} );
+
+			it( 'omits rel and target property', () => {
+				expect( button ).to.not.have.prop( 'target' );
+				expect( button ).to.not.have.prop( 'rel' );
+			} );
+
+			it( 'has not href property', () => {
+				expect( button ).to.not.have.prop( 'href' );
+			} );
+		} );
+	} );
+} );

--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -12,6 +12,9 @@ import Button from '../';
 import Gridicon from 'components/gridicon';
 
 describe( 'Button', () => {
+	const blank = '_blank';
+	const relString = 'noopener noreferrer';
+
 	describe( 'renders', () => {
 		it( 'with modifiers', () => {
 			const button = shallow( <Button scary primary borderless compact /> );
@@ -44,55 +47,47 @@ describe( 'Button', () => {
 		} );
 	} );
 
-	describe( 'link', () => {
-		const blank = '_blank';
-		const relString = 'noopener noreferrer';
+	describe( 'with href prop', () => {
+		const address = 'https://wordpress.com/';
+		const button = shallow( <Button href={ address } target={ blank } rel={ relString } type="submit" /> );
 
-		describe( '< a > element', () => {
-			const address = 'https://wordpress.com/';
-			const button = shallow( <Button href={ address } target={ blank } rel={ relString } type='submit' /> );
-
-			it( 'is rendered', () => {
-				expect( button ).to.match( 'a' );
-			} );
-
-			it( 'omits type property', () => {
-				expect( button ).to.not.have.prop( 'type' );
-			} );
-
-			it( 'has href, target and rel property', () => {
-				expect( button ).to.have.prop( 'href' ).equal( address );
-				expect( button ).to.have.prop( 'target' ).equal( blank );
-				expect( button ).to.have.prop( 'rel' ).equal( relString );
-			} );
+		it( 'renders as a link', () => {
+			expect( button ).to.match( 'a' );
 		} );
 
-		describe( '< button > element', () => {
-			const button = shallow( <Button target={ blank } rel={ relString } /> );
+		it( 'ignores type prop and renders a link without type attribute', () => {
+			expect( button ).to.not.have.prop( 'type' );
+		} );
 
-			it( 'is rendered', () => {
-				expect( button ).to.match( 'button' );
-			} );
+		it( 'including target and rel props renders a link with target and rel attributes', () => {
+			expect( button ).to.have.prop( 'href' ).equal( address );
+			expect( button ).to.have.prop( 'target' ).equal( blank );
+			expect( button ).to.have.prop( 'rel' ).equal( relString );
+		} );
+	} );
 
-			it( 'renders with `type` prop assigned to `button` by default', () => {
-				expect( button ).to.have.prop( 'type' ).equal( 'button' );
-			} );
+	describe( 'without href prop', () => {
+		const button = shallow( <Button target={ blank } rel={ relString } /> );
 
-			it( '`type` prop changes when overridden', () => {
-				const typeProp = 'submit';
-				const submitButton = shallow( <Button target={ blank } rel={ relString } type={ typeProp } /> );
+		it( 'renders as a button', () => {
+			expect( button ).to.match( 'button' );
+			expect( button ).to.not.have.prop( 'href' );
+		} );
 
-				expect( submitButton ).to.have.prop( 'type' ).equal( typeProp );
-			} );
+		it( 'renders button with type attribute set to "button" by default', () => {
+			expect( button ).to.have.prop( 'type' ).equal( 'button' );
+		} );
 
-			it( 'omits rel and target property', () => {
-				expect( button ).to.not.have.prop( 'target' );
-				expect( button ).to.not.have.prop( 'rel' );
-			} );
+		it( 'renders button with type attribute set to type prop if specified', () => {
+			const typeProp = 'submit';
+			const submitButton = shallow( <Button target={ blank } rel={ relString } type={ typeProp } /> );
 
-			it( 'has not href property', () => {
-				expect( button ).to.not.have.prop( 'href' );
-			} );
+			expect( submitButton ).to.have.prop( 'type' ).equal( typeProp );
+		} );
+
+		it( 'renders button without rel and target attributes', () => {
+			expect( button ).to.not.have.prop( 'target' );
+			expect( button ).to.not.have.prop( 'rel' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Hi, I would like to solve #7936 and write tests for `<Button/>` component. 

We need to simulate the rendering of the component and then test every possible variation of  `Button`'s styles.

Firstly, I was not sure, whether to use shallow rendering, mount or full DOM rendering. Then I realized, that shallow rendering is needed only when I don't want to render children and test their styles or behavior. 
So in my PR I use `shallow` when passing a text to the `Button` as a child. And `mount`, when I need to test, whether the child - `Gridicon` component has expected className.

I was also thinking about all possible variations of `Button`s and I found them in <a href="https://wpcalypso.wordpress.com/devdocs/design">DevDocs</a>. 
<img width="1280" alt="screen shot 2016-10-14 at 14 41 24" src="https://cloud.githubusercontent.com/assets/14272775/19387718/4d81a9be-921c-11e6-960b-7fd52f81085f.png">

Of course, I also need to test the button with `href` prop and `compact` prop set to true. But before I add other tests, I wanted to ask,
Is this good way testing it?

@aduth 
