### PR TITLE
Reader: Use refresh cards everywhere

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -2,11 +2,10 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { noop, truncate, get } from 'lodash';
+import { noop, truncate } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
-import debugFactory from 'debug';
 
 /**
  * Internal Dependencies
@@ -17,8 +16,6 @@ import Gravatar from 'components/gravatar';
 import Gridicon from 'components/gridicon';
 import ReaderPostActions from 'blocks/reader-post-actions';
 import * as stats from 'reader/stats';
-
-const debug = debugFactory( 'calypso:blocks:reader-post-card' );
 
 function FeaturedImage( { image, href } ) {
 	return (
@@ -123,12 +120,6 @@ export default class RefreshPostCard extends React.Component {
 			'has-thumbnail': !! featuredImage,
 			'is-photo': isPhotoOnly
 		} );
-
-		const postTitle = get( post, 'title' );
-		debug( 'site for post ' + postTitle );
-		debug( site );
-		debug( 'feed for post ' + postTitle );
-		debug( feed );
 
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -2,10 +2,11 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { noop, truncate } from 'lodash';
+import { noop, truncate, get } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
+import debugFactory from 'debug';
 
 /**
  * Internal Dependencies
@@ -16,6 +17,8 @@ import Gravatar from 'components/gravatar';
 import Gridicon from 'components/gridicon';
 import ReaderPostActions from 'blocks/reader-post-actions';
 import * as stats from 'reader/stats';
+
+const debug = debugFactory( 'calypso:blocks:reader-post-card' );
 
 function FeaturedImage( { image, href } ) {
 	return (
@@ -120,6 +123,12 @@ export default class RefreshPostCard extends React.Component {
 			'has-thumbnail': !! featuredImage,
 			'is-photo': isPhotoOnly
 		} );
+
+		const postTitle = get( post, 'title' );
+		debug( 'site for post ' + postTitle );
+		debug( site );
+		debug( 'feed for post ' + postTitle );
+		debug( feed );
 
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -142,6 +142,7 @@ export default class RefreshPostCard extends React.Component {
 						}
 					</div>
 				</div>
+				{ this.props.children }
 			</Card>
 		);
 	}

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -2,57 +2,15 @@
  * External dependencies
  */
 import React from 'react';
-import config from 'config';
 
 /**
  * Internal dependencies
  */
 import Stream from 'reader/stream';
-import ReaderPostCard from 'blocks/reader-post-card';
-
-class ReaderPostCardAdapter extends React.Component {
-
-	constructor( props ) {
-		super( props );
-		[ 'onCommentClick', 'onClick' ].forEach( method => {
-			this[ method ] = this[ method ].bind( this );
-		} );
-	}
-
-	onClick() {
-		this.props.handleClick && this.props.handleClick( this.props.post );
-	}
-
-	onCommentClick() {
-		this.props.handleClick && this.props.handleClick( this.props.post, { comments: true } );
-	}
-
-	// take what the stream hands to a card and adapt it
-	// for use by a ReaderPostCard
-	render() {
-		return ( <ReaderPostCard
-			post={ this.props.post }
-			site={ null }
-			feed={ null }
-			onClick={ this.onClick }
-			onCommentClick={ this.onCommentClick }
-		/> );
-	}
-}
-
-function refreshCardFactory( /* post */ ) {
-	// should look at the post and determine class to return.
-	// blocked posts should show a block card, x-posts an x-post card
-	return ReaderPostCardAdapter;
-}
 
 const FollowingStream = ( props ) => {
-	let cardFactory = null;
-	if ( config.isEnabled( 'reader/refresh/stream' ) ) {
-		cardFactory = refreshCardFactory;
-	}
 	return (
-		<Stream cardFactory={ cardFactory } { ...props } />
+		<Stream { ...props } />
 	);
 };
 

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -46,9 +47,11 @@ export class ReaderPostCardAdapter extends React.Component {
 
 export default connect(
 	( state, ownProps ) => {
+		const siteId = get( ownProps, 'post.site_ID' );
+		const feedId = get( ownProps, 'post.feed_ID' );
 		return {
-			site: getSite( state, ownProps.site_ID ),
-			feed: getFeed( state, ownProps.feed_ID )
+			site: getSite( state, siteId ),
+			feed: getFeed( state, feedId )
 		};
 	}
 )( ReaderPostCardAdapter );

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -27,7 +27,11 @@ export class ReaderPostCardAdapter extends React.Component {
 	// take what the stream hands to a card and adapt it
 	// for use by a ReaderPostCard
 	render() {
-		const { feed_ID: feedId, site_ID: siteId } = this.props.post;
+		const {
+			feed_ID: feedId,
+			site_ID: siteId,
+			is_external: isExternal
+		} = this.props.post;
 
 		// only query the site if the feed id is missing. feed queries end up fetching site info
 		// via a meta query, so we don't need both.
@@ -38,8 +42,8 @@ export class ReaderPostCardAdapter extends React.Component {
 				feed={ this.props.feed }
 				onClick={ this.onClick }
 				onCommentClick={ this.onCommentClick } >
-				{ feedId && <QueryReaderFeed feedId={ feedId } /> }
-				{ ! feedId && siteId && <QueryReaderSite siteId={ +siteId } /> }
+				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
+				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 			</ReaderPostCard>
 		);
 	}
@@ -48,9 +52,10 @@ export class ReaderPostCardAdapter extends React.Component {
 export default connect(
 	( state, ownProps ) => {
 		const siteId = get( ownProps, 'post.site_ID' );
+		const isExternal = get( ownProps, 'post.is_external' );
 		const feedId = get( ownProps, 'post.feed_ID' );
 		return {
-			site: getSite( state, siteId ),
+			site: isExternal ? null : getSite( state, siteId ),
 			feed: getFeed( state, feedId )
 		};
 	}

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import ReaderPostCard from 'blocks/reader-post-card';
+import { getSite } from 'state/reader/sites/selectors';
+import { getFeed } from 'state/reader/feeds/selectors';
+import QueryReaderSite from 'components/data/query-reader-site';
+import QueryReaderFeed from 'components/data/query-reader-feed';
+
+export class ReaderPostCardAdapter extends React.Component {
+
+	onClick = () => {
+		this.props.handleClick && this.props.handleClick( this.props.post );
+	}
+
+	onCommentClick = () => {
+		this.props.handleClick && this.props.handleClick( this.props.post, { comments: true } );
+	}
+
+	// take what the stream hands to a card and adapt it
+	// for use by a ReaderPostCard
+	render() {
+		const { feed_ID: feedId, site_ID: siteId } = this.props.post;
+
+		// only query the site if the feed id is missing. feed queries end up fetching site info
+		// via a meta query, so we don't need both.
+		return (
+			<ReaderPostCard
+				post={ this.props.post }
+				site={ this.props.site }
+				feed={ this.props.feed }
+				onClick={ this.onClick }
+				onCommentClick={ this.onCommentClick } >
+				{ feedId && <QueryReaderFeed feedId={ feedId } /> }
+				{ ! feedId && siteId && <QueryReaderSite siteId={ +siteId } /> }
+			</ReaderPostCard>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			site: getSite( state, ownProps.site_ID ),
+			feed: getFeed( state, ownProps.feed_ID )
+		};
+	}
+)( ReaderPostCardAdapter );

--- a/client/state/reader/feeds/actions.js
+++ b/client/state/reader/feeds/actions.js
@@ -1,5 +1,4 @@
 import isArray from 'lodash/isArray';
-import get from 'lodash/get';
 
 import wpcom from 'lib/wp';
 
@@ -7,8 +6,7 @@ import {
 	READER_FEED_REQUEST,
 	READER_FEED_REQUEST_SUCCESS,
 	READER_FEED_REQUEST_FAILURE,
-	READER_FEED_UPDATE,
-	READER_SITE_UPDATE
+	READER_FEED_UPDATE
 } from 'state/action-types';
 
 export function requestFeed( feedId ) {
@@ -19,19 +17,12 @@ export function requestFeed( feedId ) {
 				feed_ID: feedId
 			}
 		} );
-		return wpcom.undocumented().readFeed( { ID: feedId, meta: 'site' } ).then(
+		return wpcom.undocumented().readFeed( { ID: feedId } ).then(
 			function success( data ) {
 				dispatch( {
 					type: READER_FEED_REQUEST_SUCCESS,
 					payload: data
 				} );
-				const siteInfo = get( data, 'meta.data.site' );
-				if ( siteInfo ) {
-					dispatch( {
-						type: READER_SITE_UPDATE,
-						payload: siteInfo
-					} );
-				}
 				return data;
 			},
 			function failure( err ) {

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -53,22 +53,27 @@ function handleRequestFailure( state, action ) {
 	}, state );
 }
 
-function handleRequestSuccess( state, action ) {
-	const feed = assign( {}, action.payload );
+function adaptFeed( feed ) {
 	if ( feed.name ) {
 		feed.name = decodeEntities( feed.name );
 	}
+	feed.feed_ID = + feed.feed_ID;
+	feed.blog_ID = + feed.blog_ID;
+	return feed;
+}
+
+function handleRequestSuccess( state, action ) {
+	const feed = assign( {}, action.payload );
+	adaptFeed( feed );
 	return assign( {}, state, {
-		[ action.payload.feed_ID ]: feed
+		[ feed.feed_ID ]: feed
 	} );
 }
 
 function handleFeedUpdate( state, action ) {
 	const feeds = map( action.payload, feed => {
 		feed = assign( {}, feed );
-		if ( feed.name ) {
-			feed.name = decodeEntities( feed.name );
-		}
+		adaptFeed( feed );
 		return feed;
 	} );
 	return assign( {}, state, keyBy( feeds, 'feed_ID' ) );

--- a/client/state/reader/feeds/selectors.js
+++ b/client/state/reader/feeds/selectors.js
@@ -1,5 +1,3 @@
-
-
 /**
 * Returns true if we should fetch the feed
 *
@@ -11,4 +9,15 @@
 export function shouldFeedBeFetched( state, feedId ) {
 	return ! state.reader.feeds.queuedRequests[ feedId ] && // not currently queued
 		! state.reader.feeds.items[ feedId ]; // not currently loaded
+}
+
+/**
+ * Get the feed object for the given feed id
+ *
+ * @param  {Object} state  Global state tree
+ * @param  {Number} feedId The feed ID
+ * @return {Object}        The feed object
+ */
+export function getFeed( state, feedId ) {
+	return state.reader.feeds.items[ feedId ];
 }

--- a/client/state/reader/feeds/test/actions.js
+++ b/client/state/reader/feeds/test/actions.js
@@ -22,7 +22,7 @@ describe( 'actions', () => {
 
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.1/read/feed/1?meta=site' )
+				.get( '/rest/v1.1/read/feed/1' )
 				.reply( 200, {
 					feed_ID: 1,
 					name: 'My test feed'
@@ -61,7 +61,7 @@ describe( 'actions', () => {
 
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.1/read/feed/1?meta=site' )
+				.get( '/rest/v1.1/read/feed/1' )
 				.reply( 404 );
 			request = requestFeed( 1 )( spy );
 		} );

--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import isArray from 'lodash/isArray';
 
 import wpcom from 'lib/wp';
@@ -7,7 +6,6 @@ import {
 	READER_SITE_REQUEST,
 	READER_SITE_REQUEST_SUCCESS,
 	READER_SITE_REQUEST_FAILURE,
-	READER_FEED_UPDATE,
 	READER_SITE_UPDATE
 } from 'state/action-types';
 
@@ -19,19 +17,12 @@ export function requestSite( siteId ) {
 				ID: siteId
 			}
 		} );
-		return wpcom.undocumented().readSite( { site: siteId, meta: 'feed' } ).then(
+		return wpcom.undocumented().readSite( { site: siteId } ).then(
 			function success( data ) {
 				dispatch( {
 					type: READER_SITE_REQUEST_SUCCESS,
 					payload: data
 				} );
-				const feedInfo = get( data, 'meta.data.feed' );
-				if ( feedInfo ) {
-					dispatch( {
-						type: READER_FEED_UPDATE,
-						payload: feedInfo
-					} );
-				}
 				return data;
 			},
 			function failure( err ) {

--- a/client/state/reader/sites/test/actions.js
+++ b/client/state/reader/sites/test/actions.js
@@ -22,7 +22,7 @@ describe( 'actions', () => {
 
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.1/read/sites/1?meta=feed' )
+				.get( '/rest/v1.1/read/sites/1' )
 				.reply( 200, {
 					ID: 1,
 					name: 'My test site'
@@ -61,7 +61,7 @@ describe( 'actions', () => {
 
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.1/read/sites/1?meta=feed' )
+				.get( '/rest/v1.1/read/sites/1' )
 				.reply( 404 );
 			request = requestSite( 1 )( spy );
 		} );


### PR DESCRIPTION
Refactor how we inject refresh cards to support them acros the application, except in search. :/
Also, hook up feed and site info via redux. We do have this info (usually) in the flux store, but rather than making another crazy bridge, just prepare for the future and fetch what we need on demand.