### PR TITLE
Reader Refresh: ManageV1 - increase the thickness of searchbox to 2px

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -45,7 +45,7 @@
 }
 
 .is-reader-page .search-card.card {
-	box-shadow: 0 0 0 2px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+	box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
 }
 
 // The header on top of the "Existing Feed"

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -44,6 +44,10 @@
 	float: right;
 }
 
+.is-reader-page .search-card.card {
+	box-shadow: 0 0 0 2px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+}
+
 // The header on top of the "Existing Feed"
 .section-header.following-edit__header {
 	height: 51px;

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -1,5 +1,4 @@
 .following-edit {
-
 	ul {
 		list-style-type: none;
 		margin: 0;
@@ -146,9 +145,10 @@
 
 	.card.is-search-result {
 		position: absolute;
-			top: 70px;
+			top: 71px;
 		width: 100%;
 		z-index: z-index( '.following-edit', '.following-edit__subscribe-form .card.is-search-result' );
+		box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
 
 		&.is-compact {
 			padding: 16px 24px;

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -128,6 +128,10 @@
 	}
 }
 
+.is-reader-page .following-edit__subscribe-form .card.is-search-result {
+	top: 71px;
+	box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
+}
 
 // Add to Following
 .following-edit__subscribe-form {
@@ -145,10 +149,9 @@
 
 	.card.is-search-result {
 		position: absolute;
-			top: 71px;
+			top: 70px;
 		width: 100%;
 		z-index: z-index( '.following-edit', '.following-edit__subscribe-form .card.is-search-result' );
-		box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
 
 		&.is-compact {
 			padding: 16px 24px;


### PR DESCRIPTION
This PR aims to finish implementing the changes to the Manage Following page described in #9143.

Specifically, this increases the thickness of the search box to 2px (from 1px).

Screenshot of how it should look:
![default](https://cloud.githubusercontent.com/assets/24388/20400609/454881de-acaa-11e6-8bf3-da66b787508f.png)

Fixes #9143.