### PR TITLE
IE11 fix for Search overlay scrolling issues.

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -167,9 +167,26 @@ const Search = React.createClass( {
 	scrollOverlay: function() {
 		this.refs.overlay && window.requestAnimationFrame( () => {
 			if ( this.refs.overlay && this.refs.searchInput ) {
-				this.refs.overlay.scrollLeft = this.refs.searchInput.scrollLeft;
+				this.refs.overlay.scrollLeft = this.getScrollLeft( this.refs.searchInput );
 			}
 		} );
+	},
+
+	//This is fix for IE11. Does not work on Edge.
+	//On IE11 scrollLeft value for input is always 0.
+	//We are calculating it manually using TextRange object.
+	getScrollLeft: function( inputElement ) {
+		//TextRange is IE11 specific so this checks if we are not on IE11.
+		if ( ! inputElement.createTextRange ) {
+			return inputElement.scrollLeft;
+		}
+
+		const range = inputElement.createTextRange();
+		const inputStyle = window.getComputedStyle( inputElement, undefined );
+		const paddingLeft = parseFloat( inputStyle.paddingLeft );
+		const rangeRect = range.getBoundingClientRect();
+		const scrollLeft = inputElement.getBoundingClientRect().left + inputElement.clientLeft + paddingLeft - rangeRect.left;
+		return scrollLeft;
 	},
 
 	focus: function() {


### PR DESCRIPTION
IE11 has bug that makes value of `scrollLeft` for `input` always equal to `0`
This PR is a fix for that situation. It uses `TextRange` object created for `input`.
This object holds information on bounding rectangle of text that is in `TextRange` range.
When created for `input` the range covers whole text inside input. Using information from text
bounding rectangle and comparing it to `input` bounding rectangle we can calculate how much
the text is scrolled inside `input`

Test:
1. open /designusing IE11 in wpcalypso - it has Suggestions with tokens styling
2. start typing in ThemesSearch input adding tokens and text to the point where text overflows
3. open /desing on this branch 
4. start typing , add tokens, type as text overflows - tokens scroll with text.
