### PR TITLE
Pages: Fix blog posts indicator when setting posts page to homepage

### DIFF
--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import merge from 'lodash/merge';
 import store from 'store';
 
 /**
@@ -27,13 +28,13 @@ module.exports = {
 
 	// This gives us a means to fix the `SitesList` cache outside of actions
 	// @todo Remove this when `SitesList` is Reduxified
-	updateSitesList: function( { siteId, pageId } ) {
+	updateSitesList: function( { siteId, updatedOptions } ) {
 		const sites = sitesFactory();
 		const site = sites.getSite( siteId );
 
 		store.remove( 'SitesList' );
 		if ( site ) {
-			site.options.page_on_front = pageId;
+			site.options = merge( site.options, updatedOptions );
 			sites.updateSite( site );
 		}
 		sites.fetch();

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -121,7 +121,7 @@ export function setFrontPage( siteId, pageId, successCallback ) {
 				show_on_front: response.is_page_on_front ? 'page' : 'posts',
 			};
 
-			if( response.page_for_posts_id ) {
+			if ( response.page_for_posts_id ) {
 				updatedOptions.page_for_posts = parseInt( response.page_for_posts_id, 10 );
 			}
 

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -117,10 +117,13 @@ export function setFrontPage( siteId, pageId, successCallback ) {
 
 		return wpcom.undocumented().setSiteHomepageSettings( siteId, requestData ).then( ( response ) => {
 			const updatedOptions = {
-				page_for_posts: parseInt( response.page_for_posts_id, 10 ),
 				page_on_front: parseInt( response.page_on_front_id, 10 ),
 				show_on_front: response.is_page_on_front ? 'page' : 'posts',
 			};
+
+			if( response.page_for_posts_id ) {
+				updatedOptions.page_for_posts = parseInt( response.page_for_posts_id, 10 );
+			}
 
 			// This gives us a means to fix the `SitesList` cache outside of actions
 			// @todo Remove this when `SitesList` is Reduxified

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -121,7 +121,7 @@ export function setFrontPage( siteId, pageId, successCallback ) {
 				show_on_front: response.is_page_on_front ? 'page' : 'posts',
 			};
 
-			if ( response.page_for_posts_id ) {
+			if ( 0 === response.page_for_posts_id || response.page_for_posts_id ) {
 				updatedOptions.page_for_posts = parseInt( response.page_for_posts_id, 10 );
 			}
 

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -115,13 +115,19 @@ export function setFrontPage( siteId, pageId, successCallback ) {
 			page_on_front_id: pageId,
 		};
 
-		return wpcom.undocumented().setSiteHomepageSettings( siteId, requestData ).then( () => {
+		return wpcom.undocumented().setSiteHomepageSettings( siteId, requestData ).then( ( response ) => {
+			const updatedOptions = {
+				page_for_posts: parseInt( response.page_for_posts_id, 10 ),
+				page_on_front: parseInt( response.page_on_front_id, 10 ),
+				show_on_front: response.is_page_on_front ? 'page' : 'posts',
+			};
+
 			// This gives us a means to fix the `SitesList` cache outside of actions
 			// @todo Remove this when `SitesList` is Reduxified
 			if ( 'function' === typeof( successCallback ) ) {
 				successCallback( {
 					siteId,
-					pageId,
+					updatedOptions,
 				} );
 			}
 
@@ -133,7 +139,7 @@ export function setFrontPage( siteId, pageId, successCallback ) {
 			dispatch( {
 				type: SITE_FRONT_PAGE_SET_SUCCESS,
 				siteId,
-				pageId
+				updatedOptions,
 			} );
 		} ).catch( ( error ) => {
 			dispatch( bumpStat( 'calypso_front_page_set', 'failure' ) );

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -52,7 +52,7 @@ const VALID_SITE_KEYS = Object.keys( sitesSchema.patternProperties[ '^\\d+$' ].p
 export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case SITE_FRONT_PAGE_SET_SUCCESS: {
-			const { siteId, pageId } = action;
+			const { siteId, updatedOptions } = action;
 			const site = state[ siteId ];
 			if ( ! site ) {
 				break;
@@ -61,10 +61,7 @@ export function items( state = {}, action ) {
 			return {
 				...state,
 				[ siteId ]: merge( {}, site, {
-					options: {
-						show_on_front: pageId === 0 ? 'posts' : 'page',
-						page_on_front: pageId
-					}
+					options: updatedOptions,
 				} )
 			};
 		}

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -214,7 +214,10 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: SITE_FRONT_PAGE_SET_SUCCESS,
 					siteId: 2916284,
-					pageId: 1
+					updatedOptions: {
+						page_on_front: 1,
+						show_on_front: 'page',
+					}
 				} );
 			} );
 		} );

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -250,7 +250,10 @@ describe( 'reducer', () => {
 			const state = items( original, {
 				type: SITE_FRONT_PAGE_SET_SUCCESS,
 				siteId: 2916284,
-				pageId: 1
+				updatedOptions: {
+					show_on_front: 'page',
+					page_on_front: 1,
+				}
 			} );
 
 			expect( state ).to.eql( {
@@ -265,7 +268,10 @@ describe( 'reducer', () => {
 			const state = items( original, {
 				type: SITE_FRONT_PAGE_SET_SUCCESS,
 				siteId: 77203074,
-				pageId: 1
+				updatedOptions: {
+					show_on_front: 'page',
+					page_on_front: 1,
+				}
 			} );
 
 			expect( state ).to.eql( original );


### PR DESCRIPTION
This PR fixes a bug where the blog posts indicator was incorrect when setting a static posts page to the homepage.

To reproduce the bug:

* Set both a static front-page and a static posts page from wp-admin: `/wp-admin/options-reading.php`
![image](https://cloud.githubusercontent.com/assets/363749/20328282/527508ae-ab57-11e6-964c-f4ba2badaca1.png)

* Reload the pages page for that site in Calypso. It should look like this:
![image](https://cloud.githubusercontent.com/assets/363749/20328305/763ee606-ab57-11e6-88eb-3e70b87ebb68.png)

* Set the page being subsumed by the "Blog Posts" to the homepage:
![image](https://cloud.githubusercontent.com/assets/363749/20328316/9abde950-ab57-11e6-8164-03447c02ee0a.png)

* Observe that the state is inconsistent: the page is listed as both the static home page and "Your latest posts"
![image](https://cloud.githubusercontent.com/assets/363749/20328356/e2f86f6a-ab57-11e6-84f9-2b46605aa53b.png)

* Reload the page and observe that it reconciles:
![image](https://cloud.githubusercontent.com/assets/363749/20328378/ffa24e2e-ab57-11e6-8897-4f9efe616b37.png)


Checkout this branch and verify that the bug is fixed.