### PR TITLE
Components: Add QueryJetpackModules query component

### DIFF
--- a/client/components/data/query-jetpack-modules/README.md
+++ b/client/components/data/query-jetpack-modules/README.md
@@ -1,0 +1,38 @@
+Query Jetpack Modules
+================
+
+`<QueryJetpackModules />` is a React component used in managing network requests for Jetpack site modules.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import MyJetpackModulesListItem from './list-item';
+
+export default function MyJetpackModulesList( { jetpackModules } ) {
+	return (
+		<div>
+			<QueryJetpackModules siteId={ 12345678 } />
+			{ jetpackModules.map( ( module ) => {
+				return (
+					<MyJetpackModulesListItem module={ module } />
+				);
+			} }
+		</div>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which Jetpack modules should be requested.

--- a/client/components/data/query-jetpack-modules/index.jsx
+++ b/client/components/data/query-jetpack-modules/index.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isFetchingModules } from 'state/jetpack-settings/modules/selectors';
+import { fetchModuleList } from 'state/jetpack-settings/modules/actions';
+
+class QueryJetpackModules extends Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		requestingModules: PropTypes.bool,
+		fetchModuleList: PropTypes.func
+	};
+
+	componentWillMount() {
+		this.request( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.siteId !== nextProps.siteId ) {
+			this.request( nextProps );
+		}
+	}
+
+	request( props ) {
+		if ( props.requestingModules ) {
+			return;
+		}
+
+		props.fetchModuleList( props.siteId );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			requestingModules: isFetchingModules( state, ownProps.siteId )
+		};
+	},
+	{ fetchModuleList }
+)( QueryJetpackModules );


### PR DESCRIPTION
This PR introduces a `<QueryJetpackModules />` query component. Part of #9171.

We'll need it when we want to retrieve the Jetpack Modules data for a certain site in presentational components.

To test: 
Since we're not using it anywhere yet, the best way to test it is to insert it somewhere and verify that it's doing the expected network requests.

/cc @oskosk @johnHackworth 