### PR TITLE
Support: Update live courses page

### DIFF
--- a/client/me/help/help-courses/course-video.jsx
+++ b/client/me/help/help-courses/course-video.jsx
@@ -7,14 +7,12 @@ import React from 'react';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 import Card from 'components/card';
 
 export default localize( ( props ) => {
 	const {
 		title,
 		description,
-		date,
 		youtubeId
 	} = props;
 
@@ -29,10 +27,6 @@ export default localize( ( props ) => {
 			<Card compact>
 				<h1 className="help-courses__course-video-title">{ title }</h1>
 				<p className="help-courses__course-video-description">{ description }</p>
-			</Card>
-			<Card compact className="help-courses__course-video-date">
-				<Gridicon className="help-courses__course-video-date-icon" icon="time" size={ 18 } />
-				{ date.fromNow() }
 			</Card>
 		</div>
 	);

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -31,20 +31,20 @@ function getCourses() {
 			),
 			schedule: [
 				{
-					date: i18n.moment( new Date( 'Tues, 11 Oct 2016 16:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/c9f211b28c427b6066858a512be5123a'
+					date: i18n.moment( new Date( 'Tues, 25 Oct 2016 16:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/1e730113a5c480fb66858a512be5123a'
 				},
 				{
-					date: i18n.moment( new Date( 'Thur, 13 Oct 2016 20:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/8aa25fd3a2bda6a28c34be5db4a05ad8'
+					date: i18n.moment( new Date( 'Thur, 27 Oct 2016 20:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/4d80dd6869e8e7aec5b9141539e44ee6'
 				},
 				{
-					date: i18n.moment( new Date( 'Tues, 18 Oct 2016 16:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/a89296c68ee6a3d2cde7dc3c8da9331e'
+					date: i18n.moment( new Date( 'Tues, 1 Nov 2016 16:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/26e68e03fd2a1c177c24e00bf0acd2b8'
 				},
 				{
-					date: i18n.moment( new Date( 'Thur, 20 Oct 2016 20:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/76eebd735e6172cd7c24e00bf0acd2b8'
+					date: i18n.moment( new Date( 'Thur, 3 Nov 2016 20:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/eb5b3d79f1212d2b66858a512be5123a'
 				},
 			],
 			videos: [


### PR DESCRIPTION
This updates the live course offerings for the next two weeks and removes past dates. Here are the dates and registration URLs in plain text to compare:

Tuesday 10/25 9am PDT : 
https://zoom.us/webinar/register/1e730113a5c480fb66858a512be5123a

Thursday 10/27 1pm PDT: https://zoom.us/webinar/register/4d80dd6869e8e7aec5b9141539e44ee6

Tuesday 11/1 9am PDT:
https://zoom.us/webinar/register/26e68e03fd2a1c177c24e00bf0acd2b8

Thursday 11/3 1pm PDT:
https://zoom.us/webinar/register/eb5b3d79f1212d2b66858a512be5123a

I also removed the date stamp on the existing video at wordpress.com/help/courses (see discussion in p1476902823000212-slack-business-concierge. Right now, we're not updating the video regularly so the timestamp makes the video feel out of date. I left the styling in place so we could re-add at a later date easily (had to remove the Gridicon and date for tests to pass).

## To test

1. Login under an account with a Business plan.
2. Visit wordpress.com/help/courses. Confirm that the dates and times match above and that the timestamp is removed from the video.

## Screenshot

Updated dates
<img width="821" alt="screen shot 2016-10-19 at 2 09 50 pm" src="https://cloud.githubusercontent.com/assets/7240478/19535848/a3361eec-9606-11e6-8456-2e574604241a.png">

Removed timestamp
<img width="865" alt="screen shot 2016-10-19 at 2 09 54 pm" src="https://cloud.githubusercontent.com/assets/7240478/19535866/aafd14c8-9606-11e6-9adc-8266d204c6fd.png">
