### PR TITLE
Signup: User-first signup flow

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -203,6 +203,10 @@ assign( SignupFlowController.prototype, {
 		return this._flow.destination;
 	},
 
+	shouldAutoContinue: function() {
+		return !! this._flow.autoContinue;
+	},
+
 	reset: function() {
 		SignupProgressStore.off( 'change', this._boundProcess );
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -198,7 +198,15 @@ const flows = {
 		destination: getSiteDestination,
 		description: 'Used by `get.blog` users that connect their site to WordPress.com',
 		lastModified: '2016-11-14'
-	}
+	},
+
+	userfirst: {
+		steps: [ 'user' ],
+		destination: '/start',
+		description: 'User-first signup flow',
+		lastModified: '2016-11-29',
+		autoContinue: true,
+	},
 };
 
 if ( config( 'env' ) === 'development' ) {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -204,7 +204,7 @@ const Signup = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
 
 		this.signupFlowController.reset();
-		if ( dependencies.cartItem || dependencies.domainItem ) {
+		if ( dependencies.cartItem || dependencies.domainItem || this.signupFlowController.shouldAutoContinue() ) {
 			this.handleLogin( dependencies, destination );
 		} else {
 			this.setState( {


### PR DESCRIPTION
This PR aims to to enable user-first signup in Calypso.

This will allow for easier user signup and better site creation in the future. 

To test:

1. Checkout branch or use Calypso.live link
2. Start signup at `/start/userfirst`
3. Go through Signup
4. Verify there are no errors in the console
5. Confirm that the signup experience is as expected (as default, with user step as a first step)

cc @michaeldcain @coreh @meremagee 