### PR TITLE
SEO: fix wrong device button in preview on mobile

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -93,7 +93,8 @@
 
 .web-preview__close,
 .web-preview__external,
-.web-preview__device-button {
+.web-preview__device-button,
+.web-preview__seo-button {
 	color: $gray;
 	border-right: 1px solid lighten( $gray, 20% );
 	padding: 12px 16px;
@@ -136,15 +137,20 @@
 	@include breakpoint( "<660px" ) {
 		display: none;
 	}
+}
 
-	&.web-preview__seo-button {
-		padding: 0 14px;
-		height: 100%;
+.web-preview__seo-button {
+	border-right: none;
+	padding: 0 14px;
+	height: 100%;
 
-		&.is-showing-device-switcher {
-			border-left: 1px solid lighten( $gray, 20% );
-			margin-left: 8px;
-		}
+	&.is-active {
+		color: $gray-dark;
+	}
+
+	&.is-showing-device-switcher {
+		border-left: 1px solid lighten( $gray, 20% );
+		margin-left: 8px;
 	}
 }
 

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -79,15 +79,16 @@ export const PreviewToolbar = props => {
 					) ) }
 				</div>
 			}
-			{ showSEO &&
+			{ showDeviceSwitcher &&
 			<button
 				aria-hidden={ true }
 				key={ 'back-to-preview' }
 				className={ classNames(
 					'web-preview__device-button',
 					'web-preview__back-to-preview-button', {
-					'is-active': currentDevice !== 'seo'
-				} ) }
+						'is-active': currentDevice !== 'seo'
+					}
+				) }
 				onClick={ partial( setDeviceViewport, 'phone' ) }
 			>
 				<Gridicon icon="phone" />
@@ -97,11 +98,11 @@ export const PreviewToolbar = props => {
 				<button
 					aria-label={ translate( 'Show SEO and search previews' ) }
 					className={ classNames(
-						'web-preview__seo-button',
-						'web-preview__device-button', {
-						'is-active': 'seo' === currentDevice,
-						'is-showing-device-switcher': showDeviceSwitcher
-					} ) }
+						'web-preview__seo-button', {
+							'is-active': 'seo' === currentDevice,
+							'is-showing-device-switcher': showDeviceSwitcher
+						}
+					) }
 					onClick={ selectSeoPreview }
 				>
 					<Gridicon icon="globe" />

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -85,9 +85,8 @@ export const PreviewToolbar = props => {
 				key={ 'back-to-preview' }
 				className={ classNames(
 					'web-preview__device-button',
-					'web-preview__back-to-preview-button', {
-						'is-active': currentDevice !== 'seo'
-					}
+					'web-preview__back-to-preview-button',
+					{ 'is-active': 'seo' !== currentDevice }
 				) }
 				onClick={ partial( setDeviceViewport, 'phone' ) }
 			>


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/9488.

On small screens, replaced the wrong phone preview button with the
correct SEO preview one.

| Before | After |
| --- | --- |
| ![screen shot 2016-11-19 at 18 52 46](https://cloud.githubusercontent.com/assets/2070010/20458657/712eb0b2-ae89-11e6-926b-be2ab766e201.png) | ![screen shot 2016-11-19 at 18 52 59](https://cloud.githubusercontent.com/assets/2070010/20458658/712ef108-ae89-11e6-8c3d-8fca5288b0e4.png) |
