### PR TITLE
Reader: Fix Tag header font rendering in Safari

### DIFF
--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -92,7 +92,7 @@
 .tag-stream__header-image-byline-link,
 .tag-stream__header-image-byline-link:visited {
 	color: $white;
-	opacity: .8;
+	opacity: .9;
 }
 
 .tag-stream__header-image-byline-link:hover {

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -77,10 +77,12 @@
 .tag-stream__header-image-byline {
 	color: $white;
 	font-size: 12px;
+	font-weight: 500;
 	text-align: right;
 	text-shadow: 0 1px rgba(0, 0, 0, .3);
 	transform: translateY( 150% );
 	z-index: 2;
+	-webkit-font-smoothing: antialiased;
 }
 
 .tag-stream__header-image-byline-label {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/pull/9743

**Before:**
![screenshot 2016-11-30 16 28 55](https://cloud.githubusercontent.com/assets/4924246/20777174/1ccf8b38-b71a-11e6-8228-dcbd75556e33.png)

**After:**
![screenshot 2016-11-30 16 28 27](https://cloud.githubusercontent.com/assets/4924246/20777162/0a9222f0-b71a-11e6-9890-7f9086318f50.png)

