### PR TITLE
Follow Button: allow a custom follow label to be specified

### DIFF
--- a/client/components/follow-button/button.jsx
+++ b/client/components/follow-button/button.jsx
@@ -1,8 +1,9 @@
 /**
-* External dependencies
-*/
+ * External Dependencies
+ */
 import React, { PropTypes } from 'react';
 import { noop } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 const FollowButton = React.createClass( {
 
@@ -11,7 +12,8 @@ const FollowButton = React.createClass( {
 		onFollowToggle: PropTypes.func,
 		iconSize: PropTypes.number,
 		tagName: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
-		disabled: PropTypes.bool
+		disabled: PropTypes.bool,
+		followLabel: PropTypes.string
 	},
 
 	getDefaultProps() {
@@ -26,8 +28,8 @@ const FollowButton = React.createClass( {
 
 	componentWillMount() {
 		this.strings = {
-			FOLLOW: this.translate( 'Follow' ),
-			FOLLOWING: this.translate( 'Following' )
+			FOLLOW: this.props.translate( 'Follow' ),
+			FOLLOWING: this.props.translate( 'Following' )
 		};
 	},
 
@@ -46,7 +48,7 @@ const FollowButton = React.createClass( {
 	},
 
 	render() {
-		let label = this.strings.FOLLOW;
+		let label = this.props.followLabel ? this.props.followLabel : this.strings.FOLLOW;
 		const menuClasses = [ 'button', 'follow-button', 'has-icon' ];
 		const iconSize = this.props.iconSize;
 
@@ -61,15 +63,15 @@ const FollowButton = React.createClass( {
 
 		const followingIcon = ( <svg key="following" className="gridicon gridicon__following" height={ iconSize + 'px' } width={ iconSize + 'px' } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M23 13.482L15.508 21 12 17.4l1.412-1.388 2.106 2.188 6.094-6.094L23 13.482zm-7.455 1.862L20 10.89V2H2v14c0 1.1.9 2 2 2h4.538l4.913-4.832 2.095 2.176zM8 13H4v-1h4v1zm3-2H4v-1h7v1zm0-2H4V8h7v1zm7-3H4V4h14v2z" /></g></svg> ),
 			followIcon = ( <svg key="follow" className="gridicon gridicon__follow" height={ iconSize + 'px' } width={ iconSize + 'px' } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" /></g></svg> ),
-			followLabel = ( <span key="label" className="follow-button__label">{ label }</span> );
+			followLabelElement = ( <span key="label" className="follow-button__label">{ label }</span> );
 
 		return React.createElement( this.props.tagName, {
 			onClick: this.toggleFollow,
 			className: menuClasses.join( ' ' ),
 			title: label
-		}, [ followingIcon, followIcon, followLabel ] );
+		}, [ followingIcon, followIcon, followLabelElement ] );
 	}
 
 } );
 
-export default FollowButton;
+export default localize( FollowButton );

--- a/client/components/follow-button/docs/example.jsx
+++ b/client/components/follow-button/docs/example.jsx
@@ -27,6 +27,10 @@ export default React.createClass( {
 				<Card compact>
 					<FollowButton disabled={ true } />
 				</Card>
+				<Card compact>
+					<h3>With custom label</h3>
+					<FollowButton followLabel="Follow Tag" />
+				</Card>
 			</div>
 		);
 	}

--- a/client/components/follow-button/test/button.js
+++ b/client/components/follow-button/test/button.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { render } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import FollowButton from '../button';
+
+describe( 'FollowButton', () => {
+	// it should have a class of `card`
+	it( 'should apply a custom follow label', () => {
+		const wrapper = render( <FollowButton followLabel="Follow Tag" /> );
+		expect( wrapper.text() ).to.contain( 'Follow Tag' );
+	} );
+} );

--- a/client/components/follow-button/test/button.js
+++ b/client/components/follow-button/test/button.js
@@ -11,7 +11,6 @@ import { render } from 'enzyme';
 import FollowButton from '../button';
 
 describe( 'FollowButton', () => {
-	// it should have a class of `card`
 	it( 'should apply a custom follow label', () => {
 		const wrapper = render( <FollowButton followLabel="Follow Tag" /> );
 		expect( wrapper.text() ).to.contain( 'Follow Tag' );


### PR DESCRIPTION
The new Reader tag stream header (https://github.com/Automattic/wp-calypso/issues/9098) calls for a custom label on the follow button in 'unfollowed' state.

This PR adds a new prop, `followLabel`, that applies a custom label to the button:

<img width="303" alt="screen shot 2016-11-30 at 13 08 29" src="https://cloud.githubusercontent.com/assets/17325/20734406/1f20b900-b6fe-11e6-8450-09a0c378600e.png">

### To test 

Check out devdocs:

http://calypso.localhost:3000/devdocs/blocks/follow-button

Run the test:

`npm run test-client client/components/follow-button`

### Known issues 

These will be addressed in later PRs:
- `follow-button` is in the components directory, but the devdocs example is in blocks (component needs moving to blocks)
- button component and devdocs example need to use `React.Component` (or stateless functional component for the devdocs example)
