### PR TITLE
Sites: Remove edit toggle options from Site block

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -42,7 +42,7 @@
 	display: flex;
 	justify-content: space-between;
 	overflow: hidden;
-	padding: 16px 4px 16px 16px;
+	padding: 16px;
 	position: relative;
 	width: 100%;
 
@@ -127,90 +127,6 @@
 
 .site__content:hover .site__home {
 	opacity: 1;
-}
-
-.site__toggle-more-options {
-	color: $gray;
-	cursor: pointer;
-	padding-right: 16px;
-	line-height: 0;
-	.gridicon {
-		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-	}
-	&:hover {
-		.gridicon {
-			color: darken( $gray, 20% );
-		}
-	}
-}
-
-.site.is-toggled {
-	.site__toggle-more-options .gridicon {
-		transform: rotate( 90deg );
-	}
-	.site-indicator {
-		display: none;
-	}
-}
-
-.site.is-toggled.has-edit-capabilities {
-	.site-icon {
-		border: 1px dashed $gray-dark;
-		opacity: 0.8;
-	}
-}
-
-.site__actions {
-	align-items: center;
-	display: flex;
-	flex: 1 0 0;
-	justify-content: flex-end;
-	animation: appear .3s ease-in-out;
-}
-
-.site__edit-icon-text {
-	animation: appear .3s ease-in-out;
-	font-size: 10px;
-	max-width: 60px;
-}
-
-.site__edit-icon,
-.site__edit-icon:visited {
-	color: darken( $gray, 10% );
-	font-weight: 600;
-	font-size: 11px;
-	text-transform: uppercase;
-	display: flex;
-	align-items: center;
-	&:hover {
-		color: $blue-medium;
-	}
-	.gridicons-external {
-		top: -1px;
-	}
-}
-
-.site__star {
-	color: $gray;
-	cursor: pointer;
-	line-height: 0;
-
-	&:hover .gridicons-star-outline {
-		color: $alert-yellow;
-	}
-
-	.gridicons-star {
-		color: $alert-yellow;
-	}
-}
-
-a.site__cog {
-	color: $gray;
-	line-height: 0;
-
-	&:hover {
-		color: darken( $gray, 20% );
-	}
 }
 
 .site__badge {

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -74,9 +74,6 @@ const CurrentSite = React.createClass( {
 		event.preventDefault();
 		event.stopPropagation();
 		this.props.setLayoutFocus( 'sites' );
-		if ( this.refs.site ) {
-			this.refs.site.closeActions();
-		}
 
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked Switch Site' );
 	},
@@ -156,12 +153,10 @@ const CurrentSite = React.createClass( {
 					? <Site
 						site={ site }
 						homeLink={ true }
-						enableActions={ true }
 						externalLink={ true }
 						onClick={ this.previewSite }
 						onSelect={ this.previewSite }
-						tipTarget="site-card-preview"
-						ref="site" />
+						tipTarget="site-card-preview" />
 					: <AllSites sites={ this.props.sites.get() } />
 				}
 				{ ! site.jetpack && this.getDomainWarnings() }


### PR DESCRIPTION
Related: #7616
Related: #8924

This pull request seeks to remove the toggle action from the `<Site />` block, currently visible in My Sites sections. As of #8924, managing Site Icon is now available in all environments from the settings screen. The changes here are an implementation of the consensus received from the suggestion at https://github.com/Automattic/wp-calypso/pull/7616#issuecomment-242500515 . Previously, the toggled actions included a link to edit site icon and a link to site settings.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/20228279/8edc5d10-a81e-11e6-8bbb-3cc0aa01d0e8.png)|![After](https://cloud.githubusercontent.com/assets/1779930/20228278/8ed87560-a81e-11e6-877b-42ab7c880509.png)

__Testing Instructions:__

Verify that the `<Site />` component at the top of the [My Sites](http://calypso.localhost:3000/stats) sidebar behaves as a preview toggle only, without option for toggling additional actions. In particular, verify that the preview works as expected for varying site types (Jetpack, private, etc).