### PR TITLE
Fullpost: Fix Visit Site link overlapping content

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -116,8 +116,8 @@
 
 	@include breakpoint( ">660px" ) {
 		border: 0;
-		top: 47px;
-		right: 0;
+		position: absolute;
+		z-index: 0;
 	}
 }
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9066

**Before:**
![screenshot 2016-11-01 14 17 27](https://cloud.githubusercontent.com/assets/4924246/19907970/5c33bbde-a03e-11e6-8fd1-e08c01f580ed.png)

**After:**
![screenshot 2016-11-01 14 17 44](https://cloud.githubusercontent.com/assets/4924246/19907978/625310d2-a03e-11e6-94f4-5dffa5697e37.png)


