### PR TITLE
Google Apps: Update links after the rebranding

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -1,7 +1,7 @@
 const root = 'https://support.wordpress.com';
 
 export default {
-	ADDING_GOOGLE_APPS_TO_YOUR_SITE: `${root}/add-email/adding-google-apps-to-your-site`,
+	ADDING_GOOGLE_APPS_TO_YOUR_SITE: `${root}/adding-g-suite-to-your-site`,
 	ADDING_USERS: `${root}/adding-users`,
 	ALL_ABOUT_DOMAINS: `${root}/all-about-domains`,
 	AUTO_RENEWAL: `${root}/auto-renewal`,
@@ -11,7 +11,7 @@ export default {
 	CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS: `${root}/domains/change-name-servers/#finding-out-your-new-name-server`,
 	COMMENTS: `${root}/category/comments`,
 	COMMUNITY_TRANSLATOR: `${root}/community-translator`,
-	COMPLETING_GOOGLE_APPS_SIGNUP: `${root}/adding-google-apps-to-your-site/#completing-sign-up`,
+	COMPLETING_GOOGLE_APPS_SIGNUP: `${root}/adding-g-suite-to-your-site/#completing-sign-up`,
 	CONNECT: `${ root }/connect`,
 	CALYPSO_CONTACT: '/help/contact',
 	CALYPSO_COURSES: '/help/courses',


### PR DESCRIPTION
Since `Google Apps` has now become `G Suite`, we should update links to use the new name too.
Our support documentation has been updated accordingly already - thanks to the awesome work of @mikeshenry.

cc @aidvu @umurkontaci 