### PR TITLE
Reader Stream Refresh: only show photo card if post character count is <= 130

### DIFF
--- a/client/lib/post-normalizer/rule-content-word-count.js
+++ b/client/lib/post-normalizer/rule-content-word-count.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import trim from 'lodash/trim';
+import { trim } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -16,6 +16,7 @@ export default function wordCountAndReadingTime( post, dom ) {
 
 	const textContent = trim( dom.textContent );
 
+	post.character_count = textContent.length;
 	post.word_count = ( textContent.replace( /['";:,.?¿\-!¡]+/g, '' ).match( /\S+/g ) || [] ).length;
 
 	if ( post.word_count > 0 ) {

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -70,7 +70,7 @@ function classifyPost( post ) {
 	if ( post.images &&
 			post.images.length >= 1 &&
 			canonicalImage && canonicalImage.width >= PHOTO_ONLY_MIN_WIDTH &&
-			post.word_count < 100 ) {
+			post.character_count <= 130 ) {
 		displayType ^= DISPLAY_TYPES.PHOTO_ONLY;
 	}
 

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -10,6 +10,7 @@ import matches from 'lodash/matches';
 /**
  * Internal Dependencies
  */
+import config from 'config';
 import resizeImageUrl from 'lib/resize-image-url';
 import DISPLAY_TYPES from './display-types';
 
@@ -57,6 +58,10 @@ function discoverFullBleedImages( post, dom ) {
 	return post;
 }
 
+const hasShortContent = config.isEnabled( 'reader/refresh/stream' )
+	? post => post.character_count <= 130
+	: post => post.word_count < 100;
+
 /**
  * Attempt to classify the post into a display type
  * @param  {object}   post     A post to classify
@@ -70,7 +75,7 @@ function classifyPost( post ) {
 	if ( post.images &&
 			post.images.length >= 1 &&
 			canonicalImage && canonicalImage.width >= PHOTO_ONLY_MIN_WIDTH &&
-			post.character_count <= 130 ) {
+			hasShortContent( post ) ) {
 		displayType ^= DISPLAY_TYPES.PHOTO_ONLY;
 	}
 


### PR DESCRIPTION
The post classifier currently looks for posts with a word count under 100 to assign as photo-only.

As @fraying raised in https://github.com/Automattic/wp-calypso/issues/8894, we have decided to reduce this limit to 130 characters for the Stream Refresh.

This PR updates the classifier accordingly.

Fixes https://github.com/Automattic/wp-calypso/issues/8894.

