### PR TITLE
Reader: Remove jp-relatedposts-headline from content

### DIFF
--- a/client/lib/post-normalizer/rule-content-remove-elements-by-selector.js
+++ b/client/lib/post-normalizer/rule-content-remove-elements-by-selector.js
@@ -11,6 +11,7 @@ const thingsToRemove = [
 	'.sharedaddy', // share daddy
 	'script', // might be too late for these at this point...
 	'.jp-relatedposts', // jetpack related posts
+	'.jp-relatedposts-headline', // same
 	'.mc4wp-form', // mailchimp 4 wp
 	'.wpcnt', // wordads?
 	'.OUTBRAIN',

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -905,6 +905,7 @@ describe( 'index', function() {
 					<div class="sharedaddy">sharedaddy</div>
 					<script>/*hi*/</script>
 					<div class="jp-relatedposts">jetpack</div>
+					<div class="jp-relatedposts-headline">jetpack</div>
 					<div class="mc4wp-form">a form</div>
 					<div class="wpcnt">wordads</div>
 					<div class="OUTBRAIN">outbrain content ads</div>


### PR DESCRIPTION
Fixes #9306

to test compare the first result at 
https://wpcalypso.wordpress.com/read/feeds/12098?at=2016-11-11T16:28:00Z

to
https://calypso.live/read/feeds/12098?at=2016-11-11T16:28:00Z&branch=fix/reader/9306
