### PR TITLE
Fix#9206

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -4,7 +4,7 @@
  * External Dependencies
  */
 import ReactDom from 'react-dom';
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import find from 'lodash/find';
 import filter from 'lodash/filter';
 import findIndex from 'lodash/findIndex';
@@ -21,14 +21,8 @@ import DropdownLabel from 'components/select-dropdown/label';
 import Count from 'components/count';
 
 /**
- * Module variables
- */
-const { Component, PropTypes } = React;
-
-/**
  * SelectDropdown
  */
-
 class SelectDropdown extends Component {
 	static propTypes = {
 		selectedText: PropTypes.string,
@@ -55,6 +49,8 @@ class SelectDropdown extends Component {
 		onToggle: () => {},
 		style: {}
 	}
+
+	static instances = 0
 
 	constructor( props ) {
 		super( props );
@@ -130,11 +126,11 @@ class SelectDropdown extends Component {
 	getSelectedText() {
 		const { options, selectedText } = this.props;
 		const { selected } = this.state;
-		
+
 		if ( selectedText ) {
 			return selectedText;
 		}
-		
+
 		// return currently selected text
 		const selectedValue = selected ? selected : this.getInitialSelectedItem( this.props );
 		return result( find( options, { value: selectedValue } ), 'label' );
@@ -154,6 +150,7 @@ class SelectDropdown extends Component {
 				const newChild = React.cloneElement( child, {
 					ref: ( child.type === DropdownItem ) ? 'item-' + refIndex : null,
 					key: 'item-' + index,
+					isDropdownOpen: this.state.isOpen,
 					onClick: function( event ) {
 						self.refs.dropdownContainer.focus();
 						if ( typeof child.props.onClick === 'function' ) {
@@ -193,6 +190,7 @@ class SelectDropdown extends Component {
 				<DropdownItem
 					key={ 'dropdown-item-' + this.state.instanceId + '-' + item.value }
 					ref={ 'item-' + refIndex }
+					isDropdownOpen={ this.state.isOpen }
 					selected={ this.state.selected === item.value }
 					onClick={ this.onSelectItem( item ) }
 					path={ item.path }
@@ -398,8 +396,5 @@ class SelectDropdown extends Component {
 		}
 	}
 }
-
-// statics
-SelectDropdown.instances = 0;
 
 export default SelectDropdown;

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -3,31 +3,31 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { Component } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var Count = require( 'components/count' );
+import Count from 'components/count';
 
-var SelectDropdownItem = React.createClass( {
-	propTypes: {
+class SelectDropdownItem extends Component {
+	static propTypes = {
 		children: React.PropTypes.string.isRequired,
 		path: React.PropTypes.string,
+		isDropdownOpen: React.PropTypes.bool,
 		selected: React.PropTypes.bool,
 		onClick: React.PropTypes.func,
 		count: React.PropTypes.number
-	},
+	}
 
-	getDefaultProps: function() {
-		return {
-			selected: false
-		};
-	},
+	static defaultProps = {
+		isDropdownOpen: false,
+		selected: false
+	}
 
-	render: function() {
-		var optionClassName = classNames( this.props.className, {
+	render() {
+		const optionClassName = classNames( this.props.className, {
 			'select-dropdown__item': true,
 			'is-selected': this.props.selected,
 			'is-disabled': this.props.disabled
@@ -42,7 +42,7 @@ var SelectDropdownItem = React.createClass( {
 					onClick={ this.props.disabled ? null : this.props.onClick }
 					data-bold-text={ this.props.value || this.props.children }
 					role="menuitem"
-					tabIndex={ 0 }
+					tabIndex={ this.props.isDropdownOpen ? 0 : '' }
 					aria-selected={ this.props.selected } >
 					<span className="select-dropdown__item-text">
 						{ this.props.children }
@@ -62,6 +62,6 @@ var SelectDropdownItem = React.createClass( {
 			</li>
 		);
 	}
-} );
+}
 
-module.exports = SelectDropdownItem;
+export default SelectDropdownItem;

--- a/client/components/select-dropdown/label.jsx
+++ b/client/components/select-dropdown/label.jsx
@@ -3,23 +3,26 @@
 /**
  * External Dependencies
  */
-import React from 'react'
+import React from 'react';
 
 /**
  * Module variables
  */
-const { Component } = React;
+
+/**
+ * Prevents the event from bubbling up the DOM tree
+ * @param {SyntheticEvent} event - Browser's native event wrapper
+ * @return {void}
+ */
 const stopPropagation = event => event.stopPropagation();
 
-export default class SelectDropdownLabel extends Component {
-	render() {
-		return (
-			<li
-				onClick= { stopPropagation }
-				className="select-dropdown__label"
-			>
-				<label>{ this.props.children }</label>
-			</li>
-		);
-	}
-};
+export default function SelectDropdownLabel( props ) {
+	return (
+		<li
+			onClick= { stopPropagation }
+			className="select-dropdown__label"
+		>
+			<label>{ props.children }</label>
+		</li>
+	);
+}

--- a/client/components/select-dropdown/separator.jsx
+++ b/client/components/select-dropdown/separator.jsx
@@ -3,15 +3,9 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
-var SelectDropdownSeparator = React.createClass( {
+const SelectDropdownSeparator = () =>
+	<li className="select-dropdown__separator" />;
 
-	render: function() {
-		return (
-			<li className="select-dropdown__separator" />
-		);
-	}
-} );
-
-module.exports = SelectDropdownSeparator;
+export default SelectDropdownSeparator;

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -9,7 +9,6 @@ $compact-header-height: 35;
 
 .select-dropdown {
 	height: #{ $header-height }px;
-	overflow: hidden;
 
 	&.is-open {
 		overflow: visible;
@@ -31,17 +30,22 @@ $compact-header-height: 35;
 	.accessible-focus &:focus,
 	.accessible-focus .select-dropdown.is-open & {
 		z-index: z-index( 'root', '.accessible-focus .select-dropdown.is-open .select-dropdown__container' );
-		box-shadow: 0 0 0 2px $blue-light;
 		.select-dropdown__header {
 			border-color: $blue-wordpress;
 		}
 	}
 
+	.accessible-focus & {
+		border-radius: 4px;
+	}
+
 	.accessible-focus &:focus {
 		border-color: #00aadc;
-		box-shadow: 0 0 0 2px #78dcfa;
 		outline: 0;
-		border-radius: 4px;
+	}
+
+	.accessible-focus .select-dropdown.is-open & {
+		box-shadow: 0 0 0 2px $blue-light;
 	}
 }
 
@@ -106,6 +110,10 @@ $compact-header-height: 35;
 		}
 	}
 
+	.accessible-focus .select-dropdown:not(.is-open) .select-dropdown__container:focus & {
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+
 	.count {
 		position: absolute;
 		right: 40px;
@@ -130,6 +138,9 @@ $compact-header-height: 35;
 	border-top: 0;
 	// $blue-wordpress for outer (with focus shadow), $gray for border with header
 	border-radius: 0 0 4px 4px;
+	height: 0;
+	overflow: hidden;
+	opacity: 0;
 
 	.accessible-focus & {
 		border: solid 1px $blue-wordpress;
@@ -138,6 +149,8 @@ $compact-header-height: 35;
 
 	.select-dropdown.is-open & {
 		margin-top: -1px;
+		height: auto;
+		opacity: 1;
 	}
 }
 

--- a/client/components/select-dropdown/test/item.js
+++ b/client/components/select-dropdown/test/item.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import SelectDropdownItem from '../item';
+
+describe( 'item', function() {
+	useFakeDom();
+
+	describe( 'component rendering', function() {
+		it( 'should render a list entry', function() {
+			const dropdownItem = shallow( <SelectDropdownItem>Published</SelectDropdownItem> );
+			expect( dropdownItem.is( 'li.select-dropdown__option' ) ).to.be.true;
+		} );
+
+		it( 'should contain a link', function() {
+			const dropdownItem = shallow( <SelectDropdownItem>Published</SelectDropdownItem> );
+			expect( dropdownItem.children( 'a.select-dropdown__item' ).length ).to.eql( 1 );
+			expect( dropdownItem.find( 'span.select-dropdown__item-text' ).text() ).to.eql( 'Published' );
+		} );
+
+		it( 'should not have `tabindex` attribute, when the parent dropdown is closed', function() {
+			const dropdownItem = shallow( <SelectDropdownItem isDropdownOpen={ false }>Published</SelectDropdownItem> );
+			expect( dropdownItem.children( { tabIndex: 0 } ).length ).to.eql( 0 );
+		} );
+
+		it( 'should have `tabindex` attribute set to `0`, only when the parent dropdown is open (issue#9206)', function() {
+			const dropdownItem = shallow( <SelectDropdownItem isDropdownOpen={ true }>Published</SelectDropdownItem> );
+			expect( dropdownItem.children( { tabIndex: 0 } ).length ).to.eql( 1 );
+		} );
+	} );
+
+	describe( 'when the component is clicked', function() {
+		it( 'should do nothing when is disabled', function() {
+			const onClickSpy = sinon.spy();
+			const dropdownItem = shallow( <SelectDropdownItem disabled={ true } onClick={ onClickSpy }>Published</SelectDropdownItem> );
+
+			const link = dropdownItem.children( 'a.select-dropdown__item' );
+			expect( link.hasClass( 'is-disabled' ) ).to.be.true;
+
+			link.simulate( 'click' );
+			sinon.assert.notCalled( onClickSpy );
+		} );
+
+		it( 'should run the `onClick` hook', function() {
+			const onClickSpy = sinon.spy();
+			const dropdownItem = shallow( <SelectDropdownItem onClick={ onClickSpy }>Published</SelectDropdownItem> );
+			dropdownItem.children( 'a.select-dropdown__item' ).simulate( 'click' );
+			sinon.assert.calledOnce( onClickSpy );
+		} );
+	} );
+} );


### PR DESCRIPTION
With this PR, the DropdownItem childs of a Dropdown element have the `tabindex` attribute set only when the dropdown itself is open (this info is read from the Dropdown component state).

So, once the Dropdown is open it's possible to navigate through its options using the `tab` key; however pressing the `tab` key when the Dropdown is focused, but closed will result in the focus moving to the next focusable element of the page.

cc. @retrofox you were the latest person (before my previous pull request) to work on the select-dropdown component. I'd appreciate your review on this.