### PR TITLE
Reader: Update full-post body text color

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -160,6 +160,10 @@
 	}
 }
 
+.reader-full-post__story-content {
+	color: $gray-dark;
+}
+
 .reader-full-post .author-compact-profile {
 	display: inline-flex;
 	flex-direction: column;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9359

Before (body color was `darken( $gray, 30% )`/  `#3d596d`:
![screenshot 2016-11-14 13 37 44](https://cloud.githubusercontent.com/assets/4924246/20283890/c1eb5b4a-aa6f-11e6-83c4-88608d590e48.png)

After (body color is now `$gray-dark` / `#2e4453`:
![screenshot 2016-11-14 13 38 08](https://cloud.githubusercontent.com/assets/4924246/20283893/c509ff52-aa6f-11e6-86d2-7fc38a2d5b80.png)

Title and body text color for both cards and full-post are now all `$gray-dark` / `#2e4453`.
