### PR TITLE
Related Themes Card: Use getThemeDetailsUrl() selector instead of helper

### DIFF
--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import React from 'react';
 import Card from 'components/card';
 import i18n from 'i18n-calypso';
 import SectionHeader from 'components/section-header';
-import { getDetailsUrl } from 'my-sites/themes/helpers';
+import { getThemeDetailsUrl } from 'state/themes/selectors';
 
 const ThemesRelatedCard = React.createClass( {
 
@@ -58,8 +59,8 @@ const ThemesRelatedCard = React.createClass( {
 					{ themes.map( theme => (
 						<li key={ theme.id }>
 							<Card className="themes-related-card__card">
-								<a href={ getDetailsUrl( theme ) }>
-									<img src={ theme.screenshot + '?w=' + '660' }/>
+								<a href={ this.props.getDetailsUrl( theme ) }>
+									<img src={ theme.screenshot + '?w=' + '660' } />
 								</a>
 							</Card>
 						</li>
@@ -70,4 +71,8 @@ const ThemesRelatedCard = React.createClass( {
 	}
 } );
 
-export default ThemesRelatedCard;
+export default connect(
+	state => ( {
+		getDetailsUrl: getThemeDetailsUrl.bind( null, state )
+	} )
+)( ThemesRelatedCard );

--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -63,7 +63,7 @@ const ThemesRelatedCard = React.createClass( {
 						<li key={ theme.id }>
 							<Card className="themes-related-card__card">
 								<a href={ this.props.getDetailsUrl( theme ) }>
-									<img src={ theme.screenshot + '?w=' + String( THEME_THUMBNAIL_WIDTH ) } />
+									<img src={ theme.screenshot + `?w=${ THEME_THUMBNAIL_WIDTH }` } />
 								</a>
 							</Card>
 						</li>

--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -14,6 +14,8 @@ import i18n from 'i18n-calypso';
 import SectionHeader from 'components/section-header';
 import { getThemeDetailsUrl } from 'state/themes/selectors';
 
+const THEME_THUMBNAIL_WIDTH = 660;
+
 const ThemesRelatedCard = React.createClass( {
 
 	propTypes: {
@@ -60,7 +62,7 @@ const ThemesRelatedCard = React.createClass( {
 						<li key={ theme.id }>
 							<Card className="themes-related-card__card">
 								<a href={ this.props.getDetailsUrl( theme ) }>
-									<img src={ theme.screenshot + '?w=' + '660' } />
+									<img src={ theme.screenshot + '?w=' + String( THEME_THUMBNAIL_WIDTH ) } />
 								</a>
 							</Card>
 						</li>

--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -13,6 +13,7 @@ import Card from 'components/card';
 import i18n from 'i18n-calypso';
 import SectionHeader from 'components/section-header';
 import { getThemeDetailsUrl } from 'state/themes/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 const THEME_THUMBNAIL_WIDTH = 660;
 
@@ -75,6 +76,6 @@ const ThemesRelatedCard = React.createClass( {
 
 export default connect(
 	state => ( {
-		getDetailsUrl: theme => getThemeDetailsUrl( state, theme )
+		getDetailsUrl: theme => getThemeDetailsUrl( state, theme, getSelectedSiteId( state ) )
 	} )
 )( ThemesRelatedCard );

--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -75,6 +75,6 @@ const ThemesRelatedCard = React.createClass( {
 
 export default connect(
 	state => ( {
-		getDetailsUrl: getThemeDetailsUrl.bind( null, state )
+		getDetailsUrl: theme => getThemeDetailsUrl( state, theme )
 	} )
 )( ThemesRelatedCard );


### PR DESCRIPTION
To test: In the theme sheet, verify that the 'related theme' card links point to the correct URLs (compare to production).

By-product of #6924.
