### PR TITLE
Pages: Enable set homepage for wpcalypso, stage, and production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -42,6 +42,7 @@
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
+		"manage/pages/set-homepage": true,
 		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -46,6 +46,7 @@
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
+		"manage/pages/set-homepage": true,
 		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -55,6 +55,7 @@
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
+		"manage/pages/set-homepage": true,
 		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,


### PR DESCRIPTION
This PR enables the ability to set the homepage from Pages in wpcalypso, stage, and production. It was previously enabled in development.

![sethomepage](https://cloud.githubusercontent.com/assets/363749/20397474/7af25ea4-acaf-11e6-9112-e417b642e354.gif)
