### PR TITLE
Reader: Hide Gizmodo dupes a safer way

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -325,7 +325,7 @@
 
 // gizmodo fixes
 .reader-full-post.feed-19797 {
-	.reader-full-post__story-content > img {
+	.align--bleed {
 		display: none;
 	}
 }


### PR DESCRIPTION
Hide the `figure` with `.align--bleed` instead of random images in the root of the body.