### PR TITLE
Sidebar/Me: Hide support chat link, show footer

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -517,7 +517,7 @@
 
 @include breakpoint( "480px-1040px" ) {
 
-	.layout:not( .is-section-chat ) {
+	.layout:not( .is-section-happychat ) {
 		.happychat__container.is-open {
 			box-shadow: 0 1px 2px rgba( 0,0,0,.2 ), 0 1px 10px rgba( 0,0,0, .1 );
 			width: 280px;
@@ -555,7 +555,7 @@
 }
 
 @include breakpoint( "<480px" ) {
-	.layout:not( .is-section-chat ) {
+	.layout:not( .is-section-happychat ) {
 		.happychat__container.is-open {
 			right: 0;
 		}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -439,6 +439,10 @@ a.sidebar__button {
 	}
 }
 
+.layout.is-section-help .sidebar .sidebar__footer-help {
+	color: $gray-dark;
+}
+
 .sidebar__region {
 	flex-shrink: 0;
 	@include breakpoint( ">660px" ) {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -101,13 +101,6 @@
 		}
 	}
 
-	// Hide Support Chat link unless you're mobile, the item intentionally only exists for mobile users
-	li.sidebar__menu-happychat {
-		@include breakpoint( ">660px" ) {
-			display: none;
-		}
-	}
-
 	a:first-child {
 		flex: 1 0 auto;
 		width: 0;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -359,6 +359,7 @@ a.sidebar__button {
 		flex: 0 1 40px;
 		margin-right: 0;
 		margin-left: 0;
+		outline: 0;
 
 		@include breakpoint( "<660px" ) {
 			flex: 0 1 56px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -101,6 +101,13 @@
 		}
 	}
 
+	// Hide Support Chat link unless you're mobile, the item intentionally only exists for mobile users
+	li.sidebar__menu-happychat {
+		@include breakpoint( ">660px" ) {
+			display: none;
+		}
+	}
+
 	a:first-child {
 		flex: 1 0 auto;
 		width: 0;
@@ -232,7 +239,6 @@ a.sidebar__button {
 		margin: 10px 10px 0 0;
 	}
 }
-
 
 // Selected Menu
 @include breakpoint( ">660px" ) {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -11,6 +11,7 @@ const debug = debugFactory( 'calypso:me:sidebar' );
  * Internal dependencies
  */
 const Sidebar = require( 'layout/sidebar' ),
+	SidebarFooter = require( 'layout/sidebar/footer' ),
 	SidebarHeading = require( 'layout/sidebar/heading' ),
 	SidebarItem = require( 'layout/sidebar/item' ),
 	SidebarMenu = require( 'layout/sidebar/menu' ),
@@ -173,6 +174,7 @@ const MeSidebar = React.createClass( {
 								onNavigate={ this.onNavigate } /> }
 					</ul>
 				</SidebarMenu>
+				<SidebarFooter />
 			</Sidebar>
 		);
 	},

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -164,14 +164,6 @@ const MeSidebar = React.createClass( {
 							onNavigate={ this.onNavigate }
 							preloadSectionName="help"
 						/>
-						{ config.isEnabled( 'happychat' ) && <SidebarItem
-								selected= { selected === 'happychat' }
-								className="sidebar__menu-happychat"
-								link="/me/chat"
-								icon="chat"
-								label= { this.translate( 'Support Chat' ) }
-								preloadSectionName="happychat"
-								onNavigate={ this.onNavigate } /> }
 					</ul>
 				</SidebarMenu>
 				<SidebarFooter />

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -165,8 +165,9 @@ const MeSidebar = React.createClass( {
 						/>
 						{ config.isEnabled( 'happychat' ) && <SidebarItem
 								selected= { selected === 'happychat' }
+								className="sidebar__menu-happychat"
 								link="/me/chat"
-								icon="comment"
+								icon="chat"
 								label= { this.translate( 'Support Chat' ) }
 								preloadSectionName="happychat"
 								onNavigate={ this.onNavigate } /> }

--- a/client/me/sidebar/style.scss
+++ b/client/me/sidebar/style.scss
@@ -15,3 +15,8 @@
 .sidebar .profile-gravatar {
 	flex-shrink: 0;
 }
+
+// Hide Support Chat link, the item intentionally only exists for mobile users, and is accessible from the footer
+.is-group-me .sidebar__menu-happychat {
+	display: none;
+}


### PR DESCRIPTION
This PR contains two fixes:

1. It hides a support chat link that's not supposed to be visible to desktop users. 
2. It shows the new sidebar footer on all sections. This starts work on #8885 

Here's a more extended rationale. Desktop users accessing support chat need a consistent place where support chat lives. The footer in its most recent design is a good place for this, and the docked sidebar it opens is a good experience. 

Mobile users experience the same — they can open the sidebar, scroll to the bottom, to access support chat. However on mobile, overlaying scrollable panes on other scrollable elements causes scroll bleed. That's why, a while back, we implemented it so that when mobile users click the support chat link, they are taken to a dedicated section in the "Me" tab, where they see nothing but the big chat box, and aren't experiencing scroll bleed. 

To test:

<strike>
- Navigate to Me on a desktop. Verify that "Support Chat" item isn't visible in the sidebar, but the new footer is.
- Navigate via mobile, or a mobile responsive breakpoint (<660px) to the same section, verify that in the sidebar, the Support Chat item is available.
</strike> -- those test results are now obsolete.

To test now, verify that there is no support chat item, but instead, that there is a sidebar footer with a support chat button. Also verify that the help icon is highlighted when on the help section.


Before:

![screen shot 2016-10-24 at 11 58 22](https://cloud.githubusercontent.com/assets/1204802/19641668/f986bcd2-99e1-11e6-9654-358c6875dc0f.png)

After:

![screen shot 2016-10-24 at 11 57 55](https://cloud.githubusercontent.com/assets/1204802/19641675/ff32fff6-99e1-11e6-9dd3-12338b10a1f9.png)
