### PR TITLE
Taxonomies: Show the posts count on each item of the Taxonomy manager

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -59,15 +59,11 @@ class TaxonomyManagerListItem extends Component {
 		const { onDelete, postCount, name, translate } = this.props;
 
 		return (
-			<div>
+			<div className="taxonomy-manager__item">
 				<span className="taxonomy-manager__label">
 					{ name }
 				</span>
-				{ ! isUndefined( postCount ) &&
-					<span className="taxonomy-manager__count">
-						<Count count={ postCount } />
-					</span>
-				}
+				{ ! isUndefined( postCount ) && <Count count={ postCount } /> }
 				<Gridicon
 					icon="ellipsis"
 					className={ classNames( {

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,10 +12,12 @@ import { localize } from 'i18n-calypso';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
+import Count from 'components/count';
 
 class TaxonomyManagerListItem extends Component {
 	static propTypes = {
 		name: PropTypes.string,
+		postCount: PropTypes.number,
 		translate: PropTypes.func,
 		onClick: PropTypes.func,
 		onDelete: PropTypes.func,
@@ -53,11 +56,18 @@ class TaxonomyManagerListItem extends Component {
 	};
 
 	render() {
-		const { onDelete, name, translate } = this.props;
+		const { onDelete, postCount, name, translate } = this.props;
 
 		return (
 			<div>
-				<span className="taxonomy-manager__label">{ name }</span>
+				<span className="taxonomy-manager__label">
+					{ name }
+				</span>
+				{ ! isUndefined( postCount ) &&
+					<span className="taxonomy-manager__count">
+						<Count count={ postCount } />
+					</span>
+				}
 				<Gridicon
 					icon="ellipsis"
 					className={ classNames( {

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -139,7 +139,7 @@ export class TaxonomyManagerList extends Component {
 					onClick={ onClick }
 					key={ itemId }
 					className="taxonomy-manager__list-item-card">
-					<ListItem name={ name } onClick={ onClick } onDelete={ onDelete } />
+					<ListItem name={ name } postCount={ item.post_count } onClick={ onClick } onDelete={ onDelete } />
 				</CompactCard>
 				{ children.length > 0 && (
 					<div className="taxonomy-manager__nested-list">

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -66,6 +66,13 @@
 	}
 }
 
+.taxonomy-manager__count {
+	margin: 16px 28px;
+	position: absolute;
+		right: 48px;
+		top: 0;
+}
+
 .taxonomy-manager .virtual-list__list-row.is-empty {
 	padding: 16px 24px;
 	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -66,7 +66,7 @@
 	}
 }
 
-.taxonomy-manager__count {
+.taxonomy-manager__item .count {
 	margin: 16px 28px;
 	position: absolute;
 		right: 48px;


### PR DESCRIPTION
As suggested by @alisterscott this branch shows up the posts' count next to each term label.

<img width="724" alt="capture d ecran 2016-11-18 a 10 57 05 am" src="https://cloud.githubusercontent.com/assets/272444/20426291/d0d6d6a4-ad7e-11e6-8744-bdb5648a6589.png">

closes #9495

- Visit a [site settings page](http://calypso.localhost:3000/settings/writing), click 'Categories'
- On the subsequent page you should see the posts count displayed for each item

@folletto @timmyc 