### PR TITLE
isRequestingTheme: Add unit tests.

### DIFF
--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -10,6 +10,7 @@ import { values } from 'lodash';
 import {
 	getThemes,
 	getTheme,
+	isRequestingTheme,
 	getThemesForQuery,
 	isRequestingThemesForQuery,
 	getThemesFoundForQuery,
@@ -26,7 +27,6 @@ import {
 	getActiveTheme,
 	isThemeActive,
 	isThemePurchased,
-	isRequestingTheme
 } from '../selectors';
 import ThemeQueryManager from 'lib/query-manager/theme';
 
@@ -122,6 +122,46 @@ describe( 'themes selectors', () => {
 			}, 2916284, 'twentysixteen' );
 
 			expect( theme ).to.equal( twentysixteen );
+		} );
+	} );
+
+	describe( '#isRequestingTheme()', () => {
+		it( 'should return false if there are no active requests for site', () => {
+			const isRequesting = isRequestingTheme( {
+				themes: {
+					themeRequests: { }
+				}
+			}, 2916284, 'twentyfifteen' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return false if there is no active request for theme for site', () => {
+			const isRequesting = isRequestingTheme( {
+				themes: {
+					themeRequests: {
+						2916284: {
+							twentysixteen: true,
+						}
+					}
+				}
+			}, 2916284, 'twentyfifteen' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return true if there is request ongoing for theme for site', () => {
+			const isRequesting = isRequestingTheme( {
+				themes: {
+					themeRequests: {
+						2916284: {
+							twentysixteen: true,
+						}
+					}
+				}
+			}, 2916284, 'twentysixteen' );
+
+			expect( isRequesting ).to.be.true;
 		} );
 	} );
 
@@ -240,46 +280,6 @@ describe( 'themes selectors', () => {
 			}, 2916284, { search: 'Sixteen' } );
 
 			expect( isRequesting ).to.be.false;
-		} );
-	} );
-
-	describe( '#isRequestingTheme()', () => {
-		it( 'should return false if there are no active requests for site', () => {
-			const isRequesting = isRequestingTheme( {
-				themes: {
-					themeRequests: { }
-				}
-			}, 2916284, 'twentyfifteen' );
-
-			expect( isRequesting ).to.be.false;
-		} );
-
-		it( 'should return false if there is no active request for theme for site', () => {
-			const isRequesting = isRequestingTheme( {
-				themes: {
-					themeRequests: {
-						2916284: {
-							twentysixteen: true,
-						}
-					}
-				}
-			}, 2916284, 'twentyfifteen' );
-
-			expect( isRequesting ).to.be.false;
-		} );
-
-		it( 'should return true if there is request ongoing for theme for site', () => {
-			const isRequesting = isRequestingTheme( {
-				themes: {
-					themeRequests: {
-						2916284: {
-							twentysixteen: true,
-						}
-					}
-				}
-			}, 2916284, 'twentysixteen' );
-
-			expect( isRequesting ).to.be.true;
 		} );
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -25,7 +25,8 @@ import {
 	getThemeSignupUrl,
 	getActiveTheme,
 	isThemeActive,
-	isThemePurchased
+	isThemePurchased,
+	isRequestingTheme
 } from '../selectors';
 import ThemeQueryManager from 'lib/query-manager/theme';
 
@@ -239,6 +240,46 @@ describe( 'themes selectors', () => {
 			}, 2916284, { search: 'Sixteen' } );
 
 			expect( isRequesting ).to.be.false;
+		} );
+	} );
+
+	describe( '#isRequestingTheme()', () => {
+		it( 'should return false if there are no active requests for site', () => {
+			const isRequesting = isRequestingTheme( {
+				themes: {
+					themeRequests: { }
+				}
+			}, 2916284, 'twentyfifteen' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return false if there is no active request for theme for site', () => {
+			const isRequesting = isRequestingTheme( {
+				themes: {
+					themeRequests: {
+						2916284: {
+							twentysixteen: true,
+						}
+					}
+				}
+			}, 2916284, 'twentyfifteen' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return true if there is request ongoing for theme for site', () => {
+			const isRequesting = isRequestingTheme( {
+				themes: {
+					themeRequests: {
+						2916284: {
+							twentysixteen: true,
+						}
+					}
+				}
+			}, 2916284, 'twentysixteen' );
+
+			expect( isRequesting ).to.be.true;
 		} );
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -283,7 +283,7 @@ describe( 'themes selectors', () => {
 		} );
 	} );
 
-	describe( 'getThemesFoundForQuery()', () => {
+	describe( '#getThemesFoundForQuery()', () => {
 		it( 'should return null if the site query is not tracked', () => {
 			const found = getThemesFoundForQuery( {
 				themes: {
@@ -491,7 +491,7 @@ describe( 'themes selectors', () => {
 		} );
 	} );
 
-	( '#getThemesForQueryIgnoringPage()', () => {
+	describe( '#getThemesForQueryIgnoringPage()', () => {
 		it( 'should return null if the query is not tracked', () => {
 			const themes = getThemesForQueryIgnoringPage( {
 				themes: {
@@ -567,7 +567,7 @@ describe( 'themes selectors', () => {
 		} );
 	} );
 
-	describe( 'isRequestingThemesForQueryIgnoringPage()', () => {
+	describe( '#isRequestingThemesForQueryIgnoringPage()', () => {
 		it( 'should return false if not requesting for query', () => {
 			const isRequesting = isRequestingThemesForQueryIgnoringPage( {
 				themes: {


### PR DESCRIPTION
Three new unit tests are added that cover functionality of `isRequestingTheme` selector:

1. Check when there where no requests.
2. Check when there was no request for that theme.
3. Check when there is request for theme.

This becomes part of regression so no check needed - this will be run for all commits.