### PR TITLE
Pages: Do not allow deletion of current homepage

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -235,7 +235,7 @@ const Page = React.createClass( {
 	},
 
 	getSendToTrashItem: function() {
-		if ( this.props.hasStaticFrontPage && this.props.isPostsPage ) {
+		if ( ( this.props.hasStaticFrontPage && this.props.isPostsPage ) || this.props.isFrontPage ) {
 			return null;
 		}
 


### PR DESCRIPTION
Deleting the currently assigned homepage in Pages reverts the site to showing the latest blog posts on the homepage. It is not clear that the user is intending to do this when they delete the current homepage. They might want to set another static page as the homepage. So, this PR prevents the deletion of the currently set homepage. The user will need to set another page as the homepage, or explicitly set their blog posts as the homepage, before being able to delete the page.

<img width="733" alt="screencapture at thu oct 20 16 19 52 edt 2016" src="https://cloud.githubusercontent.com/assets/2098816/19576586/7ee40c44-96e1-11e6-8fc8-676b4af39429.png">


To test:
- Set a static page as the homepage, using either wp-admin, Customizer, or Calypso (`development` env only currently)
- Verify that the popover menu for the current homepage does not allow it to be deleted
- Verify that the popover menu for other pages allow them to be deleted