### PR TITLE
Themes: Add missing siteSelection middleware

### DIFF
--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -18,7 +18,7 @@ export default function( router ) {
 		if ( isLoggedIn ) {
 			router(
 				`/design/:vertical(${ verticals })?/:tier(free|premium)?`,
-				multiSite, makeNavigation, makeLayout
+				siteSelection, multiSite, makeNavigation, makeLayout
 			);
 			router(
 				`/design/:vertical(${ verticals })?/:tier(free|premium)?/:site_id`,


### PR DESCRIPTION
Fixes current site selection in sidebar when 'All Sites' is selected on the /design route.

**To Test**
* Go to http://calypso.localhost:3000/design
* Click _Switch Site_ and choose a site
* Click _Switch Site_ and choose _All Sites_
Expected: _All Sites_ shows in as the selected site

Compare with production /design, where the last selected site always shows.

