### PR TITLE
Plugins: Take two of #9493

### DIFF
--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { doSearch, getSearchOpen } from 'lib/mixins/url-search';
+
+export default function( Component ) {
+	const componentName = Component.displayName || Component.name || '';
+
+	return class extends React.Component {
+		state = {
+			searchOpen: false
+		};
+
+		displayName = 'Searchable' + componentName;
+
+		constructor(props) {
+			super(props);
+
+			this.doSearch = doSearch.bind( this );
+			this.getSearchOpen = getSearchOpen.bind( this );
+		}
+
+		componentWillReceiveProps = ( { search } ) => ! search && this.setState( { searchOpen: false } );
+
+		render() {
+			return <Component { ...{
+				...this.props,
+				doSearch: this.doSearch,
+				getSearchOpen: this.getSearch,
+			} } />
+		}
+	};
+}

--- a/client/my-sites/plugins-wpcom/index.jsx
+++ b/client/my-sites/plugins-wpcom/index.jsx
@@ -8,6 +8,6 @@ import React from 'react';
  */
 import PluginPanel from 'my-sites/plugins-wpcom/plugin-panel';
 
-export const WpcomPluginsPanel = () => <PluginPanel />;
+export const WpcomPluginsPanel = ( { category, search } ) => <PluginPanel { ...{ category, search } } />;
 
 export default WpcomPluginsPanel;

--- a/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import PurchaseButton from './purchase-button';
+
+export const JetpackPluginItem = ( {
+	plugin,
+	siteSlug,
+	translate = identity
+} ) => {
+	const translatePlan = {
+		premium: translate( 'Premium' ),
+		business: translate( 'Business' ),
+	};
+	const planClasses = [
+		'button',
+		'is-compact',
+		'is-borderless',
+		`plugins-wpcom__is-${ plugin.plan }-plugin`,
+	].join( ' ' );
+	const featureLink = plugin.feature ? `?feature=${ plugin.feature }` : '';
+
+	return (
+		<CompactCard className="plugins-wpcom__jetpack-plugin-item">
+			<a href={ plugin.link } className="plugins-wpcom__plugin-link">
+				<div className="plugins-wpcom__plugin-name">
+					{ plugin.name }
+					{ [ 'premium', 'business' ].includes( plugin.plan ) &&
+						<span className={ planClasses }>
+							{ translatePlan[ plugin.plan ] }
+						</span>
+					}
+				</div>
+				<div className="plugins-wpcom__plugin-description">
+					{ plugin.description }
+				</div>
+			</a>
+			<div className="plugins-wpcom__plugin-actions">
+				<PurchaseButton { ...{
+					isActive: plugin.isActive,
+					href: `/plans/${ siteSlug }${ featureLink }`
+				} } />
+			</div>
+		</CompactCard>
+	);
+};
+
+JetpackPluginItem.propTypes = {
+	plugin: PropTypes.object,
+	siteSlug: PropTypes.string,
+};
+
+export default localize( JetpackPluginItem );

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -1,0 +1,220 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import {
+	find,
+	identity,
+	includes,
+	matchesProperty,
+	overSome,
+	some,
+} from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import urlSearch from 'lib/url-search';
+import CompactCard from 'components/card/compact';
+import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import JetpackPluginItem from './jetpack-plugin-item';
+import SectionHeader from 'components/section-header';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import Search from 'components/search';
+import jetpackPlugins from './jetpack-plugins';
+
+const filterGroup = category => group => {
+	if ( category && category !== 'all' ) {
+		return group.category === category;
+	}
+
+	return true;
+};
+
+const searchPlugins = search => overSome(
+	( { name } ) => includes( name.toLocaleLowerCase(), search.toLocaleLowerCase() ),
+	( { description } ) => includes( description.toLocaleLowerCase(), search.toLocaleLowerCase() )
+);
+
+const isPluginActive = ( plugin, hasBusiness, hasPremium ) => some( [
+	'standard' === plugin.plan,
+	'premium' === plugin.plan && hasPremium,
+	'business' === plugin.plan && hasBusiness,
+] );
+
+class JetpackPluginsPanel extends Component {
+
+	static propTypes = {
+		siteSlug: PropTypes.string,
+		hasBusiness: PropTypes.bool,
+		hasPremium: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		translate: identity,
+		category: 'all',
+		search: '',
+	};
+
+	getSearchPlaceholder() {
+		const { translate, category } = this.props;
+		switch ( category ) {
+			case 'all':
+				return translate( 'Search All…', { textOnly: true } );
+			case 'engagement':
+				return translate( 'Search Engagement…', { textOnly: true } );
+			case 'security':
+				return translate( 'Search Security…', { textOnly: true } );
+			case 'appearance':
+				return translate( 'Search Appearance…', { textOnly: true } );
+			case 'writing':
+				return translate( 'Search Writing…', { textOnly: true } );
+		}
+	}
+
+	getSelectedText( category ) {
+		const found = find( this.getNavItems(), matchesProperty( 'key', category ) );
+		return found ? found.title : '';
+	}
+
+	getNavItems() {
+		const { translate, siteSlug } = this.props;
+		const siteFilter = siteSlug ? '/' + siteSlug : '';
+		const basePath = '/plugins/category';
+
+		return [
+			{
+				key: 'all',
+				title: translate( 'All', { context: 'Filter label for plugins list' } ),
+				path: '/plugins' + siteFilter,
+			},
+			{
+				key: 'engagement',
+				title: translate( 'Engagement', { context: 'Filter label for plugins list' } ),
+				path: basePath + '/engagement' + siteFilter,
+			},
+			{
+				key: 'security',
+				title: translate( 'Security', { context: 'Filter label for plugins list' } ),
+				path: basePath + '/security' + siteFilter,
+			},
+			{
+				key: 'appearance',
+				title: translate( 'Appearance', { context: 'Filter label for plugins list' } ),
+				path: basePath + '/appearance' + siteFilter,
+			},
+			{
+				key: 'writing',
+				title: translate( 'Writing', { context: 'Filter label for plugins list' } ),
+				path: basePath + '/writing' + siteFilter,
+			},
+		];
+	}
+
+	render() {
+		const {
+			translate,
+			doSearch,
+			category,
+			siteSlug,
+			search,
+			hasPremium,
+			hasBusiness
+		} = this.props;
+
+		const filteredPlugins = jetpackPlugins( translate )
+			.filter( filterGroup( category ) )
+			.map( group => ( {
+				...group,
+				plugins: group.plugins
+					.filter( searchPlugins( search ) )
+					.map( plugin => ( {
+						...plugin,
+						isActive: isPluginActive( plugin, hasPremium, hasBusiness ),
+					} ) )
+			} ) )
+			.filter( group => group.plugins.length > 0 );
+
+		return (
+			<div className="plugins-wpcom__jetpack-plugins-panel">
+
+				<SectionNav selectedText={ this.getSelectedText( category ) }>
+					<NavTabs selectedText={ this.getSelectedText( category ) }>
+						{ this.getNavItems().map( item =>
+							<NavItem { ...item } selected={ item.key === category }>
+								{ item.title }
+							</NavItem>
+						) }
+					</NavTabs>
+					<Search
+						pinned
+						fitsContainer
+						delaySearch
+						onSearch={ doSearch }
+						placeholder={ this.getSearchPlaceholder() }
+					/>
+				</SectionNav>
+
+				<SectionHeader label={ translate( 'Plugins' ) } />
+
+				<CompactCard className="plugins-wpcom__jetpack-main-plugin plugins-wpcom__jetpack-plugin-item">
+					<div className="plugins-wpcom__plugin-link">
+						<PluginIcon image="//ps.w.org/jetpack/assets/icon-256x256.png" />
+						<div className="plugins-wpcom__plugin-content">
+							<div className="plugins-wpcom__plugin-name">
+								{ translate( 'Jetpack by WordPress.com' ) }
+							</div>
+							<div className="plugins-wpcom__plugin-description">
+								{ translate( 'Jetpack essential features are included with every plan' ) }
+							</div>
+						</div>
+					</div>
+					<div className="plugins-wpcom__plugin-actions">
+						<Button className="plugins-wpcom__plugin-is-active is-active-plugin" compact borderless>
+							<Gridicon icon="checkmark" />{ translate( 'Active' ) }
+						</Button>
+					</div>
+				</CompactCard>
+
+				<CompactCard className="plugins-wpcom__jetpack-plugins-list">
+					{ filteredPlugins.length > 0 &&
+						filteredPlugins.map( group => (
+						<div key={ group.category }>
+							<CompactCard className="plugins-wpcom__jetpack-category-header">
+								<Gridicon icon={ group.icon } />
+								<span>
+									{ group.name }
+								</span>
+							</CompactCard>
+							{ group.plugins.map( ( plugin, index ) => (
+							<JetpackPluginItem
+								{ ...{
+									key: index,
+									plugin,
+									siteSlug,
+								} }
+							/>
+							) ) }
+						</div>
+						) )
+					}
+					{ filteredPlugins.length === 0 &&
+						<div className="plugins-wpcom__empty-results">
+							{ translate( 'No features match your search for \'%s\'.', {
+								args: [ search ]
+							} )}
+						</div>
+					}
+				</CompactCard>
+
+			</div>
+		);
+	}
+}
+
+export default localize( urlSearch( JetpackPluginsPanel ) );

--- a/client/my-sites/plugins-wpcom/jetpack-plugins.js
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins.js
@@ -1,0 +1,185 @@
+/**
+ * External dependencies
+ */
+import { identity } from 'lodash';
+
+const jetpackPlugins = ( translate = identity ) => [
+	{
+		category: 'engagement',
+		name: translate( 'Engagement' ),
+		icon: 'stats-alt',
+		plugins: [
+			{
+				name: translate( 'Stats' ),
+				link: 'https://support.wordpress.com/stats/',
+				description: translate( 'View your site\'s visits, referrers, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Social Media' ),
+				link: 'https://support.wordpress.com/sharing/',
+				description: translate( 'Add social media buttons to your posts and pages.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Publicize' ),
+				link: 'https://support.wordpress.com/publicize/',
+				description: translate( 'Automatically share your posts on Facebook, Twitter, Tumblr, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Email Subscriptions' ),
+				link: 'https://support.wordpress.com/follow-blog-widget/',
+				description: translate( 'Enables your readers to sign up to receive your posts via email.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Related Posts' ),
+				link: 'https://support.wordpress.com/related-posts/',
+				description: translate( 'Pulls relevant content from your blog to display at the bottom of your posts.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Likes' ),
+				link: 'https://support.wordpress.com/likes/',
+				description: translate( 'Engage readers with a Like button on your posts.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Advanced Comments' ),
+				link: 'https://support.wordpress.com/comments/',
+				description: translate( 'Comment likes, user mentions, notifications, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'SEO Tools' ),
+				link: 'https://support.wordpress.com/seo-tools/',
+				description: translate( 'Custom meta descriptions, social media previews, and more.' ),
+				plan: 'business',
+				feature: 'advanced-seo'
+			},
+			{
+				name: translate( 'Google Analytics' ),
+				link: 'https://support.wordpress.com/google-analytics/',
+				description: translate( 'Advanced features to complement WordPress.com stats. Funnel reports, goal conversion, and more.' ),
+				plan: 'business',
+				feature: 'google-analytics'
+			},
+		],
+	},
+	{
+		category: 'security',
+		name: translate( 'Security' ),
+		icon: 'spam',
+		plugins: [
+			{
+				name: translate( 'Security Scanning' ),
+				link: 'https://support.wordpress.com/security/',
+				description: translate( 'Constant monitoring of your site for threats.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Backup & Export' ),
+				link: 'https://support.wordpress.com/export/#backups',
+				description: translate( '24/7 backup of your entire site. Export everything.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Akismet' ),
+				link: 'http://akismet.com/',
+				description: translate( 'Advanced anti-spam security.' ),
+				plan: 'standard',
+			},
+		],
+	},
+	{
+		category: 'appearance',
+		name: translate( 'Appearance' ),
+		icon: 'customize',
+		plugins: [
+			{
+				name: translate( 'Advanced Galleries' ),
+				link: 'https://support.wordpress.com/images/gallery/',
+				description: translate( 'Tiled, mosaic, slideshows, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Extended Customizer' ),
+				link: 'https://support.wordpress.com/customizer/',
+				description: translate( 'Edit colors and backgrounds.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Extended Widgets' ),
+				link: 'https://support.wordpress.com/widgets-sidebars/',
+				description: translate( 'Eventbrite, Flickr, Google Calendar, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Infinite Scroll' ),
+				link: 'https://support.wordpress.com/infinite-scroll/',
+				description: translate( 'Load more posts when you reach the bottom of a page on your site.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Photon CDN' ),
+				link: 'https://support.wordpress.com/photon/',
+				description: translate( 'Faster image loading and editing.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Custom Design' ),
+				link: 'https://support.wordpress.com/custom-design/',
+				description: translate( 'Customize your blog\'s look with custom fonts, a CSS editor, and more.' ),
+				plan: 'premium',
+				feature: 'advanced-design'
+			},
+		],
+	},
+	{
+		category: 'writing',
+		name: translate( 'Writing' ),
+		icon: 'pencil',
+		plugins: [
+			{
+				name: translate( 'Form Builder' ),
+				link: 'https://support.wordpress.com/contact-form/',
+				description: translate( 'Build contact forms so visitors can get in touch.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Extended Shortcodes' ),
+				link: 'https://support.wordpress.com/shortcodes/',
+				description: translate( 'YouTube, Twitter, Instagram, Spotify, and more.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Importer' ),
+				link: 'https://support.wordpress.com/import/',
+				description: translate( 'Import your blog content from a variety of other blogging platforms.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Polls & Surveys' ),
+				link: 'https://support.wordpress.com/polls/',
+				description: translate( 'Add polls and surveys to your site.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Markdown' ),
+				link: 'https://support.wordpress.com/markdown/',
+				description: translate( 'Text formatting using a lightweight markup language.' ),
+				plan: 'standard',
+			},
+			{
+				name: translate( 'Video Uploads' ),
+				link: 'https://support.wordpress.com/videopress/',
+				description: translate( 'Upload and host your video files on your site with VideoPress.' ),
+				plan: 'premium',
+				feature: 'video-upload'
+			},
+		],
+	},
+];
+
+export default jetpackPlugins;

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import {
 	getSelectedSite,
 	getSelectedSiteId
@@ -20,66 +19,30 @@ import {
 	isBusiness,
 	isEnterprise
 } from 'lib/products-values';
-import StandardPluginsPanel from './standard-plugins-panel';
-import PremiumPluginsPanel from './premium-plugins-panel';
-import BusinessPluginsPanel from './business-plugins-panel';
+import JetpackPluginsPanel from './jetpack-plugins-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import {
-	defaultStandardPlugins,
-	defaultPremiumPlugins,
-	defaultBusinessPlugins
-} from './default-plugins';
-
-/*
- *replacements e.g. { siteSlug: 'mytestblog.wordpress.com', siteId: 12345 }
- */
-const linkInterpolator = replacements => plugin => {
-	const { descriptionLink: link } = plugin;
-	const descriptionLink = Object
-		.keys( replacements )
-		.reduce(
-			( s, r ) => s.replace( new RegExp( `{${ r }}` ), replacements[ r ] ),
-			link
-		);
-
-	return { ...plugin, descriptionLink };
-};
 
 export const PluginPanel = ( {
 	plan,
 	siteSlug,
-	translate,
+	category,
+	search,
 } ) => {
-	const standardPluginsLink = `/plugins/category/standard/${ siteSlug }`;
-	const purchaseLink = `/plans/${ siteSlug }`;
-
 	const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
 	const hasPremium = hasBusiness || isPremium( plan );
 
-	const interpolateLink = linkInterpolator( { siteSlug } );
-
-	const standardPlugins = defaultStandardPlugins.map( interpolateLink );
-	const premiumPlugins = defaultPremiumPlugins.map( interpolateLink );
-	const businessPlugins = defaultBusinessPlugins.map( interpolateLink );
-
 	return (
-		<div className="wpcom-plugin-panel">
+		<div className="plugins-wpcom__panel">
 			<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
-			<Card compact className="plugins-wpcom__header">
-				<div className="plugins-wpcom__header-text">
-					<span className="plugins-wpcom__header-title">{ translate( 'Included Plugins' ) }</span>
-					<span className="plugins-wpcom__header-subtitle">
-						{ translate( 'Every plan includes a set of plugins specially tailored to supercharge your site.' ) }
-					</span>
-				</div>
-				<img className="plugins-wpcom__header-image" src="/calypso/images/plugins/plugins_hero.svg" />
-			</Card>
-			<StandardPluginsPanel plugins={ standardPlugins } displayCount={ 9 } />
-			<Card className="wpcom-plugin-panel__panel-footer" href={ standardPluginsLink }>
-				{ translate( 'View all standard plugins' ) }
-			</Card>
-			<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium } { ...{ purchaseLink } } />
-			<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness } { ...{ purchaseLink } } />
+
+			<JetpackPluginsPanel { ...{
+				siteSlug,
+				hasBusiness,
+				hasPremium,
+				category,
+				search,
+			} } />
+
 		</div>
 	);
 };

--- a/client/my-sites/plugins-wpcom/purchase-button.jsx
+++ b/client/my-sites/plugins-wpcom/purchase-button.jsx
@@ -23,7 +23,7 @@ export const PurchaseButton = ( {
 	)
 	: (
 		<Button compact primary { ...{ href } }>
-			{ translate( 'Purchase' ) }
+			{ translate( 'Upgrade' ) }
 		</Button>
 	);
 

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -50,11 +50,11 @@
 // Special styles for displaying only two plugins
 .wpcom-plugins__business-panel .wpcom-plugins__plugin-item {
 	width: 100%;
-	
+
 	&:last-child {
 		border-right: none;
 	}
-	
+
 	@include breakpoint( ">960px" ) {
 		width: 50%;
 		border-right: 1px solid lighten( $gray, 20% );
@@ -114,10 +114,12 @@
 	margin-bottom: 0;
 }
 
-.wpcom-plugin-panel button.is-active-plugin {
+.plugins-wpcom__panel button.is-active-plugin {
 	color: $alert-green;
+	cursor: default;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		color: $alert-green;
 	}
 }
@@ -146,7 +148,7 @@
 	}
 }
 
-.wpcom-plugin-panel .notice {
+.plugins-wpcom__panel .notice {
 	margin: 0;
 }
 
@@ -195,5 +197,149 @@
 
 	@include breakpoint( ">960px" ) {
 		margin: 0 auto;
+	}
+}
+
+.plugins-wpcom__empty-results {
+	padding: 11px 16px;
+}
+
+.plugins-wpcom__jetpack-plugin-item.card {
+	display: flex;
+	flex-direction: row;
+	padding: 0;
+
+	.plugins-wpcom__plugin-link {
+		display: block;
+		flex-grow: 1;
+		font-size: 14px;
+		padding: 16px 0 16px 16px;
+		overflow: hidden;
+	}
+
+	.plugins-wpcom__plugin-name {
+		color: $gray-dark;
+		display: block;
+		line-height: 21px;
+		overflow: hidden;
+		text-align: left;
+		text-overflow: ellipsis;
+		white-space: pre;
+	}
+
+	.plugins-wpcom__plugin-description {
+		color: $gray;
+		font-size: 12px;
+		padding: 2px 0;
+
+		@include breakpoint( '>480px' ) {
+			font-size: 14px;
+		}
+	}
+
+	.plugins-wpcom__plugin-actions {
+		align-self: center;
+		flex-grow: 1;
+		flex-shrink: 0;
+		padding: 16px;
+		text-align: right;
+
+		@include breakpoint( '>480px' ) {
+			flex-grow: 0;
+		}
+
+		@include breakpoint( '>660px' ) {
+			padding-right: 24px;
+			padding-left: 24px;
+		}
+	}
+
+	.plugins-wpcom__is-premium-plugin,
+	.plugins-wpcom__is-business-plugin {
+		display: block;
+		@include breakpoint( '>480px' ) {
+			display: inline-block;
+			margin-left: 10px;
+		}
+	}
+	.plugins-wpcom__is-premium-plugin {
+		color: $alert-green;
+	}
+	.plugins-wpcom__is-business-plugin {
+		color: $alert-purple;
+	}
+}
+
+.plugins-wpcom__jetpack-main-plugin.card {
+	.plugins-wpcom__plugin-link {
+		display: flex;
+		padding: 16px 0 16px 16px;
+		@include breakpoint( '>660px' ) {
+			padding: 24px 0 24px 24px;
+		}
+
+		.plugin-icon {
+			float: none;
+			flex-shrink: 0;
+		}
+		.plugins-wpcom__plugin-content {
+			flex-grow: 1;
+			overflow: hidden;
+		}
+	}
+
+	.plugins-wpcom__plugin-name {
+		@include breakpoint( '>480px' ) {
+			font-size: 24px;
+			font-weight: 700;
+			font-family: $serif;
+			line-height: 32px;
+		}
+	}
+}
+
+.plugins-wpcom__jetpack-plugins-list.card {
+	padding: 0;
+
+	.plugins-wpcom__jetpack-plugin-item.card {
+		&:hover {
+			//box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+			//	0 1px 2px darken( $gray, 30% );
+			box-shadow: 0 0 0 1px $gray;
+		}
+	}
+
+	.plugins-wpcom__plugin-name {
+		@include breakpoint( '>480px' ) {
+			font-size: 18px;
+		}
+	}
+}
+
+.plugins-wpcom__jetpack-category-header.card {
+	color: $gray;
+	font-size: 14px;
+	line-height: 15px;
+	padding-bottom: 11px;
+	padding-left: 50px;
+	padding-top: 11px;
+	position: relative;
+
+	@include breakpoint( '>480px' ) {
+		line-height: 25px;
+		padding-left: 60px;
+	}
+
+	.gridicon {
+		height: 24px;
+		left: 16px;
+		position: absolute;
+		top: 6px;
+		width: 24px;
+
+		@include breakpoint( '>480px' ) {
+			left: 24px;
+			top: 11px;
+		}
 	}
 }

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -93,6 +93,7 @@ function renderPluginList( context, basePath ) {
 				path: basePath,
 				context,
 				filter: context.params.pluginFilter,
+				category: context.params.category,
 				sites,
 				search
 			} )

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -51,7 +51,7 @@ module.exports = function() {
 			controller.siteSelection,
 			controller.navigation,
 			nonJetpackRedirectTo( '/plugins' ),
-			pluginsController.plugin,
+			pluginsController.plugins.bind( null, 'all' ),
 		);
 
 		page( '/plugins',

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -328,14 +328,21 @@ const PluginsMain = React.createClass( {
 	},
 
 	render() {
-		const { selectedSite } = this.props;
+		const {
+			category,
+			search,
+			selectedSite,
+		} = this.props;
 
 		if ( selectedSite && ! this.props.selectedSiteIsJetpack ) {
 			return (
 				<Main>
 					{ this.renderDocumentHead() }
 					<SidebarNavigation />
-					<WpcomPluginPanel />
+					<WpcomPluginPanel { ...{
+						category,
+						search,
+					} } />
 				</Main>
 			);
 		}


### PR DESCRIPTION
See #9493 

When deploying #9493 we missed that some rebase conflicts were resolved
improperly, having removed the work that @tyxla did removing references
to `sites-list`.

This resolution caused the plugins page to always show the list of
Jetpack features for WordPress.com sites even when proper Jetpack sites
were selected.

This patch has been created by cloning the diff of the changes from that
branch and fixing the conflicts properly.

cc: @roundhill @rodrigoi @vindl @Copons @drw158 