### PR TITLE
Analytics: Add Google Analytics e-commerce tracking

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -250,6 +250,10 @@ var analytics = {
 					};
 				}
 				window.ga( 'create', config( 'google_analytics_key' ), 'auto', parameters );
+
+				// Load the Ecommerce Plugin
+				window.ga( 'require', 'ecommerce' );
+
 				analytics.ga.initialized = true;
 			}
 		},


### PR DESCRIPTION
This PR adds Google Analytics e-commerce tracking to Calypso so we can precisely measure the revenue we bring through Google Analytics.

To test:

Before you begin, read through [this implementation guidance](https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce) provided by Google. As you're reviewing the code in this PR, check it against the guidance provided by Google to make sure I didn't miss anything.

1) In `config/development.json`, change both `ad-tracking` and `google_analytics_enabled` to `true`.

2) On a test WordPress.com account, make a purchase.

3) Open Chrome's Network tab and search for `google-analytics.com`. You should see one request that tracks the item purchased and another that tracks the overall order.

Here's the item:

![screen shot 2016-11-01 at 1 21 40 pm](https://cloud.githubusercontent.com/assets/44436/19900036/8bf6383e-a038-11e6-9723-9be6fe6ff8cb.png)

Note that `in` is set to `personal-bundle` (the slug of the plan I purchased), `ip` is set to the price in USD, `35.88`, and `cu`, the currency, is set to `USD`.

And here's the transaction for the overall order:

![screen shot 2016-11-01 at 1 47 45 pm](https://cloud.githubusercontent.com/assets/44436/19900419/cdcb5bbc-a039-11e6-9ee7-3cc38de49f4c.png)

Note that `ti` is set to the order id, `ta` to `WordPress.com` (which is hardcoded), `tr` to the cost, and `cu` to the currency, `USD`.

4) Repeat this process for a non-USD currency and verifying that all is well. For example, here's what the item tracking looks like for purchasing the Personal Plan for 4320 yen:

![screen shot 2016-11-01 at 1 55 12 pm](https://cloud.githubusercontent.com/assets/44436/19900712/e3885aee-a03a-11e6-91db-ecb7b7b2a0ed.png)
