### PR TITLE
Enable Taxonomy Management in Horizon and wpcalypso.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -59,6 +59,7 @@
 		"manage/seo": true,
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
+		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
 		"manage/themes": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -70,6 +70,7 @@
 		"manage/seo": true,
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
+		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,


### PR DESCRIPTION
The taxonomy manager is getting to a point where it might be nice to solicit feedback via User Testing, or just broader testing within Automattic.  This PR just enables the feature in wpcalypso and horizon environments.

/cc @youknowriad 

__To Test__
You can see the taxonomy manager by visiting Site Settings > Writing.  At the top of the page you will see two links for Categories and Tags.