### PR TITLE
Plugins: add upgrade nudge for non-biz .com

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -21,19 +21,35 @@ import {
 } from 'lib/products-values';
 import JetpackPluginsPanel from './jetpack-plugins-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import config from 'config';
+import { FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 
 export const PluginPanel = ( {
 	plan,
 	siteSlug,
 	category,
 	search,
+	translate,
 } ) => {
 	const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
 	const hasPremium = hasBusiness || isPremium( plan );
 
 	return (
 		<div className="plugins-wpcom__panel">
+
 			<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
+
+			{ config.isEnabled( 'automated-transfer' ) && ! hasBusiness &&
+				<div className="plugins-wpcom__upgrade-nudge">
+					<UpgradeNudge
+						feature={ FEATURE_UPLOAD_PLUGINS }
+						title={ translate( 'Upgrade to the Business plan to install third-party plugins.' ) }
+						message={ translate( 'Upgrade to the Business plan to install plugins.' ) }
+						event={ 'calypso_plugins_page_upgrade_nudge' }
+					/>
+				</div>
+			}
 
 			<JetpackPluginsPanel { ...{
 				siteSlug,

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -22,8 +22,8 @@ import {
 import JetpackPluginsPanel from './jetpack-plugins-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import config from 'config';
-import { FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
+import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
+import Banner from 'components/banner';
 
 export const PluginPanel = ( {
 	plan,
@@ -41,14 +41,11 @@ export const PluginPanel = ( {
 			<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
 
 			{ config.isEnabled( 'automated-transfer' ) && ! hasBusiness &&
-				<div className="plugins-wpcom__upgrade-nudge">
-					<UpgradeNudge
-						feature={ FEATURE_UPLOAD_PLUGINS }
-						title={ translate( 'Upgrade to the Business plan to install plugins.' ) }
-						message={ translate( 'Upgrade to the Business plan to install plugins.' ) }
-						event={ 'calypso_plugins_page_upgrade_nudge' }
-					/>
-				</div>
+				<Banner
+					feature={ FEATURE_UPLOAD_PLUGINS }
+					plan={ PLAN_BUSINESS }
+					title={ translate( 'Upgrade to the Business plan to install plugins.' ) }
+				/>
 			}
 
 			<JetpackPluginsPanel { ...{

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -44,7 +44,7 @@ export const PluginPanel = ( {
 				<div className="plugins-wpcom__upgrade-nudge">
 					<UpgradeNudge
 						feature={ FEATURE_UPLOAD_PLUGINS }
-						title={ translate( 'Upgrade to the Business plan to install third-party plugins.' ) }
+						title={ translate( 'Upgrade to the Business plan to install plugins.' ) }
 						message={ translate( 'Upgrade to the Business plan to install plugins.' ) }
 						event={ 'calypso_plugins_page_upgrade_nudge' }
 					/>


### PR DESCRIPTION
Add an upgrade nudge on the Jetpack plugins page for non-biz .com sites.

@dmsnell I've used the same `<UpgradeNudge>` you've used [here](https://github.com/Automattic/wp-calypso/commit/6df3daf426537c12951c742d6980a73e848b870a), but I'm not overly fond of having to add a message to render it correctly.
Are there plans to use the message prop for something useful (it defaults to `'And get your own domain address.'`) or should I change the component in order to properly allow an empty message (currently it misalign vertically the nudge title)?