### PR TITLE
Fix search page so that it doesn't crash calypso when clicked on

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -164,7 +164,7 @@ export default class ReaderStream extends React.Component {
 			recs,
 			updateCount: store.getUpdateCount(),
 			selectedIndex: store.getSelectedIndex(),
-			isFetchingNextPage: store.isFetchingNextPage(),
+			isFetchingNextPage: store.isFetchingNextPage && store.isFetchingNextPage(),
 			isLastPage: store.isLastPage()
 		};
 	}


### PR DESCRIPTION
Will fill in shortly

To test:
- Open up search page in the reader. confirm it loads.
- Confirm following still loads as well