### PR TITLE
Revert "Themes: Use Selectors instead of Helpers"

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -4,7 +4,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
-import { isEmpty, isEqual } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Internal dependencies
@@ -62,12 +63,7 @@ const Theme = React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps ) {
-		// TODO: Once we're not using theme.active and theme.purchased anymore, just compare theme.id instead of entire theme objects.
-		return ! isEqual( nextProps.theme, this.props.theme ) ||
-			! isEqual( nextProps.buttonContents, this.props.buttonContents ) ||
-			( nextProps.screenshotClickUrl !== this.props.screenshotClickUrl ) ||
-			( nextProps.onScreenshotClick !== this.props.onScreenshotClick ) ||
-			( nextProps.onMoreButtonClick !== this.props.onMoreButtonClick );
+		return ! isEqual( nextProps.theme, this.props.theme );
 	},
 
 	getDefaultProps() {
@@ -135,7 +131,7 @@ const Theme = React.createClass( {
 							? <img className="theme__img"
 								src={ screenshot + '?w=' + screenshotWidth }
 								onClick={ this.onScreenshotClick }
-								id={ screenshotID } />
+								id={ screenshotID }/>
 							: <div className="theme__no-screenshot" >
 								<Gridicon icon="themes" size={ 48 } />
 							</div>

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -3,8 +3,9 @@
  */
 import React from 'react';
 import times from 'lodash/times';
+import isEqual from 'lodash/isEqual';
 import { localize } from 'i18n-calypso';
-import { identity, isEqual } from 'lodash';
+import identity from 'lodash/identity';
 import { connect } from 'react-redux';
 
 /**
@@ -64,12 +65,8 @@ export const ThemesList = React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps ) {
-		return nextProps.loading !== this.props.loading ||
-			! isEqual( nextProps.themes, this.props.themes ) ||
-			( nextProps.getButtonOptions, this.props.getButtonOptions ) ||
-			( nextProps.getScreenshotUrl !== this.props.getScreenshotUrl ) ||
-			( nextProps.onScreenshotClick !== this.props.onScreenshotClick ) ||
-			( nextProps.onMoreButtonClick !== this.props.onMoreButtonClick );
+		return this.props.loading !== nextProps.loading ||
+			! isEqual( this.props.themes, nextProps.themes );
 	},
 
 	renderTheme( theme, index ) {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -36,7 +36,15 @@ import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCurrentTheme from 'components/data/query-current-theme';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
-import { connectOptions } from 'my-sites/themes/theme-options';
+import {
+	signup,
+	purchase,
+	activate,
+	customize,
+	tryandcustomize,
+	bindOptionsToDispatch,
+	bindOptionsToSite
+} from 'my-sites/themes/theme-options';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import ThemePreview from 'my-sites/themes/theme-preview';
@@ -70,23 +78,20 @@ const ThemeSheet = React.createClass( {
 		siteSlug: React.PropTypes.string,
 		backPath: React.PropTypes.string,
 		defaultOption: React.PropTypes.shape( {
-			label: React.PropTypes.string,
+			label: React.PropTypes.string.isRequired,
 			action: React.PropTypes.func,
 			getUrl: React.PropTypes.func,
 		} ),
 		secondaryOption: React.PropTypes.shape( {
-			label: React.PropTypes.string,
+			label: React.PropTypes.string.isRequired,
 			action: React.PropTypes.func,
 			getUrl: React.PropTypes.func,
 		} ),
 	},
 
 	getDefaultProps() {
-		// The defaultOption default prop is surprisingly important, see the long
-		// comment near the connect() function at the bottom of this file.
 		return {
 			section: '',
-			defaultOption: {}
 		};
 	},
 
@@ -321,26 +326,14 @@ const ThemeSheet = React.createClass( {
 		return <ThemeDownloadCard theme={ this.props.id } href={ this.props.download } />;
 	},
 
-	getDefaultOptionLabel() {
-		const { defaultOption, active: isActive, isLoggedIn, price } = this.props;
-		if ( isLoggedIn && ! isActive ) {
-			if ( price ) { // purchase
-				return i18n.translate( 'Pick this design' );
-			} // else: activate
-			return i18n.translate( 'Activate this design' );
-		}
-		return defaultOption.label;
-	},
-
 	renderPreview() {
-		const { active, isLoggedIn, defaultOption, secondaryOption } = this.props;
-
+		const { secondaryOption, active, isLoggedIn, defaultOption } = this.props;
 		const showSecondaryButton = secondaryOption && ! active && isLoggedIn;
 		return (
 			<ThemePreview showPreview={ this.state.showPreview }
 				theme={ this.props }
 				onClose={ this.togglePreview }
-				primaryButtonLabel={ this.getDefaultOptionLabel() }
+				primaryButtonLabel={ defaultOption.label }
 				getPrimaryButtonHref={ defaultOption.getUrl }
 				onPrimaryButtonClick={ this.onButtonClick }
 				secondaryButtonLabel={ showSecondaryButton ? secondaryOption.label : null }
@@ -386,8 +379,7 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderButton() {
-		const { getUrl } = this.props.defaultOption;
-		const label = this.getDefaultOptionLabel();
+		const { label, getUrl } = this.props.defaultOption;
 		const placeholder = <span className="theme__sheet-button-placeholder">loading......</span>;
 
 		return (
@@ -473,88 +465,61 @@ const ThemeSheet = React.createClass( {
 	},
 } );
 
-const ConnectedThemeSheet = connectOptions(
-	( props ) => {
-		if ( ! props.isLoggedIn || props.selectedSite ) {
-			return <ThemeSheet { ...props } />;
-		}
-
-		return (
-			<ThemesSiteSelectorModal { ...props }
-				sourcePath={ `/theme/${ props.id }${ props.section ? '/' + props.section : '' }` }>
-				<ThemeSheet />
-			</ThemesSiteSelectorModal>
-		);
+const WrappedThemeSheet = ( props ) => {
+	if ( ! props.isLoggedIn || props.selectedSite ) {
+		return <ThemeSheet { ...props } />;
 	}
-);
 
-const ThemeSheetWithOptions = ( props ) => {
-	const { selectedSite: site, active: isActive, price, isLoggedIn } = props;
+	return (
+		<ThemesSiteSelectorModal { ...props }
+			sourcePath={ `/theme/${ props.id }${ props.section ? '/' + props.section : '' }` }>
+			<ThemeSheet />
+		</ThemesSiteSelectorModal>
+	);
+};
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const { selectedSite: site, active: isActive, price, isLoggedIn } = stateProps;
 
 	let defaultOption;
 
 	if ( ! isLoggedIn ) {
-		defaultOption = 'signup';
+		defaultOption = dispatchProps.signup;
 	} else if ( isActive ) {
-		defaultOption = 'customize';
+		defaultOption = dispatchProps.customize;
 	} else if ( price ) {
-		defaultOption = 'purchase';
+		defaultOption = dispatchProps.purchase;
+		defaultOption.label = i18n.translate( 'Pick this design' );
 	} else {
-		defaultOption = 'activate';
+		defaultOption = dispatchProps.activate;
+		defaultOption.label = i18n.translate( 'Activate this design' );
 	}
 
-	return (
-		<ConnectedThemeSheet { ...props }
-			site={ site }
-			theme={ props /* TODO: Have connectOptions() only use theme ID */ }
-			options={ [
-				'signup',
-				'customize',
-				'tryandcustomize',
-				'purchase',
-				'activate'
-			] }
-			defaultOption={ defaultOption }
-			secondaryOption="tryandcustomize"
-			source="showcase-sheet" />
+	const dispatchOptions = {
+		defaultOption,
+		secondaryOption: dispatchProps.tryandcustomize
+	};
+
+	return Object.assign(
+		{},
+		ownProps,
+		stateProps,
+		site ? bindOptionsToSite( dispatchOptions, site ) : dispatchOptions,
 	);
 };
 
 export default connect(
-	/*
-	 * A number of the props that this mapStateToProps function computes are used
-	 * by ThemeSheetWithOptions to compute defaultOption. After a state change
-	 * triggered by an async action, connect()ed child components are, quite
-	 * counter-intuitively, updated before their connect()ed parents (this is
-	 * https://github.com/reactjs/redux/issues/1415), and might be fixed by
-	 * react-redux 5.0.
-	 * For this reason, after e.g. activating a theme in single-site mode,
-	 * first the ThemeSheetWithOptions component's (child) connectOptions component
-	 * will update in response to the currently displayed theme being activated.
-	 * Doing so, it will filter and remove the activate option (adding customize
-	 * instead). However, since the parent connect()ed-ThemeSheetWithOptions will
-	 * only react to the state change afterwards, there is a brief moment when
-	 * connectOptions still receives "activate" as its defaultOption prop, when
-	 * activate is no longer part of its filtered options set, hence passing on
-	 * undefined as the defaultOption object prop for its child. For the theme
-	 * sheet, which eventually gets that defaultOption object prop, this means
-	 * we must be careful to not accidentally access any attribute of that
-	 * defaultOption prop. Otherwise, there will be an error that will prevent the
-	 * state update from finishing properly, hence not updating defaultOption at all.
-	 * The solution to this incredibly intricate issue is simple: Give ThemeSheet
-	 * a valid defaultProp for defaultOption.
-	 */
-	( state, { id } ) => {
+	( state, props ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
-		const themeDetails = getThemeDetails( state, id );
+		const themeDetails = getThemeDetails( state, props.id );
 
 		return {
 			...themeDetails,
-			id,
+			id: props.id,
 			selectedSite,
 			siteSlug,
 			backPath,
@@ -562,5 +527,13 @@ export default connect(
 			isCurrentUserPaid,
 			isLoggedIn: !! currentUserId,
 		};
-	}
-)( ThemeSheetWithOptions );
+	},
+	bindOptionsToDispatch( {
+		signup,
+		customize,
+		tryandcustomize,
+		purchase,
+		activate,
+	}, 'showcase-sheet' ),
+	mergeProps
+)( WrappedThemeSheet );

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -1,10 +1,6 @@
 /** @ssr-ready **/
 
 /**
- * DEPRECATED. Use client/state/themes/selectors instead.
- */
-
-/**
  * External dependencies
  */
 import analytics from 'lib/analytics';

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -1,29 +1,42 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import ThemeShowcase from './theme-showcase';
-import { connectOptions } from './theme-options';
+import {
+	preview,
+	signup,
+	separator,
+	info,
+	support,
+	help,
+	bindOptionsToDispatch
+} from './theme-options';
 
-const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
-
-export default props => (
-	<ConnectedThemeShowcase { ...props }
-	options={ [
-		'signup',
-		'preview',
-		'separator',
-		'info',
-		'support',
-		'help'
-	] }
-	defaultOption="signup"
-	getScreenshotOption={ function() {
-		return 'info';
-	} }
-	source="showcase" />
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => Object.assign(
+	{},
+	ownProps,
+	stateProps,
+	{
+		options: dispatchProps,
+		defaultOption: dispatchProps.signup,
+		getScreenshotOption: () => dispatchProps.info
+	}
 );
+
+export default connect(
+	null,
+	bindOptionsToDispatch( {
+		signup,
+		preview,
+		separator,
+		info,
+		support,
+		help
+	}, 'showcase' ),
+	mergeProps
+)( ThemeShowcase );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -2,40 +2,57 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
-import { connectOptions } from './theme-options';
+import {
+	preview,
+	purchase,
+	activate,
+	tryandcustomize,
+	separator,
+	info,
+	support,
+	help,
+	bindOptionsToDispatch
+} from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
-const MultiSiteThemeShowcase = connectOptions(
-	( props ) => (
-		<ThemesSiteSelectorModal { ...props } sourcePath="/design">
-			<ThemeShowcase source="showcase">
-				<SidebarNavigation />
-			</ThemeShowcase>
-		</ThemesSiteSelectorModal>
-	)
+const ThemesMultiSite = props => (
+	<ThemesSiteSelectorModal { ...props } sourcePath="/design">
+		<ThemeShowcase { ...props }>
+			<SidebarNavigation />
+		</ThemeShowcase>
+	</ThemesSiteSelectorModal>
 );
 
-export default ( props ) => (
-	<MultiSiteThemeShowcase { ...props }
-		options={ [
-			'preview',
-			'purchase',
-			'activate',
-			'tryandcustomize',
-			'separator',
-			'info',
-			'support',
-			'help',
-		] }
-		defaultOption="activate"
-		secondaryOption="tryandcustomize"
-		getScreenshotOption={ function() {
-			return 'info';
-		} } />
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => Object.assign(
+	{},
+	ownProps,
+	stateProps,
+	{
+		options: dispatchProps,
+		defaultOption: dispatchProps.activate,
+		secondaryOption: dispatchProps.tryandcustomize,
+		getScreenshotOption: () => dispatchProps.info
+	}
 );
+
+export default connect(
+	null,
+	bindOptionsToDispatch( {
+		preview,
+		purchase,
+		activate,
+		tryandcustomize,
+		separator,
+		info,
+		support,
+		help,
+	}, 'showcase' ),
+	mergeProps
+)( ThemesMultiSite );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -4,9 +4,8 @@
  * External dependencies
  */
 import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
-import { has, identity, mapValues, pick, pickBy } from 'lodash';
+import mapValues from 'lodash/mapValues';
 
 /**
  * Internal dependencies
@@ -19,18 +18,15 @@ import {
 	isPremiumTheme as isPremium
 } from 'state/themes/utils';
 import {
-	getThemeSignupUrl as getSignupUrl,
-	getThemePurchaseUrl as getPurchaseUrl,
-	getThemeCustomizeUrl as	getCustomizeUrl,
-	getThemeDetailsUrl as getDetailsUrl,
-	getThemeSupportUrl as getSupportUrl,
-	getThemeHelpUrl as getHelpUrl
-} from 'state/themes/selectors';
-import { isActiveTheme as isActive } from 'state/themes/current-theme/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
+	getSignupUrl,
+	getPurchaseUrl,
+	getCustomizeUrl,
+	getDetailsUrl,
+	getSupportUrl,
+	getHelpUrl
+} from './helpers';
 
-const purchase = config.isEnabled( 'upgrades/checkout' )
+export const purchase = config.isEnabled( 'upgrades/checkout' )
 	? {
 		label: i18n.translate( 'Purchase', {
 			context: 'verb'
@@ -39,163 +35,113 @@ const purchase = config.isEnabled( 'upgrades/checkout' )
 			context: 'verb',
 			comment: 'label for selecting a site for which to purchase a theme'
 		} ),
-		getUrl: getPurchaseUrl,
-		hideForTheme: ( state, theme, site ) => ! theme.price || isActive( state, theme.id, site ) || theme.purchased
+		getUrl: ( theme, site ) => getPurchaseUrl( theme, site ),
+		hideForTheme: theme => ! theme.price || theme.active || theme.purchased
 	}
 	: {};
 
-const activate = {
+export const activate = {
 	label: i18n.translate( 'Activate' ),
 	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
 	action: activateAction,
-	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site ) || ( theme.price && ! theme.purchased )
+	hideForTheme: theme => theme.active || ( theme.price && ! theme.purchased )
 };
 
-const customize = {
+export const customize = {
 	label: i18n.translate( 'Customize' ),
 	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a site for which to customize a theme' } ),
 	icon: 'customize',
-	getUrl: getCustomizeUrl,
-	hideForSite: ( state, site ) => ! canCurrentUser( state, site, 'edit_theme_options' ),
-	hideForTheme: ( state, theme, site ) => ! isActive( state, theme.id, site )
+	getUrl: ( theme, site ) => getCustomizeUrl( theme, site ),
+	hideForSite: ( { isCustomizable = false } = {} ) => ! isCustomizable,
+	hideForTheme: theme => ! theme.active
 };
 
-const tryandcustomize = {
+export const tryandcustomize = {
 	label: i18n.translate( 'Try & Customize' ),
 	header: i18n.translate( 'Try & Customize on:', {
 		comment: 'label in the dialog for opening the Customizer with the theme in preview'
 	} ),
-	getUrl: getCustomizeUrl,
-	hideForSite: ( state, site ) => ! canCurrentUser( state, site, 'edit_theme_options' ),
-	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site )
+	getUrl: ( theme, site ) => getCustomizeUrl( theme, site ),
+	hideForSite: ( { isCustomizable = false } = {} ) => ! isCustomizable,
+	hideForTheme: theme => theme.active
 };
 
 // This is a special option that gets its `action` added by `ThemeShowcase` or `ThemeSheet`,
 // respectively. TODO: Replace with a real action once we're able to use `SitePreview`.
-const preview = {
+export const preview = {
 	label: i18n.translate( 'Live demo', {
 		comment: 'label for previewing the theme demo website'
 	} ),
-	hideForSite: ( state, site ) => isJetpackSite( state, site ),
-	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site )
+	hideForSite: ( { isJetpack = false } = {} ) => isJetpack,
+	hideForTheme: theme => theme.active
 };
 
-const signup = {
+export const signup = {
 	label: i18n.translate( 'Pick this design', {
 		comment: 'when signing up for a WordPress.com account with a selected theme'
 	} ),
-	getUrl: getSignupUrl
+	getUrl: theme => getSignupUrl( theme )
 };
 
-const separator = {
+export const separator = {
 	separator: true
 };
 
-const info = {
+export const info = {
 	label: i18n.translate( 'Info', {
 		comment: 'label for displaying the theme info sheet'
 	} ),
 	icon: 'info',
-	getUrl: getDetailsUrl,
+	getUrl: ( theme, site ) => getDetailsUrl( theme, site ), // TODO: Make this a selector
 };
 
-const support = {
+export const support = {
 	label: i18n.translate( 'Setup' ),
 	icon: 'help',
-	getUrl: getSupportUrl,
+	getUrl: ( theme, site ) => getSupportUrl( theme, site ),
 	// We don't know where support docs for a given theme on a self-hosted WP install are.
-	hideForSite: ( state, site ) => isJetpackSite( state, site ),
-	hideForTheme: ( state, theme ) => ! isPremium( theme )
+	hideForSite: ( { isJetpack = false } = {} ) => isJetpack,
+	hideForTheme: theme => ! isPremium( theme )
 };
 
-const help = {
+export const help = {
 	label: i18n.translate( 'Support' ),
-	getUrl: getHelpUrl,
+	getUrl: ( theme, site ) => getHelpUrl( theme, site ),
 	// We don't know where support docs for a given theme on a self-hosted WP install are.
-	hideForSite: ( state, site ) => isJetpackSite( state, site ),
+	hideForSite: ( { isJetpack = false } = {} ) => isJetpack,
 };
 
-const ALL_THEME_OPTIONS = {
-	customize,
-	preview,
-	purchase,
-	activate,
-	tryandcustomize,
-	signup,
-	separator,
-	info,
-	support,
-	help
-};
+export function bindOptionToDispatch( option, source ) {
+	return dispatch => Object.assign(
+		{},
+		option,
+		option.action
+			? { action: bindActionCreators(
+				( theme, site ) => option.action( theme, site, source ),
+				dispatch
+				) }
+			: {}
+	);
+}
 
-const ALL_THEME_ACTIONS = { activate: activateAction }; // All theme related actions available.
+export function bindOptionsToDispatch( options, source ) {
+	return dispatch => mapValues( options, option => bindOptionToDispatch( option, source )( dispatch ) );
+}
 
-export const connectOptions = connect(
-	( state, { options: optionNames, site } ) => {
-		let options = pick( ALL_THEME_OPTIONS, optionNames );
-		let mapGetUrl = identity, mapHideForSite = identity;
+// Ideally: same sig as mergeProps. stateProps, dispatchProps, ownProps
+function bindOptionToSite( option, site ) {
+	return Object.assign(
+		{},
+		option,
+		option.action
+			? { action: theme => option.action( theme, site ) }
+			: {},
+		option.getUrl
+			? { getUrl: theme => option.getUrl( theme, site ) }
+			: {}
+	);
+}
 
-		// We bind hideForTheme to site even if it is null since the selectors
-		// that are used by it are expected to recognize that case as "no site selected"
-		// and work accordingly.
-		const mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, site ? site.ID : null );
-
-		if ( site ) {
-			const siteId = site.ID;
-
-			mapGetUrl = getUrl => ( t ) => getUrl( state, t, siteId );
-			options = pickBy( options, option =>
-				! ( option.hideForSite && option.hideForSite( state, siteId ) )
-			);
-		} else {
-			mapGetUrl = getUrl => ( t, s ) => getUrl( state, t, s );
-			mapHideForSite = hideForSite => ( s ) => hideForSite( state, s );
-		}
-
-		return mapValues( options, option => Object.assign(
-			{},
-			option,
-			option.getUrl
-				? { getUrl: mapGetUrl( option.getUrl ) }
-				: {},
-			option.hideForSite
-				? { hideForSite: mapHideForSite( option.hideForSite ) }
-				: {},
-			option.hideForTheme
-				? { hideForTheme: mapHideForTheme( option.hideForTheme ) }
-				: {}
-		) );
-	},
-	( dispatch, { site, source = 'unknown' } ) => {
-		let mapAction;
-
-		if ( site ) {
-			// TODO (@ockham): Change actions to use siteId.
-			mapAction = action => ( t ) => action( t, site, source );
-		} else { // Bind only source.
-			mapAction = action => ( t, s ) => action( t, s, source );
-		}
-
-		return bindActionCreators(
-			mapValues( ALL_THEME_ACTIONS, action => mapAction( action ) ),
-			dispatch
-		);
-	},
-	( options, actions, ownProps ) => {
-		const { defaultOption, secondaryOption, getScreenshotOption } = ownProps;
-		options = mapValues( options, ( option, name ) => {
-			if ( has( actions, name ) ) {
-				return { ...option, action: actions[ name ] };
-			}
-			return option;
-		} );
-
-		return {
-			...ownProps,
-			options,
-			defaultOption: options[ defaultOption ],
-			secondaryOption: secondaryOption ? options[ secondaryOption ] : null,
-			getScreenshotOption: ( theme ) => options[ getScreenshotOption( theme ) ]
-		};
-	}
-);
+export function bindOptionsToSite( options, site ) {
+	return mapValues( options, option => bindOptionToSite( option, site ) );
+}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -170,9 +170,8 @@ const ThemeShowcase = React.createClass( {
 	}
 } );
 
-export default connect(
-	state => ( {
-		queryParams: getQueryParams( state ),
-		themesList: getThemesList( state ),
-	} )
+export default connect( state => ( {
+	queryParams: getQueryParams( state ),
+	themesList: getThemesList( state )
+} )
 )( localize( ThemeShowcase ) );

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -14,19 +14,14 @@ import Theme from 'components/theme';
 import SiteSelectorModal from 'components/site-selector-modal';
 import { trackClick } from './helpers';
 
-const OPTION_SHAPE = PropTypes.shape( {
-	label: PropTypes.string,
-	header: PropTypes.string,
-	getUrl: PropTypes.func,
-	action: PropTypes.func
-} );
-
 const ThemesSiteSelectorModal = React.createClass( {
 	propTypes: {
-		children: PropTypes.element,
-		options: PropTypes.objectOf( OPTION_SHAPE ),
-		defaultOption: OPTION_SHAPE,
-		secondaryOption: OPTION_SHAPE,
+		options: React.PropTypes.objectOf( React.PropTypes.shape( {
+			label: React.PropTypes.string,
+			header: React.PropTypes.string,
+			action: React.PropTypes.func
+		} ) ),
+		selectedSite: React.PropTypes.object,
 		// Will be prepended to site slug for a redirect on selection
 		sourcePath: PropTypes.string.isRequired,
 	},
@@ -107,7 +102,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 					mainAction={ this.trackAndCallAction }
 					mainActionLabel={ selectedOption.label }
 					getMainUrl={ selectedOption.getUrl ? function( site ) {
-						return selectedOption.getUrl( selectedTheme, site.ID );
+						return selectedOption.getUrl( selectedTheme, site );
 					} : null } >
 
 					<Theme isActionable={ false } theme={ selectedTheme } />

--- a/client/state/themes/current-theme/selectors.js
+++ b/client/state/themes/current-theme/selectors.js
@@ -4,11 +4,6 @@ export function getCurrentTheme( state, siteId ) {
 	return state.themes.currentTheme.get( 'currentThemes' ).get( siteId );
 }
 
-export function isActiveTheme( state, themeId, siteId ) {
-	const theme = getCurrentTheme( state, siteId );
-	return theme && theme.id === themeId;
-}
-
 export function isActivating( state ) {
 	return state.themes.currentTheme.get( 'isActivating' );
 }

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -150,13 +150,6 @@ export function getThemeSignupUrl( state, theme ) {
 /**
  * Returns the currently active theme on a given site.
  *
- * DON'T USE YET! This relies on a site object's options.theme_slug attr. If you trigger my-sites' siteSelection
- * middleware during theme activation, it will fetch the current site fresh from the API even though that
- * theme_slug attr might not have been updated on the server yet -- and you'll end up with the old themeId!
- * This happens in particular after purchasing a premium theme in single-site mode since after a theme purchase,
- * the checkout-thank-you component always redirects to the theme showcase for the current site.
- * One possible fix would be to get rid of that redirect (related: https://github.com/Automattic/wp-calypso/issues/8262).
- *
  * @param  {Object}  state   Global state tree
  * @param  {Number}  siteId  Site ID
  * @return {?String}         Theme ID
@@ -184,8 +177,6 @@ export function getActiveTheme( state, siteId ) {
 /**
  * Returns whether the theme is currently active on the given site.
  *
- * DON'T USE YET! This relies on the getActiveTheme() selector; see its JSDoc.
- *
  * @param  {Object}  state   Global state tree
  * @param  {String}  themeId Theme ID
  * @param  {Number}  siteId  Site ID
@@ -199,8 +190,6 @@ export function isThemeActive( state, themeId, siteId ) {
  * Returns whether the theme has been purchased for the given site.
  *
  * Use this selector alongside with the <QuerySitePurchases /> component.
- *
- * DON'T USE YET! This uses the getSitePurchases() which sometimes seems to omit some purchases.
  *
  * @param  {Object}  state   Global state tree
  * @param  {String}  themeId Theme ID


### PR DESCRIPTION
Reverts Automattic/wp-calypso#6924

@seear found a (somewhat hard-to-repro) bug while testing on staging.