### PR TITLE
Jetpack Connect: Persist only non-stale data from the Redux store

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -60,13 +60,13 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import { isStale } from 'state/jetpack-connect/utils';
 
 /**
  * Constants
  */
 const PLANS_PAGE = '/jetpack/connect/plans/';
 const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
-const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
 
 const SiteCard = React.createClass( {
 	render() {
@@ -583,9 +583,8 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 	isSSO() {
 		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
 		if ( this.props.jetpackSSOSessions && this.props.jetpackSSOSessions[ site ] ) {
-			const currentTime = ( new Date() ).getTime();
 			const sessionTimestamp = this.props.jetpackSSOSessions[ site ].timestamp || 0;
-			return ( currentTime - sessionTimestamp < JETPACK_CONNECT_TTL );
+			return ! isStale( sessionTimestamp );
 		}
 
 		return false;

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -60,7 +60,6 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import { isStale } from 'state/jetpack-connect/utils';
 
 /**
  * Constants
@@ -582,12 +581,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 	isSSO() {
 		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
-		if ( this.props.jetpackSSOSessions && this.props.jetpackSSOSessions[ site ] ) {
-			const sessionTimestamp = this.props.jetpackSSOSessions[ site ].timestamp || 0;
-			return ! isStale( sessionTimestamp );
-		}
-
-		return false;
+		return !! ( this.props.jetpackSSOSessions && this.props.jetpackSSOSessions[ site ] );
 	},
 
 	renderNoQueryArgsError() {

--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -1,0 +1,1 @@
+export const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // an hour

--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -1,1 +1,2 @@
 export const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // an hour
+export const JETPACK_CONNECT_AUTHORIZE_TTL = 5 * 60 * 1000; // 5 minutes

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -1,8 +1,7 @@
 /**
  * External dependencis
  */
-import isEmpty from 'lodash/isEmpty';
-import omit from 'lodash/omit';
+import { isEmpty, omit, pickBy } from 'lodash';
 import { combineReducers } from 'redux';
 
 /**
@@ -38,6 +37,7 @@ import {
 
 import { isValidStateWithSchema } from 'state/utils';
 import { jetpackConnectSessionsSchema } from './schema';
+import { isStale } from './utils';
 
 const defaultAuthorizeState = {
 	queryObject: {},
@@ -61,7 +61,9 @@ export function jetpackConnectSessions( state = {}, action ) {
 			return Object.assign( {}, state, buildNoProtocolUrlObj( action.url, action.flowType ) );
 		case DESERIALIZE:
 			if ( isValidStateWithSchema( state, jetpackConnectSessionsSchema ) ) {
-				return state;
+				return pickBy( state, ( session ) => {
+					return ! isStale( session.timestamp );
+				} );
 			}
 			return {};
 		case SERIALIZE:

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -38,6 +38,7 @@ import {
 import { isValidStateWithSchema } from 'state/utils';
 import { jetpackConnectSessionsSchema } from './schema';
 import { isStale } from './utils';
+import { JETPACK_CONNECT_AUTHORIZE_TTL } from './constants';
 
 function buildDefaultAuthorizeState() {
 	return {
@@ -249,7 +250,7 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_REDIRECT_WP_ADMIN:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
 		case DESERIALIZE:
-			return ! isStale( state.timestamp ) ? state : {};
+			return ! isStale( state.timestamp, JETPACK_CONNECT_AUTHORIZE_TTL ) ? state : {};
 		case SERIALIZE:
 			return state;
 	}

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -288,8 +288,9 @@ export function jetpackSSOSessions( state = {}, action ) {
 		case JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS:
 			return Object.assign( {}, state, buildNoProtocolUrlObj( action.siteUrl ) );
 		case SERIALIZE:
-		case DESERIALIZE:
 			return state;
+		case DESERIALIZE:
+			return ! isStale( state.timestamp ) ? state : {};
 	}
 	return state;
 }

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -39,12 +39,15 @@ import { isValidStateWithSchema } from 'state/utils';
 import { jetpackConnectSessionsSchema } from './schema';
 import { isStale } from './utils';
 
-const defaultAuthorizeState = {
-	queryObject: {},
-	isAuthorizing: false,
-	authorizeSuccess: false,
-	authorizeError: false
-};
+function buildDefaultAuthorizeState() {
+	return {
+		queryObject: {},
+		isAuthorizing: false,
+		authorizeSuccess: false,
+		authorizeError: false,
+		timestamp: Date.now()
+	};
+}
 
 function buildNoProtocolUrlObj( url, flowType ) {
 	const noProtocolUrl = url.replace( /.*?:\/\//g, '' );
@@ -194,7 +197,7 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 			const queryObject = Object.assign( {}, action.queryObject );
 			return Object.assign(
 				{},
-				defaultAuthorizeState,
+				buildDefaultAuthorizeState(),
 				{ queryObject: queryObject }
 			);
 		case JETPACK_CONNECT_QUERY_UPDATE:
@@ -246,7 +249,7 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_REDIRECT_WP_ADMIN:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
 		case DESERIALIZE:
-			return state;
+			return ! isStale( state.timestamp ) ? state : {};
 		case SERIALIZE:
 			return state;
 	}

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -20,7 +20,7 @@ export const jetpackConnectAuthorizeSchema = {
 	patternProperties: {
 		'^.+$': {
 			type: 'object',
-			required: [ 'queryObject' ],
+			required: [ 'queryObject', 'timestamp' ],
 			properties: {
 				activateManageSecret: { type: 'string' },
 				authorizationCode: { type: 'string ' },
@@ -54,6 +54,7 @@ export const jetpackConnectAuthorizeSchema = {
 					},
 					additionalProperties: false
 				},
+				timestamp: { type: 'number' },
 				siteReceived: { type: 'boolean' }
 			},
 			additionalProperties: false

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -54,7 +54,7 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 	const site = siteSlug.replace( /.*?:\/\//g, '' );
 	const sessions = getSessions( state );
 
-	if ( sessions[ site ] ) {
+	if ( sessions[ site ] && sessions[ site ].timestamp ) {
 		return ! isStale( sessions[ site ].timestamp );
 	}
 

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -7,8 +7,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { getSiteByUrl } from 'state/sites/selectors';
-
-const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // an hour
+import { isStale } from './utils';
 
 const getConnectingSite = ( state ) => {
 	return get( state, [ 'jetpackConnect', 'jetpackConnectSite' ] );
@@ -56,8 +55,7 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 	const sessions = getSessions( state );
 
 	if ( sessions[ site ] ) {
-		const currentTime = ( new Date() ).getTime();
-		return ( currentTime - sessions[ site ].timestamp < JETPACK_CONNECT_TTL );
+		return ! isStale( sessions[ site ].timestamp );
 	}
 
 	return false;

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -142,8 +142,17 @@ describe( 'reducer', () => {
 			expect( state ).to.be.eql( {} );
 		} );
 
+		it( 'should not restore a state with a property with a stale timestamp', () => {
+			const state = jetpackConnectSessions( { 'example.wordpress.com': { timestamp: 1 } }, {
+				type: DESERIALIZE
+			} );
+
+			expect( state ).to.be.eql( {} );
+		} );
+
 		it( 'should not restore a state with a session stored with extra properties', () => {
-			const state = jetpackConnectSessions( { 'example.wordpress.com': { timestamp: 1, foo: 'bar' } }, {
+			const timestamp = Date.now();
+			const state = jetpackConnectSessions( { 'example.wordpress.com': { timestamp, foo: 'bar' } }, {
 				type: DESERIALIZE
 			} );
 
@@ -151,19 +160,33 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'should restore a valid state', () => {
-			const state = jetpackConnectSessions( { 'example.wordpress.com': { timestamp: 1 } }, {
+			const timestamp = Date.now();
+			const state = jetpackConnectSessions( { 'example.wordpress.com': { timestamp } }, {
 				type: DESERIALIZE
 			} );
 
-			expect( state ).to.be.eql( { 'example.wordpress.com': { timestamp: 1 } } );
+			expect( state ).to.be.eql( { 'example.wordpress.com': { timestamp } } );
 		} );
 
 		it( 'should restore a valid state including dashes, slashes and semicolons', () => {
-			const state = jetpackConnectSessions( { 'https://example.wordpress.com:3000/test-one': { timestamp: 1 } }, {
+			const timestamp = Date.now();
+			const state = jetpackConnectSessions( { 'https://example.wordpress.com:3000/test-one': { timestamp } }, {
 				type: DESERIALIZE
 			} );
 
-			expect( state ).to.be.eql( { 'https://example.wordpress.com:3000/test-one': { timestamp: 1 } } );
+			expect( state ).to.be.eql( { 'https://example.wordpress.com:3000/test-one': { timestamp } } );
+		} );
+
+		it( 'should restore only sites with non-stale timestamps', () => {
+			const timestamp = Date.now();
+			const state = jetpackConnectSessions( {
+				'example.wordpress.com': { timestamp: 1 },
+				'automattic.wordpress.com': { timestamp },
+			}, {
+				type: DESERIALIZE
+			} );
+
+			expect( state ).to.be.eql( { 'automattic.wordpress.com': { timestamp } } );
 		} );
 	} );
 

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -105,7 +105,7 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'should store a timestamp when checking a new url', () => {
-			const nowTime = ( new Date() ).getTime();
+			const nowTime = Date.now();
 			const state = jetpackConnectSessions( undefined, {
 				type: JETPACK_CONNECT_CHECK_URL,
 				url: 'https://example.wordpress.com'
@@ -116,7 +116,7 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'should update the timestamp when checking an existent url', () => {
-			const nowTime = ( new Date() ).getTime();
+			const nowTime = Date.now();
 			const state = jetpackConnectSessions( { 'example.wordpress.com': { timestamp: 1 } }, {
 				type: JETPACK_CONNECT_CHECK_URL,
 				url: 'https://example.wordpress.com'
@@ -336,7 +336,7 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'should store an integer timestamp when creating new session', () => {
-			const nowTime = ( new Date() ).getTime();
+			const nowTime = Date.now();
 			const state = jetpackSSOSessions( undefined, {
 				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
 				ssoUrl: 'https://example.wordpress.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
@@ -674,7 +674,8 @@ describe( 'reducer', () => {
 				queryObject: {
 					client_id: 'example.com',
 					redirect_uri: 'https://example.com/',
-				}
+				},
+				timestamp: Date.now()
 			} );
 			const state = jetpackConnectAuthorize( originalState, {
 				type: SERIALIZE
@@ -688,13 +689,29 @@ describe( 'reducer', () => {
 				queryObject: {
 					client_id: 'example.com',
 					redirect_uri: 'https://example.com/',
-				}
+				},
+				timestamp: Date.now()
 			} );
 			const state = jetpackConnectAuthorize( originalState, {
 				type: DESERIALIZE
 			} );
 
 			expect( state ).to.be.eql( originalState );
+		} );
+
+		it( 'should not load stale state', () => {
+			const originalState = deepFreeze( {
+				queryObject: {
+					client_id: 'example.com',
+					redirect_uri: 'https://example.com/',
+				},
+				timestamp: 1
+			} );
+			const state = jetpackConnectAuthorize( originalState, {
+				type: DESERIALIZE
+			} );
+
+			expect( state ).to.be.eql( {} );
 		} );
 	} );
 

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -364,13 +364,27 @@ describe( 'reducer', () => {
 		it( 'should load valid persisted state', () => {
 			const originalState = deepFreeze( {
 				ssoUrl: 'https://example.wordpress.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
-				siteUrl: 'https://example.wordpress.com'
+				siteUrl: 'https://example.wordpress.com',
+				timestamp: Date.now()
 			} );
 			const state = jetpackSSOSessions( originalState, {
 				type: DESERIALIZE
 			} );
 
 			expect( state ).to.be.eql( originalState );
+		} );
+
+		it( 'should not load stale state', () => {
+			const originalState = deepFreeze( {
+				ssoUrl: 'https://example.wordpress.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
+				siteUrl: 'https://example.wordpress.com',
+				timestamp: 1
+			} );
+			const state = jetpackSSOSessions( originalState, {
+				type: DESERIALIZE
+			} );
+
+			expect( state ).to.be.eql( {} );
 		} );
 	} );
 

--- a/client/state/jetpack-connect/test/utils.js
+++ b/client/state/jetpack-connect/test/utils.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isStale } from '../utils';
+
+describe( 'utils', () => {
+	describe( '#isStale()', () => {
+		it( 'should return false if the passed timestamp is null', () => {
+			expect( isStale( null ) ).to.be.false;
+		} );
+
+		it( 'should return false if the passed timestamp is undefined', () => {
+			expect( isStale( undefined ) ).to.be.false;
+		} );
+
+		it( 'should return false if the passed timestamp is not stale', () => {
+			expect( isStale( new Date().getTime() - 60 ) ).to.be.false;
+		} );
+
+		it( 'should return false if the passed timestamp is a millisecond away from being stale', () => {
+			expect( isStale( new Date().getTime() ) ).to.be.false;
+		} );
+
+		it( 'should return true if the passed timestamp is stale', () => {
+			expect( isStale( 1 ) ).to.be.true;
+		} );
+	} );
+} );

--- a/client/state/jetpack-connect/test/utils.js
+++ b/client/state/jetpack-connect/test/utils.js
@@ -29,5 +29,13 @@ describe( 'utils', () => {
 		it( 'should return true if the passed timestamp is stale', () => {
 			expect( isStale( 1 ) ).to.be.true;
 		} );
+
+		it( 'should return false if the timestamp is not stale with a specific expiration', () => {
+			expect( isStale( new Date().getTime(), 60 ) ).to.be.false;
+		} );
+
+		it( 'should return true if the timestamp is stale with a specific expiration', () => {
+			expect( isStale( new Date().getTime() - 61, 60 ) ).to.be.true;
+		} );
 	} );
 } );

--- a/client/state/jetpack-connect/utils.js
+++ b/client/state/jetpack-connect/utils.js
@@ -10,5 +10,8 @@ import { JETPACK_CONNECT_TTL } from './constants';
  */
 export function isStale( timestamp ) {
 	const now = new Date().getTime();
+	if ( ! timestamp ) {
+		return false;
+	}
 	return ( now - timestamp ) >= JETPACK_CONNECT_TTL;
 }

--- a/client/state/jetpack-connect/utils.js
+++ b/client/state/jetpack-connect/utils.js
@@ -5,10 +5,10 @@ import { JETPACK_CONNECT_TTL } from './constants';
 
 /***
  * Whether a Jetpack Connect store timestamp is stale.
- * @param {Object} Item to check.
- * @returns {Boolean} True if the timestamp is stale, false otherwise.
+ * @param   {Number} timestamp  Item to check.
+ * @returns {Boolean}           True if the timestamp is stale, false otherwise.
  */
 export function isStale( timestamp ) {
 	const now = new Date().getTime();
-	return ( now - timestamp ) > JETPACK_CONNECT_TTL;
+	return ( now - timestamp ) >= JETPACK_CONNECT_TTL;
 }

--- a/client/state/jetpack-connect/utils.js
+++ b/client/state/jetpack-connect/utils.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { JETPACK_CONNECT_TTL } from './constants';
+
+/***
+ * Whether a Jetpack Connect store timestamp is stale.
+ * @param {Object} Item to check.
+ * @returns {Boolean} True if the timestamp is stale, false otherwise.
+ */
+export function isStale( timestamp ) {
+	const now = new Date().getTime();
+	return ( now - timestamp ) > JETPACK_CONNECT_TTL;
+}

--- a/client/state/jetpack-connect/utils.js
+++ b/client/state/jetpack-connect/utils.js
@@ -6,12 +6,13 @@ import { JETPACK_CONNECT_TTL } from './constants';
 /***
  * Whether a Jetpack Connect store timestamp is stale.
  * @param   {Number} timestamp  Item to check.
+ * @param   {Number} expiration Expiration to compare with, in milliseconds. Default is JETPACK_CONNECT_TTL.
  * @returns {Boolean}           True if the timestamp is stale, false otherwise.
  */
-export function isStale( timestamp ) {
+export function isStale( timestamp, expiration = JETPACK_CONNECT_TTL ) {
 	const now = new Date().getTime();
 	if ( ! timestamp ) {
 		return false;
 	}
-	return ( now - timestamp ) >= JETPACK_CONNECT_TTL;
+	return ( now - timestamp ) >= expiration;
 }


### PR DESCRIPTION
Occasionally we encounter issues with odd, inconsistent behavior within the JPC flows when we connect the same site after it has been disconnected, or when the connection has not been completed the previous time. This PR approaches this problem by implementing a TTL for the JPC state data within the Redux store, so it will persist only non-stale data.

TTL is currently 1 hour, I expect your feedback if we should increase or decrease it.

To test:
- Checkout this branch
- Verify there are no regressions in the JPC flow.
- Verify there are no regressions in the JPC SSO flow.
- Verify all tests pass - `npm run test-client client/state/jetpack-connect`
