### PR TITLE
Checkout: Fix non-standard property in Apple Pay tracks event

### DIFF
--- a/client/lib/apple-pay/index.js
+++ b/client/lib/apple-pay/index.js
@@ -7,7 +7,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 const MERCHANT_IDENTIFIER = 'merchant.com.wordpress';
 
 const recordApplePayStatusEvent = canMakePaymentsWithActiveCard => recordTracksEvent( 'calypso_apple_pay_status', {
-	canMakePaymentsWithActiveCard
+	can_make_payments_with_active_card: canMakePaymentsWithActiveCard
 } );
 
 export const recordApplePayStatus = () => dispatch => {


### PR DESCRIPTION
Follow up for #8641.

> Property names should also be lowercase and use underscores instead of dashes, but do not need to be prefixed by the service name because the event they are tied to already provides that information. Property names with leading underscores are reserved for special properties so you should always start your property names with a letter.

`calypso_apple_pay_status` is beeing rejected at the moment by Tracks Live View tool. This PR changes property name to align it with conventions used.

/cc @scruffian @Automattic/sdev-feed 