### PR TITLE
Site Settings: Enable cropping site icon after selecting media

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -158,6 +158,9 @@ class SiteIconSetting extends Component {
 								onDone: this.setSiteIcon
 							} }
 							visible
+							labels={ {
+								confirm: translate( 'Continue' )
+							} }
 							single />
 					</MediaLibrarySelectedData>
 				) }

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -42,10 +42,16 @@ class SiteIconSetting extends Component {
 	};
 
 	state = {
-		isModalVisible: false
+		isModalVisible: false,
+		hasToggledModal: false
 	};
 
-	toggleModal = ( isModalVisible ) => this.setState( { isModalVisible } );
+	toggleModal = ( isModalVisible ) => {
+		this.setState( {
+			isModalVisible,
+			hasToggledModal: true
+		} );
+	};
 
 	hideModal = () => this.toggleModal( false );
 
@@ -60,9 +66,6 @@ class SiteIconSetting extends Component {
 	};
 
 	setSiteIcon = ( error, blob ) => {
-		this.hideModal();
-		this.props.resetAllImageEditorState();
-
 		if ( error || ! blob ) {
 			return;
 		}
@@ -92,6 +95,9 @@ class SiteIconSetting extends Component {
 		};
 
 		MediaStore.on( 'change', checkUploadComplete );
+
+		this.hideModal();
+		this.props.resetAllImageEditorState();
 	};
 
 	preloadModal() {
@@ -100,7 +106,7 @@ class SiteIconSetting extends Component {
 
 	render() {
 		const { translate, siteId, isJetpack, customizerUrl, generalOptionsUrl } = this.props;
-		const { isModalVisible } = this.state;
+		const { isModalVisible, hasToggledModal } = this.state;
 		const isIconManagementEnabled = isEnabled( 'manage/site-settings/site-icon' );
 
 		let buttonProps;
@@ -141,14 +147,14 @@ class SiteIconSetting extends Component {
 					compact>
 					{ translate( 'Change', { context: 'verb' } ) }
 				</Button>
-				{ isIconManagementEnabled && isModalVisible && (
+				{ isIconManagementEnabled && hasToggledModal && (
 					<MediaLibrarySelectedData siteId={ siteId }>
 						<AsyncLoad
 							require="post-editor/media-modal"
 							placeholder={ (
 								<Dialog
 									additionalClassNames="editor-media-modal"
-									isVisible />
+									isVisible={ isModalVisible } />
 							) }
 							siteId={ siteId }
 							onClose={ this.editSelectedMedia }
@@ -157,7 +163,7 @@ class SiteIconSetting extends Component {
 								allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
 								onDone: this.setSiteIcon
 							} }
-							visible
+							visible={ isModalVisible }
 							labels={ {
 								confirm: translate( 'Continue' )
 							} }

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { partial } from 'lodash';
+import { uniqueId, head, partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,6 +24,10 @@ import { isEnabled } from 'config';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import InfoPopover from 'components/info-popover';
+import MediaActions from 'lib/media/actions';
+import MediaStore from 'lib/media/store';
+import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
+import { isItemBeingUploaded } from 'lib/media/utils';
 import { addQueryArgs } from 'lib/url';
 
 class SiteIconSetting extends Component {
@@ -58,6 +62,36 @@ class SiteIconSetting extends Component {
 	setSiteIcon = ( error, blob ) => {
 		this.hideModal();
 		this.props.resetAllImageEditorState();
+
+		if ( error || ! blob ) {
+			return;
+		}
+
+		const { siteId } = this.props;
+		const selectedItem = head( MediaLibrarySelectedStore.getAll( siteId ) );
+		if ( ! selectedItem ) {
+			return;
+		}
+
+		const transientMediaId = uniqueId( 'site-icon' );
+
+		MediaActions.add( siteId, {
+			ID: transientMediaId,
+			fileName: `cropped-${ selectedItem.file }`,
+			fileContents: blob
+		} );
+
+		const checkUploadComplete = () => {
+			const transientMedia = MediaStore.get( siteId, transientMediaId );
+			if ( isItemBeingUploaded( transientMedia ) ) {
+				return;
+			}
+
+			MediaStore.off( 'change', checkUploadComplete );
+			alert( transientMedia.ID );
+		};
+
+		MediaStore.on( 'change', checkUploadComplete );
 	};
 
 	preloadModal() {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -59,7 +59,8 @@ export const EditorMediaModal = React.createClass( {
 			labels: Object.freeze( {} ),
 			setView: noop,
 			resetView: noop,
-			view: ModalViews.LIST
+			view: ModalViews.LIST,
+			imageEditorProps: {}
 		};
 	},
 
@@ -411,6 +412,7 @@ export const EditorMediaModal = React.createClass( {
 			case ModalViews.IMAGE_EDITOR:
 				const {
 					site,
+					imageEditorProps,
 					mediaLibrarySelectedItems: items
 				} = this.props;
 
@@ -423,6 +425,7 @@ export const EditorMediaModal = React.createClass( {
 						media={ media }
 						onDone={ this.onImageEditorDone }
 						onCancel={ this.onImageEditorCancel }
+						{ ...imageEditorProps }
 					/>
 				);
 				break;

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -88,6 +88,7 @@ export const EditorMediaModal = React.createClass( {
 
 	componentWillUnmount() {
 		this.props.resetView();
+		MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
 	},
 
 	getDefaultState: function( props ) {


### PR DESCRIPTION
This pull request seeks to prompt the user to crop the selected media item after confirming their selection for site icon.

![site-icon](https://cloud.githubusercontent.com/assets/1779930/20686193/a3f4e342-b585-11e6-9ba8-5d8aa30fff6f.gif)

__Work in Progress:__

While the cropping and upload works as expected, one critical flaw with this approach is that it depends on the user not navigating away from the page after having confirmed the icon, as otherwise a zombie event handler will exist for the upload flow where an event listener is attached to the media store. Ideally this logic would not exist in the component but instead would be managed through Redux state (as a middleware and/or reducer handler) which exists globally. Handlers for this behavior may need to be implemented as part of a separate parallel pull request.

__Testing Instructions:__

Verify that you can select, crop, and confirm a media as site icon. After confirming your selection, a new media item should be uploaded and an alert shown with the ID of the new media.

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Click "Change" next to the site icon button
4. Select an image to use for site icon
5. Click "Insert" (label to be changed in a subsequent pull request)
6. Crop the image
7. Click "Confirm"
8. Note that after a brief delay, an alert is shown with a numeric ID

__Follow-up Tasks:__

- Change "Insert" label to "Continue"
- Save to site settings after media finishes uploading
