### PR TITLE
GuidedTours: don't require tour authors to use CSS classes

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -254,6 +254,7 @@ export class Step extends Component {
 
 	render() {
 		const { when, children } = this.props;
+		const { isLastStep } = this.context;
 
 		debug( 'Step#render' );
 		if ( this.context.shouldPause ) {
@@ -273,6 +274,7 @@ export class Step extends Component {
 			'guided-tours__step',
 			'guided-tours__step-glow',
 			this.context.step === 'init' && 'guided-tours__step-first',
+			isLastStep && 'guided-tours__step-finish',
 			targetSlug && 'guided-tours__step-pointing',
 			targetSlug && 'guided-tours__step-pointing-' + getValidatedArrowPosition( {
 				targetSlug,
@@ -413,7 +415,11 @@ export class Continue extends Component {
 			return null;
 		}
 
-		return <i>{ this.props.children || translate( 'Click to continue.' ) }</i>;
+		return (
+			<p className="guided-tours__actionstep-instructions">
+				<i>{ this.props.children || translate( 'Click to continue.' ) }</i>
+			</p>
+		);
 	}
 }
 
@@ -424,7 +430,7 @@ export class ButtonRow extends Component {
 
 	render() {
 		return (
-			<div className="guided-tours__choice-button-row">
+			<div className="{ this.props.single === true ? 'guided-tours__single-button-row' : 'guided-tours__choice-button-row' }">
 				{ this.props.children }
 			</div>
 		);

--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -430,7 +430,7 @@ export class ButtonRow extends Component {
 
 	render() {
 		return (
-			<div className="{ this.props.single === true ? 'guided-tours__single-button-row' : 'guided-tours__choice-button-row' }">
+			<div className={ this.props.single === true ? 'guided-tours__single-button-row' : 'guided-tours__choice-button-row' }>
 				{ this.props.children }
 			</div>
 		);

--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -417,6 +417,20 @@ export class Continue extends Component {
 	}
 }
 
+export class ButtonRow extends Component {
+	constructor( props ) {
+		super( props );
+	}
+
+	render() {
+		return (
+			<div className="guided-tours__choice-button-row">
+				{ this.props.children }
+			</div>
+		);
+	}
+}
+
 export class Link extends Component {
 	constructor( props ) {
 		super( props );

--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -272,6 +272,7 @@ export class Step extends Component {
 			this.props.className,
 			'guided-tours__step',
 			'guided-tours__step-glow',
+			this.context.step === 'init' && 'guided-tours__step-first',
 			targetSlug && 'guided-tours__step-pointing',
 			targetSlug && 'guided-tours__step-pointing-' + getValidatedArrowPosition( {
 				targetSlug,

--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -424,12 +424,11 @@ export class Continue extends Component {
 }
 
 export const ButtonRow = ( { children } ) => {
-	const isSingleButton = React.Children.count( children ) === 1;
-	return (
-		<div className={ isSingleButton ? 'guided-tours__single-button-row' : 'guided-tours__choice-button-row' }>
-			{ children }
-		</div>
-	);
+	const className = React.Children.count( children ) === 1
+		? 'guided-tours__single-button-row'
+		: 'guided-tours__choice-button-row';
+
+	return <div className={ className }>{ children }</div>;
 };
 
 export class Link extends Component {

--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -417,25 +417,20 @@ export class Continue extends Component {
 
 		return (
 			<p className="guided-tours__actionstep-instructions">
-				<i>{ this.props.children || translate( 'Click to continue.' ) }</i>
+				<em>{ this.props.children || translate( 'Click to continue.' ) }</em>
 			</p>
 		);
 	}
 }
 
-export class ButtonRow extends Component {
-	constructor( props ) {
-		super( props );
-	}
-
-	render() {
-		return (
-			<div className={ this.props.single === true ? 'guided-tours__single-button-row' : 'guided-tours__choice-button-row' }>
-				{ this.props.children }
-			</div>
-		);
-	}
-}
+export const ButtonRow = ( { children } ) => {
+	const isSingleButton = React.Children.count( children ) === 1;
+	return (
+		<div className={ isSingleButton ? 'guided-tours__single-button-row' : 'guided-tours__choice-button-row' }>
+			{ children }
+		</div>
+	);
+};
 
 export class Link extends Component {
 	constructor( props ) {

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -28,7 +28,7 @@ const scrollSidebarToTop = () =>
 
 export const MainTour = makeTour(
 	<Tour name="main" version="20160601" path="/" when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }>
-		<Step name="init" placement="right" className="guided-tours__step-first">
+		<Step name="init" placement="right">
 			<p className="guided-tours__step-text">
 				{
 					translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place," +

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -30,7 +30,7 @@ const scrollSidebarToTop = () =>
 export const MainTour = makeTour(
 	<Tour name="main" version="20160601" path="/" when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }>
 		<Step name="init" placement="right">
-			<p className="guided-tours__step-text">
+			<p>
 				{
 					translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place," +
 											'and give you some ideas for what to do next.',
@@ -52,7 +52,7 @@ export const MainTour = makeTour(
 			placement="below"
 			arrow="top-left"
 		>
-			<p className="guided-tours__step-text">
+			<p>
 				{
 					translate( "{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing " +
 											"your site's content and design.",
@@ -63,17 +63,15 @@ export const MainTour = makeTour(
 						} )
 				}
 			</p>
-			<p className="guided-tours__actionstep-instructions">
-				<Continue icon="my-sites" target="my-sites" step="sidebar" click>
-					{
-						translate( 'Click the {{GridIcon/}} to continue.', {
-							components: {
-								GridIcon: <Gridicon icon="my-sites" size={ 24 } />,
-							}
-						} )
-					}
-				</Continue>
-			</p>
+			<Continue icon="my-sites" target="my-sites" step="sidebar" click>
+				{
+					translate( 'Click the {{GridIcon/}} to continue.', {
+						components: {
+							GridIcon: <Gridicon icon="my-sites" size={ 24 } />,
+						}
+					} )
+				}
+			</Continue>
 		</Step>
 
 		<Step name="sidebar"
@@ -81,24 +79,23 @@ export const MainTour = makeTour(
 			arrow="left-middle"
 			placement="beside"
 		>
-			<p className="guided-tours__step-text">
+			<p>
 				{ translate( 'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.' ) }
 			</p>
-			<div className="guided-tours__choice-button-row">
+			<ButtonRow>
 				<Next step="click-preview" />
 				<Quit />
-			</div>
+			</ButtonRow>
 		</Step>
 
 		<Step name="click-preview"
-			className="guided-tours__step-action"
 			target="site-card-preview"
 			arrow="top-left"
 			placement="below"
 			when={ selectedSiteIsPreviewable }
 			scrollContainer=".sidebar__region"
 		>
-			<p className="guided-tours__step-text">
+			<p>
 				{
 					translate( "This shows your currently {{strong}}selected site{{/strong}}'s name and address.", {
 						components: {
@@ -107,24 +104,22 @@ export const MainTour = makeTour(
 					} )
 				}
 			</p>
-			<p className="guided-tours__actionstep-instructions">
-				<Continue step="in-preview" target="site-card-preview" click>
-					{
-						translate( "Click {{strong}}your site's name{{/strong}} to continue.", {
-							components: {
-								strong: <strong />,
-							},
-						} )
-					}
-				</Continue>
-			</p>
+			<Continue step="in-preview" target="site-card-preview" click>
+				{
+					translate( "Click {{strong}}your site's name{{/strong}} to continue.", {
+						components: {
+							strong: <strong />,
+						},
+					} )
+				}
+			</Continue>
 		</Step>
 
 		<Step name="in-preview"
 			placement="center"
 			when={ selectedSiteIsPreviewable }
 		>
-			<p className="guided-tours__step-text">
+			<p>
 				{
 					translate( "This is your site's {{strong}}Preview{{/strong}}. From here you can see how your site looks to others.", {
 						components: {
@@ -133,34 +128,31 @@ export const MainTour = makeTour(
 					} )
 				}
 			</p>
-			<div className="guided-tours__choice-button-row">
+			<ButtonRow>
 				<Next step="close-preview" />
 				<Quit />
 				<Continue step="close-preview" when={ previewIsNotShowing } hidden />
-			</div>
+			</ButtonRow>
 		</Step>
 
 		<Step name="close-preview"
-			className="guided-tours__step-action"
 			target="web-preview__close"
 			arrow="left-top"
 			placement="beside"
 			when={ and( selectedSiteIsPreviewable, previewIsShowing ) }
 		>
-			<p className="guided-tours__step-text">
+			<p>
 				{ translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ) }
 			</p>
-			<p className="guided-tours__actionstep-instructions">
-				<Continue step="themes" target="web-preview__close" when={ previewIsNotShowing }>
-					{
-						translate( 'Click the {{GridIcon/}} to continue.', {
-							components: {
-								GridIcon: <Gridicon icon="cross-small" size={ 24 } />,
-							}
-						} )
-					}
-				</Continue>
-			</p>
+			<Continue step="themes" target="web-preview__close" when={ previewIsNotShowing }>
+				{
+					translate( 'Click the {{GridIcon/}} to continue.', {
+						components: {
+							GridIcon: <Gridicon icon="cross-small" size={ 24 } />,
+						}
+					} )
+				}
+			</Continue>
 		</Step>
 
 		<Step name="themes"
@@ -171,7 +163,7 @@ export const MainTour = makeTour(
 			scrollContainer=".sidebar__region"
 			shouldScrollTo
 		>
-			<p className="guided-tours__step-text">
+			<p>
 				{
 					translate( 'Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} ' +
 											"your theme's colors, fonts, and more.",
@@ -182,17 +174,14 @@ export const MainTour = makeTour(
 						} )
 				}
 			</p>
-			<div className="guided-tours__choice-button-row">
+			<ButtonRow>
 				<Next step="finish" />
 				<Quit />
-			</div>
+			</ButtonRow>
 		</Step>
 
-		<Step name="finish"
-			placement="center"
-			className="guided-tours__step-finish"
-		>
-			<p className="guided-tours__step-text">
+		<Step name="finish" placement="center">
+			<p>
 				{
 					translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.", {
 						components: {
@@ -201,11 +190,11 @@ export const MainTour = makeTour(
 					} )
 				}
 			</p>
-			<div className="guided-tours__single-button-row">
+			<ButtonRow single={ true }>
 				<Quit onClick={ scrollSidebarToTop } primary>
 					{ translate( "We're all done!" ) }
 				</Quit>
-			</div>
+			</ButtonRow>
 			<Link href="https://learn.wordpress.com">
 				{ translate( 'Learn more about WordPress.com' ) }
 			</Link>

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -6,6 +6,7 @@ import {
 	makeTour,
 	Tour,
 	Step,
+	ButtonRow,
 	Next,
 	Quit,
 	Continue,
@@ -40,10 +41,10 @@ export const MainTour = makeTour(
 						} )
 				}
 			</p>
-			<div className="guided-tours__choice-button-row">
+			<ButtonRow>
 				<Next step="my-sites">{ translate( "Let's go!" ) }</Next>
 				<Quit>{ translate( 'No thanks.' ) }</Quit>
-			</div>
+			</ButtonRow>
 		</Step>
 
 		<Step name="my-sites"

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -190,7 +190,7 @@ export const MainTour = makeTour(
 					} )
 				}
 			</p>
-			<ButtonRow single={ true }>
+			<ButtonRow>
 				<Quit onClick={ scrollSidebarToTop } primary>
 					{ translate( "We're all done!" ) }
 				</Quit>

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -13,7 +13,7 @@
 	animation-name: guided-tours__step-fadein;
 	animation-timing-function: ease-in-out;
 
-	.guided-tours__step-text {
+	p {
 		color: lighten( $gray, 30 );
 		margin-bottom: 16px;
 


### PR DESCRIPTION
Currently when you write a tour for GuidedTours, you will need to use GT's CSS classes explicitly to make your tour look the way we want all tours to look. 

As an example, the text in a tour step would be a paragraph like this:

``` JSX
<p className="guided-tours__step-text">
...
</p>
```

However, we'd prefer that tour authors not have to worry about using the correct CSS classes. 

This change moves the responsibility to apply the correct CSS classes to the framework and out of the tour definition files. 

Closes #8974. 

To test: 

- check out `master`
- go to `http://calypso.localhost:3000/?tour=main` to trigger the main tour
- record or memorize what the tour looks like
- checkout this branch
- go to `http://calypso.localhost:3000/?tour=main` to trigger the main tour
- make sure the tour looks exactly the same as the one on `master`
- make sure the tour definition `tour-main.js` does not include any className declarations anymore
