### PR TITLE
Jetpack Connect: Fix error detection

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -278,7 +278,7 @@ const LoggedInForm = React.createClass( {
 		if ( activateManageSecret && ! manageActivated ) {
 			return this.activateManageAndRedirect();
 		}
-		if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
+		if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_expired' ) >= 0 ) {
 			window.location.href = queryObject.site + authUrl;
 			return;
 		}
@@ -359,7 +359,7 @@ const LoggedInForm = React.createClass( {
 		if ( authorizeError.message.indexOf( 'already_connected' ) >= 0 ) {
 			return <JetpackConnectNotices noticeType="alreadyConnected" />;
 		}
-		if ( authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
+		if ( authorizeError.message.indexOf( 'verify_secrets_expired' ) >= 0 ) {
 			return <JetpackConnectNotices noticeType="secretExpired" siteUrl={ queryObject.site } />;
 		}
 		if ( this.props.requestHasXmlrpcError() ) {
@@ -387,7 +387,7 @@ const LoggedInForm = React.createClass( {
 			return this.translate( 'Return to your site' );
 		}
 
-		if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
+		if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_expired' ) >= 0 ) {
 			return this.translate( 'Try again' );
 		}
 


### PR DESCRIPTION
Because the response codes in Jetpack have changed, we need to update logic for detecting when authorization fails due to expired secrets.

To test:
- On an unconnected jetpack site, replace `verify_action` method in class.jetpack-xmlrpc-server.php with the following:
 - https://gist.github.com/roccotripaldi/69800a83232e71b82767902852d3709b
 - This will allow you to force an expired secret error
- Run this branch locally, and go to calypso.localhost:3000/jetpack/connect
- Try connecting your site and ensure you get this message:

<img width="470" alt="screen shot 2016-10-27 at 3 00 53 pm" src="https://cloud.githubusercontent.com/assets/2694219/19781260/8853d168-9c56-11e6-845d-b6b9a6ccb754.png">

- Restore class.jetpack-xmlrpc-server.php to it's stable state on your jetpack site
- Click try again
- Ensure you can connect

cc: @johnHackworth @tyxla 
