### PR TITLE
Site: improve alt text for previewing a site

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -202,10 +202,7 @@ export default React.createClass( {
 							href={ this.props.homeLink ? site.URL : this.props.href }
 							data-tip-target={ this.props.tipTarget }
 							target={ this.props.externalLink && ! this.state.showMoreActions && '_blank' }
-							title={ this.props.homeLink
-								? this.translate( 'View "%(title)s"', { args: { title: site.title } } )
-								: site.title
-							}
+							title={ this.translate( 'Preview your site' ) }
 							onTouchTap={ this.onSelect }
 							onClick={ this.props.onClick }
 							onMouseEnter={ this.onMouseEnter }

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -202,7 +202,10 @@ export default React.createClass( {
 							href={ this.props.homeLink ? site.URL : this.props.href }
 							data-tip-target={ this.props.tipTarget }
 							target={ this.props.externalLink && ! this.state.showMoreActions && '_blank' }
-							title={ this.translate( 'Preview your site' ) }
+							title={ this.props.homeLink
+								? this.translate( 'Preview this site' )
+								: this.translate( 'Open this site' )
+							}
 							onTouchTap={ this.onSelect }
 							onClick={ this.props.onClick }
 							onMouseEnter={ this.onMouseEnter }

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -203,8 +203,8 @@ export default React.createClass( {
 							data-tip-target={ this.props.tipTarget }
 							target={ this.props.externalLink && ! this.state.showMoreActions && '_blank' }
 							title={ this.props.homeLink
-								? this.translate( 'Preview this site' )
-								: this.translate( 'Open this site' )
+								? this.translate( 'View this site' )
+								: this.translate( 'Select this site' )
 							}
 							onTouchTap={ this.onSelect }
 							onClick={ this.props.onClick }


### PR DESCRIPTION
Fixes #6433

Moved from #9086 props @jchimienti89

To test:

1. Open the Live Branch (or test locally)
2. Go to Sites list
3. Hover mouse over sites in the list — should see `Open this site` as alt text
4. Click into a site
5. Hover mouse over the site title — should see `Preview this site` as alt text