### PR TITLE
ESLint: Add rules for restricting usage of sites-list and data-observe

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,8 @@ module.exports = {
 		'no-extra-semi': 1,
 		'no-multiple-empty-lines': [ 1, { max: 1 } ],
 		'no-multi-spaces': 1,
+		'no-restricted-imports': [ 1, 'lib/sites-list', 'lib/mixins/data-observe' ],
+		'no-restricted-modules': [ 1, 'lib/sites-list', 'lib/mixins/data-observe' ],
 		'no-shadow': 1,
 		'no-spaced-func': 1,
 		'no-trailing-spaces': 1,


### PR DESCRIPTION
I'm just using no-restricted-(imports|modules) at the moment. The error message isn't great. Perhaps this is Good Enough™ for now.

![screen shot 2016-11-18 at 12 30 44](https://cloud.githubusercontent.com/assets/215074/20430189/de68adc2-ad8a-11e6-9a3a-09b914d64155.png)

/cc lint-master @aduth 