### PR TITLE
Reader: Use three-line clamped excerpts

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -127,7 +127,7 @@ export default class RefreshPostCard extends React.Component {
 						<h1 className="reader-post-card__title">
 							<a className="reader-post-card__title-link" href={ post.URL }>{ title }</a>
 						</h1>
-						{ showExcerpt && <div className="reader-post-card__excerpt">{ post.short_excerpt }</div> }
+						{ showExcerpt && <div className="reader-post-card__excerpt">{ post.better_excerpt_no_html }</div> }
 						{ post &&
 							<ReaderPostActions
 								post={ originalPost ? originalPost : post }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -317,6 +317,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	overflow: hidden;
 	max-height: 15px * 1.6 * 3;
 	position: relative;
+
 	&::before {
 		@include long-content-fade( $size: 15px * 1.6 * 5 );
 		top: inherit;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -314,6 +314,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	font-weight: 100;
 	margin-top: 9px;
 	word-break: break-word;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	-webkit-line-clamp: 3;
+	max-height: 15px * 1.6 * 3;
 }
 
 // Action buttons in post card

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -314,11 +314,14 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	font-weight: 100;
 	margin-top: 9px;
 	word-break: break-word;
-	display: -webkit-box;
-	-webkit-box-orient: vertical;
 	overflow: hidden;
-	-webkit-line-clamp: 3;
 	max-height: 15px * 1.6 * 3;
+	position: relative;
+	&::before {
+		@include long-content-fade( $size: 15px * 1.6 * 5 );
+		top: inherit;
+		height: 15px * 1.6;
+	}
 }
 
 // Action buttons in post card


### PR DESCRIPTION
Use the three-line clamped excerpts like the old post-excerpt component. This will have an ellipsis when cut off on webkit / blink browsers, and just truncate on everything else.