### PR TITLE
Add Tracks Events for SEO Tools

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -35,6 +35,7 @@ import {
 	getSectionName,
 	getSelectedSite
 } from 'state/ui/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const PREVIEW_IMAGE_WIDTH = 512;
 const largeBlavatar = site => `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=${ PREVIEW_IMAGE_WIDTH }`;
@@ -177,15 +178,19 @@ export class SeoPreviewPane extends PureComponent {
 	constructor( props ) {
 		super( props );
 
+		const defaultService = props.post ? 'wordpress' : 'google';
 		this.state = {
-			selectedService: props.post ? 'wordpress' : 'google'
+			selectedService: defaultService
 		};
 
 		this.selectPreview = this.selectPreview.bind( this );
+
+		recordTracksEvent( 'calypso_seo_tools_social_preview', defaultService );
 	}
 
 	selectPreview( selectedService ) {
 		this.setState( { selectedService } );
+		recordTracksEvent( 'calypso_seo_tools_social_preview', selectedService );
 	}
 
 	render() {

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -185,6 +185,14 @@ export class SeoPreviewPane extends PureComponent {
 		this.selectPreview = this.selectPreview.bind( this );
 	}
 
+	componentDidMount() {
+		// Track the first service that is viewed
+		const { trackPreviewService } = this.props;
+		const { selectedService } = this.state;
+
+		trackPreviewService( selectedService );
+	}
+
 	selectPreview( selectedService ) {
 		this.setState( { selectedService } );
 

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -178,19 +178,18 @@ export class SeoPreviewPane extends PureComponent {
 	constructor( props ) {
 		super( props );
 
-		const defaultService = props.post ? 'wordpress' : 'google';
 		this.state = {
-			selectedService: defaultService
+			selectedService: props.post ? 'wordpress' : 'google'
 		};
 
 		this.selectPreview = this.selectPreview.bind( this );
-
-		recordTracksEvent( 'calypso_seo_tools_social_preview', defaultService );
 	}
 
 	selectPreview( selectedService ) {
 		this.setState( { selectedService } );
-		recordTracksEvent( 'calypso_seo_tools_social_preview', selectedService );
+
+		const { trackPreviewService } = this.props;
+		trackPreviewService( selectedService );
 	}
 
 	render() {
@@ -275,4 +274,8 @@ const mapStateToProps = state => {
 	};
 };
 
-export default connect( mapStateToProps, null )( localize( SeoPreviewPane ) );
+const mapDispatchToProps = dispatch => ( {
+	trackPreviewService: service => dispatch( recordTracksEvent( 'calypso_seo_tools_social_preview', { service } ) )
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( SeoPreviewPane ) );

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -310,15 +310,20 @@ export const SeoForm = React.createClass( {
 
 	trackSubmission() {
 		const { dirtyFields } = this.state;
+		const {
+			trackFormSubmitted,
+			trackTitleFormatsUpdated,
+			trackFrontPageMetaUpdated
+		} = this.props;
 
-		recordTracksEvent( 'calypso_seo_settings_form_submit', {} );
+		trackFormSubmitted();
 
 		if ( dirtyFields.has( 'seoTitleFormats' ) ) {
-			recordTracksEvent( 'calypso_seo_tools_title_formats_updated', {} );
+			trackTitleFormatsUpdated();
 		}
 
 		if ( dirtyFields.has( 'frontPageMetaDescription' ) ) {
-			recordTracksEvent( 'calypso_seo_tools_front_page_meta_updated', {} );
+			trackFrontPageMetaUpdated();
 		}
 	},
 
@@ -680,9 +685,12 @@ const mapStateToProps = ( state, ownProps ) => {
 	};
 };
 
-const mapDispatchToProps = {
-	refreshSiteData: siteId => requestSite( siteId )
-};
+const mapDispatchToProps = dispatch => ( {
+	refreshSiteData: siteId => dispatch( requestSite( siteId ) ),
+	trackFormSubmitted: () => dispatch( recordTracksEvent( 'calypso_seo_settings_form_submit', {} ) ),
+	trackTitleFormatsUpdated: () => dispatch( recordTracksEvent( 'calypso_seo_tools_title_formats_updated', {} ) ),
+	trackFrontPageMetaUpdated: () => dispatch( recordTracksEvent( 'calypso_seo_tools_front_page_meta_updated', {} ) )
+} );
 
 export default connect(
 	mapStateToProps,

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -224,7 +224,6 @@ export const SeoForm = React.createClass( {
 		const {
 			site,
 			storedTitleFormats,
-			trackSubmission,
 			showAdvancedSeo,
 			showWebsiteMeta
 		} = this.props;
@@ -306,7 +305,21 @@ export const SeoForm = React.createClass( {
 			}
 		} );
 
-		trackSubmission();
+		this.trackSubmission();
+	},
+
+	trackSubmission() {
+		const { dirtyFields } = this.state;
+
+		recordTracksEvent( 'calypso_seo_settings_form_submit', {} );
+
+		if ( dirtyFields.has( 'seoTitleFormats' ) ) {
+			recordTracksEvent( 'calypso_seo_tools_title_formats_updated', {} );
+		}
+
+		if ( dirtyFields.has( 'frontPageMetaDescription' ) ) {
+			recordTracksEvent( 'calypso_seo_tools_front_page_meta_updated', {} );
+		}
 	},
 
 	refreshCustomTitles() {
@@ -668,8 +681,7 @@ const mapStateToProps = ( state, ownProps ) => {
 };
 
 const mapDispatchToProps = {
-	refreshSiteData: siteId => requestSite( siteId ),
-	trackSubmission: () => recordTracksEvent( 'calypso_seo_settings_form_submit', {} ),
+	refreshSiteData: siteId => requestSite( siteId )
 };
 
 export default connect(


### PR DESCRIPTION
This PR adds a few tracks events for actions taken in the SEO Tools:

- When the title formats or site meta description is updated.
- When a social preview panel is viewed in the SEO preview area.