### PR TITLE
Reader: Add byline to Feed Header

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -95,6 +95,7 @@ class FeedHeader extends Component {
 					{ this.state.siteish ? <Site site={ this.state.siteish } href={ this.state.siteish.URL } indicator={ false } /> : null }
 					<div className="reader-feed-header__details">
 						<span className="reader-feed-header__description">{ ( site && site.get( 'description' ) ) }</span>
+						<span className="reader-feed-header__byline">By First Last</span>
 					</div>
 				</Card>
 			</div>

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -61,7 +61,8 @@ class FeedHeader extends Component {
 			feed = this.props.feed,
 			headerImage = site && site.getIn( [ 'options', 'header_image' ] ),
 			headerColor = site && site.getIn( [ 'options', 'background_color' ] ),
-			followerCount = this.getFollowerCount( feed, site );
+			followerCount = this.getFollowerCount( feed, site ),
+			ownerDisplayName = site && site.get( 'owner_display_name' );
 
 		let headerImageUrl;
 
@@ -95,7 +96,17 @@ class FeedHeader extends Component {
 					{ this.state.siteish ? <Site site={ this.state.siteish } href={ this.state.siteish.URL } indicator={ false } /> : null }
 					<div className="reader-feed-header__details">
 						<span className="reader-feed-header__description">{ ( site && site.get( 'description' ) ) }</span>
-						<span className="reader-feed-header__byline">By First Last</span>
+						{ ownerDisplayName && <span className="reader-feed-header__byline">
+							{ this.props.translate(
+								'by %(author)s',
+								{
+									args: {
+										author: ownerDisplayName
+									}
+								}
+							)
+						}
+						</span> }
 					</div>
 				</Card>
 			</div>

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -62,7 +62,7 @@ class FeedHeader extends Component {
 			headerImage = site && site.getIn( [ 'options', 'header_image' ] ),
 			headerColor = site && site.getIn( [ 'options', 'background_color' ] ),
 			followerCount = this.getFollowerCount( feed, site ),
-			ownerDisplayName = site && site.get( 'owner_display_name' );
+			ownerDisplayName = site && site.getIn( [ 'owner', 'name' ] );
 
 		let headerImageUrl;
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -100,6 +100,10 @@
 	}
 }
 
+.reader-feed-header .reader-feed-header__byline {
+	display: block;
+}
+
 .reader-feed-header .card {
 	background: none;
 	box-shadow: none;


### PR DESCRIPTION
The new Feed Header needs to have a byline added to it:

![screenshot 2016-11-22 12 01 46](https://cloud.githubusercontent.com/assets/4924246/20539863/82baa01a-b0ab-11e6-9d45-16817af7bcee.png)

- Display Author's First Last name
- If there isn't one, fall back to username
- If there are multiple Authors, display primary owner
