### PR TITLE
Components: Add the ability to select a specific item in PopoverItem component

### DIFF
--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -59,7 +59,7 @@ use this property if you want to add a cuestom css class to this root element.
 
 #### `showDelay { number } - default: 0 (false)`
 
-Adds a delay before to show the popober. Its value is defined in `milliseconds`.
+Adds a delay before to show the popover. Its value is defined in `milliseconds`.
 
 #### `onClose { func }`
 
@@ -69,7 +69,7 @@ is called.
 
 #### `onShow { func } - optional`
 
-This function will be executed when the popober is shown.
+This function will be executed when the popover is shown.
 
 
 PopoverMenu
@@ -77,6 +77,38 @@ PopoverMenu
 
 `PopoverMenu` is a component based on `Popover` used to show a menu of actions in a popover.
 It is fully keyboard accessible.
+
+
+PopoverMenuItem
+===============
+
+`PopoverMenuItem` is a component used to represent a single item in a `PopoverMenu`.
+
+### Properties
+
+#### `href { string } - optional`
+
+If set, `PopoverMenuItem` will be rendered as a link; otherwise, it will be rendered as a button.
+
+#### `className { string } - optional`
+
+Sets a custom className on the button or link.
+
+#### `isSelected { bool } - default: false`
+
+Defines whether or not the `PopoverMenuItem` is the currently selected one.
+
+#### `icon { string } - optional`
+
+If set, a `Gridicon` is rendered, where its `icon` prop is set to this value.
+
+#### `focusOnHover { bool } - default: true`
+
+Defines whether or not the `PopoverMenuItem` should receive the focus when it is hovered over.
+
+#### `children { node } - optional`
+
+The children to render inside of the `PopoverMenuItem`.
 
 
 ### `Popover` Usage

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -30,7 +30,14 @@ export default class PopoverMenuItem extends Component {
 	}
 
 	render() {
-		const { className, href, selected, focusOnHover, icon, children } = this.props;
+		const {
+			children,
+			className,
+			focusOnHover,
+			href,
+			icon,
+			selected,
+		} = this.props;
 		const classes = classnames( 'popover__menu-item', className, {
 			'is-selected': selected
 		} );

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -14,12 +14,14 @@ export default class PopoverMenuItem extends Component {
 	static propTypes = {
 		href: PropTypes.string,
 		className: PropTypes.string,
+		selected: PropTypes.bool,
 		icon: PropTypes.string,
 		focusOnHover: PropTypes.bool,
 		children: PropTypes.node
 	};
 
 	static defaultProps = {
+		selected: false,
 		focusOnHover: true
 	};
 
@@ -28,8 +30,10 @@ export default class PopoverMenuItem extends Component {
 	}
 
 	render() {
-		const { className, href, focusOnHover, icon, children } = this.props;
-		const classes = classnames( 'popover__menu-item', className );
+		const { className, href, selected, focusOnHover, icon, children } = this.props;
+		const classes = classnames( 'popover__menu-item', className, {
+			'is-selected': selected
+		} );
 		const ItemComponent = href ? 'a' : 'button';
 
 		let hoverHandler;

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -53,7 +53,7 @@ export default class PopoverMenuItem extends Component {
 				role="menuitem"
 				onMouseOver={ hoverHandler }
 				tabIndex="-1"
-				{ ...omit( this.props, 'icon', 'focusOnHover' ) }
+				{ ...omit( this.props, 'icon', 'focusOnHover', 'isSelected' ) }
 				className={ classes }>
 				{ icon && <Gridicon icon={ icon } size={ 18 } /> }
 				{ children }

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -14,14 +14,14 @@ export default class PopoverMenuItem extends Component {
 	static propTypes = {
 		href: PropTypes.string,
 		className: PropTypes.string,
-		selected: PropTypes.bool,
+		isSelected: PropTypes.bool,
 		icon: PropTypes.string,
 		focusOnHover: PropTypes.bool,
 		children: PropTypes.node
 	};
 
 	static defaultProps = {
-		selected: false,
+		isSelected: false,
 		focusOnHover: true
 	};
 
@@ -36,10 +36,10 @@ export default class PopoverMenuItem extends Component {
 			focusOnHover,
 			href,
 			icon,
-			selected,
+			isSelected,
 		} = this.props;
 		const classes = classnames( 'popover__menu-item', className, {
-			'is-selected': selected
+			'is-selected': isSelected
 		} );
 		const ItemComponent = href ? 'a' : 'button';
 

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -107,7 +107,7 @@
 
 	// inner
 	&.is-top .popover__inner,
-	&.is-top-left .popover__inner, 
+	&.is-top-left .popover__inner,
 	&.is-top-right .popover__inner {
 		top: -10px #{"/*rtl:ignore*/"};
 	}
@@ -119,7 +119,7 @@
 	}
 
 	&.is-bottom .popover__inner,
-	&.is-bottom-left .popover__inner, 
+	&.is-bottom-left .popover__inner,
 	&.is-bottom-right .popover__inner {
 		top: 10px #{"/*rtl:ignore*/"};
 	}
@@ -166,6 +166,7 @@
 		color: $gray-dark;
 	}
 
+	&.is-selected,
 	&:hover,
 	&:focus {
 		background-color: $blue-medium;


### PR DESCRIPTION
Adds a new `isSelected` prop to indicate whether an item in `<PopoverMenu />` is the currently selected item. If set to `true`, the same styling is applied as when the item is hovered over or has the focus.

![popoveritem](https://cloud.githubusercontent.com/assets/1190420/20084344/abe5c91a-a52f-11e6-9092-49b77db94504.png)