### PR TITLE
Chat: Improve closure notice for live chat

### DIFF
--- a/client/me/help/chat-closure-notice/index.jsx
+++ b/client/me/help/chat-closure-notice/index.jsx
@@ -13,45 +13,17 @@ import i18n, { localize } from 'i18n-calypso';
  */
 import FormSectionHeading from 'components/forms/form-section-heading';
 import olarkStore from 'lib/olark-store';
+import { title, upcoming, closed } from './messages';
 
-const Closed = localize( ( { translate, closedTo } ) =>
+const Notice = localize( ( { translate, closedFrom, closedTo, reason } ) =>
 	<div className="chat-closure-notice">
-		<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
+		<FormSectionHeading>{ title( { translate, closedFrom, closedTo, reason } ) }</FormSectionHeading>
 		<p>
-			{ translate(
-				'Live chat is closed today for the US Thanksgiving holiday. To get in touch, please ' +
-				'submit a support request below and we will get to it as fast as we can. Live chat ' +
-				'will reopen on {{strong}}%(closed_end_date)s{{/strong}}. Thank you!', {
-					args: {
-						closed_end_date: closedTo.format( 'dddd, MMMM Do, YYYY HH:mm' ),
-					},
-					components: {
-						strong: <strong />
-					}
-				}
-			) }
-		</p>
-	</div>
-);
-
-const Upcoming = localize( ( { translate, closedFrom, closedTo } ) =>
-	<div className="chat-closure-notice">
-		<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
-		<p>
-			{ translate(
-				'Live chat support will be closed from ' +
-				'{{strong}}%(closed_start_date)s{{/strong}} through {{strong}}%(closed_end_date)s{{/strong}} ' +
-				'for the US Thanksgiving holiday. If you need to get in touch with us that day, you’ll be able ' +
-				'to submit a support request from this page and we will get to it as fast as we can. Thank you!', {
-					args: {
-						closed_start_date: closedFrom.format( 'dddd, MMMM Do, YYYY HH:mm' ),
-						closed_end_date: closedTo.format( 'dddd, MMMM Do, YYYY HH:mm' ),
-					},
-					components: {
-						strong: <strong />
-					}
-				}
-			) }
+			{
+				i18n.moment().isBefore( closedFrom )
+					? upcoming( { translate, closedFrom, closedTo, reason } )
+					: closed( { translate, closedFrom, closedTo, reason } )
+			}
 		</p>
 	</div>
 );
@@ -88,12 +60,11 @@ export default class ChatClosureNotice extends Component {
 			return null;
 		}
 
-		// Closure period is upcoming
-		if ( i18n.moment().isBefore( closedFrom ) ) {
-			return <Upcoming closedFrom={ closedFrom } closedTo={ closedTo } />;
-		}
-
-		return <Closed closedFrom={ closedFrom } closedTo={ closedTo } />;
+		return <Notice
+			reason={ this.props.reason }
+			closedFrom={ closedFrom }
+			closedTo={ closedTo }
+		/>;
 	}
 }
 

--- a/client/me/help/chat-closure-notice/index.jsx
+++ b/client/me/help/chat-closure-notice/index.jsx
@@ -15,7 +15,7 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 import olarkStore from 'lib/olark-store';
 
 const Closed = localize( ( { translate, closedTo } ) =>
-	<div className="help-contact-closure-notice">
+	<div className="chat-closure-notice">
 		<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
 		<p>
 			{ translate(
@@ -35,7 +35,7 @@ const Closed = localize( ( { translate, closedTo } ) =>
 );
 
 const Upcoming = localize( ( { translate, closedFrom, closedTo } ) =>
-	<div className="help-contact-closure-notice">
+	<div className="chat-closure-notice">
 		<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
 		<p>
 			{ translate(
@@ -56,7 +56,7 @@ const Upcoming = localize( ( { translate, closedFrom, closedTo } ) =>
 	</div>
 );
 
-export default class HelpContactClosureNotice extends Component {
+export default class ChatClosureNotice extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = { olark: olarkStore.get() };
@@ -97,7 +97,7 @@ export default class HelpContactClosureNotice extends Component {
 	}
 }
 
-HelpContactClosureNotice.PropTypes = {
+ChatClosureNotice.PropTypes = {
 	from: React.PropTypes.string.isRequired,
 	to: React.PropTypes.string.isRequired,
 };

--- a/client/me/help/chat-closure-notice/messages.jsx
+++ b/client/me/help/chat-closure-notice/messages.jsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+
+export const title = ( { translate, reason } ) => {
+	switch ( reason ) {
+		case 'thanksgiving':
+			return translate( 'Limited Support For Thanksgiving' );
+	}
+
+	return null;
+};
+
+export const upcoming = ( { translate, reason, closedFrom, closedTo } ) => {
+	switch ( reason ) {
+		case 'thanksgiving':
+			return translate(
+				'Live chat support will be closed from ' +
+				'{{strong}}%(closed_start_date)s{{/strong}} through {{strong}}%(closed_end_date)s{{/strong}} ' +
+				'for the US Thanksgiving holiday. If you need to get in touch with us that day, you’ll be able ' +
+				'to submit a support request from this page and we will get to it as fast as we can. Thank you!', {
+					args: {
+						closed_start_date: closedFrom.format( 'llll' ),
+						closed_end_date: closedTo.format( 'llll' ),
+					},
+					components: {
+						strong: <strong />
+					}
+				}
+			);
+	}
+
+	return null;
+};
+
+export const closed = ( { translate, reason, closedTo } ) => {
+	switch ( reason ) {
+		case 'thanksgiving':
+			return translate(
+				'Live chat is closed today for the US Thanksgiving holiday. To get in touch, please ' +
+				'submit a support request below and we will get to it as fast as we can. Live chat ' +
+				'will reopen on {{strong}}%(closed_end_date)s{{/strong}}. Thank you!', {
+					args: {
+						closed_end_date: closedTo.format( 'llll' ),
+					},
+					components: {
+						strong: <strong />
+					}
+				}
+			);
+	}
+};

--- a/client/me/help/chat-closure-notice/messages.jsx
+++ b/client/me/help/chat-closure-notice/messages.jsx
@@ -50,4 +50,6 @@ export const closed = ( { translate, reason, closedTo } ) => {
 				}
 			);
 	}
+
+	return null;
 };

--- a/client/me/help/chat-closure-notice/style.scss
+++ b/client/me/help/chat-closure-notice/style.scss
@@ -1,4 +1,4 @@
-.help-contact-closure-notice {
+.chat-closure-notice {
 	color: $gray-dark;
 	font-size: 14px;
 }

--- a/client/me/help/help-contact-closure-notice/index.jsx
+++ b/client/me/help/help-contact-closure-notice/index.jsx
@@ -14,10 +14,7 @@ import i18n, { localize } from 'i18n-calypso';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import olarkStore from 'lib/olark-store';
 
-const closedFrom = i18n.moment( 'Thu, 24 Nov 2016 08:00:00 +0000' );
-const closedTo = i18n.moment( 'Fri, 25 Nov 2016 08:00:00 +0000' );
-
-const Closed = localize( ( { translate } ) =>
+const Closed = localize( ( { translate, closedTo } ) =>
 	<div className="help-contact-closure-notice">
 		<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
 		<p>
@@ -37,7 +34,7 @@ const Closed = localize( ( { translate } ) =>
 	</div>
 );
 
-const Upcoming = localize( ( { translate } ) =>
+const Upcoming = localize( ( { translate, closedFrom, closedTo } ) =>
 	<div className="help-contact-closure-notice">
 		<FormSectionHeading>{ translate( 'Limited Support For Thanksgiving' ) }</FormSectionHeading>
 		<p>
@@ -60,8 +57,8 @@ const Upcoming = localize( ( { translate } ) =>
 );
 
 export default class HelpContactClosureNotice extends Component {
-	constructor() {
-		super();
+	constructor( props ) {
+		super( props );
 		this.state = { olark: olarkStore.get() };
 	}
 
@@ -79,6 +76,8 @@ export default class HelpContactClosureNotice extends Component {
 	}
 
 	render() {
+		const closedFrom = i18n.moment( this.props.from );
+		const closedTo = i18n.moment( this.props.to );
 		// Don't show notice if user isn't eligible for chat
 		if ( ! this.state.olark.isUserEligible ) {
 			return null;
@@ -91,9 +90,14 @@ export default class HelpContactClosureNotice extends Component {
 
 		// Closure period is upcoming
 		if ( i18n.moment().isBefore( closedFrom ) ) {
-			return <Upcoming />;
+			return <Upcoming closedFrom={ closedFrom } closedTo={ closedTo } />;
 		}
 
-		return <Closed />;
+		return <Closed closedFrom={ closedFrom } closedTo={ closedTo } />;
 	}
 }
+
+HelpContactClosureNotice.PropTypes = {
+	from: React.PropTypes.string.isRequired,
+	to: React.PropTypes.string.isRequired,
+};

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -223,6 +223,7 @@ export const HelpContactForm = React.createClass( {
 		return (
 			<div className="help-contact-form">
 				<ChatClosureNotice
+					reason="thanksgiving"
 					from="2016-11-24T08:00:00Z"
 					to="2016-11-25T08:00:00Z"
 				/>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -222,7 +222,10 @@ export const HelpContactForm = React.createClass( {
 
 		return (
 			<div className="help-contact-form">
-				<HelpContactClosureNotice />
+				<HelpContactClosureNotice
+					from="Thu, 24 Nov 2016 08:00:00 +0000"
+					to="Fri, 25 Nov 2016 08:00:00 +0000"
+				/>
 				{ formDescription && ( <p>{ formDescription }</p> ) }
 
 				{ showHowCanWeHelpField && (

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -223,8 +223,8 @@ export const HelpContactForm = React.createClass( {
 		return (
 			<div className="help-contact-form">
 				<HelpContactClosureNotice
-					from="Thu, 24 Nov 2016 08:00:00 +0000"
-					to="Fri, 25 Nov 2016 08:00:00 +0000"
+					from="2016-11-24T08:00:00Z"
+					to="2016-11-25T08:00:00Z"
 				/>
 				{ formDescription && ( <p>{ formDescription }</p> ) }
 

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -22,7 +22,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
 import siteList from 'lib/sites-list';
-import HelpContactClosureNotice from '../help-contact-closure-notice';
+import ChatClosureNotice from '../chat-closure-notice';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
@@ -222,7 +222,7 @@ export const HelpContactForm = React.createClass( {
 
 		return (
 			<div className="help-contact-form">
-				<HelpContactClosureNotice
+				<ChatClosureNotice
 					from="2016-11-24T08:00:00Z"
 					to="2016-11-25T08:00:00Z"
 				/>


### PR DESCRIPTION
This addresses @omarjackman's feedback in #9463:

 - Renames `HelpContactClosureNotice` to `ChatClosureNotice`.
 - Allows the notice to be modified for future chat closures using the component props instead of modifying the internals.

Instead of:

```
<HelpContactClosureNotice />
```

It's now:

```
<ChatClosureNotice
	reason="thanksgiving"
	from="2016-11-24T08:00:00Z"
	to="2016-11-25T08:00:00Z"
/>
```