### PR TITLE
Framework: Upgrade ESLint no-console to error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,6 @@ module.exports = {
 		'keyword-spacing': 1,
 		'max-len': [ 1, { code: 140 } ],
 		'new-cap': [ 1, { capIsNew: false, newIsCap: true } ],
-		'no-console': 1,
 		'no-else-return': 1,
 		'no-extra-semi': 1,
 		'no-lonely-if': 1,

--- a/client/components/count/test/index.jsx
+++ b/client/components/count/test/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var expect = require( 'chai' ).expect,
-	sinon = require( 'sinon' ),
 	useMockery = require( 'test/helpers/use-mockery' );
 
 describe( 'Count', function() {
@@ -78,10 +77,4 @@ describe( 'Count', function() {
 
 		expect( result.props.children ).to.equal( '3' );
 	} );
-
-	it( 'should warn when passing something that is not a number', sinon.test( function() {
-		this.stub( console, 'error' );
-		renderer.render( <Count count={ "17" } /> );
-		expect( console.error ).to.have.been.called;
-	} ) );
 } );

--- a/client/devdocs/docs-example/util.js
+++ b/client/devdocs/docs-example/util.js
@@ -1,3 +1,14 @@
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+import debug from 'debug';
+
+/**
+ * Module variables
+ */
+const log = debug( 'calypso:docs-example:util' );
 
 const getComponentName = docsExample => {
 	if ( ! docsExample ) {
@@ -17,7 +28,7 @@ const getComponentName = docsExample => {
 
 const slugToCamelCase = name => {
 	if ( ! name ) {
-		console.warn( 'name is not defined' );
+		log( 'name is not defined' );
 		return console.trace();
 	}
 
@@ -28,7 +39,7 @@ const slugToCamelCase = name => {
 
 const camelCaseToSlug = name => {
 	if ( ! name ) {
-		console.warn( 'name is not defined' );
+		log( 'name is not defined' );
 		return console.trace();
 	}
 

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -3,6 +3,7 @@
  */
 var React = require( 'react' ),
 	isFunction = require( 'lodash/isFunction' );
+import debug from 'debug';
 
 /**
  * Internal dependencies
@@ -12,15 +13,25 @@ var DocService = require( './service' ),
 	Main = require( 'components/main' ),
 	SearchCard = require( 'components/search-card' );
 
+/**
+ * Constants
+ */
+
 var DEFAULT_FILES = [
-		'docs/guide/index.md',
-		'README.md',
-		'.github/CONTRIBUTING.md',
-		'docs/coding-guidelines.md',
-		'docs/coding-guidelines/javascript.md',
-		'docs/coding-guidelines/css.md',
-		'docs/coding-guidelines/html.md'
-	];
+	'docs/guide/index.md',
+	'README.md',
+	'.github/CONTRIBUTING.md',
+	'docs/coding-guidelines.md',
+	'docs/coding-guidelines/javascript.md',
+	'docs/coding-guidelines/css.md',
+	'docs/coding-guidelines/html.md'
+];
+
+/**
+ * Module variables
+ */
+
+const log = debug( 'calypso:devdocs' );
 
 module.exports = React.createClass( {
 	displayName: 'Devdocs',
@@ -93,7 +104,7 @@ module.exports = React.createClass( {
 		}
 		DocService.search( term, function( err, results ) {
 			if ( err ) {
-				console.log( err );
+				log( 'search error: %o', err );
 			}
 
 			this.setState( {

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -6,12 +6,18 @@ var ReactDom = require( 'react-dom' ),
 	assign = require( 'lodash/assign' ),
 	url = require( 'url' ),
 	qs = require( 'querystring' );
+import debug from 'debug';
 
 /**
  * Internal dependencies
  */
 var analytics = require( 'lib/analytics' ),
 	EmptyContent = require( 'components/empty-content' );
+
+/**
+ * Module variables
+ */
+const log = debug( 'calypso:layout' );
 
 var LoadingError = React.createClass( {
 
@@ -34,7 +40,7 @@ var LoadingError = React.createClass( {
 		},
 
 		show: function( chunkName ) {
-			console.error( 'Chunk %s could not be loaded', chunkName );
+			log( 'Chunk %s could not be loaded', chunkName );
 			analytics.mc.bumpStat( 'calypso_chunk_error', chunkName );
 			ReactDom.render(
 				React.createElement( LoadingError, {} ),

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -1,7 +1,27 @@
+/**
+ * External dependencies
+ */
 import TraceKit from 'tracekit';
+import debug from 'debug';
 
-// Interval for error reports so we don't flood te endpoint. More frequent reports get throttled.
+/**
+ * Module variables
+ */
+
+/**
+ * Interval for error reports so we don't flood te endpoint. More frequent
+ * reports get throttled.
+ *
+ * @type {Number}
+ */
 const REPORT_INTERVAL = 60000;
+
+/**
+ * Debug logger
+ *
+ * @type {Function}
+ */
+const log = debug( 'calypso:error-logger' );
 
 export default class ErrorLogger {
 	constructor() {
@@ -79,7 +99,7 @@ export default class ErrorLogger {
 				this.saveDiagnosticData( diagnosticReducer() );
 			} catch ( e ) {
 				this.saveDiagnosticData( { diagnosticError: e.message } );
-				console.warn( 'diagnostic', this.diagnosticData );
+				log( 'diagnostic: %o', this.diagnosticData );
 			}
 		} );
 

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 /**
  * External dependencies
  */
@@ -9,26 +11,24 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import createSelector from '../';
+import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'index', () => {
 	let selector, getSitePosts;
 
-	before( () => {
-		selector = sinon.spy( ( state, siteId ) => {
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
+		selector = sandbox.spy( ( state, siteId ) => {
 			return filter( state.posts, { site_ID: siteId } );
 		} );
+	} );
+
+	before( () => {
 		getSitePosts = createSelector( selector, ( state ) => state.posts );
-		sinon.stub( console, 'warn' );
 	} );
 
 	beforeEach( () => {
-		console.warn.reset();
-		selector.reset();
 		getSitePosts.memoizedSelector.cache.clear();
-	} );
-
-	after( () => {
-		console.warn.restore();
 	} );
 
 	it( 'should expose its memoized function', () => {

--- a/client/lib/css-hot-reload/index.js
+++ b/client/lib/css-hot-reload/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 /**
  * External dependencies
  */

--- a/client/lib/localforage/index.js
+++ b/client/lib/localforage/index.js
@@ -3,11 +3,17 @@
  */
 import localforage from 'localforage';
 import reduce from 'lodash/reduce';
+import debug from 'debug';
 
 /**
  * Internal dependencies
  */
 import localforageBypass from './localforage-bypass';
+
+/**
+ * Module variables
+ */
+const log = debug( 'calypso:localforage' );
 
 const config = {
 	name: 'calypso',
@@ -29,7 +35,7 @@ const localForagePromise = localforage.defineDriver( localforageBypass )
 		_ready = true;
 		return localforage;
 	} )
-	.catch( ( error ) => console.error( 'Configuring localforage: %s', error ) );
+	.catch( ( error ) => log( 'Configuring localforage: %s', error ) );
 
 // Wraps a function to run after waiting until a promise has resolved.
 // The promise should contain the original object for context.
@@ -58,7 +64,7 @@ const localForageProxy = reduce(
 
 localForageProxy.bypass = () => {
 	if ( _ready ) {
-		console.error( 'Cannot bypass localforage after initialization' );
+		log( 'Cannot bypass localforage after initialization' );
 	} else {
 		config.driver = [ localforageBypass._driver ];
 	}

--- a/client/lib/plugins/test/mocks/wpcom.js
+++ b/client/lib/plugins/test/mocks/wpcom.js
@@ -60,20 +60,17 @@ var pluginsInstallCalls = 0,
 	},
 
 	siteMock = {
-		plugin: function( pluginId ) {
-			console.log( 'Create %s plugin', pluginId );
+		plugin: function() {
 			return pluginMock;
 		},
 
-		wpcomPlugin: function( pluginId ) {
-			console.log( 'Create %s wpcom plugin', pluginId );
+		wpcomPlugin: function() {
 			return wpcomPluginMock;
 		}
 	},
 
 	mock = {
-		site: function( siteId ) {
-			console.log( 'Create %s site', siteId );
+		site: function() {
 			return siteMock;
 		},
 

--- a/client/lib/service-worker/service-worker.js
+++ b/client/lib/service-worker/service-worker.js
@@ -1,6 +1,9 @@
+/* eslint-disable no-console */
+
 /**
- *  This file is served as-is as /service-worker.js
- **/
+ * WARNING: DO NOT USE ES2015+ OR COMMONJS. This file is served as-is and isn't
+ * transpiled by Babel or bundled by Webpack.
+ */
 
 /* eslint-disable */
 'use strict';

--- a/client/lib/warn/index.js
+++ b/client/lib/warn/index.js
@@ -1,4 +1,5 @@
 /** @ssr-ready **/
+/* eslint-disable no-console */
 
 /**
  * Internal Dependencies

--- a/client/lib/wrap-es6-functions/index.js
+++ b/client/lib/wrap-es6-functions/index.js
@@ -1,3 +1,8 @@
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
 import partial from 'lodash/partial';
 import isFunction from 'lodash/isFunction';
 

--- a/client/state/comments/test/utils.js
+++ b/client/state/comments/test/utils.js
@@ -80,11 +80,6 @@ describe( 'utils', () => {
 
 				const isListsEqual = actualDatesList.equals( sortedDatesList );
 
-				if ( ! isListsEqual ) {
-					// hint what are the nodes involved
-					console.error( 'Bad child nodes', childNodesList );
-				}
-
 				expect( isListsEqual ).to.be.true;
 
 				if ( isListsEqual ) {

--- a/client/state/geo/test/reducer.js
+++ b/client/state/geo/test/reducer.js
@@ -117,7 +117,6 @@ describe( 'reducer', () => {
 			const state = geo( original, { type: DESERIALIZE } );
 
 			expect( state ).to.be.null;
-			expect( console.warn ).to.have.been.called; // eslint-disable-line no-console
 		} );
 	} );
 } );

--- a/client/state/page-templates/test/reducer.js
+++ b/client/state/page-templates/test/reducer.js
@@ -224,7 +224,6 @@ describe( 'reducer', () => {
 			const state = items( original, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {} );
-			expect( console.warn ).to.have.been.calledTwice; // eslint-disable-line no-console
 		} );
 	} );
 } );

--- a/client/state/post-types/test/reducer.js
+++ b/client/state/post-types/test/reducer.js
@@ -215,7 +215,6 @@ describe( 'reducer', () => {
 			} ), { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {} );
-			expect( console.warn ).to.have.been.calledOnce;
 		} );
 	} );
 } );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -3,11 +3,11 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
+import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	POST_DELETE,
 	POST_DELETE_SUCCESS,
@@ -37,12 +37,8 @@ import reducer, {
 import PostQueryManager from 'lib/query-manager/post';
 
 describe( 'reducer', () => {
-	before( () => {
-		sinon.stub( console, 'warn' );
-	} );
-
-	after( () => {
-		console.warn.restore();
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
 	} );
 
 	it( 'should include expected keys in return value', () => {

--- a/client/state/products-list/test/reducer.js
+++ b/client/state/products-list/test/reducer.js
@@ -3,11 +3,11 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
+import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	DESERIALIZE,
 	PRODUCTS_LIST_RECEIVE,
@@ -21,12 +21,8 @@ import reducer, {
 } from '../reducer';
 
 describe( 'reducer', () => {
-	before( () => {
-		sinon.stub( console, 'warn' );
-	} );
-
-	after( () => {
-		console.warn.restore();
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
 	} );
 
 	it( 'should include expected keys in return value', () => {

--- a/client/state/sites/guided-transfer/test/reducer.js
+++ b/client/state/sites/guided-transfer/test/reducer.js
@@ -3,11 +3,11 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
+import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	DESERIALIZE,
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE,
@@ -28,12 +28,8 @@ import reducer, {
 describe( 'reducer', () => {
 	const testSiteId = 100658273;
 
-	before( () => {
-		sinon.stub( console, 'warn' );
-	} );
-
-	after( () => {
-		console.warn.restore();
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
 	} );
 
 	it( 'should include expected keys in return value', () => {

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
 import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
+import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	SITE_FRONT_PAGE_SET_SUCCESS,
 	SITE_RECEIVE,
@@ -26,11 +26,8 @@ import {
 import reducer, { items, requestingAll, requesting } from '../reducer';
 
 describe( 'reducer', () => {
-	before( function() {
-		sinon.stub( console, 'warn' );
-	} );
-	after( function() {
-		console.warn.restore();
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
 	} );
 
 	it( 'should export expected reducer keys', () => {

--- a/client/state/stats/posts/test/reducer.js
+++ b/client/state/stats/posts/test/reducer.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
 import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
+import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	POST_STATS_RECEIVE,
 	POST_STATS_REQUEST,
@@ -19,12 +19,8 @@ import {
 import { requesting, items } from '../reducer';
 
 describe( 'reducer', () => {
-	before( () => {
-		sinon.stub( console, 'warn' );
-	} );
-
-	after( () => {
-		console.warn.restore();
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
 	} );
 
 	describe( '#requesting()', () => {
@@ -334,7 +330,6 @@ describe( 'reducer', () => {
 			const state = items( previousInvalidState, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {} );
-			expect( console.warn ).to.have.been.calledOnce;
 		} );
 	} );
 } );

--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -1,12 +1,14 @@
+/* eslint-disable no-console */
+
 /**
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
+import { useSandbox } from 'test/helpers/use-sinon';
 import { createReduxStore } from '../';
 import currentUser from 'state/current-user/reducer';
 
@@ -32,12 +34,8 @@ describe( 'index', () => {
 		} );
 
 		describe( 'invalid data', () => {
-			before( () => {
-				sinon.stub( console, 'error' );
-			} );
-
-			after( () => {
-				console.error.restore();
+			useSandbox( ( sandbox ) => {
+				sandbox.stub( console, 'error' );
 			} );
 
 			it( 'ignores non-existent keys', () => {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 /**
  * External dependencies.
  */

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"no-console": 0
+	}
+}

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"no-console": 0
+	}
+}


### PR DESCRIPTION
Related: #8562

This pull request continues the crusade to upgrade all ESLint rules to errors by resolving remaining issues with [`no-console` rule](http://eslint.org/docs/rules/no-console).

__Implementation notes:__

Revisions include:

- Updating `console` messaging to `debug` where appropriate
- Avoiding direct `console` calls where stubbing via `useSandbox` test helper suffices
- Removing test cases which don't need to test `console` calls themselves
- Allow `console` in `test` and `server` directories

__Testing Instructions:__

That CircleCI passes is indication that the changes included are working as intended.