### PR TITLE
Refactor: my-sites/sidebar/sidebar convert to es6 class

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -1,66 +1,70 @@
 /**
  * External dependencies
  */
-var analytics = require( 'lib/analytics' ),
-	classNames = require( 'classnames' ),
-	debug = require( 'debug' )( 'calypso:my-sites:sidebar' ),
-	has = require( 'lodash/has' ),
-	includes = require( 'lodash/includes' ),
-	React = require( 'react' );
-
+import classNames from 'classnames';
+import debugFactory from 'debug';
+import { has, includes } from 'lodash';
+import { localize } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	CurrentSite = require( 'my-sites/current-site' ),
-	Gridicon = require( 'components/gridicon' ),
-	productsValues = require( 'lib/products-values' ),
-	PublishMenu = require( './publish-menu' ),
-	Sidebar = require( 'layout/sidebar' ),
-	SidebarHeading = require( 'layout/sidebar/heading' ),
-	SidebarItem = require( 'layout/sidebar/item' ),
-	SidebarMenu = require( 'layout/sidebar/menu' ),
-	SidebarRegion = require( 'layout/sidebar/region' ),
-	SiteStatsStickyLink = require( 'components/site-stats-sticky-link' );
-
+import analytics from 'lib/analytics';
 import Button from 'components/button';
+import config from 'config';
+import CurrentSite from 'my-sites/current-site';
+import Gridicon from 'components/gridicon';
+import productsValues from 'lib/products-values';
+import PublishMenu from './publish-menu';
+import Sidebar from 'layout/sidebar';
 import SidebarButton from 'layout/sidebar/button';
 import SidebarFooter from 'layout/sidebar/footer';
+import SidebarHeading from 'layout/sidebar/heading';
+import SidebarItem from 'layout/sidebar/item';
+import SidebarMenu from 'layout/sidebar/menu';
+import SidebarRegion from 'layout/sidebar/region';
+import SiteStatsStickyLink from 'components/site-stats-sticky-link';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getThemeCustomizeUrl as getCustomizeUrl } from 'state/themes/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
 
-export const MySitesSidebar = React.createClass( {
-	propTypes: {
-		setNextLayoutFocus: React.PropTypes.func.isRequired,
-		setLayoutFocus: React.PropTypes.func.isRequired,
-		path: React.PropTypes.string,
-		sites: React.PropTypes.object,
-		currentUser: React.PropTypes.object,
-	},
+/**
+ * Module variables
+ */
+const debug = debugFactory( 'calypso:my-sites:sidebar' );
 
-	componentDidMount: function() {
+export class MySitesSidebar extends Component {
+
+	static propTypes = {
+		setNextLayoutFocus: PropTypes.func.isRequired,
+		setLayoutFocus: PropTypes.func.isRequired,
+		path: PropTypes.string,
+		sites: PropTypes.object,
+		currentUser: PropTypes.object,
+	};
+
+	componentDidMount() {
 		debug( 'The sidebar React component is mounted.' );
-	},
+	}
 
-	onNavigate: function() {
+	onNavigate = () => {
 		this.props.setNextLayoutFocus( 'content' );
 		window.scrollTo( 0, 0 );
-	},
+	};
 
-	onPreviewSite( event ) {
+	onPreviewSite = ( event ) => {
 		const site = this.getSelectedSite();
 		if ( site.is_previewable && ! event.metaKey && ! event.ctrlKey ) {
 			event.preventDefault();
 			this.props.setLayoutFocus( 'preview' );
 		}
-	},
+	};
 
-	itemLinkClass: function( paths, existingClasses ) {
+	itemLinkClass = ( paths, existingClasses ) => {
 		var classSet = {};
 
 		if ( typeof existingClasses !== 'undefined' ) {
@@ -76,9 +80,9 @@ export const MySitesSidebar = React.createClass( {
 		classSet.selected = this.isItemLinkSelected( paths );
 
 		return classNames( classSet );
-	},
+	};
 
-	isItemLinkSelected: function( paths ) {
+	isItemLinkSelected( paths ) {
 		if ( ! Array.isArray( paths ) ) {
 			paths = [ paths ];
 		}
@@ -86,39 +90,39 @@ export const MySitesSidebar = React.createClass( {
 		return paths.some( function( path ) {
 			return path === this.props.path || 0 === this.props.path.indexOf( path + '/' );
 		}, this );
-	},
+	}
 
-	isSingle: function() {
+	isSingle() {
 		return !! ( this.props.sites.getSelectedSite() || this.props.sites.get().length === 1 );
-	},
+	}
 
-	getSingleSiteDomain: function() {
+	getSingleSiteDomain() {
 		if ( this.props.sites.selected ) {
 			return this.getSelectedSite().slug;
 		}
 
 		return this.props.sites.getPrimary().slug;
-	},
+	}
 
-	getSelectedSite: function() {
+	getSelectedSite() {
 		if ( this.props.sites.get().length === 1 ) {
 			return this.props.sites.getPrimary();
 		}
 
 		return this.props.sites.getSelectedSite();
-	},
+	}
 
-	hasJetpackSites: function() {
+	hasJetpackSites() {
 		return this.props.sites.get().some( function( site ) {
 			return site.jetpack;
 		} );
-	},
+	}
 
-	siteSuffix: function() {
+	siteSuffix() {
 		return this.isSingle() ? '/' + this.getSingleSiteDomain() : '';
-	},
+	}
 
-	publish: function() {
+	publish() {
 		return (
 			<PublishMenu site={ this.getSelectedSite() }
 				sites={ this.props.sites }
@@ -127,9 +131,9 @@ export const MySitesSidebar = React.createClass( {
 				itemLinkClass={ this.itemLinkClass }
 				onNavigate={ this.onNavigate } />
 		);
-	},
+	}
 
-	stats: function() {
+	stats() {
 		var site = this.getSelectedSite();
 
 		if ( site && ! site.capabilities ) {
@@ -144,13 +148,13 @@ export const MySitesSidebar = React.createClass( {
 			<li className={ this.itemLinkClass( '/stats', 'stats' ) }>
 				<SiteStatsStickyLink onClick={ this.onNavigate }>
 					<Gridicon icon="stats-alt" size={ 24 } />
-					<span className="menu-link-text">{ this.translate( 'Stats' ) }</span>
+					<span className="menu-link-text">{ this.props.translate( 'Stats' ) }</span>
 				</SiteStatsStickyLink>
 			</li>
 		);
-	},
+	}
 
-	ads: function() {
+	ads() {
 		var site = this.getSelectedSite(),
 			adsLink = '/ads/earnings' + this.siteSuffix();
 
@@ -166,9 +170,9 @@ export const MySitesSidebar = React.createClass( {
 				onNavigate={ this.onNavigate }
 				icon="speaker" />
 		);
-	},
+	}
 
-	themes: function() {
+	themes() {
 		var site = this.getSelectedSite(),
 			jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' ),
 			themesLink;
@@ -191,7 +195,7 @@ export const MySitesSidebar = React.createClass( {
 
 		return (
 			<SidebarItem
-				label={ this.translate( 'Themes' ) }
+				label={ this.props.translate( 'Themes' ) }
 				tipTarget="themes"
 				className={ this.itemLinkClass( '/design', 'themes' ) }
 				link={ themesLink }
@@ -200,13 +204,13 @@ export const MySitesSidebar = React.createClass( {
 				preloadSectionName="themes"
 			>
 				<SidebarButton href={ this.props.customizeUrl } preloadSectionName="customize">
-					{ this.translate( 'Customize' ) }
+					{ this.props.translate( 'Customize' ) }
 				</SidebarButton>
 			</SidebarItem>
 		);
-	},
+	}
 
-	menus: function() {
+	menus() {
 		var site = this.getSelectedSite(),
 			menusLink = '/menus' + this.siteSuffix(),
 			showClassicLink = ! config.isEnabled( 'manage/menus' );
@@ -234,16 +238,16 @@ export const MySitesSidebar = React.createClass( {
 		return (
 			<SidebarItem
 				tipTarget="menus"
-				label={ this.translate( 'Menus' ) }
+				label={ this.props.translate( 'Menus' ) }
 				className={ this.itemLinkClass( '/menus', 'menus' ) }
 				link={ menusLink }
 				onNavigate={ this.onNavigate }
 				icon="menus"
 				preloadSectionName="menus" />
 		);
-	},
+	}
 
-	plugins: function() {
+	plugins() {
 		var site = this.getSelectedSite(),
 			pluginsLink = '/plugins' + this.siteSuffix(),
 			addPluginsLink;
@@ -268,7 +272,7 @@ export const MySitesSidebar = React.createClass( {
 
 		return (
 			<SidebarItem
-				label={ this.translate( 'Plugins' ) }
+				label={ this.props.translate( 'Plugins' ) }
 				className={ this.itemLinkClass( '/plugins', 'plugins' ) }
 				link={ pluginsLink }
 				onNavigate={ this.onNavigate }
@@ -276,13 +280,13 @@ export const MySitesSidebar = React.createClass( {
 				preloadSectionName="plugins"
 			>
 				<SidebarButton href={ addPluginsLink }>
-					{ this.translate( 'Add' ) }
+					{ this.props.translate( 'Add' ) }
 				</SidebarButton>
 			</SidebarItem>
 		);
-	},
+	}
 
-	upgrades: function() {
+	upgrades() {
 		var site = this.getSelectedSite(),
 			domainsLink = '/domains/manage' + this.siteSuffix(),
 			addDomainLink = '/domains/add' + this.siteSuffix();
@@ -309,7 +313,7 @@ export const MySitesSidebar = React.createClass( {
 
 		return (
 			<SidebarItem
-				label={ this.translate( 'Domains' ) }
+				label={ this.props.translate( 'Domains' ) }
 				className={ this.itemLinkClass( [ '/domains' ], 'domains' ) }
 				link={ domainsLink }
 				onNavigate={ this.onNavigate }
@@ -317,13 +321,13 @@ export const MySitesSidebar = React.createClass( {
 				preloadSectionName="upgrades"
 			>
 				<SidebarButton href={ addDomainLink }>
-					{ this.translate( 'Add' ) }
+					{ this.props.translate( 'Add' ) }
 				</SidebarButton>
 			</SidebarItem>
 		);
-	},
+	}
 
-	plan: function() {
+	plan() {
 		if ( ! config.isEnabled( 'manage/plans' ) ) {
 			return null;
 		}
@@ -361,7 +365,7 @@ export const MySitesSidebar = React.createClass( {
 		let planName = site.plan.product_name_short;
 
 		if ( productsValues.isFreeTrial( site.plan ) ) {
-			planName = this.translate( 'Trial', {
+			planName = this.props.translate( 'Trial', {
 				context: 'Label in the sidebar indicating that the user is on the free trial for a plan.'
 			} );
 		}
@@ -370,21 +374,21 @@ export const MySitesSidebar = React.createClass( {
 			<li className={ this.itemLinkClass( [ '/plans' ], linkClass ) }>
 				<a onClick={ this.trackUpgradeClick } href={ planLink }>
 					<Gridicon icon="clipboard" size={ 24 } />
-					<span className="menu-link-text">{ this.translate( 'Plan', { context: 'noun' } ) }</span>
+					<span className="menu-link-text">{ this.props.translate( 'Plan', { context: 'noun' } ) }</span>
 				</a>
 				<a href={ planLink } className="plan-name" onClick={ this.trackUpgradeClick }>{ planName }</a>
 			</li>
 		);
-	},
+	}
 
-	trackUpgradeClick: function() {
+	trackUpgradeClick = () => {
 		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
 			cta_name: 'sidebar_upgrade_default'
 		} );
 		this.onNavigate();
-	},
+	};
 
-	sharing: function() {
+	sharing() {
 		var site = this.getSelectedSite(),
 			sharingLink = '/sharing' + this.siteSuffix();
 
@@ -414,16 +418,16 @@ export const MySitesSidebar = React.createClass( {
 
 		return (
 			<SidebarItem
-				label={ this.translate( 'Sharing' ) }
+				label={ this.props.translate( 'Sharing' ) }
 				className={ this.itemLinkClass( '/sharing', 'sharing' ) }
 				link={ sharingLink }
 				onNavigate={ this.onNavigate }
 				icon="share"
 				preloadSectionName="sharing" />
 		);
-	},
+	}
 
-	users: function() {
+	users() {
 		var site = this.getSelectedSite(),
 			usersLink = '/people/team' + this.siteSuffix(),
 			addPeopleLink = '/people/new' + this.siteSuffix();
@@ -452,7 +456,7 @@ export const MySitesSidebar = React.createClass( {
 
 		return (
 			<SidebarItem
-				label={ this.translate( 'People' ) }
+				label={ this.props.translate( 'People' ) }
 				className={ this.itemLinkClass( '/people', 'users' ) }
 				link={ usersLink }
 				onNavigate={ this.onNavigate }
@@ -460,13 +464,13 @@ export const MySitesSidebar = React.createClass( {
 				preloadSectionName="people"
 			>
 				<SidebarButton href={ addPeopleLink }>
-					{ this.translate( 'Add' ) }
+					{ this.props.translate( 'Add' ) }
 				</SidebarButton>
 			</SidebarItem>
 		);
-	},
+	}
 
-	siteSettings: function() {
+	siteSettings() {
 		var site = this.getSelectedSite(),
 			siteSettingsLink = '/settings/general' + this.siteSuffix();
 
@@ -484,16 +488,16 @@ export const MySitesSidebar = React.createClass( {
 
 		return (
 			<SidebarItem
-				label={ this.translate( 'Settings' ) }
+				label={ this.props.translate( 'Settings' ) }
 				className={ this.itemLinkClass( '/settings', 'settings' ) }
 				link={ siteSettingsLink }
 				onNavigate={ this.onNavigate }
 				icon="cog"
 				preloadSectionName="settings" />
 		);
-	},
+	}
 
-	wpAdmin: function() {
+	wpAdmin() {
 		var site = this.getSelectedSite(),
 			currentUser = this.props.currentUser;
 
@@ -517,18 +521,18 @@ export const MySitesSidebar = React.createClass( {
 			<li className="wp-admin">
 				<a onClick={ this.trackWpadminClick } href={ site.options.admin_url } target="_blank" rel="noopener noreferrer">
 					<Gridicon icon="my-sites" size={ 24 } />
-					<span className="menu-link-text">{ this.translate( 'WP Admin' ) }</span>
+					<span className="menu-link-text">{ this.props.translate( 'WP Admin' ) }</span>
 					<span className="noticon noticon-external" />
 				</a>
 			</li>
 		);
-	},
+	}
 
-	trackWpadminClick: function() {
+	trackWpadminClick = () => {
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked WP Admin' );
-	},
+	};
 
-	vip: function() {
+	vip() {
 		var site, viplink;
 
 		if ( ! config.isEnabled( 'vip' ) ) {
@@ -545,13 +549,13 @@ export const MySitesSidebar = React.createClass( {
 		return (
 			<li className={ this.itemLinkClass( '/vip/updates', 'sidebar__vip' ) } >
 				<a href={ viplink } >
-					<span className="menu-link-text">{ this.translate( 'Updates' ) }</span>
+					<span className="menu-link-text">{ this.props.translate( 'Updates' ) }</span>
 				</a>
 			</li>
 		);
-	},
+	}
 
-	vipDeploys: function() {
+	vipDeploys() {
 		var site, viplink;
 
 		if ( ! config.isEnabled( 'vip/deploys' ) ) {
@@ -568,13 +572,13 @@ export const MySitesSidebar = React.createClass( {
 		return (
 			<li className={ this.itemLinkClass( '/vip/deploys', 'sidebar__vip-deploys' ) } >
 				<a href={ viplink } >
-					<span className="menu-link-text">{ this.translate( 'Deploys' ) }</span>
+					<span className="menu-link-text">{ this.props.translate( 'Deploys' ) }</span>
 				</a>
 			</li>
 		);
-	},
+	}
 
-	vipBilling: function() {
+	vipBilling() {
 		var site, viplink;
 
 		if ( ! config.isEnabled( 'vip/billing' ) ) {
@@ -591,13 +595,13 @@ export const MySitesSidebar = React.createClass( {
 		return (
 			<li className={ this.itemLinkClass( '/vip/billing', 'sidebar__vip-billing' ) }>
 				<a href={ viplink } >
-					<span className="menu-link-text">{ this.translate( 'Billing' ) }</span>
+					<span className="menu-link-text">{ this.props.translate( 'Billing' ) }</span>
 				</a>
 			</li>
 		);
-	},
+	}
 
-	vipSupport: function() {
+	vipSupport() {
 		var viplink;
 
 		if ( ! config.isEnabled( 'vip/support' ) ) {
@@ -609,13 +613,13 @@ export const MySitesSidebar = React.createClass( {
 		return (
 			<li className={ this.itemLinkClass( '/vip/support', 'sidebar__vip-support' ) }>
 				<a href={ viplink } >
-					<span className="menu-link-text">{ this.translate( 'Support' ) }</span>
+					<span className="menu-link-text">{ this.props.translate( 'Support' ) }</span>
 				</a>
 			</li>
 		);
-	},
+	}
 
-	vipBackups: function() {
+	vipBackups() {
 		var site, viplink;
 
 		if ( ! config.isEnabled( 'vip/backups' ) ) {
@@ -632,13 +636,13 @@ export const MySitesSidebar = React.createClass( {
 		return (
 			<li className={ this.itemLinkClass( '/vip/backups', 'sidebar__vip-backups' ) }>
 				<a href={ viplink } >
-					<span className="menu-link-text">{ this.translate( 'Backups' ) }</span>
+					<span className="menu-link-text">{ this.props.translate( 'Backups' ) }</span>
 				</a>
 			</li>
 		);
-	},
+	}
 
-	vipLogs: function() {
+	vipLogs() {
 		var site, viplink;
 
 		if ( ! config.isEnabled( 'vip/logs' ) ) {
@@ -655,17 +659,17 @@ export const MySitesSidebar = React.createClass( {
 		return (
 			<li className={ this.itemLinkClass( '/vip/logs', 'sidebar__vip-logs' ) }>
 				<a href={ viplink } >
-					<span className="menu-link-text">{ this.translate( 'Logs' ) }</span>
+					<span className="menu-link-text">{ this.props.translate( 'Logs' ) }</span>
 				</a>
 			</li>
 		);
-	},
+	}
 
-	focusContent: function() {
+	focusContent = () => {
 		this.props.setLayoutFocus( 'content' );
-	},
+	};
 
-	addNewSite: function() {
+	addNewSite() {
 		if ( this.props.currentUser.visible_site_count > 1 ) {
 			return null;
 		}
@@ -676,12 +680,12 @@ export const MySitesSidebar = React.createClass( {
 				href={ config( 'signup_url' ) + '?ref=calypso-selector' }
 				onClick={ this.focusContent }
 			>
-				<Gridicon icon="add-outline" /> { this.translate( 'Add New Site' ) }
+				<Gridicon icon="add-outline" /> { this.props.translate( 'Add New Site' ) }
 			</Button>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		var publish = !! this.publish(),
 			appearance = ( !! this.themes() || !! this.menus() ),
 			configuration = ( !! this.sharing() || !! this.users() || !! this.siteSettings() || !! this.plugins() || !! this.upgrades() ),
@@ -719,7 +723,7 @@ export const MySitesSidebar = React.createClass( {
 
 				{ publish
 					? <SidebarMenu>
-						<SidebarHeading>{ this.translate( 'Publish' ) }</SidebarHeading>
+						<SidebarHeading>{ this.props.translate( 'Publish' ) }</SidebarHeading>
 						{ this.publish() }
 					</SidebarMenu>
 					: null
@@ -727,7 +731,7 @@ export const MySitesSidebar = React.createClass( {
 
 				{ appearance
 					? <SidebarMenu>
-						<SidebarHeading>{ this.translate( 'Personalize' ) }</SidebarHeading>
+						<SidebarHeading>{ this.props.translate( 'Personalize' ) }</SidebarHeading>
 						<ul>
 							{ this.themes() }
 							{ this.menus() }
@@ -738,7 +742,7 @@ export const MySitesSidebar = React.createClass( {
 
 				{ configuration
 					? <SidebarMenu>
-						<SidebarHeading>{ this.translate( 'Configure' ) }</SidebarHeading>
+						<SidebarHeading>{ this.props.translate( 'Configure' ) }</SidebarHeading>
 						<ul>
 							{ this.ads() }
 							{ this.sharing() }
@@ -758,7 +762,7 @@ export const MySitesSidebar = React.createClass( {
 			</Sidebar>
 		);
 	}
-} );
+}
 
 function mapStateToProps( state ) {
 	const selectedSiteId = getSelectedSiteId( state );
@@ -769,4 +773,4 @@ function mapStateToProps( state ) {
 }
 
 // TODO: make this pure when sites can be retrieved from the Redux state
-export default connect( mapStateToProps, { setNextLayoutFocus, setLayoutFocus }, null, { pure: false } )( MySitesSidebar );
+export default connect( mapStateToProps, { setNextLayoutFocus, setLayoutFocus }, null, { pure: false } )( localize( MySitesSidebar ) );

--- a/client/my-sites/sidebar/test/sidebar.jsx
+++ b/client/my-sites/sidebar/test/sidebar.jsx
@@ -27,7 +27,8 @@ describe( 'MySitesSidebar', () => {
 
 	describe( '#isItemLinkSelected()', () => {
 		it( 'should return false if none of the paths are a prefix', () => {
-			const isSelected = MySitesSidebar.prototype.isItemLinkSelected.call( {
+			const instance = new MySitesSidebar();
+			const isSelected = instance.isItemLinkSelected.call( {
 				props: {
 					path: '/posts/example.wordpress.com'
 				}
@@ -37,7 +38,8 @@ describe( 'MySitesSidebar', () => {
 		} );
 
 		it( 'should return false if one of the paths is a prefix, but not at end or separated by slash', () => {
-			const isSelected = MySitesSidebar.prototype.isItemLinkSelected.call( {
+			const instance = new MySitesSidebar();
+			const isSelected = instance.isItemLinkSelected.call( {
 				props: {
 					path: '/types/jetpack-testimonial-jk'
 				}
@@ -47,7 +49,8 @@ describe( 'MySitesSidebar', () => {
 		} );
 
 		it( 'should return true if one of the paths is a prefix of the current path and separated by slash', () => {
-			const isSelected = MySitesSidebar.prototype.isItemLinkSelected.call( {
+			const instance = new MySitesSidebar();
+			const isSelected = instance.isItemLinkSelected.call( {
 				props: {
 					path: '/types/jetpack-testimonial/example.wordpress.com'
 				}
@@ -57,7 +60,8 @@ describe( 'MySitesSidebar', () => {
 		} );
 
 		it( 'should return true if one of the paths is a prefix of the current path and at end', () => {
-			const isSelected = MySitesSidebar.prototype.isItemLinkSelected.call( {
+			const instance = new MySitesSidebar();
+			const isSelected = instance.isItemLinkSelected.call( {
 				props: {
 					path: '/types/jetpack-testimonial'
 				}
@@ -67,7 +71,8 @@ describe( 'MySitesSidebar', () => {
 		} );
 
 		it( 'should accept a path string', () => {
-			const isSelected = MySitesSidebar.prototype.isItemLinkSelected.call( {
+			const instance = new MySitesSidebar();
+			const isSelected = instance.isItemLinkSelected.call( {
 				props: {
 					path: '/types/jetpack-testimonial'
 				}


### PR DESCRIPTION
Part of #9054

### Aims
This PR refactors my-sites/sidebar/sidebar to extend the React.Component Class rather than use React.createClass.
It also wraps the exported component with the localize HoC to give access to translate through props.
It should not differ in functionality at all.

### Test Plan
Test that the MySites sidebar renders and works as usual.
Try navigating using the links in the sidebar - they should still go to the expected locations & should have the correct copy via `translate`.

> Note: Without fake accounts with different privileges and available functionality I'm not sure how to thoroughly test the sidebar beyond just making sure that your set up works both before and after this PR.

> Also Note: I'm not particularly happy with the refactor of the unit tests. I tried a number of methods, shallow rendering etc. but there are seemingly too many hiccups with missing methods on the component / props of the component when doing this.
I didn't want to make too much change beyond converting the component to a React.Component so these tests are the minimal change I could think of to still have the tests pass accurately.

### Out of scope
- All other syntax updates (Will be be done here: #9032)
- Better logic and structure
- Splitting up of 'sub' components (currently jsx rendering methods)
