### PR TITLE
Image Editor: use `edit()` method only when the media file is edited.

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -222,7 +222,7 @@ MediaActions.edit = function( siteId, item ) {
 	} );
 };
 
-MediaActions.update = function( siteId, item ) {
+MediaActions.update = function( siteId, item, editMediaFile = false ) {
 	if ( Array.isArray( item ) ) {
 		item.forEach( MediaActions.update.bind( null, siteId ) );
 		return;
@@ -248,10 +248,12 @@ MediaActions.update = function( siteId, item ) {
 	debug( 'Updating media for %o by ID %o to %o', siteId, mediaId, updateAction );
 	Dispatcher.handleViewAction( updateAction );
 
+	const method = editMediaFile ? 'edit' : 'update';
+
 	wpcom
 		.site( siteId )
 		.media( item.ID )
-		.edit( item, function( error, data ) {
+		[ method ]( item, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_MEDIA_ITEM',
 				error: error,

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -225,7 +225,7 @@ export const EditorMediaModal = React.createClass( {
 			}
 		};
 
-		MediaActions.update( site.ID, item );
+		MediaActions.update( site.ID, item, true );
 
 		resetAllImageEditorState();
 


### PR DESCRIPTION
This PRs fixes a bug when the metadata of a media is edited adding a third parameter to `update()` `Media` library which defines if the media will be updated via `update` or `edit` endpoint. 

The main difference between these endpoints is that `edit()` allows change the attached file of the media. The issue is that some sites aren't ready to update the attached files, such as Jetpack sites.

### Testing

1) Select a Jetpack site
2) Create/edit a post
3) Add a media
4) Edit its metadata 

Everything should be ok. You would take a look a to the `network` tab in chrome dev tool.

![image](https://cloud.githubusercontent.com/assets/77539/19744367/a61a0d42-9ba3-11e6-8909-8a4e91b41bdc.png)
