### PR TITLE
Reader: Suppress features for Laughing Squid

### DIFF
--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -12,6 +12,10 @@ import { makeImageURLSafe } from './utils';
 export default function safeImagePropertiesForWidth( maxWidth ) {
 	return function safeImageProperties( post ) {
 		makeImageURLSafe( post.author, 'avatar_URL', maxWidth );
+		if ( post.feed_ID === 12098 || +post.site_ID === 1065188 ) {
+			post.featured_image = '';
+			delete post.post_thumbnail;
+		}
 		makeImageURLSafe( post, 'featured_image', maxWidth, post.URL );
 		if ( post.post_thumbnail ) {
 			makeImageURLSafe( post.post_thumbnail, 'URL', maxWidth, post.URL );


### PR DESCRIPTION
LS uses featured images in a weird way. Suppress them and rely on picking things up from content instead.