### PR TITLE
Taxonomies: Show taxonomies on all the space available on the page

### DIFF
--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -11,6 +11,7 @@
 		margin: 0 auto;
 		overflow: hidden;
 		max-width: none;
+		padding-top: 32px;
 		padding-left: 0;
 		padding-right: 0;
 	}

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -13,6 +13,7 @@ import {
 	reduce,
 	union,
 } from 'lodash';
+import WindowScroller from 'react-virtualized/WindowScroller';
 
 /**
  * Internal dependencies
@@ -167,18 +168,24 @@ export class TaxonomyManagerList extends Component {
 						query={ { ...query, page } } />
 				) ) }
 
-				<VirtualList
-					items={ terms }
-					lastPage={ lastPage }
-					loading={ loading }
-					getRowHeight={ this.getRowHeight }
-					renderRow={ this.renderRow }
-					onRequestPages={ this.requestPages }
-					perPage={ DEFAULT_TERMS_PER_PAGE }
-					loadOffset={ LOAD_OFFSET }
-					searching={ query.search && query.search.length }
-					defaultRowHeight={ ITEM_HEIGHT }
-				/>
+				<WindowScroller>
+					{ ( { height, scrollTop } ) => (
+						<VirtualList
+							items={ terms }
+							lastPage={ lastPage }
+							loading={ loading }
+							getRowHeight={ this.getRowHeight }
+							renderRow={ this.renderRow }
+							onRequestPages={ this.requestPages }
+							perPage={ DEFAULT_TERMS_PER_PAGE }
+							loadOffset={ LOAD_OFFSET }
+							searching={ query.search && query.search.length }
+							defaultRowHeight={ ITEM_HEIGHT }
+							height={ height }
+							scrollTop={ scrollTop }
+						/>
+				) }
+				</WindowScroller>
 			</div>
 		);
 	}

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -1,5 +1,4 @@
 .taxonomy-manager {
-	height: 300px;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 }

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -451,7 +451,7 @@
 
 	// add space in the main column for the docked sidebar
 	.has-chat .layout__content {
-		padding: 32px 304px;
+		padding: 79px 304px 32px;
 	}
 
 	// adjust when scoll arrows show up in stats insights when panel is open
@@ -462,7 +462,7 @@
 
 	// adjust themes page to accomodate docked sidebar
 	.has-chat.is-section-theme .layout__content {
-		padding: 32px 0;
+		padding: 79px 0 32px;
 	}
 
 	.has-chat.is-section-theme .theme__sheet {
@@ -475,7 +475,7 @@
 
 	// add space in the editor for the docked sidebar
 	.has-chat.is-group-editor .layout__content {
-		padding: 0 272px 0 0;
+		padding: 47px 272px 0 0;
 	}
 
 	.has-chat.is-group-editor .editor__header,

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -23,7 +23,9 @@ export class VirtualList extends Component {
 		perPage: PropTypes.number,
 		loadOffset: PropTypes.number,
 		query: PropTypes.object,
-		defaultRowHeight: PropTypes.number
+		defaultRowHeight: PropTypes.number,
+		height: PropTypes.number,
+		scrollTop: PropTypes.number
 	};
 
 	static defaultProps = {
@@ -159,14 +161,14 @@ export class VirtualList extends Component {
 
 	render() {
 		const rowCount = this.getRowCount();
-		const { className, loading, defaultRowHeight, getRowHeight } = this.props;
+		const { className, loading, defaultRowHeight, getRowHeight, height, scrollTop } = this.props;
 		const classes = classNames( 'virtual-list', className, {
 			'is-loading': loading
 		} );
 
 		return (
-			<AutoSizer>
-				{ ( { height, width } ) => (
+			<AutoSizer disableHeight>
+				{ ( { width } ) => (
 					<div className={ classes }>
 						<VirtualScroll
 							ref={ this.setVirtualScrollRef }
@@ -179,6 +181,8 @@ export class VirtualList extends Component {
 							className={ className }
 							width={ width }
 							height={ height }
+							scrollTop={ scrollTop }
+							autoHeight
 						/>
 					</div>
 				) }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -10,8 +10,8 @@
 .layout__content {
 	@include clear-fix;
 	position: relative;
-	margin: 47px 0 0 0;
-	padding: 32px 32px 32px ( $sidebar-width-max + 32px );
+	margin: 0;
+	padding: 79px 32px 32px ( $sidebar-width-max + 32px );
 	box-sizing: border-box;
 	overflow: hidden;
 	transition: opacity 0.3s;
@@ -33,8 +33,7 @@
 // Tablets
 @include breakpoint( "<960px" ) {
 	.layout__content {
-		padding: 24px;
-		padding-left: ( $sidebar-width-min + 24px );
+		padding: 71px 24px 24px ( $sidebar-width-min + 24px );
 
 		.has-no-sidebar & {
 			padding-left: 24px;
@@ -52,6 +51,7 @@
 	.layout__content {
 		margin-left: 0;
 		padding: 0;
+		padding-top: 47px;
 
 		.has-no-sidebar & {
 			padding-left: 0;

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -11,7 +11,7 @@
 }
 
 .is-group-editor .layout__content {
-	padding: 0;
+	padding: 47px 0 0;
 }
 
 .post-editor__inner {

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -1,5 +1,5 @@
 .is-reader-page .layout__content {
-	padding-top: 0;
+	padding-top: 47px;
 }
 
 .is-reader-page .reader__content,


### PR DESCRIPTION
Use WindowScroller from react-virtualized to show the taxonomies on all the available space on the page.

Also, I noticed that we can scroll on every page of Calypso even if the content fits in the available space, I fixed that here, by changing the margin to padding on `.layout__content` 

<img width="1280" alt="capture d ecran 2016-11-09 a 4 34 06 pm" src="https://cloud.githubusercontent.com/assets/272444/20143781/925ab5c0-a69a-11e6-8d64-8c28f9f9b957.png">


**Testing instructions**

 * Open the taxonomies page `/settings/taxonomies/$site/category`
 * Make sure to have a large number of categories
 * You can scroll smoothly and the taxonomies are shown on all the available space

cc @timmyc