### PR TITLE
Domain Management: add Office 365 verification + dns setup

### DIFF
--- a/client/lib/domains/dns/reducer.js
+++ b/client/lib/domains/dns/reducer.js
@@ -131,6 +131,13 @@ function reducer( state, payload ) {
 				isBeingAdded: false
 			} );
 			break;
+		case ActionTypes.DNS_ADD_OFFICE_COMPLETED:
+			state = updateDomainState( state, action.domainName, {
+				records: action.records,
+				isFetching: false,
+				hasLoadedFromServer: true
+			} );
+			break;
 		case ActionTypes.DNS_ADD_FAILED:
 			state = updateDomainState( state, action.domainName, {
 				isSubmittingForm: false

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -291,7 +291,14 @@ function deleteDns( domainName, record, onComplete ) {
 }
 
 function addDnsOffice( domainName, token, onComplete ) {
-	wpcom.addDnsOffice( domainName, token, ( error ) => {
+	wpcom.addDnsOffice( domainName, token, ( error, data ) => {
+		if ( ! error ) {
+			Dispatcher.handleServerAction( {
+				type: ActionTypes.DNS_FETCH_COMPLETED,
+				records: data && data.records,
+				domainName
+			} );
+		}
 		onComplete( error );
 	} );
 }

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -294,7 +294,7 @@ function addDnsOffice( domainName, token, onComplete ) {
 	wpcom.addDnsOffice( domainName, token, ( error, data ) => {
 		if ( ! error ) {
 			Dispatcher.handleServerAction( {
-				type: ActionTypes.DNS_FETCH_COMPLETED,
+				type: ActionTypes.DNS_ADD_OFFICE_COMPLETED,
 				records: data && data.records,
 				domainName
 			} );

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -290,6 +290,12 @@ function deleteDns( domainName, record, onComplete ) {
 	} );
 }
 
+function addDnsOffice( domainName, token, onComplete ) {
+	wpcom.addDnsOffice( domainName, token, ( error ) => {
+		onComplete( error );
+	} );
+}
+
 function fetchNameservers( domainName ) {
 	const nameservers = NameserversStore.getByDomainName( domainName );
 
@@ -551,6 +557,7 @@ function declineTransfer( domainName, onComplete ) {
 export {
 	acceptTransfer,
 	addDns,
+	addDnsOffice,
 	addEmailForwarding,
 	closeSiteRedirectNotice,
 	declineTransfer,

--- a/client/lib/upgrades/constants.js
+++ b/client/lib/upgrades/constants.js
@@ -11,6 +11,7 @@ module.exports.action = keyMirror( {
 	DNS_ADD: null,
 	DNS_ADD_COMPLETED: null,
 	DNS_ADD_FAILED: null,
+	DNS_ADD_OFFICE_COMPLETED: null,
 	DNS_DELETE: null,
 	DNS_DELETE_COMPLETED: null,
 	DNS_DELETE_FAILED: null,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1573,6 +1573,10 @@ Undocumented.prototype.updateDns = function( domain, records, fn ) {
 	return this.wpcom.req.post( '/domains/' + domain + '/dns', body, fn );
 };
 
+Undocumented.prototype.addDnsOffice = function( domain, token, callback ) {
+	return this.wpcom.req.post( '/domains/' + domain + '/dns/office/add', { token }, callback );
+};
+
 Undocumented.prototype.fetchWapiDomainInfo = function( domainName, fn ) {
 	return this.wpcom.req.get( '/domains/' + domainName + '/status', fn );
 };

--- a/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import classnames from 'classnames';
 import includes from 'lodash/includes';
 import assign from 'lodash/assign';
 import find from 'lodash/find';
@@ -33,7 +32,6 @@ const DnsAddNew = React.createClass( {
 
 	getInitialState() {
 		return {
-			show: false,
 			fields: null,
 			type: 'A'
 		};
@@ -77,11 +75,6 @@ const DnsAddNew = React.createClass( {
 	onAddDnsRecord( event ) {
 		event.preventDefault();
 
-		if ( ! this.state.show ) {
-			this.setState( { show: true } );
-			return;
-		}
-
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			if ( hasErrors ) {
 				return;
@@ -100,7 +93,6 @@ const DnsAddNew = React.createClass( {
 					notices.success( this.translate( 'The DNS record has been added.' ), {
 						duration: 5000
 					} );
-					this.setState( { show: true } );
 				}
 			} );
 		} );
@@ -145,8 +137,7 @@ const DnsAddNew = React.createClass( {
 	},
 
 	render() {
-		const classes = classnames( 'form-content', { 'is-hidden': ! this.state.show } ),
-			options = [ 'A', 'AAAA', 'CNAME', 'MX', 'SRV', 'TXT' ].map( function( type ) {
+		const options = [ 'A', 'AAAA', 'CNAME', 'MX', 'SRV', 'TXT' ].map( function( type ) {
 				return <option key={ type }>{ type }</option>;
 			} ),
 			isSubmitDisabled = formState.isSubmitButtonDisabled( this.state.fields ) ||
@@ -155,7 +146,7 @@ const DnsAddNew = React.createClass( {
 
 		return (
 			<form className="dns__add-new">
-				<div className={ classes }>
+				<div className="dns__form-content">
 					<FormFieldset>
 						<FormLabel>{ this.translate( 'Type', { context: 'DNS Record' } ) }</FormLabel>
 
@@ -169,25 +160,13 @@ const DnsAddNew = React.createClass( {
 
 				<FormFooter>
 					<FormButton
-						disabled={ this.state.show ? isSubmitDisabled : false }
+						disabled={ isSubmitDisabled }
 						onClick={ this.onAddDnsRecord }>
 						{ this.translate( 'Add New DNS Record' ) }
 					</FormButton>
-
-					{ this.state.show && <FormButton
-						type="button"
-						disabled={ this.props.isSubmittingForm }
-						isPrimary={ false }
-						onClick={ this.onCancel }>
-						{ this.translate( 'Cancel' ) }
-					</FormButton> }
 				</FormFooter>
 			</form>
 		);
-	},
-
-	onCancel() {
-		this.setState( { show: false } );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/dns/index.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/index.jsx
@@ -7,13 +7,15 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import DnsAddNew from './dns-add-new';
-import Office365 from './office-365';
 import DnsDetails from './dns-details';
 import DnsList from './dns-list';
 import DomainMainPlaceholder from 'my-sites/upgrades/domain-management/components/domain/main-placeholder';
+import Gridicon from 'components/gridicon';
 import Header from 'my-sites/upgrades/domain-management/components/header';
 import Main from 'components/main';
+import Office365 from './office-365';
 import paths from 'my-sites/upgrades/paths';
 import { getSelectedDomain, isRegisteredDomain } from 'lib/domains';
 import Card from 'components/card/compact';
@@ -76,9 +78,12 @@ const Dns = React.createClass( {
 							selectedDomainName={ this.props.selectedDomainName } />
 					}
 
-					{ ! this.hasOffice() && <a className="dns__office-link" href="#" onClick={ this.office365Toggle }>{ this.state.addNew
+					{ ! this.hasOffice() && <Button borderless onClick={ this.office365Toggle }>
+						<Gridicon icon="mail" />{ ' ' }
+						{ this.state.addNew
+
 							? this.translate( 'Looking for Office 365 setup? Continue from here.' )
-							: this.translate( 'Add new DNS records' ) }</a>
+							: this.translate( 'Add new DNS records' ) }</Button>
 					}
 				</Card>
 			</Main>

--- a/client/my-sites/upgrades/domain-management/dns/index.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/index.jsx
@@ -34,6 +34,17 @@ const Dns = React.createClass( {
 		return { addNew: true };
 	},
 
+	hasOffice() {
+		const { dns } = this.props;
+		if ( ! dns || ! dns.records ) {
+			return false;
+		}
+
+		return !! dns.records.filter( ( record ) => {
+			return 'autodiscover.outlook.com.' === record.data;
+		} ).length;
+	},
+
 	render() {
 		if ( ! this.props.dns.hasLoadedFromServer ) {
 			return <DomainMainPlaceholder goBack={ this.goBack } />;
@@ -56,7 +67,7 @@ const Dns = React.createClass( {
 						selectedSite={ this.props.selectedSite }
 						selectedDomainName={ this.props.selectedDomainName } />
 
-					{ this.state.addNew
+					{ this.state.addNew || this.hasOffice()
 						? <DnsAddNew
 							isSubmittingForm={ this.props.dns.isSubmittingForm }
 							selectedDomainName={ this.props.selectedDomainName } />
@@ -65,9 +76,11 @@ const Dns = React.createClass( {
 							selectedDomainName={ this.props.selectedDomainName } />
 					}
 
-					<a className="dns__office-link" href="#" onClick={ this.office365Toggle }>{ this.state.addNew
-						? this.translate( 'Looking for Office 365 setup? Continue from here.' )
-						: this.translate( 'Add new DNS records' ) }</a>
+					{ ! this.hasOffice()
+						? <a className="dns__office-link" href="#" onClick={ this.office365Toggle }>{ this.state.addNew
+							? this.translate( 'Looking for Office 365 setup? Continue from here.' )
+							: this.translate( 'Add new DNS records' ) }</a>
+						: null }
 				</Card>
 			</Main>
 		);

--- a/client/my-sites/upgrades/domain-management/dns/index.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/index.jsx
@@ -30,6 +30,10 @@ const Dns = React.createClass( {
 		] ).isRequired
 	},
 
+	getInitialState() {
+		return { addNew: true };
+	},
+
 	render() {
 		if ( ! this.props.dns.hasLoadedFromServer ) {
 			return <DomainMainPlaceholder goBack={ this.goBack } />;
@@ -52,13 +56,18 @@ const Dns = React.createClass( {
 						selectedSite={ this.props.selectedSite }
 						selectedDomainName={ this.props.selectedDomainName } />
 
-					<DnsAddNew
-						isSubmittingForm={ this.props.dns.isSubmittingForm }
-						selectedDomainName={ this.props.selectedDomainName } />
+					{ this.state.addNew
+						? <DnsAddNew
+							isSubmittingForm={ this.props.dns.isSubmittingForm }
+							selectedDomainName={ this.props.selectedDomainName } />
+						: <Office365
+							isSubmittingForm={ this.props.dns.isSubmittingForm }
+							selectedDomainName={ this.props.selectedDomainName } />
+					}
 
-					<Office365
-						isSubmittingForm={ this.props.dns.isSubmittingForm }
-						selectedDomainName={ this.props.selectedDomainName } />
+					<button onClick={ this.office365Toggle }>{ this.state.addNew
+						? this.translate( 'Looking for Office 365 setup? Continue from here.' )
+						: this.translate( 'Add new DNS records' ) }</button>
 				</Card>
 			</Main>
 		);
@@ -77,6 +86,11 @@ const Dns = React.createClass( {
 			this.props.selectedSite.slug,
 			this.props.selectedDomainName
 		) );
+	},
+
+	office365Toggle() {
+		event.preventDefault();
+		this.setState( { addNew: ! this.state.addNew } );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/dns/index.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/index.jsx
@@ -40,9 +40,9 @@ const Dns = React.createClass( {
 			return false;
 		}
 
-		return !! dns.records.filter( ( record ) => {
+		return dns.records.some( ( record ) => {
 			return 'autodiscover.outlook.com.' === record.data;
-		} ).length;
+		} );
 	},
 
 	render() {
@@ -76,11 +76,10 @@ const Dns = React.createClass( {
 							selectedDomainName={ this.props.selectedDomainName } />
 					}
 
-					{ ! this.hasOffice()
-						? <a className="dns__office-link" href="#" onClick={ this.office365Toggle }>{ this.state.addNew
+					{ ! this.hasOffice() && <a className="dns__office-link" href="#" onClick={ this.office365Toggle }>{ this.state.addNew
 							? this.translate( 'Looking for Office 365 setup? Continue from here.' )
 							: this.translate( 'Add new DNS records' ) }</a>
-						: null }
+					}
 				</Card>
 			</Main>
 		);

--- a/client/my-sites/upgrades/domain-management/dns/index.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/index.jsx
@@ -8,6 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import DnsAddNew from './dns-add-new';
+import Office365 from './office-365';
 import DnsDetails from './dns-details';
 import DnsList from './dns-list';
 import DomainMainPlaceholder from 'my-sites/upgrades/domain-management/components/domain/main-placeholder';
@@ -52,6 +53,10 @@ const Dns = React.createClass( {
 						selectedDomainName={ this.props.selectedDomainName } />
 
 					<DnsAddNew
+						isSubmittingForm={ this.props.dns.isSubmittingForm }
+						selectedDomainName={ this.props.selectedDomainName } />
+
+					<Office365
 						isSubmittingForm={ this.props.dns.isSubmittingForm }
 						selectedDomainName={ this.props.selectedDomainName } />
 				</Card>

--- a/client/my-sites/upgrades/domain-management/dns/index.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/index.jsx
@@ -65,9 +65,9 @@ const Dns = React.createClass( {
 							selectedDomainName={ this.props.selectedDomainName } />
 					}
 
-					<button onClick={ this.office365Toggle }>{ this.state.addNew
+					<a className="dns__office-link" href="#" onClick={ this.office365Toggle }>{ this.state.addNew
 						? this.translate( 'Looking for Office 365 setup? Continue from here.' )
-						: this.translate( 'Add new DNS records' ) }</button>
+						: this.translate( 'Add new DNS records' ) }</a>
 				</Card>
 			</Main>
 		);
@@ -88,7 +88,7 @@ const Dns = React.createClass( {
 		) );
 	},
 
-	office365Toggle() {
+	office365Toggle( event ) {
 		event.preventDefault();
 		this.setState( { addNew: ! this.state.addNew } );
 	}

--- a/client/my-sites/upgrades/domain-management/dns/office-365.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/office-365.jsx
@@ -20,7 +20,7 @@ import * as upgradesActions from 'lib/upgrades/actions';
 class Office365 extends Component {
 	constructor( props ) {
 		super( props );
-		this.state = { token: '' };
+		this.state = { token: '', submitting: false };
 	}
 
 	onChange = ( event ) => {
@@ -30,11 +30,13 @@ class Office365 extends Component {
 
 	onAddDnsRecords = ( event ) => {
 		event.preventDefault();
+		this.setState( { submitting: true } );
 		upgradesActions.addDnsOffice( this.props.selectedDomainName, this.state.token, ( error ) => {
 			if ( error ) {
 				notices.error( error.message || this.props.translate( 'The DNS record has not been added.' ) );
+				this.setState( { submitting: false } );
 			} else {
-				notices.success( this.props.translate( 'The DNS record has been added.' ), {
+				notices.success( this.props.translate( 'The DNS records have been added.' ), {
 					duration: 5000
 				} );
 			}
@@ -60,7 +62,7 @@ class Office365 extends Component {
 
 					<FormFooter>
 						<FormButton
-							disabled={ ! isDataValid }
+							disabled={ ! isDataValid || this.state.submitting }
 							onClick={ this.onAddDnsRecords }>
 							{ this.props.translate( 'Set up Office 365' ) }
 						</FormButton>

--- a/client/my-sites/upgrades/domain-management/dns/office-365.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/office-365.jsx
@@ -56,8 +56,8 @@ class Office365 extends Component {
 							isError={ ! isEmpty( this.state.token ) && ! isDataValid }
 							onChange={ this.onChange }
 							placeholder="MS=ms..." />
-						{ this.state.token && ! isDataValid
-							? <FormInputValidation text={ this.props.translate( 'Invalid Token' ) } isError={ true } /> : null }
+						{ this.state.token && ! isDataValid &&
+							<FormInputValidation text={ this.props.translate( 'Invalid Token' ) } isError={ true } /> }
 					</FormFieldset>
 
 					<FormFooter>

--- a/client/my-sites/upgrades/domain-management/dns/office-365.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/office-365.jsx
@@ -36,7 +36,7 @@ class Office365 extends Component {
 				notices.error( error.message || this.props.translate( 'The DNS record has not been added.' ) );
 				this.setState( { submitting: false } );
 			} else {
-				notices.success( this.props.translate( 'The DNS records have been added.' ), {
+				notices.success( this.props.translate( 'All DNS records that Office 365 needs have been added.' ), {
 					duration: 5000
 				} );
 			}
@@ -50,7 +50,7 @@ class Office365 extends Component {
 			<form className="dns__office365">
 				<div className="dns__form-content">
 					<FormFieldset>
-						<FormLabel>{ this.props.translate( 'Office 365 Verification Token' ) }</FormLabel>
+						<FormLabel>{ this.props.translate( 'Office 365 Verification Token - from the TXT record verification' ) }</FormLabel>
 						<FormTextInput
 							name="token"
 							isError={ ! isEmpty( this.state.token ) && ! isDataValid }

--- a/client/my-sites/upgrades/domain-management/dns/office-365.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/office-365.jsx
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import isEmpty from 'lodash/isEmpty';
+import React, { Component } from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormFooter from 'my-sites/upgrades/domain-management/components/form-footer';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import notices from 'notices';
+import * as upgradesActions from 'lib/upgrades/actions';
+
+class Office365 extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { show: false, token: '' };
+	}
+
+	onAddOffice365 = ( event ) => {
+		event.preventDefault();
+		this.setState( { show: true } );
+	}
+
+	onChange = ( event ) => {
+		const { value } = event.target;
+		this.setState( { show: true, token: value } );
+	}
+
+	onAddDnsRecords = ( event ) => {
+		event.preventDefault();
+		upgradesActions.addDnsOffice( this.props.selectedDomainName, this.state.token, ( error ) => {
+			if ( error ) {
+				notices.error( error.message || this.props.translate( 'The DNS record has not been added.' ) );
+			} else {
+				notices.success( this.props.translate( 'The DNS record has been added.' ), {
+					duration: 5000
+				} );
+				this.setState( { show: true } );
+			}
+		} );
+	}
+
+	render() {
+		const classes = classnames( 'form-content', { 'is-hidden': ! this.state.show } );
+		const isDataValid = this.state.token.match( /^MS=ms\d+$/ );
+
+		return (
+			<form className="dns__office365">
+				<a onClick={ this.onAddOffice365 }>{ this.props.translate( 'Looking for Office 365 setup? Continue from here.' ) }</a>
+				<div className={ classes }>
+					<FormFieldset>
+						<FormLabel>{ this.props.translate( 'Office 365 Verification Token' ) }</FormLabel>
+						<FormTextInput
+							name="token"
+							isError={ ! isEmpty( this.state.token ) && ! isDataValid }
+							onChange={ this.onChange }
+							placeholder="MS=ms..." />
+						{ this.state.token && ! isDataValid
+							? <FormInputValidation text={ this.props.translate( 'Invalid Token' ) } isError={ true } /> : null }
+					</FormFieldset>
+
+					<FormFooter>
+						<FormButton
+							disabled={ ! isDataValid }
+							onClick={ this.onAddDnsRecords }>
+							{ this.props.translate( 'Add New DNS Records' ) }
+						</FormButton>
+					</FormFooter>
+				</div>
+			</form>
+		);
+	}
+}
+
+export default localize( Office365 );

--- a/client/my-sites/upgrades/domain-management/dns/office-365.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/office-365.jsx
@@ -3,7 +3,6 @@
  */
 import isEmpty from 'lodash/isEmpty';
 import React, { Component } from 'react';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -21,17 +20,12 @@ import * as upgradesActions from 'lib/upgrades/actions';
 class Office365 extends Component {
 	constructor( props ) {
 		super( props );
-		this.state = { show: false, token: '' };
-	}
-
-	onAddOffice365 = ( event ) => {
-		event.preventDefault();
-		this.setState( { show: true } );
+		this.state = { token: '' };
 	}
 
 	onChange = ( event ) => {
 		const { value } = event.target;
-		this.setState( { show: true, token: value } );
+		this.setState( { token: value } );
 	}
 
 	onAddDnsRecords = ( event ) => {
@@ -43,19 +37,16 @@ class Office365 extends Component {
 				notices.success( this.props.translate( 'The DNS record has been added.' ), {
 					duration: 5000
 				} );
-				this.setState( { show: true } );
 			}
 		} );
 	}
 
 	render() {
-		const classes = classnames( 'form-content', { 'is-hidden': ! this.state.show } );
 		const isDataValid = this.state.token.match( /^MS=ms\d+$/ );
 
 		return (
 			<form className="dns__office365">
-				<a onClick={ this.onAddOffice365 }>{ this.props.translate( 'Looking for Office 365 setup? Continue from here.' ) }</a>
-				<div className={ classes }>
+				<div className="dns__form-content">
 					<FormFieldset>
 						<FormLabel>{ this.props.translate( 'Office 365 Verification Token' ) }</FormLabel>
 						<FormTextInput
@@ -71,7 +62,7 @@ class Office365 extends Component {
 						<FormButton
 							disabled={ ! isDataValid }
 							onClick={ this.onAddDnsRecords }>
-							{ this.props.translate( 'Add New DNS Records' ) }
+							{ this.props.translate( 'Set up Office 365' ) }
 						</FormButton>
 					</FormFooter>
 				</div>

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -546,6 +546,7 @@ input[type=radio].domain-management-list-item__radio {
 }
 
 .dns__details,
+.dns__office-link,
 .custom-nameservers-form__explanation,
 .email-forwarding__explanation,
 .site-redirect__explanation {

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -546,7 +546,6 @@ input[type=radio].domain-management-list-item__radio {
 }
 
 .dns__details,
-.dns__office-link,
 .custom-nameservers-form__explanation,
 .email-forwarding__explanation,
 .site-redirect__explanation {

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -570,6 +570,7 @@ input[type=radio].domain-management-list-item__radio {
 }
 
 .dns__add-new,
+.dns__office365,
 .email-forwarding__add-new {
 	.email-forwarding__limit,
 	.form-content {

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -573,6 +573,7 @@ input[type=radio].domain-management-list-item__radio {
 .dns__office365,
 .email-forwarding__add-new {
 	.email-forwarding__limit,
+	.dns__form-content,
 	.form-content {
 		border-top: 1px solid $gray-light;
 		overflow: visible;


### PR DESCRIPTION
This is work in progress, my Hack Day November 15th.

Adds a short way for adding all the DNS records needed for Office 365 to Domain Management -> DNS.

See D3363-code

![office365](https://cloud.githubusercontent.com/assets/82778/20343661/ee4d5a9c-abf7-11e6-80b2-257d25bcb59a.gif)

To test:
1. Go to Domain Management > Edit Dns for a domain registration that you have
2. Copy/Paste the token from MS Office 365 or invent one starting with MS=ms1234