### PR TITLE
Site Selector: Fix responsive issue.

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -111,6 +111,10 @@
 .site-selector__sites {
 	max-height: calc( 100% - 93px );
 	overflow-y: auto;
+
+	@include breakpoint( "<660px" ) {
+		max-height: calc( 100% - 109px );
+	}
 }
 
 .site-selector__no-results {
@@ -126,11 +130,6 @@
 	display: flex;
 	flex-direction: row;
 	padding-left: 10px;
-
-	@include breakpoint( "<660px" ) {
-		margin-top: 16px;
-	}
-
 }
 
 .site-selector__add-new-site .button {


### PR DESCRIPTION
This PR fixes a margin/height issue introduced by a recent sidebar footer refactor. Before, it wasn't tall enough to stay on screen at mobile breakpoints. This PR fixes that.

Before:

![screen shot 2016-10-24 at 10 11 48](https://cloud.githubusercontent.com/assets/1204802/19638572/e60182b2-99d4-11e6-85e8-5a0975ebc6d0.png)

After:

![screen shot 2016-10-24 at 10 17 48](https://cloud.githubusercontent.com/assets/1204802/19638583/ebc91e4e-99d4-11e6-8333-adf9350cf8d7.png)

To test: 

- Have more than one site
- Navigate to Me/Sidebar/Switch Site on a mobile responsive (<660px) breakpoint
- Verify that the sidebar footer with the add new site button is visible.