### PR TITLE
Taxonomies: Fix phantom categories showing up when editing/deleting categories

### DIFF
--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -71,7 +71,7 @@ export class TaxonomyManagerList extends Component {
 
 	componentWillReceiveProps( newProps ) {
 		if ( newProps.terms !== this.props.terms ) {
-			this.termIds = map( this.props.terms, 'ID' );
+			this.termIds = map( newProps.terms, 'ID' );
 		}
 	}
 


### PR DESCRIPTION
We were using the old props to update the termIds, so the terms were not showing up correctly

closes #9554 and #9509

**testing instructions**

Follow instructions on either #9509 or #9554 

cc @timmyc @hoverduck @unDemian 