### PR TITLE
Reader Refresh: Search container page

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -6,6 +6,14 @@ $reader-post-card-breakpoint-large: "( min-width: 961px ) and ( max-width: 1040p
 $reader-post-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 940px )";
 $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
+// Overrides 30px top margin, moves first card closer to top of stream
+.is-reader-page .following.main .card.reader-post-card:nth-child(2) {
+	
+	@include breakpoint( ">480px" ) {
+		margin-top: -18px;
+	}
+}
+
 // Adds a top border to first card in the Site Stream
 .is-reader-page .is-site-stream .reader-post-card.card {
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -6,14 +6,6 @@ $reader-post-card-breakpoint-large: "( min-width: 961px ) and ( max-width: 1040p
 $reader-post-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 940px )";
 $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
-// Overrides 30px top margin, moves first card closer to top of stream
-.is-reader-page .following.main .card.reader-post-card:nth-child(2) {
-
-	@include breakpoint( ">480px" ) {
-		margin-top: -18px;
-	}
-}
-
 // Adds a top border to first card in the Site Stream
 .is-reader-page .is-site-stream .reader-post-card.card {
 

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -84,7 +84,7 @@ function RelatedPostCardPlaceholder() {
 	);
 }
 
-export function RelatedPostCard( { post, site, siteId, lineClamp = 10, onPostClick = noop, onSiteClick = noop } ) {
+export function RelatedPostCard( { post, site, siteId, onPostClick = noop, onSiteClick = noop } ) {
 	if ( ! post || post._state === 'minimal' || post._state === 'pending' ) {
 		return <RelatedPostCardPlaceholder />;
 	}
@@ -97,9 +97,6 @@ export function RelatedPostCard( { post, site, siteId, lineClamp = 10, onPostCli
 	const postClickTracker = partial( onPostClick, post );
 	const siteClickTracker = partial( onSiteClick, post );
 
-	// TODO: is this okay?
-	const style = { WebkitLineClamp: lineClamp };
-
 	return (
 		<Card className={ classes }>
 			{ siteId && ! site && <QueryReaderSite siteId={ siteId } /> }
@@ -110,7 +107,7 @@ export function RelatedPostCard( { post, site, siteId, lineClamp = 10, onPostCli
 						onClick={ postClickTracker } /> }
 					<div className="reader-related-card-v2__site-info">
 						<h1 className="reader-related-card-v2__title">{ post.title }</h1>
-						<div className="reader-related-card-v2__excerpt post-excerpt" style={ style }>
+						<div className="reader-related-card-v2__excerpt post-excerpt">
 							{ featuredImage ? post.short_excerpt : post.better_excerpt_no_html }
 						</div>
 					</div>

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -32,6 +32,7 @@ function AuthorAndSiteFollow( { post, site, onSiteClick } ) {
 	const siteUrl = getStreamUrl( post.feed_ID, post.site_ID );
 	const siteName = ( site && site.title ) || post.site_name;
 	const authorAndSiteAreDifferent = siteName.toLowerCase() !== post.author.name.toLowerCase();
+
 	return (
 		<div className="reader-related-card-v2__meta">
 			<a href={ siteUrl } onClick={ onSiteClick }>
@@ -83,8 +84,7 @@ function RelatedPostCardPlaceholder() {
 	);
 }
 
-export function RelatedPostCard( { post, site, siteId, onPostClick = noop, onSiteClick = noop } ) {
-/* eslint-enable no-unused-vars */
+export function RelatedPostCard( { post, site, siteId, lineClamp = 10, onPostClick = noop, onSiteClick = noop } ) {
 	if ( ! post || post._state === 'minimal' || post._state === 'pending' ) {
 		return <RelatedPostCardPlaceholder />;
 	}
@@ -97,9 +97,12 @@ export function RelatedPostCard( { post, site, siteId, onPostClick = noop, onSit
 	const postClickTracker = partial( onPostClick, post );
 	const siteClickTracker = partial( onSiteClick, post );
 
+	// TODO: is this okay?
+	const style = { WebkitLineClamp: lineClamp };
+
 	return (
 		<Card className={ classes }>
-		{ siteId && ! site && <QueryReaderSite siteId={ siteId } /> }
+			{ siteId && ! site && <QueryReaderSite siteId={ siteId } /> }
 			<AuthorAndSiteFollow post={ post } site={ site } onSiteClick={ siteClickTracker } />
 			<a href={ postLink } className="reader-related-card-v2__post reader-related-card-v2__link-block"
 				onClick={ postClickTracker } >
@@ -107,7 +110,7 @@ export function RelatedPostCard( { post, site, siteId, onPostClick = noop, onSit
 						onClick={ postClickTracker } /> }
 					<div className="reader-related-card-v2__site-info">
 						<h1 className="reader-related-card-v2__title">{ post.title }</h1>
-						<div className="reader-related-card-v2__excerpt post-excerpt">
+						<div className="reader-related-card-v2__excerpt post-excerpt" style={ style }>
 							{ featuredImage ? post.short_excerpt : post.better_excerpt_no_html }
 						</div>
 					</div>

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -443,7 +443,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		overflow : hidden;
 		text-overflow: ellipsis;
 		display: -webkit-box;
-		-webkit-line-clamp: 10;
 		-webkit-box-orient: vertical;
 		max-height: none;
 	}
@@ -507,4 +506,3 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	margin-top: 20px;
 	padding-top: 20px;
 }
-

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -180,7 +180,7 @@ function getStoreForRecommendedPosts( storeId ) {
 		id: storeId,
 		fetcher: fetcher,
 		keyMaker: siteKeyMaker,
-		perPage: 5
+		perPage: 6,
 	} );
 
 	function fetcher( query, callback ) {

--- a/client/reader/search-stream/blank.jsx
+++ b/client/reader/search-stream/blank.jsx
@@ -7,7 +7,6 @@ import React from 'react';
  * Internal Dependencies
  */
 
-// TODO post-refresh: delete this file
 export function BlankContent() {
 	const imgPath = '/calypso/images/drake/drake-404.svg';
 

--- a/client/reader/search-stream/blank.jsx
+++ b/client/reader/search-stream/blank.jsx
@@ -6,38 +6,16 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import { localize } from 'i18n-calypso';
-import Suggestion from './suggestion';
 
-export function BlankContent( { translate, suggestions } ) {
-	let suggest = null;
-	if ( suggestions ) {
-		let sugList = suggestions
-			.map( function( query ) {
-				return (
-					<Suggestion suggestion={ query } />
-				);
-			} );
-		sugList = sugList
-			.slice( 1 )
-			.reduce( function( xs, x ) {
-				return xs.concat( [ ', ', x ] );
-			}, [ sugList[ 0 ] ] );
-
-		suggest = (
-			<p className="search-stream__blank-suggestions">
-				{ translate( 'Suggestions: {{suggestions /}}.', { components: { suggestions: sugList } } ) }
-			</p> );
-	}
-
+// TODO post-refresh: delete this file
+export function BlankContent() {
 	const imgPath = '/calypso/images/drake/drake-404.svg';
 
 	return (
 		<div className="search-stream__blank">
-			{ suggest }
 			<img src={ imgPath } width="500" className="empty-content__illustration" />
 		</div>
 	);
 }
 
-export default localize( BlankContent );
+export default BlankContent;

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import ReactDom from 'react-dom';
-import { trim, sampleSize } from 'lodash';
+import { initial, flatMap, trim, sampleSize } from 'lodash';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
 
@@ -34,10 +34,10 @@ function RecommendedPosts( { post, site, } ) {
 	}
 
 	return (
-		<li className="search-stream__recommendation-list-item">
+		<div className="search-stream__recommendation-list-item">
 			<RelatedPostCard key={ post.global_ID } post={ post } site={ site }
 				lineClamp={ 3 } />
-		</li>
+		</div>
 	);
 }
 
@@ -197,12 +197,8 @@ const SearchStream = React.createClass( {
 			searchPlaceholderText = this.props.translate( 'Search billions of WordPress.com posts…' );
 		}
 
-		let sugList = this.state.suggestions.map( ( query ) => <Suggestion suggestion={ query } /> );
-		sugList = sugList
-			.slice( 1 )
-			.reduce( function( xs, x ) {
-				return xs.concat( [ ', ', x ] );
-			}, [ sugList[ 0 ] ] );
+		const sugList = initial( flatMap( this.state.suggestions, query =>
+			[ <Suggestion suggestion={ query } />, ', ' ] ) );
 
 		return (
 			<Stream { ...this.props } store={ store }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -181,7 +181,8 @@ const SearchStream = React.createClass( {
 	},
 
 	cardFactory() {
-		return SearchCardAdapter( ! this.props.query );
+		const isRecommendations = ! this.props.query;
+		return SearchCardAdapter( isRecommendations );
 	},
 
 	render() {

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { initial, flatMap, trim, sampleSize } from 'lodash';
 import closest from 'component-closest';
@@ -28,34 +28,34 @@ import ReaderPostCard from 'blocks/reader-post-card';
 import { RelatedPostCard } from 'blocks/reader-related-card-v2';
 import config from 'config';
 
-function RecommendedPosts( { post, site, } ) {
+const isRefreshedStream = config.isEnabled( 'reader/refresh/stream' );
+
+function RecommendedPosts( { post, site } ) {
 	if ( ! site ) {
 		site = { title: post.site_name, };
 	}
 
 	return (
-		<div className="search-stream__recommendation-list-item">
-			<RelatedPostCard key={ post.global_ID } post={ post } site={ site }
+		<div className="search-stream__recommendation-list-item" key={ post.global_ID }>
+			<RelatedPostCard post={ post } site={ site }
 				lineClamp={ 3 } />
 		</div>
 	);
 }
 
-const SearchCardAdapter = ( isRecommendations ) => React.createClass( {
-	getInitialState() {
-		return this.getStateFromStores();
-	},
+const SearchCardAdapter = ( isRecommendations ) => class extends Component {
+	state = this.getStateFromStores();
 
 	getStateFromStores( props = this.props ) {
 		return {
 			site: SiteStore.get( props.post.site_ID ),
 			feed: props.post.feed_ID ? FeedStore.get( props.post.feed_ID ) : null
 		};
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		this.setState( this.getStateFromStores( nextProps ) );
-	},
+	}
 
 	onCardClick( props, event ) {
 		if ( event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
@@ -77,19 +77,18 @@ const SearchCardAdapter = ( isRecommendations ) => React.createClass( {
 
 		event.preventDefault();
 		this.props.handleClick( this.props.post, {} );
-	},
+	}
 
 	onRefreshCardClick( post ) {
 		recordTrackForPost( 'calypso_reader_searchcard_clicked', this.props.post );
 		this.props.handleClick( post, {} );
-	},
+	}
 
 	onCommentClick() {
 		this.props.handleClick( this.props.post, { comments: true } );
-	},
+	}
 
 	render() {
-		const isRefreshedStream = config.isEnabled( 'reader/refresh/stream' );
 		let CardComponent;
 
 		if ( ! isRefreshedStream ) {
@@ -109,7 +108,7 @@ const SearchCardAdapter = ( isRecommendations ) => React.createClass( {
 			showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
 		/>;
 	}
-} );
+};
 
 const emptyStore = {
 	get() {
@@ -185,6 +184,17 @@ const SearchStream = React.createClass( {
 		return SearchCardAdapter( isRecommendations );
 	},
 
+	placeholderFactory( { key, ...rest } ) {
+		if ( isRefreshedStream && ! this.props.query ) {
+			return (
+				<div className="search-stream__recommendation-list-item" key={ key }>
+					<RelatedPostCard { ...rest } />
+				</div>
+			);
+		}
+		return null;
+	},
+
 	render() {
 		const blankContent = this.props.showBlankContent ? <BlankContent suggestions={ this.state.suggestions } /> : null;
 		const emptyContent = this.props.query
@@ -208,6 +218,7 @@ const SearchStream = React.createClass( {
 				showDefaultEmptyContentIfMissing={ this.props.showBlankContent }
 				showFollowInHeader={ true }
 				cardFactory={ this.cardFactory }
+				placeholderFactory={ this.placeholderFactory }
 				className="search-stream" >
 				{ this.props.showBack && <HeaderBack /> }
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) } ) } />

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -221,20 +221,21 @@ const SearchStream = React.createClass( {
 				className="search-stream" >
 				{ this.props.showBack && <HeaderBack /> }
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) } ) } />
-				<CompactCard className="search-stream__input-card">
-					<SearchInput
-						initialValue={ this.props.query }
-						onSearch={ this.updateQuery }
-						autoFocus={ ! this.props.query }
-						delaySearch={ true }
-						delayTimeout={ 500 }
-						placeholder={ searchPlaceholderText } />
-				</CompactCard>
-				{ ! this.props.query && (
+				<div className="search-stream__fixed-area">
+					<CompactCard className="search-stream__input-card">
+						<SearchInput
+							initialValue={ this.props.query }
+							onSearch={ this.updateQuery }
+							autoFocus={ ! this.props.query }
+							delaySearch={ true }
+							delayTimeout={ 500 }
+							placeholder={ searchPlaceholderText } />
+					</CompactCard>
 					<p className="search-stream__blank-suggestions">
 						{ this.props.translate( 'Suggestions: {{suggestions /}}.', { components: { suggestions: sugList } } ) }
 					</p>
-				) }
+					<hr className="search-stream__fixed-area-separator" />
+				</div>
 			</Stream>
 		);
 	}

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -37,8 +37,7 @@ function RecommendedPosts( { post, site } ) {
 
 	return (
 		<div className="search-stream__recommendation-list-item" key={ post.global_ID }>
-			<RelatedPostCard post={ post } site={ site }
-				lineClamp={ 3 } />
+			<RelatedPostCard post={ post } site={ site } />
 		</div>
 	);
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -24,8 +24,8 @@
  .is-reader-page .search-stream__recommendation-list-item {
 	 flex-basis: 30%;
 	 flex-grow: 0.5;
-	 margin-right: 45px; // TODO this isn't right
-	 padding-bottom: 10px; // TODO neither is this
+	 margin-right: 45px;
+	 padding-bottom: 10px;
 	 display: flex;
 	 list-style-type: none;
 	 border-top: 1px solid lighten( $gray, 20% );

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -9,7 +9,7 @@
 }
 
 .is-reader-page .search-stream__input-card.card {
-	box-shadow: 0 0 0 2px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+	box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
  }
 
  .is-reader-page .search-stream .reader__content {
@@ -18,7 +18,7 @@
  }
 
 .is-reader-page .search-stream__recommendation-list-item:nth-child(odd) {
-	margin-right: 0px; 
+	margin-right: 0px;
  }
 
  .is-reader-page .search-stream__recommendation-list-item {
@@ -28,7 +28,7 @@
 	 padding-bottom: 10px; // TODO neither is this
 	 display: flex;
 	 list-style-type: none;
-	 border-top: 1px solid #c8d7e1;
+	 border-top: 1px solid lighten( $gray, 20% );
 	 padding-top: 2px; // this seems to be necessary to create the line above
  }
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -8,6 +8,28 @@
 	margin: 0;
 }
 
+.search-stream__fixed-area-separator {
+	margin-top: 31px;
+	margin-bottom: 0;
+}
+
+.is-reader-page .search-stream .reader-post-card.card {
+	width: 100%;
+}
+
+.is-reader-page .search-stream__fixed-area {
+	background-color: $white;
+	position: fixed;
+	top: 0px;
+	padding-top: 75px;
+	z-index: 20;
+	width: 830px;
+}
+
+.is-reader-page .search-stream .reader__content {
+	padding-top: 100px;
+}
+
 .is-reader-page .search-stream__input-card.card {
 	box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
  }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -17,6 +17,14 @@
 	 flex-wrap: wrap;
  }
 
+ .search-stream  .reader-related-card-v2__title {
+	 padding-top: 15px;
+ }
+
+ .is-reader-page .search-stream__blank-suggestions {
+	 margin-bottom: -15px;
+ }
+
 .is-reader-page .search-stream__recommendation-list-item:nth-child(odd) {
 	margin-right: 0px;
  }
@@ -25,11 +33,11 @@
 	 flex-basis: 30%;
 	 flex-grow: 0.5;
 	 margin-right: 45px;
-	 padding-bottom: 10px;
 	 display: flex;
 	 list-style-type: none;
 	 border-top: 1px solid lighten( $gray, 20% );
-	 padding-top: 2px; // this seems to be necessary to create the line above
+	 padding-top: 14px;
+	 padding-bottom: 12px;
  }
 
 .search-stream__input-card.card {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -4,6 +4,15 @@
 	}
 }
 
+// Overrides top margin, moves first card closer to top of stream
+.is-reader-page .following.main.search-stream .card.reader-post-card:nth-child(2) {
+
+	@include breakpoint( ">480px" ) {
+		margin-top: -4px;
+	}
+}
+
+
 .search-stream .search {
 	margin: 0;
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -8,6 +8,30 @@
 	margin: 0;
 }
 
+.is-reader-page .search-stream__input-card.card {
+	box-shadow: 0 0 0 2px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+ }
+
+ .is-reader-page .search-stream .reader__content {
+	 display: flex;
+	 flex-wrap: wrap;
+ }
+
+.is-reader-page .search-stream__recommendation-list-item:nth-child(odd) {
+	margin-right: 0px; 
+ }
+
+ .is-reader-page .search-stream__recommendation-list-item {
+	 flex-basis: 30%;
+	 flex-grow: 0.5;
+	 margin-right: 45px; // TODO this isn't right
+	 padding-bottom: 10px; // TODO neither is this
+	 display: flex;
+	 list-style-type: none;
+	 border-top: 1px solid #c8d7e1;
+	 padding-top: 2px; // this seems to be necessary to create the line above
+ }
+
 .search-stream__input-card.card {
 	margin-bottom: 16px;
 	padding: 0;

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -12,11 +12,14 @@ import feedStreamFactory from 'lib/feed-stream-store';
 import { recordTrack } from 'reader/stats';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
 import { renderWithReduxStore } from 'lib/react-helpers';
+import config from 'config';
 
 const analyticsPageTitle = 'Reader';
 
 export default {
 	search: function( context ) {
+		const isRefresh = config.isEnabled( 'reader/refresh/stream' );
+
 		var SearchStream = require( 'reader/search-stream' ),
 			basePath = '/read/search',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Search',
@@ -25,9 +28,12 @@ export default {
 
 		let store;
 		if ( searchSlug ) {
-			store = feedStreamFactory( 'search:' + searchSlug ),
-			ensureStoreLoading( store, context );
+			store = feedStreamFactory( 'search:' + searchSlug );
+		} else if ( isRefresh ) {
+			// TODO confirm with greg which feed to actually use...
+			store = feedStreamFactory( 'cold_posts_1w' );
 		}
+		ensureStoreLoading( store, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		if ( searchSlug ) {

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -29,11 +29,12 @@ export default {
 		let store;
 		if ( searchSlug ) {
 			store = feedStreamFactory( 'search:' + searchSlug );
+			ensureStoreLoading( store, context );
 		} else if ( isRefresh ) {
 			// TODO confirm with greg which feed to actually use...
-			store = feedStreamFactory( 'cold_posts_1w' );
+			store = feedStreamFactory( 'recommendations_posts' );
+			ensureStoreLoading( store, context );
 		}
-		ensureStoreLoading( store, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		if ( searchSlug ) {

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -31,7 +31,6 @@ export default {
 			store = feedStreamFactory( 'search:' + searchSlug );
 			ensureStoreLoading( store, context );
 		} else if ( isRefresh ) {
-			// TODO confirm with greg which feed to actually use...
 			store = feedStreamFactory( 'recommendations_posts' );
 			ensureStoreLoading( store, context );
 		}

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -31,7 +31,7 @@ export default {
 			store = feedStreamFactory( 'search:' + searchSlug );
 			ensureStoreLoading( store, context );
 		} else if ( isRefresh ) {
-			store = feedStreamFactory( 'recommendations_posts' );
+			store = feedStreamFactory( 'custom_recs_posts_with_images' );
 			ensureStoreLoading( store, context );
 		}
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -128,7 +128,9 @@ export default class ReaderStream extends React.Component {
 		className: React.PropTypes.string,
 		showDefaultEmptyContentIfMissing: React.PropTypes.bool,
 		showPrimaryFollowButtonOnCards: React.PropTypes.bool,
-		showMobileBackToSidebar: React.PropTypes.bool
+		showMobileBackToSidebar: React.PropTypes.bool,
+		cardFactory: React.PropTypes.func,
+		placeholderFactory: React.PropTypes.func,
 	}
 
 	static defaultProps = {
@@ -419,8 +421,15 @@ export default class ReaderStream extends React.Component {
 		const count = this.state.posts.length ? 2 : this.props.store.getPerPage(),
 			placeholders = [];
 
-		times( count, function( i ) {
-			placeholders.push( <PostPlaceholder key={ 'feed-post-placeholder-' + i } /> );
+		times( count, ( i ) => {
+			let placeholder;
+			if ( this.props.placeholderFactory ) {
+				placeholder = this.props.placeholderFactory( { key: 'feed-post-placeholder-' + i } );
+			}
+			if ( ! placeholder ) {
+				placeholder = <PostPlaceholder key={ 'feed-post-placeholder-' + i } />;
+			}
+			placeholders.push( placeholder );
 		} );
 
 		return placeholders;

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -418,21 +418,14 @@ export default class ReaderStream extends React.Component {
 	}
 
 	renderLoadingPlaceholders = () => {
-		const count = this.state.posts.length ? 2 : this.props.store.getPerPage(),
-			placeholders = [];
+		const count = this.state.posts.length ? 2 : this.props.store.getPerPage();
 
-		times( count, ( i ) => {
-			let placeholder;
+		return times( count, ( i ) => {
 			if ( this.props.placeholderFactory ) {
-				placeholder = this.props.placeholderFactory( { key: 'feed-post-placeholder-' + i } );
+				return this.props.placeholderFactory( { key: 'feed-post-placeholder-' + i } );
 			}
-			if ( ! placeholder ) {
-				placeholder = <PostPlaceholder key={ 'feed-post-placeholder-' + i } />;
-			}
-			placeholders.push( placeholder );
+			return <PostPlaceholder key={ 'feed-post-placeholder-' + i } />;
 		} );
-
-		return placeholders;
 	}
 
 	getPostRef = ( postKey ) => {


### PR DESCRIPTION
This PR aims to implement the [Refreshed Search Page](https://github.com/Automattic/wp-calypso/issues/9106).  For the full details/description of what the refreshed search page is, check out #9106.

Key differences include:
- scrollable recommended posts on the empty search page.  If a search is placed, then Xed out, the recommended posts reappear.
- sticky search bar, so that when you scroll about search is always in view
- 2px border around search bar

Screenshot of how it should look with empty search + recommendations showing:
![empty search screenshot](https://cloud.githubusercontent.com/assets/24388/19951619/811cfc4c-a11c-11e6-97b4-1e73b65f939a.jpg)

Screenshot of search results page:
![after search has been placed](https://cloud.githubusercontent.com/assets/24388/19951680/ebf04664-a11c-11e6-9689-23a78fe4f168.jpg)

In order to test: 
- [ ] make sure that following still looks correct
- [ ] make sure that search looks like the mocks. fixed search behaves appropriately