### PR TITLE
New setting: JP Monitor WordPress.com Notes.

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -292,8 +292,8 @@ JetpackSite.prototype.fetchMonitorSettings = function( callback ) {
 	}
 };
 
-JetpackSite.prototype.updateMonitorSettings = function( emailNotifications, callback ) {
-	wpcom.undocumented().updateMonitorSettings( this.ID, emailNotifications, function( error, data ) {
+JetpackSite.prototype.updateMonitorSettings = function( emailNotifications, wpNoteNotifications, callback ) {
+	wpcom.undocumented().updateMonitorSettings( this.ID, emailNotifications, wpNoteNotifications, function( error, data ) {
 		if ( error ) {
 			debug( 'error updating Jetpack Monitor settings', error );
 			callback && callback( error );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -132,9 +132,9 @@ Undocumented.prototype.fetchMonitorSettings = function( siteId, fn ) {
 	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId }, fn );
 };
 
-Undocumented.prototype.updateMonitorSettings = function( siteId, emailNotifications, fn ) {
+Undocumented.prototype.updateMonitorSettings = function( siteId, emailNotifications, wpNoteNotifications, fn ) {
 	debug( '/jetpack-blogs/:site_id: query' );
-	return this.wpcom.req.post( { path: '/jetpack-blogs/' + siteId }, {}, { email_notifications: emailNotifications }, fn );
+	return this.wpcom.req.post( { path: '/jetpack-blogs/' + siteId }, {}, { email_notifications: emailNotifications, wp_note_notifications: wpNoteNotifications }, fn );
 };
 
 /**

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -36,7 +36,8 @@ module.exports = protectForm( React.createClass( {
 	resetState: function() {
 		this.replaceState( {
 			togglingModule: false,
-			emailNotifications: false
+			emailNotifications: false,
+			wpNoteNotifications: false
 		} );
 	},
 
@@ -46,7 +47,8 @@ module.exports = protectForm( React.createClass( {
 		site.fetchMonitorSettings( ( function( error, data ) {
 			if ( ! error ) {
 				this.setState( {
-					emailNotifications: data.settings.email_notifications
+					emailNotifications: data.settings.email_notifications,
+					wpNoteNotifications: data.settings.wp_note_notifications
 				} );
 			} else {
 				debug( 'error getting Monitor settings', error );
@@ -83,7 +85,7 @@ module.exports = protectForm( React.createClass( {
 	saveSettings: function() {
 		this.setState( { submitingForm: true } );
 		notices.clearNotices( 'notices' );
-		this.props.site.updateMonitorSettings( this.state.emailNotifications, ( function( error ) {
+		this.props.site.updateMonitorSettings( this.state.emailNotifications, this.state.wpNoteNotifications, ( function( error ) {
 			if ( error ) {
 				this.handleError();
 				notices.error( this.translate( 'There was a problem saving your changes. Please, try again.' ) );
@@ -99,22 +101,45 @@ module.exports = protectForm( React.createClass( {
 		return (
 			<div>
 				<p>{ this.translate( "Jetpack is currently monitoring your site's uptime." ) }</p>
+				{ this.settingsMonitorEmailCheckbox() }
+				{ config.isEnabled( 'settings/security/monitor/wp-note' ) ? this.settingsMonitorWpNoteCheckbox() : '' }
+			</div>
+		);
+	},
+
+	settingsMonitorEmailCheckbox: function() {
+		return (
+			<FormLabel>
+				<FormCheckbox
+					disabled={ this.disableForm() }
+					onClick={ this.recordEvent.bind( this, 'Clicked on Monitor email checkbox' ) }
+					id="jetpack_monitor_email"
+					checkedLink={ this.linkState( 'emailNotifications' ) }
+					name="jetpack_monitor_email" />
+				<span>
+					{ this.translate( 'Send notifications to your {{a}}WordPress.com email address{{/a}}.', {
+						components: {
+							a: <a href="/me/account" onClick={ this.recordEvent.bind( this, 'Clicked on Monitor Link to WordPress.com Email Address' ) } />
+						}
+					} ) }
+				</span>
+			</FormLabel>
+		);
+	},
+
+	settingsMonitorWpNoteCheckbox: function() {
+		return (
 				<FormLabel>
 					<FormCheckbox
 						disabled={ this.disableForm() }
-						onClick={ this.recordEvent.bind( this, 'Clicked on Monitor email checkbox' ) }
-						id="jetpack_monitor_email"
-						checkedLink={ this.linkState( 'emailNotifications' ) }
-						name="jetpack_monitor_email" />
+						onClick={ this.recordEvent.bind( this, 'Clicked on Monitor wp-note checkbox' ) }
+						id="jetpack_monitor_wp_note"
+						checkedLink={ this.linkState( 'wpNoteNotifications' ) }
+						name="jetpack_monitor_wp_note" />
 					<span>
-						{ this.translate( 'Send notifications to your {{a}}WordPress.com email address{{/a}}.', {
-							components: {
-								a: <a href="/me/account" onClick={ this.recordEvent.bind( this, 'Clicked on Monitor Link to WordPress.com Email Address' ) } />
-							}
-						} ) }
+						{ this.translate( 'Send notifications via WordPress.com notification.' ) }
 					</span>
 				</FormLabel>
-			</div>
 		);
 	},
 

--- a/config/development.json
+++ b/config/development.json
@@ -140,6 +140,7 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"settings/security/monitor/wp-note": true,
 		"settings/security/scan": true,
 		"support-user": true,
 		"sync-handler": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,6 +96,7 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"settings/security/monitor/wp-note": true,
 		"settings/security/scan": true,
 		"support-user": true,
 		"sync-handler": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -112,6 +112,7 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"settings/security/monitor/wp-note": true,
 		"settings/security/scan": true,
 		"support-user": true,
 		"sync-handler": true,


### PR DESCRIPTION
In the same place as users toggle their Jetpack Monitor emails, they can toggle
their Jetpack Monitor WordPress.com notifications. Only visible on stage,
development and wpcalypso for now.

This UI goes with D2984. This PR should not be merged until D2984 is live.