### PR TITLE
GuidedTours: bail from tours when in a blacklisted section

### DIFF
--- a/client/state/ui/guided-tours/selectors.js
+++ b/client/state/ui/guided-tours/selectors.js
@@ -3,18 +3,24 @@
 /**
  * External dependencies
  */
-import { get, difference, find, map, noop, startsWith, uniq } from 'lodash';
+import { get, difference, find, includes, map, noop, startsWith, uniq } from 'lodash';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import { ROUTE_SET } from 'state/action-types';
-import { getInitialQueryArguments } from 'state/ui/selectors';
+import { getInitialQueryArguments, getSectionName } from 'state/ui/selectors';
 import { getActionLog } from 'state/ui/action-log/selectors';
 import { getPreference } from 'state/preferences/selectors';
 import GuidedToursConfig from 'layout/guided-tours/config';
 import createSelector from 'lib/create-selector';
+
+const BLACKLISTED_SECTIONS = [
+	'signup',
+	'upgrades', // checkout
+	'checkout-thank-you', // thank you page
+];
 
 const getToursHistory = state => getPreference( state, 'guided-tours-history' );
 const debug = debugFactory( 'calypso:guided-tours' );
@@ -123,8 +129,13 @@ const findTriggeredTour = state => {
 	} );
 };
 
+const shouldBail = state => {
+	// bail if we're on a blacklisted page
+	return includes( BLACKLISTED_SECTIONS, getSectionName( state ) );
+};
+
 export const findEligibleTour = createSelector(
-	state => findRequestedTour( state ) || findTriggeredTour( state ),
+	state => ! shouldBail( state ) && ( findRequestedTour( state ) || findTriggeredTour( state ) ),
 	[ getActionLog, getToursHistory ]
 );
 


### PR DESCRIPTION
Currently, tours aren't restricted from being shown during checkout and on similar pages where we definitely never want to distract the user with a tour. 

This PR introduces a list of blacklisted sections in which we'll always bail from showing a tour. 

I included signup and the post-checkout thank you page for now. It's for discussion whether it makes sense to blacklist them. 

Arguments in favor:
- "thank you" is a giant CTA all by itself, we don't want to distract from that. If we want to change the CTA, we should change the page itself, not add a tour. 
- "signup" is a very critical sub-process that we definitely do not want to disturb. If we want to improve the process, then we should do that by ... improving the process itself, not add a distraction to it. 

To test:
- Go through signup, upgrade to a plan, then do checkout until you get to the thank you page. Make sure no tour shows up. 
- On `/start`, the checkout, and the thank you page, add `?tour=main` to the URL. Make sure still no tour shows up. 
- Make sure the `main` tour still gets triggered here: `http://calypso.localhost:3000/?tour=main`

/cc @mcsf @marekhrabe 

Closes #7635. 
