### PR TITLE
Reader: hide site name on site and feed streams

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -27,11 +27,13 @@ class PostByline extends React.Component {
 		post: React.PropTypes.object.isRequired,
 		site: React.PropTypes.object,
 		feed: React.PropTypes.object,
-		isDiscoverPost: React.PropTypes.bool
+		isDiscoverPost: React.PropTypes.bool,
+		showSiteName: React.PropTypes.bool
 	}
 
 	static defaultProps = {
-		isDiscoverPost: false
+		isDiscoverPost: false,
+		showSiteName: true
 	}
 
 	recordTagClick = () => {
@@ -47,7 +49,7 @@ class PostByline extends React.Component {
 	}
 
 	render() {
-		const { post, site, feed, isDiscoverPost } = this.props;
+		const { post, site, feed, isDiscoverPost, showSiteName } = this.props;
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
 		const primaryTag = post && post.primary_tag;
@@ -79,14 +81,14 @@ class PostByline extends React.Component {
 							{ post.author.name }
 						</ReaderAuthorLink>
 						}
-						{ shouldDisplayAuthor && ', ' }
-						<ReaderSiteStreamLink
+						{ shouldDisplayAuthor && showSiteName && ', ' }
+						{ showSiteName && <ReaderSiteStreamLink
 							className="reader-post-card__site reader-post-card__link"
 							feedId={ feedId }
 							siteId={ siteId }
 							post={ post }>
 							{ siteName }
-						</ReaderSiteStreamLink>
+						</ReaderSiteStreamLink> }
 					</div>
 					<div className="reader-post-card__timestamp-and-tag">
 						{ post.date && post.URL &&

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -33,7 +33,8 @@ export default class RefreshPostCard extends React.Component {
 		showPrimaryFollowButton: PropTypes.bool,
 		originalPost: PropTypes.object, // used for Discover only
 		showEntireExcerpt: PropTypes.bool,
-		useBetterExcerpt: PropTypes.bool
+		useBetterExcerpt: PropTypes.bool,
+		showSiteName: PropTypes.bool
 	};
 
 	static defaultProps = {
@@ -101,7 +102,8 @@ export default class RefreshPostCard extends React.Component {
 			showPrimaryFollowButton,
 			isSelected,
 			showEntireExcerpt,
-			useBetterExcerpt
+			useBetterExcerpt,
+			showSiteName
 		} = this.props;
 		const isPhotoOnly = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGallery = !! ( post.display_type & DisplayTypes.GALLERY );
@@ -139,7 +141,7 @@ export default class RefreshPostCard extends React.Component {
 
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>
-				<PostByline post={ post } site={ site } feed={ feed } />
+				<PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
 				{ showPrimaryFollowButton && <FollowButton siteUrl={ followUrl } /> }
 				<div className="reader-post-card__post">
 					{ ! isGallery && featuredAsset }

--- a/client/reader/feed-stream/README.md
+++ b/client/reader/feed-stream/README.md
@@ -1,9 +1,9 @@
 # Reader Feed Stream
 
-A stream for a feed, identified by a feed ID
+A stream for a feed, identified by a feed ID.
 
 ## Props
 
 - `feedId`: The ID for the feed to show
 
-See `reader/following-stream` for more props
+Any other props specified are passed along to the <Stream> component.

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -141,7 +141,7 @@ var FeedStream = React.createClass( {
 		}
 
 		return (
-			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showPostHeader={ false }>
+			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showPostHeader={ false } showSiteNameOnCards={ false }>
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: this.state.title } ) } />
 				{ this.props.showBack && <HeaderBack /> }
 				<FeedHeader feed={ feed } site={ this.state.site } />

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -151,7 +151,7 @@ class SiteStream extends React.Component {
 		}
 
 		return (
-			<Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showPostHeader={ false }>
+			<Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showPostHeader={ false } showSiteNameOnCards={ false }>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				{ this.props.showBack && <HeaderBack /> }
 				<FeedHeader site={ site } feed={ this.state.feed } />

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -423,7 +423,8 @@ export default class ReaderStream extends React.Component {
 					showPostHeader: this.props.showPostHeader,
 					showFollowInHeader: this.props.showFollowInHeader,
 					handleClick: this.showFullPost,
-					showPrimaryFollowButtonOnCards: this.props.showPrimaryFollowButtonOnCards
+					showPrimaryFollowButton: this.props.showPrimaryFollowButtonOnCards,
+					showSiteName: this.props.showSiteNameOnCards
 				} );
 
 		}

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -53,9 +53,10 @@ class ReaderPostCardAdapter extends React.Component {
 				onClick={ this.onClick }
 				onCommentClick={ this.onCommentClick }
 				isSelected={ this.props.isSelected }
-				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
+				showPrimaryFollowButton={ this.props.showPrimaryFollowButton }
 				showEntireExcerpt={ isDiscoverPost }
-				useBetterExcerpt={ ! isDiscoverPost }>
+				useBetterExcerpt={ ! isDiscoverPost }
+				showSiteName={ this.props.showSiteName }>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 			</ReaderPostCard>


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/9097:

> [On post cards] omit the Site Name (since they're all from the same site).

### To test

Pull up a site stream, e.g.:

http://calypso.localhost:3000/read/blogs/48500948

and feed stream, e.g.:

http://calypso.localhost:3000/read/feeds/15197253

Ensure the site name is not displayed in the card header:

<img width="880" alt="screen shot 2016-11-22 at 14 44 32" src="https://cloud.githubusercontent.com/assets/17325/20507824/395726fc-b0c2-11e6-8c61-dc9f2bbfa101.png">

Ensure that the site name _is_ displayed in other streams (e.g. Following stream).