### PR TITLE
Media: Call correct reset prop on unmount

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -80,7 +80,7 @@ export const EditorMediaModal = React.createClass( {
 	},
 
 	componentWillUnmount() {
-		this.props.resetMediaModalView();
+		this.props.resetView();
 	},
 
 	getDefaultState: function( props ) {


### PR DESCRIPTION
Regression introduced in #8691

This pull request seeks to resolve an error which can be logged when unmounting the media modal, caused by calling a prop function which does not exist. While `resetMediaModalView` is the name of the action creator function, in the component's `mapDispatchToProps` it is renamed to `resetView`. The changes in this pull request correct this error.

__Testing Instructions:__

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click Add Media in the editor toolbar
4. Dismiss the modal
5. Note that no errors are logged to console