### PR TITLE
Sharing: Update connections list to use ES6

### DIFF
--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -4,6 +4,11 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
 export default class AccountDialogAccount extends Component {
 	static propTypes = {
 		account: PropTypes.shape( {
@@ -54,6 +59,7 @@ export default class AccountDialogAccount extends Component {
 		return (
 			<li className={ classes }>
 				<label className="account-dialog-account__label">
+					{ this.props.conflicting && <Gridicon icon="notice" /> }
 					{ this.getRadioElement() }
 					{ this.getPictureElement() }
 					<span className="account-dialog-account__name">{ this.props.account.name }</span>

--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -1,51 +1,54 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 
-module.exports = React.createClass( {
-	displayName: 'AccountDialogAccount',
-
-	propTypes: {
-		account: React.PropTypes.shape( {
-			ID: React.PropTypes.oneOfType( [ React.PropTypes.number, React.PropTypes.string ] ),
-			name: React.PropTypes.string,
-			picture: React.PropTypes.string,
-			keyringConnectionId: React.PropTypes.number,
-			isConnected: React.PropTypes.bool,
-			isExternal: React.PropTypes.bool
+export default class AccountDialogAccount extends Component {
+	static propTypes = {
+		account: PropTypes.shape( {
+			ID: PropTypes.oneOfType( [ React.PropTypes.number, React.PropTypes.string ] ),
+			name: PropTypes.string,
+			picture: PropTypes.string,
+			keyringConnectionId: PropTypes.number,
+			isConnected: PropTypes.bool,
+			isExternal: PropTypes.bool
 		} ).isRequired,
-		selected: React.PropTypes.bool,
-		conflicting: React.PropTypes.bool,
-		onChange: React.PropTypes.func
-	},
+		selected: PropTypes.bool,
+		conflicting: PropTypes.bool,
+		onChange: PropTypes.func,
+	};
 
-	getDefaultProps: function() {
-		return {
-			connected: false,
-			selected: false,
-			conflicting: false,
-			onChange: function() {}
-		};
-	},
+	static defaultProps = {
+		conflicting: false,
+		connected: false,
+		onChange: () => {},
+		selected: false,
+	};
 
-	getPictureElement: function() {
+	getPictureElement() {
 		if ( this.props.account.picture ) {
-			return <img src={ this.props.account.picture } alt={ this.props.account.name } className="account-dialog-account__picture" />;
+			return <img
+				src={ this.props.account.picture }
+				alt={ this.props.account.name }
+				className="account-dialog-account__picture" />;
 		}
-	},
+	}
 
-	getRadioElement: function() {
+	getRadioElement() {
 		if ( ! this.props.account.isConnected ) {
-			return <input type="radio" onChange={ this.props.onChange } checked={ this.props.selected } className="account-dialog-account__input" />;
+			return <input
+				type="radio"
+				onChange={ this.props.onChange }
+				checked={ this.props.selected }
+				className="account-dialog-account__input" />;
 		}
-	},
+	}
 
-	render: function() {
-		var classes = classNames( 'account-dialog-account', {
+	render() {
+		const classes = classNames( 'account-dialog-account', {
 			'is-connected': this.props.account.isConnected,
-			'is-conflict': this.props.conflicting
+			'is-conflict': this.props.conflicting,
 		} );
 
 		return (
@@ -58,4 +61,4 @@ module.exports = React.createClass( {
 			</li>
 		);
 	}
-} );
+}

--- a/client/my-sites/sharing/connections/account-dialog-account.scss
+++ b/client/my-sites/sharing/connections/account-dialog-account.scss
@@ -28,12 +28,9 @@
 	cursor: pointer;
 }
 
-.account-dialog-account.is-conflict::before {
-	@include noticon( '\f414', 16px );
+.account-dialog-account.is-conflict .gridicons-notice {
 	position: absolute;
-		left: 4px;
-		top: 50%;
-	margin-top: -6px;
+		left: -5px;
 	color: $alert-yellow;
 }
 
@@ -41,13 +38,13 @@
 .account-dialog .account-dialog-account__picture {
 	position: absolute;
 		left: 8px;
-		top: 3px;
+		top: 0;
 	width: 34px;
 	height: 34px;
 }
 
 .account-dialog-account:not( .is-connected ) .account-dialog-account__picture {
-	left: 22px;
+	left: 26px;
 }
 
 .account-dialog-account__name {

--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -20,6 +20,8 @@ class AccountDialog extends Component {
 		isVisible: PropTypes.bool,
 		onAccountSelected: PropTypes.func,
 		service: PropTypes.object,
+		translate: PropTypes.func,
+		warningNotice: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -27,7 +29,21 @@ class AccountDialog extends Component {
 		isVisible: true,
 		onAccountSelected: () => {},
 		service: Object.freeze( {} ),
+		translate: () => {},
+		warningNotice: () => {},
 	};
+
+	onClose = ( action ) => {
+		const accountToConnect = this.getAccountToConnect();
+
+		if ( 'connect' === action && accountToConnect ) {
+			this.props.onAccountSelected( this.props.service, accountToConnect.keyringConnectionId, accountToConnect.ID );
+		} else {
+			this.props.onAccountSelected();
+		}
+	};
+
+	onSelectedAccountChanged = ( account ) => this.setState( { selectedAccount: account } );
 
 	constructor( props ) {
 		super( props );
@@ -35,9 +51,6 @@ class AccountDialog extends Component {
 		this.state = {
 			selectedAccount: null
 		};
-
-		this.onClose = this.onClose.bind( this );
-		this.onSelectedAccountChanged = this.onSelectedAccountChanged.bind( this );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -80,10 +93,6 @@ class AccountDialog extends Component {
 		return selectedAccount && this.props.accounts.some( ( maybeConnectedAccount ) =>
 			maybeConnectedAccount.isConnected && this.areAccountsConflicting( maybeConnectedAccount, selectedAccount )
 		);
-	}
-
-	onSelectedAccountChanged( account ) {
-		this.setState( { selectedAccount: account } );
 	}
 
 	getAccountElements( accounts ) {
@@ -131,16 +140,6 @@ class AccountDialog extends Component {
 			'Select the account you wish to authorize. Note that your posts will be shared to the selected account automatically.', {
 				context: 'Sharing: Publicize connection confirmation'
 			} );
-	}
-
-	onClose( action ) {
-		const accountToConnect = this.getAccountToConnect();
-
-		if ( 'connect' === action && accountToConnect ) {
-			this.props.onAccountSelected( this.props.service, accountToConnect.keyringConnectionId, accountToConnect.ID );
-		} else {
-			this.props.onAccountSelected();
-		}
 	}
 
 	render() {

--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import AccountDialogAccount from './account-dialog-account';
 import Dialog from 'components/dialog';
+import Gridicon from 'components/gridicon';
 import { warningNotice } from 'state/notices/actions';
 
 class AccountDialog extends Component {
@@ -153,7 +154,7 @@ class AccountDialog extends Component {
 
 		if ( this.isSelectedAccountConflicting() ) {
 			this.props.warningNotice( this.props.translate( 'The connection marked {{icon/}} will be replaced with your selection.', {
-				components: { icon: <span className="noticon noticon-warning" /> },
+				components: { icon: <Gridicon icon="notice" size={ 18 } /> },
 				context: 'Sharing: Publicize confirmation',
 			} ), { showDismiss: false } );
 		}

--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { filter, find, isEqual } from 'lodash';
+import { filter, find, identity, isEqual } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -30,7 +30,7 @@ class AccountDialog extends Component {
 		isVisible: true,
 		onAccountSelected: () => {},
 		service: Object.freeze( {} ),
-		translate: () => {},
+		translate: identity,
 		warningNotice: () => {},
 	};
 

--- a/client/my-sites/sharing/connections/account-dialog.scss
+++ b/client/my-sites/sharing/connections/account-dialog.scss
@@ -42,12 +42,5 @@
 }
 
 .account-dialog.single-account .account-dialog__accounts {
-	margin: 0 0 0 1em;
-}
-
-// Adjust position of noticon placed inline the warning phrase
-.account-dialog .notice .noticon-warning {
-	position: relative;
-	top: 2px;
-	margin: 0 2px;
+	margin: 0 0 1em 1em;
 }

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -38,7 +39,7 @@ class SharingConnection extends Component {
 		onToggleSitewideConnection: () => {},
 		recordGoogleEvent: () => {},
 		showDisconnect: false,
-		translate: ( string ) => string,
+		translate: identity,
 		userHasCaps: false,
 		userId: 0,
 	};

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -1,159 +1,178 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
-	serviceConnections = require( './service-connections' );
+import { canCurrentUser, getCurrentUserId } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
+import site from 'lib/site';
 
-module.exports = React.createClass( {
-	displayName: 'SharingConnection',
+class SharingConnection extends Component {
+	static propTypes = {
+		connection: PropTypes.object.isRequired,    // The single connection object
+		isDisconnecting: PropTypes.bool,            // Is a service disconnection request pending?
+		isRefreshing: PropTypes.bool,               // Is a service refresh request pending?
+		onDisconnect: PropTypes.func,               // Handler to invoke when disconnecting
+		onRefresh: PropTypes.func,                  // Handler to invoke when refreshing
+		onToggleSitewideConnection: PropTypes.func, // Handler to invoke when toggling sitewide connection
+		recordGoogleEvent: PropTypes.func,
+		service: PropTypes.object.isRequired,       // The service to which the connection is made
+		showDisconnect: PropTypes.bool,             // Display an inline disconnect button
+		translate: PropTypes.func,
+		userHasCaps: PropTypes.bool,                // Whether the current users has the caps to delete a connection.
+		userId: PropTypes.number,                   // The Id of the current user.
+	};
 
-	propTypes: {
-		site: React.PropTypes.object,                    // The site for which the connection was created
-		user: React.PropTypes.object,                    // A user object
-		connection: React.PropTypes.object.isRequired,   // The single connection object
-		service: React.PropTypes.object.isRequired,      // The service to which the connection is made
-		onDisconnect: React.PropTypes.func,              // Handler to invoke when disconnecting
-		isDisconnecting: React.PropTypes.bool,           // Is a service disconnection request pending?
-		showDisconnect: React.PropTypes.bool,            // Display an inline disconnect button
-		onRefresh: React.PropTypes.func,                 // Handler to invoke when refreshing
-		isRefreshing: React.PropTypes.bool,              // Is a service refresh request pending?
-		onToggleSitewideConnection: React.PropTypes.func // Handler to invoke when toggling sitewide connection
-	},
+	static defaultProps = {
+		isDisconnecting: false,
+		isRefreshing: false,
+		onDisconnect: () => {},
+		onRefresh: () => {},
+		onToggleSitewideConnection: () => {},
+		recordGoogleEvent: () => {},
+		showDisconnect: false,
+		translate: ( string ) => string,
+		userHasCaps: false,
+		userId: 0,
+	};
 
-	getInitialState: function() {
-		return { isSavingSitewide: false };
-	},
-
-	componentDidUpdate: function( prevProps ) {
-		if ( this.state.isSavingSitewide && this.props.connection.shared !== prevProps.connection.shared ) {
-			this.setState( { isSavingSitewide: false } );
-		}
-	},
-
-	getDefaultProps: function() {
-		return {
-			onDisconnect: function() {},
-			isDisconnecting: false,
-			showDisconnect: false,
-			onRefresh: function() {},
-			isRefreshing: false,
-			onToggleSitewideConnection: function() {}
-		};
-	},
-
-	disconnect: function() {
+	disconnect = () => {
 		if ( ! this.props.isDisconnecting ) {
 			this.props.onDisconnect( this.props.connection );
 		}
-	},
+	};
 
-	refresh: function() {
+	refresh = () => {
 		if ( ! this.props.isRefreshing ) {
 			this.props.onRefresh( this.props.connection );
 		}
-	},
+	};
 
-	getProfileImage: function() {
-		if ( this.props.connection.external_profile_picture ) {
-			return <img src={ this.props.connection.external_profile_picture } alt={ this.props.connection.label } className="sharing-connection__account-avatar" />;
-		} else {
-			return (
-				<span className={ 'sharing-connection__account-avatar is-fallback ' + this.props.connection.service }>
-					<span className="screen-reader-text">{ this.props.connection.label }</span>
-				</span>
-			);
-		}
-	},
-
-	getReconnectButton: function() {
-		var currentUser = this.props.user.get();
-
-		if ( currentUser && 'broken' === this.props.connection.status && currentUser.ID === this.props.connection.keyring_connection_user_ID ) {
-			return (
-				<a onClick={ this.refresh } className="sharing-connection__account-action reconnect">
-					{ this.translate( 'Reconnect' ) }
-				</a>
-			);
-		}
-	},
-
-	getDisconnectButton: function() {
-		if ( this.props.showDisconnect && serviceConnections.canCurrentUserPerformActionOnConnection( 'delete', this.props.connection ) ) {
-			return (
-				<a onClick={ this.disconnect } className="sharing-connection__account-action disconnect">
-					{ this.translate( 'Disconnect' ) }
-				</a>
-			);
-		}
-	},
-
-	toggleSitewideConnection: function( event ) {
+	toggleSitewideConnection = ( event ) => {
 		if ( ! this.state.isSavingSitewide ) {
-			var isNowSitewide = event.target.checked;
+			const isNowSitewide = event.target.checked;
+
 			this.setState( { isSavingSitewide: true } );
 			this.props.onToggleSitewideConnection( this.props.connection, isNowSitewide );
-			analytics.ga.recordEvent( 'Sharing', 'Clicked Connection Available to All Users Checkbox', this.props.service.ID, isNowSitewide ? 1 : 0 );
+			this.props.recordGoogleEvent( 'Sharing', 'Clicked Connection Available to All Users Checkbox',
+				this.props.service.ID, isNowSitewide ? 1 : 0 );
 		}
-	},
+	};
 
-	isConnectionShared: function() {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isSavingSitewide: false,
+		};
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.state.isSavingSitewide && this.props.connection.shared !== prevProps.connection.shared ) {
+			this.setState( { isSavingSitewide: false } );
+		}
+	}
+
+	getProfileImage() {
+		if ( this.props.connection.external_profile_picture ) {
+			return <img
+				src={ this.props.connection.external_profile_picture }
+				alt={ this.props.connection.label }
+				className="sharing-connection__account-avatar" />;
+		}
+
+		return (
+			<span className={ 'sharing-connection__account-avatar is-fallback ' + this.props.connection.service }>
+				<span className="screen-reader-text">{ this.props.connection.label }</span>
+			</span>
+		);
+	}
+
+	getReconnectButton() {
+		if ( 'broken' === this.props.connection.status && this.props.userId === this.props.connection.keyring_connection_user_ID ) {
+			return (
+				<a onClick={ this.refresh } className="sharing-connection__account-action reconnect">
+					{ this.props.translate( 'Reconnect' ) }
+				</a>
+			);
+		}
+	}
+
+	getDisconnectButton() {
+		const userCanDelete = this.props.userHasCaps || this.props.connection.user_ID === this.props.userId;
+
+		if ( this.props.showDisconnect && userCanDelete ) {
+			return (
+				<a onClick={ this.disconnect } className="sharing-connection__account-action disconnect">
+					{ this.props.translate( 'Disconnect' ) }
+				</a>
+			);
+		}
+	}
+
+	isConnectionShared() {
 		return this.state.isSavingSitewide ? ! this.props.connection.shared : this.props.connection.shared;
-	},
+	}
 
-	getConnectionKeyringUserLabel: function() {
-		var currentUser = this.props.user.get(),
-			keyringUser = this.props.site.getUser( this.props.connection.keyring_connection_user_ID );
+	getConnectionKeyringUserLabel() {
+		const keyringUser = site().getUser( this.props.connection.keyring_connection_user_ID );
 
-		if ( currentUser && keyringUser && currentUser.ID !== keyringUser.ID ) {
+		if ( keyringUser && this.props.userId !== keyringUser.ID ) {
 			return (
 				<aside className="sharing-connection__keyring-user">
-					{ this.translate( 'Connected by %(username)s', {
+					{ this.props.translate( 'Connected by %(username)s', {
 						args: { username: keyringUser.nice_name },
 						context: 'Sharing: connections'
 					} ) }
 				</aside>
 			);
 		}
-	},
+	}
 
-	getConnectionSitewideElement: function() {
-		var userCanUpdate = serviceConnections.canCurrentUserPerformActionOnConnection( 'update', this.props.connection ),
-			content = [];
-
-		if ( ! serviceConnections.isServiceForPublicize( this.props.service.ID ) ) {
+	getConnectionSitewideElement() {
+		if ( 'publicize' !== this.props.service.type ) {
 			return;
 		}
 
-		if ( userCanUpdate ) {
-			content.push( <input key="checkbox" type="checkbox" checked={ this.isConnectionShared() } onChange={ this.toggleSitewideConnection } readOnly={ this.state.isSavingSitewide } /> );
+		const content = [];
+
+		if ( this.props.userHasCaps ) {
+			content.push( <input
+				key="checkbox"
+				type="checkbox"
+				checked={ this.isConnectionShared() }
+				onChange={ this.toggleSitewideConnection }
+				readOnly={ this.state.isSavingSitewide } /> );
 		}
 
-		if ( userCanUpdate || this.props.connection.shared ) {
-			content.push( <span key="label">{ this.translate( 'Connection available to all administrators, editors, and authors', { context: 'Sharing: Publicize' } ) }</span> );
+		if ( this.props.userHasCaps || this.props.connection.shared ) {
+			content.push( <span key="label">
+				{ this.props.translate( 'Connection available to all administrators, editors, and authors', {
+					context: 'Sharing: Publicize'
+				} ) }
+			</span> );
 		}
 
 		if ( content.length ) {
 			return <label className="sharing-connection__account-sitewide-connection">{ content }</label>;
 		}
-	},
+	}
 
-	render: function() {
-		var connectionSitewideElement = this.getConnectionSitewideElement(),
-			connectionClasses, statusClasses;
-
-		connectionClasses = classNames( 'sharing-connection', {
-			disabled: this.props.isDisconnecting || this.props.isRefreshing
-		} );
-
-		statusClasses = classNames( 'sharing-connection__account-status', {
-			'is-shareable': undefined !== connectionSitewideElement
-		} );
+	render() {
+		const connectionSitewideElement = this.getConnectionSitewideElement(),
+			connectionClasses = classNames( 'sharing-connection', {
+				disabled: this.props.isDisconnecting || this.props.isRefreshing
+			} ),
+			statusClasses = classNames( 'sharing-connection__account-status', {
+				'is-shareable': undefined !== connectionSitewideElement
+			} );
 
 		return (
 			<li className={ connectionClasses }>
@@ -170,4 +189,12 @@ module.exports = React.createClass( {
 			</li>
 		);
 	}
-} );
+}
+
+export default connect(
+	( state ) => ( {
+		userHasCaps: canCurrentUser( state, getSelectedSiteId( state ), 'edit_others_posts' ),
+		userId: getCurrentUserId( state ),
+	} ),
+	{ recordGoogleEvent },
+)( localize( SharingConnection ) );

--- a/client/my-sites/sharing/connections/connections.jsx
+++ b/client/my-sites/sharing/connections/connections.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import QueryKeyringServices from 'components/data/query-keyring-services';
 import SharingServicesGroup from './services-group';
 
 class SharingConnections extends Component {
@@ -17,12 +18,14 @@ class SharingConnections extends Component {
 	};
 
 	static defaultProps = {
+		connections: Object.freeze( {} ),
 		translate: identity,
 	};
 
 	render() {
 		return (
 			<div className="sharing-settings sharing-connections">
+				<QueryKeyringServices />
 				<SharingServicesGroup
 					type="publicize"
 					title={ this.props.translate( 'Publicize Your Posts' ) }

--- a/client/my-sites/sharing/connections/connections.jsx
+++ b/client/my-sites/sharing/connections/connections.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,6 +14,10 @@ class SharingConnections extends Component {
 	static propTypes = {
 		connections: PropTypes.object,
 		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		translate: identity,
 	};
 
 	render() {

--- a/client/my-sites/sharing/connections/connections.jsx
+++ b/client/my-sites/sharing/connections/connections.jsx
@@ -1,138 +1,35 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import observe from 'lib/mixins/data-observe';
-import analytics from 'lib/analytics';
 import SharingServicesGroup from './services-group';
-import AccountDialog from './account-dialog';
-import serviceConnections from './service-connections';
 
-export default React.createClass( {
-	displayName: 'SharingConnections',
+class SharingConnections extends Component {
+	static propTypes = {
+		connections: PropTypes.object,
+		translate: PropTypes.func,
+	};
 
-	mixins: [ observe( 'sites', 'connections', 'user' ) ],
-
-	getInitialState: function() {
-		return { selectingAccountForService: null };
-	},
-
-	getConnections: function() {
-		if ( this.props.sites.selected ) {
-			return this.props.connections.get( this.props.sites.getSelectedSite().ID );
-		}
-
-		return this.props.connections.get();
-	},
-
-	addConnection: function( service, keyringConnectionId, externalUserId ) {
-		let siteId;
-		if ( this.props.sites.selected ) {
-			siteId = this.props.sites.getSelectedSite().ID;
-		}
-
-		if ( service ) {
-			// Attempt to create a new connection. If a Keyring connection ID
-			// is not provided, the user will need to authorize the app
-			this.props.connections.create( service, siteId, keyringConnectionId, externalUserId );
-
-			// In the case that a Keyring connection doesn't exist, wait for app
-			// authorization to occur, then display with the available connections
-			if ( ! keyringConnectionId ) {
-				this.props.connections.once( 'connect', function() {
-					if ( serviceConnections.didKeyringConnectionSucceed( service.ID, siteId ) &&
-							serviceConnections.isServiceForPublicize( service.ID ) ) {
-						this.setState( { selectingAccountForService: service } );
-					}
-				}.bind( this ) );
-			} else {
-				analytics.ga.recordEvent( 'Sharing', 'Clicked Connect Button in Modal', this.state.selectingAccountForService.ID );
-			}
-		} else {
-			// If an account wasn't selected from the dialog or the user cancels
-			// the connection, the dialog should simply close
-			this.props.connections.emit( 'create:error', { cancel: true } );
-			analytics.ga.recordEvent( 'Sharing', 'Clicked Cancel Button in Modal', this.state.selectingAccountForService.ID );
-		}
-
-		// Reset active account selection
-		this.setState( { selectingAccountForService: null } );
-	},
-
-	refreshConnection: function( connection ) {
-		this.props.connections.refresh( connection );
-	},
-
-	removeConnection: function( connections ) {
-		connections = serviceConnections.filterConnectionsToRemove( connections );
-		this.props.connections.destroy( connections );
-	},
-
-	toggleSitewideConnection: function( connection, isSitewide ) {
-		this.props.connections.update( connection, { shared: isSitewide } );
-	},
-
-	getAccountDialog: function() {
-		const isSelectingAccount = !! this.state.selectingAccountForService;
-		let accounts, siteId;
-
-		if ( isSelectingAccount ) {
-			if ( this.props.sites.selected ) {
-				siteId = this.props.sites.getSelectedSite().ID;
-			}
-
-			accounts = serviceConnections.getAvailableExternalAccounts( this.state.selectingAccountForService.ID, siteId );
-		}
-
+	render() {
 		return (
-			<AccountDialog
-				isVisible={ isSelectingAccount }
-				service={ this.state.selectingAccountForService }
-				accounts={ accounts }
-				onAccountSelected={ this.addConnection } />
-		);
-	},
-
-	renderServiceGroups: function() {
-		const commonGroupProps = {
-			user: this.props.user,
-			connections: this.props.connections,
-			onAddConnection: this.addConnection,
-			onRemoveConnection: this.removeConnection,
-			onRefreshConnection: this.refreshConnection,
-			onToggleSitewideConnection: this.toggleSitewideConnection,
-			initialized: !! this.props.sites.selected
-		};
-
-		if ( this.props.sites.selected ) {
-			commonGroupProps.site = this.props.sites.getSelectedSite();
-		}
-
-		return (
-			<div>
+			<div className="sharing-settings sharing-connections">
 				<SharingServicesGroup
 					type="publicize"
-					title={ this.translate( 'Publicize Your Posts' ) }
-					{ ...commonGroupProps } />
+					title={ this.props.translate( 'Publicize Your Posts' ) }
+					connections={ this.props.connections } />
 				<SharingServicesGroup
 					type="other"
-					title={ this.translate( 'Other Connections' ) }
-					description={ this.translate( 'Connect any of these additional services to further enhance your site.' ) }
-					{ ...commonGroupProps } />
-			</div>
-		);
-	},
-
-	render: function() {
-		return (
-			<div id="sharing-connections" className="sharing-settings sharing-connections">
-				{ this.getAccountDialog() }
-				{ this.renderServiceGroups() }
+					title={ this.props.translate( 'Other Connections' ) }
+					description={ this.props.translate( 'Connect any of these additional services to further enhance your site.' ) }
+					connections={ this.props.connections } />
 			</div>
 		);
 	}
-} );
+}
+
+export default localize( SharingConnections );

--- a/client/my-sites/sharing/connections/service-action.jsx
+++ b/client/my-sites/sharing/connections/service-action.jsx
@@ -71,7 +71,6 @@ class SharingServiceAction extends Component {
 		return (
 			<Button
 				primary={ primary }
-				borderless={ false }
 				scary={ warning }
 				compact
 				onClick={ this.onActionClick }

--- a/client/my-sites/sharing/connections/service-action.jsx
+++ b/client/my-sites/sharing/connections/service-action.jsx
@@ -73,7 +73,7 @@ class SharingServiceAction extends Component {
 				primary={ primary }
 				borderless={ false }
 				scary={ warning }
-				compact={ true }
+				compact
 				onClick={ this.onActionClick }
 				disabled={ isPending }>
 				{ label }

--- a/client/my-sites/sharing/connections/service-action.jsx
+++ b/client/my-sites/sharing/connections/service-action.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -24,11 +25,13 @@ class SharingServiceAction extends Component {
 
 	static defaultProps = {
 		connections: Object.freeze( [] ),
+		isConnecting: false,
 		isDisconnecting: false,
 		isRefreshing: false,
-		isConnecting: false,
 		onAction: () => {},
+		removableConnections: Object.freeze( [] ),
 		status: 'unknown',
+		translate: identity,
 	};
 
 	onActionClick = ( event ) => {

--- a/client/my-sites/sharing/connections/service-action.jsx
+++ b/client/my-sites/sharing/connections/service-action.jsx
@@ -1,89 +1,85 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import serviceConnections from './service-connections';
 import Button from 'components/button';
 
-module.exports = React.createClass( {
-	displayName: 'SharingServiceAction',
+class SharingServiceAction extends Component {
+	static propTypes = {
+		connections: PropTypes.array,
+		isConnecting: PropTypes.bool,
+		isDisconnecting: PropTypes.bool,
+		isRefreshing: PropTypes.bool,
+		onAction: PropTypes.func,
+		removableConnections: PropTypes.array,
+		service: PropTypes.object.isRequired,
+		status: PropTypes.string,
+		translate: PropTypes.func,
+	};
 
-	propTypes: {
-		status: React.PropTypes.string,
-		service: React.PropTypes.object.isRequired,
-		onAction: React.PropTypes.func,
-		connections: React.PropTypes.array,
-		isDisconnecting: React.PropTypes.bool,
-		isRefreshing: React.PropTypes.bool,
-		isConnecting: React.PropTypes.bool
-	},
+	static defaultProps = {
+		connections: Object.freeze( [] ),
+		isDisconnecting: false,
+		isRefreshing: false,
+		isConnecting: false,
+		onAction: () => {},
+		status: 'unknown',
+	};
 
-	getDefaultProps: function() {
-		return {
-			status: 'unknown',
-			onAction: function() {},
-			connections: Object.freeze( [] ),
-			isDisconnecting: false,
-			isRefreshing: false,
-			isConnecting: false
-		};
-	},
-
-	onActionClick: function( event ) {
+	onActionClick = ( event ) => {
 		event.stopPropagation();
 		this.props.onAction();
-	},
+	};
 
-	render: function() {
+	render() {
 		let primary = false,
-			borderless = false,
 			warning = false,
-			isPending, removableConnections, label;
+			label;
 
-		isPending = 'unknown' === this.props.status || this.props.isDisconnecting ||
-			this.props.isRefreshing || this.props.isConnecting;
-
-		if ( 'connected' === this.props.status ) {
-			removableConnections = serviceConnections.getRemovableConnections( this.props.service.ID );
-		}
+		const { translate } = this.props,
+			isPending = 'unknown' === this.props.status || this.props.isDisconnecting ||
+				this.props.isRefreshing || this.props.isConnecting;
 
 		if ( 'unknown' === this.props.status ) {
-			label = this.translate( 'Loading…', { context: 'Sharing: Publicize status pending button label' } );
+			label = translate( 'Loading…', { context: 'Sharing: Publicize status pending button label' } );
 		} else if ( this.props.isDisconnecting ) {
-			label = this.translate( 'Disconnecting…', { context: 'Sharing: Publicize disconnect pending button label' } );
+			label = translate( 'Disconnecting…', { context: 'Sharing: Publicize disconnect pending button label' } );
 		} else if ( this.props.isRefreshing ) {
-			label = this.translate( 'Reconnecting…', { context: 'Sharing: Publicize reconnect pending button label' } );
+			label = translate( 'Reconnecting…', { context: 'Sharing: Publicize reconnect pending button label' } );
 			warning = true;
 		} else if ( this.props.isConnecting ) {
-			label = this.translate( 'Connecting…', { context: 'Sharing: Publicize connect pending button label' } );
-		} else if ( 'connected' === this.props.status && removableConnections.length ) {
-			if ( removableConnections.length > 1 ) {
-				label = this.translate( 'Disconnect All', { context: 'Sharing: Publicize disconnect button label' } );
+			label = translate( 'Connecting…', { context: 'Sharing: Publicize connect pending button label' } );
+		} else if ( 'connected' === this.props.status ) {
+			if ( this.props.removableConnections.length > 1 ) {
+				label = translate( 'Disconnect All', { context: 'Sharing: Publicize disconnect button label' } );
 			} else {
-				label = this.translate( 'Disconnect', { context: 'Sharing: Publicize disconnect button label' } );
+				label = translate( 'Disconnect', { context: 'Sharing: Publicize disconnect button label' } );
 			}
 		} else if ( 'reconnect' === this.props.status ) {
-			label = this.translate( 'Reconnect', { context: 'Sharing: Publicize reconnect pending button label' } );
+			label = translate( 'Reconnect', { context: 'Sharing: Publicize reconnect pending button label' } );
 			warning = true;
 		} else {
-			label = this.translate( 'Connect', { context: 'Sharing: Publicize connect pending button label' } );
+			label = translate( 'Connect', { context: 'Sharing: Publicize connect pending button label' } );
 			primary = true;
 		}
 
 		return (
 			<Button
 				primary={ primary }
-				borderless={ borderless }
+				borderless={ false }
 				scary={ warning }
-				compact
+				compact={ true }
 				onClick={ this.onActionClick }
 				disabled={ isPending }>
 				{ label }
 			</Button>
 		);
 	}
-} );
+}
+
+export default localize( SharingServiceAction );

--- a/client/my-sites/sharing/connections/service-connected-accounts.jsx
+++ b/client/my-sites/sharing/connections/service-connected-accounts.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -33,6 +34,7 @@ class SharingServiceConnectedAccounts extends Component {
 		onRefreshConnection: () => {},
 		onRemoveConnection: () => {},
 		onToggleSitewideConnection: () => {},
+		translate: identity,
 	};
 
 	connectAnother = () => {

--- a/client/my-sites/sharing/connections/service-connected-accounts.jsx
+++ b/client/my-sites/sharing/connections/service-connected-accounts.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Connection from './connection';
-import serviceConnections from './service-connections';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class SharingServiceConnectedAccounts extends Component {
@@ -36,36 +35,34 @@ class SharingServiceConnectedAccounts extends Component {
 		onToggleSitewideConnection: () => {},
 	};
 
+	connectAnother = () => {
+		this.props.onAddConnection();
+		this.props.recordGoogleEvent( 'Sharing', 'Clicked Connect Another Account Button', this.props.service.ID );
+	};
+
 	getConnectionElements() {
 		return this.props.connections.map( ( connection ) =>
 			<Connection
 				key={ connection.keyring_connection_ID }
-				site={ this.props.site }
-				user={ this.props.user }
 				connection={ connection }
-				service={ this.props.service }
-				onDisconnect={ this.props.onRemoveConnection }
 				isDisconnecting={ this.props.isDisconnecting }
-				showDisconnect={ this.props.connections.length > 1 || 'broken' === connection.status }
-				onRefresh={ this.props.onRefreshConnection }
 				isRefreshing={ this.props.isRefreshing }
-				onToggleSitewideConnection={ this.props.onToggleSitewideConnection } />
+				onDisconnect={ this.props.onRemoveConnection }
+				onRefresh={ this.props.onRefreshConnection }
+				onToggleSitewideConnection={ this.props.onToggleSitewideConnection }
+				service={ this.props.service }
+				showDisconnect={ this.props.connections.length > 1 || 'broken' === connection.status } />
 		);
 	}
 
 	getConnectAnotherElement() {
-		if ( serviceConnections.supportsMultipleConnectionsPerSite( this.props.service.ID ) ) {
+		if ( 'publicize' === this.props.service.type ) {
 			return (
 				<a onClick={ this.connectAnother } className="button new-account">
 					{ this.props.translate( 'Connect a different account', { comment: 'Sharing: Publicize connections' } ) }
 				</a>
 			);
 		}
-	}
-
-	connectAnother() {
-		this.props.onAddConnection();
-		this.props.recordGoogleEvent( 'Sharing', 'Clicked Connect Another Account Button', this.props.service.ID );
 	}
 
 	render() {

--- a/client/my-sites/sharing/connections/service-connected-accounts.jsx
+++ b/client/my-sites/sharing/connections/service-connected-accounts.jsx
@@ -1,46 +1,44 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var Connection = require( './connection' ),
-	serviceConnections = require( './service-connections' ),
-	analytics = require( 'lib/analytics' );
+import Connection from './connection';
+import serviceConnections from './service-connections';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
-module.exports = React.createClass( {
-	displayName: 'SharingServiceConnectedAccounts',
+class SharingServiceConnectedAccounts extends Component {
+	static propTypes = {
+		connections: PropTypes.array,               // Set of connections for the service
+		isDisconnecting: PropTypes.bool,            // Whether a disconnect request is pending
+		isRefreshing: PropTypes.bool,               // Whether a connection refresh is pending
+		onAddConnection: PropTypes.func,            // Handler to invoke when adding a new connection
+		onRefreshConnection: PropTypes.func,        // Handler to invoke when refreshing a connection
+		onRemoveConnection: PropTypes.func,         // Handler to invoke when removing an existing connection
+		onToggleSitewideConnection: PropTypes.func, // Handler to invoke when toggling a connection to be shared sitewide
+		recordGoogleEvent: PropTypes.func,          // Redux action to track an event
+		service: PropTypes.object.isRequired,       // The service object
+		translate: PropTypes.func,
+	};
 
-	propTypes: {
-		site: React.PropTypes.object,                    // The site for which the connections were created
-		user: React.PropTypes.object,                    // A user object
-		service: React.PropTypes.object.isRequired,      // The service object
-		connections: React.PropTypes.array,              // Set of connections for the service
-		onAddConnection: React.PropTypes.func,           // Handler to invoke when adding a new connection
-		onRemoveConnection: React.PropTypes.func,        // Handler to invoke when removing an existing connection
-		isDisconnecting: React.PropTypes.bool,           // Whether a disconnect request is pending
-		onRefreshConnection: React.PropTypes.func,       // Handler to invoke when refreshing a connection
-		isRefreshing: React.PropTypes.bool,              // Whether a connection refresh is pending
-		onToggleSitewideConnection: React.PropTypes.func // Handler to invoke when toggling a connection to be shared sitewide
-	},
+	static defaultProps = {
+		connections: Object.freeze( [] ),
+		isDisconnecting: false,
+		isRefreshing: false,
+		onAddConnection: () => {},
+		onRefreshConnection: () => {},
+		onRemoveConnection: () => {},
+		onToggleSitewideConnection: () => {},
+	};
 
-	getDefaultProps: function() {
-		return {
-			connections: Object.freeze( [] ),
-			onAddConnection: function() {},
-			onRemoveConnection: function() {},
-			isDisconnecting: false,
-			onRefreshConnection: function() {},
-			isRefreshing: false,
-			onToggleSitewideConnection: function() {}
-		};
-	},
-
-	getConnectionElements: function() {
-		return this.props.connections.map( function( connection ) {
-			return <Connection
+	getConnectionElements() {
+		return this.props.connections.map( ( connection ) =>
+			<Connection
 				key={ connection.keyring_connection_ID }
 				site={ this.props.site }
 				user={ this.props.user }
@@ -51,26 +49,26 @@ module.exports = React.createClass( {
 				showDisconnect={ this.props.connections.length > 1 || 'broken' === connection.status }
 				onRefresh={ this.props.onRefreshConnection }
 				isRefreshing={ this.props.isRefreshing }
-				onToggleSitewideConnection={ this.props.onToggleSitewideConnection } />;
-		}, this );
-	},
+				onToggleSitewideConnection={ this.props.onToggleSitewideConnection } />
+		);
+	}
 
-	getConnectAnotherElement: function() {
+	getConnectAnotherElement() {
 		if ( serviceConnections.supportsMultipleConnectionsPerSite( this.props.service.ID ) ) {
 			return (
 				<a onClick={ this.connectAnother } className="button new-account">
-					{ this.translate( 'Connect a different account', { comment: 'Sharing: Publicize connections' } ) }
+					{ this.props.translate( 'Connect a different account', { comment: 'Sharing: Publicize connections' } ) }
 				</a>
 			);
 		}
-	},
+	}
 
-	connectAnother: function() {
+	connectAnother() {
 		this.props.onAddConnection();
-		analytics.ga.recordEvent( 'Sharing', 'Clicked Connect Another Account Button', this.props.service.ID );
-	},
+		this.props.recordGoogleEvent( 'Sharing', 'Clicked Connect Another Account Button', this.props.service.ID );
+	}
 
-	render: function() {
+	render() {
 		return (
 			<div className="sharing-service-accounts-detail">
 				<ul className="sharing-service-connected-accounts">
@@ -80,4 +78,11 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default connect(
+	null,
+	{
+		recordGoogleEvent,
+	},
+)( localize( SharingServiceConnectedAccounts ) );

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -1,92 +1,109 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
-module.exports = React.createClass( {
-	displayName: 'SharingServiceDescription',
+class SharingServiceDescription extends Component {
+	static propTypes = {
+		descriptions: PropTypes.object,
+		numberOfConnections: PropTypes.number,
+		translate: PropTypes.func,
+	};
 
-	propTypes: {
-		descriptions: React.PropTypes.object,
-		numberOfConnections: React.PropTypes.number
-	},
-
-	getDefaultProps: function() {
-		return {
-			descriptions: Object.freeze( {
-				facebook: function() {
-					if ( this.props.numberOfConnections > 0 ) {
-						return this.translate( 'Sharing posts to your news feed.', 'Sharing posts to your news feeds.', {
-							count: this.props.numberOfConnections,
-							comment: 'Description for Facebook Publicize when one or more accounts are connected'
-						} );
-					} else {
-						return this.translate( 'Share posts to your news feed.', { comment: 'Description for Facebook Publicize when no accounts are connected' } );
-					}
-				},
-				twitter: function() {
-					if ( this.props.numberOfConnections > 0 ) {
-						return this.translate( 'Sharing posts to your Twitter feed.', 'Sharing posts to your Twitter feeds.', {
-							count: this.props.numberOfConnections,
-							comment: 'Description for Twitter Publicize when one or more accounts are connected'
-						} );
-					} else {
-						return this.translate( 'Share posts to your Twitter feed.', { comment: 'Description for Twitter Publicize when no accounts are connected' } );
-					}
-				},
-				google_plus: function() {
-					if ( this.props.numberOfConnections > 0 ) {
-						return this.translate( 'Commenting and sharing to your profile.', 'Commenting and sharing to your profiles.', {
-							count: this.props.numberOfConnections,
-							comment: 'Description for Google+ Publicize when one or more accounts are connected'
-						} );
-					} else {
-						return this.translate( 'Comment and share to your profile.', { comment: 'Description for Google+ Publicize when no accounts are connected' } );
-					}
-				},
-				linkedin: function() {
-					if ( this.props.numberOfConnections > 0 ) {
-						return this.translate( 'Sharing posts to your connections.', { comment: 'Description for LinkedIn Publicize when one or more accounts are connected' } );
-					} else {
-						return this.translate( 'Share posts to your connections.', { comment: 'Description for LinkedIn Publicize when no accounts are connected' } );
-					}
-				},
-				tumblr: function() {
-					if ( this.props.numberOfConnections > 0 ) {
-						return this.translate( 'Sharing posts to your Tumblr blog.', 'Sharing posts to your Tumblr blogs.', {
-							count: this.props.numberOfConnections,
-							comment: 'Description for Tumblr Publicize when one or more accounts are connected'
-						} );
-					} else {
-						return this.translate( 'Share posts to your Tumblr blog.', { comment: 'Description for Tumblr Publicize when no accounts are connected' } );
-					}
-				},
-				path: function() {
-					if ( this.props.numberOfConnections > 0 ) {
-						return this.translate( 'Sharing posts to your Path timeline.', 'Sharing posts to your Path timelines.', {
-							count: this.props.numberOfConnections,
-							comment: 'Description for Path Publicize when one or more accounts are connected'
-						} );
-					} else {
-						return this.translate( 'Share posts to your Path timeline.', { comment: 'Description for Path Publicize when no accounts are connected' } );
-					}
-				},
-				eventbrite: function() {
-					if ( this.props.numberOfConnections > 0 ) {
-						return this.translate( 'Connected to your Eventbrite account.', { comment: 'Description for Eventbrite when one or more accounts are connected' } );
-					} else {
-						return this.translate( 'Connect to your Eventbrite account.', { comment: 'Description for Eventbrite when no accounts are connected' } );
-					}
+	static defaultProps = {
+		numberOfConnections: 0,
+		descriptions: Object.freeze( {
+			facebook: function() {
+				if ( this.props.numberOfConnections > 0 ) {
+					return this.props.translate( 'Sharing posts to your news feed.', 'Sharing posts to your news feeds.', {
+						count: this.props.numberOfConnections,
+						comment: 'Description for Facebook Publicize when one or more accounts are connected'
+					} );
 				}
-			} ),
-			numberOfConnections: 0
-		};
-	},
 
-	render: function() {
-		var description;
+				return this.props.translate( 'Share posts to your news feed.', {
+					comment: 'Description for Facebook Publicize when no accounts are connected'
+				} );
+			},
+			twitter: function() {
+				if ( this.props.numberOfConnections > 0 ) {
+					return this.props.translate( 'Sharing posts to your Twitter feed.', 'Sharing posts to your Twitter feeds.', {
+						count: this.props.numberOfConnections,
+						comment: 'Description for Twitter Publicize when one or more accounts are connected'
+					} );
+				}
+
+				return this.props.translate( 'Share posts to your Twitter feed.', {
+					comment: 'Description for Twitter Publicize when no accounts are connected'
+				} );
+			},
+			google_plus: function() {
+				if ( this.props.numberOfConnections > 0 ) {
+					return this.props.translate( 'Commenting and sharing to your profile.', 'Commenting and sharing to your profiles.', {
+						count: this.props.numberOfConnections,
+						comment: 'Description for Google+ Publicize when one or more accounts are connected'
+					} );
+				}
+
+				return this.props.translate( 'Comment and share to your profile.', {
+					comment: 'Description for Google+ Publicize when no accounts are connected'
+				} );
+			},
+			linkedin: function() {
+				if ( this.props.numberOfConnections > 0 ) {
+					return this.props.translate( 'Sharing posts to your connections.', {
+						comment: 'Description for LinkedIn Publicize when one or more accounts are connected'
+					} );
+				}
+
+				return this.props.translate( 'Share posts to your connections.', {
+					comment: 'Description for LinkedIn Publicize when no accounts are connected'
+				} );
+			},
+			tumblr: function() {
+				if ( this.props.numberOfConnections > 0 ) {
+					return this.props.translate( 'Sharing posts to your Tumblr blog.', 'Sharing posts to your Tumblr blogs.', {
+						count: this.props.numberOfConnections,
+						comment: 'Description for Tumblr Publicize when one or more accounts are connected'
+					} );
+				}
+
+				return this.props.translate( 'Share posts to your Tumblr blog.', {
+					comment: 'Description for Tumblr Publicize when no accounts are connected'
+				} );
+			},
+			path: function() {
+				if ( this.props.numberOfConnections > 0 ) {
+					return this.props.translate( 'Sharing posts to your Path timeline.', 'Sharing posts to your Path timelines.', {
+						count: this.props.numberOfConnections,
+						comment: 'Description for Path Publicize when one or more accounts are connected'
+					} );
+				}
+
+				return this.props.translate( 'Share posts to your Path timeline.', {
+					comment: 'Description for Path Publicize when no accounts are connected'
+				} );
+			},
+			eventbrite: function() {
+				if ( this.props.numberOfConnections > 0 ) {
+					return this.props.translate( 'Connected to your Eventbrite account.', {
+						comment: 'Description for Eventbrite when one or more accounts are connected'
+					} );
+				}
+
+				return this.props.translate( 'Connect to your Eventbrite account.', {
+					comment: 'Description for Eventbrite when no accounts are connected'
+				} );
+			},
+		} ),
+	};
+
+	render() {
+		let description;
+
 		if ( 'reconnect' === this.props.status ) {
-			description = this.translate( 'There is an issue connecting to %(service)s.', {
+			description = this.props.translate( 'There is an issue connecting to %(service)s.', {
 				args: { service: this.props.service.label },
 				context: 'Sharing: Publicize'
 			} );
@@ -96,4 +113,6 @@ module.exports = React.createClass( {
 
 		return ( <p className="sharing-service__description">{ description }</p> );
 	}
-} );
+}
+
+export default localize( SharingServiceDescription );

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 class SharingServiceDescription extends Component {
@@ -12,7 +13,6 @@ class SharingServiceDescription extends Component {
 	};
 
 	static defaultProps = {
-		numberOfConnections: 0,
 		descriptions: Object.freeze( {
 			facebook: function() {
 				if ( this.props.numberOfConnections > 0 ) {
@@ -97,6 +97,8 @@ class SharingServiceDescription extends Component {
 				} );
 			},
 		} ),
+		numberOfConnections: 0,
+		translate: identity,
 	};
 
 	render() {

--- a/client/my-sites/sharing/connections/service-example.jsx
+++ b/client/my-sites/sharing/connections/service-example.jsx
@@ -1,27 +1,25 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 
-module.exports = React.createClass( {
-	displayName: 'SharingServiceExample',
-
-	propTypes: {
-		image: React.PropTypes.shape( {
-			src: React.PropTypes.string,
-			alt: React.PropTypes.string
+class SharingServiceExample extends Component {
+	static propTypes = {
+		image: PropTypes.shape( {
+			src: PropTypes.string,
+			alt: PropTypes.string
 		} ),
-		label: React.PropTypes.node,
-		single: React.PropTypes.bool
-	},
+		label: PropTypes.node,
+		single: PropTypes.bool,
+	};
 
-	getDefaultProps: function() {
-		return { single: false };
-	},
+	static defaultProps = {
+		single: false,
+	};
 
-	render: function() {
-		var classes = classNames( 'sharing-service-example', {
+	render() {
+		const classes = classNames( 'sharing-service-example', {
 			'is-single': this.props.single
 		} );
 
@@ -34,4 +32,6 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default SharingServiceExample;

--- a/client/my-sites/sharing/connections/service-example.jsx
+++ b/client/my-sites/sharing/connections/service-example.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 
-class SharingServiceExample extends Component {
+export default class SharingServiceExample extends Component {
 	static propTypes = {
 		image: PropTypes.shape( {
 			src: PropTypes.string,
@@ -33,5 +33,3 @@ class SharingServiceExample extends Component {
 		);
 	}
 }
-
-export default SharingServiceExample;

--- a/client/my-sites/sharing/connections/service-examples.jsx
+++ b/client/my-sites/sharing/connections/service-examples.jsx
@@ -1,254 +1,307 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { includes } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var ServiceExample = require( 'my-sites/sharing/connections/service-example' );
+import { getSelectedSite } from 'state/ui/selectors';
+import ServiceExample from './service-example';
 
-module.exports = React.createClass( {
-	displayName: 'SharingServiceExamples',
+/**
+ * Module constants
+ */
+/**
+ * Whitelist of services that we provide examples for.
+ *
+ * When adding examples for more services, please update the whitelist in addition to adding
+ * a method with the example's content.
+ *
+ * @type {string[]}
+ */
+const SERVICES_WHITELIST = [
+	'bandpage',
+	'eventbrite',
+	'facebook',
+	'google_plus',
+	'instagram',
+	'linkedin',
+	'path',
+	'tumblr',
+	'twitter',
+];
 
-	propTypes: {
-		examples: React.PropTypes.object,
-		site: React.PropTypes.object
-	},
+class SharingServiceExamples extends Component {
+	static propTypes = {
+		service: PropTypes.object.isRequired,
+		site: PropTypes.object,
+	};
 
-	getDefaultProps: function() {
-		return {
-			examples: Object.freeze( {
-				facebook: function() {
-					return [
-						{
-							image: {
-								src: '/calypso/images/sharing/facebook-profile.png',
-								alt: this.translate( 'Share posts to your Facebook page or profile', { textOnly: true } )
-							},
-							label: this.translate( '{{strong}}Connect{{/strong}} to automatically share posts on your Facebook page or profile.', {
-								components: {
-									strong: <strong />
-								}
-							} )
-						},
-						{
-							image: {
-								src: '/calypso/images/sharing/facebook-sharing.png',
-								alt: this.translate( 'Add a sharing button', { textOnly: true } )
-							},
-							label: this.translate( 'Add a {{link}}sharing button{{/link}} to your posts so readers can share your story with their friends.', {
-								components: {
-									link: <a href={ this.props.site ? '/sharing/buttons/' + this.props.site.slug : 'https://support.wordpress.com/sharing/' } />
-								}
-							} )
-						}
-					];
-				},
-				instagram: function() {
-					return [
-						{
-							image: {
-								src: '/calypso/images/sharing/instagram-widget.png',
-								alt: this.translate( 'Add an Instagram widget', { textOnly: true } )
-							},
-							label: this.translate( 'Add an {{link}}Instagram widget{{/link}} to display your latest photos.', {
-								components: {
-									link: <a href="https://support.wordpress.com/instagram/instagram-widget/" />
-								}
-							} )
-						},
-						{
-							image: {
-								src: '/calypso/images/sharing/instagram-media.png',
-								alt: this.translate( 'Access Instagram photos via the Media Library', { textOnly: true } )
-							},
-							label: this.translate( 'Get instant access to all your Instagram photos through the {{link}}Media Library{{/link}}.', {
-								components: {
-									link: <a href="https://support.wordpress.com/media/" />
-								}
-							} )
-						}
-					];
-				},
-				twitter: function() {
-					return [
-						{
-							image: {
-								src: '/calypso/images/sharing/twitter-publicize.png',
-								alt: this.translate( 'Share posts to your Twitter followers', { textOnly: true } )
-							},
-							label: this.translate( '{{strong}}Connect{{/strong}} to automatically share posts with your Twitter followers.', {
-								components: {
-									strong: <strong />
-								}
-							} )
-						},
-						{
-							image: {
-								src: '/calypso/images/sharing/twitter-timeline.png',
-								alt: this.translate( 'Add a Twitter Timeline Widget', { textOnly: true } )
-							},
-							label: this.translate( 'Add a {{link}}Twitter Timeline Widget{{/link}} to display your latest tweets on your site.', {
-								components: {
-									link: <a href="https://support.wordpress.com/widgets/twitter-timeline-widget/" />
-								}
-							} )
-						}
-					];
-				},
-				google_plus: function() {
-					return [
-						{
-							image: {
-								src: '/calypso/images/sharing/google-publicize.png',
-								alt: this.translate( 'Share posts to your Google+ page', { textOnly: true } )
-							},
-							label: this.translate( '{{strong}}Connect{{/strong}} to automatically share posts to your Google+ page.', {
-								components: {
-									strong: <strong />
-								}
-							} )
-						},
-						{
-							image: {
-								src: '/calypso/images/sharing/google-sharing.png',
-								alt: this.translate( 'Add a sharing button', { textOnly: true } )
-							},
-							label: this.translate( 'Add a {{link}}sharing button{{/link}} to your posts so readers can share your story with their circles.', {
-								components: {
-									link: <a href={ this.props.site ? '/sharing/buttons/' + this.props.site.slug : 'https://support.wordpress.com/sharing/' } />
-								}
-							} )
-						}
-					];
-				},
-				linkedin: function() {
-					return [
-						{
-							image: {
-								src: '/calypso/images/sharing/linkedin-publicize.png',
-								alt: this.translate( 'Share posts with your LinkedIn connections', { textOnly: true } )
-							},
-							label: this.translate( '{{strong}}Connect{{/strong}} to automatically share posts with your LinkedIn connections.', {
-								components: {
-									strong: <strong />
-								}
-							} )
-						},
-						{
-							image: {
-								src: '/calypso/images/sharing/linkedin-sharing.png',
-								alt: this.translate( 'Add a sharing button', { textOnly: true } )
-							},
-							label: this.translate( 'Add a {{link}}sharing button{{/link}} to your posts so readers can share your story with their connections.', {
-								components: {
-									link: <a href={ this.props.site ? '/sharing/buttons/' + this.props.site.slug : 'https://support.wordpress.com/sharing/' } />
-								}
-							} )
-						}
-					];
-				},
-				tumblr: function() {
-					return [
-						{
-							image: {
-								src: '/calypso/images/sharing/tumblr-publicize.png',
-								alt: this.translate( 'Share posts to your Tumblr blog', { textOnly: true } )
-							},
-							label: this.translate( '{{strong}}Connect{{/strong}} to automatically share posts to your Tumblr blog.', {
-								components: {
-									strong: <strong />
-								}
-							} )
-						},
-						{
-							image: {
-								src: '/calypso/images/sharing/tumblr-sharing.png',
-								alt: this.translate( 'Add a sharing button', { textOnly: true } )
-							},
-							label: this.translate( 'Add a {{link}}sharing button{{/link}} to your posts so readers can share your story with their followers.', {
-								components: {
-									link: <a href={ this.props.site ? '/sharing/buttons/' + this.props.site.slug : 'https://support.wordpress.com/sharing/' } />
-								}
-							} )
-						}
-					];
-				},
-				path: function() {
-					return [
-						{
-							image: {
-								src: '/calypso/images/sharing/path-publicize.png',
-								alt: this.translate( 'Share posts to your Path timeline', { textOnly: true } )
-							},
-							label: this.translate( '{{strong}}Connect{{/strong}} to automatically share posts to your Path timeline.', {
-								components: {
-									strong: <strong />
-								}
-							} )
-						}
-					];
-				},
-				eventbrite: function() {
-					return [
-						{
-							image: {
-								src: '/calypso/images/sharing/eventbrite-list.png',
-								alt: this.translate( 'Connect Eventbrite to list your events', { textOnly: true } )
-							},
-							label: this.translate( '{{strong}}Connect{{/strong}} Eventbrite to {{link}}list all your events{{/link}} on a page.', {
-								components: {
-									strong: <strong />,
-									link: <a href="https://support.wordpress.com/eventbrite" />
-								}
-							} )
-						},
-						{
-							image: {
-								src: '/calypso/images/sharing/eventbrite-widget.png',
-								alt: this.translate( 'Add an Eventbrite widget to your page', { textOnly: true } )
-							},
-							label: this.translate( 'Add an {{link}}Eventbrite widget{{/link}} to display a list of your upcoming events.', {
-								components: {
-									link: <a href="https://support.wordpress.com/widgets/eventbrite-event-calendarlisting-widget/" />
-								}
-							} )
-						}
-					];
-				},
-				bandpage: function() {
-					return [
-						{
-							image: {
-								src: '/calypso/images/sharing/bandpage-widget.png',
-								alt: this.translate( 'Add a BandPage widget', { textOnly: true } )
-							},
-							label: this.translate( 'Add a {{link}}BandPage widget{{/link}} to display your music, photos, videos bio, and event listings.', {
-								components: {
-									link: <a href="https://support.wordpress.com/widgets/bandpage-widget/" />
-								}
-							} )
-						}
-					];
-				}
-			} )
-		};
-	},
-
-	getExamples: function() {
-		var examples;
-
-		if ( this.props.examples[ this.props.service.ID ] ) {
-			examples = this.props.examples[ this.props.service.ID ].call( this );
-
-			return examples.map( function( example, i ) {
-				return <ServiceExample key={ i } image={ example.image } label={ example.label } single={ 1 === examples.length } />;
-			} );
-		}
-	},
-
-	render: function() {
-		return <div className="sharing-service-examples">{ this.getExamples() }</div>;
+	getSharingButtonsLink() {
+		return this.props.site ? '/sharing/buttons/' + this.props.site.slug : 'https://support.wordpress.com/sharing/';
 	}
-} );
+
+	bandpage() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/bandpage-widget.png',
+					alt: this.props.translate( 'Add a BandPage widget', { textOnly: true } )
+				},
+				label: this.props.translate(
+					'Add a {{link}}BandPage widget{{/link}} to display your music, photos, videos bio, and event listings.', {
+						components: {
+							link: <a href="https://support.wordpress.com/widgets/bandpage-widget/" />
+						}
+					}
+				),
+			},
+		];
+	}
+
+	eventbrite() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/eventbrite-list.png',
+					alt: this.props.translate( 'Connect Eventbrite to list your events', { textOnly: true } )
+				},
+				label: this.props.translate(
+					'{{strong}}Connect{{/strong}} Eventbrite to {{link}}list all your events{{/link}} on a page.', {
+						components: {
+							strong: <strong />,
+							link: <a href="https://support.wordpress.com/eventbrite" />
+						}
+					}
+				),
+			},
+			{
+				image: {
+					src: '/calypso/images/sharing/eventbrite-widget.png',
+					alt: this.props.translate( 'Add an Eventbrite widget to your page', { textOnly: true } )
+				},
+				label: this.props.translate( 'Add an {{link}}Eventbrite widget{{/link}} to display a list of your upcoming events.', {
+					components: {
+						link: <a href="https://support.wordpress.com/widgets/eventbrite-event-calendarlisting-widget/" />
+					}
+				} ),
+			},
+		];
+	}
+
+	facebook() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/facebook-profile.png',
+					alt: this.props.translate( 'Share posts to your Facebook page or profile', { textOnly: true } ),
+				},
+				label: this.props.translate(
+					'{{strong}}Connect{{/strong}} to automatically share posts on your Facebook page or profile.', {
+						components: {
+							strong: <strong />
+						}
+					}
+				),
+			},
+			{
+				image: {
+					src: '/calypso/images/sharing/facebook-sharing.png',
+					alt: this.props.translate( 'Add a sharing button', { textOnly: true } )
+				},
+				label: this.props.translate(
+					'Add a {{link}}sharing button{{/link}} to your posts so readers can share your story with their friends.', {
+						components: {
+							link: <a href={ this.getSharingButtonsLink() } />
+						}
+					}
+				),
+			},
+		];
+	}
+
+	google_plus() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/google-publicize.png',
+					alt: this.props.translate( 'Share posts to your Google+ page', { textOnly: true } )
+				},
+				label: this.props.translate( '{{strong}}Connect{{/strong}} to automatically share posts to your Google+ page.', {
+					components: {
+						strong: <strong />
+					}
+				} ),
+			},
+			{
+				image: {
+					src: '/calypso/images/sharing/google-sharing.png',
+					alt: this.props.translate( 'Add a sharing button', { textOnly: true } )
+				},
+				label: this.props.translate(
+					'Add a {{link}}sharing button{{/link}} to your posts so readers can share your story with their circles.', {
+						components: {
+							link: <a href={ this.getSharingButtonsLink() } />
+						}
+					}
+				),
+			},
+		];
+	}
+
+	instagram() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/instagram-widget.png',
+					alt: this.props.translate( 'Add an Instagram widget', { textOnly: true } )
+				},
+				label: this.props.translate( 'Add an {{link}}Instagram widget{{/link}} to display your latest photos.', {
+					components: {
+						link: <a href="https://support.wordpress.com/instagram/instagram-widget/" />
+					}
+				} ),
+			},
+			{
+				image: {
+					src: '/calypso/images/sharing/instagram-media.png',
+					alt: this.props.translate( 'Access Instagram photos via the Media Library', { textOnly: true } )
+				},
+				label: this.props.translate(
+					'Get instant access to all your Instagram photos through the {{link}}Media Library{{/link}}.', {
+						components: {
+							link: <a href="https://support.wordpress.com/media/" />
+						}
+					}
+				),
+			},
+		];
+	}
+
+	linkedin() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/linkedin-publicize.png',
+					alt: this.props.translate( 'Share posts with your LinkedIn connections', { textOnly: true } )
+				},
+				label: this.props.translate( '{{strong}}Connect{{/strong}} to automatically share posts with your LinkedIn connections.', {
+					components: {
+						strong: <strong />
+					}
+				} ),
+			},
+			{
+				image: {
+					src: '/calypso/images/sharing/linkedin-sharing.png',
+					alt: this.props.translate( 'Add a sharing button', { textOnly: true } )
+				},
+				label: this.props.translate(
+					'Add a {{link}}sharing button{{/link}} to your posts so readers can share your story with their connections.', {
+						components: {
+							link: <a href={ this.getSharingButtonsLink() } />
+						}
+					}
+				),
+			},
+		];
+	}
+
+	path() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/path-publicize.png',
+					alt: this.props.translate( 'Share posts to your Path timeline', { textOnly: true } )
+				},
+				label: this.props.translate( '{{strong}}Connect{{/strong}} to automatically share posts to your Path timeline.', {
+					components: {
+						strong: <strong />
+					}
+				} ),
+			},
+		];
+	}
+
+	tumblr() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/tumblr-publicize.png',
+					alt: this.props.translate( 'Share posts to your Tumblr blog', { textOnly: true } )
+				},
+				label: this.props.translate( '{{strong}}Connect{{/strong}} to automatically share posts to your Tumblr blog.', {
+					components: {
+						strong: <strong />
+					}
+				} ),
+			},
+			{
+				image: {
+					src: '/calypso/images/sharing/tumblr-sharing.png',
+					alt: this.props.translate( 'Add a sharing button', { textOnly: true } )
+				},
+				label: this.props.translate(
+					'Add a {{link}}sharing button{{/link}} to your posts so readers can share your story with their followers.', {
+						components: {
+							link: <a href={ this.getSharingButtonsLink() } />
+						}
+					}
+				),
+			},
+		];
+	}
+
+	twitter() {
+		return [
+			{
+				image: {
+					src: '/calypso/images/sharing/twitter-publicize.png',
+					alt: this.props.translate( 'Share posts to your Twitter followers', { textOnly: true } )
+				},
+				label: this.props.translate( '{{strong}}Connect{{/strong}} to automatically share posts with your Twitter followers.', {
+					components: {
+						strong: <strong />
+					}
+				} ),
+			},
+			{
+				image: {
+					src: '/calypso/images/sharing/twitter-timeline.png',
+					alt: this.props.translate( 'Add a Twitter Timeline Widget', { textOnly: true } )
+				},
+				label: this.props.translate( 'Add a {{link}}Twitter Timeline Widget{{/link}} to display your latest tweets on your site.', {
+					components: {
+						link: <a href="https://support.wordpress.com/widgets/twitter-timeline-widget/" />
+					}
+				} ),
+			},
+		];
+	}
+
+	render() {
+		if ( ! includes( SERVICES_WHITELIST, this.props.service.ID ) ) {
+			return <div className="sharing-service-examples" />;
+		}
+
+		const examples = this[ this.props.service.ID ]();
+
+		return (
+			<div className="sharing-service-examples">
+				{ examples.map( ( example, index ) =>
+					<ServiceExample key={ index } image={ example.image } label={ example.label } single={ 1 === examples.length } />
+				) }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		site: getSelectedSite( state ),
+	} ),
+)( localize( SharingServiceExamples ) );

--- a/client/my-sites/sharing/connections/service-examples.jsx
+++ b/client/my-sites/sharing/connections/service-examples.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
+import { identity, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -39,6 +39,12 @@ class SharingServiceExamples extends Component {
 	static propTypes = {
 		service: PropTypes.object.isRequired,
 		site: PropTypes.object,
+		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		site: Object.freeze( {} ),
+		translate: identity,
 	};
 
 	getSharingButtonsLink() {

--- a/client/my-sites/sharing/connections/service-placeholder.jsx
+++ b/client/my-sites/sharing/connections/service-placeholder.jsx
@@ -1,17 +1,22 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
 import GridIcon from 'components/gridicon';
 
-module.exports = React.createClass( {
-	displayName: 'SharingServicePlaceholder',
+class SharingServicePlaceholder extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+	};
 
-	render: function() {
-
+	render() {
 		const header = (
 			<div>
 				<GridIcon
@@ -20,19 +25,15 @@ module.exports = React.createClass( {
 					className="sharing-service__logo" />
 
 				<div className="sharing-service__name">
-					<h2></h2>
-					<p className="sharing-service__description"></p>
+					<h2 />
+					<p className="sharing-service__description" />
 				</div>
 			</div>
 		);
 
 		const summary = (
-			<Button
-				compact
-				disabled
-				>{ this.translate( 'Loading' ) }</Button>
+			<Button compact disabled>{ this.props.translate( 'Loading' ) }</Button>
 		);
-
 
 		return (
 			<li className="sharing-service is-placeholder">
@@ -40,11 +41,12 @@ module.exports = React.createClass( {
 					header={ header }
 					summary={ summary }
 					className="sharing-service"
-					compact
-					>
-					<div></div>
+					compact>
+					<div />
 				</FoldableCard>
 			</li>
 		);
 	}
-} );
+}
+
+export default localize( SharingServicePlaceholder );

--- a/client/my-sites/sharing/connections/service-placeholder.jsx
+++ b/client/my-sites/sharing/connections/service-placeholder.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,6 +15,10 @@ import GridIcon from 'components/gridicon';
 class SharingServicePlaceholder extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		translate: identity,
 	};
 
 	render() {

--- a/client/my-sites/sharing/connections/service-tip.jsx
+++ b/client/my-sites/sharing/connections/service-tip.jsx
@@ -1,69 +1,98 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
-module.exports = React.createClass( {
-	displayName: 'SharingServiceTip',
+/**
+ * Module constants
+ */
+/**
+ * Whitelist of services that we provide tips for.
+ *
+ * When adding tips for more services, please update the whitelist in addition to adding
+ * a method with the tip's content.
+ *
+ * @type {string[]}
+ */
+const SERVICES_WHITELIST = [
+	'facebook',
+	'twitter',
+	'instagram',
+	'google_plus',
+	'eventbrite',
+];
 
-	getDefaultProps: function() {
-		return {
-			tips: Object.freeze( {
-				facebook: function() {
-					return this.translate( 'You can also add a {{likeBoxLink}}Like Box{{/likeBoxLink}}, a {{shareButtonLink}}share button{{/shareButtonLink}}, or {{embedLink}}embed{{/embedLink}} your page or profile on your site.', {
-						components: {
-							likeBoxLink: <a href="https://support.wordpress.com/facebook-integration/#facebook-like-box" />,
-							shareButtonLink: <a href="https://support.wordpress.com/sharing/" />,
-							embedLink: <a href="https://support.wordpress.com/facebook-integration/facebook-embeds/" />
-						},
-						context: 'Sharing: Tip in settings'
-					} );
-				},
-				twitter: function() {
-					return this.translate( 'You can also add a {{widgetLink}}Twitter Timeline Widget{{/widgetLink}} to display any public timeline on your site.', {
-						components: {
-							widgetLink: <a href="https://support.wordpress.com/widgets/twitter-timeline-widget/" />
-						},
-						context: 'Sharing: Tip in settings'
-					} );
-				},
-				instagram: function() {
-					return this.translate( 'You can also add an {{widgetLink}}Instagram Widget{{/widgetLink}} to display your latest Instagram photos on your site.', {
-						components: {
-							widgetLink: <a href="https://support.wordpress.com/instagram/instagram-widget/" />
-						},
-						context: 'Sharing: Tip in settings'
-					} );
-				},
-				google_plus: function() {
-					return this.translate( 'You can also {{embedLink}}embed a Google+ post{{/embedLink}} onto a post or page.', {
-						components: {
-							embedLink: <a href="https://support.wordpress.com/google-plus-embeds/" />
-						},
-						context: 'Sharing: Tip in settings'
-					} );
-				},
-				eventbrite: function() {
-					return this.translate( 'You can also add the {{embedLink}}Eventbrite widget{{/embedLink}} to display events in a sidebar.', {
-						components: {
-							embedLink: <a href="https://support.wordpress.com/widgets/eventbrite-event-calendarlisting-widget/" />
-						},
-						context: 'Sharing: Tip in settings'
-					} );
-				}
-			} )
-		};
-	},
+class SharingServiceTip extends Component {
+	static propTypes = {
+		service: PropTypes.object.isRequired,
+		translate: PropTypes.func,
+	};
 
-	render: function() {
-		if ( 'function' === typeof this.props.tips[ this.props.service.ID ] ) {
-			return (
-				<div className="sharing-service-tip">
-					<span className="noticon noticon-info"></span>{ this.props.tips[ this.props.service.ID ].call( this ) }
-				</div>
-			);
-		} else {
+	facebook() {
+		return this.props.translate(
+			'You can also add a {{likeBoxLink}}Like Box{{/likeBoxLink}}, a {{shareButtonLink}}share button{{/shareButtonLink}}, or {{embedLink}}embed{{/embedLink}} your page or profile on your site.', {
+				components: {
+					likeBoxLink: <a href="https://support.wordpress.com/facebook-integration/#facebook-like-box" />,
+					shareButtonLink: <a href="https://support.wordpress.com/sharing/" />,
+					embedLink: <a href="https://support.wordpress.com/facebook-integration/facebook-embeds/" />
+				},
+				context: 'Sharing: Tip in settings'
+			} );
+	}
+
+	twitter() {
+		return this.props.translate(
+			'You can also add a {{widgetLink}}Twitter Timeline Widget{{/widgetLink}} to display any public timeline on your site.', {
+				components: {
+					widgetLink: <a href="https://support.wordpress.com/widgets/twitter-timeline-widget/" />
+				},
+				context: 'Sharing: Tip in settings'
+			} );
+	}
+
+	instagram() {
+		return this.props.translate(
+			'You can also add an {{widgetLink}}Instagram Widget{{/widgetLink}} to display your latest Instagram photos on your site.', {
+				components: {
+					widgetLink: <a href="https://support.wordpress.com/instagram/instagram-widget/" />
+				},
+				context: 'Sharing: Tip in settings'
+			} );
+	}
+
+	google_plus() {
+		return this.props.translate(
+			'You can also {{embedLink}}embed a Google+ post{{/embedLink}} onto a post or page.', {
+				components: {
+					embedLink: <a href="https://support.wordpress.com/google-plus-embeds/" />
+				},
+				context: 'Sharing: Tip in settings'
+			} );
+	}
+
+	eventbrite() {
+		return this.props.translate(
+			'You can also add the {{embedLink}}Eventbrite widget{{/embedLink}} to display events in a sidebar.', {
+				components: {
+					embedLink: <a href="https://support.wordpress.com/widgets/eventbrite-event-calendarlisting-widget/" />
+				},
+				context: 'Sharing: Tip in settings'
+			} );
+	}
+
+	render() {
+		if ( -1 === SERVICES_WHITELIST.indexOf( this.props.service.ID ) ) {
 			return <div className="sharing-service-tip" />;
 		}
+
+		return (
+			<div className="sharing-service-tip">
+				<span className="noticon noticon-info" />
+				{ this[ this.props.service.ID ]() }
+			</div>
+		);
 	}
-} );
+}
+
+export default localize( SharingServiceTip );

--- a/client/my-sites/sharing/connections/service-tip.jsx
+++ b/client/my-sites/sharing/connections/service-tip.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { includes } from 'lodash';
+import { identity, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -33,6 +33,10 @@ class SharingServiceTip extends Component {
 	static propTypes = {
 		service: PropTypes.object.isRequired,
 		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		translate: identity,
 	};
 
 	facebook() {

--- a/client/my-sites/sharing/connections/service-tip.jsx
+++ b/client/my-sites/sharing/connections/service-tip.jsx
@@ -2,7 +2,13 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
 
 /**
  * Module constants
@@ -82,13 +88,13 @@ class SharingServiceTip extends Component {
 	}
 
 	render() {
-		if ( -1 === SERVICES_WHITELIST.indexOf( this.props.service.ID ) ) {
+		if ( ! includes( SERVICES_WHITELIST, this.props.service.ID ) ) {
 			return <div className="sharing-service-tip" />;
 		}
 
 		return (
 			<div className="sharing-service-tip">
-				<span className="noticon noticon-info" />
+				<Gridicon icon="info" size={ 18 } />
 				{ this[ this.props.service.ID ]() }
 			</div>
 		);

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -13,7 +13,6 @@ var ServiceTip = require( './service-tip' ),
 	ServiceConnectedAccounts = require( './service-connected-accounts' ),
 	notices = require( 'notices' ),
 	observe = require( 'lib/mixins/data-observe' ),
-	sites = require( 'lib/sites-list' )(),
 	serviceConnections = require( './service-connections' ),
 	analytics = require( 'lib/analytics' ),
 	FoldableCard = require( 'components/foldable-card' ),
@@ -227,7 +226,7 @@ module.exports = React.createClass( {
 		const content = (
 			<div
 				className={ 'sharing-service__content ' + ( serviceConnections.isFetchingAccounts() ? 'is-placeholder' : '' ) }>
-				<ServiceExamples service={ this.props.service } site={ sites.getSelectedSite() } />
+				<ServiceExamples service={ this.props.service } />
 				<ServiceConnectedAccounts
 					connections={ connections }
 					isDisconnecting={ this.state.isDisconnecting }

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -246,7 +246,8 @@ module.exports = React.createClass( {
 				onAction={ this.performAction }
 				isConnecting={ this.state.isConnecting }
 				isRefreshing={ this.state.isRefreshing }
-				isDisconnecting={ this.state.isDisconnecting } />
+				isDisconnecting={ this.state.isDisconnecting }
+				removableConnections={ serviceConnections.getRemovableConnections( this.props.service.ID ) } />
 		);
 		return (
 			<FoldableCard

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -229,16 +229,14 @@ module.exports = React.createClass( {
 				className={ 'sharing-service__content ' + ( serviceConnections.isFetchingAccounts() ? 'is-placeholder' : '' ) }>
 				<ServiceExamples service={ this.props.service } site={ sites.getSelectedSite() } />
 				<ServiceConnectedAccounts
-					site={ this.props.site }
-					user={ this.props.user }
-					service={ this.props.service }
 					connections={ connections }
-					onAddConnection={ this.connect }
-					onRemoveConnection={ this.disconnect }
 					isDisconnecting={ this.state.isDisconnecting }
-					onRefreshConnection={ this.refresh }
 					isRefreshing={ this.state.isRefreshing }
-					onToggleSitewideConnection={ this.props.onToggleSitewideConnection } />
+					onAddConnection={ this.connect }
+					onRefreshConnection={ this.refresh }
+					onRemoveConnection={ this.disconnect }
+					onToggleSitewideConnection={ this.props.onToggleSitewideConnection }
+					service={ this.props.service } />
 				<ServiceTip service={ this.props.service } />
 			</div> );
 

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -29,6 +30,7 @@ const SharingService = React.createClass( {
 		connections: PropTypes.object.isRequired,   // A collections-list instance
 		service: PropTypes.object.isRequired,       // The single service object
 		siteId: PropTypes.number,                   // The site ID for which connections are created
+		translate: PropTypes.func,
 	},
 
 	mixins: [ observe( 'connections' ) ],
@@ -46,6 +48,7 @@ const SharingService = React.createClass( {
 	getDefaultProps: function() {
 		return {
 			siteId: 0,
+			translate: identity,
 		};
 	},
 

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -22,32 +22,22 @@ import ServicePlaceholder from './service-placeholder';
 const NUMBER_OF_PLACEHOLDERS = 4;
 
 class SharingServicesGroup extends Component {
-
 	static propTypes = {
-		site: PropTypes.object,
-		user: PropTypes.object,
 		connections: PropTypes.object,
-		onAddConnection: PropTypes.func,
-		onRemoveConnection: PropTypes.func,
-		onRefreshConnection: PropTypes.func,
-		onToggleSitewideConnection: PropTypes.func,
-		initialized: PropTypes.bool,
+		description: PropTypes.string,
 		services: PropTypes.array,
 		title: PropTypes.string.isRequired,
-		description: PropTypes.string
 	};
 
 	static defaultProps = {
-		onAddConnection: () => {},
-		onRemoveConnection: () => {},
-		onRefreshConnection: () => {},
-		onToggleSitewideConnection: () => {},
-		initialized: false
+		connections: Object.freeze( {} ),
+		description: '',
+		services: Object.freeze( [] ),
 	};
 
 	render() {
 		const classes = classNames( 'sharing-services-group', {
-			'is-empty': this.props.initialized && ! this.props.services.length
+			'is-empty': ! this.props.services.length
 		} );
 
 		return (
@@ -55,18 +45,12 @@ class SharingServicesGroup extends Component {
 				<QueryKeyringServices />
 				<SectionHeader label={ this.props.title } />
 				<ul className="sharing-services-group__services">
-					{ this.props.initialized
+					{ this.props.services.length
 						? this.props.services.map( ( service ) =>
 							<Service
 								key={ service.ID }
 								connections={ this.props.connections }
-								onAddConnection={ this.props.onAddConnection }
-								onRefreshConnection={ this.props.onRefreshConnection }
-								onRemoveConnection={ this.props.onRemoveConnection }
-								onToggleSitewideConnection={ this.props.onToggleSitewideConnection }
-								service={ service }
-								site={ this.props.site }
-								user={ this.props.user } /> )
+								service={ service } /> )
 						: times( NUMBER_OF_PLACEHOLDERS, ( index ) =>
 							<ServicePlaceholder
 								key={ 'service-placeholder-' + index } /> )

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -11,7 +11,6 @@ import { times } from 'lodash';
  */
 import { getEligibleKeyringServices } from 'state/sharing/services/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import QueryKeyringServices from 'components/data/query-keyring-services';
 import SectionHeader from 'components/section-header';
 import Service from './service';
 import ServicePlaceholder from './service-placeholder';
@@ -27,6 +26,7 @@ class SharingServicesGroup extends Component {
 		description: PropTypes.string,
 		services: PropTypes.array,
 		title: PropTypes.string.isRequired,
+		type: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
@@ -42,7 +42,6 @@ class SharingServicesGroup extends Component {
 
 		return (
 			<div className={ classes }>
-				<QueryKeyringServices />
 				<SectionHeader label={ this.props.title } />
 				<ul className="sharing-services-group__services">
 					{ this.props.services.length

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -9,7 +9,6 @@ var page = require( 'page' ),
  * Internal Dependencies
  */
 var sites = require( 'lib/sites-list' )(),
-	user = require( 'lib/user' )(),
 	utils = require( 'lib/site/utils' ),
 	notices = require( 'notices' ),
 	route = require( 'lib/route' ),
@@ -65,9 +64,7 @@ module.exports = {
 			analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Connections' );
 
 			context.contentComponent = React.createElement( SharingConnections, {
-				user: user,
 				connections: connectionsList,
-				sites: sites
 			} );
 		}
 

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -146,8 +146,9 @@
 		font-size: 14px;
 		color: darken( $gray,10 );
 
-		.noticon-info {
-			margin: 3px 3px 0 0;
+		.gridicons-info {
+			margin-right: 3px;
+			vertical-align: text-bottom;
 		}
 	}
 


### PR DESCRIPTION
This PR is the second step in removing `connections-list` and using Redux instead.

Although it's a fairly big diff, most of it should be fairly straight forward to review since it's mostly syntax changes. I also started using Redux where it made sense to reduce props noise between components.

The biggest functional change is probably moving some of the service-specific action handlers from `connections/connections.jsx` to `connections/service.jsx`. This will make it a lot easier to have these actions be done in Redux in the future.

I was not able to convert `connections/service.jsx` to using an ES6 class because it still needs the mixin to listen to connections-list updates. If anyone has an idea on how I can mimic the mixin's functionality in a class structure, I'm all ears.

See #8991, #9068, #5046.