### PR TITLE
Themes: Use isThemePurchased selector instead of theme.purchased attr

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -65,6 +65,7 @@ const Theme = React.createClass( {
 		return nextProps.theme.id !== this.props.theme.id ||
 			! isEqual( nextProps.buttonContents, this.props.buttonContents ) ||
 			( nextProps.active !== this.props.active ) ||
+			( nextProps.purchased !== this.props.purchased ) ||
 			( nextProps.screenshotClickUrl !== this.props.screenshotClickUrl ) ||
 			( nextProps.onScreenshotClick !== this.props.onScreenshotClick ) ||
 			( nextProps.onMoreButtonClick !== this.props.onMoreButtonClick );

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -29,8 +29,6 @@ const Theme = React.createClass( {
 			screenshot: React.PropTypes.string,
 			// Theme price (pre-formatted string) -- empty string indicates free theme
 			price: React.PropTypes.string,
-			// If true, the user has 'purchased' the theme
-			purchased: React.PropTypes.bool,
 			author: React.PropTypes.string,
 			author_uri: React.PropTypes.string,
 			demo_uri: React.PropTypes.string,
@@ -38,6 +36,8 @@ const Theme = React.createClass( {
 		} ),
 		// If true, highlight this theme as active
 		active: React.PropTypes.bool,
+		// If true, the user has 'purchased' the theme
+		purchased: React.PropTypes.bool,
 		// If true, render a placeholder
 		isPlaceholder: React.PropTypes.bool,
 		// URL the screenshot link points to
@@ -62,8 +62,7 @@ const Theme = React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps ) {
-		// TODO: Once we're not using theme.purchased anymore, just compare theme.id instead of entire theme objects.
-		return ! isEqual( nextProps.theme, this.props.theme ) ||
+		return nextProps.theme.id !== this.props.theme.id ||
 			! isEqual( nextProps.buttonContents, this.props.buttonContents ) ||
 			( nextProps.active !== this.props.active ) ||
 			( nextProps.screenshotClickUrl !== this.props.screenshotClickUrl ) ||
@@ -111,10 +110,12 @@ const Theme = React.createClass( {
 		const {
 			name,
 			price,
-			purchased,
 			screenshot
 		} = this.props.theme;
-		const { active } = this.props;
+		const {
+			active,
+			purchased
+		} = this.props;
 		const themeClass = classNames( 'theme', {
 			'is-active': active,
 			'is-actionable': !! ( this.props.screenshotClickUrl || this.props.onScreenshotClick )

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -36,6 +36,7 @@ export const ThemesList = React.createClass( {
 		onMoreButtonClick: React.PropTypes.func,
 		getActionLabel: React.PropTypes.func,
 		isActive: React.PropTypes.func,
+		isPurchased: React.PropTypes.func,
 		// i18n function provided by localize()
 		translate: React.PropTypes.func,
 		showThemeUpload: React.PropTypes.bool,
@@ -57,7 +58,8 @@ export const ThemesList = React.createClass( {
 			fetchNextPage: noop,
 			optionsGenerator: () => [],
 			getActionLabel: () => '',
-			isActive: () => false
+			isActive: () => false,
+			isPurchased: () => false
 		};
 	},
 
@@ -80,7 +82,8 @@ export const ThemesList = React.createClass( {
 			actionLabel={ this.props.getActionLabel( theme ) }
 			index={ index }
 			theme={ theme }
-			active={ this.props.isActive( theme.id ) } />;
+			active={ this.props.isActive( theme.id ) }
+			purchased={ this.props.isPurchased( theme.id ) } />;
 	},
 
 	renderLoadingPlaceholders() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -63,7 +63,6 @@ const ThemeSheet = React.createClass( {
 		download: React.PropTypes.string,
 		taxonomies: React.PropTypes.object,
 		stylesheet: React.PropTypes.string,
-		purchased: React.PropTypes.bool,
 		// Connected props
 		isLoggedIn: React.PropTypes.bool,
 		isActive: React.PropTypes.bool,

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -9,17 +9,12 @@ import React from 'react';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import { connectOptions } from './theme-options';
-import QueryUserPurchases from 'components/data/query-user-purchases';
 import ThemeShowcase from './theme-showcase';
-import userFactory from 'lib/user';
-
-const user = userFactory();
 
 const MultiSiteThemeShowcase = connectOptions(
 	( props ) => (
 		<ThemesSiteSelectorModal { ...props } sourcePath="/design">
 			<ThemeShowcase source="showcase">
-				{ <QueryUserPurchases userId={ user.get().ID } /> }
 				<SidebarNavigation />
 			</ThemeShowcase>
 		</ThemesSiteSelectorModal>

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -9,12 +9,17 @@ import React from 'react';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import { connectOptions } from './theme-options';
+import QueryUserPurchases from 'components/data/query-user-purchases';
 import ThemeShowcase from './theme-showcase';
+import userFactory from 'lib/user';
+
+const user = userFactory();
 
 const MultiSiteThemeShowcase = connectOptions(
 	( props ) => (
 		<ThemesSiteSelectorModal { ...props } sourcePath="/design">
 			<ThemeShowcase source="showcase">
+				{ <QueryUserPurchases userId={ user.get().ID } /> }
 				<SidebarNavigation />
 			</ThemeShowcase>
 		</ThemesSiteSelectorModal>

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -25,6 +25,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import { isActiveTheme } from 'state/themes/current-theme/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 
 const sites = sitesFactory();
@@ -53,6 +54,7 @@ const SingleSiteThemeShowcase = connectOptions(
 
 			return (
 				<ThemeShowcase { ...props } siteId={ site && site.ID }>
+					{ site && <QuerySitePurchases siteId={ site.ID } /> }
 					<SidebarNavigation />
 					<ThanksModal
 						site={ site }

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -22,7 +22,8 @@ import {
 	getThemeCustomizeUrl as	getCustomizeUrl,
 	getThemeDetailsUrl as getDetailsUrl,
 	getThemeSupportUrl as getSupportUrl,
-	getThemeHelpUrl as getHelpUrl
+	getThemeHelpUrl as getHelpUrl,
+	isThemePurchased as isPurchased
 } from 'state/themes/selectors';
 import { isActiveTheme as isActive } from 'state/themes/current-theme/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -38,7 +39,7 @@ const purchase = config.isEnabled( 'upgrades/checkout' )
 			comment: 'label for selecting a site for which to purchase a theme'
 		} ),
 		getUrl: getPurchaseUrl,
-		hideForTheme: ( state, theme, site ) => ! theme.price || isActive( state, theme.id, site ) || theme.purchased
+		hideForTheme: ( state, theme, site ) => ! theme.price || isActive( state, theme.id, site ) || isPurchased( state, theme.id, site )
 	}
 	: {};
 
@@ -46,7 +47,7 @@ const activate = {
 	label: i18n.translate( 'Activate' ),
 	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
 	action: activateTheme,
-	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site ) || ( theme.price && ! theme.purchased )
+	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site ) || ( theme.price && ! isPurchased( state, theme.id, site ) )
 };
 
 const customize = {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -163,6 +163,10 @@ export default connect(
 	( state, { siteId } ) => ( {
 		siteSlug: getSiteSlug( state, siteId ),
 		isActiveTheme: themeId => isActiveTheme( state, themeId, siteId ),
+		// Note: This component assumes that purchase data is already present in the state tree
+		// (used by the isThemePurchased selector). At the time of implementation there's no caching
+		// in <QuerySitePurchases /> and a parent component is already rendering it. So to avoid
+		// redundant AJAX requests, we're not rendering the query component locally.
 		isThemePurchased: themeId => isThemePurchased( state, themeId, siteId )
 	} )
 )( ThemesSelection );

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -17,6 +17,7 @@ import analytics from 'lib/analytics';
 import buildUrl from 'lib/mixins/url-search/build-url';
 import { getSiteSlug } from 'state/sites/selectors';
 import { isActiveTheme } from 'state/themes/current-theme/selectors';
+import { isThemePurchased } from 'state/themes/selectors';
 import {
 	getFilter,
 	getSortedFilterTerms,
@@ -47,6 +48,7 @@ const ThemesSelection = React.createClass( {
 		// connected props
 		siteSlug: React.PropTypes.string,
 		isActiveTheme: React.PropTypes.func,
+		isThemePurchased: React.PropTypes.func,
 	},
 
 	getDefaultProps() {
@@ -148,7 +150,8 @@ const ThemesSelection = React.createClass( {
 						onScreenshotClick={ this.onScreenshotClick }
 						getScreenshotUrl={ this.props.getScreenshotUrl }
 						getActionLabel={ this.props.getActionLabel }
-						isActive={ this.props.isActiveTheme } />
+						isActive={ this.props.isActiveTheme }
+						isPurchased={ this.props.isThemePurchased } />
 				</ThemesData>
 			</div>
 		);
@@ -159,6 +162,7 @@ const ThemesSelection = React.createClass( {
 export default connect(
 	( state, { siteId } ) => ( {
 		siteSlug: getSiteSlug( state, siteId ),
-		isActiveTheme: themeId => isActiveTheme( state, themeId, siteId )
+		isActiveTheme: themeId => isActiveTheme( state, themeId, siteId ),
+		isThemePurchased: themeId => isThemePurchased( state, themeId, siteId )
 	} )
 )( ThemesSelection );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -200,8 +200,6 @@ export function isThemeActive( state, themeId, siteId ) {
  *
  * Use this selector alongside with the <QuerySitePurchases /> component.
  *
- * DON'T USE YET! This uses the getSitePurchases() which sometimes seems to omit some purchases.
- *
  * @param  {Object}  state   Global state tree
  * @param  {String}  themeId Theme ID
  * @param  {Number}  siteId  Site ID


### PR DESCRIPTION
**This is waiting on a fix to the `sites/[siteId]/purchases` endpoint to ensure `<QuerySitePurchases ... />` yields accurate purchase information.**

Replaces all uses of `theme.purchased` to use the `isThemePurchased` selector. See #6924 for context. Closely mirrors work done in #9193.

### Notes
- The results are hard to empirically test in-browser, because often when we're checking for `purchased` we're also checking for a `price` on the Theme (a la `if ( price && ! purchased )`). But purchased themes come back with `price === undefined` — so even if the `purchased` flag is broken, the `price` field masks it because it _also_ kind of represents when a theme is purchased.
- References to `purchased` are left in the action creators and reducers, since those will be refactored soon anyways.