### PR TITLE
Remove blocking wait from my-sites while sites-list loads

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -189,7 +189,6 @@ module.exports = {
 		// set site visibility to just that site on the picker
 		if ( sites.select( siteID ) ) {
 			onSelectedSiteAvailable();
-			next();
 		} else {
 			// if sites has fresh data and siteID is invalid
 			// redirect to allSitesPath
@@ -211,15 +210,14 @@ module.exports = {
 					waitingNotice = notices.info( i18n.translate( 'Finishing set up…' ), { showDismiss: false } );
 					sites.once( 'change', selectOnSitesChange );
 					sites.fetch();
-					return;
 				} else {
 					page.redirect( allSitesPath );
 				}
-				next();
 			};
 			// Otherwise, check when sites has loaded
 			sites.once( 'change', selectOnSitesChange );
 		}
+		next();
 	},
 
 	awaitSiteLoaded( context, next ) {


### PR DESCRIPTION
This removes the wait in rendering while sites-list finishes loading. Initially added to pause Jetpack-connected sites, that bug has been fixed, and now instead we're just blocking page render for all my-sites pages.

To test:

- Visit any page in my-sites, like stats, posts, etc
- Clear localstorage
- Reload the page, you should see placeholder content (whereas before, you waited on a blank page for a while)

See #7250 for discussion.