### PR TITLE
People: filtering users by role (reimplementation)

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -74,6 +74,7 @@
 		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
+		"manage/people/role-filtering": true,
 		"manage/plans": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,


### PR DESCRIPTION
This is a replacement for #8746 (which should be considered a spike implementation for the purpose of exploring different design options and obtaining feedback).

I now plan to reimplement the feature from scratch adding test coverage around the people feature and avoiding some of the complexity in components introduced by the initial implementation.

Here are the aspects of the initial implementation that I think are reasonable (and i'd start with again):

* make the change to the `client/lib/mixins/url-search` mixin to allow an optional base url to be used instead of window.location.href (perhaps this should be a separate PR).
* add the generic `/people/team/role/:role` and `/people/team/role/:role/:site_id` routes (binding to the existing people controller).

Here are some things I will do differently:

* Create a new component for RoleSelect dropdown navigation (instead of just adding completel new behaviour to the existing component).
* Create some helper functions for the complicated branching logic to determine display results and text in `client/my-sites/people/team-list/team.jsx`.
