### PR TITLE
Masterbar: Replace sitesList.getSelectedSite() with selector

### DIFF
--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,8 +13,9 @@ import SitesPopover from 'components/sites-popover';
 import paths from 'lib/paths';
 import viewport from 'lib/viewport';
 import { preload } from 'sections-preload';
+import { getSelectedSite } from 'state/ui/selectors';
 
-export default React.createClass( {
+const Publish = React.createClass( {
 	displayName: 'MasterbarItemNew',
 
 	propTypes: {
@@ -22,6 +24,8 @@ export default React.createClass( {
 		isActive: React.PropTypes.bool,
 		className: React.PropTypes.string,
 		tooltip: React.PropTypes.string,
+		// connected props
+		selectedSite: React.PropTypes.object,
 	},
 
 	getInitialState() {
@@ -69,7 +73,7 @@ export default React.createClass( {
 
 	render() {
 		const classes = classNames( this.props.className );
-		const currentSite = this.props.sites.getSelectedSite() || this.props.user.get().primarySiteSlug;
+		const currentSite = this.props.selectedSite || this.props.user.get().primarySiteSlug;
 		const newPostPath = paths.newPost( currentSite );
 
 		return (
@@ -96,3 +100,7 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	return { selectedSite: getSelectedSite( state ) };
+} )( Publish );

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -15,9 +15,7 @@ import viewport from 'lib/viewport';
 import { preload } from 'sections-preload';
 import { getSelectedSite } from 'state/ui/selectors';
 
-const Publish = React.createClass( {
-	displayName: 'MasterbarItemNew',
-
+const MasterbarItemNew = React.createClass( {
 	propTypes: {
 		user: React.PropTypes.object,
 		sites: React.PropTypes.object,
@@ -103,4 +101,4 @@ const Publish = React.createClass( {
 
 export default connect( ( state ) => {
 	return { selectedSite: getSelectedSite( state ) };
-} )( Publish );
+} )( MasterbarItemNew );


### PR DESCRIPTION
Replace use of sitesList.getSelectedSite() with redux selector.

**To Test**
* Hover over 'new post' button on masterbar (top right)
* Check that url (bottom left) contains selected site, or primary site if no site selected

<img width="1164" alt="screen shot 2016-10-18 at 14 11 07" src="https://cloud.githubusercontent.com/assets/7767559/19479063/e9180292-953c-11e6-9156-f9c6118609fa.png">
