### PR TITLE
JS Errors: Introduce throttling

### DIFF
--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -1,5 +1,8 @@
 import TraceKit from 'tracekit';
 
+// Interval for error reports so we don't flood te endpoint. More frequent reports get throttled.
+const REPORT_INTERVAL = 60000;
+
 export default class ErrorLogger {
 	constructor() {
 		this.diagnosticData = {
@@ -34,8 +37,8 @@ export default class ErrorLogger {
 					}
 				}
 
-				const now = ( new Date() ).getTime();
-				if ( this.lastReport + 60000 < now ) {
+				const now = Date.now();
+				if ( this.lastReport + REPORT_INTERVAL < now ) {
 					this.lastReport = now;
 					this.diagnose();
 					this.sendToApi( Object.assign( error, this.diagnosticData ) );

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -37,7 +37,7 @@ export default class ErrorLogger {
 				this.diagnose();
 
 				if ( this.reportingTimeout ) {
-					this.diagnosticData.debounced_count++;
+					this.diagnosticData.extra.debounced_count++;
 					clearTimeout( this.reportingTimeout );
 				}
 
@@ -45,7 +45,7 @@ export default class ErrorLogger {
 					this.sendToApi( Object.assign( error, this.diagnosticData ) );
 					clearTimeout( this.reportingTimeout );
 					this.reportingTimeout = null;
-					this.diagnosticData.debounced_count = 0;
+					this.diagnosticData.extra.debounced_count = 0;
 				}, 60000 );
 			} );
 		}


### PR DESCRIPTION
Recently, we introduced some minor error and that ended up flooding the js-error endpoint with 100 000 000 requests (yep) in an hour.
@bazza has disabled the endpoint (again).

I am introducing many layers of rate-limiting so that we can avoid these kinds of mishaps again.
This one is client-side throttling.

- Client is rate-limited to 1 error / minute.
- Only the first error is passed
- I added `throttled ` property to inform us how many of these errors have been caught in the meantime.

CC @gwwar @lamosty @aduth @rralian 