### PR TITLE
Reader: Change how we build the better excerpt for the refresh

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -101,6 +101,9 @@ normalizePost.pickCanonicalImage = wrapSync( pickCanonicalImage );
 import createBetterExcerpt from './rule-create-better-excerpt';
 normalizePost.createBetterExcerpt = wrapSync( createBetterExcerpt );
 
+import createBetterExcerptRefresh from './rule-create-better-excerpt-refresh';
+normalizePost.createBetterExcerptRefresh = wrapSync( createBetterExcerptRefresh );
+
 import withContentDOM from './rule-with-content-dom';
 normalizePost.withContentDOM = function( transforms ) {
 	return function( post, callback ) {

--- a/client/lib/post-normalizer/rule-create-better-excerpt-refresh.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt-refresh.js
@@ -1,0 +1,61 @@
+/**
+ * External Dependencies
+ */
+import { forEach } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { domForHtml } from './utils';
+
+function removeElement( element ) {
+	element.parentNode && element.parentNode.removeChild( element );
+}
+
+export function formatExcerpt( content ) {
+	if ( ! content ) {
+		return '';
+	}
+
+	// Spin up a new DOM for the linebreak markup
+	const dom = domForHtml( content );
+
+	// Ditch any photo captions with the wp-caption-text class, styles, scripts
+	forEach(
+		dom.querySelectorAll( '.wp-caption-text, style, script, blockquote[class^="instagram-"], figure' ),
+		removeElement
+	);
+
+	forEach(
+		dom.querySelectorAll( 'p, br' ),
+		p => {
+			p.appendChild( document.createTextNode( ' ' ) );
+		}
+	);
+
+	const betterExcerpt = dom.textContent;
+	dom.innerHTML = '';
+	return betterExcerpt;
+}
+
+export default function createBetterExcerpt( post ) {
+	if ( ! post || ! post.content ) {
+		return post;
+	}
+
+	post.better_excerpt_no_html = post.better_excerpt = formatExcerpt( post.content );
+
+	// also make a shorter excerpt...
+	if ( post.better_excerpt_no_html ) {
+		// replace any trailing [...] with an actual ellipsis
+		let shorterExcerpt = post.better_excerpt_no_html.replace( /\[...\]\w*$/, '…' );
+		// limit to 160 characters
+		if ( shorterExcerpt.length > 160 ) {
+			const lastSpace = shorterExcerpt.lastIndexOf( ' ', 160 );
+			shorterExcerpt = shorterExcerpt.substring( 0, lastSpace ) + '…';
+		}
+		post.short_excerpt = shorterExcerpt;
+	}
+
+	return post;
+}

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -926,6 +926,7 @@ describe( 'index', function() {
 			);
 		} );
 	} );
+
 	describe( 'The fancy excerpt creator', function() {
 		function assertExcerptBecomes( source, expected, done ) {
 			normalizer( { content: source }, [ normalizer.createBetterExcerpt ], function( err, normalized ) {
@@ -948,7 +949,11 @@ describe( 'index', function() {
 		} );
 
 		it( 'limits the excerpt to 3 elements after trimming', function( done ) {
-			assertExcerptBecomes( '<br /><p></p><p>one</p><p>two</p><p></p><br><p>three</p><p>four</p><br><p></p>', '<p>one</p><p>two</p><br>', done );
+			assertExcerptBecomes(
+				'<br /><p></p><p>one</p><p>two</p><p></p><br><p>three</p><p>four</p><br><p></p>',
+				'<p>one</p><p>two</p><br>',
+				done
+			);
 		} );
 
 		it( 'only trims top-level breaks', function( done ) {
@@ -961,6 +966,23 @@ describe( 'index', function() {
 				'<p>hi there</p>',
 				done
 			);
+		} );
+	} );
+
+	describe( 'The refreshed fancy excerpt creator', () => {
+		function assertExcerptBecomes( source, expected, done ) {
+			normalizer( { content: source }, [ normalizer.createBetterExcerptRefresh ], function( err, normalized ) {
+				assert.strictEqual( normalized.better_excerpt, expected );
+				done( err );
+			} );
+		}
+
+		it( 'removes tags but inserts spaces between p tags', function( done ) {
+			assertExcerptBecomes( '<p>one</p><p>two</p><p>three</p><p>four</p>', 'one two three four ', done );
+		} );
+
+		it( 'turns br tags into spaces', function( done ) {
+			assertExcerptBecomes( '<p>one<br>two<br/>three</p>', 'one two three ', done );
 		} );
 	} );
 } );

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -18,6 +18,7 @@ import DISPLAY_TYPES from './display-types';
  * Rules
  */
 import createBetterExcerpt from 'lib/post-normalizer/rule-create-better-excerpt';
+import createBetterExcerptRefresh from 'lib/post-normalizer/rule-create-better-excerpt-refresh';
 import detectEmbeds from 'lib/post-normalizer/rule-content-detect-embeds';
 import detectMedia from 'lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'lib/post-normalizer/rule-content-detect-polls';
@@ -171,7 +172,7 @@ const fastPostNormalizationRules = flow( [
 		detectPolls,
 	] ),
 	firstPassCanonicalImage,
-	createBetterExcerpt,
+	config.isEnabled( 'reader/refresh/stream' ) ? createBetterExcerptRefresh : createBetterExcerpt,
 	pickCanonicalMedia,
 	classifyPost,
 ] );


### PR DESCRIPTION
use textContent to make things simpler, since we no longer have html content in excerpts.
also add spaces after p tags and replace breaks with spaces.

Fixes #9290 

This ends up changing how excerpts are built across the app, so test the cards in all of the main streams too. Following / tags / search / etc