### PR TITLE
Makes the $gray var less blue to increase contrast between blue and g…

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -5,9 +5,11 @@ $blue-medium:            #00aadc;
 $blue-dark:              #005082;
 
 // Grays
-$gray:                   #8F9EAE;
+$gray:                   #87a6bc;
 $gray-light:             lighten( $gray, 33% ); //#f3f6f8
 $gray-dark:              darken( $gray, 38% ); //#2e4453
+
+$gray-text:              #687582;
 
 // $gray color functions:
 // lighten( $gray, 10% )

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -5,7 +5,7 @@ $blue-medium:            #00aadc;
 $blue-dark:              #005082;
 
 // Grays
-$gray:                   #87a6bc;
+$gray:                   #8F9EAE;
 $gray-light:             lighten( $gray, 33% ); //#f3f6f8
 $gray-dark:              darken( $gray, 38% ); //#2e4453
 

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -9,7 +9,7 @@ $gray:                   #87a6bc;
 $gray-light:             lighten( $gray, 33% ); //#f3f6f8
 $gray-dark:              darken( $gray, 38% ); //#2e4453
 
-$gray-text:              #687582;
+$gray-text:              darken( $gray, 18% ); //#537994
 
 // $gray color functions:
 // lighten( $gray, 10% )


### PR DESCRIPTION
…ray elements

Carrying on from https://github.com/Automattic/wp-calypso/pull/9031 let's look at our `$gray` color first.

The purpose of this change is twofold;

* Create more contrast in the Calypso color scheme / UI (basically; make the gray more _gray_ and less _blue_)
* Build a foundation from which we can begin addressing the wider color contrast and accessibility issues

The proposed hex for the updated gray is `#8F9EAE` which was suggested by @drw158 and looks pretty good to me, but we can definitely tweak. It still might be a _little_ too blue.

Before;

![before](https://cldup.com/wjoWPAHpDM.png)

After;

![after](https://cldup.com/0SEm0XF-ry-2000x2000.png)

Palette based on` #8F9EAE`;

![palette](https://cldup.com/SgWaROP0HY.png)

cc @folletto @mtias 