### PR TITLE
Reader Cold Start: bump react-masonry-component version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -531,7 +531,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000569"
+      "version": "1.0.30000570"
     },
     "caseless": {
       "version": "0.11.0"
@@ -588,7 +588,7 @@
       "version": "1.6.1"
     },
     "chrono-node": {
-      "version": "1.2.4"
+      "version": "1.2.5"
     },
     "circular-json": {
       "version": "0.3.1",
@@ -796,7 +796,7 @@
       "dev": true
     },
     "cross-spawn-async": {
-      "version": "2.2.4"
+      "version": "2.2.5"
     },
     "crypt": {
       "version": "0.0.1",
@@ -1318,7 +1318,7 @@
       }
     },
     "esprima": {
-      "version": "3.0.0"
+      "version": "3.1.0"
     },
     "esrecurse": {
       "version": "4.1.0",
@@ -2188,7 +2188,7 @@
       "version": "0.0.3"
     },
     "jsx-ast-utils": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dev": true
     },
     "key-mirror": {
@@ -2300,6 +2300,9 @@
       "version": "3.1.1",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8"
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "dev": true
@@ -2311,6 +2314,9 @@
     "lodash.keys": {
       "version": "3.1.2",
       "dev": true
+    },
+    "lodash.omit": {
+      "version": "4.5.0"
     },
     "lodash.pad": {
       "version": "4.5.1"
@@ -2337,12 +2343,7 @@
       "version": "1.0.1"
     },
     "loose-envify": {
-      "version": "1.2.0",
-      "dependencies": {
-        "js-tokens": {
-          "version": "1.0.3"
-        }
-      }
+      "version": "1.3.0"
     },
     "loud-rejection": {
       "version": "1.6.0"
@@ -2878,7 +2879,7 @@
       "version": "3.3.0"
     },
     "prebuild": {
-      "version": "4.3.1",
+      "version": "4.4.0",
       "dependencies": {
         "async": {
           "version": "1.5.2"
@@ -3036,7 +3037,7 @@
       "version": "0.1.2"
     },
     "react-masonry-component": {
-      "version": "4.0.4"
+      "version": "4.2.2"
     },
     "react-pure-render": {
       "version": "1.0.2"
@@ -3121,7 +3122,7 @@
       "dev": true
     },
     "recast": {
-      "version": "0.11.14",
+      "version": "0.11.15",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -3840,7 +3841,7 @@
       "version": "1.0.0"
     },
     "tryit": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true
     },
     "tty-browserify": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "react-click-outside": "2.1.0",
     "react-day-picker": "2.4.1",
     "react-dom": "15.3.0",
-    "react-masonry-component": "4.0.4",
+    "react-masonry-component": "4.2.2",
     "react-pure-render": "1.0.2",
     "react-redux": "4.4.5",
     "react-tap-event-plugin": "1.0.0",


### PR DESCRIPTION
We're currently using v4.0.4 of `react-masonry-component` to layout recommendation cards in Reader Cold Start:

http://calypso.localhost:3000/recommendations/start

This version creates unknown prop warnings:

<img width="1233" alt="screen shot 2016-10-31 at 13 28 25" src="https://cloud.githubusercontent.com/assets/17325/19841688/2790e926-9f74-11e6-98a8-8a97110a623e.png">

This PR bumps the version to v4.2.2. The unknown prop warnings were fixed in 4.2.0:

https://github.com/eiriklv/react-masonry-component/blob/master/CHANGELOG.md
### To test

Load http://calypso.localhost:3000/recommendations/start and check that there are no visual regressions with card display at various widths. Also ensure that there are no unknown prop warnings in the console.

<img width="746" alt="screen shot 2016-10-31 at 14 12 28" src="https://cloud.githubusercontent.com/assets/17325/19841685/19682eea-9f74-11e6-8a73-a53a20c9315e.png">
