### PR TITLE
Enable precancellation chat on the purchase removal form

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -99,7 +99,8 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true
+		"upgrades/removal-survey": true,
+		"upgrades/precancellation-chat": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -100,7 +100,8 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true
+		"upgrades/removal-survey": true,
+		"upgrades/precancellation-chat": true
 	},
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/config/stage.json
+++ b/config/stage.json
@@ -106,7 +106,8 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true
+		"upgrades/removal-survey": true,
+		"upgrades/precancellation-chat": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,7 +120,8 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true
+		"upgrades/removal-survey": true,
+		"upgrades/precancellation-chat": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
This pull request enables the `update/precancellation-chat/enable` feature flag on the stage, horizon, wpcalypso and production environments. Though this feature will be enabled users wont see the chat with us button until the availability is set from within wp-admin.

For more context see #9261