### PR TITLE
Themes: Use Selectors instead of Helpers, take two

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -4,8 +4,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
-import isEmpty from 'lodash/isEmpty';
-import isEqual from 'lodash/isEqual';
+import { isEmpty, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -63,7 +62,12 @@ const Theme = React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps ) {
-		return ! isEqual( nextProps.theme, this.props.theme );
+		// TODO: Once we're not using theme.active and theme.purchased anymore, just compare theme.id instead of entire theme objects.
+		return ! isEqual( nextProps.theme, this.props.theme ) ||
+			! isEqual( nextProps.buttonContents, this.props.buttonContents ) ||
+			( nextProps.screenshotClickUrl !== this.props.screenshotClickUrl ) ||
+			( nextProps.onScreenshotClick !== this.props.onScreenshotClick ) ||
+			( nextProps.onMoreButtonClick !== this.props.onMoreButtonClick );
 	},
 
 	getDefaultProps() {
@@ -131,7 +135,7 @@ const Theme = React.createClass( {
 							? <img className="theme__img"
 								src={ screenshot + '?w=' + screenshotWidth }
 								onClick={ this.onScreenshotClick }
-								id={ screenshotID }/>
+								id={ screenshotID } />
 							: <div className="theme__no-screenshot" >
 								<Gridicon icon="themes" size={ 48 } />
 							</div>

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -3,9 +3,8 @@
  */
 import React from 'react';
 import times from 'lodash/times';
-import isEqual from 'lodash/isEqual';
 import { localize } from 'i18n-calypso';
-import identity from 'lodash/identity';
+import { identity, isEqual } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -65,8 +64,12 @@ export const ThemesList = React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps ) {
-		return this.props.loading !== nextProps.loading ||
-			! isEqual( this.props.themes, nextProps.themes );
+		return nextProps.loading !== this.props.loading ||
+			! isEqual( nextProps.themes, this.props.themes ) ||
+			( nextProps.getButtonOptions, this.props.getButtonOptions ) ||
+			( nextProps.getScreenshotUrl !== this.props.getScreenshotUrl ) ||
+			( nextProps.onScreenshotClick !== this.props.onScreenshotClick ) ||
+			( nextProps.onMoreButtonClick !== this.props.onMoreButtonClick );
 	},
 
 	renderTheme( theme, index ) {

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -4,24 +4,15 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import map from 'lodash/map';
-import pickBy from 'lodash/pickBy';
+import { map, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 import CurrentThemeButton from './button';
-import {
-	customize,
-	info,
-	support,
-	bindOptionsToDispatch,
-	bindOptionsToSite
-} from '../theme-options';
+import { connectOptions } from '../theme-options';
 import { trackClick } from '../helpers';
-import { isJetpackSite } from 'state/sites/selectors';
-import { canCurrentUser } from 'state/current-user/selectors';
 import { getCurrentTheme } from 'state/themes/current-theme/selectors';
 import QueryCurrentTheme from 'components/data/query-current-theme';
 
@@ -42,8 +33,6 @@ const CurrentTheme = React.createClass( {
 			PropTypes.bool
 		] ).isRequired,
 		// connected props
-		isCustomizable: PropTypes.bool.isRequired,
-		isJetpack: PropTypes.bool.isRequired,
 		currentTheme: PropTypes.object
 	},
 
@@ -54,9 +43,13 @@ const CurrentTheme = React.createClass( {
 			placeholderText = <span className="current-theme__placeholder">loading...</span>,
 			text = ( currentTheme && currentTheme.name ) ? currentTheme.name : placeholderText;
 
+		const options = pickBy( this.props.options, option =>
+			currentTheme && ! ( option.hideForTheme && option.hideForTheme( currentTheme ) )
+		);
+
 		return (
 			<Card className="current-theme">
-				{ site && <QueryCurrentTheme siteId={ site.ID }/> }
+				{ site && <QueryCurrentTheme siteId={ site.ID } /> }
 				<div className="current-theme__current">
 					<span className="current-theme__label">
 						{ this.translate( 'Current Theme' ) }
@@ -67,12 +60,11 @@ const CurrentTheme = React.createClass( {
 				</div>
 				<div className={ classNames(
 					'current-theme__actions',
-					{ 'two-buttons': Object.keys( this.props.options ).length === 2 }
+					{ 'two-buttons': Object.keys( options ).length === 2 }
 					) } >
-					{ map( this.props.options, ( option, name ) => (
-						<CurrentThemeButton
+					{ map( options, ( option, name ) => (
+						<CurrentThemeButton name={ name }
 							key={ name }
-							name={ name }
 							label={ option.label }
 							icon={ option.icon }
 							href={ currentTheme && option.getUrl( currentTheme ) }
@@ -84,39 +76,21 @@ const CurrentTheme = React.createClass( {
 	}
 } );
 
-const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const { site } = ownProps;
-	// FIXME (ockham): Remove this ugly hack. Currently required since the endpoint doesn't return an `active` attr
-	const theme = Object.assign( {}, stateProps.currentTheme, { active: true } );
+const ConnectedCurrentTheme = connectOptions( CurrentTheme );
 
-	const filteredOptions = pickBy( dispatchProps, option =>
-		! ( option.hideForSite && option.hideForSite( stateProps ) ) &&
-		! ( option.hideForTheme && option.hideForTheme( theme ) )
-	);
-
-	return Object.assign(
-		{},
-		ownProps,
-		stateProps,
-		{
-			options: bindOptionsToSite( filteredOptions, site )
-		}
-	);
-};
+const CurrentThemeWithOptions = ( { site, currentTheme } ) => (
+	<ConnectedCurrentTheme currentTheme={ currentTheme }
+		site={ site }
+		options={ [
+			'customize',
+			'info',
+			'support'
+		] }
+		source="current theme" />
+);
 
 export default connect(
-	( state, props ) => {
-		const { site: selectedSite } = props;
-		return {
-			isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
-			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' ),
-			currentTheme: selectedSite && getCurrentTheme( state, selectedSite.ID )
-		};
-	},
-	bindOptionsToDispatch( {
-		customize,
-		info,
-		support
-	}, 'current theme' ),
-	mergeProps
-)( CurrentTheme );
+	( state, { site } ) => ( {
+		currentTheme: site && getCurrentTheme( state, site.ID )
+	} )
+)( CurrentThemeWithOptions );

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -1,6 +1,10 @@
 /** @ssr-ready **/
 
 /**
+ * DEPRECATED. Use client/state/themes/selectors instead.
+ */
+
+/**
  * External dependencies
  */
 import analytics from 'lib/analytics';

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -1,42 +1,29 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import ThemeShowcase from './theme-showcase';
-import {
-	preview,
-	signup,
-	separator,
-	info,
-	support,
-	help,
-	bindOptionsToDispatch
-} from './theme-options';
+import { connectOptions } from './theme-options';
 
-const mergeProps = ( stateProps, dispatchProps, ownProps ) => Object.assign(
-	{},
-	ownProps,
-	stateProps,
-	{
-		options: dispatchProps,
-		defaultOption: dispatchProps.signup,
-		getScreenshotOption: () => dispatchProps.info
-	}
+const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
+
+export default props => (
+	<ConnectedThemeShowcase { ...props }
+	options={ [
+		'signup',
+		'preview',
+		'separator',
+		'info',
+		'support',
+		'help'
+	] }
+	defaultOption="signup"
+	getScreenshotOption={ function() {
+		return 'info';
+	} }
+	source="showcase" />
 );
-
-export default connect(
-	null,
-	bindOptionsToDispatch( {
-		signup,
-		preview,
-		separator,
-		info,
-		support,
-		help
-	}, 'showcase' ),
-	mergeProps
-)( ThemeShowcase );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -2,57 +2,40 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
-import {
-	preview,
-	purchase,
-	activate,
-	tryandcustomize,
-	separator,
-	info,
-	support,
-	help,
-	bindOptionsToDispatch
-} from './theme-options';
+import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
-const ThemesMultiSite = props => (
-	<ThemesSiteSelectorModal { ...props } sourcePath="/design">
-		<ThemeShowcase { ...props }>
-			<SidebarNavigation />
-		</ThemeShowcase>
-	</ThemesSiteSelectorModal>
+const MultiSiteThemeShowcase = connectOptions(
+	( props ) => (
+		<ThemesSiteSelectorModal { ...props } sourcePath="/design">
+			<ThemeShowcase source="showcase">
+				<SidebarNavigation />
+			</ThemeShowcase>
+		</ThemesSiteSelectorModal>
+	)
 );
 
-const mergeProps = ( stateProps, dispatchProps, ownProps ) => Object.assign(
-	{},
-	ownProps,
-	stateProps,
-	{
-		options: dispatchProps,
-		defaultOption: dispatchProps.activate,
-		secondaryOption: dispatchProps.tryandcustomize,
-		getScreenshotOption: () => dispatchProps.info
-	}
+export default ( props ) => (
+	<MultiSiteThemeShowcase { ...props }
+		options={ [
+			'preview',
+			'purchase',
+			'activate',
+			'tryandcustomize',
+			'separator',
+			'info',
+			'support',
+			'help',
+		] }
+		defaultOption="activate"
+		secondaryOption="tryandcustomize"
+		getScreenshotOption={ function() {
+			return 'info';
+		} } />
 );
-
-export default connect(
-	null,
-	bindOptionsToDispatch( {
-		preview,
-		purchase,
-		activate,
-		tryandcustomize,
-		separator,
-		info,
-		support,
-		help,
-	}, 'showcase' ),
-	mergeProps
-)( ThemesMultiSite );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import pickBy from 'lodash/pickBy';
 
 /**
  * Internal dependencies
@@ -17,19 +16,7 @@ import config from 'config';
 import EmptyContent from 'components/empty-content';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
-import {
-	customize,
-	preview,
-	purchase,
-	activate,
-	tryandcustomize,
-	separator,
-	info,
-	support,
-	help,
-	bindOptionsToDispatch,
-	bindOptionsToSite
-} from './theme-options';
+import { connectOptions } from './theme-options';
 import sitesFactory from 'lib/sites-list';
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
@@ -44,11 +31,9 @@ const sites = sitesFactory();
 const JetpackThemeReferrerPage = localize(
 	( { translate, site, analyticsPath, analyticsPageTitle } ) => (
 		<Main className="themes">
-			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle }/>
+			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 			<SidebarNavigation />
-			<CurrentTheme
-				site={ site }
-				canCustomize={ site && site.isCustomizable() } />
+			<CurrentTheme site={ site } />
 			<EmptyContent title={ translate( 'Changing Themes?' ) }
 				line={ translate( 'Use your site theme browser to manage themes.' ) }
 				action={ translate( 'Open Site Theme Browser' ) }
@@ -59,9 +44,34 @@ const JetpackThemeReferrerPage = localize(
 	)
 );
 
-const ThemesSingleSite = ( props ) => {
+const SingleSiteThemeShowcase = connectOptions(
+	localize(
+		( props ) => {
+			const site = sites.getSelectedSite(),
+				{ translate } = props;
+
+			return (
+				<ThemeShowcase { ...props } siteId={ site && site.ID }>
+					<SidebarNavigation />
+					<ThanksModal
+						site={ site }
+						source={ 'list' } />
+					<CurrentTheme site={ site } />
+					<UpgradeNudge
+						title={ translate( 'Get Custom Design with Premium' ) }
+						message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }
+						feature={ FEATURE_ADVANCED_DESIGN }
+						event="themes_custom_design"
+					/>
+				</ThemeShowcase>
+			);
+		}
+	)
+);
+
+const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 	const site = sites.getSelectedSite(),
-		{ analyticsPath, analyticsPageTitle, isJetpack, translate } = props,
+		{ analyticsPath, analyticsPageTitle, isJetpack } = props,
 		jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
 	// If we've only just switched from single to multi-site, there's a chance
@@ -76,7 +86,7 @@ const ThemesSingleSite = ( props ) => {
 			return (
 				<JetpackThemeReferrerPage site={ site }
 					analyticsPath={ analyticsPath }
-					analyticsPageTitle={ analyticsPageTitle }/>
+					analyticsPageTitle={ analyticsPageTitle } />
 			);
 		}
 		if ( ! site.hasJetpackThemes ) {
@@ -88,66 +98,35 @@ const ThemesSingleSite = ( props ) => {
 	}
 
 	return (
-		<ThemeShowcase { ...props } siteId={ site && site.ID }>
-			<SidebarNavigation />
-			<ThanksModal
-				site={ site }
-				source={ 'list' }/>
-			<CurrentTheme
-				site={ site }
-				canCustomize={ site && site.isCustomizable() } />
-			<UpgradeNudge
-				title={ translate( 'Get Custom Design with Premium' ) }
-				message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }
-				feature={ FEATURE_ADVANCED_DESIGN }
-				event="themes_custom_design"
-			/>
-		</ThemeShowcase>
-	);
-};
-
-const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const { selectedSite: site } = stateProps;
-	const options = dispatchProps;
-
-	const filteredOptions = pickBy( options, option =>
-		! ( option.hideForSite && option.hideForSite( stateProps ) )
-	);
-
-	const boundOptions = bindOptionsToSite( filteredOptions, site );
-
-	return Object.assign(
-		{},
-		ownProps,
-		stateProps,
-		{
-			options: boundOptions,
-			defaultOption: boundOptions.activate,
-			secondaryOption: boundOptions.tryandcustomize,
-			getScreenshotOption: theme => theme.active ? boundOptions.customize : boundOptions.info
-		}
+		<SingleSiteThemeShowcase { ...props }
+			site={ site }
+			options={ [
+				'customize',
+				'preview',
+				'purchase',
+				'activate',
+				'tryandcustomize',
+				'separator',
+				'info',
+				'support',
+				'help'
+			] }
+			defaultOption="activate"
+			secondaryOption="tryandcustomize"
+			getScreenshotOption={ function( theme ) {
+				return theme.active ? 'customize' : 'info';
+			} }
+			source="showcase" />
 	);
 };
 
 export default connect(
-	state => {
+	( state ) => {
 		const selectedSite = getSelectedSite( state );
 		return {
 			selectedSite,
 			isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
 			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' )
 		};
-	},
-	bindOptionsToDispatch( {
-		customize,
-		preview,
-		purchase,
-		activate,
-		tryandcustomize,
-		separator,
-		info,
-		support,
-		help
-	}, 'showcase' ),
-	mergeProps
-)( localize( ThemesSingleSite ) );
+	}
+)( SingleSiteThemeShowcaseWithOptions );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -4,8 +4,9 @@
  * External dependencies
  */
 import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
-import mapValues from 'lodash/mapValues';
+import { has, identity, mapValues, pick, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,15 +19,18 @@ import {
 	isPremiumTheme as isPremium
 } from 'state/themes/utils';
 import {
-	getSignupUrl,
-	getPurchaseUrl,
-	getCustomizeUrl,
-	getDetailsUrl,
-	getSupportUrl,
-	getHelpUrl
-} from './helpers';
+	getThemeSignupUrl as getSignupUrl,
+	getThemePurchaseUrl as getPurchaseUrl,
+	getThemeCustomizeUrl as	getCustomizeUrl,
+	getThemeDetailsUrl as getDetailsUrl,
+	getThemeSupportUrl as getSupportUrl,
+	getThemeHelpUrl as getHelpUrl
+} from 'state/themes/selectors';
+import { isActiveTheme as isActive } from 'state/themes/current-theme/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import { canCurrentUser } from 'state/current-user/selectors';
 
-export const purchase = config.isEnabled( 'upgrades/checkout' )
+const purchase = config.isEnabled( 'upgrades/checkout' )
 	? {
 		label: i18n.translate( 'Purchase', {
 			context: 'verb'
@@ -35,113 +39,163 @@ export const purchase = config.isEnabled( 'upgrades/checkout' )
 			context: 'verb',
 			comment: 'label for selecting a site for which to purchase a theme'
 		} ),
-		getUrl: ( theme, site ) => getPurchaseUrl( theme, site ),
-		hideForTheme: theme => ! theme.price || theme.active || theme.purchased
+		getUrl: getPurchaseUrl,
+		hideForTheme: ( state, theme, site ) => ! theme.price || isActive( state, theme.id, site ) || theme.purchased
 	}
 	: {};
 
-export const activate = {
+const activate = {
 	label: i18n.translate( 'Activate' ),
 	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
 	action: activateAction,
-	hideForTheme: theme => theme.active || ( theme.price && ! theme.purchased )
+	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site ) || ( theme.price && ! theme.purchased )
 };
 
-export const customize = {
+const customize = {
 	label: i18n.translate( 'Customize' ),
 	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a site for which to customize a theme' } ),
 	icon: 'customize',
-	getUrl: ( theme, site ) => getCustomizeUrl( theme, site ),
-	hideForSite: ( { isCustomizable = false } = {} ) => ! isCustomizable,
-	hideForTheme: theme => ! theme.active
+	getUrl: getCustomizeUrl,
+	hideForSite: ( state, site ) => ! canCurrentUser( state, site, 'edit_theme_options' ),
+	hideForTheme: ( state, theme, site ) => ! isActive( state, theme.id, site )
 };
 
-export const tryandcustomize = {
+const tryandcustomize = {
 	label: i18n.translate( 'Try & Customize' ),
 	header: i18n.translate( 'Try & Customize on:', {
 		comment: 'label in the dialog for opening the Customizer with the theme in preview'
 	} ),
-	getUrl: ( theme, site ) => getCustomizeUrl( theme, site ),
-	hideForSite: ( { isCustomizable = false } = {} ) => ! isCustomizable,
-	hideForTheme: theme => theme.active
+	getUrl: getCustomizeUrl,
+	hideForSite: ( state, site ) => ! canCurrentUser( state, site, 'edit_theme_options' ),
+	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site )
 };
 
 // This is a special option that gets its `action` added by `ThemeShowcase` or `ThemeSheet`,
 // respectively. TODO: Replace with a real action once we're able to use `SitePreview`.
-export const preview = {
+const preview = {
 	label: i18n.translate( 'Live demo', {
 		comment: 'label for previewing the theme demo website'
 	} ),
-	hideForSite: ( { isJetpack = false } = {} ) => isJetpack,
-	hideForTheme: theme => theme.active
+	hideForSite: ( state, site ) => isJetpackSite( state, site ),
+	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site )
 };
 
-export const signup = {
+const signup = {
 	label: i18n.translate( 'Pick this design', {
 		comment: 'when signing up for a WordPress.com account with a selected theme'
 	} ),
-	getUrl: theme => getSignupUrl( theme )
+	getUrl: getSignupUrl
 };
 
-export const separator = {
+const separator = {
 	separator: true
 };
 
-export const info = {
+const info = {
 	label: i18n.translate( 'Info', {
 		comment: 'label for displaying the theme info sheet'
 	} ),
 	icon: 'info',
-	getUrl: ( theme, site ) => getDetailsUrl( theme, site ), // TODO: Make this a selector
+	getUrl: getDetailsUrl,
 };
 
-export const support = {
+const support = {
 	label: i18n.translate( 'Setup' ),
 	icon: 'help',
-	getUrl: ( theme, site ) => getSupportUrl( theme, site ),
+	getUrl: getSupportUrl,
 	// We don't know where support docs for a given theme on a self-hosted WP install are.
-	hideForSite: ( { isJetpack = false } = {} ) => isJetpack,
-	hideForTheme: theme => ! isPremium( theme )
+	hideForSite: ( state, site ) => isJetpackSite( state, site ),
+	hideForTheme: ( state, theme ) => ! isPremium( theme )
 };
 
-export const help = {
+const help = {
 	label: i18n.translate( 'Support' ),
-	getUrl: ( theme, site ) => getHelpUrl( theme, site ),
+	getUrl: getHelpUrl,
 	// We don't know where support docs for a given theme on a self-hosted WP install are.
-	hideForSite: ( { isJetpack = false } = {} ) => isJetpack,
+	hideForSite: ( state, site ) => isJetpackSite( state, site ),
 };
 
-export function bindOptionToDispatch( option, source ) {
-	return dispatch => Object.assign(
-		{},
-		option,
-		option.action
-			? { action: bindActionCreators(
-				( theme, site ) => option.action( theme, site, source ),
-				dispatch
-				) }
-			: {}
-	);
-}
+const ALL_THEME_OPTIONS = {
+	customize,
+	preview,
+	purchase,
+	activate,
+	tryandcustomize,
+	signup,
+	separator,
+	info,
+	support,
+	help
+};
 
-export function bindOptionsToDispatch( options, source ) {
-	return dispatch => mapValues( options, option => bindOptionToDispatch( option, source )( dispatch ) );
-}
+const ALL_THEME_ACTIONS = { activate: activateAction }; // All theme related actions available.
 
-// Ideally: same sig as mergeProps. stateProps, dispatchProps, ownProps
-function bindOptionToSite( option, site ) {
-	return Object.assign(
-		{},
-		option,
-		option.action
-			? { action: theme => option.action( theme, site ) }
-			: {},
-		option.getUrl
-			? { getUrl: theme => option.getUrl( theme, site ) }
-			: {}
-	);
-}
+export const connectOptions = connect(
+	( state, { options: optionNames, site } ) => {
+		let options = pick( ALL_THEME_OPTIONS, optionNames );
+		let mapGetUrl = identity, mapHideForSite = identity;
 
-export function bindOptionsToSite( options, site ) {
-	return mapValues( options, option => bindOptionToSite( option, site ) );
-}
+		// We bind hideForTheme to site even if it is null since the selectors
+		// that are used by it are expected to recognize that case as "no site selected"
+		// and work accordingly.
+		const mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, site ? site.ID : null );
+
+		if ( site ) {
+			const siteId = site.ID;
+
+			mapGetUrl = getUrl => ( t ) => getUrl( state, t, siteId );
+			options = pickBy( options, option =>
+				! ( option.hideForSite && option.hideForSite( state, siteId ) )
+			);
+		} else {
+			mapGetUrl = getUrl => ( t, s ) => getUrl( state, t, s );
+			mapHideForSite = hideForSite => ( s ) => hideForSite( state, s );
+		}
+
+		return mapValues( options, option => Object.assign(
+			{},
+			option,
+			option.getUrl
+				? { getUrl: mapGetUrl( option.getUrl ) }
+				: {},
+			option.hideForSite
+				? { hideForSite: mapHideForSite( option.hideForSite ) }
+				: {},
+			option.hideForTheme
+				? { hideForTheme: mapHideForTheme( option.hideForTheme ) }
+				: {}
+		) );
+	},
+	( dispatch, { site, source = 'unknown' } ) => {
+		let mapAction;
+
+		if ( site ) {
+			// TODO (@ockham): Change actions to use siteId.
+			mapAction = action => ( t ) => action( t, site, source );
+		} else { // Bind only source.
+			mapAction = action => ( t, s ) => action( t, s, source );
+		}
+
+		return bindActionCreators(
+			mapValues( ALL_THEME_ACTIONS, action => mapAction( action ) ),
+			dispatch
+		);
+	},
+	( options, actions, ownProps ) => {
+		const { defaultOption, secondaryOption, getScreenshotOption } = ownProps;
+		options = mapValues( options, ( option, name ) => {
+			if ( has( actions, name ) ) {
+				return { ...option, action: actions[ name ] };
+			}
+			return option;
+		} );
+
+		return {
+			...ownProps,
+			options,
+			defaultOption: options[ defaultOption ],
+			secondaryOption: secondaryOption ? options[ secondaryOption ] : null,
+			getScreenshotOption: ( theme ) => options[ getScreenshotOption( theme ) ]
+		};
+	}
+);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -170,8 +170,9 @@ const ThemeShowcase = React.createClass( {
 	}
 } );
 
-export default connect( state => ( {
-	queryParams: getQueryParams( state ),
-	themesList: getThemesList( state )
-} )
+export default connect(
+	state => ( {
+		queryParams: getQueryParams( state ),
+		themesList: getThemesList( state ),
+	} )
 )( localize( ThemeShowcase ) );

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -14,14 +14,19 @@ import Theme from 'components/theme';
 import SiteSelectorModal from 'components/site-selector-modal';
 import { trackClick } from './helpers';
 
+const OPTION_SHAPE = PropTypes.shape( {
+	label: PropTypes.string,
+	header: PropTypes.string,
+	getUrl: PropTypes.func,
+	action: PropTypes.func
+} );
+
 const ThemesSiteSelectorModal = React.createClass( {
 	propTypes: {
-		options: React.PropTypes.objectOf( React.PropTypes.shape( {
-			label: React.PropTypes.string,
-			header: React.PropTypes.string,
-			action: React.PropTypes.func
-		} ) ),
-		selectedSite: React.PropTypes.object,
+		children: PropTypes.element,
+		options: PropTypes.objectOf( OPTION_SHAPE ),
+		defaultOption: OPTION_SHAPE,
+		secondaryOption: OPTION_SHAPE,
 		// Will be prepended to site slug for a redirect on selection
 		sourcePath: PropTypes.string.isRequired,
 	},
@@ -102,7 +107,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 					mainAction={ this.trackAndCallAction }
 					mainActionLabel={ selectedOption.label }
 					getMainUrl={ selectedOption.getUrl ? function( site ) {
-						return selectedOption.getUrl( selectedTheme, site );
+						return selectedOption.getUrl( selectedTheme, site.ID );
 					} : null } >
 
 					<Theme isActionable={ false } theme={ selectedTheme } />

--- a/client/state/themes/current-theme/selectors.js
+++ b/client/state/themes/current-theme/selectors.js
@@ -4,6 +4,11 @@ export function getCurrentTheme( state, siteId ) {
 	return state.themes.currentTheme.get( 'currentThemes' ).get( siteId );
 }
 
+export function isActiveTheme( state, themeId, siteId ) {
+	const theme = getCurrentTheme( state, siteId );
+	return theme && theme.id === themeId;
+}
+
 export function isActivating( state ) {
 	return state.themes.currentTheme.get( 'isActivating' );
 }

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -150,6 +150,13 @@ export function getThemeSignupUrl( state, theme ) {
 /**
  * Returns the currently active theme on a given site.
  *
+ * DON'T USE YET! This relies on a site object's options.theme_slug attr. If you trigger my-sites' siteSelection
+ * middleware during theme activation, it will fetch the current site fresh from the API even though that
+ * theme_slug attr might not have been updated on the server yet -- and you'll end up with the old themeId!
+ * This happens in particular after purchasing a premium theme in single-site mode since after a theme purchase,
+ * the checkout-thank-you component always redirects to the theme showcase for the current site.
+ * One possible fix would be to get rid of that redirect (related: https://github.com/Automattic/wp-calypso/issues/8262).
+ *
  * @param  {Object}  state   Global state tree
  * @param  {Number}  siteId  Site ID
  * @return {?String}         Theme ID
@@ -177,6 +184,8 @@ export function getActiveTheme( state, siteId ) {
 /**
  * Returns whether the theme is currently active on the given site.
  *
+ * DON'T USE YET! This relies on the getActiveTheme() selector; see its JSDoc.
+ *
  * @param  {Object}  state   Global state tree
  * @param  {String}  themeId Theme ID
  * @param  {Number}  siteId  Site ID
@@ -190,6 +199,8 @@ export function isThemeActive( state, themeId, siteId ) {
  * Returns whether the theme has been purchased for the given site.
  *
  * Use this selector alongside with the <QuerySitePurchases /> component.
+ *
+ * DON'T USE YET! This uses the getSitePurchases() which sometimes seems to omit some purchases.
  *
  * @param  {Object}  state   Global state tree
  * @param  {String}  themeId Theme ID


### PR DESCRIPTION
**Need to fix a spurious TypeError complaining about `id` being undefined, see #9214**

Add a `connectOptions` helper function that bundles all binding to state and site (if given) in one place for greater ease-of-use, and have it use selectors instead of helpers for `getUrl` attrs. Furthermore, use (newly written) `isActiveTheme` selector in theme options' `hideForTheme` predicates.

The latter feature is particularly relevant as it is the first (and hardest) step to decoupling theme objects from contextual data, and using selectors like `isActiveTheme` that take state, site ID, and theme as arguments instead tying that information to theme object (as in `theme.active`). This will allow us to keep only one list of all wpcom themes that just contains bare, i.e. non-contextual, theme information, without relying on attrs like `.active` or `.purchased`, that we can use both in multi- and single-site mode (instead of multiplicating that list for all sites a user has).

We can't use the `isThemePurchased` selector yet as `getSitePurchases` (the selector it relies on) seems to be buggy -- it doesn't always return the same results. We'll need to do a separate PR -- the code changes to use that selector in `hideForTheme` should be fairly easy, most of the effort will need to go into researching why and how the underlying selector is broken.

This PR also updates `shouldComponentUpdate`s in the `Theme` and `ThemesList` components. This is required so those components also update if `buttonOptions` change, which, as of this PR, will happen e.g. if a theme is activated, since `ThemeOptions` now makes use of the `isActiveTheme` selector inside `hideForTheme`.

Note that I had to add a new `isActive` selector which relies on the existing `current-theme` Redux subtree instead of the `isThemeActive` selector that relies on a given site's `options.theme_slug` attr (and which I hoped would allow us to stop tracking active themes per site in a separate subtree). However, there's a rather tricky bug with `options.theme_slug` which is documented in a comment in the source code, so I'm afraid we'll have to keep our own `current-theme` subtree around for the time being (though we should refactor it to be in line with the new `themes` state tree structure). cc @budzanowski 

No visual changes. To test:
Make sure that the theme showcase still works as before (compare to `master` or production).
* Since this is an invasive change, it requires extensive testing in all modes (logged-out, multi-site, single-site [for both wpcom and Jetpack sites], and theme sheets)
* Testing should cover:
 * Verifying that a theme thumbnail's ellipsis menu contains all the right items, and that they all work as expected.
 * Verifying that call-to-action buttons in a theme sheet, and in theme preview are present, present the correct action, and are correctly labelled.

Next step -- next PR:
Replace all remaining occurrences of `theme.active` by the new `isActiveTheme` selector. Figure out what to do about the `Theme` component.

TODO for later PRs:
- [ ] Have selectors accept a `themeID` instead of an entire theme object (and have them obtain other required theme attributes as needed). (Possibly same for `site` -> `siteId`)
- [ ] Replace all `get...Url()` helpers by selectors.
- [ ] Make `isPremiumTheme` a selector
- [ ] Get rid of `window` dependency
- [ ] Add tests for `theme-options`, move to `lib/` or `components/`.
- [ ] Add `getCustomizeUrl( state, siteId )` alias for  `getThemeCustomizeUrl( state, null, siteId )` ?
- [ ] Use our new selectors to implement [this one](https://github.com/Automattic/wp-calypso/pull/7779)
- [ ] Delete `helpers.js` (once all usages have been replaced by selectors)

Reverts Automattic/wp-calypso#9214