### PR TITLE
Devdocs: Show upgrade nudge

### DIFF
--- a/client/my-sites/upgrade-nudge/docs/example.jsx
+++ b/client/my-sites/upgrade-nudge/docs/example.jsx
@@ -19,6 +19,7 @@ export default React.createClass( {
 					<UpgradeNudge
 						feature="custom-domain"
 						href="#"
+						shouldDisplay={ () => true }
 					/>
 				</div>
 				<div>
@@ -26,6 +27,7 @@ export default React.createClass( {
 						title="This is a title"
 						message="This is a custom message"
 						icon="customize"
+						shouldDisplay={ () => true }
 						compact
 					/>
 				</div>


### PR DESCRIPTION
Fixes #9006 - upgrade nudge display on `devdocs/blocks`.

**Before**
![screen shot 2016-11-03 at 10 41 52 am](https://cloud.githubusercontent.com/assets/1427136/19970373/2e80a3d0-a1b2-11e6-9bcd-3d43b3d5e007.png)

**After**
![screen shot 2016-11-03 at 10 41 59 am](https://cloud.githubusercontent.com/assets/1427136/19970397/36b13bc8-a1b2-11e6-8707-58737d770ada.png)

/cc @rickybanister, @mtias, @retrofox 