### PR TITLE
Taxonomies: Add the terms total to the TaxonomyCard component

### DIFF
--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -2,10 +2,21 @@
 	font-size: 16px;
 	line-height: 24px;
 	color: $gray-dark;
+	padding-bottom: 10px;
 
 	&.is-loading {
 		@include placeholder;
 		width: 80px;
 		display: inline-block;
+	}
+}
+
+.taxonomies__card-content {
+	color: $gray;
+	font-size: 13px;
+
+	.gridicon {
+		padding-right: 5px;
+		vertical-align: top;
 	}
 }

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { connect } from 'react-redux';
+import { get, isUndefined } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -11,18 +11,28 @@ import classNames from 'classnames';
  */
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
+import { countFoundTermsForQuery } from 'state/terms/selectors';
 
 import CompactCard from 'components/card/compact';
+import QueryTerms from 'components/data/query-terms';
+import Gridicon from 'components/gridicon';
 
-const TaxonomyCard = ( { labels, site, taxonomy } ) => {
+const TaxonomyCard = ( { count, labels, site, taxonomy } ) => {
 	const settingsLink = site ? `/settings/taxonomies/${ site.slug }/${ taxonomy }` : null;
+	const isLoading = ! labels.name || isUndefined( count );
 	const classes = classNames( 'taxonomies__card-title', {
-		'is-loading': ! labels.name
+		'is-loading': isLoading
 	} );
 
 	return (
 		<CompactCard href={ settingsLink }>
-				<h2 className={ classes }>{ labels.name }</h2>
+			{ site && <QueryTerms siteId={ site.ID } taxonomy={ taxonomy }	query={ {} } /> }
+			<h2 className={ classes }>{ labels.name }</h2>
+			{ ! isLoading &&
+				<div className="taxonomies__card-content">
+					<Gridicon icon="tag" size={ 18 } /> { count } { labels.name }
+				</div>
+			}
 		</CompactCard>
 	);
 };
@@ -32,7 +42,9 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const site = getSelectedSite( state );
 		const labels = get( getPostTypeTaxonomy( state, siteId, postType, taxonomy ), 'labels', {} );
+		const count = countFoundTermsForQuery( state, siteId, taxonomy, {} );
 		return {
+			count,
 			labels,
 			site
 		};

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -166,3 +166,21 @@ export function getTerm( state, siteId, taxonomy, termId ) {
 
 	return term;
 }
+
+/**
+ * Returns the total count of terms for a specified query
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  taxonomy Taxonomy slug
+ * @param  {Object}  query    Terms query object
+ * @return {?Number}          Count terms
+ */
+export function countFoundTermsForQuery( state, siteId, taxonomy, query ) {
+	const manager = get( state.terms.queries, [ siteId, taxonomy ] );
+	if ( ! manager ) {
+		return null;
+	}
+
+	return manager.getFound( query );
+}

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import TermQueryManager from 'lib/query-manager/term';
 import {
+	countFoundTermsForQuery,
 	getTerm,
 	getTerms,
 	getTermsForQuery,
@@ -537,6 +538,49 @@ describe( 'selectors', () => {
 			}, 2916284, 'jetpack-portfolio', 100 );
 
 			expect( term ).to.be.null;
+		} );
+	} );
+
+	describe( 'countFoundTermsForQuery()', () => {
+		it( 'should return null if no matching query results exist', () => {
+			const count = countFoundTermsForQuery( {
+				terms: {
+					queries: {}
+				}
+			}, 2916284, 'category', {} );
+
+			expect( count ).to.be.null;
+		} );
+
+		it( 'should return the found value of the query', () => {
+			const count = countFoundTermsForQuery( {
+				terms: {
+					queries: {
+						2916284: {
+							category: new TermQueryManager( {
+								items: {
+									111: {
+										ID: 111,
+										name: 'Chicken and a biscuit'
+									},
+									112: {
+										ID: 112,
+										name: 'Ribs'
+									}
+								},
+								queries: {
+									'[["search","ribs"]]': {
+										itemKeys: [ 111 ],
+										found: 4
+									}
+								}
+							} )
+						}
+					}
+				}
+			}, 2916284, 'category', { search: 'ribs' } );
+
+			expect( count ).to.eql( 4 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds the taxonomies total count on the TaxonomyCard component as show on the screenshot

<img width="724" alt="capture d ecran 2016-11-17 a 10 06 57 am" src="https://cloud.githubusercontent.com/assets/272444/20382849/d72f4d32-acad-11e6-8793-5fe074c8d7b6.png">

closes #9457

**testing instructions**

 * navigate to the writing settings page `/settings/writing/$site`
 * The count should show up correctly 
 * Test without cache as well

cc @timmyc 