### PR TITLE
Domains: Reorder availability error messages

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -23,7 +23,7 @@ function ValidationError( code ) {
 inherits( ValidationError, Error );
 
 function canAddGoogleApps( domainName ) {
-	var tld = domainName.split( '.' )[ 1 ],
+	const tld = domainName.split( '.' )[ 1 ],
 		includesBannedPhrase = some( GOOGLE_APPS_BANNED_PHRASES, function( phrase ) {
 			return includes( domainName, phrase );
 		} );
@@ -78,7 +78,7 @@ function canMap( domainName, onComplete ) {
 	}
 
 	wpcom.undocumented().isDomainMappable( domainName, function( serverError, data ) {
-		var errorCode;
+		let errorCode;
 		if ( serverError ) {
 			errorCode = serverError.error;
 		} else if ( ! data.is_mappable ) {
@@ -132,7 +132,7 @@ function isSubdomain( domainName ) {
 }
 
 function isInitialized( state, siteId ) {
-	var siteState = state[ siteId ];
+	const siteState = state[ siteId ];
 	return siteState && ( siteState.hasLoadedFromServer || siteState.isFetching );
 }
 

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -51,15 +51,14 @@ function canRegister( domainName, onComplete ) {
 		} = data;
 
 		let errorCode;
-		if ( ! isAvailable ) {
-			if ( isMappable ) {
-				errorCode = 'not_available_but_mappable';
-			} else if ( unmappabilityReason ) {
-				errorCode = `not_mappable_${ unmappabilityReason }`;
-			} else {
-				errorCode = 'not_mappable';
+		if ( ! isMappable ) {
+			errorCode = 'not_mappable';
+			if ( unmappabilityReason ) {
+				errorCode += `_${ unmappabilityReason }`;
 			}
-		} else if ( ! isRegistrable ) {
+		} else if ( ! isAvailable && isMappable ) {
+			errorCode = 'not_available_but_mappable';
+		} else if ( isAvailable && ! isRegistrable ) {
 			errorCode = 'available_but_not_registrable';
 		}
 


### PR DESCRIPTION
Prioritize not mappable. If a domain isn't mappable we don't care whether it's available or not. Even if they register elsewhere, they won't be able to map (most likely).

Before if you searched for an available domain that has an `unmappabilityReason` it just show the `register elsewhere then map` message, which is wrong.

Test:
Search for `test123wordpress.lawyer`.
Make sure it shows the blacklisted message.

Needs `D3311-code`