### PR TITLE
Reader: refactor image safety rules

### DIFF
--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -145,6 +145,7 @@ export default function detectMedia( post, dom ) {
 
 	post.content_media = compact( contentMedia );
 	post.content_embeds = filter( post.content_media, m => m.mediaType === 'video' );
+	post.content_images = filter( post.content_media, m => m.mediaType === 'image' );
 
 	return post;
 }

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -1,13 +1,8 @@
 /**
- * External Dependencies
- */
-import filter from 'lodash/filter';
-import forEach from 'lodash/forEach';
-import every from 'lodash/every';
-import some from 'lodash/some';
-import startsWith from 'lodash/startsWith';
-import toArray from 'lodash/toArray';
+* External Dependencies
+*/
 import url from 'url';
+import { forEach, startsWith, some, includes, filter } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -17,126 +12,83 @@ import { maxWidthPhotonishURL } from './utils';
 
 const TRANSPARENT_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-function removeUnsafeAttributes( node ) {
+/**
+* @param {Node} node - Takes in a DOM Node and mutates it so that it no longer has an 'on*' event handlers e.g. onClick
+*/
+const removeUnwantedAttributes = ( node ) => {
 	if ( ! node || ! node.hasAttributes() ) {
 		return;
 	}
 
-	// Have to toArray this because attributes is a live
-	// NodeMap and would node removals would invalidate
-	// the current index as we walked it.
-	forEach( toArray( node.attributes ), function( attr ) {
-		if ( startsWith( attr.name, 'on' ) ) {
-			node.removeAttribute( attr.name );
-		}
-	} );
+	const inlineEventHandlerAttributes = filter( node.attributes, ( attr ) => startsWith( attr.name, 'on' ) );
+	inlineEventHandlerAttributes.forEach( ( a ) => node.removeAttribute( a.name ) );
+
+	// always remove srcset because they are very difficult to make safe and may not be worth the trouble
+	node.removeAttribute( 'srcset' );
+};
+
+/** Checks whether or not imageUrl should be removed from the dom
+ * @param {string} imageUrl - the url of the image
+ * @returns {boolean} whether or not it should be removed from the dom
+ */
+const imageShouldBeRemovedFromContent = ( imageUrl ) => {
+	if ( ! imageUrl ) {
+		return;
+	}
+
+	const bannedUrlParts = [
+		'feeds.feedburner.com',
+		'feeds.wordpress.com/',
+		'.feedsportal.com',
+		'wp-includes',
+		'wp-content/themes',
+		'wp-content/plugins',
+		'stats.wordpress.com',
+		'pixel.wp.com'
+	];
+
+	return some( bannedUrlParts, ( part ) => includes( imageUrl.toLowerCase(), part ) );
+};
+
+function makeImageSafe( post, image, maxWidth ) {
+	let imgSource = image.getAttribute( 'src' );
+	const parsedImgSrc = url.parse( imgSource, false, true );
+	const hostName = parsedImgSrc.hostname;
+
+	// if imgSource is relative, prepend post domain so it isn't relative to calypso
+	if ( ! hostName ) {
+		imgSource = url.resolve( post.URL, imgSource );
+	}
+
+	const safeSource = ( maxWidth
+		? maxWidthPhotonishURL( safeImageURL( imgSource ), maxWidth )
+		: safeImageURL( imgSource )
+		);
+
+	removeUnwantedAttributes( image );
+
+	// trickery to remove it from the dom / not load the image
+	// TODO: test if this is necessary
+	if ( ! safeSource || imageShouldBeRemovedFromContent( imgSource ) ) {
+		image.remove();
+		// fun fact: removing the node from the DOM will not prevent it from loading. You actually have to
+		// change out the src to change what loads. The following is a 1x1 transparent gif as a data URL
+		image.setAttribute( 'src', TRANSPARENT_GIF );
+		return;
+	}
+
+	image.setAttribute( 'src', safeSource );
 }
 
-const bannedUrlParts = [
-	'feeds.feedburner.com',
-	'feeds.wordpress.com/',
-	'.feedsportal.com',
-	'wp-includes',
-	'wp-content/themes',
-	'wp-content/plugins',
-	'stats.wordpress.com',
-	'pixel.wp.com'
-];
+const makeImagesSafe = ( maxWidth ) => ( post, dom ) => {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
 
-function imageShouldBeRemovedFromContent( imageUrl ) {
-	return some( bannedUrlParts, function( part ) {
-		return imageUrl && imageUrl.toLowerCase().indexOf( part ) !== -1;
-	} );
-}
+	const images = dom.querySelectorAll( 'img[src]' );
+	forEach( images, ( image ) => makeImageSafe( post, image, maxWidth ) );
 
-const excludedContentImageUrlParts = [
-	'gravatar.com',
-	'/wpcom-smileys/'
-];
+	return post;
+};
 
-function isCandidateForContentImage( imageUrl ) {
-	return ! imageShouldBeRemovedFromContent( imageUrl ) && every( excludedContentImageUrlParts, function( part ) {
-		return imageUrl && imageUrl.toLowerCase().indexOf( part ) === -1;
-	} );
-}
-
-export default function( maxWidth = false ) {
-	return function makeImagesSafe( post, dom ) {
-		let content_images = [],
-			images;
-
-		if ( ! dom ) {
-			throw new Error( 'this transform must be used as part of withContentDOM' );
-		}
-		images = dom.querySelectorAll( 'img[src]' );
-
-		// push everything, including tracking pixels, over to a safe URL
-		forEach( images, function( image ) {
-			let imgSource = image.getAttribute( 'src' ),
-				parsedImgSrc = url.parse( imgSource, false, true ),
-				hostName = parsedImgSrc.hostname;
-
-			let safeSource;
-			// if imgSource is relative, prepend post domain so it isn't relative to calypso
-			if ( ! hostName ) {
-				imgSource = url.resolve( post.URL, imgSource );
-				parsedImgSrc = url.parse( imgSource, false, true );
-			}
-
-			safeSource = safeImageURL( imgSource );
-			if ( ! safeSource && parsedImgSrc.search ) {
-				// we can't make externals with a querystring safe.
-				// try stripping it and retry
-				parsedImgSrc.search = null;
-				parsedImgSrc.query = null;
-				safeSource = safeImageURL( url.format( parsedImgSrc ) );
-			}
-
-			removeUnsafeAttributes( image );
-
-			if ( ! safeSource || imageShouldBeRemovedFromContent( imgSource ) ) {
-				image.parentNode.removeChild( image );
-				// fun fact: removing the node from the DOM will not prevent it from loading. You actually have to
-				// change out the src to change what loads. The following is a 1x1 transparent gif as a data URL
-				image.setAttribute( 'src', TRANSPARENT_GIF );
-				image.removeAttribute( 'srcset' );
-				return;
-			}
-
-			if ( maxWidth ) {
-				safeSource = maxWidthPhotonishURL( safeSource, maxWidth );
-			}
-
-			image.setAttribute( 'src', safeSource );
-
-			if ( image.hasAttribute( 'srcset' ) ) {
-				image.removeAttribute( 'srcset' );
-			}
-
-			if ( isCandidateForContentImage( imgSource ) ) {
-				content_images.push( {
-					src: safeSource,
-					original_src: imgSource,
-					width: image.width,
-					height: image.height
-				} );
-			}
-		} );
-
-		// grab all of the non-tracking pixels and push them into content_images
-		content_images = filter( content_images, function( image ) {
-			if ( ! image.src ) {
-				return false;
-			}
-			const edgeLength = image.height + image.width;
-			// if the image size isn't set (0) or is greater than 2, keep it
-			return edgeLength === 0 || edgeLength > 2;
-		} );
-
-		if ( content_images.length ) {
-			post.content_images = content_images;
-		}
-
-		return post;
-	};
-}
+export default makeImagesSafe;

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -758,6 +758,39 @@ describe( 'index', function() {
 				}
 			);
 		} );
+
+		it( 'detects images intermixed with embeds and in the correct order', function( done ) {
+			normalizer(
+				{
+					content: '<img src="example1.png" /> <iframe src="https://vimeo.com/v/hi"></iframe> <img src="example2.png" />'
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ], function( err, normalized ) {
+					assert.lengthOf( normalized.content_media, 3 );
+					assert.lengthOf( normalized.content_images, 2 );
+					assert.lengthOf( normalized.content_embeds, 1 );
+					assert.equal( normalized.content_media[ 0 ], normalized.content_images[ 0 ] );
+					assert.equal( normalized.content_media[ 1 ], normalized.content_embeds[ 0 ] );
+					assert.equal( normalized.content_media[ 2 ], normalized.content_images[ 1 ] );
+					done( err );
+				}
+			);
+		} );
+
+		it( 'detects images', function( done ) {
+			normalizer(
+				{
+					content: '<img src="example1.png" /> <img src="/relativeurl.png" /> <img src="https://google.com/images/absoluteurl.jpg"> text in the middle</img>'
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ], function( err, normalized ) {
+					assert.lengthOf( normalized.content_media, 3 );
+					assert.lengthOf( normalized.content_images, 3 );
+					assert.lengthOf( normalized.content_embeds, 0 );
+
+					done( err );
+				}
+			);
+		} );
+
 		it( 'detects trusted iframes', function( done ) {
 			normalizer(
 				{


### PR DESCRIPTION
As of now, `rule-content-make-images-safe` both makes the images safe AND scans the dom/adds images to post.content_images.  This PR seeks to remove the latter functionality.
Also cleans up `makeImagesSafe` a good deal.

Before:
- makeImagesSafe stripped unsafe stuff + created `content_images`
- detectMedia created `content_embeds` 

After:
- makeImagesSafe strips unsafe stuff
- detectMedia creates both `content_embeds` + `content_images`