### PR TITLE
Signup: Add vertical query string

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -88,7 +88,7 @@ assign( SignupFlowController.prototype, {
 			dependenciesNotProvided = difference( step.dependencies, keys( dependenciesFound ), this._getFlowProvidesDependencies() );
 			if ( ! isEmpty( dependenciesNotProvided ) ) {
 				throw new Error( 'The ' + step.stepName + ' step requires dependencies [' + dependenciesNotProvided + '] which ' +
-				'are not provided in the ' + this._flowName + ' flow and are not already present in the redux store.' );
+				'are not provided in the ' + this._flowName + ' flow and are not already present in the store.' );
 			}
 			return true;
 		}.bind( this ) );

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -84,10 +84,11 @@ assign( SignupFlowController.prototype, {
 				return true;
 			}
 
-			dependenciesNotProvided = difference( step.dependencies, this._getFlowProvidesDependencies() );
+			const dependenciesFound = pick( SignupDependencyStore.get(), step.dependencies );
+			dependenciesNotProvided = difference( step.dependencies, keys( dependenciesFound ), this._getFlowProvidesDependencies() );
 			if ( ! isEmpty( dependenciesNotProvided ) ) {
 				throw new Error( 'The ' + step.stepName + ' step requires dependencies [' + dependenciesNotProvided + '] which ' +
-				'are not provided in the ' + this._flowName + ' flow.' );
+				'are not provided in the ' + this._flowName + ' flow and are not already present in the redux store.' );
 			}
 			return true;
 		}.bind( this ) );

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -129,7 +129,11 @@ assign( SignupFlowController.prototype, {
 	},
 
 	_process: function() {
-		var signupProgress = SignupProgressStore.get(),
+		var currentSteps = this._flow.steps,
+			signupProgress = filter(
+				SignupProgressStore.get(),
+				step => ( -1 !== currentSteps.indexOf( step.stepName ) ),
+			),
 			pendingSteps = filter( signupProgress, { status: 'pending' } ),
 			completedSteps = filter( signupProgress, { status: 'completed' } ),
 			bearerToken = SignupDependencyStore.get().bearer_token,
@@ -143,7 +147,7 @@ assign( SignupFlowController.prototype, {
 			map( pendingSteps, this._processStep.bind( this ) );
 		}
 
-		if ( completedSteps.length === this._flow.steps.length && undefined !== this._onComplete ) {
+		if ( completedSteps.length === currentSteps.length && undefined !== this._onComplete ) {
 			if ( this._assertFlowProvidedRequiredDependencies() ) {
 				// deferred to ensure that the onComplete function is called after the stores have
 				// emitted their final change events.

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -15,7 +15,8 @@ var debug = require( 'debug' )( 'calypso:signup:flow-controller' ), // eslint-di
 	filter = require( 'lodash/filter' ),
 	find = require( 'lodash/find' ),
 	pick = require( 'lodash/pick' ),
-	keys = require( 'lodash/keys' );
+	keys = require( 'lodash/keys' ),
+	page = require( 'page' );
 
 /**
  * Internal dependencies
@@ -26,7 +27,8 @@ var SignupActions = require( './actions' ),
 	flows = require( 'signup/config/flows' ),
 	steps = require( 'signup/config/steps' ),
 	wpcom = require( 'lib/wp' ),
-	user = require( 'lib/user' )();
+	user = require( 'lib/user' )(),
+	utils = require( 'signup/utils' );
 
 /**
  * Constants
@@ -87,6 +89,12 @@ assign( SignupFlowController.prototype, {
 			const dependenciesFound = pick( SignupDependencyStore.get(), step.dependencies );
 			dependenciesNotProvided = difference( step.dependencies, keys( dependenciesFound ), this._getFlowProvidesDependencies() );
 			if ( ! isEmpty( dependenciesNotProvided ) ) {
+
+				if ( this._flowName !== flows.defaultFlowName ) {
+					// redirect to the default signup flow, hopefully it will be valid
+					page( utils.getStepUrl() );
+				}
+
 				throw new Error( 'The ' + step.stepName + ' step requires dependencies [' + dependenciesNotProvided + '] which ' +
 				'are not provided in the ' + this._flowName + ' flow and are not already present in the store.' );
 			}

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -81,13 +81,12 @@ assign( SignupFlowController.prototype, {
 
 	_assertFlowHasValidDependencies: function() {
 		return every( pick( steps, this._flow.steps ), function( step ) {
-			var dependenciesNotProvided;
 			if ( ! step.dependencies ) {
 				return true;
 			}
 
 			const dependenciesFound = pick( SignupDependencyStore.get(), step.dependencies );
-			dependenciesNotProvided = difference( step.dependencies, keys( dependenciesFound ), this._getFlowProvidesDependencies() );
+			const dependenciesNotProvided = difference( step.dependencies, keys( dependenciesFound ), this._getFlowProvidesDependencies() );
 			if ( ! isEmpty( dependenciesNotProvided ) ) {
 
 				if ( this._flowName !== flows.defaultFlowName ) {

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -166,7 +166,7 @@ assign( SignupFlowController.prototype, {
 			currentSteps = this._flow.steps,
 			signupProgress = filter(
 				SignupProgressStore.get(),
-				step => ( -1 !== currentSteps.indexOf( step.stepName ) ),
+				_step => ( -1 !== currentSteps.indexOf( _step.stepName ) ),
 			),
 			allStepsSubmitted = reject( signupProgress, {
 				status: 'in-progress'

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -163,9 +163,14 @@ assign( SignupFlowController.prototype, {
 			dependencies = steps[ step.stepName ].dependencies || [],
 			dependenciesFound = pick( SignupDependencyStore.get(), dependencies ),
 			dependenciesSatisfied = dependencies.length === keys( dependenciesFound ).length,
-			allStepsSubmitted = reject( SignupProgressStore.get(), {
+			currentSteps = this._flow.steps,
+			signupProgress = filter(
+				SignupProgressStore.get(),
+				step => ( -1 !== currentSteps.indexOf( step.stepName ) ),
+			),
+			allStepsSubmitted = reject( signupProgress, {
 				status: 'in-progress'
-			} ).length === this._flow.steps.length;
+			} ).length === currentSteps.length;
 
 		return dependenciesSatisfied &&
 			! this._processingSteps[ step.stepName ] &&

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -87,7 +87,7 @@ describe( 'flow-controller', function() {
 	describe( 'controlling a flow w/ dependencies', function() {
 		it( 'should call the apiRequestFunction callback with its dependencies', function( done ) {
 			signupFlowController = SignupFlowController( {
-				flowName: 'flow_with_async',
+				flowName: 'flow_with_dependencies',
 				onComplete: function( dependencies, destination ) {
 					assert.equal( destination, '/checkout/testsite.wordpress.com' );
 					done();

--- a/client/lib/signup/test/signup/config/flows.js
+++ b/client/lib/signup/test/signup/config/flows.js
@@ -6,13 +6,13 @@ var flows = {
 
 	flow_with_async: {
 		steps: [ 'userCreation', 'asyncStep' ],
-		destination: function( dependencies ) {
-			return '/checkout/' + dependencies.siteSlug;
-		}
 	},
 
 	flow_with_dependencies: {
-		steps: [ 'siteCreation', 'userCreation' ]
+		steps: [ 'siteCreation', 'userCreation' ],
+		destination: function( dependencies ) {
+			return '/checkout/' + dependencies.siteSlug;
+		}
 	},
 
 	invalid_flow_with_dependencies: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -96,7 +96,7 @@ const flows = {
 	},
 
 	subdomain: {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Provide a vertical for subdomains',
 		lastModified: '2016-10-31'

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -95,6 +95,13 @@ const flows = {
 		lastModified: '2016-01-27'
 	},
 
+	subdomain: {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		destination: getSiteDestination,
+		description: 'Provide a vertical for subdomains',
+		lastModified: '2016-10-31'
+	},
+
 	main: {
 		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -108,7 +108,7 @@ const Signup = React.createClass( {
 			} );
 
 			SignupActions.submitSignupStep(
-				{	stepName: 'survey' }, [],	{ surveySiteType: 'blog', surveyQuestion: vertical }
+				{ stepName: 'survey' }, [], { surveySiteType: 'blog', surveyQuestion: vertical }
 			);
 		}
 	},

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -139,7 +139,7 @@ const Signup = React.createClass( {
 		const flowSteps = flows.getFlow( this.props.flowName ).steps;
 		const flowStepsInProgressStore = filter(
 			SignupProgressStore.get(),
-			step => ( -1 !== flowSteps.indexOf( step.name ) ),
+			step => ( -1 !== flowSteps.indexOf( step.stepName ) ),
 		);
 
 		if ( flowStepsInProgressStore.length > 0 ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -11,6 +11,7 @@ import startsWith from 'lodash/startsWith';
 import sortBy from 'lodash/sortBy';
 import last from 'lodash/last';
 import find from 'lodash/find';
+import filter from 'lodash/filter';
 import some from 'lodash/some';
 import defer from 'lodash/defer';
 import delay from 'lodash/delay';
@@ -135,7 +136,13 @@ const Signup = React.createClass( {
 
 		this.loadProgressFromStore();
 
-		if ( SignupProgressStore.get().length > 0 ) {
+		const flowSteps = flows.getFlow( this.props.flowName ).steps;
+		const flowStepsInProgressStore = filter(
+			SignupProgressStore.get(),
+			step => ( -1 !== flowSteps.indexOf( step.name ) ),
+		);
+
+		if ( flowStepsInProgressStore.length > 0 ) {
 			// we loaded progress from local storage, attempt to resume progress
 			return this.resumeProgress();
 		}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -94,9 +94,9 @@ const Signup = React.createClass( {
 	},
 
 	submitQueryDependencies() {
-		let vertical = this.props.queryObject.vertical;
-		let steps = flows.getFlow( this.props.flowName ).steps;
-		if ( 'undefined' !== typeof vertical && -1 === find( steps, { stepName: 'survey' } ) ) {
+		const vertical = this.props.queryObject.vertical;
+		const flowSteps = flows.getFlow( this.props.flowName ).steps;
+		if ( 'undefined' !== typeof vertical && -1 === find( flowSteps, { stepName: 'survey' } ) ) {
 			SignupActions.submitSignupStep(
 				{	stepName: 'survey' }, [],	{ surveyQuestion: this.props.vertical }
 			);

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -18,7 +18,6 @@ import delay from 'lodash/delay';
 import assign from 'lodash/assign';
 import matchesProperty from 'lodash/matchesProperty';
 import indexOf from 'lodash/indexOf';
-import reject from 'lodash/reject';
 import { setSurvey } from 'state/signup/steps/survey/actions';
 
 /**
@@ -350,8 +349,16 @@ const Signup = React.createClass( {
 	},
 
 	isEveryStepSubmitted() {
-		var flowSteps = flows.getFlow( this.props.flowName ).steps;
-		return flowSteps.length === reject( SignupProgressStore.get(), { status: 'in-progress' } ).length;
+		const flowSteps = flows.getFlow( this.props.flowName ).steps;
+		const signupProgress = filter(
+				SignupProgressStore.get(),
+				step => (
+					-1 !== flowSteps.indexOf( step.stepName )
+					&& 'in-progress' !== step.status
+				),
+			);
+
+		return flowSteps.length === signupProgress.length;
 	},
 
 	positionInFlow() {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -94,11 +94,14 @@ const Signup = React.createClass( {
 	},
 
 	submitQueryDependencies() {
+		if ( 'undefined' === typeof this.props.queryObject ) {
+			return;
+		}
 		const vertical = this.props.queryObject.vertical;
 		const flowSteps = flows.getFlow( this.props.flowName ).steps;
-		if ( 'undefined' !== typeof vertical && -1 === find( flowSteps, { stepName: 'survey' } ) ) {
+		if ( 'undefined' !== typeof vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
 			SignupActions.submitSignupStep(
-				{	stepName: 'survey' }, [],	{ surveyQuestion: this.props.vertical }
+				{	stepName: 'survey' }, [],	{ surveySiteType: 'blog', surveyQuestion: vertical }
 			);
 		}
 	},

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -255,8 +255,11 @@ const Signup = React.createClass( {
 	},
 
 	firstUnsubmittedStepName() {
-		const signupProgress = SignupProgressStore.get(),
-			currentSteps = flows.getFlow( this.props.flowName ).steps,
+		const currentSteps = flows.getFlow( this.props.flowName ).steps,
+			signupProgress = filter(
+				SignupProgressStore.get(),
+				step => ( -1 !== currentSteps.indexOf( step.stepName ) ),
+			),
 			nextStepName = currentSteps[ signupProgress.length ],
 			firstInProgressStep = find( signupProgress, { status: 'in-progress' } ) || {},
 			firstInProgressStepName = firstInProgressStep.stepName;
@@ -268,7 +271,11 @@ const Signup = React.createClass( {
 		// Update the Flows object to know that the signup flow is being resumed.
 		flows.resumingFlow = true;
 
-		const signupProgress = SignupProgressStore.get(),
+		const flowSteps = flows.getFlow( this.props.flowName ).steps,
+			signupProgress = filter(
+				SignupProgressStore.get(),
+				step => ( -1 !== flowSteps.indexOf( step.stepName ) ),
+			),
 			lastUpdatedStep = sortBy( signupProgress, 'lastUpdated' ).reverse()[ 0 ],
 			lastUpdatedStepName = lastUpdatedStep.stepName,
 			stepSectionName = lastUpdatedStep.stepSectionName,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -101,16 +101,16 @@ const Signup = React.createClass( {
 		}
 		const vertical = this.props.queryObject.vertical;
 		const flowSteps = flows.getFlow( this.props.flowName ).steps;
-		if ( 'undefined' !== typeof vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
-			this.props.setSurvey( {
-				vertical,
-				otherText: '',
-			} );
-
-			SignupActions.submitSignupStep(
-				{ stepName: 'survey' }, [], { surveySiteType: 'blog', surveyQuestion: vertical }
-			);
+		if ( 'undefined' === typeof vertical || -1 !== flowSteps.indexOf( 'survey' ) ) {
+			return;
 		}
+		this.props.setSurvey( {
+			vertical,
+			otherText: '',
+		} );
+		SignupActions.submitSignupStep(
+			{ stepName: 'survey' }, [], { surveySiteType: 'blog', surveyQuestion: vertical }
+		);
 	},
 
 	componentWillMount() {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -43,6 +43,7 @@ import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import * as oauthToken from 'lib/oauth-token';
 import DocumentHead from 'components/data/document-head';
 import { translate } from 'i18n-calypso';
+import SignupActions from 'lib/signup/actions';
 
 /**
  * Constants
@@ -92,11 +93,23 @@ const Signup = React.createClass( {
 		}
 	},
 
+	submitQueryDependencies() {
+		let vertical = this.props.queryObject.vertical;
+		let steps = flows.getFlow( this.props.flowName ).steps;
+		if ( 'undefined' !== typeof vertical && -1 === find( steps, { stepName: 'survey' } ) ) {
+			SignupActions.submitSignupStep(
+				{	stepName: 'survey' }, [],	{ surveyQuestion: this.props.vertical }
+			);
+		}
+	},
+
 	componentWillMount() {
 		analytics.tracks.recordEvent( 'calypso_signup_start', {
 			flow: this.props.flowName,
 			ref: this.props.refParameter
 		} );
+
+		this.submitQueryDependencies();
 
 		this.signupFlowController = new SignupFlowController( {
 			flowName: this.props.flowName,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -19,6 +19,7 @@ import assign from 'lodash/assign';
 import matchesProperty from 'lodash/matchesProperty';
 import indexOf from 'lodash/indexOf';
 import reject from 'lodash/reject';
+import { setSurvey } from 'state/signup/steps/survey/actions';
 
 /**
  * Internal dependencies
@@ -101,6 +102,11 @@ const Signup = React.createClass( {
 		const vertical = this.props.queryObject.vertical;
 		const flowSteps = flows.getFlow( this.props.flowName ).steps;
 		if ( 'undefined' !== typeof vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
+			this.props.setSurvey( {
+				vertical,
+				otherText: '',
+			} );
+
 			SignupActions.submitSignupStep(
 				{	stepName: 'survey' }, [],	{ surveySiteType: 'blog', surveyQuestion: vertical }
 			);
@@ -448,6 +454,6 @@ export default connect(
 		domainsWithPlansOnly: getCurrentUser( state ) ? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ) : true,
 		signupDependencies: getSignupDependencyStore( state ),
 	} ),
-	() => ( {} ),
+	{ setSurvey },
 	undefined,
 	{ pure: false } )( Signup );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -96,21 +96,24 @@ const Signup = React.createClass( {
 	},
 
 	submitQueryDependencies() {
-		if ( 'undefined' === typeof this.props.queryObject ) {
+		if ( ! this.props.queryObject ) {
 			return;
 		}
-		const vertical = this.props.queryObject.vertical;
+
 		const flowSteps = flows.getFlow( this.props.flowName ).steps;
-		if ( 'undefined' === typeof vertical || -1 !== flowSteps.indexOf( 'survey' ) ) {
-			return;
+
+		// `vertical` query parameter
+		const vertical = this.props.queryObject.vertical;
+		if ( 'undefined' !== typeof vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
+			debug( 'From query string: vertical = %s', vertical );
+			this.props.setSurvey( {
+				vertical,
+				otherText: '',
+			} );
+			SignupActions.submitSignupStep(
+				{ stepName: 'survey' }, [], { surveySiteType: 'blog', surveyQuestion: vertical }
+			);
 		}
-		this.props.setSurvey( {
-			vertical,
-			otherText: '',
-		} );
-		SignupActions.submitSignupStep(
-			{ stepName: 'survey' }, [], { surveySiteType: 'blog', surveyQuestion: vertical }
-		);
 	},
 
 	componentWillMount() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -198,7 +198,8 @@ const DomainsStep = React.createClass( {
 				analyticsSection="signup"
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				includeWordPressDotCom
-				includeDotBlogSubdomain={ abtest( 'domainDotBlogSubdomain' ) === 'includeDotBlogSubdomain' }
+				includeDotBlogSubdomain={ ( this.props.flowName === 'subdomain' ) ||
+					( abtest( 'domainDotBlogSubdomain' ) === 'includeDotBlogSubdomain' ) }
 				isSignupStep
 				showExampleSuggestions
 				surveyVertical={ this.props.surveyVertical }


### PR DESCRIPTION
This PR lays down initial ground work to allow us to pass signup steps/dependencies as part of the query string.

## Testing plan

First of all, make sure you visit https://calypso.live/?branch=add/vertical-query-string to switch to the right branch on calypso live.

1. Open https://calypso.live/start/ (Normal flow, without query string args)
2. Make sure you can complete the signup successfully
3. Open https://calypso.live/start/subdomain?vertical=a8c.1.6 (Subdomains flow, with query string args. a8c.1.6 is the 'music' vertical)
4. Make sure that you are suggested a .music.blog subdomain, and that you can complete the signup successfully
