### PR TITLE
Themes: Use isActiveTheme selector instead of theme.active attr

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -31,13 +31,13 @@ const Theme = React.createClass( {
 			price: React.PropTypes.string,
 			// If true, the user has 'purchased' the theme
 			purchased: React.PropTypes.bool,
-			// If true, highlight this theme as active
-			active: React.PropTypes.bool,
 			author: React.PropTypes.string,
 			author_uri: React.PropTypes.string,
 			demo_uri: React.PropTypes.string,
 			stylesheet: React.PropTypes.string
 		} ),
+		// If true, highlight this theme as active
+		active: React.PropTypes.bool,
 		// If true, render a placeholder
 		isPlaceholder: React.PropTypes.bool,
 		// URL the screenshot link points to
@@ -62,9 +62,10 @@ const Theme = React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps ) {
-		// TODO: Once we're not using theme.active and theme.purchased anymore, just compare theme.id instead of entire theme objects.
+		// TODO: Once we're not using theme.purchased anymore, just compare theme.id instead of entire theme objects.
 		return ! isEqual( nextProps.theme, this.props.theme ) ||
 			! isEqual( nextProps.buttonContents, this.props.buttonContents ) ||
+			( nextProps.active !== this.props.active ) ||
 			( nextProps.screenshotClickUrl !== this.props.screenshotClickUrl ) ||
 			( nextProps.onScreenshotClick !== this.props.onScreenshotClick ) ||
 			( nextProps.onMoreButtonClick !== this.props.onMoreButtonClick );
@@ -75,7 +76,8 @@ const Theme = React.createClass( {
 			isPlaceholder: false,
 			buttonContents: {},
 			onMoreButtonClick: noop,
-			actionLabel: ''
+			actionLabel: '',
+			active: false
 		} );
 	},
 
@@ -108,11 +110,11 @@ const Theme = React.createClass( {
 	render() {
 		const {
 			name,
-			active,
 			price,
 			purchased,
 			screenshot
 		} = this.props.theme;
+		const { active } = this.props;
 		const themeClass = classNames( 'theme', {
 			'is-active': active,
 			'is-actionable': !! ( this.props.screenshotClickUrl || this.props.onScreenshotClick )
@@ -156,6 +158,7 @@ const Theme = React.createClass( {
 								<ThemeMoreButton
 									index={ this.props.index }
 									theme={ this.props.theme }
+									active={ this.props.active }
 									onClick={ this.props.onMoreButtonClick }
 									options={ this.props.buttonContents } />
 							</TrackInteractions> : null }

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -47,7 +47,7 @@ class ThemeMoreButton extends React.Component {
 	render() {
 		const classes = classNames(
 			'theme__more-button',
-			{ 'is-active': this.props.theme.active },
+			{ 'is-active': this.props.active },
 			{ 'is-open': this.state.showPopover }
 		);
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import times from 'lodash/times';
 import { localize } from 'i18n-calypso';
-import { identity, isEqual } from 'lodash';
+import { identity, isEqual, noop } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -35,6 +35,7 @@ export const ThemesList = React.createClass( {
 		onScreenshotClick: React.PropTypes.func.isRequired,
 		onMoreButtonClick: React.PropTypes.func,
 		getActionLabel: React.PropTypes.func,
+		isActive: React.PropTypes.func,
 		// i18n function provided by localize()
 		translate: React.PropTypes.func,
 		showThemeUpload: React.PropTypes.bool,
@@ -53,13 +54,10 @@ export const ThemesList = React.createClass( {
 			showThemeUpload: false,
 			themeUploadClickRecorder: identity,
 			onThemeUpload: identity,
-			fetchNextPage() {},
-			optionsGenerator() {
-				return [];
-			},
-			getActionLabel() {
-				return '';
-			}
+			fetchNextPage: noop,
+			optionsGenerator: () => [],
+			getActionLabel: () => '',
+			isActive: () => false
 		};
 	},
 
@@ -81,7 +79,8 @@ export const ThemesList = React.createClass( {
 			onMoreButtonClick={ this.props.onMoreButtonClick }
 			actionLabel={ this.props.getActionLabel( theme ) }
 			index={ index }
-			theme={ theme } />;
+			theme={ theme }
+			active={ this.props.isActive( theme.id ) } />;
 	},
 
 	renderLoadingPlaceholders() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -37,6 +37,7 @@ import QueryCurrentTheme from 'components/data/query-current-theme';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
 import { connectOptions } from 'my-sites/themes/theme-options';
+import { isActiveTheme } from 'state/themes/current-theme/selectors';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import ThemePreview from 'my-sites/themes/theme-preview';
@@ -62,10 +63,10 @@ const ThemeSheet = React.createClass( {
 		download: React.PropTypes.string,
 		taxonomies: React.PropTypes.object,
 		stylesheet: React.PropTypes.string,
-		active: React.PropTypes.bool,
 		purchased: React.PropTypes.bool,
 		// Connected props
 		isLoggedIn: React.PropTypes.bool,
+		isActive: React.PropTypes.bool,
 		selectedSite: React.PropTypes.object,
 		siteSlug: React.PropTypes.string,
 		backPath: React.PropTypes.string,
@@ -322,7 +323,7 @@ const ThemeSheet = React.createClass( {
 	},
 
 	getDefaultOptionLabel() {
-		const { defaultOption, active: isActive, isLoggedIn, price } = this.props;
+		const { defaultOption, isActive, isLoggedIn, price } = this.props;
 		if ( isLoggedIn && ! isActive ) {
 			if ( price ) { // purchase
 				return i18n.translate( 'Pick this design' );
@@ -333,9 +334,9 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderPreview() {
-		const { active, isLoggedIn, defaultOption, secondaryOption } = this.props;
+		const { isActive, isLoggedIn, defaultOption, secondaryOption } = this.props;
 
-		const showSecondaryButton = secondaryOption && ! active && isLoggedIn;
+		const showSecondaryButton = secondaryOption && ! isActive && isLoggedIn;
 		return (
 			<ThemePreview showPreview={ this.state.showPreview }
 				theme={ this.props }
@@ -376,7 +377,7 @@ const ThemeSheet = React.createClass( {
 
 	renderPrice() {
 		let price = this.props.price;
-		if ( ! this.isLoaded() || this.props.active ) {
+		if ( ! this.isLoaded() || this.props.isActive ) {
 			price = '';
 		} else if ( ! isPremium( this.props ) ) {
 			price = i18n.translate( 'Free' );
@@ -489,7 +490,7 @@ const ConnectedThemeSheet = connectOptions(
 );
 
 const ThemeSheetWithOptions = ( props ) => {
-	const { selectedSite: site, active: isActive, price, isLoggedIn } = props;
+	const { selectedSite: site, isActive, price, isLoggedIn } = props;
 
 	let defaultOption;
 
@@ -561,6 +562,7 @@ export default connect(
 			currentUserId,
 			isCurrentUserPaid,
 			isLoggedIn: !! currentUserId,
+			isActive: selectedSite && isActiveTheme( state, id, selectedSite.ID )
 		};
 	}
 )( ThemeSheetWithOptions );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -22,6 +22,7 @@ import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import { isActiveTheme } from 'state/themes/current-theme/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ThemeShowcase from './theme-showcase';
@@ -113,9 +114,6 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 			] }
 			defaultOption="activate"
 			secondaryOption="tryandcustomize"
-			getScreenshotOption={ function( theme ) {
-				return theme.active ? 'customize' : 'info';
-			} }
 			source="showcase" />
 	);
 };
@@ -126,7 +124,8 @@ export default connect(
 		return {
 			selectedSite,
 			isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
-			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' )
+			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' ),
+			getScreenshotOption: ( theme ) => ( selectedSite && isActiveTheme( state, theme.id, selectedSite.ID ) ) ? 'customize' : 'info'
 		};
 	}
 )( SingleSiteThemeShowcaseWithOptions );

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -16,6 +16,7 @@ import StickyPanel from 'components/sticky-panel';
 import analytics from 'lib/analytics';
 import buildUrl from 'lib/mixins/url-search/build-url';
 import { getSiteSlug } from 'state/sites/selectors';
+import { isActiveTheme } from 'state/themes/current-theme/selectors';
 import {
 	getFilter,
 	getSortedFilterTerms,
@@ -107,7 +108,7 @@ const ThemesSelection = React.createClass( {
 
 	onScreenshotClick( theme, resultsRank ) {
 		trackClick( 'theme', 'screenshot' );
-		if ( ! theme.active ) {
+		if ( ! this.props.isActiveTheme( theme.id ) ) {
 			this.recordSearchResultsClick( theme, resultsRank );
 		}
 		this.props.onScreenshotClick && this.props.onScreenshotClick( theme );
@@ -153,6 +154,7 @@ const ThemesSelection = React.createClass( {
 
 export default connect(
 	( state, { siteId } ) => ( {
-		siteSlug: getSiteSlug( state, siteId )
+		siteSlug: getSiteSlug( state, siteId ),
+		isActiveTheme: themeId => isActiveTheme( state, themeId, siteId )
 	} )
 )( ThemesSelection );

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -44,6 +44,9 @@ const ThemesSelection = React.createClass( {
 		tier: React.PropTypes.string,
 		filter: React.PropTypes.string,
 		vertical: React.PropTypes.string,
+		// connected props
+		siteSlug: React.PropTypes.string.isRequired,
+		isActiveTheme: React.PropTypes.func,
 	},
 
 	getDefaultProps() {
@@ -120,31 +123,32 @@ const ThemesSelection = React.createClass( {
 	},
 
 	render() {
-		const site = this.props.selectedSite;
+		const { selectedSite: site } = this.props;
 
 		return (
 			<div className="themes__selection">
 				<StickyPanel>
 					<ThemesSearchCard
-							site={ site }
-							onSearch={ this.doSearch }
-							search={ this.prependFilterKeys() + this.props.search }
-							tier={ this.props.tier }
-							select={ this.onTierSelect } />
+						site={ site }
+						onSearch={ this.doSearch }
+						search={ this.prependFilterKeys() + this.props.search }
+						tier={ this.props.tier }
+						select={ this.onTierSelect } />
 				</StickyPanel>
 				<ThemesData
-						site={ site }
-						isMultisite={ ! this.props.siteId } // Not the same as `! site` !
-						search={ this.props.search }
-						tier={ this.props.tier }
-						filter={ this.addVerticalToFilters() }
-						onRealScroll={ this.trackScrollPage }
-						onLastPage={ this.trackLastPage } >
+					site={ site }
+					isMultisite={ ! this.props.siteId } // Not the same as `! site` !
+					search={ this.props.search }
+					tier={ this.props.tier }
+					filter={ this.addVerticalToFilters() }
+					onRealScroll={ this.trackScrollPage }
+					onLastPage={ this.trackLastPage } >
 					<ThemesList getButtonOptions={ this.props.getOptions }
 						onMoreButtonClick={ this.onMoreButtonClick }
 						onScreenshotClick={ this.onScreenshotClick }
 						getScreenshotUrl={ this.props.getScreenshotUrl }
-						getActionLabel={ this.props.getActionLabel } />
+						getActionLabel={ this.props.getActionLabel }
+						isActive={ this.props.isActiveTheme } />
 				</ThemesData>
 			</div>
 		);


### PR DESCRIPTION
Rationale -- if a theme is active makes only sense in the context of a given site, and shouldn't be tied to a theme object (which rather contains general information, such as a theme's title, description, or screenshot URL). This is one prerequisite for us to only store one list of WPCOM themes and re-use for all WPCOM sites a user has.

To test:
* Verify that the theme showcase still works, specifically the following instances where code was changed:
* In single-site mode:
  * Verify that the currently active theme (as indicated by the "Current Theme" bar) is highlighted. 
  * Verify that the screenshot option for the active theme is 'Customize', and 'Info' for inactive themes.
  * Verify that theme activation moves that highlight to the newly activated theme.
* Theme Sheet -- verify that the call-to-action button reads "Pick this design" for an inactive theme, and "Customize" for an active one.
* Turn on debugging for analytics (`localStorage.setItem( 'debug', 'calypso:analytics*' )`). In single-site mode (or any other mode, for that matter), verify that clicking on any but the currently active theme triggers, among others, a `calypso_themeshowcase_theme_click` event. Verify that clicking on the currently active theme conversely doesn't.