### PR TITLE
Site Settings: Position site icon setting to left of title, tagline

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -129,32 +129,34 @@ const FormGeneral = React.createClass( {
 
 	siteOptions() {
 		return (
-			<div>
-				<FormFieldset>
-					<FormLabel htmlFor="blogname">{ this.translate( 'Site Title' ) }</FormLabel>
-					<FormInput
-						name="blogname"
-						id="blogname"
-						type="text"
-						valueLink={ this.linkState( 'blogname' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.onRecordEvent( 'Clicked Site Title Field' ) }
-						onKeyPress={ this.onRecordEventOnce( 'typedTitle', 'Typed in Site Title Field' ) } />
-				</FormFieldset>
-				<FormFieldset>
-					<FormLabel htmlFor="blogdescription">{ this.translate( 'Site Tagline' ) }</FormLabel>
-					<FormInput
-						name="blogdescription"
-						type="text"
-						id="blogdescription"
-						valueLink={ this.linkState( 'blogdescription' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.onRecordEvent( 'Clicked Site Site Tagline Field' ) }
-						onKeyPress={ this.onRecordEventOnce( 'typedTagline', 'Typed in Site Site Tagline Field' ) } />
-					<FormSettingExplanation>
-						{ this.translate( 'In a few words, explain what this site is about.' ) }
-					</FormSettingExplanation>
-				</FormFieldset>
+			<div className="site-settings__site-options">
+				<div className="site-settings__site-title-tagline">
+					<FormFieldset>
+						<FormLabel htmlFor="blogname">{ this.translate( 'Site Title' ) }</FormLabel>
+						<FormInput
+							name="blogname"
+							id="blogname"
+							type="text"
+							valueLink={ this.linkState( 'blogname' ) }
+							disabled={ this.state.fetchingSettings }
+							onClick={ this.onRecordEvent( 'Clicked Site Title Field' ) }
+							onKeyPress={ this.onRecordEventOnce( 'typedTitle', 'Typed in Site Title Field' ) } />
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="blogdescription">{ this.translate( 'Site Tagline' ) }</FormLabel>
+						<FormInput
+							name="blogdescription"
+							type="text"
+							id="blogdescription"
+							valueLink={ this.linkState( 'blogdescription' ) }
+							disabled={ this.state.fetchingSettings }
+							onClick={ this.onRecordEvent( 'Clicked Site Site Tagline Field' ) }
+							onKeyPress={ this.onRecordEventOnce( 'typedTagline', 'Typed in Site Site Tagline Field' ) } />
+						<FormSettingExplanation>
+							{ this.translate( 'In a few words, explain what this site is about.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+				</div>
 				<SiteIconSetting />
 			</div>
 		);

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -53,7 +53,7 @@ function SiteIconSetting( { translate, siteId, isJetpack, customizerUrl, general
 				{ ...buttonProps }
 				className="site-icon-setting__change-button"
 				compact>
-				{ translate( 'Change' ) }
+				{ translate( 'Change', { context: 'verb' } ) }
 			</Button>
 		</FormFieldset>
 	);

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -15,12 +15,16 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { isEnabled } from 'config';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import InfoPopover from 'components/info-popover';
 import { addQueryArgs } from 'lib/url';
 
 function SiteIconSetting( { translate, siteId, isJetpack, customizerUrl, generalOptionsUrl } ) {
 	let buttonProps;
-	if ( ! isEnabled( 'manage/site-settings/site-icon' ) ) {
+	if ( isEnabled( 'manage/site-settings/site-icon' ) ) {
+		buttonProps = {
+			type: 'button'
+		};
+	} else {
 		buttonProps = { rel: 'external' };
 
 		if ( isJetpack ) {
@@ -35,16 +39,22 @@ function SiteIconSetting( { translate, siteId, isJetpack, customizerUrl, general
 
 	return (
 		<FormFieldset className="site-icon-setting">
-			<FormLabel>{ translate( 'Site Icon' ) }</FormLabel>
-			<div className="site-icon-setting__controls">
-				<SiteIcon size={ 64 } siteId={ siteId } />
-				<Button { ...buttonProps } className="site-icon-setting__change-button">
-					{ translate( 'Change site icon' ) }
-				</Button>
-			</div>
-			<FormSettingExplanation>
-				{ translate( 'The Site Icon is used as a browser and app icon for your site.' ) }
-			</FormSettingExplanation>
+			<FormLabel className="site-icon-setting__heading">
+				{ translate( 'Site Icon' ) }
+				<InfoPopover position="bottom right">
+					{ translate( 'A browser and app icon for your site.' ) }
+				</InfoPopover>
+			</FormLabel>
+			{ React.createElement( buttonProps.href ? 'a' : 'button', {
+				...buttonProps,
+				className: 'site-icon-setting__icon'
+			}, <SiteIcon size={ 96 } siteId={ siteId } /> ) }
+			<Button
+				{ ...buttonProps }
+				className="site-icon-setting__change-button"
+				compact>
+				{ translate( 'Change' ) }
+			</Button>
 		</FormFieldset>
 	);
 }

--- a/client/my-sites/site-settings/site-icon-setting/style.scss
+++ b/client/my-sites/site-settings/site-icon-setting/style.scss
@@ -1,8 +1,24 @@
-.site-icon-setting__controls {
+.form-label.site-icon-setting__heading {
 	display: flex;
 	align-items: center;
+
+	.info-popover {
+		margin-left: 8px;
+	}
+
+	.gridicon {
+		display: block;
+	}
+}
+
+.site-icon-setting__icon:hover .site-icon {
+	border-style: dashed;
+	border-color: $gray-dark;
+	opacity: 0.8;
 }
 
 .site-icon-setting__change-button {
-	margin-left: 8px;
+	min-width: 98px;
+	margin-top: 8px;
+	text-align: center;
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -144,7 +144,34 @@
 	}
 
 	fieldset.site-icon-setting {
-		margin-bottom: 24px;
+		@include breakpoint( ">660px" ) {
+			flex: 0 0 122px;
+			order: 1;
+			margin-bottom: 0;
+			padding-right: 24px;
+		}
+	}
+
+	.site-icon-setting__heading {
+		@include breakpoint( ">660px" ) {
+			justify-content: space-between;
+			white-space: nowrap;
+		}
+	}
+}
+
+.site-settings__site-options {
+	padding-bottom: 24px;
+
+	@include breakpoint( ">660px" ) {
+		display: flex;
+	}
+}
+
+.site-settings__site-title-tagline {
+	@include breakpoint( ">660px" ) {
+		flex: 0 1 100%;
+		order: 2;
 	}
 }
 


### PR DESCRIPTION
This pull request seeks to reposition the site settings icon field to be floated left of the title and tagline fields for larger viewports.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/20272911/6afdf8f4-aa5d-11e6-8e48-39b2979bc890.png)|![After](https://cloud.githubusercontent.com/assets/1779930/20448065/1b469fae-adb0-11e6-89bc-ece428a37800.png)

__Testing instructions:__

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Note that the site icon field is floated to the left of title, tagline fields

cc @mtias 