### PR TITLE
Sharing: Fix unknown prop warnings in SharingButtonsPreviewAction

### DIFF
--- a/client/my-sites/sharing/buttons/preview-action.jsx
+++ b/client/my-sites/sharing/buttons/preview-action.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	classNames = require( 'classnames' );
+	classNames = require( 'classnames' ),
+	omit = require( 'lodash' ).omit;
 
 module.exports = React.createClass( {
 	displayName: 'SharingButtonsPreviewAction',
@@ -43,7 +44,7 @@ module.exports = React.createClass( {
 		} );
 
 		return (
-			<button type="button" className={ classes } { ...this.props }>
+			<button type="button" className={ classes } { ...omit( this.props, [ 'active', 'position' ] ) }>
 				{ this.getIconElement() }
 				{ this.props.children }
 			</button>

--- a/client/my-sites/sharing/buttons/preview-action.jsx
+++ b/client/my-sites/sharing/buttons/preview-action.jsx
@@ -1,53 +1,44 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	omit = require( 'lodash' ).omit;
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { omit, startsWith, endsWith } from 'lodash';
 
-module.exports = React.createClass( {
-	displayName: 'SharingButtonsPreviewAction',
+const SharingButtonsPreviewAction = ( props ) => {
+	const { active, position, icon, children } = props;
+	const classes = classNames( 'sharing-buttons-preview-action', {
+		'is-active': active,
+		'is-top': startsWith( position, 'top' ),
+		'is-right': endsWith( position, '-right' ),
+		'is-bottom': startsWith( position, 'bottom' ),
+		'is-left': endsWith( position, '-left' )
+	} );
 
-	propTypes: {
-		active: React.PropTypes.bool,
-		position: React.PropTypes.oneOf( [
-			'top-left',
-			'top-right',
-			'bottom-left',
-			'bottom-right'
-		] ),
-		icon: React.PropTypes.string,
-		onClick: React.PropTypes.func
-	},
+	return (
+		<button type="button" className={ classes } { ...omit( props, [ 'active', 'position', 'icon' ] ) }>
+			{ icon && <span className={ 'noticon noticon-' + icon } /> }
+			{ children }
+		</button>
+	);
+};
 
-	getDefaultProps: function() {
-		return {
-			active: true,
-			position: 'top-left',
-			onClick: function() {}
-		};
-	},
+SharingButtonsPreviewAction.propTypes = {
+	active: PropTypes.bool,
+	position: PropTypes.oneOf( [
+		'top-left',
+		'top-right',
+		'bottom-left',
+		'bottom-right'
+	] ),
+	icon: PropTypes.string,
+	onClick: PropTypes.func
+};
 
-	getIconElement: function() {
-		if ( this.props.icon ) {
-			return <span className={ 'noticon noticon-' + this.props.icon } />;
-		}
-	},
+SharingButtonsPreviewAction.defaultProps = {
+	active: true,
+	position: 'top-left',
+	onClick: () => {}
+};
 
-	render: function() {
-		var classes = classNames( 'sharing-buttons-preview-action', {
-			'is-active': this.props.active,
-			'is-top': 0 === this.props.position.indexOf( 'top' ),
-			'is-right': -1 !== this.props.position.indexOf( '-right' ),
-			'is-bottom': 0 === this.props.position.indexOf( 'bottom' ),
-			'is-left': -1 !== this.props.position.indexOf( '-left' )
-		} );
-
-		return (
-			<button type="button" className={ classes } { ...omit( this.props, [ 'active', 'position' ] ) }>
-				{ this.getIconElement() }
-				{ this.props.children }
-			</button>
-		);
-	}
-} );
+export default SharingButtonsPreviewAction;


### PR DESCRIPTION
This PR clears JS warnings emitted by the `SharingButtonsPreviewAction` component - they were caused by unnecessary props being specified to the `<button />` tag. In addition, the PR ES6ifies that component and removes the existing ESLint warnings.

Note: this PR is part of the unknown prop warning resolve PR series: #7413.

To test:

* Checkout this branch.
* Go to `/sharing/buttons/$site`, where `$site` is the slug of one of your sites.
* Verify that there are no JS warnings caused by`SharingButtonsPreviewAction`.

/cc @aduth