### PR TITLE
Editor: remove usage of site.isModuleActive from publicize-options.

### DIFF
--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -219,19 +219,6 @@ const EditorSharingPublicizeOptions = React.createClass( {
 			);
 		}
 
-		if ( ! isPublicizeEnabled ) {
-			return (
-				<div className="editor-sharing__publicize-disabled">
-					<p><span>{ this.translate( 'Enable the Publicize module to automatically share new posts to social networks.' ) }</span></p>
-					<button
-							className="editor-sharing__jetpack-modules-button button is-secondary"
-							onClick={ this.jetpackModulePopup } >
-						{ this.translate( 'View Module Settings' ) }
-					</button>
-				</div>
-			);
-		}
-
 		const classes = classNames( 'editor-sharing__publicize-options', {
 			'has-connections': this.hasConnections(),
 			'has-add-option': this.props.userCanPublishPosts

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -206,12 +206,12 @@ const EditorSharingPublicizeOptions = React.createClass( {
 		this.props.dismissShareConfirmation( this.props.siteId, this.props.post.ID );
 	},
 	render: function() {
-		const { isPublicizeEnabled, publicizePermanentlyDisabled, site } = this.props;
+		const { isPublicizeEnabled, publicizePermanentlyDisabled } = this.props;
 		if ( ! isPublicizeEnabled ) {
 			return null;
 		}
 
-		if ( site && publicizePermanentlyDisabled ) {
+		if ( publicizePermanentlyDisabled ) {
 			return (
 				<div className="editor-sharing__publicize-disabled">
 					<p><span>{ this.translate( 'Publicize is disabled on this site.' ) }</span></p>
@@ -219,7 +219,7 @@ const EditorSharingPublicizeOptions = React.createClass( {
 			);
 		}
 
-		if ( site && ! isPublicizeEnabled ) {
+		if ( ! isPublicizeEnabled ) {
 			return (
 				<div className="editor-sharing__publicize-disabled">
 					<p><span>{ this.translate( 'Enable the Publicize module to automatically share new posts to social networks.' ) }</span></p>


### PR DESCRIPTION
While working on migrating `sitesList` usage in `<PostEditor />` for #8726 - I encountered some issues with the `<PublicizeOptions />` component, specifically the usage of `site.isModuleActive` which is a method on Jetpack sites in the `sitesList`.  In lieu of updating all cases of `isModuleActive` in one PR, I think doing it on a per-component basis will make things easier to review.

No functional changes should be encountered by this branch, but I'm not entirely savvy with all the various edge cases of Publicize in the editor sidebar, so paging the expertise of @aduth on what are some of the big gotchas to test.  In my testing on JP and WPCOM sites, all seems to be working as expected.
