### PR TITLE
Theme Showcase: Enable baseline Server-Side Rendering for logged-out users

### DIFF
--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -41,15 +41,36 @@ export default class Spinner extends PureComponent {
 		duration: 3000
 	};
 
+	constructor() {
+		super();
+		this.state = {
+			// We won't always have access to user-agent in server-side context, so
+			// initialize the spinner with fallback animations and check for support
+			// in componentDidMount()
+			isSVGCSSAnimationSupported: false
+		};
+	}
+
 	componentWillMount() {
 		this.setState( {
 			instanceId: ++Spinner.instances
 		} );
 	}
 
+	componentDidMount() {
+		if ( isSVGCSSAnimationSupported ) {
+			// Turning off eslint rule on this line as an exception — we want to trigger
+			// a re-render if we're progressively enhancing with SVG animations.
+			// eslint-disable-next-line react/no-did-mount-set-state
+			this.setState( {
+				isSVGCSSAnimationSupported: isSVGCSSAnimationSupported
+			} );
+		}
+	}
+
 	getClassName() {
 		return classNames( 'spinner', this.props.className, {
-			'is-fallback': ! isSVGCSSAnimationSupported
+			'is-fallback': ! this.state.isSVGCSSAnimationSupported
 		} );
 	}
 
@@ -68,7 +89,7 @@ export default class Spinner extends PureComponent {
 	}
 
 	render() {
-		if ( ! isSVGCSSAnimationSupported ) {
+		if ( ! this.state.isSVGCSSAnimationSupported ) {
 			return this.renderFallback();
 		}
 

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -121,7 +121,7 @@ const Theme = React.createClass( {
 			return this.renderPlaceholder();
 		}
 
-		const screenshotWidth = window && window.devicePixelRatio > 1 ? 680 : 340;
+		const screenshotWidth = typeof window !== 'undefined' && window.devicePixelRatio > 1 ? 680 : 340;
 		return (
 			<Card className={ themeClass }>
 				<div className="theme__content">

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -72,15 +72,23 @@ export function multiSite( context, next ) {
 
 export function loggedOut( context, next ) {
 	const props = getProps( context );
+
+	context.primary = <LoggedOutComponent { ...props } />;
+	next();
+}
+
+export function fetchThemeData( context, next ) {
+	if ( ! context.isServerSide ) {
+		return next();
+	}
+
 	const queryParams = {
 		search: context.query.s,
 		tier: context.params.tier,
-		filter: props.filter,
+		filter: context.params.filter,
 		page: 0,
 		perPage: PER_PAGE,
 	};
-
-	context.primary = <LoggedOutComponent { ...props } />;
 
 	context.store.dispatch( query( queryParams ) );
 	context.store.dispatch( fetchNextPage( false ) ).then( () => next() );

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -11,6 +11,8 @@ import MultiSiteComponent from 'my-sites/themes/multi-site';
 import LoggedOutComponent from './logged-out';
 import trackScrollPage from 'lib/track-scroll-page';
 import { getAnalyticsData } from './helpers';
+import { fetchNextPage, query } from 'state/themes/actions';
+import { PER_PAGE } from 'state/themes/themes-list/constants';
 
 function getProps( context ) {
 	const { tier, filter, vertical, site_id: siteId } = context.params;
@@ -70,7 +72,16 @@ export function multiSite( context, next ) {
 
 export function loggedOut( context, next ) {
 	const props = getProps( context );
+	const queryParams = {
+		search: context.query.s,
+		tier: context.params.tier,
+		filter: props.filter,
+		page: 0,
+		perPage: PER_PAGE,
+	};
 
 	context.primary = <LoggedOutComponent { ...props } />;
-	next();
+
+	context.store.dispatch( query( queryParams ) );
+	context.store.dispatch( fetchNextPage( false ) ).then( () => next() );
 }

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import SingleSiteComponent from './single-site';
-import MultiSiteComponent from './multi-site';
+import SingleSiteComponent from 'my-sites/themes/single-site';
+import MultiSiteComponent from 'my-sites/themes/multi-site';
 import LoggedOutComponent from './logged-out';
 import trackScrollPage from 'lib/track-scroll-page';
 import { getAnalyticsData } from './helpers';

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -124,7 +124,8 @@ function appendActionTracking( option, name ) {
 }
 
 export function getAnalyticsData( path, tier, site_id ) {
-	let basePath = route.sectionify( path );
+	// Since lib/route isn't available in SSR context, check for it before we use it
+	let basePath = route.sectionify && route.sectionify( path );
 	let analyticsPageTitle = 'Themes';
 
 	if ( tier ) {

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -4,7 +4,7 @@
 import config from 'config';
 import { makeLayout } from 'controller';
 import { getSubjects } from './theme-filters.js';
-import { loggedOut } from './controller';
+import { fetchThemeData, loggedOut } from './controller';
 
 // `logged-out` middleware isn't SSR-compliant yet, but we can at least render
 // the layout.
@@ -15,9 +15,9 @@ export default function( router ) {
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( config.isEnabled( 'manage/themes-ssr' ) ) {
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, loggedOut, makeLayout );
-			router( '/design/*', loggedOut, makeLayout ); // Needed so direct hits don't result in a 404.
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeData, loggedOut, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, fetchThemeData, loggedOut, makeLayout );
+			router( '/design/*', fetchThemeData, loggedOut, makeLayout ); // Needed so direct hits don't result in a 404.
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -4,17 +4,30 @@
 import config from 'config';
 import { makeLayout } from 'controller';
 import { getSubjects } from './theme-filters.js';
+import React from 'react';
 
 // `logged-out` middleware isn't SSR-compliant yet, but we can at least render
 // the layout.
 // FIXME: Also create loggedOut/multiSite/singleSite elements, depending on route.
 
+function serverRender( context, next ) {
+	// Temporary dummy middleware to validate that server rendering is working.
+	context.primary = React.createElement( 'div', {}, 'Loading...' );
+	next();
+}
+
 export default function( router ) {
 	const verticals = getSubjects().join( '|' );
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
-		router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
-		router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );
-		router( '/design/*', makeLayout ); // Needed so direct hits don't result in a 404.
+		if ( config.isEnabled( 'manage/themes-ssr' ) ) {
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, serverRender, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, serverRender, makeLayout );
+			router( '/design/*', serverRender, makeLayout ); // Needed so direct hits don't result in a 404.
+		} else {
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );
+			router( '/design/*', makeLayout ); // Needed so direct hits don't result in a 404.
+		}
 	}
 }

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -4,26 +4,20 @@
 import config from 'config';
 import { makeLayout } from 'controller';
 import { getSubjects } from './theme-filters.js';
-import React from 'react';
+import { loggedOut } from './controller';
 
 // `logged-out` middleware isn't SSR-compliant yet, but we can at least render
 // the layout.
 // FIXME: Also create loggedOut/multiSite/singleSite elements, depending on route.
-
-function serverRender( context, next ) {
-	// Temporary dummy middleware to validate that server rendering is working.
-	context.primary = React.createElement( 'div', {}, 'Loading...' );
-	next();
-}
 
 export default function( router ) {
 	const verticals = getSubjects().join( '|' );
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( config.isEnabled( 'manage/themes-ssr' ) ) {
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, serverRender, makeLayout );
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, serverRender, makeLayout );
-			router( '/design/*', serverRender, makeLayout ); // Needed so direct hits don't result in a 404.
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, loggedOut, makeLayout );
+			router( '/design/*', loggedOut, makeLayout ); // Needed so direct hits don't result in a 404.
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -44,7 +44,7 @@ export function fetchThemes( site ) {
 
 		debug( 'Query params', queryParams );
 
-		wpcom.undocumented().themes( site, queryParams )
+		return wpcom.undocumented().themes( site, queryParams )
 			.then( themes => {
 				const responseTime = ( new Date().getTime() ) - startTime;
 				dispatch( receiveThemes( themes, site, queryParams, responseTime ) );
@@ -56,7 +56,7 @@ export function fetchThemes( site ) {
 export function fetchNextPage( site ) {
 	return dispatch => {
 		dispatch( incrementThemesPage( site ) );
-		dispatch( fetchThemes( site ) );
+		return dispatch( fetchThemes( site ) );
 	};
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -91,6 +91,7 @@
 		"manage/stats/podcasts": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
+		"manage/themes-ssr": true,
 		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
 		"manage/themes/magic-search": true,

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -94,9 +94,12 @@ var webpackConfig = {
 		new webpack.NormalModuleReplacementPlugin( /^lib\/olark$/, 'lodash/noop' ), // Too many dependencies, e.g. sites-list
 		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ), // Depends too much on page.js
 		new webpack.NormalModuleReplacementPlugin( /^lib\/post-normalizer\/rule-create-better-excerpt$/, 'lodash/noop' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/preview-upgrade-nudge$/, 'components/empty-component' ), //Depends on page.js and should never be required server side
+		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/preview-upgrade-nudge$/, 'components/empty-component' ), // Depends on page.js and should never be required server side
+		new webpack.NormalModuleReplacementPlugin( /^components\/popover$/, 'components/empty-component' ), // Depends on BOM and interactions don't work without JS
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/single-site$/, 'components/empty-component' ), // Depends on DOM
+		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/multi-site$/, 'components/empty-component' ), // Depends on DOM
 		new webpack.NormalModuleReplacementPlugin( /^state\/ui\/editor\/selectors$/, 'lodash/noop' ), // will never be called server-side
 		new webpack.NormalModuleReplacementPlugin( /^state\/posts\/selectors$/, 'lodash/noop' ), // will never be called server-side
 		new webpack.NormalModuleReplacementPlugin( /^client\/layout\/guided-tours\/config$/, 'components/empty-component' ) // should never be required server side


### PR DESCRIPTION
While individual Theme pages are fully server-rendered, the Theme Showcase doesn't render until client-side JavaScript executes. This PR will improve the UX and SEO of the Theme Showcase by sending the initial render with the server payload.

Since SSR for logged-in users is a [dependency nightmare](https://github.com/Automattic/wp-calypso/blob/master/docs/server-side-rendering.md#i-want-to-server-side-render-my-components), this PR will only handle the logged-out use case.

This PR will also only provide a baseline experience, behind a feature flag, to be improved upon in further PRs.

Known issues to be fixed before public release:
* All users are being served the `<LoggedOut>` component in server render, not just logged-out users
* Server-side theme fetch is not cached
* `ThemesListFetcher` indiscriminately re-requests the data already provided by the server [when it mounts client-side](https://github.com/Automattic/wp-calypso/blob/master/client/components/data/themes-list-fetcher/index.jsx#L48)