### PR TITLE
Gravatar: Show current user's local image

### DIFF
--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -43,7 +43,7 @@ describe( 'EditGravatar', function() {
 	before( function() {
 		EditGravatar = require( 'blocks/edit-gravatar' ).EditGravatar;
 		FilePicker = require( 'components/file-picker' );
-		Gravatar = require( 'components/gravatar' );
+		Gravatar = require( 'components/gravatar' ).default;
 		ImageEditor = require( 'blocks/image-editor' );
 	} );
 

--- a/client/components/gravatar/README.md
+++ b/client/components/gravatar/README.md
@@ -1,7 +1,11 @@
 Gravatar
 ======
 
-This component is used to display the [Gravatar](https://gravatar.com/) for a user. It takes a User object as a prop and read the images from user.avatar_URL. The images size is set at 96px, used at smaller sizes for retina display. Using one size allows us to only request one image and cache it on the browser. Even if you are displaying it at smaller sizes you should not change the source image.
+This component is used to display the [Gravatar](https://gravatar.com/) for a user. It takes a User object as a prop and read the images from user.avatar_URL.
+
+If the current user has uploaded a new Gravatar recently on Calypso, and therefore has a temporary image set, this component will display the temporary image instead. It reads the temporary image using the redux selector `getUserTempGravatar`.
+
+The images size is set at 96px, used at smaller sizes for retina display. Using one size allows us to only request one image and cache it on the browser. Even if you are displaying it at smaller sizes you should not change the source image.
 
 #### How to use:
 

--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import url from 'url';
 import qs from 'querystring';
 import { connect } from 'react-redux';
@@ -15,76 +15,91 @@ import {
 	getUserTempGravatar
 } from 'state/current-user/gravatar-status/selectors';
 
-export const Gravatar = React.createClass( {
-	displayName: 'Gravatar',
-
-	propTypes: {
-		user: React.PropTypes.object,
-		size: React.PropTypes.number,
-		imgSize: React.PropTypes.number,
-		// connected props:
-		tempImage: React.PropTypes.oneOfType( [
-			React.PropTypes.string, // the temp image base64 string if it exists
-			React.PropTypes.bool // or false if the temp image does not exist
-		] ),
-	},
-
-	getDefaultProps() {
-		// The REST-API returns s=96 by default, so that is most likely to be cached
-		return {
-			imgSize: 96,
-			size: 32
-		};
-	},
-
-	getInitialState() {
-		return {
+export class Gravatar extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
 			failedToLoad: false
 		};
-	},
+	}
+
+	static propTypes = {
+		user: PropTypes.object,
+		size: PropTypes.number,
+		imgSize: PropTypes.number,
+		// connected props:
+		tempImage: PropTypes.oneOfType( [
+			PropTypes.string, // the temp image base64 string if it exists
+			PropTypes.bool // or false if the temp image does not exist
+		] ),
+	};
+
+	static defaultProps = {
+		// The REST-API returns s=96 by default, so that is most likely to be cached
+		imgSize: 96,
+		size: 32
+	};
 
 	getResizedImageURL( imageURL ) {
+		const { imgSize } = this.props;
 		imageURL = imageURL || 'https://www.gravatar.com/avatar/0';
 		const parsedURL = url.parse( imageURL );
 		const query = qs.parse( parsedURL.query );
 
 		if ( /^([-a-zA-Z0-9_]+\.)*(gravatar.com)$/.test( parsedURL.hostname ) ) {
-			query.s = this.props.imgSize;
+			query.s = imgSize;
 			query.d = 'mm';
 		} else {
 			// assume photon
-			query.resize = this.props.imgSize + ',' + this.props.imgSize;
+			query.resize = imgSize + ',' + imgSize;
 		}
 
 		parsedURL.search = qs.stringify( query );
 		return url.format( parsedURL );
-	},
+	}
 
-	onError() {
-		this.setState( { failedToLoad: true } );
-	},
+	onError = () => this.setState( { failedToLoad: true } );
 
 	render() {
-		const size = this.props.size;
+		const {
+			alt,
+			size,
+			tempImage,
+			user,
+		} = this.props;
 
-		if ( ! this.props.user ) {
-			return <span className="gravatar is-placeholder" style={ { width: size, height: size } } />;
-		} else if ( this.state.failedToLoad ) {
+		if ( ! user ) {
+			return (
+				<span
+					className="gravatar is-placeholder"
+					style={ { width: size, height: size } }
+				/>
+			);
+		}
+
+		if ( this.state.failedToLoad ) {
 			return <span className="gravatar is-missing" />;
 		}
 
-		const alt = this.props.alt || this.props.user.display_name;
+		const altText = alt || user.display_name;
 
 		const avatarURL = (
-			this.props.tempImage ||
-			this.getResizedImageURL( safeImageURL( this.props.user.avatar_URL ) )
+			tempImage ||
+			this.getResizedImageURL( safeImageURL( user.avatar_URL ) )
 		);
 
 		return (
-			<img alt={ alt } className="gravatar" src={ avatarURL } width={ size } height={ size } onError={ this.onError } />
+			<img
+				alt={ altText }
+				className="gravatar"
+				src={ avatarURL }
+				width={ size }
+				height={ size }
+				onError={ this.onError }
+			/>
 		);
 	}
-} );
+}
 
 export default connect( ( state, ownProps ) => ( {
 	tempImage: getUserTempGravatar( state, get( ownProps, 'user.ID', false ) ),

--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -4,19 +4,29 @@
 import React from 'react';
 import url from 'url';
 import qs from 'querystring';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import safeImageURL from 'lib/safe-image-url';
+import {
+	getUserTempGravatar
+} from 'state/current-user/gravatar-status/selectors';
 
-module.exports = React.createClass( {
+export const Gravatar = React.createClass( {
 	displayName: 'Gravatar',
 
 	propTypes: {
 		user: React.PropTypes.object,
 		size: React.PropTypes.number,
-		imgSize: React.PropTypes.number
+		imgSize: React.PropTypes.number,
+		// connected props:
+		tempImage: React.PropTypes.oneOfType( [
+			React.PropTypes.string, // the temp image base64 string if it exists
+			React.PropTypes.bool // or false if the temp image does not exist
+		] ),
 	},
 
 	getDefaultProps() {
@@ -64,10 +74,18 @@ module.exports = React.createClass( {
 		}
 
 		const alt = this.props.alt || this.props.user.display_name;
-		const avatarURL = this.getResizedImageURL( safeImageURL( this.props.user.avatar_URL ) );
+
+		const avatarURL = (
+			this.props.tempImage ||
+			this.getResizedImageURL( safeImageURL( this.props.user.avatar_URL ) )
+		);
 
 		return (
 			<img alt={ alt } className="gravatar" src={ avatarURL } width={ size } height={ size } onError={ this.onError } />
 		);
 	}
 } );
+
+export default connect( ( state, ownProps ) => ( {
+	tempImage: getUserTempGravatar( state, get( ownProps, 'user.ID', false ) ),
+} ) )( Gravatar );

--- a/client/components/gravatar/test/index.jsx
+++ b/client/components/gravatar/test/index.jsx
@@ -1,15 +1,14 @@
-
 /**
  * External dependencies
  */
-var assert = require( 'assert' ),
-	ReactDomServer = require( 'react-dom/server' ),
-	React = require( 'react' );
+import assert from 'assert';
+import ReactDomServer from 'react-dom/server';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var Gravatar = require( '../' );
+import { Gravatar } from '../';
 
 /**
  * Pass in a react-generated html string to remove react-specific attributes
@@ -22,53 +21,74 @@ function stripReactAttributes( string ) {
 }
 
 describe( 'Gravatar', function() {
-	var bobTester = {
+	const bobTester = {
 		avatar_URL: 'https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=identicon',
 		display_name: 'Bob The Tester'
 	};
 
 	describe( 'rendering', function() {
 		it( 'should render an image given a user with valid avatar_URL, with default width and height 32', function() {
-			var gravatar = <Gravatar user={ bobTester } />,
-				expectedResultString = '<img alt="Bob The Tester" class="gravatar" src="https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" width="32" height="32"/>';
+			const gravatar = <Gravatar user={ bobTester } />;
+			const expectedResultString = '<img alt="Bob The Tester" ' +
+				'class="gravatar" ' +
+				'src="https://0.gravatar.com/' +
+				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" ' +
+				'width="32" height="32"/>';
 
 			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
 		} );
 
 		it( 'should update the width and height when given a size attribute', function() {
-			var gravatar = <Gravatar user={ bobTester } size={ 100 } />,
-				expectedResultString = '<img alt="Bob The Tester" class="gravatar" src="https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" width="100" height="100"/>';
+			const gravatar = <Gravatar user={ bobTester } size={ 100 } />;
+			const expectedResultString = '<img alt="Bob The Tester" ' +
+				'class="gravatar" ' +
+				'src="https://0.gravatar.com/' +
+				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" ' +
+				'width="100" height="100"/>';
 
 			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
 		} );
 
 		it( 'should update source image when given imgSize attribute', function() {
-			var gravatar = <Gravatar user={ bobTester } imgSize={ 200 } />,
-				expectedResultString = '<img alt="Bob The Tester" class="gravatar" src="https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=200&amp;d=mm" width="32" height="32"/>';
+			const gravatar = <Gravatar user={ bobTester } imgSize={ 200 } />;
+			const expectedResultString = '<img alt="Bob The Tester" ' +
+				'class="gravatar" ' +
+				'src="https://0.gravatar.com/' +
+				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=200&amp;d=mm" ' +
+				'width="32" height="32"/>';
 
 			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
 		} );
 
 		it( 'should serve a default image if no avatar_URL available', function() {
-			var noImageTester = { display_name: 'Bob The Tester' },
-				gravatar = <Gravatar user={ noImageTester } />,
-				expectedResultString = '<img alt="Bob The Tester" class="gravatar" src="https://www.gravatar.com/avatar/0?s=96&amp;d=mm" width="32" height="32"/>';
+			const noImageTester = { display_name: 'Bob The Tester' };
+			const gravatar = <Gravatar user={ noImageTester } />;
+			const expectedResultString = '<img alt="Bob The Tester" ' +
+				'class="gravatar" ' +
+				'src="https://www.gravatar.com/avatar/0?s=96&amp;d=mm" ' +
+				'width="32" height="32"/>';
 
 			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
 		} );
 
 		it( 'should allow overriding the alt attribute', function() {
-			var gravatar = <Gravatar user={ bobTester } alt="Alternate Alt" />,
-				expectedResultString = '<img alt="Alternate Alt" class="gravatar" src="https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" width="32" height="32"/>';
+			const gravatar = <Gravatar user={ bobTester } alt="Alternate Alt" />;
+			const expectedResultString = '<img alt="Alternate Alt" ' +
+				'class="gravatar" ' +
+				'src="https://0.gravatar.com/' +
+				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" ' +
+				'width="32" height="32"/>';
 
 			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
 		} );
 
 		// I believe jetpack sites could have custom avatars, so can't assume it's always a gravatar
 		it( 'should promote non-secure avatar urls to secure', function() {
-			var nonSecureTester = { avatar_URL: 'http://www.example.com/avatar' },
-				gravatar = <Gravatar user={ nonSecureTester } />,
-				expectedResultString = '<img class="gravatar" src="https://i2.wp.com/www.example.com/avatar?resize=96%2C96" width="32" height="32"/>';
+			const nonSecureTester = { avatar_URL: 'http://www.example.com/avatar' };
+			const gravatar = <Gravatar user={ nonSecureTester } />;
+			const expectedResultString = '<img class="gravatar" ' +
+				'src="https://i2.wp.com/www.example.com/avatar?resize=96%2C96" ' +
+				'width="32" height="32"/>';
 
 			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
 		} );

--- a/client/components/user/index.jsx
+++ b/client/components/user/index.jsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var Gravatar = require( 'components/gravatar' );
+import Gravatar from 'components/gravatar';
 
 module.exports = React.createClass( {
 	displayName: 'UserItem',

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -18,9 +18,9 @@ const Card = require( 'components/card' ),
 	FormButtonsBar = require( 'components/forms/form-buttons-bar' ),
 	AuthorSelector = require( 'blocks/author-selector' ),
 	UsersActions = require( 'lib/users/actions' ),
-	Gravatar = require( 'components/gravatar' ),
 	accept = require( 'lib/accept' ),
 	analytics = require( 'lib/analytics' );
+import Gravatar from 'components/gravatar';
 
 module.exports = React.createClass( {
 	displayName: 'DeleteUser',

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -1,18 +1,24 @@
 /**
  * External dependencies
  */
-const React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-const Gravatar = require( 'components/gravatar' ),
-	user = require( 'lib/user' )(),
-	AuthorSelector = require( 'blocks/author-selector' ),
-	PostActions = require( 'lib/posts/actions' ),
-	touchDetect = require( 'lib/touch-detect' ),
-	sites = require( 'lib/sites-list' )(),
-	stats = require( 'lib/posts/stats' );
+import Gravatar from 'components/gravatar';
+import userFactory from 'lib/user';
+import AuthorSelector from 'blocks/author-selector';
+import PostActions from 'lib/posts/actions';
+import touchDetect from 'lib/touch-detect';
+import sitesFactory from 'lib/sites-list';
+import * as stats from 'lib/posts/stats';
+
+/**
+ * Module dependencies
+ */
+const user = userFactory();
+const sites = sitesFactory();
 
 export default React.createClass( {
 	displayName: 'EditorAuthor',

--- a/client/state/current-user/gravatar-status/test/selectors.js
+++ b/client/state/current-user/gravatar-status/test/selectors.js
@@ -45,7 +45,7 @@ describe( 'selectors', () => {
 		const currentUserId = 1;
 		const anotherUserId = 2;
 
-		it( 'returns false if user ID is not passed in', () => {
+		it( 'returns false if user ID is not passed in, or is false', () => {
 			const state = {
 				currentUser: {
 					gravatarStatus: {
@@ -57,6 +57,7 @@ describe( 'selectors', () => {
 				}
 			};
 			expect( getUserTempGravatar( state ) ).to.equal( false );
+			expect( getUserTempGravatar( state, false ) ).to.equal( false );
 		} );
 
 		it( 'returns false if the user ID passed is not the current user ID', () => {


### PR DESCRIPTION
The changes in this PR:
- `<Gravatar />` becomes a connected component that uses `getUserTempGravatar`
- `<Gravatar />` exports `default` and `Gravatar`. The 3 components that use `require` to use `<Gravatar />` now use the default export
- update `<Gravatar />` to an ES6 class

## What we're testing

In each case, test to make sure that the `<Gravatar/>` on the page shows up, and that there are no errors in the console.

## Manual Testing

The three components that use `require` to use `<Gravatar />` are:
1. `components/user` (`UserItem`)
  This can be tested at `http://calypso.localhost:3000/settings/import/$wpcom_site` by going through an import
2. `my-sites/people/delete-user` (`DeleteUser`)
  This cannot be tested right now since the component seems to not be working atm (not allowing to reassign posts to a user). The link to test is here: `http://calypso.localhost:3000/people/edit/editor/$jetpack_site` - try deleting a user
3. `post-editor/editor-author` (`EditorAuthor`)
  This can be tested at the editor: `http://calypso.localhost:3000/post/$site`

The following components use `import` to use `<Gravatar />`, and did not need to be changed, sorted by URL:

A: `http://calypso.localhost:3000/read/feeds/45401477/posts/1216523546#comments`
1. `reader/comments/form.jsx` - try to leave a comment
2. `reader/comments/post-comment.jsx` - read the comments already there
3. `blocks/reader-avatar` (`ReaderAvatar`)
4. `blocks/reader-related-card-v2` (`RelatedPostCard`)

B: `http://calypso.localhost:3000/posts/my/$site`
1. `blocks/comments/form.jsx` (`PostCommentForm`) - leave a comment
2. `blocks/comments/post-comment` - view comments
3. `my-sites/posts/posts-navigation` - the navigation bar at the top of the page: published/me/everyone

C: `http://calypso.localhost:3000/me`
1. `layout/masterbar/logged-in` - the masterbar
2. `me/sidebar-navigation/sidebar-navigation.jsx`
3. `me/profile-gravatar`
4. `EditGravatar`

D: `http://calypso.localhost:3000/`
`reader/post-byline`

E: `http://calypso.localhost:3000/people/team/$site`
`my-sites/people/people-profile`

F: `http://calypso.localhost:3000/posts/$site`
`my-sites/draft/index.jsx` click on 'everyone' to see the drafts list with Gravatars

G: `http://calypso.localhost:3000/read/a8c`
`reader/site-and-author-icon/` - find an x-post

H: `http://calypso.localhost:3000/devdocs/blocks/search-card`
`blocks/reader-author-and-site` (`AuthorAndSite`) (not in prod)

I: `http://calypso.localhost:3000/recommendations/start`
`reader/start/post-preview.jsx`

J: `http://calypso.localhost:3000/jetpack/connect`
`signup/jetpack-connect/authorize-form.jsx` enter a .org URL to connect to JP

K: user invitation link
1. `my-sites/invites/invite-header`
2. `my-sites/invites/invite-accept-logged-in`

L: `https://wpcalypso.wordpress.com/devdocs/blocks/happiness-support`
`components/happiness-support` (`HappinessSupport`)

M: `http://calypso.localhost:3000/help`
`me/help/help-happiness-engineers`

N: Component: `signup/jetpack-connect/sso.jsx`. Steps:
1. Start with a connected Jetpack site
2. Enable the SSO module in Jetpack
3. Sign out of both .com and the Jetpack site
4. Sign in to WP.com with a different account (that isn't connected to the Jetpack site)
5. Visit selfhostedsite/wp-admin
6. "Connect to WP.com:
7. See a "Connect with WordPress.com" screen, switch to `calypso.localhost:3000` in the URL
8. Make sure you see the `<Gravatar />` and no errors

## e2e tests

For the original PR (#8456) that attempted to make similar changes there were some failing e2e tests. All of the e2e tests pass, except these 3:
- wp-post-nux-spec: customizer timeout
- wp-theme-multisite-spec: timeout on element (cannot repro, and element we're waiting for does indeed not exist)
- wp-theme-switch-spec: timeout on element (cannot repro, and element we're waiting for does indeed not exist)