### PR TITLE
Guided Tours: prevent errors on single-step tours

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -66,8 +66,10 @@ export class Tour extends Component {
 	render() {
 		const { children } = this.props;
 		const { step } = this.context;
-		const nextStep = find( children, stepComponent =>
-			stepComponent.props.name === step );
+		const nextStep = Array.isArray( children )
+			? find( children, stepComponent =>
+				stepComponent.props.name === step )
+			: children;
 
 		return nextStep || null;
 	}


### PR DESCRIPTION
See: https://github.com/Automattic/wp-calypso/pull/9699#issuecomment-263732634

React handles multiple children as Array, but single child as Object,
breaking the `Tour` render method's `nextStep`.

This PR simply adds a check on `this.props.children`.
If it's an array, performs the current `_.find` logic to find the actual next step child.
Otherwise simply returns `this.props.children` itself.

cc @mcsf 