### PR TITLE
Reader Refresh: Prefer first media in absence of usable canonical image

### DIFF
--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -2,7 +2,8 @@
  * External Dependencies
  */
 import React from 'react';
-import { find } from 'lodash';
+import { find, endsWith, some, } from 'lodash';
+import url from 'url';
 
 /**
  * Internal Dependencies
@@ -18,42 +19,48 @@ const candidateForFeature = ( media ) => {
 	if ( media.mediaType === 'image' ) {
 		const image = media;
 
-		// image is not wide enough
-		if ( image.naturalWidth < 350 ) {
-			return false;
-		}
+		const imageIsTallEnough = 350 <= image.width || 350 <= image.naturalWidth;
+		const imageIsWideEnough = 85 <= image.height || 85 <= image.naturalHeight;
 
-		// image does not have enough area
-		if ( ( image.naturalWidth * image.naturalHeight ) < 30000 ) {
-			return false;
-		}
+		return imageIsTallEnough && imageIsWideEnough;
 	} else if ( media.mediaType === 'video' ) {
-		// we do not know how to autoplay it
+		// we need to have a thumbnail and know how to autoplay it
 		return media.thumbnailUrl && media.autoplayIframe;
 	}
 
 	return true;
 };
 
+// jetpack lies about thumbnails so we need to make sure its actually an image. See: thumbIsLikelyImage in pick-canonical-image rule
+const uriIsLikelyAnImage = ( uri ) => {
+	const withoutQuery = url.parse( uri ).pathname;
+	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], ext => endsWith( withoutQuery, ext ) );
+};
+
+/**
+ * Given a post:
+ *  1. prefer to return the post's featured image ( post.post_thumbnail )
+ *  2. if there is no usable featured image, use the media that appears first in the content of the post
+ *  3. if there is no eligible asset, return null
+ */
 const FeaturedAsset = ( { post } ) => {
 	if ( ! post ) {
 		return null;
 	}
 
-	// take either the canonical image or if that doesn't exist, the first usable media in the content of the post
-	const featuredMedia = candidateForFeature( post.featured_image )
-		? post.featured_image
-		: find( post.featured_media, candidateForFeature );
-
-	if ( ! featuredMedia ) {
-		return null;
+	if ( post.featured_image && uriIsLikelyAnImage( post.featured_image ) ) {
+		return <FeaturedImage imageUri={ post.featured_image } href={ post.URL } />;
 	}
 
-	const featuredAsset = featuredMedia.mediaType === 'video'
-		? <FeaturedVideo { ...featuredMedia } videoEmbed={ featuredMedia } />
-		: <FeaturedImage imageUri={ featuredMedia.src } href={ post.URL } />;
+	const featuredMedia = find( post.content_media, candidateForFeature );
 
-	return featuredAsset;
+	if ( featuredMedia && featuredMedia.mediaType === 'video' ) {
+		return <FeaturedVideo { ...featuredMedia } videoEmbed={ featuredMedia } />;
+	} else if ( featuredMedia && featuredMedia.mediaType === 'image' ) {
+		return <FeaturedImage imageUri={ featuredMedia.src } href={ post.URL } />;
+	}
+
+	return null;
 };
 
 FeaturedAsset.propTypes = {

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -2,14 +2,14 @@
  * External Dependencies
  */
 import React from 'react';
-import { find, endsWith, some, } from 'lodash';
-import url from 'url';
+import { find } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import FeaturedVideo from './featured-video';
 import FeaturedImage from './featured-image';
+import { isUrlLikelyAnImage } from '../../lib/post-normalizer/utils.js';
 
 function isCandidateForFeature( media ) {
 	if ( ! media ) {
@@ -19,8 +19,8 @@ function isCandidateForFeature( media ) {
 	if ( media.mediaType === 'image' ) {
 		const image = media;
 
-		const imageIsTallEnough = 350 <= image.width || 350 <= image.naturalWidth;
-		const imageIsWideEnough = 85 <= image.height || 85 <= image.naturalHeight;
+		const imageIsTallEnough = 350 <= image.width;
+		const imageIsWideEnough = 85 <= image.height;
 
 		return imageIsTallEnough && imageIsWideEnough;
 	} else if ( media.mediaType === 'video' ) {
@@ -28,13 +28,7 @@ function isCandidateForFeature( media ) {
 		return media.thumbnailUrl && media.autoplayIframe;
 	}
 
-	return true;
-}
-
-// jetpack lies about thumbnails so we need to make sure its actually an image. See: thumbIsLikelyImage in pick-canonical-image rule
-function isUrlLikelyAnImage( uri ) {
-	const withoutQuery = url.parse( uri ).pathname;
-	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], ext => endsWith( withoutQuery, ext ) );
+	return false;
 }
 
 /**
@@ -48,6 +42,7 @@ const FeaturedAsset = ( { post } ) => {
 		return null;
 	}
 
+	// jetpack lies about thumbnails/featured_images so we need to make sure its actually an image
 	if ( post.featured_image && isUrlLikelyAnImage( post.featured_image ) ) {
 		return <FeaturedImage imageUri={ post.featured_image } href={ post.URL } />;
 	}

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -11,18 +11,27 @@ import FeaturedVideo from './featured-video';
 import FeaturedImage from './featured-image';
 import { isUrlLikelyAnImage } from '../../lib/post-normalizer/utils.js';
 
+/** Returns true if an image is large enough to be a featured asset
+ * @param {object} image - image must have a width and height property
+ * @returns {boolean} true if large enough, false if image undefined or too small
+ */
+function isImageLargeEnoughForFeature( image ) {
+	if ( ! image ) {
+		return false;
+	}
+	const imageIsTallEnough = 350 <= image.width;
+	const imageIsWideEnough = 85 <= image.height;
+
+	return imageIsTallEnough && imageIsWideEnough;
+}
+
 function isCandidateForFeature( media ) {
 	if ( ! media ) {
 		return false;
 	}
 
 	if ( media.mediaType === 'image' ) {
-		const image = media;
-
-		const imageIsTallEnough = 350 <= image.width;
-		const imageIsWideEnough = 85 <= image.height;
-
-		return imageIsTallEnough && imageIsWideEnough;
+		return isImageLargeEnoughForFeature( media );
 	} else if ( media.mediaType === 'video' ) {
 		// we need to have a thumbnail and know how to autoplay it
 		return media.thumbnailUrl && media.autoplayIframe;
@@ -43,7 +52,8 @@ const FeaturedAsset = ( { post } ) => {
 	}
 
 	// jetpack lies about thumbnails/featured_images so we need to make sure its actually an image
-	if ( post.featured_image && isUrlLikelyAnImage( post.featured_image ) ) {
+	if ( post.featured_image && isUrlLikelyAnImage( post.featured_image ) &&
+			isImageLargeEnoughForFeature( post.post_thumbnail ) ) {
 		return <FeaturedImage imageUri={ post.featured_image } href={ post.URL } />;
 	}
 

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -11,7 +11,7 @@ import url from 'url';
 import FeaturedVideo from './featured-video';
 import FeaturedImage from './featured-image';
 
-const candidateForFeature = ( media ) => {
+function isCandidateForFeature( media ) {
 	if ( ! media ) {
 		return false;
 	}
@@ -29,13 +29,13 @@ const candidateForFeature = ( media ) => {
 	}
 
 	return true;
-};
+}
 
 // jetpack lies about thumbnails so we need to make sure its actually an image. See: thumbIsLikelyImage in pick-canonical-image rule
-const uriIsLikelyAnImage = ( uri ) => {
+function isUrlLikelyAnImage( uri ) {
 	const withoutQuery = url.parse( uri ).pathname;
 	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], ext => endsWith( withoutQuery, ext ) );
-};
+}
 
 /**
  * Given a post:
@@ -48,11 +48,11 @@ const FeaturedAsset = ( { post } ) => {
 		return null;
 	}
 
-	if ( post.featured_image && uriIsLikelyAnImage( post.featured_image ) ) {
+	if ( post.featured_image && isUrlLikelyAnImage( post.featured_image ) ) {
 		return <FeaturedImage imageUri={ post.featured_image } href={ post.URL } />;
 	}
 
-	const featuredMedia = find( post.content_media, candidateForFeature );
+	const featuredMedia = find( post.content_media, isCandidateForFeature );
 
 	if ( featuredMedia && featuredMedia.mediaType === 'video' ) {
 		return <FeaturedVideo { ...featuredMedia } videoEmbed={ featuredMedia } />;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -15,7 +15,8 @@ import DisplayTypes from 'state/reader/posts/display-types';
 import ReaderPostActions from 'blocks/reader-post-actions';
 import * as stats from 'reader/stats';
 import PostByline from './byline';
-import FeaturedAsset from './featured-asset';
+import FeaturedVideo from './featured-video';
+import FeaturedImage from './featured-image';
 import FollowButton from 'reader/follow-button';
 import PostGallery from './gallery';
 
@@ -86,9 +87,8 @@ export default class RefreshPostCard extends React.Component {
 		const { post, originalPost, site, feed, onCommentClick, showPrimaryFollowButton } = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
-		const featuredAsset = FeaturedAsset( { post } ); // this is ... gross? gross.
 		const classes = classnames( 'reader-post-card', {
-			'has-thumbnail': !! featuredAsset,
+			'has-thumbnail': !! post.canonical_media,
 			'is-photo': isPhotoOnly,
 			'is-gallery': isGallery
 		} );
@@ -105,6 +105,15 @@ export default class RefreshPostCard extends React.Component {
 		let followUrl;
 		if ( showPrimaryFollowButton ) {
 			followUrl = feed ? feed.feed_URL : post.site_URL;
+		}
+
+		let featuredAsset;
+		if ( ! post.canonical_media ) {
+			featuredAsset = null;
+		} else if ( post.canonical_media.mediaType === 'video' ) {
+			featuredAsset = <FeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } />;
+		} else {
+			featuredAsset = <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 
 		return (

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -20,7 +20,6 @@ export default function pickCanonicalImage( post ) {
 		if ( canonicalImage ) {
 			canonicalImage = {
 				uri: canonicalImage.src,
-				src: canonicalImage.src,
 				width: canonicalImage.width,
 				height: canonicalImage.height
 			};

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -20,6 +20,7 @@ export default function pickCanonicalImage( post ) {
 		if ( canonicalImage ) {
 			canonicalImage = {
 				uri: canonicalImage.src,
+				src: canonicalImage.src,
 				width: canonicalImage.width,
 				height: canonicalImage.height
 			};

--- a/client/lib/post-normalizer/rule-pick-canonical-media.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-media.js
@@ -1,15 +1,12 @@
 /**
  * External Dependencies
  */
-import React from 'react';
 import { find } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-import FeaturedVideo from './featured-video';
-import FeaturedImage from './featured-image';
-import { isUrlLikelyAnImage } from '../../lib/post-normalizer/utils.js';
+import { isUrlLikelyAnImage } from './utils.js';
 
 /** Returns true if an image is large enough to be a featured asset
  * @param {object} image - image must have a width and height property
@@ -46,30 +43,27 @@ function isCandidateForFeature( media ) {
  *  2. if there is no usable featured image, use the media that appears first in the content of the post
  *  3. if there is no eligible asset, return null
  */
-const FeaturedAsset = ( { post } ) => {
+export default function pickCanonicalMedia( post ) {
 	if ( ! post ) {
-		return null;
+		return post;
 	}
 
 	// jetpack lies about thumbnails/featured_images so we need to make sure its actually an image
 	if ( post.featured_image && isUrlLikelyAnImage( post.featured_image ) &&
 			isImageLargeEnoughForFeature( post.post_thumbnail ) ) {
-		return <FeaturedImage imageUri={ post.featured_image } href={ post.URL } />;
+		post.canonical_media = {
+			src: post.featured_image,
+			height: post.post_thumbnail.height,
+			width: post.post_thumbnail.width,
+			mediaType: 'image',
+		};
+		return post;
 	}
 
-	const featuredMedia = find( post.content_media, isCandidateForFeature );
-
-	if ( featuredMedia && featuredMedia.mediaType === 'video' ) {
-		return <FeaturedVideo { ...featuredMedia } videoEmbed={ featuredMedia } />;
-	} else if ( featuredMedia && featuredMedia.mediaType === 'image' ) {
-		return <FeaturedImage imageUri={ featuredMedia.src } href={ post.URL } />;
+	const canonicalMedia = find( post.content_media, isCandidateForFeature );
+	if ( canonicalMedia ) {
+		post.canonical_media = canonicalMedia;
 	}
 
-	return null;
-};
-
-FeaturedAsset.propTypes = {
-	post: React.PropTypes.object.isRequired,
-};
-
-export default FeaturedAsset;
+	return post;
+}

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -66,7 +66,7 @@ export default function waitForImagesToLoad( post ) {
 			post.content_media = map( post.content_media, ( media ) => {
 				if ( media.mediaType === 'image' ) {
 					const img = find( post.images, { src: media.src } );
-					return { ...img, ...media, };
+					return { ...media, ...img };
 				}
 				return media;
 			} );

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -62,6 +62,15 @@ export default function waitForImagesToLoad( post ) {
 				return find( post.images, { src: image.src } );
 			} ), Boolean );
 
+			// this adds naturalHeight and naturalWidth to the images
+			post.content_media = map( post.content_media, ( media ) => {
+				if ( media.mediaType === 'image' ) {
+					const img = find( post.images, { src: media.src } );
+					return { ...img, ...media, };
+				}
+				return media;
+			} );
+
 			resolve( post );
 		}
 

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -62,7 +62,7 @@ export default function waitForImagesToLoad( post ) {
 				return find( post.images, { src: image.src } );
 			} ), Boolean );
 
-			// this adds naturalHeight and naturalWidth to the images
+			// this adds adds height/width to images
 			post.content_media = map( post.content_media, ( media ) => {
 				if ( media.mediaType === 'image' ) {
 					const img = find( post.images, { src: media.src } );

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -86,6 +86,15 @@ export function domForHtml( html ) {
 	return dom;
 }
 
+/** Determine if url is likely pointed to an image
+ * @param {string} uri - a url
+ * @returns {boolean} - true or false depending on if it is probably an image (has the right extension)
+ */
+export function isUrlLikelyAnImage( uri ) {
+	const withoutQuery = url.parse( uri ).pathname;
+	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], ext => endsWith( withoutQuery, ext ) );
+}
+
 /**
  * Determine if a post thumbnail is likely an image
  * @param  {object} thumb the thumbnail object from a post
@@ -100,11 +109,7 @@ export function thumbIsLikelyImage( thumb ) {
 	//if ( startsWith( thumb.mime_type, 'image/' ) ) {
 	//	return true;
 	// }
-
-	const { pathname } = url.parse( thumb.URL, true, true );
-	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], function( ext ) {
-		return endsWith( pathname, ext );
-	} );
+	return isUrlLikelyAnImage( thumb.URL );
 }
 
 /**


### PR DESCRIPTION
This is to solve one of the final parts of #8555 

- **Previous behavior for featuring content**: canonical image > content embed > content image > text only
- **This commit**: canonical image > first usable media > text only