### PR TITLE
Plans: Wait until selected site is loaded before rendering

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -27,8 +27,8 @@ const Plans = React.createClass( {
 		context: React.PropTypes.object.isRequired,
 		intervalType: React.PropTypes.string,
 		plans: React.PropTypes.array.isRequired,
-		selectedSite: React.PropTypes.object.isRequired,
-		selectedSiteId: React.PropTypes.number.isRequired,
+		selectedSite: React.PropTypes.object,
+		selectedSiteId: React.PropTypes.number,
 		sitePlans: React.PropTypes.object.isRequired
 	},
 
@@ -45,8 +45,26 @@ const Plans = React.createClass( {
 		}
 	},
 
+	renderPlaceholder() {
+		return (
+			<div>
+				<DocumentHead title={ this.props.translate( 'Plans', { textOnly: true } ) } />
+				<Main wideLayout={ true } >
+					<SidebarNavigation />
+
+					<div id="plans" className="plans has-sidebar">
+					</div>
+				</Main>
+			</div>
+		);
+	},
+
 	render() {
 		const { selectedSite, selectedSiteId, translate } = this.props;
+
+		if ( this.props.isPlaceholder ) {
+			return this.renderPlaceholder();
+		}
 
 		return (
 			<div>
@@ -82,9 +100,11 @@ const Plans = React.createClass( {
 export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
+		const isPlaceholder = ! selectedSiteId;
 		return {
+			isPlaceholder,
 			plans: getPlans( state ),
-			sitePlans: getPlansBySiteId( state, selectedSiteId ),
+			sitePlans: isPlaceholder ? {} : getPlansBySiteId( state, selectedSiteId ),
 			selectedSite: getSelectedSite( state ),
 			selectedSiteId: selectedSiteId
 		};


### PR DESCRIPTION
Right now, if you go to wordpress.com/plans/:siteslug: with an empty local storage, you get a javascript exception because we can't find the currently selected site. Having an empty localstorage shouldn't be a problem for wpcom sites, since they can't get to this point without sites-list being loaded already, but this is a common case for people accessing to their plans page from their jetpack wp-admin dashboard.

This PR makes the plans page wait until we find the current site info before rendering the sites list. It could be improved (right now we are not showing any placeholder while we wait, just the "loading my sites" message in the sidebar, but since this is currently broken for jp sites, I'm going to try to merge this as soon as possible and the work in an improved version

![image](https://cloud.githubusercontent.com/assets/1554855/20497824/f74bfed2-b02a-11e6-91b3-dd04ff7e8570.png)

How to test
=========
0. You need a connected jetpack site
1. Go to http://calypso.localhost:3000/plans/:siteslug:
2. When everything loads fine, open the developer tools and run `localStorage.clear()`
3. Reload the page. You should briefly see the screen pictured up there, and then your plans list should be shown without any javascript error

ping @stephanethomas @Tug & @artpi , mainly because you are the ones with more committed lines in this file :)