### PR TITLE
Reader full post: inside image captions, display emoji inline

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -250,6 +250,10 @@
 		img {
 			display: block;
 			margin: 0 auto;
+
+			&.emoji {
+				display: inline;
+			}
 		}
 	}
 


### PR DESCRIPTION
In full post view, emoji within image captions are `display:block`, which means they currently look like this:

<img width="766" alt="screen shot 2016-10-19 at 20 56 15" src="https://cloud.githubusercontent.com/assets/17325/19510178/8b270446-963e-11e6-93a6-23984bd6a25a.png">

This PR fixes them to display as expected:

<img width="767" alt="screen shot 2016-10-19 at 20 56 10" src="https://cloud.githubusercontent.com/assets/17325/19510177/8b237600-963e-11e6-86ee-15f917e9a588.png">

### To test 

Check out the third image caption on http://calypso.localhost:3000/read/feeds/35794949/posts/1190137923. Make sure the caption displays on a single line.