### PR TITLE
Checkout: allow streamlined paid NUX test in any locale

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,12 +98,13 @@ module.exports = {
 		allowExistingUsers: false,
 	},
 	paidNuxStreamlined: {
-		datestamp: '20160912',
+		datestamp: '20161020',
 		variations: {
 			original: 50,
 			streamlined: 50,
 		},
 		defaultVariation: 'original',
+		allowAnyLocale: true,
 	},
 	readerFullPost: {
 		datestamp: '20160929',


### PR DESCRIPTION
We've seen good results from the streamlined paid NUX test so far. Now let's make sure this holds in non-en locales as well. 

To test: make sure the test allows non-en locales. 