### PR TITLE
state/themes: Remove THEME_ACTIVATE_REQUEST_SUCCESS listeners from all reducers but current-theme

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -136,7 +136,6 @@ export function receiveThemeDetails( theme ) {
 		themeTaxonomies: theme.taxonomies,
 		themeStylesheet: theme.stylesheet,
 		themeDemoUri: theme.demo_uri,
-		themeActive: theme.active,
 		themePurchased: theme.purchased,
 	};
 }

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -135,8 +135,7 @@ export function receiveThemeDetails( theme ) {
 		themeDownload: theme.download_uri || undefined,
 		themeTaxonomies: theme.taxonomies,
 		themeStylesheet: theme.stylesheet,
-		themeDemoUri: theme.demo_uri,
-		themePurchased: theme.purchased,
+		themeDemoUri: theme.demo_uri
 	};
 }
 

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -34,7 +34,6 @@ export default ( state = Map(), action ) => {
 					taxonomies: action.themeTaxonomies,
 					stylesheet: action.themeStylesheet,
 					demo_uri: action.themeDemoUri,
-					active: action.themeActive,
 					purchased: action.themePurchased,
 					isRequesting: false
 				} ) );

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -34,7 +34,6 @@ export default ( state = Map(), action ) => {
 					taxonomies: action.themeTaxonomies,
 					stylesheet: action.themeStylesheet,
 					demo_uri: action.themeDemoUri,
-					purchased: action.themePurchased,
 					isRequesting: false
 				} ) );
 		case THEME_DETAILS_RECEIVE_FAILURE:

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -10,12 +10,10 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 	SERVER_DESERIALIZE,
-	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEME_DETAILS_RECEIVE,
 	THEME_DETAILS_RECEIVE_FAILURE,
 	THEME_DETAILS_REQUEST,
 } from 'state/action-types';
-import { setActiveTheme } from '../themes/reducer';
 
 export default ( state = Map(), action ) => {
 	switch ( action.type ) {
@@ -42,8 +40,6 @@ export default ( state = Map(), action ) => {
 				} ) );
 		case THEME_DETAILS_RECEIVE_FAILURE:
 			return state.set( action.themeId, Map( { error: action.error } ) );
-		case THEME_ACTIVATE_REQUEST_SUCCESS:
-			return state.update( setActiveTheme.bind( null, action.theme.id ) );
 		case DESERIALIZE:
 			return Map();
 		case SERVER_DESERIALIZE:

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -52,7 +52,6 @@ describe( 'reducer', () => {
 					filter: 'raw'
 				} ]
 			},
-			themeActive: false,
 			themePurchased: false
 		} );
 
@@ -82,7 +81,6 @@ describe( 'reducer', () => {
 					filter: 'raw'
 				} ]
 			},
-			active: false,
 			purchased: false,
 			isRequesting: false,
 		} );

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -51,8 +51,7 @@ describe( 'reducer', () => {
 					count: 0,
 					filter: 'raw'
 				} ]
-			},
-			themePurchased: false
+			}
 		} );
 
 		expect( state.get( 'mood' ).toJS() ).to.eql( {
@@ -81,7 +80,6 @@ describe( 'reducer', () => {
 					filter: 'raw'
 				} ]
 			},
-			purchased: false,
 			isRequesting: false,
 		} );
 	} );

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -11,7 +11,6 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 	SERVER_DESERIALIZE,
-	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEME_DETAILS_RECEIVE
 } from 'state/action-types';
 import reducer from '../reducer';
@@ -87,55 +86,6 @@ describe( 'reducer', () => {
 			purchased: false,
 			isRequesting: false,
 		} );
-	} );
-
-	// Copied from state/themes/themes/test/reducer
-	it( 'should set the `active` field to true for the given ID on theme activation', () => {
-		const twentyfifteen = Map( {
-			name: 'Twenty Fifteen',
-			author: 'the WordPress team',
-			screenshot: 'https://i1.wp.com/theme.wordpress.com/wp-content/themes/pub/twentyfifteen/screenshot.png',
-			description: 'Our 2015 default theme is clean, blog-focused, and designed for clarity. ...',
-			descriptionLong: '<p>Something something</p>',
-			download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentyfifteen.zip',
-			taxonomies: {},
-			stylesheet: 'pub/twentyfifteen',
-			demo_uri: 'https://twentyfifteendemo.wordpress.com/',
-			active: true
-		} );
-		const twentysixteen = Map( {
-			name: 'Twenty Sixteen',
-			author: 'the WordPress team',
-			screenshot: 'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
-			description: 'Twenty Sixteen is a modernized take on an ever-popular WordPress layout — ...',
-			descriptionLong: '<p>Mumble Mumble</p>',
-			download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentysixteen.zip',
-			taxonomies: {},
-			stylesheet: 'pub/twentysixteen',
-			demo_uri: 'https://twentysixteendemo.wordpress.com/'
-		} );
-		const initialState = Map( { twentyfifteen, twentysixteen } );
-
-		const state = reducer( initialState, {
-			type: THEME_ACTIVATE_REQUEST_SUCCESS,
-			theme: {
-				author: 'the WordPress team',
-				author_uri: 'https://wordpress.org/',
-				demo_uri: 'https://twentysixteendemo.wordpress.com/',
-				id: 'twentysixteen',
-				name: 'Twenty Sixteen',
-				screenshot: 'https://i0.wp.com'
-			},
-			site: {
-				ID: 2916284,
-				name: 'Testy McTestsite',
-				description: 'Nothing to see here. Move on.',
-				URL: 'https://example.wordpress.com'
-			}
-		} );
-
-		expect( state.get( 'twentysixteen' ).get( 'active' ) ).to.be.true;
-		expect( state.get( 'twentyfifteen' ).get( 'active' ) ).to.be.not.true;
 	} );
 
 	describe( 'persistence', () => {

--- a/client/state/themes/themes-list/reducer.js
+++ b/client/state/themes/themes-list/reducer.js
@@ -34,8 +34,7 @@ export const initialState = query( fromJS( {
 	list: [],
 	nextId: 0,
 	query: {},
-	queryState: {},
-	active: 0
+	queryState: {}
 } ) );
 
 /**

--- a/client/state/themes/themes-list/reducer.js
+++ b/client/state/themes/themes-list/reducer.js
@@ -3,7 +3,7 @@
  */
 import { fromJS } from 'immutable';
 import map from 'lodash/map';
-import uniq from 'lodash/uniq'
+import uniq from 'lodash/uniq';
 /**
  * Internal dependencies
  */
@@ -12,7 +12,6 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 	SERVER_DESERIALIZE,
-	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEME_ACTIVATE_REQUEST_FAILURE,
 	THEMES_INCREMENT_PAGE,
 	THEMES_QUERY,
@@ -96,12 +95,6 @@ export default ( state = initialState, action ) => {
 				.setIn( [ 'queryState', 'isLastPage' ], true )
 				.setIn( [ 'queryState', 'error' ], true );
 
-		case THEME_ACTIVATE_REQUEST_SUCCESS:
-			// The `active` attribute isn't ever really read, but since
-			// `createReducerStore()` only emits a `change` event when the new
-			// state is different from the old one, we need something to change
-			// here.
-			return state.set( 'active', action.theme.id );
 		case DESERIALIZE:
 			return initialState;
 		case SERVER_DESERIALIZE:

--- a/client/state/themes/themes-list/test/reducer.js
+++ b/client/state/themes/themes-list/test/reducer.js
@@ -31,8 +31,7 @@ describe( 'themes-list reducer', () => {
 				queryState: {
 					isLastPage: true,
 					isFetchingNextPage: false
-				},
-				active: 0
+				}
 			} );
 			const state = fromJS( jsObject );
 			const persistedState = reducer( state, { type: SERIALIZE } );
@@ -52,8 +51,7 @@ describe( 'themes-list reducer', () => {
 				queryState: {
 					isLastPage: true,
 					isFetchingNextPage: false
-				},
-				active: 0
+				}
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
 			expect( state ).to.eql( initialState );
@@ -73,8 +71,7 @@ describe( 'themes-list reducer', () => {
 				queryState: {
 					isLastPage: true,
 					isFetchingNextPage: false
-				},
-				active: 0
+				}
 			} );
 			const state = reducer( jsObject, { type: SERVER_DESERIALIZE } );
 			expect( state ).to.eql( query( fromJS( jsObject ) ) );

--- a/client/state/themes/themes/reducer.js
+++ b/client/state/themes/themes/reducer.js
@@ -25,12 +25,6 @@ function add( newThemes, themes ) {
 	}, {} ) );
 }
 
-export function setActiveTheme( themeId, themes ) {
-	return themes
-		.map( theme => theme.delete( 'active' ) )
-		.setIn( [ themeId, 'active' ], true );
-}
-
 export default ( state = initialState, action ) => {
 	switch ( action.type ) {
 		case THEMES_RECEIVE: {

--- a/client/state/themes/themes/reducer.js
+++ b/client/state/themes/themes/reducer.js
@@ -11,7 +11,6 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 	SERVER_DESERIALIZE,
-	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEMES_RECEIVE
 } from 'state/action-types';
 
@@ -43,11 +42,9 @@ export default ( state = initialState, action ) => {
 			return state.withMutations( ( temporaryState ) => {
 				temporaryState
 					.set( 'themes', mergedThemes )
-					.set( 'currentSiteId', action.siteId )
+					.set( 'currentSiteId', action.siteId );
 			} );
 		}
-		case THEME_ACTIVATE_REQUEST_SUCCESS:
-			return state.update( 'themes', setActiveTheme.bind( null, action.theme.id ) );
 		case DESERIALIZE:
 			return initialState;
 		case SERVER_DESERIALIZE:

--- a/client/state/themes/themes/test/index.js
+++ b/client/state/themes/themes/test/index.js
@@ -8,7 +8,7 @@ describe( 'themes', () => {
 	const actionReceiveThemes = {
 		type: THEMES_RECEIVE,
 		themes: [
-			{ id: 'bold-news', active: true },
+			{ id: 'bold-news' },
 			{ id: 'picard' }
 		]
 	};

--- a/client/state/themes/themes/test/index.js
+++ b/client/state/themes/themes/test/index.js
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { createStore } from 'redux';
 
-import { THEME_ACTIVATE_REQUEST_SUCCESS, THEMES_RECEIVE } from 'state/action-types';
+import { THEMES_RECEIVE } from 'state/action-types';
 import reducer from '../reducer';
 
 describe( 'themes', () => {
@@ -19,17 +19,8 @@ describe( 'themes', () => {
 			{ id: 'hue' }
 		]
 	};
-	const actionThemeActivated = {
-		type: THEME_ACTIVATE_REQUEST_SUCCESS,
-		theme: { id: 'picard' }
-	};
 
 	let store;
-
-	function getThemeById( id ) {
-		const theme = store.getState().getIn( [ 'themes', id ] );
-		return theme ? theme.toJS() : undefined;
-	}
 
 	beforeEach( () => {
 		store = createStore( reducer );
@@ -55,19 +46,6 @@ describe( 'themes', () => {
 			store.dispatch( actionReceiveMoreThemes );
 			const themes = store.getState().get( 'themes' );
 			assert( themes.size === 3, 'duplicates found' );
-		} );
-	} );
-
-	context( 'when THEME_ACTIVATE_REQUEST_SUCCESS is received', () => {
-		beforeEach( () => {
-			store.dispatch( actionReceiveThemes );
-		} );
-
-		it( 'clears previous active flag', () => {
-			assert.ok( getThemeById( 'bold-news' ).active, 'initial theme not active' );
-			store.dispatch( actionThemeActivated );
-			assert.notOk( getThemeById( 'bold-news' ).active, 'initial theme still active' );
-			assert.ok( getThemeById( 'picard' ).active, 'new theme not active' );
 		} );
 	} );
 } );

--- a/client/state/themes/themes/test/reducer.js
+++ b/client/state/themes/themes/test/reducer.js
@@ -24,7 +24,6 @@ describe( 'themes reducer', () => {
 				currentSiteId: 12345678,
 				themes: {
 					activetest: {
-						active: true,
 						id: 'activetest',
 						author: 'activetest author',
 						screenshot: 'http://example.com',
@@ -54,7 +53,6 @@ describe( 'themes reducer', () => {
 				currentSiteId: 12345678,
 				themes: {
 					activetest: {
-						active: true,
 						id: 'activetest',
 						author: 'activetest author',
 						screenshot: 'http://example.com',
@@ -84,7 +82,6 @@ describe( 'themes reducer', () => {
 				currentSiteId: 12345678,
 				themes: {
 					activetest: {
-						active: true,
 						id: 'activetest',
 						author: 'activetest author',
 						screenshot: 'http://example.com',

--- a/client/state/themes/themes/test/reducer.js
+++ b/client/state/themes/themes/test/reducer.js
@@ -13,61 +13,11 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 	SERVER_DESERIALIZE,
-	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEMES_RECEIVE,
 } from 'state/action-types';
 import reducer, { initialState } from '../reducer';
 
 describe( 'themes reducer', () => {
-	describe( 'theme activation', () => {
-		it( 'should set the `active` field to true for the given ID on theme activation', () => {
-			const twentyfifteen = Map( {
-				name: 'Twenty Fifteen',
-				author: 'the WordPress team',
-				screenshot: 'https://i1.wp.com/theme.wordpress.com/wp-content/themes/pub/twentyfifteen/screenshot.png',
-				description: 'Our 2015 default theme is clean, blog-focused, and designed for clarity. ...',
-				descriptionLong: '<p>Something something</p>',
-				download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentyfifteen.zip',
-				taxonomies: {},
-				stylesheet: 'pub/twentyfifteen',
-				demo_uri: 'https://twentyfifteendemo.wordpress.com/',
-				active: true
-			} );
-			const twentysixteen = Map( {
-				name: 'Twenty Sixteen',
-				author: 'the WordPress team',
-				screenshot: 'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
-				description: 'Twenty Sixteen is a modernized take on an ever-popular WordPress layout — ...',
-				descriptionLong: '<p>Mumble Mumble</p>',
-				download: 'https://public-api.wordpress.com/rest/v1/themes/download/twentysixteen.zip',
-				taxonomies: {},
-				stylesheet: 'pub/twentysixteen',
-				demo_uri: 'https://twentysixteendemo.wordpress.com/'
-			} );
-
-			const state = reducer( Map( { themes: Map( { twentyfifteen, twentysixteen } ) } ), {
-				type: THEME_ACTIVATE_REQUEST_SUCCESS,
-				theme: {
-					author: 'the WordPress team',
-					author_uri: 'https://wordpress.org/',
-					demo_uri: 'https://twentysixteendemo.wordpress.com/',
-					id: 'twentysixteen',
-					name: 'Twenty Sixteen',
-					screenshot: 'https://i0.wp.com'
-				},
-				site: {
-					ID: 2916284,
-					name: 'Testy McTestsite',
-					description: 'Nothing to see here. Move on.',
-					URL: 'https://example.wordpress.com'
-				}
-			} );
-
-			expect( state.getIn( [ 'themes', 'twentysixteen' ] ).get( 'active' ) ).to.be.true;
-			expect( state.getIn( [ 'themes', 'twentyfifteen' ] ).get( 'active' ) ).to.be.not.true;
-		} );
-	} );
-
 	describe( 'persistence', () => {
 		it( 'does not persist state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {


### PR DESCRIPTION
We no longer rely on the theme.active attr to determine is a theme is active but on the isActiveTheme() selector from `state/themes/current-theme`.
Hence, we can remove the listeners that redundantly set that attr from all other reducers. Likewise, we don't need to update any `purchased` attrs anymore.

(This is mostly to get rid of some confusion that might arise during the remainder of the Redux subtree re-arch.)

To test -- verify that the theme showcase still works, with special focus on theme activation and purchase.