### PR TITLE
ThemesSiteSelectorModal: Fix siteSlug value of null

### DIFF
--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -12,6 +12,7 @@ import mapValues from 'lodash/mapValues';
  */
 import Theme from 'components/theme';
 import SiteSelectorModal from 'components/site-selector-modal';
+import QuerySites from 'components/data/query-sites';
 import { trackClick } from './helpers';
 
 const OPTION_SHAPE = PropTypes.shape( {
@@ -39,8 +40,8 @@ const ThemesSiteSelectorModal = React.createClass( {
 	},
 
 	trackAndCallAction( site ) {
-		const action = this.state.selectedOption.action;
-		const theme = this.state.selectedTheme;
+		const { selectedOption: optionName, selectedTheme: theme } = this.state;
+		const action = this.props.options[ optionName ].action;
 
 		trackClick( 'site selector', this.props.name );
 		page( this.props.sourcePath + '/' + site.slug );
@@ -70,12 +71,12 @@ const ThemesSiteSelectorModal = React.createClass( {
 	 * but only if it also has a header, because the latter indicates it really needs
 	 * a site to be selected and doesn't work otherwise.
 	 */
-	wrapOption( option ) {
+	wrapOption( option, name ) {
 		return Object.assign(
 			{},
 			option,
 			option.action || ( option.getUrl && option.header )
-				? { action: theme => this.showSiteSelectorModal( option, theme ) }
+				? { action: theme => this.showSiteSelectorModal( name, theme ) }
 				: {},
 			option.getUrl && option.header
 				? { getUrl: null }
@@ -93,7 +94,8 @@ const ThemesSiteSelectorModal = React.createClass( {
 			} )
 		);
 
-		const { selectedOption, selectedTheme } = this.state;
+		const { selectedOption: selectedOptionName, selectedTheme } = this.state;
+		const selectedOption = this.props.options[ selectedOptionName ];
 
 		return (
 			<div>
@@ -109,7 +111,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 					getMainUrl={ selectedOption.getUrl ? function( site ) {
 						return selectedOption.getUrl( selectedTheme, site.ID );
 					} : null } >
-
+					<QuerySites allSites />
 					<Theme isActionable={ false } theme={ selectedTheme } />
 					<h1>{ selectedOption.header }</h1>
 				</SiteSelectorModal> }

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -109,7 +109,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 					mainAction={ this.trackAndCallAction }
 					mainActionLabel={ selectedOption.label }
 					getMainUrl={ selectedOption.getUrl ? function( site ) {
-						return selectedOption.getUrl( selectedTheme, site.ID );
+						return site && selectedOption.getUrl( selectedTheme, site.ID );
 					} : null } >
 					<QuerySites allSites />
 					<Theme isActionable={ false } theme={ selectedTheme } />

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -41,7 +41,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 
 	trackAndCallAction( site ) {
 		const { selectedOption: optionName, selectedTheme: theme } = this.state;
-		const action = this.props.options[ optionName ].action;
+		const { action } = this.props.options[ optionName ];
 
 		trackClick( 'site selector', this.props.name );
 		page( this.props.sourcePath + '/' + site.slug );


### PR DESCRIPTION
Fixes #9298.

The fix consists of two parts:
* Add a `<QuerySites />` component to `<ThemesSiteSelectorModal />` so that it fetches a user's sites from the network and populates the corresponding Redux state.
* Have `<ThemesSiteSelectorModal />` store only the current option's name (instead of the entire option object) in component state. This way, when Redux state updates, the component's `options` prop will update and cause a re-render with updated `getUrl` and `action` fields. 

To test:
* Verify that #9298 is fixed. (Also make sure to reproduce that issue on `master`. Remember to log out and in again each time or you won't be able to repro!)

cc @hoverduck 