### PR TITLE
Signup: Redirect non-wordpress.com sites to HTTP, because they may not be HTTPS ready.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -27,7 +27,18 @@ function getSiteDestination( dependencies ) {
 		return getCheckoutUrl( dependencies );
 	}
 
-	return 'https://' + dependencies.siteSlug;
+	let protocol = 'https';
+
+	/**
+	 * It is possible that non-wordpress.com sites are not HTTPS ready.
+	 *
+	 * Redirect them
+	 */
+	if ( ! dependencies.siteSlug.match(/wordpress\.[a-z]+$/i) ) {
+		protocol = 'http';
+	}
+
+	return protocol + '://' + dependencies.siteSlug;
 }
 
 function getPostsDestination( dependencies ) {


### PR DESCRIPTION
This PR makes sure that when a user creates a new non-wordpress.com site, they will be redirected properly to their new site, without throwing an error about the HTTPS certificate. 

To test:

1. Checkout branch or use Calypso.live link.
2. Start signup.
3. Reach domains step.
4. Choose a non-wordpress.com option. If you are not sure about what to choose, ping me.
5. Finish signup.
6. Verify that you are redirected properly to your site at the end of signup, without a certificate warning.

cc @michaeldcain @coreh @meremagee 