### PR TITLE
State: Add Jetpack computed properties to site object

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -100,7 +100,6 @@ let Followers = React.createClass( {
 				key={ follower.ID }
 				user={ follower }
 				type="follower"
-				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing }
 				onRemove={ removeFollower }
 			/>

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -84,7 +84,7 @@ export default React.createClass( {
 			<Main>
 				<SidebarNavigation />
 				<div>
-					{ <PeopleSectionNav { ...omit( this.props, [ 'sites' ] ) } site={ site } /> }
+					<PeopleSectionNav { ...omit( this.props, [ 'sites' ] ) } />
 					<PeopleNotices />
 					{ this.renderPeopleList( site ) }
 				</div>

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -16,10 +16,6 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { localize } from 'i18n-calypso';
 
 class PeopleListItem extends React.PureComponent {
-	constructor( props ) {
-		super( props );
-	}
-
 	navigateToUser() {
 		window.scrollTo( 0, 0 );
 		analytics.ga.recordEvent( 'People', 'Clicked User Profile From Team List' );

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
-import omit from 'lodash/omit';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,22 +12,23 @@ import CompactCard from 'components/card/compact';
 import PeopleProfile from 'my-sites/people/people-profile';
 import analytics from 'lib/analytics';
 import config from 'config';
+import { getSelectedSite } from 'state/ui/selectors';
+import { localize } from 'i18n-calypso';
 
-export default React.createClass( {
-
-	displayName: 'PeopleListItem',
-
-	mixins: [ PureRenderMixin ],
+class PeopleListItem extends React.PureComponent {
+	constructor( props ) {
+		super( props );
+	}
 
 	navigateToUser() {
 		window.scrollTo( 0, 0 );
 		analytics.ga.recordEvent( 'People', 'Clicked User Profile From Team List' );
-	},
+	}
 
 	userHasPromoteCapability() {
 		const site = this.props.site;
 		return site && site.capabilities && site.capabilities.promote_users;
-	},
+	}
 
 	canLinkToProfile() {
 		const site = this.props.site,
@@ -42,13 +42,12 @@ export default React.createClass( {
 			this.userHasPromoteCapability() &&
 			! this.props.isSelectable
 		);
-	},
+	}
 
 	render() {
 		const canLinkToProfile = this.canLinkToProfile();
 		return (
 			<CompactCard
-				{ ...omit( this.props, 'className', 'user', 'site', 'isSelectable', 'onRemove' ) }
 				className={ classNames( 'people-list-item', this.props.className ) }
 				tagName="a"
 				href={ canLinkToProfile && '/people/edit/' + this.props.site.slug + '/' + this.props.user.login }
@@ -60,11 +59,19 @@ export default React.createClass( {
 				this.props.onRemove &&
 				<div className="people-list-item__actions">
 					<button className="button is-link people-list-item__remove-button" onClick={ this.props.onRemove }>
-						{ this.translate( 'Remove', { context: 'Verb: Remove a user or follower from the blog.' } ) }
+						{ this.props.translate( 'Remove', { context: 'Verb: Remove a user or follower from the blog.' } ) }
 					</button>
 				</div>
 				}
 			</CompactCard>
 		);
 	}
-} );
+}
+
+const mapStateToProps = ( state ) => {
+	return {
+		site: getSelectedSite( state )
+	};
+};
+
+export default localize( connect( mapStateToProps )( PeopleListItem ) );

--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -12,6 +12,7 @@ import PeopleLog from 'lib/people/log-store';
 import PeopleActions from 'lib/people/actions';
 import Notice from 'components/notice';
 import { getSelectedSite } from 'state/ui/selectors';
+import { get } from 'lodash';
 
 const isSameSite = ( siteId, log ) => siteId && log.siteId && log.siteId === siteId;
 
@@ -56,8 +57,8 @@ const PeopleNotices = React.createClass( {
 	},
 
 	getState() {
-		const siteId = this.props.site && this.props.site.ID,
-			userId = this.props.user && this.props.user.ID;
+		const siteId = get( this.props, 'site.ID' ),
+			userId = get( this.props, 'user.ID' );
 
 		return {
 			errors: PeopleLog.getErrors( filterBy.bind( this, siteId, userId ) ),

--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -56,7 +56,7 @@ const PeopleNotices = React.createClass( {
 	},
 
 	getState() {
-		const siteId = this.props.site.ID,
+		const siteId = this.props.site && this.props.site.ID,
 			userId = this.props.user && this.props.user.ID;
 
 		return {

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -89,7 +89,8 @@ class PeopleSectionNav extends React.PureComponent {
 	}
 
 	getFilters() {
-		const siteFilter = this.props.site.slug,
+		const { site } = this.props,
+			siteFilter = ( site && site.slug ) ? site.slug : '',
 			filters = [
 				{
 					title: this.props.translate( 'Team', { context: 'Filter label for people list' } ),
@@ -131,13 +132,16 @@ class PeopleSectionNav extends React.PureComponent {
 	}
 
 	shouldDisplayViewers() {
-		if ( 'viewers' === this.props.filter || ( ! this.props.site.jetpack && this.props.site.is_private ) ) {
+		const { site, filter } = this.props;
+		if ( site && ( 'viewers' === filter || ( ! site.jetpack && site.is_private ) ) ) {
 			return true;
 		}
 		return false;
 	}
 
 	render() {
+		const { site } = this.props;
+
 		let hasPinnedItems = false,
 			search = null;
 
@@ -145,7 +149,7 @@ class PeopleSectionNav extends React.PureComponent {
 			return <SectionNav></SectionNav>;
 		}
 
-		if ( this.canSearch() ) {
+		if ( site && this.canSearch() ) {
 			hasPinnedItems = true;
 			search = <PeopleSearch { ...this.props } />;
 		}

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -1,22 +1,27 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	config = require( 'config' ),
-	find = require( 'lodash/find' ),
-	includes = require( 'lodash/includes' );
+import React from 'react';
+import config from 'config';
+import find from 'lodash/find';
+import includes from 'lodash/includes';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-var Search = require( 'components/search' ),
-	UrlSearch = require( 'lib/mixins/url-search' ),
-	SectionNav = require( 'components/section-nav' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	NavItem = require( 'components/section-nav/item' );
+import Search from 'components/search';
+import UrlSearch from 'lib/mixins/url-search';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import { localize } from 'i18n-calypso';
+import { getSelectedSite } from 'state/ui/selectors';
+import versionCompare from 'lib/version-compare';
 
-let PeopleSearch = React.createClass( {
+const PeopleSearch = React.createClass( { // eslint-disable-line react/prefer-es6-class
 	displayName: 'PeopleSearch',
+
 	mixins: [ UrlSearch ],
 
 	render: function() {
@@ -33,9 +38,12 @@ let PeopleSearch = React.createClass( {
 	}
 } );
 
-let PeopleNavTabs = React.createClass( {
-	displayName: 'PeopleNavTabs',
-	render: function() {
+class PeopleNavTabs extends React.PureComponent {
+	constructor( props ) {
+		super( props );
+	}
+
+	render() {
 		return (
 			<NavTabs selectedText={ this.props.selectedText }>
 				{ this.props.filters.map( function( filterItem ) {
@@ -51,63 +59,65 @@ let PeopleNavTabs = React.createClass( {
 			</NavTabs>
 		);
 	}
-} );
+}
 
-module.exports = React.createClass( {
+class PeopleSectionNav extends React.PureComponent {
+	constructor( props ) {
+		super( props );
+	}
 
-	displayName: 'PeopleSectionNav',
+	canSearch() {
+		const { site, filter } = this.props;
 
-	canSearch: function() {
 		// Disable search for wpcom followers and viewers
-		if ( this.props.filter ) {
-			if ( 'followers' === this.props.filter || 'viewers' === this.props.filter ) {
+		if ( filter ) {
+			if ( 'followers' === filter || 'viewers' === filter ) {
 				return false;
 			}
 		}
 
-		if ( ! this.props.site.jetpack ) {
+		if ( ! site.jetpack ) {
 			// wpcom sites will always support search
 			return true;
 		}
-
-		if ( 'team' === this.props.filter && ! this.props.site.versionCompare( '3.7.0-beta', '>=' ) ) {
+		if ( 'team' === filter && versionCompare( site.options.jetpack_version, '3.7.0-beta' ) < 0 ) {
 			// Jetpack sites can only search team on versions of 3.7.0-beta or later
 			return false;
 		}
 
 		return true;
-	},
+	}
 
-	getFilters: function() {
-		var siteFilter = this.props.site.slug,
+	getFilters() {
+		const siteFilter = this.props.site.slug,
 			filters = [
 				{
-					title: this.translate( 'Team', { context: 'Filter label for people list' } ),
+					title: this.props.translate( 'Team', { context: 'Filter label for people list' } ),
 					path: '/people/team/' + siteFilter,
 					id: 'team'
 				},
 				{
-					title: this.translate( 'Followers', { context: 'Filter label for people list' } ),
+					title: this.props.translate( 'Followers', { context: 'Filter label for people list' } ),
 					path: '/people/followers/' + siteFilter,
 					id: 'followers'
 				},
 				{
-					title: this.translate( 'Email Followers', { context: 'Filter label for people list' } ),
+					title: this.props.translate( 'Email Followers', { context: 'Filter label for people list' } ),
 					path: '/people/email-followers/' + siteFilter,
 					id: 'email-followers'
 				},
 				{
-					title: this.translate( 'Viewers', { context: 'Filter label for people list' } ),
+					title: this.props.translate( 'Viewers', { context: 'Filter label for people list' } ),
 					path: '/people/viewers/' + siteFilter,
 					id: 'viewers'
 				}
 			];
 
 		return filters;
-	},
+	}
 
-	getNavigableFilters: function() {
-		var allowedFilterIds = [ 'team' ];
+	getNavigableFilters() {
+		let allowedFilterIds = [ 'team' ]; // eslint-disable-line prefer-const
 		if ( config.isEnabled( 'manage/people/readers' ) ) {
 			allowedFilterIds.push( 'followers' );
 			allowedFilterIds.push( 'email-followers' );
@@ -118,22 +128,21 @@ module.exports = React.createClass( {
 		}
 
 		return this.getFilters().filter( filter => this.props.filter === filter.id || includes( allowedFilterIds, filter.id ) );
-	},
+	}
 
-	shouldDisplayViewers: function() {
+	shouldDisplayViewers() {
 		if ( 'viewers' === this.props.filter || ( ! this.props.site.jetpack && this.props.site.is_private ) ) {
 			return true;
 		}
 		return false;
-	},
+	}
 
-	render: function() {
-		var selectedText,
-			hasPinnedItems = false,
+	render() {
+		let hasPinnedItems = false,
 			search = null;
 
 		if ( this.props.fetching ) {
-			return <SectionNav></SectionNav>
+			return <SectionNav></SectionNav>;
 		}
 
 		if ( this.canSearch() ) {
@@ -141,7 +150,7 @@ module.exports = React.createClass( {
 			search = <PeopleSearch { ...this.props } />;
 		}
 
-		selectedText = find( this.getFilters(), { id: this.props.filter } ).title;
+		const selectedText = find( this.getFilters(), { id: this.props.filter } ).title;
 		return (
 			<SectionNav selectedText={ selectedText } hasPinnedItems={ hasPinnedItems }>
 				<PeopleNavTabs { ...this.props } selectedText={ selectedText } filters={ this.getNavigableFilters() } />
@@ -149,4 +158,13 @@ module.exports = React.createClass( {
 			</SectionNav>
 		);
 	}
-} );
+}
+
+const mapStateToProps = ( state ) => {
+	return {
+		site: getSelectedSite( state )
+	};
+};
+
+export default localize( connect( mapStateToProps )( PeopleSectionNav ) );
+

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -3,8 +3,7 @@
  */
 import React from 'react';
 import config from 'config';
-import find from 'lodash/find';
-import includes from 'lodash/includes';
+import { find, includes, get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -19,7 +18,7 @@ import { localize } from 'i18n-calypso';
 import { getSelectedSite } from 'state/ui/selectors';
 import versionCompare from 'lib/version-compare';
 
-const PeopleSearch = React.createClass( { // eslint-disable-line react/prefer-es6-class
+const PeopleSearch = React.createClass( {
 	displayName: 'PeopleSearch',
 
 	mixins: [ UrlSearch ],
@@ -39,10 +38,6 @@ const PeopleSearch = React.createClass( { // eslint-disable-line react/prefer-es
 } );
 
 class PeopleNavTabs extends React.PureComponent {
-	constructor( props ) {
-		super( props );
-	}
-
 	render() {
 		return (
 			<NavTabs selectedText={ this.props.selectedText }>
@@ -62,10 +57,6 @@ class PeopleNavTabs extends React.PureComponent {
 }
 
 class PeopleSectionNav extends React.PureComponent {
-	constructor( props ) {
-		super( props );
-	}
-
 	canSearch() {
 		const { site, filter } = this.props;
 
@@ -89,26 +80,26 @@ class PeopleSectionNav extends React.PureComponent {
 	}
 
 	getFilters() {
-		const { site } = this.props,
-			siteFilter = ( site && site.slug ) ? site.slug : '',
+		const { translate } = this.props,
+			siteFilter = get( this.props, 'site.slug', '' ),
 			filters = [
 				{
-					title: this.props.translate( 'Team', { context: 'Filter label for people list' } ),
+					title: translate( 'Team', { context: 'Filter label for people list' } ),
 					path: '/people/team/' + siteFilter,
 					id: 'team'
 				},
 				{
-					title: this.props.translate( 'Followers', { context: 'Filter label for people list' } ),
+					title: translate( 'Followers', { context: 'Filter label for people list' } ),
 					path: '/people/followers/' + siteFilter,
 					id: 'followers'
 				},
 				{
-					title: this.props.translate( 'Email Followers', { context: 'Filter label for people list' } ),
+					title: translate( 'Email Followers', { context: 'Filter label for people list' } ),
 					path: '/people/email-followers/' + siteFilter,
 					id: 'email-followers'
 				},
 				{
-					title: this.props.translate( 'Viewers', { context: 'Filter label for people list' } ),
+					title: translate( 'Viewers', { context: 'Filter label for people list' } ),
 					path: '/people/viewers/' + siteFilter,
 					id: 'viewers'
 				}
@@ -118,7 +109,7 @@ class PeopleSectionNav extends React.PureComponent {
 	}
 
 	getNavigableFilters() {
-		let allowedFilterIds = [ 'team' ]; // eslint-disable-line prefer-const
+		const allowedFilterIds = [ 'team' ];
 		if ( config.isEnabled( 'manage/people/readers' ) ) {
 			allowedFilterIds.push( 'followers' );
 			allowedFilterIds.push( 'email-followers' );

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -112,7 +112,6 @@ var Team = React.createClass( {
 				key={ user.ID }
 				user={ user }
 				type="user"
-				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing } />
 		);
 	},

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -81,7 +81,6 @@ let Viewers = React.createClass( {
 				key={ viewer.ID }
 				user={ viewer }
 				type="viewer"
-				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing }
 				onRemove={ removeThisViewer }
 			/>

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -62,7 +62,7 @@ export const getSite = createSelector(
 			return null;
 		}
 
-		return {
+		let attributes = {
 			...site,
 			...getComputedAttributes( site ),
 			hasConflict: isSiteConflicting( state, siteId ),
@@ -71,6 +71,22 @@ export const getSite = createSelector(
 			domain: getSiteDomain( state, siteId ),
 			is_previewable: isSitePreviewable( state, siteId )
 		};
+
+		if ( attributes.jetpack ) {
+			attributes = Object.assign( attributes, {
+				canManage: canJetpackSiteManage( state, siteId ),
+				canUpdateFiles: canJetpackSiteUpdateFiles( state, siteId ),
+				canAutoupdateFiles: canJetpackSiteAutoUpdateFiles( state, siteId ),
+				hasJetpackMenus: hasJetpackSiteJetpackMenus( state, siteId ),
+				hasJetpackThemes: hasJetpackSiteJetpackThemes( state, siteId ),
+				isMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
+				isSecondaryNetworkSite: isJetpackSiteSecondaryNetworkSite( state, siteId ),
+				hasMinimumJetpackVersion: siteHasMinimumJetpackVersion( state, siteId ),
+				fileModDisabledReason: getJetpackSiteUpdateFilesDisabledReasons( state, siteId )
+			} );
+		}
+
+		return attributes;
 	},
 	( state ) => state.sites.items
 );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -898,6 +898,10 @@ export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action 
 
 	const fileModDisabled = getSiteOption( state, siteId, 'file_mod_disabled' );
 
+	if ( ! Array.isArray( fileModDisabled ) ) {
+		return false;
+	}
+
 	return compact( fileModDisabled.map( clue => {
 		if ( action === 'modifyFiles' || action === 'autoupdateFiles' || action === 'autoupdateCore' ) {
 			if ( clue === 'has_no_file_system_write_access' ) {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -48,201 +48,6 @@ import {
 	getCustomizerUrl
 } from '../selectors';
 
-/**
- * Module variables
- */
-const singleJetpackSite = {
-	sites: {
-		items: {
-			95250642: {
-				ID: 95250642,
-				name: 'Another sandbox site',
-				description: 'Just another sandbox site',
-				URL: 'http://sandbox.wpsandbox.me',
-				user_can_manage: false,
-				capabilities: {
-					edit_pages: true,
-					edit_posts: true,
-					edit_others_posts: true,
-					edit_others_pages: true,
-					delete_posts: true,
-					delete_others_posts: true,
-					edit_theme_options: true,
-					edit_users: true,
-					list_users: true,
-					manage_categories: true,
-					manage_options: true,
-					activate_wordads: true,
-					promote_users: true,
-					publish_posts: true,
-					upload_files: true,
-					delete_users: false,
-					remove_users: true,
-					view_stats: true
-				},
-				jetpack: true,
-				is_multisite: true,
-				post_count: 2,
-				subscribers_count: 0,
-				lang: 'en-US',
-				logo: {
-					id: 0,
-					sizes: [],
-					url: ''
-				},
-				visible: false,
-				is_private: false,
-				single_user_site: true,
-				is_vip: false,
-				is_following: false,
-				options: {
-					timezone: '',
-					gmt_offset: 0,
-					videopress_enabled: false,
-					upgraded_filetypes_enabled: true,
-					login_url: 'http://sandbox.wpsandbox.me/wp-login.php',
-					admin_url: 'http://sandbox.wpsandbox.me/wp-admin/',
-					is_mapped_domain: true,
-					is_redirect: false,
-					unmapped_url: 'http://sandbox.wpsandbox.me',
-					featured_images_enabled: false,
-					theme_slug: 'twentyfifteen',
-					header_image: false,
-					background_color: false,
-					image_default_link_type: 'file',
-					image_thumbnail_width: 150,
-					image_thumbnail_height: 150,
-					image_thumbnail_crop: 0,
-					image_medium_width: 300,
-					image_medium_height: 300,
-					image_large_width: 1024,
-					image_large_height: 1024,
-					permalink_structure: '/%year%/%monthnum%/%day%/%postname%/',
-					post_formats: [],
-					default_post_format: '0',
-					default_category: 1,
-					allowed_file_types: [
-						'jpg',
-						'jpeg',
-						'png',
-						'gif',
-						'pdf',
-						'doc',
-						'ppt',
-						'odt',
-						'pptx',
-						'docx',
-						'pps',
-						'ppsx',
-						'xls',
-						'xlsx',
-						'key'
-					],
-					show_on_front: 'posts',
-					default_likes_enabled: true,
-					default_sharing_status: false,
-					default_comment_status: true,
-					default_ping_status: true,
-					software_version: '4.5-beta1-36798',
-					created_at: '2015-07-08T16:27:57+00:00',
-					wordads: false,
-					publicize_permanently_disabled: false,
-					frame_nonce: '77e7b3b6a0',
-					headstart: false,
-					headstart_is_fresh: false,
-					ak_vp_bundle_enabled: 0,
-					advanced_seo_front_page_description: '',
-					verification_services_codes: null,
-					podcasting_archive: null,
-					jetpack_version: '3.8.2-alpha',
-					main_network_site: 'http://sandbox.wpsandbox.me',
-					active_modules: [
-						'protect',
-						'after-the-deadline',
-						'contact-form',
-						'custom-content-types',
-						'custom-css',
-						'enhanced-distribution',
-						'gravatar-hovercards',
-						'json-api',
-						'latex',
-						'notes',
-						'omnisearch',
-						'post-by-email',
-						'publicize',
-						'sharedaddy',
-						'shortcodes',
-						'shortlinks',
-						'stats',
-						'subscriptions',
-						'verification-tools',
-						'widget-visibility',
-						'widgets',
-						'manage',
-						'carousel',
-						'photon',
-						'related-posts',
-						'sso',
-						'vaultpress'
-					],
-					max_upload_size: '1536000',
-					is_multi_network: false,
-					is_multi_site: true,
-					file_mod_disabled: [
-						'is_version_controlled'
-					]
-				},
-				plan: {
-					product_id: 2002,
-					product_slug: 'jetpack_free',
-					product_name_short: 'Free',
-					free_trial: false,
-					expired: false,
-					user_is_owner: false
-				},
-				jetpack_modules: [
-					'protect',
-					'after-the-deadline',
-					'contact-form',
-					'custom-content-types',
-					'custom-css',
-					'enhanced-distribution',
-					'gravatar-hovercards',
-					'json-api',
-					'latex',
-					'notes',
-					'omnisearch',
-					'post-by-email',
-					'publicize',
-					'sharedaddy',
-					'shortcodes',
-					'shortlinks',
-					'stats',
-					'subscriptions',
-					'verification-tools',
-					'widget-visibility',
-					'widgets',
-					'manage',
-					'carousel',
-					'photon',
-					'related-posts',
-					'sso',
-					'vaultpress'
-				],
-				meta: {
-					links: {
-						self: 'https://public-api.wordpress.com/rest/v1.1/sites/95250642',
-						help: 'https://public-api.wordpress.com/rest/v1.1/sites/95250642/help',
-						posts: 'https://public-api.wordpress.com/rest/v1.1/sites/95250642/posts/',
-						comments: 'https://public-api.wordpress.com/rest/v1.1/sites/95250642/comments/',
-						xmlrpc: 'http://sandbox.wpsandbox.me/xmlrpc.php'
-					}
-				}
-			}
-		}
-	}
-};
-
 describe( 'selectors', () => {
 	const createStateWithItems = items => deepFreeze( {
 		sites: { items }
@@ -306,7 +111,22 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return a normalized site with Jetpack specific computed attributes when site is Jetpack', () => {
-			const site = getSite( singleJetpackSite, 95250642 ),
+			const site = getSite( {
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								name: 'WordPress.com Example Blog',
+								URL: 'https://example.com',
+								options: {
+									unmapped_url: 'https://example.wordpress.com',
+									file_mod_disabled: [ 'has_no_file_system_write_access' ]
+								},
+								jetpack: true
+							}
+						}
+					}
+				}, 2916284 ),
 				expectedProps = [
 					'canManage',
 					'canUpdateFiles',

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -48,6 +48,201 @@ import {
 	getCustomizerUrl
 } from '../selectors';
 
+/**
+ * Module variables
+ */
+const singleJetpackSite = {
+	sites: {
+		items: {
+			95250642: {
+				ID: 95250642,
+				name: 'Another sandbox site',
+				description: 'Just another sandbox site',
+				URL: 'http://sandbox.wpsandbox.me',
+				user_can_manage: false,
+				capabilities: {
+					edit_pages: true,
+					edit_posts: true,
+					edit_others_posts: true,
+					edit_others_pages: true,
+					delete_posts: true,
+					delete_others_posts: true,
+					edit_theme_options: true,
+					edit_users: true,
+					list_users: true,
+					manage_categories: true,
+					manage_options: true,
+					activate_wordads: true,
+					promote_users: true,
+					publish_posts: true,
+					upload_files: true,
+					delete_users: false,
+					remove_users: true,
+					view_stats: true
+				},
+				jetpack: true,
+				is_multisite: true,
+				post_count: 2,
+				subscribers_count: 0,
+				lang: 'en-US',
+				logo: {
+					id: 0,
+					sizes: [],
+					url: ''
+				},
+				visible: false,
+				is_private: false,
+				single_user_site: true,
+				is_vip: false,
+				is_following: false,
+				options: {
+					timezone: '',
+					gmt_offset: 0,
+					videopress_enabled: false,
+					upgraded_filetypes_enabled: true,
+					login_url: 'http://sandbox.wpsandbox.me/wp-login.php',
+					admin_url: 'http://sandbox.wpsandbox.me/wp-admin/',
+					is_mapped_domain: true,
+					is_redirect: false,
+					unmapped_url: 'http://sandbox.wpsandbox.me',
+					featured_images_enabled: false,
+					theme_slug: 'twentyfifteen',
+					header_image: false,
+					background_color: false,
+					image_default_link_type: 'file',
+					image_thumbnail_width: 150,
+					image_thumbnail_height: 150,
+					image_thumbnail_crop: 0,
+					image_medium_width: 300,
+					image_medium_height: 300,
+					image_large_width: 1024,
+					image_large_height: 1024,
+					permalink_structure: '/%year%/%monthnum%/%day%/%postname%/',
+					post_formats: [],
+					default_post_format: '0',
+					default_category: 1,
+					allowed_file_types: [
+						'jpg',
+						'jpeg',
+						'png',
+						'gif',
+						'pdf',
+						'doc',
+						'ppt',
+						'odt',
+						'pptx',
+						'docx',
+						'pps',
+						'ppsx',
+						'xls',
+						'xlsx',
+						'key'
+					],
+					show_on_front: 'posts',
+					default_likes_enabled: true,
+					default_sharing_status: false,
+					default_comment_status: true,
+					default_ping_status: true,
+					software_version: '4.5-beta1-36798',
+					created_at: '2015-07-08T16:27:57+00:00',
+					wordads: false,
+					publicize_permanently_disabled: false,
+					frame_nonce: '77e7b3b6a0',
+					headstart: false,
+					headstart_is_fresh: false,
+					ak_vp_bundle_enabled: 0,
+					advanced_seo_front_page_description: '',
+					verification_services_codes: null,
+					podcasting_archive: null,
+					jetpack_version: '3.8.2-alpha',
+					main_network_site: 'http://sandbox.wpsandbox.me',
+					active_modules: [
+						'protect',
+						'after-the-deadline',
+						'contact-form',
+						'custom-content-types',
+						'custom-css',
+						'enhanced-distribution',
+						'gravatar-hovercards',
+						'json-api',
+						'latex',
+						'notes',
+						'omnisearch',
+						'post-by-email',
+						'publicize',
+						'sharedaddy',
+						'shortcodes',
+						'shortlinks',
+						'stats',
+						'subscriptions',
+						'verification-tools',
+						'widget-visibility',
+						'widgets',
+						'manage',
+						'carousel',
+						'photon',
+						'related-posts',
+						'sso',
+						'vaultpress'
+					],
+					max_upload_size: '1536000',
+					is_multi_network: false,
+					is_multi_site: true,
+					file_mod_disabled: [
+						'is_version_controlled'
+					]
+				},
+				plan: {
+					product_id: 2002,
+					product_slug: 'jetpack_free',
+					product_name_short: 'Free',
+					free_trial: false,
+					expired: false,
+					user_is_owner: false
+				},
+				jetpack_modules: [
+					'protect',
+					'after-the-deadline',
+					'contact-form',
+					'custom-content-types',
+					'custom-css',
+					'enhanced-distribution',
+					'gravatar-hovercards',
+					'json-api',
+					'latex',
+					'notes',
+					'omnisearch',
+					'post-by-email',
+					'publicize',
+					'sharedaddy',
+					'shortcodes',
+					'shortlinks',
+					'stats',
+					'subscriptions',
+					'verification-tools',
+					'widget-visibility',
+					'widgets',
+					'manage',
+					'carousel',
+					'photon',
+					'related-posts',
+					'sso',
+					'vaultpress'
+				],
+				meta: {
+					links: {
+						self: 'https://public-api.wordpress.com/rest/v1.1/sites/95250642',
+						help: 'https://public-api.wordpress.com/rest/v1.1/sites/95250642/help',
+						posts: 'https://public-api.wordpress.com/rest/v1.1/sites/95250642/posts/',
+						comments: 'https://public-api.wordpress.com/rest/v1.1/sites/95250642/comments/',
+						xmlrpc: 'http://sandbox.wpsandbox.me/xmlrpc.php'
+					}
+				}
+			}
+		}
+	}
+};
+
 describe( 'selectors', () => {
 	const createStateWithItems = items => deepFreeze( {
 		sites: { items }
@@ -107,6 +302,25 @@ describe( 'selectors', () => {
 					default_post_format: 'standard',
 					unmapped_url: 'https://example.wordpress.com'
 				}
+			} );
+		} );
+
+		it( 'should return a normalized site with Jetpack specific computed attributes when site is Jetpack', () => {
+			const site = getSite( singleJetpackSite, 95250642 ),
+				expectedProps = [
+					'canManage',
+					'canUpdateFiles',
+					'canAutoupdateFiles',
+					'hasJetpackMenus',
+					'hasJetpackThemes',
+					'isMainNetworkSite',
+					'isSecondaryNetworkSite',
+					'hasMinimumJetpackVersion',
+					'fileModDisabledReason'
+				];
+
+			expectedProps.forEach( ( prop ) => {
+				expect( site ).to.have.property( prop );
 			} );
 		} );
 	} );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2006,6 +2006,18 @@ describe( 'selectors', () => {
 			const reason = getJetpackSiteUpdateFilesDisabledReasons( state, siteId, 'autoupdateCore' );
 			expect( reason ).to.deep.equal( [ 'Core autoupdates are explicitly disabled by a site administrator.' ] );
 		} );
+
+		it( 'it should return false if file_mod_disabled is not set', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					jetpack: true
+				}
+			} );
+
+			const reason = getJetpackSiteUpdateFilesDisabledReasons( state, siteId, 'autoupdateCore' );
+			expect( reason ).to.be.false;
+		} );
 	} );
 
 	describe( '#isJetpackSiteMainNetworkSite()', () => {


### PR DESCRIPTION
Closes #9122 

This PR adds Jetpack specific computed properties to the Jetpack site object. I did not add the `hasJetpackSiteCustomDomain()` selector since I believe that should probably be a WP.com only selector. Also, I did not add `verifyJetpackModulesActive()` because that selector seems like something we'll want to use within each component since it's checking if a given module(s) is active.

Of note, all of these properties that have been added to the redux-ed Jetpack site are scalar (not functions). Much of the current implementation relies on the Jetpack site properties being methods. So, we'll need to update these.

Ex. => `site.getRemoteManagementURL()` => `site.getRemoteManagementURL`

To test:

- Checkout `update/jetpack-site-computed-properties` branch
- To go `/people/team/$site` where `$site` is a Jetpack site
- Ensure that you can navigate through the tabs and that the search icon shows on the team tab
- Ensure that each of the people cards render OK on each list

cc @gwwar for review