### PR TITLE
Add: lastQuery reducer and selector.

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -220,6 +220,13 @@ export const queries = ( () => {
 	} );
 } )();
 
+export const lastQuery = createReducer( {}, {
+	[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query } ) => ( {
+		...state,
+		[ siteId ]: query
+	} )
+} );
+
 export default combineReducers( {
 	// Old reducers:
 	themes,
@@ -228,6 +235,7 @@ export default combineReducers( {
 	// New reducers:
 	// queries,
 	// queryRequests,
+	// lastQuery
 	// themeRequests,
 	// activationRequests,
 	currentTheme,

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -220,6 +220,14 @@ export const queries = ( () => {
 	} );
 } )();
 
+/**
+ * Returns the updated themes last query state.
+ * The state reflects a mapping of site Id to last query that was issued on that site.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
 export const lastQuery = createReducer( {}, {
 	[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query } ) => ( {
 		...state,

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -127,6 +127,17 @@ export function getThemesFoundForQuery( state, siteId, query ) {
 }
 
 /**
+ * Returns last query used.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {String}         Last quer
+ */
+export function getLastQuery( state, siteId ) {
+	return get( state.themes.lastQuery, siteId, '' );
+}
+
+/**
  * Returns the last queryable page of themes for the given query, or null if the
  * total number of queryable themes if unknown.
  *

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -100,10 +100,10 @@ export const getThemesForQuery = createSelector(
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
- * @return {String}         Last quer
+ * @return {Object}         Last query
  */
-export function getLastQuery( state, siteId ) {
-	return get( state.themes.lastQuery, siteId, '' );
+export function getLastThemeQuery( state, siteId ) {
+	return get( state.themes.lastQuery, siteId, {} );
 }
 
 /**

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -96,6 +96,17 @@ export const getThemesForQuery = createSelector(
 );
 
 /**
+ * Returns last query used.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {String}         Last quer
+ */
+export function getLastQuery( state, siteId ) {
+	return get( state.themes.lastQuery, siteId, '' );
+}
+
+/**
  * Returns true if currently requesting themes for the themes query, or false
  * otherwise.
  *
@@ -124,17 +135,6 @@ export function getThemesFoundForQuery( state, siteId, query ) {
 	}
 
 	return state.themes.queries[ siteId ].getFound( query );
-}
-
-/**
- * Returns last query used.
- *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @return {String}         Last quer
- */
-export function getLastQuery( state, siteId ) {
-	return get( state.themes.lastQuery, siteId, '' );
 }
 
 /**

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -27,6 +27,7 @@ import {
 import reducer, {
 	queryRequests,
 	queries,
+	lastQuery,
 	themeRequests,
 	activeThemes,
 	activationRequests,
@@ -309,6 +310,51 @@ describe( 'reducer', () => {
 			const state = queries( original, { type: DESERIALIZE } );
 
 			expect( state ).to.deep.equal( {} );
+		} );
+	} );
+
+	describe( '#lastQuery()', () => {
+		it( 'should default to an empty object', () => {
+			const state = lastQuery( undefined, {} );
+
+			expect( state ).to.deep.equal( {} );
+		} );
+
+		it( 'should store last query', () => {
+			const state = lastQuery( deepFreeze( {} ), {
+				type: THEMES_REQUEST_SUCCESS,
+				siteId: 2916284,
+				query: { search: 'Sixteen' },
+			} );
+
+			expect( state ).to.have.keys( [ '2916284' ] );
+			expect( state ).to.deep.equal( {
+				2916284: {
+					search: 'Sixteen'
+				}
+			} );
+		} );
+
+		it( 'should overwrite last query with new query', () => {
+			const state = lastQuery(
+				deepFreeze( {
+					2916284: {
+						search: 'Sixteen'
+					}
+				} ),
+				{
+					type: THEMES_REQUEST_SUCCESS,
+					siteId: 2916284,
+					query: { search: 'orange color' },
+				}
+			);
+
+			expect( state ).to.have.keys( [ '2916284' ] );
+			expect( state ).to.deep.equal( {
+				2916284: {
+					search: 'orange color'
+				}
+			} );
 		} );
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -12,7 +12,7 @@ import {
 	getTheme,
 	isRequestingTheme,
 	getThemesForQuery,
-	getLastQuery,
+	getLastThemeQuery,
 	isRequestingThemesForQuery,
 	getThemesFoundForQuery,
 	getThemesLastPageForQuery,
@@ -238,30 +238,30 @@ describe( 'themes selectors', () => {
 		} );
 	} );
 
-	describe( '#getLastQuery', () => {
-		it( 'given no site, should return empty string', () => {
-			const query = getLastQuery( {
+	describe( '#getLastThemeQuery', () => {
+		it( 'given no site, should return empty object', () => {
+			const query = getLastThemeQuery( {
 				themes: {
 					lastQuery: {}
 				}
 			} );
 
-			expect( query ).to.equal( '' );
+			expect( query ).to.deep.equal( {} );
 		} );
 
 		it( 'given a site, should return last used query', () => {
-			const query = getLastQuery(
+			const query = getLastThemeQuery(
 				{
 					themes: {
 						lastQuery: {
-							2916284: 'theme that has this thing and does not have the other one'
+							2916284: { search: 'theme that has this thing and does not have the other one' }
 						}
 					}
 				},
 				2916284
 			);
 
-			expect( query ).to.equal( 'theme that has this thing and does not have the other one' );
+			expect( query ).to.deep.equal( { search: 'theme that has this thing and does not have the other one' } );
 		} );
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	getTheme,
 	isRequestingTheme,
 	getThemesForQuery,
+	getLastQuery,
 	isRequestingThemesForQuery,
 	getThemesFoundForQuery,
 	getThemesLastPageForQuery,
@@ -234,6 +235,33 @@ describe( 'themes selectors', () => {
 			}, 2916284, { search: 'Fifteen', number: 1, page: 2 } );
 
 			expect( siteThemes ).to.be.null;
+		} );
+	} );
+
+	describe( '#getLastQuery', () => {
+		it( 'given no site, should return empty string', () => {
+			const query = getLastQuery( {
+				themes: {
+					lastQuery: {}
+				}
+			} );
+
+			expect( query ).to.equal( '' );
+		} );
+
+		it( 'given a site, should return last used query', () => {
+			const query = getLastQuery(
+				{
+					themes: {
+						lastQuery: {
+							2916284: 'theme that has this thing and does not have the other one'
+						}
+					}
+				},
+				2916284
+			);
+
+			expect( query ).to.equal( 'theme that has this thing and does not have the other one' );
 		} );
 	} );
 


### PR DESCRIPTION
### Info
New Themes Redux sub-tree and cleanup that is done during refactor forces to add last query reducer that will serve as a point of knowledge what was the last query that user has made :) in themes showcase. This will be used to feed analytics. 

### Changes
Added `lastQuery` reducer that responds to `THEMES_REQUEST_SUCCESS` action type.
Added `getLastQuery` selector that returns stored query value.
Added test for reducer and selector.

### Testing
Code is not connected yet. Will be integrated in #8785.