### PR TITLE
Revert "Framework: People: Fix an issue where editing user with slug like usernames failed"

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -28,16 +28,18 @@ function getSiteFragment( path ) {
 
 	// There are 2 URL positions where we should look for the site fragment:
 	// last (most sections) and second-to-last (post ID is last in editor)
-	//
-	// This block will check the second-to-last segment for a site fragment or
-	// site ID, and then will check the first-to-last segment for the same.
+
+	// Check last and second-to-last piece for site slug
 	for ( let i = 2; i > 0; i-- ) {
-		let piece = pieces[ pieces.length - i ];
+		const piece = pieces[ pieces.length - i ];
 		if ( piece && -1 !== piece.indexOf( '.' ) ) {
 			return piece;
 		}
+	}
 
-		piece = parseInt( piece, 10 );
+	// Check last and second-to-last piece for numeric site ID
+	for ( let i = 2; i > 0; i-- ) {
+		const piece = parseInt( pieces[ pieces.length - i ], 10 );
 		if ( Number.isSafeInteger( piece ) ) {
 			return piece;
 		}
@@ -64,7 +66,7 @@ function addSiteFragment( path, site ) {
 }
 
 function sectionify( path ) {
-	let basePath = path.split( '?' )[ 0 ];
+	let basePath = path.split( '?' )[ 0 ];
 	const site = getSiteFragment( basePath );
 
 	if ( site ) {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -248,16 +248,6 @@ describe( 'route', function() {
 				).to.be.false;
 			} );
 		} );
-		describe( 'for people paths', function() {
-			it( 'should return a site when viewing username with a dot', () => {
-				expect(
-					route.getSiteFragment( '/people/edit/example.com/user.name' )
-				).to.equal( 'example.com' );
-				expect(
-					route.getSiteFragment( '/people/edit/123456/user.name' )
-				).to.equal( 123456 );
-			} );
-		} );
 	} );
 
 	describe( 'addSiteFragment', function() {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#9445

Fixes #9542 and Fixes #9550.

In #9445 we tried to rewrite how `getSiteFragment()` works with numeric site IDS , such as `/people/edit/123456/user.name`. But, this ended up  causing some issues with existing routes. Since we don't have intentions of changing to use numeric site IDs any time soon for people, we can safely revert to fix these other issues.

cc @timmyc @enejb for review.