### PR TITLE
Sidebar: "Help" highlight

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -441,7 +441,8 @@ a.sidebar__button {
 }
 
 .layout.is-section-help .sidebar .sidebar__footer-help {
-	color: $gray-dark;
+	background-color: $sidebar-selected-color;
+	color: $white;
 }
 
 .sidebar__region {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -155,15 +155,6 @@ const MeSidebar = React.createClass( {
 							onNavigate={ this.onNavigate }
 						/>
 						{ this.renderNextStepsItem( selected ) }
-						<SidebarItem
-							selected={ selected === 'help' }
-							link={ config.isEnabled( 'help' ) ? '/help' : '//support.wordpress.com' }
-							label={ this.translate( 'Help' ) }
-							external={ config.isEnabled( 'help' ) ? 'false' : 'true' }
-							icon="help-outline"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="help"
-						/>
 					</ul>
 				</SidebarMenu>
 				<SidebarFooter />


### PR DESCRIPTION
Uses the same highlight treatment we use for sidebar items and removes redundant Help item in sidebar of Me.

Before:
![image](https://cloud.githubusercontent.com/assets/548849/19682273/1d6409f4-9aad-11e6-8ea0-629e48ee3b95.png)

After:
![image](https://cloud.githubusercontent.com/assets/548849/19682232/f3926850-9aac-11e6-8643-cf4d0391e549.png)

cc @jasmussen 
