### PR TITLE
Domain Suggestions Flag: Don't show flag for subdomains

### DIFF
--- a/client/components/domains/domain-suggestion-flag/index.jsx
+++ b/client/components/domains/domain-suggestion-flag/index.jsx
@@ -10,28 +10,24 @@ import { localize } from 'i18n-calypso';
  */
 import Notice from 'components/notice';
 
-class DomainSuggestionFlag extends React.Component {
-	render() {
-		const newTLDs = [ 'blog' ];
+function DomainSuggestionFlag( { domain, translate } ) {
+	const newTLDs = [ 'blog' ];
 
-		if ( newTLDs.some( ( tld ) => {
-			return endsWith( this.props.domain, tld );
-		} ) ) {
-			return (
-				<Notice
-					isCompact
-					status="is-success">
-					{ this.props.translate( 'New', { context: 'Domain suggestion flag' } ) }
-				</Notice>
-			);
-		}
+	if ( newTLDs.some( ( tld ) => {
+		const isSubdomain = domain.substring( 0, domain.length - ( tld.length + 1 ) ).indexOf( '.' ) > -1;
 
-		return null;
+		return endsWith( domain, tld ) && ! isSubdomain;
+	} ) ) {
+		return (
+			<Notice
+				isCompact
+				status="is-success">
+				{ translate( 'New', { context: 'Domain suggestion flag' } ) }
+			</Notice>
+		);
 	}
-}
 
-DomainSuggestionFlag.propTypes = {
-	domain: React.PropTypes.string.isRequired
-};
+	return null;
+}
 
 export default localize( DomainSuggestionFlag );

--- a/client/components/domains/domain-suggestion-flag/index.jsx
+++ b/client/components/domains/domain-suggestion-flag/index.jsx
@@ -13,11 +13,9 @@ import Notice from 'components/notice';
 function DomainSuggestionFlag( { domain, translate } ) {
 	const newTLDs = [ 'blog' ];
 
-	if ( newTLDs.some( ( tld ) => {
-		const isSubdomain = domain.substring( 0, domain.length - ( tld.length + 1 ) ).indexOf( '.' ) > -1;
-
-		return endsWith( domain, tld ) && ! isSubdomain;
-	} ) ) {
+	if ( newTLDs.some(
+		( tld ) => endsWith( domain, tld ) && domain.substring( 0, domain.length - ( tld.length + 1 ) ).indexOf( '.' ) === -1
+	) ) {
 		return (
 			<Notice
 				isCompact


### PR DESCRIPTION
The suggestion engine never returns subdomains. So something.test.blog shouldn't be treated as new. Only something.blow is new.

Change component to functional, as it's stateless.