### PR TITLE
Purchases: Disable cancel for pending_transfer domains

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -41,6 +41,7 @@ function createPurchaseObject( purchase ) {
 			countryCode: purchase.payment_country_code,
 			countryName: purchase.payment_country_name
 		},
+		pendingTransfer: Boolean( purchase.pending_transfer ),
 		productId: Number( purchase.product_id ),
 		productName: purchase.product_name,
 		productSlug: purchase.product_slug,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -91,6 +91,10 @@ function isCancelable( purchase ) {
 		return false;
 	}
 
+	if ( isPendingTransfer( purchase ) ) {
+		return false;
+	}
+
 	if ( isExpired( purchase ) ) {
 		return false;
 	}
@@ -125,6 +129,10 @@ function isOneTimePurchase( purchase ) {
 
 function isPaidWithPaypal( purchase ) {
 	return 'paypal' === purchase.payment.type;
+}
+
+function isPendingTransfer( purchase ) {
+	return true === purchase.pendingTransfer;
 }
 
 function isRedeemable( purchase ) {
@@ -261,4 +269,4 @@ export {
 	paymentLogoType,
 	purchaseType,
 	showCreditCardExpiringWarning,
-}
+};

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -132,7 +132,7 @@ function isPaidWithPaypal( purchase ) {
 }
 
 function isPendingTransfer( purchase ) {
-	return true === purchase.pendingTransfer;
+	return purchase.pendingTransfer;
 }
 
 function isRedeemable( purchase ) {

--- a/client/lib/purchases/test/data/index.js
+++ b/client/lib/purchases/test/data/index.js
@@ -9,6 +9,16 @@ const DOMAIN_PURCHASE = {
 	isCancelable: true
 };
 
+const DOMAIN_PURCHASE_PENDING_TRANSFER = {
+	expiryStatus: 'active',
+	id: 10001,
+	isDomainRegistration: true,
+	meta: 'foo.com',
+	productName: 'Domain Registration',
+	productSlug: 'domain_reg',
+	pendingTransfer: true
+};
+
 const DOMAIN_PURCHASE_EXPIRED = Object.assign( {}, DOMAIN_PURCHASE, {
 	expiryStatus: 'expired',
 	id: 10002,
@@ -65,6 +75,7 @@ const PLAN_PURCHASE = {
 
 export default {
 	DOMAIN_PURCHASE,
+	DOMAIN_PURCHASE_PENDING_TRANSFER,
 	DOMAIN_PURCHASE_EXPIRED,
 	DOMAIN_PURCHASE_INCLUDED_IN_PLAN,
 	DOMAIN_MAPPING_PURCHASE,
@@ -72,4 +83,4 @@ export default {
 	PLAN_PURCHASE,
 	SITE_REDIRECT_PURCHASE,
 	SITE_REDIRECT_PURCHASE_EXPIRED
-}
+};

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -62,7 +62,7 @@ describe( 'index', () => {
 			expect( isCancelable( PLAN_PURCHASE ) ).to.be.true;
 		} );
 
-		it( 'should be cancelable when the purchase can have auto-renew disabled', () => {
+		it( 'should not be cancelable if domain is pending transfer', () => {
 			expect( isCancelable( DOMAIN_PURCHASE_PENDING_TRANSFER ) ).to.be.false;
 		} );
 	} );

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	DOMAIN_PURCHASE,
+	DOMAIN_PURCHASE_PENDING_TRANSFER,
 	DOMAIN_PURCHASE_EXPIRED,
 	DOMAIN_PURCHASE_INCLUDED_IN_PLAN,
 	DOMAIN_MAPPING_PURCHASE,
@@ -59,6 +60,10 @@ describe( 'index', () => {
 
 		it( 'should be cancelable when the purchase can have auto-renew disabled', () => {
 			expect( isCancelable( PLAN_PURCHASE ) ).to.be.true;
+		} );
+
+		it( 'should be cancelable when the purchase can have auto-renew disabled', () => {
+			expect( isCancelable( DOMAIN_PURCHASE_PENDING_TRANSFER ) ).to.be.false;
 		} );
 	} );
 } );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -96,6 +96,7 @@ describe( 'selectors', () => {
 				priceText: 'undefinedundefined',
 				productId: NaN,
 				productSlug: undefined,
+				pendingTransfer: false,
 				refundPeriodInDays: undefined,
 				refundText: 'undefinedundefined',
 				renewDate: undefined,


### PR DESCRIPTION
Users were able to `cancel` domains that were pending transfer through `/purchases`, although the `cancel` would always fail.

Hide the `cancel` option if the domain is `pending transfer`.

Requires D3106-code.