### PR TITLE
Remove decended sitesList.getSelectedSite() usage from my-sites/sidebar component

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -27,6 +27,7 @@ import SidebarRegion from 'layout/sidebar/region';
 import SiteStatsStickyLink from 'components/site-stats-sticky-link';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getThemeCustomizeUrl as getCustomizeUrl } from 'state/themes/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -107,11 +108,13 @@ export class MySitesSidebar extends Component {
 	}
 
 	getSelectedSite() {
-		if ( this.props.sites.get().length === 1 ) {
-			return this.props.sites.getPrimary();
+		const { selectedSite, sites } = this.props;
+
+		if ( sites.get().length === 1 ) {
+			return sites.getPrimary();
 		}
 
-		return this.props.sites.getSelectedSite();
+		return selectedSite;
 	}
 
 	hasJetpackSites() {
@@ -177,7 +180,7 @@ export class MySitesSidebar extends Component {
 			jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' ),
 			themesLink;
 
-		if ( site && ! site.isCustomizable() ) {
+		if ( site && ! ( site.capabilities && site.capabilities.edit_theme_options ) ) {
 			return null;
 		}
 
@@ -790,7 +793,8 @@ function mapStateToProps( state ) {
 	return {
 		currentUser: getCurrentUser( state ),
 		customizeUrl: getCustomizeUrl( state, null, selectedSiteId ),
-		isJetpack: isJetpackSite( state, selectedSiteId )
+		isJetpack: isJetpackSite( state, selectedSiteId ),
+		selectedSite: getSelectedSite( state ),
 	};
 }
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -27,6 +27,7 @@ import SidebarRegion from 'layout/sidebar/region';
 import SiteStatsStickyLink from 'components/site-stats-sticky-link';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { canCurrentUser } from 'state/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getThemeCustomizeUrl as getCustomizeUrl } from 'state/themes/selectors';
@@ -179,8 +180,9 @@ export class MySitesSidebar extends Component {
 		var site = this.getSelectedSite(),
 			jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' ),
 			themesLink;
+		const { canUserCustomizeSite } = this.props;
 
-		if ( site && ! ( site.capabilities && site.capabilities.edit_theme_options ) ) {
+		if ( site && ! canUserCustomizeSite ) {
 			return null;
 		}
 
@@ -217,6 +219,7 @@ export class MySitesSidebar extends Component {
 		var site = this.getSelectedSite(),
 			menusLink = '/menus' + this.siteSuffix(),
 			showClassicLink = ! config.isEnabled( 'manage/menus' );
+		const { canUserCustomizeSite } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -226,7 +229,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( site.capabilities && ! site.capabilities.edit_theme_options ) {
+		if ( ! canUserCustomizeSite ) {
 			return null;
 		}
 
@@ -792,6 +795,7 @@ function mapStateToProps( state ) {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		currentUser: getCurrentUser( state ),
+		canUserCustomizeSite: canCurrentUser( state, selectedSiteId, 'edit_theme_options' ),
 		customizeUrl: getCustomizeUrl( state, null, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId ),
 		selectedSite: getSelectedSite( state ),


### PR DESCRIPTION
### Aims
This PR aims to remove sitesList.getSelectedSite  part of #9054 and ultimately #8726.

This seems to be the minimal amount of change to remove reference to getSelectedSite.

### Test Plan
I'm not entirely sure how to test this as rigorously as I'd like to but I have checked that the sidebar renders each section the same both before and after the changes.
I'm thinking of a solid way to test type of behaviour, perhaps by mocking a sites attributes... possibly through redux dev tools.
Just thinking out loud for now & open to suggestions but when I have something reliable I'll update this PR :D

### Notes

- I have another branch that utilizes the `canCurrentUser` selector which handles a lot of the `site.capabilities` related logic in a much cleaner way. I think this was a change intended by @ehg  - PR will be up shortly.
- `site.isCustomizable` is not available on the site when selected in this way so for now I've replicated it's logic.
- This PR doesn't aim to tackle any issues with code style, that's mostly addressed in [another PR](https://github.com/Automattic/wp-calypso/pull/9032) (#9032)