### PR TITLE
Add validation API functions to `undocumented/me`

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -283,6 +283,25 @@ UndocumentedMe.prototype.deleteAccountRecoveryPhone = function( callback ) {
 	return this.wpcom.req.post( args, callback );
 };
 
+UndocumentedMe.prototype.newValidationAccountRecoveryPhone = function( callback ) {
+	var args = {
+		apiVersion: '1.1',
+		path: '/me/account-recovery/phone/validation/new',
+	};
+
+	return this.wpcom.req.post( args, callback );
+};
+
+UndocumentedMe.prototype.validateAccountRecoveryPhone = function( code, callback ) {
+	var args = {
+		apiVersion: '1.1',
+		path: '/me/account-recovery/phone/validation',
+		body: { code },
+	};
+
+	return this.wpcom.req.post( args, callback );
+};
+
 UndocumentedMe.prototype.updateAccountRecoveryEmail = function( email, callback ) {
 	var args = {
 		apiVersion: '1.1',
@@ -299,6 +318,15 @@ UndocumentedMe.prototype.deleteAccountRecoveryEmail = function( callback ) {
 	var args = {
 		apiVersion: '1.1',
 		path: '/me/account-recovery/email/delete'
+	};
+
+	return this.wpcom.req.post( args, callback );
+};
+
+UndocumentedMe.prototype.newValidationAccountRecoveryEmail = function( callback ) {
+	var args = {
+		apiVersion: '1.1',
+		path: '/me/account-recovery/email/validation/new',
 	};
 
 	return this.wpcom.req.post( args, callback );


### PR DESCRIPTION
This PR is part of the account recovery project. Currently, we have no way to validate if the recovery options a user set are valid or not, thus they couldn't serve as reliable ways for recovery. The following endpoints are now in production for validating these options:

* `/me/account-recovery/phone/validation/new`
* `/me/account-recovery/phone/validation`
* `/me/account-recovery/email/validation/new`

This PR simply adds corresponding async functions to `undocumented/me` to communicate with each.

cc @jordwest 