### PR TITLE
Checkout: Disappearing cart error notice

### DIFF
--- a/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
+++ b/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
@@ -78,7 +78,8 @@ module.exports = {
 
 		if ( ! isEmpty( messages.errors ) ) {
 			notices.error(
-				messages.errors.map( ( error, index ) => ( <p key={ `${ error.code }-${ index }` }>{ error.message }</p> ) )
+				messages.errors.map( ( error, index ) => ( <p key={ `${ error.code }-${ index }` }>{ error.message }</p> ) ),
+				{ persistent: true }
 			);
 		} else if ( ! isEmpty( messages.success ) ) {
 			notices.success(

--- a/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
+++ b/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	isEmpty = require( 'lodash/isEmpty' );
+import React from 'react';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var notices = require( 'notices' ),
-	getNewMessages = require( 'lib/cart-values' ).getNewMessages;
+import notices from 'notices';
+import { getNewMessages } from 'lib/cart-values';
 
 module.exports = {
 	componentWillReceiveProps( nextProps ) {
@@ -21,9 +21,11 @@ module.exports = {
 		}
 	},
 
-	getChargebackErrorMessage: function() {
-		return this.translate(
-			"{{strong}}Warning:{{/strong}} One or more transactions linked to this site were refunded due to a contested charge. This may have happened because of a chargeback by the credit card holder or a PayPal investigation. Each contested charge carries a fine. To resolve the issue and re-enable posting, please {{a}}pay for the chargeback fine{{/a}}.",
+	getChargebackErrorMessage() {
+		return this.props.translate(
+			'{{strong}}Warning:{{/strong}} One or more transactions linked to this site were refunded due to a contested charge. ' +
+				'This may have happened because of a chargeback by the credit card holder or a PayPal investigation. Each contested ' +
+				'charge carries a fine. To resolve the issue and re-enable posting, please {{a}}pay for the chargeback fine{{/a}}.',
 			{
 				components: {
 					strong: <strong />,
@@ -33,35 +35,41 @@ module.exports = {
 		);
 	},
 
-	getBlockedPurchaseErrorMessage: function() {
-		return this.translate(
-			"Purchases are currently disabled. Please {{a}}contact us{{/a}} to re-enable purchases.",
+	getBlockedPurchaseErrorMessage() {
+		return this.props.translate(
+			'Purchases are currently disabled. Please {{a}}contact us{{/a}} to re-enable purchases.',
 			{
 				components: {
-					a: <a href={ 'https://wordpress.com/error-report/?url=payment@' + this.props.selectedSite.slug } target="_blank" rel="noopener noreferrer" />
+					a: <a
+						href={ 'https://wordpress.com/error-report/?url=payment@' + this.props.selectedSite.slug }
+						target="_blank"
+						rel="noopener noreferrer" />
 				}
 			}
 		);
 	},
 
-	getPrettyErrorMessages: function( messages ) {
+	getPrettyErrorMessages( messages ) {
 		if ( ! messages ) {
 			return [];
 		}
 
-		return messages.map( function( error ) {
-			if ( error.code === 'chargeback' ) {
-				return Object.assign( error, { message: this.getChargebackErrorMessage() } );
-			} else if ( error.code === 'blocked' ) {
-				return Object.assign( error, { message: this.getBlockedPurchaseErrorMessage() } );
-			} else {
-				return error;
+		return messages.map( ( error ) => {
+			switch ( error.code ) {
+				case 'chargeback':
+					return Object.assign( error, { message: this.getChargebackErrorMessage() } );
+
+				case 'blocked':
+					return Object.assign( error, { message: this.getBlockedPurchaseErrorMessage() } );
+
+				default:
+					return error;
 			}
-		}, this );
+		} );
 	},
 
-	displayCartMessages: function( newCart ) {
-		var previousCart = ( this.state ) ? this.state.previousCart : null,
+	displayCartMessages( newCart ) {
+		const previousCart = ( this.state ) ? this.state.previousCart : null,
 			messages = getNewMessages( previousCart, newCart );
 
 		messages.errors = this.getPrettyErrorMessages( messages.errors );
@@ -69,13 +77,13 @@ module.exports = {
 		this.setState( { previousCart: newCart } );
 
 		if ( ! isEmpty( messages.errors ) ) {
-			notices.error( messages.errors.map( function( error ) {
-				return ( <p key={ error.code }>{ error.message }</p> );
-			}, this ) );
+			notices.error(
+				messages.errors.map( ( error, index ) => ( <p key={ `${ error.code }-${ index }` }>{ error.message }</p> ) )
+			);
 		} else if ( ! isEmpty( messages.success ) ) {
-			notices.success( messages.success.map( function( success ) {
-				return ( <p key={ success.code }>{ success.message }</p> );
-			}, this ) );
+			notices.success(
+				messages.success.map( ( success, index ) => ( <p key={ `${ success.code }-${ index }` }>{ success.message }</p> ) )
+			);
 		}
 	}
 };

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import reject from 'lodash/reject';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ import CartTrialAd from './cart-trial-ad';
 import { isCredits } from 'lib/products-values';
 import Gridicon from 'components/gridicon';
 
-var PopoverCart = React.createClass( {
+const PopoverCart = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
@@ -62,7 +63,7 @@ var PopoverCart = React.createClass( {
 					<button className="cart-toggle-button"
 							ref="toggleButton"
 							onClick={ this.onToggle }>
-						<div className="popover-cart__label">{ this.translate( 'Cart' ) }</div>
+						<div className="popover-cart__label">{ this.props.translate( 'Cart' ) }</div>
 						<Gridicon icon='cart' size={ 24 } />
 						{ countBadge }
 					</button>
@@ -152,4 +153,4 @@ var PopoverCart = React.createClass( {
 	}
 } );
 
-module.exports = PopoverCart;
+export default localize( PopoverCart );

--- a/client/my-sites/upgrades/cart/secondary-cart.jsx
+++ b/client/my-sites/upgrades/cart/secondary-cart.jsx
@@ -1,24 +1,25 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var CartBody = require( 'my-sites/upgrades/cart/cart-body' ),
-	CartMessagesMixin = require( './cart-messages-mixin' ),
-	CartSummaryBar = require( 'my-sites/upgrades/cart/cart-summary-bar' ),
-	CartPlanAd = require( './cart-plan-ad' ),
-	CartPlanDiscountAd = require( './cart-plan-discount-ad' ),
-	Sidebar = require( 'layout/sidebar' ),
-	observe = require( 'lib/mixins/data-observe' );
+import CartBody from 'my-sites/upgrades/cart/cart-body';
+import CartMessagesMixin from './cart-messages-mixin';
+import CartSummaryBar from 'my-sites/upgrades/cart/cart-summary-bar';
+import CartPlanAd from './cart-plan-ad';
+import CartPlanDiscountAd from './cart-plan-discount-ad';
+import Sidebar from 'layout/sidebar';
+import observe from 'lib/mixins/data-observe';
 import CartBodyLoadingPlaceholder from 'my-sites/upgrades/cart/cart-body/loading-placeholder';
 
-var SecondaryCart = React.createClass( {
+const SecondaryCart = React.createClass( {
 	mixins: [ CartMessagesMixin, observe( 'sites' ) ],
 
-	render: function() {
+	render() {
 		const { cart, selectedSite } = this.props;
 
 		if ( ! cart.hasLoadedFromServer ) {
@@ -48,4 +49,4 @@ var SecondaryCart = React.createClass( {
 	}
 } );
 
-module.exports = SecondaryCart;
+export default localize( SecondaryCart );


### PR DESCRIPTION
This PR makes the error notice showing cart error messages persistent. Otherwise, the error just flashes on the screen - it is dismissed automatically because the user is navigated away from the view.
Adding the `persistent` option prevents that from happening and lets the user read the notice at their leisure.

### Testing
The easiest way for me to trigger this type of cart error was to try to purchase G Suite for a domain that already has a subscription with another provider (Google or others).
You can also hack the backend to return an error (including the G Suite one).

Upon adding G Suite account to such domain, you should be redirected to `/plans` and presented an error notice:
<img width="1116" alt="screen shot 2016-11-16 at 23 07 28" src="https://cloud.githubusercontent.com/assets/3392497/20367842/89305966-ac51-11e6-8734-c869f3d0c216.png">

The notice should be persistent - only explicitly dismissing it should close it. Before the PR the notice would flash for a second just before the user was redirected to `/plans`.

/cc @Lochlaer for testing 😊 