### PR TITLE
State: Improve state handling for connections list

### DIFF
--- a/client/state/sharing/keyring/README.md
+++ b/client/state/sharing/keyring/README.md
@@ -72,14 +72,14 @@ import { getKeyringConnectionById } from 'state/sharing/keyring/selectors';
 const connection = getKeyringConnectionById( state, 23353);
 ```
 
-#### `getKeyringConnectionByName( state: object, service: string )`
+#### `getKeyringConnectionsByName( state: object, service: string )`
 
-Returns a keyring connection object for a specified service.
+Returns an array of keyring connection objects for a specified service.
 
 ```js
-import { getKeyringConnectionByName } from 'state/sharing/keyring/selectors';
+import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
 
-const twitterConnection = getKeyringConnectionByName( state, 'twitter' );
+const twitterConnections = getKeyringConnectionsByName( state, 'twitter' );
 ```
 
 #### `getUserConnections( state: object,  userId: number  )`

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -28,11 +28,11 @@ export const isFetching = createReducer( false, {
 // Stores the list of available keyring connections
 export const items = createReducer( {}, {
 	[ KEYRING_CONNECTIONS_RECEIVE ]: ( state, { connections } ) => ( { ...keyBy( connections, 'ID' ) } ),
-	[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { ID, siteId } ) => ( { ...state, [ ID ]: {
-		...state[ ID ], sites: [ ...state[ ID ].sites, siteId.toString() ]
+	[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { connection: { keyring_connection_ID: ID, site_ID } } ) => ( { ...state, [ ID ]: {
+		...state[ ID ], sites: [ ...state[ ID ].sites, site_ID.toString() ]
 	} } ),
-	[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { ID, siteId } ) => ( { ...state, [ ID ]: {
-		...state[ ID ], sites: without( state[ ID ].sites, siteId.toString() )
+	[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { connection: { keyring_connection_ID: ID, site_ID } } ) => ( { ...state, [ ID ]: {
+		...state[ ID ], sites: without( state[ ID ].sites, site_ID.toString() )
 	} } ),
 }, itemSchema );
 

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -28,17 +28,19 @@ export const isFetching = createReducer( false, {
 // Stores the list of available keyring connections
 export const items = createReducer( {}, {
 	[ KEYRING_CONNECTIONS_RECEIVE ]: ( state, { connections } ) => ( { ...keyBy( connections, 'ID' ) } ),
-	[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { connection: { keyring_connection_ID: id, site_ID } } ) => {
-		const connection = state[ id ];
-		const sites = [ ...connection.sites, site_ID.toString() ];
+	[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { connection } ) => {
+		const { keyring_connection_ID: id, site_ID: siteId } = connection;
+		const keyringConnection = state[ id ];
+		const sites = [ ...keyringConnection.sites, siteId.toString() ];
 
-		return { ...state, [ id ]: { ...connection, sites } };
+		return { ...state, [ id ]: { ...keyringConnection, sites } };
 	},
-	[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { connection: { keyring_connection_ID: id, site_ID } } ) => {
-		const connection = state[ id ];
-		const sites = without( connection.sites, site_ID.toString() );
+	[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { connection } ) => {
+		const { keyring_connection_ID: id, site_ID: siteId } = connection;
+		const keyringConnection = state[ id ];
+		const sites = without( keyringConnection.sites, siteId.toString() );
 
-		return { ...state, [ id ]: { ...connection, sites } };
+		return { ...state, [ id ]: { ...keyringConnection, sites } };
 	},
 }, itemSchema );
 

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -28,12 +28,18 @@ export const isFetching = createReducer( false, {
 // Stores the list of available keyring connections
 export const items = createReducer( {}, {
 	[ KEYRING_CONNECTIONS_RECEIVE ]: ( state, { connections } ) => ( { ...keyBy( connections, 'ID' ) } ),
-	[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { connection: { keyring_connection_ID: ID, site_ID } } ) => ( { ...state, [ ID ]: {
-		...state[ ID ], sites: [ ...state[ ID ].sites, site_ID.toString() ]
-	} } ),
-	[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { connection: { keyring_connection_ID: ID, site_ID } } ) => ( { ...state, [ ID ]: {
-		...state[ ID ], sites: without( state[ ID ].sites, site_ID.toString() )
-	} } ),
+	[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { connection: { keyring_connection_ID: id, site_ID } } ) => {
+		const connection = state[ id ];
+		const sites = [ ...connection.sites, site_ID.toString() ];
+
+		return { ...state, [ id ]: { ...connection, sites } };
+	},
+	[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { connection: { keyring_connection_ID: id, site_ID } } ) => {
+		const connection = state[ id ];
+		const sites = without( connection.sites, site_ID.toString() );
+
+		return { ...state, [ id ]: { ...connection, sites } };
+	},
 }, itemSchema );
 
 export default combineReducers( {

--- a/client/state/sharing/keyring/selectors.js
+++ b/client/state/sharing/keyring/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, find, values } from 'lodash';
+import { filter, values } from 'lodash';
 
 /**
  * Returns an array of keyring connection objects.
@@ -25,14 +25,14 @@ export function getKeyringConnectionById( state, keyringConnectionId ) {
 }
 
 /**
- * Returns a keyring connection object for a specified service.
+ * Returns an array of keyring connection objects for a specified service.
  *
  * @param  {Object} state   Global state tree
  * @param  {String} service Service slug.
- * @return {?Object}        Keyring connection, if known.
+ * @return {Array}         Keyring connections, if known.
  */
-export function getKeyringConnectionByName( state, service ) {
-	return find( state.sharing.keyring.items, { service } ) || null;
+export function getKeyringConnectionsByName( state, service ) {
+	return filter( getKeyringConnections( state ), { service } ) || [];
 }
 
 /**

--- a/client/state/sharing/keyring/selectors.js
+++ b/client/state/sharing/keyring/selectors.js
@@ -39,7 +39,7 @@ export function getKeyringConnectionById( state, keyringConnectionId ) {
  * @return {Array}         Keyring connections, if known.
  */
 export function getKeyringConnectionsByName( state, service ) {
-	return filter( getKeyringConnections( state ), { service } ) || [];
+	return filter( getKeyringConnections( state ), { service } );
 }
 
 /**

--- a/client/state/sharing/keyring/selectors.js
+++ b/client/state/sharing/keyring/selectors.js
@@ -1,14 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, flatten, some, values } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteUserConnectionsForService } from 'state/sharing/publicize/selectors';
+import { filter, values } from 'lodash';
 
 /**
  * Returns an array of keyring connection objects.
@@ -53,50 +46,6 @@ export function getUserConnections( state, userId ) {
 	return filter( state.sharing.keyring.items, ( connection ) => (
 		connection.shared || connection.keyring_connection_user_ID === userId
 	) );
-}
-
-/**
- * Given a service, returns a flattened array of all possible accounts for the
- * service for which a connection can be created.
- *
- * @param  {Object} state   Global state tree
- * @param  {String} service The name of the service to check
- * @return {Array}          Flattened array of all possible accounts for the service
- */
-export function getAvailableExternalConnections( state, service ) {
-	const siteUserConnectionsForService = getSiteUserConnectionsForService(
-		state, getSelectedSiteId( state ), getCurrentUserId( state ), service
-	);
-
-	// Iterate over Keyring connections for this service and generate a
-	// flattened array of all accounts, including external users
-	return flatten( getKeyringConnectionsByName( state, service ).map( ( keyringConnection ) => {
-		const accounts = [ {
-			name: keyringConnection.external_display || keyringConnection.external_name,
-			picture: keyringConnection.external_profile_picture,
-			keyringConnectionId: keyringConnection.ID,
-			isConnected: some( siteUserConnectionsForService, {
-				keyring_connection_ID: keyringConnection.ID,
-				external_ID: keyringConnection.external_ID,
-			} ),
-		} ];
-
-		keyringConnection.additional_external_users.forEach( ( externalUser ) => {
-			accounts.push( {
-				ID: externalUser.external_ID,
-				name: externalUser.external_name,
-				picture: externalUser.external_profile_picture,
-				keyringConnectionId: keyringConnection.ID,
-				isConnected: some( siteUserConnectionsForService, {
-					keyring_connection_ID: keyringConnection.ID,
-					external_ID: externalUser.external_ID,
-				} ),
-				isExternal: true,
-			} );
-		} );
-
-		return accounts;
-	} ) );
 }
 
 /**

--- a/client/state/sharing/keyring/test/reducer.js
+++ b/client/state/sharing/keyring/test/reducer.js
@@ -112,8 +112,10 @@ describe( 'reducers', () => {
 				1: { ID: 1, sites: [ '2916284' ] }
 			} ), {
 				type: PUBLICIZE_CONNECTION_CREATE,
-				ID: 1,
-				siteId: '77203074',
+				connection: {
+					keyring_connection_ID: 1,
+					site_ID: '77203074',
+				},
 			} );
 
 			expect( state ).to.eql( {
@@ -126,8 +128,10 @@ describe( 'reducers', () => {
 				1: { ID: 1, sites: [ '2916284', '77203074' ] }
 			} ), {
 				type: PUBLICIZE_CONNECTION_DELETE,
-				ID: 1,
-				siteId: 77203074,
+				connection: {
+					keyring_connection_ID: 1,
+					site_ID: 77203074,
+				},
 			} );
 
 			expect( state ).to.eql( {

--- a/client/state/sharing/keyring/test/selectors.js
+++ b/client/state/sharing/keyring/test/selectors.js
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import {
 	getKeyringConnections,
 	getKeyringConnectionById,
-	getKeyringConnectionByName,
+	getKeyringConnectionsByName,
 	getUserConnections,
 	isKeyringConnectionsFetching
 } from '../selectors';
@@ -70,19 +70,19 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getKeyringConnectionByName()', () => {
+	describe( 'getKeyringConnectionsByName()', () => {
 		it( 'should return null for a connection which has not yet been fetched', () => {
-			const connections = getKeyringConnectionByName( activeState, 'tumblr' );
+			const connections = getKeyringConnectionsByName( activeState, 'tumblr' );
 
-			expect( connections ).to.be.null;
+			expect( connections ).to.be.empty;
 		} );
 
 		it( 'should return the connection object for the ID', () => {
-			const connections = getKeyringConnectionByName( activeState, 'facebook' );
+			const connections = getKeyringConnectionsByName( activeState, 'facebook' );
 
-			expect( connections ).to.eql(
+			expect( connections ).to.eql( [
 				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
-			);
+			] );
 		} );
 	} );
 

--- a/client/state/sharing/keyring/test/selectors.js
+++ b/client/state/sharing/keyring/test/selectors.js
@@ -11,6 +11,7 @@ import {
 	getKeyringConnectionById,
 	getKeyringConnectionsByName,
 	getUserConnections,
+	getAvailableExternalConnections,
 	isKeyringConnectionsFetching
 } from '../selectors';
 
@@ -24,16 +25,31 @@ describe( 'selectors', () => {
 		}
 	};
 	const activeState = {
+		currentUser: {
+			id: 26957695,
+		},
 		sharing: {
 			keyring: {
 				items: {
-					1: { ID: 1, service: 'twitter', sites: [ '2916284' ] },
-					2: { ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1 },
-					3: { ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
+					1: { ID: 1, service: 'twitter', sites: [ '2916284' ], additional_external_users: [] },
+					2: { ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1, additional_external_users: [] },
+					3: { ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
 				},
 				isFetching: true,
+			},
+			publicize: {
+				connectionsBySiteId: {
+					2916284: [ 1, 2, 3 ]
+				},
+				connections: {
+					1: { ID: 1, site_ID: 2916284, shared: true },
+					2: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 },
+				}
 			}
-		}
+		},
+		ui: {
+			selectedSiteId: 2916284,
+		},
 	};
 
 	describe( 'getKeyringConnections()', () => {
@@ -47,9 +63,9 @@ describe( 'selectors', () => {
 			const connections = getKeyringConnections( activeState );
 
 			expect( connections ).to.eql( [
-				{ ID: 1, service: 'twitter', sites: [ '2916284' ] },
-				{ ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1 },
-				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
+				{ ID: 1, service: 'twitter', sites: [ '2916284' ], additional_external_users: [] },
+				{ ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1, additional_external_users: [] },
+				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
 			] );
 		} );
 	} );
@@ -65,7 +81,7 @@ describe( 'selectors', () => {
 			const connections = getKeyringConnectionById( activeState, 1 );
 
 			expect( connections ).to.eql(
-				{ ID: 1, service: 'twitter', sites: [ '2916284' ] },
+				{ ID: 1, service: 'twitter', sites: [ '2916284' ], additional_external_users: [] },
 			);
 		} );
 	} );
@@ -81,7 +97,7 @@ describe( 'selectors', () => {
 			const connections = getKeyringConnectionsByName( activeState, 'facebook' );
 
 			expect( connections ).to.eql( [
-				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
+				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
 			] );
 		} );
 	} );
@@ -99,7 +115,7 @@ describe( 'selectors', () => {
 			const connections = getUserConnections( activeState, 3 );
 
 			expect( connections ).to.eql( [
-				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
+				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
 			] );
 		} );
 
@@ -107,8 +123,24 @@ describe( 'selectors', () => {
 			const connections = getUserConnections( activeState, 1 );
 
 			expect( connections ).to.eql( [
-				{ ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1 },
-				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
+				{ ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1, additional_external_users: [] },
+				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
+			] );
+		} );
+	} );
+
+	describe( 'getAvailableExternalConnections()', () => {
+		it( 'should return an empty array for a site which has not yet been fetched', () => {
+			const connections = getAvailableExternalConnections( activeState, 'path' );
+
+			expect( connections ).to.eql( [] );
+		} );
+
+		it( 'should return an array of connection objects that are available to any user', () => {
+			const connections = getAvailableExternalConnections( activeState, 'twitter' );
+
+			expect( connections ).to.eql( [
+				{ isConnected: false, keyringConnectionId: 1, name: undefined, picture: undefined },
 			] );
 		} );
 	} );

--- a/client/state/sharing/keyring/test/selectors.js
+++ b/client/state/sharing/keyring/test/selectors.js
@@ -30,9 +30,9 @@ describe( 'selectors', () => {
 		sharing: {
 			keyring: {
 				items: {
-					1: { ID: 1, service: 'twitter', sites: [ '2916284' ], additional_external_users: [] },
-					2: { ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1, additional_external_users: [] },
-					3: { ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
+					1: { ID: 1, service: 'twitter', sites: [ '2916284' ] },
+					2: { ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1 },
+					3: { ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
 				},
 				isFetching: true,
 			},
@@ -62,9 +62,9 @@ describe( 'selectors', () => {
 			const connections = getKeyringConnections( activeState );
 
 			expect( connections ).to.eql( [
-				{ ID: 1, service: 'twitter', sites: [ '2916284' ], additional_external_users: [] },
-				{ ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1, additional_external_users: [] },
-				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
+				{ ID: 1, service: 'twitter', sites: [ '2916284' ] },
+				{ ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1 },
+				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
 			] );
 		} );
 	} );
@@ -80,7 +80,7 @@ describe( 'selectors', () => {
 			const connections = getKeyringConnectionById( activeState, 1 );
 
 			expect( connections ).to.eql(
-				{ ID: 1, service: 'twitter', sites: [ '2916284' ], additional_external_users: [] },
+				{ ID: 1, service: 'twitter', sites: [ '2916284' ] },
 			);
 		} );
 	} );
@@ -96,7 +96,7 @@ describe( 'selectors', () => {
 			const connections = getKeyringConnectionsByName( activeState, 'facebook' );
 
 			expect( connections ).to.eql( [
-				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
+				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
 			] );
 		} );
 	} );
@@ -114,7 +114,7 @@ describe( 'selectors', () => {
 			const connections = getUserConnections( activeState, 3 );
 
 			expect( connections ).to.eql( [
-				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
+				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
 			] );
 		} );
 
@@ -122,8 +122,8 @@ describe( 'selectors', () => {
 			const connections = getUserConnections( activeState, 1 );
 
 			expect( connections ).to.eql( [
-				{ ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1, additional_external_users: [] },
-				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
+				{ ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1 },
+				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
 			] );
 		} );
 	} );

--- a/client/state/sharing/keyring/test/selectors.js
+++ b/client/state/sharing/keyring/test/selectors.js
@@ -11,7 +11,6 @@ import {
 	getKeyringConnectionById,
 	getKeyringConnectionsByName,
 	getUserConnections,
-	getAvailableExternalConnections,
 	isKeyringConnectionsFetching
 } from '../selectors';
 
@@ -125,22 +124,6 @@ describe( 'selectors', () => {
 			expect( connections ).to.eql( [
 				{ ID: 2, service: 'insta', sites: [ '77203074' ], keyring_connection_user_ID: 1, additional_external_users: [] },
 				{ ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
-			] );
-		} );
-	} );
-
-	describe( 'getAvailableExternalConnections()', () => {
-		it( 'should return an empty array for a site which has not yet been fetched', () => {
-			const connections = getAvailableExternalConnections( activeState, 'path' );
-
-			expect( connections ).to.eql( [] );
-		} );
-
-		it( 'should return an array of connection objects that are available to any user', () => {
-			const connections = getAvailableExternalConnections( activeState, 'twitter' );
-
-			expect( connections ).to.eql( [
-				{ isConnected: false, keyringConnectionId: 1, name: undefined, picture: undefined },
 			] );
 		} );
 	} );

--- a/client/state/sharing/keyring/test/selectors.js
+++ b/client/state/sharing/keyring/test/selectors.js
@@ -24,9 +24,6 @@ describe( 'selectors', () => {
 		}
 	};
 	const activeState = {
-		currentUser: {
-			id: 26957695,
-		},
 		sharing: {
 			keyring: {
 				items: {
@@ -35,20 +32,8 @@ describe( 'selectors', () => {
 					3: { ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true },
 				},
 				isFetching: true,
-			},
-			publicize: {
-				connectionsBySiteId: {
-					2916284: [ 1, 2, 3 ]
-				},
-				connections: {
-					1: { ID: 1, site_ID: 2916284, shared: true },
-					2: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 },
-				}
 			}
-		},
-		ui: {
-			selectedSiteId: 2916284,
-		},
+		}
 	};
 
 	describe( 'getKeyringConnections()', () => {

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -86,10 +86,7 @@ export function createSiteConnection( siteId, keyringConnectionId, externalUserI
 				type: PUBLICIZE_CONNECTION_CREATE,
 				connection,
 			} ) )
-			.catch( ( error ) => dispatch( {
-				type: PUBLICIZE_CONNECTION_CREATE_FAILURE,
-				error,
-			} ) );
+			.catch( ( error ) => dispatch( failCreateConnection( error ) ) );
 }
 
 /**
@@ -137,6 +134,13 @@ export function deleteSiteConnection( connection ) {
 					error,
 				} );
 			} );
+}
+
+export function failCreateConnection( error ) {
+	return {
+		type: PUBLICIZE_CONNECTION_CREATE_FAILURE,
+		error,
+	};
 }
 
 /**

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -92,21 +92,23 @@ export function createSiteConnection( siteId, keyringConnectionId, externalUserI
 /**
  * Triggers a network request to update a Publicize connection for a specific site.
  *
- * @param  {Number} siteId       Site ID for which the connection is deleted.
- * @param  {Number} connectionId ID of the connection to be deleted.
- * @param  {Object} attributes   The update request body.
- * @return {Function}            Action thunk
+ * @param  {Object} connection         Connection to be updated.
+ * @param  {Number} connection.site_ID Site ID for which the connection is updated.
+ * @param  {Number} connection.ID      ID of the connection to be updated.
+ * @param  {String} connection.label   Name of the connected service.
+ * @param  {Object} attributes         The update request body.
+ * @return {Function}                  Action thunk
  */
-export function updateSiteConnection( siteId, connectionId, attributes ) {
+export function updateSiteConnection( connection, attributes ) {
 	return ( dispatch ) =>
-		wpcom.undocumented().updateConnection( siteId, connectionId, attributes )
+		wpcom.undocumented().updateConnection( connection.site_ID, connection.ID, attributes )
 			.then( ( connection ) => dispatch( {
 				type: PUBLICIZE_CONNECTION_UPDATE,
 				connection,
 			} ) )
 			.catch( ( error ) => dispatch( {
 				type: PUBLICIZE_CONNECTION_UPDATE_FAILURE,
-				error,
+				error: { ...error, label: connection.label },
 			} ) );
 }
 

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -151,8 +151,7 @@ export function deleteSiteConnection( connection ) {
 export function deleteConnection( connection ) {
 	return {
 		type: PUBLICIZE_CONNECTION_DELETE,
-		connectionId: connection.ID,
-		siteId: connection.site_ID,
+		connection,
 	};
 }
 

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -102,9 +102,9 @@ export function createSiteConnection( siteId, keyringConnectionId, externalUserI
 export function updateSiteConnection( connection, attributes ) {
 	return ( dispatch ) =>
 		wpcom.undocumented().updateConnection( connection.site_ID, connection.ID, attributes )
-			.then( ( connection ) => dispatch( {
+			.then( ( response ) => dispatch( {
 				type: PUBLICIZE_CONNECTION_UPDATE,
-				connection,
+				connection: response,
 			} ) )
 			.catch( ( error ) => dispatch( {
 				type: PUBLICIZE_CONNECTION_UPDATE_FAILURE,

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -138,6 +138,13 @@ export function deleteSiteConnection( connection ) {
 			} );
 }
 
+/**
+ * Returns an action object to be used in signalling that creating a Publicize
+ * connection has failed.
+ *
+ * @param  {Object} error Error object
+ * @return {Object}       Action object
+ */
 export function failCreateConnection( error ) {
 	return {
 		type: PUBLICIZE_CONNECTION_CREATE_FAILURE,
@@ -150,8 +157,6 @@ export function failCreateConnection( error ) {
  * removing a Publicize connection has been received.
  *
  * @param  {Object} connection         Connection to be deleted.
- * @param  {Number} connection.site_ID Site ID for which the connection is deleted.
- * @param  {Number} connection.ID      ID of the connection to be deleted.
  * @return {Object}                    Action object
  */
 export function deleteConnection( connection ) {

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -58,7 +58,7 @@ export const connections = createReducer( {}, {
 		...keyBy( action.data.connections, 'ID' )
 	} ),
 	[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { connection } ) => ( { ...state, [ connection.ID ]: connection } ),
-	[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { ID } ) => omit( state, ID ),
+	[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { connection: { ID } } ) => omit( state, ID ),
 }, connectionsSchema );
 
 export default combineReducers( {

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -10,6 +10,7 @@ import { keyBy, omit, omitBy } from 'lodash';
 import {
 	PUBLICIZE_CONNECTION_CREATE,
 	PUBLICIZE_CONNECTION_DELETE,
+	PUBLICIZE_CONNECTION_UPDATE,
 	PUBLICIZE_CONNECTIONS_REQUEST,
 	PUBLICIZE_CONNECTIONS_RECEIVE,
 	PUBLICIZE_CONNECTIONS_REQUEST_FAILURE,
@@ -59,6 +60,7 @@ export const connections = createReducer( {}, {
 	} ),
 	[ PUBLICIZE_CONNECTION_CREATE ]: ( state, { connection } ) => ( { ...state, [ connection.ID ]: connection } ),
 	[ PUBLICIZE_CONNECTION_DELETE ]: ( state, { connection: { ID } } ) => omit( state, ID ),
+	[ PUBLICIZE_CONNECTION_UPDATE ]: ( state, { connection } ) => ( { ...state, [ connection.ID ]: connection } ),
 }, connectionsSchema );
 
 export default combineReducers( {

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -32,6 +32,20 @@ export function getSiteUserConnections( state, siteId, userId ) {
 }
 
 /**
+ * Returns an array of known connections for the given site ID
+ * that are available to the specified user ID.
+ *
+ * @param  {Object} state   Global state tree
+ * @param  {Number} siteId  Site ID
+ * @param  {Number} userId  User ID to filter
+ * @param  {String} service The name of the service to check
+ * @return {Array}          User connections
+ */
+export function getSiteUserConnectionsForService( state, siteId, userId, service ) {
+	return filter( getSiteUserConnections( state, siteId, userId ), ( connection ) => connection.service === service );
+}
+
+/**
  * Returns true if connections have been fetched for the given site ID.
  *
  * @param  {Object} state  Global state tree

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -42,7 +42,7 @@ export function getSiteUserConnections( state, siteId, userId ) {
  * @return {Array}          User connections
  */
 export function getSiteUserConnectionsForService( state, siteId, userId, service ) {
-	return filter( getSiteUserConnections( state, siteId, userId ), ( connection ) => connection.service === service );
+	return filter( getSiteUserConnections( state, siteId, userId ), { service } );
 }
 
 /**

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -7,8 +7,8 @@ import get from 'lodash/get';
 /**
  * Internal dependencies
  */
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
+import { canCurrentUser, getCurrentUserId } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Returns an array of known connections for the given site ID.
@@ -65,13 +65,15 @@ export function getSiteUserConnectionsForService( state, siteId, userId, service
  *                          permitted to remove.
  */
 export function getRemovableConnections( state, service ) {
-	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
 	const userId = getCurrentUserId( state );
-	const siteUserConnectionsForService = getSiteUserConnectionsForService( state, site.ID, userId, service );
+	const siteUserConnectionsForService = getSiteUserConnectionsForService( state, siteId, userId, service );
 
-	return siteUserConnectionsForService.filter( ( connection ) => (
-		site.capabilities && site.capabilities.edit_others_posts || connection.user_ID === userId
-	) );
+	if ( canCurrentUser( state, siteId, 'edit_others_posts' ) ) {
+		return siteUserConnectionsForService;
+	}
+
+	return filter( siteUserConnectionsForService, { user_ID: userId } );
 }
 
 /**

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -5,6 +5,12 @@ import filter from 'lodash/filter';
 import get from 'lodash/get';
 
 /**
+ * Internal dependencies
+ */
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+
+/**
  * Returns an array of known connections for the given site ID.
  *
  * @param  {Object} state  Global state tree
@@ -43,6 +49,29 @@ export function getSiteUserConnections( state, siteId, userId ) {
  */
 export function getSiteUserConnectionsForService( state, siteId, userId, service ) {
 	return filter( getSiteUserConnections( state, siteId, userId ), { service } );
+}
+
+/**
+ * Given a service name, returns the connections that the current user is
+ * allowed to remove.
+ *
+ * For them to be allowed to remove a connection they need to have either the
+ * `edit_others_posts` capability or it's a connection to one of
+ * their accounts.
+ *
+ * @param  {Object} state   Global state tree
+ * @param  {string} service The name of the service
+ * @return {Array}          Connections for which the current user is
+ *                          permitted to remove.
+ */
+export function getRemovableConnections( state, service ) {
+	const site = getSelectedSite( state );
+	const userId = getCurrentUserId( state );
+	const siteUserConnectionsForService = getSiteUserConnectionsForService( state, site.ID, userId, service );
+
+	return siteUserConnectionsForService.filter( ( connection ) => (
+		site.capabilities && site.capabilities.edit_others_posts || connection.user_ID === userId
+	) );
 }
 
 /**

--- a/client/state/sharing/publicize/test/actions.js
+++ b/client/state/sharing/publicize/test/actions.js
@@ -152,7 +152,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch update action when request completes', () => {
-			updateSiteConnection( 2916284, 2, attributes )( spy ).then( () => {
+			updateSiteConnection( { ID: 2, site_ID: 2916284, label: 'Facebook' }, attributes )( spy ).then( () => {
 				const action = spy.getCall( 0 ).args[ 0 ];
 
 				expect( action.type ).to.equal( PUBLICIZE_CONNECTION_UPDATE );
@@ -161,7 +161,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch fail action when request fails', () => {
-			updateSiteConnection( 77203074, 2, attributes )( spy ).then( () => {
+			updateSiteConnection( { ID: 2, site_ID: 77203074, label: 'Facebook' }, attributes )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: PUBLICIZE_CONNECTION_UPDATE_FAILURE,
 					error: sinon.match( { message: 'An active access token must be used to access publicize connections.' } )

--- a/client/state/sharing/publicize/test/actions.js
+++ b/client/state/sharing/publicize/test/actions.js
@@ -19,13 +19,14 @@ import {
 	PUBLICIZE_CONNECTIONS_REQUEST_FAILURE
 } from 'state/action-types';
 import {
-	fetchConnections,
 	createSiteConnection,
-	updateSiteConnection,
 	deleteSiteConnection,
 	deleteConnection,
+	failCreateConnection,
+	failConnectionsRequest,
+	fetchConnections,
 	receiveConnections,
-	failConnectionsRequest
+	updateSiteConnection,
 } from '../actions';
 import useNock from 'test/helpers/use-nock';
 import { useSandbox } from 'test/helpers/use-sinon';
@@ -215,6 +216,19 @@ describe( 'actions', () => {
 				connection: {
 					ID: 2,
 					site_ID: 2916284,
+				},
+			} );
+		} );
+	} );
+
+	describe( 'failCreateConnection()', () => {
+		it( 'should return an action object', () => {
+			const action = failCreateConnection( { message: 'An error occurred' } );
+
+			expect( action ).to.eql( {
+				type: PUBLICIZE_CONNECTION_CREATE_FAILURE,
+				error: {
+					message: 'An error occurred',
 				},
 			} );
 		} );

--- a/client/state/sharing/publicize/test/actions.js
+++ b/client/state/sharing/publicize/test/actions.js
@@ -186,11 +186,13 @@ describe( 'actions', () => {
 
 		it( 'should dispatch delete action when request completes', () => {
 			deleteSiteConnection( { ID: 2, site_ID: 2916284 } )( spy ).then( () => {
-				const action = spy.getCall( 0 ).args[ 0 ];
-
-				expect( action.type ).to.equal( PUBLICIZE_CONNECTION_DELETE );
-				expect( action.connectionId ).to.eql( 2 );
-				expect( action.siteId ).to.eql( 2916284 );
+				expect( spy ).to.have.been.calledWith( {
+					type: PUBLICIZE_CONNECTION_DELETE,
+					connection: {
+						ID: 2,
+						site_ID: 2916284,
+					},
+				} );
 			} );
 		} );
 
@@ -210,8 +212,10 @@ describe( 'actions', () => {
 
 			expect( action ).to.eql( {
 				type: PUBLICIZE_CONNECTION_DELETE,
-				connectionId: 2,
-				siteId: 2916284,
+				connection: {
+					ID: 2,
+					site_ID: 2916284,
+				},
 			} );
 		} );
 	} );

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -174,6 +174,20 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should update existing connections', () => {
+			const newConnection = { ID: 1, site_ID: 2916284 },
+				state = connections( deepFreeze( {
+					1: { ID: 1, site_ID: 77203074 },
+				} ), {
+					type: PUBLICIZE_CONNECTION_CREATE,
+					connection: newConnection,
+				} );
+
+			expect( state ).to.eql( {
+				1: newConnection,
+			} );
+		} );
+
 		describe( 'persistence', () => {
 			useSandbox( ( sandbox ) => sandbox.stub( console, 'warn' ) );
 

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -163,8 +163,10 @@ describe( 'reducer', () => {
 				2: { ID: 2, site_ID: 2916284 },
 			} ), {
 				type: PUBLICIZE_CONNECTION_DELETE,
-				ID: 2,
-				siteId: 2916284,
+				connection: {
+					ID: 2,
+					site_ID: 2916284,
+				},
 			} );
 
 			expect( state ).to.eql( {

--- a/client/state/sharing/publicize/test/selectors.js
+++ b/client/state/sharing/publicize/test/selectors.js
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import {
 	getConnectionsBySiteId,
 	getSiteUserConnections,
+	getSiteUserConnectionsForService,
 	hasFetchedConnections,
 	isFetchingConnections
 } from '../selectors';
@@ -82,6 +83,43 @@ describe( '#getSiteUserConnections()', () => {
 		expect( connections ).to.eql( [
 			{ ID: 1, site_ID: 2916284, shared: true },
 			{ ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 }
+		] );
+	} );
+} );
+
+describe( '#getSiteUserConnectionsForService()', () => {
+	it( 'should return an empty array for a site which has not yet been fetched', () => {
+		const connections = getSiteUserConnectionsForService( {
+			sharing: {
+				publicize: {
+					connectionsBySiteId: {},
+					connections: {}
+				}
+			}
+		}, 2916284, 26957695 );
+
+		expect( connections ).to.eql( [] );
+	} );
+
+	it( 'should return an array of connection objects received for the site that are available to the current user', () => {
+		const connections = getSiteUserConnectionsForService( {
+			sharing: {
+				publicize: {
+					connectionsBySiteId: {
+						2916284: [ 1, 2, 3 ]
+					},
+					connections: {
+						1: { ID: 1, site_ID: 2916284, shared: true, service: 'twitter' },
+						2: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695, service: 'twitter' },
+						3: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 18342963, service: 'facebook' }
+					}
+				}
+			}
+		}, 2916284, 26957695, 'twitter' );
+
+		expect( connections ).to.eql( [
+			{ ID: 1, site_ID: 2916284, shared: true, service: 'twitter' },
+			{ ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695, service: 'twitter' }
 		] );
 	} );
 } );

--- a/client/state/sharing/publicize/test/selectors.js
+++ b/client/state/sharing/publicize/test/selectors.js
@@ -129,6 +129,11 @@ describe( '#getRemovableConnections()', () => {
 	const state = {
 		currentUser: {
 			id: 26957695,
+			capabilities: {
+				2916284: {
+					edit_others_posts: true,
+				},
+			},
 		},
 		sharing: {
 			publicize: {
@@ -178,7 +183,7 @@ describe( '#getRemovableConnections()', () => {
 	} );
 
 	it( 'should return an array of connection objects for the current user that are removable by that same user', () => {
-		state.sites.items[ 2916284 ].capabilities.edit_others_posts = false;
+		state.currentUser.capabilities[ 2916284 ].edit_others_posts = false;
 		const connections = getRemovableConnections( state, 'twitter' );
 
 		expect( connections ).to.eql( [

--- a/client/state/sharing/selectors.js
+++ b/client/state/sharing/selectors.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getKeyringConnectionsByName } from './keyring/selectors';
+import { getSiteUserConnectionsForService } from './publicize/selectors';
+
+/**
+ * Given a service, returns a flattened array of all possible accounts for the
+ * service for which a connection can be created.
+ *
+ * @param  {Object} state   Global state tree
+ * @param  {String} service The name of the service to check
+ * @return {Array}          Flattened array of all possible accounts for the service
+ */
+export function getAvailableExternalAccounts( state, service ) {
+	const isConnected = ( keyring_connection_ID, external_ID ) => {
+		const siteUserConnectionsForService = getSiteUserConnectionsForService(
+			state, getSelectedSiteId( state ), getCurrentUserId( state ), service
+		);
+
+		return some( siteUserConnectionsForService, { keyring_connection_ID, external_ID } );
+	};
+
+	// Iterate over Keyring connections for this service and generate a
+	// flattened array of all accounts, including external users
+	return getKeyringConnectionsByName( state, service ).reduce( ( memo, keyringConnection ) =>
+		memo.concat( [ {
+			name: keyringConnection.external_display || keyringConnection.external_name,
+			picture: keyringConnection.external_profile_picture,
+			keyringConnectionId: keyringConnection.ID,
+			isConnected: isConnected( keyringConnection.ID, keyringConnection.external_ID ),
+		} ] )
+		.concat( keyringConnection.additional_external_users.map( ( externalUser ) => ( {
+			ID: externalUser.external_ID,
+			name: externalUser.external_name,
+			picture: externalUser.external_profile_picture,
+			keyringConnectionId: keyringConnection.ID,
+			isConnected: isConnected( keyringConnection.ID, externalUser.external_ID ),
+			isExternal: true,
+		} ) ) ), [] );
+}

--- a/client/state/sharing/test/selectors.js
+++ b/client/state/sharing/test/selectors.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getAvailableExternalAccounts,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	const state = {
+		currentUser: {
+			id: 26957695,
+		},
+		sharing: {
+			keyring: {
+				items: {
+					1: { ID: 1, service: 'twitter', sites: [ '2916284' ], additional_external_users: [] },
+					2: { ID: 2, service: 'instagram', sites: [ '77203074' ], keyring_connection_user_ID: 1, additional_external_users: [] },
+					3: { ID: 3, service: 'facebook', sites: [ '2916284', '77203074' ], shared: true, additional_external_users: [] },
+					4: { ID: 4, service: 'facebook', sites: [ '77203074' ], shared: false, additional_external_users: [ {
+						external_ID: 1,
+						external_name: 'John',
+						external_profile_picture: undefined,
+					} ] },
+				},
+				isFetching: true,
+			},
+			publicize: {
+				connectionsBySiteId: {
+					2916284: [ 1, 2, 3 ]
+				},
+				connections: {
+					1: { ID: 1, site_ID: 2916284, shared: true },
+					2: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 },
+				}
+			}
+		},
+		ui: {
+			selectedSiteId: 2916284,
+		},
+	};
+
+	describe( 'getAvailableExternalAccounts()', () => {
+		it( 'should return an empty array for a site which has not yet been fetched', () => {
+			const connections = getAvailableExternalAccounts( state, 'path' );
+
+			expect( connections ).to.eql( [] );
+		} );
+
+		it( 'should return an array of available accounts', () => {
+			const connections = getAvailableExternalAccounts( state, 'twitter' );
+
+			expect( connections ).to.eql( [
+				{ isConnected: false, keyringConnectionId: 1, name: undefined, picture: undefined },
+			] );
+		} );
+
+		it( 'should return an array of available accounts including external users', () => {
+			const connections = getAvailableExternalAccounts( state, 'facebook' );
+
+			expect( connections ).to.eql( [
+				{ isConnected: false, keyringConnectionId: 3, name: undefined, picture: undefined },
+				{ isConnected: false, keyringConnectionId: 4, name: undefined, picture: undefined },
+				{ ID: 1, isConnected: false, isExternal: true, keyringConnectionId: 4, name: 'John', picture: undefined },
+			] );
+		} );
+	} );
+} );


### PR DESCRIPTION
First part in separating out changes from #8991 to make it easier to review and safer to merge.

The changes introduced in this PR are mainly fixes for things that didn’t work in real life quite as good as I thought they might. It also introduces a few new selectors and action handlers that emerged from working on #8991.

Based on previous work in #8729.