### PR TITLE
Add a chat with us button to the credit card form in checkout

### DIFF
--- a/client/components/olark-chat-button/index.jsx
+++ b/client/components/olark-chat-button/index.jsx
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { isOperatorsAvailable, isChatAvailable } from 'state/ui/olark/selectors';
+import olarkApi from 'lib/olark-api';
+import olarkActions from 'lib/olark-store/actions';
+import olarkEvents from 'lib/olark-events';
+import analytics from 'lib/analytics';
+
+class OlarkChatButton extends Component {
+	onChatBegin = () => {
+		const { chatContext } = this.props;
+		this.recordChatEvent( 'calypso_chat_button_chat_begin' );
+
+		olarkApi( 'api.chat.sendNotificationToOperator', {
+			body: `Context: ${ chatContext }`
+		} );
+	};
+
+	openChat = ( event ) => {
+		event.preventDefault();
+
+		olarkActions.expandBox();
+		olarkActions.focusBox();
+		this.recordChatEvent( 'calypso_chat_button_click' );
+	};
+
+	componentWillMount() {
+		olarkEvents.on( 'api.chat.onBeginConversation', this.onChatBegin );
+	}
+
+	componentWillUnmount() {
+		olarkEvents.off( 'api.chat.onBeginConversation', this.onChatBegin );
+	}
+
+	recordChatEvent( eventAction ) {
+		const { chatContext, tracksData } = this.props;
+		analytics.tracks.recordEvent( eventAction, {
+			...{ tracksData },
+			chat_context: chatContext,
+		} );
+	}
+
+	render() {
+		const { className, isAvailable, title, borderless } = this.props;
+		const classes = classnames( className, 'olark-chat-button', 'button', {
+			'is-borderless': !! borderless
+		} );
+
+		if ( ! isAvailable ) {
+			return null;
+		}
+
+		return (
+			<button className={ classes } onClick={ this.openChat }>
+				{ title }
+			</button>
+		);
+	}
+}
+
+OlarkChatButton.defaultProps = {
+	tracksData: {},
+};
+
+OlarkChatButton.propTypes = {
+	chatContext: PropTypes.string.isRequired,
+	tracksData: PropTypes.object,
+};
+
+export default connect( ( state, { chatContext } ) => ( {
+	isAvailable: isOperatorsAvailable( state ) && isChatAvailable( state, chatContext ),
+} ) )( OlarkChatButton );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -125,5 +125,14 @@ module.exports = {
 		defaultVariation: 'showPlansAfterAuth',
 		allowExistingUsers: true
 	},
-};
 
+	presaleChatButton: {
+		datestamp: '20161129',
+		variations: {
+			showChatButton: 20,
+			original: 80
+		},
+		defaultVariation: 'original',
+		allowAnyLocale: true,
+	},
+};

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -13,7 +14,10 @@ var PayButton = require( './pay-button' ),
 	analytics = require( 'lib/analytics' ),
 	cartValues = require( 'lib/cart-values' );
 
+import { abtest } from 'lib/abtest';
 import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
+import PaymentChatButton from './payment-chat-button';
+import config from 'config';
 
 var CreditCardPaymentBox = React.createClass( {
 	getInitialState: function() {
@@ -30,6 +34,14 @@ var CreditCardPaymentBox = React.createClass( {
 
 	content: function() {
 		var cart = this.props.cart;
+
+		const showPaymentChatButton =
+			config.isEnabled( 'upgrades/presale-chat' ) &&
+			abtest( 'presaleChatButton' ) === 'showChatButton';
+
+		const paypalButtonClasses = classnames( 'credit-card-payment-box__switch-link', {
+			'credit-card-payment-box__switch-link-left': showPaymentChatButton
+		} );
 
 		return (
 			<form autoComplete="off" onSubmit={ this.props.onSubmit }>
@@ -50,8 +62,16 @@ var CreditCardPaymentBox = React.createClass( {
 						transactionStep={ this.props.transactionStep } />
 
 					{ cartValues.isPayPalExpressEnabled( cart )
-						? <a className="credit-card-payment-box__switch-link" href="" onClick={ this.handleToggle }>{ this.translate( 'or use PayPal' ) }</a>
+						? <a className={ paypalButtonClasses } href="" onClick={ this.handleToggle }>{ this.translate( 'or use PayPal' ) }</a>
 						: null
+					}
+
+					{
+						showPaymentChatButton &&
+						<PaymentChatButton
+							paymentType="credits"
+							cart={ this.props.cart }
+							transactionStep={ this.props.transactionStep } />
 					}
 				</div>
 			</form>

--- a/client/my-sites/upgrades/checkout/credits-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credits-payment-box.jsx
@@ -10,11 +10,17 @@ var PayButton = require( './pay-button' ),
 	PaymentBox = require( './payment-box' ),
 	TermsOfService = require( './terms-of-service' );
 
-import CartCoupon from 'my-sites/upgrades/cart/cart-coupon'
+import { abtest } from 'lib/abtest';
+import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
+import PaymentChatButton from './payment-chat-button';
+import config from 'config';
 
 var CreditsPaymentBox = React.createClass( {
 	content: function() {
-		var cart = this.props.cart;
+		const { cart, transactionStep } = this.props;
+		const showPaymentChatButton =
+			config.isEnabled( 'upgrades/presale-chat' ) &&
+			abtest( 'presaleChatButton' ) === 'showChatButton';
 
 		return (
 			<form onSubmit={ this.props.onSubmit }>
@@ -43,7 +49,14 @@ var CreditsPaymentBox = React.createClass( {
 				<div className="payment-box-actions">
 					<PayButton
 						cart={ this.props.cart }
-						transactionStep={ this.props.transactionStep } />
+						transactionStep={ transactionStep } />
+					{
+						showPaymentChatButton &&
+						<PaymentChatButton
+							paymentType="credits"
+							cart={ cart }
+							transactionStep={ transactionStep } />
+					}
 				</div>
 			</form>
 		);

--- a/client/my-sites/upgrades/checkout/payment-chat-button.jsx
+++ b/client/my-sites/upgrades/checkout/payment-chat-button.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import OlarkChatButton from 'components/olark-chat-button';
+
+export default localize( ( { cart, translate, paymentType, transactionStep } ) => {
+	const { products } = cart;
+	const product = products && products[ 0 ];
+	const productSlug = product && product.product_slug;
+
+	return (
+		<OlarkChatButton
+			borderless
+			className="checkout__payment-chat-button"
+			chatContext="presale"
+			tracksData={ {
+				payment_type: paymentType,
+				transaction_step: transactionStep,
+				product_slug: productSlug,
+			} }
+			title={ translate( 'Need help? Chat with us' ) } />
+	);
+} );

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -818,6 +818,29 @@
 	}
 }
 
+.credit-card-payment-box__switch-link-left {
+	@include breakpoint( ">960px" ) {
+		float: left;
+		padding-left: 20px
+	}
+}
+
+.checkout__payment-chat-button {
+	@include breakpoint( "<660px" ) {
+		width: 100%;
+	}
+
+	@include breakpoint( ">960px" ) {
+		float: right;
+	}
+}
+
+.credits-payment-box .checkout__payment-chat-button {
+	@include breakpoint( ">660px" ) {
+		float: right;
+	}
+}
+
 .checkout__domain-details-form-submit-button {
 	clear: both;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -152,6 +152,7 @@
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
+		"upgrades/presale-chat": true,
 		"vip": false,
 		"vip/backups": true,
 		"vip/billing": true,


### PR DESCRIPTION
This pull request adds a "Chat with us" button to the credit card variation of the checkout screen so that we can offer users the chance to chat with a Happiness Engineer before making their purchase.

Note that the first two commits in this pull request come from #9584 and has not been merged yet.

For now the button sits behind the `upgrades/presale-chat` feature flag.

### How to test
1. Navigate to http://calypso.localhost:3000/plans
2. From the browser console enter: `localStorage.setItem( 'ABTests', '{"presaleChatButton_20161129":"showChatButton"}' )`. This will allow us to bypass the abtest
3. Select an upgrade
4. Notice on the checkout screen you will see a new button on the bottom right labeled "Need help? Chat with us"
5. Click the chat with us button.
6. Within tracks notice that a ping has been made for `calypso_chat_button_click`
7. Start a chat.
8. Within olark notice that the user is tagged with "Context: presale"
9. Check tracks and notice that another ping has made for `calypso_chat_button_chat_begin`


### What to expect
![screen shot 2016-11-29 at 6 13 55 pm](https://cloud.githubusercontent.com/assets/1854440/20733770/40313d18-b663-11e6-8d12-f8a5fd89750f.png)
![screen shot 2016-11-29 at 6 13 40 pm](https://cloud.githubusercontent.com/assets/1854440/20733773/432d8fd0-b663-11e6-8019-7b32784d6f63.png)
![screen shot 2016-11-29 at 6 13 16 pm](https://cloud.githubusercontent.com/assets/1854440/20733777/468ac3d2-b663-11e6-82ab-09ea85e5acdd.png)