### PR TITLE
Taxonomies: Add/Edit Categories from the Writing settings page

### DIFF
--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -14,6 +14,7 @@ import TermsList from './list';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import QueryTaxonomies from 'components/data/query-taxonomies';
+import TermFormDialog from 'blocks/term-form-dialog';
 
 export class TaxonomyManager extends Component {
 	static propTypes = {
@@ -28,7 +29,26 @@ export class TaxonomyManager extends Component {
 	};
 
 	state = {
-		search: null
+		search: null,
+		termFormDialogOpened: false
+	};
+
+	closeTermFormDialog = () => {
+		this.setState( { termFormDialogOpened: false } );
+	};
+
+	newTerm = () => {
+		this.setState( {
+			termFormDialogOpened: true,
+			selectedTerm: undefined
+		} );
+	};
+
+	editTerm = term => {
+		this.setState( {
+			termFormDialogOpened: true,
+			selectedTerm: term
+		} );
 	};
 
 	onSearch = searchTerm => {
@@ -53,12 +73,20 @@ export class TaxonomyManager extends Component {
 				<div className="taxonomy-manager__header">
 					<SearchCard onSearch={ this.onSearch } delaySearch />
 					<div className="taxonomy-manager__actions">
-						<Button compact primary>
+						<Button compact primary onClick={ this.newTerm }>
 							{ labels.add_new_item }
 						</Button>
 					</div>
 				</div>
-				<TermsList query={ query } taxonomy={ taxonomy } />
+				<TermsList query={ query } taxonomy={ taxonomy } onTermClick={ this.editTerm } />
+				<TermFormDialog
+					showDialog={ this.state.termFormDialogOpened }
+					onClose={ this.closeTermFormDialog }
+					taxonomy={ this.props.taxonomy }
+					postType={ this.props.postType }
+					term={ this.state.selectedTerm }
+					showDescriptionInput
+				/>
 			</div>
 		);
 	}

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -30,10 +30,11 @@ class TaxonomyManagerListItem extends Component {
 		};
 	}
 
-	togglePopoverMenu = () => {
+	togglePopoverMenu = event => {
+		event.stopPropagation && event.stopPropagation();
 		this.setState( {
 			popoverMenuOpen: ! this.state.popoverMenuOpen
-		} )
+		} );
 	}
 
 	render() {

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -35,7 +35,14 @@ class TaxonomyManagerListItem extends Component {
 		this.setState( {
 			popoverMenuOpen: ! this.state.popoverMenuOpen
 		} );
-	}
+	};
+
+	editItem = () => {
+		this.setState( {
+			popoverMenuOpen: false
+		} );
+		this.props.onClick();
+	};
 
 	render() {
 		const { name, translate } = this.props;
@@ -57,7 +64,7 @@ class TaxonomyManagerListItem extends Component {
 					position={ 'bottom left' }
 					context={ this.refs && this.refs.popoverMenuButton }
 				>
-					<PopoverMenuItem onClick={ this.props.onClick }>
+					<PopoverMenuItem onClick={ this.editItem }>
 						<Gridicon icon="pencil" size={ 18 } />
 						{ translate( 'Edit' ) }
 					</PopoverMenuItem>

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -173,10 +173,11 @@ class TermFormDialog extends Component {
 
 		const lowerCasedTermName = values.name.toLowerCase();
 		const matchingTerm = find( this.props.terms, ( term ) => {
-			return ( term.name.toLowerCase() === lowerCasedTermName ) &&
-				( ! this.props.isHierarchical ||
-					( term.parent === values.parent && ( ! this.props.term || term.ID !== this.props.term.ID ) )
-				);
+			return (
+				term.name.toLowerCase() === lowerCasedTermName &&
+				( ! this.props.term || term.ID !== this.props.term.ID ) &&
+				( ! this.props.isHierarchical || ( term.parent === values.parent ) )
+			);
 		} );
 
 		if ( matchingTerm ) {

--- a/client/blocks/term-form-dialog/style.scss
+++ b/client/blocks/term-form-dialog/style.scss
@@ -1,3 +1,8 @@
+.term-form-dialog {
+	max-height: 100%;
+	overflow-y: auto;
+}
+
 .term-form-dialog .dialog__content {
 	min-width: 40vw;
 }

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -47,12 +47,12 @@ export default class TermQueryManager extends PaginatedQueryManager {
 		let order;
 
 		switch ( query.order_by ) {
-			case 'name':
-				order = termA.name.localeCompare( termB.name );
-				break;
-
 			case 'count':
 				order = termA.post_count - termB.post_count;
+				break;
+			case 'name':
+			default:
+				order = termA.name.localeCompare( termB.name );
 				break;
 		}
 

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -25,6 +25,7 @@ import {
 	updateTerm
 } from '../actions';
 import PostQueryManager from 'lib/query-manager/post';
+import TermQueryManager from 'lib/query-manager/term';
 
 /**
  * Module Variables
@@ -278,7 +279,18 @@ describe( 'actions', () => {
 							items: postObjects[ siteId ]
 						} )
 					},
-
+				},
+				terms: {
+					queries: {
+						[ siteId ]: {
+							[ taxonomyName ]: new TermQueryManager( {
+								items: {
+									11: { ID: 11, name: 'chicken', slug: 'chicken', parent: 10 }
+								},
+								queries: {}
+							} )
+						}
+					}
 				}
 			};
 			const getState = () => state;
@@ -294,7 +306,10 @@ describe( 'actions', () => {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
-					terms: [ { ID: 123, name: 'ribs', description: '' } ],
+					terms: [
+						{ ID: 11, name: 'chicken', slug: 'chicken', parent: 123 },
+						{ ID: 123, name: 'ribs', description: '' }
+					],
 					query: undefined,
 					found: undefined
 				} );


### PR DESCRIPTION
Use the TermFormDialog component to allow editing and adding categories right from the Settings writing page.

**testing instructions**
- Go to the /settings/taxonomies/$site/category page
- Click "Add Category" and add new categories
- Click on a category to display the edition dialog. You should be able to edit the term and the related posts should be updated correctly.
- Try to edit the description, the parent item, the name
- Try to edit terms with children
- Try to add/edit tags as well

cc @timmyc 