### PR TITLE
Themes: Add `isThemePremium` selector

### DIFF
--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { every, some, includes, startsWith } from 'lodash';
+import { every, some, includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import PaginatedQueryManager from '../paginated';
 import ThemeQueryKey from './key';
+import { isPremium } from './util';
 import { DEFAULT_THEME_QUERY } from './constants';
 
 const SEARCH_TAXONOMIES = [ 'subject', 'feature', 'color', 'style', 'column', 'layout' ];
@@ -61,10 +62,8 @@ export default class ThemeQueryManager extends PaginatedQueryManager {
 					if ( ! value ) {
 						return true;
 					}
-					// TODO: Use isPremium() helper here once its module has fewer dependencies (SSR!)
 					const queryingForPremium = value === 'premium';
-					const isPremiumTheme = startsWith( theme.stylesheet, 'premium/' );
-					return queryingForPremium === isPremiumTheme;
+					return queryingForPremium === isPremium( theme );
 			}
 
 			return true;

--- a/client/lib/query-manager/theme/test/util.js
+++ b/client/lib/query-manager/theme/test/util.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isPremium } from '../util';
+
+describe( 'utils', () => {
+	describe( '#isPremium()', () => {
+		it( 'given no theme object, should return false', () => {
+			const premium = isPremium();
+			expect( premium ).to.be.false;
+		} );
+
+		it( 'given a theme object with no stylesheet attr, should return false', () => {
+			const premium = isPremium( {
+				id: 'twentysixteen'
+			} );
+			expect( premium ).to.be.false;
+		} );
+
+		it( 'given a theme object with a stylesheet attr that doesn\'t start with "premium/", should return false', () => {
+			const premium = isPremium( {
+				id: 'twentysixteen',
+				stylesheet: 'pub/twentysixteen'
+			} );
+			expect( premium ).to.be.false;
+		} );
+
+		it( 'given a theme object with a stylesheet attr that starts with "premium/", should return true', () => {
+			const premium = isPremium( {
+				id: 'mood',
+				stylesheet: 'premium/mood'
+			} );
+			expect( premium ).to.be.true;
+		} );
+	} );
+} );

--- a/client/lib/query-manager/theme/util.js
+++ b/client/lib/query-manager/theme/util.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { get, startsWith } from 'lodash';
+
+/**
+ * Whether a given theme object is premium.
+ *
+ * @param  {Object} theme Theme object
+ * @return {Boolean}      True if the theme is premium
+ */
+export function isPremium( theme ) {
+	const themeStylesheet = get( theme, 'stylesheet', false );
+	return themeStylesheet && startsWith( themeStylesheet, 'premium/' );
+}

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -16,16 +16,6 @@ import config from 'config';
 import { sectionify } from 'lib/route/path';
 import { oldShowcaseUrl, isPremiumTheme as isPremium } from 'state/themes/utils';
 
-export function getSignupUrl( theme ) {
-	let url = '/start/with-theme?ref=calypshowcase&theme=' + theme.id;
-
-	if ( isPremium( theme ) ) {
-		url += '&premium=true';
-	}
-
-	return url;
-}
-
 export function getPreviewUrl( theme, site ) {
 	if ( site && site.jetpack ) {
 		return site.options.admin_url + 'customize.php?theme=' + theme.id + '&return=' + encodeURIComponent( window.location );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -16,7 +16,8 @@ import {
 	getNormalizedThemesQuery,
 	getSerializedThemesQuery,
 	getSerializedThemesQueryWithoutPage
- } from './utils';
+} from './utils';
+import { isPremium } from 'lib/query-manager/theme/util';
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
@@ -416,6 +417,21 @@ export function getActiveTheme( state, siteId ) {
  */
 export function isThemeActive( state, themeId, siteId ) {
 	return getActiveTheme( state, siteId ) === themeId;
+}
+
+/**
+ * Whether a WPCOM theme given by its ID is premium.
+ *
+ * Note that we aren't using this selector yet since the necessary reducer (queries)
+ * isn't wired yet!
+ *
+ * @param  {Object} state   Global state tree
+ * @param  {Object} themeId Theme ID
+ * @return {Boolean}        True if the theme is premium
+ */
+export function isThemePremium( state, themeId ) {
+	const theme = getTheme( state, 'wpcom', themeId );
+	return isPremium( theme );
 }
 
 /**

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -26,6 +26,7 @@ import {
 	getThemeSignupUrl,
 	getActiveTheme,
 	isThemeActive,
+	isThemePremium,
 	isThemePurchased,
 } from '../selectors';
 import ThemeQueryManager from 'lib/query-manager/theme';
@@ -1120,6 +1121,67 @@ describe( 'themes selectors', () => {
 			);
 
 			expect( isActive ).to.be.true;
+		} );
+	} );
+
+	describe( '#isPremium()', () => {
+		it( 'given no theme object, should return false', () => {
+			const premium = isThemePremium(
+				{
+					themes: {
+						queries: {}
+					}
+				}
+			);
+			expect( premium ).to.be.false;
+		} );
+
+		it( 'given the ID of a theme that doesn\'t exist, should return false', () => {
+			const premium = isThemePremium(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { twentysixteen }
+							} )
+						}
+					}
+				},
+				'twentyumpteen'
+			);
+			expect( premium ).to.be.false;
+		} );
+
+		it( 'given the ID of a free theme, should return false', () => {
+			const premium = isThemePremium(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { twentysixteen }
+							} )
+						}
+					}
+				},
+				'twentysixteen'
+			);
+			expect( premium ).to.be.false;
+		} );
+
+		it( 'given the ID of a premium theme, should return false', () => {
+			const premium = isThemePremium(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { mood }
+							} )
+						}
+					}
+				},
+				'mood'
+			);
+			expect( premium ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
Adds an `isPremium()` util (that accepts a theme object as arg), and uses it inside `ThemeQueryManager`.
Uses that util to implement a `isThemePremium()` selector that accepts a theme ID as arg. 

Not wired yet -- only covered by unit tests.