### PR TITLE
Reader full post: scope full post action button styles so comment likes aren't affected

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -220,14 +220,14 @@
 }
 
 // Action buttons in full-post
-.reader-full-post .reader-post-actions{
+.reader-full-post .reader-post-actions {
 	margin-bottom: 20px;
-}
 
-.reader-full-post .post-edit-button__label,
-.reader-full-post .comment-button__label,
-.reader-full-post .like-button__label {
-	font-size: 17px;
+	.post-edit-button__label,
+	.comment-button__label,
+	.like-button__label {
+		font-size: 17px;
+	}
 }
 
 .reader-full-post__sidebar .like-button {


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/8662/files#diff-6bbcdd387e5ed792d7ef6779d8e9edf0R230 we made all action buttons in full post a consistent text size: 17px.

Unfortunately this caused a small regression with comment likes, which also started appearing at 17px instead of 14px:

<img width="205" alt="screen shot 2016-10-17 at 10 45 21" src="https://cloud.githubusercontent.com/assets/17325/19421552/60586744-9460-11e6-8b90-decb9d2985fc.png">

This PR scopes the 17px font size to the `.reader-post-actions` component.

### To test

Visit a full post with comments (e.g. http://calypso.localhost:3000/read/feeds/40474296/posts/999143144). In the comments section, ensure that the 'Reply' and 'Like' labels have the same text size.