### PR TITLE
Reader: Fix opening of x-posts

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -338,7 +338,7 @@ export default class ReaderStream extends React.Component {
 		return 'feed-post-' + ( postKey.feedId || postKey.blogId ) + '-' + postKey.postId;
 	}
 
-	showFullXPost( xMetadata ) {
+	showFullXPost = ( xMetadata ) => {
 		if ( xMetadata.blogId && xMetadata.postId ) {
 			const mappedPost = {
 				site_ID: xMetadata.blogId,


### PR DESCRIPTION
cc @blowery since you've just pushed #9475

Opening x-posts in the wpcalypso Reader was broken:

<img width="460" alt="screen shot 2016-11-21 at 20 17 58" src="https://cloud.githubusercontent.com/assets/150562/20499112/e440d590-b027-11e6-9643-f134c52866e6.png">
