### PR TITLE
SiteSelectorModal: ES6ify

### DIFF
--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { includes } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,11 +16,8 @@ import sitesListFactory from 'lib/sites-list';
 
 const sitesList = sitesListFactory();
 
-/**
- * Component
- */
-const SiteSelectorModal = React.createClass( {
-	propTypes: {
+class SiteSelectorModal extends Component {
+	static propTypes = {
 		// children: Custom content. Will be displayed above the `SitesDropdown`.
 		children: React.PropTypes.node,
 		// filter: Function to filter sites to display
@@ -35,53 +33,57 @@ const SiteSelectorModal = React.createClass( {
 		// mainActionLabel: Label for the call-for-action button.
 		mainActionLabel: React.PropTypes.string.isRequired,
 		// className: class name(s) to be added to the Dialog
-		className: React.PropTypes.string
-	},
+		className: React.PropTypes.string,
+		// from localize()
+		translate: React.PropTypes.func.isRequired
+	}
 
-	getInitialState() {
+	constructor( props ) {
+		super( props );
+
 		const primarySite = sitesList.getPrimary();
 		let filteredSites = sitesList.getVisible();
 
-		if ( this.props.filter ) {
-			filteredSites = filteredSites.filter( this.props.filter );
+		if ( props.filter ) {
+			filteredSites = filteredSites.filter( props.filter );
 		}
 
-		return {
+		this.state = {
 			site: includes( filteredSites, primarySite )
 				? primarySite
 				: filteredSites[ 0 ]
 		};
-	},
+	}
 
-	setSite( slug ) {
+	setSite = ( slug ) => {
 		const site = sitesList.getSite( slug );
 		this.setState( { site: site } );
-	},
+	}
 
-	onClose( action ) {
+	onClose = ( action ) => {
 		if ( 'mainAction' === action ) {
 			this.props.mainAction( this.state.site );
 		}
 
 		this.props.hide();
-	},
+	}
 
-	onButtonClick() {
+	onButtonClick = () => {
 		this.props.mainAction( this.state.site );
-	},
+	}
 
-	getMainLink() {
+	getMainLink = () => {
 		const url = this.props.getMainUrl && this.props.getMainUrl( this.state.site );
 
 		return url
 			? <Button primary href={ url } onClick={ this.onButtonClick } >{ this.props.mainActionLabel }</Button>
 			: { action: 'mainAction', label: this.props.mainActionLabel, isPrimary: true };
-	},
+	}
 
 	render() {
 		const mainLink = this.getMainLink(),
 			buttons = [
-				{ action: 'back', label: this.translate( 'Back' ) },
+				{ action: 'back', label: this.props.translate( 'Back' ) },
 				mainLink
 			],
 			classNames = classnames( 'site-selector-modal', this.props.className );
@@ -101,6 +103,6 @@ const SiteSelectorModal = React.createClass( {
 			</Dialog>
 		);
 	}
-} );
+}
 
-export default SiteSelectorModal;
+export default localize( SiteSelectorModal );

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -19,23 +19,23 @@ const sitesList = sitesListFactory();
 class SiteSelectorModal extends Component {
 	static propTypes = {
 		// children: Custom content. Will be displayed above the `SitesDropdown`.
-		children: React.PropTypes.node,
+		children: PropTypes.node,
 		// filter: Function to filter sites to display
-		filter: React.PropTypes.func,
+		filter: PropTypes.func,
 		// hide: Will be called when clicking either button. Should toggle the `isVisible` prop.
-		hide: React.PropTypes.func.isRequired,
+		hide: PropTypes.func.isRequired,
 		// isVisible: Determines if `SiteSelectorModal` will be displayed.
-		isVisible: React.PropTypes.bool.isRequired,
+		isVisible: PropTypes.bool.isRequired,
 		// mainAction: Will be run upon clicking the call-for-action button. Receives `site` as argument.
-		mainAction: React.PropTypes.func.isRequired,
+		mainAction: PropTypes.func.isRequired,
 		// getMainUrl: Use if the call-for-action button should be turned into an `<a>` link. Receives `site` as argument, returns a URL.
-		getMainUrl: React.PropTypes.func,
+		getMainUrl: PropTypes.func,
 		// mainActionLabel: Label for the call-for-action button.
-		mainActionLabel: React.PropTypes.string.isRequired,
+		mainActionLabel: PropTypes.string.isRequired,
 		// className: class name(s) to be added to the Dialog
-		className: React.PropTypes.string,
+		className: PropTypes.string,
 		// from localize()
-		translate: React.PropTypes.func.isRequired
+		translate: PropTypes.func.isRequired
 	}
 
 	constructor( props ) {

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -57,7 +57,7 @@ class SiteSelectorModal extends Component {
 
 	setSite = ( slug ) => {
 		const site = sitesList.getSite( slug );
-		this.setState( { site: site } );
+		this.setState( { site } );
 	}
 
 	onClose = ( action ) => {
@@ -72,7 +72,7 @@ class SiteSelectorModal extends Component {
 		this.props.mainAction( this.state.site );
 	}
 
-	getMainLink = () => {
+	getMainLink() {
 		const url = this.props.getMainUrl && this.props.getMainUrl( this.state.site );
 
 		return url
@@ -81,12 +81,12 @@ class SiteSelectorModal extends Component {
 	}
 
 	render() {
-		const mainLink = this.getMainLink(),
-			buttons = [
-				{ action: 'back', label: this.props.translate( 'Back' ) },
-				mainLink
-			],
-			classNames = classnames( 'site-selector-modal', this.props.className );
+		const mainLink = this.getMainLink();
+		const buttons = [
+			{ action: 'back', label: this.props.translate( 'Back' ) },
+			mainLink
+		];
+		const classNames = classnames( 'site-selector-modal', this.props.className );
 
 		return (
 			<Dialog className={ classNames }

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -1,22 +1,24 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' ),
-	includes = require( 'lodash/includes' );
+import React from 'react';
+import classnames from 'classnames';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var Dialog = require( 'components/dialog' ),
-	Button = require( 'components/button' ),
-	SitesDropdown = require( 'components/sites-dropdown' ),
-	sitesList = require( 'lib/sites-list' )();
+import Dialog from 'components/dialog';
+import Button from 'components/button';
+import SitesDropdown from 'components/sites-dropdown';
+import sitesListFactory from 'lib/sites-list';
+
+const sitesList = sitesListFactory();
 
 /**
  * Component
  */
-var SiteSelectorModal = React.createClass( {
+const SiteSelectorModal = React.createClass( {
 	propTypes: {
 		// children: Custom content. Will be displayed above the `SitesDropdown`.
 		children: React.PropTypes.node,
@@ -36,7 +38,7 @@ var SiteSelectorModal = React.createClass( {
 		className: React.PropTypes.string
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		const primarySite = sitesList.getPrimary();
 		let filteredSites = sitesList.getVisible();
 
@@ -47,16 +49,16 @@ var SiteSelectorModal = React.createClass( {
 		return {
 			site: includes( filteredSites, primarySite )
 				? primarySite
-				: filteredSites[0]
+				: filteredSites[ 0 ]
 		};
 	},
 
-	setSite: function( slug ) {
-		var site = sitesList.getSite( slug );
+	setSite( slug ) {
+		const site = sitesList.getSite( slug );
 		this.setState( { site: site } );
 	},
 
-	onClose: function( action ) {
+	onClose( action ) {
 		if ( 'mainAction' === action ) {
 			this.props.mainAction( this.state.site );
 		}
@@ -64,20 +66,20 @@ var SiteSelectorModal = React.createClass( {
 		this.props.hide();
 	},
 
-	onButtonClick: function() {
+	onButtonClick() {
 		this.props.mainAction( this.state.site );
 	},
 
-	getMainLink: function() {
-		var url = this.props.getMainUrl && this.props.getMainUrl( this.state.site );
+	getMainLink() {
+		const url = this.props.getMainUrl && this.props.getMainUrl( this.state.site );
 
 		return url
 			? <Button primary href={ url } onClick={ this.onButtonClick } >{ this.props.mainActionLabel }</Button>
 			: { action: 'mainAction', label: this.props.mainActionLabel, isPrimary: true };
 	},
 
-	render: function() {
-		var mainLink = this.getMainLink(),
+	render() {
+		const mainLink = this.getMainLink(),
 			buttons = [
 				{ action: 'back', label: this.translate( 'Back' ) },
 				mainLink
@@ -101,4 +103,4 @@ var SiteSelectorModal = React.createClass( {
 	}
 } );
 
-module.exports = SiteSelectorModal;
+export default SiteSelectorModal;


### PR DESCRIPTION
Since I'm going to work on this component soon (because of #9298), I figured I'd ES6ify it first.
Its only consumer seems to be `ThemeSiteSelectorModal` AFAICT.

To test:
* http://calypso.localhost:3000/design
* Click any theme's '...' menu and select any option above the separator
* You're prompted with the `ThemeSiteSelectorModal`. Verify that it's not broken.
* Select a site and click the call-to-action button. Verify that the expected option is executed for the selected site.