### PR TITLE
Reader Stream Refresh: split featured asset components into separate files

### DIFF
--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -1,0 +1,42 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { head, filter, get } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import FeaturedVideo from './featured-video';
+import FeaturedImage from './featured-image';
+
+const FeaturedAsset = ( { post } ) => {
+	if ( ! post ) {
+		return null;
+	}
+
+	const featuredImage = post.canonical_image;
+	let featuredAsset;
+
+	// only feature an embed if we know how to thumbnail & autoplay it
+	const featuredEmbed = head( filter( post.content_embeds, ( embed ) => embed.thumbnailUrl && embed.autoplayIframe ) );
+
+	// we only show a featured embed when all of these are true
+	//   - there is no featured image on the post that's big enough to pass as the canonical image
+	//   - there is an available embed
+	//
+	const useFeaturedEmbed = featuredEmbed &&
+		( ! featuredImage || ( featuredImage !== post.featured_image && featuredImage !== get( post, 'post_thumbnail.URL' ) ) );
+
+	featuredAsset = useFeaturedEmbed
+		? <FeaturedVideo { ...featuredEmbed } videoEmbed={ featuredEmbed } />
+		: <FeaturedImage imageUri={ get( featuredImage, 'uri' ) } href={ post.URL } />;
+
+	return featuredAsset;
+};
+
+FeaturedAsset.propTypes = {
+	post: React.PropTypes.object.isRequired,
+};
+
+export default FeaturedAsset;

--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -1,0 +1,26 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
+	if ( imageUri === undefined ) {
+		return null;
+	}
+
+	const featuredImageStyle = {
+		backgroundImage: 'url(' + imageUri + ')',
+		backgroundSize: 'cover',
+		backgroundRepeat: 'no-repeat',
+		backgroundPosition: '50% 50%'
+	};
+
+	return (
+		<a className="reader-post-card__featured-image" href={ href } style={ featuredImageStyle } onClick={ onClick } >
+			{ children }
+		</a>
+	);
+};
+
+export default FeaturedImage;
+

--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import { noop } from 'lodash';
 
 const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 	if ( imageUri === undefined ) {
@@ -20,6 +21,16 @@ const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 			{ children }
 		</a>
 	);
+};
+
+FeaturedImage.propTypes = {
+	imageUri: React.PropTypes.string,
+	href: React.PropTypes.string,
+	onClick: React.PropTypes.func,
+};
+
+FeaturedImage.defaultProps = {
+	onClick: noop,
 };
 
 export default FeaturedImage;

--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -1,0 +1,81 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { throttle, constant } from 'lodash';
+import ReactDom from 'react-dom';
+import { translate } from 'i18n-calypso'; // @todo use localize HOC instead
+
+/**
+ * Internal Dependencies
+ */
+import EmbedHelper from 'reader/embed-helper';
+import FeaturedImage from './featured-image';
+
+class FeaturedVideo extends React.Component {
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			preferThumbnail: true
+		};
+	}
+
+	setVideoSizingStrategy = ( videoEmbed ) => {
+		let sizingFunction = constant( {} );
+		if ( videoEmbed ) {
+			const maxWidth = ReactDom.findDOMNode( this ).parentNode.offsetWidth;
+			const embedSize = EmbedHelper.getEmbedSizingFunction( videoEmbed );
+
+			sizingFunction = ( available = maxWidth ) => embedSize( available );
+		}
+		this.getEmbedSize = sizingFunction;
+	}
+
+	updateVideoSize = () => {
+		if ( this.videoEmbedRef ) {
+			const iframe = ReactDom.findDOMNode( this.videoEmbedRef ).querySelector( 'iframe' );
+			Object.assign( iframe.style, this.getEmbedSize() );
+		}
+	}
+
+	handleThumbnailClick = ( e ) => {
+		e.preventDefault();
+		this.setState( { preferThumbnail: false }, () => this.updateVideoSize() );
+	}
+
+	setVideoEmbedRef = ( c ) => {
+		this.videoEmbedRef = c;
+		this.setVideoSizingStrategy( this.props.videoEmbed );
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'resize', throttle( this.updateVideoSize, 100 ) );
+	}
+
+	render() {
+		const { thumbnailUrl, autoplayIframe, iframe } = this.props;
+		const preferThumbnail = this.state.preferThumbnail;
+
+		if ( preferThumbnail && thumbnailUrl ) {
+			return (
+				<FeaturedImage imageUri={ thumbnailUrl } onClick={ this.handleThumbnailClick }>
+					<div className="reader-post-card__play-icon-container"
+						title={ translate( 'Click to Play' ) }>
+						<img className="reader-post-card__play-icon" src="/calypso/images/reader/play-icon.png" />
+					</div>
+				</FeaturedImage>
+			);
+		}
+
+		/* eslint-disable react/no-danger */
+		return (
+			<div ref={ this.setVideoEmbedRef }
+				dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
+			/>
+		);
+		/* eslint-enable-line react/no-danger */
+	}
+}
+
+export default FeaturedVideo;

--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -14,6 +14,13 @@ import FeaturedImage from './featured-image';
 
 class FeaturedVideo extends React.Component {
 
+	static propTypes = {
+		thumbnailUrl: React.PropTypes.string,
+		autoplayIframe: React.PropTypes.string,
+		iframe: React.PropTypes.string,
+		videoEmbed: React.PropTypes.object,
+	}
+
 	constructor( props ) {
 		super( props );
 		this.state = {

--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { throttle, constant } from 'lodash';
 import ReactDom from 'react-dom';
-import { translate } from 'i18n-calypso'; // @todo use localize HOC instead
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -61,7 +61,7 @@ class FeaturedVideo extends React.Component {
 	}
 
 	render() {
-		const { thumbnailUrl, autoplayIframe, iframe } = this.props;
+		const { thumbnailUrl, autoplayIframe, iframe, translate } = this.props;
 		const preferThumbnail = this.state.preferThumbnail;
 
 		if ( preferThumbnail && thumbnailUrl ) {
@@ -85,4 +85,4 @@ class FeaturedVideo extends React.Component {
 	}
 }
 
-export default FeaturedVideo;
+export default localize( FeaturedVideo );

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -2,11 +2,10 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { throttle, constant, noop, truncate, head, filter, get } from 'lodash';
+import { noop, truncate } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
-import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -16,92 +15,7 @@ import DisplayTypes from 'state/reader/posts/display-types';
 import ReaderPostActions from 'blocks/reader-post-actions';
 import * as stats from 'reader/stats';
 import PostByline from './byline';
-import EmbedHelper from 'reader/embed-helper';
-
-function FeaturedImage( { imageUri, href, children, onClick } ) {
-	if ( imageUri === undefined ) {
-		return null;
-	}
-
-	const featuredImageStyle = {
-		backgroundImage: 'url(' + imageUri + ')',
-		backgroundSize: 'cover',
-		backgroundRepeat: 'no-repeat',
-		backgroundPosition: '50% 50%'
-	};
-
-	return (
-		<a className="reader-post-card__featured-image" href={ href } style={ featuredImageStyle } onClick={ onClick } >
-			{ children }
-		</a>
-	);
-}
-
-class FeaturedVideo extends React.Component {
-
-	constructor( props ) {
-		super( props );
-		this.state = {
-			preferThumbnail: true
-		};
-	}
-
-	setVideoSizingStrategy = ( videoEmbed ) => {
-		let sizingFunction = constant( {} );
-		if ( videoEmbed ) {
-			const maxWidth = ReactDom.findDOMNode( this ).parentNode.offsetWidth;
-			const embedSize = EmbedHelper.getEmbedSizingFunction( videoEmbed );
-
-			sizingFunction = ( available = maxWidth ) => embedSize( available );
-		}
-		this.getEmbedSize = sizingFunction;
-	}
-
-	updateVideoSize = () => {
-		if ( this.videoEmbedRef ) {
-			const iframe = ReactDom.findDOMNode( this.videoEmbedRef ).querySelector( 'iframe' );
-			Object.assign( iframe.style, this.getEmbedSize() );
-		}
-	}
-
-	handleThumbnailClick = ( e ) => {
-		e.preventDefault();
-		this.setState( { preferThumbnail: false }, () => this.updateVideoSize() );
-	}
-
-	setVideoEmbedRef = ( c ) => {
-		this.videoEmbedRef = c;
-		this.setVideoSizingStrategy( this.props.videoEmbed );
-	}
-
-	componentDidMount() {
-		window.addEventListener( 'resize', throttle( this.updateVideoSize, 100 ) );
-	}
-
-	render() {
-		const { thumbnailUrl, autoplayIframe, iframe } = this.props;
-		const preferThumbnail = this.state.preferThumbnail;
-
-		if ( preferThumbnail && thumbnailUrl ) {
-			return (
-				<FeaturedImage imageUri={ thumbnailUrl } onClick={ this.handleThumbnailClick }>
-					<div className="reader-post-card__play-icon-container"
-						title={ translate( 'Click to Play' ) }>
-						<img className="reader-post-card__play-icon" src="/calypso/images/reader/play-icon.png" />
-					</div>
-				</FeaturedImage>
-			);
-		}
-
-		/* eslint-disable react/no-danger */
-		return (
-			<div ref={ this.setVideoEmbedRef }
-				dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
-			/>
-		);
-		/* eslint-enable-line react/no-danger */
-	}
-}
+import FeaturedAsset from './featured-asset';
 
 export default class RefreshPostCard extends React.Component {
 	static propTypes = {
@@ -169,29 +83,16 @@ export default class RefreshPostCard extends React.Component {
 
 	render() {
 		const { post, site, feed, onCommentClick } = this.props;
-		const featuredImage = post.canonical_image;
 		const isPhotoOnly = post.display_type & DisplayTypes.PHOTO_ONLY;
 		const title = truncate( post.title, {
 			length: 140,
 			separator: /,? +/
 		} );
-
-		// only feature an embed if we know how to thumbnail & autoplay it
-		const featuredEmbed = head( filter( post.content_embeds, ( embed ) => embed.thumbnailUrl && embed.autoplayIframe ) );
-
-		// we only show a featured embed when all of these are true
-		//   - there is no featured image on the post that's big enough to pass as the canonical image
-		//   - there is an available embed
-		//
-		const useFeaturedEmbed = featuredEmbed &&
-			( ! featuredImage || ( featuredImage !== post.featured_image && featuredImage !== get( post, 'post_thumbnail.URL' ) ) );
-
-		const featuredAsset = useFeaturedEmbed
-			? <FeaturedVideo { ...featuredEmbed } videoEmbed={ featuredEmbed } />
-			: <FeaturedImage imageUri={ get( featuredImage, 'uri' ) } href={ post.URL } />;
+		const featuredAsset = ( <FeaturedAsset post={ post } /> );
+		const hasFeaturedAsset = !! featuredAsset;
 
 		const classes = classnames( 'reader-post-card', {
-			'has-thumbnail': !! featuredAsset,
+			'has-thumbnail': hasFeaturedAsset,
 			'is-photo': isPhotoOnly
 		} );
 
@@ -199,7 +100,7 @@ export default class RefreshPostCard extends React.Component {
 			<Card className={ classes } onClick={ this.handleCardClick }>
 				<PostByline post={ post } site={ site } feed={ feed } />
 				<div className="reader-post-card__post">
-					{ featuredAsset }
+					{ hasFeaturedAsset && featuredAsset }
 					<div className="reader-post-card__post-details">
 						<h1 className="reader-post-card__title">
 							<a className="reader-post-card__title-link" href={ post.URL }>{ title }</a>

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -89,10 +89,9 @@ export default class RefreshPostCard extends React.Component {
 			separator: /,? +/
 		} );
 		const featuredAsset = ( <FeaturedAsset post={ post } /> );
-		const hasFeaturedAsset = !! featuredAsset;
 
 		const classes = classnames( 'reader-post-card', {
-			'has-thumbnail': hasFeaturedAsset,
+			'has-thumbnail': !! featuredAsset,
 			'is-photo': isPhotoOnly
 		} );
 
@@ -100,7 +99,7 @@ export default class RefreshPostCard extends React.Component {
 			<Card className={ classes } onClick={ this.handleCardClick }>
 				<PostByline post={ post } site={ site } feed={ feed } />
 				<div className="reader-post-card__post">
-					{ hasFeaturedAsset && featuredAsset }
+					{ featuredAsset }
 					<div className="reader-post-card__post-details">
 						<h1 className="reader-post-card__title">
 							<a className="reader-post-card__title-link" href={ post.URL }>{ title }</a>


### PR DESCRIPTION
This PR does the following reorganisational goodness:
- creates a new wrapper component for featured image and video called `FeaturedAsset`
- moves existing image and video components to their own files
