### PR TITLE
Add the new account recovery settings state tree, `account-recovery/settings`

### DIFF
--- a/client/state/account-recovery/reducer.js
+++ b/client/state/account-recovery/reducer.js
@@ -11,61 +11,22 @@ import settings from './settings/reducer';
 
 import { createReducer } from 'state/utils';
 
-import {
-	ACCOUNT_RECOVERY_FETCH,
-	ACCOUNT_RECOVERY_FETCH_SUCCESS,
-	ACCOUNT_RECOVERY_FETCH_FAILED,
+import settings from './settings/reducer';
 
-	ACCOUNT_RECOVERY_PHONE_UPDATE,
-	ACCOUNT_RECOVERY_PHONE_UPDATE_SUCCESS,
-	ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED,
+import {
+	ACCOUNT_RECOVERY_SETTINGS_FETCH,
+	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
+	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 } from 'state/action-types';
 
-const createActionInProgressReducer = ( initiateActions, finishActions ) => {
-	const trueFunc = () => true;
-	const falseFunc = () => false;
-
-	const initiateHandlers = initiateActions.reduce(
-		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: trueFunc } ),
-		{}
-	);
-	const finishHandlers = finishActions.reduce(
-		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: falseFunc } ),
-		{}
-	);
-
-	return createReducer( false, {
-		...initiateHandlers,
-		...finishHandlers,
-	} );
-};
-
-const isFetching = createActionInProgressReducer(
-	[ ACCOUNT_RECOVERY_FETCH ],
-	[ ACCOUNT_RECOVERY_FETCH_SUCCESS, ACCOUNT_RECOVERY_FETCH_FAILED ]
-);
-
-const isUpdatingPhone = createActionInProgressReducer(
-	[ ACCOUNT_RECOVERY_PHONE_UPDATE ],
-	[ ACCOUNT_RECOVERY_PHONE_UPDATE_SUCCESS, ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED ]
-);
-
-const data = createReducer( {}, {
-	[ ACCOUNT_RECOVERY_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
-		...state,
-		email,
-		emailValidated: email_validated,
-		phone,
-		phoneValidated: phone_validated
-	} ),
-
-	[ ACCOUNT_RECOVERY_PHONE_UPDATE_SUCCESS ]: ( state, { phone } ) => ( {
-		...state,
-		phone,
-	} ),
+const isFetchingSettings = createReducer( false, {
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH ]: () => true,
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: () => false,
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: () => false,
 } );
 
 export default combineReducers( {
 	settings,
 	reset,
+	isFetchingSettings,
 } );

--- a/client/state/account-recovery/reducer.js
+++ b/client/state/account-recovery/reducer.js
@@ -11,8 +11,6 @@ import settings from './settings/reducer';
 
 import { createReducer } from 'state/utils';
 
-import settings from './settings/reducer';
-
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,

--- a/client/state/account-recovery/reducer.js
+++ b/client/state/account-recovery/reducer.js
@@ -9,6 +9,62 @@ import { combineReducers } from 'redux';
 import reset from './reset/reducer';
 import settings from './settings/reducer';
 
+import { createReducer } from 'state/utils';
+
+import {
+	ACCOUNT_RECOVERY_FETCH,
+	ACCOUNT_RECOVERY_FETCH_SUCCESS,
+	ACCOUNT_RECOVERY_FETCH_FAILED,
+
+	ACCOUNT_RECOVERY_PHONE_UPDATE,
+	ACCOUNT_RECOVERY_PHONE_UPDATE_SUCCESS,
+	ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED,
+} from 'state/action-types';
+
+const createActionInProgressReducer = ( initiateActions, finishActions ) => {
+	const trueFunc = () => true;
+	const falseFunc = () => false;
+
+	const initiateHandlers = initiateActions.reduce(
+		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: trueFunc } ),
+		{}
+	);
+	const finishHandlers = finishActions.reduce(
+		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: falseFunc } ),
+		{}
+	);
+
+	return createReducer( false, {
+		...initiateHandlers,
+		...finishHandlers,
+	} );
+};
+
+const isFetching = createActionInProgressReducer(
+	[ ACCOUNT_RECOVERY_FETCH ],
+	[ ACCOUNT_RECOVERY_FETCH_SUCCESS, ACCOUNT_RECOVERY_FETCH_FAILED ]
+);
+
+const isUpdatingPhone = createActionInProgressReducer(
+	[ ACCOUNT_RECOVERY_PHONE_UPDATE ],
+	[ ACCOUNT_RECOVERY_PHONE_UPDATE_SUCCESS, ACCOUNT_RECOVERY_PHONE_UPDATE_FAILED ]
+);
+
+const data = createReducer( {}, {
+	[ ACCOUNT_RECOVERY_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
+		...state,
+		email,
+		emailValidated: email_validated,
+		phone,
+		phoneValidated: phone_validated
+	} ),
+
+	[ ACCOUNT_RECOVERY_PHONE_UPDATE_SUCCESS ]: ( state, { phone } ) => ( {
+		...state,
+		phone,
+	} ),
+} );
+
 export default combineReducers( {
 	settings,
 	reset,

--- a/client/state/account-recovery/selectors.js
+++ b/client/state/account-recovery/selectors.js
@@ -1,3 +1,1 @@
 export const isFetchingAccountRecoverySettings = ( state ) => state.accountRecovery.isFetchingSettings;
-
-export const getAccountRecoverySettings = ( state ) => state.accountRecovery.settings;

--- a/client/state/account-recovery/selectors.js
+++ b/client/state/account-recovery/selectors.js
@@ -1,0 +1,3 @@
+export const isFetchingAccountRecoverySettings = ( state ) => state.accountRecovery.isFetchingSettings;
+
+export const getAccountRecoverySettings = ( state ) => state.accountRecovery.settings;

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -20,28 +20,28 @@ import {
 const TARGET_PHONE = 'phone';
 const TARGET_EMAIL = 'email';
 
-export const accountRecoveryFetchSuccess = ( settings ) => {
+export const accountRecoverySettingsFetchSuccess = ( settings ) => {
 	return {
 		type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 		settings,
 	};
 };
 
-export const accountRecoveryFetchFailed = ( error ) => {
+export const accountRecoverySettingsFetchFailed = ( error ) => {
 	return {
 		type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 		error,
 	};
 };
 
-export const accountRecoveryFetch = () => ( dispatch ) => {
+export const accountRecoverySettingsFetch = () => ( dispatch ) => {
 	dispatch( { type: ACCOUNT_RECOVERY_SETTINGS_FETCH } );
 
 	return wpcom.undocumented().me().getAccountRecovery()
 		.then( ( accountRecoverySettings ) =>
-			dispatch( accountRecoveryFetchSuccess( accountRecoverySettings ) )
+			dispatch( accountRecoverySettingsFetchSuccess( accountRecoverySettings ) )
 		).catch( ( { status, message } ) =>
-			dispatch( accountRecoveryFetchFailed( { status, message } ) )
+			dispatch( accountRecoverySettingsFetchFailed( { status, message } ) )
 		);
 };
 

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -20,10 +20,10 @@ import {
 const TARGET_PHONE = 'phone';
 const TARGET_EMAIL = 'email';
 
-export const accountRecoveryFetchSuccess = ( accountRecoverySettings ) => {
+export const accountRecoveryFetchSuccess = ( settings ) => {
 	return {
 		type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-		...accountRecoverySettings,
+		settings,
 	};
 };
 

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -79,7 +79,7 @@ export const updateAccountRecoveryPhone = ( countryCode, number ) => ( dispatch 
 	} );
 
 	return wpcom.undocumented().me().updateAccountRecoveryPhone( countryCode, number )
-		.then( ( phone ) =>
+		.then( ( { phone } ) =>
 			dispatch( updateAccountRecoveryPhoneSuccess( phone ) )
 		).catch( ( error ) =>
 			dispatch( updateAccountRecoveryPhoneFailed( error ) )

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -40,8 +40,8 @@ export const accountRecoverySettingsFetch = () => ( dispatch ) => {
 	return wpcom.undocumented().me().getAccountRecovery()
 		.then( ( accountRecoverySettings ) =>
 			dispatch( accountRecoverySettingsFetchSuccess( accountRecoverySettings ) )
-		).catch( ( { status, message } ) =>
-			dispatch( accountRecoverySettingsFetchFailed( { status, message } ) )
+		).catch( ( error ) =>
+			dispatch( accountRecoverySettingsFetchFailed( error ) )
 		);
 };
 
@@ -81,8 +81,8 @@ export const updateAccountRecoveryPhone = ( countryCode, number ) => ( dispatch 
 	return wpcom.undocumented().me().updateAccountRecoveryPhone( countryCode, number )
 		.then( ( phone ) =>
 			dispatch( updateAccountRecoveryPhoneSuccess( phone ) )
-		).catch( ( { status, message } ) =>
-			dispatch( updateAccountRecoveryPhoneFailed( { status, message } ) )
+		).catch( ( error ) =>
+			dispatch( updateAccountRecoveryPhoneFailed( error ) )
 		);
 };
 
@@ -99,8 +99,8 @@ export const deleteAccountRecoveryPhone = () => ( dispatch ) => {
 	return wpcom.undocumented().me().deleteAccountRecoveryPhone()
 		.then( () =>
 			dispatch( deleteAccountRecoveryPhoneSuccess() )
-		).catch( ( { status, message } ) =>
-			dispatch( deleteAccountRecoveryPhoneFailed( { status, message } ) )
+		).catch( ( error ) =>
+			dispatch( deleteAccountRecoveryPhoneFailed( error ) )
 		);
 };
 
@@ -117,8 +117,8 @@ export const updateAccountRecoveryEmail = ( newEmail ) => ( dispatch ) => {
 	return wpcom.undocumented().me().updateAccountRecoveryEmail( newEmail )
 		.then( ( { email } ) =>
 			dispatch( updateAccountRecoveryEmailSuccess( email ) )
-		).catch( ( { status, message } ) =>
-			dispatch( updateAccountRecoveryEmailFailed( { status, message } ) )
+		).catch( ( error ) =>
+			dispatch( updateAccountRecoveryEmailFailed( error ) )
 		);
 };
 
@@ -135,7 +135,7 @@ export const deleteAccountRecoveryEmail = () => ( dispatch ) => {
 	return wpcom.undocumented().me().deleteAccountRecoveryEmail()
 		.then( () =>
 			dispatch( deleteAccountRecoveryEmailSuccess() )
-		).catch( ( { status, message } ) =>
-			dispatch( deleteAccountRecoveryEmailFailed( { status, message } ) )
+		).catch( ( error ) =>
+			dispatch( deleteAccountRecoveryEmailFailed( error ) )
 		);
 };

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -56,6 +56,11 @@ const isDeletingPhone = createActionInProgressReducer(
 	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
 );
 
+const isUpdatingEmail = createActionInProgressReducer(
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
+);
+
 const data = createReducer( {}, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
 		...state,
@@ -69,6 +74,8 @@ const data = createReducer( {}, {
 		switch ( target ) {
 			case 'phone':
 				return { ...state, phone: data };
+			case 'email':
+				return { ...state, email: data };
 			default: // do nothing to unknown targets
 				return { ...state };
 		}
@@ -88,5 +95,6 @@ export default combineReducers( {
 	isFetching,
 	isUpdatingPhone,
 	isDeletingPhone,
+	isUpdatingEmail,
 	data,
 } );

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -12,6 +12,10 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
+
+	ACCOUNT_RECOVERY_SETTINGS_UPDATE,
+	ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
+	ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
 } from 'state/action-types';
 
 const createActionInProgressReducer = ( initiateActions, finishActions ) => {
@@ -38,6 +42,11 @@ const isFetching = createActionInProgressReducer(
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]
 );
 
+const isUpdatingPhone = createActionInProgressReducer(
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
+);
+
 const data = createReducer( {}, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
 		...state,
@@ -46,9 +55,19 @@ const data = createReducer( {}, {
 		phone,
 		phoneValidated: phone_validated
 	} ),
+
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target, data } ) => {
+		switch ( target ) {
+			case 'phone':
+				return { ...state, phone: data };
+			default: // do nothing to unknown fields
+				return { ...state };
+		}
+	},
 } );
 
 export default combineReducers( {
 	isFetching,
+	isUpdatingPhone,
 	data,
 } );

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -61,6 +61,11 @@ const isUpdatingEmail = createActionInProgressReducer(
 	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
 );
 
+const isDeletingEmail = createActionInProgressReducer(
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
+);
+
 const data = createReducer( {}, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
 		...state,
@@ -85,6 +90,8 @@ const data = createReducer( {}, {
 		switch ( target ) {
 			case 'phone':
 				return { ...state, phone: {} };
+			case 'email':
+				return { ...state, email: '' };
 			default: // do nothing to unknown targets
 				return { ...state };
 		}
@@ -96,5 +103,6 @@ export default combineReducers( {
 	isUpdatingPhone,
 	isDeletingPhone,
 	isUpdatingEmail,
+	isDeletingEmail,
 	data,
 } );

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -96,12 +96,12 @@ const data = createReducer( {}, {
 		phoneValidated: phone_validated
 	} ),
 
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target, data } ) => {
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target, value } ) => {
 		switch ( target ) {
 			case 'phone':
-				return { ...state, phone: data };
+				return { ...state, phone: value };
 			case 'email':
-				return { ...state, email: data };
+				return { ...state, email: value };
 			default: // do nothing to unknown targets
 				return { ...state };
 		}

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+
+/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
@@ -9,25 +14,41 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 } from 'state/action-types';
 
-const reducer = createReducer( {}, {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH ]: ( state ) => ( {
-		...state,
-		isFetching: true,
-	} ),
+const createActionInProgressReducer = ( initiateActions, finishActions ) => {
+	const trueFunc = () => true;
+	const falseFunc = () => false;
 
+	const initiateHandlers = initiateActions.reduce(
+		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: trueFunc } ),
+		{}
+	);
+	const finishHandlers = finishActions.reduce(
+		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: falseFunc } ),
+		{}
+	);
+
+	return createReducer( false, {
+		...initiateHandlers,
+		...finishHandlers,
+	} );
+};
+
+const isFetching = createActionInProgressReducer(
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH ],
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]
+);
+
+const data = createReducer( {}, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
 		...state,
 		email,
 		emailValidated: email_validated,
 		phone,
-		phoneValidated: phone_validated,
-		isFetching: false,
-	} ),
-
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: ( state ) => ( {
-		...state,
-		isFetching: false,
+		phoneValidated: phone_validated
 	} ),
 } );
 
-export default reducer;
+export default combineReducers( {
+	isFetching,
+	data,
+} );

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -16,6 +16,10 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE,
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
+
+	ACCOUNT_RECOVERY_SETTINGS_DELETE,
+	ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
+	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 } from 'state/action-types';
 
 const createActionInProgressReducer = ( initiateActions, finishActions ) => {
@@ -47,6 +51,11 @@ const isUpdatingPhone = createActionInProgressReducer(
 	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
 );
 
+const isDeletingPhone = createActionInProgressReducer(
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
+);
+
 const data = createReducer( {}, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
 		...state,
@@ -60,7 +69,16 @@ const data = createReducer( {}, {
 		switch ( target ) {
 			case 'phone':
 				return { ...state, phone: data };
-			default: // do nothing to unknown fields
+			default: // do nothing to unknown targets
+				return { ...state };
+		}
+	},
+
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) => {
+		switch ( target ) {
+			case 'phone':
+				return { ...state, phone: {} };
+			default: // do nothing to unknown targets
 				return { ...state };
 		}
 	},
@@ -69,5 +87,6 @@ const data = createReducer( {}, {
 export default combineReducers( {
 	isFetching,
 	isUpdatingPhone,
+	isDeletingPhone,
 	data,
 } );

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -22,16 +22,29 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 } from 'state/action-types';
 
-const createActionInProgressReducer = ( initiateActions, finishActions ) => {
-	const trueFunc = () => true;
-	const falseFunc = () => false;
+const createActionInProgressReducer = ( initiateActions, finishActions, actionTargetCheck = () => true ) => {
+	const initiateCallback = ( state, action ) => {
+		if ( actionTargetCheck( action ) ) {
+			return true;
+		}
+
+		return state;
+	};
+
+	const finishCallback = ( state, action ) => {
+		if ( actionTargetCheck( action ) ) {
+			return false;
+		}
+
+		return state;
+	};
 
 	const initiateHandlers = initiateActions.reduce(
-		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: trueFunc } ),
+		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: initiateCallback } ),
 		{}
 	);
 	const finishHandlers = finishActions.reduce(
-		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: falseFunc } ),
+		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: finishCallback } ),
 		{}
 	);
 
@@ -46,24 +59,32 @@ const isFetching = createActionInProgressReducer(
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]
 );
 
+const phoneActionTargetCheck = ( { target } ) => ( 'phone' === target );
+
 const isUpdatingPhone = createActionInProgressReducer(
 	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ],
+	phoneActionTargetCheck
 );
 
 const isDeletingPhone = createActionInProgressReducer(
 	[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ],
+	phoneActionTargetCheck
 );
+
+const emailActionTargetCheck = ( { target } ) => ( 'email' === target );
 
 const isUpdatingEmail = createActionInProgressReducer(
 	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ],
+	emailActionTargetCheck
 );
 
 const isDeletingEmail = createActionInProgressReducer(
 	[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ],
+	emailActionTargetCheck
 );
 
 const data = createReducer( {}, {

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -116,6 +116,10 @@ const emailValidated = createReducer( false, {
 		'email' === target ? false : state,
 } );
 
+const isReady = createReducer( false, {
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: () => true,
+} );
+
 export default combineReducers( {
 	data: combineReducers( {
 		phone,
@@ -125,4 +129,5 @@ export default combineReducers( {
 	} ),
 	isUpdating,
 	isDeleting,
+	isReady,
 } );

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -9,9 +9,7 @@ import { combineReducers } from 'redux';
 import { createReducer } from 'state/utils';
 
 import {
-	ACCOUNT_RECOVERY_SETTINGS_FETCH,
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE,
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
@@ -22,70 +20,35 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 } from 'state/action-types';
 
-const createActionInProgressReducer = ( initiateActions, finishActions, actionTargetCheck = () => true ) => {
-	const initiateCallback = ( state, action ) => {
-		if ( actionTargetCheck( action ) ) {
-			return true;
-		}
+const isUpdating = createReducer( {}, {
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ]: ( state, { target } ) => ( {
+		...state,
+		[ target ]: true,
+	} ),
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target } ) => ( {
+		...state,
+		[ target ]: false,
+	} ),
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]: ( state, { target } ) => ( {
+		...state,
+		[ target ]: false,
+	} ),
+} );
 
-		return state;
-	};
-
-	const finishCallback = ( state, action ) => {
-		if ( actionTargetCheck( action ) ) {
-			return false;
-		}
-
-		return state;
-	};
-
-	const initiateHandlers = initiateActions.reduce(
-		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: initiateCallback } ),
-		{}
-	);
-	const finishHandlers = finishActions.reduce(
-		( accumulator, actionType ) => ( { ...accumulator, [ actionType ]: finishCallback } ),
-		{}
-	);
-
-	return createReducer( false, {
-		...initiateHandlers,
-		...finishHandlers,
-	} );
-};
-
-const isFetching = createActionInProgressReducer(
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH ],
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]
-);
-
-const phoneActionTargetCheck = ( { target } ) => ( 'phone' === target );
-
-const isUpdatingPhone = createActionInProgressReducer(
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ],
-	phoneActionTargetCheck
-);
-
-const isDeletingPhone = createActionInProgressReducer(
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ],
-	phoneActionTargetCheck
-);
-
-const emailActionTargetCheck = ( { target } ) => ( 'email' === target );
-
-const isUpdatingEmail = createActionInProgressReducer(
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ],
-	emailActionTargetCheck
-);
-
-const isDeletingEmail = createActionInProgressReducer(
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ],
-	emailActionTargetCheck
-);
+const isDeleting = createReducer( {}, {
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE ]: ( state, { target } ) => ( {
+		...state,
+		[ target ]: true,
+	} ),
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) => ( {
+		...state,
+		[ target ]: false,
+	} ),
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]: ( state, { target } ) => ( {
+		...state,
+		[ target ]: false,
+	} ),
+} );
 
 const data = createReducer( {}, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
@@ -120,10 +83,7 @@ const data = createReducer( {}, {
 } );
 
 export default combineReducers( {
-	isFetching,
-	isUpdatingPhone,
-	isDeletingPhone,
-	isUpdatingEmail,
-	isDeletingEmail,
 	data,
+	isUpdating,
+	isDeleting,
 } );

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -70,68 +70,59 @@ const convertPhoneResponse = ( phoneResponse ) => {
 	};
 };
 
-const convertEmailResponse = ( emailResponse ) => {
-	return emailResponse ? emailResponse : '';
-};
+const convertEmailResponse = ( emailResponse ) => emailResponse || '';
 
-const data = createReducer( null, {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) => {
-		const {
-			email,
-			email_validated,
-			phone,
-			phone_validated,
-		} = settings;
+const phone = createReducer( null, {
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) =>
+		convertPhoneResponse( settings.phone ),
 
-		// At the moment, the response from /me/account-recovery could have an object or false for the phone field,
-		// and an string or false for the email field. I personally don't like the mixed value so did the conversion
-		// in the following.
-		return {
-			...state,
-			email: convertEmailResponse( email ),
-			emailValidated: email_validated,
-			phone: convertPhoneResponse( phone ),
-			phoneValidated: phone_validated,
-		};
-	},
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target, value } ) =>
+		'phone' === target ? convertPhoneResponse( value ) : state,
 
-	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target, value } ) => {
-		switch ( target ) {
-			case 'phone':
-				return {
-					...state,
-					phone: convertPhoneResponse( value ),
-				};
-			case 'email':
-				return {
-					...state,
-					email: convertEmailResponse( value ),
-				};
-			default: // do nothing to unknown targets
-				return { ...state };
-		}
-	},
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) =>
+		'phone' === target ? null : state,
+} );
 
-	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) => {
-		switch ( target ) {
-			case 'phone':
-				return {
-					...state,
-					phone: null,
-				};
-			case 'email':
-				return {
-					...state,
-					email: '',
-				};
-			default: // do nothing to unknown targets
-				return { ...state };
-		}
-	},
+const email = createReducer( '', {
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) =>
+		convertEmailResponse( settings.email ),
+
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target, value } ) =>
+		'email' === target ? convertEmailResponse( value ) : state,
+
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) =>
+		'email' === target ? '' : state,
+} );
+
+const phoneValidated = createReducer( false, {
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) =>
+		settings.phone_validated,
+
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target } ) =>
+		'phone' === target ? false : state,
+
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) =>
+		'phone' === target ? false : state,
+} );
+
+const emailValidated = createReducer( false, {
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) =>
+		settings.email_validated,
+
+	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target } ) =>
+		'email' === target ? false : state,
+
+	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) =>
+		'email' === target ? false : state,
 } );
 
 export default combineReducers( {
-	data,
+	data: combineReducers( {
+		phone,
+		phoneValidated,
+		email,
+		emailValidated,
+	} ),
 	isUpdating,
 	isDeleting,
 } );

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -50,7 +50,7 @@ const isDeleting = createReducer( {}, {
 	} ),
 } );
 
-const data = createReducer( {}, {
+const data = createReducer( null, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
 		...state,
 		email,

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -50,20 +50,28 @@ const isDeleting = createReducer( {}, {
 	} ),
 } );
 
-const convertPhoneProperties = ( rawPhone ) => {
+const convertPhoneResponse = ( phoneResponse ) => {
+	if ( ! phoneResponse ) {
+		return null;
+	}
+
 	const {
 		country_code,
 		country_numeric_code,
 		number,
 		number_full,
-	} = rawPhone;
+	} = phoneResponse;
 
 	return {
-		phoneCountryCode: country_code,
-		phoneCountryNumericCode: country_numeric_code,
-		phoneNumber: number,
-		phoneNumberFull: number_full,
+		countryCode: country_code,
+		countryNumericCode: country_numeric_code,
+		number: number,
+		numberFull: number_full,
 	};
+};
+
+const convertEmailResponse = ( emailResponse ) => {
+	return emailResponse ? emailResponse : '';
 };
 
 const data = createReducer( null, {
@@ -75,12 +83,15 @@ const data = createReducer( null, {
 			phone_validated,
 		} = settings;
 
+		// At the moment, the response from /me/account-recovery could have an object or false for the phone field,
+		// and an string or false for the email field. I personally don't like the mixed value so did the conversion
+		// in the following.
 		return {
 			...state,
-			email,
+			email: convertEmailResponse( email ),
 			emailValidated: email_validated,
-			...convertPhoneProperties( phone ),
-			phoneValidated: phone_validated
+			phone: convertPhoneResponse( phone ),
+			phoneValidated: phone_validated,
 		};
 	},
 
@@ -89,12 +100,12 @@ const data = createReducer( null, {
 			case 'phone':
 				return {
 					...state,
-					...convertPhoneProperties( value ),
+					phone: convertPhoneResponse( value ),
 				};
 			case 'email':
 				return {
 					...state,
-					email: value,
+					email: convertEmailResponse( value ),
 				};
 			default: // do nothing to unknown targets
 				return { ...state };
@@ -106,10 +117,7 @@ const data = createReducer( null, {
 			case 'phone':
 				return {
 					...state,
-					phoneCountryCode: '',
-					phoneCountryNumericCode: '',
-					phoneNumber: '',
-					phoneNumberFull: '',
+					phone: null,
 				};
 			case 'email':
 				return {

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -50,21 +50,52 @@ const isDeleting = createReducer( {}, {
 	} ),
 } );
 
+const convertPhoneProperties = ( rawPhone ) => {
+	const {
+		country_code,
+		country_numeric_code,
+		number,
+		number_full,
+	} = rawPhone;
+
+	return {
+		phoneCountryCode: country_code,
+		phoneCountryNumericCode: country_numeric_code,
+		phoneNumber: number,
+		phoneNumberFull: number_full,
+	};
+};
+
 const data = createReducer( null, {
-	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { email, email_validated, phone, phone_validated } ) => ( {
-		...state,
-		email,
-		emailValidated: email_validated,
-		phone,
-		phoneValidated: phone_validated
-	} ),
+	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: ( state, { settings } ) => {
+		const {
+			email,
+			email_validated,
+			phone,
+			phone_validated,
+		} = settings;
+
+		return {
+			...state,
+			email,
+			emailValidated: email_validated,
+			...convertPhoneProperties( phone ),
+			phoneValidated: phone_validated
+		};
+	},
 
 	[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS ]: ( state, { target, value } ) => {
 		switch ( target ) {
 			case 'phone':
-				return { ...state, phone: value };
+				return {
+					...state,
+					...convertPhoneProperties( value ),
+				};
 			case 'email':
-				return { ...state, email: value };
+				return {
+					...state,
+					email: value,
+				};
 			default: // do nothing to unknown targets
 				return { ...state };
 		}
@@ -73,9 +104,18 @@ const data = createReducer( null, {
 	[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS ]: ( state, { target } ) => {
 		switch ( target ) {
 			case 'phone':
-				return { ...state, phone: {} };
+				return {
+					...state,
+					phoneCountryCode: '',
+					phoneCountryNumericCode: '',
+					phoneNumber: '',
+					phoneNumberFull: '',
+				};
 			case 'email':
-				return { ...state, email: '' };
+				return {
+					...state,
+					email: '',
+				};
 			default: // do nothing to unknown targets
 				return { ...state };
 		}

--- a/client/state/account-recovery/settings/selectors.js
+++ b/client/state/account-recovery/settings/selectors.js
@@ -1,5 +1,5 @@
-const isSettingsDataExist = ( state ) => {
-	return null == state.accountRecovery.settings.data;
+export const isAccountRecoverySettingsReady = ( state ) => {
+	return null != state.accountRecovery.settings.data;
 };
 
 const getSettingsData = ( state ) => {
@@ -7,31 +7,31 @@ const getSettingsData = ( state ) => {
 };
 
 export const isAccountRecoveryPhoneValidated = ( state ) => {
-	return isSettingsDataExist( state ) ? false : getSettingsData( state ).phoneValidated;
+	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneValidated : false;
 };
 
 export const isAccountRecoveryEmailValidated = ( state ) => {
-	return isSettingsDataExist( state ) ? false : getSettingsData( state ).emailValidated;
+	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).emailValidated : false;
 };
 
 export const getAccountRecoveryEmail = ( state ) => {
-	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).email;
+	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).email : '';
 };
 
 export const getAccountRecoveryPhoneCountryCode = ( state ) => {
-	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).phoneCountryCode;
+	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneCountryCode : '';
 };
 
 export const getAccountRecoveryPhoneCountryNumericCode = ( state ) => {
-	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).phoneCountryNumericCode;
+	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneCountryNumericCode : '';
 };
 
 export const getAccountRecoveryPhoneNumber = ( state ) => {
-	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).phoneNumber;
+	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneNumber : '';
 };
 
 export const getAccountRecoveryPhoneNumberFull = ( state ) => {
-	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).phoneNumberFull;
+	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneNumberFull : '';
 };
 
 export const isUpdatingAccountRecoveryPhone = ( state ) => {

--- a/client/state/account-recovery/settings/selectors.js
+++ b/client/state/account-recovery/settings/selectors.js
@@ -18,20 +18,8 @@ export const getAccountRecoveryEmail = ( state ) => {
 	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).email : '';
 };
 
-export const getAccountRecoveryPhoneCountryCode = ( state ) => {
-	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneCountryCode : '';
-};
-
-export const getAccountRecoveryPhoneCountryNumericCode = ( state ) => {
-	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneCountryNumericCode : '';
-};
-
-export const getAccountRecoveryPhoneNumber = ( state ) => {
-	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneNumber : '';
-};
-
-export const getAccountRecoveryPhoneNumberFull = ( state ) => {
-	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneNumberFull : '';
+export const getAccountRecoveryPhone = ( state ) => {
+	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phone : null;
 };
 
 export const isUpdatingAccountRecoveryPhone = ( state ) => {

--- a/client/state/account-recovery/settings/selectors.js
+++ b/client/state/account-recovery/settings/selectors.js
@@ -33,3 +33,19 @@ export const getAccountRecoveryPhoneNumber = ( state ) => {
 export const getAccountRecoveryPhoneNumberFull = ( state ) => {
 	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).phoneNumberFull;
 };
+
+export const isUpdatingAccountRecoveryPhone = ( state ) => {
+	return !! state.accountRecovery.settings.isUpdating.phone;
+};
+
+export const isUpdatingAccountRecoveryEmail = ( state ) => {
+	return !! state.accountRecovery.settings.isUpdating.email;
+};
+
+export const isDeletingAccountRecoveryPhone = ( state ) => {
+	return !! state.accountRecovery.settings.isDeleting.phone;
+};
+
+export const isDeletingAccountRecoveryEmail = ( state ) => {
+	return !! state.accountRecovery.settings.isDeleting.email;
+};

--- a/client/state/account-recovery/settings/selectors.js
+++ b/client/state/account-recovery/settings/selectors.js
@@ -1,5 +1,5 @@
-const isSettingsExist = ( state ) => {
-	return null == state.accountRecovery.settings;
+const isSettingsDataExist = ( state ) => {
+	return null == state.accountRecovery.settings.data;
 };
 
 const getSettingsData = ( state ) => {
@@ -7,29 +7,29 @@ const getSettingsData = ( state ) => {
 };
 
 export const isAccountRecoveryPhoneValidated = ( state ) => {
-	return isSettingsExist( state ) ? false : getSettingsData( state ).phoneValidated;
+	return isSettingsDataExist( state ) ? false : getSettingsData( state ).phoneValidated;
 };
 
 export const isAccountRecoveryEmailValidated = ( state ) => {
-	return isSettingsExist( state ) ? false : getSettingsData( state ).emailValidated;
+	return isSettingsDataExist( state ) ? false : getSettingsData( state ).emailValidated;
 };
 
 export const getAccountRecoveryEmail = ( state ) => {
-	return isSettingsExist( state ) ? '' : getSettingsData( state ).email;
+	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).email;
 };
 
 export const getAccountRecoveryPhoneCountryCode = ( state ) => {
-	return isSettingsExist( state ) ? '' : getSettingsData( state ).phoneCountryCode;
+	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).phoneCountryCode;
 };
 
 export const getAccountRecoveryPhoneCountryNumericCode = ( state ) => {
-	return isSettingsExist( state ) ? '' : getSettingsData( state ).phoneCountryNumericCode;
+	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).phoneCountryNumericCode;
 };
 
 export const getAccountRecoveryPhoneNumber = ( state ) => {
-	return isSettingsExist( state ) ? '' : getSettingsData( state ).phoneNumber;
+	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).phoneNumber;
 };
 
 export const getAccountRecoveryPhoneNumberFull = ( state ) => {
-	return isSettingsExist( state ) ? '' : getSettingsData( state ).phoneNumberFull;
+	return isSettingsDataExist( state ) ? '' : getSettingsData( state ).phoneNumberFull;
 };

--- a/client/state/account-recovery/settings/selectors.js
+++ b/client/state/account-recovery/settings/selectors.js
@@ -1,9 +1,9 @@
-export const isAccountRecoverySettingsReady = ( state ) => {
-	return null != state.accountRecovery.settings.data;
-};
-
 const getSettingsData = ( state ) => {
 	return state.accountRecovery.settings.data;
+};
+
+export const isAccountRecoverySettingsReady = ( state ) => {
+	return null != getSettingsData( state );
 };
 
 export const isAccountRecoveryPhoneValidated = ( state ) => {

--- a/client/state/account-recovery/settings/selectors.js
+++ b/client/state/account-recovery/settings/selectors.js
@@ -1,25 +1,21 @@
-const getSettingsData = ( state ) => {
-	return state.accountRecovery.settings.data;
-};
-
 export const isAccountRecoverySettingsReady = ( state ) => {
-	return null != getSettingsData( state );
+	return state.accountRecovery.settings.isReady;
 };
 
 export const isAccountRecoveryPhoneValidated = ( state ) => {
-	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phoneValidated : false;
+	return state.accountRecovery.settings.data.phoneValidated;
 };
 
 export const isAccountRecoveryEmailValidated = ( state ) => {
-	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).emailValidated : false;
+	return state.accountRecovery.settings.data.emailValidated;
 };
 
 export const getAccountRecoveryEmail = ( state ) => {
-	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).email : '';
+	return state.accountRecovery.settings.data.email;
 };
 
 export const getAccountRecoveryPhone = ( state ) => {
-	return isAccountRecoverySettingsReady( state ) ? getSettingsData( state ).phone : null;
+	return state.accountRecovery.settings.data.phone;
 };
 
 export const isUpdatingAccountRecoveryPhone = ( state ) => {

--- a/client/state/account-recovery/settings/selectors.js
+++ b/client/state/account-recovery/settings/selectors.js
@@ -1,0 +1,35 @@
+const isSettingsExist = ( state ) => {
+	return null == state.accountRecovery.settings;
+};
+
+const getSettingsData = ( state ) => {
+	return state.accountRecovery.settings.data;
+};
+
+export const isAccountRecoveryPhoneValidated = ( state ) => {
+	return isSettingsExist( state ) ? false : getSettingsData( state ).phoneValidated;
+};
+
+export const isAccountRecoveryEmailValidated = ( state ) => {
+	return isSettingsExist( state ) ? false : getSettingsData( state ).emailValidated;
+};
+
+export const getAccountRecoveryEmail = ( state ) => {
+	return isSettingsExist( state ) ? '' : getSettingsData( state ).email;
+};
+
+export const getAccountRecoveryPhoneCountryCode = ( state ) => {
+	return isSettingsExist( state ) ? '' : getSettingsData( state ).phoneCountryCode;
+};
+
+export const getAccountRecoveryPhoneCountryNumericCode = ( state ) => {
+	return isSettingsExist( state ) ? '' : getSettingsData( state ).phoneCountryNumericCode;
+};
+
+export const getAccountRecoveryPhoneNumber = ( state ) => {
+	return isSettingsExist( state ) ? '' : getSettingsData( state ).phoneNumber;
+};
+
+export const getAccountRecoveryPhoneNumberFull = ( state ) => {
+	return isSettingsExist( state ) ? '' : getSettingsData( state ).phoneNumberFull;
+};

--- a/client/state/account-recovery/settings/test/actions.js
+++ b/client/state/account-recovery/settings/test/actions.js
@@ -44,7 +44,7 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 } from 'state/action-types';
 
-import dummyData from './test-data';
+import { dummyData, dummyNewPhone, dummyNewEmail } from './test-data';
 import { generateSuccessAndFailedTestsForThunk } from './utils';
 
 describe( 'account-recovery actions', () => {
@@ -98,22 +98,15 @@ describe( 'account-recovery actions', () => {
 		} );
 	} );
 
-	const newPhoneData = {
-		country_code: 'US',
-		country_numeric_code: '+1',
-		number: '8881234567',
-		number_full: '+18881234567',
-	};
-
 	generateSuccessAndFailedTestsForThunk( {
 		testBaseName: '#updateAccountRecoveryPhone',
 		nockSettings: {
 			method: 'post',
 			endpoint: '/rest/v1.1/me/account-recovery/phone',
-			successResponse: newPhoneData,
+			successResponse: dummyNewPhone,
 			errorResponse: errorResponse,
 		},
-		thunk: () => updateAccountRecoveryPhone( newPhoneData.country_code, newPhoneData.number )( spy ),
+		thunk: () => updateAccountRecoveryPhone( dummyNewPhone.country_code, dummyNewPhone.number )( spy ),
 		preCondition: () =>
 			assert( spy.calledWith( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
@@ -123,7 +116,7 @@ describe( 'account-recovery actions', () => {
 			assert( spy.calledWith( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 				target: 'phone',
-				value: newPhoneData,
+				data: dummyNewPhone,
 			} ) ),
 		postConditionFailed: () =>
 			assert( spy.calledWith( {
@@ -208,17 +201,15 @@ describe( 'account-recovery actions', () => {
 		} );
 	} );
 
-	const newEmail = 'newtest@example.com';
-
 	generateSuccessAndFailedTestsForThunk( {
 		testBaseName: '#updateAccountRecoveryEmail',
 		nockSettings: {
 			method: 'post',
 			endpoint: '/rest/v1.1/me/account-recovery/email',
-			successResponse: { email: newEmail },
+			successResponse: { email: dummyNewEmail },
 			errorResponse: errorResponse,
 		},
-		thunk: () => updateAccountRecoveryEmail( newEmail )( spy ),
+		thunk: () => updateAccountRecoveryEmail( dummyNewEmail )( spy ),
 		preCondition: () =>
 			assert( spy.calledWith( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
@@ -228,7 +219,7 @@ describe( 'account-recovery actions', () => {
 			assert( spy.calledWith( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 				target: 'email',
-				value: newEmail,
+				data: dummyNewEmail,
 			} ) );
 		},
 		postConditionFailed: () => {

--- a/client/state/account-recovery/settings/test/actions.js
+++ b/client/state/account-recovery/settings/test/actions.js
@@ -116,7 +116,7 @@ describe( 'account-recovery actions', () => {
 			assert( spy.calledWith( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 				target: 'phone',
-				data: dummyNewPhone,
+				value: dummyNewPhone,
 			} ) ),
 		postConditionFailed: () =>
 			assert( spy.calledWith( {
@@ -219,7 +219,7 @@ describe( 'account-recovery actions', () => {
 			assert( spy.calledWith( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 				target: 'email',
-				data: dummyNewEmail,
+				value: dummyNewEmail,
 			} ) );
 		},
 		postConditionFailed: () => {

--- a/client/state/account-recovery/settings/test/actions.js
+++ b/client/state/account-recovery/settings/test/actions.js
@@ -104,7 +104,7 @@ describe( 'account-recovery actions', () => {
 		nockSettings: {
 			method: 'post',
 			endpoint: '/rest/v1.1/me/account-recovery/phone',
-			successResponse: dummyNewPhone,
+			successResponse: { phone: dummyNewPhone },
 			errorResponse: errorResponse,
 		},
 		thunk: () => updateAccountRecoveryPhone( dummyNewPhone.country_code, dummyNewPhone.number )( spy ),

--- a/client/state/account-recovery/settings/test/actions.js
+++ b/client/state/account-recovery/settings/test/actions.js
@@ -66,7 +66,7 @@ describe( 'account-recovery actions', () => {
 		postConditionSuccess: () => {
 			assert( spy.calledWith( {
 				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-				...dummyData,
+				settings: dummyData,
 			} ) );
 		},
 		postConditionFailed: () => {
@@ -82,7 +82,7 @@ describe( 'account-recovery actions', () => {
 			const action = accountRecoveryFetchSuccess( dummyData );
 			assert.deepEqual( action, {
 				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-				...dummyData,
+				settings: dummyData,
 			} );
 		} );
 	} );

--- a/client/state/account-recovery/settings/test/actions.js
+++ b/client/state/account-recovery/settings/test/actions.js
@@ -9,9 +9,9 @@ import { assert } from 'chai';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 import {
-	accountRecoveryFetch,
-	accountRecoveryFetchSuccess,
-	accountRecoveryFetchFailed,
+	accountRecoverySettingsFetch,
+	accountRecoverySettingsFetchSuccess,
+	accountRecoverySettingsFetchFailed,
 
 	updateAccountRecoveryPhone,
 	updateAccountRecoveryPhoneSuccess,
@@ -54,14 +54,14 @@ describe( 'account-recovery actions', () => {
 	const errorResponse = { status: 400, message: 'Something wrong!' };
 
 	generateSuccessAndFailedTestsForThunk( {
-		testBaseName: '#accountRecoveryFetch',
+		testBaseName: '#accountRecoverySettingsFetch',
 		nockSettings: {
 			method: 'get',
 			endpoint: '/rest/v1.1/me/account-recovery',
 			successResponse: dummyData,
 			errorResponse: errorResponse,
 		},
-		thunk: () => accountRecoveryFetch()( spy ),
+		thunk: () => accountRecoverySettingsFetch()( spy ),
 		preCondition: () => assert( spy.calledWith( { type: ACCOUNT_RECOVERY_SETTINGS_FETCH } ) ),
 		postConditionSuccess: () => {
 			assert( spy.calledWith( {
@@ -77,9 +77,9 @@ describe( 'account-recovery actions', () => {
 		},
 	} );
 
-	describe( '#accountRecoveryFetchSuccess()', () => {
+	describe( '#accountRecoverySettingsFetchSuccess()', () => {
 		it( 'should return ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS', () => {
-			const action = accountRecoveryFetchSuccess( dummyData );
+			const action = accountRecoverySettingsFetchSuccess( dummyData );
 			assert.deepEqual( action, {
 				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 				settings: dummyData,
@@ -87,9 +87,9 @@ describe( 'account-recovery actions', () => {
 		} );
 	} );
 
-	describe( '#accountRecoveryFetchFailed()', () => {
+	describe( '#accountRecoverySettingsFetchFailed()', () => {
 		it( 'should return ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED', () => {
-			const action = accountRecoveryFetchFailed( errorResponse );
+			const action = accountRecoverySettingsFetchFailed( errorResponse );
 
 			assert.deepEqual( action, {
 				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,

--- a/client/state/account-recovery/settings/test/actions.js
+++ b/client/state/account-recovery/settings/test/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { assert } from 'chai';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -70,10 +71,10 @@ describe( 'account-recovery actions', () => {
 			} ) );
 		},
 		postConditionFailed: () => {
-			assert( spy.calledWith( {
+			assert( spy.calledWith( sinon.match( {
 				type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 				error: errorResponse,
-			} ) );
+			} ) ) );
 		},
 	} );
 
@@ -119,11 +120,11 @@ describe( 'account-recovery actions', () => {
 				value: dummyNewPhone,
 			} ) ),
 		postConditionFailed: () =>
-			assert( spy.calledWith( {
+			assert( spy.calledWith( sinon.match( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
 				target: 'phone',
 				error: errorResponse,
-			} ) ),
+			} ) ) ),
 	} );
 
 	describe( '#updateAccountRecoveryPhoneSuccess', () => {
@@ -171,11 +172,11 @@ describe( 'account-recovery actions', () => {
 				target: 'phone',
 			} ) ),
 		postConditionFailed: () =>
-			assert( spy.calledWith( {
+			assert( spy.calledWith( sinon.match( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 				target: 'phone',
 				error: errorResponse,
-			} ) ),
+			} ) ) ),
 	} );
 
 	describe( '#deleteAccountRecoveryPhoneSuccess', () => {
@@ -223,11 +224,11 @@ describe( 'account-recovery actions', () => {
 			} ) );
 		},
 		postConditionFailed: () => {
-			assert( spy.calledWith( {
+			assert( spy.calledWith( sinon.match( {
 				type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
 				target: 'email',
 				error: errorResponse,
-			} ) );
+			} ) ) );
 		},
 	} );
 
@@ -275,11 +276,11 @@ describe( 'account-recovery actions', () => {
 				target: 'email',
 			} ) ),
 		postConditionFailed: () =>
-			assert( spy.calledWith( {
+			assert( spy.calledWith( sinon.match( {
 				type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 				target: 'email',
 				error: errorResponse,
-			} ) ),
+			} ) ) ),
 	} );
 
 	describe( '#deleteAccountRecoveryEmailSuccess', () => {

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -104,38 +104,45 @@ describe( '#account-recovery reducer update / delete:', () => {
 } );
 
 describe( '#account-recovery reducer action status flags: ', () => {
+	const targetPhone = { target: 'phone' };
+	const targetEmail = { target: 'email' };
+
 	generateActionInProgressStateFlagTests(
 		'isFetching',
 		reducer,
 		[ ACCOUNT_RECOVERY_SETTINGS_FETCH ],
-		[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]
+		[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ],
 	);
 
 	generateActionInProgressStateFlagTests(
 		'isUpdatingPhone',
 		reducer,
 		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
+		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ],
+		targetPhone
 	);
 
 	generateActionInProgressStateFlagTests(
 		'isDeletingPhone',
 		reducer,
 		[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
-		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
+		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ],
+		targetPhone
 	);
 
 	generateActionInProgressStateFlagTests(
 		'isUpdatingEmail',
 		reducer,
 		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
+		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ],
+		targetEmail
 	);
 
 	generateActionInProgressStateFlagTests(
 		'isDeletingEmail',
 		reducer,
 		[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
-		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
+		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ],
+		targetEmail
 	);
 } );

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -25,6 +25,7 @@ describe( 'account-recovery reducer', () => {
 			phoneValidated: dummyData.phone_validated,
 		},
 		isFetching: false,
+		isUpdatingPhone: false,
 	};
 
 	it( 'should return an initial object with the settings data.', () => {

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -40,31 +40,6 @@ describe( '#account-recovery reducer fetch:', () => {
 
 		assert.deepEqual( initState, expectedState );
 	} );
-
-	it( 'should populate isFetching in the state', () => {
-		const state = reducer( undefined, {
-			type: ACCOUNT_RECOVERY_SETTINGS_FETCH,
-		} );
-
-		assert( state.isFetching );
-	} );
-
-	it( 'ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS action should set isFetching to false', () => {
-		const state = reducer( { isFetching: true }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-			...dummyData,
-		} );
-
-		assert.isFalse( state.isFetching );
-	} );
-
-	it( 'ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED action should set isFetching to false', () => {
-		const state = reducer( { isFetching: true }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
-		} );
-
-		assert.isFalse( state.isFetching );
-	} );
 } );
 
 describe( '#account-recovery reducer update / delete:', () => {
@@ -94,6 +69,31 @@ describe( '#account-recovery reducer update / delete:', () => {
 } );
 
 describe( '#account-recovery reducer action status flags: ', () => {
+	it( 'ACCOUNT_RECOVERY_SETTINGS_FETCH should set isFetching to true', () => {
+		const state = reducer( { isFetching: false }, {
+			type: ACCOUNT_RECOVERY_SETTINGS_FETCH,
+		} );
+
+		assert( state.isFetching );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS action should set isFetching to false', () => {
+		const state = reducer( { isFetching: true }, {
+			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
+			...dummyData,
+		} );
+
+		assert.isFalse( state.isFetching );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED action should set isFetching to false', () => {
+		const state = reducer( { isFetching: true }, {
+			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
+		} );
+
+		assert.isFalse( state.isFetching );
+	} );
+
 	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE action should set isUpdatingPhone to true', () => {
 		const state = reducer( { isUpdatingPhone: true }, {
 			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { assert } from 'chai';
-import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -19,15 +18,17 @@ import reducer from '../reducer';
 
 describe( 'account-recovery reducer', () => {
 	const expectedState = {
-		email: dummyData.email,
-		emailValidated: dummyData.email_validated,
-		phone: dummyData.phone,
-		phoneValidated: dummyData.phone_validated,
+		data: {
+			email: dummyData.email,
+			emailValidated: dummyData.email_validated,
+			phone: dummyData.phone,
+			phoneValidated: dummyData.phone_validated,
+		},
 		isFetching: false,
 	};
 
 	it( 'should return an initial object with the settings data.', () => {
-		const initState = reducer( null, {
+		const initState = reducer( undefined, {
 			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 			...dummyData,
 		} );
@@ -35,25 +36,8 @@ describe( 'account-recovery reducer', () => {
 		assert.deepEqual( initState, expectedState );
 	} );
 
-	it( 'should return a new state object with the settings data.', () => {
-		const prevState = deepFreeze( {
-			foo: '1',
-			bar: 'bar',
-		} );
-
-		const state = reducer( prevState, {
-			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-			...dummyData,
-		} );
-
-		assert.deepEqual( state, {
-			...prevState,
-			...expectedState,
-		} );
-	} );
-
 	it( 'should populate isFetching in the state', () => {
-		const state = reducer( null, {
+		const state = reducer( undefined, {
 			type: ACCOUNT_RECOVERY_SETTINGS_FETCH,
 		} );
 

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -22,6 +22,7 @@ import {
 } from 'state/action-types';
 
 import { dummyData, dummyNewPhone } from './test-data';
+import { generateActionInProgressStateFlagTests } from './utils';
 import reducer from '../reducer';
 
 describe( '#account-recovery reducer fetch:', () => {
@@ -82,30 +83,12 @@ describe( '#account-recovery reducer update / delete:', () => {
 } );
 
 describe( '#account-recovery reducer action status flags: ', () => {
-	it( 'ACCOUNT_RECOVERY_SETTINGS_FETCH should set isFetching to true', () => {
-		const state = reducer( { isFetching: false }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_FETCH,
-		} );
-
-		assert( state.isFetching );
-	} );
-
-	it( 'ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS action should set isFetching to false', () => {
-		const state = reducer( { isFetching: true }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-			...dummyData,
-		} );
-
-		assert.isFalse( state.isFetching );
-	} );
-
-	it( 'ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED action should set isFetching to false', () => {
-		const state = reducer( { isFetching: true }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
-		} );
-
-		assert.isFalse( state.isFetching );
-	} );
+	generateActionInProgressStateFlagTests(
+		'isFetching',
+		reducer,
+		[ ACCOUNT_RECOVERY_SETTINGS_FETCH ],
+		[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]
+	);
 
 	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE action should set isUpdatingPhone to true', () => {
 		const state = reducer( { isUpdatingPhone: true }, {

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -90,44 +90,17 @@ describe( '#account-recovery reducer action status flags: ', () => {
 		[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]
 	);
 
-	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE action should set isUpdatingPhone to true', () => {
-		const state = reducer( { isUpdatingPhone: true }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
-			target: 'phone',
-		} );
+	generateActionInProgressStateFlagTests(
+		'isUpdatingPhone',
+		reducer,
+		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
+		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
+	);
 
-		assert.isTrue( state.isUpdatingPhone );
-	} );
-
-	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED action should set isUpdatingPhone to false', () => {
-		const state = reducer( { isUpdatingPhone: true }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
-		} );
-
-		assert.isFalse( state.isUpdatingPhone );
-	} );
-
-	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE action should set isDeletingPhone to true', () => {
-		const state = reducer( { isDeletingPhone: false }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_DELETE,
-		} );
-
-		assert.isTrue( state.isDeletingPhone );
-	} );
-
-	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS action should set isDeletingPhone to false', () => {
-		const state = reducer( { isDeletingPhone: true }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
-		} );
-
-		assert.isFalse( state.isDeletingPhone );
-	} );
-
-	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED action should set isDeletingPhone to false', () => {
-		const state = reducer( { isDeletingPhone: true }, {
-			type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
-		} );
-
-		assert.isFalse( state.isDeletingPhone );
-	} );
+	generateActionInProgressStateFlagTests(
+		'isDeletingPhone',
+		reducer,
+		[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
+		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
+	);
 } );

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -15,6 +15,10 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE,
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
+
+	ACCOUNT_RECOVERY_SETTINGS_DELETE,
+	ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
+	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 } from 'state/action-types';
 
 import { dummyData, dummyNewPhone } from './test-data';
@@ -30,6 +34,7 @@ describe( '#account-recovery reducer fetch:', () => {
 		},
 		isFetching: false,
 		isUpdatingPhone: false,
+		isDeletingPhone: false,
 	};
 
 	it( 'should return an initial object with the settings data.', () => {
@@ -63,8 +68,15 @@ describe( '#account-recovery reducer update / delete:', () => {
 			...initState.data,
 			phone: dummyNewPhone,
 		} );
+	} );
 
-		assert.isFalse( state.isUpdatingPhone );
+	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS action with phone target should wipe the phone field', () => {
+		const state = reducer( initState, {
+			type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
+			target: 'phone',
+		} );
+
+		assert.deepEqual( state.data.phone, {} );
 	} );
 } );
 
@@ -109,5 +121,29 @@ describe( '#account-recovery reducer action status flags: ', () => {
 		} );
 
 		assert.isFalse( state.isUpdatingPhone );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE action should set isDeletingPhone to true', () => {
+		const state = reducer( { isDeletingPhone: false }, {
+			type: ACCOUNT_RECOVERY_SETTINGS_DELETE,
+		} );
+
+		assert.isTrue( state.isDeletingPhone );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS action should set isDeletingPhone to false', () => {
+		const state = reducer( { isDeletingPhone: true }, {
+			type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
+		} );
+
+		assert.isFalse( state.isDeletingPhone );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED action should set isDeletingPhone to false', () => {
+		const state = reducer( { isDeletingPhone: true }, {
+			type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
+		} );
+
+		assert.isFalse( state.isDeletingPhone );
 	} );
 } );

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -38,6 +38,7 @@ describe( '#account-recovery reducer fetch:', () => {
 		isUpdatingPhone: false,
 		isDeletingPhone: false,
 		isUpdatingEmail: false,
+		isDeletingEmail: false,
 	};
 
 	it( 'should return an initial object with the settings data.', () => {
@@ -89,7 +90,16 @@ describe( '#account-recovery reducer update / delete:', () => {
 			data: dummyNewEmail,
 		} );
 
-		assert.deepEqual( state.data.email, dummyNewEmail );
+		assert.equal( state.data.email, dummyNewEmail );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS action with email target should wipe the email field', () => {
+		const state = reducer( initState, {
+			type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
+			target: 'email',
+		} );
+
+		assert.equal( state.data.email, '' );
 	} );
 } );
 
@@ -120,5 +130,12 @@ describe( '#account-recovery reducer action status flags: ', () => {
 		reducer,
 		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
 		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
+	);
+
+	generateActionInProgressStateFlagTests(
+		'isDeletingEmail',
+		reducer,
+		[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
+		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
 	);
 } );

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -35,6 +35,7 @@ describe( '#account-recovery reducer fetch:', () => {
 		isFetching: false,
 		isUpdatingPhone: false,
 		isDeletingPhone: false,
+		isUpdatingEmail: false,
 	};
 
 	it( 'should return an initial object with the settings data.', () => {

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -11,12 +11,16 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
+
+	ACCOUNT_RECOVERY_SETTINGS_UPDATE,
+	ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
+	ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
 } from 'state/action-types';
 
-import dummyData from './test-data';
+import { dummyData, dummyNewPhone } from './test-data';
 import reducer from '../reducer';
 
-describe( 'account-recovery reducer', () => {
+describe( '#account-recovery reducer fetch:', () => {
 	const expectedState = {
 		data: {
 			email: dummyData.email,
@@ -60,5 +64,50 @@ describe( 'account-recovery reducer', () => {
 		} );
 
 		assert.isFalse( state.isFetching );
+	} );
+} );
+
+describe( '#account-recovery reducer update / delete:', () => {
+	let initState;
+
+	beforeEach( () => {
+		initState = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
+			...dummyData,
+		} );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action with phone target should update the phone field', () => {
+		const state = reducer( initState, {
+			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
+			target: 'phone',
+			data: dummyNewPhone,
+		} );
+
+		assert.deepEqual( state.data, {
+			...initState.data,
+			phone: dummyNewPhone,
+		} );
+
+		assert.isFalse( state.isUpdatingPhone );
+	} );
+} );
+
+describe( '#account-recovery reducer action status flags: ', () => {
+	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE action should set isUpdatingPhone to true', () => {
+		const state = reducer( { isUpdatingPhone: true }, {
+			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
+			target: 'phone',
+		} );
+
+		assert.isTrue( state.isUpdatingPhone );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED action should set isUpdatingPhone to false', () => {
+		const state = reducer( { isUpdatingPhone: true }, {
+			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
+		} );
+
+		assert.isFalse( state.isUpdatingPhone );
 	} );
 } );

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -65,7 +65,7 @@ describe( '#account-recovery reducer update / delete:', () => {
 		const state = reducer( initState, {
 			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 			target: 'phone',
-			data: dummyNewPhone,
+			value: dummyNewPhone,
 		} );
 
 		assert.deepEqual( state.data, {
@@ -87,7 +87,7 @@ describe( '#account-recovery reducer update / delete:', () => {
 		const state = reducer( initState, {
 			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
 			target: 'email',
-			data: dummyNewEmail,
+			value: dummyNewEmail,
 		} );
 
 		assert.equal( state.data.email, dummyNewEmail );

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -21,8 +21,9 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
 } from 'state/action-types';
 
-import { dummyData, dummyNewPhone } from './test-data';
+import { dummyData, dummyNewPhone, dummyNewEmail } from './test-data';
 import { generateActionInProgressStateFlagTests } from './utils';
+
 import reducer from '../reducer';
 
 describe( '#account-recovery reducer fetch:', () => {
@@ -80,6 +81,16 @@ describe( '#account-recovery reducer update / delete:', () => {
 
 		assert.deepEqual( state.data.phone, {} );
 	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action with email target should update the email field', () => {
+		const state = reducer( initState, {
+			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
+			target: 'email',
+			data: dummyNewEmail,
+		} );
+
+		assert.deepEqual( state.data.email, dummyNewEmail );
+	} );
 } );
 
 describe( '#account-recovery reducer action status flags: ', () => {
@@ -102,5 +113,12 @@ describe( '#account-recovery reducer action status flags: ', () => {
 		reducer,
 		[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
 		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ]
+	);
+
+	generateActionInProgressStateFlagTests(
+		'isUpdatingEmail',
+		reducer,
+		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
+		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ]
 	);
 } );

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -24,20 +24,24 @@ import { dummyData, dummyNewPhone, dummyNewEmail } from './test-data';
 import reducer from '../reducer';
 
 describe( '#account-recovery reducer fetch:', () => {
-	const expectedData = {
+	const expectedState = {
 		email: dummyData.email,
 		emailValidated: dummyData.email_validated,
-		phone: dummyData.phone,
+
+		phoneCountryCode: dummyData.phone.country_code,
+		phoneCountryNumericCode: dummyData.phone.country_numeric_code,
+		phoneNumber: dummyData.phone.number,
+		phoneNumberFull: dummyData.phone.number_full,
 		phoneValidated: dummyData.phone_validated,
 	};
 
 	it( 'should return an initial object with the settings data.', () => {
 		const initState = reducer( undefined, {
 			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-			...dummyData,
+			settings: dummyData,
 		} );
 
-		assert.deepEqual( initState.data, expectedData );
+		assert.deepEqual( initState.data, expectedState );
 	} );
 } );
 
@@ -47,7 +51,7 @@ describe( '#account-recovery/settings reducer:', () => {
 	beforeEach( () => {
 		initState = reducer( undefined, {
 			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-			...dummyData,
+			settings: dummyData,
 		} );
 	} );
 
@@ -60,7 +64,10 @@ describe( '#account-recovery/settings reducer:', () => {
 
 		assert.deepEqual( state.data, {
 			...initState.data,
-			phone: dummyNewPhone,
+			phoneCountryCode: dummyNewPhone.country_code,
+			phoneCountryNumericCode: dummyNewPhone.country_numeric_code,
+			phoneNumber: dummyNewPhone.number,
+			phoneNumberFull: dummyNewPhone.number_full,
 		} );
 	} );
 
@@ -70,7 +77,10 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: 'phone',
 		} );
 
-		assert.deepEqual( state.data.phone, {} );
+		assert.equal( state.data.phoneCountryCode, '' );
+		assert.equal( state.data.phoneCountryNumericCode, '' );
+		assert.equal( state.data.phoneNumber, '' );
+		assert.equal( state.data.phoneNumberFull, '' );
 	} );
 
 	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action with email target should update the email field', () => {

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -27,11 +27,13 @@ describe( '#account-recovery reducer fetch:', () => {
 	const expectedState = {
 		email: dummyData.email,
 		emailValidated: dummyData.email_validated,
+		phone: {
+			countryCode: dummyData.phone.country_code,
+			countryNumericCode: dummyData.phone.country_numeric_code,
+			number: dummyData.phone.number,
+			numberFull: dummyData.phone.number_full,
+		},
 
-		phoneCountryCode: dummyData.phone.country_code,
-		phoneCountryNumericCode: dummyData.phone.country_numeric_code,
-		phoneNumber: dummyData.phone.number,
-		phoneNumberFull: dummyData.phone.number_full,
 		phoneValidated: dummyData.phone_validated,
 	};
 
@@ -64,10 +66,12 @@ describe( '#account-recovery/settings reducer:', () => {
 
 		assert.deepEqual( state.data, {
 			...initState.data,
-			phoneCountryCode: dummyNewPhone.country_code,
-			phoneCountryNumericCode: dummyNewPhone.country_numeric_code,
-			phoneNumber: dummyNewPhone.number,
-			phoneNumberFull: dummyNewPhone.number_full,
+			phone: {
+				countryCode: dummyNewPhone.country_code,
+				countryNumericCode: dummyNewPhone.country_numeric_code,
+				number: dummyNewPhone.number,
+				numberFull: dummyNewPhone.number_full,
+			},
 		} );
 	} );
 
@@ -77,10 +81,7 @@ describe( '#account-recovery/settings reducer:', () => {
 			target: 'phone',
 		} );
 
-		assert.equal( state.data.phoneCountryCode, '' );
-		assert.equal( state.data.phoneCountryNumericCode, '' );
-		assert.equal( state.data.phoneNumber, '' );
-		assert.equal( state.data.phoneNumberFull, '' );
+		assert.isNull( state.data.phone );
 	} );
 
 	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action with email target should update the email field', () => {

--- a/client/state/account-recovery/settings/test/reducer.js
+++ b/client/state/account-recovery/settings/test/reducer.js
@@ -8,9 +8,7 @@ import { assert } from 'chai';
  */
 
 import {
-	ACCOUNT_RECOVERY_SETTINGS_FETCH,
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
-	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
 
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE,
 	ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
@@ -22,23 +20,15 @@ import {
 } from 'state/action-types';
 
 import { dummyData, dummyNewPhone, dummyNewEmail } from './test-data';
-import { generateActionInProgressStateFlagTests } from './utils';
 
 import reducer from '../reducer';
 
 describe( '#account-recovery reducer fetch:', () => {
-	const expectedState = {
-		data: {
-			email: dummyData.email,
-			emailValidated: dummyData.email_validated,
-			phone: dummyData.phone,
-			phoneValidated: dummyData.phone_validated,
-		},
-		isFetching: false,
-		isUpdatingPhone: false,
-		isDeletingPhone: false,
-		isUpdatingEmail: false,
-		isDeletingEmail: false,
+	const expectedData = {
+		email: dummyData.email,
+		emailValidated: dummyData.email_validated,
+		phone: dummyData.phone,
+		phoneValidated: dummyData.phone_validated,
 	};
 
 	it( 'should return an initial object with the settings data.', () => {
@@ -47,11 +37,11 @@ describe( '#account-recovery reducer fetch:', () => {
 			...dummyData,
 		} );
 
-		assert.deepEqual( initState, expectedState );
+		assert.deepEqual( initState.data, expectedData );
 	} );
 } );
 
-describe( '#account-recovery reducer update / delete:', () => {
+describe( '#account-recovery/settings reducer:', () => {
 	let initState;
 
 	beforeEach( () => {
@@ -101,48 +91,60 @@ describe( '#account-recovery reducer update / delete:', () => {
 
 		assert.equal( state.data.email, '' );
 	} );
-} );
 
-describe( '#account-recovery reducer action status flags: ', () => {
-	const targetPhone = { target: 'phone' };
-	const targetEmail = { target: 'email' };
+	const arbitraryTargetName = 'whatever';
 
-	generateActionInProgressStateFlagTests(
-		'isFetching',
-		reducer,
-		[ ACCOUNT_RECOVERY_SETTINGS_FETCH ],
-		[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ],
-	);
+	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE action should set the isUpdating sub field', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE,
+			target: arbitraryTargetName,
+		} );
 
-	generateActionInProgressStateFlagTests(
-		'isUpdatingPhone',
-		reducer,
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ],
-		targetPhone
-	);
+		assert.isTrue( state.isUpdating[ arbitraryTargetName ] );
+	} );
 
-	generateActionInProgressStateFlagTests(
-		'isDeletingPhone',
-		reducer,
-		[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
-		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ],
-		targetPhone
-	);
+	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS action should unset the isUpdating sub field', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS,
+			target: arbitraryTargetName,
+		} );
 
-	generateActionInProgressStateFlagTests(
-		'isUpdatingEmail',
-		reducer,
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE ],
-		[ ACCOUNT_RECOVERY_SETTINGS_UPDATE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED ],
-		targetEmail
-	);
+		assert.isFalse( state.isUpdating[ arbitraryTargetName ] );
+	} );
 
-	generateActionInProgressStateFlagTests(
-		'isDeletingEmail',
-		reducer,
-		[ ACCOUNT_RECOVERY_SETTINGS_DELETE ],
-		[ ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS, ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED ],
-		targetEmail
-	);
+	it( 'ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED action should unset the isUpdating sub field', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_UPDATE_FAILED,
+			target: arbitraryTargetName,
+		} );
+
+		assert.isFalse( state.isUpdating[ arbitraryTargetName ] );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINS_DELETE action should set the isDeleting sub field', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_DELETE,
+			target: arbitraryTargetName,
+		} );
+
+		assert.isTrue( state.isDeleting[ arbitraryTargetName ] );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS action should unset the isDeleting sub field', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_DELETE_SUCCESS,
+			target: arbitraryTargetName,
+		} );
+
+		assert.isFalse( state.isDeleting[ arbitraryTargetName ] );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED action should unset the isDeleting sub field', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_DELETE_FAILED,
+			target: arbitraryTargetName,
+		} );
+
+		assert.isFalse( state.isDeleting[ arbitraryTargetName ] );
+	} );
 } );

--- a/client/state/account-recovery/settings/test/selectors.js
+++ b/client/state/account-recovery/settings/test/selectors.js
@@ -78,7 +78,6 @@ describe( '#account-recovery/settings/selectors', () => {
 		} );
 	} );
 
-
 	describe( '#getAccountRecoveryPhoneCountryCode', () => {
 		it( 'should return a default value on absence', () => {
 			assert.equal( getAccountRecoveryPhoneCountryCode( stateBeforeFetching ), '' );

--- a/client/state/account-recovery/settings/test/selectors.js
+++ b/client/state/account-recovery/settings/test/selectors.js
@@ -28,7 +28,13 @@ describe( '#account-recovery/settings/selectors', () => {
 	const stateBeforeFetching = {
 		accountRecovery: {
 			settings: {
-				data: null,
+				data: {
+					email: '',
+					emailValidated: false,
+					phone: null,
+					phoneValidated: false,
+				},
+				isReady: false,
 			},
 		},
 	};
@@ -47,6 +53,7 @@ describe( '#account-recovery/settings/selectors', () => {
 					},
 					phoneValidated: true,
 				},
+				isReady: true,
 			},
 		},
 	};

--- a/client/state/account-recovery/settings/test/selectors.js
+++ b/client/state/account-recovery/settings/test/selectors.js
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isAccountRecoveryEmailValidated,
+	isAccountRecoveryPhoneValidated,
+	getAccountRecoveryEmail,
+	getAccountRecoveryPhoneCountryCode,
+	getAccountRecoveryPhoneCountryNumericCode,
+	getAccountRecoveryPhoneNumber,
+	getAccountRecoveryPhoneNumberFull,
+} from '../selectors';
+
+import {
+	dummyNewPhone,
+	dummyNewEmail,
+} from './test-data';
+
+describe( '#account-recovery/settings/selectors', () => {
+	const stateBeforeFetching = {
+		accountRecovery: {
+			settings: null,
+		},
+	};
+
+	const stateAfterFetching = {
+		accountRecovery: {
+			settings: {
+				data: {
+					email: dummyNewEmail,
+					emailValidated: true,
+					phoneCountryCode: dummyNewPhone.country_code,
+					phoneCountryNumericCode: dummyNewPhone.country_numeric_code,
+					phoneNumber: dummyNewPhone.number,
+					phoneNumberFull: dummyNewPhone.number_full,
+					phoneValidated: true,
+				},
+			},
+		},
+	};
+
+	describe( '#isAccountRecoveryEmailValidated:', () => {
+		it( 'should return false on absence', () => {
+			assert.isFalse( isAccountRecoveryEmailValidated( stateBeforeFetching ) );
+		} );
+
+		it( 'should return the emailValidated field', () => {
+			assert.isTrue( isAccountRecoveryEmailValidated( stateAfterFetching ) );
+		} );
+	} );
+
+	describe( '#isAccountRecoveryPhoneValidated:', () => {
+		it( 'should return false on absence', () => {
+			assert.isFalse( isAccountRecoveryPhoneValidated( stateBeforeFetching ) );
+		} );
+
+		it( 'should return the phoneValidated field', () => {
+			assert.isTrue( isAccountRecoveryPhoneValidated( stateAfterFetching ) );
+		} );
+	} );
+
+	describe( '#getAccountRecoveryEmail:', () => {
+		it( 'should return a default value on absence', () => {
+			assert.equal( getAccountRecoveryEmail( stateBeforeFetching ), '' );
+		} );
+
+		it( 'should return the email field', () => {
+			assert.equal( getAccountRecoveryEmail( stateAfterFetching ), dummyNewEmail );
+		} );
+	} );
+
+
+	describe( '#getAccountRecoveryPhoneCountryCode', () => {
+		it( 'should return a default value on absence', () => {
+			assert.equal( getAccountRecoveryPhoneCountryCode( stateBeforeFetching ), '' );
+		} );
+
+		it( 'should return the phoneCountryCode field', () => {
+			assert.equal( getAccountRecoveryPhoneCountryCode( stateAfterFetching ), dummyNewPhone.country_code );
+		} );
+	} );
+
+	describe( '#getAccountRecoveryPhoneCountryNumericCode', () => {
+		it( 'should return a default value on absence', () => {
+			assert.equal( getAccountRecoveryPhoneCountryNumericCode( stateBeforeFetching ), '' );
+		} );
+
+		it( 'should return the phoneCountryNumericCode field', () => {
+			assert.equal( getAccountRecoveryPhoneCountryNumericCode( stateAfterFetching ), dummyNewPhone.country_numeric_code );
+		} );
+	} );
+
+	describe( '#getAccountRecoveryPhoneNumber', () => {
+		it( 'should return a default value on absence', () => {
+			assert.equal( getAccountRecoveryPhoneNumber( stateBeforeFetching ), '' );
+		} );
+
+		it( 'should return the phoneNumber field', () => {
+			assert.equal( getAccountRecoveryPhoneNumber( stateAfterFetching ), dummyNewPhone.number );
+		} );
+	} );
+
+	describe( '#getAccountRecoveryPhoneNumberFull', () => {
+		it( 'should return a default value on absence', () => {
+			assert.equal( getAccountRecoveryPhoneNumberFull( stateBeforeFetching ), '' );
+		} );
+
+		it( 'should return the phoneNumberFull field', () => {
+			assert.equal( getAccountRecoveryPhoneNumberFull( stateAfterFetching ), dummyNewPhone.number_full );
+		} );
+	} );
+} );

--- a/client/state/account-recovery/settings/test/selectors.js
+++ b/client/state/account-recovery/settings/test/selectors.js
@@ -7,6 +7,7 @@ import { assert } from 'chai';
  * Internal dependencies
  */
 import {
+	isAccountRecoverySettingsReady,
 	isAccountRecoveryEmailValidated,
 	isAccountRecoveryPhoneValidated,
 	getAccountRecoveryEmail,
@@ -49,6 +50,16 @@ describe( '#account-recovery/settings/selectors', () => {
 			},
 		},
 	};
+
+	describe( '#isAccountRecoverySettingsReady', () => {
+		it( 'should return false on absence', () => {
+			assert.isFalse( isAccountRecoverySettingsReady( stateBeforeFetching ) );
+		} );
+
+		it( 'should return true if exists', () => {
+			assert.isTrue( isAccountRecoverySettingsReady( stateAfterFetching ) );
+		} );
+	} );
 
 	describe( '#isAccountRecoveryEmailValidated:', () => {
 		it( 'should return false on absence', () => {

--- a/client/state/account-recovery/settings/test/selectors.js
+++ b/client/state/account-recovery/settings/test/selectors.js
@@ -10,15 +10,13 @@ import {
 	isAccountRecoverySettingsReady,
 	isAccountRecoveryEmailValidated,
 	isAccountRecoveryPhoneValidated,
-	getAccountRecoveryEmail,
-	getAccountRecoveryPhoneCountryCode,
-	getAccountRecoveryPhoneCountryNumericCode,
-	getAccountRecoveryPhoneNumber,
-	getAccountRecoveryPhoneNumberFull,
 	isUpdatingAccountRecoveryPhone,
 	isUpdatingAccountRecoveryEmail,
 	isDeletingAccountRecoveryPhone,
 	isDeletingAccountRecoveryEmail,
+
+	getAccountRecoveryEmail,
+	getAccountRecoveryPhone,
 } from '../selectors';
 
 import {
@@ -41,10 +39,12 @@ describe( '#account-recovery/settings/selectors', () => {
 				data: {
 					email: dummyNewEmail,
 					emailValidated: true,
-					phoneCountryCode: dummyNewPhone.country_code,
-					phoneCountryNumericCode: dummyNewPhone.country_numeric_code,
-					phoneNumber: dummyNewPhone.number,
-					phoneNumberFull: dummyNewPhone.number_full,
+					phone: {
+						countryCode: dummyNewPhone.country_code,
+						countryNumericCode: dummyNewPhone.country_numeric_code,
+						number: dummyNewPhone.number,
+						numberFull: dummyNewPhone.number_full,
+					},
 					phoneValidated: true,
 				},
 			},
@@ -91,43 +91,18 @@ describe( '#account-recovery/settings/selectors', () => {
 		} );
 	} );
 
-	describe( '#getAccountRecoveryPhoneCountryCode', () => {
+	describe( '#getAccountRecoveryPhone', () => {
 		it( 'should return a default value on absence', () => {
-			assert.equal( getAccountRecoveryPhoneCountryCode( stateBeforeFetching ), '' );
+			assert.isNull( getAccountRecoveryPhone( stateBeforeFetching ) );
 		} );
 
-		it( 'should return the phoneCountryCode field', () => {
-			assert.equal( getAccountRecoveryPhoneCountryCode( stateAfterFetching ), dummyNewPhone.country_code );
-		} );
-	} );
-
-	describe( '#getAccountRecoveryPhoneCountryNumericCode', () => {
-		it( 'should return a default value on absence', () => {
-			assert.equal( getAccountRecoveryPhoneCountryNumericCode( stateBeforeFetching ), '' );
-		} );
-
-		it( 'should return the phoneCountryNumericCode field', () => {
-			assert.equal( getAccountRecoveryPhoneCountryNumericCode( stateAfterFetching ), dummyNewPhone.country_numeric_code );
-		} );
-	} );
-
-	describe( '#getAccountRecoveryPhoneNumber', () => {
-		it( 'should return a default value on absence', () => {
-			assert.equal( getAccountRecoveryPhoneNumber( stateBeforeFetching ), '' );
-		} );
-
-		it( 'should return the phoneNumber field', () => {
-			assert.equal( getAccountRecoveryPhoneNumber( stateAfterFetching ), dummyNewPhone.number );
-		} );
-	} );
-
-	describe( '#getAccountRecoveryPhoneNumberFull', () => {
-		it( 'should return a default value on absence', () => {
-			assert.equal( getAccountRecoveryPhoneNumberFull( stateBeforeFetching ), '' );
-		} );
-
-		it( 'should return the phoneNumberFull field', () => {
-			assert.equal( getAccountRecoveryPhoneNumberFull( stateAfterFetching ), dummyNewPhone.number_full );
+		it( 'should return the phone field', () => {
+			assert.deepEqual( getAccountRecoveryPhone( stateAfterFetching ), {
+				countryCode: dummyNewPhone.country_code,
+				countryNumericCode: dummyNewPhone.country_numeric_code,
+				number: dummyNewPhone.number,
+				numberFull: dummyNewPhone.number_full,
+			} );
 		} );
 	} );
 

--- a/client/state/account-recovery/settings/test/selectors.js
+++ b/client/state/account-recovery/settings/test/selectors.js
@@ -14,6 +14,10 @@ import {
 	getAccountRecoveryPhoneCountryNumericCode,
 	getAccountRecoveryPhoneNumber,
 	getAccountRecoveryPhoneNumberFull,
+	isUpdatingAccountRecoveryPhone,
+	isUpdatingAccountRecoveryEmail,
+	isDeletingAccountRecoveryPhone,
+	isDeletingAccountRecoveryEmail,
 } from '../selectors';
 
 import {
@@ -26,8 +30,6 @@ describe( '#account-recovery/settings/selectors', () => {
 		accountRecovery: {
 			settings: {
 				data: null,
-				isUpdating: false,
-				isDeleting: false,
 			},
 		},
 	};
@@ -115,6 +117,84 @@ describe( '#account-recovery/settings/selectors', () => {
 
 		it( 'should return the phoneNumberFull field', () => {
 			assert.equal( getAccountRecoveryPhoneNumberFull( stateAfterFetching ), dummyNewPhone.number_full );
+		} );
+	} );
+
+	const stateBeforeUpdating = {
+		accountRecovery: {
+			settings: {
+				isUpdating: {},
+			},
+		},
+	};
+
+	const stateDuringUpdating = {
+		accountRecovery: {
+			settings: {
+				isUpdating: {
+					phone: true,
+					email: true,
+				},
+			},
+		},
+	};
+
+	describe( '#isUpdatingAccountRecoveryPhone', () => {
+		it( 'should return false on absence', () => {
+			assert.isFalse( isUpdatingAccountRecoveryPhone( stateBeforeUpdating ) );
+		} );
+
+		it( 'should return isUpdating.phone', () => {
+			assert.isTrue( isUpdatingAccountRecoveryPhone( stateDuringUpdating ) );
+		} );
+	} );
+
+	describe( '#isUpdatingAccountRecoveryEmail', () => {
+		it( 'should return false on absence', () => {
+			assert.isFalse( isUpdatingAccountRecoveryEmail( stateBeforeUpdating ) );
+		} );
+
+		it( 'should return isUpdating.email', () => {
+			assert.isTrue( isUpdatingAccountRecoveryEmail( stateDuringUpdating ) );
+		} );
+	} );
+
+	const stateBeforeDeleting = {
+		accountRecovery: {
+			settings: {
+				isDeleting: {},
+			},
+		},
+	};
+
+	const stateDuringDeleting = {
+		accountRecovery: {
+			settings: {
+				isDeleting: {
+					phone: true,
+					email: true,
+				},
+			},
+		},
+	};
+
+	describe( '#isDeletingAccountRecoveryPhone', () => {
+		it( 'should return false on absence', () => {
+			assert.isFalse( isDeletingAccountRecoveryPhone( stateBeforeDeleting ) );
+		} );
+
+		it( 'should return isDeleting.phone', () => {
+			assert.isTrue( isDeletingAccountRecoveryPhone( stateDuringDeleting ) );
+		} );
+	} );
+
+	describe( '#isDeletingAccountRecoveryEmail', () => {
+		it( 'should return false on absence', () => {
+			assert.isFalse( isDeletingAccountRecoveryEmail( stateBeforeDeleting ) );
+		} );
+
+		it( 'should return isDeleting.email', () => {
+			assert.isTrue( isDeletingAccountRecoveryEmail( stateDuringDeleting ) );
 		} );
 	} );
 } );

--- a/client/state/account-recovery/settings/test/selectors.js
+++ b/client/state/account-recovery/settings/test/selectors.js
@@ -24,7 +24,11 @@ import {
 describe( '#account-recovery/settings/selectors', () => {
 	const stateBeforeFetching = {
 		accountRecovery: {
-			settings: null,
+			settings: {
+				data: null,
+				isUpdating: false,
+				isDeleting: false,
+			},
 		},
 	};
 

--- a/client/state/account-recovery/settings/test/test-data.js
+++ b/client/state/account-recovery/settings/test/test-data.js
@@ -1,4 +1,4 @@
-const dummyData = {
+export const dummyData = {
 	email: 'dummytest@example.com',
 	email_validated: false,
 	phone: {
@@ -10,4 +10,11 @@ const dummyData = {
 	phone_validated: false,
 };
 
-export default dummyData;
+export const dummyNewPhone = {
+	country_code: 'US',
+	country_numeric_code: '+1',
+	number: '8881234567',
+	number_full: '+18881234567',
+};
+
+export const dummyNewEmail = 'newtest@example.com';

--- a/client/state/account-recovery/settings/test/utils.js
+++ b/client/state/account-recovery/settings/test/utils.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
  * Internal dependencies
  */
 import { useNock } from 'test/helpers/use-nock';
@@ -49,6 +54,28 @@ export const generateSuccessAndFailedTestsForThunk = ( {
 			preCondition();
 
 			return action.then( postConditionFailed );
+		} );
+	} );
+};
+
+export const generateActionInProgressStateFlagTests = ( stateKey, reducer, initiateActions, finishActions ) => {
+	initiateActions.forEach( ( action ) => {
+		it( action + ' should set ' + stateKey + ' to true', () => {
+			const state = reducer( { [ stateKey ]: false }, {
+				type: action,
+			} );
+
+			assert.isTrue( state[ stateKey ] );
+		} );
+	} );
+
+	finishActions.forEach( ( action ) => {
+		it( action + ' should set ' + stateKey + ' to false', () => {
+			const state = reducer( { [ stateKey ]: true }, {
+				type: action,
+			} );
+
+			assert.isFalse( state[ stateKey ] );
 		} );
 	} );
 };

--- a/client/state/account-recovery/settings/test/utils.js
+++ b/client/state/account-recovery/settings/test/utils.js
@@ -58,22 +58,27 @@ export const generateSuccessAndFailedTestsForThunk = ( {
 	} );
 };
 
-export const generateActionInProgressStateFlagTests = ( stateKey, reducer, initiateActions, finishActions ) => {
-	initiateActions.forEach( ( action ) => {
-		it( action + ' should set ' + stateKey + ' to true', () => {
-			const state = reducer( { [ stateKey ]: false }, {
-				type: action,
-			} );
+export const generateActionInProgressStateFlagTests = ( stateKey, reducer, initiateActions, finishActions, extraActionProperties = {} ) => {
+	initiateActions.forEach( ( actionType ) => {
+		it( actionType + ' should set ' + stateKey + ' to true', () => {
+			const action = {
+				...extraActionProperties,
+				type: actionType,
+			};
+			const state = reducer( { [ stateKey ]: false }, action );
 
 			assert.isTrue( state[ stateKey ] );
 		} );
 	} );
 
-	finishActions.forEach( ( action ) => {
-		it( action + ' should set ' + stateKey + ' to false', () => {
-			const state = reducer( { [ stateKey ]: true }, {
-				type: action,
-			} );
+	finishActions.forEach( ( actionType ) => {
+		it( actionType + ' should set ' + stateKey + ' to false', () => {
+			const action = {
+				...extraActionProperties,
+				type: actionType,
+			};
+
+			const state = reducer( { [ stateKey ]: true }, action );
 
 			assert.isFalse( state[ stateKey ] );
 		} );

--- a/client/state/account-recovery/settings/test/utils.js
+++ b/client/state/account-recovery/settings/test/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { assert } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { useNock } from 'test/helpers/use-nock';
@@ -54,33 +49,6 @@ export const generateSuccessAndFailedTestsForThunk = ( {
 			preCondition();
 
 			return action.then( postConditionFailed );
-		} );
-	} );
-};
-
-export const generateActionInProgressStateFlagTests = ( stateKey, reducer, initiateActions, finishActions, extraActionProperties = {} ) => {
-	initiateActions.forEach( ( actionType ) => {
-		it( actionType + ' should set ' + stateKey + ' to true', () => {
-			const action = {
-				...extraActionProperties,
-				type: actionType,
-			};
-			const state = reducer( { [ stateKey ]: false }, action );
-
-			assert.isTrue( state[ stateKey ] );
-		} );
-	} );
-
-	finishActions.forEach( ( actionType ) => {
-		it( actionType + ' should set ' + stateKey + ' to false', () => {
-			const action = {
-				...extraActionProperties,
-				type: actionType,
-			};
-
-			const state = reducer( { [ stateKey ]: true }, action );
-
-			assert.isFalse( state[ stateKey ] );
 		} );
 	} );
 };

--- a/client/state/account-recovery/test/reducer.js
+++ b/client/state/account-recovery/test/reducer.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ACCOUNT_RECOVERY_SETTINGS_FETCH,
+	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
+	ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
+} from 'state/action-types';
+
+import reducer from '../reducer';
+
+describe( '#account-recovery/isFetchingSettings reducer :', () => {
+	it( 'should set isFetchingSettings flag.', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_FETCH,
+		} );
+
+		assert.isTrue( state.isFetchingSettings );
+	} );
+
+	it( 'should unset isFetchingSettings flag on success.', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
+		} );
+
+		assert.isFalse( state.isFetchingSettings );
+	} );
+
+	it( 'should unset isFetchingSettings flag on failure.', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED,
+		} );
+
+		assert.isFalse( state.isFetchingSettings );
+	} );
+} );

--- a/client/state/account-recovery/test/reducer.js
+++ b/client/state/account-recovery/test/reducer.js
@@ -26,6 +26,12 @@ describe( '#account-recovery/isFetchingSettings reducer :', () => {
 	it( 'should unset isFetchingSettings flag on success.', () => {
 		const state = reducer( undefined, {
 			type: ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
+			settings: {
+				email: '',
+				email_validated: true,
+				phone: {},
+				phone_validated: true,
+			},
 		} );
 
 		assert.isFalse( state.isFetchingSettings );

--- a/client/state/account-recovery/test/selectors.js
+++ b/client/state/account-recovery/test/selectors.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isFetchingAccountRecoverySettings,
+	getAccountRecoverySettings,
+} from '../selectors';
+
+describe( '#account-recovery selector isFetchingAccountRecoverySettings:', () => {
+	it( 'should return the correct property.', () => {
+		const state = {
+			accountRecovery: {
+				isFetchingSettings: true,
+			},
+		};
+
+		assert.isTrue( isFetchingAccountRecoverySettings( state ) );
+	} );
+} );
+
+describe( '#account-recovery selector getAccountRecoverySettings:', () => {
+	it( 'should extract where the settings reside.', () => {
+		const settings = {
+			email: 'aaa@example.com',
+			emailValidated: false,
+		};
+		const state = {
+			accountRecovery: {
+				settings
+			},
+		};
+
+		assert.deepEqual( getAccountRecoverySettings( state ), settings );
+	} );
+} );

--- a/client/state/account-recovery/test/selectors.js
+++ b/client/state/account-recovery/test/selectors.js
@@ -11,7 +11,7 @@ import {
 } from '../selectors';
 
 describe( '#account-recovery selector isFetchingAccountRecoverySettings:', () => {
-	it( 'should return the correct property.', () => {
+	it( 'should return the field isFetchingSettings.', () => {
 		const state = {
 			accountRecovery: {
 				isFetchingSettings: true,

--- a/client/state/account-recovery/test/selectors.js
+++ b/client/state/account-recovery/test/selectors.js
@@ -8,7 +8,6 @@ import { assert } from 'chai';
  */
 import {
 	isFetchingAccountRecoverySettings,
-	getAccountRecoverySettings,
 } from '../selectors';
 
 describe( '#account-recovery selector isFetchingAccountRecoverySettings:', () => {
@@ -20,21 +19,5 @@ describe( '#account-recovery selector isFetchingAccountRecoverySettings:', () =>
 		};
 
 		assert.isTrue( isFetchingAccountRecoverySettings( state ) );
-	} );
-} );
-
-describe( '#account-recovery selector getAccountRecoverySettings:', () => {
-	it( 'should extract where the settings reside.', () => {
-		const settings = {
-			email: 'aaa@example.com',
-			emailValidated: false,
-		};
-		const state = {
-			accountRecovery: {
-				settings
-			},
-		};
-
-		assert.deepEqual( getAccountRecoverySettings( state ), settings );
 	} );
 } );


### PR DESCRIPTION
## Summary
This PR aims to complete the account recovery settings state tree. ~It is based on #9111 and #9173 , and thus should keep the In Progress label before those two got in.~ ( these two have been merged )

In general, it consists of the following of `account-recovery/settings` state

* The reducer and its tests
* The selectors
* Some additional polishes against the actions

## Test Plan
Run `npm run test-client client/state/account-recovery/test/` or let CircleCI do the fun.