### PR TITLE
Jetpack Settings: Add selectors for retrieving general module data

### DIFF
--- a/client/state/jetpack-settings/modules/selectors.js
+++ b/client/state/jetpack-settings/modules/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import get from 'lodash/get';
+import { get } from 'lodash';
 
 /**
  * Returns true if the module is currently active. False otherwise.
@@ -53,4 +53,29 @@ export function isDeactivatingModule( state, siteId, moduleSlug ) {
  */
 export function isFetchingModules( state, siteId ) {
 	return get( state.jetpackSettings.jetpackModules.requests, [ siteId, 'fetchingModules' ], null );
+}
+
+/**
+ * Returns the data for all modules on a certain site.
+ * Returns null if the site is unknown, or modules have not been fetched yet.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {String}  siteId  The ID of the site we're querying
+ * @return {?Object}         Modules data
+ */
+export function getModules( state, siteId ) {
+	return get( state.jetpackSettings.jetpackModules.items, [ siteId ], null );
+}
+
+/**
+ * Returns the data for a specified module on a certain site.
+ * Returns null if the site or module is unknown, or modules have not been fetched yet.
+ *
+ * @param  {Object}  state       Global state tree
+ * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {String}  moduleSlug  Slug of the module
+ * @return {?Object}             Module data
+ */
+export function getModule( state, siteId, moduleSlug ) {
+	return get( state.jetpackSettings.jetpackModules.items, [ siteId, moduleSlug ], null );
 }

--- a/client/state/jetpack-settings/modules/test/selectors.js
+++ b/client/state/jetpack-settings/modules/test/selectors.js
@@ -7,12 +7,15 @@ import {
 	isActivatingModule,
 	isDeactivatingModule,
 	isModuleActive,
-	isFetchingModules
+	isFetchingModules,
+	getModules,
+	getModule
 } from '../selectors';
 
 import {
 	modules as MODULES_FIXTURE,
-	requests as REQUESTS_FIXTURE
+	requests as REQUESTS_FIXTURE,
+	moduleData as MODULE_DATA_FIXTURE
 } from './fixture';
 
 describe( 'selectors', () => {
@@ -151,6 +154,85 @@ describe( 'selectors', () => {
 				siteId = 123456;
 			const output = isFetchingModules( stateIn, siteId );
 			expect( output ).to.be.true;
+		} );
+	} );
+
+	describe( '#getModules', () => {
+		it( 'should return data for all modules for a known site', () => {
+			const stateIn = {
+					jetpackSettings: {
+						jetpackModules: {
+							items: {
+								123456: MODULE_DATA_FIXTURE
+							}
+						}
+					}
+				},
+				siteId = 123456;
+			const output = getModules( stateIn, siteId );
+			expect( output ).to.eql( MODULE_DATA_FIXTURE );
+		} );
+
+		it( 'should return null for an unknown site', () => {
+			const stateIn = {
+					jetpackSettings: {
+						jetpackModules: {
+							items: {
+								654321: MODULE_DATA_FIXTURE
+							}
+						}
+					}
+				},
+				siteId = 123456;
+			const output = getModules( stateIn, siteId );
+			expect( output ).to.be.null;
+		} );
+	} );
+
+	describe( '#getModule', () => {
+		it( 'should return data for a specified module for a known site', () => {
+			const stateIn = {
+					jetpackSettings: {
+						jetpackModules: {
+							items: {
+								123456: MODULE_DATA_FIXTURE
+							}
+						}
+					}
+				},
+				siteId = 123456;
+			const output = getModule( stateIn, siteId, 'module-a' );
+			expect( output ).to.eql( MODULE_DATA_FIXTURE[ 'module-a' ] );
+		} );
+
+		it( 'should return null for an unknown site', () => {
+			const stateIn = {
+					jetpackSettings: {
+						jetpackModules: {
+							items: {
+								654321: MODULE_DATA_FIXTURE
+							}
+						}
+					}
+				},
+				siteId = 123456;
+			const output = getModule( stateIn, siteId, 'module-a' );
+			expect( output ).to.be.null;
+		} );
+
+		it( 'should return null for an unknown module', () => {
+			const stateIn = {
+					jetpackSettings: {
+						jetpackModules: {
+							items: {
+								123456: MODULE_DATA_FIXTURE
+							}
+						}
+					}
+				},
+				siteId = 123456;
+			const output = getModule( stateIn, siteId, 'module-z' );
+			expect( output ).to.be.null;
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR is part of #9171. It introduces 2 new selectors for retrieving general data for Jetpack modules:

* `getModules()` - for retrieving the data for all modules of a certain site.
* `getModule()` - for retrieving the data for a specific module of a certain site.

To test:

* Checkout this branch.
* Verify all tests pass: `npm run test-client client/state/jetpack-settings/`.

/cc @oskosk @johnHackworth 