### PR TITLE
Add the missing space after dot due to #8912.

### DIFF
--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -37,7 +37,7 @@ const SecurityCheckup = React.createClass( {
 
 				<CompactCard className="security-checkup-intro">
 					<p className="security-checkup-intro__text">
-						{ this.props.translate( 'Keep your account safe by adding a backup email address and phone number.' +
+						{ this.props.translate( 'Keep your account safe by adding a backup email address and phone number. ' +
 								'If you ever have problems accessing your account, WordPress.com will use what ' +
 								'you enter here to verify your identity.' ) }
 					</p>


### PR DESCRIPTION
A space after dot is missing in the string due to #8912 and causes the translation fuzzy. This PR adds it back.