### PR TITLE
Plugins: ES6ify the PluginAction component

### DIFF
--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -1,20 +1,17 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var CompactToggle = require( 'components/forms/form-toggle/compact' ),
-	InfoPopover = require( 'components/info-popover' );
+import CompactToggle from 'components/forms/form-toggle/compact';
+import InfoPopover from 'components/info-popover';
 
-module.exports = React.createClass( {
-
-	displayName: 'PluginAction',
-
-	handleAction: function( event ) {
+const PluginAction = React.createClass( {
+	handleAction( event ) {
 		if ( ! this.props.disabledInfo ) {
 			this.props.action();
 		} else {
@@ -22,7 +19,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	renderLabel: function() {
+	renderLabel() {
 		if ( this.props.label ) {
 			return (
 				<label
@@ -39,21 +36,24 @@ module.exports = React.createClass( {
 		return null;
 	},
 
-	renderDisabledInfo: function() {
-		return [ <InfoPopover
-					key="renderDisabledInfoPopOver"
-					className="plugin-action__disabled-info"
-					position="bottom left"
-					popoverName={ 'Plugin Action Disabled' + this.props.label }
-					gaEventCategory="Plugins"
-					ref="infoPopover"
-					ignoreContext={ this.refs && this.refs.disabledInfoLabel }
-					>
-					{ this.props.disabledInfo }
-				</InfoPopover>, this.renderLabel() ];
+	renderDisabledInfo() {
+		return [
+			<InfoPopover
+				key="renderDisabledInfoPopOver"
+				className="plugin-action__disabled-info"
+				position="bottom left"
+				popoverName={ 'Plugin Action Disabled' + this.props.label }
+				gaEventCategory="Plugins"
+				ref="infoPopover"
+				ignoreContext={ this.refs && this.refs.disabledInfoLabel }
+				>
+				{ this.props.disabledInfo }
+			</InfoPopover>,
+			this.renderLabel()
+		];
 	},
 
-	renderToggle: function() {
+	renderToggle() {
 		return (
 			<CompactToggle
 				onChange={ this.props.action }
@@ -67,7 +67,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderChildren: function() {
+	renderChildren() {
 		return (
 			<div>
 				<span className="plugin-action__children">{ this.props.children }</span>
@@ -76,7 +76,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderInner: function() {
+	renderInner() {
 		if ( this.props.disabledInfo ) {
 			return this.renderDisabledInfo();
 		}
@@ -88,11 +88,18 @@ module.exports = React.createClass( {
 		return this.renderToggle();
 	},
 
-	render: function() {
+	render() {
+		const additionalClasses = {
+			'is-disabled': this.props.disabled,
+			'has-disabled-info': !! this.props.disabledInfo
+		};
+
 		return (
-			<div className={ classNames( 'plugin-action', { 'is-disabled': this.props.disabled, 'has-disabled-info': !! this.props.disabledInfo }, this.props.className ) }>
+			<div className={ classNames( 'plugin-action', additionalClasses, this.props.className ) }>
 				{ this.renderInner() }
 			</div>
 		);
 	}
 } );
+
+export default PluginAction;


### PR DESCRIPTION
This PR ES6ifies the `PluginAction` component, fixes some ESLint warnings, and improves code style a bit.

To test:

* Checkout this branch
* Go to a page that has a list of plugins with actions (like `http://calypso.localhost:3000/plugins/$site`, where `$site` is one of your Jetpack sites.
* Verify there are no regressions with the display and functionality of the actions.
* Verify the component tests still pass: `npm run test-client client/my-sites/plugins/plugin-action
`

/cc @johnHackworth @ryelle @oskosk 