### PR TITLE
Taxonomy Manager: show a tooltip on taxonomy items count that explains the number

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -82,7 +82,7 @@ class TaxonomyManagerListItem extends Component {
 
 	tooltipText = () => {
 		const { term, translate } = this.props;
-		const name = decodeEntities( term.name ) || translate( 'Untitled' );
+		const name = this.name();
 		const postCount = term.post_count;
 		return translate(
 			'%(postCount)d \'%(name)s\' post',
@@ -105,9 +105,13 @@ class TaxonomyManagerListItem extends Component {
 		this.setState( { showTooltip: false } );
 	};
 
+	name = () => {
+		const { term, translate } = this.props;
+		return decodeEntities( term.name ) || translate( 'Untitled' );
+	};
+
 	render() {
 		const { canSetAsDefault, isDefault, onClick, term, translate } = this.props;
-		const name = decodeEntities( term.name ) || translate( 'Untitled' );
 		const className = classNames( 'taxonomy-manager__item', {
 			'is-default': isDefault
 		} );
@@ -122,7 +126,7 @@ class TaxonomyManagerListItem extends Component {
 					<Gridicon icon={ isDefault ? 'checkmark-circle' : 'folder' } />
 				</span>
 				<span className="taxonomy-manager__label" onClick={ onClick }>
-					<span>{ name }</span>
+					<span>{ this.name() }</span>
 					{ isDefault &&
 					<span className="taxonomy-manager__default-label">
 							{ translate( 'default', { context: 'label for terms marked as default' } ) }

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -82,7 +82,7 @@ class TaxonomyManagerListItem extends Component {
 
 	tooltipText = () => {
 		const { term, translate } = this.props;
-		const name = this.name();
+		const name = this.getName();
 		const postCount = term.post_count;
 		return translate(
 			'%(postCount)d \'%(name)s\' post',
@@ -105,7 +105,7 @@ class TaxonomyManagerListItem extends Component {
 		this.setState( { showTooltip: false } );
 	};
 
-	name = () => {
+	getName = () => {
 		const { term, translate } = this.props;
 		return decodeEntities( term.name ) || translate( 'Untitled' );
 	};
@@ -126,7 +126,7 @@ class TaxonomyManagerListItem extends Component {
 					<Gridicon icon={ isDefault ? 'checkmark-circle' : 'folder' } />
 				</span>
 				<span className="taxonomy-manager__label" onClick={ onClick }>
-					<span>{ this.name() }</span>
+					<span>{ this.getName() }</span>
 					{ isDefault &&
 					<span className="taxonomy-manager__default-label">
 							{ translate( 'default', { context: 'label for terms marked as default' } ) }

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -81,7 +81,9 @@ class TaxonomyManagerListItem extends Component {
 	}
 
 	tooltipText = () => {
-		const { postCount, name, translate } = this.props;
+		const { term, translate } = this.props;
+		const name = decodeEntities( term.name ) || translate( 'Untitled' );
+		const postCount = term.post_count;
 		return translate(
 			'%(postCount)d \'%(name)s\' post',
 			'%(postCount)d \'%(name)s\' posts',

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -5,7 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { get, isUndefined, noop } from 'lodash';
+import { get, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -139,7 +139,6 @@ class TaxonomyManagerListItem extends Component {
 					context={ this.refs && this.refs.count }
 					isVisible={ this.state.showTooltip }
 					position="left"
-					onClose={ noop }
 				>
 					{ this.tooltipText() }
 				</Tooltip>

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -154,9 +154,9 @@ class TaxonomyManagerListItem extends Component {
 					</PopoverMenuItem>
 					{ canSetAsDefault && ! isDefault && <PopoverMenuSeparator /> }
 					{ canSetAsDefault && ! isDefault &&
-					<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">
-						{ translate( 'Set as default' ) }
-					</PopoverMenuItem>
+						<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">
+							{ translate( 'Set as default' ) }
+						</PopoverMenuItem>
 					}
 				</EllipsisMenu>
 				<Dialog

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
+import { omit } from 'lodash';
 
 export default React.createClass( {
 
@@ -15,8 +16,9 @@ export default React.createClass( {
 	},
 
 	render() {
+		const inheritProps = omit( this.props, [ 'count' ] );
 		return (
-			<span className="count">{ this.numberFormat( this.props.count ) }</span>
+			<span className="count" { ...inheritProps }>{ this.numberFormat( this.props.count ) }</span>
 		);
 	}
 } );

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
-import { omit } from 'lodash';
 
 export default React.createClass( {
 
@@ -16,9 +15,9 @@ export default React.createClass( {
 	},
 
 	render() {
-		const inheritProps = omit( this.props, [ 'count' ] );
+		const { count, ...inheritProps } = this.props;
 		return (
-			<span className="count" { ...inheritProps }>{ this.numberFormat( this.props.count ) }</span>
+			<span className="count" { ...inheritProps }>{ this.numberFormat( count ) }</span>
 		);
 	}
 } );


### PR DESCRIPTION
This PR adds tooltips to the post count on taxonomy items when managing terms.

**Before:**

![before](https://cloud.githubusercontent.com/assets/128826/20513851/661765be-b0d4-11e6-98d1-de3b72a3aeca.gif)

**After:**

![tooltips](https://cloud.githubusercontent.com/assets/128826/20551329/e9f69b32-b18a-11e6-8215-fa46b8bcbd91.gif)
