### PR TITLE
SEO Tools: Show notice when module is inactive

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -475,11 +475,11 @@ export const SeoForm = React.createClass( {
 						status="is-warning"
 						showDismiss={ false }
 						text={ this.translate(
-							'You must activate SEO Tools module in Jetpack\'s dashboard for these changes to take effect.'
+							'SEO Tools module is disabled in Jetpack.'
 						) }
 					>
 						<NoticeAction href={ '//' + slug + '/wp-admin/admin.php?page=jetpack#/engagement' }>
-							{ this.translate( 'Activate Now' ) }
+							{ this.translate( 'Enable' ) }
 						</NoticeAction>
 					</Notice>
 				}

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -470,6 +470,17 @@ export const SeoForm = React.createClass( {
 					</Notice>
 				}
 
+				{ jetpack && ! this.props.site.isModuleActive( 'seo-tools' ) &&
+					<Notice
+						status="is-warning"
+						showDismiss={ false }
+						text={ this.translate(
+							'You must activate SEO Tools module in Jetpack\'s dashboard for these changes to take effect.'
+						) }
+					>
+					</Notice>
+				}
+
 				{ showUpgradeNudge &&
 					<UpgradeNudge
 						feature={ FEATURE_ADVANCED_SEO }
@@ -718,7 +729,7 @@ const mapStateToProps = ( state, ownProps ) => {
 
 	const seoFeatureEnabled = site &&
 		( ! site.jetpack && config.isEnabled( 'manage/advanced-seo' ) ||
-			site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) && jetpackVersionSupportsSeo && site.isModuleActive( 'seo-tools' ) );
+			site.jetpack && config.isEnabled( 'jetpack/seo-tools' ) && jetpackVersionSupportsSeo );
 
 	return {
 		selectedSite: getSelectedSite( state ),

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -478,6 +478,9 @@ export const SeoForm = React.createClass( {
 							'You must activate SEO Tools module in Jetpack\'s dashboard for these changes to take effect.'
 						) }
 					>
+						<NoticeAction href={ '//' + slug + '/wp-admin/admin.php?page=jetpack#/engagement' }>
+							{ this.translate( 'Activate Now' ) }
+						</NoticeAction>
 					</Notice>
 				}
 


### PR DESCRIPTION
Shows notice in case SEO Tools module is not active in Jetpack, instead of hiding SEO related sections.

![modulemsg](https://cloud.githubusercontent.com/assets/1182160/20376211/5868bf44-ac8d-11e6-906e-1351b85b04d6.png)


