### PR TITLE
Editor: Fix warning when opening the editor

### DIFF
--- a/client/post-editor/editor-post-type/index.jsx
+++ b/client/post-editor/editor-post-type/index.jsx
@@ -63,7 +63,7 @@ EditorPostType.propTypes = {
 	isNew: PropTypes.bool,
 	typeSlug: PropTypes.string,
 	type: PropTypes.object,
-	globalId: PropTypes.number
+	globalId: PropTypes.string
 };
 
 export default connect( ( state ) => {


### PR DESCRIPTION
I noticed this warning when opening the editor 

![b1ebe50e-9ab4-11e6-91b0-e9ea638828a4](https://cloud.githubusercontent.com/assets/272444/19812703/8da7833e-9d2e-11e6-98f4-eb5984a9dbb1.png)


It was introduced here https://github.com/Automattic/wp-calypso/pull/8679

**testing instructions**

* Open the post's editor, you should see this warning on the console

cc @aduth 