### PR TITLE
Help: Update live course dates

### DIFF
--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -31,20 +31,32 @@ function getCourses() {
 			),
 			schedule: [
 				{
-					date: i18n.moment( new Date( 'Tues, 25 Oct 2016 16:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/1e730113a5c480fb66858a512be5123a'
+					date: i18n.moment( new Date( 'Tues, 8 Nov 2016 17:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/41e6b07223685cefd746f627e8486654'
 				},
 				{
-					date: i18n.moment( new Date( 'Thur, 27 Oct 2016 20:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/4d80dd6869e8e7aec5b9141539e44ee6'
+					date: i18n.moment( new Date( 'Thur, 10 Nov 2016 21:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/ee792031a8a1ac46cde7dc3c8da9331e'
 				},
 				{
-					date: i18n.moment( new Date( 'Tues, 1 Nov 2016 16:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/26e68e03fd2a1c177c24e00bf0acd2b8'
+					date: i18n.moment( new Date( 'Tues, 15 Nov 2016 17:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/77c70936e27841fdc5b9141539e44ee6'
 				},
 				{
-					date: i18n.moment( new Date( 'Thur, 3 Nov 2016 20:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/eb5b3d79f1212d2b66858a512be5123a'
+					date: i18n.moment( new Date( 'Thur, 17 Nov 2016 21:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/54616e2abdab5bc0c5b9141539e44ee6'
+				},
+				{
+					date: i18n.moment( new Date( 'Tues, 22 Nov 2016 17:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/55cfed1ec7ebbe7a66858a512be5123a'
+				},
+				{
+					date: i18n.moment( new Date( 'Tues, 29 Nov 2016 17:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/5befd4070efdbacdd746f627e8486654'
+				},
+				{
+					date: i18n.moment( new Date( 'Thur, 1 Dec 2016 21:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/2b9f02639a37b3c034538d7d4481ef37'
 				},
 			],
 			videos: [


### PR DESCRIPTION
This PR updates the live course dates for Business customers on /help/courses throughout November and into December. The tricky part about this is that Daylight Savings Time ends on Nov 6. I used World Time Buddy ([link to view](http://www.worldtimebuddy.com/?pl=1&lid=5368361,100&h=5368361&date=11/8/2016%7C6)) to interpret what time to use in UTC format.

We should show the following (with link):

- 11/8 Tuesday 9am Pacific: https://zoom.us/webinar/register/41e6b07223685cefd746f627e8486654
- 11/10 Thursday 1pm Pacific: https://zoom.us/webinar/register/ee792031a8a1ac46cde7dc3c8da9331e
- 11/15 Tuesday 9am Pacific: https://zoom.us/webinar/register/77c70936e27841fdc5b9141539e44ee6
- 11/17 Thursday 1pm Pacific: https://zoom.us/webinar/register/54616e2abdab5bc0c5b9141539e44ee6
- 11/22 Tuesday 9am Pacific: https://zoom.us/webinar/register/55cfed1ec7ebbe7a66858a512be5123a
- 11/29 Tuesday 9am Pacific: https://zoom.us/webinar/register/5befd4070efdbacdd746f627e8486654
- 12/1 Thursday 1pm Pacific: https://zoom.us/webinar/register/2b9f02639a37b3c034538d7d4481ef37

I think I did the UTC time conversion right, but in any case, I'll set a reminder to check on Sunday morning when I wake up just in case. 

### To test
1. Load up this branch and open /help/courses on an account with a Business bundle.
2. Check the registration URLs to make sure they're correct for the given date