### PR TITLE
Plugins: ES6ify the PluginActivateToggle component

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-activate-toggle/README.md
@@ -6,7 +6,7 @@ This component is used to display a plugin activation toggle.
 #### How to use:
 
 ```js
-var PluginActivateToggle = require( 'my-sites/plugins/plugin-activate-toggle' );
+import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 
 render: function() {
 	return (

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -1,87 +1,88 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var PluginsActions = require( 'lib/plugins/actions' ),
-	PluginsLog = require( 'lib/plugins/log-store' ),
-	PluginAction = require( 'my-sites/plugins/plugin-action/plugin-action' ),
-	DisconnectJetpackButton = require( 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button' ),
-	analytics = require( 'lib/analytics' );
+import PluginsActions from 'lib/plugins/actions';
+import PluginsLog from 'lib/plugins/log-store';
+import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
+import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
+import analytics from 'lib/analytics';
 
-module.exports = React.createClass( {
-
-	displayName: 'PluginActivateToggle',
-
-	propTypes: {
-		isMock: React.PropTypes.bool,
-		site: React.PropTypes.object.isRequired,
-		plugin: React.PropTypes.object.isRequired,
-	},
-
-	toggleActivation: function() {
-		if ( this.props.isMock || this.props.disabled ) {
+class PluginActivateToggle extends Component {
+	toggleActivation = () => {
+		const { isMock, disabled, site, plugin, notices } = this.props;
+		if ( isMock || disabled ) {
 			return;
 		}
 
-		PluginsActions.togglePluginActivation( this.props.site, this.props.plugin );
-		PluginsActions.removePluginsNotices( this.props.notices.completed.concat( this.props.notices.errors ) );
+		PluginsActions.togglePluginActivation( site, plugin );
+		PluginsActions.removePluginsNotices( notices.completed.concat( notices.errors ) );
 
-		if ( this.props.plugin.active ) {
-			analytics.ga.recordEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', this.props.plugin.slug );
+		if ( plugin.active ) {
+			analytics.ga.recordEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', plugin.slug );
 			analytics.tracks.recordEvent( 'calypso_plugin_deactivate_click', {
-				site: this.props.site.ID,
-				plugin: this.props.plugin.slug
+				site: site.ID,
+				plugin: plugin.slug
 			} );
 		} else {
-			analytics.ga.recordEvent( 'Plugins', 'Clicked Toggle Activate Plugin', 'Plugin Name', this.props.plugin.slug );
+			analytics.ga.recordEvent( 'Plugins', 'Clicked Toggle Activate Plugin', 'Plugin Name', plugin.slug );
 			analytics.tracks.recordEvent( 'calypso_plugin_activate_click', {
-				site: this.props.site.ID,
-				plugin: this.props.plugin.slug
+				site: site.ID,
+				plugin: plugin.slug
 			} );
 		}
-	},
+	}
 
-	render: function() {
-		var inProgress;
+	render() {
+		const { site, plugin, isMock, disabled, translate } = this.props;
 
-		if ( ! this.props.site ) {
+		if ( ! site ) {
 			return null;
 		}
 
-		inProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, [
+		const inProgress = PluginsLog.isInProgressAction( site.ID, plugin.slug, [
 			'ACTIVATE_PLUGIN',
 			'DEACTIVATE_PLUGIN'
 		] );
 
-		if ( this.props.plugin && 'jetpack' === this.props.plugin.slug ) {
+		if ( plugin && 'jetpack' === plugin.slug ) {
 			return (
 				<PluginAction
 					className="plugin-activate-toggle"
-					htmlFor={ 'disconnect-jetpack-' + this.props.site.ID }
+					htmlFor={ 'disconnect-jetpack-' + site.ID }
 					>
 					<DisconnectJetpackButton
-						disabled={ this.props.disabled || ! this.props.plugin }
-						site={ this.props.site }
+						disabled={ disabled || ! plugin }
+						site={ site }
 						redirect="/plugins/jetpack"
-						isMock={ this.props.isMock }
+						isMock={ isMock }
 						/>
 				</PluginAction>
 			);
 		}
 		return (
 			<PluginAction
-				disabled={ this.props.disabled }
+				disabled={ disabled }
 				className="plugin-activate-toggle"
-				label={ this.translate( 'Active', { context: 'plugin status' } ) }
+				label={ translate( 'Active', { context: 'plugin status' } ) }
 				inProgress={ inProgress }
-				status={ this.props.plugin && this.props.plugin.active }
+				status={ plugin && plugin.active }
 				action={ this.toggleActivation }
-				htmlFor={ 'activate-' + this.props.plugin.slug + '-' + this.props.site.ID }
+				htmlFor={ 'activate-' + plugin.slug + '-' + site.ID }
 				/>
 		);
 	}
-} );
+}
+
+PluginActivateToggle.propTypes = {
+	site: PropTypes.object.isRequired,
+	plugin: PropTypes.object.isRequired,
+	isMock: PropTypes.bool,
+};
+
+export default localize( PluginActivateToggle );

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,9 +12,9 @@ import PluginsActions from 'lib/plugins/actions';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
 import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
-import analytics from 'lib/analytics';
+import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
-class PluginActivateToggle extends Component {
+export class PluginActivateToggle extends Component {
 	toggleActivation = () => {
 		const { isMock, disabled, site, plugin, notices } = this.props;
 		if ( isMock || disabled ) {
@@ -24,14 +25,14 @@ class PluginActivateToggle extends Component {
 		PluginsActions.removePluginsNotices( notices.completed.concat( notices.errors ) );
 
 		if ( plugin.active ) {
-			analytics.ga.recordEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', plugin.slug );
-			analytics.tracks.recordEvent( 'calypso_plugin_deactivate_click', {
+			this.props.recordGoogleEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', plugin.slug );
+			this.props.recordTracksEvent( 'calypso_plugin_deactivate_click', {
 				site: site.ID,
 				plugin: plugin.slug
 			} );
 		} else {
-			analytics.ga.recordEvent( 'Plugins', 'Clicked Toggle Activate Plugin', 'Plugin Name', plugin.slug );
-			analytics.tracks.recordEvent( 'calypso_plugin_activate_click', {
+			this.props.recordGoogleEvent( 'Plugins', 'Clicked Toggle Activate Plugin', 'Plugin Name', plugin.slug );
+			this.props.recordTracksEvent( 'calypso_plugin_activate_click', {
 				site: site.ID,
 				plugin: plugin.slug
 			} );
@@ -85,4 +86,10 @@ PluginActivateToggle.propTypes = {
 	isMock: PropTypes.bool,
 };
 
-export default localize( PluginActivateToggle );
+export default connect(
+	null,
+	{
+		recordGoogleEvent,
+		recordTracksEvent
+	}
+)( localize( PluginActivateToggle ) );

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -91,7 +91,14 @@ export class PluginActivateToggle extends Component {
 PluginActivateToggle.propTypes = {
 	site: PropTypes.object.isRequired,
 	plugin: PropTypes.object.isRequired,
+	notices: React.PropTypes.object,
 	isMock: PropTypes.bool,
+	disabled: React.PropTypes.bool,
+};
+
+PluginActivateToggle.defaultProps = {
+	isMock: false,
+	disabled: false,
 };
 
 export default connect(

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -37,7 +37,7 @@ export class PluginActivateToggle extends Component {
 				plugin: plugin.slug
 			} );
 		}
-	}
+	};
 
 	render() {
 		const { site, plugin, isMock, disabled, translate } = this.props;

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -16,7 +16,15 @@ import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 export class PluginActivateToggle extends Component {
 	toggleActivation = () => {
-		const { isMock, disabled, site, plugin, notices } = this.props;
+		const {
+			isMock,
+			disabled,
+			site,
+			plugin,
+			notices,
+			recordGoogleEvent: recordGAEvent,
+			recordTracksEvent: recordEvent
+		} = this.props;
 		if ( isMock || disabled ) {
 			return;
 		}
@@ -25,14 +33,14 @@ export class PluginActivateToggle extends Component {
 		PluginsActions.removePluginsNotices( notices.completed.concat( notices.errors ) );
 
 		if ( plugin.active ) {
-			this.props.recordGoogleEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', plugin.slug );
-			this.props.recordTracksEvent( 'calypso_plugin_deactivate_click', {
+			recordGAEvent( 'Plugins', 'Clicked Toggle Deactivate Plugin', 'Plugin Name', plugin.slug );
+			recordEvent( 'calypso_plugin_deactivate_click', {
 				site: site.ID,
 				plugin: plugin.slug
 			} );
 		} else {
-			this.props.recordGoogleEvent( 'Plugins', 'Clicked Toggle Activate Plugin', 'Plugin Name', plugin.slug );
-			this.props.recordTracksEvent( 'calypso_plugin_activate_click', {
+			recordGAEvent( 'Plugins', 'Clicked Toggle Activate Plugin', 'Plugin Name', plugin.slug );
+			recordEvent( 'calypso_plugin_activate_click', {
 				site: site.ID,
 				plugin: plugin.slug
 			} );

--- a/client/my-sites/plugins/plugin-activate-toggle/test/fixtures/index.js
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/fixtures/index.js
@@ -1,10 +1,12 @@
-module.exports = {
+export default {
 	site: {
 		slug: 'test',
 		domain: '',
 		name: ''
 	},
-	plugin: { slug: 'test' },
+	plugin: {
+		slug: 'test'
+	},
 	notices: {
 		completed: [],
 		errors: []

--- a/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import identity from 'lodash/identity';
 import mockery from 'mockery';
 import { mount } from 'enzyme';
 import React from 'react';
@@ -20,8 +19,9 @@ import useMockery from 'test/helpers/use-mockery';
 
 describe( 'PluginActivateToggle', function() {
 	const analyticsMock = {
-		ga: { recordEvent: spy() },
-		tracks: { recordEvent: spy() }
+		recordGoogleEvent: spy(),
+		recordTracksEvent: spy(),
+		translate: spy()
 	};
 	let PluginActivateToggle;
 
@@ -29,37 +29,35 @@ describe( 'PluginActivateToggle', function() {
 	useMockery();
 
 	before( function() {
-		mockery.registerMock( 'lib/analytics', analyticsMock );
 		mockery.registerMock( 'my-sites/plugins/plugin-action/plugin-action', mockedPluginAction );
 		mockery.registerMock( 'lib/plugins/actions', mockedActions );
 		mockery.registerMock( 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button', EmptyComponent );
 
-		PluginActivateToggle = require( 'my-sites/plugins/plugin-activate-toggle' );
-		PluginActivateToggle.prototype.translate = identity;
+		PluginActivateToggle = require( 'my-sites/plugins/plugin-activate-toggle' ).PluginActivateToggle;
 	} );
 
 	afterEach( function() {
 		mockedActions.togglePluginActivation.reset();
-		analyticsMock.ga.recordEvent.reset();
+		analyticsMock.recordGoogleEvent.reset();
 	} );
 
 	it( 'should render the component', function() {
-		const wrapper = mount( <PluginActivateToggle { ...fixtures } /> );
+		const wrapper = mount( <PluginActivateToggle { ...analyticsMock } { ...fixtures } /> );
 
 		expect( wrapper.find( '.plugin-action' ) ).to.have.lengthOf( 1 );
 	} );
 
 	it( 'should register an event when the subcomponent action is executed', function() {
-		const wrapper = mount( <PluginActivateToggle { ...fixtures } /> );
+		const wrapper = mount( <PluginActivateToggle { ...analyticsMock } { ...fixtures } /> );
 
 		wrapper.simulate( 'click' );
 
-		expect( analyticsMock.ga.recordEvent.called ).to.equal( true );
-		expect( analyticsMock.tracks.recordEvent.called ).to.equal( true );
+		expect( analyticsMock.recordGoogleEvent.called ).to.equal( true );
+		expect( analyticsMock.recordTracksEvent.called ).to.equal( true );
 	} );
 
 	it( 'should call an action when the subcomponent action is executed', function() {
-		const wrapper = mount( <PluginActivateToggle { ...fixtures } /> );
+		const wrapper = mount( <PluginActivateToggle { ...analyticsMock } { ...fixtures } /> );
 
 		wrapper.simulate( 'click' );
 

--- a/client/my-sites/plugins/plugin-activate-toggle/test/mocks/actions.js
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/mocks/actions.js
@@ -1,6 +1,9 @@
-var sinon = require( 'sinon' );
+/**
+ * External dependencies
+ */
+import sinon from 'sinon';
 
-module.exports = {
+export default {
 	togglePluginActivation: sinon.spy(),
-	removePluginsNotices: function() {}
+	removePluginsNotices: () => {}
 };

--- a/client/my-sites/plugins/plugin-activate-toggle/test/mocks/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/mocks/plugin-action.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
-module.exports = React.createClass( {
-	render: function() {
+export default React.createClass( {
+	render() {
 		return <div className="plugin-action" onClick={ this.props.action }></div>;
 	}
 } );

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var FoldableCard = require( 'components/foldable-card' ),
-	PluginsLog = require( 'lib/plugins/log-store' ),
-	PluginActivateToggle = require( 'my-sites/plugins/plugin-activate-toggle' ),
-	PluginAutoupdateToggle = require( 'my-sites/plugins/plugin-autoupdate-toggle' ),
-	PluginUpdateIndicator = require( 'my-sites/plugins/plugin-site-update-indicator' ),
-	PluginInstallButton = require( 'my-sites/plugins/plugin-install-button' ),
-	PluginRemoveButton = require( 'my-sites/plugins/plugin-remove-button' ),
-	PluginSiteDisabledManage = require( 'my-sites/plugins/plugin-site-disabled-manage' ),
-	Site = require( 'blocks/site' );
+import FoldableCard from 'components/foldable-card';
+import PluginsLog from 'lib/plugins/log-store';
+import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
+import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
+import PluginUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
+import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
+import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
+import PluginSiteDisabledManage from 'my-sites/plugins/plugin-site-disabled-manage';
+import Site from 'blocks/site';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'PluginSiteJetpack',
 

--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -1,24 +1,24 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var FoldableCard = require( 'components/foldable-card' ),
-	CompactCard = require( 'components/card/compact' ),
-	AllSites = require( 'my-sites/all-sites' ),
-	PluginsLog = require( 'lib/plugins/log-store' ),
-	PluginActivateToggle = require( 'my-sites/plugins/plugin-activate-toggle' ),
-	PluginAutoupdateToggle = require( 'my-sites/plugins/plugin-autoupdate-toggle' ),
-	PluginUpdateIndicator = require( 'my-sites/plugins/plugin-site-update-indicator' ),
-	PluginInstallButton = require( 'my-sites/plugins/plugin-install-button' ),
-	PluginRemoveButton = require( 'my-sites/plugins/plugin-remove-button' ),
-	PluginSiteDisabledManage = require( 'my-sites/plugins/plugin-site-disabled-manage' ),
-	Site = require( 'blocks/site' );
+import FoldableCard from 'components/foldable-card';
+import CompactCard from 'components/card/compact';
+import AllSites from 'my-sites/all-sites';
+import PluginsLog from 'lib/plugins/log-store';
+import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
+import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
+import PluginUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
+import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
+import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
+import PluginSiteDisabledManage from 'my-sites/plugins/plugin-site-disabled-manage';
+import Site from 'blocks/site';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'PluginSiteNetwork',
 


### PR DESCRIPTION
This PR ES6ifies the `PluginActivateToggle` component, converting it into an ES6 class, and fixing all warnings. It also converts the `lib/analytics` usage to the Redux `state/analytics`, and fixes the tests.

To test:

* Checkout this branch
* Go to a page that has a list of plugins (like `http://calypso.localhost:3000/plugins/$site`, where `$site` is one of your Jetpack sites).
* Play around with activation and deactivation of plugins and verify there are no regressions with the display and functionality of the activation toggle.
* Verify the component tests still pass: `npm run test-client client/my-sites/plugins/plugin-activate-toggle/`.

/cc @johnHackworth @ryelle @oskosk