### PR TITLE
Themes Showcase: Fix prop warning in Multi-Site and Logged-Out Mode

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -45,7 +45,7 @@ const ThemesSelection = React.createClass( {
 		filter: React.PropTypes.string,
 		vertical: React.PropTypes.string,
 		// connected props
-		siteSlug: React.PropTypes.string.isRequired,
+		siteSlug: React.PropTypes.string,
 		isActiveTheme: React.PropTypes.func,
 	},
 


### PR DESCRIPTION
@ockham I noticed this prop warning after #9193 was merged. Since the `getSiteSlug` selector returns `null` if not found (as in Multi-Site and Logged-Out modes) the `isRequired` prop check was failing. I thought it made more sense to remove the required flag than set a default string (`getSiteSlug(...) || ''`).

To test:
- On `master` load Theme Showcase in Multi-Site or Logged-Out mode. Check browser console for prop check warning.
- On this branch, do the same. Prop warning is gone.
- 🎉 