### PR TITLE
Sites-List: Remove from DomainManagement.EmailData

### DIFF
--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -11,6 +11,7 @@ import StoreConnection from 'components/data/store-connection';
 import DomainsStore from 'lib/domains/store';
 import CartStore from 'lib/cart/store';
 import QueryProducts from 'components/data/query-products-list';
+import QuerySites from 'components/data/query-sites';
 import { fetchDomains } from 'lib/upgrades/actions';
 import userFactory from 'lib/user';
 import {
@@ -25,6 +26,7 @@ import {
 import { shouldFetchSitePlans } from 'lib/plans';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 
 const user = userFactory();
 
@@ -56,36 +58,38 @@ const EmailData = React.createClass( {
 		context: React.PropTypes.object.isRequired,
 		productsList: React.PropTypes.object.isRequired,
 		selectedDomainName: React.PropTypes.string,
+		selectedSite: React.PropTypes.object.isRequired,
 		sitePlans: React.PropTypes.object.isRequired,
-		sites: React.PropTypes.object.isRequired,
 		googleAppsUsers: React.PropTypes.array.isRequired,
 		googleAppsUsersLoaded: React.PropTypes.bool.isRequired
 	},
 
 	componentWillMount() {
-		this.loadDomainsAndSitePlans();
-		this.props.fetchGoogleAppsUsers();
+		const { selectedSite } = this.props;
+
+		this.loadDomainsAndSitePlans( selectedSite );
+		this.props.fetchGoogleAppsUsers( selectedSite.ID );
 	},
 
-	componentWillUpdate() {
-		this.loadDomainsAndSitePlans();
-	},
+	componentWillUpdate( nextProps ) {
+		const { selectedSite: nextSite } = nextProps;
+		const { selectedSite: prevSite } = this.props;
 
-	loadDomainsAndSitePlans() {
-		const selectedSite = this.props.sites.getSelectedSite();
-
-		if ( this.prevSelectedSite !== selectedSite ) {
-			fetchDomains( selectedSite.ID );
-			this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
-
-			this.prevSelectedSite = selectedSite;
+		if ( nextSite !== prevSite ) {
+			this.loadDomainsAndSitePlans( nextSite );
 		}
+	},
+
+	loadDomainsAndSitePlans( site ) {
+		fetchDomains( site.ID );
+		this.props.fetchSitePlans( this.props.sitePlans, site );
 	},
 
 	render() {
 		return (
 			<div>
 				<QueryProducts />
+				<QuerySites />
 				<StoreConnection
 					domains={ this.props.domains }
 					googleAppsUsers={ this.props.googleAppsUsers }
@@ -95,7 +99,7 @@ const EmailData = React.createClass( {
 					getStateFromStores={ getStateFromStores }
 					products={ this.props.products }
 					selectedDomainName={ this.props.selectedDomainName }
-					selectedSite={ this.props.sites.getSelectedSite() }
+					selectedSite={ this.props.selectedSite }
 					sitePlans={ this.props.sitePlans }
 					context={ this.props.context } />
 			</div>
@@ -104,25 +108,27 @@ const EmailData = React.createClass( {
 } );
 
 export default connect(
-	( state, { selectedDomainName, sites } ) => {
+	( state, { selectedDomainName } ) => {
+		const selectedSite = getSelectedSite( state );
 		const googleAppsUsers = selectedDomainName
 			? getByDomain( state, selectedDomainName )
-			: getBySite( state, sites.getSelectedSite().ID );
+			: getBySite( state, selectedSite.ID );
 
 		return {
 			googleAppsUsers,
 			googleAppsUsersLoaded: isLoaded( state ),
 			products: state.productsList.items,
-			sitePlans: getPlansBySite( state, sites.getSelectedSite() )
+			sitePlans: getPlansBySite( state, selectedSite ),
+			selectedSite,
 		};
 	},
-	( dispatch, { selectedDomainName, sites } ) => {
+	( dispatch, { selectedDomainName } ) => {
 		const googleAppsUsersFetcher = selectedDomainName
 			? () => fetchByDomain( selectedDomainName )
-			: () => fetchBySiteId( sites.getSelectedSite().ID );
+			: siteId => fetchBySiteId( siteId );
 
 		return {
-			fetchGoogleAppsUsers: () => dispatch( googleAppsUsersFetcher() ),
+			fetchGoogleAppsUsers: siteId => dispatch( googleAppsUsersFetcher( siteId ) ),
 			fetchSitePlans: ( sitePlans, site ) => {
 				if ( shouldFetchSitePlans( sitePlans, site ) ) {
 					dispatch( fetchSitePlans( site.ID ) );

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -165,7 +165,7 @@ module.exports = {
 				productsList={ productsList }
 				selectedDomainName={ pageContext.params.domain }
 				context={ pageContext }
-				sites={ sites } />,
+			/>,
 			document.getElementById( 'primary' ),
 			pageContext.store
 		);


### PR DESCRIPTION
Follows #8869 in refactoring the `<EmailData />` component to not rely
on `sites-list`. This PR actually removes the dependency.

> There should be no functional or visual changes in this PR

**Testing**

Please navigate to the **G Suite** tab in **Domains** and switch sites
around. Bonus points if you can switch to a site with _G Suite_ enabled.

cc: @gwwar