### PR TITLE
Olark: Send chat context to operator

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -23,6 +23,7 @@ import { removePurchase } from 'state/purchases/actions';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import userFactory from 'lib/user';
 import { isOperatorsAvailable, isChatAvailable } from 'state/ui/olark/selectors';
+import olarkApi from 'lib/olark-api';
 import olarkActions from 'lib/olark-store/actions';
 import olarkEvents from 'lib/olark-events';
 import analytics from 'lib/analytics';
@@ -59,15 +60,18 @@ const RemovePurchase = React.createClass( {
 	},
 
 	componentWillMount() {
-		olarkEvents.on( 'api.chat.onBeginConversation', this.recordChatStartedEvent );
+		olarkEvents.on( 'api.chat.onBeginConversation', this.chatStarted );
 	},
 
 	componentWillUnmount() {
-		olarkEvents.off( 'api.chat.onBeginConversation', this.recordChatStartedEvent );
+		olarkEvents.off( 'api.chat.onBeginConversation', this.chatStarted );
 	},
 
-	recordChatStartedEvent: () => {
+	chatStarted: () => {
 		this.recordChatEvent( 'calypso_precancellation_chat_begin' );
+		olarkApi( 'api.chat.sendNotificationToOperator', {
+			body: 'Context: Precancellation'
+		} );
 	},
 
 	recordChatEvent( eventAction ) {


### PR DESCRIPTION
This pull request sends the chat context to the olark operator letting them know that the chat is coming from the purchase removal survey.

### How to test
1. Navigate to http://calypso.localhost:3000/me/purchases/
2. Select a product to cancel
3. Click the "Remove WordPress.com Business" (or whatever the product is)
4. If operators are available you should see the chat with us link
5. Click the chat with us link
6. Notice that the olark chatbox appears in the lower right corner and the text area has focus
7. Start a chat
8. In olark you'll notice that there is a new operator notice appearing on the chat that says "Context: Precancellation"

### What to expect

![screen shot 2016-11-22 at 10 03 34 am](https://cloud.githubusercontent.com/assets/1854440/20528732/55561cc2-b09b-11e6-877c-0f55201e864e.png)
