### PR TITLE
Billing History: Fix payment method on PayPal Express receipts

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -104,7 +104,9 @@ module.exports = React.createClass( {
 		var transaction = this.props.transaction,
 			text;
 
-		if ( 'NOT STORED' === transaction.cc_type.toUpperCase() ) {
+		if ( transaction.pay_part === 'paypal_express' ) {
+			text = this.translate( 'PayPal' );
+		} else if ( 'NOT STORED' === transaction.cc_type.toUpperCase() ) {
 			text = this.translate( 'Credit Card' );
 		} else {
 			text = transaction.cc_type.toUpperCase() + this.translate( ' ending in ' ) + transaction.cc_num;


### PR DESCRIPTION
Previously, it always showed "Credit Card", even though receipts were Paypal Express. Now it shows "PayPal".

![image](https://cloud.githubusercontent.com/assets/203105/19859974/77922102-9f87-11e6-800c-14f605ed8506.png)

This only works for receipts that has `paypal_express` as payment parter, which are currently all receipts newer than 2015-06-26, and there is job running to update all of them.

To test, open PayPal Express receipt in Billing History (Profile -> Manage Purchases -> Billing History -> View receipt).

p2MSmN-5vu