### PR TITLE
Reader Stream Refresh: only display photo cards if character limit is <= 100

### DIFF
--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -59,7 +59,7 @@ function discoverFullBleedImages( post, dom ) {
 }
 
 const hasShortContent = config.isEnabled( 'reader/refresh/stream' )
-	? post => post.character_count <= 130
+	? post => post.character_count <= 100
 	: post => post.word_count < 100;
 
 /**


### PR DESCRIPTION
In #9010 @fraying suggests:

> I still see a bunch of cards that really shouldn't be photo cards. So I suggest we lower the character limit to 100 to use the photo card.

This PR reduces the character count required to qualify as a photo card to <= 100.

Fixes #9010.
