### PR TITLE
Taxonomy Manager: update taxonomy management page to have set page title

### DIFF
--- a/client/my-sites/site-settings/taxonomies/index.jsx
+++ b/client/my-sites/site-settings/taxonomies/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import page from 'page';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import HeaderCake from 'components/header-cake';
 import TaxonomyManager from 'blocks/taxonomy-manager';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
+import DocumentHead from 'components/data/document-head';
 
 const Taxonomies = ( { labels, postType, site, taxonomy } ) => {
 	const goBack = () => {
@@ -20,7 +22,8 @@ const Taxonomies = ( { labels, postType, site, taxonomy } ) => {
 	};
 
 	return (
-		<div className="main main-column" role="main">
+		<div className="main main-col	umn" role="main">
+			<DocumentHead title={ i18n.translate( 'Manage %(taxonomy)s', { args: { taxonomy: labels.name } } ) } />
 			<HeaderCake onClick={ goBack }>
 				<h1>{ labels.name }</h1>
 			</HeaderCake>

--- a/client/my-sites/site-settings/taxonomies/index.jsx
+++ b/client/my-sites/site-settings/taxonomies/index.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,14 +16,14 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import DocumentHead from 'components/data/document-head';
 
-const Taxonomies = ( { labels, postType, site, taxonomy } ) => {
+const Taxonomies = ( { translate, labels, postType, site, taxonomy } ) => {
 	const goBack = () => {
 		page( '/settings/writing/' + site.slug );
 	};
 
 	return (
-		<div className="main main-col	umn" role="main">
-			<DocumentHead title={ i18n.translate( 'Manage %(taxonomy)s', { args: { taxonomy: labels.name } } ) } />
+		<div className="main main-column" role="main">
+			<DocumentHead title={ translate( 'Manage %(taxonomy)s', { args: { taxonomy: labels.name } } ) } />
 			<HeaderCake onClick={ goBack }>
 				<h1>{ labels.name }</h1>
 			</HeaderCake>
@@ -32,7 +32,7 @@ const Taxonomies = ( { labels, postType, site, taxonomy } ) => {
 	);
 };
 
-export default connect(
+export default localize( connect(
 	( state, { taxonomy, postType } ) => {
 		const siteId = getSelectedSiteId( state );
 		const site = getSelectedSite( state );
@@ -42,4 +42,4 @@ export default connect(
 			labels
 		};
 	}
-)( Taxonomies );
+)( Taxonomies ) );


### PR DESCRIPTION
There is currently an issue where if you refresh the page(s) where you manage categories or tags, the browser page title reverts to the site's title.

Example:

![before](https://cloud.githubusercontent.com/assets/128826/20615954/0d2dc74c-b32a-11e6-86c2-dcf3f35853c7.gif)

This PR adds specific page titles to the manage taxonomy terms pages so this bug no longer appears:

![after](https://cloud.githubusercontent.com/assets/128826/20615960/1611c3ae-b32a-11e6-9ae5-7b3c1addc51f.gif)
