### PR TITLE
Reader Search: use ReaderPostCard instead of SearchCard

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -3,8 +3,9 @@
  */
 import React from 'react';
 import ReactDom from 'react-dom';
-import { trim } from 'lodash';
+import { trim, sampleSize } from 'lodash';
 import closest from 'component-closest';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -19,14 +20,12 @@ import SearchInput from 'components/search';
 import SiteStore from 'lib/reader-site-store';
 import FeedStore from 'lib/feed-store';
 import { recordTrackForPost } from 'reader/stats';
-import sampleSize from 'lodash/sampleSize';
 import i18nUtils from 'lib/i18n-utils';
 import { staffSuggestions, popularSuggestions } from './suggestions';
 import { abtest } from 'lib/abtest';
 import SearchCard from 'blocks/reader-search-card';
 import ReaderPostCard from 'blocks/reader-post-card';
 import config from 'config';
-import { localize } from 'i18n-calypso';
 
 const SearchCardAdapter = React.createClass( {
 	getInitialState() {
@@ -77,15 +76,15 @@ const SearchCardAdapter = React.createClass( {
 
 	render() {
 		const isRefreshedStream = config.isEnabled( 'reader/refresh/stream' );
-		const cardComponent = isRefreshedStream ? ReaderPostCard : SearchCard;
-		return React.createElement( cardComponent, {
-			post: this.props.post,
-			site: this.props.site,
-			feed: this.props.feed,
-			onClick: isRefreshedStream ? this.onRefreshCardClick : this.onCardClick,
-			onCommentClick: this.onCommentClick,
-			showPrimaryFollowButton: this.props.showPrimaryFollowButtonOnCards
-		} );
+		const CardComponent = isRefreshedStream ? ReaderPostCard : SearchCard;
+		return <CardComponent
+			post={ this.props.post }
+			site={ this.props.site }
+			feed={ this.props.feed }
+			onClick={ isRefreshedStream ? this.onRefreshCardClick : this.onCardClick }
+			onCommentClick={ this.onCommentClick }
+			showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
+		/>;
 	}
 } );
 
@@ -106,7 +105,7 @@ const emptyStore = {
 	off() {}
 };
 
-const FeedStream = React.createClass( {
+const SearchStream = React.createClass( {
 
 	propTypes: {
 		query: React.PropTypes.string
@@ -207,4 +206,4 @@ const FeedStream = React.createClass( {
 	}
 } );
 
-export default localize( FeedStream );
+export default localize( SearchStream );

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -26,6 +26,7 @@ import { abtest } from 'lib/abtest';
 import SearchCard from 'blocks/reader-search-card';
 import ReaderPostCard from 'blocks/reader-post-card';
 import config from 'config';
+import { localize } from 'i18n-calypso';
 
 const SearchCardAdapter = React.createClass( {
 	getInitialState() {
@@ -173,19 +174,19 @@ const FeedStream = React.createClass( {
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
 		if ( ! searchPlaceholderText ) {
-			searchPlaceholderText = this.translate( 'Search billions of WordPress.com posts…' );
+			searchPlaceholderText = this.props.translate( 'Search billions of WordPress.com posts…' );
 		}
 
 		return (
 			<Stream { ...this.props } store={ store }
-				listName={ this.translate( 'Search' ) }
+				listName={ this.props.translate( 'Search' ) }
 				emptyContent={ emptyContent }
 				showDefaultEmptyContentIfMissing={ this.props.showBlankContent }
 				showFollowInHeader={ true }
 				cardFactory={ this.cardFactory }
 				className="search-stream" >
 				{ this.props.showBack && <HeaderBack /> }
-				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: this.state.title || this.translate( 'Search' ) } ) } />
+				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) } ) } />
 				<CompactCard className="search-stream__input-card">
 					<SearchInput
 						initialValue={ this.props.query }
@@ -200,4 +201,4 @@ const FeedStream = React.createClass( {
 	}
 } );
 
-export default FeedStream;
+export default localize( FeedStream );

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -23,7 +23,9 @@ import sampleSize from 'lodash/sampleSize';
 import i18nUtils from 'lib/i18n-utils';
 import { staffSuggestions, popularSuggestions } from './suggestions';
 import { abtest } from 'lib/abtest';
+import SearchCard from 'blocks/reader-search-card';
 import ReaderPostCard from 'blocks/reader-post-card';
+import config from 'config';
 
 const SearchCardAdapter = React.createClass( {
 	getInitialState() {
@@ -68,13 +70,15 @@ const SearchCardAdapter = React.createClass( {
 	},
 
 	render() {
-		return <ReaderPostCard
-			post={ this.props.post }
-			site={ this.state.site }
-			feed={ this.state.feed }
-			onClick={ this.onCardClick }
-			onCommentClick={ this.onCommentClick }
-			showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards } />;
+		const cardComponent = config.isEnabled( 'reader/refresh/stream' ) ? ReaderPostCard : SearchCard;
+		return React.createElement( cardComponent, {
+			post: this.props.post,
+			site: this.props.site,
+			feed: this.props.feed,
+			onClick: this.onCardClick,
+			onCommentClick: this.onCommentClick,
+			showPrimaryFollowButton: this.props.showPrimaryFollowButtonOnCards
+		} );
 	}
 } );
 

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -66,17 +66,25 @@ const SearchCardAdapter = React.createClass( {
 		this.props.handleClick( this.props.post, {} );
 	},
 
+	onRefreshCardClick( post ) {
+		recordTrackForPost( 'calypso_reader_searchcard_clicked', this.props.post );
+
+		event.preventDefault();
+		this.props.handleClick( post, {} );
+	},
+
 	onCommentClick() {
 		this.props.handleClick( this.props.post, { comments: true } );
 	},
 
 	render() {
-		const cardComponent = config.isEnabled( 'reader/refresh/stream' ) ? ReaderPostCard : SearchCard;
+		const isRefreshedStream = config.isEnabled( 'reader/refresh/stream' );
+		const cardComponent = isRefreshedStream ? ReaderPostCard : SearchCard;
 		return React.createElement( cardComponent, {
 			post: this.props.post,
 			site: this.props.site,
 			feed: this.props.feed,
-			onClick: this.onCardClick,
+			onClick: isRefreshedStream ? this.onRefreshCardClick : this.onCardClick,
 			onCommentClick: this.onCommentClick,
 			showPrimaryFollowButton: this.props.showPrimaryFollowButtonOnCards
 		} );

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -68,8 +68,6 @@ const SearchCardAdapter = React.createClass( {
 
 	onRefreshCardClick( post ) {
 		recordTrackForPost( 'calypso_reader_searchcard_clicked', this.props.post );
-
-		event.preventDefault();
 		this.props.handleClick( post, {} );
 	},
 

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -16,7 +16,6 @@ import EmptyContent from './empty';
 import BlankContent from './blank';
 import HeaderBack from 'reader/header-back';
 import SearchInput from 'components/search';
-import SearchCard from 'blocks/reader-search-card';
 import SiteStore from 'lib/reader-site-store';
 import FeedStore from 'lib/feed-store';
 import { recordTrackForPost } from 'reader/stats';
@@ -24,6 +23,7 @@ import sampleSize from 'lodash/sampleSize';
 import i18nUtils from 'lib/i18n-utils';
 import { staffSuggestions, popularSuggestions } from './suggestions';
 import { abtest } from 'lib/abtest';
+import ReaderPostCard from 'blocks/reader-post-card';
 
 const SearchCardAdapter = React.createClass( {
 	getInitialState() {
@@ -68,7 +68,7 @@ const SearchCardAdapter = React.createClass( {
 	},
 
 	render() {
-		return <SearchCard
+		return <ReaderPostCard
 			post={ this.props.post }
 			site={ this.state.site }
 			feed={ this.state.feed }

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -52,7 +52,7 @@ export default {
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				showBack: false,
-				showPrimaryFollowButtonOnCards: false,
+				showPrimaryFollowButtonOnCards: true,
 				onQueryChange: function( newValue ) {
 					let searchUrl = '/read/search';
 					if ( newValue ) {


### PR DESCRIPTION
Changes Reader Search to use the ReaderPostCard (as used by the rest of the refreshed streams) instead of the existing SearchCard.

It should look like this:

<img width="892" alt="screen shot 2016-11-04 at 11 34 38" src="https://cloud.githubusercontent.com/assets/17325/19988010/d67a3b48-a282-11e6-800c-78ed89454609.png">

http://calypso.localhost:3000/read/search?q=Beach

Fixes #9077.

### To do
- [x] Fix full post opening
- [x] Check follow button display
- [x] Check search stats are correctly fired