### PR TITLE
Reader: clean up list stream header for Refresh

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -396,7 +396,7 @@
 @import 'reader/stream/style';
 @import 'reader/list-gap/style';
 @import 'reader/list-item/style';
-@import 'reader/list-management/style';
+@import 'reader/list-stream/style';
 @import 'reader/post-byline/style';
 @import 'reader/post-errors/style';
 @import 'reader/post-excerpt-link/style';

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -14,24 +14,24 @@ import { isExternal } from 'lib/url';
 import FollowButton from 'components/follow-button/button';
 
 const ListStreamHeader = (
-	{ icon, isPlaceholder, title, description, showEdit, editUrl, showFollow, following, onFollowToggle, translate }
+	{ isPlaceholder, title, description, showEdit, editUrl, showFollow, following, onFollowToggle, translate }
 	) => {
 	const classes = classnames( {
 		'list-stream__header': true,
 		'is-placeholder': isPlaceholder,
-		'has-icon': !! icon,
 		'has-description': !! description
 	} );
 
 	return (
 		<Card className={ classes }>
-			{ icon &&
 			<span className="list-stream__header-icon">
-				{ icon }
-			</span> }
+				<Gridicon icon="list-unordered" size={ 24 } />
+			</span>
 
-			<h1 className="list-stream__header-title">{ title }</h1>
-			{ description && <p className="list-stream__header-description">{ description }</p> }
+			<div className="list-stream__header-details">
+				<h1 className="list-stream__header-title">{ title }</h1>
+				{ description && <p className="list-stream__header-description">{ description }</p> }
+			</div>
 
 			{ showFollow &&
 				<div className="list-stream__header-follow">
@@ -50,7 +50,6 @@ const ListStreamHeader = (
 };
 
 ListStreamHeader.propTypes = {
-	icon: React.PropTypes.element,
 	isPlaceholder: React.PropTypes.bool,
 	title: React.PropTypes.string,
 	description: React.PropTypes.string,

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import { isExternal } from 'lib/url';
+import FollowButton from 'components/follow-button/button';
+
+const ListStreamHeader = (
+	{ icon, isPlaceholder, title, description, showEdit, editUrl, showFollow, following, onFollowToggle, translate }
+	) => {
+	const classes = classnames( {
+		'list-stream__header': true,
+		'is-placeholder': isPlaceholder,
+		'has-icon': !! icon,
+		'has-description': !! description
+	} );
+
+	return (
+		<Card className={ classes }>
+			{ icon &&
+			<span className="list-stream__header-icon">
+				{ icon }
+			</span> }
+
+			<h1 className="list-stream__header-title">{ title }</h1>
+			{ description && <p className="list-stream__header-description">{ description }</p> }
+
+			{ showFollow &&
+				<div className="list-stream__header-follow">
+					<FollowButton iconSize={ 24 } following={ following } onFollowToggle={ onFollowToggle } />
+			</div> }
+
+			{ showEdit && editUrl &&
+			<div className="list-stream__header-edit">
+				<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
+					<span className="list-stream__header-action-icon"><Gridicon icon="cog" size={ 24 } /></span>
+					<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
+				</a>
+			</div> }
+		</Card>
+	);
+};
+
+ListStreamHeader.propTypes = {
+	icon: React.PropTypes.element,
+	isPlaceholder: React.PropTypes.bool,
+	title: React.PropTypes.string,
+	description: React.PropTypes.string,
+	showEdit: React.PropTypes.bool,
+	editUrl: React.PropTypes.string,
+	showFollow: React.PropTypes.bool,
+	following: React.PropTypes.bool,
+	onFollowToggle: React.PropTypes.func
+};
+
+export default localize( ListStreamHeader );

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -13,12 +13,12 @@ import Stream from 'reader/stream';
 import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';
 import ListMissing from './missing';
-import StreamHeader from 'reader/stream-header';
+import OldStreamHeader from 'reader/stream-header';
+import ListStreamHeader from './header';
 import { followList, unfollowList } from 'state/reader/lists/actions';
 import { getListByOwnerAndSlug, isSubscribedByOwnerAndSlug, isMissingByOwnerAndSlug } from 'state/reader/lists/selectors';
 import QueryReaderList from 'components/data/query-reader-list';
-
-const stats = require( 'reader/stats' );
+import * as stats from 'reader/stats';
 
 const ListStream = React.createClass( {
 
@@ -61,6 +61,8 @@ const ListStream = React.createClass( {
 		if ( this.props.isMissing ) {
 			return <ListMissing owner={ this.props.owner } slug={ this.props.slug } />;
 		}
+
+		const StreamHeader = config.isEnabled( 'reader/refresh/stream' ) ? ListStreamHeader : OldStreamHeader;
 
 		return (
 			<Stream { ...this.props } store={ this.props.postStore } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ shouldShowFollow }>

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -1,4 +1,4 @@
-.is-group-reader .card.stream-header {
+.is-group-reader .card.list-stream__header {
 	min-height: 72px;
 	padding: 24px 144px 24px 24px;
 
@@ -21,7 +21,7 @@
 	}
 }
 
-.stream-header__icon {
+.list-stream__header-icon {
 	position: absolute;
 		top: 12px;
 		left: 12px;
@@ -45,27 +45,27 @@
 	}
 }
 
-.stream-header__title {
+.list-stream__header-title {
 	color: $gray-dark;
 	font-size: 16px;
 }
 
-.stream-header__description {
+.list-stream__header-description {
 	margin: 0;
 	color: $gray;
 }
 
-.stream-header__follow {
+.list-stream__header-follow {
 	position: absolute;
 		right: 10px;
 		top: 15px;
 }
 
-.stream-header.is-placeholder {
+.list-stream__header.is-placeholder {
 	pointer-events: none;
 	user-select: none;
 
-	.stream-header__title,
+	.list-stream__header-title,
 	.follow-button,
 	.follow-button__label {
 		color: transparent;
@@ -73,7 +73,7 @@
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 
-	.stream-header__title {
+	.list-stream__header-title {
 		margin-right: 25%;
 	}
 
@@ -83,13 +83,13 @@
 	}
 }
 
-.stream-header__edit {
+.list-stream__header-edit {
 
-	.stream-header__action-label {
+	.list-stream__header-action-label {
 		display: none;
 	}
 
-	.stream-header__action-icon svg {
+	.list-stream__header-action-icon svg {
 		fill: $gray;
 		position: absolute;
 		margin: auto;

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -17,8 +17,9 @@
 
 	&:hover {
 		cursor: default;
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
 	}
+
+	box-shadow: none;
 }
 
 .list-stream__header-icon {

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -1,18 +1,12 @@
 .is-group-reader .card.list-stream__header {
-	min-height: 72px;
-	padding: 24px 144px 24px 24px;
+	min-height: 48px;
 
 	@include breakpoint( "<660px" ) {
 		padding-right: 72px;
 	}
 
-	&.has-icon {
-		padding-left: 72px;
-	}
-
 	&.has-description {
-		padding-top: 13px;
-		padding-bottom: 13px;
+		padding-bottom: 18px;
 	}
 
 	&:hover {
@@ -20,30 +14,28 @@
 	}
 
 	box-shadow: none;
+	border-bottom: 1px solid lighten( $gray, 30 );
+	padding: 0 0 6px 0;
+	display: flex;
 }
 
 .list-stream__header-icon {
-	position: absolute;
-		top: 12px;
-		left: 12px;
-	height: 48px;
-	width: 48px;
+	height: 24px;
+	width: 24px;
 	background: lighten( $gray, 20 );
 	text-align: center;
+	padding: 2px;
 
 	.gridicon {
 		fill: $white;
 		height: 24px;
 		width: 24px;
-		position: relative;
-			top: 12px;
 	}
+}
 
-	.gridicon__tag {
-		transform: rotate( -45deg );
-		top: 11px;
-		left: 1px;
-	}
+.list-stream__header-details {
+	margin-left: 10px;
+	margin-top: 2px;
 }
 
 .list-stream__header-title {
@@ -80,11 +72,11 @@
 
 	.gridicon {
 		display: none;
-		border: 1px solid red;
 	}
 }
 
 .list-stream__header-edit {
+	margin-left: auto;
 
 	.list-stream__header-action-label {
 		display: none;
@@ -92,10 +84,5 @@
 
 	.list-stream__header-action-icon svg {
 		fill: $gray;
-		position: absolute;
-		margin: auto;
-		top: 0;
-		bottom: 0;
-		right: 24px;
 	}
 }

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -37,8 +37,8 @@
 }
 
 .list-stream__header-details {
+	align-self: center;
 	margin-left: 10px;
-	margin-top: 2px;
 }
 
 .list-stream__header-title {

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -41,8 +41,12 @@
 	align-self: center;
 	display: flex;
 	flex-direction: column;
-	margin-left: 10px;
-	width: calc(100% - 90px);
+	margin: 0 10px;
+	width: calc( 100% - 15px);
+
+	@include breakpoint( ">660px" ) {
+		width: calc( 100% - 165px );
+	}
 }
 
 .list-stream__header-title {
@@ -59,6 +63,7 @@
 .list-stream__header-description {
 	height: 22px;
 	overflow: hidden;
+	position: relative;
 
 	&:after {
 		@include long-content-fade( $size: 15% );
@@ -66,9 +71,14 @@
 }
 
 .list-stream__header-follow {
-	position: absolute;
-		top: 8px;
-		right: 0;
+	align-items: stretch;
+	display: flex;
+	margin-left: auto;
+	z-index: 1;
+
+	.follow-button {
+		padding: 0;
+	}
 }
 
 .list-stream__header.is-placeholder {

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -66,7 +66,8 @@
 }
 
 .list-stream__header-follow {
-	margin-left: auto;
+	position: absolute;
+	right: 0;
 }
 
 .list-stream__header.is-placeholder {

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -88,7 +88,7 @@
 		margin: auto;
 		position: relative;
 			bottom: 0;
-			top: 15px;
+			top: 12px;
 			right: -6px;
 	}
 }

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -42,7 +42,7 @@
 	display: flex;
 	flex-direction: column;
 	margin: 0 10px;
-	width: calc( 100% - 15px);
+	width: calc( 100% - 15px );
 
 	@include breakpoint( ">660px" ) {
 		width: calc( 100% - 165px );

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -52,9 +52,7 @@
 }
 
 .list-stream__header-follow {
-	position: absolute;
-		right: 10px;
-		top: 15px;
+	margin-left: auto;
 }
 
 .list-stream__header.is-placeholder {

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -40,7 +40,7 @@
 .list-stream__header-details {
 	align-self: center;
 	display: flex;
-    flex-direction: column;
+	flex-direction: column;
 	margin-left: 10px;
 	width: calc(100% - 90px);
 }

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -1,8 +1,12 @@
 .is-group-reader .card.list-stream__header {
 	min-height: 48px;
+	margin-top: 24px;
+	padding: 0 14px 14px 14px;
 
-	@include breakpoint( "<660px" ) {
-		padding-right: 72px;
+	@include breakpoint( ">660px" ) {
+		padding-left: 0;
+		padding-right: 0;
+		margin-top: 0;
 	}
 
 	&.has-description {
@@ -15,7 +19,6 @@
 
 	box-shadow: none;
 	border-bottom: 1px solid lighten( $gray, 30 );
-	padding: 0 0 6px 0;
 	display: flex;
 }
 

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -1,7 +1,10 @@
 .is-group-reader .card.list-stream__header {
+	box-shadow: none;
+	border-bottom: 1px solid lighten( $gray, 30% );
+	display: flex;
 	min-height: 48px;
 	margin-top: 24px;
-	padding: 0 14px 14px 14px;
+	padding: 0 14px 14px;
 
 	@include breakpoint( ">660px" ) {
 		padding-left: 0;
@@ -16,22 +19,19 @@
 	&:hover {
 		cursor: default;
 	}
-
-	box-shadow: none;
-	border-bottom: 1px solid lighten( $gray, 30 );
-	display: flex;
 }
 
 .list-stream__header-icon {
-	height: 24px;
-	width: 24px;
-	background: lighten( $gray, 20 );
+	height: 48px;
+	width: 48px;
+	background: lighten( $gray, 20% );
 	text-align: center;
-	padding: 2px;
 
 	.gridicon {
 		fill: $white;
 		height: 24px;
+		position: relative;
+			top: 12px;
 		width: 24px;
 	}
 }
@@ -83,7 +83,12 @@
 		display: none;
 	}
 
-	.list-stream__header-action-icon svg {
+	.list-stream__header-action-icon .gridicon {
 		fill: $gray;
+		margin: auto;
+		position: relative;
+			bottom: 0;
+			top: 15px;
+			right: -6px;
 	}
 }

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -67,7 +67,8 @@
 
 .list-stream__header-follow {
 	position: absolute;
-	right: 0;
+		top: 8px;
+		right: 0;
 }
 
 .list-stream__header.is-placeholder {

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -2,6 +2,7 @@
 	box-shadow: none;
 	border-bottom: 1px solid lighten( $gray, 30% );
 	display: flex;
+	flex-direction: row;
 	min-height: 48px;
 	margin-top: 24px;
 	padding: 0 14px 14px;
@@ -38,7 +39,10 @@
 
 .list-stream__header-details {
 	align-self: center;
+	display: flex;
+    flex-direction: column;
 	margin-left: 10px;
+	width: calc(100% - 90px);
 }
 
 .list-stream__header-title {
@@ -49,6 +53,16 @@
 .list-stream__header-description {
 	margin: 0;
 	color: $gray;
+}
+
+.list-stream__header-title,
+.list-stream__header-description {
+	height: 22px;
+	overflow: hidden;
+
+	&:after {
+		@include long-content-fade( $size: 15% );
+	}
 }
 
 .list-stream__header-follow {

--- a/client/reader/stream-header/README.md
+++ b/client/reader/stream-header/README.md
@@ -1,6 +1,6 @@
 # Reader Stream Header
 
-The header for a stream in the reader
+The header for a stream in the Reader.
 
 ## Props
 

--- a/client/reader/stream-header/index.jsx
+++ b/client/reader/stream-header/index.jsx
@@ -27,7 +27,7 @@ var StreamHeader = React.createClass( {
 		} );
 
 		return (
-			<Card className={ classes } >
+			<Card className={ classes }>
 				{ this.props.icon ?
 				<span className="stream-header__icon">
 					{ this.props.icon }

--- a/client/reader/stream-header/style.scss
+++ b/client/reader/stream-header/style.scss
@@ -17,9 +17,10 @@
 
 	&:hover {
 		cursor: default;
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-			0 1px 2px lighten( $gray, 30% );
+		box-shadow: none;
 	}
+
+	box-shadow: none;
 }
 
 .stream-header__icon {

--- a/config/development.json
+++ b/config/development.json
@@ -126,7 +126,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/list-management": true,
+		"reader/list-management": false,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/refresh/stream": true,

--- a/config/test.json
+++ b/config/test.json
@@ -94,7 +94,7 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/list-management": true,
+		"reader/list-management": false,
 		"republicize": false,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/9125.

- [x] Remove box-shadow from header
- [x] Reduce padding on icon
- [x] Clean up stream header component
- [x] Add bottom border before stream cards ~~(Can you confirm @fraying?)~~
- [x] Fix mobile styles
- [x] Drop follow button down (e.g. on http://calypso.localhost:3000/read/list/blowery/comics)

![4c3a007c-a1b9-11e6-8298-df260d3faeaf](https://cloud.githubusercontent.com/assets/17325/20508828/39d47664-b0c9-11e6-9ad5-901328d6e0d1.png)

