### PR TITLE
Themes: Drop sites-list usage

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -38,7 +38,6 @@ JetpackSite.prototype.updateComputedAttributes = function() {
 	this.canUpdateFiles = SiteUtils.canUpdateFiles( this );
 	this.canAutoupdateFiles = SiteUtils.canAutoupdateFiles( this );
 	this.hasJetpackMenus = versionCompare( this.options.jetpack_version, '3.5-alpha' ) >= 0;
-	this.hasJetpackThemes = versionCompare( this.options.jetpack_version, '3.7-beta' ) >= 0;
 };
 
 JetpackSite.prototype.versionCompare = function( compare, operator ) {

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -56,7 +56,7 @@ const CurrentTheme = React.createClass( {
 
 		return (
 			<Card className="current-theme">
-				{ site && <QueryCurrentTheme siteId={ site.ID }/> }
+				{ site && <QueryCurrentTheme siteId={ site.ID } /> }
 				<div className="current-theme__current">
 					<span className="current-theme__label">
 						{ this.translate( 'Current Theme' ) }

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -33,7 +33,7 @@ import {
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { getSelectedSite } from 'state/ui/selectors';
-import { getSiteOption, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { getSiteOption, hasJetpackSiteJetpackThemes, isJetpackSite } from 'state/sites/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ThemeShowcase from './theme-showcase';
@@ -140,7 +140,7 @@ export default connect(
 			isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
 			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' ),
 			adminUrl: getSiteOption( state, selectedSite.ID, 'admin_url' ),
-			hasJetpackThemes: isJetpackMinimumVersion( state, selectedSite.ID, '3.7-beta' )
+			hasJetpackThemes: hasJetpackSiteJetpackThemes( state, selectedSite.ID )
 		};
 	},
 	bindOptionsToDispatch( {

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -30,7 +30,6 @@ import {
 	bindOptionsToDispatch,
 	bindOptionsToSite
 } from './theme-options';
-import sitesFactory from 'lib/sites-list';
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -39,16 +38,14 @@ import { canCurrentUser } from 'state/current-user/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ThemeShowcase from './theme-showcase';
 
-const sites = sitesFactory();
-
 const JetpackThemeReferrerPage = localize(
-	( { translate, site, analyticsPath, analyticsPageTitle } ) => (
+	( { translate, site, isCustomizable, analyticsPath, analyticsPageTitle } ) => (
 		<Main className="themes">
-			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle }/>
+			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 			<SidebarNavigation />
 			<CurrentTheme
 				site={ site }
-				canCustomize={ site && site.isCustomizable() } />
+				canCustomize={ isCustomizable } />
 			<EmptyContent title={ translate( 'Changing Themes?' ) }
 				line={ translate( 'Use your site theme browser to manage themes.' ) }
 				action={ translate( 'Open Site Theme Browser' ) }
@@ -60,8 +57,14 @@ const JetpackThemeReferrerPage = localize(
 );
 
 const ThemesSingleSite = ( props ) => {
-	const site = sites.getSelectedSite(),
-		{ analyticsPath, analyticsPageTitle, isJetpack, translate } = props,
+	const {
+		analyticsPath,
+		analyticsPageTitle,
+		selectedSite: site,
+		isCustomizable,
+		isJetpack,
+		translate
+	} = props,
 		jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
 	// If we've only just switched from single to multi-site, there's a chance
@@ -75,6 +78,7 @@ const ThemesSingleSite = ( props ) => {
 		if ( ! jetpackEnabled ) {
 			return (
 				<JetpackThemeReferrerPage site={ site }
+					isCustomizable={ isCustomizable }
 					analyticsPath={ analyticsPath }
 					analyticsPageTitle={ analyticsPageTitle }/>
 			);
@@ -95,7 +99,7 @@ const ThemesSingleSite = ( props ) => {
 				source={ 'list' }/>
 			<CurrentTheme
 				site={ site }
-				canCustomize={ site && site.isCustomizable() } />
+				canCustomize={ isCustomizable } />
 			<UpgradeNudge
 				title={ translate( 'Get Custom Design with Premium' ) }
 				message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -33,7 +33,12 @@ import {
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { getSelectedSite } from 'state/ui/selectors';
-import { getSiteOption, hasJetpackSiteJetpackThemes, isJetpackSite } from 'state/sites/selectors';
+import {
+	canJetpackSiteManage,
+	getSiteOption,
+	hasJetpackSiteJetpackThemes,
+	isJetpackSite
+} from 'state/sites/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ThemeShowcase from './theme-showcase';
@@ -59,6 +64,7 @@ const ThemesSingleSite = ( props ) => {
 		adminUrl,
 		analyticsPath,
 		analyticsPageTitle,
+		canManage,
 		hasJetpackThemes,
 		isCustomizable,
 		isJetpack,
@@ -87,7 +93,7 @@ const ThemesSingleSite = ( props ) => {
 		if ( ! hasJetpackThemes ) {
 			return <JetpackUpgradeMessage site={ site } />;
 		}
-		if ( ! site.canManage() ) {
+		if ( ! canManage ) {
 			return <JetpackManageDisabledMessage site={ site } />;
 		}
 	}
@@ -140,7 +146,8 @@ export default connect(
 			isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
 			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' ),
 			adminUrl: getSiteOption( state, selectedSite.ID, 'admin_url' ),
-			hasJetpackThemes: hasJetpackSiteJetpackThemes( state, selectedSite.ID )
+			hasJetpackThemes: hasJetpackSiteJetpackThemes( state, selectedSite.ID ),
+			canManage: canJetpackSiteManage( state, selectedSite.ID )
 		};
 	},
 	bindOptionsToDispatch( {

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -39,13 +39,11 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ThemeShowcase from './theme-showcase';
 
 const JetpackThemeReferrerPage = localize(
-	( { translate, adminUrl, site, isCustomizable, analyticsPath, analyticsPageTitle } ) => (
+	( { translate, adminUrl, site, analyticsPath, analyticsPageTitle } ) => (
 		<Main className="themes">
 			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 			<SidebarNavigation />
-			<CurrentTheme
-				site={ site }
-				canCustomize={ isCustomizable } />
+			<CurrentTheme site={ site } />
 			<EmptyContent title={ translate( 'Changing Themes?' ) }
 				line={ translate( 'Use your site theme browser to manage themes.' ) }
 				action={ translate( 'Open Site Theme Browser' ) }
@@ -100,9 +98,7 @@ const ThemesSingleSite = ( props ) => {
 			<ThanksModal
 				site={ site }
 				source={ 'list' } />
-			<CurrentTheme
-				site={ site }
-				canCustomize={ isCustomizable } />
+			<CurrentTheme site={ site } />
 			<UpgradeNudge
 				title={ translate( 'Get Custom Design with Premium' ) }
 				message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }


### PR DESCRIPTION
WIP. Blocked by #8762. TODO:
- `themes/single-site`:
  - [x] `site.hasJetpackThemes`
  - [x] `site.canManage()` (Use `canJetpackSiteManage` from #8762)
  - [ ] Check if any dependency components rely on `site` object attrs that aren't there (if obtained via the `getSelectedSite()` selector). Ideally, have them rely on `siteId` instead.
