### PR TITLE
Reader: Make checking for thumbnail urls safer

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -92,7 +92,7 @@ export function domForHtml( html ) {
  * @return {boolean}       whether or not we think this is an image
  */
 export function thumbIsLikelyImage( thumb ) {
-	if ( ! thumb ) {
+	if ( ! thumb || ! thumb.URL ) {
 		return false;
 	}
 	// this doesn't work because jetpack 4.2 lies


### PR DESCRIPTION
Currently throws on Laughing Squid, because the post_thumbnail is an object with a null URL