### PR TITLE
Refactor `manage-contact`, `recovery-phone` and `recovery-email` components as ES6 class

### DIFF
--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -39,7 +39,7 @@ const SecurityCheckup = React.createClass( {
 
 				<CompactCard className="security-checkup-intro">
 					<p className="security-checkup-intro__text">
-						{ this.translate( 'Keep your account safe by adding a backup email address and phone number.' +
+						{ this.props.translate( 'Keep your account safe by adding a backup email address and phone number.' +
 								'If you ever have problems accessing your account, WordPress.com will use what ' +
 								'you enter here to verify your identity.' ) }
 					</p>

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import Main from 'components/main';
 import CompactCard from 'components/card/compact';
-import QueryPreferences from 'components/data/query-preferences';
 import SecuritySectionNav from 'me/security-section-nav';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
@@ -30,7 +29,6 @@ const SecurityCheckup = React.createClass( {
 	render: function() {
 		return (
 			<Main className="security-checkup">
-				<QueryPreferences />
 				<MeSidebarNavigation />
 
 				<SecuritySectionNav path={ this.props.path } />

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import observe from 'lib/mixins/data-observe';
+import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -11,20 +11,19 @@ import { translate } from 'i18n-calypso';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import Main from 'components/main';
 import CompactCard from 'components/card/compact';
+import QueryPreferences from 'components/data/query-preferences';
 import SecuritySectionNav from 'me/security-section-nav';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import RecoveryEmail from './recovery-email';
 import RecoveryPhone from './recovery-phone';
+import { getPreference } from 'state/preferences/selectors';
 
 class SecurityCheckup extends Component {
-	componentDidMount() {
-		this.props.userSettings.getSettings();
-	}
-
 	render() {
 		return (
 			<Main className="security-checkup">
+				<QueryPreferences />
 				<MeSidebarNavigation />
 
 				<SecuritySectionNav path={ this.props.path } />
@@ -33,7 +32,9 @@ class SecurityCheckup extends Component {
 
 				<CompactCard className="security-checkup-intro">
 					<p className="security-checkup-intro__text">
-						{ translate( 'Keep your account safe by adding a backup email address and phone number. If you ever have problems accessing your account, WordPress.com will use what you enter here to verify your identity.' ) }
+						{ translate( 'Keep your account safe by adding a backup email address and phone number.' +
+								'If you ever have problems accessing your account, WordPress.com will use what ' +
+								'you enter here to verify your identity.' ) }
 					</p>
 				</CompactCard>
 
@@ -50,8 +51,10 @@ class SecurityCheckup extends Component {
 	}
 }
 
-SecurityCheckup.displayName = 'SecurityCheckup';
+const mapStateToProps = ( state ) => {
+	return {
+		userSettings: getPreference( state ),
+	};
+};
 
-SecurityCheckup.mixins = [ observe( 'userSettings' ) ];
-
-export default SecurityCheckup;
+export default connect( mapStateToProps )( SecurityCheckup );

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -15,12 +14,20 @@ import QueryPreferences from 'components/data/query-preferences';
 import SecuritySectionNav from 'me/security-section-nav';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
+import observe from 'lib/mixins/data-observe';
 import RecoveryEmail from './recovery-email';
 import RecoveryPhone from './recovery-phone';
-import { getPreference } from 'state/preferences/selectors';
 
-class SecurityCheckup extends Component {
-	render() {
+module.exports = React.createClass( {
+	displayName: 'SecurityCheckup',
+
+	mixins: [ observe( 'userSettings' ) ],
+
+	componentDidMount: function() {
+		this.props.userSettings.getSettings();
+	},
+
+	render: function() {
 		return (
 			<Main className="security-checkup">
 				<QueryPreferences />
@@ -48,13 +55,5 @@ class SecurityCheckup extends Component {
 
 			</Main>
 		);
-	}
-}
-
-const mapStateToProps = ( state ) => {
-	return {
-		userSettings: getPreference( state ),
-	};
-};
-
-export default connect( mapStateToProps )( SecurityCheckup );
+	},
+} );

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import observe from 'lib/mixins/data-observe';
 import RecoveryEmail from './recovery-email';
 import RecoveryPhone from './recovery-phone';
 
-module.exports = React.createClass( {
+const SecurityCheckup = React.createClass( {
 	displayName: 'SecurityCheckup',
 
 	mixins: [ observe( 'userSettings' ) ],
@@ -39,7 +39,7 @@ module.exports = React.createClass( {
 
 				<CompactCard className="security-checkup-intro">
 					<p className="security-checkup-intro__text">
-						{ translate( 'Keep your account safe by adding a backup email address and phone number.' +
+						{ this.translate( 'Keep your account safe by adding a backup email address and phone number.' +
 								'If you ever have problems accessing your account, WordPress.com will use what ' +
 								'you enter here to verify your identity.' ) }
 					</p>
@@ -57,3 +57,5 @@ module.exports = React.createClass( {
 		);
 	},
 } );
+
+export default localize( SecurityCheckup );

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -1,31 +1,28 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	observe = require( 'lib/mixins/data-observe' );
+import React, { Component } from 'react';
+import observe from 'lib/mixins/data-observe';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var MeSidebarNavigation = require( 'me/sidebar-navigation' ),
-	Main = require( 'components/main' ),
-	CompactCard = require( 'components/card/compact' ),
-	SecuritySectionNav = require( 'me/security-section-nav' ),
-	ReauthRequired = require( 'me/reauth-required' ),
-	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	RecoveryEmail = require( './recovery-email' ),
-	RecoveryPhone = require( './recovery-phone' );
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import Main from 'components/main';
+import CompactCard from 'components/card/compact';
+import SecuritySectionNav from 'me/security-section-nav';
+import ReauthRequired from 'me/reauth-required';
+import twoStepAuthorization from 'lib/two-step-authorization';
+import RecoveryEmail from './recovery-email';
+import RecoveryPhone from './recovery-phone';
 
-module.exports = React.createClass( {
-	displayName: 'SecurityCheckup',
-
-	mixins: [ observe( 'userSettings' ) ],
-
-	componentDidMount: function() {
+class SecurityCheckup extends Component {
+	componentDidMount() {
 		this.props.userSettings.getSettings();
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<Main className="security-checkup">
 				<MeSidebarNavigation />
@@ -36,7 +33,7 @@ module.exports = React.createClass( {
 
 				<CompactCard className="security-checkup-intro">
 					<p className="security-checkup-intro__text">
-						{ this.translate( 'Keep your account safe by adding a backup email address and phone number. If you ever have problems accessing your account, WordPress.com will use what you enter here to verify your identity.' ) }
+						{ translate( 'Keep your account safe by adding a backup email address and phone number. If you ever have problems accessing your account, WordPress.com will use what you enter here to verify your identity.' ) }
 					</p>
 				</CompactCard>
 
@@ -51,4 +48,10 @@ module.exports = React.createClass( {
 			</Main>
 		);
 	}
-} );
+}
+
+SecurityCheckup.displayName = 'SecurityCheckup';
+
+SecurityCheckup.mixins = [ observe( 'userSettings' ) ];
+
+export default SecurityCheckup;

--- a/client/me/security-checkup/manage-contact.jsx
+++ b/client/me/security-checkup/manage-contact.jsx
@@ -79,19 +79,14 @@ class ManageContact extends Component {
 	}
 
 	renderNotice() {
-		const lastNotice = this.props.lastNotice;
-
-		let notice = null,
-			showDismiss,
-			onClick,
-			isError;
+		const { lastNotice } = this.props;
 
 		if ( lastNotice && lastNotice.message ) {
-			isError = lastNotice.type === 'error';
-			showDismiss = lastNotice.showDismiss !== false;
-			onClick = showDismiss ? this.dismissNotice : null;
+			const isError = lastNotice.type === 'error';
+			const showDismiss = lastNotice.showDismiss !== false;
+			const onClick = showDismiss ? this.dismissNotice : null;
 
-			notice = (
+			return (
 				<Notice
 					status={ isError ? 'is-error' : 'is-success' }
 					onDismissClick={ onClick }
@@ -101,7 +96,8 @@ class ManageContact extends Component {
 				</Notice>
 			);
 		}
-		return notice;
+
+		return null;
 	}
 
 	renderLoading() {
@@ -166,8 +162,6 @@ class ManageContact extends Component {
 		analytics.tracks.recordEvent( event );
 	}
 }
-
-ManageContact.displayName = 'SecurityCheckupRecoveryContact';
 
 ManageContact.propTypes = {
 	type: React.PropTypes.string,

--- a/client/me/security-checkup/manage-contact.jsx
+++ b/client/me/security-checkup/manage-contact.jsx
@@ -1,38 +1,33 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	keyMirror = require( 'key-mirror' ),
-	assign = require( 'lodash/assign' );
+import React, { Component } from 'react';
+import keyMirror from 'key-mirror';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var FormButton = require( 'components/forms/form-button' ),
-	Notice = require( 'components/notice' ),
-	analytics = require( 'lib/analytics' );
+import FormButton from 'components/forms/form-button';
+import Notice from 'components/notice';
+import analytics from 'lib/analytics';
 
-var views = keyMirror( {
+const views = keyMirror( {
 	VIEWING: null,
 	EDITING: null
 } );
 
-module.exports = React.createClass( {
-	displayName: 'SecurityCheckupRecoveryContact',
+class ManageContact extends Component {
+	constructor( props ) {
+		super( props );
 
-	propTypes: {
-		type: React.PropTypes.string,
-		disabled: React.PropTypes.bool
-	},
-
-	getInitialState: function() {
-		return assign( {
+		this.state = {
 			currentView: views.VIEWING
-		} );
-	},
+		};
+	}
 
-	renderHeader: function() {
-		var isEditing = views.EDITING === this.state.currentView;
+	renderHeader() {
+		const isEditing = views.EDITING === this.state.currentView;
 
 		return (
 			<div className="security-checkup-contact__header">
@@ -54,17 +49,17 @@ module.exports = React.createClass( {
 								disabled={ this.props.disabled }
 								isPrimary={ false }
 								onClick={ this.onEdit }>
-								{ this.props.hasValue ? this.translate( 'Edit' ) : this.translate( 'Add' ) }
+								{ this.props.hasValue ? translate( 'Edit' ) : translate( 'Add' ) }
 							</FormButton>
 						</div>
 					)
 				}
 			</div>
 		);
-	},
+	}
 
-	renderEdit: function() {
-		var view = null;
+	renderEdit() {
+		let view = null;
 
 		if ( views.EDITING === this.state.currentView ) {
 			view = (
@@ -81,11 +76,12 @@ module.exports = React.createClass( {
 		}
 
 		return view;
-	},
+	}
 
-	renderNotice: function() {
-		var notice = null,
-			lastNotice = this.props.lastNotice,
+	renderNotice() {
+		const lastNotice = this.props.lastNotice;
+
+		let notice = null,
 			showDismiss,
 			onClick,
 			isError;
@@ -106,18 +102,18 @@ module.exports = React.createClass( {
 			);
 		}
 		return notice;
-	},
+	}
 
-	renderLoading: function() {
+	renderLoading() {
 		return (
 			<div>
 				<p className="security-checkup-contact__placeholder-heading"> &nbsp; </p>
 				<p className="security-checkup-contact__placeholder-text"> &nbsp; </p>
 			</div>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		if ( this.props.isLoading ) {
 			return this.renderLoading();
 		}
@@ -129,44 +125,53 @@ module.exports = React.createClass( {
 				{ this.renderNotice() }
 			</div>
 		);
-	},
+	}
 
-	onEdit: function() {
+	onEdit = () => {
 		this.dismissNotice();
 		this.setState( { currentView: views.EDITING }, function() {
 			this.recordEvent( this.props.hasValue ? 'edit' : 'add' );
 		} );
-	},
+	}
 
-	onCancel: function() {
+	onCancel = () => {
 		this.dismissNotice();
 		this.setState( { currentView: views.VIEWING }, function() {
 			this.recordEvent( 'cancel' );
 		} );
-	},
+	}
 
-	onSave: function( data ) {
+	onSave = ( data ) => {
 		this.dismissNotice();
 		this.setState( { currentView: views.VIEWING }, function() {
 			this.props.onSave( data );
 			this.recordEvent( 'save' );
 		} );
-	},
+	}
 
-	onDelete: function() {
+	onDelete = () => {
 		this.dismissNotice();
 		this.setState( { currentView: views.VIEWING }, function() {
 			this.props.onDelete();
 			this.recordEvent( 'delete' );
 		} );
-	},
+	}
 
-	dismissNotice: function() {
+	dismissNotice = () => {
 		this.props.onDismissNotice();
-	},
+	}
 
-	recordEvent: function( action ) {
-		let event = `calypso_security_checkup_${ this.props.type }_${ action }_click`;
+	recordEvent( action ) {
+		const event = `calypso_security_checkup_${ this.props.type }_${ action }_click`;
 		analytics.tracks.recordEvent( event );
 	}
-} );
+}
+
+ManageContact.displayName = 'SecurityCheckupRecoveryContact';
+
+ManageContact.propTypes = {
+	type: React.PropTypes.string,
+	disabled: React.PropTypes.bool
+};
+
+export default ManageContact;

--- a/client/me/security-checkup/manage-contact.jsx
+++ b/client/me/security-checkup/manage-contact.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import keyMirror from 'key-mirror';
-import { translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -28,6 +28,7 @@ class ManageContact extends Component {
 
 	renderHeader() {
 		const isEditing = views.EDITING === this.state.currentView;
+		const { translate } = this.props;
 
 		return (
 			<div className="security-checkup-contact__header">
@@ -168,4 +169,4 @@ ManageContact.propTypes = {
 	disabled: React.PropTypes.bool
 };
 
-export default ManageContact;
+export default localize( ManageContact );

--- a/client/me/security-checkup/recovery-email.jsx
+++ b/client/me/security-checkup/recovery-email.jsx
@@ -37,8 +37,8 @@ class RecoveryEmail extends Component {
 	}
 
 	render() {
-		const email = this.state.data ? this.state.data.email : false,
-			primaryEmail = this.props.userSettings.getSetting( 'user_email' );
+		const email = this.state.data ? this.state.data.email : false;
+		const primaryEmail = this.props.userSettings.getSetting( 'user_email' );
 
 		return (
 			<ManageContact
@@ -61,10 +61,6 @@ class RecoveryEmail extends Component {
 		);
 	}
 
-	haveEmail() {
-		return !! this.state.data.email;
-	}
-
 	onSave = ( email ) => {
 		SecurityCheckupActions.updateEmail( email, this.state.data.email );
 	}
@@ -81,7 +77,5 @@ class RecoveryEmail extends Component {
 		SecurityCheckupActions.dismissEmailNotice();
 	}
 }
-
-RecoveryEmail.displayName = 'SecurityCheckupRecoveryEmail';
 
 export default RecoveryEmail;

--- a/client/me/security-checkup/recovery-email.jsx
+++ b/client/me/security-checkup/recovery-email.jsx
@@ -1,51 +1,51 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	assign = require( 'lodash/assign' );
+import React, { Component } from 'react';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var AccountRecoveryStore = require( 'lib/security-checkup/account-recovery-store' ),
-	SecurityCheckupActions = require( 'lib/security-checkup/actions' ),
-	ManageContact = require( './manage-contact' ),
-	EditEmail = require( './edit-email' ),
-	accept = require( 'lib/accept' );
+import AccountRecoveryStore from 'lib/security-checkup/account-recovery-store';
+import SecurityCheckupActions from 'lib/security-checkup/actions';
+import ManageContact from './manage-contact';
+import EditEmail from './edit-email';
+import accept from 'lib/accept';
 
-module.exports = React.createClass( {
-	displayName: 'SecurityCheckupRecoveryEmail',
+class RecoveryEmail extends Component {
+	constructor( props ) {
+		super( props );
 
-	componentDidMount: function() {
+		this.state = this.getDataFromStores();
+	}
+
+	componentDidMount() {
 		AccountRecoveryStore.on( 'change', this.refreshData );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		AccountRecoveryStore.off( 'change', this.refreshData );
-	},
+	}
 
-	getInitialState: function() {
-		return assign( {}, this.getDataFromStores() );
-	},
-
-	refreshData: function() {
+	refreshData = () => {
 		this.setState( this.getDataFromStores() );
-	},
+	}
 
-	getDataFromStores: function() {
+	getDataFromStores() {
 		return AccountRecoveryStore.getEmail();
-	},
+	}
 
-	render: function() {
-		var email = this.state.data ? this.state.data.email : false,
+	render() {
+		const email = this.state.data ? this.state.data.email : false,
 			primaryEmail = this.props.userSettings.getSetting( 'user_email' );
 
 		return (
 			<ManageContact
 				type="email"
 				isLoading={ this.state.loading }
-				title={ this.translate( 'Recovery Email Address' ) }
-				subtitle={ email ? email : this.translate( 'Not set' ) }
+				title={ translate( 'Recovery Email Address' ) }
+				subtitle={ email ? email : translate( 'Not set' ) }
 				hasValue={ !! email }
 				lastNotice={ this.state.lastNotice }
 
@@ -59,25 +59,29 @@ module.exports = React.createClass( {
 						/>
 				</ManageContact>
 		);
-	},
+	}
 
-	haveEmail: function() {
+	haveEmail() {
 		return !! this.state.data.email;
-	},
+	}
 
-	onSave: function( email ) {
+	onSave = ( email ) => {
 		SecurityCheckupActions.updateEmail( email, this.state.data.email );
-	},
+	}
 
-	onDelete: function() {
-		accept( this.translate( 'Are you sure you want to remove the email address?' ), function( accepted ) {
+	onDelete = () => {
+		accept( translate( 'Are you sure you want to remove the email address?' ), function( accepted ) {
 			if ( accepted ) {
 				SecurityCheckupActions.deleteEmail();
 			}
 		} );
-	},
+	}
 
-	onDismissNotice: function() {
+	onDismissNotice = () => {
 		SecurityCheckupActions.dismissEmailNotice();
 	}
-} );
+}
+
+RecoveryEmail.displayName = 'SecurityCheckupRecoveryEmail';
+
+export default RecoveryEmail;

--- a/client/me/security-checkup/recovery-email.jsx
+++ b/client/me/security-checkup/recovery-email.jsx
@@ -67,7 +67,7 @@ class RecoveryEmail extends Component {
 	}
 
 	onDelete = () => {
-		accept( this.translate( 'Are you sure you want to remove the email address?' ), function( accepted ) {
+		accept( this.props.translate( 'Are you sure you want to remove the email address?' ), function( accepted ) {
 			if ( accepted ) {
 				SecurityCheckupActions.deleteEmail();
 			}

--- a/client/me/security-checkup/recovery-email.jsx
+++ b/client/me/security-checkup/recovery-email.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -39,6 +39,7 @@ class RecoveryEmail extends Component {
 	render() {
 		const email = this.state.data ? this.state.data.email : false;
 		const primaryEmail = this.props.userSettings.getSetting( 'user_email' );
+		const { translate } = this.props;
 
 		return (
 			<ManageContact
@@ -66,7 +67,7 @@ class RecoveryEmail extends Component {
 	}
 
 	onDelete = () => {
-		accept( translate( 'Are you sure you want to remove the email address?' ), function( accepted ) {
+		accept( this.translate( 'Are you sure you want to remove the email address?' ), function( accepted ) {
 			if ( accepted ) {
 				SecurityCheckupActions.deleteEmail();
 			}
@@ -78,4 +79,4 @@ class RecoveryEmail extends Component {
 	}
 }
 
-export default RecoveryEmail;
+export default localize( RecoveryEmail );

--- a/client/me/security-checkup/recovery-phone.jsx
+++ b/client/me/security-checkup/recovery-phone.jsx
@@ -4,7 +4,7 @@
 
 import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
-import { translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -42,7 +42,7 @@ class RecoveryPhone extends Component {
 		if ( twoStepEnabled ) {
 			return {
 				type: 'error',
-				message: translate( 'To edit your SMS Number, go to {{a}}Two-Step Authentication{{/a}}.', {
+				message: this.translate( 'To edit your SMS Number, go to {{a}}Two-Step Authentication{{/a}}.', {
 					components: {
 						a: <a href="/me/security/two-step" />
 					}
@@ -58,6 +58,7 @@ class RecoveryPhone extends Component {
 		const phone = ! isEmpty( this.state.data ) ? this.state.data : false;
 		const twoStepEnabled = this.props.userSettings.isTwoStepEnabled();
 		const twoStepNotice = this.getTwoStepNotice( twoStepEnabled );
+		const { translate } = this.props;
 
 		return (
 			<ManageContact
@@ -87,7 +88,7 @@ class RecoveryPhone extends Component {
 	}
 
 	onDelete = () => {
-		accept( translate( 'Are you sure you want to remove the SMS number?' ), function( accepted ) {
+		accept( this.translate( 'Are you sure you want to remove the SMS number?' ), function( accepted ) {
 			if ( accepted ) {
 				SecurityCheckupActions.deletePhone();
 			}
@@ -99,4 +100,4 @@ class RecoveryPhone extends Component {
 	}
 }
 
-export default RecoveryPhone;
+export default localize( RecoveryPhone );

--- a/client/me/security-checkup/recovery-phone.jsx
+++ b/client/me/security-checkup/recovery-phone.jsx
@@ -3,7 +3,7 @@
  */
 
 import React, { Component } from 'react';
-import isEmpty from 'lodash/isEmpty';
+import { isEmpty } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -38,14 +38,9 @@ class RecoveryPhone extends Component {
 		return AccountRecoveryStore.getPhone();
 	}
 
-	render() {
-		const phone = ! isEmpty( this.state.data ) ? this.state.data : false,
-			twoStepEnabled = this.props.userSettings.isTwoStepEnabled();
-
-		let twoStepNotice = null;
-
+	getTwoStepNotice( twoStepEnabled ) {
 		if ( twoStepEnabled ) {
-			twoStepNotice = {
+			return {
 				type: 'error',
 				message: translate( 'To edit your SMS Number, go to {{a}}Two-Step Authentication{{/a}}.', {
 					components: {
@@ -55,6 +50,14 @@ class RecoveryPhone extends Component {
 				showDismiss: false
 			};
 		}
+
+		return null;
+	}
+
+	render() {
+		const phone = ! isEmpty( this.state.data ) ? this.state.data : false;
+		const twoStepEnabled = this.props.userSettings.isTwoStepEnabled();
+		const twoStepNotice = this.getTwoStepNotice( twoStepEnabled );
 
 		return (
 			<ManageContact
@@ -95,7 +98,5 @@ class RecoveryPhone extends Component {
 		SecurityCheckupActions.dismissPhoneNotice();
 	}
 }
-
-RecoveryPhone.displayName = 'SecurityCheckupRecoveryPhone';
 
 export default RecoveryPhone;

--- a/client/me/security-checkup/recovery-phone.jsx
+++ b/client/me/security-checkup/recovery-phone.jsx
@@ -42,7 +42,7 @@ class RecoveryPhone extends Component {
 		if ( twoStepEnabled ) {
 			return {
 				type: 'error',
-				message: this.translate( 'To edit your SMS Number, go to {{a}}Two-Step Authentication{{/a}}.', {
+				message: this.props.translate( 'To edit your SMS Number, go to {{a}}Two-Step Authentication{{/a}}.', {
 					components: {
 						a: <a href="/me/security/two-step" />
 					}
@@ -88,7 +88,7 @@ class RecoveryPhone extends Component {
 	}
 
 	onDelete = () => {
-		accept( this.translate( 'Are you sure you want to remove the SMS number?' ), function( accepted ) {
+		accept( this.props.translate( 'Are you sure you want to remove the SMS number?' ), function( accepted ) {
 			if ( accepted ) {
 				SecurityCheckupActions.deletePhone();
 			}

--- a/client/me/security-checkup/recovery-phone.jsx
+++ b/client/me/security-checkup/recovery-phone.jsx
@@ -1,51 +1,53 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	assign = require( 'lodash/assign' ),
-	isEmpty = require( 'lodash/isEmpty' );
+
+import React, { Component } from 'react';
+import isEmpty from 'lodash/isEmpty';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var AccountRecoveryStore = require( 'lib/security-checkup/account-recovery-store' ),
-	SecurityCheckupActions = require( 'lib/security-checkup/actions' ),
-	ManageContact = require( './manage-contact' ),
-	EditPhone = require( './edit-phone' ),
-	accept = require( 'lib/accept' );
+import AccountRecoveryStore from 'lib/security-checkup/account-recovery-store';
+import SecurityCheckupActions from 'lib/security-checkup/actions';
+import ManageContact from './manage-contact';
+import EditPhone from './edit-phone';
+import accept from 'lib/accept';
 
-module.exports = React.createClass( {
-	displayName: 'SecurityCheckupRecoveryPhone',
+class RecoveryPhone extends Component {
+	constructor( props ) {
+		super( props );
 
-	componentDidMount: function() {
+		this.state = this.getDataFromStores();
+	}
+
+	componentDidMount() {
 		AccountRecoveryStore.on( 'change', this.refreshData );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		AccountRecoveryStore.off( 'change', this.refreshData );
-	},
+	}
 
-	getInitialState: function() {
-		return assign( {}, this.getDataFromStores() );
-	},
-
-	refreshData: function() {
+	refreshData = () => {
 		this.setState( this.getDataFromStores() );
-	},
+	}
 
-	getDataFromStores: function() {
+	getDataFromStores() {
 		return AccountRecoveryStore.getPhone();
-	},
+	}
 
-	render: function() {
-		var phone = ! isEmpty( this.state.data ) ? this.state.data : false,
-			twoStepEnabled = this.props.userSettings.isTwoStepEnabled(),
-			twoStepNotice = null;
+	render() {
+		const phone = ! isEmpty( this.state.data ) ? this.state.data : false,
+			twoStepEnabled = this.props.userSettings.isTwoStepEnabled();
+
+		let twoStepNotice = null;
 
 		if ( twoStepEnabled ) {
 			twoStepNotice = {
 				type: 'error',
-				message: this.translate( 'To edit your SMS Number, go to {{a}}Two-Step Authentication{{/a}}.', {
+				message: translate( 'To edit your SMS Number, go to {{a}}Two-Step Authentication{{/a}}.', {
 					components: {
 						a: <a href="/me/security/two-step" />
 					}
@@ -58,10 +60,10 @@ module.exports = React.createClass( {
 			<ManageContact
 				type="sms"
 				isLoading={ this.state.loading }
-				title={ this.translate( 'Recovery SMS Number', {
+				title={ translate( 'Recovery SMS Number', {
 					comment: 'Account security'
 				} ) }
-				subtitle={ phone ? phone.numberFull : this.translate( 'Not set' ) }
+				subtitle={ phone ? phone.numberFull : translate( 'Not set' ) }
 				hasValue={ !! phone }
 				lastNotice={ twoStepNotice || this.state.lastNotice }
 				disabled={ twoStepEnabled }
@@ -75,21 +77,25 @@ module.exports = React.createClass( {
 						/>
 				</ManageContact>
 		);
-	},
+	}
 
-	onSave: function( phone ) {
+	onSave = ( phone ) => {
 		SecurityCheckupActions.updatePhone( phone, this.state.data );
-	},
+	}
 
-	onDelete: function() {
-		accept( this.translate( 'Are you sure you want to remove the SMS number?' ), function( accepted ) {
+	onDelete = () => {
+		accept( translate( 'Are you sure you want to remove the SMS number?' ), function( accepted ) {
 			if ( accepted ) {
 				SecurityCheckupActions.deletePhone();
 			}
 		} );
-	},
+	}
 
-	onDismissNotice: function() {
+	onDismissNotice = () => {
 		SecurityCheckupActions.dismissPhoneNotice();
 	}
-} );
+}
+
+RecoveryPhone.displayName = 'SecurityCheckupRecoveryPhone';
+
+export default RecoveryPhone;


### PR DESCRIPTION
## Summary

This PR aims to move several account recovery related components to ES6 classes to make the up-coming works smoother.

## Test Plan
There should be no functional changes at all. Thus it is mainly about going through each UI to see if they works as usual.

1. Pick a test account without 2FA setup.
1. Go to `/me/security/checkup`
1. Try to add / update / delete the recovery email.
1. Try to add / update /delete the recovery phone.
1. Upon each successful update, click the dismiss button 'X' to see if it can be dismissed properly.

cc @jordwest 

