### PR TITLE
Wporg Plugins: Update selectors to also accept the entire state.

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -26,7 +26,7 @@ import URLSearch from 'lib/mixins/url-search';
 import EmptyContent from 'components/empty-content';
 import PluginsStore from 'lib/plugins/store';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
-import * as WporgPluginsSelectors from 'state/plugins/wporg/selectors';
+import { getPlugin as getWporgPlugin } from 'state/plugins/wporg/selectors';
 import FeatureExample from 'components/feature-example';
 import PluginsList from './plugins-list';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
@@ -86,7 +86,7 @@ const PluginsMain = React.createClass( {
 	// plugins for Jetpack sites require additional data from the wporg-data store
 	addWporgDataToPlugins( plugins ) {
 		return plugins.map( plugin => {
-			const pluginData = WporgPluginsSelectors.getPlugin( this.props.wporgPlugins, plugin.slug );
+			const pluginData = getWporgPlugin( this.props.wporgPlugins, plugin.slug );
 			if ( ! pluginData ) {
 				this.props.wporgFetchPluginData( plugin.slug );
 			}

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -26,7 +26,7 @@ import URLSearch from 'lib/mixins/url-search';
 import EmptyContent from 'components/empty-content';
 import PluginsStore from 'lib/plugins/store';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
-import WporgPluginsSelectors from 'state/plugins/wporg/selectors';
+import * as WporgPluginsSelectors from 'state/plugins/wporg/selectors';
 import FeatureExample from 'components/feature-example';
 import PluginsList from './plugins-list';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -18,7 +18,11 @@ import HeaderCake from 'components/header-cake';
 import PluginMeta from 'my-sites/plugins/plugin-meta';
 import PluginsStore from 'lib/plugins/store';
 import PluginsLog from 'lib/plugins/log-store';
-import * as WporgPluginsSelectors from 'state/plugins/wporg/selectors';
+import {
+	getPlugin as getWporgPlugin,
+	isFetching as isWporgFetching,
+	isFetched as isWporgFetched
+} from 'state/plugins/wporg/selectors';
 import PluginsActions from 'lib/plugins/actions';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
 import PluginNotices from 'lib/plugins/notices';
@@ -195,7 +199,7 @@ const SinglePlugin = React.createClass( {
 	},
 
 	isFetched() {
-		return WporgPluginsSelectors.isFetched( this.props.wporgPlugins, this.props.pluginSlug );
+		return isWporgFetched( this.props.wporgPlugins, this.props.pluginSlug );
 	},
 
 	isFetchingSites() {
@@ -206,7 +210,7 @@ const SinglePlugin = React.createClass( {
 	getPlugin() {
 		let plugin = Object.assign( {}, this.state.plugin );
 		// assign it .org details
-		plugin = Object.assign( plugin, WporgPluginsSelectors.getPlugin( this.props.wporgPlugins, this.props.pluginSlug ) );
+		plugin = Object.assign( plugin, getWporgPlugin( this.props.wporgPlugins, this.props.pluginSlug ) );
 
 		return plugin;
 	},
@@ -371,7 +375,7 @@ export default connect(
 	( state, props ) => {
 		return {
 			wporgPlugins: state.plugins.wporg.items,
-			wporgFetching: WporgPluginsSelectors.isFetching( state.plugins.wporg.fetchingItems, props.pluginSlug )
+			wporgFetching: isWporgFetching( state.plugins.wporg.fetchingItems, props.pluginSlug )
 		};
 	},
 	dispatch => bindActionCreators( { wporgFetchPluginData }, dispatch )

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -18,7 +18,7 @@ import HeaderCake from 'components/header-cake';
 import PluginMeta from 'my-sites/plugins/plugin-meta';
 import PluginsStore from 'lib/plugins/store';
 import PluginsLog from 'lib/plugins/log-store';
-import WporgPluginsSelectors from 'state/plugins/wporg/selectors';
+import * as WporgPluginsSelectors from 'state/plugins/wporg/selectors';
 import PluginsActions from 'lib/plugins/actions';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
 import PluginNotices from 'lib/plugins/notices';

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -1,20 +1,34 @@
-const getPlugin = function( state, pluginSlug ) {
-	if ( ! state || ! state[ pluginSlug ] ) {
+export function getPlugin( state, pluginSlug ) {
+	let plugins;
+	// Some components just pass in the list of plugins, not the entire state.
+	if ( ! state.hasOwnProperty( 'plugins' ) ) {
+		plugins = state;
+	} else {
+		plugins = state.plugins.wporg.items;
+	}
+	if ( typeof plugins[ pluginSlug ] === 'undefined' ) {
 		return null;
 	}
-	return Object.assign( {}, state[ pluginSlug ] );
-};
+	return Object.assign( {}, plugins[ pluginSlug ] );
+}
 
-const isFetching = function( state, pluginSlug ) {
+export function isFetching( state, pluginSlug ) {
 	// if the `isFetching` attribute doesn't exist yet,
 	// we assume we are still launching the fetch action, so it's true
-	if ( typeof state[ pluginSlug ] === 'undefined' ) {
+	let fetching;
+	// Some components just pass in the list of plugins, not the entire state.
+	if ( ! state.hasOwnProperty( 'plugins' ) ) {
+		fetching = state;
+	} else {
+		fetching = state.plugins.wporg.fetchingItems;
+	}
+	if ( typeof fetching[ pluginSlug ] === 'undefined' ) {
 		return true;
 	}
-	return state[ pluginSlug ];
-};
+	return fetching[ pluginSlug ];
+}
 
-const isFetched = function( state, pluginSlug ) {
+export function isFetched( state, pluginSlug ) {
 	const plugin = getPlugin( state, pluginSlug );
 	// if the plugin or the `isFetching` attribute doesn't exist yet,
 	// we assume we are still launching the fetch action, so it's true
@@ -22,6 +36,4 @@ const isFetched = function( state, pluginSlug ) {
 		return false;
 	}
 	return !! plugin.fetched;
-};
-
-export default { getPlugin, isFetching, isFetched };
+}

--- a/client/state/plugins/wporg/test/selectors.js
+++ b/client/state/plugins/wporg/test/selectors.js
@@ -7,19 +7,25 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import selectors from '../selectors';
+import * as selectors from '../selectors';
 
-const items = deepFreeze( {
-	test: { slug: 'test'},
-	fetchingTest: { slug: 'fetchingTest' },
-	fetchedTest: { slug: 'fetchingTest', fetched: true },
-	fetchedTest2: { slug: 'fetchingTest', fetched: true }
-} );
-const fetchingItems = deepFreeze( {
-	test: false,
-	fetchingTest: true,
-	fetchedTest: false,
-	fetchedTest2: true
+const state = deepFreeze( {
+	plugins: {
+		wporg: {
+			fetchingItems: {
+				test: false,
+				fetchingTest: true,
+				fetchedTest: false,
+				fetchedTest2: true
+			},
+			items: {
+				test: { slug: 'test' },
+				fetchingTest: { slug: 'fetchingTest' },
+				fetchedTest: { slug: 'fetchingTest', fetched: true },
+				fetchedTest2: { slug: 'fetchingTest', fetched: true },
+			},
+		}
+	}
 } );
 
 describe( 'WPorg Selectors', function() {
@@ -33,49 +39,54 @@ describe( 'WPorg Selectors', function() {
 
 	describe( 'getPlugin', function() {
 		it( 'Should get null if the requested plugin is not in the current state', function() {
-			assert.equal( selectors.getPlugin( items, 'no-test' ), null );
+			assert.equal( selectors.getPlugin( state, 'no-test' ), null );
 		} );
 
 		it( 'Should get the plugin if the requested plugin is in the current state', function() {
-			assert.equal( selectors.getPlugin( items, 'test' ).slug, 'test' );
+			assert.equal( selectors.getPlugin( state, 'test' ).slug, 'test' );
 		} );
 
 		it( 'Should return a new object with no pointers to the one stored in state', function() {
-			let plugin = selectors.getPlugin( items, 'fetchedTest' );
+			const plugin = selectors.getPlugin( state, 'fetchedTest' );
 			plugin.fetched = false;
-			assert.equal( selectors.getPlugin( items, 'fetchedTest' ).fetched, true );
+			assert.equal( selectors.getPlugin( state, 'fetchedTest' ).fetched, true );
+		} );
+
+		// Used by components with flux stores, see `addWporgDataToPlugins` in `client/my-sites/plugins/main.jsx`)
+		it( 'Should get the plugin from the items substate', function() {
+			assert.equal( selectors.getPlugin( state.plugins.wporg.items, 'test' ).slug, 'test' );
 		} );
 	} );
 
 	describe( 'isFetching', function() {
 		it( 'Should get `true` if the requested plugin is not in the current state', function() {
-			assert.equal( selectors.isFetching( fetchingItems, 'no.test' ), true );
+			assert.equal( selectors.isFetching( state, 'no.test' ), true );
 		} );
 
 		it( 'Should get `false` if the requested plugin is not being fetched', function() {
-			assert.equal( selectors.isFetching( fetchingItems, 'test' ), false );
+			assert.equal( selectors.isFetching( state, 'test' ), false );
 		} );
 
 		it( 'Should get `true` if the requested plugin is being fetched', function() {
-			assert.equal( selectors.isFetching( fetchingItems, 'fetchingTest' ), true );
+			assert.equal( selectors.isFetching( state, 'fetchingTest' ), true );
 		} );
 	} );
 
 	describe( 'isFetched', function() {
 		it( 'Should get `false` if the requested plugin is not in the current state', function() {
-			assert.equal( selectors.isFetched( items, 'no.test' ), false );
+			assert.equal( selectors.isFetched( state, 'no.test' ), false );
 		} );
 
 		it( 'Should get `false` if the requested plugin has not being fetched', function() {
-			assert.equal( selectors.isFetched( items, 'test' ), false );
+			assert.equal( selectors.isFetched( state, 'test' ), false );
 		} );
 
 		it( 'Should get `true` if the requested plugin has being fetched', function() {
-			assert.equal( selectors.isFetched( items, 'fetchedTest' ), true );
+			assert.equal( selectors.isFetched( state, 'fetchedTest' ), true );
 		} );
 
 		it( 'Should get `true` if the requested plugin has being fetched even if it\'s being fetche again', function() {
-			assert.equal( selectors.isFetched( items, 'fetchedTest2' ), true );
+			assert.equal( selectors.isFetched( state, 'fetchedTest2' ), true );
 		} );
 	} );
 } );

--- a/client/state/plugins/wporg/test/selectors.js
+++ b/client/state/plugins/wporg/test/selectors.js
@@ -7,7 +7,11 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import * as selectors from '../selectors';
+import {
+	getPlugin,
+	isFetching,
+	isFetched
+} from '../selectors';
 
 const state = deepFreeze( {
 	plugins: {
@@ -30,63 +34,67 @@ const state = deepFreeze( {
 
 describe( 'WPorg Selectors', function() {
 	it( 'Should contain getPlugin method', function() {
-		assert.equal( typeof selectors.getPlugin, 'function' );
+		assert.equal( typeof getPlugin, 'function' );
 	} );
 
 	it( 'Should contain isFetching method', function() {
-		assert.equal( typeof selectors.isFetching, 'function' );
+		assert.equal( typeof isFetching, 'function' );
+	} );
+
+	it( 'Should contain isFetched method', function() {
+		assert.equal( typeof isFetched, 'function' );
 	} );
 
 	describe( 'getPlugin', function() {
 		it( 'Should get null if the requested plugin is not in the current state', function() {
-			assert.equal( selectors.getPlugin( state, 'no-test' ), null );
+			assert.equal( getPlugin( state, 'no-test' ), null );
 		} );
 
 		it( 'Should get the plugin if the requested plugin is in the current state', function() {
-			assert.equal( selectors.getPlugin( state, 'test' ).slug, 'test' );
+			assert.equal( getPlugin( state, 'test' ).slug, 'test' );
 		} );
 
 		it( 'Should return a new object with no pointers to the one stored in state', function() {
-			const plugin = selectors.getPlugin( state, 'fetchedTest' );
+			const plugin = getPlugin( state, 'fetchedTest' );
 			plugin.fetched = false;
-			assert.equal( selectors.getPlugin( state, 'fetchedTest' ).fetched, true );
+			assert.equal( getPlugin( state, 'fetchedTest' ).fetched, true );
 		} );
 
 		// Used by components with flux stores, see `addWporgDataToPlugins` in `client/my-sites/plugins/main.jsx`)
 		it( 'Should get the plugin from the items substate', function() {
-			assert.equal( selectors.getPlugin( state.plugins.wporg.items, 'test' ).slug, 'test' );
+			assert.equal( getPlugin( state.plugins.wporg.items, 'test' ).slug, 'test' );
 		} );
 	} );
 
 	describe( 'isFetching', function() {
 		it( 'Should get `true` if the requested plugin is not in the current state', function() {
-			assert.equal( selectors.isFetching( state, 'no.test' ), true );
+			assert.equal( isFetching( state, 'no.test' ), true );
 		} );
 
 		it( 'Should get `false` if the requested plugin is not being fetched', function() {
-			assert.equal( selectors.isFetching( state, 'test' ), false );
+			assert.equal( isFetching( state, 'test' ), false );
 		} );
 
 		it( 'Should get `true` if the requested plugin is being fetched', function() {
-			assert.equal( selectors.isFetching( state, 'fetchingTest' ), true );
+			assert.equal( isFetching( state, 'fetchingTest' ), true );
 		} );
 	} );
 
 	describe( 'isFetched', function() {
 		it( 'Should get `false` if the requested plugin is not in the current state', function() {
-			assert.equal( selectors.isFetched( state, 'no.test' ), false );
+			assert.equal( isFetched( state, 'no.test' ), false );
 		} );
 
 		it( 'Should get `false` if the requested plugin has not being fetched', function() {
-			assert.equal( selectors.isFetched( state, 'test' ), false );
+			assert.equal( isFetched( state, 'test' ), false );
 		} );
 
 		it( 'Should get `true` if the requested plugin has being fetched', function() {
-			assert.equal( selectors.isFetched( state, 'fetchedTest' ), true );
+			assert.equal( isFetched( state, 'fetchedTest' ), true );
 		} );
 
 		it( 'Should get `true` if the requested plugin has being fetched even if it\'s being fetche again', function() {
-			assert.equal( selectors.isFetched( state, 'fetchedTest2' ), true );
+			assert.equal( isFetched( state, 'fetchedTest2' ), true );
 		} );
 	} );
 } );


### PR DESCRIPTION
In our current standards, selectors should receive the entire state tree. This PR updates the selectors, but still leaves a window where older components can pass in the subtree (because older components are using flux stores, we can't use the selector as part of `mapStateToProps`, [example](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/plugins/main.jsx#L87:L95)).

This is part of a migration to redux, once plugins are migrated the conditionals can be removed. See #8213

To test:
1. Run `npm run test-client client/state/plugins/wporg/test/selectors.js`
2. Everything's green 😄 

cc @tyxla @johnHackworth 
