### PR TITLE
Media Modal: allow editing meta of currently uploading media

### DIFF
--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -10,6 +10,8 @@ var Dispatcher = require( 'dispatcher' ),
 	emitter = require( 'lib/mixins/emitter' ),
 	MediaValidationStore = require( './validation-store' );
 
+import { isItemBeingUploaded } from 'lib/media/utils';
+
 /**
  * Module variables
  */
@@ -31,6 +33,15 @@ function receiveSingle( siteId, item, itemId ) {
 		}
 
 		MediaStore._pointers[ siteId ][ itemId ] = item.ID;
+
+		const maybeTransientMediaItem = MediaStore._media[ siteId ][ itemId ];
+
+		if ( isItemBeingUploaded( maybeTransientMediaItem ) ) {
+			item.description = maybeTransientMediaItem.description;
+			item.alt = maybeTransientMediaItem.alt;
+			item.caption = maybeTransientMediaItem.caption;
+		}
+
 		delete MediaStore._media[ siteId ][ itemId ];
 	}
 


### PR DESCRIPTION
Fixes #8537. If we edit meta of the media which is currently being uploaded, it gets overwritten by empty meta after the media is uploaded (by meta I mean caption, description and alt text). Let's fix that in this PR.

## Testing instructions

1. Navigate to Media Modal and in the "Network" tab of Chrome Dev Tools, throttle network speed to Edge or slower;
2. Drag'n'drop an image or other supported media type to the Media Modal;
3. In the list of media in the Media Modal, your media will be shown as being uploading;
4. Click on the edit icon to edit the media meta data;
5. Edit the caption, alt text and description of this media;
6. In the "Network" tab in Chrome Dev Tools, disable network speed throttling;
7. Wait till the image is uploaded;
8. Has the meta you've typed in been left unchanged?

/cc @gwwar @artpi @gziolo (you are shown on the blame list of `lib/media/store` file ;) )