### PR TITLE
State: Add getSection() UI selector

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import MasterbarLoggedOut from 'layout/masterbar/logged-out';
+import { getSection } from 'state/ui/selectors';
 
 const LayoutLoggedOut = ( {
 	primary,
@@ -57,6 +58,6 @@ LayoutLoggedOut.propTypes = {
 
 export default connect(
 	state => ( {
-		section: state.ui.section
+		section: getSection( state )
 	} )
 )( LayoutLoggedOut );

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -22,7 +22,7 @@ import PluginComponent from './plugin';
 import PluginBrowser from './plugins-browser';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSection } from 'state/ui/selectors';
 
 /**
  * Module variables
@@ -154,7 +154,7 @@ function renderPluginsBrowser( context ) {
 
 function renderProvisionPlugins( context ) {
 	const state = context.store.getState();
-	const section = state.ui.section;
+	const section = getSection( state );
 	const site = getSelectedSite( state );
 	context.store.dispatch( setSection( Object.assign( {}, section, { secondary: false } ) ) );
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );

--- a/client/state/ui/first-view/selectors.js
+++ b/client/state/ui/first-view/selectors.js
@@ -12,7 +12,7 @@ import { some, startsWith, takeRightWhile, find, findLast } from 'lodash';
 import { FIRST_VIEW_CONFIG } from './constants';
 import { getActionLog } from 'state/ui/action-log/selectors';
 import { getPreference, preferencesLastFetchedTimestamp } from 'state/preferences/selectors';
-import { isSectionLoading, getInitialQueryArguments } from 'state/ui/selectors';
+import { isSectionLoading, getInitialQueryArguments, getSection } from 'state/ui/selectors';
 import { FIRST_VIEW_HIDE, ROUTE_SET } from 'state/action-types';
 import { getCurrentUserDate } from 'state/current-user/selectors';
 
@@ -74,7 +74,7 @@ export function wasFirstViewHiddenSinceEnteringCurrentSection( state, config ) {
 }
 
 function routeSetIsInCurrentSection( state, routeSet ) {
-	const section = state.ui.section;
+	const section = getSection( state );
 	return some( section.paths, path => startsWith( routeSet.path, path ) );
 }
 

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -58,7 +58,7 @@ export function getSelectedSiteSlug( state ) {
  * @return {Object}        Current section
  */
 export function getSection( state ) {
-	return state.ui.section || {};
+	return state.ui.section || false;
 }
 
 /**
@@ -68,7 +68,11 @@ export function getSection( state ) {
  * @return {?String}       Current section name
  */
 export function getSectionName( state ) {
-	return get( getSection( state ), 'name', null );
+	const section = getSection( state );
+	if ( ! section ) {
+		return null;
+	}
+	return get( section, 'name', null );
 }
 
 /**
@@ -78,7 +82,11 @@ export function getSectionName( state ) {
  * @return {?String}       Current section group name
  */
 export function getSectionGroup( state ) {
-	return get( getSection( state ), 'group', null );
+	const section = getSection( state );
+	if ( ! section ) {
+		return null;
+	}
+	return get( section, 'group', null );
 }
 
 /**
@@ -110,7 +118,11 @@ export function isSectionLoading( state ) {
  * @see client/sections
  */
 export function isSectionIsomorphic( state ) {
-	return get( getSection( state ), 'isomorphic', false );
+	const section = getSection( state );
+	if ( ! section ) {
+		return false;
+	}
+	return get( section, 'isomorphic', false );
 }
 
 /**

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -68,7 +68,7 @@ export function getSection( state ) {
  * @return {?String}       Current section name
  */
 export function getSectionName( state ) {
-	return get( state.ui.section, 'name', null );
+	return get( getSection( state ), 'name', null );
 }
 
 /**
@@ -78,7 +78,7 @@ export function getSectionName( state ) {
  * @return {?String}       Current section group name
  */
 export function getSectionGroup( state ) {
-	return get( state.ui.section, 'group', null );
+	return get( getSection( state ), 'group', null );
 }
 
 /**
@@ -110,7 +110,7 @@ export function isSectionLoading( state ) {
  * @see client/sections
  */
 export function isSectionIsomorphic( state ) {
-	return get( state.ui.section, 'isomorphic', false );
+	return get( getSection( state ), 'isomorphic', false );
 }
 
 /**
@@ -139,5 +139,5 @@ export function hasSidebar( state ) {
 	if ( val === false ) {
 		return false;
 	}
-	return get( state.ui.section, 'secondary', true );
+	return get( getSection( state ), 'secondary', true );
 }

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -68,11 +68,7 @@ export function getSection( state ) {
  * @return {?String}       Current section name
  */
 export function getSectionName( state ) {
-	const section = getSection( state );
-	if ( ! section ) {
-		return null;
-	}
-	return get( section, 'name', null );
+	return get( getSection( state ), 'name', null );
 }
 
 /**
@@ -82,11 +78,7 @@ export function getSectionName( state ) {
  * @return {?String}       Current section group name
  */
 export function getSectionGroup( state ) {
-	const section = getSection( state );
-	if ( ! section ) {
-		return null;
-	}
-	return get( section, 'group', null );
+	return get( getSection( state ), 'group', null );
 }
 
 /**
@@ -118,11 +110,7 @@ export function isSectionLoading( state ) {
  * @see client/sections
  */
 export function isSectionIsomorphic( state ) {
-	const section = getSection( state );
-	if ( ! section ) {
-		return false;
-	}
-	return get( section, 'isomorphic', false );
+	return get( getSection( state ), 'isomorphic', false );
 }
 
 /**

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -52,6 +52,16 @@ export function getSelectedSiteSlug( state ) {
 }
 
 /**
+ * Returns the current section.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {Object}        Current section
+ */
+export function getSection( state ) {
+	return state.ui.section || {};
+}
+
+/**
  * Returns the current section name.
  *
  * @param  {Object}  state Global state tree

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -113,14 +113,14 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSection()', () => {
-		it( 'should return an empty object if no section is assigned', () => {
+		it( 'should return false if no section is assigned', () => {
 			const section = getSection( {
 				ui: {
 					section: false
 				}
 			} );
 
-			expect( section ).to.eql( {} );
+			expect( section ).to.eql( false );
 		} );
 
 		it( 'should return the current section if there is one assigned', () => {

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -10,6 +10,7 @@ import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSelectedSiteSlug,
+	getSection,
 	getSectionName,
 	getSectionGroup,
 	isSiteSection,
@@ -108,6 +109,35 @@ describe( 'selectors', () => {
 			} );
 
 			expect( slug ).to.eql( 'example.com' );
+		} );
+	} );
+
+	describe( '#getSection()', () => {
+		it( 'should return an empty object if no section is assigned', () => {
+			const section = getSection( {
+				ui: {
+					section: false
+				}
+			} );
+
+			expect( section ).to.eql( {} );
+		} );
+
+		it( 'should return the current section if there is one assigned', () => {
+			const sectionObj = {
+				name: 'post-editor',
+				paths: [ '/post', '/page' ],
+				module: 'post-editor',
+				group: 'editor',
+				secondary: true
+			};
+			const section = getSection( {
+				ui: {
+					section: sectionObj
+				}
+			} );
+
+			expect( section ).to.equal( sectionObj );
 		} );
 	} );
 


### PR DESCRIPTION
This PR implements a `getSection()` UI selector, as suggested in https://github.com/Automattic/wp-calypso/pull/9179#discussion_r87052238.

To test:

* Checkout this branch.
* Verify the tests of the new selector pass: `npm run test-client client/state/ui/test/selectors.js -- --grep "getSection\(\)"`.
* Verify all tests still pass: `npm run test-client`.

/cc @gwwar 