### PR TITLE
Reader Search: end search suggestion A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -61,15 +61,6 @@ module.exports = {
 		defaultVariation: 'hideThemeUpload',
 		allowExistingUsers: false,
 	},
-	readerSearchSuggestions: {
-		datestamp: '20160804',
-		variations: {
-			staffSuggestions: 50,
-			popularSuggestions: 50
-		},
-		defaultVariation: 'staffSuggestions',
-		allowExistingUsers: true
-	},
 	domainSuggestionPopover: {
 		datestamp: '20160809',
 		variations: {

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -21,8 +21,7 @@ import SiteStore from 'lib/reader-site-store';
 import FeedStore from 'lib/feed-store';
 import { recordTrackForPost } from 'reader/stats';
 import i18nUtils from 'lib/i18n-utils';
-import { staffSuggestions, popularSuggestions } from './suggestions';
-import { abtest } from 'lib/abtest';
+import { suggestions } from './suggestions';
 import SearchCard from 'blocks/reader-search-card';
 import ReaderPostCard from 'blocks/reader-post-card';
 import config from 'config';
@@ -113,18 +112,10 @@ const SearchStream = React.createClass( {
 
 	getInitialState() {
 		const lang = i18nUtils.getLocaleSlug();
-		let sourceSuggestions = null;
 		let pickedSuggestions = null;
 
-		// Which set of suggestions should we use?
-		if ( abtest( 'readerSearchSuggestions' ) === 'popularSuggestions' ) {
-			sourceSuggestions = popularSuggestions;
-		} else {
-			sourceSuggestions = staffSuggestions;
-		}
-
-		if ( sourceSuggestions[ lang ] ) {
-			pickedSuggestions = sampleSize( sourceSuggestions[ lang ], 3 );
+		if ( suggestions[ lang ] ) {
+			pickedSuggestions = sampleSize( suggestions[ lang ], 3 );
 		}
 
 		return {

--- a/client/reader/search-stream/suggestions.js
+++ b/client/reader/search-stream/suggestions.js
@@ -1,13 +1,11 @@
-export const staffSuggestions = {
+export const suggestions = {
 	en: [
-		'2016 Election',
 		'Astrology',
 		'Batman',
 		'Beach',
 		'Beautiful',
 		'Bloom',
 		'Chickens',
-		'Clinton',
 		'Cocktails',
 		'Colorado',
 		'Craft Beer',
@@ -32,9 +30,7 @@ export const staffSuggestions = {
 		'Michigan',
 		'Monkeys',
 		'Mountain Biking',
-		'Obama',
 		'Overwatch',
-		'Pokemon GO',
 		'Pride',
 		'Recipe',
 		'Red Sox',
@@ -47,15 +43,9 @@ export const staffSuggestions = {
 		'Toddlers',
 		'Travel Backpacks',
 		'Travel',
-		'Trump',
 		'Woodworking',
 		'WordPress',
-		'Zombies'
-	]
-};
-
-export const popularSuggestions = {
-	en: [
+		'Zombies',
 		'Food',
 		'Writing',
 		'Life',
@@ -65,7 +55,6 @@ export const popularSuggestions = {
 		'Love',
 		'Health',
 		'Funny',
-		'Trump',
 		'Fashion',
 		'Fitness',
 		'Anime',


### PR DESCRIPTION
This PR:
- ends the Reader search suggestion A/B test (between staff suggestions and popular suggestions)
- combines the two lists of suggestions
- removes outdated or US-centric terms from the suggestion list