### PR TITLE
state/themes: Add new actions

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1454,17 +1454,10 @@ Undocumented.prototype.getLocaleSuggestions = function( fn ) {
 	return this.wpcom.req.get( { path: '/locale-guess' }, fn );
 };
 
-Undocumented.prototype.themes = function( site, query, fn ) {
-	var path = site ? '/sites/' + site.ID + '/themes' : '/themes';
+Undocumented.prototype.themes = function( siteId, query, fn ) {
+	var path = siteId ? '/sites/' + siteId + '/themes' : '/themes';
 	debug( path );
-	return this.wpcom.req.get( path, {
-		search: query.search,
-		tier: query.tier,
-		filter: query.filter,
-		page: query.page,
-		number: query.perPage,
-		apiVersion: site.jetpack ? '1' : '1.2'
-	}, fn );
+	return this.wpcom.req.get( path, query, fn );
 };
 
 Undocumented.prototype.themeDetails = function( themeId, site, fn ) {

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -20,7 +20,7 @@ import useMockery from 'test/helpers/use-mockery';
 import {
 	incrementThemesPage,
 	query,
-	receiveThemes,
+	legacyReceiveThemes as receiveThemes,
 	receiveServerError
 } from 'state/themes/actions';
 

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -20,7 +20,7 @@ import useMockery from 'test/helpers/use-mockery';
 import {
 	incrementThemesPage,
 	query,
-	legacyReceiveThemes as receiveThemes,
+	legacyReceiveThemes,
 	receiveServerError
 } from 'state/themes/actions';
 
@@ -111,7 +111,7 @@ describe( 'logged-out', () => {
 		it( 'renders without error when themes are present', () => {
 			this.store.dispatch( query( this.queryParams ) );
 			this.store.dispatch( incrementThemesPage( false ) );
-			this.store.dispatch( receiveThemes( { themes: this.themes }, false, this.queryParams ) );
+			this.store.dispatch( legacyReceiveThemes( { themes: this.themes }, false, this.queryParams ) );
 
 			let markup;
 			assert.doesNotThrow( () => {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -3,40 +3,50 @@
 /**
  * External dependencies
  */
-import conforms from 'lodash/conforms';
+import { conforms, property } from 'lodash';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
-import property from 'lodash/property';
 
 /**
  * Internal dependencies
  */
+import wpcom from 'lib/wp';
 import {
-	THEME_ACTIVATE_REQUEST,
-	THEME_ACTIVATE_REQUEST_SUCCESS,
-	THEME_ACTIVATE_REQUEST_FAILURE,
+	// Old action names
 	THEME_BACK_PATH_SET,
 	THEME_CLEAR_ACTIVATED,
 	THEME_DETAILS_RECEIVE,
 	THEME_DETAILS_RECEIVE_FAILURE,
 	THEME_DETAILS_REQUEST,
+	THEMES_INCREMENT_PAGE,
+	THEMES_QUERY,
+	// New action names
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
 	ACTIVE_THEME_REQUEST_FAILURE,
-	THEMES_INCREMENT_PAGE,
-	THEMES_QUERY,
+	THEME_REQUEST,
+	THEME_REQUEST_SUCCESS,
+	THEME_REQUEST_FAILURE,
 	THEMES_RECEIVE,
+	THEMES_REQUEST,
+	THEMES_REQUEST_SUCCESS,
+	THEMES_REQUEST_FAILURE,
+	THEME_ACTIVATE_REQUEST,
+	THEME_ACTIVATE_REQUEST_SUCCESS,
+	THEME_ACTIVATE_REQUEST_FAILURE,
 	THEMES_RECEIVE_SERVER_ERROR,
-} from '../action-types';
-import { getCurrentTheme } from './current-theme/selectors';
+} from 'state/action-types';
 import {
 	recordTracksEvent,
 	withAnalytics
 } from 'state/analytics/actions';
+import { getCurrentTheme } from './current-theme/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getQueryParams } from './themes-list/selectors';
 import { getThemeById } from './themes/selectors';
-import wpcom from 'lib/wp';
+
+const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
+
+// Old actions
 
 export function fetchThemes( site ) {
 	return ( dispatch, getState ) => {
@@ -48,7 +58,7 @@ export function fetchThemes( site ) {
 		return wpcom.undocumented().themes( site, queryParams )
 			.then( themes => {
 				const responseTime = ( new Date().getTime() ) - startTime;
-				return dispatch( receiveThemes( themes, site, queryParams, responseTime ) );
+				return dispatch( legacyReceiveThemes( themes, site, queryParams, responseTime ) );
 			} )
 			.catch( error => receiveServerError( error ) );
 	};
@@ -72,41 +82,6 @@ export function incrementThemesPage( site ) {
 	return {
 		type: THEMES_INCREMENT_PAGE,
 		site: site
-	};
-}
-
-/**
- * This action queries wpcom endpoint for active theme for site.
- * If request success information about active theme is stored in Redux themes subtree.
- * In case of error, error is stored in Redux themes subtree.
- *
- * @param  {Object} siteId Site for which to check active theme
- * @return {Object}        Redux thunk with request action
- */
-export function requestActiveTheme( siteId ) {
-	return dispatch => {
-		dispatch( {
-			type: ACTIVE_THEME_REQUEST,
-			siteId,
-		} );
-
-		return wpcom.undocumented().activeTheme( siteId )
-			.then( theme => {
-				debug( 'Received current theme', theme );
-				dispatch( {
-					type: ACTIVE_THEME_REQUEST_SUCCESS,
-					siteId,
-					themeId: theme.id,
-					themeName: theme.name,
-					themeCost: theme.cost
-				} );
-			} ).catch( error => {
-				dispatch( {
-					type: ACTIVE_THEME_REQUEST_FAILURE,
-					siteId,
-					error,
-				} );
-			} );
 	};
 }
 
@@ -168,7 +143,7 @@ const isFirstPageOfSearch = conforms( {
 	page: a => a === 1
 } );
 
-export function receiveThemes( data, site, queryParams, responseTime ) {
+export function legacyReceiveThemes( data, site, queryParams, responseTime ) {
 	return ( dispatch, getState ) => {
 		const themeAction = {
 			type: THEMES_RECEIVE,
@@ -201,6 +176,180 @@ export function receiveThemes( data, site, queryParams, responseTime ) {
 	};
 }
 
+export function clearActivated() {
+	return {
+		type: THEME_CLEAR_ACTIVATED
+	};
+}
+
+// Set destination for 'back' button on theme sheet
+export function setBackPath( path ) {
+	return {
+		type: THEME_BACK_PATH_SET,
+		path: path,
+	};
+}
+
+// New actions
+
+/**
+ * Returns an action object to be used in signalling that a theme object has
+ * been received.
+ *
+ * @param  {Object} theme  Theme received
+ * @param  {Number} siteId ID of site for which themes have been received
+ * @return {Object}        Action object
+ */
+export function receiveTheme( theme, siteId ) {
+	return receiveThemes( [ theme ], siteId );
+}
+
+/**
+ * Returns an action object to be used in signalling that theme objects have
+ * been received.
+ *
+ * @param  {Array}  themes Themes received
+ * @param  {Number} siteId ID of site for which themes have been received
+ * @return {Object}        Action object
+ */
+export function receiveThemes( themes, siteId ) {
+	return {
+		type: THEMES_RECEIVE,
+		themes,
+		siteId
+	};
+}
+
+/**
+ * Triggers a network request to fetch themes for the specified site and query.
+ *
+ * @param  {Number|String} siteId Jetpack site ID or 'wpcom' for any WPCOM site
+ * @param  {String}        query  Theme query
+ * @return {Function}             Action thunk
+ */
+export function requestThemes( siteId, query = {} ) {
+	return ( dispatch ) => {
+		let siteIdToQuery, queryWithApiVersion;
+
+		if ( siteId === 'wpcom' ) {
+			siteIdToQuery = null;
+			queryWithApiVersion = { ...query, apiVersion: '1.2' };
+		} else {
+			siteIdToQuery = siteId;
+			queryWithApiVersion = { ...query, apiVersion: '1' };
+		}
+
+		dispatch( {
+			type: THEMES_REQUEST,
+			siteId,
+			query
+		} );
+
+		return wpcom.undocumented().themes( siteIdToQuery, queryWithApiVersion ).then( ( { found, themes } ) => {
+			dispatch( receiveThemes( themes, siteId ) );
+			dispatch( {
+				type: THEMES_REQUEST_SUCCESS,
+				siteId,
+				query,
+				found,
+				themes
+			} );
+		} ).catch( ( error ) => {
+			dispatch( {
+				type: THEMES_REQUEST_FAILURE,
+				siteId,
+				query,
+				error
+			} );
+		} );
+	};
+}
+
+/**
+ * Triggers a network request to fetch a specific theme from a site.
+ *
+ * @param  {String}   themeId Theme ID
+ * @param  {Number}   siteId  Site ID
+ * @return {Function}         Action thunk
+ */
+export function requestTheme( themeId, siteId ) {
+	return ( dispatch ) => {
+		let siteIdToQuery;
+
+		if ( siteId === 'wpcom' ) {
+			siteIdToQuery = null;
+		} else {
+			siteIdToQuery = siteId;
+		}
+
+		dispatch( {
+			type: THEME_REQUEST,
+			siteId,
+			themeId
+		} );
+
+		return wpcom.undocumented().themeDetails( themeId, siteIdToQuery ).then( ( theme ) => {
+			dispatch( receiveTheme( theme, siteId ) );
+			dispatch( {
+				type: THEME_REQUEST_SUCCESS,
+				siteId,
+				themeId
+			} );
+		} ).catch( ( error ) => {
+			dispatch( {
+				type: THEME_REQUEST_FAILURE,
+				siteId,
+				themeId,
+				error
+			} );
+		} );
+	};
+}
+
+/**
+ * This action queries wpcom endpoint for active theme for site.
+ * If request success information about active theme is stored in Redux themes subtree.
+ * In case of error, error is stored in Redux themes subtree.
+ *
+ * @param  {Number}   siteId Site for which to check active theme
+ * @return {Function}        Redux thunk with request action
+ */
+export function requestActiveTheme( siteId ) {
+	return dispatch => {
+		dispatch( {
+			type: ACTIVE_THEME_REQUEST,
+			siteId,
+		} );
+
+		return wpcom.undocumented().activeTheme( siteId )
+			.then( theme => {
+				debug( 'Received current theme', theme );
+				dispatch( {
+					type: ACTIVE_THEME_REQUEST_SUCCESS,
+					siteId,
+					themeId: theme.id,
+					themeName: theme.name,
+					themeCost: theme.cost
+				} );
+			} ).catch( error => {
+				dispatch( {
+					type: ACTIVE_THEME_REQUEST_FAILURE,
+					siteId,
+					error,
+				} );
+			} );
+	};
+}
+
+/**
+ * Triggers a network request to activate a specific theme on a given site.
+ *
+ * @param  {String}   themeId   Theme ID
+ * @param  {Number}   siteId    Site ID
+ * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
+ * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
+ * @return {Function}           Action thunk
+ */
 export function activateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
 	return dispatch => {
 		dispatch( {
@@ -224,6 +373,16 @@ export function activateTheme( themeId, siteId, source = 'unknown', purchased = 
 	};
 }
 
+/**
+ * Returns an action thunk to be used in signalling that a theme has been activated
+ * on a given site.
+ *
+ * @param  {Object}   theme     Theme object
+ * @param  {Number}   siteId    Site ID
+ * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
+ * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
+ * @return {Function}           Action thunk
+ */
 export function themeActivated( theme, siteId, source = 'unknown', purchased = false ) {
 	const themeActivatedThunk = ( dispatch, getState ) => {
 		if ( typeof theme !== 'object' ) {
@@ -251,18 +410,4 @@ export function themeActivated( theme, siteId, source = 'unknown', purchased = f
 		dispatch( withAnalytics( trackThemeActivation, action ) );
 	};
 	return themeActivatedThunk; // it is named function just for testing purposes
-}
-
-export function clearActivated() {
-	return {
-		type: THEME_CLEAR_ACTIVATED
-	};
-}
-
-// Set destination for 'back' button on theme sheet
-export function setBackPath( path ) {
-	return {
-		type: THEME_BACK_PATH_SET,
-		path: path,
-	};
 }

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { conforms, property } from 'lodash';
+import { conforms, omit, property } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -55,7 +55,16 @@ export function fetchThemes( site ) {
 
 		debug( 'Query params', queryParams );
 
-		return wpcom.undocumented().themes( site, queryParams )
+		const extendedQueryParams = omit(
+			{
+				...queryParams,
+				number: queryParams.perPage,
+				apiVersion: site.jetpack ? '1' : '1.2'
+			},
+			'perPage'
+		);
+
+		return wpcom.undocumented().themes( site ? site.ID : null, extendedQueryParams )
 			.then( themes => {
 				const responseTime = ( new Date().getTime() ) - startTime;
 				return dispatch( legacyReceiveThemes( themes, site, queryParams, responseTime ) );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -195,7 +195,7 @@ export function clearActivated() {
 export function setBackPath( path ) {
 	return {
 		type: THEME_BACK_PATH_SET,
-		path: path,
+		path,
 	};
 }
 


### PR DESCRIPTION
This PR is slightly more advanced than previous ones (#9476, #9506) in that there is a name collision: I had to rename our existing `receiveThemes` action to `legacyReceiveThemes`. This means that reviewers should check that is is imported correctly.

These actions will later replace the current `themes`, `themesList`, and `themeDetails` ones. This PR doesn't wire them to the live code yet, so their functionality is only covered by tests right now.

I hope the JSDoc blocks for individual actions are explanatory enough, so I'm not describing them here. If they aren't, just add a comment! I also added JSDoc blocks to a number of other actions that didn't have them yet.

To test: Make sure that the app still works as before (the theme showcase, specifically)