### PR TITLE
Themes: Add upload page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -336,6 +336,7 @@
 @import 'my-sites/themes/style';
 @import 'my-sites/themes/themes-search-card/style';
 @import 'my-sites/themes/themes-magic-search-card/style';
+@import 'my-sites/themes/theme-upload/style';
 @import 'my-sites/upgrade-nudge/style';
 @import 'my-sites/upgrades/cart/style';
 @import 'my-sites/upgrades/checkout/stored-card';

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -12,6 +12,7 @@ import React from 'react';
 import SingleSiteComponent from 'my-sites/themes/single-site';
 import MultiSiteComponent from 'my-sites/themes/multi-site';
 import LoggedOutComponent from './logged-out';
+import Upload from 'my-sites/themes/theme-upload';
 import trackScrollPage from 'lib/track-scroll-page';
 import { PER_PAGE } from 'state/themes/themes-list/constants';
 import {
@@ -54,6 +55,11 @@ function getProps( context ) {
 		search: context.query.s,
 		trackScrollPage: boundTrackScrollPage
 	};
+}
+
+export function upload( context, next ) {
+	context.primary = <Upload />;
+	next();
 }
 
 export function singleSite( context, next ) {

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -18,10 +18,12 @@ export default function( router ) {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?$`, fetchThemeDataWithCaching, loggedOut, makeLayout );
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeData, loggedOut, makeLayout );
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, fetchThemeData, loggedOut, makeLayout );
+			router( '/design/upload/*', makeLayout );
 			router( '/design/*', fetchThemeData, loggedOut, makeLayout ); // Needed so direct hits don't result in a 404.
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );
+			router( '/design/upload/*', makeLayout );
 			router( '/design/*', makeLayout ); // Needed so direct hits don't result in a 404.
 		}
 	}

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
 import config from 'config';

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -1,11 +1,15 @@
 /**
+ * External dependencies
+ */
+
+/**
  * Internal dependencies
  */
 import config from 'config';
 import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
 import { makeNavigation, siteSelection } from 'my-sites/controller';
-import { singleSite, multiSite, loggedOut } from './controller';
+import { singleSite, multiSite, loggedOut, upload } from './controller';
 import { getSubjects } from './theme-filters';
 import validateFilters from './validate-filters';
 
@@ -32,6 +36,11 @@ export default function( router ) {
 				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id`,
 				validateFilters, siteSelection, singleSite, makeNavigation, makeLayout
 			);
+			router(
+				'/design/upload/:site_id',
+				siteSelection, upload, makeNavigation, makeLayout
+			);
+			// TODO (seear): make `sites` middleware work for single-tree to allow /design/upload
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );
 			router(

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -32,11 +32,13 @@ export default function( router ) {
 				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id`,
 				validateFilters, siteSelection, singleSite, makeNavigation, makeLayout
 			);
-			router(
-				'/design/upload/:site_id',
-				siteSelection, upload, makeNavigation, makeLayout
-			);
-			// TODO (seear): make `sites` middleware work for single-tree to allow /design/upload
+			if ( config.isEnabled( 'manage/themes/upload' ) ) {
+				router(
+					'/design/upload/:site_id',
+					siteSelection, upload, makeNavigation, makeLayout
+				);
+				// TODO (seear): make `sites` middleware work for single-tree to allow /design/upload
+			}
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );
 			router(

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -29,23 +29,21 @@ function upload( { translate } ) {
 	const uploadInstructionsText = translate(
 		"Make sure it's a single zip file, and upload it here."
 	);
+	const dropText = translate(
+		'Drop files or click here to upload'
+	);
 
 	return (
 		<div>
-			<HeaderCake onClick={ page.back }>
-				{ translate( 'Upload theme' ) }
-			</HeaderCake>
+			<HeaderCake onClick={ page.back }>{ translate( 'Upload theme' ) }</HeaderCake>
 			<Card>
 				<span className="theme-upload__prompt">{ uploadPromptText }</span>
 				<span className="theme-upload__instructions">{ uploadInstructionsText }</span>
 				<div className="theme-upload__dropzone">
 					<DropZone onFilesDrop={ onFileSelect } />
-					<FilePicker accept="application/zip"
-								onPick={ onFileSelect } >
+					<FilePicker accept="application/zip" onPick={ onFileSelect } >
 						<Gridicon className="theme-upload__dropzone-icon" icon="cloud-upload" size={ 48 } />
-						<span className="theme-upload__dropzone-text">
-							{ translate( 'Drop files or click here to upload' ) }
-						</span>
+						<span className="theme-upload__dropzone-text">{ dropText }</span>
 					</FilePicker>
 				</div>
 			</Card>

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -21,10 +21,6 @@ const debug = debugFactory( 'calypso:themes:theme-upload' );
 
 class Upload extends React.Component {
 
-	constructor( props ) {
-		super( props );
-	}
-
 	onFileSelect = ( files ) => {
 		const { translate } = this.props;
 		const errorMessage = translate( 'Please drop a single zip file' );
@@ -33,6 +29,7 @@ class Upload extends React.Component {
 			notices.error( errorMessage );
 			return;
 		}
+		// Supplied param can be an array or a FileList
 		const file = files[ 0 ] || files.item( 0 );
 		if ( file.type !== 'application/zip' ) {
 			notices.error( errorMessage );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -42,8 +42,11 @@ function upload( { translate } ) {
 				<div className="theme-upload__dropzone">
 					<DropZone onFilesDrop={ onFileSelect } />
 					<FilePicker accept="application/zip" onPick={ onFileSelect } >
-						<Gridicon className="theme-upload__dropzone-icon" icon="cloud-upload" size={ 48 } />
-						<span className="theme-upload__dropzone-text">{ dropText }</span>
+						<Gridicon
+							className="theme-upload__dropzone-icon"
+							icon="cloud-upload"
+							size={ 48 } />
+						{ dropText }
 					</FilePicker>
 				</div>
 			</Card>

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'components/header-cake';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import FilePicker from 'components/file-picker';
+import { localize } from 'i18n-calypso';
+
+const onPick = function() {
+};
+
+function upload( { translate } ) {
+	const uploadPromptText = translate(
+		'Do you have a custom theme to upload to your site?'
+	);
+	const uploadInstructionsText = translate(
+		"Make sure it's a single zip file, and upload it here."
+	);
+
+	return (
+		<div>
+			<HeaderCake onClick={ page.back }>
+				{ translate( 'Upload theme' ) }
+			</HeaderCake>
+			<Card>
+				<span className="theme-upload__prompt">{ uploadPromptText }</span>
+				<span className="theme-upload__instructions">{ uploadInstructionsText }</span>
+				<div className="theme-upload__dropzone">
+					<FilePicker accept="application/zip"
+								onPick={ onPick } >
+						<Gridicon className="theme-upload__dropzone-icon" icon="cloud-upload" size={ 48 } />
+						<span className="theme-upload__dropzone-text">
+							{ translate( 'Drop files or click here to upload' ) }
+						</span>
+					</FilePicker>
+				</div>
+			</Card>
+		</div>
+	);
+}
+
+export default localize( upload );
+

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -13,56 +13,66 @@ import Gridicon from 'components/gridicon';
 import FilePicker from 'components/file-picker';
 import DropZone from 'components/drop-zone';
 import { localize } from 'i18n-calypso';
+import notices from 'notices';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
-const onFileSelect = function( files ) {
-	// files can be FileList object or array
-	debug( 'Chosen files:', files );
-	if ( files.length !== 1 ) {
-		debug( 'multiple files not allowed' );
-		return;
-	}
-	const file = files[ 0 ] || files.item( 0 );
-	if ( file.type !== 'application/zip' ) {
-		debug( 'file must be a zip' );
-		return;
-	}
-	debug( 'zip file:', file );
-};
+class Upload extends React.Component {
 
-function upload( { translate } ) {
-	const uploadPromptText = translate(
-		'Do you have a custom theme to upload to your site?'
-	);
-	const uploadInstructionsText = translate(
-		"Make sure it's a single zip file, and upload it here."
-	);
-	const dropText = translate(
-		'Drop files or click here to upload'
-	);
+	constructor( props ) {
+		super( props );
+	}
 
-	return (
-		<div>
-			<HeaderCake onClick={ page.back }>{ translate( 'Upload theme' ) }</HeaderCake>
-			<Card>
-				<span className="theme-upload__prompt">{ uploadPromptText }</span>
-				<span className="theme-upload__instructions">{ uploadInstructionsText }</span>
-				<div className="theme-upload__dropzone">
-					<DropZone onFilesDrop={ onFileSelect } />
-					<FilePicker accept="application/zip" onPick={ onFileSelect } >
-						<Gridicon
-							className="theme-upload__dropzone-icon"
-							icon="cloud-upload"
-							size={ 48 } />
-						{ dropText }
-					</FilePicker>
-				</div>
-			</Card>
-		</div>
-	);
+	onFileSelect = ( files ) => {
+		const { translate } = this.props;
+		const errorMessage = translate( 'Please drop a single zip file' );
+
+		if ( files.length !== 1 ) {
+			notices.error( errorMessage );
+			return;
+		}
+		const file = files[ 0 ] || files.item( 0 );
+		if ( file.type !== 'application/zip' ) {
+			notices.error( errorMessage );
+			return;
+		}
+		debug( 'zip file:', file );
+	}
+
+	render() {
+		const { translate } = this.props;
+		const uploadPromptText = translate(
+			'Do you have a custom theme to upload to your site?'
+		);
+		const uploadInstructionsText = translate(
+			"Make sure it's a single zip file, and upload it here."
+		);
+		const dropText = translate(
+			'Drop files or click here to upload'
+		);
+
+		return (
+			<div>
+				<HeaderCake onClick={ page.back }>{ translate( 'Upload theme' ) }</HeaderCake>
+				<Card>
+					<span className="theme-upload__prompt">{ uploadPromptText }</span>
+					<span className="theme-upload__instructions">{ uploadInstructionsText }</span>
+					<div className="theme-upload__dropzone">
+						<DropZone onFilesDrop={ this.onFileSelect } />
+						<FilePicker accept="application/zip" onPick={ this.onFileSelect } >
+							<Gridicon
+								className="theme-upload__dropzone-icon"
+								icon="cloud-upload"
+								size={ 48 } />
+							{ dropText }
+						</FilePicker>
+					</div>
+				</Card>
+			</div>
+		);
+	}
 }
 
-export default localize( upload );
+export default localize( Upload );
 

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -20,6 +20,16 @@ const debug = debugFactory( 'calypso:themes:theme-upload' );
 const onFileSelect = function( files ) {
 	// files can be FileList object or array
 	debug( 'Chosen files:', files );
+	if ( files.length !== 1 ) {
+		debug( 'multiple files not allowed' );
+		return;
+	}
+	const file = files[ 0 ] || files.item( 0 );
+	if ( file.type !== 'application/zip' ) {
+		debug( 'file must be a zip' );
+		return;
+	}
+	debug( 'zip file:', file );
 };
 
 function upload( { translate } ) {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -11,9 +11,15 @@ import HeaderCake from 'components/header-cake';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import FilePicker from 'components/file-picker';
+import DropZone from 'components/drop-zone';
 import { localize } from 'i18n-calypso';
+import debugFactory from 'debug';
 
-const onPick = function() {
+const debug = debugFactory( 'calypso:themes:theme-upload' );
+
+const onFileSelect = function( files ) {
+	// files can be FileList object or array
+	debug( 'Chosen files:', files );
 };
 
 function upload( { translate } ) {
@@ -33,8 +39,9 @@ function upload( { translate } ) {
 				<span className="theme-upload__prompt">{ uploadPromptText }</span>
 				<span className="theme-upload__instructions">{ uploadInstructionsText }</span>
 				<div className="theme-upload__dropzone">
+					<DropZone onFilesDrop={ onFileSelect } />
 					<FilePicker accept="application/zip"
-								onPick={ onPick } >
+								onPick={ onFileSelect } >
 						<Gridicon className="theme-upload__dropzone-icon" icon="cloud-upload" size={ 48 } />
 						<span className="theme-upload__dropzone-text">
 							{ translate( 'Drop files or click here to upload' ) }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
@@ -53,7 +54,7 @@ class Upload extends React.Component {
 		);
 
 		return (
-			<div>
+			<Main>
 				<HeaderCake onClick={ page.back }>{ translate( 'Upload theme' ) }</HeaderCake>
 				<Card>
 					<span className="theme-upload__prompt">{ uploadPromptText }</span>
@@ -69,7 +70,7 @@ class Upload extends React.Component {
 						</FilePicker>
 					</div>
 				</Card>
-			</div>
+			</Main>
 		);
 	}
 }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -29,7 +29,8 @@ class Upload extends React.Component {
 			notices.error( errorMessage );
 			return;
 		}
-		// Supplied param can be an array or a FileList
+
+		// DropZone supplies an array, FilePicker supplies a FileList
 		const file = files[ 0 ] || files.item( 0 );
 		if ( file.type !== 'application/zip' ) {
 			notices.error( errorMessage );

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -1,0 +1,29 @@
+.theme-upload__prompt {
+	display: block;
+	color: darken( $gray, 20 );
+}
+
+.theme-upload__instructions {
+	display: block;
+	font-style: italic;
+}
+
+.theme-upload__dropzone {
+	background-color: $gray-light;
+	border: 2px dashed $gray;
+	margin: 20px 0;
+
+	.file-picker {
+		color: darken( $gray, 20 );
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		height: 180px;
+	}
+}
+
+.theme-upload__dropzone-icon {
+	color: $gray;
+}
+

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -9,6 +9,7 @@
 }
 
 .theme-upload__dropzone {
+	position: relative;
 	background-color: $gray-light;
 	border: 2px dashed $gray;
 	margin: 20px 0;

--- a/config/development.json
+++ b/config/development.json
@@ -100,6 +100,7 @@
 		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
 		"manage/themes/magic-search": true,
+		"manage/themes/upload": true,
 		"me/account": true,
 		"me/edit-gravatar": false,
 		"me/find-friends": false,

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -103,6 +103,7 @@ var webpackConfig = {
 		new webpack.NormalModuleReplacementPlugin( /^components\/popover$/, 'components/empty-component' ), // Depends on BOM and interactions don't work without JS
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/theme-upload$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/single-site$/, 'components/empty-component' ), // Depends on DOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/multi-site$/, 'components/empty-component' ), // Depends on DOM
 		new webpack.NormalModuleReplacementPlugin( /^state\/ui\/editor\/selectors$/, 'lodash/noop' ), // will never be called server-side


### PR DESCRIPTION
<img width="1277" alt="screen shot 2016-11-22 at 15 29 58" src="https://cloud.githubusercontent.com/assets/7767559/20529676/ecf43cf8-b0c8-11e6-9f5f-8dbbb126b1b5.png">


**To Test**
* Go to http://calypso.localhost:3000/design/upload/sseearrotation.com
* in the browser console, type `localStorage.setItem('debug', 'calypso:themes:theme-upload' )`
* Test selecting files by clicking on the dropzone
* Test selecting files by dragging into the dropzone
* Anything other than a single zip file should show an error notice
*  A successful file selection should show a message in the console:
```
calypso:themes:theme-upload zip file: +0ms File {name: "canape-wpcom-1-0-3 (1) (1) (1).zip", lastModified: 1479833199000, lastModifiedDate: Tue Nov 22 2016 16:46:39 GMT+0000 (GMT), webkitRelativePath: "", size: 928342…}
```


