### PR TITLE
Use babel class-properties transformation to easily bind methods

### DIFF
--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -58,10 +58,6 @@ class DailyPostButton extends React.Component {
 
 		this._closeTimerId = null;
 		this._isMounted = false;
-
-		[ 'openEditorWithSite', 'toggle', 'closeMenu', 'renderSitesPopover' ].forEach(
-			( method ) => this[ method ] = this[ method ].bind( this )
-		);
 	}
 
 	static propTypes = {
@@ -97,7 +93,7 @@ class DailyPostButton extends React.Component {
 		} );
 	}
 
-	openEditorWithSite( siteSlug ) {
+	openEditorWithSite = ( siteSlug ) => {
 		const pingbackAttributes = getPingbackAttributes( this.props.post );
 
 		recordAction( 'daily_post_challenge' );
@@ -110,7 +106,7 @@ class DailyPostButton extends React.Component {
 		return true;
 	}
 
-	toggle( event ) {
+	toggle = ( event ) => {
 		preventDefault( event );
 		if ( ! this.state.showingMenu ) {
 			recordAction( 'open_daily_post_challenge' );
@@ -125,7 +121,7 @@ class DailyPostButton extends React.Component {
 		this.deferMenuChange( ! this.state.showingMenu );
 	}
 
-	closeMenu() {
+	closeMenu = () => {
 		// have to defer this to let the mouseup / click escape.
 		// If we don't defer and remove the DOM node on this turn of the event loop,
 		// Chrome (at least) will not fire the click
@@ -134,7 +130,7 @@ class DailyPostButton extends React.Component {
 		}
 	}
 
-	renderSitesPopover() {
+	renderSitesPopover = () => {
 		return (
 			<SitesPopover
 				key="menu"


### PR DESCRIPTION
Hi there,

I was going around through the repo, to gather information for another pull request on which I'm working, and I noticed the way this component is binding its methods.

We're already using babel's class-properties transformation in other places; the code should be easier to read now.

What do you think?

cc. @bluefuton 