### PR TITLE
Fix: site fragment to be the accept the second parameters to have dots in them

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -33,8 +33,9 @@ function getSiteFragment( path ) {
 	if ( last_piece && -1 !== last_piece.indexOf( '.' ) ) {
 		return last_piece;
 	}
-
-	const second_to_last_piece = pieces[ pieces.length - 2 ];
+	// People section can have usernames in the url that have dits in the name.
+	// So we can just ignore the second to last part
+	const second_to_last_piece = pieces[ 1 ] === 'people' ? '' : pieces[ pieces.length - 2 ];
 	if ( second_to_last_piece && -1 !== second_to_last_piece.indexOf( '.' ) ) {
 		return second_to_last_piece;
 	}

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -8,13 +8,13 @@ import includes from 'lodash/includes';
 /**
  * Internal Dependencies
  */
-var trailingslashit = require( './trailingslashit' ),
+const trailingslashit = require( './trailingslashit' ),
 	untrailingslashit = require( './untrailingslashit' );
 
 /**
  * Module variables
  */
-var statsLocationsByTab = {
+const statsLocationsByTab = {
 	day: '/stats/day/',
 	week: '/stats/week/',
 	month: '/stats/month/',
@@ -23,26 +23,31 @@ var statsLocationsByTab = {
 };
 
 function getSiteFragment( path ) {
-	const basePath = path.split( '?' )[0];
+	const basePath = path.split( '?' )[ 0 ];
 	const pieces = basePath.split( '/' );
 
 	// There are 2 URL positions where we should look for the site fragment:
 	// last (most sections) and second-to-last (post ID is last in editor)
-
 	// Check last and second-to-last piece for site slug
-	for ( let i = 2; i > 0; i-- ) {
-		const piece = pieces[ pieces.length - i ];
-		if ( piece && -1 !== piece.indexOf( '.' ) ) {
-			return piece;
-		}
+	const last_piece = pieces[ pieces.length - 1 ];
+	if ( last_piece && -1 !== last_piece.indexOf( '.' ) ) {
+		return last_piece;
+	}
+
+	const second_to_last_piece = pieces[ pieces.length - 2 ];
+	if ( second_to_last_piece && -1 !== second_to_last_piece.indexOf( '.' ) ) {
+		return second_to_last_piece;
 	}
 
 	// Check last and second-to-last piece for numeric site ID
-	for ( let i = 2; i > 0; i-- ) {
-		const piece = parseInt( pieces[ pieces.length - i ], 10 );
-		if ( Number.isSafeInteger( piece ) ) {
-			return piece;
-		}
+	const second_to_last_piece_int = parseInt( second_to_last_piece, 10 );
+	if ( Number.isSafeInteger( second_to_last_piece_int ) ) {
+		return second_to_last_piece_int;
+	}
+
+	const last_piece_int = parseInt( last_piece, 10 );
+	if ( Number.isSafeInteger( last_piece_int ) ) {
+		return last_piece_int;
 	}
 
 	// No site fragment here
@@ -66,8 +71,8 @@ function addSiteFragment( path, site ) {
 }
 
 function sectionify( path ) {
-	var basePath = path.split( '?' )[0],
-		site = getSiteFragment( basePath );
+	let basePath = path.split( '?' )[ 0 ];
+	const site = getSiteFragment( basePath );
 
 	if ( site ) {
 		basePath = trailingslashit( basePath ).replace( '/' + site + '/', '/' );
@@ -76,7 +81,7 @@ function sectionify( path ) {
 }
 
 function getStatsDefaultSitePage( slug ) {
-	var path = '/stats/insights/';
+	const path = '/stats/insights/';
 
 	if ( slug ) {
 		return path + slug;
@@ -86,8 +91,6 @@ function getStatsDefaultSitePage( slug ) {
 }
 
 function getStatsPathForTab( tab, siteIdOrSlug ) {
-	var path;
-
 	if ( ! tab ) {
 		return getStatsDefaultSitePage( siteIdOrSlug );
 	}
@@ -97,7 +100,7 @@ function getStatsPathForTab( tab, siteIdOrSlug ) {
 		return getStatsDefaultSitePage();
 	}
 
-	path = statsLocationsByTab[ tab ];
+	const path = statsLocationsByTab[ tab ];
 
 	if ( ! path ) {
 		return getStatsDefaultSitePage( siteIdOrSlug );

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -33,7 +33,7 @@ function getSiteFragment( path ) {
 	if ( last_piece && -1 !== last_piece.indexOf( '.' ) ) {
 		return last_piece;
 	}
-	// People section can have usernames in the url that have dits in the name.
+	// People section can have usernames in the url that have dots in the name.
 	// So we can just ignore the second to last part
 	const second_to_last_piece = pieces[ 1 ] === 'people' ? '' : pieces[ pieces.length - 2 ];
 	if ( second_to_last_piece && -1 !== second_to_last_piece.indexOf( '.' ) ) {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -19,7 +19,7 @@ describe( 'route', function() {
 
 	describe( '#addQueryArgs()', () => {
 		it( 'should error when args is not an object', () => {
-			var types = [
+			const types = [
 				undefined,
 				1,
 				true,
@@ -36,7 +36,7 @@ describe( 'route', function() {
 		} );
 
 		it( 'should error when url is not a string', () => {
-			var types = [
+			const types = [
 				{},
 				undefined,
 				1,
@@ -223,6 +223,16 @@ describe( 'route', function() {
 				expect(
 					route.getSiteFragment( '/pages/drafts/1000000000000000000000' )
 				).to.be.false;
+			} );
+			it( 'should not return a site when viewing username without a dot', () => {
+				expect(
+					route.getSiteFragment( '/people/edit/bob/example.com' )
+				).to.equal( 'example.com' );
+			} );
+			it( 'should not return a site when viewing username with a dot', () => {
+				expect(
+					route.getSiteFragment( '/people/edit/bob.bob/example.com' )
+				).to.equal( 'example.com' );
 			} );
 		} );
 		describe( 'for stats paths', function() {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -234,6 +234,11 @@ describe( 'route', function() {
 					route.getSiteFragment( '/people/edit/bob.bob/example.com' )
 				).to.equal( 'example.com' );
 			} );
+			it( 'should not return a site when viewing username with a dot', () => {
+				expect(
+					route.getSiteFragment( '/people/edit/bob.bob/12345' )
+				).to.equal( 12345 );
+			} );
 		} );
 		describe( 'for stats paths', function() {
 			it( 'should return false when there is no site yet', function() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/9405

By making sure that the site id gets returned by getSiteFragment as expected.
Which means 

To test
create a user with a dot in the username on your jetpack site. See https://codex.wordpress.org/Function_Reference/sanitize_user

visit http://calypso.localhost:3000/people/team/jetpacksite.com
and notice that you can click on a user that has a dot in the username.


cc @ebinnion 