### PR TITLE
Show support options from /help/contact by the chat and ticket eligibility accordingly

### DIFF
--- a/client/components/data/query-ticket-support-configuration/index.jsx
+++ b/client/components/data/query-ticket-support-configuration/index.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  */
 import {
 	ticketSupportConfigurationRequest,
-} from 'state/ticket-support/configuration/actions';
+} from 'state/help/ticket/actions';
 
 import {
 	isRequestingTicketSupportConfiguration,

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -29,6 +29,7 @@ import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { isHappychatAvailable } from 'state/happychat/selectors';
 import QueryOlark from 'components/data/query-olark';
+import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';
 import { connectChat as connectHappychat, sendChatMessage as sendHappychatMessage } from 'state/happychat/actions';
 import { openChat as openHappychat } from 'state/ui/happychat/actions';
@@ -506,6 +507,7 @@ const HelpContact = React.createClass( {
 					{ this.getView() }
 				</Card>
 				<QueryOlark />
+				<QueryTicketSupportConfiguration />
 			</Main>
 		);
 	}

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -29,6 +29,7 @@ import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { isHappychatAvailable } from 'state/happychat/selectors';
 import { isTicketSupportEligible } from 'state/ticket-support/configuration/selectors';
+import { isRequestingTicketSupportConfiguration } from 'state/ticket-support/is-requesting/selectors';
 import QueryOlark from 'components/data/query-olark';
 import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';
@@ -420,14 +421,14 @@ const HelpContact = React.createClass( {
 	 */
 	getView: function() {
 		const { olark, confirmation, sitesInitialized, isSubmitting } = this.state;
-		const { isTicketSupportEligible } = this.props;
+		const { isRequestingTicketSupportConfiguration, isTicketSupportEligible } = this.props;
 
 		const showHappychatVariation = this.shouldUseHappychat();
 		const showChatVariation = olark.isUserEligible && olark.isOperatorAvailable;
 		const showKayakoVariation = ! showChatVariation && ( olark.details.isConversing || isTicketSupportEligible );
 		const showForumsVariation = ! ( showChatVariation || showKayakoVariation );
 		const showHelpLanguagePrompt = ( olark.locale !== i18n.getLocaleSlug() );
-		const showPreloadForm = ! ( olark.isOlarkReady && sitesInitialized ) && ! this.props.olarkTimedOut;
+		const showPreloadForm = ! ( olark.isOlarkReady && sitesInitialized ) && ! isRequestingTicketSupportConfiguration && ! this.props.olarkTimedOut;
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;
@@ -522,6 +523,7 @@ export default connect(
 			olarkTimedOut: isOlarkTimedOut( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			isHappychatAvailable: isHappychatAvailable( state ),
+			isRequestingTicketSupportConfiguration: isRequestingTicketSupportConfiguration( state ),
 			isTicketSupportEligible: isTicketSupportEligible( state ),
 		};
 	},

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -419,7 +419,9 @@ const HelpContact = React.createClass( {
 	 * @return {object} A JSX object that should be rendered
 	 */
 	getView: function() {
-		const { olark, confirmation, sitesInitialized, isSubmitting, isTicketSupportEligible } = this.state;
+		const { olark, confirmation, sitesInitialized, isSubmitting } = this.state;
+		const { isTicketSupportEligible } = this.props;
+
 		const showHappychatVariation = this.shouldUseHappychat();
 		const showChatVariation = olark.isUserEligible && olark.isOperatorAvailable;
 		const showKayakoVariation = ! showChatVariation && ( olark.details.isConversing || isTicketSupportEligible );

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -28,8 +28,7 @@ import i18n from 'lib/i18n-utils';
 import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { isHappychatAvailable } from 'state/happychat/selectors';
-import { isTicketSupportEligible } from 'state/ticket-support/configuration/selectors';
-import { isRequestingTicketSupportConfiguration } from 'state/ticket-support/is-requesting/selectors';
+import { isTicketSupportEligible, isTicketSupportConfigurationReady } from 'state/ticket-support/configuration/selectors';
 import QueryOlark from 'components/data/query-olark';
 import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';
@@ -421,14 +420,16 @@ const HelpContact = React.createClass( {
 	 */
 	getView: function() {
 		const { olark, confirmation, sitesInitialized, isSubmitting } = this.state;
-		const { isRequestingTicketSupportConfiguration, isTicketSupportEligible } = this.props;
+		const { isTicketSupportConfigurationReady, isTicketSupportEligible } = this.props;
 
 		const showHappychatVariation = this.shouldUseHappychat();
 		const showChatVariation = olark.isUserEligible && olark.isOperatorAvailable;
 		const showKayakoVariation = ! showChatVariation && ( olark.details.isConversing || isTicketSupportEligible );
 		const showForumsVariation = ! ( showChatVariation || showKayakoVariation );
 		const showHelpLanguagePrompt = ( olark.locale !== i18n.getLocaleSlug() );
-		const showPreloadForm = ! ( olark.isOlarkReady && sitesInitialized ) && ! isRequestingTicketSupportConfiguration && ! this.props.olarkTimedOut;
+
+		const olarkReadyOrTimedOut = olark.isOlarkReady && ! this.props.olarkTimedOut;
+		const showPreloadForm = ! sitesInitialized || ! isTicketSupportConfigurationReady || ! olarkReadyOrTimedOut;
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;
@@ -523,7 +524,7 @@ export default connect(
 			olarkTimedOut: isOlarkTimedOut( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			isHappychatAvailable: isHappychatAvailable( state ),
-			isRequestingTicketSupportConfiguration: isRequestingTicketSupportConfiguration( state ),
+			isTicketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
 			isTicketSupportEligible: isTicketSupportEligible( state ),
 		};
 	},

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -28,6 +28,7 @@ import i18n from 'lib/i18n-utils';
 import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { isHappychatAvailable } from 'state/happychat/selectors';
+import { isTicketSupportEligible } from 'state/ticket-support/configuration/selectors';
 import QueryOlark from 'components/data/query-olark';
 import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';
@@ -418,10 +419,10 @@ const HelpContact = React.createClass( {
 	 * @return {object} A JSX object that should be rendered
 	 */
 	getView: function() {
-		const { olark, confirmation, sitesInitialized, isSubmitting } = this.state;
+		const { olark, confirmation, sitesInitialized, isSubmitting, isTicketSupportEligible } = this.state;
 		const showHappychatVariation = this.shouldUseHappychat();
 		const showChatVariation = olark.isUserEligible && olark.isOperatorAvailable;
-		const showKayakoVariation = ! showChatVariation && ( olark.details.isConversing || olark.isUserEligible );
+		const showKayakoVariation = ! showChatVariation && ( olark.details.isConversing || isTicketSupportEligible );
 		const showForumsVariation = ! ( showChatVariation || showKayakoVariation );
 		const showHelpLanguagePrompt = ( olark.locale !== i18n.getLocaleSlug() );
 		const showPreloadForm = ! ( olark.isOlarkReady && sitesInitialized ) && ! this.props.olarkTimedOut;
@@ -518,7 +519,8 @@ export default connect(
 		return {
 			olarkTimedOut: isOlarkTimedOut( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
-			isHappychatAvailable: isHappychatAvailable( state )
+			isHappychatAvailable: isHappychatAvailable( state ),
+			isTicketSupportEligible: isTicketSupportEligible( state ),
 		};
 	},
 	{ connectHappychat, openHappychat, sendHappychatMessage }

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -28,7 +28,7 @@ import i18n from 'lib/i18n-utils';
 import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { isHappychatAvailable } from 'state/happychat/selectors';
-import { isTicketSupportEligible, isTicketSupportConfigurationReady } from 'state/ticket-support/configuration/selectors';
+import { isTicketSupportEligible, isTicketSupportConfigurationReady } from 'state/help/ticket/selectors';
 import QueryOlark from 'components/data/query-olark';
 import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import config from 'config';
 import Main from 'components/main';
 import Card from 'components/card';
+import Notice from 'components/notice';
 import OlarkChatbox from 'components/olark-chatbox';
 import olarkStore from 'lib/olark-store';
 import olarkActions from 'lib/olark-store/actions';
@@ -420,7 +421,7 @@ const HelpContact = React.createClass( {
 	 */
 	getView: function() {
 		const { olark, confirmation, sitesInitialized, isSubmitting } = this.state;
-		const { isTicketSupportConfigurationReady, isTicketSupportEligible } = this.props;
+		const { isTicketSupportConfigurationReady, isTicketSupportEligible, ticketSupportRequestError } = this.props;
 
 		const showHappychatVariation = this.shouldUseHappychat();
 		const showChatVariation = olark.isUserEligible && olark.isOperatorAvailable;
@@ -429,7 +430,9 @@ const HelpContact = React.createClass( {
 		const showHelpLanguagePrompt = ( olark.locale !== i18n.getLocaleSlug() );
 
 		const olarkReadyOrTimedOut = olark.isOlarkReady && ! this.props.olarkTimedOut;
-		const showPreloadForm = ! sitesInitialized || ! isTicketSupportConfigurationReady || ! olarkReadyOrTimedOut;
+		const ticketReadyOrError = isTicketSupportConfigurationReady || null !== ticketSupportRequestError;
+
+		const showPreloadForm = ! sitesInitialized || ! ticketReadyOrError || ! olarkReadyOrTimedOut ;
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;
@@ -500,7 +503,20 @@ const HelpContact = React.createClass( {
 		// Hide the olark widget in the bottom right corner.
 		olarkActions.hideBox();
 
-		return <HelpContactForm { ...contactFormProps } />;
+		const shouldShowTicketRequestErrorNotice = ! showChatVariation && null !== ticketSupportRequestError;
+
+		return (
+			<div>
+				{ shouldShowTicketRequestErrorNotice &&
+					<Notice
+						status='is-error'
+						text={ this.translate( 'An error occurred while requesting for email support settings. Please try again later.' ) }
+						showDismiss={ false }
+					/>
+				}
+				<HelpContactForm { ...contactFormProps } />
+			</div>
+		);
 	},
 
 	render: function() {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -186,8 +187,8 @@ const HelpContact = React.createClass( {
 			this.setState( {
 				isSubmitting: false,
 				confirmation: {
-					title: this.translate( 'We\'re on it!' ),
-					message: this.translate(
+					title: this.props.translate( 'We\'re on it!' ),
+					message: this.props.translate(
 						'We\'ve received your message, and you\'ll hear back from ' +
 						'one of our Happiness Engineers shortly.'
 					)
@@ -221,8 +222,8 @@ const HelpContact = React.createClass( {
 			this.setState( {
 				isSubmitting: false,
 				confirmation: {
-					title: this.translate( 'Got it!' ),
-					message: this.translate(
+					title: this.props.translate( 'Got it!' ),
+					message: this.props.translate(
 						'Your message has been submitted to our ' +
 						'{{a}}community forums{{/a}}',
 						{
@@ -357,9 +358,9 @@ const HelpContact = React.createClass( {
 		}
 
 		if ( isAvailable ) {
-			notices.success( this.translate( 'Our Happiness Engineers have returned, chat with us.' ) );
+			notices.success( this.props.translate( 'Our Happiness Engineers have returned, chat with us.' ) );
 		} else {
-			notices.warning( this.translate( 'Sorry! We just missed you as our Happiness Engineers stepped away.' ) );
+			notices.warning( this.props.translate( 'Sorry! We just missed you as our Happiness Engineers stepped away.' ) );
 		}
 	},
 
@@ -369,7 +370,7 @@ const HelpContact = React.createClass( {
 		if ( ! isUserEligible || isOlarkReady ) {
 			return;
 		}
-		notices.warning( this.translate(
+		notices.warning( this.props.translate(
 			'Our chat tools did not load. If you have an adblocker ' +
 			'please disable it and refresh this page.'
 		) );
@@ -441,6 +442,7 @@ const HelpContact = React.createClass( {
 
 	getContactFormPropsVariation: function( variationSlug ) {
 		const { isSubmitting } = this.state;
+		const { translate } = this.props;
 		const moreThanOneSite = sites.get().length > 1;
 
 		switch ( variationSlug ) {
@@ -448,7 +450,7 @@ const HelpContact = React.createClass( {
 				const isDev = ( ( config( 'env' ) === 'development' ) || ( config( 'env_id' ) === 'stage' ) );
 				return {
 					onSubmit: this.startHappychat,
-					buttonLabel: isDev ? 'Happychat' : this.translate( 'Chat with us' ),
+					buttonLabel: isDev ? 'Happychat' : translate( 'Chat with us' ),
 					showSubjectField: false,
 					showHowCanWeHelpField: true,
 					showHowYouFeelField: true,
@@ -458,7 +460,7 @@ const HelpContact = React.createClass( {
 			case SUPPORT_LIVECHAT:
 				return {
 					onSubmit: this.startChat,
-					buttonLabel: this.translate( 'Chat with us' ),
+					buttonLabel: translate( 'Chat with us' ),
 					showSubjectField: false,
 					showHowCanWeHelpField: true,
 					showHowYouFeelField: true,
@@ -468,7 +470,7 @@ const HelpContact = React.createClass( {
 			case SUPPORT_TICKET:
 				return {
 					onSubmit: this.submitKayakoTicket,
-					buttonLabel: isSubmitting ? this.translate( 'Sending email' ) : this.translate( 'Email us' ),
+					buttonLabel: isSubmitting ? translate( 'Sending email' ) : translate( 'Email us' ),
 					showSubjectField: true,
 					showHowCanWeHelpField: true,
 					showHowYouFeelField: true,
@@ -479,8 +481,8 @@ const HelpContact = React.createClass( {
 			default:
 				return {
 					onSubmit: this.submitSupportForumsTopic,
-					buttonLabel: isSubmitting ? this.translate( 'Asking in the forums' ) : this.translate( 'Ask in the forums' ),
-					formDescription: this.translate(
+					buttonLabel: isSubmitting ? translate( 'Asking in the forums' ) : translate( 'Ask in the forums' ),
+					formDescription: translate(
 						'Post a new question in our {{strong}}public forums{{/strong}}, ' +
 						'where it may be answered by helpful community members, ' +
 						'by submitting the form below. ' +
@@ -575,7 +577,7 @@ const HelpContact = React.createClass( {
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) &&
 					<Notice
 						status="is-warning"
-						text={ this.translate( 'We had trouble loading the support information for your account. ' +
+						text={ this.props.translate( 'We had trouble loading the support information for your account. ' +
 							'Please check your internet connection and reload the page, or try again later.' ) }
 						showDismiss={ false }
 					/>
@@ -588,7 +590,7 @@ const HelpContact = React.createClass( {
 	render: function() {
 		return (
 			<Main className="help-contact">
-				<HeaderCake onClick={ this.backToHelp } isCompact={ true }>{ this.translate( 'Contact Us' ) }</HeaderCake>
+				<HeaderCake onClick={ this.backToHelp } isCompact={ true }>{ this.props.translate( 'Contact Us' ) }</HeaderCake>
 				{ ! this.props.isEmailVerified && <HelpUnverifiedWarning /> }
 				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
 					{ this.getView() }
@@ -612,4 +614,4 @@ export default connect(
 		};
 	},
 	{ connectHappychat, openHappychat, sendHappychatMessage }
-)( HelpContact );
+)( localize( HelpContact ) );

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -477,7 +477,6 @@ const HelpContact = React.createClass( {
 					showSiteField: moreThanOneSite,
 				};
 
-			case SUPPORT_FORUM:
 			default:
 				return {
 					onSubmit: this.submitSupportForumsTopic,

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -509,8 +509,9 @@ const HelpContact = React.createClass( {
 			<div>
 				{ shouldShowTicketRequestErrorNotice &&
 					<Notice
-						status='is-error'
-						text={ this.translate( 'An error occurred while requesting for email support settings. Please try again later.' ) }
+						status='is-warning'
+						text={ this.translate( 'We had trouble loading the support information for your account. ' +
+							'Please check your internet connection and reload the page, or try again later.' ) }
 						showDismiss={ false }
 					/>
 				}

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -514,7 +514,7 @@ const HelpContact = React.createClass( {
 	shouldShowTicketRequestErrorNotice: function( variationSlug ) {
 		const { ticketSupportRequestError } = this.props;
 
-		return SUPPORT_HAPPYCHAT !== variationSlug && SUPPORT_LIVECHAT !== variationSlug && null !== ticketSupportRequestError;
+		return SUPPORT_HAPPYCHAT !== variationSlug && SUPPORT_LIVECHAT !== variationSlug && null != ticketSupportRequestError;
 	},
 
 	shouldShowPreloadForm: function() {
@@ -522,7 +522,7 @@ const HelpContact = React.createClass( {
 		const { ticketSupportConfigurationReady, ticketSupportRequestError } = this.props;
 
 		const olarkReadyOrTimedOut = olark.isOlarkReady && ! this.props.olarkTimedOut;
-		const ticketReadyOrError = ticketSupportConfigurationReady || null !== ticketSupportRequestError;
+		const ticketReadyOrError = ticketSupportConfigurationReady || null != ticketSupportRequestError;
 
 		return ! sitesInitialized || ! ticketReadyOrError || ! olarkReadyOrTimedOut;
 	},

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -423,7 +423,7 @@ const HelpContact = React.createClass( {
 
 	getSupportVariation: function() {
 		const { olark } = this.state;
-		const { isTicketSupportEligible } = this.props;
+		const { ticketSupportEligible } = this.props;
 
 		if ( this.shouldUseHappychat() ) {
 			return SUPPORT_HAPPYCHAT;
@@ -433,7 +433,7 @@ const HelpContact = React.createClass( {
 			return SUPPORT_LIVECHAT;
 		}
 
-		if ( olark.details.isConversing || isTicketSupportEligible ) {
+		if ( olark.details.isConversing || ticketSupportEligible ) {
 			return SUPPORT_TICKET;
 		}
 
@@ -519,10 +519,10 @@ const HelpContact = React.createClass( {
 
 	shouldShowPreloadForm: function() {
 		const { olark, sitesInitialized } = this.state;
-		const { isTicketSupportConfigurationReady, ticketSupportRequestError } = this.props;
+		const { ticketSupportConfigurationReady, ticketSupportRequestError } = this.props;
 
 		const olarkReadyOrTimedOut = olark.isOlarkReady && ! this.props.olarkTimedOut;
-		const ticketReadyOrError = isTicketSupportConfigurationReady || null !== ticketSupportRequestError;
+		const ticketReadyOrError = ticketSupportConfigurationReady || null !== ticketSupportRequestError;
 
 		return ! sitesInitialized || ! ticketReadyOrError || ! olarkReadyOrTimedOut;
 	},
@@ -607,8 +607,8 @@ export default connect(
 			olarkTimedOut: isOlarkTimedOut( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			isHappychatAvailable: isHappychatAvailable( state ),
-			isTicketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
-			isTicketSupportEligible: isTicketSupportEligible( state ),
+			ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
+			ticketSupportEligible: isTicketSupportEligible( state ),
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 		};
 	},

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -443,7 +443,7 @@ const HelpContact = React.createClass( {
 	getContactFormPropsVariation: function( variationSlug ) {
 		const { isSubmitting } = this.state;
 		const { translate } = this.props;
-		const moreThanOneSite = sites.get().length > 1;
+		const hasMoreThanOneSite = sites.get().length > 1;
 
 		switch ( variationSlug ) {
 			case SUPPORT_HAPPYCHAT:
@@ -454,7 +454,7 @@ const HelpContact = React.createClass( {
 					showSubjectField: false,
 					showHowCanWeHelpField: true,
 					showHowYouFeelField: true,
-					showSiteField: moreThanOneSite,
+					showSiteField: hasMoreThanOneSite,
 				};
 
 			case SUPPORT_LIVECHAT:
@@ -464,7 +464,7 @@ const HelpContact = React.createClass( {
 					showSubjectField: false,
 					showHowCanWeHelpField: true,
 					showHowYouFeelField: true,
-					showSiteField: moreThanOneSite,
+					showSiteField: hasMoreThanOneSite,
 				};
 
 			case SUPPORT_TICKET:
@@ -474,7 +474,7 @@ const HelpContact = React.createClass( {
 					showSubjectField: true,
 					showHowCanWeHelpField: true,
 					showHowYouFeelField: true,
-					showSiteField: moreThanOneSite,
+					showSiteField: hasMoreThanOneSite,
 				};
 
 			default:

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -28,7 +28,7 @@ import i18n from 'lib/i18n-utils';
 import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { isHappychatAvailable } from 'state/happychat/selectors';
-import { isTicketSupportEligible, isTicketSupportConfigurationReady } from 'state/help/ticket/selectors';
+import { isTicketSupportEligible, isTicketSupportConfigurationReady, getTicketSupportRequestError } from 'state/help/ticket/selectors';
 import QueryOlark from 'components/data/query-olark';
 import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';
@@ -526,6 +526,7 @@ export default connect(
 			isHappychatAvailable: isHappychatAvailable( state ),
 			isTicketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
 			isTicketSupportEligible: isTicketSupportEligible( state ),
+			ticketSupportRequestError: getTicketSupportRequestError( state ),
 		};
 	},
 	{ connectHappychat, openHappychat, sendHappychatMessage }


### PR DESCRIPTION
## Summary
As we are separating eligibility from the chat support and the ticket support, this PR rearranges the conditional flows that leads to the final support option in `/help/contact`.

This PR is based on #9499 and needs the new endpoint, `/help/tickets/kayako/mine`, to be available.

## Test Plan
### Test for the support eligibilities
1. Logging in as a user with plan subscriptions, `/help/contact` should show you chat support as long as there are operators available.
1. Logging in as a user with plan subscriptions, `/help/contact` should show you email support if there is no operator available.
1. Logging in as a user with a la carte upgrades, `/help/contact` should show you email support no matter there are operators available or not.
1. Logging in as a user with access to business sites but doesn't have any upgrades by itself, `/help/contact` should show you chat support as long as there are operators available.
1. Logging in as a user with only free plan, `/help/contact` should show you forum support.

### Test for the error notice
Unfortunately there doesn't seem to be an easy way to fail the request other than ruining it by code. e.g. Change the `Undocumented.prototype.getKayakoConfiguration` to access an endpoint that doesn't exist.

1. Logging in as a chat support eligible user, and you shouldn't see the error notice even if there is an error.
1. Logging in as a email support eligible user, and you should see the error notice like below:
![2016-12-05 2 55 00](https://cloud.githubusercontent.com/assets/1842898/20876141/d660db72-bafa-11e6-8823-80b47914b764.png)
* image updated after f86599d3d5cdba9d7991c771770deab77f7a4475
