### PR TITLE
JPC: Allow connected sites in JPC flow so they can reach the plans page

### DIFF
--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -17,7 +17,7 @@ export default React.createClass( {
 		siteUrl: PropTypes.string
 	},
 
-	getNoticeValues( url ) {
+	getNoticeValues() {
 		const noticeValues = {
 			icon: 'notice',
 			status: 'is-error',
@@ -74,16 +74,6 @@ export default React.createClass( {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'status';
 			noticeValues.text = this.translate( 'This site is already connected!' );
-			return noticeValues;
-		}
-		if ( this.props.noticeType === 'alreadyOwned' ) {
-			noticeValues.status = 'is-success';
-			noticeValues.icon = 'status';
-			noticeValues.text = this.translate( '{{a}}Your site{{/a}} is already connected!', {
-				components: {
-					a: <a href={ '/stats/day/' + url } />
-				}
-			} );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'wordpress.com' ) {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -3,6 +3,7 @@
  */
 const debug = require( 'debug' )( 'calypso:jetpack-connect:actions' );
 import pick from 'lodash/pick';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -41,6 +42,7 @@ import config from 'config';
 import addQueryArgs from 'lib/route/add-query-args';
 import { externalRedirect } from 'lib/route/path';
 import { urlToSlug } from 'lib/url';
+import { JPC_PLANS_PAGE } from './constants';
 
 /**
  *  Local variables;
@@ -169,6 +171,20 @@ export default {
 					error: error
 				} );
 			} );
+		};
+	},
+	goToPlans( url ) {
+		return ( dispatch ) => {
+			dispatch( {
+				type: JETPACK_CONNECT_REDIRECT,
+				url: url
+			} );
+			tracksEvent( dispatch, 'calypso_jpc_success_redirect', {
+				url: url,
+				type: 'plans_selection'
+			} );
+
+			page.redirect( JPC_PLANS_PAGE + urlToSlug( url ) );
 		};
 	},
 	goToRemoteAuth( url ) {

--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -1,3 +1,4 @@
 export const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 hour
 export const JETPACK_CONNECT_AUTHORIZE_TTL = 60 * 60 * 1000; // 1 hour
 export const AUTH_ATTEMPS_TTL = 60 * 1000; // 1 minute
+export const JPC_PLANS_PAGE = '/jetpack/connect/plans/';


### PR DESCRIPTION
Until now we didn't allow connected sites to go through the JPC flow. When someone tried to introduce an already connected site in the first step of it, we were showing a warning about the site being already connected and stopped it right there.

This PR changes this, so now you are directly redirected to the plans page if you enter an already connected site.

How to test
======

0. You need a connected jetpack site
1. Go to http://calypso.localhost:3000/jetpack/connect/ and enter the url of your site
2. You should be redirected to http://calypso.localhost:3000/jetpack/connect/plans/:yoursite: (or to /plans/my-plan if your site already have a paid plan)

ping @richardmuscat  @dereksmart 