### PR TITLE
Domains: Improve free subdomain handling in domain suggestion screen, second try

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -28,7 +28,7 @@ var productsValues = require( 'lib/products-values' ),
 	isUnlimitedThemes = productsValues.isUnlimitedThemes,
 	isVideoPress = productsValues.isVideoPress,
 	isJetpackPlan = productsValues.isJetpackPlan,
-	isWordPressDomain = productsValues.isWordPressDomain,
+	isFreeWordPressComDomain = productsValues.isFreeWordPressComDomain,
 	sortProducts = require( 'lib/products-values/sort' ),
 	PLAN_PERSONAL = require( 'lib/plans/constants' ).PLAN_PERSONAL;
 
@@ -729,7 +729,7 @@ function shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggesti
 		// not free or a cart item
 		( isDomainRegistration( suggestionOrCartItem ) ||
 			isDomainMapping( suggestionOrCartItem ) ||
-			( suggestionOrCartItem.domain_name && ! isWordPressDomain( suggestionOrCartItem ) ) ) &&
+			( suggestionOrCartItem.domain_name && ! isFreeWordPressComDomain( suggestionOrCartItem ) ) ) &&
 		( ! isDomainBeingUsedForPlan( cart, suggestionOrCartItem.domain_name ) ) && // a plan in cart
 		( ! isNextDomainFree( cart ) ) && // domain credit
 		( ! hasPlan( cart ) ) && // already a plan in cart

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 var assign = require( 'lodash/assign' ),
-	endsWith = require( 'lodash/endsWith' ),
 	difference = require( 'lodash/difference' ),
 	isEmpty = require( 'lodash/isEmpty' ),
 	pick = require( 'lodash/pick' );
@@ -262,6 +261,11 @@ function isDependentProduct( product, dependentProduct, domainsWithPlansOnly ) {
 		product.meta === dependentProduct.meta
 	);
 }
+function isFreeWordPressComDomain( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+	return product.is_free === true;
+}
 
 function isGoogleApps( product ) {
 	product = formatProduct( product );
@@ -319,13 +323,6 @@ function isUnlimitedThemes( product ) {
 	return 'unlimited_themes' === product.product_slug;
 }
 
-function isWordPressDomain( product ) {
-	product = formatProduct( product );
-	assertValidProduct( product );
-
-	return endsWith( product.domain_name, '.wordpress.com' );
-}
-
 function whitelistAttributes( product ) {
 	return pick( product, Object.keys( schema.properties ) );
 }
@@ -358,6 +355,7 @@ module.exports = {
 	isFreePlan,
 	isPersonal,
 	isFreeTrial,
+	isFreeWordPressComDomain,
 	isGoogleApps,
 	isGuidedTransfer,
 	isJetpackBusiness,
@@ -376,6 +374,5 @@ module.exports = {
 	isUnlimitedSpace,
 	isUnlimitedThemes,
 	isVideoPress,
-	isWordPressDomain,
 	whitelistAttributes
 };


### PR DESCRIPTION
This is a redo of #9216. I accidentally merged the branch before merging the backend update. 

--- Original PR description below ---

This PR aims to improve the handling of free subdomains in the domains selection screen.

We're improving the way the free subdomains logic is handled and adding a is_free property to the results, returned by the suggestions endpoint.

To test:

1. Checkout branch / Use Calypso.live link.
2. Apply D3224-code backend patch
3. Start Signup
4. Reach the domains screen
5. Search for something
6. Verify the free .wordpress.com still says Select on the CTA button.
cc @michaeldcain @coreh

cc2 @umurkontaci since you last touched that code :)