### PR TITLE
Reader Stream Refresh: add follow button to post card

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -25,13 +25,12 @@ export default class RefreshPostCard extends React.Component {
 		feed: PropTypes.object,
 		onClick: PropTypes.func,
 		onCommentClick: PropTypes.func,
-		showFollow: PropTypes.bool
+		showPrimaryFollowButton: PropTypes.bool
 	};
 
 	static defaultProps = {
 		onClick: noop,
-		onCommentClick: noop,
-		showFollow: true
+		onCommentClick: noop
 	};
 
 	propagateCardClick = () => {
@@ -85,7 +84,7 @@ export default class RefreshPostCard extends React.Component {
 	}
 
 	render() {
-		const { post, site, feed, onCommentClick, showFollow } = this.props;
+		const { post, site, feed, onCommentClick, showPrimaryFollowButton } = this.props;
 		const isPhotoOnly = post.display_type & DisplayTypes.PHOTO_ONLY;
 		const title = truncate( post.title, {
 			length: 140,
@@ -99,14 +98,14 @@ export default class RefreshPostCard extends React.Component {
 		} );
 
 		let followUrl;
-		if ( showFollow ) {
+		if ( showPrimaryFollowButton ) {
 			followUrl = feed ? feed.feed_URL : post.site_URL;
 		}
 
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>
 				<PostByline post={ post } site={ site } feed={ feed } />
-				{ showFollow && <FollowButton siteUrl={ followUrl } /> }
+				{ showPrimaryFollowButton && <FollowButton siteUrl={ followUrl } /> }
 				<div className="reader-post-card__post">
 					{ featuredAsset }
 					<div className="reader-post-card__post-details">

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -16,6 +16,7 @@ import ReaderPostActions from 'blocks/reader-post-actions';
 import * as stats from 'reader/stats';
 import PostByline from './byline';
 import FeaturedAsset from './featured-asset';
+import FollowButton from 'reader/follow-button';
 
 export default class RefreshPostCard extends React.Component {
 	static propTypes = {
@@ -23,12 +24,14 @@ export default class RefreshPostCard extends React.Component {
 		site: PropTypes.object,
 		feed: PropTypes.object,
 		onClick: PropTypes.func,
-		onCommentClick: PropTypes.func
+		onCommentClick: PropTypes.func,
+		showFollow: PropTypes.bool
 	};
 
 	static defaultProps = {
 		onClick: noop,
-		onCommentClick: noop
+		onCommentClick: noop,
+		showFollow: true
 	};
 
 	propagateCardClick = () => {
@@ -82,7 +85,7 @@ export default class RefreshPostCard extends React.Component {
 	}
 
 	render() {
-		const { post, site, feed, onCommentClick } = this.props;
+		const { post, site, feed, onCommentClick, showFollow } = this.props;
 		const isPhotoOnly = post.display_type & DisplayTypes.PHOTO_ONLY;
 		const title = truncate( post.title, {
 			length: 140,
@@ -95,9 +98,15 @@ export default class RefreshPostCard extends React.Component {
 			'is-photo': isPhotoOnly
 		} );
 
+		let followUrl;
+		if ( showFollow ) {
+			followUrl = feed ? feed.feed_URL : post.site_URL;
+		}
+
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>
 				<PostByline post={ post } site={ site } feed={ feed } />
+				{ showFollow && <FollowButton siteUrl={ followUrl } /> }
 				<div className="reader-post-card__post">
 					{ featuredAsset }
 					<div className="reader-post-card__post-details">

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -9,15 +9,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader-post-card.card {
 	border-bottom: 1px solid lighten( $gray, 30% );
 	box-shadow: none;
-	margin: 10px;
-	padding: 20px 10px;
+	margin: 0 15px;
+	padding: 20px 0 20px;
 
 	@include breakpoint( ">660px" ) {
-		padding: 20px 0;
-	}
-
-	@media #{$reader-post-card-breakpoint-xlarge}  {
-		margin: 0 15px;
+		margin: 0;
 		padding: 20px 0;
 	}
 
@@ -109,7 +105,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader-post-card__byline {
 	display: flex;
 	font-size: 13px;
-	margin: -4px 0 15px;
 }
 
 .reader-post-card__author::after {
@@ -190,6 +185,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__post {
+	clear: both;
 	display: flex;
 	flex-wrap: wrap;
 	flex-direction: row;
@@ -287,6 +283,38 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		@include breakpoint( "<660px" ) {
 			display: none;
+		}
+	}
+}
+
+// Follow button for stream cards
+.reader-post-card.card .follow-button {
+	border: 0;
+	float: right;
+	padding: 0;
+	position: relative;
+		top: -42px;
+
+	@include breakpoint( "<660px" ) {
+		left: 5px;
+	}
+
+	.gridicon {
+		fill: $blue-medium;
+	}
+
+	.follow-button__label {
+		color: $blue-medium;
+	}
+
+	&.is-following {
+
+		.gridicon {
+			fill: $alert-green;
+		}
+
+		.follow-button__label {
+			color: $alert-green;
 		}
 	}
 }

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -212,6 +212,7 @@ module.exports = {
 					key: 'following',
 					listName: i18n.translate( 'Followed Sites' ),
 					store: followingStore,
+					showPrimaryFollowButtonOnCards: false,
 					trackScrollPage: trackScrollPage.bind(
 						null,
 						basePath,
@@ -339,6 +340,7 @@ module.exports = {
 						analyticsPageTitle,
 						mcKey
 					),
+					showPrimaryFollowButtonOnCards: false,
 					onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
 				} ),
 			),

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -17,7 +17,7 @@ const ANALYTICS_PAGE_TITLE = 'Reader';
 
 export default {
 	discover( context ) {
-		var blogId = config( 'discover_blog_id' ),
+		const blogId = config( 'discover_blog_id' ),
 			SiteStream = require( 'reader/site-stream' ),
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Site > ' + blogId,
@@ -44,6 +44,7 @@ export default {
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				suppressSiteNameLink: true,
+				showPrimaryFollowButtonOnCards: false,
 				showBack: false
 			} ),
 			document.getElementById( 'primary' ),

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -52,6 +52,7 @@ export default {
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				showBack: false,
+				showPrimaryFollowButtonOnCards: false,
 				onQueryChange: function( newValue ) {
 					let searchUrl = '/read/search';
 					if ( newValue ) {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -86,7 +86,7 @@ module.exports = React.createClass( {
 			onShowUpdates: noop,
 			className: '',
 			showDefaultEmptyContentIfMissing: true,
-			showPrimaryFollowButtonOnCards: false,
+			showPrimaryFollowButtonOnCards: true,
 			showMobileBackToSidebar: true
 		};
 	},

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -41,7 +41,8 @@ export class ReaderPostCardAdapter extends React.Component {
 				site={ this.props.site }
 				feed={ this.props.feed }
 				onClick={ this.onClick }
-				onCommentClick={ this.onCommentClick } >
+				onCommentClick={ this.onCommentClick }
+				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 			</ReaderPostCard>


### PR DESCRIPTION
Add a follow button to the top right of the new stream cards in Reader, except on Following, team stream and Discover.

Fixes https://github.com/Automattic/wp-calypso/issues/8526.

![5fcad452-8bd6-11e6-86f0-22b84722b5b7](https://cloud.githubusercontent.com/assets/17325/19581493/e15bcf62-9789-11e6-8f86-7113c5939280.jpg)
### todo
- [x] Add button component
- [x] Hide from Following stream
- [x] Position and style button (@jancavan)
