### PR TITLE
Sites: hide link to wp-admin to change visibility.

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -405,8 +405,8 @@ const SiteSelector = React.createClass( {
 					{ hiddenSitesCount > 0 && ! this.state.search &&
 						<span className="site-selector__hidden-sites-message">
 							{ this.translate(
-								'%(hiddenSitesCount)d more hidden site. {{a}}Change{{/a}}.{{br/}}Use search to access it.',
-								'%(hiddenSitesCount)d more hidden sites. {{a}}Change{{/a}}.{{br/}}Use search to access them.',
+								'%(hiddenSitesCount)d more hidden site.{{br/}}Use search to access it.',
+								'%(hiddenSitesCount)d more hidden sites.{{br/}}Use search to access them.',
 								{
 									count: hiddenSitesCount,
 									args: {
@@ -414,12 +414,6 @@ const SiteSelector = React.createClass( {
 									},
 									components: {
 										br: <br />,
-										a: <a
-											href="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=hidden"
-											className="site-selector__manage-hidden-sites"
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
 									}
 								}
 							) }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -95,14 +95,10 @@ function renderNoVisibleSites( context ) {
 				args: { hidden: hiddenSites }
 			} ),
 
-			line: i18n.translate( 'To manage it here, set it to visible.', 'To manage them here, set them to visible.', {
-				count: hiddenSites
-			} ),
+			line: i18n.translate( 'Use search to access them.' ),
 
-			action: i18n.translate( 'Change Visibility' ),
-			actionURL: '//dashboard.wordpress.com/wp-admin/index.php?page=my-blogs',
-			secondaryAction: i18n.translate( 'Create New Site' ),
-			secondaryActionURL: `${ signup_url }?ref=calypso-nosites`
+			action: i18n.translate( 'Create New Site' ),
+			actionURL: `${ signup_url }?ref=calypso-nosites`
 		} ),
 		document.getElementById( 'primary' ),
 		context.store


### PR DESCRIPTION
Fixes #8335

This removes a legacy wp-admin dashboard link. Calypso handles hidden sites now gracefully by allowing you to find them via search.

Before:
<img width="1392" alt="screen shot 2016-11-22 at 14 58 30" src="https://cloud.githubusercontent.com/assets/66797/20544013/4674588e-b0c5-11e6-99db-a3fc24e08230.png">

After:
<img width="1392" alt="screen shot 2016-11-22 at 14 59 35" src="https://cloud.githubusercontent.com/assets/66797/20544016/4939effc-b0c5-11e6-8ed0-06bfd06734d5.png">
