### PR TITLE
Reader: Use DocumentHead to set the page title on full post

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -52,6 +52,7 @@ import { getSite } from 'state/reader/sites/selectors';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
 import ExternalLink from 'components/external-link';
+import DocumentHead from 'components/data/document-head';
 
 export class FullPostView extends React.Component {
 	constructor( props ) {
@@ -255,6 +256,10 @@ export class FullPostView extends React.Component {
 		/*eslint-disable react/jsx-no-target-blank */
 		return (
 			<ReaderMain className={ classNames( classes ) }>
+				{ ! post || post._state === 'pending'
+					? <DocumentHead title={ translate( 'Loading' ) } />
+					: <DocumentHead title={ `${ post.title } ‹ ${ siteName } ‹ Reader` } />
+				}
 				{ post && post.feed_ID && <QueryReaderFeed feedId={ post.feed_ID } /> }
 				{ post && ! post.is_external && post.site_ID && <QueryReaderSite siteId={ post.site_ID } /> }
 				<div className="reader-full-post__back-container">


### PR DESCRIPTION
Regression from current full post, where we set the title properly.

To test, pull up a full post view and notice the title has been properly set. Also try reloading the full post view, the title should flow through a 'loading' phase before showing the proper title.