### PR TITLE
Hide slide-in search bar overflow

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -377,6 +377,9 @@
 
 // -------- Search --------
 .section-nav {
+	.search {
+		overflow: hidden;
+	}
 	@include breakpoint( "<480px" ) {
 		.search.is-expanded-to-container {
 			height: 46px;


### PR DESCRIPTION
Hidden the search overflow in `<SectionNav>` to prevent it to appear outside the nav box.
Not sure if it was intended, though.

Before:
![sectionnavsearch_before](https://cloud.githubusercontent.com/assets/2070010/20412425/5e682b46-ad05-11e6-814f-44f081e94da5.gif)

After:
![sectionnavsearch_after](https://cloud.githubusercontent.com/assets/2070010/20412426/5e6c322c-ad05-11e6-810b-4e8d18db66dd.gif)

I can provide much, much faster gifs if you want to party hard tonight.