### PR TITLE
Reader Refresh: post-normalizer rule to detect all media

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -114,6 +114,7 @@ import safeContentImages from './rule-content-safe-images';
 import makeEmbedsSecure from './rule-content-make-embeds-secure';
 import wordCountAndReadingTime from './rule-content-word-count';
 import detectEmbeds from './rule-content-detect-embeds';
+import detectMedia from './rule-content-detect-media';
 import { disableAutoPlayOnMedia, disableAutoPlayOnEmbeds } from './rule-content-disable-autoplay';
 import detectPolls from './rule-content-detect-polls';
 
@@ -123,6 +124,7 @@ normalizePost.content = {
 	makeEmbedsSecure,
 	wordCountAndReadingTime,
 	detectEmbeds,
+	detectMedia,
 	disableAutoPlayOnMedia,
 	disableAutoPlayOnEmbeds,
 	detectPolls

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -1,0 +1,151 @@
+/**
+ * External Dependencies
+ */
+import { map, compact, includes, some } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { iframeIsWhitelisted } from './utils';
+
+/** Checks whether or not an image is a tracking pixel
+* @param {Node} image - DOM node for an img
+* @returns {boolean} isTrackingPixel - returns true if image is probably a tracking pixel
+*/
+function isTrackingPixel( image ) {
+	if ( ! image || ! image.src ) {
+		return false;
+	}
+
+	const edgeLength = image.height + image.width;
+	return edgeLength === 1 || edgeLength === 2;
+}
+
+function isCandidateForContentImage( image ) {
+	if ( ! image || ! image.getAttribute( 'src' ) ) {
+		return false;
+	}
+
+	const ineligibleCandidateUrlParts = [
+		'gravatar.com',
+		'/wpcom-smileys/',
+	];
+
+	const imageUrl = image.getAttribute( 'src' );
+
+	const imageShouldBeExcludedFromCandidacy = some( ineligibleCandidateUrlParts,
+		( urlPart ) => includes( imageUrl.toLowerCase(), urlPart )
+	);
+
+	return ! ( isTrackingPixel( image ) || imageShouldBeExcludedFromCandidacy );
+}
+
+/** detects and returns  metadata if it should be considered as a content image
+* @param {image} image - the image
+* @returns {object} metadata - regarding the image or null
+*/
+const detectImage = ( image ) => {
+	if ( isCandidateForContentImage( image ) ) {
+		return {
+			src: image.getAttribute( 'src' ),
+			width: image.width,
+			height: image.height,
+			mediaType: 'image',
+		};
+	}
+	return false;
+};
+
+// get the iframe src that autoplays the embed if we know how to, else null
+const getAutoplayIframe = ( iframe ) => {
+	if ( iframe.src.indexOf( 'youtube' ) > 0 ) {
+		const autoplayIframe = iframe.cloneNode();
+		if ( autoplayIframe.src.indexOf( '?' ) === -1 ) {
+			autoplayIframe.src += '?autoplay=1';
+		} else {
+			autoplayIframe.src += '&autoplay=1';
+		}
+		return autoplayIframe.outerHTML;
+	}
+	return null;
+};
+
+// get a picture thumnail version of the embed if it exists, else null
+const getThumbnailUrl = ( iframe ) => {
+	if ( iframe.src.indexOf( 'youtube' ) > 0 ) {
+		// grabbed from: http://stackoverflow.com/questions/3452546/javascript-regex-how-to-get-youtube-video-id-from-url
+		const regExp = /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
+		const match = iframe.src.match( regExp );
+		const videoId = match && ( match && match[ 2 ].length === 11 ) ? match[ 2 ] : false;
+
+		return videoId ? `https://img.youtube.com/vi/${ videoId }/mqdefault.jpg` : null;
+	}
+	return null;
+};
+
+const getEmbedType = ( iframe ) => {
+	let node = iframe;
+	let matches;
+
+	do {
+		if ( ! node.className ) {
+			continue;
+		}
+		matches = node.className.match( /\bembed-([-a-zA-Z0-9_]+)\b/ );
+		if ( matches ) {
+			return ( matches[ 1 ] );
+		}
+	} while ( ( node = node.parentNode ) );
+
+	return null;
+};
+
+const detectEmbed = ( iframe ) => {
+	if ( ! iframeIsWhitelisted( iframe ) ) {
+		return false;
+	}
+
+	const width = Number( iframe.width );
+	const height = Number( iframe.height );
+	const aspectRatio = width / height;
+
+	const embedUrl = iframe.getAttribute( 'data-wpcom-embed-url' );
+
+	return {
+		type: getEmbedType( iframe ),
+		src: iframe.src,
+		embedUrl,
+		iframe: iframe.outerHTML,
+		aspectRatio: aspectRatio,
+		width: width,
+		height: height,
+		mediaType: 'video',
+		autoplayIframe: getAutoplayIframe( iframe ),
+		thumbnailUrl: getThumbnailUrl( iframe ),
+	};
+};
+
+/** Adds an ordered list of all of the content_media to the post
+* @param {post} post - the post object to add content_media to
+* @param {dom} dom - the dom of the post to scan for media
+*/
+export default function detectMedia( post, dom ) {
+	const imageSelector = 'img[src]';
+	const embedSelector = 'iframe';
+	const media = dom.querySelectorAll( `${ imageSelector }, ${ embedSelector }` );
+
+	const contentMedia = map( media, ( element ) => {
+		const nodeName = element.nodeName.toLowerCase();
+
+		if ( nodeName === 'iframe' ) {
+			return detectEmbed( element );
+		} else if ( nodeName === 'img' ) {
+			return detectImage( element );
+		}
+		return false;
+	} );
+
+	post.content_media = compact( contentMedia );
+
+	return post;
+}

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -31,7 +31,7 @@ export function imageSizeFromAttachments( post, imageUrl ) {
 }
 
 export function maxWidthPhotonishURL( imageURL, width ) {
-	if ( ! imageURL ) {
+	if ( ! imageURL || ! width ) {
 		return imageURL;
 	}
 
@@ -119,3 +119,31 @@ export function thumbIsLikelyImage( thumb ) {
 		return endsWith( pathname, ext );
 	} );
 }
+
+/**
+ * Determines if an iframe is from a source we trust.  We allow these to be the featured media and also give
+ * them a free-er sandbox
+ */
+export function iframeIsWhitelisted( iframe ) {
+	const iframeWhitelist = [
+		'youtube.com',
+		'youtube-nocookie.com',
+		'videopress.com',
+		'vimeo.com',
+		'cloudup.com',
+		'soundcloud.com',
+		'8tracks.com',
+		'spotify.com',
+		'me.sh',
+		'bandcamp.com',
+		'kickstarter.com',
+		'facebook.com',
+		'embed.itunes.apple.com'
+	];
+
+	const iframeSrc = iframe.src && url.parse( iframe.src ).hostname.toLowerCase();
+	return some( iframeWhitelist, function( whitelistedSuffix ) {
+		return endsWith( '.' + iframeSrc, '.' + whitelistedSuffix );
+	} );
+}
+

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -19,6 +19,7 @@ import DISPLAY_TYPES from './display-types';
  */
 import createBetterExcerpt from 'lib/post-normalizer/rule-create-better-excerpt';
 import detectEmbeds from 'lib/post-normalizer/rule-content-detect-embeds';
+import detectMedia from 'lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'lib/post-normalizer/rule-content-detect-polls';
 import makeEmbedsSecure from 'lib/post-normalizer/rule-content-make-embeds-secure';
 import removeStyles from 'lib/post-normalizer/rule-content-remove-styles';
@@ -146,6 +147,7 @@ const fastPostNormalizationRules = flow( [
 		disableAutoPlayOnEmbeds,
 		disableAutoPlayOnMedia,
 		detectEmbeds,
+		detectMedia,
 		detectPolls,
 		wordCount
 	] ),

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -531,7 +531,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000570"
+      "version": "1.0.30000572"
     },
     "caseless": {
       "version": "0.11.0"
@@ -1318,7 +1318,7 @@
       }
     },
     "esprima": {
-      "version": "3.1.0"
+      "version": "3.1.1"
     },
     "esrecurse": {
       "version": "4.1.0",
@@ -1584,6 +1584,9 @@
     "get-stdin": {
       "version": "4.0.1"
     },
+    "get-video-id": {
+      "version": "1.1.0"
+    },
     "getpass": {
       "version": "0.1.6",
       "dependencies": {
@@ -1641,7 +1644,7 @@
           "version": "7.1.1"
         },
         "lodash": {
-          "version": "4.16.4"
+          "version": "4.16.5"
         },
         "minimatch": {
           "version": "3.0.3"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express": "4.13.3",
     "filesize": "3.2.1",
     "flux": "2.1.1",
+    "get-video-id": "1.1.0",
     "hard-source-webpack-plugin": "0.0.42",
     "he": "0.5.0",
     "html-loader": "0.4.0",


### PR DESCRIPTION
This PR is part of the effort eventually enable: https://github.com/Automattic/wp-calypso/issues/8555 (prefer-first-media). It breaks up the monolithic PR #8994.  

- It adds `detectMedia`.  A normalization rule that detects all usable media (images and videos) and attaches them to the post object in an ordered list called `content_media`.
- it leaves the current rules that generate `content_embeds` and `content_images` intact.  Those will be dealt with in a later PR.

To test:
- Open any stream in the reader. Then in react developer tools, search for refreshpostcard.  If you expand the props `post` you should be able to see a new field `content_media` that has both images and videos in content order