### PR TITLE
Guided Tours: Add a theme sheet tour

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -372,11 +372,11 @@ export class Continue extends Component {
 	}
 
 	componentDidMount() {
-		! this.props.hidden && this.addTargetListener();
+		this.addTargetListener();
 	}
 
 	componentWillUnmount() {
-		! this.props.hidden && this.removeTargetListener();
+		this.removeTargetListener();
 	}
 
 	componentWillReceiveProps( nextProps, nextContext ) {

--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -96,6 +96,7 @@ export class Step extends Component {
 		] ),
 		when: PropTypes.func,
 		scrollContainer: PropTypes.string,
+		style: PropTypes.object,
 	};
 
 	static contextTypes = contextTypes;
@@ -287,8 +288,10 @@ export class Step extends Component {
 			} ),
 		].filter( Boolean );
 
+		const style = { ...this.props.style, ...stepCoords };
+
 		return (
-			<Card className={ classNames( ...classes ) } style={ stepCoords } >
+			<Card className={ classNames( ...classes ) } style={ style } >
 				{ children }
 			</Card>
 		);

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -4,8 +4,10 @@
 import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/main-tour';
 import { DesignShowcaseWelcomeTour } from 'layout/guided-tours/design-showcase-welcome-tour';
+import { ThemeSheetTour } from 'layout/guided-tours/theme-sheet-tour';
 
 export default combineTours( {
 	main: MainTour,
 	designShowcaseWelcome: DesignShowcaseWelcomeTour,
+	theme: ThemeSheetTour,
 } );

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -4,10 +4,10 @@
 import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/main-tour';
 import { DesignShowcaseWelcomeTour } from 'layout/guided-tours/design-showcase-welcome-tour';
-import { ThemeSheetWelcomeTour } from 'layout/guided-tours/theme-sheet-tour';
+import { ThemeSheetWelcomeTour } from 'layout/guided-tours/theme-sheet-welcome-tour';
 
 export default combineTours( {
 	main: MainTour,
 	designShowcaseWelcome: DesignShowcaseWelcomeTour,
-	theme: ThemeSheetWelcomeTour,
+	themeSheetWelcomeTour: ThemeSheetWelcomeTour,
 } );

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -4,10 +4,10 @@
 import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/main-tour';
 import { DesignShowcaseWelcomeTour } from 'layout/guided-tours/design-showcase-welcome-tour';
-import { ThemeSheetTour } from 'layout/guided-tours/theme-sheet-tour';
+import { ThemeSheetWelcomeTour } from 'layout/guided-tours/theme-sheet-tour';
 
 export default combineTours( {
 	main: MainTour,
 	designShowcaseWelcome: DesignShowcaseWelcomeTour,
-	theme: ThemeSheetTour,
+	theme: ThemeSheetWelcomeTour,
 } );

--- a/client/layout/guided-tours/theme-sheet-tour.js
+++ b/client/layout/guided-tours/theme-sheet-tour.js
@@ -28,7 +28,7 @@ export const ThemeSheetTour = makeTour(
 	<Tour name="theme" version="20160812" path="/theme" when={ and( isNewUser, isEnabled( 'guided-tours/theme', isDesktop ) ) }>
 		<Step name="init" placement="right" next="live-preview" className="guided-tours__step-first">
 			<p className="guided-tours__step-text">
-				{ 'This page shows all the details about a specific theme design. Can I show you around?' }
+				{ 'This page shows all the details about a specific theme design. May I show you around?' }
 			</p>
 			<div className="guided-tours__choice-button-row">
 				<Next step="live-preview">{ translate( "Let's go!" ) }</Next>
@@ -43,7 +43,7 @@ export const ThemeSheetTour = makeTour(
 			next="close-preview"
 		>
 			<p className="guided-tours__step-text">
-				{ 'Here you can see the design live.' }
+				{ 'Here you can see the design in action in a demo site.' }
 			</p>
 			<p className="guided-tours__actionstep-instructions">
 				<Continue step="close-preview" target="theme-sheet-preview" click />
@@ -58,7 +58,7 @@ export const ThemeSheetTour = makeTour(
 			next="pick-activate"
 		>
 			<p className="guided-tours__step-text">
-				{ 'This is the live demo. Take a look around! Then tap here to close.' }
+				{ 'This is the live demo. Take a look around, see if the design suits you! Then tap here to close.' }
 			</p>
 			<p className="guided-tours__actionstep-instructions">
 				<Continue when={ not( previewIsShowing ) } step="pick-activate" />

--- a/client/layout/guided-tours/theme-sheet-tour.js
+++ b/client/layout/guided-tours/theme-sheet-tour.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { overEvery as and, negate as not } from 'lodash';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Continue,
+	Next,
+	Quit,
+	Step,
+	Tour,
+	makeTour,
+} from 'layout/guided-tours/config-elements';
+import {
+	inSection,
+	isEnabled,
+	isNewUser,
+	previewIsShowing,
+} from 'state/ui/guided-tours/contexts';
+import { isDesktop } from 'lib/viewport';
+
+export const ThemeSheetTour = makeTour(
+	<Tour name="theme" version="20160812" path="/theme" when={ and( isNewUser, isEnabled( 'guided-tours/theme', isDesktop ) ) }>
+		<Step name="init" placement="right" next="live-preview" className="guided-tours__step-first">
+			<p className="guided-tours__step-text">
+				{ 'This page shows all the details about a specific theme design. Can I show you around?' }
+			</p>
+			<div className="guided-tours__choice-button-row">
+				<Next step="live-preview">{ translate( "Let's go!" ) }</Next>
+				<Quit>{ translate( 'No thanks.' ) }</Quit>
+			</div>
+		</Step>
+
+		<Step name="live-preview"
+			target="theme-sheet-preview"
+			placement="below"
+			arrow="top-left"
+			next="close-preview"
+		>
+			<p className="guided-tours__step-text">
+				{ 'Here you can see the design live.' }
+			</p>
+			<p className="guided-tours__actionstep-instructions">
+				<Continue step="close-preview" target="theme-sheet-preview" click />
+			</p>
+		</Step>
+
+		<Step name="close-preview"
+			target=".web-preview.is-visible [data-tip-target='web-preview__close']"
+			arrow="left-top"
+			placement="beside"
+			when={ previewIsShowing }
+			next="pick-activate"
+		>
+			<p className="guided-tours__step-text">
+				{ 'This is the live demo. Take a look around! Then tap here to close.' }
+			</p>
+			<p className="guided-tours__actionstep-instructions">
+				<Continue when={ not( previewIsShowing ) } step="pick-activate" />
+			</p>
+		</Step>
+
+		<Step name="pick-activate"
+			target=".theme__sheet-primary-button"
+			arrow="top-left"
+			placement="below"
+			next="back-to-list"
+		>
+			<p className="guided-tours__step-text">
+				{ 'This will activate the design you’re currently seeing on your site.' }
+			</p>
+			<div className="guided-tours__choice-button-row">
+				<Next step="back-to-list" />
+				<Quit />
+			</div>
+		</Step>
+
+		<Step name="back-to-list"
+			target=".theme__sheet-action-bar .header-cake__back.button"
+			placement="beside"
+			arrow="left-top"
+			when={ inSection( 'theme' ) }
+		>
+			<p className="guided-tours__step-text">
+				{ 'You can go back to the themes list here.' }
+			</p>
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/theme-sheet-tour.js
+++ b/client/layout/guided-tours/theme-sheet-tour.js
@@ -25,10 +25,21 @@ import {
 import { isDesktop } from 'lib/viewport';
 
 export const ThemeSheetTour = makeTour(
-	<Tour name="theme" version="20161129" path="/theme" when={ and( isEnabled( 'guided-tours/theme' ), isNewUser, isDesktop ) }>
-		<Step name="init" placement="right" next="live-preview" className="guided-tours__step-first">
+	<Tour name="theme"
+		version="20161129"
+		path="/theme"
+		when={ and(
+			isEnabled( 'guided-tours/theme' ),
+			isNewUser,
+			isDesktop
+			) }
+	>
+		<Step name="init" placement="right" next="live-preview">
 			<p>
-				{ translate( 'This page shows all the details about a specific theme design. May I show you around?' ) }
+				{ translate(
+					'This page shows all the details about a specific theme ' +
+					'design. May I show you around?'
+				) }
 			</p>
 			<ButtonRow>
 				<Next step="live-preview">{ translate( "Let's go!" ) }</Next>
@@ -92,7 +103,9 @@ export const ThemeSheetTour = makeTour(
 			next="back-to-list"
 		>
 			<p>
-				{ translate( 'This will activate the design you’re currently seeing on your site.' ) }
+				{ translate(
+					'This will activate the design you’re currently seeing on your site.'
+				) }
 			</p>
 			<ButtonRow>
 				<Next step="back-to-list">{ translate( 'Got it' ) }</Next>
@@ -104,13 +117,15 @@ export const ThemeSheetTour = makeTour(
 			target=".theme__sheet-action-bar .header-cake__back.button"
 			placement="beside"
 			arrow="left-top"
-			style={ { marginTop: '-15px' } }
+			style={ { marginTop: '-15px' } }
 		>
 			<p>
-				{ translate( 'That\'s it! You can return to our design showcase anytime through here.' ) }
+				{ translate(
+					'That\'s it! You can return to our design showcase anytime through here.'
+				) }
 			</p>
 			<ButtonRow>
-				<Quit primary={ true }>{ translate( 'Done' ) }</Quit>
+				<Quit primary>{ translate( 'Done' ) }</Quit>
 			</ButtonRow>
 		</Step>
 	</Tour>

--- a/client/layout/guided-tours/theme-sheet-tour.js
+++ b/client/layout/guided-tours/theme-sheet-tour.js
@@ -9,6 +9,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import {
+	ButtonRow,
 	Continue,
 	Next,
 	Quit,
@@ -17,7 +18,6 @@ import {
 	makeTour,
 } from 'layout/guided-tours/config-elements';
 import {
-	inSection,
 	isEnabled,
 	isNewUser,
 	previewIsShowing,
@@ -25,15 +25,15 @@ import {
 import { isDesktop } from 'lib/viewport';
 
 export const ThemeSheetTour = makeTour(
-	<Tour name="theme" version="20160812" path="/theme" when={ and( isNewUser, isEnabled( 'guided-tours/theme', isDesktop ) ) }>
+	<Tour name="theme" version="20161129" path="/theme" when={ and( isEnabled( 'guided-tours/theme' ), isNewUser, isDesktop ) }>
 		<Step name="init" placement="right" next="live-preview" className="guided-tours__step-first">
-			<p className="guided-tours__step-text">
-				{ 'This page shows all the details about a specific theme design. May I show you around?' }
+			<p>
+				{ translate( 'This page shows all the details about a specific theme design. May I show you around?' ) }
 			</p>
-			<div className="guided-tours__choice-button-row">
+			<ButtonRow>
 				<Next step="live-preview">{ translate( "Let's go!" ) }</Next>
-				<Quit>{ translate( 'No thanks.' ) }</Quit>
-			</div>
+				<Quit>{ translate( 'No, thanks' ) }</Quit>
+			</ButtonRow>
 		</Step>
 
 		<Step name="live-preview"
@@ -42,27 +42,47 @@ export const ThemeSheetTour = makeTour(
 			arrow="top-left"
 			next="close-preview"
 		>
-			<p className="guided-tours__step-text">
-				{ 'Here you can see the design in action in a demo site.' }
+			<p>
+				{ translate( 'Here you can see the design in action in a demo site.' ) }
 			</p>
-			<p className="guided-tours__actionstep-instructions">
-				<Continue step="close-preview" target="theme-sheet-preview" click />
+			<ButtonRow>
+				<Continue step="try-viewport" target="theme-sheet-preview" click />
+			</ButtonRow>
+		</Step>
+
+		<Step name="try-viewport"
+			target=".web-preview.is-visible"
+			placement="middle"
+			when={ previewIsShowing }
+		>
+			<p>
+				{ translate(
+					'This is the live demo. You can also see what the design ' +
+					'will look like on mobile devices by clicking on the phone ' +
+					'or tablet icons in the toolbar.'
+				) }
 			</p>
+			<ButtonRow>
+				<Next step="close-preview" />
+			</ButtonRow>
 		</Step>
 
 		<Step name="close-preview"
 			target=".web-preview.is-visible [data-tip-target='web-preview__close']"
-			arrow="left-top"
 			placement="beside"
+			arrow="left-top"
 			when={ previewIsShowing }
 			next="pick-activate"
 		>
-			<p className="guided-tours__step-text">
-				{ 'This is the live demo. Take a look around, see if the design suits you! Then tap here to close.' }
+			<p>
+				{ translate(
+					'Take a look around, see if the design suits you! Then ' +
+					'close the preview to return.'
+				) }
 			</p>
-			<p className="guided-tours__actionstep-instructions">
-				<Continue when={ not( previewIsShowing ) } step="pick-activate" />
-			</p>
+			<ButtonRow>
+				<Continue when={ not( previewIsShowing ) } step="pick-activate" icon="cross" />
+			</ButtonRow>
 		</Step>
 
 		<Step name="pick-activate"
@@ -71,24 +91,26 @@ export const ThemeSheetTour = makeTour(
 			placement="below"
 			next="back-to-list"
 		>
-			<p className="guided-tours__step-text">
-				{ 'This will activate the design you’re currently seeing on your site.' }
+			<p>
+				{ translate( 'This will activate the design you’re currently seeing on your site.' ) }
 			</p>
-			<div className="guided-tours__choice-button-row">
-				<Next step="back-to-list" />
+			<ButtonRow>
+				<Next step="back-to-list">{ translate( 'Got it' ) }</Next>
 				<Quit />
-			</div>
+			</ButtonRow>
 		</Step>
 
 		<Step name="back-to-list"
 			target=".theme__sheet-action-bar .header-cake__back.button"
 			placement="beside"
 			arrow="left-top"
-			when={ inSection( 'theme' ) }
 		>
-			<p className="guided-tours__step-text">
-				{ 'You can go back to the themes list here.' }
+			<p>
+				{ translate( 'That\'s it! You can return to our design showcase anytime through here.' ) }
 			</p>
+			<ButtonRow>
+				<Quit primary={ true }>{ translate( 'Done' ) }</Quit>
+			</ButtonRow>
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/theme-sheet-tour.js
+++ b/client/layout/guided-tours/theme-sheet-tour.js
@@ -22,7 +22,7 @@ import {
 	isNewUser,
 	previewIsShowing,
 } from 'state/ui/guided-tours/contexts';
-import { isDesktop } from 'lib/viewport';
+import { isDesktop, isMobile } from 'lib/viewport';
 
 export const ThemeSheetTour = makeTour(
 	<Tour name="theme"
@@ -31,7 +31,7 @@ export const ThemeSheetTour = makeTour(
 		when={ and(
 			isEnabled( 'guided-tours/theme' ),
 			isNewUser,
-			isDesktop
+			not( isMobile )
 			) }
 	>
 		<Step name="init" placement="right" next="live-preview">

--- a/client/layout/guided-tours/theme-sheet-tour.js
+++ b/client/layout/guided-tours/theme-sheet-tour.js
@@ -109,6 +109,7 @@ export const ThemeSheetTour = makeTour(
 			</p>
 			<ButtonRow>
 				<Next step="back-to-list">{ translate( 'Got it' ) }</Next>
+				<Continue step="back-to-list" target=".theme__sheet-primary-button" click hidden />
 				<Quit />
 			</ButtonRow>
 		</Step>
@@ -117,7 +118,7 @@ export const ThemeSheetTour = makeTour(
 			target=".theme__sheet-action-bar .header-cake__back.button"
 			placement="beside"
 			arrow="left-top"
-			style={ { marginTop: '-15px' } }
+			style={ { marginTop: '-15px', zIndex: 1 } }
 		>
 			<p>
 				{ translate(

--- a/client/layout/guided-tours/theme-sheet-tour.js
+++ b/client/layout/guided-tours/theme-sheet-tour.js
@@ -24,6 +24,14 @@ import {
 } from 'state/ui/guided-tours/contexts';
 import { isDesktop, isMobile } from 'lib/viewport';
 
+const PickActivateStep = () => (
+	<p>
+		{ translate(
+			'This will activate the design you’re currently seeing on your site.'
+		) }
+	</p>
+);
+
 export const ThemeSheetTour = makeTour(
 	<Tour name="theme"
 		version="20161129"
@@ -57,24 +65,7 @@ export const ThemeSheetTour = makeTour(
 				{ translate( 'Here you can see the design in action in a demo site.' ) }
 			</p>
 			<ButtonRow>
-				<Continue step="try-viewport" target="theme-sheet-preview" click />
-			</ButtonRow>
-		</Step>
-
-		<Step name="try-viewport"
-			target=".web-preview.is-visible"
-			placement="middle"
-			when={ previewIsShowing }
-		>
-			<p>
-				{ translate(
-					'This is the live demo. You can also see what the design ' +
-					'will look like on mobile devices by clicking on the phone ' +
-					'or tablet icons in the toolbar.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="close-preview" />
+				<Continue step="close-preview" target="theme-sheet-preview" click />
 			</ButtonRow>
 		</Step>
 
@@ -86,8 +77,7 @@ export const ThemeSheetTour = makeTour(
 		>
 			<p>
 				{ translate(
-					'Take a look around, see if the design suits you! Then ' +
-					'close the preview to return.'
+					'This is the live demo. Take a look around, see if the design suits you! Then close the preview to return.'
 				) }
 			</p>
 			<ButtonRow>
@@ -96,31 +86,45 @@ export const ThemeSheetTour = makeTour(
 		</Step>
 
 		<Step name="theme-docs"
-			target=".theme__sheet-content p:nth-child(2)"
+			target=".theme__sheet-content .section-nav-tab:last-child"
 			placement="beside"
 			arrow="left-top"
-			scrollContainer="body"
-			shouldScrollTo
-		>
-			<p>Here be docs. Here be docs. Here be docs. Here be docs. Here be docs. </p>
-			<ButtonRow>
-				<Next step="pick-activate" />
-			</ButtonRow>
-		</Step>
-
-		<Step name="pick-activate"
-			target=".theme__sheet-primary-button"
-			arrow="top-left"
-			placement="below"
-			next="back-to-list"
-			scrollContainer="body"
-			shouldScrollTo
 		>
 			<p>
 				{ translate(
-					'This will activate the design you’re currently seeing on your site.'
+					'There\'s more to your theme than meets the eye! Unlock its ' +
+					'full potential, discover its features — everything is ' +
+					'in the documentation.'
 				) }
 			</p>
+			<ButtonRow>
+				<Next step="pick-activate-wide" />
+			</ButtonRow>
+		</Step>
+
+		<Step name="pick-activate-wide"
+			target=".theme__sheet-primary-button"
+			arrow="top-left"
+			placement="below"
+			when={ isDesktop }
+			next="pick-activate-narrow"
+		>
+			<PickActivateStep />
+			<ButtonRow>
+				<Next step="pick-activate-narrow">{ translate( 'Got it' ) }</Next>
+				<Continue step="pick-activate-narrow" target=".theme__sheet-primary-button" click hidden />
+				<Quit />
+			</ButtonRow>
+		</Step>
+
+		<Step name="pick-activate-narrow"
+			target=".theme__sheet-primary-button"
+			arrow="top-right"
+			placement="below"
+			next="back-to-list"
+			when={ not( isDesktop ) }
+		>
+			<PickActivateStep />
 			<ButtonRow>
 				<Next step="back-to-list">{ translate( 'Got it' ) }</Next>
 				<Continue step="back-to-list" target=".theme__sheet-primary-button" click hidden />

--- a/client/layout/guided-tours/theme-sheet-tour.js
+++ b/client/layout/guided-tours/theme-sheet-tour.js
@@ -83,7 +83,6 @@ export const ThemeSheetTour = makeTour(
 			placement="beside"
 			arrow="left-top"
 			when={ previewIsShowing }
-			next="pick-activate"
 		>
 			<p>
 				{ translate(
@@ -92,7 +91,20 @@ export const ThemeSheetTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
-				<Continue when={ not( previewIsShowing ) } step="pick-activate" icon="cross" />
+				<Continue when={ not( previewIsShowing ) } step="theme-docs" icon="cross" />
+			</ButtonRow>
+		</Step>
+
+		<Step name="theme-docs"
+			target=".theme__sheet-content p:nth-child(2)"
+			placement="beside"
+			arrow="left-top"
+			scrollContainer="body"
+			shouldScrollTo
+		>
+			<p>Here be docs. Here be docs. Here be docs. Here be docs. Here be docs. </p>
+			<ButtonRow>
+				<Next step="pick-activate" />
 			</ButtonRow>
 		</Step>
 
@@ -101,6 +113,8 @@ export const ThemeSheetTour = makeTour(
 			arrow="top-left"
 			placement="below"
 			next="back-to-list"
+			scrollContainer="body"
+			shouldScrollTo
 		>
 			<p>
 				{ translate(

--- a/client/layout/guided-tours/theme-sheet-tour.js
+++ b/client/layout/guided-tours/theme-sheet-tour.js
@@ -104,6 +104,7 @@ export const ThemeSheetTour = makeTour(
 			target=".theme__sheet-action-bar .header-cake__back.button"
 			placement="beside"
 			arrow="left-top"
+			style={ { marginTop: '-15px' } }
 		>
 			<p>
 				{ translate( 'That\'s it! You can return to our design showcase anytime through here.' ) }

--- a/client/layout/guided-tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/theme-sheet-welcome-tour.js
@@ -21,24 +21,24 @@ import {
 	isAbTestInVariant,
 	isEnabled,
 	isNewUser,
-	previewIsShowing,
+	isPreviewShowing,
 } from 'state/ui/guided-tours/contexts';
 import { isDesktop, isMobile } from 'lib/viewport';
 
-const PickActivateStep = () => (
+const PickActivateStepText = () => (
 	<p>
-		{ translate(
-			'This will activate the design you’re currently seeing on your site.'
-		) }
+		{
+			'This would activate the design you\'re currently seeing on your site.'
+		}
 	</p>
 );
 
 export const ThemeSheetWelcomeTour = makeTour(
-	<Tour name="theme"
+	<Tour name="themeSheetWelcomeTour"
 		version="20161129"
 		path="/theme"
 		when={ and(
-			isEnabled( 'guided-tours/theme' ),
+			isEnabled( 'guided-tours/theme-sheet-welcome' ),
 			isNewUser,
 			not( isMobile ),
 			isAbTestInVariant( 'themeSheetWelcomeTour', 'enabled' )
@@ -46,10 +46,10 @@ export const ThemeSheetWelcomeTour = makeTour(
 	>
 		<Step name="init" placement="right" next="live-preview">
 			<p>
-				{ translate(
-					'This page shows all the details about a specific theme ' +
-					'design. May I show you around?'
-				) }
+				{
+					'This page shows all the details about a specific theme. ' +
+					'May I show you around?'
+				}
 			</p>
 			<ButtonRow>
 				<Next step="live-preview">{ translate( "Let's go!" ) }</Next>
@@ -64,7 +64,7 @@ export const ThemeSheetWelcomeTour = makeTour(
 			next="close-preview"
 		>
 			<p>
-				{ translate( 'Here you can see the design in action in a demo site.' ) }
+				{ 'Here you can see the design in action in a demo site.' }
 			</p>
 			<ButtonRow>
 				<Continue step="close-preview" target="theme-sheet-preview" click />
@@ -75,15 +75,15 @@ export const ThemeSheetWelcomeTour = makeTour(
 			target=".web-preview.is-visible [data-tip-target='web-preview__close']"
 			placement="beside"
 			arrow="left-top"
-			when={ previewIsShowing }
+			when={ isPreviewShowing }
 		>
 			<p>
-				{ translate(
+				{
 					'This is the live demo. Take a look around, see if the design suits you! Then close the preview to return.'
-				) }
+				}
 			</p>
 			<ButtonRow>
-				<Continue when={ not( previewIsShowing ) } step="theme-docs" icon="cross" />
+				<Continue when={ not( isPreviewShowing ) } step="theme-docs" icon="cross" />
 			</ButtonRow>
 		</Step>
 
@@ -93,11 +93,11 @@ export const ThemeSheetWelcomeTour = makeTour(
 			arrow="left-top"
 		>
 			<p>
-				{ translate(
+				{
 					'There\'s more to your theme than meets the eye! Unlock its ' +
 					'full potential, discover its features — everything is ' +
 					'in the documentation.'
-				) }
+				}
 			</p>
 			<ButtonRow>
 				<Next step="pick-activate-wide" />
@@ -111,7 +111,7 @@ export const ThemeSheetWelcomeTour = makeTour(
 			when={ isDesktop }
 			next="pick-activate-narrow"
 		>
-			<PickActivateStep />
+			<PickActivateStepText />
 			<ButtonRow>
 				<Next step="pick-activate-narrow">{ translate( 'Got it' ) }</Next>
 				<Continue step="pick-activate-narrow" target=".theme__sheet-primary-button" click hidden />
@@ -126,7 +126,7 @@ export const ThemeSheetWelcomeTour = makeTour(
 			next="back-to-list"
 			when={ not( isDesktop ) }
 		>
-			<PickActivateStep />
+			<PickActivateStepText />
 			<ButtonRow>
 				<Next step="back-to-list">{ translate( 'Got it' ) }</Next>
 				<Continue step="back-to-list" target=".theme__sheet-primary-button" click hidden />
@@ -141,9 +141,9 @@ export const ThemeSheetWelcomeTour = makeTour(
 			style={ { marginTop: '-15px', zIndex: 1 } }
 		>
 			<p>
-				{ translate(
+				{
 					'That\'s it! You can return to our design showcase anytime through here.'
-				) }
+				}
 			</p>
 			<ButtonRow>
 				<Quit primary>{ translate( 'Done' ) }</Quit>

--- a/client/layout/guided-tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/theme-sheet-welcome-tour.js
@@ -23,15 +23,7 @@ import {
 	isNewUser,
 	isPreviewShowing,
 } from 'state/ui/guided-tours/contexts';
-import { isDesktop, isMobile } from 'lib/viewport';
-
-const PickActivateStepText = () => (
-	<p>
-		{
-			'This would activate the design you\'re currently seeing on your site.'
-		}
-	</p>
-);
+import { isDesktop } from 'lib/viewport';
 
 export const ThemeSheetWelcomeTour = makeTour(
 	<Tour name="themeSheetWelcomeTour"
@@ -40,7 +32,7 @@ export const ThemeSheetWelcomeTour = makeTour(
 		when={ and(
 			isEnabled( 'guided-tours/theme-sheet-welcome' ),
 			isNewUser,
-			not( isMobile ),
+			isDesktop,
 			isAbTestInVariant( 'themeSheetWelcomeTour', 'enabled' )
 		) }
 	>
@@ -108,25 +100,13 @@ export const ThemeSheetWelcomeTour = makeTour(
 			target=".theme__sheet-primary-button"
 			arrow="top-left"
 			placement="below"
-			when={ isDesktop }
-			next="pick-activate-narrow"
-		>
-			<PickActivateStepText />
-			<ButtonRow>
-				<Next step="pick-activate-narrow">{ translate( 'Got it' ) }</Next>
-				<Continue step="pick-activate-narrow" target=".theme__sheet-primary-button" click hidden />
-				<Quit />
-			</ButtonRow>
-		</Step>
-
-		<Step name="pick-activate-narrow"
-			target=".theme__sheet-primary-button"
-			arrow="top-right"
-			placement="below"
 			next="back-to-list"
-			when={ not( isDesktop ) }
 		>
-			<PickActivateStepText />
+			<p>
+				{
+					'This would activate the design you\'re currently seeing on your site.'
+				}
+			</p>
 			<ButtonRow>
 				<Next step="back-to-list">{ translate( 'Got it' ) }</Next>
 				<Continue step="back-to-list" target=".theme__sheet-primary-button" click hidden />

--- a/client/layout/guided-tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/theme-sheet-welcome-tour.js
@@ -18,6 +18,7 @@ import {
 	makeTour,
 } from 'layout/guided-tours/config-elements';
 import {
+	isAbTestInVariant,
 	isEnabled,
 	isNewUser,
 	previewIsShowing,
@@ -32,15 +33,16 @@ const PickActivateStep = () => (
 	</p>
 );
 
-export const ThemeSheetTour = makeTour(
+export const ThemeSheetWelcomeTour = makeTour(
 	<Tour name="theme"
 		version="20161129"
 		path="/theme"
 		when={ and(
 			isEnabled( 'guided-tours/theme' ),
 			isNewUser,
-			not( isMobile )
-			) }
+			not( isMobile ),
+			isAbTestInVariant( 'themeSheetWelcomeTour', 'enabled' )
+		) }
 	>
 		<Step name="init" placement="right" next="live-preview">
 			<p>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -80,6 +80,15 @@ module.exports = {
 		defaultVariation: 'disabled',
 		allowExistingUsers: true,
 	},
+	themeSheetWelcomeTour: {
+		datestamp: '20161206',
+		variations: {
+			enabled: 0,
+			disabled: 100,
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: true,
+	},
 	siteTitleStep: {
 		datestamp: '20160928',
 		variations: {

--- a/config/development.json
+++ b/config/development.json
@@ -44,6 +44,7 @@
 		"guided-tours": true,
 		"guided-tours/main": true,
 		"guided-tours/design-showcase-welcome": true,
+		"guided-tours/theme": true,
 		"guided-tours/themes": false,
 		"help": true,
 		"help/courses": true,

--- a/config/development.json
+++ b/config/development.json
@@ -44,7 +44,7 @@
 		"guided-tours": true,
 		"guided-tours/main": true,
 		"guided-tours/design-showcase-welcome": true,
-		"guided-tours/theme": true,
+		"guided-tours/theme-sheet-welcome": true,
 		"guided-tours/themes": false,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,6 +27,7 @@
 		"guided-tours": true,
 		"guided-tours/main": false,
 		"guided-tours/design-showcase-welcome": true,
+		"guided-tours/theme-sheet-welcome": true,
 		"guided-tours/themes": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
This PR adds a theme sheet tour to show people around `/theme/:slug`.

Partly implements #7083 

![gt-themes-tour](https://cloud.githubusercontent.com/assets/150562/20775482/0e57809a-b753-11e6-8c68-3697dc0fb9f6.gif)

# To test

- Visit http://calypso.localhost:3000/theme/twentysixteen/?tour=themeSheetWelcomeTour and http://calypso.localhost:3000/theme/twentysixteen/MYSITE?tour=themeSheetWelcomeTour
- Go through the tour, make sure the experience makes sense and is fluid and that steps are rendered properly.