### PR TITLE
Clean/site list/sites dropdown

### DIFF
--- a/client/components/sites-dropdown/docs/example.jsx
+++ b/client/components/sites-dropdown/docs/example.jsx
@@ -1,18 +1,55 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import find from 'lodash/find';
+import { urlToSlug } from 'lib/url';
+
 
 /**
  * Internal dependencies
  */
 import SitesDropdown from 'components/sites-dropdown';
 
-export default React.createClass( {
-
-	displayName: 'SitesDropdown',
-
-	render: function() {
-		return <SitesDropdown />;
+class SitesDropdownExample extends PureComponent {
+	static propTypes = {
+		selectedSiteId: React.PropTypes.number
 	}
-} );
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			selectedSiteId: this.props.selectedSiteId
+		};
+	}
+
+	updateSelectedSite = ( siteSlug ) => {
+		const selectedSite = find( this.props.sites, site => urlToSlug( site.URL ) === siteSlug );
+		if ( selectedSite ) {
+			this.setState( { selectedSiteId: selectedSite.ID } );
+		}
+	}
+
+	render(){
+		return (
+			<SitesDropdown
+				selectedSiteId={ this.state.selectedSiteId }
+				onSiteSelect={ this.updateSelectedSite } />
+		);
+	}
+}
+
+const getAllSites = ( state ) => state.sites.items;
+
+const getFirstSiteId = ( state ) => Object.keys( state.sites.items )[ 0 ];
+
+const ConnectedSitesDropdownExample = connect( ( state ) => ( {
+	sites: getAllSites( state ),
+	selectedSiteId: getFirstSiteId( state )
+} ) )( SitesDropdownExample );
+
+ConnectedSitesDropdownExample.displayName = 'SitesDropdown'
+
+export default ConnectedSitesDropdownExample;

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -2,22 +2,24 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
  */
+import QuerySites from 'components/data/query-sites';
 import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import SiteSelector from 'components/site-selector';
-import sitesList from 'lib/sites-list';
 import Gridicon from 'components/gridicon';
+import sitesList from 'lib/sites-list';
+import { getSite } from 'state/sites/selectors';
 
 const sites = sitesList();
 
-export default class SitesDropdown extends PureComponent {
-
+export class SitesDropdown extends PureComponent {
 	static propTypes = {
 		selectedSiteId: React.PropTypes.number,
 		showAllSites: React.PropTypes.bool,
@@ -38,20 +40,23 @@ export default class SitesDropdown extends PureComponent {
 		super( props );
 
 		this.selectSite = this.selectSite.bind( this );
-		this.toggleOpen = this.toggleOpen.bind( this );
+		this.toggleDropdown = this.toggleDropdown.bind( this );
 		this.onClose = this.onClose.bind( this );
 
-		const selectedSite = props.selectedSiteId
-			? sites.getSite( props.selectedSiteId )
-			: sites.getPrimary();
+		const selectedSite = props.primarySite || sites.getPrimary();
 
 		this.state = {
 			selectedSiteSlug: selectedSite && selectedSite.slug
 		};
 	}
 
-	getSelectedSite() {
-		return sites.getSite( this.state.selectedSiteSlug );
+	componentWillReceiveProps( nextProps ) {
+		const { primarySite } = nextProps;
+		if ( primarySite && primarySite.slug !== this.state.selectedSiteSlug ) {
+			this.setState( {
+				selectedSiteSlug: primarySite.slug
+			} );
+		}
 	}
 
 	selectSite( siteSlug ) {
@@ -62,7 +67,7 @@ export default class SitesDropdown extends PureComponent {
 		} );
 	}
 
-	toggleOpen() {
+	toggleDropdown() {
 		this.setState( { open: ! this.state.open } );
 	}
 
@@ -74,14 +79,15 @@ export default class SitesDropdown extends PureComponent {
 	render() {
 		return (
 			<div className={ classNames( 'sites-dropdown', { 'is-open': this.state.open } ) }>
+				<QuerySites allSites={ true } />
 				<div className="sites-dropdown__wrapper">
 					<div
 						className="sites-dropdown__selected"
-						onClick={ this.toggleOpen } >
+						onClick={ this.toggleDropdown } >
 						{
-							this.props.isPlaceholder
+							this.props.isPlaceholder || this.props.primarySite == null
 							? <SitePlaceholder />
-							: <Site site={ this.getSelectedSite() } indicator={ false } />
+							: <Site site={ this.props.primarySite } indicator={ false } />
 						}
 						<Gridicon icon="chevron-down" />
 					</div>
@@ -101,3 +107,11 @@ export default class SitesDropdown extends PureComponent {
 		);
 	}
 }
+
+const mapStateToProps = ( state, ownProps ) => ( {
+	primarySite: getSite( state, ownProps.selectedSiteId ),
+} );
+
+export { mapStateToProps };
+
+export default connect( mapStateToProps )( SitesDropdown );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,11 +29,11 @@
       "version": "0.8.2"
     },
     "ajv": {
-      "version": "4.10.1",
+      "version": "4.10.4",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true
     },
     "align-text": {
@@ -57,6 +57,9 @@
     },
     "anymatch": {
       "version": "1.3.0"
+    },
+    "aproba": {
+      "version": "1.0.4"
     },
     "are-we-there-yet": {
       "version": "1.1.2"
@@ -529,7 +532,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000602"
+      "version": "1.0.30000604"
     },
     "caseless": {
       "version": "0.11.0"
@@ -729,6 +732,9 @@
       "dev": true
     },
     "console-browserify": {
+      "version": "1.1.0"
+    },
+    "console-control-strings": {
       "version": "1.1.0"
     },
     "constant-case": {
@@ -1448,7 +1454,7 @@
       "version": "1.0.2"
     },
     "fast-levenshtein": {
-      "version": "2.0.5",
+      "version": "2.0.6",
       "dev": true
     },
     "fast-luhn": {
@@ -1597,7 +1603,7 @@
       "version": "1.0.0"
     },
     "gauge": {
-      "version": "1.2.7"
+      "version": "2.6.0"
     },
     "gaze": {
       "version": "1.1.2"
@@ -1749,6 +1755,9 @@
           "version": "0.0.1"
         }
       }
+    },
+    "has-color": {
+      "version": "0.1.7"
     },
     "has-cors": {
       "version": "1.1.0"
@@ -2303,10 +2312,10 @@
       "version": "1.3.1"
     },
     "level-packager": {
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     "leveldown": {
-      "version": "1.5.0",
+      "version": "1.5.3",
       "dependencies": {
         "abstract-leveldown": {
           "version": "2.6.1"
@@ -2619,6 +2628,9 @@
         }
       }
     },
+    "node-abi": {
+      "version": "1.0.3"
+    },
     "node-contains": {
       "version": "1.0.0"
     },
@@ -2638,6 +2650,9 @@
       "dependencies": {
         "minimatch": {
           "version": "3.0.3"
+        },
+        "npmlog": {
+          "version": "3.1.2"
         }
       }
     },
@@ -2647,8 +2662,14 @@
     "node-ninja": {
       "version": "1.0.2",
       "dependencies": {
+        "gauge": {
+          "version": "1.2.7"
+        },
         "minimatch": {
           "version": "3.0.3"
+        },
+        "npmlog": {
+          "version": "2.0.4"
         }
       }
     },
@@ -2711,7 +2732,15 @@
       }
     },
     "npmlog": {
-      "version": "2.0.4"
+      "version": "4.0.2",
+      "dependencies": {
+        "gauge": {
+          "version": "2.7.2"
+        },
+        "supports-color": {
+          "version": "0.2.0"
+        }
+      }
     },
     "nth-check": {
       "version": "1.0.1",
@@ -2915,7 +2944,7 @@
       "dev": true
     },
     "postcss": {
-      "version": "5.2.6",
+      "version": "5.2.8",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -2957,10 +2986,10 @@
       "version": "3.3.0"
     },
     "prebuild": {
-      "version": "4.5.0",
+      "version": "5.1.2",
       "dependencies": {
         "async": {
-          "version": "1.5.2"
+          "version": "2.1.4"
         },
         "minimist": {
           "version": "1.2.0"
@@ -4264,6 +4293,9 @@
     },
     "which-module": {
       "version": "1.0.0"
+    },
+    "wide-align": {
+      "version": "1.1.0"
     },
     "window-size": {
       "version": "0.1.0"


### PR DESCRIPTION
Hi everybody,

@gwwar , as you suggested I am opening a pull request to track our work on this request; this is not ready to be merged now.

I've also a couple of questions for you;
I understand that you might be working on completely different things right now, so let me give you a little more context before asking the questions (sorry for the long text).

I am working on the `sites-dropdown` component.
It permits the user to select what site should be considered as *primary*. It uses `site-selector` component for the selection logic, and considers as initially selected the site that is currently the user's primary site (indepentently from what is the currently selected site in the redux store).

Since the component receives the currently primary site as `selected` prop, we can't use `getSelectedSite` from 'state/ui/selectors' to get the site that should be initially selected.

Currently I am trying using `getSite` from 'state/sites/selectors'.
Its signature is `( state, siteId ) => Site`. So it works on the basis of the `siteId`.

```js
const mapStateToProps = ( state, ownProps ) => ( {
	primarySite: getSite( state, ownProps.selected ),
} );

export default connect( mapStateToProps )( SitesDropdown );
```

Here, the problem is that sometimes the `sites-dropdown` component is used, specifing as `selected` prop the `siteSlug`, instead of that the `siteId`.
In these cases this PR, at the current state, introduces a bug.

From a quick search in the codebase I found that `sites-dropdown` is used only in the following components/pages.

```txt
# providing selected prop as slug
components/site-selector-modal
me/help/help-contact-form

# providing selected prop as siteId
me/account/main.jsx
```

My first feeling was that we should uniform, and probably use always the `siteId` (since *selectors* work exclusively with it).
I've started doing this but I felt that I was just increasing confusion around `siteId`, and `slug`; I've now reverted those changes.
For example `site-selector` when an option is selected, executes `onSiteSelect` passing as argument the `slug` (not the `siteId`), and this depend more deeper by the `site` component.

```js
const SiteSelector = React.createClass( {
    ...
    onSiteSelect( event, siteSlug ) {
        const handledByHost = this.props.onSiteSelect( siteSlug );
        ...
```

At this regard my first question is: what do you consider the best way to identify a site (siteId or slug)?
The codebase is not completely uniform here; for example `site-selector` works mostly with the slug name. I guess this is due to the fact that *selectors* are a relatively new introduction, and you want to have uniformity one day.
Eventually I would be happy to help.

A completely different approach would be to make `getRawSite` work both with `siteId`, both with `slug` transparently.
That's surely less work, but I am not sure it is the right thing to do. What do you think?

```js
export const getRawSite = ( state, siteId ) => {
	return state.sites.items[ siteId ] || null;
};
```

Can you think to other alternatives which haven't come to my mind?
