### PR TITLE
Stats: Avoid passing siteId of 0 on Insights

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -82,7 +82,7 @@ export default React.createClass( {
 					<PostingActivity />
 					<LatestPostSummary site={ site } />
 					<TodaysStats
-						siteId={ site ? site.ID : 0 }
+						siteId={ site ? site.ID : null }
 						period="day"
 						date={ summaryDate }
 						path={ '/stats/day' }
@@ -90,7 +90,7 @@ export default React.createClass( {
 					/>
 					<AllTime />
 					<MostPopular />
-					<DomainTip siteId={ site ? site.ID : 0 } event="stats_insights_domain" />
+					{ site && <DomainTip siteId={ site.ID } event="stats_insights_domain" /> }
 					<div className="stats-insights__nonperiodic has-recent">
 						<div className="stats__module-list">
 							<div className="stats__module-column">


### PR DESCRIPTION
Fixes issue noted at https://github.com/Automattic/wp-calypso/pull/5975#discussion_r86022541

This pull request seeks to avoid passing a `siteId` prop of `0` to the Insight's `<TodayStats />` and `<DomainTip />` components. Doing so avoids a `0` text being rendered to the page when the site is not yet available (e.g. fresh localStorage).

__Implementation notes:__

In the case of `<DomainTip />`, since the `siteId` prop is [documented as required](https://github.com/Automattic/wp-calypso/blob/175bc2bf8118260d1a569d96786cb3d1b156c6d4/client/my-sites/domain-tip/index.jsx#L37) and there [is special render logic for non-available site](https://github.com/Automattic/wp-calypso/blob/175bc2bf8118260d1a569d96786cb3d1b156c6d4/client/my-sites/domain-tip/index.jsx#L64-L66), I chose the route of simply not rendering the component if `site.ID` is not available.

__Testing instructions:__

Verify that no `0` text is rendered to the screen when loading Stats Insights with a fresh localStorage.

1. Navigate to [Stats > Insights](http://calypso.localhost:3000/stats/insights)
2. Clear localStorage by entering `localStorage.clear()` in your developer tools console (or Application > Clear storage in Chrome developer tools)
3. Refresh the page
4. Note that there is no `0` rendered to page, and that the "Today's Stats" panel renders accurately after sites have finished loading

cc @gwwar @timmyc