### PR TITLE
Reader Refresh: Fix video cards for safari

### DIFF
--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -4,12 +4,13 @@
 import React from 'react';
 import { noop } from 'lodash';
 
-const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
+const FeaturedImage = ( { style, imageUri, href, children, onClick } ) => {
 	if ( imageUri === undefined ) {
 		return null;
 	}
 
 	const featuredImageStyle = {
+		...style,
 		backgroundImage: 'url(' + imageUri + ')',
 		backgroundSize: 'cover',
 		backgroundRepeat: 'no-repeat',

--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -4,13 +4,12 @@
 import React from 'react';
 import { noop } from 'lodash';
 
-const FeaturedImage = ( { style, imageUri, href, children, onClick } ) => {
+const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 	if ( imageUri === undefined ) {
 		return null;
 	}
 
 	const featuredImageStyle = {
-		...style,
 		backgroundImage: 'url(' + imageUri + ')',
 		backgroundSize: 'cover',
 		backgroundRepeat: 'no-repeat',

--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -42,7 +42,9 @@ class FeaturedVideo extends React.Component {
 	updateVideoSize = () => {
 		if ( this.videoEmbedRef ) {
 			const iframe = ReactDom.findDOMNode( this.videoEmbedRef ).querySelector( 'iframe' );
-			Object.assign( iframe.style, this.getEmbedSize() );
+			const availableWidth = ReactDom.findDOMNode( this ).parentNode.offsetWidth;
+
+			Object.assign( iframe.style, this.getEmbedSize( availableWidth ) );
 		}
 	}
 
@@ -66,18 +68,18 @@ class FeaturedVideo extends React.Component {
 
 		if ( preferThumbnail && thumbnailUrl ) {
 			return (
-				<FeaturedImage imageUri={ thumbnailUrl } onClick={ this.handleThumbnailClick }>
-					<div className="reader-post-card__play-icon-container"
-						title={ translate( 'Click to Play' ) }>
-						<img className="reader-post-card__play-icon" src="/calypso/images/reader/play-icon.png" />
-					</div>
+				<FeaturedImage imageUri={ thumbnailUrl } onClick={ this.handleThumbnailClick } style={ { pointer: 'cursor' } }>
+					<img className="reader-post-card__play-icon"
+						src="/calypso/images/reader/play-icon.png"
+						title={ translate( 'Click to Play' ) }
+					/>
 				</FeaturedImage>
 			);
 		}
 
 		/* eslint-disable react/no-danger */
 		return (
-			<div ref={ this.setVideoEmbedRef }
+			<div ref={ this.setVideoEmbedRef } className="reader-post-card__video"
 				dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
 			/>
 		);

--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -68,10 +68,10 @@ class FeaturedVideo extends React.Component {
 
 		if ( preferThumbnail && thumbnailUrl ) {
 			return (
-				<FeaturedImage imageUri={ thumbnailUrl } onClick={ this.handleThumbnailClick } style={ { pointer: 'cursor' } }>
+				<FeaturedImage imageUri={ thumbnailUrl } onClick={ this.handleThumbnailClick } >
 					<img className="reader-post-card__play-icon"
 						src="/calypso/images/reader/play-icon.png"
-						title={ translate( 'Click to Play' ) }
+						title={ translate( 'Play Video' ) }
 					/>
 				</FeaturedImage>
 			);

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -28,6 +28,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			flex-grow: 1;
 			margin-right: 20px;
 			max-width: 190px;
+			cursor: pointer;
 
 			@include breakpoint( ">960px" ) {
 				max-width: 250px;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -21,6 +21,9 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	&.has-thumbnail {
 
 		.reader-post-card__featured-image {
+			display: flex;
+			align-items: center;
+			justify-content: center;
 			flex-basis: auto;
 			flex-grow: 1;
 			margin-right: 20px;
@@ -43,6 +46,15 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				width: 100%;
 				margin-bottom: 10px;
 			}
+
+			&:hover .reader-post-card__play-icon {
+				opacity: 1;
+			}
+		}
+
+		.reader-post-card__play-icon {
+			opacity: .8;
+			transition: opacity .25s;
 		}
 
 		&.is-photo {
@@ -368,30 +380,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 }
 
-.reader-post-card__play-icon-container {
-	position: relative;
-	margin: 0;
-	padding: 0;
-	height: 100%;
-	width: 100%;
-	cursor: pointer;
-
-	&:hover .reader-post-card__play-icon {
-		opacity: 1;
-	}
-}
-
-.reader-post-card__play-icon {
-	margin: auto;
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	opacity: .8;
-	transition: opacity .25s;
-}
-
 // Gallery cards
 .reader-post-card__gallery {
 	display: flex;
@@ -418,6 +406,14 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			display: none;
 		}
 	}
+}
+
+.reader-post-card__video {
+	padding-bottom: 20px;
+}
+
+.reader-post-card__video iframe {
+	display: flex;
 }
 
 .reader-post-card__gallery-image {

--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -24,7 +24,8 @@ var embedsConfig = {
 			}
 			return {
 				width: `${ width | 0 }px`,
-				height: `${ height | 0 }px`
+				height: `${ height | 0 }px`,
+				paddingRight: '1px', // this exists to solve a bug in safari that we found here: https://github.com/Automattic/wp-calypso/issues/8987
 			};
 		}
 	},


### PR DESCRIPTION
This fixes two issues:
- video cards' play-icon is misaligned in safari
- After being expanded, safari does not render the excerpt below the video

Issue: #8987