### PR TITLE
Plans: remove domains to plans nudge

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -30,7 +30,6 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import formatCurrency from 'lib/format-currency';
 import { canCurrentUser } from 'state/current-user/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
-import { abtest } from 'lib/abtest';
 
 class DomainToPlanNudge extends Component {
 
@@ -68,8 +67,7 @@ class DomainToPlanNudge extends Component {
 			rawPrice &&       //plans info has loaded
 			site &&           //site exists
 			site.wpcom_url && //has a mapped domain
-			hasFreePlan &&    //has a free wpcom plan
-			abtest( 'domainToPersonalPlanNudge2' ) === 'nudge';
+			hasFreePlan;      //has a free wpcom plan
 	}
 
 	personalCheckout() {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,15 +98,6 @@ module.exports = {
 		defaultVariation: 'hideSiteTitleStep',
 		allowExistingUsers: false
 	},
-	domainToPersonalPlanNudge2: {
-		datestamp: '20161018',
-		variations: {
-			original: 50,
-			nudge: 50
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true
-	},
 	gSuiteOnSignup: {
 		datestamp: '20161025',
 		variations: {

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -36,7 +36,6 @@ import { hasDomainCredit } from 'state/sites/plans/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { isPlanFeaturesEnabled } from 'lib/plans';
-import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 
 export const List = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'list' ) ],
@@ -96,7 +95,6 @@ export const List = React.createClass( {
 		return (
 			<Main wideLayout={ isPlanFeaturesEnabled() }>
 				<SidebarNavigation />
-				<DomainToPlanNudge />
 				<UpgradesNavigation
 					path={ this.props.context.path }
 					cart={ this.props.cart }

--- a/client/my-sites/upgrades/domain-management/list/test/index.js
+++ b/client/my-sites/upgrades/domain-management/list/test/index.js
@@ -42,7 +42,6 @@ describe( 'index', function() {
 				getProducts: noop
 			} )
 		} );
-		mockery.registerMock( 'blocks/domain-to-plan-nudge', EmptyComponent );
 	} );
 
 	before( () => {


### PR DESCRIPTION
This PR removes the DomainToPlanNudge from the domains management page

## Testing Instructions
- We can navigate to `calypso.localhost:3000/domains/manage/:siteID:` without seeing a large upgrade to Personal Plan nudge
- Previous conditions to see this were: select a site with a paid domain and free plan, and set the abtest`domainToPersonalPlanNudge2` to  'nudge'