### PR TITLE
Sites state: add remaining Jetpack selectors

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -744,19 +744,19 @@ export function isJetpackSiteMainNetworkSite( state, siteId ) {
 		return true;
 	}
 
-	if ( site.is_multisite ) {
-		const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
-		const mainNetworkSite = getSiteOption( state, siteId, 'main_network_site' );
-
-		if ( ! unmappedUrl || ! mainNetworkSite ) {
-			return false;
-		}
-
-		// Compare unmapped_url with the main_network_site to see if is the main network site.
-		return withoutHttp( unmappedUrl ) === withoutHttp( mainNetworkSite );
+	if ( ! site.is_multisite ) {
+		return false;
 	}
 
-	return false;
+	const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
+	const mainNetworkSite = getSiteOption( state, siteId, 'main_network_site' );
+
+	if ( ! unmappedUrl || ! mainNetworkSite ) {
+		return false;
+	}
+
+	// Compare unmapped_url with the main_network_site to see if is the main network site.
+	return withoutHttp( unmappedUrl ) === withoutHttp( mainNetworkSite );
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -621,7 +621,7 @@ export function canJetpackSiteManage( state, siteId ) {
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} if the site can update its file
+ * @return {Boolean} true if the site can update its file
  */
 export function canJetpackSiteUpdateFiles( state, siteId ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
@@ -660,7 +660,7 @@ export function canJetpackSiteUpdateFiles( state, siteId ) {
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} if the site can auto update
+ * @return {Boolean} true if the site can auto update
  */
 export function canJetpackSiteAutoUpdateFiles( state, siteId ) {
 	if ( ! canJetpackSiteUpdateFiles( state, siteId ) ) {
@@ -681,7 +681,7 @@ export function canJetpackSiteAutoUpdateFiles( state, siteId ) {
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} if the site can auto update WordPress
+ * @return {Boolean} true if the site can auto update WordPress
  */
 export function canJetpackSiteAutoUpdateCore( state, siteId ) {
 	return canJetpackSiteAutoUpdateFiles( state, siteId );
@@ -692,7 +692,7 @@ export function canJetpackSiteAutoUpdateCore( state, siteId ) {
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} if the site has Jetpack menus
+ * @return {Boolean} true if the site has Jetpack menus management
  */
 export function hasJetpackSiteJetpackMenus( state, siteId ) {
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
@@ -704,7 +704,7 @@ export function hasJetpackSiteJetpackMenus( state, siteId ) {
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} if the site has Jetpack themes
+ * @return {Boolean} true if the site has Jetpack themes management
  */
 export function hasJetpackSiteJetpackThemes( state, siteId ) {
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
@@ -718,7 +718,7 @@ export function hasJetpackSiteJetpackThemes( state, siteId ) {
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} if the site is the main site
+ * @return {Boolean} true if the site is the main site
  */
 export function isJetpackSiteMainNetworkSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
@@ -757,7 +757,7 @@ export function isJetpackSiteMainNetworkSite( state, siteId ) {
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} if the site is a secondary network site
+ * @return {Boolean} true if the site is a secondary network site
  */
 export function isJetpackSiteSecondaryNetworkSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
@@ -785,7 +785,7 @@ export function isJetpackSiteSecondaryNetworkSite( state, siteId ) {
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
  * @param {Array} moduleIds A list of active module ids to verify
- * @return {Boolean} if the all the given modules are active for this site
+ * @return {Boolean} true if the all the given modules are active for this site
  */
 export function verifyJetpackModulesActive( state, siteId, moduleIds ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
@@ -876,7 +876,7 @@ export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action 
  *
  * @param  {Object} state - whole state tree
  * @param  {Number} siteId - site id
- * @return {Boolean} true is the site has minimum jetpack version
+ * @return {Boolean} true if the site has minimum jetpack version
  */
 export function siteHasMinimumJetpackVersion( state, siteId ) {
 	if ( ! siteId ) {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -594,7 +594,8 @@ export function hasStaticFrontPage( state, siteId ) {
 }
 
 /**
- * Determines if a Jetpack site has opted in for full-site management
+ * Determines if a Jetpack site has opted in for full-site management.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
@@ -619,10 +620,11 @@ export function canJetpackSiteManage( state, siteId ) {
 
 /**
  * Determines if a Jetpack site can update its files.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} true if the site can update its file
+ * @return {?Boolean} true if the site can update its file
  */
 export function canJetpackSiteUpdateFiles( state, siteId ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
@@ -657,13 +659,18 @@ export function canJetpackSiteUpdateFiles( state, siteId ) {
 
 /**
  * Determines if a Jetpack site can auto update its files.
- * This function checks if the given Jetpack site can update its files and if the automatic updater is enabled
+ * This function checks if the given Jetpack site can update its files and if the automatic updater is enabled.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} true if the site can auto update
+ * @return {?Boolean} true if the site can auto update
  */
 export function canJetpackSiteAutoUpdateFiles( state, siteId ) {
+	if ( ! isJetpackSite( state, siteId ) ) {
+		return null;
+	}
+
 	if ( ! canJetpackSiteUpdateFiles( state, siteId ) ) {
 		return false;
 	}
@@ -679,35 +686,46 @@ export function canJetpackSiteAutoUpdateFiles( state, siteId ) {
 
 /**
  * Determines if a Jetpack site can auto update WordPress core.
+ * This function is currently identical to canJetpackSiteAutoUpdateFiles.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} true if the site can auto update WordPress
+ * @return {?Boolean} true if the site can auto update WordPress
  */
 export function canJetpackSiteAutoUpdateCore( state, siteId ) {
 	return canJetpackSiteAutoUpdateFiles( state, siteId );
 }
 
 /**
- * Determines if the Jetpack plugin of a Jetpack Site has menus
+ * Determines if the Jetpack plugin of a Jetpack Site has menus.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} true if the site has Jetpack menus management
+ * @return {?Boolean} true if the site has Jetpack menus management
  */
 export function hasJetpackSiteJetpackMenus( state, siteId ) {
+	if ( ! isJetpackSite( state, siteId ) ) {
+		return null;
+	}
+
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
 	return versionCompare( siteJetpackVersion, '3.5-alpha' ) >= 0;
 }
 
 /**
- * Determines if the Jetpack plugin of a Jetpack Site has themes
+ * Determines if the Jetpack plugin of a Jetpack Site has themes.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} true if the site has Jetpack themes management
+ * @return {?Boolean} true if the site has Jetpack themes management
  */
 export function hasJetpackSiteJetpackThemes( state, siteId ) {
+	if ( ! isJetpackSite( state, siteId ) ) {
+		return null;
+	}
+
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
 	return versionCompare( siteJetpackVersion, '3.7-beta' ) >= 0;
 }
@@ -715,16 +733,17 @@ export function hasJetpackSiteJetpackThemes( state, siteId ) {
 /**
  * Determines if a site is the main site in a Network
  * True if it is either in a non multi-site configuration
- * or if its url matches the `main_network_site` url option
+ * or if its url matches the `main_network_site` url option.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} true if the site is the main site
+ * @return {?Boolean} true if the site is the main site
  */
 export function isJetpackSiteMainNetworkSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
 
-	if ( ! site ) {
+	if ( ! site || ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}
 
@@ -754,16 +773,17 @@ export function isJetpackSiteMainNetworkSite( state, siteId ) {
 }
 
 /**
- * Determines if a Jetpack site is a secondary network site
+ * Determines if a Jetpack site is a secondary network site.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} true if the site is a secondary network site
+ * @return {?Boolean} true if the site is a secondary network site
  */
 export function isJetpackSiteSecondaryNetworkSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
 
-	if ( ! site ) {
+	if ( ! site || ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}
 
@@ -781,12 +801,13 @@ export function isJetpackSiteSecondaryNetworkSite( state, siteId ) {
 }
 
 /**
- * Determines if all given modules are active for a Jetpack Site
+ * Determines if all given modules are active for a Jetpack Site.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
  * @param {Array} moduleIds A list of active module ids to verify
- * @return {Boolean} true if the all the given modules are active for this site
+ * @return {?Boolean} true if the all the given modules are active for this site
  */
 export function verifyJetpackModulesActive( state, siteId, moduleIds ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
@@ -801,11 +822,12 @@ export function verifyJetpackModulesActive( state, siteId, moduleIds ) {
 }
 
 /**
- * Returns the remote management url for a Jetpack site
+ * Returns the remote management url for a Jetpack site.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {String} the remote management url for the site
+ * @return {?String} the remote management url for the site
  */
 export function getJetpackSiteRemoteManagementURL( state, siteId ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
@@ -821,16 +843,22 @@ export function getJetpackSiteRemoteManagementURL( state, siteId ) {
 
 /**
  * Checks whether a Jetpack site has a custom mapped URL.
+ * Returns null if the site is not known, is not a Jetpack site
+ * or has an undefined value for `domain` or `unmapped_url`.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
  * @return {?Boolean} Whether site has custom domain
  */
 export function hasJetpackSiteCustomDomain( state, siteId ) {
-	const site = getRawSite( state, siteId ),
-		domain = getSiteDomain( state, siteId ),
+	if ( ! isJetpackSite( state, siteId ) ) {
+		return null;
+	}
+
+	const domain = getSiteDomain( state, siteId ),
 		unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
-	if ( ! site || ! domain || ! unmappedUrl ) {
+
+	if ( ! domain || ! unmappedUrl ) {
 		return null;
 	}
 
@@ -838,14 +866,20 @@ export function hasJetpackSiteCustomDomain( state, siteId ) {
 }
 
 /**
- * Returns an explanation on why updates are disabled on a Jetpack Site
+ * Returns an explanation on why updates are disabled on a Jetpack Site.
+ * Returns null if the site is not known or is not a Jetpack site.
+ * Can return an empty array if no reason have been found
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
  * @param {String} action The update action we wanted to perform on this site
- * @return {?String} The reason why file update is disabled
+ * @return {?Array<String>} The reasons why file update is disabled
  */
 export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action = 'modifyFiles' ) {
+	if ( ! isJetpackSite( state, siteId ) ) {
+		return null;
+	}
+
 	const fileModDisabled = getSiteOption( state, siteId, 'file_mod_disabled' );
 
 	return compact( fileModDisabled.map( clue => {
@@ -874,16 +908,13 @@ export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action 
 /**
  * Return true is the given Jetpack site has a version equal or greater than
  * the minimum Jetpack version as set by the 'jetpack_min_version' config value.
+ * Returns null if the site is not known or is not a Jetpack site.
  *
  * @param  {Object} state - whole state tree
  * @param  {Number} siteId - site id
- * @return {Boolean} true if the site has minimum jetpack version
+ * @return {?Boolean} true if the site has minimum jetpack version
  */
 export function siteHasMinimumJetpackVersion( state, siteId ) {
-	if ( ! siteId ) {
-		return null;
-	}
-
 	if ( ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -651,17 +651,14 @@ export function canJetpackSiteUpdateFiles( state, siteId ) {
 
 	const fileModDisabled = getSiteOption( state, siteId, 'file_mod_disabled' );
 
-	if (
-		fileModDisabled &&
-		(
-			-1 < fileModDisabled.indexOf( 'disallow_file_mods' ) ||
-			-1 < fileModDisabled.indexOf( 'has_no_file_system_write_access' )
-		)
-	) {
-		return false;
+	if ( ! fileModDisabled ) {
+		return true;
 	}
 
-	return true;
+	return (
+		! includes( fileModDisabled, 'disallow_file_mods' ) &&
+		! includes( fileModDisabled, 'has_no_file_system_write_access' )
+	);
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -609,11 +609,8 @@ export function canJetpackSiteManage( state, siteId ) {
 
 	if ( versionCompare( siteJetpackVersion, '3.4', '>=' ) ) {
 		// if we haven't fetched the modules yet, we default to true
-		const modules = getSiteOption( state, siteId, 'active_modules' );
-		if ( ! modules || modules.length === 0 ) {
-			return true;
-		}
-		return isJetpackModuleActive( state, siteId, 'manage' );
+		const isModuleActive = isJetpackModuleActive( state, siteId, 'manage' );
+		return isModuleActive === null ? true : isModuleActive;
 	}
 	// for version lower than 3.4, we cannot not determine canManage, we'll assume they can
 	return true;

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -308,6 +308,7 @@ export function getSiteOption( state, siteId, optionName ) {
 	if ( ! site || ! site.options ) {
 		return null;
 	}
+
 	return site.options[ optionName ];
 }
 
@@ -618,9 +619,42 @@ export function canJetpackSiteManage( state, siteId ) {
 	return true;
 }
 
-// TODO: remove this once #8197 is merged
-export function canJetpackSiteUpdateFiles() {
-	return null;
+export function canJetpackSiteUpdateFiles( state, siteId ) {
+	if ( ! siteId ) {
+		return null;
+	}
+
+	if ( ! isJetpackSite( state, siteId ) ) {
+		return null;
+	}
+
+	if ( ! siteHasMinimumJetpackVersion( state, siteId ) ) {
+		return false;
+	}
+
+	const isMultiNetwork = getSiteOption( state, siteId, 'is_multi_network' );
+
+	if ( isMultiNetwork ) {
+		return false;
+	}
+
+	if ( ! isMainNetworkSite( state, siteId ) ) {
+		return false;
+	}
+
+	const fileModDisabled = getSiteOption( state, siteId, 'file_mod_disabled' );
+
+	if (
+		fileModDisabled &&
+		(
+			-1 < fileModDisabled.indexOf( 'disallow_file_mods' ) ||
+			-1 < fileModDisabled.indexOf( 'has_no_file_system_write_access' )
+		)
+	) {
+		return false;
+	}
+
+	return true;
 }
 
 /**
@@ -643,6 +677,38 @@ export function canJetpackSiteAutoUpdateFiles( state, siteId ) {
 	}
 
 	return true;
+}
+
+export function isMainNetworkSite( state, siteId ) {
+	const site = getRawSite( state, siteId );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	const isMultiNetwork = getSiteOption( state, siteId, 'is_multi_network' );
+
+	if ( isMultiNetwork ) {
+		return false;
+	}
+
+	if ( site.is_multisite === false ) {
+		return true;
+	}
+
+	if ( site.is_multisite ) {
+		const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
+		const mainNetworkSite = getSiteOption( state, siteId, 'main_network_site' );
+
+		if ( ! unmappedUrl || ! mainNetworkSite ) {
+			return false;
+		}
+
+		// Compare unmapped_url with the main_network_site to see if is the main network site.
+		return withoutHttp( unmappedUrl ) === withoutHttp( mainNetworkSite );
+	}
+
+	return false;
 }
 
 /**
@@ -796,4 +862,27 @@ export function getJetpackSiteFileModDisableReasons( state, siteId, action = 'mo
 		}
 		return null;
 	} ).filter( reason => reason );
+}
+
+/**
+ * Return true is the given Jetpack site has a version equal
+ * or greater than the minimum Jetpack version to operate.
+ *
+ * @param  {Object} state - whole state tree
+ * @param  {Number} siteId - site id
+ * @return {Boolean} true is the site has minimum jetpack version
+ */
+export function siteHasMinimumJetpackVersion( state, siteId ) {
+	if ( ! siteId ) {
+		return null;
+	}
+
+	if ( ! isJetpackSite( state, siteId ) ) {
+		return null;
+	}
+
+	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
+	const jetpackMinVersion = config( 'jetpack_min_version' );
+
+	return versionCompare( siteJetpackVersion, jetpackMinVersion ) >= 0;
 }

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -645,7 +645,7 @@ export function canJetpackSiteUpdateFiles( state, siteId ) {
 		return false;
 	}
 
-	if ( ! isMainNetworkSite( state, siteId ) ) {
+	if ( ! isJetpackSiteMainNetworkSite( state, siteId ) ) {
 		return false;
 	}
 
@@ -730,7 +730,7 @@ export function hasJetpackSiteJetpackThemes( state, siteId ) {
  * @param {Number} siteId Site ID
  * @return {Boolean} if the site is the main site
  */
-export function isMainNetworkSite( state, siteId ) {
+export function isJetpackSiteMainNetworkSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
 
 	if ( ! site ) {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -627,10 +627,6 @@ export function canJetpackSiteManage( state, siteId ) {
  * @return {Boolean} if the site can update its file
  */
 export function canJetpackSiteUpdateFiles( state, siteId ) {
-	if ( ! siteId ) {
-		return null;
-	}
-
 	if ( ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -872,8 +872,8 @@ export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action 
 }
 
 /**
- * Return true is the given Jetpack site has a version equal
- * or greater than the minimum Jetpack version to operate.
+ * Return true is the given Jetpack site has a version equal or greater than
+ * the minimum Jetpack version as set by the 'jetpack_min_version' config value.
  *
  * @param  {Object} state - whole state tree
  * @param  {Number} siteId - site id

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -597,7 +597,7 @@ export function hasStaticFrontPage( state, siteId ) {
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} if the site can be managed from calypso
+ * @return {?Boolean} if the site can be managed from calypso
  */
 export function canJetpackSiteManage( state, siteId ) {
 	// for versions 3.4 and higher, canManage can be determined by the state of the Manage Module

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import {
+	compact,
 	every,
 	filter,
 	find,
@@ -847,7 +848,7 @@ export function hasJetpackSiteCustomDomain( state, siteId ) {
 export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action = 'modifyFiles' ) {
 	const fileModDisabled = getSiteOption( state, siteId, 'file_mod_disabled' );
 
-	return fileModDisabled.map( clue => {
+	return compact( fileModDisabled.map( clue => {
 		if ( action === 'modifyFiles' || action === 'autoupdateFiles' || action === 'autoupdateCore' ) {
 			if ( clue === 'has_no_file_system_write_access' ) {
 				return i18n.translate( 'The file permissions on this host prevent editing files.' );
@@ -867,7 +868,7 @@ export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action 
 			return i18n.translate( 'Core autoupdates are explicitly disabled by a site administrator.' );
 		}
 		return null;
-	} ).filter( reason => reason );
+	} ) );
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -624,7 +624,7 @@ export function canJetpackSiteManage( state, siteId ) {
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {Boolean} if the site can update
+ * @return {Boolean} if the site can update its file
  */
 export function canJetpackSiteUpdateFiles( state, siteId ) {
 	if ( ! siteId ) {
@@ -851,7 +851,7 @@ export function hasJetpackSiteCustomDomain( state, siteId ) {
  * @param {String} action The update action we wanted to perform on this site
  * @return {?String} The reason why file update is disabled
  */
-export function getJetpackSiteFileModDisableReasons( state, siteId, action = 'modifyFiles' ) {
+export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action = 'modifyFiles' ) {
 	const fileModDisabled = getSiteOption( state, siteId, 'file_mod_disabled' );
 
 	return fileModDisabled.map( clue => {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -619,6 +619,13 @@ export function canJetpackSiteManage( state, siteId ) {
 	return true;
 }
 
+/**
+ * Determines if a Jetpack site can update its files.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId Site ID
+ * @return {Boolean} if the site can update
+ */
 export function canJetpackSiteUpdateFiles( state, siteId ) {
 	if ( ! siteId ) {
 		return null;
@@ -679,38 +686,6 @@ export function canJetpackSiteAutoUpdateFiles( state, siteId ) {
 	return true;
 }
 
-export function isMainNetworkSite( state, siteId ) {
-	const site = getRawSite( state, siteId );
-
-	if ( ! site ) {
-		return null;
-	}
-
-	const isMultiNetwork = getSiteOption( state, siteId, 'is_multi_network' );
-
-	if ( isMultiNetwork ) {
-		return false;
-	}
-
-	if ( site.is_multisite === false ) {
-		return true;
-	}
-
-	if ( site.is_multisite ) {
-		const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
-		const mainNetworkSite = getSiteOption( state, siteId, 'main_network_site' );
-
-		if ( ! unmappedUrl || ! mainNetworkSite ) {
-			return false;
-		}
-
-		// Compare unmapped_url with the main_network_site to see if is the main network site.
-		return withoutHttp( unmappedUrl ) === withoutHttp( mainNetworkSite );
-	}
-
-	return false;
-}
-
 /**
  * Determines if a Jetpack site can auto update WordPress core.
  *
@@ -744,6 +719,47 @@ export function hasJetpackSiteJetpackMenus( state, siteId ) {
 export function hasJetpackSiteJetpackThemes( state, siteId ) {
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
 	return versionCompare( siteJetpackVersion, '3.7-beta' ) >= 0;
+}
+
+/**
+ * Determines if a site is the main site in a Network
+ * True if it is either in a non multi-site configuration
+ * or if its url matches the `main_network_site` url option
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId Site ID
+ * @return {Boolean} if the site is the main site
+ */
+export function isMainNetworkSite( state, siteId ) {
+	const site = getRawSite( state, siteId );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	const isMultiNetwork = getSiteOption( state, siteId, 'is_multi_network' );
+
+	if ( isMultiNetwork ) {
+		return false;
+	}
+
+	if ( site.is_multisite === false ) {
+		return true;
+	}
+
+	if ( site.is_multisite ) {
+		const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
+		const mainNetworkSite = getSiteOption( state, siteId, 'main_network_site' );
+
+		if ( ! unmappedUrl || ! mainNetworkSite ) {
+			return false;
+		}
+
+		// Compare unmapped_url with the main_network_site to see if is the main network site.
+		return withoutHttp( unmappedUrl ) === withoutHttp( mainNetworkSite );
+	}
+
+	return false;
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1414,6 +1414,12 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#canJetpackSiteUpdateFiles()', () => {
+		let config;
+
+		useSandbox( ( sandbox ) => {
+			config = sandbox.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
+		} );
+
 		it( 'should return `null` for a non-existing site', () => {
 			const state = {
 				sites: {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1430,7 +1430,11 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					jetpack: true,
-					is_multi_network: true,
+					is_multisite: true,
+					options: {
+						is_multi_network: true,
+						jetpack_version: '3.4',
+					}
 				}
 			} );
 
@@ -1447,6 +1451,7 @@ describe( 'selectors', () => {
 					is_multisite: true,
 					options: {
 						is_multi_network: false,
+						jetpack_version: '3.4',
 						unmapped_url: 'https://example.wordpress.com',
 						main_network_site: 'https://anotherexample.wordpress.com'
 					}
@@ -1466,6 +1471,7 @@ describe( 'selectors', () => {
 					is_multisite: true,
 					options: {
 						is_multi_network: false,
+						jetpack_version: '3.4',
 						unmapped_url: 'https://example.wordpress.com',
 						main_network_site: 'https://example.wordpress.com',
 						file_mod_disabled: [
@@ -1488,6 +1494,7 @@ describe( 'selectors', () => {
 					is_multisite: true,
 					options: {
 						is_multi_network: false,
+						jetpack_version: '3.4',
 						unmapped_url: 'https://example.wordpress.com',
 						main_network_site: 'https://example.wordpress.com',
 						file_mod_disabled: [
@@ -1510,6 +1517,7 @@ describe( 'selectors', () => {
 					is_multisite: true,
 					options: {
 						is_multi_network: false,
+						jetpack_version: '3.4',
 						unmapped_url: 'https://example.wordpress.com',
 						main_network_site: 'https://example.wordpress.com',
 						file_mod_disabled: []
@@ -1518,7 +1526,7 @@ describe( 'selectors', () => {
 			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
-			expect( canUpdateFiles ).to.equal( false );
+			expect( canUpdateFiles ).to.equal( true );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -41,7 +41,7 @@ import {
 	verifyJetpackModulesActive,
 	getJetpackSiteRemoteManagementURL,
 	hasJetpackSiteCustomDomain,
-	getJetpackSiteFileModDisableReasons,
+	getJetpackSiteUpdateFilesDisabledReasons,
 	siteHasMinimumJetpackVersion,
 	isJetpackSiteMainNetworkSite
 } from '../selectors';
@@ -1927,7 +1927,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getJetpackSiteFileModDisableReasons()', () => {
+	describe( '#getJetpackSiteUpdateFilesDisabledReasons()', () => {
 		it( 'it should have the correct reason for the clue `has_no_file_system_write_access`', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
@@ -1938,7 +1938,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			const reason = getJetpackSiteFileModDisableReasons( state, siteId );
+			const reason = getJetpackSiteUpdateFilesDisabledReasons( state, siteId );
 			expect( reason ).to.deep.equal( [ 'The file permissions on this host prevent editing files.' ] );
 		} );
 
@@ -1952,7 +1952,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			const reason = getJetpackSiteFileModDisableReasons( state, siteId );
+			const reason = getJetpackSiteUpdateFilesDisabledReasons( state, siteId );
 			expect( reason ).to.deep.equal( [ 'File modifications are explicitly disabled by a site administrator.' ] );
 		} );
 
@@ -1966,7 +1966,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			const reason = getJetpackSiteFileModDisableReasons( state, siteId, 'autoupdateCore' );
+			const reason = getJetpackSiteUpdateFilesDisabledReasons( state, siteId, 'autoupdateCore' );
 			expect( reason ).to.deep.equal( [ 'Any autoupdates are explicitly disabled by a site administrator.' ] );
 		} );
 
@@ -1980,7 +1980,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			const reason = getJetpackSiteFileModDisableReasons( state, siteId, 'autoupdateCore' );
+			const reason = getJetpackSiteUpdateFilesDisabledReasons( state, siteId, 'autoupdateCore' );
 			expect( reason ).to.deep.equal( [ 'Core autoupdates are explicitly disabled by a site administrator.' ] );
 		} );
 	} );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -33,6 +33,7 @@ import {
 	getSiteFrontPageType,
 	hasStaticFrontPage,
 	canJetpackSiteManage,
+	canJetpackSiteUpdateFiles,
 	canJetpackSiteAutoUpdateFiles,
 	hasJetpackSiteJetpackMenus,
 	hasJetpackSiteJetpackThemes,
@@ -42,7 +43,7 @@ import {
 	hasJetpackSiteCustomDomain,
 	getJetpackSiteFileModDisableReasons,
 	siteHasMinimumJetpackVersion,
-	isMainNetworkSite,
+	isMainNetworkSite
 } from '../selectors';
 
 /**
@@ -1412,6 +1413,187 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( '#canJetpackSiteUpdateFiles()', () => {
+		it( 'should return `null` for a non-existing site', () => {
+			const state = {
+				sites: {
+					items: {}
+				}
+			};
+			let siteId;
+
+			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
+			expect( canUpdateFiles ).to.equal( null );
+		} );
+
+		it( 'it should return `false` for a non jetpack site', () => {
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: false,
+						}
+					}
+				}
+			};
+
+			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
+			expect( canUpdateFiles ).to.equal( null );
+		} );
+
+		it( 'it should return `false` if jetpack version is smaller than minimum version', () => {
+			const jetpackMinVersion = config( 'jetpack_min_version' );
+			const smallerVersion = changeVersion( jetpackMinVersion, -1 );
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: true,
+							options: {
+								jetpack_version: smallerVersion
+							}
+						}
+					}
+				}
+			};
+
+			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
+			expect( canUpdateFiles ).to.equal( false );
+		} );
+
+		it( 'it should return `false` if is a multi-network site', () => {
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: true,
+							is_multi_network: true,
+						}
+					}
+				}
+			};
+
+			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
+			expect( canUpdateFiles ).to.equal( false );
+		} );
+
+		it( 'it should return `false` if is not a main network site (urls don\'t match)', () => {
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: true,
+							URL: 'https://jetpacksite.me',
+							is_multisite: true,
+							options: {
+								is_multi_network: false,
+								unmapped_url: 'https://example.wordpress.com',
+								main_network_site: 'https://anotherexample.wordpress.com'
+							}
+						}
+					}
+				}
+			};
+
+			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
+			expect( canUpdateFiles ).to.equal( false );
+		} );
+
+		it( 'it should return `false` if `disallow_file_mods` is disabled', () => {
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: true,
+							URL: 'https://jetpacksite.me',
+							is_multisite: true,
+							options: {
+								is_multi_network: false,
+								unmapped_url: 'https://example.wordpress.com',
+								main_network_site: 'https://example.wordpress.com',
+								file_mod_disabled: [
+									'disallow_file_mods',
+								]
+							}
+						}
+					}
+				}
+			};
+
+			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
+			expect( canUpdateFiles ).to.equal( false );
+		} );
+
+		it( 'it should return `false` if `has_no_file_system_write_access` is disabled', () => {
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: true,
+							URL: 'https://jetpacksite.me',
+							is_multisite: true,
+							options: {
+								is_multi_network: false,
+								unmapped_url: 'https://example.wordpress.com',
+								main_network_site: 'https://example.wordpress.com',
+								file_mod_disabled: [
+									'has_no_file_system_write_access',
+								]
+							}
+						}
+					}
+				}
+			};
+
+			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
+			expect( canUpdateFiles ).to.equal( false );
+		} );
+
+		it( 'it should return `true` for the site right configurations', () => {
+			const siteId = 77203074;
+
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: siteId,
+							jetpack: true,
+							URL: 'https://jetpacksite.me',
+							is_multisite: true,
+							options: {
+								is_multi_network: false,
+								unmapped_url: 'https://example.wordpress.com',
+								main_network_site: 'https://example.wordpress.com',
+								file_mod_disabled: []
+							}
+						}
+					}
+				}
+			};
+
+			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
+			expect( canUpdateFiles ).to.equal( false );
+		} );
+	} );
+
 	describe( '#canJetpackSiteAutoUpdateFiles()', () => {
 		it( 'it should return `true` if the `file_mod_disabled` option does not contain `automatic_updater_disabled`', () => {
 			const siteId = 77203074;
@@ -1516,7 +1698,7 @@ describe( 'selectors', () => {
 
 		it( 'it should return `true` if jetpack version is equal to minimum version', () => {
 			const jetpackMinVersion = config( 'jetpack_min_version' );
-			const greaterVersion = jetpackMinVersion;
+			const equalVersion = jetpackMinVersion;
 			const siteId = 77203074;
 
 			const state = {
@@ -1526,7 +1708,7 @@ describe( 'selectors', () => {
 							ID: siteId,
 							jetpack: true,
 							options: {
-								jetpack_version: greaterVersion
+								jetpack_version: equalVersion
 							}
 						}
 					}

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -7,7 +7,6 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import config from 'config';
-import i18n from 'i18n-calypso';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	getSite,
@@ -2191,7 +2190,7 @@ describe( 'selectors', () => {
 			};
 
 			const reason = getJetpackSiteFileModDisableReasons( state, siteId );
-			expect( reason ).to.deep.equal( [ i18n.translate( 'The file permissions on this host prevent editing files.' ) ] );
+			expect( reason ).to.deep.equal( [ 'The file permissions on this host prevent editing files.' ] );
 		} );
 
 		it( 'it should have the correct reason for the clue `disallow_file_mods`', () => {
@@ -2211,7 +2210,7 @@ describe( 'selectors', () => {
 			};
 
 			const reason = getJetpackSiteFileModDisableReasons( state, siteId );
-			expect( reason ).to.deep.equal( [ i18n.translate( 'File modifications are explicitly disabled by a site administrator.' ) ] );
+			expect( reason ).to.deep.equal( [ 'File modifications are explicitly disabled by a site administrator.' ] );
 		} );
 
 		it( 'it should have the correct reason for the clue `automatic_updater_disabled`', () => {
@@ -2231,7 +2230,7 @@ describe( 'selectors', () => {
 			};
 
 			const reason = getJetpackSiteFileModDisableReasons( state, siteId, 'autoupdateCore' );
-			expect( reason ).to.deep.equal( [ i18n.translate( 'Any autoupdates are explicitly disabled by a site administrator.' ) ] );
+			expect( reason ).to.deep.equal( [ 'Any autoupdates are explicitly disabled by a site administrator.' ] );
 		} );
 
 		it( 'it should have the correct reason for the clue `wp_auto_update_core_disabled`', () => {
@@ -2251,7 +2250,7 @@ describe( 'selectors', () => {
 			};
 
 			const reason = getJetpackSiteFileModDisableReasons( state, siteId, 'autoupdateCore' );
-			expect( reason ).to.deep.equal( [ i18n.translate( 'Core autoupdates are explicitly disabled by a site administrator.' ) ] );
+			expect( reason ).to.deep.equal( [ 'Core autoupdates are explicitly disabled by a site administrator.' ] );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1684,6 +1684,7 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
+					jetpack: true,
 					is_multisite: false
 				}
 			} );
@@ -1697,6 +1698,7 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
+					jetpack: true,
 					options: {
 						is_multi_network: false
 					}
@@ -1712,6 +1714,7 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
+					jetpack: true,
 					is_multisite: true,
 					options: {
 						is_multi_network: false,
@@ -1729,6 +1732,7 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
+					jetpack: true,
 					is_multisite: true,
 					options: {
 						is_multi_network: false,
@@ -1746,6 +1750,7 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
+					jetpack: true,
 					is_multisite: true,
 					options: {
 						unmapped_url: 'https://secondary.wordpress.com',
@@ -1769,6 +1774,7 @@ describe( 'selectors', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
+					jetpack: false,
 					options: {}
 				}
 			} );
@@ -1876,6 +1882,7 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
+					jetpack: true,
 					options: {
 						unmapped_url: 'https://jetpack.co'
 					}
@@ -1891,6 +1898,7 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
+					jetpack: true,
 					options: {
 						unmapped_url: 'https://jetpacksite.me'
 					}
@@ -1907,6 +1915,7 @@ describe( 'selectors', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
+					jetpack: true,
 					options: {
 						file_mod_disabled: [ 'has_no_file_system_write_access' ]
 					}
@@ -1921,6 +1930,7 @@ describe( 'selectors', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
+					jetpack: true,
 					options: {
 						file_mod_disabled: [ 'disallow_file_mods' ]
 					}
@@ -1935,6 +1945,7 @@ describe( 'selectors', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
+					jetpack: true,
 					options: {
 						file_mod_disabled: [ 'automatic_updater_disabled' ]
 					}
@@ -1949,6 +1960,7 @@ describe( 'selectors', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
+					jetpack: true,
 					options: {
 						file_mod_disabled: [ 'wp_auto_update_core_disabled' ]
 					}
@@ -1971,6 +1983,7 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
+					jetpack: true,
 					options: {
 						is_multi_network: true
 					}
@@ -1986,6 +1999,7 @@ describe( 'selectors', () => {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
+					jetpack: true,
 					is_multisite: false,
 				}
 			} );
@@ -2000,6 +2014,7 @@ describe( 'selectors', () => {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
 					is_multisite: true,
+					jetpack: true,
 					options: {
 						is_multi_network: false,
 						main_network_site: 'https://example.wordpress.com'
@@ -2017,6 +2032,7 @@ describe( 'selectors', () => {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
 					is_multisite: true,
+					jetpack: true,
 					options: {
 						is_multi_network: false,
 						unmapped_url: 'https://example.wordpress.com'
@@ -2034,6 +2050,7 @@ describe( 'selectors', () => {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
 					is_multisite: true,
+					jetpack: true,
 					options: {
 						is_multi_network: false,
 						unmapped_url: 'https://example.wordpress.com',

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -56,14 +56,14 @@ function changeVersion( version, operator = 1 ) {
 	const splitVersion = version.split( '.' );
 
 	if ( operator >= 1 ) {
-		splitVersion[ splitVersion.length - 1 ] ++;
+		splitVersion[ splitVersion.length - 1 ]++;
 		return splitVersion.join( '.' );
 	}
 
 	if ( splitVersion[ splitVersion.length - 1 ] === '0' ) {
-		splitVersion[ splitVersion.length - 2 ] --;
+		splitVersion[ splitVersion.length - 2 ]--;
 	} else {
-		splitVersion[ splitVersion.length - 1 ] --;
+		splitVersion[ splitVersion.length - 1 ]--;
 	}
 
 	return splitVersion.join( '.' );
@@ -1385,10 +1385,10 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#canJetpackSiteUpdateFiles()', () => {
-		let config;
+		let configStub;
 
 		useSandbox( ( sandbox ) => {
-			config = sandbox.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
+			configStub = sandbox.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
 		} );
 
 		it( 'should return `null` for a non-existing site', () => {
@@ -1409,7 +1409,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'it should return `false` if jetpack version is smaller than minimum version', () => {
-			const jetpackMinVersion = config( 'jetpack_min_version' );
+			const jetpackMinVersion = configStub( 'jetpack_min_version' );
 			const smallerVersion = changeVersion( jetpackMinVersion, -1 );
 			const state = createStateWithItems( {
 				[ siteId ]: {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3,6 +3,7 @@
  */
 import deepFreeze from 'deep-freeze';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -1385,11 +1386,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#canJetpackSiteUpdateFiles()', () => {
-		let configStub;
-
-		useSandbox( ( sandbox ) => {
-			configStub = sandbox.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
-		} );
+		const configStub = sinon.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
 
 		it( 'should return `null` for a non-existing site', () => {
 			const canUpdateFiles = canJetpackSiteUpdateFiles( stateWithNoItems, nonExistingSiteId );
@@ -1569,11 +1566,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#siteHasMinimumJetpackVersion()', () => {
-		let configStub;
-
-		useSandbox( ( sandbox ) => {
-			configStub = sandbox.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
-		} );
+		const configStub = sinon.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
 
 		it( 'it should return `null` for a non-existing site', () => {
 			const hasMinimumVersion = siteHasMinimumJetpackVersion( stateWithNoItems, nonExistingSiteId );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import deepFreeze from 'deep-freeze';
 import { expect } from 'chai';
 
 /**
@@ -55,20 +56,28 @@ function changeVersion( version, operator = 1 ) {
 	const splitVersion = version.split( '.' );
 
 	if ( operator >= 1 ) {
-		splitVersion[ splitVersion.length - 1 ]++;
+		splitVersion[ splitVersion.length - 1 ] ++;
 		return splitVersion.join( '.' );
 	}
 
 	if ( splitVersion[ splitVersion.length - 1 ] === '0' ) {
-		splitVersion[ splitVersion.length - 2 ]--;
+		splitVersion[ splitVersion.length - 2 ] --;
 	} else {
-		splitVersion[ splitVersion.length - 1 ]--;
+		splitVersion[ splitVersion.length - 1 ] --;
 	}
 
 	return splitVersion.join( '.' );
 }
 
 describe( 'selectors', () => {
+	const createStateWithItems = items => deepFreeze( {
+		sites: { items }
+	} );
+
+	const siteId = 77203074;
+	const nonExistingSiteId = 123;
+	const stateWithNoItems = createStateWithItems( {} );
+
 	beforeEach( () => {
 		getSite.memoizedSelector.cache.clear();
 		getSiteCollisions.memoizedSelector.cache.clear();
@@ -1291,121 +1300,84 @@ describe( 'selectors', () => {
 
 	describe( '#canJetpackSiteManage()', () => {
 		it( 'it should return `null` for a non-existing site', () => {
-			const state = {
-				sites: {
-					items: {}
-				}
-			};
-			const siteId = 123;
-
-			const canManage = canJetpackSiteManage( state, siteId );
+			const canManage = canJetpackSiteManage( stateWithNoItems, nonExistingSiteId );
 			expect( canManage ).to.equal( null );
 		} );
 
 		it( 'it should return `null` for a non jetpack site', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: false
-						}
-					}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: false
 				}
-			};
+			} );
 
 			const canManage = canJetpackSiteManage( state, siteId );
 			expect( canManage ).to.equal( null );
 		} );
 
 		it( 'it should return `true` if jetpack version is strictly less than 3.4', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								jetpack_version: '3.3'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						jetpack_version: '3.3'
 					}
 				}
-			};
+			} );
 
 			const canManage = canJetpackSiteManage( state, siteId );
 			expect( canManage ).to.equal( true );
 		} );
 
 		it( 'it should return `true` if the modules has not yet been fetched', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								active_modules: [],
-								jetpack_version: '3.4'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						active_modules: [],
+						jetpack_version: '3.4'
 					}
 				}
-			};
+			} );
 
 			const canManage = canJetpackSiteManage( state, siteId );
 			expect( canManage ).to.equal( true );
 		} );
 
 		it( 'it should return `true` if jetpack version is greater or equal to 3.4 and the manage module is active', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								active_modules: [ 'manage' ],
-								jetpack_version: '3.4'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						active_modules: [ 'manage' ],
+						jetpack_version: '3.4'
 					}
 				}
-			};
+			} );
 
 			const canManage = canJetpackSiteManage( state, siteId );
 			expect( canManage ).to.equal( true );
 		} );
 
 		it( 'it should return `false` if jetpack version is greater or equal to 3.4 and the manage module is not active', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								active_modules: [ 'sso' ],
-								jetpack_version: '3.4'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						active_modules: [ 'sso' ],
+						jetpack_version: '3.4'
 					}
 				}
-			};
+			} );
 
 			const canManage = canJetpackSiteManage( state, siteId );
 			expect( canManage ).to.equal( false );
@@ -1420,30 +1392,17 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return `null` for a non-existing site', () => {
-			const state = {
-				sites: {
-					items: {}
-				}
-			};
-			const siteId = 123;
-
-			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
+			const canUpdateFiles = canJetpackSiteUpdateFiles( stateWithNoItems, nonExistingSiteId );
 			expect( canUpdateFiles ).to.equal( null );
 		} );
 
 		it( 'it should return `false` for a non jetpack site', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: false,
-						}
-					}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: false,
 				}
-			};
+			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
 			expect( canUpdateFiles ).to.equal( null );
@@ -1452,147 +1411,111 @@ describe( 'selectors', () => {
 		it( 'it should return `false` if jetpack version is smaller than minimum version', () => {
 			const jetpackMinVersion = config( 'jetpack_min_version' );
 			const smallerVersion = changeVersion( jetpackMinVersion, -1 );
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: true,
-							options: {
-								jetpack_version: smallerVersion
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true,
+					options: {
+						jetpack_version: smallerVersion
 					}
 				}
-			};
+			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
 			expect( canUpdateFiles ).to.equal( false );
 		} );
 
 		it( 'it should return `false` if is a multi-network site', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: true,
-							is_multi_network: true,
-						}
-					}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true,
+					is_multi_network: true,
 				}
-			};
+			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
 			expect( canUpdateFiles ).to.equal( false );
 		} );
 
 		it( 'it should return `false` if is not a main network site (urls don\'t match)', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: true,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								is_multi_network: false,
-								unmapped_url: 'https://example.wordpress.com',
-								main_network_site: 'https://anotherexample.wordpress.com'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						is_multi_network: false,
+						unmapped_url: 'https://example.wordpress.com',
+						main_network_site: 'https://anotherexample.wordpress.com'
 					}
 				}
-			};
+			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
 			expect( canUpdateFiles ).to.equal( false );
 		} );
 
 		it( 'it should return `false` if `disallow_file_mods` is disabled', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: true,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								is_multi_network: false,
-								unmapped_url: 'https://example.wordpress.com',
-								main_network_site: 'https://example.wordpress.com',
-								file_mod_disabled: [
-									'disallow_file_mods',
-								]
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						is_multi_network: false,
+						unmapped_url: 'https://example.wordpress.com',
+						main_network_site: 'https://example.wordpress.com',
+						file_mod_disabled: [
+							'disallow_file_mods',
+						]
 					}
 				}
-			};
+			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
 			expect( canUpdateFiles ).to.equal( false );
 		} );
 
 		it( 'it should return `false` if `has_no_file_system_write_access` is disabled', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: true,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								is_multi_network: false,
-								unmapped_url: 'https://example.wordpress.com',
-								main_network_site: 'https://example.wordpress.com',
-								file_mod_disabled: [
-									'has_no_file_system_write_access',
-								]
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						is_multi_network: false,
+						unmapped_url: 'https://example.wordpress.com',
+						main_network_site: 'https://example.wordpress.com',
+						file_mod_disabled: [
+							'has_no_file_system_write_access',
+						]
 					}
 				}
-			};
+			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
 			expect( canUpdateFiles ).to.equal( false );
 		} );
 
 		it( 'it should return `true` for the site right configurations', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: true,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								is_multi_network: false,
-								unmapped_url: 'https://example.wordpress.com',
-								main_network_site: 'https://example.wordpress.com',
-								file_mod_disabled: []
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						is_multi_network: false,
+						unmapped_url: 'https://example.wordpress.com',
+						main_network_site: 'https://example.wordpress.com',
+						file_mod_disabled: []
 					}
 				}
-			};
+			} );
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
 			expect( canUpdateFiles ).to.equal( false );
@@ -1601,46 +1524,36 @@ describe( 'selectors', () => {
 
 	describe( '#canJetpackSiteAutoUpdateFiles()', () => {
 		it( 'it should return `true` if the `file_mod_disabled` option does not contain `automatic_updater_disabled`', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: false,
-							jetpack: true,
-							options: {
-								file_mod_disabled: [],
-								jetpack_version: '3.4'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: false,
+					jetpack: true,
+					options: {
+						file_mod_disabled: [],
+						jetpack_version: '3.4'
 					}
 				}
-			};
+			} );
 
 			const canAutoUpdateFiles = canJetpackSiteAutoUpdateFiles( state, siteId );
 			expect( canAutoUpdateFiles ).to.equal( true );
 		} );
 
 		it( 'it should return `true` if the `file_mod_disabled` option contains `automatic_updater_disabled`', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: false,
-							jetpack: true,
-							options: {
-								file_mod_disabled: [ 'automatic_updater_disabled' ],
-								jetpack_version: '3.4'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: false,
+					jetpack: true,
+					options: {
+						file_mod_disabled: [ 'automatic_updater_disabled' ],
+						jetpack_version: '3.4'
 					}
 				}
-			};
+			} );
 
 			const canAutoUpdateFiles = canJetpackSiteAutoUpdateFiles( state, siteId );
 			expect( canAutoUpdateFiles ).to.equal( false );
@@ -1649,30 +1562,17 @@ describe( 'selectors', () => {
 
 	describe( '#siteHasMinimumJetpackVersion()', () => {
 		it( 'it should return `null` for a non-existing site', () => {
-			const state = {
-				sites: {
-					items: {}
-				}
-			};
-			const siteId = 123;
-
-			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
+			const hasMinimumVersion = siteHasMinimumJetpackVersion( stateWithNoItems, nonExistingSiteId );
 			expect( hasMinimumVersion ).to.equal( null );
 		} );
 
 		it( 'it should return `null` for a non jetpack site', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: false,
-						}
-					}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: false,
 				}
-			};
+			} );
 
 			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
 			expect( hasMinimumVersion ).to.equal( null );
@@ -1681,21 +1581,15 @@ describe( 'selectors', () => {
 		it( 'it should return `true` if jetpack version is greater that minimum version', () => {
 			const jetpackMinVersion = config( 'jetpack_min_version' );
 			const greaterVersion = changeVersion( jetpackMinVersion );
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: true,
-							options: {
-								jetpack_version: greaterVersion
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true,
+					options: {
+						jetpack_version: greaterVersion
 					}
 				}
-			};
+			} );
 
 			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
 			expect( hasMinimumVersion ).to.equal( true );
@@ -1704,21 +1598,15 @@ describe( 'selectors', () => {
 		it( 'it should return `true` if jetpack version is equal to minimum version', () => {
 			const jetpackMinVersion = config( 'jetpack_min_version' );
 			const equalVersion = jetpackMinVersion;
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: true,
-							options: {
-								jetpack_version: equalVersion
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true,
+					options: {
+						jetpack_version: equalVersion
 					}
 				}
-			};
+			} );
 
 			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
 			expect( hasMinimumVersion ).to.equal( true );
@@ -1727,21 +1615,15 @@ describe( 'selectors', () => {
 		it( 'it should return `false` if jetpack version is smaller than minimum version', () => {
 			const jetpackMinVersion = config( 'jetpack_min_version' );
 			const smallerVersion = changeVersion( jetpackMinVersion, -1 );
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							jetpack: true,
-							options: {
-								jetpack_version: smallerVersion
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true,
+					options: {
+						jetpack_version: smallerVersion
 					}
 				}
-			};
+			} );
 
 			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
 			expect( hasMinimumVersion ).to.equal( false );
@@ -1750,44 +1632,32 @@ describe( 'selectors', () => {
 
 	describe( '#hasJetpackSiteJetpackMenus()', () => {
 		it( 'it should return `false` if jetpack version is smaller than 3.5-alpha', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								jetpack_version: '3.4'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						jetpack_version: '3.4'
 					}
 				}
-			};
+			} );
 
 			const hasMenus = hasJetpackSiteJetpackMenus( state, siteId );
 			expect( hasMenus ).to.equal( false );
 		} );
 
 		it( 'it should return `true` if jetpack version is greater or equal to 3.5-alpha', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								jetpack_version: '3.5'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						jetpack_version: '3.5'
 					}
 				}
-			};
+			} );
 
 			const hasMenus = hasJetpackSiteJetpackMenus( state, siteId );
 			expect( hasMenus ).to.equal( true );
@@ -1796,44 +1666,32 @@ describe( 'selectors', () => {
 
 	describe( '#hasJetpackSiteJetpackThemes()', () => {
 		it( 'it should return `false` if jetpack version is smaller than 3.7-beta', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								jetpack_version: '3.7-alpha'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						jetpack_version: '3.7-alpha'
 					}
 				}
-			};
+			} );
 
 			const hasThemes = hasJetpackSiteJetpackThemes( state, siteId );
 			expect( hasThemes ).to.equal( false );
 		} );
 
 		it( 'it should return `true` if jetpack version is greater or equal to 3.7-beta', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								jetpack_version: '3.7'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						jetpack_version: '3.7'
 					}
 				}
-			};
+			} );
 
 			const hasThemes = hasJetpackSiteJetpackThemes( state, siteId );
 			expect( hasThemes ).to.equal( true );
@@ -1842,116 +1700,84 @@ describe( 'selectors', () => {
 
 	describe( '#isJetpackSiteSecondaryNetworkSite()', () => {
 		it( 'should return `null` for a non-existing site', () => {
-			const state = {
-				sites: {
-					items: {}
-				}
-			};
-			const siteId = 123;
-
-			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
+			const isSecondary = isJetpackSiteSecondaryNetworkSite( stateWithNoItems, nonExistingSiteId );
 			expect( isSecondary ).to.equal( null );
 		} );
 
 		it( 'it should return `false` for non multisite site', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: false
-						}
-					}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: false
 				}
-			};
+			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
 			expect( isSecondary ).to.equal( false );
 		} );
 
 		it( 'it should return `false` for non-multisite/non-multinetwork sites', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							options: {
-								is_multi_network: false
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					options: {
+						is_multi_network: false
 					}
 				}
-			};
+			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
 			expect( isSecondary ).to.equal( false );
 		} );
 
 		it( 'it should return `false` for multisite sites without unmapped url', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								is_multi_network: false,
-								main_network_site: 'https://example.wordpress.com'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						is_multi_network: false,
+						main_network_site: 'https://example.wordpress.com'
 					}
 				}
-			};
+			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
 			expect( isSecondary ).to.equal( false );
 		} );
 
 		it( 'it should return `false` for multisite sites without main_network_site', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								is_multi_network: false,
-								unmapped_url: 'https://example.wordpress.com'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						is_multi_network: false,
+						unmapped_url: 'https://example.wordpress.com'
 					}
 				}
-			};
+			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
 			expect( isSecondary ).to.equal( false );
 		} );
 
 		it( 'it should return `true` for multisite sites which unmapped_url does not match with main_network_site', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								unmapped_url: 'https://secondary.wordpress.com',
-								main_network_site: 'https://example.wordpress.com'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						unmapped_url: 'https://secondary.wordpress.com',
+						main_network_site: 'https://example.wordpress.com'
 					}
 				}
-			};
+			} );
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
 			expect( isSecondary ).to.equal( true );
@@ -1960,75 +1786,49 @@ describe( 'selectors', () => {
 
 	describe( '#verifyJetpackModulesActive()', () => {
 		it( 'should return `null` for a non-existing site', () => {
-			const state = {
-				sites: {
-					items: {}
-				}
-			};
-			const siteId = 123;
-
-			const modulesActive = verifyJetpackModulesActive( state, siteId, [ 'manage' ] );
+			const modulesActive = verifyJetpackModulesActive( stateWithNoItems, nonExistingSiteId, [ 'manage' ] );
 			expect( modulesActive ).to.equal( null );
 		} );
 
 		it( 'it should return `null` for a non jetpack site', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							options: {
-							}
-						}
-					}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					options: {}
 				}
-			};
+			} );
 
 			const modulesActive = verifyJetpackModulesActive( state, siteId, [ 'manage' ] );
 			expect( modulesActive ).to.equal( null );
 		} );
 
 		it( 'it should return `true` if all given modules are active for a site', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								active_modules: [ 'manage', 'sso', 'photon', 'omnisearch' ]
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						active_modules: [ 'manage', 'sso', 'photon', 'omnisearch' ]
 					}
 				}
-			};
+			} );
 
 			const modulesActive = verifyJetpackModulesActive( state, siteId, [ 'omnisearch', 'sso', 'photon' ] );
 			expect( modulesActive ).to.equal( true );
 		} );
 
 		it( 'it should return `false` if not all given modules are active for a site', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								active_modules: [ 'manage', 'sso', 'photon', 'omnisearch' ]
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						active_modules: [ 'manage', 'sso', 'photon', 'omnisearch' ]
 					}
 				}
-			};
+			} );
 
 			const modulesActive = verifyJetpackModulesActive( state, siteId, [ 'after-the-deadline', 'manage' ] );
 			expect( modulesActive ).to.equal( false );
@@ -2037,79 +1837,53 @@ describe( 'selectors', () => {
 
 	describe( '#getJetpackSiteRemoteManagementURL()', () => {
 		it( 'should return `null` for a non-existing site', () => {
-			const state = {
-				sites: {
-					items: {}
-				}
-			};
-			const siteId = 123;
-
-			const managementUrl = getJetpackSiteRemoteManagementURL( state, siteId );
+			const managementUrl = getJetpackSiteRemoteManagementURL( stateWithNoItems, nonExistingSiteId );
 			expect( managementUrl ).to.equal( null );
 		} );
 
 		it( 'it should return `false` for a non jetpack site', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							options: {
-							}
-						}
-					}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					options: {}
 				}
-			};
+			} );
 
 			const managementUrl = getJetpackSiteRemoteManagementURL( state, siteId );
 			expect( managementUrl ).to.equal( null );
 		} );
 
 		it( 'it should return the correct url for version of jetpack less than 3.4', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								active_modules: [ 'manage', 'sso', 'photon', 'omnisearch' ],
-								admin_url: 'https://jetpacksite.me/wp-admin/',
-								jetpack_version: '3.3'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						active_modules: [ 'manage', 'sso', 'photon', 'omnisearch' ],
+						admin_url: 'https://jetpacksite.me/wp-admin/',
+						jetpack_version: '3.3'
 					}
 				}
-			};
+			} );
 
 			const managementUrl = getJetpackSiteRemoteManagementURL( state, siteId );
 			expect( managementUrl ).to.equal( 'https://jetpacksite.me/wp-admin/admin.php?page=jetpack&configure=manage' );
 		} );
 
 		it( 'it should return the correct url for versions of jetpack greater than or equal to 3.4', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							jetpack: true,
-							options: {
-								active_modules: [ 'manage', 'sso', 'photon', 'omnisearch' ],
-								admin_url: 'https://jetpacksite.me/wp-admin/',
-								jetpack_version: '3.4'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						active_modules: [ 'manage', 'sso', 'photon', 'omnisearch' ],
+						admin_url: 'https://jetpacksite.me/wp-admin/',
+						jetpack_version: '3.4'
 					}
 				}
-			};
+			} );
 
 			const managementUrl = getJetpackSiteRemoteManagementURL( state, siteId );
 			expect( managementUrl ).to.equal( 'https://jetpacksite.me/wp-admin/admin.php?page=jetpack&configure=json-api' );
@@ -2118,54 +1892,35 @@ describe( 'selectors', () => {
 
 	describe( '#hasJetpackSiteCustomDomain()', () => {
 		it( 'should return `null` for a non-existing site', () => {
-			const state = {
-				sites: {
-					items: {}
-				}
-			};
-			const siteId = 123;
-
-			const hasCustomDomain = hasJetpackSiteCustomDomain( state, siteId );
+			const hasCustomDomain = hasJetpackSiteCustomDomain( stateWithNoItems, nonExistingSiteId );
 			expect( hasCustomDomain ).to.equal( null );
 		} );
 
 		it( 'it should return `true` if `URL` and `unmapped_url` have the same domain', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							options: {
-								unmapped_url: 'https://jetpack.co'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					options: {
+						unmapped_url: 'https://jetpack.co'
 					}
 				}
-			};
+			} );
 
 			const hasCustomDomain = hasJetpackSiteCustomDomain( state, siteId );
 			expect( hasCustomDomain ).to.equal( true );
 		} );
 
 		it( 'it should return `false` if `URL` and `unmapped_url` have different domains', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							options: {
-								unmapped_url: 'https://jetpacksite.me'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					options: {
+						unmapped_url: 'https://jetpacksite.me'
 					}
 				}
-			};
+			} );
 
 			const hasCustomDomain = hasJetpackSiteCustomDomain( state, siteId );
 			expect( hasCustomDomain ).to.equal( false );
@@ -2174,80 +1929,56 @@ describe( 'selectors', () => {
 
 	describe( '#getJetpackSiteFileModDisableReasons()', () => {
 		it( 'it should have the correct reason for the clue `has_no_file_system_write_access`', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							options: {
-								file_mod_disabled: [ 'has_no_file_system_write_access' ]
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					options: {
+						file_mod_disabled: [ 'has_no_file_system_write_access' ]
 					}
 				}
-			};
+			} );
 
 			const reason = getJetpackSiteFileModDisableReasons( state, siteId );
 			expect( reason ).to.deep.equal( [ 'The file permissions on this host prevent editing files.' ] );
 		} );
 
 		it( 'it should have the correct reason for the clue `disallow_file_mods`', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							options: {
-								file_mod_disabled: [ 'disallow_file_mods' ]
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					options: {
+						file_mod_disabled: [ 'disallow_file_mods' ]
 					}
 				}
-			};
+			} );
 
 			const reason = getJetpackSiteFileModDisableReasons( state, siteId );
 			expect( reason ).to.deep.equal( [ 'File modifications are explicitly disabled by a site administrator.' ] );
 		} );
 
 		it( 'it should have the correct reason for the clue `automatic_updater_disabled`', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							options: {
-								file_mod_disabled: [ 'automatic_updater_disabled' ]
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					options: {
+						file_mod_disabled: [ 'automatic_updater_disabled' ]
 					}
 				}
-			};
+			} );
 
 			const reason = getJetpackSiteFileModDisableReasons( state, siteId, 'autoupdateCore' );
 			expect( reason ).to.deep.equal( [ 'Any autoupdates are explicitly disabled by a site administrator.' ] );
 		} );
 
 		it( 'it should have the correct reason for the clue `wp_auto_update_core_disabled`', () => {
-			const siteId = 77203074;
-
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							options: {
-								file_mod_disabled: [ 'wp_auto_update_core_disabled' ]
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					options: {
+						file_mod_disabled: [ 'wp_auto_update_core_disabled' ]
 					}
 				}
-			};
+			} );
 
 			const reason = getJetpackSiteFileModDisableReasons( state, siteId, 'autoupdateCore' );
 			expect( reason ).to.deep.equal( [ 'Core autoupdates are explicitly disabled by a site administrator.' ] );
@@ -2256,117 +1987,85 @@ describe( 'selectors', () => {
 
 	describe( '#isJetpackSiteMainNetworkSite()', () => {
 		it( 'should return `null` for a non-existing site', () => {
-			const state = {
-				sites: {
-					items: {}
-				}
-			};
-			const siteId = 123;
-
-			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
+			const isMainNetwork = isJetpackSiteMainNetworkSite( stateWithNoItems, nonExistingSiteId );
 			expect( isMainNetwork ).to.equal( null );
 		} );
 
 		it( 'it should return `false` for multi-network sites', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							options: {
-								is_multi_network: true
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					options: {
+						is_multi_network: true
 					}
 				}
-			};
+			} );
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( false );
 		} );
 
 		it( 'it should return `true` for non multisite site', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: false,
-						}
-					}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: false,
 				}
-			};
+			} );
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( true );
 		} );
 
 		it( 'it should return `false` for multisite sites without unmapped url', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								is_multi_network: false,
-								main_network_site: 'https://example.wordpress.com'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						is_multi_network: false,
+						main_network_site: 'https://example.wordpress.com'
 					}
 				}
-			};
+			} );
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( false );
 		} );
 
 		it( 'it should return `false` for multisite sites without main_network_site', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								is_multi_network: false,
-								unmapped_url: 'https://example.wordpress.com'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						is_multi_network: false,
+						unmapped_url: 'https://example.wordpress.com'
 					}
 				}
-			};
+			} );
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( false );
 		} );
 
 		it( 'it should return `true` for multisite sites and unmapped_url matches with main_network_site', () => {
-			const siteId = 77203074;
-			const state = {
-				sites: {
-					items: {
-						77203074: {
-							ID: siteId,
-							URL: 'https://jetpacksite.me',
-							is_multisite: true,
-							options: {
-								is_multi_network: false,
-								unmapped_url: 'https://example.wordpress.com',
-								main_network_site: 'https://example.wordpress.com'
-							}
-						}
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: true,
+					options: {
+						is_multi_network: false,
+						unmapped_url: 'https://example.wordpress.com',
+						main_network_site: 'https://example.wordpress.com'
 					}
 				}
-			};
+			} );
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( true );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1741,7 +1741,7 @@ describe( 'selectors', () => {
 			expect( isSecondary ).to.equal( false );
 		} );
 
-		it( 'it should return `true` for multisite sites which unmapped_url does not match with main_network_site', () => {
+		it( 'it should return `true` for multisite sites which unmapped_url does not match their main_network_site', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1297,7 +1297,7 @@ describe( 'selectors', () => {
 					items: {}
 				}
 			};
-			let siteId;
+			const siteId = 123;
 
 			const canManage = canJetpackSiteManage( state, siteId );
 			expect( canManage ).to.equal( null );
@@ -1426,7 +1426,7 @@ describe( 'selectors', () => {
 					items: {}
 				}
 			};
-			let siteId;
+			const siteId = 123;
 
 			const canUpdateFiles = canJetpackSiteUpdateFiles( state, siteId );
 			expect( canUpdateFiles ).to.equal( null );
@@ -1655,7 +1655,7 @@ describe( 'selectors', () => {
 					items: {}
 				}
 			};
-			let siteId;
+			const siteId = 123;
 
 			const hasMinimumVersion = siteHasMinimumJetpackVersion( state, siteId );
 			expect( hasMinimumVersion ).to.equal( null );
@@ -1848,7 +1848,7 @@ describe( 'selectors', () => {
 					items: {}
 				}
 			};
-			let siteId;
+			const siteId = 123;
 
 			const isSecondary = isJetpackSiteSecondaryNetworkSite( state, siteId );
 			expect( isSecondary ).to.equal( null );
@@ -1966,7 +1966,7 @@ describe( 'selectors', () => {
 					items: {}
 				}
 			};
-			let siteId;
+			const siteId = 123;
 
 			const modulesActive = verifyJetpackModulesActive( state, siteId, [ 'manage' ] );
 			expect( modulesActive ).to.equal( null );
@@ -2043,7 +2043,7 @@ describe( 'selectors', () => {
 					items: {}
 				}
 			};
-			let siteId;
+			const siteId = 123;
 
 			const managementUrl = getJetpackSiteRemoteManagementURL( state, siteId );
 			expect( managementUrl ).to.equal( null );
@@ -2124,7 +2124,7 @@ describe( 'selectors', () => {
 					items: {}
 				}
 			};
-			let siteId;
+			const siteId = 123;
 
 			const hasCustomDomain = hasJetpackSiteCustomDomain( state, siteId );
 			expect( hasCustomDomain ).to.equal( null );
@@ -2262,7 +2262,7 @@ describe( 'selectors', () => {
 					items: {}
 				}
 			};
-			let siteId;
+			const siteId = 123;
 
 			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( null );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1549,7 +1549,7 @@ describe( 'selectors', () => {
 			expect( canAutoUpdateFiles ).to.equal( true );
 		} );
 
-		it( 'it should return `true` if the `file_mod_disabled` option contains `automatic_updater_disabled`', () => {
+		it( 'it should return `false` if the `file_mod_disabled` option contains `automatic_updater_disabled`', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
@@ -1569,6 +1569,12 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#siteHasMinimumJetpackVersion()', () => {
+		let configStub;
+
+		useSandbox( ( sandbox ) => {
+			configStub = sandbox.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
+		} );
+
 		it( 'it should return `null` for a non-existing site', () => {
 			const hasMinimumVersion = siteHasMinimumJetpackVersion( stateWithNoItems, nonExistingSiteId );
 			expect( hasMinimumVersion ).to.equal( null );
@@ -1587,7 +1593,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'it should return `true` if jetpack version is greater that minimum version', () => {
-			const jetpackMinVersion = config( 'jetpack_min_version' );
+			const jetpackMinVersion = configStub( 'jetpack_min_version' );
 			const greaterVersion = changeVersion( jetpackMinVersion );
 			const state = createStateWithItems( {
 				[ siteId ]: {
@@ -1604,8 +1610,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'it should return `true` if jetpack version is equal to minimum version', () => {
-			const jetpackMinVersion = config( 'jetpack_min_version' );
-			const equalVersion = jetpackMinVersion;
+			const equalVersion = config( 'jetpack_min_version' );
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
@@ -1904,7 +1909,7 @@ describe( 'selectors', () => {
 			expect( hasCustomDomain ).to.equal( null );
 		} );
 
-		it( 'it should return `true` if `URL` and `unmapped_url` have the same domain', () => {
+		it( 'it should return `true` if `URL` and `unmapped_url` have different domains', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
@@ -1919,7 +1924,7 @@ describe( 'selectors', () => {
 			expect( hasCustomDomain ).to.equal( true );
 		} );
 
-		it( 'it should return `false` if `URL` and `unmapped_url` have different domains', () => {
+		it( 'it should return `false` if `URL` and `unmapped_url` have the same domain', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1396,8 +1396,11 @@ describe( 'selectors', () => {
 						77203074: {
 							ID: siteId,
 							URL: 'https://jetpacksite.me',
+							is_multisite: false,
+							jetpack: true,
 							options: {
-								file_mod_disabled: []
+								file_mod_disabled: [],
+								jetpack_version: '3.4'
 							}
 						}
 					}
@@ -1416,8 +1419,11 @@ describe( 'selectors', () => {
 						77203074: {
 							ID: siteId,
 							URL: 'https://jetpacksite.me',
+							is_multisite: false,
+							jetpack: true,
 							options: {
-								file_mod_disabled: [ 'automatic_updater_disabled' ]
+								file_mod_disabled: [ 'automatic_updater_disabled' ],
+								jetpack_version: '3.4'
 							}
 						}
 					}
@@ -1425,7 +1431,7 @@ describe( 'selectors', () => {
 			};
 
 			const canAutoUpdateFiles = canJetpackSiteAutoUpdateFiles( state, siteId );
-			expect( canAutoUpdateFiles ).to.equal( true );
+			expect( canAutoUpdateFiles ).to.equal( false );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3,7 +3,6 @@
  */
 import deepFreeze from 'deep-freeze';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -46,29 +45,6 @@ import {
 	siteHasMinimumJetpackVersion,
 	isJetpackSiteMainNetworkSite
 } from '../selectors';
-
-/**
- * Simple util function to increase/decrease a version with `x.x.x` format
- * @param  {String} version - version reference
- * @param  {Number} operator - increase/decrease given version
- * @return {String} new version string
- */
-function changeVersion( version, operator = 1 ) {
-	const splitVersion = version.split( '.' );
-
-	if ( operator >= 1 ) {
-		splitVersion[ splitVersion.length - 1 ]++;
-		return splitVersion.join( '.' );
-	}
-
-	if ( splitVersion[ splitVersion.length - 1 ] === '0' ) {
-		splitVersion[ splitVersion.length - 2 ]--;
-	} else {
-		splitVersion[ splitVersion.length - 1 ]--;
-	}
-
-	return splitVersion.join( '.' );
-}
 
 describe( 'selectors', () => {
 	const createStateWithItems = items => deepFreeze( {
@@ -1340,7 +1316,7 @@ describe( 'selectors', () => {
 					URL: 'https://jetpacksite.me',
 					jetpack: true,
 					options: {
-						active_modules: [],
+						active_modules: null,
 						jetpack_version: '3.4'
 					}
 				}
@@ -1386,8 +1362,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#canJetpackSiteUpdateFiles()', () => {
-		const configStub = sinon.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
-
 		it( 'should return `null` for a non-existing site', () => {
 			const canUpdateFiles = canJetpackSiteUpdateFiles( stateWithNoItems, nonExistingSiteId );
 			expect( canUpdateFiles ).to.equal( null );
@@ -1406,8 +1380,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'it should return `false` if jetpack version is smaller than minimum version', () => {
-			const jetpackMinVersion = configStub( 'jetpack_min_version' );
-			const smallerVersion = changeVersion( jetpackMinVersion, -1 );
+			const smallerVersion = '3.2';
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
@@ -1566,8 +1539,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#siteHasMinimumJetpackVersion()', () => {
-		const configStub = sinon.stub().withArgs( 'jetpack_min_version' ).returns( '3.3' );
-
 		it( 'it should return `null` for a non-existing site', () => {
 			const hasMinimumVersion = siteHasMinimumJetpackVersion( stateWithNoItems, nonExistingSiteId );
 			expect( hasMinimumVersion ).to.equal( null );
@@ -1586,8 +1557,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'it should return `true` if jetpack version is greater that minimum version', () => {
-			const jetpackMinVersion = configStub( 'jetpack_min_version' );
-			const greaterVersion = changeVersion( jetpackMinVersion );
+			const greaterVersion = '3.5';
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
@@ -1619,8 +1589,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'it should return `false` if jetpack version is smaller than minimum version', () => {
-			const jetpackMinVersion = config( 'jetpack_min_version' );
-			const smallerVersion = changeVersion( jetpackMinVersion, -1 );
+			const smallerVersion = '3.2';
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -43,7 +43,7 @@ import {
 	hasJetpackSiteCustomDomain,
 	getJetpackSiteFileModDisableReasons,
 	siteHasMinimumJetpackVersion,
-	isMainNetworkSite
+	isJetpackSiteMainNetworkSite
 } from '../selectors';
 
 /**
@@ -2249,7 +2249,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#isMainNetworkSite()', () => {
+	describe( '#isJetpackSiteMainNetworkSite()', () => {
 		it( 'should return `null` for a non-existing site', () => {
 			const state = {
 				sites: {
@@ -2258,7 +2258,7 @@ describe( 'selectors', () => {
 			};
 			let siteId;
 
-			const isMainNetwork = isMainNetworkSite( state, siteId );
+			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( null );
 		} );
 
@@ -2278,7 +2278,7 @@ describe( 'selectors', () => {
 				}
 			};
 
-			const isMainNetwork = isMainNetworkSite( state, siteId );
+			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( false );
 		} );
 
@@ -2296,7 +2296,7 @@ describe( 'selectors', () => {
 				}
 			};
 
-			const isMainNetwork = isMainNetworkSite( state, siteId );
+			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( true );
 		} );
 
@@ -2318,7 +2318,7 @@ describe( 'selectors', () => {
 				}
 			};
 
-			const isMainNetwork = isMainNetworkSite( state, siteId );
+			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( false );
 		} );
 
@@ -2340,7 +2340,7 @@ describe( 'selectors', () => {
 				}
 			};
 
-			const isMainNetwork = isMainNetworkSite( state, siteId );
+			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( false );
 		} );
 
@@ -2363,7 +2363,7 @@ describe( 'selectors', () => {
 				}
 			};
 
-			const isMainNetwork = isMainNetworkSite( state, siteId );
+			const isMainNetwork = isJetpackSiteMainNetworkSite( state, siteId );
 			expect( isMainNetwork ).to.equal( true );
 		} );
 	} );


### PR DESCRIPTION
This is a follow up of https://github.com/Automattic/wp-calypso/pull/8197 which aims at adding the last remaining selectors for Jetpack sites.

| Selector | matching function/prop in `lib/site` |
| --- | --- |
| canJetpackSiteManage() | site/jetpack.js - [canManage()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/jetpack.js#L49) |
| canJetpackSiteUpdateFiles() | site/utils.js - [canUpdateFiles()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/utils.js#L97) |
| canJetpackSiteAutoUpdateFiles() | site/utils.js - [canAutoupdateFiles()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/utils.js#L124) |
| canJetpackSiteAutoUpdateCore() | site/utils.js - [canAutoupdateCore()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/utils.js#L136) |
| hasJetpackSiteJetpackMenus() | site/jetpack.js - [hasJetpackMenus](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/jetpack.js#L40) |
| hasJetpackSiteJetpackThemes() | site/jetpack.js - [hasJetpackThemes](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/jetpack.js#L41) |
| isJetpackSiteMainNetworkSite() | site/utils.js - [isMainNetworkSite()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/utils.js#L148) |
| isJetpackSiteSecondaryNetworkSite() | site/jetpack.js - [isSecondaryNetworkSite()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/jetpack.js#L77) |
| verifyJetpackModulesActive() | site/jetpack.js - [verifyModulesActive()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/jetpack.js#L91) |
| getJetpackSiteRemoteManagementURL() | site/jetpack.js - [getRemoteManagementURL()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/jetpack.js#L105) |
| hasJetpackSiteCustomDomain() | site/utils.js - [hasCustomDomain()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/utils.js#L183) |
| getJetpackSiteFileModDisableReasons() | site/utils.js - [getSiteFileModDisableReason()](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/utils.js#L69) |
| siteHasMinimumJetpackVersion() | site/jetpack.js - [hasMinimumJetpackVersion](https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/jetpack.js#L33) |
### Testing Instructions
- `git checkout update/add-jetpack-site-selectors-2`
- `npm run test-client client/state/sites/test/selectors.js`
### Reviews
- [ ] Code
- [ ] Product
