### PR TITLE
Notice: improving the mobile-first styles for notices

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -51,13 +51,11 @@
 	}
 }
 
-.global-notices .notice__text {
-	padding-left: 16px;
+.global-notices .notice__content {
 	flex-basis: auto;
 	flex-grow: 1;
 
 	@include breakpoint( ">660px" ) {
-		flex-grow: 0;
 		padding: 9px 13px;
 	}
 }

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -54,7 +54,13 @@ export const Notice = React.createClass( {
 		let content, text;
 
 		if ( typeof this.props.children === 'string' ) {
-			return <span className="notice__text"><span>{ this.props.children }</span></span>;
+			return (
+				<span className="notice__content">
+					<span className="notice__text">
+						<span>{ this.props.children }</span>
+					</span>
+				</span>
+			);
 		}
 
 		if ( this.props.text ) {
@@ -65,9 +71,17 @@ export const Notice = React.createClass( {
 			}
 
 			content = [ this.props.children ];
-			content.unshift( <span key="notice_text" className="notice__text">{ text }</span> );
+			content.unshift(
+				<span className="notice__content">
+					<span key="notice_text" className="notice__text">{ text }</span>
+				</span>
+			);
 		} else {
-			content = <span key="notice_text" className="notice__text">{ this.props.children }</span>;
+			content =
+				<span className="notice__content">
+					<span key="notice_text" className="notice__text">{ this.props.children }</span>
+				</span>
+			;
 		}
 
 		return content;
@@ -123,9 +137,7 @@ export const Notice = React.createClass( {
 		return (
 			<div className={ classnames( this.props.className, noticeClass ) }>
 				<Gridicon className="notice__icon" icon={ this.props.icon || this.getIcon() } size={ 24 } />
-				<div className="notice__content">
 					{ this.renderChildren() }
-				</div>
 				{ dismiss }
 			</div>
 		);

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -50,43 +50,6 @@ export const Notice = React.createClass( {
 		}
 	},
 
-	renderChildren() {
-		let content, text;
-
-		if ( typeof this.props.children === 'string' ) {
-			return (
-				<span className="notice__content">
-					<span className="notice__text">
-						<span>{ this.props.children }</span>
-					</span>
-				</span>
-			);
-		}
-
-		if ( this.props.text ) {
-			if ( typeof this.props.text === 'string' ) {
-				text = <span>{ this.props.text }</span>;
-			} else {
-				text = this.props.text;
-			}
-
-			content = [ this.props.children ];
-			content.unshift(
-				<span className="notice__content">
-					<span key="notice_text" className="notice__text">{ text }</span>
-				</span>
-			);
-		} else {
-			content =
-				<span className="notice__content">
-					<span key="notice_text" className="notice__text">{ this.props.children }</span>
-				</span>
-			;
-		}
-
-		return content;
-	},
-
 	getIcon() {
 		let icon;
 
@@ -112,33 +75,29 @@ export const Notice = React.createClass( {
 	},
 
 	render() {
-		let dismiss;
+		const { status, className, isCompact, showDismiss } = this.props;
+		const classes = classnames( 'notice', status, className, {
+			'is-compact': isCompact,
+			'is-dismissable': showDismiss
+		} );
 
-		// The class determines the nature of a notice
-		// and its status.
-		let noticeClass = classnames( 'notice', this.props.status );
-
-		if ( this.props.isCompact ) {
-			noticeClass = classnames( noticeClass, 'is-compact' );
-		}
-
-		// By default, a dismiss button is rendered to
-		// allow the user to hide the notice
-		if ( this.props.showDismiss ) {
-			noticeClass = classnames( noticeClass, 'is-dismissable' );
-			dismiss = (
-				<span tabIndex="0" className="notice__dismiss" onClick={ this.props.onDismissClick } >
-					<Gridicon icon="cross" size={ 24 } />
-					<span className="screen-reader-text">{ this.props.translate( 'Dismiss' ) }</span>
-				</span>
-				);
-		}
+		const { icon, text, children, onDismissClick, translate } = this.props;
 
 		return (
-			<div className={ classnames( this.props.className, noticeClass ) }>
-				<Gridicon className="notice__icon" icon={ this.props.icon || this.getIcon() } size={ 24 } />
-					{ this.renderChildren() }
-				{ dismiss }
+			<div className={ classes }>
+				<Gridicon className="notice__icon" icon={ icon || this.getIcon() } size={ 24 } />
+				<span className="notice__content">
+					<span className="notice__text">
+						{ text ? text : children }
+					</span>
+				</span>
+				{ text ? children : null }
+				{ showDismiss && (
+					<span tabIndex="0" className="notice__dismiss" onClick={ onDismissClick } >
+						<Gridicon icon="cross" size={ 24 } />
+						<span className="screen-reader-text">{ translate( 'Dismiss' ) }</span>
+					</span>
+				) }
 			</div>
 		);
 	}

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -1,15 +1,15 @@
 .notice {
 	display: flex;
+		flex-direction: column;
 	position: relative;
+	width: 100%;
 	margin-bottom: 24px;
-	border-radius: 1px;
 	background: lighten( $gray, 30 );
 	box-sizing: border-box;
-	font-size: 14px;
 	animation: appear .3s ease-in-out;
 
-	@include breakpoint( ">660px" ) {
-		font-size: inherit;
+	@include breakpoint( ">480px" ) {
+		flex-direction: row;
 	}
 
 	// Success!
@@ -49,35 +49,40 @@
 }
 
 .notice__icon {
-	flex-shrink: 0;
-	padding: 13px 0 13px 16px;
-	flex-shrink: 0;
+	position: absolute;
+		top: 0;
+		left: 0;
+	display: flex;
+		flex-shrink: 0;
+	width: 18px;
+	height: 18px;
+	padding: 14px 16px;
 
-	@include breakpoint( "<660px" ) {
-		display: none;
+	@include breakpoint( ">480px" ) {
+		position: relative;
+		padding: 13px 0px 13px 16px;
+		width: 24px;
+		height: 24px;
 	}
 }
 
 .notice__content {
 	display: flex;
-	flex-grow: 1;
+		flex-grow: 1;
+	padding: 14px 48px;
+	font-size: 12px;
 
-	@include breakpoint( "<480px" ) {
-		flex-direction: column;
+	@include breakpoint( ">480px" ) {
+		font-size: 14px;
+		padding: 13px;
 	}
 }
 
 .notice__text {
-	font-size: 15px;
-	padding: 11px 24px;
 
 	& > span,
 	& > div {
 		max-width: 680px;
-	}
-
-	@include breakpoint( ">660px" ) {
-		padding: 13px;
 	}
 
 	a {
@@ -111,14 +116,28 @@
 
 // "X" for dismissing a notice
 .notice__dismiss {
+	position: absolute;
+		top: 0;
+		right: 0;
 	display: flex;
 		flex-shrink: 0;
-	padding: 11px 16px;
+	padding: 14px 16px;
 	cursor: pointer;
 	color: $gray;
 
-	@include breakpoint( ">660px" ) {
+	.gridicon {
+		width: 18px;
+		height: 18px;
+	}
+
+	@include breakpoint( ">480px" ) {
+		position: relative;
 		padding: 13px 16px;
+
+		.gridicon {
+			width: 24px;
+			height: 24px;
+		}
 	}
 
 	&:hover,
@@ -140,16 +159,33 @@
 // specificity for general `a` elements within notice is too great
 a.notice__action {
 	display: flex;
-		align-items: center;
+		justify-content: center;
 		flex-shrink: 0;
+		flex-grow: 1;
 	box-sizing: border-box;
+	margin: 0 8px 8px 8px;
+	padding: 8px;
+	border-radius: 3px;
 	cursor: pointer;
-	font-size: 15px;
+	font-size: 12px;
 	font-weight: 400;
-	margin-left: auto; // forces the element to the right;
-	padding: 13px 16px;
 	text-decoration: none;
 	white-space: nowrap;
+
+	@include breakpoint( ">480px" ) {
+			flex-shrink: 1;
+			flex-grow: 0;
+		align-items: center;
+		border-radius: 0;
+		font-size: 14px;
+		margin: 0 0 0 auto; // forces the element to the right;
+		padding: 13px 16px;
+
+		.gridicon {
+			width: 24px;
+			height: 24px;
+		}
+	}
 
 	.is-success &,
 	.is-error &,
@@ -166,24 +202,23 @@ a.notice__action {
 	.gridicon {
 		margin-left: 8px;
 		opacity: 0.7;
+		width: 18px;
+		height: 18px;
 	}
 
 	&:hover,
 	&:focus {
 		background: rgba( 255, 255, 255, 0.2 );
 	}
-
-	@include breakpoint( "<480px" ) {
-		margin: 0;
-		justify-content: flex-end;
-	}
 }
 
 // Compact notices
 .notice.is-compact {
-	border-radius: 2px;
 	display: inline-flex;
-	flex-wrap: nowrap;
+		flex-wrap: nowrap;
+		flex-direction: row;
+	width: auto;
+	border-radius: 2px;
 	min-height: 20px;
 	margin: 0;
 	padding: 0;
@@ -198,13 +233,17 @@ a.notice__action {
 		color: $white;
 	}
 
-	.notice__text {
+	.notice__content {
 		font-size: 12px;
 		padding: 6px 8px;
+	}
+
+	.notice__text {
 		line-height: 1;
 	}
 
 	.notice__icon {
+		position: relative;
 		align-self: center;
 		flex-shrink: 0;
 		margin: 0 0 0 8px;
@@ -221,7 +260,8 @@ a.notice__action {
 	a.notice__action {
 		background: transparent;
 		display: inline-block;
-		font-size: 11px;
+		margin: 0;
+		font-size: 12px;
 		font-weight: 600;
 		align-self: center;
 		margin-left: 16px;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -171,6 +171,7 @@ a.notice__action {
 	font-weight: 400;
 	text-decoration: none;
 	white-space: nowrap;
+	background: lighten( $gray, 28 );
 
 	@include breakpoint( ">480px" ) {
 			flex-shrink: 1;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -79,11 +79,7 @@
 }
 
 .notice__text {
-
-	& > span,
-	& > div {
-		max-width: 680px;
-	}
+	max-width: 680px;
 
 	a {
 		text-decoration: underline;


### PR DESCRIPTION
Fixes #8127

At narrow widths notices with actions now make a lot more sense.

After:

<img width="626" alt="screen shot 2016-11-16 at 3 29 51 pm" src="https://cloud.githubusercontent.com/assets/437258/20364579/a9156f9a-ac11-11e6-979c-0d51592665f4.png">
<img width="632" alt="screen shot 2016-11-16 at 3 30 01 pm" src="https://cloud.githubusercontent.com/assets/437258/20364578/a911fb58-ac11-11e6-8732-03fcf2718dde.png">
<img width="462" alt="screen shot 2016-11-16 at 3 30 14 pm" src="https://cloud.githubusercontent.com/assets/437258/20364577/a9100528-ac11-11e6-92dd-e0c160255912.png">

cc @mtias @drw158 @MichaelArestad @folletto 

This requires some further refactoring of the notice code, it's a bit messy in index.jsx right now. It also requires some improvements to devdocs to show more edge-case notices like when we have a notice action and a dismiss X. 