### PR TITLE
Jetpack Plugins: Open author and plugin .org links in new window

### DIFF
--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -68,6 +68,7 @@ export default React.createClass( {
 				icon={ true }
 				href={ 'https://' + this._WPORG_PLUGINS_URL + this.props.plugin.slug + '/' }
 				onClick={ recordEvent }
+				target="_blank"
 				className="plugin-information__external-link" >
 				{ this.translate( 'WordPress.org Plugin page' ) }
 			</ExternalLink>

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -52,6 +52,7 @@ export default React.createClass( {
 				icon={ true }
 				href={ this.props.plugin.plugin_url }
 				onClick={ recordEvent }
+				target="_blank"
 				className="plugin-information__external-link" >
 				{ this.translate( 'Plugin homepage' ) }
 			</ExternalLink>

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -13,6 +13,7 @@ import analytics from 'lib/analytics';
 import Card from 'components/card';
 import Count from 'components/count';
 import NoticeAction from 'components/notice/notice-action';
+import ExternalLink from 'components/external-link';
 import Notice from 'components/notice';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginsActions from 'lib/plugins/actions';
@@ -107,9 +108,9 @@ export default React.createClass( {
 			return;
 		}
 		const linkToAuthor = (
-			<a className="plugin-meta__author" href={ safeProtocolUrl( this.props.plugin.author_url ) }>
+			<ExternalLink className="plugin-meta__author" href={ safeProtocolUrl( this.props.plugin.author_url ) } target="_blank">
 				{ this.props.plugin.author_name }
-			</a>
+			</ExternalLink>
 		);
 
 		return this.translate( 'By {{linkToAuthor/}}', {


### PR DESCRIPTION
### Purpose

This PR concerns 3 specific links on the plugin page:
* The plugins **Author URI** link
* The plugin .org link
* The plugin homepage link

All of these links do not open in a new window, and they should, because they're considered external for Calypso. 

This PR changes these links so they open in new window.

### Preview

Here is a preview of where these links are in the plugins page (such page is `/plugins/hello-dolly/$site`, where `$site` is one of your Jetpack sites):

**Author URI link:**
![](https://cldup.com/_wtz69-bh2.png)

**Plugin .org link:**
![](https://cldup.com/r4iXfv41cw.png)

**Plugin homepage link**
![](https://cldup.com/C1qTiT53vj.png)

### Testing

* Checkout this branch.
* Go to `/plugins/hello-dolly/$site`, where `$site` is one of your Jetpack sites.
* Verify the plugin author link opens in a new window.
* Verify the plugin .org link opens in a new window.
* Verify the plugin homepage link opens in a new window. Such link can be seen in some plugins like `better-wp-security` - `/plugins/better-wp-security/$site`.
* Verify that `rel="external noopener noreferrer` is added to both of the links.

/cc @johnHackworth @roccotripaldi 