### PR TITLE
Limit pre sales chat to the business bundle

### DIFF
--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -18,6 +18,8 @@ import { abtest } from 'lib/abtest';
 import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import config from 'config';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { some } from 'lodash';
 
 var CreditCardPaymentBox = React.createClass( {
 	getInitialState: function() {
@@ -35,8 +37,10 @@ var CreditCardPaymentBox = React.createClass( {
 	content: function() {
 		var cart = this.props.cart;
 
+		const hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } );
 		const showPaymentChatButton =
 			config.isEnabled( 'upgrades/presale-chat' ) &&
+			hasBusinessPlanInCart &&
 			abtest( 'presaleChatButton' ) === 'showChatButton';
 
 		const paypalButtonClasses = classnames( 'credit-card-payment-box__switch-link', {

--- a/client/my-sites/upgrades/checkout/credits-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credits-payment-box.jsx
@@ -14,12 +14,16 @@ import { abtest } from 'lib/abtest';
 import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import config from 'config';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { some } from 'lodash';
 
 var CreditsPaymentBox = React.createClass( {
 	content: function() {
 		const { cart, transactionStep } = this.props;
+		const hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } );
 		const showPaymentChatButton =
 			config.isEnabled( 'upgrades/presale-chat' ) &&
+			hasBusinessPlanInCart &&
 			abtest( 'presaleChatButton' ) === 'showChatButton';
 
 		return (


### PR DESCRIPTION
This pull request limits pre sales chat to users who have the business bundle in their shopping carts.

### How to test
1. Navigate to http://calypso.localhost:3000/plans
2. From the browser console enter: `localStorage.setItem( 'ABTests', '{"presaleChatButton_20161129":"showChatButton"}' )`. This will allow us to bypass the abtest
3. Select any other plan than "Business"
4. Notice on the checkout screen you no longer see the "Need help? Chat with us" button
5. Go back and select the "Business" plan.
6. Notice that the "Need help? Chat with us" button appears

### What to expect
![screen shot 2016-11-30 at 1 19 58 pm](https://cloud.githubusercontent.com/assets/1854440/20765451/61c26a90-b700-11e6-9a20-b74139084fb0.png)
![screen shot 2016-11-30 at 1 20 21 pm](https://cloud.githubusercontent.com/assets/1854440/20765460/6a4eb8b2-b700-11e6-8801-0fa74f74a3b2.png)
