### PR TITLE
Media: Rename modal classes to reflect editor independence

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -180,9 +180,9 @@ $z-layers: (
 		'.media-library__list-item-edit': 20
 	),
 	'.dialog__backdrop': (
-		'.editor-media-modal .section-nav': 10,
-		'.editor-media-modal .notice': 10,
-		'.editor-media-modal-gallery__preview-toggle': 100,
+		'.media-modal .section-nav': 10,
+		'.media-modal .notice': 10,
+		'.media-modal-gallery__preview-toggle': 100,
 		'.editor-contact-form-modal .section-nav': 10
 	),
 	'.following-edit': ( //aka 'main'

--- a/client/post-editor/media-modal/back-to-library.jsx
+++ b/client/post-editor/media-modal/back-to-library.jsx
@@ -8,7 +8,7 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<span className="editor-media-modal__back-to-library">
+			<span className="media-modal__back-to-library">
 				<span className="is-mobile">{ this.translate( 'Library' ) }</span>
 				<span className="is-desktop">{ this.translate( 'Media Library' ) }</span>
 			</span>

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -1,4 +1,4 @@
-.editor-media-modal-detail .header-cake.card {
+.media-modal-detail .header-cake.card {
 	padding-top: 0;
 	padding-bottom: 0;
 
@@ -7,11 +7,11 @@
 	}
 }
 
-.editor-media-modal-detail .header-cake__title {
+.media-modal-detail .header-cake__title {
 	padding: 6px;
 }
 
-.editor-media-modal-detail .editor-media-modal-detail__title-input {
+.media-modal-detail .media-modal-detail__title-input {
 	width: 100%;
 	color: inherit;
 	word-break: normal;
@@ -33,7 +33,7 @@
 	}
 }
 
-.editor-media-modal-detail__preview-wrapper {
+.media-modal-detail__preview-wrapper {
 	flex: 2 0 0%;
 	position: relative;
 	border-bottom: 1px solid lighten( $gray, 20% );
@@ -46,8 +46,8 @@
 	}
 }
 
-.editor-media-modal-detail__preview-wrapper .spinner,
-.editor-media-modal-detail__preview {
+.media-modal-detail__preview-wrapper .spinner,
+.media-modal-detail__preview {
 	position: absolute;
 		top: 50%;
 		left: 50%;
@@ -60,7 +60,7 @@
 	}
 }
 
-.editor-media-modal-detail__preview {
+.media-modal-detail__preview {
 	&.is-image {
 		width: auto;
 		height: auto;
@@ -73,8 +73,8 @@
 	}
 }
 
-.editor-media-modal-detail__previous,
-.editor-media-modal-detail__next {
+.media-modal-detail__previous,
+.media-modal-detail__next {
 	position: absolute;
 		top: 50%;
 	width: 46px;
@@ -94,7 +94,7 @@
 	}
 }
 
-.editor-media-modal-detail__previous {
+.media-modal-detail__previous {
 	left: 10px #{"/*rtl:ignore*/"};
 
 	&:before {
@@ -102,7 +102,7 @@
 	}
 }
 
-.editor-media-modal-detail__next {
+.media-modal-detail__next {
 	right: 10px #{"/*rtl:ignore*/"};
 
 	&:before {
@@ -110,7 +110,7 @@
 	}
 }
 
-.editor-media-modal-detail__edition-bar {
+.media-modal-detail__edition-bar {
 	display: none;
 
 	&.is-desktop {
@@ -149,7 +149,7 @@
 	}
 }
 
-.editor-media-modal-detail__sidebar {
+.media-modal-detail__sidebar {
 	flex: 2 0 0%;
 	padding: 16px;
 
@@ -161,34 +161,34 @@
 	}
 }
 
-.editor-media-modal-detail__sidebar textarea {
+.media-modal-detail__sidebar textarea {
 	resize: vertical;
 }
 
-.editor-media-modal-detail__file-info {
+.media-modal-detail__file-info {
 	display: block;
 	margin: 0;
 	padding: 8px 0;
 }
 
-.editor-media-modal-detail__file-info tbody {
+.media-modal-detail__file-info tbody {
 	display: flex;
 	flex-wrap: wrap;
 }
 
-.editor-media-modal-detail__file-info tr {
+.media-modal-detail__file-info tr {
 	display: block;
 	flex-basis: 50%;
 	width: 100%;
 }
 
-.editor-media-modal-detail__file-info th,
-.editor-media-modal-detail__file-info td {
+.media-modal-detail__file-info th,
+.media-modal-detail__file-info td {
 	width: 90%;
 	display: block;
 }
 
-.editor-media-modal-detail__file-info th {
+.media-modal-detail__file-info th {
 	color: $gray;
 	display: block;
 	font-size: 11px;
@@ -196,7 +196,7 @@
 	text-transform: uppercase;
 }
 
-.editor-media-modal-detail__file-info td {
+.media-modal-detail__file-info td {
 	position: relative;
 	overflow: hidden;
 	margin-bottom: 16px;
@@ -211,7 +211,7 @@
 	}
 }
 
-.editor-media-modal-detail__file-info.is-loading td {
+.media-modal-detail__file-info.is-loading td {
 	position: relative;
 	color: transparent;
 
@@ -226,11 +226,11 @@
 	}
 }
 
-.editor-media-modal-detail__file-info tr:last-child td,
-.editor-media-modal-detail__file-info tr:nth-last-child( 2 ):nth-child( odd ) td {
+.media-modal-detail__file-info tr:last-child td,
+.media-modal-detail__file-info tr:nth-last-child( 2 ):nth-child( odd ) td {
 	margin-bottom: 0;
 }
 
-.editor-media-modal-detail__file-info abbr {
+.media-modal-detail__file-info abbr {
 	border-bottom-width: 0;
 }

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -5,7 +5,7 @@ var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	debounce = require( 'lodash/debounce' ),
 	assign = require( 'lodash/assign' ),
-	debug = require( 'debug' )( 'calypso:editor-media-modal' );
+	debug = require( 'debug' )( 'calypso:media-modal' );
 
 /**
  * Internal dependencies
@@ -124,7 +124,7 @@ module.exports = React.createClass( {
 
 	render: function() {
 		return (
-			<div className="editor-media-modal-detail__fields">
+			<div className="media-modal-detail__fields">
 				<EditorMediaModalFieldset legend={ this.translate( 'Caption' ) }>
 					<TrackInputChanges onNewValue={ this.bumpStat.bind( this, 'caption' ) }>
 						<FormTextarea name="caption" value={ this.getItemValue( 'caption' ) } onChange={ this.onChange } />

--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -79,7 +79,7 @@ module.exports = React.createClass( {
 	},
 
 	render() {
-		let classes = classNames( 'editor-media-modal-detail__file-info', {
+		let classes = classNames( 'media-modal-detail__file-info', {
 			'is-loading': ! this.props.item
 		} );
 

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -63,7 +63,7 @@ class EditorMediaModalDetailItem extends Component {
 
 		return (
 			<Button
-				className="editor-media-modal-detail__edit"
+				className="media-modal-detail__edit"
 				onClick={ onEdit }
 				disabled={ isItemBeingUploaded( item ) }
 			>
@@ -94,7 +94,7 @@ class EditorMediaModalDetailItem extends Component {
 		return (
 			<Button
 				className={ classNames(
-					'editor-media-modal-detail__restore',
+					'media-modal-detail__restore',
 				) }
 				onClick={ this.handleOnRestoreClick }
 				disabled={ isItemBeingUploaded( item ) }
@@ -119,7 +119,7 @@ class EditorMediaModalDetailItem extends Component {
 			return null;
 		}
 
-		const classes = classNames( 'editor-media-modal-detail__edition-bar', classname );
+		const classes = classNames( 'media-modal-detail__edition-bar', classname );
 
 		return (
 			<div className={ classes }>
@@ -157,7 +157,7 @@ class EditorMediaModalDetailItem extends Component {
 		return (
 			<button
 				onClick={ onShowPreviousItem }
-				className="editor-media-modal-detail__previous">
+				className="media-modal-detail__previous">
 				<Gridicon icon="chevron-left" size={ 36 } />
 				<span className="screen-reader-text">
 					{ translate( 'Previous' ) }
@@ -180,7 +180,7 @@ class EditorMediaModalDetailItem extends Component {
 		return (
 			<button
 				onClick={ onShowNextItem }
-				className="editor-media-modal-detail__next">
+				className="media-modal-detail__next">
 				<Gridicon icon="chevron-right" size={ 36 } />
 				<span className="screen-reader-text">
 					{ translate( 'Next' ) }
@@ -219,22 +219,22 @@ class EditorMediaModalDetailItem extends Component {
 	render() {
 		const { item } = this.props;
 
-		const classes = classNames( 'editor-media-modal-detail__item', {
+		const classes = classNames( 'media-modal-detail__item', {
 			'is-loading': ! item
 		} );
 
 		return (
 			<figure className={ classes }>
-				<div className="editor-media-modal-detail__content editor-media-modal__content">
+				<div className="media-modal-detail__content media-modal__content">
 
-					<div className="editor-media-modal-detail__preview-wrapper">
+					<div className="media-modal-detail__preview-wrapper">
 						{ this.renderItem() }
 						{ this.renderImageEditorButtons( item ) }
 						{ this.renderPreviousItemButton() }
 						{ this.renderNextItemButton() }
 					</div>
 
-					<div className="editor-media-modal-detail__sidebar">
+					<div className="media-modal-detail__sidebar">
 						{ this.renderImageEditorButtons( item, 'is-mobile' ) }
 						{ this.renderFields() }
 						<EditorMediaModalDetailFileInfo

--- a/client/post-editor/media-modal/detail/detail-preview-audio.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-audio.jsx
@@ -20,7 +20,7 @@ module.exports = React.createClass( {
 			<audio
 				src={ MediaUtils.url( this.props.item ) }
 				controls
-				className="editor-media-modal-detail__preview is-audio" />
+				className="media-modal-detail__preview is-audio" />
 		);
 	}
 } );

--- a/client/post-editor/media-modal/detail/detail-preview-document.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-document.jsx
@@ -13,7 +13,7 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<div className="editor-media-modal-detail__preview is-document">
+			<div className="media-modal-detail__preview is-document">
 				<Gridicon icon="pages" size={ 120 } />
 			</div>
 		);

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -60,7 +60,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 		// - `is-blob` when the image is shown using local `blob` data.
 
 		const classes = classNames(
-			'editor-media-modal-detail__preview',
+			'media-modal-detail__preview',
 			'is-image',
 			{ 'is-uploading': uploading },
 			{ 'is-loading': loading },
@@ -71,7 +71,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 		// in order to improve the UX between the states that an image could have,
 		// for instance when the image is restored.
 		const fakeClasses = classNames(
-			'editor-media-modal-detail__preview',
+			'media-modal-detail__preview',
 			'is-image',
 			'is-fake',
 			{ 'is-uploading': uploading },

--- a/client/post-editor/media-modal/detail/detail-preview-video.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-video.jsx
@@ -25,7 +25,7 @@ module.exports = React.createClass( {
 			<video
 				src={ MediaUtils.url( this.props.item ) }
 				controls
-				className="editor-media-modal-detail__preview is-video" />
+				className="media-modal-detail__preview is-video" />
 		);
 	}
 } );

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -41,7 +41,7 @@ module.exports = React.createClass( {
 				width={ this.props.item.width }
 				height={ this.props.item.height }
 				allowFullScreen
-				className="editor-media-modal-detail__preview is-video" />
+				className="media-modal-detail__preview is-video" />
 		);
 	}
 } );

--- a/client/post-editor/media-modal/detail/detail-title.jsx
+++ b/client/post-editor/media-modal/detail/detail-title.jsx
@@ -89,7 +89,7 @@ export default React.createClass( {
 					value={ this.getTitleValue() }
 					placeholder={ this.translate( 'Untitled' ) }
 					readOnly={ ! userCan( 'upload_files', this.props.site ) }
-					className="editor-media-modal-detail__title-input" />
+					className="media-modal-detail__title-input" />
 			</TrackInputChanges>
 		);
 	}

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -70,7 +70,7 @@ const EditorMediaModalDetail = React.createClass( {
 		const item = items[ selectedIndex ];
 
 		return (
-			<div className="editor-media-modal-detail">
+			<div className="media-modal-detail">
 				<HeaderCake onClick={ onReturnToList } backText={ this.translate( 'Media Library' ) }>
 					<EditorMediaModalDetailTitle
 						site={ site }

--- a/client/post-editor/media-modal/fieldset.jsx
+++ b/client/post-editor/media-modal/fieldset.jsx
@@ -16,8 +16,8 @@ module.exports = React.createClass( {
 
 	render: function() {
 		return (
-			<fieldset className={ classNames( 'editor-media-modal__fieldset', this.props.className ) }>
-				<legend className="editor-media-modal__fieldset-legend">{ this.props.legend }</legend>
+			<fieldset className={ classNames( 'media-modal__fieldset', this.props.className ) }>
+				<legend className="media-modal__fieldset-legend">{ this.props.legend }</legend>
 				{ this.props.children }
 			</fieldset>
 		);

--- a/client/post-editor/media-modal/fieldset.scss
+++ b/client/post-editor/media-modal/fieldset.scss
@@ -1,25 +1,25 @@
-.editor-media-modal__fieldset {
+.media-modal__fieldset {
 	margin-bottom: 16px;
 }
 
-.editor-media-modal__fieldset,
-.editor-media-modal__fieldset .form-text-input,
-.editor-media-modal__fieldset textarea {
+.media-modal__fieldset,
+.media-modal__fieldset .form-text-input,
+.media-modal__fieldset textarea {
 	font-size: 13px;
 }
 
-.editor-media-modal__fieldset textarea {
+.media-modal__fieldset textarea {
 	min-height: 76px;
 }
 
-.editor-media-modal__fieldset-legend {
+.media-modal__fieldset-legend {
 	display: block;
 	font-weight: bold;
 	line-height: 1;
 	margin-bottom: 6px;
 }
 
-.editor-media-modal__fieldset .select-dropdown.is-compact {
+.media-modal__fieldset .select-dropdown.is-compact {
 	.select-dropdown__header {
 		padding: 6px 44px 6px 16px;
 	}

--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -81,17 +81,17 @@ const EditorMediaModalGalleryHelp =  React.createClass( {
 				position="bottom"
 				isVisible={ ! isMobile() }
 				className="popover__gallery-help is-dialog-visible">
-				<div className="editor-media-modal__gallery-help-content">
-					<div className="editor-media-modal__gallery-help-instruction">
-						<span className="editor-media-modal__gallery-help-icon">
+				<div className="media-modal__gallery-help-content">
+					<div className="media-modal__gallery-help-instruction">
+						<span className="media-modal__gallery-help-icon">
 							<Gridicon icon="image-multiple" size={ 20 } />
 						</span>
-						<span className="editor-media-modal__gallery-help-text">
+						<span className="media-modal__gallery-help-text">
 							{ this.translate( 'Select more than one image to create a gallery.' ) }
 						</span>
 					</div>
-					<div className="editor-media-modal__gallery-help-actions">
-						<label className="editor-media-modal__gallery-help-remember-dismiss">
+					<div className="media-modal__gallery-help-actions">
+						<label className="media-modal__gallery-help-remember-dismiss">
 							<FormCheckbox checked={ this.state.rememberDismiss } onChange={ this.toggleRememberDismiss } />
 							<span>
 								{ this.translate( 'Don\'t show again' ) }
@@ -111,7 +111,7 @@ const EditorMediaModalGalleryHelp =  React.createClass( {
 			return null;
 		}
 		return (
-			<div ref={ this.setRenderContext } className="editor-media-modal__gallery-help">
+			<div ref={ this.setRenderContext } className="media-modal__gallery-help">
 				<QueryPreferences />
 				{ this.renderPopover() }
 			</div>

--- a/client/post-editor/media-modal/gallery/caption.jsx
+++ b/client/post-editor/media-modal/gallery/caption.jsx
@@ -62,7 +62,7 @@ export default React.createClass( {
 				onChange={ this.setCaption }
 				onBlur={ this.saveCaption }
 				onMouseDown={ ( event ) => event.stopPropagation() }
-				className="editor-media-modal-gallery__caption" />
+				className="media-modal-gallery__caption" />
 		);
 	}
 } );

--- a/client/post-editor/media-modal/gallery/edit-item.jsx
+++ b/client/post-editor/media-modal/gallery/edit-item.jsx
@@ -43,7 +43,7 @@ export default React.createClass( {
 		const { site, item, showRemoveButton } = this.props;
 
 		return (
-			<div className="editor-media-modal-gallery__edit-item">
+			<div className="media-modal-gallery__edit-item">
 				<MediaLibraryListItem
 					media={ item }
 					scale={ 1 }

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -150,7 +150,7 @@ export const EditorMediaModalGalleryFields = React.createClass( {
 		const sizes = this.getSizeOptions();
 
 		return (
-			<div className="editor-media-modal-gallery__fields">
+			<div className="media-modal-gallery__fields">
 				{ this.renderDropdown( this.props.translate( 'Layout' ), types, 'type' ) }
 				{ this.renderColumnsOption() }
 				{ this.renderRandomOption() }

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -118,12 +118,12 @@ const EditorMediaModalGallery = React.createClass( {
 		const { site, items, settings } = this.props;
 
 		return (
-			<div className="editor-media-modal-gallery">
+			<div className="media-modal-gallery">
 				<EditorMediaModalGalleryDropZone
 					site={ site }
 					onInvalidItemAdded={ () => this.setState( { invalidItemDropped: true } ) } />
 				<HeaderCake onClick={ this.props.onReturnToList } backText={ this.translate( 'Media Library' ) } />
-				<div className="editor-media-modal-gallery__content editor-media-modal__content">
+				<div className="media-modal-gallery__content media-modal__content">
 					<EditorMediaModalGalleryPreview
 						site={ site }
 						items={ items }
@@ -131,7 +131,7 @@ const EditorMediaModalGallery = React.createClass( {
 						onUpdateSetting={ this.updateSetting }
 						invalidItemDropped={ this.state.invalidItemDropped }
 						onDismissInvalidItemDropped={ () => this.setState( { invalidItemDropped: false } ) } />
-					<div className="editor-media-modal-gallery__sidebar">
+					<div className="media-modal-gallery__sidebar">
 						<EditorMediaModalGalleryFields
 							site={ site }
 							settings={ settings }

--- a/client/post-editor/media-modal/gallery/preview-individual.jsx
+++ b/client/post-editor/media-modal/gallery/preview-individual.jsx
@@ -27,8 +27,8 @@ export default React.createClass( {
 		} );
 
 		return (
-			<div className="editor-media-modal-gallery__preview-individual">
-				<div className="editor-media-modal-gallery__preview-individual-content">
+			<div className="media-modal-gallery__preview-individual">
+				<div className="media-modal-gallery__preview-individual-content">
 					{ items }
 				</div>
 			</div>

--- a/client/post-editor/media-modal/gallery/preview-shortcode.jsx
+++ b/client/post-editor/media-modal/gallery/preview-shortcode.jsx
@@ -51,7 +51,7 @@ export default React.createClass( {
 	render() {
 		const { siteId, settings } = this.props;
 		const { isLoading, shortcode } = this.state;
-		const classes = classNames( 'editor-media-modal-gallery__preview-shortcode', {
+		const classes = classNames( 'media-modal-gallery__preview-shortcode', {
 			'is-loading': isLoading || some( settings.items, 'transient' )
 		} );
 

--- a/client/post-editor/media-modal/gallery/preview.jsx
+++ b/client/post-editor/media-modal/gallery/preview.jsx
@@ -41,7 +41,7 @@ export default React.createClass( {
 
 	renderPreviewModeToggle() {
 		return (
-			<SegmentedControl className="editor-media-modal-gallery__preview-toggle" compact={ true }>
+			<SegmentedControl className="media-modal-gallery__preview-toggle" compact={ true }>
 				<SegmentedControlItem
 					selected={ ! this.state.isEditing }
 					onClick={ () => this.setState( { isEditing: false } ) }>
@@ -88,13 +88,13 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<div className="editor-media-modal-gallery__preview">
+			<div className="media-modal-gallery__preview">
 				{ this.props.invalidItemDropped && (
 					<Notice status="is-warning" onDismissClick={ this.props.onDismissInvalidItemDropped } isCompact>
 						{ this.translate( 'Galleries can only include images. All other uploads will be added to your media library.' ) }
 					</Notice>
 				) }
-				<div className="editor-media-modal-gallery__preview-wrapper">
+				<div className="media-modal-gallery__preview-wrapper">
 					{ this.renderPreview() }
 				</div>
 				{ this.renderPreviewModeToggle() }

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -39,7 +39,7 @@ export default React.createClass( {
 			<button
 				onClick={ this.remove }
 				onMouseDown={ ( event ) => event.stopPropagation() }
-				className="editor-media-modal-gallery__remove">
+				className="media-modal-gallery__remove">
 				<span className="screen-reader-text">{ this.translate( 'Remove' ) }</span>
 				<Gridicon icon="cross" />
 			</button>

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -1,4 +1,4 @@
-.editor-media-modal-gallery__preview {
+.media-modal-gallery__preview {
 	position: relative;
 	display: flex;
 	flex-direction: column;
@@ -13,7 +13,7 @@
 	}
 }
 
-.editor-media-modal-gallery__preview .notice {
+.media-modal-gallery__preview .notice {
 	position: absolute;
 		top: 0;
 		left: 0;
@@ -22,11 +22,11 @@
 	overflow: hidden;
 }
 
-.editor-media-modal-gallery__preview-toggle {
+.media-modal-gallery__preview-toggle {
 	position: absolute;
 		top: -28px;
 		right: 15px;
-	z-index: z-index( '.dialog__backdrop', '.editor-media-modal-gallery__preview-toggle' );
+	z-index: z-index( '.dialog__backdrop', '.media-modal-gallery__preview-toggle' );
 	width: 200px;
 
 	@include breakpoint( ">660px" ) {
@@ -51,11 +51,11 @@
 	}
 }
 
-.editor-media-modal-gallery__preview-toggle .segmented-control__item {
+.media-modal-gallery__preview-toggle .segmented-control__item {
 	flex-basis: 0%;
 }
 
-.editor-media-modal-gallery .sortable-list__item {
+.media-modal-gallery .sortable-list__item {
 	width: 44%;
 	margin: 3%;
 
@@ -65,11 +65,11 @@
 	}
 }
 
-.editor-media-modal-gallery__edit-item {
+.media-modal-gallery__edit-item {
 	position: relative;
 }
 
-.editor-media-modal-gallery__remove {
+.media-modal-gallery__remove {
 	position: absolute;
 		top: 0;
 		/*rtl:ignore*/
@@ -85,29 +85,29 @@
 	cursor: pointer;
 }
 
-.editor-media-modal-gallery__remove .gridicon {
+.media-modal-gallery__remove .gridicon {
 	position: absolute;
 		top: 50%;
 		left: 50%;
 	transform: translate( -50%, -50% );
 }
 
-.editor-media-modal-gallery .media-library__list-item {
+.media-modal-gallery .media-library__list-item {
 	display: block;
 }
 
-.editor-media-modal-gallery .media-library__list-item-edit {
+.media-modal-gallery .media-library__list-item-edit {
 	display: none;
 }
 
-.editor-media-modal-gallery .sortable-list__navigation {
+.media-modal-gallery .sortable-list__navigation {
 	position: absolute;
 		top: 16px;
 		left: 16px;
 	margin: 0;
 }
 
-.editor-media-modal-gallery .sortable-list__navigation-button {
+.media-modal-gallery .sortable-list__navigation-button {
 	background-color: $white;
 
 	&:disabled {
@@ -116,7 +116,7 @@
 	}
 }
 
-input.editor-media-modal-gallery__caption[type="text"] {
+input.media-modal-gallery__caption[type="text"] {
 	font-size: 12px;
 
 	&:focus {
@@ -124,7 +124,7 @@ input.editor-media-modal-gallery__caption[type="text"] {
 	}
 }
 
-.editor-media-modal-gallery__sidebar {
+.media-modal-gallery__sidebar {
 	flex: 1 0 0%;
 	padding: 16px;
 
@@ -135,7 +135,7 @@ input.editor-media-modal-gallery__caption[type="text"] {
 	}
 }
 
-.editor-media-modal-gallery__preview-wrapper {
+.media-modal-gallery__preview-wrapper {
 	position: absolute;
 		top: 0;
 		right: 0;
@@ -146,14 +146,14 @@ input.editor-media-modal-gallery__caption[type="text"] {
 	padding: 16px;
 }
 
-.editor-media-modal-gallery__preview-shortcode {
+.media-modal-gallery__preview-shortcode {
 	&,
 	& .shortcode-frame {
 		width: 100%;
 	}
 }
 
-.editor-media-modal-gallery__preview-shortcode {
+.media-modal-gallery__preview-shortcode {
 	&.is-loading {
 		animation: loading-fade 0.8s ease-in-out infinite;
 	}
@@ -200,7 +200,7 @@ input.editor-media-modal-gallery__caption[type="text"] {
 	}
 }
 
-.editor-media-modal-gallery__fields .for-setting-type {
+.media-modal-gallery__fields .for-setting-type {
 	position: absolute;
 		top: 0;
 		left: 16px;
@@ -211,7 +211,7 @@ input.editor-media-modal-gallery__caption[type="text"] {
 	}
 }
 
-.editor-media-modal-gallery__fields .for-setting-type .editor-media-modal__fieldset-legend {
+.media-modal-gallery__fields .for-setting-type .media-modal__fieldset-legend {
 	display: none;
 
 	@include breakpoint( ">660px" ) {
@@ -219,7 +219,7 @@ input.editor-media-modal-gallery__caption[type="text"] {
 	}
 }
 
-.editor-media-modal-gallery__fields .for-setting-type .select-dropdown__container {
+.media-modal-gallery__fields .for-setting-type .select-dropdown__container {
 	width: 100%;
 
 	@include breakpoint( ">660px" ) {
@@ -227,11 +227,11 @@ input.editor-media-modal-gallery__caption[type="text"] {
 	}
 }
 
-input[type].editor-media-modal-gallery__input-width-auto {
+input[type].media-modal-gallery__input-width-auto {
 	width: auto;
 }
 
-.editor-media-modal-gallery__preview-individual-content {
+.media-modal-gallery__preview-individual-content {
 	padding-top: 8px;
 
 	@include breakpoint( ">660px" ) {
@@ -244,7 +244,7 @@ input[type].editor-media-modal-gallery__input-width-auto {
 	}
 }
 
-.editor-media-modal-gallery__preview-individual .wp-caption {
+.media-modal-gallery__preview-individual .wp-caption {
 	@extend %content-font;
 	margin: 0 auto;
 	text-align: center;
@@ -253,7 +253,7 @@ input[type].editor-media-modal-gallery__input-width-auto {
 
 // Copied from TinyMCE iframe.scss:
 
-.editor-media-modal-gallery__preview-individual .wp-caption {
+.media-modal-gallery__preview-individual .wp-caption {
 	background: none;
 	box-sizing: border-box;
 	border: none;
@@ -270,16 +270,16 @@ input[type].editor-media-modal-gallery__input-width-auto {
 	}
 }
 
-.editor-media-modal-gallery__preview-individual .wp-caption-dt {
+.media-modal-gallery__preview-individual .wp-caption-dt {
 	overflow: hidden;
 }
 
-.editor-media-modal-gallery__preview-individual .wp-caption img[class*="wp-image-"] {
+.media-modal-gallery__preview-individual .wp-caption img[class*="wp-image-"] {
 	display: block;
 	margin: 0;
 }
 
-.editor-media-modal-gallery__preview-individual .wp-caption-dd {
+.media-modal-gallery__preview-individual .wp-caption-dd {
 	background: $gray-light;
 	color: darken( $gray, 20% );
 	font-size: 14px;

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -453,7 +453,7 @@ export const EditorMediaModal = React.createClass( {
 				isVisible={ this.props.visible }
 				buttons={ this.getModalButtons() }
 				onClose={ this.onClose }
-				additionalClassNames="editor-media-modal"
+				additionalClassNames="media-modal"
 				onClickOutside={ this.preventClose }>
 				{ this.renderContent() }
 			</Dialog>

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -1,8 +1,8 @@
-.editor-media-modal {
+.media-modal {
 	padding: 0;
 }
 
-.editor-media-modal.dialog.card {
+.media-modal.dialog.card {
 	position: absolute;
 		top: 0;
 		right: 0;
@@ -25,14 +25,14 @@
 	}
 }
 
-.editor-media-modal .dialog__content {
+.media-modal .dialog__content {
 	position: static;
 	color: $gray-dark;
 	height: 100%;
 }
 
-.editor-media-modal .section-nav {
-	z-index: z-index( '.dialog__backdrop', '.editor-media-modal .section-nav' );
+.media-modal .section-nav {
+	z-index: z-index( '.dialog__backdrop', '.media-modal .section-nav' );
 	padding: 0 16px;
 
 	@include breakpoint( ">660px" ) {
@@ -40,24 +40,24 @@
 	}
 }
 
-.editor-media-modal .header-cake.card {
+.media-modal .header-cake.card {
 	@include breakpoint( "<660px" ) {
 		margin-top: 0;
 		justify-content: left;
 	}
 }
 
-.editor-media-modal .header-cake__corner {
+.media-modal .header-cake__corner {
 	@include breakpoint( "<660px" ) {
 		flex: none;
 	}
 }
 
-.editor-media-modal .media-library__content {
+.media-modal .media-library__content {
 	position: static;
 }
 
-.editor-media-modal .media-library__list {
+.media-modal .media-library__list {
 	padding: 0 16px;
 
 	@include breakpoint( ">660px" ) {
@@ -65,7 +65,7 @@
 	}
 }
 
-.editor-media-modal .media-library__header {
+.media-modal .media-library__header {
 	padding: 0 16px;
 
 	@include breakpoint( ">660px" ) {
@@ -73,8 +73,8 @@
 	}
 }
 
-.editor-media-modal .media-library__scale-toggle,
-.editor-media-modal .media-library__scale-range.range {
+.media-modal .media-library__scale-toggle,
+.media-modal .media-library__scale-range.range {
 	right: 16px;
 
 	@include breakpoint( ">660px" ) {
@@ -82,11 +82,11 @@
 	}
 }
 
-.editor-media-modal .media-library__content .no-results {
+.media-modal .media-library__content .no-results {
 	padding: 0 24px 24px;
 }
 
-.editor-media-modal__content {
+.media-modal__content {
 	display: flex;
 	flex-direction: column;
 	position: absolute;
@@ -96,7 +96,7 @@
 		left: 0;
 	overflow-y: auto;
 
-	&.editor-media-modal-gallery__content {
+	&.media-modal-gallery__content {
 		margin-top: 16px;
 
 		@include breakpoint( ">660px" ) {
@@ -111,8 +111,8 @@
 	}
 }
 
-.editor-media-modal .media-library__list {
-	@extend .editor-media-modal__content;
+.media-modal .media-library__list {
+	@extend .media-modal__content;
 	display: block;
 	top: 117px;
 	right: 0;
@@ -128,17 +128,17 @@
 	}
 }
 
-.editor-media-modal .notice {
-	z-index: z-index( '.dialog__backdrop', '.editor-media-modal .notice' );
+.media-modal .notice {
+	z-index: z-index( '.dialog__backdrop', '.media-modal .notice' );
 	margin-top: -4px;
 }
 
-.editor-media-modal .media-library__upload-url-cancel {
+.media-modal .media-library__upload-url-cancel {
 	padding-right: 0;
 	padding-left: 12px;
 }
 
-.editor-media-modal .empty-content {
+.media-modal .empty-content {
 	position: absolute;
 		top: 50%;
 		left: 50%;
@@ -148,7 +148,7 @@
 	width: 100%;
 }
 
-.editor-media-modal .media-library__content .empty-content__illustration {
+.media-modal .media-library__content .empty-content__illustration {
 	width: 65vh;
 	min-width: 300px;
 	max-width: 37.5vw;
@@ -165,34 +165,34 @@
 	}
 }
 
-.editor-media-modal .media-library__list-item-figure {
+.media-modal .media-library__list-item-figure {
 	background-color: $gray-light;
 	box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
 }
 
-.editor-media-modal .media-library__list-item-file-name {
+.media-modal .media-library__list-item-file-name {
 	&::after {
 		@include long-content-fade( $color: $gray-light );
 	}
 }
 
-.editor-media-modal__gallery-help {
+.media-modal__gallery-help {
 	position: absolute;
 		bottom: 8px;
 		right: 22px;
 }
 
-.editor-media-modal__gallery-help-content {
+.media-modal__gallery-help-content {
 	font-size: 15px;
 	text-align: left;
 }
 
-.editor-media-modal__gallery-help-instruction {
+.media-modal__gallery-help-instruction {
 	padding: 16px;
 	max-width: 280px;
 }
 
-.editor-media-modal__gallery-help-icon {
+.media-modal__gallery-help-icon {
 	position: relative;
 	display: block;
 	width: 34px;
@@ -204,41 +204,41 @@
 	color: $gray-dark;
 }
 
-.editor-media-modal__gallery-help-icon .gridicon {
+.media-modal__gallery-help-icon .gridicon {
 	position: absolute;
 		top: 50%;
 		left: 50%;
 	transform: translate( -50%, -50% );
 }
 
-.editor-media-modal__gallery-help-actions {
+.media-modal__gallery-help-actions {
 	overflow-y: hidden;
 	padding: 8px 16px;
 	border-top: 1px solid lighten( $gray, 30% );
 }
 
-.editor-media-modal__gallery-help-remember-dismiss {
+.media-modal__gallery-help-remember-dismiss {
 	float: left;
 	margin-top: 4px;
 	font-size: 13px;
 }
 
-.editor-media-modal__gallery-help-remember-dismiss .form-checkbox {
+.media-modal__gallery-help-remember-dismiss .form-checkbox {
 	margin-top: 2px;
 }
 
-.editor-media-modal__gallery-help-actions .button {
+.media-modal__gallery-help-actions .button {
 	float: right;
 }
 
-.editor-media-modal__secondary-actions {
+.media-modal__secondary-actions {
 	float: left;
 	display: flex;
 	justify-content: center;
 	height: 40px;
 }
 
-.editor-media-modal__secondary-actions .gridicon {
+.media-modal__secondary-actions .gridicon {
 	position: absolute;
 		top: 50%;
 		left: 50%;
@@ -250,7 +250,7 @@
 	}
 }
 
-.editor-media-modal__secondary-action {
+.media-modal__secondary-action {
 	&.is-mobile {
 		position: relative;
 		min-width: 60px;
@@ -272,7 +272,7 @@
 	}
 }
 
-.editor-media-modal__secondary-action:not( .is-mobile ).editor-media-modal__delete {
+.media-modal__secondary-action:not( .is-mobile ).media-modal__delete {
 	line-height: 1;
 	color: $alert-red;
 
@@ -287,7 +287,7 @@
 	}
 }
 
-.editor-media-modal__secondary-action.is-active {
+.media-modal__secondary-action.is-active {
 	transform: rotate( 90deg );
 
 	.gridicon,
@@ -296,7 +296,7 @@
 	}
 }
 
-.editor-media-modal .dialog__action-buttons {
+.media-modal .dialog__action-buttons {
 	position: absolute;
 		right: 0;
 		bottom: 0;
@@ -304,11 +304,11 @@
 	margin: 0;
 }
 
-.editor-media-modal .dialog__action-buttons .button:first-of-type {
+.media-modal .dialog__action-buttons .button:first-of-type {
 	margin-left: 0;
 }
 
-.editor-media-modal__back-to-library {
+.media-modal__back-to-library {
 	.is-desktop {
 		display: none;
 	}
@@ -324,7 +324,7 @@
 	}
 }
 
-.editor-media-modal__plan-storage {
+.media-modal__plan-storage {
 	display: none;
 
 	@include breakpoint( ">480px" ) {

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -95,7 +95,7 @@ const MediaModalSecondaryActions = React.createClass( {
 			buttons.push( {
 				key: 'delete',
 				value: this.translate( 'Delete' ),
-				className: 'is-link editor-media-modal__delete',
+				className: 'is-link media-modal__delete',
 				disabled: disabled || some( selectedItems, 'transient' ),
 				onClick: onDelete
 			} );
@@ -117,7 +117,7 @@ const MediaModalSecondaryActions = React.createClass( {
 			return;
 		}
 
-		const classes = classNames( 'editor-media-modal__secondary-action', 'button', 'is-mobile', 'is-link', {
+		const classes = classNames( 'media-modal__secondary-action', 'button', 'is-mobile', 'is-link', {
 			'is-active': this.state.isMobilePopoverVisible
 		} );
 
@@ -161,7 +161,7 @@ const MediaModalSecondaryActions = React.createClass( {
 			return React.createElement( 'input', Object.assign( {
 				type: 'button'
 			}, button, {
-				className: classNames( 'editor-media-modal__secondary-action', 'button', 'is-desktop', button.className )
+				className: classNames( 'media-modal__secondary-action', 'button', 'is-desktop', button.className )
 			} ) );
 		} );
 	},
@@ -172,7 +172,7 @@ const MediaModalSecondaryActions = React.createClass( {
 			const eventProperties = { cta_name: 'plan-media-storage' };
 			return (
 				<PlanStorage
-					className="editor-media-modal__plan-storage"
+					className="media-modal__plan-storage"
 					onClick={ this.navigateToPlans }
 					siteId={ this.props.site.ID } >
 					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
@@ -184,7 +184,7 @@ const MediaModalSecondaryActions = React.createClass( {
 
 	render() {
 		return (
-			<div className="editor-media-modal__secondary-actions">
+			<div className="media-modal__secondary-actions">
 				{ this.renderMobileButtons() }
 				{ this.renderDesktopButtons() }
 				{ this.renderPlanStorage() }


### PR DESCRIPTION
Related: #7333

This pull request seeks to update classnames in the media modal to reflect its intended usage outside the editor. This will be part of a series of pull requests to migrate `media-modal` to the `blocks` directory. For the Site Icon milestone, the media modal will need to be used independent of the editor, so it's ideal to make it more generic in its usage and folder placement.

__Implementation notes:__

The changes are effectively a find/replace of `editor-media-modal` -> `media-modal` throughout the entire codebase.

__Testing instructions:__

Verify that there are no regressions in any of the media modal workflows in the editor where it is currently used.

/cc @mtias 