### PR TITLE
JS Errors: Disable prod & horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -16,7 +16,7 @@
 		"accept-invite": true,
 		"ad-tracking": false,
 		"apple-pay": false,
-		"catch-js-errors": true,
+		"catch-js-errors": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -14,7 +14,7 @@
 		"accept-invite": true,
 		"ad-tracking": true,
 		"apple-pay": false,
-		"catch-js-errors": true,
+		"catch-js-errors": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,


### PR DESCRIPTION
Recently, we introduced some minor error and that ended up flooding the js-error endpoint with 100 000 000 requests (yep) in an hour.
@bazza has disabled the endpoint (again).

This disables prod & horizon because endpoint is now returning 403

## Testing

Only a feature flag, no need to test.

Work continues in #8748 to provide rate-limiting.

CC @lamosty @gwwar @rralian @aduth 
