### PR TITLE
Framework: Pass default export in asyncRequire callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .webpack-cache
 .sass-cache
+.babel-cache
 .vagrant
 .unison
 .env

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ build-desktop build-desktop-mac-app-store: build-server $(CLIENT_CONFIG_FILE) bu
 # the `clean` rule deletes all the files created from `make build`, but not
 # those created by `make install`
 clean:
-	@rm -rf public/style*.css public/style-debug.css.map public/*.js $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js server/devdocs/components-usage-stats.json public/editor.css build/* server/bundler/*.json
+	@rm -rf public/style*.css public/style-debug.css.map public/*.js $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js server/devdocs/components-usage-stats.json public/editor.css build/* server/bundler/*.json .babel-cache
 
 # the `distclean` rule deletes all the files created from `make install`
 distclean: clean

--- a/server/bundler/babel/babel-loader-cache-identifier/index.js
+++ b/server/bundler/babel/babel-loader-cache-identifier/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+/**
+ * Given a module name, returns the package version
+ *
+ * @param  {String} id Module name
+ * @return {String}    Module version
+ */
+function getModuleVersion( id ) {
+	return require( path.dirname( require.resolve( id ) ) + '/package' ).version;
+}
+
+/**
+ * Cache identifier string for use with babel-loader. This is an extension of
+ * the default cacheIdentifier, including package version from our custom Babel
+ * transform plugin to ensure proper cachebusting.
+ *
+ * @see https://github.com/babel/babel-loader/blob/501d60d/src/index.js#L85-L92
+ * @type {String}
+ */
+module.exports = JSON.stringify( {
+	'babel-loader': getModuleVersion( 'babel-loader' ),
+	'babel-core': getModuleVersion( 'babel-core' ),
+	'babel-plugin-transform-wpcalypso-async': getModuleVersion( '../babel-plugin-transform-wpcalypso-async' ),
+	babelrc: fs.readFileSync( path.resolve( __dirname, '../../../../.babelrc' ), 'utf8' ),
+	env: process.env.BABEL_ENV || process.env.NODE_ENV
+} );

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
@@ -70,10 +70,18 @@ module.exports = ( { types: t } ) => {
 				const isAsync = state.opts.async;
 
 				// In both asynchronous and synchronous case, we'll finish by
-				// calling require on the loaded module
-				let requireCall = t.memberExpression(
-					t.callExpression( t.identifier( 'require' ), [ argument ] ),
-					t.identifier( 'default' )
+				// calling require on the loaded module. If the module is an
+				// ES2015 module, use its default export.
+				let requireCall = t.conditionalExpression(
+					t.memberExpression(
+						t.callExpression( t.identifier( 'require' ), [ argument ] ),
+						t.identifier( '__esModule' )
+					),
+					t.memberExpression(
+						t.callExpression( t.identifier( 'require' ), [ argument ] ),
+						t.identifier( 'default' )
+					),
+					t.callExpression( t.identifier( 'require' ), [ argument ] )
 				);
 
 				// If a callback was passed as an argument, wrap it as part of

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/index.js
@@ -71,7 +71,10 @@ module.exports = ( { types: t } ) => {
 
 				// In both asynchronous and synchronous case, we'll finish by
 				// calling require on the loaded module
-				let requireCall = t.callExpression( t.identifier( 'require' ), [ argument ] );
+				let requireCall = t.memberExpression(
+					t.callExpression( t.identifier( 'require' ), [ argument ] ),
+					t.identifier( 'default' )
+				);
 
 				// If a callback was passed as an argument, wrap it as part of
 				// the transformation

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/package.json
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "babel-plugin-transform-wpcalypso-async",
+	"version": "1.0.1",
+	"private": true
+}

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
@@ -36,7 +36,7 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 			it( 'should replace a require string prop with hoisting', () => {
 				const code = transform( 'export default () => <AsyncLoad require="foo" />;' );
 
-				expect( code ).to.equal( 'var _ref = function (callback) {\n  require.ensure("foo", function (require) {\n    callback(require("foo"));\n  }, "async-load-foo");\n};\n\nexport default (() => <AsyncLoad require={_ref} />);' );
+				expect( code ).to.equal( 'var _ref = function (callback) {\n  require.ensure("foo", function (require) {\n    callback(require("foo").default);\n  }, "async-load-foo");\n};\n\nexport default (() => <AsyncLoad require={_ref} />);' );
 			} );
 		} );
 
@@ -44,7 +44,7 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 			it( 'should replace a require string prop with hoisting', () => {
 				const code = transform( 'export default () => <AsyncLoad require="foo" />;', false );
 
-				expect( code ).to.equal( 'var _ref = function (callback) {\n  callback(require("foo"));\n};\n\nexport default (() => <AsyncLoad require={_ref} />);' );
+				expect( code ).to.equal( 'var _ref = function (callback) {\n  callback(require("foo").default);\n};\n\nexport default (() => <AsyncLoad require={_ref} />);' );
 			} );
 		} );
 	} );
@@ -66,13 +66,13 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 			it( 'should call require directly after ensure when no callback', () => {
 				const code = transform( 'asyncRequire( "foo/bar" );' );
 
-				expect( code ).to.equal( 'require.ensure("foo/bar", function (require) {\n  require("foo/bar");\n}, "async-load-foo-bar");' );
+				expect( code ).to.equal( 'require.ensure("foo/bar", function (require) {\n  require("foo/bar").default;\n}, "async-load-foo-bar");' );
 			} );
 
 			it( 'should invoke callback with require after ensure', () => {
 				const code = transform( 'asyncRequire( "foo/bar", cb );' );
 
-				expect( code ).to.equal( 'require.ensure("foo/bar", function (require) {\n  cb(require("foo/bar"));\n}, "async-load-foo-bar");' );
+				expect( code ).to.equal( 'require.ensure("foo/bar", function (require) {\n  cb(require("foo/bar").default);\n}, "async-load-foo-bar");' );
 			} );
 		} );
 
@@ -80,13 +80,13 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 			it( 'should call require directly when no callback', () => {
 				const code = transform( 'asyncRequire( "foo" );', false );
 
-				expect( code ).to.equal( 'require("foo");' );
+				expect( code ).to.equal( 'require("foo").default;' );
 			} );
 
 			it( 'should invoke callback with require', () => {
 				const code = transform( 'asyncRequire( "foo", cb );', false );
 
-				expect( code ).to.equal( 'cb(require("foo"));' );
+				expect( code ).to.equal( 'cb(require("foo").default);' );
 			} );
 		} );
 	} );

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
@@ -36,7 +36,7 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 			it( 'should replace a require string prop with hoisting', () => {
 				const code = transform( 'export default () => <AsyncLoad require="foo" />;' );
 
-				expect( code ).to.equal( 'var _ref = function (callback) {\n  require.ensure("foo", function (require) {\n    callback(require("foo").default);\n  }, "async-load-foo");\n};\n\nexport default (() => <AsyncLoad require={_ref} />);' );
+				expect( code ).to.equal( 'var _ref = function (callback) {\n  require.ensure("foo", function (require) {\n    callback(require("foo").__esModule ? require("foo").default : require("foo"));\n  }, "async-load-foo");\n};\n\nexport default (() => <AsyncLoad require={_ref} />);' );
 			} );
 		} );
 
@@ -44,7 +44,7 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 			it( 'should replace a require string prop with hoisting', () => {
 				const code = transform( 'export default () => <AsyncLoad require="foo" />;', false );
 
-				expect( code ).to.equal( 'var _ref = function (callback) {\n  callback(require("foo").default);\n};\n\nexport default (() => <AsyncLoad require={_ref} />);' );
+				expect( code ).to.equal( 'var _ref = function (callback) {\n  callback(require("foo").__esModule ? require("foo").default : require("foo"));\n};\n\nexport default (() => <AsyncLoad require={_ref} />);' );
 			} );
 		} );
 	} );
@@ -66,13 +66,13 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 			it( 'should call require directly after ensure when no callback', () => {
 				const code = transform( 'asyncRequire( "foo/bar" );' );
 
-				expect( code ).to.equal( 'require.ensure("foo/bar", function (require) {\n  require("foo/bar").default;\n}, "async-load-foo-bar");' );
+				expect( code ).to.equal( 'require.ensure("foo/bar", function (require) {\n  require("foo/bar").__esModule ? require("foo/bar").default : require("foo/bar");\n}, "async-load-foo-bar");' );
 			} );
 
 			it( 'should invoke callback with require after ensure', () => {
 				const code = transform( 'asyncRequire( "foo/bar", cb );' );
 
-				expect( code ).to.equal( 'require.ensure("foo/bar", function (require) {\n  cb(require("foo/bar").default);\n}, "async-load-foo-bar");' );
+				expect( code ).to.equal( 'require.ensure("foo/bar", function (require) {\n  cb(require("foo/bar").__esModule ? require("foo/bar").default : require("foo/bar"));\n}, "async-load-foo-bar");' );
 			} );
 		} );
 
@@ -80,13 +80,13 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 			it( 'should call require directly when no callback', () => {
 				const code = transform( 'asyncRequire( "foo" );', false );
 
-				expect( code ).to.equal( 'require("foo").default;' );
+				expect( code ).to.equal( 'require("foo").__esModule ? require("foo").default : require("foo");' );
 			} );
 
 			it( 'should invoke callback with require', () => {
 				const code = transform( 'asyncRequire( "foo", cb );', false );
 
-				expect( code ).to.equal( 'cb(require("foo").default);' );
+				expect( code ).to.equal( 'cb(require("foo").__esModule ? require("foo").default : require("foo"));' );
 			} );
 		} );
 	} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,7 +148,7 @@ const jsLoader = {
 	exclude: /node_modules/,
 	loader: 'babel',
 	query: {
-		cacheDirectory: true,
+		cacheDirectory: './.babel-cache',
 		plugins: [ [
 			path.join( __dirname, 'server', 'bundler', 'babel', 'babel-plugin-transform-wpcalypso-async' ),
 			{ async: config.isEnabled( 'code-splitting' ) }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const webpack = require( 'webpack' ),
  */
 const config = require( './server/config' ),
 	sections = require( './client/sections' ),
+	cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' ),
 	ChunkFileNamePlugin = require( './server/bundler/plugin' ),
 	HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' );
 
@@ -149,6 +150,7 @@ const jsLoader = {
 	loader: 'babel',
 	query: {
 		cacheDirectory: './.babel-cache',
+		cacheIdentifier: cacheIdentifier,
 		plugins: [ [
 			path.join( __dirname, 'server', 'bundler', 'babel', 'babel-plugin-transform-wpcalypso-async' ),
 			{ async: config.isEnabled( 'code-splitting' ) }


### PR DESCRIPTION
This pull request seeks to resolve an issue where it's not possible to use `<AsyncLoad />` with a module that exports both a named and default export, since in these cases the result of `require( 'component' );` would be an object containing the named and `default` exports as properties.

The reason `<AsyncLoad />` works with components with only a default export is because our configured [`add-module-exports` Babel plugin](https://www.npmjs.com/package/babel-plugin-add-module-exports) assigns the default export as `module.exports` if there are no named exports in a file.

Because the `default` property still exists with this compatibility layer, we can reference it to cover both cases, where named and default exports exists, or only a default export exists.

__Testing instructions:__

Verify that there are no regressions in the usage of `<AsyncLoad />`, currently limited to the post editor (see #8544, #9112).

cc @mtias @blowery @ehg 