### PR TITLE
Signup: Reset Verticals step state on signup complete

### DIFF
--- a/client/state/signup/steps/survey/reducer.js
+++ b/client/state/signup/steps/survey/reducer.js
@@ -3,6 +3,7 @@
  */
 import {
 	SIGNUP_STEPS_SURVEY_SET,
+	SIGNUP_COMPLETE_RESET,
 } from 'state/action-types';
 
 import { createReducer } from 'state/utils';
@@ -16,6 +17,9 @@ export default createReducer( {},
 				vertical: action.survey.vertical,
 				otherText: action.survey.otherText
 			};
+		},
+		[ SIGNUP_COMPLETE_RESET ]: () => {
+			return {};
 		},
 	},
 	surveyStepSchema

--- a/client/state/signup/steps/survey/test/reducer.js
+++ b/client/state/signup/steps/survey/test/reducer.js
@@ -28,9 +28,15 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should reset the survey on signup complete', () => {
-		expect( signupSurveyReducer( {}, {
-			type: SIGNUP_COMPLETE_RESET,
-			action: {}
-		} ) ).to.be.eql( {} );
+		expect( signupSurveyReducer(
+			{
+				vertical: 'test-survey',
+				otherText: 'test-other-text'
+			},
+			{
+				type: SIGNUP_COMPLETE_RESET,
+				action: {}
+			}
+		) ).to.be.eql( {} );
 	} );
 } );

--- a/client/state/signup/steps/survey/test/reducer.js
+++ b/client/state/signup/steps/survey/test/reducer.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	SIGNUP_STEPS_SURVEY_SET,
+	SIGNUP_COMPLETE_RESET,
+} from 'state/action-types';
+
+import signupSurveyReducer from '../reducer';
+
+describe( 'reducer', () => {
+	it( 'should update the survey', () => {
+		expect( signupSurveyReducer( {}, {
+			type: SIGNUP_STEPS_SURVEY_SET,
+			survey: {
+				vertical: 'test-survey',
+				otherText: 'test-other-text'
+			}
+		} ) ).to.be.eql( {
+			vertical: 'test-survey',
+			otherText: 'test-other-text'
+		} );
+	} );
+
+	it( 'should reset the survey on signup complete', () => {
+		expect( signupSurveyReducer( {}, {
+			type: SIGNUP_COMPLETE_RESET,
+			action: {}
+		} ) ).to.be.eql( {} );
+	} );
+} );

--- a/client/state/signup/steps/survey/test/selectors.js
+++ b/client/state/signup/steps/survey/test/selectors.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSurveyVertical, getSurveyOtherText } from '../selectors';
+
+describe( 'selectors', () => {
+	it( 'should return empty string as a default state', () => {
+		expect( getSurveyVertical( { signup: undefined } ) ).to.be.eql( '' );
+		expect( getSurveyOtherText( { signup: undefined } ) ).to.be.eql( '' );
+	} );
+
+	it( 'should return chosen vertical from the state', () => {
+		expect( getSurveyVertical( {
+			signup: {
+				steps: {
+					survey: {
+						vertical: 'test-survey',
+						otherText: 'test-other-text',
+					}
+				}
+			}
+		} ) ).to.be.eql( 'test-survey' );
+	} );
+
+	it( 'should return typed other text from the state', () => {
+		expect( getSurveyOtherText( {
+			signup: {
+				steps: {
+					survey: {
+						vertical: 'test-survey',
+						otherText: 'test-other-text',
+					}
+				}
+			}
+		} ) ).to.be.eql( 'test-other-text' );
+	} );
+} );


### PR DESCRIPTION
A Signup Redux state reset mechanism was introduced in #8682 .

This PR brings the Survey Signup step to follow that pattern.

There shouldn't be any functional changes in the way Signup works. 

To test:

1. Checkout branch or use the Calypso.live link.
2. Start signup and make sure to use `surveyStepV2` AB variation.
3. Go through Signup
4. At the user step, before submitting, check IndexedDB if it contains the proper verticals you chose in `signup.steps.survey`
5. Submit the user form and wait for the `Continue` button to activate. Do NOT submit.
6. Follow the same steps from _4._ and verify that the `survey` state has been reset to an empty object - `{}`
7. Verify there were no console errors. 


cc @michaeldcain @coreh 