### PR TITLE
pathToSection: don't depend on 'wordpress-com'

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -14,17 +14,16 @@ import {
 	mapValues,
 	omit,
 	property,
-	startsWith,
 } from 'lodash';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-import wpSections from 'wordpress-com';
 import Card from 'components/card';
 import Button from 'components/button';
 import ExternalLink from 'components/external-link';
+import pathToSection from 'lib/path-to-section';
 import { ROUTE_SET } from 'state/action-types';
 import { tourBranching } from './config-parsing';
 import {
@@ -34,17 +33,6 @@ import {
 	query,
 	targetForSlug,
 } from './positioning';
-
-// FIXME(mcsf): this is temporarily requiring 'wordpress-com', as requiring
-// 'sections' directly  makes webpack create a lot of new dependencies on
-// chunks 'theme' and 'themes'
-const pathToSection = path => {
-	const match = find( wpSections, section =>
-			section.paths.some( sectionPath =>
-				startsWith( path, sectionPath ) ) );
-
-	return match && match.name;
-};
 
 const debug = debugFactory( 'calypso:guided-tours' );
 const contextTypes = Object.freeze( {

--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -20,7 +20,7 @@ const sections = config( 'project' ) === 'wordpress-com'
  *  f( '/me/account' ) === 'me"
  *  f( '/read' ) === 'reader'
  */
-const wpcomImplementation = path => {
+export const wpcomImplementation = path => {
 	const match = find( sections, section =>
 			section.paths.some( sectionPath =>
 				startsWith( path, sectionPath ) ) );
@@ -33,7 +33,7 @@ const wpcomImplementation = path => {
  *
  * 	f( '/foo/bar' ) === 'foo'
  */
-const fallbackImplementation = path => {
+export const fallbackImplementation = path => {
 	const match = path.match( /[^/]+/ );
 	return match && match[ 0 ];
 };

--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { find, startsWith } from 'lodash';
+
+/**
+ * Conditional dependency
+ */
+const sections = config( 'project' ) === 'wordpress-com'
+	? require( 'wordpress-com' )
+	: null;
+
+/*
+ * wordpress-com-aware implementation where
+ *
+ *  f( '/' ) === 'reader"
+ *  f( '/design' ) === 'themes'
+ *  f( '/me' ) === 'me"
+ *  f( '/me/account' ) === 'me"
+ *  f( '/read' ) === 'reader'
+ */
+const wpcomImplementation = path => {
+	const match = find( sections, section =>
+			section.paths.some( sectionPath =>
+				startsWith( path, sectionPath ) ) );
+
+	return match && match.name;
+};
+
+/*
+ * Dead-simple alternative implementation where
+ *
+ * 	f( '/foo/bar' ) === 'foo'
+ */
+const fallbackImplementation = path => {
+	const match = path.match( /[^/]+/ );
+	return match && match[ 0 ];
+};
+
+const pathToSection = sections
+	? wpcomImplementation
+	: fallbackImplementation;
+
+export default pathToSection;

--- a/client/lib/path-to-section/index.js
+++ b/client/lib/path-to-section/index.js
@@ -31,6 +31,7 @@ export const wpcomImplementation = path => {
 /*
  * Dead-simple alternative implementation where
  *
+ * 	f( '/' ) === null
  * 	f( '/foo/bar' ) === 'foo'
  */
 export const fallbackImplementation = path => {

--- a/client/lib/path-to-section/test/index.js
+++ b/client/lib/path-to-section/test/index.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+import {
+	wpcomImplementation,
+	fallbackImplementation
+} from '..';
+
+describe( 'pathToSection', () => {
+	describe( 'wpcomImplementation', () => {
+		it( 'should assume the Reader as the app root', () => {
+			expect( wpcomImplementation( '/' ) ).to.equal( 'reader' );
+		} );
+		it( 'should handle cases where path and section have different names', () => {
+			expect( wpcomImplementation( '/design' ) ).to.equal( 'themes' );
+			expect( wpcomImplementation( '/read' ) ).to.equal( 'reader' );
+		} );
+		it( 'should handle deep paths', () => {
+			expect( wpcomImplementation( '/me/account' ) ).to.equal( 'me' );
+		} );
+	} );
+
+	describe( 'fallbackImplementation', () => {
+		it( 'should assume the top of the path is the section', () => {
+			expect( fallbackImplementation( '/foo/bar' ) ).to.equal( 'foo' );
+		} );
+		it( 'should return null if unsuccessful', () => {
+			expect( fallbackImplementation( '/' ) ).to.equal( null );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes #8855 
# To test
- Make sure your regular Calypso builds with no unusual complaints
- Make sure Guided Tours can run (append `?tour=main`) and its [blanket exit](https://github.com/Automattic/wp-calypso/pull/7908) feature works as it should
- Rename the `project` config key (see `config/_shared.json`) and make sure that Calypso still builds and runs normally — the logic for the blanket exit feature in Guided Tours should be affected, but that is of no concern.
# To do
- [x] Basic unit tests
