### PR TITLE
Jetpack Connect: Convert forward slash to double colon consistently

### DIFF
--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -83,6 +83,14 @@ function setUrlScheme( url, scheme ) {
 	return url.replace( schemeRegex, schemeWithSlashes );
 }
 
+function urlToSlug( url ) {
+	if ( ! url ) {
+		return null;
+	}
+
+	return withoutHttp( url ).replace( /\//g, '::' );
+}
+
 export default {
 	isOutsideCalypso,
 	isExternal,
@@ -90,4 +98,5 @@ export default {
 	withoutHttp,
 	addSchemeIfMissing,
 	setUrlScheme,
+	urlToSlug,
 };

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -12,6 +12,7 @@ import {
 	withoutHttp,
 	addSchemeIfMissing,
 	setUrlScheme,
+	urlToSlug,
 } from '../';
 
 describe( 'withoutHttp', () => {
@@ -188,5 +189,51 @@ describe( 'setUrlScheme()', () => {
 		const actual = setUrlScheme( source, 'http' );
 
 		expect( actual ).to.equal( expected );
+	} );
+} );
+
+describe( 'urlToSlug()', () => {
+	it( 'should return null if URL is not provided', () => {
+		expect( urlToSlug() ).to.be.null;
+	} );
+
+	it( 'should return empty string if URL is empty string', () => {
+		const urlEmptyString = '';
+
+		expect( urlToSlug( urlEmptyString ) ).to.be.null;
+	} );
+
+	it( 'should return URL without initial http', () => {
+		const urlWithHttp = 'http://example.com';
+		const urlWithoutHttp = urlToSlug( urlWithHttp );
+
+		expect( urlWithoutHttp ).to.equal( 'example.com' );
+	} );
+
+	it( 'should return URL without initial https', () => {
+		const urlWithHttps = 'https://example.com';
+		const urlWithoutHttps = urlToSlug( urlWithHttps );
+
+		expect( urlWithoutHttps ).to.equal( 'example.com' );
+	} );
+
+	it( 'should return URL without initial http and query string if has any', () => {
+		const urlWithHttpAndQueryString = 'http://example.com?foo=bar#anchor';
+		const urlWithoutHttpAndQueryString = urlToSlug( urlWithHttpAndQueryString );
+
+		expect( urlWithoutHttpAndQueryString ).to.equal( 'example.com?foo=bar#anchor' );
+	} );
+
+	it( "should return provided URL if it doesn't include http(s)", () => {
+		const urlWithoutHttp = 'example.com';
+
+		expect( urlToSlug( urlWithoutHttp ) ).to.equal( urlWithoutHttp );
+	} );
+
+	it( 'should return a slug with forward slashes converted to double colons', () => {
+		const urlWithHttp = 'http://example.com/example/test123';
+		const urlWithoutHttp = urlToSlug( urlWithHttp );
+
+		expect( urlWithoutHttp ).to.equal( 'example.com::example::test123' );
 	} );
 } );

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -54,7 +54,7 @@ import { requestSites } from 'state/sites/actions';
 import { isRequestingSites } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
-import { withoutHttp } from 'lib/url';
+import { urlToSlug } from 'lib/url';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -477,7 +477,7 @@ const LoggedInForm = React.createClass( {
 	getRedirectionTarget() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 		const site = queryObject.site;
-		const siteSlug = withoutHttp( site ).replace( /\//g, '::' );
+		const siteSlug = urlToSlug( site );
 		return PLANS_PAGE + siteSlug;
 	},
 
@@ -580,7 +580,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 	mixins: [ observe( 'userModule' ) ],
 
 	isSSO() {
-		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
+		const site = urlToSlug( this.props.jetpackConnectAuthorize.queryObject.site );
 		return !! ( this.props.jetpackSSOSessions && this.props.jetpackSSOSessions[ site ] );
 	},
 

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -7,7 +7,7 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import Notice from 'components/notice';
-import { withoutHttp } from 'lib/url';
+import { urlToSlug } from 'lib/url';
 
 export default React.createClass( {
 	displayName: 'JetpackConnectNotices',
@@ -120,7 +120,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const urlSlug = this.props.url ? withoutHttp( this.props.url ).replace( /\//g, '::' ) : '';
+		const urlSlug = this.props.url ? urlToSlug( this.props.url ) : '';
 		const values = this.getNoticeValues( urlSlug );
 		if ( values ) {
 			return (

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -51,7 +51,7 @@ function buildDefaultAuthorizeState() {
 }
 
 function buildNoProtocolUrlObj( url, flowType ) {
-	const noProtocolUrl = url.replace( /.*?:\/\//g, '' );
+	const noProtocolUrl = url.replace( /.*?:\/\//g, '' ).replace( /\//g, '::' );
 	const sessionValue = {
 		timestamp: Date.now(),
 		flowType: flowType || ''

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -39,6 +39,7 @@ import { isValidStateWithSchema } from 'state/utils';
 import { jetpackConnectSessionsSchema } from './schema';
 import { isStale } from './utils';
 import { JETPACK_CONNECT_AUTHORIZE_TTL } from './constants';
+import { urlToSlug } from 'lib/url';
 
 function buildDefaultAuthorizeState() {
 	return {
@@ -50,19 +51,19 @@ function buildDefaultAuthorizeState() {
 	};
 }
 
-function buildNoProtocolUrlObj( url, flowType ) {
-	const noProtocolUrl = url.replace( /.*?:\/\//g, '' ).replace( /\//g, '::' );
+function buildUrlSessionObj( url, flowType ) {
+	const slug = urlToSlug( url );
 	const sessionValue = {
 		timestamp: Date.now(),
 		flowType: flowType || ''
 	};
-	return { [ noProtocolUrl ]: sessionValue };
+	return { [ slug ]: sessionValue };
 }
 
 export function jetpackConnectSessions( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_CHECK_URL:
-			return Object.assign( {}, state, buildNoProtocolUrlObj( action.url, action.flowType ) );
+			return Object.assign( {}, state, buildUrlSessionObj( action.url, action.flowType ) );
 		case DESERIALIZE:
 			if ( isValidStateWithSchema( state, jetpackConnectSessionsSchema ) ) {
 				return pickBy( state, ( session ) => {
@@ -287,7 +288,7 @@ export function jetpackSSO( state = {}, action ) {
 export function jetpackSSOSessions( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS:
-			return Object.assign( {}, state, buildNoProtocolUrlObj( action.siteUrl ) );
+			return Object.assign( {}, state, buildUrlSessionObj( action.siteUrl ) );
 		case SERIALIZE:
 			return state;
 		case DESERIALIZE:

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -8,6 +8,7 @@ import { get } from 'lodash';
  */
 import { getSiteByUrl } from 'state/sites/selectors';
 import { isStale } from './utils';
+import { urlToSlug } from 'lib/url';
 
 const getConnectingSite = ( state ) => {
 	return get( state, [ 'jetpackConnect', 'jetpackConnectSite' ] );
@@ -51,7 +52,7 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 	if ( ! siteSlug ) {
 		return false;
 	}
-	const site = siteSlug.replace( /.*?:\/\//g, '' ).replace( /\//g, '::' );
+	const site = urlToSlug( siteSlug );
 	const sessions = getSessions( state );
 
 	if ( sessions[ site ] && sessions[ site ].timestamp ) {
@@ -63,7 +64,7 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 
 const getFlowType = function( state, siteSlug ) {
 	const sessions = getSessions( state );
-	siteSlug = siteSlug.replace( /\//g, '::' );
+	siteSlug = urlToSlug( siteSlug );
 
 	if ( siteSlug && sessions[ siteSlug ] ) {
 		return sessions[ siteSlug ].flowType;

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -51,7 +51,7 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 	if ( ! siteSlug ) {
 		return false;
 	}
-	const site = siteSlug.replace( /.*?:\/\//g, '' );
+	const site = siteSlug.replace( /.*?:\/\//g, '' ).replace( /\//g, '::' );
 	const sessions = getSessions( state );
 
 	if ( sessions[ site ] && sessions[ site ].timestamp ) {
@@ -63,6 +63,8 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 
 const getFlowType = function( state, siteSlug ) {
 	const sessions = getSessions( state );
+	siteSlug = siteSlug.replace( /\//g, '::' );
+
 	if ( siteSlug && sessions[ siteSlug ] ) {
 		return sessions[ siteSlug ].flowType;
 	}

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -104,6 +104,15 @@ describe( 'reducer', () => {
 			expect( state ).to.have.property( 'example.wordpress.com' ).to.be.a( 'object' );
 		} );
 
+		it( 'should convert forward slashes to double colon when checking a new url', () => {
+			const state = jetpackConnectSessions( undefined, {
+				type: JETPACK_CONNECT_CHECK_URL,
+				url: 'https://example.wordpress.com/example123'
+			} );
+
+			expect( state ).to.have.property( 'example.wordpress.com::example123' ).to.be.a( 'object' );
+		} );
+
 		it( 'should store a timestamp when checking a new url', () => {
 			const nowTime = Date.now();
 			const state = jetpackConnectSessions( undefined, {
@@ -347,6 +356,17 @@ describe( 'reducer', () => {
 				.to.be.a( 'object' );
 			expect( state[ 'example.wordpress.com' ] ).to.have.property( 'timestamp' )
 				.to.be.at.least( nowTime );
+		} );
+
+		it( 'should convert forward slashes to double colon when creating a new session', () => {
+			const state = jetpackSSOSessions( undefined, {
+				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
+				ssoUrl: 'https://example.wordpress.com/example123?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
+				siteUrl: 'https://example.wordpress.com/example123'
+			} );
+
+			expect( state ).to.have.property( 'example.wordpress.com::example123' )
+				.to.be.a( 'object' );
 		} );
 
 		it( 'should persist state', () => {

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -311,6 +311,21 @@ describe( 'selectors', () => {
 			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.true;
 		} );
 
+		it( 'should return true if the user has just started a session in calypso and site contains a forward slash', () => {
+			const state = {
+				jetpackConnect: {
+					jetpackConnectSessions: {
+						'example.com::example123': {
+							timestamp: Date.now(),
+							flow: ''
+						}
+					}
+				}
+			};
+
+			expect( isCalypsoStartedConnection( state, 'example.com/example123' ) ).to.be.true;
+		} );
+
 		it( 'should return false if the user haven\'t started a session in calypso  ', () => {
 			const state = {
 				jetpackConnect: {
@@ -355,14 +370,29 @@ describe( 'selectors', () => {
 			expect( getFlowType( state, 'sitetest' ) ).to.eql( 'pro' );
 		} );
 
-		it( 'should return the false if there\'s no session for a site', () => {
+		it( 'should return the flow of the session for a site with slash in the site slug', () => {
+			const state = {
+				jetpackConnect: {
+					jetpackConnectSessions: {
+						'example.com::example123': {
+							timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
+							flowType: 'pro'
+						}
+					}
+				}
+			};
+
+			expect( getFlowType( state, 'example.com/example123' ) ).to.eql( 'pro' );
+		} );
+
+		it( 'should return false if there\'s no session for a site', () => {
 			const state = {
 				jetpackConnect: {
 					jetpackConnectSessions: {}
 				}
 			};
 
-			expect( getFlowType( state, { slug: 'sitetest' } ) ).to.be.false;
+			expect( getFlowType( state, 'sitetest' ) ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
While testing #8483 I've noticed that in JPC there are inconsistencies with sites that contain a forward slash `/` in the site slug - for example `example.com/site123`. In some cases, these were stored/retrieved by `example.com/site123`, and in some cases by `example.com::site123`. 

This PR makes sure that all of the forward slashes `/` in site slugs are being converted properly to double colons `::` when storing or retrieving data by/for a particular site slug. It introduces a new utility method `urlToSlug()` and adds tests for it, also alters the JPC components and state to use it consistently.

To test: 
* Checkout this branch
* Verify the JPC process works fine with a site that contains a forward slash in the site slug, and:
 * Has no plan
 * Has a yearly plan (make sure to disconnect the site first)
 * Has a monthly plan (make sure to disconnect the site first)
* Verify all JPC state tests pass: `npm run test-client client/state/jetpack-connect`
* Verify that the new utility function `urlToSlug()` tests pass: `npm run test-client client/lib/url/ -- --grep "urlToSlug"`

/cc @johnHackworth for review and testing.