### PR TITLE
Reader: fix emoji height in full post

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -59,6 +59,10 @@
 		height: auto;
 		display: inline;
 		margin: auto;
+
+		&.emoji {
+			height: 1em;
+		}
 	}
 
 	iframe[class^="twitter-"],


### PR DESCRIPTION
In certain circumstances, an emoji can currently display like this:

<img width="768" alt="screen shot 2016-11-03 at 16 30 15" src="https://cloud.githubusercontent.com/assets/17325/19955095/e7db20c8-a1e2-11e6-93e2-953c74167d02.png">

https://wordpress.com/read/feeds/40474296/posts/1209766909

This PR fixes the height of emoji to 1em, so it will now look like this:

<img width="742" alt="screen shot 2016-11-03 at 16 30 27" src="https://cloud.githubusercontent.com/assets/17325/19955104/fa3c2186-a1e2-11e6-8cb1-ca21c858f0d4.png">

### To test

Visit http://calypso.localhost:3000/read/feeds/40474296/posts/1209766909 and make sure the frog displays correctly 🐸 