### PR TITLE
Plans: display regular size domain to plan nudge

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,6 +98,15 @@ module.exports = {
 		defaultVariation: 'hideSiteTitleStep',
 		allowExistingUsers: false
 	},
+	domainToPersonalPlanNudge3: {
+		datestamp: '20161109',
+		variations: {
+			original: 50,
+			nudge: 50
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true
+	},
 	gSuiteOnSignup: {
 		datestamp: '20161025',
 		variations: {

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -36,6 +36,7 @@ import { hasDomainCredit } from 'state/sites/plans/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { isPlanFeaturesEnabled } from 'lib/plans';
+import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 
 export const List = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'list' ) ],
@@ -112,6 +113,8 @@ export const List = React.createClass( {
 					{ this.notice() }
 					{ this.listItems() }
 				</div>
+
+				<DomainToPlanNudge />
 			</Main>
 		);
 	},

--- a/client/my-sites/upgrades/domain-management/list/test/index.js
+++ b/client/my-sites/upgrades/domain-management/list/test/index.js
@@ -42,6 +42,7 @@ describe( 'index', function() {
 				getProducts: noop
 			} )
 		} );
+		mockery.registerMock( 'blocks/domain-to-plan-nudge', EmptyComponent );
 	} );
 
 	before( () => {


### PR DESCRIPTION
As a follow up to #8635 and p3fqKv-40j-p2 this PR renders a regular size nudge on the domains page when:
* A site has a paid domain
* The site has a free plan
* abtest `domainToPersonalPlanNudge3` is set to `nudge`
<img width="703" alt="screen shot 2016-11-09 at 3 11 07 pm" src="https://cloud.githubusercontent.com/assets/1270189/20158391/dbcb133c-a68e-11e6-80c1-8a7808f5620a.png">

We'll run this test for 2 weeks, using the same baseline as the last test p3fqKv-3LH-p2.

### Testing Instructions:
- Navigate to http://calypso.localhost:3000/domains
- Set the abtest `domainToPersonalPlanNudge3` to `nudge`
- Select a wpcom site that has a paid domain, but a free plan
- We should see a nudge render below domains
- An impression analytics event should fire:
<img width="1122" alt="screen shot 2016-11-09 at 11 54 24 am" src="https://cloud.githubusercontent.com/assets/1270189/20152839/c4471892-a674-11e6-9a51-3f0951ddb2c7.png">
- Clicking on the nudge takes us to checkout with a personal plan in cart
- The following analytics event should fire:
<img width="1109" alt="screen shot 2016-11-09 at 11 55 11 am" src="https://cloud.githubusercontent.com/assets/1270189/20152855/db578e2c-a674-11e6-92fa-6c9c56490206.png">

cc @rralian @apeatling @lamosty @retrofox 
