### PR TITLE
Sites-List: Remove references from `<DomainManagement.Nameservers />`

### DIFF
--- a/client/components/data/domain-management/nameservers/index.jsx
+++ b/client/components/data/domain-management/nameservers/index.jsx
@@ -7,29 +7,25 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import DomainsStore from 'lib/domains/store';
 import NameserversStore from 'lib/domains/nameservers/store';
+import QuerySiteDomains from 'components/data/query-site-domains';
 import StoreConnection from 'components/data/store-connection';
-import { fetchDomains, fetchNameservers } from 'lib/upgrades/actions';
+import { fetchNameservers } from 'lib/upgrades/actions';
+import { getDomainsBySite } from 'state/sites/domains/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const stores = [
-	DomainsStore,
 	NameserversStore
 ];
 
 function getStateFromStores( props ) {
-	let domains;
-
-	if ( props.selectedSite ) {
-		domains = DomainsStore.getBySite( props.selectedSite.ID );
-	}
-
 	return {
-		domains,
+		domains: props.domains,
 		nameservers: NameserversStore.getByDomainName( props.selectedDomainName ),
 		selectedDomainName: props.selectedDomainName,
-		selectedSite: props.selectedSite
+		// undefined is not permitted by the passed component
+		// so we have to explicitly choose a bool in that case
+		selectedSite: props.selectedSite || false,
 	};
 }
 
@@ -43,42 +39,55 @@ export class NameserversData extends Component {
 	constructor( props ) {
 		super( props );
 
-		if ( props.selectedSite ) {
-			this.loadDomains( props.selectedSite.ID );
-		}
-
 		this.loadNameservers();
 	}
 
-	componentWillUpdate( nextProps ) {
-		const { selectedSite: nextSite } = nextProps;
-		const { selectedSite: prevSite } = this.props;
-
-		if ( nextSite && nextSite !== prevSite ) {
-			this.loadDomains( nextSite.ID );
-		}
-
+	componentWillUpdate() {
 		this.loadNameservers();
 	}
 
-	loadDomains = siteId => fetchDomains( siteId );
 	loadNameservers = () => fetchNameservers( this.props.selectedDomainName );
 
 	render() {
+		const { selectedSite } = this.props;
+
 		return (
-			<StoreConnection
-				component={ this.props.component }
-				stores={ stores }
-				getStateFromStores={ getStateFromStores }
-				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.selectedSite }
-			/>
+			<div>
+				<QuerySiteDomains siteId={ selectedSite && selectedSite.ID } />
+				<StoreConnection
+					component={ this.props.component }
+					domains={ this.props.domains }
+					stores={ stores }
+					getStateFromStores={ getStateFromStores }
+					selectedDomainName={ this.props.selectedDomainName }
+					selectedSite={ selectedSite }
+				/>
+			</div>
 		);
 	}
 }
 
-const mapStateToProps = state => ( {
-	selectedSite: getSelectedSite( state ),
-} );
+const mapStateToProps = state => {
+	const selectedSite = getSelectedSite( state );
+	const domains = getDomainsBySite( state, selectedSite );
+
+	return {
+		domains: {
+			// this doesn't appear to be currently
+			// stored in our app state as it was in
+			// the domains store. we know if we are
+			// currently fetching, but not if a fetch
+			// has taken place. in this case, I'm
+			// using the length of the array to indicate
+			// `hasLoaded` because this component should
+			// never exist in the app without at least
+			// one domain. thus, if we have at least one
+			// then we have loaded them.
+			hasLoadedFromServer: !! domains.length,
+			list: domains,
+		},
+		selectedSite
+	};
+};
 
 export default connect( mapStateToProps )( NameserversData );

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -227,7 +227,7 @@ module.exports = {
 			<NameserversData
 				component={ DomainManagement.NameServers }
 				selectedDomainName={ pageContext.params.domain }
-				sites={ sites } />,
+			/>,
 			document.getElementById( 'primary' ),
 			pageContext.store
 		);


### PR DESCRIPTION
Part of the ongoing project to remove `sites-list`
https://github.com/Automattic/wp-calypso/projects/3

Removes the dependency on the domain management DNS component.

> There should be no functional or visual changes to this PR

**Testing**
Navigate to **My Sites** > **Domains** for a site with a custom domain purchased through Wordpress.com, then click on the **Nameserver** settings for that domain. Makes sure that things switch as expected when changing sites. Make sure that no errors appear when switching from DNS settings to nameserver settings. Load on a clean cache. Make sure it all works as expected.

cc: @gwwar 