### PR TITLE
AsyncLoad and the Editor

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -35,6 +35,7 @@
 @import 'blocks/term-tree-selector/style';
 @import 'components/accordion/style';
 @import 'components/animate/style';
+@import 'components/async-load/style';
 @import 'components/bulk-select/style';
 @import 'components/button/style';
 @import 'components/button-group/style';

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -46,6 +46,6 @@ export default class AsyncLoad extends Component {
 			return this.props.placeholder;
 		}
 
-		return null;
+		return <div className="async-load" />;
 	}
 }

--- a/client/components/async-load/style.scss
+++ b/client/components/async-load/style.scss
@@ -1,0 +1,10 @@
+.async-load {
+	background: lighten( $gray, 22% );
+	border-radius: 20px;
+	content: '';
+	display: block;
+	height: 8px;
+	width: 80px;
+	margin: 0 16px;
+	animation: pulse-light 0.8s ease-in-out infinite;
+}

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import AsyncLoad from 'components/async-load';
 import Button from 'components/button';
 import FormToggle from 'components/forms/form-toggle/compact';
 import Revisions from 'post-editor/editor-revisions';
@@ -17,7 +18,6 @@ import postUtils from 'lib/posts/utils';
 import Popover from 'components/popover';
 import InfoPopover from 'components/info-popover';
 import Tooltip from 'components/tooltip';
-import PostSchedule from 'components/post-schedule';
 import postScheduleUtils from 'components/post-schedule/utils';
 import siteUtils from 'lib/site/utils';
 import { recordStat, recordEvent } from 'lib/posts/stats';
@@ -200,12 +200,13 @@ class EditPostStatus extends Component {
 				onClose={ this.togglePostSchedulePopover }
 			>
 				<div className="edit-post-status__post-schedule">
-					<PostSchedule
+					<AsyncLoad
+						require="components/post-schedule"
 						selectedDay={ selectedDay }
 						timezone={ tz }
 						gmtOffset={ gmt }
-						onDateChange={ this.props.onDateChange }>
-					</PostSchedule>
+						onDateChange={ this.props.onDateChange }
+					/>
 				</div>
 			</Popover>
 		);

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -196,7 +196,7 @@ class EditPostStatus extends Component {
 			<Popover
 				context={ this.refs && this.refs.postStatusTooltip }
 				isVisible={ this.state.showPostSchedulePopover }
-				position="right"
+				position="bottom left"
 				onClose={ this.togglePostSchedulePopover }
 			>
 				<div className="edit-post-status__post-schedule">

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -76,4 +76,9 @@
 	display: block;
 	padding: 0 16px;
 	width: 237px;
+
+	.async-load {
+		margin: 16px 0;
+		width: auto;
+	}
 }

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import EditorAuthor from 'post-editor/editor-author';
+import AsyncLoad from 'components/async-load';
 import EditorDeletePost from 'post-editor/editor-delete-post';
 import EditorPostType from 'post-editor/editor-post-type';
 import EditorSticky from 'post-editor/editor-sticky';
@@ -68,7 +68,13 @@ export default React.createClass( {
 		return (
 			<div className="editor-action-bar">
 				<div className="editor-action-bar__first-group">
-					{ multiUserSite && <EditorAuthor post={ this.props.post } isNew={ this.props.isNew } /> }
+					{ multiUserSite &&
+						<AsyncLoad
+							require="post-editor/editor-author"
+							post={ this.props.post }
+							isNew={ this.props.isNew }
+						/>
+					}
 				</div>
 				<EditorPostType />
 				<div className="editor-action-bar__last-group">

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -43,3 +43,8 @@
 .editor-action-bar__view-post-tooltip .popover__inner {
 	white-space: nowrap;
 }
+
+.editor-action-bar .async-load {
+	max-width: 30%;
+	margin-top: 6px;
+}

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -14,7 +14,6 @@ import Gridicon from 'components/gridicon';
 import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordion';
 import AsyncLoad from 'components/async-load';
 import FormTextarea from 'components/forms/form-textarea';
-import PostFormatsAccordion from 'post-editor/editor-post-formats/accordion';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
 import PostMetadata from 'lib/post-metadata';
 import TrackInputChanges from 'components/track-input-changes';
@@ -131,7 +130,8 @@ const EditorDrawer = React.createClass( {
 		}
 
 		return (
-			<PostFormatsAccordion
+			<AsyncLoad
+				require="post-editor/editor-post-formats/accordion"
 				post={ this.props.post }
 				className="editor-drawer__accordion"
 			/>

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -15,9 +15,6 @@ import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordio
 import AsyncLoad from 'components/async-load';
 import FormTextarea from 'components/forms/form-textarea';
 import PostFormatsAccordion from 'post-editor/editor-post-formats/accordion';
-import Location from 'post-editor/editor-location';
-import Discussion from 'post-editor/editor-discussion';
-import SeoAccordion from 'post-editor/editor-seo-accordion';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
 import PostMetadata from 'lib/post-metadata';
 import TrackInputChanges from 'components/track-input-changes';
@@ -32,7 +29,7 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import { isJetpackMinimumVersion } from 'state/sites/selectors';
 import config from 'config';
-import EditorDrawerFeaturedImage from './featured-image';
+
 import EditorDrawerTaxonomies from './taxonomies';
 import EditorDrawerPageOptions from './page-options';
 import EditorDrawerLabel from './label';
@@ -156,9 +153,11 @@ const EditorDrawer = React.createClass( {
 		}
 
 		return (
-			<EditorDrawerFeaturedImage
+			<AsyncLoad
+				require="./featured-image"
 				site={ this.props.site }
-				post={ this.props.post } />
+				post={ this.props.post }
+			/>
 		);
 	},
 
@@ -206,7 +205,10 @@ const EditorDrawer = React.createClass( {
 		return (
 			<AccordionSection>
 				<EditorDrawerLabel labelText={ this.translate( 'Location' ) } />
-				<Location coordinates={ PostMetadata.geoCoordinates( this.props.post ) } />
+				<AsyncLoad
+					require="post-editor/editor-location"
+					coordinates={ PostMetadata.geoCoordinates( this.props.post ) }
+				/>
 			</AccordionSection>
 		);
 	},
@@ -218,7 +220,8 @@ const EditorDrawer = React.createClass( {
 
 		return (
 			<AccordionSection>
-				<Discussion
+				<AsyncLoad
+					require="post-editor/editor-discussion"
 					site={ this.props.site }
 					post={ this.props.post }
 					isNew={ this.props.isNew }
@@ -239,7 +242,10 @@ const EditorDrawer = React.createClass( {
 		}
 
 		return (
-			<SeoAccordion metaDescription={ PostMetadata.metaDescription( this.props.post ) } />
+			<AsyncLoad
+				require="post-editor/editor-seo-accordion"
+				metaDescription={ PostMetadata.metaDescription( this.props.post ) }
+			/>
 		);
 	},
 

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -78,3 +78,8 @@
 		left: 0;
 		right: 0;
 }
+
+.editor-drawer .async-load {
+	margin: 16px;
+	width: auto;
+}

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -17,11 +17,12 @@ const Card = require( 'components/card' ),
 	StatusLabel = require( 'post-editor/editor-status-label' ),
 	postUtils = require( 'lib/posts/utils' ),
 	siteUtils = require( 'lib/site/utils' ),
-	PostSchedule = require( 'components/post-schedule' ),
 	postActions = require( 'lib/posts/actions' ),
 	Tooltip = require( 'components/tooltip' ),
 	PostListFetcher = require( 'components/post-list-fetcher' ),
 	stats = require( 'lib/posts/stats' );
+
+import AsyncLoad from 'components/async-load';
 
 export default React.createClass( {
 	displayName: 'EditorGroundControl',
@@ -246,13 +247,14 @@ export default React.createClass( {
 				: null;
 
 		return (
-			<PostSchedule
+			<AsyncLoad
+				require="components/post-schedule"
 				selectedDay={ postDate }
 				timezone={ tz }
 				gmtOffset={ gmtOffset }
 				onDateChange={ this.setPostDate }
-				onMonthChange={ this.setCurrentMonth }>
-			</PostSchedule>
+				onMonthChange={ this.setCurrentMonth }
+			/>
 		);
 	},
 

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -69,6 +69,11 @@
 	display: block;
 	padding: 0 16px;
 	width: 237px;
+
+	.async-load {
+		margin: 16px 0;
+		width: auto;
+	}
 }
 
 .editor-ground-control .edit-post-status {

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -18,7 +18,7 @@ import { getEditorPostId, isEditorDraftsVisible } from 'state/ui/editor/selector
 import { toggleEditorDraftsVisible } from 'state/ui/editor/actions';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
-import DraftsButton from 'post-editor/drafts-button';
+import AsyncLoad from 'components/async-load';
 
 function EditorSidebarHeader( { translate, type, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar } ) {
 	const className = classnames( 'editor-sidebar__header', {
@@ -53,7 +53,7 @@ function EditorSidebarHeader( { translate, type, showDrafts, toggleDrafts, allPo
 				</Button>
 			) }
 			{ type === 'post' && (
-				<DraftsButton onClick={ toggleDrafts } />
+				<AsyncLoad require="post-editor/drafts-button" onClick={ toggleDrafts } />
 			) }
 			<Button
 				onClick={ toggleSidebar }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -29,7 +29,6 @@ const actions = require( 'lib/posts/actions' ),
 	SegmentedControlItem = require( 'components/segmented-control/item' ),
 	EditorMobileNavigation = require( 'post-editor/editor-mobile-navigation' ),
 	observe = require( 'lib/mixins/data-observe' ),
-	DraftList = require( 'my-sites/drafts/draft-list' ),
 	InvalidURLDialog = require( 'post-editor/invalid-url-dialog' ),
 	RestorePostDialog = require( 'post-editor/restore-post-dialog' ),
 	VerifyEmailDialog = require( 'post-editor/verify-email-dialog' ),
@@ -38,6 +37,7 @@ const actions = require( 'lib/posts/actions' ),
 	stats = require( 'lib/posts/stats' ),
 	analytics = require( 'lib/analytics' );
 
+import AsyncLoad from 'components/async-load';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-draft/actions';
 import { isEditorDraftsVisible, getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
@@ -271,7 +271,9 @@ const PostEditor = React.createClass( {
 							allPostsUrl={ this.getAllPostsUrl() }
 							toggleSidebar={ this.toggleSidebar } />
 						{ this.props.showDrafts
-							? <DraftList { ...this.props }
+							? <AsyncLoad
+								require="my-sites/drafts/draft-list"
+								{ ...this.props }
 								onTitleClick={ this.toggleSidebar }
 								showAllActionsMenu={ false }
 								siteID={ site ? site.ID : null }


### PR DESCRIPTION
Implements AsyncLoad in different places in the editor and adjusts the base display when no placeholder is passed.

![screen shot 2016-11-03 at 11 56 45](https://cloud.githubusercontent.com/assets/548849/19963426/a282f31e-a1bc-11e6-88ff-58761a9a4980.png)

The post-schedule is a nice reduction:

![screen shot 2016-11-03 at 12 07 09](https://cloud.githubusercontent.com/assets/548849/19963745/15d03a9c-a1be-11e6-9899-864b1b47f888.png)
