### PR TITLE
Docs: Add missing package to Sublime Text `eslint` instructions.

### DIFF
--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -1040,7 +1040,7 @@ If you are using Sublime Text, you can use the `SublimeLinter-eslint` plugin to 
 Before following these instructions, you'll want to globally install ESLint and related dependencies by running the following command in your terminal:
 
 ```bash
-npm install -g eslint eslint-plugin-wpcalypso eslint-plugin-react babel-eslint
+npm install -g eslint babel-eslint eslint-plugin-react eslint-plugin-wpcalypso eslint-config-wpcalypso
 ```
 
 #### Identifying Spaces with Sublime Text


### PR DESCRIPTION
The `eslint-config-wpcalypso` [package](https://github.com/Automattic/wp-calypso/blob/master/package.json#L162) is missing from instructions for setting up Calypso linting with global packages; this PR adds it in.