### PR TITLE
Refactor out products list observer in DomainManagement.Email

### DIFF
--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import StoreConnection from 'components/data/store-connection';
 import DomainsStore from 'lib/domains/store';
 import CartStore from 'lib/cart/store';
-import observe from 'lib/mixins/data-observe';
+import QueryProducts from 'components/data/query-products-list';
 import { fetchDomains } from 'lib/upgrades/actions';
 import userFactory from 'lib/user';
 import {
@@ -23,6 +23,7 @@ import {
 	isLoaded
 } from 'state/google-apps-users/selectors';
 import { shouldFetchSitePlans } from 'lib/plans';
+import { getProductsList } from 'state/products-list/selectors';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 
@@ -62,8 +63,6 @@ const EmailData = React.createClass( {
 		googleAppsUsersLoaded: React.PropTypes.bool.isRequired
 	},
 
-	mixins: [ observe( 'productsList' ) ],
-
 	componentWillMount() {
 		this.loadDomainsAndSitePlans();
 		this.props.fetchGoogleAppsUsers();
@@ -86,18 +85,21 @@ const EmailData = React.createClass( {
 
 	render() {
 		return (
-			<StoreConnection
-				domains={ this.props.domains }
-				googleAppsUsers={ this.props.googleAppsUsers }
-				googleAppsUsersLoaded={ this.props.googleAppsUsersLoaded }
-				component={ this.props.component }
-				stores={ stores }
-				getStateFromStores={ getStateFromStores }
-				products={ this.props.productsList.get() }
-				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.sites.getSelectedSite() }
-				sitePlans={ this.props.sitePlans }
-				context={ this.props.context } />
+			<div>
+				<QueryProducts />
+				<StoreConnection
+					domains={ this.props.domains }
+					googleAppsUsers={ this.props.googleAppsUsers }
+					googleAppsUsersLoaded={ this.props.googleAppsUsersLoaded }
+					component={ this.props.component }
+					stores={ stores }
+					getStateFromStores={ getStateFromStores }
+					products={ this.props.products }
+					selectedDomainName={ this.props.selectedDomainName }
+					selectedSite={ this.props.sites.getSelectedSite() }
+					sitePlans={ this.props.sitePlans }
+					context={ this.props.context } />
+			</div>
 		);
 	}
 } );
@@ -111,6 +113,7 @@ export default connect(
 		return {
 			googleAppsUsers,
 			googleAppsUsersLoaded: isLoaded( state ),
+			products: getProductsList( state ),
 			sitePlans: getPlansBySite( state, sites.getSelectedSite() )
 		}
 	},

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -1,3 +1,7 @@
+import { property } from 'lodash';
+
+export const getProductsList = property( 'items' );
+
 export function isProductsListFetching( state ) {
 	return state.productsList.isFetching;
 }

--- a/client/state/products-list/test/actions.js
+++ b/client/state/products-list/test/actions.js
@@ -16,6 +16,9 @@ import {
 	receiveProductsList,
 	requestProductsList,
 } from '../actions';
+import {
+	guided_transfer,
+} from './fixtures';
 import useNock from 'test/helpers/use-nock';
 
 describe( 'actions', () => {
@@ -24,17 +27,6 @@ describe( 'actions', () => {
 	beforeEach( () => {
 		spy.reset();
 	} );
-
-	const guided_transfer = {
-		product_id: 40,
-		product_name: 'Guided Transfer',
-		product_slug: 'guided_transfer',
-		prices: { USD: 129, AUD: 169 },
-		is_domain_registration: false,
-		description: 'Guided Transfer',
-		cost: 129,
-		cost_display: '$129',
-	};
 
 	describe( '#receiveProductsList()', () => {
 		it( 'should return an action object', () => {

--- a/client/state/products-list/test/fixtures.js
+++ b/client/state/products-list/test/fixtures.js
@@ -1,0 +1,10 @@
+export const guided_transfer = {
+	product_id: 40,
+	product_name: 'Guided Transfer',
+	product_slug: 'guided_transfer',
+	prices: { USD: 129, AUD: 169 },
+	is_domain_registration: false,
+	description: 'Guided Transfer',
+	cost: 129,
+	cost_display: '$129',
+};

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import {
+	PRODUCTS_LIST_RECEIVE,
+} from 'state/action-types';
+import {
+	getProductsList,
+} from '../selectors';
+import {
+	guided_transfer,
+} from './fixtures';
+
+describe( 'selectors', () => {
+	const initialState = reducer( undefined, { type: 'INIT' } );
+
+	describe( '#getProductsList', () => {
+		it( 'should return the initial products list', () => {
+			expect( getProductsList( initialState ) ).to.eql( {} );
+		} );
+
+		it( 'should return a hydrated products list', () => {
+			const hydrated = reducer( initialState, {
+				type: PRODUCTS_LIST_RECEIVE,
+				productsList: { guided_transfer },
+			} );
+
+			expect( getProductsList( hydrated ) ).to.eql( { guided_transfer });
+		} );
+	} );
+} );


### PR DESCRIPTION
Part of #8760

The <EmailData /> component relies on the sites list and I have been
trying to extract that dependency. Getting there runs deep however and
this PR is one in a line of split-up patches to get us there.

This PR removes the observer mixin on the component and replaces it with
the `<QueryProducts />` component.

> This should include no visual or functional changes.

**Testing**
Smoke test the domain management screen at **Domains** > **G Suite**

cc: @gwwar 