### PR TITLE
Reader Stream Refresh: Add border to images

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -416,7 +416,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // Gallery cards
 .reader-post-card__gallery {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid lighten( $gray, 30% );
 	display: flex;
 	margin: 0 0 17px;
 	padding: 0;
@@ -434,7 +434,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	cursor: pointer;
 	flex: 1;
 	list-style-type: none;
-	border-right: 1px solid lighten( $gray, 20% );
+	border-right: 1px solid lighten( $gray, 30% );
 
 	&:last-child {
 		border-right: 0;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -20,6 +20,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	&.has-thumbnail {
 
 		.reader-post-card__featured-image {
+			border: 1px solid lighten( $gray, 20% );
 			display: flex;
 			align-items: center;
 			justify-content: center;
@@ -415,6 +416,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // Gallery cards
 .reader-post-card__gallery {
+	border: 1px solid lighten( $gray, 20% );
 	display: flex;
 	margin: 0 0 17px;
 	padding: 0;
@@ -432,11 +434,16 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	cursor: pointer;
 	flex: 1;
 	list-style-type: none;
-	margin-right: 1px;
+	border-right: 1px solid lighten( $gray, 20% );
+
+	&:last-child {
+		border-right: 0;
+	}
 
 	&:last-child {
 
-		@media #{$reader-post-card-breakpoint-medium}  {
+		@media #{$reader-post-card-breakpoint-medium} {
+			border-right: 0;
 			display: none;
 		}
 	}
@@ -445,6 +452,20 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		@include breakpoint( "<480px" ) {
 			display: none;
+		}
+	}
+
+	&:nth-child(3) {
+
+		@media #{$reader-post-card-breakpoint-medium} {
+			border-right: 0;
+		}
+	}
+
+	&:nth-child(2) {
+
+		@include breakpoint( "<480px" ) {
+			border-right: 0;
 		}
 	}
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9187

**Before:**

![screenshot 2016-11-09 14 11 30](https://cloud.githubusercontent.com/assets/4924246/20156748/8c1d51e0-a686-11e6-934f-453045c109d0.png)
![screenshot 2016-11-09 14 11 52](https://cloud.githubusercontent.com/assets/4924246/20156746/8c19fbee-a686-11e6-84ed-09a41f2d5c73.png)
![screenshot 2016-11-09 14 12 00](https://cloud.githubusercontent.com/assets/4924246/20156747/8c1be2f6-a686-11e6-86fc-548815db360a.png)

**After:**
![screenshot 2016-11-09 15 12 05](https://cloud.githubusercontent.com/assets/4924246/20158430/0ada5dd6-a68f-11e6-94f0-80728f0ceec9.png)
![screenshot 2016-11-09 15 12 16](https://cloud.githubusercontent.com/assets/4924246/20158431/0adb1ece-a68f-11e6-8f3c-48aed82770c8.png)
![screenshot 2016-11-09 15 12 23](https://cloud.githubusercontent.com/assets/4924246/20158429/0ad96aca-a68f-11e6-9e5f-47258d788cce.png)

