### PR TITLE
Reader: Reload posts that are marked as such

### DIFF
--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -1,11 +1,15 @@
 /**
  * External Dependencies
  */
-import filter from 'lodash/filter';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import isUndefined from 'lodash/isUndefined';
-import reject from 'lodash/reject';
+import {
+	filter,
+	forEach,
+	has,
+	isUndefined,
+	map,
+	omit,
+	partition,
+	reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,9 +21,68 @@ import analytics from 'lib/analytics';
 import { runFastRules, runSlowRules } from './normalization-rules';
 import Dispatcher from 'dispatcher';
 import { action } from 'lib/feed-post-store/constants';
+import wpcom from 'lib/wp';
 
 function trackRailcarRender( post ) {
 	analytics.tracks.recordEvent( 'calypso_traintracks_render', post.railcar );
+}
+
+function postToKey( post ) {
+	return {
+		feedId: post.feed_ID,
+		postId: post.ID,
+		blogId: ! post.is_external && post.site_ID ? post.site_ID : undefined
+	};
+}
+
+function fetchForKey( postKey ) {
+	let req;
+	if ( postKey.blogId ) {
+		req = wpcom.undocumented().readSitePost( {
+			site: postKey.blogId,
+			postId: postKey.postId
+		} );
+	} else {
+		req = wpcom.undocumented().readFeedPost( postKey );
+	}
+	return req;
+}
+
+export function fetchPost( postKey ) {
+	return function( dispatch ) {
+		return fetchForKey( postKey ).then(
+			( data ) => {
+				dispatch( receivePosts( [ data ] ) );
+			},
+			( err ) => {
+				dispatch( {
+					type: READER_POSTS_RECEIVE,
+					posts: [ {
+						feed_ID: postKey.feedId,
+						ID: postKey.ID,
+						site_ID: postKey.blogId,
+						is_external: ! postKey.blogId,
+						is_error: true,
+						global_ID: `${ postKey.feedId }-${ postKey.blogId }-${ postKey.postId }`,
+						error: err
+					} ]
+				} );
+			}
+		);
+	};
+}
+
+export function reloadPost( post ) {
+	return function( dispatch ) {
+		// keep track of any railcars we might have
+		const railcar = post.railcar;
+		return fetchForKey( postToKey( post ) ).then(
+			( data ) => {
+				data.railcar = railcar;
+				dispatch( receivePosts( [ data ] ) );
+			}
+		);
+	};
 }
 
 /**
@@ -29,14 +92,21 @@ function trackRailcarRender( post ) {
  * @return {Object} Action object
  */
 export function receivePosts( posts ) {
-	if ( ! posts ) {
-		return Promise.resolve( [] );
-	}
 	return function( dispatch ) {
+		if ( ! posts ) {
+			return Promise.resolve( [] );
+		}
+
 		const withoutUndefined = reject( posts, isUndefined );
 		const normalizedPosts = map( withoutUndefined, runFastRules );
 
-		forEach( map( normalizedPosts, runSlowRules ), slowPromise => {
+		const [ postsToReload, postsToProcess ] = partition( normalizedPosts, '_should_reload' );
+		forEach( postsToReload, post => {
+			delete post._should_reload;
+			dispatch( reloadPost( post ) );
+		} );
+
+		forEach( map( postsToProcess, runSlowRules ), slowPromise => {
 			slowPromise.then( post => {
 				dispatch( {
 					type: READER_POSTS_RECEIVE,
@@ -58,13 +128,14 @@ export function receivePosts( posts ) {
 
 		// keep the old feed post store in sync
 		forEach( normalizedPosts, post => {
+			const postForFlux = has( post, '_should_reload' ) ? omit( post, '_should_reload' ) : post;
 			Dispatcher.handleServerAction( {
-				data: post,
+				data: postForFlux,
 				type: action.RECEIVE_NORMALIZED_FEED_POST
 			} );
 		} );
 
-		forEach( filter( normalizedPosts, 'railcar' ), trackRailcarRender );
+		forEach( filter( postsToProcess, 'railcar' ), trackRailcarRender );
 
 		return Promise.resolve( normalizedPosts );
 	};

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -59,11 +59,11 @@ export function fetchPost( postKey ) {
 					type: READER_POSTS_RECEIVE,
 					posts: [ {
 						feed_ID: postKey.feedId,
-						ID: postKey.ID,
+						ID: postKey.postId,
 						site_ID: postKey.blogId,
 						is_external: ! postKey.blogId,
 						is_error: true,
-						global_ID: `${ postKey.feedId }-${ postKey.blogId }-${ postKey.postId }`,
+						global_ID: `${ postKey.feedId || 'na' }-${ postKey.blogId || 'na' }-${ postKey.postId }`,
 						error: err
 					} ]
 				} );

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -27,61 +27,63 @@ function trackRailcarRender( post ) {
 	analytics.tracks.recordEvent( 'calypso_traintracks_render', post.railcar );
 }
 
-function postToKey( post ) {
+export function postToKey( post ) {
+	if ( post && post.feed_ID && post.feed_item_ID ) {
+		return {
+			feedId: post.feed_ID,
+			postId: post.feed_item_ID
+		};
+	}
+
+	if ( post.is_external ) {
+		return {
+			feedId: post.feed_ID,
+			postId: post.ID
+		};
+	}
+
 	return {
-		feedId: post.feed_ID,
 		postId: post.ID,
-		blogId: ! post.is_external && post.site_ID ? post.site_ID : undefined
+		blogId: post.site_ID
 	};
 }
 
 function fetchForKey( postKey ) {
-	let req;
 	if ( postKey.blogId ) {
-		req = wpcom.undocumented().readSitePost( {
+		return wpcom.undocumented().readSitePost( {
 			site: postKey.blogId,
 			postId: postKey.postId
 		} );
-	} else {
-		req = wpcom.undocumented().readFeedPost( postKey );
 	}
-	return req;
+	return wpcom.undocumented().readFeedPost( postKey );
 }
 
 export function fetchPost( postKey ) {
-	return function( dispatch ) {
-		return fetchForKey( postKey ).then(
-			( data ) => {
-				dispatch( receivePosts( [ data ] ) );
-			},
-			( err ) => {
-				dispatch( {
-					type: READER_POSTS_RECEIVE,
-					posts: [ {
-						feed_ID: postKey.feedId,
-						ID: postKey.postId,
-						site_ID: postKey.blogId,
-						is_external: ! postKey.blogId,
-						is_error: true,
-						global_ID: `${ postKey.feedId || 'na' }-${ postKey.blogId || 'na' }-${ postKey.postId }`,
-						error: err
-					} ]
-				} );
-			}
-		);
-	};
+	return dispatch => fetchForKey( postKey ).then(
+		data => dispatch( receivePosts( [ data ] ) ),
+		err => dispatch( {
+			type: READER_POSTS_RECEIVE,
+			posts: [ {
+				feed_ID: postKey.feedId,
+				ID: postKey.postId,
+				site_ID: postKey.blogId,
+				is_external: ! postKey.blogId,
+				is_error: true,
+				global_ID: `${ postKey.feedId || 'na' }-${ postKey.blogId || 'na' }-${ postKey.postId }`,
+				error: err
+			} ]
+		} )
+	);
 }
 
 export function reloadPost( post ) {
-	return function( dispatch ) {
+	return dispatch => {
 		// keep track of any railcars we might have
 		const railcar = post.railcar;
-		return fetchForKey( postToKey( post ) ).then(
-			( data ) => {
-				data.railcar = railcar;
-				dispatch( receivePosts( [ data ] ) );
-			}
-		);
+		return fetchForKey( postToKey( post ) ).then( data => {
+			data.railcar = railcar;
+			return dispatch( receivePosts( [ data ] ) );
+		} );
 	};
 }
 

--- a/client/state/reader/posts/selectors.js
+++ b/client/state/reader/posts/selectors.js
@@ -36,11 +36,11 @@ export function getPostBySiteAndId( state, siteId, postId ) {
 			internalPosts = filter( items, post => post && post.site_ID && post.ID && ! post.is_external );
 
 		postMapBySiteAndPost = keyBy( internalPosts, post => {
-			return `${post.site_ID}-${post.ID}`;
+			return `${ post.site_ID }-${ post.ID }`;
 		} );
 
 		previousItems = items;
 	}
 
-	return postMapBySiteAndPost[ `${siteId}-${postId}` ];
+	return postMapBySiteAndPost[ `${ siteId }-${ postId }` ];
 }

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -13,9 +13,11 @@ import {
 import useMockery from 'test/helpers/use-mockery';
 
 describe( 'actions', () => {
-	let receivePosts;
+	let actions;
 	const dispatchSpy = sinon.spy();
 	const trackingSpy = sinon.spy();
+	const readFeedStub = sinon.stub();
+	const readSiteStub = sinon.stub();
 
 	useMockery( mockery => {
 		mockery.registerMock( 'lib/analytics', {
@@ -24,18 +26,27 @@ describe( 'actions', () => {
 			}
 		} );
 
-		receivePosts = require( '../actions' ).receivePosts;
+		mockery.registerMock( 'lib/wp', {
+			undocumented: () => ( {
+				readFeedPost: readFeedStub,
+				readSitePost: readSiteStub
+			} )
+		} );
+
+		actions = require( '../actions' );
 	} );
 
 	afterEach( () => {
 		dispatchSpy.reset();
 		trackingSpy.reset();
+		readFeedStub.reset();
+		readSiteStub.reset();
 	} );
 
 	describe( '#receivePosts()', () => {
 		it( 'should return an action object and dispatch posts receive', () => {
 			const posts = [];
-			return receivePosts( posts )( dispatchSpy ).then( () => {
+			return actions.receivePosts( posts )( dispatchSpy ).then( () => {
 				expect( dispatchSpy ).to.have.been.calledWith( {
 					type: READER_POSTS_RECEIVE,
 					posts
@@ -52,8 +63,103 @@ describe( 'actions', () => {
 					railcar: 'foo'
 				}
 			];
-			receivePosts( posts )( dispatchSpy );
+			actions.receivePosts( posts )( dispatchSpy );
 			expect( trackingSpy ).to.have.been.calledWith( 'calypso_traintracks_render', 'foo' );
+		} );
+
+		it( 'should try to reload posts marked with should_reload', () => {
+			const posts = [
+				{
+					ID: 1,
+					site_ID: 1,
+					global_ID: 1,
+					railcar: '1234',
+					_should_reload: true
+				}
+			];
+
+			actions.receivePosts( posts )( dispatchSpy );
+			return expect( dispatchSpy ).to.have.been.calledWith( sinon.match.func );
+		} );
+	} );
+
+	describe( '#fetchPost', () => {
+		it( 'should call read/sites for blog posts', () => {
+			readSiteStub.returns( Promise.resolve( {} ) );
+			const req = actions.fetchPost( { blogId: 1, postId: 2 } )( dispatchSpy );
+
+			expect( readSiteStub ).to.have.been.calledWith( {
+				site: 1,
+				postId: 2
+			} );
+
+			return req.then( () => {
+				expect( dispatchSpy ).to.have.been.calledWith( sinon.match.func );
+			} );
+		} );
+
+		it( 'should call read/feeds for feed posts', () => {
+			readFeedStub.returns( Promise.resolve( {} ) );
+			const req = actions.fetchPost( { feedId: 1, postId: 2 } )( dispatchSpy );
+
+			expect( readFeedStub ).to.have.been.calledWith( {
+				feedId: 1,
+				postId: 2
+			} );
+
+			return req.then( () => {
+				expect( dispatchSpy ).to.have.been.calledWith( sinon.match.func );
+			} );
+		} );
+
+		it( 'should dispatch an error when a blog post call fails', () => {
+			readSiteStub.returns( Promise.reject( { status: 'oh no' } ) );
+			const req = actions.fetchPost( { blogId: 1, postId: 2 } )( dispatchSpy );
+
+			expect( readSiteStub ).to.have.been.calledWith( {
+				site: 1,
+				postId: 2
+			} );
+
+			return req.then( () => {
+				expect( dispatchSpy ).to.have.been.calledWith( {
+					type: READER_POSTS_RECEIVE,
+					posts: [ {
+						ID: 2,
+						site_ID: 1,
+						is_external: false,
+						is_error: true,
+						error: { status: 'oh no' },
+						feed_ID: undefined,
+						global_ID: 'na-1-2'
+					} ]
+				} );
+			} );
+		} );
+
+		it( 'should dispatch an error when a feed post call fails', () => {
+			readFeedStub.returns( Promise.reject( { status: 'oh no' } ) );
+			const req = actions.fetchPost( { feedId: 1, postId: 2 } )( dispatchSpy );
+
+			expect( readFeedStub ).to.have.been.calledWith( {
+				feedId: 1,
+				postId: 2
+			} );
+
+			return req.then( () => {
+				expect( dispatchSpy ).to.have.been.calledWith( {
+					type: READER_POSTS_RECEIVE,
+					posts: [ {
+						ID: 2,
+						site_ID: undefined,
+						is_external: true,
+						is_error: true,
+						error: { status: 'oh no' },
+						feed_ID: 1,
+						global_ID: '1-na-2'
+					} ]
+				} );
+			} );
 		} );
 	} );
 } );

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -43,6 +43,36 @@ describe( 'actions', () => {
 		readSiteStub.reset();
 	} );
 
+	describe( '#postToKey', () => {
+		it( 'should return a feed key for an external post', () => {
+			expect( actions.postToKey( {
+				feed_ID: 1,
+				site_ID: 1,
+				ID: 3,
+				feed_item_ID: 3,
+				is_external: true
+			} ) ).to.deep.equal( { feedId: 1, postId: 3 } );
+		} );
+
+		it( 'should return an blog id key for an internal post', () => {
+			expect( actions.postToKey( {
+				site_ID: 2,
+				ID: 4,
+				is_external: false
+			} ) ).to.deep.equal( { blogId: 2, postId: 4 } );
+		} );
+
+		it( 'should return a feed key for a post with both a feed id and a site id', () => {
+			expect( actions.postToKey( {
+				feed_ID: 1,
+				site_ID: 2,
+				ID: 4,
+				feed_item_ID: 3,
+				is_external: false
+			} ) ).to.deep.equal( { feedId: 1, postId: 3 } );
+		} );
+	} );
+
 	describe( '#receivePosts()', () => {
 		it( 'should return an action object and dispatch posts receive', () => {
 			const posts = [];


### PR DESCRIPTION
Some posts can only be served from the /read/site/... endpoints. We're now marking posts from other /read/ endpoints as such and need to reload them when we see them. This PR will teach the redux and flux stores how to do that.

This is a bit weird, since we have two post stores right now, and a one-way bridge from redux back to flux. 

The plan is to implement the reloader on both sides of the bridge, but strip off the reload attribute before a post crosses the bridge. That way, redux can reload the post and just tell flux about the new variant once it arrives.