### PR TITLE
Signup: Replace the Ecto theme with Intergalactic.

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -54,12 +54,12 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Ecto',
-		slug: 'ecto',
+		name: 'Intergalactic',
+		slug: 'intergalactic',
 		repo: 'pub',
 		fallback: true,
 		design: 'blog',
-		demo_uri: 'https://ectodemo.wordpress.com',
+		demo_uri: 'https://intergalacticdemo.wordpress.com',
 		verticals: []
 	},
 	{

--- a/client/my-sites/theme/themes-related-card/index.jsx
+++ b/client/my-sites/theme/themes-related-card/index.jsx
@@ -25,7 +25,7 @@ const ThemesRelatedCard = React.createClass( {
 			'rowling',
 			'hemingway-rewritten',
 			'gazette',
-			'ecto',
+			'intergalactic',
 			'isola',
 			'edin',
 			'sela',


### PR DESCRIPTION
This PR replaces Ecto with Intergalactic in both the blog signup, and in the related ("You might also like") themes section of theme sheets (eg. https://wordpress.com/theme/intergalactic).