### PR TITLE
Reader: Don't convert all URLs to http when subscribing

### DIFF
--- a/client/lib/reader-feed-subscriptions/helper.js
+++ b/client/lib/reader-feed-subscriptions/helper.js
@@ -13,3 +13,8 @@ export function prepareSiteUrl( url ) {
 	// remove trailing /
 	return url && untrailingslashit( url );
 }
+
+export function prepareComparableUrl( url ) {
+	const preparedUrl = prepareSiteUrl( url );
+	return preparedUrl && preparedUrl.replace( /^https?:\/\//, '' ).toLowerCase();
+}

--- a/client/lib/reader-feed-subscriptions/helper.js
+++ b/client/lib/reader-feed-subscriptions/helper.js
@@ -1,10 +1,15 @@
-var untrailingslashit = require( 'lib/route/untrailingslashit' );
+/**
+ * External Dependencies
+ */
 
-module.exports = {
-	// Prepare site URL for use with the FeedSubscriptionStore
-	prepareSiteUrl: function( url ) {
-		// Convert https:// to http://, remove trailing /
-		var preparedUrl = url && untrailingslashit( url.replace( 'https://', 'http://' ) );
-		return preparedUrl;
-	}
-};
+
+/**
+ * Internal Dependencies
+ */
+import untrailingslashit from 'lib/route/untrailingslashit';
+
+// Prepare site URL for use with the FeedSubscriptionStore
+export function prepareSiteUrl( url ) {
+	// remove trailing /
+	return url && untrailingslashit( url );
+}

--- a/client/lib/reader-feed-subscriptions/test/index.js
+++ b/client/lib/reader-feed-subscriptions/test/index.js
@@ -31,6 +31,7 @@ describe( 'store', function() {
 		expect( FeedSubscriptionStore.getSubscription( siteUrl ) ).to.immutablyEqual( immutable.fromJS(
 			{
 				URL: siteUrl,
+				comparableUrl: 'trailnose.com',
 				state: 'SUBSCRIBED'
 			}
 		) );
@@ -82,6 +83,7 @@ describe( 'store', function() {
 
 		expect( FeedSubscriptionStore.getSubscription( siteUrl ) ).to.immutablyEqual( immutable.fromJS( {
 			URL: siteUrl,
+			comparableUrl: 'trailnose.com',
 			feed_ID: 123,
 			state: 'SUBSCRIBED'
 		} ) );
@@ -156,6 +158,7 @@ describe( 'store', function() {
 		expect( FeedSubscriptionStore.getSubscription( 'http://www.banana.com' ) ).to.immutablyEqual( immutable.fromJS( {
 			ID: 1,
 			URL: 'http://www.banana.com',
+			comparableUrl: 'www.banana.com',
 			feed_ID: 123,
 			state: 'SUBSCRIBED'
 		} ) );
@@ -173,6 +176,7 @@ describe( 'store', function() {
 		expect( FeedSubscriptionStore.getSubscription( 'http://www.dragonfruit.com' ) ).to.immutablyEqual( immutable.fromJS( {
 			ID: 3,
 			URL: 'http://www.dragonfruit.com',
+			comparableUrl: 'www.dragonfruit.com',
 			feed_ID: 456,
 			state: 'SUBSCRIBED'
 		} ) );


### PR DESCRIPTION
Some sites only support https and don't redirect in a sane manner. Looking at you MSDN.

To test, try subscribing to https://blogs.msdn.microsoft.com/oldnewthing/ before and after this patch.