### PR TITLE
Reader Stream Refresh: Update x-posts

### DIFF
--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -221,6 +221,34 @@
 	}
 }
 
+// X-Posts
+
+.is-reader-page {
+
+	.reader__card.card.is-x-post {
+		border-bottom: 1px solid lighten( $gray, 30% );
+		margin: 0;
+		padding: 20px;
+
+		&:hover {
+			box-shadow: none; // Disables hover for now until we implement hover in all card types
+		}
+
+		.reader__site-and-author-icon {
+			margin-right: 12px;
+			width: auto;
+		}
+
+		.site-icon {
+			border: 1px solid lighten( $gray, 30% );
+		}
+
+		.gravatar {
+			border: 1px solid $white;
+		}
+	}
+}
+
 // Featured Image/Video
 .reader__post-featured-image,
 .reader__post-featured-video {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9011

**Before:**
![screenshot 2016-11-11 14 31 38](https://cloud.githubusercontent.com/assets/4924246/20232247/b950f31a-a81b-11e6-9d04-35f3cbb1b346.png)

**After:**
![screenshot 2016-11-11 14 31 47](https://cloud.githubusercontent.com/assets/4924246/20232249/bcba4272-a81b-11e6-9dac-39b76ff80a93.png)

![screenshot-2016-11-11-14 14 05](https://cloud.githubusercontent.com/assets/4924246/20232330/67455e8e-a81c-11e6-9ec7-6ae8d4d6eb89.jpg)

@fraying I also experimented removing the indentation in x-posts, although I think indenting them is better, but just wanted to see what you think:

![screenshot 2016-11-11 14 34 12](https://cloud.githubusercontent.com/assets/4924246/20232315/3397c90a-a81c-11e6-8d7c-f03ec207c564.png)