### PR TITLE
Jetpack: avoid aprove button in jetpack connect flow

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -29,6 +29,7 @@ import {
 import {
 	getAuthorizationData,
 	getAuthorizationRemoteSite,
+	isRemoteSiteOnSitesList,
 	getSSOSessions,
 	isCalypsoStartedConnection,
 	hasXmlrpcError
@@ -639,7 +640,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 export default connect(
 	state => {
-		const remoteSite = getAuthorizationRemoteSite( state );
+		const remoteSiteUrl = getAuthorizationRemoteSite( state );
 
 		const requestHasXmlrpcError = () => {
 			return hasXmlrpcError( state );
@@ -648,14 +649,13 @@ export default connect(
 		const isFetchingSites = () => {
 			return isRequestingSites( state );
 		};
-
 		return {
 			jetpackConnectAuthorize: getAuthorizationData( state ),
 			jetpackSSOSessions: getSSOSessions( state ),
-			isAlreadyOnSitesList: !! remoteSite,
+			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			isFetchingSites,
 			requestHasXmlrpcError,
-			calypsoStartedConnection: remoteSite && isCalypsoStartedConnection( state, remoteSite.URL )
+			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl )
 		};
 	},
 	dispatch => bindActionCreators( {

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -23,13 +23,17 @@ const getAuthorizationRemoteQueryData = ( state ) => {
 };
 
 const getAuthorizationRemoteSite = ( state ) => {
-	const remoteUrl = get( getAuthorizationRemoteQueryData( state ), [ 'site' ] );
+	return get( getAuthorizationRemoteQueryData( state ), [ 'site' ] );
+};
+
+const isRemoteSiteOnSitesList = ( state ) => {
+	const remoteUrl = getAuthorizationRemoteSite( state );
 
 	if ( ! remoteUrl ) {
-		return null;
+		return false;
 	}
 
-	return getSiteByUrl( state, remoteUrl );
+	return !! getSiteByUrl( state, remoteUrl );
 };
 
 const getSessions = ( state ) => {
@@ -103,6 +107,7 @@ export default {
 	getSSOSessions,
 	getSSO,
 	isCalypsoStartedConnection,
+	isRemoteSiteOnSitesList,
 	getFlowType,
 	getJetpackSiteByUrl,
 	hasXmlrpcError

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -15,6 +15,7 @@ import {
 	getSSOSessions,
 	getSSO,
 	isCalypsoStartedConnection,
+	isRemoteSiteOnSitesList,
 	getFlowType,
 	getJetpackSiteByUrl,
 	hasXmlrpcError
@@ -116,16 +117,16 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getAuthorizationRemoteSite()', () => {
-		it( 'should return null if user has not started the authorization flow', () => {
+	describe( '#isRemoteSiteOnSitesList()', () => {
+		it( 'should return false if user has not started the authorization flow', () => {
 			const state = {
 				jetpackConnect: {}
 			};
 
-			expect( getAuthorizationRemoteSite( state ) ).to.be.null;
+			expect( isRemoteSiteOnSitesList( state ) ).to.be.false;
 		} );
 
-		it( 'should return the current authorization site if there is such', () => {
+		it( 'should return true if there site is in the sites list', () => {
 			const state = {
 				sites: {
 					items: {
@@ -150,7 +151,37 @@ describe( 'selectors', () => {
 				}
 			};
 
-			expect( getAuthorizationRemoteSite( state ) ).to.eql( state.sites.items[ 12345678 ] );
+			expect( isRemoteSiteOnSitesList( state ) ).to.be.true;
+		} );
+	} );
+
+	describe( '#getAuthorizationRemoteSite()', () => {
+		it( 'should return null if user has not started the authorization flow', () => {
+			const state = {
+				jetpackConnect: {}
+			};
+
+			expect( getAuthorizationRemoteSite( state ) ).to.be.undefined;
+		} );
+
+		it( 'should return the current authorization url if there is such', () => {
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize: {
+						queryObject: {
+							_wp_nonce: 'nonce',
+							client_id: '12345678',
+							redirect_uri: 'https://wordpress.com/',
+							scope: 'auth',
+							secret: '1234abcd',
+							state: 12345678,
+							site: 'https://wordpress.com/'
+						}
+					}
+				}
+			};
+
+			expect( getAuthorizationRemoteSite( state ) ).to.eql( state.jetpackConnect.jetpackConnectAuthorize.queryObject.site );
 		} );
 	} );
 


### PR DESCRIPTION
With the last refactor of our selectors, we introduced a small regression:  When a connection flow starts from the first step of jetpack connect, once we arrive at the authorization page, we are not being able to detect that it is a calypso started connection and we are asking the user for approval, as if they had started the connection on wp-admin. We should be just connecting the site right away. This PR fixes this.

How to test
========

0. You need an unconnected jetpack site
1. Go to http://calypso.localhost:3000/jetpack/connect/
2. Enter the url of your site
3. The auth flow should happen and you shouldn't be asked to 'approve' the connection at any point

@roccotripaldi @tyxla 