### PR TITLE
Happychat: Force URL schemes for links in messages

### DIFF
--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -42,6 +42,7 @@ function isHttps( url ) {
 	return url && startsWith( url, 'https://' );
 }
 
+const schemeRegex = /^\w+:\/\//;
 const urlWithoutHttpRegex = /^https?:\/\//;
 
 /**
@@ -61,9 +62,32 @@ function withoutHttp( url ) {
 	return url.replace( urlWithoutHttpRegex, '' );
 }
 
+function addSchemeIfMissing( url, scheme ) {
+	if ( false === schemeRegex.test( url ) ) {
+		return scheme + '://' + url;
+	}
+	return url;
+}
+
+function setUrlScheme( url, scheme ) {
+	const schemeWithSlashes = scheme + '://';
+	if ( startsWith( url, schemeWithSlashes ) ) {
+		return url;
+	}
+
+	const newUrl = addSchemeIfMissing( url, scheme );
+	if ( newUrl !== url ) {
+		return newUrl;
+	}
+
+	return url.replace( schemeRegex, schemeWithSlashes );
+}
+
 export default {
 	isOutsideCalypso,
 	isExternal,
 	isHttps,
-	withoutHttp
+	withoutHttp,
+	addSchemeIfMissing,
+	setUrlScheme,
 };

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -7,7 +7,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
-import { isExternal, withoutHttp } from '../';
+import {
+	isExternal,
+	withoutHttp,
+	addSchemeIfMissing,
+	setUrlScheme,
+} from '../';
 
 describe( 'withoutHttp', () => {
 	it( 'should return null if URL is not provided', () => {
@@ -134,5 +139,54 @@ describe( 'isExternal', () => {
 
 			expect( actual ).to.be.true;
 		} );
+	} );
+} );
+
+describe( 'addSchemeIfMissing()', () => {
+	it( 'should add scheme if missing', () => {
+		const source = 'example.com/path';
+		const expected = 'https://example.com/path';
+
+		const actual = addSchemeIfMissing( source, 'https' );
+
+		expect( actual ).to.equal( expected );
+	} );
+
+	it( 'should skip if scheme exists', () => {
+		const source = 'https://example.com/path';
+		const expected = 'https://example.com/path';
+
+		const actual = addSchemeIfMissing( source, 'https' );
+
+		expect( actual ).to.equal( expected );
+	} );
+} );
+
+describe( 'setUrlScheme()', () => {
+	it( 'should skip if scheme already set', () => {
+		const source = 'http://example.com/path';
+		const expected = 'http://example.com/path';
+
+		const actual = setUrlScheme( source, 'http' );
+
+		expect( actual ).to.equal( expected );
+	} );
+
+	it( 'should add scheme if missing', () => {
+		const source = 'example.com/path';
+		const expected = 'http://example.com/path';
+
+		const actual = setUrlScheme( source, 'http' );
+
+		expect( actual ).to.equal( expected );
+	} );
+
+	it( 'should replace scheme if different', () => {
+		const source = 'https://example.com/path';
+		const expected = 'http://example.com/path';
+
+		const actual = setUrlScheme( source, 'http' );
+
+		expect( actual ).to.equal( expected );
 	} );
 } );


### PR DESCRIPTION
For internal URLs, we should match the current scheme of the page. For all other URLs, append `http` scheme if not already set.

## To Test

- Open a new chat chat via the "Support Chat" link the sidebar.
- Send yourself a message with the following links (assuming you're on `https://calypso.live`):
 - `https://example.com` (should stay unchanged and open in new window)
 - `http://example.com` (should stay unchanged and open in new window)
 - `http://calypso.live/me` (link should have scheme set to `https` and navigate without a reload)
 - `https://calypso.live/me` (link should stay as-is and navigate without reload)