### PR TITLE
Reader Stream Refresh: Correct gallery card image border

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -464,7 +464,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // Gallery cards
 .reader-post-card__gallery {
-	border: 1px solid lighten( $gray, 30% );
 	display: flex;
 	margin: 0 0 17px;
 	padding: 0;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -479,19 +479,19 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__gallery-item {
+	border: 1px solid lighten( $gray, 30% );
 	cursor: pointer;
 	flex: 1;
 	list-style-type: none;
-	border-right: 2px solid $white;
+	margin-right: 1px;
 
 	&:last-child {
-		border-right: 0;
+		margin-right: 0;
 	}
 
 	&:last-child {
 
 		@media #{$reader-post-card-breakpoint-medium} {
-			border-right: 0;
 			display: none;
 		}
 	}
@@ -500,20 +500,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		@include breakpoint( "<480px" ) {
 			display: none;
-		}
-	}
-
-	&:nth-child(3) {
-
-		@media #{$reader-post-card-breakpoint-medium} {
-			border-right: 0;
-		}
-	}
-
-	&:nth-child(2) {
-
-		@include breakpoint( "<480px" ) {
-			border-right: 0;
 		}
 	}
 }


### PR DESCRIPTION
As mentioned in: https://github.com/Automattic/wp-calypso/pull/9439#issuecomment-261098947, the gallery card photos actually need to have a 1px border around them plus a 1px gap in between each image.

**Before:**
![screenshot 2016-11-16 15 18 08](https://cloud.githubusercontent.com/assets/4924246/20369825/19c1f79c-ac10-11e6-807f-aceb25ab25be.png)

**After:**
![screenshot 2016-11-16 15 18 49](https://cloud.githubusercontent.com/assets/4924246/20369826/1d9b6f9c-ac10-11e6-867c-43e6f3f31819.png)

