### PR TITLE
Masterbar: Add label to Post button on large screens.

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -96,7 +96,7 @@ const MasterbarLoggedIn = React.createClass( {
 					className="masterbar__item-new"
 					tooltip={ this.translate( 'Create a New Post', { textOnly: true } ) }
 				>
-					{ this.translate( 'New Post' ) }
+					{ this.translate( 'Post' ) }
 				</Publish>
 				<Item
 					tipTarget="me"

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -97,7 +97,7 @@ const MasterbarLoggedIn = React.createClass( {
 					tooltip={ this.translate( 'Create a New Post', { textOnly: true } ) }
 				>
 					{ this.translate( 'Post', {
-						context: 'add new on admin bar'
+						context: 'add new from admin bar'
 					} ) }
 				</Publish>
 				<Item

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -96,9 +96,7 @@ const MasterbarLoggedIn = React.createClass( {
 					className="masterbar__item-new"
 					tooltip={ this.translate( 'Create a New Post', { textOnly: true } ) }
 				>
-					{ this.translate( 'Post', {
-						context: 'add new from admin bar'
-					} ) }
+					{ this.translate( 'Write' ) }
 				</Publish>
 				<Item
 					tipTarget="me"

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -96,7 +96,9 @@ const MasterbarLoggedIn = React.createClass( {
 					className="masterbar__item-new"
 					tooltip={ this.translate( 'Create a New Post', { textOnly: true } ) }
 				>
-					{ this.translate( 'Post' ) }
+					{ this.translate( 'Post', {
+						context: 'verb'
+					} ) }
 				</Publish>
 				<Item
 					tipTarget="me"

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -97,7 +97,7 @@ const MasterbarLoggedIn = React.createClass( {
 					tooltip={ this.translate( 'Create a New Post', { textOnly: true } ) }
 				>
 					{ this.translate( 'Post', {
-						context: 'verb'
+						context: 'add new on admin bar'
 					} ) }
 				</Publish>
 				<Item

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -158,7 +158,12 @@ $autobar-height: 20px;
 	}
 
 	.masterbar__item-content {
+		color: $blue-wordpress;
 		display: none;
+
+		@include breakpoint( ">660px" ) {
+			display: block;
+		}
 	}
 
 	.is-support-user &,

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -161,7 +161,7 @@ $autobar-height: 20px;
 		color: $blue-wordpress;
 		display: none;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( ">960px" ) {
 			display: block;
 		}
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -163,6 +163,7 @@ $autobar-height: 20px;
 
 		@include breakpoint( ">960px" ) {
 			display: block;
+			margin-right: 4px;
 		}
 	}
 


### PR DESCRIPTION
This PR makes the "Post" button show a label on larger screens — viewports > 660px. The motivation for doing this is two-fold:

1. make it clearer what this button does, icon+label is almost always clearer than icon only
2. provide a larger hit area so the button is easier to click

Smaller screens still show the icon-only button.

Incidentally, this PR also renames the button from "New Post" to "Post". While the label hasn't been visible in the past, the "New Post" label has been there for screen readers and accessability purposes. The `title` remains unchanged, though.

Provided there's agreement that this PR deserves merging, we should make sure and check that the new "Post" title is translated, as it's a highly visible spot.

Screenshot:

<img width="319" alt="screen shot 2016-11-04 at 11 20 40" src="https://cloud.githubusercontent.com/assets/1204802/20002444/34394ba4-a281-11e6-9413-9f012a8c4b17.png">
