### PR TITLE
ImageEditor: restore original media file

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -243,6 +243,8 @@ MediaActions.update = function( siteId, item, editMediaFile = false ) {
 		// Show a fake transient media item that can be rendered into the list immediately,
 		// even before the media has persisted to the server`
 		updateAction.data = { ...newItem, ...MediaActions.createTransientMedia( mediaId, item.media ) };
+	} else if ( editMediaFile && item.media_url ) {
+		updateAction.data = { ...newItem, ...MediaActions.createTransientMedia( mediaId, item.media_url ) };
 	}
 
 	debug( 'Updating media for %o by ID %o to %o', siteId, mediaId, updateAction );

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -241,7 +241,7 @@ MediaActions.update = function( siteId, item, editMediaFile = false ) {
 
 	if ( item.media ) {
 		// Show a fake transient media item that can be rendered into the list immediately,
-		// even before the media has persisted to the server`
+		// even before the media has persisted to the server
 		updateAction.data = { ...newItem, ...MediaActions.createTransientMedia( mediaId, item.media ) };
 	} else if ( editMediaFile && item.media_url ) {
 		updateAction.data = { ...newItem, ...MediaActions.createTransientMedia( mediaId, item.media_url ) };

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -33,12 +33,6 @@
 	}
 }
 
-.editor-media-modal-detail.is-original-loaded {
-	.image-preloader {
-		opacity: 0.5;
-	}
-}
-
 .editor-media-modal-detail__preview-wrapper {
 	flex: 2 0 0%;
 	position: relative;
@@ -68,7 +62,7 @@
 		height: auto;
 	}
 
-	&.is-fake {
+	&.is-image.is-loading {
 		opacity: 0.5;
 	}
 }

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -54,15 +54,21 @@
 	max-height: 100%;
 	max-width: 100%;
 	transform: translate( -50%, -50% );
+
+	.spinner__border {
+		fill: transparent;
+	}
 }
 
 .editor-media-modal-detail__preview {
 	&.is-image {
 		width: auto;
 		height: auto;
+		transition: opacity 200ms ease-in-out;
 	}
 
-	&.is-image.is-loading {
+	&.is-uploading,
+	&.is-loading {
 		opacity: 0.5;
 	}
 }
@@ -111,8 +117,8 @@
 		@include breakpoint( ">480px" ) {
 			display: block;
 			position: absolute;
-		    top: 8px;
-		    right: 8px;
+			    top: 8px;
+			    right: 8px;
 
 		    button {
 		    	margin-left: 8px;

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -67,6 +67,10 @@
 		width: auto;
 		height: auto;
 	}
+
+	&.is-fake {
+		opacity: 0.5;
+	}
 }
 
 .editor-media-modal-detail__previous,

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -33,6 +33,12 @@
 	}
 }
 
+.editor-media-modal-detail.is-original-loaded {
+	.image-preloader {
+		opacity: 0.5;
+	}
+}
+
 .editor-media-modal-detail__preview-wrapper {
 	flex: 2 0 0%;
 	position: relative;
@@ -100,26 +106,43 @@
 	}
 }
 
-.editor-media-modal-detail__edit {
-	font-weight: bold;
+.editor-media-modal-detail__edition-bar {
 	display: none;
+
 	&.is-desktop {
 		@include breakpoint( ">480px" ) {
 			display: block;
 			position: absolute;
-			top: 8px;
-			right: 8px;
+		    top: 8px;
+		    right: 8px;
+
+		    button {
+		    	margin-left: 8px;
+		    }
 		}
 	}
 
 	&.is-mobile {
 		@include breakpoint( "<480px" ) {
 			display: block;
-			width: 100%;
- 			margin-bottom: 16px;
+			button {
+				width: 48%;
+	 			margin-bottom: 8px;
+
+	 			&:first-child {
+	 				margin-right: 2%;
+	 			}
+
+	 			&:last-child {
+	 				margin-left: 2%;
+	 			}
+	 		}
 		}
 	}
 
+	button {
+		font-weight: bold;
+	}
 }
 
 .editor-media-modal-detail__sidebar {

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -175,6 +175,7 @@
 .editor-media-modal-detail__file-info tr {
 	display: block;
 	flex-basis: 50%;
+	width: 100%;
 }
 
 .editor-media-modal-detail__file-info th,
@@ -199,6 +200,10 @@
 
 	&::after {
 		@include long-content-fade( $color: $white );
+	}
+
+	span {
+		display: block;
 	}
 }
 

--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -88,7 +88,9 @@ module.exports = React.createClass( {
 				<tbody>
 					<tr>
 						<th>{ this.translate( 'File Name' ) }</th>
-						<td title={ this.getItemValue( 'file' ) }>{ this.getItemValue( 'file' ) }</td>
+						<td title={ this.getItemValue( 'file' ) }>
+							<span>{ this.getItemValue( 'file' ) }</span>
+						</td>
 					</tr>
 					<tr>
 						<th>{ this.translate( 'File Type' ) }</th>

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import { noop } from 'lodash';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
+import url from 'url';
 
 /**
  * Internal dependencies
@@ -95,6 +96,14 @@ class EditorMediaModalDetailItem extends Component {
 			item,
 			translate
 		} = this.props;
+
+		//do a simple guid vs url check
+		const guidParts = url.parse( item.guid );
+		const URLParts = url.parse( item.URL );
+
+		if ( guidParts.pathname === URLParts.pathname ) {
+			return false;
+		}
 
 		return (
 			<Button

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { noop } from 'lodash';
-import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 
@@ -22,8 +21,6 @@ import Gridicon from 'components/gridicon';
 import { userCan, isJetpack } from 'lib/site/utils';
 import MediaUtils, { isItemBeingUploaded } from 'lib/media/utils';
 import config from 'config';
-
-const debug = debugFactory( 'calypso:post-editor:media:detail-item' );
 
 class EditorMediaModalDetailItem extends Component {
 	static propTypes = {
@@ -54,18 +51,7 @@ class EditorMediaModalDetailItem extends Component {
 			translate
 		} = this.props;
 
-		// Do not render edit button for private sites
-		if ( site.is_private ) {
-			debug( 'Do not show `Edit button` for private sites' );
-			return null;
-		}
-
-		if (
-			! config.isEnabled( 'post-editor/image-editor' ) ||
-			! userCan( 'upload_files', site ) ||
-			isJetpack( site ) ||
-			! item
-		) {
+		if ( ! userCan( 'upload_files', site ) ) {
 			return null;
 		}
 
@@ -124,14 +110,8 @@ class EditorMediaModalDetailItem extends Component {
 	renderImageEditorButtons( item, classname = 'is-desktop' ) {
 		const { site } = this.props;
 
-		// Do not render edit button for private sites
-		if ( site.is_private ) {
-			debug( 'Do not show `Restore button` for private sites' );
-
-			return null;
-		}
-
 		if (
+			site.is_private ||
 			! config.isEnabled( 'post-editor/image-editor' ) ||
 			isJetpack( site ) ||
 			! item

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -89,7 +89,7 @@ class EditorMediaModalDetailItem extends Component {
 	handleOnRestoreClick = () => {
 		const { site, item, onRestore } = this.props;
 		onRestore( site && site.ID, item );
-	}
+	};
 
 	renderRestoreButton() {
 		const {

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -32,7 +32,8 @@ class EditorMediaModalDetailItem extends Component {
 		hasNextItem: PropTypes.bool,
 		onShowPreviousItem: PropTypes.func,
 		onShowNextItem: PropTypes.func,
-		onEdit: PropTypes.func
+		onEdit: PropTypes.func,
+		onRestore: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -40,10 +41,11 @@ class EditorMediaModalDetailItem extends Component {
 		hasNextItem: false,
 		onShowPreviousItem: noop,
 		onShowNextItem: noop,
-		onEdit: noop
+		onEdit: noop,
+		onRestore: noop,
 	};
 
-	renderEditButton( className ) {
+	renderEditButton() {
 		const {
 			item,
 			onEdit,
@@ -54,7 +56,6 @@ class EditorMediaModalDetailItem extends Component {
 		// Do not render edit button for private sites
 		if ( site.is_private ) {
 			debug( 'Do not show `Edit button` for private sites' );
-
 			return null;
 		}
 
@@ -75,12 +76,67 @@ class EditorMediaModalDetailItem extends Component {
 
 		return (
 			<Button
-				className={ classNames( 'editor-media-modal-detail__edit', className ) }
+				className="editor-media-modal-detail__edit"
 				onClick={ onEdit }
 				disabled={ isItemBeingUploaded( item ) }
 			>
 				<Gridicon icon="pencil" size={ 36 } /> { translate( 'Edit Image' ) }
 			</Button>
+		);
+	}
+
+	handleOnRestoreClick = () => {
+		const { site, item, onRestore } = this.props;
+		onRestore( site && site.ID, item );
+	}
+
+	renderRestoreButton() {
+		const {
+			item,
+			translate
+		} = this.props;
+
+		return (
+			<Button
+				className={ classNames(
+					'editor-media-modal-detail__restore',
+				) }
+				onClick={ this.handleOnRestoreClick }
+				disabled={ isItemBeingUploaded( item ) }
+			>
+				<Gridicon
+					icon="refresh"
+					size={ 36 } />
+					{ translate( 'Restore Original' ) }
+			</Button>
+		);
+	}
+
+	renderImageEditorButtons( item, classname = 'is-desktop' ) {
+		const { site } = this.props;
+
+		// Do not render edit button for private sites
+		if ( site.is_private ) {
+			debug( 'Do not show `Restore button` for private sites' );
+
+			return null;
+		}
+
+		if (
+			! config.isEnabled( 'post-editor/image-editor' ) ||
+			isJetpack( site ) ||
+			! item
+		) {
+			return null;
+		}
+
+		const classes = classNames( 'editor-media-modal-detail__edition-bar', classname );
+
+		return (
+			<div className={ classes }>
+				{ this.renderRestoreButton( classname ) }
+				{ this.renderEditButton() }
+			</div>
 		);
 	}
 
@@ -181,18 +237,21 @@ class EditorMediaModalDetailItem extends Component {
 		return (
 			<figure className={ classes }>
 				<div className="editor-media-modal-detail__content editor-media-modal__content">
+
 					<div className="editor-media-modal-detail__preview-wrapper">
 						{ this.renderItem() }
-						{ this.renderEditButton( 'is-desktop' ) }
+						{ this.renderImageEditorButtons( item ) }
 						{ this.renderPreviousItemButton() }
 						{ this.renderNextItemButton() }
 					</div>
+
 					<div className="editor-media-modal-detail__sidebar">
-						{ this.renderEditButton( 'is-mobile' ) }
+						{ this.renderImageEditorButtons( item, 'is-mobile' ) }
 						{ this.renderFields() }
 						<EditorMediaModalDetailFileInfo
 							item={ item } />
 					</div>
+
 				</div>
 			</figure>
 		);

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +16,14 @@ export default React.createClass( {
 
 	propTypes: {
 		site: PropTypes.object,
-		item: PropTypes.object.isRequired
+		item: PropTypes.object.isRequired,
+		onLoad: PropTypes.func,
+	},
+
+	getDefaultProps: function() {
+		return {
+			onLoad: noop
+		};
 	},
 
 	render() {
@@ -29,6 +37,7 @@ export default React.createClass( {
 				width={ this.props.item.width }
 				height={ this.props.item.height }
 				placeholder={ <Spinner /> }
+				onLoad={ this.props.onLoad }
 				alt={ this.props.item.alt || this.props.item.title }
 				className="editor-media-modal-detail__preview is-image" />
 		);

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -3,13 +3,14 @@
  */
 import React, { PropTypes } from 'react';
 import { noop } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import ImagePreloader from 'components/image-preloader';
 import Spinner from 'components/spinner';
-import MediaUtils from 'lib/media/utils';
+import { url, isItemBeingUploaded } from 'lib/media/utils';
 
 export default React.createClass( {
 	displayName: 'EditorMediaModalDetailPreviewImage',
@@ -27,29 +28,26 @@ export default React.createClass( {
 	},
 
 	render() {
-		const src = MediaUtils.url( this.props.item, {
+		const src = url( this.props.item, {
 			photon: this.props.site && ! this.props.site.is_private
 		} );
 
-		const { item, onLoad } = this.props;
-		const { alt, height, width, title } = item;
-
+		const classes = classNames(
+			'editor-media-modal-detail__preview',
+			'is-image',
+			{
+				'is-loading': isItemBeingUploaded( this.props.item )
+			}
+		);
 		return (
-			<div>
-				<img
-					className="editor-media-modal-detail__preview is-image is-fake"
-					src={ src }
-					width={ width }
-					height={ height } />
-				<ImagePreloader
-					src={ src }
-					width={ width }
-					height={ height }
-					placeholder={ <Spinner /> }
-					onLoad={ onLoad }
-					alt={ alt || title }
-					className="editor-media-modal-detail__preview is-image" />
-			</div>
+			<ImagePreloader
+				src={ src }
+				width={ this.props.item.width }
+				height={ this.props.item.height }
+				placeholder={ <Spinner /> }
+				onLoad={ this.props.onLoad }
+				alt={ this.props.item.alt || this.props.item.title }
+				className={ classes } />
 		);
 	}
 } );

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -31,23 +31,26 @@ export default React.createClass( {
 		const src = url( this.props.item, {
 			photon: this.props.site && ! this.props.site.is_private
 		} );
+		const loading = isItemBeingUploaded( this.props.item );
 
 		const classes = classNames(
 			'editor-media-modal-detail__preview',
-			'is-image',
-			{
-				'is-loading': isItemBeingUploaded( this.props.item )
+			'is-image', {
+				'is-loading': loading
 			}
 		);
 		return (
-			<ImagePreloader
-				src={ src }
-				width={ this.props.item.width }
-				height={ this.props.item.height }
-				placeholder={ <Spinner /> }
-				onLoad={ this.props.onLoad }
-				alt={ this.props.item.alt || this.props.item.title }
-				className={ classes } />
+			<div>
+				<ImagePreloader
+					src={ src }
+					width={ this.props.item.width }
+					height={ this.props.item.height }
+					placeholder={ <span /> }
+					onLoad={ this.props.onLoad }
+					alt={ this.props.item.alt || this.props.item.title }
+					className={ classes } />
+				{ loading && <Spinner /> }
+			</div>
 		);
 	}
 } );

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -31,15 +31,25 @@ export default React.createClass( {
 			photon: this.props.site && ! this.props.site.is_private
 		} );
 
+		const { item, onLoad } = this.props;
+		const { alt, height, width, title } = item;
+
 		return (
-			<ImagePreloader
-				src={ src }
-				width={ this.props.item.width }
-				height={ this.props.item.height }
-				placeholder={ <Spinner /> }
-				onLoad={ this.props.onLoad }
-				alt={ this.props.item.alt || this.props.item.title }
-				className="editor-media-modal-detail__preview is-image" />
+			<div>
+				<img
+					className="editor-media-modal-detail__preview is-image is-fake"
+					src={ src }
+					width={ width }
+					height={ height } />
+				<ImagePreloader
+					src={ src }
+					width={ width }
+					height={ height }
+					placeholder={ <Spinner /> }
+					onLoad={ onLoad }
+					alt={ alt || title }
+					className="editor-media-modal-detail__preview is-image" />
+			</div>
 		);
 	}
 } );

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
 import { noop } from 'lodash';
 import classNames from 'classnames';
 
@@ -12,45 +12,93 @@ import ImagePreloader from 'components/image-preloader';
 import Spinner from 'components/spinner';
 import { url, isItemBeingUploaded } from 'lib/media/utils';
 
-export default React.createClass( {
-	displayName: 'EditorMediaModalDetailPreviewImage',
-
-	propTypes: {
+export default class EditorMediaModalDetailPreviewImage extends Component {
+	static propTypes = {
 		site: PropTypes.object,
 		item: PropTypes.object.isRequired,
-		onLoad: PropTypes.func,
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			onLoad: noop
-		};
-	},
+	static defaultProps = {
+		onLoad: noop
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.onImagePreloaderLoad = this.onImagePreloaderLoad.bind( this );
+		this.state = { loading: false };
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.item.URL === nextProps.item.URL ) {
+			return null;
+		}
+
+		this.setState( { loading: true } );
+	}
+
+	onImagePreloaderLoad() {
+		this.setState( { loading: false } );
+		this.props.onLoad();
+	}
 
 	render() {
 		const src = url( this.props.item, {
 			photon: this.props.site && ! this.props.site.is_private
 		} );
-		const loading = isItemBeingUploaded( this.props.item );
+		const uploading = isItemBeingUploaded( this.props.item );
+		const loading = this.state.loading;
+		const isBlob = /^blob/.test( src );
+
+		// Let's add special classes to differentiate
+		// the different states that an image could have.
+		//
+		// - `is-uploading` when the image is being uploaded
+		//    from the client to the server.
+		// - `is-loading` when the image is being downloaded
+		//    from the server to the client.
+		// - `is-blob` when the image is shown using local `blob` data.
 
 		const classes = classNames(
 			'editor-media-modal-detail__preview',
-			'is-image', {
-				'is-loading': loading
-			}
+			'is-image',
+			{ 'is-uploading': uploading },
+			{ 'is-loading': loading },
+			{ 'is-blob': isBlob },
 		);
+
+		// A fake image element is added behind the preloading image
+		// in order to improve the UX between the states that an image could have,
+		// for instance when the image is restored.
+		const fakeClasses = classNames(
+			'editor-media-modal-detail__preview',
+			'is-image',
+			'is-fake',
+			{ 'is-uploading': uploading },
+			{ 'is-loading': loading },
+			{ 'is-blob': isBlob },
+		);
+
 		return (
 			<div>
+				<img
+					src={ src }
+					width={ this.props.item.width }
+					height={ this.props.item.height }
+					alt={ this.props.item.alt || this.props.item.title }
+					className={ fakeClasses } />
+
 				<ImagePreloader
 					src={ src }
 					width={ this.props.item.width }
 					height={ this.props.item.height }
+					onLoad={ this.onImagePreloaderLoad }
 					placeholder={ <span /> }
-					onLoad={ this.props.onLoad }
 					alt={ this.props.item.alt || this.props.item.title }
 					className={ classes } />
-				{ loading && <Spinner /> }
+
+				{ ( uploading || loading ) && <Spinner /> }
 			</div>
 		);
 	}
-} );
+}

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -23,7 +23,8 @@ const EditorMediaModalDetail = React.createClass( {
 		selectedIndex: React.PropTypes.number,
 		onSelectedIndexChange: React.PropTypes.func,
 		onReturnToList: React.PropTypes.func,
-		onEdit: React.PropTypes.func
+		onEdit: React.PropTypes.func,
+		onRestore: React.PropTypes.func,
 	},
 
 	getDefaultProps: function() {
@@ -56,23 +57,34 @@ const EditorMediaModalDetail = React.createClass( {
 	},
 
 	render: function() {
-		const { items } = this.props;
+		const {
+			items,
+			selectedIndex,
+			site,
+
+			onEditItem,
+			onRestoreItem,
+			onReturnToList,
+		} = this.props;
+
+		const item = items[ selectedIndex ];
 
 		return (
 			<div className="editor-media-modal-detail">
-				<HeaderCake onClick={ this.props.onReturnToList } backText={ this.translate( 'Media Library' ) }>
+				<HeaderCake onClick={ onReturnToList } backText={ this.translate( 'Media Library' ) }>
 					<EditorMediaModalDetailTitle
-						site={ this.props.site }
-						item={ items[ this.props.selectedIndex ] } />
+						site={ site }
+						item={ items[ selectedIndex ] } />
 				</HeaderCake>
 				<DetailItem
-					site={ this.props.site }
-					item={ items[ this.props.selectedIndex ] }
-					hasPreviousItem={ this.props.selectedIndex - 1 >= 0 }
-					hasNextItem={ this.props.selectedIndex + 1 < items.length }
+					site={ site }
+					item={ item }
+					hasPreviousItem={ selectedIndex - 1 >= 0 }
+					hasNextItem={ selectedIndex + 1 < items.length }
 					onShowPreviousItem={ this.incrementIndex.bind( this, -1 ) }
 					onShowNextItem={ this.incrementIndex.bind( this, 1 ) }
-					onEdit={ this.props.onEditItem } />
+					onRestore={ onRestoreItem }
+					onEdit={ onEditItem } />
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -200,6 +200,13 @@ export const EditorMediaModal = React.createClass( {
 		this.props.setView( ModalViews.IMAGE_EDITOR );
 	},
 
+	restoreOriginalMedia: function( siteId, item ) {
+		if ( ! siteId || ! item ) {
+			return;
+		}
+		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
+	},
+
 	onImageEditorDone( error, blob, imageEditorProps ) {
 		if ( error ) {
 			this.onImageEditorCancel( imageEditorProps );
@@ -229,8 +236,8 @@ export const EditorMediaModal = React.createClass( {
 
 		resetAllImageEditorState();
 
-		MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
-		this.props.setView( ModalViews.LIST );
+		this.props.setView( ModalViews.DETAIL );
+
 	},
 
 	onImageEditorCancel: function( imageEditorProps ) {
@@ -383,6 +390,7 @@ export const EditorMediaModal = React.createClass( {
 						site={ this.props.site }
 						items={ this.props.mediaLibrarySelectedItems }
 						selectedIndex={ this.getDetailSelectedIndex() }
+						onRestoreItem={ this.restoreOriginalMedia }
 						onSelectedIndexChange={ this.setDetailSelectedIndex } />
 				);
 				break;

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -204,6 +204,7 @@ export const EditorMediaModal = React.createClass( {
 		if ( ! siteId || ! item ) {
 			return;
 		}
+
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
 	},
 
@@ -237,7 +238,6 @@ export const EditorMediaModal = React.createClass( {
 		resetAllImageEditorState();
 
 		this.props.setView( ModalViews.DETAIL );
-
 	},
 
 	onImageEditorCancel: function( imageEditorProps ) {


### PR DESCRIPTION
This PR tries to achieve the functionality to restoring the original media file once the media was edited.

Although we already have some description for this implementation I've had to implement some behaviors using my own criteria. 😨 
For this reason, I would like to know the opinion of @adambbecker and @mtias. Here an animation:

![calypso-image-editor-restore-image-17](https://cloud.githubusercontent.com/assets/77539/19949617/78ed53a4-a131-11e6-9c70-7844e6ba939d.gif)

Keep in mind that this PR belongs to [Editor V1 project](https://github.com/Automattic/wp-calypso/projects/4), and we have thought to continue with [Editor V2](https://github.com/Automattic/wp-calypso/projects/5) immediately once V1 is ready. Thus I'm pretty sure that, although this implementation is ok at least in my opinion, it's very probable that it will be updated soon according to new improvements.
### Testing

A picture is worth a thousand words. Take a look at the animation above.
