### PR TITLE
Reader Stream Refresh: Fix featured image background position in Safari

### DIFF
--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -13,7 +13,7 @@ const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 		backgroundImage: 'url(' + imageUri + ')',
 		backgroundSize: 'cover',
 		backgroundRepeat: 'no-repeat',
-		backgroundPosition: '50% 50%'
+		backgroundPosition: 'right center'
 	};
 
 	return (


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9357

I'm not sure if this is a known bug in Safari, but I can't seem to find an explanation for it.

But this PR fixes the issue by scooting the background image (x value) all the way to the right.

**Before:**
![screenshot 2016-11-14 11 42 42](https://cloud.githubusercontent.com/assets/4924246/20280113/fe40b5a0-aa5f-11e6-9cdb-7fd14bcb3da9.png)
![screenshot 2016-11-14 11 42 47](https://cloud.githubusercontent.com/assets/4924246/20280114/fe411590-aa5f-11e6-91e8-06f34d7521f8.png)

**After:**
![screenshot 2016-11-14 11 42 52](https://cloud.githubusercontent.com/assets/4924246/20280122/05c7ee92-aa60-11e6-87a2-22b5cd50c2e9.png)
![screenshot 2016-11-14 11 42 55](https://cloud.githubusercontent.com/assets/4924246/20280123/05f36392-aa60-11e6-85bb-d9f9d83b92c4.png)

