### PR TITLE
Reader Refresh: Use white background on the following/edit page

### DIFF
--- a/client/components/reader-main/index.jsx
+++ b/client/components/reader-main/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal Dependencies
  */
 import Main from 'components/main';
+import config from 'config';
 
 /**
  * A specialization of `Main` that adds a class to the body of the document
@@ -16,7 +17,9 @@ import Main from 'components/main';
  */
 export default class ReaderMain extends React.Component {
 	componentWillMount() {
-		document.querySelector( 'body' ).classList.add( 'is-reader-page' );
+		if ( config.isEnabled( 'reader/refresh/stream' ) ) {
+			document.querySelector( 'body' ).classList.add( 'is-reader-page' );
+		}
 	}
 
 	componentWillUnmount() {

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -8,7 +8,7 @@ import remove from 'lodash/remove';
 import classnames from 'classnames';
 
 // Internal dependencies
-import Main from 'components/main';
+import ReaderMain from 'components/reader-main';
 import Gridicon from 'components/gridicon';
 import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
 import SiteStore from 'lib/reader-site-store';
@@ -516,7 +516,7 @@ const FollowingEdit = React.createClass( {
 		}, 'following-edit' );
 
 		return (
-			<Main className={ containerClasses }>
+			<ReaderMain className={ containerClasses }>
 				<MobileBackToSidebar>
 					<h1>{ this.translate( 'Manage Followed Sites' ) }</h1>
 				</MobileBackToSidebar>
@@ -583,7 +583,7 @@ const FollowingEdit = React.createClass( {
 				}
 
 				{ hasNoSubscriptions ? <EmptyContent /> : null }
-			</Main>
+			</ReaderMain>
 		);
 	}
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -38,6 +38,12 @@
 	}
 }
 
+.is-reader-page .follow-button {
+	border: 0;
+	border-radius: 0;
+	float: right;
+}
+
 // The header on top of the "Existing Feed"
 .section-header.following-edit__header {
 	height: 51px;

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -11,7 +11,6 @@ import times from 'lodash/times';
  * Internal dependencies
  */
 import config from 'config';
-import Main from 'components/main';
 import ReaderMain from 'components/reader-main';
 import DISPLAY_TYPES from 'lib/feed-post-store/display-types';
 import EmptyContent from './empty';
@@ -476,10 +475,8 @@ module.exports = React.createClass( {
 			showingStream = true;
 		}
 
-		const StreamMain = config.isEnabled( 'reader/refresh/stream' ) ? ReaderMain : Main;
-
 		return (
-			<StreamMain className={ classnames( 'following', this.props.className ) }>
+			<ReaderMain className={ classnames( 'following', this.props.className ) }>
 				{ this.props.showMobileBackToSidebar && <MobileBackToSidebar>
 					<h1>{ this.props.listName }</h1>
 				</MobileBackToSidebar> }
@@ -491,7 +488,7 @@ module.exports = React.createClass( {
 					? <div className="infinite-scroll-end" />
 					: null
 				}
-			</StreamMain>
+			</ReaderMain>
 		);
 	}
 


### PR DESCRIPTION
This PR aims to implement the MVP of the Manage Following page as described in #9143

It does two things:
1. changes the background to white on the Manage Following page
2. modifies the follow button to look like the refreshed following buttons (borderless)

While implementing the white background, I decided to add the `is-reader-page` class to `ReaderMain` so that during the refresh we don't need to duplicate the Main vs. ReaderMain logic in all of our newly-white-backgrounded changes.

Screenshot of how it should look:
![manage-1](https://cloud.githubusercontent.com/assets/24388/19989944/238e960a-a1e7-11e6-97da-b81ce6d61236.png)
