### PR TITLE
Me: E-Mail subscription: Rephrase Digests description

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -110,11 +110,11 @@ const MainComponent = React.createClass( {
 		if ( 'marketing' === this.props.category ) {
 			return this.translate( 'Tips for getting the most out of WordPress.com.' );
 		} else if ( 'research' === this.props.category ) {
-			return this.translate( 'Opportunities to participate in WordPress.com research & surveys.' );
+			return this.translate( 'Opportunities to participate in WordPress.com research and surveys.' );
 		} else if ( 'community' === this.props.category ) {
-			return this.translate( 'Information on WordPress.com courses and events (online & in-person).' );
+			return this.translate( 'Information on WordPress.com courses and events (online and in-person).' );
 		} else if ( 'digest' === this.props.category ) {
-			return this.translate( 'A compilation of interesting tidbits from both your personal feed and your own writing.' );
+			return this.translate( 'Popular content from the blogs you follow, and reports on your own site and its performance.' );
 		}
 
 		return null;

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -4,6 +4,7 @@
 import page from 'page';
 import React from 'react';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -49,7 +50,7 @@ const MainComponent = React.createClass( {
 	},
 
 	getSubscribedMessage() {
-		return this.translate( 'Subscribed to {{em}}%(categoryName)s{{/em}}', {
+		return this.props.translate( 'Subscribed to {{em}}%(categoryName)s{{/em}}', {
 			args: {
 				categoryName: this.getCategoryName()
 			},
@@ -60,7 +61,7 @@ const MainComponent = React.createClass( {
 	},
 
 	getUnsubscribedMessage() {
-		return this.translate( 'Unsubscribed from {{em}}%(categoryName)s{{/em}}', {
+		return this.props.translate( 'Unsubscribed from {{em}}%(categoryName)s{{/em}}', {
 			args: {
 				categoryName: this.getCategoryName()
 			},
@@ -71,7 +72,7 @@ const MainComponent = React.createClass( {
 	},
 
 	getSubscribedErrorMessage() {
-		return this.translate( 'Error subscribing to {{em}}%(categoryName)s{{/em}} mailing list! Try again later.', {
+		return this.props.translate( 'Error subscribing to {{em}}%(categoryName)s{{/em}} mailing list! Try again later.', {
 			args: {
 				categoryName: this.getCategoryName()
 			},
@@ -82,7 +83,7 @@ const MainComponent = React.createClass( {
 	},
 
 	getUnsubscribedErrorMessage() {
-		return this.translate( 'Error unsubscribing from {{em}}%(categoryName)s{{/em}} mailing list! Try again later.', {
+		return this.props.translate( 'Error unsubscribing from {{em}}%(categoryName)s{{/em}} mailing list! Try again later.', {
 			args: {
 				categoryName: this.getCategoryName()
 			},
@@ -94,13 +95,13 @@ const MainComponent = React.createClass( {
 
 	getCategoryName() {
 		if ( 'marketing' === this.props.category ) {
-			return this.translate( 'Suggestions' );
+			return this.props.translate( 'Suggestions' );
 		} else if ( 'research' === this.props.category ) {
-			return this.translate( 'Research' );
+			return this.props.translate( 'Research' );
 		} else if ( 'community' === this.props.category ) {
-			return this.translate( 'Community' );
+			return this.props.translate( 'Community' );
 		} else if ( 'digest' === this.props.category ) {
-			return this.translate( 'Digests' );
+			return this.props.translate( 'Digests' );
 		}
 
 		return this.props.category;
@@ -108,13 +109,13 @@ const MainComponent = React.createClass( {
 
 	getCategoryDescription() {
 		if ( 'marketing' === this.props.category ) {
-			return this.translate( 'Tips for getting the most out of WordPress.com.' );
+			return this.props.translate( 'Tips for getting the most out of WordPress.com.' );
 		} else if ( 'research' === this.props.category ) {
-			return this.translate( 'Opportunities to participate in WordPress.com research and surveys.' );
+			return this.props.translate( 'Opportunities to participate in WordPress.com research and surveys.' );
 		} else if ( 'community' === this.props.category ) {
-			return this.translate( 'Information on WordPress.com courses and events (online and in-person).' );
+			return this.props.translate( 'Information on WordPress.com courses and events (online and in-person).' );
 		} else if ( 'digest' === this.props.category ) {
-			return this.translate( 'Popular content from the blogs you follow, and reports on your own site and its performance.' );
+			return this.props.translate( 'Popular content from the blogs you follow, and reports on your own site and its performance.' );
 		}
 
 		return null;
@@ -143,12 +144,13 @@ const MainComponent = React.createClass( {
 	},
 
 	render() {
+		const translate = this.props.translate;
 		var headingLabel = this.state.isSubscribed
-								? this.translate( 'You\'re subscribed' )
-								: this.translate( 'We\'ve unsubscribed your email.' ),
+								? translate( 'You\'re subscribed' )
+								: translate( 'We\'ve unsubscribed your email.' ),
 			messageLabel = this.state.isSubscribed
-								? this.translate( 'We\'ll send you updates for this mailing list.' )
-								: this.translate( 'You will no longer receive updates for this mailing list.' );
+								? translate( 'We\'ll send you updates for this mailing list.' )
+								: translate( 'You will no longer receive updates for this mailing list.' );
 
 		return(
 			<div className="mailing-lists">
@@ -165,14 +167,22 @@ const MainComponent = React.createClass( {
 					<h4>{ this.getCategoryName() }</h4>
 					<p>{ this.getCategoryDescription() }</p>
 					{ this.state.isSubscribed
-						? <button className="button is-primary" onClick={ this.onUnsubscribeClick }>{ this.translate( 'Unsubscribe' ) }</button>
-						: <button className="button" onClick={ this.onResubscribeClick }>{ this.translate( 'Resubscribe' ) }</button> }
+						? <button className="mailing-lists__unsubscribe-button button is-primary" onClick={ this.onUnsubscribeClick }>
+							{ translate( 'Unsubscribe' ) }
+						</button>
+						: <button className="mailing-lists__resubscribe-button button" onClick={ this.onResubscribeClick }>
+							{ translate( 'Resubscribe' ) }
+						</button> }
 				</Card>
 
-				<p className="mailing-lists__manage-link"><button className="button is-link" onClick={ this.onManageUpdatesClick }>{ this.translate( 'Manage all your email subscriptions' ) }</button></p>
+				<p className="mailing-lists__manage-link">
+					<button className="mailing-lists__manage-button button is-link" onClick={ this.onManageUpdatesClick }>
+						{ translate( 'Manage all your email subscriptions' ) }
+					</button>
+				</p>
 			</div>
 		);
 	}
 } );
 
-export default MainComponent;
+export default localize( MainComponent );

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -114,7 +114,7 @@ const MainComponent = React.createClass( {
 		} else if ( 'community' === this.props.category ) {
 			return this.translate( 'Information on WordPress.com courses and events (online & in-person).' );
 		} else if ( 'digest' === this.props.category ) {
-			return this.translate( 'Reading & writing digests, tailored for you.' );
+			return this.translate( 'A compilation of interesting tidbits from both your personal feed and your own writing.' );
 		}
 
 		return null;

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -94,13 +94,13 @@ const WPCOMNotifications = React.createClass( {
 					name={ options.research }
 					isEnabled={ this.state.settings.get( options.research ) }
 					title={ this.translate( 'Research' ) }
-					description={ this.translate( 'Opportunities to participate in WordPress.com research & surveys.' ) }
+					description={ this.translate( 'Opportunities to participate in WordPress.com research and surveys.' ) }
 				/>
 
 				<EmailCategory
 					name={ options.community } isEnabled={ this.state.settings.get( options.community ) }
 					title={ this.translate( 'Community' ) }
-					description={ this.translate( 'Information on WordPress.com courses and events (online & in-person).' ) }
+					description={ this.translate( 'Information on WordPress.com courses and events (online and in-person).' ) }
 				/>
 
 				<EmailCategory
@@ -118,7 +118,7 @@ const WPCOMNotifications = React.createClass( {
 				<EmailCategory
 					name={ options.digest } isEnabled={ this.state.settings.get( options.digest ) }
 					title={ this.translate( 'Digests' ) }
-					description={ this.translate( 'A compilation of interesting tidbits from both your personal feed and your own writing.' ) }
+					description={ this.translate( 'Popular content from the blogs you follow, and reports on your own site and its performance.' ) }
 				/>
 
 				<ActionButtons

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -55,11 +56,11 @@ const WPCOMNotifications = React.createClass( {
 		const state = store.getStateFor( 'wpcom' );
 
 		if ( state.error ) {
-			this.props.errorNotice( this.translate( 'There was a problem saving your changes. Please, try again.' ) );
+			this.props.errorNotice( this.props.translate( 'There was a problem saving your changes. Please, try again.' ) );
 		}
 
 		if ( state.status === 'success' ) {
-			this.props.successNotice( this.translate( 'Settings saved successfully!' ) );
+			this.props.successNotice( this.props.translate( 'Settings saved successfully!' ) );
 		}
 
 		this.setState( state );
@@ -77,7 +78,7 @@ const WPCOMNotifications = React.createClass( {
 		return (
 			<div>
 				<p>
-					{ this.translate(
+					{ this.props.translate(
 						'We\'ll always send important emails regarding your account, security, ' +
 						'privacy, and purchase transactions, but you can get some helpful extras, too.'
 					) }
@@ -86,39 +87,40 @@ const WPCOMNotifications = React.createClass( {
 				<EmailCategory
 					name={ options.marketing }
 					isEnabled={ this.state.settings.get( options.marketing ) }
-					title={ this.translate( 'Suggestions' ) }
-					description={ this.translate( 'Tips for getting the most out of WordPress.com.' ) }
+					title={ this.props.translate( 'Suggestions' ) }
+					description={ this.props.translate( 'Tips for getting the most out of WordPress.com.' ) }
 				/>
 
 				<EmailCategory
 					name={ options.research }
 					isEnabled={ this.state.settings.get( options.research ) }
-					title={ this.translate( 'Research' ) }
-					description={ this.translate( 'Opportunities to participate in WordPress.com research and surveys.' ) }
+					title={ this.props.translate( 'Research' ) }
+					description={ this.props.translate( 'Opportunities to participate in WordPress.com research and surveys.' ) }
 				/>
 
 				<EmailCategory
 					name={ options.community } isEnabled={ this.state.settings.get( options.community ) }
-					title={ this.translate( 'Community' ) }
-					description={ this.translate( 'Information on WordPress.com courses and events (online and in-person).' ) }
+					title={ this.props.translate( 'Community' ) }
+					description={ this.props.translate( 'Information on WordPress.com courses and events (online and in-person).' ) }
 				/>
 
 				<EmailCategory
 					name={ options.promotion } isEnabled={ this.state.settings.get( options.promotion ) }
-					title={ this.translate( 'Promotions' ) }
-					description={ this.translate( 'Promotions and deals on upgrades.' ) }
+					title={ this.props.translate( 'Promotions' ) }
+					description={ this.props.translate( 'Promotions and deals on upgrades.' ) }
 				/>
 
 				<EmailCategory
 					name={ options.news } isEnabled={ this.state.settings.get( options.news ) }
-					title={ this.translate( 'News' ) }
-					description={ this.translate( 'WordPress.com news and announcements.' ) }
+					title={ this.props.translate( 'News' ) }
+					description={ this.props.translate( 'WordPress.com news and announcements.' ) }
 				/>
 
 				<EmailCategory
 					name={ options.digest } isEnabled={ this.state.settings.get( options.digest ) }
-					title={ this.translate( 'Digests' ) }
-					description={ this.translate( 'Popular content from the blogs you follow, and reports on your own site and its performance.' ) }
+					title={ this.props.translate( 'Digests' ) }
+					description={ this.props.translate( 'Popular content from the blogs you follow, and reports on ' +
+						'your own site and its performance.' ) }
 				/>
 
 				<ActionButtons
@@ -145,7 +147,7 @@ const WPCOMNotifications = React.createClass( {
 
 				<Card>
 					<FormSectionHeading>
-						{ this.translate( 'Email from WordPress.com' ) }
+						{ this.props.translate( 'Email from WordPress.com' ) }
 					</FormSectionHeading>
 					{ this.state.settings ? this.renderWpcomPreferences() : this.renderPlaceholder() }
 				</Card>
@@ -157,4 +159,4 @@ const WPCOMNotifications = React.createClass( {
 export default connect(
 	null,
 	dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch )
-)( WPCOMNotifications );
+)( localize( WPCOMNotifications ) );

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -118,7 +118,7 @@ const WPCOMNotifications = React.createClass( {
 				<EmailCategory
 					name={ options.digest } isEnabled={ this.state.settings.get( options.digest ) }
 					title={ this.translate( 'Digests' ) }
-					description={ this.translate( 'Reading & writing digests, tailored for you.' ) }
+					description={ this.translate( 'A compilation of interesting tidbits from both your personal feed and your own writing.' ) }
 				/>
 
 				<ActionButtons


### PR DESCRIPTION
Currently the _Digests_ e-mail subscription is explained with the description _Reading & Writing digests, tailored for you_. While this is very much to the point, one must know that these mean:
- Reader digest: you might like to read these things that others published. you are a reader.
- Writer digest: here’s a look at what you published and how it did in the last month. you are a writer.

I'd like to suggest to change the description to something easier to understand, for example _Your personal feed with interesting tidbits to read and digests about your writing._

Other suggestions are welcome!

cc @meremagee 

<img width="714" alt="screencapture at thu oct 6 21 48 58 edt 2016" src="https://cloud.githubusercontent.com/assets/2098816/19176537/c2e00098-8c0e-11e6-9120-24cdf9b34b87.png">
