### PR TITLE
Reader: Remove comma container

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -72,7 +72,7 @@ class PostByline extends React.Component {
 							{ post.author.name }
 						</ReaderAuthorLink>
 					}
-					{ shouldDisplayAuthor && <span className="reader-post-card__byline-separator">,</span> }
+					{ shouldDisplayAuthor && ', ' }
 					<ReaderSiteStreamLink
 						className="reader-post-card__site reader-post-card__link"
 						feedId={ feedId }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -40,6 +40,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__byline-details {
+	color: $blue-medium;
 	margin-top: -2px;
 	width: 100%;
 }
@@ -243,11 +244,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			display: none;
 		}
 	}
-}
-
-.reader-post-card__byline-separator {
-	padding-right: 2px;
-	color: $blue-medium;
 }
 
 // For these borderless cards to look more presentable on Devdocs


### PR DESCRIPTION
Super tiny update for: https://github.com/Automattic/wp-calypso/pull/8701

Wanted to just eliminate the extra span and padding.