### PR TITLE
Sites-list: Remove dependency from upgrades/checkout

### DIFF
--- a/client/lib/checkout/index.js
+++ b/client/lib/checkout/index.js
@@ -23,5 +23,5 @@ export function getExitCheckoutUrl( cart, siteSlug ) {
 		url = '/design/';
 	}
 
-	return url + siteSlug;
+	return siteSlug ? url + siteSlug : url;
 }

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -43,7 +43,11 @@ import {
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
-import { getSelectedSite } from 'state/ui/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'state/ui/selectors';
 
 const Checkout = React.createClass( {
 	mixins: [ observe( 'sites', 'productsList' ) ],
@@ -140,7 +144,7 @@ const Checkout = React.createClass( {
 	redirectIfEmptyCart: function() {
 		let redirectTo = '/plans/';
 
-		const { selectedSite } = this.props
+		const { selectedSiteSlug } = this.props;
 
 		if ( ! this.state.previousCart && this.props.product ) {
 			// the plan hasn't been added to the cart yet
@@ -156,7 +160,7 @@ const Checkout = React.createClass( {
 		}
 
 		if ( this.state.previousCart ) {
-			redirectTo = getExitCheckoutUrl( this.state.previousCart, selectedSite.slug );
+			redirectTo = getExitCheckoutUrl( this.state.previousCart, selectedSiteSlug );
 		}
 
 		page.redirect( redirectTo );
@@ -185,7 +189,7 @@ const Checkout = React.createClass( {
 			receiptId = ':receiptId';
 
 		const receipt = this.props.transaction.step.data;
-		const { selectedSite } = this.props;
+		const { selectedSiteId, selectedSiteSlug } = this.props;
 
 		this.props.clearPurchases();
 
@@ -232,9 +236,9 @@ const Checkout = React.createClass( {
 
 			return purchasePaths.managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
 		} else if ( cartItems.hasFreeTrial( this.props.cart ) ) {
-			this.props.clearSitePlans( selectedSite.ID );
+			this.props.clearSitePlans( selectedSiteId );
 
-			return `/plans/${ selectedSite.slug }/thank-you`;
+			return `/plans/${ selectedSiteSlug }/thank-you`;
 		}
 
 		if ( receipt && receipt.receipt_id ) {
@@ -247,8 +251,8 @@ const Checkout = React.createClass( {
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
-			? `/checkout/thank-you/features/${ this.props.selectedFeature }/${ selectedSite.slug }/${ receiptId }`
-			: `/checkout/thank-you/${ selectedSite.slug }/${ receiptId }`;
+			? `/checkout/thank-you/features/${ this.props.selectedFeature }/${ selectedSiteSlug }/${ receiptId }`
+			: `/checkout/thank-you/${ selectedSiteSlug }/${ receiptId }`;
 	},
 
 	content: function() {
@@ -310,18 +314,22 @@ const Checkout = React.createClass( {
 	}
 } );
 
-function mapStateToProps ( state ) {
+function mapStateToProps( state ) {
 	const cards = getStoredCards( state );
 	const selectedSite = getSelectedSite( state );
+	const selectedSiteId = getSelectedSiteId( state );
+	const selectedSiteSlug = getSelectedSiteSlug( state );
 
 	return {
 		cards,
 		selectedSite,
-	}
+		selectedSiteId,
+		selectedSiteSlug,
+	};
 }
 
 module.exports = connect(
-	mapStateToProps,	
+	mapStateToProps,
 	{
 		clearPurchases,
 		clearSitePlans,

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -240,7 +240,7 @@ const Checkout = React.createClass( {
 
 			return selectedSiteSlug
 				? `/plans/${ selectedSiteSlug }/thank-you`
-				: '/plans/';
+				: '/checkout/thank-you/plans';
 		}
 
 		if ( receipt && receipt.receipt_id ) {
@@ -253,7 +253,7 @@ const Checkout = React.createClass( {
 		}
 
 		if ( ! selectedSiteSlug ) {
-			return '/checkout/';
+			return '/checkout/thank-you/features';
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -238,7 +238,9 @@ const Checkout = React.createClass( {
 		} else if ( cartItems.hasFreeTrial( this.props.cart ) ) {
 			this.props.clearSitePlans( selectedSiteId );
 
-			return `/plans/${ selectedSiteSlug }/thank-you`;
+			return selectedSiteSlug
+				? `/plans/${ selectedSiteSlug }/thank-you`
+				: '/plans/';
 		}
 
 		if ( receipt && receipt.receipt_id ) {
@@ -248,6 +250,10 @@ const Checkout = React.createClass( {
 				receiptId: receiptId,
 				purchases: this.getPurchasesFromReceipt()
 			} );
+		}
+
+		if ( ! selectedSiteSlug ) {
+			return '/checkout/';
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -196,7 +196,7 @@ module.exports = {
 						product={ product }
 						productsList={ productsList }
 						selectedFeature={ selectedFeature }
-						sites={ sites } />
+					/>
 				</CheckoutData>
 			),
 			document.getElementById( 'primary' ),


### PR DESCRIPTION
### Aims
As part of #8726, this PR removes reference to 'lib/sites-list' from the upgrades/checkout component.

### Test Plan

- Navigate to [plans](http://calypso.localhost:3000/plans) and select a site.
- Choose an upgrade... this should take you to the checkout page.
- Check that this page has not changed functionally.
    - it should be visually identical before & after this patch
