### PR TITLE
Reader: Increase stream width

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -69,7 +69,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		max-width: 190px;
 
 		@include breakpoint( ">960px" ) {
-			max-width: 300px;
+			max-width: 250px;
 		}
 
 		@media #{$reader-post-card-breakpoint-medium} {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -69,7 +69,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		max-width: 190px;
 
 		@include breakpoint( ">960px" ) {
-			max-width: 250px;
+			max-width: 300px;
 		}
 
 		@media #{$reader-post-card-breakpoint-medium} {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -14,6 +14,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	@include breakpoint( ">660px" ) {
 		padding: 20px 0;
 	}
+
+	@media #{$reader-post-card-breakpoint-xlarge}  {
+		padding: 20px 15px;
+	}
 }
 
 .reader-post-card__meta {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -1,7 +1,7 @@
 // Reader-specific tweaks to components
 
-.following.main {
-	max-width: 850px;
+.is-reader-page .following.main {
+	max-width: 830px;
 }
 
 .following {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -1,5 +1,9 @@
 // Reader-specific tweaks to components
 
+.following.main {
+	max-width: 850px;
+}
+
 .following {
 
 	@include breakpoint( "<660px" ) {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -1,5 +1,6 @@
 // Reader-specific tweaks to components
 
+// Overrides default 720px width
 .is-reader-page .following.main {
 	max-width: 830px;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -125,7 +125,7 @@
 		"reader/related-posts": true,
 		"reader/refresh/full-post-ab-test": true,
 		"reader/refresh/force-full-post": false,
-		"reader/refresh/stream": false,
+		"reader/refresh/stream": true,
 		"reader/search": true,
 		"reader/start": true,
 		"reader/tags-with-elasticsearch": true,

--- a/config/development.json
+++ b/config/development.json
@@ -125,7 +125,7 @@
 		"reader/related-posts": true,
 		"reader/refresh/full-post-ab-test": true,
 		"reader/refresh/force-full-post": false,
-		"reader/refresh/stream": true,
+		"reader/refresh/stream": false,
 		"reader/search": true,
 		"reader/start": true,
 		"reader/tags-with-elasticsearch": true,


### PR DESCRIPTION
This is a try branch to address: https://github.com/Automattic/wp-calypso/issues/8732

Default 720px (with 250px featured image):
![750-default](https://cloud.githubusercontent.com/assets/4924246/19451183/2ac9b974-9461-11e6-94c1-bd11b0210b08.png)

A few other widths I tried:

**800px (250px featured image):**
![800](https://cloud.githubusercontent.com/assets/4924246/19451217/4ba941e6-9461-11e6-95a3-10545ca07780.png)

**830px (250px featured image):**
![830](https://cloud.githubusercontent.com/assets/4924246/19451225/54fc8a46-9461-11e6-8cf2-c7a282e98368.png)

**850px (300px featured image):**
![850-300 image](https://cloud.githubusercontent.com/assets/4924246/19451240/655f26be-9461-11e6-9596-558ff28b54f1.png)

@fraying I think either 800 or 830 is good. 850 is actually good too for cards with featured images, it's just a bit wide for excerpt-only ones.

This branch's link only has 850 to test so I included screenshots for other widths. I also just applied the width increase to the Following stream.
