### PR TITLE
Editor: Display warning on accordion toggle if broken connection exists

### DIFF
--- a/client/components/accordion/README.md
+++ b/client/components/accordion/README.md
@@ -28,3 +28,9 @@ The following props are available to customize the accordion:
 - `title`: Main heading shown in the always-visible toggle button
 - `subtitle`: Subheading shown in the always-visible toggle button
 - `icon`: React element to be shown as an icon adjacent to the headings in the always-visible toggle button.
+- `status`: Optional object describing a status to be shown in accordion toggle, of shape:
+  - `type`: `"info"`, `"warning"`, `"error"`
+  - `text`: `string` for tooltip
+  - `url`: `string` for click navigation
+  - `position`: `string`, refer to [`<Tooltip />` documentation](../tooltip)
+  - `onClick`: `function` callback on status click

--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable max-len */
+
 /**
  * External dependencies
  */
@@ -50,22 +52,29 @@ module.exports = React.createClass( {
 					</Accordion>
 					<Accordion
 						title="Section Three"
-						subtitle={ this.state.showSubtitles ? "With Subtitle" : null }
-					>
+						subtitle={ this.state.showSubtitles ? 'With Subtitle' : null }>
 						Suspendisse pellentesque diam in nisi pulvinar maximus. Integer feugiat feugiat justo ac vehicula. Curabitur iaculis, risus suscipit sodales auctor, nisl urna elementum sem, non vestibulum mauris ante et purus. Duis iaculis nisl neque, eget rutrum erat imperdiet non.
 					</Accordion>
 					<Accordion
 						title="Section Four"
-						subtitle={ this.state.showSubtitles ? "With a Very Long Subtitle to Demonstrate the Fade Effect" : null }
-					>
-						Drumstick ham tongue flank doner pork chop picanha. Cow short ribs tail kevin capicola ball tip. Leberkas shankle landjaeger tenderloin, chuck cupim pastrami cow frankfurter. Kielbasa bacon capicola shoulder porchetta, frankfurter rump short loin pig cupim. Tri-tip spare ribs porchetta flank jerky bresaola bacon kevin shank cupim meatball ground round ham sirloin ball tip. Tail bresaola shank, beef ribs turkey tenderloin meatloaf frankfurter.
+						subtitle={ this.state.showSubtitles ? 'With a Very Long Subtitle to Demonstrate the Fade Effect' : null }>
+						Drumstick ham tongue flank doner pork chop picanha. Cow short ribs tail kevin capicola ball tip. Leberkas shankle landjaeger tenderloin, chuck cupim pastrami cow frankfurter. Kielbasa bacon capicola shoulder porchetta, frankfurter rump short loin pig cupim.
 					</Accordion>
 					<Accordion
 						title="Section Five"
-						subtitle={ this.state.showSubtitles ? "With Subtitle and Icon" : null }
-						icon={ <Gridicon icon="time" /> }
-					>
+						subtitle={ this.state.showSubtitles ? 'With Subtitle and Icon' : null }
+						icon={ <Gridicon icon="time" /> }>
 						Etiam dictum odio elit, id faucibus urna elementum ac. Mauris in est nec tortor luctus auctor ut a velit. Suspendisse vulputate lectus arcu, sed condimentum risus rutrum vitae. Nullam sagittis ultricies nisl. Duis accumsan libero vel arcu sodales venenatis.
+					</Accordion>
+					<Accordion
+						title="Section Six"
+						subtitle={ this.state.showSubtitles ? 'With Subtitle and Status' : null }
+						status={ {
+							type: 'warning',
+							text: 'Warning!',
+							url: '/devdocs/design'
+						} }>
+						Suspendisse pellentesque diam in nisi pulvinar maximus. Integer feugiat feugiat justo ac vehicula. Curabitur iaculis, risus suscipit sodales auctor, nisl urna elementum sem, non vestibulum mauris ante et purus. Duis iaculis nisl neque, eget rutrum erat imperdiet non.
 					</Accordion>
 				</div>
 			</div>

--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -5,12 +5,18 @@ import React, { Component, PropTypes } from 'react';
 import { noop } from 'lodash';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import AccordionStatus from './status';
+
 export default class Accordion extends Component {
 	static propTypes = {
 		initialExpanded: PropTypes.bool,
 		onToggle: PropTypes.func,
 		title: PropTypes.string.isRequired,
 		subtitle: PropTypes.string,
+		status: PropTypes.object,
 		icon: PropTypes.element
 	};
 
@@ -34,11 +40,12 @@ export default class Accordion extends Component {
 	}
 
 	render() {
-		const { className, icon, title, subtitle, children } = this.props;
+		const { className, icon, title, subtitle, status, children } = this.props;
 		const classes = classNames( 'accordion', className, {
 			'is-expanded': this.state.isExpanded,
 			'has-icon': !! icon,
-			'has-subtitle': !! subtitle
+			'has-subtitle': !! subtitle,
+			'has-status': !! status
 		} );
 
 		return (
@@ -49,6 +56,7 @@ export default class Accordion extends Component {
 						<span className="accordion__title">{ title }</span>
 						{ subtitle && <span className="accordion__subtitle">{ subtitle }</span> }
 					</button>
+					{ status && <AccordionStatus { ...status } /> }
 				</header>
 				<div className="accordion__content">
 					<div className="accordion__content-wrap">

--- a/client/components/accordion/status.jsx
+++ b/client/components/accordion/status.jsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent, PropTypes } from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import Tooltip from 'components/tooltip';
+
+/**
+ * Mapping of Notice status to Gridicon icon
+ *
+ * @type {Object}
+ */
+const STATUS_GRIDICON = {
+	info: 'info',
+	warning: 'notice',
+	error: 'notice'
+};
+
+export default class AccordionStatus extends PureComponent {
+	static propTypes = {
+		type: PropTypes.oneOf( [
+			'info',
+			'warning',
+			'error'
+		] ),
+		text: PropTypes.node,
+		url: PropTypes.string,
+		position: PropTypes.string,
+		onClick: PropTypes.func
+	};
+
+	static defaultProps = {
+		type: 'info',
+		onClick: () => {}
+	};
+
+	state = {};
+
+	constructor() {
+		super( ...arguments );
+
+		this.showTooltip = this.toggleTooltip.bind( this, true );
+		this.hideTooltip = this.toggleTooltip.bind( this, false );
+	}
+
+	setTooltipContext = ( tooltipContext ) => {
+		if ( tooltipContext ) {
+			this.setState( { tooltipContext } );
+		}
+	};
+
+	toggleTooltip( isTooltipVisible ) {
+		this.setState( { isTooltipVisible } );
+	}
+
+	render() {
+		const { type, text, url, position } = this.props;
+
+		return (
+			<a
+				href={ url }
+				onClick={ this.props.onClick }
+				ref={ this.setTooltipContext }
+				onMouseEnter={ this.showTooltip }
+				onMouseLeave={ this.hideTooltip }
+				className={ classNames( 'accordion__status', `is-${ type }` ) }>
+				<Gridicon icon={ STATUS_GRIDICON[ type ] } />
+				{ text && (
+					<Tooltip
+						position={ position }
+						isVisible={ this.state.isTooltipVisible }
+						context={ this.state.tooltipContext }>
+						{ text }
+					</Tooltip>
+				) }
+			</a>
+		);
+	}
+}

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -11,11 +11,14 @@ $accordion-background-expanded: $white;
 	position: relative;
 }
 
+.accordion__header {
+	position: relative;
+}
+
 .accordion__toggle {
 	display: block;
 	width: 100%;
 	cursor: pointer;
-	position: relative;
 	margin: 0;
 	padding: $accordion-padding;
 	padding-right: ( $accordion-padding + 22px );
@@ -79,6 +82,10 @@ $accordion-background-expanded: $white;
 	.accordion.has-icon & {
 		padding-left: 28px;
 	}
+
+	.accordion.has-status & {
+		padding-right: 28px;
+	}
 }
 
 .accordion__subtitle {
@@ -129,4 +136,55 @@ $accordion-background-expanded: $white;
 
 .accordion__section:last-child {
 	margin-bottom: 0;
+}
+
+.accordion__status {
+	position: absolute;
+		right: ( $accordion-padding + 20px + 4px );
+		top: 50%;
+	transform: translateY( -50% );
+	padding: 4px;
+
+	&::before {
+		content: '';
+		position: absolute;
+			top: 4px;
+			left: 4px;
+		width: 14px;
+		height: 14px;
+		background-color: $white;
+		border-radius: 50%;
+	}
+
+	.gridicon {
+		position: relative;
+		display: block;
+		width: 18px;
+		height: 18px;
+		margin: -2px;
+	}
+
+	&.is-warning {
+		color: $alert-yellow;
+
+		&:hover {
+			color: lighten( $alert-yellow, 5% );
+		}
+	}
+
+	&.is-error {
+		color: $alert-red;
+
+		&:hover {
+			color: lighten( $alert-red, 5% );
+		}
+	}
+
+	&.is-info {
+		color: $blue-wordpress;
+
+		&:hover {
+			color: lighten( $blue-wordpress, 5% );
+		}
+	}
 }

--- a/client/components/accordion/test/index.jsx
+++ b/client/components/accordion/test/index.jsx
@@ -8,10 +8,18 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
+import useFakeDom from 'test/helpers/use-fake-dom';
 import Gridicon from 'components/gridicon';
-import Accordion from '../';
 
 describe( 'Accordion', function() {
+	let Accordion, AccordionStatus;
+
+	useFakeDom();
+	before( () => {
+		Accordion = require( '../' );
+		AccordionStatus = require( '../status' );
+	} );
+
 	it( 'should render as expected with a title and content', function() {
 		const wrapper = shallow( <Accordion title="Section">Content</Accordion> );
 
@@ -38,6 +46,14 @@ describe( 'Accordion', function() {
 
 		expect( wrapper ).to.have.className( 'has-subtitle' );
 		expect( wrapper.find( '.accordion__subtitle' ) ).to.have.text( 'Subtitle' );
+	} );
+
+	it( 'should accept a status prop to be rendered in the toggle', () => {
+		const status = { type: 'error', text: 'Warning!', url: 'https://wordpress.com', position: 'top left', onClick() {} };
+		const wrapper = shallow( <Accordion title="Section" status={ status }>Content</Accordion> );
+
+		expect( wrapper ).to.have.className( 'has-status' );
+		expect( wrapper.find( AccordionStatus ).props() ).to.eql( status );
 	} );
 
 	context( 'events', () => {

--- a/client/components/accordion/test/status.jsx
+++ b/client/components/accordion/test/status.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import Gridicon from 'components/gridicon';
+
+describe( 'AccordionStatus', function() {
+	let AccordionStatus, Tooltip;
+
+	useFakeDom();
+	before( () => {
+		AccordionStatus = require( '../status' );
+		Tooltip = require( 'components/tooltip' );
+	} );
+
+	it( 'should render with explicit props', () => {
+		const status = { type: 'error', text: 'Warning!', url: 'https://wordpress.com', position: 'top left' };
+		const wrapper = shallow( <AccordionStatus { ...status } /> );
+
+		expect( wrapper ).to.have.prop( 'href' ).equal( 'https://wordpress.com' );
+		expect( wrapper ).to.have.className( 'is-error' );
+		expect( wrapper.find( Gridicon ) ).to.have.prop( 'icon' ).equal( 'notice' );
+		expect( wrapper.find( Tooltip ) ).to.have.prop( 'children' ).equal( 'Warning!' );
+		expect( wrapper.find( Tooltip ) ).to.have.prop( 'position' ).equal( 'top left' );
+	} );
+
+	it( 'should render with default props', () => {
+		const wrapper = shallow( <AccordionStatus /> );
+
+		expect( wrapper ).to.not.have.prop( 'href' );
+		expect( wrapper ).to.have.className( 'is-info' );
+		expect( wrapper.find( Gridicon ) ).to.have.prop( 'icon' ).equal( 'info' );
+		expect( wrapper ).to.not.have.descendants( Tooltip );
+	} );
+
+	it( 'should show tooltip on hover', () => {
+		const wrapper = shallow( <AccordionStatus text="Warning!" /> );
+
+		expect( wrapper.find( Tooltip ) ).to.not.have.prop( 'isVisible' );
+		expect( wrapper.find( Tooltip ) ).to.have.prop( 'position' ).equal( 'top' );
+
+		wrapper.simulate( 'mouseEnter' );
+
+		expect( wrapper.find( Tooltip ) ).to.have.prop( 'isVisible' ).be.true;
+
+		wrapper.simulate( 'mouseLeave' );
+
+		expect( wrapper.find( Tooltip ) ).to.have.prop( 'isVisible' ).be.false;
+	} );
+
+	it( 'should call onClick callback', () => {
+		const spy = sinon.spy();
+		const wrapper = shallow( <AccordionStatus onClick={ spy } /> );
+
+		wrapper.simulate( 'click' );
+
+		expect( spy ).to.have.been.calledOnce;
+	} );
+} );

--- a/client/state/selectors/has-broken-site-user-connection.js
+++ b/client/state/selectors/has-broken-site-user-connection.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
+
+/**
+ * Returns true if a broken Publicize connections exists for the specified site
+ * and user, or false otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Number}  userId User ID
+ * @return {Boolean}        Whether broken connection exists
+ */
+export default function hasBrokenSiteUserConnection( state, siteId, userId ) {
+	return some( getSiteUserConnections( state, siteId, userId ), { status: 'broken' } );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -26,6 +26,7 @@ export getMediaUrl from './get-media-url';
 export getPastBillingTransaction from './get-past-billing-transaction';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
+export hasBrokenSiteUserConnection from './has-broken-site-user-connection';
 export isAutomatedTransferActive from './is-automated-transfer-active';
 export isDomainOnlySite from './is-domain-only-site';
 export isPrivateSite from './is-private-site';

--- a/client/state/selectors/test/has-broken-site-user-connection.js
+++ b/client/state/selectors/test/has-broken-site-user-connection.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { hasBrokenSiteUserConnection } from '../';
+
+describe( 'hasBrokenSiteUserConnection()', () => {
+	it( 'should return false if no connections for site', () => {
+		const hasBroken = hasBrokenSiteUserConnection( {
+			sharing: {
+				publicize: {
+					connections: {}
+				}
+			}
+		}, 2916284, 26957695 );
+
+		expect( hasBroken ).to.be.false;
+	} );
+
+	it( 'should return false if all connections ok', () => {
+		const hasBroken = hasBrokenSiteUserConnection( {
+			sharing: {
+				publicize: {
+					connections: {
+						1: { ID: 1, site_ID: 2916284, shared: true, status: 'ok' },
+						2: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'ok' }
+					}
+				}
+			}
+		}, 2916284, 26957695 );
+
+		expect( hasBroken ).to.be.false;
+	} );
+
+	it( 'should return true if any connections broken', () => {
+		const hasBroken = hasBrokenSiteUserConnection( {
+			sharing: {
+				publicize: {
+					connections: {
+						1: { ID: 1, site_ID: 2916284, shared: true, status: 'ok' },
+						2: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'broken' }
+					}
+				}
+			}
+		}, 2916284, 26957695 );
+
+		expect( hasBroken ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
Closes #3277

This pull request seeks to improve the visibility of broken Sharing connections in the post editor by displaying a warning in the accordion toggle.

| Before | After |
| --- | --- |
| ![Before](https://cloud.githubusercontent.com/assets/1779930/19826103/42f2bb56-9d51-11e6-893f-9b74cf09cb3a.png) | ![After](https://cloud.githubusercontent.com/assets/1779930/19896589/40a7fdfc-a02b-11e6-9f63-d60e7fb5c96c.png) |

Many services' tokens are not permanent, and unless a user expands the sharing accordion or visits their connection settings screen, they will not be made aware that the connection is broken, leading to frustration when the post fails to Publicize.

**Testing instructions:**

Verify that a status indicator is shown in the Sharing accordion toggle if a broken connection exists for the site and user. It's easiest to test using a service that allows you to revoke an integration (e.g. Twitter). Due to connection status caching, it's also preferred that you test using two sites.
1. Navigate to http://calypso.localhost:3000/sharing
2. Select a site
3. Click Connect on the Twitter connection heading
4. Connect to a Twitter account
5. Confirm the connection after returning to Calypso
6. Navigate to https://twitter.com/settings/applications
7. Revoke WordPress
8. Navigate to http://calypso.localhost:3000/sharing
9. Select a _different_ site
10. Click Connect on the Twitter connection heading
11. _Do not_ authorize the connection, simply close the modal
12. Confirm the connection established in step 4
13. The connection should show as broken (needing Reconnect) after established
14. Navigate to the post editor for this site
15. Note that the Sharing accordion displays a warning indicator, linking back to the connections screen

Also verify that the demonstration on [DevDocs Design](http://calypso.localhost:3000/devdocs/design/accordion) includes a working example of an Accordion including status.
