### PR TITLE
Reader Stream Refresh: add photo-only card

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -113,7 +113,7 @@ export default class RefreshPostCard extends React.Component {
 						<h1 className="reader-post-card__title">
 							<a className="reader-post-card__title-link" href={ post.URL }>{ title }</a>
 						</h1>
-						<div className="reader-post-card__excerpt">{ post.short_excerpt }</div>
+						{ ! isPhotoOnly && <div className="reader-post-card__excerpt">{ post.short_excerpt }</div> }
 						{ post &&
 							<ReaderPostActions
 								post={ post }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -96,7 +96,7 @@ export default class RefreshPostCard extends React.Component {
 		const featuredImage = post.canonical_image;
 		const isPhotoOnly = post.display_type & DisplayTypes.PHOTO_ONLY;
 		const title = truncate( post.title, {
-			length: isPhotoOnly ? 50 : 140,
+			length: isPhotoOnly ? 500 : 140,
 			separator: /,? +/
 		} );
 		const classes = classnames( 'reader-post-card', {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -96,7 +96,7 @@ export default class RefreshPostCard extends React.Component {
 		const featuredImage = post.canonical_image;
 		const isPhotoOnly = post.display_type & DisplayTypes.PHOTO_ONLY;
 		const title = truncate( post.title, {
-			length: isPhotoOnly ? 500 : 140,
+			length: 140,
 			separator: /,? +/
 		} );
 		const classes = classnames( 'reader-post-card', {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -19,6 +19,82 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin: 0 15px;
 		padding: 20px 0;
 	}
+
+	&.has-thumbnail {
+
+		.reader-post-card__featured-image {
+			flex-basis: auto;
+			flex-grow: 1;
+			margin-right: 20px;
+			max-width: 190px;
+
+			@include breakpoint( ">960px" ) {
+				max-width: 250px;
+			}
+
+			@media #{$reader-post-card-breakpoint-medium} {
+				height: 100px;
+				max-width: none;
+				width: 100%;
+			}
+
+			@media #{$reader-post-card-breakpoint-small} {
+				height: 100px;
+				max-width: none;
+				width: 100%;
+			}
+		}
+
+		&.is-photo {
+
+			.reader-post-card__featured-image {
+				position: relative;
+					top: 0;
+				height: 225px;
+				margin-right: 0;
+				max-width: 100%;
+
+				&::before {
+					content: '';
+					background: $gray-dark;
+					height: 225px;
+					opacity: .4;
+					position: absolute;
+					width: 100%;
+					z-index: 1;
+				}
+			}
+
+			.reader-post-card__post {
+				flex-direction: column;
+			}
+
+			.reader-post-card__post-details,
+			.reader-post-card__social {
+				padding-left: 0;
+			}
+
+			.reader-post-card__post-details {
+				margin-top: -10px;
+			}
+
+			.reader-post-card__title {
+				font-family: $sans;
+				font-size: 10px;
+				position: relative;
+					bottom: 22px;
+					left: 20px;
+				text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+				z-index: 2;
+			}
+
+			.reader-post-card__title .reader-post-card__title-link {
+				color: $white;
+				font-size: 12px;
+				letter-spacing: 0.01em;
+			}
+		}
+	}
 }
 
 .reader-post-card__byline {
@@ -96,29 +172,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	display: flex;
 	flex-wrap: wrap;
 	flex-direction: row;
-
-	.reader-post-card__featured-image {
-		flex-basis: auto;
-		flex-grow: 1;
-		margin-right: 20px;
-		max-width: 190px;
-
-		@include breakpoint( ">960px" ) {
-			max-width: 250px;
-		}
-
-		@media #{$reader-post-card-breakpoint-medium} {
-			height: 100px;
-			max-width: none;
-			width: 100%;
-		}
-
-		@media #{$reader-post-card-breakpoint-small} {
-			height: 100px;
-			max-width: none;
-			width: 100%;
-		}
-	}
 
 	.reader-post-card__post-details {
 		flex: 1;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -56,8 +56,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 				&::before {
 					content: '';
-					background: $gray-dark;
-					background: linear-gradient(to top, black 0px, transparent 60px);
+					background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1) 100% );
 					height: 225px;
 					opacity: .4;
 					position: absolute;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -56,7 +56,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 				&::before {
 					content: '';
-					background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1) 100% );
+					background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1 ) 100% );
 					height: 225px;
 					opacity: .4;
 					position: absolute;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -79,7 +79,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 
 			.reader-post-card__title {
-				color: $white;
 				font-family: $sans;
 				font-size: 10px;
 				position: relative;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -57,6 +57,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				&::before {
 					content: '';
 					background: $gray-dark;
+					background: linear-gradient(to top, black 0px, transparent 60px);
 					height: 225px;
 					opacity: .4;
 					position: absolute;
@@ -79,6 +80,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 
 			.reader-post-card__title {
+				color: $white;
 				font-family: $sans;
 				font-size: 10px;
 				position: relative;
@@ -86,6 +88,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 					left: 20px;
 				text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 				z-index: 2;
+				white-space: nowrap;
+				width: calc( 100% - 44px );
+				text-overflow: ellipsis;
+				overflow: hidden;
 			}
 
 			.reader-post-card__title .reader-post-card__title-link {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -79,6 +79,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 
 			.reader-post-card__title {
+				color: $white;
 				font-family: $sans;
 				font-size: 10px;
 				position: relative;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/8518

![1af553b4-8bc4-11e6-8329-e839005b2279](https://cloud.githubusercontent.com/assets/17325/19503469/3d807bd8-9610-11e6-8083-6ef76ec4252b.jpg)
