### PR TITLE
EditGravatar: Add uploaded image to state

### DIFF
--- a/client/state/current-user/gravatar-status/actions.js
+++ b/client/state/current-user/gravatar-status/actions.js
@@ -24,12 +24,17 @@ export function uploadGravatar( file, bearerToken, email ) {
 			.send( data )
 			.set( 'Authorization', 'Bearer ' + bearerToken )
 			.then( () => {
-				dispatch( {
-					type: GRAVATAR_UPLOAD_RECEIVE
+				const fileReader = new FileReader( file );
+				fileReader.addEventListener( 'load', function() {
+					dispatch( {
+						type: GRAVATAR_UPLOAD_RECEIVE,
+						src: fileReader.result,
+					} );
+					dispatch( {
+						type: GRAVATAR_UPLOAD_REQUEST_SUCCESS
+					} );
 				} );
-				dispatch( {
-					type: GRAVATAR_UPLOAD_REQUEST_SUCCESS
-				} );
+				fileReader.readAsDataURL( file );
 			} )
 			.catch( () => {
 				dispatch( {

--- a/client/state/current-user/gravatar-status/reducer.js
+++ b/client/state/current-user/gravatar-status/reducer.js
@@ -7,6 +7,7 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import {
+	GRAVATAR_UPLOAD_RECEIVE,
 	GRAVATAR_UPLOAD_REQUEST,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE
@@ -19,6 +20,15 @@ export const isUploading = createReducer( false, {
 	[ GRAVATAR_UPLOAD_REQUEST_FAILURE ]: () => false
 } );
 
+export const tempImage = createReducer( {}, {
+	[ GRAVATAR_UPLOAD_RECEIVE ]: ( state, action ) => {
+		return {
+			src: action.src
+		};
+	}
+} );
+
 export default combineReducers( {
-	isUploading
+	isUploading,
+	tempImage
 } );

--- a/client/state/current-user/gravatar-status/selectors.js
+++ b/client/state/current-user/gravatar-status/selectors.js
@@ -11,3 +11,15 @@ import { get } from 'lodash';
 export function isCurrentUserUploadingGravatar( state ) {
 	return get( state, 'currentUser.gravatarStatus.isUploading', false );
 }
+
+/**
+ * Returns the temp Gravatar if it exists and
+ * the current user ID is passed in, otherwise false
+ * @param {Object} state - The state
+ * @param {Number} userId - The ID of the user we're checking
+ * @returns {String|Boolean} - The temp Gravatar string, or false
+ */
+export function getUserTempGravatar( state, userId ) {
+	return state.currentUser.id === userId &&
+		get( state, 'currentUser.gravatarStatus.tempImage.src', false );
+}

--- a/client/state/current-user/gravatar-status/test/actions.js
+++ b/client/state/current-user/gravatar-status/test/actions.js
@@ -19,11 +19,19 @@ import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'actions', () => {
 	let sandbox, spy;
+	const tempImageSrc = 'tempImageSrc';
 	useSandbox( newSandbox => {
 		sandbox = newSandbox;
 		spy = sandbox.spy();
 		global.FormData = sandbox.stub().returns( {
 			append: noop
+		} );
+		global.FileReader = sandbox.stub().returns( {
+			readAsDataURL: noop,
+			addEventListener: function( event, callback ) {
+				this.result = tempImageSrc;
+				callback();
+			}
 		} );
 	} );
 
@@ -47,7 +55,8 @@ describe( 'actions', () => {
 				return uploadGravatar( 'file', 'bearerToken', 'email' )( spy )
 					.then( () => {
 						expect( spy ).to.have.been.calledWith( {
-							type: GRAVATAR_UPLOAD_RECEIVE
+							type: GRAVATAR_UPLOAD_RECEIVE,
+							src: tempImageSrc
 						} );
 					} );
 			} );

--- a/client/state/current-user/gravatar-status/test/reducer.js
+++ b/client/state/current-user/gravatar-status/test/reducer.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	GRAVATAR_UPLOAD_RECEIVE,
 	GRAVATAR_UPLOAD_REQUEST,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
@@ -14,13 +15,15 @@ import {
 	DESERIALIZE
 } from 'state/action-types';
 import reducer, {
-	isUploading
+	isUploading,
+	tempImage
 } from '../reducer';
 
 describe( 'reducer', () => {
 	it( 'exports expected reducer keys', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'isUploading',
+			'tempImage'
 		] );
 	} );
 
@@ -56,6 +59,33 @@ describe( 'reducer', () => {
 			expect( isUploading( true, {
 				type: DESERIALIZE
 			} ) ).to.equal( false );
+		} );
+	} );
+
+	describe( '#tempImage', () => {
+		const imageSrc = 'image';
+
+		it( 'returns empty object by default', () => {
+			const state = tempImage( undefined, {} );
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'returns object with image src when response is received', () => {
+			const state = tempImage( undefined, {
+				type: GRAVATAR_UPLOAD_RECEIVE,
+				src: imageSrc
+			} );
+			expect( state ).to.eql( {
+				src: imageSrc
+			} );
+		} );
+
+		it( 'never persists state', () => {
+			const state = {
+				src: imageSrc
+			};
+			expect( tempImage( state, { type: SERIALIZE } ) ).to.eql( {} );
+			expect( tempImage( state, { type: DESERIALIZE } ) ).to.eql( {} );
 		} );
 	} );
 } );

--- a/client/state/current-user/gravatar-status/test/selectors.js
+++ b/client/state/current-user/gravatar-status/test/selectors.js
@@ -7,7 +7,8 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	isCurrentUserUploadingGravatar
+	isCurrentUserUploadingGravatar,
+	getUserTempGravatar,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -36,6 +37,67 @@ describe( 'selectors', () => {
 			};
 			expect( isCurrentUserUploadingGravatar( notUploadingState ) )
 				.to.equal( false );
+		} );
+	} );
+
+	describe( '#getUserTempGravatar', () => {
+		const imageSrc = 'image';
+		const currentUserId = 1;
+		const anotherUserId = 2;
+
+		it( 'returns false if user ID is not passed in', () => {
+			const state = {
+				currentUser: {
+					gravatarStatus: {
+						tempImage: {
+							src: imageSrc
+						}
+					},
+					id: currentUserId
+				}
+			};
+			expect( getUserTempGravatar( state ) ).to.equal( false );
+		} );
+
+		it( 'returns false if the user ID passed is not the current user ID', () => {
+			const state = {
+				currentUser: {
+					gravatarStatus: {
+						tempImage: {
+							src: imageSrc
+						}
+					},
+					id: currentUserId
+				}
+			};
+			expect( getUserTempGravatar( state, anotherUserId ) ).to.equal( false );
+		} );
+
+		it( 'returns false if the current user does not have temp image set', () => {
+			const emptyTempImage = {
+				currentUser: {
+					gravatarStatus: {
+						tempImage: {}
+					},
+					id: currentUserId
+				}
+			};
+			expect( getUserTempGravatar( emptyTempImage, currentUserId ) )
+				.to.equal( false );
+		} );
+
+		it( 'returns image src if given the current user ID, and the current user has a temp image set', () => {
+			const state = {
+				currentUser: {
+					gravatarStatus: {
+						tempImage: {
+							src: imageSrc
+						}
+					},
+					id: currentUserId
+				}
+			};
+			expect( getUserTempGravatar( state, currentUserId ) ).to.equal( imageSrc );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds the local image to the state, so that it can be used later to display the newly-uploaded Gravatar immediately. The changes to `<Gravatar/>` will come in a subsequent PR.

## How to test
1. Run using `ENABLE_FEATURES=me/edit-gravatar make run`
2. Get a bearer token using this script:
    ```
    curl -# -X POST --data-urlencode "grant_type=password" --data-urlencode "client_id=appid" --data-urlencode "client_secret=appsecret" --data-urlencode "username=username" --data-urlencode "password=password" https://public-api.wordpress.com/oauth2/token
    ```
    You can use Calypso's app ID & secret, found [here](https://github.com/Automattic/wp-calypso/blob/a1c610c300e040a2c101bb5af6a66f7cd72b52d6/config/production.json#L108-L109).
    If you have 2FA enabled, you can add this extra parameter to the call: `--data-urlencode     "wpcom_otp=one-time-password"`, or you can create a new application password to use instead.
3. Save the bearer token to localStorage using `localStorage.setItem('bearerToken', 'your_bearer_token');`
4. Go to `/me` and upload a new Gravatar, see that it gets saved to the state
5. Refresh the page. See that the image gets removed from the state.

## Showing the new image: local image vs cache-busting URL

The problem: after the new Gravatar is uploaded, it does not immediately change in the browser since the GET request for the image has a 5 minute cache directive. In order to have a smooth user experience, I'd like to show the new Gravatar immediately everywhere in Calypso.

We can show the new Gravatar in Calypso in two ways:
1. Use a cache-busting URL to get the browser to download the new image
2. Show the local image the user chose

I opted for the local image for these reasons:
- **A smoother user experience**: the local image can be shown right away and will not require extra time for downloading the new image
- **Better for slower networks**: it's better to reduce the number of network requests when we can. In this case, there's no reason to download the new image from Gravatar.com since we already have it locally

## Limitations
1. Persistence - right now the temporary image is not persisted. This means that it goes away on hard refresh and will not show up in new tabs. I am ok with this limitation for now, and it can be revisited when we have more data (user complaints, stats, etc). If we end up persisting the state, we'll also need to account for Chrome's behaviour ([ref](https://github.com/Automattic/wp-calypso/pull/8456#issuecomment-256493017)) for not re-downloading the Gravatar until refresh.
2. Does not show up in other environments (new browser, different device, etc). This limitation would be present either way - either using cache-busing or the local image. If we cared about solving it, we could persist the image in the database, or change the Gravatar API.

There were two previous discussions on this: [initial discussion](https://github.com/Automattic/wp-calypso/pull/8456#discussion_r83319355), and [more discussion](https://github.com/Automattic/wp-calypso/pull/8456#discussion_r85481764)

cc @gwwar 