### PR TITLE
Jetpack: fix an incorrect slug sent from jetpack 4.3

### DIFF
--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -24,6 +24,12 @@ const getPluginsForSite = function( state, siteId, whitelist = false ) {
 	if ( typeof pluginList === 'undefined' ) {
 		return [];
 	}
+
+	// patch to solve a bug in jp 4.3 ( https://github.com/Automattic/jetpack/issues/5498 )
+	if ( whitelist === 'backups' ) {
+		whitelist = 'vaultpress';
+	}
+
 	return filter( pluginList, ( plugin ) => {
 		if ( !! whitelist ) {
 			return ( whitelist === plugin.slug );
@@ -33,7 +39,7 @@ const getPluginsForSite = function( state, siteId, whitelist = false ) {
 };
 
 const isFinished = function( state, siteId, whitelist = false ) {
-	let pluginList = getPluginsForSite( state, siteId, whitelist );
+	const pluginList = getPluginsForSite( state, siteId, whitelist );
 	if ( pluginList.length === 0 ) {
 		return true;
 	}
@@ -44,7 +50,7 @@ const isFinished = function( state, siteId, whitelist = false ) {
 };
 
 const isInstalling = function( state, siteId, whitelist = false ) {
-	let pluginList = getPluginsForSite( state, siteId, whitelist );
+	const pluginList = getPluginsForSite( state, siteId, whitelist );
 	if ( pluginList.length === 0 ) {
 		return false;
 	}


### PR DESCRIPTION
The Problem
==========

The new jetpack dashboard has some links where premium plans owners can click to go to calypso to autoconfigure their plans. The button that should configure Vaultpress is adding the wrong slug to the redirection link, so it doesn't do anything once in calypso

This is a video of the problem:
https://cloudup.com/cfWn0M57pUd

The solution
============
Well, there's nothing we can do to fix those incoming links , since jetpack 4.3 is already released. So I'm capturing the incorrect slugs and transforming them into "vaultpress".

To test
=====
0. You need a connected jetpack site, with a premium or pro plans. Go to your jetpack dashboard and in the "backups" section, click on the "setup button"
1. Copy the url where you are bein redirected and replace wordpress.com for calypso.localhost:3000
2. Your vaultpress key should be configured on your site


ping @zinigor @ryelle @richardmuscat 
