### PR TITLE
Plans: Turn stuff from lib/plans into selectors in state/sites/plans/selectors

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -3,7 +3,6 @@
  */
 import moment from 'moment';
 import {
-	find,
 	get,
 	includes,
 	invoke
@@ -65,19 +64,6 @@ export function getSitePlanSlug( siteID ) {
 		site = sitesList.getSelectedSite();
 	}
 	return get( site, 'plan.product_slug' );
-}
-
-export function canUpgradeToPlan( planKey, site = sitesList.getSelectedSite() ) {
-	const plan = get( site, [ 'plan', 'expired' ], false ) ? PLAN_FREE : get( site, [ 'plan', 'product_slug' ], PLAN_FREE );
-	return get( getPlan( planKey ), 'availableFor', () => false )( plan );
-}
-
-export function getUpgradePlanSlugFromPath( path, siteID ) {
-	const site = siteID ? sitesList.getSite( siteID ) : sitesList.getSelectedSite();
-	return find( Object.keys( PLANS_LIST ), planKey => (
-		( planKey === path || getPlanPath( planKey ) === path ) &&
-		canUpgradeToPlan( planKey, site )
-	) );
 }
 
 export function getPlanPath( plan ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
-import {
-	get,
-	includes,
-	invoke
-} from 'lodash';
+import { get, includes, invoke } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,12 +20,10 @@ import {
 	PLAN_JETPACK_FREE,
 	PLAN_PERSONAL
 } from 'lib/plans/constants';
-import SitesList from 'lib/sites-list';
 
 /**
  * Module vars
  */
-const sitesList = SitesList();
 const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 
 export function isFreePlan( plan ) {
@@ -56,26 +50,12 @@ export function getFeatureTitle( feature ) {
 	return invoke( FEATURES_LIST, [ feature, 'getTitle' ] );
 }
 
-export function getSitePlanSlug( siteID ) {
-	let site;
-	if ( siteID ) {
-		site = sitesList.getSite( siteID );
-	} else {
-		site = sitesList.getSelectedSite();
-	}
-	return get( site, 'plan.product_slug' );
-}
-
 export function getPlanPath( plan ) {
 	return get( getPlan( plan ), 'getPathSlug', () => undefined )();
 }
 
 export function planHasFeature( plan, feature ) {
 	return includes( get( getPlan( plan ), 'getFeatures', () => [] )(), feature );
-}
-
-export function hasFeature( feature, siteID ) {
-	return planHasFeature( getSitePlanSlug( siteID ), feature );
 }
 
 export function getCurrentTrialPeriodInDays( plan ) {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -17,10 +17,14 @@ import PlanFeaturesItem from './item';
 import Popover from 'components/popover';
 import PlanFeaturesActions from './actions';
 import { isCurrentPlanPaid, isCurrentSitePlan, getSitePlan, getSiteSlug } from 'state/sites/selectors';
-import { isCurrentUserCurrentPlanOwner, getPlansBySiteId } from 'state/sites/plans/selectors';
+import {
+	canUpgradeToPlan,
+	getPlanDiscountedRawPrice,
+	getPlansBySiteId,
+	isCurrentUserCurrentPlanOwner
+} from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
 import {
 	getPlanRawPrice,
 	getPlan,
@@ -43,7 +47,6 @@ import {
 import { isFreePlan } from 'lib/plans';
 import {
 	getPlanPath,
-	canUpgradeToPlan,
 	applyTestFiltersToPlansList
 } from 'lib/plans';
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
@@ -517,7 +520,7 @@ export default connect(
 				const planObject = getPlan( state, planProductId );
 				const isLoadingSitePlans = ! isInSignup && ! sitePlans.hasLoadedFromServer;
 				const showMonthly = ! isMonthly( plan );
-				const available = isInSignup ? true : canUpgradeToPlan( plan ) && canPurchase;
+				const available = isInSignup ? true : canUpgradeToPlan( state, selectedSiteId, plan ) && canPurchase;
 				const relatedMonthlyPlan = showMonthly ? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) ) : null;
 				const popular = isPopular( plan ) && ! isPaid;
 				const newPlan = isNew( plan ) && ! isPaid;
@@ -575,4 +578,3 @@ export default connect(
 		recordTracksEvent
 	}
 )( localize( PlanFeatures ) );
-

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -36,13 +36,11 @@ const analytics = require( 'lib/analytics' ),
 	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
 	upgradesActions = require( 'lib/upgrades/actions' );
 
-import {
-	isValidFeatureKey,
-	getUpgradePlanSlugFromPath
-} from 'lib/plans';
+import { isValidFeatureKey } from 'lib/plans';
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
+import { getUpgradePlanSlugFromPath } from 'state/sites/plans/selectors';
 
 const Checkout = React.createClass( {
 	mixins: [ observe( 'sites', 'productsList' ) ],
@@ -112,7 +110,7 @@ const Checkout = React.createClass( {
 	},
 
 	addProductToCart: function() {
-		const planSlug = getUpgradePlanSlugFromPath( this.props.product );
+		const planSlug = this.props.getUpgradePlanSlugFromPath( this.props.sites.getSelectedSite().ID, this.props.product );
 
 		let cartItem,
 			cartMeta;
@@ -309,7 +307,8 @@ const Checkout = React.createClass( {
 module.exports = connect(
 	function( state ) {
 		return {
-			cards: getStoredCards( state )
+			cards: getStoredCards( state ),
+			getUpgradePlanSlugFromPath: ( siteId, path ) => getUpgradePlanSlugFromPath( state, siteId, path )
 		};
 	},
 	{

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { find, get, includes } from 'lodash';
+
+import { find, get } from 'lodash';
 import debugFactory from 'debug';
 import moment from 'moment';
 
@@ -12,7 +13,7 @@ import { initialSiteState } from './reducer';
 import { getSite } from 'state/sites/selectors';
 import { createSitePlanObject } from './assembler';
 import createSelector from 'lib/create-selector';
-import { getPlan, getPlanPath } from 'lib/plans';
+import { getPlan, getPlanPath, planHasFeature } from 'lib/plans';
 import { PLAN_FREE, PLANS_LIST } from 'lib/plans/constants';
 
 /**
@@ -212,11 +213,6 @@ export function isCurrentUserCurrentPlanOwner( state, siteId ) {
  */
 export function getSitePlanSlug( state, siteId ) {
 	return get( getCurrentPlan( state, siteId ), 'productSlug', null );
-}
-
-// Duplicated from lib/plans. Proper solution in https://github.com/Automattic/wp-calypso/pull/9635
-function planHasFeature( plan, feature ) {
-	return includes( get( PLANS_LIST[ plan ], 'getFeatures', () => [] )(), feature );
 }
 
 /**

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -12,7 +12,8 @@ import { initialSiteState } from './reducer';
 import { getSite } from 'state/sites/selectors';
 import { createSitePlanObject } from './assembler';
 import createSelector from 'lib/create-selector';
-import { PLANS_LIST } from 'lib/plans/constants';
+import { getPlan, getPlanPath } from 'lib/plans';
+import { PLAN_FREE, PLANS_LIST } from 'lib/plans/constants';
 
 /**
  * Module dependencies
@@ -228,4 +229,17 @@ function planHasFeature( plan, feature ) {
  */
 export function hasFeature( state, siteId, feature ) {
 	return planHasFeature( getSitePlanSlug( state, siteId ), feature );
+}
+
+export function canUpgradeToPlan( state, siteId, planKey ) {
+	const plan = getCurrentPlan( state, siteId );
+	const planSlug = get( plan, 'expired', false ) ? PLAN_FREE : get( plan, 'productSlug', PLAN_FREE );
+	return get( getPlan( planKey ), 'availableFor', () => false )( planSlug );
+}
+
+export function getUpgradePlanSlugFromPath( state, siteId, path ) {
+	return find( Object.keys( PLANS_LIST ), planKey => (
+		( planKey === path || getPlanPath( planKey ) === path ) &&
+		canUpgradeToPlan( state, siteId, planKey )
+	) );
 }


### PR DESCRIPTION
Also, remove `sites-list` dependency from both `lib/plans` and `my-sites/upgrade-nudge`.

TODO:
* Write tests for new selectors, `UpgradeNudge`
* It's possible that I still need to add a couple of query components where I'm now using selectors instead of the previous, `sites-list` based, `lib/plans` functions.

To test: Verify that Calypso still works.
* [`UpgradeNudge` component](http://calypso.localhost:3000/devdocs/blocks/upgrade-nudge)