### PR TITLE
JPC: add instructions link

### DIFF
--- a/client/signup/jetpack-connect/example-components/jetpack-activate.jsx
+++ b/client/signup/jetpack-connect/example-components/jetpack-activate.jsx
@@ -10,9 +10,9 @@ import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
-const JetpackConnectExampleActivate = ( { isInstall, url, translate } ) => {
+const JetpackConnectExampleActivate = ( { isInstall, url, translate, onClick } ) => {
 	return (
-		<div className="example-components__main">
+		<div className="example-components__main" onClick={ onClick }>
 			<div className="example-components__browser-chrome example-components__site-url-input-container">
 				<div className="example-components__browser-chrome-dots">
 					<div className="example-components__browser-chrome-dot"></div>
@@ -68,6 +68,14 @@ const JetpackConnectExampleActivate = ( { isInstall, url, translate } ) => {
 			</div>
 		</div>
 	);
+};
+
+JetpackConnectExampleActivate.propTypes = {
+	onClick: React.PropTypes.func
+};
+
+JetpackConnectExampleActivate.defaultProps = {
+	onClick: () => {}
 };
 
 export default localize( JetpackConnectExampleActivate );

--- a/client/signup/jetpack-connect/example-components/jetpack-connect.jsx
+++ b/client/signup/jetpack-connect/example-components/jetpack-connect.jsx
@@ -11,12 +11,12 @@ import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
-const JetpackConnectExampleConnect = ( { isLegacy, url, translate } ) => {
+const JetpackConnectExampleConnect = ( { isLegacy, url, translate, onClick } ) => {
 	const contentClassName = classNames( 'example-components__content', 'example-components__connect-jetpack', {
 		'is-legacy': isLegacy
 	} );
 	return (
-		<div className="example-components__main">
+		<div className="example-components__main" onClick={ onClick }>
 			<div className="example-components__browser-chrome example-components__site-url-input-container">
 				<div className="example-components__browser-chrome-dots">
 					<div className="example-components__browser-chrome-dot"></div>
@@ -66,12 +66,14 @@ const JetpackConnectExampleConnect = ( { isLegacy, url, translate } ) => {
 
 JetpackConnectExampleConnect.propTypes = {
 	isLegacy: React.PropTypes.bool,
-	url: React.PropTypes.string
+	url: React.PropTypes.string,
+	onClick: React.PropTypes.func
 };
 
 JetpackConnectExampleConnect.defaultProps = {
 	isLegacy: false,
-	url: ''
+	url: '',
+	onClick: () => {}
 };
 
 export default localize( JetpackConnectExampleConnect );

--- a/client/signup/jetpack-connect/example-components/jetpack-install.jsx
+++ b/client/signup/jetpack-connect/example-components/jetpack-install.jsx
@@ -10,9 +10,9 @@ import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 
-const JetpackConnectExampleInstall = ( { url, translate } ) => {
+const JetpackConnectExampleInstall = ( { url, translate, onClick } ) => {
 	return (
-		<div className="example-components__main">
+		<div className="example-components__main" onClick={ onClick }>
 			<div className="example-components__browser-chrome example-components__site-url-input-container">
 				<div className="example-components__browser-chrome-dots">
 					<div className="example-components__browser-chrome-dot"></div>
@@ -44,6 +44,14 @@ const JetpackConnectExampleInstall = ( { url, translate } ) => {
 			</div>
 		</div>
 	);
+};
+
+JetpackConnectExampleInstall.propTypes = {
+	onClick: React.PropTypes.func
+};
+
+JetpackConnectExampleInstall.defaultProps = {
+	onClick: () => {}
 };
 
 export default localize( JetpackConnectExampleInstall );

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -396,6 +396,7 @@ const JetpackConnectMain = React.createClass( {
 										isInstall={ isInstall }
 										currentUrl={ currentUrl }
 										confirmJetpackInstallStatus={ this.props.confirmJetpackInstallStatus }
+										onClick={ instructionsData.buttonOnClick }
 									/>
 								);
 							} )

--- a/client/signup/jetpack-connect/install-step.jsx
+++ b/client/signup/jetpack-connect/install-step.jsx
@@ -49,7 +49,10 @@ export default React.createClass( {
 			this.props.jetpackVersion &&
 			versionCompare( this.props.jetpackVersion, NEW_INSTRUCTIONS_JETPACK_VERSION, '<' )
 		);
-		const jetpackConnectExample = <JetpackExampleConnect url={ this.props.currentUrl } isLegacy={ isLegacyVersion } />;
+		const jetpackConnectExample = <JetpackExampleConnect
+			url={ this.props.currentUrl }
+			isLegacy={ isLegacyVersion }
+			onClick={ this.props.onClick } />;
 		const steps = {
 			installJetpack: {
 				title: this.translate( '1. Install Jetpack' ),
@@ -59,13 +62,13 @@ export default React.createClass( {
 					: this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s ' +
 					'dashboard to install Jetpack. Click the blue install button.' ),
 				action: this.renderAlreadyHaveJetpackButton(),
-				example: <JetpackExampleInstall url={ this.props.currentUrl } />
+				example: <JetpackExampleInstall url={ this.props.currentUrl } onClick={ this.props.onClick } />
 			},
 			activateJetpackAfterInstall: {
 				title: this.translate( '2. Activate Jetpack' ),
 				text: this.translate( 'Then you\'ll click the blue "Activate" link to activate Jetpack.' ),
 				action: null,
-				example: <JetpackExampleActivate url={ this.props.currentUrl } isInstall={ true } />
+				example: <JetpackExampleActivate url={ this.props.currentUrl } isInstall={ true } onClick={ this.props.onClick } />
 			},
 			connectJetpackAfterInstall: {
 				title: this.translate( '3. Connect Jetpack' ),
@@ -78,7 +81,7 @@ export default React.createClass( {
 				text: this.translate( 'You will be redirected to your site\'s dashboard to activate Jetpack. ' +
 					'Click the blue "Activate" link. ' ),
 				action: this.renderNotJetpackButton(),
-				example: <JetpackExampleActivate url={ this.props.currentUrl } isInstall={ false } />
+				example: <JetpackExampleActivate url={ this.props.currentUrl } isInstall={ false } onClick={ this.props.onClick } />
 			},
 			connectJetpack: {
 				title: this.translate( '2. Connect Jetpack' ),

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -142,6 +142,7 @@
 }
 
 .example-components__main {
+	cursor: pointer;
 	width: 100%;
 }
 

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -122,6 +122,11 @@
 
 	@include breakpoint( ">480px" ) {
 		max-width: 360px;
+
+		&:hover {
+			box-shadow: 0 0 0 1px $gray,
+						0 2px 4px lighten( $gray, 20% );
+		}
 	}
 
 	@include breakpoint( ">660px" ) {

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -173,7 +173,7 @@
 
 .example-components__content {
 	position: relative;
-	margin: 0 1px;
+	margin: 0;
 	line-height: 0;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -122,11 +122,6 @@
 
 	@include breakpoint( ">480px" ) {
 		max-width: 360px;
-
-		&:hover {
-			box-shadow: 0 0 0 1px $gray,
-						0 2px 4px lighten( $gray, 20% );
-		}
 	}
 
 	@include breakpoint( ">660px" ) {
@@ -149,6 +144,11 @@
 .example-components__main {
 	cursor: pointer;
 	width: 100%;
+
+	&:hover > div {
+		box-shadow: 0 0 0 1px $gray,
+					0 2px 4px lighten( $gray, 20% );
+	}
 }
 
 .example-components__browser-chrome {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/9307

This PR adds a link that mirrors the modal window button action to the example screenshots of the jetpack install / activation instructions 

![image](https://cloud.githubusercontent.com/assets/1554855/20343127/7e3d6bf2-abed-11e6-98d7-adc578231bed.png)

How to test
=========
0. You need a self-hosted site without an installed jetpack (or a not active one)
1. Go to http://calypso.localhost:3000/jetpack/connect and enter the url of your site
2. You should get a modal window with some instructions on how to get your jetpack on
3. Click on any of the images. They should take you to the first step of the process in your wp-admin

ping @rickybanister @keoshi @jeffgolenski 