### PR TITLE
Jetpack Connect: Fix crash in Plans page after connecting a site with paid plan

### DIFF
--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -62,6 +62,11 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 	return false;
 };
 
+const isRedirectingToWpAdmin = function( state ) {
+	const authorizationData = getAuthorizationData( state );
+	return !! authorizationData.isRedirectingToWpAdmin;
+};
+
 const getFlowType = function( state, siteSlug ) {
 	const sessions = getSessions( state );
 	siteSlug = urlToSlug( siteSlug );
@@ -108,6 +113,7 @@ export default {
 	getSSOSessions,
 	getSSO,
 	isCalypsoStartedConnection,
+	isRedirectingToWpAdmin,
 	isRemoteSiteOnSitesList,
 	getFlowType,
 	getJetpackSiteByUrl,

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -15,6 +15,7 @@ import {
 	getSSOSessions,
 	getSSO,
 	isCalypsoStartedConnection,
+	isRedirectingToWpAdmin,
 	isRemoteSiteOnSitesList,
 	getFlowType,
 	getJetpackSiteByUrl,
@@ -351,6 +352,42 @@ describe( 'selectors', () => {
 			};
 
 			expect( isCalypsoStartedConnection( state, 'sitetest' ) ).to.be.false;
+		} );
+	} );
+
+	describe( '#isRedirectingToWpAdmin()', () => {
+		it( 'should return false if redirection flag is not set', () => {
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize: {}
+				}
+			};
+
+			expect( isRedirectingToWpAdmin( state ) ).to.be.false;
+		} );
+
+		it( 'should return false if redirection flag is set to false', () => {
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize: {
+						isRedirectingToWpAdmin: false
+					}
+				}
+			};
+
+			expect( isRedirectingToWpAdmin( state ) ).to.be.false;
+		} );
+
+		it( 'should return false if redirection flag is set to true', () => {
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize: {
+						isRedirectingToWpAdmin: true
+					}
+				}
+			};
+
+			expect( isRedirectingToWpAdmin( state ) ).to.be.true;
 		} );
 	} );
 

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -378,7 +378,7 @@ describe( 'selectors', () => {
 			expect( isRedirectingToWpAdmin( state ) ).to.be.false;
 		} );
 
-		it( 'should return false if redirection flag is set to true', () => {
+		it( 'should return true if redirection flag is set to true', () => {
 			const state = {
 				jetpackConnect: {
 					jetpackConnectAuthorize: {


### PR DESCRIPTION
### Purpose

This PR fixes #9209, where the window crashed after connecting a site with a premium plan when the connection process started from wp-admin. It introduces a new selector to check whether we're currently redirecting to wp-admin (includes tests).

The PR also addresses the edge case when the user visits `/jetpack/connect/plans/$site` with an active plan but without an active authorization session. In that case it was supposed to redirect to wp-admin, ut it didn't - redirection to wp-admin was failing because when the authorization `queryObject` was not there, so its `redirect_after_auth` was not defined. The PR resolves this by redirecting to wp-admin without using the authorization object in that case.

### To test:

**Test case 1**

* Disconnect one of your Jetpack sites that has a Premium plan.
* Go to /wp-admin/admin.php?page=jetpack of your Jetpack site.
* Click the "Connect Jetpack" button to start authorization.
* Add `&calypso_env=development` to the end of the long authorization URL.
* In the authorization window, click the "Approve" button.
* Verify you're redirected to wp-admin after connection process has completed, and there are no errors in the console in the meantime.

**Test case 2**

* Visit `/jetpack/connect/plans/$site`, where `$site` is a connected Jetpack sites that has a Premium plan.
* Verify you're properly redirected to My Plan page with no errors in the console.

Also, verify tests of the new `isRedirectingToWpAdmin()` selector are passing: `npm run test-client client/state/jetpack-connect/test/selectors.js -- --grep "isRedirectingToWpAdmin"`

/cc @dereksmart @roccotrip @johnHackworth @ryelle @oskosk