### PR TITLE
Preview: fix positioning on IE11

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -51,6 +51,7 @@
 	transition: transform 0.2s ease-out,
 		opacity 0.1s ease-in-out,
 		max-width 0.2s ease-out;
+	width: 100%;
 
 	.is-computer & {
 		max-width: 1200px;


### PR DESCRIPTION
Added explicit width to the preview content in order to force IE11 to respect the `margin: 0 auto;`.

| Before | After |
| --- | --- |
| ![before](https://cloud.githubusercontent.com/assets/2070010/20213462/1916378c-a809-11e6-9f2b-022c1017e1dd.jpg) | ![after](https://cloud.githubusercontent.com/assets/2070010/20213467/1d1c1810-a809-11e6-9fe1-743e70c70c49.jpg) |

Tested on Internet Explorer 11, and on Chrome 54 and Edge for possible regressions.