### PR TITLE
Components: Author Select

### DIFF
--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -102,7 +102,6 @@ SwitcherShell = React.createClass( {
 						<InfiniteList
 							items={ users }
 							key={ infiniteListKey }
-							namespace={ infiniteListKey }
 							className="author-selector__infinite-list"
 							ref={ this._setListContext }
 							context={ this.state.listContext }
@@ -177,7 +176,6 @@ SwitcherShell = React.createClass( {
 				onClick={ this._selectAuthor.bind( this, author ) }
 				focusOnHover={ false }
 				key={ authorGUID }
-				ref={ authorGUID }
 				tabIndex="-1">
 				<UserItem user={ author }/>
 			</PopoverMenuItem>


### PR DESCRIPTION
This PR removes js warnings emitted by the AuthorSelect component.
It is part of the clean up effort at #7413 

Errors can be viewed by:
- running the latest master locally
- going to edit a post on a site with multiple authors
- change the author, and note the errors in the console

To test:
- apply this patch
- ensure the errors are gone
- ensure there are no regressions when changing a post's author

Note: there are some ES6 lint warnings still present in this component. They can be cleaned in a separate PR
