### PR TITLE
Reader Refresh: rule-pick-canonical-media

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -15,7 +15,8 @@ import DisplayTypes from 'state/reader/posts/display-types';
 import ReaderPostActions from 'blocks/reader-post-actions';
 import * as stats from 'reader/stats';
 import PostByline from './byline';
-import FeaturedAsset from './featured-asset';
+import FeaturedVideo from './featured-video';
+import FeaturedImage from './featured-image';
 import FollowButton from 'reader/follow-button';
 import PostGallery from './gallery';
 
@@ -86,9 +87,8 @@ export default class RefreshPostCard extends React.Component {
 		const { post, originalPost, site, feed, onCommentClick, showPrimaryFollowButton } = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
-		const featuredAsset = FeaturedAsset( { post } ); // this is ... gross? gross.
 		const classes = classnames( 'reader-post-card', {
-			'has-thumbnail': !! featuredAsset,
+			'has-thumbnail': !! post.canonical_media,
 			'is-photo': isPhotoOnly,
 			'is-gallery': isGallery
 		} );
@@ -105,6 +105,15 @@ export default class RefreshPostCard extends React.Component {
 		let followUrl;
 		if ( showPrimaryFollowButton ) {
 			followUrl = feed ? feed.feed_URL : post.site_URL;
+		}
+
+		let featuredAsset;
+		if ( ! post.canonical_media ) {
+			featuredAsset = null;
+		} else if ( post.canonical_media.mediaType === 'video' ) {
+			featuredAsset = <FeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } />;
+		} else {
+			featuredAsset = <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 
 		return (

--- a/client/lib/post-normalizer/rule-pick-canonical-media.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-media.js
@@ -61,8 +61,9 @@ export default function pickCanonicalMedia( post ) {
 	}
 
 	const canonicalMedia = find( post.content_media, isCandidateForFeature );
-	post.canonical_media = { ...canonicalMedia };
+	if ( canonicalMedia ) {
+		post.canonical_media = canonicalMedia;
+	}
 
 	return post;
 }
-

--- a/client/lib/post-normalizer/rule-pick-canonical-media.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-media.js
@@ -1,15 +1,12 @@
 /**
  * External Dependencies
  */
-import React from 'react';
 import { find } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-import FeaturedVideo from './featured-video';
-import FeaturedImage from './featured-image';
-import { isUrlLikelyAnImage } from '../../lib/post-normalizer/utils.js';
+import { isUrlLikelyAnImage } from './utils.js';
 
 /** Returns true if an image is large enough to be a featured asset
  * @param {object} image - image must have a width and height property
@@ -46,30 +43,26 @@ function isCandidateForFeature( media ) {
  *  2. if there is no usable featured image, use the media that appears first in the content of the post
  *  3. if there is no eligible asset, return null
  */
-const FeaturedAsset = ( { post } ) => {
+export default function pickCanonicalMedia( post ) {
 	if ( ! post ) {
-		return null;
+		return post;
 	}
 
 	// jetpack lies about thumbnails/featured_images so we need to make sure its actually an image
 	if ( post.featured_image && isUrlLikelyAnImage( post.featured_image ) &&
 			isImageLargeEnoughForFeature( post.post_thumbnail ) ) {
-		return <FeaturedImage imageUri={ post.featured_image } href={ post.URL } />;
+		post.canonical_media = {
+			src: post.featured_image,
+			height: post.post_thumbnail.height,
+			width: post.post_thumbnail.width,
+			mediaType: 'image',
+		};
+		return post;
 	}
 
-	const featuredMedia = find( post.content_media, isCandidateForFeature );
+	const canonicalMedia = find( post.content_media, isCandidateForFeature );
+	post.canonical_media = { ...canonicalMedia };
 
-	if ( featuredMedia && featuredMedia.mediaType === 'video' ) {
-		return <FeaturedVideo { ...featuredMedia } videoEmbed={ featuredMedia } />;
-	} else if ( featuredMedia && featuredMedia.mediaType === 'image' ) {
-		return <FeaturedImage imageUri={ featuredMedia.src } href={ post.URL } />;
-	}
+	return post;
+}
 
-	return null;
-};
-
-FeaturedAsset.propTypes = {
-	post: React.PropTypes.object.isRequired,
-};
-
-export default FeaturedAsset;


### PR DESCRIPTION
As was suggested in [here](https://github.com/Automattic/wp-calypso/pull/9149#issuecomment-259808345), I've created `rule-pick-canonical-media` to help with post-classification and styling of cards.

This also obviates the need for `FeaturedAsset` as its own Component.

Fixes #9239.

This change is dependent on #9149 landing

To test:
- stream should look identical as before with two exceptions:
- The post objects will have a `canonical_media` prop if you check react dev tools
- videos will no longer ever get the photo-only card. compare:
  - https://calypso.live/read/feeds/55800870?branch=add/reader/refresh-rule-pick-canonical-media 
  -  https://wpcalypso.wordpress.com/read/feeds/55800870