### PR TITLE
Reader: Add a min-height for featured images in refresh stream

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -100,9 +100,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		flex-grow: 1;
 		margin-right: 20px;
 		max-width: 190px;
+		min-height: 143px;
 
 		@include breakpoint( ">960px" ) {
 			max-width: 250px;
+			min-height: 188px;
 		}
 
 		@media #{$reader-post-card-breakpoint-medium} {


### PR DESCRIPTION
This prevents cards from totally collapsing when the excerpt is short.