### PR TITLE
Pages: work around caching issue with setting homepages

### DIFF
--- a/client/my-sites/pages/blog-posts-page.jsx
+++ b/client/my-sites/pages/blog-posts-page.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
-import store from 'store';
 
 /**
  * Internal dependencies
@@ -14,13 +13,11 @@ import CompactCard from 'components/card/compact';
 import Gridicon from 'components/gridicon';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
-import sitesFactory from 'lib/sites-list';
 import { isEnabled } from 'config';
 import { getSiteFrontPageType, getSitePostsPage } from 'state/sites/selectors';
 import { setFrontPage } from 'state/sites/actions';
 import { userCan } from 'lib/site/utils';
-
-const sites = sitesFactory();
+import { updateSitesList } from './helpers';
 
 const BlogPostsPage = React.createClass( {
 	propTypes() {
@@ -41,12 +38,7 @@ const BlogPostsPage = React.createClass( {
 
 	setAsHomepage: function() {
 		this.setState( { showPageActions: false } );
-		this.props.setFrontPage( this.props.site.ID, 0, function() {
-			// This gives us a means to fix the `SitesList` cache outside of actions
-			// @todo Remove this when `SitesList` is Reduxified
-			store.remove( 'SitesList' );
-			sites.fetch();
-		}  );
+		this.props.setFrontPage( this.props.site.ID, 0, updateSitesList );
 	},
 
 	getSetAsHomepageItem: function() {

--- a/client/my-sites/pages/blog-posts-page.jsx
+++ b/client/my-sites/pages/blog-posts-page.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
+import store from 'store';
 
 /**
  * Internal dependencies
@@ -13,10 +14,13 @@ import CompactCard from 'components/card/compact';
 import Gridicon from 'components/gridicon';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
+import sitesFactory from 'lib/sites-list';
 import { isEnabled } from 'config';
 import { getSiteFrontPageType, getSitePostsPage } from 'state/sites/selectors';
 import { setFrontPage } from 'state/sites/actions';
 import { userCan } from 'lib/site/utils';
+
+const sites = sitesFactory();
 
 const BlogPostsPage = React.createClass( {
 	propTypes() {
@@ -37,7 +41,12 @@ const BlogPostsPage = React.createClass( {
 
 	setAsHomepage: function() {
 		this.setState( { showPageActions: false } );
-		this.props.setFrontPage( this.props.site.ID, 0 );
+		this.props.setFrontPage( this.props.site.ID, 0, function() {
+			// This gives us a means to fix the `SitesList` cache outside of actions
+			// @todo Remove this when `SitesList` is Reduxified
+			store.remove( 'SitesList' );
+			sites.fetch();
+		}  );
 	},
 
 	getSetAsHomepageItem: function() {

--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -27,10 +27,15 @@ module.exports = {
 
 	// This gives us a means to fix the `SitesList` cache outside of actions
 	// @todo Remove this when `SitesList` is Reduxified
-	updateSitesList: function() {
+	updateSitesList: function( { siteId, pageId } ) {
 		const sites = sitesFactory();
+		let site = sites.getSite( siteId ) ;
 
 		store.remove( 'SitesList' );
+		if ( site ) {
+			site.options.page_on_front = pageId;
+			sites.updateSite( site );
+		}
 		sites.fetch();
 	},
 };

--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -1,3 +1,13 @@
+/**
+ * External dependencies
+ */
+import store from 'store';
+
+/**
+ * Internal dependencies
+ */
+import sitesFactory from 'lib/sites-list';
+
 module.exports = {
 	editLinkForPage: function( page, site ) {
 		if ( ! ( page && page.ID ) || ! ( site && site.ID ) ) {
@@ -13,5 +23,14 @@ module.exports = {
 			return false;
 		}
 		return site.options.page_on_front === page.ID;
-	}
+	},
+
+	// This gives us a means to fix the `SitesList` cache outside of actions
+	// @todo Remove this when `SitesList` is Reduxified
+	updateSitesList: function() {
+		const sites = sitesFactory();
+
+		store.remove( 'SitesList' );
+		sites.fetch();
+	},
 };

--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -29,7 +29,7 @@ module.exports = {
 	// @todo Remove this when `SitesList` is Reduxified
 	updateSitesList: function( { siteId, pageId } ) {
 		const sites = sitesFactory();
-		let site = sites.getSite( siteId ) ;
+		const site = sites.getSite( siteId );
 
 		store.remove( 'SitesList' );
 		if ( site ) {

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -8,7 +8,6 @@ var React = require( 'react' ),
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import store from 'store';
 
 /**
  * Internal dependencies
@@ -33,9 +32,7 @@ import {
 } from 'state/pages/selectors';
 import { setFrontPage } from 'state/sites/actions';
 import { userCan } from 'lib/site/utils';
-import sitesFactory from 'lib/sites-list';
-
-const sites = sitesFactory();
+import { updateSitesList } from './helpers';
 
 function recordEvent( eventAction ) {
 	analytics.ga.recordEvent( 'Pages', eventAction );
@@ -112,12 +109,7 @@ const Page = React.createClass( {
 
 	setAsHomepage: function() {
 		this.setState( { showPageActions: false } );
-		this.props.setFrontPage( this.props.page.site_ID, this.props.page.ID, function() {
-			// This gives us a means to fix the `SitesList` cache outside of actions
-			// @todo Remove this when `SitesList` is Reduxified
-			store.remove( 'SitesList' );
-			sites.fetch();
-		} );
+		this.props.setFrontPage( this.props.page.site_ID, this.props.page.ID, updateSitesList );
 	},
 
 	getSetAsHomepageItem: function() {

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -8,6 +8,7 @@ var React = require( 'react' ),
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import store from 'store';
 
 /**
  * Internal dependencies
@@ -22,7 +23,8 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 	analytics = require( 'lib/analytics' ),
 	utils = require( 'lib/posts/utils' ),
 	classNames = require( 'classnames' ),
-	config = require( 'config' );
+	config = require( 'config' ),
+	sites = require( 'lib/sites-list' )();
 
 import MenuSeparator from 'components/popover/menu-separator';
 import { hasStaticFrontPage } from 'state/sites/selectors';
@@ -109,7 +111,12 @@ const Page = React.createClass( {
 
 	setAsHomepage: function() {
 		this.setState( { showPageActions: false } );
-		this.props.setFrontPage( this.props.page.site_ID, this.props.page.ID );
+		this.props.setFrontPage( this.props.page.site_ID, this.props.page.ID, function() {
+			// This gives us a means to fix the `SitesList` cache outside of actions
+			// @todo Remove this when `SitesList` is Reduxified
+			store.remove( 'SitesList' );
+			sites.fetch();
+		} );
 	},
 
 	getSetAsHomepageItem: function() {

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -23,8 +23,7 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 	analytics = require( 'lib/analytics' ),
 	utils = require( 'lib/posts/utils' ),
 	classNames = require( 'classnames' ),
-	config = require( 'config' ),
-	sites = require( 'lib/sites-list' )();
+	config = require( 'config' );
 
 import MenuSeparator from 'components/popover/menu-separator';
 import { hasStaticFrontPage } from 'state/sites/selectors';
@@ -34,7 +33,9 @@ import {
 } from 'state/pages/selectors';
 import { setFrontPage } from 'state/sites/actions';
 import { userCan } from 'lib/site/utils';
+import sitesFactory from 'lib/sites-list';
 
+const sites = sitesFactory();
 
 function recordEvent( eventAction ) {
 	analytics.ga.recordEvent( 'Pages', eventAction );

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -102,7 +102,7 @@ export function requestSite( siteId ) {
 	};
 }
 
-export function setFrontPage( siteId, pageId ) {
+export function setFrontPage( siteId, pageId, successCallback ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: SITE_FRONT_PAGE_SET,
@@ -116,6 +116,12 @@ export function setFrontPage( siteId, pageId ) {
 		};
 
 		return wpcom.undocumented().setSiteHomepageSettings( siteId, requestData ).then( () => {
+			// This gives us a means to fix the `SitesList` cache outside of actions
+			// @todo Remove this when `SitesList` is Reduxified
+			if ( 'function' === typeof( successCallback ) ) {
+				successCallback();
+			}
+
 			dispatch( recordTracksEvent( 'calypso_front_page_set', {
 				siteId,
 				pageId,

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -119,7 +119,10 @@ export function setFrontPage( siteId, pageId, successCallback ) {
 			// This gives us a means to fix the `SitesList` cache outside of actions
 			// @todo Remove this when `SitesList` is Reduxified
 			if ( 'function' === typeof( successCallback ) ) {
-				successCallback();
+				successCallback( {
+					siteId,
+					pageId,
+				} );
 			}
 
 			dispatch( recordTracksEvent( 'calypso_front_page_set', {


### PR DESCRIPTION
This PR fixes a bug when attempting to set a page as the homepage from the Pages page. That feature is part of a larger epic and is behind a feature flag, `manage/pages/set-homepage`, that is only enabled in `development`.

Prior to this PR, setting the homepage and then reloading the page would cause an old cached value from `SitesList` to be shown (rather than the actual value you just set).

This PR creates a callback which is used to clear the `SitesList` cache, and attempts to refetch `SitesList` so that it's ready upon reloading the page.

To test:
* Checkout branch. `make run`
* Visit the Pages page and update your homepage using the ellipsis menu.
* Reload the page. If the `SitesList` hasn't yet reloaded, you may notice a slight delay, but your update should be reflected.
* `make test` and make sure that all tests pass.