### PR TITLE
Jetpack Connect: Increase authorization data TTL back to 1 hour

### DIFF
--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -1,2 +1,2 @@
-export const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // an hour
-export const JETPACK_CONNECT_AUTHORIZE_TTL = 5 * 60 * 1000; // 5 minutes
+export const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 hour
+export const JETPACK_CONNECT_AUTHORIZE_TTL = 60 * 60 * 1000; // 1 hour


### PR DESCRIPTION
A week ago in #8962 we introduced a TTL for authorization data and set it to 5 min. 

This PR increases the authorization data TTL back to 1 hour in attempt to reduce the Jetpack connection errors that recently spiked up. 

/cc @johnHackworth @roccotripaldi @kraftbj 