### PR TITLE
Reader: Make using the DomParser a bit safer

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -82,7 +82,7 @@ try {
 		// text/html parsing is natively supported
 		_useDomParser = true;
 	}
-} catch ( ex ) { }
+} catch ( ex ) {}
 
 export function domForHtml( html ) {
 	let dom;

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -74,11 +74,24 @@ export function makeImageURLSafe( object, propName, maxWidth, baseURL ) {
 	}
 }
 
+let _useDomParser = false;
+// Firefox/Opera/IE throw errors on unsupported types
+try {
+	// WebKit returns null on unsupported types
+	if ( ( new DOMParser() ).parseFromString( '', 'text/html' ) ) {
+		// text/html parsing is natively supported
+		_useDomParser = true;
+	}
+} catch ( ex ) { }
+
 export function domForHtml( html ) {
 	let dom;
-	if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
+	if ( _useDomParser ) {
 		const parser = new DOMParser();
-		dom = parser.parseFromString( html, 'text/html' ).body;
+		const doc = parser.parseFromString( html, 'text/html' );
+		if ( doc && doc.body ) {
+			dom = doc.body;
+		}
 	} else {
 		dom = document.createElement( 'div' );
 		dom.innerHTML = html;


### PR DESCRIPTION
Prevent using the body if/when the document comes back null or bad.
Make choosing to use the DomParser a bit safer.

Based on https://developer.mozilla.org/en-US/docs/Web/API/DOMParser, which is public domain.