### PR TITLE
Reader: Remove srcset instead of fixing it

### DIFF
--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -8,7 +8,6 @@ import some from 'lodash/some';
 import startsWith from 'lodash/startsWith';
 import toArray from 'lodash/toArray';
 import url from 'url';
-import srcset from 'srcset';
 
 /**
  * Internal Dependencies
@@ -111,26 +110,7 @@ export default function( maxWidth ) {
 			image.setAttribute( 'src', safeSource );
 
 			if ( image.hasAttribute( 'srcset' ) ) {
-				let imgSrcSet;
-				try {
-					imgSrcSet = srcset.parse( image.getAttribute( 'srcset' ) );
-				} catch ( ex ) {
-					// if srcset parsing fails, set the srcset to an empty array. This will have the effect of removing the srcset entirely.
-					imgSrcSet = [];
-				}
-				imgSrcSet = imgSrcSet.map( imgSrc => {
-					if ( ! url.parse( imgSrc.url, false, true ).hostname ) {
-						imgSrc.url = url.resolve( post.URL, imgSrc.url );
-					}
-					imgSrc.url = safeImageURL( imgSrc.url );
-					return imgSrc;
-				} ).filter( imgSrc => imgSrc.url );
-				const newSrcSet = srcset.stringify( imgSrcSet );
-				if ( newSrcSet ) {
-					image.setAttribute( 'srcset', newSrcSet );
-				} else {
-					image.removeAttribute( 'srcset' );
-				}
+				image.removeAttribute( 'srcset' );
 			}
 
 			if ( isCandidateForContentImage( imgSource ) ) {
@@ -145,7 +125,9 @@ export default function( maxWidth ) {
 
 		// grab all of the non-tracking pixels and push them into content_images
 		content_images = filter( content_images, function( image ) {
-			if ( ! image.src ) return false;
+			if ( ! image.src ) {
+				return false;
+			}
 			const edgeLength = image.height + image.width;
 			// if the image size isn't set (0) or is greater than 2, keep it
 			return edgeLength === 0 || edgeLength > 2;

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -466,13 +466,13 @@ describe( 'index', function() {
 			);
 		} );
 
-		it( 'fixes up srcsets', function( done ) {
+		it( 'removes srcsets', function( done ) {
 			normalizer(
 				{
 					content: '<img src="http://example.com/example.jpg" srcset="http://example.com/example-100.jpg 100w, http://example.com/example-600.jpg 600w">'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
-					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE" srcset="http://example.com/example-100.jpg-SAFE 100w, http://example.com/example-600.jpg-SAFE 600w">' );
+					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE">' );
 					done( err );
 				}
 			);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -120,7 +120,7 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.0"
+      "version": "0.9.2"
     },
     "async": {
       "version": "0.9.0"
@@ -531,7 +531,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000574"
+      "version": "1.0.30000578"
     },
     "caseless": {
       "version": "0.11.0"
@@ -637,7 +637,7 @@
       "dev": true
     },
     "code-point-at": {
-      "version": "1.0.1"
+      "version": "1.1.0"
     },
     "collapse-white-space": {
       "version": "1.0.2",
@@ -1033,7 +1033,7 @@
       }
     },
     "editions": {
-      "version": "1.3.1",
+      "version": "1.3.3",
       "dev": true
     },
     "ee-first": {
@@ -1532,7 +1532,7 @@
       "version": "0.6.1"
     },
     "form-data": {
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "formatio": {
       "version": "1.1.1",
@@ -3125,7 +3125,7 @@
       "dev": true
     },
     "recast": {
-      "version": "0.11.15",
+      "version": "0.11.17",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -3148,7 +3148,7 @@
       "version": "1.3.1"
     },
     "regenerator-runtime": {
-      "version": "0.9.5"
+      "version": "0.9.6"
     },
     "regex-cache": {
       "version": "0.4.3"
@@ -3187,7 +3187,7 @@
       "version": "2.0.1"
     },
     "request": {
-      "version": "2.76.0",
+      "version": "2.78.0",
       "dependencies": {
         "qs": {
           "version": "6.3.0"
@@ -3205,7 +3205,7 @@
       "version": "1.0.1"
     },
     "require-uncached": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true
     },
     "requireindex": {
@@ -3532,9 +3532,6 @@
     "sprintf-js": {
       "version": "1.0.3",
       "dev": true
-    },
-    "srcset": {
-      "version": "1.0.0"
     },
     "sshpk": {
       "version": "1.10.1",
@@ -3874,7 +3871,7 @@
       "version": "0.0.6"
     },
     "ua-parser-js": {
-      "version": "0.7.10"
+      "version": "0.7.11"
     },
     "uglify-js": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "source-map": "0.1.39",
     "source-map-loader": "0.1.5",
     "source-map-support": "0.3.2",
-    "srcset": "1.0.0",
     "store": "1.3.16",
     "striptags": "2.1.1",
     "superagent": "2.1.0",


### PR DESCRIPTION
Also remove the srcset library, as we no longer need it, and update shrinkwrap.

To test, pull up the Reader and look at any stream. Find a post with images from a WordPress.com site and open the full post view. Inspect any image, it should not have srcset attributes.