### PR TITLE
Reader: Only autofocus the search box if there's no query

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -186,7 +186,7 @@ const FeedStream = React.createClass( {
 					<SearchInput
 						initialValue={ this.props.query }
 						onSearch={ this.updateQuery }
-						autoFocus={ true }
+						autoFocus={ ! this.props.query }
 						delaySearch={ true }
 						delayTimeout={ 500 }
 						placeholder={ searchPlaceholderText } />


### PR DESCRIPTION
Prevents the search listing from scrolling back to the top when you come back from a full post.

To test:
- Pull up search ( http://calypso.localhost:3000 )
- Type in a search (I like Michigan)
- Scroll down a few pages, pick a result
- Hit the back button to leave the full post view
- You should now be at the same place in the stream you left from
  and the stream should not scroll to the top

If you try this on wpcalypso.wordpress.com, it'll scroll to the top