### PR TITLE
Media: Fix argument signature on media markup

### DIFF
--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -175,10 +175,11 @@ Markup = {
 		 * Given an audio media object, returns a markup string representing that
 		 * audio object as HTML.
 		 *
+		 * @param  {Object} site  A site object
 		 * @param  {Object} media An audio media object
 		 * @return {string}       An audio markup string
 		 */
-		audio: function( media ) {
+		audio: function( site, media ) {
 			return Shortcode.stringify( {
 				tag: 'audio',
 				attrs: {
@@ -191,10 +192,11 @@ Markup = {
 		 * Given a video media object, returns a markup string representing that
 		 * video object as HTML.
 		 *
+		 * @param  {Object} site  A site object
 		 * @param  {string} media A video media object
 		 * @return {string}       A video markup string
 		 */
-		video: function( media ) {
+		video: function( site, media ) {
 			if ( MediaUtils.isVideoPressItem( media ) ) {
 				return Shortcode.stringify( {
 					tag: 'wpvideo',

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -252,7 +252,7 @@ describe( 'markup', function() {
 
 		describe( '#audio()', function() {
 			it( 'should return an `audio` shortcode for an audio item', function() {
-				var value = markup.mimeTypes.audio( {
+				var value = markup.mimeTypes.audio( site, {
 					URL: 'http://example.com/wp-content/uploads/2015/06/loop.mp3'
 				} );
 
@@ -262,7 +262,7 @@ describe( 'markup', function() {
 
 		describe( '#video()', function() {
 			it( 'should return a `wpvideo` shortcode for a VideoPress video', function() {
-				var value = markup.mimeTypes.video( {
+				var value = markup.mimeTypes.video( site, {
 					videopress_guid: '11acMj3O'
 				} );
 
@@ -270,7 +270,7 @@ describe( 'markup', function() {
 			} );
 
 			it( 'should return a `video` shortcode for a video', function() {
-				var value = markup.mimeTypes.video( {
+				var value = markup.mimeTypes.video( site, {
 					URL: 'http://example.com/wp-content/uploads/2015/06/loop.mp4',
 					height: 454,
 					width: 1436


### PR DESCRIPTION
Fixes #9349 
Related: #8448

This pull request seeks to resolve an issue where inserting a video or audio into a post inserts invalid shortcode markup, since the argument signature for these methods was changed in #8448 but not applied to video or audio.

__Testing instructions__

Repeat steps to reproduce in #8448

cc @kriskarkoski @youknowriad 