### PR TITLE
Jetpack Plugins: Improve styling for blockquote in plugin content

### DIFF
--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -42,6 +42,14 @@
 	a {
 		word-break: break-all;
 	}
+	blockquote {
+		padding: 10px;
+		margin-bottom: 16px;
+
+		p:last-child {
+			margin-bottom: 0;
+		}
+	}
 }
 
 .plugin-sections__read-more {


### PR DESCRIPTION
This PR improves the style of `blockquote` within the content of a plugin.

### Before:
![](https://cldup.com/yHpHjY-8xK.png)

### After:
![](https://cldup.com/phoX26vwNt.png)

### To test:

1. Checkout this branch.
2. Install the `google-sitemap-generator` plugin on one of your Jetpack sites.
3. Go to `/plugins/google-sitemap-generator/$site` where `$site` is your Jetpack site.
4. Verify the `blockquote` in the Description tab looks like the "After" screenshot.

/cc @rickybanister @folletto @keoshi 

