### PR TITLE
Signup: Improve the `developers` signup flow for simplicity and speed.

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -39,10 +39,6 @@ import support from 'lib/url/support';
 
 const domains = wpcom.domains();
 
-// max amount of domain suggestions we should fetch/display
-const SUGGESTION_QUANTITY = 10;
-const INITIAL_SUGGESTION_QUANTITY = 2;
-
 const analytics = analyticsMixin( 'registerDomain' ),
 	searchVendor = 'domainsbot';
 
@@ -57,7 +53,7 @@ function getQueryObject( props ) {
 	}
 	return {
 		query: props.selectedSite.domain.split( '.' )[ 0 ],
-		quantity: SUGGESTION_QUANTITY,
+		quantity: this.props.suggestionQuantity,
 		vendor: searchVendor,
 		includeSubdomain: props.includeWordPressDotCom,
 		surveyVertical: props.surveyVertical,
@@ -114,12 +110,16 @@ const RegisterDomainStep = React.createClass( {
 		surveyVertical: React.PropTypes.string,
 		includeWordPressDotCom: React.PropTypes.bool,
 		includeDotBlogSubdomain: React.PropTypes.bool,
+		suggestionQuantity: React.PropTypes.number,
+		initialSuggestionQuantity: React.PropTypes.number
 	},
 
 	getDefaultProps: function() {
 		return {
 			onDomainsAvailabilityChange: noop,
-			analyticsSection: 'domains'
+			analyticsSection: 'domains',
+			suggestionQuantity: 10,
+			initialSuggestionQuantity: 2
 		};
 	},
 
@@ -367,9 +367,10 @@ const RegisterDomainStep = React.createClass( {
 					} );
 				},
 				callback => {
+
 					const query = {
 							query: domain,
-							quantity: SUGGESTION_QUANTITY,
+							quantity: this.props.suggestionQuantity,
 							include_wordpressdotcom: this.props.includeWordPressDotCom,
 							include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 							vendor: searchVendor,
@@ -426,12 +427,12 @@ const RegisterDomainStep = React.createClass( {
 			suggestions;
 
 		if ( this.isLoadingSuggestions() ) {
-			domainRegistrationSuggestions = times( INITIAL_SUGGESTION_QUANTITY + 1, function( n ) {
+			domainRegistrationSuggestions = times( this.props.initialSuggestionQuantity + 1, function( n ) {
 				return <DomainSuggestion.Placeholder key={ 'suggestion-' + n } />;
 			} );
 		} else {
 			// only display two suggestions initially
-			suggestions = this.props.defaultSuggestions ? this.props.defaultSuggestions.slice( 0, INITIAL_SUGGESTION_QUANTITY ) : [];
+			suggestions = this.props.defaultSuggestions ? this.props.defaultSuggestions.slice( 0, this.props.initialSuggestionQuantity ) : [];
 
 			domainRegistrationSuggestions = suggestions.map( function( suggestion ) {
 				return (
@@ -509,7 +510,7 @@ const RegisterDomainStep = React.createClass( {
 				products={ this.props.products }
 				selectedSite={ this.props.selectedSite }
 				offerMappingOption={ this.props.offerMappingOption }
-				placeholderQuantity={ SUGGESTION_QUANTITY }
+				placeholderQuantity={ this.props.suggestionQuantity }
 				cart={ this.props.cart } />
 		);
 	},

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -175,7 +175,7 @@ const flows = {
 	},
 
 	developer: {
-		steps: [ 'themes', 'site', 'user' ],
+		steps: [ 'themes', 'domains', 'user' ],
 		destination: '/devdocs/welcome',
 		description: 'Signup flow for developers in developer environment',
 		lastModified: '2015-11-23'

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -178,7 +178,7 @@ const flows = {
 		steps: [ 'domains-only', 'user' ],
 		destination: '/devdocs/welcome',
 		description: 'Signup flow for developers in developer environment',
-		lastModified: '2016-10-26'
+		lastModified: '2016-12-06'
 	},
 
 	pressable: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -175,10 +175,10 @@ const flows = {
 	},
 
 	developer: {
-		steps: [ 'themes', 'domains', 'user' ],
+		steps: [ 'domains-only', 'user' ],
 		destination: '/devdocs/welcome',
 		description: 'Signup flow for developers in developer environment',
-		lastModified: '2015-11-23'
+		lastModified: '2016-06-22'
 	},
 
 	pressable: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -178,7 +178,7 @@ const flows = {
 		steps: [ 'domains-only', 'user' ],
 		destination: '/devdocs/welcome',
 		description: 'Signup flow for developers in developer environment',
-		lastModified: '2016-06-22'
+		lastModified: '2016-10-26'
 	},
 
 	pressable: {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -76,7 +76,11 @@ const DomainsStep = React.createClass( {
 	},
 
 	getThemeSlug: function() {
-		return this.props.queryObject ? this.props.queryObject.theme : undefined;
+		if ( this.props.queryObject && this.props.queryObject.theme ) {
+			return this.props.queryObject.theme;
+		}
+
+		return 'developer' === this.props.flowName ? 'twentysixteen' : undefined;
 	},
 
 	getThemeArgs: function() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -178,7 +178,7 @@ const DomainsStep = React.createClass( {
 				mapDomainUrl={ this.getMapDomainUrl() }
 				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
 				onSave={ this.handleSave.bind( this, 'domainForm' ) }
-				offerMappingOption
+				offerMappingOption={ ! isDeveloperFlow }
 				analyticsSection="signup"
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				includeWordPressDotCom

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	{ connect } = require( 'react-redux' ),
 	defer = require( 'lodash/defer' ),
 	page = require( 'page' ),
 	i18n = require( 'i18n-calypso' );
@@ -13,7 +14,7 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	productsList = require( 'lib/products-list' )(),
 	cartItems = require( 'lib/cart-values' ).cartItems,
 	SignupActions = require( 'lib/signup/actions' ),
-	MapDomain = require( 'components/domains/map-domain' ),
+	MapDomainStep = require( 'components/domains/map-domain-step' ),
 	RegisterDomainStep = require( 'components/domains/register-domain-step' ),
 	{ getCurrentUser, currentUserHasFlag } = require( 'state/current-user/selectors' ),
 	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
@@ -23,6 +24,9 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	abtest = require( 'lib/abtest' ).abtest;
 
 import Notice from 'components/notice';
+
+const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
+	mapDomainAnalytics = analyticsMixin( 'mapDomain' );
 
 const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
 	mapDomainAnalytics = analyticsMixin( 'mapDomain' );
@@ -77,7 +81,7 @@ const DomainsStep = React.createClass( {
 
 	getThemeArgs: function() {
 		const themeSlug = this.getThemeSlug(),
-			themeSlugWithRepo = this.getThemeSlugWithRepo(),
+			themeSlugWithRepo = this.getThemeSlugWithRepo( themeSlug ),
 			themeItem = this.isPurchasingTheme()
 			? cartItems.themeItem( themeSlug, 'signup-with-theme' )
 			: undefined;
@@ -85,13 +89,12 @@ const DomainsStep = React.createClass( {
 		return { themeSlug, themeSlugWithRepo, themeItem };
 	},
 
-	getThemeSlugWithRepo: function() {
-		const themeSlug = this.getThemeSlug();
+	getThemeSlugWithRepo: function( themeSlug ) {
 		if ( ! themeSlug ) {
 			return undefined;
 		}
-		// Only allow free themes for now; a valid theme value here (free or premium) will cause a theme_switch by Headstart.
-		return this.isPurchasingTheme() ? undefined : 'pub/' + themeSlug;
+		const repo = this.isPurchasingTheme() ? 'premium' : 'pub';
+		return `${repo}/${themeSlug}`;
 	},
 
 	submitWithDomain: function( googleAppsCartItem ) {
@@ -126,6 +129,8 @@ const DomainsStep = React.createClass( {
 		const domainItem = cartItems.domainMapping( { domain } );
 		const isPurchasingItem = true;
 
+		mapDomainAnalytics.recordEvent( 'addDomainButtonClick', domain, 'signup' );
+
 		SignupActions.submitSignupStep( Object.assign( {
 			processingMessage: this.translate( 'Adding your domain mapping' ),
 			stepName: this.props.stepName,
@@ -149,8 +154,7 @@ const DomainsStep = React.createClass( {
 
 	domainForm: function() {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
-		const isPlansOnlyTest = abtest( 'domainsWithPlansOnly' ) === 'plansOnly';
-		const isDeveloperFlow = 'developer' === this.props.flowName;
+
 		return (
 			<RegisterDomainStep
 				path={ this.props.path }
@@ -161,9 +165,9 @@ const DomainsStep = React.createClass( {
 				mapDomainUrl={ this.getMapDomainUrl() }
 				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
 				onSave={ this.handleSave.bind( this, 'domainForm' ) }
-				offerMappingOption={ ! isDeveloperFlow }
+				offerMappingOption
 				analyticsSection="signup"
-				withPlansOnly={ isPlansOnlyTest }
+				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				includeWordPressDotCom
 				includeDotBlogSubdomain={ ( this.props.flowName === 'subdomain' ) ||
 					( abtest( 'domainDotBlogSubdomain' ) === 'includeDotBlogSubdomain' ) }
@@ -180,14 +184,14 @@ const DomainsStep = React.createClass( {
 
 		return (
 			<div className="domains-step__section-wrapper">
-				<MapDomain
+				<MapDomainStep
 					initialState={ initialState }
 					path={ this.props.path }
-					onAddDomain={ this.handleAddDomain }
-					onAddMapping={ this.handleAddMapping.bind( this, 'mappingForm' ) }
+					onRegisterDomain={ this.handleAddDomain }
+					onMapDomain={ this.handleAddMapping.bind( this, 'mappingForm' ) }
 					onSave={ this.handleSave.bind( this, 'mappingForm' ) }
-					productsList={ productsList }
-					withPlansOnly={ abtest( 'domainsWithPlansOnly' ) === 'plansOnly' }
+					products={ productsList.get() }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					initialQuery={ initialQuery }
 					analyticsSection="signup" />
 			</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -28,9 +28,6 @@ import Notice from 'components/notice';
 const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
 	mapDomainAnalytics = analyticsMixin( 'mapDomain' );
 
-const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
-	mapDomainAnalytics = analyticsMixin( 'mapDomain' );
-
 const DomainsStep = React.createClass( {
 	showDomainSearch: function() {
 		page( signupUtils.getStepUrl( this.props.flowName, this.props.stepName, this.props.locale ) );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -166,7 +166,7 @@ const DomainsStep = React.createClass( {
 
 	domainForm: function() {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
-		const isDeveloperFlow = this.props.flowName;
+		const isDeveloperFlow = Boolean( 'developer' === this.props.flowName );
 
 		return (
 			<RegisterDomainStep

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -152,6 +152,14 @@ const DomainsStep = React.createClass( {
 		} );
 	},
 
+	getSuggestion: function() {
+		if ( this.props.queryObject && this.props.queryObject.new ) {
+			return this.props.queryObject.new;
+		}
+
+		return 'developer' === this.props.flowName ? 'calypsodev' : '';
+	},
+
 	domainForm: function() {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
 
@@ -174,7 +182,7 @@ const DomainsStep = React.createClass( {
 				isSignupStep
 				surveyVertical={ this.props.surveyVertical }
 				showExampleSuggestions={ ! isDeveloperFlow }
-				suggestion={ this.props.queryObject ? this.props.queryObject.new : '' } />
+				suggestion={ this.getSuggestion() } />
 		);
 	},
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -166,6 +166,7 @@ const DomainsStep = React.createClass( {
 
 	domainForm: function() {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
+		const isDeveloperFlow = this.props.flowName;
 
 		return (
 			<RegisterDomainStep
@@ -186,6 +187,8 @@ const DomainsStep = React.createClass( {
 				isSignupStep
 				surveyVertical={ this.props.surveyVertical }
 				showExampleSuggestions={ ! isDeveloperFlow }
+				suggestionQuantity={ isDeveloperFlow ? 1 : undefined }
+				initialSuggestionQuantity={ isDeveloperFlow ? 0 : undefined }
 				suggestion={ this.getSuggestion() } />
 		);
 	},


### PR DESCRIPTION
Continuation of #6008.

By removing the `themes` step and simplifying the `domains` step, developers will be able to move through registration and get going as quick as possible.
