### PR TITLE
Reader: Add in-stream post recommendations

### DIFF
--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import { getPost } from 'state/reader/posts/selectors';
-import { getSite } from 'state/reader/sites/selectors';
 import Card from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import FollowButton from 'reader/follow-button';
@@ -27,9 +26,9 @@ function FeaturedImage( { image, href } ) {
 		} } ></div> );
 }
 
-function AuthorAndSiteFollow( { post, site } ) {
+function AuthorAndSiteFollow( { post } ) {
 	const siteUrl = getStreamUrl( post.feed_ID, post.site_ID );
-	const authorAndSiteAreDifferent = site.title.toLowerCase() !== post.author.name.toLowerCase();
+	const authorAndSiteAreDifferent = post.site_name.toLowerCase() !== post.author.name.toLowerCase();
 	return (
 		<div className="reader-related-card-v2__meta">
 			<a href={ siteUrl }>
@@ -41,7 +40,7 @@ function AuthorAndSiteFollow( { post, site } ) {
 				</span>
 				{ authorAndSiteAreDifferent &&
 				<span className="reader-related-card-v2__byline-site">
-					<a href={ siteUrl } className="reader-related-card-v2__link">{ site.title }</a>
+					<a href={ siteUrl } className="reader-related-card-v2__link">{ post.site_name }</a>
 				</span>
 				}
 			</div>
@@ -82,7 +81,7 @@ function RelatedPostCardPlaceholder() {
 }
 
 /* eslint-disable no-unused-vars */
-export function RelatedPostCard( { post, site, onPostClick = noop, onSiteClick = noop } ) {
+export function RelatedPostCard( { post, onPostClick = noop, onSiteClick = noop } ) {
 // onSiteClick is not being used
 /* eslint-enable no-unused-vars */
 	if ( ! post || post._state === 'minimal' || post._state === 'pending' ) {
@@ -97,7 +96,7 @@ export function RelatedPostCard( { post, site, onPostClick = noop, onSiteClick =
 
 	return (
 		<Card className={ classes }>
-			<AuthorAndSiteFollow post={ post } site={ site } />
+			<AuthorAndSiteFollow post={ post } />
 			<a href={ postLink } className="reader-related-card-v2__post reader-related-card-v2__link-block"
 				onClick={ partial( onPostClick, post ) } >
 					{ featuredImage && <FeaturedImage image={ featuredImage } href={ post.URL }
@@ -119,10 +118,8 @@ export default connect(
 	( state, ownProps ) => {
 		const { post } = ownProps;
 		const actualPost = getPost( state, post );
-		const site = actualPost && getSite( state, actualPost.site_ID );
 		return {
-			post: actualPost,
-			site
+			post: actualPost
 		};
 	}
 )( LocalizedRelatedPostCard );

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import { getPost } from 'state/reader/posts/selectors';
+import { getSite } from 'state/reader/sites/selectors';
+import QueryReaderSite from 'components/data/query-reader-site';
 import Card from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import FollowButton from 'reader/follow-button';
@@ -26,9 +28,10 @@ function FeaturedImage( { image, href } ) {
 		} } ></div> );
 }
 
-function AuthorAndSiteFollow( { post, onSiteClick } ) {
+function AuthorAndSiteFollow( { post, site, onSiteClick } ) {
 	const siteUrl = getStreamUrl( post.feed_ID, post.site_ID );
-	const authorAndSiteAreDifferent = post.site_name.toLowerCase() !== post.author.name.toLowerCase();
+	const siteName = ( site && site.title ) || post.site_name;
+	const authorAndSiteAreDifferent = siteName.toLowerCase() !== post.author.name.toLowerCase();
 	return (
 		<div className="reader-related-card-v2__meta">
 			<a href={ siteUrl } onClick={ onSiteClick }>
@@ -40,7 +43,7 @@ function AuthorAndSiteFollow( { post, onSiteClick } ) {
 				</span>
 				{ authorAndSiteAreDifferent &&
 				<span className="reader-related-card-v2__byline-site">
-					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">{ post.site_name }</a>
+					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">{ siteName }</a>
 				</span>
 				}
 			</div>
@@ -80,7 +83,7 @@ function RelatedPostCardPlaceholder() {
 	);
 }
 
-export function RelatedPostCard( { post, onPostClick = noop, onSiteClick = noop } ) {
+export function RelatedPostCard( { post, site, siteId, onPostClick = noop, onSiteClick = noop } ) {
 /* eslint-enable no-unused-vars */
 	if ( ! post || post._state === 'minimal' || post._state === 'pending' ) {
 		return <RelatedPostCardPlaceholder />;
@@ -96,7 +99,8 @@ export function RelatedPostCard( { post, onPostClick = noop, onSiteClick = noop 
 
 	return (
 		<Card className={ classes }>
-			<AuthorAndSiteFollow post={ post } onSiteClick={ siteClickTracker } />
+		{ siteId && ! site && <QueryReaderSite siteId={ siteId } /> }
+			<AuthorAndSiteFollow post={ post } site={ site } onSiteClick={ siteClickTracker } />
 			<a href={ postLink } className="reader-related-card-v2__post reader-related-card-v2__link-block"
 				onClick={ postClickTracker } >
 					{ featuredImage && <FeaturedImage image={ featuredImage } href={ post.URL }
@@ -118,8 +122,12 @@ export default connect(
 	( state, ownProps ) => {
 		const { post } = ownProps;
 		const actualPost = getPost( state, post );
+		const siteId = post && post.site_ID;
+		const site = siteId && getSite( state, siteId );
 		return {
-			post: actualPost
+			post: actualPost,
+			site,
+			siteId
 		};
 	}
 )( LocalizedRelatedPostCard );

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -26,21 +26,21 @@ function FeaturedImage( { image, href } ) {
 		} } ></div> );
 }
 
-function AuthorAndSiteFollow( { post } ) {
+function AuthorAndSiteFollow( { post, onSiteClick } ) {
 	const siteUrl = getStreamUrl( post.feed_ID, post.site_ID );
 	const authorAndSiteAreDifferent = post.site_name.toLowerCase() !== post.author.name.toLowerCase();
 	return (
 		<div className="reader-related-card-v2__meta">
-			<a href={ siteUrl }>
+			<a href={ siteUrl } onClick={ onSiteClick }>
 				<Gravatar user={ post.author } />
 			</a>
 			<div className="reader-related-card-v2__byline">
 				<span className="reader-related-card-v2__byline-author">
-					<a href={ siteUrl } className="reader-related-card-v2__link">{ post.author.name }</a>
+					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">{ post.author.name }</a>
 				</span>
 				{ authorAndSiteAreDifferent &&
 				<span className="reader-related-card-v2__byline-site">
-					<a href={ siteUrl } className="reader-related-card-v2__link">{ post.site_name }</a>
+					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">{ post.site_name }</a>
 				</span>
 				}
 			</div>
@@ -80,9 +80,7 @@ function RelatedPostCardPlaceholder() {
 	);
 }
 
-/* eslint-disable no-unused-vars */
 export function RelatedPostCard( { post, onPostClick = noop, onSiteClick = noop } ) {
-// onSiteClick is not being used
 /* eslint-enable no-unused-vars */
 	if ( ! post || post._state === 'minimal' || post._state === 'pending' ) {
 		return <RelatedPostCardPlaceholder />;
@@ -93,14 +91,16 @@ export function RelatedPostCard( { post, onPostClick = noop, onSiteClick = noop 
 	const classes = classnames( 'reader-related-card-v2', {
 		'has-thumbnail': !! featuredImage
 	} );
+	const postClickTracker = partial( onPostClick, post );
+	const siteClickTracker = partial( onSiteClick, post );
 
 	return (
 		<Card className={ classes }>
-			<AuthorAndSiteFollow post={ post } />
+			<AuthorAndSiteFollow post={ post } onSiteClick={ siteClickTracker } />
 			<a href={ postLink } className="reader-related-card-v2__post reader-related-card-v2__link-block"
-				onClick={ partial( onPostClick, post ) } >
+				onClick={ postClickTracker } >
 					{ featuredImage && <FeaturedImage image={ featuredImage } href={ post.URL }
-						onClick={ partial( onPostClick, post ) } /> }
+						onClick={ postClickTracker } /> }
 					<div className="reader-related-card-v2__site-info">
 						<h1 className="reader-related-card-v2__title">{ post.title }</h1>
 						<div className="reader-related-card-v2__excerpt post-excerpt">

--- a/client/lib/feed-post-store/post-fetcher.js
+++ b/client/lib/feed-post-store/post-fetcher.js
@@ -43,7 +43,7 @@ assign( PostFetcher.prototype, {
 			const post = FeedPostStore.get( postKey );
 
 			if ( post && post._state !== 'minimal' ) {
-				throw new Error( post._state );
+				return;
 			}
 
 			this.onFetch( postKey );

--- a/client/lib/feed-post-store/post-fetcher.js
+++ b/client/lib/feed-post-store/post-fetcher.js
@@ -21,7 +21,7 @@ assign( PostFetcher.prototype, {
 		this.postsToFetch = this.postsToFetch.add( Immutable.fromJS( postKey ) );
 
 		if ( ! this.batchQueued ) {
-			this.batchQueued = setTimeout( this.run.bind( this ), 0 );
+			this.batchQueued = setTimeout( this.run.bind( this ), 100 );
 		}
 	},
 

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -123,19 +123,17 @@ FeedStreamActions = {
 		} );
 	},
 
-	selectNextItem: function( id, selectedIndex ) {
+	selectNextItem: function( id ) {
 		Dispatcher.handleViewAction( {
 			type: ActionType.SELECT_NEXT_ITEM,
-			id: id,
-			selectedIndex: selectedIndex
+			id: id
 		} );
 	},
 
-	selectPrevItem: function( id, selectedIndex ) {
+	selectPrevItem: function( id ) {
 		Dispatcher.handleViewAction( {
 			type: ActionType.SELECT_PREV_ITEM,
-			id: id,
-			selectedIndex: selectedIndex
+			id: id
 		} );
 	},
 

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -175,32 +175,44 @@ assign( FeedStream.prototype, {
 			post._state !== 'minimal';
 	},
 
-	selectNextItem: function( selectedIndex ) {
-		var nextIndex = selectedIndex + 1;
-		if ( nextIndex > -1 && nextIndex < this.postKeys.length ) {
-			if ( this._isValidPostOrGap( this.postKeys[ nextIndex ] ) ) {
-				this.selectedIndex = nextIndex;
-				this.emit( 'change' );
-			} else {
-				this.selectNextItem( nextIndex );
-			}
+	selectNextItem: function( ) {
+		if ( this.selectedIndex == null ) {
+			return;
 		}
+		let nextIndex = this.selectedIndex + 1;
+		const numPosts = this.postKeys.length;
+		while ( nextIndex < numPosts && ! this._isValidPostOrGap( this.postKeys[ nextIndex ] ) ) {
+			nextIndex++;
+		}
+
+		if ( nextIndex === numPosts ) {
+			return;
+		}
+
+		this.selectedIndex = nextIndex;
+		this.emitChange();
 	},
 
-	selectPrevItem: function( selectedIndex ) {
-		var nextIndex = selectedIndex - 1;
-		if ( nextIndex > -1 && nextIndex < this.postKeys.length ) {
-			if ( this._isValidPostOrGap( this.postKeys[ nextIndex ] ) ) {
-				this.selectedIndex = nextIndex;
-				this.emit( 'change' );
-			} else {
-				this.selectPrevItem( nextIndex );
-			}
+	selectPrevItem: function() {
+		if ( ! this.selectedIndex ) {
+			return;
 		}
+		let nextIndex = this.selectedIndex - 1;
+		while ( nextIndex >= 0 && ! this._isValidPostOrGap( this.postKeys[ nextIndex ] ) ) {
+			nextIndex--;
+		}
+
+		this.selectedIndex = nextIndex;
+		this.emitChange();
 	},
 
 	selectItem: function( selectedIndex ) {
-		this.selectNextItem( selectedIndex - 1 );
+		if ( selectedIndex >= 0 &&
+			selectedIndex < this.postKeys.length &&
+			this._isValidPostOrGap( this.postKeys[ selectedIndex ] ) ) {
+			this.selectedIndex = selectedIndex;
+			this.emit( 'change' );
+		}
 	},
 
 	getLastItemWithDate: function() {

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -4,6 +4,8 @@
 var assign = require( 'lodash/assign' ),
 	debug = require( 'debug' )( 'calypso:feed-store:post-list-store' ),
 	filter = require( 'lodash/filter' ),
+	findIndex = require( 'lodash/findIndex' ),
+	findLastIndex = require( 'lodash/findLastIndex' ),
 	forEach = require( 'lodash/forEach' ),
 	map = require( 'lodash/map' ),
 	moment = require( 'moment' ),
@@ -176,34 +178,25 @@ assign( FeedStream.prototype, {
 	},
 
 	selectNextItem: function( ) {
-		if ( this.selectedIndex == null ) {
+		if ( this.selectedIndex === -1 ) {
 			return;
 		}
-		let nextIndex = this.selectedIndex + 1;
-		const numPosts = this.postKeys.length;
-		while ( nextIndex < numPosts && ! this._isValidPostOrGap( this.postKeys[ nextIndex ] ) ) {
-			nextIndex++;
+		const nextIndex = findIndex( this.postKeys, this._isValidPostOrGap, this.selectedIndex + 1 );
+		if ( nextIndex !== -1 ) {
+			this.selectedIndex = nextIndex;
+			this.emitChange();
 		}
-
-		if ( nextIndex === numPosts ) {
-			return;
-		}
-
-		this.selectedIndex = nextIndex;
-		this.emitChange();
 	},
 
 	selectPrevItem: function() {
-		if ( ! this.selectedIndex ) {
+		if ( this.selectedIndex < 1 ) { // this also captures a selectedIndex of 0, and that's intentional
 			return;
 		}
-		let nextIndex = this.selectedIndex - 1;
-		while ( nextIndex >= 0 && ! this._isValidPostOrGap( this.postKeys[ nextIndex ] ) ) {
-			nextIndex--;
+		const prevIndex = findLastIndex( this.postKeys, this._isValidPostOrGap, this.selectedIndex - 1 );
+		if ( prevIndex !== -1 ) {
+			this.selectedIndex = prevIndex;
+			this.emitChange();
 		}
-
-		this.selectedIndex = nextIndex;
-		this.emitChange();
 	},
 
 	selectItem: function( selectedIndex ) {

--- a/client/lib/feed-stream-store/test/index.js
+++ b/client/lib/feed-stream-store/test/index.js
@@ -125,7 +125,7 @@ describe( 'FeedPostList', function() {
 	} );
 
 	describe( 'Selected index', function() {
-		var fetcherStub, store, feedPostStoreStub;
+		var fetcherStub, store, feedPostStoreStub, fakePosts;
 		beforeEach( function() {
 			fetcherStub = sinon.stub();
 			feedPostStoreStub = sinon.stub( FeedPostStore, 'get' );
@@ -136,12 +136,13 @@ describe( 'FeedPostList', function() {
 					return post;
 				}
 			} );
-			store.receivePage( 'test', null, { posts: [
+			fakePosts = [
 				{ feed_ID: 1, ID: 1 },
 				{ feed_ID: 1, ID: 2 },
 				{ feed_ID: 1, ID: 3 },
-				{ feed_ID: 1, ID: 4 } ]
-			} );
+				{ feed_ID: 1, ID: 4 }
+			];
+			store.receivePage( 'test', null, { posts: fakePosts } );
 		} );
 		afterEach( function() {
 			FeedPostStore.get.restore();
@@ -154,41 +155,50 @@ describe( 'FeedPostList', function() {
 
 		it( 'should select the next item', function() {
 			feedPostStoreStub.returns( {} );
-			store.selectNextItem( -1 );
-			expect( store.getSelectedIndex() ).to.equal( 0 );
+			store.selectItem( 0 );
+			store.selectNextItem();
+			expect( store.getSelectedIndex() ).to.equal( 1 );
 		} );
 
 		it( 'should select the next valid post', function() {
 			feedPostStoreStub
-				.onCall( 0 ).returns( { _state: 'error'} )
-				.onCall( 1 ).returns( { _state: 'minimal' } )
-				.onCall( 2 ).returns( {} )
-				.onCall( 3 ).returns( {} );
-			store.selectNextItem( -1 );
-			expect( store.getSelectedIndex() ).to.equal( 2 );
+				.onCall( 0 ).returns( {} )
+				.onCall( 1 ).returns( { _state: 'error'} )
+				.onCall( 2 ).returns( { _state: 'minimal' } )
+				.onCall( 3 ).returns( {} )
+				.onCall( 4 ).returns( {} );
+			store.selectItem( 0 );
+			store.selectNextItem();
+			expect( store.getSelectedIndex() ).to.equal( 3 );
 		} );
 
 		it( 'should be able to select a gap', function() {
+			fakePosts[1].isGap = true;
 			feedPostStoreStub
 				.onCall( 0 ).returns( { _state: 'error'} )
-				.onCall( 1 ).returns( { isGap: true } )
+				.onCall( 1 ).returns( {} )
 				.onCall( 2 ).returns( {} )
 				.onCall( 3 ).returns( {} );
-			store.selectNextItem( -1 );
+			store.selectItem( 1 );
 			expect( store.getSelectedIndex() ).to.equal( 1 );
 		} );
 
 		it( 'should select the prev item', function() {
 			feedPostStoreStub.returns( {} );
-			store.selectPrevItem( 3 );
+			store.selectItem( 3 );
+			expect( store.getSelectedIndex() ).to.equal( 3 );
+			store.selectPrevItem();
 			expect( store.getSelectedIndex() ).to.equal( 2 );
 		} );
 
 		it( 'should select the prev valid post', function() {
 			feedPostStoreStub
-				.onCall( 0 ).returns( { _state: 'error' } )
-				.onCall( 1 ).returns( {} );
-			store.selectPrevItem( 3 );
+				.onCall( 0 ).returns( {} )
+				.onCall( 1 ).returns( { _state: 'error' } )
+				.onCall( 2 ).returns( {} );
+			store.selectItem( 3 );
+			expect( store.getSelectedIndex() ).to.equal( 3 );
+			store.selectPrevItem();
 			expect( store.getSelectedIndex() ).to.equal( 1 );
 		} );
 	} );

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -151,7 +151,7 @@ module.exports = {
 			recommendationsStore = feedStreamFactory( 'recommendations_posts' ),
 			mcKey = 'following';
 
-		recommendationsStore.perPage = 2;
+		recommendationsStore.perPage = 4;
 
 		ensureStoreLoading( followingStore, context );
 

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -148,7 +148,10 @@ module.exports = {
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Following',
 			followingStore = feedStreamFactory( 'following' ),
+			recommendationsStore = feedStreamFactory( 'recommendations_posts' ),
 			mcKey = 'following';
+
+		recommendationsStore.perPage = 2;
 
 		ensureStoreLoading( followingStore, context );
 
@@ -163,6 +166,7 @@ module.exports = {
 					key: 'following',
 					listName: i18n.translate( 'Followed Sites' ),
 					store: followingStore,
+					recommendationsStore,
 					showPrimaryFollowButtonOnCards: false,
 					trackScrollPage: trackScrollPage.bind(
 						null,

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -10,6 +10,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import config from 'config';
 import { abtest } from 'lib/abtest';
 import route from 'lib/route';
 import feedStreamFactory from 'lib/feed-stream-store';
@@ -148,10 +149,13 @@ module.exports = {
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Following',
 			followingStore = feedStreamFactory( 'following' ),
-			recommendationsStore = feedStreamFactory( 'recommendations_posts' ),
 			mcKey = 'following';
 
-		recommendationsStore.perPage = 4;
+		let recommendationsStore = null;
+		if ( config.isEnabled( 'reader/refresh/stream' ) ) {
+			recommendationsStore = feedStreamFactory( 'recommendations_posts' );
+			recommendationsStore.perPage = 4;
+		}
 
 		ensureStoreLoading( followingStore, context );
 

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -393,3 +393,32 @@
 	font-size: 12px;
 	line-height: 1;
 }
+
+.reader-stream__recommendation-block {
+	margin: 20px 0;
+	border-bottom: 1px solid lighten( $gray, 30% );
+}
+
+.reader-stream__recommendation-block-posts {
+	display: flex;
+	flex-direction: row;
+}
+
+.reader-stream__recommendation-block-header {
+	color: lighten( $gray, 10% );
+	font-weight: 400;
+	text-transform: uppercase;
+	margin-top: -12px;
+	.gridicon {
+		fill: lighten( $gray, 10% );
+		position: relative;
+			top: 5px;
+	}
+}
+
+.reader-stream__recommendation-block-posts .reader-related-card-v2 {
+	margin: 16px 0;
+	&:first-child {
+		margin-right: 30px;
+	}
+}

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -464,7 +464,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.reader-related-card-v2__post {
-		max-height: 125px;
+		max-height: 200px;
 
 		&::after {
 			@include long-content-fade( $size: 30% );

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -394,21 +394,24 @@
 	line-height: 1;
 }
 
-.reader-stream__recommendation-block {
-	margin: 20px 0;
-	border-bottom: 1px solid lighten( $gray, 30% );
-}
+// In-stream Recommendations
 
-.reader-stream__recommendation-block-posts {
-	display: flex;
-	flex-direction: row;
+// Custom breakpoints needed to match Related Posts
+
+$reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
+$reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
+
+.reader-stream__recommendation-block {
+	border-bottom: 1px solid lighten( $gray, 30% );
+	margin: 18px 0 0;
 }
 
 .reader-stream__recommendation-block-header {
 	color: lighten( $gray, 10% );
 	font-weight: 400;
 	text-transform: uppercase;
-	margin-top: -12px;
+	margin-top: -11px;
+
 	.gridicon {
 		fill: lighten( $gray, 10% );
 		position: relative;
@@ -416,9 +419,59 @@
 	}
 }
 
+.reader-stream__recommendation-block-posts {
+	display: flex;
+	flex-direction: row;
+
+	@media #{$reader-related-card-v2-breakpoint-medium} {
+		flex-direction: column;
+	}
+
+	@include breakpoint( "<660px" ) {
+		flex-direction: row;
+	}
+
+	@media #{$reader-related-card-v2-breakpoint-small} {
+		flex-direction: column;
+	}
+}
+
 .reader-stream__recommendation-block-posts .reader-related-card-v2 {
 	margin: 16px 0;
+
 	&:first-child {
 		margin-right: 30px;
+	}
+}
+
+.reader-stream__recommendation-block {
+
+	.reader-related-card-v2__featured-image {
+		border: 1px solid lighten( $gray, 20% );
+		margin: 5px 0 17px;
+	}
+
+	.reader-related-card-v2__meta {
+		margin-bottom: 13px;
+	}
+
+	.reader-related-card-v2__site-info {
+		margin-top: 2px;
+	}
+
+	.reader-related-card-v2__meta .gravatar {
+		margin: 2px 8px 0 0;
+	}
+
+	.reader-related-card-v2__post {
+		max-height: 125px;
+
+		&::after {
+			@include long-content-fade( $size: 30% );
+			bottom: 0;
+			height: 22px;
+			top: inherit;
+			visibility: visible;
+		}
 	}
 }

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -401,12 +401,12 @@
 $reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
 $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
-.reader-stream__recommendation-block {
+.reader-stream__recommended-posts {
 	border-bottom: 1px solid lighten( $gray, 30% );
 	margin: 18px 0 0;
 }
 
-.reader-stream__recommendation-block-header {
+.reader-stream__recommended-posts-header {
 	color: lighten( $gray, 10% );
 	font-weight: 400;
 	text-transform: uppercase;
@@ -419,7 +419,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 }
 
-.reader-stream__recommendation-block-posts {
+.reader-stream__recommended-posts-posts {
 	display: flex;
 	flex-direction: row;
 
@@ -436,7 +436,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 }
 
-.reader-stream__recommendation-block-posts .reader-related-card-v2 {
+.reader-stream__recommended-posts-posts .reader-related-card-v2 {
 	margin: 16px 0;
 
 	&:first-child {
@@ -444,7 +444,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 }
 
-.reader-stream__recommendation-block {
+.reader-stream__recommended-posts {
 
 	.reader-related-card-v2__featured-image {
 		border: 1px solid lighten( $gray, 20% );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -448,7 +448,7 @@ export default class ReaderStream extends React.Component {
 		}
 
 		if ( postKey.isRecommendationBlock ) {
-			return <RecommendationBlock recommendations={ postKey.recommendations } key={ `recs-${ index }`} />;
+			return <RecommendationBlock recommendations={ postKey.recommendations } key={ `recs-${ index }` } />;
 		}
 
 		const itemKey = this.getPostRef( postKey );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -4,7 +4,7 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import classnames from 'classnames';
-import { defer, map, noop, times } from 'lodash';
+import { defer, noop, times } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,7 +16,6 @@ import DISPLAY_TYPES from 'lib/feed-post-store/display-types';
 import EmptyContent from './empty';
 import FeedStreamStoreActions from 'lib/feed-stream-store/actions';
 import FeedstoreActions from 'lib/feed-post-store/actions';
-import Gridicon from 'components/gridicon';
 import ListGap from 'reader/list-gap';
 import LikeStore from 'lib/like-store/like-store';
 import LikeStoreActions from 'lib/like-store/actions';
@@ -30,13 +29,12 @@ import page from 'page';
 import PostUnavailable from './post-unavailable';
 import PostPlaceholder from './post-placeholder';
 import PostStore from 'lib/feed-post-store';
-import SiteStore from 'lib/reader-site-store';
 import UpdateNotice from 'reader/update-notice';
 import PostBlocked from './post-blocked';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import scrollTo from 'lib/scroll-to';
 import XPostHelper from 'reader/xpost-helper';
-import { RelatedPostCard } from 'blocks/reader-related-card-v2';
+import RecommendationBlock from './recommendation-block';
 
 const GUESSED_POST_HEIGHT = 600;
 const HEADER_OFFSET_TOP = 46;
@@ -435,20 +433,7 @@ export default class ReaderStream extends React.Component {
 		}
 
 		if ( postKey.isRecommendationBlock ) {
-			return (
-				<div className="reader-stream__recommendation-block" key={ `recommendation-${ index }` }>
-					<h5 className="reader-stream__recommendation-block-header"><Gridicon icon="star" /> Recommended Posts</h5>
-					<div className="reader-stream__recommendation-block-posts">
-					{
-						map( postKey.recommendations, postKey => {
-							const post = PostStore.get( postKey );
-							const site = SiteStore.get( postKey.blogId );
-							return post && <RelatedPostCard key={ post.global_ID } post={ post } site={ site } />;
-						}	)
-					}
-					</div>
-				</div>
-			);
+			return <RecommendationBlock recommendations={ postKey.recommendations } key={ `recs-${ index }`} />;
 		}
 
 		const post = PostStore.get( postKey );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -72,10 +72,17 @@ function getDistanceBetweenRecs() {
 	// This lets the distance between recs grow quickly as you add subs early on, and slow down as you
 	// become a common user of the reader.
 	const totalSubs = FeedSubscriptionStore.getTotalSubscriptions();
-	return clamp(
+	if ( totalSubs <= 0 ) {
+		// 0 means either we don't know yet, or the user actually has zero subs.
+		// if a user has zero subs, we don't show posts at all, so just treat 0 as 'unknown' and
+		// push recs to the max.
+		return MAX_DISTANCE_BETWEEN_RECS;
+	}
+	const distance = clamp(
 		Math.floor( ( Math.log( totalSubs ) * Math.LOG2E * 5 ) - 6 ),
 		MIN_DISTANCE_BETWEEN_RECS,
 		MAX_DISTANCE_BETWEEN_RECS );
+	return distance;
 }
 
 function injectRecommendations( posts, recs = [] ) {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -4,7 +4,7 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import classnames from 'classnames';
-import { defer, lastIndexOf, noop, times } from 'lodash';
+import { defer, flatMap, lastIndexOf, noop, times } from 'lodash';
 
 /**
  * Internal dependencies
@@ -91,19 +91,22 @@ function injectRecommendations( posts, recs = [] ) {
 		return posts;
 	}
 
-	const items = [];
+	let recIndex = 0;
 
-	for ( let postIndex = 0, recIndex = 0; postIndex < posts.length; postIndex += itemsBetweenRecs, recIndex += RECS_PER_BLOCK ) {
-		items.push.apply( items, posts.slice( postIndex, postIndex + itemsBetweenRecs ) );
-		// only insert recs if we have them and if we filled a full block of posts
-		if ( recIndex < recs.length && postIndex + itemsBetweenRecs < posts.length ) {
-			items.push( {
+	return flatMap( posts, ( post, index ) => {
+		if ( index && index % itemsBetweenRecs === 0 && recIndex < recs.length ) {
+			const recBlock = {
 				isRecommendationBlock: true,
 				recommendations: recs.slice( recIndex, recIndex + RECS_PER_BLOCK )
-			} );
+			};
+			recIndex += RECS_PER_BLOCK;
+			return [
+				recBlock,
+				post
+			];
 		}
-	}
-	return items;
+		return post;
+	} );
 }
 
 export default class ReaderStream extends React.Component {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -4,7 +4,7 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import classnames from 'classnames';
-import { defer, flatMap, lastIndexOf, noop, times } from 'lodash';
+import { defer, flatMap, lastIndexOf, noop, times, clamp } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,12 +72,10 @@ function getDistanceBetweenRecs() {
 	// This lets the distance between recs grow quickly as you add subs early on, and slow down as you
 	// become a common user of the reader.
 	const totalSubs = FeedSubscriptionStore.getTotalSubscriptions();
-	return Math.min(
-		MAX_DISTANCE_BETWEEN_RECS,
-		Math.max(
-			( Math.log( totalSubs ) * Math.LOG2E * 5 ) - 6,
-			MIN_DISTANCE_BETWEEN_RECS )
-			);
+	return clamp(
+		Math.floor( ( Math.log( totalSubs ) * Math.LOG2E * 5 ) - 6 ),
+		MIN_DISTANCE_BETWEEN_RECS,
+		MAX_DISTANCE_BETWEEN_RECS );
 }
 
 function injectRecommendations( posts, recs = [] ) {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -32,7 +32,7 @@ import PostBlocked from './post-blocked';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import scrollTo from 'lib/scroll-to';
 import XPostHelper from 'reader/xpost-helper';
-import RecommendationBlock from './recommendation-block';
+import RecommendedPosts from './recommended-posts';
 import PostLifecycle from './post-lifecycle';
 import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
 
@@ -474,7 +474,7 @@ export default class ReaderStream extends React.Component {
 		}
 
 		if ( postKey.isRecommendationBlock ) {
-			return <RecommendationBlock recommendations={ postKey.recommendations } key={ `recs-${ index }` } />;
+			return <RecommendedPosts recommendations={ postKey.recommendations } key={ `recs-${ index }` } />;
 		}
 
 		const itemKey = this.getPostRef( postKey );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -458,12 +458,13 @@ export default class ReaderStream extends React.Component {
 
 	renderPost = ( postKey, index ) => {
 		const selectedPostKey = this.props.store.getSelectedPost();
-		const isSelected = selectedPostKey &&
+		const isSelected = !! ( selectedPostKey &&
 			selectedPostKey.postId === postKey.postId &&
 			(
 				selectedPostKey.blogId === postKey.blogId ||
 				selectedPostKey.feedId === postKey.feedId
-			);
+			)
+		);
 
 		if ( postKey.isGap ) {
 			return (

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -20,14 +20,19 @@ export default class PostLifecycle extends React.PureComponent {
 	}
 
 	state = {
-		post: PostStore.get( this.props.postKey )
+		post: this.getPostFromStore()
 	}
 
-	updatePost = ( props = this.props ) => {
+	getPostFromStore( props = this.props ) {
 		const post = PostStore.get( props.postKey );
 		if ( ! post || post._state === 'minimal' ) {
 			defer( () => PostStoreActions.fetchPost( props.postKey ) );
 		}
+		return post;
+	}
+
+	updatePost = ( props = this.props ) => {
+		const post = this.getPostFromStore( props );
 		if ( post !== this.state.post ) {
 			this.setState( { post } );
 		}

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -14,7 +14,7 @@ import PostUnavailable from './post-unavailable';
 import CrossPost from './x-post';
 import XPostHelper from 'reader/xpost-helper';
 
-export default class PostSelector extends React.PureComponent {
+export default class PostLifecycle extends React.PureComponent {
 	static propTypes = {
 		postKey: PropTypes.object
 	}
@@ -25,7 +25,7 @@ export default class PostSelector extends React.PureComponent {
 
 	updatePost = ( props = this.props ) => {
 		const post = PostStore.get( props.postKey );
-		if ( post !== ( this.state && this.state.post ) ) {
+		if ( post !== this.state.post ) {
 			this.setState( { post } );
 		}
 		if ( ! post || post._state === 'minimal' ) {

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -25,11 +25,11 @@ export default class PostLifecycle extends React.PureComponent {
 
 	updatePost = ( props = this.props ) => {
 		const post = PostStore.get( props.postKey );
+		if ( ! post || post._state === 'minimal' ) {
+			defer( () => PostStoreActions.fetchPost( props.postKey ) );
+		}
 		if ( post !== this.state.post ) {
 			this.setState( { post } );
-		}
-		if ( ! post || post._state === 'minimal' ) {
-			defer( () => PostStoreActions.fetchPost( this.props.postKey ) );
 		}
 	}
 

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -1,0 +1,86 @@
+/**
+ * External Dependencies
+ */
+import React, { PropTypes } from 'react';
+import { defer } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import PostStore from 'lib/feed-post-store';
+import PostStoreActions from 'lib/feed-post-store/actions';
+import PostPlaceholder from './post-placeholder';
+import PostUnavailable from './post-unavailable';
+import CrossPost from './x-post';
+import XPostHelper from 'reader/xpost-helper';
+
+export default class PostSelector extends React.PureComponent {
+	static propTypes = {
+		postKey: PropTypes.object
+	}
+
+	state = {
+		post: PostStore.get( this.props.postKey )
+	}
+
+	updatePost = ( props = this.props ) => {
+		const post = PostStore.get( props.postKey );
+		if ( post !== ( this.state && this.state.post ) ) {
+			this.setState( { post } );
+		}
+		if ( ! post || post._state === 'minimal' ) {
+			defer( () => PostStoreActions.fetchPost( this.props.postKey ) );
+		}
+	}
+
+	componentWillMount() {
+		PostStore.on( 'change', this.updatePost );
+	}
+
+	componentWillUnmount() {
+		PostStore.off( 'change', this.updatePost );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.updatePost( nextProps );
+	}
+
+	render() {
+		const post = this.state.post;
+		let postState = post._state;
+
+		if ( ! post || postState === 'minimal' ) {
+			postState = 'pending';
+		}
+
+		switch ( postState ) {
+			case 'pending':
+				return <PostPlaceholder />;
+			case 'error':
+				return <PostUnavailable post={ post } />;
+			default:
+				const PostClass = this.props.cardClassForPost( post );
+				if ( PostClass === CrossPost ) {
+					const xMetadata = XPostHelper.getXPostMetadata( post );
+					return <CrossPost
+						post={ post }
+						isSelected={ this.props.isSelected }
+						xMetadata={ xMetadata }
+						xPostedTo={ this.props.store.getSitesCrossPostedTo( xMetadata.commentURL || xMetadata.postURL ) }
+						handleClick={ this.props.handleXPostClick } />;
+				}
+
+				return <PostClass
+					post={ post }
+					isSelected={ this.props.isSelected }
+					xPostedTo={ this.props.store.getSitesCrossPostedTo( post.URL ) }
+					suppressSiteNameLink={ this.props.suppressSiteNameLink }
+					showPostHeader={ this.props.showPostHeader }
+					showFollowInHeader={ this.props.showFollowInHeader }
+					handleClick={ this.props.handleClick }
+					showPrimaryFollowButtonOnCards={ this.props.showPrimaryFollowButtonOnCards }
+					showSiteName={ this.props.showSiteName }
+				/>;
+		}
+	}
+}

--- a/client/reader/stream/recommendation-block.jsx
+++ b/client/reader/stream/recommendation-block.jsx
@@ -1,0 +1,48 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { map, some } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { RelatedPostCard } from 'blocks/reader-related-card-v2';
+import PostStore from 'lib/feed-post-store';
+import Gridicon from 'components/gridicon';
+
+export default class RecommendationBlock extends React.PureComponent {
+	state = {
+		posts: map( this.props.recommendations, PostStore.get.bind( PostStore ) )
+	}
+
+	updatePosts = ( props = this.props ) => {
+		const posts = map( props.recommendations, PostStore.get.bind( PostStore ) );
+		if ( some( posts, ( post, i ) => post !== this.state.posts[ i ] ) ) {
+			this.setState( posts );
+		}
+	}
+
+	componentWillMount() {
+		PostStore.on( 'change', this.updatePosts );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.updatePosts( nextProps );
+	}
+
+	componentWillUnmount() {
+		PostStore.off( 'change', this.updatePosts );
+	}
+
+	render() {
+		return (
+			<div className="reader-stream__recommendation-block">
+				<h5 className="reader-stream__recommendation-block-header"><Gridicon icon="star" /> Recommended Posts</h5>
+				<div className="reader-stream__recommendation-block-posts">
+					{ map( this.state.posts, post => <RelatedPostCard key={ post.global_ID } post={ post } /> ) }
+				</div>
+			</div>
+		);
+	}
+}

--- a/client/reader/stream/recommendation-block.jsx
+++ b/client/reader/stream/recommendation-block.jsx
@@ -19,7 +19,7 @@ export default class RecommendationBlock extends React.PureComponent {
 	updatePosts = ( props = this.props ) => {
 		const posts = map( props.recommendations, PostStore.get.bind( PostStore ) );
 		if ( some( posts, ( post, i ) => post !== this.state.posts[ i ] ) ) {
-			this.setState( posts );
+			this.setState( { posts } );
 		}
 	}
 

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -11,7 +11,7 @@ import { RelatedPostCard } from 'blocks/reader-related-card-v2';
 import PostStore from 'lib/feed-post-store';
 import Gridicon from 'components/gridicon';
 
-export default class RecommendationBlock extends React.PureComponent {
+export default class RecommendedPosts extends React.PureComponent {
 	state = {
 		posts: map( this.props.recommendations, PostStore.get.bind( PostStore ) )
 	}
@@ -37,9 +37,9 @@ export default class RecommendationBlock extends React.PureComponent {
 
 	render() {
 		return (
-			<div className="reader-stream__recommendation-block">
-				<h5 className="reader-stream__recommendation-block-header"><Gridicon icon="star" /> Recommended Posts</h5>
-				<div className="reader-stream__recommendation-block-posts">
+			<div className="reader-stream__recommended-posts">
+				<h5 className="reader-stream__recommended-posts-header"><Gridicon icon="star" /> Recommended Posts</h5>
+				<div className="reader-stream__recommended-posts-posts">
 					{ map( this.state.posts, post => <RelatedPostCard key={ post.global_ID } post={ post } /> ) }
 				</div>
 			</div>

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { map, some } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -10,8 +11,9 @@ import { map, some } from 'lodash';
 import { RelatedPostCard } from 'blocks/reader-related-card-v2';
 import PostStore from 'lib/feed-post-store';
 import Gridicon from 'components/gridicon';
+import * as stats from 'reader/stats';
 
-export default class RecommendedPosts extends React.PureComponent {
+export class RecommendedPosts extends React.PureComponent {
 	state = {
 		posts: map( this.props.recommendations, PostStore.get.bind( PostStore ) )
 	}
@@ -21,6 +23,16 @@ export default class RecommendedPosts extends React.PureComponent {
 		if ( some( posts, ( post, i ) => post !== this.state.posts[ i ] ) ) {
 			this.setState( { posts } );
 		}
+	}
+
+	handlePostClick = ( post ) => {
+		stats.recordTrackForPost( 'calypso_reader_in_stream_rec_post_clicked', post );
+		stats.recordAction( 'in_stream_rec_post_click' );
+	}
+
+	handleSiteClick = ( post ) => {
+		stats.recordTrackForPost( 'calypso_reader_in_stream_rec_site_clicked', post );
+		stats.recordAction( 'in_stream_rec_site_click' );
 	}
 
 	componentWillMount() {
@@ -38,11 +50,18 @@ export default class RecommendedPosts extends React.PureComponent {
 	render() {
 		return (
 			<div className="reader-stream__recommended-posts">
-				<h5 className="reader-stream__recommended-posts-header"><Gridicon icon="star" /> Recommended Posts</h5>
+				<h5 className="reader-stream__recommended-posts-header"><Gridicon icon="star" />&nbsp;{ this.props.translate( 'Recommended Posts' ) }</h5>
 				<div className="reader-stream__recommended-posts-posts">
-					{ map( this.state.posts, post => <RelatedPostCard key={ post.global_ID } post={ post } /> ) }
+					{
+						map(
+							this.state.posts,
+							post => <RelatedPostCard key={ post.global_ID } post={ post } onPostClick={ this.handlePostClick } onSiteClick={ this.handleSiteClick } />
+						)
+					}
 				</div>
 			</div>
 		);
 	}
 }
+
+export default localize( RecommendedPosts );


### PR DESCRIPTION
This adds in-stream recommendations to the refreshed reader following stream. 

Things to test:
- [x] Keyboard shortcuts. Next (`j`) and Previous (`k`) should skip recommendation blocks.
- [x] The distance between recs should increase as you subscribe to more things. It grows quickly at first, but slows down as you add more subs. Yay math.
- [x] Test all the streams, both in the refresh and out of it. This is a pretty major refactor of how the post lifecycle works. 

Fixes #9194 