### PR TITLE
Components: Refactor Accordion as ES6 component

### DIFF
--- a/client/components/accordion/README.md
+++ b/client/components/accordion/README.md
@@ -5,20 +5,18 @@ Accordion is a React component to display collapsible content panels.
 
 ## Usage
 
-At a minimum, you must provide a `title` for your Accordion, and a child or set of children to be shown in the panel.
+At a minimum, you must provide a `title` for your Accordion, and a child or set of children to be shown in the expanded panel.
 
 ```jsx
-var Accordion = require( 'components/accordion' );
+import Accordion from 'components/accordion';
 
-module.exports = React.createClass( {
-	render: function() {
-		return (
-			<Accordion title="Section One">
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum eget libero at pretium. Morbi hendrerit arcu mauris, laoreet dapibus est maximus nec. Sed volutpat, lorem semper porta efficitur, dui augue tempor ante, eget faucibus quam erat vitae velit.
-			</Accordion>
-		);
-	}
-} );
+export default function MyComponent() {
+	return (
+		<Accordion title="Section One">
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+		</Accordion>
+	);	
+}
 ```
 
 ## Props
@@ -29,4 +27,4 @@ The following props are available to customize the accordion:
 - `onToggle`: Function handler to invoke when the user toggles the accordion. The function will be passed a boolean indicating the expanded state after the toggle.
 - `title`: Main heading shown in the always-visible toggle button
 - `subtitle`: Subheading shown in the always-visible toggle button
-- `icon`: String or React element to be shown as an icon adjacent to the headings in the always-visible toggle button. A string will be assumed to be used as the Noticon class suffix for the icon element.
+- `icon`: React element to be shown as an icon adjacent to the headings in the always-visible toggle button.

--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -1,95 +1,61 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import { noop } from 'lodash';
 import classNames from 'classnames';
 
-module.exports = React.createClass( {
-	displayName: 'Accordion',
+export default class Accordion extends Component {
+	static propTypes = {
+		initialExpanded: PropTypes.bool,
+		onToggle: PropTypes.func,
+		title: PropTypes.string.isRequired,
+		subtitle: PropTypes.string,
+		icon: PropTypes.element
+	};
 
-	propTypes: {
-		initialExpanded: React.PropTypes.bool,
-		onToggle: React.PropTypes.func,
-		title: React.PropTypes.string.isRequired,
-		subtitle: React.PropTypes.string,
-		icon: React.PropTypes.oneOfType( [
-			React.PropTypes.string,
-			React.PropTypes.element
-		] )
-	},
+	static defaultProps = {
+		initialExpanded: false,
+		onToggle: noop
+	};
 
-	getInitialState: function() {
-		return {
-			isExpanded: this.props.initialExpanded
+	constructor( props ) {
+		super( ...arguments );
+
+		this.state = {
+			isExpanded: props.initialExpanded
 		};
-	},
+	}
 
-	getDefaultProps: function() {
-		return {
-			onToggle: noop
-		};
-	},
-
-	toggleExpanded: function() {
+	toggleExpanded = () => {
 		const isExpanded = ! this.state.isExpanded;
-
-		this.setState( {
-			isExpanded: isExpanded
-		} );
-
+		this.setState( { isExpanded } );
 		this.props.onToggle( isExpanded );
-	},
+	}
 
-	renderIcon: function() {
-		if ( ! this.props.icon ) {
-			return;
-		}
-
-		if ( 'string' === typeof this.props.icon ) {
-			return <span className={ classNames( 'accordion__icon', this.props.icon ) } />;
-		}
-
-		return <span className="accordion__icon">{ this.props.icon }</span>;
-	},
-
-	renderSubtitle: function() {
-		if ( this.props.subtitle ) {
-			return <span className="accordion__subtitle">{ this.props.subtitle }</span>;
-		}
-	},
-
-	renderHeader: function() {
-		const classes = classNames( 'accordion__header', {
-			'has-icon': !! this.props.icon,
-			'has-subtitle': !! this.props.subtitle
-		} );
-
-		return (
-			<header className={ classes }>
-				<button type="button" onTouchTap={ this.toggleExpanded } className="accordion__toggle">
-					{ this.renderIcon() }
-					<span className="accordion__title">{ this.props.title }</span>
-					{ this.renderSubtitle() }
-				</button>
-			</header>
-		);
-	},
-
-	render: function() {
-		const classes = classNames( 'accordion', this.props.className, {
-			'is-expanded': this.state.isExpanded
+	render() {
+		const { className, icon, title, subtitle, children } = this.props;
+		const classes = classNames( 'accordion', className, {
+			'is-expanded': this.state.isExpanded,
+			'has-icon': !! icon,
+			'has-subtitle': !! subtitle
 		} );
 
 		return (
 			<div className={ classes }>
-				{ this.renderHeader() }
-				<div ref="content" className="accordion__content">
+				<header className="accordion__header">
+					<button type="button" onTouchTap={ this.toggleExpanded } className="accordion__toggle">
+						{ icon && <span className="accordion__icon">{ icon }</span> }
+						<span className="accordion__title">{ title }</span>
+						{ subtitle && <span className="accordion__subtitle">{ subtitle }</span> }
+					</button>
+				</header>
+				<div className="accordion__content">
 					<div className="accordion__content-wrap">
-						{ this.props.children }
+						{ children }
 					</div>
 				</div>
 			</div>
 		);
 	}
-} );
+}

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -35,6 +35,11 @@ $accordion-background-expanded: $white;
 		transform: translateY( -50% );
 		color: lighten( $gray, 10% );
 	}
+
+	.accordion.has-subtitle & {
+		padding-top: ( $accordion-padding - $accordion-subtitle-height / 2 );
+		padding-bottom: ( $accordion-padding - $accordion-subtitle-height / 2 );
+	}
 }
 
 .accordion.is-expanded {
@@ -54,11 +59,6 @@ $accordion-background-expanded: $white;
 	}
 }
 
-.accordion__header.has-subtitle .accordion__toggle {
-	padding-top: ( $accordion-padding - $accordion-subtitle-height / 2 );
-	padding-bottom: ( $accordion-padding - $accordion-subtitle-height / 2 );
-}
-
 .accordion__icon {
 	position: absolute;
 		left: $accordion-padding;
@@ -75,11 +75,10 @@ $accordion-background-expanded: $white;
 .accordion__title,
 .accordion__subtitle {
 	display: block;
-}
 
-.accordion__header.has-icon .accordion__title,
-.accordion__header.has-icon .accordion__subtitle {
-	padding-left: 28px;
+	.accordion.has-icon & {
+		padding-left: 28px;
+	}
 }
 
 .accordion__subtitle {

--- a/client/components/accordion/test/index.jsx
+++ b/client/components/accordion/test/index.jsx
@@ -5,86 +5,95 @@ import { expect } from 'chai';
 import ReactDom from 'react-dom';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import { shallow, mount } from 'enzyme';
+import createReactTapEventPlugin from 'react-tap-event-plugin';
 
 /**
  * Internal dependencies
  */
-const Accordion = require( '../' );
+import useFakeDom from 'test/helpers/use-fake-dom';
+import Gridicon from 'components/gridicon';
+import Accordion from '../';
 
-describe( 'index', function() {
-	require( 'react-tap-event-plugin' )();
-	require( 'test/helpers/use-fake-dom' )();
-
-	afterEach( function() {
-		ReactDom.unmountComponentAtNode( document.body );
+describe( 'Accordion', function() {
+	before( () => {
+		// Unfortunately, there is no corresponding teardown for this plugin
+		createReactTapEventPlugin();
 	} );
 
 	it( 'should render as expected with a title and content', function() {
-		const tree = TestUtils.renderIntoDocument( <Accordion title="Section">Content</Accordion> ),
-			node = ReactDom.findDOMNode( tree );
+		const wrapper = shallow( <Accordion title="Section">Content</Accordion> );
 
-		expect( node.className ).to.equal( 'accordion' );
-		expect( tree.state.isExpanded ).to.not.be.ok;
-		expect( node.querySelector( '.accordion__header:not( .has-icon ):not( .has-subtitle )' ) ).to.be.an.instanceof( window.Element );
-		expect( node.querySelector( '.accordion__icon' ) ).to.be.null;
-		expect( node.querySelector( '.accordion__title' ).textContent ).to.equal( 'Section' );
-		expect( node.querySelector( '.accordion__subtitle' ) ).to.be.null;
-		expect( ReactDom.findDOMNode( tree.refs.content ).textContent ).to.equal( 'Content' );
+		expect( wrapper ).to.have.className( 'accordion' );
+		expect( wrapper ).to.have.state( 'isExpanded' ).be.false;
+		expect( wrapper ).to.not.have.className( 'has-icon' );
+		expect( wrapper ).to.not.have.className( 'has-subtitle' );
+		expect( wrapper ).to.not.have.descendants( '.accordion__icon' );
+		expect( wrapper.find( '.accordion__title' ) ).to.have.text( 'Section' );
+		expect( wrapper ).to.not.have.descendants( '.accordion__subtitle' );
+		expect( wrapper ).to.not.have.descendants( '.accordion__icon' );
+		expect( wrapper.find( '.accordion__content' ) ).to.have.text( 'Content' );
 	} );
 
-	it( 'should accept an icon prop to be rendered as a noticon', function() {
-		const tree = TestUtils.renderIntoDocument( <Accordion title="Section" icon="time">Content</Accordion> ),
-			node = ReactDom.findDOMNode( tree );
+	it( 'should accept an icon prop to be rendered', function() {
+		const wrapper = shallow( <Accordion title="Section" icon={ <Gridicon icon="time" /> }>Content</Accordion> );
 
-		expect( node.querySelector( '.accordion__header.has-icon:not( .has-subtitle )' ) ).to.be.an.instanceof( window.Element );
-		expect( node.querySelector( '.accordion__icon' ) ).to.be.an.instanceof( window.Element );
+		expect( wrapper ).to.have.className( 'has-icon' );
+		expect( wrapper.find( '.accordion__icon' ) ).to.have.descendants( Gridicon );
 	} );
 
 	it( 'should accept a subtitle prop to be rendered aside the title', function() {
-		const tree = TestUtils.renderIntoDocument( <Accordion title="Section" subtitle="Subtitle">Content</Accordion> ),
-			node = ReactDom.findDOMNode( tree );
+		const wrapper = shallow( <Accordion title="Section" subtitle="Subtitle">Content</Accordion> );
 
-		expect( node.querySelector( '.accordion__header.has-subtitle:not( .has-icon )' ) ).to.be.an.instanceof( window.Element );
-		expect( node.querySelector( '.accordion__subtitle' ).textContent ).to.equal( 'Subtitle' );
+		expect( wrapper ).to.have.className( 'has-subtitle' );
+		expect( wrapper.find( '.accordion__subtitle' ) ).to.have.text( 'Subtitle' );
 	} );
 
-	it( 'should toggle when clicked', function() {
-		const tree = TestUtils.renderIntoDocument( <Accordion title="Section">Content</Accordion> );
+	context( 'events', () => {
+		useFakeDom();
 
-		TestUtils.Simulate.touchTap( ReactDom.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'accordion__toggle' ) ) );
-
-		expect( tree.state.isExpanded ).to.be.ok;
-	} );
-
-	it( 'should accept an onToggle function handler to be invoked when toggled', function( done ) {
-		const tree = TestUtils.renderIntoDocument( <Accordion title="Section" onToggle={ finishTest }>Content</Accordion> );
-
-		TestUtils.Simulate.touchTap( ReactDom.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'accordion__toggle' ) ) );
-
-		function finishTest( isExpanded ) {
-			expect( isExpanded ).to.be.ok;
-
-			process.nextTick( function() {
-				expect( tree.state.isExpanded ).to.be.ok;
-				done();
-			} );
+		function simulateTouchTap( wrapper ) {
+			TestUtils.Simulate.touchTap( ReactDom.findDOMNode( wrapper.find( '.accordion__toggle' ).node ) );
 		}
-	} );
 
-	it( 'should always use the initialExpanded prop, if specified', function( done ) {
-		const tree = TestUtils.renderIntoDocument(
-			<Accordion initialExpanded={ true } title="Section" onToggle={ finishTest }>Content</Accordion>
-		);
+		it( 'should toggle when clicked', function() {
+			const wrapper = mount( <Accordion title="Section">Content</Accordion> );
 
-		TestUtils.Simulate.touchTap( ReactDom.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'accordion__toggle' ) ) );
+			simulateTouchTap( wrapper );
 
-		function finishTest( isExpanded ) {
-			expect( isExpanded ).to.not.be.ok;
+			expect( wrapper ).to.have.state( 'isExpanded' ).be.true;
+		} );
 
-			process.nextTick( function() {
-				expect( tree.state.isExpanded ).to.not.be.ok;
-				done();
-			} );
-		}
+		it( 'should accept an onToggle function handler to be invoked when toggled', function( done ) {
+			const wrapper = mount( <Accordion title="Section" onToggle={ finishTest }>Content</Accordion> );
+
+			simulateTouchTap( wrapper );
+
+			function finishTest( isExpanded ) {
+				expect( isExpanded ).to.be.true;
+
+				process.nextTick( function() {
+					expect( wrapper ).to.have.state( 'isExpanded' ).be.true;
+					done();
+				} );
+			}
+		} );
+
+		it( 'should always use the initialExpanded prop, if specified', function( done ) {
+			const wrapper = mount(
+				<Accordion initialExpanded={ true } title="Section" onToggle={ finishTest }>Content</Accordion>
+			);
+
+			simulateTouchTap( wrapper );
+
+			function finishTest( isExpanded ) {
+				expect( isExpanded ).to.be.false;
+
+				process.nextTick( function() {
+					expect( wrapper ).to.have.state( 'isExpanded' ).be.false;
+					done();
+				} );
+			}
+		} );
 	} );
 } );


### PR DESCRIPTION
Related: #3277

This pull request seeks to refactor the `<Accordion />` component as an ES6 component, update its tests to using [`enzyme`](https://github.com/airbnb/enzyme) shallow rendering where possible, and removing a deprecated `icon` string prop (previously used with Noticon).

Originally I'd planned for this branch to satisfy #3277 by adding a status icon to the accordion component, but quickly realized that the refactoring had become substantial enough to live as its own pull request. A subsequent pull request will add the status icon.

__Testing instructions:__

Verify that there is no change in behavior or appearance in accordions:

http://calypso.localhost:3000/devdocs/design/accordion

If feeling ambitious, confirm that there are no instances of icon string prop anywhere in codebase (I'd used regex `<Accordion[^>]+icon="[^>+]>` mass file search).