### PR TITLE
.org Plans: Fix site slug in plan cancellation survey

### DIFF
--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -91,6 +91,14 @@ function urlToSlug( url ) {
 	return withoutHttp( url ).replace( /\//g, '::' );
 }
 
+function slugToUrl( slug ) {
+	if ( ! slug ) {
+		return null;
+	}
+
+	return slug.replace( /::/g, '/' );
+}
+
 export default {
 	isOutsideCalypso,
 	isExternal,
@@ -99,4 +107,5 @@ export default {
 	addSchemeIfMissing,
 	setUrlScheme,
 	urlToSlug,
+	slugToUrl,
 };

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -13,6 +13,7 @@ import {
 	addSchemeIfMissing,
 	setUrlScheme,
 	urlToSlug,
+	slugToUrl,
 } from '../';
 
 describe( 'withoutHttp', () => {
@@ -197,7 +198,7 @@ describe( 'urlToSlug()', () => {
 		expect( urlToSlug() ).to.be.null;
 	} );
 
-	it( 'should return empty string if URL is empty string', () => {
+	it( 'should return null if URL is empty string', () => {
 		const urlEmptyString = '';
 
 		expect( urlToSlug( urlEmptyString ) ).to.be.null;
@@ -235,5 +236,22 @@ describe( 'urlToSlug()', () => {
 		const urlWithoutHttp = urlToSlug( urlWithHttp );
 
 		expect( urlWithoutHttp ).to.equal( 'example.com::example::test123' );
+	} );
+} );
+
+describe( 'slugToUrl()', () => {
+	it( 'should return null if slug is not provided', () => {
+		expect( slugToUrl() ).to.be.null;
+	} );
+
+	it( 'should return null if slug is empty string', () => {
+		expect( slugToUrl( '' ) ).to.be.null;
+	} );
+
+	it( 'should return null convert double colons to forward slashes', () => {
+		const slug = 'example.com::example::test123';
+		const expected = 'example.com/example/test123';
+
+		expect( slugToUrl( slug ) ).to.equal( expected );
 	} );
 } );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -22,6 +22,7 @@ import purchasePaths from '../paths';
 import { removePurchase } from 'state/purchases/actions';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import userFactory from 'lib/user';
+import { slugToUrl } from 'lib/url';
 
 const user = userFactory();
 
@@ -130,7 +131,7 @@ const RemovePurchase = React.createClass( {
 				notices.success(
 					this.translate( '%(productName)s was removed from {{siteName/}}.', {
 						args: { productName },
-						components: { siteName: <em>{ selectedSite.slug }</em> }
+						components: { siteName: <em>{ slugToUrl( selectedSite.slug ) }</em> }
 					} ),
 					{ persistent: true }
 				);
@@ -287,7 +288,7 @@ const RemovePurchase = React.createClass( {
 							'Are you sure you want to remove %(productName)s from {{siteName/}}?',
 							{
 								args: { productName },
-								components: { siteName: <em>{ this.props.selectedSite.slug }</em> }
+								components: { siteName: <em>{ slugToUrl( this.props.selectedSite.slug ) }</em> }
 							}
 						)
 					}


### PR DESCRIPTION
This PR fixes #9200, where the site slug is not properly formatted and displays `::` instead of `/` when the Jetpack site is installed in a subdirectory. 

To test:

* Checkout this branch
* Purchase a plan for a Jetpack site which is installed in a subdirectory
* Go through the process of canceling the plan
* Verify the site slug is displayed with `/` and not with `::` in the "Are you sure you want to remove {PLAN} from {SLUG}" text in the removal step
* Verify the site slug is displayed with `/` and not with `::` in the "{PLAN} was removed from {SLUG}" text in the removal confirmation notice.
* Verify tests of the new `slugToUrl` method pass: ` npm run test-client client/lib/url/test/index.js -- --grep "slugToUrl"`

/cc @beaulebens @johnHackworth