### PR TITLE
Upgrades: do not overwrite google apps slugs with 'gapps'

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -563,18 +563,6 @@ function getDomainMappings( cart ) {
 }
 
 /**
- * Retrieves all the Google Apps items in the specified shopping cart.
- *
- * @param {Object} cart - cart as `CartValue` object
- * @returns {Object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
- */
-function getGoogleApps( cart ) {
-	return getAll( cart ).filter( function( cartItem ) {
-		return ( cartItem.product_slug === 'gapps' ) || ( cartItem.product_slug === 'gapps_extra_license' );
-	} );
-}
-
-/**
  * Returns a renewal CartItem object with the given properties and product slug.
  *
  * @param {String} product - the product object
@@ -784,7 +772,6 @@ module.exports = {
 	getDomainRegistrations,
 	getDomainRegistrationsWithoutPrivacy,
 	getDomainRegistrationTld,
-	getGoogleApps,
 	getIncludedDomain,
 	getItemForPlan,
 	getRenewalItemFromCartItem,

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -446,7 +446,8 @@ function domainRedemption( properties ) {
 }
 
 function googleApps( properties ) {
-	var item = domainItem( 'gapps', properties.meta ? properties.meta : properties.domain );
+	const productSlug = properties.product_slug || 'gapps',
+		item = domainItem( productSlug, properties.meta ? properties.meta : properties.domain );
 
 	return assign( item, { extra: { google_apps_users: properties.users } } );
 }


### PR DESCRIPTION
We have users with the product_slug 'gapps_unlimited' and they currently can't renew because their product is being replaced with 'gapps'. It is not possible to purchase 'gapps_unlimited', the product has been deprecated and not supported by Calypso. It, however, needs to renew and in order for that to happen, we need to be able to add it to the shopping cart.

The way this code seems to be supposed to be fixed is by making a major copy/paste and duplicating isGoogleApps, googleApps etc. in dozens of files. I chose a simpler two-line fix over repetition which I think is sufficient to resolve the issue cleanly.

To test:
1. purchase G Suite, make sure it works
2. Make your G Suite expire and renew it
3. Break your G Suite subscription by setting the product_id to 70 ('gapps_unlimited') in the test subscription table
4. Try to add it to cart. It should not be replaced by 'gapps'