### PR TITLE
Refreshed Stream: Fix default card images too tall

### DIFF
--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -45,10 +45,3 @@
 		margin-right: 0;
 	}
 }
-
-.reader-post-actions .reader-post-options-menu .button {
-
-	&.is-borderless .gridicon {
-		top: -2px;
-	}
-}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -244,6 +244,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 // Action buttons in post card
 .reader-post-card.card .reader-post-actions__item {
 	font-size: 14px;
+	height: 22px;
 
 	&.reader-post-actions__visit .gridicon {
 		fill: lighten( $gray, 10% );
@@ -288,6 +289,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		@include breakpoint( "<660px" ) {
 			display: none;
 		}
+	}
+
+	.ellipsis-menu .button.is-borderless .gridicon {
+		top: -2px;
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/8897

I poked at this for quite a bit and the main culprit is the default padding set in `.ellipsis-menu .button`. But the default paddings/heights around each action component were contributing to it as well. Setting a height to the `li` itself was a more practical fix.

**Before:**
![screenshot 2016-11-01 11 49 20](https://cloud.githubusercontent.com/assets/4924246/19903848/5866ebfe-a02d-11e6-8bce-d5adea0cd5f3.png)

**After:**
![screenshot 2016-11-01 11 58 23](https://cloud.githubusercontent.com/assets/4924246/19903852/5cc0f802-a02d-11e6-8d95-8ec925f1cf9b.png)

