### PR TITLE
Remove SiteList ref from UpgradeNudge and Localize UpgradeNudge

### DIFF
--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,16 +14,12 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import analytics from 'lib/analytics';
-import sitesList from 'lib/sites-list';
 import { getValidFeatureKeys, hasFeature } from 'lib/plans';
 import { isFreePlan } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { getSelectedSite } from 'state/ui/selectors';
 
-const sites = sitesList();
-
-export default React.createClass( {
-
-	displayName: 'UpgradeNudge',
+const UpgradeNudge = React.createClass( {
 
 	propTypes: {
 		onClick: React.PropTypes.func,
@@ -33,7 +31,8 @@ export default React.createClass( {
 		jetpack: React.PropTypes.bool,
 		compact: React.PropTypes.bool,
 		feature: React.PropTypes.oneOf( [ false, ...getValidFeatureKeys() ] ),
-		shouldDisplay: React.PropTypes.func
+		shouldDisplay: React.PropTypes.func,
+		site: React.PropTypes.object,
 	},
 
 	getDefaultProps() {
@@ -60,8 +59,8 @@ export default React.createClass( {
 		this.props.onClick();
 	},
 
-	shouldDisplay( site ) {
-		const { feature, jetpack, shouldDisplay } = this.props;
+	shouldDisplay() {
+		const { feature, jetpack, shouldDisplay, site } = this.props;
 		if ( shouldDisplay ) {
 			return shouldDisplay();
 		}
@@ -84,9 +83,8 @@ export default React.createClass( {
 	},
 
 	render() {
+		const { site, translate } = this.props;
 		const classes = classNames( this.props.className, 'upgrade-nudge' );
-
-		const site = sites.getSelectedSite();
 		let href = this.props.href;
 
 		if ( ! this.shouldDisplay( site ) ) {
@@ -107,7 +105,7 @@ export default React.createClass( {
 					<Gridicon className="upgrade-nudge__icon" icon={ this.props.icon } />
 					<div className="upgrade-nudge__info">
 						<span className="upgrade-nudge__title">
-							{ this.props.title || this.translate( 'Upgrade to Premium' ) }
+							{ this.props.title || translate( 'Upgrade to Premium' ) }
 						</span>
 						<span className="upgrade-nudge__message" >
 							{ this.props.message }
@@ -122,7 +120,7 @@ export default React.createClass( {
 				<Gridicon className="upgrade-nudge__icon" icon={ this.props.icon } size={ 18 } />
 				<div className="upgrade-nudge__info">
 					<span className="upgrade-nudge__title">
-						{ this.props.title || this.translate( 'Upgrade to Premium' ) }
+						{ this.props.title || translate( 'Upgrade to Premium' ) }
 					</span>
 					<span className="upgrade-nudge__message" >
 						{ this.props.message }
@@ -139,3 +137,13 @@ export default React.createClass( {
 		);
 	}
 } );
+
+function mapStateToProps( state ) {
+	const site = getSelectedSite( state );
+
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( UpgradeNudge ) );

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import noop from 'lodash/noop';
+import { identity, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -44,7 +44,9 @@ const UpgradeNudge = React.createClass( {
 			jetpack: false,
 			feature: false,
 			compact: false,
-			shouldDisplay: null
+			shouldDisplay: null,
+			site: null,
+			translate: identity,
 		};
 	},
 
@@ -138,12 +140,8 @@ const UpgradeNudge = React.createClass( {
 	}
 } );
 
-function mapStateToProps( state ) {
-	const site = getSelectedSite( state );
-
-	return {
-		site,
-	};
-}
-
-export default connect( mapStateToProps )( localize( UpgradeNudge ) );
+export default connect(
+	state => ( {
+		site: getSelectedSite( state ),
+	} )
+)( localize( UpgradeNudge ) );

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -13,10 +13,10 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
-import analytics from 'lib/analytics';
 import { getValidFeatureKeys, hasFeature } from 'lib/plans';
 import { isFreePlan } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { recordGoogleEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const UpgradeNudge = React.createClass( {
@@ -51,14 +51,17 @@ const UpgradeNudge = React.createClass( {
 	},
 
 	handleClick() {
-		if ( this.props.event || this.props.feature ) {
-			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
-				cta_name: this.props.event,
-				cta_feature: this.props.feature,
+		const { event, feature, onClick } = this.props;
+
+		if ( event || feature ) {
+			this.props.recordGoogleEvent( 'calypso_upgrade_nudge_cta_click', {
+				cta_name: event,
+				cta_feature: feature,
 				cta_size: 'regular'
 			} );
 		}
-		this.props.onClick();
+
+		onClick();
 	},
 
 	shouldDisplay() {
@@ -143,5 +146,6 @@ const UpgradeNudge = React.createClass( {
 export default connect(
 	state => ( {
 		site: getSelectedSite( state ),
-	} )
+	} ),
+	{ recordGoogleEvent }
 )( localize( UpgradeNudge ) );

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -16,7 +16,7 @@ import Gridicon from 'components/gridicon';
 import { getValidFeatureKeys, hasFeature } from 'lib/plans';
 import { isFreePlan } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const UpgradeNudge = React.createClass( {
@@ -51,10 +51,10 @@ const UpgradeNudge = React.createClass( {
 	},
 
 	handleClick() {
-		const { event, feature, onClick } = this.props;
+		const { event, feature, onClick, recordTracksEvent: recordTracks } = this.props;
 
 		if ( event || feature ) {
-			this.props.recordGoogleEvent( 'calypso_upgrade_nudge_cta_click', {
+			recordTracks( 'calypso_upgrade_nudge_cta_click', {
 				cta_name: event,
 				cta_feature: feature,
 				cta_size: 'regular'
@@ -92,7 +92,7 @@ const UpgradeNudge = React.createClass( {
 		const classes = classNames( this.props.className, 'upgrade-nudge' );
 		let href = this.props.href;
 
-		if ( ! this.shouldDisplay( site ) ) {
+		if ( ! this.shouldDisplay() ) {
 			return null;
 		}
 
@@ -147,5 +147,5 @@ export default connect(
 	state => ( {
 		site: getSelectedSite( state ),
 	} ),
-	{ recordGoogleEvent }
+	{ recordTracksEvent }
 )( localize( UpgradeNudge ) );


### PR DESCRIPTION
### Aims
As part of #8726, this PR removes reference to 'lib/sites-list' in the UpgradeNudge component.

Also, while refactoring I added the localize HoC :)

### Test Plan

- Navigate to [stat insights](http://calypso.localhost:3000/stats/insights) and select a ___.wordpress.com site.
- Scroll to find the 'nudge', it should appear between `Most popular day and hour` and `Comments`.
- Check that this nudge has not changed in anyway
    - it should be visually identical before & after this patch
    - clicking it should route to `domains/add/__site-name__`
