### PR TITLE
Media: add a 'Reverse Order' button to the gallery editor dialog

### DIFF
--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -153,7 +153,7 @@ export default React.createClass( {
 	renderReverseOrderButton() {
 		return (
 			<EditorMediaModalFieldset>
-				<Button onClick={ this.updateReverseOrder }>
+				<Button onClick={ this.updateReverseOrder } disabled={ this.props.settings.orderBy === 'rand' } >
 					{ this.translate( 'Reverse Order' ) }
 				</Button>
 			</EditorMediaModalFieldset>

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -7,6 +7,7 @@ import noop from 'lodash/noop';
 import includes from 'lodash/includes';
 import times from 'lodash/times';
 import fromPairs from 'lodash/fromPairs';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import Button from 'components/button';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'lib/media/constants';
 
-export default React.createClass( {
+export const EditorMediaModalGalleryFields = React.createClass( {
 	displayName: 'EditorMediaModalGalleryFields',
 
 	propTypes: {
@@ -151,10 +152,12 @@ export default React.createClass( {
 	},
 
 	renderReverseOrderButton() {
+		const { translate } = this.props;
+
 		return (
 			<EditorMediaModalFieldset>
 				<Button onClick={ this.updateReverseOrder } disabled={ this.props.settings.orderBy === 'rand' } >
-					{ this.translate( 'Reverse Order' ) }
+					{ translate( 'Reverse Order' ) }
 				</Button>
 			</EditorMediaModalFieldset>
 		);
@@ -177,3 +180,5 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default localize( EditorMediaModalGalleryFields );

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -25,6 +25,7 @@ export default React.createClass( {
 		site: PropTypes.object,
 		settings: PropTypes.object,
 		onUpdateSetting: PropTypes.func,
+		onReverse: PropTypes.func,
 		numberOfItems: PropTypes.number
 	},
 
@@ -96,6 +97,10 @@ export default React.createClass( {
 		this.props.onUpdateSetting( 'orderBy', event.target.checked ? 'rand' : null );
 	},
 
+	updateReverseOrder() {
+		this.props.onReverse();
+	},
+
 	renderDropdown( legend, options, settingName ) {
 		const { settings, onUpdateSetting } = this.props;
 
@@ -148,7 +153,7 @@ export default React.createClass( {
 	renderReverseOrderButton() {
 		return (
 			<EditorMediaModalFieldset>
-				<Button>
+				<Button onClick={ this.updateReverseOrder }>
 					{ this.translate( 'Reverse Order' ) }
 				</Button>
 			</EditorMediaModalFieldset>

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -20,8 +20,6 @@ import Button from 'components/button';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'lib/media/constants';
 
 export const EditorMediaModalGalleryFields = React.createClass( {
-	displayName: 'EditorMediaModalGalleryFields',
-
 	propTypes: {
 		site: PropTypes.object,
 		settings: PropTypes.object,

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -170,12 +170,12 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 
 		return (
 			<div className="editor-media-modal-gallery__fields">
-				{ this.renderReverseOrderButton() }
 				{ this.renderDropdown( this.translate( 'Layout' ), types, 'type' ) }
 				{ this.renderColumnsOption() }
 				{ this.renderRandomOption() }
 				{ this.renderDropdown( this.translate( 'Link To' ), links, 'link' ) }
 				{ this.renderDropdown( this.translate( 'Size' ), sizes, 'size' ) }
+				{ this.renderReverseOrderButton() }
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -15,6 +15,7 @@ import EditorMediaModalFieldset from '../fieldset';
 import SelectDropdown from 'components/select-dropdown';
 import SelectDropdownItem from 'components/select-dropdown/item';
 import FormCheckbox from 'components/forms/form-checkbox';
+import Button from 'components/button';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'lib/media/constants';
 
 export default React.createClass( {
@@ -144,6 +145,16 @@ export default React.createClass( {
 		);
 	},
 
+	renderReverseOrderButton() {
+		return (
+			<EditorMediaModalFieldset>
+				<Button>
+					{ this.translate( 'Reverse Order' ) }
+				</Button>
+			</EditorMediaModalFieldset>
+		);
+	},
+
 	render() {
 		const types = this.getTypeOptions();
 		const links = this.getLinkOptions();
@@ -151,6 +162,7 @@ export default React.createClass( {
 
 		return (
 			<div className="editor-media-modal-gallery__fields">
+				{ this.renderReverseOrderButton() }
 				{ this.renderDropdown( this.translate( 'Layout' ), types, 'type' ) }
 				{ this.renderColumnsOption() }
 				{ this.renderRandomOption() }

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -97,10 +97,6 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 		this.props.onUpdateSetting( 'orderBy', event.target.checked ? 'rand' : null );
 	},
 
-	updateReverseOrder() {
-		this.props.onReverse();
-	},
-
 	renderDropdown( legend, options, settingName ) {
 		const { settings, onUpdateSetting } = this.props;
 
@@ -155,7 +151,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 
 		return (
 			<EditorMediaModalFieldset>
-				<Button onClick={ this.updateReverseOrder } disabled={ this.props.settings.orderBy === 'rand' } >
+				<Button onClick={ this.props.onReverse } disabled={ this.props.settings.orderBy === 'rand' } >
 					{ translate( 'Reverse Order' ) }
 				</Button>
 			</EditorMediaModalFieldset>

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -32,6 +32,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 		return {
 			settings: Object.freeze( {} ),
 			onUpdateSetting: noop,
+			onReverse: noop,
 			numberOfItems: 0
 		};
 	},

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -146,18 +146,6 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 		);
 	},
 
-	renderReverseOrderButton() {
-		const { translate } = this.props;
-
-		return (
-			<EditorMediaModalFieldset>
-				<Button onClick={ this.props.onReverse } disabled={ this.props.settings.orderBy === 'rand' } >
-					{ translate( 'Reverse Order' ) }
-				</Button>
-			</EditorMediaModalFieldset>
-		);
-	},
-
 	render() {
 		const types = this.getTypeOptions();
 		const links = this.getLinkOptions();
@@ -170,7 +158,11 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 				{ this.renderRandomOption() }
 				{ this.renderDropdown( this.translate( 'Link To' ), links, 'link' ) }
 				{ this.renderDropdown( this.translate( 'Size' ), sizes, 'size' ) }
-				{ this.renderReverseOrderButton() }
+				<EditorMediaModalFieldset>
+					<Button onClick={ this.props.onReverse } disabled={ this.props.settings.orderBy === 'rand' } >
+						{ this.props.translate( 'Reverse Order' ) }
+					</Button>
+				</EditorMediaModalFieldset>
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -115,7 +115,7 @@ const EditorMediaModalGallery = React.createClass( {
 	},
 
 	reverseOrder( ) {
-		const reverseItems = reverse( this.props.items );
+		const reverseItems = reverse( this.props.settings.items.slice( 0 ) );
 		this.updateSetting( {
 			items: reverseItems
 		} );

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { noop, assign, omitBy, some, isEqual, partial } from 'lodash';
+import { noop, assign, omitBy, some, isEqual, partial, reverse } from 'lodash';
 
 /**
  * Internal dependencies
@@ -114,6 +114,13 @@ const EditorMediaModalGallery = React.createClass( {
 		this.props.onUpdateSettings( updatedSettings );
 	},
 
+	reverseOrder( ) {
+		const reverseItems = reverse( this.props.items );
+		this.updateSetting( {
+			items: reverseItems
+		} );
+	},
+
 	render() {
 		const { site, items, settings } = this.props;
 
@@ -136,7 +143,8 @@ const EditorMediaModalGallery = React.createClass( {
 							site={ site }
 							settings={ settings }
 							onUpdateSetting={ this.updateSetting }
-							numberOfItems={ items.length } />
+							numberOfItems={ items.length }
+							onReverse = { this.reverseOrder } />
 					</div>
 				</div>
 			</div>

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -144,7 +144,7 @@ const EditorMediaModalGallery = React.createClass( {
 							settings={ settings }
 							onUpdateSetting={ this.updateSetting }
 							numberOfItems={ items.length }
-							onReverse = { this.reverseOrder } />
+							onReverse={ this.reverseOrder } />
 					</div>
 				</div>
 			</div>

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -115,7 +115,7 @@ const EditorMediaModalGallery = React.createClass( {
 	},
 
 	reverseOrder( ) {
-		const reverseItems = reverse( this.props.settings.items.slice( 0 ) );
+		const reverseItems = reverse( [ ...this.props.settings.items ] );
 		this.updateSetting( {
 			items: reverseItems
 		} );


### PR DESCRIPTION
This PR seeks to add a ‘Reverse Order’ button to the add new gallery dialog (similar to wp-admin)

Fixes #339 

**Outstanding issues:**

1. Needs design review - I think it makes sense to have the button with the other inputs on the right hand side instead of just in the Edit component
2. `warning.js:36 Warning: Failed prop type: Required prop `legend` was not specified in `EditorMediaModalFieldset`` I'm not sure we need a legend for this button, and I don't know how to supress this warning
3. No unit tests for the new functionality - since no unit tests exist for this existing component I'm not sure where to start on this

cc: @designsimply for testing 😊

**Before**

No 'Reverse Order' option

<img width="817" alt="before calypso" src="https://cloud.githubusercontent.com/assets/128826/19714311/7e27b9be-9b90-11e6-9319-57be0a23c3c2.png">

**After**

![reverse images](https://cloud.githubusercontent.com/assets/128826/19750444/722a321e-9c34-11e6-838f-312d8f4dcfb5.gif)


**WP-Admin**

<img width="782" alt="wp-admin reorder" src="https://cloud.githubusercontent.com/assets/128826/19714248/f25a1684-9b8f-11e6-8fba-5775c4c316cd.png">


