### PR TITLE
Jetpack Plugins: Remove context from the filter labels

### DIFF
--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -97,27 +97,27 @@ class JetpackPluginsPanel extends Component {
 		return [
 			{
 				key: 'all',
-				title: translate( 'All', { context: 'Filter label for plugins list' } ),
+				title: translate( 'All' ),
 				path: '/plugins' + siteFilter,
 			},
 			{
 				key: 'engagement',
-				title: translate( 'Engagement', { context: 'Filter label for plugins list' } ),
+				title: translate( 'Engagement' ),
 				path: basePath + '/engagement' + siteFilter,
 			},
 			{
 				key: 'security',
-				title: translate( 'Security', { context: 'Filter label for plugins list' } ),
+				title: translate( 'Security' ),
 				path: basePath + '/security' + siteFilter,
 			},
 			{
 				key: 'appearance',
-				title: translate( 'Appearance', { context: 'Filter label for plugins list' } ),
+				title: translate( 'Appearance' ),
 				path: basePath + '/appearance' + siteFilter,
 			},
 			{
 				key: 'writing',
-				title: translate( 'Writing', { context: 'Filter label for plugins list' } ),
+				title: translate( 'Writing' ),
 				path: basePath + '/writing' + siteFilter,
 			},
 		];


### PR DESCRIPTION
The captions on the top bar have a well-intentioned context added to them but this actually causes partially translated UI:

![screen shot 2016-11-24 at 15 13 20](https://cloud.githubusercontent.com/assets/203408/20601376/9fff33c6-b258-11e6-8b86-2864fb2a54c9.png)

Both the label in the header and the headline should have the same translation but do not because of a specified context. See [Context vs. Comment](https://translate.wordpress.com/2016/11/24/context-vs-comment/) for tips on when to use context.

cc @dmsnell @roundhill 