### PR TITLE
Reader: feed stream spring clean

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -212,7 +212,7 @@ module.exports = {
 			React.createElement( FeedStream, {
 				key: 'feed-' + context.params.feed_id,
 				store: feedStore,
-				feedId: context.params.feed_id,
+				feedId: +context.params.feed_id,
 				trackScrollPage: trackScrollPage.bind(
 					null,
 					basePath,

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import url from 'url';
-import localize from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -49,13 +49,13 @@ class FeedStream extends React.Component {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.feedId !== this.props.feedId ) {
-			this.updateState();
+			this.updateState( nextProps );
 		}
 	}
 
-	getState = () => {
-		const feed = this.getFeed(),
-			site = this.getSite( feed ),
+	getState = ( props = this.props ) => {
+		const feed = this.getFeed( props ),
+			site = this.getSite( props ),
 			title = this.getTitle( feed, site );
 
 		return {
@@ -103,18 +103,18 @@ class FeedStream extends React.Component {
 		return title;
 	}
 
-	getFeed = () => {
-		const feed = FeedStore.get( this.props.feedId );
+	getFeed = ( props = this.props ) => {
+		const feed = FeedStore.get( props.feedId );
 
 		if ( ! feed ) {
-			FeedStoreActions.fetch( this.props.feedId );
+			FeedStoreActions.fetch( props.feedId );
 		}
 
 		return feed;
 	}
 
-	getSite = () => {
-		const feed = FeedStore.get( this.props.feedId );
+	getSite = ( props = this.props ) => {
+		const feed = FeedStore.get( props.feedId );
 		let site;
 
 		if ( feed && feed.blog_ID ) {
@@ -128,9 +128,9 @@ class FeedStream extends React.Component {
 		return site;
 	}
 
-	updateState = () => {
-		const feed = this.getFeed(),
-			site = this.getSite(),
+	updateState = ( props = this.props ) => {
+		const feed = this.getFeed( props ),
+			site = this.getSite( props ),
 			title = this.getTitle( feed, site ),
 			newState = {};
 
@@ -169,7 +169,6 @@ class FeedStream extends React.Component {
 			</Stream>
 		);
 	}
-
 }
 
 export default localize( FeedStream );

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -11,7 +11,7 @@ import localize from 'i18n-calypso';
 import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';
 import Stream from 'reader/stream';
-import FeedHeader from 'reader/feed-header';
+import OldFeedHeader from 'reader/feed-header';
 import FeedStore from 'lib/feed-store';
 import FeedStoreActions from 'lib/feed-store/actions';
 import { state as FeedStoreState } from 'lib/feed-store/constants';
@@ -19,6 +19,8 @@ import FeedError from 'reader/feed-error';
 import HeaderBack from 'reader/header-back';
 import SiteStore from 'lib/reader-site-store';
 import { state as SiteState } from 'lib/reader-site-store/constants';
+import RefreshFeedHeader from 'blocks/reader-feed-header';
+import config from 'config';
 
 class FeedStream extends React.Component {
 


### PR DESCRIPTION
ES6-ify `FeedStream` and switch to use `React.Component`.

No functional changes.

### To test

Load a feed stream (e.g. http://calypso.localhost:3000/read/feeds/53502863) and ensure there are no errors or warnings in the console.