### PR TITLE
Theme Actions: Use siteId instead of site object

### DIFF
--- a/client/my-sites/customize/actions.js
+++ b/client/my-sites/customize/actions.js
@@ -38,7 +38,7 @@ var CustomizeActions = {
 
 		page( '/design/' + site.slug );
 
-		themeActivated( id, site, 'customizer' );
+		themeActivated( id, site.ID, 'customizer' );
 
 		Dispatcher.handleViewAction( {
 			type: 'THEME_ACTIVATED_WITH_CUSTOMIZER',

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -458,6 +458,19 @@ const ThemeSheet = React.createClass( {
 	},
 } );
 
+const WrappedThemeSheet = ( props ) => {
+	if ( ! props.isLoggedIn || props.selectedSite ) {
+		return <ThemeSheet { ...props } />;
+	}
+
+	return (
+		<ThemesSiteSelectorModal { ...props }
+			sourcePath={ `/theme/${ props.id }${ props.section ? '/' + props.section : '' }` }>
+			<ThemeSheet />
+		</ThemesSiteSelectorModal>
+	);
+};
+
 const ThemeSheetWithOptions = ( props ) => {
 	const { selectedSite: site, isActive, price, isLoggedIn } = props;
 
@@ -488,21 +501,8 @@ const ThemeSheetWithOptions = ( props ) => {
 			defaultOption={ defaultOption }
 			secondaryOption="tryandcustomize"
 			source="showcase-sheet">
-			<ThemeSheet { ...props } />
+			<WrappedThemeSheet { ...props } />
 		</ThemeOptions>
-	);
-};
-
-const WrappedThemeSheet = ( props ) => {
-	if ( ! props.isLoggedIn || props.selectedSite ) {
-		return <ThemeSheetWithOptions { ...props } />;
-	}
-
-	return (
-		<ThemesSiteSelectorModal { ...props }
-			sourcePath={ `/theme/${ props.id }${ props.section ? '/' + props.section : '' }` }>
-			<ThemeSheetWithOptions />
-		</ThemesSiteSelectorModal>
 	);
 };
 
@@ -528,4 +528,4 @@ export default connect(
 			isLoggedIn: !! currentUserId,
 		};
 	}
-)( WrappedThemeSheet );
+)( ThemeSheetWithOptions );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -31,7 +31,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { isUserPaid } from 'state/purchases/selectors';
 import { getForumUrl } from 'my-sites/themes/helpers';
-import { isPremiumTheme as isPremium } from 'state/themes/utils';
+import { isThemeActive, isPremiumTheme as isPremium } from 'state/themes/selectors';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCurrentTheme from 'components/data/query-current-theme';
 import QueryUserPurchases from 'components/data/query-user-purchases';
@@ -70,9 +70,9 @@ const ThemeSheet = React.createClass( {
 		download: React.PropTypes.string,
 		taxonomies: React.PropTypes.object,
 		stylesheet: React.PropTypes.string,
-		active: React.PropTypes.bool,
 		purchased: React.PropTypes.bool,
 		// Connected props
+		isActive: React.PropTypes.bool,
 		isLoggedIn: React.PropTypes.bool,
 		selectedSite: React.PropTypes.object,
 		siteSlug: React.PropTypes.string,
@@ -327,8 +327,8 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderPreview() {
-		const { secondaryOption, active, isLoggedIn, defaultOption } = this.props;
-		const showSecondaryButton = secondaryOption && ! active && isLoggedIn;
+		const { secondaryOption, isActive, isLoggedIn, defaultOption } = this.props;
+		const showSecondaryButton = secondaryOption && ! isActive && isLoggedIn;
 		return (
 			<ThemePreview showPreview={ this.state.showPreview }
 				theme={ this.props }
@@ -369,7 +369,7 @@ const ThemeSheet = React.createClass( {
 
 	renderPrice() {
 		let price = this.props.price;
-		if ( ! this.isLoaded() || this.props.active ) {
+		if ( ! this.isLoaded() || this.props.isActive ) {
 			price = '';
 		} else if ( ! isPremium( this.props ) ) {
 			price = i18n.translate( 'Free' );
@@ -479,7 +479,7 @@ const WrappedThemeSheet = ( props ) => {
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const { selectedSite: site, active: isActive, price, isLoggedIn } = stateProps;
+	const { selectedSite: site, isActive, price, isLoggedIn } = stateProps;
 
 	let defaultOption;
 
@@ -516,10 +516,12 @@ export default connect(
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
 		const themeDetails = getThemeDetails( state, props.id );
+		const isActive = selectedSite && isThemeActive( state, props.id, selectedSite.ID );
 
 		return {
 			...themeDetails,
 			id: props.id,
+			isActive,
 			selectedSite,
 			siteSlug,
 			backPath,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -37,7 +37,7 @@ import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCurrentTheme from 'components/data/query-current-theme';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
-import { ThemeOptions } from 'my-sites/themes/theme-options';
+import ThemeOptions from 'my-sites/themes/theme-options';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import ThemePreview from 'my-sites/themes/theme-preview';

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -83,8 +83,11 @@ const ThemeSheet = React.createClass( {
 	},
 
 	getDefaultProps() {
+		// The defaultOption default prop is surprisingly important, see the long
+		// comment at the connect() function near the bottom of this file.
 		return {
 			section: '',
+			defaultOption: {}
 		};
 	},
 
@@ -507,6 +510,27 @@ const ThemeSheetWithOptions = ( props ) => {
 };
 
 export default connect(
+	// A number of the props that this mapStateToProps function computes are used
+	// by ThemeSheetWithOptions to compute defaultOption. After a state change
+	// triggered by an async action, connect()ed child components are, quite
+	// counter-intuitively, updated before their connect()ed parents (this is
+	// https://github.com/reactjs/redux/issues/1415), and might be fixed by
+	// react-redux 5.0.
+	// For this reason, after e.g. activating a theme in single-site mode,
+	// first the ThemeSheetWithOptions component's (child) ThemeOptions component
+	// will update in response to the currently displayed theme being activated.
+	// Doing so, it will filter and remove the activate option (adding customize
+	// instead). However, since the parent connect()ed-ThemeSheetWithOptions will
+	// only react to the state change afterwards, there is a brief moment when
+	// ThemeOptions still receives "activate" as its defaultOption prop, when
+	// activate is no longer part of its filtered options set, hence passing on
+	// undefined as the defaultOption object prop for its child. For the theme
+	// sheet, which eventually gets that defaultOption object prop, this means
+	// we must be careful to not accidentally access any attribute of that
+	// defaultOption prop. Otherwise, there will be an error that will prevent the
+	// state update from finishing properly, hence not updating defaultOption at all.
+	// The solution to this incredibly intricate issue is simple: Give ThemeSheet
+	// a valid defaultProp for defaultOption.
 	( state, props ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -475,7 +475,7 @@ const WrappedThemeSheet = ( props ) => {
 };
 
 const ThemeSheetWithOptions = ( props ) => {
-	const { selectedSite: site, isActive, price, isLoggedIn } = props;
+	const { siteId, isActive, price, isLoggedIn } = props;
 
 	let defaultOption;
 
@@ -492,7 +492,7 @@ const ThemeSheetWithOptions = ( props ) => {
 	}
 
 	return (
-		<ThemeOptions site={ site }
+		<ThemeOptions siteId={ siteId }
 			theme={ props /* TODO: Have ThemeOptions only use theme ID */ }
 			options={ [
 				'signup',
@@ -545,6 +545,7 @@ export default connect(
 			id: props.id,
 			isActive,
 			selectedSite,
+			siteId: selectedSite && selectedSite.ID,
 			siteSlug,
 			backPath,
 			currentUserId,

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -16,12 +16,10 @@ import {
 	customize,
 	info,
 	support,
-	bindOptionsToDispatch,
-	bindOptionsToSite
+	bindToSite,
+	bindOptions
 } from '../theme-options';
 import { trackClick } from '../helpers';
-import { isJetpackSite } from 'state/sites/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
 import { getCurrentTheme } from 'state/themes/current-theme/selectors';
 import QueryCurrentTheme from 'components/data/query-current-theme';
 
@@ -42,8 +40,6 @@ const CurrentTheme = React.createClass( {
 			PropTypes.bool
 		] ).isRequired,
 		// connected props
-		isCustomizable: PropTypes.bool.isRequired,
-		isJetpack: PropTypes.bool.isRequired,
 		currentTheme: PropTypes.object
 	},
 
@@ -56,7 +52,7 @@ const CurrentTheme = React.createClass( {
 
 		return (
 			<Card className="current-theme">
-				{ site && <QueryCurrentTheme siteId={ site.ID }/> }
+				{ site && <QueryCurrentTheme siteId={ site.ID } /> }
 				<div className="current-theme__current">
 					<span className="current-theme__label">
 						{ this.translate( 'Current Theme' ) }
@@ -70,9 +66,8 @@ const CurrentTheme = React.createClass( {
 					{ 'two-buttons': Object.keys( this.props.options ).length === 2 }
 					) } >
 					{ map( this.props.options, ( option, name ) => (
-						<CurrentThemeButton
+						<CurrentThemeButton name={ name }
 							key={ name }
-							name={ name }
 							label={ option.label }
 							icon={ option.icon }
 							href={ currentTheme && option.getUrl( currentTheme ) }
@@ -84,39 +79,28 @@ const CurrentTheme = React.createClass( {
 	}
 } );
 
-const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const { site } = ownProps;
+const bindToTheme = ( state, { site, options } ) => {
+	const currentTheme = site && getCurrentTheme( state, site.ID );
 	// FIXME (ockham): Remove this ugly hack. Currently required since the endpoint doesn't return an `active` attr
-	const theme = Object.assign( {}, stateProps.currentTheme, { active: true } );
+	const theme = Object.assign( {}, currentTheme, { active: true } );
 
-	const filteredOptions = pickBy( dispatchProps, option =>
-		! ( option.hideForSite && option.hideForSite( stateProps ) ) &&
-		! ( option.hideForTheme && option.hideForTheme( theme ) )
-	);
-
-	return Object.assign(
-		{},
-		ownProps,
-		stateProps,
-		{
-			options: bindOptionsToSite( filteredOptions, site )
-		}
-	);
+	return {
+		currentTheme,
+		options: pickBy( options, option =>
+			! ( option.hideForSite && option.hideForSite() ) &&
+			! ( option.hideForTheme && option.hideForTheme( theme ) )
+		)
+	};
 };
 
-export default connect(
-	( state, props ) => {
-		const { site: selectedSite } = props;
-		return {
-			isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
-			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' ),
-			currentTheme: selectedSite && getCurrentTheme( state, selectedSite.ID )
-		};
-	},
-	bindOptionsToDispatch( {
+const ConnectedCurrentTheme = connect( bindToSite )( connect( ...bindOptions )( connect( bindToTheme )( CurrentTheme ) ) );
+
+export default props => (
+	<ConnectedCurrentTheme { ...props }
+	options={ {
 		customize,
 		info,
 		support
-	}, 'current theme' ),
-	mergeProps
-)( CurrentTheme );
+	} }
+	source="current theme" />
+);

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -11,7 +11,7 @@ import map from 'lodash/map';
  */
 import Card from 'components/card';
 import CurrentThemeButton from './button';
-import { ThemeOptions } from '../theme-options';
+import ThemeOptions from '../theme-options';
 import { trackClick } from '../helpers';
 import { getCurrentTheme } from 'state/themes/current-theme/selectors';
 import QueryCurrentTheme from 'components/data/query-current-theme';

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -5,20 +5,13 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import map from 'lodash/map';
-import pickBy from 'lodash/pickBy';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 import CurrentThemeButton from './button';
-import {
-	customize,
-	info,
-	support,
-	bindToSite,
-	bindOptions
-} from '../theme-options';
+import { ThemeOptions } from '../theme-options';
 import { trackClick } from '../helpers';
 import { getCurrentTheme } from 'state/themes/current-theme/selectors';
 import QueryCurrentTheme from 'components/data/query-current-theme';
@@ -79,28 +72,27 @@ const CurrentTheme = React.createClass( {
 	}
 } );
 
-const bindToTheme = ( state, { site, options } ) => {
-	const currentTheme = site && getCurrentTheme( state, site.ID );
-	// FIXME (ockham): Remove this ugly hack. Currently required since the endpoint doesn't return an `active` attr
-	const theme = Object.assign( {}, currentTheme, { active: true } );
-
-	return {
-		currentTheme,
-		options: pickBy( options, option =>
-			! ( option.hideForSite && option.hideForSite() ) &&
-			! ( option.hideForTheme && option.hideForTheme( theme ) )
-		)
-	};
-};
-
-const ConnectedCurrentTheme = connect( bindToSite )( connect( ...bindOptions )( connect( bindToTheme )( CurrentTheme ) ) );
-
-export default props => (
-	<ConnectedCurrentTheme { ...props }
-	options={ {
-		customize,
-		info,
-		support
-	} }
-	source="current theme" />
+const CurrentThemeWithOptions = ( { site, currentTheme } ) => (
+	<ThemeOptions site={ site }
+		theme={ currentTheme /* TODO: Have ThemeOptions only use theme ID */ }
+		options={ [
+			'customize',
+			'info',
+			'support'
+		] }
+		source="current theme">
+		<CurrentTheme site={ site } currentTheme={ currentTheme } />
+	</ThemeOptions>
 );
+
+export default connect(
+	( state, { site } ) => {
+		const currentTheme = site && getCurrentTheme( state, site.ID );
+		// FIXME (ockham): Remove this ugly hack. Currently required since the endpoint doesn't return an `active` attr
+		const theme = Object.assign( {}, currentTheme, { active: true } );
+
+		return {
+			currentTheme: theme
+		};
+	}
+)( CurrentThemeWithOptions );

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -14,26 +14,12 @@ import config from 'config';
 import route from 'lib/route';
 import { oldShowcaseUrl, isPremiumTheme as isPremium } from 'state/themes/utils';
 
-export function getSignupUrl( theme ) {
-	let url = '/start/with-theme?ref=calypshowcase&theme=' + theme.id;
-
-	if ( isPremium( theme ) ) {
-		url += '&premium=true';
-	}
-
-	return url;
-}
-
 export function getPreviewUrl( theme, site ) {
 	if ( site && site.jetpack ) {
 		return site.options.admin_url + 'customize.php?theme=' + theme.id + '&return=' + encodeURIComponent( window.location );
 	}
 
 	return `${ theme.demo_uri }?demo=true&iframe=true&theme_preview=true`;
-}
-
-export function getPurchaseUrl( theme, site ) {
-	return `/checkout/${ site.slug }/theme:${ theme.id }`;
 }
 
 export function getCustomizeUrl( theme, site ) {
@@ -62,35 +48,8 @@ export function getDetailsUrl( theme, site ) {
 	return baseUrl + ( site ? `/${ site.slug }` : '' );
 }
 
-export function getSupportUrl( theme, site ) {
-	if ( site && site.jetpack ) {
-		return '//wordpress.org/support/theme/' + theme.id;
-	}
-
-	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		const sitePart = site ? `/${ site.slug }` : '';
-		return `/theme/${ theme.id }/setup${ sitePart }`;
-	}
-
-	const sitePart = site ? `${ site.slug }/` : '';
-	return `${ oldShowcaseUrl }${ sitePart }${ theme.id }/support`;
-}
-
 export function getForumUrl( theme ) {
 	return isPremium( theme ) ? '//premium-themes.forums.wordpress.com/forum/' + theme.id : '//en.forums.wordpress.com/forum/themes';
-}
-
-export function getHelpUrl( theme, site ) {
-	if ( site && site.jetpack ) {
-		return getSupportUrl( theme, site );
-	}
-
-	let baseUrl = oldShowcaseUrl + theme.id;
-	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		baseUrl = `/theme/${ theme.id }/support`;
-	}
-
-	return baseUrl + ( site ? `/${ site.slug }` : '' );
 }
 
 export function getExternalThemesUrl( site ) {

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -7,7 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import ThemeShowcase from './theme-showcase';
-import { ThemeOptions } from './theme-options';
+import ThemeOptions from './theme-options';
 
 export default props => (
 	<ThemeOptions { ...props }

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -14,29 +15,24 @@ import {
 	info,
 	support,
 	help,
-	bindOptionsToDispatch
+	bindOptions
 } from './theme-options';
 
-const mergeProps = ( stateProps, dispatchProps, ownProps ) => Object.assign(
-	{},
-	ownProps,
-	stateProps,
-	{
-		options: dispatchProps,
-		defaultOption: dispatchProps.signup,
-		getScreenshotOption: () => dispatchProps.info
-	}
-);
+const BoundThemeShowcase = connect( ...bindOptions )( ThemeShowcase );
 
-export default connect(
-	null,
-	bindOptionsToDispatch( {
+export default props => (
+	<BoundThemeShowcase { ...props }
+	options={ {
 		signup,
 		preview,
 		separator,
 		info,
 		support,
 		help
-	}, 'showcase' ),
-	mergeProps
-)( ThemeShowcase );
+	} }
+	defaultOption="signup"
+	getScreenshotOption={ function() {
+		return 'info';
+	} }
+	source="showcase" />
+);

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -2,37 +2,28 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import ThemeShowcase from './theme-showcase';
-import {
-	preview,
-	signup,
-	separator,
-	info,
-	support,
-	help,
-	bindOptions
-} from './theme-options';
-
-const BoundThemeShowcase = connect( ...bindOptions )( ThemeShowcase );
+import { ThemeOptions } from './theme-options';
 
 export default props => (
-	<BoundThemeShowcase { ...props }
-	options={ {
-		signup,
-		preview,
-		separator,
-		info,
-		support,
-		help
-	} }
+	<ThemeOptions { ...props }
+	options={ [
+		'signup',
+		'preview',
+		'separator',
+		'info',
+		'support',
+		'help'
+	] }
 	defaultOption="signup"
 	getScreenshotOption={ function() {
 		return 'info';
 	} }
-	source="showcase" />
+	source="showcase">
+		<ThemeShowcase { ...props } />
+	</ThemeOptions>
 );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  */
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
-import { ThemeOptions } from './theme-options';
+import ThemeOptions from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
 export default props => (

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -17,34 +16,12 @@ import {
 	separator,
 	info,
 	support,
-	help,
-	bindOptionsToDispatch
+	help
 } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
-const ThemesMultiSite = props => (
-	<ThemesSiteSelectorModal { ...props } sourcePath="/design">
-		<ThemeShowcase { ...props }>
-			<SidebarNavigation />
-		</ThemeShowcase>
-	</ThemesSiteSelectorModal>
-);
-
-const mergeProps = ( stateProps, dispatchProps, ownProps ) => Object.assign(
-	{},
-	ownProps,
-	stateProps,
-	{
-		options: dispatchProps,
-		defaultOption: dispatchProps.activate,
-		secondaryOption: dispatchProps.tryandcustomize,
-		getScreenshotOption: () => dispatchProps.info
-	}
-);
-
-export default connect(
-	null,
-	bindOptionsToDispatch( {
+export default props => (
+	<ThemesSiteSelectorModal options={ {
 		preview,
 		purchase,
 		activate,
@@ -53,6 +30,15 @@ export default connect(
 		info,
 		support,
 		help,
-	}, 'showcase' ),
-	mergeProps
-)( ThemesMultiSite );
+	} }
+	defaultOption="activate"
+	secondaryOption="tryandcustomize"
+	getScreenshotOption={ function() {
+		return 'info';
+	} }
+	sourcePath="/design">
+		<ThemeShowcase { ...props } source="showcase">
+			<SidebarNavigation />
+		</ThemeShowcase>
+	</ThemesSiteSelectorModal>
+);

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -8,37 +8,29 @@ import React from 'react';
  */
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
-import {
-	preview,
-	purchase,
-	activate,
-	tryandcustomize,
-	separator,
-	info,
-	support,
-	help
-} from './theme-options';
+import { ThemeOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
 export default props => (
-	<ThemesSiteSelectorModal options={ {
-		preview,
-		purchase,
-		activate,
-		tryandcustomize,
-		separator,
-		info,
-		support,
-		help,
-	} }
+	<ThemeOptions options={ [
+		'preview',
+		'purchase',
+		'activate',
+		'tryandcustomize',
+		'separator',
+		'info',
+		'support',
+		'help',
+	] }
 	defaultOption="activate"
 	secondaryOption="tryandcustomize"
 	getScreenshotOption={ function() {
 		return 'info';
-	} }
-	sourcePath="/design">
-		<ThemeShowcase { ...props } source="showcase">
-			<SidebarNavigation />
-		</ThemeShowcase>
-	</ThemesSiteSelectorModal>
+	} }>
+		<ThemesSiteSelectorModal sourcePath="/design">
+			<ThemeShowcase { ...props } source="showcase">
+				<SidebarNavigation />
+			</ThemeShowcase>
+		</ThemesSiteSelectorModal>
+	</ThemeOptions>
 );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -16,19 +16,7 @@ import config from 'config';
 import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
-import {
-	customize,
-	preview,
-	purchase,
-	activate,
-	tryandcustomize,
-	separator,
-	info,
-	support,
-	help,
-	bindToSite,
-	bindOptions
-} from './theme-options';
+import { customize, info, ThemeOptions } from './theme-options';
 import sitesFactory from 'lib/sites-list';
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
@@ -57,9 +45,6 @@ const JetpackThemeReferrerPage = localize(
 		</Main>
 	)
 );
-
-const BoundThemeShowcase = connect( ...bindOptions )( ThemeShowcase );
-
 const ThemesSingleSiteBase = ( props ) => {
 	const site = sites.getSelectedSite(),
 		{ analyticsPath, analyticsPageTitle, isJetpack, translate } = props,
@@ -89,21 +74,40 @@ const ThemesSingleSiteBase = ( props ) => {
 	}
 
 	return (
-		<BoundThemeShowcase { ...props }>
-			<SidebarNavigation />
-			<ThanksModal
-				site={ site }
-				source={ 'list' } />
-			<CurrentTheme
-				site={ site }
-				canCustomize={ site && site.isCustomizable() } />
-			<UpgradeNudge
-				title={ translate( 'Get Custom Design with Premium' ) }
-				message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }
-				feature={ FEATURE_ADVANCED_DESIGN }
-				event="themes_custom_design"
-			/>
-		</BoundThemeShowcase>
+		<ThemeOptions site={ site }
+			options={ [
+				'customize',
+				'preview',
+				'purchase',
+				'activate',
+				'tryandcustomize',
+				'separator',
+				'info',
+				'support',
+				'help'
+			] }
+			defaultOption="activate"
+			secondaryOption="tryandcustomize"
+			getScreenshotOption={ function( theme ) {
+				return theme.active ? customize : info;
+			} }
+			source="showcase">
+			<ThemeShowcase { ...props }>
+				<SidebarNavigation />
+				<ThanksModal
+					site={ site }
+					source={ 'list' } />
+				<CurrentTheme
+					site={ site }
+					canCustomize={ site && site.isCustomizable() } />
+				<UpgradeNudge
+					title={ translate( 'Get Custom Design with Premium' ) }
+					message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }
+					feature={ FEATURE_ADVANCED_DESIGN }
+					event="themes_custom_design"
+				/>
+			</ThemeShowcase>
+		</ThemeOptions>
 	);
 };
 
@@ -118,25 +122,10 @@ const bindSingleSite = ( state ) => {
 
 const ThemesSingleSite = connect( bindSingleSite )( localize( ThemesSingleSiteBase ) );
 
-const ThemeShowcaseBoundToSite = connect( bindToSite )( ThemesSingleSite );
-
+// bind To site
 export default props => (
-	<ThemeShowcaseBoundToSite { ...props }
-		options={ {
-			customize,
-			preview,
-			purchase,
-			activate,
-			tryandcustomize,
-			separator,
-			info,
-			support,
-			help
-		} }
-		defaultOption="activate"
-		secondaryOption="tryandcustomize"
+	<ThemesSingleSite { ...props }
 		getScreenshotOption={ function( theme ) {
-			return theme.active ? 'customize' : 'info';
-		} }
-		source="showcase" />
+			return theme.active ? customize : info;
+		} } />
 );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -72,7 +72,7 @@ const SingleSiteThemeShowcase = ( props ) => {
 	}
 
 	return (
-		<ThemeOptions site={ site }
+		<ThemeOptions siteId={ site.ID }
 			options={ [
 				'customize',
 				'preview',

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -16,7 +16,7 @@ import config from 'config';
 import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
-import { customize, info, ThemeOptions } from './theme-options';
+import { ThemeOptions } from './theme-options';
 import sitesFactory from 'lib/sites-list';
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
@@ -89,7 +89,7 @@ const SingleSiteThemeShowcase = ( props ) => {
 			defaultOption="activate"
 			secondaryOption="tryandcustomize"
 			getScreenshotOption={ function( theme ) {
-				return theme.active ? customize : info;
+				return theme.active ? 'customize' : 'info';
 			} }
 			source="showcase">
 			<ThemeShowcase { ...props }>

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -45,7 +45,7 @@ const JetpackThemeReferrerPage = localize(
 		</Main>
 	)
 );
-const ThemesSingleSiteBase = ( props ) => {
+const SingleSiteThemeShowcase = ( props ) => {
 	const site = sites.getSelectedSite(),
 		{ analyticsPath, analyticsPageTitle, isJetpack, translate } = props,
 		jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
@@ -120,4 +120,4 @@ export default connect(
 			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' )
 		};
 	}
-)( localize( ThemesSingleSiteBase ) );
+)( localize( SingleSiteThemeShowcase ) );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -16,7 +16,7 @@ import config from 'config';
 import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
-import { ThemeOptions } from './theme-options';
+import ThemeOptions from './theme-options';
 import sitesFactory from 'lib/sites-list';
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -111,21 +111,13 @@ const ThemesSingleSiteBase = ( props ) => {
 	);
 };
 
-const bindSingleSite = ( state ) => {
-	const selectedSite = getSelectedSite( state );
-	return {
-		selectedSite,
-		isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
-		isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' )
-	};
-};
-
-const ThemesSingleSite = connect( bindSingleSite )( localize( ThemesSingleSiteBase ) );
-
-// bind To site
-export default props => (
-	<ThemesSingleSite { ...props }
-		getScreenshotOption={ function( theme ) {
-			return theme.active ? customize : info;
-		} } />
-);
+export default connect(
+	( state ) => {
+		const selectedSite = getSelectedSite( state );
+		return {
+			selectedSite,
+			isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
+			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' )
+		};
+	}
+)( localize( ThemesSingleSiteBase ) );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -33,9 +33,7 @@ const JetpackThemeReferrerPage = localize(
 		<Main className="themes">
 			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 			<SidebarNavigation />
-			<CurrentTheme
-				site={ site }
-				canCustomize={ site && site.isCustomizable() } />
+			<CurrentTheme site={ site } />
 			<EmptyContent title={ translate( 'Changing Themes?' ) }
 				line={ translate( 'Use your site theme browser to manage themes.' ) }
 				action={ translate( 'Open Site Theme Browser' ) }
@@ -97,9 +95,7 @@ const SingleSiteThemeShowcase = ( props ) => {
 				<ThanksModal
 					site={ site }
 					source={ 'list' } />
-				<CurrentTheme
-					site={ site }
-					canCustomize={ site && site.isCustomizable() } />
+				<CurrentTheme site={ site } />
 				<UpgradeNudge
 					title={ translate( 'Get Custom Design with Premium' ) }
 					message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -195,7 +195,7 @@ export default connect(
 	( dispatch, { theme, site, source = 'unknown' } ) => {
 		let mapAction;
 
-		if ( site !== undefined ) {
+		if ( site ) {
 			// TODO (@ockham): Change actions to use siteId.
 			if ( theme ) { // Bind theme and site.
 				mapAction = action => () => action( theme, site, source );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -218,7 +218,7 @@ class ThemeOptionsComponent extends React.Component {
 				options,
 				defaultOption: options[ defaultOption ],
 				secondaryOption: secondaryOption ? options[ secondaryOption ] : null,
-				getScreenshotOption
+				getScreenshotOption: ( theme ) => options[ getScreenshotOption( theme ) ]
 			}
 		);
 	}

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
-import { has, mapValues, merge, pick } from 'lodash';
+import { has, mapValues, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,7 +29,6 @@ import {
 } from 'state/themes/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
 
 export const purchase = config.isEnabled( 'upgrades/checkout' )
 	? {
@@ -115,99 +114,6 @@ export const help = {
 	// We don't know where support docs for a given theme on a self-hosted WP install are.
 	hideForSite: ( state, site ) => isJetpackSite( state, site ),
 };
-
-export function bindOptionToDispatch( option, source ) {
-	return dispatch => Object.assign(
-		{},
-		//option,
-		option.action
-			? { action: bindActionCreators(
-				( theme, site ) => option.action( theme, site, source ),
-				dispatch
-				) }
-			: {}
-	);
-}
-
-export const bindOptionsToDispatch = ( dispatch, { options, source } ) => (
-	mapValues( options, option => bindOptionToDispatch( option, source )( dispatch ) )
-);
-
-function bindOptionToState( option, state ) {
-	return Object.assign(
-		{},
-		option,
-		option.getUrl
-			? { getUrl: ( theme, siteId ) => option.getUrl( state, theme, siteId ) }
-			: {},
-		option.hideForSite
-			? { hideForSite: siteId => option.hideForSite( state, siteId ) }
-			: {},
-	);
-}
-
-// Sig: state, ownProps?
-export function bindOptionsToState( options, state ) {
-	return mapValues( options, option => bindOptionToState( option, state ) );
-}
-
-export const bindToState = ( state, { options } ) => ( {
-	options: bindOptionsToState( options, state )
-} );
-
-// Ideally: same sig as mergeProps. stateProps, dispatchProps, ownProps
-function bindOptionToSite( option, site ) {
-	return Object.assign(
-		{},
-		option,
-		option.action
-			? { action: theme => option.action( theme, site ) } // TODO (@ockham): Change actions to use siteId.
-			: {},
-		option.getUrl
-			? { getUrl: ( state, theme ) => option.getUrl( state, theme, site.ID ) }
-			: {},
-		option.hideForSite
-			? { hideForSite: state => option.hideForSite( state, site.ID ) }
-			: {},
-	);
-}
-
-export function bindOptionsToSite( options, site ) {
-	return mapValues( options, option => bindOptionToSite( option, site ) );
-}
-
-export const bindToSite = ( state, { options } ) => ( {
-	options: bindOptionsToSite( options, getSelectedSite( state ) )
-} );
-
-export const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const options = merge(
-		{},
-		stateProps.options,
-		dispatchProps
-	);
-
-	return Object.assign(
-		{},
-		ownProps,
-		stateProps,
-		{
-			options,
-			defaultOption: options[ ownProps.defaultOption ],
-			secondaryOption: options[ ownProps.secondaryOption ],
-			getScreenshotOption: function( theme ) {
-				const screenshotOption = ownProps.getScreenshotOption( theme );
-				return options[ screenshotOption ];
-			}
-		}
-	);
-};
-
-export const bindOptions = [
-	bindToState,
-	bindOptionsToDispatch,
-	mergeProps
-];
 
 const ThemeOptionsComponent = ( { children, options, defaultOption, secondaryOption, getScreenshotOption } ) => (
 	React.cloneElement(

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -209,20 +209,17 @@ export const bindOptions = [
 	mergeProps
 ];
 
-class ThemeOptionsComponent extends React.Component {
-	render() {
-		const { options, defaultOption, secondaryOption, getScreenshotOption } = this.props;
-		return React.cloneElement(
-			this.props.children,
-			{
-				options,
-				defaultOption: options[ defaultOption ],
-				secondaryOption: secondaryOption ? options[ secondaryOption ] : null,
-				getScreenshotOption: ( theme ) => options[ getScreenshotOption( theme ) ]
-			}
-		);
-	}
-}
+const ThemeOptionsComponent = ( { children, options, defaultOption, secondaryOption, getScreenshotOption } ) => (
+	React.cloneElement(
+		children,
+		{
+			options,
+			defaultOption: options[ defaultOption ],
+			secondaryOption: secondaryOption ? options[ secondaryOption ] : null,
+			getScreenshotOption: ( theme ) => options[ getScreenshotOption( theme ) ]
+		}
+	)
+);
 
 export const ThemeOptions = connect(
 	( state, { options: optionNames, site, theme } ) => {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -241,13 +241,9 @@ export const ThemeOptions = connect(
 		const options = pick( allOptions, optionNames );
 		let mapGetUrl, mapHideForSite;
 
-		if ( site !== undefined ) {
-			let siteId;
-			if ( site !== null ) {
-				siteId = site.ID;
-			} else {
-				siteId = null;
-			}
+		if ( site ) {
+			const siteId = site.ID;
+
 			if ( theme ) { // Bind everything.
 				mapGetUrl = getUrl => () => getUrl( state, theme, siteId );
 				mapHideForSite = hideForSite => () => hideForSite( state, siteId );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -127,7 +127,7 @@ const ThemeOptionsComponent = ( { children, options, defaultOption, secondaryOpt
 	)
 );
 
-export const ThemeOptions = connect(
+export default connect(
 	( state, { options: optionNames, site, theme } ) => {
 		const allOptions = {
 			customize,

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -144,18 +144,16 @@ const ALL_THEME_OPTIONS = {
 const ALL_THEME_ACTIONS = { activate: activateAction }; // All theme related actions available.
 
 export default connect(
-	( state, { options: optionNames, site, theme } ) => {
+	( state, { options: optionNames, siteId, theme } ) => {
 		let options = pick( ALL_THEME_OPTIONS, optionNames );
 		let mapGetUrl = identity, mapHideForSite = identity;
 
-		// We bind hideForTheme to site even if it is null since the selectors
+		// We bind hideForTheme to siteId even if it is null since the selectors
 		// that are used by it are expected to recognize that case as "no site selected"
 		// and work accordingly.
-		const mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, site ? site.ID : null );
+		const mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, siteId );
 
-		if ( site ) {
-			const siteId = site.ID;
-
+		if ( siteId ) {
 			mapGetUrl = getUrl => ( t ) => getUrl( state, t, siteId );
 			options = pickBy( options, option =>
 				! ( option.hideForSite && option.hideForSite( state, siteId ) )
@@ -184,12 +182,11 @@ export default connect(
 				: {}
 		) );
 	},
-	( dispatch, { site, source = 'unknown' } ) => {
+	( dispatch, { siteId, source = 'unknown' } ) => {
 		let mapAction;
 
-		if ( site ) {
-			// TODO (@ockham): Change actions to use siteId.
-			mapAction = action => ( t ) => action( t, site, source );
+		if ( siteId ) {
+			mapAction = action => ( t ) => action( t, siteId, source );
 		} else { // Bind only source.
 			mapAction = action => ( t, s ) => action( t, s, source );
 		}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -170,8 +170,9 @@ const ThemeShowcase = React.createClass( {
 	}
 } );
 
-export default connect( state => ( {
-	queryParams: getQueryParams( state ),
-	themesList: getThemesList( state )
-} )
+export default connect(
+	state => ( {
+		queryParams: getQueryParams( state ),
+		themesList: getThemesList( state ),
+	} )
 )( localize( ThemeShowcase ) );

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -49,7 +49,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 		 */
 		if ( action ) {
 			defer( () => {
-				action( theme, site );
+				action( theme, site.ID );
 			} );
 		}
 	},

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
 import page from 'page';
 import defer from 'lodash/defer';
 import omit from 'lodash/omit';
@@ -14,7 +13,6 @@ import mapValues from 'lodash/mapValues';
 import Theme from 'components/theme';
 import SiteSelectorModal from 'components/site-selector-modal';
 import { trackClick } from './helpers';
-import { bindOptions } from './theme-options';
 
 const ThemesSiteSelectorModal = React.createClass( {
 	propTypes: {
@@ -118,4 +116,4 @@ const ThemesSiteSelectorModal = React.createClass( {
 	}
 } );
 
-export default connect( ...bindOptions )( ThemesSiteSelectorModal );
+export default ThemesSiteSelectorModal;

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import page from 'page';
 import defer from 'lodash/defer';
 import omit from 'lodash/omit';
@@ -13,15 +14,19 @@ import mapValues from 'lodash/mapValues';
 import Theme from 'components/theme';
 import SiteSelectorModal from 'components/site-selector-modal';
 import { trackClick } from './helpers';
+import { bindOptions } from './theme-options';
 
 const ThemesSiteSelectorModal = React.createClass( {
 	propTypes: {
-		options: React.PropTypes.objectOf( React.PropTypes.shape( {
-			label: React.PropTypes.string,
-			header: React.PropTypes.string,
-			action: React.PropTypes.func
+		children: PropTypes.element,
+		options: PropTypes.objectOf( PropTypes.shape( {
+			label: PropTypes.string,
+			header: PropTypes.string,
+			getUrl: PropTypes.func,
+			action: PropTypes.func
 		} ) ),
-		selectedSite: React.PropTypes.object,
+		defaultOption: PropTypes.string,
+		secondaryOption: PropTypes.string,
 		// Will be prepended to site slug for a redirect on selection
 		sourcePath: PropTypes.string.isRequired,
 	},
@@ -102,7 +107,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 					mainAction={ this.trackAndCallAction }
 					mainActionLabel={ selectedOption.label }
 					getMainUrl={ selectedOption.getUrl ? function( site ) {
-						return selectedOption.getUrl( selectedTheme, site );
+						return selectedOption.getUrl( selectedTheme, site.ID );
 					} : null } >
 
 					<Theme isActionable={ false } theme={ selectedTheme } />
@@ -113,4 +118,4 @@ const ThemesSiteSelectorModal = React.createClass( {
 	}
 } );
 
-export default ThemesSiteSelectorModal;
+export default connect( ...bindOptions )( ThemesSiteSelectorModal );

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -141,7 +141,7 @@ const CheckoutThankYou = React.createClass( {
 
 	redirectIfThemePurchased() {
 		if ( this.props.receipt.hasLoadedFromServer && getPurchases( this.props ).every( isTheme ) ) {
-			this.props.activatedTheme( getPurchases( this.props )[ 0 ].meta, this.props.selectedSite );
+			this.props.activatedTheme( getPurchases( this.props )[ 0 ].meta, this.props.selectedSite.ID );
 
 			page.redirect( '/design/' + this.props.selectedSite.slug );
 		}

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -192,17 +192,17 @@ export function receiveThemes( data, site, queryParams, responseTime ) {
 	};
 }
 
-export function activate( theme, site, source = 'unknown' ) {
+export function activate( theme, siteId, source = 'unknown' ) {
 	return dispatch => {
 		dispatch( {
 			type: THEME_ACTIVATE,
 			theme: theme,
-			site: site
+			siteId: siteId
 		} );
 
-		wpcom.undocumented().activateTheme( theme, site.ID )
+		wpcom.undocumented().activateTheme( theme, siteId )
 			.then( () => {
-				dispatch( activated( theme, site, source ) );
+				dispatch( activated( theme, siteId, source ) );
 			} )
 			.catch( error => {
 				dispatch( receiveServerError( error ) );
@@ -210,9 +210,9 @@ export function activate( theme, site, source = 'unknown' ) {
 	};
 }
 
-export function activated( theme, site, source = 'unknown', purchased = false ) {
+export function activated( theme, siteId, source = 'unknown', purchased = false ) {
 	return ( dispatch, getState ) => {
-		const previousTheme = getCurrentTheme( getState(), site.ID );
+		const previousTheme = getCurrentTheme( getState(), siteId );
 		const queryParams = getState().themes.themesList.get( 'query' );
 
 		if ( typeof theme !== 'object' ) {
@@ -222,8 +222,7 @@ export function activated( theme, site, source = 'unknown', purchased = false ) 
 		const action = {
 			type: THEME_ACTIVATED,
 			theme,
-			site,
-			siteId: site.ID
+			siteId: siteId
 		};
 
 		const trackThemeActivation = recordTracksEvent(

--- a/client/state/themes/current-theme/reducer.js
+++ b/client/state/themes/current-theme/reducer.js
@@ -55,7 +55,7 @@ export default ( state = initialState, action ) => {
 			return state
 				.set( 'isActivating', false )
 				.set( 'hasActivated', true )
-				.setIn( [ 'currentThemes', action.site.ID ], action.theme );
+				.setIn( [ 'currentThemes', action.siteId ], action.theme );
 		case THEME_CLEAR_ACTIVATED:
 			return state.set( 'hasActivated', false );
 		case DESERIALIZE:


### PR DESCRIPTION
Rebase after merging #6924. [Diff](https://github.com/Automattic/wp-calypso/compare/update/themes-turn-helpers-into-selectors-take-two...update/themes-actions-use-site-id-instead-of-object).
