### PR TITLE
SEO settings: Fix urls for sites with subdomains

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -372,6 +372,7 @@ export const SeoForm = React.createClass( {
 			jetpackVersionSupportsSeo,
 		} = this.props;
 		const {
+			domain = '',
 			slug = '',
 			settings: {
 				blog_public = 1
@@ -397,7 +398,7 @@ export const SeoForm = React.createClass( {
 		const isDisabled = isSitePrivate || isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
 		const isSaveDisabled = isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
 
-		const siteUrl = `https://${ slug }/`;
+		const siteUrl = `https://${ domain }/`;
 		const sitemapUrl = `${ siteUrl }sitemap.xml`;
 		const generalTabUrl = getGeneralTabUrl( slug );
 		const jetpackUpdateUrl = getJetpackPluginUrl( slug );
@@ -476,7 +477,7 @@ export const SeoForm = React.createClass( {
 							'SEO Tools module is disabled in Jetpack.'
 						) }
 					>
-						<NoticeAction href={ '//' + slug + '/wp-admin/admin.php?page=jetpack#/engagement' }>
+						<NoticeAction href={ '//' + domain + '/wp-admin/admin.php?page=jetpack#/engagement' }>
 							{ this.translate( 'Enable' ) }
 						</NoticeAction>
 					</Notice>
@@ -595,7 +596,7 @@ export const SeoForm = React.createClass( {
 								'Site Verification Services are disabled in Jetpack.'
 							) }
 						>
-							<NoticeAction href={ '//' + slug + '/wp-admin/admin.php?page=jetpack#/engagement' }>
+							<NoticeAction href={ '//' + domain + '/wp-admin/admin.php?page=jetpack#/engagement' }>
 								{ this.translate( 'Enable' ) }
 							</NoticeAction>
 						</Notice>


### PR DESCRIPTION
The notices we are showing in the SEO tools admin page are using the slug of the site to construct the url where they should redirect the user after they click. So, when the site contains a subdirectory on its url, the redirection is invalid

This PR changes this so we use the site domain, so the redirection should be valid for every site.

![image](https://cloud.githubusercontent.com/assets/1554855/20492500/41a1cbb2-b015-11e6-8bbb-53bdfbf384eb.png)


ping @beaulebens 