### PR TITLE
Discover: show full post excerpt in stream

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -31,13 +31,15 @@ export default class RefreshPostCard extends React.Component {
 		onClick: PropTypes.func,
 		onCommentClick: PropTypes.func,
 		showPrimaryFollowButton: PropTypes.bool,
-		originalPost: PropTypes.object // used for Discover only
+		originalPost: PropTypes.object, // used for Discover only
+		showEntireExcerpt: PropTypes.bool
 	};
 
 	static defaultProps = {
 		onClick: noop,
 		onCommentClick: noop,
-		isSelected: false
+		isSelected: false,
+		showEntireExcerpt: false
 	};
 
 	propagateCardClick = () => {
@@ -88,14 +90,24 @@ export default class RefreshPostCard extends React.Component {
 	}
 
 	render() {
-		const { post, originalPost, site, feed, onCommentClick, showPrimaryFollowButton, isSelected } = this.props;
+		const {
+			post,
+			originalPost,
+			site,
+			feed,
+			onCommentClick,
+			showPrimaryFollowButton,
+			isSelected,
+			showEntireExcerpt
+		} = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
 			'is-photo': isPhotoOnly,
 			'is-gallery': isGallery,
-			'is-selected': isSelected
+			'is-selected': isSelected,
+			'is-showing-entire-excerpt': showEntireExcerpt
 		} );
 		const showExcerpt = ! isPhotoOnly;
 		let title = truncate( post.title, {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -32,14 +32,16 @@ export default class RefreshPostCard extends React.Component {
 		onCommentClick: PropTypes.func,
 		showPrimaryFollowButton: PropTypes.bool,
 		originalPost: PropTypes.object, // used for Discover only
-		showEntireExcerpt: PropTypes.bool
+		showEntireExcerpt: PropTypes.bool,
+		excerptAttribute: PropTypes.string
 	};
 
 	static defaultProps = {
 		onClick: noop,
 		onCommentClick: noop,
 		isSelected: false,
-		showEntireExcerpt: false
+		showEntireExcerpt: false,
+		excerptAttribute: 'better_excerpt_no_html'
 	};
 
 	propagateCardClick = () => {
@@ -98,7 +100,8 @@ export default class RefreshPostCard extends React.Component {
 			onCommentClick,
 			showPrimaryFollowButton,
 			isSelected,
-			showEntireExcerpt
+			showEntireExcerpt,
+			excerptAttribute
 		} = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
@@ -144,7 +147,7 @@ export default class RefreshPostCard extends React.Component {
 						<h1 className="reader-post-card__title">
 							<a className="reader-post-card__title-link" href={ post.URL }>{ title }</a>
 						</h1>
-						{ showExcerpt && <div className="reader-post-card__excerpt">{ post.better_excerpt_no_html }</div> }
+						{ showExcerpt && <div className="reader-post-card__excerpt">{ post[ excerptAttribute ] }</div> }
 						{ isDailyPostChallengeOrPrompt( post ) && <DailyPostButton post={ post } tagName="span" /> }
 						{ post &&
 							<ReaderPostActions

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -33,7 +33,7 @@ export default class RefreshPostCard extends React.Component {
 		showPrimaryFollowButton: PropTypes.bool,
 		originalPost: PropTypes.object, // used for Discover only
 		showEntireExcerpt: PropTypes.bool,
-		excerptAttribute: PropTypes.string
+		useBetterExcerpt: PropTypes.bool
 	};
 
 	static defaultProps = {
@@ -41,7 +41,7 @@ export default class RefreshPostCard extends React.Component {
 		onCommentClick: noop,
 		isSelected: false,
 		showEntireExcerpt: false,
-		excerptAttribute: 'better_excerpt_no_html'
+		useBetterExcerpt: true
 	};
 
 	propagateCardClick = () => {
@@ -101,7 +101,7 @@ export default class RefreshPostCard extends React.Component {
 			showPrimaryFollowButton,
 			isSelected,
 			showEntireExcerpt,
-			excerptAttribute
+			useBetterExcerpt
 		} = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
@@ -113,6 +113,7 @@ export default class RefreshPostCard extends React.Component {
 			'is-showing-entire-excerpt': showEntireExcerpt
 		} );
 		const showExcerpt = ! isPhotoOnly;
+		const excerptAttribute = useBetterExcerpt ? 'better_excerpt_no_html' : 'excerpt_no_html';
 		let title = truncate( post.title, {
 			length: 140,
 			separator: /,? +/

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -350,15 +350,21 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	font-weight: 100;
 	margin-top: 9px;
 	word-break: break-word;
-	overflow: hidden;
-	max-height: 15px * 1.6 * 3;
 	position: relative;
+}
 
-	&::before {
-		@include long-content-fade( $size: 15px * 1.6 * 5 );
-		top: inherit;
-		height: 15px * 1.6;
-	}
+// If we're not showing the entire excerpt, clamp to 3 lines
+.reader-post-card.card:not(.is-showing-entire-excerpt) {
+	.reader-post-card__excerpt {
+    	overflow: hidden;
+		max-height: 15px * 1.6 * 3;
+
+		&::before {
+			@include long-content-fade( $size: 15px * 1.6 * 5 );
+			top: inherit;
+			height: 15px * 1.6;
+		}
+  	}
 }
 
 // Action buttons in post card

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -238,10 +238,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__tag {
-    overflow: hidden;
-    position: relative;
-    height: 20px;
-    width: 100%;
+	overflow: hidden;
+	position: relative;
+	height: 20px;
+	width: 100%;
 
 	&::after {
 		@include long-content-fade( $size: 10% );
@@ -249,10 +249,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__tag .gridicons-tag {
-    height: 18px;
-    margin: -4px 5px 0 0;
-    position: relative;
-    	top: 5px;
+	height: 18px;
+	margin: -4px 5px 0 0;
+	position: relative;
+		top: 5px;
 	width: 15px;
 	fill: lighten( $gray, 10% );
 }
@@ -356,7 +356,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 // If we're not showing the entire excerpt, clamp to 3 lines
 .reader-post-card.card:not(.is-showing-entire-excerpt) {
 	.reader-post-card__excerpt {
-    	overflow: hidden;
+		overflow: hidden;
 		max-height: 15px * 1.6 * 3;
 
 		&::before {
@@ -364,7 +364,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			top: inherit;
 			height: 15px * 1.6;
 		}
-  	}
+	}
 }
 
 // Action buttons in post card

--- a/client/lib/post-normalizer/rule-create-better-excerpt-refresh.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt-refresh.js
@@ -43,6 +43,10 @@ export default function createBetterExcerpt( post ) {
 		return post;
 	}
 
+	// Create standard excerpt for Discover
+	post.excerpt_no_html = formatExcerpt( post.excerpt );
+
+	// Create better excerpt from the main post content
 	post.better_excerpt_no_html = post.better_excerpt = formatExcerpt( post.content );
 
 	// also make a shorter excerpt...

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -26,10 +26,6 @@ export function isDiscoverPost( post ) {
 	return !! ( get( post, 'discover_metadata' ) || get( post, 'site_ID' ) === config( 'discover_blog_id' ) );
 }
 
-export function isDiscoverPick( post ) {
-	return hasDiscoverSlug( post, 'pick' );
-}
-
 export function isDiscoverSitePick( post ) {
 	return hasDiscoverSlug( post, 'site-pick' );
 }

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -13,6 +13,11 @@ const debug = Debug( 'calypso:reader:discover' ); // eslint-disable-line
 import userUtils from 'lib/user/utils';
 import { getSiteUrl as readerRouteGetSiteUrl } from 'reader/route';
 
+function hasDiscoverSlug( post, searchSlug ) {
+	const metaData = get( post, 'discover_metadata.discover_fp_post_formats' );
+	return !! ( metaData && find( metaData, { slug: searchSlug } ) );
+}
+
 export function isDiscoverEnabled() {
 	return userUtils.getLocaleSlug() === 'en';
 }
@@ -21,9 +26,12 @@ export function isDiscoverPost( post ) {
 	return !! ( get( post, 'discover_metadata' ) || get( post, 'site_ID' ) === config( 'discover_blog_id' ) );
 }
 
+export function isDiscoverPick( post ) {
+	return hasDiscoverSlug( post, 'pick' );
+}
+
 export function isDiscoverSitePick( post ) {
-	const metaData = get( post, 'discover_metadata.discover_fp_post_formats' );
-	return !! ( metaData && find( metaData, { slug: 'site-pick' } ) );
+	return hasDiscoverSlug( post, 'site-pick' );
 }
 
 export function isInternalDiscoverPost( post ) {

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -55,7 +55,7 @@ class ReaderPostCardAdapter extends React.Component {
 				isSelected={ this.props.isSelected }
 				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
 				showEntireExcerpt={ isDiscoverPost }
-				excerptAttribute={ isDiscoverPost ? 'excerpt_no_html' : 'better_excerpt_no_html' }>
+				useBetterExcerpt={ ! isDiscoverPost }>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 			</ReaderPostCard>

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -40,6 +40,7 @@ class ReaderPostCardAdapter extends React.Component {
 			site_ID: siteId,
 			is_external: isExternal
 		} = this.props.post;
+		const isDiscoverPick = this.props.post && DiscoverHelper.isDiscoverPick( this.props.post );
 
 		// only query the site if the feed id is missing. feed queries end up fetching site info
 		// via a meta query, so we don't need both.
@@ -52,7 +53,8 @@ class ReaderPostCardAdapter extends React.Component {
 				onClick={ this.onClick }
 				onCommentClick={ this.onCommentClick }
 				isSelected={ this.props.isSelected }
-				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }>
+				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
+				showEntireExcerpt={ isDiscoverPick }>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 			</ReaderPostCard>

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -40,7 +40,7 @@ class ReaderPostCardAdapter extends React.Component {
 			site_ID: siteId,
 			is_external: isExternal
 		} = this.props.post;
-		const isDiscoverPick = this.props.post && DiscoverHelper.isDiscoverPick( this.props.post );
+		const isDiscoverPost = this.props.post && DiscoverHelper.isDiscoverPost( this.props.post );
 
 		// only query the site if the feed id is missing. feed queries end up fetching site info
 		// via a meta query, so we don't need both.
@@ -54,7 +54,8 @@ class ReaderPostCardAdapter extends React.Component {
 				onCommentClick={ this.onCommentClick }
 				isSelected={ this.props.isSelected }
 				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
-				showEntireExcerpt={ isDiscoverPick }>
+				showEntireExcerpt={ isDiscoverPost }
+				excerptAttribute={ isDiscoverPost ? 'excerpt_no_html' : 'better_excerpt_no_html' }>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 			</ReaderPostCard>


### PR DESCRIPTION
For Discover posts, show the entire `post.excerpt` in the stream.

A normal post (clamped at 3 lines):

<img width="865" alt="screen shot 2016-11-16 at 16 34 44" src="https://cloud.githubusercontent.com/assets/17325/20333877/b2c9cf14-ac1a-11e6-8709-9985539eccb5.png">

A Discover pick (shows entire excerpt):

<img width="857" alt="screen shot 2016-11-16 at 16 33 41" src="https://cloud.githubusercontent.com/assets/17325/20333880/b6642660-ac1a-11e6-8db0-be90d7eba263.png">

Part of #9096.

cc @jancavan for CSS sanity check.