### PR TITLE
Domains: Show proper WHOIS preview when privacy protection is enabled

### DIFF
--- a/client/lib/domains/whois/README.md
+++ b/client/lib/domains/whois/README.md
@@ -19,8 +19,8 @@ The store is a singleton object which offers `get` and `getByDomainName` methods
 ```js
 import WhoisStore from 'lib/domains/whois/store';
 
-DomainsStore.get()
-DomainsStore.getByDomainName( 'example.wordpress.com' )
+WhoisStore.get()
+WhoisStore.getByDomainName( 'example.wordpress.com' )
 ```
 
 To interact with the store, use the actions made available in [`domain-management.js`](../../upgrades/actions/domain-management.js):

--- a/client/lib/domains/whois/assembler.js
+++ b/client/lib/domains/whois/assembler.js
@@ -1,10 +1,25 @@
 /**
  * External dependencies
  */
-const find = require( 'lodash/find' );
+import find from 'lodash/find';
 
-function createDomainObject( dataTransferObject ) {
-	const contactInformation = find( dataTransferObject, 'type', 'registrant' ) || {};
+/**
+ * Internal dependencies
+ */
+import { whoisType } from './constants';
+
+function createDomainWhois( dataTransferObject ) {
+	const registrantWhois = createWhois( dataTransferObject, whoisType.REGISTRANT ),
+		privacyServiceWhois = createWhois( dataTransferObject, whoisType.PRIVACY_SERVICE );
+
+	return [
+		registrantWhois,
+		privacyServiceWhois
+	];
+}
+
+function createWhois( dataTransferObject, type ) {
+	const contactInformation = find( dataTransferObject, { type } ) || {};
 
 	return {
 		firstName: contactInformation.fname || '',
@@ -20,10 +35,11 @@ function createDomainObject( dataTransferObject ) {
 		countryName: contactInformation.cc || '',
 		email: contactInformation.email || '',
 		phone: contactInformation.phone || '',
-		fax: contactInformation.fax || ''
+		fax: contactInformation.fax || '',
+		type
 	};
 }
 
-module.exports = {
-	createDomainObject
+export default {
+	createDomainWhois
 };

--- a/client/lib/domains/whois/constants.js
+++ b/client/lib/domains/whois/constants.js
@@ -1,0 +1,8 @@
+const whoisType = {
+	REGISTRANT: 'registrant',
+	PRIVACY_SERVICE: 'privacy_service'
+};
+
+export default {
+	whoisType
+};

--- a/client/lib/domains/whois/test/assembler.js
+++ b/client/lib/domains/whois/test/assembler.js
@@ -1,110 +1,149 @@
 /**
  * External dependencies
  */
-const expect = require( 'chai' ).expect;
+import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
-const whoisAssembler = require( './../assembler' );
+import whoisAssembler from './../assembler';
+import { whoisType } from './../constants';
+
+const FIRST_NAME = 'First-name',
+	LAST_NAME = 'Last-name',
+	ORGANIZATION = 'Organisation',
+	ADDRESS = 'Address line 1',
+	ADDRESS_LINE_2 = 'Address line 2',
+	CITY = 'City',
+	STATE_CODE = 'ST',
+	STATE = 'State',
+	POSTAL_CODE = '12345',
+	COUNTRY_CODE = 'CO',
+	COUNTRY = 'Country',
+	EMAIL = 'email@email.com',
+	PHONE = '123456789',
+	FAX = '987654321';
+
+function buildEmptyWhois( type ) {
+	return {
+		type,
+		firstName: '',
+		lastName: '',
+		organization: '',
+		address1: '',
+		address2: '',
+		city: '',
+		state: '',
+		stateName: '',
+		postalCode: '',
+		countryCode: '',
+		countryName: '',
+		email: '',
+		phone: '',
+		fax: ''
+	};
+}
+
+function buildWhois( suffix, type ) {
+	return {
+		type,
+		firstName: FIRST_NAME + suffix,
+		lastName: LAST_NAME + suffix,
+		organization: ORGANIZATION + suffix,
+		address1: ADDRESS + suffix,
+		address2: ADDRESS_LINE_2 + suffix,
+		city: CITY + suffix,
+		state: STATE_CODE + suffix,
+		stateName: STATE + suffix,
+		postalCode: POSTAL_CODE + suffix,
+		countryCode: COUNTRY_CODE + suffix,
+		countryName: COUNTRY + suffix,
+		email: EMAIL + suffix,
+		phone: PHONE + suffix,
+		fax: FAX + suffix
+	};
+}
+
+function buildWhoisTranferObject( suffix, type ) {
+	return {
+		type,
+		fname: FIRST_NAME + suffix,
+		lname: LAST_NAME + suffix,
+		org: ORGANIZATION + suffix,
+		sa1: ADDRESS + suffix,
+		sa2: ADDRESS_LINE_2 + suffix,
+		city: CITY + suffix,
+		state: STATE_CODE + suffix,
+		sp: STATE + suffix,
+		pc: POSTAL_CODE + suffix,
+		country_code: COUNTRY_CODE + suffix,
+		cc: COUNTRY + suffix,
+		email: EMAIL + suffix,
+		phone: PHONE + suffix,
+		fax: FAX + suffix
+	};
+}
 
 describe( 'assembler', () => {
-	const FIRST_NAME = 'First-name',
-		LAST_NAME = 'Last-name',
-		ORGANIZATION = 'Organisation',
-		ADDRESS = 'Address line 1',
-		ADDRESS_LINE_2 = 'Address line 2',
-		CITY = 'City',
-		STATE_CODE = 'ST',
-		STATE = 'State',
-		POSTAL_CODE = '12345',
-		COUNTRY_CODE = 'CO',
-		COUNTRY = 'Country',
-		EMAIL = 'email@email.com',
-		PHONE = '123456789',
-		FAX = '987654321';
+	const { REGISTRANT, PRIVACY_SERVICE } = whoisType;
 
-	it( 'should return object with default contact info when there is no registrant entry in data transfer object', () => {
+	it( 'should return WHOIS with empty contact info when there is no valid entry in data transfer object', () => {
 		const invalidDataTransferObject = [ { type: 'anything' } ],
-			expectedDomainObject = {
-				firstName: '',
-				lastName: '',
-				organization: '',
-				address1: '',
-				address2: '',
-				city: '',
-				state: '',
-				stateName: '',
-				postalCode: '',
-				countryCode: '',
-				countryName: '',
-				email: '',
-				phone: '',
-				fax: ''
-			};
+			expectedDomainWhois = [
+				buildEmptyWhois( REGISTRANT ),
+				buildEmptyWhois( PRIVACY_SERVICE )
+			];
 
-		expect( whoisAssembler.createDomainObject( invalidDataTransferObject ) ).to.be.eql( expectedDomainObject );
+		expect( whoisAssembler.createDomainWhois( invalidDataTransferObject ) ).to.be.eql( expectedDomainWhois );
 	} );
 
-	it( 'should return object with default contact info when there is any registrant entry in data transfer object', () => {
+	it( 'should return WHOIS with empty contact info when there is an empty registrant entry in data transfer object', () => {
 		const emptyDataTransferObject = [ {
-				type: 'registrant'
+				type: REGISTRANT
 			} ],
-			expectedDomainObject = {
-				firstName: '',
-				lastName: '',
-				organization: '',
-				address1: '',
-				address2: '',
-				city: '',
-				state: '',
-				stateName: '',
-				postalCode: '',
-				countryCode: '',
-				countryName: '',
-				email: '',
-				phone: '',
-				fax: ''
-			};
+			expectedDomainWhois = [
+				buildEmptyWhois( REGISTRANT ),
+				buildEmptyWhois( PRIVACY_SERVICE )
+			];
 
-		expect( whoisAssembler.createDomainObject( emptyDataTransferObject ) ).to.be.eql( expectedDomainObject );
+		expect( whoisAssembler.createDomainWhois( emptyDataTransferObject ) ).to.be.eql( expectedDomainWhois );
 	} );
 
-	it( 'should return object with all contact info when there is full registrant entry in data transfer object', () => {
-		const registrantDataTransferObject = [ {
-				type: 'registrant',
-				fname: FIRST_NAME,
-				lname: LAST_NAME,
-				org: ORGANIZATION,
-				sa1: ADDRESS,
-				sa2: ADDRESS_LINE_2,
-				city: CITY,
-				state: STATE_CODE,
-				sp: STATE,
-				pc: POSTAL_CODE,
-				country_code: COUNTRY_CODE,
-				cc: COUNTRY,
-				email: EMAIL,
-				phone: PHONE,
-				fax: FAX
-			} ],
-			expectedDomainObject = {
-				firstName: FIRST_NAME,
-				lastName: LAST_NAME,
-				organization: ORGANIZATION,
-				address1: ADDRESS,
-				address2: ADDRESS_LINE_2,
-				city: CITY,
-				state: STATE_CODE,
-				stateName: STATE,
-				postalCode: POSTAL_CODE,
-				countryCode: COUNTRY_CODE,
-				countryName: COUNTRY,
-				email: EMAIL,
-				phone: PHONE,
-				fax: FAX
-			};
+	it( 'should return full registrant and empty privacy service WHOIS when there is only registrant entry in data transfer object', () => {
+		const registrantDataTransferObject = [
+				buildWhoisTranferObject( 1, REGISTRANT )
+			],
+			expectedDomainWhois = [
+				buildWhois( 1, REGISTRANT ),
+				buildEmptyWhois( PRIVACY_SERVICE )
+			];
 
-		expect( whoisAssembler.createDomainObject( registrantDataTransferObject ) ).to.be.eql( expectedDomainObject );
+		expect( whoisAssembler.createDomainWhois( registrantDataTransferObject ) ).to.be.eql( expectedDomainWhois );
+	} );
+
+	it( 'should return full registrant and privacy service WHOIS when there are both entries in data transfer object', () => {
+		const registrantDataTransferObject = [
+				buildWhoisTranferObject( 1, REGISTRANT ),
+				buildWhoisTranferObject( 2, PRIVACY_SERVICE )
+			],
+			expectedDomainWhois = [
+				buildWhois( 1, REGISTRANT ),
+				buildWhois( 2, PRIVACY_SERVICE )
+			];
+
+		expect( whoisAssembler.createDomainWhois( registrantDataTransferObject ) ).to.be.eql( expectedDomainWhois );
+	} );
+
+	it( 'should return full registrant and privacy service WHOIS when data transfer object is shuffled', () => {
+		const registrantDataTransferObject = [
+				buildWhoisTranferObject( 2, PRIVACY_SERVICE ),
+				buildWhoisTranferObject( 1, REGISTRANT )
+			],
+			expectedDomainWhois = [
+				buildWhois( 1, REGISTRANT ),
+				buildWhois( 2, PRIVACY_SERVICE )
+			];
+
+		expect( whoisAssembler.createDomainWhois( registrantDataTransferObject ) ).to.be.eql( expectedDomainWhois );
 	} );
 } );

--- a/client/lib/domains/whois/utils.js
+++ b/client/lib/domains/whois/utils.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import find from 'lodash/find';
+
+/**
+ * Internal dependencies
+ */
+import { whoisType } from './constants';
+
+function findRegistrantWhois( whoisContacts ) {
+	return find( whoisContacts, { type: whoisType.REGISTRANT } );
+}
+
+function findPrivacyServiceWhois( whoisContacts ) {
+	return find( whoisContacts, { type: whoisType.PRIVACY_SERVICE } );
+}
+
+export default {
+	findRegistrantWhois,
+	findPrivacyServiceWhois
+};

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -187,7 +187,7 @@ function fetchWhois( domainName ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.WHOIS_FETCH_COMPLETED,
 				domainName,
-				data: whoisAssembler.createDomainObject( data )
+				data: whoisAssembler.createDomainWhois( data )
 			} );
 		}
 	} );
@@ -196,13 +196,18 @@ function fetchWhois( domainName ) {
 function updateWhois( domainName, contactInformation, onComplete ) {
 	wpcom.updateWhois( domainName, contactInformation, ( error, data ) => {
 		if ( ! error ) {
-			// update may take a few minutes, we try after 1 minute to see if it is already done
+			Dispatcher.handleServerAction( {
+				type: ActionTypes.WHOIS_UPDATE_COMPLETED,
+				domainName
+			} );
+
+			// For WWD the update may take longer
+			// After 1 minute, we mark the WHOIS as needing updating
 			setTimeout( () => {
 				Dispatcher.handleServerAction( {
 					type: ActionTypes.WHOIS_UPDATE_COMPLETED,
 					domainName
 				} );
-				fetchWhois( domainName );
 			}, 60000 );
 		}
 

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
@@ -15,6 +15,7 @@ import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import paths from 'my-sites/upgrades/paths';
 import { getSelectedDomain } from 'lib/domains';
+import { findRegistrantWhois, findPrivacyServiceWhois } from 'lib/domains/whois/utils';
 
 const ContactsPrivacy = React.createClass( {
 	propTypes: {
@@ -33,7 +34,10 @@ const ContactsPrivacy = React.createClass( {
 		}
 
 		const domain = getSelectedDomain( this.props ),
-			{ hasPrivacyProtection, privateDomain, currentUserCanManage } = domain;
+			{ hasPrivacyProtection, privateDomain, currentUserCanManage } = domain,
+			contactInformation = privateDomain
+				? findPrivacyServiceWhois( this.props.whois.data )
+				: findRegistrantWhois( this.props.whois.data );
 
 		return (
 			<Main className="domain-management-contacts-privacy">
@@ -45,7 +49,7 @@ const ContactsPrivacy = React.createClass( {
 
 				<VerticalNav>
 					<ContactsPrivacyCard
-						contactInformation= { this.props.whois.data }
+						contactInformation= { contactInformation }
 						selectedDomainName={ this.props.selectedDomainName }
 						selectedSite={ this.props.selectedSite }
 						hasPrivacyProtection={ hasPrivacyProtection }

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/index.jsx
@@ -15,6 +15,7 @@ import Header from 'my-sites/upgrades/domain-management/components/header';
 import Main from 'components/main';
 import paths from 'my-sites/upgrades/paths';
 import { getSelectedDomain } from 'lib/domains';
+import { findRegistrantWhois } from 'lib/domains/whois/utils';
 import SectionHeader from 'components/section-header';
 
 const EditContactInfo = React.createClass( {
@@ -64,7 +65,7 @@ const EditContactInfo = React.createClass( {
 			<div>
 				<SectionHeader label={ this.translate( 'Edit Contact Info' ) } />
 				<EditContactInfoFormCard
-					contactInformation={ this.props.whois.data }
+					contactInformation={ findRegistrantWhois( this.props.whois.data ) }
 					selectedDomainName={ this.props.selectedDomainName }
 					selectedSite={ this.props.selectedSite } />
 			</div>


### PR DESCRIPTION
This patch adds support for parsing and using the new `privacy_service` WHOIS record returned by the `whois` endpoint. This record should be shown when privacy protection is enabled for a domain.

The reason for this is that there's a discrepancy how WWD and Tucows handle WHOIS API calls.
WWD:
 * privacy protection enabled: return privacy service's WHOIS
 * privacy protection disabled: return registrant's WHOIS

Tucows:
 * always return registrant's WHOIS (this is the correct way)

As a result, in `D3272-code` I propose to add a new WHOIS record to be returned by the `whois` endpoint - of type `privacy_service`. This record should be shown in the public record preview screen when privacy protection is enabled.

### Testing: ###

* Run unit tests.
* Test for both Tucows (`.live, newly registered .net, .wales`) and WWD (`.com`).
* Verify that when privacy protection is disabled (for example, by starting a transfer), your real WHOIS is shown:
<img width="689" alt="screen shot 2016-11-06 at 21 32 29" src="https://cloud.githubusercontent.com/assets/3392497/20041396/9c83a784-a468-11e6-8d77-1083637c0ab6.png">

* Verify that when privacy protection is enabled, the privacy service's WHOIS info is shown:
  * WWD (`.com`):
  <img width="749" alt="screen shot 2016-11-06 at 21 34 52" src="https://cloud.githubusercontent.com/assets/3392497/20041407/e368a154-a468-11e6-9fd7-88fb623af176.png">

   * OpenSRS (`.live`):
   <img width="748" alt="screen shot 2016-11-06 at 21 36 21" src="https://cloud.githubusercontent.com/assets/3392497/20041420/1810894e-a469-11e6-82c4-79dcec3a24d3.png">

   * OpenHRS (`.wales, new .net registrations`):
   <img width="755" alt="screen shot 2016-11-06 at 21 37 15" src="https://cloud.githubusercontent.com/assets/3392497/20041423/356806fc-a469-11e6-94a7-fddfd9a7149e.png">

* Verify that you can edit and save properly WHOIS info (for WWD you need to disable privacy protection first). Please note that for WWD, the update might take a while (around a minute). OpenSRS/HRS should be instantaneous.

Fixes #6920