### PR TITLE
Prevent expanding of search over suggestions.

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -17,6 +17,10 @@
 		}
 	}
 
+	.search.is-expanded-to-container {
+		height: 58px;
+	}
+
 	.section-nav {
 		margin: 0;
 	}


### PR DESCRIPTION
`Search` is-expanded-to-container class behavior covers `Suggestions` list/welcome:
![image](https://cloud.githubusercontent.com/assets/17271089/19667029/99ebbbde-9a4e-11e6-995d-b152ae9b4315.png)
After the fix:
![image](https://cloud.githubusercontent.com/assets/17271089/19667055/d90f9e20-9a4e-11e6-8940-3decf634d298.png)
