### PR TITLE
Guided Tours: Allow Continue to listen for any event

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -235,11 +235,11 @@ export class Continue extends Component {
 
 	static propTypes = {
 		children: PropTypes.node,
-		click: PropTypes.bool,
 		hidden: PropTypes.bool,
 		icon: PropTypes.string,
 		step: PropTypes.string.isRequired,
 		target: PropTypes.string,
+		targetEvent: PropTypes.string,
 		when: PropTypes.func,
 	};
 
@@ -272,20 +272,20 @@ export class Continue extends Component {
 	}
 
 	addTargetListener() {
-		const { target = false, click, when } = this.props;
+		const { target = false, targetEvent, when } = this.props;
 		const targetNode = targetForSlug( target );
 
-		if ( click && ! when && targetNode && targetNode.addEventListener ) {
-			targetNode.addEventListener( 'click', this.onContinue );
+		if ( targetEvent && ! when && targetNode && targetNode.addEventListener ) {
+			targetNode.addEventListener( targetEvent, this.onContinue );
 		}
 	}
 
 	removeTargetListener() {
-		const { target = false, click, when } = this.props;
+		const { target = false, targetEvent, when } = this.props;
 		const targetNode = targetForSlug( target );
 
-		if ( click && ! when && targetNode && targetNode.removeEventListener ) {
-			targetNode.removeEventListener( 'click', this.onContinue );
+		if ( targetEvent && ! when && targetNode && targetNode.removeEventListener ) {
+			targetNode.removeEventListener( targetEvent, this.onContinue );
 		}
 	}
 

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -64,7 +64,7 @@ export const MainTour = makeTour(
 				}
 			</p>
 			<p className="guided-tours__actionstep-instructions">
-				<Continue icon="my-sites" target="my-sites" step="sidebar" click>
+				<Continue icon="my-sites" target="my-sites" step="sidebar" targetEvent="click">
 					{
 						translate( 'Click the {{GridIcon/}} to continue.', {
 							components: {
@@ -110,11 +110,11 @@ export const MainTour = makeTour(
 				}
 			</p>
 			<p className="guided-tours__actionstep-instructions">
-				<Continue step="in-preview" target="site-card-preview" click>
+				<Continue step="in-preview" target="site-card-preview" targetEvent="click">
 					{
 						translate( "Click {{strong}}your site's name{{/strong}} to continue.", {
 							components: {
-								strong: <strong/>,
+								strong: <strong />,
 							},
 						} )
 					}


### PR DESCRIPTION
When creating a new tour, I noticed I would love to listen for `focus` or `change` events. This makes it possible. 
