### PR TITLE
Themes: use withMutations for multiple changes to state

### DIFF
--- a/client/state/themes/themes/reducer.js
+++ b/client/state/themes/themes/reducer.js
@@ -36,7 +36,7 @@ export default ( state = initialState, action ) => {
 	switch ( action.type ) {
 		case THEMES_RECEIVE: {
 			const isCurrentSite = action.siteId === state.get( 'currentSiteId' );
-			const isNewSite = action.isJetpack && !isCurrentSite;
+			const isNewSite = action.isJetpack && ! isCurrentSite;
 			const currentThemes = isNewSite ? new Map() : state.get( 'themes' );
 			const mergedThemes = add( action.themes, currentThemes );
 

--- a/client/state/themes/themes/reducer.js
+++ b/client/state/themes/themes/reducer.js
@@ -34,13 +34,18 @@ export function setActiveTheme( themeId, themes ) {
 
 export default ( state = initialState, action ) => {
 	switch ( action.type ) {
-		case THEMES_RECEIVE:
-			const isNewSite = action.isJetpack && ( action.siteId !== state.get( 'currentSiteId' ) );
-			return state
-				.update( 'themes', themes => isNewSite ? new Map() : themes )
-				.set( 'currentSiteId', action.siteId )
-				.update( 'themes', add.bind( null, action.themes ) );
+		case THEMES_RECEIVE: {
+			const isCurrentSite = action.siteId === state.get( 'currentSiteId' );
+			const isNewSite = action.isJetpack && !isCurrentSite;
+			const currentThemes = isNewSite ? new Map() : state.get( 'themes' );
+			const mergedThemes = add( action.themes, currentThemes );
 
+			return state.withMutations( ( temporaryState ) => {
+				temporaryState
+					.set( 'themes', mergedThemes )
+					.set( 'currentSiteId', action.siteId )
+			} );
+		}
 		case THEME_ACTIVATED:
 			return state.update( 'themes', setActiveTheme.bind( null, action.theme.id ) );
 		case DESERIALIZE:

--- a/client/state/themes/themes/test/reducer.js
+++ b/client/state/themes/themes/test/reducer.js
@@ -13,7 +13,8 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 	SERVER_DESERIALIZE,
-	THEME_ACTIVATED
+	THEME_ACTIVATED,
+	THEMES_RECEIVE,
 } from 'state/action-types';
 import reducer, { initialState } from '../reducer';
 
@@ -156,6 +157,40 @@ describe( 'themes reducer', () => {
 			} );
 			const state = reducer( jsObject, { type: SERVER_DESERIALIZE } );
 			expect( state ).to.eql( fromJS( jsObject ) );
+		} );
+	} );
+
+	describe( 'themes received', () => {
+		const siteId = 12345678;
+		const twentyfifteen = Map( {
+			name: 'Twenty Fifteen',
+			id: 'twentyfifteen'
+		} );
+		const twentysixteen = {
+			name: 'Twenty Sixteen',
+			id: 'twentysixteen'
+		};
+		const state = fromJS( {
+			themes: {
+				twentyfifteen
+			},
+			siteId: 87654321
+		} );
+		const newState = reducer( state, {
+			type: THEMES_RECEIVE,
+			themes: [
+				twentysixteen
+			],
+			siteId: siteId
+		} );
+
+		it( 'adds newly received themes to existing themes state', () => {
+			expect( newState.getIn( [ 'themes', 'twentysixteen' ] ).toJS() ).to.eql( twentysixteen );
+			expect( newState.get( 'themes' ).size ).to.eql( 2 );
+		} );
+
+		it( 'sets the currentSiteId', () => {
+			expect( newState.get( 'currentSiteId' ) ).to.eql( siteId );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR is an attempt to more efficiently make changes to state by making the various changes in .withMutations.

I've described the benefits to this approach in [Issue 8773](https://github.com/Automattic/wp-calypso/issues/8773).

For now, this PR should mostly serve as an example, until theres been more of a discussion on [Issue 8773](https://github.com/Automattic/wp-calypso/issues/8773).

I also added unit test coverage to test that both the original code and the refactored code in this PR both pass :D

cc'ing @apeatling - is there anything in this refactor that deviates from the original logic? I've double & triple checked but I always like to get another pair of eyes on my code :)

TIA guys