### PR TITLE
Remove char-spinner dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -27,7 +27,7 @@
       "version": "0.8.2"
     },
     "ajv": {
-      "version": "4.7.7"
+      "version": "4.8.0"
     },
     "ajv-keywords": {
       "version": "1.1.1"
@@ -138,7 +138,7 @@
       "version": "0.6.0"
     },
     "aws4": {
-      "version": "1.4.1"
+      "version": "1.5.0"
     },
     "babel-code-frame": {
       "version": "6.16.0",
@@ -371,7 +371,7 @@
       "version": "6.16.0"
     },
     "babylon": {
-      "version": "6.11.4"
+      "version": "6.12.0"
     },
     "backo2": {
       "version": "1.0.2"
@@ -514,7 +514,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000548"
+      "version": "1.0.30000559"
     },
     "caseless": {
       "version": "0.11.0"
@@ -548,9 +548,6 @@
     "change-case": {
       "version": "2.3.1"
     },
-    "char-spinner": {
-      "version": "1.0.1"
-    },
     "character-parser": {
       "version": "2.2.0"
     },
@@ -566,7 +563,7 @@
       }
     },
     "chokidar": {
-      "version": "1.6.0"
+      "version": "1.6.1"
     },
     "chrono-node": {
       "version": "1.2.4"
@@ -884,7 +881,7 @@
       "version": "2.0.0"
     },
     "doctrine": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "isarray": {
           "version": "1.0.0"
@@ -966,7 +963,7 @@
       }
     },
     "editions": {
-      "version": "1.1.2"
+      "version": "1.3.1"
     },
     "ee-first": {
       "version": "1.1.1"
@@ -1175,7 +1172,7 @@
           "version": "1.1.3"
         },
         "globals": {
-          "version": "9.10.0"
+          "version": "9.12.0"
         },
         "strip-bom": {
           "version": "3.0.0"
@@ -1250,6 +1247,9 @@
     },
     "execall": {
       "version": "1.0.0"
+    },
+    "execspawn": {
+      "version": "1.0.1"
     },
     "exit-hook": {
       "version": "1.1.1"
@@ -1665,7 +1665,7 @@
       "version": "1.1.8"
     },
     "ignore": {
-      "version": "3.1.5"
+      "version": "3.2.0"
     },
     "imagesloaded": {
       "version": "4.1.1"
@@ -1700,7 +1700,7 @@
       "version": "2.0.3"
     },
     "inflight": {
-      "version": "1.0.5"
+      "version": "1.0.6"
     },
     "inherits": {
       "version": "2.0.1"
@@ -2016,7 +2016,7 @@
       "version": "0.0.3"
     },
     "jsx-ast-utils": {
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     "key-mirror": {
       "version": "1.0.1"
@@ -2040,7 +2040,7 @@
       "version": "1.2.1"
     },
     "level": {
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "level-codec": {
       "version": "6.1.0"
@@ -2055,10 +2055,15 @@
       "version": "1.2.0"
     },
     "leveldown": {
-      "version": "1.4.6"
+      "version": "1.5.0",
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.6.1"
+        }
+      }
     },
     "levelup": {
-      "version": "1.3.2"
+      "version": "1.3.3"
     },
     "levn": {
       "version": "0.3.0"
@@ -2293,7 +2298,7 @@
       "version": "0.0.5"
     },
     "nan": {
-      "version": "2.3.5"
+      "version": "2.4.0"
     },
     "natives": {
       "version": "1.1.0"
@@ -2317,7 +2322,7 @@
       "version": "8.0.0",
       "dependencies": {
         "qs": {
-          "version": "6.2.1"
+          "version": "6.3.0"
         }
       }
     },
@@ -2630,7 +2635,7 @@
       "version": "3.3.0"
     },
     "prebuild": {
-      "version": "4.2.2",
+      "version": "4.3.0",
       "dependencies": {
         "async": {
           "version": "1.5.2"
@@ -2959,7 +2964,7 @@
       "version": "2.5.4",
       "dependencies": {
         "glob": {
-          "version": "7.1.0"
+          "version": "7.1.1"
         },
         "minimatch": {
           "version": "3.0.3"
@@ -3043,7 +3048,7 @@
       "version": "2.2.0"
     },
     "select": {
-      "version": "1.0.6"
+      "version": "1.1.0"
     },
     "semver": {
       "version": "5.1.0"
@@ -3345,7 +3350,7 @@
           "version": "1.0.0"
         },
         "qs": {
-          "version": "6.2.1"
+          "version": "6.3.0"
         },
         "readable-stream": {
           "version": "2.1.5"
@@ -3391,7 +3396,7 @@
       "version": "2.2.1"
     },
     "tar-fs": {
-      "version": "1.13.2"
+      "version": "1.14.0"
     },
     "tar-stream": {
       "version": "1.5.2",
@@ -3584,6 +3589,9 @@
     },
     "util-deprecate": {
       "version": "1.0.2"
+    },
+    "util-extend": {
+      "version": "1.0.3"
     },
     "utils-merge": {
       "version": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "bounding-client-rect": "1.0.5",
     "browser-filesaver": "1.1.0",
     "chalk": "1.0.0",
-    "char-spinner": "1.0.1",
     "chrono-node": "^1.0.6",
     "classnames": "1.1.1",
     "click-outside": "2.0.1",


### PR DESCRIPTION
One of Calypso's dependencies is `char-spinner`, but I've noticed that we're not using it anywhere. This PR suggests removing that dependency. 

/cc @gwwar 