### PR TITLE
Reader: Add top margin that's missing in some streams

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -11,8 +11,8 @@
 	}
 }
 
-.is-group-reader-refresh .recommended-for-you.main,
-.is-group-reader-refresh .following.main {
+.is-reader-page .recommended-for-you.main,
+.is-reader-page .following.main {
 
 	@include breakpoint( ">660px" ) {
 		margin: 30px auto;


### PR DESCRIPTION
In Refreshed Site and Search streams, the top margin is missing.

**Before:**
![screenshot 2016-11-04 10 51 26](https://cloud.githubusercontent.com/assets/4924246/20016700/cde4d4b6-a27d-11e6-8630-79729028c926.png)

![screenshot 2016-11-04 10 52 07](https://cloud.githubusercontent.com/assets/4924246/20016703/d087cf7a-a27d-11e6-9a47-def24f5950c9.png)

**After:**
![screenshot 2016-11-04 10 52 41](https://cloud.githubusercontent.com/assets/4924246/20016683/b89bf602-a27d-11e6-8d01-373d51056268.png)

![screenshot 2016-11-04 10 52 29](https://cloud.githubusercontent.com/assets/4924246/20016687/bb9acd10-a27d-11e6-80a0-f6d056ef867f.png)
