### PR TITLE
Theme Showcase: Prevent re-fetching themes that are already fetched server-side

### DIFF
--- a/client/components/data/themes-list-fetcher/index.jsx
+++ b/client/components/data/themes-list-fetcher/index.jsx
@@ -83,14 +83,14 @@ const ThemesListFetcher = React.createClass( {
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? props.tier : 'free';
 
 		this.props.query( {
-			search,
-			tier,
-			filter: props.filter,
-			page: 0,
-			perPage: PER_PAGE,
+			params: {
+				search,
+				tier,
+				filter: props.filter,
+				perPage: PER_PAGE,
+			},
+			site
 		} );
-
-		this.props.fetchNextPage( site );
 	},
 
 	fetchNextPage: function( options ) {

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -11,7 +11,7 @@ import MultiSiteComponent from 'my-sites/themes/multi-site';
 import LoggedOutComponent from './logged-out';
 import trackScrollPage from 'lib/track-scroll-page';
 import { getAnalyticsData } from './helpers';
-import { fetchNextPage, query } from 'state/themes/actions';
+import { query } from 'state/themes/actions';
 import { PER_PAGE } from 'state/themes/themes-list/constants';
 
 function getProps( context ) {
@@ -83,13 +83,16 @@ export function fetchThemeData( context, next ) {
 	}
 
 	const queryParams = {
-		search: context.query.s,
-		tier: context.params.tier,
-		filter: context.params.filter,
-		page: 0,
+		search: context.query.s || '',
+		tier: context.params.tier || '',
+		filter: context.params.filter || '',
 		perPage: PER_PAGE,
 	};
 
-	context.store.dispatch( query( queryParams ) );
-	context.store.dispatch( fetchNextPage( false ) ).then( () => next() );
+	context.store.dispatch(
+		query( {
+			params: queryParams,
+			site: false
+		} )
+	).then( () => next() );
 }

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -60,10 +60,35 @@ export function fetchNextPage( site ) {
 	};
 }
 
-export function query( params ) {
-	return {
-		type: THEMES_QUERY,
-		params: params
+function haveQueryParamsChanged( oldQueryParams, newQueryParams ) {
+	const relevantParams = [ 'search', 'filter', 'tier', 'perPage' ];
+	return relevantParams.filter(
+		param => oldQueryParams[ param ] !== newQueryParams[ param ]
+	).length > 0;
+}
+
+/**
+ * If the passed-in query params differ from the current ones, reset the query
+ * state using the new params and fetch the first page of data
+ *
+ * @return {Object}  Promise representing the first page of data fetched, or an empty object if no fetch is made
+ */
+export function query( { params, site } ) {
+	return ( dispatch, getState ) => {
+		const currentQueryParams = getQueryParams( getState() );
+		if ( ! haveQueryParamsChanged( currentQueryParams, params ) ) {
+			// These are the same query params we've been working with, do nothing
+			return Promise.resolve( { } );
+		}
+
+		// The query params have changed. Reset the query and the list of themes...
+		dispatch( {
+			type: THEMES_QUERY,
+			params: params
+		} );
+
+		// ... and fetch the first page of new data using these new queries
+		return dispatch( fetchNextPage( site ) );
 	};
 }
 

--- a/client/state/themes/themes-list/reducer.js
+++ b/client/state/themes/themes-list/reducer.js
@@ -21,6 +21,8 @@ import {
 
 const defaultQuery = fromJS( {
 	search: '',
+	filter: '',
+	tier: '',
 	perPage: PER_PAGE,
 	page: 0
 } );
@@ -103,7 +105,7 @@ export default ( state = initialState, action ) => {
 		case DESERIALIZE:
 			return initialState;
 		case SERVER_DESERIALIZE:
-			return query( fromJS( state ) );
+			return fromJS( state ).set( 'list', state.list );
 		case SERIALIZE:
 			return {};
 	}


### PR DESCRIPTION
WIP, looking for feedback on this approach.

Server-fetched Theme Showcase data is ignored on client render, and that's what I'm trying to fix. See how there's a flip back to "placeholder" boxes when the client render starts ([screengrab courtesy @seear](https://github.com/Automattic/wp-calypso/pull/8942#issuecomment-257556539)):

![](https://cloud.githubusercontent.com/assets/7767559/19889999/10bbcdbc-a030-11e6-99d6-d4867c1495b2.gif)

I'd chatted with @ockham about possibly using [ThemeQueryManager](https://github.com/Automattic/wp-calypso/tree/master/client/lib/query-manager/theme) to keep track of what queries have already been fetched. But after getting my head around things a bit more, that would require some big changes to the state tree, and it's probably not a complete solution on its own. 

**So this PR represents a minimal-change solution to the overfetching problem.** I think there's still some core issues to be addressed for long-term stability, but I'm wary of making big changes to the state tree, when I still don't fully grasp how far it reaches and what the edge cases are. So this is kind of duct-tape to hopefully understand the problem better and solicit some feedback on the best way forward.

I'll fix broken tests and write some new ones if this seems like an OK solution for now.