### PR TITLE
Framework: Use webpack extension resolver order instead of package.jsons

### DIFF
--- a/client/controller/package.json
+++ b/client/controller/package.json
@@ -1,4 +1,0 @@
-{
-	"main": "index.node.js",
-	"browser": "index.web.js"
-}

--- a/client/my-sites/theme/package.json
+++ b/client/my-sites/theme/package.json
@@ -1,4 +1,0 @@
-{
-	"main": "index.node.js",
-	"browser": "index.web.js"
-}

--- a/client/my-sites/themes/package.json
+++ b/client/my-sites/themes/package.json
@@ -1,4 +1,0 @@
-{
-	"main": "index.node.js",
-	"browser": "index.web.js"
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,7 @@ const webpackConfig = {
 		]
 	},
 	resolve: {
-		extensions: [ '', '.json', '.js', '.jsx' ],
+		extensions: [ '', '.json', '.web.js', '.web.jsx', '.js', '.jsx' ],
 		root: [ path.join( __dirname, 'client' ) ],
 		modulesDirectories: [ 'node_modules' ],
 		alias: {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -83,7 +83,7 @@ var webpackConfig = {
 		]
 	},
 	resolve: {
-		extensions: [ '', '.json', '.js', '.jsx' ],
+		extensions: [ '', '.json', '.node.js', '.node.jsx', '.js', '.jsx' ],
 		root: [ path.join( __dirname, 'server' ), path.join( __dirname, 'client' ), __dirname ],
 		modulesDirectories: [ 'node_modules' ]
 	},


### PR DESCRIPTION
Where we want to change the main entry point for a module, let's not use
package.json to do this.