### PR TITLE
Taxonomy Manager: Fix switching sites

### DIFF
--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -34,7 +34,7 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'manage/site-settings/categories' ) ) {
-		page( '/settings/taxonomies/:site_id/:taxonomy', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.taxonomies );
+		page( '/settings/taxonomies/:taxonomy/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.taxonomies );
 	}
 
 	page( '/settings/:section', settingsController.legacyRedirects, controller.siteSelection, controller.sites );

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -18,7 +18,7 @@ import QueryTerms from 'components/data/query-terms';
 import Gridicon from 'components/gridicon';
 
 const TaxonomyCard = ( { count, labels, site, taxonomy } ) => {
-	const settingsLink = site ? `/settings/taxonomies/${ site.slug }/${ taxonomy }` : null;
+	const settingsLink = site ? `/settings/taxonomies/${ taxonomy }/${ site.slug }` : null;
 	const isLoading = ! labels.name || isUndefined( count );
 	const classes = classNames( 'taxonomies__card-title', {
 		'is-loading': isLoading


### PR DESCRIPTION
While testing out the Taxonomy Manager, I stumbled upon a bug that when using the site switcher while viewing post tags or categories, the resultant route would result in an error state:

![site-switch](https://cloud.githubusercontent.com/assets/22080/20609233/9a059682-b23e-11e6-8dfb-ae9a7018a1e5.gif)

This branch changes the route structure for the Taxonomy Manager pages, to better match the other routes in settings where the `:site_id` is the last fragment.

__To Test__
- Open a [Settings Writing Page](http://calypso.localhost:3000/settings/writing)
- Select Categories or Tags from the top of the page
- While viewing that taxonomy management page, use the site switcher in the sidebar and choose another site
- Verify the page updates with the categories or tags for the site you selected

/cc @youknowriad 