### PR TITLE
Domains: Proper regex for detecting valid domains

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -608,6 +608,7 @@ const RegisterDomainStep = React.createClass( {
 				} );
 				break;
 
+			case 'mappable_but_invalid_tld':
 			case 'invalid_query':
 				message = this.translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
 					args: { domain: domain }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -314,7 +314,7 @@ const RegisterDomainStep = React.createClass( {
 						return callback();
 					}
 
-					if ( ! domain.match( /^[A-Za-z][A-Za-z0-9\.-]{2,}\.[A-Za-z]{2,}$/ ) ) {
+					if ( ! domain.match( /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/i ) ) {
 						return callback();
 					}
 					const timestamp = Date.now();


### PR DESCRIPTION
The previous one did not like (valid) domains starting with a digit. Hence, no `is-available` call was triggered and the domain could not be registered.
The new regex is based on the one from backend for detecting subdomains (with loosened up restriction so that both subdomains and domains pass it).

I've additionally added a handler for an error (a valid one) that I've encountered when testing: `mappable_but_invalid_tld`. It's returned by the backend, when the user enters a mappable (but not registrable) domain with an invalid TLD. Something like `asdf.zxcv.ss`.

*Testing*

Verify valid behaviour for different combinations of (sub)domains:
* `example.com`
* `asdfas.example.com`
* `asdf-adfa.ead-zzz.com`
* `123123123testing.com`

etc.

Bug found by @dennishhong (thanks!)
cc @aidvu @umurkontaci