### PR TITLE
Reader Feed Header: fix hover tooltip to say 'Visit this site'

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -92,7 +92,14 @@ class FeedHeader extends Component {
 					<div className="reader-feed-header__image" style={ headerColor ? { backgroundColor: '#' + headerColor } : null }>
 						{ headerImageUrl ? <img src={ headerImageUrl } /> : null }
 					</div>
-					{ this.state.siteish ? <Site site={ this.state.siteish } href={ this.state.siteish.URL } indicator={ false } /> : null }
+					{ this.state.siteish &&
+						<Site
+							site={ this.state.siteish }
+							homeLink={ true }
+							showHomeIcon={ false }
+							href={ this.state.siteish.URL }
+							indicator={ false } />
+					}
 					<div className="reader-feed-header__details">
 						<span className="reader-feed-header__description">{ ( site && site.get( 'description' ) ) }</span>
 					</div>

--- a/client/blocks/site/README.md
+++ b/client/blocks/site/README.md
@@ -21,3 +21,4 @@ render() {
 * `href (string)` - A URL to add to the anchor.
 * `isSelected (bool)` - Whether the site should be marked as selected.
 * `homeLink (bool)` - Whether the site should behave as a link to the site home URL
+* `showHomeIcon (bool)` - Whether to show a 'home' icon if homeLink is enabled

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import classnames from 'classnames';
-import noop from 'lodash/noop';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,6 +39,7 @@ export default React.createClass( {
 			isSelected: false,
 
 			homeLink: false,
+			showHomeIcon: true, // if homeLink is enabled
 			enableActions: false
 		};
 	},
@@ -54,7 +55,9 @@ export default React.createClass( {
 		isHighlighted: React.PropTypes.bool,
 		site: React.PropTypes.object.isRequired,
 		onClick: React.PropTypes.func,
-		enableActions: React.PropTypes.bool
+		enableActions: React.PropTypes.bool,
+		homeLink: React.PropTypes.bool,
+		showHomeIcon: React.PropTypes.bool
 	},
 
 	getInitialState() {
@@ -238,7 +241,7 @@ export default React.createClass( {
 								</div>
 								<div className="site__domain">{ site.domain }</div>
 							</div>
-							{ this.props.homeLink &&
+							{ this.props.homeLink && this.props.showHomeIcon &&
 								<span className="site__home">
 									<Gridicon icon="house" size={ 18 } />
 								</span>


### PR DESCRIPTION
When you hover over the site avatar and name, the tooltip currently says "Select this site".

This PR changes it to say "Visit this site" and makes some minor changes to the `Site` component to support this usage.

Before:

![2aa95d84-b0c5-11e6-938d-39edb40267a9](https://cloud.githubusercontent.com/assets/17325/20613769/0b84bdf4-b32c-11e6-9837-6eda0d6b78f5.png)

After:

<img width="212" alt="screen shot 2016-11-28 at 11 29 21" src="https://cloud.githubusercontent.com/assets/17325/20652439/082da2ea-b55e-11e6-97e1-45c80929282b.png">

Fixes #9591.