### PR TITLE
Devdocs: fix ReaderAuthorLink example

### DIFF
--- a/client/blocks/reader-author-link/docs/example.jsx
+++ b/client/blocks/reader-author-link/docs/example.jsx
@@ -9,16 +9,17 @@ import React from 'react';
 import ReaderAuthorLink from 'blocks/reader-author-link';
 import Card from 'components/card';
 
-export default React.createClass( {
+const ReaderAuthorLinkExample = () => {
 
-	displayName: 'ReaderAuthorLink',
+	const author = { URL: 'http://wpcalypso.wordpress.com', name: 'Barnaby Blogwit' };
 
-	render() {
-		const author = { URL: 'http://wpcalypso.wordpress.com' };
-		return (
-			<Card>
-				<ReaderAuthorLink author={ author }>Author site</ReaderAuthorLink>
-			</Card>
-		);
-	}
-} );
+	return (
+		<Card>
+			<ReaderAuthorLink author={ author }>{ author.name }</ReaderAuthorLink>
+		</Card>
+	);
+};
+
+ReaderAuthorLinkExample.displayName = 'ReaderAuthorLink';
+
+export default ReaderAuthorLinkExample;

--- a/client/blocks/reader-author-link/docs/example.jsx
+++ b/client/blocks/reader-author-link/docs/example.jsx
@@ -15,7 +15,7 @@ const ReaderAuthorLinkExample = () => {
 
 	return (
 		<Card>
-			<ReaderAuthorLink author={ author }>{ author.name }</ReaderAuthorLink>
+			<ReaderAuthorLink author={ author }>Author site</ReaderAuthorLink>
 		</Card>
 	);
 };


### PR DESCRIPTION
@hoverduck noted in #8821 that there's a regression in the `ReaderAuthorLink` in Devdocs, introduced by a change in behaviour when `author.name` is null in #8701.

This PR fixes the example:

http://calypso.localhost:3000/devdocs/blocks/reader-author-link

...which should now look like this:

<img width="672" alt="screen shot 2016-10-19 at 11 56 55" src="https://cloud.githubusercontent.com/assets/17325/19499475/2d895988-95f3-11e6-858c-60290cdbf358.png">
