### PR TITLE
TaxonomyManager: add link for View Posts.

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -18,6 +18,7 @@ import Count from 'components/count';
 import Dialog from 'components/dialog';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
+import { getSite } from 'state/sites/selectors';
 import { deleteTerm } from 'state/terms/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
 import { decodeEntities } from 'lib/formatting';
@@ -32,6 +33,8 @@ class TaxonomyManagerListItem extends Component {
 		siteId: PropTypes.number,
 		term: PropTypes.object,
 		translate: PropTypes.func,
+		siteUrl: PropTypes.string,
+		slug: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -44,7 +47,9 @@ class TaxonomyManagerListItem extends Component {
 	};
 
 	togglePopoverMenu = event => {
-		event.stopPropagation && event.stopPropagation();
+		if ( event && event.stopPropagation ) {
+			event.stopPropagation();
+		}
 		this.setState( {
 			popoverMenuOpen: ! this.state.popoverMenuOpen
 		} );
@@ -83,6 +88,16 @@ class TaxonomyManagerListItem extends Component {
 			popoverMenuOpen: false
 		} );
 	};
+
+	getTaxonomyLink() {
+		const { taxonomy, siteUrl, term } = this.props;
+		let taxonomyBase = taxonomy;
+
+		if ( taxonomy === 'post_tag' ) {
+			taxonomyBase = 'tag';
+		}
+		return `${ siteUrl }/${ taxonomyBase }/${ term.slug }/`;
+	}
 
 	render() {
 		const { canSetAsDefault, isDefault, term, translate } = this.props;
@@ -132,7 +147,7 @@ class TaxonomyManagerListItem extends Component {
 					<PopoverMenuItem onClick={ this.deleteItem } icon="trash">
 						{ translate( 'Delete' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem icon="external" >
+					<PopoverMenuItem href={ this.getTaxonomyLink() } icon="external">
 						{ translate( 'View Posts' ) }
 					</PopoverMenuItem>
 					{ canSetAsDefault && ! isDefault && <PopoverMenuSeparator /> }
@@ -161,11 +176,13 @@ export default connect(
 		const siteSettings = getSiteSettings( state, siteId );
 		const canSetAsDefault = taxonomy === 'category';
 		const isDefault = canSetAsDefault && get( siteSettings, [ 'default_category' ] ) === term.ID;
+		const siteUrl = get( getSite( state, siteId ), 'URL' );
 
 		return {
 			isDefault,
 			canSetAsDefault,
 			siteId,
+			siteUrl,
 		};
 	},
 	{ deleteTerm, saveSiteSettings }


### PR DESCRIPTION
This branch adds a taxonomy-specific link for the "View Posts" option in the term action menu:

<img width="738" alt="testingtimmy2_wordpress_com_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/20510582/3b358ce4-b026-11e6-9caa-a5fff70783a2.png">

To achieve this link, a new site selector `getSiteUrl` was created, and some tests to cover the selector are also in this PR.  I couldn't find an attribute in the taxonomy state tree to represent the proper URL taxonomy path - which for everything besides `post_tag` is simply the taxonomy name.  So a bit of `if` logic for that, otherwise a pretty straightforward implementation.

We had talked a bit about making this link open a post listing in Calypso, but I opted to emmulate the front-end links that are seen in taxonomy management in wp-admin instead.

__To Test__
- Open a [Settings Writing](http://calypso.localhost:3000/settings/writing/testingtimmy2.wordpress.com) page
- Click on Categories or Tags
- Expand the action menu for a term, click "View Posts"
- Verify the link opens the front-end post listing for either the tag or the category

/cc @youknowriad 