### PR TITLE
Domains: fix redirect loop when user has one site and lacks manage_option capability

### DIFF
--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import Dispatcher from 'dispatcher';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -54,6 +55,7 @@ const PlansNavigation = React.createClass( {
 		const path = sectionify( this.props.path );
 		const hasPlan = site && site.plan && site.plan.product_slug !== 'free_plan';
 		const sectionTitle = path.split( '?' )[ 0 ].replace( /\//g, ' ' );
+		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
 
 		return (
 			<SectionNav
@@ -69,13 +71,13 @@ const PlansNavigation = React.createClass( {
 					<NavItem path={ `/plans/${ site.slug }` } key="plans" selected={ path === '/plans' || path === '/plans/monthly' }>
 						{ this.translate( 'Plans' ) }
 					</NavItem>
-					{ ! isJetpack &&
+					{ ! isJetpack && userCanManageOptions &&
 						<NavItem path={ `/domains/manage/${ site.slug }` } key="domains"
 							selected={ path === '/domains/manage' || path === '/domains/add' }>
 							{ this.translate( 'Domains' ) }
 						</NavItem>
 					}
-					{ ! isJetpack &&
+					{ ! isJetpack && userCanManageOptions &&
 						<NavItem path={ `/domains/manage/email/${ site.slug }` } key="googleApps"
 							selected={ path === '/domains/manage/email' }>
 							{ this.translate( 'G Suite' ) }


### PR DESCRIPTION
Fixes #2142 where we could get into an infinite redirect loop on the /domains page. This was caused by:
1. The /domains/manage/:site: route handler redirecting to base /domains for site selection
2. site selection automatically occurs, as the user only has a single site
3. user goes back to the site specific url: /domains/manage/:site: and the loop repeats.

## Testing Instructions
1. As an admin on a site, invite a new user to the site with a role less than admin. (For example, editor)
2. Check inbox for invite, complete registration in another browser
3. Navigate to http://calypso.localhost:3000
4. Click on "My Sites"
5. Note that the sidebar does not render plans or domain links
6. Navigate to http://calypso.localhost:3000/plans
7. Page should render fine, but links to domains or email management should not be seen in the header

<img width="1039" alt="screen shot 2016-11-12 at 3 54 07 pm" src="https://cloud.githubusercontent.com/assets/1270189/20242789/4e8dab10-a8f0-11e6-80cf-6d7fec5e9fec.png">

8. Navigate directly to http://calypso.localhost:3000/domains
9. You will be redirected to /stats
10. Switch to the admin user /domains and /plans behaves normally

cc @umurkontaci @lancewillett @lamosty @retrofox @lamosty 
