### PR TITLE
Reader: Make sure the background url is safe

### DIFF
--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -4,12 +4,21 @@
 import React from 'react';
 import { map, take } from 'lodash';
 
+/**
+ * Internal Dependencies
+ */
+import resizeImageUrl from 'lib/resize-image-url';
+
+const GALLERY_ITEM_WIDTH = 206;
+
 const PostGallery = ( { post } ) => {
 	const numberOfImagesToDisplay = 4;
 	const imagesToDisplay = take( post.content_images, numberOfImagesToDisplay );
 	const listItems = map( imagesToDisplay, ( image, index ) => {
+		const imageUrl = resizeImageUrl( image.src, { w: GALLERY_ITEM_WIDTH } );
+		const safeCssUrl = imageUrl.replace( ')', '\\)' ).replace( '(', '\\(' );
 		const imageStyle = {
-			backgroundImage: 'url(' + image.src + ')',
+			backgroundImage: 'url(' + safeCssUrl + ')',
 			backgroundSize: 'cover',
 			backgroundPosition: '50% 50%',
 			backgroundRepeat: 'no-repeat'


### PR DESCRIPTION
Have to escape ( and ) in the actual URL before inserting it into the backgroundImagge property.

Also, take this opportunity to resize the gallery items down a bit. Helps with animation speed on gifs and bandwidth otherwise.

To test, try 
https://wpcalypso.wordpress.com/read/feeds/55576197 (broken) vs 
https://calypso.live/read/feeds/55576197?branch=fix/reader/9123 (fixed)