### PR TITLE
Reader: Make the excerpts we use for related posts better

### DIFF
--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -105,7 +105,7 @@ export function RelatedPostCard( { post, site, onPostClick = noop, onSiteClick =
 					<div className="reader-related-card-v2__site-info">
 						<h1 className="reader-related-card-v2__title">{ post.title }</h1>
 						<div className="reader-related-card-v2__excerpt post-excerpt">
-							{ featuredImage ? post.short_excerpt : post.excerpt }
+							{ featuredImage ? post.short_excerpt : post.better_excerpt_no_html }
 						</div>
 					</div>
 			</a>

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -110,6 +110,7 @@ normalizePost.withContentDOM = function( transforms ) {
 };
 
 import removeStyles from './rule-content-remove-styles';
+import removeElementsBySelector from './rule-content-remove-elements-by-selector';
 import makeImagesSafe from './rule-content-make-images-safe';
 import makeEmbedsSafe from './rule-content-make-embeds-safe';
 import wordCountAndReadingTime from './rule-content-word-count';
@@ -120,6 +121,7 @@ import detectPolls from './rule-content-detect-polls';
 
 normalizePost.content = {
 	removeStyles,
+	removeElementsBySelector,
 	makeImagesSafe,
 	makeEmbedsSafe,
 	wordCountAndReadingTime,

--- a/client/lib/post-normalizer/rule-content-remove-elements-by-selector.js
+++ b/client/lib/post-normalizer/rule-content-remove-elements-by-selector.js
@@ -7,7 +7,7 @@ import forEach from 'lodash/forEach';
  * Internal Dependencies
  */
 
-const thingsToHide = [
+const thingsToRemove = [
 	'.sharedaddy', // share daddy
 	'script', // might be too late for these at this point...
 	'.jp-relatedposts', // jetpack related posts
@@ -20,17 +20,20 @@ const thingsToHide = [
 	'select',
 	'button',
 	'textarea'
-].join( ', ' );
+].join( ', ' ); // make them all into one big selector
+
+function removeElement( element ) {
+	element.parentNode && element.parentNode.removeChild( element );
+}
 
 export default function sanitizeContent( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}
 
-	const elements = dom.querySelectorAll( thingsToHide );
-	forEach( elements, function( element ) {
-		element.parentNode && element.parentNode.removeChild( element );
-	} );
+	const elements = dom.querySelectorAll( thingsToRemove );
+	// using forEach because qsa doesn't return a real array
+	forEach( elements,  removeElement );
 
 	return post;
 }

--- a/client/lib/post-normalizer/rule-content-remove-elements-by-selector.js
+++ b/client/lib/post-normalizer/rule-content-remove-elements-by-selector.js
@@ -33,7 +33,7 @@ export default function sanitizeContent( post, dom ) {
 
 	const elements = dom.querySelectorAll( thingsToRemove );
 	// using forEach because qsa doesn't return a real array
-	forEach( elements,  removeElement );
+	forEach( elements, removeElement );
 
 	return post;
 }

--- a/client/lib/post-normalizer/rule-content-sanitize.js
+++ b/client/lib/post-normalizer/rule-content-sanitize.js
@@ -1,0 +1,36 @@
+/**
+ * External Dependencies
+ */
+import forEach from 'lodash/forEach';
+
+/**
+ * Internal Dependencies
+ */
+
+const thingsToHide = [
+	'.sharedaddy', // share daddy
+	'script', // might be too late for these at this point...
+	'.jp-relatedposts', // jetpack related posts
+	'.mc4wp-form', // mailchimp 4 wp
+	'.wpcnt', // wordads?
+	'.OUTBRAIN',
+	'.adsbygoogle',
+	'form', // no form elements
+	'input',
+	'select',
+	'button',
+	'textarea'
+].join( ', ' );
+
+export default function sanitizeContent( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	const elements = dom.querySelectorAll( thingsToHide );
+	forEach( elements, function( element ) {
+		element.parentNode && element.parentNode.removeChild( element );
+	} );
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -9,6 +9,7 @@ import trim from 'lodash/trim';
  * Internal Dependencies
  */
 import { domForHtml } from './utils';
+import { stripHTML } from 'lib/formatting';
 
 export function formatExcerpt( content ) {
 	if ( ! content ) {
@@ -67,11 +68,12 @@ export default function createBetterExcerpt( post ) {
 	}
 
 	post.better_excerpt = formatExcerpt( post.content );
+	post.better_excerpt_no_html = stripHTML( post.better_excerpt );
 
 	// also make a shorter excerpt...
-	if ( post.excerpt ) {
+	if ( post.better_excerpt ) {
 		// replace any trailing [...] with an actual ellipsis
-		let shorterExcerpt = post.excerpt.replace( /\[...\]\w*$/, '…' );
+		let shorterExcerpt = post.better_excerpt_no_html.replace( /\[...\]\w*$/, '…' );
 		// limit to 160 characters
 		if ( shorterExcerpt.length > 160 ) {
 			const lastSpace = shorterExcerpt.lastIndexOf( ' ', 160 );

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -71,7 +71,7 @@ export default function createBetterExcerpt( post ) {
 	post.better_excerpt_no_html = stripHTML( post.better_excerpt );
 
 	// also make a shorter excerpt...
-	if ( post.better_excerpt ) {
+	if ( post.better_excerpt_no_html ) {
 		// replace any trailing [...] with an actual ellipsis
 		let shorterExcerpt = post.better_excerpt_no_html.replace( /\[...\]\w*$/, '…' );
 		// limit to 160 characters

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 const assert = require( 'chai' ).assert,
-	Spy = require( 'sinon' ).spy;
+	Spy = require( 'sinon' ).spy,
+	trim = require( 'lodash/trim' );
 
 /**
  * Internal dependencies
@@ -42,6 +43,7 @@ describe( 'index', function() {
 			normalizer.withContentDOM(),
 			normalizer.withContentDOM( [
 				normalizer.content.removeStyles,
+				normalizer.content.sanitizeContent,
 				normalizer.content.makeImagesSafe( 300 ),
 				normalizer.content.makeEmbedsSafe,
 				normalizer.content.detectEmbeds,
@@ -944,6 +946,33 @@ describe( 'index', function() {
 					normalizer.withContentDOM( [ normalizer.content.detectPolls ] )
 				], function( err, normalized ) {
 					assert.include( normalized.content, '<p><a target="_blank" rel="external noopener noreferrer" href="https://polldaddy.com/poll/8980420">Take our poll</a></p>' );
+					done( err );
+				}
+			);
+		} );
+
+		it( 'removes elements by selector', function( done ) {
+			normalizer(
+				{
+					content: `
+					<div class="sharedaddy">sharedaddy</div>
+					<script>/*hi*/</script>
+					<div class="jp-relatedposts">jetpack</div>
+					<div class="mc4wp-form">a form</div>
+					<div class="wpcnt">wordads</div>
+					<div class="OUTBRAIN">outbrain content ads</div>
+					<div class="adsbygoogle">google ads</div>
+					<form><input type="text"></form>
+					<input type="password">
+					<select><option>nope</option></select>
+					<button>hi</button>
+					<textarea>noooope</textarea>
+					`,
+				},
+				[
+					normalizer.withContentDOM( [ normalizer.content.removeElementsBySelector ] )
+				], function( err, normalized ) {
+					assert.equal( trim( normalized.content ), '' );
 					done( err );
 				}
 			);

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -37,7 +37,7 @@ import withContentDom from 'lib/post-normalizer/rule-with-content-dom';
 import keepValidImages from 'lib/post-normalizer/rule-keep-valid-images';
 import pickCanonicalImage from 'lib/post-normalizer/rule-pick-canonical-image';
 import waitForImagesToLoad from 'lib/post-normalizer/rule-wait-for-images-to-load';
-import sanitizeContent from 'lib/post-normalizer/rule-content-sanitize';
+import removeElementsBySelector from 'lib/post-normalizer/rule-content-remove-elements-by-selector';
 
 /**
  * Module vars
@@ -144,7 +144,7 @@ const fastPostNormalizationRules = flow( [
 	firstPassCanonicalImage,
 	withContentDom( [
 		removeStyles,
-		sanitizeContent,
+		removeElementsBySelector,
 		makeImagesSafe( READER_CONTENT_WIDTH ),
 		discoverFullBleedImages,
 		makeEmbedsSafe,

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -37,6 +37,7 @@ import withContentDom from 'lib/post-normalizer/rule-with-content-dom';
 import keepValidImages from 'lib/post-normalizer/rule-keep-valid-images';
 import pickCanonicalImage from 'lib/post-normalizer/rule-pick-canonical-image';
 import waitForImagesToLoad from 'lib/post-normalizer/rule-wait-for-images-to-load';
+import sanitizeContent from 'lib/post-normalizer/rule-content-sanitize';
 
 /**
  * Module vars
@@ -143,6 +144,7 @@ const fastPostNormalizationRules = flow( [
 	firstPassCanonicalImage,
 	withContentDom( [
 		removeStyles,
+		sanitizeContent,
 		makeImagesSafe( READER_CONTENT_WIDTH ),
 		discoverFullBleedImages,
 		makeEmbedsSafe,


### PR DESCRIPTION
And remove some cruft from jetpack sites. Especially LaughingSquid.

This teaches the post normalizer a new rule: `sanitizeContent`. It removes a bunch of cruft from many posts that use common WordPress plugins, like Jetpack Related Posts, WordAds, Google Ads, form elements, etc. 

To test, try http://calypso.localhost:3000/read/feeds/12098 and click through into some posts, then click on the related post links. Notice most of the cruft at the top and bottom of each post is missing in full post view, and the excerpts are much better.

cc @beaulebens as this would be much better to fix on ingest, rather than pulling it out in the client.
