### PR TITLE
Reader: Fix in-stream recs broken in narrow widths

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -24,6 +24,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	font-weight: 600;
 	margin-bottom: 20px;
 	display: -webkit-box;
+	letter-spacing: 0.01em;
 	max-height: 22px;
 	overflow: hidden;
 	position: relative;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -450,18 +450,18 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	margin-top: -3px;
 
 	&:first-child {
-		margin-right: 15px;
+		margin-right: 10px;
 
-		@include breakpoint( "<660px" ) {
-			margin-right: 10px;
+		@include breakpoint( ">660px" ) {
+			margin-right: 15px;
 		}
 	}
 
 	&:last-child {
-		margin-left: 15px;
+		margin-left: 10px;
 
-		@include breakpoint( "<660px" ) {
-			margin-left: 10px;
+		@include breakpoint( ">660px" ) {
+			margin-left: 15px;
 		}
 	}
 

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -404,8 +404,8 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 .reader-stream__recommended-posts {
 
 	@include breakpoint( "<660px" ) {
-			margin: 0 15px;
-		}
+		margin: 0 15px;
+	}
 }
 
 .reader-stream__recommended-posts-header {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -402,15 +402,20 @@ $reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width
 $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-stream__recommended-posts {
-	border-bottom: 1px solid lighten( $gray, 30% );
-	margin: 18px 0 0;
+
+	@include breakpoint( "<660px" ) {
+			margin: 0 15px;
+		}
 }
 
 .reader-stream__recommended-posts-header {
 	color: lighten( $gray, 10% );
-	font-weight: 400;
+	font-size: 14px;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+	margin-bottom: 20px;
+	position: relative;
 	text-transform: uppercase;
-	margin-top: -11px;
 
 	.gridicon {
 		fill: lighten( $gray, 10% );
@@ -422,6 +427,8 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 .reader-stream__recommended-posts-posts {
 	display: flex;
 	flex-direction: row;
+	margin: 0;
+	padding: 0;
 
 	@media #{$reader-related-card-v2-breakpoint-medium} {
 		flex-direction: column;
@@ -436,42 +443,99 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 }
 
-.reader-stream__recommended-posts-posts .reader-related-card-v2 {
-	margin: 16px 0;
+.reader-stream__recommended-posts-item {
+	flex-basis: 0;
+	flex-grow: 1;
+	list-style-type: none;
+	margin-top: -3px;
 
 	&:first-child {
-		margin-right: 30px;
-	}
-}
+		margin-right: 15px;
 
-.reader-stream__recommended-posts {
-
-	.reader-related-card-v2__featured-image {
-		border: 1px solid lighten( $gray, 20% );
-		margin: 5px 0 17px;
+		@include breakpoint( "<660px" ) {
+			margin-right: 10px;
+		}
 	}
 
-	.reader-related-card-v2__meta {
-		margin-bottom: 13px;
+	&:last-child {
+		margin-left: 15px;
+
+		@include breakpoint( "<660px" ) {
+			margin-left: 10px;
+		}
 	}
 
-	.reader-related-card-v2__site-info {
-		margin-top: 2px;
+	&:first-child,
+	&:last-child {
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			margin: 0 0 20px 0;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			margin: 0 0 20px 0;
+		}
+
+		@include breakpoint( "<480px" ) {
+			margin: 0 0 20px 0;
+		}
 	}
 
-	.reader-related-card-v2__meta .gravatar {
-		margin: 2px 8px 0 0;
+	&:only-child {
+		margin: 0;
 	}
 
 	.reader-related-card-v2__post {
-		max-height: 200px;
+		max-height: 205px;
 
-		&::after {
-			@include long-content-fade( $size: 30% );
-			bottom: 0;
-			height: 22px;
-			top: inherit;
-			visibility: visible;
+		@include breakpoint( "<960px" ) {
+			max-height: 249px;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			max-height: 165px;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			max-height: 142px;
+		}
+	}
+
+	.has-thumbnail {
+
+		.reader-related-card-v2__site-info {
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				margin-top: 50px;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				margin-top: 50px;
+			}
+		}
+
+		.reader-related-card-v2__post {
+			max-height: 220px;
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				max-height: 170px;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				max-height: 170px;
+			}
+		}
+	}
+
+	.reader-related-card-v2__featured-image {
+		margin: 4px 0 19px;
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			margin: 0 15px 0 0;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			margin: 0 15px 0 0;
 		}
 	}
 }

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -55,7 +55,7 @@ export class RecommendedPosts extends React.PureComponent {
 					{
 						map(
 							this.state.posts,
-							post => <li className="reader-stream__recommended-posts-item"><RelatedPostCard key={ post.global_ID } post={ post } onPostClick={ this.handlePostClick } onSiteClick={ this.handleSiteClick } /></li>
+							post => <li className="reader-stream__recommended-posts-item" key={ post.global_ID }><RelatedPostCard post={ post } onPostClick={ this.handlePostClick } onSiteClick={ this.handleSiteClick } /></li>
 						)
 					}
 				</ul>

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -52,12 +52,12 @@ export class RecommendedPosts extends React.PureComponent {
 			<div className="reader-stream__recommended-posts">
 				<h1 className="reader-stream__recommended-posts-header"><Gridicon icon="star" />&nbsp;{ this.props.translate( 'Recommended Posts' ) }</h1>
 				<ul className="reader-stream__recommended-posts-posts">
-						{
-							map(
-								this.state.posts,
-								post => <li className="reader-stream__recommended-posts-item"><RelatedPostCard key={ post.global_ID } post={ post } onPostClick={ this.handlePostClick } onSiteClick={ this.handleSiteClick } /></li>
-							)
-						}
+					{
+						map(
+							this.state.posts,
+							post => <li className="reader-stream__recommended-posts-item"><RelatedPostCard key={ post.global_ID } post={ post } onPostClick={ this.handlePostClick } onSiteClick={ this.handleSiteClick } /></li>
+						)
+					}
 				</ul>
 			</div>
 		);

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -50,15 +50,15 @@ export class RecommendedPosts extends React.PureComponent {
 	render() {
 		return (
 			<div className="reader-stream__recommended-posts">
-				<h5 className="reader-stream__recommended-posts-header"><Gridicon icon="star" />&nbsp;{ this.props.translate( 'Recommended Posts' ) }</h5>
-				<div className="reader-stream__recommended-posts-posts">
-					{
-						map(
-							this.state.posts,
-							post => <RelatedPostCard key={ post.global_ID } post={ post } onPostClick={ this.handlePostClick } onSiteClick={ this.handleSiteClick } />
-						)
-					}
-				</div>
+				<h1 className="reader-stream__recommended-posts-header"><Gridicon icon="star" />&nbsp;{ this.props.translate( 'Recommended Posts' ) }</h1>
+				<ul className="reader-stream__recommended-posts-posts">
+						{
+							map(
+								this.state.posts,
+								post => <li className="reader-stream__recommended-posts-item"><RelatedPostCard key={ post.global_ID } post={ post } onPostClick={ this.handlePostClick } onSiteClick={ this.handleSiteClick } /></li>
+							)
+						}
+				</ul>
 			</div>
 		);
 	}


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9690

Basically redid all of the styling that was already in place for in-stream recs so I'm going to need to back and fix spacing issues that were supposedly already addressed in: https://github.com/Automattic/wp-calypso/pull/9490#issuecomment-262664725. I'll take care of those in a separate PR.

**Before:**
![screenshot 2016-11-29 12 23 51](https://cloud.githubusercontent.com/assets/4924246/20727526/b22f52f4-b62e-11e6-98ab-e88869a75dae.png)

**After:**
![screenshot 2016-11-29 12 23 01](https://cloud.githubusercontent.com/assets/4924246/20727498/9d88a24c-b62e-11e6-8253-25b8707da7c8.png)
