### PR TITLE
Chat: Add closure notice for Thanksgiving

### DIFF
--- a/client/me/help/help-contact-closure-notice/index.jsx
+++ b/client/me/help/help-contact-closure-notice/index.jsx
@@ -24,9 +24,12 @@ const Closed = localize( ( { translate } ) =>
 			{ translate(
 				'Live chat is closed today for the US Thanksgiving holiday. To get in touch, please ' +
 				'submit a support request below and we will get to it as fast as we can. Live chat ' +
-				'will reopen on %(closed_end_date)s. Thank you!', {
+				'will reopen on {{strong}}%(closed_end_date)s{{/strong}}. Thank you!', {
 					args: {
 						closed_end_date: closedTo.format( 'dddd, MMMM Do, YYYY HH:mm' ),
+					},
+					components: {
+						strong: <strong />
 					}
 				}
 			) }
@@ -39,12 +42,16 @@ const Upcoming = localize( ( { translate } ) =>
 		<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
 		<p>
 			{ translate(
-				'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s ' +
-				'for the US Thanksgiving holiday. If you need to get in touch with us that day, you’ll be able to submit a support ' +
-				'request from this page and we will get to it as fast as we can. Thank you!', {
+				'Live chat support will be closed from ' +
+				'{{strong}}%(closed_start_date)s{{/strong}} through {{strong}}%(closed_end_date)s{{/strong}} ' +
+				'for the US Thanksgiving holiday. If you need to get in touch with us that day, you’ll be able ' +
+				'to submit a support request from this page and we will get to it as fast as we can. Thank you!', {
 					args: {
 						closed_start_date: closedFrom.format( 'dddd, MMMM Do, YYYY HH:mm' ),
 						closed_end_date: closedTo.format( 'dddd, MMMM Do, YYYY HH:mm' ),
+					},
+					components: {
+						strong: <strong />
 					}
 				}
 			) }

--- a/client/me/help/help-contact-closure-notice/index.jsx
+++ b/client/me/help/help-contact-closure-notice/index.jsx
@@ -5,7 +5,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import i18n, { localize } from 'i18n-calypso';
 
 /**
@@ -16,24 +16,53 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 const closedFrom = i18n.moment( 'Thu, 24 Nov 2016 08:00:00 +0000' );
 const closedTo = i18n.moment( 'Fri, 25 Nov 2016 08:00:00 +0000' );
 
-export default localize( ( props ) => {
-	const {	translate } = props;
-
-	return (
-		<div className="help-contact-closure-notice">
-			<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
-			<p>
-				{ translate(
-					'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s ' +
-					'for the US Thanksgiving holiday. If you need to get in touch with us that day, you’ll be able to submit a support ' +
-					'request from this page and we will get to it as fast as we can. Thank you!', {
-						args: {
-							closed_start_date: closedFrom.format( 'dddd, MMMM Do, YYYY HH:mm' ),
-							closed_end_date: closedTo.format( 'dddd, MMMM Do, YYYY HH:mm' ),
-						}
+const Closed = localize( ( { translate } ) =>
+	<div className="help-contact-closure-notice">
+		<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
+		<p>
+			{ translate(
+				'Live chat is closed today for the US Thanksgiving holiday. To get in touch, please ' +
+				'submit a support request below and we will get to it as fast as we can. Live chat ' +
+				'will reopen on %(closed_end_date)s. Thank you!', {
+					args: {
+						closed_end_date: closedTo.format( 'dddd, MMMM Do, YYYY HH:mm' ),
 					}
-				) }
-			</p>
-		</div>
-	);
-} );
+				}
+			) }
+		</p>
+	</div>
+);
+
+const Upcoming = localize( ( { translate } ) =>
+	<div className="help-contact-closure-notice">
+		<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
+		<p>
+			{ translate(
+				'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s ' +
+				'for the US Thanksgiving holiday. If you need to get in touch with us that day, you’ll be able to submit a support ' +
+				'request from this page and we will get to it as fast as we can. Thank you!', {
+					args: {
+						closed_start_date: closedFrom.format( 'dddd, MMMM Do, YYYY HH:mm' ),
+						closed_end_date: closedTo.format( 'dddd, MMMM Do, YYYY HH:mm' ),
+					}
+				}
+			) }
+		</p>
+	</div>
+);
+
+export default class HelpContactClosureNotice extends Component {
+	render() {
+		// Closure period is over, don't show any notice
+		if ( i18n.moment().isAfter( closedTo ) ) {
+			return null;
+		}
+
+		// Closure period is upcoming
+		if ( i18n.moment().isBefore( closedFrom ) ) {
+			return <Upcoming />;
+		}
+
+		return <Closed />;
+	}
+}

--- a/client/me/help/help-contact-closure-notice/index.jsx
+++ b/client/me/help/help-contact-closure-notice/index.jsx
@@ -12,6 +12,7 @@ import i18n, { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FormSectionHeading from 'components/forms/form-section-heading';
+import olarkStore from 'lib/olark-store';
 
 const closedFrom = i18n.moment( 'Thu, 24 Nov 2016 08:00:00 +0000' );
 const closedTo = i18n.moment( 'Fri, 25 Nov 2016 08:00:00 +0000' );
@@ -52,7 +53,30 @@ const Upcoming = localize( ( { translate } ) =>
 );
 
 export default class HelpContactClosureNotice extends Component {
+	constructor() {
+		super();
+		this.state = { olark: olarkStore.get() };
+	}
+
+	componentDidMount() {
+		this.updateOlarkState();
+		olarkStore.on( 'change', this.updateOlarkState );
+	}
+
+	componentWillUnmount() {
+		olarkStore.removeListener( 'change', this.updateOlarkState );
+	}
+
+	updateOlarkState = () => {
+		this.setState( { olark: olarkStore.get() } );
+	}
+
 	render() {
+		// Don't show notice if user isn't eligible for chat
+		if ( ! this.state.olark.isUserEligible ) {
+			return null;
+		}
+
 		// Closure period is over, don't show any notice
 		if ( i18n.moment().isAfter( closedTo ) ) {
 			return null;

--- a/client/me/help/help-contact-closure-notice/index.jsx
+++ b/client/me/help/help-contact-closure-notice/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * Fixed notice about upcoming support closures
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import i18n, { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormSectionHeading from 'components/forms/form-section-heading';
+
+const closedFrom = i18n.moment( 'Thu, 24 Nov 2016 08:00:00 +0000' );
+const closedTo = i18n.moment( 'Fri, 25 Nov 2016 08:00:00 +0000' );
+
+export default localize( ( props ) => {
+	const {	translate } = props;
+
+	return (
+		<div className="help-contact-closure-notice">
+			<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
+			<p>
+				{ translate(
+					'Live chat support will be closed from %(closed_start_date)s through %(closed_end_date)s ' +
+					'for the US Thanksgiving holiday. If you need to get in touch with us that day, you’ll be able to submit a support ' +
+					'request from this page and we will get to it as fast as we can. Thank you!', {
+						args: {
+							closed_start_date: closedFrom.format( 'dddd, MMMM Do, YYYY HH:mm' ),
+							closed_end_date: closedTo.format( 'dddd, MMMM Do, YYYY HH:mm' ),
+						}
+					}
+				) }
+			</p>
+		</div>
+	);
+} );

--- a/client/me/help/help-contact-closure-notice/style.scss
+++ b/client/me/help/help-contact-closure-notice/style.scss
@@ -1,0 +1,4 @@
+.help-contact-closure-notice {
+	color: $gray-dark;
+	font-size: 14px;
+}

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -22,6 +22,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
 import siteList from 'lib/sites-list';
+import HelpContactClosureNotice from '../help-contact-closure-notice';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 /**
@@ -220,6 +221,7 @@ export const HelpContactForm = React.createClass( {
 
 		return (
 			<div className="help-contact-form">
+				<HelpContactClosureNotice />
 				{ formDescription && ( <p>{ formDescription }</p> ) }
 
 				{ showHowCanWeHelpField && (


### PR DESCRIPTION
See: p2UL9c-33A-p2

Adds a notice at the top of /help/contact informing chat-eligible users of the upcoming closure for the US Thanksgiving holiday. When the closure begins, the notice is automatically adjusted. When the closure ends, the notice disappears.

### How to test

1. Log in as a plan user who is eligible for live chat support.
1. Head to http://calypso.localhost:3000/help/contact, confirm that the **before closure** notice is displayed.
1. Change your system time to somewhere between the closure period, then reload the page. Confirm that the **during closure** notice is displayed.
1. Change your system time to some time after the closure period, then reload the page. Confirm that no notice is displayed.
1. Reset system time to normal.
1. Log in as a free user who is not eligible for chat. You should not see the notice.

### Before closure:

<img width="645" alt="screen shot 2016-11-18 at 4 14 39 pm" src="https://cloud.githubusercontent.com/assets/416133/20420631/c5bbd6e4-adaa-11e6-922b-504c44dc6d7e.png">

### During closure:

<img width="647" alt="screen shot 2016-11-18 at 4 15 21 pm" src="https://cloud.githubusercontent.com/assets/416133/20420638/cdaf37ec-adaa-11e6-9d6e-c269b859cfd8.png">

### After closure

<img width="652" alt="screen shot 2016-11-18 at 4 22 17 pm" src="https://cloud.githubusercontent.com/assets/416133/20420701/319463cc-adab-11e6-94e3-9e4c4180c199.png">

### Todo

- [x] Upcoming closure notice
- [x] Only show for chat-eligible users
- [x] Show different notice after closure has begun
- [x] Hide notice when we reopen