### PR TITLE
Reader Stream Refresh: Add fade if site title is long

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -69,7 +69,8 @@ class PostByline extends React.Component {
 					preferGravatar={ true }
 					siteUrl={ streamUrl } />
 				<div className="reader-post-card__byline-details">
-					{ shouldDisplayAuthor &&
+					<div className="reader-post-card__byline-author-site">
+						{ shouldDisplayAuthor &&
 						<ReaderAuthorLink
 							className="reader-post-card__link"
 							author={ post.author }
@@ -77,15 +78,16 @@ class PostByline extends React.Component {
 							post={ post }>
 							{ post.author.name }
 						</ReaderAuthorLink>
-					}
-					{ shouldDisplayAuthor && ', ' }
-					<ReaderSiteStreamLink
-						className="reader-post-card__site reader-post-card__link"
-						feedId={ feedId }
-						siteId={ siteId }
-						post={ post }>
-						{ siteName }
-					</ReaderSiteStreamLink>
+						}
+						{ shouldDisplayAuthor && ', ' }
+						<ReaderSiteStreamLink
+							className="reader-post-card__site reader-post-card__link"
+							feedId={ feedId }
+							siteId={ siteId }
+							post={ post }>
+							{ siteName }
+						</ReaderSiteStreamLink>
+					</div>
 					<div className="reader-post-card__timestamp-and-tag">
 						{ post.date && post.URL &&
 							<span className="reader-post-card__timestamp">

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -168,6 +168,21 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	width: 100%;
 }
 
+.reader-post-card__byline-author-site {
+	overflow: hidden;
+	position: relative;
+	height: 20px;
+	width: calc( 100% - 25px );
+
+	&::after {
+		@include long-content-fade( $size: 10% );
+	}
+
+	@include breakpoint( ">660px" ) {
+		width: calc( 100% - 90px );
+	}
+}
+
 .reader-post-card__timestamp-and-tag {
 	display: flex;
 	flex-direction: row;
@@ -186,9 +201,9 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
     height: 20px;
     width: 100%;
 
-    &::after {
-    	@include long-content-fade( $size: 10% );
-    }
+	&::after {
+		@include long-content-fade( $size: 10% );
+	}
 }
 
 .reader-post-card__tag .gridicons-tag {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9161

**Before:**
![screenshot 2016-11-10 15 16 52](https://cloud.githubusercontent.com/assets/4924246/20198365/057e9fd0-a759-11e6-9269-bc228a908177.png)

**After:**
![screenshot 2016-11-10 15 17 07](https://cloud.githubusercontent.com/assets/4924246/20198367/08fa9ede-a759-11e6-8fd9-0bf81d0aa5bd.png)

Works the same way if the Author name is long:
![screenshot 2016-11-10 15 20 12](https://cloud.githubusercontent.com/assets/4924246/20198392/3dee5acc-a759-11e6-9b10-1074006a45bc.png)

