### PR TITLE
Search Component: Fix SSR reconciliation error

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -71,7 +71,8 @@ const Search = React.createClass( {
 		return {
 			keyword: this.props.initialValue || '',
 			isOpen: !! this.props.isOpen,
-			hasFocus: false
+			hasFocus: false,
+			instanceId: 0
 		};
 	},
 
@@ -100,10 +101,6 @@ const Search = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		this.setState( {
-			instanceId: ++Search.instances
-		} );
-
 		this.closeListener = keyListener.bind( this, 'closeSearch' );
 		this.openListener = keyListener.bind( this, 'openSearch' );
 	},
@@ -167,6 +164,16 @@ const Search = React.createClass( {
 			// this hack makes autoFocus work correctly in Dropdown
 			setTimeout( () => this.focus(), 0 );
 		}
+
+		// Setting a unique instance ID lets each component instance have unique HTML id
+		// attributes, needed for proper ARIA support. Unfortunately, setting this before
+		// first render causes reconciliation errors when the component is server-rendered
+		// (it's tough to keep the server and client instance count sync'd). That's why
+		// we're only setting a unique ID after the client has mounted.
+		// eslint-disable-next-line react/no-did-mount-set-state
+		this.setState( {
+			instanceId: ++Search.instances
+		} );
 	},
 
 	scrollOverlay: function() {


### PR DESCRIPTION
## The problem
Instances of the `<Search>` component need unique `id` HTML attributes for ARIA support. This is accomplished with an auto-incrementing component-level counter. On client requests, this counter starts at 0 every time. However for server requests, since the module is never re-loaded, the counter continues incrementing across requests. This leads to a mismatch in rendered HTML, and a reconciliation warning in the console.

### To reproduce
Checkout `master`, visit http://calypso.localhost:3000/design — on the first visit after the server mounts, you'll see this unrelated reconciliation error: 

![screen shot 2016-11-11 at 10 01 09 pm](https://cloud.githubusercontent.com/assets/518059/20235540/6638bfac-a85a-11e6-8e2b-e285cfd5e2a1.png)

The error we're concerned with doesn't show until after the first request, since now the server counter will have incremented and the client counter will start back at 0. Click the Free tab and then refresh (to get a server render on a new uncached page) and you'll see this warning:

![screen shot 2016-11-11 at 10 06 02 pm](https://cloud.githubusercontent.com/assets/518059/20235573/260a5962-a85b-11e6-8d88-1559da8aa875.png)

## The solution

There's a couple approaches we could take, but the quickest one that makes most sense seems to be — default every instanceId to 0 so that the server and client first render are the same, and then in `componentDidMount` on the client, set the actual unique ID.

### To verify
Follow the repro instructions above on this branch — the `search-component-1` reconciliation error should be gone.

### Caveats
- ARIA support on the server-rendered code only works in instances where there's a single `<Search>` component on the page — otherwise the components will share IDs.
- This causes each `<Search>` component to have a guaranteed double render on mount
