### PR TITLE
Checkout: Add a way for users on small screens to apply a coupon at checkout

### DIFF
--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -13,6 +13,8 @@ var PayButton = require( './pay-button' ),
 	analytics = require( 'lib/analytics' ),
 	cartValues = require( 'lib/cart-values' );
 
+import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
+
 var CreditCardPaymentBox = React.createClass( {
 	getInitialState: function() {
 		return { previousCart: null };
@@ -39,6 +41,8 @@ var CreditCardPaymentBox = React.createClass( {
 
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) } />
+
+				<CartCoupon cart={ cart } />
 
 				<div className="payment-box-actions">
 					<PayButton

--- a/client/my-sites/upgrades/checkout/credits-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credits-payment-box.jsx
@@ -10,6 +10,8 @@ var PayButton = require( './pay-button' ),
 	PaymentBox = require( './payment-box' ),
 	TermsOfService = require( './terms-of-service' );
 
+import CartCoupon from 'my-sites/upgrades/cart/cart-coupon'
+
 var CreditsPaymentBox = React.createClass( {
 	content: function() {
 		var cart = this.props.cart;
@@ -35,6 +37,9 @@ var CreditsPaymentBox = React.createClass( {
 				</div>
 
 				<TermsOfService />
+
+				<CartCoupon cart={ cart } />
+
 				<div className="payment-box-actions">
 					<PayButton
 						cart={ this.props.cart }

--- a/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
@@ -17,6 +17,8 @@ var analytics = require( 'lib/analytics' ),
 	TermsOfService = require( './terms-of-service' ),
 	wpcom = require( 'lib/wp' ).undocumented();
 
+import CartCoupon from 'my-sites/upgrades/cart/cart-coupon'
+
 module.exports = React.createClass( {
 	displayName: 'PaypalPaymentBox',
 
@@ -145,6 +147,8 @@ module.exports = React.createClass( {
 
 				<TermsOfService
 					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( this.props.cart ) } />
+
+				<CartCoupon cart={ this.props.cart } />
 
 				<div className="payment-box-actions">
 					<div className="pay-button">

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -244,6 +244,22 @@
 		}
 	}
 
+	.cart-coupon {
+		display: none;
+		margin: 16px 0;
+
+		// On larger screens, users can use the coupon functionality present on the sidebar
+		@include breakpoint( "<660px" ) {
+			display: block;
+			text-align: center;
+		}
+
+		input {
+			margin-right: 15px;
+			width: 50%;
+		}
+	}
+
 	.payment-box-actions {
 		@include breakpoint( ">660px" ) {
 			margin: 20px -30px 0px -30px;


### PR DESCRIPTION
On the sidebar at checkout, there's a "Have a coupon code?" link that toggles a field that lets users apply a coupon to their cart. Problem is that on small screens (< 660px) the sidebar gets hidden so there's no way for those users to apply a coupon.

This PR adds the same "Have a coupon?" component below the Terms of Service when the screen is less than 660px so those users can also apply a coupon:

![screen shot 2016-11-15 at 3 18 04 pm](https://cloud.githubusercontent.com/assets/44436/20322385/d6b5365e-ab46-11e6-8373-3d3edb39ef93.png)

![screen shot 2016-11-15 at 3 19 08 pm](https://cloud.githubusercontent.com/assets/44436/20322395/e0df9926-ab46-11e6-8f49-083c9dc46042.png)

## Testing Instructions

1. Add a plan to your cart
2. Ensure the existing sidebar coupon functionality still works (ping me if you're not sure where to get a valid coupon)
3. Clear your cart so the plan reverts to the original price (ping me if you're not sure how to do this)
4. Reduce the width of your screen so that the coupon section on the checkout form displays
5. Apply a coupon and ensure it works
6. Clear your cart again
7. This time, click checkout with PayPal and ensure the coupon form is there and works
8. Clear your cart again
9. This time, give your account some credits and ensure that the coupon form is there and works 