### PR TITLE
Fix function site.canManage not a function error on Akismet setup page

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -456,7 +456,7 @@ const PlansSetup = React.createClass( {
 		}
 
 		let turnOnManage;
-		if ( site && ! site.canManage() ) {
+		if ( site && ! site.canManage ) {
 			const manageUrl = site.getRemoteManagementURL() + '&section=plugins-setup';
 			turnOnManage = (
 				<Card className="jetpack-plugins-setup__need-manage">


### PR DESCRIPTION
When setting up Akismet plugin (after clicking on the setup page from Jetpack's plans page), I was getting a crash:

![jetpack-akisment-setup-crash](https://cloud.githubusercontent.com/assets/51896/20450818/4db111fc-ada8-11e6-8cdd-d466c10b694d.png)

`Uncaught (in promise) TypeError: site.canManage is not a function`

The URL is along the lines of: 

https://wordpress.com/plugins/setup/mynewjetpacksite.com?only=akismet

This crash is weird because everywhere else in Calypso, site.canManage() IS a function. Anyway, what I've pushed here is probably not the "real" solution but fixes the problem for me, and perhaps can guide some more experienced Calypso dev to the root cause.
