### PR TITLE
Build: Remove emitter-component dependency

### DIFF
--- a/client/lib/stats/stats-list/README.md
+++ b/client/lib/stats/stats-list/README.md
@@ -19,14 +19,11 @@ Stats Parser
 Functions within `stats-parser.js` are utilized to transform the data into standard arrays that are then consumed by .jsx views.
 
 
-External Dependencies
-=====================
-* `emitter-component` to send `change` events which are subscribed to via the `mixins\data-observe` within your jsx component.
-
 Internal Dependencies
 =====================
 * `wpcom-undocumented` to fetch data from the `/sites/{ site.ID }/stats/{ statType }` endpoint
 * `local-list` to persist api responses to localStorage by siteID and options:w
+* `emitter` mixin to send `change` events which are subscribed to within your jsx component.
 
 Methods
 =======

--- a/client/lib/stats/stats-list/index.js
+++ b/client/lib/stats/stats-list/index.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-var Emitter = require( 'lib/mixins/emitter'),
-	debug = require( 'debug' )( 'calypso:stats-list' );
+var debug = require( 'debug' )( 'calypso:stats-list' );
 
 /**
  * Internal dependencies
  */
 var wpcom = require( 'lib/wp' ),
+	Emitter = require( 'lib/mixins/emitter'),
 	statsParser = require( './stats-parser' )(),
 	analytics = require( 'lib/analytics' );
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -531,7 +531,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000572"
+      "version": "1.0.30000574"
     },
     "caseless": {
       "version": "0.11.0"
@@ -1665,7 +1665,7 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.9"
+      "version": "4.1.10"
     },
     "graceful-readlink": {
       "version": "1.0.1"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -40,7 +40,7 @@
       "version": "0.1.4"
     },
     "amdefine": {
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     "ansi": {
       "version": "0.3.1"
@@ -1043,7 +1043,7 @@
       "version": "1.0.1"
     },
     "emitter-component": {
-      "version": "1.1.1"
+      "version": "1.0.0"
     },
     "emojis-list": {
       "version": "2.1.0"
@@ -1644,7 +1644,7 @@
           "version": "7.1.1"
         },
         "lodash": {
-          "version": "4.16.5"
+          "version": "4.16.6"
         },
         "minimatch": {
           "version": "3.0.3"
@@ -3908,7 +3908,7 @@
       "dev": true
     },
     "unzip-response": {
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "update-notifier": {
       "version": "0.3.2",
@@ -4139,9 +4139,6 @@
       "dependencies": {
         "cookiejar": {
           "version": "1.3.0"
-        },
-        "emitter-component": {
-          "version": "1.0.0"
         },
         "extend": {
           "version": "1.2.1"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "dom-scroll-into-view": "1.0.1",
     "draft-js": "0.8.1",
     "email-validator": "1.0.1",
-    "emitter-component": "1.1.1",
     "escape-regexp": "0.0.1",
     "escape-string-regexp": "1.0.3",
     "events": "1.0.2",


### PR DESCRIPTION
It appears we're not using the `emitter-component` dependency. This PR attempts to remove it. 

/cc @gwwar 