### PR TITLE
Checkout: move email notice on top of thank you page

### DIFF
--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -5,26 +5,26 @@
 	background-color: darken( $alert-green, 10 );
 	border-radius: 8px 8px 6px 6px;
 	overflow: hidden;
-	margin: 0 auto 24px;
+	margin: 12px auto 24px;
 	color: $white;
 	font-family: $sans;
 	text-align: center;
 
 	@include breakpoint( ">480px" ) {
-		margin-top: 56px;
+		margin-top: 28px;
 	}
 }
 
 .plan-thank-you-card__header {
 	background-color: $alert-green;
-	padding: 24px 0;
+	padding: 12px 0;
 	position: relative;
 	line-height: 1.2;
 	border-radius: 6px 6px 0 0;
 	overflow: hidden;
 
 	@include breakpoint( ">480px" ) {
-		padding: 75px 0 30px;
+		padding: 37px 0 15px;
 	}
 }
 

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -24,7 +24,7 @@
 	overflow: hidden;
 
 	@include breakpoint( ">480px" ) {
-		padding: 37px 0 15px;
+		padding: 32px 0 15px;
 	}
 }
 
@@ -68,8 +68,9 @@
 	font-size: 14px;
 	height: 40px;
 	line-height: 40px;
+	max-width: 280px;
 	padding: 0;
-	width: 280px;
+	width: 100%;
 	margin: 0 auto;
 	border-style: solid;
 	border-color: darken( $alert-green, 20 );
@@ -222,11 +223,11 @@
 }
 
 .plan-thank-you-card__main-icon {
-	width: 100px;
-	height: 100px;
+	width: 72px;
+	height: 72px;
 
 	@include breakpoint( ">480px" ) {
-		width: 140px;
-		height: 140px;
+		width: 96px;
+		height: 96px;
 	}
 }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -79,6 +79,15 @@ module.exports = {
 		defaultVariation: 'showPopover',
 		allowExistingUsers: false,
 	},
+	paidNuxThankYouPage: {
+		datestamp: '20161021',
+		variations: {
+			original: 50,
+			emailNudgeOnTop: 50,
+		},
+		defaultVariation: 'original',
+		allowAnyLocale: true,
+	},
 	siteTitleStep: {
 		datestamp: '20160928',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -80,7 +80,7 @@ module.exports = {
 		allowExistingUsers: false,
 	},
 	paidNuxThankYouPage: {
-		datestamp: '20161021',
+		datestamp: '20161114',
 		variations: {
 			original: 50,
 			emailNudgeOnTop: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -86,7 +86,6 @@ module.exports = {
 			emailNudgeOnTop: 50,
 		},
 		defaultVariation: 'original',
-		allowAnyLocale: true,
 	},
 	siteTitleStep: {
 		datestamp: '20160928',

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -116,7 +116,11 @@ const CheckoutThankYou = React.createClass( {
 		}
 
 		return (
-			<Notice className="checkout-thank-you__verification-notice" showDismiss={ false }>
+			<Notice
+				className="checkout-thank-you__verification-notice"
+				showDismiss={ false }
+				status="is-warning"
+				>
 				{ this.translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. ' +
 					'Please check your email to confirm your address.', {
 						args: { email: this.props.user.email },
@@ -195,8 +199,8 @@ const CheckoutThankYou = React.createClass( {
 		if ( isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
 				<Main className="checkout-thank-you">
-					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />
 					{ this.renderConfirmationNotice() }
+					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);
 		}

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -202,7 +202,7 @@ const CheckoutThankYou = React.createClass( {
 		// streamlined paid NUX thanks page
 		if ( isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
-				<Main className="checkout-thank-you{ emailNudgeOnTop ? ' checkout-thank-you__email-nudge-top-test' }">
+				<Main className="checkout-thank-you">
 					{ emailNudgeOnTop ? this.renderConfirmationNotice() : null }
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />
 					{ ! emailNudgeOnTop ? this.renderConfirmationNotice() : null }

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -116,11 +116,13 @@ const CheckoutThankYou = React.createClass( {
 			return null;
 		}
 
+		const emailNudgeOnTop = abtest( 'paidNuxThankYouPage' ) === 'emailNudgeOnTop';
+
 		return (
 			<Notice
 				className="checkout-thank-you__verification-notice"
 				showDismiss={ false }
-				status="is-warning"
+				status={ emailNudgeOnTop ? 'is-warning' : '' }
 				>
 				{ this.translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. ' +
 					'Please check your email to confirm your address.', {
@@ -185,6 +187,7 @@ const CheckoutThankYou = React.createClass( {
 
 		const userCreatedMoment = moment( this.props.userDate );
 		const isNewUser = userCreatedMoment.isAfter( moment().subtract( 2, 'hours' ) );
+		const emailNudgeOnTop = abtest( 'paidNuxThankYouPage' ) === 'emailNudgeOnTop';
 
 		// this placeholder is using just wp logo here because two possible states do not share a common layout
 		if ( ! purchases && ! this.isGenericReceipt() ) {
@@ -199,9 +202,10 @@ const CheckoutThankYou = React.createClass( {
 		// streamlined paid NUX thanks page
 		if ( isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
-				<Main className="checkout-thank-you">
-					{ this.renderConfirmationNotice() }
+				<Main className="checkout-thank-you{ emailNudgeOnTop ? ' checkout-thank-you__email-nudge-top-test' }">
+					{ emailNudgeOnTop ? this.renderConfirmationNotice() : null }
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />
+					{ ! emailNudgeOnTop ? this.renderConfirmationNotice() : null }
 				</Main>
 			);
 		}

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -54,6 +54,8 @@ import { getFeatureByKey, shouldFetchSitePlans } from 'lib/plans';
 import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
 import upgradesPaths from 'my-sites/upgrades/paths';
+import { abtest } from 'lib/abtest';
+import { localize } from 'i18n-calypso';
 
 function getPurchases( props ) {
 	return props.receipt.data.purchases;
@@ -108,26 +110,6 @@ const CheckoutThankYou = React.createClass( {
 
 	hasPlanOrDomainProduct( props = this.props ) {
 		return getPurchases( props ).some( purchase => isPlan( purchase ) || isDomainProduct( purchase ) );
-	},
-
-	renderConfirmationNotice: function() {
-		if ( ! this.props.user || ! this.props.user.email || this.props.email_verified ) {
-			return null;
-		}
-
-		return (
-			<Notice
-				className="checkout-thank-you__verification-notice"
-				showDismiss={ false }
-				status="is-warning"
-				>
-				{ this.translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. ' +
-					'Please check your email to confirm your address.', {
-						args: { email: this.props.user.email },
-						components: { strong: <strong className="checkout-thank-you__verification-notice-email" />
-				} } ) }
-			</Notice>
-		);
 	},
 
 	isDataLoaded() {
@@ -199,7 +181,9 @@ const CheckoutThankYou = React.createClass( {
 		if ( isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
 				<Main className="checkout-thank-you">
-					{ this.renderConfirmationNotice() }
+					{ this.props.user && this.props.user.email && this.props.email_verified &&
+						<ConfirmationNotice email={ this.props.user.email } />
+					}
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);
@@ -317,6 +301,20 @@ const CheckoutThankYou = React.createClass( {
 		);
 	}
 } );
+
+const ConfirmationNotice = localize( ( { email, translate } ) => (
+	<Notice
+		className="checkout-thank-you__verification-notice"
+		showDismiss={ false }
+		status="is-warning"
+		>
+		{ translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. ' +
+			'Please check your email to confirm your address.', {
+				args: { email },
+				components: { strong: <strong className="checkout-thank-you__verification-notice-email" />
+		} } ) }
+	</Notice>
+) );
 
 export default connect(
 	( state, props ) => {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -55,7 +55,6 @@ import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
 import upgradesPaths from 'my-sites/upgrades/paths';
 import { abtest } from 'lib/abtest';
-import { localize } from 'i18n-calypso';
 
 function getPurchases( props ) {
 	return props.receipt.data.purchases;
@@ -110,6 +109,26 @@ const CheckoutThankYou = React.createClass( {
 
 	hasPlanOrDomainProduct( props = this.props ) {
 		return getPurchases( props ).some( purchase => isPlan( purchase ) || isDomainProduct( purchase ) );
+	},
+
+	renderConfirmationNotice: function() {
+		if ( ! this.props.user || ! this.props.user.email || this.props.email_verified ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				className="checkout-thank-you__verification-notice"
+				showDismiss={ false }
+				status="is-warning"
+				>
+				{ this.translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. ' +
+					'Please check your email to confirm your address.', {
+						args: { email: this.props.user.email },
+						components: { strong: <strong className="checkout-thank-you__verification-notice-email" />
+				} } ) }
+			</Notice>
+		);
 	},
 
 	isDataLoaded() {
@@ -181,9 +200,7 @@ const CheckoutThankYou = React.createClass( {
 		if ( isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
 				<Main className="checkout-thank-you">
-					{ this.props.user && this.props.user.email && this.props.email_verified &&
-						<ConfirmationNotice email={ this.props.user.email } />
-					}
+					{ this.renderConfirmationNotice() }
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);
@@ -301,20 +318,6 @@ const CheckoutThankYou = React.createClass( {
 		);
 	}
 } );
-
-const ConfirmationNotice = localize( ( { email, translate } ) => (
-	<Notice
-		className="checkout-thank-you__verification-notice"
-		showDismiss={ false }
-		status="is-warning"
-		>
-		{ translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. ' +
-			'Please check your email to confirm your address.', {
-				args: { email },
-				components: { strong: <strong className="checkout-thank-you__verification-notice-email" />
-		} } ) }
-	</Notice>
-) );
 
 export default connect(
 	( state, props ) => {


### PR DESCRIPTION
This adds an A/B test that tries placing the email verification notice on the thank you page on top of the page and in a "warning" notice.

TODO:
- [x] make this an A/B test, not simply a change
- [x] figure out whether to test the CSS as well (no: the changes are small and make sense either way)

To test:

- sign up as a new user; during signup put a plan in your cart and pay for it
- before checkout, make sure you're in the `original` variation for the `paidNuxThankYouPage` A/B test (e.g. using the bottom-right A/B testing menu)
- pay for the plan
- make sure the thank-you page looks good and similar to the screenshots here
- make sure the "please verify your email" nudge appears **BELOW** the green thank-you card
- repeat the process (new user who buys a plan) with the `emailNudgeOnTop` variation of the `paidNuxThankYouPage` A/B test
- make sure the thank-you page looks good and similar to the screenshots here
- make sure the "please verify your email" nudge appears **ABOVE** the green thank-you card

Screenshots of the original layout: 

![desktop-old](https://cloud.githubusercontent.com/assets/23619/19598272/48207dfa-979a-11e6-9ed1-b56cdc547a24.png)

![tablet-old](https://cloud.githubusercontent.com/assets/23619/19598273/49ede5e6-979a-11e6-8389-979ba31ebb89.png)

![phone-old](https://cloud.githubusercontent.com/assets/23619/19598279/4edade4c-979a-11e6-9ac4-0087e2e74db7.png)

Screenshots of the updated layout: 

![desktop](https://cloud.githubusercontent.com/assets/23619/19598219/f0bed35e-9799-11e6-874e-cc808073ab18.png)

![tablet](https://cloud.githubusercontent.com/assets/23619/19598222/f3f8fe82-9799-11e6-897e-e6c651bc41ff.png)

![phone](https://cloud.githubusercontent.com/assets/23619/19598229/f6e9511e-9799-11e6-9674-4952a3d9ad94.png)
