### PR TITLE
Checkout: make the streamlined paid NUX experience the default

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,15 +89,6 @@ module.exports = {
 		defaultVariation: 'showPopover',
 		allowExistingUsers: false,
 	},
-	paidNuxStreamlined: {
-		datestamp: '20161020',
-		variations: {
-			original: 50,
-			streamlined: 50,
-		},
-		defaultVariation: 'original',
-		allowAnyLocale: true,
-	},
 	siteTitleStep: {
 		datestamp: '20160928',
 		variations: {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -54,7 +54,6 @@ import { getFeatureByKey, shouldFetchSitePlans } from 'lib/plans';
 import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
 import upgradesPaths from 'my-sites/upgrades/paths';
-import { abtest } from 'lib/abtest';
 
 function getPurchases( props ) {
 	return props.receipt.data.purchases;
@@ -181,7 +180,6 @@ const CheckoutThankYou = React.createClass( {
 
 		const userCreatedMoment = moment( this.props.userDate );
 		const isNewUser = userCreatedMoment.isAfter( moment().subtract( 2, 'hours' ) );
-		const isPaidNuxStreamlinedAbTest = abtest( 'paidNuxStreamlined' ) === 'streamlined';
 
 		// this placeholder is using just wp logo here because two possible states do not share a common layout
 		if ( ! purchases && ! this.isGenericReceipt() ) {
@@ -194,7 +192,7 @@ const CheckoutThankYou = React.createClass( {
 		}
 
 		// streamlined paid NUX thanks page
-		if ( isPaidNuxStreamlinedAbTest && isNewUser && wasOnlyDotcomPlanPurchased ) {
+		if ( isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
 				<Main className="checkout-thank-you">
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -7,11 +7,6 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import Notice from 'components/notice';
 
-/**
- * Internal dependencies
- */
-import { abtest } from 'lib/abtest';
-
 module.exports = React.createClass( {
 	displayName: 'SignupProcessingScreen',
 
@@ -27,7 +22,7 @@ module.exports = React.createClass( {
 			return;
 		}
 
-		if ( this.props.hasCartItems && abtest( 'paidNuxStreamlined' ) === 'streamlined' ) {
+		if ( this.props.hasCartItems ) {
 			return;
 		}
 


### PR DESCRIPTION
This was previously an A/B test, but it performed well enough for us to use it as the default for new users who are looking to buy a plan.

This pull request removes A/B testing code and makes the tested behavior the default. 

Future iterations will look at further improving conversion rates and verified email rates.

To test:

- go through signup as a new user, making sure you're not in the `paidNuxStreamlined` a/b test (in fact it shouldn't even be in the dropdown)
- add a plan to your cart
- make sure the "processing" screen does **not** show the "verify your email address" nudge
- after checkout, make sure the updated thank-you page displays (uses [the PlanThankYouCard block](/Automattic/wp-calypso/tree/master/client/blocks/plan-thank-you-card); only two CTAs: view your site, and verify your email address)
