### PR TITLE
TermFormDialog: update validation to not allow duplicate term names.

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -184,8 +184,7 @@ class TermFormDialog extends Component {
 		const matchingTerm = find( this.props.terms, ( term ) => {
 			return (
 				term.name.toLowerCase() === lowerCasedTermName &&
-				( ! this.props.term || term.ID !== this.props.term.ID ) &&
-				( ! this.props.isHierarchical || ( term.parent === values.parent ) )
+				( ! this.props.term || term.ID !== this.props.term.ID )
 			);
 		} );
 


### PR DESCRIPTION
This closes #9496 - although a fix is in place in the API to return an error message instead of a 500, we still need to close the issue of duplicate term names not being able to be used when updating a term.

The current logic allows for duplicate term names for hierarchical taxonomies, as long as the duplicate terms do not live at the same level in the tree.  This is working fine on initial creation, but updates are not working properly - due to some issues with underlying core logic in `wp_update_term`.

This branch restricts using an identical term name regardless of if a term is hierarchical or not - so a term name can only exist once in the entire tree.  Ideally it would be best to revert this logic once we have a more permanent fix in place on the API side of things, but this will have to do for now... unless someone has another idea ( /cc @youknowriad @aduth )

__To Test__
- Open up a [site settings writing page](http://calypso.localhost:3000/settings/writing)
- Select categories
- Click Add New Category
- Try to use an existing category name in the form, note the validation will not let this happen regardless of parent