### PR TITLE
Jetpack Plugins: Remove sitesList.getSelectedSite() from controller

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -22,6 +22,7 @@ import PluginComponent from './plugin';
 import PluginBrowser from './plugins-browser';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
+import { getSelectedSite } from 'state/ui/selectors';
 
 /**
  * Module variables
@@ -34,7 +35,7 @@ let lastPluginsListVisited,
 
 function renderSinglePlugin( context, siteUrl ) {
 	const pluginSlug = decodeURIComponent( context.params.plugin );
-	const site = sites.getSelectedSite();
+	const site = getSelectedSite( context.store.getState() );
 	const analyticsPageTitle = 'Plugins';
 
 	let baseAnalyticsPath = 'plugins/:plugin';
@@ -82,7 +83,7 @@ function getPathWithoutSiteSlug( context, site ) {
 
 function renderPluginList( context, basePath ) {
 	const search = context.query.s;
-	const site = sites.getSelectedSite();
+	const site = getSelectedSite( context.store.getState() );
 
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );
 	lastPluginsQuerystring = context.querystring;
@@ -117,7 +118,7 @@ function renderPluginList( context, basePath ) {
 
 function renderPluginsBrowser( context ) {
 	const searchTerm = context.query.s;
-	let site = sites.getSelectedSite();
+	let site = getSelectedSite( context.store.getState() );
 	let { category } = context.params;
 
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );
@@ -152,8 +153,9 @@ function renderPluginsBrowser( context ) {
 }
 
 function renderProvisionPlugins( context ) {
-	const section = context.store.getState().ui.section;
-	const site = sites.getSelectedSite();
+	const state = context.store.getState();
+	const section = state.ui.section;
+	const site = getSelectedSite( state );
 	context.store.dispatch( setSection( Object.assign( {}, section, { secondary: false } ) ) );
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 
@@ -172,7 +174,7 @@ const controller = {
 	validateFilters( filter, context, next ) {
 		const wpcomFilter = 'standard';
 		const siteUrl = route.getSiteFragment( context.path );
-		const site = sites.getSelectedSite();
+		const site = getSelectedSite( context.store.getState() );
 		const appliedFilter = ( filter ? filter : context.params.plugin ).toLowerCase();
 
 		// bail if /plugins/:site_id?


### PR DESCRIPTION
This PR removes usage of `sitesList.getSelectedSite()` from the Plugins main controller. It also fixes a couple of ESLint warnings that were occurring in that file.

To test:

* Checkout this branch
* Verify there are no regressions in the following pages:
 * Single plugin - `/plugins/jetpack/$site`
 * Site plugins list - `plugins/$site`
 * Plugin browser - `/plugins/browse/$site`
 * Premium plan plugin setup - `/plugins/setup/$site`

/cc @gwwar @ryelle @roccotripaldi @johnHackworth 