### PR TITLE
Fix broken link to 'config' doc

### DIFF
--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -26,7 +26,7 @@ First thing is to enable your new feature in Calypso. We'll do that by opening `
 "hello-world": true
 ```
 
-Features flags are a great way to enable/disable certain features in specific environments. For example, we can merge our "Hello, World!" code in `master,` but hide it behind a feature flag. We have [more documentation on feature flags](../client/config).
+Features flags are a great way to enable/disable certain features in specific environments. For example, we can merge our "Hello, World!" code in `master,` but hide it behind a feature flag. We have [more documentation on feature flags](../../client/config).
 
 ### 2. Set up folder structure
 


### PR DESCRIPTION
I was going through docs, and code trying to figure out how things work (it's a pretty big codebase now) and found a broken link into the `hello-world` tutorial.

I suppose the intention was to make it points to the main `config` readme, that is one further level up.

