### PR TITLE
Reader Stream Refresh: Move cards up a bit

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -6,6 +6,11 @@ $reader-post-card-breakpoint-large: "( min-width: 961px ) and ( max-width: 1040p
 $reader-post-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 940px )";
 $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
+// Overrides 30px top margin, moves first card closer to top of stream
+.is-reader-page .following.main .card.reader-post-card:nth-child(2) {
+	margin-top: -18px;
+}
+
 .reader-post-card.card {
 	border-bottom: 1px solid lighten( $gray, 30% );
 	box-shadow: none;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -8,7 +8,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // Overrides 30px top margin, moves first card closer to top of stream
 .is-reader-page .following.main .card.reader-post-card:nth-child(2) {
-	margin-top: -18px;
+
+	@include breakpoint( ">480px" ) {
+		margin-top: -18px;
+	}
 }
 
 .reader-post-card.card {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/9403

Had to apply change to the first card in the stream as applying it to `.following .main` affects most streams.

**Before:**
![screenshot 2016-11-16 13 30 33](https://cloud.githubusercontent.com/assets/4924246/20366658/fa5ae4e0-ac00-11e6-88f5-f1ee1e086eff.png)

**After:**
![screenshot 2016-11-16 13 30 51](https://cloud.githubusercontent.com/assets/4924246/20366663/ff7257e2-ac00-11e6-94ba-dd893d6d3548.png)
