### PR TITLE
Reader Refresh: Choose random tag stream header image

### DIFF
--- a/client/components/data/query-reader-tag-images/index.jsx
+++ b/client/components/data/query-reader-tag-images/index.jsx
@@ -8,12 +8,12 @@ import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
-import { isRequestingTagImages } from 'state/reader/tags/images/selectors';
+import { shouldRequestTagImages } from 'state/reader/tags/images/selectors';
 import { requestTagImages } from 'state/reader/tags/images/actions';
 
 class QueryReaderTagImages extends Component {
 	componentWillMount() {
-		if ( this.props.isRequestingTagImages || ! this.props.tag ) {
+		if ( ! this.props.shouldRequestTagImages || ! this.props.tag ) {
 			return;
 		}
 
@@ -26,7 +26,7 @@ class QueryReaderTagImages extends Component {
 }
 
 QueryReaderTagImages.propTypes = {
-	isRequestingTagImages: PropTypes.bool,
+	shouldRequestTagImages: PropTypes.bool,
 	requestTagImages: PropTypes.func
 };
 
@@ -37,7 +37,7 @@ QueryReaderTagImages.defaultProps = {
 export default connect(
 	( state, ownProps ) => {
 		return {
-			isRequestingTagImages: isRequestingTagImages( state, ownProps.tag )
+			shouldRequestTagImages: shouldRequestTagImages( state, ownProps.tag )
 		};
 	},
 	( dispatch ) => {

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -5,77 +5,106 @@ import React from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { sample } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FollowButton from 'components/follow-button/button';
 import QueryReaderTagImages from 'components/data/query-reader-tag-images';
-import { getFirstImageForTag } from 'state/reader/tags/images/selectors';
+import { getTagImages } from 'state/reader/tags/images/selectors';
 import resizeImageUrl from 'lib/resize-image-url';
 import cssSafeUrl from 'lib/css-safe-url';
 import { decodeEntities } from 'lib/formatting';
 import Gridicon from 'components/gridicon';
 
 const TAG_HEADER_WIDTH = 830;
+const TAG_HEADER_HEIGHT = 140;
 
-const TagStreamHeader = (
-		{ tag, tagImage, isPlaceholder, showFollow, following, onFollowToggle, translate, hasBackButton }
-	) => {
-	const classes = classnames( {
-		'tag-stream__header': true,
-		'is-placeholder': isPlaceholder,
-		'has-back-button': hasBackButton
-	} );
-	const imageStyle = {};
+class TagStreamHeader extends React.Component {
 
-	if ( tagImage ) {
-		const imageUrl = resizeImageUrl( tagImage.url, { w: TAG_HEADER_WIDTH } );
-		const safeCssUrl = cssSafeUrl( imageUrl );
-		imageStyle.backgroundImage = 'url(//' + safeCssUrl + ')';
+	static propTypes = {
+		isPlaceholder: React.PropTypes.bool,
+		tag: React.PropTypes.string,
+		showFollow: React.PropTypes.bool,
+		following: React.PropTypes.bool,
+		onFollowToggle: React.PropTypes.func,
+		tagImages: React.PropTypes.array,
+		hasBackButton: React.PropTypes.bool
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			tag: props.tag,
+			tagImages: props.tagImages
+		};
+		this.pickNewTagImage( props );
 	}
 
-	return (
-		<div className={ classes }>
-			<QueryReaderTagImages tag={ tag } />
-			{ showFollow &&
-				<div className="tag-stream__header-follow">
-					<FollowButton
-						followLabel={ translate( 'Follow Tag' ) }
-						followingLabel={ translate( 'Following Tag' ) }
-						iconSize={ 24 }
-						following={ following }
-						onFollowToggle={ onFollowToggle } />
-				</div>
-			}
+	componentWillReceiveProps( nextProps ) {
+		this.pickNewTagImage( nextProps );
+	}
 
-			<div className="tag-stream__header-image" style={ imageStyle }>
-				<h1 className="tag-stream__header-image-title">
-					<Gridicon icon="tag" size={ 24 } />{ tag }
-				</h1>
-				{ tagImage &&
-					<div className="tag-stream__header-image-byline">
-						<span className="tag-stream__header-image-byline-label">{ translate( 'Photo by' ) }</span> <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="author external">{ decodeEntities( tagImage.author ) }</a>, <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="external">{ decodeEntities( tagImage.blog_title ) }</a>
+	pickNewTagImage = ( props = this.props ) => {
+		if ( this.state && this.state.tagImages !== props.tagImages ) {
+			this.state = {
+				tag: props.tag,
+				tagImages: props.tagImages,
+				chosenTagImage: sample( props.tagImages )
+			};
+		}
+	}
+
+	render() {
+		const { tag, isPlaceholder, showFollow, following, onFollowToggle, translate, hasBackButton } = this.props;
+		const classes = classnames( {
+			'tag-stream__header': true,
+			'is-placeholder': isPlaceholder,
+			'has-back-button': hasBackButton
+		} );
+		const imageStyle = {};
+		const tagImage = this.state.chosenTagImage;
+
+		if ( tagImage ) {
+			const imageUrl = resizeImageUrl( 'https://' + tagImage.url, { resize: `${ TAG_HEADER_WIDTH },${ TAG_HEADER_HEIGHT }` } );
+			const safeCssUrl = cssSafeUrl( imageUrl );
+			imageStyle.backgroundImage = 'url(' + safeCssUrl + ')';
+		}
+
+		return (
+			<div className={ classes }>
+				<QueryReaderTagImages tag={ tag } />
+				{ showFollow &&
+					<div className="tag-stream__header-follow">
+						<FollowButton
+							followLabel={ translate( 'Follow Tag' ) }
+							followingLabel={ translate( 'Following Tag' ) }
+							iconSize={ 24 }
+							following={ following }
+							onFollowToggle={ onFollowToggle } />
 					</div>
 				}
-			</div>
-		</div>
-	);
-};
 
-TagStreamHeader.propTypes = {
-	isPlaceholder: React.PropTypes.bool,
-	tag: React.PropTypes.string,
-	showFollow: React.PropTypes.bool,
-	following: React.PropTypes.bool,
-	onFollowToggle: React.PropTypes.func,
-	hasBackButton: React.PropTypes.bool
-};
+				<div className="tag-stream__header-image" style={ imageStyle }>
+					<h1 className="tag-stream__header-image-title">
+						<Gridicon icon="tag" size={ 24 } />{ tag }
+					</h1>
+					{ tagImage &&
+						<div className="tag-stream__header-image-byline">
+							<span className="tag-stream__header-image-byline-label">{ translate( 'Photo by' ) }</span> <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="author external">{ decodeEntities( tagImage.author ) }</a>, <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="external">{ decodeEntities( tagImage.blog_title ) }</a>
+						</div>
+					}
+				</div>
+			</div>
+		);
+	}
+}
 
 export default connect(
 	( state, ownProps ) => {
 		return {
-			tagImage: getFirstImageForTag( state, ownProps.tag )
+			tagImages: getTagImages( state, ownProps.tag )
 		};
 	}
 )( localize( TagStreamHeader ) );

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -33,26 +33,23 @@ class TagStreamHeader extends React.Component {
 		hasBackButton: React.PropTypes.bool
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			tag: props.tag,
-			tagImages: props.tagImages
-		};
-		this.pickNewTagImage( props );
+	static defaultProps = {
+		tagImages: []
 	}
+
+	pickTagImage = ( props = this.props ) => {
+		return sample( props.tagImages );
+	}
+
+	state = {
+		tag: this.props.tag,
+		tagImages: this.props.tagImages,
+		chosenTagImage: this.pickTagImage()
+	};
 
 	componentWillReceiveProps( nextProps ) {
-		this.pickNewTagImage( nextProps );
-	}
-
-	pickNewTagImage = ( props = this.props ) => {
-		if ( this.state && this.state.tagImages !== props.tagImages ) {
-			this.state = {
-				tag: props.tag,
-				tagImages: props.tagImages,
-				chosenTagImage: sample( props.tagImages )
-			};
+		if ( nextProps.tagImages !== this.props.tagImages ) {
+			this.setState( { chosenTagImage: this.pickTagImage( nextProps ) } );
 		}
 	}
 

--- a/client/state/reader/tags/images/actions.js
+++ b/client/state/reader/tags/images/actions.js
@@ -41,7 +41,7 @@ export function receiveTagImages( tag, images ) {
  * @param  {Integer} limit Maximum number of results to return
  * @return {Function} Action thunk
  */
-export function requestTagImages( tag, limit = 10 ) {
+export function requestTagImages( tag, limit = 5 ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: READER_TAG_IMAGES_REQUEST,

--- a/client/state/reader/tags/images/actions.js
+++ b/client/state/reader/tags/images/actions.js
@@ -41,7 +41,7 @@ export function receiveTagImages( tag, images ) {
  * @param  {Integer} limit Maximum number of results to return
  * @return {Function} Action thunk
  */
-export function requestTagImages( tag, limit = 1 ) {
+export function requestTagImages( tag, limit = 10 ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: READER_TAG_IMAGES_REQUEST,

--- a/client/state/reader/tags/images/selectors.js
+++ b/client/state/reader/tags/images/selectors.js
@@ -21,14 +21,13 @@ export function getTagImages( state, tag ) {
 }
 
 /**
- * Returns true if a request is in progress to retrieve the tag images
- * for a given tag.
+ * Returns true if we need to request tag images
  *
  * @param  {Object}  state  Global state tree
  * @param  {String}  tag 	Tag
- * @return {Boolean} Whether a request is in progress
+ * @return {Boolean} Whether a request is in progress or we already have tags
  */
-export function isRequestingTagImages( state, tag ) {
-	return !! state.reader.tags.images.requesting[ tag ];
+export function shouldRequestTagImages( state, tag ) {
+	return ! ( getTagImages( state, tag ) || state.reader.tags.images.requesting[ tag ] );
 }
 

--- a/client/state/reader/tags/images/selectors.js
+++ b/client/state/reader/tags/images/selectors.js
@@ -1,23 +1,23 @@
 /**
  * External dependencies
  */
-import { get, head } from 'lodash';
+import { get } from 'lodash';
 
 /**
- * Returns the first image available for a given tag.
+ * Returns the all images available for a given tag.
  *
  * @param  {Object}  state  Global state tree
  * @param  {String}  tag 	Tag
  * @return {Object} Image
  */
-export function getFirstImageForTag( state, tag ) {
+export function getTagImages( state, tag ) {
 	const items = get( state, 'reader.tags.images.items' );
 
 	if ( ! items || ! items[ tag ] ) {
 		return undefined;
 	}
 
-	return head( state.reader.tags.images.items[ tag ] );
+	return state.reader.tags.images.items[ tag ];
 }
 
 /**

--- a/client/state/reader/tags/images/test/actions.js
+++ b/client/state/reader/tags/images/test/actions.js
@@ -42,7 +42,7 @@ describe( 'actions', () => {
 	describe( '#requestTagImages', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.2/read/tags/banana/images?number=10' )
+				.get( '/rest/v1.2/read/tags/banana/images?number=5' )
 				.reply( 200, deepFreeze( sampleSuccessResponse ) );
 		} );
 

--- a/client/state/reader/tags/images/test/actions.js
+++ b/client/state/reader/tags/images/test/actions.js
@@ -42,7 +42,7 @@ describe( 'actions', () => {
 	describe( '#requestTagImages', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.2/read/tags/banana/images?number=1' )
+				.get( '/rest/v1.2/read/tags/banana/images?number=10' )
 				.reply( 200, deepFreeze( sampleSuccessResponse ) );
 		} );
 

--- a/client/state/reader/tags/images/test/selectors.js
+++ b/client/state/reader/tags/images/test/selectors.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getTagImages,
-	isRequestingTagImages
+	shouldRequestTagImages
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -56,15 +56,19 @@ describe( 'selectors', () => {
 						images: {
 							requesting: {
 								banana: true,
-								feijoa: false
+								feijoa: false,
+							},
+							items: {
+								pants: [ { url: 'foo' } ]
 							}
 						}
 					}
 				}
 			};
-			expect( isRequestingTagImages( state, 'banana' ) ).to.equal( true );
-			expect( isRequestingTagImages( state, 'feijoa' ) ).to.equal( false );
-			expect( isRequestingTagImages( state, 'unknown' ) ).to.equal( false );
+			expect( shouldRequestTagImages( state, 'banana' ) ).to.equal( false );
+			expect( shouldRequestTagImages( state, 'feijoa' ) ).to.equal( true );
+			expect( shouldRequestTagImages( state, 'unknown' ) ).to.equal( true );
+			expect( shouldRequestTagImages( state, 'pants' ) ).to.equal( false );
 		} );
 	} );
 } );

--- a/client/state/reader/tags/images/test/selectors.js
+++ b/client/state/reader/tags/images/test/selectors.js
@@ -7,12 +7,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	getFirstImageForTag,
+	getTagImages,
 	isRequestingTagImages
 } from '../selectors';
 
 describe( 'selectors', () => {
-	describe( '#getFirstImageForTag()', () => {
+	describe( '#getTagImages()', () => {
 		it( 'should return undefined if there is no image available', () => {
 			const state = {
 				reader: {
@@ -23,13 +23,12 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			expect( getFirstImageForTag( state, 'banana' ) ).to.equal( undefined );
+			expect( getTagImages( state, 'banana' ) ).to.equal( undefined );
 		} );
 
-		it( 'should return the first image if images exist for a tag', () => {
+		it( 'should return the an image if images exist for a tag', () => {
 			const firstBananaImage = { url: 'http://example.com/banana1.jpg' };
 			const secondBananaImage = { url: 'http://example.com/banana2.jpg' };
-			const firstAppleImage = { url: 'http://example.com/apple1.jpg' };
 			const state = {
 				reader: {
 					tags: {
@@ -38,17 +37,14 @@ describe( 'selectors', () => {
 								banana: [
 									firstBananaImage,
 									secondBananaImage
-								],
-								apple: [
-									firstAppleImage
 								]
 							}
 						}
 					}
 				}
 			};
-			expect( getFirstImageForTag( state, 'banana' ) ).to.eql( firstBananaImage );
-			expect( getFirstImageForTag( state, 'apple' ) ).to.eql( firstAppleImage );
+			expect( getTagImages( state, 'banana' ) ).to.have.length( 2 );
+			expect( getTagImages( state, 'apple' ) ).to.eql( undefined );
 		} );
 	} );
 


### PR DESCRIPTION
Currently, the same tag header is showed every time the same tag page is visited. 

This PR greets the user with random image from a collection of 10 returned by the tag image API.

<img width="869" alt="screen shot 2016-12-02 at 13 02 02" src="https://cloud.githubusercontent.com/assets/17325/20817942/8e3b897c-b88f-11e6-893a-7c852a128f8d.png">
