### PR TITLE
Domains: Don't show the .blog notice in signup

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -201,20 +201,24 @@ const RegisterDomainStep = React.createClass( {
 		this.setState( { dotBlogNotice: false } );
 	},
 
+	dotBlogNotice() {
+		return this.state.dotBlogNotice && ! this.props.isSignupStep &&
+			<Notice
+				text={ this.props.translate(
+					'New! {{strong}}.blog{{/strong}} domains are now available for registration.',
+					{ components: { strong: <strong /> } }
+				) }
+				status={ 'is-info' }
+				showDismiss={ true }
+				onDismissClick={ this.dismissDotBlogNotice }
+			/>;
+	},
+
 	render: function() {
 		return (
 			<div className="register-domain-step">
 				{ this.searchForm() }
-				{ this.state.dotBlogNotice &&
-					<Notice
-						text={ this.props.translate(
-							'New! {{strong}}.blog{{/strong}} domains are now available for registration.',
-							{ components: { strong: <strong /> } }
-						) }
-						status={ 'is-info' }
-						showDismiss={ true }
-						onDismissClick={ this.dismissDotBlogNotice } />
-				}
+				{ this.dotBlogNotice() }
 				{ this.notices() }
 				{ this.content() }
 				{ this.queryDomainsSuggestions() }


### PR DESCRIPTION
- Remove 'New!' .blog notice from signup
- Extract the notice in a function

Test:
- Domains -> Add: Should see `New! .blog domains are...`
- NUX -> Domain Add step -> Shouldn't see the notice