### PR TITLE
Help: Update live course dates and links

### DIFF
--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -31,32 +31,24 @@ function getCourses() {
 			),
 			schedule: [
 				{
-					date: i18n.moment( new Date( 'Tues, 8 Nov 2016 17:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/41e6b07223685cefd746f627e8486654'
-				},
-				{
-					date: i18n.moment( new Date( 'Thur, 10 Nov 2016 21:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/ee792031a8a1ac46cde7dc3c8da9331e'
-				},
-				{
-					date: i18n.moment( new Date( 'Tues, 15 Nov 2016 17:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/77c70936e27841fdc5b9141539e44ee6'
-				},
-				{
-					date: i18n.moment( new Date( 'Thur, 17 Nov 2016 21:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/54616e2abdab5bc0c5b9141539e44ee6'
-				},
-				{
-					date: i18n.moment( new Date( 'Tues, 22 Nov 2016 17:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/55cfed1ec7ebbe7a66858a512be5123a'
-				},
-				{
-					date: i18n.moment( new Date( 'Tues, 29 Nov 2016 17:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/5befd4070efdbacdd746f627e8486654'
-				},
-				{
 					date: i18n.moment( new Date( 'Thur, 1 Dec 2016 21:00:00 +0000' ) ),
 					registrationUrl: 'https://zoom.us/webinar/register/2b9f02639a37b3c034538d7d4481ef37'
+				},
+				{
+					date: i18n.moment( new Date( 'Tues, 6 Dec 2016 17:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/c94f4ef4fe99f8d98c34be5db4a05ad8'
+				},
+				{
+					date: i18n.moment( new Date( 'Thur, 8 Dec 2016 21:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/a69213fc2d8c050bc5b9141539e44ee6'
+				},
+				{
+					date: i18n.moment( new Date( 'Tues, 13 Dec 2016 17:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/7822f4075ca71dbf8c34be5db4a05ad8'
+				},
+				{
+					date: i18n.moment( new Date( 'Thur, 15 Dec 2016 21:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/6fbbf535429502c78c34be5db4a05ad8'
 				},
 			],
 			videos: [


### PR DESCRIPTION
This PR updates the live course listings on /help/courses. It removes old dates
and adds in future times.

## Testing
1. Log into WordPress.com on an account with a Business plan.
2. Visit wordpress.com/help/courses

In addition to 11/29 and 12/1, you should see the following (localized to your timezone):

- 12/6 Tuesday 9AM PST:
https://zoom.us/webinar/register/c94f4ef4fe99f8d98c34be5db4a05ad8
- 12/8 Thursday 1PM PST: 
https://zoom.us/webinar/register/a69213fc2d8c050bc5b9141539e44ee6
- 12/13 Tuesday 9AM PST: 
https://zoom.us/webinar/register/7822f4075ca71dbf8c34be5db4a05ad8
- 12/15 Thursday 1PM PST: 
https://zoom.us/webinar/register/6fbbf535429502c78c34be5db4a05ad8

## Screenshot

<img width="725" alt="screen shot 2016-11-24 at 2 24 37 pm" src="https://cloud.githubusercontent.com/assets/7240478/20610092/230b8082-b252-11e6-80ac-12b93d20d98f.png">
