### PR TITLE
Reader: Limit Site Titles in Feed Header

### DIFF
--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -31,13 +31,27 @@
 		font-family: $serif;
 		font-size: 21px;
 		font-weight: 600;
-		overflow: inherit;
+		height: 90px;
+		overflow: hidden;
+		position: relative;
 		text-align: center;
 		white-space: normal;
 
 		&::after {
 			background: none;
-			content:'';
+			content: '';
+			height: 22px;
+			@include long-content-fade( $size: 15% );
+			top: calc( 100% - 32px );
+
+			@include breakpoint( ">660px" ) {
+				@include long-content-fade( $size: 10% );
+				top: 0;
+			}
+		}
+
+		@include breakpoint( ">660px" ) {
+			height: 30px;
 		}
 	}
 


### PR DESCRIPTION
- Limit to a single line in wider viewports.
- Limit to 3 lines on mobile.

**Before:**
![screenshot 2016-11-22 14 55 42](https://cloud.githubusercontent.com/assets/4924246/20545547/a8b8b798-b0c4-11e6-9107-25536459f881.png)

![screenshot 2016-11-22 14 55 49](https://cloud.githubusercontent.com/assets/4924246/20545548/aa3cca0a-b0c4-11e6-8876-ba121fad9fc3.png)

**After:**
![screenshot 2016-11-22 15 02 41](https://cloud.githubusercontent.com/assets/4924246/20545564/b97a894e-b0c4-11e6-9fe1-8623b0d0b438.png)

![screenshot 2016-11-22 14 57 23](https://cloud.githubusercontent.com/assets/4924246/20545567/beaf4eae-b0c4-11e6-86c0-4de17306ebf6.png)
