### PR TITLE
Domains: Update/signup domains analytics for .blog subdomains

### DIFF
--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -28,7 +28,6 @@ const getDomainTypeTextFromSearch = function( suggestion ) {
 		}
 		return 'wpcom_subdomain';
 	}
-
 	return 'domain_reg';
 };
 

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -3,7 +3,7 @@
  */
 import analytics from 'lib/analytics';
 import { type as domainTypes } from 'lib/domains/constants';
-import snakeCase from 'lodash/snakeCase';
+import { snakeCase, endsWith } from 'lodash';
 
 const getDomainTypeText = function( domain ) {
 	switch ( domain.type ) {
@@ -19,6 +19,19 @@ const getDomainTypeText = function( domain ) {
 		case domainTypes.WPCOM:
 			return 'Wpcom Domain';
 	}
+};
+
+/*
+ * TODO: Finish :)
+ * - WordPress.com subdomains have already been stripped of TLD.
+ * - Might need to account for mapped domains.
+ */
+const getDomainTypeTextFromSearch = function( suggestion ) {
+	if ( suggestion.is_free && endsWith( suggestion.domain_name, '.blog' ) ) {
+		return 'DotBlog Subdomain';
+	}
+
+	return '';
 };
 
 const EVENTS = {
@@ -135,6 +148,23 @@ const EVENTS = {
 					section
 				}
 			);
+		},
+
+		submitDomainStepSelection( suggestion, section ) {
+			const domainType = getDomainTypeTextFromSearch( suggestion );
+
+			analytics.ga.recordEvent(
+				'Domain Search',
+				`Submitted Domain Selection for a ${ domainType } on a Domain Registration`,
+				'Domain Name',
+				suggestion.domain_name
+			);
+
+			analytics.tracks.recordEvent( 'calypso_domain_search_submit_step', {
+				domain_name: suggestion.domain_name,
+				section,
+				type: domainType
+			} );
 		}
 	},
 

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -21,17 +21,16 @@ const getDomainTypeText = function( domain ) {
 	}
 };
 
-/*
- * TODO: Finish :)
- * - WordPress.com subdomains have already been stripped of TLD.
- * - Might need to account for mapped domains.
- */
 const getDomainTypeTextFromSearch = function( suggestion ) {
-	if ( suggestion.is_free && endsWith( suggestion.domain_name, '.blog' ) ) {
-		return 'DotBlog Subdomain';
+	if ( suggestion.is_free ) {
+		if ( endsWith( suggestion.domain_name, '.blog' ) ) {
+			return 'dotblog_subdomain';
+		}
+		return 'wpcom_subdomain';
 	}
-
-	return '';
+	else {
+		return 'domain_reg';
+	}
 };
 
 const EVENTS = {
@@ -152,7 +151,6 @@ const EVENTS = {
 
 		submitDomainStepSelection( suggestion, section ) {
 			const domainType = getDomainTypeTextFromSearch( suggestion );
-
 			analytics.ga.recordEvent(
 				'Domain Search',
 				`Submitted Domain Selection for a ${ domainType } on a Domain Registration`,

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -28,9 +28,8 @@ const getDomainTypeTextFromSearch = function( suggestion ) {
 		}
 		return 'wpcom_subdomain';
 	}
-	else {
-		return 'domain_reg';
-	}
+
+	return 'domain_reg';
 };
 
 const EVENTS = {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -24,12 +24,6 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	signupUtils = require( 'signup/utils' ),
 	abtest = require( 'lib/abtest' ).abtest;
 
-/**
- * Debug
- */
-import debugModule from 'debug';
-const debug = debugModule( 'calypso:signup' );
-
 import Notice from 'components/notice';
 
 const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
@@ -130,8 +124,6 @@ const DomainsStep = React.createClass( {
 					productSlug: suggestion.product_slug
 				} )
 				: undefined;
-
-		debug( 'Suggestion', suggestion );
 
 		registerDomainAnalytics.recordEvent( 'submitDomainStepSelection', suggestion, 'signup' );
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -24,6 +24,12 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	signupUtils = require( 'signup/utils' ),
 	abtest = require( 'lib/abtest' ).abtest;
 
+/**
+ * Debug
+ */
+import debugModule from 'debug';
+const debug = debugModule( 'calypso:signup' );
+
 import Notice from 'components/notice';
 
 const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
@@ -124,6 +130,10 @@ const DomainsStep = React.createClass( {
 					productSlug: suggestion.product_slug
 				} )
 				: undefined;
+
+		debug( 'Suggestion', suggestion );
+
+		registerDomainAnalytics.recordEvent( 'submitDomainStepSelection', suggestion, 'signup' );
 
 		SignupActions.submitSignupStep( Object.assign( {
 			processingMessage: this.translate( 'Adding your domain' ),


### PR DESCRIPTION
This PR aims to improve analytics information about the chosen domain in the Domains Search step in Signup.

To test:

1. Checkout branch or use Calypso.live
2. Start Sigunp
3. Get into the .blog subdomains AB test
4. Reach the Domains step
5. Search for something
6. Select .blog subdomain
7. Verify that there is a tracking request for the event `calypso_domain_search_submit_step`
8. Do 6 and 7 for `.wordpress.com` and a normal domain.

cc @michaeldcain @coreh @meremagee 