### PR TITLE
Jetpack Plans: Support monthly billing cycle in purchase detail page

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -55,6 +55,7 @@ import support from 'lib/url/support';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
 import * as upgradesActions from 'lib/upgrades/actions';
+import { isMonthly } from 'lib/plans/constants';
 
 const user = userFactory();
 
@@ -274,7 +275,7 @@ const ManagePurchase = React.createClass( {
 
 	renderPrice() {
 		const purchase = getPurchase( this.props ),
-			{ amount, currencyCode, currencySymbol } = purchase;
+			{ amount, currencyCode, currencySymbol, productSlug } = purchase;
 
 		if ( isOneTimePurchase( purchase ) ) {
 			return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}(one-time){{/period}}', {
@@ -289,8 +290,13 @@ const ManagePurchase = React.createClass( {
 			return this.translate( 'Free with Plan' );
 		}
 
-		return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}/ year{{/period}}', {
-			args: { amount, currencyCode, currencySymbol },
+		return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
+			args: {
+				amount,
+				currencyCode,
+				currencySymbol,
+				period: productSlug && isMonthly( productSlug ) ? 'month' : 'year'
+			},
 			components: {
 				period: <span className="manage-purchase__time-period" />
 			}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -273,27 +273,10 @@ const ManagePurchase = React.createClass( {
 		page( '/checkout/' + this.props.selectedSite.slug );
 	},
 
-	renderPricePerPeriod() {
+	renderPrice() {
 		const purchase = getPurchase( this.props ),
 			{ amount, currencyCode, currencySymbol, productSlug } = purchase,
 			period = productSlug && isMonthly( productSlug ) ? this.translate( 'month' ) : this.translate( 'year' );
-
-		return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
-			args: {
-				amount,
-				currencyCode,
-				currencySymbol,
-				period
-			},
-			components: {
-				period: <span className="manage-purchase__time-period" />
-			}
-		} );
-	},
-
-	renderPrice() {
-		const purchase = getPurchase( this.props ),
-			{ amount, currencyCode, currencySymbol } = purchase;
 
 		if ( isOneTimePurchase( purchase ) ) {
 			return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}(one-time){{/period}}', {
@@ -308,7 +291,17 @@ const ManagePurchase = React.createClass( {
 			return this.translate( 'Free with Plan' );
 		}
 
-		return this.renderPricePerPeriod();
+		return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
+			args: {
+				amount,
+				currencyCode,
+				currencySymbol,
+				period
+			},
+			components: {
+				period: <span className="manage-purchase__time-period" />
+			}
+		} );
 	},
 
 	renderPaymentInfo() {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -273,9 +273,27 @@ const ManagePurchase = React.createClass( {
 		page( '/checkout/' + this.props.selectedSite.slug );
 	},
 
+	renderPricePerPeriod() {
+		const purchase = getPurchase( this.props ),
+			{ amount, currencyCode, currencySymbol, productSlug } = purchase,
+			period = productSlug && isMonthly( productSlug ) ? this.translate( 'month' ) : this.translate( 'year' );
+
+		return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
+			args: {
+				amount,
+				currencyCode,
+				currencySymbol,
+				period
+			},
+			components: {
+				period: <span className="manage-purchase__time-period" />
+			}
+		} );
+	},
+
 	renderPrice() {
 		const purchase = getPurchase( this.props ),
-			{ amount, currencyCode, currencySymbol, productSlug } = purchase;
+			{ amount, currencyCode, currencySymbol } = purchase;
 
 		if ( isOneTimePurchase( purchase ) ) {
 			return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}(one-time){{/period}}', {
@@ -290,17 +308,7 @@ const ManagePurchase = React.createClass( {
 			return this.translate( 'Free with Plan' );
 		}
 
-		return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
-			args: {
-				amount,
-				currencyCode,
-				currencySymbol,
-				period: productSlug && isMonthly( productSlug ) ? this.translate( 'month' ) : this.translate( 'year' )
-			},
-			components: {
-				period: <span className="manage-purchase__time-period" />
-			}
-		} );
+		return this.renderPricePerPeriod();
 	},
 
 	renderPaymentInfo() {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -295,7 +295,7 @@ const ManagePurchase = React.createClass( {
 				amount,
 				currencyCode,
 				currencySymbol,
-				period: productSlug && isMonthly( productSlug ) ? 'month' : 'year'
+				period: productSlug && isMonthly( productSlug ) ? this.translate( 'month' ) : this.translate( 'year' )
 			},
 			components: {
 				period: <span className="manage-purchase__time-period" />


### PR DESCRIPTION
This PR fixes #9344, where the monthly plans are not supported properly when displaying the plan price. 

To test:

* Checkout this branch.
* Load `/me/purchases/$site/`, where `$site` is one of your Jetpack sites that has a paid monthly plan.
* Click the monthly plan purchase.
* Verify it displays `{price}` / month instead of `{price}` / year (where `{price}` is the monthly price of the plan).
* Load `/me/purchases/$site/`, where `$site` is one of your Jetpack sites that has a paid yearly plan.
* Click the yearly plan purchase.
* Verify it displays `{price}` / year like it did before.

/cc @johnHackworth @rickybanister 