### PR TITLE
Plans: Add getSitePlanSlug() and planHasFeatures() selectors

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -32,6 +32,7 @@ import { getForumUrl } from 'my-sites/themes/helpers';
 import { isPremiumTheme as isPremium } from 'state/themes/utils';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCurrentTheme from 'components/data/query-current-theme';
+import QuerySitePlans from 'components/data/query-site-plans';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
 import { connectOptions } from 'my-sites/themes/theme-options';
@@ -431,6 +432,7 @@ const ThemeSheet = React.createClass( {
 			<Main className="theme__sheet">
 				<QueryThemeDetails id={ this.props.id } siteId={ siteID } />
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
+				{ siteID && <QuerySitePlans siteId={ siteID } /> }
 				<DocumentHead
 					title={ title }
 					meta={ metas }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -14,6 +14,7 @@ import JetpackReferrerMessage from './jetpack-referrer-message';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import { connectOptions } from './theme-options';
+import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 
@@ -45,6 +46,7 @@ export default connectOptions(
 
 		return (
 			<ThemeShowcase { ...props } siteId={ siteId }>
+				{ siteId && <QuerySitePlans siteId={ siteId } /> }
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 				<SidebarNavigation />
 				<ThanksModal

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -12,6 +12,7 @@ import ThanksModal from 'my-sites/themes/thanks-modal';
 import { connectOptions } from './theme-options';
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 
@@ -21,6 +22,7 @@ export default connectOptions(
 
 		return (
 			<ThemeShowcase { ...props } siteId={ siteId }>
+				{ siteId && <QuerySitePlans siteId={ siteId } /> }
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 				<SidebarNavigation />
 				<ThanksModal

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -25,7 +25,9 @@ import {
 } from 'state/themes/selectors';
 import { isActiveTheme as isActive } from 'state/themes/current-theme/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import { hasFeature } from 'state/sites/plans/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
 const purchase = config.isEnabled( 'upgrades/checkout' )
 	? {
@@ -37,6 +39,7 @@ const purchase = config.isEnabled( 'upgrades/checkout' )
 			comment: 'label for selecting a site for which to purchase a theme'
 		} ),
 		getUrl: getPurchaseUrl,
+		hideForSite: ( state, siteId ) => hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 		hideForTheme: ( state, theme, siteId ) =>
 			! theme.price || isActive( state, theme.id, siteId ) || isPurchased( state, theme.id, siteId )
 	}
@@ -46,8 +49,13 @@ const activate = {
 	label: i18n.translate( 'Activate' ),
 	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
 	action: activateTheme,
-	hideForTheme: ( state, theme, siteId ) =>
-		isActive( state, theme.id, siteId ) || ( theme.price && ! isPurchased( state, theme.id, siteId ) )
+	hideForTheme: ( state, theme, siteId ) => (
+		isActive( state, theme.id, siteId ) || (
+			theme.price &&
+			! isPurchased( state, theme.id, siteId ) &&
+			! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )
+		)
+	)
 };
 
 const customize = {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -16,8 +16,10 @@ import StickyPanel from 'components/sticky-panel';
 import analytics from 'lib/analytics';
 import buildUrl from 'lib/mixins/url-search/build-url';
 import { getSiteSlug } from 'state/sites/selectors';
+import { hasFeature } from 'state/sites/plans/selectors';
 import { isActiveTheme } from 'state/themes/current-theme/selectors';
 import { isThemePurchased } from 'state/themes/selectors';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 import {
 	getFilter,
 	getSortedFilterTerms,
@@ -163,10 +165,15 @@ export default connect(
 	( state, { siteId } ) => ( {
 		siteSlug: getSiteSlug( state, siteId ),
 		isActiveTheme: themeId => isActiveTheme( state, themeId, siteId ),
-		// Note: This component assumes that purchase data is already present in the state tree
-		// (used by the isThemePurchased selector). At the time of implementation there's no caching
-		// in <QuerySitePurchases /> and a parent component is already rendering it. So to avoid
-		// redundant AJAX requests, we're not rendering the query component locally.
-		isThemePurchased: themeId => isThemePurchased( state, themeId, siteId )
+		isThemePurchased: themeId => (
+			// Note: This component assumes that purchase and data is already present in the state tree
+			// (used by the isThemePurchased selector). At the time of implementation there's no caching
+			// in <QuerySitePurchases /> and a parent component is already rendering it. So to avoid
+			// redundant AJAX requests, we're not rendering the query component locally.
+			isThemePurchased( state, themeId, siteId ) ||
+			// The same is true for the `hasFeature` selector, which relies on the presence of
+			// a `<QuerySitePlans />` component in a parent component.
+			hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )
+		)
 	} )
 )( ThemesSelection );

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import find from 'lodash/find';
-import get from 'lodash/get';
+import { find, get, includes } from 'lodash';
 import debugFactory from 'debug';
 import moment from 'moment';
 
@@ -13,6 +12,7 @@ import { initialSiteState } from './reducer';
 import { getSite } from 'state/sites/selectors';
 import { createSitePlanObject } from './assembler';
 import createSelector from 'lib/create-selector';
+import { PLANS_LIST } from 'lib/plans/constants';
 
 /**
  * Module dependencies
@@ -200,4 +200,32 @@ export function isCurrentUserCurrentPlanOwner( state, siteId ) {
 	const currentPlan = getCurrentPlan( state, siteId );
 
 	return get( currentPlan, 'userIsOwner', false );
+}
+
+/**
+ * Returns a site's current plan's product slug
+ *
+ * @param  {Object}  state   Global State tree
+ * @param  {Number}  siteId  Site ID
+ * @return {String}          The site's current plan's product slug
+ */
+export function getSitePlanSlug( state, siteId ) {
+	return get( getCurrentPlan( state, siteId ), 'productSlug', null );
+}
+
+// Duplicated from lib/plans. Proper solution in https://github.com/Automattic/wp-calypso/pull/9635
+function planHasFeature( plan, feature ) {
+	return includes( get( PLANS_LIST[ plan ], 'getFeatures', () => [] )(), feature );
+}
+
+/**
+ * Whether a site's current plan includes a given feature
+ *
+ * @param  {Object}  state   Global State tree
+ * @param  {Number}  siteId  Site ID
+ * @param  {String}  feature The feature we're looking for
+ * @return {Boolean}         True if the site's current plan includes the feature
+ */
+export function hasFeature( state, siteId, feature ) {
+	return planHasFeature( getSitePlanSlug( state, siteId ), feature );
 }

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -18,8 +18,11 @@ import {
 	hasDomainCredit,
 	isCurrentUserCurrentPlanOwner,
 	isRequestingSitePlans,
-	isSitePlanDiscounted
+	isSitePlanDiscounted,
+	getSitePlanSlug,
+	hasFeature
 } from '../selectors';
+import { PLAN_PREMIUM, PLAN_BUSINESS, FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
 describe( 'selectors', () => {
 	describe( '#getPlansBySite()', () => {
@@ -652,6 +655,130 @@ describe( 'selectors', () => {
 
 		it( 'should return true if user is a plan owner', () => {
 			expect( isCurrentUserCurrentPlanOwner( state, 77203074 ) ).to.be.true;
+		} );
+	} );
+
+	describe( '#getSitePlanSlug()', () => {
+		it( 'should return null if no plan data is found for the given siteId', () => {
+			expect( getSitePlanSlug(
+				{
+					sites: {
+						plans: {
+							2916284: {}
+						}
+					}
+				},
+				2916284
+			) ).to.be.null;
+		} );
+
+		it( 'should return the given site\'s current plan\'s product slug', () => {
+			expect( getSitePlanSlug(
+				{
+					sites: {
+						plans: {
+							2916284: {
+								data: [ {
+									currentPlan: true,
+									productSlug: PLAN_PREMIUM
+								} ]
+							}
+						}
+					}
+				},
+				2916284
+			) ).to.equal( PLAN_PREMIUM );
+		} );
+	} );
+
+	describe( '#hasFeature()', () => {
+		it( 'should return false if no siteId is given', () => {
+			expect( hasFeature(
+				{
+					sites: {
+						plans: {
+							2916284: {
+								data: [ {
+									currentPlan: true,
+									productSlug: PLAN_BUSINESS
+								} ]
+							}
+						}
+					}
+				},
+				null,
+				FEATURE_UNLIMITED_PREMIUM_THEMES
+			) ).to.be.false;
+		} );
+
+		it( 'should return false if no feature is given', () => {
+			expect( hasFeature(
+				{
+					sites: {
+						plans: {
+							2916284: {
+								data: [ {
+									currentPlan: true,
+									productSlug: PLAN_BUSINESS
+								} ]
+							}
+						}
+					}
+				},
+				2916284
+			) ).to.be.false;
+		} );
+
+		it( 'should return false if no plan data is found for the given siteId', () => {
+			expect( hasFeature(
+				{
+					sites: {
+						plans: {
+							2916284: {}
+						}
+					}
+				},
+				2916284,
+				FEATURE_UNLIMITED_PREMIUM_THEMES
+			) ).to.be.false;
+		} );
+
+		it( 'should return false if the site\'s current plan doesn\'t include the specified feature', () => {
+			expect( hasFeature(
+				{
+					sites: {
+						plans: {
+							2916284: {
+								data: [ {
+									currentPlan: true,
+									productSlug: PLAN_PREMIUM
+								} ]
+							}
+						}
+					}
+				},
+				2916284,
+				FEATURE_UNLIMITED_PREMIUM_THEMES
+			) ).to.be.false;
+		} );
+
+		it( 'should return true if the site\'s current plan includes the specified feature', () => {
+			expect( hasFeature(
+				{
+					sites: {
+						plans: {
+							2916284: {
+								data: [ {
+									currentPlan: true,
+									productSlug: PLAN_BUSINESS
+								} ]
+							}
+						}
+					}
+				},
+				2916284,
+				FEATURE_UNLIMITED_PREMIUM_THEMES
+			) ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
Down-sized version of #9635, limited to the stuff we really need for https://github.com/Automattic/wp-calypso/milestone/136

Rationale is that we can't use `lib/plans` from any selectors that are supposed to work on the server side (theme showcase!) since it contains a `sites-list` import (which breaks SSR). Proper fix is in #9635, but that will need way more testing and possibly some more query components inserted in various places. This PR keeps the changes to a minimum, which has the downside of duplicating a helper function or two. It does use the new selector in the relevant places however, but that shouldn't change any behavior, as long as we're still relying on `theme.price`, too.

Note -- no tests for the `planHasFeature()` helper. This is a helper that's used only by `hasFeature` right now, and will be removed by #9635 in favor of the "original" in `lib/plans`.

To test:

* In logged-out, multi-site, and single-site mode for a site without a Business plan:
  * Verify that Premium themes that haven't been purchased yet are displayed with their price, have a `Purchase` (and no `Activate`) item in their '...' menu, and can be purchased.
  * Verify that the opposite is true for premium themes that _have_ been purchased (i.e. no price shown, `Activate`, no `Purchase` item, can be activated).
* In single-site mode for a site _with_ a Business plan:
  * Verify that all Premium themes are displayed without a price, have an `Activate` item in their '...' menu, and can be activated.