### PR TITLE
Reader: Turn on search for Desktop

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -69,6 +69,7 @@
 		"preview-layout": true,
 		"reader": true,
 		"reader/full-errors": false,
+		"reader/search": true,
 		"resume-editing": true,
 		"republicize": false,
 		"rubberband-scroll-disable": true,


### PR DESCRIPTION
I didn't realize that search was never turned on for the desktop app. This turns it on.

cc @sendhil 