### PR TITLE
Reader: Fix photo card spacing

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -99,6 +99,14 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				font-size: 12px;
 				letter-spacing: 0.01em;
 			}
+
+			.reader-post-actions {
+				margin: 8px 0 0;
+			}
+
+			.reader-post-actions .reader-post-actions__visit {
+				margin-left: -3px;
+			}
 		}
 	}
 
@@ -265,11 +273,15 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	font-size: 14px;
 	height: 22px;
 
-	&.reader-post-actions__visit .gridicon {
-		fill: lighten( $gray, 10% );
-		position: relative;
-			left: -8px;
-			top: -1px;
+	&.reader-post-actions__visit {
+		margin-left: -2px;
+
+		.gridicon {
+			fill: lighten( $gray, 10% );
+			position: relative;
+				left: -8px;
+				top: -1px;
+		}
 	}
 
 	.gridicons-external {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/8895

Also fixes "Visit" alignment for non-photo cards.

**Before:**
![screenshot 2016-11-03 14 53 51](https://cloud.githubusercontent.com/assets/4924246/19987197/2a4a288e-a1d7-11e6-986d-21f10f12e24c.png)

**After:**
![screenshot 2016-11-03 14 54 31](https://cloud.githubusercontent.com/assets/4924246/19987217/4a9cab7a-a1d7-11e6-870b-b7d6d8949f3b.png)
