### PR TITLE
Add Subdomain A/B test

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -113,6 +113,7 @@ const RegisterDomainStep = React.createClass( {
 		domainsWithPlansOnly: React.PropTypes.bool,
 		isSignupStep: React.PropTypes.bool,
 		surveyVertical: React.PropTypes.string,
+		includeWordPressDotCom: React.PropTypes.bool,
 		includeDotBlogSubdomain: React.PropTypes.bool,
 	},
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -113,6 +113,7 @@ const RegisterDomainStep = React.createClass( {
 		domainsWithPlansOnly: React.PropTypes.bool,
 		isSignupStep: React.PropTypes.bool,
 		surveyVertical: React.PropTypes.string,
+		includeDotBlogSubdomain: React.PropTypes.bool,
 	},
 
 	getDefaultProps: function() {
@@ -349,6 +350,7 @@ const RegisterDomainStep = React.createClass( {
 							query: domain,
 							quantity: SUGGESTION_QUANTITY,
 							include_wordpressdotcom: this.props.includeWordPressDotCom,
+							include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 							vendor: searchVendor,
 							vertical: this.props.surveyVertical,
 						},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -76,7 +76,8 @@ module.exports = {
 			excludeDotBlogSubdomain: 90,
 			includeDotBlogSubdomain: 10,
 		},
-		defaultVariation: 'excludeDotBlogSubdomain'
+		defaultVariation: 'excludeDotBlogSubdomain',
+		allowAnyLocale: true,
 	},
 	paidNuxThankYouPage: {
 		datestamp: '20161114',

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -70,6 +70,14 @@ module.exports = {
 		defaultVariation: 'showPopover',
 		allowExistingUsers: false,
 	},
+	domainDotBlogSubdomain: {
+		datestamp: '20161118',
+		variations: {
+			excludeDotBlogSubdomain: 90,
+			includeDotBlogSubdomain: 10,
+		},
+		defaultVariation: 'excludeDotBlogSubdomain'
+	},
 	paidNuxThankYouPage: {
 		datestamp: '20161114',
 		variations: {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -198,6 +198,7 @@ const DomainsStep = React.createClass( {
 				analyticsSection="signup"
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				includeWordPressDotCom
+				includeDotBlogSubdomain={ abtest( 'domainDotBlogSubdomain' ) === 'includeDotBlogSubdomain' }
 				isSignupStep
 				showExampleSuggestions
 				surveyVertical={ this.props.surveyVertical }


### PR DESCRIPTION
To test:

1. Go to signup domains step
  a. Switch to the `excludeDotBlogSubdomain` variation of the A/B test
  b. Make sure **NO** subdomains are suggested
  c. Switch to the `includeDotBlogSubdomain` variation of the A/B test
  d. Make sure subdomains are suggested
2. Go to `/domains/`
  a. Make sure **NO** subdomains are suggested

**Important:** redux will cache the API response, so you need to change the search query after switching A/B test variations