### PR TITLE
Reader: Fix the sizing of audio elements

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -65,6 +65,12 @@
 		}
 	}
 
+	audio {
+		display: block;
+		width: 90%;
+		margin: 24px auto;
+	}
+
 	iframe[class^="twitter-"],
 	iframe[class^="instagram-"],
 	.fb_iframe_widget {

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -67,7 +67,7 @@
 
 	audio {
 		display: block;
-		width: 90%;
+		width: 100%;
 		margin: 24px auto;
 	}
 


### PR DESCRIPTION
Force to centered block elements. Chrome defaults them to inline, which ends up stacking in odd ways.

Fixes #8690 

before
<img width="801" alt="_jan_cavan_boulas_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/20274753/c53b6bca-aa63-11e6-9e4e-daad97ff7dbb.png">

after
<img width="800" alt="_jan_cavan_boulas_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/20274742/b8dd785a-aa63-11e6-9477-5ea6b413fef6.png">
