### PR TITLE
Domains: Make sure the domain is not available when it's unmappable

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -47,7 +47,7 @@ var DomainSearchResults = React.createClass( {
 				'domain-search-results__domain-not-available': ! availableDomain
 			} ),
 			lastDomainSearched = this.props.lastDomainSearched,
-			suggestions = this.props.suggestions,
+			suggestions = this.props.suggestions || [],
 			availabilityElement,
 			domainSuggestionElement,
 			mappingOffer;
@@ -77,7 +77,7 @@ var DomainSearchResults = React.createClass( {
 					cart={ this.props.cart }
 					onButtonClick={ this.props.onClickResult.bind( null, availableDomain ) } />
 				);
-		} else if ( suggestions && suggestions.length !== 0 && this.isDomainMappable() && this.props.products.domain_map ) {
+		} else if ( suggestions.length !== 0 && this.isDomainMappable() && this.props.products.domain_map ) {
 			const components = { a: <a href="#" onClick={ this.addMappingAndRedirect } />, small: <small /> };
 			if ( this.props.domainsWithPlansOnly ) {
 				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}}' +

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -4,8 +4,7 @@
 const React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	page = require( 'page' ),
-	times = require( 'lodash/times' ),
-	includes = require( 'lodash/includes' );
+	times = require( 'lodash/times' );
 
 import Notice from 'components/notice';
 
@@ -37,9 +36,8 @@ var DomainSearchResults = React.createClass( {
 		onAddMapping: React.PropTypes.func,
 		onClickMapping: React.PropTypes.func
 	},
-	isDomainUnavailable: function() {
-		return this.props.lastDomainError &&
-			includes( [ 'not_available', 'not_available_but_mappable' ], this.props.lastDomainError.code );
+	isDomainMappable: function() {
+		return this.props.lastDomainError && 'not_available_but_mappable' === this.props.lastDomainError.code;
 	},
 
 	domainAvailability: function() {
@@ -49,6 +47,7 @@ var DomainSearchResults = React.createClass( {
 				'domain-search-results__domain-not-available': ! availableDomain
 			} ),
 			lastDomainSearched = this.props.lastDomainSearched,
+			suggestions = this.props.suggestions,
 			availabilityElement,
 			domainSuggestionElement,
 			mappingOffer;
@@ -78,33 +77,31 @@ var DomainSearchResults = React.createClass( {
 					cart={ this.props.cart }
 					onButtonClick={ this.props.onClickResult.bind( null, availableDomain ) } />
 				);
-		} else if ( this.props.suggestions && this.props.suggestions.length !== 0 && this.isDomainUnavailable() ) {
-			if ( this.props.products.domain_map && this.props.lastDomainError.code === 'not_available_but_mappable' ) {
-				const components = { a: <a href="#" onClick={ this.addMappingAndRedirect }/>, small: <small /> };
-				if ( this.props.domainsWithPlansOnly ) {
-					mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}}' +
-						' with WordPress.com Premium.{{/small}}', {
-							args: { domain: lastDomainSearched },
-							components
-						}
-					);
-				} else {
-					if ( isNextDomainFree( this.props.cart ) ) {
-						mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}', {
-							args: {
-								domain: lastDomainSearched
-							},
-							components
-						} );
-					} else {
-						mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}', {
-							args: {
-								domain: lastDomainSearched,
-								cost: this.props.products.domain_map.cost_display
-							},
-							components
-						} );
+		} else if ( suggestions && suggestions.length !== 0 && this.isDomainMappable() && this.props.products.domain_map ) {
+			const components = { a: <a href="#" onClick={ this.addMappingAndRedirect } />, small: <small /> };
+			if ( this.props.domainsWithPlansOnly ) {
+				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}}' +
+					' with WordPress.com Premium.{{/small}}', {
+						args: { domain: lastDomainSearched },
+						components
 					}
+				);
+			} else {
+				if ( isNextDomainFree( this.props.cart ) ) {
+					mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}', {
+						args: {
+							domain: lastDomainSearched
+						},
+						components
+					} );
+				} else {
+					mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}', {
+						args: {
+							domain: lastDomainSearched,
+							cost: this.props.products.domain_map.cost_display
+						},
+						components
+					} );
 				}
 			}
 
@@ -155,7 +152,7 @@ var DomainSearchResults = React.createClass( {
 		} );
 	},
 
-	suggestions: function() {
+	domainSuggestions: function() {
 		var suggestionElements,
 			mappingOffer;
 
@@ -198,7 +195,7 @@ var DomainSearchResults = React.createClass( {
 		return (
 			<div className="domain-search-results">
 				{ this.domainAvailability() }
-				{ this.suggestions() }
+				{ this.domainSuggestions() }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -37,7 +37,7 @@ var DomainSearchResults = React.createClass( {
 		onClickMapping: React.PropTypes.func
 	},
 	isDomainMappable: function() {
-		return this.props.lastDomainError && 'not_available_but_mappable' === this.props.lastDomainError.code;
+		return this.props.lastDomainError && this.props.lastDomainError.code === 'not_available_but_mappable';
 	},
 
 	domainAvailability: function() {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -540,7 +540,7 @@ const RegisterDomainStep = React.createClass( {
 				);
 				severity = 'info';
 				break;
-			case 'not_registrable':
+			case 'available_but_not_registrable':
 				const tldIndex = domain.lastIndexOf( '.' );
 				if ( tldIndex !== -1 ) {
 					message = this.translate(
@@ -557,7 +557,6 @@ const RegisterDomainStep = React.createClass( {
 					severity = 'info';
 				}
 				break;
-			case 'not_available':
 			case 'not_available_but_mappable':
 			case 'domain_registration_unavailable':
 				// unavailable domains are displayed in the search results, not as a notice OR
@@ -565,7 +564,7 @@ const RegisterDomainStep = React.createClass( {
 				message = null;
 				break;
 
-			case 'mappable_but_blacklisted_domain':
+			case 'not_mappable_blacklisted_domain':
 				if ( domain.toLowerCase().indexOf( 'wordpress' ) > -1 ) {
 					message = this.translate(
 						'Due to {{a1}}trademark policy{{/a1}}, ' +
@@ -584,18 +583,34 @@ const RegisterDomainStep = React.createClass( {
 				}
 				break;
 
-			case 'mappable_but_forbidden_subdomain':
+			case 'not_mappable_forbidden_subdomain':
 				message = this.translate( 'Subdomains starting with \'www.\' cannot be mapped to a WordPress.com blog' );
 				break;
 
-			case 'mappable_but_mapped_domain':
+			case 'not_mappable_invalid_tld':
+			case 'invalid_query':
+				message = this.translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
+					args: { domain: domain }
+				} );
+				break;
+
+			case 'not_mappable_mapped_domain':
 				message = this.translate( 'This domain is already mapped to a WordPress.com site.' );
 				break;
 
-			case 'mappable_but_restricted_domain':
+			case 'not_mappable_restricted_domain':
 				message = this.translate(
 					'You cannot map another WordPress.com subdomain - try creating a new site or one of the custom domains below.'
 				);
+				break;
+
+			case 'not_mappable_recently_mapped':
+				message = this.translate( 'This domain has been recently mapped by a different user - please try again later.' );
+				break;
+
+			// Generic error message when domain is not mappable without an explicit unmappability reason
+			case 'not_mappable':
+				message = this.translate( 'This domain cannot be mapped.' );
 				break;
 
 			case 'empty_query':
@@ -608,19 +623,8 @@ const RegisterDomainStep = React.createClass( {
 				} );
 				break;
 
-			case 'mappable_but_invalid_tld':
-			case 'invalid_query':
-				message = this.translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
-					args: { domain: domain }
-				} );
-				break;
-
 			case 'server_error':
 				message = this.translate( 'Sorry, there was a problem processing your request. Please try again in a few minutes.' );
-				break;
-
-			case 'mappable_but_recently_mapped':
-				message = this.translate( 'This domain cannot currently be mapped.' );
 				break;
 
 			default:

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -605,7 +605,7 @@ const RegisterDomainStep = React.createClass( {
 				break;
 
 			case 'not_mappable_recently_mapped':
-				message = this.translate( 'This domain has been recently mapped by a different user - please try again later.' );
+				message = this.translate( 'This domain has been recently unmapped by a different user - please try again later.' );
 				break;
 
 			// Generic error message when domain is not mappable without an explicit unmappability reason

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -610,7 +610,7 @@ const RegisterDomainStep = React.createClass( {
 
 			// Generic error message when domain is not mappable without an explicit unmappability reason
 			case 'not_mappable':
-				message = this.translate( 'This domain cannot be mapped.' );
+				message = this.translate( 'Sorry, this domain cannot be mapped.' );
 				break;
 
 			case 'empty_query':

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -605,7 +605,8 @@ const RegisterDomainStep = React.createClass( {
 				break;
 
 			case 'not_mappable_recently_mapped':
-				message = this.translate( 'This domain has been recently unmapped by a different user - please try again later.' );
+				message = this.translate( 'This domain was recently in use by someone else and is not available to map yet. ' +
+					'Please try again later or contact support.' );
 				break;
 
 			// Generic error message when domain is not mappable without an explicit unmappability reason

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -38,17 +38,29 @@ function canRegister( domainName, onComplete ) {
 	}
 
 	wpcom.undocumented().isDomainAvailable( domainName, function( serverError, data ) {
-		var errorCode;
 		if ( serverError ) {
-			errorCode = serverError.error;
-		} else if ( ! data.is_available && data.is_mappable ) {
-			errorCode = 'not_available_but_mappable';
-		} else if ( ! data.is_mappable && data.unmappability_reason ) {
-			errorCode = `mappable_but_${data.unmappability_reason}`;
-		} else if ( ! data.is_registrable ) {
-			errorCode = 'not_registrable';
-		} else if ( ! data.is_available ) {
-			errorCode = 'not_available';
+			onComplete( new ValidationError( serverError.error ) );
+			return;
+		}
+
+		const {
+			is_available: isAvailable,
+			is_mappable: isMappable,
+			is_registrable: isRegistrable,
+			unmappability_reason: unmappabilityReason
+		} = data;
+
+		let errorCode;
+		if ( ! isAvailable ) {
+			if ( isMappable ) {
+				errorCode = 'not_available_but_mappable';
+			} else if ( unmappabilityReason ) {
+				errorCode = `not_mappable_${ unmappabilityReason }`;
+			} else {
+				errorCode = 'not_mappable';
+			}
+		} else if ( ! isRegistrable ) {
+			errorCode = 'available_but_not_registrable';
 		}
 
 		if ( errorCode ) {


### PR DESCRIPTION
This patch rearranges the logic surrounding the three flags returned by the `is-available` endpoint:
- `is_available` - domain is available, that is, it's not registered
- `is_registrable` - domain can be registered on WordPress.com. Meaning, we support that TLD, there are no blacklisted terms in the domain, etc.
- `is_mappable` - domain is _not_ available and there's no other reason why it can't be mapped (such as blacklisted term, domain already mapped to another WordPress.com site, etc.).

Hopefully, no cases were missed during this refactor. If anything, it should be more complete - for example, this patch fixes the bug that showed a domain as "unmappable" (because there was an "unmappability" reason for it), but ignored the fact that the domain is also available for registration.

I've also renamed the resulting "error codes" to be more truthful to what they represent. So instead of `mappable_but_reason`, it's now `not_mappable_reason`. Other flags were also renamed to make them all consistent - so now instead of an ambiguous `not_registrable` there's `available_but_not_registrable`, etc.

_Testing:_
Please try out different domains:
- valid domains
- valid subdomains
- invalid domains
- invalid subdomains
- valid domains already mapped to another WordPress.com site
- recently unmapped domains (by another user or the same user)
- domains containing blacklisted words
- etc.

/cc @aidvu @umurkontaci 
Hat tip to @dcoleonline for reporting this issue.
