### PR TITLE
Plugins: Remove validateFilters from plugins controller

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -50,7 +50,7 @@ export const PluginPanel = ( {
 	siteSlug,
 	translate,
 } ) => {
-	const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
+	const standardPluginsLink = `/plugins/category/standard/${ siteSlug }`;
 	const purchaseLink = `/plans/${ siteSlug }`;
 
 	const hasBusiness = isBusiness( plan ) || isEnterprise( plan );

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -20,7 +20,7 @@ import { defaultStandardPlugins } from './default-plugins';
 
 export const PluginsList = ( { siteSlug, translate } ) => (
 	<div className="wpcom-plugin-panel wpcom-plugins-expanded">
-		<PageViewTracker path="/plugins/standard/:site" title="Plugins > WPCOM Site > Standard Plugins" />
+		<PageViewTracker path="/plugins/category/standard/:site" title="Plugins > WPCOM Site > Standard Plugins" />
 		<HeaderCake backHref={ `/plugins/${ siteSlug }` } onClick={ noop }>
 			{ translate( 'Standard Plugins' ) }
 		</HeaderCake>

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -6,7 +6,6 @@ import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 import some from 'lodash/some';
-import includes from 'lodash/includes';
 import capitalize from 'lodash/capitalize';
 
 /**
@@ -180,38 +179,6 @@ function renderProvisionPlugins( context ) {
 }
 
 const controller = {
-	validateFilters( filter, context, next ) {
-		const wpcomFilter = 'standard';
-		const siteUrl = route.getSiteFragment( context.path );
-		const site = getSelectedSite( context.store.getState() );
-		const appliedFilter = ( filter ? filter : context.params.plugin ).toLowerCase();
-
-		// bail if /plugins/:site_id?
-		if ( siteUrl && appliedFilter === siteUrl.toString().toLowerCase() ) {
-			next();
-			return;
-		}
-		// When site URL is present, bail if ...
-		//
-		// ... the plugin parameter is not on the WordPress.com list for a WordPress.com site.
-		const pluginIsNotInList = site && ! site.jetpack && ! includes( [ 'all', wpcomFilter ], appliedFilter );
-
-		// ... or the plugin parameter is on the WordPress.com list for a Jetpack site.
-		// if no site URL is provided, bail if a WordPress.com filter was provided.
-		//  Only Jetpack plugins should work when no URL is provided.
-		const onlyJetPack = site && site.jetpack && appliedFilter === wpcomFilter;
-
-		if ( siteUrl && ( pluginIsNotInList || onlyJetPack ) ) {
-			page.redirect( '/plugins/' + siteUrl );
-			return;
-		} else if ( ! siteUrl && appliedFilter === wpcomFilter ) {
-			page.redirect( '/plugins' );
-			return;
-		}
-
-		next();
-	},
-
 	plugins( filter, context, next ) {
 		const siteUrl = route.getSiteFragment( context.path );
 		const basePath = route.sectionify( context.path ).replace( '/' + filter, '' );

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -1,32 +1,83 @@
 /**
  * External dependencies
  */
-var page = require( 'page' );
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-var controller = require( 'my-sites/controller' ),
-	config = require( 'config' ),
-	pluginsController = require( './controller' );
+import controller from 'my-sites/controller';
+import config from 'config';
+import pluginsController from './controller';
+import { getSelectedSite } from 'state/ui/selectors';
+
+const nonJetpackRedirectTo = path => ( context, next ) => {
+	const site = getSelectedSite( context.store.getState() );
+
+	if ( site.jetpack ) {
+		page.redirect( `${ path }/${ site.slug }` );
+	}
+
+	next();
+};
 
 module.exports = function() {
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
-		page( '/plugins/setup', controller.siteSelection, pluginsController.setupPlugins );
-		page( '/plugins/setup/:site', controller.siteSelection, pluginsController.setupPlugins );
+		page( '/plugins/setup',
+			controller.siteSelection,
+			pluginsController.setupPlugins
+		);
+
+		page( '/plugins/setup/:site',
+			controller.siteSelection,
+			pluginsController.setupPlugins
+		);
 	}
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {
-		page( '/plugins/browse/:category/:site', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
-		page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
+		page( '/plugins/browse/:category/:site',
+			controller.siteSelection,
+			controller.navigation,
+			pluginsController.browsePlugins
+		);
 
-		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, 'all' ), pluginsController.plugins.bind( null, 'all' ), controller.sites );
+		page( '/plugins/browse/:siteOrCategory?',
+			controller.siteSelection,
+			controller.navigation,
+			pluginsController.browsePlugins
+		);
 
-		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {
-			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, filter ), pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
-		} );
+		page( '/plugins/category/:category/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			nonJetpackRedirectTo( '/plugins' ),
+			pluginsController.plugin,
+		);
 
-		page( '/plugins/:plugin/:business_plugin?/:site_id?', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, null ), pluginsController.plugin );
-		page.exit( '/plugins*', pluginsController.resetHistory );
+		page( '/plugins',
+			controller.siteSelection,
+			controller.navigation,
+			pluginsController.plugins.bind( null, 'all' ),
+			controller.sites
+		);
+
+		[ 'active', 'inactive', 'updates' ].forEach( filter => (
+			page( `/plugins/${ filter }/:site_id?`,
+				controller.siteSelection,
+				controller.navigation,
+				pluginsController.jetpackCanUpdate.bind( null, filter ),
+				pluginsController.plugins.bind( null, filter )
+			)
+		) );
+
+		page( '/plugins/:plugin/:business_plugin?/:site_id?',
+			controller.siteSelection,
+			controller.navigation,
+			pluginsController.plugin
+		);
+
+		page.exit( '/plugins*',
+			pluginsController.resetHistory
+		);
 	}
 };


### PR DESCRIPTION
Previously we were reusing some code in the page controller to support a
pseudo-plug slug that would show categories of "plugins" available on
dotcom. This only existed for `all` and `standard` and was used once
when viewing plugins for dotcom sites.

Now, I have created a separate route with the explicit `category` prefix
so that we can grab the route before combining it with the route for
individual plugins. `/plugins/category/standard/siteSlug`

**Testing**
Try to navigate around all the different possible plugin navigation combinations.

> There should be no functional changes here and the only visible change is the update in the URL from `/plugins/standard/siteSlug` for a dotcom site to `/plugins/category/standard/siteSlug`

cc: @roundhill @rodrigoi 