### PR TITLE
Themes: prevent losing focus when interacting with search Suggestions and WelcomeBanner

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -107,7 +107,10 @@ const Suggestions = React.createClass( {
 	},
 
 	onMouseDown( event ) {
-		this.props.suggest( event.target.textContent );
+		event.stopPropagation();
+		event.preventDefault();
+		//Additional empty space at the end adds fluidity to workflow
+		this.props.suggest( event.target.textContent + ' ' );
 	},
 
 	onMouseOver( event ) {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -191,6 +191,10 @@
 	}
 }
 
+.themes-magic-search-card__welcome-taxonomy-icon {
+	pointer-events: none;
+}
+
 .themes-magic-search-card__welcome-taxonomy-type-color {
 	color: rgb( 0, 170, 220 );
 }

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -20,6 +20,8 @@ class MagicSearchWelcome extends React.Component {
 
 	onMouseDown = ( event ) => {
 		this.props.suggestionsCallback( event.target.textContent + ':' );
+		event.stopPropagation();
+		event.preventDefault();
 	}
 
 	renderToken = ( taxonomy ) => {
@@ -31,7 +33,7 @@ class MagicSearchWelcome extends React.Component {
 		return (
 			<div
 				className={ themesTokenTypeClass }
-				onMouseDown={ this.onMouseDown }
+				onMouseDownCapture={ this.onMouseDown }
 				key={ taxonomy }
 			>
 				<Gridicon icon={ taxonomyToGridicon( taxonomy ) } className="themes-magic-search-card__welcome-taxonomy-icon" size={ 18 } />


### PR DESCRIPTION
### Fixes `Suggestions` `Welcome Banner` user interaction.

Previously `Input` lost focus when user has clicked item inside `Welcome Banner`:
![bad_focus](https://cloud.githubusercontent.com/assets/17271089/19773420/cc7626da-9c69-11e6-8e53-aed8f23d3b3b.gif)

Now `Input` keeps focus:
![good_focus](https://cloud.githubusercontent.com/assets/17271089/19773455/f16b58f2-9c69-11e6-854f-ec327976bd5e.gif)

To test compare interactions in `/design` from this PR and current version at `wpcalypso`

Additionally what is not shown on ^ gif is addition of space at the end of suggestion. This keeps suggestions panel open and ready for picking other categories.