### PR TITLE
Config: Enable Apple Pay status tracking on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -13,7 +13,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": true,
-		"apple-pay": false,
+		"apple-pay": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,


### PR DESCRIPTION
This is a follow up for #8641 and #8686.

This PR enables Apple Pay status tracking on `production` env. We have managed to setup Merchant id properly and confirmed it works on `stage`.

Props to @astralbodies, @kwonye and @frosty for help with setup :)