### PR TITLE
Plans: allow existing users to see nudge

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -69,7 +69,7 @@ class DomainToPlanNudge extends Component {
 			site &&           //site exists
 			site.wpcom_url && //has a mapped domain
 			hasFreePlan &&    //has a free wpcom plan
-			abtest( 'domainToPersonalPlanNudge' ) === 'nudge';
+			abtest( 'domainToPersonalPlanNudge2' ) === 'nudge';
 	}
 
 	personalCheckout() {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,13 +123,13 @@ module.exports = {
 		defaultVariation: 'hideSiteTitleStep',
 		allowExistingUsers: false
 	},
-	domainToPersonalPlanNudge: {
-		datestamp: '20161011',
+	domainToPersonalPlanNudge2: {
+		datestamp: '20161018',
 		variations: {
 			original: 50,
 			nudge: 50
 		},
 		defaultVariation: 'original',
-		allowExistingUsers: false
+		allowExistingUsers: true
 	}
 };


### PR DESCRIPTION
I checked in on this, and it looks like I set the abtest config incorrectly in #8635 before to not allow existing users. Due to the nudge constraints (has a paid domain with free plan) this was highly unlikely to be shown to anyone.

<img width="932" alt="36d88958-8f06-11e6-88a8-ff8875352bb9" src="https://cloud.githubusercontent.com/assets/1270189/19481755/e3645b0e-9503-11e6-8b38-532135ea1f59.png">


## Testing Instructions

- Navigate to calypso.localhost:3000/domains
- Select a wpcom site with: (a free plan + a paid domain )
- Set the abtest value of 'domainToPersonalPlanNudge2' to 'nudge'
- The nudge should render
- Clicking on upgrade should take us to checkout
- Clicking the 'x' dismiss should make this item never appear again