### PR TITLE
Taxonomies: Show the default category on the taxonomy card

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -190,6 +190,9 @@ $z-layers: (
 		'.following-edit__subscribe-form .card.is-search-result': 35,
 		'.following-edit__subscribe-form .search': 36
 	),
+	'.site-settings__taxonomies': (
+		'.card__link-indicator': 1
+	),
 
 	// The following may be inserted into different areas.
 	// The parent stacking context may be root, or something else depending on where it is inserted.

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -18,11 +18,15 @@
 	overflow: hidden;
 
 	&:after {
-		@include long-content-fade();
+		@include long-content-fade( $size: 40% );
 	}
 
 	.gridicon {
 		padding-right: 5px;
 		vertical-align: top;
 	}
+}
+
+.site-settings__taxonomies .card__link-indicator {
+	z-index: z-index( '.site-settings__taxonomies', '.card__link-indicator' );
 }

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -14,6 +14,12 @@
 .taxonomies__card-content {
 	color: $gray;
 	font-size: 13px;
+	white-space: nowrap;
+	overflow: hidden;
+
+	&:after {
+		@include long-content-fade();
+	}
 
 	.gridicon {
 		padding-right: 5px;

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -5,19 +5,23 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get, isUndefined } from 'lodash';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
-import { countFoundTermsForQuery } from 'state/terms/selectors';
+import { countFoundTermsForQuery, getTerm } from 'state/terms/selectors';
+import { getSiteSettings } from 'state/site-settings/selectors';
+import { decodeEntities } from 'lib/formatting';
 
 import CompactCard from 'components/card/compact';
 import QueryTerms from 'components/data/query-terms';
+import QuerySiteSettings from 'components/data/query-site-settings';
 import Gridicon from 'components/gridicon';
 
-const TaxonomyCard = ( { count, labels, site, taxonomy } ) => {
+const TaxonomyCard = ( { count, defaultTerm, labels, site, taxonomy, translate } ) => {
 	const settingsLink = site ? `/settings/taxonomies/${ taxonomy }/${ site.slug }` : null;
 	const isLoading = ! labels.name || isUndefined( count );
 	const classes = classNames( 'taxonomies__card-title', {
@@ -26,11 +30,17 @@ const TaxonomyCard = ( { count, labels, site, taxonomy } ) => {
 
 	return (
 		<CompactCard href={ settingsLink }>
+			{ site && <QuerySiteSettings siteId={ site.ID } /> }
 			{ site && <QueryTerms siteId={ site.ID } taxonomy={ taxonomy }	query={ {} } /> }
 			<h2 className={ classes }>{ labels.name }</h2>
 			{ ! isLoading &&
 				<div className="taxonomies__card-content">
 					<Gridicon icon="tag" size={ 18 } /> { count } { labels.name }
+					{ defaultTerm &&
+						<span>
+							, { translate( 'default category:' ) } { decodeEntities( defaultTerm.name ) }
+						</span>
+					}
 				</div>
 			}
 		</CompactCard>
@@ -43,10 +53,14 @@ export default connect(
 		const site = getSelectedSite( state );
 		const labels = get( getPostTypeTaxonomy( state, siteId, postType, taxonomy ), 'labels', {} );
 		const count = countFoundTermsForQuery( state, siteId, taxonomy, {} );
+		const siteSettings = getSiteSettings( state, siteId );
+		const hasDefaultTerm = taxonomy === 'category';
+		const defaultTerm = hasDefaultTerm && getTerm( state, siteId, taxonomy, get( siteSettings, [ 'default_category' ] ) );
 		return {
 			count,
+			defaultTerm,
 			labels,
 			site
 		};
 	}
-)( TaxonomyCard );
+)( localize( TaxonomyCard ) );


### PR DESCRIPTION
This PR shows the default category on the taxonomy card (like Davide's mockup)

<img width="731" alt="capture d ecran 2016-11-25 a 12 04 35 pm" src="https://cloud.githubusercontent.com/assets/272444/20623453/f50dd25a-b307-11e6-8968-0302316247a7.png">

**Testing instructions**

 * Just make sure the default category shows up correctly on the taxonomy card.

cc @timmyc 