### PR TITLE
Reader: Remove Recommendations sidebar item

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -176,12 +176,14 @@ export const ReaderSidebar = React.createClass( {
 							)
 						}
 
+						{ ! config.isEnabled( 'reader/refresh/stream' ) && (
 						<li className={ ReaderSidebarHelper.itemLinkClass( '/recommendations', this.props.path, { 'sidebar-streams__recommendations': true } ) }>
 							<a href="/recommendations">
 								<Gridicon icon="thumbs-up" size={ 24 } />
 								<span className="menu-link-text">{ this.props.translate( 'Recommendations' ) }</span>
 							</a>
-						</li>
+						</li> )
+						}
 
 						<li className={ ReaderSidebarHelper.itemLinkClass( '/activities/likes', this.props.path, { 'sidebar-activity__likes': true } ) }>
 							<a href="/activities/likes">


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/9102

**Before:**
![screenshot-2016-11-18-11 35 40](https://cloud.githubusercontent.com/assets/4924246/20444137/ab144ab8-ad84-11e6-9638-a0ce19dabfad.jpg)

**After:**
![screenshot 2016-11-18 11 35 45](https://cloud.githubusercontent.com/assets/4924246/20443831/6f0ece4a-ad83-11e6-8f73-50aaa6535806.png)

@fraying: The link is still accessible via `/recommendations`, does that need to be removed as well?