### PR TITLE
Reader: remove follow button from cards in list stream

### DIFF
--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -4,20 +4,19 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import feedStreamFactory from 'lib/feed-stream-store';
 import { recordTrack } from 'reader/stats';
-import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage, setPageTitle } from 'reader/controller-helper';
+import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
 
 const analyticsPageTitle = 'Reader';
 
 export default {
 	listListing( context ) {
-		var ListStream = require( 'reader/list-stream' ),
+		const ListStream = require( 'reader/list-stream' ),
 			basePath = '/read/list/:owner/:slug',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > List > ' + context.params.user + ' - ' + context.params.list,
 			listStore = feedStreamFactory( 'list:' + context.params.user + '-' + context.params.list ),
@@ -38,6 +37,7 @@ export default {
 					postStore: listStore,
 					owner: encodeURIComponent( context.params.user ),
 					slug: encodeURIComponent( context.params.list ),
+					showPrimaryFollowButtonOnCards: false,
 					trackScrollPage: trackScrollPage.bind(
 						null,
 						basePath,
@@ -46,89 +46,6 @@ export default {
 						mcKey
 					),
 					onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
-				} )
-			),
-			document.getElementById( 'primary' )
-		);
-	},
-
-	listManagementSites( context ) {
-		const listManagement = require( 'reader/list-management' ),
-			basePath = '/read/list/:owner/:slug/sites',
-			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage List > Sites',
-			mcKey = 'list_sites';
-
-		setPageTitle( context, i18n.translate( 'Manage List' ) );
-
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( listManagement, {
-					key: 'list-management-sites',
-					owner: encodeURIComponent( context.params.user ),
-					slug: encodeURIComponent( context.params.list ),
-					tab: 'sites',
-					trackScrollPage: trackScrollPage.bind(
-						null,
-						basePath,
-						fullAnalyticsPageTitle,
-						analyticsPageTitle,
-						mcKey
-					)
-				} )
-			),
-			document.getElementById( 'primary' )
-		);
-	},
-
-	listManagementTags( context ) {
-		const listManagement = require( 'reader/list-management' ),
-			basePath = '/read/list/:owner/:slug/tags',
-			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage List > Tags',
-			mcKey = 'list_tags';
-
-		setPageTitle( context, i18n.translate( 'Manage List' ) );
-
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( listManagement, {
-					key: 'list-management-tags',
-					owner: encodeURIComponent( context.params.user ),
-					slug: encodeURIComponent( context.params.list ),
-					tab: 'tags',
-					trackScrollPage: trackScrollPage.bind(
-						null,
-						basePath,
-						fullAnalyticsPageTitle,
-						analyticsPageTitle,
-						mcKey
-					)
-				} )
-			),
-			document.getElementById( 'primary' )
-		);
-	},
-
-	listManagementDescriptionEdit( context ) {
-		const listManagement = require( 'reader/list-management' ),
-			basePath = '/read/list/:owner/:slug/edit',
-			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage List > Description',
-			mcKey = 'list_edit';
-
-		setPageTitle( context, i18n.translate( 'Manage List Description' ) );
-
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( listManagement, {
-					key: 'list-management-description-edit',
-					owner: encodeURIComponent( context.params.user ),
-					slug: encodeURIComponent( context.params.list ),
-					tab: 'description-edit'
 				} )
 			),
 			document.getElementById( 'primary' )


### PR DESCRIPTION
Removes follow button from cards in list stream as requested in #9437.

Also cleans up list management controller actions that are not in use.

Fixes https://github.com/Automattic/wp-calypso/issues/9437.

### To test

Compare 

https://wpcalypso.wordpress.com/read/list/bluefuton/2016-01 (before)

with 

http://calypso.localhost:3000/read/list/bluefuton/2016-01 (after).

Cards should look like this (no follow button):

<img width="866" alt="screen shot 2016-11-21 at 14 53 38" src="https://cloud.githubusercontent.com/assets/17325/20468306/57190c0a-affa-11e6-9aa1-7eb6810b7ae4.png">
