### PR TITLE
Remove xgettext-js dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -531,7 +531,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000568"
+      "version": "1.0.30000569"
     },
     "caseless": {
       "version": "0.11.0"
@@ -2666,7 +2666,7 @@
       "dev": true
     },
     "object.omit": {
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     "object.values": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -128,8 +128,7 @@
     "wpcom": "5.3.0",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "3.0.0",
-    "wpcom-xhr-request": "1.0.0",
-    "xgettext-js": "1.0.0"
+    "wpcom-xhr-request": "1.0.0"
   },
   "engines": {
     "node": "6.9.1",


### PR DESCRIPTION
One of Calypso's dependencies is `xgettext-js`, but I've noticed that we're not using it anywhere. It is used by `i18n-calypso`, but this is a separate module which includes it separately as a dependency. This PR suggests removing that dependency.

/cc @gwwar