### PR TITLE
Stats: remove use of sitesList.getSelectedSite in Follows

### DIFF
--- a/client/my-sites/stats/follows/index.jsx
+++ b/client/my-sites/stats/follows/index.jsx
@@ -2,35 +2,34 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import observe from 'lib/mixins/data-observe';
 import Followers from '../stats-followers-page';
 import HeaderCake from 'components/header-cake';
 import analytics from 'lib/analytics';
 import Main from 'components/main';
 import StatsFirstView from '../stats-first-view';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
-export default React.createClass( {
-	displayName: 'StatsFollows',
-
-	mixins: [ observe( 'sites', 'site', 'followersList' ) ],
-
+const StatsFollows = React.createClass( {
 	propTypes: {
 		followType: PropTypes.string,
 		followList: PropTypes.object,
 		follwersList: PropTypes.object,
 		page: PropTypes.number,
 		perPage: PropTypes.number,
-		sites: PropTypes.object
+		slug: PropTypes.string,
+		translate: PropTypes.func,
 	},
 
 	goBack() {
-		const site = this.props.sites.getSelectedSite();
-		page( '/stats/insights/' + site.slug );
+		page( '/stats/insights/' + this.props.slug );
 	},
 
 	componentDidMount() {
@@ -38,26 +37,23 @@ export default React.createClass( {
 	},
 
 	paginationHandler( pageNum ) {
-		const site = this.props.sites.getSelectedSite();
 		let path = '/stats/follows/' + this.props.followType + '/';
 		if ( pageNum > 1 ) {
 			path += pageNum + '/';
 		}
-		path += site.slug;
+		path += this.props.slug;
 		analytics.ga.recordEvent( 'Stats', 'Used Pagination on Followers Page', pageNum );
 		page( path );
 	},
 
 	changeFilter( selection ) {
-		const site = this.props.sites.getSelectedSite();
 		const filter = selection.value;
 
-		page( '/stats/follows/' + filter + '/' + site.slug );
+		page( '/stats/follows/' + filter + '/' + this.props.slug );
 	},
 
 	render() {
-		const { followType, followersList, followList, perPage, sites } = this.props;
-		const site = sites.getSelectedSite();
+		const { followType, followersList, followList, perPage, translate } = this.props;
 
 		return (
 			<Main>
@@ -65,11 +61,10 @@ export default React.createClass( {
 
 				<div id="my-stats-content" className={ 'follows-detail follows-detail-' + followType }>
 					<HeaderCake onClick={ this.goBack }>
-						{ this.translate( 'Followers' ) }
+						{ translate( 'Followers' ) }
 					</HeaderCake>
 					<Followers
 						path={ followType + '-follow-summary' }
-						site={ site }
 						followersList={ followersList }
 						followType={ followType }
 						followList={ followList }
@@ -82,3 +77,11 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		slug: getSiteSlug( state, siteId )
+	};
+} )( localize( StatsFollows ) );

--- a/client/my-sites/stats/stats-followers-page/index.jsx
+++ b/client/my-sites/stats/stats-followers-page/index.jsx
@@ -3,6 +3,8 @@
  */
 var React = require( 'react' ),
 	classNames = require( 'classnames' );
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,9 +19,11 @@ var StatsList = require( '../stats-list' ),
 	Card = require( 'components/card' ),
 	SectionHeader = require( 'components/section-header' ),
 	Button = require( 'components/button' );
+import observe from 'lib/mixins/data-observe';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-module.exports = React.createClass( {
-	displayName: 'StatModuleFollowersPage',
+const StatModuleFollowersPage = React.createClass( {
+	mixins: [ observe( 'followersList' ) ],
 
 	data: function( nextProps ) {
 		var props = nextProps || this.props;
@@ -40,15 +44,16 @@ module.exports = React.createClass( {
 	},
 
 	filterSelect: function() {
+		const { translate } = this.props;
 		var selectFilter,
 			options = [
 				{
 					value: 'wpcom',
-					label: this.translate( 'WordPress.com Followers' )
+					label: translate( 'WordPress.com Followers' )
 				},
 				{
 					value: 'email',
-					label: this.translate( 'Email Followers' )
+					label: translate( 'Email Followers' )
 				}
 			];
 
@@ -64,6 +69,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
+		const { translate } = this.props;
 		var data = this.data(),
 			hasError = this.props.followersList.isError(),
 			noData = this.props.followersList.isEmpty( 'subscribers' ),
@@ -92,15 +98,15 @@ module.exports = React.createClass( {
 
 		switch ( this.props.followType ) {
 			case 'comment':
-				itemType = this.translate( 'Comments' );
+				itemType = translate( 'Comments' );
 				break;
 
 			case 'email':
-				itemType = this.translate( 'Email' );
+				itemType = translate( 'Email' );
 				break;
 
 			case 'wpcom':
-				itemType = this.translate( 'WordPress.com' );
+				itemType = translate( 'WordPress.com' );
 				break;
 		}
 
@@ -112,7 +118,7 @@ module.exports = React.createClass( {
 				endIndex = data.total;
 			}
 
-			paginationSummary = this.translate( 'Showing %(startIndex)s - %(endIndex)s of %(total)s %(itemType)s followers', {
+			paginationSummary = translate( 'Showing %(startIndex)s - %(endIndex)s of %(total)s %(itemType)s followers', {
 				context: 'pagination',
 				comment: '"Showing [start index] - [end index] of [total] [item]" Example: Showing 21 - 40 of 300 WordPress.com followers',
 				args: {
@@ -134,32 +140,32 @@ module.exports = React.createClass( {
 
 		if ( data && data.posts ) {
 			followers = <StatsList data={ data.posts } moduleName="Followers" />;
-			labelLegend = this.translate( 'Post', {
+			labelLegend = translate( 'Post', {
 				context: 'noun'
 			} );
-			valueLegend = this.translate( 'Followers' );
+			valueLegend = translate( 'Followers' );
 		} else if ( data && data.subscribers ) {
 			followers = <StatsList data={ data.subscribers } followList={ this.props.followList } moduleName="Followers" />;
-			labelLegend = this.translate( 'Follower' );
-			valueLegend = this.translate( 'Since' );
+			labelLegend = translate( 'Follower' );
+			valueLegend = translate( 'Since' );
 		}
 
 		if ( 'email' === this.props.followType ) {
-			emailExportUrl = 'https://dashboard.wordpress.com/wp-admin/index.php?page=stats&blog=' + this.props.site.ID + '&blog_subscribers=csv&type=email';
+			emailExportUrl = 'https://dashboard.wordpress.com/wp-admin/index.php?page=stats&blog=' + this.props.siteId + '&blog_subscribers=csv&type=email';
 		}
 
 		return (
 			<div className="followers">
-				<SectionHeader label={ this.translate( 'Followers' ) }>
+				<SectionHeader label={ translate( 'Followers' ) }>
 					{ emailExportUrl
-						? ( <Button compact href={ emailExportUrl }>{ this.translate( 'Download Data as CSV' ) }</Button> )
+						? ( <Button compact href={ emailExportUrl }>{ translate( 'Download Data as CSV' ) }</Button> )
 						: null }
 				</SectionHeader>
 				<Card className={ classNames( classes ) }>
 					<div className="module-content">
 						{ this.filterSelect() }
 
-						{ ( noData && ! hasError ) ? <ErrorPanel className="is-empty-message" message={ this.translate( 'No followers' ) } /> : null }
+						{ ( noData && ! hasError ) ? <ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } /> : null }
 
 						{ paginationSummary }
 
@@ -180,3 +186,11 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId
+	};
+} )( localize( StatModuleFollowersPage ) );


### PR DESCRIPTION
For #8726 - this branch removes usage of `sitesList.getSelectedSite` from `< StatsFollows />` and `<StatModuleFollowersPage />`.  Both components need further updating, but I just replaced `getSelectedSite` and `this.translate` usage.

__To Test__
- Visit an Insights page for a site that has followers
- Click "View All" link at the bottom of the followers module
- Utilize pagination on the followers list, ensure it works as expected
- Toggle between follower types using the select drop down at the top of the page
- Then click the header cake link and verify you are sent back to the stats page for the site