### PR TITLE
DevDocs: Auto Proptype Documentation for Components and Blocks

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -27,6 +27,7 @@
 @import 'blocks/post-item/style';
 @import 'blocks/post-relative-time/style';
 @import 'blocks/post-status/style';
+@import 'blocks/props-editor/style';
 @import 'blocks/reader-avatar/style';
 @import 'blocks/reader-full-post/style';
 @import 'blocks/reader-post-actions/style';

--- a/client/blocks/author-selector/docs/example.jsx
+++ b/client/blocks/author-selector/docs/example.jsx
@@ -11,13 +11,14 @@ import AuthorSelector from '../';
 import Card from 'components/card';
 import { getCurrentUser } from 'state/current-user/selectors';
 
-function AuthorSelectorExample( { primarySiteId, displayName } ) {
+function AuthorSelectorExample( { primarySiteId, displayName, ...props } ) {
 	return (
 		<Card>
 			<AuthorSelector
 				siteId={ primarySiteId }
 				allowSingleUser
 				popoverPosition="bottom"
+				{ ...props }
 			>
 				<span>You are { displayName } </span>
 			</AuthorSelector>

--- a/client/blocks/comment-button/docs/example.jsx
+++ b/client/blocks/comment-button/docs/example.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 /**
  * Internal dependencies
@@ -12,7 +12,27 @@ import Card from 'components/card';
 export default React.createClass( {
 	displayName: 'CommentButtonExample',
 
+	propTypes: {
+		isShowingOff: PropTypes.bool
+	},
+
+	getDefaultProps() {
+		return {
+			isShowingOff: false
+		};
+	},
+
 	render() {
+		if ( this.props.isShowingOff ) {
+			return (
+				<div>
+					<Card compact>
+						<CommentButton { ...this.props } />
+					</Card>
+				</div>
+			);
+		}
+
 		return (
 			<div>
 				<Card compact>

--- a/client/blocks/like-button/docs/example.jsx
+++ b/client/blocks/like-button/docs/example.jsx
@@ -1,7 +1,7 @@
 /**
 * External dependencies
 */
-import React from 'react';
+import React, { PropTypes, PureComponent } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
@@ -43,11 +43,27 @@ const LikeButtons = React.createClass( {
 
 	mixins: [ PureRenderMixin ],
 
+	defaultProps: {
+		tagName: 'a',
+		likeCount: 0,
+		isShowingOff: false
+	},
+
 	render() {
+		if (this.props.isShowingOff) {
+			return (
+				<div>
+					<Card compact>
+						<SimpleLikeButtonContainer { ...this.props } />
+					</Card>
+				</div>
+			);
+		}
+
 		return (
 			<div>
 				<Card compact>
-					<SimpleLikeButtonContainer tagName="a" likeCount={ 0 } />
+					<SimpleLikeButtonContainer tagName="a" likeCount={ 0 } { ...this.props } />
 				</Card>
 				<Card compact>
 					<SimpleLikeButtonContainer tagName="a" likeCount={ 12 } />

--- a/client/blocks/props-editor/index.jsx
+++ b/client/blocks/props-editor/index.jsx
@@ -1,0 +1,305 @@
+/**
+ * External Dependencies
+ */
+
+import React, { Component } from 'react';
+
+/**
+ * Internal Dependencies
+ */
+
+import Spinner from 'components/spinner';
+import Card from 'components/card';
+import DocService from 'devdocs/service';
+import Table from './table';
+import { slugToCamelCase } from 'devdocs/docs-example/util';
+
+class PropsEditor extends Component {
+	constructor( props ) {
+		super( props );
+		this.includePath = null;
+	}
+
+	componentWillMount() {
+		this.requestPropsFor( this.props.component );
+	}
+
+	componentWillReceiveProps() {
+		this.requestPropsFor( this.props.component );
+	}
+
+	/**
+	 * Given a propType from the code, convert it to an easily digestible array of propTypes
+	 * @param {Object} props The object of props
+	 * @returns {Array} An array of props
+	 */
+	reducePropTypes = ( props ) => {
+		return Object.keys( props.props ).reduce( ( previous, current ) => {
+			const prop = props.props[ current ];
+
+			// if this is an arrayOf, or another "holding" type, this will be the type that array holds.
+			// Using an IIFE so that it's easier to read
+			const holds = ( () => {
+				if ( ! prop.type ) {
+					return null;
+				}
+				switch ( prop.type.name ) {
+					case 'arrayOf':
+					default:
+						if ( ! prop.type.value ) {
+							return 'unknown';
+						}
+						return prop.type.value.name;
+				}
+			} )();
+
+			// Allows example wrappers to override default values
+			// Using an IIFE so that it's easier to read...
+			const overrodeDefaultValue = ( () => {
+				if ( prop.type && prop.type.name === 'func' ) {
+					return ( ...args ) => {
+						console.log( `Function ${ prop.name } called with:`, args ); // eslint-disable-line no-console
+					};
+				}
+
+				if ( prop.defaultValue &&
+					prop.defaultValue.value !== undefined ) {
+					return prop.defaultValue.value;
+				}
+
+				if ( props.example &&
+					props.example.props &&
+					props.example.props[ current ] !== undefined ) {
+					const newVal = props.example.props[ current ]; // doing this for easy grok
+					if ( newVal.defaultValue &&
+						newVal.defaultValue.value !== undefined ) {
+						return newVal.defaultValue.value;
+					}
+				}
+
+				return '\'undefined\'';
+			} )();
+
+			previous.push( {
+				/**
+				 * Whether or not the defaultValue is a computed property
+				 */
+				computed: prop.defaultValue ? prop.defaultValue.computed : false,
+
+				/**
+				 * The description defined by jsdoc comments like these
+				 */
+				description: prop.description,
+
+				/**
+				 * If this prop is a container, the type the container holds
+				 */
+				holds,
+
+				/**
+				 * The name of the prop
+				 */
+				name: current,
+
+				/**
+				 * Whether or not the prop is required to render
+				 */
+				required: prop.required,
+
+				/**
+				 * The type of the prop, unknown if its missing from propTypes
+				 */
+				type: prop.type ? prop.type.name : 'unknown',
+
+				/**
+				 * The default value defined by the component
+				 */
+				defaultValue: prop.defaultValue && prop.defaultValue.value ? prop.defaultValue.value : '\'undefined\'',
+
+				/**
+				 * The current value of the rendered component
+				 */
+				value: overrodeDefaultValue,
+			} );
+
+			return previous;
+		}, [] );
+	};
+
+	/**
+	 * Get the props for a given component and update the state
+	 * @param {string} component The component to search for in slug form
+	 */
+	requestPropsFor = ( component ) => {
+		this.setState( { loading: true } );
+
+		DocService.props( component, ( error, sourceProps ) => {
+			if ( error ) {
+				this.setState( {
+					loading: false,
+					error
+				} );
+				return;
+			}
+
+			const includePath = sourceProps.includePath;
+			const supported = sourceProps.example.props && sourceProps.example.props.isShowingOff;
+
+			const loading = false,
+				props = this.reducePropTypes( sourceProps );
+
+			const computedProps = {
+				isShowingOff: true
+			};
+
+			props.forEach( ( prop ) => {
+				computedProps[ prop.name ] = this.parse( prop.type, prop.value, prop.name );
+			} );
+
+			this.setState( {
+				loading,
+				props,
+				computedProps,
+				includePath,
+				supported
+			} );
+		} );
+	};
+
+	/**
+	 * Renders the example wrapper
+	 * @returns {Element} The example wrapper or an error message
+	 */
+	renderExample = () => {
+		if ( ! this.state.renderError ) {
+			return React.cloneElement( this.props.example, this.state.computedProps );
+		}
+
+		return ( <div>You've passed an invalid prop. Fix it to re-render.</div> );
+	};
+
+	/**
+	 * Creates an error boundary, currently unstable in React, but prevents errors from bubbling up the render tree
+	 * and breaking the app.
+	 * @see https://github.com/facebook/react/issues/2461
+	 */
+	unstable_handleError() {
+		this.setState( {
+			renderError: true
+		} );
+	}
+
+	/**
+	 * Given a prop type, name and value, parse the new value and update the render tree with new props
+	 * @param {string} type The type of the prop
+	 * @param {string} name The name of the prop to update
+	 * @param {string} value The new value of the prop
+	 */
+	updateProp = ( type, name, value ) => {
+		// if the value is an event, then use the event's target's value
+		if ( value.target ) {
+			value = value.target.value;
+		}
+
+		this.state.computedProps[ name ] = this.parse( type, value );
+
+		this.setState( {
+			computedProps: { ...this.state.computedProps },
+			renderError: false
+		} );
+	};
+
+	/**
+	 * Parse a value, based on the expected type
+	 * @param {string} type The type of the value
+	 * @param {string} value The value to parse
+	 * @param {string} name An optional name of the thing being parsed
+	 * @returns {*} The parsed value
+	 */
+	parse = ( type, value, name = '' ) => {
+		if ( value === '\'undefined\'' ) {
+			value = undefined;
+		}
+
+		switch ( type ) {
+			case 'number':
+				if ( value === undefined ) {
+					return 0;
+				}
+				return parseInt( value.replace( /'/g, '' ) );
+			case 'string':
+				if ( value === undefined ) {
+					return '';
+				}
+				return value.replace( /'/g, '' );
+			case 'bool':
+				return value === 'true';
+			case 'arrayOf':
+				if ( value !== undefined && value.indexOf( '[' ) === 0 && value.indexOf( ']' ) === value.length - 1 ) {
+					return JSON.parse( value );
+				}
+				return value;
+			case 'object':
+				if ( value !== undefined && value.indexOf( '{' ) === 0 && value.indexOf( '}' ) === value.length - 1 ) {
+					return JSON.parse( value );
+				}
+				return value;
+			case 'func':
+				return ( ...args ) => {
+					console.log( `Function( ${ name } ) called with`, args ); //eslint-disable-line no-console
+				};
+			default:
+				return value;
+		}
+	};
+
+	/**
+	 * Renders a table
+	 * @returns {Element} The table to render
+	 */
+	renderProps = () => {
+		return (
+			<Table props={ this.state.props } onUpdate={ this.updateProp } />
+		);
+	};
+
+	render() {
+		if ( this.state.loading ) {
+			return (
+				<div>
+					<Card>
+						<div>
+							Reading the code so you don't have to...
+						</div>
+						<Spinner size={ 50 } />
+					</Card>
+				</div>
+			);
+		}
+
+		if ( this.state.error ) {
+			return this.renderExample();
+		}
+
+		return (
+			<div>
+				{ this.renderExample() }
+				{
+					this.state.supported ? null : <p>
+						This component does not yet support editing the props,
+						see (todo: insert some doc link here) to make it so you can edit the props.
+					</p>
+				}
+				<p>
+					Require this component: &nbsp;
+					<code>
+						import { slugToCamelCase( this.props.component ) } from { this.state.includePath }
+					</code>
+				</p>
+				{ this.renderProps() }
+			</div>
+		);
+	}
+}
+
+export default PropsEditor;

--- a/client/blocks/props-editor/style.scss
+++ b/client/blocks/props-editor/style.scss
@@ -1,4 +1,4 @@
-table.props-editor-table{
+table.props-editor__table{
   > tbody tr:last-child > td {
 	border-bottom: solid 1px #eee;
   }

--- a/client/blocks/props-editor/style.scss
+++ b/client/blocks/props-editor/style.scss
@@ -1,0 +1,48 @@
+table.props-editor-table{
+  > tbody tr:last-child > td {
+	border-bottom: solid 1px #eee;
+  }
+
+  tr:hover {
+  	background-color: rgba(0, 113, 96, 0.05);
+  }
+
+  th {
+	border-bottom: 1px solid $gray-dark;
+  }
+
+  td {
+	vertical-align: top;
+  }
+
+  td.props-editor__table-row-name {
+	color: rgb(17, 147, 154);
+  }
+
+  td.props-editor__table-row-optional {
+	color: #c6c6c6;
+  }
+
+  td.props-editor__table-row-required {
+	color: rgb(255, 76, 34);
+  }
+
+  td.props-editor__table-row-default {
+	color: rgb(236, 171, 32);
+  }
+
+  td.props-editor__table-row-current {
+	color: rgb(32, 171, 236);
+	display: inline-flex;
+	width: 100%
+  }
+
+  tr.props-editor__unknown-type {
+	background-color: rgba(255, 131, 131, 0.46);
+  }
+
+  th, td {
+	text-align: left;
+	padding: 10px 10px;
+  }
+}

--- a/client/blocks/props-editor/table-row.jsx
+++ b/client/blocks/props-editor/table-row.jsx
@@ -1,0 +1,136 @@
+/**
+ * External Dependencies
+ */
+
+import React, { PureComponent } from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal Dependencies
+ */
+
+import Gridicon from 'components/gridicon';
+
+class TableRow extends PureComponent {
+	componentWillMount() {
+		this.setState( {
+			editing: false,
+			value: this.props.value,
+			defaultValue: this.props.value
+		} );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.setState( {
+			editing: false,
+			value: nextProps.value,
+			defaultValue: nextProps.value
+		} );
+	}
+
+	componentWillUnmount() {
+		this.editorRef = null;
+	}
+
+	makeEditable = () => {
+		this.setState( {
+			editing: true
+		}, () => {
+			if ( this.editorRef ) {
+				this.editorRef.focus();
+			}
+		} );
+	};
+
+	updateValue = ( event ) => {
+		this.setState( {
+			value: event.target.textContent
+		} );
+	};
+
+	blurish = ( event ) => {
+		if ( event.key === 'Enter' ) {
+			if ( this.editorRef ) {
+				this.editorRef.blur();
+			}
+		}
+	};
+
+	setValue = () => {
+		this.setState( {
+			editing: false
+		}, () => {
+			if ( this.props.onChange ) {
+				this.props.onChange( this.state.value );
+			}
+		} );
+	};
+
+	resetValue = () => {
+		if ( this.editorRef ) {
+			this.editorRef.blur();
+		}
+
+		this.setState( {
+			editing: false,
+			value: this.state.defaultValue
+		} );
+	};
+
+	editor = ( ref ) => {
+		this.editorRef = ref;
+	};
+
+	render() {
+		const requiredClasses = classnames( {
+			'props-editor__table-row-required': this.props.required,
+			'props-editor__table-row-optional': ! this.props.required,
+		} );
+
+		const rowClass = classnames( {
+			'props-editor__unknown-type': this.props.type === 'unknown'
+		} );
+
+		const type = this.props.holds === 'unknown' || this.props.holds === 'null'
+			? this.props.type
+			: `${ this.props.type }( ${ this.props.holds } )`;
+
+		return (
+			<tr className={ rowClass }>
+				<td className="props-editor__table-row-name">
+					{ this.props.name }
+				</td>
+				<td className="props-editor__table-row-type">
+					{ type }
+				</td>
+				<td className={ requiredClasses }>
+					{ this.props.required ? 'required' : 'optional' }
+				</td>
+				<td className="props-editor__table-row-current" onClick={ this.makeEditable }>
+					<div
+						ref={ this.editor }
+						contentEditable={ this.state.editing }
+						onInput={ this.updateValue }
+						onBlur={ this.setValue }
+						onKeyDown={ this.blurish }
+					>
+						{ this.state.value }
+					</div>
+					{ this.state.defaultValue !== this.state.value
+						? <Gridicon icon="undo" onClick={ this.resetValue } />
+						: null }
+				</td>
+				<td className="props-editor__table-row-default">
+					{ this.props.defaultValue }
+				</td>
+				<td className="props-editor__table-row-description">
+					{ this.props.type === 'unknown'
+						? <p>This prop is missing from propTypes!</p>
+						: this.props.description }
+				</td>
+			</tr>
+		);
+	}
+}
+
+export default TableRow;

--- a/client/blocks/props-editor/table-row.jsx
+++ b/client/blocks/props-editor/table-row.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 
-import React, { PureComponent } from 'react';
+import React, { PropTypes, PureComponent } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -11,6 +11,9 @@ import classnames from 'classnames';
 
 import Gridicon from 'components/gridicon';
 
+/**
+ * A row for the props-editor table
+ */
 class TableRow extends PureComponent {
 	componentWillMount() {
 		this.setState( {
@@ -32,6 +35,9 @@ class TableRow extends PureComponent {
 		this.editorRef = null;
 	}
 
+	/**
+	 * Makes it so that a user may edit the current value on the table
+	 */
 	makeEditable = () => {
 		this.setState( {
 			editing: true
@@ -42,12 +48,20 @@ class TableRow extends PureComponent {
 		} );
 	};
 
+	/**
+	 * Updates the value, given an event from react
+	 * @param {SyntheticEvent} event The event with the new content
+	 */
 	updateValue = ( event ) => {
 		this.setState( {
 			value: event.target.textContent
 		} );
 	};
 
+	/**
+	 * Called when the user presses enter and we want to stop editing
+	 * @param {SyntheticEvent} event The event from the keyboard
+	 */
 	blurish = ( event ) => {
 		if ( event.key === 'Enter' ) {
 			if ( this.editorRef ) {
@@ -56,6 +70,9 @@ class TableRow extends PureComponent {
 		}
 	};
 
+	/**
+	 * Called when the user leaves the input on the row, it calls the callback passed via props with the new value.
+	 */
 	setValue = () => {
 		this.setState( {
 			editing: false
@@ -66,6 +83,9 @@ class TableRow extends PureComponent {
 		} );
 	};
 
+	/**
+	 * Resets the value back to the defaultValue
+	 */
 	resetValue = () => {
 		if ( this.editorRef ) {
 			this.editorRef.blur();
@@ -77,6 +97,10 @@ class TableRow extends PureComponent {
 		} );
 	};
 
+	/**
+	 * Stores the ref to the div that is editable
+	 * @param {Ref} ref The ref to the editable div
+	 */
 	editor = ( ref ) => {
 		this.editorRef = ref;
 	};
@@ -132,5 +156,47 @@ class TableRow extends PureComponent {
 		);
 	}
 }
+
+TableRow.propTypes = {
+	/**
+	 * The prop's default value
+	 */
+	defaultValue: PropTypes.any,
+
+	/**
+	 * A description of the prop
+	 */
+	description: PropTypes.string,
+
+	/**
+	 * If the type is a container type (such as an array), this is the type that it holds
+	 */
+	holds: PropTypes.string,
+
+	/**
+	 * The name of the prop
+	 */
+	name: PropTypes.string.isRequired,
+
+	/**
+	 * Called when the user edits the current value
+	 */
+	onChange: PropTypes.func,
+
+	/**
+	 * Whether or not the prop is required
+	 */
+	required: PropTypes.bool,
+
+	/**
+	 * The type of the prop, a string from just after `PropTypes.`
+	 */
+	type: PropTypes.string.isRequired,
+
+	/**
+	 * The starting value of the prop
+	 */
+	value: PropTypes.any.isRequired
+};
 
 export default TableRow;

--- a/client/blocks/props-editor/table.jsx
+++ b/client/blocks/props-editor/table.jsx
@@ -1,0 +1,47 @@
+/**
+ * External Dependencies
+ */
+
+import React, { PureComponent } from 'react';
+
+import TableRow from './table-row';
+
+class Table extends PureComponent {
+
+	updated = ( name, type ) => ( value ) => {
+		if ( this.props.onUpdate ) {
+			this.props.onUpdate( type, name, value );
+		}
+	};
+
+	render() {
+		return (
+			<div className="props-editor__table-container">
+				<table className="props-editor__table">
+					<thead>
+					<tr>
+						<th>Prop</th>
+						<th>Type</th>
+						<th>Required?</th>
+						<th>Current Value</th>
+						<th>Default Value</th>
+						<th>Description</th>
+					</tr>
+					</thead>
+					<tbody>
+					{
+						this.props.props.map( ( prop ) =>
+							<TableRow
+								onChange={ this.updated( prop.name, prop.type ) }
+								key={ prop.name }
+								{ ...prop }
+							/> )
+					}
+					</tbody>
+				</table>
+			</div>
+		);
+	}
+}
+
+export default Table;

--- a/client/blocks/props-editor/table.jsx
+++ b/client/blocks/props-editor/table.jsx
@@ -2,12 +2,18 @@
  * External Dependencies
  */
 
-import React, { PureComponent } from 'react';
+import React, { PropTypes, PureComponent } from 'react';
 
 import TableRow from './table-row';
 
 class Table extends PureComponent {
 
+	/**
+	 * Returns a function to be called when a row updates the current value
+	 * @param {string} name The name of the prop that will be updated
+	 * @param {string} type The type of the prop that will be update
+	 * @return {function} A function to be used in a row's callback
+	 */
 	updated = ( name, type ) => ( value ) => {
 		if ( this.props.onUpdate ) {
 			this.props.onUpdate( type, name, value );
@@ -43,5 +49,17 @@ class Table extends PureComponent {
 		);
 	}
 }
+
+Table.propTypes = {
+	/**
+	 * An array of props
+	 */
+	props: PropTypes.arrayOf( PropTypes.object ),
+
+	/**
+	 * Function called whenever a prop's current value changes
+	 */
+	onUpdate: PropTypes.func
+};
 
 export default Table;

--- a/client/blocks/props-editor/test/table-row.jsx
+++ b/client/blocks/props-editor/test/table-row.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import TableRow from '../table-row';
+
+describe( 'PropsEditor.TableRow', () => {
+	it( 'renders a row for a table', () => {
+		const prop = {
+			name: 'test',
+			type: 'string',
+			value: 'testString'
+		};
+
+		const wrapper = shallow( <TableRow { ...prop } /> );
+		assert( prop.value, wrapper.state.value );
+	} );
+
+	it( 'can edit a value and revert it', () => {
+		const prop = {
+			name: 'test',
+			type: 'string',
+			value: 'testString'
+		};
+
+		const event = {
+			target: {
+				textContent: '123'
+			}
+		};
+
+		const onUpdate = ( newValue ) => {
+			assert( '123', newValue );
+		};
+
+		const wrapper = shallow( <TableRow { ...prop } onChange={ onUpdate } /> );
+		assert( prop.value, wrapper.state.value );
+		wrapper.instance().updateValue( event );
+		assert( '123', wrapper.state.value );
+		assert( prop.value, wrapper.state.defaultValue );
+		wrapper.instance().resetValue();
+		assert( prop.value, wrapper.state.value );
+	} );
+} );

--- a/client/blocks/props-editor/test/table.jsx
+++ b/client/blocks/props-editor/test/table.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { assert } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Table from '../table';
+
+describe( 'PropsEditor.Table', () => {
+	it( 'renders a set of props', () => {
+		const props = [
+			{
+				name: 'test1',
+				type: 'string',
+				value: 'testString1'
+			},
+			{
+				name: 'test2',
+				type: 'string',
+				value: 'testString2'
+			}
+		];
+
+		const wrapper = shallow( <Table props={ props } /> );
+		assert( props.length, wrapper.children().length );
+	} );
+} );

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -11,6 +11,7 @@ import {
 	camelCaseToSlug,
 	getComponentName,
 } from 'devdocs/docs-example/util';
+import PropsEditor from 'blocks/props-editor';
 
 const shouldShowInstance = ( example, filter, component ) => {
 	const name = getComponentName( example );
@@ -64,7 +65,7 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 				unique={ !! component }
 				url={ exampleLink }
 			>
-				{ example }
+				{ component ? <PropsEditor component={ component } example={ example } /> : example }
 			</DocsExampleWrapper>
 		);
 	} );

--- a/client/devdocs/service.js
+++ b/client/devdocs/service.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var request = require( 'superagent' );
+import request from 'superagent';
 
 function fetchDocsEndpoint( endpoint, params, callback ) {
 	request.
@@ -13,7 +13,7 @@ function fetchDocsEndpoint( endpoint, params, callback ) {
 			} else {
 				callback( 'Error invoking /devdocs/' + endpoint + ': ' + res.text, null );
 			}
-		});
+		} );
 }
 
 /**
@@ -26,10 +26,14 @@ module.exports = {
 	},
 
 	list: function( filenames, callback ) {
-		fetchDocsEndpoint( 'list', { files: filenames.join(',') }, callback );
+		fetchDocsEndpoint( 'list', { files: filenames.join( ',' ) }, callback );
 	},
 
 	fetch: function( path, callback ) {
-		fetchDocsEndpoint( 'content', { path: path }, callback );
+		fetchDocsEndpoint( 'content', { path }, callback );
+	},
+
+	props: function( component, callback ) {
+		fetchDocsEndpoint( 'component', { component }, callback );
 	}
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -953,11 +953,9 @@
     },
     "doctrine": {
       "version": "1.5.0",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         }
       }
     },
@@ -1722,6 +1720,9 @@
       "version": "2.0.0"
     },
     "has-binary": {
+      "version": "0.1.7"
+    },
+    "has-color": {
       "version": "0.1.7"
     },
     "has-cors": {
@@ -2632,6 +2633,20 @@
         }
       }
     },
+    "nomnom": {
+      "version": "1.8.1",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0"
+        },
+        "chalk": {
+          "version": "0.4.0"
+        },
+        "strip-ansi": {
+          "version": "0.1.1"
+        }
+      }
+    },
     "noop-logger": {
       "version": "0.1.1"
     },
@@ -3048,6 +3063,17 @@
     },
     "react-day-picker": {
       "version": "2.4.1"
+    },
+    "react-docgen": {
+      "version": "2.12.1",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2"
+        },
+        "babylon": {
+          "version": "5.8.38"
+        }
+      }
     },
     "react-dom": {
       "version": "15.4.0"
@@ -3921,6 +3947,9 @@
     },
     "ultron": {
       "version": "1.0.2"
+    },
+    "underscore": {
+      "version": "1.6.0"
     },
     "uniq": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react-addons-update": "15.4.0",
     "react-click-outside": "2.1.0",
     "react-day-picker": "2.4.1",
+    "react-docgen": "2.12.1",
     "react-dom": "15.4.0",
     "react-masonry-component": "4.2.2",
     "react-pure-render": "1.0.2",

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -268,7 +268,8 @@ module.exports = function() {
 			const basePath = fs.realpathSync( fspath.join( root, 'client' ) );
 			const results = [
 				fspath.join( basePath, 'blocks' ),
-				fspath.join( basePath, 'components' )
+				fspath.join( basePath, 'components' ),
+				fspath.join( basePath, 'my-sites' )
 			]
 				.map( ( search ) => findDirectoryWithName( search, component, 1 ) );
 			const files = [].concat.apply( [], results );
@@ -289,7 +290,16 @@ module.exports = function() {
 				return;
 			}
 
-			response.send( reactParser( fs.readFileSync( file, { encoding: 'utf8' } ) ) );
+			const componentJSON = reactParser( fs.readFileSync( file, { encoding: 'utf8' } ) );
+			const exampleFile = fspath.join( files[ 0 ], 'docs', 'example.jsx' );
+			const regex = new RegExp( `^${ fspath.join( root, 'client' ) }/(.*)/index.jsx` );
+			componentJSON.includePath = file.replace( regex, '$1' );
+
+			if ( fs.statSync( exampleFile ).isFile() ) {
+				componentJSON.example = reactParser( fs.readFileSync( exampleFile, { encoding: 'utf8' } ) );
+			}
+
+			response.send( componentJSON );
 		} catch ( err ) {
 			console.error( err );
 			response


### PR DESCRIPTION
# Auto Proptype Documentation for Components and Blocks

![demonstration](https://cloud.githubusercontent.com/assets/1883296/20956318/20c01314-bc17-11e6-9b04-e9544277503f.gif)

Props are the way we configure child components. As a developer, it can be confusing sometimes as to what a simple change to a prop can do. It can change behavior and appearance. Wouldn't it be nice to tinker with the example in the Dev Docs?

Well, now you can.

# Overview and Approach

In order to get prop types, the code has to be read, as there's no reliable way I could discover to read propTypes while the code is running. I used `react-docgen` to parse the component's source and figure out the propTypes. From there, I could have used a webpack loader or read it on the nodejs server. I chose to avoid the webpack loader for fear that I could have increased a production bundle size in some way. If my thinking is wrong in this, please let me know. ;)

Once having the propTypes in the client, it's fairly straightforward to render a table. There's some internal bookkeeping and two copies of the props being passed about. The flow goes something like:

![flow](https://cloud.githubusercontent.com/assets/1883296/20956721/b9ed89f2-bc19-11e6-8870-0f1f5f97e040.png)

One copy is used for rendering the table, and is the raw form the user is editing along with metadata, the other, is passed to the "component under props" -- for lack of a better term -- called `computedProps`. `computedProps` have been parsed and are sent to the child component.

Currently, the example component must be modified to pass props it receives onto its children, and is responsible for wiring up global state, if needed. The prop is called `isShowingOff`, which seems like an apt name for a prop which makes the component show off everything it is capable of.

The "editor" attempts to detect the presence of this prop, and will show a notification if it isn't present in the example component, alerting the user that their changes may not be propagated.

As a helpful tidbit, it also shows the `import` statement, in order to help developers save some time looking for where the shown component is located.

Feel free to check it out: [on calypso.live](https://calypso.live/?branch=add/devknobs)

Currently, the only components able to be edited via the props-editor are:

- author-selector: which doesn't do much
- comment-button
- like-button

# Still remaining

Alas, there's still a ways to go!

- [ ] Fix a bug where clicking the revert focuses the cursor instead of fully reverting
- [ ] Tests 🔴 -> 💚  
- [ ] Redux, which should actually simplify things
- [ ] Add jsdoc to table components
- [ ] Documentation -- specifically around how an example component should be updated
- [ ] Documentation -- specifically around how to write a parser, in the event a new propType gets invented
- [ ] Documentation -- specifically propTypes
- [ ] Check for the possibility of a memory leak somewhere (may be unrelated to my code, but I'm going to check)
- [ ] Make the serverside code async (or switch to a module loader)
- [ ] General polishing
- [ ] Address any concerns that you may have