### PR TITLE
Domains: Remove .blog coming soon message

### DIFF
--- a/client/components/domains/domain-suggestion-flag/index.jsx
+++ b/client/components/domains/domain-suggestion-flag/index.jsx
@@ -2,20 +2,17 @@
  * External dependencies
  */
 import React from 'react';
-import endsWith from 'lodash/endsWith';
+import { endsWith } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Notice from 'components/notice';
 
-const DomainSuggestionFlag = React.createClass( {
-	propTypes: {
-		domain: React.PropTypes.string.isRequired
-	},
-
+class DomainSuggestionFlag extends React.Component {
 	render() {
-		const newTLDs = [ 'wales' ];
+		const newTLDs = [ 'blog' ];
 
 		if ( newTLDs.some( ( tld ) => {
 			return endsWith( this.props.domain, tld );
@@ -24,13 +21,17 @@ const DomainSuggestionFlag = React.createClass( {
 				<Notice
 					isCompact
 					status="is-success">
-					{ this.translate( 'New', { context: 'Domain suggestion flag' } ) }
+					{ this.props.translate( 'New', { context: 'Domain suggestion flag' } ) }
 				</Notice>
 			);
 		}
 
 		return null;
 	}
-} );
+}
 
-export default DomainSuggestionFlag;
+DomainSuggestionFlag.propTypes = {
+	domain: React.PropTypes.string.isRequired
+};
+
+export default localize( DomainSuggestionFlag );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -13,7 +13,6 @@ import noop from 'lodash/noop';
 import startsWith from 'lodash/startsWith';
 import page from 'page';
 import qs from 'qs';
-import endsWith from 'lodash/endsWith';
 import { connect } from 'react-redux';
 
 /**
@@ -310,12 +309,6 @@ const RegisterDomainStep = React.createClass( {
 		async.parallel(
 			[
 				callback => {
-					if ( endsWith( domain, '.blog' ) ) {
-						const error = { code: 'dotblog_domain' };
-						this.showValidationErrorMessage( domain, error );
-						return callback();
-					}
-
 					if ( ! domain.match( /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/i ) ) {
 						return callback();
 					}
@@ -527,22 +520,6 @@ const RegisterDomainStep = React.createClass( {
 			severity = 'error';
 
 		switch ( error.code ) {
-			case 'dotblog_domain':
-				message = this.translate(
-					'.blog domains are not available yet. {{a}}Sign up{{/a}} to get updates on the launch.', {
-						components: {
-							a: <a
-								target="_blank"
-								rel="noopener noreferrer"
-								href={ `https://dotblog.wordpress.com/
-									?email=${ this.props.currentUser && encodeURIComponent( this.props.currentUser.email ) || '' }
-									&domain=${ domain }`
-									} />
-						}
-					}
-				);
-				severity = 'info';
-				break;
 			case 'available_but_not_registrable':
 				const tldIndex = domain.lastIndexOf( '.' );
 				if ( tldIndex !== -1 ) {


### PR DESCRIPTION
- Remove the .blog coming soon message
- Add "New" flag for .blog
- Refactor DomainSuggestionFlag

Test:
- Search for `.blog`, make sure you don't see the `not available yet` message, instead it will show the `To use a domain ending with .blog on your site, you can register it elsewhere...` message, as we don't have them added yet.
- If `.blog` appears in suggestions it should have `New` flag. We don't return these suggestions yet, but try adding it manually to the response in back-end or in JS.