### PR TITLE
JPC: Hide free plan in akismet landing page

### DIFF
--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -223,7 +223,7 @@ export default {
 	},
 
 	akismetLanding( context ) {
-		getPlansLandingPage( context, false, '/jetpack/connect/akismet' );
+		getPlansLandingPage( context, true, '/jetpack/connect/akismet' );
 	},
 
 	plansLanding( context ) {


### PR DESCRIPTION
Quick PR to hide the free plan in the akismet plans landing page

How to test
==========

1. go http://calypso.localhost:3000/jetpack/connect/akismet . You shouldn't see the free plan there
![image](https://cloud.githubusercontent.com/assets/1554855/20429564/be1af746-ad8f-11e6-8ca4-3768a3863d57.png)
