### PR TITLE
Signup: Remove survey step dependency for user step

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -21,6 +21,7 @@ import { PLAN_PREMIUM } from 'lib/plans/constants';
 import analytics from 'lib/analytics';
 
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
+import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 
 function createSiteWithCart( callback, dependencies, {
 	cartItem,
@@ -33,13 +34,14 @@ function createSiteWithCart( callback, dependencies, {
 	themeItem
 } ) {
 	const siteTitle = getSiteTitle( this._reduxStore.getState() ).trim();
+	const surveyVertical = getSurveyVertical( this._reduxStore.getState() ).trim();
 
 	wpcom.undocumented().sitesNew( {
 		blog_name: siteUrl,
 		blog_title: siteTitle,
 		options: {
 			theme: dependencies.theme || themeSlugWithRepo,
-			vertical: dependencies.surveyQuestion || undefined
+			vertical: surveyVertical || undefined
 		},
 		validate: false,
 		find_available_url: isPurchasingItem
@@ -175,13 +177,16 @@ module.exports = {
 	},
 
 	createAccount( callback, dependencies, { userData, flowName, queryArgs } ) {
+		const surveyVertical = getSurveyVertical( this._reduxStore.getState() ).trim();
+		const surveySiteType = getSurveySiteType( this._reduxStore.getState() ).trim();
+
 		wpcom.undocumented().usersNew( assign(
 			{}, userData, {
 				ab_test_variations: getSavedVariations(),
 				validate: false,
 				signup_flow_name: flowName,
-				nux_q_site_type: dependencies.surveySiteType,
-				nux_q_question_primary: dependencies.surveyQuestion,
+				nux_q_site_type: surveySiteType,
+				nux_q_question_primary: surveyVertical,
 				jetpack_redirect: queryArgs.jetpackRedirect
 			}
 		), ( error, response ) => {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -47,7 +47,7 @@ const flows = {
 	},
 
 	business: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
@@ -59,7 +59,7 @@ const flows = {
 	},
 
 	premium: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
@@ -71,7 +71,7 @@ const flows = {
 	},
 
 	free: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
 		destination: getSiteDestination,
 		description: 'Create an account and a blog and default to the free plan.',
 		lastModified: '2016-06-02'
@@ -85,28 +85,28 @@ const flows = {
 	},
 
 	main: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2016-05-23'
 	},
 
 	sitetitle: {
-		steps: [ 'survey', 'site-title', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'site-title', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2016-05-23'
 	},
 
 	website: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Website" on the two-button homepage. It is now linked to from the default homepage CTA as the main flow was slightly behind given translations.',
 		lastModified: '2016-05-23'
 	},
 
 	blog: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Blog" on the two-button homepage. It is now used from blog-specific landing pages so that verbiage in survey steps refers to "blog" instead of "website".',
 		lastModified: '2016-05-23'
@@ -136,21 +136,21 @@ const flows = {
 	},
 
 	'delta-blog': {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go through this flow receive a blogging-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
 	'delta-site': {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go through this flow receive a website-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
 	desktop: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getPostsDestination,
 		description: 'Signup flow for desktop app',
 		lastModified: '2016-05-30'
@@ -164,7 +164,7 @@ const flows = {
 	},
 
 	pressable: {
-		steps: [ 'survey', 'design-type-with-store', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Signup flow for testing the pressable-store step',
 		lastModified: '2016-06-27'

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -47,14 +47,6 @@ module.exports = {
 		providesDependencies: [ 'bearer_token', 'username' ]
 	},
 
-	'survey-user': {
-		stepName: 'survey-user',
-		apiRequestFunction: stepActions.createAccount,
-		providesToken: true,
-		dependencies: [ 'surveySiteType', 'surveyQuestion' ],
-		providesDependencies: [ 'bearer_token', 'username' ]
-	},
-
 	'site-title': {
 		stepName: 'site-title',
 		providesDependencies: [ 'siteTitle' ]

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -150,6 +150,7 @@ const SurveyStep = React.createClass( {
 		this.props.setSurvey( {
 			vertical: value,
 			otherText: otherWriteIn || '',
+			siteType: this.props.surveySiteType,
 		} );
 
 		SignupActions.submitSignupStep(

--- a/client/state/signup/steps/survey/reducer.js
+++ b/client/state/signup/steps/survey/reducer.js
@@ -15,7 +15,8 @@ export default createReducer( {},
 			return {
 				...state,
 				vertical: action.survey.vertical,
-				otherText: action.survey.otherText
+				otherText: action.survey.otherText,
+				siteType: action.survey.siteType,
 			};
 		},
 		[ SIGNUP_COMPLETE_RESET ]: () => {

--- a/client/state/signup/steps/survey/schema.js
+++ b/client/state/signup/steps/survey/schema.js
@@ -2,7 +2,7 @@ export const surveyStepSchema = {
 	type: 'object',
 	properties: {
 		vertical: 'string',
-		otherText: 'string'
-
+		otherText: 'string',
+		siteType: 'string',
 	}
 };

--- a/client/state/signup/steps/survey/selectors.js
+++ b/client/state/signup/steps/survey/selectors.js
@@ -10,3 +10,7 @@ export function getSurveyVertical( state ) {
 export function getSurveyOtherText( state ) {
 	return get( state, 'signup.steps.survey.otherText', '' );
 }
+
+export function getSurveySiteType( state ) {
+	return get( state, 'signup.steps.survey.siteType', '' );
+}

--- a/client/state/signup/steps/survey/test/reducer.js
+++ b/client/state/signup/steps/survey/test/reducer.js
@@ -19,11 +19,13 @@ describe( 'reducer', () => {
 			type: SIGNUP_STEPS_SURVEY_SET,
 			survey: {
 				vertical: 'test-survey',
-				otherText: 'test-other-text'
+				otherText: 'test-other-text',
+				siteType: 'test-site-type',
 			}
 		} ) ).to.be.eql( {
 			vertical: 'test-survey',
-			otherText: 'test-other-text'
+			otherText: 'test-other-text',
+			siteType: 'test-site-type',
 		} );
 	} );
 
@@ -31,7 +33,8 @@ describe( 'reducer', () => {
 		expect( signupSurveyReducer(
 			{
 				vertical: 'test-survey',
-				otherText: 'test-other-text'
+				otherText: 'test-other-text',
+				siteType: 'test-site-type',
 			},
 			{
 				type: SIGNUP_COMPLETE_RESET,

--- a/client/state/signup/steps/survey/test/selectors.js
+++ b/client/state/signup/steps/survey/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getSurveyVertical, getSurveyOtherText } from '../selectors';
+import { getSurveyVertical, getSurveyOtherText, getSurveySiteType } from '../selectors';
 
 describe( 'selectors', () => {
 	it( 'should return empty string as a default state', () => {
@@ -21,6 +21,7 @@ describe( 'selectors', () => {
 					survey: {
 						vertical: 'test-survey',
 						otherText: 'test-other-text',
+						siteType: 'test-site-type',
 					}
 				}
 			}
@@ -34,9 +35,24 @@ describe( 'selectors', () => {
 					survey: {
 						vertical: 'test-survey',
 						otherText: 'test-other-text',
+						siteType: 'test-site-type',
 					}
 				}
 			}
 		} ) ).to.be.eql( 'test-other-text' );
+	} );
+
+	it( 'should return site type from the state', () => {
+		expect( getSurveySiteType( {
+			signup: {
+				steps: {
+					survey: {
+						vertical: 'test-survey',
+						otherText: 'test-other-text',
+						siteType: 'test-site-type',
+					}
+				}
+			}
+		} ) ).to.be.eql( 'test-site-type' );
 	} );
 } );

--- a/client/state/signup/steps/survey/test/selectors.js
+++ b/client/state/signup/steps/survey/test/selectors.js
@@ -12,6 +12,7 @@ describe( 'selectors', () => {
 	it( 'should return empty string as a default state', () => {
 		expect( getSurveyVertical( { signup: undefined } ) ).to.be.eql( '' );
 		expect( getSurveyOtherText( { signup: undefined } ) ).to.be.eql( '' );
+		expect( getSurveySiteType( { signup: undefined } ) ).to.be.eql( '' );
 	} );
 
 	it( 'should return chosen vertical from the state', () => {


### PR DESCRIPTION
This PR removes the survey dependency on the `user` step. This opens up more testing possibilities and simplifies the code if new flows have to be created.

To test:

1. Checkout branch or use Calypso.live link.
2. Start signup.
3. Go through signup.
4. Verify the survey information is properly submitted at user and site creation.
5. Make sure no errors pop in the console.

cc @michaeldcain @coreh @meremagee 