### PR TITLE
Add: global notice handlers for account recovery error actions

### DIFF
--- a/client/state/notices/README.md
+++ b/client/state/notices/README.md
@@ -2,7 +2,7 @@ Notices
 ===========
 
 A subtree of state that manages global notices.
-Suported types of notices are `error`, `success`.
+Supported types of notices are `error`, `success`.
 
 ## How to use?
 

--- a/client/state/notices/account-recovery/index.js
+++ b/client/state/notices/account-recovery/index.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { dispatchError } from '../utils';
+
+import {
+	ACCOUNT_RECOVERY_FETCH_FAILED,
+	ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED,
+	ACCOUNT_RECOVERY_PHONE_DELETE_FAILED,
+	ACCOUNT_RECOVERY_EMAIL_UPDATE_FAILED,
+	ACCOUNT_RECOVERY_EMAIL_DELETE_FAILED,
+} from 'state/action-types';
+
+const handlers = {
+	[ ACCOUNT_RECOVERY_FETCH_FAILED ]: dispatchError(
+		translate( 'An error occurred while fetching for your account recovery settings.' )
+	),
+	[ ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED ]: dispatchError(
+		translate( 'An error occurred while updating your account recovery phone number.' )
+	),
+	[ ACCOUNT_RECOVERY_PHONE_DELETE_FAILED ]: dispatchError(
+		translate( 'An error occurred while deleting your account recovery phone number.' )
+	),
+	[ ACCOUNT_RECOVERY_EMAIL_UPDATE_FAILED ]: dispatchError(
+		translate( 'An error occurred while updating your account recovery email.' )
+	),
+	[ ACCOUNT_RECOVERY_EMAIL_DELETE_FAILED ]: dispatchError(
+		translate( 'An error occurred while deleting your account recovery email.' )
+	),
+};
+
+export default handlers;

--- a/client/state/notices/account-recovery/index.js
+++ b/client/state/notices/account-recovery/index.js
@@ -9,9 +9,6 @@ import { translate } from 'i18n-calypso';
 import { errorNotice } from 'state/notices/actions';
 import { dispatchError } from '../utils';
 
-import {
-} from 'state/action-types';
-
 const getUpdateErrorMessage = ( target ) => {
 	switch ( target ) {
 		case 'phone':

--- a/client/state/notices/account-recovery/index.js
+++ b/client/state/notices/account-recovery/index.js
@@ -6,32 +6,43 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { errorNotice } from 'state/notices/actions';
 import { dispatchError } from '../utils';
 
 import {
-	ACCOUNT_RECOVERY_FETCH_FAILED,
-	ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED,
-	ACCOUNT_RECOVERY_PHONE_DELETE_FAILED,
-	ACCOUNT_RECOVERY_EMAIL_UPDATE_FAILED,
-	ACCOUNT_RECOVERY_EMAIL_DELETE_FAILED,
+	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
+	ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
+	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 } from 'state/action-types';
 
+const getUpdateErrorNotice = ( target ) => {
+	switch ( target ) {
+		case 'phone':
+			return errorNotice( translate( 'An error occurred while updating your account recovery phone number.' ) );
+		case 'email':
+			return errorNotice( translate( 'An error occurred while updating your account recovery email.' ) );
+		default:
+			return errorNotice( translate( 'An error occurred while updating your account recovery options.' ) );
+	}
+};
+
+const getDeleteErrorNotice = ( target ) => {
+	switch ( target ) {
+		case 'phone':
+			return errorNotice( translate( 'An error occurred while deleting your account recovery phone number.' ) );
+		case 'email':
+			return errorNotice( translate( 'An error occurred while deleting your account recovery email.' ) );
+		default:
+			return errorNotice( translate( 'An error occurred while deleting your account recovery options.' ) );
+	}
+};
+
 const handlers = {
-	[ ACCOUNT_RECOVERY_FETCH_FAILED ]: dispatchError(
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: dispatchError(
 		translate( 'An error occurred while fetching for your account recovery settings.' )
 	),
-	[ ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED ]: dispatchError(
-		translate( 'An error occurred while updating your account recovery phone number.' )
-	),
-	[ ACCOUNT_RECOVERY_PHONE_DELETE_FAILED ]: dispatchError(
-		translate( 'An error occurred while deleting your account recovery phone number.' )
-	),
-	[ ACCOUNT_RECOVERY_EMAIL_UPDATE_FAILED ]: dispatchError(
-		translate( 'An error occurred while updating your account recovery email.' )
-	),
-	[ ACCOUNT_RECOVERY_EMAIL_DELETE_FAILED ]: dispatchError(
-		translate( 'An error occurred while deleting your account recovery email.' )
-	),
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]: ( dispatch, { target } ) => dispatch( getUpdateErrorNotice( target ) ),
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]: ( dispatch, { target } ) => dispatch( getDeleteErrorNotice( target ) ),
 };
 
 export default handlers;

--- a/client/state/notices/account-recovery/index.js
+++ b/client/state/notices/account-recovery/index.js
@@ -39,7 +39,7 @@ const getDeleteErrorMessage = ( target ) => {
 
 const handlers = {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: dispatchError(
-		translate( 'An error occurred while fetching for your account recovery settings.' )
+		translate( 'An error occurred while fetching your account recovery settings.' )
 	),
 	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]: ( dispatch, { target } ) => dispatch( errorNotice( getUpdateErrorMessage( target ) ) ),
 	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]: ( dispatch, { target } ) => dispatch( errorNotice( getDeleteErrorMessage( target ) ) ),

--- a/client/state/notices/account-recovery/index.js
+++ b/client/state/notices/account-recovery/index.js
@@ -10,9 +10,6 @@ import { errorNotice } from 'state/notices/actions';
 import { dispatchError } from '../utils';
 
 import {
-	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
-	ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
-	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 } from 'state/action-types';
 
 const getUpdateErrorMessage = ( target ) => {
@@ -37,12 +34,11 @@ const getDeleteErrorMessage = ( target ) => {
 	}
 };
 
-const handlers = {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: dispatchError(
-		translate( 'An error occurred while fetching your account recovery settings.' )
-	),
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]: ( dispatch, { target } ) => dispatch( errorNotice( getUpdateErrorMessage( target ) ) ),
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]: ( dispatch, { target } ) => dispatch( errorNotice( getDeleteErrorMessage( target ) ) ),
-};
+export const onAccountRecoverySettingsFetchFailed = dispatchError(
+	translate( 'An error occurred while fetching your account recovery settings.' )
+);
 
-export default handlers;
+export const onAccountRecoverySettingsUpdateFailed = ( dispatch, { target } ) => dispatch( errorNotice( getUpdateErrorMessage( target ) ) );
+
+export const onAccountRecoverySettingsDeleteFailed = ( dispatch, { target } ) => dispatch( errorNotice( getDeleteErrorMessage( target ) ) );
+

--- a/client/state/notices/account-recovery/index.js
+++ b/client/state/notices/account-recovery/index.js
@@ -15,25 +15,25 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 } from 'state/action-types';
 
-const getUpdateErrorNotice = ( target ) => {
+const getUpdateErrorMessage = ( target ) => {
 	switch ( target ) {
 		case 'phone':
-			return errorNotice( translate( 'An error occurred while updating your account recovery phone number.' ) );
+			return translate( 'An error occurred while updating your account recovery phone number.' );
 		case 'email':
-			return errorNotice( translate( 'An error occurred while updating your account recovery email.' ) );
+			return translate( 'An error occurred while updating your account recovery email.' );
 		default:
-			return errorNotice( translate( 'An error occurred while updating your account recovery options.' ) );
+			return translate( 'An error occurred while updating your account recovery options.' );
 	}
 };
 
-const getDeleteErrorNotice = ( target ) => {
+const getDeleteErrorMessage = ( target ) => {
 	switch ( target ) {
 		case 'phone':
-			return errorNotice( translate( 'An error occurred while deleting your account recovery phone number.' ) );
+			return translate( 'An error occurred while deleting your account recovery phone number.' );
 		case 'email':
-			return errorNotice( translate( 'An error occurred while deleting your account recovery email.' ) );
+			return translate( 'An error occurred while deleting your account recovery email.' );
 		default:
-			return errorNotice( translate( 'An error occurred while deleting your account recovery options.' ) );
+			return translate( 'An error occurred while deleting your account recovery options.' );
 	}
 };
 
@@ -41,8 +41,8 @@ const handlers = {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: dispatchError(
 		translate( 'An error occurred while fetching for your account recovery settings.' )
 	),
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]: ( dispatch, { target } ) => dispatch( getUpdateErrorNotice( target ) ),
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]: ( dispatch, { target } ) => dispatch( getDeleteErrorNotice( target ) ),
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]: ( dispatch, { target } ) => dispatch( errorNotice( getUpdateErrorMessage( target ) ) ),
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]: ( dispatch, { target } ) => dispatch( errorNotice( getDeleteErrorMessage( target ) ) ),
 };
 
 export default handlers;

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -10,11 +10,6 @@ import { truncate } from 'lodash';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getSitePost } from 'state/posts/selectors';
 import {
-	ACCOUNT_RECOVERY_FETCH_FAILED,
-	ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED,
-	ACCOUNT_RECOVERY_PHONE_DELETE_FAILED,
-	ACCOUNT_RECOVERY_EMAIL_UPDATE_FAILED,
-	ACCOUNT_RECOVERY_EMAIL_DELETE_FAILED,
 	GRAVATAR_RECEIVE_IMAGE_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
@@ -27,17 +22,9 @@ import {
 	SITE_FRONT_PAGE_SET_FAILURE
 } from 'state/action-types';
 
-/**
- * Utility
- */
+import { dispatchSuccess, dispatchError } from './utils';
 
-export function dispatchSuccess( message ) {
-	return ( dispatch ) => dispatch( successNotice( message ) );
-}
-
-export function dispatchError( message ) {
-	return ( dispatch ) => dispatch( errorNotice( message ) );
-}
+import accountRecoveryNoticeHandlers from './account-recovery';
 
 /**
  * Handlers
@@ -95,11 +82,8 @@ export function onPostSaveSuccess( dispatch, action ) {
  */
 
 export const handlers = {
-	[ ACCOUNT_RECOVERY_FETCH_FAILED ]: dispatchError( translate( 'An error occurred while fetching for your account recovery settings.' ) ),
-	[ ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED ]: dispatchError( translate( 'An error occurred while updating your account recovery phone number.' ) ),
-	[ ACCOUNT_RECOVERY_PHONE_DELETE_FAILED ]: dispatchError( translate( 'An error occurred while deleting your account recovery phone number.' ) ),
-	[ ACCOUNT_RECOVERY_EMAIL_UPDATE_FAILED ]: dispatchError( translate( 'An error occurred while updating your account recovery email.' ) ),
-	[ ACCOUNT_RECOVERY_EMAIL_DELETE_FAILED ]: dispatchError( translate( 'An error occurred while deleting your account recovery email.' ) ),
+	...accountRecoveryNoticeHandlers,
+
 	[ GRAVATAR_RECEIVE_IMAGE_FAILURE ]: ( dispatch, action ) => {
 		dispatch( errorNotice( action.errorMessage ) );
 	},
@@ -111,7 +95,7 @@ export const handlers = {
 	[ POST_RESTORE_SUCCESS ]: dispatchSuccess( translate( 'Post successfully restored' ) ),
 	[ POST_SAVE_SUCCESS ]: onPostSaveSuccess,
 	[ GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS ]: dispatchSuccess( translate( 'Thanks for confirming those details!' ) ),
-	[ SITE_FRONT_PAGE_SET_FAILURE ]: dispatchError( translate( 'An error occurred while setting the homepage' ) )
+	[ SITE_FRONT_PAGE_SET_FAILURE ]: dispatchError( translate( 'An error occurred while setting the homepage' ) ),
 };
 
 /**

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -11,6 +11,10 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import { getSitePost } from 'state/posts/selectors';
 import {
 	ACCOUNT_RECOVERY_FETCH_FAILED,
+	ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED,
+	ACCOUNT_RECOVERY_PHONE_DELETE_FAILED,
+	ACCOUNT_RECOVERY_EMAIL_UPDATE_FAILED,
+	ACCOUNT_RECOVERY_EMAIL_DELETE_FAILED,
 	GRAVATAR_RECEIVE_IMAGE_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
@@ -92,6 +96,10 @@ export function onPostSaveSuccess( dispatch, action ) {
 
 export const handlers = {
 	[ ACCOUNT_RECOVERY_FETCH_FAILED ]: dispatchError( translate( 'An error occurred while fetching for your account recovery settings.' ) ),
+	[ ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED ]: dispatchError( translate( 'An error occurred while updating your account recovery phone number.' ) ),
+	[ ACCOUNT_RECOVERY_PHONE_DELETE_FAILED ]: dispatchError( translate( 'An error occurred while deleting your account recovery phone number.' ) ),
+	[ ACCOUNT_RECOVERY_EMAIL_UPDATE_FAILED ]: dispatchError( translate( 'An error occurred while updating your account recovery email.' ) ),
+	[ ACCOUNT_RECOVERY_EMAIL_DELETE_FAILED ]: dispatchError( translate( 'An error occurred while deleting your account recovery email.' ) ),
 	[ GRAVATAR_RECEIVE_IMAGE_FAILURE ]: ( dispatch, action ) => {
 		dispatch( errorNotice( action.errorMessage ) );
 	},

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -10,6 +10,9 @@ import { truncate } from 'lodash';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getSitePost } from 'state/posts/selectors';
 import {
+	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
+	ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
+	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 	GRAVATAR_RECEIVE_IMAGE_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
@@ -24,7 +27,11 @@ import {
 
 import { dispatchSuccess, dispatchError } from './utils';
 
-import accountRecoveryNoticeHandlers from './account-recovery';
+import {
+	onAccountRecoverySettingsFetchFailed,
+	onAccountRecoverySettingsUpdateFailed,
+	onAccountRecoverySettingsDeleteFailed,
+} from './account-recovery';
 
 /**
  * Handlers
@@ -82,8 +89,9 @@ export function onPostSaveSuccess( dispatch, action ) {
  */
 
 export const handlers = {
-	...accountRecoveryNoticeHandlers,
-
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: onAccountRecoverySettingsFetchFailed,
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]: onAccountRecoverySettingsUpdateFailed,
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]: onAccountRecoverySettingsDeleteFailed,
 	[ GRAVATAR_RECEIVE_IMAGE_FAILURE ]: ( dispatch, action ) => {
 		dispatch( errorNotice( action.errorMessage ) );
 	},

--- a/client/state/notices/test/middleware.js
+++ b/client/state/notices/test/middleware.js
@@ -9,10 +9,9 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import PostQueryManager from 'lib/query-manager/post';
+import { dispatchSuccess, dispatchError } from '../utils';
 import noticesMiddleware, {
 	handlers,
-	dispatchError,
-	dispatchSuccess,
 	onPostDeleteFailure,
 	onPostRestoreFailure,
 	onPostSaveSuccess

--- a/client/state/notices/utils.js
+++ b/client/state/notices/utils.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { successNotice, errorNotice } from 'state/notices/actions';
+
+export function dispatchSuccess( message ) {
+	return ( dispatch ) => dispatch( successNotice( message ) );
+}
+
+export function dispatchError( message ) {
+	return ( dispatch ) => dispatch( errorNotice( message ) );
+}


### PR DESCRIPTION
## Summary
This PR is a following act of the migrating the security checkup store from `flux` to `redux`, initiating by #9109 . It is based on #9111 , thus should only be labeled as "needs review" after it.

It adds all the handlers to the global notice middleware for the error actions from the `account-recovery` redux store. Namely,

* `ACCOUNT_RECOVERY_FETCH_FAILED`
* `ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED`
* `ACCOUNT_RECOVERY_EMAIL_UPDATE_FAILED`
* `ACCOUNT_RECOVERY_PHONE_DELETE_FAILED`
* `ACCOUNT_RECOVERY_EMAIL_DELETE_FAILED`

To make `state/notices/middleware.js` less clutter, it also introduces the handlers in its own subdirectory, and move `dispatchSuccess` and `dispatchError` utility functions into its own module, `utils.js`.

## Test Plan
If your redux devtool could dispatch actions properly, the fastest way would be dispatching those actions through it, and see if the global notices pop up properly. In my case, my devtool doesn't work, and thus I added the following line in the `reduxStoreReady( reduxStore )` function:
```
window.testDispatch = ( action ) => reduxStore.dispatch( action );
```
and then call this newly-added `testDispatch` function from the debug console to see them in action.
