### PR TITLE
Reader Full Post: Fix More on WPCOM RP Follow issues

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -17,6 +17,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin: 0;
 	}
 
+	&:nth-last-child(2) {
+		border-bottom: 0;
+	}
+
 	&.is-selected {
 		&::before {
 			content: '';

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -17,10 +17,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin: 0;
 	}
 
-	&:nth-last-child(2) {
-		border-bottom: 0;
-	}
-
 	&.is-selected {
 		&::before {
 			content: '';

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -134,6 +134,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	.reader-related-card-v2__meta {
 		display: flex;
 		margin-bottom: 13px;
+		z-index: 1;
 	}
 
 	.reader-related-card-v2__post {
@@ -365,6 +366,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	margin-bottom: 12px;
 	margin-top: -4px;
 	padding: 0;
+	z-index: 1;
 
 	.gridicon__follow {
 		fill: $blue-medium;


### PR DESCRIPTION
**This PR fixes two things in More on WPCOM RP:**

1. Follow button and meta info both incorrectly link to the post itself and Follow button doesn't let you follow the site. This only happens in widths where thumbnail is on the left.

Video: https://cloudup.com/c06NIct-FfA

2. Follow button `focused` state is cut-off.

Before:
![screenshot 2016-11-15 11 26 29](https://cloud.githubusercontent.com/assets/4924246/20320767/e0bea1a4-ab27-11e6-9c59-7a7ada071445.png)

![screenshot 2016-11-15 11 28 02](https://cloud.githubusercontent.com/assets/4924246/20320770/e3dc8d10-ab27-11e6-81a5-f9e491ab062b.png)

After:
![screenshot 2016-11-15 11 38 48](https://cloud.githubusercontent.com/assets/4924246/20320829/1d8344be-ab28-11e6-886e-ce30c1842774.png)

![screenshot 2016-11-15 11 38 58](https://cloud.githubusercontent.com/assets/4924246/20320837/2336c4e4-ab28-11e6-82f2-9a022d37f55c.png)

