### PR TITLE
Reader: Make post title smaller in smallest breakpoint

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -324,11 +324,15 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader-post-card__title-link:visited {
 	color: $gray-dark;
 	cursor: pointer;
-	font-size: 21px;
+	font-size: 18px;
 	font-weight: 700;
 
 	&:hover {
 		color: $gray-dark;
+	}
+
+	@include breakpoint( ">480px" ) {
+		font-size: 21px;
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/9438

**Before:**
![screenshot 2016-11-16 14 45 55](https://cloud.githubusercontent.com/assets/4924246/20369032/b02fd01e-ac0b-11e6-9c6f-bd0681a50abc.png)

**After:**
![screenshot 2016-11-16 14 45 55](https://cloud.githubusercontent.com/assets/4924246/20369035/b457df92-ac0b-11e6-96ab-8ba12a36e50a.png)
