### PR TITLE
Fix Image Editor Devdocs onDone handler

### DIFF
--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -15,30 +15,34 @@ function ImageEditorExample( { primarySiteId } ) {
 	const media = {
 		URL: 'https://cldup.com/mA_hqNVj0w.jpg'
 	};
-	
+
 	const getTestingImage = () => document.querySelector( "#devdocs-example-image-editor-result" );
-	
-	const onImageExtracted = ( blob ) => {
-		const imageUrl = window.URL.createObjectURL( blob );
+
+	const onImageEditorDone = ( error, blob ) => {
+		if ( error ) {
+			return;
+		}
 		
+		const imageUrl = window.URL.createObjectURL( blob );
+
 		getTestingImage().src = imageUrl;
 	};
-	
+
 	const onImageEditorReset = () => {
 		getTestingImage().src = media.URL;
 	};
-	
+
 	return (
 		<div>
 			<div style={ { height: '80vh' } }>
 				<ImageEditor
 					siteId={ primarySiteId }
 					media={ media }
-					onImageExtracted={ onImageExtracted }
+					onDone={ onImageEditorDone }
 					onReset={ onImageEditorReset }
 				/>
 			</div>
-			<div style={ { 
+			<div style={ {
 				textAlign: 'center',
 				marginTop: '15px'
 			} }>


### PR DESCRIPTION
Follow-up of #8759. In that PR, we changed the signature of the "Done" button handler from `onImageExtracted` to `onDone`. We forgot to change this in image editor devdocs. This PR introduces that change as well as marking the `media` prop object of `ImageEditor` component as `isRequired` as per the readme file.

/cc @gwwar 