### PR TITLE
Reader Refresh: remove header image from reader-feed-header component

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -11,8 +11,6 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import ReaderFollowButton from 'reader/follow-button';
-import resizeImageUrl from 'lib/resize-image-url';
-import safeImageUrl from 'lib/safe-image-url';
 import Site from 'blocks/site';
 import { state as feedState } from 'lib/feed-store/constants';
 
@@ -59,19 +57,8 @@ class FeedHeader extends Component {
 	render() {
 		const site = this.props.site,
 			feed = this.props.feed,
-			headerImage = site && site.getIn( [ 'options', 'header_image' ] ),
-			headerColor = site && site.getIn( [ 'options', 'background_color' ] ),
 			followerCount = this.getFollowerCount( feed, site ),
 			ownerDisplayName = site && site.getIn( [ 'owner', 'name' ] );
-
-		let headerImageUrl;
-
-		if ( headerImage && headerImage.get( 'width' ) > 300 ) {
-			headerImageUrl = resizeImageUrl(
-				safeImageUrl( headerImage.get( 'url' ) ),
-				{ w: 600 }
-			);
-		}
 
 		const classes = classnames( {
 			'reader-feed-header': true,
@@ -90,9 +77,6 @@ class FeedHeader extends Component {
 					</div> : null }
 				</div>
 				<Card className="reader-feed-header__site">
-					<div className="reader-feed-header__image" style={ headerColor ? { backgroundColor: '#' + headerColor } : null }>
-						{ headerImageUrl ? <img src={ headerImageUrl } /> : null }
-					</div>
 					{ this.state.siteish &&
 						<Site
 							site={ this.state.siteish }


### PR DESCRIPTION
We no longer plan to show the site header image on site and feed streams.

Fixes #9656.

### To test

Visit a site with a header image (e.g. http://calypso.localhost:3000/read/feeds/26990 🔒) and make sure the header image is not displayed:

<img width="932" alt="screen shot 2016-12-01 at 11 18 53" src="https://cloud.githubusercontent.com/assets/17325/20773703/fd9258ce-b7b7-11e6-96f6-31319a744cf2.png">

