### PR TITLE
ThemesSiteSelectorModal: Fix siteSlug value of null, take two

### DIFF
--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -60,17 +60,35 @@ class SiteSelectorModal extends Component {
 	}
 
 	getMainLink() {
-		const url = this.props.getMainUrl && this.props.getMainUrl( this.state.siteId );
+		const { siteId } = this.state;
+		const url = this.props.getMainUrl && siteId && this.props.getMainUrl( siteId );
 
-		return url
-			? <Button primary href={ url } onClick={ this.onButtonClick } >{ this.props.mainActionLabel }</Button>
-			: { action: 'mainAction', label: this.props.mainActionLabel, isPrimary: true };
+		if ( url ) {
+			return (
+				<Button
+					primary
+					key="mainAction"
+					disabled={ ! siteId }
+					href={ url }
+					onClick={ this.onButtonClick } >
+					{ this.props.mainActionLabel }
+				</Button>
+			);
+		}
+
+		return {
+			key: 'mainAction',
+			action: siteId && 'mainAction',
+			label: this.props.mainActionLabel,
+			isPrimary: true,
+			disabled: ! siteId
+		};
 	}
 
 	render() {
 		const mainLink = this.getMainLink();
 		const buttons = [
-			{ action: 'back', label: this.props.translate( 'Back' ) },
+			{ key: 'back', action: 'back', label: this.props.translate( 'Back' ) },
 			mainLink
 		];
 		const classNames = classnames( 'site-selector-modal', this.props.className );

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -86,7 +86,8 @@ class SiteSelectorModal extends Component {
 				<SitesDropdown
 					onSiteSelect={ this.setSite }
 					selectedSiteId={ this.state.siteId }
-					filter={ this.props.filter } />
+					filter={ this.props.filter }
+					isPlaceholder={ ! this.props.initialSiteId } />
 			</Dialog>
 		);
 	}

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -45,8 +45,8 @@ const ThemesSiteSelectorModal = React.createClass( {
 	},
 
 	trackAndCallAction( siteId ) {
-		const action = this.state.selectedOption.action;
-		const themeId = this.state.selectedThemeId;
+		const { selectedOption: optionName, selectedThemeId: themeId } = this.state;
+		const { action } = this.props.options[ optionName ];
 		const { search } = this.props;
 		const siteSlug = this.props.getSiteSlug( siteId );
 
@@ -83,12 +83,12 @@ const ThemesSiteSelectorModal = React.createClass( {
 	 * but only if it also has a header, because the latter indicates it really needs
 	 * a site to be selected and doesn't work otherwise.
 	 */
-	wrapOption( option ) {
+	wrapOption( option, name ) {
 		return Object.assign(
 			{},
 			option,
 			option.header
-				? { action: themeId => this.showSiteSelectorModal( option, themeId ) }
+				? { action: themeId => this.showSiteSelectorModal( name, themeId ) }
 				: {},
 			option.getUrl && option.header
 				? { getUrl: null }
@@ -106,7 +106,8 @@ const ThemesSiteSelectorModal = React.createClass( {
 			} )
 		);
 
-		const { selectedOption, selectedThemeId } = this.state;
+		const { selectedOption: selectedOptionName, selectedThemeId } = this.state;
+		const selectedOption = this.props.options[ selectedOptionName ];
 		const theme = this.props.getWpcomTheme( selectedThemeId );
 
 		return (


### PR DESCRIPTION
Have `<ThemesSiteSelectorModal />` store only the current option's name (instead of the entire option object) in component state. This way, when Redux state updates, the component's `options` prop will update and cause a re-render with updated `getUrl` and `action` fields.

To test:
* Verify that #9298 is fixed. (Also make sure to reproduce that issue on `master`. Remember to log out and in again each time or you won't be able to repro!)

Reverts Automattic/wp-calypso#9367