### PR TITLE
Pages: show label for the page that shows current posts

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -25,7 +25,10 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 	config = require( 'config' );
 
 import MenuSeparator from 'components/popover/menu-separator';
-import { isFrontPage } from 'state/pages/selectors';
+import {
+	isFrontPage,
+	isPostsPage,
+} from 'state/pages/selectors';
 import { setFrontPage } from 'state/sites/actions';
 import { userCan } from 'lib/site/utils';
 
@@ -316,6 +319,7 @@ const Page = React.createClass( {
 					{ this.props.isFrontPage ? <Gridicon icon="house" size={ 18 } /> : null }
 					{ title }
 				</a>
+				{ this.props.isPostsPage ? <div className="page__posts-page">{ this.translate( 'Your latest posts' ) }</div> : null }
 				{ this.props.multisite ? <span className="page__site-url">{ this.getSiteDomain() }</span> : null }
 				<Gridicon
 					icon="ellipsis"
@@ -379,7 +383,8 @@ const Page = React.createClass( {
 export default connect(
 	( state, props ) => {
 		return {
-			isFrontPage: isFrontPage( state, props.page.site_ID, props.page.ID )
+			isFrontPage: isFrontPage( state, props.page.site_ID, props.page.ID ),
+			isPostsPage: isPostsPage( state, props.page.site_ID, props.page.ID ),
 		};
 	},
 	( dispatch ) => bindActionCreators( {

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -66,6 +66,13 @@
 	}
 }
 
+.page__posts-page {
+	color: $gray;
+	display: block;
+	font-size: 12px;
+	margin-top: -3px;
+}
+
 .page__site-url {
 	color: $gray;
 	display: block;

--- a/client/state/pages/selectors.js
+++ b/client/state/pages/selectors.js
@@ -6,8 +6,15 @@
 /**
  * Internal dependencies
  */
-import { getSiteFrontPage } from 'state/sites/selectors';
+import {
+	getSiteFrontPage,
+	getSitePostsPage,
+} from 'state/sites/selectors';
 
 export function isFrontPage( state, siteId, pageId ) {
 	return pageId === getSiteFrontPage( state, siteId );
+}
+
+export function isPostsPage( state, siteId, pageId ) {
+	return pageId === getSitePostsPage( state, siteId );
 }

--- a/client/state/pages/test/selectors.js
+++ b/client/state/pages/test/selectors.js
@@ -6,7 +6,10 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isFrontPage } from '../selectors';
+import {
+	isFrontPage,
+	isPostsPage,
+} from '../selectors';
 
 describe( 'selectors', () => {
 	describe( 'isFrontPage()', () => {
@@ -69,6 +72,54 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the site is not known', () => {
 			const result = isFrontPage( {
+				sites: {
+					items: {}
+				}
+			}, 77203074, 1 );
+
+			expect( result ).to.equal( false );
+		} );
+	} );
+
+	describe( 'isPostsPage()', () => {
+		it( 'should return true if the page is set as the posts page', () => {
+			const result = isPostsPage( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							options: {
+								page_for_posts: 1
+							}
+						}
+					}
+				}
+			}, 77203074, 1 );
+
+			expect( result ).to.eql( true );
+		} );
+
+		it( 'should return false if the page is not set as the posts page', () => {
+			const result = isPostsPage( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							options: {
+								page_for_posts: 2
+							}
+						}
+					}
+				}
+			}, 77203074, 1 );
+
+			expect( result ).to.eql( false );
+		} );
+
+		it( 'should return false if the site is not known', () => {
+			const result = isPostsPage( {
 				sites: {
 					items: {}
 				}


### PR DESCRIPTION
This pull request creates a new selector `isPostsPage` (and adds tests for that selector), which is used to display a label on the Pages page when a page is set to display your latest posts. This PR doesn't include anything to update that setting.

![image](https://cloud.githubusercontent.com/assets/363749/19569090/fa53c89c-96b9-11e6-946b-6f063b9a841c.png)

To test:
* Make sure tests pass: `npm run test-client -- --grep "state pages"`
* From reading settings in wp-admin (`/wp-admin/options-reading.php`) set a static front page and static posts page (make sure they aren't the same, as wp-admin actually unsets the static posts page if they are)
* `make run`
* Visit the Pages page in Calypso and make sure the label appears under the page you set in wp-admin