### PR TITLE
Refactor <EmailData> in Domains Management to remove sites-list

### DIFF
--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -3,17 +3,16 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { partial } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import StoreConnection from 'components/data/store-connection';
-import DomainsStore from 'lib/domains/store';
 import CartStore from 'lib/cart/store';
 import QueryProducts from 'components/data/query-products-list';
-import { fetchDomains } from 'lib/upgrades/actions';
-import userFactory from 'lib/user';
+import QuerySiteDomains from 'components/data/query-site-domains';
+import QuerySitePlans from 'components/data/query-site-plans';
+import { getCurrentUser } from 'state/current-user/selectors';
 import {
 	fetchByDomain,
 	fetchBySiteId
@@ -23,29 +22,25 @@ import {
 	getBySite,
 	isLoaded
 } from 'state/google-apps-users/selectors';
-import { shouldFetchSitePlans } from 'lib/plans';
-import { fetchSitePlans } from 'state/sites/plans/actions';
+import { getDomainsBySite, isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 
-const user = userFactory();
-
 const stores = [
-	DomainsStore,
 	CartStore
 ];
 
 function getStateFromStores( props ) {
 	return {
-		domains: DomainsStore.getBySite( props.selectedSite.ID ) || {},
+		domains: props.domains,
 		cart: CartStore.get(),
 		context: props.context,
 		products: props.products,
 		selectedDomainName: props.selectedDomainName,
 		selectedSite: props.selectedSite,
 		sitePlans: props.sitePlans,
-		user: user.get(),
+		user: props.user,
 		googleAppsUsers: props.googleAppsUsers,
 		googleAppsUsersLoaded: props.googleAppsUsersLoaded
 	};
@@ -53,8 +48,8 @@ function getStateFromStores( props ) {
 
 export class EmailData extends Component {
 	static propTypes = {
+		component: PropTypes.func.isRequired,
 		context: PropTypes.object.isRequired,
-		fetchSitePlans: PropTypes.func.isRequired,
 		products: PropTypes.object.isRequired,
 		selectedDomainName: PropTypes.string,
 		selectedSite: PropTypes.object.isRequired,
@@ -63,29 +58,20 @@ export class EmailData extends Component {
 		googleAppsUsersLoaded: PropTypes.bool.isRequired,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		props.loadDomainsAndSitePlans();
-	}
-
 	componentDidMount() {
 		this.props.fetchGoogleAppsUsers();
 	}
 
-	componentWillUpdate( nextProps ) {
-		const { selectedSite: nextSite } = nextProps;
-		const { selectedSite: prevSite } = this.props;
-
-		if ( nextSite !== prevSite ) {
-			this.props.loadDomainsAndSitePlans();
-		}
-	}
-
 	render() {
+		const {
+			selectedSite: { ID: siteId },
+		} = this.props;
+
 		return (
 			<div>
 				<QueryProducts />
+				<QuerySiteDomains { ...{ siteId } } />
+				<QuerySitePlans { ...{ siteId } } />
 				<StoreConnection
 					component={ this.props.component }
 					domains={ this.props.domains }
@@ -97,25 +83,13 @@ export class EmailData extends Component {
 					selectedDomainName={ this.props.selectedDomainName }
 					selectedSite={ this.props.selectedSite }
 					sitePlans={ this.props.sitePlans }
+					user={ this.props.currentUser }
 					context={ this.props.context }
 				/>
 			</div>
 		);
 	}
 }
-
-const loadDomainsAndSitePlans = ( fetchSitePlans, selectedSite, sitePlans ) => {
-	if ( ! selectedSite ) {
-		return;
-	}
-
-	if ( ! shouldFetchSitePlans( sitePlans, selectedSite ) ) {
-		return;
-	}
-
-	fetchDomains( selectedSite.ID );
-	fetchSitePlans( selectedSite.ID );
-};
 
 const mapStateToProps = ( state, { selectedDomainName } ) => {
 	const selectedSite = getSelectedSite( state );
@@ -126,6 +100,11 @@ const mapStateToProps = ( state, { selectedDomainName } ) => {
 	return {
 		googleAppsUsers,
 		selectedSite,
+		currentUser: getCurrentUser( state ),
+		domains: {
+			isFetching: isRequestingSiteDomains( state, selectedSite.ID ),
+			list: getDomainsBySite( state, selectedSite ),
+		},
 		googleAppsUsersLoaded: isLoaded( state ),
 		products: getProductsList( state ),
 		sitePlans: getPlansBySite( state, selectedSite ),
@@ -137,34 +116,18 @@ const mapDispatchToProps = ( dispatch, { selectedDomainName } ) => {
 		? () => dispatch( fetchByDomain( selectedDomainName ) )
 		: selectedSite => dispatch( fetchBySiteId( selectedSite.ID ) );
 
-	return {
-		fetchSitePlans: siteId => dispatch( fetchSitePlans( siteId ) ),
-		googleAppsUsersFetcher,
-	};
+	return { googleAppsUsersFetcher };
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const {
-		selectedSite,
-		sitePlans,
-	} = stateProps;
-
-	const {
-		fetchSitePlans,
-		googleAppsUsersFetcher,
-	} = dispatchProps;
+	const { selectedSite } = stateProps;
+	const { googleAppsUsersFetcher } = dispatchProps;
 
 	return {
 		...ownProps,
 		...stateProps,
 		...dispatchProps,
 		fetchGoogleAppsUsers: () => googleAppsUsersFetcher( selectedSite ),
-		loadDomainsAndSitePlans: partial(
-			loadDomainsAndSitePlans,
-			fetchSitePlans,
-			selectedSite,
-			sitePlans,
-		)
 	};
 };
 

--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -125,9 +125,9 @@ const mapStateToProps = ( state, { selectedDomainName } ) => {
 
 	return {
 		googleAppsUsers,
+		selectedSite,
 		googleAppsUsersLoaded: isLoaded( state ),
 		products: getProductsList( state ),
-		selectedSite,
 		sitePlans: getPlansBySite( state, selectedSite ),
 	};
 };

--- a/client/components/data/query-site-plans/index.jsx
+++ b/client/components/data/query-site-plans/index.jsx
@@ -24,7 +24,7 @@ class QuerySitePlans extends Component {
 		}
 	}
 
-	componentWillMount() {
+	componentDidMount() {
 		this.requestPlans();
 	}
 

--- a/client/components/data/store-connection/index.jsx
+++ b/client/components/data/store-connection/index.jsx
@@ -58,17 +58,22 @@ const StoreConnection = React.createClass( {
 	},
 
 	render() {
+		const props = {
+			...this.props,
+			...this.state,
+		};
+
 		if ( this.isDataLoading() ) {
-			return React.createElement( this.props.loadingPlaceholder, this.state );
+			return React.createElement( this.props.loadingPlaceholder, props );
 		}
 
 		if ( this.props.component ) {
-			return React.createElement( this.props.component, this.state );
+			return React.createElement( this.props.component, props );
 		}
 
 		const child = React.Children.only( this.props.children );
 
-		return React.cloneElement( child, this.state );
+		return React.cloneElement( child, props );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -162,10 +162,9 @@ module.exports = {
 		renderWithReduxStore(
 			<EmailData
 				component={ DomainManagement.Email }
-				productsList={ productsList }
 				selectedDomainName={ pageContext.params.domain }
 				context={ pageContext }
-				sites={ sites } />,
+			/>,
 			document.getElementById( 'primary' ),
 			pageContext.store
 		);

--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
+import { identity, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -74,8 +75,16 @@ const Email = React.createClass( {
 	},
 
 	content() {
-		if ( ! ( this.props.domains.hasLoadedFromServer && this.props.googleAppsUsersLoaded ) ) {
-			return <Placeholder />;
+		const {
+			domains,
+			googleAppsUsersLoaded,
+		} = this.props;
+
+		if ( some( [
+			! domains.list.length && domains.isFetching,
+			! googleAppsUsersLoaded,
+		], identity ) ) {
+			return <Placeholder/>;
 		}
 
 		const domainList = this.props.selectedDomainName

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -1,3 +1,7 @@
+import { property } from 'lodash';
+
+export const getProductsList = property( 'productsList.items' );
+
 export function isProductsListFetching( state ) {
 	return state.productsList.isFetching;
 }


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/projects/3

This PR refactors the `<EmailData />` component in domain management under **Domains** > **G Suite**

It no longer relies on `sites-list` and it no longer incorporates an `observe()` mixing.

There should be no functional or visible changes with this PR.

**Testing**
Please navigate to the domain settings pages and smoke-test with sites which are and sites which aren't connected to _G Suite_. Switch sites and make sure things update properly. We should try and make sure that product updates from the API update this page but I'm not sure how to do that.

**Notes**
 - This component is still pretty messy. The store connection is an obstacle in cleaning it up but is a big project in its own right easily deferrable until later.
 - There's some funky business going on in `connect()` because the dispatch-able functions depend on app state. I wasn't sure how to clean that up since I don't understand all the inner-workings of the components and so I hooked it all up in `mergeProps`. There has got to be a cleaner and simpler way to hook up this component.

cc: @gwwar (@umurkontaci @drewblaisdell @gziolo since y'all were on the history in that component)