### PR TITLE
Reader Stream Refresh: Fix cards wrapping if Happy Chat is open

### DIFF
--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -19,6 +19,14 @@
 			color: lighten( $gray, 10% );
 		}
 
+		.external-link {
+			align-items: center;
+			box-sizing: border-box;
+			display: inline-flex;
+			padding: 4px 4px 4px 0;
+			position: relative;
+		}
+
 		.external-link:hover,
 		.external-link:focus,
 		.external-link:active {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -179,30 +179,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	flex-wrap: wrap;
 	flex-direction: row;
 
-	.reader-post-card__featured-image {
-		flex-basis: auto;
-		flex-grow: 1;
-		margin-right: 20px;
-		max-width: 190px;
-
-		@include breakpoint( ">960px" ) {
-			max-width: 250px;
-		}
-
-		@media #{$reader-post-card-breakpoint-medium} {
-
-			ight: 100px;
-			max-width: 100%;
-		}
-
-		@media #{$reader-post-card-breakpoint-small} {
-			height: 100px;
-
-			max-width: none;
-			width: 100%;
-		}
-	}
-
 	.reader-post-card__post-details {
 		flex: 1;
 	}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -1,5 +1,6 @@
 // Custom breakpoints needed to match original design
 
+$reader-post-card-breakpoint-xxlarge: "( min-width: 1100px )";
 $reader-post-card-breakpoint-xlarge: "( min-width: 1040px )";
 $reader-post-card-breakpoint-large: "( min-width: 961px ) and ( max-width: 1040px )";
 $reader-post-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 940px )";
@@ -178,6 +179,30 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	flex-wrap: wrap;
 	flex-direction: row;
 
+	.reader-post-card__featured-image {
+		flex-basis: auto;
+		flex-grow: 1;
+		margin-right: 20px;
+		max-width: 190px;
+
+		@include breakpoint( ">960px" ) {
+			max-width: 250px;
+		}
+
+		@media #{$reader-post-card-breakpoint-medium} {
+
+			ight: 100px;
+			max-width: 100%;
+		}
+
+		@media #{$reader-post-card-breakpoint-small} {
+			height: 100px;
+
+			max-width: none;
+			width: 100%;
+		}
+	}
+
 	.reader-post-card__post-details {
 		flex: 1;
 	}
@@ -227,27 +252,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader-post-card.card .reader-post-actions__item {
 	font-size: 14px;
 
-	&.reader-post-actions__visit {
-		padding: 2px 0 0;
-
-		@media #{$reader-post-card-breakpoint-large} {
-			padding: 0;
-		}
-
-		@media #{$reader-post-card-breakpoint-medium} {
-			padding: 0;
-		}
-
-		@include breakpoint( "<660px" ) {
-			padding: 0;
-		}
-
-		.gridicon {
-			fill: lighten( $gray, 10% );
-			position: relative;
-				left: -8px;
-				top: 3px;
-		}
+	&.reader-post-actions__visit .gridicon {
+		fill: lighten( $gray, 10% );
+		position: relative;
+			left: -8px;
+			top: -1px;
 	}
 
 	.gridicons-external {
@@ -271,35 +280,42 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin-right: 2px;
 	}
 
-	.comment-button,
-	.like-button {
-
-		@media #{$reader-post-card-breakpoint-large} {
-			top: -2px;
-		}
-
-		@media #{$reader-post-card-breakpoint-medium} {
-			top: -2px;
-		}
-
-		@include breakpoint( "<660px" ) {
-			top: -2px;
-		}
-	}
-
 	.reader-share__button-label,
 	.comment-button__label-status,
 	.like-button__label-status {
 
-		@media #{$reader-post-card-breakpoint-large} {
+		@include breakpoint( ">960px" ) {
 			display: none;
 		}
 
-		@media #{$reader-post-card-breakpoint-medium} {
-			display: none;
+		@media #{$reader-post-card-breakpoint-xxlarge} {
+			display: inline;
 		}
 
 		@include breakpoint( "<660px" ) {
+			display: none;
+		}
+	}
+}
+
+// If chat window is open
+.is-group-reader.has-chat {
+
+	@media #{$reader-post-card-breakpoint-xlarge} {
+
+		.reader-post-card__post {
+			flex-direction: column;
+		}
+
+		.reader-post-card__post .reader-post-card__featured-image {
+			height: 100px;
+			margin-right: 0;
+			max-width: 100%;
+		}
+
+		.reader-share__button-label,
+		.comment-button__label-status,
+		.like-button__label-status {
 			display: none;
 		}
 	}


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8856

In this PR,

1. Fixed/cleaned up `Visit` button alignment to eliminate some custom positioning
2. Fixed refresh cards wrapping (wrapping begins at around `1041px`:

**Before:**
![screenshot 2016-10-19 14 24 29](https://cloud.githubusercontent.com/assets/4924246/19538530/531e20e6-9609-11e6-92f3-4ab50b6a03cf.png)

**After:**
![screenshot 2016-10-19 14 26 25](https://cloud.githubusercontent.com/assets/4924246/19538551/6ac143fe-9609-11e6-8633-a0cae5476e94.png)
