### PR TITLE
Sites-List: Remove reference from <DomainManagement.Dns />

### DIFF
--- a/client/components/data/domain-management/dns/index.jsx
+++ b/client/components/data/domain-management/dns/index.jsx
@@ -1,16 +1,17 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-var StoreConnection = require( 'components/data/store-connection' ),
-	DnsStore = require( 'lib/domains/dns/store' ),
-	DomainsStore = require( 'lib/domains/store' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	upgradesActions = require( 'lib/upgrades/actions' );
+import StoreConnection from 'components/data/store-connection';
+import DnsStore from 'lib/domains/dns/store';
+import DomainsStore from 'lib/domains/store';
+import upgradesActions from 'lib/upgrades/actions';
+import { getSelectedSite } from 'state/ui/selectors';
 
 const stores = [
 	DomainsStore,
@@ -32,16 +33,12 @@ function getStateFromStores( props ) {
 	};
 }
 
-module.exports = React.createClass( {
-	displayName: 'DnsData',
-
+export const DnsData = React.createClass( {
 	propTypes: {
 		component: React.PropTypes.func.isRequired,
 		selectedDomainName: React.PropTypes.string.isRequired,
 		sites: React.PropTypes.object.isRequired
 	},
-
-	mixins: [ observe( 'sites' ) ],
 
 	componentWillMount() {
 		this.loadDns();
@@ -62,7 +59,13 @@ module.exports = React.createClass( {
 				stores={ stores }
 				getStateFromStores={ getStateFromStores }
 				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.sites.getSelectedSite() } />
+				selectedSite={ this.props.selectedSite} />
 		);
 	}
 } );
+
+const mapStateToProps = state => ( {
+	selectedSite: getSelectedSite( state ),
+} );
+
+export default connect( mapStateToProps )( DnsData );

--- a/client/components/data/domain-management/dns/index.jsx
+++ b/client/components/data/domain-management/dns/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -33,24 +33,26 @@ function getStateFromStores( props ) {
 	};
 }
 
-export const DnsData = React.createClass( {
-	propTypes: {
+export class DnsData extends Component {
+	static propTypes = {
 		component: PropTypes.func.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.object,
-	},
+	};
 
-	componentWillMount() {
+	constructor( props ) {
+		super( props );
+
 		this.loadDns();
-	},
+	}
 
 	componentWillUpdate() {
 		this.loadDns();
-	},
+	}
 
-	loadDns() {
+	loadDns = () => {
 		upgradesActions.fetchDns( this.props.selectedDomainName );
-	},
+	};
 
 	render() {
 		return (
@@ -59,10 +61,11 @@ export const DnsData = React.createClass( {
 				stores={ stores }
 				getStateFromStores={ getStateFromStores }
 				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.selectedSite} />
+				selectedSite={ this.props.selectedSite }
+			/>
 		);
 	}
-} );
+}
 
 const mapStateToProps = state => ( {
 	selectedSite: getSelectedSite( state ),

--- a/client/components/data/domain-management/dns/index.jsx
+++ b/client/components/data/domain-management/dns/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -35,9 +35,9 @@ function getStateFromStores( props ) {
 
 export const DnsData = React.createClass( {
 	propTypes: {
-		component: React.PropTypes.func.isRequired,
-		selectedDomainName: React.PropTypes.string.isRequired,
-		sites: React.PropTypes.object.isRequired
+		component: PropTypes.func.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSite: PropTypes.object,
 	},
 
 	componentWillMount() {

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -207,7 +207,7 @@ module.exports = {
 			<DnsData
 				component={ DomainManagement.Dns }
 				selectedDomainName={ pageContext.params.domain }
-				sites={ sites } />,
+			/>,
 			document.getElementById( 'primary' ),
 			pageContext.store
 		);


### PR DESCRIPTION
Part of the ongoing project to remove `sites-list`
https://github.com/Automattic/wp-calypso/projects/3

Removes the dependency on the domain management DNS component.

> There should be no functional or visual changes to this PR

**Testing**
Navigate to **My Sites** > **Domains** for a site with a custom domain, then click on the **DNS** settings for that domain. Makes sure that things switch as expected when changing sites. Load on a clean cache. Make sure it all works as expected.

cc: @gwwar 