### PR TITLE
Reader Refresh: Fix for undefined error occuring inside of hasShortContent

### DIFF
--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -64,10 +64,18 @@ function discoverFullBleedImages( post, dom ) {
 }
 
 function getWordCount( post ) {
+	if ( ! post || ! post.better_excerpt_no_html ) {
+		return 0;
+	}
+
 	return ( post.better_excerpt_no_html.replace( /['";:,.?¿\-!¡]+/g, '' ).match( /\S+/g ) || [] ).length;
 }
 
 function getCharacterCount( post ) {
+	if ( ! post || ! post.better_excerpt_no_html ) {
+		return 0;
+	}
+
 	return post.better_excerpt_no_html.length;
 }
 


### PR DESCRIPTION
thank you @aaronyan for finding this bug!
This is currently when specific posts cross people's following page.

<img width="822" alt="wordpress_follow_stream_error" src="https://cloud.githubusercontent.com/assets/4656974/20231863/8258c024-a819-11e6-82f5-c12f6425d291.png">
