### PR TITLE
Happychat: Enables happychat for customers

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -19,7 +19,7 @@
 		"community-translator": true,
 		"desktop-promo": true,
 		"guided-tours": true,
-		"happychat": false,
+		"happychat": true,
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,


### PR DESCRIPTION
Customers will be able open a happychat session if happychat is staffed and
enabled from the Happiness Engineer interface.