### PR TITLE
My Sites Sidebar: Pull out AppearanceMenu in to separate component

### DIFF
--- a/client/my-sites/sidebar/appearanceMenu.jsx
+++ b/client/my-sites/sidebar/appearanceMenu.jsx
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { includes } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import SidebarButton from 'layout/sidebar/button';
+import SidebarHeading from 'layout/sidebar/heading';
+import SidebarItem from 'layout/sidebar/item';
+import SidebarMenu from 'layout/sidebar/menu';
+import { canCurrentUser } from 'state/current-user/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+import { getCustomizeUrl } from 'my-sites/themes/helpers';
+
+class AppearanceMenu extends Component {
+
+	static propTypes = {
+		path: PropTypes.string,
+		site: PropTypes.object.isRequired,
+		sites: PropTypes.object.isRequired,
+	}
+
+	isSingle() {
+		return !! ( this.props.site || this.props.sites.get().length === 1 );
+	}
+
+	isItemLinkSelected( path ) {
+		return path === this.props.path || includes( this.props.path, path + '/' );
+	}
+
+	renderThemesOption() {
+		const { site, translate, userCanCustomize } = this.props;
+		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
+		const themeManagementEnabled = config.isEnabled( 'manage/themes' );
+		let link = '/design';
+
+		if ( ( site && ! userCanCustomize ) || ! themeManagementEnabled ) {
+			return null;
+		}
+
+		if ( site.jetpack && ! jetpackEnabled && site.options ) {
+			link = site.options.admin_url + 'themes.php';
+		} else if ( this.isSingle() ) {
+			link = '/design/' + site.slug;
+		}
+
+		return (
+			<SidebarItem
+				label={ translate( 'Themes' ) }
+				tipTarget="themes"
+				className="themes"
+				link={ link }
+				onNavigate={ this.onNavigate }
+				icon="themes"
+				preloadSectionName="themes"
+				selected={ this.isItemLinkSelected( '/design' ) }
+			>
+				<SidebarButton href={ getCustomizeUrl( null, site ) } preloadSectionName="customize">
+					{ translate( 'Customize' ) }
+				</SidebarButton>
+			</SidebarItem>
+		);
+	}
+
+	renderMenusOption() {
+		const { site, translate, userCanCustomize } = this.props;
+		const showClassicLink = ! config.isEnabled( 'manage/menus' );
+
+		if ( ! site || ! userCanCustomize || ! this.isSingle() ) {
+			return null;
+		}
+
+		const link = showClassicLink
+			? site.options.admin_url + 'nav-menus.php'
+			: '/menus/' + site.slug;
+
+		return (
+			<SidebarItem
+				tipTarget="menus"
+				label={ translate( 'Menus' ) }
+				className="menus"
+				link={ link }
+				onNavigate={ this.onNavigate }
+				icon="menus"
+				preloadSectionName="menus"
+				selected={ this.isItemLinkSelected( '/menus' ) }
+			/>
+		);
+	}
+
+	render() {
+		if ( ! this.props.userCanCustomize ) {
+			return null;
+		}
+
+		return (
+			<SidebarMenu>
+				<SidebarHeading>{ this.props.translate( 'Personalize' ) }</SidebarHeading>
+				<ul>
+					{ this.renderThemesOption() }
+					{ this.renderMenusOption() }
+				</ul>
+			</SidebarMenu>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSite( state );
+	const userCanCustomize = canCurrentUser( state, site.ID, 'edit_theme_options' );
+
+	return {
+		site,
+		userCanCustomize
+	};
+}
+
+export default connect( mapStateToProps )( localize( AppearanceMenu ) );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -15,7 +15,6 @@ import { connect } from 'react-redux';
  */
 var config = require( 'config' ),
 	CurrentSite = require( 'my-sites/current-site' ),
-	getCustomizeUrl = require( '../themes/helpers' ).getCustomizeUrl,
 	Gridicon = require( 'components/gridicon' ),
 	productsValues = require( 'lib/products-values' ),
 	PublishMenu = require( './publish-menu' ),
@@ -32,6 +31,7 @@ import SidebarFooter from 'layout/sidebar/footer';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
+import AppearanceMenu from './appearanceMenu';
 
 export const MySitesSidebar = React.createClass( {
 	propTypes: {
@@ -164,81 +164,6 @@ export const MySitesSidebar = React.createClass( {
 				link={ adsLink }
 				onNavigate={ this.onNavigate }
 				icon="speaker" />
-		);
-	},
-
-	themes: function() {
-		var site = this.getSelectedSite(),
-			jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' ),
-			themesLink;
-
-		if ( site && ! site.isCustomizable() ) {
-			return null;
-		}
-
-		if ( ! config.isEnabled( 'manage/themes' ) ) {
-			return null;
-		}
-
-		if ( site.jetpack && ! jetpackEnabled && site.options ) {
-			themesLink = site.options.admin_url + 'themes.php';
-		} else if ( this.isSingle() ) {
-			themesLink = '/design' + this.siteSuffix();
-		} else {
-			themesLink = '/design';
-		}
-
-		return (
-			<SidebarItem
-				label={ this.translate( 'Themes' ) }
-				tipTarget="themes"
-				className={ this.itemLinkClass( '/design', 'themes' ) }
-				link={ themesLink }
-				onNavigate={ this.onNavigate }
-				icon="themes"
-				preloadSectionName="themes"
-			>
-				<SidebarButton href={ getCustomizeUrl( null, site ) } preloadSectionName="customize">
-					{ this.translate( 'Customize' ) }
-				</SidebarButton>
-			</SidebarItem>
-		);
-	},
-
-	menus: function() {
-		var site = this.getSelectedSite(),
-			menusLink = '/menus' + this.siteSuffix(),
-			showClassicLink = ! config.isEnabled( 'manage/menus' );
-
-		if ( ! site ) {
-			return null;
-		}
-
-		if ( ! site.capabilities ) {
-			return null;
-		}
-
-		if ( site.capabilities && ! site.capabilities.edit_theme_options ) {
-			return null;
-		}
-
-		if ( ! this.isSingle() ) {
-			return null;
-		}
-
-		if ( showClassicLink ) {
-			menusLink = site.options.admin_url + 'nav-menus.php';
-		}
-
-		return (
-			<SidebarItem
-				tipTarget="menus"
-				label={ this.translate( 'Menus' ) }
-				className={ this.itemLinkClass( '/menus', 'menus' ) }
-				link={ menusLink }
-				onNavigate={ this.onNavigate }
-				icon="menus"
-				preloadSectionName="menus" />
 		);
 	},
 
@@ -682,7 +607,6 @@ export const MySitesSidebar = React.createClass( {
 
 	render: function() {
 		var publish = !! this.publish(),
-			appearance = ( !! this.themes() || !! this.menus() ),
 			configuration = ( !! this.sharing() || !! this.users() || !! this.siteSettings() || !! this.plugins() || !! this.upgrades() ),
 			vip = !! this.vip();
 
@@ -724,16 +648,7 @@ export const MySitesSidebar = React.createClass( {
 					: null
 				}
 
-				{ appearance
-					? <SidebarMenu>
-						<SidebarHeading>{ this.translate( 'Personalize' ) }</SidebarHeading>
-						<ul>
-							{ this.themes() }
-							{ this.menus() }
-						</ul>
-					</SidebarMenu>
-					: null
-				}
+				<AppearanceMenu sites={ this.props.sites } path={ this.props.path } />
 
 				{ configuration
 					? <SidebarMenu>


### PR DESCRIPTION
### Aims
As part of #9054 I've started to break down the `/my-sites/sidebar/sidebar.jsx` file in to more workable components.
I think the first step to this is just to pull out each menu - that alone should make the file a lot easier to manage & reason about.

In an attempt to keep the pull requests small and easy to review, this particular PR aims to pull out the appearance / personalize menu into a new AppearanceMenu component only.

There should ultimately be no new or changed behaviour, though I have cut out some seemingly redundant logic.

### Test

To test, make sure that the appearance / personalize menu functions as it did before this patch.

Here's how it should look:

<img width="231" alt="personalize" src="https://cloud.githubusercontent.com/assets/4335450/20234203/748913aa-a8cc-11e6-8842-66399a9373ab.png">  

Clicking on either menu item should navigate you to the correct route and that menu item should then show a 'selected' state.

<img width="230" alt="selected" src="https://cloud.githubusercontent.com/assets/4335450/20234235/bd10251e-a8cc-11e6-937e-e9d3273d7ffb.png">  

'Themes' should link to: `/design/something.wordpress.com` (unless jetpack  is not enabled?)
'Customize' should link to: `/customize/something.wordpress.com`
'Menus' should link to: `/menus/something.wordpress.com`


### Notes

Some of the logic that I've removed _seemed_ redundant, but it's entirely possible that in removing this I've missed the point of it's use in the first place

- Selected Site - I'm assuming that the `getSelectedSite` selector can replace the `props.sites.getSelectedSite` method and reach the same (if not _more_ accurate) effect.

- Primary Site - The same goes for the `this.props.sites.getPrimary` (site) method. Do we default the selected site? So, if no site is selected, `getSelectedSite` will give the 'primary' site?

- Passed Props - Ideally, I'd love not to have to pass down `path` or `sites` to the AppearanceMenu component or any of the others that I'll be refactoring...
I believe that 'sites' will soon have a state selector. Is there some other safe way to get `path` in the same way that the routing middleware does?

- ClassNames - I _think_ that I managed to do-away with the dependancy on ClassNames by setting the selected state via a prop rather than a className... Am I missing something here? The origin method seemed needlessly convoluted.

### Still To Do
- Add tests around this new component
- Update branch! Oops!
- Possibly move the AppearanceMenu & subsequent menus in to a `menus` subdirectory.