### PR TITLE
Reader Refresh 2: add tag stream header with tag background image

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -412,6 +412,7 @@
 @import 'reader/site-and-author-icon/style';
 @import 'reader/site-stream/style';
 @import 'reader/start/style';
+@import 'reader/tag-stream/style';
 @import 'reader/style';
 @import 'reader/stream-header/style';
 @import 'reader/update-notice/style';

--- a/client/components/follow-button/button.jsx
+++ b/client/components/follow-button/button.jsx
@@ -13,7 +13,8 @@ const FollowButton = React.createClass( {
 		iconSize: PropTypes.number,
 		tagName: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
 		disabled: PropTypes.bool,
-		followLabel: PropTypes.string
+		followLabel: PropTypes.string,
+		followingLabel: PropTypes.string,
 	},
 
 	getDefaultProps() {
@@ -54,7 +55,7 @@ const FollowButton = React.createClass( {
 
 		if ( this.props.following ) {
 			menuClasses.push( 'is-following' );
-			label = this.strings.FOLLOWING;
+			label = this.props.followingLabel ? this.props.followingLabel : this.strings.FOLLOWING;
 		}
 
 		if ( this.props.disabled ) {

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import FollowButton from 'components/follow-button/button';
+import QueryReaderTagImages from 'components/data/query-reader-tag-images';
+import { getFirstImageForTag } from 'state/reader/tags/images/selectors';
+import resizeImageUrl from 'lib/resize-image-url';
+import cssSafeUrl from 'lib/css-safe-url';
+import { decodeEntities } from 'lib/formatting';
+
+const TAG_HEADER_WIDTH = 830;
+
+const TagStreamHeader = ( { tag, tagImage, isPlaceholder, showFollow, following, onFollowToggle, translate } ) => {
+	const classes = classnames( {
+		'tag-stream__header': true,
+		'is-placeholder': isPlaceholder
+	} );
+	const imageStyle = {};
+
+	if ( tagImage ) {
+		const imageUrl = resizeImageUrl( tagImage.url, { w: TAG_HEADER_WIDTH } );
+		const safeCssUrl = cssSafeUrl( imageUrl );
+		imageStyle.backgroundImage = 'url(//' + safeCssUrl + ')';
+	}
+
+	return (
+		<div className={ classes }>
+			<QueryReaderTagImages tag={ tag } />
+			{ showFollow &&
+				<div className="tag-stream__header-follow">
+					<FollowButton
+						followLabel={ translate( 'Follow Tag' ) }
+						followingLabel={ translate( 'Following Tag' ) }
+						iconSize={ 24 }
+						following={ following }
+						onFollowToggle={ onFollowToggle } />
+				</div>
+			}
+
+			<div className="tag-stream__header-image" style={ imageStyle }>
+				<h1 className="tag-stream__header-image-title">{ tag }</h1>
+				{ tagImage &&
+					<div className="tag-stream__header-image-byline">
+						<span className="tag-stream__header-image-byline-label">{ translate( 'Photo by' ) }</span> <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="author external">{ decodeEntities( tagImage.author ) }</a>, <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="external">{ decodeEntities( tagImage.blog_title ) }</a>
+					</div>
+				}
+			</div>
+		</div>
+	);
+};
+
+TagStreamHeader.propTypes = {
+	isPlaceholder: React.PropTypes.bool,
+	tag: React.PropTypes.string,
+	showFollow: React.PropTypes.bool,
+	following: React.PropTypes.bool,
+	onFollowToggle: React.PropTypes.func
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			tagImage: getFirstImageForTag( state, ownProps.tag )
+		};
+	}
+)( localize( TagStreamHeader ) );

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -17,6 +17,8 @@ import TagStreamHeader from './header';
 import smartSetState from 'lib/react-smart-set-state';
 import * as stats from 'reader/stats';
 import HeaderBack from 'reader/header-back';
+import StreamHeader from 'reader/stream-header'; // pre-refresh
+import config from 'config';
 
 const TagStream = React.createClass( {
 
@@ -95,11 +97,20 @@ const TagStream = React.createClass( {
 			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
 				{ this.props.showBack && <HeaderBack /> }
-				<TagStreamHeader
-					tag={ this.props.tag }
-					showFollow={ this.state.canFollow }
-					following={ this.state.subscribed }
-					onFollowToggle={ this.toggleFollowing } />
+				{ config.isEnabled( 'reader/refresh/stream' )
+					? <TagStreamHeader
+						tag={ this.props.tag }
+						showFollow={ this.state.canFollow }
+						following={ this.state.subscribed }
+						onFollowToggle={ this.toggleFollowing } />
+					: <StreamHeader
+						isPlaceholder={ false }
+						icon={ <svg className="gridicon gridicon__tag" height="32" width="32" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M16 7H5c-1.105 0-2 .896-2 2v6c0 1.104.895 2 2 2h11l5-5-5-5z"/></g></svg> }
+						title={ title }
+						showFollow={ this.state.canFollow }
+						following={ this.state.subscribed }
+						onFollowToggle={ this.toggleFollowing } />
+				}
 			</Stream>
 		);
 	}

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -13,10 +13,10 @@ import EmptyContent from './empty';
 import ReaderTags from 'lib/reader-tags/tags';
 import ReaderTagActions from 'lib/reader-tags/actions';
 import TagSubscriptions from 'lib/reader-tags/subscriptions';
-import StreamHeader from 'reader/stream-header';
-import HeaderBack from 'reader/header-back';
+import TagStreamHeader from './header';
 import smartSetState from 'lib/react-smart-set-state';
 import * as stats from 'reader/stats';
+import HeaderBack from 'reader/header-back';
 
 const TagStream = React.createClass( {
 
@@ -93,12 +93,10 @@ const TagStream = React.createClass( {
 
 		return (
 			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
-				{ this.props.showBack && <HeaderBack /> }
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
-				<StreamHeader
-					isPlaceholder={ false }
-					icon={ <svg className="gridicon gridicon__tag" height="32" width="32" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M16 7H5c-1.105 0-2 .896-2 2v6c0 1.104.895 2 2 2h11l5-5-5-5z"/></g></svg> }
-					title={ title }
+				{ this.props.showBack && <HeaderBack /> }
+				<TagStreamHeader
+					tag={ this.props.tag }
 					showFollow={ this.state.canFollow }
 					following={ this.state.subscribed }
 					onFollowToggle={ this.toggleFollowing } />

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -53,7 +53,7 @@
 
 	&::before {
 		content: '';
-		background: rgba( 0, 0, 0, .5 );
+		background: rgba( 0, 0, 0, .3 );
 		height: 100%;
 		position: absolute;
 			bottom: 0;

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,0 +1,99 @@
+.tag-stream__header {
+	display: flex;
+	flex-direction: column;
+}
+
+.tag-stream__header .follow-button {
+	padding: 0;
+
+	@include breakpoint( "<660px" ) {
+		margin: 12px 10px 0 0;
+	}
+
+	.gridicon {
+		fill: $blue-medium;
+	}
+
+	.follow-button__label {
+		color: $blue-medium;
+	}
+
+	&.is-following {
+
+		.gridicon {
+			fill: $alert-green;
+		}
+
+		.follow-button__label {
+			color: $alert-green;
+		}
+	}
+}
+
+.tag-stream__header .follow-button__label {
+
+	@include breakpoint( "<660px" ) {
+		display: inline;
+	}
+}
+
+.tag-stream__header-image {
+	background: lighten( $gray, 30% );
+	background-size: cover;
+	background-repeat: no-repeat;
+	background-position: right center;
+	box-sizing: content-box;
+	display: flex;
+	flex-direction: column;
+	min-height: 120px;
+	margin-top: 15px;
+	padding: 10px;
+	position: relative;
+	z-index: 0;
+
+	&::before {
+		content: '';
+		background: rgba( 0, 0, 0, .5 );
+		height: 100%;
+		position: absolute;
+			bottom: 0;
+			left: 0;
+		width: 100%;
+		z-index: 1;
+	}
+}
+
+.tag-stream__header-image-title {
+	color: $white;
+	font-size: 28px;
+	line-height: 1.3;
+	margin-top: 42px;
+	text-align: center;
+	text-transform: capitalize;
+	text-shadow: 0 1px rgba( 0, 0, 0, .3 );
+	z-index: 2;
+}
+
+.tag-stream__header-image-byline {
+	color: $white;
+	font-size: 12px;
+	text-align: right;
+	text-shadow: 0 1px rgba(0, 0, 0, .3);
+	transform: translateY( 150% );
+	z-index: 2;
+}
+
+.tag-stream__header-image-byline-label {
+	opacity: .7;
+}
+
+.tag-stream__header-image-byline-link,
+.tag-stream__header-image-byline-link:visited {
+	color: $white;
+	opacity: .8;
+}
+
+.tag-stream__header-image-byline-link:hover {
+	color: $white;
+}
+


### PR DESCRIPTION
Reverts Automattic/wp-calypso#9735.

This is attempt 2 at launching PR #9704, which adds tag images to the Reader tag stream header.

#9704 inadvertently launched this feature to the pre-Refresh Reader too.