### PR TITLE
Jetpack Plugins: Open links in plugin content in a new window

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -165,11 +165,21 @@ PluginUtils = {
 					for ( let sectionKey of Object.keys( item ) ) {
 						cleanItem[ sectionKey] = sanitizeHtml( item[ sectionKey ], {
 							allowedTags: [ 'h4', 'h5', 'h6', 'blockquote', 'code', 'b', 'i', 'em', 'strong', 'a', 'p', 'img', 'ul', 'ol', 'li' ],
-							allowedAttributes: { a: [ 'href' ], img: [ 'src' ] },
+							allowedAttributes: { a: [ 'href', 'target', 'rel' ], img: [ 'src' ] },
 							allowedSchemes: [ 'http', 'https' ],
 							transformTags: {
 								h1: 'h3',
 								h2: 'h3',
+								a: function( tagName, attribs ) {
+									return {
+										tagName: 'a',
+										attribs: {
+											...pick( attribs, [ 'href' ] ),
+											target: '_blank',
+											rel: 'external noopener noreferrer'
+										}
+									};
+								}
 							}
 						} );
 					}


### PR DESCRIPTION
Links in plugin content are always external, but we currently open them in the same window. This PR alters the normalization utility function `normalizePluginData()` so it will open the links in the plugin content in a new window.

To test:

1. Checkout this branch
2. Go to `http://calypso.localhost:3000/plugins/$plugin/$site`, where `$plugin` is a plugin with links in the content, and `$site` is one of your Jetpack sites (I used the `google-sitemap-generator` plugin for testing).
3. Verify the links in the content open in new window and contain the `target="_blank"` fixes - as discussed and done in #7680.

/cc @johnHackworth @ryelle @mtias 