### PR TITLE
Fix tests for Signup Flow Controller

### DIFF
--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -87,7 +87,7 @@ describe( 'flow-controller', function() {
 	describe( 'controlling a flow w/ dependencies', function() {
 		it( 'should call the apiRequestFunction callback with its dependencies', function( done ) {
 			signupFlowController = SignupFlowController( {
-				flowName: 'flow_with_async',
+				flowName: 'flow_with_dependencies',
 				onComplete: function( dependencies, destination ) {
 					assert.equal( destination, '/checkout/testsite.wordpress.com' );
 					done();

--- a/client/lib/signup/test/signup/config/flows.js
+++ b/client/lib/signup/test/signup/config/flows.js
@@ -6,13 +6,13 @@ var flows = {
 
 	flow_with_async: {
 		steps: [ 'userCreation', 'asyncStep' ],
-		destination: function( dependencies ) {
-			return '/checkout/' + dependencies.siteSlug;
-		}
 	},
 
 	flow_with_dependencies: {
-		steps: [ 'siteCreation', 'userCreation' ]
+		steps: [ 'siteCreation', 'userCreation' ],
+		destination: function( dependencies ) {
+			return '/checkout/' + dependencies.siteSlug;
+		}
 	},
 
 	invalid_flow_with_dependencies: {


### PR DESCRIPTION
While working on #9048, I uncovered that one of the test cases for `SignupFlowController` is using what I believe to be the incorrect `flow`.

I still haven't figured it out how the test is currently passing on `master`. There might be some bug on the `SignupFlowController` implementation that is making it pass (incorrectly). One of the changes on #9048 caused it to fail, which caught my attention, but it seems to be the expected behavior, since one of the steps of the flow is not being submitted.