### PR TITLE
Reader: fallback on regular post excerpt if better_excerpt is empty

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { noop, truncate } from 'lodash';
+import { noop, truncate, trim } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
@@ -115,7 +115,7 @@ export default class RefreshPostCard extends React.Component {
 			'is-showing-entire-excerpt': showEntireExcerpt
 		} );
 		const showExcerpt = ! isPhotoOnly;
-		const excerptAttribute = useBetterExcerpt ? 'better_excerpt_no_html' : 'excerpt_no_html';
+		const excerptAttribute = useBetterExcerpt && trim( post.better_excerpt_no_html ) ? 'better_excerpt_no_html' : 'excerpt_no_html';
 		let title = truncate( post.title, {
 			length: 140,
 			separator: /,? +/


### PR DESCRIPTION
We create our own post excerpt from `post.content`, called `better_excerpt`.

This PR adds a fallback to the regular post excerpt in cases where the `better_excerpt` is empty.

Fixes #9579.

### To test

Try http://calypso.localhost:3000/read/blogs/5089392 and verify that the posts have an excerpt.
