### PR TITLE
Themes: Upload zip to Jetpack site

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1489,6 +1489,24 @@ Undocumented.prototype.activateTheme = function( themeId, siteId, fn ) {
 	}, fn );
 };
 
+Undocumented.prototype.uploadTheme = function( siteId, file, onProgress ) {
+	debug( '/sites/:site_id/themes/new' );
+	return new Promise( ( resolve, rejectPromise ) => {
+		const resolver = ( error, data ) => {
+			error ? rejectPromise( error ) : resolve( data );
+		};
+
+		const req = this.wpcom.req.post( {
+			path: '/sites/' + siteId + '/themes/new',
+			formData: [
+				[ 'zip[]', file ]
+			]
+		}, resolver );
+
+		req.upload.onprogress = onProgress;
+	} );
+};
+
 Undocumented.prototype.emailForwards = function( domain, callback ) {
 	return this.wpcom.req.get( '/domains/' + domain + '/email', function( error, response ) {
 		if ( error ) {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -37,6 +37,18 @@ const debug = debugFactory( 'calypso:themes:theme-upload' );
 
 class Upload extends React.Component {
 
+	static propTypes = {
+		siteId: React.PropTypes.number,
+		inProgress: React.PropTypes.bool,
+		complete: React.PropTypes.bool,
+		failed: React.PropTypes.bool,
+		uploadedTheme: React.PropTypes.object,
+		error: React.PropTypes.object,
+		progressTotal: React.PropTypes.number,
+		progressLoaded: React.PropTypes.number,
+		installing: React.PropTypes.bool,
+	};
+
 	constructor( props ) {
 		super( props );
 		const { siteId, inProgress } = this.props;
@@ -59,10 +71,10 @@ class Upload extends React.Component {
 	}
 
 	successMessage() {
-		const { translate, uploadedTheme: theme } = this.props;
+		const { translate, uploadedTheme } = this.props;
 		notices.success( translate( 'Successfully uploaded theme %(name)s', {
 			args: {
-				name: theme.name
+				name: uploadedTheme.name
 			}
 		} ) );
 	}
@@ -190,18 +202,6 @@ class Upload extends React.Component {
 		);
 	}
 }
-
-Upload.propTypes = {
-	siteId: React.PropTypes.number,
-	inProgress: React.PropTypes.bool,
-	complete: React.PropTypes.bool,
-	failed: React.PropTypes.bool,
-	uploadedTheme: React.PropTypes.object,
-	error: React.PropTypes.object,
-	progressTotal: React.PropTypes.number,
-	progressLoaded: React.PropTypes.number,
-	installing: React.PropTypes.bool,
-};
 
 export default connect(
 	( state ) => {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -191,6 +191,18 @@ class Upload extends React.Component {
 	}
 }
 
+Upload.propTypes = {
+	siteId: React.PropTypes.number,
+	inProgress: React.PropTypes.bool,
+	complete: React.PropTypes.bool,
+	failed: React.PropTypes.bool,
+	uploadedTheme: React.PropTypes.object,
+	error: React.PropTypes.object,
+	progressTotal: React.PropTypes.number,
+	progressLoaded: React.PropTypes.number,
+	installing: React.PropTypes.bool,
+};
+
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -4,7 +4,6 @@
 import page from 'page';
 import React from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { includes, find } from 'lodash';
 
 /**
@@ -208,10 +207,5 @@ export default connect(
 			installing: isInstallInProgress( state, siteId ),
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators( {
-			uploadTheme,
-			clearThemeUpload,
-		}, dispatch );
-	},
+	{ uploadTheme, clearThemeUpload },
 )( localize( Upload ) );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -3,6 +3,9 @@
  */
 import page from 'page';
 import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { includes, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,13 +16,76 @@ import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import FilePicker from 'components/file-picker';
 import DropZone from 'components/drop-zone';
+import ProgressBar from 'components/progress-bar';
 import { localize } from 'i18n-calypso';
 import notices from 'notices';
 import debugFactory from 'debug';
+import { uploadTheme, clearThemeUpload } from 'state/themes/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isUploadInProgress,
+	isUploadComplete,
+	hasUploadFailed,
+	getUploadedThemeId,
+	getUploadError,
+	getUploadProgressTotal,
+	getUploadProgressLoaded,
+	isInstallInProgress,
+} from 'state/themes/upload-theme/selectors';
+import { getTheme } from 'state/themes/selectors';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
 class Upload extends React.Component {
+
+	constructor( props ) {
+		super( props );
+		const { siteId, inProgress } = this.props;
+		! inProgress && this.props.clearThemeUpload( siteId );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.siteId !== this.props.siteId ) {
+			const { siteId, inProgress } = this.props;
+			! inProgress && this.props.clearThemeUpload( siteId );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.complete && ! prevProps.complete ) {
+			this.successMessage();
+		} else if ( this.props.failed && ! prevProps.failed ) {
+			this.failureMessage();
+		}
+	}
+
+	successMessage() {
+		const { translate, uploadedTheme: theme } = this.props;
+		notices.success( translate( 'Successfully uploaded theme %(name)s', {
+			args: {
+				name: theme.name
+			}
+		} ) );
+	}
+
+	failureMessage() {
+		const { translate, error } = this.props;
+
+		debug( 'Error', error );
+
+		const errorCauses = {
+			exists: translate( 'Upload problem: Theme already installed on site.' ),
+			'Too Large': translate( 'Upload problem: Zip file too large to upload.' ),
+			incompatible: translate( 'Upload problem: Incompatible theme.' ),
+		};
+
+		const errorString = JSON.stringify( error );
+		const cause = find( errorCauses, ( v, key ) => {
+			return includes( errorString, key );
+		} );
+
+		notices.error( cause || translate( 'Problem uploading theme' ) );
+	}
 
 	onFileSelect = ( files ) => {
 		const { translate } = this.props;
@@ -37,9 +103,10 @@ class Upload extends React.Component {
 			return;
 		}
 		debug( 'zip file:', file );
+		this.props.uploadTheme( this.props.siteId, file );
 	}
 
-	render() {
+	renderDropZone() {
 		const { translate } = this.props;
 		const uploadPromptText = translate(
 			'Do you have a custom theme to upload to your site?'
@@ -52,26 +119,99 @@ class Upload extends React.Component {
 		);
 
 		return (
+			<div>
+				<span className="theme-upload__title">{ uploadPromptText }</span>
+				<span className="theme-upload__instructions">{ uploadInstructionsText }</span>
+				<div className="theme-upload__dropzone">
+					<DropZone onFilesDrop={ this.onFileSelect } />
+					<FilePicker accept="application/zip" onPick={ this.onFileSelect } >
+						<Gridicon
+							className="theme-upload__dropzone-icon"
+							icon="cloud-upload"
+							size={ 48 } />
+						{ dropText }
+					</FilePicker>
+				</div>
+			</div>
+		);
+	}
+
+	renderProgressBar() {
+		const {
+			translate,
+			progressTotal,
+			progressLoaded,
+			installing,
+		} = this.props;
+
+		const uploadingMessage = translate( 'Uploading your theme…' );
+		const installingMessage = translate( 'Installing your theme on site…' );
+
+		return (
+			<div>
+				<span className="theme-upload__title">
+					{ installing ? installingMessage : uploadingMessage }
+				</span>
+				<ProgressBar
+					value={ progressLoaded || 0 }
+					total={ progressTotal || 100 }
+					title={ translate( 'Uploading progress' ) }
+					isPulsing={ installing }
+				/>
+			</div>
+		);
+	}
+
+	renderTheme() {
+		const { uploadedTheme: theme, translate } = this.props;
+		return (
+			<div className="theme-upload__theme-sheet">
+				<span className="theme-upload__theme-name">{ theme.name }</span>
+				<span className="theme-upload__author">
+					{ translate( 'by ' ) }
+					<a href={ theme.author_uri }>{ theme.author }</a>
+				</span>
+				<img src={ theme.screenshot } />
+				<span className="theme-upload__description">{ theme.description }</span>
+			</div>
+		);
+	}
+
+	render() {
+		const { translate, inProgress, complete, failed } = this.props;
+		return (
 			<Main>
 				<HeaderCake onClick={ page.back }>{ translate( 'Upload theme' ) }</HeaderCake>
 				<Card>
-					<span className="theme-upload__prompt">{ uploadPromptText }</span>
-					<span className="theme-upload__instructions">{ uploadInstructionsText }</span>
-					<div className="theme-upload__dropzone">
-						<DropZone onFilesDrop={ this.onFileSelect } />
-						<FilePicker accept="application/zip" onPick={ this.onFileSelect } >
-							<Gridicon
-								className="theme-upload__dropzone-icon"
-								icon="cloud-upload"
-								size={ 48 } />
-							{ dropText }
-						</FilePicker>
-					</div>
+					{ ! inProgress && ! complete && this.renderDropZone() }
+					{ inProgress && this.renderProgressBar() }
+					{ complete && ! failed && this.renderTheme() }
 				</Card>
 			</Main>
 		);
 	}
 }
 
-export default localize( Upload );
-
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const themeId = getUploadedThemeId( state, siteId );
+		return {
+			siteId,
+			inProgress: isUploadInProgress( state, siteId ),
+			complete: isUploadComplete( state, siteId ),
+			failed: hasUploadFailed( state, siteId ),
+			uploadedTheme: getTheme( state, siteId, themeId ),
+			error: getUploadError( state, siteId ),
+			progressTotal: getUploadProgressTotal( state, siteId ),
+			progressLoaded: getUploadProgressLoaded( state, siteId ),
+			installing: isInstallInProgress( state, siteId ),
+		};
+	},
+	( dispatch ) => {
+		return bindActionCreators( {
+			uploadTheme,
+			clearThemeUpload,
+		}, dispatch );
+	},
+)( localize( Upload ) );

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -1,4 +1,4 @@
-.theme-upload__prompt {
+.theme-upload__title {
 	display: block;
 	color: darken( $gray, 20 );
 }
@@ -22,6 +22,23 @@
 		align-items: center;
 		height: 180px;
 	}
+}
+
+.theme-upload__theme-sheet {
+	span {
+		display: block;
+	}
+
+	img {
+		width: 300px;
+		margin: 20px;
+		border: 1px solid $gray;
+	}
+}
+
+.theme-upload__theme-name {
+	font-size: 24px;
+	font-weight: 600;
 }
 
 .theme-upload__dropzone-icon {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -433,6 +433,14 @@ export function clearActivated( siteId ) {
 	};
 }
 
+/**
+ * Triggers a theme upload to the given site.
+ *
+ * @param {Number} siteId -- Site to upload to
+ * @param {File} file -- the theme zip to upload
+ *
+ * @return {Function} the action function
+ */
 export function uploadTheme( siteId, file ) {
 	return dispatch => {
 		dispatch( {
@@ -465,11 +473,17 @@ export function uploadTheme( siteId, file ) {
 	};
 }
 
+/**
+ * Clears any state remaining from a previous
+ * theme upload to the given site.
+ *
+ * @param {Number} siteId -- site to clear state for
+ *
+ * @return {Object} the action object to dispatch
+ */
 export function clearThemeUpload( siteId ) {
-	return dispatch => {
-		dispatch( {
-			type: THEME_UPLOAD_CLEAR,
-			siteId,
-		} );
+	return {
+		type: THEME_UPLOAD_CLEAR,
+		siteId,
 	};
 }

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -33,6 +33,11 @@ import {
 	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEME_ACTIVATE_REQUEST_FAILURE,
 	THEMES_RECEIVE_SERVER_ERROR,
+	THEME_UPLOAD_START,
+	THEME_UPLOAD_SUCCESS,
+	THEME_UPLOAD_FAILURE,
+	THEME_UPLOAD_CLEAR,
+	THEME_UPLOAD_PROGRESS,
 } from 'state/action-types';
 import {
 	recordTracksEvent,
@@ -425,5 +430,46 @@ export function clearActivated( siteId ) {
 	return {
 		type: THEME_CLEAR_ACTIVATED,
 		siteId
+	};
+}
+
+export function uploadTheme( siteId, file ) {
+	return dispatch => {
+		dispatch( {
+			type: THEME_UPLOAD_START,
+			siteId,
+		} );
+		return wpcom.undocumented().uploadTheme( siteId, file, ( event ) => {
+			dispatch( {
+				type: THEME_UPLOAD_PROGRESS,
+				siteId,
+				loaded: event.loaded,
+				total: event.total
+			} );
+		} )
+			.then( ( theme ) => {
+				dispatch( receiveTheme( theme, siteId ) );
+				dispatch( {
+					type: THEME_UPLOAD_SUCCESS,
+					siteId,
+					themeId: theme.id,
+				} );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: THEME_UPLOAD_FAILURE,
+					siteId,
+					error
+				} );
+			} );
+	};
+}
+
+export function clearThemeUpload( siteId ) {
+	return dispatch => {
+		dispatch( {
+			type: THEME_UPLOAD_CLEAR,
+			siteId,
+		} );
 	};
 }

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -248,7 +248,7 @@ export default combineReducers( {
 	themeDetails,
 	themesList,
 	// New reducers:
-	// queries,
+	queries,
 	// queryRequests,
 	// themeRequests,
 	// activationRequests,

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -69,7 +69,7 @@ describe( 'reducer', () => {
 			'themeDetails',
 			'themesList',
 			// New reducers
-			//'queries',
+			'queries',
 			//'queryRequests',
 			//'themeRequests',
 			//'activeThemeRequests',


### PR DESCRIPTION
Adds working uploads to the page added in #9575. The whole page is behind the feature flag `manage/themes/upload`.

![theme_upload_3](https://cloud.githubusercontent.com/assets/7767559/20624371/741fb526-b304-11e6-968f-8cb0b4ff6b44.gif)

**To Test**
* Needs a .org site with Jetpack > 4.4
* Go to http://calypso.localhost:3000/design/upload/{jetpack site}
* Select or drag a theme zip to upload

Expected:
Theme should upload to jetpack site and show theme details

* Test some error cases (for example: existing theme, invalid zip)





