### PR TITLE
Plugins: Fix the plugin view when no site is currently selected

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 import some from 'lodash/some';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -58,6 +59,9 @@ export default React.createClass( {
 	},
 
 	hasBusinessPlan() {
+		if ( ! this.props.selectedSite ) {
+			return false;
+		}
 		return isBusiness( this.props.selectedSite.plan ) || isEnterprise( this.props.selectedSite.plan );
 	},
 
@@ -308,7 +312,7 @@ export default React.createClass( {
 						</div>
 						{ this.renderActions() }
 					</div>
-					{ ! this.props.isMock && this.props.selectedSite.jetpack &&
+					{ ! this.props.isMock && get( this.props.selectedSite, 'jetpack' ) &&
 						<PluginInformation
 							plugin={ this.props.plugin }
 							isPlaceholder={ this.props.isPlaceholder }
@@ -320,11 +324,11 @@ export default React.createClass( {
 					}
 				</Card>
 
-				{ ( this.props.selectedSite.jetpack || this.hasBusinessPlan() ) &&
+				{ ( get( this.props.selectedSite, 'jetpack' ) || this.hasBusinessPlan() ) &&
 					<div style={ { marginBottom: 16 } } />
 				}
 
-				{ ! this.props.selectedSite.jetpack && ! this.hasBusinessPlan() &&
+				{ ! get( this.props.selectedSite, 'jetpack' ) && ! this.hasBusinessPlan() &&
 					<div className="plugin-meta__upgrade_nudge">
 						<UpgradeNudge
 							feature={ FEATURE_UPLOAD_PLUGINS }


### PR DESCRIPTION
The plugin view when no site is selected is throwing an error and not rendering

Example: https://wordpress.com/plugins/vaultpress

When the plugins controller started implementing the`getSelectedSite()` selector , some code started throwing exceptions like `Cannot read property 'jetpack' of null`. 

Code was working before because `sitesList.getSelectedSite()` returned `false` instead, when no site was selected.

#### Changes introduced by this PR

* Uses `lodash/get` for accessing the `selectedSite.jetpack`. 
* Just returns false in `PluginMeta/isBusinessPlan()` if there's no selected site. 

#### Testing instructions

1. Confirm current error:
  * Visit https://wordpress.com/plugins/vaultpress
  * Confirm a blank page and an error in the browser console
2. Checkout this branch
  * Visit http://calypso.localhost:3000/plugins/vaultpress
  * Confirm that you see a VaultPpress page and no errors in the browser console