### PR TITLE
Themes: Add new reducers to replace current-themes subtree

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -40,11 +40,10 @@ export function activationRequests( state = {}, action ) {
 		case THEME_ACTIVATE_REQUEST:
 		case THEME_ACTIVATE_REQUEST_SUCCESS:
 		case THEME_ACTIVATE_REQUEST_FAILURE:
-			return Object.assign( {}, state, {
-				[ action.siteId ]: Object.assign( {}, state[ action.siteId ], {
-					[ action.themeId ]: THEME_ACTIVATE_REQUEST === action.type
-				} )
-			} );
+			return {
+				...state,
+				[ action.siteId ]: THEME_ACTIVATE_REQUEST === action.type
+			};
 
 		case SERIALIZE:
 		case DESERIALIZE:

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -6,16 +6,62 @@ import { combineReducers } from 'redux';
 /**
  * Internal dependencies
  */
+import { createReducer } from 'state/utils';
+import {
+	THEME_ACTIVATE_REQUEST,
+	THEME_ACTIVATE_REQUEST_SUCCESS,
+	THEME_ACTIVATE_REQUEST_FAILURE,
+	SERIALIZE,
+	DESERIALIZE
+} from 'state/action-types';
 import themes from './themes/reducer';
 import themeDetails from './theme-details/reducer';
 import themesList from './themes-list/reducer';
-import currentTheme from './current-theme/reducer';
 import themesUI from './themes-ui/reducer';
 
+export const activeThemes = createReducer( {}, {
+	[ THEME_ACTIVATE_REQUEST_SUCCESS ]: ( state, { siteId, theme } ) => ( {
+		...state,
+		[ siteId ]: theme.id
+	} )
+} );
+
+/**
+ * Returns the updated theme activation requests state after an action has been
+ * dispatched. The state reflects a mapping of site ID, theme ID pairing to a
+ * boolean reflecting whether a request for theme activation is in progress.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function activationRequests( state = {}, action ) {
+	switch ( action.type ) {
+		case THEME_ACTIVATE_REQUEST:
+		case THEME_ACTIVATE_REQUEST_SUCCESS:
+		case THEME_ACTIVATE_REQUEST_FAILURE:
+			return Object.assign( {}, state, {
+				[ action.siteId ]: Object.assign( {}, state[ action.siteId ], {
+					[ action.themeId ]: THEME_ACTIVATE_REQUEST === action.type
+				} )
+			} );
+
+		case SERIALIZE:
+		case DESERIALIZE:
+			return {};
+	}
+
+	return state;
+}
+
 export default combineReducers( {
+	// old reducers, will be gradually retired/rewritten
 	themes,
 	themeDetails,
 	themesList,
-	currentTheme,
 	themesUI,
+	// new reducers
+	activeThemes,
+	activationRequests,
+	// and maybe completedActivationRequests which can be cleared with a clearActivate action like we had before(?)
 } );


### PR DESCRIPTION
The idea is to store the current theme's ID per site ID (instead of storing entire theme objects, which would be redundant).
We're also adding a separate subtree to track if we're currently activating a new theme on a given site.

A couple of notes:
* We'll add all new reducers directly to `state/themes/reducer.js` instead of subdirectories of `state/themes`. The idea is that those new reducers will be small enough.
* The `activationRequests` reducer is stolen from `state/posts/reducer` (`siteRequests` reducer), but _with some modifications_. We should also steal its tests (and modify them accordingly) :-)
* We need to figure out some details, e.g. whether to pass on `themeId` with both `activate` and `activated` actions so that the `activationRequests` reducer works.
* Sometimes it makes more sense to use the `createReducer` utility, sometimes it makes more sense to write a reducer manually.
* We'll have to modify the `fetchCurrentTheme` action. For consistency's sake, I think we should rename it to `requestActiveTheme`. That action then probably needs an `activeThemeRequests` reducer (very similar to the `activationRequests` one).
* The selectors in `state/themes/current-theme` won't work after this, so we'll have to rewrite them, too. We should put them directly into `state/themes/selectors`, and probably replace the implementation of `isThemeActive` (and `getActiveTheme`) there by a new selector that reads from the new `themes.activeThemes` subtree (much like `isActiveTheme` does now). See JSDoc on top of `getActiveTheme` why we can't use `options.theme_slug` from the `sites` subtree.

Goals for this PR:
* TDD all the things!
* JSDoc all the things!