### PR TITLE
Reader Stream Refresh: Fix long links in cards

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -258,6 +258,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	line-height: 1.6;
 	font-weight: 100;
 	margin-top: 5px;
+	word-break: break-word;
 }
 
 // Action buttons in post card


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9090

**Before:**
![screenshot 2016-11-03 15 22 26](https://cloud.githubusercontent.com/assets/4924246/19987673/a262d6ac-a1d9-11e6-8272-2c14f651b3de.png)

**After:**
![screenshot 2016-11-03 15 22 44](https://cloud.githubusercontent.com/assets/4924246/19987677/a5ba75da-a1d9-11e6-968f-795c907421ea.png)
