### PR TITLE
Framework: Remove middleware that resets selected site

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -362,17 +362,6 @@ function reduxStoreReady( reduxStore ) {
 		} );
 	}
 
-	page( '*', function( context, next ) {
-		// Reset the selected site before each route is executed. This needs to
-		// occur after the sections routes execute to avoid a brief flash where
-		// sites are reset but the next section is waiting to be loaded.
-		if ( ! route.getSiteFragment( context.path ) && sites.getSelectedSite() ) {
-			sites.resetSelectedSite();
-		}
-
-		next();
-	} );
-
 	require( 'my-sites' )();
 
 	// clear notices

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -33,7 +33,6 @@ function SitesList() {
 	this.fetched = false; // false until data comes from api
 	this.fetching = false;
 	this.selected = null;
-	this.lastSelected = null;
 	this.propagateChange = this.propagateChange.bind( this );
 }
 
@@ -328,30 +327,6 @@ SitesList.prototype.getSelectedOrAll = function() {
  */
 SitesList.prototype.getSelectedSite = function() {
 	return this.getSite( this.selected );
-};
-
-/**
- * Return the last selected site or false
- *
- * @api public
- */
-SitesList.prototype.getLastSelectedSite = function() {
-	return this.getSite( this.lastSelected );
-};
-
-/**
- * Resets the selected site
- *
- * @api public
- */
-SitesList.prototype.resetSelectedSite = function() {
-	if ( ! this.selected ) {
-		return;
-	}
-
-	this.lastSelected = this.selected;
-	this.selected = null;
-	this.emit( 'change' );
 };
 
 /**

--- a/client/state/ui/README.md
+++ b/client/state/ui/README.md
@@ -38,3 +38,9 @@ import { getSelectedSite } from 'state/ui/selectors';
 
 const selectedSite = getSelectedSite( store.getState() );
 ```
+
+
+### `getSelectedSite( state: Object )`
+
+Returns the slug of the currently selected site, or null if no site is selected
+

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -8,7 +8,7 @@ import { includes, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getSite } from 'state/sites/selectors';
+import { getSite, getSiteSlug } from 'state/sites/selectors';
 
 /**
  * Returns the site object for the currently selected site.
@@ -33,6 +33,22 @@ export function getSelectedSite( state ) {
  */
 export function getSelectedSiteId( state ) {
 	return state.ui.selectedSiteId;
+}
+
+/**
+ * Returns the slug of the currently selected site,
+ * or null if no site is selected.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}       Selected site ID
+ */
+export function getSelectedSiteSlug( state ) {
+	const siteId = getSelectedSiteId( state );
+	if ( ! siteId ) {
+		return null;
+	}
+
+	return getSiteSlug( state, siteId );
 }
 
 /**

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -13,7 +13,8 @@ import {
 	getSectionGroup,
 	isSiteSection,
 	isSectionIsomorphic,
-	hasSidebar
+	hasSidebar,
+	getSelectedSiteSlug,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -76,6 +77,33 @@ describe( 'selectors', () => {
 			} );
 
 			expect( selected ).to.eql( 2916284 );
+		} );
+	} );
+
+	describe( '#getSelectedSiteSlug()', () => {
+		it( 'should return null if no site is selected', () => {
+			const slug = getSelectedSiteSlug( {
+				ui: {
+					selectedSiteSlug: null
+				}
+			} );
+
+			expect( slug ).to.be.null;
+		} );
+
+		it( 'should return slug for the selected site', () => {
+			const slug = getSelectedSiteSlug( {
+				sites: {
+					items: {
+						2916284: { ID: 2916284, name: 'WordPress.com Example Blog', URL: 'https://example.com' }
+					}
+				},
+				ui: {
+					selectedSiteId: 2916284
+				}
+			} );
+
+			expect( slug ).to.eql( 'example.com' );
 		} );
 	} );
 


### PR DESCRIPTION
Remove use of `sitesList.getSelectedSite`, since this middleware does not seem to be necessary anymore. Was added with the following comment:

> This pull request seeks to avoid an undesirable consequence of site resetting where, if the next section is not site-specific but requires a section chunk to be loaded, the site is reset but the next page isn't rendered until chunk loading has finished.

> Steps to reproduce:

> In a fresh Calypso page session, navigate to My Sites
Select a site if one isn't already selected
Click your profile image to the right of the master bar (i.e. /me)
In master: You'll see that the current My Sites view resets to All Sites while /me loads
In this branch: The current My Sites view maintains the selected site until after /me loads

> You should also confirm that the clicking the New Post button in the master bar after navigating to /me still correctly shows the site dropdown.

This PR also adds `getCurrentSiteSlug()` selector for convenience.

**To Test**
* Test case above
* Check that the help contact from behaves as master by showing the (last) selected site or primary site
