### PR TITLE
Reader Stream Refresh: turn off follow button on cards for Blog Stream and Feed Stream

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -45,13 +45,13 @@ function renderFeedError( context ) {
 }
 
 module.exports = {
-	initAbTests: function( context, next ) {
+	initAbTests( context, next ) {
 		// spin up the ab tests that are currently active for the reader
 		activeAbTests.forEach( test => abtest( test ) );
 		next();
 	},
 
-	prettyRedirects: function( context, next ) {
+	prettyRedirects( context, next ) {
 		// Do we have a 'pretty' site or feed URL?
 		let redirect;
 		if ( context.params.blog_id ) {
@@ -67,7 +67,7 @@ module.exports = {
 		next();
 	},
 
-	legacyRedirects: function( context, next ) {
+	legacyRedirects( context, next ) {
 		const legacyPathRegexes = {
 			feedStream: /^\/read\/blog\/feed\/([0-9]+)$/i,
 			feedFullPost: /^\/read\/post\/feed\/([0-9]+)\/([0-9]+)$/i,
@@ -76,13 +76,13 @@ module.exports = {
 		};
 
 		if ( context.path.match( legacyPathRegexes.feedStream ) ) {
-			page.redirect( `/read/feeds/${context.params.feed_id}` );
+			page.redirect( `/read/feeds/${ context.params.feed_id }` );
 		} else if ( context.path.match( legacyPathRegexes.feedFullPost ) ) {
-			page.redirect( `/read/feeds/${context.params.feed_id}/posts/${context.params.post_id}` );
+			page.redirect( `/read/feeds/${ context.params.feed_id }/posts/${ context.params.post_id }` );
 		} else if ( context.path.match( legacyPathRegexes.blogStream ) ) {
-			page.redirect( `/read/blogs/${context.params.blog_id}` );
+			page.redirect( `/read/blogs/${ context.params.blog_id }` );
 		} else if ( context.path.match( legacyPathRegexes.blogFullPost ) ) {
-			page.redirect( `/read/blogs/${context.params.blog_id}/posts/${context.params.post_id}` );
+			page.redirect( `/read/blogs/${ context.params.blog_id }/posts/${ context.params.post_id }` );
 		}
 
 		next();
@@ -96,13 +96,13 @@ module.exports = {
 		next();
 	},
 
-	incompleteUrlRedirects: function( context, next ) {
+	incompleteUrlRedirects( context, next ) {
 		let redirect;
 		// Have we arrived at a URL ending in /posts? Redirect to feed stream/blog stream
 		if ( context.path.match( /^\/read\/feeds\/([0-9]+)\/posts$/i ) ) {
-			redirect = `/read/feeds/${context.params.feed_id}`;
+			redirect = `/read/feeds/${ context.params.feed_id }`;
 		} else if ( context.path.match( /^\/read\/blogs\/([0-9]+)\/posts$/i ) ) {
-			redirect = `/read/blogs/${context.params.blog_id}`;
+			redirect = `/read/blogs/${ context.params.blog_id }`;
 		}
 
 		if ( redirect ) {
@@ -112,12 +112,12 @@ module.exports = {
 		next();
 	},
 
-	preloadReaderBundle: function( context, next ) {
+	preloadReaderBundle( context, next ) {
 		preload( 'reader' );
 		next();
 	},
 
-	loadSubscriptions: function( context, next ) {
+	loadSubscriptions( context, next ) {
 		// these three are included to ensure that the stores required have been loaded and can accept actions
 		const FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' ), // eslint-disable-line no-unused-vars
 			PostEmailSubscriptionStore = require( 'lib/reader-post-email-subscriptions' ), // eslint-disable-line no-unused-vars
@@ -126,8 +126,7 @@ module.exports = {
 		next();
 	},
 
-	sidebar: function( context, next ) {
-
+	sidebar( context, next ) {
 		renderWithReduxStore(
 			React.createElement( ReduxProvider, { store: context.store },
 				React.createElement( ReaderSidebarComponent, { path: context.path } )
@@ -139,13 +138,13 @@ module.exports = {
 		next();
 	},
 
-	unmountSidebar: function( context, next ) {
+	unmountSidebar( context, next ) {
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		next();
 	},
 
-	following: function( context ) {
-		var StreamComponent = require( 'reader/following/main' ),
+	following( context ) {
+		const StreamComponent = require( 'reader/following/main' ),
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Following',
 			followingStore = feedStreamFactory( 'following' ),
@@ -164,7 +163,7 @@ module.exports = {
 					key: 'following',
 					listName: i18n.translate( 'Followed Sites' ),
 					store: followingStore,
-					showPrimaryFollowButtonOnCards: false,
+					showPrimaryFollowButtonOnCards: true,
 					trackScrollPage: trackScrollPage.bind(
 						null,
 						basePath,
@@ -179,13 +178,13 @@ module.exports = {
 		);
 	},
 
-	feedDiscovery: function( context, next ) {
-		var feedLookup = require( 'lib/feed-lookup' );
+	feedDiscovery( context, next ) {
+		const feedLookup = require( 'lib/feed-lookup' );
 
 		if ( ! context.params.feed_id.match( /^\d+$/ ) ) {
 			feedLookup( context.params.feed_id )
 				.then( function( feedId ) {
-					page.redirect( `/read/feeds/${feedId}` );
+					page.redirect( `/read/feeds/${ feedId }` );
 				} )
 				.catch( function() {
 					renderFeedError( context );
@@ -195,8 +194,8 @@ module.exports = {
 		}
 	},
 
-	feedListing: function( context ) {
-		var FeedStream = require( 'reader/feed-stream' ),
+	feedListing( context ) {
+		const FeedStream = require( 'reader/feed-stream' ),
 			basePath = '/read/feeds/:feed_id',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Feed > ' + context.params.feed_id,
 			feedStore = feedStreamFactory( 'feed:' + context.params.feed_id ),
@@ -222,6 +221,7 @@ module.exports = {
 					mcKey
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+				showPrimaryFollowButtonOnCards: false,
 				suppressSiteNameLink: true,
 				showBack: userHasHistory( context )
 			} ),
@@ -230,8 +230,8 @@ module.exports = {
 		);
 	},
 
-	blogListing: function( context ) {
-		var SiteStream = require( 'reader/site-stream' ),
+	blogListing( context ) {
+		const SiteStream = require( 'reader/site-stream' ),
 			basePath = '/read/blogs/:blog_id',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Site > ' + context.params.blog_id,
 			feedStore = feedStreamFactory( 'site:' + context.params.blog_id ),
@@ -257,6 +257,7 @@ module.exports = {
 					mcKey
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+				showPrimaryFollowButtonOnCards: false,
 				suppressSiteNameLink: true,
 				showBack: userHasHistory( context )
 			} ),
@@ -265,8 +266,8 @@ module.exports = {
 		);
 	},
 
-	readA8C: function( context ) {
-		var StreamComponent = require( 'reader/stream' ),
+	readA8C( context ) {
+		const StreamComponent = require( 'reader/stream' ),
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > A8C',
 			feedStore = feedStreamFactory( 'a8c' ),
@@ -292,7 +293,7 @@ module.exports = {
 						analyticsPageTitle,
 						mcKey
 					),
-					showPrimaryFollowButtonOnCards: false,
+					showPrimaryFollowButtonOnCards: true,
 					onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
 				} ),
 			),

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -163,7 +163,7 @@ module.exports = {
 					key: 'following',
 					listName: i18n.translate( 'Followed Sites' ),
 					store: followingStore,
-					showPrimaryFollowButtonOnCards: true,
+					showPrimaryFollowButtonOnCards: false,
 					trackScrollPage: trackScrollPage.bind(
 						null,
 						basePath,
@@ -293,7 +293,7 @@ module.exports = {
 						analyticsPageTitle,
 						mcKey
 					),
-					showPrimaryFollowButtonOnCards: true,
+					showPrimaryFollowButtonOnCards: false,
 					onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
 				} ),
 			),


### PR DESCRIPTION
Fixes #9228.

Before:

<img width="874" alt="screen shot 2016-11-14 at 15 17 30" src="https://cloud.githubusercontent.com/assets/17325/20251357/876892c2-aa7d-11e6-9379-28c5947fb77a.png">

After:

<img width="869" alt="screen shot 2016-11-14 at 15 17 36" src="https://cloud.githubusercontent.com/assets/17325/20251358/8ae13012-aa7d-11e6-9116-4b261329f5d5.png">

### To test

Ensure that the Follow button is absent from cards in blog streams:

http://calypso.localhost:3000/read/blogs/76295396

...and feed streams:

http://calypso.localhost:3000/read/feeds/8901148

...but make sure it still shows up in Following.