### PR TITLE
Image Editor: add ability to pass in a local file

### DIFF
--- a/client/blocks/image-editor/README.md
+++ b/client/blocks/image-editor/README.md
@@ -28,8 +28,15 @@ Id of a site the edited image belongs to.
 	<tr><th>Required</th><td>Yes</td></tr>
 </table>
 
-This object needs to contain at least these properties:
-- `media.URL` `{string}`: the `url` of the image to be edited (e.g. `https://my-site.com/full-width1-e1.jpg`)
+This object needs to contain at least one of these properties:
+
+`media.URL` `{string}`: the `url` of the image to be edited (e.g. `https://my-site.com/full-width1-e1.jpg`).
+Use this approach if you want to load and edit a remote image file.
+
+or
+
+`media.src` `{string}`: the [object url](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) of
+the image to be edited. Use this approach if you want to edit a local image file (e.g. uploaded file or blob).
 
 It can also contain these optional properties (with defaults if not set):
 - `media.file` `{string}`: the base name of the edited image file (e.g. `full-width1-e1.jpg`), defaults to `default`

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -12,9 +12,15 @@ import ImageEditor from '../';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 class ImageEditorExample extends Component {
-	media = {
-		URL: 'https://cldup.com/mA_hqNVj0w.jpg'
-	};
+	constructor() {
+		super();
+		
+		this.state = {
+			media: {
+				URL: 'https://cldup.com/mA_hqNVj0w.jpg'
+			}
+		};
+	}
 
 	getTestingImage = () => document.querySelector( "#devdocs-example-image-editor-result" );
 
@@ -29,7 +35,27 @@ class ImageEditorExample extends Component {
 	};
 
 	onImageEditorReset = () => {
-		this.getTestingImage().src = this.media.URL;
+		this.getTestingImage().src = this.state.media.URL || this.state.media.src;
+	};
+	
+	componentDidMount() {
+		const fileInput = document.querySelector( '#devdocs-example-image-editor-file-input' );
+		
+		fileInput.addEventListener( 'change', this.onImageUpload );
+	}
+
+	onImageUpload = ( e ) => {
+		const imageFile = e.target.files[ 0 ];
+		
+		const imageObjectUrl = URL.createObjectURL( imageFile );
+		
+		this.setState( {
+			media: {
+				src: imageObjectUrl
+			}
+		} );
+
+		this.getTestingImage().src = imageObjectUrl;
 	};
 
 	render() {
@@ -39,14 +65,22 @@ class ImageEditorExample extends Component {
 		
 		return (
 			<div>
+				<div style={ {
+					marginBottom: '20px'
+				} }>
+					<h4>Upload an image</h4>
+					<input type="file" id="devdocs-example-image-editor-file-input" />
+				</div>
+
 				<div style={ { height: '80vh' } }>
 					<ImageEditor
 						siteId={ primarySiteId }
-						media={ this.media }
+						media={ this.state.media }
 						onDone={ this.onImageEditorDone }
 						onReset={ this.onImageEditorReset }
 					/>
 				</div>
+
 				<div style={ {
 					textAlign: 'center',
 					marginTop: '15px'
@@ -54,7 +88,7 @@ class ImageEditorExample extends Component {
 					<h4>Changes to the image above are shown below</h4>
 					<img
 						id="devdocs-example-image-editor-result"
-						src={ this.media.URL }
+						src={ this.state.media.URL }
 					/>
 				</div>
 			</div>

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 
@@ -11,49 +11,55 @@ import { get } from 'lodash';
 import ImageEditor from '../';
 import { getCurrentUser } from 'state/current-user/selectors';
 
-function ImageEditorExample( { primarySiteId } ) {
-	const media = {
+class ImageEditorExample extends Component {
+	media = {
 		URL: 'https://cldup.com/mA_hqNVj0w.jpg'
 	};
 
-	const getTestingImage = () => document.querySelector( "#devdocs-example-image-editor-result" );
+	getTestingImage = () => document.querySelector( "#devdocs-example-image-editor-result" );
 
-	const onImageEditorDone = ( error, blob ) => {
+	onImageEditorDone = ( error, blob ) => {
 		if ( error ) {
 			return;
 		}
 		
 		const imageUrl = window.URL.createObjectURL( blob );
 
-		getTestingImage().src = imageUrl;
+		this.getTestingImage().src = imageUrl;
 	};
 
-	const onImageEditorReset = () => {
-		getTestingImage().src = media.URL;
+	onImageEditorReset = () => {
+		this.getTestingImage().src = this.media.URL;
 	};
 
-	return (
-		<div>
-			<div style={ { height: '80vh' } }>
-				<ImageEditor
-					siteId={ primarySiteId }
-					media={ media }
-					onDone={ onImageEditorDone }
-					onReset={ onImageEditorReset }
-				/>
+	render() {
+		const {
+			primarySiteId
+		} = this.props;
+		
+		return (
+			<div>
+				<div style={ { height: '80vh' } }>
+					<ImageEditor
+						siteId={ primarySiteId }
+						media={ this.media }
+						onDone={ this.onImageEditorDone }
+						onReset={ this.onImageEditorReset }
+					/>
+				</div>
+				<div style={ {
+					textAlign: 'center',
+					marginTop: '15px'
+				} }>
+					<h4>Changes to the image above are shown below</h4>
+					<img
+						id="devdocs-example-image-editor-result"
+						src={ this.media.URL }
+					/>
+				</div>
 			</div>
-			<div style={ {
-				textAlign: 'center',
-				marginTop: '15px'
-			} }>
-				<h4>Changes to the image above are shown below</h4>
-				<img
-					id="devdocs-example-image-editor-result"
-					src={ media.URL }
-				/>
-			</div>
-		</div>
-	);
+		);
+	}
 }
 
 const ConnectedImageEditorExample = connect( ( state ) => {

--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
-import { noop, throttle } from 'lodash';
+import { noop, throttle, startsWith } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -83,12 +83,22 @@ class ImageEditorCanvas extends Component {
 		}
 	}
 
-	getImage( url ) {
+	isBlobSrc( src ) {
+		return startsWith( src, 'blob' );
+	}
+
+	getImage( src ) {
 		const { onLoadError, mimeType } = this.props;
 
 		const req = new XMLHttpRequest();
-		req.open( 'GET', url + '?', true ); // Fix #7991 by forcing Safari to ignore cache and perform valid CORS request
+
+		if ( ! this.isBlobSrc( src ) ) {
+			src = src + '?'; // Fix #7991 by forcing Safari to ignore cache and perform valid CORS request
+		}
+
+		req.open( 'GET', src, true );
 		req.responseType = 'arraybuffer';
+
 		req.onload = () => {
 			if ( ! this.isVisible ) {
 				return;

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
+import { noop, isEqual } from 'lodash';
 import path from 'path';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -66,11 +66,24 @@ const ImageEditor = React.createClass( {
 		};
 	},
 
-	componentDidMount() {
+	componentWillReceiveProps( newProps ) {
 		const {
-			media,
-			site
+			media: currentMedia
 		} = this.props;
+
+		if ( newProps.media && ! isEqual( newProps.media, currentMedia ) ) {
+			this.props.resetAllImageEditorState();
+
+			this.updateFileInfo( newProps.media );
+		}
+	},
+
+	componentDidMount() {
+		this.updateFileInfo( this.props.media );
+	},
+
+	updateFileInfo( media ) {
+		const {	site } = this.props;
 
 		let src,
 			fileName = 'default',
@@ -78,7 +91,7 @@ const ImageEditor = React.createClass( {
 			title = 'default';
 
 		if ( media ) {
-			src = MediaUtils.url( media, {
+			src = media.src || MediaUtils.url( media, {
 				photon: site && ! site.is_private
 			} );
 


### PR DESCRIPTION
Fixes #8848. Adds an ability to pass both a `URL` to an image file and a `src` to a local (ie in browser memory) file. We also update devdocs of image editor to include an interactive upload functionality for testing.

## Testing instructions

1. Make sure the image editor works as before in Media Modal;
2. Navigate to http://calypso.localhost:3000/devdocs/blocks/image-editor and upload a new image;
3. While having dev tools console open, tinker with the image (edit, upload different one, reset, etc) and see if there are no errors and everything works as expected.

## Todo

- [x] Update readme of image editor to mention that you can either add URL of an image or src of a local image blob.
- [ ] Add validation for images (do we need this?): (ie. is the file passed in a real image?)

/cc @gwwar @v18 @artpi @retrofox 