### PR TITLE
Editor: edit post status: align icons

### DIFF
--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -5,8 +5,9 @@
 	justify-content: space-between;
 
 	.gridicon {
+		margin-top: 2px;
 		margin-left: 4px;
-		vertical-align: middle;
+		vertical-align: top;
 	}
 }
 
@@ -42,8 +43,8 @@
 	.gridicon {
 		color: $gray;
 		margin-left: -2px;
-		margin-right: 8px;
-		vertical-align: bottom;
+		margin-right: 6px;
+		vertical-align: top;
 	}
 
 	&:hover,


### PR DESCRIPTION
Tiny clean up. 

To test: 
- Press 'Create a new post' button in master bar
- Add a title
- Save
- The gridicons in the edit post status area of the sidebar are now aligned. See before and after below:

Before:
![screen shot 2016-10-26 at 12 53 39 pm](https://cloud.githubusercontent.com/assets/5835847/19752944/320d3602-9bbe-11e6-9eea-d513aea3a94c.png)

After:
![screen shot 2016-10-26 at 12 53 49 pm](https://cloud.githubusercontent.com/assets/5835847/19752945/320ead02-9bbe-11e6-9e7f-478132add703.png)
