### PR TITLE
Add activationRequests reducer.

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -58,9 +58,9 @@ export const activeThemes = createReducer( {}, {
  );
 
  /**
- * Returns the updated active theme activation state after an action has been
+ * Returns the updated theme activation state after an action has been
  * dispatched. The state reflects a mapping of site ID to a boolean
- * reflecting whether a theme activation action is in progress.
+ * reflecting whether a theme is being activated on that site.
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Action payload

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -19,7 +19,9 @@ import {
 	THEMES_REQUEST,
 	THEMES_REQUEST_SUCCESS,
 	THEMES_REQUEST_FAILURE,
+	THEME_ACTIVATE_REQUEST,
 	THEME_ACTIVATE_REQUEST_SUCCESS,
+	THEME_ACTIVATE_REQUEST_FAILURE,
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
 	ACTIVE_THEME_REQUEST_FAILURE,
@@ -54,6 +56,33 @@ export const activeThemes = createReducer( {}, {
 	} ) },
 	activeThemesSchema
  );
+
+ /**
+ * Returns the updated active theme activation state after an action has been
+ * dispatched. The state reflects a mapping of site ID to a boolean
+ * reflecting whether a theme activation action is in progress.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function activationRequests( state = {}, action ) {
+	switch ( action.type ) {
+		case THEME_ACTIVATE_REQUEST:
+		case THEME_ACTIVATE_REQUEST_SUCCESS:
+		case THEME_ACTIVATE_REQUEST_FAILURE:
+			return {
+				...state,
+				[ action.siteId ]: THEME_ACTIVATE_REQUEST === action.type
+			};
+
+		case SERIALIZE:
+		case DESERIALIZE:
+			return {};
+	}
+
+	return state;
+}
 
 /**
  * Returns the updated active theme request state after an action has been
@@ -200,6 +229,7 @@ export default combineReducers( {
 	// queries,
 	// queryRequests,
 	// themeRequests,
+	// activationRequests,
 	currentTheme,
 	themesUI
 } );

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -18,7 +18,9 @@ import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
 	ACTIVE_THEME_REQUEST_FAILURE,
+	THEME_ACTIVATE_REQUEST,
 	THEME_ACTIVATE_REQUEST_SUCCESS,
+	THEME_ACTIVATE_REQUEST_FAILURE,
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
@@ -27,6 +29,7 @@ import reducer, {
 	queries,
 	themeRequests,
 	activeThemes,
+	activationRequests,
 	activeThemeRequests,
 } from '../reducer';
 import ThemeQueryManager from 'lib/query-manager/theme';
@@ -483,6 +486,93 @@ describe( 'reducer', () => {
 			} );
 
 			const state = activeThemes( original, { type: DESERIALIZE } );
+			expect( state ).to.deep.equal( {} );
+		} );
+	} );
+
+	describe( '#activationRequests', () => {
+		it( 'should default to an empty object', () => {
+			const state = activationRequests( undefined, {} );
+			expect( state ).to.deep.equal( {} );
+		} );
+
+		it( 'should map site ID to true value if request in progress', () => {
+			const state = activationRequests( deepFreeze( {} ), {
+				type: THEME_ACTIVATE_REQUEST,
+				siteId: 2916284,
+			} );
+
+			expect( state ).to.deep.equal( {
+				2916284: true
+			} );
+		} );
+
+		it( 'should accumulate mappings', () => {
+			const state = activationRequests(
+				deepFreeze( {
+					2916284: true
+				} ),
+				{
+					type: THEME_ACTIVATE_REQUEST,
+					siteId: 2916285,
+				}
+			);
+
+			expect( state ).to.deep.equal( {
+				2916284: true,
+				2916285: true,
+			} );
+		} );
+
+		it( 'should map site ID to false value if request finishes successfully', () => {
+			const state = activationRequests(
+				deepFreeze( {
+					2916284: true
+				} ),
+				{
+					type: THEME_ACTIVATE_REQUEST_SUCCESS,
+					siteId: 2916284,
+					theme: { id: 'twentysixteen' },
+				}
+			);
+
+			expect( state ).to.deep.equal( {
+				2916284: false
+			} );
+		} );
+
+		it( 'should map site ID to false value if request finishes with failure', () => {
+			const state = activationRequests( deepFreeze( {
+				2916284: true
+			} ), {
+				type: THEME_ACTIVATE_REQUEST_FAILURE,
+				siteId: 2916284,
+				themeId: 'twentysixteen',
+				error: 'Unknown blog',
+			} );
+
+			expect( state ).to.deep.equal( {
+				2916284: false
+			} );
+		} );
+
+		it( 'never persists state', () => {
+			const state = activationRequests( deepFreeze( {
+				2916284: true
+			} ), {
+				type: SERIALIZE
+			} );
+
+			expect( state ).to.deep.equal( {} );
+		} );
+
+		it( 'never loads persisted state', () => {
+			const state = activationRequests( deepFreeze( {
+				2916284: true
+			} ), {
+				type: DESERIALIZE
+			} );
+
 			expect( state ).to.deep.equal( {} );
 		} );
 	} );


### PR DESCRIPTION
This PR implements reducers for activationRequests that will be used in refactored Themes Redux Subtree. It also implements suite of tests, and currently is not yet connected to the rest of the code.

This will be integrated in #8785