### PR TITLE
Editor: fix incorrect caption when resizing image with multiple images in a post

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -391,7 +391,7 @@ function mediaButton( editor ) {
 		const caption = editor.dom.getParent( node, '.mceTemp' );
 		if ( caption ) {
 			editor.selection.select( caption );
-			parsed.media.caption = editor.dom.$( '.wp-caption-dd' ).text();
+			parsed.media.caption = editor.dom.$( '.wp-caption-dd', caption ).text();
 		}
 
 		// Attempt to find media in Flux store


### PR DESCRIPTION
Add `context` when doing select

Fix #8737 

cc @apeatling 