### PR TITLE
Reader: Stick the photo overlay in the right place

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -86,10 +86,6 @@ export default class RefreshPostCard extends React.Component {
 		const { post, originalPost, site, feed, onCommentClick, showPrimaryFollowButton } = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
-		const title = truncate( post.title, {
-			length: 140,
-			separator: /,? +/
-		} );
 		const featuredAsset = ( <FeaturedAsset post={ post } /> );
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! featuredAsset,
@@ -101,6 +97,14 @@ export default class RefreshPostCard extends React.Component {
 		let followUrl;
 		if ( showPrimaryFollowButton ) {
 			followUrl = feed ? feed.feed_URL : post.site_URL;
+		}
+
+		let title = truncate( post.title, {
+			length: 140,
+			separator: /,? +/
+		} );
+		if ( ! title ) {
+			title = '\xa0'; // force to non-breaking space if empty so that the title h1 doesn't collapse and complicate things
 		}
 
 		return (

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -74,6 +74,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 					height: 225px;
 					opacity: .4;
 					position: absolute;
+						top: 0;
+						left: 0;
 					width: 100%;
 					z-index: 1;
 				}


### PR DESCRIPTION
This 'worked' on latest Chrome, but really needs the top and left to be spec compliant.

Fixes #9182

May fix #9162