### PR TITLE
Add completedActivationRequests

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -37,7 +37,7 @@ const ThanksModal = React.createClass( {
 	},
 
 	onCloseModal() {
-		this.props.clearActivated();
+		this.props.clearActivated( this.props.site.ID );
 		this.setState( { show: false } );
 	},
 

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -183,12 +183,6 @@ export function legacyReceiveThemes( data, site, queryParams, responseTime ) {
 	};
 }
 
-export function clearActivated() {
-	return {
-		type: THEME_CLEAR_ACTIVATED
-	};
-}
-
 // Set destination for 'back' button on theme sheet
 export function setBackPath( path ) {
 	return {
@@ -417,4 +411,18 @@ export function themeActivated( theme, siteId, source = 'unknown', purchased = f
 		dispatch( withAnalytics( trackThemeActivation, action ) );
 	};
 	return themeActivatedThunk; // it is named function just for testing purposes
+}
+
+/**
+ * Returns an action object to be used in signalling that theme activated status
+ * for site should be cleared
+ *
+ * @param  {Number}   siteId    Site ID
+ * @return {Object}        Action object
+ */
+export function clearActivated( siteId ) {
+	return {
+		type: THEME_CLEAR_ACTIVATED,
+		siteId
+	};
 }

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -22,6 +22,7 @@ import {
 	THEME_ACTIVATE_REQUEST,
 	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEME_ACTIVATE_REQUEST_FAILURE,
+	THEME_CLEAR_ACTIVATED,
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
 	ACTIVE_THEME_REQUEST_FAILURE,
@@ -57,7 +58,7 @@ export const activeThemes = createReducer( {}, {
 	activeThemesSchema
  );
 
- /**
+/**
  * Returns the updated theme activation state after an action has been
  * dispatched. The state reflects a mapping of site ID to a boolean
  * reflecting whether a theme is being activated on that site.
@@ -83,6 +84,26 @@ export function activationRequests( state = {}, action ) {
 
 	return state;
 }
+
+/**
+ * Returns the updated completed theme activation requess state after an action has been
+ * dispatched. The state reflects a mapping of site ID to boolean, reflecting whether
+ * activation request has finished or has been cleared.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const completedActivationRequests = createReducer( {}, {
+	[ THEME_ACTIVATE_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( {
+		...state,
+		[ siteId ]: true,
+	} ),
+	[ THEME_CLEAR_ACTIVATED ]: ( state, { siteId } ) => ( {
+		...state,
+		[ siteId ]: false,
+	} ) }
+);
 
 /**
  * Returns the updated active theme request state after an action has been

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -15,6 +15,7 @@ import {
 	THEME_ACTIVATE_REQUEST,
 	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEME_ACTIVATE_REQUEST_FAILURE,
+	THEME_CLEAR_ACTIVATED,
 	THEME_REQUEST,
 	THEME_REQUEST_SUCCESS,
 	THEME_REQUEST_FAILURE,
@@ -25,6 +26,7 @@ import {
 } from 'state/action-types';
 import {
 	themeActivated,
+	clearActivated,
 	activateTheme,
 	requestActiveTheme,
 	receiveTheme,
@@ -331,6 +333,16 @@ describe( 'actions', () => {
 
 			themeActivated( { id: 'twentysixteen' }, 2211667 )( spy, fakeGetState );
 			expect( spy ).to.have.been.calledWith( expectedActivationSuccess );
+		} );
+	} );
+
+	describe( '#clearActivated()', () => {
+		it( 'should return an action object', () => {
+			const action = clearActivated( 22116677 );
+			expect( action ).to.eql( {
+				type: THEME_CLEAR_ACTIVATED,
+				siteId: 22116677
+			} );
 		} );
 	} );
 

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -21,6 +21,7 @@ import {
 	THEME_ACTIVATE_REQUEST,
 	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEME_ACTIVATE_REQUEST_FAILURE,
+	THEME_CLEAR_ACTIVATED,
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
@@ -31,6 +32,7 @@ import reducer, {
 	activeThemes,
 	activationRequests,
 	activeThemeRequests,
+	completedActivationRequests,
 } from '../reducer';
 import ThemeQueryManager from 'lib/query-manager/theme';
 
@@ -71,6 +73,7 @@ describe( 'reducer', () => {
 			//'queryRequests',
 			//'themeRequests',
 			//'activeThemeRequests',
+			//'completedActivationRequests',
 			'currentTheme',
 			'themesUI'
 		] );
@@ -568,6 +571,54 @@ describe( 'reducer', () => {
 
 		it( 'never loads persisted state', () => {
 			const state = activationRequests( deepFreeze( {
+				2916284: true
+			} ), {
+				type: DESERIALIZE
+			} );
+
+			expect( state ).to.deep.equal( {} );
+		} );
+	} );
+
+	describe( '#completedActivationRequests()', () => {
+		it( 'should default to an empty object', () => {
+			const state = completedActivationRequests( undefined, {} );
+
+			expect( state ).to.deep.equal( {} );
+		} );
+
+		it( 'should track theme activate request success', () => {
+			const state = completedActivationRequests( deepFreeze( {} ), {
+				type: THEME_ACTIVATE_REQUEST_SUCCESS,
+				siteId: 2211667,
+			} );
+
+			expect( state ).to.have.keys( [ '2211667' ] );
+			expect( state ).to.deep.equal( { 2211667: true } );
+		} );
+
+		it( 'should track theme clear activated', () => {
+			const state = completedActivationRequests( deepFreeze( { 2211667: true } ), {
+				type: THEME_CLEAR_ACTIVATED,
+				siteId: 2211667,
+			} );
+
+			expect( state ).to.have.keys( [ '2211667' ] );
+			expect( state ).to.deep.equal( { 2211667: false } );
+		} );
+
+		it( 'never persists state', () => {
+			const state = completedActivationRequests( deepFreeze( {
+				2916284: true
+			} ), {
+				type: SERIALIZE
+			} );
+
+			expect( state ).to.deep.equal( {} );
+		} );
+
+		it( 'never loads persisted state', () => {
+			const state = completedActivationRequests( deepFreeze( {
 				2916284: true
 			} ), {
 				type: DESERIALIZE


### PR DESCRIPTION
This PR adds new reducer `completedActivationRequests` that sets state describing that activation requests has completed. It also adds accompanying action that allows clearing of this state.

Previously this had no association to site, now this state is bounded with site.

Affects themes thanks modal.
