### PR TITLE
Jetpack Plugins: Remove sitesList.getSelectedSite() usage in DisconnectJetpack

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -3,6 +3,7 @@
  */
 import ReactDom from 'react-dom';
 import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 import some from 'lodash/some';
 import includes from 'lodash/includes';
@@ -91,16 +92,17 @@ function renderPluginList( context, basePath ) {
 	lastPluginsQuerystring = context.querystring;
 	context.store.dispatch( setTitle( i18n.translate( 'Plugins', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
-	renderWithReduxStore(
-		React.createElement( PluginListComponent, {
-			path: basePath,
-			context,
-			filter: context.params.pluginFilter,
-			sites,
-			search
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
+	ReactDom.render(
+		React.createElement( ReduxProvider, { store: context.store },
+			React.createElement( PluginListComponent, {
+				path: basePath,
+				context,
+				filter: context.params.pluginFilter,
+				sites,
+				search
+			} )
+		),
+		document.getElementById( 'primary' )
 	);
 
 	if ( search ) {

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -8,7 +8,6 @@ import page from 'page';
 import some from 'lodash/some';
 import includes from 'lodash/includes';
 import capitalize from 'lodash/capitalize';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -21,7 +20,6 @@ import PlanSetup from './jetpack-plugins-setup';
 import PluginListComponent from './main';
 import PluginComponent from './plugin';
 import PluginBrowser from './plugins-browser';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 
@@ -68,8 +66,6 @@ function renderSinglePlugin( context, siteUrl ) {
 			sites,
 			pluginSlug,
 			siteUrl,
-			// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-			onPluginRefresh: title => context.store.dispatch( setTitle( title ) )
 		} ),
 		document.getElementById( 'primary' ),
 		context.store
@@ -90,7 +86,6 @@ function renderPluginList( context, basePath ) {
 
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );
 	lastPluginsQuerystring = context.querystring;
-	context.store.dispatch( setTitle( i18n.translate( 'Plugins', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 	ReactDom.render(
 		React.createElement( ReduxProvider, { store: context.store },
@@ -137,8 +132,6 @@ function renderPluginsBrowser( context ) {
 	if ( ! site && allowedCategoryNames.indexOf( context.params.siteOrCategory ) < 0 ) {
 		site = { slug: context.params.siteOrCategory };
 	}
-
-	context.store.dispatch( setTitle( i18n.translate( 'Plugin Browser', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 	const analyticsPageTitle = 'Plugin Browser' + ( category ? ': ' + category : '' );
 	analytics

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -13,20 +13,18 @@ import DisconnectJetpackDialog from 'my-sites/plugins/disconnect-jetpack/disconn
 import analytics from 'lib/analytics';
 
 class DisconnectJetpackButton extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.handleClick = this.handleClick.bind( this );
-	}
-
-	handleClick( event ) {
+	handleClick = ( event ) => {
 		event.preventDefault();
 		if ( this.props.isMock ) {
 			return;
 		}
-		this.refs.dialog.getWrappedInstance().open();
+
+		if ( this.refs.dialog ) {
+			this.refs.dialog.getWrappedInstance().open();
+		}
+
 		analytics.ga.recordEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
-	}
+	};
 
 	render() {
 		const { site, redirect, linkDisplay } = this.props;

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import { omit } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -11,29 +12,27 @@ import Button from 'components/button';
 import DisconnectJetpackDialog from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog';
 import analytics from 'lib/analytics';
 
-export default React.createClass( {
+class DisconnectJetpackButton extends Component {
+	constructor( props ) {
+		super( props );
 
-	displayName: 'DisconnectJetpackButton',
+		this.handleClick = this.handleClick.bind( this );
+	}
 
-	propTypes: {
-		site: React.PropTypes.object.isRequired,
-		redirect: React.PropTypes.string.isRequired,
-		disabled: React.PropTypes.bool,
-		linkDisplay: React.PropTypes.bool,
-		isMock: React.PropTypes.bool,
-		text: React.PropTypes.string
-	},
+	handleClick( event ) {
+		event.preventDefault();
+		if ( this.props.isMock ) {
+			return;
+		}
 
-	getDefaultProps() {
-		return {
-			linkDisplay: true
-		};
-	},
+		this.refs.dialog.open();
+		analytics.ga.recordEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
+	}
 
 	render() {
-		const { site, redirect, linkDisplay } = this.props;
+		const { site, redirect, linkDisplay, translate } = this.props;
 
-		const omitProps = [ 'site', 'redirect', 'isMock', 'linkDisplay', 'text' ];
+		const omitProps = [ 'site', 'redirect', 'isMock', 'linkDisplay', 'text', 'moment', 'numberFormat', 'translate' ];
 		const buttonProps = {
 			...omit( this.props, omitProps ),
 			id: `disconnect-jetpack-${ site.ID }`,
@@ -42,31 +41,35 @@ export default React.createClass( {
 			disabled: this.props.disabled,
 			scary: true,
 			borderless: linkDisplay,
-			onClick: ( event ) => {
-				event.preventDefault();
-				if ( this.props.isMock ) {
-					return;
-				}
-				this.refs.dialog.open();
-				analytics.ga.recordEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
-			}
+			onClick: this.handleClick
 		};
 
 		let { text } = this.props;
 
 		if ( ! text ) {
-			text = this.translate( 'Disconnect', {
+			text = translate( 'Disconnect', {
 				context: 'Jetpack: Action user takes to disconnect Jetpack site from .com'
 			} );
 		}
 
-		const buttonChildren = (
-			<div>
-				{ text }
-				<DisconnectJetpackDialog site={ site } ref="dialog" redirect={ redirect } />
-			</div>
-		);
-
-		return React.createElement( Button, buttonProps, buttonChildren );
+		return <Button { ...buttonProps }>
+			{ text }
+			<DisconnectJetpackDialog site={ site } ref="dialog" redirect={ redirect } />
+		</Button>;
 	}
-} );
+}
+
+DisconnectJetpackButton.propTypes = {
+	site: PropTypes.object.isRequired,
+	redirect: PropTypes.string.isRequired,
+	disabled: PropTypes.bool,
+	linkDisplay: PropTypes.bool,
+	isMock: PropTypes.bool,
+	text: PropTypes.string
+};
+
+DisconnectJetpackButton.defaultProps = {
+	linkDisplay: true
+};
+
+export default localize( DisconnectJetpackButton );

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { omit } from 'lodash';
-import { localize } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -24,15 +24,14 @@ class DisconnectJetpackButton extends Component {
 		if ( this.props.isMock ) {
 			return;
 		}
-
-		this.refs.dialog.open();
+		this.refs.dialog.getWrappedInstance().open();
 		analytics.ga.recordEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
 	}
 
 	render() {
-		const { site, redirect, linkDisplay, translate } = this.props;
+		const { site, redirect, linkDisplay } = this.props;
 
-		const omitProps = [ 'site', 'redirect', 'isMock', 'linkDisplay', 'text', 'moment', 'numberFormat', 'translate' ];
+		const omitProps = [ 'site', 'redirect', 'isMock', 'linkDisplay', 'text' ];
 		const buttonProps = {
 			...omit( this.props, omitProps ),
 			id: `disconnect-jetpack-${ site.ID }`,
@@ -72,4 +71,4 @@ DisconnectJetpackButton.defaultProps = {
 	linkDisplay: true
 };
 
-export default localize( DisconnectJetpackButton );
+export default DisconnectJetpackButton;

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { omit } from 'lodash';
 import { translate } from 'i18n-calypso';
 
@@ -10,7 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import DisconnectJetpackDialog from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog';
-import analytics from 'lib/analytics';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 class DisconnectJetpackButton extends Component {
 	handleClick = ( event ) => {
@@ -23,13 +24,13 @@ class DisconnectJetpackButton extends Component {
 			this.refs.dialog.getWrappedInstance().open();
 		}
 
-		analytics.ga.recordEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
+		this.props.recordGoogleEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
 	};
 
 	render() {
 		const { site, redirect, linkDisplay } = this.props;
 
-		const omitProps = [ 'site', 'redirect', 'isMock', 'linkDisplay', 'text' ];
+		const omitProps = [ 'site', 'redirect', 'isMock', 'linkDisplay', 'text', 'recordGoogleEvent' ];
 		const buttonProps = {
 			...omit( this.props, omitProps ),
 			id: `disconnect-jetpack-${ site.ID }`,
@@ -69,4 +70,7 @@ DisconnectJetpackButton.defaultProps = {
 	linkDisplay: true
 };
 
-export default DisconnectJetpackButton;
+export default connect(
+	null,
+	{ recordGoogleEvent }
+)( DisconnectJetpackButton );

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import page from 'page';
-import React from 'react';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -14,18 +14,24 @@ import analytics from 'lib/analytics';
 import SitesListActions from 'lib/sites-list/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 
-const DisconnectJetpackDialog = React.createClass( {
-	getInitialState() {
-		return {
+class DisconnectJetpackDialog extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
 			showJetpackDisconnectDialog: false
 		};
-	},
+
+		this.open = this.open.bind( this );
+		this.close = this.close.bind( this );
+		this.disconnectJetpack = this.disconnectJetpack.bind( this );
+	}
 
 	open() {
 		this.setState( {
 			showJetpackDisconnectDialog: true
 		} );
-	},
+	}
 
 	close( action ) {
 		this.setState( {
@@ -38,7 +44,7 @@ const DisconnectJetpackDialog = React.createClass( {
 		} else {
 			analytics.ga.recordEvent( 'Jetpack', 'Clicked To Cancel Disconnect Jetpack Dialog' );
 		}
-	},
+	}
 
 	disconnectJetpack() {
 		const { site, selectedSite } = this.props;
@@ -59,7 +65,7 @@ const DisconnectJetpackDialog = React.createClass( {
 		if ( selectedSite === site ) {
 			page.redirect( '/sites' );
 		}
-	},
+	}
 
 	render() {
 		const { translate, site } = this.props;
@@ -100,7 +106,7 @@ const DisconnectJetpackDialog = React.createClass( {
 			</Dialog>
 		);
 	}
-} );
+}
 
 export default connect(
 	state => ( {

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -3,7 +3,7 @@
  */
 import page from 'page';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -68,7 +68,7 @@ class DisconnectJetpackDialog extends Component {
 	}
 
 	render() {
-		const { translate, site } = this.props;
+		const { site } = this.props;
 		const deactivationButtons = [
 			{
 				action: 'cancel',
@@ -111,5 +111,10 @@ class DisconnectJetpackDialog extends Component {
 export default connect(
 	state => ( {
 		selectedSite: getSelectedSite( state )
-	} )
-)( localize( DisconnectJetpackDialog ) );
+	} ),
+	null,
+	null,
+	{
+		withRef: true
+	}
+)( DisconnectJetpackDialog );

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -10,9 +10,9 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
-import analytics from 'lib/analytics';
 import SitesListActions from 'lib/sites-list/actions';
 import { getSelectedSite } from 'state/ui/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 class DisconnectJetpackDialog extends Component {
 	constructor( props ) {
@@ -40,9 +40,9 @@ class DisconnectJetpackDialog extends Component {
 
 		if ( action === 'continue' ) {
 			this.disconnectJetpack();
-			analytics.ga.recordEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
+			this.props.recordGoogleEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
 		} else {
-			analytics.ga.recordEvent( 'Jetpack', 'Clicked To Cancel Disconnect Jetpack Dialog' );
+			this.props.recordGoogleEvent( 'Jetpack', 'Clicked To Cancel Disconnect Jetpack Dialog' );
 		}
 	}
 
@@ -112,7 +112,9 @@ export default connect(
 	state => ( {
 		selectedSite: getSelectedSite( state )
 	} ),
-	null,
+	{
+		recordGoogleEvent
+	},
 	null,
 	{
 		withRef: true

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -1,31 +1,38 @@
 /**
  * External dependencies
  */
-var page = require( 'page' ),
-	React = require( 'react' );
+import page from 'page';
+import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var sites = require( 'lib/sites-list' )(),
-	Dialog = require( 'components/dialog' ),
-	analytics = require( 'lib/analytics' ),
-	SitesListActions = require( 'lib/sites-list/actions' );
+import sitesList from 'lib/sites-list';
+import Dialog from 'components/dialog';
+import analytics from 'lib/analytics';
+import SitesListActions from 'lib/sites-list/actions';
 
-module.exports = React.createClass( {
+const sites = sitesList();
 
-	displayName: 'DisconnectJetpackDialog',
-
-	getInitialState: function() {
-		return { showJetpackDisconnectDialog: false };
+const DisconnectJetpackDialog = React.createClass( {
+	getInitialState() {
+		return {
+			showJetpackDisconnectDialog: false
+		};
 	},
 
-	open: function() {
-		this.setState( { showJetpackDisconnectDialog: true } );
+	open() {
+		this.setState( {
+			showJetpackDisconnectDialog: true
+		} );
 	},
 
-	close: function( action ) {
-		this.setState( { showJetpackDisconnectDialog: false } );
+	close( action ) {
+		this.setState( {
+			showJetpackDisconnectDialog: false
+		} );
+
 		if ( action === 'continue' ) {
 			this.disconnectJetpack();
 			analytics.ga.recordEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
@@ -34,50 +41,51 @@ module.exports = React.createClass( {
 		}
 	},
 
-	disconnectJetpack: function() {
-		var selectedSite = sites.getSelectedSite();
+	disconnectJetpack() {
+		const { site } = this.props;
+		const selectedSite = sites.getSelectedSite();
 
 		// remove any error and completed notices
 		SitesListActions.removeSitesNotices( [ { status: 'error' }, { status: 'completed' } ] );
 
-		if ( this.props.site ) {
-			SitesListActions.disconnect( this.props.site );
-			if ( selectedSite === this.props.site && this.props.redirect ) {
+		if ( site ) {
+			SitesListActions.disconnect( site );
+			if ( selectedSite === site && this.props.redirect ) {
 				page.redirect( this.props.redirect );
 				return;
 			}
 		} else if ( this.props.sites ) {
-			this.props.sites.getSelectedOrAllWithPlugins().forEach( function( site ) {
-				SitesListActions.disconnect( site );
-			} );
+			this.props.sites.getSelectedOrAllWithPlugins().forEach( siteItem => SitesListActions.disconnect( siteItem ) );
 		}
-		if ( selectedSite === this.props.site ) {
+
+		if ( selectedSite === site ) {
 			page.redirect( '/sites' );
 		}
 	},
 
-	render: function() {
-		var moreInfo,
-			deactivationButtons = [
-				{
-					action: 'cancel',
-					label: this.translate( 'Cancel' )
-				},
-				{
-					action: 'continue',
-					label: this.translate( 'Disconnect' ),
-					isPrimary: true
-				}
-			];
+	render() {
+		const { translate, site } = this.props;
+		const deactivationButtons = [
+			{
+				action: 'cancel',
+				label: translate( 'Cancel' )
+			},
+			{
+				action: 'continue',
+				label: translate( 'Disconnect' ),
+				isPrimary: true
+			}
+		];
+		let moreInfo;
 
-		if ( this.props.site && this.props.site.name || this.props.site && this.props.site.title ) {
-			moreInfo = this.translate(
+		if ( site && site.name || site && site.title ) {
+			moreInfo = translate(
 				'Disconnecting Jetpack will remove access to WordPress.com features for %(siteName)s.', {
-					args: { siteName: this.props.site.name || this.props.site.title },
+					args: { siteName: site.name || site.title },
 					context: 'Jetpack: Warning message displayed prior to disconnecting a Jetpack Site.'
 				} );
 		} else {
-			moreInfo = this.translate(
+			moreInfo = translate(
 				'Disconnecting Jetpack will remove access to WordPress.com features.', {
 					context: 'Jetpack: Warning message displayed prior to disconnecting multiple Jetpack Sites.'
 				} );
@@ -89,9 +97,11 @@ module.exports = React.createClass( {
 				buttons={ deactivationButtons }
 				onClose={ this.close }
 				transitionLeave={ false }>
-				<h1>{ this.translate( 'Disconnect Jetpack' ) }</h1>
+				<h1>{ translate( 'Disconnect Jetpack' ) }</h1>
 				<p>{ moreInfo }</p>
 			</Dialog>
 		);
 	}
 } );
+
+export default localize( DisconnectJetpackDialog );

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -4,16 +4,15 @@
 import page from 'page';
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import sitesList from 'lib/sites-list';
 import Dialog from 'components/dialog';
 import analytics from 'lib/analytics';
 import SitesListActions from 'lib/sites-list/actions';
-
-const sites = sitesList();
+import { getSelectedSite } from 'state/ui/selectors';
 
 const DisconnectJetpackDialog = React.createClass( {
 	getInitialState() {
@@ -42,8 +41,7 @@ const DisconnectJetpackDialog = React.createClass( {
 	},
 
 	disconnectJetpack() {
-		const { site } = this.props;
-		const selectedSite = sites.getSelectedSite();
+		const { site, selectedSite } = this.props;
 
 		// remove any error and completed notices
 		SitesListActions.removeSitesNotices( [ { status: 'error' }, { status: 'completed' } ] );
@@ -104,4 +102,8 @@ const DisconnectJetpackDialog = React.createClass( {
 	}
 } );
 
-export default localize( DisconnectJetpackDialog );
+export default connect(
+	state => ( {
+		selectedSite: getSelectedSite( state )
+	} )
+)( localize( DisconnectJetpackDialog ) );

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -67,8 +67,24 @@ class DisconnectJetpackDialog extends Component {
 		}
 	}
 
-	render() {
+	renderInfo() {
 		const { site } = this.props;
+
+		if ( ! site ) {
+			return translate( 'Disconnecting Jetpack will remove access to WordPress.com features.', {
+				context: 'Jetpack: Warning message displayed prior to disconnecting multiple Jetpack Sites.'
+			} );
+		}
+
+		return translate( 'Disconnecting Jetpack will remove access to WordPress.com features for %(siteName)s.', {
+			args: {
+				siteName: site.name || site.title
+			},
+			context: 'Jetpack: Warning message displayed prior to disconnecting a Jetpack Site.'
+		} );
+	}
+
+	render() {
 		const deactivationButtons = [
 			{
 				action: 'cancel',
@@ -80,20 +96,6 @@ class DisconnectJetpackDialog extends Component {
 				isPrimary: true
 			}
 		];
-		let moreInfo;
-
-		if ( site && site.name || site && site.title ) {
-			moreInfo = translate(
-				'Disconnecting Jetpack will remove access to WordPress.com features for %(siteName)s.', {
-					args: { siteName: site.name || site.title },
-					context: 'Jetpack: Warning message displayed prior to disconnecting a Jetpack Site.'
-				} );
-		} else {
-			moreInfo = translate(
-				'Disconnecting Jetpack will remove access to WordPress.com features.', {
-					context: 'Jetpack: Warning message displayed prior to disconnecting multiple Jetpack Sites.'
-				} );
-		}
 
 		return (
 			<Dialog
@@ -102,7 +104,7 @@ class DisconnectJetpackDialog extends Component {
 				onClose={ this.close }
 				transitionLeave={ false }>
 				<h1>{ translate( 'Disconnect Jetpack' ) }</h1>
-				<p>{ moreInfo }</p>
+				<p>{ this.renderInfo() }</p>
 			</Dialog>
 		);
 	}

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -18,6 +18,7 @@ import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import pluginsAccessControl from 'my-sites/plugins/access-control';
 import PluginItem from './plugin-item/plugin-item';
+import DocumentHead from 'components/data/document-head';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
@@ -252,6 +253,10 @@ const PluginsMain = React.createClass( {
 		return isEmpty( plugins ) && this.isFetchingPlugins();
 	},
 
+	renderDocumentHead() {
+		return <DocumentHead title={ this.translate( 'Plugins', { textOnly: true } ) } />;
+	},
+
 	renderPluginsContent() {
 		const plugins = this.state.plugins || [];
 		const selectedSite = this.props.sites.getSelectedSite();
@@ -338,6 +343,7 @@ const PluginsMain = React.createClass( {
 		if ( ! getOr( selectedSite, 'jetpack', true ) ) {
 			return (
 				<Main>
+					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<WpcomPluginPanel />
 				</Main>
@@ -347,6 +353,7 @@ const PluginsMain = React.createClass( {
 		if ( this.state.accessError ) {
 			return (
 				<Main>
+					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
 					{ this.state.accessError.featureExample
@@ -360,6 +367,7 @@ const PluginsMain = React.createClass( {
 		if ( selectedSite && selectedSite.jetpack && ! selectedSite.canManage() ) {
 			return (
 				<Main>
+					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="optInManage"
@@ -379,6 +387,7 @@ const PluginsMain = React.createClass( {
 
 		return (
 			<Main className={ containerClass }>
+				{ this.renderDocumentHead() }
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -29,6 +29,7 @@ import PluginSections from 'my-sites/plugins/plugin-sections';
 import pluginsAccessControl from 'my-sites/plugins/access-control';
 import EmptyContent from 'components/empty-content';
 import FeatureExample from 'components/feature-example';
+import DocumentHead from 'components/data/document-head';
 import WpcomPluginsList from 'my-sites/plugins-wpcom/plugins-list';
 
 /**
@@ -104,7 +105,8 @@ const SinglePlugin = React.createClass( {
 			accessError: pluginsAccessControl.hasRestrictedAccess(),
 			sites: PluginsStore.getSites( sites, props.pluginSlug ) || [],
 			notInstalledSites: PluginsStore.getNotInstalledSites( sites, props.pluginSlug ) || [],
-			plugin: plugin
+			plugin: plugin,
+			pageTitle: this.buildPageTitle( plugin.name ),
 		};
 	},
 
@@ -114,6 +116,15 @@ const SinglePlugin = React.createClass( {
 		this.updatePageTitle();
 	},
 
+	buildPageTitle( pluginName ) {
+		return this.translate( '%(pluginName)s Plugin', '%(pluginName)s Plugins', {
+			count: pluginName.toLowerCase() !== 'standard' | 0,
+			args: { pluginName: upperFirst( this._currentPageTitle ) },
+			textOnly: true,
+			context: 'Page title: Plugin detail'
+		} )
+	},
+
 	updatePageTitle() {
 		const pageTitle = this.state.plugin ? this.state.plugin.name : this.props.pluginSlug;
 		if ( this._currentPageTitle === pageTitle ) {
@@ -121,14 +132,10 @@ const SinglePlugin = React.createClass( {
 		}
 
 		this._currentPageTitle = pageTitle;
-		this.pluginRefreshTimeout = setTimeout( () => {
-			this.props.onPluginRefresh( this.translate( '%(pluginName)s Plugin', '%(pluginName)s Plugins', {
-				count: pageTitle.toLowerCase() !== 'standard' | 0,
-				args: { pluginName: upperFirst( this._currentPageTitle ) },
-				textOnly: true,
-				context: 'Page title: Plugin detail'
-			} ) );
-		}, 1 );
+
+		this.setState( {
+			pageTitle: this.buildPageTitle( pageTitle )
+		} )
 	},
 
 	removeNotice( error ) {
@@ -227,6 +234,10 @@ const SinglePlugin = React.createClass( {
 		);
 	},
 
+	renderDocumentHead() {
+		return <DocumentHead title={ this.state.pageTitle } />;
+	},
+
 	renderSitesList( plugin ) {
 		if ( this.props.siteUrl || this.isFetching() ) {
 			return;
@@ -303,6 +314,7 @@ const SinglePlugin = React.createClass( {
 		if ( selectedSite && ! selectedSite.jetpack ) {
 			return (
 				<MainComponent>
+					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<WpcomPluginsList />
 				</MainComponent>
@@ -312,6 +324,7 @@ const SinglePlugin = React.createClass( {
 		if ( this.state.accessError ) {
 			return (
 				<MainComponent>
+					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
 					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
@@ -333,6 +346,7 @@ const SinglePlugin = React.createClass( {
 		if ( selectedSite && selectedSite.jetpack && ! selectedSite.canManage() ) {
 			return (
 				<MainComponent>
+					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="optInManage"
@@ -348,6 +362,7 @@ const SinglePlugin = React.createClass( {
 
 		return (
 			<MainComponent>
+				{ this.renderDocumentHead() }
 				<SidebarNavigation />
 				<div className="plugin__page">
 					{ this.displayHeader() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import pluginsAccessControl from 'my-sites/plugins/access-control';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import DocumentHead from 'components/data/document-head';
 import Search from 'components/search';
 import SearchCard from 'components/search-card';
 import SectionNav from 'components/section-nav';
@@ -265,7 +266,7 @@ const PluginsBrowser = React.createClass( {
 		);
 	},
 
-	getMockPluginItems: function() {
+	getMockPluginItems() {
 		return <PluginsBrowserList
 			plugins={ this.getPluginsShortList( 'popular' ) }
 			listName={ 'Plugins' }
@@ -273,10 +274,15 @@ const PluginsBrowser = React.createClass( {
 			size={ 12 } />;
 	},
 
+	renderDocumentHead() {
+		return <DocumentHead title={ this.translate( 'Plugin Browser', { textOnly: true } ) } />;
+	},
+
 	renderAccessError() {
 		if ( this.state.accessError ) {
 			return (
 				<MainComponent>
+					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
 					{ this.state.accessError.featureExample
@@ -290,6 +296,7 @@ const PluginsBrowser = React.createClass( {
 
 		return (
 			<MainComponent>
+				{ this.renderDocumentHead() }
 				<SidebarNavigation />
 				<JetpackManageErrorPage
 					template="optInManage"
@@ -312,6 +319,7 @@ const PluginsBrowser = React.createClass( {
 
 		return (
 			<MainComponent>
+				{ this.renderDocumentHead() }
 				<SidebarNavigation />
 				{ this.getPageHeaderView() }
 				{ this.getPluginBrowserContent() }

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -1,19 +1,21 @@
-/*
+/**
  * External dependencies
-*/
+ */
 import { expect } from 'chai';
 import { noop } from 'lodash';
+import { Provider as ReduxProvider } from 'react-redux';
 
-/*
+/**
  * Internal dependencies
-*/
+ */
 import useMockery from 'test/helpers/use-mockery';
 import useFakeDom from 'test/helpers/use-fake-dom';
+import { createReduxStore } from 'state';
 
 import { sites } from './fixtures';
 
 describe( 'PluginsList', () => {
-	let React, testRenderer, PluginsList, siteListMock;
+	let React, testRenderer, PluginsList, siteListMock, TestUtils;
 
 	useFakeDom();
 
@@ -21,19 +23,18 @@ describe( 'PluginsList', () => {
 		mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );
 		mockery.registerSubstitute( 'query', 'component-query' );
 
-		let emptyComponent = require( 'test/helpers/react/empty-component' );
+		const emptyComponent = require( 'test/helpers/react/empty-component' );
 		mockery.registerMock( 'my-sites/plugins/plugin-item/plugin-item', emptyComponent );
 		mockery.registerMock( 'my-sites/plugins/plugin-list-header', emptyComponent );
 
-		mockery.registerMock( 'lib/analytics', { ga: { recordEvent: noop }} );
+		mockery.registerMock( 'lib/analytics', { ga: { recordEvent: noop } } );
 		mockery.registerMock( 'lib/sites-list', () => siteListMock );
 	} );
 
 	before( () => {
 		React = require( 'react' );
-
-		const TestUtils = require( 'react-addons-test-utils' ),
-			ReactInjection = require( 'react/lib/ReactInjection' );
+		TestUtils = require( 'react-addons-test-utils' );
+		const ReactInjection = require( 'react/lib/ReactInjection' );
 
 		ReactInjection.Class.injectMixin( require( 'i18n-calypso' ).mixin );
 
@@ -48,8 +49,8 @@ describe( 'PluginsList', () => {
 
 		before( () => {
 			plugins = [
-				{sites, slug: 'hello', name: 'Hello Dolly'},
-				{sites, slug: 'jetpack', name: 'Jetpack'} ];
+				{ sites, slug: 'hello', name: 'Hello Dolly' },
+				{ sites, slug: 'jetpack', name: 'Jetpack' } ];
 
 			props = {
 				plugins,
@@ -62,7 +63,12 @@ describe( 'PluginsList', () => {
 		} );
 
 		beforeEach( () => {
-			renderedPluginsList = testRenderer( <PluginsList { ...props } /> );
+			renderedPluginsList = testRenderer(
+				<ReduxProvider store={ createReduxStore() }>
+					<PluginsList { ...props } />
+				</ReduxProvider>
+			);
+			renderedPluginsList = TestUtils.scryRenderedComponentsWithType( renderedPluginsList, PluginsList )[ 0 ];
 		} );
 
 		it( 'should be intialized with no selectedPlugins', () => {
@@ -76,7 +82,7 @@ describe( 'PluginsList', () => {
 		} );
 
 		it( 'should always reset to all selected when toggled on', () => {
-			renderedPluginsList.togglePlugin( plugins[0] );
+			renderedPluginsList.togglePlugin( plugins[ 0 ] );
 			expect( Object.keys( renderedPluginsList.state.selectedPlugins ) ).to.have.lengthOf( 1 );
 
 			renderedPluginsList.toggleBulkManagement();


### PR DESCRIPTION
This PR removes the usage of `sitesList.getSelectedSite()` within `my-sites/plugins/disconnect-jetpack`. It also uses the chance to refactor the 2 components there (`DisconnectJetpackDialog` and `DisconnectJetpackButton`), introducing ES6 classes, ES6ifying and fixing all ESLint warnings. 

To test:

1. Checkout this branch
2. Verify all tests pass
3. Go to `http://calypso.localhost:3000/plugins/jetpack/$site`, where `$site` is a Jetpack site and verify there are no regressions with the Disconnect Jetpack button and the Disconnect Jetpack dialog.

