### PR TITLE
NUX: Fix misaligned label in mail confirmation dialog in create post screen.

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -233,6 +233,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	margin-right: 5px;
+	vertical-align: bottom;
 }
 
 .post-editor__confirmation-dialog-reasoning {


### PR DESCRIPTION
This PR aims to fix #8460 .

The e-mail address label in the popup was misaligned with the `change...` button next to it.

To test:

1. Checkout branch or use the Calypso.live link.
2. Go through Signup.
3. Do not confirm your e-mail.
4. Go to the Add/Edit post screen.
5. Under the Publish button you'll see this warning: "To publish, check your email and confirm your address."
6. Click that message to see the overlay: "Please confirm your email address"
7. See that the email address is out of alignment.

### Before

![screen shot 2016-10-17 at 14 53 22](https://cloud.githubusercontent.com/assets/184938/19436633/f795690e-9479-11e6-8439-25dcea3b6150.png)

### After

![screen shot 2016-10-17 at 14 53 51](https://cloud.githubusercontent.com/assets/184938/19436635/fcbe6584-9479-11e6-96ad-224a89c06714.png)

cc @lancewillett @beaulebens @coreh @michaeldcain 