### PR TITLE
Reader Refresh: makes it so that clicking comment fires off the right…

### DIFF
--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -16,6 +16,7 @@ import QueryReaderFeed from 'components/data/query-reader-feed';
 import * as DiscoverHelper from 'reader/discover/helper';
 import FeedPostStore from 'lib/feed-post-store';
 import smartSetState from 'lib/react-smart-set-state';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
 class ReaderPostCardAdapter extends React.Component {
 
@@ -24,6 +25,10 @@ class ReaderPostCardAdapter extends React.Component {
 	}
 
 	onCommentClick = () => {
+		recordAction( 'click_comments' );
+		recordGaEvent( 'Clicked Post Comment Button' );
+		recordTrackForPost( 'calypso_reader_post_comments_button_clicked', this.props.post );
+
 		this.props.handleClick && this.props.handleClick( this.props.post, { comments: true } );
 	}
 


### PR DESCRIPTION
Currently this stat is missing in the refreshed card's comment button as documented [here](https://github.com/Automattic/wp-calypso/issues/9131#issuecomment-259282975).