### PR TITLE
Checkout: Add Brazilian real (BRL) currency support

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -57,7 +57,8 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		JPY: 125,
 		AUD: 1.35,
 		CAD: 1.35,
-		GBP: 0.75
+		GBP: 0.75,
+		BRL: 2.55
 	};
 
 /**

--- a/client/lib/format-currency/index.js
+++ b/client/lib/format-currency/index.js
@@ -39,6 +39,12 @@ const CURRENCIES = {
 		grouping: ',',
 		decimal: '.',
 		precision: 0
+	},
+	BRL: {
+		symbol: 'R$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
 	}
 };
 

--- a/client/lib/format-currency/test/index.js
+++ b/client/lib/format-currency/test/index.js
@@ -55,6 +55,10 @@ describe( 'formatCurrency', () => {
 			const money = formatCurrency( 9800900.32, 'JPY' );
 			expect( money ).to.equal( '¥9,800,900' );
 		} );
+		it( 'BRL', () => {
+			const money = formatCurrency( 9800900.32, 'BRL' );
+			expect( money ).to.equal( 'R$9,800,900.32' );
+		} );
 	} );
 
 	describe( 'getCurrencyDefaults()', () => {
@@ -139,6 +143,15 @@ describe( 'formatCurrency', () => {
 					symbol: '¥',
 					integer: '9,800,900',
 					fraction: '',
+					sign: ''
+				} );
+			} );
+			it( 'BRL', () => {
+				const money = getCurrencyObject( 9800900.32, 'BRL' );
+				expect( money ).to.eql( {
+					symbol: 'R$',
+					integer: '9,800,900',
+					fraction: '.32',
 					sign: ''
 				} );
 			} );


### PR DESCRIPTION
This PR adds support for a Brazilian real (BRL) currency. For the time being it only is going to work if we force BRL as a currency using backend. More to come in the follow up PR.

_At the time of writing we don't have proper prices set on the backend side._

### Testing
1. Apply backend patch D2828.
2. Follow the steps from the backend patch.
3. Open http://calypso.localhost:3000.
4. Navigate to page s where you can find domains, plans or themes upgrades. This is what you should see.

![screen shot 2016-10-18 at 09 31 16](https://cloud.githubusercontent.com/assets/699132/19472802/07aeaf1c-9529-11e6-8040-1d177a5e4842.png)
![screen shot 2016-10-18 at 09 32 24](https://cloud.githubusercontent.com/assets/699132/19472803/07c72cb8-9529-11e6-8662-8499c2131880.png)
![screen shot 2016-10-18 at 11 12 54](https://cloud.githubusercontent.com/assets/699132/19472804/07d6d5dc-9529-11e6-8be5-73058ba39c2c.png)


/cc @peterbutler @prettyboymp @janm6k 