### PR TITLE
Jetpack: Change the plans landing pages buttons text

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -23,7 +23,8 @@ const PlanFeaturesActions = ( {
 	isPlaceholder = false,
 	isInSignup,
 	translate,
-	manageHref
+	manageHref,
+	isLandingPage
 } ) => {
 	let upgradeButton;
 	const classes = classNames(
@@ -43,17 +44,19 @@ const PlanFeaturesActions = ( {
 			</Button>
 		);
 	} else if ( available || isPlaceholder ) {
+		let buttonText = freePlan
+			? translate( 'Select Free', { context: 'button' } )
+			: translate( 'Upgrade', { context: 'verb' } );
+		if ( isLandingPage ) {
+			buttonText = translate( 'Select', { context: 'button' } );
+		}
 		upgradeButton = (
 			<Button
 				className={ classes }
 				onClick={ isPlaceholder ? noop : onUpgradeClick }
 				disabled={ isPlaceholder }
 			>
-				{
-					freePlan
-						? translate( 'Select Free', { context: 'button' } )
-						: translate( 'Upgrade', { context: 'verb' } )
-				}
+				{ buttonText }
 			</Button>
 		);
 	}
@@ -75,7 +78,8 @@ PlanFeaturesActions.propTypes = {
 	available: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	freePlan: PropTypes.bool,
-	isPlaceholder: PropTypes.bool
+	isPlaceholder: PropTypes.bool,
+	isLandingPage: PropTypes.bool
 };
 
 export default localize( PlanFeaturesActions );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -129,7 +129,7 @@ class PlanFeatures extends Component {
 
 	renderMobileView() {
 		const {
-			canPurchase, translate, planProperties, isInSignup, intervalType, site, basePlansPath
+			canPurchase, translate, planProperties, isInSignup, isLandingPage, intervalType, site, basePlansPath
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -195,6 +195,7 @@ class PlanFeatures extends Component {
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
+						isLandingPage={ isLandingPage }
 					/>
 					<FoldableCard
 						header={ translate( 'Show features' ) }
@@ -284,7 +285,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderTopButtons() {
-		const { canPurchase, planProperties, isInSignup, site } = this.props;
+		const { canPurchase, isLandingPage, planProperties, isInSignup, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -314,6 +315,7 @@ class PlanFeatures extends Component {
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
+						isLandingPage={ isLandingPage }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
 					/>
 				</td>
@@ -496,7 +498,7 @@ PlanFeatures.defaultProps = {
 
 export default connect(
 	( state, ownProps ) => {
-		const { isInSignup, placeholder, plans, onUpgradeClick } = ownProps;
+		const { isInSignup, placeholder, plans, onUpgradeClick, isLandingPage } = ownProps;
 		const selectedSiteId = isInSignup ? null : getSelectedSiteId( state );
 		const sitePlan = getSitePlan( state, selectedSiteId );
 		const sitePlans = getPlansBySiteId( state, selectedSiteId );
@@ -527,6 +529,7 @@ export default connect(
 
 				return {
 					isPlaceholder,
+					isLandingPage,
 					available: available,
 					currencyCode: getCurrentUserCurrencyCode( state ),
 					current: isCurrentSitePlan( state, selectedSiteId, planProductId ),

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -40,12 +40,12 @@ class PlansFeaturesMain extends Component {
 			onUpgradeClick,
 			hideFreePlan,
 			isInSignup,
+			isLandingPage,
 			basePlansPath,
 			selectedFeature
 		} = this.props;
 
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
-
 		if ( this.isJetpackSite( site ) && intervalType === 'monthly' ) {
 			const jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ];
 			if ( hideFreePlan ) {
@@ -58,6 +58,7 @@ class PlansFeaturesMain extends Component {
 						selectedFeature={ selectedFeature }
 						onUpgradeClick={ onUpgradeClick }
 						isInSignup={ isInSignup }
+						isLandingPage={ isLandingPage }
 						basePlansPath={ basePlansPath }
 						intervalType={ intervalType }
 						site={ site }
@@ -78,6 +79,7 @@ class PlansFeaturesMain extends Component {
 						selectedFeature={ selectedFeature }
 						onUpgradeClick={ onUpgradeClick }
 						isInSignup={ isInSignup }
+						isLandingPage={ isLandingPage }
 						basePlansPath={ basePlansPath }
 						intervalType={ intervalType }
 						site={ site }
@@ -102,6 +104,7 @@ class PlansFeaturesMain extends Component {
 					plans={ plans }
 					onUpgradeClick={ onUpgradeClick }
 					isInSignup={ isInSignup }
+					isLandingPage={ isLandingPage }
 					basePlansPath={ basePlansPath }
 					selectedFeature={ selectedFeature }
 					intervalType={ intervalType }
@@ -336,6 +339,7 @@ class PlansFeaturesMain extends Component {
 PlansFeaturesMain.PropTypes = {
 	site: PropTypes.object,
 	isInSignup: PropTypes.bool,
+	isLandingPage: PropTypes.bool,
 	basePlansPath: PropTypes.string,
 	intervalType: PropTypes.string,
 	onUpgradeClick: PropTypes.func,

--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -43,6 +43,7 @@ export default React.createClass( {
 						<PlansFeaturesMain
 							site={ this.props.selectedSite || defaultJetpackSite }
 							isInSignup={ true }
+							isLandingPage={ ! this.props.selectedSite }
 							basePlansPath={ this.props.basePlansPath }
 							onUpgradeClick={ this.props.onSelect }
 							intervalType={ this.props.intervalType }


### PR DESCRIPTION
As requested by @richardmuscat , this PR changes the text of the buttons that selects a plan when they are shown in one of the jetpack plans landing pages

![image](https://cloud.githubusercontent.com/assets/1554855/20479907/623edbba-afe0-11e6-8809-bb3eca7fe12c.png)


How to test
=========
1. Go to http://calypso.localhost:3000/jetpack/connect/akismet  http://calypso.localhost:3000/jetpack/connect/akismet & http://calypso.localhost:3000/jetpack/connect/store
2. The buttons on those three pages should be labelled as "select" and not "upgrade"

