### PR TITLE
Site Settings: Show media modal when clicking Change Site Icon

### DIFF
--- a/client/components/async-load/README.md
+++ b/client/components/async-load/README.md
@@ -14,3 +14,25 @@ Pass with a `require` string for the module path to be loaded:
 Depending on the environment configuration, this will be transformed automatically into either a `require` or `require.ensure` call.
 
 See [`babel-plugin-transform-wpcalypso-async` documentation](https://github.com/Automattic/babel-plugin-transform-wpcalypso-async) for more information.
+
+## Props
+
+The following props can be passed to the AsyncLoad component:
+
+### `require`
+
+<table>
+	<tr><td>Type</td><td>String (Function)</td></tr>
+	<tr><td>Required</td><td>Yes</td></tr>
+</table>
+
+In general usage, this should be passed as a string of the module to be imported. During build, the string prop is [transformed to a function](https://github.com/Automattic/wp-calypso/tree/master/server/bundler/babel/babel-plugin-transform-wpcalypso-async) which is called to require the specified module.
+
+### `placeholder`
+
+<table>
+	<tr><td>Type</td><td>PropTypes.node</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown.

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -10,6 +10,9 @@ import { localize } from 'i18n-calypso';
  */
 import SiteIcon from 'components/site-icon';
 import Button from 'components/button';
+import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
+import AsyncLoad from 'components/async-load';
+import Dialog from 'components/dialog';
 import { isJetpackSite, getCustomizerUrl, getSiteAdminUrl } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isEnabled } from 'config';
@@ -18,54 +21,99 @@ import FormLabel from 'components/forms/form-label';
 import InfoPopover from 'components/info-popover';
 import { addQueryArgs } from 'lib/url';
 
-function SiteIconSetting( { translate, siteId, isJetpack, customizerUrl, generalOptionsUrl } ) {
-	let buttonProps;
-	if ( isEnabled( 'manage/site-settings/site-icon' ) ) {
-		buttonProps = {
-			type: 'button'
-		};
-	} else {
-		buttonProps = { rel: 'external' };
+class SiteIconSetting extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		siteId: PropTypes.number,
+		isJetpack: PropTypes.bool,
+		customizerUrl: PropTypes.string,
+		generalOptionsUrl: PropTypes.string
+	};
 
-		if ( isJetpack ) {
-			buttonProps.href = addQueryArgs( {
-				'autofocus[section]': 'title_tagline'
-			}, customizerUrl );
-		} else {
-			buttonProps.href = generalOptionsUrl;
-			buttonProps.target = '_blank';
-		}
+	state = {
+		isModalVisible: false
+	};
+
+	toggleModal = ( isModalVisible ) => this.setState( { isModalVisible } );
+
+	hideModal = () => this.toggleModal( false );
+
+	showModal = () => this.toggleModal( true );
+
+	setSiteIcon = ( media ) => {
+		// [TODO]: Handle setting site icon
+		console.log( media ); // eslint-disable-line no-console
+
+		this.hideModal();
+	};
+
+	preloadModal() {
+		asyncRequire( 'post-editor/media-modal' );
 	}
 
-	return (
-		<FormFieldset className="site-icon-setting">
-			<FormLabel className="site-icon-setting__heading">
-				{ translate( 'Site Icon' ) }
-				<InfoPopover position="bottom right">
-					{ translate( 'A browser and app icon for your site.' ) }
-				</InfoPopover>
-			</FormLabel>
-			{ React.createElement( buttonProps.href ? 'a' : 'button', {
-				...buttonProps,
-				className: 'site-icon-setting__icon'
-			}, <SiteIcon size={ 96 } siteId={ siteId } /> ) }
-			<Button
-				{ ...buttonProps }
-				className="site-icon-setting__change-button"
-				compact>
-				{ translate( 'Change', { context: 'verb' } ) }
-			</Button>
-		</FormFieldset>
-	);
-}
+	render() {
+		const { translate, siteId, isJetpack, customizerUrl, generalOptionsUrl } = this.props;
+		const { isModalVisible } = this.state;
+		const isIconManagementEnabled = isEnabled( 'manage/site-settings/site-icon' );
 
-SiteIconSetting.propTypes = {
-	translate: PropTypes.func,
-	siteId: PropTypes.number,
-	isJetpack: PropTypes.bool,
-	customizerUrl: PropTypes.string,
-	generalOptionsUrl: PropTypes.string
-};
+		let buttonProps;
+		if ( isIconManagementEnabled ) {
+			buttonProps = {
+				type: 'button',
+				onClick: this.showModal,
+				onMouseEnter: this.preloadModal
+			};
+		} else {
+			buttonProps = { rel: 'external' };
+
+			if ( isJetpack ) {
+				buttonProps.href = addQueryArgs( {
+					'autofocus[section]': 'title_tagline'
+				}, customizerUrl );
+			} else {
+				buttonProps.href = generalOptionsUrl;
+				buttonProps.target = '_blank';
+			}
+		}
+
+		return (
+			<FormFieldset className="site-icon-setting">
+				<FormLabel className="site-icon-setting__heading">
+					{ translate( 'Site Icon' ) }
+					<InfoPopover position="bottom right">
+						{ translate( 'A browser and app icon for your site.' ) }
+					</InfoPopover>
+				</FormLabel>
+				{ React.createElement( buttonProps.href ? 'a' : 'button', {
+					...buttonProps,
+					className: 'site-icon-setting__icon'
+				}, <SiteIcon size={ 96 } siteId={ siteId } /> ) }
+				<Button
+					{ ...buttonProps }
+					className="site-icon-setting__change-button"
+					compact>
+					{ translate( 'Change', { context: 'verb' } ) }
+				</Button>
+				{ isIconManagementEnabled && isModalVisible && (
+					<MediaLibrarySelectedData siteId={ siteId }>
+						<AsyncLoad
+							require="post-editor/media-modal"
+							placeholder={ (
+								<Dialog
+									additionalClassNames="editor-media-modal"
+									isVisible />
+							) }
+							siteId={ siteId }
+							onClose={ this.setSiteIcon }
+							enabledFilters={ [ 'images' ] }
+							visible
+							single />
+					</MediaLibrarySelectedData>
+				) }
+			</FormFieldset>
+		);
+	}
+}
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );

--- a/client/my-sites/site-settings/site-icon-setting/style.scss
+++ b/client/my-sites/site-settings/site-icon-setting/style.scss
@@ -11,6 +11,10 @@
 	}
 }
 
+.site-icon-setting__icon {
+	cursor: pointer;
+}
+
 .site-icon-setting__icon:hover .site-icon {
 	border-style: dashed;
 	border-color: $gray-dark;

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -22,6 +22,7 @@ var MediaLibrary = require( 'my-sites/media-library' ),
 	markup = require( './markup' ),
 	accept = require( 'lib/accept' );
 import { getMediaModalView } from 'state/ui/media-modal/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { resetMediaModalView } from 'state/ui/media-modal/actions';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
@@ -35,6 +36,7 @@ export const EditorMediaModal = React.createClass( {
 		onClose: React.PropTypes.func,
 		onInsertMedia: React.PropTypes.func,
 		site: React.PropTypes.object,
+		siteId: React.PropTypes.number,
 		labels: React.PropTypes.object,
 		single: React.PropTypes.bool,
 		defaultFilter: React.PropTypes.string,
@@ -463,8 +465,11 @@ export const EditorMediaModal = React.createClass( {
 } );
 
 export default connect(
-	( state ) => ( {
-		view: getMediaModalView( state )
+	( state, { site, siteId } ) => ( {
+		view: getMediaModalView( state ),
+		// [TODO]: Migrate toward dropping incoming site prop, accepting only
+		// siteId and forcing descendant components to access via state
+		site: site || getSelectedSite( state, siteId )
 	} ),
 	{
 		setView: setEditorMediaModalView,


### PR DESCRIPTION
This pull request seeks to implement a new media modal wrapper to handle the assignment of a media item as site icon on the Site Settings screen if enabled for the current environment (development only).

![site-icon](https://cloud.githubusercontent.com/assets/1779930/20227780/ebffe6ea-a81b-11e6-9ccf-20ab4b7b3bba.gif)

__Implementation notes:__

These changes make use of `<AsyncLoad />` to avoid unnecessarily loading much of the media modal and library logic for environments where the site icon management feature is disabled. In the future we may consider enhancing this to be even smarter about loading the modal asynchronously only on intent to change site icon (e.g. button hover). The `<AsyncLoad />` was applied to the media modal component and not the site-icon-specific media modal in anticipation of reusing this same async-load bundle within the editor.

By default, `<AsyncLoad />` renders a styled placeholder which was not ideal in the context of rendering the non-visible modal, so included in these changes is an option for disabling the default placeholder by passing an explicit `placeholder={ null }` prop to the `<AsyncLoad />` component. cc @mtias 

__Testing instructions:__

The current implementation only includes toggling of the modal and logging the selected item to console after choosing an item. It does not include image resizing, proper labels for confirming a choice, or updating the site icon after a selection has been made.

Verify that the behavior of "Change site icon" behaves as expected depending on the current environment. You can change this setting either by starting Calypso with `DISABLE_FEATURES=manage/site-settings/site-icon` or by modifying the value in the generated `client/config/index.js` while running Calypso.

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Click "Change site icon"
4. Note that...
 - If site icon feature is enabled, a modal is shown
 - If site icon feature is disabled, you are redirected to the appropriate wp-admin customization screen
5. If site icon feature is enabled, proceed to select an confirm an image
6. Note in your developer tools console that a log message is printed with your selection