### PR TITLE
Checkout: Fix error when submitting cart with chargeback 

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -4,7 +4,8 @@
 var debug = require( 'debug' )( 'calypso:store-transactions' ),
 	isEmpty = require( 'lodash/isEmpty' ),
 	Readable = require( 'stream' ).Readable,
-	inherits = require( 'inherits' );
+	inherits = require( 'inherits' ),
+	omit = require( 'lodash/omit' );
 
 /**
  * Internal dependencies
@@ -154,7 +155,7 @@ TransactionFlow.prototype._createPaygateToken = function( callback ) {
 TransactionFlow.prototype._submitWithPayment = function( payment ) {
 	var onComplete = this.push.bind( this, null ), // End the stream when the transaction has finished
 		transaction = {
-			cart: this._initialData.cart,
+			cart: omit( this._initialData.cart, [ 'messages'] ), // messages contain reference to DOMNode
 			domain_details: this._initialData.domainDetails,
 			payment: payment
 		};


### PR DESCRIPTION
This fixes `Uncaught DOMException: Failed to execute 'postMessage' on 'Window': A value could not be cloned.` when trying to pay for the chargeback fee.

To test, add `red-paypal` flag to your test site, open checkout, and try paying it. @JonahBraun noticed that it happens in Chrome but not Safari.

This feels like a dirty fix. Proper solution would be to have whitelist of cart properties that we want to send to server.

pNPgK-2fo