### PR TITLE
Theme Showcase: Automated tests for SSR

### DIFF
--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -5,6 +5,7 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { map, pickBy } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ const CurrentTheme = React.createClass( {
 	trackClick: trackClick.bind( null, 'current theme' ),
 
 	render() {
-		const { currentTheme, siteId } = this.props,
+		const { currentTheme, siteId, translate } = this.props,
 			placeholderText = <span className="current-theme__placeholder">loading...</span>,
 			text = ( currentTheme && currentTheme.name ) ? currentTheme.name : placeholderText;
 
@@ -49,7 +50,7 @@ const CurrentTheme = React.createClass( {
 				{ siteId && <QueryCurrentTheme siteId={ siteId } /> }
 				<div className="current-theme__current">
 					<span className="current-theme__label">
-						{ this.translate( 'Current Theme' ) }
+						{ translate( 'Current Theme' ) }
 					</span>
 					<span className="current-theme__name">
 						{ text }
@@ -90,4 +91,4 @@ export default connect(
 	( state, { siteId } ) => ( {
 		currentTheme: getCurrentTheme( state, siteId )
 	} )
-)( CurrentThemeWithOptions );
+)( localize( CurrentThemeWithOptions ) );

--- a/client/my-sites/themes/jetpack-manage-disabled-message.jsx
+++ b/client/my-sites/themes/jetpack-manage-disabled-message.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import noop from 'lodash/noop';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import ThemesList from 'components/themes-list';
 
-export default React.createClass( {
+const JetpackManageDisabledMessage = React.createClass( {
 	displayName: 'JetpackManageDisabledMessage',
 
 	propTypes: {
@@ -60,10 +61,10 @@ export default React.createClass( {
 				<SidebarNavigation />
 				<JetpackManageErrorPage
 					template="optInManage"
-					title={ this.translate( 'Looking to manage this site\'s themes?' ) }
+					title={ this.props.translate( 'Looking to manage this site\'s themes?' ) }
 					site={ this.props.site }
 					section="themes"
-					secondaryAction={ this.translate( 'Open Site Theme Browser' ) }
+					secondaryAction={ this.props.translate( 'Open Site Theme Browser' ) }
 					secondaryActionURL={ this.props.site.options.admin_url + 'themes.php' }
 					secondaryActionTarget="_blank"
 					actionCallback={ this.clickOnActivate }
@@ -72,3 +73,5 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default localize( JetpackManageDisabledMessage );

--- a/client/my-sites/themes/jetpack-upgrade-message.jsx
+++ b/client/my-sites/themes/jetpack-upgrade-message.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
-export default React.createClass( {
+const JetpackUpgradeMessage = React.createClass( {
 	propTypes: {
 		site: PropTypes.object
 	},
@@ -23,7 +24,7 @@ export default React.createClass( {
 					template="updateJetpack"
 					site={ this.props.site }
 					version="3.7"
-					secondaryAction={ this.translate( 'Open Site Theme Browser' ) }
+					secondaryAction={ this.props.translate( 'Open Site Theme Browser' ) }
 					secondaryActionURL={ this.props.site.options.admin_url + 'themes.php' }
 					secondaryActionTarget="_blank"
 				/>
@@ -31,3 +32,5 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default localize( JetpackUpgradeMessage );

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -17,6 +17,12 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'state';
 import EmptyComponent from 'test/helpers/react/empty-component';
 import useMockery from 'test/helpers/use-mockery';
+import {
+	incrementThemesPage,
+	query,
+	receiveThemes,
+	receiveServerError
+} from 'state/themes/actions';
 
 describe( 'logged-out', () => {
 	context( 'when calling renderToString()', function() {
@@ -27,17 +33,107 @@ describe( 'logged-out', () => {
 			mockery.registerMock( 'lib/analytics/page-view-tracker', EmptyComponent );
 
 			this.LoggedOutShowcase = require( '../logged-out' );
+
+			this.themes = [
+				{
+					author: 'AudioTheme',
+					id: 'wayfarer',
+					stylesheet: 'premium/wayfarer',
+					name: 'Wayfarer',
+					author_uri: 'https://audiotheme.com/',
+					demo_uri: 'https://wayfarerdemo.wordpress.com/',
+					screenshot: 'https://i1.wp.com/theme.wordpress.com/wp-content/themes/premium/wayfarer/screenshot.png',
+					price: '$69'
+				},
+				{
+					author: 'Organic Themes',
+					id: 'natural',
+					stylesheet: 'premium/natural',
+					name: 'Natural',
+					author_uri: 'http://www.organicthemes.com',
+					demo_uri: 'https://naturaldemo.wordpress.com/',
+					screenshot: 'https://i2.wp.com/theme.wordpress.com/wp-content/themes/premium/natural/screenshot.png',
+					price: '$69'
+				},
+				{
+					author: 'Press75',
+					id: 'attache',
+					stylesheet: 'premium/attache',
+					name: 'Attache',
+					author_uri: 'http://www.press75.com/',
+					demo_uri: 'https://attachedemo.wordpress.com/',
+					screenshot: 'https://i0.wp.com/theme.wordpress.com/wp-content/themes/premium/attache/screenshot.png',
+					price: '$69'
+				},
+				{
+					author: 'Anariel Design',
+					id: 'pena',
+					stylesheet: 'premium/pena',
+					name: 'Pena',
+					author_uri: 'http://theme.wordpress.com/themes/by/anariel-design/',
+					demo_uri: 'https://penademo.wordpress.com/',
+					screenshot: 'https://i2.wp.com/theme.wordpress.com/wp-content/themes/premium/pena/screenshot.png',
+					price: '$89'
+				},
+				{
+					author: 'Automattic',
+					id: 'karuna',
+					stylesheet: 'pub/karuna',
+					name: 'Karuna',
+					author_uri: 'http://wordpress.com/themes/',
+					demo_uri: 'https://karunademo.wordpress.com/',
+					screenshot: 'https://i1.wp.com/theme.wordpress.com/wp-content/themes/pub/karuna/screenshot.png'
+				}
+			];
+
+			this.queryParams = { perPage: 5, page: 1, filter: '', id: 1 };
 		} );
 
-		it( 'renders', () => {
-			const store = createReduxStore();
-			const layout = (
-				<ReduxProvider store={ store }>
+		beforeEach( () => {
+			this.store = createReduxStore();
+
+			this.layout = (
+				<ReduxProvider store={ this.store }>
 					<this.LoggedOutShowcase />
 				</ReduxProvider>
 			);
+		} );
 
-			assert.doesNotThrow( () => renderToString( layout ) );
+		it( 'renders without error when no themes are present', () => {
+			let markup;
+			assert.doesNotThrow( () => {
+				markup = renderToString( this.layout );
+			} );
+			// Should show a "No themes found" message
+			assert.isTrue( markup.includes( 'empty-content' ) );
+		} );
+
+		it( 'renders without error when themes are present', () => {
+			this.store.dispatch( query( this.queryParams ) );
+			this.store.dispatch( incrementThemesPage( false ) );
+			this.store.dispatch( receiveThemes( { themes: this.themes }, false, this.queryParams ) );
+
+			let markup;
+			assert.doesNotThrow( () => {
+				markup = renderToString( this.layout );
+			} );
+			// All 5 themes should appear...
+			assert.equal( 5, markup.match( /theme__content/g ).length );
+			// .. and no empty content placeholders should appear
+			assert.isFalse( markup.includes( 'empty-content' ) );
+		} );
+
+		it( 'renders without error when theme fetch fails', () => {
+			this.store.dispatch( query( this.queryParams ) );
+			this.store.dispatch( incrementThemesPage( false ) );
+			this.store.dispatch( receiveServerError( 'Error' ) );
+
+			let markup;
+			assert.doesNotThrow( () => {
+				markup = renderToString( this.layout );
+			} );
+			// Should show a "No themes found" message
+			assert.isTrue( markup.includes( 'empty-content' ) );
 		} );
 	} );
 } );

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -1,0 +1,43 @@
+/**
+ * Tests for controller.jsx
+ */
+
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import { assert } from 'chai';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { Provider as ReduxProvider } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { createReduxStore } from 'state';
+import EmptyComponent from 'test/helpers/react/empty-component';
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'logged-out', () => {
+	context( 'when calling renderToString()', function() {
+		useMockery( mockery => {
+			mockery.registerMock( 'lib/analytics', noop );
+			mockery.registerMock( './theme-preview', EmptyComponent );
+			mockery.registerMock( 'components/popover', EmptyComponent );
+			mockery.registerMock( 'lib/analytics/page-view-tracker', EmptyComponent );
+
+			this.LoggedOutShowcase = require( '../logged-out' );
+		} );
+
+		it( 'renders', () => {
+			const store = createReduxStore();
+			const layout = (
+				<ReduxProvider store={ store }>
+					<this.LoggedOutShowcase />
+				</ReduxProvider>
+			);
+
+			assert.doesNotThrow( () => renderToString( layout ) );
+		} );
+	} );
+} );

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import find from 'lodash/find';
 import debounce from 'lodash/debounce';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -89,7 +90,7 @@ const ThemesSearchCard = React.createClass( {
 							path={ getExternalThemesUrl( this.props.site ) }
 							onClick={ this.onMore }
 							isExternalLink={ true }>
-							{ this.translate( 'More' ) + ' ' }
+							{ this.props.translate( 'More' ) + ' ' }
 						</NavItem> }
 					</NavTabs>
 
@@ -99,7 +100,7 @@ const ThemesSearchCard = React.createClass( {
 						onSearch={ this.props.onSearch }
 						initialValue={ this.props.search }
 						ref="url-search"
-						placeholder={ this.translate( 'Search themes…' ) }
+						placeholder={ this.props.translate( 'Search themes…' ) }
 						analyticsGroup="Themes"
 						delaySearch={ true }
 					/>
@@ -113,9 +114,9 @@ const ThemesSearchCard = React.createClass( {
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
 
 		const tiers = [
-			{ value: 'all', label: this.translate( 'All' ) },
-			{ value: 'free', label: this.translate( 'Free' ) },
-			{ value: 'premium', label: this.translate( 'Premium' ) },
+			{ value: 'all', label: this.props.translate( 'All' ) },
+			{ value: 'free', label: this.props.translate( 'Free' ) },
+			{ value: 'premium', label: this.props.translate( 'Premium' ) },
 		];
 
 		if ( this.state.isMobile ) {
@@ -128,7 +129,7 @@ const ThemesSearchCard = React.createClass( {
 					onSearch={ this.props.onSearch }
 					initialValue={ this.props.search }
 					ref="url-search"
-					placeholder={ this.translate( 'What kind of theme are you looking for?' ) }
+					placeholder={ this.props.translate( 'What kind of theme are you looking for?' ) }
 					analyticsGroup="Themes"
 					delaySearch={ true }
 				/>
@@ -143,11 +144,11 @@ const ThemesSearchCard = React.createClass( {
 												rel="noopener noreferrer"
 												onClick={ this.onMore }>
 
-												{ this.translate( 'More' ) }
+												{ this.props.translate( 'More' ) }
 											</a> }
 			</div>
 		);
 	}
 } );
 
-export default ThemesSearchCard;
+export default localize( ThemesSearchCard );


### PR DESCRIPTION
Adds smoke tests for the Logged Out view of the Theme Showcase. This is the only view of the showcase that renders server-side.

Tests are modeled off of the Theme Sheet tests: https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/theme/test/main.jsx

The four non-test files updated are just a migration from the localize mixin to the HoC, because CircleCI was complaining about `this.translate`.