### PR TITLE
WPCOM Plugins: Update code style

### DIFF
--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -1,7 +1,15 @@
+/**
+ * External dependencies
+ */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import PurchaseButton from './purchase-button';
@@ -9,47 +17,40 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 import Plugin from './plugin';
 
-export const BusinessPluginsPanel = React.createClass( {
-	render() {
-		const {
-			isActive = false,
-			onClick,
-			purchaseLink,
-			plugins = []
-		} = this.props;
+export const BusinessPluginsPanel = ( {
+	isActive = false,
+	onClick,
+	purchaseLink,
+	plugins = [],
+	translate = identity,
+} ) => (
+	<div>
+		<SectionHeader label={ translate( 'Business Plan Upgrades' ) }>
+			<PurchaseButton { ...{ isActive, href: purchaseLink } } />
+		</SectionHeader>
 
-		const cardClasses = classNames( 'wpcom-plugins__business-panel', {
+		<Card className={ classNames( 'wpcom-plugins__business-panel', {
 			'is-disabled': ! isActive
-		} );
-
-		return (
-			<div>
-				<SectionHeader label={ this.translate( 'Business Plan Upgrades' ) }>
-					<PurchaseButton { ...{ isActive, href: purchaseLink } } />
-				</SectionHeader>
-
-				<Card className={ cardClasses }>
-					<div className="wpcom-plugins__list">
-						{ plugins.map( ( { name, descriptionLink, icon, category, description } ) =>
-							<Plugin
-								onClick={ () => onClick( name ) }
-								{ ...{
-									name,
-									key: name,
-									descriptionLink,
-									icon,
-									isActive,
-									category,
-									description
-								} }
-							/>
-						) }
-					</div>
-				</Card>
+		} ) }>
+			<div className="wpcom-plugins__list">
+				{ plugins.map( ( { name, descriptionLink, icon, category, description } ) =>
+					<Plugin
+						{ ...{
+							category,
+							description,
+							descriptionLink,
+							icon,
+							isActive,
+							key: name,
+							name,
+							onClick,
+						} }
+					/>
+				) }
 			</div>
-		);
-	}
-} );
+		</Card>
+	</div>
+);
 
 BusinessPluginsPanel.propTypes = {
 	isActive: PropTypes.bool,
@@ -57,17 +58,15 @@ BusinessPluginsPanel.propTypes = {
 	plugins: PropTypes.array
 };
 
-const trackClick = name => recordTracksEvent(
-	'calypso_plugin_wpcom_click',
-	{
+const trackClick = name =>
+	recordTracksEvent( 'calypso_plugin_wpcom_click', {
 		plugin_name: name,
-		plugin_plan: 'business'
-	}
-);
+		plugin_plan: 'business',
+	} );
 
 const mapDispatchToProps = dispatch => ( {
 	onClick: name => dispatch( trackClick( name ) )
 } );
 
-export default connect( null, mapDispatchToProps )( BusinessPluginsPanel );
+export default connect( null, mapDispatchToProps )( localize( BusinessPluginsPanel ) );
 

--- a/client/my-sites/plugins-wpcom/default-plugins.js
+++ b/client/my-sites/plugins-wpcom/default-plugins.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import i18n from 'i18n-calypso';
 
 /**

--- a/client/my-sites/plugins-wpcom/index.jsx
+++ b/client/my-sites/plugins-wpcom/index.jsx
@@ -1,11 +1,13 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import PluginPanel from 'my-sites/plugins-wpcom/plugin-panel';
 
-export const WpcomPluginsPanel = React.createClass( {
-	render() {
-		return <PluginPanel />;
-	}
-} );
+export const WpcomPluginsPanel = () => <PluginPanel />;
 
 export default WpcomPluginsPanel;

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import get from 'lodash/get';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -35,53 +35,54 @@ import {
  */
 const linkInterpolator = replacements => plugin => {
 	const { descriptionLink: link } = plugin;
-	const descriptionLink = Object.keys( replacements )
-		.reduce( ( s, r ) => s.replace( new RegExp( `{${ r }}` ), replacements[ r ] ), link );
+	const descriptionLink = Object
+		.keys( replacements )
+		.reduce(
+			( s, r ) => s.replace( new RegExp( `{${ r }}` ), replacements[ r ] ),
+			link
+		);
 
-	return Object.assign( {}, plugin, { descriptionLink } );
+	return { ...plugin, descriptionLink };
 };
 
-export const PluginPanel = React.createClass( {
-	render() {
-		const {
-			plan,
-			siteSlug
-		} = this.props;
+export const PluginPanel = ( {
+	plan,
+	siteSlug,
+	translate,
+} ) => {
+	const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
+	const purchaseLink = `/plans/${ siteSlug }`;
 
-		const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
-		const purchaseLink = `/plans/${ siteSlug }`;
+	const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
+	const hasPremium = hasBusiness || isPremium( plan );
 
-		const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
-		const hasPremium = hasBusiness || isPremium( plan );
+	const interpolateLink = linkInterpolator( { siteSlug } );
 
-		const interpolateLink = linkInterpolator( { siteSlug } );
+	const standardPlugins = defaultStandardPlugins.map( interpolateLink );
+	const premiumPlugins = defaultPremiumPlugins.map( interpolateLink );
+	const businessPlugins = defaultBusinessPlugins.map( interpolateLink );
 
-		const standardPlugins = defaultStandardPlugins.map( interpolateLink );
-		const premiumPlugins = defaultPremiumPlugins.map( interpolateLink );
-		const businessPlugins = defaultBusinessPlugins.map( interpolateLink );
-
-		return (
-			<div className="wpcom-plugin-panel">
-				<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
-				<Card compact className="plugins-wpcom__header">
-					<div className="plugins-wpcom__header-text">
-						<span className="plugins-wpcom__header-title">{ this.translate( 'Included Plugins' ) }</span>
-						<span className="plugins-wpcom__header-subtitle">
-							{ this.translate( 'Every plan includes a set of plugins specially tailored to supercharge your site.' ) }
-						</span>
-					</div>
-					<img className="plugins-wpcom__header-image" src="/calypso/images/plugins/plugins_hero.svg" />
-				</Card>
-				<StandardPluginsPanel plugins={ standardPlugins } displayCount={ 9 } />
-				<Card className="wpcom-plugin-panel__panel-footer" href={ standardPluginsLink }>
-					{ this.translate( 'View all standard plugins' ) }
-				</Card>
-				<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium } { ...{ purchaseLink } } />
-				<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness } { ...{ purchaseLink } } />
-			</div>
-		);
-	}
-} );
+	return (
+		<div className="wpcom-plugin-panel">
+			<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
+			<Card compact className="plugins-wpcom__header">
+				<div className="plugins-wpcom__header-text">
+					<span className="plugins-wpcom__header-title">{ translate( 'Included Plugins' ) }</span>
+					<span className="plugins-wpcom__header-subtitle">
+						{ translate( 'Every plan includes a set of plugins specially tailored to supercharge your site.' ) }
+					</span>
+				</div>
+				<img className="plugins-wpcom__header-image" src="/calypso/images/plugins/plugins_hero.svg" />
+			</Card>
+			<StandardPluginsPanel plugins={ standardPlugins } displayCount={ 9 } />
+			<Card className="wpcom-plugin-panel__panel-footer" href={ standardPluginsLink }>
+				{ translate( 'View all standard plugins' ) }
+			</Card>
+			<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium } { ...{ purchaseLink } } />
+			<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness } { ...{ purchaseLink } } />
+		</div>
+	);
+};
 
 const mapStateToProps = state => ( {
 	plan: get( getSelectedSite( state ), 'plan', {} ),

--- a/client/my-sites/plugins-wpcom/plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin.jsx
@@ -1,22 +1,34 @@
-import React, { PropTypes } from 'react';
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
 import noop from 'lodash/noop';
 
+/**
+ * Internal dependencies
+ */
 import Gridicon from 'components/gridicon';
 
 const hasHttpProtocol = url => ( /^https?:\/\//.test( url ) );
 
-export const Plugin = React.createClass( {
-	getInitialState() {
-		return { isUnderMouse: false };
-	},
+export class Plugin extends Component {
+	state = {
+		isUnderMouse: false,
+	};
 
-	startHover() {
-		this.setState( { isUnderMouse: true } );
-	},
+	static propTypes = {
+		category: PropTypes.string.isRequired,
+		description: PropTypes.string.isRequired,
+		icon: PropTypes.string,
+		isActive: PropTypes.bool,
+		name: PropTypes.string.isRequired,
+		onClick: PropTypes.func,
+		descriptionLink: PropTypes.string.isRequired
+	};
 
-	stopHover() {
-		this.setState( { isUnderMouse: false } );
-	},
+	startHover = () => this.setState( { isUnderMouse: true } );
+
+	stopHover = () => this.setState( { isUnderMouse: false } );
 
 	render() {
 		const {
@@ -42,10 +54,12 @@ export const Plugin = React.createClass( {
 			: icon;
 
 		return (
-			<div className="wpcom-plugins__plugin-item">
+			<div
+				className="wpcom-plugins__plugin-item"
+			>
 				<a
 					href={ descriptionLink }
-					onClick={ onClick }
+					onClick={ () => onClick( name ) }
 					onMouseEnter={ this.startHover }
 					onMouseLeave={ this.stopHover }
 					target={ target }
@@ -62,16 +76,6 @@ export const Plugin = React.createClass( {
 			</div>
 		);
 	}
-} );
-
-Plugin.propTypes = {
-	category: PropTypes.string.isRequired,
-	description: PropTypes.string.isRequired,
-	icon: PropTypes.string,
-	isActive: PropTypes.bool,
-	name: PropTypes.string.isRequired,
-	onClick: PropTypes.func,
-	descriptionLink: PropTypes.string.isRequired
-};
+}
 
 export default Plugin;

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -1,7 +1,14 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 import { connect } from 'react-redux';
-import noop from 'lodash/noop';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
 import HeaderCake from 'components/header-cake';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -11,23 +18,18 @@ import StandardPluginsPanel from './standard-plugins-panel';
 
 import { defaultStandardPlugins } from './default-plugins';
 
-export const PluginsList = React.createClass( {
-	render() {
-		const { siteSlug } = this.props;
-		const backHref = `/plugins/${ siteSlug }`;
-
-		return (
-			<div className="wpcom-plugin-panel wpcom-plugins-expanded">
-				<PageViewTracker path="/plugins/standard/:site" title="Plugins > WPCOM Site > Standard Plugins" />
-				<HeaderCake backHref={ backHref } onClick={ noop }>Standard Plugins</HeaderCake>
-				<StandardPluginsPanel plugins={ defaultStandardPlugins } />
-			</div>
-		);
-	}
-} );
+export const PluginsList = ( { siteSlug, translate } ) => (
+	<div className="wpcom-plugin-panel wpcom-plugins-expanded">
+		<PageViewTracker path="/plugins/standard/:site" title="Plugins > WPCOM Site > Standard Plugins" />
+		<HeaderCake backHref={ `/plugins/${ siteSlug }` } onClick={ noop }>
+			{ translate( 'Standard Plugins' ) }
+		</HeaderCake>
+		<StandardPluginsPanel plugins={ defaultStandardPlugins } />
+	</div>
+);
 
 const mapStateToProps = state => ( {
 	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
 } );
 
-export default connect( mapStateToProps )( PluginsList );
+export default connect( mapStateToProps )( localize( PluginsList ) );

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -1,7 +1,18 @@
+/**
+ * External dependencies
+ */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import {
+	flowRight as compose,
+	identity,
+} from 'lodash';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import PurchaseButton from './purchase-button';
@@ -9,47 +20,40 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 import Plugin from './plugin';
 
-export const PremiumPluginsPanel = React.createClass( {
-	render() {
-		const {
-			isActive = false,
-			onClick,
-			purchaseLink,
-			plugins = []
-		} = this.props;
+export const PremiumPluginsPanel = ( {
+	isActive = false,
+	onClick,
+	purchaseLink,
+	plugins = [],
+	translate = identity,
+} ) => (
+	<div>
+		<SectionHeader label={ translate( 'Premium Plan Upgrades' ) }>
+			<PurchaseButton { ...{ isActive, href: purchaseLink } } />
+		</SectionHeader>
 
-		const cardClasses = classNames( 'wpcom-plugins__premium-panel', {
-			'is-disabled': ! isActive
-		} );
-
-		return (
-			<div>
-				<SectionHeader label={ this.translate( 'Premium Plan Upgrades' ) }>
-					<PurchaseButton { ...{ isActive, href: purchaseLink } } />
-				</SectionHeader>
-
-				<Card className={ cardClasses }>
-					<div className="wpcom-plugins__list">
-						{ plugins.map( ( { name, descriptionLink, icon, category, description } ) =>
-							<Plugin
-								onClick={ () => onClick( name ) }
-								{ ...{
-									name,
-									key: name,
-									descriptionLink,
-									icon,
-									isActive,
-									category,
-									description
-								} }
-							/>
-						) }
-					</div>
-				</Card>
+		<Card className={ classNames( 'wpcom-plugins__premium-panel', {
+			'is-disabled': ! isActive,
+		} ) }>
+			<div className="wpcom-plugins__list">
+				{ plugins.map( ( { name, descriptionLink, icon, category, description } ) =>
+					<Plugin
+						{ ...{
+							category,
+							description,
+							descriptionLink,
+							icon,
+							isActive,
+							key: name,
+							name,
+							onClick,
+						} }
+					/>
+				) }
 			</div>
-		);
-	}
-} );
+		</Card>
+	</div>
+);
 
 PremiumPluginsPanel.propTypes = {
 	isActive: PropTypes.bool,
@@ -57,16 +61,14 @@ PremiumPluginsPanel.propTypes = {
 	plugins: PropTypes.array
 };
 
-const trackClick = name => recordTracksEvent(
-	'calypso_plugin_wpcom_click',
-	{
+const trackClick = name =>
+	recordTracksEvent( 'calypso_plugin_wpcom_click', {
 		plugin_name: name,
-		plugin_plan: 'premium'
-	}
-);
+		plugin_plan: 'premium',
+	} );
 
 const mapDispatchToProps = dispatch => ( {
-	onClick: name => dispatch( trackClick( name ) )
+	onClick: compose( dispatch, trackClick ),
 } );
 
-export default connect( null, mapDispatchToProps )( PremiumPluginsPanel );
+export default connect( null, mapDispatchToProps )( localize( PremiumPluginsPanel ) );

--- a/client/my-sites/plugins-wpcom/purchase-button.jsx
+++ b/client/my-sites/plugins-wpcom/purchase-button.jsx
@@ -1,34 +1,35 @@
+/**
+ * External dependencies
+ */
 import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 
-export const PurchaseButton = React.createClass( {
-	render() {
-		const {
-			href,
-			isActive
-		} = this.props;
-
-		if ( isActive ) {
-			return (
-				<Button className="is-active-plugin" compact borderless>
-					<Gridicon icon="checkmark" />{ this.translate( 'Active' ) }
-				</Button>
-			);
-		}
-
-		return (
-			<Button compact primary { ...{ href } }>
-				{ this.translate( 'Purchase' ) }
-			</Button>
-		);
-	}
-} );
+export const PurchaseButton = ( {
+	href,
+	isActive,
+	translate = identity,
+} ) => isActive
+	? (
+		<Button className="is-active-plugin" compact borderless>
+			<Gridicon icon="checkmark" />{ translate( 'Active' ) }
+		</Button>
+	)
+	: (
+		<Button compact primary { ...{ href } }>
+			{ translate( 'Purchase' ) }
+		</Button>
+	);
 
 PurchaseButton.propTypes = {
 	href: PropTypes.string.isRequired,
-	isActive: PropTypes.bool.isRequired
+	isActive: PropTypes.bool.isRequired,
 };
 
-export default PurchaseButton;
+export default localize( PurchaseButton );

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -4,6 +4,10 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import {
+	flowRight as compose,
+	identity,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,62 +21,69 @@ import Plugin from './plugin';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 
-export const StandardPluginsPanel = React.createClass( {
-	render() {
-		const {
-			displayCount,
-			onClick,
-			plugins = []
-		} = this.props;
-
-		const shownPlugins = plugins.slice( 0, displayCount );
-
-		return (
-			<div>
-				<SectionHeader label={ this.translate( 'Standard Plugins' ) }>
-					<Button className="is-active-plugin" compact borderless>
-						<Gridicon icon="checkmark" />{ this.translate( 'Active' ) }
-					</Button>
-				</SectionHeader>
-				<CompactCard className="wpcom-plugins__standard-panel">
-					<div className="wpcom-plugins__list">
-						{ shownPlugins.map( ( { name, descriptionLink, icon, category, description } ) =>
-							<Plugin
-								onClick={ () => onClick( name ) }
-								{ ...{ name, key: name, descriptionLink, icon, category, description } }
-							/>
-						) }
-					</div>
-				</CompactCard>
-				<Notice
-					status="is-info"
-					showDismiss={ false }
-					text={ this.translate( 'Uploading your own plugins is not available on WordPress.com.' ) }
-				>
-					<NoticeAction href="https://en.support.wordpress.com/plugins/" external={ true }>
-						{ this.translate( 'Learn More' ) }
-					</NoticeAction>
-				</Notice>
+export const StandardPluginsPanel = ( {
+	displayCount,
+	onClick,
+	plugins = [],
+	translate = identity,
+} ) => (
+	<div>
+		<SectionHeader label={ translate( 'Standard Plugins' ) }>
+			<Button className="is-active-plugin" compact borderless>
+				<Gridicon icon="checkmark" />{ translate( 'Active' ) }
+			</Button>
+		</SectionHeader>
+		<CompactCard className="wpcom-plugins__standard-panel">
+			<div className="wpcom-plugins__list">
+				{ plugins
+					.slice( 0, displayCount )
+					.map( ( { name, descriptionLink, icon, category, description } ) => (
+						<Plugin
+							{ ...{
+								category,
+								description,
+								descriptionLink,
+								icon,
+								key: name,
+								name,
+								onClick,
+							} }
+						/>
+					)
+				) }
 			</div>
-		);
-	}
-} );
+		</CompactCard>
+		<Notice
+			status="is-info"
+			showDismiss={ false }
+			text={ translate(
+				'Uploading your own plugins is ' +
+				'not available on WordPress.com.'
+			) }
+		>
+			<NoticeAction
+				href="https://en.support.wordpress.com/plugins/"
+				external={ true }
+			>
+				{ translate( 'Learn More' ) }
+			</NoticeAction>
+		</Notice>
+	</div>
+);
 
 StandardPluginsPanel.propTypes = {
 	displayCount: PropTypes.number,
-	plugins: PropTypes.array
+	plugins: PropTypes.array,
 };
 
-const trackClick = name => recordTracksEvent(
-	'calypso_plugin_wpcom_click',
-	{
+const trackClick = name =>
+	recordTracksEvent( 'calypso_plugin_wpcom_click', {
 		plugin_name: name,
-		plugin_plan: 'standard'
-	}
-);
+		plugin_plan: 'standard',
+	} );
 
 const mapDispatchToProps = dispatch => ( {
-	onClick: name => dispatch( trackClick( name ) )
+	onClick: compose( dispatch, trackClick ),
 } );
 
 export default connect( null, mapDispatchToProps )( localize( StandardPluginsPanel ) );


### PR DESCRIPTION
This patch updates some code to more recent Calypso style.

There are CSS naming issues but they are existing and won't be fixed
here. This patch prefixes updates to the visual style of the WPCOM
plugins page.

cc: @roundhill @drw158 @rodrigoi @vindl @Copons 