### PR TITLE
Plugins: Improve styles for code blocks

### DIFF
--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -31,13 +31,14 @@ a:active {
 }
 
 code {
-	background: lighten( $gray, 30% );
+	background: $gray-light;
 	font-family: $code;
-	padding: 4px 8px;
+	padding: 1px 4px;
+	border-radius: 2px;
 }
 
 pre {
-	background: lighten( $gray, 34% );
+	background: $gray-light;
 	font-family: $code;
 	padding: 8px;
 

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -50,6 +50,15 @@
 			margin-bottom: 0;
 		}
 	}
+	code {
+		font-size: 14px;
+		padding: 2px 5px;
+		background: $gray-light;
+	}
+	> code {
+		display: block;
+		margin-bottom: 16px;
+	}
 }
 
 .plugin-sections__read-more {

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -52,7 +52,7 @@
 	}
 	code {
 		font-size: 14px;
-		padding: 2px 5px;
+		padding: 4px 8px;
 		background: $gray-light;
 	}
 	> code {

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -52,12 +52,15 @@
 	}
 	code {
 		font-size: 14px;
-		padding: 4px 8px;
+		padding: 1px 4px;
+		border-radius: 2px;
 		background: $gray-light;
 	}
 	> code {
 		display: block;
 		margin-bottom: 16px;
+		padding: 8px;
+		border-radius: 0;
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -234,7 +234,7 @@
 
 	.notes {
 		background: $gray-light;
-		margin: 40px -20px -20px;
+		margin: 40px -20px 40px;
 		border-top: 1px solid #e9eff3;
 		padding: 20px;
 
@@ -260,6 +260,10 @@
 
 		:last-child {
 			margin-bottom: 5px;
+		}
+
+		&:last-child {
+			margin-bottom: -20px;
 		}
 	}
 }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -223,7 +223,17 @@
 	}
 
 	pre {
+		font-family: $code;
+		font-size: 14px;
 		white-space: pre-wrap;
+		padding: 8px;
+	}
+
+	code {
+		font-size: 14px;
+		background: $gray-light;
+		padding: 1px 4px;
+		border-radius: 2px;
 	}
 
 	blockquote {
@@ -236,6 +246,7 @@
 		background: $gray-light;
 		margin: 40px -20px 40px;
 		border-top: 1px solid #e9eff3;
+		border-bottom: 1px solid #e9eff3;
 		padding: 20px;
 
 		font-size: 13px;
@@ -264,6 +275,7 @@
 
 		&:last-child {
 			margin-bottom: -20px;
+			border-bottom: 0;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes #9717, improving the look of the inline and wide code blocks.

### Before

**WIde code blocks**
![screen shot 2016-11-30 at 17 00 59](https://cloud.githubusercontent.com/assets/8436925/20757600/a18ed3f6-b71f-11e6-8d68-4da753463388.png)

**Inline code blocks**
![screen shot 2016-11-30 at 17 01 24](https://cloud.githubusercontent.com/assets/8436925/20757603/a4c9c896-b71f-11e6-8fa3-de83e26bd4c4.png)

### After

**WIde code blocks**
![screen shot 2016-11-30 at 17 00 35](https://cloud.githubusercontent.com/assets/8436925/20757621/bb83fd7c-b71f-11e6-940a-8402aa619546.png)

**Inline code blocks**
![screen shot 2016-11-30 at 17 01 15](https://cloud.githubusercontent.com/assets/8436925/20757625/c10d1f94-b71f-11e6-8ca3-d2e1d9c14858.png)

### To test

* Checkout this branch.
* Go to `/plugins/really-simple-captcha/$site`, where `$site` is a Jetpack site.
* Click the "Read More" link in the "Description" tab.
* Verify wide code blocks look as shown in the "After" screenshot.
* Verify inline code blocks look as shown in the "After" screenshot.

/cc @rickybanister @keoshi @MichaelArestad - any suggestions to make this look better are very welcome.