### PR TITLE
Purchases: Change Add Payment Method button text to Add Credit Card

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -490,7 +490,7 @@ const ManagePurchase = React.createClass( {
 
 			const text = isRenewing( purchase )
 				? this.translate( 'Edit Payment Method' )
-				: this.translate( 'Add Payment Method' );
+				: this.translate( 'Add Credit Card' );
 
 			return (
 				<CompactCard href={ path }>{ text }</CompactCard>


### PR DESCRIPTION
To avoid confusion, we should change this button text to `Add Credit Card` for now since there are currently no other payment method options.

See: pNPgK-2eN-p2
