### PR TITLE
.org Plans: Use site.domain instead of slugToUrl helper

### DIFF
--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -92,14 +92,6 @@ function urlToSlug( url ) {
 	return withoutHttp( url ).replace( /\//g, '::' );
 }
 
-function slugToUrl( slug ) {
-	if ( ! slug ) {
-		return null;
-	}
-
-	return slug.replace( /::/g, '/' );
-}
-
 export default {
 	isOutsideCalypso,
 	isExternal,
@@ -108,7 +100,6 @@ export default {
 	addSchemeIfMissing,
 	setUrlScheme,
 	urlToSlug,
-	slugToUrl,
 	// [TODO]: Move lib/route/add-query-args contents here
 	addQueryArgs
 };

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -13,7 +13,6 @@ import {
 	addSchemeIfMissing,
 	setUrlScheme,
 	urlToSlug,
-	slugToUrl,
 } from '../';
 
 describe( 'withoutHttp', () => {
@@ -236,22 +235,5 @@ describe( 'urlToSlug()', () => {
 		const urlWithoutHttp = urlToSlug( urlWithHttp );
 
 		expect( urlWithoutHttp ).to.equal( 'example.com::example::test123' );
-	} );
-} );
-
-describe( 'slugToUrl()', () => {
-	it( 'should return null if slug is not provided', () => {
-		expect( slugToUrl() ).to.be.null;
-	} );
-
-	it( 'should return null if slug is empty string', () => {
-		expect( slugToUrl( '' ) ).to.be.null;
-	} );
-
-	it( 'should return null convert double colons to forward slashes', () => {
-		const slug = 'example.com::example::test123';
-		const expected = 'example.com/example/test123';
-
-		expect( slugToUrl( slug ) ).to.equal( expected );
 	} );
 } );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -22,7 +22,6 @@ import purchasePaths from '../paths';
 import { removePurchase } from 'state/purchases/actions';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import userFactory from 'lib/user';
-import { slugToUrl } from 'lib/url';
 import { isOperatorsAvailable } from 'state/ui/olark/selectors';
 import olarkActions from 'lib/olark-store/actions';
 
@@ -138,7 +137,7 @@ const RemovePurchase = React.createClass( {
 				notices.success(
 					this.translate( '%(productName)s was removed from {{siteName/}}.', {
 						args: { productName },
-						components: { siteName: <em>{ slugToUrl( selectedSite.slug ) }</em> }
+						components: { siteName: <em>{ selectedSite.domain }</em> }
 					} ),
 					{ persistent: true }
 				);
@@ -312,7 +311,7 @@ const RemovePurchase = React.createClass( {
 							'Are you sure you want to remove %(productName)s from {{siteName/}}?',
 							{
 								args: { productName },
-								components: { siteName: <em>{ slugToUrl( this.props.selectedSite.slug ) }</em> }
+								components: { siteName: <em>{ this.props.selectedSite.domain }</em> }
 							}
 						)
 					}


### PR DESCRIPTION
Reverts #9207 and uses `site.domain` instead of the `slugToUrl` helper that was previously introduced. Props to @mtias for noticing this.

There should be no observable changes or regressions caused by this PR.

To test:

* Checkout this branch
* Purchase a plan for a Jetpack site which is installed in a subdirectory
* Go through the process of canceling the plan
* Verify the site slug is displayed with `/` and not with `::` in the "Are you sure you want to remove {PLAN} from {SLUG}" text in the removal step
* Verify the site slug is displayed with `/` and not with `::` in the "{PLAN} was removed from {SLUG}" text in the removal confirmation notice.

/cc @beaulebens @johnHackworth @mtias