### PR TITLE
Fix/doc config reference

### DIFF
--- a/client/config/README.md
+++ b/client/config/README.md
@@ -1,7 +1,7 @@
 client/config
 =============
 
-The `index.js` file is generated on startup by `regenerate-client.js`. Based on the environment, data is read from the appropriate .json file in the root config directory, for example, `/config/development.json`. The data is then compared against a whitelist in `/config/client.json`, and whitelisted items are added to the data object in `/client/config/index.js`. You can read more about how to use `config` in the [main documentation](https://github.com/Automattic/wp-calypso#config).
+The `index.js` file is generated on startup by `regenerate-client.js`. Based on the environment, data is read from the appropriate .json file in the root config directory, for example, `/config/development.json`. The data is then compared against a whitelist in `/config/client.json`, and whitelisted items are added to the data object in `/client/config/index.js`. You can read more about how to use `config` in the [config documentation](../config).
 
 Feature Flags API
 -----------------

--- a/config/README.md
+++ b/config/README.md
@@ -28,8 +28,8 @@ The config files contain a features object that can be used to determine whether
 
 If you want to temporarily enable/disable some feature flags for a given build, you can do so by setting the `ENABLE_FEATURES` and/or `DISABLE_FEATURES` environment variables. Set them to a comma separated list of features you want to enable/disable, respectively:
 
-`bash
+```bash
 ENABLE_FEATURES=manage/plugins/compatibility-warning DISABLE_FEATURES=code-splitting,reader make run
-`
+```
 
 This will generate the appropriate `client/config/index.js` file. Afterwards, when you run `make run` without setting these variables, `client/config/index.js` will regenerate according to the selected config file - making this method ideal for quickly reviewing PRs or reproducing bugs.


### PR DESCRIPTION
Hi there,

I've a couple of improvements to docs here.

I've changed the link to https://github.com/Automattic/wp-calypso#config, because in the main documentation there aren't anymore reference to how configuration works.