### PR TITLE
Sites-List: Remove sites-list from DomainManagemantData

### DIFF
--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -49,7 +49,7 @@ module.exports = {
 				component={ DomainManagement.List.default }
 				context={ pageContext }
 				productsList={ productsList }
-				sites={ sites } />,
+			/>,
 			document.getElementById( 'primary' ),
 			pageContext.store
 		);
@@ -74,7 +74,7 @@ module.exports = {
 				context={ pageContext }
 				productsList={ productsList }
 				selectedDomainName={ pageContext.params.domain }
-				sites={ sites } />,
+			/>,
 			document.getElementById( 'primary' ),
 			pageContext.store
 		);
@@ -273,7 +273,7 @@ module.exports = {
 				context={ pageContext }
 				productsList={ productsList }
 				selectedDomainName={ pageContext.params.domain }
-				sites={ sites } />,
+			/>,
 			document.getElementById( 'primary' ),
 			pageContext.store
 		);


### PR DESCRIPTION
Part of the ongoing project to remove `sites-list`
https://github.com/Automattic/wp-calypso/projects/3

Removes the dependency on the domain management component.

> There should be no functional or visual changes to this PR

**Testing**
Navigate to **My Sites** > **Domains** and switch around a selected
site. Load on a clean cache. Make sure it all works as expected.

cc: @gwwar 