### PR TITLE
Jetpack Plugins: Remove sitesList.getSelectedSite() usage and cleanup

### DIFF
--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -210,6 +210,9 @@ PluginsStore = {
 	// Get Plugins for a single site
 	getSitePlugins: function( site ) {
 		var storedList;
+		if ( ! site ) {
+			return [];
+		}
 		if ( ! _pluginsBySite[ site.ID ] && ! _fetching[ site.ID ] ) {
 			storedList = getPluginsBySiteFromStorage( site.ID );
 

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -109,6 +109,7 @@ function renderPluginList( context, basePath ) {
 			? ' ' + capitalize( context.params.pluginFilter )
 			: ''
 		);
+
 	let baseAnalyticsPath = 'plugins';
 	if ( site ) {
 		baseAnalyticsPath += '/:site';

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { find, isEmpty, some } from 'lodash';
@@ -428,7 +427,5 @@ export default connect(
 		canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
 		canJetpackSiteUpdateFiles: siteId => canJetpackSiteUpdateFiles( state, siteId ),
 	} ),
-	dispatch => bindActionCreators( {
-		wporgFetchPluginData
-	}, dispatch )
+	{ wporgFetchPluginData }
 )( PluginsMain );

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -184,7 +184,7 @@ const PluginsMain = React.createClass( {
 
 		if ( selectedSite ) {
 			emptyContentData.actionURL = '/plugins/' + selectedSite.slug;
-			if ( this.props.isJetpackSite( selectedSite.ID ) ) {
+			if ( this.props.selectedSiteIsJetpack ) {
 				emptyContentData.illustration = '/calypso/images/drake/drake-jetpack.svg';
 				emptyContentData.title = this.translate( 'Plugins can\'t be updated on %(siteName)s.', {
 					textOnly: true,
@@ -229,7 +229,7 @@ const PluginsMain = React.createClass( {
 		const { selectedSite } = this.props;
 
 		if ( selectedSite ) {
-			return this.props.isJetpackSite( selectedSite.ID ) && this.props.canJetpackSiteUpdateFiles( selectedSite.ID );
+			return this.props.selectedSiteIsJetpack && this.props.canSelectedJetpackSiteUpdateFiles;
 		}
 
 		return some(
@@ -330,7 +330,7 @@ const PluginsMain = React.createClass( {
 	render() {
 		const { selectedSite } = this.props;
 
-		if ( selectedSite && ! this.props.isJetpackSite( selectedSite.ID ) ) {
+		if ( ! this.props.selectedSiteIsJetpack ) {
 			return (
 				<Main>
 					{ this.renderDocumentHead() }
@@ -354,7 +354,7 @@ const PluginsMain = React.createClass( {
 			);
 		}
 
-		if ( selectedSite && this.props.isJetpackSite( selectedSite.ID ) && ! this.props.canJetpackSiteManage( selectedSite.ID ) ) {
+		if ( this.props.selectedSiteIsJetpack && ! this.props.canSelectedJetpackSiteManage ) {
 			return (
 				<Main>
 					{ this.renderDocumentHead() }
@@ -419,13 +419,19 @@ const PluginsMain = React.createClass( {
 } );
 
 export default connect(
-	state => ( {
-		wporgPlugins: state.plugins.wporg.items,
-		selectedSite: getSelectedSite( state ),
-		selectedSiteSlug: getSelectedSiteSlug( state ),
-		isJetpackSite: siteId => isJetpackSite( state, siteId ),
-		canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
-		canJetpackSiteUpdateFiles: siteId => canJetpackSiteUpdateFiles( state, siteId ),
-	} ),
+	state => {
+		const selectedSite = getSelectedSite( state );
+
+		return {
+			selectedSite,
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+			selectedSiteIsJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
+			canSelectedJetpackSiteManage: selectedSite && canJetpackSiteManage( state, selectedSite.ID ),
+			canSelectedJetpackSiteUpdateFiles: selectedSite && canJetpackSiteUpdateFiles( state, selectedSite.ID ),
+			canJetpackSiteUpdateFiles: siteId => canJetpackSiteUpdateFiles( state, siteId ),
+			isJetpackSite: siteId => isJetpackSite( state, siteId ),
+			wporgPlugins: state.plugins.wporg.items,
+		};
+	},
 	{ wporgFetchPluginData }
 )( PluginsMain );

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -296,7 +296,6 @@ const PluginsMain = React.createClass( {
 					header={ this.translate( 'Plugins' ) }
 					plugins={ plugins }
 					sites={ this.props.sites }
-					selectedSite={ this.props.sites.getSelectedSite() }
 					pluginUpdateCount={ this.state.pluginUpdateCount }
 					isPlaceholder= { this.shouldShowPluginListPlaceholders() } />
 			</div>

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -4,12 +4,8 @@
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import debugModule from 'debug';
 import classNames from 'classnames';
-import getOr from 'lodash/get';
-import some from 'lodash/some';
-import find from 'lodash/find';
-import isEmpty from 'lodash/isEmpty';
+import { find, isEmpty, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,16 +29,10 @@ import PluginsList from './plugins-list';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import WpcomPluginPanel from 'my-sites/plugins-wpcom';
 import PluginsBrowser from './plugins-browser';
-
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:my-sites:plugins' );
+import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
+import { isJetpackSite, canJetpackSiteManage, canJetpackSiteUpdateFiles } from 'state/sites/selectors';
 
 const PluginsMain = React.createClass( {
-
-	displayName: 'PluginsMain',
-
 	mixins: [ URLSearch ],
 
 	getInitialState() {
@@ -50,7 +40,6 @@ const PluginsMain = React.createClass( {
 	},
 
 	componentDidMount() {
-		debug( 'Plugins React component mounted.' );
 		this.props.sites.on( 'change', this.refreshPlugins );
 		PluginsStore.on( 'change', this.refreshPlugins );
 	},
@@ -67,7 +56,7 @@ const PluginsMain = React.createClass( {
 	getPluginsFromStore( nextProps, sites ) {
 		const props = nextProps || this.props;
 		let	plugins = null;
-		if ( ! props.sites.selected ) {
+		if ( ! props.selectedSiteSlug ) {
 			plugins = PluginsStore.getPlugins( sites.filter( site => site.visible ), props.filter );
 		} else {
 			plugins = PluginsStore.getPlugins( sites, props.filter );
@@ -118,7 +107,7 @@ const PluginsMain = React.createClass( {
 	},
 
 	getFilters() {
-		const siteFilter = this.props.sites.selected ? '/' + this.props.sites.selected : '';
+		const siteFilter = this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '';
 
 		return [
 			{
@@ -175,7 +164,7 @@ const PluginsMain = React.createClass( {
 
 	getEmptyContentUpdateData() {
 		const emptyContentData = { illustration: '/calypso/images/drake/drake-ok.svg' },
-			selectedSite = this.props.sites.getSelectedSite();
+			{ selectedSite } = this.props;
 
 		if ( selectedSite ) {
 			emptyContentData.title = this.translate( 'All plugins on %(siteName)s are {{span}}up to date.{{/span}}', {
@@ -196,7 +185,7 @@ const PluginsMain = React.createClass( {
 
 		if ( selectedSite ) {
 			emptyContentData.actionURL = '/plugins/' + selectedSite.slug;
-			if ( selectedSite.jetpack ) {
+			if ( this.props.isJetpackSite( selectedSite.ID ) ) {
 				emptyContentData.illustration = '/calypso/images/drake/drake-jetpack.svg';
 				emptyContentData.title = this.translate( 'Plugins can\'t be updated on %(siteName)s.', {
 					textOnly: true,
@@ -238,13 +227,16 @@ const PluginsMain = React.createClass( {
 	},
 
 	getUpdatesTabVisibility() {
-		const selectedSite = this.props.sites.getSelectedSite();
+		const { selectedSite } = this.props;
 
 		if ( selectedSite ) {
-			return selectedSite.jetpack && selectedSite.canUpdateFiles;
+			return this.props.isJetpackSite( selectedSite.ID ) && this.props.canJetpackSiteUpdateFiles( selectedSite.ID );
 		}
 
-		return some( this.props.sites.getSelectedOrAllWithPlugins(), site => site && site.jetpack && site.canUpdateFiles );
+		return some(
+			this.props.sites.getSelectedOrAllWithPlugins(),
+			site => site && this.props.isJetpackSite( site.ID ) && this.props.canJetpackSiteUpdateFiles( site.ID )
+		);
 	},
 
 	shouldShowPluginListPlaceholders() {
@@ -259,7 +251,7 @@ const PluginsMain = React.createClass( {
 
 	renderPluginsContent() {
 		const plugins = this.state.plugins || [];
-		const selectedSite = this.props.sites.getSelectedSite();
+		const { selectedSite } = this.props;
 
 		if ( isEmpty( plugins ) && ! this.isFetchingPlugins() ) {
 			if ( this.props.search ) {
@@ -337,9 +329,9 @@ const PluginsMain = React.createClass( {
 	},
 
 	render() {
-		const selectedSite = this.props.sites.getSelectedSite();
+		const { selectedSite } = this.props;
 
-		if ( ! getOr( selectedSite, 'jetpack', true ) ) {
+		if ( selectedSite && ! this.props.isJetpackSite( selectedSite.ID ) ) {
 			return (
 				<Main>
 					{ this.renderDocumentHead() }
@@ -363,7 +355,7 @@ const PluginsMain = React.createClass( {
 			);
 		}
 
-		if ( selectedSite && selectedSite.jetpack && ! selectedSite.canManage() ) {
+		if ( selectedSite && this.props.isJetpackSite( selectedSite.ID ) && ! this.props.canJetpackSiteManage( selectedSite.ID ) ) {
 			return (
 				<Main>
 					{ this.renderDocumentHead() }
@@ -428,11 +420,14 @@ const PluginsMain = React.createClass( {
 } );
 
 export default connect(
-	state => {
-		return {
-			wporgPlugins: state.plugins.wporg.items
-		};
-	},
+	state => ( {
+		wporgPlugins: state.plugins.wporg.items,
+		selectedSite: getSelectedSite( state ),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+		isJetpackSite: siteId => isJetpackSite( state, siteId ),
+		canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
+		canJetpackSiteUpdateFiles: siteId => canJetpackSiteUpdateFiles( state, siteId ),
+	} ),
 	dispatch => bindActionCreators( {
 		wporgFetchPluginData
 	}, dispatch )

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -141,7 +141,7 @@ module.exports = React.createClass( {
 				return (
 					<div className={ classNames( { 'plugin-install-button__install': true, embed: this.props.isEmbed } ) }>
 						<span className="plugin-install-button__warning">{ this.translate( 'Jetpack 3.7 is required' ) }</span>
-						<Button compact={ true } onclick={ this.updateJetpackAction } href={ this.props.selectedSite.options.admin_url + 'plugins.php?plugin_status=upgrade' } >{ this.translate( 'update', { context: 'verb, update plugin button label' } ) }</Button>
+						<Button compact={ true } onClick={ this.updateJetpackAction } href={ this.props.selectedSite.options.admin_url + 'plugins.php?plugin_status=upgrade' } >{ this.translate( 'update', { context: 'verb, update plugin button label' } ) }</Button>
 					</div>
 				);
 			}

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -356,7 +356,7 @@ const SinglePlugin = React.createClass( {
 			);
 		}
 
-		const installInProgress = PluginsLog.isInProgressAction( selectedSite.ID, this.state.plugin.slug, 'INSTALL_PLUGIN' );
+		const installing = selectedSite && PluginsLog.isInProgressAction( selectedSite.ID, this.state.plugin.slug, 'INSTALL_PLUGIN' );
 
 		return (
 			<MainComponent>
@@ -375,7 +375,7 @@ const SinglePlugin = React.createClass( {
 								? null
 								: !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug )
 						}
-						isInstalling={ installInProgress } />
+						isInstalling={ installing } />
 					{ plugin.wporg && <PluginSections plugin={ plugin } /> }
 					{ this.renderSitesList( plugin ) }
 				</div>

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -2,9 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import debugModule from 'debug';
 import page from 'page';
 import uniq from 'lodash/uniq';
 import upperFirst from 'lodash/upperFirst';
@@ -12,7 +10,6 @@ import upperFirst from 'lodash/upperFirst';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import PluginSiteList from 'my-sites/plugins/plugin-site-list';
 import HeaderCake from 'components/header-cake';
 import PluginMeta from 'my-sites/plugins/plugin-meta';
@@ -31,16 +28,11 @@ import EmptyContent from 'components/empty-content';
 import FeatureExample from 'components/feature-example';
 import DocumentHead from 'components/data/document-head';
 import WpcomPluginsList from 'my-sites/plugins-wpcom/plugins-list';
-
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:my-sites:plugin' );
+import { getSelectedSite } from 'state/ui/selectors';
+import { isJetpackSite, canJetpackSiteManage } from 'state/sites/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const SinglePlugin = React.createClass( {
-
-	displayName: 'SinglePlugin',
-
 	_DEFAULT_PLUGINS_BASE_PATH: 'http://wordpress.org/plugins/',
 
 	_currentPageTitle: null,
@@ -54,7 +46,6 @@ const SinglePlugin = React.createClass( {
 	},
 
 	componentDidMount() {
-		debug( 'Plugin React component mounted.' );
 		this.props.sites.on( 'change', this.refreshSitesAndPlugins );
 		PluginsStore.on( 'change', this.refreshSitesAndPlugins );
 		PluginsLog.on( 'change', this.refreshSitesAndPlugins );
@@ -80,10 +71,10 @@ const SinglePlugin = React.createClass( {
 
 	getSitesPlugin( nextProps ) {
 		const props = nextProps || this.props,
-			selectedSite = this.props.sites.getSelectedSite();
+			{ selectedSite } = this.props;
 
 		// .com sites can't install non .com plugins, if that's the case we don't retrieve any data from the store
-		if ( selectedSite && ! selectedSite.jetpack ) {
+		if ( selectedSite && ! this.props.isJetpackSite( selectedSite.ID ) ) {
 			return {
 				accessError: false,
 				sites: [],
@@ -93,13 +84,12 @@ const SinglePlugin = React.createClass( {
 		}
 
 		const sites = uniq( props.sites.getSelectedOrAllWithPlugins() ),
-			sitePlugin = PluginsStore.getPlugin( sites, props.pluginSlug );
-
-		let plugin = Object.assign( {
-			name: props.pluginSlug,
-			id: props.pluginSlug,
-			slug: props.pluginSlug
-		}, sitePlugin );
+			sitePlugin = PluginsStore.getPlugin( sites, props.pluginSlug ),
+			plugin = Object.assign( {
+				name: props.pluginSlug,
+				id: props.pluginSlug,
+				slug: props.pluginSlug
+			}, sitePlugin );
 
 		return {
 			accessError: pluginsAccessControl.hasRestrictedAccess(),
@@ -122,7 +112,7 @@ const SinglePlugin = React.createClass( {
 			args: { pluginName: upperFirst( this._currentPageTitle ) },
 			textOnly: true,
 			context: 'Page title: Plugin detail'
-		} )
+		} );
 	},
 
 	updatePageTitle() {
@@ -135,7 +125,7 @@ const SinglePlugin = React.createClass( {
 
 		this.setState( {
 			pageTitle: this.buildPageTitle( pageTitle )
-		} )
+		} );
 	},
 
 	removeNotice( error ) {
@@ -143,15 +133,15 @@ const SinglePlugin = React.createClass( {
 	},
 
 	recordEvent( eventAction ) {
-		analytics.ga.recordEvent( 'Plugins', eventAction, 'Plugin Name', this.props.pluginSlug );
+		this.props.recordGoogleEvent( 'Plugins', eventAction, 'Plugin Name', this.props.pluginSlug );
 	},
 
 	getPreviousListUrl() {
 		const splitPluginUrl = this.props.prevPath.split( '/' + this.props.pluginSlug + '/' );
 		let previousPath = this.props.prevPath;
 
-		if ( splitPluginUrl[1] ) { // Strip out the site url part.
-			previousPath = splitPluginUrl[0];
+		if ( splitPluginUrl[ 1 ] ) { // Strip out the site url part.
+			previousPath = splitPluginUrl[ 0 ];
 		}
 		return previousPath + '/' +
 			( this.props.siteUrl || '' ) +
@@ -186,7 +176,7 @@ const SinglePlugin = React.createClass( {
 		const sites = this.props.sites.getSelectedOrAllWithPlugins() || [];
 
 		// If the plugin has at least one site then we know it exists
-		if ( plugin.sites && plugin.sites[0] ) {
+		if ( plugin.sites && plugin.sites[ 0 ] ) {
 			return true;
 		}
 
@@ -219,7 +209,7 @@ const SinglePlugin = React.createClass( {
 	},
 
 	getPluginDoesNotExistView( selectedSite ) {
-		let actionUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' ),
+		const actionUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' ),
 			action = this.translate( 'Browse all plugins' );
 
 		return (
@@ -262,7 +252,8 @@ const SinglePlugin = React.createClass( {
 	},
 
 	renderPluginPlaceholder() {
-		const selectedSite = this.props.sites.getSelectedSite();
+		const { selectedSite } = this.props;
+
 		return (
 			<MainComponent>
 				<SidebarNavigation />
@@ -271,7 +262,11 @@ const SinglePlugin = React.createClass( {
 					<PluginMeta
 						isPlaceholder
 						notices={ this.state.notices }
-						isInstalledOnSite={ this.isFetchingSites() ? null : !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug ) }
+						isInstalledOnSite={
+							this.isFetchingSites()
+								? null
+								: !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug )
+						}
 						plugin={ this.getPlugin() }
 						siteUrl={ this.props.siteUrl }
 						sites={ this.state.sites }
@@ -309,9 +304,9 @@ const SinglePlugin = React.createClass( {
 	},
 
 	render() {
-		const selectedSite = this.props.sites.getSelectedSite();
+		const { selectedSite } = this.props;
 
-		if ( selectedSite && ! selectedSite.jetpack ) {
+		if ( selectedSite && ! this.props.isJetpackSite( selectedSite.ID ) ) {
 			return (
 				<MainComponent>
 					{ this.renderDocumentHead() }
@@ -327,7 +322,10 @@ const SinglePlugin = React.createClass( {
 					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
-					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
+					{ this.state.accessError.featureExample
+						? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample>
+						: null
+					}
 				</MainComponent>
 			);
 		}
@@ -343,7 +341,7 @@ const SinglePlugin = React.createClass( {
 			return this.getPluginDoesNotExistView( selectedSite );
 		}
 
-		if ( selectedSite && selectedSite.jetpack && ! selectedSite.canManage() ) {
+		if ( selectedSite && this.props.isJetpackSite( selectedSite.ID ) && ! this.props.canJetpackSiteManage( selectedSite.ID ) ) {
 			return (
 				<MainComponent>
 					{ this.renderDocumentHead() }
@@ -372,7 +370,11 @@ const SinglePlugin = React.createClass( {
 						siteUrl={ this.props.siteUrl }
 						sites={ this.state.sites }
 						selectedSite={ selectedSite }
-						isInstalledOnSite={ this.isFetchingSites() ? null : !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug ) }
+						isInstalledOnSite={
+							this.isFetchingSites()
+								? null
+								: !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug )
+						}
 						isInstalling={ installInProgress } />
 					{ plugin.wporg && <PluginSections plugin={ plugin } /> }
 					{ this.renderSitesList( plugin ) }
@@ -383,11 +385,15 @@ const SinglePlugin = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => {
-		return {
-			wporgPlugins: state.plugins.wporg.items,
-			wporgFetching: WporgPluginsSelectors.isFetching( state.plugins.wporg.fetchingItems, props.pluginSlug )
-		};
-	},
-	dispatch => bindActionCreators( { wporgFetchPluginData }, dispatch )
+	( state, props ) => ( {
+		wporgPlugins: state.plugins.wporg.items,
+		wporgFetching: WporgPluginsSelectors.isFetching( state.plugins.wporg.fetchingItems, props.pluginSlug ),
+		selectedSite: getSelectedSite( state ),
+		isJetpackSite: siteId => isJetpackSite( state, siteId ),
+		canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
+	} ),
+	{
+		recordGoogleEvent,
+		wporgFetchPluginData
+	}
 )( SinglePlugin );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 /**
@@ -28,6 +27,8 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import FeatureExample from 'components/feature-example';
 import { hasTouch } from 'lib/touch-detect';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSite } from 'state/ui/selectors';
+import { isJetpackSite, canJetpackSiteManage } from 'state/sites/selectors';
 
 const PluginsBrowser = React.createClass( {
 
@@ -292,7 +293,7 @@ const PluginsBrowser = React.createClass( {
 				</MainComponent>
 			);
 		}
-		const selectedSite = this.props.sites.getSelectedSite();
+		const { selectedSite } = this.props;
 
 		return (
 			<MainComponent>
@@ -310,10 +311,12 @@ const PluginsBrowser = React.createClass( {
 	},
 
 	render() {
-		const selectedSite = this.props.sites.getSelectedSite();
-		if ( this.state.accessError ||
-				( selectedSite && selectedSite.jetpack && ! selectedSite.canManage() )
-			) {
+		const { selectedSite } = this.props;
+		const cantManage = selectedSite &&
+			this.props.isJetpackSite( selectedSite.ID ) &&
+			! this.props.canJetpackSiteManage( selectedSite.ID );
+
+		if ( this.state.accessError || cantManage ) {
 			return this.renderAccessError( selectedSite );
 		}
 
@@ -329,8 +332,12 @@ const PluginsBrowser = React.createClass( {
 } );
 
 export default connect(
-	null,
-	dispatch => bindActionCreators( {
+	state => ( {
+		selectedSite: getSelectedSite( state ),
+		isJetpackSite: siteId => isJetpackSite( state, siteId ),
+		canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
+	} ),
+	{
 		recordTracksEvent
-	}, dispatch )
+	}
 )( PluginsBrowser );

--- a/client/my-sites/plugins/plugins-list/README.md
+++ b/client/my-sites/plugins/plugins-list/README.md
@@ -12,7 +12,7 @@ return <PluginsList
 		header={ this.translate( 'Plugins' ) }
 		plugins={ this.getPlugins() }
 		sites={ this.props.sites }
-		selectedSite={ this.props.sites.getSelectedSite() }
+		selectedSite={ this.props.selectedSite }
 		isPlaceholder= { this.showPluginListPlaceholders( true ) } />;
 ```
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -34,7 +34,7 @@ function checkPropsChange( nextProps, propArr ) {
 	return false;
 }
 
-const PluginsList = React.createClass( {
+export const PluginsList = React.createClass( {
 	mixins: [ PluginNotices ],
 
 	propTypes: {
@@ -49,6 +49,12 @@ const PluginsList = React.createClass( {
 		selectedSiteSlug: PropTypes.string,
 		pluginUpdateCount: PropTypes.number,
 		isPlaceholder: PropTypes.bool.isRequired,
+	},
+
+	getDefaultProps() {
+		return {
+			recordGoogleEvent: () => {}
+		};
 	},
 
 	shouldComponentUpdate( nextProps, nextState ) {
@@ -456,9 +462,5 @@ export default connect(
 		selectedSite: getSelectedSite( state ),
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	} ),
-	{ recordGoogleEvent },
-	null,
-	{
-		withRef: true
-	}
+	{ recordGoogleEvent }
 )( PluginsList );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -155,7 +155,8 @@ const PluginsList = React.createClass( {
 	},
 
 	siteSuffix() {
-		return ( this.props.selectedSite || this.props.sites.get().length === 1 ) ? '/' + this.props.selectedSiteSlug : '';
+		const hasSingleSite = this.props.sites && this.props.sites.get().length === 1;
+		return ( this.props.selectedSite || hasSingleSite ) ? '/' + this.props.selectedSiteSlug : '';
 	},
 
 	recordEvent( eventAction, includeSelectedPlugins ) {
@@ -455,5 +456,9 @@ export default connect(
 		selectedSite: getSelectedSite( state ),
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	} ),
-	{ recordGoogleEvent }
+	{ recordGoogleEvent },
+	null,
+	{
+		withRef: true
+	}
 )( PluginsList );

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -40,7 +40,7 @@ describe( 'PluginsList', () => {
 
 		testRenderer = TestUtils.renderIntoDocument;
 
-		siteListMock = { getSelectedSite: () => sites[ 0 ] };
+		siteListMock = { getSelectedSite: () => sites[ 0 ], get: () => sites };
 		PluginsList = require( '../' );
 	} );
 
@@ -68,7 +68,7 @@ describe( 'PluginsList', () => {
 					<PluginsList { ...props } />
 				</ReduxProvider>
 			);
-			renderedPluginsList = TestUtils.scryRenderedComponentsWithType( renderedPluginsList, PluginsList )[ 0 ];
+			renderedPluginsList = TestUtils.scryRenderedComponentsWithType( renderedPluginsList, PluginsList )[ 0 ].getWrappedInstance();
 		} );
 
 		it( 'should be intialized with no selectedPlugins', () => {

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -41,7 +41,7 @@ describe( 'PluginsList', () => {
 		testRenderer = TestUtils.renderIntoDocument;
 
 		siteListMock = { getSelectedSite: () => sites[ 0 ], get: () => sites };
-		PluginsList = require( '../' );
+		PluginsList = require( '../' ).PluginsList;
 	} );
 
 	describe( 'rendering bulk actions', function() {
@@ -68,7 +68,7 @@ describe( 'PluginsList', () => {
 					<PluginsList { ...props } />
 				</ReduxProvider>
 			);
-			renderedPluginsList = TestUtils.scryRenderedComponentsWithType( renderedPluginsList, PluginsList )[ 0 ].getWrappedInstance();
+			renderedPluginsList = TestUtils.scryRenderedComponentsWithType( renderedPluginsList, PluginsList )[ 0 ];
 		} );
 
 		it( 'should be intialized with no selectedPlugins', () => {


### PR DESCRIPTION
This PR removes usage of `sitesList.getSelectedSite()` within `my-sites/plugins/*` - except for `jetpack-plugins-setup`, which is handled in #9089. In addition, it migrates the changed files to use the newly introduced Jetpack selectors. It also fixes some ESLint warnings and performs small cleanup where necessary. And it fixes a couple of errors that were occurring with empty Redux store.

To test:

* Checkout this branch
* Play around within all Jetpack Plugins pages: plugins list, single plugin, plugin browser, plugin install and edit actions.
* Verify there are no regressions.

/cc @gwwar @ryelle @johnHackworth