### PR TITLE
Stats: fix error on overview page redirect.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -322,6 +322,7 @@
 @import 'my-sites/stats/stats-chart-tabs/style';
 @import 'my-sites/stats/stats-comments/style';
 @import 'my-sites/stats/stats-countries/style';
+@import 'my-sites/stats/stats-date-picker/style';
 @import 'my-sites/stats/stats-error/style';
 @import 'my-sites/stats/stats-module/style';
 @import 'my-sites/stats/stats-overview-placeholder/style';

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -142,6 +142,10 @@ const CurrentSite = React.createClass( {
 			site = this.props.sites.getPrimary();
 		}
 
+		if ( ! site ) {
+			return null;
+		}
+
 		return (
 			<Card className="current-site">
 				{ this.props.siteCount > 1 &&

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -1,33 +1,36 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
+import { localize, moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import userUtils from 'lib/user/utils';
 
-export default React.createClass( {
-	displayName: 'StatsDatePicker',
-
-	propTypes: {
+class StatsDatePicker extends Component {
+	static propTypes = {
 		period: PropTypes.string.isRequired,
 		date: PropTypes.oneOfType( [
 			PropTypes.object.isRequired,
 			PropTypes.string.isRequired
 		] ),
-		summary: PropTypes.bool
-	},
+		summary: PropTypes.bool,
+		translate: PropTypes.func,
+	}
 
 	dateForDisplay() {
 		const locale = userUtils.getLocaleSlug();
-		const date = this.moment( this.props.date ).locale( locale );
+		const date = moment( this.props.date );
+		if ( date.locale() !== locale ) {
+			date.locale( locale );
+		}
 		let formattedDate;
 
 		switch ( this.props.period ) {
 			case 'week':
-				formattedDate = this.translate(
+				formattedDate = this.props.translate(
 					'%(startDate)s - %(endDate)s',
 					{
 						context: 'Date range for which stats are being displayed',
@@ -54,26 +57,26 @@ export default React.createClass( {
 		}
 
 		return formattedDate;
-	},
+	}
 
 	render() {
-		const sectionTitle = this.translate( 'Stats for {{period/}}', {
+		const sectionTitle = this.props.translate( 'Stats for {{period/}}', {
 			components: {
-				period: <span className="period">
-							<span className="date">{ this.dateForDisplay() }</span>
-						</span>
+				period: <span>{ this.dateForDisplay() }</span>
 			},
 			context: 'Stats: Main stats page heading',
 			comment: 'Example: "Stats for December 7", "Stats for December 8 - December 14", "Stats for December", "Stats for 2014"'
 		} );
 
-		return(
+		return (
 			<div>
 				{ this.props.summary
 					? <span>{ sectionTitle }</span>
-					: <h3 className="stats-section-title">{ sectionTitle }</h3>
+					: <h3 className="stats-date-picker__title">{ sectionTitle }</h3>
 				}
 			</div>
 		);
 	}
-} );
+}
+
+export default localize( StatsDatePicker );

--- a/client/my-sites/stats/stats-date-picker/style.scss
+++ b/client/my-sites/stats/stats-date-picker/style.scss
@@ -1,0 +1,12 @@
+.stats-date-picker__title {
+	@include heading;
+
+	@include breakpoint( "<660px" ) {
+		margin-left: 24px;
+		margin-right: 24px;
+	}
+
+	@include breakpoint( "<480px" ) {
+		text-align: center;
+	}
+}


### PR DESCRIPTION
Fixes #8163 

After deleting a site, users are currently redirected to the `/stats` overview page.  For some strange reason, `moment` was doing some ✨  in the `locale()` setting that was resulting in the error described in the original ticket ( thank you again esteemed @jkudish for the report ).

The fix was to only set the `locale` if the `locale` was incorrect.  Oddly enough, the bug never happens in other flows.  While in the file, I opted to do a bit of further trash pickup by removing `createClass` and tidying up other lint issues.

__To Test__
- Have a site you can delete, or make a new one to delete
- Delete the site via the site settings page
- Note you are redirected to the `/stats` page and no errors are thrown

Other Notes:  I kind of feel like we should change this redirect to `/` and show the reader instead, since that is now the default view in Calypso.  

