### PR TITLE
Reader Stream Refresh: add post options menu to card

### DIFF
--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -11,6 +11,7 @@ import CommentButton from 'blocks/comment-button';
 import LikeButton from 'reader/like-button';
 import ShareButton from 'reader/share';
 import PostEditButton from 'blocks/post-edit-button';
+import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import { shouldShowComments } from 'blocks/comments/helper';
 import { shouldShowLikes } from 'reader/like-helper';
 import { shouldShowShare } from 'reader/share/helper';
@@ -19,7 +20,7 @@ import * as stats from 'reader/stats';
 import { localize } from 'i18n-calypso';
 import ExternalLink from 'components/external-link';
 
-const ReaderPostActions = ( { translate, post, site, onCommentClick, showEdit, showVisit, iconSize, className } ) => {
+const ReaderPostActions = ( { translate, post, site, onCommentClick, showEdit, showVisit, showMenu, iconSize, className } ) => {
 	const onEditClick = () => {
 		stats.recordAction( 'edit_post' );
 		stats.recordGaEvent( 'Clicked Edit Post', 'full_post' );
@@ -71,6 +72,11 @@ const ReaderPostActions = ( { translate, post, site, onCommentClick, showEdit, s
 						showZeroCount={ false } />
 				</li>
 			}
+			{ showMenu &&
+				<li className="reader-post-actions__item">
+					<ReaderPostOptionsMenu className="ignore-click" post={ post } />
+				</li>
+			}
 		</ul>
 	);
 	/* eslint-enable react/jsx-no-target-blank */
@@ -81,12 +87,14 @@ ReaderPostActions.propTypes = {
 	site: React.PropTypes.object,
 	onCommentClick: React.PropTypes.func,
 	showEdit: React.PropTypes.bool,
-	iconSize: React.PropTypes.number
+	iconSize: React.PropTypes.number,
+	showMenu: React.PropTypes.bool
 };
 
 ReaderPostActions.defaultProps = {
 	showEdit: true,
 	showVisit: false,
+	showMenu: false,
 	iconSize: 24
 };
 

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -24,3 +24,7 @@
 		margin-right: 0;
 	}
 }
+
+.reader-post-actions .reader-post-options-menu .button.is-borderless .gridicon {
+	top: -2px;
+}

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -25,6 +25,9 @@
 	}
 }
 
-.reader-post-actions .reader-post-options-menu .button.is-borderless .gridicon {
-	top: -2px;
+.reader-post-actions .reader-post-options-menu .button.is-borderless {
+	color: lighten( $gray, 10% );
+	.gridicon {
+		top: -2px;
+	}
 }

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -18,6 +18,19 @@
 		.reader-post-actions__visit-label {
 			color: lighten( $gray, 10% );
 		}
+
+		.external-link:hover,
+		.external-link:focus,
+		.external-link:active {
+
+			.gridicon {
+				fill: $blue-light;
+			}
+
+			.reader-post-actions__visit-label {
+				color: $blue-light;
+			}
+		}
 	}
 
 	&:last-child {
@@ -25,9 +38,9 @@
 	}
 }
 
-.reader-post-actions .reader-post-options-menu .button.is-borderless {
-	color: lighten( $gray, 10% );
-	.gridicon {
+.reader-post-actions .reader-post-options-menu .button {
+
+	&.is-borderless .gridicon {
 		top: -2px;
 	}
 }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -13,7 +13,6 @@ import closest from 'component-closest';
 import Card from 'components/card';
 import DisplayTypes from 'state/reader/posts/display-types';
 import ReaderPostActions from 'blocks/reader-post-actions';
-import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import * as stats from 'reader/stats';
 import PostByline from './byline';
 
@@ -119,12 +118,12 @@ export default class RefreshPostCard extends React.Component {
 							<ReaderPostActions
 								post={ post }
 								showVisit={ true }
+								showMenu={ true }
 								onCommentClick={ onCommentClick }
 								showEdit={ false }
 								className="ignore-click"
 								iconSize={ 18 } />
 						}
-						{ post && <ReaderPostOptionsMenu className="ignore-click" post={ post } /> }
 					</div>
 				</div>
 				{ this.props.children }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -13,6 +13,7 @@ import closest from 'component-closest';
 import Card from 'components/card';
 import DisplayTypes from 'state/reader/posts/display-types';
 import ReaderPostActions from 'blocks/reader-post-actions';
+import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import * as stats from 'reader/stats';
 import PostByline from './byline';
 
@@ -123,6 +124,7 @@ export default class RefreshPostCard extends React.Component {
 								className="ignore-click"
 								iconSize={ 18 } />
 						}
+						{ post && <ReaderPostOptionsMenu className="ignore-click" post={ post } /> }
 					</div>
 				</div>
 				{ this.props.children }

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { noop, get } from 'lodash';
 import page from 'page';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -153,8 +154,10 @@ const ReaderPostOptionsMenu = React.createClass( {
 			isBlockPossible = true;
 		}
 
+		const classes = classnames( 'reader-post-options-menu', this.props.className );
+
 		return (
-			<span className="reader-post-options-menu">
+			<span className={ classes }>
 				<EllipsisMenu
 					className="reader-post-options-menu__ellipsis-menu"
 					onToggle={ this.onMenuToggle }>

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -1,9 +1,28 @@
+.reader-post-options-menu,
+.reader-post-options-menu .ellipsis-menu {
+
+	.button.is-borderless {
+		color: lighten( $gray, 10% );
+
+		&:hover,
+		&:focus,
+		&:active {
+			color: $blue-light;
+		}
+	}
+
+	&.is-menu-visible .button.is-borderless {
+		color: $blue-wordpress;
+	}
+}
+
 .reader-post-options-menu__hr {
 	margin: 8px 0;
-	background: lighten( $gray, 30 );
+	background: lighten( $gray, 30% );
 }
 
 .reader-post-options-menu__ellipsis-menu .follow-button {
+
 	&.is-following {
 
 		&:hover,

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -17,11 +17,11 @@
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	}
 
-	.is-active {
+	&.is-active {
 		color: $blue-wordpress;
 
 		.gridicon {
-			transform: rotate( 90deg );
+			fill: $blue-wordpress;
 		}
 	}
 }


### PR DESCRIPTION
Adds the new post options menu component (ellipsis menu) created in #8575 to the new post card.

![12ed1892-8bc8-11e6-9018-6e5782ba5df4](https://cloud.githubusercontent.com/assets/17325/19463685/9c41cba4-9552-11e6-9aa7-f004aeade524.jpg)

- [x] Add component (@bluefuton)
- [x] CSS positioning magic (@jancavan)