### PR TITLE
Reader Stream Refresh: Fix space under image for narrow widths

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -192,6 +192,14 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	.reader-post-card__post-details {
 		flex: 1;
+
+		@media #{$reader-post-card-breakpoint-medium} {
+			margin-top: 8px;
+		}
+
+		@media #{$reader-post-card-breakpoint-small} {
+			margin-top: 8px;
+		}
 	}
 
 	@media #{$reader-post-card-breakpoint-large} {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9012

Note that the space under the header is fixed in a separate PR: https://github.com/Automattic/wp-calypso/pull/9100

**Before:**
![screenshot 2016-11-02 11 57 32](https://cloud.githubusercontent.com/assets/4924246/19943254/d84e8d2e-a0f3-11e6-8537-d572656f7058.png)

![screenshot 2016-11-02 11 57 24](https://cloud.githubusercontent.com/assets/4924246/19943259/da1f7e60-a0f3-11e6-8fea-162c13c001e7.png)

After:
![screenshot 2016-11-02 11 56 02](https://cloud.githubusercontent.com/assets/4924246/19943270/e3202352-a0f3-11e6-82a2-c23b6a13de22.png)

![screenshot 2016-11-02 11 56 38](https://cloud.githubusercontent.com/assets/4924246/19943280/e8be0ca2-a0f3-11e6-88ff-33c120a59801.png)
