### PR TITLE
/plugins: Show appropriate page when no site selected

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -330,7 +330,7 @@ const PluginsMain = React.createClass( {
 	render() {
 		const { selectedSite } = this.props;
 
-		if ( ! this.props.selectedSiteIsJetpack ) {
+		if ( selectedSite && ! this.props.selectedSiteIsJetpack ) {
 			return (
 				<Main>
 					{ this.renderDocumentHead() }


### PR DESCRIPTION
In #9378 a bug was introduced when navigating to the `/plugins` path
wherein it would show the WordPress.com features "plugin" page even if a
user had avaiable Jetpack sites. It _should_ have shown the list of
installed plugins across all Jetpack sites in this case.

The bug came in when making the following change:
```js
// from this
if ( selectedSite && ! isJetpack() )

// to this
if ( ! isJetpack() )
```

The actual code was slightly different but this captures the change. The
condition should have been "if a site is selected _and_ it's not a
Jetpack site" and it was changed to simply "if no Jetpack site is
selected"

This fixes that by reintroducing the check for a selected site.

cc: @beaulebens @johnHackworth @enejb @tyxla 