### PR TITLE
Jetpack Post: hide post filters if no items are available

### DIFF
--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -141,12 +141,10 @@ export default React.createClass( {
 
 	_getStatusTabs( author, siteFilter ) {
 		var statusItems = [],
-			isJetpackSite = this.props.sites.getSelectedSite().jetpack,
 			status, selectedText, selectedCount;
 
 		for ( status in this.filterStatuses ) {
-			if ( 'undefined' === typeof this.state.counts[ status ] &&
-				( ! isJetpackSite ) && 'publish' !== status ) {
+			if ( 'undefined' === typeof this.state.counts[ status ] && 'publish' !== status ) {
 				continue;
 			}
 
@@ -156,16 +154,14 @@ export default React.createClass( {
 
 			let textItem = this.filterStatuses[ status ];
 
-			let count = ( ! isJetpackSite ) && false !== this.state.counts[ status ]
+			let count = false !== this.state.counts[ status ]
 				? this.state.counts[ status ]
 				: false;
 
 			if ( path === this.props.context.pathname ) {
 				selectedText = textItem;
 
-				if ( ! isJetpackSite ) {
-					selectedCount = count;
-				}
+				selectedCount = count;
 			}
 
 			if ( 'publish' === status && ! count ) {
@@ -177,10 +173,7 @@ export default React.createClass( {
 					className={ 'is-' + status }
 					key={ 'statusTabs' + path }
 					path={ path }
-					count={ null === this.props.sites.selected || isJetpackSite ?
-						null :
-						count
-					}
+					count={ null === this.props.sites.selected || count }
 					value={ textItem }
 					selected={ path === this.props.context.pathname }>
 					{ textItem }


### PR DESCRIPTION
Fixes #8684. Previously, this happened on `/posts` for a Jetpack site: "(Published/draft/scheduled) all show for a Jetpack site, even when it has none of each type of post". I found out that this was intentional and after asking why, I got this reply from @retrofox:

> I’m pretty sure that in that moment posts-count didn’t work for Jetpack plugins
> [...] this was more than a year ago

However, it seems like the post counts are still not implemented for Jetpack sites. Is it an issue or do we want to merge this anyways?

**Note:** In the original issue #8684, @gwwar mentioned that this applies for posts and **pages**. However, even on non-Jetpack site, `/pages` always show all the page filters ("Drafts", "Scheduled", etc), even if there are no items available. That's why this PR concerns only posts and not pages.

## Testing instructions
1. With a Jetpack site, navigate to "Blog Posts" in the main (left) sidebar;
2. Verify that if you have a scheduled or a trashed post, the "Scheduled" or "Trashed" shows in the posts navigation. On the other hand, verify that if you don't have a scheduled or a trashed post, the "Scheduled" or "Trashed" doesn't show in the posts navigation.
