### PR TITLE
lib/plans: Drop getCurrentPlan() and addCurrentPlanToCartAndRedirect()

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import moment from 'moment';
-import debugFactory from 'debug';
 import {
 	find,
 	get,
@@ -32,7 +31,6 @@ import SitesList from 'lib/sites-list';
  * Module vars
  */
 const sitesList = SitesList();
-const debug = debugFactory( 'calypso:plans' ); // eslint-disable-line no-unused-vars
 const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 
 export function isFreePlan( plan ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import page from 'page';
 import moment from 'moment';
 import debugFactory from 'debug';
 import {
@@ -15,8 +14,6 @@ import {
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import { addItem } from 'lib/upgrades/actions';
-import { cartItems } from 'lib/cart-values';
 import {
 	isFreeJetpackPlan,
 	isJetpackPlan,
@@ -29,14 +26,13 @@ import {
 	PLAN_JETPACK_FREE,
 	PLAN_PERSONAL
 } from 'lib/plans/constants';
-import { createSitePlanObject } from 'state/sites/plans/assembler';
 import SitesList from 'lib/sites-list';
 
 /**
  * Module vars
  */
 const sitesList = SitesList();
-const debug = debugFactory( 'calypso:plans' );
+const debug = debugFactory( 'calypso:plans' ); // eslint-disable-line no-unused-vars
 const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 
 export function isFreePlan( plan ) {
@@ -96,27 +92,6 @@ export function planHasFeature( plan, feature ) {
 
 export function hasFeature( feature, siteID ) {
 	return planHasFeature( getSitePlanSlug( siteID ), feature );
-}
-
-export function addCurrentPlanToCartAndRedirect( sitePlans, selectedSite ) {
-	addItem( cartItems.planItem( getCurrentPlan( sitePlans.data ).productSlug ) );
-
-	page( `/checkout/${ selectedSite.slug }` );
-}
-
-export function getCurrentPlan( plans ) {
-	const currentPlan = find( plans, { currentPlan: true } );
-
-	if ( currentPlan ) {
-		debug( 'current plan: %o', currentPlan );
-		return currentPlan;
-	}
-
-	// get Site plan from the `site` data
-	const site = sitesList.getSelectedSite();
-	const plan = createSitePlanObject( site.plan );
-	debug( 'current plan: %o', plan );
-	return plan;
 }
 
 export function getCurrentTrialPeriodInDays( plan ) {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -10,9 +10,9 @@ import { localize } from 'i18n-calypso';
  */
 import Main from 'components/main';
 import {
-	getPlansBySite,
 	getCurrentPlan,
-	isCurrentPlanExpiring
+	isCurrentPlanExpiring,
+	isRequestingSitePlans
 } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -33,14 +33,14 @@ class CurrentPlan extends Component {
 	static propTypes = {
 		selectedSiteId: PropTypes.number,
 		selectedSite: PropTypes.object,
-		sitePlans: PropTypes.object,
+		isRequestingSitePlans: PropTypes.bool,
 		context: PropTypes.object
 	};
 
 	isLoading() {
-		const { selectedSite, sitePlans } = this.props;
+		const { selectedSite, isRequestingSitePlans: isRequestingPlans } = this.props;
 
-		return ! selectedSite || ! sitePlans.hasLoadedFromServer;
+		return ! selectedSite || isRequestingPlans;
 	}
 
 	getHeaderWording( plan ) {
@@ -95,7 +95,6 @@ class CurrentPlan extends Component {
 		const {
 			selectedSite,
 			selectedSiteId,
-			sitePlans,
 			context,
 			currentPlan,
 			isExpiring,
@@ -114,7 +113,6 @@ class CurrentPlan extends Component {
 				{ selectedSiteId && ! isJetpack && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
 				<PlansNavigation
-					sitePlans={ sitePlans }
 					path={ context.path }
 					selectedSite={ selectedSite }
 				/>
@@ -151,11 +149,11 @@ export default connect(
 		return {
 			selectedSite,
 			selectedSiteId,
-			sitePlans: getPlansBySite( state, selectedSite ),
 			context: ownProps.context,
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
 			isJetpack: isJetpackSite( state, selectedSiteId ),
+			isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
 			domains: getDecoratedSiteDomains( state, selectedSiteId ),
 			hasDomainsLoaded: ! isRequestingSiteDomains( state, selectedSiteId )
 		};

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -9,7 +9,6 @@ import React from 'react';
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
-import { getPlansBySiteId } from 'state/sites/plans/selectors';
 import { getPlans } from 'state/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
@@ -28,8 +27,7 @@ const Plans = React.createClass( {
 		intervalType: React.PropTypes.string,
 		plans: React.PropTypes.array.isRequired,
 		selectedSite: React.PropTypes.object,
-		selectedSiteId: React.PropTypes.number,
-		sitePlans: React.PropTypes.object.isRequired
+		selectedSiteId: React.PropTypes.number
 	},
 
 	getDefaultProps() {
@@ -76,7 +74,6 @@ const Plans = React.createClass( {
 
 					<div id="plans" className="plans has-sidebar">
 						<UpgradesNavigation
-							sitePlans={ this.props.sitePlans }
 							path={ this.props.context.path }
 							cart={ this.props.cart }
 							selectedSite={ selectedSite } />
@@ -104,7 +101,6 @@ export default connect(
 		return {
 			isPlaceholder,
 			plans: getPlans( state ),
-			sitePlans: isPlaceholder ? {} : getPlansBySiteId( state, selectedSiteId ),
 			selectedSite: getSelectedSite( state ),
 			selectedSiteId: selectedSiteId
 		};

--- a/client/my-sites/upgrades/cart/cart-trial-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-trial-ad.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
+import page from 'page';
 import i18n from 'i18n-calypso';
 
 /**
@@ -9,28 +11,30 @@ import i18n from 'i18n-calypso';
  */
 import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
-import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDayOfTrial } from 'lib/plans';
+import { getDayOfTrial } from 'lib/plans';
+import { addItem } from 'lib/upgrades/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getCurrentPlan, isRequestingSitePlans } from 'state/sites/plans/selectors';
 
 const CartTrialAd = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
-		sitePlans: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
-		] ).isRequired
+		// connected props
+		currentPlan: React.PropTypes.object,
+		isRequestingSitePlans: React.PropTypes.bool,
+		selectedSiteSlug: React.PropTypes.string
 	},
 
 	addPlanAndRedirect( event ) {
 		event.preventDefault();
-
-		addCurrentPlanToCartAndRedirect( this.props.sitePlans, this.props.selectedSite );
+		addItem( cartItems.planItem( this.props.currentPlan.productSlug ) );
+		page( `/checkout/${ this.props.selectedSiteSlug }` );
 	},
 
 	render() {
-		const { cart, sitePlans } = this.props,
-			isDataLoading = ! sitePlans.hasLoadedFromServer || ! cart.hasLoadedFromServer,
-			currentPlan = getCurrentPlan( sitePlans.data );
+		const { cart, currentPlan, isRequestingSitePlans: isRequestingPlans } = this.props,
+			isDataLoading = isRequestingPlans || ! cart.hasLoadedFromServer;
 
 		if ( isDataLoading ||
 			! currentPlan.freeTrial ||
@@ -65,4 +69,13 @@ const CartTrialAd = React.createClass( {
 	}
 } );
 
-export default CartTrialAd;
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		return {
+			currentPlan: getCurrentPlan( state, selectedSiteId ),
+			isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
+			selectedSiteSlug: getSiteSlug( state, selectedSiteId )
+		};
+	}
+)( CartTrialAd );

--- a/client/my-sites/upgrades/cart/cart-trial-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-trial-ad.jsx
@@ -16,6 +16,7 @@ import { addItem } from 'lib/upgrades/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentPlan, isRequestingSitePlans } from 'state/sites/plans/selectors';
+import QuerySitePlans from 'components/data/query-site-plans';
 
 const CartTrialAd = React.createClass( {
 	propTypes: {
@@ -23,28 +24,30 @@ const CartTrialAd = React.createClass( {
 		// connected props
 		currentPlan: React.PropTypes.object,
 		isRequestingSitePlans: React.PropTypes.bool,
-		selectedSiteSlug: React.PropTypes.string
+		siteId: React.PropTypes.number,
+		siteSlug: React.PropTypes.string
 	},
 
 	addPlanAndRedirect( event ) {
 		event.preventDefault();
 		addItem( cartItems.planItem( this.props.currentPlan.productSlug ) );
-		page( `/checkout/${ this.props.selectedSiteSlug }` );
+		page( `/checkout/${ this.props.siteSlug }` );
 	},
 
 	render() {
-		const { cart, currentPlan, isRequestingSitePlans: isRequestingPlans } = this.props,
+		const { cart, currentPlan, isRequestingSitePlans: isRequestingPlans, siteId } = this.props,
 			isDataLoading = isRequestingPlans || ! cart.hasLoadedFromServer;
 
 		if ( isDataLoading ||
 			! currentPlan.freeTrial ||
 			cartItems.getDomainRegistrations( cart ).length !== 1 ||
 			cartItems.hasPlan( cart ) ) {
-			return null;
+			return <QuerySitePlans siteId={ siteId } />;
 		}
 
 		return (
 			<CartAd>
+				<QuerySitePlans siteId={ siteId } />
 				{
 					i18n.translate( 'You are currently on day %(days)d of your {{strong}}%(planName)s trial{{/strong}}.', {
 						components: { strong: <strong /> },
@@ -71,11 +74,12 @@ const CartTrialAd = React.createClass( {
 
 export default connect(
 	( state ) => {
-		const selectedSiteId = getSelectedSiteId( state );
+		const siteId = getSelectedSiteId( state );
 		return {
-			currentPlan: getCurrentPlan( state, selectedSiteId ),
-			isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
-			selectedSiteSlug: getSiteSlug( state, selectedSiteId )
+			currentPlan: getCurrentPlan( state, siteId ),
+			isRequestingSitePlans: isRequestingSitePlans( state, siteId ),
+			siteId,
+			siteSlug: getSiteSlug( state, siteId )
 		};
 	}
 )( CartTrialAd );

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -27,7 +27,6 @@ const PopoverCart = React.createClass( {
 			React.PropTypes.object,
 			React.PropTypes.bool
 		] ).isRequired,
-		sitePlans: React.PropTypes.object.isRequired,
 		onToggle: React.PropTypes.func.isRequired,
 		closeSectionNavMobilePanel: React.PropTypes.func,
 		visible: React.PropTypes.bool.isRequired,
@@ -114,10 +113,7 @@ const PopoverCart = React.createClass( {
 
 		return (
 			<div>
-				<CartTrialAd
-					cart={ this.props.cart }
-					selectedSite={ this.props.selectedSite }
-					sitePlans={ this.props.sitePlans } />
+				<CartTrialAd cart={ this.props.cart } />
 
 				<CartPlanAd
 					cart={ this.props.cart }

--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -35,7 +35,6 @@ const Email = React.createClass( {
 			React.PropTypes.object,
 			React.PropTypes.bool
 		] ).isRequired,
-		sitePlans: React.PropTypes.object.isRequired,
 		user: React.PropTypes.object.isRequired,
 		googleAppsUsers: React.PropTypes.array.isRequired,
 		googleAppsUsersLoaded: React.PropTypes.bool.isRequired
@@ -68,8 +67,7 @@ const Email = React.createClass( {
 			<UpgradesNavigation
 				path={ this.props.context.path }
 				cart={ this.props.cart }
-				selectedSite={ this.props.selectedSite }
-				sitePlans={ this.props.sitePlans } />
+				selectedSite={ this.props.selectedSite } />
 		);
 	},
 

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -99,8 +99,7 @@ export const List = React.createClass( {
 				<UpgradesNavigation
 					path={ this.props.context.path }
 					cart={ this.props.cart }
-					selectedSite={ this.props.selectedSite }
-					sitePlans={ this.props.sitePlans } />
+					selectedSite={ this.props.selectedSite } />
 				{ this.domainWarnings() }
 
 				{ this.domainCreditsInfoNotice() }

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -123,10 +123,7 @@ var DomainSearch = React.createClass( {
 		} else {
 			content = (
 				<span>
-					<FreeTrialNotice
-						cart={ this.props.cart }
-						sitePlans={ this.props.sitePlans }
-						selectedSite={ selectedSite } />
+					<FreeTrialNotice cart={ this.props.cart } />
 
 					<div className="domain-search__content">
 						<UpgradesNavigation

--- a/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
+++ b/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
@@ -71,6 +71,12 @@ export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		return {
+			// Note: This component assumes that site plans data is already present in the state tree
+			// (used by the getCurrentPlan and isRequestingSitePlans selectors).
+			// At the time of implementation, the only parent component that uses this
+			// component is my-sites/upgrades/domain-search/domain-search, which
+			// handles data fetching through the `fetchSitePlans` action.
+			// To avoid redundant AJAX requests, we're hence not rendering <QuerySitePlans /> locally.
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
 			selectedSiteSlug: getSiteSlug( state, selectedSiteId )

--- a/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
+++ b/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
@@ -2,34 +2,39 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
+import page from 'page';
 import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDayOfTrial } from 'lib/plans';
+import { cartItems } from 'lib/cart-values';
+import { getDayOfTrial } from 'lib/plans';
+import { addItem } from 'lib/upgrades/actions';
 import Notice from 'components/notice';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getCurrentPlan, isRequestingSitePlans } from 'state/sites/plans/selectors';
 
 const FreeTrialNotice = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
-		sitePlans: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
-		] ).isRequired
+		// connected props
+		currentPlan: React.PropTypes.object,
+		isRequestingSitePlans: React.PropTypes.bool,
+		selectedSiteSlug: React.PropTypes.string
 	},
 
 	addPlanAndRedirect( event ) {
 		event.preventDefault();
-
-		addCurrentPlanToCartAndRedirect( this.props.sitePlans, this.props.selectedSite );
+		addItem( cartItems.planItem( this.props.currentPlan.productSlug ) );
+		page( `/checkout/${ this.props.selectedSiteSlug }` );
 	},
 
 	render() {
-		const { cart, sitePlans } = this.props,
-			isDataLoading = ! cart.hasLoadedFromServer || ! sitePlans.hasLoadedFromServer,
-			currentPlan = getCurrentPlan( sitePlans.data );
+		const { cart, currentPlan, isRequestingSitePlans: isRequestingPlans } = this.props,
+			isDataLoading = isRequestingPlans || ! cart.hasLoadedFromServer;
 
 		if ( isDataLoading || ! currentPlan.freeTrial ) {
 			return null;
@@ -62,4 +67,13 @@ const FreeTrialNotice = React.createClass( {
 	}
 } );
 
-export default FreeTrialNotice;
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		return {
+			currentPlan: getCurrentPlan( state, selectedSiteId ),
+			isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
+			selectedSiteSlug: getSiteSlug( state, selectedSiteId )
+		};
+	}
+)( FreeTrialNotice );

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -24,8 +24,7 @@ const PlansNavigation = React.createClass( {
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool
-		] ).isRequired,
-		sitePlans: React.PropTypes.object.isRequired
+		] ).isRequired
 	},
 
 	getInitialState() {
@@ -112,7 +111,6 @@ const PlansNavigation = React.createClass( {
 
 		return (
 			<PopoverCart
-				sitePlans={ this.props.sitePlans }
 				cart={ this.props.cart }
 				selectedSite={ this.props.selectedSite }
 				onToggle={ this.toggleCartVisibility }


### PR DESCRIPTION
Have consumers use getCurrentPlan() selector instead, and inline addCurrentPlanToCartAndRedirect().

To test: Make sure that Calypso still works, in particular:
* The 'Free Trial Notice' -- visible in domain search
* The 'Cart Trial Ad' -- visible in the Popover cart during the trial period of a plan
* On a site with a Premium or Business plan, make sure that the http://calypso.localhost:3000/plans/my-plan/<mysite> page still works correctly.

Ideally someone familiar with plans related components should review this. cc'ing @gwwar since you filed #8715.

Fixes #8715