### PR TITLE
Taxonomies: Adding the "Set as default" link to the taxonomy manager

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -126,22 +126,18 @@ class TaxonomyManagerListItem extends Component {
 					position={ 'bottom left' }
 					context={ this.refs && this.refs.popoverMenuButton }
 				>
-					<PopoverMenuItem onClick={ this.editItem }>
-						<Gridicon icon="pencil" size={ 18 } />
+					<PopoverMenuItem onClick={ this.editItem } icon="pencil">
 						{ translate( 'Edit' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem onClick={ this.deleteItem }>
-						<Gridicon icon="trash" size={ 18 } />
+					<PopoverMenuItem onClick={ this.deleteItem } icon="trash">
 						{ translate( 'Delete' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem>
-						<Gridicon icon="external" size={ 18 } />
+					<PopoverMenuItem icon="external" >
 						{ translate( 'View Posts' ) }
 					</PopoverMenuItem>
 					{ canSetAsDefault && ! isDefault && <PopoverMenuSeparator /> }
 					{ canSetAsDefault && ! isDefault &&
-						<PopoverMenuItem onClick={ this.setAsDefault }>
-							<Gridicon icon="checkmark-circle" size={ 18 } />
+						<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">
 							{ translate( 'Set as default' ) }
 						</PopoverMenuItem>
 					}

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -12,6 +12,7 @@ import {
 	SITE_SETTINGS_SAVE_SUCCESS,
 	SITE_SETTINGS_UPDATE
 } from 'state/action-types';
+import { normalizeSettings } from './utils';
 
 /**
  * Returns an action object to be used in signalling that site settings have been received.
@@ -60,7 +61,7 @@ export function requestSiteSettings( siteId ) {
 		return wpcom.undocumented().settings( siteId )
 			.then( ( { name, description, settings } ) => {
 				const savedSettings = {
-					...settings,
+					...( normalizeSettings( settings ) ),
 					blogname: name,
 					blogdescription: description
 				};
@@ -92,7 +93,7 @@ export function saveSiteSettings( siteId, settings ) {
 
 		return wpcom.undocumented().settings( siteId, 'post', settings )
 			.then( ( { updated } ) => {
-				dispatch( updateSiteSettings( siteId, updated ) );
+				dispatch( updateSiteSettings( siteId, normalizeSettings( updated ) ) );
 				dispatch( {
 					type: SITE_SETTINGS_SAVE_SUCCESS,
 					siteId

--- a/client/state/site-settings/test/actions.js
+++ b/client/state/site-settings/test/actions.js
@@ -32,7 +32,7 @@ describe( 'actions', () => {
 
 	describe( 'receiveSiteSettings()', () => {
 		it( 'should return an action object', () => {
-			const settings = { default_category: 'cat' };
+			const settings = { settingKey: 'cat' };
 			const action = receiveSiteSettings( 2916284, settings );
 
 			expect( action ).to.eql( {
@@ -45,7 +45,7 @@ describe( 'actions', () => {
 
 	describe( 'updateSiteSettings()', () => {
 		it( 'should return an action object', () => {
-			const settings = { default_category: 'cat' };
+			const settings = { settingKey: 'cat' };
 			const action = updateSiteSettings( 2916284, settings );
 
 			expect( action ).to.eql( {
@@ -64,7 +64,7 @@ describe( 'actions', () => {
 				.reply( 200, {
 					name: 'blog name',
 					description: 'blog description',
-					settings: { default_category: 'cat' }
+					settings: { settingKey: 'cat' }
 				} )
 				.get( '/rest/v1.1/sites/2916285/settings' )
 				.reply( 403, {
@@ -88,7 +88,7 @@ describe( 'actions', () => {
 					receiveSiteSettings( 2916284, {
 						blogname: 'blog name',
 						blogdescription: 'blog description',
-						default_category: 'cat'
+						settingKey: 'cat'
 					} )
 				);
 			} );
@@ -130,7 +130,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch fetch action and an optimistic update when thunk triggered', () => {
-			saveSiteSettings( 2916284, { default_category: 'chicken' } )( spy );
+			saveSiteSettings( 2916284, { settingKey: 'chicken' } )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: SITE_SETTINGS_SAVE,
@@ -138,7 +138,7 @@ describe( 'actions', () => {
 			} );
 			expect( spy ).to.have.been.calledWith(
 				updateSiteSettings( 2916284, {
-					default_category: 'chicken'
+					settingKey: 'chicken'
 				} )
 			);
 		} );

--- a/client/state/site-settings/test/utils.js
+++ b/client/state/site-settings/test/utils.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { normalizeSettings } from '../utils';
+
+describe( 'utils', () => {
+	describe( 'normalizeSettings()', () => {
+		it( 'should not alter random setting', () => {
+			const settings = {
+				chicken_ribs: '10'
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				chicken_ribs: '10'
+			} );
+		} );
+
+		it( 'should cast the default category to int', () => {
+			const settings = {
+				default_category: '10'
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				default_category: 10
+			} );
+		} );
+	} );
+} );

--- a/client/state/site-settings/utils.js
+++ b/client/state/site-settings/utils.js
@@ -1,0 +1,18 @@
+/**
+ * Normalize API Settings
+ * @param  {Object} settings Raw API settings
+ * @return {Object}          Normalized settings
+ */
+export function normalizeSettings( settings ) {
+	return Object.keys( settings ).reduce( ( memo, key ) => {
+		switch ( key ) {
+			case 'default_category':
+				memo[ key ] = parseInt( settings[ key ] );
+				break;
+			default:
+				memo[ key ] = settings[ key ];
+		}
+
+		return memo;
+	}, {} );
+}


### PR DESCRIPTION
This PR adds the possibility to set a category as default right on the Ellipsis menu.
I faced two issues while working on this:

 - The default Category was not rerendered correctly when the site settings state was updated. This was due to the fact that `VirtualScroll` does not call `renderRow` again if the item object did not change. So, we need to avoid using any extra prop in the `renderRow` function. My solution was to move all the "default category" logic to `ListItem`.

 - Also, I noticed that when calling the siteSettings endpoint, the returned value of default_category is a "string". so I added a small util function to normalize settings retrieved from the API.

<img width="730" alt="capture d ecran 2016-11-23 a 11 28 42 am" src="https://cloud.githubusercontent.com/assets/272444/20558568/f3e7d328-b170-11e6-8690-f4588e101180.png">

closes #9459

**How to test**

 * Open the taxonomy manager `/settings/taxonomies/$site/category`
 * Try to update the default category from the ellipsis menu
 * The default category should be updated correctly

cc @timmyc 