### PR TITLE
Taxonomies: Add default category icon and label to the taxonomy listing

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -71,7 +71,9 @@ class TaxonomyManagerListItem extends Component {
 				<span className="taxonomy-manager__label">
 					<span>{ name }</span>
 					{ isDefault &&
-						<span className="taxonomy-manager__default-label">{ translate( 'default' ) }</span>
+						<span className="taxonomy-manager__default-label">
+							{ translate( 'default', { context: 'label for terms marked as default' } ) }
+						</span>
 					}
 				</span>
 				{ ! isUndefined( postCount ) && <Count count={ postCount } /> }

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -21,9 +21,11 @@ class TaxonomyManagerListItem extends Component {
 		translate: PropTypes.func,
 		onClick: PropTypes.func,
 		onDelete: PropTypes.func,
+		isDefault: PropTypes.bool,
 	};
 
 	static defaultProps = {
+		isDefault: false,
 		onClick: () => {},
 	};
 
@@ -56,12 +58,21 @@ class TaxonomyManagerListItem extends Component {
 	};
 
 	render() {
-		const { onDelete, postCount, name, translate } = this.props;
+		const { isDefault, onDelete, postCount, name, translate } = this.props;
+		const className = classNames( 'taxonomy-manager__item', {
+			'is-default': isDefault
+		} );
 
 		return (
-			<div className="taxonomy-manager__item">
+			<div className={ className }>
+				<span className="taxonomy-manager__icon">
+					<Gridicon icon={ isDefault ? 'checkmark-circle' : 'folder' } />
+				</span>
 				<span className="taxonomy-manager__label">
-					{ name }
+					<span>{ name }</span>
+					{ isDefault &&
+						<span className="taxonomy-manager__default-label">{ translate( 'default' ) }</span>
+					}
 				</span>
 				{ ! isUndefined( postCount ) && <Count count={ postCount } /> }
 				<Gridicon

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -123,9 +123,9 @@ export class TaxonomyManagerList extends Component {
 		}
 
 		const children = this.getTermChildren( item.ID );
-		const { onTermClick, siteSettings, taxonomy, translate } = this.props;
+		const { onTermClick, defaultTerm, translate } = this.props;
 		const itemId = item.ID;
-		const isDefault = taxonomy === 'category' && get( siteSettings, [ 'default_category' ] ) === itemId;
+		const isDefault = defaultTerm === itemId;
 		const name = decodeEntities( item.name ) || translate( 'Untitled' );
 		const onClick = () => {
 			onTermClick( item );
@@ -234,14 +234,15 @@ export class TaxonomyManagerList extends Component {
 }
 
 export default connect( ( state, ownProps ) => {
-	const siteId = getSelectedSiteId( state );
 	const { taxonomy, query } = ownProps;
+	const siteId = getSelectedSiteId( state );
+	const siteSettings = getSiteSettings( state, siteId );
 
 	return {
 		loading: isRequestingTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
 		terms: getTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
 		lastPage: getTermsLastPageForQuery( state, siteId, taxonomy, query ),
-		siteSettings: getSiteSettings( state, siteId ),
+		defaultTerm: taxonomy === 'category' ? get( siteSettings, [ 'default_category' ] ) : false,
 		siteId,
 		query
 	};

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import {
+	get,
 	includes,
 	filter,
 	map,
@@ -24,7 +25,9 @@ import CompactCard from 'components/card/compact';
 import Dialog from 'components/dialog';
 import { decodeEntities } from 'lib/formatting';
 import QueryTerms from 'components/data/query-terms';
+import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSettings } from 'state/site-settings/selectors';
 import {
 	isRequestingTermsForQueryIgnoringPage,
 	getTermsLastPageForQuery,
@@ -120,9 +123,9 @@ export class TaxonomyManagerList extends Component {
 		}
 
 		const children = this.getTermChildren( item.ID );
-
-		const { onTermClick, translate } = this.props;
+		const { onTermClick, siteSettings, taxonomy, translate } = this.props;
 		const itemId = item.ID;
+		const isDefault = taxonomy === 'category' && get( siteSettings, [ 'default_category' ] ) === itemId;
 		const name = decodeEntities( item.name ) || translate( 'Untitled' );
 		const onClick = () => {
 			onTermClick( item );
@@ -139,7 +142,13 @@ export class TaxonomyManagerList extends Component {
 					onClick={ onClick }
 					key={ itemId }
 					className="taxonomy-manager__list-item-card">
-					<ListItem name={ name } postCount={ item.post_count } onClick={ onClick } onDelete={ onDelete } />
+					<ListItem
+						name={ name }
+						postCount={ item.post_count }
+						isDefault={ isDefault }
+						onClick={ onClick }
+						onDelete={ onDelete }
+					/>
 				</CompactCard>
 				{ children.length > 0 && (
 					<div className="taxonomy-manager__nested-list">
@@ -180,6 +189,7 @@ export class TaxonomyManagerList extends Component {
 			{ action: 'cancel', label: translate( 'Cancel' ) },
 			{ action: 'delete', label: translate( 'OK' ), isPrimary: true },
 		];
+		const hasDefaultSetting = taxonomy === 'category';
 
 		return (
 			<div className={ classes }>
@@ -190,6 +200,7 @@ export class TaxonomyManagerList extends Component {
 						taxonomy={ taxonomy }
 						query={ { ...query, page } } />
 				) ) }
+				{ hasDefaultSetting && <QuerySiteSettings siteId={ siteId } /> }
 
 				<WindowScroller>
 					{ ( { height, scrollTop } ) => (
@@ -230,6 +241,7 @@ export default connect( ( state, ownProps ) => {
 		loading: isRequestingTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
 		terms: getTermsForQueryIgnoringPage( state, siteId, taxonomy, query ),
 		lastPage: getTermsLastPageForQuery( state, siteId, taxonomy, query ),
+		siteSettings: getSiteSettings( state, siteId ),
 		siteId,
 		query
 	};

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -55,22 +55,42 @@
 }
 
 .taxonomy-manager__label {
-	position: relative;
-	display: flex;
-	justify-content: space-between;
+	margin-left: 30px;
+	line-height: 18px;
 
 	.taxonomy-manager__list-item.is-placeholder & {
 		color: transparent;
 		background-color: lighten( $gray, 30% );
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
+
+	.taxonomy-manager__default-label {
+		text-transform: uppercase;
+		color: $blue-medium;
+		font-size: 12px;
+		margin-left: 10px;
+	}
 }
 
-.taxonomy-manager__item .count {
-	margin: 16px 28px;
-	position: absolute;
-		right: 48px;
-		top: 0;
+.taxonomy-manager__item {
+	.taxonomy-manager__icon {
+		margin: 15px 20px 0;
+		position: absolute;
+			left: 0px;
+			top: 0;
+		color: $gray;
+	}
+
+	.count {
+		margin: 18px 28px;
+		position: absolute;
+			right: 48px;
+			top: 0;
+	}
+
+	&.is-default .taxonomy-manager__icon {
+		color: $blue-medium;
+	}
 }
 
 .taxonomy-manager .virtual-list__list-row.is-empty {


### PR DESCRIPTION
This PR adds an icon to each term, if it's the default term, it shows the "checkmark" icon unless it shows the folder icon.

<img width="743" alt="capture d ecran 2016-11-18 a 5 14 12 pm" src="https://cloud.githubusercontent.com/assets/272444/20437209/5baffe98-adb3-11e6-946d-73c4f57cee7b.png">

closes #9458

**Testing instructions**

 - Go to /settings/taxonomies/$settings/category
 - The default category should have a "checkmark" and a default label

cc @timmyc 