### PR TITLE
Reader: Fix the double images that appear in gizmodo's feed

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -323,6 +323,13 @@
 	}
 }
 
+// gizmodo fixes
+.reader-full-post.feed-19797 {
+	.reader-full-post__story-content > img {
+		display: none;
+	}
+}
+
 
 // Hides Jetpack RP in Reader
 .reader-full-post .jp-relatedposts-headline,


### PR DESCRIPTION
Ideally we'd do this on ingest, but we cannot right now. Patching this on the client until we can.