### PR TITLE
Reader Refresh: add tag stream header with tag background image

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -412,6 +412,7 @@
 @import 'reader/site-and-author-icon/style';
 @import 'reader/site-stream/style';
 @import 'reader/start/style';
+@import 'reader/tag-stream/style';
 @import 'reader/style';
 @import 'reader/stream-header/style';
 @import 'reader/update-notice/style';

--- a/client/components/follow-button/button.jsx
+++ b/client/components/follow-button/button.jsx
@@ -13,7 +13,8 @@ const FollowButton = React.createClass( {
 		iconSize: PropTypes.number,
 		tagName: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
 		disabled: PropTypes.bool,
-		followLabel: PropTypes.string
+		followLabel: PropTypes.string,
+		followingLabel: PropTypes.string,
 	},
 
 	getDefaultProps() {
@@ -54,7 +55,7 @@ const FollowButton = React.createClass( {
 
 		if ( this.props.following ) {
 			menuClasses.push( 'is-following' );
-			label = this.strings.FOLLOWING;
+			label = this.props.followingLabel ? this.props.followingLabel : this.strings.FOLLOWING;
 		}
 
 		if ( this.props.disabled ) {

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -4,28 +4,36 @@
 import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import FollowButton from 'components/follow-button/button';
+import QueryReaderTagImages from 'components/data/query-reader-tag-images';
+import { getFirstImageForTag } from 'state/reader/tags/images/selectors';
+import resizeImageUrl from 'lib/resize-image-url';
+import cssSafeUrl from 'lib/css-safe-url';
+import { decodeEntities } from 'lib/formatting';
 
-const TagStreamHeader = ( { isPlaceholder, title, showFollow, following, onFollowToggle, translate } ) => {
+const TAG_HEADER_WIDTH = 830;
+
+const TagStreamHeader = ( { tag, tagImage, isPlaceholder, showFollow, following, onFollowToggle, translate } ) => {
 	const classes = classnames( {
 		'tag-stream__header': true,
 		'is-placeholder': isPlaceholder
 	} );
+	const imageStyle = {};
 
-	// @todo hardcoded until we can pull images from Redux
-	const tagImage = {
-		url: 'marichulambino.files.wordpress.com/2008/05/bigyellow4.jpg',
-		blog_title: 'marichu lambino . Content   &amp; design updated daily',
-		author: 'marichulambino',
-		blog_url: 'http://marichulambino.wordpress.com'
-	};
+	if ( tagImage ) {
+		const imageUrl = resizeImageUrl( tagImage.url, { w: TAG_HEADER_WIDTH } );
+		const safeCssUrl = cssSafeUrl( imageUrl );
+		imageStyle.backgroundImage = 'url(//' + safeCssUrl + ')';
+	}
 
 	return (
 		<div className={ classes }>
+			<QueryReaderTagImages tag={ tag } />
 			{ showFollow &&
 				<div className="tag-stream__header-follow">
 					<FollowButton
@@ -36,11 +44,11 @@ const TagStreamHeader = ( { isPlaceholder, title, showFollow, following, onFollo
 				</div>
 			}
 
-			<div className="tag-stream__header-image">
-				<h1 className="tag-stream__header-image-title">{ title }</h1>
+			<div className="tag-stream__header-image" style={ imageStyle }>
+				<h1 className="tag-stream__header-image-title">{ tag }</h1>
 				{ tagImage &&
 					<div className="tag-stream__header-image-byline">
-						<span className="tag-stream__header-image-byline-label">{ translate( 'Photo by' ) }</span> <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="author external">{ tagImage.author }</a>, <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="external">{ tagImage.blog_title }</a>
+						<span className="tag-stream__header-image-byline-label">{ translate( 'Photo by' ) }</span> <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="author external">{ decodeEntities( tagImage.author ) }</a>, <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="external">{ decodeEntities( tagImage.blog_title ) }</a>
 					</div>
 				}
 			</div>
@@ -50,10 +58,16 @@ const TagStreamHeader = ( { isPlaceholder, title, showFollow, following, onFollo
 
 TagStreamHeader.propTypes = {
 	isPlaceholder: React.PropTypes.bool,
-	title: React.PropTypes.string,
+	tag: React.PropTypes.string,
 	showFollow: React.PropTypes.bool,
 	following: React.PropTypes.bool,
 	onFollowToggle: React.PropTypes.func
 };
 
-export default localize( TagStreamHeader );
+export default connect(
+	( state, ownProps ) => {
+		return {
+			tagImage: getFirstImageForTag( state, ownProps.tag )
+		};
+	}
+)( localize( TagStreamHeader ) );

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -8,27 +8,44 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import FollowButton from 'components/follow-button/button';
-import HeaderBack from 'reader/header-back';
 
-const TagStreamHeader = ( { isPlaceholder, title, showFollow, following, onFollowToggle } ) => {
+const TagStreamHeader = ( { isPlaceholder, title, showFollow, following, onFollowToggle, translate } ) => {
 	const classes = classnames( {
 		'tag-stream__header': true,
 		'is-placeholder': isPlaceholder
 	} );
 
+	// @todo hardcoded until we can pull images from Redux
+	const tagImage = {
+		url: 'marichulambino.files.wordpress.com/2008/05/bigyellow4.jpg',
+		blog_title: 'marichu lambino . Content   &amp; design updated daily',
+		author: 'marichulambino',
+		blog_url: 'http://marichulambino.wordpress.com'
+	};
+
 	return (
 		<div className={ classes }>
-			<HeaderBack />
 			{ showFollow &&
 				<div className="tag-stream__header-follow">
-					<FollowButton iconSize={ 24 } following={ following } onFollowToggle={ onFollowToggle } />
-			</div> }
+					<FollowButton
+						followLabel={ translate( 'Follow Tag' ) }
+						iconSize={ 24 }
+						following={ following }
+						onFollowToggle={ onFollowToggle } />
+				</div>
+			}
 
-			<Card className="tag-stream__header-image">
-				<h1>{ title }</h1>
-			</Card>
+			<div className="tag-stream__header-image">
+				<h1 className="tag-stream__header-image-title">{ title }</h1>
+				{ tagImage &&
+					<div className="tag-stream__header-image-byline">
+						{ translate( 'Photo by' ) }&nbsp;
+						<a href={ tagImage.blog_url } rel="author external">{ tagImage.author }</a>,
+						<a href={ tagImage.blog_url } rel="external">{ tagImage.blog_title }</a>
+					</div>
+				}
+			</div>
 		</div>
 	);
 };

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -38,6 +38,7 @@ const TagStreamHeader = ( { tag, tagImage, isPlaceholder, showFollow, following,
 				<div className="tag-stream__header-follow">
 					<FollowButton
 						followLabel={ translate( 'Follow Tag' ) }
+						followingLabel={ translate( 'Following Tag' ) }
 						iconSize={ 24 }
 						following={ following }
 						onFollowToggle={ onFollowToggle } />

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FollowButton from 'components/follow-button/button';
+import HeaderBack from 'reader/header-back';
+
+const TagStreamHeader = ( { isPlaceholder, title, showFollow, following, onFollowToggle } ) => {
+	const classes = classnames( {
+		'tag-stream__header': true,
+		'is-placeholder': isPlaceholder
+	} );
+
+	return (
+		<div className={ classes }>
+			<HeaderBack />
+			{ showFollow &&
+				<div className="tag-stream__header-follow">
+					<FollowButton iconSize={ 24 } following={ following } onFollowToggle={ onFollowToggle } />
+			</div> }
+
+			<Card className="tag-stream__header-image">
+				<h1>{ title }</h1>
+			</Card>
+		</div>
+	);
+};
+
+TagStreamHeader.propTypes = {
+	isPlaceholder: React.PropTypes.bool,
+	title: React.PropTypes.string,
+	showFollow: React.PropTypes.bool,
+	following: React.PropTypes.bool,
+	onFollowToggle: React.PropTypes.func
+};
+
+export default localize( TagStreamHeader );

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -40,9 +40,7 @@ const TagStreamHeader = ( { isPlaceholder, title, showFollow, following, onFollo
 				<h1 className="tag-stream__header-image-title">{ title }</h1>
 				{ tagImage &&
 					<div className="tag-stream__header-image-byline">
-						{ translate( 'Photo by' ) }&nbsp;
-						<a href={ tagImage.blog_url } rel="author external">{ tagImage.author }</a>,
-						<a href={ tagImage.blog_url } rel="external">{ tagImage.blog_title }</a>
+						<span className="tag-stream__header-image-byline-label">{ translate( 'Photo by' ) }</span> <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="author external">{ tagImage.author }</a>, <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="external">{ tagImage.blog_title }</a>
 					</div>
 				}
 			</div>

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -13,8 +13,7 @@ import EmptyContent from './empty';
 import ReaderTags from 'lib/reader-tags/tags';
 import ReaderTagActions from 'lib/reader-tags/actions';
 import TagSubscriptions from 'lib/reader-tags/subscriptions';
-import StreamHeader from 'reader/stream-header';
-import HeaderBack from 'reader/header-back';
+import TagStreamHeader from './header';
 import smartSetState from 'lib/react-smart-set-state';
 import * as stats from 'reader/stats';
 
@@ -93,11 +92,8 @@ const TagStream = React.createClass( {
 
 		return (
 			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
-				{ this.props.showBack && <HeaderBack /> }
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
-				<StreamHeader
-					isPlaceholder={ false }
-					icon={ <svg className="gridicon gridicon__tag" height="32" width="32" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M16 7H5c-1.105 0-2 .896-2 2v6c0 1.104.895 2 2 2h11l5-5-5-5z"/></g></svg> }
+				<TagStreamHeader
 					title={ title }
 					showFollow={ this.state.canFollow }
 					following={ this.state.subscribed }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -16,6 +16,7 @@ import TagSubscriptions from 'lib/reader-tags/subscriptions';
 import TagStreamHeader from './header';
 import smartSetState from 'lib/react-smart-set-state';
 import * as stats from 'reader/stats';
+import HeaderBack from 'reader/header-back';
 
 const TagStream = React.createClass( {
 
@@ -93,6 +94,7 @@ const TagStream = React.createClass( {
 		return (
 			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
+				{ this.props.showBack && <HeaderBack /> }
 				<TagStreamHeader
 					title={ title }
 					showFollow={ this.state.canFollow }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -96,7 +96,7 @@ const TagStream = React.createClass( {
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
 				{ this.props.showBack && <HeaderBack /> }
 				<TagStreamHeader
-					title={ title }
+					tag={ this.props.tag }
 					showFollow={ this.state.canFollow }
 					following={ this.state.subscribed }
 					onFollowToggle={ this.toggleFollowing } />

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,0 +1,4 @@
+.tag-stream__header-image {
+	background-color: $gray-light; // test style
+	margin-top: 60px;
+}

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -19,7 +19,7 @@
 }
 
 .tag-stream__header-image {
-	background: url("http://lorempixel.com/400/200/") lighten( $gray, 30% ); // Temporary placeholder image
+	background: lighten( $gray, 30% );
 	background-size: cover;
 	background-repeat: no-repeat;
 	background-position: right center;

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -75,12 +75,12 @@
 }
 
 .tag-stream__header-image-byline {
-    color: $white;
-    font-size: 12px;
-    text-align: right;
+	color: $white;
+	font-size: 12px;
+	text-align: right;
 	text-shadow: 0 1px rgba(0, 0, 0, .3);
 	transform: translateY( 150% );
-    z-index: 2;
+	z-index: 2;
 }
 
 .tag-stream__header-image-byline-label {

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,16 +1,78 @@
+.tag-stream__header {
+	display: flex;
+	flex-direction: column;
+}
+
+.tag-stream__header .follow-button {
+	padding: 0;
+
+	@include breakpoint( "<660px" ) {
+		margin: 12px 10px 0 0;
+	}
+}
+
+.tag-stream__header .follow-button__label {
+
+	@include breakpoint( "<660px" ) {
+		display: inline;
+	}
+}
+
 .tag-stream__header-image {
-	background-color: $gray-light;
+	background: url("http://lorempixel.com/400/200/") lighten( $gray, 30% ); // Temporary placeholder image
+	background-size: cover;
+	background-repeat: no-repeat;
+	background-position: right center;
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
 	min-height: 140px;
+	margin-top: 15px;
+	padding: 10px;
 	position: relative;
+	z-index: 0;
+
+	&::before {
+		content: '';
+		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1 ) 100% );
+		height: 140px;
+		opacity: .4;
+		position: absolute;
+			bottom: 0;
+			left: 0;
+		width: 100%;
+		z-index: 1;
+	}
 }
 
 .tag-stream__header-image-title {
-	text-align: center;
+	color: $white;
 	font-size: 28px;
+	padding-top: 42px;
+	text-align: center;
+	text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );
 }
 
 .tag-stream__header-image-byline {
-	position: absolute;
-	bottom: 10px;
-	right: 10px;
+	color: $white;
+	font-size: 12px;
+	margin: 0 10px 0 auto;
+	padding-top: 30px;
+	z-index: 2;
+	text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );
 }
+
+.tag-stream__header-image-byline-label {
+	opacity: .5;
+}
+
+.tag-stream__header-image-byline-link,
+.tag-stream__header-image-byline-link:visited {
+	color: $white;
+	opacity: .8;
+}
+
+.tag-stream__header-image-byline-link:hover {
+	color: $white;
+}
+

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -9,6 +9,25 @@
 	@include breakpoint( "<660px" ) {
 		margin: 12px 10px 0 0;
 	}
+
+	.gridicon {
+		fill: $blue-medium;
+	}
+
+	.follow-button__label {
+		color: $blue-medium;
+	}
+
+	&.is-following {
+
+		.gridicon {
+			fill: $alert-green;
+		}
+
+		.follow-button__label {
+			color: $alert-green;
+		}
+	}
 }
 
 .tag-stream__header .follow-button__label {
@@ -23,10 +42,10 @@
 	background-size: cover;
 	background-repeat: no-repeat;
 	background-position: right center;
-	box-sizing: border-box;
+	box-sizing: content-box;
 	display: flex;
 	flex-direction: column;
-	min-height: 140px;
+	min-height: 120px;
 	margin-top: 15px;
 	padding: 10px;
 	position: relative;
@@ -34,9 +53,8 @@
 
 	&::before {
 		content: '';
-		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1 ) 100% );
-		height: 140px;
-		opacity: .4;
+		background: rgba( 0, 0, 0, .5 );
+		height: 100%;
 		position: absolute;
 			bottom: 0;
 			left: 0;
@@ -48,22 +66,25 @@
 .tag-stream__header-image-title {
 	color: $white;
 	font-size: 28px;
-	padding-top: 42px;
+	line-height: 1.3;
+	margin-top: 42px;
 	text-align: center;
+	text-transform: capitalize;
 	text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );
+	z-index: 2;
 }
 
 .tag-stream__header-image-byline {
-	color: $white;
-	font-size: 12px;
-	margin: 0 10px 0 auto;
-	padding-top: 30px;
-	z-index: 2;
-	text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );
+    color: $white;
+    font-size: 12px;
+    text-align: right;
+	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+	transform: translateY( 150% );
+    z-index: 2;
 }
 
 .tag-stream__header-image-byline-label {
-	opacity: .5;
+	opacity: .7;
 }
 
 .tag-stream__header-image-byline-link,

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -70,7 +70,7 @@
 	margin-top: 42px;
 	text-align: center;
 	text-transform: capitalize;
-	text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );
+	text-shadow: 0 1px rgba( 0, 0, 0, .3 );
 	z-index: 2;
 }
 
@@ -78,7 +78,7 @@
     color: $white;
     font-size: 12px;
     text-align: right;
-	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+	text-shadow: 0 1px rgba(0, 0, 0, .3);
 	transform: translateY( 150% );
     z-index: 2;
 }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,4 +1,15 @@
 .tag-stream__header-image {
-	background-color: $gray-light; // test style
-	margin-top: 60px;
+	background-color: $gray-light;
+	min-height: 140px;
+}
+
+.tag-stream__header-image-title {
+	text-align: center;
+	font-size: 28px;
+}
+
+.tag-stream__header-image-byline {
+	position: absolute;
+	bottom: 10px;
+	right: 10px;
 }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,6 +1,7 @@
 .tag-stream__header-image {
 	background-color: $gray-light;
 	min-height: 140px;
+	position: relative;
 }
 
 .tag-stream__header-image-title {


### PR DESCRIPTION
This PR implements the new tag stream header described in #9098:

![8a81dcf8-a0ef-11e6-8044-2c8590ef26ca](https://cloud.githubusercontent.com/assets/17325/20729565/70c9c66e-b6e7-11e6-80fb-3735dfd1be87.jpg)

It relies on image data from the new tag images endpoint, so the Redux plumbing in https://github.com/Automattic/wp-calypso/pull/9679 is a prerequisite for this PR to land.
