### PR TITLE
Themes (single-site): Fix siteId/siteSlug mixup

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -43,18 +43,12 @@ function getProps( context ) {
 }
 
 export function singleSite( context, next ) {
-	const { site_id: siteId } = context.params;
-	const props = getProps( context );
-
-	props.key = siteId;
-	props.siteId = siteId;
-
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <SingleSiteComponent { ...props } />;
+	context.primary = <SingleSiteComponent { ...getProps( context ) } />;
 	next();
 }
 

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -88,7 +88,7 @@ const ThemesSingleSite = ( props ) => {
 	}
 
 	return (
-		<ThemeShowcase { ...props }>
+		<ThemeShowcase { ...props } siteId={ site && site.ID }>
 			<SidebarNavigation />
 			<ThanksModal
 				site={ site }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import page from 'page';
 import compact from 'lodash/compact';
 
@@ -14,6 +15,7 @@ import ThemesList from 'components/themes-list';
 import StickyPanel from 'components/sticky-panel';
 import analytics from 'lib/analytics';
 import buildUrl from 'lib/mixins/url-search/build-url';
+import { getSiteSlug } from 'state/sites/selectors';
 import {
 	getFilter,
 	getSortedFilterTerms,
@@ -31,7 +33,7 @@ const ThemesSelection = React.createClass( {
 			PropTypes.object,
 			PropTypes.bool
 		] ).isRequired,
-		siteId: PropTypes.string,
+		siteId: PropTypes.number,
 		search: PropTypes.string,
 		onScreenshotClick: PropTypes.func,
 		getOptions: React.PropTypes.func,
@@ -92,9 +94,9 @@ const ThemesSelection = React.createClass( {
 	},
 
 	updateUrl( tier, filter, searchString = this.props.search ) {
-		const { siteId, vertical } = this.props;
+		const { siteSlug, vertical } = this.props;
 
-		const siteIdSection = siteId ? `/${ siteId }` : '';
+		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = tier === 'all' ? '' : `/${ tier }`;
 		const filterSection = filter ? `/filter/${ filter }` : '';
@@ -149,4 +151,8 @@ const ThemesSelection = React.createClass( {
 
 } );
 
-export default ThemesSelection;
+export default connect(
+	( state, { siteId } ) => ( {
+		siteSlug: getSiteSlug( state, siteId )
+	} )
+)( ThemesSelection );


### PR DESCRIPTION
A siteId prop was extracted from a route param, which usually is a site slug. This might lead to confusion, e.g. when passing that prop on to a selector that expects an actual siteId and cannot handle a slug. Furthermore, that `sideId` variable wasn't validated (it's up to the `siteSelection` middleware to do that, and set the currently active site based on the result).

To test: 
* In the theme showcase, in single-site mode, type something into the search bar, and verify that the browser's address bar is correct (i.e. the site slug -- not a numeric ID -- shows, and your search string is appended as a query string).

cc @mcsf and @ehg for review -- another pesky bug and small fix