### PR TITLE
Js-Errors: Re-enable

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -16,7 +16,7 @@
 		"accept-invite": true,
 		"ad-tracking": false,
 		"apple-pay": false,
-		"catch-js-errors": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -14,7 +14,7 @@
 		"accept-invite": true,
 		"ad-tracking": true,
 		"apple-pay": false,
-		"catch-js-errors": false,
+		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,


### PR DESCRIPTION
Reenables js-error catching on prod & horizon
This was disabled in https://github.com/Automattic/wp-calypso/pull/8749 because we were flooding the endpoints due to some error.
I introduced throttling in https://github.com/Automattic/wp-calypso/pull/8748 and endpoint it currently working.

This just opens feature flag on horizon and prod.

## Testing

- Build calypso with `ENABLE_FEATURES=catch-js-errors make run` 
- Introduce error somewhere
- Navigate there
- See the call to `js-error` endpoint in network tab

CC @gwwar @lamosty @aduth @retrofox 