### PR TITLE
Jetpack: Don't show DomainWarnings in current plan for Jetpack sites

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -15,6 +15,7 @@ import {
 	isCurrentPlanExpiring
 } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlansNavigation from 'my-sites/upgrades/navigation';
 import ProductPurchaseFeatures from 'blocks/product-purchase-features';
@@ -97,7 +98,8 @@ class CurrentPlan extends Component {
 			sitePlans,
 			context,
 			currentPlan,
-			isExpiring
+			isExpiring,
+			isJetpack
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug,
@@ -109,7 +111,7 @@ class CurrentPlan extends Component {
 			<Main className="current-plan" wideLayout>
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
-				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
+				{ selectedSiteId && ! isJetpack && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
 				<PlansNavigation
 					sitePlans={ sitePlans }
@@ -117,7 +119,7 @@ class CurrentPlan extends Component {
 					selectedSite={ selectedSite }
 				/>
 
-				{ this.renderDomainWarnings() }
+				{ ! isJetpack && this.renderDomainWarnings() }
 
 				<ProductPurchaseFeatures>
 					<CurrentPlanHeader
@@ -151,8 +153,9 @@ export default connect(
 			selectedSiteId,
 			sitePlans: getPlansBySite( state, selectedSite ),
 			context: ownProps.context,
-			currentPlan: getCurrentPlan( state, getSelectedSiteId( state ) ),
-			isExpiring: isCurrentPlanExpiring( state, getSelectedSiteId( state ) ),
+			currentPlan: getCurrentPlan( state, selectedSiteId ),
+			isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
+			isJetpack: isJetpackSite( state, selectedSiteId ),
 			domains: getDecoratedSiteDomains( state, selectedSiteId ),
 			hasDomainsLoaded: ! isRequestingSiteDomains( state, selectedSiteId )
 		};


### PR DESCRIPTION
`DomainWarnings` were unnecessarily shown on the current plan's view. Since we don't support domain management for Jetpack sites in Calypso, they did not make sense - and in some cases lead to bugs like #8903.

*Testing*
For non-Jetpack sites:
 * make sure the domains endpoint is hit when checking current site and/or current plan.
 * check a site with an expiring/expired domain (or one that has non-wpcom nameservers) or just hack the component to verify that the warnings are shown.

For Jetpack sites make sure the opposite is happening 😀 No `domains` fetching and certainly no domain warnings.

/cc @lamosty @gwwar @kraftbj 

Fixes #8903