### PR TITLE
Remove ColdStart v3 A/B test for newly signed up users.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -15,16 +15,6 @@ module.exports = {
 		defaultVariation: 'disabled',
 		allowExistingUsers: true,
 	},
-	coldStartReader: {
-		datestamp: '20160901',
-		variations: {
-			noEmailColdStart: 33,
-			noEmailColdStartWithAutofollows: 33,
-			noChanges: 34
-		},
-		defaultVariation: 'noChanges',
-		allowExistingUsers: false,
-	},
 	domainSuggestionClickableRow: {
 		datestamp: '20160802',
 		variations: {

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -19,7 +19,6 @@ module.exports = function() {
 		page( '/',
 			controller.preloadReaderBundle,
 			controller.loadSubscriptions,
-			controller.checkForColdStart,
 			controller.initAbTests,
 			controller.updateLastRoute,
 			controller.sidebar,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -11,8 +11,6 @@ import StepWrapper from 'signup/step-wrapper';
 import SignupForm from 'components/signup-form';
 import signupUtils from 'signup/utils';
 import SignupActions from 'lib/signup/actions';
-import { abtest } from 'lib/abtest';
-import config from 'config';
 
 export default React.createClass( {
 
@@ -58,21 +56,6 @@ export default React.createClass( {
 
 		if ( this.props.queryObject && this.props.queryObject.jetpack_redirect ) {
 			queryArgs.jetpackRedirect = this.props.queryObject.jetpack_redirect;
-		}
-
-		if ( config.isEnabled( 'reader/start' ) ) {
-			// User is participating in Reader Cold Start
-			const coldStartVariant = abtest( 'coldStartReader' );
-
-			if ( coldStartVariant === 'noEmailColdStart' || coldStartVariant === 'noEmailColdStartWithAutofollows' ) {
-				userData.subscription_delivery_email_default = 'never';
-				userData.is_new_reader = true;
-			}
-
-			// Autofollows are on by default
-			if ( coldStartVariant === 'noEmailColdStart' ) {
-				userData.follow_default_blogs = false;
-			}
 		}
 
 		const formWithoutPassword = Object.assign( {}, form, {


### PR DESCRIPTION
Ending ColdStart v3 A/B test.

This PR removes the placement of newly signed up users into ColdStart test variations. We will need to remove other pieces of code specific to ColdStart later (such as `checkForColdStart()`).

Testing:
- Copy this branch to local machine, and run it (`make run`).
- Visit http://calypso.localhost:3000/, and log out
- Create a new account
- The new account should hit the Reader and not be in ColdStart (66% of the time! :P)
- You can use Tracks Live (internal tool) to make sure the newly created account does not trigger a `calypso_abtest_start` event with properties`name=coldStartReader_20160901`