### PR TITLE
Reader Stream Refresh: Fix header spacing nits

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -108,6 +108,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	font-size: 13px;
 }
 
+.reader-post-card__byline .reader-avatar,
+.reader-post-card__byline .site-iconm {
+	margin-right: 6px;
+}
+
 .reader-post-card__author::after {
 	content: ', ';
 }
@@ -123,7 +128,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .reader-post-card__byline-details {
 	color: $blue-medium;
-	margin-top: -2px;
 	width: 100%;
 }
 
@@ -131,7 +135,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	display: flex;
 	flex-direction: row;
 	align-items: flex-start;
-	margin-top: 1px;
+	margin-top: -2px;
 }
 
 .reader-post-card__timestamp {
@@ -310,7 +314,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	padding: 0;
 	position: absolute;
 		right: 0;
-		top: 16px;
+		top: 18px;
 
 	.gridicon {
 		fill: $blue-medium;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -108,11 +108,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	font-size: 13px;
 }
 
-.reader-post-card__byline .reader-avatar,
-.reader-post-card__byline .site-iconm {
-	margin-right: 6px;
-}
-
 .reader-post-card__author::after {
 	content: ', ';
 }
@@ -163,20 +158,30 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	fill: lighten( $gray, 10% );
 }
 
-.reader-post-card .reader-avatar .gravatar,
-.reader-post-card .reader-avatar .site-icon {
-	float: left;
-	height: 32px;
-	margin: 2px 6px 0 0;
-	vertical-align: text-top;
-	width: 32px;
-}
+.reader-post-card__byline .reader-avatar {
 
-.reader-post-card .reader-avatar .site-icon {
-	width: 32px !important;
-	height: 32px !important;
-	font-size: 32px !important;
-	line-height: 32px !important;
+	&.has-gravatar {
+		margin-right: 6px;
+	}
+
+	.gravatar {
+		float: left;
+		height: 32px;
+		margin: 2px 6px 0 0;
+		vertical-align: text-top;
+		width: 32px;
+	}
+
+	&.has-site-icon {
+		margin: 0 9px 0 -1px;
+	}
+
+	.site-icon {
+		width: 32px !important;
+		height: 32px !important;
+		font-size: 32px !important;
+		line-height: 32px !important;
+	}
 }
 
 .reader-post-card .has-site-and-author-icon .gravatar {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8990

**Before:**
![screenshot 2016-11-02 13 40 34](https://cloud.githubusercontent.com/assets/4924246/19946651/0614f122-a102-11e6-8d8e-657efb5c6b7a.png)

**After:**
![screenshot 2016-11-02 13 36 17](https://cloud.githubusercontent.com/assets/4924246/19946647/0287ebc2-a102-11e6-8289-edcc513bbc75.png)
