### PR TITLE
Checkout: Add Tracks event when user applies a coupon

### DIFF
--- a/client/my-sites/upgrades/cart/cart-coupon.jsx
+++ b/client/my-sites/upgrades/cart/cart-coupon.jsx
@@ -44,6 +44,11 @@ module.exports = React.createClass( {
 
 	applyCoupon: function( event ) {
 		event.preventDefault();
+
+		analytics.tracks.recordEvent( 'calypso_checkout_coupon_submit', {
+			coupon_code: this.state.couponInputValue
+		} );
+
 		this.setState( {
 			userChangedCoupon: false,
 			hasSubmittedCoupon: true


### PR DESCRIPTION
This PR adds a Tracks event when a user submits a coupon during checkout in Calypso.

Note that this will be fired regardless of whether the coupon is valid or not, hence the name _submit_ vs _apply_.