### PR TITLE
Components: Refactor FormTelInput to resolve prop warnings

### DIFF
--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -83,7 +83,6 @@ module.exports = React.createClass( {
 						{ ...this.props.phoneInputProps }
 						disabled={ this.props.isDisabled }
 						name="phone_number"
-						ref="phoneNumber"
 						valueLink={ phoneValueLink }
 					/>
 				</FormFieldset>

--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -17,7 +17,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var otherProps = omit( this.props, [ 'className', 'type' ] ),
+		var otherProps = omit( this.props, [ 'className', 'type', 'isError' ] ),
 			classes = classNames( {
 				'form-tel-input': true,
 				'is-error': this.props.isError

--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -17,7 +17,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var otherProps = omit( this.props, [ 'className', 'type', 'isError' ] ),
+		var otherProps = omit( this.props, [ 'isError' ] ),
 			classes = classNames( {
 				'form-tel-input': true,
 				'is-error': this.props.isError

--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -1,34 +1,22 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' ),
-	omit = require( 'lodash/omit' ),
-	classNames = require( 'classnames' );
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 
-module.exports = React.createClass( {
+export default function FormTelInput( { className, isError, ...props } ) {
+	const classes = classNames( 'form-tel-input', className, {
+		'is-error': isError
+	} );
 
-	displayName: 'FormTelInput',
+	return <input { ...props } type="tel" pattern="[0-9]*" className={ classes } />;
+}
 
-	getDefaultProps: function() {
-		return {
-			isError: false
-		};
-	},
+FormTelInput.propTypes = {
+	className: PropTypes.string,
+	isError: PropTypes.bool
+};
 
-	render: function() {
-		var otherProps = omit( this.props, [ 'isError' ] ),
-			classes = classNames( {
-				'form-tel-input': true,
-				'is-error': this.props.isError
-			} );
-
-		return (
-			<input
-				{ ...otherProps }
-				type={ 'tel' }
-				pattern={ '[0-9]*' }
-				className={ classnames( this.props.className, classes ) } />
-		);
-	}
-} );
+FormTelInput.defaultProps = {
+	isError: false
+};

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -188,7 +188,6 @@ module.exports = React.createClass( {
 							name="code"
 							placeholder={ codePlaceholder }
 							onFocus={ this.recordFocusEvent( 'Reauth Required Verification Code Field' ) }
-							ref="code"
 							valueLink={ this.linkState( 'code' ) } />
 
 						{ this.renderFailedValidationMsg() }


### PR DESCRIPTION
Related: #7413

This pull request seeks to resolve warnings logged in development environments related to an `isError` prop being passed from the `<FormTelInput />` component to an `input` DOM element.

In doing so, I've refactored the component as a stateless function component, included `propTypes`, and generally simplified the render logic.

As a stateless function component, it cannot be referenced by a React `ref` prop on the parent component, so included are changes to remove those `refs` where used, which don't appear to be necessary anyways.

__Testing instructions:__

Verify that there are no regressions in the usage of `<FormTelInput />`. There is an example on the [DevDocs Design Form Fields section](http://calypso.localhost:3000/devdocs/design/form-fields). `<FormTelInput />` also appears to be used as the 2FA code input when navigating to the `/me` section, so if your token is stale, verify that the dialog continues to behave as expected.

cc @ebinnion re: 7a0831dc8ae9334b745e76e477bbe164203a0780, was there a reason `ref` was added in this commit?