### PR TITLE
Theme helpers: Import sectionify directly from lib/route/path

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/lib/route/trailingslashit.js
+++ b/client/lib/route/trailingslashit.js
@@ -1,3 +1,4 @@
+/** @ssr-ready **/
 
 var trailingSlashRe = /(\/)?$/;
 

--- a/client/lib/route/untrailingslashit.js
+++ b/client/lib/route/untrailingslashit.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 var trailingSlashRe = /\/$/;
 
 module.exports = function unTrailingSlashIt( path ) {

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -11,7 +11,7 @@ import mapValues from 'lodash/mapValues';
  * Internal dependencies
  */
 import config from 'config';
-import route from 'lib/route';
+import { sectionify } from 'lib/route/path';
 import { oldShowcaseUrl, isPremiumTheme as isPremium } from 'state/themes/utils';
 
 export function getSignupUrl( theme ) {
@@ -124,8 +124,7 @@ function appendActionTracking( option, name ) {
 }
 
 export function getAnalyticsData( path, tier, site_id ) {
-	// Since lib/route isn't available in SSR context, check for it before we use it
-	let basePath = route.sectionify && route.sectionify( path );
+	let basePath = sectionify( path );
 	let analyticsPageTitle = 'Themes';
 
 	if ( tier ) {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -98,7 +98,6 @@ var webpackConfig = {
 		new webpack.BannerPlugin( 'require( "source-map-support" ).install();', { raw: true, entryOnly: false } ),
 		new webpack.NormalModuleReplacementPlugin( /^lib\/analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib\/olark$/, 'lodash/noop' ), // Too many dependencies, e.g. sites-list
-		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ), // Depends too much on page.js
 		new webpack.NormalModuleReplacementPlugin( /^lib\/post-normalizer\/rule-create-better-excerpt$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/preview-upgrade-nudge$/, 'components/empty-component' ), // Depends on page.js and should never be required server side
 		new webpack.NormalModuleReplacementPlugin( /^components\/popover$/, 'components/empty-component' ), // Depends on BOM and interactions don't work without JS


### PR DESCRIPTION
This way, we can rely on sectionify on the server-side too, since lib/route/path doesn't depend on page (as opposed to the rest of lib/route).
Also, add @ssr-ready pragma to lib/route/path and its dependencies.

This removes the server-side
 ```
Warning: Failed prop type: Required prop `path` was not specified in `PageViewTracker`.
    in PageViewTracker
```
warning _in the terminal, not the browser console!_ that is present on `master` after first starting calypso and first loading `http://calypso.localhost:3000/design` in the browser.

To test:
* Restart Calypso, and load `http://calypso.localhost:3000/design`. Observe that there is no such warning anymore in the (node) console.
* Try loading `http://calypso.localhost:3000/design` and a theme page (e.g. `http://calypso.localhost:3000/theme/mood`) in incognito mode to make sure they're still properly SSR'd.

props @budzanowski for finding this warning and its cause in #9215.