### PR TITLE
POC: Stoic quotes in reader

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -32,6 +32,7 @@
 @import 'blocks/reader-post-actions/style';
 @import 'blocks/reader-post-card/style';
 @import 'blocks/reader-post-options-menu/style';
+@import 'blocks/reader-quote/style';
 @import 'blocks/reader-related-card/style';
 @import 'blocks/reader-related-card-v2/style';
 @import 'blocks/reader-search-card/style';

--- a/client/blocks/reader-quote/index.jsx
+++ b/client/blocks/reader-quote/index.jsx
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => <div>{ 'Everything we hear is an opinion, not a fact. Everything we see is a perspective, not the truth.' }</div>;

--- a/client/blocks/reader-quote/index.jsx
+++ b/client/blocks/reader-quote/index.jsx
@@ -3,4 +3,21 @@
  */
 import React from 'react';
 
-export default () => <div>{ 'Everything we hear is an opinion, not a fact. Everything we see is a perspective, not the truth.' }</div>;
+/**
+ * Internal Dependencies
+ */
+import getRandomQuote from './quotes';
+
+export default () => {
+	const quote = getRandomQuote();
+	return (
+		<div className="reader-quote">
+			<div className="reader-quote__content">
+				{ quote.content }
+			</div>
+			<div className="reader-quote__author">
+				{ quote.author }
+			</div>
+		</div>
+	);
+};

--- a/client/blocks/reader-quote/quotes.js
+++ b/client/blocks/reader-quote/quotes.js
@@ -1,0 +1,14 @@
+const quotes = [
+	{
+		content: 'Everything we hear is an opinion, not a fact. Everything we see is a perspective, not the truth.',
+		author: 'Marcus Aurelius'
+	}, {
+		content: 'Waste no more time arguing about what a good man should be. Be one.',
+		author: 'Marcus Aurelius'
+	}, {
+		content: 'Let not your mind run on what you lack as much as on what you have already.',
+		author: 'Marcus Aurelius'
+	}
+];
+
+export default () => quotes[ Math.floor( Math.random() * quotes.length ) ];

--- a/client/blocks/reader-quote/style.scss
+++ b/client/blocks/reader-quote/style.scss
@@ -1,0 +1,19 @@
+.reader-quote {
+	text-align: center;
+    width: 60%;
+    margin: 32px auto;
+    color: lighten( $gray, 10% );
+}
+
+.reader-quote__author {
+    text-align: right;
+    font-size: 18px;
+    font-style: italic;
+}
+
+.reader-quote__content {
+	font-size: 20px;
+    font-weight: 700;
+    font-family: Merriweather, Georgia, "Times New Roman", Times, serif;
+    font-style: oblique;
+}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -34,6 +34,7 @@ import PostBlocked from './post-blocked';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import scrollTo from 'lib/scroll-to';
 import XPostHelper from 'reader/xpost-helper';
+import Quote from 'blocks/reader-quote';
 
 const GUESSED_POST_HEIGHT = 600;
 const HEADER_OFFSET_TOP = 46;
@@ -413,7 +414,7 @@ export default class ReaderStream extends React.Component {
 					} );
 				}
 
-				return React.createElement( PostClass, {
+				const postElement = React.createElement( PostClass, {
 					ref: itemKey,
 					key: itemKey,
 					post: post,
@@ -426,6 +427,16 @@ export default class ReaderStream extends React.Component {
 					showPrimaryFollowButton: this.props.showPrimaryFollowButtonOnCards,
 					showSiteName: this.props.showSiteNameOnCards
 				} );
+
+				if ( index % 5 === 3 ) {
+					return (
+						<div key={ itemKey }>
+							<Quote />
+							{ postElement }
+						</div>
+					);
+				}
+				return postElement;
 
 		}
 	}


### PR DESCRIPTION
# Be Mindful.

Look at this reader feed:

![screen shot 2016-11-23 at 19 32 12 pm](https://cloud.githubusercontent.com/assets/3775068/20574180/946209d0-b1b3-11e6-9de0-f94f6e7b8130.png)
![screen shot 2016-11-23 at 19 31 59 pm](https://cloud.githubusercontent.com/assets/3775068/20574195/9ffd64ba-b1b3-11e6-8b5f-8b3f5ccd77e2.png)


## Why ?

Ok, 2016 was an eventful and/or stressful year for many. The holiday season is coming up, which is usually a time of reflection.

There is [ample evidence](https://aeon.co/essays/why-stoicism-is-one-of-the-best-mind-hacks-ever-devised) that stoicism is beneficial,  but the quotes dont need to be limited to stoicism.

Reader feed can sometimes be populated by stressful OR less-then-stellar quality content. Lets try to do something nice for our users.

## I dont like x

This is hacked together proof of concept. Lets try to make it a reality.
I condensed the view in the screenshots, quote will be displayed every 5 posts.
We also can move data to endpoint, make abtest, move it to redux or restrict to some reader feeds.
I'm open, but I'd like us to try to come with something that puts a user at ease instead of screaming "world is ending", like some outlets do.

CC @rralian @mtias @adambbecker @folletto @gwwar 