### PR TITLE
Framework: Upgrade ESLint no-nested-ternary to error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,6 @@ module.exports = {
 		'no-extra-semi': 1,
 		'no-multiple-empty-lines': [ 1, { max: 1 } ],
 		'no-multi-spaces': 1,
-		'no-nested-ternary': 1,
 		'no-shadow': 1,
 		'no-spaced-func': 1,
 		'no-trailing-spaces': 1,

--- a/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
@@ -65,7 +65,13 @@ function wcpomAutoResize( editor ) {
 		// Make sure we have a valid height
 		if ( isNaN( myHeight ) || myHeight <= 0 ) {
 			// Get height differently depending on the browser used
-			myHeight = tinymce.Env.ie ? body.scrollHeight : ( tinymce.Env.webkit && body.clientHeight === 0 ? 0 : body.offsetHeight );
+			if ( tinymce.Env.ie ) {
+				myHeight = body.scrollHeight;
+			} else if ( tinymce.Env.webkit && body.clientHeight === 0 ) {
+				myHeight = 0;
+			} else {
+				myHeight = body.offsetHeight;
+			}
 		}
 
 		// Don't make it smaller than the minimum height


### PR DESCRIPTION
Related: #8562

This pull request continues the crusade to upgrade all ESLint rules to errors by resolving remaining issues with [`no-nested-ternary` rule](http://eslint.org/docs/rules/no-nested-ternary).

__Testing Instructions:__

That CircleCI passes is indication that the changes included are working as intended.