### PR TITLE
Signup: Survey step - make the chevron not-clickable

### DIFF
--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -114,6 +114,7 @@
 
 .survey__vertical-chevron {
 	color: lighten( $gray, 20% );
+	pointer-events: none;
 }
 
 .survey__other {


### PR DESCRIPTION
This PR is a fix for #9018.

The problem was that when the user clicks on the small arrow on the right of the button, an error was thrown and the user was not sent to the next signup step. 

I removed the click event for the arrow with CSS so now when the user clicks, the click is passed down directly to the button.

To test:

1. Checkout branch or use Calypso.live link
2. Start signup and on the Survey step (first step) verify the following:
3. When you hover on the button/arrow it will animate after a moment, nudging the user to chose it.
4. When you click the arrow it will send the user to the next step.
5. When you click the button itself it will send the user to the next step.

cc @coreh @michaeldcain @fabianapsimoes @ranh 