### PR TITLE
Jetpack plans: Bump mc stats for Jetpack Plans

### DIFF
--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -35,6 +35,7 @@ import {
 	getAuthorizationData,
 	isCalypsoStartedConnection
 } from 'state/jetpack-connect/selectors';
+import { mc } from 'lib/analytics';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
@@ -205,31 +206,37 @@ class Plans extends Component {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_39', {
 				user: this.props.userId
 			} );
+			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_personal' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PERSONAL_MONTHLY ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_3', {
 				user: this.props.userId
 			} );
+			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_personal_monthly' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PREMIUM ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_99', {
 				user: this.props.userId
 			} );
+			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_premium' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PREMIUM_MONTHLY ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_12', {
 				user: this.props.userId
 			} );
+			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_premium_monthly' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_BUSINESS ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_299', {
 				user: this.props.userId
 			} );
+			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_business' );
 		}
 		if ( cartItem.product_slug === PLAN_JETPACK_BUSINESS_MONTHLY ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_29', {
 				user: this.props.userId
 			} );
+			mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_business_monthly' );
 		}
 		addItem( cartItem );
 		this.redirecting = true;


### PR DESCRIPTION
This pull request seeks to implement MC stat bumping for interactions on the Plans Page for Jetpack connections

**Testing instructions:**

_Incoming..._