### PR TITLE
Image Editor: add ability to specify allowed/default aspect ratios

### DIFF
--- a/client/blocks/image-editor/README.md
+++ b/client/blocks/image-editor/README.md
@@ -44,6 +44,30 @@ It can also contain these optional properties (with defaults if not set):
 - `media.mime_type` `{string}`: the MIME of the edited image (e.g. `image/jpeg`), defaults to `image/png`
 - `media.title` `{string}`: the title of the edited image (e.g. `some image file`), defaults to `default`
 
+### `defaultAspectRatio`
+
+<table>
+	<tr><th>Type</th><td>string</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td>'FREE'</td></tr>
+</table>
+
+Default, pre-selected aspect ratio for the image editor. If `allowedAspectRatios` prop is present as well,
+it must include the `defaultAspectRatio`. For the list of all possible aspect ratios, see
+`client/state/ui/editor/image-editor/constants`.
+
+### `allowedAspectRatios`
+
+<table>
+	<tr><th>Type</th><td>array</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td>all possible aspect ratios</td></tr>
+</table>
+
+List allowed aspect ratios user can select when editing an image. If there is only a single specified aspect ratio in
+the `allowedAspectRatios` array, it will be set as `defaultAspectRatio` as well.
+For the list of all possible aspect ratios, see `client/state/ui/editor/image-editor/constants`.
+
 ### `onDone`
 
 <table>

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -10,6 +10,7 @@ import { get } from 'lodash';
  */
 import ImageEditor from '../';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 
 class ImageEditorExample extends Component {
 	constructor() {
@@ -78,6 +79,7 @@ class ImageEditorExample extends Component {
 						media={ this.state.media }
 						onDone={ this.onImageEditorDone }
 						onReset={ this.onImageEditorReset }
+						defaultAspectRatio={ AspectRatios.ASPECT_3X2 }
 					/>
 				</div>
 

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -64,6 +64,11 @@ class ImageEditorExample extends Component {
 			primarySiteId
 		} = this.props;
 		
+		const allowedAspectRatios = [
+			AspectRatios.ASPECT_1X1,
+			AspectRatios.ASPECT_4X3
+		];
+		
 		return (
 			<div>
 				<div style={ {
@@ -80,6 +85,7 @@ class ImageEditorExample extends Component {
 						onDone={ this.onImageEditorDone }
 						onReset={ this.onImageEditorReset }
 						defaultAspectRatio={ AspectRatios.ASPECT_3X2 }
+						allowedAspectRatios={ allowedAspectRatios }
 					/>
 				</div>
 

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -15,7 +15,7 @@ import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 class ImageEditorExample extends Component {
 	constructor() {
 		super();
-		
+
 		this.state = {
 			media: {
 				URL: 'https://cldup.com/mA_hqNVj0w.jpg'
@@ -29,7 +29,7 @@ class ImageEditorExample extends Component {
 		if ( error ) {
 			return;
 		}
-		
+
 		const imageUrl = window.URL.createObjectURL( blob );
 
 		this.getTestingImage().src = imageUrl;
@@ -38,18 +38,18 @@ class ImageEditorExample extends Component {
 	onImageEditorReset = () => {
 		this.getTestingImage().src = this.state.media.URL || this.state.media.src;
 	};
-	
+
 	componentDidMount() {
 		const fileInput = document.querySelector( '#devdocs-example-image-editor-file-input' );
-		
+
 		fileInput.addEventListener( 'change', this.onImageUpload );
 	}
 
 	onImageUpload = ( e ) => {
 		const imageFile = e.target.files[ 0 ];
-		
+
 		const imageObjectUrl = URL.createObjectURL( imageFile );
-		
+
 		this.setState( {
 			media: {
 				src: imageObjectUrl
@@ -63,7 +63,7 @@ class ImageEditorExample extends Component {
 		const {
 			primarySiteId
 		} = this.props;
-		
+
 		return (
 			<div>
 				<div style={ {

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -64,11 +64,6 @@ class ImageEditorExample extends Component {
 			primarySiteId
 		} = this.props;
 		
-		const allowedAspectRatios = [
-			AspectRatios.ASPECT_1X1,
-			AspectRatios.ASPECT_4X3
-		];
-		
 		return (
 			<div>
 				<div style={ {
@@ -84,8 +79,6 @@ class ImageEditorExample extends Component {
 						media={ this.state.media }
 						onDone={ this.onImageEditorDone }
 						onReset={ this.onImageEditorReset }
-						defaultAspectRatio={ AspectRatios.ASPECT_3X2 }
-						allowedAspectRatios={ allowedAspectRatios }
 					/>
 				</div>
 

--- a/client/blocks/image-editor/docs/example.jsx
+++ b/client/blocks/image-editor/docs/example.jsx
@@ -79,6 +79,12 @@ class ImageEditorExample extends Component {
 						media={ this.state.media }
 						onDone={ this.onImageEditorDone }
 						onReset={ this.onImageEditorReset }
+						allowedAspectRatios={ [
+							AspectRatios.ASPECT_1X1,
+							AspectRatios.ASPECT_4X3,
+							AspectRatios.ASPECT_16X9
+						] }
+						defaultAspectRatio={ AspectRatios.ASPECT_1X1 }
 					/>
 				</div>
 

--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -80,6 +80,10 @@ class ImageEditorCrop extends Component {
 		};
 	}
 
+	componentWillMount() {
+		this.updateCrop( this.getDefaultState( this.props ), this.props, this.applyCrop );
+	}
+
 	componentWillReceiveProps( newProps ) {
 		const {
 			bounds,

--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -98,12 +98,18 @@ class ImageEditorCrop extends Component {
 			const newBottom = newTop + newProps.crop.heightRatio * imageHeight;
 			const newRight = newLeft + newProps.crop.widthRatio * imageWidth;
 
-			this.setState( {
+			const newBounds = {
 				top: newTop,
 				left: newLeft,
 				bottom: newBottom,
 				right: newRight
-			} );
+			};
+
+			this.setState( newBounds );
+
+			// We need to update crop even after clicking on the "Reset" button so let's
+			// always update it on receiving new props (without calling the applyCrop callback).
+			this.updateCrop( newBounds );
 		}
 
 		if ( aspectRatio !== newProps.aspectRatio ) {

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -3,7 +3,10 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
+import {
+	noop,
+	values as objectValues
+} from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -27,13 +30,15 @@ class ImageEditorToolbar extends Component {
 		aspectRatio: PropTypes.string,
 		imageEditorRotateCounterclockwise: PropTypes.func,
 		imageEditorFlip: PropTypes.func,
-		setImageEditorAspectRatio: PropTypes.func
+		setImageEditorAspectRatio: PropTypes.func,
+		allowedAspectRatios: PropTypes.array
 	};
 
 	static defaultProps = {
 		imageEditorRotateCounterclockwise: noop,
 		imageEditorFlip: noop,
-		setImageEditorAspectRatio: noop
+		setImageEditorAspectRatio: noop,
+		allowedAspectRatios: objectValues( AspectRatios )
 	};
 
 	constructor( props ) {
@@ -88,7 +93,8 @@ class ImageEditorToolbar extends Component {
 
 		const {
 			translate,
-			aspectRatio
+			aspectRatio,
+			allowedAspectRatios
 		} = this.props;
 
 		const items = [
@@ -126,16 +132,18 @@ class ImageEditorToolbar extends Component {
 				className="image-editor__toolbar-popover popover is-dialog-visible"
 			>
 				{ items.map( item => (
-					<PopoverMenuItem
-						key={ 'image-editor-toolbar-aspect-' + item.action }
-						action={ item.action }>
-						{
-							aspectRatio === item.action
-								? <Gridicon icon="checkmark" size={ 12 } />
-								: false
-						}
-						{ item.label }
-					</PopoverMenuItem>
+					allowedAspectRatios.indexOf( item.action ) !== -1
+						? <PopoverMenuItem
+							key={ 'image-editor-toolbar-aspect-' + item.action }
+							action={ item.action }>
+							{
+								aspectRatio === item.action
+									? <Gridicon icon="checkmark" size={ 12 } />
+									: false
+							}
+							{ item.label }
+						</PopoverMenuItem>
+						: null
 				) ) }
 			</PopoverMenu>
 		);

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -87,15 +87,15 @@ class ImageEditorToolbar extends Component {
 			showAspectPopover
 		} = this.state;
 
-		if ( ! popoverContext ) {
-			return;
-		}
-
 		const {
 			translate,
 			aspectRatio,
 			allowedAspectRatios
 		} = this.props;
+
+		if ( ! popoverContext || allowedAspectRatios.length === 1 ) {
+			return;
+		}
 
 		const items = [
 			{
@@ -150,7 +150,10 @@ class ImageEditorToolbar extends Component {
 	}
 
 	renderButtons() {
-		const { translate } = this.props;
+		const {
+			translate,
+			allowedAspectRatios
+		} = this.props;
 
 		const buttons = [
 			{
@@ -159,13 +162,15 @@ class ImageEditorToolbar extends Component {
 				text: translate( 'Rotate' ),
 				onClick: this.rotate
 			},
-			{
-				tool: 'aspect',
-				ref: this.setAspectMenuContext,
-				icon: 'layout',
-				text: translate( 'Aspect' ),
-				onClick: this.onAspectOpen
-			},
+			allowedAspectRatios.length === 1
+				? null
+				: {
+					tool: 'aspect',
+					ref: this.setAspectMenuContext,
+					icon: 'layout',
+					text: translate( 'Aspect' ),
+					onClick: this.onAspectOpen
+				},
 			{
 				tool: 'flip-vertical',
 				icon: 'flip-vertical',
@@ -174,17 +179,21 @@ class ImageEditorToolbar extends Component {
 			}
 		];
 
-		return buttons.map( button => (
-			<button
-				key={ 'image-editor-toolbar-' + button.tool }
-				ref={ button.ref }
-				className={ 'image-editor__toolbar-button' }
-				onClick={ button.onClick }
-			>
-				<Gridicon icon={ button.icon } />
-				<span>{ button.text }</span>
-			</button>
-		) );
+		return buttons.map( button =>
+			button
+				? (
+					<button
+						key={ 'image-editor-toolbar-' + button.tool }
+						ref={ button.ref }
+						className={ 'image-editor__toolbar-button' }
+						onClick={ button.onClick }
+					>
+						<Gridicon icon={ button.icon } />
+						<span>{ button.text }</span>
+					</button>
+				)
+				: null
+		);
 	}
 
 	render() {

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -20,7 +20,8 @@ import closeOnEsc from 'lib/mixins/close-on-esc';
 import {
 	resetImageEditorState,
 	resetAllImageEditorState,
-	setImageEditorFileInfo
+	setImageEditorFileInfo,
+	setImageEditorAspectRatio
 } from 'state/ui/editor/image-editor/actions';
 import {
 	getImageEditorFileInfo,
@@ -29,6 +30,7 @@ import {
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import QuerySites from 'components/data/query-sites';
+import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 
 const ImageEditor = React.createClass( {
 	mixins: [ closeOnEsc( 'onCancel' ) ],
@@ -41,6 +43,22 @@ const ImageEditor = React.createClass( {
 		onCancel: PropTypes.func,
 		onReset: PropTypes.func,
 		className: PropTypes.string,
+		defaultAspectRatio: PropTypes.oneOf( [
+			AspectRatios.FREE,
+			AspectRatios.ORIGINAL,
+			AspectRatios.ASPECT_1X1,
+			AspectRatios.ASPECT_16X9,
+			AspectRatios.ASPECT_4X3,
+			AspectRatios.ASPECT_3X2
+		] ),
+		allowedAspectRatios: PropTypes.arrayOf( PropTypes.oneOf( [
+			AspectRatios.FREE,
+			AspectRatios.ORIGINAL,
+			AspectRatios.ASPECT_1X1,
+			AspectRatios.ASPECT_16X9,
+			AspectRatios.ASPECT_4X3,
+			AspectRatios.ASPECT_3X2
+		] ) ),
 
 		// Redux props
 		site: PropTypes.object,
@@ -56,7 +74,8 @@ const ImageEditor = React.createClass( {
 			onDone: noop,
 			onCancel: null,
 			onReset: noop,
-			isImageLoaded: false
+			isImageLoaded: false,
+			defaultAspectRatio: AspectRatios.FREE
 		};
 	},
 
@@ -75,11 +94,23 @@ const ImageEditor = React.createClass( {
 			this.props.resetAllImageEditorState();
 
 			this.updateFileInfo( newProps.media );
+
+			this.setDefaultAspectRatio();
 		}
 	},
 
 	componentDidMount() {
 		this.updateFileInfo( this.props.media );
+
+		this.setDefaultAspectRatio();
+	},
+
+	setDefaultAspectRatio() {
+		const { defaultAspectRatio } = this.props;
+
+		if ( defaultAspectRatio ) {
+			this.props.setImageEditorAspectRatio( defaultAspectRatio );
+		}
 	},
 
 	updateFileInfo( media ) {
@@ -230,6 +261,7 @@ export default connect(
 	{
 		resetImageEditorState,
 		resetAllImageEditorState,
-		setImageEditorFileInfo
+		setImageEditorFileInfo,
+		setImageEditorAspectRatio
 	}
 )( localize( ImageEditor ) );

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -84,6 +84,23 @@ const ImageEditor = React.createClass( {
 		};
 	},
 
+	componentWillMount() {
+		const {
+			allowedAspectRatios,
+			defaultAspectRatio
+		} = this.props;
+
+		if (
+			allowedAspectRatios &&
+			allowedAspectRatios.length !== 1 &&
+			allowedAspectRatios.indexOf( defaultAspectRatio ) === -1
+		) {
+			// If allowedAspectRatios prop is specified and has more than one item,
+			// defaultAspectRatio prop must contain a value which is included in allowedAspectRatios.
+			throw new Error( 'Image Editor props: defaultAspectRatio not found in allowedAspectRatios' );
+		}
+	},
+
 	getInitialState() {
 		return {
 			canvasError: null
@@ -111,7 +128,16 @@ const ImageEditor = React.createClass( {
 	},
 
 	setDefaultAspectRatio() {
-		const { defaultAspectRatio } = this.props;
+		const {
+			defaultAspectRatio,
+			allowedAspectRatios
+		} = this.props;
+
+		if ( allowedAspectRatios && allowedAspectRatios.length === 1 ) {
+			this.props.setImageEditorAspectRatio( allowedAspectRatios[ 0 ] );
+
+			return;
+		}
 
 		if ( defaultAspectRatio ) {
 			this.props.setImageEditorAspectRatio( defaultAspectRatio );

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -102,9 +102,14 @@ const ImageEditor = React.createClass( {
 	},
 
 	setDefaultAspectRatio() {
-		const {	defaultAspectRatio } = this.props;
+		const {
+			defaultAspectRatio,
+			allowedAspectRatios
+		} = this.props;
 
-		this.props.setImageEditorAspectRatio( getDefaultAspectRatio( defaultAspectRatio ) );
+		this.props.setImageEditorAspectRatio(
+			getDefaultAspectRatio( defaultAspectRatio, allowedAspectRatios )
+		);
 	},
 
 	updateFileInfo( media ) {
@@ -256,7 +261,11 @@ export default connect(
 		};
 	},
 	( dispatch, ownProp ) => {
-		const defaultAspectRatio = getDefaultAspectRatio( ownProp.defaultAspectRatio );
+		const defaultAspectRatio = getDefaultAspectRatio(
+			ownProp.defaultAspectRatio,
+			ownProp.allowedAspectRatios
+		);
+
 		const resetActionsAdditionalData = {
 			aspectRatio: defaultAspectRatio
 		};

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -85,20 +85,7 @@ const ImageEditor = React.createClass( {
 	},
 
 	componentWillMount() {
-		const {
-			allowedAspectRatios,
-			defaultAspectRatio
-		} = this.props;
-
-		if (
-			allowedAspectRatios &&
-			allowedAspectRatios.length !== 1 &&
-			allowedAspectRatios.indexOf( defaultAspectRatio ) === -1
-		) {
-			// If allowedAspectRatios prop is specified and has more than one item,
-			// defaultAspectRatio prop must contain a value which is included in allowedAspectRatios.
-			throw new Error( 'Image Editor props: defaultAspectRatio not found in allowedAspectRatios' );
-		}
+		this.checkForValidAspectRatioSettings();
 	},
 
 	getInitialState() {
@@ -113,6 +100,8 @@ const ImageEditor = React.createClass( {
 		} = this.props;
 
 		if ( newProps.media && ! isEqual( newProps.media, currentMedia ) ) {
+			this.checkForValidAspectRatioSettings();
+
 			this.props.resetAllImageEditorState();
 
 			this.updateFileInfo( newProps.media );
@@ -125,6 +114,23 @@ const ImageEditor = React.createClass( {
 		this.updateFileInfo( this.props.media );
 
 		this.setDefaultAspectRatio();
+	},
+
+	checkForValidAspectRatioSettings() {
+		const {
+			allowedAspectRatios,
+			defaultAspectRatio
+		} = this.props;
+
+		if (
+			allowedAspectRatios &&
+			allowedAspectRatios.length !== 1 &&
+			allowedAspectRatios.indexOf( defaultAspectRatio ) === -1
+		) {
+			// If allowedAspectRatios prop is specified and has more than one item,
+			// defaultAspectRatio prop must contain a value which is included in allowedAspectRatios.
+			throw new Error( 'Image Editor props: defaultAspectRatio not found in allowedAspectRatios' );
+		}
 	},
 
 	setDefaultAspectRatio() {

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -36,6 +36,8 @@ import { getSite } from 'state/sites/selectors';
 import QuerySites from 'components/data/query-sites';
 import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 
+const aspectRatiosValues = objectValues( AspectRatios );
+
 const ImageEditor = React.createClass( {
 	mixins: [ closeOnEsc( 'onCancel' ) ],
 
@@ -47,22 +49,8 @@ const ImageEditor = React.createClass( {
 		onCancel: PropTypes.func,
 		onReset: PropTypes.func,
 		className: PropTypes.string,
-		defaultAspectRatio: PropTypes.oneOf( [
-			AspectRatios.FREE,
-			AspectRatios.ORIGINAL,
-			AspectRatios.ASPECT_1X1,
-			AspectRatios.ASPECT_16X9,
-			AspectRatios.ASPECT_4X3,
-			AspectRatios.ASPECT_3X2
-		] ),
-		allowedAspectRatios: PropTypes.arrayOf( PropTypes.oneOf( [
-			AspectRatios.FREE,
-			AspectRatios.ORIGINAL,
-			AspectRatios.ASPECT_1X1,
-			AspectRatios.ASPECT_16X9,
-			AspectRatios.ASPECT_4X3,
-			AspectRatios.ASPECT_3X2
-		] ) ),
+		defaultAspectRatio: PropTypes.oneOf( aspectRatiosValues ),
+		allowedAspectRatios: PropTypes.arrayOf( PropTypes.oneOf( aspectRatiosValues ) ),
 
 		// Redux props
 		site: PropTypes.object,
@@ -80,7 +68,7 @@ const ImageEditor = React.createClass( {
 			onReset: noop,
 			isImageLoaded: false,
 			defaultAspectRatio: AspectRatios.FREE,
-			allowedAspectRatios: objectValues( AspectRatios )
+			allowedAspectRatios: aspectRatiosValues
 		};
 	},
 

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -3,7 +3,11 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { noop, isEqual } from 'lodash';
+import {
+	noop,
+	isEqual,
+	values as objectValues
+} from 'lodash';
 import path from 'path';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -75,7 +79,8 @@ const ImageEditor = React.createClass( {
 			onCancel: null,
 			onReset: noop,
 			isImageLoaded: false,
-			defaultAspectRatio: AspectRatios.FREE
+			defaultAspectRatio: AspectRatios.FREE,
+			allowedAspectRatios: objectValues( AspectRatios )
 		};
 	},
 
@@ -211,7 +216,8 @@ const ImageEditor = React.createClass( {
 	render() {
 		const {
 			className,
-			siteId
+			siteId,
+			allowedAspectRatios
 		} = this.props;
 
 		const classes = classNames(
@@ -231,7 +237,9 @@ const ImageEditor = React.createClass( {
 							ref="editCanvas"
 							onLoadError={ this.onLoadCanvasError }
 						/>
-						<ImageEditorToolbar />
+						<ImageEditorToolbar
+							allowedAspectRatios={ allowedAspectRatios }
+						/>
 						<ImageEditorButtons
 							onCancel={ this.props.onCancel && this.onCancel }
 							onDone={ this.onDone }

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -72,10 +72,6 @@ const ImageEditor = React.createClass( {
 		};
 	},
 
-	componentWillMount() {
-		this.checkForValidAspectRatioSettings();
-	},
-
 	getInitialState() {
 		return {
 			canvasError: null
@@ -88,8 +84,6 @@ const ImageEditor = React.createClass( {
 		} = this.props;
 
 		if ( newProps.media && ! isEqual( newProps.media, currentMedia ) ) {
-			this.checkForValidAspectRatioSettings();
-
 			this.props.resetAllImageEditorState();
 
 			this.updateFileInfo( newProps.media );
@@ -104,33 +98,21 @@ const ImageEditor = React.createClass( {
 		this.setDefaultAspectRatio();
 	},
 
-	checkForValidAspectRatioSettings() {
-		const {
-			allowedAspectRatios,
-			defaultAspectRatio
-		} = this.props;
-
-		if (
-			allowedAspectRatios &&
-			allowedAspectRatios.length !== 1 &&
-			allowedAspectRatios.indexOf( defaultAspectRatio ) === -1
-		) {
-			// If allowedAspectRatios prop is specified and has more than one item,
-			// defaultAspectRatio prop must contain a value which is included in allowedAspectRatios.
-			throw new Error( 'Image Editor props: defaultAspectRatio not found in allowedAspectRatios' );
-		}
-	},
-
 	setDefaultAspectRatio() {
 		const {
 			defaultAspectRatio,
 			allowedAspectRatios
 		} = this.props;
 
-		if ( allowedAspectRatios && allowedAspectRatios.length === 1 ) {
-			this.props.setImageEditorAspectRatio( allowedAspectRatios[ 0 ] );
+		if ( allowedAspectRatios && allowedAspectRatios.length >= 1 ) {
+			if (
+				allowedAspectRatios.length === 1 ||
+				allowedAspectRatios.indexOf( defaultAspectRatio ) === -1
+			) {
+				this.props.setImageEditorAspectRatio( allowedAspectRatios[ 0 ] );
 
-			return;
+				return;
+			}
 		}
 
 		if ( defaultAspectRatio ) {

--- a/client/blocks/image-editor/utils.js
+++ b/client/blocks/image-editor/utils.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import {
+	indexOf,
+	get
+} from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { AspectRatiosValues } from 'state/ui/editor/image-editor/constants';
+
+/**
+ * Returns the default aspect ratio image editor should use.
+ *
+ * If only aspectRatio is specified and is valid, we return it. If only aspectRatios is specified and is valid,
+ * we return its first item. If both aspectRatio and aspectRatios are specified, we return either:
+ * 1. aspectRatio, if it is included in aspectRatios
+ * 2. aspectRatios[ 0 ] if aspectRatio is not included in aspectRatios
+ *
+ * We return AllAspectRatios.FREE if no specified aspect ratio is valid.
+ *
+ * @param   {String} aspectRatio  an aspect ratio which should be validated and used as default one for image editor
+ * @param   {Array}  aspectRatios list of aspect ratios to be validated and used in image editor
+ * @returns {String}              the default valid aspect ratio image editor should use
+ */
+export function getDefaultAspectRatio( aspectRatio = null, aspectRatios = AspectRatiosValues ) {
+	if ( indexOf( aspectRatios, aspectRatio ) === -1 ) {
+		aspectRatio = get( aspectRatios, '0', AspectRatiosValues.FREE );
+	}
+
+	return indexOf( AspectRatiosValues, aspectRatio ) === -1
+		? getDefaultAspectRatio( aspectRatio )
+		: aspectRatio;
+}

--- a/client/state/ui/editor/image-editor/actions.js
+++ b/client/state/ui/editor/image-editor/actions.js
@@ -14,6 +14,7 @@ import {
 } from 'state/action-types';
 
 // Doesn't reset image file info (src, fileName, etc).
+// additionalData can contain arbitrarily needed data.
 export function resetImageEditorState( additionalData = {} ) {
 	return {
 		type: IMAGE_EDITOR_STATE_RESET,
@@ -22,9 +23,11 @@ export function resetImageEditorState( additionalData = {} ) {
 }
 
 // Resets image file info as well (src, fileName, etc).
-export function resetAllImageEditorState() {
+// additionalData can contain arbitrarily needed data.
+export function resetAllImageEditorState( additionalData = {} ) {
 	return {
-		type: IMAGE_EDITOR_STATE_RESET_ALL
+		type: IMAGE_EDITOR_STATE_RESET_ALL,
+		additionalData
 	};
 }
 

--- a/client/state/ui/editor/image-editor/actions.js
+++ b/client/state/ui/editor/image-editor/actions.js
@@ -14,9 +14,10 @@ import {
 } from 'state/action-types';
 
 // Doesn't reset image file info (src, fileName, etc).
-export function resetImageEditorState() {
+export function resetImageEditorState( additionalData = {} ) {
 	return {
-		type: IMAGE_EDITOR_STATE_RESET
+		type: IMAGE_EDITOR_STATE_RESET,
+		additionalData
 	};
 }
 

--- a/client/state/ui/editor/image-editor/constants.js
+++ b/client/state/ui/editor/image-editor/constants.js
@@ -1,3 +1,7 @@
+import { 
+	values as objectValues
+} from 'lodash';
+
 export const AspectRatios = {
 	FREE: 'FREE',
 	ORIGINAL: 'ORIGINAL',
@@ -6,3 +10,5 @@ export const AspectRatios = {
 	ASPECT_4X3: 'ASPECT_4X3',
 	ASPECT_3X2: 'ASPECT_3X2'
 };
+
+export const AspectRatiosValues = objectValues( AspectRatios );

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -152,6 +152,12 @@ export function aspectRatio( state = AspectRatios.FREE, action ) {
 			return action.ratio;
 		case IMAGE_EDITOR_STATE_RESET:
 		case IMAGE_EDITOR_STATE_RESET_ALL:
+			const { aspectRatio: payloadAspectRatio } = action.additionalData;
+
+			if ( payloadAspectRatio && AspectRatios[ payloadAspectRatio ] ) {
+				return payloadAspectRatio;
+			}
+
 			return AspectRatios.FREE;
 	}
 

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -152,7 +152,8 @@ export function aspectRatio( state = AspectRatios.FREE, action ) {
 			return action.ratio;
 		case IMAGE_EDITOR_STATE_RESET:
 		case IMAGE_EDITOR_STATE_RESET_ALL:
-			const { aspectRatio: payloadAspectRatio } = action.additionalData;
+			const { additionalData = {} } = action;
+			const { aspectRatio: payloadAspectRatio } = additionalData;
 
 			if ( payloadAspectRatio && AspectRatios[ payloadAspectRatio ] ) {
 				return payloadAspectRatio;

--- a/client/state/ui/editor/image-editor/test/actions.js
+++ b/client/state/ui/editor/image-editor/test/actions.js
@@ -59,7 +59,19 @@ describe( 'actions', () => {
 			const action = resetAllImageEditorState();
 
 			expect( action ).to.eql( {
-				type: IMAGE_EDITOR_STATE_RESET_ALL
+				type: IMAGE_EDITOR_STATE_RESET_ALL,
+				additionalData: {}
+			} );
+		} );
+
+		it( 'should return an action object with additional data if specified', () => {
+			const action = resetAllImageEditorState( { aspectRatio: AspectRatios.FREE } );
+
+			expect( action ).to.eql( {
+				type: IMAGE_EDITOR_STATE_RESET_ALL,
+				additionalData: {
+					aspectRatio: AspectRatios.FREE
+				}
 			} );
 		} );
 	} );

--- a/client/state/ui/editor/image-editor/test/actions.js
+++ b/client/state/ui/editor/image-editor/test/actions.js
@@ -37,7 +37,19 @@ describe( 'actions', () => {
 			const action = resetImageEditorState();
 
 			expect( action ).to.eql( {
-				type: IMAGE_EDITOR_STATE_RESET
+				type: IMAGE_EDITOR_STATE_RESET,
+				additionalData: {}
+			} );
+		} );
+
+		it( 'should return an action object with additional data if specified', () => {
+			const action = resetImageEditorState( { aspectRatio: AspectRatios.FREE } );
+
+			expect( action ).to.eql( {
+				type: IMAGE_EDITOR_STATE_RESET,
+				additionalData: {
+					aspectRatio: AspectRatios.FREE
+				}
 			} );
 		} );
 	} );


### PR DESCRIPTION
Fixes #8883. This PR adds two new props to `ImageEditor` component:
- `defaultAspectRatio`: allows specifying the default, pre-selected aspect ratio;
- `allowedAspectRatios`: allows specifying which aspect ratios from `client/state/ui/editor/image-editor/constants` are allowed.
## Testing instructions
1. Test that image editor is working as before in both media library and image editor devdocs page;
2. To test `defaultAspectRatio` prop, edit `client/blocks/image-editor/docs/example` `ImageEditor` code as follows:
   
   ``` js
   <ImageEditor [leave all the props in place]
   defaultAspectRatio={ AspectRatios.ASPECT_4X3 }
   />
   ```
   
   Reload image editor devdocs page and ensure the default aspect ratio is `4:3`.
3. To test `allowedAspectRatios` prop with single value, edit `client/blocks/image-editor/docs/example` `ImageEditor` code as follows:
   
   ``` js
   <ImageEditor [leave all the props in place]
   allowedAspectRatios={ [ AspectRatios.ASPECT_1X1 ] }
   />
   ```
   
   Reload image editor devdocs page and ensure the only possible aspect ratio is `Square`. It should be also set as default.
4. To test `allowedAspectRatios` prop with multiple values, edit `client/blocks/image-editor/docs/example` `ImageEditor` code as follows:
   
   ``` js
   <ImageEditor [leave all the props in place]
   allowedAspectRatios={ [ AspectRatios.ASPECT_1X1, AspectRatios.ASPECT_4X3 ] }
   defaultAspectRatio={ AspectRatios.ASPECT_4X3 }
   />
   ```
   
   Reload image editor devdocs page and ensure the only possible aspect ratios are `Square` and `4:3`. `4:3` should also be set as default. If you remove the `defaultAspectRatio` prop, you should get an `Error` saying that the `defaultAspectRatio` (which is set to `AspectRatios.FREE` by default) must be included in `allowedAspectRatios` if that prop contains more than 1 items.

/cc @gwwar @artpi @v18 
