### PR TITLE
Bump Stats JS Version to 55

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -29,7 +29,7 @@ window.ga = window.ga || function() {
 };
 window.ga.l = +new Date();
 
-loadScript( '//stats.wp.com/w.js?54' ); // W_JS_VER
+loadScript( '//stats.wp.com/w.js?55' ); // W_JS_VER
 loadScript( '//www.google-analytics.com/analytics.js' );
 
 function buildQuerystring( group, name ) {


### PR DESCRIPTION
This is needed to bust the cache due to changes that gets rid of some userid tracking code in:

r144809-wpcom