### PR TITLE
General: update Instagram color

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -53,7 +53,7 @@ $color-gplus: #df4a32;
 $color-tumblr: #35465c;
 $color-linkedin: #0976b4;
 $color-path: #df3b2f;
-$color-instagram: #E12F67;
+$color-instagram: #e12f67;
 $color-eventbrite: #ff8000;
 $color-stumbleupon: #eb4924;
 $color-reddit: #5f99cf;

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -53,7 +53,7 @@ $color-gplus: #df4a32;
 $color-tumblr: #35465c;
 $color-linkedin: #0976b4;
 $color-path: #df3b2f;
-$color-instagram: #517fa4;
+$color-instagram: #E12F67;
 $color-eventbrite: #ff8000;
 $color-stumbleupon: #eb4924;
 $color-reddit: #5f99cf;


### PR DESCRIPTION
Instagram has updated their logo and branding. The logo in our icon set has been updated (still needs to be updated in wp-calypso):

https://github.com/Automattic/social-logos/pull/38

http://findguidelin.es suggests using this color for Instagram:

![screen shot 2016-10-17 at 11 46 35 am](https://cloud.githubusercontent.com/assets/618551/19446652/5ebb2abc-945f-11e6-8052-71b6035ff009.png)