### PR TITLE
Framework: Optimize decodeEntities to skip unnecessary decoding

### DIFF
--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -7,12 +7,11 @@ import stripTags from 'striptags';
 /**
  * Internal Dependencies
  */
-import warn from 'lib/warn';
 import decode from './decode-entities';
 
 function decodeEntities( text ) {
-	if ( text === undefined || text === false || text === null ) {
-		warn( 'Don\'t call `decodeEntities` with an `undefined`, `false`, or `null` value.' );
+	// Bypass decode if text doesn't include entities
+	if ( 'string' !== typeof text || -1 === text.indexOf( '&' ) ) {
 		return text;
 	}
 

--- a/client/state/document-head/selectors.js
+++ b/client/state/document-head/selectors.js
@@ -6,6 +6,7 @@ import { compact } from 'lodash';
 /**
  * Internal dependencies
  */
+import createSelector from 'lib/create-selector';
 import { decodeEntities } from 'lib/formatting';
 import { getSelectedSiteId, isSiteSection } from 'state/ui/selectors';
 import { getSiteTitle } from 'state/sites/selectors';
@@ -59,25 +60,28 @@ export function getDocumentHeadCappedUnreadCount( state ) {
  * @param  {Object}  state  Global state tree
  * @return {String}         Formatted title
  */
-export function getDocumentHeadFormattedTitle( state ) {
-	let title = '';
+export const getDocumentHeadFormattedTitle = createSelector(
+	( state ) => {
+		let title = '';
 
-	const unreadCount = getDocumentHeadCappedUnreadCount( state );
-	if ( unreadCount ) {
-		title += `(${ unreadCount }) `;
-	}
+		const unreadCount = getDocumentHeadCappedUnreadCount( state );
+		if ( unreadCount ) {
+			title += `(${ unreadCount }) `;
+		}
 
-	title += compact( [
-		getDocumentHeadTitle( state ),
-		isSiteSection( state ) && getSiteTitle( state, getSelectedSiteId( state ) )
-	] ).join( ' ‹ ' );
+		title += compact( [
+			getDocumentHeadTitle( state ),
+			isSiteSection( state ) && getSiteTitle( state, getSelectedSiteId( state ) )
+		] ).join( ' ‹ ' );
 
-	if ( title ) {
-		title = decodeEntities( title ) + ' — ';
-	}
+		if ( title ) {
+			title = decodeEntities( title ) + ' — ';
+		}
 
-	return title + 'WordPress.com';
-}
+		return title + 'WordPress.com';
+	},
+	( state ) => state.documentHead
+);
 
 /**
  * Returns an array of document meta objects as set by the DocumentHead

--- a/client/state/document-head/test/selectors.js
+++ b/client/state/document-head/test/selectors.js
@@ -16,6 +16,10 @@ import {
 } from '../selectors';
 
 describe( 'selectors', () => {
+	beforeEach( () => {
+		getDocumentHeadFormattedTitle.memoizedSelector.cache.clear();
+	} );
+
 	describe( '#getDocumentHeadTitle()', () => {
 		it( 'should return the currently set title', () => {
 			const title = getDocumentHeadTitle( {


### PR DESCRIPTION
This pull request seeks to replace the current `decodeEntities` implementation with a much simpler alternative, with the hopes of improving performance. `decodeEntities` is a top culprit in profiling page transitions in Calypso, often the top time-consuming function in Chrome Timeline reports:

Before|After
---|---
![decodeEntities before](https://cloud.githubusercontent.com/assets/1779930/20763137/d4611e5c-b6f6-11e6-9fae-a0f39295a826.png)|![decodeEntities after](https://cloud.githubusercontent.com/assets/1779930/20767603/ea102a56-b708-11e6-855c-46836f5d26c2.png)

_([See earlier implementation results](https://cloud.githubusercontent.com/assets/1779930/20764198/22b5cf2c-b6fb-11e6-870c-824896fab034.png))_

__Implementation notes:__

~~With these changes, `decodeEntities` will no longer decode all entities, only those which we expect to have been encoded by the [WordPress `_wp_specialchars` method](https://developer.wordpress.org/reference/functions/_wp_specialchars/). In other words, it should now mimic the behavior of [`wp_specialchars_decode`](https://developer.wordpress.org/reference/functions/wp_specialchars_decode/).~~

~~There was previously a test that expected entities like `&#209;` (Ñ) to have been decoded for plugin authors, but in my real-world testing, I find that these entities are never encoded to begin with and continue to display correctly. You can verify this yourself with [an example plugin](https://cloudup.com/cnpODyBf7LI) which specifies an author name including both "&" and "Ñ" characters. On the plugin detail screen, the author name shows correctly as "Andrew Duthie Ñáð & Friends". cc @enejb re: 6123-gh-calypso-pre-oss~~

Another minor optimization inspired by the `wp_specialchars_decode` implementation is to skip replacement attempts if there are no entities in the text argument, detected by presence of a `&` character.

**Edit:** After further review, it was determined that we rely on full entity decoding in many places (Reader, post titles with user-entered entities such as `&bull;`). The changes here are limited to the above-noted inspired `&` check optimization, and memoization of the title-generating selector which makes use of `decodeEntities` on every screen.

__Testing instructions:__

Verify that wherever content is rendered using REST API data where text would be encoded (e.g. post titles, assigned categories), that the text continues to display as decoded. This should include expected encoded values `&` `<` `>` `'` `"` as well as other special characters that are never encoded `Ñ` `á` `ð`.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter title "Ñáð & Friends"
4. Save post
5. Return to posts listing
6. Note that draft title is rendered exactly as "Ñáð & Friends"

__Open questions:__

~~Is there anywhere in the codebase that we're expecting `decodeEntities` to decode more than just the entities that would have been encoded by WordPress core logic?~~

cc @blowery 