### PR TITLE
Use siteId in connectOptions

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -505,7 +505,7 @@ const ThemeSheetWithOptions = ( props ) => {
 
 	return (
 		<ConnectedThemeSheet { ...props }
-			site={ site }
+			siteId={ site.ID }
 			theme={ props /* TODO: Have connectOptions() only use theme ID */ }
 			options={ [
 				'signup',

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -438,8 +438,8 @@ const ThemeSheet = React.createClass( {
 					meta={ metas }
 					link={ links } />
 				<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
-					{ this.renderBar() }
-					{ siteID && <QueryCurrentTheme siteId={ siteID } /> }
+				{ this.renderBar() }
+				{ siteID && <QueryCurrentTheme siteId={ siteID } /> }
 				<ThanksModal
 					site={ this.props.selectedSite }
 					source={ 'details' } />
@@ -490,6 +490,7 @@ const ConnectedThemeSheet = connectOptions(
 
 const ThemeSheetWithOptions = ( props ) => {
 	const { selectedSite: site, isActive, price, isLoggedIn } = props;
+	const siteId = site ? site.ID : null;
 
 	let defaultOption;
 
@@ -505,7 +506,7 @@ const ThemeSheetWithOptions = ( props ) => {
 
 	return (
 		<ConnectedThemeSheet { ...props }
-			siteId={ site.ID }
+			siteId={ siteId }
 			theme={ props /* TODO: Have connectOptions() only use theme ID */ }
 			options={ [
 				'signup',

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -445,8 +445,8 @@ const ThemeSheet = React.createClass( {
 					source={ 'details' } />
 				{ this.state.showPreview && this.renderPreview() }
 				<HeaderCake className="theme__sheet-action-bar"
-							backHref={ this.props.backPath }
-							backText={ i18n.translate( 'All Themes' ) }>
+					backHref={ this.props.backPath }
+					backText={ i18n.translate( 'All Themes' ) }>
 					{ this.renderButton() }
 				</HeaderCake>
 				<div className="theme__sheet-columns">

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -28,10 +28,7 @@ const CurrentTheme = React.createClass( {
 			icon: PropTypes.string.isRequired,
 			getUrl: PropTypes.func.isRequired
 		} ) ),
-		site: PropTypes.oneOfType( [
-			PropTypes.object,
-			PropTypes.bool
-		] ).isRequired,
+		siteID: PropTypes.number.isRequired,
 		// connected props
 		currentTheme: PropTypes.object
 	},
@@ -39,7 +36,7 @@ const CurrentTheme = React.createClass( {
 	trackClick: trackClick.bind( null, 'current theme' ),
 
 	render() {
-		const { currentTheme, site } = this.props,
+		const { currentTheme, siteId } = this.props,
 			placeholderText = <span className="current-theme__placeholder">loading...</span>,
 			text = ( currentTheme && currentTheme.name ) ? currentTheme.name : placeholderText;
 
@@ -49,7 +46,7 @@ const CurrentTheme = React.createClass( {
 
 		return (
 			<Card className="current-theme">
-				{ site && <QueryCurrentTheme siteId={ site.ID } /> }
+				{ siteId && <QueryCurrentTheme siteId={ siteId } /> }
 				<div className="current-theme__current">
 					<span className="current-theme__label">
 						{ this.translate( 'Current Theme' ) }
@@ -78,9 +75,9 @@ const CurrentTheme = React.createClass( {
 
 const ConnectedCurrentTheme = connectOptions( CurrentTheme );
 
-const CurrentThemeWithOptions = ( { site, currentTheme } ) => (
+const CurrentThemeWithOptions = ( { siteId, currentTheme } ) => (
 	<ConnectedCurrentTheme currentTheme={ currentTheme }
-		site={ site }
+		siteId={ siteId }
 		options={ [
 			'customize',
 			'info',
@@ -90,7 +87,7 @@ const CurrentThemeWithOptions = ( { site, currentTheme } ) => (
 );
 
 export default connect(
-	( state, { site } ) => ( {
-		currentTheme: site && getCurrentTheme( state, site.ID )
+	( state, { siteId } ) => ( {
+		currentTheme: siteId && getCurrentTheme( state, siteId )
 	} )
 )( CurrentThemeWithOptions );

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -28,7 +28,7 @@ const CurrentTheme = React.createClass( {
 			icon: PropTypes.string.isRequired,
 			getUrl: PropTypes.func.isRequired
 		} ) ),
-		siteID: PropTypes.number.isRequired,
+		siteId: PropTypes.number.isRequired,
 		// connected props
 		currentTheme: PropTypes.object
 	},

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -88,6 +88,6 @@ const CurrentThemeWithOptions = ( { siteId, currentTheme } ) => (
 
 export default connect(
 	( state, { siteId } ) => ( {
-		currentTheme: siteId && getCurrentTheme( state, siteId )
+		currentTheme: getCurrentTheme( state, siteId )
 	} )
 )( CurrentThemeWithOptions );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -102,7 +102,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 
 	return (
 		<SingleSiteThemeShowcase { ...props }
-			site={ site }
+			siteId={ site.ID }
 			options={ [
 				'customize',
 				'preview',

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -49,17 +49,18 @@ const JetpackThemeReferrerPage = localize(
 const SingleSiteThemeShowcase = connectOptions(
 	localize(
 		( props ) => {
+			const { siteId } = props;
 			const site = sites.getSelectedSite(),
 				{ translate } = props;
 
 			return (
-				<ThemeShowcase { ...props } siteId={ site && site.ID }>
-					{ site && <QuerySitePurchases siteId={ site.ID } /> }
+				<ThemeShowcase { ...props } siteId={ siteId }>
+					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<SidebarNavigation />
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />
-					<CurrentTheme site={ site } />
+					<CurrentTheme siteId={ siteId } />
 					<UpgradeNudge
 						title={ translate( 'Get Custom Design with Premium' ) }
 						message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -36,27 +36,29 @@ const purchase = config.isEnabled( 'upgrades/checkout' )
 		} ),
 		header: i18n.translate( 'Purchase on:', {
 			context: 'verb',
-			comment: 'label for selecting a site for which to purchase a theme'
+			comment: 'label for selecting a siteId for which to purchase a theme'
 		} ),
 		getUrl: getPurchaseUrl,
-		hideForTheme: ( state, theme, site ) => ! theme.price || isActive( state, theme.id, site ) || isPurchased( state, theme.id, site )
+		hideForTheme: ( state, theme, siteId ) =>
+			! theme.price || isActive( state, theme.id, siteId ) || isPurchased( state, theme.id, siteId )
 	}
 	: {};
 
 const activate = {
 	label: i18n.translate( 'Activate' ),
-	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
+	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a siteId on which to activate a theme' } ),
 	action: activateTheme,
-	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site ) || ( theme.price && ! isPurchased( state, theme.id, site ) )
+	hideForTheme: ( state, theme, siteId ) =>
+		isActive( state, theme.id, siteId ) || ( theme.price && ! isPurchased( state, theme.id, siteId ) )
 };
 
 const customize = {
 	label: i18n.translate( 'Customize' ),
-	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a site for which to customize a theme' } ),
+	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a siteIdId for which to customize a theme' } ),
 	icon: 'customize',
 	getUrl: getCustomizeUrl,
-	hideForSite: ( state, site ) => ! canCurrentUser( state, site, 'edit_theme_options' ),
-	hideForTheme: ( state, theme, site ) => ! isActive( state, theme.id, site )
+	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ),
+	hideForTheme: ( state, theme, siteId ) => ! isActive( state, theme.id, siteId )
 };
 
 const tryandcustomize = {
@@ -65,18 +67,18 @@ const tryandcustomize = {
 		comment: 'label in the dialog for opening the Customizer with the theme in preview'
 	} ),
 	getUrl: getCustomizeUrl,
-	hideForSite: ( state, site ) => ! canCurrentUser( state, site, 'edit_theme_options' ),
-	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site )
+	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ),
+	hideForTheme: ( state, theme, siteId ) => isActive( state, theme.id, siteId )
 };
 
 // This is a special option that gets its `action` added by `ThemeShowcase` or `ThemeSheet`,
 // respectively. TODO: Replace with a real action once we're able to use `SitePreview`.
 const preview = {
 	label: i18n.translate( 'Live demo', {
-		comment: 'label for previewing the theme demo website'
+		comment: 'label for previewing the theme demo websiteId'
 	} ),
-	hideForSite: ( state, site ) => isJetpackSite( state, site ),
-	hideForTheme: ( state, theme, site ) => isActive( state, theme.id, site )
+	hideForSite: ( state, siteId ) => isJetpackSite( state, siteId ),
+	hideForTheme: ( state, theme, siteId ) => isActive( state, theme.id, siteId )
 };
 
 const signup = {
@@ -103,7 +105,7 @@ const support = {
 	icon: 'help',
 	getUrl: getSupportUrl,
 	// We don't know where support docs for a given theme on a self-hosted WP install are.
-	hideForSite: ( state, site ) => isJetpackSite( state, site ),
+	hideForSite: ( state, siteId ) => isJetpackSite( state, siteId ),
 	hideForTheme: ( state, theme ) => ! isPremium( theme )
 };
 
@@ -111,7 +113,7 @@ const help = {
 	label: i18n.translate( 'Support' ),
 	getUrl: getHelpUrl,
 	// We don't know where support docs for a given theme on a self-hosted WP install are.
-	hideForSite: ( state, site ) => isJetpackSite( state, site ),
+	hideForSite: ( state, siteId ) => isJetpackSite( state, siteId ),
 };
 
 const ALL_THEME_OPTIONS = {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -128,16 +128,15 @@ const ALL_THEME_OPTIONS = {
 };
 
 const ALL_THEME_ACTIONS = { activate: activateTheme }; // All theme related actions available.
-
 export const connectOptions = connect(
 	( state, { options: optionNames, siteId } ) => {
 		let options = pick( ALL_THEME_OPTIONS, optionNames );
 		let mapGetUrl = identity, mapHideForSite = identity;
 
-		// We bind hideForTheme to site even if it is null since the selectors
+		// We bind hideForTheme to siteId even if it is null since the selectors
 		// that are used by it are expected to recognize that case as "no site selected"
 		// and work accordingly.
-		const mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, siteId || null );
+		const mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, siteId );
 
 		if ( siteId ) {
 			mapGetUrl = getUrl => ( t ) => getUrl( state, t, siteId );
@@ -163,13 +162,13 @@ export const connectOptions = connect(
 				: {}
 		) );
 	},
-	( dispatch, { site, source = 'unknown' } ) => {
+	( dispatch, { siteId, source = 'unknown' } ) => {
 		let mapAction;
 
-		if ( site ) {
-			mapAction = action => ( t ) => action( t.id, site.ID, source );
+		if ( siteId ) {
+			mapAction = action => ( t ) => action( t.id, siteId, source );
 		} else { // Bind only source.
-			mapAction = action => ( t, s ) => action( t.id, s.ID, source );
+			mapAction = action => ( t, s ) => action( t.id, s, source );
 		}
 
 		return bindActionCreators(

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -54,7 +54,7 @@ const activate = {
 
 const customize = {
 	label: i18n.translate( 'Customize' ),
-	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a siteIdId for which to customize a theme' } ),
+	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a siteId for which to customize a theme' } ),
 	icon: 'customize',
 	getUrl: getCustomizeUrl,
 	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ),
@@ -75,7 +75,7 @@ const tryandcustomize = {
 // respectively. TODO: Replace with a real action once we're able to use `SitePreview`.
 const preview = {
 	label: i18n.translate( 'Live demo', {
-		comment: 'label for previewing the theme demo websiteId'
+		comment: 'label for previewing the theme demo website'
 	} ),
 	hideForSite: ( state, siteId ) => isJetpackSite( state, siteId ),
 	hideForTheme: ( state, theme, siteId ) => isActive( state, theme.id, siteId )

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -130,18 +130,16 @@ const ALL_THEME_OPTIONS = {
 const ALL_THEME_ACTIONS = { activate: activateTheme }; // All theme related actions available.
 
 export const connectOptions = connect(
-	( state, { options: optionNames, site } ) => {
+	( state, { options: optionNames, siteId } ) => {
 		let options = pick( ALL_THEME_OPTIONS, optionNames );
 		let mapGetUrl = identity, mapHideForSite = identity;
 
 		// We bind hideForTheme to site even if it is null since the selectors
 		// that are used by it are expected to recognize that case as "no site selected"
 		// and work accordingly.
-		const mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, site ? site.ID : null );
+		const mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, siteId || null );
 
-		if ( site ) {
-			const siteId = site.ID;
-
+		if ( siteId ) {
 			mapGetUrl = getUrl => ( t ) => getUrl( state, t, siteId );
 			options = pickBy( options, option =>
 				! ( option.hideForSite && option.hideForSite( state, siteId ) )

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -36,7 +36,7 @@ const purchase = config.isEnabled( 'upgrades/checkout' )
 		} ),
 		header: i18n.translate( 'Purchase on:', {
 			context: 'verb',
-			comment: 'label for selecting a siteId for which to purchase a theme'
+			comment: 'label for selecting a site for which to purchase a theme'
 		} ),
 		getUrl: getPurchaseUrl,
 		hideForTheme: ( state, theme, siteId ) =>

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -46,7 +46,7 @@ const purchase = config.isEnabled( 'upgrades/checkout' )
 
 const activate = {
 	label: i18n.translate( 'Activate' ),
-	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a siteId on which to activate a theme' } ),
+	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
 	action: activateTheme,
 	hideForTheme: ( state, theme, siteId ) =>
 		isActive( state, theme.id, siteId ) || ( theme.price && ! isPurchased( state, theme.id, siteId ) )
@@ -54,7 +54,7 @@ const activate = {
 
 const customize = {
 	label: i18n.translate( 'Customize' ),
-	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a siteId for which to customize a theme' } ),
+	header: i18n.translate( 'Customize on:', { comment: 'label in the dialog for selecting a site for which to customize a theme' } ),
 	icon: 'customize',
 	getUrl: getCustomizeUrl,
 	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ),

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -51,7 +51,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 		 */
 		if ( action ) {
 			defer( () => {
-				action( theme, site );
+				action( theme, site.ID );
 			} );
 		}
 	},


### PR DESCRIPTION
## Info
`connectOptions` is a utility that connects `options` and `actions` from theme domain to various Theme components. For now actions and options where accepting site object where only site id was sufficient. This PR clears this situation and makes use of siteId wherever it is applicable for actions and options from `connectedOptions`. 

## Testing 
Open, ThemesShowcase and ThemesSheet in different modes (single-site, multi-site, logged-out) and check that options and actions work correctly. Those are purchase, activation, try & customize, 

