### PR TITLE
Pages: Suppress "View Page", "Edit" and "Trash" menu items when a static front page is set and the item is the main archive page

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -25,6 +25,7 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 	config = require( 'config' );
 
 import MenuSeparator from 'components/popover/menu-separator';
+import { hasStaticFrontPage } from 'state/sites/selectors';
 import {
 	isFrontPage,
 	isPostsPage,
@@ -137,6 +138,10 @@ const Page = React.createClass( {
 			return null;
 		}
 
+		if ( this.props.hasStaticFrontPage && this.props.isPostsPage ) {
+			return null;
+		}
+
 		if ( this.props.page.status !== 'publish' ) {
 			return (
 				<PopoverMenuItem onClick={ this.viewPage }>
@@ -213,6 +218,10 @@ const Page = React.createClass( {
 	},
 
 	getEditItem: function() {
+		if ( this.props.hasStaticFrontPage && this.props.isPostsPage ) {
+			return null;
+		}
+
 		if ( ! utils.userCan( 'edit_post', this.props.page ) ) {
 			return null;
 		}
@@ -226,6 +235,10 @@ const Page = React.createClass( {
 	},
 
 	getSendToTrashItem: function() {
+		if ( this.props.hasStaticFrontPage && this.props.isPostsPage ) {
+			return null;
+		}
+
 		if ( ! utils.userCan( 'delete_post', this.props.page ) ) {
 			return null;
 		}
@@ -304,6 +317,23 @@ const Page = React.createClass( {
 		}
 
 		const setAsHomepageItem = this.getSetAsHomepageItem();
+		const viewItem = this.getViewItem();
+		const publishItem = this.getPublishItem();
+		const editItem = this.getEditItem();
+		const restoreItem = this.getRestoreItem();
+		const sendToTrashItem = this.getSendToTrashItem();
+		const moreInfoItem = this.popoverMoreInfo();
+
+		const setHomepageMenuSeparator = (
+			setAsHomepageItem && (
+				viewItem ||
+				publishItem ||
+				editItem ||
+				restoreItem ||
+				sendToTrashItem ||
+				moreInfoItem
+			)
+		) ? <MenuSeparator /> : null;
 
 		return (
 			<CompactCard className="page">
@@ -336,13 +366,13 @@ const Page = React.createClass( {
 					context={ this.refs && this.refs.popoverMenuButton }
 				>
 					{ setAsHomepageItem }
-					{ setAsHomepageItem ? <MenuSeparator /> : null }
-					{ this.getViewItem() }
-					{ this.getPublishItem() }
-					{ this.getEditItem() }
-					{ this.getRestoreItem() }
-					{ this.getSendToTrashItem() }
-					{ this.popoverMoreInfo() }
+					{ setHomepageMenuSeparator }
+					{ viewItem }
+					{ publishItem }
+					{ editItem }
+					{ restoreItem }
+					{ sendToTrashItem }
+					{ moreInfoItem }
 				</PopoverMenu>
 				<ReactCSSTransitionGroup
 					transitionName="updated-trans"
@@ -383,6 +413,7 @@ const Page = React.createClass( {
 export default connect(
 	( state, props ) => {
 		return {
+			hasStaticFrontPage: hasStaticFrontPage( state, props.page.site_ID ),
 			isFrontPage: isFrontPage( state, props.page.site_ID, props.page.ID ),
 			isPostsPage: isPostsPage( state, props.page.site_ID, props.page.ID ),
 		};

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -550,3 +550,14 @@ export function getSitePostsPage( state, siteId ) {
 export function getSiteFrontPageType( state, siteId ) {
 	return getSiteOption( state, siteId, 'show_on_front' );
 }
+
+/**
+ * Returns true if the site is using a static front page
+ *
+ * @param {Object} state Global state tree
+ * @param {Object} siteId Site ID
+ * @return {Boolean} False if not set or set to `0`. True otherwise.
+ */
+export function hasStaticFrontPage( state, siteId ) {
+	return !! getSiteFrontPage( state, siteId );
+}

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -29,7 +29,8 @@ import {
 	isCurrentPlanPaid,
 	getSiteFrontPage,
 	getSitePostsPage,
-	getSiteFrontPageType
+	getSiteFrontPageType,
+	hasStaticFrontPage,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -1098,6 +1099,74 @@ describe( 'selectors', () => {
 			}, 77203074 );
 
 			expect( frontPage ).to.eql( 1 );
+		} );
+	} );
+
+	describe( 'hasStaticFrontPage()', () => {
+		it( 'should return false if the site does not have a static page set as the front page', () => {
+			const hasFrontPage = hasStaticFrontPage( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							options: {
+								show_on_front: 'posts',
+								page_on_front: 0
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( hasFrontPage ).to.eql( false );
+		} );
+
+		it( 'should return false if the site does not have a `page_on_front` value', () => {
+			const hasFrontPage = hasStaticFrontPage( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							options: {
+								show_on_front: 'posts',
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( hasFrontPage ).to.eql( false );
+		} );
+
+		it( 'should return false if the site is not known', () => {
+			const hasFrontPage = hasStaticFrontPage( {
+				sites: {
+					items: {}
+				}
+			}, 77203074 );
+
+			expect( hasFrontPage ).to.eql( false );
+		} );
+
+		it( 'should return true if the site has a static page set as the front page', () => {
+			const hasFrontPage = hasStaticFrontPage( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							options: {
+								show_on_front: 'page',
+								page_on_front: 42
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( hasFrontPage ).to.eql( true );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request creates a new selector `hasStaticFrontPage` (including tests).

It is used here in conjunction with the `isPostsPage` selector merged in #8884 to determine proper display of the "dropdown menu items" for the list of pages on the Pages screen.

Previous behavior was to show `View Page`, `Edit`, & `Trash` menu items regardless of "front page" and "posts page" site settings.

This hides those items when a static front page is set and the page being listed is the "posts page" / archive page.

For a page with settings (in `/wp-admin/options-reading.php`):
<img width="521" alt="screen shot 2016-10-20 at 1 28 58 pm" src="https://cloud.githubusercontent.com/assets/1587282/19570706/273657da-96c9-11e6-82ac-8a1da6aca9f7.png">

## Previous behavior

<img width="731" alt="screen shot 2016-10-20 at 1 32 53 pm" src="https://cloud.githubusercontent.com/assets/1587282/19570922/f6df5252-96c9-11e6-8dc4-e1831087cdb6.png">

## New behavior

<img width="733" alt="screen shot 2016-10-20 at 1 32 04 pm" src="https://cloud.githubusercontent.com/assets/1587282/19570944/09c36b74-96ca-11e6-9cbb-b4687db07afc.png">

## To Test

* Make sure tests pass: `npm run test-client -- --grep "state sites"`
* From reading settings in wp-admin (`/wp-admin/options-reading.php`) set a static front page and static posts page (make sure they aren't the same, as wp-admin actually unsets the static posts page if they are)
* make run
* Visit the Pages page in Calypso:
  * Make sure the list of pages make sense:
    * "Regular" pages should not be affected (_should_ have view / edit / trash dropdown menu items, etc.)
    * "Posts" pages should _not_ have the view / edit / trash dropdown menu items -- only `Set as Homepage`
    * If a page is set as the "Front Page", it should have the "house" icon and it _should_ have view / edit / trash dropdown menu items

NOTE: This is still subject to `SitesList` caching, thus, it may take a few times refreshing the browser window & waiting for the sites call to complete for the Calypso view to reflect the site settings. See #8726