### PR TITLE
Reader: add ReaderAuthorLink tests

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -56,7 +56,7 @@ const AuthorCompactProfile = React.createClass( {
 				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames &&
 					<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>{ author.name }</ReaderAuthorLink> }
 				{ siteName &&
-					<ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId } post={ post } >
+					<ReaderSiteStreamLink className="author-compact-profile__site-link" feedId={ feedId } siteId={ siteId } post={ post }>
 						{ siteName }
 					</ReaderSiteStreamLink> }
 

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -32,12 +32,12 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children, className } ) => {
 		return null;
 	}
 
-	// If we have neither author.URL or siteUrl, just return children
-	if ( ! siteUrl ) {
-		return children;
-	}
-
 	const classes = classnames( 'reader-author-link', className );
+
+	// If we have neither author.URL or siteUrl, just return children in a wrapper
+	if ( ! siteUrl ) {
+		return ( <span className={ classes }>{children}</span> );
+	}
 
 	return (
 		<a className={ classes } href={ siteUrl } onClick={ recordAuthorClick }>

--- a/client/blocks/reader-author-link/test/index.jsx
+++ b/client/blocks/reader-author-link/test/index.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ReaderAuthorLink from '../index';
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'ReaderAuthorLink', () => {
+	useMockery( mockery => {
+		mockery.registerMock( 'reader/stats', {
+			recordAction: noop,
+			recordGaEvent: noop,
+			recordTrackForPost: noop
+		} );
+	} );
+
+	// check that content within a card renders correctly
+	it( 'should render children', () => {
+		const link = shallow( <ReaderAuthorLink>Barnaby Blogwit</ReaderAuthorLink> );
+		expect( link.contains( 'Barnaby Blogwit' ) ).to.equal( true );
+	} );
+} );

--- a/client/blocks/reader-author-link/test/index.jsx
+++ b/client/blocks/reader-author-link/test/index.jsx
@@ -9,10 +9,11 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import ReaderAuthorLink from '../index';
 import useMockery from 'test/helpers/use-mockery';
 
 describe( 'ReaderAuthorLink', () => {
+	let ReaderAuthorLink;
+
 	useMockery( mockery => {
 		mockery.registerMock( 'reader/stats', {
 			recordAction: noop,
@@ -21,9 +22,14 @@ describe( 'ReaderAuthorLink', () => {
 		} );
 	} );
 
+	before( () => {
+		ReaderAuthorLink = require( '../index' );
+	} );
+
 	// check that content within a card renders correctly
 	it( 'should render children', () => {
-		const link = shallow( <ReaderAuthorLink>Barnaby Blogwit</ReaderAuthorLink> );
+		const author = { URL: 'http://wpcalypso.wordpress.com', name: 'Barnaby Blogwit' };
+		const link = shallow( <ReaderAuthorLink author={ author }>Barnaby Blogwit</ReaderAuthorLink> );
 		expect( link.contains( 'Barnaby Blogwit' ) ).to.equal( true );
 	} );
 } );

--- a/client/blocks/reader-author-link/test/index.jsx
+++ b/client/blocks/reader-author-link/test/index.jsx
@@ -24,28 +24,49 @@ describe( 'ReaderAuthorLink', () => {
 
 	before( () => {
 		ReaderAuthorLink = require( '../index' );
+	} );
+
+	beforeEach( () => {
 		author = { URL: 'http://wpcalypso.wordpress.com', name: 'Barnaby Blogwit' };
 	} );
 
 	it( 'should render children', () => {
-		const link = shallow( <ReaderAuthorLink author={ author }>Barnaby Blogwit</ReaderAuthorLink> );
-		expect( link.contains( 'Barnaby Blogwit' ) ).to.equal( true );
+		const wrapper = shallow( <ReaderAuthorLink author={ author }>Barnaby Blogwit</ReaderAuthorLink> );
+		expect( wrapper.contains( 'Barnaby Blogwit' ) ).to.equal( true );
 	} );
 
 	it( 'should accept a custom class of `test__ace`', () => {
-		const link = shallow( <ReaderAuthorLink author={ author } className="test__ace">xyz</ReaderAuthorLink> );
-		expect( link.is( '.test__ace' ) ).to.equal( true );
+		const wrapper = shallow( <ReaderAuthorLink author={ author } className="test__ace">xyz</ReaderAuthorLink> );
+		expect( wrapper.is( '.test__ace' ) ).to.equal( true );
 	} );
 
-	it( 'it should return null with a null author name', () => {
+	it( 'should return null with a null author name', () => {
 		author.name = null;
-		const link = shallow( <ReaderAuthorLink author={ author } className="test__ace">xyz</ReaderAuthorLink> );
-		expect( link.type() ).to.be.null;
+		const wrapper = shallow( <ReaderAuthorLink author={ author }>xyz</ReaderAuthorLink> );
+		expect( wrapper.type() ).to.be.null;
 	} );
 
-	it( 'it should return null with a blacklisted author name', () => {
+	it( 'should return null with a blacklisted author name', () => {
 		author.name = 'admin';
-		const link = shallow( <ReaderAuthorLink author={ author } className="test__ace">xyz</ReaderAuthorLink> );
-		expect( link.type() ).to.be.null;
+		const wrapper = shallow( <ReaderAuthorLink author={ author }>xyz</ReaderAuthorLink> );
+		expect( wrapper.type() ).to.be.null;
+	} );
+
+	it( 'should use siteUrl if provided', () => {
+		const siteUrl = 'http://discover.wordpress.com';
+		const wrapper = shallow( <ReaderAuthorLink author={ author } siteUrl={ siteUrl }>xyz</ReaderAuthorLink> );
+		expect( wrapper.find( '.reader-author-link' ) ).to.have.prop( 'href' ).equal( siteUrl );
+	} );
+
+	it( 'should use author.URL if site URL is not provided', () => {
+		const wrapper = shallow( <ReaderAuthorLink author={ author }>xyz</ReaderAuthorLink> );
+		expect( wrapper.find( '.reader-author-link' ) ).to.have.prop( 'href' ).equal( author.URL );
+	} );
+
+	it( 'should not return a link if siteUrl and author.URL are both missing', () => {
+		author.URL = null;
+		const wrapper = shallow( <ReaderAuthorLink author={ author }>xyz</ReaderAuthorLink> );
+		// Should just return children
+		expect( wrapper.html() ).to.equal( '<span class="reader-author-link">xyz</span>' );
 	} );
 } );

--- a/client/blocks/reader-author-link/test/index.jsx
+++ b/client/blocks/reader-author-link/test/index.jsx
@@ -12,7 +12,7 @@ import { noop } from 'lodash';
 import useMockery from 'test/helpers/use-mockery';
 
 describe( 'ReaderAuthorLink', () => {
-	let ReaderAuthorLink;
+	let ReaderAuthorLink, author;
 
 	useMockery( mockery => {
 		mockery.registerMock( 'reader/stats', {
@@ -24,12 +24,28 @@ describe( 'ReaderAuthorLink', () => {
 
 	before( () => {
 		ReaderAuthorLink = require( '../index' );
+		author = { URL: 'http://wpcalypso.wordpress.com', name: 'Barnaby Blogwit' };
 	} );
 
-	// check that content within a card renders correctly
 	it( 'should render children', () => {
-		const author = { URL: 'http://wpcalypso.wordpress.com', name: 'Barnaby Blogwit' };
 		const link = shallow( <ReaderAuthorLink author={ author }>Barnaby Blogwit</ReaderAuthorLink> );
 		expect( link.contains( 'Barnaby Blogwit' ) ).to.equal( true );
+	} );
+
+	it( 'should accept a custom class of `test__ace`', () => {
+		const link = shallow( <ReaderAuthorLink author={ author } className="test__ace">xyz</ReaderAuthorLink> );
+		expect( link.is( '.test__ace' ) ).to.equal( true );
+	} );
+
+	it( 'it should return null with a null author name', () => {
+		author.name = null;
+		const link = shallow( <ReaderAuthorLink author={ author } className="test__ace">xyz</ReaderAuthorLink> );
+		expect( link.type() ).to.be.null;
+	} );
+
+	it( 'it should return null with a blacklisted author name', () => {
+		author.name = 'admin';
+		const link = shallow( <ReaderAuthorLink author={ author } className="test__ace">xyz</ReaderAuthorLink> );
+		expect( link.type() ).to.be.null;
 	} );
 } );


### PR DESCRIPTION
Adds tests for the `ReaderAuthorLink` block.

### To test

`npm run test-client client/blocks/reader-author-link`
