### PR TITLE
Support Chat: Tune welcome message with transcript info.

### DIFF
--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -128,9 +128,11 @@ const groupMessages = messages => {
 	return grouped.groups.concat( [ grouped.group ] );
 };
 
-const welcomeMessage = () => (
+const welcomeMessage = ( { currentUserEmail } ) => (
 	<div className="happychat__welcome">
-		{ translate( 'Welcome to WordPress.com support chat!' ) }
+		<p>{ translate( 'Welcome to WordPress.com support chat! We\'ll send a transcript to %s at the end of the chat.', {
+			args: currentUserEmail
+		} ) }</p>
 	</div>
 );
 
@@ -174,7 +176,8 @@ const mapProps = state => {
 	return {
 		connectionStatus: getHappychatConnectionStatus( state ),
 		timeline: getHappychatTimeline( state ),
-		isCurrentUser: ( { user_id } ) => user_id === current_user.ID
+		isCurrentUser: ( { user_id } ) => user_id === current_user.ID,
+		currentUserEmail: current_user.email
 	};
 };
 


### PR DESCRIPTION
This PR changes the welcome message to include a note that at transcript will be emailed at the end of the chat.

Screenshot:

![screen shot 2016-10-24 at 13 27 54](https://cloud.githubusercontent.com/assets/1204802/19644050/f83cb17c-99ed-11e6-96bd-7a1b53fbc787.png)

To test: 

- Click support chat icon from sidebar footer.
- Verify that the above message shows up as intended, showing your users email address.