### PR TITLE
Taxonomy Management: Load taxonomies and show indicator in TaxonomyCard.

### DIFF
--- a/client/components/data/query-taxonomies/index.jsx
+++ b/client/components/data/query-taxonomies/index.jsx
@@ -25,7 +25,7 @@ class QueryTaxonomies extends Component {
 	}
 
 	request( props ) {
-		if ( props.requesting ) {
+		if ( props.requesting || ! props.siteId ) {
 			return;
 		}
 
@@ -42,7 +42,7 @@ class QueryTaxonomies extends Component {
 }
 
 QueryTaxonomies.propTypes = {
-	siteId: PropTypes.number.isRequired,
+	siteId: PropTypes.number,
 	postType: PropTypes.string.isRequired,
 	requesting: PropTypes.bool.isRequired,
 	requestPostTypeTaxonomies: PropTypes.func.isRequired

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -21,6 +21,7 @@ import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
 import QueryTerms from 'components/data/query-terms';
+import QueryTaxonomies from 'components/data/query-taxonomies';
 import TaxonomyCard from './taxonomies/taxonomy-card';
 import { isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -123,6 +124,7 @@ const SiteSettingsFormWriting = React.createClass( {
 			<form id="site-settings" onSubmit={ this.submitFormAndActivateCustomContentModule } onChange={ this.markChanged }>
 				{ config.isEnabled( 'manage/site-settings/categories' ) &&
 					<div className="site-settings__taxonomies">
+						<QueryTaxonomies siteId={ this.props.siteId } postType="post" />
 						<TaxonomyCard taxonomy="category" postType="post" />
 						<TaxonomyCard taxonomy="post_tag" postType="post" />
 					</div>

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -2,4 +2,10 @@
 	font-size: 16px;
 	line-height: 24px;
 	color: $gray-dark;
+
+	&.is-loading {
+		@include placeholder;
+		width: 80px;
+		display: inline-block;
+	}
 }

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -14,10 +15,14 @@ import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import CompactCard from 'components/card/compact';
 
 const TaxonomyCard = ( { labels, site, taxonomy } ) => {
-	const settingsLink = `/settings/taxonomies/${ site.slug }/${ taxonomy }`;
+	const settingsLink = site ? `/settings/taxonomies/${ site.slug }/${ taxonomy }` : null;
+	const classes = classNames( 'taxonomies__card-title', {
+		'is-loading': ! labels.name
+	} );
+
 	return (
 		<CompactCard href={ settingsLink }>
-				<h2 className="taxonomies__card-title">{ labels.name }</h2>
+				<h2 className={ classes }>{ labels.name }</h2>
 		</CompactCard>
 	);
 };


### PR DESCRIPTION
While testing #9292 I noticed that the `<TaxonomyCard />`s on the Settings>Writing page had no labels on an un-primed state:

![site_settings_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/20229099/7daa34aa-a809-11e6-9134-a31f16f56e0d.png)

In this branch, I've added a `<QueryTaxonomies />` call to the Settings page to ensure the Taxonomies will be available in the state tree.  I also added an `is-loading` class to show a placeholder when the taxonomies haven't been loaded into the state tree yet:

![loading-taxons](https://cloud.githubusercontent.com/assets/22080/20229145/ac91c382-a809-11e6-9810-6b18df5e1f7a.gif)

__To Test__
- Clear out the local state tree
- Load a settings>writing page
- Note the loading placeholder is shown while the taxonomies are still loading

/cc @youknowriad 