### PR TITLE
Framework: Drop usage of sitesList from PostTotalViews Component

### DIFF
--- a/client/my-sites/posts/post-total-views.jsx
+++ b/client/my-sites/posts/post-total-views.jsx
@@ -17,14 +17,13 @@ import { getPostStat } from 'state/stats/posts/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 
 function PostTotalViews( { clickHandler, numberFormat, post, slug, translate, viewCount } ) {
-	const postId = post.ID,
-		siteId = post.site_ID;
+	const { ID: postId, site_ID: siteId } = post;
 	let viewsCountDisplay = '',
 		viewsTitle;
 
-	if ( viewCount && ! isNaN( viewCount ) ) {
+	if ( viewCount ) {
 		viewsCountDisplay = numberFormat( viewCount );
-		viewsTitle = translate( '1 Total View', '%(count)s Total Views', {
+		viewsTitle = translate( '%(count)s Total View', '%(count)s Total Views', {
 			count: viewCount,
 			args: {
 				count: viewCount
@@ -34,8 +33,12 @@ function PostTotalViews( { clickHandler, numberFormat, post, slug, translate, vi
 		viewsTitle = translate( 'Total Views' );
 	}
 
+	if ( ! slug ) {
+		return <QuerySites siteId={ siteId } />;
+	}
+
 	return (
-		<a href={ `/stats/post/${postId}/${slug}` }
+		<a href={ `/stats/post/${ postId }/${ slug }` }
 			className={ classNames( {
 				'post__total-views': true,
 				'is-empty': ! viewsCountDisplay
@@ -43,7 +46,6 @@ function PostTotalViews( { clickHandler, numberFormat, post, slug, translate, vi
 			title={ viewsTitle }
 			onClick={ clickHandler }>
 			<QueryPostStats siteId= { siteId } postId={ postId } stat="views" />
-			<QuerySites siteId={ siteId } />
 			<Gridicon icon="visible" size={ 24 } />
 			<StatUpdateIndicator updateOn={ viewsCountDisplay }>{ viewsCountDisplay }</StatUpdateIndicator>
 		</a>

--- a/client/my-sites/posts/post-total-views.jsx
+++ b/client/my-sites/posts/post-total-views.jsx
@@ -4,68 +4,67 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import StatUpdateIndicator from 'components/stat-update-indicator';
 import Gridicon from 'components/gridicon';
-import sitesList from 'lib/sites-list';
 import QueryPostStats from 'components/data/query-post-stats';
+import QuerySites from 'components/data/query-sites';
 import { getPostStat } from 'state/stats/posts/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
-const sites = sitesList();
+function PostTotalViews( { clickHandler, numberFormat, post, slug, translate, viewCount } ) {
+	const postId = post.ID,
+		siteId = post.site_ID;
+	let viewsCountDisplay = '',
+		viewsTitle;
 
-var PostTotalViews = React.createClass( {
-
-	propTypes: {
-		post: PropTypes.object.isRequired,
-		viewCount: PropTypes.number,
-		clickHandler: PropTypes.func
-	},
-
-	render() {
-		const { viewCount, post } = this.props,
-			postId = post.ID,
-			siteId = post.site_ID;
-		let viewsCountDisplay = '',
-			viewsTitle;
-
-		if ( viewCount && ! isNaN( viewCount ) ) {
-			viewsCountDisplay = this.numberFormat( viewCount );
-			viewsTitle = this.translate( '1 Total View', '%(count)s Total Views', {
-				count: viewCount,
-				args: {
-					count: viewCount
-				}
-			} );
-		} else {
-			viewsTitle = this.translate( 'Total Views' );
-		}
-
-		const site = sites.getSite( siteId );
-
-		return (
-			<a href={ `/stats/post/${postId}/${site.slug}` }
-				className={ classNames( {
-					'post__total-views': true,
-					'is-empty': ! viewsCountDisplay
-				} ) }
-				title={ viewsTitle }
-				onClick={ this.props.clickHandler }>
-				<QueryPostStats siteId= { siteId } postId={ postId } stat="views" />
-				<Gridicon icon="visible" size={ 24 } />
-				<StatUpdateIndicator updateOn={ viewsCountDisplay }>{ viewsCountDisplay }</StatUpdateIndicator>
-			</a>
-		);
+	if ( viewCount && ! isNaN( viewCount ) ) {
+		viewsCountDisplay = numberFormat( viewCount );
+		viewsTitle = translate( '1 Total View', '%(count)s Total Views', {
+			count: viewCount,
+			args: {
+				count: viewCount
+			}
+		} );
+	} else {
+		viewsTitle = translate( 'Total Views' );
 	}
-} );
+
+	return (
+		<a href={ `/stats/post/${postId}/${slug}` }
+			className={ classNames( {
+				'post__total-views': true,
+				'is-empty': ! viewsCountDisplay
+			} ) }
+			title={ viewsTitle }
+			onClick={ clickHandler }>
+			<QueryPostStats siteId= { siteId } postId={ postId } stat="views" />
+			<QuerySites siteId={ siteId } />
+			<Gridicon icon="visible" size={ 24 } />
+			<StatUpdateIndicator updateOn={ viewsCountDisplay }>{ viewsCountDisplay }</StatUpdateIndicator>
+		</a>
+	);
+}
+
+PostTotalViews.propTypes = {
+	clickHandler: PropTypes.func,
+	numberFormat: PropTypes.func,
+	post: PropTypes.object.isRequired,
+	slug: PropTypes.string,
+	translate: PropTypes.func,
+	viewCount: PropTypes.number
+};
 
 export default connect( ( state, ownProps ) => {
 	const { post } = ownProps;
 	const viewCount = getPostStat( state, 'views', post.site_ID, post.ID );
 
 	return {
+		slug: getSiteSlug( state, post.site_ID ),
 		viewCount
 	};
-} )( PostTotalViews );
+} )( localize( PostTotalViews ) );


### PR DESCRIPTION
For #8726 - this branch removes sitesList.getSelectedSite() on the <PostTotalViews /> component.

**To Test**
- Open a `/posts/my` page
- Check that the views count is showing up correctly (no JS error)
- Click on the view count, you should be redirected to the stat page for this post
