### PR TITLE
G Suite: Validate the username field when adding new users

### DIFF
--- a/client/components/upgrades/google-apps/dialog/index.jsx
+++ b/client/components/upgrades/google-apps/dialog/index.jsx
@@ -207,8 +207,7 @@ const GoogleAppsDialog = React.createClass( {
 	validateForm() {
 		const validation = validateGappsUsers( {
 			users: this.state.users,
-			fields: this.getFields(),
-			domainSuffix: this.props.domain
+			fields: this.getFields()
 		} );
 
 		if ( validation.errors.length > 0 ) {
@@ -227,7 +226,7 @@ const GoogleAppsDialog = React.createClass( {
 
 		users = users.map( ( user ) => {
 			return {
-				email: `${ user.email.value }@${ this.props.domain }`,
+				email: `${ user.email.value }@${ this.props.domain }`.toLowerCase(),
 				firstname: user.firstName.value.trim(),
 				lastname: user.lastName.value.trim()
 			};

--- a/client/components/upgrades/google-apps/dialog/users.jsx
+++ b/client/components/upgrades/google-apps/dialog/users.jsx
@@ -28,7 +28,8 @@ const GoogleAppsUsers = React.createClass( {
 		return {
 			email: { value: '', error: null },
 			firstName: { value: '', error: null },
-			lastName: { value: '', error: null }
+			lastName: { value: '', error: null },
+			domain: { value: this.props.domain, error: null }
 		};
 	},
 
@@ -66,7 +67,7 @@ const GoogleAppsUsers = React.createClass( {
 						name="email"
 						value={ user.email.value }
 						suffix={ '@' + this.props.domain }
-						isError={ user.email.error }
+						isError={ !! user.email.error }
 						onChange={ this.updateField.bind( this, index ) }
 						onBlur={ this.props.onBlur }
 						onClick={ this.recordInputFocus.bind( this, index, 'Email' ) } />
@@ -79,7 +80,7 @@ const GoogleAppsUsers = React.createClass( {
 						name="firstName"
 						value={ user.firstName.value }
 						maxLength={ 60 }
-						isError={ user.firstName.error }
+						isError={ !! user.firstName.error }
 						onChange={ this.updateField.bind( this, index ) }
 						onBlur={ this.props.onBlur }
 						onClick={ this.recordInputFocus.bind( this, index, 'First Name' ) } />
@@ -92,7 +93,7 @@ const GoogleAppsUsers = React.createClass( {
 						name="lastName"
 						value={ user.lastName.value }
 						maxLength={ 60 }
-						isError={ user.lastName.error }
+						isError={ !! user.lastName.error }
 						onChange={ this.updateField.bind( this, index ) }
 						onBlur={ this.props.onBlur }
 						onClick={ this.recordInputFocus.bind( this, index, 'Last Name' ) } />
@@ -121,8 +122,8 @@ const GoogleAppsUsers = React.createClass( {
 	updateField( index, event ) {
 		event.preventDefault();
 
-		const newValue = event.target.value,
-			fieldName = event.target.name,
+		const fieldName = event.target.name,
+			newValue = fieldName === 'email' ? event.target.value.trim() : event.target.value,
 			updatedFields = clone( this.props.fields );
 		updatedFields[ index ] = clone( updatedFields[ index ] );
 		updatedFields[ index ][ fieldName ] = clone( updatedFields[ index ][ fieldName ] );

--- a/client/lib/domains/google-apps-users/index.js
+++ b/client/lib/domains/google-apps-users/index.js
@@ -37,7 +37,7 @@ function validate( { users, fields, domainSuffix } ) {
 				if ( field.value.length > 60 ) {
 					error = i18n.translate( 'This field can\'t be longer than 60 characters.' );
 				}
-			} else if ( 'email' === key ) {
+			} else if ( includes( [ 'email', 'username' ], key ) ) {
 				if ( /[^[0-9a-z_'.-]/i.test( field.value ) ) {
 					error = i18n.translate( 'Only number, letters, dashes, underscores, apostrophes and periods are allowed.' );
 				} else if ( ! emailValidator.validate( `${ field.value }@${ domainSuffix }` ) ) {

--- a/client/lib/domains/google-apps-users/index.js
+++ b/client/lib/domains/google-apps-users/index.js
@@ -38,7 +38,7 @@ function validate( { users, fields, domainSuffix } ) {
 					error = i18n.translate( 'This field can\'t be longer than 60 characters.' );
 				}
 			} else if ( includes( [ 'email', 'username' ], key ) ) {
-				if ( /[^[0-9a-z_'.-]/i.test( field.value ) ) {
+				if ( ! /^[0-9a-z_'-](\.?[0-9a-z_'-])*$/.test( field.value ) ) {
 					error = i18n.translate( 'Only number, letters, dashes, underscores, apostrophes and periods are allowed.' );
 				} else if ( ! emailValidator.validate( `${ field.value }@${ domainSuffix }` ) ) {
 					error = i18n.translate( 'Please provide a valid email address.' );

--- a/client/lib/domains/google-apps-users/index.js
+++ b/client/lib/domains/google-apps-users/index.js
@@ -23,7 +23,7 @@ function filter( { users, fields } ) {
 	} );
 }
 
-function validate( { users, fields, domainSuffix } ) {
+function validate( { users, fields } ) {
 	var errors;
 
 	users = filter( { users, fields } );
@@ -38,9 +38,9 @@ function validate( { users, fields, domainSuffix } ) {
 					error = i18n.translate( 'This field can\'t be longer than 60 characters.' );
 				}
 			} else if ( includes( [ 'email', 'username' ], key ) ) {
-				if ( ! /^[0-9a-z_'-](\.?[0-9a-z_'-])*$/.test( field.value ) ) {
+				if ( ! /^[0-9a-z_'-](\.?[0-9a-z_'-])*$/i.test( field.value ) ) {
 					error = i18n.translate( 'Only number, letters, dashes, underscores, apostrophes and periods are allowed.' );
-				} else if ( ! emailValidator.validate( `${ field.value }@${ domainSuffix }` ) ) {
+				} else if ( ! emailValidator.validate( `${ field.value }@${ user.domain.value }` ) ) {
 					error = i18n.translate( 'Please provide a valid email address.' );
 				}
 			}

--- a/client/my-sites/upgrades/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/upgrades/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -170,7 +170,7 @@ const AddEmailAddressesCard = React.createClass( {
 		let command = { fieldsets: {} };
 
 		command.fieldsets[ index ] = {};
-		command.fieldsets[ index ][ fieldName ] = { value: { $set: newValue } };
+		command.fieldsets[ index ][ fieldName ] = { value: { $set: newValue.trim() } };
 
 		if ( fieldName === 'domain' ) {
 			this.recordEvent( 'domainChange', newValue, index );
@@ -286,7 +286,7 @@ function getGoogleAppsCartItems( { domains, fieldsets } ) {
 	groups = mapValues( groups, function( group ) {
 		return map( group, function( fieldset ) {
 			return {
-				email: fieldset.username.value + '@' + fieldset.domain.value
+				email: `${ fieldset.username.value }@${ fieldset.domain.value }`.toLowerCase()
 			};
 		} );
 	} );


### PR DESCRIPTION
The field with the account/username is named differentely in the two forms we have for setting up G Suite users: in one it's `email`, in the other it's `username`. Since our validation code was only looking for `email`, it did not validate properly the `username` field from the second form and allowed invalid usernames to be submitted.

*Testing*
Try adding new G Suite users and verify that the validation works.

1. Adding to a custom domain you've already purchased on WordPress.com:
 * `Domains` -> `G Suite` -> `Add G Suite`
<img width="763" alt="screen shot 2016-11-01 at 18 52 59" src="https://cloud.githubusercontent.com/assets/3392497/19900658/9a157a98-a064-11e6-886e-306bc225dcaa.png">

 * `Domains` -> select a custom domain -> `Email` -> `Add G Suite`
<img width="762" alt="screen shot 2016-11-01 at 18 54 07" src="https://cloud.githubusercontent.com/assets/3392497/19900675/aa8ea174-a064-11e6-91a0-49a2fd5a8b53.png">

2. Purchasing G Suite along with a new custom domain: `Domains` -> `Add` -> search and select domain -> `Add Email`

<img width="742" alt="screen shot 2016-11-01 at 18 52 08" src="https://cloud.githubusercontent.com/assets/3392497/19900685/b3bde50c-a064-11e6-9478-8acf45f1de3b.png">

Fixes #9053 

cc @Lochlaer 
cc @aidvu @umurkontaci 