### PR TITLE
Domains: Show correct privacy protection example depending on registrar

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -1,8 +1,22 @@
-var keyMirror = require( 'key-mirror' );
+/**
+ * External dependencies
+ */
+import keyMirror from 'key-mirror';
 
-module.exports.type = keyMirror( {
+const type = keyMirror( {
 	MAPPED: null,
 	REGISTERED: null,
 	SITE_REDIRECT: null,
 	WPCOM: null
 } );
+
+const registrar = {
+	OPENHRS: 'OpenHRS',
+	OPENSRS: 'OpenSRS',
+	WWD: 'WWD'
+};
+
+export default {
+	type,
+	registrar
+};

--- a/client/lib/domains/whois/protected-contact-information.js
+++ b/client/lib/domains/whois/protected-contact-information.js
@@ -1,0 +1,69 @@
+/**
+ * Internal dependencies
+ */
+import { registrar as registrarNames } from 'lib/domains/constants';
+
+function getOpenHrsProtectedContactInformation( domain ) {
+	return {
+		firstName: 'Private',
+		lastName: 'Whois',
+		organization: 'Knock Knock Whois Not There LLC',
+		email: `${ domain }@privatewho.is`,
+		phone: '+1.8772738550',
+		address1: '60, 29th Street, #343',
+		address2: '',
+		city: 'San Francisco',
+		state: 'CA',
+		postalCode: '94110-4929',
+		countryCode: 'US'
+	};
+}
+
+function getOpenSrsProtectedContactInformation( domain ) {
+	return {
+		firstName: 'Contact Privacy Inc.',
+		lastName: 'Customer 012345',
+		organization: 'Contact Privacy Inc. Customer 012345',
+		email: `${ domain }@contactprivacy.com`,
+		phone: '+1.4165385457',
+		address1: '96 Mowat Ave',
+		address2: '',
+		city: 'Toronto',
+		state: 'ON',
+		postalCode: 'M6K 3M1',
+		countryCode: 'CA'
+	};
+}
+
+function getWwdProtectedContactInformation( domain ) {
+	return {
+		firstName: 'Registration',
+		lastName: 'Private',
+		organization: 'Domains By Proxy, LLC',
+		email: `${ domain }@domainsbyproxy.com`,
+		phone: '+1.4806242599',
+		address1: '14747 N Northsight Blvd',
+		address2: 'Suite 111, PMB 309',
+		city: 'Scottsdale',
+		state: 'AZ',
+		postalCode: '85260',
+		countryCode: 'US'
+	};
+}
+
+function getProtectedContactInformation( domain, registrar ) {
+	const { OPENHRS, OPENSRS, WWD } = registrarNames;
+	switch ( registrar ) {
+		case OPENHRS:
+			return getOpenHrsProtectedContactInformation( domain );
+
+		case OPENSRS:
+			return getOpenSrsProtectedContactInformation( domain );
+
+		case WWD:
+		default:
+			return getWwdProtectedContactInformation( domain );
+	}
+}
+
+export default getProtectedContactInformation;

--- a/client/my-sites/upgrades/checkout/privacy-protection-dialog.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection-dialog.jsx
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-const React = require( 'react' );
+import React from 'react';
+import transform from 'lodash/transform';
 
 /**
  * Internal dependencies
  */
-const Dialog = require( 'components/dialog' ),
-	PrivacyProtectionExample = require( './privacy-protection-example' );
+import Dialog from 'components/dialog';
+import PrivacyProtectionExample from './privacy-protection-example';
+import getProtectedContactInformation from 'lib/domains/whois/protected-contact-information';
 
 module.exports = React.createClass( {
 	displayName: 'PrivacyProtectionDialog',
@@ -18,20 +20,10 @@ module.exports = React.createClass( {
 		};
 	},
 
-	getProtectedFields: function() {
-		return {
-			firstName: {},
-			lastName: {},
-			organization: { value: 'Domains By Proxy, LLC' },
-			email: { value: this.props.domain + '@domainsbyproxy.com' },
-			phone: { value: '+1.4806242599' },
-			address1: { value: '14747 N Northsight Blvd' },
-			address2: { value: 'Suite 111, PMB 309' },
-			city: { value: 'Scottsdale' },
-			state: { value: 'AZ' },
-			postalCode: { value: '85260' },
-			countryCode: { value: 'US' }
-		};
+	formatAsFields: function( contactInformation ) {
+		return transform( contactInformation, ( result, value, key ) => {
+			result[ key ] = { value };
+		}, {} );
 	},
 
 	render: function() {
@@ -49,7 +41,9 @@ module.exports = React.createClass( {
 					<h1>{ this.translate( 'Why do I need Privacy Protection?' ) }</h1>
 					<p>
 						{ this.translate( 'Domains are required to have publicly accessible contact information.' ) }
-						<span className="line-break">{ this.translate( 'With Privacy Protection, we show our partner\'s contact information instead of your own, helping to:' ) }</span>
+						<span className="line-break">
+							{ this.translate( 'With Privacy Protection, we show our partner\'s contact information instead of your own, helping to:' ) }
+						</span>
 					</p>
 				</header>
 				<ul className="privacy-features">
@@ -68,7 +62,7 @@ module.exports = React.createClass( {
 						</div>
 						<PrivacyProtectionExample
 							countriesList= { this.props.countriesList }
-							fields={ this.getProtectedFields() } />
+							fields={ this.formatAsFields( getProtectedContactInformation( this.props.domain, this.props.registrar ) ) } />
 						<button
 								className="button is-primary"
 								disabled={ this.props.disabled }

--- a/client/my-sites/upgrades/checkout/privacy-protection.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-const cartItems = require( 'lib/cart-values' ).cartItems,
-	PrivacyProtectionDialog = require( './privacy-protection-dialog' ),
-	Card = require( 'components/card' ),
-	Gridicon = require( 'components/gridicon' );
+import { cartItems } from 'lib/cart-values';
+import PrivacyProtectionDialog from './privacy-protection-dialog';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
 
 module.exports = React.createClass( {
 	displayName: 'PrivacyProtection',
@@ -30,33 +30,20 @@ module.exports = React.createClass( {
 		this.props.onDialogClose();
 	},
 
-	getDomainRegistrations: function() {
-		return cartItems.getDomainRegistrations( this.props.cart );
-	},
-
-	getFirstDomainToRegister: function() {
-		const domainRegistration = this.getDomainRegistrations().shift();
-
-		return domainRegistration.meta;
-	},
-
 	hasDomainPartOfPlan: function() {
 		const cart = this.props.cart;
 		return cart.has_bundle_credit || cartItems.hasPlan( cart );
 	},
 
-	getNumberOfDomainRegistrations: function() {
-		return this.getDomainRegistrations().length;
-	},
-
 	getPrivacyProtectionCost: function() {
 		const products = this.props.productsList.get();
-
 		return products.private_whois.cost_display;
 	},
 
 	render: function() {
-		const numberOfDomainRegistrations = this.getNumberOfDomainRegistrations(),
+		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart ),
+			numberOfDomainRegistrations = domainRegistrations.length,
+			firstDomainToRegister = domainRegistrations[0],
 			hasOneFreePrivacy = this.hasDomainPartOfPlan() && numberOfDomainRegistrations === 1,
 			privacyText = this.translate(
 				"Privacy Protection hides your personal information in your domain's public records, to protect your identity and prevent spam."
@@ -100,7 +87,8 @@ module.exports = React.createClass( {
 				</Card>
 				<PrivacyProtectionDialog
 					disabled={ this.props.disabled }
-					domain={ this.getFirstDomainToRegister() }
+					domain={ firstDomainToRegister.meta }
+					registrar={ firstDomainToRegister.extra && firstDomainToRegister.extra.registrar }
 					cost={ this.getPrivacyProtectionCost() }
 					countriesList={ this.props.countriesList }
 					fields={ this.props.fields }

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -708,8 +708,8 @@
 				display: block;
 				height: 25px;
 				position: absolute;
-					left: -8px;
-					top: -8px;
+				left: -8px;
+				top: -8px;
 				width: 25px;
 			}
 
@@ -750,7 +750,7 @@
 				background: $gray-light;
 				font-size: 12px;
 				margin: 20px -20px;
-				min-height: 126px;
+				min-height: 144px;
 				padding: 20px;
 
 				span {


### PR DESCRIPTION
Depending on the registrar for the domain about to be registered, we should display a different privacy protection examples - each registrar uses their own privacy service:
* WWD: Domains By Proxy
* OpenSRS (`.live`): Contact Privacy Inc.
* OpenHRS (`.wales and new .net registrations`): Knock Knock Whois **Not** There LLC (ha-ha, get it?)

### Testing ###
Requires `D3276-code` on the backend.
During checkout, make sure that in the privacy protection dialog, the correct privacy service's contact details are used:
  **WWD domain during checkout**
  <img width="704" alt="screen shot 2016-07-27 at 11 05 41" src="https://cloud.githubusercontent.com/assets/3392497/17169985/67dd2e84-53ea-11e6-9fff-584cca22aae8.png">
  **OpenHRS domain during checkout**
  <img width="699" alt="screen shot 2016-07-27 at 11 06 55" src="https://cloud.githubusercontent.com/assets/3392497/17169988/681e2754-53ea-11e6-9cab-d13191b4681a.png">
  **OpenSRS domain during checkout**
  <img width="690" alt="screen shot 2016-07-27 at 11 07 52" src="https://cloud.githubusercontent.com/assets/3392497/17169987/6812dd9a-53ea-11e6-8d94-48f789be8e8e.png">

Fixes #6938