### PR TITLE
Reader: Prevent esc key in full post from killing network loading

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -120,7 +120,8 @@ export class FullPostView extends React.Component {
 		KeyboardShortcuts.off( 'like-selection', this.handleLike );
 	}
 
-	handleBack() {
+	handleBack( event ) {
+		event.preventDefault();
 		recordAction( 'full_post_close' );
 		recordGaEvent( 'Closed Full Post Dialog' );
 		recordTrackForPost( 'calypso_reader_article_closed', this.props.post );


### PR DESCRIPTION
Fixes #9334

Testing this is ... interesting. I have not been able to get `esc` to kill loading or active network connections on a mac / chrome set up just yet, but this change _should_ prevent it from killing things, I think. 

@pento can you give this a shot using the calypso.live link below and see if it changes things for you?