### PR TITLE
Reader: Add in better post permalink tracking.

### DIFF
--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -9,19 +9,18 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import ExternalLink from 'components/external-link';
-import { recordPermalinkClick, recordGaEvent } from 'reader/stats';
+import { recordPermalinkClick } from 'reader/stats';
 import PostTime from 'reader/post-time';
 import ReaderFullPostHeaderTags from './header-tags';
 import Gridicon from 'components/gridicon';
 
 const ReaderFullPostHeader = ( { post } ) => {
 	const handlePermalinkClick = ( { } ) => {
-		recordPermalinkClick( 'full_post_title' );
+		recordPermalinkClick( 'full_post_title', post );
 	};
 
-	const recordDateClick = ( { } ) => {
-		recordPermalinkClick( 'timestamp' );
-		recordGaEvent( 'Clicked Post Permalink', 'timestamp' );
+	const recordDateClick = () => {
+		recordPermalinkClick( 'timestamp', post );
 	};
 
 	const classes = { 'reader-full-post__header': true };

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -20,7 +20,7 @@ const ReaderFullPostHeader = ( { post } ) => {
 	};
 
 	const recordDateClick = () => {
-		recordPermalinkClick( 'timestamp', post );
+		recordPermalinkClick( 'timestamp_full_post', post );
 	};
 
 	const classes = { 'reader-full-post__header': true };

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -32,7 +32,7 @@ import DailyPostButton from 'reader/daily-post';
 import { shouldShowLikes } from 'reader/like-helper';
 import { shouldShowComments } from 'blocks/comments/helper';
 import CommentButton from 'blocks/comment-button';
-import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrackForPost, recordPermalinkClick } from 'reader/stats';
 import Comments from 'blocks/comments';
 import scrollTo from 'lib/scroll-to';
 import PostExcerptLink from 'reader/post-excerpt-link';
@@ -59,6 +59,7 @@ export class FullPostView extends React.Component {
 		[
 			'handleBack',
 			'handleCommentClick',
+			'handleVisitSiteClick',
 			'handleLike',
 			'handleRelatedPostFromSameSiteClicked',
 			'handleRelatedPostFromOtherSiteClicked',
@@ -155,6 +156,10 @@ export class FullPostView extends React.Component {
 		recordTrackForPost( 'calypso_reader_related_post_from_same_site_clicked', this.props.post );
 	}
 
+	handleVisitSiteClick() {
+		recordPermalinkClick( 'full_post_visit_link', this.props.post );
+	}
+
 	handleRelatedPostFromOtherSiteClicked() {
 		recordTrackForPost( 'calypso_reader_related_post_from_other_site_clicked', this.props.post );
 	}
@@ -246,7 +251,8 @@ export class FullPostView extends React.Component {
 			classes[ 'feed-' + post.feed_ID ] = true;
 		}
 
-		/*eslint-disable react/no-danger*/
+		/*eslint-disable react/no-danger */
+		/*eslint-disable react/jsx-no-target-blank */
 		return (
 			<ReaderMain className={ classNames( classes ) }>
 				{ post && post.feed_ID && <QueryReaderFeed feedId={ post.feed_ID } /> }
@@ -258,7 +264,7 @@ export class FullPostView extends React.Component {
 					</Button>
 				</div>
 				<div className="reader-full-post__visit-site-container">
-					<ExternalLink icon={ true } href={ post.URL }>
+					<ExternalLink icon={ true } href={ post.URL } onClick={ this.handleVisitSiteClick } target="_blank">
 						<span className="reader-full-post__visit-site-label">{ translate( 'Visit Site' ) }</span>
 					</ExternalLink>
 				</div>

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -27,6 +27,10 @@ const ReaderPostActions = ( { translate, post, site, onCommentClick, showEdit, s
 		stats.recordTrackForPost( 'calypso_reader_edit_post_clicked', post );
 	};
 
+	function onPermalinkVisit() {
+		stats.recordPermalinkClick( 'card', post );
+	}
+
 	const listClassnames = classnames( 'reader-post-actions', className );
 
 	/* eslint-disable react/jsx-no-target-blank */
@@ -34,7 +38,12 @@ const ReaderPostActions = ( { translate, post, site, onCommentClick, showEdit, s
 		<ul className={ listClassnames }>
 			{ showVisit &&
 				<li className="reader-post-actions__item reader-post-actions__visit">
-					<ExternalLink href={ post.URL } target="_blank" icon={ true } showIconFirst={ true } iconSize={ iconSize }>
+					<ExternalLink href={ post.URL }
+						target="_blank"
+						icon={ true }
+						showIconFirst={ true }
+						iconSize={ iconSize }
+						onClick={ onPermalinkVisit }>
 						<span className="reader-post-actions__visit-label">{ translate( 'Visit' ) }</span>
 					</ExternalLink>
 				</li>

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -43,7 +43,7 @@ class PostByline extends React.Component {
 	}
 
 	recordDateClick = () => {
-		recordPermalinkClick( 'timestamp', this.props.post );
+		recordPermalinkClick( 'timestamp_card', this.props.post );
 	}
 
 	render() {

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -42,7 +42,7 @@ class PostByline extends React.Component {
 		} );
 	}
 
-	recordDateClick() {
+	recordDateClick = () => {
 		recordPermalinkClick( 'timestamp', this.props.post );
 	}
 

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -43,8 +43,7 @@ class PostByline extends React.Component {
 	}
 
 	recordDateClick() {
-		recordPermalinkClick( 'timestamp' );
-		recordGaEvent( 'Clicked Post Permalink', 'timestamp' );
+		recordPermalinkClick( 'timestamp', this.props.post );
 	}
 
 	render() {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -57,8 +57,7 @@ export default class RefreshPostCard extends React.Component {
 		// if the click has modifier or was not primary, ignore it
 		if ( event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
 			if ( closest( event.target, '.reader-post-card__title-link', true, rootNode ) ) {
-				stats.recordPermalinkClick( 'card_title_with_modifier' );
-				stats.recordGaEvent( 'Clicked Post Permalink with Modifier' );
+				stats.recordPermalinkClick( 'card_title_with_modifier', this.props.post );
 			}
 			return;
 		}

--- a/client/reader/full-post/main.jsx
+++ b/client/reader/full-post/main.jsx
@@ -135,7 +135,7 @@ FullPostView = React.createClass( {
 	},
 
 	handlePermalinkClick: function() {
-		stats.recordPermalinkClick( 'full_post_title' );
+		stats.recordPermalinkClick( 'full_post_title', this.props.post );
 	},
 
 	pickSite: function( event ) {

--- a/client/reader/post-byline/index.jsx
+++ b/client/reader/post-byline/index.jsx
@@ -20,12 +20,6 @@ import {
 
 class PostByline extends React.Component {
 
-	constructor( ) {
-		super( );
-		this.recordTagClick = this.recordTagClick.bind( this );
-		this.recordAuthorClick = this.recordAuthorClick.bind( this );
-	}
-
 	static propTypes = {
 		post: React.PropTypes.object.isRequired,
 		site: React.PropTypes.object,
@@ -38,7 +32,7 @@ class PostByline extends React.Component {
 		isDiscoverPost: false
 	}
 
-	recordTagClick() {
+	recordTagClick = () => {
 		recordAction( 'click_tag' );
 		recordGaEvent( 'Clicked Tag Link' );
 		recordTrackForPost( 'calypso_reader_tag_clicked', this.props.post, {
@@ -46,12 +40,11 @@ class PostByline extends React.Component {
 		} );
 	}
 
-	recordDateClick() {
-		recordPermalinkClick( 'timestamp' );
-		recordGaEvent( 'Clicked Post Permalink', 'timestamp' );
+	recordDateClick = () => {
+		recordPermalinkClick( 'timestamp', this.props.post );
 	}
 
-	recordAuthorClick() {
+	recordAuthorClick = () => {
 		recordAction( 'click_author' );
 		recordGaEvent( 'Clicked Author Link' );
 		recordTrackForPost( 'calypso_reader_author_link_clicked', this.props.post );

--- a/client/reader/post-byline/test/index.jsx
+++ b/client/reader/post-byline/test/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { spy } from 'sinon';
 import { each, omit } from 'lodash';
 
@@ -74,10 +74,6 @@ describe( 'PostByline', () => {
 			it( 'records permalink clicks', () => {
 				assert.isTrue( statsSpies.recordPermalinkClick.calledWith( 'timestamp' ) );
 			} );
-
-			it( 'records GA event', () => {
-				assert.isTrue( statsSpies.recordGaEvent.calledWith( 'Clicked Post Permalink', 'timestamp' ) );
-			} );
 		} );
 
 		context( 'author click', () => {
@@ -90,7 +86,7 @@ describe( 'PostByline', () => {
 			} );
 
 			it( 'records GA event', () =>{
-				assert.isTrue( statsSpies.recordGaEvent.calledWith( 'Clicked Author Link' ) );
+				expect( statsSpies.recordGaEvent ).to.have.been.calledWith( 'Clicked Author Link' );
 			} );
 
 			it( 'records track for post', () => {

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -8,8 +8,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import {
-	recordPermalinkClick,
-	recordGaEvent
+	recordPermalinkClick
 } from 'reader/stats';
 
 const PostExcerptLink = React.createClass( {
@@ -34,7 +33,6 @@ const PostExcerptLink = React.createClass( {
 
 	recordClick() {
 		recordPermalinkClick( 'summary_card_site_name' );
-		recordGaEvent( 'Clicked Excerpt Notice Permalink' );
 	},
 
 	render() {

--- a/client/reader/post-permalink/index.jsx
+++ b/client/reader/post-permalink/index.jsx
@@ -16,7 +16,6 @@ var PostPermalink = React.createClass( {
 
 	recordClick: function() {
 		stats.recordPermalinkClick( 'card_visit_link' );
-		stats.recordGaEvent( 'Clicked Card Permalink' );
 	},
 
 	render: function() {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -18,14 +18,21 @@ export function recordGaEvent( action, label, value ) {
 	ga.recordEvent( 'Reader', action, label, value );
 }
 
-export function recordPermalinkClick( where ) {
+export function recordPermalinkClick( where, post ) {
 	mc.bumpStat( {
 		reader_actions: 'visited_post_permalink',
 		reader_permalink_source: where
 	} );
-	recordTrack( 'calypso_reader_permalink_click', {
+	recordGaEvent( 'Clicked Post Permalink', where )
+	const trackEvent = 'calypso_reader_permalink_click';
+	const args = {
 		source: where
-	} );
+	};
+	if ( post ) {
+		recordTrackForPost( trackEvent, post, args );
+	} else {
+		recordTrack( trackEvent, args );
+	}
 }
 
 function getLocation() {
@@ -108,6 +115,7 @@ tracksRailcarEventWhitelist
 	.add( 'calypso_reader_startcard_clicked' )
 	.add( 'calypso_reader_searchcard_clicked' )
 	.add( 'calypso_reader_author_link_clicked' )
+	.add( 'calypso_reader_permalink_click' )
 ;
 
 export function recordTracksRailcar( action, eventName, railcar ) {

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -208,8 +208,7 @@ const Post = React.createClass( {
 		// if the click has modifier or was not primary, ignore it
 		if ( event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
 			if ( closest( event.target, '.reader__post-title-link', true, rootNode ) ) {
-				stats.recordPermalinkClick( 'card_title_with_modifier' );
-				stats.recordGaEvent( 'Clicked Post Permalink with Modifier' );
+				stats.recordPermalinkClick( 'card_title_with_modifier', this.props.post );
 			}
 			return;
 		}


### PR DESCRIPTION
Fixes #8791

This adds event tracking for the new `visit site` link from #8907 and refactors permalink tracking to take an optional `post` object and updates all the calls into `recordPermalink` to pass a post if it can. 

I also moved the GA event into `recordPermalink` since it was effectively the same everywhere and we can differentiate based on the `where` param.

To test, turn on the debugger using `localStorage.debug = 'calypso:analytics'` in the console and try out the various post permalink links in the reader, both with the refreshed streams and the current streams. Toggle them off with `DISABLE_FEATURES=reader/refresh/stream make run`