### PR TITLE
Post/page: update inserted image url if edited

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -178,8 +178,6 @@ function mediaButton( editor ) {
 			const media = MediaStore.get( selectedSite.ID, current.media.ID );
 			if ( current.media.transient && ( ! media || ! media.transient ) ) {
 				transients--;
-			} else {
-				return;
 			}
 
 			let markup;

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -37,7 +37,6 @@ var sites = require( 'lib/sites-list' )(),
 import EditorMediaModal from 'post-editor/media-modal';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
-import { withoutHttp } from 'lib/url';
 
 /**
  * Module variables
@@ -136,8 +135,6 @@ function mediaButton( editor ) {
 		return { isLoaded, onLoad };
 	} )();
 
-	const mediaHasChanged = ( media ) => withoutHttp( media.guid ) !== withoutHttp( media.URL );
-
 	updateMedia = debounce( function() {
 		var selectedSite = sites.getSelectedSite(),
 			isTransientDetected = false,
@@ -181,8 +178,6 @@ function mediaButton( editor ) {
 			const media = MediaStore.get( selectedSite.ID, current.media.ID );
 			if ( current.media.transient && ( ! media || ! media.transient ) ) {
 				transients--;
-			} else if ( ! mediaHasChanged( media ) ) {
-				return;
 			}
 
 			let markup;
@@ -195,13 +190,11 @@ function mediaButton( editor ) {
 
 				let useMediaWidthHeight = false;
 
-				if ( mediaHasChanged( media ) ) {
-					if (
-						media.width < current.media.width ||
-						media.height < current.media.height
-					) {
-						useMediaWidthHeight = true;
-					}
+				if (
+					media.width < current.media.width ||
+					media.height < current.media.height
+				) {
+					useMediaWidthHeight = true;
 				}
 
 				// When merging, allow any updated field to be used if it doesn't

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -178,6 +178,8 @@ function mediaButton( editor ) {
 			const media = MediaStore.get( selectedSite.ID, current.media.ID );
 			if ( current.media.transient && ( ! media || ! media.transient ) ) {
 				transients--;
+			} else if ( ! media.transient ) {
+				return;
 			}
 
 			let markup;

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -192,8 +192,8 @@ function mediaButton( editor ) {
 
 				// When merging, allow any updated field to be used if it doesn't
 				// already exist in the current markup, but otherwise only force
-				// update ID and URL attributes to their new values
-				const merged = assign( {}, media, current.media, pick( media, 'ID', 'URL' ), {
+				// update ID, URL, width and height attributes to their new values
+				const merged = assign( {}, media, current.media, pick( media, 'ID', 'URL', 'width', 'height' ), {
 					transient: !! media.transient
 				} );
 				const options = assign( {}, current.appearance, {

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -168,6 +168,12 @@ function mediaButton( editor ) {
 				return;
 			}
 
+			const media = MediaStore.get( selectedSite.ID, current.media.ID );
+
+			if ( media.isDirty ) {
+				current.media.transient = true;
+			}
+
 			if ( current.media.transient ) {
 				transients++;
 				isTransientDetected = true;
@@ -175,9 +181,10 @@ function mediaButton( editor ) {
 
 			// We only want to update post contents in cases where the media
 			// transitions to being persisted
-			const media = MediaStore.get( selectedSite.ID, current.media.ID );
 			if ( current.media.transient && ( ! media || ! media.transient ) ) {
 				transients--;
+			} else {
+				return;
 			}
 
 			let markup;
@@ -279,6 +286,10 @@ function mediaButton( editor ) {
 				level.content = level.content.replace( imgString, event.content );
 				return level;
 			} );
+
+			if ( media.isDirty ) {
+				MediaActions.edit( selectedSite.ID, { ...media, isDirty: false } );
+			}
 		} );
 
 		if ( ! transients && PostEditStore.isSaveBlocked( 'MEDIA_MODAL_TRANSIENT_INSERT' ) ) {

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -195,14 +195,11 @@ function mediaButton( editor ) {
 					return;
 				}
 
-				let useMediaWidthHeight = false;
-
-				if (
+				// If an image is edited through image editor and its final size is smaller than the size of
+				// the inserted image, let's update the size of inserted image to the size of edited image.
+				const useMediaSize =
 					media.width < current.media.width ||
-					media.height < current.media.height
-				) {
-					useMediaWidthHeight = true;
-				}
+					media.height < current.media.height;
 
 				// When merging, allow any updated field to be used if it doesn't
 				// already exist in the current markup, but otherwise only force
@@ -215,8 +212,8 @@ function mediaButton( editor ) {
 						media,
 						'ID',
 						'URL',
-						useMediaWidthHeight ? 'width' : '',
-						useMediaWidthHeight ? 'height' : ''
+						useMediaSize ? 'width' : '',
+						useMediaSize ? 'height' : ''
 					),
 					{
 						transient: !! media.transient

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -195,11 +195,15 @@ function mediaButton( editor ) {
 					return;
 				}
 
-				// If an image is edited through image editor and its final size is smaller than the size of
-				// the inserted image, let's update the size of inserted image to the size of edited image.
-				const useMediaSize =
-					media.width < current.media.width ||
-					media.height < current.media.height;
+				let useMediaSize = false;
+
+				if ( media.isDirty ) {
+					// If an image is edited through image editor and its final size is smaller than the size of
+					// the inserted image, let's update the size of inserted image to the size of edited image.
+					useMediaSize =
+						media.width < current.media.width ||
+						media.height < current.media.height;
+				}
 
 				// When merging, allow any updated field to be used if it doesn't
 				// already exist in the current markup, but otherwise only force

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -148,6 +148,7 @@ function mediaButton( editor ) {
 			return;
 		}
 
+
 		isVisualEditMode = ! editor.isHidden();
 
 		if ( isVisualEditMode ) {
@@ -173,6 +174,7 @@ function mediaButton( editor ) {
 
 			const media = MediaStore.get( selectedSite.ID, current.media.ID );
 
+			// If image is edited in image editor, let's update it in post/page editor.
 			if ( media && media.isDirty ) {
 				if (
 					! lastDirtyImage ||
@@ -205,9 +207,12 @@ function mediaButton( editor ) {
 				isTransientDetected = true;
 			}
 
-			// We only want to update post contents in cases where the media
-			// transitions to being persisted
-			if ( current.media.transient && ( ! media || ! media.transient ) ) {
+			if (
+				// We only want to update post contents in cases where the media
+				// transitions to being persisted
+				current.media.transient && ( ! media || ! media.transient ) ||
+				current.media.transient && media && media.isDirty && media.transient
+			) {
 				transients--;
 			} else {
 				return;

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -148,16 +148,15 @@ function mediaButton( editor ) {
 		const dirtyImage = MediaStore.getDirtyImage();
 		let numOfImagesToUpdate = Number.MAX_SAFE_INTEGER;
 
+		if ( dirtyImage ) {
+			const dirtyImages = editor.dom.select( `img.wp-image-${ dirtyImage.ID }` );
+			numOfImagesToUpdate = dirtyImages.length;
+		}
+
 		isVisualEditMode = ! editor.isHidden();
 
 		if ( isVisualEditMode ) {
-			if ( dirtyImage ) {
-				images = editor.dom.select( `img.wp-image-${ dirtyImage.ID }` );
-
-				numOfImagesToUpdate = images.length;
-			} else {
-				images = editor.dom.select( 'img' );
-			}
+			images = editor.dom.select( 'img' );
 		} else {
 			// Attempt to pull the post from the edit store so that the post
 			// contents can be analyzed for images.
@@ -181,7 +180,7 @@ function mediaButton( editor ) {
 			let mediaHasCaption = false;
 			let captionNode = null;
 
-			if ( media.isDirty ) {
+			if ( media && media.isDirty ) {
 				current.media.transient = true;
 
 				captionNode = editor.dom.getParent( img, '.mceTemp' );

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -209,7 +209,7 @@ function mediaButton( editor ) {
 		}
 
 		const dirtyImage = MediaStore.getDirtyImage();
-		let numOfImagesToUpdate = 0;
+		let numOfImagesToUpdate = Number.MAX_SAFE_INTEGER;
 
 		isVisualEditMode = ! editor.isHidden();
 
@@ -407,8 +407,8 @@ function mediaButton( editor ) {
 			editor.fire( 'change' );
 		}
 
-		if ( numOfImagesToUpdate === 0 ) {
-			MediaActions.edit(  selectedSite.ID, { ...dirtyImage, isDirty: false } );
+		if ( dirtyImage && dirtyImage.isDirty && numOfImagesToUpdate === 0 ) {
+			MediaActions.edit( selectedSite.ID, { ...dirtyImage, isDirty: false } );
 		}
 	} );
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -45,7 +45,7 @@ var REGEXP_IMG = /<img\s[^>]*\/?>/ig,
 	SIZE_ORDER = [ 'thumbnail', 'medium', 'large', 'full' ];
 
 let lastDirtyImage = null,
-	numOfImagesToUpdate = Number.MAX_SAFE_INTEGER;
+	numOfImagesToUpdate = null;
 
 function mediaButton( editor ) {
 	const store = editor.getParam( 'redux_store' );
@@ -334,7 +334,9 @@ function mediaButton( editor ) {
 				return level;
 			} );
 
-			numOfImagesToUpdate -= 1;
+			if ( numOfImagesToUpdate ) {
+				numOfImagesToUpdate -= 1;
+			}
 		} );
 
 		if ( ! transients && PostEditStore.isSaveBlocked( 'MEDIA_MODAL_TRANSIENT_INSERT' ) ) {
@@ -358,7 +360,7 @@ function mediaButton( editor ) {
 		if ( lastDirtyImage && lastDirtyImage.isDirty && numOfImagesToUpdate === 0 ) {
 			MediaActions.edit( selectedSite.ID, { ...lastDirtyImage, isDirty: false } );
 
-			numOfImagesToUpdate = Number.MAX_SAFE_INTEGER;
+			numOfImagesToUpdate = null;
 		}
 	} );
 

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -247,6 +247,11 @@ MediaActions.update = function( siteId, item, editMediaFile = false ) {
 		updateAction.data = { ...newItem, ...MediaActions.createTransientMedia( mediaId, item.media_url ) };
 	}
 
+	if ( editMediaFile && updateAction.data ) {
+		// We need this to show a transient (edited) image in post/page editor after it has been edited there.
+		updateAction.data.isDirty = true;
+	}
+
 	debug( 'Updating media for %o by ID %o to %o', siteId, mediaId, updateAction );
 	Dispatcher.handleViewAction( updateAction );
 

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -260,7 +260,9 @@ MediaActions.update = function( siteId, item, editMediaFile = false ) {
 				type: 'RECEIVE_MEDIA_ITEM',
 				error: error,
 				siteId: siteId,
-				data: { ...data, isDirty: true }
+				data: editMediaFile
+					? { ...data, isDirty: true }
+					: data
 			} );
 		} );
 };

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -260,7 +260,7 @@ MediaActions.update = function( siteId, item, editMediaFile = false ) {
 				type: 'RECEIVE_MEDIA_ITEM',
 				error: error,
 				siteId: siteId,
-				data: data
+				data: { ...data, isDirty: true }
 			} );
 		} );
 };

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -17,7 +17,8 @@ import { isItemBeingUploaded } from 'lib/media/utils';
  */
 const MediaStore = {
 	_media: {},
-	_pointers: {}
+	_pointers: {},
+	_dirtyImageRef: null
 };
 
 emitter( MediaStore );
@@ -46,6 +47,10 @@ function receiveSingle( siteId, item, itemId ) {
 	}
 
 	MediaStore._media[ siteId ][ item.ID ] = item;
+
+	if ( item.isDirty ) {
+		MediaStore._dirtyImageRef = MediaStore._media[ siteId ][ item.ID ];
+	}
 }
 
 function removeSingle( siteId, item ) {
@@ -61,6 +66,10 @@ function receivePage( siteId, items ) {
 		receiveSingle( siteId, item );
 	} );
 }
+
+MediaStore.getDirtyImage = () => {
+	return MediaStore._dirtyImageRef;
+};
 
 MediaStore.get = function( siteId, postId ) {
 	if ( ! ( siteId in MediaStore._media ) ) {

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -17,8 +17,7 @@ import { isItemBeingUploaded } from 'lib/media/utils';
  */
 const MediaStore = {
 	_media: {},
-	_pointers: {},
-	_dirtyImageRef: null
+	_pointers: {}
 };
 
 emitter( MediaStore );
@@ -47,10 +46,6 @@ function receiveSingle( siteId, item, itemId ) {
 	}
 
 	MediaStore._media[ siteId ][ item.ID ] = item;
-
-	if ( item.isDirty ) {
-		MediaStore._dirtyImageRef = MediaStore._media[ siteId ][ item.ID ];
-	}
 }
 
 function removeSingle( siteId, item ) {
@@ -66,14 +61,6 @@ function receivePage( siteId, items ) {
 		receiveSingle( siteId, item );
 	} );
 }
-
-MediaStore.getDirtyImage = () => {
-	if ( MediaStore._dirtyImageRef && MediaStore._dirtyImageRef.isDirty ) {
-		return MediaStore._dirtyImageRef;
-	}
-
-	return null;
-};
 
 MediaStore.get = function( siteId, postId ) {
 	if ( ! ( siteId in MediaStore._media ) ) {

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -68,7 +68,11 @@ function receivePage( siteId, items ) {
 }
 
 MediaStore.getDirtyImage = () => {
-	return MediaStore._dirtyImageRef;
+	if ( MediaStore._dirtyImageRef && MediaStore._dirtyImageRef.isDirty ) {
+		return MediaStore._dirtyImageRef;
+	}
+
+	return null;
 };
 
 MediaStore.get = function( siteId, postId ) {


### PR DESCRIPTION
Fixes #9036. After editing an inserted image in a post/page, let's update its url in the post/page as it is changed on the backend.

## Testing instructions

1. Open a post/page and insert an image;
2. Edit the image in image editor and click "Done";
3. Verify that the inserted image has correct (updated) url

## Todo

- [x] After editing an image, update it in post/page as a transient one (use the edited image from client if possible). Update the image again once it has been successfully uploaded to a server.


/cc @gwwar @aduth @timmyc 