### PR TITLE
SEO Tools: update wording of Pro to Professional

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -416,7 +416,7 @@ export const SeoForm = React.createClass( {
 		};
 
 		const nudgeTitle = jetpack
-			? this.translate( 'Enable SEO Tools Features by Upgrading to Jetpack Pro' )
+			? this.translate( 'Enable SEO Tools Features by Upgrading to Jetpack Professional' )
 			: this.translate( 'Enable SEO Tools Features by Upgrading to the Business Plan' );
 
 		const submitButton = (


### PR DESCRIPTION
This removes ambiguity in the next step when user is presented with two plans in two columns and SEO Tools feature is at the bottom.

cc @vindl for review, thanks!