### PR TITLE
Jetpack Connect: Remove usage of sites-list from plans

### DIFF
--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -25,10 +25,8 @@ import i18nUtils from 'lib/i18n-utils';
 import analytics from 'lib/analytics';
 import config from 'config';
 import route from 'lib/route';
-import sitesFactory from 'lib/sites-list';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-
-const sites = sitesFactory();
+import { getSelectedSite } from 'state/ui/selectors';
 
 /**
  * Module variables
@@ -178,7 +176,7 @@ export default {
 	plansLanding( context ) {
 		const Plans = require( './plans' ),
 			CheckoutData = require( 'components/data/checkout' ),
-			site = sites.getSelectedSite(),
+			site = getSelectedSite( context.store.getState() ),
 			analyticsPageTitle = 'Plans',
 			basePath = route.sectionify( context.path ),
 			analyticsBasePath = basePath + '/:site';
@@ -198,7 +196,6 @@ export default {
 		renderWithReduxStore(
 			<CheckoutData>
 				<Plans
-					sites={ sites }
 					context={ context }
 					destinationType={ context.params.destinationType }
 					intervalType={ context.params.intervalType } />

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -25,17 +25,17 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { requestPlans } from 'state/plans/actions';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 
 const Plans = React.createClass( {
-	mixins: [ observe( 'sites', 'plans' ) ],
+	mixins: [ observe( 'plans' ) ],
 
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
 		context: React.PropTypes.object.isRequired,
 		destinationType: React.PropTypes.string,
-		sites: React.PropTypes.object.isRequired,
 		sitePlans: React.PropTypes.object.isRequired,
 		showJetpackFreePlan: React.PropTypes.bool,
 		intervalType: React.PropTypes.string
@@ -163,9 +163,9 @@ const Plans = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => {
+	state => {
 		const user = getCurrentUser( state );
-		const selectedSite = props.sites.getSelectedSite();
+		const selectedSite = getSelectedSite( state );
 
 		const searchPlanBySlug = ( planSlug ) => {
 			return getPlanBySlug( state, planSlug );


### PR DESCRIPTION
This PR removes `sites-list` usage in favor of the Redux UI selectors within `signup/jetpack-connect`. It is part of the group effort to remove usage of `sites-list` (https://github.com/Automattic/wp-calypso/projects/3), particularly `getSelectedSite()` - #8726.

To test:

* Checkout this branch.
* Go to `/jetpack/connect` and connect a site
* Verify you're seeing the proper plans page
* Toggle monthly/yearly view and verify that the plans page works properly and has no regressions.

/cc @roccotripaldi @gwwar 