### PR TITLE
Media: Extract editor-specific markup generation to separate modal component

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -23,8 +23,7 @@ import MediaUtils from 'lib/media/utils';
 import { deserialize } from 'lib/media-serialization';
 import MediaMarkup from 'post-editor/media-modal/markup';
 import MediaStore from 'lib/media/store';
-import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
-import EditorMediaModal from 'post-editor/media-modal';
+import EditorMediaModal from 'post-editor/editor-media-modal';
 import notices from 'notices';
 import TinyMCEDropZone from './drop-zone';
 import restrictSize from './restrict-size';
@@ -92,16 +91,13 @@ function mediaButton( editor ) {
 
 		ReactDom.render(
 			<ReduxProvider store={ store }>
-				<MediaLibrarySelectedData siteId={ selectedSite.ID }>
-					<EditorMediaModal
-						{ ...props }
-						onClose={ renderModal.bind( null, { visible: false } ) }
-						onInsertMedia={ ( markup ) => {
-							insertMedia( markup );
-							renderModal( { visible: false } );
-						} }
-						site={ selectedSite } />
-				</MediaLibrarySelectedData>
+				<EditorMediaModal
+					{ ...props }
+					onClose={ renderModal.bind( null, { visible: false } ) }
+					onInsertMedia={ ( markup ) => {
+						insertMedia( markup );
+						renderModal( { visible: false } );
+					} } />
 			</ReduxProvider>,
 			nodes.modal
 		);

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -59,8 +59,8 @@ class SiteIconSetting extends Component {
 
 	showModal = () => this.toggleModal( true );
 
-	editSelectedMedia = ( media ) => {
-		if ( media ) {
+	editSelectedMedia = ( value ) => {
+		if ( value ) {
 			this.props.onEditSelectedMedia();
 		} else {
 			this.hideModal();

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
-import EditorMediaModal from 'post-editor/media-modal';
+import MediaModal from 'post-editor/media-modal';
 import PostActions from 'lib/posts/actions';
 import PostUtils from 'lib/posts/utils';
 import * as stats from 'lib/posts/stats';
@@ -52,16 +52,16 @@ export default React.createClass( {
 		} );
 	},
 
-	setImage( items ) {
+	setImage( value ) {
 		this.hideMediaModal();
 		this.props.onImageSelected();
 
-		if ( ! items || ! items.length ) {
+		if ( ! value ) {
 			return;
 		}
 
 		PostActions.edit( {
-			featured_image: items[0].ID
+			featured_image: value.items[ 0 ].ID
 		} );
 
 		stats.recordStat( 'featured_image_set' );
@@ -75,7 +75,7 @@ export default React.createClass( {
 
 		return (
 			<MediaLibrarySelectedData siteId={ this.props.site.ID }>
-				<EditorMediaModal
+				<MediaModal
 					visible={ this.props.selecting || this.state.isSelecting }
 					onClose={ this.setImage }
 					site={ this.props.site }

--- a/client/post-editor/editor-media-modal/index.jsx
+++ b/client/post-editor/editor-media-modal/index.jsx
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { some, partial, map, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
+import MediaModal from 'post-editor/media-modal';
+import PostActions from 'lib/posts/actions';
+import { generateGalleryShortcode } from 'lib/media/utils';
+import markup from 'post-editor/media-modal/markup';
+import { bumpStat } from 'state/analytics/actions';
+import { getSelectedSite } from 'state/ui/selectors';
+
+class EditorMediaModal extends Component {
+	static propTypes = {
+		site: PropTypes.object,
+		onInsertMedia: PropTypes.func,
+		onClose: PropTypes.func
+	};
+
+	static defaultProps = {
+		onInsertMedia: () => {},
+		onClose: () => {}
+	};
+
+	insertMedia( { type, items, settings } ) {
+		const { site } = this.props;
+		let media, stat;
+
+		const getItemMarkup = partial( markup.get, site );
+
+		switch ( type ) {
+			case 'gallery':
+				if ( 'individual' === get( settings, 'type' ) ) {
+					media = map( settings.items, getItemMarkup ).join( '' );
+				} else {
+					media = generateGalleryShortcode( settings );
+				}
+
+				stat = 'insert_gallery';
+				break;
+
+			case 'media':
+			default:
+				media = map( items, getItemMarkup ).join( '' );
+				stat = 'insert_item';
+		}
+
+		if ( some( items, 'transient' ) ) {
+			PostActions.blockSave( 'MEDIA_MODAL_TRANSIENT_INSERT' );
+		}
+
+		if ( media ) {
+			this.props.onInsertMedia( media );
+
+			if ( stat ) {
+				this.props.bumpStat( 'editor_media_actions', stat );
+			}
+		}
+
+		this.props.onClose();
+	}
+
+	onClose = ( value ) => {
+		if ( value ) {
+			this.insertMedia( value );
+		} else {
+			this.props.onClose();
+		}
+	};
+
+	render() {
+		const { site } = this.props;
+
+		return (
+			<MediaLibrarySelectedData siteId={ get( site, 'ID' ) }>
+				<MediaModal
+					{ ...this.props }
+					onClose={ this.onClose } />
+			</MediaLibrarySelectedData>
+		);
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		site: getSelectedSite( state )
+	} ),
+	{ bumpStat }
+)( EditorMediaModal );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -20,7 +20,7 @@ var MediaLibrary = require( 'my-sites/media-library' ),
 	Dialog = require( 'components/dialog' ),
 	accept = require( 'lib/accept' );
 import { getMediaModalView } from 'state/ui/media-modal/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSite } from 'state/sites/selectors';
 import { resetMediaModalView } from 'state/ui/media-modal/actions';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
@@ -447,7 +447,7 @@ export default connect(
 		view: getMediaModalView( state ),
 		// [TODO]: Migrate toward dropping incoming site prop, accepting only
 		// siteId and forcing descendant components to access via state
-		site: site || getSelectedSite( state, siteId )
+		site: site || getSite( state, siteId )
 	} ),
 	{
 		setView: setEditorMediaModalView,

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -12,14 +12,12 @@ import { noop, head, some, findIndex, partial, values } from 'lodash';
  */
 var MediaLibrary = require( 'my-sites/media-library' ),
 	analytics = require( 'lib/analytics' ),
-	PostActions = require( 'lib/posts/actions' ),
 	PostStats = require( 'lib/posts/stats' ),
 	MediaModalSecondaryActions = require( './secondary-actions' ),
 	MediaModalGallery = require( './gallery' ),
 	MediaActions = require( 'lib/media/actions' ),
 	MediaUtils = require( 'lib/media/utils' ),
 	Dialog = require( 'components/dialog' ),
-	markup = require( './markup' ),
 	accept = require( 'lib/accept' );
 import { getMediaModalView } from 'state/ui/media-modal/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -34,7 +32,6 @@ export const EditorMediaModal = React.createClass( {
 		visible: React.PropTypes.bool,
 		mediaLibrarySelectedItems: React.PropTypes.arrayOf( React.PropTypes.object ),
 		onClose: React.PropTypes.func,
-		onInsertMedia: React.PropTypes.func,
 		site: React.PropTypes.object,
 		siteId: React.PropTypes.number,
 		labels: React.PropTypes.object,
@@ -55,7 +52,6 @@ export const EditorMediaModal = React.createClass( {
 			visible: false,
 			mediaLibrarySelectedItems: Object.freeze( [] ),
 			onClose: noop,
-			onInsertMedia: noop,
 			labels: Object.freeze( {} ),
 			setView: noop,
 			resetView: noop,
@@ -107,40 +103,18 @@ export const EditorMediaModal = React.createClass( {
 	},
 
 	confirmSelection: function() {
-		var selectedItems = this.props.mediaLibrarySelectedItems,
-			gallerySettings = this.state.gallerySettings,
-			media, stat;
-		const site = this.props.site;
+		const { view, mediaLibrarySelectedItems } = this.props;
 
-		if ( ! this.props.visible ) {
-			return;
+		let value;
+		if ( mediaLibrarySelectedItems.length ) {
+			value = {
+				type: ModalViews.GALLERY === view ? 'gallery' : 'media',
+				items: mediaLibrarySelectedItems,
+				settings: this.state.gallerySettings
+			};
 		}
 
-		if ( ModalViews.GALLERY === this.props.view ) {
-			if ( gallerySettings && 'individual' === gallerySettings.type ) {
-				media = gallerySettings.items.map( item => markup.get( site, item ) ).join( '' );
-			} else {
-				media = MediaUtils.generateGalleryShortcode( gallerySettings );
-			}
-			stat = 'insert_gallery';
-		} else {
-			media = selectedItems.map( item => markup.get( site, item ) ).join( '' );
-			stat = 'insert_item';
-		}
-
-		if ( some( selectedItems, 'transient' ) ) {
-			PostActions.blockSave( 'MEDIA_MODAL_TRANSIENT_INSERT' );
-		}
-
-		if ( media ) {
-			this.props.onInsertMedia( media );
-
-			if ( stat ) {
-				analytics.mc.bumpStat( 'editor_media_actions', stat );
-			}
-		}
-
-		this.props.onClose( selectedItems );
+		this.props.onClose( value );
 	},
 
 	setDetailSelectedIndex: function( index ) {


### PR DESCRIPTION
Related: #7333
Related: #9160

This pull request seeks to extract logic from the `post-editor/media-modal` component specific to editor markup generation to a separate `post-editor/editor-media-modal` component. This is part of a series of pull requests to migrate the core media modal to `blocks/media-modal`.

The included changes are intended to be used for the Site Icon feature to facilitate the `onClose` callback being passed with media objects (perhaps eventually media IDs) instead of a markup string. I observed after already having completed the implementation that the Featured Image component achieves this by using the array of `selectedItems` previously passed with `onClose`. The changes here are still desirable since there's no need to run the markup logic for featured images (and similarly Site Icon).

__Implementation notes:__

A few editor-specific stat bumps still exist after these changes, and will be migrated separately.

__Testing instructions:__

Verify that there are no regressions in usage of the editor media modal, particularly:

- Assigning a featured image
- Inserting a single media item
- Inserting multiple images as a gallery (with individual layout)
- Inserting multiple images as a gallery (with a layout other than individual)
- Editing an existing gallery