### PR TITLE
SEO: Update Copy

### DIFF
--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -68,14 +68,14 @@ const SeoPreviewNudge = ( { translate, domain, plan = {}, businessPlan = {} } ) 
 			<div className="preview-upgrade-nudge__plan">
 				<div className="preview-upgrade-nudge__plan-icon"></div>
 			</div>
-			<h2 className="preview-upgrade-nudge__title">{ translate( 'Advanced SEO Features' ) }</h2>
+			<h2 className="preview-upgrade-nudge__title">{ translate( 'SEO Features' ) }</h2>
 			<div className="preview-upgrade-nudge__features">
 				<FeatureExample>
 					<img src="/calypso/images/advanced-seo-nudge.png" />
 				</FeatureExample>
 				<div className="preview-upgrade-nudge__features-details">
 					<p className="preview-upgrade-nudge__features-title">
-						{ translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
+						{ translate( 'By upgrading to a Business Plan you\'ll enable SEO Tools on your site.' ) }
 					</p>
 					<ul className="preview-upgrade-nudge__features-list">
 						<li className="preview-upgrade-nudge__features-list-item">

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -425,11 +425,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_ADVANCED_SEO ]: {
 		getSlug: () => FEATURE_ADVANCED_SEO,
-		getTitle: () => i18n.translate( '{{strong}}Advanced{{/strong}} SEO', {
-			components: {
-				strong: <strong />
-			}
-		} ),
+		getTitle: () => i18n.translate( 'SEO Tools' ),
 		getDescription: () => i18n.translate(
 			'Adds tools to enhance your site\'s content for better results on search engines and social media.'
 		)

--- a/client/my-sites/plugins-wpcom/default-plugins.js
+++ b/client/my-sites/plugins-wpcom/default-plugins.js
@@ -12,13 +12,6 @@ export const defaultStandardPlugins = [
 		description: i18n.translate( 'View your site\'s visits, referrers, and more.' )
 	},
 	{
-		name: i18n.translate( 'Essential SEO' ),
-		descriptionLink: 'http://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/',
-		icon: 'search',
-		category: 'Traffic Growth',
-		description: i18n.translate( 'Search engine optimization and sitemaps.' )
-	},
-	{
 		name: i18n.translate( 'Security Scanning' ),
 		descriptionLink: 'https://support.wordpress.com/security/',
 		icon: 'lock',
@@ -185,8 +178,8 @@ export const defaultPremiumPlugins = [
  */
 export const defaultBusinessPlugins = [
 	{
-		name: i18n.translate( 'Advanced SEO' ),
-		descriptionLink: 'https://support.wordpress.com/advanced-seo/',
+		name: i18n.translate( 'SEO Tools' ),
+		descriptionLink: 'https://support.wordpress.com/seo-tools/',
 		icon: 'search',
 		category: 'Traffic Growth',
 		description: i18n.translate( 'Custom meta descriptions, social media previews, and more.' )

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -422,7 +422,7 @@ export const SeoForm = React.createClass( {
 				{ showUpgradeNudge &&
 					<UpgradeNudge
 						feature={ FEATURE_ADVANCED_SEO }
-						title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
+						title={ this.translate( 'Upgrade to a Business Plan and Enable SEO Tools' ) }
 						message={ this.translate( `By upgrading to a Business Plan you'll enable advanced SEO features on your site.` ) }
 						event={ 'calypso_seo_settings_upgrade_nudge' }
 					/>

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -422,8 +422,8 @@ export const SeoForm = React.createClass( {
 				{ showUpgradeNudge &&
 					<UpgradeNudge
 						feature={ FEATURE_ADVANCED_SEO }
-						title={ this.translate( 'Upgrade to a Business Plan and Enable SEO Tools' ) }
-						message={ this.translate( `By upgrading to a Business Plan you'll enable advanced SEO features on your site.` ) }
+						title={ this.translate( 'Enable SEO Tools by Upgrading to the Business Plan' ) }
+						message={ this.translate( `Adds tools to optimize your site for search engines and social media sharing.` ) }
 						event={ 'calypso_seo_settings_upgrade_nudge' }
 					/>
 				}

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -17,7 +17,7 @@ import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 function EditorSeoAccordion( { translate, metaDescription = '' } ) {
 	return (
 		<Accordion
-			title={ translate( 'Advanced SEO' ) }
+			title={ translate( 'SEO Tools' ) }
 			icon={ <Gridicon icon="search" /> }
 			className="editor-seo-accordion"
 		>

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -17,7 +17,7 @@ import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 function EditorSeoAccordion( { translate, metaDescription = '' } ) {
 	return (
 		<Accordion
-			title={ translate( 'SEO Tools' ) }
+			title={ translate( 'SEO Description' ) }
 			icon={ <Gridicon icon="search" /> }
 			className="editor-seo-accordion"
 		>


### PR DESCRIPTION
`Advanced SEO` becomes `SEO Tools` to better align with the Jetpack release. I also updated the text of the upgrade nudge and removed the 'Essential SEO' plugin card.

**Screenshots**
<img width="305" alt="screen shot 2016-10-25 at 10 58 51 am" src="https://cloud.githubusercontent.com/assets/789137/19697966/58651d50-9aa2-11e6-959a-3283dfd51bd9.png">
<img width="527" alt="screen shot 2016-10-25 at 10 59 19 am" src="https://cloud.githubusercontent.com/assets/789137/19697968/587dc792-9aa2-11e6-98da-3e380de3c064.png">
<img width="279" alt="screen shot 2016-10-25 at 11 00 08 am" src="https://cloud.githubusercontent.com/assets/789137/19697967/587c57cc-9aa2-11e6-8976-8d8e2be35e7d.png">

cc @drw158 @vindl 

Fixes #8936