### PR TITLE
Discover: open the site stream when site picks are clicked

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -21,7 +21,6 @@ import FollowButton from 'reader/follow-button';
 import PostGallery from './gallery';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
-import { isDiscoverSitePick } from 'reader/discover/helper';
 
 export default class RefreshPostCard extends React.Component {
 	static propTypes = {
@@ -42,17 +41,10 @@ export default class RefreshPostCard extends React.Component {
 	};
 
 	propagateCardClick = () => {
-		let customClickUrl;
-
-		// If it's a Discover site pick, open the site stream rather than a full post
-		if ( isDiscoverSitePick( this.props.post ) ) {
-			customClickUrl = `/read/blogs/${ +this.props.post.blog_ID }`;
-		}
-
 		// If we have an original post available (e.g. for a Discover pick), send the original post
 		// to the full post view
 		const postToOpen = this.props.originalPost ? this.props.originalPost : this.props.post;
-		this.props.onClick( postToOpen, customClickUrl );
+		this.props.onClick( postToOpen );
 	}
 
 	handleCardClick = ( event ) => {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -21,6 +21,7 @@ import FollowButton from 'reader/follow-button';
 import PostGallery from './gallery';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
+import { isDiscoverSitePick } from 'reader/discover/helper';
 
 export default class RefreshPostCard extends React.Component {
 	static propTypes = {
@@ -41,10 +42,17 @@ export default class RefreshPostCard extends React.Component {
 	};
 
 	propagateCardClick = () => {
+		let customClickUrl;
+
+		// If it's a Discover site pick, open the site stream rather than a full post
+		if ( isDiscoverSitePick( this.props.post ) ) {
+			customClickUrl = `/read/blogs/${ +this.props.post.blog_ID }`;
+		}
+
 		// If we have an original post available (e.g. for a Discover pick), send the original post
 		// to the full post view
 		const postToOpen = this.props.originalPost ? this.props.originalPost : this.props.post;
-		this.props.onClick( postToOpen );
+		this.props.onClick( postToOpen, customClickUrl );
 	}
 
 	handleCardClick = ( event ) => {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -34,6 +34,7 @@ import PostBlocked from './post-blocked';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import scrollTo from 'lib/scroll-to';
 import XPostHelper from 'reader/xpost-helper';
+import { isDiscoverSitePick } from 'reader/discover/helper';
 
 const GUESSED_POST_HEIGHT = 600;
 const HEADER_OFFSET_TOP = 46;
@@ -77,7 +78,7 @@ module.exports = React.createClass( {
 		showMobileBackToSidebar: React.PropTypes.bool
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			showPostHeader: true,
 			suppressSiteNameLink: false,
@@ -90,11 +91,11 @@ module.exports = React.createClass( {
 		};
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return this.getStateFromStores();
 	},
 
-	getStateFromStores: function( store ) {
+	getStateFromStores( store ) {
 		store = store || this.props.store;
 		return {
 			posts: store.get(),
@@ -103,11 +104,11 @@ module.exports = React.createClass( {
 		};
 	},
 
-	updateState: function( store ) {
+	updateState( store ) {
 		this.setState( this.getStateFromStores( store ) );
 	},
 
-	componentDidUpdate: function( prevProps, prevState ) {
+	componentDidUpdate( prevProps, prevState ) {
 		if ( prevState.selectedIndex !== this.state.selectedIndex ) {
 			this.scrollToSelectedPost( true );
 			if ( this.isPostFullScreen() ) {
@@ -116,7 +117,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	_popstate: function() {
+	_popstate() {
 		if ( this.state.selectedIndex > -1 && history.scrollRestoration !== 'manual' ) {
 			this.scrollToSelectedPost( false );
 		}
@@ -132,7 +133,7 @@ module.exports = React.createClass( {
 		return defaultCardFactory( post );
 	},
 
-	scrollToSelectedPost: function( animate ) {
+	scrollToSelectedPost( animate ) {
 		let HEADER_OFFSET = -80, // a fixed position header means we can't just scroll the element into view.
 			selectedNode,
 			boundingClientRect,
@@ -159,7 +160,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	componentDidMount: function() {
+	componentDidMount() {
 		this.props.store.on( 'change', this.updateState );
 		PostStore.on( 'change', this.updateState ); // should move this dep down into the individual items
 
@@ -174,7 +175,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		this.props.store.off( 'change', this.updateState );
 		PostStore.off( 'change', this.updateState );
 
@@ -189,7 +190,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.store !== this.props.store ) {
 			this.props.store.off( 'change', this.updateState );
 			nextProps.store.on( 'change', this.updateState );
@@ -198,7 +199,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	showSelectedPost: function( options ) {
+	showSelectedPost( options ) {
 		let postKey = this.props.store.getSelectedPost(),
 			mappedPost;
 		if ( !! postKey ) {
@@ -227,7 +228,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	toggleLikeOnSelectedPost: function() {
+	toggleLikeOnSelectedPost() {
 		const postKey = this.props.store.getSelectedPost();
 		let post;
 
@@ -250,7 +251,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	toggleLikeAction: function( siteId, postId ) {
+	toggleLikeAction( siteId, postId ) {
 		const liked = LikeStore.isPostLikedByCurrentUser( siteId, postId );
 		if ( liked === null ) {
 			// unknown... ignore for now
@@ -259,11 +260,11 @@ module.exports = React.createClass( {
 		LikeStoreActions[ liked ? 'unlikePost' : 'likePost' ]( siteId, postId );
 	},
 
-	isPostFullScreen: function() {
+	isPostFullScreen() {
 		return !! window.location.pathname.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i );
 	},
 
-	goToTop: function() {
+	goToTop() {
 		if ( this.state.updateCount && this.state.updateCount > 0 ) {
 			this.showUpdates();
 		} else {
@@ -271,11 +272,11 @@ module.exports = React.createClass( {
 		}
 	},
 
-	getVisibleItemIndexes: function() {
+	getVisibleItemIndexes() {
 		return this._list && this._list.getVisibleItemIndexes( { offsetTop: HEADER_OFFSET_TOP } );
 	},
 
-	selectNextItem: function() {
+	selectNextItem() {
 		let visibleIndexes = this.getVisibleItemIndexes(),
 			visibleIndex,
 			index,
@@ -297,7 +298,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	selectPrevItem: function() {
+	selectPrevItem() {
 		let visibleIndexes = this.getVisibleItemIndexes(),
 			visibleIndex,
 			index,
@@ -319,7 +320,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	fetchNextPage: function( options ) {
+	fetchNextPage( options ) {
 		if ( this.props.store.isLastPage() || this.props.store.isFetchingNextPage() ) {
 			return;
 		}
@@ -329,7 +330,7 @@ module.exports = React.createClass( {
 		FeedStreamStoreActions.fetchNextPage( this.props.store.id );
 	},
 
-	showUpdates: function() {
+	showUpdates() {
 		this.props.onUpdatesShown();
 		FeedStreamStoreActions.showUpdates( this.props.store.id );
 		if ( this._list ) {
@@ -337,7 +338,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	renderLoadingPlaceholders: function() {
+	renderLoadingPlaceholders() {
 		let count = this.state.posts.length ? 2 : this.props.store.getPerPage(),
 			placeholders = [];
 
@@ -348,11 +349,11 @@ module.exports = React.createClass( {
 		return placeholders;
 	},
 
-	getPostRef: function( postKey ) {
+	getPostRef( postKey ) {
 		return 'feed-post-' + ( postKey.feedId || postKey.blogId ) + '-' + postKey.postId;
 	},
 
-	showFullXPost: function( xMetadata ) {
+	showFullXPost( xMetadata ) {
 		if ( xMetadata.blogId && xMetadata.postId ) {
 			const mappedPost = {
 				site_ID: xMetadata.blogId,
@@ -364,7 +365,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	showFullPost: function( post, options ) {
+	showFullPost( post, options ) {
 		options = options || {};
 		let hashtag = '';
 		if ( options.comments ) {
@@ -378,7 +379,11 @@ module.exports = React.createClass( {
 		}
 	},
 
-	renderPost: function( postKey, index ) {
+	showSiteStream( post ) {
+		page.show( '/read/blogs/' + post.site_ID );
+	},
+
+	renderPost( postKey, index ) {
 		let post,
 			postState,
 			itemKey,
@@ -440,7 +445,7 @@ module.exports = React.createClass( {
 						suppressSiteNameLink: this.props.suppressSiteNameLink,
 						showPostHeader: this.props.showPostHeader,
 						showFollowInHeader: this.props.showFollowInHeader,
-						handleClick: this.showFullPost,
+						handleClick: isDiscoverSitePick( post ) ? this.showSiteStream : this.showFullPost,
 						showPrimaryFollowButtonOnCards: this.props.showPrimaryFollowButtonOnCards
 					} );
 				}
@@ -449,7 +454,7 @@ module.exports = React.createClass( {
 		return content;
 	},
 
-	render: function() {
+	render() {
 		let store = this.props.store,
 			hasNoPosts = store.isLastPage() && ( ( ! this.state.posts ) || this.state.posts.length === 0 ),
 			body, showingStream;


### PR DESCRIPTION
For Discover site picks, open the site stream (e.g. /read/blogs/xxx) when the stream card is clicked rather than showing the full post.

Part of #9096.
