### PR TITLE
Themes: Strip redundant whitespace from search string

### DIFF
--- a/client/my-sites/themes/test/theme-filters.js
+++ b/client/my-sites/themes/test/theme-filters.js
@@ -75,7 +75,7 @@ describe( 'theme-filters', () => {
 	describe( 'stripFilters', () => {
 		it( 'should strip filters from a mixed input string', () => {
 			const remaining = stripFilters( 'blah color:blue yah' );
-			assert.equal( remaining, 'blah  yah' );
+			assert.equal( remaining, 'blah yah' );
 		} );
 
 		it( 'should still strip invalid filters', () => {

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -319,7 +319,8 @@ export function getSortedFilterTerms( input ) {
  * @return {string} input string minus any filters
  */
 export function stripFilters( input ) {
-	return input.replace( FILTER_REGEX_GLOBAL, '' ).trim();
+	const withoutFilters = input.replace( FILTER_REGEX_GLOBAL, '' ).trim();
+	return withoutFilters.replace( /\s+/g, ' ' );
 }
 
 export function getSubjects() {


### PR DESCRIPTION
Prevent unwanted whitespace chars from accumulating in the theme search URL.

**Before**
<img width="592" alt="screen shot 2016-10-17 at 13 01 06" src="https://cloud.githubusercontent.com/assets/7767559/19436753/ed3f4d40-9469-11e6-9e3a-e9643660f403.png">

**After**
<img width="654" alt="screen shot 2016-10-17 at 13 01 42" src="https://cloud.githubusercontent.com/assets/7767559/19436756/f1b4aaaa-9469-11e6-90d7-6f652b796b05.png">

cc @folletto 