### PR TITLE
Publicize: Share action in post actions

### DIFF
--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -108,6 +108,16 @@ module.exports = React.createClass( {
 				onClick: this.viewStats,
 				icon: 'stats-alt'
 			} );
+
+			if ( config.isEnabled( 'republicize' ) ) {
+				availableControls.push( {
+					text: this.translate( 'Share' ),
+					className: 'post-controls__share',
+					onClick: this.props.onToggleShare,
+					icon: 'share'
+				} );
+			}
+
 		} else if ( post.status !== 'trash' ) {
 			parsed = url.parse( post.URL, true );
 			parsed.query.preview = 'true';

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -317,20 +317,6 @@ module.exports = React.createClass( {
 			) );
 		}
 
-		if ( config.isEnabled( 'republicize' ) && post && ( post.status === 'publish' ) ) {
-			metaItems.push(
-				<a
-					className={ classNames( {
-						'post__comments': true,
-					} ) }
-					title={ this.translate( 'Share' ) }
-					onClick={ () => this.setState( { showShare: ! this.state.showShare } ) }
-				>
-				<Gridicon icon="speaker" size={ 24 } />
-				</a>
-			);
-		}
-
 		if ( metaItems.length ) {
 			footerMetaItems = metaItems.map( function( item, i ) {
 				const itemKey = 'meta-' + postId + '-' + i;
@@ -378,6 +364,10 @@ module.exports = React.createClass( {
 		this.analyticsEvents.commentIconClick();
 	},
 
+	toggleShare() {
+		this.setState( { showShare: ! this.state.showShare } );
+	},
+
 	render() {
 		const site = this.getSite();
 
@@ -405,6 +395,7 @@ module.exports = React.createClass( {
 					onTrash={ this.trashPost }
 					onDelete={ this.deletePost }
 					onRestore={ this.restorePost }
+					onToggleShare={ this.toggleShare }
 					site={ site }
 				/>
 				<ReactCSSTransitionGroup


### PR DESCRIPTION
Resolvs #8543 by moving publicize drawer toggle to post action "Share" instead if just having a megaphone.

![screen shot 2016-11-29 at 21 22 47 pm](https://cloud.githubusercontent.com/assets/3775068/20727483/ff9c10fe-b679-11e6-91a6-b5c1d2021348.png)

CC @folletto @enejb @gziolo @gwwar 