### PR TITLE
Themes: Add renderToString() test for theme info page (take 2)

### DIFF
--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -45,7 +45,7 @@ describe( 'main', function() {
 			} );
 
 			// longer timeout for compilation of main.jsx
-			this.timeout( 4000 );
+			this.timeout( 10000 );
 			this.ThemeSheetComponent = require( '../main' );
 
 			this.themeData = {

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { renderToString } from 'react-dom/server';
+import mockery from 'mockery';
+import noop from 'lodash/noop';
+import {
+	receiveThemeDetails,
+	receiveThemeDetailsFailure,
+} from 'state/themes/actions';
+
+/**
+ * Internal dependencies
+ */
+import { createReduxStore } from 'state';
+import useMockery from 'test/helpers/use-mockery';
+import EmptyComponent from 'test/helpers/react/empty-component';
+
+describe( 'main', function() {
+	describe( 'Calling renderToString() on Theme Info sheet', function() {
+		useMockery();
+
+		before( function() {
+			mockery.registerMock( 'my-sites/themes/theme-preview', EmptyComponent );
+			mockery.registerMock( 'my-sites/themes/thanks-modal', EmptyComponent );
+			mockery.registerMock( 'my-sites/themes/themes-site-selector-modal', EmptyComponent );
+			mockery.registerMock( 'components/data/query-user-purchases', EmptyComponent );
+			mockery.registerMock( 'lib/analytics', {} );
+			mockery.registerMock( 'my-sites/themes/helpers', {
+				isPremium: noop,
+				getForumUrl: noop,
+				getDetailsUrl: noop,
+			} );
+			mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );
+			mockery.registerMock( 'lib/wp', {
+				me: () => ( {
+					get: noop
+				} ),
+				undocumented: () => ( {
+					getProducts: noop
+				} ),
+			} );
+
+			// longer timeout for compilation of main.jsx
+			this.timeout( 4000 );
+			this.ThemeSheetComponent = require( '../main' );
+
+			this.themeData = {
+				name: 'Twenty Sixteen',
+				author: 'the WordPress team',
+				screenshot: 'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
+				description: 'Twenty Sixteen is a modernized take on an ever-popular WordPress layout — ...',
+				descriptionLong: '<p>Mumble Mumble</p>',
+				download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentysixteen.zip',
+				taxonomies: {},
+				stylesheet: 'pub/twentysixteen',
+				demo_uri: 'https://twentysixteendemo.wordpress.com/'
+			};
+		} );
+
+		it( "doesn't throw an exception without theme data", function() {
+			const store = createReduxStore();
+			const layout = (
+				<ReduxProvider store={ store }>
+					<this.ThemeSheetComponent id={ 'twentysixteen' } />
+				</ReduxProvider>
+			);
+			let markup;
+			assert.doesNotThrow( () => {
+				markup = renderToString( layout );
+			} );
+			assert.isTrue( markup.includes( 'theme__sheet' ) );
+		} );
+
+		it( "doesn't throw an exception with theme data", function() {
+			const store = createReduxStore();
+			store.dispatch( receiveThemeDetails( this.themeData ) );
+			const layout = (
+				<ReduxProvider store={ store }>
+					<this.ThemeSheetComponent id={ 'twentysixteen' } />
+				</ReduxProvider>
+			);
+			let markup;
+			assert.doesNotThrow( () => {
+				markup = renderToString( layout );
+			} );
+			assert.isTrue( markup.includes( 'theme__sheet' ) );
+		} );
+
+		it( "doesn't throw an exception with invalid theme data", function() {
+			const store = createReduxStore();
+			store.dispatch( receiveThemeDetailsFailure( 'invalidthemeid', 'not found' ) );
+			const layout = (
+				<ReduxProvider store={ store }>
+					<this.ThemeSheetComponent id={ 'invalidthemeid' } />
+				</ReduxProvider>
+			);
+			let markup;
+			assert.doesNotThrow( () => {
+				markup = renderToString( layout );
+			} );
+			assert.isTrue( markup.includes( 'empty-content' ) );
+		} );
+	} );
+} );
+


### PR DESCRIPTION
Re-attempting #8628 without the timeouts.

#8628 had a custom timeout, intended to allow more time when running locally, that was actually [shorter](https://github.com/Automattic/wp-calypso/blob/121b3812296a1d5b54f2e67c910b0e8cd30c43d7/test/runner.js#L47) than the default CircleCI timeout, causing problems when running on CircleCI. Fixed in c820f78.
