### PR TITLE
Plugins: Check registration keys on site before automatically setting up purchased plugins

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -299,6 +299,11 @@ const PlansSetup = React.createClass( {
 					{ translate( 'Manual Installation' ) }
 				</NoticeAction>
 			);
+			if ( plugin.error.code === 'already_registered' ) {
+				statusProps.status = 'is-info';
+				statusProps.text = translate( 'This plugin is already registered with another plan.' );
+				delete statusProps.children;
+			}
 		} else {
 			statusProps.icon = 'plugins';
 			statusProps.status = 'is-info';
@@ -342,13 +347,10 @@ const PlansSetup = React.createClass( {
 		return null;
 	},
 
-	renderErrorMessage() {
+	renderErrorMessage( plugins ) {
 		let noticeText;
 		const { translate } = this.props;
-		const plugins = this.addWporgDataToPlugins( this.props.plugins );
-		const pluginsWithErrors = filter( plugins, ( item ) => {
-			return ( item.error !== null );
-		} );
+		const pluginsWithErrors = this.addWporgDataToPlugins( plugins );
 
 		const tracksData = {};
 		pluginsWithErrors.map( ( item ) => {
@@ -398,7 +400,7 @@ const PlansSetup = React.createClass( {
 		}
 
 		const pluginsWithErrors = filter( this.props.plugins, ( item ) => {
-			return ( item.error !== null );
+			return ( item.error !== null ) && ( item.error.code !== 'already_registered' );
 		} );
 
 		if ( pluginsWithErrors.length ) {

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -7,6 +7,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import filter from 'lodash/filter';
 import range from 'lodash/range';
+import get from 'lodash/get';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -400,7 +401,8 @@ const PlansSetup = React.createClass( {
 		}
 
 		const pluginsWithErrors = filter( this.props.plugins, ( item ) => {
-			return ( item.error !== null ) && ( item.error.code !== 'already_registered' );
+			const errorCode = get( item, 'error.code', null );
+			return errorCode && errorCode !== 'already_registered';
 		} );
 
 		if ( pluginsWithErrors.length ) {

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -209,27 +209,59 @@ function configure( site, plugin, dispatch ) {
 			action: 'register',
 		} );
 	}
-	site.setOption( { option_name: option, option_value: optionValue }, ( error, data ) => {
-		if ( ( 'vaultpress' === plugin.slug ) && versionCompare( plugin.version, '1.8.3', '>' ) ) {
-			const response = JSON.parse( data.option_value );
-			if ( 'response' === response.action && 'broken' === response.status ) {
-				error = new Error( response.error );
-				error.name = 'RegisterError';
+
+	const saveOption = () => {
+		return site.setOption( { option_name: option, option_value: optionValue }, ( error, data ) => {
+			if ( ( 'vaultpress' === plugin.slug ) && versionCompare( plugin.version, '1.8.3', '>' ) ) {
+				const response = JSON.parse( data.option_value );
+				if ( 'response' === response.action && 'broken' === response.status ) {
+					error = new Error( response.error );
+					error.name = 'RegisterError';
+				}
 			}
-		}
-		if ( error ) {
+			if ( error ) {
+				dispatch( {
+					type: PLUGIN_SETUP_ERROR,
+					siteId: site.ID,
+					slug: plugin.slug,
+					error,
+				} );
+			}
+			dispatch( {
+				type: PLUGIN_SETUP_FINISH,
+				siteId: site.ID,
+				slug: plugin.slug,
+			} );
+		} );
+	};
+
+	// We don't need to check for VaultPress
+	if ( 'vaultpress' === plugin.slug ) {
+		return saveOption();
+	}
+
+	return site.getOption( { option_name: option }, ( getError, getData ) => {
+		if ( getData.option_value && getData.option_value === optionValue ) {
+			// Already registered with this key
+			dispatch( {
+				type: PLUGIN_SETUP_FINISH,
+				siteId: site.ID,
+				slug: plugin.slug,
+			} );
+			return;
+		} else if ( getData.option_value ) {
+			// Already registered with another key
+			const alreadyRegistered = new Error();
+			alreadyRegistered.code = 'already_registered';
 			dispatch( {
 				type: PLUGIN_SETUP_ERROR,
 				siteId: site.ID,
 				slug: plugin.slug,
-				error,
+				error: alreadyRegistered,
 			} );
+			return;
 		}
-		dispatch( {
-			type: PLUGIN_SETUP_FINISH,
-			siteId: site.ID,
-			slug: plugin.slug,
-		} );
+		return saveOption();
 	} );
 }
 

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -3,6 +3,7 @@
  */
 const wpcom = require( 'lib/wp' );
 import keys from 'lodash/keys';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -241,7 +242,7 @@ function configure( site, plugin, dispatch ) {
 	}
 
 	return site.getOption( { option_name: option }, ( getError, getData ) => {
-		if ( getData.option_value && getData.option_value === optionValue ) {
+		if ( get( getData, 'option_value' ) === optionValue ) {
 			// Already registered with this key
 			dispatch( {
 				type: PLUGIN_SETUP_FINISH,


### PR DESCRIPTION
This fixes #9320: Plugin registration options are overwritten if the user already has, for example, Akismet registered under a different account.

This PR adds a check for the current registration option for each plugin before trying to save the new registration key. It will detect if the plugin is already registered with the given key, and do nothing (considered a successful setup), or detect if the plugin is already configured with a different key. If it's already registered with a different key, we'll show a little info notice. Since technically everything should be working, I don't think an error state makes sense, so even in this case it ends in "success"

To test:

- Set up Akismet under one wp.com account
- Connect Jetpack on that site to a _different_ wp.com account, and buy a plan
- Go through the autoconfig flow (should be prompted after buying plan, or you can go directly to `/plugins/setup/$site`)
- The plugins will run through installing, and once everything's finished, you should see a blue notice under Akismet, saying "This plugin is already registered with another plan."

![screen shot 2016-11-29 at 2 59 12 pm](https://cloud.githubusercontent.com/assets/541093/20726655/85ebcd2e-b644-11e6-8d7a-1819978dca84.png)

cc @johnHackworth @rickybanister