### PR TITLE
Jetpack: Use raw redux site when creating Jetpack site

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -30,7 +30,7 @@ import utils from 'lib/site/utils';
 
 // Redux actions & selectors
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, isRequestingSites } from 'state/sites/selectors';
+import { isJetpackSite, isRequestingSites, getRawSite } from 'state/sites/selectors';
 import { getPlugin } from 'state/plugins/wporg/selectors';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { requestSites } from 'state/sites/actions';
@@ -508,6 +508,11 @@ export default connect(
 		const site = getSelectedSite( state );
 		const whitelist = ownProps.whitelist || false;
 
+		// We need to pass the raw redux site to JetpackSite() in order to properly build the site.
+		const selectedSite = site && isJetpackSite( state, siteId )
+			? JetpackSite( getRawSite( state, siteId ) )
+			: site;
+
 		return {
 			wporg: state.plugins.wporg.items,
 			isRequesting: isRequesting( state, siteId ),
@@ -517,7 +522,7 @@ export default connect(
 			plugins: getPluginsForSite( state, siteId, whitelist ),
 			activePlugin: getActivePlugin( state, siteId, whitelist ),
 			nextPlugin: getNextPlugin( state, siteId, whitelist ),
-			selectedSite: site && isJetpackSite( state, siteId ) ? JetpackSite( site ) : site,
+			selectedSite: selectedSite,
 			isRequestingSites: isRequestingSites( state ),
 			siteId
 		};

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -30,7 +30,7 @@ import FeatureExample from 'components/feature-example';
 import DocumentHead from 'components/data/document-head';
 import WpcomPluginsList from 'my-sites/plugins-wpcom/plugins-list';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, canJetpackSiteManage } from 'state/sites/selectors';
+import { isJetpackSite, canJetpackSiteManage, getRawSite } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 const SinglePlugin = React.createClass( {
@@ -395,10 +395,15 @@ export default connect(
 		const selectedSiteId = getSelectedSiteId( state );
 		const site = getSelectedSite( state );
 
+		// We need to pass the raw redux site to JetpackSite() in order to properly build the site.
+		const selectedSite = site && isJetpackSite( state, selectedSiteId )
+			? JetpackSite( getRawSite( state, selectedSiteId ) )
+			: site;
+
 		return {
 			wporgPlugins: state.plugins.wporg.items,
 			wporgFetching: WporgPluginsSelectors.isFetching( state.plugins.wporg.fetchingItems, props.pluginSlug ),
-			selectedSite: site && isJetpackSite( state, selectedSiteId ) ? JetpackSite( site ) : site,
+			selectedSite: selectedSite,
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),
 			canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
 		};


### PR DESCRIPTION
This PR begins sending the raw redux site when creating a Jetpack site, as opposed to how we were previously sending the computed attributes from redux when creating the Jetpack site.