### PR TITLE
Reader: Drop min size for photo only photos to 480px

### DIFF
--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -42,9 +42,11 @@ import removeElementsBySelector from 'lib/post-normalizer/rule-content-remove-el
 /**
  * Module vars
  */
-const READER_CONTENT_WIDTH = 720,
+const
+	isRefreshedStream = config.isEnabled( 'reader/refresh/stream' ),
+	READER_CONTENT_WIDTH = 720,
 	DISCOVER_FULL_BLEED_WIDTH = 1082,
-	PHOTO_ONLY_MIN_WIDTH = READER_CONTENT_WIDTH * 0.8,
+	PHOTO_ONLY_MIN_WIDTH = isRefreshedStream ? 480 : 570,
 	DISCOVER_BLOG_ID = 53424024,
 	GALLERY_MIN_IMAGES = 4;
 
@@ -61,7 +63,7 @@ function discoverFullBleedImages( post, dom ) {
 	return post;
 }
 
-const hasShortContent = config.isEnabled( 'reader/refresh/stream' )
+const hasShortContent = isRefreshedStream
 	? post => post.character_count <= 100
 	: post => post.word_count < 100;
 


### PR DESCRIPTION
Only for refreshed streams

Fixes #9227 

before
![matt_on_not-wordpress_ _reader_ _wordpress_com](https://cloud.githubusercontent.com/assets/14350/20113195/59b9b01e-a5bd-11e6-83a9-1acaa273f7b7.png)

after
![matt_on_not-wordpress_ _reader_ _wordpress_com](https://cloud.githubusercontent.com/assets/14350/20113214/6ee6e858-a5bd-11e6-81b9-1de2ec80525a.png)


