### PR TITLE
Reader: Keep small images out of the refreshed galleries

### DIFF
--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -2,20 +2,26 @@
  * External Dependencies
  */
 import React from 'react';
-import { map, take } from 'lodash';
+import { map, take, filter } from 'lodash';
 
 /**
  * Internal Dependencies
  */
+import { imageIsBigEnoughForGallery } from 'state/reader/posts/normalization-rules';
 import resizeImageUrl from 'lib/resize-image-url';
 
-const GALLERY_ITEM_WIDTH = 206;
+const GALLERY_ITEM_THUMBNAIL_WIDTH = 420;
+
+function getGalleryWorthyImages( post ) {
+	const worthyImages = filter( post.images, imageIsBigEnoughForGallery );
+	const numberOfImagesToDisplay = 4;
+	return take( worthyImages, numberOfImagesToDisplay );
+}
 
 const PostGallery = ( { post } ) => {
-	const numberOfImagesToDisplay = 4;
-	const imagesToDisplay = take( post.content_images, numberOfImagesToDisplay );
+	const imagesToDisplay = getGalleryWorthyImages( post );
 	const listItems = map( imagesToDisplay, ( image, index ) => {
-		const imageUrl = resizeImageUrl( image.src, { w: GALLERY_ITEM_WIDTH } );
+		const imageUrl = resizeImageUrl( image.src, { w: GALLERY_ITEM_THUMBNAIL_WIDTH } );
 		const safeCssUrl = imageUrl.replace( ')', '\\)' ).replace( '(', '\\(' );
 		const imageStyle = {
 			backgroundImage: 'url(' + safeCssUrl + ')',

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -236,11 +236,11 @@ describe( 'index', function() {
 				}
 			};
 			normalizer( post, [ normalizer.safeImageProperties( 200 ) ], function( err, normalized ) {
-				assert.strictEqual( normalized.author.avatar_URL, 'http://example.com/me.jpg-SAFE?w=200&quality=80&strip=info' );
-				assert.strictEqual( normalized.featured_image, 'http://foo.bar/-SAFE?w=200&quality=80&strip=info' );
-				assert.strictEqual( normalized.post_thumbnail.URL, 'http://example.com/thumb.jpg-SAFE?w=200&quality=80&strip=info' );
-				assert.strictEqual( normalized.featured_media.uri, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' );
-				assert.strictEqual( normalized.attachments[ '1234' ].URL, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' );
+				assert.strictEqual( normalized.author.avatar_URL, 'http://example.com/me.jpg-SAFE?quality=80&strip=info&w=200' );
+				assert.strictEqual( normalized.featured_image, 'http://foo.bar/-SAFE?quality=80&strip=info&w=200' );
+				assert.strictEqual( normalized.post_thumbnail.URL, 'http://example.com/thumb.jpg-SAFE?quality=80&strip=info&w=200' );
+				assert.strictEqual( normalized.featured_media.uri, 'http://example.com/media.jpg-SAFE?quality=80&strip=info&w=200' );
+				assert.strictEqual( normalized.attachments[ '1234' ].URL, 'http://example.com/media.jpg-SAFE?quality=80&strip=info&w=200' );
 				assert.strictEqual( normalized.attachments[ '3456' ].URL, 'http://example.com/media.jpg' );
 				done( err );
 			} );
@@ -433,7 +433,7 @@ describe( 'index', function() {
 					content: '<img src="http://example.com/example.jpg"><img src="http://example.com/example2.jpg">'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe( 400 ) ] ) ], function( err, normalized ) {
-					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE?w=400&amp;quality=80&amp;strip=info"><img src="http://example.com/example2.jpg-SAFE?w=400&amp;quality=80&amp;strip=info">' );
+					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE?quality=80&amp;strip=info&amp;w=400"><img src="http://example.com/example2.jpg-SAFE?quality=80&amp;strip=info&amp;w=400">' );
 					done( err );
 				}
 			);

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -58,6 +58,12 @@ export function maxWidthPhotonishURL( imageURL, width ) {
 		parsedURL.query.strip = 'info'; // strip all exif data, leave ICC intact
 	}
 
+	// make a new query object with keys in a known order
+	parsedURL.query = Object.keys( parsedURL.query ).sort().reduce( ( memo, key ) => {
+		memo[ key ] = parsedURL.query[ key ];
+		return memo;
+	}, {} );
+
 	return url.format( parsedURL );
 }
 

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,11 +1,8 @@
 /**
  * External Dependencies
  */
-import find from 'lodash/find';
-import flow from 'lodash/flow';
-import forEach from 'lodash/forEach';
+import { filter, find, flow, forEach, matches } from 'lodash';
 import url from 'url';
-import matches from 'lodash/matches';
 
 /**
  * Internal Dependencies
@@ -48,7 +45,8 @@ const
 	DISCOVER_FULL_BLEED_WIDTH = 1082,
 	PHOTO_ONLY_MIN_WIDTH = isRefreshedStream ? 480 : 570,
 	DISCOVER_BLOG_ID = 53424024,
-	GALLERY_MIN_IMAGES = 4;
+	GALLERY_MIN_IMAGES = 4,
+	GALLERY_MIN_IMAGE_WIDTH = 350;
 
 function discoverFullBleedImages( post, dom ) {
 	if ( post.site_ID === DISCOVER_BLOG_ID ) {
@@ -77,6 +75,10 @@ function getCharacterCount( post ) {
 	}
 
 	return post.better_excerpt_no_html.length;
+}
+
+export function imageIsBigEnoughForGallery( image ) {
+	return image.width >= GALLERY_MIN_IMAGE_WIDTH;
 }
 
 const hasShortContent = isRefreshedStream
@@ -138,7 +140,7 @@ function classifyPost( post ) {
 		displayType ^= DISPLAY_TYPES.FEATURED_VIDEO;
 	}
 
-	if ( post.content_images && post.content_images.length >= GALLERY_MIN_IMAGES ) {
+	if ( post.content_images && filter( post.content_images, imageIsBigEnoughForGallery ).length >= GALLERY_MIN_IMAGES ) {
 		displayType ^= DISPLAY_TYPES.GALLERY;
 	}
 


### PR DESCRIPTION
Require a min width of 350px and require enough images to be marked as a gallery card.

Fixes #9159 

To test, compare https://wpcalypso.wordpress.com/read/feeds/34222 to https://calypso.live/read/feeds/34222?branch=fix/reader/9123
