### PR TITLE
Sharing: Fix warnings on the Sharing Buttons Page

### DIFF
--- a/client/components/forms/multi-checkbox/index.jsx
+++ b/client/components/forms/multi-checkbox/index.jsx
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { omit } from 'lodash';
-import debugFactory from 'debug';
-
-const debug = debugFactory( 'calypso:forms:multi-checkbox' );
+import { includes, omit } from 'lodash';
 
 export default class MultiCheckbox extends Component {
 	static propTypes = {
@@ -13,23 +10,20 @@ export default class MultiCheckbox extends Component {
 		defaultChecked: PropTypes.array,
 		disabled: PropTypes.bool,
 		onChange: PropTypes.func,
-		options: PropTypes.array,
+		options: PropTypes.array.isRequired,
 		name: PropTypes.string,
 	};
 
 	static defaultProps = {
 		defaultChecked: Object.freeze( [] ),
-		onChange: function() {},
-		disabled: false
+		disabled: false,
+		onChange: () => {},
+		name: 'mutliCheckbox'
 	};
 
 	state = {
 		initialChecked: this.props.defaultChecked
 	};
-
-	componentWillMount() {
-		debug( 'Mounting MultiCheckbox React component.' );
-	}
 
 	handleChange = ( event ) => {
 		const target = event.target;
@@ -45,31 +39,25 @@ export default class MultiCheckbox extends Component {
 		event.stopPropagation();
 	};
 
-	getCheckboxElements() {
-		const checked = this.props.checked || this.state.initialChecked;
-
-		return this.props.options.map( ( option ) => {
-			const isChecked = checked.indexOf( option.value ) !== -1;
-
-			return (
-				<label key={ option.value }>
-					<input
-						name={ this.props.name + '[]' }
-						type="checkbox" value={ option.value }
-						checked={ isChecked }
-						onChange={ this.handleChange }
-						disabled={ this.props.disabled }
-					/>
-					<span>{ option.label }</span>
-				</label>
-			);
-		}, this );
-	}
-
 	render() {
+		const { disabled, name, options } = this.props;
+		const checked = this.props.checked || this.state.initialChecked;
 		return (
 			<div className="multi-checkbox" { ...omit( this.props, Object.keys( MultiCheckbox.propTypes ) ) }>
-				{ this.getCheckboxElements() }
+				{ options.map( ( option ) => (
+						<label key={ option.value }>
+							<input
+								name={ name + '[]' }
+								type="checkbox"
+								value={ option.value }
+								checked={ includes( checked, option.value ) }
+								onChange={ this.handleChange }
+								disabled={ disabled }
+							/>
+							<span>{ option.label }</span>
+						</label>
+					) )
+				}
 			</div>
 		);
 	}

--- a/client/components/forms/multi-checkbox/index.jsx
+++ b/client/components/forms/multi-checkbox/index.jsx
@@ -18,7 +18,7 @@ export default class MultiCheckbox extends Component {
 		defaultChecked: Object.freeze( [] ),
 		disabled: false,
 		onChange: () => {},
-		name: 'mutliCheckbox'
+		name: 'multiCheckbox'
 	};
 
 	state = {
@@ -45,19 +45,18 @@ export default class MultiCheckbox extends Component {
 		return (
 			<div className="multi-checkbox" { ...omit( this.props, Object.keys( MultiCheckbox.propTypes ) ) }>
 				{ options.map( ( option ) => (
-						<label key={ option.value }>
-							<input
-								name={ name + '[]' }
-								type="checkbox"
-								value={ option.value }
-								checked={ includes( checked, option.value ) }
-								onChange={ this.handleChange }
-								disabled={ disabled }
-							/>
-							<span>{ option.label }</span>
-						</label>
-					) )
-				}
+					<label key={ option.value }>
+						<input
+							name={ name + '[]' }
+							type="checkbox"
+							value={ option.value }
+							checked={ includes( checked, option.value ) }
+							onChange={ this.handleChange }
+							disabled={ disabled }
+						/>
+						<span>{ option.label }</span>
+					</label>
+				) ) }
 			</div>
 		);
 	}

--- a/client/components/forms/multi-checkbox/index.jsx
+++ b/client/components/forms/multi-checkbox/index.jsx
@@ -1,40 +1,40 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	omit = require( 'lodash/omit' ),
-	debug = require( 'debug' )( 'calypso:forms:multi-checkbox' );
+import React, { Component, PropTypes } from 'react';
+import { omit } from 'lodash';
+import debugFactory from 'debug';
 
-var MultiCheckbox = module.exports = React.createClass({
-	displayName: 'MultiCheckbox',
+const debug = debugFactory( 'calypso:forms:multi-checkbox' );
 
-	propTypes: {
-		defaultChecked: React.PropTypes.array,
-		onChange: React.PropTypes.func,
-		disabled: React.PropTypes.bool
-	},
+export default class MultiCheckbox extends Component {
+	static propTypes = {
+		checked: PropTypes.array,
+		defaultChecked: PropTypes.array,
+		disabled: PropTypes.bool,
+		onChange: PropTypes.func,
+		options: PropTypes.array,
+		name: PropTypes.string,
+	};
 
-	getInitialState: function() {
-		return { initialChecked: this.props.defaultChecked };
-	},
+	static defaultProps = {
+		defaultChecked: Object.freeze( [] ),
+		onChange: function() {},
+		disabled: false
+	};
 
-	getDefaultProps: function() {
-		return {
-			defaultChecked: Object.freeze( [] ),
-			onChange: function() {},
-			disabled: false
-		};
-	},
+	state = {
+		initialChecked: this.props.defaultChecked
+	};
 
-	componentWillMount: function() {
-		debug( 'Mounting ' + this.constructor.displayName + ' React component.' );
-	},
+	componentWillMount() {
+		debug( 'Mounting MultiCheckbox React component.' );
+	}
 
-	handleChange: function( event ) {
-		var target = event.target,
-			checked = this.props.checked || this.state.initialChecked;
-
-		checked = checked.concat( [ target.value ] ).filter( function( currentValue ) {
+	handleChange = ( event ) => {
+		const target = event.target;
+		let checked = this.props.checked || this.state.initialChecked;
+		checked = checked.concat( [ target.value ] ).filter( ( currentValue ) => {
 			return currentValue !== target.value || target.checked;
 		} );
 
@@ -43,24 +43,34 @@ var MultiCheckbox = module.exports = React.createClass({
 		} );
 
 		event.stopPropagation();
-	},
+	};
 
-	getCheckboxElements: function() {
-		var checked = this.props.checked || this.state.initialChecked;
+	getCheckboxElements() {
+		const checked = this.props.checked || this.state.initialChecked;
 
-		return this.props.options.map( function( option ) {
-			var isChecked = checked.indexOf( option.value ) !== -1;
+		return this.props.options.map( ( option ) => {
+			const isChecked = checked.indexOf( option.value ) !== -1;
 
 			return (
 				<label key={ option.value }>
-					<input name={ this.props.name + '[]' } type="checkbox" value={ option.value } checked={ isChecked } onChange={ this.handleChange } disabled={ this.props.disabled } />
+					<input
+						name={ this.props.name + '[]' }
+						type="checkbox" value={ option.value }
+						checked={ isChecked }
+						onChange={ this.handleChange }
+						disabled={ this.props.disabled }
+					/>
 					<span>{ option.label }</span>
 				</label>
 			);
 		}, this );
-	},
-
-	render: function() {
-		return <div className="form-checkbox-group" { ...omit( this.props, Object.keys( MultiCheckbox.propTypes ) ) }>{ this.getCheckboxElements() }</div>;
 	}
-} );
+
+	render() {
+		return (
+			<div className="multi-checkbox" { ...omit( this.props, Object.keys( MultiCheckbox.propTypes ) ) }>
+				{ this.getCheckboxElements() }
+			</div>
+		);
+	}
+}

--- a/client/my-sites/sharing/buttons/options.jsx
+++ b/client/my-sites/sharing/buttons/options.jsx
@@ -134,13 +134,22 @@ module.exports = React.createClass( {
 			return;
 		}
 
+		const checked = typeof this.props.values.jetpack_comment_likes_enabled === 'undefined'
+			? false
+			: this.props.values.jetpack_comment_likes_enabled;
+
 		return (
 			<fieldset className="sharing-buttons__fieldset">
 				<legend className="sharing-buttons__fieldset-heading">
 					{ this.translate( 'Comment Likes', { context: 'Sharing options: Header' } ) }
 				</legend>
 				<label>
-					<input name="jetpack_comment_likes_enabled" type="checkbox" checked={ this.props.values.jetpack_comment_likes_enabled } onChange={ this.handleChange } disabled={ ! this.props.initialized } />
+					<input name="jetpack_comment_likes_enabled"
+						type="checkbox"
+						checked={ checked }
+						onChange={ this.handleChange }
+						disabled={ ! this.props.initialized }
+					/>
 					<span>{ this.translate( 'On for all posts', { context: 'Sharing options: Comment Likes' } ) }</span>
 				</label>
 			</fieldset>

--- a/client/my-sites/sharing/buttons/options.jsx
+++ b/client/my-sites/sharing/buttons/options.jsx
@@ -1,15 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	some = require( 'lodash/some' ),
-	xor = require( 'lodash/xor' );
+import React from 'react';
+import { get, some, xor } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var MultiCheckbox = require( 'components/forms/multi-checkbox' ),
-	analytics = require( 'lib/analytics' );
+import MultiCheckbox from 'components/forms/multi-checkbox';
+import analytics from 'lib/analytics';
 
 module.exports = React.createClass( {
 	displayName: 'SharingButtonsOptions',
@@ -134,9 +133,7 @@ module.exports = React.createClass( {
 			return;
 		}
 
-		const checked = typeof this.props.values.jetpack_comment_likes_enabled === 'undefined'
-			? false
-			: this.props.values.jetpack_comment_likes_enabled;
+		const checked = get( this.props.values, 'jetpack_comment_likes_enabled', false );
 
 		return (
 			<fieldset className="sharing-buttons__fieldset">


### PR DESCRIPTION
When working on the Sharing Buttons Page, I noticed some warnings on the console, mostly due to the `MultiCheckbox` Component.

In this PR, I'm fixing those warnings and I'm upgrading the `MultiCheckbox` component to our latest coding style.

**testing instructions**

 * Navigate to the Sharing Buttons settings page `sharing/buttons/$site`
 * We should be able to update the settings correctly
 * There should be no warnings on the console