### PR TITLE
Reader: Support Twitter moments embeds

### DIFF
--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -19,7 +19,7 @@ const debug = debugFactory( 'calypso:components:embed-container' );
 
 const embedsToLookFor = {
 	'blockquote[class^="instagram-"]': embedInstagram,
-	'blockquote[class^="twitter-"]': embedTwitter,
+	'blockquote[class^="twitter-"], a[class^="twitter-"]': embedTwitter,
 	'fb\\\:post, [class^=fb-]': embedFacebook,
 	'[class^=tumblr-]': embedTumblr,
 	'.jetpack-slideshow': embedSlideshow


### PR DESCRIPTION
Fixes #9430 

compare http://calypso.localhost:3000/read/feeds/46000043/posts/1225709978 to https://wordpress.com/read/feeds/46000043/posts/1225709978