### PR TITLE
Pages: after the homepage is set, update sites

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -25,7 +25,7 @@ import sitesFactory from 'lib/sites-list';
 /**
  * Constants
  */
- const sites = sitesFactory();
+const sitesList = sitesFactory();
 
 /**
  * Returns an action object to be used in signalling that a site object has
@@ -124,7 +124,7 @@ export function setFrontPage( siteId, pageId ) {
 		return wpcom.undocumented().setSiteHomepageSettings( siteId, requestData ).then( () => {
 			// Update the sites-list so that our change doesn't get wiped when the state is restored
 			// @TODO: Remove this when https://github.com/Automattic/wp-calypso/issues/8726 is complete
-			sites.fetch();
+			sitesList.fetch();
 
 			dispatch( recordTracksEvent( 'calypso_front_page_set', {
 				siteId,

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -20,6 +20,12 @@ import {
 	recordTracksEvent,
 } from 'state/analytics/actions';
 import { omit } from 'lodash';
+import sitesFactory from 'lib/sites-list';
+
+/**
+ * Constants
+ */
+ const sites = sitesFactory();
 
 /**
  * Returns an action object to be used in signalling that a site object has
@@ -116,6 +122,10 @@ export function setFrontPage( siteId, pageId ) {
 		};
 
 		return wpcom.undocumented().setSiteHomepageSettings( siteId, requestData ).then( () => {
+			// Update the sites-list so that our change doesn't get wiped when the state is restored
+			// @TODO: Remove this when https://github.com/Automattic/wp-calypso/issues/8726 is complete
+			sites.fetch();
+
 			dispatch( recordTracksEvent( 'calypso_front_page_set', {
 				siteId,
 				pageId,

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -31,6 +31,7 @@ import {
 } from 'state/action-types';
 import { sitesSchema } from './schema';
 import { isValidStateWithSchema, createReducer } from 'state/utils';
+import sitesFactory from 'lib/sites-list';
 
 /**
  * Constants
@@ -38,6 +39,7 @@ import { isValidStateWithSchema, createReducer } from 'state/utils';
 // [TODO]: This validation is only necessary so long as we continue to receive
 // decorated sites from the `lib/sites-list` module.
 const VALID_SITE_KEYS = Object.keys( sitesSchema.patternProperties[ '^\\d+$' ].properties );
+const sites = sitesFactory();
 
 /**
  * Tracks all known site objects, indexed by site ID.
@@ -54,6 +56,10 @@ export function items( state = {}, action ) {
 			if ( ! site ) {
 				break;
 			}
+
+			// Update the sites-list so that our change doesn't get wiped when the state is restored
+			// @TODO: Remove this when https://github.com/Automattic/wp-calypso/issues/8726 is complete
+			sites.fetch();
 
 			return {
 				...state,

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -31,7 +31,6 @@ import {
 } from 'state/action-types';
 import { sitesSchema } from './schema';
 import { isValidStateWithSchema, createReducer } from 'state/utils';
-import sitesFactory from 'lib/sites-list';
 
 /**
  * Constants
@@ -39,7 +38,6 @@ import sitesFactory from 'lib/sites-list';
 // [TODO]: This validation is only necessary so long as we continue to receive
 // decorated sites from the `lib/sites-list` module.
 const VALID_SITE_KEYS = Object.keys( sitesSchema.patternProperties[ '^\\d+$' ].properties );
-const sites = sitesFactory();
 
 /**
  * Tracks all known site objects, indexed by site ID.
@@ -56,10 +54,6 @@ export function items( state = {}, action ) {
 			if ( ! site ) {
 				break;
 			}
-
-			// Update the sites-list so that our change doesn't get wiped when the state is restored
-			// @TODO: Remove this when https://github.com/Automattic/wp-calypso/issues/8726 is complete
-			sites.fetch();
 
 			return {
 				...state,


### PR DESCRIPTION
This pull request fetches the sites list via the API after updating so that, after refreshing the page, the state is correct. This fixes an issue where the state was incorrect upon refreshing the page. It is part of a larger epic and is behind a feature flag, `manage/pages/set-homepage`, that is only enabled in `development`.

Note: this is a work-around, which can be removed when https://github.com/Automattic/wp-calypso/issues/8726 is resolved.

![homepage](https://cloud.githubusercontent.com/assets/363749/19449358/e73426d6-946a-11e6-8d6a-c8a794653b49.gif)

To test:
* Checkout branch and `make run`.
* Visit http://calypso.localhost:3000/pages/ and select a site using the site-selector.
* Change your homepage settings by using the ellipsis next to one of your pages. Give your sites list a while to load from the API.
* Reload the page, and verify that your homepage is reflected correctly.