### PR TITLE
ImageEditor: edit media instead of create a new copy

### DIFF
--- a/client/blocks/image-editor/README.md
+++ b/client/blocks/image-editor/README.md
@@ -40,6 +40,7 @@ the image to be edited. Use this approach if you want to edit a local image file
 
 It can also contain these optional properties (with defaults if not set):
 - `media.file` `{string}`: the base name of the edited image file (e.g. `full-width1-e1.jpg`), defaults to `default`
+- `media.ID` `{number}`: An ID of the media item.
 - `media.mime_type` `{string}`: the MIME of the edited image (e.g. `image/jpeg`), defaults to `image/png`
 - `media.title` `{string}`: the title of the edited image (e.g. `some image file`), defaults to `default`
 

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -136,12 +136,13 @@ const ImageEditor = React.createClass( {
 		const {
 			src,
 			fileName,
+			media,
 			mimeType,
 			title,
 			site
 		} = this.props;
 
-		return {
+		const imageProperties = {
 			src,
 			fileName,
 			mimeType,
@@ -149,6 +150,12 @@ const ImageEditor = React.createClass( {
 			site,
 			resetAllImageEditorState: this.props.resetAllImageEditorState
 		};
+
+		if ( media && media.ID ) {
+			imageProperties.ID = media.ID;
+		}
+
+		return imageProperties;
 	},
 
 	onLoadCanvasError() {

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -228,15 +228,19 @@ MediaActions.update = function( siteId, item ) {
 		data: newItem
 	} );
 
-	debug( 'Updating media for %d by ID %d to %o', siteId, item.ID, item );
-	wpcom.site( siteId ).media( item.ID ).update( item, function( error, data ) {
-		Dispatcher.handleServerAction( {
-			type: 'RECEIVE_MEDIA_ITEM',
-			error: error,
-			siteId: siteId,
-			data: data
+	debug( 'Updating media for %o by ID %o to %o', siteId, item.ID, item );
+
+	wpcom
+		.site( siteId )
+		.media( item.ID )
+		.edit( item, function( error, data ) {
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_MEDIA_ITEM',
+				error: error,
+				siteId: siteId,
+				data: data
+			} );
 		} );
-	} );
 };
 
 MediaActions.delete = function( siteId, item ) {

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -69,6 +69,7 @@ describe( 'MediaActions', function() {
 						return {
 							get: mediaGet.bind( [ siteId, mediaId ].join() ),
 							update: mediaUpdate.bind( [ siteId, mediaId ].join() ),
+							edit: mediaUpdate.bind( [ siteId, mediaId ].join() ),
 							'delete': mediaDelete.bind( [ siteId, mediaId ].join() )
 						};
 					}

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -172,7 +172,7 @@ export const EditorMediaModal = React.createClass( {
 	},
 
 	deleteMedia: function() {
-		var selectedCount, confirmMessage;
+		let selectedCount;
 
 		if ( ModalViews.DETAIL === this.props.view ) {
 			selectedCount = 1;
@@ -180,7 +180,7 @@ export const EditorMediaModal = React.createClass( {
 			selectedCount = this.props.mediaLibrarySelectedItems.length;
 		}
 
-		confirmMessage = this.translate(
+		const confirmMessage = this.translate(
 			'Are you sure you want to permanently delete this item?',
 			'Are you sure you want to permanently delete these items?',
 			{ count: selectedCount }
@@ -210,36 +210,22 @@ export const EditorMediaModal = React.createClass( {
 		const {
 			fileName,
 			site,
+			ID,
 			resetAllImageEditorState
 		} = imageEditorProps;
 
 		const mimeType = MediaUtils.getMimeType( fileName );
 
-		// check if a title is already post-fixed with '(edited copy)'
-		const editedCopyText = this.translate(
-			'%(title)s (edited copy)', {
-				args: {
-					title: ''
-				}
-			} );
+		const item = {
+			ID: ID,
+			media: {
+				fileName: fileName,
+				fileContents: blob,
+				mimeType: mimeType
+			}
+		};
 
-		let { title } = imageEditorProps;
-
-		if ( title.indexOf( editedCopyText ) === -1 ) {
-			title = this.translate(
-				'%(title)s (edited copy)', {
-					args: {
-						title: title
-					}
-				} );
-		}
-
-		MediaActions.add( site.ID, {
-			fileName: fileName,
-			fileContents: blob,
-			title: title,
-			mimeType: mimeType
-		} );
+		MediaActions.update( site.ID, item );
 
 		resetAllImageEditorState();
 
@@ -417,8 +403,8 @@ export const EditorMediaModal = React.createClass( {
 					mediaLibrarySelectedItems: items
 				} = this.props;
 
-				const selectedIndex = this.getDetailSelectedIndex(),
-					media = items ? items[ selectedIndex ] : null;
+				const selectedIndex = this.getDetailSelectedIndex();
+				const media = items ? items[ selectedIndex ] : null;
 
 				content = (
 					<ImageEditor

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1526,7 +1526,7 @@
       "version": "0.6.1"
     },
     "form-data": {
-      "version": "2.0.0"
+      "version": "2.1.1"
     },
     "formatio": {
       "version": "1.1.1",
@@ -3161,19 +3161,10 @@
       "version": "1.1.3"
     },
     "request": {
-      "version": "2.75.0",
+      "version": "2.76.0",
       "dependencies": {
-        "bl": {
-          "version": "1.1.2"
-        },
-        "isarray": {
-          "version": "1.0.0"
-        },
         "qs": {
-          "version": "6.2.1"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
+          "version": "6.3.0"
         }
       }
     },
@@ -4111,7 +4102,7 @@
       "version": "1.3.0"
     },
     "wpcom": {
-      "version": "5.2.0"
+      "version": "5.3.0"
     },
     "wpcom-oauth": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "walk": "2.3.4",
     "webpack": "1.13.1",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "5.2.0",
+    "wpcom": "5.3.0",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "3.0.0",
     "wpcom-xhr-request": "1.0.0",


### PR DESCRIPTION
This PR replaces the behavior when an image is edited through of the image-editor block. It is now possible thank to a new /edit media endpoint.
The request is done through of the Media.edit() method of the wpcom.js lib.

### Issues

#8081

![calypso-image-editor-02](https://cloud.githubusercontent.com/assets/77539/19691308/2ecc3ac0-9aaa-11e6-9c8c-279795128b4b.gif)

### Testing

1) Be sure your local dependencies have been rightly updated. I usually do:

```cli
> rm -rf node_modules/
> make clean
> make
> make run
```

2) Make the whole workflow edit an image:

* Upload a new one
* Edit (crop, scale, rotate)
* save

The image should be updated without creating a new one.