### PR TITLE
Reader Refresh: renamed two of the post-normalizer rules

### DIFF
--- a/client/lib/feed-post-store/test/lib/post-normalizer.js
+++ b/client/lib/feed-post-store/test/lib/post-normalizer.js
@@ -15,7 +15,7 @@ function noopFactory() {
 
 fakeNormalize.content = {};
 
-[ 'safeContentImages' ].forEach( function( prop ) {
+[ 'makeImagesSafe' ].forEach( function( prop ) {
 	fakeNormalize.content[ prop ] = noopFactory;
 } );
 

--- a/client/lib/feed-stream-store/test/lib/post-normalizer.js
+++ b/client/lib/feed-stream-store/test/lib/post-normalizer.js
@@ -15,7 +15,7 @@ function noopFactory() {
 
 fakeNormalize.content = {};
 
-[ 'safeContentImages' ].forEach( function( prop ) {
+[ 'makeImagesSafe' ].forEach( function( prop ) {
 	fakeNormalize.content[ prop ] = noopFactory;
 } );
 

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -110,8 +110,8 @@ normalizePost.withContentDOM = function( transforms ) {
 };
 
 import removeStyles from './rule-content-remove-styles';
-import safeContentImages from './rule-content-safe-images';
-import makeEmbedsSecure from './rule-content-make-embeds-secure';
+import makeImagesSafe from './rule-content-make-images-safe';
+import makeEmbedsSafe from './rule-content-make-embeds-safe';
 import wordCountAndReadingTime from './rule-content-word-count';
 import detectEmbeds from './rule-content-detect-embeds';
 import detectMedia from './rule-content-detect-media';
@@ -120,8 +120,8 @@ import detectPolls from './rule-content-detect-polls';
 
 normalizePost.content = {
 	removeStyles,
-	safeContentImages,
-	makeEmbedsSecure,
+	makeImagesSafe,
+	makeEmbedsSafe,
 	wordCountAndReadingTime,
 	detectEmbeds,
 	detectMedia,

--- a/client/lib/post-normalizer/rule-content-make-embeds-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-embeds-safe.js
@@ -8,7 +8,7 @@ import startsWith from 'lodash/startsWith';
  * Internal Dependencies
  */
 
-export default function makeEmbedsSecure( post, dom ) {
+export default function makeEmbedsSafe( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -62,7 +62,7 @@ function isCandidateForContentImage( imageUrl ) {
 }
 
 export default function( maxWidth ) {
-	return function safeContentImages( post, dom ) {
+	return function makeImagesSafe( post, dom ) {
 		let content_images = [],
 			images;
 

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -42,8 +42,8 @@ describe( 'index', function() {
 			normalizer.withContentDOM(),
 			normalizer.withContentDOM( [
 				normalizer.content.removeStyles,
-				normalizer.content.safeContentImages( 300 ),
-				normalizer.content.makeEmbedsSecure,
+				normalizer.content.makeImagesSafe( 300 ),
+				normalizer.content.makeEmbedsSafe,
 				normalizer.content.detectEmbeds,
 				normalizer.content.wordCountAndReadingTime
 			] ),
@@ -387,13 +387,13 @@ describe( 'index', function() {
 		} );
 	} );
 
-	describe( 'content.safeContentImages', function() {
+	describe( 'content.makeImagesSafe', function() {
 		it( 'can route all images through wp-safe-image if no size specified', function( done ) {
 			normalizer(
 				{
 					content: '<img src="http://example.com/example.jpg"><img src="http://example.com/example2.jpg">'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages() ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE"><img src="http://example.com/example2.jpg-SAFE">' );
 					done( err );
 				}
@@ -406,7 +406,7 @@ describe( 'index', function() {
 					URL: 'http://example.wordpress.com/?post=123',
 					content: '<img src="/example.jpg"><img src="example2.jpg">'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages() ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '<img src="http://example.wordpress.com/example.jpg-SAFE"><img src="http://example.wordpress.com/example2.jpg-SAFE">' );
 					done( err );
 				}
@@ -419,7 +419,7 @@ describe( 'index', function() {
 					URL: 'http://example.wordpress.com/2015/01/my-post/',
 					content: '<img src="../../../example.jpg">'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages() ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '<img src="http://example.wordpress.com/example.jpg-SAFE">' );
 					done( err );
 				}
@@ -431,7 +431,7 @@ describe( 'index', function() {
 				{
 					content: '<img src="http://example.com/example.jpg"><img src="http://example.com/example2.jpg">'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages( 400 ) ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe( 400 ) ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE?w=400&amp;quality=80&amp;strip=info"><img src="http://example.com/example2.jpg-SAFE?w=400&amp;quality=80&amp;strip=info">' );
 					done( err );
 				}
@@ -444,7 +444,7 @@ describe( 'index', function() {
 				{
 					content: '<img width="700" height="700" src="http://example.com/example.jpg?nope">'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages( 400 ) ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe( 400 ) ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '' );
 					done( err );
 				}
@@ -457,7 +457,7 @@ describe( 'index', function() {
 				{
 					content: '<img onload="hi" onerror="there" src="http://example.com/example.jpg">'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages() ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE">' );
 					done( err );
 				}
@@ -469,7 +469,7 @@ describe( 'index', function() {
 				{
 					content: '<img src="http://example.com/example.jpg" srcset="http://example.com/example-100.jpg 100w, http://example.com/example-600.jpg 600w">'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages() ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE" srcset="http://example.com/example-100.jpg-SAFE 100w, http://example.com/example-600.jpg-SAFE 600w">' );
 					done( err );
 				}
@@ -481,7 +481,7 @@ describe( 'index', function() {
 				{
 					content: '<img src="http://example.com/example.jpg" srcset="http://example.com/example-100-and-a-half.jpg 100.5w, http://example.com/example-600.jpg 600w">'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages() ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE">' );
 					done( err );
 				}
@@ -712,13 +712,13 @@ describe( 'index', function() {
 		} );
 	} );
 
-	describe( 'content.makeEmbedsSecure', function() {
+	describe( 'content.makeEmbedsSafe', function() {
 		it( 'makes iframes safe, rewriting to ssl and sandboxing', function( done ) {
 			normalizer(
 				{
 					content: '<iframe src="http://example.com"></iframe>'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSecure ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ], function( err, normalized ) {
 					assert.strictEqual( normalized.content, '<iframe src="https://example.com/" sandbox=""></iframe>' );
 					done( err );
 				}
@@ -730,7 +730,7 @@ describe( 'index', function() {
 				{
 					content: '<iframe src=""></iframe>'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSecure ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ], function( err, normalized ) {
 					assert.strictEqual( normalized.content, '' );
 					done( err );
 				}
@@ -743,7 +743,7 @@ describe( 'index', function() {
 					is_external: true,
 					content: '<object data="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="></object>'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSecure ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ], function( err, normalized ) {
 					assert.strictEqual( normalized.content, '' );
 					done( err );
 				}
@@ -756,7 +756,7 @@ describe( 'index', function() {
 					is_external: true,
 					content: '<embed src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">'
 				},
-				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSecure ] ) ], function( err, normalized ) {
+				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ], function( err, normalized ) {
 					assert.strictEqual( normalized.content, '' );
 					done( err );
 				}

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -137,7 +137,7 @@ var utils = {
 				postNormalizer.firstPassCanonicalImage,
 				postNormalizer.withContentDOM( [
 					postNormalizer.content.removeStyles,
-					postNormalizer.content.safeContentImages( imageWidth )
+					postNormalizer.content.makeImagesSafe( imageWidth )
 				] )
 			],
 			callback

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -21,9 +21,9 @@ import createBetterExcerpt from 'lib/post-normalizer/rule-create-better-excerpt'
 import detectEmbeds from 'lib/post-normalizer/rule-content-detect-embeds';
 import detectMedia from 'lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'lib/post-normalizer/rule-content-detect-polls';
-import makeEmbedsSecure from 'lib/post-normalizer/rule-content-make-embeds-secure';
+import makeEmbedsSafe from 'lib/post-normalizer/rule-content-make-embeds-safe';
 import removeStyles from 'lib/post-normalizer/rule-content-remove-styles';
-import safeImages from 'lib/post-normalizer/rule-content-safe-images';
+import makeImagesSafe from 'lib/post-normalizer/rule-content-make-images-safe';
 import wordCount from 'lib/post-normalizer/rule-content-word-count';
 import { disableAutoPlayOnMedia, disableAutoPlayOnEmbeds } from 'lib/post-normalizer/rule-content-disable-autoplay';
 import decodeEntities from 'lib/post-normalizer/rule-decode-entities';
@@ -141,9 +141,9 @@ const fastPostNormalizationRules = flow( [
 	firstPassCanonicalImage,
 	withContentDom( [
 		removeStyles,
-		safeImages( READER_CONTENT_WIDTH ),
+		makeImagesSafe( READER_CONTENT_WIDTH ),
 		discoverFullBleedImages,
-		makeEmbedsSecure,
+		makeEmbedsSafe,
 		disableAutoPlayOnEmbeds,
 		disableAutoPlayOnMedia,
 		detectEmbeds,


### PR DESCRIPTION
Splitting up #9051 into two PRs. Part of #8555

This PR is just for renaming two files.
`rule-content-safe-images` --> `rule-content-make-images-safe`
`rule-content-make-embeds-secure` --> `rule-content-make-embeds-safe`