### PR TITLE
Add Survey Vertical to domains step

### DIFF
--- a/client/components/data/query-domains-suggestions/index.jsx
+++ b/client/components/data/query-domains-suggestions/index.jsx
@@ -17,7 +17,7 @@ function getQueryObject( props ) {
 		vendor,
 		quantity,
 		include_wordpressdotcom: includeSubdomain,
-		survey_vertical: surveyVertical,
+		vertical: surveyVertical,
 	};
 }
 

--- a/client/components/data/query-domains-suggestions/index.jsx
+++ b/client/components/data/query-domains-suggestions/index.jsx
@@ -11,12 +11,13 @@ import { isRequestingDomainsSuggestions } from 'state/domains/suggestions/select
 import { requestDomainsSuggestions } from 'state/domains/suggestions/actions';
 
 function getQueryObject( props ) {
-	const { query, vendor, quantity, includeSubdomain } = props;
+	const { query, vendor, quantity, includeSubdomain, surveyVertical } = props;
 	return {
 		query,
 		vendor,
 		quantity,
-		include_wordpressdotcom: includeSubdomain
+		include_wordpressdotcom: includeSubdomain,
+		survey_vertical: surveyVertical,
 	};
 }
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -59,7 +59,8 @@ function getQueryObject( props ) {
 		query: props.selectedSite.domain.split( '.' )[ 0 ],
 		quantity: SUGGESTION_QUANTITY,
 		vendor: searchVendor,
-		includeSubdomain: props.includeWordPressDotCom
+		includeSubdomain: props.includeWordPressDotCom,
+		surveyVertical: props.surveyVertical,
 	};
 }
 
@@ -109,7 +110,8 @@ const RegisterDomainStep = React.createClass( {
 		basePath: React.PropTypes.string.isRequired,
 		suggestion: React.PropTypes.string,
 		domainsWithPlansOnly: React.PropTypes.bool,
-		isSignupStep: React.PropTypes.bool
+		isSignupStep: React.PropTypes.bool,
+		surveyVertical: React.PropTypes.string,
 	},
 
 	getDefaultProps: function() {
@@ -346,7 +348,8 @@ const RegisterDomainStep = React.createClass( {
 							query: domain,
 							quantity: SUGGESTION_QUANTITY,
 							include_wordpressdotcom: this.props.includeWordPressDotCom,
-							vendor: searchVendor
+							vendor: searchVendor,
+							survey_vertical: this.props.surveyVertical,
 						},
 						timestamp = Date.now();
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -349,7 +349,7 @@ const RegisterDomainStep = React.createClass( {
 							quantity: SUGGESTION_QUANTITY,
 							include_wordpressdotcom: this.props.includeWordPressDotCom,
 							vendor: searchVendor,
-							survey_vertical: this.props.surveyVertical,
+							vertical: this.props.surveyVertical,
 						},
 						timestamp = Date.now();
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -20,6 +20,7 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	Notice = require( 'components/notice' ),
 	{ getCurrentUser, currentUserHasFlag } = require( 'state/current-user/selectors' ),
 	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
+	{ getSurveyVertical } = require( 'state/signup/steps/survey/selectors.js' ),
 	analyticsMixin = require( 'lib/mixins/analytics' ),
 	signupUtils = require( 'signup/utils' );
 
@@ -197,6 +198,7 @@ const DomainsStep = React.createClass( {
 				includeWordPressDotCom
 				isSignupStep
 				showExampleSuggestions
+				surveyVertical={ this.props.surveyVertical }
 				suggestion={ this.props.queryObject ? this.props.queryObject.new : '' } />
 		);
 	},
@@ -268,6 +270,7 @@ const DomainsStep = React.createClass( {
 module.exports = connect( ( state ) => {
 	return {
 		// no user = DOMAINS_WITH_PLANS_ONLY
-		domainsWithPlansOnly: getCurrentUser( state ) ? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ) : true
+		domainsWithPlansOnly: getCurrentUser( state ) ? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ) : true,
+		surveyVertical: getSurveyVertical( state ),
 	};
 } ) ( DomainsStep );


### PR DESCRIPTION
This pull request makes the `domains` signup step read the vertical info provided during the survey, and pass it down to the domain suggestion API endpoint. That way we can provide better suggestions
