### PR TITLE
update/8693-mobile-layout-get-apps

### DIFF
--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -19,12 +19,13 @@ module.exports = React.createClass( {
 		return (
 			<Main className="get-apps">
 				<MeSidebarNavigation />
-
-				<h1 className="get-apps__title">{ this.translate( 'Get Apps' ) }</h1>
-				<p className="get-apps__subheading">{ this.translate( 'Manage all your WordPress.com and Jetpack-enabled sites in one place. On your desktop, or on the go.' ) }</p>
-
-				<h2 className="form-section-heading">{ this.translate( 'Desktop apps' ) }</h2>
+				
 				<Card className="get-apps__desktop">
+
+					<h1 className="get-apps__title">{ this.translate( 'Get Apps' ) }</h1>
+					<p className="get-apps__subheading">{ this.translate( 'Manage all your WordPress.com and Jetpack-enabled sites in one place. On your desktop, or on the go.' ) }</p>
+
+					<h2 className="form-section-heading">{ this.translate( 'Desktop apps' ) }</h2>
 
 					<section className="get-apps__app">
 						<div className="get-apps__app-icon">

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -14,81 +14,81 @@ import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
 export const GetApps = ( { translate } ) => (
-  <Main className="get-apps">
-    <MeSidebarNavigation />
-    <SectionHeader label={ translate( 'Desktop apps' ) } />
-    <Card className="get-apps__desktop">
+	<Main className="get-apps">
+		<MeSidebarNavigation />
+		<SectionHeader label={ translate( 'Desktop apps' ) } />
+		<Card className="get-apps__desktop">
 
-      <section className="get-apps__app">
-        <div className="get-apps__app-icon">
-          <img src="/calypso/images/me/get-apps-osx.svg" alt={ translate( 'Mac' ) } width="96" height="96" />
-        </div>
-        <p><strong>{ translate( 'Mac' ) }</strong><br />
-        { translate( 'Requires 10.11 or newer' ) }</p>
-        <Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ translate( 'Download', { context: 'verb' } ) }</Button>
-      </section>
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-osx.svg" alt={ translate( 'Mac' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'Mac' ) }</strong><br />
+				{ translate( 'Requires 10.11 or newer' ) }</p>
+				<Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ translate( 'Download', { context: 'verb' } ) }</Button>
+			</section>
 
-      <section className="get-apps__app">
-        <div className="get-apps__app-icon">
-          <img src="/calypso/images/me/get-apps-windows.svg" alt={ translate( 'Windows' ) } width="96" height="96" />
-        </div>
-        <p><strong>{ translate( 'Windows' ) }</strong><br />
-        { translate( 'Requires 7 or newer' ) }</p>
-        <Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ translate( 'Download' ) }</Button>
-      </section>
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-windows.svg" alt={ translate( 'Windows' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'Windows' ) }</strong><br />
+				{ translate( 'Requires 7 or newer' ) }</p>
+				<Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ translate( 'Download' ) }</Button>
+			</section>
 
-      <section className="get-apps__app">
-        <div className="get-apps__app-icon">
-          <img src="/calypso/images/me/get-apps-linux.svg" alt={ translate( 'Linux' ) } width="96" height="96" />
-        </div>
-        <p><strong>{ translate( 'Linux' ) }</strong><br />
-        { translate( 'Choose your distribution' ) }</p>
-        <Button href="https://apps.wordpress.com/d/linux?ref=getapps">
-          { translate( '.TAR.GZ' ) }
-        </Button>
-        <Button
-          href="https://apps.wordpress.com/d/linux-deb?ref=getapps"
-        >
-          { translate( '.DEB' ) }
-        </Button>
-      </section>
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-linux.svg" alt={ translate( 'Linux' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'Linux' ) }</strong><br />
+				{ translate( 'Choose your distribution' ) }</p>
+				<Button href="https://apps.wordpress.com/d/linux?ref=getapps">
+					{ translate( '.TAR.GZ' ) }
+				</Button>
+				<Button
+					href="https://apps.wordpress.com/d/linux-deb?ref=getapps"
+				>
+					{ translate( '.DEB' ) }
+				</Button>
+			</section>
 
-    </Card>
+		</Card>
 
-    <SectionHeader label={ translate( 'Mobile apps' ) } />
-    <Card className="get-apps__mobile">
+		<SectionHeader label={ translate( 'Mobile apps' ) } />
+		<Card className="get-apps__mobile">
 
-      <section className="get-apps__app">
-        <div className="get-apps__app-icon">
-          <img src="/calypso/images/me/get-apps-ios.svg" alt={ translate( 'iOS' ) } width="96" height="96" />
-        </div>
-        <p><strong>{ translate( 'iOS' ) }</strong></p>
-        <a href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8">
-          <img
-            src="/calypso/images/me/get-apps-app-store.png"
-            alt={ translate( 'Get on the iOS App Store' ) }
-          />
-        </a>
-      </section>
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-ios.svg" alt={ translate( 'iOS' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'iOS' ) }</strong></p>
+				<a href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8">
+					<img
+						src="/calypso/images/me/get-apps-app-store.png"
+						alt={ translate( 'Get on the iOS App Store' ) }
+					/>
+				</a>
+			</section>
 
-      <section className="get-apps__app">
-        <div className="get-apps__app-icon">
-          <img src="/calypso/images/me/get-apps-android.svg" alt={ translate( 'Android' ) } width="96" height="96" />
-        </div>
-        <p><strong>{ translate( 'Android' ) }</strong></p>
-        <a
-          href="https://play.google.com/store/apps/details?id=org.wordpress.android"
-        >
-          <img
-            src="/calypso/images/me/get-apps-google-play.png"
-            alt={ translate( 'Get on Google Play' ) }
-          />
-        </a>
-      </section>
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-android.svg" alt={ translate( 'Android' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'Android' ) }</strong></p>
+				<a
+					href="https://play.google.com/store/apps/details?id=org.wordpress.android"
+				>
+					<img
+						src="/calypso/images/me/get-apps-google-play.png"
+						alt={ translate( 'Get on Google Play' ) }
+					/>
+				</a>
+			</section>
 
-    </Card>
+		</Card>
 
-  </Main>
+	</Main>
 );
 
 GetApps.propTypes = {

--- a/client/me/get-apps/style.scss
+++ b/client/me/get-apps/style.scss
@@ -1,5 +1,4 @@
 .get-apps__title {
-	text-align: center;
 	font-size: 24px;
 	font-family: $serif;
 	font-weight: 700;
@@ -14,7 +13,6 @@
 .get-apps__subheading {
 	max-width: 500px;
 	margin: 16px auto;
-	text-align: center;
 }
 
 .get-apps__app {


### PR DESCRIPTION
Fixes #8693

Moved title and subheading into card component.

**Before**

![before-commit-fix-mobile-layout](https://cloud.githubusercontent.com/assets/16620120/19827092/29644ef0-9d6c-11e6-9c39-cbb3d1327b65.png)

**After Moving Component**

![after-moving-component](https://cloud.githubusercontent.com/assets/16620120/19827091/29602578-9d6c-11e6-8ddd-7715552c8abb.png)

**After removing centered text**

![remove_center_text_heading_subheading_get_apps](https://cloud.githubusercontent.com/assets/16620120/19827093/29648a0a-9d6c-11e6-9795-324841bc4c35.png)
Removed centered alignment in heading
