### PR TITLE
Reader: Fix various card spacing inconsistencies

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -103,14 +103,6 @@ export default class RefreshPostCard extends React.Component {
 			followUrl = feed ? feed.feed_URL : post.site_URL;
 		}
 
-		let title = truncate( post.title, {
-			length: 140,
-			separator: /,? +/
-		} );
-		if ( ! title ) {
-			title = '\xa0'; // force to non-breaking space if empty so that the title h1 doesn't collapse and complicate things
-		}
-
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>
 				<PostByline post={ post } site={ site } feed={ feed } />

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -86,7 +86,11 @@ export default class RefreshPostCard extends React.Component {
 		const { post, originalPost, site, feed, onCommentClick, showPrimaryFollowButton } = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
-		const featuredAsset = ( <FeaturedAsset post={ post } /> );
+		const title = truncate( post.title, {
+			length: 140,
+			separator: /,? +/
+		} );
+		const featuredAsset = FeaturedAsset( { post } ); // this is ... gross? gross.
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! featuredAsset,
 			'is-photo': isPhotoOnly,

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -86,10 +86,6 @@ export default class RefreshPostCard extends React.Component {
 		const { post, originalPost, site, feed, onCommentClick, showPrimaryFollowButton } = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
-		const title = truncate( post.title, {
-			length: 140,
-			separator: /,? +/
-		} );
 		const featuredAsset = FeaturedAsset( { post } ); // this is ... gross? gross.
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! featuredAsset,
@@ -97,6 +93,14 @@ export default class RefreshPostCard extends React.Component {
 			'is-gallery': isGallery
 		} );
 		const showExcerpt = ! isPhotoOnly;
+		let title = truncate( post.title, {
+			length: 140,
+			separator: /,? +/
+		} );
+
+		if ( ! title && isPhotoOnly ) {
+			title = '\xa0'; // force to non-breaking space if empty so that the title h1 doesn't collapse and complicate things
+		}
 
 		let followUrl;
 		if ( showPrimaryFollowButton ) {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -245,10 +245,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		@media #{$reader-post-card-breakpoint-medium} {
 			margin-top: 7px;
+			width: 100%;
 		}
 
 		@media #{$reader-post-card-breakpoint-small} {
 			margin-top: 7px;
+			width: 100%;
 		}
 	}
 
@@ -453,7 +455,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__gallery-image {
-	height: 130px;
+	height: 100px;
+
+	@include brakpoint( ">960px" ) {
+		height: 130px;
+	}
 }
 
 // For these borderless cards to look more presentable on Devdocs

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -10,12 +10,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	border-bottom: 1px solid lighten( $gray, 30% );
 	box-shadow: none;
 	margin: 0 15px;
-	padding: 20px 0 20px;
+	padding: 18px 0 20px;
 	position: relative;
 
 	@include breakpoint( ">660px" ) {
 		margin: 0;
-		padding: 18px 0 20px;
 	}
 
 	&.has-thumbnail {
@@ -53,6 +52,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 		}
 
+		.reader-post-card__post {
+			margin-top: 17px;
+		}
+
 		.reader-post-card__play-icon {
 			opacity: .8;
 			transition: opacity .25s;
@@ -74,8 +77,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 					height: 225px;
 					opacity: .4;
 					position: absolute;
-						top: 0;
-						left: 0;
 					width: 100%;
 					z-index: 1;
 				}
@@ -116,7 +117,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 
 			.reader-post-actions {
-				margin: 8px 0 0;
+				margin: 7px 0 0;
 			}
 
 			.reader-post-actions .reader-post-actions__visit {
@@ -127,6 +128,17 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	&.is-gallery .reader-post-card__post {
 		flex-direction: column;
+	}
+
+	.reader-post-actions {
+		margin: 4px 0 0;
+	}
+
+	&.is-excerpt {
+
+		.reader-post-card__post {
+			margin-top: 15px;
+		}
 	}
 }
 
@@ -226,17 +238,17 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	display: flex;
 	flex-wrap: wrap;
 	flex-direction: row;
-	margin-top: 17px;
+	margin-top: 14px;
 
 	.reader-post-card__post-details {
 		flex: 1;
 
 		@media #{$reader-post-card-breakpoint-medium} {
-			margin-top: 8px;
+			margin-top: 7px;
 		}
 
 		@media #{$reader-post-card-breakpoint-small} {
-			margin-top: 8px;
+			margin-top: 7px;
 		}
 	}
 
@@ -280,7 +292,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	font-size: 15px;
 	line-height: 1.6;
 	font-weight: 100;
-	margin-top: 5px;
+	margin-top: 9px;
 	word-break: break-word;
 }
 
@@ -351,7 +363,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	padding: 0;
 	position: absolute;
 		right: 0;
-		top: 18px;
+		top: 16px;
 
 	.gridicon {
 		fill: $blue-medium;
@@ -399,8 +411,16 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 // Gallery cards
 .reader-post-card__gallery {
 	display: flex;
-	margin: 0 0 20px;
+	margin: 0 0 17px;
 	padding: 0;
+
+	@media #{$reader-post-card-breakpoint-medium}  {
+		margin: 0 0 10px;
+	}
+
+	@media #{$reader-post-card-breakpoint-small}  {
+		margin: 0 0 10px;
+	}
 }
 
 .reader-post-card__gallery-item {
@@ -425,7 +445,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__video {
-	padding-bottom: 20px;
+	padding-bottom: 17px;
 }
 
 .reader-post-card__video iframe {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -15,7 +15,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	@include breakpoint( ">660px" ) {
 		margin: 0;
-		padding: 20px 0;
+		padding: 18px 0 20px;
 	}
 
 	&.has-thumbnail {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -77,6 +77,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 					height: 225px;
 					opacity: .4;
 					position: absolute;
+						bottom: 0;
+						left: 0;
 					width: 100%;
 					z-index: 1;
 				}
@@ -353,6 +355,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	.ellipsis-menu .button.is-borderless .gridicon {
+		left: 2px;
 		top: -2px;
 	}
 }
@@ -457,7 +460,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader-post-card__gallery-image {
 	height: 100px;
 
-	@include brakpoint( ">960px" ) {
+	@include breakpoint( ">960px" ) {
 		height: 130px;
 	}
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9144

Make sure spacing is consistent in all the cards:
- Default
- Excerpt
- Photo
- Gallery
- Video

> In addition to the 20px thing, I'm also suggesting that we limit the gallery card images to 100px tall when in the narrow screen

It also seems like spacing changes depending on viewport so have to check those as well.
