### PR TITLE
Reader Full Post: Fix misaligned YouTube embeds

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -513,6 +513,8 @@
 	margin-bottom: 25px;
 	position: relative;
 	padding: 25px 0 56.25%;
+	// We currently have to use !important here to override the inline style on the Youtube embed
+	// - see https://github.com/Automattic/wp-calypso/issues/9615
 	text-align: initial !important;
 
 	iframe {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -510,8 +510,10 @@
 .reader-full-post .embed-youtube,
 .reader-full-post .embed-vimeo {
 	display: block;
+	margin-bottom: 25px;
 	position: relative;
 	padding: 25px 0 56.25%;
+	text-align: initial !important;
 
 	iframe {
 		height: 100%;
@@ -522,5 +524,5 @@
 }
 
 .reader-full-post .embed-vimeo {
-	margin-bottom: 33px;
+	margin-bottom: 0;
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9605

**Before:**
![screenshot 2016-11-23 11 58 55](https://cloud.githubusercontent.com/assets/4924246/20576885/a2a2305e-b174-11e6-953a-b36ee8fa615c.png)

**After:**
![screenshot 2016-11-23 12 02 15](https://cloud.githubusercontent.com/assets/4924246/20576911/b452d628-b174-11e6-8c4c-5e70d68315ec.png)

I don't want to be using `!important` here, but I'm unsure where the inline `text-align: center;` is coming from.

/cc @blowery @samouri 