### PR TITLE
QueryThemes: Add

### DIFF
--- a/client/components/data/query-themes/README.md
+++ b/client/components/data/query-themes/README.md
@@ -1,0 +1,53 @@
+Query Themes
+============
+
+Query Themes is a React component used in managing the fetching of themes queries.
+
+## Usage
+
+Render the component, passing `siteId` and `query`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryThemes from 'components/data/query-themes';
+import Theme from 'components/theme';
+
+export default function MyThemesList( { themes } ) {
+	return (
+		<div>
+			<QueryThemes
+				siteId={ 3584907 }
+				query={ { search: 'Automattic' } } />
+			{ themes.map( ( theme ) => {
+				return (
+					<Theme
+						key={ theme.id }
+						theme={ theme } />
+				);
+			} }
+		</div>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td><code>null</code></td></tr>
+</table>
+
+The site ID for which themes should be queried.
+
+### `query`
+
+<table>
+	<tr><th>Type</th><td>Object</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td><code>null</code></td></tr>
+</table>
+
+The query to be used in requesting themes.

--- a/client/components/data/query-themes/README.md
+++ b/client/components/data/query-themes/README.md
@@ -9,10 +9,12 @@ Render the component, passing `siteId` and `query`. It does not accept any child
 
 ```jsx
 import React from 'react';
+import { connect } from 'react-redux';
 import QueryThemes from 'components/data/query-themes';
 import Theme from 'components/theme';
+import { getThemesForQueryIgnoringPage } from 'state/themes/selectors';
 
-export default function MyThemesList( { themes } ) {
+function MyThemesList( { themes } ) {
 	return (
 		<div>
 			<QueryThemes
@@ -28,6 +30,12 @@ export default function MyThemesList( { themes } ) {
 		</div>
 	);
 }
+
+export default connect(
+	( state ) => ( {
+		themes: getThemesForQueryIgnoringPage( state, 3584907, { search: 'Automattic' } )
+	} )
+)( MyThemesList );
 ```
 
 ## Props

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isJetpackSite } from 'state/sites/selectors';
 import { requestThemes } from 'state/themes/actions';
 import { isRequestingThemesForQuery } from 'state/themes/selectors';
 
@@ -17,7 +16,6 @@ class QueryThemes extends Component {
 		siteId: PropTypes.number,
 		query: PropTypes.object,
 		// Connected props
-		isJetpackSite: PropTypes.bool.isRequired,
 		isRequesting: PropTypes.bool.isRequired,
 		requestThemes: PropTypes.func.isRequired,
 	}
@@ -36,11 +34,7 @@ class QueryThemes extends Component {
 
 	request( props ) {
 		if ( ! props.isRequesting ) {
-			let { siteId } = props;
-			if ( ! props.isJetpackSite ) {
-				siteId = 'wpcom';
-			}
-			props.requestThemes( siteId, props.query );
+			props.requestThemes( props.siteId, props.query );
 		}
 	}
 
@@ -51,8 +45,7 @@ class QueryThemes extends Component {
 
 export default connect(
 	( state, { query, siteId } ) => ( {
-		isJetpackSite: !! isJetpackSite( state, siteId ),
-		isRequesting: isRequestingThemesForQuery( state, siteId || 'wpcom', query ),
+		isRequesting: isRequestingThemesForQuery( state, siteId, query ),
 	} ),
 	{ requestThemes }
 )( QueryThemes );

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -13,7 +13,10 @@ import { isRequestingThemesForQuery } from 'state/themes/selectors';
 
 class QueryThemes extends Component {
 	static propTypes = {
-		siteId: PropTypes.number,
+		siteId: PropTypes.oneOfType( [
+			PropTypes.number,
+			PropTypes.oneOf( [ 'wpcom' ] )
+		] ).isRequired,
 		query: PropTypes.object,
 		// Connected props
 		isRequesting: PropTypes.bool.isRequired,

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -36,7 +36,7 @@ class QueryThemes extends Component {
 
 	request( props ) {
 		if ( ! props.isRequesting ) {
-			let siteId = { props };
+			let { siteId } = props;
 			if ( ! props.isJetpackSite ) {
 				siteId = 'wpcom';
 			}

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import shallowEqual from 'react-pure-render/shallowEqual';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isJetpackSite } from 'state/sites/selectors';
+import { requestThemes } from 'state/themes/actions';
+import { isRequestingThemesForQuery } from 'state/themes/selectors';
+
+class QueryThemes extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		query: PropTypes.object,
+		// Connected props
+		isJetpackSite: PropTypes.bool.isRequired,
+		isRequesting: PropTypes.bool.isRequired,
+		requestThemes: PropTypes.func.isRequired,
+	}
+
+	componentDidMount() {
+		this.request( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.siteId === nextProps.siteId &&
+				shallowEqual( this.props.query, nextProps.query ) ) {
+			return;
+		}
+		this.request( nextProps );
+	}
+
+	request( props ) {
+		if ( ! props.isRequesting ) {
+			let siteId = { props };
+			if ( ! props.isJetpackSite ) {
+				siteId = 'wpcom';
+			}
+			props.requestThemes( siteId, props.query );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state, { query, siteId } ) => ( {
+		isJetpackSite: !! isJetpackSite( state, siteId ),
+		isRequesting: isRequestingThemesForQuery( state, siteId || 'wpcom', query ),
+	} ),
+	{ requestThemes }
+)( QueryThemes );

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { Component, PropTypes } from 'react';
-import shallowEqual from 'react-pure-render/shallowEqual';
 import { connect } from 'react-redux';
+import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ class QueryThemes extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.siteId === nextProps.siteId &&
-				shallowEqual( this.props.query, nextProps.query ) ) {
+				isEqual( this.props.query, nextProps.query ) ) {
 			return;
 		}
 		this.request( nextProps );

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -24,20 +24,21 @@ class QueryThemes extends Component {
 	}
 
 	componentDidMount() {
-		this.request( this.props );
+		this.request();
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteId === nextProps.siteId &&
-				isEqual( this.props.query, nextProps.query ) ) {
-			return;
-		}
-		this.request( nextProps );
+	shouldComponentUpdate( nextProps ) {
+		return this.props.siteId !== nextProps.siteId ||
+			! isEqual( this.props.query, nextProps.query );
 	}
 
-	request( props ) {
-		if ( ! props.isRequesting ) {
-			props.requestThemes( props.siteId, props.query );
+	componentDidUpdate() {
+		this.request();
+	}
+
+	request() {
+		if ( ! this.props.isRequesting ) {
+			this.props.requestThemes( this.props.siteId, this.props.query );
 		}
 	}
 

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -17,7 +17,19 @@ class QueryThemes extends Component {
 			PropTypes.number,
 			PropTypes.oneOf( [ 'wpcom' ] )
 		] ).isRequired,
-		query: PropTypes.object,
+		query: PropTypes.shape( {
+			// The search string
+			search: PropTypes.string,
+			// The tier to look for -- 'free', 'premium', or '' (for all themes). Doesn't work on Jetpack sites
+			tier: PropTypes.oneOf( [ '', 'free', 'premium' ] ),
+			// Comma-separated list of filters; see my-sites/themes/theme-filters
+			filter: PropTypes.string,
+			// Which page of the results list to display
+			page: PropTypes.number,
+			// How many results per page
+			number: PropTypes.number
+
+		} ),
 		// Connected props
 		isRequesting: PropTypes.bool.isRequired,
 		requestThemes: PropTypes.func.isRequired,

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -17,10 +17,11 @@ class QueryThemes extends Component {
 			PropTypes.number,
 			PropTypes.oneOf( [ 'wpcom' ] )
 		] ).isRequired,
+		// A theme query. Note that on Jetpack sites, only the `search` argument is supported.
 		query: PropTypes.shape( {
 			// The search string
 			search: PropTypes.string,
-			// The tier to look for -- 'free', 'premium', or '' (for all themes). Doesn't work on Jetpack sites
+			// The tier to look for -- 'free', 'premium', or '' (for all themes)
 			tier: PropTypes.oneOf( [ '', 'free', 'premium' ] ),
 			// Comma-separated list of filters; see my-sites/themes/theme-filters
 			filter: PropTypes.string,


### PR DESCRIPTION
Add a new `QueryThemes` query component for use with the new themes Redux state architecture. Uses actions from #9518, but can be merged independently.

Not covered by tests -- will be wired with #8785.