### PR TITLE
Jetpack plans: Fix a mistaken querystring param from jetpack

### DIFF
--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -26,7 +26,7 @@ const getPluginsForSite = function( state, siteId, whitelist = false ) {
 	}
 
 	// patch to solve a bug in jp 4.3 ( https://github.com/Automattic/jetpack/issues/5498 )
-	if ( whitelist === 'backups' ) {
+	if ( whitelist === 'backups' || whitelist === 'scan' ) {
 		whitelist = 'vaultpress';
 	}
 


### PR DESCRIPTION
We added a fix in https://github.com/Automattic/wp-calypso/pull/9113 to handle some redirections that adding some parameters we weren't expected from this side. This PR just add a new case that should end in calypso autoconfiguring Vaultpress for you.

ping @dereksmart @ryelle 