### PR TITLE
Themes: split single-site JSX in DotCom and Jetpack JSXs

### DIFF
--- a/client/my-sites/themes/jetpack-referrer-message.jsx
+++ b/client/my-sites/themes/jetpack-referrer-message.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import CurrentTheme from 'my-sites/themes/current-theme';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import EmptyContent from 'components/empty-content';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+
+export default localize(
+	( { site, translate, analyticsPath, analyticsPageTitle } ) => (
+		<Main className="themes">
+			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
+			<SidebarNavigation />
+			<CurrentTheme siteId={ site.ID } />
+			<EmptyContent title={ translate( 'Changing Themes?' ) }
+				line={ translate( 'Use your site theme browser to manage themes.' ) }
+				action={ translate( 'Open Site Theme Browser' ) }
+				actionURL={ site.options.admin_url + 'themes.php' }
+				actionTarget="_blank"
+				illustration="/calypso/images/drake/drake-jetpack.svg" />
+		</Main>
+	)
+);

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CurrentTheme from 'my-sites/themes/current-theme';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import ThanksModal from 'my-sites/themes/thanks-modal';
+import config from 'config';
+import JetpackReferrerMessage from './jetpack-referrer-message';
+import JetpackUpgradeMessage from './jetpack-upgrade-message';
+import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
+import { connectOptions } from './theme-options';
+import sitesFactory from 'lib/sites-list';
+import QuerySitePurchases from 'components/data/query-site-purchases';
+import ThemeShowcase from './theme-showcase';
+
+export default connectOptions(
+	( props ) => {
+		const { siteId, analyticsPath, analyticsPageTitle } = props;
+		const sites = sitesFactory();
+		const site = sites.getSelectedSite();
+		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
+
+		if ( ! jetpackEnabled ) {
+			return (
+				<JetpackReferrerMessage
+					site={ site }
+					analyticsPath={ analyticsPath }
+					analyticsPageTitle={ analyticsPageTitle } />
+			);
+		}
+		if ( ! site.hasJetpackThemes ) {
+			return (
+				<JetpackUpgradeMessage
+					site={ site } />
+			);
+		}
+		if ( ! site.canManage() ) {
+			return (
+				<JetpackManageDisabledMessage
+					site={ site } />
+			);
+		}
+
+		return (
+			<ThemeShowcase { ...props } siteId={ siteId }>
+				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+				<SidebarNavigation />
+				<ThanksModal
+					site={ site }
+					source={ 'list' } />
+				<CurrentTheme siteId={ siteId } />
+			</ThemeShowcase>
+		);
+	}
+);

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -14,15 +14,12 @@ import JetpackReferrerMessage from './jetpack-referrer-message';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import { connectOptions } from './theme-options';
-import sitesFactory from 'lib/sites-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 
 export default connectOptions(
 	( props ) => {
-		const { siteId, analyticsPath, analyticsPageTitle } = props;
-		const sites = sitesFactory();
-		const site = sites.getSelectedSite();
+		const { site, siteId, analyticsPath, analyticsPageTitle } = props;
 		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
 		if ( ! jetpackEnabled ) {

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -10,7 +10,6 @@ import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import { connectOptions } from './theme-options';
-import sitesFactory from 'lib/sites-list';
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import QuerySitePurchases from 'components/data/query-site-purchases';
@@ -18,9 +17,7 @@ import ThemeShowcase from './theme-showcase';
 
 export default connectOptions(
 	( props ) => {
-		const { siteId, translate } = props;
-		const sites = sitesFactory();
-		const site = sites.getSelectedSite();
+		const { site, siteId, translate } = props;
 
 		return (
 			<ThemeShowcase { ...props } siteId={ siteId }>

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CurrentTheme from 'my-sites/themes/current-theme';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import ThanksModal from 'my-sites/themes/thanks-modal';
+import { connectOptions } from './theme-options';
+import sitesFactory from 'lib/sites-list';
+import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
+import QuerySitePurchases from 'components/data/query-site-purchases';
+import ThemeShowcase from './theme-showcase';
+
+export default connectOptions(
+	( props ) => {
+		const { siteId, translate } = props;
+		const sites = sitesFactory();
+		const site = sites.getSelectedSite();
+
+		return (
+			<ThemeShowcase { ...props } siteId={ siteId }>
+				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+				<SidebarNavigation />
+				<ThanksModal
+					site={ site }
+					source={ 'list' } />
+				<CurrentTheme siteId={ siteId } />
+				<UpgradeNudge
+					title={ translate( 'Get Custom Design with Premium' ) }
+					message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }
+					feature={ FEATURE_ADVANCED_DESIGN }
+					event="themes_custom_design"
+					/>
+			</ThemeShowcase>
+		);
+	}
+ );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -18,7 +18,7 @@ import { isActiveTheme } from 'state/themes/current-theme/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
 
 const SingleSiteThemeShowcaseWithOptions = ( props ) => {
-	const { analyticsPath, analyticsPageTitle, isJetpack } = props;
+	const { isJetpack } = props;
 	const sites = sitesFactory();
 	const site = sites.getSelectedSite();
 
@@ -47,8 +47,6 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 				defaultOption="activate"
 				secondaryOption="tryandcustomize"
 				source="showcase"
-				analyticsPath={ analyticsPath }
-				analyticsPageTitle={ analyticsPageTitle }
 			/>
 		);
 	}

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -9,74 +9,18 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Main from 'components/main';
-import CurrentTheme from 'my-sites/themes/current-theme';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
-import ThanksModal from 'my-sites/themes/thanks-modal';
-import config from 'config';
-import EmptyContent from 'components/empty-content';
-import JetpackUpgradeMessage from './jetpack-upgrade-message';
-import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
-import { connectOptions } from './theme-options';
+import SingleSiteThemeShowcase from './single-site-wpcom';
+import SingleSiteThemeShowcaseJetpack from './single-site-jetpack';
 import sitesFactory from 'lib/sites-list';
-import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { isActiveTheme } from 'state/themes/current-theme/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QuerySitePurchases from 'components/data/query-site-purchases';
-import ThemeShowcase from './theme-showcase';
-
-const sites = sitesFactory();
-
-const JetpackThemeReferrerPage = localize(
-	( { translate, site, analyticsPath, analyticsPageTitle } ) => (
-		<Main className="themes">
-			<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
-			<SidebarNavigation />
-			<CurrentTheme site={ site } />
-			<EmptyContent title={ translate( 'Changing Themes?' ) }
-				line={ translate( 'Use your site theme browser to manage themes.' ) }
-				action={ translate( 'Open Site Theme Browser' ) }
-				actionURL={ site.options.admin_url + 'themes.php' }
-				actionTarget="_blank"
-				illustration="/calypso/images/drake/drake-jetpack.svg" />
-		</Main>
-	)
-);
-
-const SingleSiteThemeShowcase = connectOptions(
-	localize(
-		( props ) => {
-			const { siteId } = props;
-			const site = sites.getSelectedSite(),
-				{ translate } = props;
-
-			return (
-				<ThemeShowcase { ...props } siteId={ siteId }>
-					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-					<SidebarNavigation />
-					<ThanksModal
-						site={ site }
-						source={ 'list' } />
-					<CurrentTheme siteId={ siteId } />
-					<UpgradeNudge
-						title={ translate( 'Get Custom Design with Premium' ) }
-						message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }
-						feature={ FEATURE_ADVANCED_DESIGN }
-						event="themes_custom_design"
-					/>
-				</ThemeShowcase>
-			);
-		}
-	)
-);
 
 const SingleSiteThemeShowcaseWithOptions = ( props ) => {
-	const site = sites.getSelectedSite(),
-		{ analyticsPath, analyticsPageTitle, isJetpack } = props,
-		jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
+	const { analyticsPath, analyticsPageTitle, isJetpack } = props;
+	const sites = sitesFactory();
+	const site = sites.getSelectedSite();
 
 	// If we've only just switched from single to multi-site, there's a chance
 	// this component is still being rendered with site unset, so we need to guard
@@ -86,19 +30,27 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 	}
 
 	if ( isJetpack ) {
-		if ( ! jetpackEnabled ) {
-			return (
-				<JetpackThemeReferrerPage site={ site }
-					analyticsPath={ analyticsPath }
-					analyticsPageTitle={ analyticsPageTitle } />
-			);
-		}
-		if ( ! site.hasJetpackThemes ) {
-			return <JetpackUpgradeMessage site={ site } />;
-		}
-		if ( ! site.canManage() ) {
-			return <JetpackManageDisabledMessage site={ site } />;
-		}
+		return (
+			<SingleSiteThemeShowcaseJetpack { ...props }
+				siteId={ site.ID }
+				options={ [
+					'customize',
+					'preview',
+					'purchase',
+					'activate',
+					'tryandcustomize',
+					'separator',
+					'info',
+					'support',
+					'help'
+				] }
+				defaultOption="activate"
+				secondaryOption="tryandcustomize"
+				source="showcase"
+				analyticsPath={ analyticsPath }
+				analyticsPageTitle={ analyticsPageTitle }
+			/>
+		);
 	}
 
 	return (
@@ -131,4 +83,4 @@ export default connect(
 			getScreenshotOption: ( theme ) => ( selectedSite && isActiveTheme( state, theme.id, selectedSite.ID ) ) ? 'customize' : 'info'
 		};
 	}
-)( SingleSiteThemeShowcaseWithOptions );
+)( localize( SingleSiteThemeShowcaseWithOptions ) );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -32,6 +32,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 	if ( isJetpack ) {
 		return (
 			<SingleSiteThemeShowcaseJetpack { ...props }
+				site={ site }
 				siteId={ site.ID }
 				options={ [
 					'customize',
@@ -53,6 +54,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 
 	return (
 		<SingleSiteThemeShowcase { ...props }
+			site={ site }
 			siteId={ site.ID }
 			options={ [
 				'customize',

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Main from 'components/main';
-import SingleSiteThemeShowcase from './single-site-wpcom';
+import SingleSiteThemeShowcaseWpcom from './single-site-wpcom';
 import SingleSiteThemeShowcaseJetpack from './single-site-jetpack';
 import sitesFactory from 'lib/sites-list';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -53,7 +53,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 	}
 
 	return (
-		<SingleSiteThemeShowcase { ...props }
+		<SingleSiteThemeShowcaseWpcom { ...props }
 			site={ site }
 			siteId={ site.ID }
 			options={ [


### PR DESCRIPTION
Architectural change: from a single `single-site.jsx` that handled rendering both single-site view for WordPress·com sites and single-site view for Jetpack sites, to two files with clear functional separation.

In detail:

* No visual changes. 
* No functional changes.
* `single-site.jsx` now only retains the splitting logic (`isJetpack`)
* `single-site-wpcom.jsx` is exclusively for .com sites.
* `single-site-jetpack.jsx` is exclusively for Jetpack sites (and handles error messages too).
* `jetpack-referrer-message.jsx` split out an existing message, similarly to the other two.

More cleanup is probably due, but this is a first PR that exclusively addresses the splitting.

### To test

* Open My Sites → Themes
* Try a .com site, and make sure everything works from that page (search, info, customize, activate, ...)
* Try a Jetpack site, and make sure everything works from that page (search, info, customize, activate, ...)
* Try a Jetpack site with Jetpack before 3.7
* Try a Jetpack site with Jetpack Manage disabled