### PR TITLE
Plugins: Show Jetpack as already installed for WordPress.com sites

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -6,13 +6,16 @@ import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 import some from 'lodash/some';
 import get from 'lodash/get';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import Button from 'components/button';
 import Card from 'components/card';
 import Count from 'components/count';
+import Gridicon from 'components/gridicon';
 import NoticeAction from 'components/notice/notice-action';
 import ExternalLink from 'components/external-link';
 import Notice from 'components/notice';
@@ -65,6 +68,16 @@ export default React.createClass( {
 		return isBusiness( this.props.selectedSite.plan ) || isEnterprise( this.props.selectedSite.plan );
 	},
 
+	isWpcomPreinstalled: function() {
+		const installedPlugins = [ 'Jetpack by WordPress.com', 'Akismet' ];
+
+		if ( ! this.props.selectedSite ) {
+			return false;
+		}
+
+		return ! this.props.selectedSite.jetpack && includes( installedPlugins, this.props.plugin.name );
+	},
+
 	renderActions() {
 		if ( ! this.props.selectedSite ) {
 			return (
@@ -88,8 +101,18 @@ export default React.createClass( {
 			return;
 		}
 
-		if ( this.props.isInstalledOnSite === null && this.props.selectedSite.jetpack) {
+		if ( this.props.isInstalledOnSite === null && this.props.selectedSite.jetpack ) {
 			return;
+		}
+
+		if ( this.isWpcomPreinstalled() ) {
+			return (
+				<div className="plugin-meta__actions">
+					<Button className="" compact borderless>
+						<Gridicon icon="checkmark" />{ this.translate( 'Active' ) }
+					</Button>
+				</div>
+			);
 		}
 
 		if ( this.props.isInstalledOnSite === false || ! this.props.selectedSite.jetpack ) {
@@ -324,11 +347,11 @@ export default React.createClass( {
 					}
 				</Card>
 
-				{ ( get( this.props.selectedSite, 'jetpack' ) || this.hasBusinessPlan() ) &&
+				{ ( get( this.props.selectedSite, 'jetpack' ) || this.hasBusinessPlan() || this.isWpcomPreinstalled() ) &&
 					<div style={ { marginBottom: 16 } } />
 				}
 
-				{ ! get( this.props.selectedSite, 'jetpack' ) && ! this.hasBusinessPlan() &&
+				{ ! get( this.props.selectedSite, 'jetpack' ) && ! this.hasBusinessPlan() && ! this.isWpcomPreinstalled() &&
 					<div className="plugin-meta__upgrade_nudge">
 						<UpgradeNudge
 							feature={ FEATURE_UPLOAD_PLUGINS }

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -108,7 +108,7 @@ export default React.createClass( {
 		if ( this.isWpcomPreinstalled() ) {
 			return (
 				<div className="plugin-meta__actions">
-					<Button className="" compact borderless>
+					<Button className="plugin-meta__active" compact borderless>
 						<Gridicon icon="checkmark" />{ this.translate( 'Active' ) }
 					</Button>
 				</div>

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -155,6 +155,10 @@
 	padding: 0;
 }
 
+.plugin-meta__actions .plugin-meta__active {
+	color: $alert-green;
+}
+
 a.plugin-meta__settings-link {
 	color: $gray;
 	display: block;

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,19 +1,21 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
+import { connect } from 'react-redux';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var PluginIcon = require( 'my-sites/plugins/plugin-icon/plugin-icon' ),
-	PluginsStore = require( 'lib/plugins/store' ),
-	Rating = require( 'components/rating/' ),
-	analytics = require( 'lib/analytics' );
+import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
+import PluginsStore from 'lib/plugins/store';
+import Rating from 'components/rating/';
+import analytics from 'lib/analytics';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
-module.exports = React.createClass( {
-
-	displayName: 'PluginsBrowserListElement',
+const PluginsBrowserListElement = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
@@ -43,9 +45,22 @@ module.exports = React.createClass( {
 		} );
 	},
 
+	isWpcomPreinstalled: function() {
+		const installedPlugins = [
+			'Jetpack by WordPress.com',
+			'Akismet',
+		];
+
+		if ( ! this.props.site ) {
+			return false;
+		}
+
+		return ! this.props.isJetpackSite && includes( installedPlugins, this.props.plugin.name );
+	},
+
 	renderInstalledIn: function() {
 		var sites = this.getSites();
-		if ( sites && sites.length > 0 ) {
+		if ( sites && sites.length > 0 || this.isWpcomPreinstalled() ) {
 			return (
 				<div className="plugins-browser-item__installed">
 						{ this.translate( 'Installed' ) }
@@ -89,3 +104,13 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			isJetpackSite: isJetpackSite( state, selectedSiteId ),
+		};
+	}
+)( PluginsBrowserListElement );

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -46,10 +46,7 @@ const PluginsBrowserListElement = React.createClass( {
 	},
 
 	isWpcomPreinstalled: function() {
-		const installedPlugins = [
-			'Jetpack by WordPress.com',
-			'Akismet',
-		];
+		const installedPlugins = [ 'Jetpack by WordPress.com', 'Akismet' ];
 
 		if ( ! this.props.site ) {
 			return false;


### PR DESCRIPTION
Closes #9574.

Display Jetpack and Akismet as installed in the plugins directory page, and the plugin detail page for WordPress.com sites.

Visual changes:

![jetpackinstalled](https://cloud.githubusercontent.com/assets/1182160/20634438/4cbe0332-b351-11e6-9dd7-2a07de8c92bf.png)

Plugin detail page:

![plugindetail](https://cloud.githubusercontent.com/assets/1182160/20664031/eee01c18-b559-11e6-86c4-bee1cb67730f.png)

