### PR TITLE
Plugins: Fixes some of inconsistant urls introduced in #9392

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -110,7 +110,7 @@ function renderPluginList( context, basePath ) {
 			? ' ' + capitalize( context.params.pluginFilter )
 			: ''
 		);
-	let baseAnalyticsPath = 'plugins/';
+	let baseAnalyticsPath = 'plugins';
 	if ( site ) {
 		baseAnalyticsPath += '/:site';
 	}
@@ -135,7 +135,7 @@ function renderPluginsBrowser( context ) {
 	}
 
 	const analyticsPageTitle = 'Plugin Browser' + ( category ? ': ' + category : '' );
-	let baseAnalyticsPath = 'plugins/browser' + ( category ? '/' + category : '' );
+	let baseAnalyticsPath = 'plugins/browse' + ( category ? '/' + category : '' );
 	if ( site ) {
 		baseAnalyticsPath += '/:site';
 	}


### PR DESCRIPTION
Previously urls passed to analytics were 
plugins/ and not plugins//

also the path should be 
plugins/browse not plugins/browser 
as introduced in #9392. 

cc: @johnHackworth 
