### PR TITLE
Add MC tracking to Jetpack Plans selection when Free Jetpack plan is selected

### DIFF
--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -187,6 +187,8 @@ class Plans extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_submit_free', {
 			user: this.props.userId
 		} );
+		mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_free' );
+
 		if ( this.props.calypsoStartedConnection ) {
 			this.redirect( CALYPSO_REDIRECTION_PAGE );
 		} else {


### PR DESCRIPTION
This pull request seeks to implement MC stat bumping for interactions on the Plans Page for Jetpack connections when selecting the Free Plan.

**Why**

We introduced MC stats bumping in #9617 but not for Free Plans. 

**Testing instructions:**

_Incoming..._