### PR TITLE
Themes: Add activate and customize buttons on theme upload completion

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -18,6 +18,7 @@ import DropZone from 'components/drop-zone';
 import ProgressBar from 'components/progress-bar';
 import Button from 'components/button';
 import ThanksModal from 'my-sites/themes/thanks-modal';
+// Necessary for ThanksModal (QueryTheme not needed, since we've stored upload details)
 import QueryActiveTheme from 'components/data/query-active-theme';
 import { localize } from 'i18n-calypso';
 import notices from 'notices';
@@ -215,7 +216,7 @@ class Upload extends React.Component {
 				<QueryActiveTheme siteId={ siteId } />
 				<ThanksModal
 					site={ selectedSite }
-					source={ 'details' } />
+					source="upload" />
 				<HeaderCake onClick={ page.back }>{ translate( 'Upload theme' ) }</HeaderCake>
 				<Card>
 					{ ! inProgress && ! complete && this.renderDropZone() }
@@ -227,11 +228,7 @@ class Upload extends React.Component {
 	}
 }
 
-const ConnectedUpload = connectOptions(
-	( props ) => (
-		<Upload { ...props } />
-	)
-);
+const ConnectedUpload = connectOptions( Upload );
 
 const UploadWithOptions = ( props ) => {
 	const { siteId, uploadedTheme } = props;

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -16,6 +16,8 @@ import Gridicon from 'components/gridicon';
 import FilePicker from 'components/file-picker';
 import DropZone from 'components/drop-zone';
 import ProgressBar from 'components/progress-bar';
+import Button from 'components/button';
+import ThanksModal from 'my-sites/themes/thanks-modal';
 import { localize } from 'i18n-calypso';
 import notices from 'notices';
 import debugFactory from 'debug';
@@ -32,6 +34,7 @@ import {
 	isInstallInProgress,
 } from 'state/themes/upload-theme/selectors';
 import { getTheme } from 'state/themes/selectors';
+import { connectOptions } from 'my-sites/themes/theme-options';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
@@ -173,8 +176,15 @@ class Upload extends React.Component {
 		);
 	}
 
+	onActivateClick = () => {
+		const { activate } = this.props.options;
+		activate.action( this.props.uploadedTheme );
+	};
+
 	renderTheme() {
-		const { uploadedTheme: theme, translate } = this.props;
+		const { uploadedTheme: theme, translate, options } = this.props;
+		const { tryandcustomize, activate } = options;
+
 		return (
 			<div className="theme-upload__theme-sheet">
 				<span className="theme-upload__theme-name">{ theme.name }</span>
@@ -184,14 +194,25 @@ class Upload extends React.Component {
 				</span>
 				<img src={ theme.screenshot } />
 				<span className="theme-upload__description">{ theme.description }</span>
+				<Button href={ tryandcustomize.getUrl( theme ) }>
+					{ tryandcustomize.label }
+				</Button>
+				<Button primary onClick={ this.onActivateClick }>
+					{ activate.label }
+				</Button>
 			</div>
 		);
 	}
 
 	render() {
 		const { translate, inProgress, complete, failed } = this.props;
+		// TODO (seear): Add in <QueryActiveTheme> component when it is ready
+		// to get the ThanksModal working properly
 		return (
 			<Main>
+				<ThanksModal
+					site={ this.props.selectedSite }
+					source={ 'details' } />
 				<HeaderCake onClick={ page.back }>{ translate( 'Upload theme' ) }</HeaderCake>
 				<Card>
 					{ ! inProgress && ! complete && this.renderDropZone() }
@@ -202,6 +223,22 @@ class Upload extends React.Component {
 		);
 	}
 }
+
+const ConnectedUpload = connectOptions(
+	( props ) => (
+		<Upload { ...props } />
+	)
+);
+
+const UploadWithOptions = ( props ) => {
+	const { siteId, uploadedTheme } = props;
+	return (
+		<ConnectedUpload { ...props }
+			siteId={ siteId }
+			theme={ uploadedTheme }
+			options={ [ 'tryandcustomize', 'activate' ] } />
+	);
+};
 
 export default connect(
 	( state ) => {
@@ -220,4 +257,4 @@ export default connect(
 		};
 	},
 	{ uploadTheme, clearThemeUpload },
-)( localize( Upload ) );
+)( localize( UploadWithOptions ) );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -18,11 +18,14 @@ import DropZone from 'components/drop-zone';
 import ProgressBar from 'components/progress-bar';
 import Button from 'components/button';
 import ThanksModal from 'my-sites/themes/thanks-modal';
+import QueryActiveTheme from 'components/data/query-active-theme';
 import { localize } from 'i18n-calypso';
 import notices from 'notices';
 import debugFactory from 'debug';
 import { uploadTheme, clearThemeUpload } from 'state/themes/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+
 import {
 	isUploadInProgress,
 	isUploadComplete,
@@ -42,6 +45,7 @@ class Upload extends React.Component {
 
 	static propTypes = {
 		siteId: React.PropTypes.number,
+		selectedSite: React.PropTypes.object,
 		inProgress: React.PropTypes.bool,
 		complete: React.PropTypes.bool,
 		failed: React.PropTypes.bool,
@@ -205,13 +209,12 @@ class Upload extends React.Component {
 	}
 
 	render() {
-		const { translate, inProgress, complete, failed } = this.props;
-		// TODO (seear): Add in <QueryActiveTheme> component when it is ready
-		// to get the ThanksModal working properly
+		const { translate, inProgress, complete, failed, siteId, selectedSite } = this.props;
 		return (
 			<Main>
+				<QueryActiveTheme siteId={ siteId } />
 				<ThanksModal
-					site={ this.props.selectedSite }
+					site={ selectedSite }
 					source={ 'details' } />
 				<HeaderCake onClick={ page.back }>{ translate( 'Upload theme' ) }</HeaderCake>
 				<Card>
@@ -246,6 +249,7 @@ export default connect(
 		const themeId = getUploadedThemeId( state, siteId );
 		return {
 			siteId,
+			selectedSite: getSelectedSite( state ),
 			inProgress: isUploadInProgress( state, siteId ),
 			complete: isUploadComplete( state, siteId ),
 			failed: hasUploadFailed( state, siteId ),

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -34,6 +34,10 @@
 		margin: 20px;
 		border: 1px solid $gray;
 	}
+
+	.button {
+		margin: 20px 20px 0 0;
+	}
 }
 
 .theme-upload__theme-name {


### PR DESCRIPTION
<img width="739" alt="screen shot 2016-11-30 at 22 40 52" src="https://cloud.githubusercontent.com/assets/7767559/20774440/34e7b7f2-b74e-11e6-9f86-e598daa68d02.png">

**To Test**
* Needs a .org site with Jetpack > 4.4
* Go to http://calypso.localhost:3000/design/upload/{jetpack site}
* Select or drag a theme zip to upload

**Expected**
* On completion of upload, you should see theme details with new buttons underneath
* Clicking the 'Activate' button should show the 'thanks' modal and activate the theme on the site
* Clicking on 'Try & Customize' should take you to the customizer

The customizer flow is not ideal at the moment—clicking on the X in the top-left brings you back to the empty upload page. We can iterate on this.
