### PR TITLE
Reader: Clear the action buttons in full post view

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -290,6 +290,7 @@
 // Action buttons in full-post
 .reader-full-post .reader-post-actions {
 	margin-bottom: 20px;
+	clear: both;
 
 	.post-edit-button__label,
 	.comment-button__label,
@@ -515,4 +516,3 @@
 .reader-full-post .embed-vimeo {
 	margin-bottom: 33px;
 }
-


### PR DESCRIPTION
This fixes cases like http://calypso.localhost:3000/read/feeds/25801/posts/1216319301 where the last thing in a post is floated content.

See for the bad https://wordpress.com/read/feeds/25801/posts/1216319301