### PR TITLE
Taxonomies: displays a "saving..." indicator before closing the modal

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -32,7 +32,8 @@ class TermFormDialog extends Component {
 		selectedParent: [],
 		isTopLevel: true,
 		isValid: false,
-		error: null
+		error: null,
+		saving: false
 	};
 
 	static propTypes = {
@@ -56,15 +57,14 @@ class TermFormDialog extends Component {
 		showDialog: false
 	};
 
-	state = {
-		saving: false
-	};
-
 	onSearch = searchTerm => {
 		this.setState( { searchTerm: searchTerm } );
 	};
 
 	closeDialog = () => {
+		if ( this.state.saving ) {
+			return;
+		}
 		this.setState( this.constructor.initialState );
 		this.props.onClose();
 	};

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -56,6 +56,10 @@ class TermFormDialog extends Component {
 		showDialog: false
 	};
 
+	state = {
+		saving: false
+	};
+
 	onSearch = searchTerm => {
 		this.setState( { searchTerm: searchTerm } );
 	};
@@ -101,18 +105,23 @@ class TermFormDialog extends Component {
 
 	saveTerm = () => {
 		const term = this.getFormValues();
-		if ( ! this.isValid() ) {
+		if ( ! this.isValid() || this.state.saving ) {
 			return;
 		}
 
+		this.setState( { saving: true } );
 		const { siteId, taxonomy } = this.props;
 		const isNew = ! this.props.term;
 		const savePromise = isNew
 			? this.props.addTerm( siteId, taxonomy, term )
 			: this.props.updateTerm( siteId, taxonomy, this.props.term.ID, this.props.term.slug, term );
 
-		savePromise.then( this.props.onSuccess );
-		this.closeDialog();
+		savePromise
+			.then( savedTerm => {
+				this.setState( { saving: false } );
+				this.props.onSuccess( savedTerm );
+				this.closeDialog();
+			} );
 	};
 
 	constructor( props ) {
@@ -232,14 +241,15 @@ class TermFormDialog extends Component {
 		const { isHierarchical, labels, term, translate, showDescriptionInput, showDialog } = this.props;
 		const { name, description } = this.state;
 		const isNew = ! term;
+		const submitLabel = isNew ? translate( 'Add' ) : translate( 'Update' );
 		const buttons = [ {
 			action: 'cancel',
 			label: translate( 'Cancel' )
 		}, {
 			action: isNew ? 'add' : 'update',
-			label: isNew ? translate( 'Add' ) : translate( 'Update' ),
+			label: this.state.saving ? translate( 'Saving…' ) : submitLabel,
 			isPrimary: true,
-			disabled: ! this.state.isValid,
+			disabled: ! this.state.isValid || this.state.saving,
 			onClick: this.saveTerm
 		} ];
 


### PR DESCRIPTION
When we rename or change the parent of term in the taxonomy manager, we see the term moving when we're back to the term's list. In this PR, I add a "saving" state to TermFormDialog, to mimic the behavior of other Calypso's form settings.

**Testing instructions**

 * navigate to `/settings/category/$site`
 * Rename a category 
 * When the category is updated, we don't see it moving on the list

cc @timmyc 