### PR TITLE
Update Reader Recommendations with new posts_with_images algorithm

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -200,6 +200,9 @@ function getStoreForRecommendedPosts( storeId ) {
 			case 'cold_posts_topics':
 				query.algorithm = 'read:recommendations:posts/es/6';
 				break;
+			case 'custom_recs_posts_with_images':
+				query.algorithm = 'read:recommendations:posts/es/7';
+				break;
 			default:
 				query.algorithm = 'read:recommendations:posts/es/1';
 		}
@@ -248,6 +251,8 @@ function feedStoreFactory( storeId ) {
 	} else if ( storeId === 'recommendations_posts' ) {
 		store = getStoreForRecommendedPosts( storeId );
 	} else if ( startsWith( storeId, 'cold_posts' ) ) {
+		store = getStoreForRecommendedPosts( storeId );
+	} else if ( startsWith( storeId, 'custom_recs' ) ) {
 		store = getStoreForRecommendedPosts( storeId );
 	} else if ( storeId.indexOf( 'feed:' ) === 0 ) {
 		store = getStoreForFeed( storeId );

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -78,8 +78,8 @@ export default {
 				break;
 			default:
 				fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Recommended Posts';
-				RecommendedPostsStore = feedStreamFactory( 'recommendations_posts' );
-				mcKey = 'recommendations_posts';
+				RecommendedPostsStore = feedStreamFactory( 'custom_recs_posts_with_images' );
+				mcKey = 'custom_recs_posts_with_images';
 		}
 
 		ensureStoreLoading( RecommendedPostsStore, context );


### PR DESCRIPTION
Adding the new algorithm option to the feed-stream-store for Recommended Posts. This algorithm will exclusively return Recommended Posts with images.

Updated the default algorithm for /recommendations/posts to `custom_recs_posts_with_images`. This is simply to demonstrate the new algorithm is working and gives an example how to use the new algorithm.

In summary, the changes are as follows:

1. Add new algorithm RecommendedPosts algo to feed-stream-store
2. Updated default algorithm for /recommendations/posts to `custom_recs_posts_with_images`
