### PR TITLE
Sites: make site preview alt text more descriptive

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -202,10 +202,7 @@ export default React.createClass( {
 							href={ this.props.homeLink ? site.URL : this.props.href }
 							data-tip-target={ this.props.tipTarget }
 							target={ this.props.externalLink && ! this.state.showMoreActions && '_blank' }
-							title={ this.props.homeLink
-								? this.translate( 'View "%(title)s"', { args: { title: site.title } } )
-								: site.title
-							}
+							title={ this.translate( 'Preview your site' ) }
 							onTouchTap={ this.onSelect }
 							onClick={ this.props.onClick }
 							onMouseEnter={ this.onMouseEnter }


### PR DESCRIPTION
Change the tooltip title to read "Preview your site".

reference:  #6433 

![changetooltip](https://cloud.githubusercontent.com/assets/16620120/19929316/28771ac0-a0d9-11e6-83a9-7be5fa964bec.png)

