### PR TITLE
Focus olark chatbox when a user clicks "Chat with us"

### DIFF
--- a/client/lib/olark-store/actions.js
+++ b/client/lib/olark-store/actions.js
@@ -86,6 +86,15 @@ const olarkActions = {
 
 	hideBox() {
 		olarkApi( 'api.box.hide' );
+	},
+
+	focusBox() {
+		if ( ! document ) {
+			return;
+		}
+
+		const chatInput = document.querySelector( '#habla_wcsend_input' );
+		chatInput && chatInput.focus();
 	}
 };
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -100,6 +100,7 @@ const RemovePurchase = React.createClass( {
 
 	openChat() {
 		olarkActions.expandBox();
+		olarkActions.focusBox();
 		this.recordChatEvent( 'calypso_precancellation_chat_click' );
 		this.setState( { isDialogVisible: false } );
 	},


### PR DESCRIPTION
This pull request adds a function that will set focus to the olark chat box when a user clicks the chat with us link from the precancellation survey. 

As suggested in https://github.com/Automattic/wp-calypso/pull/9513#issuecomment-261651552

### How to test
1. Navigate to http://calypso.localhost:3000/me/purchases/
2. Select a product to cancel
3. Click the "Remove WordPress.com Business" (or whatever the product is)
4. If operators are available you should see the chat with us link
5. Click the chat with us link
6. Notice that the olark chatbox appears in the lower right corner and the text area has focus

