### PR TITLE
Jetpack Connect: Cleanup and ES6ify Plans

### DIFF
--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -26,7 +26,8 @@ import analytics from 'lib/analytics';
 import config from 'config';
 import route from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 /**
  * Module variables
@@ -176,12 +177,14 @@ export default {
 	plansLanding( context ) {
 		const Plans = require( './plans' ),
 			CheckoutData = require( 'components/data/checkout' ),
-			site = getSelectedSite( context.store.getState() ),
+			state = context.store.getState(),
+			siteId = getSelectedSiteId( state ),
+			isJetpack = isJetpackSite( state, siteId ),
 			analyticsPageTitle = 'Plans',
 			basePath = route.sectionify( context.path ),
 			analyticsBasePath = basePath + '/:site';
 
-		if ( ! site || ! site.jetpack || ! config.isEnabled( 'jetpack/connect' ) ) {
+		if ( ! config.isEnabled( 'jetpack/connect' ) || ! isJetpack ) {
 			return;
 		}
 

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -54,7 +54,7 @@ class Plans extends Component {
 			user: this.props.userId
 		} );
 
-		if ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) {
+		if ( this.isFlowTypePaid() ) {
 			return this.autoselectPlan();
 		}
 	}
@@ -68,7 +68,7 @@ class Plans extends Component {
 				page.redirect( CALYPSO_REDIRECTION_PAGE + this.props.selectedSite.slug );
 			}
 
-			if ( ! this.props.isRequestingPlans && ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) ) {
+			if ( ! this.props.isRequestingPlans && this.isFlowTypePaid() ) {
 				return this.autoselectPlan();
 			}
 		} else if ( this.props.hasPaidPlan || ! this.props.canPurchasePlans ) {
@@ -77,20 +77,26 @@ class Plans extends Component {
 		}
 	}
 
+	isFlowTypePaid() {
+		return this.props.flowType === 'pro' || this.props.flowType === 'premium';
+	}
+
 	autoselectPlan() {
-		if ( this.props.flowType === 'pro' ) {
-			const plan = this.props.getPlanBySlug( PLAN_JETPACK_BUSINESS );
-			if ( plan ) {
-				this.selectPlan( plan );
-				return;
-			}
+		if ( ! this.isFlowTypePaid() ) {
+			return;
 		}
-		if ( this.props.flowType === 'premium' ) {
-			const plan = this.props.getPlanBySlug( PLAN_JETPACK_PREMIUM );
-			if ( plan ) {
-				this.selectPlan( plan );
-				return;
-			}
+
+		let planSlug = '';
+		if ( this.props.flowType === 'pro' ) {
+			planSlug = PLAN_JETPACK_BUSINESS;
+		} else if ( this.props.flowType === 'premium' ) {
+			planSlug = PLAN_JETPACK_PREMIUM;
+		}
+
+		const plan = this.props.getPlanBySlug( planSlug );
+		if ( plan ) {
+			this.selectPlan( plan );
+			return;
 		}
 	}
 
@@ -128,7 +134,7 @@ class Plans extends Component {
 	render() {
 		const { translate } = this.props;
 
-		if ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) {
+		if ( this.isFlowTypePaid() ) {
 			return null;
 		}
 

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -31,6 +31,11 @@ const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLAN_PAGE = '/plans/my-plan/';
 
 class Plans extends Component {
+	constructor() {
+		super();
+		this.selectPlan = this.selectPlan.bind( this );
+	}
+
 	static propTypes = {
 		cart: PropTypes.object.isRequired,
 		context: PropTypes.object.isRequired,

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -18,13 +18,13 @@ import PlansFeaturesMain from 'my-sites/plans-features-main';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import * as upgradesActions from 'lib/upgrades/actions';
-import { userCan } from 'lib/site/utils';
 import { getAuthorizationData, isCalypsoStartedConnection } from 'state/jetpack-connect/selectors';
 import { goBackToWpAdmin } from 'state/jetpack-connect/actions';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
+import { canCurrentUser } from 'state/current-user/selectors';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLAN_PAGE = '/plans/my-plan/';
@@ -174,7 +174,7 @@ export default connect(
 			sitePlans: getPlansBySite( state, selectedSite ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),
 			userId: user ? user.ID : null,
-			canPurchasePlans: userCan( 'manage_options', selectedSite ),
+			canPurchasePlans: canCurrentUser( state, selectedSite.ID, 'manage_options' ),
 			flowType: getFlowType( state, selectedSite && selectedSite.slug ),
 			isRequestingPlans: isRequestingPlans( state ),
 			getPlanBySlug: searchPlanBySlug,

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { PLAN_JETPACK_FREE, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { isCurrentPlanPaid } from 'state/sites/selectors';
 import { getFlowType } from 'state/jetpack-connect/selectors';
@@ -73,14 +74,14 @@ class Plans extends Component {
 
 	autoselectPlan() {
 		if ( this.props.flowType === 'pro' ) {
-			const plan = this.props.getPlanBySlug( 'jetpack_business' );
+			const plan = this.props.getPlanBySlug( PLAN_JETPACK_BUSINESS );
 			if ( plan ) {
 				this.selectPlan( plan );
 				return;
 			}
 		}
 		if ( this.props.flowType === 'premium' ) {
-			const plan = this.props.getPlanBySlug( 'jetpack_premium' );
+			const plan = this.props.getPlanBySlug( PLAN_JETPACK_PREMIUM );
 			if ( plan ) {
 				this.selectPlan( plan );
 				return;
@@ -102,15 +103,15 @@ class Plans extends Component {
 
 	selectPlan( cartItem ) {
 		const checkoutPath = `/checkout/${ this.props.selectedSite.slug }`;
-		if ( cartItem.product_slug === 'jetpack_free' ) {
+		if ( cartItem.product_slug === PLAN_JETPACK_FREE ) {
 			return this.selectFreeJetpackPlan();
 		}
-		if ( cartItem.product_slug === 'jetpack_premium' ) {
+		if ( cartItem.product_slug === PLAN_JETPACK_PREMIUM ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_99', {
 				user: this.props.userId
 			} );
 		}
-		if ( cartItem.product_slug === 'jetpack_business' ) {
+		if ( cartItem.product_slug === PLAN_JETPACK_BUSINESS ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_299', {
 				user: this.props.userId
 			} );

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -18,7 +18,7 @@ import StepHeader from '../step-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
-import * as upgradesActions from 'lib/upgrades/actions';
+import { addItem } from 'lib/upgrades/actions';
 import { getAuthorizationData, isCalypsoStartedConnection } from 'state/jetpack-connect/selectors';
 import { goBackToWpAdmin } from 'state/jetpack-connect/actions';
 import QueryPlans from 'components/data/query-plans';
@@ -116,7 +116,7 @@ class Plans extends Component {
 				user: this.props.userId
 			} );
 		}
-		upgradesActions.addItem( cartItem );
+		addItem( cartItem );
 		page( checkoutPath );
 	}
 

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -3,7 +3,8 @@
  */
 import { connect } from 'react-redux';
 import page from 'page';
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -28,21 +29,19 @@ import { getSelectedSite } from 'state/ui/selectors';
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLAN_PAGE = '/plans/my-plan/';
 
-const Plans = React.createClass( {
-	propTypes: {
-		cart: React.PropTypes.object.isRequired,
-		context: React.PropTypes.object.isRequired,
-		destinationType: React.PropTypes.string,
-		sitePlans: React.PropTypes.object.isRequired,
-		showJetpackFreePlan: React.PropTypes.bool,
-		intervalType: React.PropTypes.string
-	},
+class Plans extends Component {
+	static propTypes = {
+		cart: PropTypes.object.isRequired,
+		context: PropTypes.object.isRequired,
+		destinationType: PropTypes.string,
+		sitePlans: PropTypes.object.isRequired,
+		showJetpackFreePlan: PropTypes.bool,
+		intervalType: PropTypes.string
+	};
 
-	getDefaultProps() {
-		return {
-			intervalType: 'yearly'
-		};
-	},
+	static defaultProps = {
+		intervalType: 'yearly'
+	};
 
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_view', {
@@ -52,7 +51,7 @@ const Plans = React.createClass( {
 		if ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) {
 			return this.autoselectPlan();
 		}
-	},
+	}
 
 	componentDidUpdate() {
 		if ( this.props.calypsoStartedConnection ) {
@@ -70,7 +69,7 @@ const Plans = React.createClass( {
 			const { queryObject } = this.props.jetpackConnectAuthorize;
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		}
-	},
+	}
 
 	autoselectPlan() {
 		if ( this.props.flowType === 'pro' ) {
@@ -87,7 +86,7 @@ const Plans = React.createClass( {
 				return;
 			}
 		}
-	},
+	}
 
 	selectFreeJetpackPlan() {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_submit_free', {
@@ -99,7 +98,7 @@ const Plans = React.createClass( {
 			const { queryObject } = this.props.jetpackConnectAuthorize;
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		}
-	},
+	}
 
 	selectPlan( cartItem ) {
 		const checkoutPath = `/checkout/${ this.props.selectedSite.slug }`;
@@ -118,9 +117,11 @@ const Plans = React.createClass( {
 		}
 		upgradesActions.addItem( cartItem );
 		page( checkoutPath );
-	},
+	}
 
 	render() {
+		const { translate } = this.props;
+
 		if ( this.props.flowType === 'pro' || this.props.flowType === 'premium' ) {
 			return null;
 		}
@@ -136,8 +137,8 @@ const Plans = React.createClass( {
 					<QuerySitePlans siteId={ this.props.selectedSite.ID } />
 					<div className="jetpack-connect__plans">
 						<StepHeader
-							headerText={ this.translate( 'Your site is now connected!' ) }
-							subHeaderText={ this.translate( 'Now pick a plan that\'s right for you.' ) }
+							headerText={ translate( 'Your site is now connected!' ) }
+							subHeaderText={ translate( 'Now pick a plan that\'s right for you.' ) }
 							step={ 1 }
 							steps={ 3 } />
 
@@ -154,7 +155,7 @@ const Plans = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect(
 	state => {
@@ -184,4 +185,4 @@ export default connect(
 		goBackToWpAdmin,
 		recordTracksEvent
 	}
-)( Plans );
+)( localize( Plans ) );

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -4,7 +4,6 @@
 import { connect } from 'react-redux';
 import page from 'page';
 import React from 'react';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -14,7 +13,6 @@ import { isCurrentPlanPaid } from 'state/sites/selectors';
 import { getFlowType } from 'state/jetpack-connect/selectors';
 import Main from 'components/main';
 import StepHeader from '../step-header';
-import observe from 'lib/mixins/data-observe';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -24,7 +22,6 @@ import { getAuthorizationData, isCalypsoStartedConnection } from 'state/jetpack-
 import { goBackToWpAdmin } from 'state/jetpack-connect/actions';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { requestPlans } from 'state/plans/actions';
 import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 
@@ -32,8 +29,6 @@ const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLAN_PAGE = '/plans/my-plan/';
 
 const Plans = React.createClass( {
-	mixins: [ observe( 'plans' ) ],
-
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
 		context: React.PropTypes.object.isRequired,
@@ -79,7 +74,6 @@ const Plans = React.createClass( {
 
 	autoselectPlan() {
 		if ( this.props.flowType === 'pro' ) {
-			this.props.requestPlans();
 			const plan = this.props.getPlanBySlug( 'jetpack_business' );
 			if ( plan ) {
 				this.selectPlan( plan );
@@ -87,7 +81,6 @@ const Plans = React.createClass( {
 			}
 		}
 		if ( this.props.flowType === 'premium' ) {
-			this.props.requestPlans();
 			const plan = this.props.getPlanBySlug( 'jetpack_premium' );
 			if ( plan ) {
 				this.selectPlan( plan );
@@ -187,14 +180,8 @@ export default connect(
 			calypsoStartedConnection: isCalypsoStartedConnection( state, selectedSite.slug )
 		};
 	},
-	( dispatch ) => {
-		return Object.assign( {},
-			bindActionCreators( { goBackToWpAdmin, requestPlans }, dispatch ),
-			{
-				recordTracksEvent( eventName, props ) {
-					dispatch( recordTracksEvent( eventName, props ) );
-				}
-			}
-		);
+	{
+		goBackToWpAdmin,
+		recordTracksEvent
 	}
 )( Plans );


### PR DESCRIPTION
This PR aims to refactor and cleanup the Jetpack Connect - Plans page. It is inspired by @gwwar's [thorough review](https://github.com/Automattic/wp-calypso/pull/8976#pullrequestreview-6092390) on #8976. Key points of the refactor are:

* Removing mixins and manual dispatch fetches.
* Refactoring into an ES6 class and fixing ESLint warnings.
* Cleaning up `mapDispatchToProps`.
* Using lighter selectors where possible (avoid fetching full site object when we need just the ID).
* Using `current-user` redux state selectors instead of `lib/sites/utils`.
* Using plan constants instead of their direct string representations.
* Using only necessary `upgrades` actions instead of importing `*`.
* Simplifying `flowType` logic and avoid related code repetition.

To test:

* Checkout this branch.
* Go to `/jetpack/connect` and connect a site that has no plan. Verify it works correctly and there are no regressions in the JPC flow and the Plans page.
* Go to `/jetpack/connect` and connect a site that has a premium/business plan. Verify it works correctly and there are no regressions in the JPC flow and the Plans page.
* Verify that there are no functional or visual changes in the JPC flow and its Plans page.
