### PR TITLE
Posts: Pick the canonical image after running makeImagesSafe

### DIFF
--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -134,11 +134,11 @@ var utils = {
 				postNormalizer.decodeEntities,
 				postNormalizer.stripHTML,
 				postNormalizer.safeImageProperties( imageWidth ),
-				postNormalizer.firstPassCanonicalImage,
 				postNormalizer.withContentDOM( [
 					postNormalizer.content.removeStyles,
 					postNormalizer.content.makeImagesSafe( imageWidth )
-				] )
+				] ),
+				postNormalizer.firstPassCanonicalImage
 			],
 			callback
 		);


### PR DESCRIPTION
This helps us get better images from the content of a post. `makeImagesSafe` now extracts the width and height of images in the body of the post when it can, and moving the canonical picker after this happens lets it pick up those images as candidates.

Fixes #9720