### PR TITLE
Framework: Update abtest to remove site list usage

### DIFF
--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -32,8 +32,6 @@ You should include the following information:
 
 There are also several optional configuration settings available:
 
-* `excludeJetpackSites` - A/B tests run where a Jetpack site is selected will not be eligible for the test. Default is false (Jetpack sites are eligible).
-* `excludeSitesWithPaidPlan` - A/B tests run on sites with a paid plan is selected will not be eligible for the test. Default is false (sites with paid plans are eligible).
 * `allowAnyLocale` - Relaxes the locale restraint on the A/B test, allowing users of any locale to be allocated to a test.  Don't forget: this means strings will need to be translated.
 
 Next, in your code, require the `abtest` module's `abtest` method:


### PR DESCRIPTION
Part of #8726 this removes the siteList.getSelectedSite() usage in this library.

~~Note that I'm still working through if the callee should always pass through needed data, versus exposing the redux store to this library.~~

As @nb suggested, in this particular library the `excludeJetpackSites` and `excludeSitesWithPaidPlan` do not appear to be used on any active tests. With this change I've removed them. 

In the future, any components needing complex test activation logic can work around this by checking for the abtest condition last to avoid triggering an ab test start event in an incorrect group:
```javascript
condition1 &&
condition2 &&
abtest( 'experiment' )
```

### Testing Instructions
- No functional changes
- Set debug to `localStorage.debug = 'calypso:abtests';`
- Existing abtests fire

cc @artpi @dmsnell @aduth @rralian @lamosty 