### PR TITLE
Reader: Teach empty store about isFetchingNextPage

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -94,6 +94,9 @@ const emptyStore = {
 	isLastPage() {
 		return true;
 	},
+	isFetchingNextPage() {
+		return false;
+	},
 	getUpdateCount() {
 		return 0;
 	},


### PR DESCRIPTION
Alternate fix for #9692.

Search should still work. Following should still work.