### PR TITLE
Reader: Fix j and k keyboard shortcuts for next and previous in refreshed streams

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -25,6 +25,7 @@ export default class RefreshPostCard extends React.Component {
 		post: PropTypes.object.isRequired,
 		site: PropTypes.object,
 		feed: PropTypes.object,
+		isSelected: PropTypes.bool,
 		onClick: PropTypes.func,
 		onCommentClick: PropTypes.func,
 		showPrimaryFollowButton: PropTypes.bool,
@@ -33,7 +34,8 @@ export default class RefreshPostCard extends React.Component {
 
 	static defaultProps = {
 		onClick: noop,
-		onCommentClick: noop
+		onCommentClick: noop,
+		isSelected: false
 	};
 
 	propagateCardClick = () => {
@@ -84,13 +86,14 @@ export default class RefreshPostCard extends React.Component {
 	}
 
 	render() {
-		const { post, originalPost, site, feed, onCommentClick, showPrimaryFollowButton } = this.props;
+		const { post, originalPost, site, feed, onCommentClick, showPrimaryFollowButton, isSelected } = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
 			'is-photo': isPhotoOnly,
-			'is-gallery': isGallery
+			'is-gallery': isGallery,
+			'is-selected': isSelected
 		} );
 		const showExcerpt = ! isPhotoOnly;
 		let title = truncate( post.title, {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -17,6 +17,22 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin: 0;
 	}
 
+	&.is-selected {
+		&::before {
+			content: '';
+			position: absolute;
+				top: 0;
+				bottom: 0;
+				left: -8px;
+				width: 2px;
+			background: $blue-wordpress;
+
+			@include breakpoint( ">660px" ) {
+				left: -16px;
+			}
+		}
+	}
+
 	&.has-thumbnail {
 
 		.reader-post-card__featured-image {

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -46,6 +46,7 @@ class ReaderPostCardAdapter extends React.Component {
 				feed={ this.props.feed }
 				onClick={ this.onClick }
 				onCommentClick={ this.onCommentClick }
+				isSelected={ this.props.isSelected }
 				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }


### PR DESCRIPTION
Teach the refresh cards about the is-selected prop and add new styles to indicate the selected post.

Fixes #9074