### PR TITLE
Advanced SEO: fix visual glitches in SEO preview on Windows

### DIFF
--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -86,7 +86,6 @@
 
 .seo-preview-pane__preview-area {
 	margin: 10px auto;
-	overflow-y: scroll;
 }
 
 .seo-preview-pane__preview {

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -101,6 +101,7 @@
 
 .facebook-preview__description {
 	color: #4b4f56;
+	flex-grow: 1;
 	font-family: helvetica, arial, sans-serif;
 	font-size: 12px;
 	line-height: 16px;
@@ -160,14 +161,11 @@
 		width: 158px;
 
 		& img {
+			display: block;
 			font-size: 14px;
 			height: auto;
 			width: 100%;
 		}
-	}
-
-	.facebook-preview__body {
-		height: 138px;
 	}
 
 	.facebook-preview__title {
@@ -177,6 +175,7 @@
 
 	.facebook-preview__url {
 		margin-top: auto;
+		margin-bottom: 5px;
 	}
 }
 

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -105,7 +105,6 @@
 	font-family: helvetica, arial, sans-serif;
 	font-size: 12px;
 	line-height: 16px;
-	max-height: 50px;
 	overflow-y: hidden;
 }
 
@@ -157,6 +156,7 @@
 	max-height: 158px;
 
 	.facebook-preview__image {
+		flex-shrink: 0;
 		height: 100%;
 		width: 158px;
 
@@ -166,6 +166,10 @@
 			height: auto;
 			width: 100%;
 		}
+	}
+
+	.facebook-preview__body {
+		width: 100%;
 	}
 
 	.facebook-preview__title {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/8695.

Removed unnecessary vertical scrollbar.
Fixed flex glitches in the Facebook preview.
Added `margin-bottom: 5px;` to the URL, as it's what Facebook does.

| Before | After |
| --- | --- |
| ![before](https://cloud.githubusercontent.com/assets/2070010/20212864/ce875546-a805-11e6-9434-3af4d312bd51.png) | ![after](https://cloud.githubusercontent.com/assets/2070010/20212857/c5a3836e-a805-11e6-8623-779dc915b35d.png) |

Tested also on Chome 54, Internet Explorer 11, and Edge.