### PR TITLE
State: Add primary site selectors

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -51,7 +51,8 @@ var config = require( 'config' ),
 	syncHandler = require( 'lib/wp/sync-handler' ),
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
 	supportUser = require( 'lib/user/support-user-interop' ),
-	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default;
+	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default,
+	reduxFluxSync = require( 'lib/redux-flux-sync' );
 
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -185,6 +186,8 @@ function reduxStoreReady( reduxStore ) {
 	let layoutSection, validSections = [];
 
 	bindWpLocaleState( reduxStore );
+
+	reduxFluxSync( reduxStore );
 
 	supportUser.setReduxStore( reduxStore );
 

--- a/client/lib/redux-flux-sync/index.js
+++ b/client/lib/redux-flux-sync/index.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import Dispatcher from 'dispatcher';
+import { receiveSites } from 'state/sites/actions';
+
+/**
+ * Object mapping Flux action type to a function which, when called with the
+ * Flux action object, returns a Redux action object to be dispatched to the
+ * Redux store.
+ */
+const SYNC_ACTIONS = {
+	SITES_RECEIVE: ( action ) => receiveSites( action.sites )
+};
+
+/**
+ * Subscribes to the global Flux dispatcher and dispatches to the provided
+ * Redux store instance if an action mapping can be determined when a Flux
+ * action is dispatched.
+ *
+ * @param  {Object} store Redux store instance
+ * @return {String}       Dispatcher subscription ID
+ */
+export default function( store ) {
+	return Dispatcher.register( ( payload ) => {
+		const handler = SYNC_ACTIONS[ payload.action.type ];
+		if ( handler ) {
+			store.dispatch( handler( payload.action ) );
+		}
+	} );
+}

--- a/client/lib/redux-flux-sync/test/index.js
+++ b/client/lib/redux-flux-sync/test/index.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+/**
+ * Internal dependencies
+ */
+import Dispatcher from 'dispatcher';
+import reduxFluxSync from '../';
+import { receiveSites } from 'state/sites/actions';
+
+describe( 'reduxFluxSync', () => {
+	let sandbox, store, dispatch, subscriberId;
+
+	before( () => {
+		chai.use( sinonChai );
+
+		sandbox = sinon.sandbox.create();
+		sandbox.spy( Dispatcher, 'register' );
+		dispatch = sandbox.spy();
+		store = { dispatch };
+	} );
+
+	beforeEach( () => {
+		sandbox.reset();
+		subscriberId = reduxFluxSync( store );
+	} );
+
+	afterEach( () => {
+		Dispatcher.unregister( subscriberId );
+	} );
+
+	after( () => {
+		sandbox.restore();
+	} );
+
+	it( 'should register to the dispatcher', () => {
+		expect( Dispatcher.register ).to.have.been.calledOnce;
+	} );
+
+	it( 'should return a dispatcher subscription ID', () => {
+		expect( subscriberId ).to.be.a( 'string' );
+	} );
+
+	it( 'should dispatch when having received a mapped action', () => {
+		const sites = { 12345678: {
+			ID: 12345678,
+			URL: 'https://example.wordpress.com/'
+		} };
+
+		Dispatcher.handleServerAction( {
+			type: 'SITES_RECEIVE',
+			sites
+		} );
+
+		expect( dispatch ).to.have.been.calledWith( receiveSites( sites ) );
+	} );
+} );

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -6,7 +6,8 @@ var debug = require( 'debug' )( 'calypso:sites-list' ),
 	assign = require( 'lodash/assign' ),
 	find = require( 'lodash/find' ),
 	isEmpty = require( 'lodash/isEmpty' ),
-	some = require( 'lodash/some' );
+	some = require( 'lodash/some' ),
+	Dispatcher = require( 'dispatcher' );
 
 /**
  * Internal dependencies
@@ -17,7 +18,8 @@ var wpcom = require( 'lib/wp' ),
 	Searchable = require( 'lib/mixins/searchable' ),
 	Emitter = require( 'lib/mixins/emitter' ),
 	isPlan = require( 'lib/products-values' ).isPlan,
-	userUtils = require( 'lib/user/utils' );
+	userUtils = require( 'lib/user/utils' ),
+	receiveSites = require( 'state/sites/actions' ).receiveSites;
 
 /**
  * SitesList component
@@ -83,6 +85,7 @@ SitesList.prototype.fetch = function() {
 			return;
 		}
 
+		Dispatcher.handleViewAction( receiveSites( data.sites ) );
 		this.sync( data );
 		this.fetching = false;
 	}.bind( this ) );

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -55,7 +55,8 @@ export const sitesSchema = {
 						user_is_owner: { type: 'boolean' }
 					}
 				},
-				single_user_site: { type: 'boolean' }
+				single_user_site: { type: 'boolean' },
+				is_primary: { type: 'boolean' }
 			}
 		}
 	},

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -73,35 +73,19 @@ export const getSite = createSelector(
 );
 
 /**
- * Returns a the ID of the primary site.
+ * Returns a the primary site object.
  *
  * @param  {Object}   state  Global state tree
- * @return {?Number}         The ID of the primary site
+ * @return {?Object}         The primary site object
  */
-export function getPrimarySiteId( state ) {
+export function getPrimarySite( state ) {
 	const site = find( state.sites.items, 'is_primary' );
 
 	if ( ! site ) {
 		return null;
 	}
 
-	return site.ID;
-}
-
-/**
- * Returns true if the specified WordPress.com site ID is the ID of the primary site.
- *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @return {?Boolean}       Whether this is the primary site
- */
-export function isPrimarySiteId( state, siteId ) {
-	const site = getRawSite( state, siteId );
-	if ( ! site ) {
-		return null;
-	}
-
-	return site.is_primary;
+	return getSite( state, site.ID );
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -73,6 +73,38 @@ export const getSite = createSelector(
 );
 
 /**
+ * Returns a the ID of the primary site.
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?Number}         The ID of the primary site
+ */
+export function getPrimarySiteId( state ) {
+	const site = find( state.sites.items, 'is_primary' );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return site.ID;
+}
+
+/**
+ * Returns true if the specified WordPress.com site ID is the ID of the primary site.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Boolean}       Whether this is the primary site
+ */
+export function isPrimarySiteId( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	return site.is_primary;
+}
+
+/**
  * Returns a filtered array of WordPress.com site IDs where a Jetpack site
  * exists in the set of sites with the same URL.
  *

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -10,6 +10,8 @@ import config from 'config';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	getSite,
+	getPrimarySiteId,
+	isPrimarySiteId,
 	getSiteCollisions,
 	isSiteConflicting,
 	isSingleUserSite,
@@ -85,6 +87,114 @@ describe( 'selectors', () => {
 					unmapped_url: 'https://example.wordpress.com'
 				}
 			} );
+		} );
+	} );
+
+	describe( '#getPrimarySiteId', () => {
+		it( 'should return null if there are no sites', () => {
+			const primarySiteId = getPrimarySiteId( {
+				sites: {
+					items: {}
+				}
+			}, 77203074 );
+
+			expect( primarySiteId ).to.be.null;
+		} );
+
+		it( 'should return the primary site properly if there is one', () => {
+			const primarySiteId = getPrimarySiteId( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							is_primary: false
+						},
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							is_primary: true
+						},
+					}
+				}
+			} );
+
+			expect( primarySiteId ).to.eql( 77203199 );
+		} );
+
+		it( 'should return null if there is no primary site', () => {
+			const primarySiteId = getPrimarySiteId( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							is_primary: false
+						},
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							is_primary: false
+						},
+					}
+				}
+			} );
+
+			expect( primarySiteId ).to.be.null;
+		} );
+	} );
+
+	describe( '#isPrimarySiteId()', () => {
+		it( 'should return null if the site is not known', () => {
+			const isPrimary = isPrimarySiteId( {
+				sites: {
+					items: {}
+				}
+			}, 77203074 );
+
+			expect( isPrimary ).to.be.null;
+		} );
+
+		it( 'it should return true if the site is the primary site', () => {
+			const isPrimary = isPrimarySiteId( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							is_primary: false
+						},
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							is_primary: true
+						},
+					}
+				}
+			}, 77203199 );
+
+			expect( isPrimary ).to.be.true;
+		} );
+
+		it( 'it should return false if the site is not the primary site', () => {
+			const isPrimary = isPrimarySiteId( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							is_primary: false
+						},
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							is_primary: true
+						},
+					}
+				}
+			}, 77203074 );
+
+			expect( isPrimary ).to.be.false;
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -10,8 +10,7 @@ import config from 'config';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	getSite,
-	getPrimarySiteId,
-	isPrimarySiteId,
+	getPrimarySite,
 	getSiteCollisions,
 	isSiteConflicting,
 	isSingleUserSite,
@@ -90,19 +89,19 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getPrimarySiteId', () => {
+	describe( '#getPrimarySite', () => {
 		it( 'should return null if there are no sites', () => {
-			const primarySiteId = getPrimarySiteId( {
+			const primarySite = getPrimarySite( {
 				sites: {
 					items: {}
 				}
-			}, 77203074 );
+			} );
 
-			expect( primarySiteId ).to.be.null;
+			expect( primarySite ).to.be.null;
 		} );
 
-		it( 'should return the primary site properly if there is one', () => {
-			const primarySiteId = getPrimarySiteId( {
+		it( 'should return the normalized primary site if there is one', () => {
+			const primarySite = getPrimarySite( {
 				sites: {
 					items: {
 						77203074: {
@@ -119,11 +118,24 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			expect( primarySiteId ).to.eql( 77203199 );
+			expect( primarySite ).to.eql( {
+				ID: 77203199,
+				URL: 'https://example.com',
+				is_primary: true,
+				domain: 'example.com',
+				hasConflict: false,
+				is_customizable: false,
+				is_previewable: false,
+				options: {
+					default_post_format: 'standard'
+				},
+				slug: 'example.com',
+				title: 'example.com'
+			} );
 		} );
 
 		it( 'should return null if there is no primary site', () => {
-			const primarySiteId = getPrimarySiteId( {
+			const primarySite = getPrimarySite( {
 				sites: {
 					items: {
 						77203074: {
@@ -140,61 +152,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			expect( primarySiteId ).to.be.null;
-		} );
-	} );
-
-	describe( '#isPrimarySiteId()', () => {
-		it( 'should return null if the site is not known', () => {
-			const isPrimary = isPrimarySiteId( {
-				sites: {
-					items: {}
-				}
-			}, 77203074 );
-
-			expect( isPrimary ).to.be.null;
-		} );
-
-		it( 'it should return true if the site is the primary site', () => {
-			const isPrimary = isPrimarySiteId( {
-				sites: {
-					items: {
-						77203074: {
-							ID: 77203074,
-							URL: 'https://testonesite2014.wordpress.com',
-							is_primary: false
-						},
-						77203199: {
-							ID: 77203199,
-							URL: 'https://example.com',
-							is_primary: true
-						},
-					}
-				}
-			}, 77203199 );
-
-			expect( isPrimary ).to.be.true;
-		} );
-
-		it( 'it should return false if the site is not the primary site', () => {
-			const isPrimary = isPrimarySiteId( {
-				sites: {
-					items: {
-						77203074: {
-							ID: 77203074,
-							URL: 'https://testonesite2014.wordpress.com',
-							is_primary: false
-						},
-						77203199: {
-							ID: 77203199,
-							URL: 'https://example.com',
-							is_primary: true
-						},
-					}
-				}
-			}, 77203074 );
-
-			expect( isPrimary ).to.be.false;
+			expect( primarySite ).to.be.null;
 		} );
 	} );
 


### PR DESCRIPTION
This PR does the following:

* Dispatches a Flux action each time the sites list is fetched.
* Introduces a mechanism to sync Flux actions to Redux (as borrowed from #2167).
* Uses the above mechanism to sync the new Flux action to the Redux one, so we receive the sites in the Redux tree.
* Introduces the `getPrimarySite` selector.
* Includes tests for the new selector and the sync module.

It depends on D3252-code, which adds an additional `is_primary` prop to each site.

To test:
* Checkout this branch.
* Point `public-api.wordpress.com` to your sandbox.
* Apply D3252-code on your sandbox.
* Clear your Redux state.
* Go to a page that does not specifically fetch the sites Redux tree (for example `/me`.
* Verify each site from the `/me/sites` request contains a `is_primary` prop, and it's true only for your primary site. If there's no such property, you're using the production API.
* Verify that once `/me/sites` loads, the sites are stored in the `sites.items` Redux tree.
* Verify that the selector tests pass: `npm run test-client client/state/sites/test/selectors.js -- --grep "getPrimarySite"`
* Verify that the sync module tests pass: `npm run test-client client/lib/redux-flux-sync/`