### PR TITLE
DevDocs: Display Readme Alongside Component in Single View

### DIFF
--- a/client/components/clipboard-button-input/README.md
+++ b/client/components/clipboard-button-input/README.md
@@ -22,22 +22,7 @@ export default function MyComponent() {
 
 The following props can be passed to the ClipboardButtonInput component. With the exception of `className`, all props, including those not listed below, will be passed to the child `<input />` element.
 
-### `value`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>""</code></td></tr>
-</table>
-
-The value of the `<input />` element, and the text to be copied when clicking the copy button.
-
-### `disabled`
-
-<table>
-	<tr><td>Type</td><td>Boolean</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>false</code></td></tr>
-</table>
-
-Whether the children `<input />` and `<button />` should be rendered as `disabled`.
+| prop     | type    | required | default | comment |
+| -------- | ------- | :------: | ------- | ------- |
+| value    | string  | No       | ""      | The value of the `<input />` element, and the text to be copied when clicking the button |
+| disabled | boolean | No       | false   | Whether the children `<input />` and `<button />` should be rendered as `disabled` | 

--- a/client/components/forms/clipboard-button/README.md
+++ b/client/components/forms/clipboard-button/README.md
@@ -24,22 +24,7 @@ React.createClass( {
 
 Below is a list of supported props. With the exception of `className`, any other props passed will be transferred to the rendered `<FormButton />` component.
 
-### `text`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>undefined</code></td></tr>
-</table>
-
-The text to copy to the user's clipboard upon clicking the button.
-
-### `onCopy`
-
-<table>
-	<tr><td>Type</td><td>Function</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>lodash/noop</code></td></tr>
-</table>
-
-Function to invoke after the text has been copied to the user's clipboard. This will not be triggered if the a prompt is shown in place of direct clipboard copy, in cases where the browser does not grant clipboard access.
+| prop   | type     | required | default     | comment |
+| ------ | :------: | :------: | ----------- | ------- |
+| text   | string   | No       | undefined   | The text to copy to the user's clipboard upon clicking the button |
+| opCopy | function | No       | lodash/noop | Function to invoke after the text has been copied to the user's clipboard. This will not be triggered if the prompt is show in place of a direct clipboard copy, in cases where the browser does no grant clipboard access |

--- a/client/components/spinner/README.md
+++ b/client/components/spinner/README.md
@@ -3,7 +3,7 @@ Spinner
 
 Spinner is a React component for rendering a loading indicator.
 
-<img src="https://cldup.com/H27NKdxFBN.gif" alt="Demo" />
+![Spinner Demo](https://cldup.com/H27NKdxFBN.gif)
 
 __Please exercise caution in deciding to use a spinner in your component.__ A lone spinner is a poor user-experience and conveys little context to what the user should expect from the page. Refer to [the _Reactivity and Loading States_ guide](https://github.com/Automattic/wp-calypso/blob/master/docs/reactivity.md) for more information on building fast interfaces and making the most of data already available to use.
 
@@ -24,22 +24,8 @@ React.createClass( {
 
 The following props can be passed to the Spinner component:
 
-### `size`
+| prop name | type   | required | default | comment |
+| --------- | ------ | :------: | ------: | ------- |
+| size      | Number | No       | 20      | The width and height, in pixels |
+| duration  | Number | No       | 3000    | The duration of a single revolution, in milliseconds |
 
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td>20</td></tr>
-</table>
-
-The width and height of the spinner, in pixels.
-
-### `duration`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td>3000</td></tr>
-</table>
-
-The duration of a single spin animation, in milliseconds.

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -11,6 +11,7 @@ import {
 	camelCaseToSlug,
 	getComponentName,
 } from 'devdocs/docs-example/util';
+import Readme from 'devdocs/docs-example/readme';
 
 const shouldShowInstance = ( example, filter, component ) => {
 	const name = getComponentName( example );
@@ -65,6 +66,7 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 				url={ exampleLink }
 			>
 				{ example }
+				{ component ? <Readme component={ component } /> : null }
 			</DocsExampleWrapper>
 		);
 	} );

--- a/client/devdocs/docs-example/readme.jsx
+++ b/client/devdocs/docs-example/readme.jsx
@@ -1,10 +1,14 @@
-/** External Dependencies */
+/**
+ * External Dependencies
+ */
 import React, { Component, PropTypes } from 'react';
 import request from 'superagent';
 import Remarkable from 'remarkable';
 import RemarkableReactRenderer from 'remarkable-react';
 
-/** Internal Dependencies */
+/**
+ * Internal Dependencies
+ */
 import Spinner from 'components/spinner';
 import Card from 'components/card';
 import Ribbon from 'components/ribbon';
@@ -53,29 +57,33 @@ class Readme extends Component {
 	render() {
 		if ( this.state.loading ) {
 			return (
-				<div>
+				<div className="docs-example__readme-content">
 					<hr />
-					<div className="docs-example__readme-loading-message">
-						Loading readme, please wait
-					</div>
-					<Spinner className="docs-example__readme-spinner" size={ 50 } />
+					<Card>
+						<div className="docs-example__readme-loading-message">
+							Loading readme, please wait
+						</div>
+						<Spinner className="docs-example__readme-spinner" size={ 50 } />
+					</Card>
 				</div>
 			);
 		}
 
 		if ( this.state.error ) {
 			return (
-				<div>
-					<p>An error has occurred loading the readme! The server
-						responded: { `${ this.state.error }` }</p>
+				<div className="docs-example__readme-content">
 					<hr />
-					<p>
-						Reasons that you may be seeing this error:
-					</p>
-					<ul>
-						<li>Check that { `${ this.props.component }` }/README.md exists</li>
-						<li>Ensure the server is running</li>
-					</ul>
+					<Card>
+						<p>An error has occurred loading the readme! The server
+							responded: { `${ this.state.error }` }</p>
+						<p>
+							Reasons that you may be seeing this error:
+						</p>
+						<ul>
+							<li>Check that { `${ this.props.component }` }/README.md exists</li>
+							<li>Ensure the server is running</li>
+						</ul>
+					</Card>
 				</div>
 			);
 		}

--- a/client/devdocs/docs-example/readme.jsx
+++ b/client/devdocs/docs-example/readme.jsx
@@ -6,6 +6,8 @@ import RemarkableReactRenderer from 'remarkable-react';
 
 /** Internal Dependencies */
 import Spinner from 'components/spinner';
+import Card from 'components/card';
+import Ribbon from 'components/ribbon';
 
 class Readme extends Component {
 	constructor( props ) {
@@ -81,7 +83,10 @@ class Readme extends Component {
 		return (
 			<div className="docs-example__readme-content">
 				<hr />
-				{ this.md.render( this.state.readmeHtml ) }
+				<Card>
+					<Ribbon>README.md</Ribbon>
+					{ this.md.render( this.state.readmeHtml ) }
+				</Card>
 			</div>
 		);
 	}

--- a/client/devdocs/docs-example/readme.jsx
+++ b/client/devdocs/docs-example/readme.jsx
@@ -1,7 +1,8 @@
 /** External Dependencies */
 import React, { Component, PropTypes } from 'react';
 import request from 'superagent';
-import ReactMarkdown from 'react-markdown';
+import Remarkable from 'remarkable';
+import RemarkableReactRenderer from 'remarkable-react';
 
 /** Internal Dependencies */
 import Spinner from 'components/spinner';
@@ -9,6 +10,12 @@ import Spinner from 'components/spinner';
 class Readme extends Component {
 	constructor( props ) {
 		super( props );
+
+		this.md = new Remarkable( {
+			linkify: true, // auto-convert things that look like links to <a> components
+			typographer: true // prettify quotes in the content
+		} );
+		this.md.renderer = new RemarkableReactRenderer();
 	}
 
 	componentWillMount() {
@@ -30,9 +37,7 @@ class Readme extends Component {
 			.then( ( { text } ) => {
 				this.setState( {
 					loading: false,
-					readmeHtml: (
-						<ReactMarkdown source={ text } escapeHtml={ true } />
-					)
+					readmeHtml: text
 				} );
 			} )
 			.catch( ( err ) => {
@@ -48,10 +53,10 @@ class Readme extends Component {
 			return (
 				<div>
 					<hr />
-					<div className="docs-example__readme_loading_message">
+					<div className="docs-example__readme-loading-message">
 						Loading readme, please wait
 					</div>
-					<Spinner className="docs-example__readme_spinner" size={ 50 } />
+					<Spinner className="docs-example__readme-spinner" size={ 50 } />
 				</div>
 			);
 		}
@@ -59,13 +64,25 @@ class Readme extends Component {
 		if ( this.state.error ) {
 			return (
 				<div>
-					An error has occurred loading the readme!
+					<p>An error has occurred loading the readme! The server
+						responded: { `${ this.state.error }` }</p>
+					<hr />
+					<p>
+						Reasons that you may be seeing this error:
+					</p>
+					<ul>
+						<li>Check that { `${ this.props.component }` }/README.md exists</li>
+						<li>Ensure the server is running</li>
+					</ul>
 				</div>
 			);
 		}
 
 		return (
-			this.state.readmeHtml
+			<div className="docs-example__readme-content">
+				<hr />
+				{ this.md.render( this.state.readmeHtml ) }
+			</div>
 		);
 	}
 }

--- a/client/devdocs/docs-example/readme.jsx
+++ b/client/devdocs/docs-example/readme.jsx
@@ -1,0 +1,77 @@
+/** External Dependencies */
+import React, { Component, PropTypes } from 'react';
+import request from 'superagent';
+import ReactMarkdown from 'react-markdown';
+
+/** Internal Dependencies */
+import Spinner from 'components/spinner';
+
+class Readme extends Component {
+	constructor( props ) {
+		super( props );
+	}
+
+	componentWillMount() {
+		this.requestReadme( this.props.component );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.component !== nextProps.component ) {
+			this.requestReadme( this.props.component );
+		}
+	}
+
+	requestReadme = ( component ) => {
+		this.setState( {
+			loading: true
+		} );
+		request.get( '/devdocs/service/content' )
+			.query( { component } )
+			.then( ( { text } ) => {
+				this.setState( {
+					loading: false,
+					readmeHtml: (
+						<ReactMarkdown source={ text } escapeHtml={ true } />
+					)
+				} );
+			} )
+			.catch( ( err ) => {
+				this.setState( {
+					loading: false,
+					error: err
+				} );
+			} );
+	};
+
+	render() {
+		if ( this.state.loading ) {
+			return (
+				<div>
+					<hr />
+					<div className="docs-example__readme_loading_message">
+						Loading readme, please wait
+					</div>
+					<Spinner className="docs-example__readme_spinner" size={ 50 } />
+				</div>
+			);
+		}
+
+		if ( this.state.error ) {
+			return (
+				<div>
+					An error has occurred loading the readme!
+				</div>
+			);
+		}
+
+		return (
+			this.state.readmeHtml
+		);
+	}
+}
+
+Readme.propTypes = {
+	component: PropTypes.string.isRequired
+};
+
+export default Readme;

--- a/client/devdocs/docs-example/readme.jsx
+++ b/client/devdocs/docs-example/readme.jsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import request from 'superagent';
 import Remarkable from 'remarkable';
 import RemarkableReactRenderer from 'remarkable-react';
 
@@ -12,6 +11,7 @@ import RemarkableReactRenderer from 'remarkable-react';
 import Spinner from 'components/spinner';
 import Card from 'components/card';
 import Ribbon from 'components/ribbon';
+import DocService from 'devdocs/service';
 
 class Readme extends Component {
 	constructor( props ) {
@@ -38,20 +38,20 @@ class Readme extends Component {
 		this.setState( {
 			loading: true
 		} );
-		request.get( '/devdocs/service/content' )
-			.query( { component } )
-			.then( ( { text } ) => {
+		DocService.readme( component, ( error, readmeHtml ) => {
+			if ( error ) {
 				this.setState( {
 					loading: false,
-					readmeHtml: text
+					error
 				} );
-			} )
-			.catch( ( err ) => {
-				this.setState( {
-					loading: false,
-					error: err
-				} );
+				return;
+			}
+
+			this.setState( {
+				loading: false,
+				readmeHtml
 			} );
+		} );
 	};
 
 	render() {

--- a/client/devdocs/docs-example/style.scss
+++ b/client/devdocs/docs-example/style.scss
@@ -84,4 +84,13 @@
   li p {
 	margin-bottom: 0;
   }
+
+  p pre {
+	display: inline-block;
+	margin-bottom: 0;
+	padding: 0;
+	line-height: inherit;
+	font-size: inherit;
+	overflow: inherit;
+  }
 }

--- a/client/devdocs/docs-example/style.scss
+++ b/client/devdocs/docs-example/style.scss
@@ -85,12 +85,21 @@
 	margin-bottom: 0;
   }
 
-  p pre {
-	display: inline-block;
-	margin-bottom: 0;
-	padding: 0;
-	line-height: inherit;
-	font-size: inherit;
-	overflow: inherit;
+  hr {
+	border-top: 4px double $gray-dark;
+	text-align: center;
+	margin-top: 1.5em;
   }
+
+  hr:after {
+	content: '\002665';
+	display: inline-block;
+	position: relative;
+	top: -15px;
+	padding: 0 10px;
+	background: $gray-light;
+	color: $blue-wordpress;
+	font-size: 18px;
+  }
+
 }

--- a/client/devdocs/docs-example/style.scss
+++ b/client/devdocs/docs-example/style.scss
@@ -102,4 +102,22 @@
 	font-size: 18px;
   }
 
+  table {
+	border-collapse: collapse;
+	border-spacing: 0;
+
+	th {
+	  padding-top: 11px;
+	  padding-bottom: 11px;
+	  background-color: $blue-light;
+	  color: white;
+	}
+
+	td, th {
+	  border: 1px solid $gray;
+	  text-align: left;
+	  padding: 8px;
+	}
+  }
+
 }

--- a/client/devdocs/docs-example/style.scss
+++ b/client/devdocs/docs-example/style.scss
@@ -86,9 +86,11 @@
   }
 
   hr {
-	border-top: 4px double $gray-dark;
 	text-align: center;
 	margin-top: 1.5em;
+	border: 0;
+	height: 1px;
+	background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
   }
 
   hr:after {
@@ -100,6 +102,10 @@
 	background: $gray-light;
 	color: $blue-wordpress;
 	font-size: 18px;
+  }
+
+  .card hr:after {
+	content: '';
   }
 
   table {

--- a/client/devdocs/docs-example/style.scss
+++ b/client/devdocs/docs-example/style.scss
@@ -64,12 +64,24 @@
 	}
 }
 
-.docs-example__readme_spinner {
+.docs-example__readme-spinner {
   margin: auto;
   width: 50px;
 }
 
-.docs-example__readme_loading_message {
+.docs-example__readme-loading-message {
   text-align: center;
   padding-bottom: 25px;
+}
+
+.docs-example__readme-content {
+  h1 {
+	font-size: 24px;
+	font-weight: 300;
+	line-height: 32px;
+  }
+
+  li p {
+	margin-bottom: 0;
+  }
 }

--- a/client/devdocs/docs-example/style.scss
+++ b/client/devdocs/docs-example/style.scss
@@ -63,3 +63,13 @@
 		}
 	}
 }
+
+.docs-example__readme_spinner {
+  margin: auto;
+  width: 50px;
+}
+
+.docs-example__readme_loading_message {
+  text-align: center;
+  padding-bottom: 25px;
+}

--- a/client/devdocs/docs-example/util.js
+++ b/client/devdocs/docs-example/util.js
@@ -44,7 +44,7 @@ const camelCaseToSlug = name => {
 	}
 
 	return name
-		.replace( /\.?([A-Z])/g, ( x, y ) => '-' + y.toLowerCase() )
+		.replace( /\.?([A-Z]+)/g, ( x, y ) => '-' + y.toLowerCase() )
 		.replace( /^-/, '' );
 };
 

--- a/client/devdocs/service.js
+++ b/client/devdocs/service.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var request = require( 'superagent' );
+import request from 'superagent';
 
 function fetchDocsEndpoint( endpoint, params, callback ) {
 	request.
@@ -13,7 +13,7 @@ function fetchDocsEndpoint( endpoint, params, callback ) {
 			} else {
 				callback( 'Error invoking /devdocs/' + endpoint + ': ' + res.text, null );
 			}
-		});
+		} );
 }
 
 /**
@@ -26,10 +26,14 @@ module.exports = {
 	},
 
 	list: function( filenames, callback ) {
-		fetchDocsEndpoint( 'list', { files: filenames.join(',') }, callback );
+		fetchDocsEndpoint( 'list', { files: filenames.join( ',' ) }, callback );
 	},
 
 	fetch: function( path, callback ) {
 		fetchDocsEndpoint( 'content', { path: path }, callback );
+	},
+
+	readme: function( component, callback ) {
+		fetchDocsEndpoint( 'content', { component }, callback );
 	}
 };

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react-click-outside": "2.1.0",
     "react-day-picker": "2.4.1",
     "react-dom": "15.4.0",
+    "react-markdown": "2.4.2",
     "react-masonry-component": "4.2.2",
     "react-pure-render": "1.0.2",
     "react-redux": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,8 @@
     "react-virtualized": "7.9.1",
     "redux": "3.0.4",
     "redux-thunk": "1.0.0",
+    "remarkable": "1.7.1",
+    "remarkable-react": "0.0.2",
     "rtlcss": "2.0.5",
     "sanitize-html": "1.11.1",
     "semver": "5.1.0",

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -153,8 +153,11 @@ function findDirectoryWithName( startPath, name, depth = 2 ) {
 
 	const children = listDirectories( startPath );
 
+	// this is quite likely the dumbest way to do this ... but it currently covers all existing cases
+	const singularName = name.substring( 0, name.length - 1 );
+
 	const matches = children
-		.filter( ( dir ) => dir === name )
+		.filter( ( dir ) => dir === name || dir === singularName )
 		.map( ( dir ) => fspath.join( startPath, dir ) );
 
 	if ( matches.length > 0 ) {

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -130,23 +130,34 @@ function defaultSnippet( doc ) {
 	return escapeHTML( content ) + '…';
 }
 
+/**
+ * Gets a list of subdirectories from a given path
+ * @param {string} path The path to get the list from
+ * @returns {Array} The list of subdirectories
+ */
 function listDirectories( path ) {
 	try {
 		return fs.readdirSync( path ).filter( ( file ) => {
 			try {
 				return fs.statSync( fspath.join( path, file ) ).isDirectory();
-			}
-			catch (err) {
+			} catch ( err ) {
 				return false;
 			}
-		} )
-	}
-	catch (err) {
+		} );
+	} catch ( err ) {
 		return [];
 	}
 }
 
+/**
+ * Recursively searches a path for a subdirectory with a given name
+ * @param {string} startPath The path to start searching from
+ * @param {string} name The name to search for
+ * @param {Number} depth The depth to go down, default is 2 levels, -1 for infinite
+ * @returns {Array} List of paths that matched the name
+ */
 function findDirectoryWithName( startPath, name, depth = 2 ) {
+	// stop searching once we exceed our depth
 	if ( depth === 0 ) {
 		return [];
 	}
@@ -164,7 +175,12 @@ function findDirectoryWithName( startPath, name, depth = 2 ) {
 		return matches;
 	}
 
-	return [].concat.apply( [], children.map( ( dir ) => findDirectoryWithName( fspath.join( startPath, dir ), name, depth - 1 ) ) );
+	// flatten the results
+	return [].concat.apply( [],
+		children.map( ( dir ) =>
+			findDirectoryWithName( fspath.join( startPath, dir ), name, depth - 1 )
+		)
+	);
 }
 
 /**
@@ -237,9 +253,9 @@ module.exports = function() {
 	// return the HTML content of a document (assumes that the document is in markdown format)
 	app.get( '/devdocs/service/content', ( request, response ) => {
 		let path = request.query.path;
-		let component = request.query.component;
+		const component = request.query.component;
 
-		if ( ! (path || component) ) {
+		if ( ! ( path || component ) ) {
 			response
 				.status( 400 )
 				.send( 'Need to provide a file path (e.g. path=client/devdocs/README.md) or component (e.g. component=author-selector)' );
@@ -298,12 +314,10 @@ module.exports = function() {
 				}
 
 				response.send( fs.readFileSync( readme, { encoding: 'utf8' } ) );
-			}
-			catch ( err ) {
+			} catch ( err ) {
 				response
 					.status( 404 )
 					.send( 'Unable to find component' );
-				return;
 			}
 		}
 	} );


### PR DESCRIPTION
My first real life PR to wp-calypso! Do not be gentle :p

Now you can save yourself time when browsing the devdocs. No longer do you have to hunt down a readme in your editor, as it's displayed right below the component! 

Here it is in action: 

![calypso](https://cloud.githubusercontent.com/assets/1883296/20460138/7755f364-aea8-11e6-8347-5a039c01854a.gif)

![calypso](https://cloud.githubusercontent.com/assets/1883296/20460289/7c8eacfa-aeac-11e6-8e8f-2c41659355a2.gif)

cc: @ehg 