### PR TITLE
New plugins page design on .com

### DIFF
--- a/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import Button from 'components/button';
+import PurchaseButton from './purchase-button';
+
+export const JetpackPluginItem = ( {
+	plugin,
+	siteSlug,
+	isActive,
+	translate = identity
+} ) => {
+	let plan;
+
+	if ( plugin.plan === 'premium' ) {
+		plan = <Button compact borderless className="plugins-wpcom__is-premium-plugin">
+			{ translate( 'Premium' ) }
+		</Button>;
+	} else if ( plugin.plan === 'business' ) {
+		plan = <Button compact borderless className="plugins-wpcom__is-business-plugin">
+			{ translate( 'Business' ) }
+		</Button>;
+	} else {
+		plan = null;
+	}
+
+	return (
+		<CompactCard className="plugins-wpcom__jetpack-plugin-item">
+			<a href={ plugin.descriptionLink } className="plugins-wpcom__plugin-link">
+				<div className="plugins-wpcom__plugin-name">
+					{ plugin.name }
+					{ plan }
+				</div>
+				<div className="plugins-wpcom__plugin-description">
+					{ plugin.description }
+				</div>
+			</a>
+			<div className="plugins-wpcom__plugin-actions">
+				<PurchaseButton { ...{ isActive: isActive, href: `/plans/${ siteSlug }` } } />
+			</div>
+		</CompactCard>
+	);
+};
+
+JetpackPluginItem.propTypes = {
+	plugin: PropTypes.object,
+	siteSlug: PropTypes.string,
+	isActive: PropTypes.bool,
+};
+
+export default localize( JetpackPluginItem );

--- a/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
@@ -4,12 +4,12 @@
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Button from 'components/button';
 import PurchaseButton from './purchase-button';
 
 export const JetpackPluginItem = ( {
@@ -18,19 +18,21 @@ export const JetpackPluginItem = ( {
 	isActive,
 	translate = identity
 } ) => {
-	let plan;
-
-	if ( plugin.plan === 'premium' ) {
-		plan = <Button compact borderless className="plugins-wpcom__is-premium-plugin">
-			{ translate( 'Premium' ) }
-		</Button>;
-	} else if ( plugin.plan === 'business' ) {
-		plan = <Button compact borderless className="plugins-wpcom__is-business-plugin">
-			{ translate( 'Business' ) }
-		</Button>;
-	} else {
-		plan = null;
-	}
+	const translatePlan = {
+		premium: translate( 'Premium' ),
+		business: translate( 'Business' ),
+	};
+	const planClasses = classNames(
+		'button',
+		'is-compact',
+		'is-borderless',
+		`plugins-wpcom__is-${ plugin.plan }-plugin`
+	);
+	const plan = [ 'premium', 'business' ].includes( plugin.plan )
+		? <span className={ planClasses }>
+				{ translatePlan[ plugin.plan ] }
+			</span>
+		: null;
 
 	return (
 		<CompactCard className="plugins-wpcom__jetpack-plugin-item">

--- a/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
@@ -34,7 +34,7 @@ export const JetpackPluginItem = ( {
 
 	return (
 		<CompactCard className="plugins-wpcom__jetpack-plugin-item">
-			<a href={ plugin.descriptionLink } className="plugins-wpcom__plugin-link">
+			<a href={ plugin.link } className="plugins-wpcom__plugin-link">
 				<div className="plugins-wpcom__plugin-name">
 					{ plugin.name }
 					{ plan }

--- a/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
@@ -4,7 +4,6 @@
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -22,31 +21,30 @@ export const JetpackPluginItem = ( {
 		premium: translate( 'Premium' ),
 		business: translate( 'Business' ),
 	};
-	const planClasses = classNames(
+	const planClasses = [
 		'button',
 		'is-compact',
 		'is-borderless',
-		`plugins-wpcom__is-${ plugin.plan }-plugin`
-	);
-	const plan = [ 'premium', 'business' ].includes( plugin.plan )
-		? <span className={ planClasses }>
-				{ translatePlan[ plugin.plan ] }
-			</span>
-		: null;
+		`plugins-wpcom__is-${ plugin.plan }-plugin`,
+	].join( ' ' );
 
 	return (
 		<CompactCard className="plugins-wpcom__jetpack-plugin-item">
 			<a href={ plugin.link } className="plugins-wpcom__plugin-link">
 				<div className="plugins-wpcom__plugin-name">
 					{ plugin.name }
-					{ plan }
+					{ [ 'premium', 'business' ].includes( plugin.plan ) &&
+						<span className={ planClasses }>
+							{ translatePlan[ plugin.plan ] }
+						</span>
+					}
 				</div>
 				<div className="plugins-wpcom__plugin-description">
 					{ plugin.description }
 				</div>
 			</a>
 			<div className="plugins-wpcom__plugin-actions">
-				<PurchaseButton { ...{ isActive: isActive, href: `/plans/${ siteSlug }` } } />
+				<PurchaseButton { ...{ isActive, href: `/plans/${ siteSlug }` } } />
 			</div>
 		</CompactCard>
 	);

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -119,7 +119,9 @@ class JetpackPluginsPanel extends Component {
 				return <div key={ group.category }>
 					<CompactCard className="plugins-wpcom__jetpack-category-header">
 						<Gridicon icon={ group.icon } />
-						{ group.name }
+						<span>
+							{ group.name }
+						</span>
 					</CompactCard>
 					{ plugins }
 				</div>;

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -6,7 +6,8 @@ import { localize } from 'i18n-calypso';
 import {
 	identity,
 	find,
-	matchesProperty
+	matchesProperty,
+	some
 } from 'lodash';
 
 /**
@@ -99,7 +100,7 @@ class JetpackPluginsPanel extends Component {
 	}
 
 	getJetpackPlugins() {
-		const groupedPlugins = jetpackPlugins.map( group => this.filterGroup( group ) ).filter( g => g );
+		const groupedPlugins = jetpackPlugins.map( this.filterGroup ).filter( identity );
 		if ( groupedPlugins.length ) {
 			return groupedPlugins;
 		}
@@ -111,9 +112,9 @@ class JetpackPluginsPanel extends Component {
 		</div>;
 	}
 
-	filterGroup( group ) {
+	filterGroup = group => {
 		if ( 'all' === this.state.selectedGroup || group.category === this.state.selectedGroup ) {
-			const plugins = group.plugins.map( ( plugin, j ) => this.filterPlugin( plugin, j ) ).filter( p => p );
+			const plugins = group.plugins.map( this.filterPlugin ).filter( p => p );
 
 			if ( plugins.length > 0 ) {
 				return <div key={ group.category }>
@@ -129,19 +130,16 @@ class JetpackPluginsPanel extends Component {
 		}
 	}
 
-	filterPlugin( plugin, pluginKey ) {
+	filterPlugin = ( plugin, pluginKey ) => {
 		if (
 			! this.state.searchTerm ||
 			-1 !== plugin.name.toLowerCase().indexOf( this.state.searchTerm.toLowerCase() )
 		) {
-			let isActive = false;
-			if (
-				'standard' === plugin.plan ||
-				( 'premium' === plugin.plan && this.props.hasPremium ) ||
-				( 'business' === plugin.plan && this.props.hasBusiness )
-			) {
-				isActive = true;
-			}
+			const isActive = some(
+				'standard' === plugin.plan,
+				'premium' === plugin.plan && this.props.hasPremium,
+				'business' === plugin.plan && this.props.hasBusiness
+			);
 
 			return <JetpackPluginItem
 				{ ...{

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import {
-	map,
 	identity,
 	find
 } from 'lodash';
@@ -111,6 +110,19 @@ class JetpackPluginsPanel extends Component {
 		];
 	}
 
+	getJetpackPlugins() {
+		const groupedPlugins = jetpackPlugins.map( group => this.filterGroup( group ) ).filter( g => g );
+		if ( groupedPlugins.length ) {
+			return groupedPlugins;
+		}
+
+		return <div>
+			{ this.props.translate( 'No features match your search for %s.', {
+				args: [ this.state.searchTerm ]
+			} )}
+		</div>;
+	}
+
 	filterGroup( group ) {
 		if ( 'all' === this.state.selectedGroup || group.category === this.state.selectedGroup ) {
 			const plugins = group.plugins.map( ( plugin, j ) => this.filterPlugin( plugin, j ) ).filter( p => p );
@@ -197,7 +209,7 @@ class JetpackPluginsPanel extends Component {
 				</CompactCard>
 
 				<CompactCard className="plugins-wpcom__jetpack-plugins-list">
-					{ map( jetpackPlugins, group => this.filterGroup( group ) ) }
+					{ this.getJetpackPlugins() }
 				</CompactCard>
 
 			</div>

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -1,0 +1,201 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import {
+	map,
+	identity,
+	find
+} from 'lodash';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import JetpackPluginItem from './jetpack-plugin-item';
+import SectionHeader from 'components/section-header';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import Search from 'components/search';
+import jetpackPlugins from './jetpack-plugins';
+
+class JetpackPluginsPanel extends Component {
+
+	static propTypes = {
+		siteSlug: PropTypes.string,
+		hasBusiness: PropTypes.bool,
+		hasPremium: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		translate: identity,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			selectedGroup: 'all',
+			searchTerm: '',
+		};
+	}
+
+	onNavClick( group ) {
+		this.setState( {
+			selectedGroup: group,
+		} );
+	}
+
+	onNavSearch = searchTerm => {
+		this.setState( {
+			searchTerm,
+		} );
+	}
+
+	getSearchPlaceholder() {
+		const { translate } = this.props;
+		switch ( this.state.selectedGroup ) {
+			case 'all':
+				return translate( 'Search All…', { textOnly: true } );
+			case 'engagement':
+				return translate( 'Search Engagement…', { textOnly: true } );
+			case 'security':
+				return translate( 'Search Security…', { textOnly: true } );
+			case 'appearance':
+				return translate( 'Search Appearance…', { textOnly: true } );
+			case 'writing':
+				return translate( 'Search Writing…', { textOnly: true } );
+		}
+	}
+
+	getSelectedText() {
+		const found = find( this.getNavItems(), item => this.state.selectedGroup === item.key );
+		return found ? found.title : '';
+	}
+
+	getNavItems() {
+		const { translate } = this.props;
+
+		return [
+			{
+				key: 'all',
+				title: translate( 'All', { context: 'Filter label for plugins list' } ),
+				onClick: () => this.onNavClick( 'all' ),
+			},
+			{
+				key: 'engagement',
+				title: translate( 'Engagement', { context: 'Filter label for plugins list' } ),
+				onClick: () => this.onNavClick( 'engagement' ),
+			},
+			{
+				key: 'security',
+				title: translate( 'Security', { context: 'Filter label for plugins list' } ),
+				onClick: () => this.onNavClick( 'security' ),
+			},
+			{
+				key: 'appearance',
+				title: translate( 'Appearance', { context: 'Filter label for plugins list' } ),
+				onClick: () => this.onNavClick( 'appearance' ),
+			},
+			{
+				key: 'writing',
+				title: translate( 'Writing', { context: 'Filter label for plugins list' } ),
+				onClick: () => this.onNavClick( 'writing' ),
+			},
+		];
+	}
+
+	filterGroup( group ) {
+		if ( 'all' === this.state.selectedGroup || group.category === this.state.selectedGroup ) {
+			const plugins = group.plugins.map( ( plugin, j ) => this.filterPlugin( plugin, j ) ).filter( p => p );
+
+			if ( plugins.length > 0 ) {
+				return <div key={ group.category }>
+					<SectionHeader label={ group.name } />
+					{ plugins }
+				</div>;
+			}
+		}
+	}
+
+	filterPlugin( plugin, pluginKey ) {
+		if (
+			! this.state.searchTerm ||
+			-1 !== plugin.name.toLowerCase().indexOf( this.state.searchTerm.toLowerCase() )
+		) {
+			let isActive = false;
+			if (
+				'standard' === plugin.plan ||
+				( 'premium' === plugin.plan && this.props.hasPremium ) ||
+				( 'business' === plugin.plan && this.props.hasBusiness )
+			) {
+				isActive = true;
+			}
+
+			return <JetpackPluginItem
+				{ ...{
+					key: pluginKey,
+					plugin,
+					isActive,
+					siteSlug: this.props.siteSlug,
+				} }
+			/>;
+		}
+	}
+
+	render() {
+		const { translate } = this.props;
+		return (
+			<div className="plugins-wpcom__jetpack-plugins-panel">
+
+				<SectionNav selectedText={ this.getSelectedText() }>
+					<NavTabs selectedText={ this.getSelectedText() }>
+						{ this.getNavItems().map( item =>
+							<NavItem { ...item } selected={ item.key === this.state.selectedGroup }>
+								{ item.title }
+							</NavItem>
+						) }
+					</NavTabs>
+					<Search
+						pinned
+						fitsContainer
+						onSearch={ this.onNavSearch }
+						placeholder={ this.getSearchPlaceholder() }
+					/>
+				</SectionNav>
+
+				<SectionHeader label={ translate( 'Plugin' ) } />
+
+				<CompactCard className={ classNames( 'plugins-wpcom__jetpack-main-plugin', 'plugins-wpcom__jetpack-plugin-item' ) }>
+					<a href="" className="plugins-wpcom__plugin-link">
+						<PluginIcon image="//ps.w.org/jetpack/assets/icon-256x256.png" />
+						<div className="plugins-wpcom__plugin-name">
+							{ translate( 'Jetpack by WordPress.com' ) }
+						</div>
+						<div className="plugins-wpcom__plugin-description">
+							{ translate( 'Jetpack essential features are included on every plan' ) }
+						</div>
+					</a>
+					<div className="plugins-wpcom__plugin-actions">
+						<Button className="plugins-wpcom__plugin-is-active plugin-is-active" compact borderless>
+							<Gridicon icon="checkmark" />{ translate( 'Active' ) }
+						</Button>
+					</div>
+				</CompactCard>
+
+				<CompactCard className="plugins-wpcom__jetpack-plugins-list">
+					{ map( jetpackPlugins, group => this.filterGroup( group ) ) }
+				</CompactCard>
+
+			</div>
+		);
+	}
+}
+
+export default localize( JetpackPluginsPanel );

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -117,7 +117,10 @@ class JetpackPluginsPanel extends Component {
 
 			if ( plugins.length > 0 ) {
 				return <div key={ group.category }>
-					<SectionHeader label={ group.name } />
+					<CompactCard className="plugins-wpcom__jetpack-category-header">
+						<Gridicon icon={ group.icon } />
+						{ group.name }
+					</CompactCard>
 					{ plugins }
 				</div>;
 			}
@@ -183,7 +186,7 @@ class JetpackPluginsPanel extends Component {
 						</div>
 					</a>
 					<div className="plugins-wpcom__plugin-actions">
-						<Button className="plugins-wpcom__plugin-is-active plugin-is-active" compact borderless>
+						<Button className="plugins-wpcom__plugin-is-active is-active-plugin" compact borderless>
 							<Gridicon icon="checkmark" />{ translate( 'Active' ) }
 						</Button>
 					</div>

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -5,9 +5,9 @@ import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import {
 	identity,
-	find
+	find,
+	matchesProperty
 } from 'lodash';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -36,26 +36,14 @@ class JetpackPluginsPanel extends Component {
 		translate: identity,
 	};
 
-	constructor( props ) {
-		super( props );
+	state = {
+		selectedGroup: 'all',
+		searchTerm: '',
+	};
 
-		this.state = {
-			selectedGroup: 'all',
-			searchTerm: '',
-		};
-	}
+	onNavClick = selectedGroup => this.setState( { selectedGroup } );
 
-	onNavClick( group ) {
-		this.setState( {
-			selectedGroup: group,
-		} );
-	}
-
-	onNavSearch = searchTerm => {
-		this.setState( {
-			searchTerm,
-		} );
-	}
+	onNavSearch = searchTerm => this.setState( { searchTerm } );
 
 	getSearchPlaceholder() {
 		const { translate } = this.props;
@@ -74,7 +62,7 @@ class JetpackPluginsPanel extends Component {
 	}
 
 	getSelectedText() {
-		const found = find( this.getNavItems(), item => this.state.selectedGroup === item.key );
+		const found = find( this.getNavItems(), matchesProperty( 'key', this.state.selectedGroup ) );
 		return found ? found.title : '';
 	}
 
@@ -189,7 +177,7 @@ class JetpackPluginsPanel extends Component {
 
 				<SectionHeader label={ translate( 'Plugins' ) } />
 
-				<CompactCard className={ classNames( 'plugins-wpcom__jetpack-main-plugin', 'plugins-wpcom__jetpack-plugin-item' ) }>
+				<CompactCard className="plugins-wpcom__jetpack-main-plugin plugins-wpcom__jetpack-plugin-item">
 					<div className="plugins-wpcom__plugin-link">
 						<PluginIcon image="//ps.w.org/jetpack/assets/icon-256x256.png" />
 						<div className="plugins-wpcom__plugin-content">

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -175,18 +175,20 @@ class JetpackPluginsPanel extends Component {
 					/>
 				</SectionNav>
 
-				<SectionHeader label={ translate( 'Plugin' ) } />
+				<SectionHeader label={ translate( 'Plugins' ) } />
 
 				<CompactCard className={ classNames( 'plugins-wpcom__jetpack-main-plugin', 'plugins-wpcom__jetpack-plugin-item' ) }>
-					<a href="" className="plugins-wpcom__plugin-link">
+					<div className="plugins-wpcom__plugin-link">
 						<PluginIcon image="//ps.w.org/jetpack/assets/icon-256x256.png" />
-						<div className="plugins-wpcom__plugin-name">
-							{ translate( 'Jetpack by WordPress.com' ) }
+						<div className="plugins-wpcom__plugin-content">
+							<div className="plugins-wpcom__plugin-name">
+								{ translate( 'Jetpack by WordPress.com' ) }
+							</div>
+							<div className="plugins-wpcom__plugin-description">
+								{ translate( 'Jetpack essential features are included on every plan' ) }
+							</div>
 						</div>
-						<div className="plugins-wpcom__plugin-description">
-							{ translate( 'Jetpack essential features are included on every plan' ) }
-						</div>
-					</a>
+					</div>
 					<div className="plugins-wpcom__plugin-actions">
 						<Button className="plugins-wpcom__plugin-is-active is-active-plugin" compact borderless>
 							<Gridicon icon="checkmark" />{ translate( 'Active' ) }

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -99,8 +99,8 @@ class JetpackPluginsPanel extends Component {
 		];
 	}
 
-	getJetpackPlugins() {
-		const groupedPlugins = jetpackPlugins.map( this.filterGroup ).filter( identity );
+	getJetpackPlugins( translatedPlugins ) {
+		const groupedPlugins = translatedPlugins.map( this.filterGroup ).filter( identity );
 		if ( groupedPlugins.length ) {
 			return groupedPlugins;
 		}
@@ -195,7 +195,7 @@ class JetpackPluginsPanel extends Component {
 				</CompactCard>
 
 				<CompactCard className="plugins-wpcom__jetpack-plugins-list">
-					{ this.getJetpackPlugins() }
+					{ this.getJetpackPlugins( jetpackPlugins( translate ) ) }
 				</CompactCard>
 
 			</div>

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -135,11 +135,11 @@ class JetpackPluginsPanel extends Component {
 			! this.state.searchTerm ||
 			-1 !== plugin.name.toLowerCase().indexOf( this.state.searchTerm.toLowerCase() )
 		) {
-			const isActive = some(
+			const isActive = some( [
 				'standard' === plugin.plan,
 				'premium' === plugin.plan && this.props.hasPremium,
 				'business' === plugin.plan && this.props.hasBusiness
-			);
+			] );
 
 			return <JetpackPluginItem
 				{ ...{

--- a/client/my-sites/plugins-wpcom/jetpack-plugins.js
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins.js
@@ -1,0 +1,187 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+const jetpackPlugins = [
+	{
+		category: 'engagement',
+		name: translate( 'Engagement' ),
+		icon: 'stats-alt',
+		plugins: [
+			{
+				name: translate( 'Stats' ),
+				link: 'https://support.wordpress.com/stats/',
+				description: translate( 'View your site\'s visits, referrers, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Social Media' ),
+				link: 'https://support.wordpress.com/sharing/',
+				description: translate( 'Add social media buttons to your posts and pages.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Publicize' ),
+				link: 'https://support.wordpress.com/publicize/',
+				description: translate( 'Automatically share your posts on Facebook, Twitter, Tumblr, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Email Subscriptions' ),
+				link: 'https://support.wordpress.com/follow-blog-widget/',
+				description: translate( 'Enables your readers to sign up to receive your posts via email.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Related Posts' ),
+				link: 'https://support.wordpress.com/related-posts/',
+				description: translate( 'Pulls relevant content from your blog to display at the bottom of your posts.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Likes' ),
+				link: 'https://support.wordpress.com/likes/',
+				description: translate( 'Engage readers with a Like button on your posts.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Advanced Comments' ),
+				link: 'https://support.wordpress.com/comments/',
+				description: translate( 'Comment likes, user mentions, notifications, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'SEO Tools' ),
+				link: 'https://support.wordpress.com/seo-tools/',
+				description: translate( 'Custom meta descriptions, social media previews, and more.' ),
+				plan: 'business',
+			},
+			{
+				name: translate( 'Google Analytics' ),
+				link: 'https://support.wordpress.com/google-analytics/',
+				description: translate( 'Advanced features to complement WordPress.com stats. Funnel reports, goal conversion, and more.' ),
+				plan: 'business',
+			},
+		],
+	},
+	{
+		category: 'security',
+		name: translate( 'Security' ),
+		icon: 'spam',
+		plugins: [
+			{
+				name: translate( 'Security Scanning' ),
+				link: 'https://support.wordpress.com/security/',
+				description: translate( 'Constant monitoring of your site for threats.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Backup & Export' ),
+				link: 'https://support.wordpress.com/export/#backups',
+				description: translate( '24/7 backup of your entire site. Export everything.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Akismet' ),
+				link: 'http://akismet.com/',
+				description: translate( 'Advanced anti-spam security.' ),
+				plan: 'standard',
+			},
+		],
+	},
+	{
+		category: 'appearance',
+		name: translate( 'Appearance' ),
+		icon: 'customize',
+		plugins: [
+			{
+				name: translate( 'Advanced Galleries' ),
+				link: 'https://support.wordpress.com/images/gallery/',
+				description: translate( 'Tiled, mosaic, slideshows, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Extended Customizer' ),
+				link: 'https://support.wordpress.com/customizer/',
+				description: translate( 'Edit colors and backgrounds.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Extended Widgets' ),
+				link: 'https://support.wordpress.com/widgets-sidebars/',
+				description: translate( 'Eventbrite, Flickr, Google Calendar, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Infinite Scroll' ),
+				link: 'https://support.wordpress.com/infinite-scroll/',
+				description: translate( 'Load more posts when you reach the bottom of a page on your site.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Photon CDN' ),
+				link: 'https://support.wordpress.com/photon/',
+				description: translate( 'Faster image loading and editing.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'No Advertising' ),
+				link: 'https://support.wordpress.com/no-ads/',
+				description: translate( 'Faster image loading and editing.' ),
+				plan: 'premium',
+			},
+			{
+				name: translate( 'Custom Design' ),
+				link: 'https://support.wordpress.com/custom-design/',
+				description: translate( 'Customize your blog\'s look with custom fonts, a CSS editor, and more.' ),
+				plan: 'premium',
+			},
+		],
+	},
+	{
+		category: 'writing',
+		name: translate( 'Writing' ),
+		icon: 'pencil',
+		plugins: [
+			{
+				name: translate( 'Form Builder' ),
+				link: 'https://support.wordpress.com/contact-form/',
+				description: translate( 'Build contact forms so visitors can get in touch.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Extended Shortcodes' ),
+				link: 'https://support.wordpress.com/shortcodes/',
+				description: translate( 'YouTube, Twitter, Instagram, Spotify, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Importer' ),
+				link: 'https://support.wordpress.com/import/',
+				description: translate( 'Import your blog content from a variety of other blogging platforms.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Polls & Surveys' ),
+				link: 'https://support.wordpress.com/polls/',
+				description: translate( 'Add polls and surveys to your site.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Markdown' ),
+				link: 'https://support.wordpress.com/markdown/',
+				description: translate( 'Text formatting using a lightweight markup language.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Video Uploads' ),
+				link: 'https://support.wordpress.com/videopress/',
+				description: translate( 'Upload and host your video files on your site with VideoPress.' ),
+				plan: 'premium',
+			},
+		],
+	},
+];
+
+export default jetpackPlugins;

--- a/client/my-sites/plugins-wpcom/jetpack-plugins.js
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { translate } from 'i18n-calypso';
+import { identity } from 'lodash';
 
-const jetpackPlugins = [
+const jetpackPlugins = ( translate = identity ) => [
 	{
 		category: 'engagement',
 		name: translate( 'Engagement' ),

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import {
 	getSelectedSite,
 	getSelectedSiteId
@@ -20,66 +19,26 @@ import {
 	isBusiness,
 	isEnterprise
 } from 'lib/products-values';
-import StandardPluginsPanel from './standard-plugins-panel';
-import PremiumPluginsPanel from './premium-plugins-panel';
-import BusinessPluginsPanel from './business-plugins-panel';
+import JetpackPluginsPanel from './jetpack-plugins-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import {
-	defaultStandardPlugins,
-	defaultPremiumPlugins,
-	defaultBusinessPlugins
-} from './default-plugins';
-
-/*
- *replacements e.g. { siteSlug: 'mytestblog.wordpress.com', siteId: 12345 }
- */
-const linkInterpolator = replacements => plugin => {
-	const { descriptionLink: link } = plugin;
-	const descriptionLink = Object
-		.keys( replacements )
-		.reduce(
-			( s, r ) => s.replace( new RegExp( `{${ r }}` ), replacements[ r ] ),
-			link
-		);
-
-	return { ...plugin, descriptionLink };
-};
 
 export const PluginPanel = ( {
 	plan,
 	siteSlug,
-	translate,
 } ) => {
-	const standardPluginsLink = `/plugins/category/standard/${ siteSlug }`;
-	const purchaseLink = `/plans/${ siteSlug }`;
-
 	const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
 	const hasPremium = hasBusiness || isPremium( plan );
 
-	const interpolateLink = linkInterpolator( { siteSlug } );
-
-	const standardPlugins = defaultStandardPlugins.map( interpolateLink );
-	const premiumPlugins = defaultPremiumPlugins.map( interpolateLink );
-	const businessPlugins = defaultBusinessPlugins.map( interpolateLink );
-
 	return (
-		<div className="wpcom-plugin-panel">
+		<div className="plugins-wpcom__panel">
 			<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
-			<Card compact className="plugins-wpcom__header">
-				<div className="plugins-wpcom__header-text">
-					<span className="plugins-wpcom__header-title">{ translate( 'Included Plugins' ) }</span>
-					<span className="plugins-wpcom__header-subtitle">
-						{ translate( 'Every plan includes a set of plugins specially tailored to supercharge your site.' ) }
-					</span>
-				</div>
-				<img className="plugins-wpcom__header-image" src="/calypso/images/plugins/plugins_hero.svg" />
-			</Card>
-			<StandardPluginsPanel plugins={ standardPlugins } displayCount={ 9 } />
-			<Card className="wpcom-plugin-panel__panel-footer" href={ standardPluginsLink }>
-				{ translate( 'View all standard plugins' ) }
-			</Card>
-			<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium } { ...{ purchaseLink } } />
-			<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness } { ...{ purchaseLink } } />
+
+			<JetpackPluginsPanel { ...{
+				siteSlug,
+				hasBusiness,
+				hasPremium,
+			} } />
+
 		</div>
 	);
 };

--- a/client/my-sites/plugins-wpcom/purchase-button.jsx
+++ b/client/my-sites/plugins-wpcom/purchase-button.jsx
@@ -23,7 +23,7 @@ export const PurchaseButton = ( {
 	)
 	: (
 		<Button compact primary { ...{ href } }>
-			{ translate( 'Purchase' ) }
+			{ translate( 'Upgrade' ) }
 		</Button>
 	);
 

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -226,7 +226,7 @@
 	.plugins-wpcom__plugin-description {
 		color: $gray;
 		font-size: 12px;
-		padding: 6px 0;
+		padding: 2px 0;
 
 		@include breakpoint( '>480px' ) {
 			font-size: 14px;

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -289,7 +289,8 @@
 	}
 }
 
-.plugins-wpcom__jetpack-plugins-list {
+.plugins-wpcom__jetpack-plugins-list.card {
+	padding: 0;
 	.plugins-wpcom__plugin-name {
 		@include breakpoint( '>480px' ) {
 			font-size: 18px;

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -291,20 +291,25 @@
 	font-size: 14px;
 	line-height: 15px;
 	padding-bottom: 11px;
-	padding-top: 3px;
+	padding-left: 50px;
+	padding-top: 11px;
+	position: relative;
 
 	@include breakpoint( '>480px' ) {
 		line-height: 28px;
-		padding-top: 11px;
+		padding-left: 60px;
 	}
 
 	.gridicon {
-		margin-right: 8px;
-		position: relative;
-		top: 5px;
+		height: 24px;
+		left: 16px;
+		position: absolute;
+		top: 6px;
+		width: 24px;
 
 		@include breakpoint( '>480px' ) {
-			margin-right: 12px;
+			left: 24px;
+			top: 11px;
 		}
 	}
 }

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -50,11 +50,11 @@
 // Special styles for displaying only two plugins
 .wpcom-plugins__business-panel .wpcom-plugins__plugin-item {
 	width: 100%;
-	
+
 	&:last-child {
 		border-right: none;
 	}
-	
+
 	@include breakpoint( ">960px" ) {
 		width: 50%;
 		border-right: 1px solid lighten( $gray, 20% );
@@ -114,7 +114,7 @@
 	margin-bottom: 0;
 }
 
-.wpcom-plugin-panel button.is-active-plugin {
+.plugins-wpcom__panel button.is-active-plugin {
 	color: $alert-green;
 
 	&:hover {
@@ -146,7 +146,7 @@
 	}
 }
 
-.wpcom-plugin-panel .notice {
+.plugins-wpcom__panel .notice {
 	margin: 0;
 }
 
@@ -195,5 +195,93 @@
 
 	@include breakpoint( ">960px" ) {
 		margin: 0 auto;
+	}
+}
+
+.plugins-wpcom__jetpack-plugin-item.card {
+	display: flex;
+	flex-direction: row;
+	padding: 0;
+
+	.plugins-wpcom__plugin-link {
+		display: block;
+		flex-grow: 1;
+		font-size: 14px;
+		padding: 16px;
+		overflow: hidden;
+	}
+
+	.plugins-wpcom__plugin-name {
+		color: $gray-dark;
+		display: block;
+		font-weight: 600;
+		line-height: 21px;
+		overflow: hidden;
+		text-align: left;
+		text-overflow: ellipsis;
+		white-space: pre;
+	}
+
+	.plugins-wpcom__plugin-description {
+		color: $gray;
+		font-size: 12px;
+		line-height: 1;
+		padding: 6px 0;
+
+		@include breakpoint( '>480px' ) {
+			font-size: 14px;
+		}
+	}
+
+	.plugins-wpcom__plugin-actions {
+		align-self: center;
+		flex-grow: 1;
+		flex-shrink: 0;
+		padding: 16px;
+		text-align: right;
+
+		@include breakpoint( '>480px' ) {
+			flex-grow: 0;
+		}
+
+		@include breakpoint( '>660px' ) {
+			padding-right: 24px;
+			padding-left: 24px;
+		}
+	}
+
+	.plugins-wpcom__is-premium-plugin,
+	.plugins-wpcom__is-business-plugin {
+		color: $alert-purple;
+		display: block;
+		@include breakpoint( '>480px' ) {
+			display: inline-block;
+			margin-left: 10px;
+		}
+	}
+}
+
+.plugins-wpcom__jetpack-main-plugin.card {
+	.plugins-wpcom__plugin-name {
+		@include breakpoint( '>480px' ) {
+			font-size: 24px;
+			font-weight: 700;
+			font-family: $serif;
+			line-height: 32px;
+		}
+	}
+}
+
+.plugins-wpcom__jetpack-plugins-list {
+	padding: 16px;
+
+	> div:not(:first-child) {
+		margin-top: 16px;
+	}
+
+	.plugins-wpcom__plugin-name {
+		@include breakpoint( '>480px' ) {
+			font-size: 18px;
+		}
 	}
 }

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -285,3 +285,26 @@
 		}
 	}
 }
+
+.plugins-wpcom__jetpack-category-header.card {
+	color: $gray;
+	font-size: 14px;
+	line-height: 15px;
+	padding-bottom: 11px;
+	padding-top: 3px;
+
+	@include breakpoint( '>480px' ) {
+		line-height: 28px;
+		padding-top: 11px;
+	}
+
+	.gridicon {
+		margin-right: 8px;
+		position: relative;
+		top: 5px;
+
+		@include breakpoint( '>480px' ) {
+			margin-right: 12px;
+		}
+	}
+}

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -116,8 +116,10 @@
 
 .plugins-wpcom__panel button.is-active-plugin {
 	color: $alert-green;
+	cursor: default;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		color: $alert-green;
 	}
 }
@@ -214,7 +216,6 @@
 	.plugins-wpcom__plugin-name {
 		color: $gray-dark;
 		display: block;
-		font-weight: 600;
 		line-height: 21px;
 		overflow: hidden;
 		text-align: left;
@@ -225,7 +226,6 @@
 	.plugins-wpcom__plugin-description {
 		color: $gray;
 		font-size: 12px;
-		line-height: 1;
 		padding: 6px 0;
 
 		@include breakpoint( '>480px' ) {
@@ -252,16 +252,33 @@
 
 	.plugins-wpcom__is-premium-plugin,
 	.plugins-wpcom__is-business-plugin {
-		color: $alert-purple;
 		display: block;
 		@include breakpoint( '>480px' ) {
 			display: inline-block;
 			margin-left: 10px;
 		}
 	}
+	.plugins-wpcom__is-premium-plugin {
+		color: $alert-green;
+	}
+	.plugins-wpcom__is-business-plugin {
+		color: $alert-purple;
+	}
 }
 
 .plugins-wpcom__jetpack-main-plugin.card {
+	.plugins-wpcom__plugin-link {
+		display: flex;
+		.plugin-icon {
+			float: none;
+			flex-shrink: 0;
+		}
+		.plugins-wpcom__plugin-content {
+			flex-grow: 1;
+			overflow: hidden;
+		}
+	}
+
 	.plugins-wpcom__plugin-name {
 		@include breakpoint( '>480px' ) {
 			font-size: 24px;

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -290,12 +290,6 @@
 }
 
 .plugins-wpcom__jetpack-plugins-list {
-	padding: 16px;
-
-	> div:not(:first-child) {
-		margin-top: 16px;
-	}
-
 	.plugins-wpcom__plugin-name {
 		@include breakpoint( '>480px' ) {
 			font-size: 18px;


### PR DESCRIPTION
See: https://github.com/Automattic/wp-calypso/issues/9423

Created an all new Jetpack-only view for .com plugins, following this design:
![artboard copy 17](https://cloud.githubusercontent.com/assets/618551/20349792/b157f0fa-abea-11e6-9cca-f45505e2e0ab.png)
and these new category names: Engagement, Security, Appearance, Writing.

The legacy files are still available, in the off chance this page will eventually show non-Jetpack plugins too.

Before|After
---|---
![before](https://cloud.githubusercontent.com/assets/618551/20395496/ea0f599c-acc1-11e6-901a-c2ca9ce341a6.png)|![after2](https://cloud.githubusercontent.com/assets/618551/20399540/2769b3f6-acd0-11e6-8fb4-bc5d9174cd69.png)

