### PR TITLE
Add a chat with us button to the purchase checkout page

### DIFF
--- a/client/components/olark-chat-button/index.jsx
+++ b/client/components/olark-chat-button/index.jsx
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { isOperatorsAvailable, isChatAvailable } from 'state/ui/olark/selectors';
+import olarkApi from 'lib/olark-api';
+import olarkActions from 'lib/olark-store/actions';
+import olarkEvents from 'lib/olark-events';
+import analytics from 'lib/analytics';
+
+class OlarkChatButton extends Component {
+	onChatBegin = () => {
+		const { chatContext } = this.props;
+		this.recordChatEvent( 'calypso_chat_button_chat_begin' );
+
+		olarkApi( 'api.chat.sendNotificationToOperator', {
+			body: `Context: ${ chatContext }`
+		} );
+	};
+
+	openChat = ( event ) => {
+		event.preventDefault();
+
+		olarkActions.expandBox();
+		olarkActions.focusBox();
+		this.recordChatEvent( 'calypso_chat_button_click' );
+	};
+
+	componentWillMount() {
+		olarkEvents.on( 'api.chat.onBeginConversation', this.onChatBegin );
+	}
+
+	componentWillUnmount() {
+		olarkEvents.off( 'api.chat.onBeginConversation', this.onChatBegin );
+	}
+
+	recordChatEvent( eventAction ) {
+		const { chatContext, tracksData } = this.props;
+		analytics.tracks.recordEvent( eventAction, {
+			...{ tracksData },
+			chat_context: chatContext,
+		} );
+	}
+
+	render() {
+		const { className, isAvailable, title, borderless } = this.props;
+		const classes = classnames( className, 'olark-chat-button', 'button', {
+			'is-borderless': !! borderless
+		} );
+
+		if ( ! isAvailable ) {
+			return null;
+		}
+
+		return (
+			<button className={ classes } onClick={ this.openChat }>
+				{ title }
+			</button>
+		);
+	}
+}
+
+OlarkChatButton.defaultProps = {
+	tracksData: {},
+};
+
+OlarkChatButton.propTypes = {
+	chatContext: PropTypes.string.isRequired,
+	onChatBegin: PropTypes.func,
+	tracksData: PropTypes.object,
+};
+
+export default connect( ( state, { chatContext } ) => ( {
+	isAvailable: isOperatorsAvailable( state ) && isChatAvailable( state, chatContext ),
+} ) )( OlarkChatButton );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -125,5 +125,14 @@ module.exports = {
 		defaultVariation: 'showPlansAfterAuth',
 		allowExistingUsers: true
 	},
-};
 
+	presaleChatButton: {
+		datestamp: '20161129',
+		variations: {
+			showChatButton: 80,
+			original: 20
+		},
+		defaultVariation: 'original',
+		allowAnyLocale: true,
+	},
+};

--- a/client/my-sites/upgrades/checkout/credits-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credits-payment-box.jsx
@@ -10,11 +10,13 @@ var PayButton = require( './pay-button' ),
 	PaymentBox = require( './payment-box' ),
 	TermsOfService = require( './terms-of-service' );
 
-import CartCoupon from 'my-sites/upgrades/cart/cart-coupon'
+import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
+import PaymentChatButton from './payment-chat-button';
+import config from 'config';
 
 var CreditsPaymentBox = React.createClass( {
 	content: function() {
-		var cart = this.props.cart;
+		const { cart, transactionStep } = this.props;
 
 		return (
 			<form onSubmit={ this.props.onSubmit }>
@@ -43,7 +45,14 @@ var CreditsPaymentBox = React.createClass( {
 				<div className="payment-box-actions">
 					<PayButton
 						cart={ this.props.cart }
-						transactionStep={ this.props.transactionStep } />
+						transactionStep={ transactionStep } />
+					{
+						config.isEnabled( 'upgrades/presale-chat' ) &&
+						<PaymentChatButton
+							paymentType="credits"
+							cart={ cart }
+							transactionStep={ transactionStep } />
+					}
 				</div>
 			</form>
 		);

--- a/client/my-sites/upgrades/checkout/credits-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credits-payment-box.jsx
@@ -10,6 +10,7 @@ var PayButton = require( './pay-button' ),
 	PaymentBox = require( './payment-box' ),
 	TermsOfService = require( './terms-of-service' );
 
+import { abtest } from 'lib/abtest';
 import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import config from 'config';
@@ -48,6 +49,7 @@ var CreditsPaymentBox = React.createClass( {
 						transactionStep={ transactionStep } />
 					{
 						config.isEnabled( 'upgrades/presale-chat' ) &&
+						abtest( 'presaleChatButton' ) === 'showChatButton' &&
 						<PaymentChatButton
 							paymentType="credits"
 							cart={ cart }

--- a/client/my-sites/upgrades/checkout/payment-chat-button.jsx
+++ b/client/my-sites/upgrades/checkout/payment-chat-button.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import OlarkChatButton from 'components/olark-chat-button';
+
+export default localize( ( { cart, translate, paymentType, transactionStep } ) => {
+	return (
+		<OlarkChatButton
+			borderless
+			className="checkout__payment-chat-button"
+			chatContext="presale"
+			tracksData={ {
+				payment_type: paymentType,
+				transaction_step: transactionStep,
+				product_slug: cart.products[ 0 ].product_slug,
+			} }
+			title={ translate( 'Need help? Chat with us' ) } />
+	);
+} );

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -818,6 +818,10 @@
 	}
 }
 
+.checkout__payment-chat-button {
+	float: right;
+}
+
 .checkout__domain-details-form-submit-button {
 	clear: both;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -151,6 +151,7 @@
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
+		"upgrades/presale-chat": true,
 		"vip": false,
 		"vip/backups": true,
 		"vip/billing": true,


### PR DESCRIPTION
This pull request adds a "Chat with us" button to the checkout screen so that we can offer users the chance to chat with a Happiness Engineer before making their purchase.

For now the button is only offered on the variation of the checkout page used for paying with credits and it sits behind the `upgrades/presale-chat` feature flag.

### How to test
1. Add credits enough credits to your account to make a purchase.
2. Navigate to http://calypso.localhost:3000/plans
3. From the browser console enter: `localStorage.setItem( 'ABTests', '{"presaleChatButton_20161129":"showChatButton"}' )`. This will allow us to bypass the abtest
4. Select an upgrade
5. Notice on the checkout screen you will see a new button on the bottom right labeled "Need help? Chat with us"
6. Click the chat with us button.
7. Within tracks notice that a ping has been made for `calypso_chat_button_click`
8. Start a chat.
9. Within olark notice that the user is tagged with "Context: presale"
10. Check tracks and notice that another ping has made for `calypso_chat_button_chat_begin`


### What to expect
![screen shot 2016-11-22 at 4 30 43 pm](https://cloud.githubusercontent.com/assets/1854440/20542758/0d53f95e-b0d1-11e6-9222-895489acf579.png)
