### PR TITLE
Reader Refresh: Vimeo support for the new video cards

### DIFF
--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -15,7 +15,7 @@ import FeaturedImage from './featured-image';
 class FeaturedVideo extends React.Component {
 
 	static propTypes = {
-		thumbnailUrl: React.PropTypes.string,
+		thumbnailUrlPromise: React.PropTypes.object,
 		autoplayIframe: React.PropTypes.string,
 		iframe: React.PropTypes.string,
 		videoEmbed: React.PropTypes.object,
@@ -24,8 +24,13 @@ class FeaturedVideo extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			preferThumbnail: true
+			preferThumbnail: true,
+			thumbnailUrl: null,
 		};
+
+		this.props.thumbnailUrlPromise
+			.then( url => this.setState( { thumbnailUrl: url } ) )
+			.catch( () => this.setState( { preferThumbnail: false } ) );
 	}
 
 	setVideoSizingStrategy = ( videoEmbed ) => {
@@ -63,12 +68,12 @@ class FeaturedVideo extends React.Component {
 	}
 
 	render() {
-		const { thumbnailUrl, autoplayIframe, iframe, translate } = this.props;
+		const { thumbnailUrlPromise, autoplayIframe, iframe, translate } = this.props;
 		const preferThumbnail = this.state.preferThumbnail;
 
-		if ( preferThumbnail && thumbnailUrl ) {
+		if ( preferThumbnail && thumbnailUrlPromise ) {
 			return (
-				<FeaturedImage imageUri={ thumbnailUrl } onClick={ this.handleThumbnailClick } >
+				<FeaturedImage imageUri={ this.state.thumbnailUrl } onClick={ this.handleThumbnailClick } >
 					<img className="reader-post-card__play-icon"
 						src="/calypso/images/reader/play-icon.png"
 						title={ translate( 'Play Video' ) }
@@ -80,7 +85,7 @@ class FeaturedVideo extends React.Component {
 		/* eslint-disable react/no-danger */
 		return (
 			<div ref={ this.setVideoEmbedRef } className="reader-post-card__video"
-				dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
+				dangerouslySetInnerHTML={ { __html: this.state.thumbnailUrl ? autoplayIframe : iframe } }
 			/>
 		);
 		/* eslint-enable-line react/no-danger */

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -3,6 +3,7 @@
  */
 import { map, compact, includes, some, filter } from 'lodash';
 import getVideoId from 'get-video-id';
+import request from 'superagent';
 
 /**
  * Internal Dependencies
@@ -90,11 +91,10 @@ const getThumbnailUrlPromise = ( iframe ) => {
 		return Promise.resolve( thumbnailUrl );
 	} else if ( includes( iframe.src, 'vimeo' ) ) {
 		const videoId = getVideoId( iframe.src );
-		const fetchUrl = `http://vimeo.com/api/v2/video/${ videoId }.json`;
+		const fetchUrl = `https://vimeo.com/api/v2/video/${ videoId }.json`;
 
-		return fetch( fetchUrl, { method: 'get' } )
-			.then( resp => resp.json() )
-			.then( resp => Promise.resolve( resp[ 0 ].thumbnail_large ) )
+		return request.get( fetchUrl )
+			.then( resp => Promise.resolve( resp.body[ 0 ].thumbnail_large ) )
 			.catch( err => Promise.reject( err ) );
 	}
 	return Promise.reject();

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -66,9 +66,9 @@ const detectImage = ( image ) => {
  * @returns {string} html src for an iframe that autoplays if from a source we understand.  else null;
  */
 const getAutoplayIframe = ( iframe ) => {
-	if ( iframe.src.indexOf( 'youtube' ) > 0 ) {
+	if ( includes( iframe.src, 'youtube' ) || includes( iframe.src, 'vimeo' ) ) {
 		const autoplayIframe = iframe.cloneNode();
-		if ( autoplayIframe.src.indexOf( '?' ) === -1 ) {
+		if ( ! includes( autoplayIframe.src, '?' ) ) {
 			autoplayIframe.src += '?autoplay=1';
 		} else {
 			autoplayIframe.src += '&autoplay=1';
@@ -82,13 +82,22 @@ const getAutoplayIframe = ( iframe ) => {
  * @param {Node} iframe - the DOM node for the iframe
  * @returns {string} thumbnailUrl - the url for a thumbnail of the video, null if we cannot determine it
  */
-const getThumbnailUrl = ( iframe ) => {
-	if ( iframe.src.indexOf( 'youtube' ) > 0 ) {
+const getThumbnailUrlPromise = ( iframe ) => {
+	if ( includes( iframe.src, 'youtube' ) ) {
 		const videoId = getVideoId( iframe.src );
+		const thumbnailUrl = videoId ? `https://img.youtube.com/vi/${ videoId }/mqdefault.jpg` : null;
 
-		return videoId ? `https://img.youtube.com/vi/${ videoId }/mqdefault.jpg` : null;
+		return Promise.resolve( thumbnailUrl );
+	} else if ( includes( iframe.src, 'vimeo' ) ) {
+		const videoId = getVideoId( iframe.src );
+		const fetchUrl = `http://vimeo.com/api/v2/video/${ videoId }.json`;
+
+		return fetch( fetchUrl, { method: 'get' } )
+			.then( resp => resp.json() )
+			.then( resp => Promise.resolve( resp[ 0 ].thumbnail_large ) )
+			.catch( err => Promise.reject( err ) );
 	}
-	return null;
+	return Promise.reject();
 };
 
 const getEmbedType = ( iframe ) => {
@@ -133,7 +142,7 @@ const detectEmbed = ( iframe ) => {
 		height: height,
 		mediaType: 'video',
 		autoplayIframe: getAutoplayIframe( iframe ),
-		thumbnailUrl: getThumbnailUrl( iframe ),
+		thumbnailUrlPromise: getThumbnailUrlPromise( iframe ),
 	};
 };
 

--- a/client/lib/post-normalizer/rule-pick-canonical-media.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-media.js
@@ -31,7 +31,7 @@ function isCandidateForFeature( media ) {
 		return isImageLargeEnoughForFeature( media );
 	} else if ( media.mediaType === 'video' ) {
 		// we need to have a thumbnail and know how to autoplay it
-		return media.thumbnailUrl && media.autoplayIframe;
+		return media.thumbnailUrlPromise && media.autoplayIframe;
 	}
 
 	return false;


### PR DESCRIPTION
See #9611

In the current reader refresh, a card with a video embed will sometimes look like this:
![vimeo not working](https://cldup.com/WPRnXaZalB.png)

**After this change** it will look like this:
![vimeo video working!](https://cldup.com/GaXbUMDrbc.png)

When a user clicks on the play button, the video should have the same behavior as youtube (expand + play)