### PR TITLE
Taxonomy Manager: make Elipsis Menu Click Target Larger.

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -77,14 +77,17 @@ class TaxonomyManagerListItem extends Component {
 					}
 				</span>
 				{ ! isUndefined( postCount ) && <Count count={ postCount } /> }
-				<Gridicon
-					icon="ellipsis"
-					className={ classNames( {
-						'taxonomy-manager__list-item-toggle': true,
-						'is-active': this.state.popoverMenuOpen
-					} ) }
+				<span
+					className="taxonomy-manager__action-wrapper"
 					onClick={ this.togglePopoverMenu }
-					ref="popoverMenuButton" />
+					ref="popoverMenuButton">
+					<Gridicon
+						icon="ellipsis"
+						className={ classNames( {
+							'taxonomy-manager__list-item-toggle': true,
+							'is-active': this.state.popoverMenuOpen
+						} ) } />
+				</span>
 				<PopoverMenu
 					isVisible={ this.state.popoverMenuOpen }
 					onClose={ this.togglePopoverMenu }

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -38,14 +38,17 @@
 	cursor: pointer;
 }
 
-.taxonomy-manager__list-item-toggle {
-	color: $gray;
+.taxonomy-manager__action-wrapper {
 	cursor: pointer;
 	font-size: 24px;
-	margin: 17px 28px;
+	padding: 10px 28px;
 	position: absolute;
 		right: 0;
 		top: 0;
+}
+
+.taxonomy-manager__list-item-toggle {
+	color: $gray;
 	transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
 	&.is-active {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/projects/11#card-836137

From p5j4vm-1pD-p2, @alisterscott noted that the click target for the ellipsis menu in the TaxonomyManager is quite small, to the point where you often accidentally click on the row behind and the edit window opens.

This branch wraps the gridicon in an element to make the target bigger.

__To Test__
- Visit a [site settings page](http://calypso.localhost:3000/settings/writing), click 'Categories'
- On the subsequent page, interact with the action menu for a category

/cc @youknowriad 