### PR TITLE
Site Settings: Show Site Icon setting even when feature disabled

### DIFF
--- a/client/components/button/index.jsx
+++ b/client/components/button/index.jsx
@@ -5,7 +5,7 @@
  */
 import { PropTypes, createElement, PureComponent } from 'react';
 import classNames from 'classnames';
-import { omit } from 'lodash';
+import { omit, compact } from 'lodash';
 
 export default class Button extends PureComponent {
 	static propTypes = {
@@ -35,8 +35,15 @@ export default class Button extends PureComponent {
 			omitProps.push( 'target', 'rel' );
 		}
 
+		const props = omit( this.props, omitProps );
+
+		// Block referrers when external link
+		if ( props.target ) {
+			props.rel = compact( [ props.rel, 'noopener', 'noreferrer' ] ).join( ' ' );
+		}
+
 		return createElement( tag, {
-			...omit( this.props, omitProps ),
+			...props,
 			className: classNames( 'button', this.props.className, {
 				'is-compact': this.props.compact,
 				'is-primary': this.props.primary,

--- a/client/components/button/index.jsx
+++ b/client/components/button/index.jsx
@@ -5,7 +5,7 @@
  */
 import { PropTypes, createElement, PureComponent } from 'react';
 import classNames from 'classnames';
-import { omit, compact } from 'lodash';
+import { omit, uniq, compact } from 'lodash';
 
 export default class Button extends PureComponent {
 	static propTypes = {
@@ -39,7 +39,11 @@ export default class Button extends PureComponent {
 
 		// Block referrers when external link
 		if ( props.target ) {
-			props.rel = compact( [ props.rel, 'noopener', 'noreferrer' ] ).join( ' ' );
+			props.rel = uniq( compact( [
+				...( props.rel || '' ).split( ' ' ),
+				'noopener',
+				'noreferrer'
+			] ) ).join( ' ' );
 		}
 
 		return createElement( tag, {

--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -12,9 +12,6 @@ import Button from '../';
 import Gridicon from 'components/gridicon';
 
 describe( 'Button', () => {
-	const blank = '_blank';
-	const relString = 'noopener noreferrer';
-
 	describe( 'renders', () => {
 		it( 'with modifiers', () => {
 			const button = shallow( <Button scary primary borderless compact /> );
@@ -48,26 +45,36 @@ describe( 'Button', () => {
 	} );
 
 	describe( 'with href prop', () => {
-		const address = 'https://wordpress.com/';
-		const button = shallow( <Button href={ address } target={ blank } rel={ relString } type="submit" /> );
-
 		it( 'renders as a link', () => {
+			const button = shallow( <Button href="https://wordpress.com/" /> );
+
 			expect( button ).to.match( 'a' );
+			expect( button ).to.have.prop( 'href' ).equal( 'https://wordpress.com/' );
 		} );
 
 		it( 'ignores type prop and renders a link without type attribute', () => {
+			const button = shallow( <Button href="https://wordpress.com/" type="submit" /> );
+
 			expect( button ).to.not.have.prop( 'type' );
 		} );
 
 		it( 'including target and rel props renders a link with target and rel attributes', () => {
-			expect( button ).to.have.prop( 'href' ).equal( address );
-			expect( button ).to.have.prop( 'target' ).equal( blank );
-			expect( button ).to.have.prop( 'rel' ).equal( relString );
+			const button = shallow( <Button href="https://wordpress.com/" target="_blank" rel="noopener noreferrer" /> );
+
+			expect( button ).to.have.prop( 'target' ).equal( '_blank' );
+			expect( button ).to.have.prop( 'rel' ).equal( 'noopener noreferrer' );
+		} );
+
+		it( 'adds noopener noreferrer rel if target is specified', () => {
+			const button = shallow( <Button href="https://wordpress.com/" target="_blank" /> );
+
+			expect( button ).to.have.prop( 'target' ).equal( '_blank' );
+			expect( button ).to.have.prop( 'rel' ).equal( 'noopener noreferrer' );
 		} );
 	} );
 
 	describe( 'without href prop', () => {
-		const button = shallow( <Button target={ blank } rel={ relString } /> );
+		const button = shallow( <Button target="_blank" rel="noopener noreferrer" /> );
 
 		it( 'renders as a button', () => {
 			expect( button ).to.match( 'button' );
@@ -80,7 +87,7 @@ describe( 'Button', () => {
 
 		it( 'renders button with type attribute set to type prop if specified', () => {
 			const typeProp = 'submit';
-			const submitButton = shallow( <Button target={ blank } rel={ relString } type={ typeProp } /> );
+			const submitButton = shallow( <Button target="_blank" rel="noopener noreferrer" type={ typeProp } /> );
 
 			expect( submitButton ).to.have.prop( 'type' ).equal( typeProp );
 		} );

--- a/client/lib/route/add-query-args.js
+++ b/client/lib/route/add-query-args.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -10,6 +10,7 @@ import startsWith from 'lodash/startsWith';
  * Internal dependencies
  */
 import config from 'config';
+import addQueryArgs from 'lib/route/add-query-args';
 
 /**
  * Check if a URL is located outside of Calypso.
@@ -108,4 +109,6 @@ export default {
 	setUrlScheme,
 	urlToSlug,
 	slugToUrl,
+	// [TODO]: Move lib/route/add-query-args contents here
+	addQueryArgs
 };

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -10,15 +10,27 @@ import { localize } from 'i18n-calypso';
  */
 import SiteIcon from 'components/site-icon';
 import Button from 'components/button';
+import { isJetpackSite, getCustomizerUrl, getSiteAdminUrl } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isEnabled } from 'config';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import { addQueryArgs } from 'lib/url';
 
-function SiteIconSetting( { translate, siteId } ) {
+function SiteIconSetting( { translate, siteId, isJetpack, customizerUrl, generalOptionsUrl } ) {
+	let buttonProps;
 	if ( ! isEnabled( 'manage/site-settings/site-icon' ) ) {
-		return null;
+		buttonProps = { rel: 'external' };
+
+		if ( isJetpack ) {
+			buttonProps.href = addQueryArgs( {
+				'autofocus[section]': 'title_tagline'
+			}, customizerUrl );
+		} else {
+			buttonProps.href = generalOptionsUrl;
+			buttonProps.target = '_blank';
+		}
 	}
 
 	return (
@@ -26,7 +38,7 @@ function SiteIconSetting( { translate, siteId } ) {
 			<FormLabel>{ translate( 'Site Icon' ) }</FormLabel>
 			<div className="site-icon-setting__controls">
 				<SiteIcon size={ 64 } siteId={ siteId } />
-				<Button className="site-icon-setting__change-button">
+				<Button { ...buttonProps } className="site-icon-setting__change-button">
 					{ translate( 'Change site icon' ) }
 				</Button>
 			</div>
@@ -39,9 +51,19 @@ function SiteIconSetting( { translate, siteId } ) {
 
 SiteIconSetting.propTypes = {
 	translate: PropTypes.func,
-	siteId: PropTypes.number
+	siteId: PropTypes.number,
+	isJetpack: PropTypes.bool,
+	customizerUrl: PropTypes.string,
+	generalOptionsUrl: PropTypes.string
 };
 
-export default connect( ( state ) => ( {
-	siteId: getSelectedSiteId( state )
-} ) )( localize( SiteIconSetting ) );
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+		isJetpack: isJetpackSite( state, siteId ),
+		customizerUrl: getCustomizerUrl( state, siteId ),
+		generalOptionsUrl: getSiteAdminUrl( state, siteId, 'options-general.php' )
+	};
+} )( localize( SiteIconSetting ) );


### PR DESCRIPTION
Related: #8235
Related: #7616 

This pull request seeks to display the site icon setting on the site settings screen in all environments.

![Site Icon](https://cloud.githubusercontent.com/assets/1779930/18881684/4ebe86d2-84aa-11e6-822a-93a0acff8e4c.png)

The behavior of the button varies depending on the feature flag setting for the environment. If the work-in-progress Site Icon feature is disabled (all environments except development), then the button will lead to either the `options-general.php` wp-admin screen for WordPress.com sites, or the Customizer screen for Jetpack sites. This is consistent with the behavior of the edit icon link in the `<Site />` component.

**Testing instructions:**

Verify that the behavior of the button matches expectations for the feature flag setting and depending on whether the site is hosted on WordPress.com or running Jetpack. Because the site icon feature is enabled in development, you may need to restart your running Calypso process with `DISABLE_FEATURES=manage/site-settings/site-icon` to verify the behavior.
1. Navigate to the [site settings screen](http://calypso.localhost:3000/settings/general)
2. Select a site, if prompted
3. Note that the Site Icon setting is displayed
4. Click "Change site icon"
5. Note that...
   - If the feature flag is enabled, nothing happens
   - If the feature flag is disabled, you are redirected to the wp-admin settings screen
6. If redirected in step 5, note that...
   - You are directed to the general options screen for WordPress.com sites (Blavatar)
   - You are directed to the customizer for Jetpack sites, focused to site identity

**Caveats:**

The "return" URL behavior does not work in development because [only WordPress.com is whitelisted as a valid return host](https://github.com/Automattic/jetpack/blob/0ef64c0e8f05a57363c10723ba2b7b906e5c9834/modules/manage.php#L25-L32).

cc @bluefuton re: #7680 . Included in the changes here, I added behavior to check for the presence of a `target` prop on `<Button />` to include the referrer blocking `rel` attributes.
