### PR TITLE
Reader: Fix divider alignment in stream

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -16,7 +16,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	@media #{$reader-post-card-breakpoint-xlarge}  {
-		padding: 20px 15px;
+		margin: 0 15px;
+		padding: 20px 0;
 	}
 }
 


### PR DESCRIPTION
We've increased the width for streams in: https://github.com/Automattic/wp-calypso/pull/8792 and wanted some extra padding for widths `>1040px`, but should have used `margin` instead of `padding` as this caused some misalignment:

Before:
![screenshot 2016-10-18 16 36 09](https://cloud.githubusercontent.com/assets/4924246/19500417/d15b0d92-9551-11e6-8784-7b11b8af5910.png)

After:
![screenshot 2016-10-18 16 38 45](https://cloud.githubusercontent.com/assets/4924246/19500420/d506e970-9551-11e6-82ba-1a0cc5ae9c34.png)


