### PR TITLE
Terms: fix prop warning in TermTreeSelector

### DIFF
--- a/client/components/data/query-terms/index.jsx
+++ b/client/components/data/query-terms/index.jsx
@@ -44,7 +44,7 @@ class QueryTerms extends Component {
 }
 
 QueryTerms.propTypes = {
-	siteId: PropTypes.number.isRequired,
+	siteId: PropTypes.number,
 	taxonomy: PropTypes.string.isRequired,
 	query: PropTypes.object,
 	requesting: PropTypes.bool.isRequired,


### PR DESCRIPTION
In #9057, @aduth pointed out that there was a prop warning being thrown by the `<TermTreeSelector />` when `localStore` was empty.  While I could not re-create the warning myself, this one-liner should fix it up.

__To Test__
- Try to re-create the issue outlined in #9057
- Interact with the term tree selector ( Categories ) in the editor sidebar - note that operations like searching still work as expected.