### PR TITLE
Taxonomies: Truncate long categories labels

### DIFF
--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -99,12 +99,10 @@ const ReaderPostOptionsMenu = React.createClass( {
 		stats.recordTrackForPost( 'calypso_reader_post_options_menu_' + ( isMenuVisible ? 'opened' : 'closed' ), this.props.post );
 	},
 
-	editPost( closeMenu ) {
+	editPost() {
 		const post = this.props.post,
 			site = SiteStore.get( this.props.post.site_ID );
 		let editUrl = '//wordpress.com/post/' + post.site_ID + '/' + post.ID + '/';
-
-		closeMenu();
 
 		if ( site && site.get( 'slug' ) ) {
 			editUrl = PostUtils.getEditURL( post, site.toJS() );

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -10,7 +10,7 @@ import { get, isUndefined } from 'lodash';
 /**
  * Internal dependencies
  */
-import PopoverMenu from 'components/popover/menu';
+import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import PopoverMenuSeparator from 'components/popover/menu-separator';
 import Gridicon from 'components/gridicon';
@@ -42,29 +42,17 @@ class TaxonomyManagerListItem extends Component {
 	};
 
 	state = {
-		popoverMenuOpen: false,
 		showDeleteDialog: false,
 	};
 
-	togglePopoverMenu = event => {
-		if ( event && event.stopPropagation ) {
-			event.stopPropagation();
-		}
-		this.setState( {
-			popoverMenuOpen: ! this.state.popoverMenuOpen
-		} );
-	};
-
-	editItem = () => {
-		this.setState( {
-			popoverMenuOpen: false
-		} );
+	editItem = closeMenu => {
+		closeMenu();
 		this.props.onClick();
 	};
 
-	deleteItem = () => {
+	deleteItem = closeMenu => {
+		closeMenu();
 		this.setState( {
-			popoverMenuOpen: false,
 			showDeleteDialog: true
 		} );
 	};
@@ -79,14 +67,12 @@ class TaxonomyManagerListItem extends Component {
 		} );
 	};
 
-	setAsDefault = () => {
+	setAsDefault = closeMenu => {
+		closeMenu();
 		const { canSetAsDefault, siteId, term } = this.props;
 		if ( canSetAsDefault ) {
 			this.props.saveSiteSettings( siteId, { default_category: term.ID } );
 		}
-		this.setState( {
-			popoverMenuOpen: false
-		} );
 	};
 
 	getTaxonomyLink() {
@@ -100,7 +86,7 @@ class TaxonomyManagerListItem extends Component {
 	}
 
 	render() {
-		const { canSetAsDefault, isDefault, term, translate } = this.props;
+		const { canSetAsDefault, isDefault, onClick, term, translate } = this.props;
 		const name = decodeEntities( term.name ) || translate( 'Untitled' );
 		const className = classNames( 'taxonomy-manager__item', {
 			'is-default': isDefault
@@ -112,12 +98,11 @@ class TaxonomyManagerListItem extends Component {
 
 		return (
 			<div className={ className }>
-				<span className="taxonomy-manager__icon">
+				<span className="taxonomy-manager__icon" onClick={ onClick }>
 					<Gridicon icon={ isDefault ? 'checkmark-circle' : 'folder' } />
 				</span>
-				<span className="taxonomy-manager__label">
+				<span className="taxonomy-manager__label" onClick={ onClick }>
 					<span>{ name }</span>
-
 					{ isDefault &&
 						<span className="taxonomy-manager__default-label">
 							{ translate( 'default', { context: 'label for terms marked as default' } ) }
@@ -125,24 +110,9 @@ class TaxonomyManagerListItem extends Component {
 					}
 				</span>
 				{ ! isUndefined( term.post_count ) && <Count count={ term.post_count } /> }
-				<span
-					className="taxonomy-manager__action-wrapper"
-					onClick={ this.togglePopoverMenu }
-					ref="popoverMenuButton">
-					<Gridicon
-						icon="ellipsis"
-						className={ classNames( {
-							'taxonomy-manager__item-toggle': true,
-							'is-active': this.state.popoverMenuOpen
-						} ) } />
-				</span>
-				<PopoverMenu
-					isVisible={ this.state.popoverMenuOpen }
-					onClose={ this.togglePopoverMenu }
-					position={ 'bottom left' }
-					context={ this.refs && this.refs.popoverMenuButton }
-				>
-					<PopoverMenuItem onClick={ this.editItem } icon="pencil">
+				<EllipsisMenu position={ 'bottom left' }>
+					<PopoverMenuItem onClick={ this.editItem }>
+						<Gridicon icon="pencil" size={ 18 } />
 						{ translate( 'Edit' ) }
 					</PopoverMenuItem>
 					<PopoverMenuItem onClick={ this.deleteItem } icon="trash">
@@ -157,8 +127,7 @@ class TaxonomyManagerListItem extends Component {
 							{ translate( 'Set as default' ) }
 						</PopoverMenuItem>
 					}
-				</PopoverMenu>
-
+				</EllipsisMenu>
 				<Dialog
 					isVisible={ this.state.showDeleteDialog }
 					buttons={ deleteDialogButtons }

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -117,6 +117,7 @@ class TaxonomyManagerListItem extends Component {
 				</span>
 				<span className="taxonomy-manager__label">
 					<span>{ name }</span>
+
 					{ isDefault &&
 						<span className="taxonomy-manager__default-label">
 							{ translate( 'default', { context: 'label for terms marked as default' } ) }
@@ -131,7 +132,7 @@ class TaxonomyManagerListItem extends Component {
 					<Gridicon
 						icon="ellipsis"
 						className={ classNames( {
-							'taxonomy-manager__list-item-toggle': true,
+							'taxonomy-manager__item-toggle': true,
 							'is-active': this.state.popoverMenuOpen
 						} ) } />
 				</span>

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -45,13 +45,7 @@ class TaxonomyManagerListItem extends Component {
 		showDeleteDialog: false,
 	};
 
-	editItem = closeMenu => {
-		closeMenu();
-		this.props.onClick();
-	};
-
-	deleteItem = closeMenu => {
-		closeMenu();
+	deleteItem = () => {
 		this.setState( {
 			showDeleteDialog: true
 		} );
@@ -67,8 +61,7 @@ class TaxonomyManagerListItem extends Component {
 		} );
 	};
 
-	setAsDefault = closeMenu => {
-		closeMenu();
+	setAsDefault = () => {
 		const { canSetAsDefault, siteId, term } = this.props;
 		if ( canSetAsDefault ) {
 			this.props.saveSiteSettings( siteId, { default_category: term.ID } );
@@ -110,8 +103,8 @@ class TaxonomyManagerListItem extends Component {
 					}
 				</span>
 				{ ! isUndefined( term.post_count ) && <Count count={ term.post_count } /> }
-				<EllipsisMenu position={ 'bottom left' }>
-					<PopoverMenuItem onClick={ this.editItem }>
+				<EllipsisMenu position="bottom left">
+					<PopoverMenuItem onClick={ onClick }>
 						<Gridicon icon="pencil" size={ 18 } />
 						{ translate( 'Edit' ) }
 					</PopoverMenuItem>

--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -112,7 +112,6 @@ export class TaxonomyManagerList extends Component {
 		return (
 			<div key={ 'term-wrapper-' + itemId } className="taxonomy-manager__list-item">
 				<CompactCard
-					onClick={ onClick }
 					key={ itemId }
 					className="taxonomy-manager__list-item-card">
 					<ListItem onClick={ onClick } taxonomy={ taxonomy } term={ item } />

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -59,8 +59,12 @@
 		line-height: 18px;
 		white-space: nowrap;
 		overflow: hidden;
-		text-overflow: ellipsis;
 		flex-grow: 1;
+		position: relative;
+
+		&::after {
+			@include long-content-fade();
+		}
 
 		.taxonomy-manager__list-item.is-placeholder & {
 			color: transparent;
@@ -89,6 +93,7 @@
 			display: block;
 			color: $gray;
 			transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+			min-width: 24px;
 
 			&.is-active {
 				color: $blue-medium;

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -36,63 +36,65 @@
 
 .taxonomy-manager__list-item-card {
 	cursor: pointer;
-}
-
-.taxonomy-manager__action-wrapper {
-	cursor: pointer;
-	font-size: 24px;
-	padding: 10px 28px;
-	position: absolute;
-		right: 0;
-		top: 0;
-}
-
-.taxonomy-manager__list-item-toggle {
-	color: $gray;
-	transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-
-	&.is-active {
-		color: $blue-medium;
-		transform: rotate( 90deg );
-	}
-}
-
-.taxonomy-manager__label {
-	margin-left: 30px;
-	line-height: 18px;
-
-	.taxonomy-manager__list-item.is-placeholder & {
-		color: transparent;
-		background-color: lighten( $gray, 30% );
-		animation: loading-fade 1.6s ease-in-out infinite;
-	}
-
-	.taxonomy-manager__default-label {
-		text-transform: uppercase;
-		color: $blue-medium;
-		font-size: 12px;
-		margin-left: 10px;
-	}
+	padding: 0 !important;
 }
 
 .taxonomy-manager__item {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
 	.taxonomy-manager__icon {
-		margin: 15px 20px 0;
-		position: absolute;
-			left: 0px;
-			top: 0;
+		margin: 15px;
 		color: $gray;
+		.gridicon {
+			display: block;
+		}
+	}
+	&.is-default .taxonomy-manager__icon {
+		color: $blue-medium;
+	}
+
+	.taxonomy-manager__label {
+		line-height: 18px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		flex-grow: 1;
+
+		.taxonomy-manager__list-item.is-placeholder & {
+			color: transparent;
+			background-color: lighten( $gray, 30% );
+			animation: loading-fade 1.6s ease-in-out infinite;
+		}
+
+		.taxonomy-manager__default-label {
+			text-transform: uppercase;
+			color: $blue-medium;
+			font-size: 12px;
+			margin-left: 10px;
+		}
 	}
 
 	.count {
-		margin: 18px 28px;
-		position: absolute;
-			right: 48px;
-			top: 0;
+		margin: 18px 2px;
 	}
 
-	&.is-default .taxonomy-manager__icon {
-		color: $blue-medium;
+	.taxonomy-manager__action-wrapper {
+		cursor: pointer;
+		font-size: 24px;
+		padding: 15px 28px;
+
+		.taxonomy-manager__item-toggle {
+			display: block;
+			color: $gray;
+			transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+			&.is-active {
+				color: $blue-medium;
+				transform: rotate( 90deg );
+			}
+		}
 	}
 }
 

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -36,7 +36,10 @@
 
 .taxonomy-manager__list-item-card {
 	cursor: pointer;
-	padding: 0 !important;
+}
+
+.taxonomy-manager__list-item-card.card.is-compact {
+	padding: 0;
 }
 
 .taxonomy-manager__item {
@@ -84,21 +87,20 @@
 		margin: 18px 2px;
 	}
 
-	.taxonomy-manager__action-wrapper {
-		cursor: pointer;
-		font-size: 24px;
-		padding: 15px 28px;
-
-		.taxonomy-manager__item-toggle {
-			display: block;
+	.ellipsis-menu {
+		.ellipsis-menu__toggle.button.is-borderless {
+			cursor: pointer;
+			font-size: 24px;
 			color: $gray;
-			transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+			padding: 15px 24px;
 			min-width: 24px;
-
-			&.is-active {
-				color: $blue-medium;
-				transform: rotate( 90deg );
+			.gridicon {
+				top: 2px;
 			}
+		}
+
+		&.is-menu-visible .ellipsis-menu__toggle.button.is-borderless {
+			color: $blue-medium;
 		}
 	}
 }

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -45,10 +45,9 @@
 .taxonomy-manager__item {
 	display: flex;
 	flex-direction: row;
-	align-items: center;
 
 	.taxonomy-manager__icon {
-		margin: 15px;
+		padding: 15px;
 		color: $gray;
 		.gridicon {
 			display: block;
@@ -59,7 +58,7 @@
 	}
 
 	.taxonomy-manager__label {
-		line-height: 18px;
+		line-height: 54px;
 		white-space: nowrap;
 		overflow: hidden;
 		flex-grow: 1;

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -3,6 +3,7 @@
 */
 const ReactDom = require( 'react-dom' ),
 	React = require( 'react' );
+import { over } from 'lodash';
 
 /**
 * Internal dependencies
@@ -60,7 +61,7 @@ const PopoverMenu = React.createClass( {
 		let onClick = boundOnClose;
 
 		if ( child.props.onClick ) {
-			onClick = child.props.onClick.bind( null, boundOnClose );
+			onClick = over( [ child.props.onClick, boundOnClose ] );
 		}
 
 		return React.cloneElement( child, {


### PR DESCRIPTION
This PR is blocked by #9508 and closes #9510 

In this PR, I update the style of Term Items, to use Flexbox instead of absolute positioning. That way, I can use `text-overflow` to truncate the category label when it's larger than the available space.

I noticed sometimes that the ellipsis menu icon seems a litter thinner when the label is too long. I'm not sure exactly why this is happening (I wonder if it's not a browser bug).

<img width="730" alt="capture d ecran 2016-11-21 a 11 04 20 am" src="https://cloud.githubusercontent.com/assets/272444/20478496/a606a82e-afda-11e6-9dfd-992144e6db90.png">


**testing instructions**

 * Create categories with long labels
 * The label should be truncated and fill all the available space.

cc @timmyc 

