### PR TITLE
Media section: Reintroduce V1

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -244,6 +244,7 @@
 @import 'my-sites/invites/invite-accept-logged-in/style';
 @import 'my-sites/invites/invite-accept/style';
 @import 'my-sites/media-library/style';
+@import 'my-sites/media/style';
 @import 'my-sites/menus/style';
 @import 'my-sites/no-results/style';
 @import 'my-sites/pages/style';

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -1,0 +1,7 @@
+.main.media {
+	max-width: 100%;
+
+	.media-library__list {
+		padding: 0;
+	}
+}

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -78,6 +78,17 @@ const PublishMenu = React.createClass( {
 				buttonLink: site ? '/page/' + site.slug : '/page',
 				wpAdminLink: 'edit.php?post_type=page',
 				showOnAllMySites: true,
+			},
+			{
+				name: 'media',
+				label: this.translate( 'Media' ),
+				className: 'media-section',
+				capability: 'upload_files',
+				queryable: true,
+				config: 'manage/media',
+				link: '/media',
+				wpAdminLink: 'upload.php',
+				showOnAllMySites: false,
 			}
 		];
 	},

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -53,7 +53,7 @@ const PublishMenu = React.createClass( {
 	getDefaultMenuItems() {
 		const { site } = this.props;
 
-		return [
+		const items = [
 			{
 				name: 'post',
 				label: this.translate( 'Blog Posts' ),
@@ -78,8 +78,11 @@ const PublishMenu = React.createClass( {
 				buttonLink: site ? '/page/' + site.slug : '/page',
 				wpAdminLink: 'edit.php?post_type=page',
 				showOnAllMySites: true,
-			},
-			{
+			}
+		];
+
+		if ( config.isEnabled( 'manage/media' ) ) {
+			items.push( {
 				name: 'media',
 				label: this.translate( 'Media' ),
 				className: 'media-section',
@@ -89,8 +92,9 @@ const PublishMenu = React.createClass( {
 				link: '/media',
 				wpAdminLink: 'upload.php',
 				showOnAllMySites: false,
-			}
-		];
+			} );
+		}
+		return items;
 	},
 
 	onNavigate( postType ) {

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -16,7 +16,7 @@ var DetailItem = require( './detail-item' ),
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 
-const EditorMediaModalDetail = React.createClass( {
+export const EditorMediaModalDetail = React.createClass( {
 	propTypes: {
 		site: React.PropTypes.object,
 		items: React.PropTypes.array,

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -15,7 +15,6 @@ var MediaLibrary = require( 'my-sites/media-library' ),
 	PostActions = require( 'lib/posts/actions' ),
 	PostStats = require( 'lib/posts/stats' ),
 	MediaModalSecondaryActions = require( './secondary-actions' ),
-	MediaModalDetail = require( './detail' ),
 	MediaModalGallery = require( './gallery' ),
 	MediaActions = require( 'lib/media/actions' ),
 	MediaUtils = require( 'lib/media/utils' ),
@@ -27,6 +26,7 @@ import { resetMediaModalView } from 'state/ui/media-modal/actions';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import ImageEditor from 'blocks/image-editor';
+import MediaModalDetail from './detail';
 
 export const EditorMediaModal = React.createClass( {
 	propTypes: {

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -45,7 +45,7 @@ describe( 'EditorMediaModal', function() {
 
 		// Mockery
 		mockery.registerMock( 'my-sites/media-library', EMPTY_COMPONENT );
-		mockery.registerMock( './detail', EMPTY_COMPONENT );
+		mockery.registerMock( './detail', { 'default': EMPTY_COMPONENT } );
 		mockery.registerMock( './gallery', EMPTY_COMPONENT );
 		mockery.registerMock( './markup', { get: identity } );
 		mockery.registerMock( './secondary-actions', EMPTY_COMPONENT );

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -41,7 +41,7 @@
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
-		"manage/media": true,
+		"manage/media": false,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/pages": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -49,6 +49,7 @@
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
+		"manage/media": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": true,


### PR DESCRIPTION
Reintroduces https://github.com/Automattic/wp-calypso/pull/8619 reverted in #9140
It turned out that sidebar item is not protected by a feature flag as I thought.

## Pics or it didn't happen

<img width="1367" alt="zrzut ekranu 2016-10-30 o 14 27 22" src="https://cloud.githubusercontent.com/assets/3775068/19839456/1c188f46-9eb0-11e6-9ce4-8a7847a87002.png">
### [Video](https://cloudup.com/iq1Pt8XiAHa)

(lags are because of my crappy mexican wifi)
## Testing

- Just try to use media section like you always wanted.
- Make sure to test it with the feature flag ON and OFF

## Future work
- Icon (Need Gridicon, @amylaneio design has a dashicon "media", which we didnt port to gridicons yet)
- Add button
- Space nudge at the bottom

