### PR TITLE
Reader: Fix more card inconsistencies

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -69,10 +69,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 		}
 
-		.reader-post-card__post {
-			margin-top: 17px;
-		}
-
 		.reader-post-card__play-icon {
 			opacity: .8;
 			transition: opacity .25s;
@@ -145,19 +141,41 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 	}
 
+	&.has-thumbnail,
+	&.is-gallery {
+
+		.reader-post-card__post {
+			margin-top: 18px;
+		}
+
+		.reader-post-card__post-details {
+
+			@media #{$reader-post-card-breakpoint-medium} {
+				margin-top: 7px;
+				width: 100%;
+			}
+
+			@media #{$reader-post-card-breakpoint-small} {
+				margin-top: 7px;
+				width: 100%;
+			}
+		}
+	}
+
 	&.is-gallery .reader-post-card__post {
 		flex-direction: column;
 	}
 
-	.reader-post-actions {
-		margin: 4px 0 0;
-	}
-
-	&.is-excerpt {
+	&.is-gallery,
+	&.is-photo {
 
 		.reader-post-card__post {
-			margin-top: 15px;
+			margin-top: 17px;
 		}
+	}
+
+	.reader-post-actions {
+		margin: 4px 0 0;
 	}
 }
 
@@ -276,16 +294,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	.reader-post-card__post-details {
 		flex: 1;
-
-		@media #{$reader-post-card-breakpoint-medium} {
-			margin-top: 7px;
-			width: 100%;
-		}
-
-		@media #{$reader-post-card-breakpoint-small} {
-			margin-top: 7px;
-			width: 100%;
-		}
 	}
 
 	@media #{$reader-post-card-breakpoint-large} {
@@ -512,6 +520,14 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .reader-post-card__video {
 	padding-bottom: 17px;
+
+	@media #{$reader-post-card-breakpoint-medium} {
+		padding-bottom: 10px;
+	}
+
+	@media #{$reader-post-card-breakpoint-small} {
+		padding-bottom: 10px;
+	}
 }
 
 .reader-post-card__video iframe {


### PR DESCRIPTION
We still found some spacing inconsistencies in cards and this PR fixes those.

However, the `.has-thumbnail` class still exists in excerpt/text-only cards so spacing issues for those won't be fixed until we land https://github.com/Automattic/wp-calypso/pull/9149 (but properties for those are already in place).

I've re-checked each and every type of card to make sure their spacing remains consistent.

## Default card:

![default-1](https://cloud.githubusercontent.com/assets/4924246/20226248/4a6e3dd2-a7fc-11e6-8bb9-2d0bb62b0eb7.jpg)
![deafult-2](https://cloud.githubusercontent.com/assets/4924246/20226249/4a6e4a5c-a7fc-11e6-9628-8879d406ce3e.jpg)
![default-3](https://cloud.githubusercontent.com/assets/4924246/20226250/4a714da6-a7fc-11e6-9320-6fda125bcd9a.jpg)

## Excerpt/text card (the `.has-thumbnail` class has to be removed from this card for its correct properties to be applied):

![excerpt-1](https://cloud.githubusercontent.com/assets/4924246/20226271/58c9a902-a7fc-11e6-9776-b1eb0906fea3.jpg)
![excerpt-2](https://cloud.githubusercontent.com/assets/4924246/20226272/58cb298a-a7fc-11e6-8b55-1643173b0eef.jpg)
![excerpt-3](https://cloud.githubusercontent.com/assets/4924246/20226273/58cc9540-a7fc-11e6-9976-0bd4a47dca21.jpg)

## Photo card:

![photo-1](https://cloud.githubusercontent.com/assets/4924246/20226294/68a7249e-a7fc-11e6-9aa9-6c811fc1da12.jpg)
![photo-2](https://cloud.githubusercontent.com/assets/4924246/20226296/68a954a8-a7fc-11e6-865b-adae37affd57.jpg)
![photo-3](https://cloud.githubusercontent.com/assets/4924246/20226295/68a9026e-a7fc-11e6-8d11-8a1ad6fe4737.jpg)

## Gallery card:

![gallery-1](https://cloud.githubusercontent.com/assets/4924246/20226303/715a3540-a7fc-11e6-889d-318e6c5fc03d.jpg)
![gallery-2](https://cloud.githubusercontent.com/assets/4924246/20226304/715b8508-a7fc-11e6-9ba3-abdfb2265ac1.jpg)
![gallery-3](https://cloud.githubusercontent.com/assets/4924246/20226305/715d7732-a7fc-11e6-98ab-d419ac8285b6.jpg)

## Video card:

![video-1](https://cloud.githubusercontent.com/assets/4924246/20226314/7bb78ae2-a7fc-11e6-8df9-f3ba8325a3c5.jpg)
![video-2](https://cloud.githubusercontent.com/assets/4924246/20226316/7bb7b198-a7fc-11e6-9bd8-8bfdf711e8d0.jpg)
![video-3](https://cloud.githubusercontent.com/assets/4924246/20226315/7bb7938e-a7fc-11e6-8e95-724076123505.jpg)

## Video card (playing):

![videop-1](https://cloud.githubusercontent.com/assets/4924246/20226330/85ca8bc4-a7fc-11e6-94a0-1295b6de40a8.jpg)
![videop-2](https://cloud.githubusercontent.com/assets/4924246/20226331/85cb3164-a7fc-11e6-9893-661ac59b86eb.jpg)
![videop-3](https://cloud.githubusercontent.com/assets/4924246/20226332/85ccc5ce-a7fc-11e6-8869-434ab61fa112.jpg)

/cc @fraying 

Related: https://github.com/Automattic/wp-calypso/pull/9163

