### PR TITLE
i18n: Avoid switching locale if no change to be made

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -18,6 +18,10 @@ function languageFileUrl( localeSlug ) {
 }
 
 export default function switchLocale( localeSlug ) {
+	if ( localeSlug === i18n.getLocaleSlug() ) {
+		return;
+	}
+
 	if ( localeSlug === config( 'i18n_default_locale_slug' ) ) {
 		i18n.configure( { defaultLocaleSlug: localeSlug } );
 		return;


### PR DESCRIPTION
This pull request seeks to resolve an issue where `change` events on the user object [invoke a locale switch](https://github.com/Automattic/wp-calypso/blob/94cd9e7bef80cbd5170559466cfd8ee8eafa8bbb/client/boot/index.js#L156-L162) which in turn [forces all localized components to rerender](https://github.com/Automattic/i18n-calypso/blob/d56d4929bdc2606862f256660febcf6599e44252/lib/localize/index.js#L24). This was most obvious in the editor for accounts who haven't yet verified their email. If a post contained galleries of images, the email verification polling would cause the gallery to reload every poll interval due to the change event emitted to the user, causing very jarring scrolling to occur.

The changes here skip `switchLocale` if the locale slug passed matches the current configured locale. This will avoid unnecessary rerenders when a `user` object `change` event occurs but the locale stays the same.

We should separately investigate why email verification polling is emitting a `change` event on the user if it is not necessary (cc @coreh).

__Testing instructions:__

I'm not aware of any instances in which a locale switch would occur in the same page session, as the language toggle will cause a full refresh of the page (cc @rralian , do you know?)

Instead, ensure that no unnecessary scrolling occurs on the email verification polling in an editor session where (a) the post contains enough content to scroll and gallery shortcodes and (b) the current user has not verified their email ([applying this patch will simplify testing](https://cloudup.com/files/iN-aMAxTKe7/download)).

cc @kriskarkoski @lizkarkoski