### PR TITLE
Framework: People: Fix an issue where editing user with slug like usernames failed

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -8,13 +8,13 @@ import includes from 'lodash/includes';
 /**
  * Internal Dependencies
  */
-var trailingslashit = require( './trailingslashit' ),
-	untrailingslashit = require( './untrailingslashit' );
+import trailingslashit from './trailingslashit';
+import untrailingslashit from './untrailingslashit';
 
 /**
  * Module variables
  */
-var statsLocationsByTab = {
+const statsLocationsByTab = {
 	day: '/stats/day/',
 	week: '/stats/week/',
 	month: '/stats/month/',
@@ -23,23 +23,21 @@ var statsLocationsByTab = {
 };
 
 function getSiteFragment( path ) {
-	const basePath = path.split( '?' )[0];
+	const basePath = path.split( '?' )[ 0 ];
 	const pieces = basePath.split( '/' );
 
 	// There are 2 URL positions where we should look for the site fragment:
 	// last (most sections) and second-to-last (post ID is last in editor)
-
-	// Check last and second-to-last piece for site slug
+	//
+	// This block will check the second-to-last segment for a site fragment or
+	// site ID, and then will check the first-to-last segment for the same.
 	for ( let i = 2; i > 0; i-- ) {
-		const piece = pieces[ pieces.length - i ];
+		let piece = pieces[ pieces.length - i ];
 		if ( piece && -1 !== piece.indexOf( '.' ) ) {
 			return piece;
 		}
-	}
 
-	// Check last and second-to-last piece for numeric site ID
-	for ( let i = 2; i > 0; i-- ) {
-		const piece = parseInt( pieces[ pieces.length - i ], 10 );
+		piece = parseInt( piece, 10 );
 		if ( Number.isSafeInteger( piece ) ) {
 			return piece;
 		}
@@ -66,8 +64,8 @@ function addSiteFragment( path, site ) {
 }
 
 function sectionify( path ) {
-	var basePath = path.split( '?' )[0],
-		site = getSiteFragment( basePath );
+	let basePath = path.split( '?' )[ 0 ];
+	const site = getSiteFragment( basePath );
 
 	if ( site ) {
 		basePath = trailingslashit( basePath ).replace( '/' + site + '/', '/' );
@@ -76,7 +74,7 @@ function sectionify( path ) {
 }
 
 function getStatsDefaultSitePage( slug ) {
-	var path = '/stats/insights/';
+	const path = '/stats/insights/';
 
 	if ( slug ) {
 		return path + slug;
@@ -86,8 +84,6 @@ function getStatsDefaultSitePage( slug ) {
 }
 
 function getStatsPathForTab( tab, siteIdOrSlug ) {
-	var path;
-
 	if ( ! tab ) {
 		return getStatsDefaultSitePage( siteIdOrSlug );
 	}
@@ -97,7 +93,7 @@ function getStatsPathForTab( tab, siteIdOrSlug ) {
 		return getStatsDefaultSitePage();
 	}
 
-	path = statsLocationsByTab[ tab ];
+	const path = statsLocationsByTab[ tab ];
 
 	if ( ! path ) {
 		return getStatsDefaultSitePage( siteIdOrSlug );

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -248,6 +248,16 @@ describe( 'route', function() {
 				).to.be.false;
 			} );
 		} );
+		describe( 'for people paths', function() {
+			it( 'should return a site when viewing username with a dot', () => {
+				expect(
+					route.getSiteFragment( '/people/edit/example.com/user.name' )
+				).to.equal( 'example.com' );
+				expect(
+					route.getSiteFragment( '/people/edit/123456/user.name' )
+				).to.equal( 123456 );
+			} );
+		} );
 	} );
 
 	describe( 'addSiteFragment', function() {

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -34,7 +34,7 @@ module.exports = function() {
 		}
 
 		page(
-			'/people/edit/:user_login/:site_id',
+			'/people/edit/:site_id/:user_login',
 			peopleController.enforceSiteEnding,
 			controller.siteSelection,
 			controller.navigation,

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -51,7 +51,7 @@ export default React.createClass( {
 				{ ...omit( this.props, 'className', 'user', 'site', 'isSelectable', 'onRemove' ) }
 				className={ classNames( 'people-list-item', this.props.className ) }
 				tagName="a"
-				href={ canLinkToProfile && '/people/edit/' + this.props.user.login + '/' + this.props.site.slug }
+				href={ canLinkToProfile && '/people/edit/' + this.props.site.slug + '/' + this.props.user.login }
 				onClick={ canLinkToProfile && this.navigateToUser }>
 				<div className="people-list-item__profile-container">
 					<PeopleProfile user={ this.props.user } />


### PR DESCRIPTION
@enejb and I paired today and were able to come up with an alternative solution to #9408.

The original approach required adding some `people` specific login in to `getSiteFragment()`. And while it worked, what if we changed our routing in the future, or other sections had similar issues.

So, for our needs, we decided to flip the routing such that the username was before the site fragment, since `getSiteFragment()` checks the second-to-last position before checking the last segment. This handles the case for URLs like `/people/edit/example.com/user.name`. Then, to handle URLs like `/people/edit/123456/user.name`, we changed how `getSiteFragment()` works such that it will look in the second-to-last fragment for *both* a site fragment or an integer before moving on to the last segment.

To test:

- Checkout `update/people-edit-routing` branch
- Go to `/people/team/$site` where `$site` has a user with username that contains a `.`
- Click the user with the `.` in their username
- Ensure that you can properly view the user's profile
- Browse Calypso for breakage