### PR TITLE
Pages: Don't show the ellipsis and popover when empty

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -323,17 +323,39 @@ const Page = React.createClass( {
 		const restoreItem = this.getRestoreItem();
 		const sendToTrashItem = this.getSendToTrashItem();
 		const moreInfoItem = this.popoverMoreInfo();
-
-		const setHomepageMenuSeparator = (
-			setAsHomepageItem && (
-				viewItem ||
-				publishItem ||
-				editItem ||
-				restoreItem ||
-				sendToTrashItem ||
-				moreInfoItem
-			)
-		) ? <MenuSeparator /> : null;
+		const hasSeparatedItems = (
+			viewItem || publishItem || editItem ||
+			restoreItem || sendToTrashItem || moreInfoItem
+		);
+		const hasPopoverItems = setAsHomepageItem || hasSeparatedItems;
+		const setHomepageMenuSeparator = ( setAsHomepageItem && hasSeparatedItems ) ? <MenuSeparator /> : null;
+		const popoverMenu = hasPopoverItems ? (
+			<PopoverMenu
+				isVisible={ this.state.showPageActions }
+				onClose={ this.togglePageActions }
+				position={ 'bottom left' }
+				context={ this.refs && this.refs.popoverMenuButton }
+			>
+				{ setAsHomepageItem }
+				{ setHomepageMenuSeparator }
+				{ viewItem }
+				{ publishItem }
+				{ editItem }
+				{ restoreItem }
+				{ sendToTrashItem }
+				{ moreInfoItem }
+			</PopoverMenu>
+		) : null;
+		const ellipsisGridicon = hasPopoverItems ? (
+			<Gridicon
+			icon="ellipsis"
+			className={ classNames( {
+				'page__actions-toggle': true,
+				'is-active': this.state.showPageActions
+			} ) }
+			onClick={ this.togglePageActions }
+			ref="popoverMenuButton" />
+		) : null;
 
 		return (
 			<CompactCard className="page">
@@ -351,29 +373,8 @@ const Page = React.createClass( {
 				</a>
 				{ this.props.isPostsPage ? <div className="page__posts-page">{ this.translate( 'Your latest posts' ) }</div> : null }
 				{ this.props.multisite ? <span className="page__site-url">{ this.getSiteDomain() }</span> : null }
-				<Gridicon
-					icon="ellipsis"
-					className={ classNames( {
-						'page__actions-toggle': true,
-						'is-active': this.state.showPageActions
-					} ) }
-					onClick={ this.togglePageActions }
-					ref="popoverMenuButton" />
-				<PopoverMenu
-					isVisible={ this.state.showPageActions }
-					onClose={ this.togglePageActions }
-					position={ 'bottom left' }
-					context={ this.refs && this.refs.popoverMenuButton }
-				>
-					{ setAsHomepageItem }
-					{ setHomepageMenuSeparator }
-					{ viewItem }
-					{ publishItem }
-					{ editItem }
-					{ restoreItem }
-					{ sendToTrashItem }
-					{ moreInfoItem }
-				</PopoverMenu>
+				{ ellipsisGridicon }
+				{ popoverMenu }
 				<ReactCSSTransitionGroup
 					transitionName="updated-trans"
 					transitionEnterTimeout={ 300 }


### PR DESCRIPTION
When #8863 got merged, page items without items to show in the popover resulted in empty popovers showing:

<img width="561" alt="screen shot 2016-10-20 at 2 44 24 pm" src="https://cloud.githubusercontent.com/assets/1587282/19573667/360543c8-96d5-11e6-8aae-e7e8b35ff784.png">

This does not render the Ellipses or the Popover menu when there's nothing to show.

## To test:
* From reading settings in wp-admin (`/wp-admin/options-reading.php`) set a static front page and static posts page (make sure they aren't the same, as wp-admin actually unsets the static posts page if they are)
* make run
* Visit the Pages page in Calypso:
  * Make sure the list of pages make sense:
    * "Regular" pages should not be affected (_should_ have view / edit / trash dropdown menu items, etc.)
    * "Posts" pages should _not_ have the view / edit / trash dropdown menu items -- only `Set as Homepage`
    * If a page is set as the "Front Page", it should have the "house" icon and it _should_ have view / edit / trash dropdown menu items
* Set `config/development.json` feature flag `"manage/pages/set-homepage": false,` and make sure there are no empty popovers or ellipses without actions to perform