### PR TITLE
JPC: Remove plans first test in jetpack auth flow

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -36,7 +36,6 @@ import {
 	isRemoteSiteOnSitesList,
 	getGlobalSelectedPlan
 } from 'state/jetpack-connect/selectors';
-import { abtest } from 'lib/abtest';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import observe from 'lib/mixins/data-observe';
 import userUtilities from 'lib/user/utils';
@@ -596,7 +595,6 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		return !! ( this.props.jetpackSSOSessions && this.props.jetpackSSOSessions[ site ] );
 	},
 
-
 	renderNoQueryArgsError() {
 		return (
 			<Main>
@@ -680,7 +678,7 @@ export default connect(
 			siteSlug,
 			selectedPlan,
 			jetpackConnectAuthorize: getAuthorizationData( state ),
-			plansFirst: abtest( 'jetpackConnectPlansFirst' ) === 'showPlansBeforeAuth',
+			plansFirst: false,
 			jetpackSSOSessions: getSSOSessions( state ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			isFetchingSites,


### PR DESCRIPTION
The jetpack plans-first test wasn't doing so great, so we are going to remove it by now

