### PR TITLE
Editor: fix edit galleries button

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -17,7 +17,7 @@ import closest from 'component-closest';
 import SiteListFactory from 'lib/sites-list';
 import PostActions from 'lib/posts/actions';
 import PostEditStore from 'lib/posts/post-edit-store';
-import MediaConstants from 'lib/media/constants';
+import * as MediaConstants from 'lib/media/constants';
 import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
 import { deserialize } from 'lib/media-serialization';


### PR DESCRIPTION
Related: #8448 

This PR fixes a bug about the edit gallery button. the MediaConstants were not imported correctly.

**Testing instructions**

 - Create a gallery on the editor
 - Click the "Edit" Button on this gallery
 - It should open the dialog to edit the gallery

cc @aduth 

