### PR TITLE
PostNorm: Eagerly grab and use the width and height for images

### DIFF
--- a/client/lib/post-normalizer/rule-first-pass-canonical-image.js
+++ b/client/lib/post-normalizer/rule-first-pass-canonical-image.js
@@ -23,7 +23,7 @@ export default function firstPassCanonicalImage( post ) {
 	} else if ( post.content_images && post.content_images.length ) {
 		const canonicalImage = find( post.content_images, isCandidateForCanonicalImage );
 		if ( canonicalImage ) {
-			post.canonicalImage = {
+			post.canonical_image = {
 				uri: canonicalImage.src,
 				width: canonicalImage.width,
 				height: canonicalImage.height

--- a/client/lib/post-normalizer/rule-first-pass-canonical-image.js
+++ b/client/lib/post-normalizer/rule-first-pass-canonical-image.js
@@ -1,12 +1,12 @@
 /**
  * External Dependencies
  */
-import { assign, find, startsWith } from 'lodash';
+import { assign, find } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-import { imageSizeFromAttachments, thumbIsLikelyImage } from './utils';
+import { imageSizeFromAttachments, thumbIsLikelyImage, isCandidateForCanonicalImage } from './utils';
 
 export default function firstPassCanonicalImage( post ) {
 	if ( thumbIsLikelyImage( post.post_thumbnail ) ) {
@@ -14,23 +14,19 @@ export default function firstPassCanonicalImage( post ) {
 		post.canonical_image = {
 			uri: url,
 			width,
-			height,
-			type: 'image'
+			height
 		};
 	} else if ( post.featured_image ) {
 		post.canonical_image = assign( {
-			uri: post.featured_image,
-			type: 'image'
+			uri: post.featured_image
 		}, imageSizeFromAttachments( post.featured_image ) );
-	} else {
-		const candidate = find( post.attachments, ( { mime_type } ) => startsWith( mime_type, 'image/' ) );
-
-		if ( candidate ) {
-			post.canonical_image = {
-				uri: candidate.URL,
-				width: candidate.width,
-				height: candidate.height,
-				type: 'image'
+	} else if ( post.content_images && post.content_images.length ) {
+		const canonicalImage = find( post.content_images, isCandidateForCanonicalImage );
+		if ( canonicalImage ) {
+			post.canonicalImage = {
+				uri: canonicalImage.src,
+				width: canonicalImage.width,
+				height: canonicalImage.height
 			};
 		}
 	}

--- a/client/lib/post-normalizer/rule-keep-valid-images.js
+++ b/client/lib/post-normalizer/rule-keep-valid-images.js
@@ -9,7 +9,7 @@ import filter from 'lodash/filter';
 
 function imageHasMinWidthAndHeight( width, height ) {
 	return function( image ) {
-		return image.naturalWidth >= width && image.naturalHeight >= height;
+		return image.width >= width && image.height >= height;
 	};
 }
 

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -2,31 +2,13 @@
  * External Dependencies
  */
 import { find } from 'lodash';
-import debugFactory from 'debug';
 
 /**
  * Internal Dependencies
  */
-import { thumbIsLikelyImage } from './utils';
+import { thumbIsLikelyImage, isCandidateForCanonicalImage } from './utils';
 
-const debug = debugFactory( 'calypso:post-normalizer:pick-canonical-image' );
 
-function candidateForCanonicalImage( image ) {
-	if ( ! image ) {
-		return false;
-	}
-
-	if ( image.naturalWidth < 350 ) {
-		debug( ( image && image.src ), ': not wide enough' );
-		return false;
-	}
-
-	if ( ( image.naturalWidth * image.naturalHeight ) < 30000 ) {
-		debug( ( image && image.src ), ': not enough area' );
-		return false;
-	}
-	return true;
-}
 
 export default function pickCanonicalImage( post ) {
 	let canonicalImage;
@@ -34,12 +16,12 @@ export default function pickCanonicalImage( post ) {
 		post.canonical_image = null;
 	}
 	if ( post.images ) {
-		canonicalImage = find( post.images, candidateForCanonicalImage );
+		canonicalImage = find( post.images, isCandidateForCanonicalImage );
 		if ( canonicalImage ) {
 			canonicalImage = {
 				uri: canonicalImage.src,
-				width: canonicalImage.naturalWidth,
-				height: canonicalImage.naturalHeight
+				width: canonicalImage.width,
+				height: canonicalImage.height
 			};
 		}
 	} else if ( thumbIsLikelyImage( post.post_thumbnail ) ) {

--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -19,7 +19,7 @@ export default function safeImagePropertiesForWidth( maxWidth ) {
 		if ( post.featured_media && post.featured_media.type === 'image' ) {
 			makeImageURLSafe( post.featured_media, 'uri', maxWidth, post.URL );
 		}
-		if ( post.canonical_image && post.canonical_image.type === 'image' ) {
+		if ( post.canonical_image && post.canonical_image.uri ) {
 			makeImageURLSafe( post.canonical_image, 'uri', maxWidth, post.URL );
 		}
 		if ( post.attachments ) {

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -7,7 +7,6 @@ import {
 	flow,
 	forEach,
 	map,
-	pick,
 	pull,
 	uniq
 } from 'lodash';
@@ -21,7 +20,12 @@ import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:post-normalizer:wait-for-images-to-load' );
 
 function convertImageToObject( image ) {
-	return pick( image, [ 'src', 'naturalWidth', 'naturalHeight' ] );
+	return {
+		src: image.src,
+		// use natural height and width
+		width: image.naturalWidth,
+		height: image.naturalHeight
+	};
 }
 
 function imageForURL( imageUrl ) {

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -615,25 +615,25 @@ describe( 'index', function() {
 				images: [
 					null, // null reference
 					{
-						naturalHeight: 1,
-						naturalWidth: 1
+						height: 1,
+						width: 1
 					}, // too small
 					{
-						naturalHeight: 351,
-						naturalWidth: 5
+						height: 351,
+						width: 5
 					}, // too narrow
 					{
-						naturalHeight: 5,
-						naturalWidth: 351
+						height: 5,
+						width: 351
 					}, // too short
 					{
-						naturalHeight: 351,
-						naturalWidth: 351,
+						height: 351,
+						width: 351,
 						src: 'http://example.com/image.jpg'
 					}, // YES
 					{
-						naturalHeight: 3500,
-						naturalWidth: 3500
+						height: 3500,
+						width: 3500
 					} // prefer first that passes
 				]
 			};
@@ -686,8 +686,8 @@ describe( 'index', function() {
 		it( 'should filter post.images based on size', function() {
 			function fakeImage( width, height ) {
 				return {
-					naturalWidth: width,
-					naturalHeight: height
+					width: width,
+					height: height
 				};
 			}
 			let post = {

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -31,7 +31,7 @@ export function imageSizeFromAttachments( post, imageUrl ) {
 }
 
 export function maxWidthPhotonishURL( imageURL, width ) {
-	if ( ! imageURL || ! width ) {
+	if ( ! imageURL ) {
 		return imageURL;
 	}
 
@@ -74,24 +74,11 @@ export function makeImageURLSafe( object, propName, maxWidth, baseURL ) {
 	}
 }
 
-let _useDomParser = false;
-// Firefox/Opera/IE throw errors on unsupported types
-try {
-	// WebKit returns null on unsupported types
-	if ( ( new DOMParser() ).parseFromString( '', 'text/html' ) ) {
-		// text/html parsing is natively supported
-		_useDomParser = true;
-	}
-} catch ( ex ) {}
-
 export function domForHtml( html ) {
 	let dom;
-	if ( _useDomParser ) {
+	if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
 		const parser = new DOMParser();
-		const doc = parser.parseFromString( html, 'text/html' );
-		if ( doc && doc.body ) {
-			dom = doc.body;
-		}
+		dom = parser.parseFromString( html, 'text/html' ).body;
 	} else {
 		dom = document.createElement( 'div' );
 		dom.innerHTML = html;
@@ -147,3 +134,17 @@ export function iframeIsWhitelisted( iframe ) {
 	} );
 }
 
+export function isCandidateForCanonicalImage( image ) {
+	if ( ! image ) {
+		return false;
+	}
+
+	if ( image.width < 350 ) {
+		return false;
+	}
+
+	if ( ( image.width * image.height ) < 30000 ) {
+		return false;
+	}
+	return true;
+}

--- a/client/my-sites/post/post-image/index.jsx
+++ b/client/my-sites/post/post-image/index.jsx
@@ -22,13 +22,13 @@ var PostImage = React.createClass( {
 			} ),
 			content_images: React.PropTypes.arrayOf( React.PropTypes.shape( {
 				src: React.PropTypes.string.isRequired,
-				naturalWidth: React.PropTypes.number,
-				naturalHeight: React.PropTypes.number
+				width: React.PropTypes.number,
+				height: React.PropTypes.number
 			} ) ),
 			images: React.PropTypes.arrayOf( React.PropTypes.shape( {
 				src: React.PropTypes.string.isRequired,
-				naturalWidth: React.PropTypes.number,
-				naturalHeight: React.PropTypes.number
+				width: React.PropTypes.number,
+				height: React.PropTypes.number
 			} ) )
 		} )
 	},

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -136,7 +136,6 @@ describe( 'selectors', () => {
 					name: 'Badman '
 				},
 				canonical_image: {
-					type: 'image',
 					uri: 'https://example.com/logo.png'
 				}
 			} );

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -77,7 +77,6 @@ describe( 'utils', () => {
 					name: 'Badman '
 				},
 				canonical_image: {
-					type: 'image',
 					uri: 'https://example.com/logo.png'
 				}
 			} );

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -143,7 +143,6 @@ const fastPostNormalizationRules = flow( [
 	makeSiteIdSafeForApi,
 	pickPrimaryTag,
 	safeImageProperties( READER_CONTENT_WIDTH ),
-	firstPassCanonicalImage,
 	withContentDom( [
 		removeStyles,
 		removeElementsBySelector,
@@ -157,6 +156,7 @@ const fastPostNormalizationRules = flow( [
 		detectPolls,
 		wordCount
 	] ),
+	firstPassCanonicalImage,
 	createBetterExcerpt,
 	classifyPost
 ] );


### PR DESCRIPTION
Previously, we used the naturalHeight and naturalWidth to capture and communicate the dimensions of a loaded image.

This changes things to normalize onto the normal width and height attributes, and teaches some of the rules downstream from wait-for-content-images-to-load how to use these new attributes.

This allows the reader to pick a canonical image much earlier in the process and for that canonical image to be stable in many more cases.