### PR TITLE
Domains: Hide Edit site address in domains view for .blog subdomains

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/wpcom-domain.jsx
@@ -20,6 +20,26 @@ const WpcomDomain = React.createClass( {
 		this.recordEvent( 'navigationClick', 'Edit Site Address', this.props.domain );
 	},
 
+	getEditSiteAddressBlock() {
+		/**
+		 * Hide Edit site address for .blog subdomains as this is unsupported for now.
+		 */
+		if ( this.props.domain.name.match( /\.\w+\.blog$/ ) ) {
+			return null;
+		}
+
+		return (
+			<VerticalNav>
+				<VerticalNavItem
+					path={ `https://${ this.props.domain.name }/wp-admin/index.php?page=my-blogs#blog_row_${ this.props.selectedSite.ID }` }
+					external={ true }
+					onClick={ this.handleEditSiteAddressClick }>
+					{ this.translate( 'Edit Site Address' ) }
+				</VerticalNavItem>
+			</VerticalNav>
+		);
+	},
+
 	render() {
 		return (
 			<div>
@@ -36,15 +56,7 @@ const WpcomDomain = React.createClass( {
 						</Property>
 					</Card>
 				</div>
-
-				<VerticalNav>
-					<VerticalNavItem
-						path={ `https://${ this.props.domain.name }/wp-admin/index.php?page=my-blogs#blog_row_${ this.props.selectedSite.ID }` }
-						external={ true }
-						onClick={ this.handleEditSiteAddressClick }>
-						{ this.translate( 'Edit Site Address' ) }
-					</VerticalNavItem>
-				</VerticalNav>
+				{ this.getEditSiteAddressBlock() }
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR hides the `Edit site address` option in the domain management screen as this functionality is not yet supported for .blog subdomains.

To test:

1. Checkout branch or use Calypso.live link
2. Register a .blog subdomain name
3. Go to Domains
4. Choose the .blog subdomain
5. Verify there is no option for editing the site address.

Before:
![screen shot 2016-11-22 at 14 43 34](https://cloud.githubusercontent.com/assets/184938/20524380/fe02f6c0-b0c2-11e6-9a2c-9687addd4ec8.png)

After:
![screen shot 2016-11-22 at 14 42 45](https://cloud.githubusercontent.com/assets/184938/20524382/02a098cc-b0c3-11e6-998e-a8d2eb93f2b7.png)

cc @michaeldcain @coreh 