### PR TITLE
Pages: Fix popover menu offset issue

### DIFF
--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -95,7 +95,7 @@
 	color: $gray;
 	padding: 4px 16px 8px;
 	font-size: 12px;
-	max-width: 200px;
+	max-width: 150px;
 	text-align: left;
 }
 


### PR DESCRIPTION
This PR fixes an issue observed when bringing up the popover menu for a page that has been set as the homepage.

Before:

![popover menu offset - broken](https://cloud.githubusercontent.com/assets/2098816/19396258/333fc614-9210-11e6-969f-9a1420d5909b.gif)

After:

![popover menu offset - fixed](https://cloud.githubusercontent.com/assets/2098816/19396261/3cb895ea-9210-11e6-899e-c4ae5d3340b0.gif)

To test:

- Bring up the popover menu multiple times and make sure that it always points to the ellipsis