### PR TITLE
Plugins: Fix false error when installing plugins

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -146,6 +146,11 @@ const PlansSetup = React.createClass( {
 	},
 
 	startNextPlugin( plugin ) {
+		// We're already installing.
+		if ( this.props.isInstalling ) {
+			return;
+		}
+
 		const install = this.props.installPlugin;
 		const site = this.props.selectedSite;
 

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -151,7 +151,7 @@ function activate( site, plugin, dispatch ) {
 	};
 
 	getPluginHandler( site, plugin.id ).activate().then( success ).catch( ( error ) => {
-		if ( ( error.name === 'ActivationErrorError' ) || ( error.name === 'ActivationError' ) ) {
+		if ( error.name === 'ActivationErrorError' || error.name === 'ActivationError' ) {
 			// Technically it failed, but only because it's already active.
 			success( plugin );
 			return;

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -151,7 +151,7 @@ function activate( site, plugin, dispatch ) {
 	};
 
 	getPluginHandler( site, plugin.id ).activate().then( success ).catch( ( error ) => {
-		if ( error.name === 'ActivationErrorError' ) {
+		if ( ( error.name === 'ActivationErrorError' ) || ( error.name === 'ActivationError' ) ) {
 			// Technically it failed, but only because it's already active.
 			success( plugin );
 			return;

--- a/client/state/plugins/premium/test/selectors.js
+++ b/client/state/plugins/premium/test/selectors.js
@@ -9,7 +9,7 @@ import deepFreeze from 'deep-freeze';
  */
 import selectors from '../selectors';
 // Example state data
-import { initSite, installingSite, finishedSite } from './examples';
+import { initSite, installingSite, finishedSite, configuringSite } from './examples';
 
 const state = deepFreeze( {
 	plugins: {
@@ -22,6 +22,7 @@ const state = deepFreeze( {
 				'start.site': initSite,
 				'installing.site': installingSite,
 				'finished.site': finishedSite,
+				'config.site': configuringSite
 			}
 		}
 	}
@@ -76,6 +77,28 @@ describe( 'Premium Plugin Selectors', function() {
 		} );
 	} );
 
+	describe( 'isInstalling', function() {
+		it( 'Should get `false` if the requested site is not in the current state', function() {
+			assert.equal( selectors.isInstalling( state, 'no.site' ), false );
+		} );
+
+		it( 'Should get `true` if there is a plugin installing on the requested site', function() {
+			assert.equal( selectors.isInstalling( state, 'installing.site' ), true );
+		} );
+
+		it( 'Should get `true` if there is a plugin installing on the requested site, using whitelist', function() {
+			assert.equal( selectors.isInstalling( state, 'installing.site', 'akismet' ), true );
+		} );
+
+		it( 'Should get `true` if there is a plugin installing on the requested site, using whitelist', function() {
+			assert.equal( selectors.isInstalling( state, 'config.site', 'akismet' ), true );
+		} );
+
+		it( 'Should get `false` if all plugins on the requested site are either done or have errors', function() {
+			assert.equal( selectors.isInstalling( state, 'finished.site' ), false );
+		} );
+	} );
+
 	describe( 'getPluginsForSite', function() {
 		it( 'Should get `false` if the requested site is not in the current state', function() {
 			assert.equal( selectors.getPluginsForSite( state, 'no.site' ), false );
@@ -83,9 +106,9 @@ describe( 'Premium Plugin Selectors', function() {
 
 		it( 'Should get the list of plugins if the site exists in the current state', function() {
 			assert.equal( selectors.getPluginsForSite( state, 'start.site' ).length, 3 );
-			assert.equal( selectors.getPluginsForSite( state, 'start.site' )[0].slug, 'vaultpress' );
-			assert.equal( selectors.getPluginsForSite( state, 'start.site' )[1].slug, 'akismet' );
-			assert.equal( selectors.getPluginsForSite( state, 'start.site' )[2].slug, 'polldaddy' );
+			assert.equal( selectors.getPluginsForSite( state, 'start.site' )[ 0 ].slug, 'vaultpress' );
+			assert.equal( selectors.getPluginsForSite( state, 'start.site' )[ 1 ].slug, 'akismet' );
+			assert.equal( selectors.getPluginsForSite( state, 'start.site' )[ 2 ].slug, 'polldaddy' );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/5685: plugins that are already installed report an error activating, but in reality activated correctly. There were actually 2 issues here:

- The code which triggers the install step was being run repeatedly, triggering 4+ install events, so now we check again if we're installing before continuing with `startNextPlugin`.
- Plugins that are already active when the activate action runs report an error that we used to ignore (`ActivationErrorError`), but that name has changed to `ActivationError`. I'm not sure the source of the change (Jetpack, or wp.com), so we'll accept both now as "not-really-errors" that pass through the the next step. @samhotchkiss hit this step because the first install action activated the plugin, and the following actions got caught in this error.

This also adds tests for the `isInstalling` selector, since I thought that was the issue at first.

**To test:**

1. Have a Jetpack site with a premium or professional plan, with Akismet installed, but not active
2. Run the autoconfig for Akismet by visiting `/plugins/setup/$site?only=akismet`

You should not see an error, and Akismet should be active and working on your site.

cc @samhotchkiss @johnHackworth @oskosk @tyxla 