### PR TITLE
Taxonomies: Adding the possibility to delete terms from the taxonomies settings page

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -17,10 +17,11 @@ class TaxonomyManagerListItem extends Component {
 		name: PropTypes.string,
 		translate: PropTypes.func,
 		onClick: PropTypes.func,
+		onDelete: PropTypes.func,
 	};
 
 	static defaultProps = {
-		onClick: () => {}
+		onClick: () => {},
 	};
 
 	constructor( props ) {
@@ -44,8 +45,15 @@ class TaxonomyManagerListItem extends Component {
 		this.props.onClick();
 	};
 
+	deleteItem= () => {
+		this.setState( {
+			popoverMenuOpen: false
+		} );
+		this.props.onDelete();
+	};
+
 	render() {
-		const { name, translate } = this.props;
+		const { onDelete, name, translate } = this.props;
 
 		return (
 			<div>
@@ -68,10 +76,12 @@ class TaxonomyManagerListItem extends Component {
 						<Gridicon icon="pencil" size={ 18 } />
 						{ translate( 'Edit' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem>
-						<Gridicon icon="trash" size={ 18 } />
-						{ translate( 'Delete' ) }
-					</PopoverMenuItem>
+					{ onDelete &&
+						<PopoverMenuItem onClick={ this.deleteItem }>
+							<Gridicon icon="trash" size={ 18 } />
+							{ translate( 'Delete' ) }
+						</PopoverMenuItem>
+					}
 					<PopoverMenuItem>
 						<Gridicon icon="external" size={ 18 } />
 						{ translate( 'View Posts' ) }

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { has, get, includes, isEqual, omit, some } from 'lodash';
+import { filter, find, has, get, includes, isEqual, omit, some } from 'lodash';
 import createSelector from 'lib/create-selector';
 import moment from 'moment-timezone';
 
@@ -445,4 +445,11 @@ export function getPostPreviewUrl( state, siteId, postId ) {
 	}
 
 	return previewUrl;
+}
+
+export function getSitePostsByTerm( state, siteId, taxonomy, termId ) {
+	return filter( getSitePosts( state, siteId ), post => {
+		return post.terms && post.terms[ taxonomy ] &&
+			find( post.terms[ taxonomy ], postTerm => postTerm.ID === termId );
+	} );
 }

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -26,7 +26,8 @@ import {
 	getEditedPostValue,
 	getEditedPostSlug,
 	isEditedPostDirty,
-	getPostPreviewUrl
+	getPostPreviewUrl,
+	getSitePostsByTerm
 } from '../selectors';
 import PostQueryManager from 'lib/query-manager/post';
 
@@ -1686,6 +1687,44 @@ describe( 'selectors', () => {
 			}, 2916284, 841 );
 
 			expect( slug ).to.eql( '' );
+		} );
+	} );
+
+	describe( 'getSitePostsByTerm()', () => {
+		it( 'should return an array of post objects for the site matching the termId', () => {
+			const postObjects = {
+				2916284: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64': {
+						ID: 841,
+						site_ID: 2916284,
+						global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+						title: 'Hello World',
+						terms: {
+							category: [
+								{ ID: 10 }
+							]
+						}
+					},
+					'6c831c187ffef321eb43a67761a525a3': {
+						ID: 413,
+						site_ID: 2916284,
+						global_ID: '6c831c187ffef321eb43a67761a525a3',
+						title: 'Ribs &amp; Chicken'
+					}
+				}
+			};
+			const state = {
+				posts: {
+					queries: {
+						2916284: new PostQueryManager( {
+							items: postObjects[ 2916284 ]
+						} )
+					},
+				}
+			};
+
+			expect( getSitePostsByTerm( state, 2916284, 'category', 10 ) )
+				.to.have.members( [ postObjects[ 2916284 ][ '3d097cb7c5473c169bba0eb8e3c6cb64' ] ] );
 		} );
 	} );
 } );

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -16,7 +16,7 @@ import {
 } from 'state/action-types';
 import { editPost } from 'state/posts/actions';
 import { getSitePosts } from 'state/posts/selectors';
-import { getTerms } from './selectors';
+import { getTerm, getTerms } from './selectors';
 
 /**
  * Returns an action thunk, dispatching progress of a request to add a new term
@@ -89,6 +89,53 @@ export function updateTerm( siteId, taxonomy, termId, termSlug, term ) {
 				} );
 
 				return updatedTerm;
+			}
+		);
+	};
+}
+
+/**
+ * Returns an action thunk, deleting a term and removing it from the store
+ *
+ * @param  {Number} siteId   Site ID
+ * @param  {String} taxonomy Taxonomy Slug
+ * @param  {Number} termId   term Id
+ * @param  {String} termSlug term Slug
+ * @return {Object}          Action object
+ */
+export function deleteTerm( siteId, taxonomy, termId, termSlug ) {
+	return ( dispatch, getState ) => {
+		return wpcom.site( siteId ).taxonomy( taxonomy ).term( termSlug ).delete().then(
+			() => {
+				const state = getState();
+				const deletedTerm = getTerm( state, siteId, taxonomy, termId );
+
+				// Update the parentId of its children
+				const termsToUpdate = filter( getTerms( state, siteId, taxonomy ), term => {
+					return term.parent === termId;
+				} ).map( term => {
+					return { ...term, parent: deletedTerm.parent };
+				} );
+				if ( termsToUpdate.length ) {
+					dispatch( receiveTerms( siteId, taxonomy, termsToUpdate ) );
+				}
+
+				// Drop the term from posts
+				const postsToUpdate = filter( getSitePosts( getState(), siteId ), post => {
+					return post.terms && post.terms[ taxonomy ] &&
+						find( post.terms[ taxonomy ], postTerm => postTerm.ID === termId );
+				} );
+				postsToUpdate.forEach( post => {
+					const newTerms = filter( post.terms[ taxonomy ], postTerm => postTerm.ID !== termId );
+					dispatch( editPost( siteId, post.ID, {
+						terms: {
+							[ taxonomy ]: newTerms
+						}
+					} ) );
+				} );
+
+				// remove the term from the store
+				dispatch( removeTerm( siteId, taxonomy, termId ) );
 			}
 		);
 	};

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, uniqueId, find } from 'lodash';
+import { filter, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ import {
 	TERMS_REQUEST_FAILURE
 } from 'state/action-types';
 import { editPost } from 'state/posts/actions';
-import { getSitePosts } from 'state/posts/selectors';
+import { getSitePostsByTerm } from 'state/posts/selectors';
 import { getTerm, getTerms } from './selectors';
 
 /**
@@ -73,11 +73,7 @@ export function updateTerm( siteId, taxonomy, termId, termSlug, term ) {
 				dispatch( receiveTerms( siteId, taxonomy, children.concat( [ updatedTerm ] ) ) );
 
 				// We also have to update post terms
-				const postsToUpdate = filter( getSitePosts( state, siteId ), post => {
-					return post.terms && post.terms[ taxonomy ] &&
-						find( post.terms[ taxonomy ], postTerm => postTerm.ID === termId );
-				} );
-
+				const postsToUpdate = getSitePostsByTerm( state, siteId, taxonomy, termId );
 				postsToUpdate.forEach( post => {
 					const newTerms = filter( post.terms[ taxonomy ], postTerm => postTerm.ID !== termId );
 					newTerms.push( updatedTerm );
@@ -121,10 +117,7 @@ export function deleteTerm( siteId, taxonomy, termId, termSlug ) {
 				}
 
 				// Drop the term from posts
-				const postsToUpdate = filter( getSitePosts( getState(), siteId ), post => {
-					return post.terms && post.terms[ taxonomy ] &&
-						find( post.terms[ taxonomy ], postTerm => postTerm.ID === termId );
-				} );
+				const postsToUpdate = getSitePostsByTerm( state, siteId, taxonomy, termId );
 				postsToUpdate.forEach( post => {
 					const newTerms = filter( post.terms[ taxonomy ], postTerm => postTerm.ID !== termId );
 					dispatch( editPost( siteId, post.ID, {


### PR DESCRIPTION
When we delete a term, we make sure we update the related posts and drop this term from their terms list.

We also update the parent ID of the term's children.

**testing instructions**
- Go to the /settings/taxonomies/$site/category page
- Try to delete a category which has children
- The parent category of these terms should be updated to the parent term of the deleted category
- Try to delete a category related to a post
- The post categories should be updated and this category dropped from them
- Try to delete tags

cc @timmyc 