### PR TITLE
Editor: Resolve logged error when finishing AfterTheDeadline checks

### DIFF
--- a/client/components/tinymce/plugins/after-the-deadline/plugin.js
+++ b/client/components/tinymce/plugins/after-the-deadline/plugin.js
@@ -154,7 +154,7 @@ function plugin( editor ) {
 	function checkIfFinished() {
 		if ( ! editor.dom.select( 'span.hiddenSpellError, span.hiddenGrammarError, span.hiddenSuggestion' ).length ) {
 			if ( suggestionsMenu ) {
-				suggestionsMenu.hideMenu();
+				suggestionsMenu.hide();
 			}
 
 			finish();


### PR DESCRIPTION
This pull request seeks to resolve an error which can occur after finishing an AfterTheDeadline proofread. If the plugin determines that there are no more errors to be resolved, it hides the suggestion menu. While it appears that the menu is hidden regardless of the errroring line, the included changes simply update it to invoke the correct function.

Following the logic:
- `suggestionsMenu` is of type [`SuggestionsMenu`](https://github.com/Automattic/wp-calypso/blob/717d52a020316408176765c541204b9d08a7d6be/client/components/tinymce/plugins/after-the-deadline/plugin.js#L45)
- `SuggestionsMenu` extends [`tinymce.ui.Menu`](https://github.com/tinymce/tinymce/blob/master/js/tinymce/classes/ui/Menu.js)
- There is only a [`hideMenu` function](https://github.com/tinymce/tinymce/blob/b75d2cac5774803efeb7a4c22c5ffb890711f4d1/js/tinymce/classes/ui/MenuItem.js#L175-L195) on the `MenuItem` class
- `Menu` extends `FloatPanel`, which [has a `hide` function](https://github.com/tinymce/tinymce/blob/b75d2cac5774803efeb7a4c22c5ffb890711f4d1/js/tinymce/classes/ui/FloatPanel.js#L314-L325), [overridden in `SuggestionsMenu`](https://github.com/Automattic/wp-calypso/blob/717d52a020316408176765c541204b9d08a7d6be/client/components/tinymce/plugins/after-the-deadline/plugin.js#L63-L68) with custom logic

__Testing instructions:__

Verify that no errors are logged to the console after finishing a proofread, and that the menu is hidden as expected.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site
3. Enter text with a typo, like "This is a tst"
4. Click Proofread Writing button in the editor toolbar
5. Click the erring text "tst"
6. Choose a suggested alternative
7. Note that the text is replaced, the suggestions menu is closed, and no errors are logged to console

Repeating the same steps in [the production editor](https://wordpress.com/post), you should observe that at step 7, an error is logged:

>post-editor.729ffa8….min.js:36 Uncaught TypeError: suggestionsMenu.hideMenu is not a function