### PR TITLE
Plans: enable domain-to-plan-nudge for all applicable users

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -30,7 +30,6 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import formatCurrency from 'lib/format-currency';
 import { canCurrentUser } from 'state/current-user/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
-import { abtest } from 'lib/abtest';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 
 class DomainToPlanNudge extends Component {
@@ -65,8 +64,7 @@ class DomainToPlanNudge extends Component {
 			rawPrice &&       //plans info has loaded
 			site &&           //site exists
 			site.wpcom_url && //has a mapped domain
-			hasFreePlan &&    //has a free wpcom plan
-			abtest( 'domainToPersonalPlanNudge3' ) === 'nudge';
+			hasFreePlan;      //has a free wpcom plan
 	}
 
 	personalCheckout = () => {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -96,15 +96,6 @@ module.exports = {
 		defaultVariation: 'hideSiteTitleStep',
 		allowExistingUsers: false
 	},
-	domainToPersonalPlanNudge3: {
-		datestamp: '20161109',
-		variations: {
-			original: 50,
-			nudge: 50
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true
-	},
 
 	gSuiteOnSignup: {
 		datestamp: '20161025',


### PR DESCRIPTION
As a follow up to #9254 this enables the following nudge for folks with a paid domain and a free plan

<img width="850" alt="screen shot 2016-11-29 at 2 44 11 pm" src="https://cloud.githubusercontent.com/assets/1270189/20732405/6a29779a-b643-11e6-9b5b-6fbfe9ea20b1.png">

### Testing Instructions:
- Navigate to http://calypso.localhost:3000/domains
- Select a wpcom site that has a paid domain, but a free plan
- We should see a nudge render below domains
- An impression analytics event should fire:
<img width="1122" alt="screen shot 2016-11-09 at 11 54 24 am" src="https://cloud.githubusercontent.com/assets/1270189/20152839/c4471892-a674-11e6-9a51-3f0951ddb2c7.png">
- Clicking on the nudge takes us to checkout with a personal plan in cart
- The following analytics event should fire:
<img width="1109" alt="screen shot 2016-11-09 at 11 55 11 am" src="https://cloud.githubusercontent.com/assets/1270189/20152855/db578e2c-a674-11e6-92fa-6c9c56490206.png">

cc @rralian @artpi @lamosty @retrofox @obenland 