### PR TITLE
SEO Tools: Show notice when Verification tools module is inactive

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -589,6 +589,17 @@ export const SeoForm = React.createClass( {
 						</div>
 					}
 
+					{ jetpack && ! this.props.site.isModuleActive( 'verification-tools' ) &&
+						<Notice
+							status="is-warning"
+							showDismiss={ false }
+							text={ this.translate(
+								'You must activate Site Verification module in Jetpack\'s dashboard for these changes to take effect.'
+							) }
+						>
+						</Notice>
+					}
+
 					<SectionHeader label={ this.translate( 'Site Verification Services' ) }>
 						{ submitButton }
 					</SectionHeader>

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -597,6 +597,9 @@ export const SeoForm = React.createClass( {
 								'You must activate Site Verification module in Jetpack\'s dashboard for these changes to take effect.'
 							) }
 						>
+							<NoticeAction href={ '//' + slug + '/wp-admin/admin.php?page=jetpack#/engagement' }>
+								{ this.translate( 'Activate Now' ) }
+							</NoticeAction>
 						</Notice>
 					}
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -594,11 +594,11 @@ export const SeoForm = React.createClass( {
 							status="is-warning"
 							showDismiss={ false }
 							text={ this.translate(
-								'You must activate Site Verification module in Jetpack\'s dashboard for these changes to take effect.'
+								'Site Verification Services are disabled in Jetpack.'
 							) }
 						>
 							<NoticeAction href={ '//' + slug + '/wp-admin/admin.php?page=jetpack#/engagement' }>
-								{ this.translate( 'Activate Now' ) }
+								{ this.translate( 'Enable' ) }
 							</NoticeAction>
 						</Notice>
 					}


### PR DESCRIPTION
Resolves: #9297

### Testing steps:

1. Disable the Site Verification Tools module in your Jetpack Settings
2. Starting at URL: https://wordpress.com/settings/seo
3. Verify that appropriate notice is being shown above the Site Verification section when this module is inactive

![sitever](https://cloud.githubusercontent.com/assets/1182160/20376123/b4e3a5f0-ac8c-11e6-9875-854e4948b8ab.png)

