### PR TITLE
Fix/running out of date version of jetpack plugins

### DIFF
--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -1,30 +1,22 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var PluginsActions = require( 'lib/plugins/actions' ),
-	PluginsLog = require( 'lib/plugins/log-store' ),
-	PluginAction = require( 'my-sites/plugins/plugin-action/plugin-action' ),
-	ExternalLink = require( 'components/external-link' ),
-	analytics = require( 'lib/analytics' ),
-	utils = require( 'lib/site/utils' );
+import PluginsActions from 'lib/plugins/actions';
+import PluginsLog from 'lib/plugins/log-store';
+import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
+import ExternalLink from 'components/external-link';
+import analytics from 'lib/analytics';
+import utils from 'lib/site/utils';
+import i18n from 'i18n-calypso';
 
-module.exports = React.createClass( {
+class PluginAutopdateToggle extends React.Component {
 
-	displayName: 'PluginAutopdateToggle',
-
-	propTypes: {
-		isMock: React.PropTypes.bool,
-		site: React.PropTypes.object.isRequired,
-		plugin: React.PropTypes.object.isRequired,
-		wporg: React.PropTypes.bool
-	},
-
-	toggleAutoupdates: function() {
+	toggleAutoupdates() {
 		if ( this.props.isMock || this.props.disabled ) {
 			return;
 		}
@@ -45,73 +37,75 @@ module.exports = React.createClass( {
 				plugin: this.props.plugin.slug
 			} );
 		}
-	},
+	}
 
-	getDisabledInfo: function() {
+	recordEvent() {
+		analytics.ga.recordEvent( 'Plugins', 'Clicked How do I fix disabled autoupdates' );
+	}
+
+	getDisabledInfo() {
 		if ( ! this.props.site ) { // we don't have enough info
 			return null;
 		}
 
 		if ( ! this.props.wporg ) {
-			return this.translate( 'This plugin is not in the WordPress.org plugin repository, so we can\'t autoupdate it.' );
+			return i18n.translate( 'This plugin is not in the WordPress.org plugin repository, so we can\'t autoupdate it.' );
 		}
 
 		if ( ! this.props.site.hasMinimumJetpackVersion ) {
-			return this.translate( '%(site)s is not running an up to date version of Jetpack', {
+			return i18n.translate( '%(site)s is not running an up to date version of Jetpack', {
 				args: { site: this.props.site.title }
 			} );
 		}
 
 		if ( this.props.site.options.is_multi_network ) {
-			return this.translate( '%(site)s is part of a multi-network installation, which is not currently supported.', {
+			return i18n.translate( '%(site)s is part of a multi-network installation, which is not currently supported.', {
 				args: { site: this.props.site.title }
 			} );
 		}
 
 		if ( ! utils.isMainNetworkSite( this.props.site ) ) {
-			return this.translate( 'Only the main site on a multi-site installation can enable autoupdates for plugins.', {
+			return i18n.translate( 'Only the main site on a multi-site installation can enable autoupdates for plugins.', {
 				args: { site: this.props.site.title }
 			} );
 		}
 
 		if ( ! this.props.site.canAutoupdateFiles && this.props.site.options.file_mod_disabled ) {
-			let reasons = utils.getSiteFileModDisableReason( this.props.site, 'autoupdateFiles' );
-			let html = [];
+			const reasons = utils.getSiteFileModDisableReason( this.props.site, 'autoupdateFiles' );
+			const html = [];
 
 			if ( reasons.length > 1 ) {
 				html.push(
 					<p key="reason-shell">
-						{ this.translate( 'Autoupdates are not available for %(site)s:', { args: { site: this.props.site.title } } ) }
+						{ i18n.translate( 'Autoupdates are not available for %(site)s:', { args: { site: this.props.site.title } } ) }
 					</p>
 				);
-				let list = reasons.map( ( reason, i ) => ( <li key={ 'reason-i' + i + '-' + this.props.site.ID } >{ reason }</li> ) );
+				const list = reasons.map( ( reason, i ) => ( <li key={ 'reason-i' + i + '-' + this.props.site.ID } >{ reason }</li> ) );
 				html.push( <ul className="plugin-action__disabled-info-list" key="reason-shell-list">{ list }</ul> );
 			} else {
 				html.push(
 					<p key="reason-shell">{
-						this.translate( 'Autoupdates are not available for %(site)s. %(reason)s', {
-							args: { site: this.props.site.title, reason: reasons[0] }
+						i18n.translate( 'Autoupdates are not available for %(site)s. %(reason)s', {
+							args: { site: this.props.site.title, reason: reasons[ 0 ] }
 						} )
 					}</p> );
 			}
 			html.push(
 				<ExternalLink
 					key="external-link"
-					onClick={
-						analytics.ga.recordEvent.bind( this, 'Plugins', 'Clicked How do I fix disabled autoupdates' )
-					}
+					onClick={ this.recordEvent }
 					href="https://jetpack.me/support/site-management/#file-update-disabled"
 					>
-					{ this.translate( 'How do I fix this?' ) }
+					{ i18n.translate( 'How do I fix this?' ) }
 				</ExternalLink>
 			);
 
 			return html;
 		}
 		return null;
-	},
+	}
 
-	render: function() {
+	render() {
 		if ( ! this.props.site.jetpack ) {
 			return null;
 		}
@@ -122,10 +116,10 @@ module.exports = React.createClass( {
 			] ),
 			getDisabledInfo = this.getDisabledInfo(),
 			label = getDisabledInfo
-				? this.translate( 'Autoupdates disabled', {
+				? i18n.translate( 'Autoupdates disabled', {
 					context: 'this goes next to an icon that displays if the plugin has "autoupdates disabled" active'
 				} )
-				: this.translate( 'Autoupdates', {
+				: i18n.translate( 'Autoupdates', {
 					context: 'this goes next to an icon that displays if the plugin has "autoupdates" active'
 				} );
 
@@ -140,4 +134,15 @@ module.exports = React.createClass( {
 				htmlFor={ 'autoupdates-' + this.props.plugin.slug + '-' + this.props.site.ID } />
 		);
 	}
-} );
+}
+
+PluginAutopdateToggle.displayName = 'PluginAutopdateToggle';
+
+PluginAutopdateToggle.propTypes = {
+	isMock: React.PropTypes.bool,
+	site: React.PropTypes.object.isRequired,
+	plugin: React.PropTypes.object.isRequired,
+	wporg: React.PropTypes.bool
+};
+
+export default PluginAutopdateToggle;

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -16,6 +16,13 @@ import i18n from 'i18n-calypso';
 
 class PluginAutopdateToggle extends React.Component {
 
+	constructor() {
+		super();
+		[ 'toggleAutoupdates', 'recordEvent' ].forEach(
+			( method ) => this[ method ] = this[ method ].bind( this )
+		);
+	}
+
 	toggleAutoupdates() {
 		if ( this.props.isMock || this.props.disabled ) {
 			return;

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -65,6 +65,7 @@ export const getSite = createSelector(
 		return {
 			...site,
 			...getComputedAttributes( site ),
+			...getJetpackComputedAttributes( state, siteId ),
 			hasConflict: isSiteConflicting( state, siteId ),
 			title: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
@@ -74,6 +75,16 @@ export const getSite = createSelector(
 	},
 	( state ) => state.sites.items
 );
+
+export function getJetpackComputedAttributes( state, siteId ) {
+	if ( ! isJetpackSite( state, siteId ) ) {
+		return {};
+	}
+	return {
+		hasMinimumJetpackVersion: siteHasMinimumJetpackVersion( state, siteId ),
+		canAutoupdateFiles: canJetpackSiteAutoUpdateFiles( state, siteId ),
+	};
+}
 
 /**
  * Returns a filtered array of WordPress.com site IDs where a Jetpack site


### PR DESCRIPTION
Currently when a user visits plugins/example.com they see that they can't autoupdate plugins. 
This PR fixes it by making sure that the state tree has the attributes available. 

Before:
![screen shot 2016-11-21 at 23 08 13](https://cloud.githubusercontent.com/assets/115071/20514179/697de376-b03f-11e6-86fb-80e1cd2d0b8b.png)

After:
![screen shot 2016-11-21 at 23 08 04](https://cloud.githubusercontent.com/assets/115071/20514189/6d8a738a-b03f-11e6-8287-2ddb56858067.png)


To test: visit calypso
http://calypso.localhost:3000/plugins/example.com

And notice that this 
As far as I can tell this shouldn't create any regressions. 

I think this is high propriety since we release jetpack 4.4 and users are checking out the url and ironically is not working for them. 

cc: @johnHackworth, @ebinnion, @tyxla 
