### PR TITLE
state/themes: Add new selectors

### DIFF
--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -183,12 +183,7 @@ export const getThemesForQueryIgnoringPage = createSelector(
 			return null;
 		}
 
-		const itemsIgnoringPage = themes.getItemsIgnoringPage( query );
-		if ( ! itemsIgnoringPage ) {
-			return null;
-		}
-
-		return itemsIgnoringPage;
+		return themes.getItemsIgnoringPage( query );
 	},
 	( state ) => state.themes.queries,
 	( state, siteId, query ) => getSerializedThemesQueryWithoutPage( query, siteId )

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import { some, split } from 'lodash';
+import { includes, isEqual, omit, some, split } from 'lodash';
+import createSelector from 'lib/create-selector';
 
 /**
  * Internal dependencies
@@ -12,6 +13,235 @@ import config from 'config';
 import { getSiteSlug, getSiteOption, isJetpackSite } from 'state/sites/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import { isPremiumTheme, oldShowcaseUrl } from './utils';
+import {
+	getDeserializedThemesQueryDetails,
+	getNormalizedThemesQuery,
+	getSerializedThemesQuery,
+	getSerializedThemesQueryWithoutPage
+ } from './utils';
+import { DEFAULT_THEME_QUERY } from './constants';
+
+/**
+ * Returns an array of theme objects by site ID.
+ *
+ * @param  {Object} state  Global state tree
+ * @param  {Number} siteId Site ID
+ * @return {Array}         Site themes
+ */
+export const getThemes = createSelector(
+	( state, siteId ) => {
+		const manager = state.themes.queries[ siteId ];
+		if ( ! manager ) {
+			return [];
+		}
+
+		return manager.getItems();
+	},
+	( state ) => state.themes.queries
+);
+
+/**
+ * Returns a theme object by site ID, theme ID pair.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {String}  themeId Theme ID
+ * @return {?Object}        Theme object
+ */
+export const getTheme = createSelector(
+	( state, siteId, themeId ) => {
+		const manager = state.themes.queries[ siteId ];
+		if ( ! manager ) {
+			return null;
+		}
+
+		return manager.getItem( themeId );
+	},
+	( state ) => state.themes.queries
+);
+
+/**
+ * Returns an array of normalized themes for the themes query, or null if no
+ * themes have been received.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Object}  query  Theme query object
+ * @return {?Array}         Themes for the theme query
+ */
+export const getThemesForQuery = createSelector(
+	( state, siteId, query ) => {
+		const manager = state.themes.queries[ siteId ];
+		if ( ! manager ) {
+			return null;
+		}
+
+		const themes = manager.getItems( query );
+		if ( ! themes ) {
+			return null;
+		}
+
+		// ThemeQueryManager will return an array including undefined entries if
+		// it knows that a page of results exists for the query (via a previous
+		// request's `found` value) but the items haven't been received. While
+		// we could impose this on the developer to accommodate, instead we
+		// simply return null when any `undefined` entries exist in the set.
+		if ( includes( themes, undefined ) ) {
+			return null;
+		}
+
+		return themes;
+	},
+	( state ) => state.themes.queries,
+	( state, siteId, query ) => getSerializedThemesQuery( query, siteId )
+);
+
+/**
+ * Returns true if currently requesting themes for the themes query, or false
+ * otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Object}  query  Theme query object
+ * @return {Boolean}        Whether themes are being requested
+ */
+export function isRequestingThemesForQuery( state, siteId, query ) {
+	const serializedQuery = getSerializedThemesQuery( query, siteId );
+	return !! state.themes.queryRequests[ serializedQuery ];
+}
+
+/**
+ * Returns the total number of items reported to be found for the given query,
+ * or null if the total number of queryable themes if unknown.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Object}  query  Theme query object
+ * @return {?Number}        Total number of found items
+ */
+export function getThemesFoundForQuery( state, siteId, query ) {
+	if ( ! state.themes.queries[ siteId ] ) {
+		return null;
+	}
+
+	return state.themes.queries[ siteId ].getFound( query );
+}
+
+/**
+ * Returns the last queryable page of themes for the given query, or null if the
+ * total number of queryable themes if unknown.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Object}  query  Theme query object
+ * @return {?Number}        Last themes page
+ */
+export function getThemesLastPageForQuery( state, siteId, query ) {
+	if ( ! state.themes.queries[ siteId ] ) {
+		return null;
+	}
+
+	const pages = state.themes.queries[ siteId ].getNumberOfPages( query );
+	if ( null === pages ) {
+		return null;
+	}
+
+	return Math.max( pages, 1 );
+}
+
+/**
+ * Returns true if the query has reached the last page of queryable pages, or
+ * null if the total number of queryable themes if unknown.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @param  {Object}   query  Theme query object
+ * @return {?Boolean}        Whether last themes page has been reached
+ */
+export function isThemesLastPageForQuery( state, siteId, query = {} ) {
+	const lastPage = getThemesLastPageForQuery( state, siteId, query );
+	if ( null === lastPage ) {
+		return lastPage;
+	}
+
+	return lastPage === ( query.page || DEFAULT_THEME_QUERY.page );
+}
+
+/**
+ * Returns an array of normalized themes for the themes query, including all
+ * known queried pages, or null if the themes for the query are not known.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Object}  query  Post query object
+ * @return {?Array}         Themes for the post query
+ */
+export const getThemesForQueryIgnoringPage = createSelector(
+	( state, siteId, query ) => {
+		const themes = state.themes.queries[ siteId ];
+		if ( ! themes ) {
+			return null;
+		}
+
+		const itemsIgnoringPage = themes.getItemsIgnoringPage( query );
+		if ( ! itemsIgnoringPage ) {
+			return null;
+		}
+
+		return itemsIgnoringPage;
+	},
+	( state ) => state.themes.queries,
+	( state, siteId, query ) => getSerializedThemesQueryWithoutPage( query, siteId )
+);
+
+/**
+ * Returns true if currently requesting themes for the themes query, regardless
+ * of page, or false otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Object}  query  Post query object
+ * @return {Boolean}        Whether themes are being requested
+ */
+export const isRequestingThemesForQueryIgnoringPage = createSelector(
+	( state, siteId, query ) => {
+		const normalizedQueryWithoutPage = omit( getNormalizedThemesQuery( query ), 'page' );
+		return some( state.themes.queryRequests, ( isRequesting, serializedQuery ) => {
+			if ( ! isRequesting ) {
+				return false;
+			}
+
+			const queryDetails = getDeserializedThemesQueryDetails( serializedQuery );
+			if ( queryDetails.siteId !== siteId ) {
+				return false;
+			}
+
+			return isEqual(
+				normalizedQueryWithoutPage,
+				omit( queryDetails.query, 'page' )
+			);
+		} );
+	},
+	( state ) => state.themes.queryRequests,
+	( state, siteId, query ) => getSerializedThemesQuery( query, siteId )
+);
+
+/**
+ * Returns true if a request is in progress for the specified site theme, or
+ * false otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Number}  themeId Theme ID
+ * @return {Boolean}        Whether request is in progress
+ */
+export function isRequestingSiteTheme( state, siteId, themeId ) {
+	if ( ! state.themes.themeRequests[ siteId ] ) {
+		return false;
+	}
+
+	return !! state.themes.themeRequests[ siteId ][ themeId ];
+}
 
 /**
  * Returns the URL for a given theme's details sheet.

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -173,8 +173,8 @@ export function isThemesLastPageForQuery( state, siteId, query = {} ) {
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
- * @param  {Object}  query  Post query object
- * @return {?Array}         Themes for the post query
+ * @param  {Object}  query  Theme query object
+ * @return {?Array}         Themes for the theme query
  */
 export const getThemesForQueryIgnoringPage = createSelector(
 	( state, siteId, query ) => {
@@ -200,7 +200,7 @@ export const getThemesForQueryIgnoringPage = createSelector(
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
- * @param  {Object}  query  Post query object
+ * @param  {Object}  query  Theme query object
  * @return {Boolean}        Whether themes are being requested
  */
 export const isRequestingThemesForQueryIgnoringPage = createSelector(


### PR DESCRIPTION
These selectors will later replace the current `themes`, `themesList`, and `themeDetails` ones. This PR doesn't wire them to the live code yet, so their functionality is only covered by tests right now.

I hope the JSDoc blocks for individual selectors are explanatory enough, so I'm not describing them here. If they aren't, just add a comment!

To test: Make sure that the app still works as before (the theme showcase, specifically)