### PR TITLE
Reader Stream Refresh: open original post on Discover where available

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -261,7 +261,7 @@ export class FullPostView extends React.Component {
 					: <DocumentHead title={ `${ post.title } ‹ ${ siteName } ‹ Reader` } />
 				}
 				{ post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
-				{ post && ! post.is_external && post.site_ID && <QueryReaderSite siteId={ post.site_ID } /> }
+				{ post && ! post.is_external && post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
 				<div className="reader-full-post__back-container">
 					<Button className="reader-full-post__back" borderless compact onClick={ this.handleBack }>
 						<Gridicon icon="arrow-left" />

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -25,7 +25,8 @@ export default class RefreshPostCard extends React.Component {
 		feed: PropTypes.object,
 		onClick: PropTypes.func,
 		onCommentClick: PropTypes.func,
-		showPrimaryFollowButton: PropTypes.bool
+		showPrimaryFollowButton: PropTypes.bool,
+		originalPost: PropTypes.object // used for Discover only
 	};
 
 	static defaultProps = {
@@ -34,13 +35,10 @@ export default class RefreshPostCard extends React.Component {
 	};
 
 	propagateCardClick = () => {
-		const postToOpen = this.props.post;
-
-		// @todo
-		// For Discover posts (but not site picks), open the original post in full post view
-		// https://github.com/Automattic/wp-calypso/issues/8696
-
-		this.props.onClick( { post: postToOpen, site: this.props.site, feed: this.props.feed } );
+		// If we have an original post available (e.g. for a Discover pick), send the original post
+		// to the full post view
+		const postToOpen = this.props.originalPost ? this.props.originalPost : this.props.post;
+		this.props.onClick( postToOpen );
 	}
 
 	handleCardClick = ( event ) => {
@@ -84,7 +82,7 @@ export default class RefreshPostCard extends React.Component {
 	}
 
 	render() {
-		const { post, site, feed, onCommentClick, showPrimaryFollowButton } = this.props;
+		const { post, originalPost, site, feed, onCommentClick, showPrimaryFollowButton } = this.props;
 		const isPhotoOnly = post.display_type & DisplayTypes.PHOTO_ONLY;
 		const title = truncate( post.title, {
 			length: 140,
@@ -115,7 +113,7 @@ export default class RefreshPostCard extends React.Component {
 						{ ! isPhotoOnly && <div className="reader-post-card__excerpt">{ post.short_excerpt }</div> }
 						{ post &&
 							<ReaderPostActions
-								post={ post }
+								post={ originalPost ? originalPost : post }
 								showVisit={ true }
 								showMenu={ true }
 								onCommentClick={ onCommentClick }

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -121,6 +121,8 @@ FeedPostStore.dispatchToken = Dispatcher.register( function( payload ) {
 	}
 } );
 
+FeedPostStore.setMaxListeners( 100 );
+
 function _setFeedPost( id, post ) {
 	if ( ! id ) {
 		return false;

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -13,11 +13,14 @@ import { getSite } from 'state/reader/sites/selectors';
 import { getFeed } from 'state/reader/feeds/selectors';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
+import * as DiscoverHelper from 'reader/discover/helper';
+import FeedPostStore from 'lib/feed-post-store';
+import smartSetState from 'lib/react-smart-set-state';
 
-export class ReaderPostCardAdapter extends React.Component {
+class ReaderPostCardAdapter extends React.Component {
 
-	onClick = () => {
-		this.props.handleClick && this.props.handleClick( this.props.post );
+	onClick = ( postToOpen ) => {
+		this.props.handleClick && this.props.handleClick( postToOpen );
 	}
 
 	onCommentClick = () => {
@@ -38,6 +41,7 @@ export class ReaderPostCardAdapter extends React.Component {
 		return (
 			<ReaderPostCard
 				post={ this.props.post }
+				originalPost={ this.props.originalPost }
 				site={ this.props.site }
 				feed={ this.props.feed }
 				onClick={ this.onClick }
@@ -50,14 +54,70 @@ export class ReaderPostCardAdapter extends React.Component {
 	}
 }
 
-export default connect(
+const ConnectedReaderPostCardAdapter = connect(
 	( state, ownProps ) => {
 		const siteId = get( ownProps, 'post.site_ID' );
 		const isExternal = get( ownProps, 'post.is_external' );
 		const feedId = get( ownProps, 'post.feed_ID' );
 		return {
 			site: isExternal ? null : getSite( state, siteId ),
-			feed: getFeed( state, feedId )
+			feed: getFeed( state, feedId ),
+			originalPost: ownProps.originalPost
 		};
 	}
 )( ReaderPostCardAdapter );
+
+/**
+ * A container for the ReaderPostCardAdapter responsible for binding to Flux stores
+ */
+export default class ReaderPostCardAdapterFluxContainer extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.state = this.getStateFromStores( props );
+		this.smartSetState = smartSetState;
+	}
+
+	getStateFromStores( props = this.props ) {
+		const post = props.post;
+		const isDiscoverPost = post && DiscoverHelper.isDiscoverPost( post );
+		let isDiscoverSitePick = false;
+		if ( isDiscoverPost ) {
+			isDiscoverSitePick = post && DiscoverHelper.isDiscoverSitePick( post );
+		}
+
+		// If it's a discover post (but not a site pick), we want the original post too
+		let originalPost;
+		if ( isDiscoverPost && ! isDiscoverSitePick && get( post, 'discover_metadata.featured_post_wpcom_data.blog_id' ) ) {
+			originalPost = FeedPostStore.get( {
+				blogId: post.discover_metadata.featured_post_wpcom_data.blog_id,
+				postId: post.discover_metadata.featured_post_wpcom_data.post_id
+			} );
+		}
+
+		return {
+			originalPost
+		};
+	}
+
+	updateState = ( newState = this.getStateFromStores() ) => {
+		this.smartSetState( newState );
+	}
+
+	componentWillMount() {
+		FeedPostStore.on( 'change', this.updateState );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.updateState( this.getStateFromStores( nextProps ) );
+	}
+
+	componentWillUnmount() {
+		FeedPostStore.off( 'change', this.updateState );
+	}
+
+	render() {
+		return ( <ConnectedReaderPostCardAdapter
+					{ ...this.props }
+					originalPost={ this.state.originalPost } /> );
+	}
+}


### PR DESCRIPTION
In the current Reader stream, opening a post in Discover opens the _original_ post in full post view, rather than the Discover post. This happens for all Discover posts except site picks.

The like and comment buttons on the stream card should also reflect the counts from the original post, not the Discover post.

<img width="854" alt="screen shot 2016-11-02 at 18 29 28" src="https://cloud.githubusercontent.com/assets/17325/19917703/633d858a-a12a-11e6-80e0-92c7cc491944.png">

This PR adds the same functionality to the new Reader stream.

Fixes https://github.com/Automattic/wp-calypso/issues/8696.

### To test

Open the Discover stream at http://calypso.localhost:3000/discover.

Find a post that isn't a site pick, and open it in full post view. It should open the post from the original site, not the Discover post.

Example recent posts: "Plot Twist" and "Framing the Past".

<img width="747" alt="screen shot 2016-11-02 at 18 32 10" src="https://cloud.githubusercontent.com/assets/17325/19917732/b8ee8970-a12a-11e6-8266-97742387674c.png"> 

### Background on Discover post types

> 1. Features & Collections / These behave just like regular posts. Awesome!
> 2. Editors’ Picks / Similar to reblogs, these reference posts on other blogs. On the post card, they carry an attribution line, and likes + comments are mapped to the original post (not ours). Opening up a detail view from here opens up the original post.
> 3. Site Picks / Site picks are a type of Editors’ Pick, but they point to an entire site instead of a single post. We show the Discover post in detail, and include a text link to the site.