### PR TITLE
Guided Tours: Don't require `sections` due to bundle deps issue

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -20,7 +20,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import sections from 'sections';
+import wpSections from 'wordpress-com';
 import Card from 'components/card';
 import Button from 'components/button';
 import ExternalLink from 'components/external-link';
@@ -34,8 +34,11 @@ import {
 	targetForSlug,
 } from './positioning';
 
+// FIXME(mcsf): this is temporarily requiring 'wordpress-com', as requiring
+// 'sections' directly  makes webpack create a lot of new dependencies on
+// chunks 'theme' and 'themes'
 const pathToSection = path => {
-	const match = find( sections.get(), section =>
+	const match = find( wpSections, section =>
 			section.paths.some( sectionPath =>
 				startsWith( path, sectionPath ) ) );
 


### PR DESCRIPTION
#7908's `pathToSection` change led to a lot of Calypso chunks unintentionally depending on chunks `theme` and `themes`. Fix this by requiring `wordpress-com` instead of `sections` while we think of a different approach, potentially using `require.ensure`.

h/t @blowery @ehg 

# To test
- Make sure the "blanket exit" feature introduced in #7908 still works, as well as Guided Tours in general
- Make sure nothing funky happens during build and that `theme` and `themes` are not dependencies of other chunks
- Make sure all sections load correctly across Calypso