### PR TITLE
Revert "State: Add Jetpack computed properties to site object"

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -100,6 +100,7 @@ let Followers = React.createClass( {
 				key={ follower.ID }
 				user={ follower }
 				type="follower"
+				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing }
 				onRemove={ removeFollower }
 			/>

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -84,7 +84,7 @@ export default React.createClass( {
 			<Main>
 				<SidebarNavigation />
 				<div>
-					<PeopleSectionNav { ...omit( this.props, [ 'sites' ] ) } />
+					{ <PeopleSectionNav { ...omit( this.props, [ 'sites' ] ) } site={ site } /> }
 					<PeopleNotices />
 					{ this.renderPeopleList( site ) }
 				</div>

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
+import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
@@ -12,19 +13,22 @@ import CompactCard from 'components/card/compact';
 import PeopleProfile from 'my-sites/people/people-profile';
 import analytics from 'lib/analytics';
 import config from 'config';
-import { getSelectedSite } from 'state/ui/selectors';
-import { localize } from 'i18n-calypso';
 
-class PeopleListItem extends React.PureComponent {
+export default React.createClass( {
+
+	displayName: 'PeopleListItem',
+
+	mixins: [ PureRenderMixin ],
+
 	navigateToUser() {
 		window.scrollTo( 0, 0 );
 		analytics.ga.recordEvent( 'People', 'Clicked User Profile From Team List' );
-	}
+	},
 
 	userHasPromoteCapability() {
 		const site = this.props.site;
 		return site && site.capabilities && site.capabilities.promote_users;
-	}
+	},
 
 	canLinkToProfile() {
 		const site = this.props.site,
@@ -38,12 +42,13 @@ class PeopleListItem extends React.PureComponent {
 			this.userHasPromoteCapability() &&
 			! this.props.isSelectable
 		);
-	}
+	},
 
 	render() {
 		const canLinkToProfile = this.canLinkToProfile();
 		return (
 			<CompactCard
+				{ ...omit( this.props, 'className', 'user', 'site', 'isSelectable', 'onRemove' ) }
 				className={ classNames( 'people-list-item', this.props.className ) }
 				tagName="a"
 				href={ canLinkToProfile && '/people/edit/' + this.props.site.slug + '/' + this.props.user.login }
@@ -55,19 +60,11 @@ class PeopleListItem extends React.PureComponent {
 				this.props.onRemove &&
 				<div className="people-list-item__actions">
 					<button className="button is-link people-list-item__remove-button" onClick={ this.props.onRemove }>
-						{ this.props.translate( 'Remove', { context: 'Verb: Remove a user or follower from the blog.' } ) }
+						{ this.translate( 'Remove', { context: 'Verb: Remove a user or follower from the blog.' } ) }
 					</button>
 				</div>
 				}
 			</CompactCard>
 		);
 	}
-}
-
-const mapStateToProps = ( state ) => {
-	return {
-		site: getSelectedSite( state )
-	};
-};
-
-export default localize( connect( mapStateToProps )( PeopleListItem ) );
+} );

--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -12,7 +12,6 @@ import PeopleLog from 'lib/people/log-store';
 import PeopleActions from 'lib/people/actions';
 import Notice from 'components/notice';
 import { getSelectedSite } from 'state/ui/selectors';
-import { get } from 'lodash';
 
 const isSameSite = ( siteId, log ) => siteId && log.siteId && log.siteId === siteId;
 
@@ -57,8 +56,8 @@ const PeopleNotices = React.createClass( {
 	},
 
 	getState() {
-		const siteId = get( this.props, 'site.ID' ),
-			userId = get( this.props, 'user.ID' );
+		const siteId = this.props.site.ID,
+			userId = this.props.user && this.props.user.ID;
 
 		return {
 			errors: PeopleLog.getErrors( filterBy.bind( this, siteId, userId ) ),

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -1,26 +1,22 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import config from 'config';
-import { find, includes, get } from 'lodash';
-import { connect } from 'react-redux';
+var React = require( 'react' ),
+	config = require( 'config' ),
+	find = require( 'lodash/find' ),
+	includes = require( 'lodash/includes' );
 
 /**
  * Internal dependencies
  */
-import Search from 'components/search';
-import UrlSearch from 'lib/mixins/url-search';
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
-import { localize } from 'i18n-calypso';
-import { getSelectedSite } from 'state/ui/selectors';
-import versionCompare from 'lib/version-compare';
+var Search = require( 'components/search' ),
+	UrlSearch = require( 'lib/mixins/url-search' ),
+	SectionNav = require( 'components/section-nav' ),
+	NavTabs = require( 'components/section-nav/tabs' ),
+	NavItem = require( 'components/section-nav/item' );
 
-const PeopleSearch = React.createClass( {
+let PeopleSearch = React.createClass( {
 	displayName: 'PeopleSearch',
-
 	mixins: [ UrlSearch ],
 
 	render: function() {
@@ -37,8 +33,9 @@ const PeopleSearch = React.createClass( {
 	}
 } );
 
-class PeopleNavTabs extends React.PureComponent {
-	render() {
+let PeopleNavTabs = React.createClass( {
+	displayName: 'PeopleNavTabs',
+	render: function() {
 		return (
 			<NavTabs selectedText={ this.props.selectedText }>
 				{ this.props.filters.map( function( filterItem ) {
@@ -54,62 +51,63 @@ class PeopleNavTabs extends React.PureComponent {
 			</NavTabs>
 		);
 	}
-}
+} );
 
-class PeopleSectionNav extends React.PureComponent {
-	canSearch() {
-		const { site, filter } = this.props;
+module.exports = React.createClass( {
 
+	displayName: 'PeopleSectionNav',
+
+	canSearch: function() {
 		// Disable search for wpcom followers and viewers
-		if ( filter ) {
-			if ( 'followers' === filter || 'viewers' === filter ) {
+		if ( this.props.filter ) {
+			if ( 'followers' === this.props.filter || 'viewers' === this.props.filter ) {
 				return false;
 			}
 		}
 
-		if ( ! site.jetpack ) {
+		if ( ! this.props.site.jetpack ) {
 			// wpcom sites will always support search
 			return true;
 		}
-		if ( 'team' === filter && versionCompare( site.options.jetpack_version, '3.7.0-beta' ) < 0 ) {
+
+		if ( 'team' === this.props.filter && ! this.props.site.versionCompare( '3.7.0-beta', '>=' ) ) {
 			// Jetpack sites can only search team on versions of 3.7.0-beta or later
 			return false;
 		}
 
 		return true;
-	}
+	},
 
-	getFilters() {
-		const { translate } = this.props,
-			siteFilter = get( this.props, 'site.slug', '' ),
+	getFilters: function() {
+		var siteFilter = this.props.site.slug,
 			filters = [
 				{
-					title: translate( 'Team', { context: 'Filter label for people list' } ),
+					title: this.translate( 'Team', { context: 'Filter label for people list' } ),
 					path: '/people/team/' + siteFilter,
 					id: 'team'
 				},
 				{
-					title: translate( 'Followers', { context: 'Filter label for people list' } ),
+					title: this.translate( 'Followers', { context: 'Filter label for people list' } ),
 					path: '/people/followers/' + siteFilter,
 					id: 'followers'
 				},
 				{
-					title: translate( 'Email Followers', { context: 'Filter label for people list' } ),
+					title: this.translate( 'Email Followers', { context: 'Filter label for people list' } ),
 					path: '/people/email-followers/' + siteFilter,
 					id: 'email-followers'
 				},
 				{
-					title: translate( 'Viewers', { context: 'Filter label for people list' } ),
+					title: this.translate( 'Viewers', { context: 'Filter label for people list' } ),
 					path: '/people/viewers/' + siteFilter,
 					id: 'viewers'
 				}
 			];
 
 		return filters;
-	}
+	},
 
-	getNavigableFilters() {
-		const allowedFilterIds = [ 'team' ];
+	getNavigableFilters: function() {
+		var allowedFilterIds = [ 'team' ];
 		if ( config.isEnabled( 'manage/people/readers' ) ) {
 			allowedFilterIds.push( 'followers' );
 			allowedFilterIds.push( 'email-followers' );
@@ -120,32 +118,30 @@ class PeopleSectionNav extends React.PureComponent {
 		}
 
 		return this.getFilters().filter( filter => this.props.filter === filter.id || includes( allowedFilterIds, filter.id ) );
-	}
+	},
 
-	shouldDisplayViewers() {
-		const { site, filter } = this.props;
-		if ( site && ( 'viewers' === filter || ( ! site.jetpack && site.is_private ) ) ) {
+	shouldDisplayViewers: function() {
+		if ( 'viewers' === this.props.filter || ( ! this.props.site.jetpack && this.props.site.is_private ) ) {
 			return true;
 		}
 		return false;
-	}
+	},
 
-	render() {
-		const { site } = this.props;
-
-		let hasPinnedItems = false,
+	render: function() {
+		var selectedText,
+			hasPinnedItems = false,
 			search = null;
 
 		if ( this.props.fetching ) {
-			return <SectionNav></SectionNav>;
+			return <SectionNav></SectionNav>
 		}
 
-		if ( site && this.canSearch() ) {
+		if ( this.canSearch() ) {
 			hasPinnedItems = true;
 			search = <PeopleSearch { ...this.props } />;
 		}
 
-		const selectedText = find( this.getFilters(), { id: this.props.filter } ).title;
+		selectedText = find( this.getFilters(), { id: this.props.filter } ).title;
 		return (
 			<SectionNav selectedText={ selectedText } hasPinnedItems={ hasPinnedItems }>
 				<PeopleNavTabs { ...this.props } selectedText={ selectedText } filters={ this.getNavigableFilters() } />
@@ -153,13 +149,4 @@ class PeopleSectionNav extends React.PureComponent {
 			</SectionNav>
 		);
 	}
-}
-
-const mapStateToProps = ( state ) => {
-	return {
-		site: getSelectedSite( state )
-	};
-};
-
-export default localize( connect( mapStateToProps )( PeopleSectionNav ) );
-
+} );

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -112,6 +112,7 @@ var Team = React.createClass( {
 				key={ user.ID }
 				user={ user }
 				type="user"
+				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing } />
 		);
 	},

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -81,6 +81,7 @@ let Viewers = React.createClass( {
 				key={ viewer.ID }
 				user={ viewer }
 				type="viewer"
+				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing }
 				onRemove={ removeThisViewer }
 			/>

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -62,7 +62,7 @@ export const getSite = createSelector(
 			return null;
 		}
 
-		let attributes = {
+		return {
 			...site,
 			...getComputedAttributes( site ),
 			hasConflict: isSiteConflicting( state, siteId ),
@@ -71,22 +71,6 @@ export const getSite = createSelector(
 			domain: getSiteDomain( state, siteId ),
 			is_previewable: isSitePreviewable( state, siteId )
 		};
-
-		if ( attributes.jetpack ) {
-			attributes = Object.assign( attributes, {
-				canManage: canJetpackSiteManage( state, siteId ),
-				canUpdateFiles: canJetpackSiteUpdateFiles( state, siteId ),
-				canAutoupdateFiles: canJetpackSiteAutoUpdateFiles( state, siteId ),
-				hasJetpackMenus: hasJetpackSiteJetpackMenus( state, siteId ),
-				hasJetpackThemes: hasJetpackSiteJetpackThemes( state, siteId ),
-				isMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
-				isSecondaryNetworkSite: isJetpackSiteSecondaryNetworkSite( state, siteId ),
-				hasMinimumJetpackVersion: siteHasMinimumJetpackVersion( state, siteId ),
-				fileModDisabledReason: getJetpackSiteUpdateFilesDisabledReasons( state, siteId )
-			} );
-		}
-
-		return attributes;
 	},
 	( state ) => state.sites.items
 );
@@ -897,10 +881,6 @@ export function getJetpackSiteUpdateFilesDisabledReasons( state, siteId, action 
 	}
 
 	const fileModDisabled = getSiteOption( state, siteId, 'file_mod_disabled' );
-
-	if ( ! Array.isArray( fileModDisabled ) ) {
-		return false;
-	}
 
 	return compact( fileModDisabled.map( clue => {
 		if ( action === 'modifyFiles' || action === 'autoupdateFiles' || action === 'autoupdateCore' ) {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -109,40 +109,6 @@ describe( 'selectors', () => {
 				}
 			} );
 		} );
-
-		it( 'should return a normalized site with Jetpack specific computed attributes when site is Jetpack', () => {
-			const site = getSite( {
-					sites: {
-						items: {
-							2916284: {
-								ID: 2916284,
-								name: 'WordPress.com Example Blog',
-								URL: 'https://example.com',
-								options: {
-									unmapped_url: 'https://example.wordpress.com',
-									file_mod_disabled: [ 'has_no_file_system_write_access' ]
-								},
-								jetpack: true
-							}
-						}
-					}
-				}, 2916284 ),
-				expectedProps = [
-					'canManage',
-					'canUpdateFiles',
-					'canAutoupdateFiles',
-					'hasJetpackMenus',
-					'hasJetpackThemes',
-					'isMainNetworkSite',
-					'isSecondaryNetworkSite',
-					'hasMinimumJetpackVersion',
-					'fileModDisabledReason'
-				];
-
-			expectedProps.forEach( ( prop ) => {
-				expect( site ).to.have.property( prop );
-			} );
-		} );
 	} );
 
 	describe( '#getSiteCollisions', () => {
@@ -2005,18 +1971,6 @@ describe( 'selectors', () => {
 
 			const reason = getJetpackSiteUpdateFilesDisabledReasons( state, siteId, 'autoupdateCore' );
 			expect( reason ).to.deep.equal( [ 'Core autoupdates are explicitly disabled by a site administrator.' ] );
-		} );
-
-		it( 'it should return false if file_mod_disabled is not set', () => {
-			const state = createStateWithItems( {
-				[ siteId ]: {
-					ID: siteId,
-					jetpack: true
-				}
-			} );
-
-			const reason = getJetpackSiteUpdateFilesDisabledReasons( state, siteId, 'autoupdateCore' );
-			expect( reason ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#9389

Alternative solution to #9521. When I merged #9389 earlier, it was with the understanding that we'd need to slowly migrate components that relied on the Jetpack properties being present slowly. It turns out that there is already at least one place that is using the redux site, and then adding Jetpack properties by passing the site object to `lib/site/jetpack`.

Being late on a Friday night, I'm going to revert my changes from earlier and we can find another way to move forward.

To test:

- On a Jetpack site without a plan, purchase and a plan and attempt to auto-configure
- Ensure there is no error