### PR TITLE
Help: Use user account locale for submitting forum posts

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -36,6 +36,7 @@ import QueryTicketSupportConfiguration from 'components/data/query-ticket-suppor
 import HelpUnverifiedWarning from '../help-unverified-warning';
 import { connectChat as connectHappychat, sendChatMessage as sendHappychatMessage } from 'state/happychat/actions';
 import { openChat as openHappychat } from 'state/ui/happychat/actions';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
 
 /**
  * Module variables
@@ -206,7 +207,7 @@ const HelpContact = React.createClass( {
 
 	submitSupportForumsTopic: function( contactForm ) {
 		const { subject, message } = contactForm;
-		const { locale } = this.state.olark;
+		const locale = this.props.currentUserLocale;
 
 		this.setState( { isSubmitting: true } );
 
@@ -604,6 +605,7 @@ const HelpContact = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
+			currentUserLocale: getCurrentUserLocale( state ),
 			olarkTimedOut: isOlarkTimedOut( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			isHappychatAvailable: isHappychatAvailable( state ),


### PR DESCRIPTION
This builds on previous work in #7710 to tag posts to forums from /help/contact with the user's locale.

Previously the olark locale was used, which was limited to `en`, `es` and `pt-br`, so forum posts to other locales were being sent to the en forums.

This replaces the olark locale with the user's account locale, so that posts in other locales should be redirected to the correct language forum.

Testing is mostly the same as #7710:

 - Log in as a **free plan** user (ie, not eligible for chat/ticket support) with any locale **except the following**: en, es, pt-pr
 - Start Calypso in this branch
 - Enable the network console in your browser.
 - Go to /help/contact and submit a forum request
 - Check that the network console shows the user's locale:

![screen shot 2016-11-23 at 3 55 07 pm](https://cloud.githubusercontent.com/assets/416133/20552325/86245526-b195-11e6-8391-c13d29c0f394.png)

