### PR TITLE
GuidedTours: target-based blanket exit without `Continue`

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -135,7 +135,7 @@ export class Step extends Component {
 
 	/*
 	 * A step belongs to a specific section. This datum is used by the "blank
-	 * exit" feature (cf. quitIfInvalidRoute in Step and Continue).
+	 * exit" feature (cf. Step.quitIfInvalidRoute).
 	 *
 	 * `setStepSection` has specific logic to deal with the fact that `step` and
 	 * `section` transitions are not synchronized. Notably, navigating to a
@@ -193,12 +193,22 @@ export class Step extends Component {
 		if ( ! hasContinue && hasJustNavigated &&
 				this.isDifferentSection( lastAction.path ) ) {
 			defer( () => {
-				debug( 'Step.quitIfInvalidRoute: quitting' );
+				debug( 'Step.quitIfInvalidRoute: quitting (different section)' );
 				this.context.quit( this.context );
 			} );
-		} else {
-			debug( 'Step.quitIfInvalidRoute: not quitting' );
 		}
+
+		// quit if we have a target but cant find it
+		defer( () => {
+			const { quit } = this.context;
+			const target = targetForSlug( this.props.target );
+			if ( this.props.target && ! target ) {
+				debug( 'Step.quitIfInvalidRoute: quitting (cannot find target)' );
+				quit( this.context );
+			} else {
+				debug( 'Step.quitIfInvalidRoute: not quitting' );
+			}
+		} );
 	}
 
 	isDifferentSection( path ) {
@@ -353,7 +363,6 @@ export class Continue extends Component {
 
 	componentDidMount() {
 		! this.props.hidden && this.addTargetListener();
-		this.quitIfInvalidRoute( this.props, this.context );
 	}
 
 	componentWillUnmount() {
@@ -369,23 +378,7 @@ export class Continue extends Component {
 	}
 
 	componentDidUpdate() {
-		this.quitIfInvalidRoute( this.props, this.context );
 		this.addTargetListener();
-	}
-
-	quitIfInvalidRoute( props ) {
-		debug( 'Continue.quitIfInvalidRoute' );
-		defer( () => {
-			const { quit } = this.context;
-			const target = targetForSlug( props.target );
-			// quit if we have a target but cant find it
-			if ( props.target && ! target ) {
-				debug( 'Continue.quitIfInvalidRoute: quitting' );
-				quit( this.context );
-			} else {
-				debug( 'Continue.quitIfInvalidRoute: not quitting' );
-			}
-		} );
 	}
 
 	onContinue = () => {


### PR DESCRIPTION
In Guided Tours, "blanket exit" is the idea that when a user navigates away, they might want to quit the tour that is currently running. It tries to infer user intent.

One heuristic we use is to quit the tour if the current step has a target we want to point at but we can't find that target on the page. However, we have used that only in the `Continue` element, since we had assumed that only there would we need targets.

Now that @marekhrabe has been working on a "site title" tour in #8627, we noticed that having a target is perfectly legitimate even when the user advances the step manually with a "Next" button. In such a case, "blanket exit" would not have worked because the check for finding the target element would not have been called.

Therefore, this change moves the check for the target into the more general `Step` component. If our step has a target and we can't find it on the page, we quit the tour.

Fixed #9178. 

To test: 

- make sure the `main` tour and the `siteTitle` tour (apply this change to #8627) both still work
- make sure blanket exit works for both the `main` tour and the `siteTitle` tour (apply this change to #8627)

