### PR TITLE
Reader Refresh: Changed in stream recommendations to use the thumbs-u…

### DIFF
--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -424,7 +424,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		margin-right: -2px;
 		position: relative;
 			left: -2px;
-			top: 5px;
+			top: 2px;
 	}
 }
 

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -50,7 +50,9 @@ export class RecommendedPosts extends React.PureComponent {
 	render() {
 		return (
 			<div className="reader-stream__recommended-posts">
-				<h1 className="reader-stream__recommended-posts-header"><Gridicon icon="star" />&nbsp;{ this.props.translate( 'Recommended Posts' ) }</h1>
+				<h1 className="reader-stream__recommended-posts-header">
+					<Gridicon icon="thumbs-up" size={ 18 }/>&nbsp;{ this.props.translate( 'Recommended Posts' ) }
+				</h1>
 				<ul className="reader-stream__recommended-posts-list">
 					{
 						map(


### PR DESCRIPTION
This PR aims to change the icon used to demarcate in-stream recommendations from a star to a thumbs up.

before: 
![screen shot 2016-11-29 at 9 29 20 am](https://cldup.com/lEkwPOjTsd.png)

after:
![after](https://cldup.com/LLCwa8JY5L.png)
We want it to use a thumbs up which is more of a symbol for recommendations for us whereas the star means likes.

see #9691