### PR TITLE
Reader: Add thicker border to gallery photos

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -482,7 +482,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	cursor: pointer;
 	flex: 1;
 	list-style-type: none;
-	border-right: 1px solid lighten( $gray, 30% );
+	border-right: 2px solid $white;
 
 	&:last-child {
 		border-right: 0;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9406

**Before:**
![screenshot 2016-11-16 10 43 24](https://cloud.githubusercontent.com/assets/4924246/20361176/7e76b990-abeb-11e6-9732-87b5d52e6680.png)

**After:**
![screenshot 2016-11-16 10 43 13](https://cloud.githubusercontent.com/assets/4924246/20361178/8231d588-abeb-11e6-8b0a-eaabe9214481.png)
