### PR TITLE
Update/theme activated action sig

### DIFF
--- a/client/my-sites/customize/actions.js
+++ b/client/my-sites/customize/actions.js
@@ -33,18 +33,12 @@ var CustomizeActions = {
 	// `themeActivated` shouldn't be passed as an argument anymore,
 	// but directly imported and dispatch()ed from inside `activated()`,
 	// which needs to be turned into a Redux thunk.
-	activated: function( id, site, themeActivated ) {
+	activated: function( stylesheet, site, themeActivated ) {
 		trackClick( 'customizer', 'activate' );
 
 		page( '/design/' + site.slug );
 
-		themeActivated( id, site.ID, 'customizer' );
-
-		Dispatcher.handleViewAction( {
-			type: 'THEME_ACTIVATED_WITH_CUSTOMIZER',
-			id: id,
-			site: site
-		} );
+		themeActivated( stylesheet, site.ID, 'customizer' );
 	},
 
 	close: function( previousPath ) {

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -233,8 +233,7 @@ var Customize = React.createClass( {
 					this.setState( { iframeLoaded: true } );
 					break;
 				case 'activated':
-					themeSlug = message.theme.stylesheet.split( '/' )[ 1 ];
-					Actions.activated( themeSlug, site, this.props.themeActivated );
+					Actions.activated( message.theme.stylesheet, site, this.props.themeActivated );
 					break;
 				case 'purchased':
 					themeSlug = message.theme.stylesheet.split( '/' )[ 1 ];

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -147,7 +147,8 @@ const CheckoutThankYou = React.createClass( {
 
 	redirectIfThemePurchased() {
 		if ( this.props.receipt.hasLoadedFromServer && getPurchases( this.props ).every( isTheme ) ) {
-			this.props.activatedTheme( getPurchases( this.props )[ 0 ].meta, this.props.selectedSite.ID );
+			const themeId = getPurchases( this.props )[ 0 ].meta;
+			this.props.activatedTheme( 'premium/' + themeId, this.props.selectedSite.ID );
 
 			page.redirect( '/design/' + this.props.selectedSite.slug );
 		}

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -109,7 +109,7 @@ export function items( state = {}, action ) {
 			}, {} );
 
 		case THEME_ACTIVATE_REQUEST_SUCCESS:
-			const { siteId, theme } = action;
+			const { siteId, themeStylesheet } = action;
 			const site = state[ siteId ];
 			if ( ! site ) {
 				break;
@@ -119,7 +119,7 @@ export function items( state = {}, action ) {
 				...state,
 				[ siteId ]: merge( {}, site, {
 					options: {
-						theme_slug: theme.stylesheet
+						theme_slug: themeStylesheet
 					}
 				} )
 			};

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -226,10 +226,7 @@ describe( 'reducer', () => {
 			const state = items( original, {
 				type: THEME_ACTIVATE_REQUEST_SUCCESS,
 				siteId: 2916284,
-				theme: {
-					name: 'Twenty Sixteen',
-					stylesheet: 'pub/twentysixteen'
-				}
+				themeStylesheet: 'pub/twentysixteen'
 			} );
 
 			expect( state ).to.eql( {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -41,7 +41,7 @@ import {
 import { getCurrentTheme } from './current-theme/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getQueryParams } from './themes-list/selectors';
-import { getThemeById } from './themes/selectors';
+import { getThemeIdFromStylesheet } from './utils';
 
 const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
 
@@ -362,7 +362,8 @@ export function activateTheme( themeId, siteId, source = 'unknown', purchased = 
 
 		return wpcom.undocumented().activateTheme( themeId, siteId )
 			.then( ( theme ) => {
-				dispatch( themeActivated( theme, siteId, source, purchased ) );
+				const themeStylesheet = theme.stylesheet || themeId; // Fall back to ID for Jetpack sites which don't return a stylesheet attr.
+				dispatch( themeActivated( themeStylesheet, siteId, source, purchased ) );
 			} )
 			.catch( error => {
 				dispatch( {
@@ -377,23 +378,20 @@ export function activateTheme( themeId, siteId, source = 'unknown', purchased = 
 
 /**
  * Returns an action thunk to be used in signalling that a theme has been activated
- * on a given site.
+ * on a given site. Careful, this action is different from most others here in that
+ * expects a theme stylesheet string (not just a theme ID).
  *
- * @param  {Object}   theme     Theme object
- * @param  {Number}   siteId    Site ID
- * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
- * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
- * @return {Function}           Action thunk
+ * @param  {String}   themeStylesheet Theme stylesheet string (*not* just a theme ID!)
+ * @param  {Number}   siteId          Site ID
+ * @param  {String}   source          The source that is reuquesting theme activation, e.g. 'showcase'
+ * @param  {Boolean}  purchased       Whether the theme has been purchased prior to activation
+ * @return {Function}                 Action thunk
  */
-export function themeActivated( theme, siteId, source = 'unknown', purchased = false ) {
+export function themeActivated( themeStylesheet, siteId, source = 'unknown', purchased = false ) {
 	const themeActivatedThunk = ( dispatch, getState ) => {
-		if ( typeof theme !== 'object' ) {
-			theme = getThemeById( getState(), theme );
-		}
-
 		const action = {
 			type: THEME_ACTIVATE_REQUEST_SUCCESS,
-			theme,
+			themeStylesheet,
 			siteId,
 		};
 		const previousTheme = getCurrentTheme( getState(), siteId );
@@ -402,7 +400,7 @@ export function themeActivated( theme, siteId, source = 'unknown', purchased = f
 		const trackThemeActivation = recordTracksEvent(
 			'calypso_themeshowcase_theme_activate',
 			{
-				theme: theme.id,
+				theme: getThemeIdFromStylesheet( themeStylesheet ),
 				previous_theme: previousTheme.id,
 				source: source,
 				purchased: purchased,

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -30,7 +30,8 @@ import {
 	DESERIALIZE
 } from 'state/action-types';
 import {
-	getSerializedThemesQuery
+	getSerializedThemesQuery,
+	getThemeIdFromStylesheet
 } from './utils';
 import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { queriesSchema, activeThemesSchema } from './schema';
@@ -48,9 +49,9 @@ import uploadTheme from './upload-theme/reducer';
  * @return {Object}        Updated state
  */
 export const activeThemes = createReducer( {}, {
-	[ THEME_ACTIVATE_REQUEST_SUCCESS ]: ( state, { siteId, theme } ) => ( {
+	[ THEME_ACTIVATE_REQUEST_SUCCESS ]: ( state, { siteId, themeStylesheet } ) => ( {
 		...state,
-		[ siteId ]: theme.id
+		[ siteId ]: getThemeIdFromStylesheet( themeStylesheet )
 	} ),
 	[ ACTIVE_THEME_REQUEST_SUCCESS ]: ( state, { siteId, themeId } ) => ( {
 		...state,

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -313,7 +313,7 @@ describe( 'actions', () => {
 					],
 				},
 				type: THEME_ACTIVATE_REQUEST_SUCCESS,
-				theme: { id: 'twentysixteen' },
+				themeStylesheet: 'pub/twentysixteen',
 				siteId: 2211667,
 			};
 
@@ -331,7 +331,7 @@ describe( 'actions', () => {
 				}
 			} );
 
-			themeActivated( { id: 'twentysixteen' }, 2211667 )( spy, fakeGetState );
+			themeActivated( 'pub/twentysixteen', 2211667 )( spy, fakeGetState );
 			expect( spy ).to.have.been.calledWith( expectedActivationSuccess );
 		} );
 	} );

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -507,7 +507,7 @@ describe( 'reducer', () => {
 		it( 'should track theme activate request success', () => {
 			const state = activeThemes( deepFreeze( {} ), {
 				type: THEME_ACTIVATE_REQUEST_SUCCESS,
-				theme: { id: 'twentysixteen' },
+				themeStylesheet: 'twentysixteen',
 				siteId: 2211888,
 			} );
 
@@ -582,7 +582,7 @@ describe( 'reducer', () => {
 				{
 					type: THEME_ACTIVATE_REQUEST_SUCCESS,
 					siteId: 2916284,
-					theme: { id: 'twentysixteen' },
+					themeStylesheet: 'twentysixteen',
 				}
 			);
 

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	getThemeIdFromStylesheet,
 	getNormalizedThemesQuery,
 	getSerializedThemesQuery,
 	getDeserializedThemesQueryDetails,
@@ -14,6 +15,23 @@ import {
 } from '../utils';
 
 describe( 'utils', () => {
+	describe( '#getThemeIdFromStylesheet()', () => {
+		it( 'should return undefined when given no argument', () => {
+			const themeId = getThemeIdFromStylesheet();
+			expect( themeId ).to.be.undefined;
+		} );
+
+		it( 'should return the argument if it doesn\'t contain a slash (/)', () => {
+			const themeId = getThemeIdFromStylesheet( 'twentysixteen' );
+			expect( themeId ).to.equal( 'twentysixteen' );
+		} );
+
+		it( 'should return argument\'s part after the slash if it does contain a slash (/)', () => {
+			const themeId = getThemeIdFromStylesheet( 'pub/twentysixteen' );
+			expect( themeId ).to.equal( 'twentysixteen' );
+		} );
+	} );
+
 	describe( '#getNormalizedThemesQuery()', () => {
 		it( 'should exclude default values', () => {
 			const query = getNormalizedThemesQuery( {

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import startsWith from 'lodash/startsWith';
-import { omit, omitBy } from 'lodash';
+import { omit, omitBy, split } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +19,20 @@ export const oldShowcaseUrl = '//wordpress.com/themes/';
 /**
  * Utility
  */
+
+/**
+ * Given a theme stylesheet string (like 'pub/twentysixteen'), returns the corresponding theme ID ('twentysixteen').
+ *
+ * @param  {String}  stylesheet Theme stylesheet
+ * @return {?String}            Theme ID
+ */
+export function getThemeIdFromStylesheet( stylesheet ) {
+	const [ , slug ] = split( stylesheet, '/', 2 );
+	if ( ! slug ) {
+		return stylesheet;
+	}
+	return slug;
+}
 
 /**
  * Returns a normalized themes query, excluding any values which match the


### PR DESCRIPTION
Previously, we were obscurely catering for both the case of an entire theme object, or a theme ID, for which we would fetch the corresponding theme object from state.
Not only is the latter an anti-pattern, it also breaks with the new Redux arch: getTheme() (in contrast to its predecessor getThemeById()) not only requires a themeId arg, but also a siteId, for which we would have to introduce some complicated siteId-or-wpcom-string handling inside the action, which would require even more (site related) selectors.

Instead, I've opted to drop those theme object lookups, and instead to only pass along the theme stylesheet, which as of r146595-wpcom is returned by the `/sites/<mysite>/themes/mine` endpoint. The reason we cannot rely solely on a theme ID is that the `sites` reducer relies on the action that themeActivated() dispatches to update the current site's `options.theme_slug` attr -- which is a stylesheet-like theme slug, not just an ID.

To test: Verify that all ways of activating a theme still work (and cover different modes, i.e. single-site, multi-site, etc):
* '...' menu and theme sheets;
* via 'Try & Customize' -> 'Save & Activate'
* via purchase

Prereq for #9644.

