### PR TITLE
Media: refactor/clean up the post-editor/media-modal/gallery/fields component

### DIFF
--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -7,6 +7,7 @@ import noop from 'lodash/noop';
 import includes from 'lodash/includes';
 import times from 'lodash/times';
 import fromPairs from 'lodash/fromPairs';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,8 +18,7 @@ import SelectDropdownItem from 'components/select-dropdown/item';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'lib/media/constants';
 
-export default React.createClass( {
-	displayName: 'EditorMediaModalGalleryFields',
+export const EditorMediaModalGalleryFields = React.createClass( {
 
 	propTypes: {
 		site: PropTypes.object,
@@ -39,22 +39,22 @@ export default React.createClass( {
 		const { site } = this.props;
 
 		let options = {
-			individual: this.translate( 'Individual Images' ),
-			default: this.translate( 'Thumbnail Grid' )
+			individual: this.props.translate( 'Individual Images' ),
+			default: this.props.translate( 'Thumbnail Grid' )
 		};
 
 		if ( site && ( ! site.jetpack || site.isModuleActive( 'tiled-gallery' ) ) ) {
 			assign( options, {
-				rectangular: this.translate( 'Tiled Mosaic' ),
-				square: this.translate( 'Square Tiles' ),
-				circle: this.translate( 'Circles' ),
-				columns: this.translate( 'Tiled Columns' )
+				rectangular: this.props.translate( 'Tiled Mosaic' ),
+				square: this.props.translate( 'Square Tiles' ),
+				circle: this.props.translate( 'Circles' ),
+				columns: this.props.translate( 'Tiled Columns' )
 			} );
 		}
 
 		if ( site && ( ! site.jetpack || site.isModuleActive( 'shortcodes' ) ) ) {
 			assign( options, {
-				slideshow: this.translate( 'Slideshow' )
+				slideshow: this.props.translate( 'Slideshow' )
 			} );
 		}
 
@@ -67,9 +67,9 @@ export default React.createClass( {
 		}
 
 		return {
-			'': this.translate( 'Attachment Page' ),
-			file: this.translate( 'Media File' ),
-			none: this.translate( 'None' ),
+			'': this.props.translate( 'Attachment Page' ),
+			file: this.props.translate( 'Media File' ),
+			none: this.props.translate( 'None' ),
 		};
 	},
 
@@ -79,10 +79,10 @@ export default React.createClass( {
 		}
 
 		return {
-			thumbnail: this.translate( 'Thumbnail' ),
-			medium: this.translate( 'Medium' ),
-			large: this.translate( 'Large' ),
-			full: this.translate( 'Full Size' ),
+			thumbnail: this.props.translate( 'Thumbnail' ),
+			medium: this.props.translate( 'Medium' ),
+			large: this.props.translate( 'Large' ),
+			full: this.props.translate( 'Full Size' ),
 		};
 	},
 
@@ -127,7 +127,7 @@ export default React.createClass( {
 			return;
 		}
 
-		return this.renderDropdown( this.translate( 'Columns' ), this.getColumnOptions(), 'columns' );
+		return this.renderDropdown( this.props.translate( 'Columns' ), this.getColumnOptions(), 'columns' );
 	},
 
 	renderRandomOption() {
@@ -138,7 +138,7 @@ export default React.createClass( {
 		}
 
 		return (
-			<EditorMediaModalFieldset legend={ this.translate( 'Random Order' ) }>
+			<EditorMediaModalFieldset legend={ this.props.translate( 'Random Order' ) }>
 				<FormCheckbox onChange={ this.updateRandomOrder } checked={ settings.orderBy === 'rand' } />
 			</EditorMediaModalFieldset>
 		);
@@ -151,12 +151,14 @@ export default React.createClass( {
 
 		return (
 			<div className="editor-media-modal-gallery__fields">
-				{ this.renderDropdown( this.translate( 'Layout' ), types, 'type' ) }
+				{ this.renderDropdown( this.props.translate( 'Layout' ), types, 'type' ) }
 				{ this.renderColumnsOption() }
 				{ this.renderRandomOption() }
-				{ this.renderDropdown( this.translate( 'Link To' ), links, 'link' ) }
-				{ this.renderDropdown( this.translate( 'Size' ), sizes, 'size' ) }
+				{ this.renderDropdown( this.props.translate( 'Link To' ), links, 'link' ) }
+				{ this.renderDropdown( this.props.translate( 'Size' ), sizes, 'size' ) }
 			</div>
 		);
 	}
 } );
+
+export default localize( EditorMediaModalGalleryFields );

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -38,9 +38,9 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 	getTypeOptions() {
 		const { site } = this.props;
 
-		let options = {
+		const options = {
 			individual: this.props.translate( 'Individual Images' ),
-			default: this.props.translate( 'Thumbnail Grid' )
+			'default': this.props.translate( 'Thumbnail Grid' )
 		};
 
 		if ( site && ( ! site.jetpack || site.isModuleActive( 'tiled-gallery' ) ) ) {
@@ -104,14 +104,14 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 
 		return (
 			<EditorMediaModalFieldset legend={ legend } className={ 'for-setting-' + settingName }>
-				<SelectDropdown selectedText={ options[ settings[settingName] ] }>
+				<SelectDropdown selectedText={ options[ settings[ settingName ] ] }>
 					{ Object.keys( options ).map( ( value ) => {
 						const label = options[ value ];
 
 						return (
 							<SelectDropdownItem
 								key={ 'value-' + value }
-								selected={ value === settings[settingName] }
+								selected={ value === settings[ settingName ] }
 								onClick={ () => onUpdateSetting( settingName, isFinite( parseInt( value ) ) ? +value : value ) }>
 								{ label }
 							</SelectDropdownItem>

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -18,7 +18,22 @@ import SelectDropdownItem from 'components/select-dropdown/item';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'lib/media/constants';
 
-export class EditorMediaModalGalleryFields extends React.Component {
+export const EditorMediaModalGalleryFields = React.createClass( {
+
+	propTypes: {
+		site: PropTypes.object,
+		settings: PropTypes.object,
+		onUpdateSetting: PropTypes.func,
+		numberOfItems: PropTypes.number
+	},
+
+	getDefaultProps() {
+		return {
+			settings: Object.freeze( {} ),
+			onUpdateSetting: noop,
+			numberOfItems: 0
+		};
+	},
 
 	getTypeOptions() {
 		const { site } = this.props;
@@ -44,7 +59,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 		}
 
 		return options;
-	}
+	},
 
 	getLinkOptions() {
 		if ( 'individual' === this.props.settings.type ) {
@@ -56,7 +71,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 			file: this.props.translate( 'Media File' ),
 			none: this.props.translate( 'None' ),
 		};
-	}
+	},
 
 	getSizeOptions() {
 		if ( ! includes( GallerySizeableTypes, this.props.settings.type ) ) {
@@ -69,16 +84,16 @@ export class EditorMediaModalGalleryFields extends React.Component {
 			large: this.props.translate( 'Large' ),
 			full: this.props.translate( 'Full Size' ),
 		};
-	}
+	},
 
 	getColumnOptions() {
 		const max = Math.min( this.props.numberOfItems, 9 );
 		return fromPairs( times( max, ( n ) => [ n + 1, ( n + 1 ).toString() ] ) );
-	}
+	},
 
 	updateRandomOrder( event ) {
 		this.props.onUpdateSetting( 'orderBy', event.target.checked ? 'rand' : null );
-	}
+	},
 
 	renderDropdown( legend, options, settingName ) {
 		const { settings, onUpdateSetting } = this.props;
@@ -105,7 +120,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 				</SelectDropdown>
 			</EditorMediaModalFieldset>
 		);
-	}
+	},
 
 	renderColumnsOption() {
 		if ( ! includes( GalleryColumnedTypes, this.props.settings.type ) ) {
@@ -113,7 +128,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 		}
 
 		return this.renderDropdown( this.props.translate( 'Columns' ), this.getColumnOptions(), 'columns' );
-	}
+	},
 
 	renderRandomOption() {
 		const { settings } = this.props;
@@ -127,7 +142,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 				<FormCheckbox onChange={ this.updateRandomOrder } checked={ settings.orderBy === 'rand' } />
 			</EditorMediaModalFieldset>
 		);
-	}
+	},
 
 	render() {
 		const types = this.getTypeOptions();
@@ -144,19 +159,6 @@ export class EditorMediaModalGalleryFields extends React.Component {
 			</div>
 		);
 	}
-}
-
-EditorMediaModalGalleryFields.propTypes = {
-	site: PropTypes.object,
-	settings: PropTypes.object,
-	onUpdateSetting: PropTypes.func,
-	numberOfItems: PropTypes.number
-};
-
-EditorMediaModalGalleryFields.defaultProps = {
-	settings: Object.freeze( {} ),
-	onUpdateSetting: noop,
-	numberOfItems: 0
-};
+} );
 
 export default localize( EditorMediaModalGalleryFields );

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -18,22 +18,7 @@ import SelectDropdownItem from 'components/select-dropdown/item';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'lib/media/constants';
 
-export const EditorMediaModalGalleryFields = React.createClass( {
-
-	propTypes: {
-		site: PropTypes.object,
-		settings: PropTypes.object,
-		onUpdateSetting: PropTypes.func,
-		numberOfItems: PropTypes.number
-	},
-
-	getDefaultProps() {
-		return {
-			settings: Object.freeze( {} ),
-			onUpdateSetting: noop,
-			numberOfItems: 0
-		};
-	},
+export class EditorMediaModalGalleryFields extends React.Component {
 
 	getTypeOptions() {
 		const { site } = this.props;
@@ -59,7 +44,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 		}
 
 		return options;
-	},
+	}
 
 	getLinkOptions() {
 		if ( 'individual' === this.props.settings.type ) {
@@ -71,7 +56,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 			file: this.props.translate( 'Media File' ),
 			none: this.props.translate( 'None' ),
 		};
-	},
+	}
 
 	getSizeOptions() {
 		if ( ! includes( GallerySizeableTypes, this.props.settings.type ) ) {
@@ -84,16 +69,16 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 			large: this.props.translate( 'Large' ),
 			full: this.props.translate( 'Full Size' ),
 		};
-	},
+	}
 
 	getColumnOptions() {
 		const max = Math.min( this.props.numberOfItems, 9 );
 		return fromPairs( times( max, ( n ) => [ n + 1, ( n + 1 ).toString() ] ) );
-	},
+	}
 
 	updateRandomOrder( event ) {
 		this.props.onUpdateSetting( 'orderBy', event.target.checked ? 'rand' : null );
-	},
+	}
 
 	renderDropdown( legend, options, settingName ) {
 		const { settings, onUpdateSetting } = this.props;
@@ -120,7 +105,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 				</SelectDropdown>
 			</EditorMediaModalFieldset>
 		);
-	},
+	}
 
 	renderColumnsOption() {
 		if ( ! includes( GalleryColumnedTypes, this.props.settings.type ) ) {
@@ -128,7 +113,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 		}
 
 		return this.renderDropdown( this.props.translate( 'Columns' ), this.getColumnOptions(), 'columns' );
-	},
+	}
 
 	renderRandomOption() {
 		const { settings } = this.props;
@@ -142,7 +127,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 				<FormCheckbox onChange={ this.updateRandomOrder } checked={ settings.orderBy === 'rand' } />
 			</EditorMediaModalFieldset>
 		);
-	},
+	}
 
 	render() {
 		const types = this.getTypeOptions();
@@ -159,6 +144,19 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+EditorMediaModalGalleryFields.propTypes = {
+	site: PropTypes.object,
+	settings: PropTypes.object,
+	onUpdateSetting: PropTypes.func,
+	numberOfItems: PropTypes.number
+};
+
+EditorMediaModalGalleryFields.defaultProps = {
+	settings: Object.freeze( {} ),
+	onUpdateSetting: noop,
+	numberOfItems: 0
+};
 
 export default localize( EditorMediaModalGalleryFields );


### PR DESCRIPTION
This is a janitorial PR that cleans up a few things in this component:
1. now uses localize from i18n-calypso and this.props.translate
2. fixes a couple of eslint errors

There are no functional updates in this PR.

**Testing Instructions**

Add a new image gallery and ensure all the fields display/function as per existing behaviour:

<img width="684" alt="screen shot 2016-10-31 at 9 18 41 am" src="https://cloud.githubusercontent.com/assets/128826/19840835/21f649bc-9f4b-11e6-9557-d11309ce2a3c.png">
