### PR TITLE
Build: Move react-dom and redux-thunk into vendor, drop debug

### DIFF
--- a/webpack-dll.config.js
+++ b/webpack-dll.config.js
@@ -15,13 +15,14 @@ module.exports = {
 	entry: {
 		vendor: [
 			'classnames',
-			'debug',
 			'i18n-calypso',
 			'moment',
 			'page',
 			'react',
+			'react-dom',
 			'react-redux',
 			'redux',
+			'redux-thunk',
 			'store',
 			'wpcom',
 		]


### PR DESCRIPTION
Drop debug becauase we no-op it for production and if it's in vendor, the no-op doesn't really take.

No functional changes here